### PR TITLE
feat: provider authentication — OAuth login + API key management

### DIFF
--- a/apps/desktop/electron/ipc/auth.ts
+++ b/apps/desktop/electron/ipc/auth.ts
@@ -1,0 +1,294 @@
+/**
+ * Auth IPC handlers — OAuth login + API key management.
+ *
+ * Bridges the Pi SDK's AuthStorage.login() callback-driven OAuth flow
+ * across Electron IPC, and provides simple set/remove for API keys.
+ *
+ * OAuth flow:
+ *   1. Renderer calls `login(providerId)`
+ *   2. Main calls `authStorage.login(providerId, callbacks)`
+ *   3. Each callback sends an OAuthEvent to renderer via push channel
+ *   4. For prompts/manual input, main holds a Promise until renderer responds
+ *   5. Renderer calls `respondPrompt(value)` or `respondManualCode(value)`
+ *   6. On completion, main sends success/error event
+ *
+ * API key flow:
+ *   Renderer calls `setApiKey(providerId, key)` or `removeApiKey(providerId)`.
+ *   Main writes directly to auth.json via AuthStorage.
+ */
+
+import { ipcMain, BrowserWindow, shell } from 'electron';
+import { getOAuthProviders, getEnvApiKey } from '@mariozechner/pi-ai';
+import type { OAuthProviderId } from '@mariozechner/pi-ai';
+
+import { IpcChannels } from '../../src/types/ipc';
+import type {
+  OAuthProviderInfo,
+  ApiKeyProviderInfo,
+  AuthProvidersResponse,
+  OAuthEvent,
+} from '../../src/types/ipc';
+import { ensureInfra } from './shared-infra';
+
+// ── API-key provider definitions ─────────────────────────────
+// Providers that accept a plain API key (not OAuth).
+// Ordered roughly by popularity.
+
+const API_KEY_PROVIDERS: { id: string; name: string }[] = [
+  { id: 'anthropic', name: 'Anthropic' },
+  { id: 'openai', name: 'OpenAI' },
+  { id: 'google', name: 'Google (Gemini)' },
+  { id: 'openrouter', name: 'OpenRouter' },
+  { id: 'xai', name: 'xAI' },
+  { id: 'groq', name: 'Groq' },
+  { id: 'cerebras', name: 'Cerebras' },
+  { id: 'mistral', name: 'Mistral' },
+  { id: 'azure-openai-responses', name: 'Azure OpenAI' },
+  { id: 'huggingface', name: 'Hugging Face' },
+  { id: 'vercel-ai-gateway', name: 'Vercel AI Gateway' },
+  { id: 'zai', name: 'ZAI' },
+  { id: 'opencode', name: 'OpenCode' },
+  { id: 'kimi-coding', name: 'Kimi' },
+];
+
+// ── In-flight login state ────────────────────────────────────
+
+let abortController: AbortController | null = null;
+let promptResolver: ((value: string) => void) | null = null;
+let promptRejecter: ((err: Error) => void) | null = null;
+let manualCodeResolver: ((value: string) => void) | null = null;
+let manualCodeRejecter: ((err: Error) => void) | null = null;
+
+/** Send an OAuth event to all renderer windows. */
+function sendAuthEvent(event: OAuthEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(IpcChannels.auth.event, event);
+  }
+}
+
+/** Clear all pending resolvers (on cancel, complete, or error). */
+function clearPending(): void {
+  promptResolver = null;
+  promptRejecter = null;
+  manualCodeResolver = null;
+  manualCodeRejecter = null;
+  abortController = null;
+}
+
+// ── Registration ─────────────────────────────────────────────
+
+export function registerAuthHandlers(): void {
+  // ── Get all providers (OAuth + API key) with auth status ──
+  ipcMain.handle(
+    IpcChannels.auth.getProviders,
+    async (): Promise<AuthProvidersResponse> => {
+      const infra = await ensureInfra();
+
+      // OAuth providers
+      const oauthProviders = getOAuthProviders();
+      const oauth: OAuthProviderInfo[] = oauthProviders.map((p) => {
+        const cred = infra.authStorage.get(p.id);
+        return {
+          id: p.id,
+          name: p.name,
+          isLoggedIn: cred?.type === 'oauth',
+          usesCallbackServer: p.usesCallbackServer ?? false,
+        };
+      });
+
+      // API key providers
+      const apiKey: ApiKeyProviderInfo[] = API_KEY_PROVIDERS.map((p) => {
+        const cred = infra.authStorage.get(p.id);
+        const envKey = getEnvApiKey(p.id);
+        return {
+          id: p.id,
+          name: p.name,
+          hasKey: cred?.type === 'api_key' || !!envKey,
+          fromEnv: !cred && !!envKey,
+        };
+      });
+
+      return { oauth, apiKey };
+    },
+  );
+
+  // ── Start login ────────────────────────────────────────────
+  ipcMain.handle(
+    IpcChannels.auth.login,
+    async (_event, providerId: string): Promise<void> => {
+      const infra = await ensureInfra();
+      const providers = getOAuthProviders();
+      const provider = providers.find((p) => p.id === providerId);
+
+      if (!provider) {
+        sendAuthEvent({
+          type: 'error',
+          provider: providerId,
+          message: `Unknown OAuth provider: ${providerId}`,
+        });
+        return;
+      }
+
+      // Abort any in-flight login
+      if (abortController) {
+        abortController.abort();
+        clearPending();
+      }
+
+      abortController = new AbortController();
+      const usesCallbackServer = provider.usesCallbackServer ?? false;
+
+      try {
+        await infra.authStorage.login(providerId as OAuthProviderId, {
+          onAuth: (info) => {
+            // Open browser via Electron (better than exec)
+            shell.openExternal(info.url).catch(() => {
+              // Silently ignore — URL is shown in dialog anyway
+            });
+
+            sendAuthEvent({
+              type: 'auth',
+              url: info.url,
+              instructions: info.instructions,
+            });
+
+            // For callback server providers, also request manual input
+            if (usesCallbackServer) {
+              sendAuthEvent({
+                type: 'manual_input',
+                prompt: 'Paste redirect URL below, or complete login in browser:',
+              });
+            } else if (providerId === 'github-copilot') {
+              sendAuthEvent({
+                type: 'waiting',
+                message: 'Waiting for browser authentication...',
+              });
+            }
+          },
+
+          onPrompt: async (prompt) => {
+            sendAuthEvent({
+              type: 'prompt',
+              message: prompt.message,
+              placeholder: prompt.placeholder,
+            });
+
+            // Wait for renderer to respond
+            return new Promise<string>((resolve, reject) => {
+              promptResolver = resolve;
+              promptRejecter = reject;
+            });
+          },
+
+          onProgress: (message) => {
+            sendAuthEvent({ type: 'progress', message });
+          },
+
+          onManualCodeInput: () => {
+            // Promise that resolves when renderer submits manual code
+            return new Promise<string>((resolve, reject) => {
+              manualCodeResolver = resolve;
+              manualCodeRejecter = reject;
+            });
+          },
+
+          signal: abortController.signal,
+        });
+
+        // Success — refresh model registry so new credentials are picked up
+        infra.modelRegistry.refresh();
+
+        sendAuthEvent({
+          type: 'success',
+          provider: provider.name,
+          message: `Logged in to ${provider.name}. Credentials saved.`,
+        });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg === 'Login cancelled') {
+          sendAuthEvent({ type: 'cancelled' });
+        } else {
+          sendAuthEvent({
+            type: 'error',
+            provider: provider.name,
+            message: `Failed to login to ${provider.name}: ${msg}`,
+          });
+        }
+      } finally {
+        clearPending();
+      }
+    },
+  );
+
+  // ── Logout (OAuth or API key) ────────────────────────────
+  ipcMain.handle(
+    IpcChannels.auth.logout,
+    async (_event, providerId: string): Promise<void> => {
+      const infra = await ensureInfra();
+      infra.authStorage.logout(providerId);
+      infra.modelRegistry.refresh();
+    },
+  );
+
+  // ── Set API key ────────────────────────────────────────────
+  ipcMain.handle(
+    IpcChannels.auth.setApiKey,
+    async (_event, providerId: string, key: string): Promise<void> => {
+      const infra = await ensureInfra();
+      infra.authStorage.set(providerId, { type: 'api_key', key });
+      infra.modelRegistry.refresh();
+    },
+  );
+
+  // ── Remove API key ─────────────────────────────────────────
+  ipcMain.handle(
+    IpcChannels.auth.removeApiKey,
+    async (_event, providerId: string): Promise<void> => {
+      const infra = await ensureInfra();
+      infra.authStorage.remove(providerId);
+      infra.modelRegistry.refresh();
+    },
+  );
+
+  // ── Respond to pending prompt ──────────────────────────────
+  ipcMain.handle(
+    IpcChannels.auth.respondPrompt,
+    async (_event, value: string): Promise<void> => {
+      if (promptResolver) {
+        promptResolver(value);
+        promptResolver = null;
+        promptRejecter = null;
+      }
+    },
+  );
+
+  // ── Respond to pending manual code input ───────────────────
+  ipcMain.handle(
+    IpcChannels.auth.respondManualCode,
+    async (_event, value: string): Promise<void> => {
+      if (manualCodeResolver) {
+        manualCodeResolver(value);
+        manualCodeResolver = null;
+        manualCodeRejecter = null;
+      }
+    },
+  );
+
+  // ── Cancel in-progress login ───────────────────────────────
+  ipcMain.handle(
+    IpcChannels.auth.cancel,
+    async (): Promise<void> => {
+      if (abortController) {
+        abortController.abort();
+      }
+      // Reject any pending prompts
+      if (promptRejecter) {
+        promptRejecter(new Error('Login cancelled'));
+      }
+      if (manualCodeRejecter) {
+        manualCodeRejecter(new Error('Login cancelled'));
+      }
+      clearPending();
+    },
+  );
+}

--- a/apps/desktop/electron/ipc/auth.ts
+++ b/apps/desktop/electron/ipc/auth.ts
@@ -92,7 +92,6 @@ export function registerAuthHandlers(): void {
           id: p.id,
           name: p.name,
           isLoggedIn: cred?.type === 'oauth',
-          usesCallbackServer: p.usesCallbackServer ?? false,
         };
       });
 
@@ -253,24 +252,30 @@ export function registerAuthHandlers(): void {
   // ── Respond to pending prompt ──────────────────────────────
   ipcMain.handle(
     IpcChannels.auth.respondPrompt,
-    async (_event, value: string): Promise<void> => {
+    async (_event, value: string): Promise<boolean> => {
       if (promptResolver) {
         promptResolver(value);
         promptResolver = null;
         promptRejecter = null;
+        return true;
       }
+      console.warn('[auth] respondPrompt called but no prompt is pending — ignoring');
+      return false;
     },
   );
 
   // ── Respond to pending manual code input ───────────────────
   ipcMain.handle(
     IpcChannels.auth.respondManualCode,
-    async (_event, value: string): Promise<void> => {
+    async (_event, value: string): Promise<boolean> => {
       if (manualCodeResolver) {
         manualCodeResolver(value);
         manualCodeResolver = null;
         manualCodeRejecter = null;
+        return true;
       }
+      console.warn('[auth] respondManualCode called but no input is pending — ignoring');
+      return false;
     },
   );
 

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -13,6 +13,7 @@ import { registerAppAgentHandlers } from './app-agent';
 import { registerShellHandlers } from './shell';
 import { registerAppStateHandlers } from './app-state';
 import { registerAppsHandlers } from './apps';
+import { registerAuthHandlers } from './auth';
 
 export function registerAllIpcHandlers(): void {
   registerWorkspaceHandlers();
@@ -22,4 +23,5 @@ export function registerAllIpcHandlers(): void {
   registerShellHandlers();
   registerAppStateHandlers();
   registerAppsHandlers();
+  registerAuthHandlers();
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -10,6 +10,8 @@ import type {
   SeroAppManifest,
   SessionUsageStats,
   SessionModelState,
+  AuthProvidersResponse,
+  OAuthEvent,
 } from '../src/types/ipc';
 
 contextBridge.exposeInMainWorld('sero', {
@@ -134,5 +136,41 @@ contextBridge.exposeInMainWorld('sero', {
   appAgent: {
     prompt: (appId: string, workspaceId: string, text: string): Promise<string> =>
       ipcRenderer.invoke(IpcChannels.appAgent.prompt, appId, workspaceId, text),
+  },
+
+  auth: {
+    getProviders: (): Promise<AuthProvidersResponse> =>
+      ipcRenderer.invoke(IpcChannels.auth.getProviders),
+
+    login: (providerId: string): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.auth.login, providerId),
+
+    logout: (providerId: string): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.auth.logout, providerId),
+
+    setApiKey: (providerId: string, key: string): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.auth.setApiKey, providerId, key),
+
+    removeApiKey: (providerId: string): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.auth.removeApiKey, providerId),
+
+    respondPrompt: (value: string): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.auth.respondPrompt, value),
+
+    respondManualCode: (value: string): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.auth.respondManualCode, value),
+
+    cancel: (): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.auth.cancel),
+
+    onEvent: (callback: (event: OAuthEvent) => void): (() => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: OAuthEvent) => {
+        callback(data);
+      };
+      ipcRenderer.on(IpcChannels.auth.event, handler);
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.auth.event, handler);
+      };
+    },
   },
 });

--- a/apps/desktop/src/components/layout/AuthLoginDialog.tsx
+++ b/apps/desktop/src/components/layout/AuthLoginDialog.tsx
@@ -1,0 +1,301 @@
+/**
+ * Auth login dialog — OAuth + API key management.
+ *
+ * Self-contained component that drives OAuth login flows and API key
+ * entry. Communicates with the main process via `window.sero.auth.*`.
+ *
+ * Usage:
+ *   <AuthLoginDialog open={open} onOpenChange={setOpen} onComplete={refreshModels} />
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { KeyRound } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import type { OAuthProviderInfo, ApiKeyProviderInfo, OAuthEvent } from '@/types/ipc';
+import {
+  ProviderListView,
+  AuthenticatingView,
+  WaitingView,
+  PromptView,
+  ApiKeyEntryView,
+  ResultView,
+} from './AuthLoginViews';
+
+// ── Types ────────────────────────────────────────────────────
+
+type DialogPhase =
+  | 'providers'       // Provider list (initial)
+  | 'authenticating'  // Browser opened, waiting for OAuth
+  | 'prompt'          // Waiting for user text input (OAuth)
+  | 'manual_input'    // Waiting for redirect URL paste (OAuth)
+  | 'waiting'         // Polling (e.g. GitHub Copilot)
+  | 'api_key_entry'   // Entering an API key
+  | 'success'
+  | 'error';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Called after a successful login, API key save, or logout. */
+  onComplete?: () => void;
+  /** Start in logout mode. */
+  mode?: 'login' | 'logout';
+}
+
+// ── Component ────────────────────────────────────────────────
+
+export function AuthLoginDialog({ open, onOpenChange, onComplete, mode = 'login' }: Props) {
+  const [oauthProviders, setOauthProviders] = useState<OAuthProviderInfo[]>([]);
+  const [apiKeyProviders, setApiKeyProviders] = useState<ApiKeyProviderInfo[]>([]);
+  const [phase, setPhase] = useState<DialogPhase>('providers');
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+  const [selectedProviderName, setSelectedProviderName] = useState('');
+  const [authUrl, setAuthUrl] = useState<string | null>(null);
+  const [promptMessage, setPromptMessage] = useState('');
+  const [promptPlaceholder, setPromptPlaceholder] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const [statusMessage, setStatusMessage] = useState('');
+  const [progressMessages, setProgressMessages] = useState<string[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // ── Load providers ──────────────────────────────────────────
+  const loadProviders = useCallback(async () => {
+    try {
+      const { oauth, apiKey } = await window.sero.auth.getProviders();
+      setOauthProviders(oauth);
+      setApiKeyProviders(apiKey);
+    } catch {
+      setOauthProviders([]);
+      setApiKeyProviders([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      setPhase('providers');
+      setSelectedProvider(null);
+      setSelectedProviderName('');
+      setAuthUrl(null);
+      setInputValue('');
+      setStatusMessage('');
+      setProgressMessages([]);
+      loadProviders();
+    }
+  }, [open, loadProviders]);
+
+  // ── Subscribe to OAuth events ───────────────────────────────
+  useEffect(() => {
+    if (!open) return;
+
+    const unsub = window.sero.auth.onEvent((event: OAuthEvent) => {
+      switch (event.type) {
+        case 'auth':
+          setAuthUrl(event.url);
+          setPhase('authenticating');
+          if (event.instructions) {
+            setProgressMessages((prev) => [...prev, event.instructions!]);
+          }
+          break;
+        case 'prompt':
+          setPromptMessage(event.message);
+          setPromptPlaceholder(event.placeholder ?? '');
+          setInputValue('');
+          setPhase('prompt');
+          setTimeout(() => inputRef.current?.focus(), 50);
+          break;
+        case 'manual_input':
+          setPromptMessage(event.prompt);
+          setInputValue('');
+          setPhase('manual_input');
+          setTimeout(() => inputRef.current?.focus(), 50);
+          break;
+        case 'waiting':
+          setStatusMessage(event.message);
+          setPhase('waiting');
+          break;
+        case 'progress':
+          setProgressMessages((prev) => [...prev, event.message]);
+          break;
+        case 'success':
+          setStatusMessage(event.message);
+          setPhase('success');
+          loadProviders();
+          onComplete?.();
+          break;
+        case 'error':
+          setStatusMessage(event.message);
+          setPhase('error');
+          break;
+        case 'cancelled':
+          setPhase('providers');
+          break;
+      }
+    });
+
+    return unsub;
+  }, [open, loadProviders, onComplete]);
+
+  // ── Cancel on close ─────────────────────────────────────────
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next && (phase === 'authenticating' || phase === 'prompt' || phase === 'manual_input' || phase === 'waiting')) {
+        window.sero.auth.cancel();
+      }
+      onOpenChange(next);
+    },
+    [phase, onOpenChange],
+  );
+
+  // ── OAuth actions ───────────────────────────────────────────
+  const handleOAuthLogin = useCallback((providerId: string) => {
+    setSelectedProvider(providerId);
+    setProgressMessages([]);
+    window.sero.auth.login(providerId);
+  }, []);
+
+  const handleLogout = useCallback(
+    async (providerId: string) => {
+      await window.sero.auth.logout(providerId);
+      await loadProviders();
+      onComplete?.();
+    },
+    [loadProviders, onComplete],
+  );
+
+  const handleSubmitPrompt = useCallback(() => {
+    if (!inputValue.trim()) return;
+    window.sero.auth.respondPrompt(inputValue.trim());
+    setInputValue('');
+    setPhase('authenticating');
+  }, [inputValue]);
+
+  const handleSubmitManualCode = useCallback(() => {
+    if (!inputValue.trim()) return;
+    window.sero.auth.respondManualCode(inputValue.trim());
+    setInputValue('');
+    setPhase('authenticating');
+  }, [inputValue]);
+
+  const handleOAuthCancel = useCallback(() => {
+    window.sero.auth.cancel();
+    setPhase('providers');
+  }, []);
+
+  // ── API key actions ─────────────────────────────────────────
+  const handleApiKeyStart = useCallback((providerId: string, providerName: string) => {
+    setSelectedProvider(providerId);
+    setSelectedProviderName(providerName);
+    setInputValue('');
+    setPhase('api_key_entry');
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, []);
+
+  const handleApiKeySave = useCallback(async () => {
+    if (!inputValue.trim() || !selectedProvider) return;
+    try {
+      await window.sero.auth.setApiKey(selectedProvider, inputValue.trim());
+      setStatusMessage(`API key saved for ${selectedProviderName}.`);
+      setPhase('success');
+      await loadProviders();
+      onComplete?.();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setStatusMessage(`Failed to save API key: ${msg}`);
+      setPhase('error');
+    }
+  }, [inputValue, selectedProvider, selectedProviderName, loadProviders, onComplete]);
+
+  const handleApiKeyRemove = useCallback(
+    async (providerId: string) => {
+      await window.sero.auth.removeApiKey(providerId);
+      await loadProviders();
+      onComplete?.();
+    },
+    [loadProviders, onComplete],
+  );
+
+  // ── Render ──────────────────────────────────────────────────
+  const isLogin = mode === 'login';
+  const title = isLogin ? 'Provider Authentication' : 'Logout from Provider';
+  const description = isLogin
+    ? 'Login via OAuth or add an API key to access models.'
+    : 'Remove saved credentials for a provider.';
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <KeyRound className="size-5" />
+            {title}
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {phase === 'providers' && (
+            <ProviderListView
+              oauthProviders={oauthProviders}
+              apiKeyProviders={apiKeyProviders}
+              mode={mode}
+              onOAuthLogin={handleOAuthLogin}
+              onApiKeyStart={handleApiKeyStart}
+              onApiKeyRemove={handleApiKeyRemove}
+              onLogout={handleLogout}
+            />
+          )}
+
+          {phase === 'authenticating' && (
+            <AuthenticatingView
+              authUrl={authUrl}
+              progressMessages={progressMessages}
+              onCancel={handleOAuthCancel}
+            />
+          )}
+
+          {phase === 'waiting' && (
+            <WaitingView message={statusMessage} onCancel={handleOAuthCancel} />
+          )}
+
+          {(phase === 'prompt' || phase === 'manual_input') && (
+            <PromptView
+              message={promptMessage}
+              placeholder={promptPlaceholder}
+              value={inputValue}
+              onChange={setInputValue}
+              onSubmit={phase === 'prompt' ? handleSubmitPrompt : handleSubmitManualCode}
+              onCancel={handleOAuthCancel}
+              inputRef={inputRef}
+            />
+          )}
+
+          {phase === 'api_key_entry' && (
+            <ApiKeyEntryView
+              providerName={selectedProviderName}
+              value={inputValue}
+              onChange={setInputValue}
+              onSave={handleApiKeySave}
+              onCancel={() => setPhase('providers')}
+              inputRef={inputRef}
+            />
+          )}
+
+          {phase === 'success' && (
+            <ResultView type="success" message={statusMessage} onDone={() => setPhase('providers')} />
+          )}
+
+          {phase === 'error' && (
+            <ResultView type="error" message={statusMessage} onDone={() => setPhase('providers')} />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/layout/AuthLoginDialog.tsx
+++ b/apps/desktop/src/components/layout/AuthLoginDialog.tsx
@@ -162,9 +162,15 @@ export function AuthLoginDialog({ open, onOpenChange, onComplete, mode = 'login'
 
   const handleLogout = useCallback(
     async (providerId: string) => {
-      await window.sero.auth.logout(providerId);
-      await loadProviders();
-      onComplete?.();
+      try {
+        await window.sero.auth.logout(providerId);
+        await loadProviders();
+        onComplete?.();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setStatusMessage(`Failed to logout: ${msg}`);
+        setPhase('error');
+      }
     },
     [loadProviders, onComplete],
   );
@@ -214,9 +220,15 @@ export function AuthLoginDialog({ open, onOpenChange, onComplete, mode = 'login'
 
   const handleApiKeyRemove = useCallback(
     async (providerId: string) => {
-      await window.sero.auth.removeApiKey(providerId);
-      await loadProviders();
-      onComplete?.();
+      try {
+        await window.sero.auth.removeApiKey(providerId);
+        await loadProviders();
+        onComplete?.();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setStatusMessage(`Failed to remove API key: ${msg}`);
+        setPhase('error');
+      }
     },
     [loadProviders, onComplete],
   );

--- a/apps/desktop/src/components/layout/AuthLoginViews.tsx
+++ b/apps/desktop/src/components/layout/AuthLoginViews.tsx
@@ -117,7 +117,10 @@ export function ProviderListView({
   // Logout mode — show all providers with credentials
   const loggedInOAuth = oauthProviders.filter((p) => p.isLoggedIn);
   const configuredApiKey = apiKeyProviders.filter((p) => p.hasKey && !p.fromEnv);
-  const all = [...loggedInOAuth.map((p) => ({ ...p, kind: 'oauth' as const })), ...configuredApiKey.map((p) => ({ ...p, kind: 'apiKey' as const }))];
+  const all = [
+    ...loggedInOAuth.map((p) => ({ ...p, kind: 'oauth' as const })),
+    ...configuredApiKey.map((p) => ({ ...p, kind: 'apiKey' as const })),
+  ];
 
   if (all.length === 0) {
     return (

--- a/apps/desktop/src/components/layout/AuthLoginViews.tsx
+++ b/apps/desktop/src/components/layout/AuthLoginViews.tsx
@@ -1,0 +1,369 @@
+/**
+ * Sub-views for AuthLoginDialog.
+ *
+ * Split out to keep each file under 500 lines.
+ */
+
+import { useState } from 'react';
+import {
+  CheckCircle,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Key,
+  Loader2,
+  LogIn,
+  LogOut,
+  Trash2,
+  XCircle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { OAuthProviderInfo, ApiKeyProviderInfo } from '@/types/ipc';
+
+// ── Provider list ─────────────────────────────────────────────
+
+export function ProviderListView({
+  oauthProviders,
+  apiKeyProviders,
+  mode,
+  onOAuthLogin,
+  onApiKeyStart,
+  onApiKeyRemove,
+  onLogout,
+}: {
+  oauthProviders: OAuthProviderInfo[];
+  apiKeyProviders: ApiKeyProviderInfo[];
+  mode: 'login' | 'logout';
+  onOAuthLogin: (id: string) => void;
+  onApiKeyStart: (id: string, name: string) => void;
+  onApiKeyRemove: (id: string) => void;
+  onLogout: (id: string) => void;
+}) {
+  const isLogin = mode === 'login';
+
+  if (isLogin) {
+    return (
+      <div className="space-y-4">
+        {/* OAuth section */}
+        <div>
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1.5 px-1">
+            OAuth
+          </h4>
+          <div className="space-y-0.5">
+            {oauthProviders.map((p) => (
+              <button
+                key={p.id}
+                onClick={() => onOAuthLogin(p.id)}
+                className="flex w-full items-center justify-between rounded-md px-3 py-2
+                           text-sm hover:bg-accent transition-colors text-left group"
+              >
+                <div className="flex items-center gap-2.5">
+                  <LogIn className="size-4 text-muted-foreground group-hover:text-foreground transition-colors" />
+                  <span>{p.name}</span>
+                </div>
+                {p.isLoggedIn && <AuthBadge />}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* API Key section */}
+        <div>
+          <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1.5 px-1">
+            API Key
+          </h4>
+          <div className="space-y-0.5">
+            {apiKeyProviders.map((p) => (
+              <div
+                key={p.id}
+                className="flex w-full items-center justify-between rounded-md px-3 py-2
+                           text-sm hover:bg-accent transition-colors group"
+              >
+                <button
+                  onClick={() => onApiKeyStart(p.id, p.name)}
+                  className="flex items-center gap-2.5 text-left flex-1 min-w-0"
+                >
+                  <Key className="size-4 text-muted-foreground group-hover:text-foreground transition-colors shrink-0" />
+                  <span className="truncate">{p.name}</span>
+                </button>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  {p.hasKey && (
+                    <>
+                      <ApiKeyBadge fromEnv={p.fromEnv} />
+                      {!p.fromEnv && (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onApiKeyRemove(p.id);
+                          }}
+                          className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+                          title="Remove API key"
+                        >
+                          <Trash2 className="size-3" />
+                        </button>
+                      )}
+                    </>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Logout mode — show all providers with credentials
+  const loggedInOAuth = oauthProviders.filter((p) => p.isLoggedIn);
+  const configuredApiKey = apiKeyProviders.filter((p) => p.hasKey && !p.fromEnv);
+  const all = [...loggedInOAuth.map((p) => ({ ...p, kind: 'oauth' as const })), ...configuredApiKey.map((p) => ({ ...p, kind: 'apiKey' as const }))];
+
+  if (all.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm py-4 text-center">
+        No providers with saved credentials.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {all.map((p) => (
+        <button
+          key={p.id}
+          onClick={() => onLogout(p.id)}
+          className="flex w-full items-center justify-between rounded-md px-3 py-2.5
+                     text-sm hover:bg-accent transition-colors text-left group"
+        >
+          <div className="flex items-center gap-2.5">
+            <LogOut className="size-4 text-muted-foreground group-hover:text-destructive transition-colors" />
+            <span>{p.name}</span>
+          </div>
+          <span className="text-xs text-muted-foreground">
+            {p.kind === 'oauth' ? 'OAuth' : 'API key'}
+          </span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ── Badges ────────────────────────────────────────────────────
+
+function AuthBadge() {
+  return (
+    <span className="text-xs text-emerald-500 flex items-center gap-1">
+      <CheckCircle className="size-3" />
+      logged in
+    </span>
+  );
+}
+
+function ApiKeyBadge({ fromEnv }: { fromEnv: boolean }) {
+  return (
+    <span className="text-xs text-emerald-500 flex items-center gap-1">
+      <CheckCircle className="size-3" />
+      {fromEnv ? 'env' : 'saved'}
+    </span>
+  );
+}
+
+// ── OAuth views ───────────────────────────────────────────────
+
+export function AuthenticatingView({
+  authUrl,
+  progressMessages,
+  onCancel,
+}: {
+  authUrl: string | null;
+  progressMessages: string[];
+  onCancel: () => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm">
+        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        <span>Waiting for browser authentication…</span>
+      </div>
+
+      {authUrl && (
+        <div className="rounded-md border p-3 space-y-1.5">
+          <p className="text-xs text-muted-foreground">
+            A browser window should have opened. If not, click below:
+          </p>
+          <a
+            href={authUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-primary hover:underline flex items-center gap-1.5 break-all"
+          >
+            <ExternalLink className="size-3.5 shrink-0" />
+            Open login page
+          </a>
+        </div>
+      )}
+
+      {progressMessages.length > 0 && (
+        <div className="text-xs text-muted-foreground space-y-0.5">
+          {progressMessages.map((msg, i) => (
+            <p key={i}>{msg}</p>
+          ))}
+        </div>
+      )}
+
+      <Button variant="outline" size="sm" onClick={onCancel} className="w-full">
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+export function WaitingView({ message, onCancel }: { message: string; onCancel: () => void }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm">
+        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        <span>{message}</span>
+      </div>
+      <Button variant="outline" size="sm" onClick={onCancel} className="w-full">
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+// ── Prompt view (OAuth) ───────────────────────────────────────
+
+export function PromptView({
+  message,
+  placeholder,
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  inputRef,
+}: {
+  message: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">{message}</p>
+      <Input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') onSubmit();
+          if (e.key === 'Escape') onCancel();
+        }}
+        placeholder={placeholder}
+        className="font-mono text-sm"
+      />
+      <div className="flex gap-2">
+        <Button size="sm" onClick={onSubmit} disabled={!value.trim()} className="flex-1">
+          Submit
+        </Button>
+        <Button variant="outline" size="sm" onClick={onCancel} className="flex-1">
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── API key entry view ────────────────────────────────────────
+
+export function ApiKeyEntryView({
+  providerName,
+  value,
+  onChange,
+  onSave,
+  onCancel,
+  inputRef,
+}: {
+  providerName: string;
+  value: string;
+  onChange: (v: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+}) {
+  const [showKey, setShowKey] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">
+        Enter API key for <span className="font-medium">{providerName}</span>:
+      </p>
+      <div className="relative">
+        <Input
+          ref={inputRef}
+          type={showKey ? 'text' : 'password'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') onSave();
+            if (e.key === 'Escape') onCancel();
+          }}
+          placeholder="sk-…"
+          className="font-mono text-sm pr-9"
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <button
+          type="button"
+          onClick={() => setShowKey((v) => !v)}
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground
+                     hover:text-foreground transition-colors rounded"
+          tabIndex={-1}
+        >
+          {showKey ? <EyeOff className="size-3.5" /> : <Eye className="size-3.5" />}
+        </button>
+      </div>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={onSave} disabled={!value.trim()} className="flex-1">
+          Save
+        </Button>
+        <Button variant="outline" size="sm" onClick={onCancel} className="flex-1">
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Result view ───────────────────────────────────────────────
+
+export function ResultView({
+  type,
+  message,
+  onDone,
+}: {
+  type: 'success' | 'error';
+  message: string;
+  onDone: () => void;
+}) {
+  const isSuccess = type === 'success';
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start gap-2 text-sm">
+        {isSuccess ? (
+          <CheckCircle className="size-4 text-emerald-500 mt-0.5 shrink-0" />
+        ) : (
+          <XCircle className="size-4 text-destructive mt-0.5 shrink-0" />
+        )}
+        <span>{message}</span>
+      </div>
+      <Button variant="outline" size="sm" onClick={onDone} className="w-full">
+        {isSuccess ? 'Done' : 'Back'}
+      </Button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -75,6 +75,10 @@ export function ChatPanel() {
   const error = focused?.error ?? null;
   const sessionId = focused?.sessionId ?? null;
 
+  const handleAuthComplete = useCallback(() => {
+    if (sessionId) fetchModelState(sessionId);
+  }, [sessionId, fetchModelState]);
+
   // ── Slash command menu state ─────────────────────────────
   // Merge SDK commands with built-in client-side commands
   const allCommands = useMemo(
@@ -269,10 +273,7 @@ export function ChatPanel() {
         open={loginDialogOpen}
         onOpenChange={setLoginDialogOpen}
         mode={loginMode}
-        onComplete={() => {
-          // Refresh model state for the active session after login/logout
-          if (sessionId) fetchModelState(sessionId);
-        }}
+        onComplete={handleAuthComplete}
       />
     </div>
   );

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -36,7 +36,14 @@ import { SlashCommandMenu } from './SlashCommandMenu';
 import { PromptAttachmentsBar, MessageAttachments } from './ChatAttachments';
 import { UsageBadge } from './UsageBadge';
 import { ModelSelector } from './ModelSelector';
+import { AuthLoginDialog } from './AuthLoginDialog';
 import type { ChatMessage, ChatAttachment, ChatToolCallMessage, SeroSlashCommandInfo } from '@/types/ipc';
+
+/** Built-in commands handled client-side (not sent to the agent). */
+const BUILTIN_COMMANDS: SeroSlashCommandInfo[] = [
+  { name: 'login', description: 'Login with OAuth provider', source: 'extension' },
+  { name: 'logout', description: 'Logout from OAuth provider', source: 'extension' },
+];
 
 /**
  * ChatPanel — agent chat panel wired to Pi SDK AgentSession pool.
@@ -58,18 +65,29 @@ export function ChatPanel() {
     return unsub;
   }, [initEventListener]);
 
+  // ── OAuth login dialog state ───────────────────────────────
+  const [loginDialogOpen, setLoginDialogOpen] = useState(false);
+  const [loginMode, setLoginMode] = useState<'login' | 'logout'>('login');
+  const fetchModelState = useAgentStore((s) => s.fetchModelState);
+
   const messages = focused?.messages ?? [];
   const isStreaming = focused?.isStreaming ?? false;
   const error = focused?.error ?? null;
   const sessionId = focused?.sessionId ?? null;
 
   // ── Slash command menu state ─────────────────────────────
+  // Merge SDK commands with built-in client-side commands
+  const allCommands = useMemo(
+    () => [...BUILTIN_COMMANDS, ...commands],
+    [commands],
+  );
+
   // Open when input starts with "/" and has no newlines before it
   const slashMenuOpen = useMemo(() => {
-    if (!commands.length) return false;
+    if (!allCommands.length) return false;
     // Match "/" at start, optionally followed by partial command text (no spaces yet = still filtering)
     return /^\/[^\s]*$/.test(input);
-  }, [input, commands]);
+  }, [input, allCommands]);
 
   // Text after the "/" for filtering
   const slashFilter = useMemo(() => {
@@ -79,6 +97,19 @@ export function ChatPanel() {
 
   const handleSlashSelect = useCallback(
     (cmd: SeroSlashCommandInfo) => {
+      // Handle built-in commands that open UI instead of sending to agent
+      if (cmd.name === 'login') {
+        setInput('');
+        setLoginMode('login');
+        setLoginDialogOpen(true);
+        return;
+      }
+      if (cmd.name === 'logout') {
+        setInput('');
+        setLoginMode('logout');
+        setLoginDialogOpen(true);
+        return;
+      }
       // Insert the command into input. Add trailing space for arguments.
       setInput(`/${cmd.name} `);
     },
@@ -96,6 +127,21 @@ export function ChatPanel() {
       if ((!text && !message.files?.length) || !sessionId) return;
       // Don't submit if slash menu is open (Enter selects from menu instead)
       if (slashMenuOpen) return;
+
+      // Intercept /login and /logout commands — handle client-side
+      if (text === '/login' || text.startsWith('/login ')) {
+        setInput('');
+        setLoginMode('login');
+        setLoginDialogOpen(true);
+        return;
+      }
+      if (text === '/logout' || text.startsWith('/logout ')) {
+        setInput('');
+        setLoginMode('logout');
+        setLoginDialogOpen(true);
+        return;
+      }
+
       setInput('');
 
       // Convert FileUIParts → ChatAttachments for persistence
@@ -161,7 +207,7 @@ export function ChatPanel() {
       <div className="relative shrink-0 p-2">
         {/* Slash command autocomplete menu */}
         <SlashCommandMenu
-          commands={commands}
+          commands={allCommands}
           filter={slashFilter}
           onSelect={handleSlashSelect}
           onClose={handleSlashClose}
@@ -217,6 +263,17 @@ export function ChatPanel() {
           </PromptInputFooter>
         </PromptInput>
       </div>
+
+      {/* Auth login/logout dialog (OAuth + API key) */}
+      <AuthLoginDialog
+        open={loginDialogOpen}
+        onOpenChange={setLoginDialogOpen}
+        mode={loginMode}
+        onComplete={() => {
+          // Refresh model state for the active session after login/logout
+          if (sessionId) fetchModelState(sessionId);
+        }}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -11,6 +11,8 @@ import type {
   SeroAppManifest,
   SessionUsageStats,
   SessionModelState,
+  AuthProvidersResponse,
+  OAuthEvent,
 } from './ipc';
 
 interface SeroWorkspaceAPI {
@@ -98,6 +100,27 @@ interface SeroAppAgentAPI {
   prompt(appId: string, workspaceId: string, text: string): Promise<string>;
 }
 
+interface SeroAuthAPI {
+  /** Get all providers (OAuth + API key) with auth status. */
+  getProviders(): Promise<AuthProvidersResponse>;
+  /** Start OAuth login for a provider. Resolves when flow completes. */
+  login(providerId: string): Promise<void>;
+  /** Logout from a provider (OAuth or API key). */
+  logout(providerId: string): Promise<void>;
+  /** Save an API key for a provider. */
+  setApiKey(providerId: string, key: string): Promise<void>;
+  /** Remove a saved API key for a provider. */
+  removeApiKey(providerId: string): Promise<void>;
+  /** Respond to a pending prompt during login. */
+  respondPrompt(value: string): Promise<void>;
+  /** Respond to a pending manual code input during login. */
+  respondManualCode(value: string): Promise<void>;
+  /** Cancel in-progress login. */
+  cancel(): Promise<void>;
+  /** Subscribe to OAuth flow events. Returns unsubscribe. */
+  onEvent(callback: (event: OAuthEvent) => void): () => void;
+}
+
 interface SeroAPI {
   platform: string;
   shell: SeroShellAPI;
@@ -107,6 +130,7 @@ interface SeroAPI {
   appState: SeroAppStateAPI;
   apps: SeroAppsAPI;
   appAgent: SeroAppAgentAPI;
+  auth: SeroAuthAPI;
 }
 
 declare global {

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -204,6 +204,46 @@ export interface SeroAppManifest {
   packagePath: string;
 }
 
+// ── OAuth / Auth ───────────────────────────────────────────────
+
+/** OAuth provider info surfaced to the renderer for the login dialog. */
+export interface OAuthProviderInfo {
+  id: string;
+  name: string;
+  isLoggedIn: boolean;
+  usesCallbackServer: boolean;
+}
+
+/** API-key provider info for the login dialog. */
+export interface ApiKeyProviderInfo {
+  id: string;
+  name: string;
+  /** Whether an API key is configured (auth.json or env var). */
+  hasKey: boolean;
+  /** True if the key comes from an environment variable (not editable via UI). */
+  fromEnv: boolean;
+}
+
+/** Combined response from getProviders — both OAuth and API-key providers. */
+export interface AuthProvidersResponse {
+  oauth: OAuthProviderInfo[];
+  apiKey: ApiKeyProviderInfo[];
+}
+
+/**
+ * Events pushed from main → renderer during an OAuth login flow.
+ * The renderer dialog reacts to each event to update its UI state.
+ */
+export type OAuthEvent =
+  | { type: 'auth'; url: string; instructions?: string }
+  | { type: 'prompt'; message: string; placeholder?: string }
+  | { type: 'manual_input'; prompt: string }
+  | { type: 'waiting'; message: string }
+  | { type: 'progress'; message: string }
+  | { type: 'success'; provider: string; message: string }
+  | { type: 'error'; provider: string; message: string }
+  | { type: 'cancelled' };
+
 // ── IPC Channels ───────────────────────────────────────────────
 
 /** IPC channel constants — single source of truth. */
@@ -271,5 +311,25 @@ export const IpcChannels = {
   appAgent: {
     /** Send a prompt to an app's dedicated agent session. Returns text response. */
     prompt: 'sero:app-agent:prompt',
+  },
+  auth: {
+    /** Get all providers (OAuth + API key) with auth status. */
+    getProviders: 'sero:auth:get-providers',
+    /** Start OAuth login for a provider. */
+    login: 'sero:auth:login',
+    /** Logout from a provider (OAuth or API key). */
+    logout: 'sero:auth:logout',
+    /** Save an API key for a provider. */
+    setApiKey: 'sero:auth:set-api-key',
+    /** Remove an API key for a provider. */
+    removeApiKey: 'sero:auth:remove-api-key',
+    /** Respond to a pending prompt during login. */
+    respondPrompt: 'sero:auth:respond-prompt',
+    /** Respond to a pending manual code input during login. */
+    respondManualCode: 'sero:auth:respond-manual-code',
+    /** Cancel in-progress login. */
+    cancel: 'sero:auth:cancel',
+    /** Main → renderer push channel for OAuth flow events. */
+    event: 'sero:auth:event',
   },
 } as const;

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -211,7 +211,6 @@ export interface OAuthProviderInfo {
   id: string;
   name: string;
   isLoggedIn: boolean;
-  usesCallbackServer: boolean;
 }
 
 /** API-key provider info for the login dialog. */

--- a/docs/oauth-login/task_plan.md
+++ b/docs/oauth-login/task_plan.md
@@ -50,13 +50,14 @@ Expose `window.sero.auth`:
 ### Phase 4: Type Declarations — `src/types/electron.d.ts` ✅
 Add `SeroAuthAPI` interface and include in `SeroAPI`.
 
-### Phase 5: React Dialog — `src/components/layout/OAuthLoginDialog.tsx` ✅
-Self-contained dialog component:
+### Phase 5: React Dialog — `src/components/layout/AuthLoginDialog.tsx` + `AuthLoginViews.tsx` ✅
+Self-contained dialog component (split into orchestrator + sub-views):
 - Provider list with login status badges
 - Auth URL display (clickable) + progress states
 - Prompt/manual-code input handling
+- API key entry with show/hide toggle
 - Success/error states
-- Triggered from ChatPanel slash command or status bar
+- Triggered from ChatPanel slash command
 
 ### Phase 6: Integration — Wire dialog into app ✅
 - Add auth store or local state in dialog
@@ -69,5 +70,6 @@ Self-contained dialog component:
 - `electron/ipc/index.ts` — register auth handlers
 - `electron/preload.ts` — add auth bridge
 - `src/types/electron.d.ts` — add auth API types
-- `src/components/layout/OAuthLoginDialog.tsx` — new file
-- Integration point (ChatPanel or TitleBar) — trigger dialog
+- `src/components/layout/AuthLoginDialog.tsx` — new file (dialog orchestrator)
+- `src/components/layout/AuthLoginViews.tsx` — new file (sub-views)
+- `src/components/layout/ChatPanel.tsx` — integration (/login, /logout interception)

--- a/docs/oauth-login/task_plan.md
+++ b/docs/oauth-login/task_plan.md
@@ -1,0 +1,73 @@
+# Task: OAuth Login Support in Sero
+
+## Goal
+Support `/login` and `/logout` for Pi OAuth providers in Sero's desktop app, 
+bridging the same `AuthStorage.login()` flow that Pi's interactive TUI mode uses,
+but over Electron IPC with a React dialog UI.
+
+## Context
+- Pi CLI's `/login` only works in interactive TUI mode (not SDK/headless mode)
+- Sero decoupled from Pi CLI and uses its own `~/.sero-ui/agent/auth.json`
+- `AuthStorage.login(providerId, callbacks)` from `@mariozechner/pi-coding-agent` drives the OAuth flow
+- The callbacks (`onAuth`, `onPrompt`, `onProgress`, `onManualCodeInput`) are what need UI
+- `getOAuthProviders()` from `@mariozechner/pi-ai` lists available providers
+- Sero uses the standard 4-layer IPC pattern: React → Store → Preload → Main → SDK
+
+## Architecture Decision
+**Bridge `AuthStorage.login()` callbacks over IPC** — the main process drives the 
+OAuth flow; the renderer shows a dialog. This reuses all Pi SDK OAuth logic.
+
+Key design choices:
+- Main process holds the login flow + pending Promise resolvers for prompts
+- Renderer subscribes to `sero:auth:event` push channel for UI state changes  
+- Renderer sends responses back via `sero:auth:respond-prompt` / `sero:auth:cancel`
+- Browser opens via Electron's `shell.openExternal()` (better than exec)
+- Dialog uses existing shadcn Dialog + Input components
+
+## Phases
+
+### Phase 1: IPC Types — `src/types/ipc.ts` ✅
+Add auth-related types and channels:
+- `OAuthProviderInfo` — id, name, isLoggedIn, usesCallbackServer
+- `OAuthEvent` — discriminated union for auth flow events
+- `IpcChannels.auth.*` — channel constants
+
+### Phase 2: Main Process Handler — `electron/ipc/auth.ts` ✅
+New file with:
+- `getProviders()` — lists providers with login status
+- `login(providerId)` — starts OAuth flow, bridges callbacks to IPC events
+- `logout(providerId)` — removes credentials
+- `respondPrompt(value)` / `respondManualCode(value)` — resolves pending promises
+- `cancel()` — aborts current login
+- Register in `electron/ipc/index.ts`
+
+### Phase 3: Preload Bridge — `electron/preload.ts` ✅
+Expose `window.sero.auth`:
+- `getProviders()`, `login()`, `logout()`
+- `respondPrompt()`, `respondManualCode()`, `cancel()`
+- `onEvent(callback)` — subscribe to auth events
+
+### Phase 4: Type Declarations — `src/types/electron.d.ts` ✅
+Add `SeroAuthAPI` interface and include in `SeroAPI`.
+
+### Phase 5: React Dialog — `src/components/layout/OAuthLoginDialog.tsx` ✅
+Self-contained dialog component:
+- Provider list with login status badges
+- Auth URL display (clickable) + progress states
+- Prompt/manual-code input handling
+- Success/error states
+- Triggered from ChatPanel slash command or status bar
+
+### Phase 6: Integration — Wire dialog into app ✅
+- Add auth store or local state in dialog
+- Trigger from slash command menu (`/login`, `/logout`)
+- Refresh model state after login/logout
+
+## Files to Create/Modify
+- `src/types/ipc.ts` — add auth types + channels
+- `electron/ipc/auth.ts` — new file
+- `electron/ipc/index.ts` — register auth handlers
+- `electron/preload.ts` — add auth bridge
+- `src/types/electron.d.ts` — add auth API types
+- `src/components/layout/OAuthLoginDialog.tsx` — new file
+- Integration point (ChatPanel or TitleBar) — trigger dialog


### PR DESCRIPTION
## Summary

Adds `/login` and `/logout` support to Sero, bridging the Pi SDK's OAuth flow over Electron IPC and adding a new API key entry UI.

After decoupling from the Pi CLI, Sero lost access to `/login` (only available in Pi's interactive TUI mode). This PR reuses all the existing OAuth logic from `@mariozechner/pi-ai` and `@mariozechner/pi-coding-agent`, bridging the callback-driven login flow across the Electron IPC boundary.

## What's New

### OAuth Login
- Full OAuth flow for all Pi providers (Anthropic, GitHub Copilot, Google Gemini CLI, Antigravity, OpenAI Codex)
- Browser opens automatically via `shell.openExternal()`
- Prompt/manual-code/progress callbacks bridged over IPC events
- Credentials saved to `~/.sero-ui/agent/auth.json`

### API Key Management
- Enter/update/remove API keys for 14 providers (OpenAI, OpenRouter, xAI, Groq, Cerebras, Mistral, etc.)
- Writes `{ "type": "api_key", "key": "..." }` format to `auth.json`
- Shows status badges: `✓ saved` (removable) vs `✓ env` (from env var, read-only)
- Password input with show/hide toggle

### Integration
- `/login` and `/logout` commands in the slash command menu
- Also intercepted when typed directly in chat input
- Model state auto-refreshes after login/logout

## Architecture

```
Renderer (AuthLoginDialog)       Electron Main (ipc/auth.ts)
┌──────────────────────┐         ┌──────────────────────────┐
│ Provider list        │◄────────│ getProviders()           │
│ OAuth flow UI        │ events  │ authStorage.login()      │
│ API key entry        │────────►│ setApiKey() / removeApiKey│
│ Result display       │ respond │ Promise resolvers        │
└──────────────────────┘         └──────────────────────────┘
```

Follows the existing 4-layer IPC pattern: `React → Store → Preload → Main → SDK`

## Files

| File | Change |
|------|--------|
| `electron/ipc/auth.ts` | **New** — Main process handlers for OAuth + API key |
| `electron/ipc/index.ts` | Register auth handlers |
| `electron/preload.ts` | Expose `window.sero.auth.*` bridge |
| `src/types/ipc.ts` | Auth types + IPC channels |
| `src/types/electron.d.ts` | `SeroAuthAPI` type declarations |
| `src/components/layout/AuthLoginDialog.tsx` | **New** — Dialog orchestrator |
| `src/components/layout/AuthLoginViews.tsx` | **New** — Sub-views (provider list, API key entry, etc.) |
| `src/components/layout/ChatPanel.tsx` | Intercept `/login` `/logout`, render dialog |

## Testing

```bash
cd apps/desktop
node scripts/build-electron.mjs   # Rebuild main + preload
bash scripts/dev.sh                # Restart
```

Then type `/login` in the chat input.