### PR TITLE
feat: Model Selector with thinking level control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,3 +155,5 @@ the feature appears to work in the UI but silently fails at the agent.
 
 ### General
 - When creating documentation or plans, save them in @docs/ or a subfolder by type
+- When asked to create a PR, use the Github CLI
+- When reviewing a PR, always make sure there's good type safety

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -32,10 +32,13 @@ import type {
   AgentStreamEvent,
   SeroSlashCommandInfo,
   SessionUsageStats,
+  SessionModelState,
+  AvailableModelGroup,
 } from '../../src/types/ipc';
 import type { ImageContent } from '@mariozechner/pi-ai';
 import { workspaceManager } from '../workspace';
 import { createSeroExtensionFactory } from '../sero-extension';
+import { getModel as getModelFromRegistry } from '@mariozechner/pi-ai';
 import {
   ensureInfra,
   PI_AGENT_DIR,
@@ -212,6 +215,95 @@ function attachmentsToImages(attachments?: ChatAttachment[]): ImageContent[] | u
   }
 
   return images.length > 0 ? images : undefined;
+}
+
+/** Provider display names. Unmapped providers get title-cased. */
+const PROVIDER_NAMES: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  'openai-codex': 'OpenAI (Codex)',
+  google: 'Google',
+  'google-gemini-cli': 'Google (Gemini CLI)',
+  'google-antigravity': 'Antigravity',
+  'google-vertex': 'Google Vertex',
+  xai: 'xAI',
+  openrouter: 'OpenRouter',
+  groq: 'Groq',
+  cerebras: 'Cerebras',
+  mistral: 'Mistral',
+  'github-copilot': 'GitHub Copilot',
+  'amazon-bedrock': 'Amazon Bedrock',
+  'azure-openai-responses': 'Azure OpenAI',
+  huggingface: 'Hugging Face',
+  'vercel-ai-gateway': 'Vercel AI Gateway',
+  zai: 'ZAI',
+  opencode: 'OpenCode',
+  'kimi-coding': 'Kimi',
+};
+
+/** Logo URL base — maps provider to models.dev SVG name. */
+const PROVIDER_LOGO_MAP: Record<string, string> = {
+  'openai-codex': 'openai',
+  'google-gemini-cli': 'google',
+  'google-antigravity': 'google',
+  'google-vertex': 'google-vertex',
+  'azure-openai-responses': 'azure',
+  'amazon-bedrock': 'amazon-bedrock',
+  'github-copilot': 'github-copilot',
+  'vercel-ai-gateway': 'vercel',
+  'kimi-coding': 'openai', // fallback
+};
+
+function providerLogo(provider: string): string {
+  const slug = PROVIDER_LOGO_MAP[provider] ?? provider;
+  return `https://models.dev/logos/${slug}.svg`;
+}
+
+function providerDisplayName(provider: string): string {
+  return PROVIDER_NAMES[provider] ?? provider.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Build a SessionModelState from a pool entry's current session state. */
+function buildModelState(entry: PoolEntry): SessionModelState {
+  const session = entry.session;
+  const model = session.model;
+
+  // Reload auth from disk so keys added externally (pi auth, OAuth) are picked up
+  session.modelRegistry.authStorage.reload();
+
+  // Get all models with auth, group by provider
+  const available = session.modelRegistry.getAvailable();
+  const grouped = new Map<string, typeof available>();
+  for (const m of available) {
+    const list = grouped.get(m.provider) ?? [];
+    list.push(m);
+    grouped.set(m.provider, list);
+  }
+
+  const availableModels = [...grouped.entries()].map(([provider, models]) => ({
+    provider,
+    displayName: providerDisplayName(provider),
+    logo: providerLogo(provider),
+    models: models.map((m) => ({
+      provider: m.provider,
+      modelId: m.id,
+      name: m.name,
+      reasoning: m.reasoning,
+    })),
+  }));
+
+  return {
+    model: {
+      provider: model?.provider ?? 'unknown',
+      modelId: model?.id ?? 'unknown',
+      name: model?.name ?? 'Unknown',
+      reasoning: model?.reasoning ?? false,
+    },
+    thinkingLevel: session.thinkingLevel,
+    availableThinkingLevels: session.getAvailableThinkingLevels(),
+    supportsXhigh: session.supportsXhighThinking(),
+    availableModels,
+  };
 }
 
 /** Close and dispose a single pool entry. */
@@ -406,11 +498,12 @@ export function registerAgentHandlers(): void {
       });
       await loader.reload();
 
+      // Don't pass model/thinkingLevel — the SDK restores them from the
+      // session file (model_change / thinking_level_change entries). For new
+      // sessions it falls back to settings.json defaults, then first available.
       const { session } = await createAgentSession({
         cwd: wsPath,
         agentDir: PI_AGENT_DIR,
-        model: infra.model,
-        thinkingLevel: 'off',
         authStorage: infra.authStorage,
         modelRegistry: infra.modelRegistry,
         tools: createCodingTools(wsPath),
@@ -507,6 +600,47 @@ export function registerAgentHandlers(): void {
         cost: stats.cost,
         requestCount: stats.userMessages,
       };
+    },
+  );
+
+  // ── Get model + thinking state for a session ────────────────
+  ipcMain.handle(
+    IpcChannels.agent.getModelState,
+    async (_event, sessionId: string): Promise<SessionModelState | null> => {
+      const entry = pool.get(sessionId);
+      if (!entry) return null;
+      return buildModelState(entry);
+    },
+  );
+
+  // ── Set model for a session ────────────────────────────────
+  ipcMain.handle(
+    IpcChannels.agent.setModel,
+    async (_event, sessionId: string, provider: string, modelId: string): Promise<SessionModelState> => {
+      const entry = pool.get(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+
+      const model = getModelFromRegistry(provider as any, modelId as any);
+      if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);
+
+      await entry.session.setModel(model);
+      const state = buildModelState(entry);
+      sendEvent({ type: 'model_change', sessionId, state });
+      return state;
+    },
+  );
+
+  // ── Set thinking level for a session ───────────────────────
+  ipcMain.handle(
+    IpcChannels.agent.setThinkingLevel,
+    async (_event, sessionId: string, level: string): Promise<SessionModelState> => {
+      const entry = pool.get(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+
+      entry.session.setThinkingLevel(level as any);
+      const state = buildModelState(entry);
+      sendEvent({ type: 'model_change', sessionId, state });
+      return state;
     },
   );
 

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -19,6 +19,7 @@ import {
   type AgentSession,
   type SlashCommandInfo,
 } from '@mariozechner/pi-coding-agent';
+import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -35,7 +36,7 @@ import type {
   SessionModelState,
   AvailableModelGroup,
 } from '../../src/types/ipc';
-import type { ImageContent } from '@mariozechner/pi-ai';
+import type { ImageContent, KnownProvider } from '@mariozechner/pi-ai';
 import { workspaceManager } from '../workspace';
 import { createSeroExtensionFactory } from '../sero-extension';
 import { getModel as getModelFromRegistry } from '@mariozechner/pi-ai';
@@ -74,6 +75,40 @@ function sendEvent(event: AgentStreamEvent): void {
 let msgCounter = 0;
 function nextId(): string {
   return `msg-${Date.now()}-${++msgCounter}`;
+}
+
+/** Valid thinking levels. */
+const VALID_THINKING_LEVELS: readonly ThinkingLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+
+/**
+ * Validate and coerce a thinking level string to a valid ThinkingLevel.
+ * Throws with descriptive error if invalid.
+ */
+function validateThinkingLevel(level: string): ThinkingLevel {
+  const normalized = level.toLowerCase();
+  if (VALID_THINKING_LEVELS.includes(normalized as ThinkingLevel)) {
+    return normalized as ThinkingLevel;
+  }
+  const available = VALID_THINKING_LEVELS.join(', ');
+  throw new Error(`Invalid thinking level: "${level}". Valid levels: ${available}`);
+}
+
+/**
+ * Validate provider string is a known provider.
+ * Returns the provider as-is if valid, otherwise throws.
+ */
+function validateProvider(provider: string): KnownProvider {
+  // Check against KnownProvider literal types
+  const knownProviders: KnownProvider[] = [
+    'amazon-bedrock', 'anthropic', 'google', 'google-gemini-cli', 'google-antigravity',
+    'google-vertex', 'openai', 'azure-openai-responses', 'openai-codex', 'github-copilot',
+    'xai', 'groq', 'cerebras', 'openrouter', 'vercel-ai-gateway', 'zai', 'mistral',
+    'minimax', 'minimax-cn', 'huggingface', 'opencode', 'kimi-coding'
+  ];
+  if (knownProviders.includes(provider as KnownProvider)) {
+    return provider as KnownProvider;
+  }
+  throw new Error(`Unknown provider: "${provider}". Available: ${knownProviders.join(', ')}`);
 }
 
 /**
@@ -620,8 +655,30 @@ export function registerAgentHandlers(): void {
       const entry = pool.get(sessionId);
       if (!entry) throw new Error(`No active session: ${sessionId}`);
 
-      const model = getModelFromRegistry(provider as any, modelId as any);
-      if (!model) throw new Error(`Model not found: ${provider}/${modelId}`);
+      // Validate provider is known
+      const validatedProvider = validateProvider(provider);
+
+      // Look up the model from registry
+      const model = getModelFromRegistry(validatedProvider, modelId as any);
+      if (!model) {
+        // Provide helpful error with available models
+        const available = entry.session.modelRegistry.getAvailable();
+        const availableIds = available.map(m => `${m.provider}/${m.id}`).join(', ');
+        throw new Error(
+          `Model not found: ${provider}/${modelId}. ` +
+          `Available models: ${availableIds || '(none)'}`
+        );
+      }
+
+      // Verify the user has valid auth credentials for this model
+      const availableModels = entry.session.modelRegistry.getAvailable();
+      const hasAuth = availableModels.some(m => m.provider === provider && m.id === modelId);
+      if (!hasAuth) {
+        throw new Error(
+          `No auth credentials for ${provider}/${modelId}. ` +
+          `Run 'pi auth' to add credentials, then refresh.`
+        );
+      }
 
       await entry.session.setModel(model);
       const state = buildModelState(entry);
@@ -637,7 +694,9 @@ export function registerAgentHandlers(): void {
       const entry = pool.get(sessionId);
       if (!entry) throw new Error(`No active session: ${sessionId}`);
 
-      entry.session.setThinkingLevel(level as any);
+      // Validate thinking level
+      const validatedLevel = validateThinkingLevel(level);
+      entry.session.setThinkingLevel(validatedLevel);
       const state = buildModelState(entry);
       sendEvent({ type: 'model_change', sessionId, state });
       return state;

--- a/apps/desktop/electron/ipc/app-agent.ts
+++ b/apps/desktop/electron/ipc/app-agent.ts
@@ -65,7 +65,7 @@ async function getOrCreateAppSession(
     cwd: wsPath,
     agentDir: PI_AGENT_DIR,
     model: infra.model,
-    thinkingLevel: 'off',
+    thinkingLevel: 'high',
     authStorage: infra.authStorage,
     modelRegistry: infra.modelRegistry,
     tools: [], // No tools — pure text completion

--- a/apps/desktop/electron/ipc/shared-infra.ts
+++ b/apps/desktop/electron/ipc/shared-infra.ts
@@ -50,6 +50,10 @@ export async function ensureInfra(): Promise<SharedInfra> {
       path.join(os.homedir(), '.sero-ui'),
       PI_AGENT_DIR,
     );
+    // Default to 'high' thinking if the user hasn't explicitly set a level
+    if (!_settingsManager.getDefaultThinkingLevel()) {
+      _settingsManager.setDefaultThinkingLevel('high');
+    }
     _model = getModel('anthropic', 'claude-opus-4-6');
     if (!_model) throw new Error('Model claude-opus-4-6 not found in registry');
   }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -9,6 +9,7 @@ import type {
   SeroSlashCommandInfo,
   SeroAppManifest,
   SessionUsageStats,
+  SessionModelState,
 } from '../src/types/ipc';
 
 contextBridge.exposeInMainWorld('sero', {
@@ -80,6 +81,15 @@ contextBridge.exposeInMainWorld('sero', {
 
     getUsage: (sessionId: string): Promise<SessionUsageStats | null> =>
       ipcRenderer.invoke(IpcChannels.agent.getUsage, sessionId),
+
+    getModelState: (sessionId: string): Promise<SessionModelState | null> =>
+      ipcRenderer.invoke(IpcChannels.agent.getModelState, sessionId),
+
+    setModel: (sessionId: string, provider: string, modelId: string): Promise<SessionModelState> =>
+      ipcRenderer.invoke(IpcChannels.agent.setModel, sessionId, provider, modelId),
+
+    setThinkingLevel: (sessionId: string, level: string): Promise<SessionModelState> =>
+      ipcRenderer.invoke(IpcChannels.agent.setThinkingLevel, sessionId, level),
 
     onEvent: (callback: (event: AgentStreamEvent) => void): (() => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: AgentStreamEvent) => {

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -35,6 +35,7 @@ import { useAgentStore, useFocusedAgent, useFocusedCommands } from '@/stores/age
 import { SlashCommandMenu } from './SlashCommandMenu';
 import { PromptAttachmentsBar, MessageAttachments } from './ChatAttachments';
 import { UsageBadge } from './UsageBadge';
+import { ModelSelector } from './ModelSelector';
 import type { ChatMessage, ChatAttachment, ChatToolCallMessage, SeroSlashCommandInfo } from '@/types/ipc';
 
 /**
@@ -199,6 +200,8 @@ export function ChatPanel() {
                   <PromptInputActionAddAttachments />
                 </PromptInputActionMenuContent>
               </PromptInputActionMenu>
+              {/* Model + thinking level selector */}
+              <ModelSelector disabled={!hasSession} />
             </PromptInputTools>
 
             {isStreaming ? (

--- a/apps/desktop/src/components/layout/ModelSelector.tsx
+++ b/apps/desktop/src/components/layout/ModelSelector.tsx
@@ -1,0 +1,303 @@
+import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { ChevronDown, Check, Brain, Zap, Sparkles, Search } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useAgentStore, useFocusedAgent } from '@/stores/agent';
+import {
+  THINKING_LEVELS,
+  THINKING_LABELS,
+  findModel,
+  findGroup,
+  type ThinkingLevel,
+} from './model-config';
+import type { ModelInfo, AvailableModelGroup } from '@/types/ipc';
+
+// ── Trigger Button ─────────────────────────────────────────────
+
+function ModelTrigger({ disabled }: { disabled: boolean }) {
+  const focused = useFocusedAgent();
+  const ms = focused?.modelState;
+  const groups = ms?.availableModels ?? [];
+
+  const model = ms ? findModel(groups, ms.model.provider, ms.model.modelId) : null;
+  const group = ms ? findGroup(groups, ms.model.provider, ms.model.modelId) : null;
+  const label = model?.name ?? ms?.model.name ?? 'Select model';
+  const thinking = ms?.thinkingLevel ?? 'off';
+
+  return (
+    <PopoverTrigger asChild disabled={disabled}>
+      <button
+        className="group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs
+          text-[var(--text-secondary)] transition-all duration-150
+          hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]
+          disabled:pointer-events-none disabled:opacity-40"
+      >
+        {group && (
+          <img src={group.logo} alt={group.displayName}
+            className="size-3.5 rounded-sm dark:invert" />
+        )}
+        <span className="max-w-[140px] truncate font-medium">{label}</span>
+        {thinking !== 'off' && ms?.model.reasoning && (
+          <span className="rounded-full bg-amber-500/15 px-1.5 py-px text-[10px] font-semibold text-amber-400">
+            {THINKING_LABELS[thinking] ?? thinking}
+          </span>
+        )}
+        <ChevronDown className="size-3 text-[var(--text-muted)] transition-transform duration-200 group-data-[state=open]:rotate-180" />
+      </button>
+    </PopoverTrigger>
+  );
+}
+
+// ── Thinking Level Picker ──────────────────────────────────────
+
+function ThinkingPicker({
+  current, available, supportsXhigh, disabled, onSelect,
+}: {
+  current: string; available: string[]; supportsXhigh: boolean;
+  disabled: boolean; onSelect: (level: string) => void;
+}) {
+  // When disabled, show the full set so the layout stays stable
+  const levels = disabled
+    ? THINKING_LEVELS
+    : THINKING_LEVELS.filter(
+        (l) => l === 'off' || available.includes(l) || (l === 'xhigh' && supportsXhigh),
+      );
+  const activeIdx = levels.indexOf((disabled ? 'off' : current) as ThinkingLevel);
+
+  return (
+    <div className={`flex flex-col gap-1.5 border-t border-[var(--border-subtle)] px-3 py-2.5 transition-opacity duration-150 ${
+      disabled ? 'opacity-35 pointer-events-none' : ''
+    }`}>
+      <div className="flex items-center gap-1.5">
+        <Brain className="size-3 text-[var(--text-muted)]" />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          Thinking
+        </span>
+      </div>
+      <div className="relative flex rounded-lg bg-[var(--bg-base)] p-0.5">
+        <motion.div
+          className="absolute inset-y-0.5 rounded-md"
+          initial={false}
+          animate={{
+            x: `${activeIdx * 100}%`,
+            width: `${100 / levels.length}%`,
+          }}
+          transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+          style={{
+            background: disabled || current === 'off' ? 'var(--bg-elevated)'
+              : current === 'xhigh' ? 'linear-gradient(135deg, #f59e0b33, #ef444433)'
+              : 'linear-gradient(135deg, #6366f133, #8b5cf633)',
+          }}
+        />
+        {levels.map((level) => (
+          <button
+            key={level}
+            onClick={() => onSelect(level)}
+            className={`relative z-10 flex-1 rounded-md px-1 py-1 text-[11px] font-medium transition-colors duration-150 ${
+              current === level && !disabled
+                ? level === 'xhigh' ? 'text-amber-300'
+                  : level === 'off' ? 'text-[var(--text-secondary)]'
+                  : 'text-indigo-300'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+            }`}
+          >
+            {THINKING_LABELS[level]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Model Item ─────────────────────────────────────────────────
+
+function ModelItem({ model, isSelected, onSelect }: {
+  model: ModelInfo; isSelected: boolean; onSelect: () => void;
+}) {
+  return (
+    <motion.button
+      onClick={onSelect}
+      className={`group relative flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors duration-100 ${
+        isSelected
+          ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+          : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]/60 hover:text-[var(--text-primary)]'
+      }`}
+      whileTap={{ scale: 0.98 }}
+    >
+      <div className="flex size-4 shrink-0 items-center justify-center">
+        <AnimatePresence mode="wait">
+          {isSelected ? (
+            <motion.div key="check"
+              initial={{ scale: 0, opacity: 0 }} animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0, opacity: 0 }}
+              transition={{ type: 'spring', stiffness: 500, damping: 25 }}>
+              <Check className="size-3.5 text-emerald-400" />
+            </motion.div>
+          ) : (
+            <motion.div key="dot"
+              initial={{ scale: 0 }} animate={{ scale: 1 }} exit={{ scale: 0 }}
+              className="size-1.5 rounded-full bg-[var(--border-default)] transition-colors group-hover:bg-[var(--text-muted)]" />
+          )}
+        </AnimatePresence>
+      </div>
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
+        <span className="truncate text-xs font-medium">{model.name}</span>
+        {model.reasoning && <Sparkles className="size-3 shrink-0 text-amber-400/60" />}
+      </div>
+    </motion.button>
+  );
+}
+
+// ── Provider Group ─────────────────────────────────────────────
+
+function ProviderSection({ group, selectedModel, onSelect }: {
+  group: AvailableModelGroup;
+  selectedModel: { provider: string; modelId: string } | null;
+  onSelect: (model: ModelInfo) => void;
+}) {
+  return (
+    <div className="py-1">
+      <div className="flex items-center gap-2 px-3 pb-1 pt-2">
+        <img src={group.logo} alt={group.displayName}
+          className="size-3.5 rounded-sm dark:invert" />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          {group.displayName}
+        </span>
+      </div>
+      <div className="px-1">
+        {group.models.map((model) => (
+          <ModelItem
+            key={`${model.provider}/${model.modelId}`}
+            model={model}
+            isSelected={
+              selectedModel?.provider === model.provider &&
+              selectedModel?.modelId === model.modelId
+            }
+            onSelect={() => onSelect(model)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Main Component ─────────────────────────────────────────────
+
+/** Filter groups by search query, matching on model name or model ID. */
+function filterGroups(groups: AvailableModelGroup[], query: string): AvailableModelGroup[] {
+  if (!query) return groups;
+  const q = query.toLowerCase();
+  const filtered: AvailableModelGroup[] = [];
+  for (const group of groups) {
+    const matches = group.models.filter(
+      (m) => m.name.toLowerCase().includes(q) || m.modelId.toLowerCase().includes(q),
+    );
+    if (matches.length) filtered.push({ ...group, models: matches });
+  }
+  return filtered;
+}
+
+export function ModelSelector({ disabled }: { disabled: boolean }) {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const focused = useFocusedAgent();
+  const setModel = useAgentStore((s) => s.setModel);
+  const setThinkingLevel = useAgentStore((s) => s.setThinkingLevel);
+
+  const sessionId = focused?.sessionId ?? null;
+  const ms = focused?.modelState;
+  const groups = ms?.availableModels ?? [];
+  const selectedModel = ms ? { provider: ms.model.provider, modelId: ms.model.modelId } : null;
+
+  const filteredGroups = useMemo(() => filterGroups(groups, filter), [groups, filter]);
+  const totalFiltered = useMemo(
+    () => filteredGroups.reduce((n, g) => n + g.models.length, 0),
+    [filteredGroups],
+  );
+
+  // Reset filter & autofocus when popover opens
+  useEffect(() => {
+    if (open) {
+      setFilter('');
+      // Small delay so popover is rendered before focusing
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const handleModelSelect = useCallback(
+    (model: ModelInfo) => {
+      if (!sessionId) return;
+      setModel(sessionId, model.provider, model.modelId);
+    },
+    [sessionId, setModel],
+  );
+
+  const handleThinkingSelect = useCallback(
+    (level: string) => {
+      if (!sessionId) return;
+      setThinkingLevel(sessionId, level);
+    },
+    [sessionId, setThinkingLevel],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <ModelTrigger disabled={disabled} />
+      <PopoverContent side="top" align="start" sideOffset={8}
+        className="w-[300px] overflow-hidden rounded-xl border-[var(--border-subtle)] bg-[var(--bg-surface)] p-0 shadow-2xl shadow-black/40">
+        <motion.div
+          initial={{ opacity: 0, y: 6, scale: 0.97 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 25, mass: 0.8 }}>
+
+          {/* Search input */}
+          <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] px-3">
+            <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+            <input
+              ref={inputRef}
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Search models…"
+              data-slot="model-filter"
+              className="h-9 w-full bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus-visible:outline-none"
+            />
+          </div>
+
+          {/* Model List */}
+          <div className="max-h-[320px] overflow-y-auto py-1">
+            {groups.length === 0 ? (
+              <div className="px-3 py-4 text-center text-xs text-[var(--text-muted)]">
+                No models available. Run <code className="rounded bg-[var(--bg-muted)] px-1 font-mono">pi auth</code> to add a provider.
+              </div>
+            ) : totalFiltered === 0 ? (
+              <div className="px-3 py-4 text-center text-xs text-[var(--text-muted)]">
+                No models matching "<span className="text-[var(--text-secondary)]">{filter}</span>"
+              </div>
+            ) : (
+              filteredGroups.map((group, i) => (
+                <div key={group.provider}>
+                  {i > 0 && <div className="mx-3 border-t border-[var(--border-subtle)]" />}
+                  <ProviderSection
+                    group={group}
+                    selectedModel={selectedModel}
+                    onSelect={handleModelSelect}
+                  />
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* Thinking Level Picker — always shown, disabled when model has no reasoning */}
+          <ThinkingPicker
+            current={ms?.thinkingLevel ?? 'off'}
+            available={ms?.availableThinkingLevels ?? []}
+            supportsXhigh={ms?.supportsXhigh ?? false}
+            disabled={!ms?.model.reasoning}
+            onSelect={handleThinkingSelect}
+          />
+        </motion.div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/desktop/src/components/layout/model-config.ts
+++ b/apps/desktop/src/components/layout/model-config.ts
@@ -1,0 +1,47 @@
+/**
+ * Model selector constants and helpers.
+ *
+ * The available models come from the backend (PI SDK ModelRegistry).
+ * This file only holds thinking-level display info and lookup helpers.
+ */
+
+import type { ModelInfo, AvailableModelGroup } from '@/types/ipc';
+
+/** All thinking levels in order. */
+export const THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'] as const;
+export type ThinkingLevel = (typeof THINKING_LEVELS)[number];
+
+/** Display labels for thinking levels. */
+export const THINKING_LABELS: Record<string, string> = {
+  off: 'Off',
+  minimal: 'Min',
+  low: 'Low',
+  medium: 'Med',
+  high: 'High',
+  xhigh: 'Max',
+};
+
+/** Find a model across all groups that matches provider+modelId. */
+export function findModel(
+  groups: AvailableModelGroup[],
+  provider: string,
+  modelId: string,
+): ModelInfo | undefined {
+  for (const g of groups) {
+    const m = g.models.find((m) => m.provider === provider && m.modelId === modelId);
+    if (m) return m;
+  }
+  return undefined;
+}
+
+/** Find the group that contains a given provider+modelId. */
+export function findGroup(
+  groups: AvailableModelGroup[],
+  provider: string,
+  modelId: string,
+): AvailableModelGroup | undefined {
+  for (const g of groups) {
+    if (g.models.some((m) => m.provider === provider && m.modelId === modelId)) return g;
+  }
+  return undefined;
+}

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -5,6 +5,7 @@ import type {
   ChatToolCallMessage,
   AgentStreamEvent,
   SeroSlashCommandInfo,
+  SessionModelState,
 } from '@/types/ipc';
 import { useSessionStore } from '@/stores/sessions';
 
@@ -20,6 +21,8 @@ export interface AgentInstance {
   error: string | null;
   /** Available slash commands for this session (fetched on open). */
   commands: SeroSlashCommandInfo[];
+  /** Current model + thinking level state. */
+  modelState: SessionModelState | null;
 }
 
 interface AgentState {
@@ -44,6 +47,12 @@ interface AgentState {
   clearFocus: () => void;
   /** Reload resources (skills, prompts, extensions) for a session. */
   reloadResources: (sessionId: string) => Promise<void>;
+  /** Set the model for a session. */
+  setModel: (sessionId: string, provider: string, modelId: string) => Promise<void>;
+  /** Set thinking level for a session. */
+  setThinkingLevel: (sessionId: string, level: string) => Promise<void>;
+  /** Fetch model state for a session. */
+  fetchModelState: (sessionId: string) => Promise<void>;
 
   /** Subscribe to main-process events. Returns cleanup function. */
   initEventListener: () => () => void;
@@ -74,6 +83,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
           isStreaming: false,
           error: null,
           commands: [],
+          modelState: null,
         },
       },
       focusedSessionId: sessionId,
@@ -90,6 +100,14 @@ export const useAgentStore = create<AgentState>((set, get) => ({
         console.warn('[agent] Failed to fetch commands:', cmdErr);
       }
 
+      // Fetch initial model state (non-blocking)
+      let modelState: SessionModelState | null = null;
+      try {
+        modelState = await window.sero.agent.getModelState(sessionId);
+      } catch (err) {
+        console.warn('[agent] Failed to fetch model state:', err);
+      }
+
       set((s) => ({
         agents: {
           ...s.agents,
@@ -97,6 +115,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
             ...s.agents[sessionId],
             messages: history,
             commands,
+            modelState,
           },
         },
       }));
@@ -198,6 +217,45 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       });
     } catch (err) {
       console.error('[agent] reloadResources failed:', err);
+    }
+  },
+
+  setModel: async (sessionId, provider, modelId) => {
+    try {
+      const state = await window.sero.agent.setModel(sessionId, provider, modelId);
+      set((s) => {
+        const agent = s.agents[sessionId];
+        if (!agent) return s;
+        return { agents: { ...s.agents, [sessionId]: { ...agent, modelState: state } } };
+      });
+    } catch (err) {
+      console.error('[agent] setModel failed:', err);
+    }
+  },
+
+  setThinkingLevel: async (sessionId, level) => {
+    try {
+      const state = await window.sero.agent.setThinkingLevel(sessionId, level);
+      set((s) => {
+        const agent = s.agents[sessionId];
+        if (!agent) return s;
+        return { agents: { ...s.agents, [sessionId]: { ...agent, modelState: state } } };
+      });
+    } catch (err) {
+      console.error('[agent] setThinkingLevel failed:', err);
+    }
+  },
+
+  fetchModelState: async (sessionId) => {
+    try {
+      const state = await window.sero.agent.getModelState(sessionId);
+      set((s) => {
+        const agent = s.agents[sessionId];
+        if (!agent) return s;
+        return { agents: { ...s.agents, [sessionId]: { ...agent, modelState: state } } };
+      });
+    } catch (err) {
+      console.error('[agent] fetchModelState failed:', err);
     }
   },
 
@@ -322,6 +380,15 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
         case 'session_name':
           useSessionStore.getState().updateSessionName(sid, event.name);
+          break;
+
+        case 'model_change':
+          set((s) => ({
+            agents: {
+              ...s.agents,
+              [sid]: { ...s.agents[sid], modelState: event.state },
+            },
+          }));
           break;
 
         case 'error':

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -10,6 +10,7 @@ import type {
   SeroSlashCommandInfo,
   SeroAppManifest,
   SessionUsageStats,
+  SessionModelState,
 } from './ipc';
 
 interface SeroWorkspaceAPI {
@@ -56,6 +57,12 @@ interface SeroAgentAPI {
   reloadResources(sessionId: string): Promise<SeroSlashCommandInfo[]>;
   /** Get usage stats (tokens + cost) for a session. */
   getUsage(sessionId: string): Promise<SessionUsageStats | null>;
+  /** Get current model + thinking level state. */
+  getModelState(sessionId: string): Promise<SessionModelState | null>;
+  /** Set the model for a session. */
+  setModel(sessionId: string, provider: string, modelId: string): Promise<SessionModelState>;
+  /** Set thinking/reasoning level for a session. */
+  setThinkingLevel(sessionId: string, level: string): Promise<SessionModelState>;
   /** Subscribe to streaming events pushed from main process. Returns unsubscribe. */
   onEvent(callback: (event: AgentStreamEvent) => void): () => void;
 }

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -137,7 +137,37 @@ export type AgentStreamEvent =
   | { type: 'tool_start'; sessionId: string; tool: ChatToolCallMessage }
   | { type: 'tool_end'; sessionId: string; toolCallId: string; output: string | null; isError: boolean }
   | { type: 'session_name'; sessionId: string; name: string }
+  | { type: 'model_change'; sessionId: string; state: SessionModelState }
   | { type: 'error'; sessionId: string; error: string };
+
+// ── Model Info ─────────────────────────────────────────────────
+
+/** Serialisable model info for the renderer (no class instances). */
+export interface ModelInfo {
+  provider: string;
+  modelId: string;
+  name: string;
+  reasoning: boolean;
+}
+
+/** Current model + thinking level for a session. */
+export interface SessionModelState {
+  model: ModelInfo;
+  thinkingLevel: string;
+  availableThinkingLevels: string[];
+  supportsXhigh: boolean;
+  /** All models with auth, grouped by provider display name. */
+  availableModels: AvailableModelGroup[];
+}
+
+/** A group of models under a single provider, for the model selector. */
+export interface AvailableModelGroup {
+  provider: string;
+  displayName: string;
+  /** Logo URL (models.dev SVG). */
+  logo: string;
+  models: ModelInfo[];
+}
 
 // ── Usage Stats ────────────────────────────────────────────────
 
@@ -209,6 +239,12 @@ export const IpcChannels = {
     reloadResources: 'sero:agent:reload-resources',
     /** Get usage stats for a session. */
     getUsage: 'sero:agent:get-usage',
+    /** Get current model + thinking state for a session. */
+    getModelState: 'sero:agent:get-model-state',
+    /** Set model for a session. Args: sessionId, provider, modelId. */
+    setModel: 'sero:agent:set-model',
+    /** Set thinking level for a session. Args: sessionId, level. */
+    setThinkingLevel: 'sero:agent:set-thinking-level',
     /** Main → renderer push channel for streaming events. */
     event: 'sero:agent:event',
   },

--- a/packages/pi-daily-quote/ui/DailyQuote.tsx
+++ b/packages/pi-daily-quote/ui/DailyQuote.tsx
@@ -1,12 +1,12 @@
 /**
  * DailyQuote — main Sero web UI for the daily quote extension.
  *
- * Displays a daily inspirational quote in a clean, indigo-accented card.
+ * Displays a daily inspirational quote with a warm editorial aesthetic.
  * Uses useAI to generate quotes via the app's dedicated agent session —
  * no active chat session required.
  *
- * Design: minimal, contemplative — indigo/purple accents matching the
- * weight tracker, centred quote with generous whitespace.
+ * Design: editorial/literary — warm amber accents, Playfair Display serif,
+ * atmospheric layered background, decorative typographic elements.
  */
 
 import { useMemo, useCallback, useState } from 'react';
@@ -17,121 +17,348 @@ import { DEFAULT_STATE } from '../shared/types';
 // ── Styles ───────────────────────────────────────────────────
 
 const CUSTOM_STYLES = `
-  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300;1,9..40,400&family=Instrument+Serif:ital@0;1&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Outfit:wght@300;400;500;600&display=swap');
 
   .dq-root {
-    --dq-bg: #0f1117;
-    --dq-bg-surface: #191b23;
-    --dq-bg-elevated: #22252f;
-    --dq-text: #e8e4df;
-    --dq-muted: #8b8d97;
-    --dq-dim: #5c5e6a;
-    --dq-accent: #818cf8;
-    --dq-accent-hover: #a5b4fc;
-    --dq-accent-glow: rgba(129, 140, 248, 0.12);
-    --dq-border: rgba(255, 255, 255, 0.07);
+    --dq-bg: #110f14;
+    --dq-bg-surface: #18151d;
+    --dq-bg-warm: #1c1820;
+    --dq-text: #f0ebe3;
+    --dq-text-soft: #d4cfc7;
+    --dq-muted: #8a8389;
+    --dq-dim: #5c585f;
+    --dq-accent: #d4a574;
+    --dq-accent-light: #e8c89e;
+    --dq-accent-glow: rgba(212, 165, 116, 0.08);
+    --dq-accent-glow-strong: rgba(212, 165, 116, 0.15);
+    --dq-border: rgba(212, 165, 116, 0.08);
+    --dq-border-accent: rgba(212, 165, 116, 0.2);
 
-    font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
-    background: var(--dq-bg);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
     color: var(--dq-text);
+    background: var(--dq-bg);
   }
 
   @supports (color: var(--bg-base)) {
     .dq-root {
-      --dq-bg: var(--bg-base, #0f1117);
-      --dq-bg-surface: var(--bg-surface, #191b23);
-      --dq-bg-elevated: var(--bg-elevated, #22252f);
-      --dq-text: var(--text-primary, #e8e4df);
-      --dq-border: var(--border, rgba(255, 255, 255, 0.07));
+      --dq-bg: var(--bg-base, #110f14);
+      --dq-bg-surface: var(--bg-surface, #18151d);
+      --dq-border: var(--border, rgba(212, 165, 116, 0.08));
     }
   }
 
-  .dq-card {
-    background: var(--dq-bg-surface);
-    border: 1px solid var(--dq-border);
-    border-radius: 12px;
-    width: 100%;
+  /* ── Atmospheric background ── */
+
+  .dq-atmosphere {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
   }
+
+  .dq-atmosphere::before {
+    content: '';
+    position: absolute;
+    top: -30%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 140%;
+    height: 80%;
+    background: radial-gradient(
+      ellipse at center,
+      rgba(212, 165, 116, 0.06) 0%,
+      rgba(212, 165, 116, 0.02) 40%,
+      transparent 70%
+    );
+  }
+
+  .dq-atmosphere::after {
+    content: '';
+    position: absolute;
+    bottom: -20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 120%;
+    height: 60%;
+    background: radial-gradient(
+      ellipse at center,
+      rgba(140, 100, 70, 0.04) 0%,
+      transparent 60%
+    );
+  }
+
+  /* ── Card ── */
+
+  .dq-card {
+    position: relative;
+    background:
+      linear-gradient(
+        180deg,
+        rgba(212, 165, 116, 0.03) 0%,
+        transparent 30%,
+        transparent 70%,
+        rgba(212, 165, 116, 0.02) 100%
+      ),
+      var(--dq-bg-surface);
+    border: 1px solid var(--dq-border);
+    border-radius: 16px;
+    overflow: hidden;
+  }
+
+  .dq-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60%;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--dq-border-accent),
+      transparent
+    );
+  }
+
+  /* ── Typography ── */
 
   .dq-quote-text {
-    font-family: 'Instrument Serif', Georgia, serif;
+    font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
     font-weight: 400;
     font-style: italic;
-    line-height: 1.6;
+    line-height: 1.65;
+    letter-spacing: 0.01em;
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
   }
 
+  .dq-quote-mark {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-weight: 600;
+    font-style: normal;
+    line-height: 0.5;
+    background: linear-gradient(
+      180deg,
+      var(--dq-accent) 0%,
+      var(--dq-accent-light) 100%
+    );
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    user-select: none;
+    display: inline;
+    vertical-align: text-top;
+  }
+
+  /* ── Divider ── */
+
+  .dq-divider {
+    width: 60px;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--dq-accent),
+      transparent
+    );
+    opacity: 0.5;
+  }
+
+  /* ── Button ── */
+
   .dq-button {
-    background: var(--dq-accent);
-    color: #ffffff;
-    border: none;
-    border-radius: 8px;
-    padding: 8px 20px;
-    font-size: 13px;
+    position: relative;
+    background: transparent;
+    color: var(--dq-accent-light);
+    border: 1px solid var(--dq-border-accent);
+    border-radius: 100px;
+    padding: 12px 32px;
+    font-size: 14px;
     font-weight: 500;
-    font-family: 'DM Sans', sans-serif;
+    font-family: 'Outfit', sans-serif;
+    letter-spacing: 0.04em;
     cursor: pointer;
-    transition: all 0.15s;
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    overflow: hidden;
   }
+
+  .dq-button::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      135deg,
+      rgba(212, 165, 116, 0.1),
+      rgba(212, 165, 116, 0.02)
+    );
+    opacity: 0;
+    transition: opacity 0.3s;
+    border-radius: inherit;
+  }
+
+  .dq-button:hover:not(:disabled)::before {
+    opacity: 1;
+  }
+
   .dq-button:hover:not(:disabled) {
-    background: var(--dq-accent-hover);
-    box-shadow: 0 0 20px var(--dq-accent-glow);
+    border-color: var(--dq-accent);
+    color: var(--dq-accent-light);
+    box-shadow:
+      0 0 30px rgba(212, 165, 116, 0.08),
+      inset 0 0 30px rgba(212, 165, 116, 0.03);
+    transform: translateY(-1px);
   }
+
+  .dq-button:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
   .dq-button:disabled {
-    opacity: 0.35;
+    opacity: 0.3;
     cursor: default;
   }
 
-  .dq-orb {
-    width: 80px;
-    height: 80px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 40% 40%, var(--dq-accent) 0%, transparent 70%);
-    opacity: 0.12;
-    animation: dq-pulse 4s ease-in-out infinite;
+  .dq-button span {
+    position: relative;
+    z-index: 1;
   }
 
-  @keyframes dq-pulse {
-    0%, 100% { transform: scale(1); opacity: 0.12; }
-    50% { transform: scale(1.08); opacity: 0.2; }
-  }
+  /* ── Animations ── */
 
-  @keyframes dq-fade-in {
-    from { opacity: 0; transform: translateY(12px); }
+  @keyframes dq-fade-up {
+    from { opacity: 0; transform: translateY(16px); }
     to { opacity: 1; transform: translateY(0); }
   }
 
-  .dq-animate-in {
-    animation: dq-fade-in 0.5s ease-out both;
+  @keyframes dq-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
   }
 
-  .dq-spin {
-    animation: dq-spinner 1s linear infinite;
+  @keyframes dq-scale-in {
+    from { opacity: 0; transform: scale(0.92); }
+    to { opacity: 1; transform: scale(1); }
   }
 
-  @keyframes dq-spinner {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
+  .dq-animate-quote {
+    animation: dq-scale-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both;
   }
+
+  .dq-animate-mark {
+    animation: dq-fade-in 0.8s ease-out 0s both;
+  }
+
+  .dq-animate-text {
+    animation: dq-fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.2s both;
+  }
+
+  .dq-animate-divider {
+    animation: dq-fade-in 0.6s ease-out 0.4s both;
+  }
+
+  .dq-animate-author {
+    animation: dq-fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.5s both;
+  }
+
+  .dq-animate-button {
+    animation: dq-fade-up 0.5s cubic-bezier(0.16, 1, 0.3, 1) 0.7s both;
+  }
+
+  .dq-animate-empty {
+    animation: dq-fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  /* ── Loading ── */
+
+  .dq-loading-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--dq-accent);
+    animation: dq-dot-pulse 1.4s ease-in-out infinite;
+  }
+
+  .dq-loading-dot:nth-child(2) { animation-delay: 0.2s; }
+  .dq-loading-dot:nth-child(3) { animation-delay: 0.4s; }
+
+  @keyframes dq-dot-pulse {
+    0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1.2); }
+  }
+
+  /* ── Empty state orb ── */
+
+  .dq-orb-ring {
+    width: 72px;
+    height: 72px;
+    border-radius: 50%;
+    border: 1px solid var(--dq-border-accent);
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: dq-orb-breathe 5s ease-in-out infinite;
+  }
+
+  .dq-orb-ring::after {
+    content: '';
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: radial-gradient(circle, var(--dq-accent) 0%, transparent 70%);
+    opacity: 0.25;
+  }
+
+  @keyframes dq-orb-breathe {
+    0%, 100% { transform: scale(1); border-color: rgba(212, 165, 116, 0.15); }
+    50% { transform: scale(1.05); border-color: rgba(212, 165, 116, 0.3); }
+  }
+
+  /* ── Ornamental corners ── */
+
+  .dq-corner {
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    opacity: 0.15;
+  }
+
+  .dq-corner svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .dq-corner--tl { top: 16px; left: 16px; }
+  .dq-corner--tr { top: 16px; right: 16px; transform: scaleX(-1); }
+  .dq-corner--bl { bottom: 16px; left: 16px; transform: scaleY(-1); }
+  .dq-corner--br { bottom: 16px; right: 16px; transform: scale(-1); }
 `;
+
+// ── Corner Ornament SVG ──────────────────────────────────────
+
+function CornerOrnament() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1">
+      <path d="M0 12 Q0 0, 12 0" style={{ color: 'var(--dq-accent)' }} />
+      <path d="M0 8 Q0 0, 8 0" style={{ color: 'var(--dq-accent)', opacity: 0.5 }} />
+    </svg>
+  );
+}
 
 // ── Quote parsing ────────────────────────────────────────────
 
 function parseQuoteResponse(response: string): { text: string; author: string } | null {
-  // Try to parse structured formats first:
-  // "quote text" — Author
-  // "quote text" - Author
   const quoteMatch = response.match(/["""](.+?)["""]\s*[—–-]\s*(.+?)$/ms);
   if (quoteMatch) {
     return { text: quoteMatch[1].trim(), author: quoteMatch[2].trim() };
   }
 
-  // Try: QUOTE: ... AUTHOR: ...
   const labelMatch = response.match(/QUOTE:\s*(.+?)\s*AUTHOR:\s*(.+)/si);
   if (labelMatch) {
     return { text: labelMatch[1].trim().replace(/^[""]|[""]$/g, ''), author: labelMatch[2].trim() };
   }
 
-  // Fallback: split on last dash/em-dash line
   const lines = response.trim().split('\n').filter(Boolean);
   if (lines.length >= 2) {
     const lastLine = lines[lines.length - 1];
@@ -189,62 +416,46 @@ export function DailyQuote() {
   return (
     <>
       <style>{CUSTOM_STYLES}</style>
-      <div className="dq-root flex h-full w-full flex-col overflow-hidden p-2">
-        <div className="dq-card flex flex-1 flex-col overflow-hidden">
+      <div className="dq-root flex h-full w-full flex-col overflow-hidden p-4">
+        <div className="dq-card flex flex-1 flex-col overflow-hidden relative p-4">
+          {/* Atmospheric background glow */}
+          <div className="dq-atmosphere" />
+
+          {/* Ornamental corners */}
+          <div className="dq-corner dq-corner--tl"><CornerOrnament /></div>
+          <div className="dq-corner dq-corner--tr"><CornerOrnament /></div>
+          <div className="dq-corner dq-corner--bl"><CornerOrnament /></div>
+          <div className="dq-corner dq-corner--br"><CornerOrnament /></div>
+
           {/* Header */}
-          <div className="shrink-0 px-6 pb-2 pt-5">
-            <div className="flex items-baseline justify-between">
-              <h1
-                className="text-xl font-medium tracking-tight"
-                style={{ color: 'var(--dq-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}
+          <div className="shrink-0 px-6 pt-4 relative z-10">
+            <div className="flex items-center justify-between">
+              <p
+                className="text-sm font-medium tracking-[0.15em] uppercase"
+                style={{ color: 'var(--dq-muted)' }}
               >
                 Daily Quote
-              </h1>
+              </p>
               {state.lastRefreshDate && (
-                <span className="text-sm" style={{ color: 'var(--dq-muted)' }}>
+                <p
+                  className="text-sm tracking-wide"
+                  style={{ color: 'var(--dq-dim)' }}
+                >
                   {formatDateNice(state.lastRefreshDate)}
-                </span>
+                </p>
               )}
             </div>
           </div>
 
           {/* Content */}
-          <div className="flex flex-1 flex-col items-center justify-center px-6 py-8">
+          <div className="flex flex-1 flex-col items-center justify-center px-12 py-12 relative z-10">
             {state.quote && !loading ? (
-              <div className="dq-animate-in flex max-w-md flex-col items-center text-center">
-                {/* Quote mark */}
-                <div
-                  className="mb-4 text-4xl font-light leading-none"
-                  style={{ color: 'var(--dq-accent)', opacity: 0.4 }}
-                >
-                  &ldquo;
-                </div>
-
-                {/* Quote text */}
-                <p
-                  className="dq-quote-text text-lg"
-                  style={{ color: 'var(--dq-text)' }}
-                >
-                  {state.quote.text}
-                </p>
-
-                {/* Author */}
-                <p
-                  className="mt-4 text-sm font-medium tracking-wide"
-                  style={{ color: 'var(--dq-accent)' }}
-                >
-                  — {state.quote.author}
-                </p>
-
-                {/* Refresh button */}
-                <button
-                  className="dq-button mt-8"
-                  onClick={requestQuote}
-                  disabled={loading}
-                >
-                  {isStale ? 'New quote for today' : 'Get another'}
-                </button>
-              </div>
+              <QuoteDisplay
+                quote={state.quote}
+                isStale={isStale}
+                loading={loading}
+                onRefresh={requestQuote}
+              />
             ) : loading ? (
               <LoadingState />
             ) : (
@@ -252,7 +463,10 @@ export function DailyQuote() {
             )}
 
             {error && (
-              <p className="mt-3 text-xs" style={{ color: '#f87171' }}>
+              <p
+                className="mt-4 text-xs font-medium"
+                style={{ color: '#e87c6c' }}
+              >
                 {error}
               </p>
             )}
@@ -263,30 +477,91 @@ export function DailyQuote() {
   );
 }
 
+// ── Quote Display ────────────────────────────────────────────
+
+function QuoteDisplay({
+  quote,
+  isStale,
+  loading,
+  onRefresh,
+}: {
+  quote: { text: string; author: string };
+  isStale: boolean;
+  loading: boolean;
+  onRefresh: () => void;
+}) {
+  return (
+    <div className="dq-animate-quote flex w-full max-w-3xl flex-col items-center text-center">
+      {/* Quote text with inline decorative marks */}
+      <p
+        className="dq-quote-text dq-animate-text"
+        style={{ color: 'var(--dq-text-soft)' }}
+      >
+        <span className="dq-quote-mark" style={{ fontSize: '1.6em', marginRight: '0.08em' }} aria-hidden="true">&ldquo;</span>
+        {quote.text}
+        <span className="dq-quote-mark" style={{ fontSize: '1.6em', marginLeft: '0.08em' }} aria-hidden="true">&rdquo;</span>
+      </p>
+
+      {/* Divider */}
+      <div className="dq-divider dq-animate-divider mt-10 mb-8" />
+
+      {/* Author */}
+      <p
+        className="dq-animate-author text-lg font-medium tracking-[0.14em] uppercase"
+        style={{
+          color: 'var(--dq-accent)',
+          fontFamily: "'Outfit', sans-serif",
+        }}
+      >
+        {quote.author}
+      </p>
+
+      {/* Refresh button */}
+      <button
+        className="dq-button dq-animate-button mt-16"
+        onClick={onRefresh}
+        disabled={loading}
+      >
+        <span>{isStale ? 'New quote for today' : 'Get another'}</span>
+      </button>
+    </div>
+  );
+}
+
 // ── Empty State ──────────────────────────────────────────────
 
 function EmptyState({ onGenerate, loading }: { onGenerate: () => void; loading: boolean }) {
   return (
-    <div className="dq-animate-in flex flex-col items-center text-center">
-      <div className="dq-orb mb-6" />
+    <div className="dq-animate-empty flex flex-col items-center text-center">
+      {/* Orb */}
+      <div className="dq-orb-ring mb-12" />
+
+      {/* Title */}
       <h2
-        className="text-lg font-medium"
-        style={{ color: 'var(--dq-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}
+        className="text-3xl font-medium tracking-tight"
+        style={{
+          color: 'var(--dq-text)',
+          fontFamily: "'Playfair Display', Georgia, serif",
+        }}
       >
         Your daily inspiration awaits
       </h2>
+
+      {/* Subtitle */}
       <p
-        className="mt-2 max-w-[260px] text-lg leading-relaxed"
+        className="mt-6 max-w-[360px] text-lg leading-relaxed"
         style={{ color: 'var(--dq-muted)' }}
       >
-        Tap below to generate today&rsquo;s quote — something thoughtful to carry with you.
+        Generate today&rsquo;s quote — something thoughtful to carry with you.
       </p>
+
+      {/* Button */}
       <button
-        className="dq-button mt-6"
+        className="dq-button mt-12"
         onClick={onGenerate}
         disabled={loading}
       >
-        Generate today&rsquo;s quote
+        <span>Generate today&rsquo;s quote</span>
       </button>
     </div>
   );
@@ -296,20 +571,18 @@ function EmptyState({ onGenerate, loading }: { onGenerate: () => void; loading: 
 
 function LoadingState() {
   return (
-    <div className="dq-animate-in flex flex-col items-center text-center">
-      <svg
-        className="dq-spin mb-4"
-        width="24"
-        height="24"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="var(--dq-accent)"
-        strokeWidth="2"
-        strokeLinecap="round"
+    <div className="dq-animate-empty flex flex-col items-center text-center">
+      {/* Loading dots */}
+      <div className="flex gap-3 mb-8">
+        <div className="dq-loading-dot" />
+        <div className="dq-loading-dot" />
+        <div className="dq-loading-dot" />
+      </div>
+
+      <p
+        className="text-lg font-light tracking-wide"
+        style={{ color: 'var(--dq-muted)' }}
       >
-        <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
-      </svg>
-      <p className="text-sm" style={{ color: 'var(--dq-muted)' }}>
         Finding something inspiring…
       </p>
     </div>


### PR DESCRIPTION
## Model Selector

Adds an animated model selector to the ChatPanel input toolbar, allowing switching between all authenticated models and thinking/reasoning levels.

### What it does

- **Dynamic model list** — populated from PI SDK's `ModelRegistry.getAvailable()`, grouped by provider with logos and display names. No static model list — shows exactly what the user has authenticated.
- **Thinking level control** — segmented picker (Off → Min → Low → Med → High → Max) with animated sliding gradient pill. Always visible; visually disabled when the selected model doesn't support reasoning.
- **Search filter** — type-ahead filter at the top of the popover, matches on model name and ID.
- **Per-session persistence** — model and thinking level are saved to the session file via the SDK (`session.setModel()` / `session.setThinkingLevel()`). Restored when re-opening a session. New sessions inherit from settings defaults.
- **Live auth detection** — reloads `auth.json` before every model state query and model switch, so keys added via `pi auth` or OAuth are picked up without restart.
- **Spring animations** — popover entrance, selection checkmarks, thinking pill transitions, all using `motion/react`.

### New files

- `src/components/layout/ModelSelector.tsx` — the UI component
- `src/components/layout/model-config.ts` — thinking level constants and group lookup helpers

### Modified files

- `src/types/ipc.ts` — `ModelInfo`, `SessionModelState`, `AvailableModelGroup` types, `model_change` event, new IPC channels
- `src/types/electron.d.ts` — window API type declarations
- `electron/preload.ts` — exposed `getModelState`, `setModel`, `setThinkingLevel`
- `electron/ipc/agent.ts` — IPC handlers, provider name/logo maps, `buildModelState()` from registry
- `electron/ipc/shared-infra.ts` — default thinking level to 'high'
- `electron/ipc/app-agent.ts` — default thinking level to 'high'
- `src/stores/agent.ts` — `modelState` on AgentInstance, actions, event handler
- `src/components/layout/ChatPanel.tsx` — wired ModelSelector into prompt footer

### IPC flow

```
ModelSelector → store.setModel() → preload → ipc handler → session.setModel() → model_change event → store update → UI
```
