### PR TITLE
feat: add light theme with toggle in status bar

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sero</title>
+    <script>
+      // Apply saved theme before first paint to prevent flash
+      (function() {
+        var theme = localStorage.getItem('sero:theme');
+        if (theme === 'light') {
+          document.documentElement.classList.remove('dark');
+        }
+      })();
+    </script>
     <style>
       body {
         font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text",
@@ -11,6 +20,10 @@
         background: #0a0a0b;
         color: #e4e4e7;
         -webkit-font-smoothing: antialiased;
+      }
+      html:not(.dark) body {
+        background: #ffffff;
+        color: #111827;
       }
     </style>
   </head>

--- a/apps/desktop/src/components/apps/coding/ActivityBar.tsx
+++ b/apps/desktop/src/components/apps/coding/ActivityBar.tsx
@@ -39,7 +39,7 @@ export function ActivityBar({ activePanel, sidebarOpen, terminalOpen, onPanelCli
   const bottomItems = items.filter((i) => i.bottom);
 
   return (
-    <nav className="flex w-10 shrink-0 flex-col items-center border-r border-border/50 bg-[var(--bg-surface)] py-1">
+    <nav className="flex w-10 shrink-0 flex-col items-center border-r border-[var(--border-default)] bg-[var(--bg-surface)] py-1">
       {/* Top items */}
       {topItems.map((item) => {
         const isActive = sidebarOpen && activePanel === item.id;

--- a/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
+++ b/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
@@ -287,7 +287,7 @@ export function CodingWorkspace() {
 
       {/* ── Bottom: terminal spans full width ──────────────── */}
       {terminalOpen && (
-        <div className="flex h-[250px] min-h-[100px] max-h-[60%] shrink-0 flex-col border-t border-border/50">
+        <div className="flex h-[250px] min-h-[100px] max-h-[60%] shrink-0 flex-col border-t border-[var(--border-default)]">
           <TerminalTabs workspaceId={workspaceId} />
           <div className="relative flex-1 min-h-0 bg-[#0a0a0b]">
             {termTabs.map((tab) => (

--- a/apps/desktop/src/components/apps/coding/TerminalPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/TerminalPanel.tsx
@@ -16,6 +16,7 @@ import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
+import { useAppStore, type Theme } from '@/stores/app';
 
 interface TerminalPanelProps {
   terminalId: string;
@@ -23,29 +24,53 @@ interface TerminalPanelProps {
   isActive: boolean;
 }
 
-/** Shared xterm.js theme — dark to match the shell. */
-const TERMINAL_THEME = {
-  background: '#0a0a0b',
-  foreground: '#d4d4d8',
-  cursor: '#d4d4d8',
-  selectionBackground: '#3f3f46',
-  black: '#18181b',
-  red: '#ef4444',
-  green: '#22c55e',
-  yellow: '#eab308',
-  blue: '#3b82f6',
-  magenta: '#a855f7',
-  cyan: '#06b6d4',
-  white: '#d4d4d8',
-  brightBlack: '#52525b',
-  brightRed: '#f87171',
-  brightGreen: '#4ade80',
-  brightYellow: '#facc15',
-  brightBlue: '#60a5fa',
-  brightMagenta: '#c084fc',
-  brightCyan: '#22d3ee',
-  brightWhite: '#fafafa',
-} as const;
+/** xterm.js themes keyed by app theme. */
+const TERMINAL_THEMES: Record<Theme, Record<string, string>> = {
+  dark: {
+    background: '#0a0a0b',
+    foreground: '#d4d4d8',
+    cursor: '#d4d4d8',
+    selectionBackground: '#3f3f46',
+    black: '#18181b',
+    red: '#ef4444',
+    green: '#22c55e',
+    yellow: '#eab308',
+    blue: '#3b82f6',
+    magenta: '#a855f7',
+    cyan: '#06b6d4',
+    white: '#d4d4d8',
+    brightBlack: '#52525b',
+    brightRed: '#f87171',
+    brightGreen: '#4ade80',
+    brightYellow: '#facc15',
+    brightBlue: '#60a5fa',
+    brightMagenta: '#c084fc',
+    brightCyan: '#22d3ee',
+    brightWhite: '#fafafa',
+  },
+  light: {
+    background: '#ffffff',
+    foreground: '#1e1e1e',
+    cursor: '#1e1e1e',
+    selectionBackground: '#add6ff',
+    black: '#1e1e1e',
+    red: '#cd3131',
+    green: '#008000',
+    yellow: '#795e26',
+    blue: '#0451a5',
+    magenta: '#bc05bc',
+    cyan: '#0598bc',
+    white: '#6a737d',
+    brightBlack: '#6a737d',
+    brightRed: '#cd3131',
+    brightGreen: '#008000',
+    brightYellow: '#795e26',
+    brightBlue: '#0451a5',
+    brightMagenta: '#bc05bc',
+    brightCyan: '#0598bc',
+    brightWhite: '#1e1e1e',
+  },
+};
 
 /**
  * Single terminal instance — mounts xterm.js and bridges IPC.
@@ -61,6 +86,7 @@ export function TerminalPanel({ terminalId, isActive }: TerminalPanelProps) {
   useEffect(() => {
     if (!containerRef.current) return;
 
+    const initialTheme = useAppStore.getState().theme;
     const term = new Terminal({
       cursorBlink: true,
       fontSize: 13,
@@ -68,7 +94,7 @@ export function TerminalPanel({ terminalId, isActive }: TerminalPanelProps) {
         "'JetBrains Mono', 'SF Mono', 'Fira Code', 'Cascadia Code', Menlo, monospace",
       lineHeight: 1.2,
       scrollback: 10000,
-      theme: TERMINAL_THEME,
+      theme: TERMINAL_THEMES[initialTheme],
     });
 
     const fitAddon = new FitAddon();
@@ -111,6 +137,20 @@ export function TerminalPanel({ terminalId, isActive }: TerminalPanelProps) {
       termRef.current = null;
       fitRef.current = null;
     };
+  }, [terminalId]);
+
+  // React to theme changes
+  useEffect(() => {
+    let prevTheme = useAppStore.getState().theme;
+    const unsub = useAppStore.subscribe((state) => {
+      if (state.theme !== prevTheme) {
+        prevTheme = state.theme;
+        if (termRef.current) {
+          termRef.current.options.theme = TERMINAL_THEMES[state.theme];
+        }
+      }
+    });
+    return unsub;
   }, [terminalId]);
 
   // Re-fit when terminal becomes active or container resizes

--- a/apps/desktop/src/components/apps/coding/TerminalTabs.tsx
+++ b/apps/desktop/src/components/apps/coding/TerminalTabs.tsx
@@ -46,7 +46,7 @@ export function TerminalTabs({ workspaceId }: TerminalTabsProps) {
   };
 
   return (
-    <div className="flex h-8 shrink-0 items-center gap-0.5 border-b border-border/50 bg-[var(--bg-surface)] px-1">
+    <div className="flex h-8 shrink-0 items-center gap-0.5 border-b border-[var(--border-default)] bg-[var(--bg-surface)] px-1">
       {/* Tabs */}
       {tabs.map((tab) => (
         <button

--- a/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
@@ -13,6 +13,7 @@ import { EditorTabBar, type EditorTab } from './EditorTabBar';
 import { useLsp } from '@/lsp/use-lsp';
 import { useContainerStore } from '@/stores/container';
 import { useActiveWorkspace } from '@/stores/workspace';
+import { useAppStore } from '@/stores/app';
 
 interface Props {
   workspaceId: string;
@@ -56,6 +57,7 @@ export function EditorPanel({
   const [monacoInstance, setMonacoInstance] = useState<Monaco | null>(null);
   const [editorInstance, setEditorInstance] = useState<monacoEditor.IStandaloneCodeEditor | null>(null);
 
+  const appTheme = useAppStore((s) => s.theme);
   const containerStatus = useContainerStore((s) => s.containers[workspaceId]?.status ?? 'none');
   const activeWorkspace = useActiveWorkspace();
   const isContainerWorkspace = activeWorkspace?.container ?? true;
@@ -220,7 +222,7 @@ export function EditorPanel({
             height="100%" language={language} path={activeTab}
             value={content} onChange={handleChange}
             beforeMount={handleBeforeMount} onMount={handleEditorMount}
-            theme="vs-dark"
+            theme={appTheme === 'dark' ? 'vs-dark' : 'vs'}
             options={{
               fontSize: 13,
               fontFamily: "'SF Mono', 'Fira Code', 'JetBrains Mono', monospace",

--- a/apps/desktop/src/components/apps/coding/editor/EditorTabBar.tsx
+++ b/apps/desktop/src/components/apps/coding/editor/EditorTabBar.tsx
@@ -47,7 +47,7 @@ function SortableEditorTab({ tab, isActive, onSelect, onClose, onMiddleClick }: 
       ref={setNodeRef} style={style}
       className={cn(
         'flex items-center gap-1 px-2.5 h-full cursor-pointer shrink-0 select-none',
-        'border-r border-border/30 text-xs whitespace-nowrap transition-colors',
+        'border-r border-[var(--border-subtle)] text-xs whitespace-nowrap transition-colors',
         'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
         isActive && 'bg-[var(--bg-elevated)] text-[var(--text-primary)] relative',
       )}
@@ -136,7 +136,7 @@ export function EditorTabBar({ tabs, activeTab, onSelectTab, onCloseTab, onReord
   if (tabs.length === 0) return null;
 
   return (
-    <div className="flex items-stretch h-8 bg-[var(--bg-base)] border-b border-border/30 shrink-0 overflow-hidden relative">
+    <div className="flex items-stretch h-8 bg-[var(--bg-base)] border-b border-[var(--border-subtle)] shrink-0 overflow-hidden relative">
       {overflowLeft && <div className="absolute top-0 bottom-px left-0 w-7 pointer-events-none z-10 bg-gradient-to-r from-[var(--bg-base)] to-transparent" />}
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd} modifiers={[restrictToHorizontal]}>
         <SortableContext items={tabs.map((t) => t.path)} strategy={horizontalListSortingStrategy}>

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -174,9 +174,9 @@ export function ChatPanel() {
   const hasSession = !!sessionId;
 
   return (
-    <div className="flex h-full flex-col bg-[var(--bg-surface)]">
+    <div className="flex h-full flex-col border-l border-[var(--border-default)] bg-[var(--bg-surface)]">
       {/* ── Header ──────────────────────────────────────────── */}
-      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-[var(--border-default)] px-3">
         <Bot className="size-3.5 text-[var(--text-muted)]" />
         <span className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
           Agent

--- a/apps/desktop/src/components/layout/DevServerPanel.tsx
+++ b/apps/desktop/src/components/layout/DevServerPanel.tsx
@@ -209,7 +209,7 @@ export const DevServerIndicator = memo(function DevServerIndicator() {
         className="w-80 p-0"
         sideOffset={8}
       >
-        <div className="border-b border-border/50 px-3 py-2">
+        <div className="border-b border-[var(--border-default)] px-3 py-2">
           <div className="flex items-center gap-1.5">
             <Server className="size-3.5 text-[var(--text-muted)]" />
             <span className="text-xs font-medium text-[var(--text-primary)]">

--- a/apps/desktop/src/components/layout/MainSidebar.tsx
+++ b/apps/desktop/src/components/layout/MainSidebar.tsx
@@ -21,7 +21,7 @@ export function MainSidebar() {
   if (!open) return null;
 
   return (
-    <aside className="flex h-full w-full min-w-0 flex-col border-r border-border/50 bg-[var(--bg-surface)]">
+    <aside className="flex h-full w-full min-w-0 flex-col border-r border-[var(--border-default)] bg-[var(--bg-surface)]">
       {/* ── Apps ──────────────────────────────────────────────── */}
       <div className="flex flex-col gap-0.5 p-2">
         <span className="px-2 pb-1 text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">

--- a/apps/desktop/src/components/layout/ModelSelector.tsx
+++ b/apps/desktop/src/components/layout/ModelSelector.tsx
@@ -38,7 +38,7 @@ function ModelTrigger({ disabled }: { disabled: boolean }) {
         )}
         <span className="max-w-[140px] truncate font-medium">{label}</span>
         {thinking !== 'off' && ms?.model.reasoning && (
-          <span className="rounded-full bg-amber-500/15 px-1.5 py-px text-[10px] font-semibold text-amber-400">
+          <span className="rounded-full bg-amber-500/15 px-1.5 py-px text-[10px] font-semibold text-amber-600 dark:text-amber-400">
             {THINKING_LABELS[thinking] ?? thinking}
           </span>
         )}
@@ -95,9 +95,9 @@ function ThinkingPicker({
             onClick={() => onSelect(level)}
             className={`relative z-10 flex-1 rounded-md px-1 py-1 text-[11px] font-medium transition-colors duration-150 ${
               current === level && !disabled
-                ? level === 'xhigh' ? 'text-amber-300'
+                ? level === 'xhigh' ? 'text-amber-600 dark:text-amber-300'
                   : level === 'off' ? 'text-[var(--text-secondary)]'
-                  : 'text-indigo-300'
+                  : 'text-indigo-600 dark:text-indigo-300'
                 : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
             }`}
           >
@@ -131,7 +131,7 @@ function ModelItem({ model, isSelected, onSelect }: {
               initial={{ scale: 0, opacity: 0 }} animate={{ scale: 1, opacity: 1 }}
               exit={{ scale: 0, opacity: 0 }}
               transition={{ type: 'spring', stiffness: 500, damping: 25 }}>
-              <Check className="size-3.5 text-emerald-400" />
+              <Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />
             </motion.div>
           ) : (
             <motion.div key="dot"
@@ -142,7 +142,7 @@ function ModelItem({ model, isSelected, onSelect }: {
       </div>
       <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
         <span className="truncate text-xs font-medium">{model.name}</span>
-        {model.reasoning && <Sparkles className="size-3 shrink-0 text-amber-400/60" />}
+        {model.reasoning && <Sparkles className="size-3 shrink-0 text-amber-500/60 dark:text-amber-400/60" />}
       </div>
     </motion.button>
   );

--- a/apps/desktop/src/components/layout/SlashCommandMenu.tsx
+++ b/apps/desktop/src/components/layout/SlashCommandMenu.tsx
@@ -145,7 +145,7 @@ export function SlashCommandMenu({
   return (
     <div
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 z-50 mb-1 max-h-64 overflow-y-auto rounded-md border border-border/50 bg-[var(--bg-surface)] shadow-lg"
+      className="absolute bottom-full left-0 right-0 z-50 mb-1 max-h-64 overflow-y-auto rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] shadow-lg"
       role="listbox"
     >
       {groups.map(({ source, items }) => (

--- a/apps/desktop/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/src/components/layout/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { FolderOpen, Bot, Bug } from 'lucide-react';
+import { FolderOpen, Bot, Bug, Sun, Moon } from 'lucide-react';
 import { useAppStore } from '@/stores/app';
 import { useActiveWorkspace } from '@/stores/workspace';
 import { useActiveAgentCount } from '@/stores/agent';
@@ -13,6 +13,7 @@ import { DevServerIndicator } from './DevServerPanel';
  */
 export function StatusBar() {
   const theme = useAppStore((s) => s.theme);
+  const toggleTheme = useAppStore((s) => s.toggleTheme);
   const activeWorkspace = useActiveWorkspace();
   const agentCount = useActiveAgentCount();
 
@@ -48,7 +49,14 @@ export function StatusBar() {
           </span>
         )}
         <span>Sero v0.1.0</span>
-        <span className="capitalize">{theme}</span>
+        <button
+          onClick={toggleTheme}
+          title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} theme`}
+          className="flex items-center gap-1 hover:text-[var(--text-primary)] transition-colors"
+        >
+          {theme === 'dark' ? <Moon className="size-3" /> : <Sun className="size-3" />}
+          <span className="capitalize">{theme}</span>
+        </button>
       </div>
     </footer>
   );

--- a/apps/desktop/src/components/layout/StatusBar.tsx
+++ b/apps/desktop/src/components/layout/StatusBar.tsx
@@ -18,7 +18,7 @@ export function StatusBar() {
   const agentCount = useActiveAgentCount();
 
   return (
-    <footer className="flex h-6 shrink-0 items-center justify-between border-t border-border/50 bg-[var(--bg-base)] px-3 text-sm text-[var(--text-muted)]">
+    <footer className="flex h-6 shrink-0 items-center justify-between border-t border-[var(--border-default)] bg-[var(--bg-base)] px-3 text-sm text-[var(--text-muted)]">
       {/* ── Left ──────────────────────────────────────────────── */}
       <div className="flex items-center gap-3">
         {activeWorkspace && (
@@ -94,7 +94,7 @@ function DebugLogToggle() {
       }
       className={`flex items-center gap-1 transition-colors ${
         enabled
-          ? 'text-amber-400 hover:text-amber-300'
+          ? 'text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300'
           : 'hover:text-[var(--text-primary)]'
       }`}
     >

--- a/apps/desktop/src/components/layout/TitleBar.tsx
+++ b/apps/desktop/src/components/layout/TitleBar.tsx
@@ -31,7 +31,7 @@ export function TitleBar() {
   const titleText = breadcrumb ? `${appLabel} — ${breadcrumb}` : appLabel;
 
   return (
-    <header className="title-bar drag-region flex h-10 shrink-0 items-center border-b border-border/50 bg-[var(--bg-base)]">
+    <header className="title-bar drag-region flex h-10 shrink-0 items-center border-b border-[var(--border-default)] bg-[var(--bg-base)]">
       {/* ── Traffic-light spacer (macOS) ─────────────────────── */}
       <div className="flex w-[78px] shrink-0" />
 

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -113,13 +113,13 @@ function deriveGroupStatus(tools: ChatToolCallMessage[]): GroupStatus {
 function groupStatusIcon(status: GroupStatus) {
   switch (status) {
     case 'running':
-      return <Loader2 className="size-3.5 animate-spin text-blue-400" />;
+      return <Loader2 className="size-3.5 animate-spin text-blue-600 dark:text-blue-400" />;
     case 'completed':
-      return <CheckCircle2 className="size-3.5 text-emerald-500" />;
+      return <CheckCircle2 className="size-3.5 text-emerald-600 dark:text-emerald-500" />;
     case 'error':
-      return <XCircle className="size-3.5 text-red-400" />;
+      return <XCircle className="size-3.5 text-red-600 dark:text-red-400" />;
     case 'cancelled':
-      return <AlertCircle className="size-3.5 text-yellow-500" />;
+      return <AlertCircle className="size-3.5 text-yellow-600 dark:text-yellow-500" />;
   }
 }
 
@@ -142,15 +142,15 @@ function groupStatusLabel(status: GroupStatus, count: number) {
 function toolStatusDot(state: ChatToolCallMessage['state']) {
   switch (state) {
     case 'pending':
-      return <span className="size-1.5 shrink-0 rounded-full bg-zinc-500" />;
+      return <span className="size-1.5 shrink-0 rounded-full bg-zinc-400 dark:bg-zinc-500" />;
     case 'running':
-      return <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-blue-400" />;
+      return <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-blue-500 dark:bg-blue-400" />;
     case 'completed':
-      return <span className="size-1.5 shrink-0 rounded-full bg-emerald-500" />;
+      return <span className="size-1.5 shrink-0 rounded-full bg-emerald-600 dark:bg-emerald-500" />;
     case 'error':
-      return <span className="size-1.5 shrink-0 rounded-full bg-red-400" />;
+      return <span className="size-1.5 shrink-0 rounded-full bg-red-500 dark:bg-red-400" />;
     case 'cancelled':
-      return <span className="size-1.5 shrink-0 rounded-full bg-yellow-500" />;
+      return <span className="size-1.5 shrink-0 rounded-full bg-yellow-600 dark:bg-yellow-500" />;
   }
 }
 
@@ -251,7 +251,7 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
           ? 'border-blue-500/20 bg-blue-500/[0.03]'
           : status === 'error'
             ? 'border-red-500/20 bg-red-500/[0.03]'
-            : 'border-border/50 bg-[var(--bg-elevated)]/50',
+            : 'border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50',
       )}
     >
       {/* Summary bar */}
@@ -290,7 +290,7 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
             transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
             className="overflow-hidden"
           >
-            <div className="border-t border-border/30 space-y-4 p-3">
+            <div className="border-t border-[var(--border-subtle)] space-y-4 p-3">
               <ToolInput input={tool.input} />
               {isComplete && (
                 <ToolOutput
@@ -374,7 +374,7 @@ export function ToolCallGroup({
           ? 'border-blue-500/20 bg-blue-500/[0.03]'
           : status === 'error'
             ? 'border-red-500/20 bg-red-500/[0.03]'
-            : 'border-border/50 bg-[var(--bg-elevated)]/50',
+            : 'border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50',
       )}
     >
       {/* Summary bar */}
@@ -412,7 +412,7 @@ export function ToolCallGroup({
             transition={{ duration: 0.2, ease: [0.25, 0.46, 0.45, 0.94] }}
             className="overflow-hidden"
           >
-            <div className="border-t border-border/30">
+            <div className="border-t border-[var(--border-subtle)]">
               {!showDetails ? (
                 <>
                   <div className="py-1">
@@ -420,7 +420,7 @@ export function ToolCallGroup({
                       <ToolLine key={tool.id} tool={tool} index={i} />
                     ))}
                   </div>
-                  <div className="border-t border-border/20 px-3 py-1.5">
+                  <div className="border-t border-[var(--border-subtle)]/60 px-3 py-1.5">
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
@@ -439,7 +439,7 @@ export function ToolCallGroup({
                       <ToolDetail key={tool.id} tool={tool} />
                     ))}
                   </div>
-                  <div className="border-t border-border/20 px-3 py-1.5">
+                  <div className="border-t border-[var(--border-subtle)]/60 px-3 py-1.5">
                     <button
                       onClick={(e) => {
                         e.stopPropagation();

--- a/apps/desktop/src/components/layout/WorkspaceTree.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceTree.tsx
@@ -299,7 +299,7 @@ function WorkspaceNode({
 
       {/* Sessions */}
       {expanded && (
-        <div className="ml-2 flex flex-col gap-0.5 pl-2 border-l border-border/30">
+        <div className="ml-2 flex flex-col gap-0.5 pl-2 border-l border-[var(--border-subtle)]">
           {sessions.length === 0 ? (
             <span className="px-2 py-1 text-xs text-[var(--text-muted)]">
               No sessions

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -54,6 +54,16 @@ interface AppState {
   toggleTheme: () => void;
 }
 
+const THEME_STORAGE_KEY = 'sero:theme';
+
+function getStoredTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark') return stored;
+  } catch { /* ignore */ }
+  return 'dark';
+}
+
 function applyTheme(theme: Theme) {
   const root = document.documentElement;
   if (theme === 'dark') {
@@ -61,6 +71,7 @@ function applyTheme(theme: Theme) {
   } else {
     root.classList.remove('dark');
   }
+  try { localStorage.setItem(THEME_STORAGE_KEY, theme); } catch { /* ignore */ }
 }
 
 /** Map a SeroAppManifest → AppEntry. */
@@ -121,8 +132,8 @@ export const useAppStore = create<AppState>((set, get) => ({
     set({ activeApp: app });
   },
 
-  // Theme
-  theme: 'dark',
+  // Theme (hydrate from localStorage)
+  theme: getStoredTheme(),
   setTheme: (theme) => {
     applyTheme(theme);
     set({ theme });

--- a/apps/desktop/src/styles/global.css
+++ b/apps/desktop/src/styles/global.css
@@ -7,35 +7,35 @@
 /* ── Sero Design System ──────────────────────────────────────── */
 
 :root {
-  /* Surface colors */
-  --bg-base: #0a0a0b;
-  --bg-surface: #111113;
-  --bg-elevated: #18181b;
-  --bg-overlay: #1f1f23;
-  --bg-muted: #27272a;
+  /* Surface colors (light) */
+  --bg-base: #ffffff;
+  --bg-surface: #f9fafb;
+  --bg-elevated: #f3f4f6;
+  --bg-overlay: #e5e7eb;
+  --bg-muted: #d1d5db;
 
-  /* Border */
-  --border-subtle: #27272a;
-  --border-default: #3f3f46;
+  /* Border (light) */
+  --border-subtle: #e5e7eb;
+  --border-default: #d1d5db;
   --border-focus: #6366f1;
 
-  /* Text */
-  --text-primary: #fafafa;
-  --text-secondary: #a1a1aa;
-  --text-muted: #71717a;
-  --text-inverse: #09090b;
+  /* Text (light) */
+  --text-primary: #111827;
+  --text-secondary: #4b5563;
+  --text-muted: #9ca3af;
+  --text-inverse: #fafafa;
 
   /* Accent (indigo) */
   --accent: oklch(0.97 0 0);
-  --accent-hover: #818cf8;
-  --accent-muted: #6366f133;
-  --accent-code: #c4b5fd;
+  --accent-hover: #6366f1;
+  --accent-muted: #6366f11a;
+  --accent-code: #7c3aed;
 
   /* Status */
-  --status-success: #22c55e;
-  --status-warning: #f59e0b;
-  --status-error: #ef4444;
-  --status-info: #3b82f6;
+  --status-success: #16a34a;
+  --status-warning: #d97706;
+  --status-error: #dc2626;
+  --status-info: #2563eb;
 
   /* Spacing */
   --space-xs: 4px;
@@ -176,6 +176,35 @@
 }
 
 .dark {
+  /* Surface colors (dark) */
+  --bg-base: #0a0a0b;
+  --bg-surface: #111113;
+  --bg-elevated: #18181b;
+  --bg-overlay: #1f1f23;
+  --bg-muted: #27272a;
+
+  /* Border (dark) */
+  --border-subtle: #27272a;
+  --border-default: #3f3f46;
+
+  /* Text (dark) */
+  --text-primary: #fafafa;
+  --text-secondary: #a1a1aa;
+  --text-muted: #71717a;
+  --text-inverse: #09090b;
+
+  /* Accent (dark) */
+  --accent-hover: #818cf8;
+  --accent-muted: #6366f133;
+  --accent-code: #c4b5fd;
+
+  /* Status (dark) */
+  --status-success: #22c55e;
+  --status-warning: #f59e0b;
+  --status-error: #ef4444;
+  --status-info: #3b82f6;
+
+  /* shadcn dark overrides */
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/apps/desktop/src/styles/global.css
+++ b/apps/desktop/src/styles/global.css
@@ -9,20 +9,20 @@
 :root {
   /* Surface colors (light) */
   --bg-base: #ffffff;
-  --bg-surface: #f9fafb;
-  --bg-elevated: #f3f4f6;
-  --bg-overlay: #e5e7eb;
-  --bg-muted: #d1d5db;
+  --bg-surface: #f4f5f7;
+  --bg-elevated: #eaecf0;
+  --bg-overlay: #dde0e6;
+  --bg-muted: #c8ccd4;
 
   /* Border (light) */
-  --border-subtle: #e5e7eb;
-  --border-default: #d1d5db;
+  --border-subtle: #d4d8e0;
+  --border-default: #bcc1cc;
   --border-focus: #6366f1;
 
   /* Text (light) */
-  --text-primary: #111827;
-  --text-secondary: #4b5563;
-  --text-muted: #9ca3af;
+  --text-primary: #0f1117;
+  --text-secondary: #3b4252;
+  --text-muted: #6b7280;
   --text-inverse: #fafafa;
 
   /* Accent (indigo) */
@@ -62,34 +62,34 @@
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
+  --card: oklch(0.98 0 0);
   --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
+  --popover: oklch(0.99 0 0);
   --popover-foreground: oklch(0.145 0 0);
   --primary: oklch(0.205 0 0);
   --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
+  --secondary: oklch(0.92 0 0);
   --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted: oklch(0.93 0 0);
+  --muted-foreground: oklch(0.45 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.85 0 0);
+  --input: oklch(0.87 0 0);
+  --ring: oklch(0.65 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
+  --sidebar: oklch(0.96 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent: oklch(0.92 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-border: oklch(0.85 0 0);
+  --sidebar-ring: oklch(0.65 0 0);
 }
 
 /* ── Scrollbars ─────────────────────────────────────────────── */

--- a/packages/pi-daily-quote/ui/DailyQuote.tsx
+++ b/packages/pi-daily-quote/ui/DailyQuote.tsx
@@ -137,7 +137,7 @@ const CUSTOM_STYLES = `
     font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
     font-weight: 400;
     font-style: italic;
-    line-height: 1.65;
+    line-height: 1.85;
     letter-spacing: 0.01em;
     font-size: clamp(1.75rem, 4vw, 2.75rem);
   }
@@ -512,7 +512,7 @@ function QuoteDisplay({
       </p>
 
       {/* Divider */}
-      <div className="dq-divider dq-animate-divider mt-10 mb-8" />
+      <div className="dq-divider dq-animate-divider mt-14 mb-10" />
 
       {/* Author */}
       <p
@@ -527,7 +527,7 @@ function QuoteDisplay({
 
       {/* Refresh button */}
       <button
-        className="dq-button dq-animate-button mt-16"
+        className="dq-button dq-animate-button mt-20"
         onClick={onRefresh}
         disabled={loading}
       >

--- a/packages/pi-daily-quote/ui/DailyQuote.tsx
+++ b/packages/pi-daily-quote/ui/DailyQuote.tsx
@@ -20,8 +20,30 @@ const CUSTOM_STYLES = `
   @import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Outfit:wght@300;400;500;600&display=swap');
 
   .dq-root {
-    --dq-bg: #110f14;
-    --dq-bg-surface: #18151d;
+    /* Light mode defaults */
+    --dq-bg: var(--bg-base, #ffffff);
+    --dq-bg-surface: var(--bg-surface, #f4f5f7);
+    --dq-bg-warm: #f0ece6;
+    --dq-text: #1a1612;
+    --dq-text-soft: #3d3529;
+    --dq-muted: #6b6158;
+    --dq-dim: #8a8078;
+    --dq-accent: #9a6b3a;
+    --dq-accent-light: #7a5428;
+    --dq-accent-glow: rgba(154, 107, 58, 0.06);
+    --dq-accent-glow-strong: rgba(154, 107, 58, 0.12);
+    --dq-border: var(--border-default, rgba(154, 107, 58, 0.15));
+    --dq-border-accent: rgba(154, 107, 58, 0.25);
+
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    color: var(--dq-text);
+    background: var(--dq-bg);
+  }
+
+  /* Dark mode overrides */
+  .dark .dq-root {
+    --dq-bg: var(--bg-base, #110f14);
+    --dq-bg-surface: var(--bg-surface, #18151d);
     --dq-bg-warm: #1c1820;
     --dq-text: #f0ebe3;
     --dq-text-soft: #d4cfc7;
@@ -31,20 +53,8 @@ const CUSTOM_STYLES = `
     --dq-accent-light: #e8c89e;
     --dq-accent-glow: rgba(212, 165, 116, 0.08);
     --dq-accent-glow-strong: rgba(212, 165, 116, 0.15);
-    --dq-border: rgba(212, 165, 116, 0.08);
+    --dq-border: var(--border-default, rgba(212, 165, 116, 0.08));
     --dq-border-accent: rgba(212, 165, 116, 0.2);
-
-    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
-    color: var(--dq-text);
-    background: var(--dq-bg);
-  }
-
-  @supports (color: var(--bg-base)) {
-    .dq-root {
-      --dq-bg: var(--bg-base, #110f14);
-      --dq-bg-surface: var(--bg-surface, #18151d);
-      --dq-border: var(--border, rgba(212, 165, 116, 0.08));
-    }
   }
 
   /* ── Atmospheric background ── */
@@ -67,9 +77,8 @@ const CUSTOM_STYLES = `
     height: 80%;
     background: radial-gradient(
       ellipse at center,
-      rgba(212, 165, 116, 0.06) 0%,
-      rgba(212, 165, 116, 0.02) 40%,
-      transparent 70%
+      var(--dq-accent-glow) 0%,
+      transparent 60%
     );
   }
 
@@ -83,7 +92,7 @@ const CUSTOM_STYLES = `
     height: 60%;
     background: radial-gradient(
       ellipse at center,
-      rgba(140, 100, 70, 0.04) 0%,
+      var(--dq-accent-glow) 0%,
       transparent 60%
     );
   }
@@ -95,10 +104,10 @@ const CUSTOM_STYLES = `
     background:
       linear-gradient(
         180deg,
-        rgba(212, 165, 116, 0.03) 0%,
+        var(--dq-accent-glow) 0%,
         transparent 30%,
         transparent 70%,
-        rgba(212, 165, 116, 0.02) 100%
+        var(--dq-accent-glow) 100%
       ),
       var(--dq-bg-surface);
     border: 1px solid var(--dq-border);
@@ -189,8 +198,8 @@ const CUSTOM_STYLES = `
     inset: 0;
     background: linear-gradient(
       135deg,
-      rgba(212, 165, 116, 0.1),
-      rgba(212, 165, 116, 0.02)
+      var(--dq-accent-glow-strong),
+      var(--dq-accent-glow)
     );
     opacity: 0;
     transition: opacity 0.3s;
@@ -205,8 +214,8 @@ const CUSTOM_STYLES = `
     border-color: var(--dq-accent);
     color: var(--dq-accent-light);
     box-shadow:
-      0 0 30px rgba(212, 165, 116, 0.08),
-      inset 0 0 30px rgba(212, 165, 116, 0.03);
+      0 0 30px var(--dq-accent-glow),
+      inset 0 0 30px var(--dq-accent-glow);
     transform: translateY(-1px);
   }
 
@@ -311,8 +320,8 @@ const CUSTOM_STYLES = `
   }
 
   @keyframes dq-orb-breathe {
-    0%, 100% { transform: scale(1); border-color: rgba(212, 165, 116, 0.15); }
-    50% { transform: scale(1.05); border-color: rgba(212, 165, 116, 0.3); }
+    0%, 100% { transform: scale(1); border-color: var(--dq-border-accent); }
+    50% { transform: scale(1.05); border-color: var(--dq-accent); }
   }
 
   /* ── Ornamental corners ── */

--- a/packages/pi-daily-quote/ui/DailyQuote.tsx
+++ b/packages/pi-daily-quote/ui/DailyQuote.tsx
@@ -137,7 +137,7 @@ const CUSTOM_STYLES = `
     font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
     font-weight: 400;
     font-style: italic;
-    line-height: 1.85;
+    line-height: 1.65;
     letter-spacing: 0.01em;
     font-size: clamp(1.75rem, 4vw, 2.75rem);
   }
@@ -512,7 +512,7 @@ function QuoteDisplay({
       </p>
 
       {/* Divider */}
-      <div className="dq-divider dq-animate-divider mt-14 mb-10" />
+      <div className="dq-divider dq-animate-divider" style={{ marginTop: '3.5rem', marginBottom: '2.5rem' }} />
 
       {/* Author */}
       <p
@@ -527,7 +527,7 @@ function QuoteDisplay({
 
       {/* Refresh button */}
       <button
-        className="dq-button dq-animate-button mt-20"
+        className="dq-button dq-animate-button" style={{ marginTop: '3rem' }}
         onClick={onRefresh}
         disabled={loading}
       >


### PR DESCRIPTION
Add a complete light theme for the app with toggling via the footer
status bar. The theme persists to localStorage and applies to the
Monaco code editor (vs/vs-dark) and xterm.js terminal. A blocking
script in index.html prevents flash of wrong theme on load.

https://claude.ai/code/session_01QzpXN5EZTBhaEeR4YpWjnR