### PR TITLE
feat: group consecutive tool calls into collapsible execution blocks

### DIFF
--- a/apps/desktop/electron/container/index.ts
+++ b/apps/desktop/electron/container/index.ts
@@ -129,7 +129,7 @@ export class ContainerManager {
       this.containers,
       (wsId, cmd, cwd) => this.exec(wsId, cmd, cwd),
       (wsId) => this.inspect(wsId),
-      this.httpProxy.getProxyUrl(),
+      this.proxyUrl ?? undefined,
     );
   }
 

--- a/apps/desktop/electron/container/lifecycle.ts
+++ b/apps/desktop/electron/container/lifecycle.ts
@@ -228,6 +228,19 @@ export async function createFreshContainer(
     /* non-fatal — prompt still tells agent to use --host */
   }
 
+  // Ensure DNS resolution works inside the container.
+  // Apple Container's vmnet NAT doesn't always configure resolv.conf,
+  // so we set public DNS servers as a fallback.
+  try {
+    await execFn(
+      config.workspaceId,
+      'grep -q "nameserver" /etc/resolv.conf 2>/dev/null || ' +
+        'printf "nameserver 8.8.8.8\\nnameserver 1.1.1.1\\n" > /etc/resolv.conf',
+    );
+  } catch {
+    /* non-fatal — proxy handles DNS when available */
+  }
+
   // Initialize workspace: git init if not already a repo
   try {
     await execFn(config.workspaceId, 'cd /workspace && [ -d .git ] || git init -q');

--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -16,6 +16,7 @@ import type {
   SeroSlashCommandInfo,
   SessionModelState,
 } from '../../src/types/ipc';
+import { resizeImageForApi } from '../utils/image-resize';
 
 // ── ID generation ────────────────────────────────────────────
 
@@ -120,6 +121,13 @@ export function convertSessionMessages(
 
 // ── Attachment conversion ────────────────────────────────────
 
+/**
+ * Convert ChatAttachments to ImageContent for the Pi SDK.
+ *
+ * Images are resized to stay within Anthropic's 5MB limit (max 2000×2000,
+ * max 4.5MB with progressive JPEG compression). This mirrors the Pi CLI's
+ * `resizeImage()` behaviour so pasted screenshots don't exceed the API limit.
+ */
 export function attachmentsToImages(attachments?: ChatAttachment[]): ImageContent[] | undefined {
   if (!attachments?.length) return undefined;
 
@@ -131,7 +139,8 @@ export function attachmentsToImages(attachments?: ChatAttachment[]): ImageConten
     const match = att.url.match(/^data:[^;]+;base64,(.+)$/);
     if (!match) continue;
 
-    images.push({ type: 'image', data: match[1], mimeType: mime });
+    const resized = resizeImageForApi(match[1], mime);
+    images.push({ type: 'image', data: resized.data, mimeType: resized.mimeType });
   }
 
   return images.length > 0 ? images : undefined;

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -167,10 +167,12 @@ app.whenReady().then(async () => {
     console.error('[sero] Failed to ensure sero-node image:', err);
   }
 
-  // Start HTTP proxy only if explicitly requested via env var.
-  // Needed when security software (Bitdefender, etc.) blocks outbound from vmnet.
-  // NAT (setup-container-nat.sh) is the default networking path.
-  if (process.env.SERO_CONTAINER_PROXY === '1') {
+  // Start HTTP proxy for container internet access.
+  // The proxy runs on the host and tunnels HTTP/HTTPS from containers via
+  // the gateway IP (192.168.64.1). This is the primary networking path because
+  // NAT alone doesn't provide DNS resolution inside the container VM.
+  // Set SERO_CONTAINER_PROXY=0 to disable if using an alternative network setup.
+  if (process.env.SERO_CONTAINER_PROXY !== '0') {
     await containerManager.startProxy();
   }
 

--- a/apps/desktop/electron/utils/image-resize.ts
+++ b/apps/desktop/electron/utils/image-resize.ts
@@ -1,0 +1,132 @@
+/**
+ * Image resizing for API submission.
+ *
+ * Uses Electron's nativeImage (zero-dependency) to ensure images stay within
+ * Anthropic's 5MB limit. Strategy mirrors Pi CLI's image-resize.ts:
+ *
+ * 1. Check if already within dimension + size limits — return unchanged
+ * 2. Resize to maxWidth/maxHeight
+ * 3. Try PNG (good for screenshots), pick if small enough
+ * 4. Try JPEG with decreasing quality
+ * 5. Progressively reduce dimensions if still too large
+ */
+
+import { nativeImage } from 'electron';
+
+export interface ImageResizeResult {
+  data: string; // base64
+  mimeType: string;
+  wasResized: boolean;
+}
+
+// 4.5MB — provides headroom below Anthropic's 5MB limit (matches Pi CLI)
+const MAX_BYTES = 4.5 * 1024 * 1024;
+const MAX_WIDTH = 2000;
+const MAX_HEIGHT = 2000;
+
+/** Pick the smaller of two encoded buffers. */
+function pickSmaller(
+  a: { buffer: Buffer; mimeType: string },
+  b: { buffer: Buffer; mimeType: string },
+): { buffer: Buffer; mimeType: string } {
+  return a.buffer.length <= b.buffer.length ? a : b;
+}
+
+/**
+ * Resize a base64-encoded image to fit within API limits.
+ *
+ * @param base64Data Raw base64 string (no data: prefix)
+ * @param mimeType   Original MIME type (e.g. "image/png")
+ * @returns Resized image data + updated mimeType
+ */
+export function resizeImageForApi(base64Data: string, mimeType: string): ImageResizeResult {
+  const inputBuffer = Buffer.from(base64Data, 'base64');
+
+  // Fast path: if small enough, check dimensions
+  if (inputBuffer.length <= MAX_BYTES) {
+    const img = nativeImage.createFromBuffer(inputBuffer);
+    if (img.isEmpty()) {
+      return { data: base64Data, mimeType, wasResized: false };
+    }
+    const size = img.getSize();
+    if (size.width <= MAX_WIDTH && size.height <= MAX_HEIGHT) {
+      return { data: base64Data, mimeType, wasResized: false };
+    }
+  }
+
+  // Load the image
+  const img = nativeImage.createFromBuffer(inputBuffer);
+  if (img.isEmpty()) {
+    // Can't process — return as-is and let the API reject if needed
+    return { data: base64Data, mimeType, wasResized: false };
+  }
+
+  const originalSize = img.getSize();
+
+  // Calculate target dimensions respecting max limits
+  let targetWidth = originalSize.width;
+  let targetHeight = originalSize.height;
+
+  if (targetWidth > MAX_WIDTH) {
+    targetHeight = Math.round((targetHeight * MAX_WIDTH) / targetWidth);
+    targetWidth = MAX_WIDTH;
+  }
+  if (targetHeight > MAX_HEIGHT) {
+    targetWidth = Math.round((targetWidth * MAX_HEIGHT) / targetHeight);
+    targetHeight = MAX_HEIGHT;
+  }
+
+  // Helper: resize to dimensions, try both PNG & JPEG, return smaller
+  function tryEncode(
+    width: number,
+    height: number,
+    jpegQuality: number,
+  ): { buffer: Buffer; mimeType: string } {
+    const resized =
+      width === originalSize.width && height === originalSize.height
+        ? img
+        : img.resize({ width, height, quality: 'better' });
+
+    const pngBuffer = resized.toPNG();
+    const jpegBuffer = resized.toJPEG(jpegQuality);
+
+    return pickSmaller(
+      { buffer: pngBuffer, mimeType: 'image/png' },
+      { buffer: jpegBuffer, mimeType: 'image/jpeg' },
+    );
+  }
+
+  const qualitySteps = [85, 70, 55, 40];
+
+  // Attempt 1: resize to target dimensions, try both formats
+  let best = tryEncode(targetWidth, targetHeight, 80);
+  if (best.buffer.length <= MAX_BYTES) {
+    return { data: best.buffer.toString('base64'), mimeType: best.mimeType, wasResized: true };
+  }
+
+  // Attempt 2: JPEG with decreasing quality at target dimensions
+  for (const quality of qualitySteps) {
+    best = tryEncode(targetWidth, targetHeight, quality);
+    if (best.buffer.length <= MAX_BYTES) {
+      return { data: best.buffer.toString('base64'), mimeType: best.mimeType, wasResized: true };
+    }
+  }
+
+  // Attempt 3: progressively reduce dimensions
+  const scaleSteps = [0.75, 0.5, 0.35, 0.25];
+  for (const scale of scaleSteps) {
+    const w = Math.round(targetWidth * scale);
+    const h = Math.round(targetHeight * scale);
+    if (w < 100 || h < 100) break;
+
+    for (const quality of qualitySteps) {
+      best = tryEncode(w, h, quality);
+      if (best.buffer.length <= MAX_BYTES) {
+        return { data: best.buffer.toString('base64'), mimeType: best.mimeType, wasResized: true };
+      }
+    }
+  }
+
+  // Last resort: return the smallest we produced
+  return { data: best.buffer.toString('base64'), mimeType: best.mimeType, wasResized: true };
+}

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -72,6 +72,17 @@ export function ChatPanel() {
   // Group consecutive tool calls into collapsible blocks
   const groupedItems = useMemo(() => groupMessages(messages), [messages]);
 
+  // Show an inline "thinking" indicator when the session is streaming but
+  // nothing in the chat is visibly active (no streaming text, no running tools).
+  // This covers the gap when the SDK is generating a large tool call payload.
+  const showThinking = useMemo(() => {
+    if (!isStreaming || groupedItems.length === 0) return false;
+    const last = groupedItems[groupedItems.length - 1];
+    if (last.kind === 'message' && last.message.type === 'assistant' && last.message.isStreaming) return false;
+    if (last.kind === 'tool-group' && last.tools.some((t) => t.state === 'pending' || t.state === 'running')) return false;
+    return true;
+  }, [isStreaming, groupedItems]);
+
   const handleAuthComplete = useCallback(() => {
     if (sessionId) fetchModelState(sessionId);
   }, [sessionId, fetchModelState]);
@@ -189,13 +200,31 @@ export function ChatPanel() {
           ) : messages.length === 0 && !isStreaming ? (
             <EmptyState message="Start a conversation" />
           ) : (
-            groupedItems.map((item) =>
-              item.kind === 'tool-group' ? (
-                <ToolCallGroup key={item.id} tools={item.tools} />
-              ) : (
+            groupedItems.map((item, index) => {
+              if (item.kind === 'tool-group') {
+                // A group is finalized when a non-tool item follows it,
+                // or it's the last item and the session is no longer streaming.
+                const isLast = index === groupedItems.length - 1;
+                const isFinalized = !isLast || !isStreaming;
+                return (
+                  <ToolCallGroup
+                    key={item.id}
+                    tools={item.tools}
+                    isFinalized={isFinalized}
+                  />
+                );
+              }
+              return (
                 <ChatMessageItem key={item.message.id} message={item.message} />
-              ),
-            )
+              );
+            })
+          )}
+
+          {showThinking && (
+            <div className="flex items-center gap-2 px-2 py-1">
+              <Loader2 className="size-3.5 animate-spin text-[var(--text-muted)]" />
+              <span className="text-xs text-[var(--text-muted)]">Thinking…</span>
+            </div>
           )}
 
           {error && (

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -24,20 +24,14 @@ import {
   PromptInputActionAddAttachments,
   type PromptInputMessage,
 } from '@/components/ai-elements/prompt-input';
-import {
-  Tool,
-  ToolHeader,
-  ToolContent,
-  ToolInput,
-  ToolOutput,
-} from '@/components/ai-elements/tool';
 import { useAgentStore, useFocusedAgent, useFocusedCommands } from '@/stores/agent';
 import { SlashCommandMenu } from './SlashCommandMenu';
 import { PromptAttachmentsBar, MessageAttachments } from './ChatAttachments';
 import { UsageBadge } from './UsageBadge';
 import { ModelSelector } from './ModelSelector';
 import { AuthLoginDialog } from './AuthLoginDialog';
-import type { ChatMessage, ChatAttachment, ChatToolCallMessage, SeroSlashCommandInfo } from '@/types/ipc';
+import { groupMessages, ToolCallGroup } from './ToolCallGroup';
+import type { ChatMessage, ChatAttachment, SeroSlashCommandInfo } from '@/types/ipc';
 
 /** Built-in commands handled client-side (not sent to the agent). */
 const BUILTIN_COMMANDS: SeroSlashCommandInfo[] = [
@@ -74,6 +68,9 @@ export function ChatPanel() {
   const isStreaming = focused?.isStreaming ?? false;
   const error = focused?.error ?? null;
   const sessionId = focused?.sessionId ?? null;
+
+  // Group consecutive tool calls into collapsible blocks
+  const groupedItems = useMemo(() => groupMessages(messages), [messages]);
 
   const handleAuthComplete = useCallback(() => {
     if (sessionId) fetchModelState(sessionId);
@@ -192,9 +189,13 @@ export function ChatPanel() {
           ) : messages.length === 0 && !isStreaming ? (
             <EmptyState message="Start a conversation" />
           ) : (
-            messages.map((msg) => (
-              <ChatMessageItem key={msg.id} message={msg} />
-            ))
+            groupedItems.map((item) =>
+              item.kind === 'tool-group' ? (
+                <ToolCallGroup key={item.id} tools={item.tools} />
+              ) : (
+                <ChatMessageItem key={item.message.id} message={item.message} />
+              ),
+            )
           )}
 
           {error && (
@@ -307,52 +308,9 @@ function ChatMessageItem({ message }: { message: ChatMessage }) {
         </Message>
       );
 
-    case 'tool':
-      return <ToolCallItem tool={message} />;
-
     default:
       return null;
   }
-}
-
-// ── Tool call renderer ─────────────────────────────────────────
-
-/** Map our state to ToolUIPart state names. */
-function mapToolState(
-  state: ChatToolCallMessage['state'],
-): 'input-streaming' | 'input-available' | 'output-available' | 'output-error' {
-  switch (state) {
-    case 'pending':
-      return 'input-streaming';
-    case 'running':
-      return 'input-available';
-    case 'completed':
-      return 'output-available';
-    case 'error':
-      return 'output-error';
-  }
-}
-
-function ToolCallItem({ tool }: { tool: ChatToolCallMessage }) {
-  const isComplete = tool.state === 'completed' || tool.state === 'error';
-
-  return (
-    <Tool defaultOpen={isComplete}>
-      <ToolHeader
-        type={`tool-${tool.toolName}` as `tool-${string}`}
-        state={mapToolState(tool.state)}
-      />
-      <ToolContent>
-        <ToolInput input={tool.input} />
-        {isComplete && (
-          <ToolOutput
-            output={tool.output}
-            errorText={tool.isError ? (tool.output ?? 'Tool execution failed') : undefined}
-          />
-        )}
-      </ToolContent>
-    </Tool>
-  );
 }
 
 // ── Empty state ────────────────────────────────────────────────

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
   ChevronRight,
@@ -28,7 +28,13 @@ export type GroupedChatItem =
 
 /**
  * Groups consecutive tool messages into collapsed blocks.
- * Text messages (user/assistant) break the grouping.
+ * Non-empty text messages (user / assistant with content) break the grouping.
+ *
+ * Empty assistant messages are dropped — they appear between sequential tool
+ * calls (the SDK emits one per tool-use block) and would otherwise break
+ * grouping and cause expand/collapse flapping.  The only exception is a
+ * streaming empty assistant that is the very last message: it is kept so the
+ * UI can show a "thinking" spinner.
  */
 export function groupMessages(
   messages: import('@/types/ipc').ChatMessage[],
@@ -38,7 +44,6 @@ export function groupMessages(
 
   const flushTools = () => {
     if (toolBuffer.length === 0) return;
-    // Use the first tool's id as the group id for stable keys
     result.push({
       kind: 'tool-group',
       tools: [...toolBuffer],
@@ -47,13 +52,25 @@ export function groupMessages(
     toolBuffer = [];
   };
 
-  for (const msg of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
     if (msg.type === 'tool') {
       toolBuffer.push(msg);
-    } else {
-      flushTools();
-      result.push({ kind: 'message', message: msg });
+      continue;
     }
+
+    // Skip empty assistant messages entirely — they appear between sequential
+    // tool calls (SDK emits one per tool-use block).  Keeping them — even
+    // streaming ones — causes the tool group to lose its "last item" position,
+    // flipping isFinalized and producing expand/collapse flapping.
+    // The header's streaming spinner is sufficient as a "thinking" indicator.
+    if (msg.type === 'assistant' && !msg.text?.trim()) {
+      continue;
+    }
+
+    flushTools();
+    result.push({ kind: 'message', message: msg });
   }
   flushTools();
 
@@ -204,12 +221,50 @@ function ToolDetail({ tool }: { tool: ChatToolCallMessage }) {
 
 // ── Main ToolCallGroup component ────────────────────────────────
 
-export function ToolCallGroup({ tools }: { tools: ChatToolCallMessage[] }) {
-  const [expanded, setExpanded] = useState(false);
-  const [showDetails, setShowDetails] = useState(false);
-
+/**
+ * @param tools       — tool messages in this group
+ * @param isFinalized — true when no more tools will be added to this group
+ *                      (a non-tool message follows it, or the session stopped streaming)
+ */
+export function ToolCallGroup({
+  tools,
+  isFinalized = true,
+}: {
+  tools: ChatToolCallMessage[];
+  isFinalized?: boolean;
+}) {
   const status = deriveGroupStatus(tools);
   const isRunning = status === 'running';
+
+  const [showDetails, setShowDetails] = useState(false);
+
+  // Track whether the group was ever running (live) vs loaded from history.
+  const wasEverRunning = useRef(isRunning);
+  if (isRunning) wasEverRunning.current = true;
+
+  // Manual toggle override — `null` means follow automatic behaviour.
+  const [manualExpanded, setManualExpanded] = useState<boolean | null>(null);
+
+  // Auto behaviour:
+  //  - Live group, not finalized: stay expanded (tools may still arrive)
+  //  - Live group, finalized + all done: collapse
+  //  - Loaded group (never ran): stay collapsed
+  const autoExpanded = wasEverRunning.current ? (!isFinalized || isRunning) : false;
+  const expanded = manualExpanded ?? autoExpanded;
+
+  // Clear manual override when the group becomes finalized (final collapse)
+  // or when new tools start running (re-expand).
+  const prevFinalized = useRef(isFinalized);
+  useEffect(() => {
+    if (isFinalized && !prevFinalized.current) {
+      setManualExpanded(null);
+    }
+    prevFinalized.current = isFinalized;
+  }, [isFinalized]);
+
+  useEffect(() => {
+    if (isRunning) setManualExpanded(null);
+  }, [isRunning]);
 
   // Single tool: just render it inline, no group wrapper
   if (tools.length === 1) {
@@ -232,7 +287,7 @@ export function ToolCallGroup({ tools }: { tools: ChatToolCallMessage[] }) {
     >
       {/* Summary bar */}
       <button
-        onClick={() => setExpanded((p) => !p)}
+        onClick={() => setManualExpanded((prev) => !(prev ?? expanded))}
         className={cn(
           'flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors duration-150',
           'hover:bg-[var(--bg-elevated)]/80',
@@ -252,24 +307,7 @@ export function ToolCallGroup({ tools }: { tools: ChatToolCallMessage[] }) {
           {groupStatusLabel(status, tools.length)}
         </span>
 
-        {/* Tool name pills (collapsed) */}
-        {!expanded && (
-          <div className="ml-auto flex items-center gap-1 overflow-hidden">
-            {tools.slice(0, 4).map((t) => (
-              <span
-                key={t.id}
-                className="shrink-0 rounded bg-[var(--bg-base)]/60 px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]"
-              >
-                {t.toolName}
-              </span>
-            ))}
-            {tools.length > 4 && (
-              <span className="shrink-0 text-[10px] text-[var(--text-muted)]">
-                +{tools.length - 4}
-              </span>
-            )}
-          </div>
-        )}
+
       </button>
 
       {/* Expanded: list of tool lines */}

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -1,0 +1,331 @@
+import { useState, useMemo } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import {
+  ChevronRight,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  WrenchIcon,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ChatToolCallMessage } from '@/types/ipc';
+import {
+  Tool,
+  ToolHeader,
+  ToolContent,
+  ToolInput,
+  ToolOutput,
+} from '@/components/ai-elements/tool';
+
+// ── Types ───────────────────────────────────────────────────────
+
+export type GroupedChatItem =
+  | { kind: 'message'; message: import('@/types/ipc').ChatMessage }
+  | { kind: 'tool-group'; tools: ChatToolCallMessage[]; id: string };
+
+// ── Grouping utility ────────────────────────────────────────────
+
+/**
+ * Groups consecutive tool messages into collapsed blocks.
+ * Text messages (user/assistant) break the grouping.
+ */
+export function groupMessages(
+  messages: import('@/types/ipc').ChatMessage[],
+): GroupedChatItem[] {
+  const result: GroupedChatItem[] = [];
+  let toolBuffer: ChatToolCallMessage[] = [];
+
+  const flushTools = () => {
+    if (toolBuffer.length === 0) return;
+    // Use the first tool's id as the group id for stable keys
+    result.push({
+      kind: 'tool-group',
+      tools: [...toolBuffer],
+      id: `tg-${toolBuffer[0].id}`,
+    });
+    toolBuffer = [];
+  };
+
+  for (const msg of messages) {
+    if (msg.type === 'tool') {
+      toolBuffer.push(msg);
+    } else {
+      flushTools();
+      result.push({ kind: 'message', message: msg });
+    }
+  }
+  flushTools();
+
+  return result;
+}
+
+// ── Map tool state ──────────────────────────────────────────────
+
+function mapToolState(
+  state: ChatToolCallMessage['state'],
+): 'input-streaming' | 'input-available' | 'output-available' | 'output-error' {
+  switch (state) {
+    case 'pending':
+      return 'input-streaming';
+    case 'running':
+      return 'input-available';
+    case 'completed':
+      return 'output-available';
+    case 'error':
+    case 'cancelled':
+      return 'output-error';
+  }
+}
+
+// ── Group status helpers ────────────────────────────────────────
+
+type GroupStatus = 'running' | 'completed' | 'error' | 'cancelled';
+
+function deriveGroupStatus(tools: ChatToolCallMessage[]): GroupStatus {
+  const hasRunning = tools.some((t) => t.state === 'pending' || t.state === 'running');
+  const hasCancelled = tools.some((t) => t.state === 'cancelled');
+  const hasError = tools.some((t) => t.state === 'error');
+
+  if (hasRunning) return 'running';
+  if (hasCancelled) return 'cancelled';
+  if (hasError) return 'error';
+  return 'completed';
+}
+
+function groupStatusIcon(status: GroupStatus) {
+  switch (status) {
+    case 'running':
+      return <Loader2 className="size-3.5 animate-spin text-blue-400" />;
+    case 'completed':
+      return <CheckCircle2 className="size-3.5 text-emerald-500" />;
+    case 'error':
+      return <XCircle className="size-3.5 text-red-400" />;
+    case 'cancelled':
+      return <AlertCircle className="size-3.5 text-yellow-500" />;
+  }
+}
+
+function groupStatusLabel(status: GroupStatus, count: number) {
+  const noun = count === 1 ? 'action' : 'actions';
+  switch (status) {
+    case 'running':
+      return `Running ${count} ${noun}…`;
+    case 'completed':
+      return `${count} ${noun} completed`;
+    case 'error':
+      return `${count} ${noun} (has errors)`;
+    case 'cancelled':
+      return `${count} ${noun} (cancelled)`;
+  }
+}
+
+// ── Single tool line (collapsed view) ───────────────────────────
+
+function toolStatusDot(state: ChatToolCallMessage['state']) {
+  switch (state) {
+    case 'pending':
+      return <span className="size-1.5 shrink-0 rounded-full bg-zinc-500" />;
+    case 'running':
+      return <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-blue-400" />;
+    case 'completed':
+      return <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" />;
+    case 'error':
+      return <span className="size-1.5 shrink-0 rounded-full bg-red-400" />;
+    case 'cancelled':
+      return <span className="size-1.5 shrink-0 rounded-full bg-yellow-500" />;
+  }
+}
+
+function ToolLine({ tool, index }: { tool: ChatToolCallMessage; index: number }) {
+  const summary = useMemo(() => {
+    const inp = tool.input;
+    // Try to build a short summary from common tool input shapes
+    if (inp.command && typeof inp.command === 'string') return inp.command;
+    if (inp.path && typeof inp.path === 'string') return inp.path;
+    if (inp.file_path && typeof inp.file_path === 'string') return inp.file_path as string;
+    if (inp.query && typeof inp.query === 'string') return inp.query;
+    if (inp.pattern && typeof inp.pattern === 'string') return inp.pattern;
+    if (inp.url && typeof inp.url === 'string') return inp.url;
+    // Fallback: first string value
+    const first = Object.values(inp).find((v) => typeof v === 'string');
+    return typeof first === 'string' ? first : '';
+  }, [tool.input]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.15, delay: index * 0.03 }}
+      className="flex items-center gap-2 px-3 py-1"
+    >
+      {toolStatusDot(tool.state)}
+      <span className="shrink-0 text-[11px] font-medium text-[var(--text-muted)]">
+        {tool.toolName}
+      </span>
+      {summary && (
+        <span className="min-w-0 truncate text-[11px] text-[var(--text-muted)]/60">
+          {summary}
+        </span>
+      )}
+    </motion.div>
+  );
+}
+
+// ── Expanded single tool (full detail) ──────────────────────────
+
+function ToolDetail({ tool }: { tool: ChatToolCallMessage }) {
+  const isComplete = tool.state === 'completed' || tool.state === 'error';
+  const isCancelled = tool.state === 'cancelled';
+
+  return (
+    <Tool defaultOpen={isComplete}>
+      <ToolHeader
+        type={`tool-${tool.toolName}` as `tool-${string}`}
+        state={mapToolState(tool.state)}
+      />
+      <ToolContent>
+        <ToolInput input={tool.input} />
+        {isComplete && (
+          <ToolOutput
+            output={tool.output}
+            errorText={tool.isError ? (tool.output ?? 'Tool execution failed') : undefined}
+          />
+        )}
+        {isCancelled && (
+          <div className="text-xs text-yellow-500/80 italic">
+            Cancelled — agent was stopped before this tool completed.
+          </div>
+        )}
+      </ToolContent>
+    </Tool>
+  );
+}
+
+// ── Main ToolCallGroup component ────────────────────────────────
+
+export function ToolCallGroup({ tools }: { tools: ChatToolCallMessage[] }) {
+  const [expanded, setExpanded] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
+
+  const status = deriveGroupStatus(tools);
+  const isRunning = status === 'running';
+
+  // Single tool: just render it inline, no group wrapper
+  if (tools.length === 1) {
+    return <ToolDetail tool={tools[0]} />;
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className={cn(
+        'group/tg overflow-hidden rounded-lg border transition-colors duration-200',
+        isRunning
+          ? 'border-blue-500/20 bg-blue-500/[0.03]'
+          : status === 'error'
+            ? 'border-red-500/20 bg-red-500/[0.03]'
+            : 'border-border/50 bg-[var(--bg-elevated)]/50',
+      )}
+    >
+      {/* Summary bar */}
+      <button
+        onClick={() => setExpanded((p) => !p)}
+        className={cn(
+          'flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors duration-150',
+          'hover:bg-[var(--bg-elevated)]/80',
+        )}
+      >
+        <motion.div
+          animate={{ rotate: expanded ? 90 : 0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+        >
+          <ChevronRight className="size-3.5 text-[var(--text-muted)]" />
+        </motion.div>
+
+        <WrenchIcon className="size-3.5 text-[var(--text-muted)]" />
+        {groupStatusIcon(status)}
+
+        <span className="text-xs font-medium text-[var(--text-secondary)]">
+          {groupStatusLabel(status, tools.length)}
+        </span>
+
+        {/* Tool name pills (collapsed) */}
+        {!expanded && (
+          <div className="ml-auto flex items-center gap-1 overflow-hidden">
+            {tools.slice(0, 4).map((t) => (
+              <span
+                key={t.id}
+                className="shrink-0 rounded bg-[var(--bg-base)]/60 px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]"
+              >
+                {t.toolName}
+              </span>
+            ))}
+            {tools.length > 4 && (
+              <span className="shrink-0 text-[10px] text-[var(--text-muted)]">
+                +{tools.length - 4}
+              </span>
+            )}
+          </div>
+        )}
+      </button>
+
+      {/* Expanded: list of tool lines */}
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="overflow-hidden"
+          >
+            <div className="border-t border-border/30">
+              {!showDetails ? (
+                <>
+                  <div className="py-1">
+                    {tools.map((tool, i) => (
+                      <ToolLine key={tool.id} tool={tool} index={i} />
+                    ))}
+                  </div>
+                  <div className="border-t border-border/20 px-3 py-1.5">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowDetails(true);
+                      }}
+                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                    >
+                      Show full details
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <div className="space-y-0 p-2">
+                    {tools.map((tool) => (
+                      <ToolDetail key={tool.id} tool={tool} />
+                    ))}
+                  </div>
+                  <div className="border-t border-border/20 px-3 py-1.5">
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setShowDetails(false);
+                      }}
+                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                    >
+                      Collapse details
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -281,12 +281,22 @@ export const useAgentStore = create<AgentState>((set, get) => ({
           break;
 
         case 'agent_end':
-          set((s) => ({
-            agents: {
-              ...s.agents,
-              [sid]: { ...s.agents[sid], isStreaming: false },
-            },
-          }));
+          set((s) => {
+            const agent = s.agents[sid];
+            if (!agent) return s;
+            // Mark any in-flight tools as cancelled (they'll never receive a tool_end)
+            const messages = agent.messages.map((m) =>
+              m.type === 'tool' && (m.state === 'pending' || m.state === 'running')
+                ? { ...m, state: 'cancelled' as const }
+                : m,
+            );
+            return {
+              agents: {
+                ...s.agents,
+                [sid]: { ...agent, isStreaming: false, messages },
+              },
+            };
+          });
           break;
 
         case 'messages_loaded':

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -121,7 +121,7 @@ export interface ChatToolCallMessage {
   input: Record<string, unknown>;
   output: string | null;
   isError: boolean;
-  state: 'pending' | 'running' | 'completed' | 'error';
+  state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
 }
 
 /**


### PR DESCRIPTION
Condenses sequential tool-only messages into a single animated UI element
instead of rendering each as a separate bubble. This keeps the chat clean
when the agent chains multiple tools (read → edit → bash) without
intermediate text.

- New ToolCallGroup component with motion animations, expand/collapse,
  and two detail levels (single-line summary vs full tool details)
- groupMessages utility groups consecutive tool messages, breaks on text
- Added 'cancelled' tool state for graceful abort handling — agent_end
  now marks in-flight tools so the UI shows them appropriately
- Single tools still render inline; groups of 2+ get the block treatment

https://claude.ai/code/session_01C1qfnvcPsapnDVkm5r96Eg