### PR TITLE
feat: add context editor for configuring LLM session context

### DIFF
--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -292,3 +292,40 @@ export function buildCommandList(entry: PoolEntryRef, hidden?: Set<string>): Ser
   if (!hidden || hidden.size === 0) return all;
   return all.filter((cmd) => !hidden.has(cmd.name));
 }
+
+// ── Context override helpers ────────────────────────────────
+
+/** Safely read _baseSystemPrompt from AgentSession (private SDK field). */
+export function getBaseSystemPrompt(session: AgentSession): string | undefined {
+  if (!('_baseSystemPrompt' in (session as any))) {
+    console.warn(
+      '[context-editor] _baseSystemPrompt not found on AgentSession — ' +
+        'SDK version mismatch? Tested against pi-coding-agent@0.52.12.',
+    );
+    return undefined;
+  }
+  return (session as any)._baseSystemPrompt;
+}
+
+/** Safely write _baseSystemPrompt + update the agent's current prompt. */
+export function setBaseSystemPrompt(session: AgentSession, prompt: string): void {
+  if (!('_baseSystemPrompt' in (session as any))) {
+    console.warn(
+      '[context-editor] _baseSystemPrompt not found on AgentSession — ' +
+        'SDK version mismatch? Tested against pi-coding-agent@0.52.12.',
+    );
+  }
+  (session as any)._baseSystemPrompt = prompt;
+  session.agent.setSystemPrompt(prompt);
+}
+
+/**
+ * Strip disabled skills from the `<available_skills>` section of a system
+ * prompt. Each skill is wrapped in `<skill><name>…</name>…</skill>`.
+ */
+export function stripDisabledSkills(prompt: string, disabled: Set<string>): string {
+  return prompt.replace(
+    /<skill>\s*\n\s*<name>([^<]+)<\/name>[\s\S]*?<\/skill>/g,
+    (match, name: string) => (disabled.has(name.trim()) ? '' : match),
+  );
+}

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -41,6 +41,9 @@ import {
   buildModelState,
   readHiddenCommands,
   buildCommandList,
+  getBaseSystemPrompt,
+  setBaseSystemPrompt,
+  stripDisabledSkills,
 } from './agent-helpers';
 import { logRawEvent, logTurnContext } from './debug';
 import { workspaceManager } from '../workspace';
@@ -68,10 +71,8 @@ interface PoolEntry {
   lastSessionName: string | undefined;
   /** Context overrides from the context editor (applied before first prompt). */
   contextOverrides: ContextOverrides | null;
-  /** Original tools list snapshot — used to restore tools when overrides change. */
-  originalTools: Array<{ name: string; [key: string]: unknown }> | null;
-  /** Original _baseSystemPrompt snapshot — used to restore when overrides change. */
-  originalBaseSystemPrompt: string | null;
+  /** Original active tool names — used to restore tools when overrides are cleared. */
+  originalToolNames: string[] | null;
 }
 
 /** Map<sessionId, PoolEntry> — one AgentSession per active chat. */
@@ -367,8 +368,7 @@ export function registerAgentHandlers(): void {
         currentAssistantId: null,
         lastSessionName: session.sessionName,
         contextOverrides: null,
-        originalTools: null,
-        originalBaseSystemPrompt: null,
+        originalToolNames: null,
       });
 
       return convertSessionMessages(session.messages);
@@ -556,55 +556,55 @@ export function registerAgentHandlers(): void {
       if (!entry) throw new Error(`No active session: ${sessionId}`);
 
       const session = entry.session;
-      const agent = session.agent;
-      const state = agent.state;
 
-      // Snapshot originals on first override application
-      if (!entry.originalTools) {
-        entry.originalTools = state.tools.map((t: any) => t);
-      }
-      if (entry.originalBaseSystemPrompt === null) {
-        // _baseSystemPrompt is the SDK's internal cached system prompt that
-        // AgentSession.prompt() resets to on every call. We must overwrite it
-        // (not just state.systemPrompt) for the override to survive a prompt.
-        entry.originalBaseSystemPrompt = (session as any)._baseSystemPrompt ?? state.systemPrompt;
+      // Snapshot original tool names on first override application.
+      // Uses the public getActiveToolNames() API instead of internal state.
+      if (!entry.originalToolNames) {
+        entry.originalToolNames = session.getActiveToolNames();
       }
 
       entry.contextOverrides = overrides;
 
       if (!overrides) {
-        // Restore original tools
-        if (entry.originalTools) {
-          state.tools = entry.originalTools as any;
-        }
-        // Restore original system prompt (both the internal base and current state)
-        if (entry.originalBaseSystemPrompt !== null) {
-          (session as any)._baseSystemPrompt = entry.originalBaseSystemPrompt;
-          agent.setSystemPrompt(entry.originalBaseSystemPrompt);
-        }
+        // Restore: setActiveToolsByName rebuilds the system prompt from
+        // scratch with all original tools and skills — no manual restore needed.
+        session.setActiveToolsByName(entry.originalToolNames!);
         return;
       }
 
-      // Apply tool overrides: filter out disabled tools
+      // Step 1: Apply tool filtering via public SDK API.
+      // setActiveToolsByName also rebuilds _baseSystemPrompt with the
+      // correct tool set + all skills from the resource loader.
+      const toolNames = entry.originalToolNames!.slice();
       if (overrides.disabledTools?.length) {
         const disabled = new Set(overrides.disabledTools);
-        state.tools = entry.originalTools!.filter(
-          (t: any) => !disabled.has(t.name),
-        ) as any;
-      } else if (entry.originalTools) {
-        // No disabled tools — restore full set
-        state.tools = entry.originalTools as any;
+        session.setActiveToolsByName(toolNames.filter((n) => !disabled.has(n)));
+      } else {
+        session.setActiveToolsByName(toolNames);
       }
 
-      // Apply system prompt override.
-      // We must overwrite _baseSystemPrompt on the AgentSession — this is what
-      // prompt() resets to before every API call. Setting state.systemPrompt
-      // alone is insufficient because prompt() calls
-      //   agent.setSystemPrompt(this._baseSystemPrompt)
-      // which would overwrite our change.
+      // Step 2: Apply skill filtering by stripping <skill> entries from the
+      // system prompt's <available_skills> section. Only applies when the
+      // user has NOT provided a full custom system prompt.
+      if (
+        overrides.disabledSkills?.length &&
+        (overrides.systemPrompt === undefined || overrides.systemPrompt === null)
+      ) {
+        const disabled = new Set(overrides.disabledSkills);
+        const prompt = getBaseSystemPrompt(session);
+        if (typeof prompt === 'string') {
+          const filtered = stripDisabledSkills(prompt, disabled);
+          setBaseSystemPrompt(session, filtered);
+        }
+      }
+
+      // Step 3: Apply full system prompt override (replaces everything
+      // including any skill filtering from step 2).
+      // We must overwrite _baseSystemPrompt — the SDK's internal cached
+      // prompt that AgentSession.prompt() resets to on every API call.
+      // Tested against pi-coding-agent@0.52.12.
       if (overrides.systemPrompt !== undefined && overrides.systemPrompt !== null) {
-        (session as any)._baseSystemPrompt = overrides.systemPrompt;
-        agent.setSystemPrompt(overrides.systemPrompt);
+        setBaseSystemPrompt(session, overrides.systemPrompt);
       }
     },
   );
@@ -615,3 +615,5 @@ export function registerAgentHandlers(): void {
     disposeAll();
   });
 }
+
+

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -26,6 +26,10 @@ import type {
   SeroSlashCommandInfo,
   SessionUsageStats,
   SessionModelState,
+  SessionContext,
+  ContextOverrides,
+  ContextToolInfo,
+  ContextSkillInfo,
 } from '../../src/types/ipc';
 
 import {
@@ -62,6 +66,10 @@ interface PoolEntry {
   currentAssistantId: string | null;
   /** Last known session name — used to detect changes and push to renderer. */
   lastSessionName: string | undefined;
+  /** Context overrides from the context editor (applied before first prompt). */
+  contextOverrides: ContextOverrides | null;
+  /** Original tools list snapshot — used to restore tools when overrides change. */
+  originalTools: Array<{ name: string; [key: string]: unknown }> | null;
 }
 
 /** Map<sessionId, PoolEntry> — one AgentSession per active chat. */
@@ -356,6 +364,8 @@ export function registerAgentHandlers(): void {
         workspaceId,
         currentAssistantId: null,
         lastSessionName: session.sessionName,
+        contextOverrides: null,
+        originalTools: null,
       });
 
       return convertSessionMessages(session.messages);
@@ -500,6 +510,80 @@ export function registerAgentHandlers(): void {
       const state = buildModelState(entry);
       sendEvent({ type: 'model_change', sessionId, state });
       return state;
+    },
+  );
+
+  // ── Get session context for context editor ─────────────────
+  ipcMain.handle(
+    IpcChannels.agent.getContext,
+    async (_event, sessionId: string): Promise<SessionContext | null> => {
+      const entry = pool.get(sessionId);
+      if (!entry) return null;
+
+      const state = entry.session.agent.state;
+
+      // Serialise tools (drop execute function)
+      const tools: ContextToolInfo[] = state.tools.map((t: any) => ({
+        name: t.name,
+        label: t.label,
+        description: t.description,
+      }));
+
+      // Get skills from resource loader
+      const { skills: rawSkills } = entry.loader.getSkills();
+      const skills: ContextSkillInfo[] = rawSkills.map((s: any) => ({
+        name: s.name,
+        description: s.description,
+        filePath: s.filePath,
+      }));
+
+      return {
+        systemPrompt: state.systemPrompt ?? '',
+        tools,
+        skills,
+      };
+    },
+  );
+
+  // ── Apply context overrides ───────────────────────────────
+  ipcMain.handle(
+    IpcChannels.agent.setContextOverrides,
+    async (_event, sessionId: string, overrides: ContextOverrides | null): Promise<void> => {
+      const entry = pool.get(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+
+      const state = entry.session.agent.state;
+
+      // Snapshot original tools on first override application
+      if (!entry.originalTools) {
+        entry.originalTools = state.tools.map((t: any) => t);
+      }
+
+      entry.contextOverrides = overrides;
+
+      if (!overrides) {
+        // Restore original tools
+        if (entry.originalTools) {
+          state.tools = entry.originalTools as any;
+        }
+        return;
+      }
+
+      // Apply tool overrides: filter out disabled tools
+      if (overrides.disabledTools?.length) {
+        const disabled = new Set(overrides.disabledTools);
+        state.tools = entry.originalTools!.filter(
+          (t: any) => !disabled.has(t.name),
+        ) as any;
+      } else if (entry.originalTools) {
+        // No disabled tools — restore full set
+        state.tools = entry.originalTools as any;
+      }
+
+      // Apply system prompt override
+      if (overrides.systemPrompt !== undefined && overrides.systemPrompt !== null) {
+        state.systemPrompt = overrides.systemPrompt;
+      }
     },
   );
 

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -70,6 +70,8 @@ interface PoolEntry {
   contextOverrides: ContextOverrides | null;
   /** Original tools list snapshot — used to restore tools when overrides change. */
   originalTools: Array<{ name: string; [key: string]: unknown }> | null;
+  /** Original _baseSystemPrompt snapshot — used to restore when overrides change. */
+  originalBaseSystemPrompt: string | null;
 }
 
 /** Map<sessionId, PoolEntry> — one AgentSession per active chat. */
@@ -366,6 +368,7 @@ export function registerAgentHandlers(): void {
         lastSessionName: session.sessionName,
         contextOverrides: null,
         originalTools: null,
+        originalBaseSystemPrompt: null,
       });
 
       return convertSessionMessages(session.messages);
@@ -552,11 +555,19 @@ export function registerAgentHandlers(): void {
       const entry = pool.get(sessionId);
       if (!entry) throw new Error(`No active session: ${sessionId}`);
 
-      const state = entry.session.agent.state;
+      const session = entry.session;
+      const agent = session.agent;
+      const state = agent.state;
 
-      // Snapshot original tools on first override application
+      // Snapshot originals on first override application
       if (!entry.originalTools) {
         entry.originalTools = state.tools.map((t: any) => t);
+      }
+      if (entry.originalBaseSystemPrompt === null) {
+        // _baseSystemPrompt is the SDK's internal cached system prompt that
+        // AgentSession.prompt() resets to on every call. We must overwrite it
+        // (not just state.systemPrompt) for the override to survive a prompt.
+        entry.originalBaseSystemPrompt = (session as any)._baseSystemPrompt ?? state.systemPrompt;
       }
 
       entry.contextOverrides = overrides;
@@ -565,6 +576,11 @@ export function registerAgentHandlers(): void {
         // Restore original tools
         if (entry.originalTools) {
           state.tools = entry.originalTools as any;
+        }
+        // Restore original system prompt (both the internal base and current state)
+        if (entry.originalBaseSystemPrompt !== null) {
+          (session as any)._baseSystemPrompt = entry.originalBaseSystemPrompt;
+          agent.setSystemPrompt(entry.originalBaseSystemPrompt);
         }
         return;
       }
@@ -580,9 +596,15 @@ export function registerAgentHandlers(): void {
         state.tools = entry.originalTools as any;
       }
 
-      // Apply system prompt override
+      // Apply system prompt override.
+      // We must overwrite _baseSystemPrompt on the AgentSession — this is what
+      // prompt() resets to before every API call. Setting state.systemPrompt
+      // alone is insufficient because prompt() calls
+      //   agent.setSystemPrompt(this._baseSystemPrompt)
+      // which would overwrite our change.
       if (overrides.systemPrompt !== undefined && overrides.systemPrompt !== null) {
-        state.systemPrompt = overrides.systemPrompt;
+        (session as any)._baseSystemPrompt = overrides.systemPrompt;
+        agent.setSystemPrompt(overrides.systemPrompt);
       }
     },
   );

--- a/apps/desktop/electron/ipc/context-presets.ts
+++ b/apps/desktop/electron/ipc/context-presets.ts
@@ -1,0 +1,36 @@
+/**
+ * IPC handlers for context editor preset persistence.
+ * Presets are stored as JSON at ~/.sero-ui/context-presets.json.
+ */
+
+import { ipcMain } from 'electron';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { IpcChannels } from '../../src/types/ipc';
+import type { ContextPreset } from '../../src/types/ipc';
+import { SERO_HOME } from '../env';
+
+const PRESETS_PATH = path.join(SERO_HOME, 'context-presets.json');
+
+export function registerContextPresetsHandlers(): void {
+  ipcMain.handle(
+    IpcChannels.contextPresets.load,
+    async (): Promise<ContextPreset[]> => {
+      try {
+        const raw = await fs.readFile(PRESETS_PATH, 'utf8');
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch {
+        return [];
+      }
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.contextPresets.save,
+    async (_event, presets: ContextPreset[]): Promise<void> => {
+      await fs.mkdir(path.dirname(PRESETS_PATH), { recursive: true });
+      await fs.writeFile(PRESETS_PATH, JSON.stringify(presets, null, 2), 'utf8');
+    },
+  );
+}

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -22,6 +22,7 @@ import { registerFileTreeHandlers } from './filetree';
 import { registerLayoutHandlers } from './layout';
 import { registerLspHandlers } from './lsp';
 import { registerDebugHandlers } from './debug';
+import { registerContextPresetsHandlers } from './context-presets';
 
 export function registerAllIpcHandlers(): void {
   registerWorkspaceHandlers();
@@ -40,4 +41,5 @@ export function registerAllIpcHandlers(): void {
   registerLayoutHandlers();
   registerLspHandlers();
   registerDebugHandlers();
+  registerContextPresetsHandlers();
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -17,6 +17,7 @@ import type {
   DevServerEvent,
   SessionContext,
   ContextOverrides,
+  ContextPreset,
 } from '../src/types/ipc';
 
 contextBridge.exposeInMainWorld('sero', {
@@ -116,6 +117,14 @@ contextBridge.exposeInMainWorld('sero', {
         ipcRenderer.removeListener(IpcChannels.agent.event, handler);
       };
     },
+  },
+
+  contextPresets: {
+    load: (): Promise<ContextPreset[]> =>
+      ipcRenderer.invoke(IpcChannels.contextPresets.load),
+
+    save: (presets: ContextPreset[]): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.contextPresets.save, presets),
   },
 
   appState: {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -15,6 +15,8 @@ import type {
   ContainerInfo,
   DevServer,
   DevServerEvent,
+  SessionContext,
+  ContextOverrides,
 } from '../src/types/ipc';
 
 contextBridge.exposeInMainWorld('sero', {
@@ -98,6 +100,12 @@ contextBridge.exposeInMainWorld('sero', {
 
     setThinkingLevel: (sessionId: string, level: string): Promise<SessionModelState> =>
       ipcRenderer.invoke(IpcChannels.agent.setThinkingLevel, sessionId, level),
+
+    getContext: (sessionId: string): Promise<SessionContext | null> =>
+      ipcRenderer.invoke(IpcChannels.agent.getContext, sessionId),
+
+    setContextOverrides: (sessionId: string, overrides: ContextOverrides | null): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.agent.setContextOverrides, sessionId, overrides),
 
     onEvent: (callback: (event: AgentStreamEvent) => void): (() => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: AgentStreamEvent) => {

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
-import { Bot, MessageSquare, Loader2, AlertCircle } from 'lucide-react';
+import { Bot, MessageSquare, Loader2, AlertCircle, Settings2 } from 'lucide-react';
 import {
   Conversation,
   ConversationContent,
@@ -22,6 +22,7 @@ import {
   PromptInputActionMenuTrigger,
   PromptInputActionMenuContent,
   PromptInputActionAddAttachments,
+  PromptInputActionMenuItem,
   type PromptInputMessage,
 } from '@/components/ai-elements/prompt-input';
 import { useAgentStore, useFocusedAgent, useFocusedCommands } from '@/stores/agent';
@@ -31,7 +32,8 @@ import { UsageBadge } from './UsageBadge';
 import { ModelSelector } from './ModelSelector';
 import { AuthLoginDialog } from './AuthLoginDialog';
 import { groupMessages, ToolCallGroup } from './ToolCallGroup';
-import { ContextEditor, ContextEditorTrigger } from './ContextEditor';
+import { ContextEditor } from './ContextEditor';
+import { useContextEditorStore, useHasOverrides } from '@/stores/context-editor';
 import type { ChatMessage, ChatAttachment, SeroSlashCommandInfo } from '@/types/ipc';
 
 /** Built-in commands handled client-side (not sent to the agent). */
@@ -188,13 +190,6 @@ export function ChatPanel() {
           </span>
         )}
         {sessionId && <UsageBadge sessionId={sessionId} />}
-        {sessionId && (
-          <ContextEditorTrigger
-            sessionId={sessionId}
-            hasMessages={messages.length > 0}
-            disabled={isStreaming}
-          />
-        )}
         {isStreaming && (
           <Loader2 className="size-3 animate-spin text-emerald-500" />
         )}
@@ -278,14 +273,15 @@ export function ChatPanel() {
 
           <PromptInputFooter>
             <PromptInputTools>
-              {/* "+" menu with "Add photos or files" action */}
+              {/* "+" menu with attachments + context editor */}
               <PromptInputActionMenu>
                 <PromptInputActionMenuTrigger
-                  tooltip={{ content: 'Attach files', shortcut: '' }}
+                  tooltip={{ content: 'Actions', shortcut: '' }}
                   disabled={!hasSession}
                 />
                 <PromptInputActionMenuContent>
                   <PromptInputActionAddAttachments />
+                  <ContextEditorMenuItem sessionId={sessionId} disabled={isStreaming} />
                 </PromptInputActionMenuContent>
               </PromptInputActionMenu>
               {/* Model + thinking level selector */}
@@ -351,6 +347,35 @@ function ChatMessageItem({ message }: { message: ChatMessage }) {
     default:
       return null;
   }
+}
+
+// ── Context editor menu item ───────────────────────────────────
+
+function ContextEditorMenuItem({
+  sessionId,
+  disabled,
+}: {
+  sessionId: string | null;
+  disabled?: boolean;
+}) {
+  const openEditor = useContextEditorStore((s) => s.open);
+  const hasOverrides = useHasOverrides();
+
+  return (
+    <PromptInputActionMenuItem
+      disabled={disabled || !sessionId}
+      onSelect={(e) => {
+        e.preventDefault();
+        if (sessionId) openEditor(sessionId);
+      }}
+    >
+      <Settings2 className="mr-2 size-4" />
+      Session context
+      {hasOverrides && (
+        <span className="ml-auto size-1.5 rounded-full bg-[var(--accent)]" />
+      )}
+    </PromptInputActionMenuItem>
+  );
 }
 
 // ── Empty state ────────────────────────────────────────────────

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -31,6 +31,7 @@ import { UsageBadge } from './UsageBadge';
 import { ModelSelector } from './ModelSelector';
 import { AuthLoginDialog } from './AuthLoginDialog';
 import { groupMessages, ToolCallGroup } from './ToolCallGroup';
+import { ContextEditor, ContextEditorTrigger } from './ContextEditor';
 import type { ChatMessage, ChatAttachment, SeroSlashCommandInfo } from '@/types/ipc';
 
 /** Built-in commands handled client-side (not sent to the agent). */
@@ -187,6 +188,13 @@ export function ChatPanel() {
           </span>
         )}
         {sessionId && <UsageBadge sessionId={sessionId} />}
+        {sessionId && (
+          <ContextEditorTrigger
+            sessionId={sessionId}
+            hasMessages={messages.length > 0}
+            disabled={isStreaming}
+          />
+        )}
         {isStreaming && (
           <Loader2 className="size-3 animate-spin text-emerald-500" />
         )}
@@ -305,6 +313,9 @@ export function ChatPanel() {
         mode={loginMode}
         onComplete={handleAuthComplete}
       />
+
+      {/* Context editor dialog (only for new sessions) */}
+      {sessionId && <ContextEditor sessionId={sessionId} />}
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/ContextEditor.tsx
+++ b/apps/desktop/src/components/layout/ContextEditor.tsx
@@ -8,6 +8,7 @@ import {
   Trash2,
   RotateCcw,
   Loader2,
+  AlertCircle,
 } from 'lucide-react';
 import {
   Dialog,
@@ -27,93 +28,66 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
-  useContextEditorStore,
   useAllPresets,
   useHasOverrides,
+  useEditorState,
+  useEditorActions,
 } from '@/stores/context-editor';
 import {
   ContextSection,
-  ToolRow,
-  SkillRow,
+  ToggleRow,
   SavePresetInput,
 } from './context-editor-parts';
 
 // ── Main Context Editor Dialog ──────────────────────────────────
 
-export function ContextEditor({
-  sessionId,
-}: {
-  sessionId: string;
-}) {
-  const isOpen = useContextEditorStore((s) => s.isOpen);
-  const close = useContextEditorStore((s) => s.close);
-  const availableContext = useContextEditorStore((s) => s.availableContext);
-  const systemPrompt = useContextEditorStore((s) => s.systemPrompt);
-  const disabledTools = useContextEditorStore((s) => s.disabledTools);
-  const disabledSkills = useContextEditorStore((s) => s.disabledSkills);
-  const allToolsDisabled = useContextEditorStore((s) => s.allToolsDisabled);
-  const allSkillsDisabled = useContextEditorStore((s) => s.allSkillsDisabled);
-  const activePresetId = useContextEditorStore((s) => s.activePresetId);
-  const setSystemPrompt = useContextEditorStore((s) => s.setSystemPrompt);
-  const toggleTool = useContextEditorStore((s) => s.toggleTool);
-  const toggleSkill = useContextEditorStore((s) => s.toggleSkill);
-  const setAllToolsDisabled = useContextEditorStore((s) => s.setAllToolsDisabled);
-  const setAllSkillsDisabled = useContextEditorStore((s) => s.setAllSkillsDisabled);
-  const apply = useContextEditorStore((s) => s.apply);
-  const resetToDefault = useContextEditorStore((s) => s.resetToDefault);
-  const loadPreset = useContextEditorStore((s) => s.loadPreset);
-  const savePreset = useContextEditorStore((s) => s.savePreset);
-  const deletePreset = useContextEditorStore((s) => s.deletePreset);
-
+export function ContextEditor({ sessionId }: { sessionId: string }) {
+  const state = useEditorState();
+  const actions = useEditorActions();
   const allPresets = useAllPresets();
   const hasOverrides = useHasOverrides();
 
   const [showSaveInput, setShowSaveInput] = useState(false);
 
+  const {
+    isOpen, availableContext, systemPrompt, disabledTools, disabledSkills,
+    allToolsDisabled, allSkillsDisabled, activePresetId, applyError,
+  } = state;
+
+  const {
+    close, setSystemPrompt, toggleTool, toggleSkill,
+    setAllToolsDisabled, setAllSkillsDisabled,
+    apply, resetToDefault, loadPreset, savePreset, deletePreset,
+  } = actions;
+
   // Computed: the system prompt text to show in the editor
   const displayedPrompt = systemPrompt ?? availableContext?.systemPrompt ?? '';
 
-  // Computed: enabled state for each tool
   const isToolEnabled = useCallback(
-    (toolName: string) => {
-      if (allToolsDisabled) return false;
-      return !disabledTools.has(toolName);
-    },
+    (toolName: string) => !allToolsDisabled && !disabledTools.has(toolName),
     [allToolsDisabled, disabledTools],
   );
 
   const isSkillEnabled = useCallback(
-    (skillName: string) => {
-      if (allSkillsDisabled) return false;
-      return !disabledSkills.has(skillName);
-    },
+    (skillName: string) => !allSkillsDisabled && !disabledSkills.has(skillName),
     [allSkillsDisabled, disabledSkills],
   );
 
-  // Count enabled tools/skills
   const enabledToolCount = useMemo(() => {
-    if (!availableContext) return 0;
-    if (allToolsDisabled) return 0;
+    if (!availableContext || allToolsDisabled) return 0;
     return availableContext.tools.filter((t) => !disabledTools.has(t.name)).length;
   }, [availableContext, allToolsDisabled, disabledTools]);
 
   const enabledSkillCount = useMemo(() => {
-    if (!availableContext) return 0;
-    if (allSkillsDisabled) return 0;
+    if (!availableContext || allSkillsDisabled) return 0;
     return availableContext.skills.filter((s) => !disabledSkills.has(s.name)).length;
   }, [availableContext, allSkillsDisabled, disabledSkills]);
 
   const handleApplyAndClose = useCallback(async () => {
-    await apply(sessionId);
-    close();
+    const ok = await apply(sessionId);
+    if (ok) close();
+    // On failure, applyError is set in the store — dialog stays open.
   }, [apply, close, sessionId]);
-
-  const handlePresetChange = useCallback(
-    (presetId: string) => {
-      loadPreset(presetId);
-    },
-    [loadPreset],
-  );
 
   const handleSavePreset = useCallback(
     (name: string) => {
@@ -123,11 +97,13 @@ export function ContextEditor({
     [savePreset],
   );
 
-  const handleDeletePreset = useCallback(
-    (presetId: string) => {
-      deletePreset(presetId);
-    },
-    [deletePreset],
+  // Active user preset (for the delete button outside the select)
+  const activeUserPreset = useMemo(
+    () =>
+      activePresetId && !activePresetId.startsWith('__')
+        ? allPresets.find((p) => p.id === activePresetId) ?? null
+        : null,
+    [activePresetId, allPresets],
   );
 
   return (
@@ -147,66 +123,19 @@ export function ContextEditor({
         </DialogHeader>
 
         {/* ── Preset Selector ─────────────────────────────── */}
-        <div className="flex items-center gap-2">
-          <span className="text-[11px] font-medium text-[var(--text-muted)]">
-            Preset:
-          </span>
-          <Select
-            value={activePresetId ?? ''}
-            onValueChange={handlePresetChange}
-          >
-            <SelectTrigger size="sm" className="h-7 w-40 text-xs">
-              <SelectValue placeholder="Custom" />
-            </SelectTrigger>
-            <SelectContent>
-              {allPresets.map((preset) => (
-                <SelectItem key={preset.id} value={preset.id}>
-                  <div className="flex items-center gap-2">
-                    <span>{preset.name}</span>
-                    {!preset.id.startsWith('__') && (
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          handleDeletePreset(preset.id);
-                        }}
-                        className="text-[var(--text-muted)] hover:text-red-400"
-                      >
-                        <Trash2 className="size-3" />
-                      </button>
-                    )}
-                  </div>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {!showSaveInput ? (
-            <button
-              onClick={() => setShowSaveInput(true)}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] transition-colors"
-            >
-              <Save className="size-3" />
-              Save as
-            </button>
-          ) : null}
-
-          {hasOverrides && (
-            <button
-              onClick={resetToDefault}
-              className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] transition-colors"
-            >
-              <RotateCcw className="size-3" />
-              Reset
-            </button>
-          )}
-        </div>
-
-        {showSaveInput && (
-          <SavePresetInput
-            onSave={handleSavePreset}
-            onCancel={() => setShowSaveInput(false)}
-          />
-        )}
+        <PresetBar
+          allPresets={allPresets}
+          activePresetId={activePresetId}
+          activeUserPreset={activeUserPreset}
+          hasOverrides={hasOverrides}
+          showSaveInput={showSaveInput}
+          onPresetChange={loadPreset}
+          onDelete={deletePreset}
+          onReset={resetToDefault}
+          onShowSave={() => setShowSaveInput(true)}
+          onSave={handleSavePreset}
+          onCancelSave={() => setShowSaveInput(false)}
+        />
 
         {/* ── Loading state ───────────────────────────────── */}
         {!availableContext ? (
@@ -252,102 +181,34 @@ export function ContextEditor({
               </ContextSection>
 
               {/* ── Tools Section ────────────────────────── */}
-              <ContextSection
-                icon={Wrench}
-                title="Tools"
-                count={availableContext.tools.length}
-                badge={
-                  allToolsDisabled
-                    ? 'all disabled'
-                    : enabledToolCount < availableContext.tools.length
-                      ? `${enabledToolCount}/${availableContext.tools.length}`
-                      : undefined
-                }
-                defaultOpen={false}
-              >
-                <div className="space-y-1">
-                  {/* Master toggle */}
-                  <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
-                    <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-                      Enable all tools
-                    </span>
-                    <Switch
-                      size="sm"
-                      checked={!allToolsDisabled}
-                      onCheckedChange={(checked) =>
-                        setAllToolsDisabled(!checked)
-                      }
-                    />
-                  </div>
-
-                  {/* Individual tool toggles */}
-                  {availableContext.tools.map((tool) => (
-                    <ToolRow
-                      key={tool.name}
-                      tool={tool}
-                      enabled={isToolEnabled(tool.name)}
-                      onToggle={() => toggleTool(tool.name)}
-                    />
-                  ))}
-
-                  {availableContext.tools.length === 0 && (
-                    <span className="text-[11px] text-[var(--text-muted)] italic">
-                      No tools available
-                    </span>
-                  )}
-                </div>
-              </ContextSection>
+              <ToolsSection
+                tools={availableContext.tools}
+                allDisabled={allToolsDisabled}
+                enabledCount={enabledToolCount}
+                isEnabled={isToolEnabled}
+                onToggle={toggleTool}
+                onToggleAll={setAllToolsDisabled}
+              />
 
               {/* ── Skills Section ───────────────────────── */}
-              <ContextSection
-                icon={Sparkles}
-                title="Skills"
-                count={availableContext.skills.length}
-                badge={
-                  allSkillsDisabled
-                    ? 'all disabled'
-                    : enabledSkillCount < availableContext.skills.length
-                      ? `${enabledSkillCount}/${availableContext.skills.length}`
-                      : undefined
-                }
-                defaultOpen={false}
-              >
-                <div className="space-y-1">
-                  {/* Master toggle */}
-                  {availableContext.skills.length > 0 && (
-                    <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
-                      <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-                        Enable all skills
-                      </span>
-                      <Switch
-                        size="sm"
-                        checked={!allSkillsDisabled}
-                        onCheckedChange={(checked) =>
-                          setAllSkillsDisabled(!checked)
-                        }
-                      />
-                    </div>
-                  )}
-
-                  {/* Individual skill toggles */}
-                  {availableContext.skills.map((skill) => (
-                    <SkillRow
-                      key={skill.name}
-                      skill={skill}
-                      enabled={isSkillEnabled(skill.name)}
-                      onToggle={() => toggleSkill(skill.name)}
-                    />
-                  ))}
-
-                  {availableContext.skills.length === 0 && (
-                    <span className="text-[11px] text-[var(--text-muted)] italic">
-                      No skills available
-                    </span>
-                  )}
-                </div>
-              </ContextSection>
+              <SkillsSection
+                skills={availableContext.skills}
+                allDisabled={allSkillsDisabled}
+                enabledCount={enabledSkillCount}
+                isEnabled={isSkillEnabled}
+                onToggle={toggleSkill}
+                onToggleAll={setAllSkillsDisabled}
+              />
             </div>
           </ScrollArea>
+        )}
+
+        {/* ── Error banner ────────────────────────────────── */}
+        {applyError && (
+          <div className="flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2">
+            <AlertCircle className="mt-0.5 size-3.5 shrink-0 text-red-400" />
+            <span className="text-[11px] text-red-400">{applyError}</span>
+          </div>
         )}
 
         {/* ── Footer ──────────────────────────────────────── */}
@@ -371,4 +232,219 @@ export function ContextEditor({
   );
 }
 
+// ── Preset Bar (extracted to keep main component readable) ──────
 
+import type { ContextPreset } from '@/types/ipc';
+
+function PresetBar({
+  allPresets,
+  activePresetId,
+  activeUserPreset,
+  hasOverrides,
+  showSaveInput,
+  onPresetChange,
+  onDelete,
+  onReset,
+  onShowSave,
+  onSave,
+  onCancelSave,
+}: {
+  allPresets: ContextPreset[];
+  activePresetId: string | null;
+  activeUserPreset: ContextPreset | null;
+  hasOverrides: boolean;
+  showSaveInput: boolean;
+  onPresetChange: (id: string) => void;
+  onDelete: (id: string) => void;
+  onReset: () => void;
+  onShowSave: () => void;
+  onSave: (name: string) => void;
+  onCancelSave: () => void;
+}) {
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] font-medium text-[var(--text-muted)]">
+          Preset:
+        </span>
+        <Select value={activePresetId ?? ''} onValueChange={onPresetChange}>
+          <SelectTrigger size="sm" className="h-7 w-40 text-xs">
+            <SelectValue placeholder="Custom" />
+          </SelectTrigger>
+          <SelectContent>
+            {allPresets.map((preset) => (
+              <SelectItem key={preset.id} value={preset.id}>
+                {preset.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Delete button — outside the select, only for user presets */}
+        {activeUserPreset && (
+          <button
+            onClick={() => onDelete(activeUserPreset.id)}
+            className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[var(--text-muted)] hover:bg-red-500/10 hover:text-red-400 transition-colors"
+            title={`Delete "${activeUserPreset.name}"`}
+          >
+            <Trash2 className="size-3" />
+          </button>
+        )}
+
+        {!showSaveInput && (
+          <button
+            onClick={onShowSave}
+            className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] transition-colors"
+          >
+            <Save className="size-3" />
+            Save as
+          </button>
+        )}
+
+        {hasOverrides && (
+          <button
+            onClick={onReset}
+            className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] transition-colors"
+          >
+            <RotateCcw className="size-3" />
+            Reset
+          </button>
+        )}
+      </div>
+
+      {showSaveInput && (
+        <SavePresetInput onSave={onSave} onCancel={onCancelSave} />
+      )}
+    </>
+  );
+}
+
+// ── Tools Section ──────────────────────────────────────────────
+
+import type { ContextToolInfo, ContextSkillInfo } from '@/types/ipc';
+
+function ToolsSection({
+  tools,
+  allDisabled,
+  enabledCount,
+  isEnabled,
+  onToggle,
+  onToggleAll,
+}: {
+  tools: ContextToolInfo[];
+  allDisabled: boolean;
+  enabledCount: number;
+  isEnabled: (name: string) => boolean;
+  onToggle: (name: string) => void;
+  onToggleAll: (disabled: boolean) => void;
+}) {
+  return (
+    <ContextSection
+      icon={Wrench}
+      title="Tools"
+      count={tools.length}
+      badge={
+        allDisabled
+          ? 'all disabled'
+          : enabledCount < tools.length
+            ? `${enabledCount}/${tools.length}`
+            : undefined
+      }
+      defaultOpen={false}
+    >
+      <div className="space-y-1">
+        <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
+          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+            Enable all tools
+          </span>
+          <Switch
+            size="sm"
+            checked={!allDisabled}
+            onCheckedChange={(checked) => onToggleAll(!checked)}
+          />
+        </div>
+
+        {tools.map((tool) => (
+          <ToggleRow
+            key={tool.name}
+            name={tool.name}
+            description={tool.description}
+            enabled={isEnabled(tool.name)}
+            onToggle={() => onToggle(tool.name)}
+          />
+        ))}
+
+        {tools.length === 0 && (
+          <span className="text-[11px] text-[var(--text-muted)] italic">
+            No tools available
+          </span>
+        )}
+      </div>
+    </ContextSection>
+  );
+}
+
+// ── Skills Section ─────────────────────────────────────────────
+
+function SkillsSection({
+  skills,
+  allDisabled,
+  enabledCount,
+  isEnabled,
+  onToggle,
+  onToggleAll,
+}: {
+  skills: ContextSkillInfo[];
+  allDisabled: boolean;
+  enabledCount: number;
+  isEnabled: (name: string) => boolean;
+  onToggle: (name: string) => void;
+  onToggleAll: (disabled: boolean) => void;
+}) {
+  return (
+    <ContextSection
+      icon={Sparkles}
+      title="Skills"
+      count={skills.length}
+      badge={
+        allDisabled
+          ? 'all disabled'
+          : enabledCount < skills.length
+            ? `${enabledCount}/${skills.length}`
+            : undefined
+      }
+      defaultOpen={false}
+    >
+      <div className="space-y-1">
+        {skills.length > 0 && (
+          <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
+            <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+              Enable all skills
+            </span>
+            <Switch
+              size="sm"
+              checked={!allDisabled}
+              onCheckedChange={(checked) => onToggleAll(!checked)}
+            />
+          </div>
+        )}
+
+        {skills.map((skill) => (
+          <ToggleRow
+            key={skill.name}
+            name={skill.name}
+            description={skill.description}
+            enabled={isEnabled(skill.name)}
+            onToggle={() => onToggle(skill.name)}
+          />
+        ))}
+
+        {skills.length === 0 && (
+          <span className="text-[11px] text-[var(--text-muted)] italic">
+            No skills available
+          </span>
+        )}
+      </div>
+    </ContextSection>
+  );
+}

--- a/apps/desktop/src/components/layout/ContextEditor.tsx
+++ b/apps/desktop/src/components/layout/ContextEditor.tsx
@@ -363,7 +363,7 @@ function ToolsSection({
       defaultOpen={false}
     >
       <div className="space-y-1">
-        <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
+        <div className="flex items-center justify-between rounded-md border-b border-border/20 px-2 pb-2 mb-1">
           <span className="text-[11px] font-medium text-[var(--text-secondary)]">
             Enable all tools
           </span>
@@ -435,7 +435,7 @@ function SkillsSection({
     >
       <div className="space-y-1">
         {skills.length > 0 && (
-          <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
+          <div className="flex items-center justify-between rounded-md border-b border-border/20 px-2 pb-2 mb-1">
             <span className="text-[11px] font-medium text-[var(--text-secondary)]">
               Enable all skills
             </span>

--- a/apps/desktop/src/components/layout/ContextEditor.tsx
+++ b/apps/desktop/src/components/layout/ContextEditor.tsx
@@ -1,0 +1,596 @@
+import { useState, useMemo, useCallback } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import {
+  ChevronRight,
+  Settings2,
+  FileText,
+  Wrench,
+  Sparkles,
+  Save,
+  Trash2,
+  RotateCcw,
+  Loader2,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Switch } from '@/components/ui/switch';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  useContextEditorStore,
+  useAllPresets,
+  useHasOverrides,
+} from '@/stores/context-editor';
+import type { ContextToolInfo, ContextSkillInfo } from '@/types/ipc';
+
+// ── Collapsible Section (ToolCallGroup style) ───────────────────
+
+function ContextSection({
+  icon: Icon,
+  title,
+  count,
+  badge,
+  defaultOpen = false,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  count?: number;
+  badge?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(defaultOpen);
+
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-lg border transition-colors duration-200',
+        'border-border/50 bg-[var(--bg-elevated)]/50',
+      )}
+    >
+      <button
+        onClick={() => setExpanded((prev) => !prev)}
+        className={cn(
+          'flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors duration-150',
+          'hover:bg-[var(--bg-elevated)]/80',
+        )}
+      >
+        <motion.div
+          animate={{ rotate: expanded ? 90 : 0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+        >
+          <ChevronRight className="size-3.5 text-[var(--text-muted)]" />
+        </motion.div>
+
+        <Icon className="size-3.5 text-[var(--text-muted)]" />
+
+        <span className="text-xs font-medium text-[var(--text-secondary)]">
+          {title}
+        </span>
+
+        {count !== undefined && (
+          <span className="text-[11px] text-[var(--text-muted)]">
+            ({count})
+          </span>
+        )}
+
+        {badge && (
+          <span className="ml-auto rounded bg-[var(--bg-base)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+            {badge}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="overflow-hidden"
+          >
+            <div className="border-t border-border/30 p-3">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Tool Toggle Row ─────────────────────────────────────────────
+
+function ToolRow({
+  tool,
+  enabled,
+  onToggle,
+}: {
+  tool: ContextToolInfo;
+  enabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1">
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
+          {tool.name}
+        </div>
+        {tool.description && (
+          <div className="truncate text-[10px] text-[var(--text-muted)]/60">
+            {tool.description}
+          </div>
+        )}
+      </div>
+      <Switch
+        size="sm"
+        checked={enabled}
+        onCheckedChange={onToggle}
+      />
+    </div>
+  );
+}
+
+// ── Skill Toggle Row ────────────────────────────────────────────
+
+function SkillRow({
+  skill,
+  enabled,
+  onToggle,
+}: {
+  skill: ContextSkillInfo;
+  enabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1">
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
+          {skill.name}
+        </div>
+        {skill.description && (
+          <div className="truncate text-[10px] text-[var(--text-muted)]/60">
+            {skill.description}
+          </div>
+        )}
+      </div>
+      <Switch
+        size="sm"
+        checked={enabled}
+        onCheckedChange={onToggle}
+      />
+    </div>
+  );
+}
+
+// ── Save Preset Dialog ──────────────────────────────────────────
+
+function SavePresetInput({
+  onSave,
+  onCancel,
+}: {
+  onSave: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState('');
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Preset name..."
+        className="flex-1 rounded-md border border-border/50 bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--accent)]"
+        autoFocus
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && name.trim()) onSave(name.trim());
+          if (e.key === 'Escape') onCancel();
+        }}
+      />
+      <button
+        onClick={() => name.trim() && onSave(name.trim())}
+        disabled={!name.trim()}
+        className="rounded-md bg-[var(--accent)] px-2 py-1 text-[11px] font-medium text-white disabled:opacity-50"
+      >
+        Save
+      </button>
+      <button
+        onClick={onCancel}
+        className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+// ── Main Context Editor Dialog ──────────────────────────────────
+
+export function ContextEditor({
+  sessionId,
+}: {
+  sessionId: string;
+}) {
+  const isOpen = useContextEditorStore((s) => s.isOpen);
+  const close = useContextEditorStore((s) => s.close);
+  const availableContext = useContextEditorStore((s) => s.availableContext);
+  const systemPrompt = useContextEditorStore((s) => s.systemPrompt);
+  const disabledTools = useContextEditorStore((s) => s.disabledTools);
+  const disabledSkills = useContextEditorStore((s) => s.disabledSkills);
+  const allToolsDisabled = useContextEditorStore((s) => s.allToolsDisabled);
+  const allSkillsDisabled = useContextEditorStore((s) => s.allSkillsDisabled);
+  const activePresetId = useContextEditorStore((s) => s.activePresetId);
+  const setSystemPrompt = useContextEditorStore((s) => s.setSystemPrompt);
+  const toggleTool = useContextEditorStore((s) => s.toggleTool);
+  const toggleSkill = useContextEditorStore((s) => s.toggleSkill);
+  const setAllToolsDisabled = useContextEditorStore((s) => s.setAllToolsDisabled);
+  const setAllSkillsDisabled = useContextEditorStore((s) => s.setAllSkillsDisabled);
+  const apply = useContextEditorStore((s) => s.apply);
+  const resetToDefault = useContextEditorStore((s) => s.resetToDefault);
+  const loadPreset = useContextEditorStore((s) => s.loadPreset);
+  const savePreset = useContextEditorStore((s) => s.savePreset);
+  const deletePreset = useContextEditorStore((s) => s.deletePreset);
+
+  const allPresets = useAllPresets();
+  const hasOverrides = useHasOverrides();
+
+  const [showSaveInput, setShowSaveInput] = useState(false);
+
+  // Computed: the system prompt text to show in the editor
+  const displayedPrompt = systemPrompt ?? availableContext?.systemPrompt ?? '';
+
+  // Computed: enabled state for each tool
+  const isToolEnabled = useCallback(
+    (toolName: string) => {
+      if (allToolsDisabled) return false;
+      return !disabledTools.has(toolName);
+    },
+    [allToolsDisabled, disabledTools],
+  );
+
+  const isSkillEnabled = useCallback(
+    (skillName: string) => {
+      if (allSkillsDisabled) return false;
+      return !disabledSkills.has(skillName);
+    },
+    [allSkillsDisabled, disabledSkills],
+  );
+
+  // Count enabled tools/skills
+  const enabledToolCount = useMemo(() => {
+    if (!availableContext) return 0;
+    if (allToolsDisabled) return 0;
+    return availableContext.tools.filter((t) => !disabledTools.has(t.name)).length;
+  }, [availableContext, allToolsDisabled, disabledTools]);
+
+  const enabledSkillCount = useMemo(() => {
+    if (!availableContext) return 0;
+    if (allSkillsDisabled) return 0;
+    return availableContext.skills.filter((s) => !disabledSkills.has(s.name)).length;
+  }, [availableContext, allSkillsDisabled, disabledSkills]);
+
+  const handleApplyAndClose = useCallback(async () => {
+    await apply(sessionId);
+    close();
+  }, [apply, close, sessionId]);
+
+  const handlePresetChange = useCallback(
+    (presetId: string) => {
+      loadPreset(presetId);
+    },
+    [loadPreset],
+  );
+
+  const handleSavePreset = useCallback(
+    (name: string) => {
+      savePreset(name);
+      setShowSaveInput(false);
+    },
+    [savePreset],
+  );
+
+  const handleDeletePreset = useCallback(
+    (presetId: string) => {
+      deletePreset(presetId);
+    },
+    [deletePreset],
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
+      <DialogContent
+        className="max-h-[85vh] bg-[var(--bg-surface)] sm:max-w-xl"
+        showCloseButton
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-sm">
+            <Settings2 className="size-4 text-[var(--text-muted)]" />
+            Context Editor
+          </DialogTitle>
+          <DialogDescription className="text-xs">
+            Configure what is included in the LLM context for this session.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* ── Preset Selector ─────────────────────────────── */}
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-medium text-[var(--text-muted)]">
+            Preset:
+          </span>
+          <Select
+            value={activePresetId ?? ''}
+            onValueChange={handlePresetChange}
+          >
+            <SelectTrigger size="sm" className="h-7 w-40 text-xs">
+              <SelectValue placeholder="Custom" />
+            </SelectTrigger>
+            <SelectContent>
+              {allPresets.map((preset) => (
+                <SelectItem key={preset.id} value={preset.id}>
+                  <div className="flex items-center gap-2">
+                    <span>{preset.name}</span>
+                    {!preset.id.startsWith('__') && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeletePreset(preset.id);
+                        }}
+                        className="text-[var(--text-muted)] hover:text-red-400"
+                      >
+                        <Trash2 className="size-3" />
+                      </button>
+                    )}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {!showSaveInput ? (
+            <button
+              onClick={() => setShowSaveInput(true)}
+              className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] transition-colors"
+            >
+              <Save className="size-3" />
+              Save as
+            </button>
+          ) : null}
+
+          {hasOverrides && (
+            <button
+              onClick={resetToDefault}
+              className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] transition-colors"
+            >
+              <RotateCcw className="size-3" />
+              Reset
+            </button>
+          )}
+        </div>
+
+        {showSaveInput && (
+          <SavePresetInput
+            onSave={handleSavePreset}
+            onCancel={() => setShowSaveInput(false)}
+          />
+        )}
+
+        {/* ── Loading state ───────────────────────────────── */}
+        {!availableContext ? (
+          <div className="flex items-center justify-center gap-2 py-8">
+            <Loader2 className="size-4 animate-spin text-[var(--text-muted)]" />
+            <span className="text-xs text-[var(--text-muted)]">
+              Loading session context...
+            </span>
+          </div>
+        ) : (
+          <ScrollArea className="max-h-[50vh]">
+            <div className="space-y-2 pr-2">
+              {/* ── System Prompt Section ────────────────── */}
+              <ContextSection
+                icon={FileText}
+                title="System Prompt"
+                badge={systemPrompt !== null ? 'modified' : undefined}
+                defaultOpen={false}
+              >
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] text-[var(--text-muted)]">
+                      {systemPrompt !== null
+                        ? 'Using custom system prompt'
+                        : 'Using default system prompt'}
+                    </span>
+                    {systemPrompt !== null && (
+                      <button
+                        onClick={() => setSystemPrompt(null)}
+                        className="text-[10px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                      >
+                        Reset to default
+                      </button>
+                    )}
+                  </div>
+                  <textarea
+                    value={displayedPrompt}
+                    onChange={(e) => setSystemPrompt(e.target.value)}
+                    className="h-40 w-full resize-y rounded-md border border-border/30 bg-[var(--bg-base)] p-2 font-mono text-[11px] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--accent)]"
+                    placeholder="Enter system prompt..."
+                  />
+                </div>
+              </ContextSection>
+
+              {/* ── Tools Section ────────────────────────── */}
+              <ContextSection
+                icon={Wrench}
+                title="Tools"
+                count={availableContext.tools.length}
+                badge={
+                  allToolsDisabled
+                    ? 'all disabled'
+                    : enabledToolCount < availableContext.tools.length
+                      ? `${enabledToolCount}/${availableContext.tools.length}`
+                      : undefined
+                }
+                defaultOpen={false}
+              >
+                <div className="space-y-1">
+                  {/* Master toggle */}
+                  <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
+                    <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+                      Enable all tools
+                    </span>
+                    <Switch
+                      size="sm"
+                      checked={!allToolsDisabled}
+                      onCheckedChange={(checked) =>
+                        setAllToolsDisabled(!checked)
+                      }
+                    />
+                  </div>
+
+                  {/* Individual tool toggles */}
+                  {availableContext.tools.map((tool) => (
+                    <ToolRow
+                      key={tool.name}
+                      tool={tool}
+                      enabled={isToolEnabled(tool.name)}
+                      onToggle={() => toggleTool(tool.name)}
+                    />
+                  ))}
+
+                  {availableContext.tools.length === 0 && (
+                    <span className="text-[11px] text-[var(--text-muted)] italic">
+                      No tools available
+                    </span>
+                  )}
+                </div>
+              </ContextSection>
+
+              {/* ── Skills Section ───────────────────────── */}
+              <ContextSection
+                icon={Sparkles}
+                title="Skills"
+                count={availableContext.skills.length}
+                badge={
+                  allSkillsDisabled
+                    ? 'all disabled'
+                    : enabledSkillCount < availableContext.skills.length
+                      ? `${enabledSkillCount}/${availableContext.skills.length}`
+                      : undefined
+                }
+                defaultOpen={false}
+              >
+                <div className="space-y-1">
+                  {/* Master toggle */}
+                  {availableContext.skills.length > 0 && (
+                    <div className="flex items-center justify-between border-b border-border/20 pb-2 mb-1">
+                      <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+                        Enable all skills
+                      </span>
+                      <Switch
+                        size="sm"
+                        checked={!allSkillsDisabled}
+                        onCheckedChange={(checked) =>
+                          setAllSkillsDisabled(!checked)
+                        }
+                      />
+                    </div>
+                  )}
+
+                  {/* Individual skill toggles */}
+                  {availableContext.skills.map((skill) => (
+                    <SkillRow
+                      key={skill.name}
+                      skill={skill}
+                      enabled={isSkillEnabled(skill.name)}
+                      onToggle={() => toggleSkill(skill.name)}
+                    />
+                  ))}
+
+                  {availableContext.skills.length === 0 && (
+                    <span className="text-[11px] text-[var(--text-muted)] italic">
+                      No skills available
+                    </span>
+                  )}
+                </div>
+              </ContextSection>
+            </div>
+          </ScrollArea>
+        )}
+
+        {/* ── Footer ──────────────────────────────────────── */}
+        <DialogFooter>
+          <button
+            onClick={close}
+            className="rounded-md border border-border/50 px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleApplyAndClose}
+            disabled={!availableContext}
+            className="rounded-md bg-[var(--accent)] px-3 py-1.5 text-xs font-medium text-white hover:bg-[var(--accent-hover)] disabled:opacity-50 transition-colors"
+          >
+            Apply
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Context Editor Trigger Button ───────────────────────────────
+
+/**
+ * Small icon button that opens the context editor.
+ * Only renders when the session is new (no messages).
+ */
+export function ContextEditorTrigger({
+  sessionId,
+  hasMessages,
+  disabled,
+}: {
+  sessionId: string;
+  hasMessages: boolean;
+  disabled?: boolean;
+}) {
+  const openEditor = useContextEditorStore((s) => s.open);
+  const hasOverrides = useHasOverrides();
+
+  // Only show for new sessions (no messages yet)
+  if (hasMessages) return null;
+
+  return (
+    <button
+      onClick={() => openEditor(sessionId)}
+      disabled={disabled}
+      title="Edit session context"
+      className={cn(
+        'relative rounded-md p-1 transition-colors',
+        'hover:bg-[var(--bg-elevated)] disabled:opacity-50 disabled:cursor-not-allowed',
+        hasOverrides
+          ? 'text-[var(--accent)]'
+          : 'text-[var(--text-muted)]',
+      )}
+    >
+      <Settings2 className="size-3.5" />
+      {hasOverrides && (
+        <span className="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-[var(--accent)]" />
+      )}
+    </button>
+  );
+}

--- a/apps/desktop/src/components/layout/ContextEditor.tsx
+++ b/apps/desktop/src/components/layout/ContextEditor.tsx
@@ -1,7 +1,5 @@
 import { useState, useMemo, useCallback } from 'react';
-import { AnimatePresence, motion } from 'motion/react';
 import {
-  ChevronRight,
   Settings2,
   FileText,
   Wrench,
@@ -11,7 +9,6 @@ import {
   RotateCcw,
   Loader2,
 } from 'lucide-react';
-import { cn } from '@/lib/utils';
 import {
   Dialog,
   DialogContent,
@@ -34,191 +31,12 @@ import {
   useAllPresets,
   useHasOverrides,
 } from '@/stores/context-editor';
-import type { ContextToolInfo, ContextSkillInfo } from '@/types/ipc';
-
-// ── Collapsible Section (ToolCallGroup style) ───────────────────
-
-function ContextSection({
-  icon: Icon,
-  title,
-  count,
-  badge,
-  defaultOpen = false,
-  children,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  count?: number;
-  badge?: string;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}) {
-  const [expanded, setExpanded] = useState(defaultOpen);
-
-  return (
-    <div
-      className={cn(
-        'overflow-hidden rounded-lg border transition-colors duration-200',
-        'border-border/50 bg-[var(--bg-elevated)]/50',
-      )}
-    >
-      <button
-        onClick={() => setExpanded((prev) => !prev)}
-        className={cn(
-          'flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors duration-150',
-          'hover:bg-[var(--bg-elevated)]/80',
-        )}
-      >
-        <motion.div
-          animate={{ rotate: expanded ? 90 : 0 }}
-          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
-        >
-          <ChevronRight className="size-3.5 text-[var(--text-muted)]" />
-        </motion.div>
-
-        <Icon className="size-3.5 text-[var(--text-muted)]" />
-
-        <span className="text-xs font-medium text-[var(--text-secondary)]">
-          {title}
-        </span>
-
-        {count !== undefined && (
-          <span className="text-[11px] text-[var(--text-muted)]">
-            ({count})
-          </span>
-        )}
-
-        {badge && (
-          <span className="ml-auto rounded bg-[var(--bg-base)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
-            {badge}
-          </span>
-        )}
-      </button>
-
-      <AnimatePresence>
-        {expanded && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
-            className="overflow-hidden"
-          >
-            <div className="border-t border-border/30 p-3">
-              {children}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
-}
-
-// ── Tool Toggle Row ─────────────────────────────────────────────
-
-function ToolRow({
-  tool,
-  enabled,
-  onToggle,
-}: {
-  tool: ContextToolInfo;
-  enabled: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-2 py-1">
-      <div className="min-w-0 flex-1">
-        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
-          {tool.name}
-        </div>
-        {tool.description && (
-          <div className="truncate text-[10px] text-[var(--text-muted)]/60">
-            {tool.description}
-          </div>
-        )}
-      </div>
-      <Switch
-        size="sm"
-        checked={enabled}
-        onCheckedChange={onToggle}
-      />
-    </div>
-  );
-}
-
-// ── Skill Toggle Row ────────────────────────────────────────────
-
-function SkillRow({
-  skill,
-  enabled,
-  onToggle,
-}: {
-  skill: ContextSkillInfo;
-  enabled: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-2 py-1">
-      <div className="min-w-0 flex-1">
-        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
-          {skill.name}
-        </div>
-        {skill.description && (
-          <div className="truncate text-[10px] text-[var(--text-muted)]/60">
-            {skill.description}
-          </div>
-        )}
-      </div>
-      <Switch
-        size="sm"
-        checked={enabled}
-        onCheckedChange={onToggle}
-      />
-    </div>
-  );
-}
-
-// ── Save Preset Dialog ──────────────────────────────────────────
-
-function SavePresetInput({
-  onSave,
-  onCancel,
-}: {
-  onSave: (name: string) => void;
-  onCancel: () => void;
-}) {
-  const [name, setName] = useState('');
-
-  return (
-    <div className="flex items-center gap-2">
-      <input
-        type="text"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="Preset name..."
-        className="flex-1 rounded-md border border-border/50 bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--accent)]"
-        autoFocus
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' && name.trim()) onSave(name.trim());
-          if (e.key === 'Escape') onCancel();
-        }}
-      />
-      <button
-        onClick={() => name.trim() && onSave(name.trim())}
-        disabled={!name.trim()}
-        className="rounded-md bg-[var(--accent)] px-2 py-1 text-[11px] font-medium text-white disabled:opacity-50"
-      >
-        Save
-      </button>
-      <button
-        onClick={onCancel}
-        className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-      >
-        Cancel
-      </button>
-    </div>
-  );
-}
+import {
+  ContextSection,
+  ToolRow,
+  SkillRow,
+  SavePresetInput,
+} from './context-editor-parts';
 
 // ── Main Context Editor Dialog ──────────────────────────────────
 
@@ -315,7 +133,7 @@ export function ContextEditor({
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
       <DialogContent
-        className="max-h-[85vh] bg-[var(--bg-surface)] sm:max-w-xl"
+        className="max-h-[85vh] overflow-hidden bg-[var(--bg-surface)] sm:max-w-[58rem]"
         showCloseButton
       >
         <DialogHeader>
@@ -399,8 +217,8 @@ export function ContextEditor({
             </span>
           </div>
         ) : (
-          <ScrollArea className="max-h-[50vh]">
-            <div className="space-y-2 pr-2">
+          <ScrollArea className="max-h-[65vh] overflow-hidden">
+            <div className="min-w-0 space-y-2 pr-2">
               {/* ── System Prompt Section ────────────────── */}
               <ContextSection
                 icon={FileText}
@@ -427,7 +245,7 @@ export function ContextEditor({
                   <textarea
                     value={displayedPrompt}
                     onChange={(e) => setSystemPrompt(e.target.value)}
-                    className="h-40 w-full resize-y rounded-md border border-border/30 bg-[var(--bg-base)] p-2 font-mono text-[11px] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--accent)]"
+                    className="h-80 w-full resize-y rounded-md border border-border/30 bg-[var(--bg-base)] p-2 font-mono text-[11px] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--accent)]"
                     placeholder="Enter system prompt..."
                   />
                 </div>
@@ -553,44 +371,4 @@ export function ContextEditor({
   );
 }
 
-// ── Context Editor Trigger Button ───────────────────────────────
 
-/**
- * Small icon button that opens the context editor.
- * Only renders when the session is new (no messages).
- */
-export function ContextEditorTrigger({
-  sessionId,
-  hasMessages,
-  disabled,
-}: {
-  sessionId: string;
-  hasMessages: boolean;
-  disabled?: boolean;
-}) {
-  const openEditor = useContextEditorStore((s) => s.open);
-  const hasOverrides = useHasOverrides();
-
-  // Only show for new sessions (no messages yet)
-  if (hasMessages) return null;
-
-  return (
-    <button
-      onClick={() => openEditor(sessionId)}
-      disabled={disabled}
-      title="Edit session context"
-      className={cn(
-        'relative rounded-md p-1 transition-colors',
-        'hover:bg-[var(--bg-elevated)] disabled:opacity-50 disabled:cursor-not-allowed',
-        hasOverrides
-          ? 'text-[var(--accent)]'
-          : 'text-[var(--text-muted)]',
-      )}
-    >
-      <Settings2 className="size-3.5" />
-      {hasOverrides && (
-        <span className="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-[var(--accent)]" />
-      )}
-    </button>
-  );
-}

--- a/apps/desktop/src/components/layout/ContextEditor.tsx
+++ b/apps/desktop/src/components/layout/ContextEditor.tsx
@@ -152,7 +152,9 @@ export function ContextEditor({ sessionId }: { sessionId: string }) {
               <ContextSection
                 icon={FileText}
                 title="System Prompt"
+                tint="blue"
                 badge={systemPrompt !== null ? 'modified' : undefined}
+                badgeVariant={systemPrompt !== null ? 'modified' : 'default'}
                 defaultOpen={false}
               >
                 <div className="space-y-2">
@@ -338,10 +340,17 @@ function ToolsSection({
   onToggle: (name: string) => void;
   onToggleAll: (disabled: boolean) => void;
 }) {
+  const badgeVariant = allDisabled
+    ? 'disabled' as const
+    : enabledCount < tools.length
+      ? 'partial' as const
+      : 'default' as const;
+
   return (
     <ContextSection
       icon={Wrench}
       title="Tools"
+      tint="amber"
       count={tools.length}
       badge={
         allDisabled
@@ -350,6 +359,7 @@ function ToolsSection({
             ? `${enabledCount}/${tools.length}`
             : undefined
       }
+      badgeVariant={badgeVariant}
       defaultOpen={false}
     >
       <div className="space-y-1">
@@ -401,10 +411,17 @@ function SkillsSection({
   onToggle: (name: string) => void;
   onToggleAll: (disabled: boolean) => void;
 }) {
+  const badgeVariant = allDisabled
+    ? 'disabled' as const
+    : enabledCount < skills.length
+      ? 'partial' as const
+      : 'default' as const;
+
   return (
     <ContextSection
       icon={Sparkles}
       title="Skills"
+      tint="violet"
       count={skills.length}
       badge={
         allDisabled
@@ -413,6 +430,7 @@ function SkillsSection({
             ? `${enabledCount}/${skills.length}`
             : undefined
       }
+      badgeVariant={badgeVariant}
       defaultOpen={false}
     >
       <div className="space-y-1">

--- a/apps/desktop/src/components/layout/ContextEditor.tsx
+++ b/apps/desktop/src/components/layout/ContextEditor.tsx
@@ -153,8 +153,16 @@ export function ContextEditor({ sessionId }: { sessionId: string }) {
                 icon={FileText}
                 title="System Prompt"
                 tint="blue"
-                badge={systemPrompt !== null ? 'modified' : undefined}
-                badgeVariant={systemPrompt !== null ? 'modified' : 'default'}
+                badge={
+                  systemPrompt !== null
+                    ? (systemPrompt === '' ? 'disabled' : 'modified')
+                    : undefined
+                }
+                badgeVariant={
+                  systemPrompt !== null
+                    ? (systemPrompt === '' ? 'disabled' : 'modified')
+                    : 'default'
+                }
                 defaultOpen={false}
               >
                 <div className="space-y-2">
@@ -354,7 +362,7 @@ function ToolsSection({
       count={tools.length}
       badge={
         allDisabled
-          ? 'all disabled'
+          ? 'disabled'
           : enabledCount < tools.length
             ? `${enabledCount}/${tools.length}`
             : undefined
@@ -425,7 +433,7 @@ function SkillsSection({
       count={skills.length}
       badge={
         allDisabled
-          ? 'all disabled'
+          ? 'disabled'
           : enabledCount < skills.length
             ? `${enabledCount}/${skills.length}`
             : undefined

--- a/apps/desktop/src/components/layout/context-editor-parts.tsx
+++ b/apps/desktop/src/components/layout/context-editor-parts.tsx
@@ -9,6 +9,39 @@ import { ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
 
+// ── Color tint definitions ──────────────────────────────────────
+
+type SectionTint = 'blue' | 'amber' | 'violet' | 'neutral';
+type BadgeVariant = 'default' | 'modified' | 'disabled' | 'partial';
+
+const iconTintClass: Record<SectionTint, string> = {
+  blue: 'text-blue-400 dark:text-blue-400',
+  amber: 'text-amber-500 dark:text-amber-400',
+  violet: 'text-violet-500 dark:text-violet-400',
+  neutral: 'text-[var(--text-muted)]',
+};
+
+const badgeClass: Record<BadgeVariant, string> = {
+  default: 'bg-[var(--bg-base)] text-[var(--text-muted)]',
+  modified: 'bg-amber-500/15 text-amber-600 dark:text-amber-400',
+  disabled: 'bg-red-500/15 text-red-600 dark:text-red-400',
+  partial: 'bg-blue-500/15 text-blue-600 dark:text-blue-400',
+};
+
+const sectionBorderClass: Record<BadgeVariant, string> = {
+  default: 'border-border/50',
+  modified: 'border-amber-500/25 dark:border-amber-500/20',
+  disabled: 'border-red-500/25 dark:border-red-500/20',
+  partial: 'border-blue-500/25 dark:border-blue-500/20',
+};
+
+const sectionBgClass: Record<BadgeVariant, string> = {
+  default: 'bg-[var(--bg-elevated)]/50',
+  modified: 'bg-amber-500/[0.03]',
+  disabled: 'bg-red-500/[0.03]',
+  partial: 'bg-blue-500/[0.03]',
+};
+
 // ── Collapsible Section (ToolCallGroup style) ───────────────────
 
 export function ContextSection({
@@ -16,6 +49,8 @@ export function ContextSection({
   title,
   count,
   badge,
+  badgeVariant = 'default',
+  tint = 'neutral',
   defaultOpen = false,
   children,
 }: {
@@ -23,6 +58,8 @@ export function ContextSection({
   title: string;
   count?: number;
   badge?: string;
+  badgeVariant?: BadgeVariant;
+  tint?: SectionTint;
   defaultOpen?: boolean;
   children: React.ReactNode;
 }) {
@@ -32,7 +69,8 @@ export function ContextSection({
     <div
       className={cn(
         'overflow-hidden rounded-lg border transition-colors duration-200',
-        'border-border/50 bg-[var(--bg-elevated)]/50',
+        sectionBorderClass[badgeVariant],
+        sectionBgClass[badgeVariant],
       )}
     >
       <button
@@ -49,7 +87,7 @@ export function ContextSection({
           <ChevronRight className="size-3.5 text-[var(--text-muted)]" />
         </motion.div>
 
-        <Icon className="size-3.5 text-[var(--text-muted)]" />
+        <Icon className={cn('size-3.5', iconTintClass[tint])} />
 
         <span className="text-xs font-medium text-[var(--text-secondary)]">
           {title}
@@ -62,7 +100,12 @@ export function ContextSection({
         )}
 
         {badge && (
-          <span className="ml-auto rounded bg-[var(--bg-base)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+          <span
+            className={cn(
+              'ml-auto rounded-full px-2 py-0.5 text-[10px] font-medium',
+              badgeClass[badgeVariant],
+            )}
+          >
             {badge}
           </span>
         )}
@@ -101,13 +144,23 @@ export function ToggleRow({
   onToggle: () => void;
 }) {
   return (
-    <div className="flex min-w-0 items-start justify-between gap-3 py-1">
+    <div
+      className={cn(
+        'flex min-w-0 items-start justify-between gap-3 rounded-md px-2 py-1.5 transition-colors',
+        enabled
+          ? 'hover:bg-[var(--bg-elevated)]/60'
+          : 'opacity-60 hover:bg-[var(--bg-elevated)]/40',
+      )}
+    >
       <div className="min-w-0 flex-1">
-        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
+        <div className={cn(
+          'text-[11px] font-medium',
+          enabled ? 'text-[var(--text-secondary)]' : 'text-[var(--text-muted)]',
+        )}>
           {name}
         </div>
         {description && (
-          <div className="text-[10px] leading-snug text-[var(--text-muted)]/60">
+          <div className="mt-0.5 text-[10px] leading-snug text-[var(--text-muted)]/60">
             {description}
           </div>
         )}

--- a/apps/desktop/src/components/layout/context-editor-parts.tsx
+++ b/apps/desktop/src/components/layout/context-editor-parts.tsx
@@ -8,7 +8,6 @@ import { AnimatePresence, motion } from 'motion/react';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Switch } from '@/components/ui/switch';
-import type { ContextToolInfo, ContextSkillInfo } from '@/types/ipc';
 
 // ── Collapsible Section (ToolCallGroup style) ───────────────────
 
@@ -88,14 +87,16 @@ export function ContextSection({
   );
 }
 
-// ── Tool Toggle Row ─────────────────────────────────────────────
+// ── Generic Toggle Row (used for both tools and skills) ─────────
 
-export function ToolRow({
-  tool,
+export function ToggleRow({
+  name,
+  description,
   enabled,
   onToggle,
 }: {
-  tool: ContextToolInfo;
+  name: string;
+  description?: string;
   enabled: boolean;
   onToggle: () => void;
 }) {
@@ -103,44 +104,11 @@ export function ToolRow({
     <div className="flex min-w-0 items-start justify-between gap-3 py-1">
       <div className="min-w-0 flex-1">
         <div className="text-[11px] font-medium text-[var(--text-secondary)]">
-          {tool.name}
+          {name}
         </div>
-        {tool.description && (
+        {description && (
           <div className="text-[10px] leading-snug text-[var(--text-muted)]/60">
-            {tool.description}
-          </div>
-        )}
-      </div>
-      <Switch
-        size="sm"
-        className="mt-0.5 shrink-0"
-        checked={enabled}
-        onCheckedChange={onToggle}
-      />
-    </div>
-  );
-}
-
-// ── Skill Toggle Row ────────────────────────────────────────────
-
-export function SkillRow({
-  skill,
-  enabled,
-  onToggle,
-}: {
-  skill: ContextSkillInfo;
-  enabled: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <div className="flex min-w-0 items-start justify-between gap-3 py-1">
-      <div className="min-w-0 flex-1">
-        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
-          {skill.name}
-        </div>
-        {skill.description && (
-          <div className="text-[10px] leading-snug text-[var(--text-muted)]/60">
-            {skill.description}
+            {description}
           </div>
         )}
       </div>

--- a/apps/desktop/src/components/layout/context-editor-parts.tsx
+++ b/apps/desktop/src/components/layout/context-editor-parts.tsx
@@ -1,0 +1,197 @@
+/**
+ * Presentational sub-components for the ContextEditor dialog.
+ * Extracted to keep ContextEditor.tsx under the 500-line limit.
+ */
+
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Switch } from '@/components/ui/switch';
+import type { ContextToolInfo, ContextSkillInfo } from '@/types/ipc';
+
+// ── Collapsible Section (ToolCallGroup style) ───────────────────
+
+export function ContextSection({
+  icon: Icon,
+  title,
+  count,
+  badge,
+  defaultOpen = false,
+  children,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  count?: number;
+  badge?: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(defaultOpen);
+
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-lg border transition-colors duration-200',
+        'border-border/50 bg-[var(--bg-elevated)]/50',
+      )}
+    >
+      <button
+        onClick={() => setExpanded((prev) => !prev)}
+        className={cn(
+          'flex w-full items-center gap-2.5 px-3 py-2 text-left transition-colors duration-150',
+          'hover:bg-[var(--bg-elevated)]/80',
+        )}
+      >
+        <motion.div
+          animate={{ rotate: expanded ? 90 : 0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 25 }}
+        >
+          <ChevronRight className="size-3.5 text-[var(--text-muted)]" />
+        </motion.div>
+
+        <Icon className="size-3.5 text-[var(--text-muted)]" />
+
+        <span className="text-xs font-medium text-[var(--text-secondary)]">
+          {title}
+        </span>
+
+        {count !== undefined && (
+          <span className="text-[11px] text-[var(--text-muted)]">
+            ({count})
+          </span>
+        )}
+
+        {badge && (
+          <span className="ml-auto rounded bg-[var(--bg-base)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+            {badge}
+          </span>
+        )}
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
+            className="overflow-hidden"
+          >
+            <div className="min-w-0 border-t border-border/30 p-3">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ── Tool Toggle Row ─────────────────────────────────────────────
+
+export function ToolRow({
+  tool,
+  enabled,
+  onToggle,
+}: {
+  tool: ContextToolInfo;
+  enabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex min-w-0 items-start justify-between gap-3 py-1">
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
+          {tool.name}
+        </div>
+        {tool.description && (
+          <div className="text-[10px] leading-snug text-[var(--text-muted)]/60">
+            {tool.description}
+          </div>
+        )}
+      </div>
+      <Switch
+        size="sm"
+        className="mt-0.5 shrink-0"
+        checked={enabled}
+        onCheckedChange={onToggle}
+      />
+    </div>
+  );
+}
+
+// ── Skill Toggle Row ────────────────────────────────────────────
+
+export function SkillRow({
+  skill,
+  enabled,
+  onToggle,
+}: {
+  skill: ContextSkillInfo;
+  enabled: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="flex min-w-0 items-start justify-between gap-3 py-1">
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] font-medium text-[var(--text-secondary)]">
+          {skill.name}
+        </div>
+        {skill.description && (
+          <div className="text-[10px] leading-snug text-[var(--text-muted)]/60">
+            {skill.description}
+          </div>
+        )}
+      </div>
+      <Switch
+        size="sm"
+        className="mt-0.5 shrink-0"
+        checked={enabled}
+        onCheckedChange={onToggle}
+      />
+    </div>
+  );
+}
+
+// ── Save Preset Input ───────────────────────────────────────────
+
+export function SavePresetInput({
+  onSave,
+  onCancel,
+}: {
+  onSave: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState('');
+
+  return (
+    <div className="flex items-center gap-2">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Preset name..."
+        className="flex-1 rounded-md border border-border/50 bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--accent)]"
+        autoFocus
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && name.trim()) onSave(name.trim());
+          if (e.key === 'Escape') onCancel();
+        }}
+      />
+      <button
+        onClick={() => name.trim() && onSave(name.trim())}
+        disabled={!name.trim()}
+        className="rounded-md bg-[var(--accent)] px-2 py-1 text-[11px] font-medium text-white disabled:opacity-50"
+      >
+        Save
+      </button>
+      <button
+        onClick={onCancel}
+        className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/stores/context-editor.ts
+++ b/apps/desktop/src/stores/context-editor.ts
@@ -1,25 +1,10 @@
 import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
 import type {
   SessionContext,
   ContextOverrides,
-  ContextToolInfo,
-  ContextSkillInfo,
+  ContextPreset,
 } from '@/types/ipc';
-
-// ── Preset Types ──────────────────────────────────────────────
-
-export interface ContextPreset {
-  id: string;
-  name: string;
-  /** If null, use the default system prompt. If string, override with this. */
-  systemPrompt: string | null;
-  /** Tool names to disable. */
-  disabledTools: string[];
-  /** Skill names to disable. */
-  disabledSkills: string[];
-}
-
-const PRESETS_STORAGE_KEY = 'sero:context-editor:presets';
 
 // ── Built-in Presets ──────────────────────────────────────────
 
@@ -44,25 +29,23 @@ const BUILTIN_PRESETS: ContextPreset[] = [DEFAULT_PRESET, NONE_PRESET];
 // ── Store Types ───────────────────────────────────────────────
 
 interface ContextEditorState {
-  /** Whether the context editor dialog is open. */
   isOpen: boolean;
-
-  /** Available context fetched from the session (null = not loaded). */
   availableContext: SessionContext | null;
 
-  /** Current override state being edited. */
   systemPrompt: string | null;
   disabledTools: Set<string>;
   disabledSkills: Set<string>;
-  /** Whether '__all__' tools/skills are disabled (the "none" pattern). */
   allToolsDisabled: boolean;
   allSkillsDisabled: boolean;
 
-  /** Currently selected preset ID (or null for custom). */
   activePresetId: string | null;
-
-  /** User-saved presets (loaded from localStorage). */
+  /** User-saved presets (persisted to disk via IPC). */
   userPresets: ContextPreset[];
+  /** Whether user presets have been loaded from disk. */
+  presetsLoaded: boolean;
+
+  /** Error message from the last apply() call, or null. */
+  applyError: string | null;
 
   // ── Actions ─────────────────────────────────────────────────
 
@@ -75,33 +58,13 @@ interface ContextEditorState {
   setAllToolsDisabled: (disabled: boolean) => void;
   setAllSkillsDisabled: (disabled: boolean) => void;
 
-  /** Apply the current overrides to the session. */
-  apply: (sessionId: string) => Promise<void>;
-  /** Reset to default (clear all overrides). */
+  /** Apply overrides to the session. Returns true on success. */
+  apply: (sessionId: string) => Promise<boolean>;
   resetToDefault: () => void;
 
-  /** Load a preset into the editor state. */
   loadPreset: (presetId: string) => void;
-  /** Save the current editor state as a new preset. */
-  savePreset: (name: string) => void;
-  /** Delete a user preset. */
-  deletePreset: (presetId: string) => void;
-}
-
-// ── Helpers ───────────────────────────────────────────────────
-
-function loadUserPresets(): ContextPreset[] {
-  try {
-    const raw = localStorage.getItem(PRESETS_STORAGE_KEY);
-    if (raw) return JSON.parse(raw);
-  } catch {
-    // Ignore parse errors
-  }
-  return [];
-}
-
-function saveUserPresets(presets: ContextPreset[]): void {
-  localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(presets));
+  savePreset: (name: string) => Promise<void>;
+  deletePreset: (presetId: string) => Promise<void>;
 }
 
 // ── Store ─────────────────────────────────────────────────────
@@ -115,12 +78,11 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
   allToolsDisabled: false,
   allSkillsDisabled: false,
   activePresetId: '__default__',
-  userPresets: loadUserPresets(),
+  userPresets: [],
+  presetsLoaded: false,
+  applyError: null,
 
   open: async (sessionId) => {
-    // Reset editor state to defaults so stale overrides from a previous
-    // session don't bleed through. The context editor is stateless between
-    // opens — it always starts from the "Default" preset.
     set({
       isOpen: true,
       availableContext: null,
@@ -130,7 +92,19 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
       allToolsDisabled: false,
       allSkillsDisabled: false,
       activePresetId: '__default__',
+      applyError: null,
     });
+
+    // Load presets from disk if not yet loaded
+    if (!get().presetsLoaded) {
+      try {
+        const presets = await window.sero.contextPresets.load();
+        set({ userPresets: presets, presetsLoaded: true });
+      } catch (err) {
+        console.error('[context-editor] Failed to load presets:', err);
+        set({ presetsLoaded: true });
+      }
+    }
 
     try {
       const context = await window.sero.agent.getContext(sessionId);
@@ -143,63 +117,40 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
   },
 
   close: () => {
-    set({ isOpen: false });
+    set({ isOpen: false, applyError: null });
   },
 
   setSystemPrompt: (value) => {
-    set({ systemPrompt: value, activePresetId: null });
+    set({ systemPrompt: value, activePresetId: null, applyError: null });
   },
 
   toggleTool: (toolName) => {
-    const { disabledTools, allToolsDisabled } = get();
+    const { disabledTools } = get();
     const next = new Set(disabledTools);
-    if (next.has(toolName)) {
-      next.delete(toolName);
-    } else {
-      next.add(toolName);
-    }
-    set({
-      disabledTools: next,
-      allToolsDisabled: false,
-      activePresetId: null,
-    });
+    if (next.has(toolName)) next.delete(toolName);
+    else next.add(toolName);
+    set({ disabledTools: next, allToolsDisabled: false, activePresetId: null, applyError: null });
   },
 
   toggleSkill: (skillName) => {
-    const { disabledSkills, allSkillsDisabled } = get();
+    const { disabledSkills } = get();
     const next = new Set(disabledSkills);
-    if (next.has(skillName)) {
-      next.delete(skillName);
-    } else {
-      next.add(skillName);
-    }
-    set({
-      disabledSkills: next,
-      allSkillsDisabled: false,
-      activePresetId: null,
-    });
+    if (next.has(skillName)) next.delete(skillName);
+    else next.add(skillName);
+    set({ disabledSkills: next, allSkillsDisabled: false, activePresetId: null, applyError: null });
   },
 
   setAllToolsDisabled: (disabled) => {
-    set({
-      allToolsDisabled: disabled,
-      disabledTools: new Set(),
-      activePresetId: null,
-    });
+    set({ allToolsDisabled: disabled, disabledTools: new Set(), activePresetId: null, applyError: null });
   },
 
   setAllSkillsDisabled: (disabled) => {
-    set({
-      allSkillsDisabled: disabled,
-      disabledSkills: new Set(),
-      activePresetId: null,
-    });
+    set({ allSkillsDisabled: disabled, disabledSkills: new Set(), activePresetId: null, applyError: null });
   },
 
   apply: async (sessionId) => {
     const { systemPrompt, disabledTools, allToolsDisabled, disabledSkills, allSkillsDisabled, availableContext } = get();
 
-    // Build the overrides to send to main process
     let toolsToDisable: string[] = [];
     if (allToolsDisabled && availableContext) {
       toolsToDisable = availableContext.tools.map((t) => t.name);
@@ -215,9 +166,7 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
     }
 
     const hasOverrides =
-      systemPrompt !== null ||
-      toolsToDisable.length > 0 ||
-      skillsToDisable.length > 0;
+      systemPrompt !== null || toolsToDisable.length > 0 || skillsToDisable.length > 0;
 
     const overrides: ContextOverrides | null = hasOverrides
       ? {
@@ -229,8 +178,13 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
 
     try {
       await window.sero.agent.setContextOverrides(sessionId, overrides);
+      set({ applyError: null });
+      return true;
     } catch (err) {
-      console.error('[context-editor] Failed to apply overrides:', err);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error('[context-editor] Failed to apply overrides:', msg);
+      set({ applyError: msg });
+      return false;
     }
   },
 
@@ -242,6 +196,7 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
       allToolsDisabled: false,
       allSkillsDisabled: false,
       activePresetId: '__default__',
+      applyError: null,
     });
   },
 
@@ -260,10 +215,11 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
       allToolsDisabled,
       allSkillsDisabled,
       activePresetId: presetId,
+      applyError: null,
     });
   },
 
-  savePreset: (name) => {
+  savePreset: async (name) => {
     const { systemPrompt, disabledTools, disabledSkills, allToolsDisabled, allSkillsDisabled, userPresets } = get();
 
     const newPreset: ContextPreset = {
@@ -275,22 +231,30 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
     };
 
     const updated = [...userPresets, newPreset];
-    saveUserPresets(updated);
-    set({ userPresets: updated, activePresetId: newPreset.id });
+    try {
+      await window.sero.contextPresets.save(updated);
+      set({ userPresets: updated, activePresetId: newPreset.id });
+    } catch (err) {
+      console.error('[context-editor] Failed to save presets:', err);
+    }
   },
 
-  deletePreset: (presetId) => {
+  deletePreset: async (presetId) => {
     const { userPresets, activePresetId } = get();
     const updated = userPresets.filter((p) => p.id !== presetId);
-    saveUserPresets(updated);
-    set({
-      userPresets: updated,
-      activePresetId: activePresetId === presetId ? null : activePresetId,
-    });
+    try {
+      await window.sero.contextPresets.save(updated);
+      set({
+        userPresets: updated,
+        activePresetId: activePresetId === presetId ? null : activePresetId,
+      });
+    } catch (err) {
+      console.error('[context-editor] Failed to save presets:', err);
+    }
   },
 }));
 
-// ── Selectors ─────────────────────────────────────────────────
+// ── Grouped Selectors (Issue #8) ──────────────────────────────
 
 /** All available presets (built-in + user). */
 export function useAllPresets(): ContextPreset[] {
@@ -298,34 +262,51 @@ export function useAllPresets(): ContextPreset[] {
   return [...BUILTIN_PRESETS, ...userPresets];
 }
 
-/** Check if a tool is enabled in the current editor state. */
-export function useIsToolEnabled(toolName: string): boolean {
-  const disabledTools = useContextEditorStore((s) => s.disabledTools);
-  const allDisabled = useContextEditorStore((s) => s.allToolsDisabled);
-  if (allDisabled) return false;
-  return !disabledTools.has(toolName);
-}
-
-/** Check if a skill is enabled in the current editor state. */
-export function useIsSkillEnabled(skillName: string): boolean {
-  const disabledSkills = useContextEditorStore((s) => s.disabledSkills);
-  const allDisabled = useContextEditorStore((s) => s.allSkillsDisabled);
-  if (allDisabled) return false;
-  return !disabledSkills.has(skillName);
-}
-
 /** Whether the current state has any overrides from the default. */
 export function useHasOverrides(): boolean {
-  const systemPrompt = useContextEditorStore((s) => s.systemPrompt);
-  const disabledTools = useContextEditorStore((s) => s.disabledTools);
-  const disabledSkills = useContextEditorStore((s) => s.disabledSkills);
-  const allToolsDisabled = useContextEditorStore((s) => s.allToolsDisabled);
-  const allSkillsDisabled = useContextEditorStore((s) => s.allSkillsDisabled);
-  return (
-    systemPrompt !== null ||
-    disabledTools.size > 0 ||
-    disabledSkills.size > 0 ||
-    allToolsDisabled ||
-    allSkillsDisabled
+  return useContextEditorStore(
+    useShallow((s) =>
+      s.systemPrompt !== null ||
+      s.disabledTools.size > 0 ||
+      s.disabledSkills.size > 0 ||
+      s.allToolsDisabled ||
+      s.allSkillsDisabled,
+    ),
+  );
+}
+
+/** Grouped editor state to reduce individual subscriptions. */
+export function useEditorState() {
+  return useContextEditorStore(
+    useShallow((s) => ({
+      isOpen: s.isOpen,
+      availableContext: s.availableContext,
+      systemPrompt: s.systemPrompt,
+      disabledTools: s.disabledTools,
+      disabledSkills: s.disabledSkills,
+      allToolsDisabled: s.allToolsDisabled,
+      allSkillsDisabled: s.allSkillsDisabled,
+      activePresetId: s.activePresetId,
+      applyError: s.applyError,
+    })),
+  );
+}
+
+/** Grouped editor actions (stable references, no re-render). */
+export function useEditorActions() {
+  return useContextEditorStore(
+    useShallow((s) => ({
+      close: s.close,
+      setSystemPrompt: s.setSystemPrompt,
+      toggleTool: s.toggleTool,
+      toggleSkill: s.toggleSkill,
+      setAllToolsDisabled: s.setAllToolsDisabled,
+      setAllSkillsDisabled: s.setAllSkillsDisabled,
+      apply: s.apply,
+      resetToDefault: s.resetToDefault,
+      loadPreset: s.loadPreset,
+      savePreset: s.savePreset,
+      deletePreset: s.deletePreset,
+    })),
   );
 }

--- a/apps/desktop/src/stores/context-editor.ts
+++ b/apps/desktop/src/stores/context-editor.ts
@@ -118,7 +118,19 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
   userPresets: loadUserPresets(),
 
   open: async (sessionId) => {
-    set({ isOpen: true, availableContext: null });
+    // Reset editor state to defaults so stale overrides from a previous
+    // session don't bleed through. The context editor is stateless between
+    // opens — it always starts from the "Default" preset.
+    set({
+      isOpen: true,
+      availableContext: null,
+      systemPrompt: null,
+      disabledTools: new Set(),
+      disabledSkills: new Set(),
+      allToolsDisabled: false,
+      allSkillsDisabled: false,
+      activePresetId: '__default__',
+    });
 
     try {
       const context = await window.sero.agent.getContext(sessionId);

--- a/apps/desktop/src/stores/context-editor.ts
+++ b/apps/desktop/src/stores/context-editor.ts
@@ -125,18 +125,34 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
   },
 
   toggleTool: (toolName) => {
-    const { disabledTools } = get();
-    const next = new Set(disabledTools);
-    if (next.has(toolName)) next.delete(toolName);
-    else next.add(toolName);
+    const { disabledTools, allToolsDisabled, availableContext } = get();
+    let next: Set<string>;
+    if (allToolsDisabled) {
+      // Transitioning from "all disabled": populate set with every tool,
+      // then remove the one being enabled so only it turns on.
+      next = new Set(availableContext?.tools.map((t) => t.name) ?? []);
+      next.delete(toolName);
+    } else {
+      next = new Set(disabledTools);
+      if (next.has(toolName)) next.delete(toolName);
+      else next.add(toolName);
+    }
     set({ disabledTools: next, allToolsDisabled: false, activePresetId: null, applyError: null });
   },
 
   toggleSkill: (skillName) => {
-    const { disabledSkills } = get();
-    const next = new Set(disabledSkills);
-    if (next.has(skillName)) next.delete(skillName);
-    else next.add(skillName);
+    const { disabledSkills, allSkillsDisabled, availableContext } = get();
+    let next: Set<string>;
+    if (allSkillsDisabled) {
+      // Transitioning from "all disabled": populate set with every skill,
+      // then remove the one being enabled so only it turns on.
+      next = new Set(availableContext?.skills.map((s) => s.name) ?? []);
+      next.delete(skillName);
+    } else {
+      next = new Set(disabledSkills);
+      if (next.has(skillName)) next.delete(skillName);
+      else next.add(skillName);
+    }
     set({ disabledSkills: next, allSkillsDisabled: false, activePresetId: null, applyError: null });
   },
 

--- a/apps/desktop/src/stores/context-editor.ts
+++ b/apps/desktop/src/stores/context-editor.ts
@@ -1,0 +1,319 @@
+import { create } from 'zustand';
+import type {
+  SessionContext,
+  ContextOverrides,
+  ContextToolInfo,
+  ContextSkillInfo,
+} from '@/types/ipc';
+
+// ── Preset Types ──────────────────────────────────────────────
+
+export interface ContextPreset {
+  id: string;
+  name: string;
+  /** If null, use the default system prompt. If string, override with this. */
+  systemPrompt: string | null;
+  /** Tool names to disable. */
+  disabledTools: string[];
+  /** Skill names to disable. */
+  disabledSkills: string[];
+}
+
+const PRESETS_STORAGE_KEY = 'sero:context-editor:presets';
+
+// ── Built-in Presets ──────────────────────────────────────────
+
+const NONE_PRESET: ContextPreset = {
+  id: '__none__',
+  name: 'None',
+  systemPrompt: '',
+  disabledTools: ['__all__'],
+  disabledSkills: ['__all__'],
+};
+
+const DEFAULT_PRESET: ContextPreset = {
+  id: '__default__',
+  name: 'Default',
+  systemPrompt: null,
+  disabledTools: [],
+  disabledSkills: [],
+};
+
+const BUILTIN_PRESETS: ContextPreset[] = [DEFAULT_PRESET, NONE_PRESET];
+
+// ── Store Types ───────────────────────────────────────────────
+
+interface ContextEditorState {
+  /** Whether the context editor dialog is open. */
+  isOpen: boolean;
+
+  /** Available context fetched from the session (null = not loaded). */
+  availableContext: SessionContext | null;
+
+  /** Current override state being edited. */
+  systemPrompt: string | null;
+  disabledTools: Set<string>;
+  disabledSkills: Set<string>;
+  /** Whether '__all__' tools/skills are disabled (the "none" pattern). */
+  allToolsDisabled: boolean;
+  allSkillsDisabled: boolean;
+
+  /** Currently selected preset ID (or null for custom). */
+  activePresetId: string | null;
+
+  /** User-saved presets (loaded from localStorage). */
+  userPresets: ContextPreset[];
+
+  // ── Actions ─────────────────────────────────────────────────
+
+  open: (sessionId: string) => Promise<void>;
+  close: () => void;
+
+  setSystemPrompt: (value: string | null) => void;
+  toggleTool: (toolName: string) => void;
+  toggleSkill: (skillName: string) => void;
+  setAllToolsDisabled: (disabled: boolean) => void;
+  setAllSkillsDisabled: (disabled: boolean) => void;
+
+  /** Apply the current overrides to the session. */
+  apply: (sessionId: string) => Promise<void>;
+  /** Reset to default (clear all overrides). */
+  resetToDefault: () => void;
+
+  /** Load a preset into the editor state. */
+  loadPreset: (presetId: string) => void;
+  /** Save the current editor state as a new preset. */
+  savePreset: (name: string) => void;
+  /** Delete a user preset. */
+  deletePreset: (presetId: string) => void;
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function loadUserPresets(): ContextPreset[] {
+  try {
+    const raw = localStorage.getItem(PRESETS_STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {
+    // Ignore parse errors
+  }
+  return [];
+}
+
+function saveUserPresets(presets: ContextPreset[]): void {
+  localStorage.setItem(PRESETS_STORAGE_KEY, JSON.stringify(presets));
+}
+
+// ── Store ─────────────────────────────────────────────────────
+
+export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
+  isOpen: false,
+  availableContext: null,
+  systemPrompt: null,
+  disabledTools: new Set(),
+  disabledSkills: new Set(),
+  allToolsDisabled: false,
+  allSkillsDisabled: false,
+  activePresetId: '__default__',
+  userPresets: loadUserPresets(),
+
+  open: async (sessionId) => {
+    set({ isOpen: true, availableContext: null });
+
+    try {
+      const context = await window.sero.agent.getContext(sessionId);
+      if (context) {
+        set({ availableContext: context });
+      }
+    } catch (err) {
+      console.error('[context-editor] Failed to load context:', err);
+    }
+  },
+
+  close: () => {
+    set({ isOpen: false });
+  },
+
+  setSystemPrompt: (value) => {
+    set({ systemPrompt: value, activePresetId: null });
+  },
+
+  toggleTool: (toolName) => {
+    const { disabledTools, allToolsDisabled } = get();
+    const next = new Set(disabledTools);
+    if (next.has(toolName)) {
+      next.delete(toolName);
+    } else {
+      next.add(toolName);
+    }
+    set({
+      disabledTools: next,
+      allToolsDisabled: false,
+      activePresetId: null,
+    });
+  },
+
+  toggleSkill: (skillName) => {
+    const { disabledSkills, allSkillsDisabled } = get();
+    const next = new Set(disabledSkills);
+    if (next.has(skillName)) {
+      next.delete(skillName);
+    } else {
+      next.add(skillName);
+    }
+    set({
+      disabledSkills: next,
+      allSkillsDisabled: false,
+      activePresetId: null,
+    });
+  },
+
+  setAllToolsDisabled: (disabled) => {
+    set({
+      allToolsDisabled: disabled,
+      disabledTools: new Set(),
+      activePresetId: null,
+    });
+  },
+
+  setAllSkillsDisabled: (disabled) => {
+    set({
+      allSkillsDisabled: disabled,
+      disabledSkills: new Set(),
+      activePresetId: null,
+    });
+  },
+
+  apply: async (sessionId) => {
+    const { systemPrompt, disabledTools, allToolsDisabled, disabledSkills, allSkillsDisabled, availableContext } = get();
+
+    // Build the overrides to send to main process
+    let toolsToDisable: string[] = [];
+    if (allToolsDisabled && availableContext) {
+      toolsToDisable = availableContext.tools.map((t) => t.name);
+    } else {
+      toolsToDisable = Array.from(disabledTools);
+    }
+
+    let skillsToDisable: string[] = [];
+    if (allSkillsDisabled && availableContext) {
+      skillsToDisable = availableContext.skills.map((s) => s.name);
+    } else {
+      skillsToDisable = Array.from(disabledSkills);
+    }
+
+    const hasOverrides =
+      systemPrompt !== null ||
+      toolsToDisable.length > 0 ||
+      skillsToDisable.length > 0;
+
+    const overrides: ContextOverrides | null = hasOverrides
+      ? {
+          systemPrompt: systemPrompt ?? undefined,
+          disabledTools: toolsToDisable.length > 0 ? toolsToDisable : undefined,
+          disabledSkills: skillsToDisable.length > 0 ? skillsToDisable : undefined,
+        }
+      : null;
+
+    try {
+      await window.sero.agent.setContextOverrides(sessionId, overrides);
+    } catch (err) {
+      console.error('[context-editor] Failed to apply overrides:', err);
+    }
+  },
+
+  resetToDefault: () => {
+    set({
+      systemPrompt: null,
+      disabledTools: new Set(),
+      disabledSkills: new Set(),
+      allToolsDisabled: false,
+      allSkillsDisabled: false,
+      activePresetId: '__default__',
+    });
+  },
+
+  loadPreset: (presetId) => {
+    const allPresets = [...BUILTIN_PRESETS, ...get().userPresets];
+    const preset = allPresets.find((p) => p.id === presetId);
+    if (!preset) return;
+
+    const allToolsDisabled = preset.disabledTools.includes('__all__');
+    const allSkillsDisabled = preset.disabledSkills.includes('__all__');
+
+    set({
+      systemPrompt: preset.systemPrompt,
+      disabledTools: new Set(allToolsDisabled ? [] : preset.disabledTools),
+      disabledSkills: new Set(allSkillsDisabled ? [] : preset.disabledSkills),
+      allToolsDisabled,
+      allSkillsDisabled,
+      activePresetId: presetId,
+    });
+  },
+
+  savePreset: (name) => {
+    const { systemPrompt, disabledTools, disabledSkills, allToolsDisabled, allSkillsDisabled, userPresets } = get();
+
+    const newPreset: ContextPreset = {
+      id: `user-${Date.now()}`,
+      name,
+      systemPrompt,
+      disabledTools: allToolsDisabled ? ['__all__'] : Array.from(disabledTools),
+      disabledSkills: allSkillsDisabled ? ['__all__'] : Array.from(disabledSkills),
+    };
+
+    const updated = [...userPresets, newPreset];
+    saveUserPresets(updated);
+    set({ userPresets: updated, activePresetId: newPreset.id });
+  },
+
+  deletePreset: (presetId) => {
+    const { userPresets, activePresetId } = get();
+    const updated = userPresets.filter((p) => p.id !== presetId);
+    saveUserPresets(updated);
+    set({
+      userPresets: updated,
+      activePresetId: activePresetId === presetId ? null : activePresetId,
+    });
+  },
+}));
+
+// ── Selectors ─────────────────────────────────────────────────
+
+/** All available presets (built-in + user). */
+export function useAllPresets(): ContextPreset[] {
+  const userPresets = useContextEditorStore((s) => s.userPresets);
+  return [...BUILTIN_PRESETS, ...userPresets];
+}
+
+/** Check if a tool is enabled in the current editor state. */
+export function useIsToolEnabled(toolName: string): boolean {
+  const disabledTools = useContextEditorStore((s) => s.disabledTools);
+  const allDisabled = useContextEditorStore((s) => s.allToolsDisabled);
+  if (allDisabled) return false;
+  return !disabledTools.has(toolName);
+}
+
+/** Check if a skill is enabled in the current editor state. */
+export function useIsSkillEnabled(skillName: string): boolean {
+  const disabledSkills = useContextEditorStore((s) => s.disabledSkills);
+  const allDisabled = useContextEditorStore((s) => s.allSkillsDisabled);
+  if (allDisabled) return false;
+  return !disabledSkills.has(skillName);
+}
+
+/** Whether the current state has any overrides from the default. */
+export function useHasOverrides(): boolean {
+  const systemPrompt = useContextEditorStore((s) => s.systemPrompt);
+  const disabledTools = useContextEditorStore((s) => s.disabledTools);
+  const disabledSkills = useContextEditorStore((s) => s.disabledSkills);
+  const allToolsDisabled = useContextEditorStore((s) => s.allToolsDisabled);
+  const allSkillsDisabled = useContextEditorStore((s) => s.allSkillsDisabled);
+  return (
+    systemPrompt !== null ||
+    disabledTools.size > 0 ||
+    disabledSkills.size > 0 ||
+    allToolsDisabled ||
+    allSkillsDisabled
+  );
+}

--- a/apps/desktop/src/stores/context-editor.ts
+++ b/apps/desktop/src/stores/context-editor.ts
@@ -137,7 +137,16 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
       if (next.has(toolName)) next.delete(toolName);
       else next.add(toolName);
     }
-    set({ disabledTools: next, allToolsDisabled: false, activePresetId: null, applyError: null });
+    // Normalize: if every tool is now individually disabled, collapse
+    // back to the allToolsDisabled flag so the master switch stays in sync.
+    const totalTools = availableContext?.tools.length ?? 0;
+    const allNowDisabled = totalTools > 0 && next.size >= totalTools;
+    set({
+      disabledTools: allNowDisabled ? new Set() : next,
+      allToolsDisabled: allNowDisabled,
+      activePresetId: null,
+      applyError: null,
+    });
   },
 
   toggleSkill: (skillName) => {
@@ -153,7 +162,16 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
       if (next.has(skillName)) next.delete(skillName);
       else next.add(skillName);
     }
-    set({ disabledSkills: next, allSkillsDisabled: false, activePresetId: null, applyError: null });
+    // Normalize: if every skill is now individually disabled, collapse
+    // back to the allSkillsDisabled flag so the master switch stays in sync.
+    const totalSkills = availableContext?.skills.length ?? 0;
+    const allNowDisabled = totalSkills > 0 && next.size >= totalSkills;
+    set({
+      disabledSkills: allNowDisabled ? new Set() : next,
+      allSkillsDisabled: allNowDisabled,
+      activePresetId: null,
+      applyError: null,
+    });
   },
 
   setAllToolsDisabled: (disabled) => {

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -18,6 +18,7 @@ import type {
   DevServerEvent,
   SessionContext,
   ContextOverrides,
+  ContextPreset,
 } from './ipc';
 
 interface SeroWorkspaceAPI {
@@ -78,6 +79,13 @@ interface SeroAgentAPI {
   setContextOverrides(sessionId: string, overrides: ContextOverrides | null): Promise<void>;
   /** Subscribe to streaming events pushed from main process. Returns unsubscribe. */
   onEvent(callback: (event: AgentStreamEvent) => void): () => void;
+}
+
+interface SeroContextPresetsAPI {
+  /** Load all user-saved context editor presets from disk. */
+  load(): Promise<ContextPreset[]>;
+  /** Save all user context editor presets to disk. */
+  save(presets: ContextPreset[]): Promise<void>;
 }
 
 interface SeroShellAPI {
@@ -251,6 +259,7 @@ interface SeroDebugAPI {
 interface SeroAPI {
   platform: string;
   shell: SeroShellAPI;
+  contextPresets: SeroContextPresetsAPI;
   workspace: SeroWorkspaceAPI;
   sessions: SeroSessionsAPI;
   agent: SeroAgentAPI;

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -16,6 +16,8 @@ import type {
   ContainerInfo,
   DevServer,
   DevServerEvent,
+  SessionContext,
+  ContextOverrides,
 } from './ipc';
 
 interface SeroWorkspaceAPI {
@@ -70,6 +72,10 @@ interface SeroAgentAPI {
   setModel(sessionId: string, provider: string, modelId: string): Promise<SessionModelState>;
   /** Set thinking/reasoning level for a session. */
   setThinkingLevel(sessionId: string, level: string): Promise<SessionModelState>;
+  /** Get session context (system prompt, tools, skills) for the context editor. */
+  getContext(sessionId: string): Promise<SessionContext | null>;
+  /** Apply context overrides (disabled tools, system prompt override). Pass null to clear. */
+  setContextOverrides(sessionId: string, overrides: ContextOverrides | null): Promise<void>;
   /** Subscribe to streaming events pushed from main process. Returns unsubscribe. */
   onEvent(callback: (event: AgentStreamEvent) => void): () => void;
 }

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -98,8 +98,20 @@ export interface ContextOverrides {
   systemPrompt?: string | null;
   /** Tool names to disable (removed from the tool list). */
   disabledTools?: string[];
-  /** Skill names to disable. */
+  /** Skill names to disable (stripped from system prompt). */
   disabledSkills?: string[];
+}
+
+/** A saved context editor preset (persisted to disk via IPC). */
+export interface ContextPreset {
+  id: string;
+  name: string;
+  /** If null, use the default system prompt. If string, override with this. */
+  systemPrompt: string | null;
+  /** Tool names to disable. */
+  disabledTools: string[];
+  /** Skill names to disable. */
+  disabledSkills: string[];
 }
 
 // ── Slash Commands ─────────────────────────────────────────────
@@ -384,6 +396,12 @@ export const IpcChannels = {
     getContext: 'sero:agent:get-context',
     /** Apply context overrides (disabled tools, system prompt override, etc.). */
     setContextOverrides: 'sero:agent:set-context-overrides',
+  },
+  contextPresets: {
+    /** Load all user-saved context editor presets from disk. */
+    load: 'sero:context-presets:load',
+    /** Save all user context editor presets to disk. */
+    save: 'sero:context-presets:save',
   },
   shell: {
     /** Open a path in the native file explorer. */

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -69,6 +69,39 @@ export interface SeroSessionInfo {
   firstMessage: string;
 }
 
+// ── Context Editor ─────────────────────────────────────────────
+
+/** Tool info for the context editor (renderer-safe, no execute function). */
+export interface ContextToolInfo {
+  name: string;
+  label?: string;
+  description?: string;
+}
+
+/** Skill info for the context editor. */
+export interface ContextSkillInfo {
+  name: string;
+  description?: string;
+  filePath?: string;
+}
+
+/** Full session context returned by getSessionContext. */
+export interface SessionContext {
+  systemPrompt: string;
+  tools: ContextToolInfo[];
+  skills: ContextSkillInfo[];
+}
+
+/** Context overrides sent to the main process. */
+export interface ContextOverrides {
+  /** If set, replaces the default system prompt entirely. */
+  systemPrompt?: string | null;
+  /** Tool names to disable (removed from the tool list). */
+  disabledTools?: string[];
+  /** Skill names to disable. */
+  disabledSkills?: string[];
+}
+
 // ── Slash Commands ─────────────────────────────────────────────
 
 /** Slash command info from PI SDK. Mirrors SlashCommandInfo from pi-coding-agent. */
@@ -347,6 +380,10 @@ export const IpcChannels = {
     setThinkingLevel: 'sero:agent:set-thinking-level',
     /** Main → renderer push channel for streaming events. */
     event: 'sero:agent:event',
+    /** Get session context (system prompt, tools, skills) for context editor. */
+    getContext: 'sero:agent:get-context',
+    /** Apply context overrides (disabled tools, system prompt override, etc.). */
+    setContextOverrides: 'sero:agent:set-context-overrides',
   },
   shell: {
     /** Open a path in the native file explorer. */


### PR DESCRIPTION
Add a dialog accessible from the ChatPanel header (Settings2 icon) that
allows editing what goes into the LLM context before sending the first
prompt. Only enabled for new sessions (no messages yet).

Features:
- Edit system prompt text with custom override
- Toggle individual tools on/off
- Toggle individual skills on/off
- Master enable/disable-all switches for tools and skills
- Preset system with save/load/delete and built-in "Default" and "None"
- Collapsible sections styled after ToolCallGroup components
- Context overrides applied via IPC to the main process agent pool

Stack: IPC types, main process handlers, preload bridge, Zustand store,
React dialog component, ChatPanel integration.

https://claude.ai/code/session_01N573damL5wVR4Y4msUjjwU