### PR TITLE
feat: Tetris app with responsive sizing and scoped keyboard events

### DIFF
--- a/docs/apps-tutorial.md
+++ b/docs/apps-tutorial.md
@@ -22,7 +22,7 @@ working agent tool + live web UI.
 - [Manifest Reference](#manifest-reference)
 - [Conventions and Rules](#conventions-and-rules)
 - [Troubleshooting](#troubleshooting)
-- [Reference Implementation](#reference-implementation)
+- [Reference Implementations](#reference-implementations)
 
 ---
 
@@ -931,6 +931,112 @@ separate files. See `apps/desktop/AGENTS.md` for full rules.
 - **Atomic writes always.** Write to a temp file, then `fs.rename()`. Both the
   extension and the `AppStateManager` do this.
 
+### Keyboard events
+
+Apps that listen for keyboard events **must scope listeners to their own
+container element**, not `window`. The shell has multiple panels (ChatPanel,
+sidebar, other apps) — a `window`-level listener will steal keystrokes when
+the user clicks into another panel.
+
+**Pattern:**
+
+```tsx
+// In your hook or component, accept a container ref:
+function useMyKeyboard(containerRef: React.RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const target = containerRef.current;
+    if (!target) return;
+    const handler = (e: KeyboardEvent) => {
+      // Only fires when this container is focused
+      e.preventDefault();
+      // ... handle key
+    };
+    target.addEventListener('keydown', handler);
+    return () => target.removeEventListener('keydown', handler);
+  }, [containerRef]);
+}
+```
+
+Make the app's root container focusable and auto-focus it on mount:
+
+```tsx
+export function MyApp() {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      className="h-full w-full outline-none"
+    >
+      {/* ... */}
+    </div>
+  );
+}
+```
+
+**Key rules:**
+- Never use `window.addEventListener('keydown', ...)` — always scope to the
+  app container.
+- Add `tabIndex={0}` so the container can receive focus.
+- Add `outline-none` (Tailwind) to suppress the browser focus ring.
+- Auto-focus the container in a `useEffect` so keyboard works immediately
+  when the app is activated.
+- If you need focus to stay on the container when child elements are clicked,
+  add an `onFocus` handler that redirects focus back:
+  ```tsx
+  onFocus={(e) => {
+    if (e.target !== containerRef.current) containerRef.current?.focus();
+  }}
+  ```
+
+### Responsive sizing
+
+Apps fill the entire main content area (`h-full w-full`). If your app has
+fixed-ratio content (game boards, canvases, grids), **compute dimensions
+dynamically** from the container size rather than using fixed pixel values.
+
+**Pattern — `ResizeObserver` hook:**
+
+```tsx
+function useDynamicSize(containerRef: React.RefObject<HTMLElement | null>) {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const measure = () => {
+      setSize({ width: el.clientWidth, height: el.clientHeight });
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [containerRef]);
+
+  return size;
+}
+```
+
+Use the measured size to derive layout values (e.g. cell size for a grid):
+
+```tsx
+const { height } = useDynamicSize(containerRef);
+const cellSize = Math.floor((height - overhead) / ROWS);
+```
+
+**Key rules:**
+- Always use `ResizeObserver`, not a one-time measurement — the container
+  resizes when the sidebar or chat panel is toggled.
+- Derive from the **minimum** of width and height constraints to maintain
+  aspect ratio.
+- Add breathing room (padding) so content doesn't touch container edges.
+- Use `Math.floor()` for pixel values to avoid sub-pixel rendering issues.
+
 ### Module Federation
 
 - `react` and `react-dom` are shared singletons via MF — the host provides
@@ -1036,6 +1142,16 @@ Current assignments: Todo=5174, Calc=5175, Weight=5176, Quote=5177.
   produce corrupt JSON that the watcher silently ignores.
 - Look for errors in the electron console (`Cmd+Option+I` → Console).
 
+**Keyboard events in my app steal input from other panels (ChatPanel, etc.):**
+- Your app is using `window.addEventListener('keydown', ...)`. Scope the
+  listener to the app's container element instead. See
+  [Keyboard events](#keyboard-events) in Conventions and Rules.
+
+**App content is tiny / doesn't fill the available space:**
+- You're using fixed pixel sizes. Use a `ResizeObserver` to compute
+  dimensions dynamically from the container. See
+  [Responsive sizing](#responsive-sizing) in Conventions and Rules.
+
 **Module Federation errors in console:**
 - Make sure the remote dev server is running on the correct port.
 - Check that `devPort` in `package.json` matches `server.port` in
@@ -1047,7 +1163,7 @@ Current assignments: Todo=5174, Calc=5175, Weight=5176, Quote=5177.
 
 ---
 
-## Reference Implementation
+## Reference Implementations
 
 The **Todo app** (`packages/pi-todo-extension/`) is the canonical reference:
 
@@ -1058,6 +1174,16 @@ The **Todo app** (`packages/pi-todo-extension/`) is the canonical reference:
 | `shared/types.ts` | Shared state shape pattern |
 | `extension/index.ts` | Tool registration, atomic file I/O, TUI rendering |
 | `ui/TodoApp.tsx` | `useAppState` usage, Tailwind styling, sub-components |
+
+The **Tetris app** (`packages/pi-tetris-extension/`) demonstrates patterns
+for interactive/game-style apps:
+
+| File | What to learn |
+|------|---------------|
+| `ui/TetrisApp.tsx` | Dynamic sizing with `ResizeObserver`, container-scoped keyboard events, `tabIndex` focus management |
+| `ui/game/useGame.ts` | Game loop hook with scoped keyboard listener (accepts `containerRef`), `setInterval` lifecycle |
+| `ui/game/engine.ts` | Pure game logic separated from React (testable, no side effects) |
+| `shared/types.ts` | Persisted stats (high score) vs. ephemeral game state (board, current piece) |
 
 ### Related documentation
 

--- a/packages/pi-tetris-extension/extension/index.ts
+++ b/packages/pi-tetris-extension/extension/index.ts
@@ -1,0 +1,7 @@
+// extension/index.ts — minimal Pi extension (UI-only app, no agent tools)
+
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+export default function (_pi: ExtensionAPI) {
+  // Tetris is a UI-only app — no agent tools needed.
+}

--- a/packages/pi-tetris-extension/package.json
+++ b/packages/pi-tetris-extension/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@sero/tetris",
+  "version": "0.1.0",
+  "description": "Tetris game for Sero",
+  "keywords": ["pi-package"],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+  },
+  "pi": {
+    "extensions": ["./extension/index.ts"]
+  },
+  "sero": {
+    "app": {
+      "id": "tetris",
+      "name": "Tetris",
+      "icon": "gamepad-2",
+      "stateFile": ".sero/apps/tetris/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "TetrisApp",
+      "devPort": 5179
+    }
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": ">=0.52.0"
+  },
+  "devDependencies": {
+    "@sero/app-runtime": "workspace:*",
+    "@module-federation/vite": "^1.11.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "@tailwindcss/vite": "^4.1.18",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/packages/pi-tetris-extension/shared/types.ts
+++ b/packages/pi-tetris-extension/shared/types.ts
@@ -1,0 +1,13 @@
+// shared/types.ts — persisted state (high scores, stats)
+
+export interface TetrisState {
+  highScore: number;
+  gamesPlayed: number;
+  totalLinesCleared: number;
+}
+
+export const DEFAULT_STATE: TetrisState = {
+  highScore: 0,
+  gamesPlayed: 0,
+  totalLinesCleared: 0,
+};

--- a/packages/pi-tetris-extension/ui/TetrisApp.tsx
+++ b/packages/pi-tetris-extension/ui/TetrisApp.tsx
@@ -1,18 +1,20 @@
-// ui/TetrisApp.tsx — Main Tetris component
+// ui/TetrisApp.tsx — Main Tetris component with HD particle effects
 
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppState } from '@sero/app-runtime';
 import type { TetrisState } from '../shared/types';
 import { DEFAULT_STATE } from '../shared/types';
-import { useGame } from './game/useGame';
+import { useGame, type ParticleEvent } from './game/useGame';
 import {
   BOARD_ROWS,
   BOARD_COLS,
-  CELL_SIZE,
   PIECE_COLORS,
   SHAPES,
   type PieceType,
 } from './game/types';
+import { ParticleEngine } from './game/particles';
+
+// ── Helpers ────────────────────────────────────────────────────────
 
 function getCellDisplay(
   row: number,
@@ -25,7 +27,7 @@ function getCellDisplay(
     col: number;
   } | null,
   ghostRow: number,
-): { color: string; opacity: number } | null {
+): { color: string; opacity: number; type: PieceType } | null {
   if (currentPiece) {
     const pr = row - currentPiece.row;
     const pc = col - currentPiece.col;
@@ -36,7 +38,7 @@ function getCellDisplay(
       pc < currentPiece.shape[0].length &&
       currentPiece.shape[pr][pc]
     ) {
-      return { color: PIECE_COLORS[currentPiece.type], opacity: 1 };
+      return { color: PIECE_COLORS[currentPiece.type], opacity: 1, type: currentPiece.type };
     }
     const gr = row - ghostRow;
     const gc = col - currentPiece.col;
@@ -47,11 +49,11 @@ function getCellDisplay(
       gc < currentPiece.shape[0].length &&
       currentPiece.shape[gr][gc]
     ) {
-      return { color: PIECE_COLORS[currentPiece.type], opacity: 0.2 };
+      return { color: PIECE_COLORS[currentPiece.type], opacity: 0.2, type: currentPiece.type };
     }
   }
   const cell = board[row]?.[col];
-  if (cell) return { color: PIECE_COLORS[cell], opacity: 1 };
+  if (cell) return { color: PIECE_COLORS[cell], opacity: 1, type: cell };
   return null;
 }
 
@@ -70,6 +72,7 @@ function NextPiecePreview({ type }: { type: PieceType }) {
                 height: 16,
                 borderRadius: 2,
                 backgroundColor: cell ? color : 'transparent',
+                boxShadow: cell ? `0 0 6px ${color}44, inset 0 1px 0 rgba(255,255,255,0.15)` : 'none',
               }}
             />
           ))}
@@ -79,10 +82,355 @@ function NextPiecePreview({ type }: { type: PieceType }) {
   );
 }
 
+const INFO_PANEL_WIDTH = 160;
+const GAP = 24;
+const BOARD_PADDING = 4;
+const BOARD_BORDER = 4;
+const BOARD_OVERHEAD = BOARD_PADDING + BOARD_BORDER;
+
+function useDynamicCellSize() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [cellSize, setCellSize] = useState(28);
+
+  const measure = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const h = el.clientHeight - 48;
+    const w = el.clientWidth - 64;
+    const fromHeight = (h - BOARD_OVERHEAD - (BOARD_ROWS - 1)) / BOARD_ROWS;
+    const fromWidth =
+      (w - INFO_PANEL_WIDTH - GAP - BOARD_OVERHEAD - (BOARD_COLS - 1)) /
+      BOARD_COLS;
+    setCellSize(Math.max(12, Math.floor(Math.min(fromHeight, fromWidth))));
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [measure]);
+
+  return { containerRef, cellSize };
+}
+
+// ── Flash overlay for line clears ──────────────────────────────────
+
+interface FlashState {
+  rows: number[];
+  startTime: number;
+  color: string;
+}
+
+// ── Main Component ─────────────────────────────────────────────────
+
 export function TetrisApp() {
   const [persisted, updatePersisted] = useAppState<TetrisState>(DEFAULT_STATE);
-  const game = useGame();
   const prevGameOver = useRef(false);
+  const { containerRef, cellSize } = useDynamicCellSize();
+
+  // Particle engine (one instance for the lifetime of the component)
+  const engineRef = useRef<ParticleEngine | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const boardRef = useRef<HTMLDivElement>(null);
+
+  // Flash state for line clear white-out effect
+  const [flashes, setFlashes] = useState<FlashState[]>([]);
+
+  // Screen shake state
+  const [shake, setShake] = useState({ x: 0, y: 0 });
+  const shakeFrameRef = useRef(0);
+
+  // Combo text popup
+  const [comboText, setComboText] = useState<{ text: string; key: number } | null>(null);
+  const comboKeyRef = useRef(0);
+
+  // Auto-focus container so keyboard works immediately
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, [containerRef]);
+
+  // ── Initialize particle engine ──────────────────────────────────
+  useEffect(() => {
+    if (!engineRef.current) {
+      engineRef.current = new ParticleEngine();
+    }
+    const canvas = canvasRef.current;
+    if (canvas && engineRef.current) {
+      engineRef.current.attach(canvas);
+    }
+    return () => {
+      engineRef.current?.detach();
+    };
+  }, []);
+
+  // ── Resize particle canvas to match board ───────────────────────
+  useEffect(() => {
+    const engine = engineRef.current;
+    const board = boardRef.current;
+    const canvas = canvasRef.current;
+    if (!engine || !board || !canvas) return;
+
+    const ro = new ResizeObserver(() => {
+      const rect = board.getBoundingClientRect();
+      // Make canvas slightly larger for particles that fly out
+      const pad = 80;
+      engine.resize(rect.width + pad * 2, rect.height + pad * 2);
+      canvas.style.position = 'absolute';
+      canvas.style.left = `${-pad}px`;
+      canvas.style.top = `${-pad}px`;
+      canvas.style.pointerEvents = 'none';
+      canvas.style.zIndex = '10';
+    });
+    ro.observe(board);
+    return () => ro.disconnect();
+  }, [cellSize]);
+
+  // ── Screen shake animation ──────────────────────────────────────
+  useEffect(() => {
+    let frame: number;
+    const tick = () => {
+      const engine = engineRef.current;
+      if (engine && (engine.shakeX !== 0 || engine.shakeY !== 0)) {
+        setShake({ x: engine.shakeX, y: engine.shakeY });
+      } else if (shake.x !== 0 || shake.y !== 0) {
+        setShake({ x: 0, y: 0 });
+      }
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  // ── Convert board coords to canvas pixel coords ─────────────────
+  const boardToCanvas = useCallback(
+    (row: number, col: number) => {
+      const pad = 80;
+      const gap = 1;
+      const x = pad + 2 + col * (cellSize + gap) + cellSize / 2;
+      const y = pad + 2 + row * (cellSize + gap) + cellSize / 2;
+      return { x, y };
+    },
+    [cellSize],
+  );
+
+  // ── Handle particle events from game engine ─────────────────────
+  const handleParticleEvent = useCallback(
+    (event: ParticleEvent) => {
+      const engine = engineRef.current;
+      if (!engine) return;
+
+      switch (event.type) {
+        case 'lineClear': {
+          const rows = event.rows || [];
+          const linesCleared = event.linesCleared || 0;
+          const combo = event.combo || 0;
+          const isTetris = linesCleared === 4;
+          const preset = isTetris ? 'tetris' as const : 'lineClear' as const;
+          const intensity = isTetris ? 2.5 : (1 + combo * 0.3);
+
+          // Emit particles along each cleared row
+          for (const rowIdx of rows) {
+            for (let col = 0; col < BOARD_COLS; col++) {
+              const { x, y } = boardToCanvas(rowIdx, col);
+              engine.emit({
+                x, y,
+                count: isTetris ? 18 : 8,
+                preset,
+                color: PIECE_COLORS[(['I', 'O', 'T', 'S', 'Z', 'J', 'L'] as PieceType[])[col % 7]],
+                intensity,
+              });
+            }
+          }
+
+          // Extra center burst for tetris
+          if (isTetris) {
+            const centerRow = rows[Math.floor(rows.length / 2)];
+            const { x, y } = boardToCanvas(centerRow, BOARD_COLS / 2);
+            engine.emit({
+              x, y,
+              count: 60,
+              preset: 'tetris',
+              color: '#ffd700',
+              intensity: 3,
+            });
+          }
+
+          // Combo particles
+          if (combo >= 2) {
+            const centerRow = rows[Math.floor(rows.length / 2)];
+            const { x, y } = boardToCanvas(centerRow, BOARD_COLS / 2);
+            engine.emit({
+              x, y,
+              count: 30 * combo,
+              preset: 'combo',
+              color: '#ffd700',
+              intensity: 1 + combo * 0.5,
+            });
+
+            // Combo text
+            comboKeyRef.current++;
+            const texts = ['', '', 'COMBO x2!', 'COMBO x3!', 'COMBO x4!', 'INSANE x5!'];
+            setComboText({
+              text: combo >= 5 ? `INSANE x${combo}!` : (texts[combo] || `COMBO x${combo}!`),
+              key: comboKeyRef.current,
+            });
+            setTimeout(() => setComboText(null), 1500);
+          }
+
+          // Screen shake
+          engine.shake(isTetris ? 20 : 8 + combo * 3, isTetris ? 8 : 3 + combo);
+
+          // Flash effect
+          setFlashes((prev) => [
+            ...prev,
+            { rows, startTime: Date.now(), color: isTetris ? '#ffd700' : '#ffffff' },
+          ]);
+          setTimeout(() => {
+            setFlashes((prev) => prev.filter((f) => Date.now() - f.startTime < 400));
+          }, 450);
+
+          break;
+        }
+
+        case 'hardDrop': {
+          if (!event.piece) break;
+          const { shape, row, col, type } = event.piece;
+          const color = PIECE_COLORS[type];
+
+          // Find bottom cells of the piece (impact points)
+          const bottomCells: { r: number; c: number }[] = [];
+          for (let c = 0; c < shape[0].length; c++) {
+            for (let r = shape.length - 1; r >= 0; r--) {
+              if (shape[r][c]) {
+                bottomCells.push({ r: row + r, c: col + c });
+                break;
+              }
+            }
+          }
+
+          // Emit impact particles from bottom of piece
+          for (const cell of bottomCells) {
+            const { x, y } = boardToCanvas(cell.r, cell.c);
+            engine.emit({
+              x, y: y + cellSize / 2,
+              count: 15,
+              preset: 'hardDrop',
+              color,
+              intensity: 1.2,
+            });
+          }
+
+          // Shockwave particles along the landing row
+          const landingRow = Math.max(...bottomCells.map((c) => c.r));
+          for (let c = 0; c < BOARD_COLS; c++) {
+            const { x, y } = boardToCanvas(landingRow, c);
+            engine.emit({
+              x, y: y + cellSize / 3,
+              count: 2,
+              preset: 'hardDrop',
+              color: '#ffffff',
+              intensity: 0.4,
+            });
+          }
+
+          engine.shake(6, 3);
+          break;
+        }
+
+        case 'pieceLock': {
+          if (!event.piece) break;
+          const { shape, row, col, type } = event.piece;
+          const color = PIECE_COLORS[type];
+
+          for (let r = 0; r < shape.length; r++) {
+            for (let c = 0; c < shape[r].length; c++) {
+              if (shape[r][c]) {
+                const { x, y } = boardToCanvas(row + r, col + c);
+                engine.emit({
+                  x, y,
+                  count: 4,
+                  preset: 'pieceLock',
+                  color,
+                  intensity: 0.8,
+                });
+              }
+            }
+          }
+          break;
+        }
+
+        case 'gameOver': {
+          // Dramatic cascade of particles from the top
+          for (let row = 0; row < BOARD_ROWS; row++) {
+            setTimeout(() => {
+              for (let col = 0; col < BOARD_COLS; col++) {
+                const { x, y } = boardToCanvas(row, col);
+                engine.emit({
+                  x, y,
+                  count: 5,
+                  preset: 'gameOver',
+                  intensity: 1.2,
+                });
+              }
+            }, row * 40);
+          }
+          engine.shake(30, 6);
+          break;
+        }
+
+        case 'levelUp': {
+          // Firework-style burst from center
+          const { x, y } = boardToCanvas(BOARD_ROWS / 2, BOARD_COLS / 2);
+          engine.emit({
+            x, y,
+            count: 120,
+            preset: 'levelUp',
+            intensity: 2,
+          });
+
+          // Corner bursts
+          for (const [r, c] of [[0, 0], [0, BOARD_COLS - 1], [BOARD_ROWS - 1, 0], [BOARD_ROWS - 1, BOARD_COLS - 1]]) {
+            const pos = boardToCanvas(r, c);
+            engine.emit({
+              x: pos.x, y: pos.y,
+              count: 30,
+              preset: 'levelUp',
+              intensity: 1.5,
+            });
+          }
+
+          engine.shake(15, 4);
+          break;
+        }
+      }
+    },
+    [boardToCanvas, cellSize],
+  );
+
+  // ── Ambient particles ───────────────────────────────────────────
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const engine = engineRef.current;
+      if (!engine) return;
+      // Spawn a few ambient particles around the board
+      for (let i = 0; i < 2; i++) {
+        const row = Math.random() * BOARD_ROWS;
+        const col = Math.random() * BOARD_COLS;
+        const { x, y } = boardToCanvas(row, col);
+        engine.emit({
+          x, y,
+          count: 1,
+          preset: 'ambient',
+        });
+      }
+    }, 200);
+    return () => clearInterval(interval);
+  }, [boardToCanvas]);
+
+  const game = useGame(handleParticleEvent, containerRef);
 
   // Update persisted state on game-over transition
   useEffect(() => {
@@ -97,65 +445,152 @@ export function TetrisApp() {
   }, [game.gameOver, game.score, game.lines, updatePersisted]);
 
   const cells = useMemo(() => {
-    const result: ({ color: string; opacity: number } | null)[][] = [];
+    const result: ({ color: string; opacity: number; type: PieceType } | null)[][] = [];
     for (let r = 0; r < BOARD_ROWS; r++) {
-      const row: ({ color: string; opacity: number } | null)[] = [];
+      const row: ({ color: string; opacity: number; type: PieceType } | null)[] = [];
       for (let c = 0; c < BOARD_COLS; c++) {
-        row.push(
-          getCellDisplay(
-            r,
-            c,
-            game.board,
-            game.currentPiece,
-            game.ghostRow,
-          ),
-        );
+        row.push(getCellDisplay(r, c, game.board, game.currentPiece, game.ghostRow));
       }
       result.push(row);
     }
     return result;
   }, [game.board, game.currentPiece, game.ghostRow]);
 
+  // Determine which rows are currently flashing
+  const flashingRows = useMemo(() => {
+    const set = new Set<number>();
+    const now = Date.now();
+    for (const f of flashes) {
+      if (now - f.startTime < 400) {
+        for (const r of f.rows) set.add(r);
+      }
+    }
+    return set;
+  }, [flashes]);
+
+  const boardWidth = BOARD_COLS * (cellSize + 1) - 1 + BOARD_OVERHEAD;
+  const boardHeight = BOARD_ROWS * (cellSize + 1) - 1 + BOARD_OVERHEAD;
+
   return (
     <div
-      className="relative flex h-full items-center justify-center bg-[var(--bg-base)]"
+      ref={containerRef}
+      tabIndex={0}
+      className="relative flex h-full w-full items-center justify-center bg-[var(--bg-base)] outline-none"
       style={{ fontFamily: "'DM Sans', sans-serif" }}
+      onFocus={(e) => {
+        // Keep focus on container even when clicking children
+        if (e.target !== containerRef.current) containerRef.current?.focus();
+      }}
     >
-      <div className="flex gap-6">
-        {/* Game Board */}
+      <div className="flex items-center" style={{ gap: GAP }}>
+        {/* Board Wrapper with shake and particle canvas */}
         <div
           style={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(${BOARD_COLS}, ${CELL_SIZE}px)`,
-            gridTemplateRows: `repeat(${BOARD_ROWS}, ${CELL_SIZE}px)`,
-            gap: 1,
-            padding: 2,
-            backgroundColor: '#0a0b0f',
-            borderRadius: 8,
-            border: '2px solid rgba(255,255,255,0.08)',
+            position: 'relative',
+            transform: `translate(${shake.x}px, ${shake.y}px)`,
+            transition: shake.x === 0 && shake.y === 0 ? 'transform 0.1s ease-out' : 'none',
           }}
         >
-          {cells.flat().map((cell, i) => (
+          {/* Particle Canvas (positioned absolutely over board) */}
+          <canvas
+            ref={canvasRef}
+            style={{
+              position: 'absolute',
+              pointerEvents: 'none',
+              zIndex: 10,
+            }}
+          />
+
+          {/* Combo text popup */}
+          {comboText && (
             <div
-              key={i}
+              key={comboText.key}
               style={{
-                width: CELL_SIZE,
-                height: CELL_SIZE,
-                borderRadius: 3,
-                backgroundColor: cell
-                  ? cell.color
-                  : 'rgba(255,255,255,0.03)',
-                opacity: cell ? cell.opacity : 1,
+                position: 'absolute',
+                top: '40%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                zIndex: 20,
+                fontSize: 28,
+                fontWeight: 900,
+                color: '#ffd700',
+                textShadow: '0 0 20px #ffd70088, 0 0 40px #ffd70044, 0 2px 4px rgba(0,0,0,0.8)',
+                letterSpacing: '0.05em',
+                textTransform: 'uppercase',
+                animation: 'comboPopIn 0.3s cubic-bezier(0.16, 1, 0.3, 1), comboFadeOut 0.5s 1s ease-out forwards',
+                pointerEvents: 'none',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {comboText.text}
+            </div>
+          )}
+
+          {/* Game Board */}
+          <div
+            ref={boardRef}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${BOARD_COLS}, ${cellSize}px)`,
+              gridTemplateRows: `repeat(${BOARD_ROWS}, ${cellSize}px)`,
+              gap: 1,
+              padding: 2,
+              backgroundColor: '#0a0b0f',
+              borderRadius: 8,
+              border: '2px solid rgba(255,255,255,0.08)',
+              position: 'relative',
+              overflow: 'hidden',
+            }}
+          >
+            {cells.flat().map((cell, i) => {
+              const row = Math.floor(i / BOARD_COLS);
+              const isFlashing = flashingRows.has(row);
+              return (
+                <div
+                  key={i}
+                  style={{
+                    width: cellSize,
+                    height: cellSize,
+                    borderRadius: 3,
+                    backgroundColor: isFlashing
+                      ? '#ffffff'
+                      : cell
+                        ? cell.color
+                        : 'rgba(255,255,255,0.03)',
+                    opacity: isFlashing ? 0.9 : cell ? cell.opacity : 1,
+                    boxShadow: cell && cell.opacity === 1
+                      ? `0 0 ${cellSize * 0.4}px ${cell.color}33, inset 0 1px 0 rgba(255,255,255,0.15), inset 0 -1px 0 rgba(0,0,0,0.3)`
+                      : 'none',
+                    transition: isFlashing ? 'background-color 0.1s, opacity 0.1s' : 'none',
+                  }}
+                />
+              );
+            })}
+
+            {/* Scanline overlay for retro feel */}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                backgroundImage:
+                  'repeating-linear-gradient(0deg, transparent, transparent 1px, rgba(0,0,0,0.03) 1px, rgba(0,0,0,0.03) 2px)',
+                pointerEvents: 'none',
+                borderRadius: 6,
               }}
             />
-          ))}
+          </div>
         </div>
 
         {/* Info Panel */}
-        <div className="flex w-40 flex-col gap-4">
+        <div className="flex flex-col gap-4" style={{ width: INFO_PANEL_WIDTH }}>
           <div className="rounded-lg bg-[var(--bg-surface)] p-3">
             <div className="text-xs text-[var(--text-muted)]">Score</div>
-            <div className="text-xl font-bold text-[var(--text-primary)]">
+            <div
+              className="text-xl font-bold text-[var(--text-primary)]"
+              style={{
+                textShadow: game.score > 0 ? '0 0 8px rgba(212,164,76,0.3)' : 'none',
+              }}
+            >
               {game.score.toLocaleString()}
             </div>
           </div>
@@ -184,7 +619,10 @@ export function TetrisApp() {
 
           <div className="rounded-lg bg-[var(--bg-surface)] p-3">
             <div className="text-xs text-[var(--text-muted)]">High Score</div>
-            <div className="text-lg font-bold text-[var(--accent)]">
+            <div
+              className="text-lg font-bold text-[var(--accent)]"
+              style={{ textShadow: '0 0 8px rgba(212,164,76,0.2)' }}
+            >
               {persisted.highScore.toLocaleString()}
             </div>
           </div>
@@ -192,7 +630,10 @@ export function TetrisApp() {
           {!game.started || game.gameOver ? (
             <button
               onClick={game.start}
-              className="rounded-lg bg-[var(--accent)] px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+              className="rounded-lg bg-[var(--accent)] px-4 py-2.5 text-sm font-semibold text-white transition-all hover:opacity-90"
+              style={{
+                boxShadow: '0 0 20px rgba(212,164,76,0.2), 0 4px 12px rgba(0,0,0,0.3)',
+              }}
             >
               {game.gameOver ? 'Play Again' : 'Start Game'}
             </button>
@@ -239,7 +680,10 @@ export function TetrisApp() {
             )}
             <button
               onClick={game.start}
-              className="mt-4 rounded-lg bg-[var(--accent)] px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+              className="mt-4 rounded-lg bg-[var(--accent)] px-6 py-2.5 text-sm font-semibold text-white transition-all hover:opacity-90"
+              style={{
+                boxShadow: '0 0 20px rgba(212,164,76,0.3)',
+              }}
             >
               {game.gameOver ? 'Play Again' : 'Start Game'}
             </button>
@@ -249,6 +693,18 @@ export function TetrisApp() {
           </div>
         </div>
       )}
+
+      {/* Inline keyframe animations */}
+      <style>{`
+        @keyframes comboPopIn {
+          0% { transform: translate(-50%, -50%) scale(0.3); opacity: 0; }
+          100% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+        }
+        @keyframes comboFadeOut {
+          0% { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+          100% { transform: translate(-50%, -60%) scale(1.2); opacity: 0; }
+        }
+      `}</style>
     </div>
   );
 }

--- a/packages/pi-tetris-extension/ui/TetrisApp.tsx
+++ b/packages/pi-tetris-extension/ui/TetrisApp.tsx
@@ -1,0 +1,256 @@
+// ui/TetrisApp.tsx — Main Tetris component
+
+import { useEffect, useMemo, useRef } from 'react';
+import { useAppState } from '@sero/app-runtime';
+import type { TetrisState } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+import { useGame } from './game/useGame';
+import {
+  BOARD_ROWS,
+  BOARD_COLS,
+  CELL_SIZE,
+  PIECE_COLORS,
+  SHAPES,
+  type PieceType,
+} from './game/types';
+
+function getCellDisplay(
+  row: number,
+  col: number,
+  board: (PieceType | null)[][],
+  currentPiece: {
+    type: PieceType;
+    shape: number[][];
+    row: number;
+    col: number;
+  } | null,
+  ghostRow: number,
+): { color: string; opacity: number } | null {
+  if (currentPiece) {
+    const pr = row - currentPiece.row;
+    const pc = col - currentPiece.col;
+    if (
+      pr >= 0 &&
+      pr < currentPiece.shape.length &&
+      pc >= 0 &&
+      pc < currentPiece.shape[0].length &&
+      currentPiece.shape[pr][pc]
+    ) {
+      return { color: PIECE_COLORS[currentPiece.type], opacity: 1 };
+    }
+    const gr = row - ghostRow;
+    const gc = col - currentPiece.col;
+    if (
+      gr >= 0 &&
+      gr < currentPiece.shape.length &&
+      gc >= 0 &&
+      gc < currentPiece.shape[0].length &&
+      currentPiece.shape[gr][gc]
+    ) {
+      return { color: PIECE_COLORS[currentPiece.type], opacity: 0.2 };
+    }
+  }
+  const cell = board[row]?.[col];
+  if (cell) return { color: PIECE_COLORS[cell], opacity: 1 };
+  return null;
+}
+
+function NextPiecePreview({ type }: { type: PieceType }) {
+  const shape = SHAPES[type];
+  const color = PIECE_COLORS[type];
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      {shape.map((row, r) => (
+        <div key={r} className="flex gap-0.5">
+          {row.map((cell, c) => (
+            <div
+              key={c}
+              style={{
+                width: 16,
+                height: 16,
+                borderRadius: 2,
+                backgroundColor: cell ? color : 'transparent',
+              }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TetrisApp() {
+  const [persisted, updatePersisted] = useAppState<TetrisState>(DEFAULT_STATE);
+  const game = useGame();
+  const prevGameOver = useRef(false);
+
+  // Update persisted state on game-over transition
+  useEffect(() => {
+    if (game.gameOver && !prevGameOver.current) {
+      updatePersisted((prev) => ({
+        highScore: Math.max(prev.highScore, game.score),
+        gamesPlayed: prev.gamesPlayed + 1,
+        totalLinesCleared: prev.totalLinesCleared + game.lines,
+      }));
+    }
+    prevGameOver.current = game.gameOver;
+  }, [game.gameOver, game.score, game.lines, updatePersisted]);
+
+  const cells = useMemo(() => {
+    const result: ({ color: string; opacity: number } | null)[][] = [];
+    for (let r = 0; r < BOARD_ROWS; r++) {
+      const row: ({ color: string; opacity: number } | null)[] = [];
+      for (let c = 0; c < BOARD_COLS; c++) {
+        row.push(
+          getCellDisplay(
+            r,
+            c,
+            game.board,
+            game.currentPiece,
+            game.ghostRow,
+          ),
+        );
+      }
+      result.push(row);
+    }
+    return result;
+  }, [game.board, game.currentPiece, game.ghostRow]);
+
+  return (
+    <div
+      className="relative flex h-full items-center justify-center bg-[var(--bg-base)]"
+      style={{ fontFamily: "'DM Sans', sans-serif" }}
+    >
+      <div className="flex gap-6">
+        {/* Game Board */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${BOARD_COLS}, ${CELL_SIZE}px)`,
+            gridTemplateRows: `repeat(${BOARD_ROWS}, ${CELL_SIZE}px)`,
+            gap: 1,
+            padding: 2,
+            backgroundColor: '#0a0b0f',
+            borderRadius: 8,
+            border: '2px solid rgba(255,255,255,0.08)',
+          }}
+        >
+          {cells.flat().map((cell, i) => (
+            <div
+              key={i}
+              style={{
+                width: CELL_SIZE,
+                height: CELL_SIZE,
+                borderRadius: 3,
+                backgroundColor: cell
+                  ? cell.color
+                  : 'rgba(255,255,255,0.03)',
+                opacity: cell ? cell.opacity : 1,
+              }}
+            />
+          ))}
+        </div>
+
+        {/* Info Panel */}
+        <div className="flex w-40 flex-col gap-4">
+          <div className="rounded-lg bg-[var(--bg-surface)] p-3">
+            <div className="text-xs text-[var(--text-muted)]">Score</div>
+            <div className="text-xl font-bold text-[var(--text-primary)]">
+              {game.score.toLocaleString()}
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <div className="flex-1 rounded-lg bg-[var(--bg-surface)] p-3">
+              <div className="text-xs text-[var(--text-muted)]">Level</div>
+              <div className="text-lg font-bold text-[var(--text-primary)]">
+                {game.level}
+              </div>
+            </div>
+            <div className="flex-1 rounded-lg bg-[var(--bg-surface)] p-3">
+              <div className="text-xs text-[var(--text-muted)]">Lines</div>
+              <div className="text-lg font-bold text-[var(--text-primary)]">
+                {game.lines}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg bg-[var(--bg-surface)] p-3">
+            <div className="mb-2 text-xs text-[var(--text-muted)]">Next</div>
+            <div className="flex justify-center">
+              <NextPiecePreview type={game.nextType} />
+            </div>
+          </div>
+
+          <div className="rounded-lg bg-[var(--bg-surface)] p-3">
+            <div className="text-xs text-[var(--text-muted)]">High Score</div>
+            <div className="text-lg font-bold text-[var(--accent)]">
+              {persisted.highScore.toLocaleString()}
+            </div>
+          </div>
+
+          {!game.started || game.gameOver ? (
+            <button
+              onClick={game.start}
+              className="rounded-lg bg-[var(--accent)] px-4 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            >
+              {game.gameOver ? 'Play Again' : 'Start Game'}
+            </button>
+          ) : (
+            <button
+              onClick={game.togglePause}
+              className="rounded-lg border border-border/50 bg-[var(--bg-surface)] px-4 py-2.5 text-sm font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)]"
+            >
+              {game.paused ? 'Resume' : 'Pause'}
+            </button>
+          )}
+
+          <div className="space-y-1 text-[10px] text-[var(--text-muted)]">
+            <div>Arrow keys &mdash; Move &amp; Rotate</div>
+            <div>Space &mdash; Hard drop</div>
+            <div>P &mdash; Pause</div>
+            <div>Enter &mdash; Start / Restart</div>
+          </div>
+
+          <div className="mt-auto space-y-0.5 text-[10px] text-[var(--text-muted)]">
+            <div>Games: {persisted.gamesPlayed}</div>
+            <div>Total lines: {persisted.totalLinesCleared}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Overlay for game-over / not-started */}
+      {(game.gameOver || !game.started) && (
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          style={{
+            backgroundColor: 'rgba(0,0,0,0.4)',
+            backdropFilter: 'blur(2px)',
+          }}
+        >
+          <div className="rounded-xl bg-[var(--bg-surface)] p-8 text-center shadow-2xl">
+            <h2 className="text-2xl font-bold text-[var(--text-primary)]">
+              {game.gameOver ? 'Game Over' : 'Tetris'}
+            </h2>
+            {game.gameOver && (
+              <p className="mt-2 text-lg text-[var(--accent)]">
+                Score: {game.score.toLocaleString()}
+              </p>
+            )}
+            <button
+              onClick={game.start}
+              className="mt-4 rounded-lg bg-[var(--accent)] px-6 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            >
+              {game.gameOver ? 'Play Again' : 'Start Game'}
+            </button>
+            <p className="mt-3 text-xs text-[var(--text-muted)]">
+              or press Enter
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TetrisApp;

--- a/packages/pi-tetris-extension/ui/game/engine.ts
+++ b/packages/pi-tetris-extension/ui/game/engine.ts
@@ -1,0 +1,112 @@
+// Pure game logic — no React dependencies
+
+import {
+  BOARD_ROWS,
+  BOARD_COLS,
+  SHAPES,
+  PIECE_TYPES,
+  type Board,
+  type Piece,
+  type PieceType,
+} from './types';
+
+export function createBoard(): Board {
+  return Array.from({ length: BOARD_ROWS }, () =>
+    Array<PieceType | null>(BOARD_COLS).fill(null),
+  );
+}
+
+export function randomPieceType(): PieceType {
+  return PIECE_TYPES[Math.floor(Math.random() * PIECE_TYPES.length)];
+}
+
+export function createPiece(type: PieceType): Piece {
+  const shape = SHAPES[type].map((row) => [...row]);
+  const col = Math.floor((BOARD_COLS - shape[0].length) / 2);
+  return { type, shape, row: 0, col };
+}
+
+export function rotateShape(shape: number[][]): number[][] {
+  const rows = shape.length;
+  const cols = shape[0].length;
+  const rotated: number[][] = Array.from({ length: cols }, () =>
+    Array(rows).fill(0),
+  );
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      rotated[c][rows - 1 - r] = shape[r][c];
+    }
+  }
+  return rotated;
+}
+
+export function isValidPosition(
+  board: Board,
+  shape: number[][],
+  row: number,
+  col: number,
+): boolean {
+  for (let r = 0; r < shape.length; r++) {
+    for (let c = 0; c < shape[r].length; c++) {
+      if (shape[r][c]) {
+        const newRow = row + r;
+        const newCol = col + c;
+        if (
+          newRow < 0 ||
+          newRow >= BOARD_ROWS ||
+          newCol < 0 ||
+          newCol >= BOARD_COLS
+        ) {
+          return false;
+        }
+        if (board[newRow][newCol] !== null) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+export function placePiece(board: Board, piece: Piece): Board {
+  const newBoard = board.map((row) => [...row]);
+  for (let r = 0; r < piece.shape.length; r++) {
+    for (let c = 0; c < piece.shape[r].length; c++) {
+      if (piece.shape[r][c]) {
+        const boardRow = piece.row + r;
+        const boardCol = piece.col + c;
+        if (boardRow >= 0 && boardRow < BOARD_ROWS) {
+          newBoard[boardRow][boardCol] = piece.type;
+        }
+      }
+    }
+  }
+  return newBoard;
+}
+
+export function clearLines(board: Board): [Board, number] {
+  const remaining = board.filter((row) => row.some((cell) => cell === null));
+  const cleared = BOARD_ROWS - remaining.length;
+  if (cleared === 0) return [board, 0];
+  const emptyRows: Board = Array.from({ length: cleared }, () =>
+    Array<PieceType | null>(BOARD_COLS).fill(null),
+  );
+  return [[...emptyRows, ...remaining], cleared];
+}
+
+export function getGhostRow(board: Board, piece: Piece): number {
+  let ghostRow = piece.row;
+  while (isValidPosition(board, piece.shape, ghostRow + 1, piece.col)) {
+    ghostRow++;
+  }
+  return ghostRow;
+}
+
+export function calculateScore(linesCleared: number, level: number): number {
+  const scores = [0, 100, 300, 500, 800];
+  return (scores[linesCleared] || 0) * level;
+}
+
+export function getSpeed(level: number): number {
+  return Math.max(100, 1000 - (level - 1) * 80);
+}

--- a/packages/pi-tetris-extension/ui/game/engine.ts
+++ b/packages/pi-tetris-extension/ui/game/engine.ts
@@ -84,14 +84,23 @@ export function placePiece(board: Board, piece: Piece): Board {
   return newBoard;
 }
 
-export function clearLines(board: Board): [Board, number] {
-  const remaining = board.filter((row) => row.some((cell) => cell === null));
+/** Returns [newBoard, clearedCount, clearedRowIndices] */
+export function clearLines(board: Board): [Board, number, number[]] {
+  const clearedRows: number[] = [];
+  const remaining: (PieceType | null)[][] = [];
+  for (let r = 0; r < BOARD_ROWS; r++) {
+    if (board[r].every((cell) => cell !== null)) {
+      clearedRows.push(r);
+    } else {
+      remaining.push(board[r]);
+    }
+  }
   const cleared = BOARD_ROWS - remaining.length;
-  if (cleared === 0) return [board, 0];
+  if (cleared === 0) return [board, 0, []];
   const emptyRows: Board = Array.from({ length: cleared }, () =>
     Array<PieceType | null>(BOARD_COLS).fill(null),
   );
-  return [[...emptyRows, ...remaining], cleared];
+  return [[...emptyRows, ...remaining], cleared, clearedRows];
 }
 
 export function getGhostRow(board: Board, piece: Piece): number {

--- a/packages/pi-tetris-extension/ui/game/particles.ts
+++ b/packages/pi-tetris-extension/ui/game/particles.ts
@@ -1,0 +1,502 @@
+// High-performance canvas particle system for Tetris
+// Supports thousands of particles at 60fps using Canvas2D with additive blending
+
+export interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  sizeEnd: number;
+  color: string;
+  r: number;
+  g: number;
+  b: number;
+  alpha: number;
+  alphaDecay: number;
+  gravity: number;
+  drag: number;
+  rotation: number;
+  rotationSpeed: number;
+  shape: 'circle' | 'square' | 'spark' | 'star' | 'ring';
+  glow: number;        // glow radius multiplier
+  pulse: number;       // pulse frequency (0 = no pulse)
+  turbulence: number;  // random motion each frame
+}
+
+export type ParticlePreset =
+  | 'lineClear'
+  | 'hardDrop'
+  | 'pieceLock'
+  | 'tetris'     // 4-line clear
+  | 'combo'
+  | 'ambient'
+  | 'gameOver'
+  | 'levelUp';
+
+interface EmitConfig {
+  x: number;
+  y: number;
+  count: number;
+  preset: ParticlePreset;
+  color?: string;
+  spread?: number;   // angular spread in radians
+  direction?: number; // base angle in radians
+  intensity?: number; // multiplier for velocity/count
+}
+
+// Parse hex color to RGB
+function hexToRgb(hex: string): [number, number, number] {
+  const h = hex.replace('#', '');
+  return [
+    parseInt(h.substring(0, 2), 16),
+    parseInt(h.substring(2, 4), 16),
+    parseInt(h.substring(4, 6), 16),
+  ];
+}
+
+// Lerp utility
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+// Random range
+function rand(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+// Random from array
+function pick<T>(arr: T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ── Preset factories ──────────────────────────────────────────────
+
+function createLineClearParticle(x: number, y: number, color: string): Partial<Particle> {
+  const [r, g, b] = hexToRgb(color);
+  const angle = rand(0, Math.PI * 2);
+  const speed = rand(1.5, 6);
+  return {
+    x, y,
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed - rand(0.5, 2),
+    life: 0, maxLife: rand(40, 80),
+    size: rand(2, 5), sizeEnd: 0,
+    r, g, b, alpha: 1, alphaDecay: 0,
+    gravity: 0.04,
+    drag: 0.98,
+    rotation: rand(0, Math.PI * 2),
+    rotationSpeed: rand(-0.15, 0.15),
+    shape: pick(['circle', 'square', 'spark']),
+    glow: 1.5,
+    pulse: 0,
+    turbulence: 0.3,
+    color,
+  };
+}
+
+function createTetrisParticle(x: number, y: number, color: string): Partial<Particle> {
+  const [r, g, b] = hexToRgb(color);
+  const angle = rand(0, Math.PI * 2);
+  const speed = rand(3, 10);
+  return {
+    x, y,
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed - rand(1, 4),
+    life: 0, maxLife: rand(60, 120),
+    size: rand(3, 8), sizeEnd: 0,
+    r, g, b, alpha: 1, alphaDecay: 0,
+    gravity: 0.03,
+    drag: 0.97,
+    rotation: rand(0, Math.PI * 2),
+    rotationSpeed: rand(-0.2, 0.2),
+    shape: pick(['circle', 'star', 'spark', 'ring']),
+    glow: 2.5,
+    pulse: rand(0, 0.1),
+    turbulence: 0.5,
+    color,
+  };
+}
+
+function createHardDropParticle(x: number, y: number, color: string): Partial<Particle> {
+  const [r, g, b] = hexToRgb(color);
+  const angle = rand(-Math.PI * 0.8, -Math.PI * 0.2); // upward fan
+  const speed = rand(2, 7);
+  return {
+    x: x + rand(-3, 3), y,
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed,
+    life: 0, maxLife: rand(25, 55),
+    size: rand(1.5, 4), sizeEnd: 0.5,
+    r, g, b, alpha: 1, alphaDecay: 0,
+    gravity: 0.08,
+    drag: 0.96,
+    rotation: 0,
+    rotationSpeed: rand(-0.1, 0.1),
+    shape: pick(['spark', 'circle']),
+    glow: 1.2,
+    pulse: 0,
+    turbulence: 0.2,
+    color,
+  };
+}
+
+function createPieceLockParticle(x: number, y: number, color: string): Partial<Particle> {
+  const [r, g, b] = hexToRgb(color);
+  const angle = rand(0, Math.PI * 2);
+  const speed = rand(0.3, 1.5);
+  return {
+    x: x + rand(-2, 2), y: y + rand(-2, 2),
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed - rand(0.2, 0.8),
+    life: 0, maxLife: rand(15, 35),
+    size: rand(1, 2.5), sizeEnd: 0,
+    r, g, b, alpha: 0.8, alphaDecay: 0,
+    gravity: 0.01,
+    drag: 0.99,
+    rotation: 0,
+    rotationSpeed: 0,
+    shape: pick(['circle', 'spark']),
+    glow: 0.8,
+    pulse: 0,
+    turbulence: 0.1,
+    color,
+  };
+}
+
+function createComboParticle(x: number, y: number, color: string): Partial<Particle> {
+  const [r, g, b] = hexToRgb(color);
+  const angle = rand(0, Math.PI * 2);
+  const speed = rand(2, 8);
+  return {
+    x, y,
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed - rand(1, 3),
+    life: 0, maxLife: rand(50, 100),
+    size: rand(2, 6), sizeEnd: 0,
+    r, g, b, alpha: 1, alphaDecay: 0,
+    gravity: 0.02,
+    drag: 0.975,
+    rotation: rand(0, Math.PI * 2),
+    rotationSpeed: rand(-0.2, 0.2),
+    shape: pick(['star', 'ring', 'circle', 'spark']),
+    glow: 2,
+    pulse: rand(0.05, 0.15),
+    turbulence: 0.6,
+    color,
+  };
+}
+
+function createAmbientParticle(x: number, y: number, _color: string): Partial<Particle> {
+  const ambientColors = ['#ffffff', '#d4a44c', '#00d4d4', '#9b59b6'];
+  const c = pick(ambientColors);
+  const [r, g, b] = hexToRgb(c);
+  return {
+    x: x + rand(-10, 10), y: y + rand(-10, 10),
+    vx: rand(-0.15, 0.15),
+    vy: rand(-0.4, -0.1),
+    life: 0, maxLife: rand(80, 200),
+    size: rand(0.5, 1.5), sizeEnd: 0,
+    r, g, b, alpha: 0.3, alphaDecay: 0,
+    gravity: -0.005,
+    drag: 0.999,
+    rotation: 0,
+    rotationSpeed: 0,
+    shape: 'circle',
+    glow: 0.5,
+    pulse: rand(0.02, 0.06),
+    turbulence: 0.15,
+    color: c,
+  };
+}
+
+function createGameOverParticle(x: number, y: number, _color: string): Partial<Particle> {
+  const colors = ['#e74c3c', '#ff6b6b', '#ff4444', '#cc0000', '#ff8888'];
+  const c = pick(colors);
+  const [r, g, b] = hexToRgb(c);
+  const angle = rand(-Math.PI, 0); // upward
+  const speed = rand(1, 5);
+  return {
+    x, y,
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed,
+    life: 0, maxLife: rand(60, 140),
+    size: rand(2, 6), sizeEnd: 0,
+    r, g, b, alpha: 1, alphaDecay: 0,
+    gravity: 0.05,
+    drag: 0.98,
+    rotation: rand(0, Math.PI * 2),
+    rotationSpeed: rand(-0.1, 0.1),
+    shape: pick(['circle', 'square', 'spark']),
+    glow: 1.5,
+    pulse: 0,
+    turbulence: 0.4,
+    color: c,
+  };
+}
+
+function createLevelUpParticle(x: number, y: number, _color: string): Partial<Particle> {
+  const colors = ['#ffd700', '#ffec80', '#d4a44c', '#ffe066', '#fff'];
+  const c = pick(colors);
+  const [r, g, b] = hexToRgb(c);
+  const angle = rand(0, Math.PI * 2);
+  const speed = rand(1, 6);
+  return {
+    x, y,
+    vx: Math.cos(angle) * speed,
+    vy: Math.sin(angle) * speed - rand(0.5, 2),
+    life: 0, maxLife: rand(50, 100),
+    size: rand(2, 5), sizeEnd: 0,
+    r, g, b, alpha: 1, alphaDecay: 0,
+    gravity: 0.02,
+    drag: 0.98,
+    rotation: rand(0, Math.PI * 2),
+    rotationSpeed: rand(-0.15, 0.15),
+    shape: pick(['star', 'circle', 'ring']),
+    glow: 2,
+    pulse: rand(0.05, 0.1),
+    turbulence: 0.3,
+    color: c,
+  };
+}
+
+const PRESET_FACTORIES: Record<ParticlePreset, (x: number, y: number, color: string) => Partial<Particle>> = {
+  lineClear: createLineClearParticle,
+  hardDrop: createHardDropParticle,
+  pieceLock: createPieceLockParticle,
+  tetris: createTetrisParticle,
+  combo: createComboParticle,
+  ambient: createAmbientParticle,
+  gameOver: createGameOverParticle,
+  levelUp: createLevelUpParticle,
+};
+
+// ── Particle Engine ───────────────────────────────────────────────
+
+const MAX_PARTICLES = 4000;
+
+export class ParticleEngine {
+  private particles: Particle[] = [];
+  private canvas: HTMLCanvasElement | null = null;
+  private ctx: CanvasRenderingContext2D | null = null;
+  private animFrame: number = 0;
+  private running = false;
+  private _screenShake = 0;
+  private _shakeIntensity = 0;
+
+  // Screen shake state (exposed for the board renderer)
+  get shakeX(): number {
+    if (this._screenShake <= 0) return 0;
+    return (Math.random() - 0.5) * this._shakeIntensity * (this._screenShake / 15);
+  }
+  get shakeY(): number {
+    if (this._screenShake <= 0) return 0;
+    return (Math.random() - 0.5) * this._shakeIntensity * (this._screenShake / 15);
+  }
+
+  attach(canvas: HTMLCanvasElement) {
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d', { alpha: true })!;
+    if (!this.running) {
+      this.running = true;
+      this.loop();
+    }
+  }
+
+  detach() {
+    this.running = false;
+    if (this.animFrame) cancelAnimationFrame(this.animFrame);
+    this.canvas = null;
+    this.ctx = null;
+    this.particles = [];
+  }
+
+  resize(width: number, height: number) {
+    if (!this.canvas) return;
+    const dpr = window.devicePixelRatio || 1;
+    this.canvas.width = width * dpr;
+    this.canvas.height = height * dpr;
+    this.canvas.style.width = `${width}px`;
+    this.canvas.style.height = `${height}px`;
+    this.ctx?.scale(dpr, dpr);
+  }
+
+  emit(config: EmitConfig) {
+    const factory = PRESET_FACTORIES[config.preset];
+    if (!factory) return;
+
+    const count = Math.min(
+      Math.floor(config.count * (config.intensity || 1)),
+      MAX_PARTICLES - this.particles.length,
+    );
+
+    const color = config.color || '#ffffff';
+
+    for (let i = 0; i < count; i++) {
+      const p = factory(config.x, config.y, color) as Particle;
+      // Apply spread/direction overrides
+      if (config.direction !== undefined && config.spread !== undefined) {
+        const angle = config.direction + rand(-config.spread / 2, config.spread / 2);
+        const speed = Math.sqrt(p.vx * p.vx + p.vy * p.vy);
+        p.vx = Math.cos(angle) * speed;
+        p.vy = Math.sin(angle) * speed;
+      }
+      this.particles.push(p);
+    }
+  }
+
+  shake(frames: number, intensity: number) {
+    this._screenShake = Math.max(this._screenShake, frames);
+    this._shakeIntensity = Math.max(this._shakeIntensity, intensity);
+  }
+
+  get particleCount() {
+    return this.particles.length;
+  }
+
+  private loop = () => {
+    if (!this.running) return;
+    this.update();
+    this.draw();
+    this.animFrame = requestAnimationFrame(this.loop);
+  };
+
+  private update() {
+    // Decrement screen shake
+    if (this._screenShake > 0) {
+      this._screenShake--;
+      if (this._screenShake <= 0) {
+        this._shakeIntensity = 0;
+      }
+    }
+
+    const alive: Particle[] = [];
+    for (const p of this.particles) {
+      p.life++;
+      if (p.life >= p.maxLife) continue;
+
+      // Physics
+      p.vy += p.gravity;
+      p.vx *= p.drag;
+      p.vy *= p.drag;
+
+      // Turbulence
+      if (p.turbulence > 0) {
+        p.vx += (Math.random() - 0.5) * p.turbulence;
+        p.vy += (Math.random() - 0.5) * p.turbulence;
+      }
+
+      p.x += p.vx;
+      p.y += p.vy;
+      p.rotation += p.rotationSpeed;
+
+      alive.push(p);
+    }
+    this.particles = alive;
+  }
+
+  private draw() {
+    const ctx = this.ctx;
+    const canvas = this.canvas;
+    if (!ctx || !canvas) return;
+
+    const w = canvas.style.width ? parseInt(canvas.style.width) : canvas.width;
+    const h = canvas.style.height ? parseInt(canvas.style.height) : canvas.height;
+
+    ctx.clearRect(0, 0, w, h);
+
+    // Use additive blending for glow effect
+    ctx.globalCompositeOperation = 'lighter';
+
+    for (const p of this.particles) {
+      const t = p.life / p.maxLife; // 0..1 normalized lifetime
+      const alpha = p.alpha * (1 - t * t); // quadratic fade
+      const size = lerp(p.size, p.sizeEnd, t);
+
+      if (alpha <= 0.01 || size <= 0.1) continue;
+
+      // Pulse
+      const pulseAlpha = p.pulse > 0
+        ? alpha * (0.7 + 0.3 * Math.sin(p.life * p.pulse * Math.PI * 2))
+        : alpha;
+
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rotation);
+      ctx.globalAlpha = pulseAlpha;
+
+      // Glow layer (larger, dimmer)
+      if (p.glow > 0) {
+        const glowSize = size * p.glow * 2;
+        const gradient = ctx.createRadialGradient(0, 0, 0, 0, 0, glowSize);
+        gradient.addColorStop(0, `rgba(${p.r},${p.g},${p.b},${pulseAlpha * 0.3})`);
+        gradient.addColorStop(1, `rgba(${p.r},${p.g},${p.b},0)`);
+        ctx.fillStyle = gradient;
+        ctx.fillRect(-glowSize, -glowSize, glowSize * 2, glowSize * 2);
+      }
+
+      ctx.fillStyle = `rgba(${p.r},${p.g},${p.b},${pulseAlpha})`;
+
+      switch (p.shape) {
+        case 'circle':
+          ctx.beginPath();
+          ctx.arc(0, 0, size, 0, Math.PI * 2);
+          ctx.fill();
+          break;
+
+        case 'square':
+          ctx.fillRect(-size, -size, size * 2, size * 2);
+          break;
+
+        case 'spark': {
+          // Elongated spark aligned to velocity direction
+          const len = size * 3;
+          ctx.beginPath();
+          ctx.moveTo(-len, 0);
+          ctx.lineTo(0, -size * 0.4);
+          ctx.lineTo(len, 0);
+          ctx.lineTo(0, size * 0.4);
+          ctx.closePath();
+          ctx.fill();
+          break;
+        }
+
+        case 'star': {
+          const spikes = 4;
+          const outerR = size;
+          const innerR = size * 0.4;
+          ctx.beginPath();
+          for (let i = 0; i < spikes * 2; i++) {
+            const angle = (i * Math.PI) / spikes - Math.PI / 2;
+            const r = i % 2 === 0 ? outerR : innerR;
+            if (i === 0) ctx.moveTo(Math.cos(angle) * r, Math.sin(angle) * r);
+            else ctx.lineTo(Math.cos(angle) * r, Math.sin(angle) * r);
+          }
+          ctx.closePath();
+          ctx.fill();
+          break;
+        }
+
+        case 'ring': {
+          ctx.beginPath();
+          ctx.arc(0, 0, size, 0, Math.PI * 2);
+          ctx.lineWidth = size * 0.3;
+          ctx.strokeStyle = `rgba(${p.r},${p.g},${p.b},${pulseAlpha})`;
+          ctx.stroke();
+          break;
+        }
+      }
+
+      ctx.restore();
+    }
+
+    // Reset composite operation
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.globalAlpha = 1;
+  }
+}
+
+// Singleton instance
+export const particleEngine = new ParticleEngine();

--- a/packages/pi-tetris-extension/ui/game/types.ts
+++ b/packages/pi-tetris-extension/ui/game/types.ts
@@ -1,0 +1,78 @@
+// Game constants, piece definitions, and in-memory types
+
+export const BOARD_ROWS = 20;
+export const BOARD_COLS = 10;
+export const CELL_SIZE = 28;
+
+export type PieceType = 'I' | 'O' | 'T' | 'S' | 'Z' | 'J' | 'L';
+
+export const PIECE_TYPES: PieceType[] = ['I', 'O', 'T', 'S', 'Z', 'J', 'L'];
+
+export const SHAPES: Record<PieceType, number[][]> = {
+  I: [
+    [0, 0, 0, 0],
+    [1, 1, 1, 1],
+    [0, 0, 0, 0],
+    [0, 0, 0, 0],
+  ],
+  O: [
+    [1, 1],
+    [1, 1],
+  ],
+  T: [
+    [0, 1, 0],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+  S: [
+    [0, 1, 1],
+    [1, 1, 0],
+    [0, 0, 0],
+  ],
+  Z: [
+    [1, 1, 0],
+    [0, 1, 1],
+    [0, 0, 0],
+  ],
+  J: [
+    [1, 0, 0],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+  L: [
+    [0, 0, 1],
+    [1, 1, 1],
+    [0, 0, 0],
+  ],
+};
+
+export const PIECE_COLORS: Record<PieceType, string> = {
+  I: '#00d4d4',
+  O: '#d4d400',
+  T: '#9b59b6',
+  S: '#2ecc71',
+  Z: '#e74c3c',
+  J: '#3498db',
+  L: '#e67e22',
+};
+
+export type Board = (PieceType | null)[][];
+
+export interface Piece {
+  type: PieceType;
+  shape: number[][];
+  row: number;
+  col: number;
+}
+
+export interface GameState {
+  board: Board;
+  currentPiece: Piece | null;
+  nextType: PieceType;
+  score: number;
+  level: number;
+  lines: number;
+  gameOver: boolean;
+  paused: boolean;
+  started: boolean;
+}

--- a/packages/pi-tetris-extension/ui/game/useGame.ts
+++ b/packages/pi-tetris-extension/ui/game/useGame.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import type { GameState } from './types';
+import { PIECE_COLORS, BOARD_COLS, type PieceType } from './types';
 import {
   createBoard,
   createPiece,
@@ -14,6 +15,18 @@ import {
   calculateScore,
   getSpeed,
 } from './engine';
+
+// ── Particle event types ──────────────────────────────────────────
+export interface ParticleEvent {
+  type: 'lineClear' | 'hardDrop' | 'pieceLock' | 'gameOver' | 'levelUp';
+  rows?: number[];           // cleared row indices
+  linesCleared?: number;     // how many lines
+  piece?: { type: PieceType; row: number; col: number; shape: number[][] };
+  combo?: number;            // consecutive clears
+  level?: number;
+}
+
+type ParticleEventCallback = (event: ParticleEvent) => void;
 
 function createInitialState(): GameState {
   return {
@@ -29,11 +42,21 @@ function createInitialState(): GameState {
   };
 }
 
-export function useGame() {
+export function useGame(
+  onParticleEvent?: ParticleEventCallback,
+  containerRef?: React.RefObject<HTMLElement | null>,
+) {
   const [state, setState] = useState<GameState>(createInitialState);
   const stateRef = useRef(state);
   stateRef.current = state;
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const comboRef = useRef(0);
+  const onParticleEventRef = useRef(onParticleEvent);
+  onParticleEventRef.current = onParticleEvent;
+
+  const emitEvent = useCallback((event: ParticleEvent) => {
+    onParticleEventRef.current?.(event);
+  }, []);
 
   const spawnPiece = useCallback((s: GameState): GameState => {
     const piece = createPiece(s.nextType);
@@ -46,12 +69,57 @@ export function useGame() {
   const lockPiece = useCallback(
     (s: GameState): GameState => {
       if (!s.currentPiece) return s;
+
+      // Emit piece lock event
+      emitEvent({
+        type: 'pieceLock',
+        piece: {
+          type: s.currentPiece.type,
+          row: s.currentPiece.row,
+          col: s.currentPiece.col,
+          shape: s.currentPiece.shape,
+        },
+      });
+
       const newBoard = placePiece(s.board, s.currentPiece);
-      const [clearedBoard, linesCleared] = clearLines(newBoard);
+      const [clearedBoard, linesCleared, clearedRows] = clearLines(newBoard);
       const newLines = s.lines + linesCleared;
       const newLevel = Math.floor(newLines / 10) + 1;
       const newScore = s.score + calculateScore(linesCleared, s.level);
-      return spawnPiece({
+
+      if (linesCleared > 0) {
+        comboRef.current++;
+
+        // Capture row colors before they're cleared for particle effects
+        const rowColors: string[][] = clearedRows.map((rowIdx) =>
+          newBoard[rowIdx].map((cell) => (cell ? PIECE_COLORS[cell] : '#ffffff')),
+        );
+
+        emitEvent({
+          type: 'lineClear',
+          rows: clearedRows,
+          linesCleared,
+          combo: comboRef.current,
+          piece: {
+            type: s.currentPiece.type,
+            row: s.currentPiece.row,
+            col: s.currentPiece.col,
+            shape: s.currentPiece.shape,
+          },
+        });
+
+        // Store row colors for the particle system to use
+        (emitEvent as any)._lastRowColors = rowColors;
+      } else {
+        comboRef.current = 0;
+      }
+
+      // Level up event
+      if (newLevel > s.level) {
+        emitEvent({ type: 'levelUp', level: newLevel });
+      }
+
+      const next = spawnPiece({
         ...s,
         board: clearedBoard,
         currentPiece: null,
@@ -59,8 +127,15 @@ export function useGame() {
         level: newLevel,
         lines: newLines,
       });
+
+      if (next.gameOver) {
+        emitEvent({ type: 'gameOver' });
+        comboRef.current = 0;
+      }
+
+      return next;
     },
-    [spawnPiece],
+    [spawnPiece, emitEvent],
   );
 
   const moveDown = useCallback(() => {
@@ -156,15 +231,28 @@ export function useGame() {
       if (!s.currentPiece || s.gameOver || s.paused) return s;
       const ghostRow = getGhostRow(s.board, s.currentPiece);
       const dropBonus = (ghostRow - s.currentPiece.row) * 2;
+
+      // Emit hard drop event
+      emitEvent({
+        type: 'hardDrop',
+        piece: {
+          type: s.currentPiece.type,
+          row: ghostRow,
+          col: s.currentPiece.col,
+          shape: s.currentPiece.shape,
+        },
+      });
+
       return lockPiece({
         ...s,
         currentPiece: { ...s.currentPiece, row: ghostRow },
         score: s.score + dropBonus,
       });
     });
-  }, [lockPiece]);
+  }, [lockPiece, emitEvent]);
 
   const start = useCallback(() => {
+    comboRef.current = 0;
     const initial = createInitialState();
     setState(spawnPiece({ ...initial, started: true }));
   }, [spawnPiece]);
@@ -190,17 +278,19 @@ export function useGame() {
     };
   }, [state.started, state.gameOver, state.paused, state.level, moveDown]);
 
-  // Keyboard controls
+  // Keyboard controls — scoped to container so they don't steal from other panels
   useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
+    const target = containerRef?.current ?? window;
+    const handleKey = (e: Event) => {
+      const ke = e as KeyboardEvent;
       if (
         ['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp', ' '].includes(
-          e.key,
+          ke.key,
         )
       ) {
-        e.preventDefault();
+        ke.preventDefault();
       }
-      switch (e.key) {
+      switch (ke.key) {
         case 'ArrowLeft':
           moveLeft();
           break;
@@ -225,9 +315,9 @@ export function useGame() {
           break;
       }
     };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [moveLeft, moveRight, moveDown, rotate, hardDrop, togglePause, start]);
+    target.addEventListener('keydown', handleKey);
+    return () => target.removeEventListener('keydown', handleKey);
+  }, [moveLeft, moveRight, moveDown, rotate, hardDrop, togglePause, start, containerRef]);
 
   const ghostRow = state.currentPiece
     ? getGhostRow(state.board, state.currentPiece)

--- a/packages/pi-tetris-extension/ui/game/useGame.ts
+++ b/packages/pi-tetris-extension/ui/game/useGame.ts
@@ -1,0 +1,237 @@
+// React hook managing Tetris game state and loop
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { GameState } from './types';
+import {
+  createBoard,
+  createPiece,
+  randomPieceType,
+  rotateShape,
+  isValidPosition,
+  placePiece,
+  clearLines,
+  getGhostRow,
+  calculateScore,
+  getSpeed,
+} from './engine';
+
+function createInitialState(): GameState {
+  return {
+    board: createBoard(),
+    currentPiece: null,
+    nextType: randomPieceType(),
+    score: 0,
+    level: 1,
+    lines: 0,
+    gameOver: false,
+    paused: false,
+    started: false,
+  };
+}
+
+export function useGame() {
+  const [state, setState] = useState<GameState>(createInitialState);
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const spawnPiece = useCallback((s: GameState): GameState => {
+    const piece = createPiece(s.nextType);
+    if (!isValidPosition(s.board, piece.shape, piece.row, piece.col)) {
+      return { ...s, gameOver: true, currentPiece: null };
+    }
+    return { ...s, currentPiece: piece, nextType: randomPieceType() };
+  }, []);
+
+  const lockPiece = useCallback(
+    (s: GameState): GameState => {
+      if (!s.currentPiece) return s;
+      const newBoard = placePiece(s.board, s.currentPiece);
+      const [clearedBoard, linesCleared] = clearLines(newBoard);
+      const newLines = s.lines + linesCleared;
+      const newLevel = Math.floor(newLines / 10) + 1;
+      const newScore = s.score + calculateScore(linesCleared, s.level);
+      return spawnPiece({
+        ...s,
+        board: clearedBoard,
+        currentPiece: null,
+        score: newScore,
+        level: newLevel,
+        lines: newLines,
+      });
+    },
+    [spawnPiece],
+  );
+
+  const moveDown = useCallback(() => {
+    setState((s) => {
+      if (!s.currentPiece || s.gameOver || s.paused) return s;
+      if (
+        isValidPosition(
+          s.board,
+          s.currentPiece.shape,
+          s.currentPiece.row + 1,
+          s.currentPiece.col,
+        )
+      ) {
+        return {
+          ...s,
+          currentPiece: { ...s.currentPiece, row: s.currentPiece.row + 1 },
+        };
+      }
+      return lockPiece(s);
+    });
+  }, [lockPiece]);
+
+  const moveLeft = useCallback(() => {
+    setState((s) => {
+      if (!s.currentPiece || s.gameOver || s.paused) return s;
+      if (
+        isValidPosition(
+          s.board,
+          s.currentPiece.shape,
+          s.currentPiece.row,
+          s.currentPiece.col - 1,
+        )
+      ) {
+        return {
+          ...s,
+          currentPiece: { ...s.currentPiece, col: s.currentPiece.col - 1 },
+        };
+      }
+      return s;
+    });
+  }, []);
+
+  const moveRight = useCallback(() => {
+    setState((s) => {
+      if (!s.currentPiece || s.gameOver || s.paused) return s;
+      if (
+        isValidPosition(
+          s.board,
+          s.currentPiece.shape,
+          s.currentPiece.row,
+          s.currentPiece.col + 1,
+        )
+      ) {
+        return {
+          ...s,
+          currentPiece: { ...s.currentPiece, col: s.currentPiece.col + 1 },
+        };
+      }
+      return s;
+    });
+  }, []);
+
+  const rotate = useCallback(() => {
+    setState((s) => {
+      if (!s.currentPiece || s.gameOver || s.paused) return s;
+      const newShape = rotateShape(s.currentPiece.shape);
+      const kicks = [0, -1, 1, -2, 2];
+      for (const kick of kicks) {
+        if (
+          isValidPosition(
+            s.board,
+            newShape,
+            s.currentPiece.row,
+            s.currentPiece.col + kick,
+          )
+        ) {
+          return {
+            ...s,
+            currentPiece: {
+              ...s.currentPiece,
+              shape: newShape,
+              col: s.currentPiece.col + kick,
+            },
+          };
+        }
+      }
+      return s;
+    });
+  }, []);
+
+  const hardDrop = useCallback(() => {
+    setState((s) => {
+      if (!s.currentPiece || s.gameOver || s.paused) return s;
+      const ghostRow = getGhostRow(s.board, s.currentPiece);
+      const dropBonus = (ghostRow - s.currentPiece.row) * 2;
+      return lockPiece({
+        ...s,
+        currentPiece: { ...s.currentPiece, row: ghostRow },
+        score: s.score + dropBonus,
+      });
+    });
+  }, [lockPiece]);
+
+  const start = useCallback(() => {
+    const initial = createInitialState();
+    setState(spawnPiece({ ...initial, started: true }));
+  }, [spawnPiece]);
+
+  const togglePause = useCallback(() => {
+    setState((s) => {
+      if (s.gameOver || !s.started) return s;
+      return { ...s, paused: !s.paused };
+    });
+  }, []);
+
+  // Game loop timer
+  useEffect(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+    if (state.started && !state.gameOver && !state.paused) {
+      timerRef.current = setInterval(moveDown, getSpeed(state.level));
+    }
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [state.started, state.gameOver, state.paused, state.level, moveDown]);
+
+  // Keyboard controls
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (
+        ['ArrowLeft', 'ArrowRight', 'ArrowDown', 'ArrowUp', ' '].includes(
+          e.key,
+        )
+      ) {
+        e.preventDefault();
+      }
+      switch (e.key) {
+        case 'ArrowLeft':
+          moveLeft();
+          break;
+        case 'ArrowRight':
+          moveRight();
+          break;
+        case 'ArrowDown':
+          moveDown();
+          break;
+        case 'ArrowUp':
+          rotate();
+          break;
+        case ' ':
+          hardDrop();
+          break;
+        case 'p':
+        case 'P':
+          togglePause();
+          break;
+        case 'Enter':
+          if (stateRef.current.gameOver || !stateRef.current.started) start();
+          break;
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [moveLeft, moveRight, moveDown, rotate, hardDrop, togglePause, start]);
+
+  const ghostRow = state.currentPiece
+    ? getGhostRow(state.board, state.currentPiece)
+    : 0;
+
+  return { ...state, ghostRow, start, togglePause };
+}

--- a/packages/pi-tetris-extension/ui/index.html
+++ b/packages/pi-tetris-extension/ui/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Sero Tetris (remote)</title></head>
+<body><div id="root"></div></body>
+</html>

--- a/packages/pi-tetris-extension/ui/tsconfig.json
+++ b/packages/pi-tetris-extension/ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero/app-runtime": ["../../app-runtime/src/index.ts"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-tetris-extension/vite.config.ts
+++ b/packages/pi-tetris-extension/vite.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_tetris',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './TetrisApp': './ui/TetrisApp.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5179,
+    strictPort: true,
+    origin: 'http://localhost:5179',
+  },
+  optimizeDeps: {
+    exclude: ['@sero/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,46 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/pi-tetris-extension:
+    dependencies:
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.52.0'
+        version: 0.52.12(ws@8.18.0)
+    devDependencies:
+      '@module-federation/vite':
+        specifier: ^1.11.0
+        version: 1.11.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@sero/app-runtime':
+        specifier: workspace:*
+        version: link:../app-runtime
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
   packages/pi-todo-extension:
     dependencies:
       '@mariozechner/pi-ai':
@@ -8529,6 +8569,18 @@ snapshots:
       - ws
       - zod
 
+  '@mariozechner/pi-agent-core@0.52.12(ws@8.18.0)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.52.12(ws@8.18.0)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-ai@0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
@@ -8577,6 +8629,30 @@ snapshots:
       - ws
       - zod
 
+  '@mariozechner/pi-ai@0.52.12(ws@8.18.0)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.990.0
+      '@google/genai': 1.41.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
+      '@mistralai/mistralai': 1.10.0
+      '@sinclair/typebox': 0.34.48
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      chalk: 5.6.2
+      openai: 6.10.0(ws@8.18.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.22.0
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-coding-agent@0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
@@ -8611,6 +8687,35 @@ snapshots:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai': 0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.52.12
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.3
+      file-type: 21.3.0
+      glob: 13.0.3
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.0
+      proper-lockfile: 4.1.2
+      yaml: 2.8.2
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.2
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-coding-agent@0.52.12(ws@8.18.0)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.52.12(ws@8.18.0)
+      '@mariozechner/pi-ai': 0.52.12(ws@8.18.0)
       '@mariozechner/pi-tui': 0.52.12
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2


### PR DESCRIPTION
## Summary

Adds a fully playable Tetris app as a Sero package, with particle effects, responsive layout, and proper keyboard scoping.

## Changes

### Tetris app (`packages/pi-tetris-extension/`)
- **Game engine** — pure logic (board, collision, rotation, line clears, scoring) in `game/engine.ts`
- **Game loop hook** — `useGame` manages state, tick interval, and keyboard input via a container-scoped ref
- **Particle system** — line clear explosions, hard drop sparks, ambient drift, combo popups, screen shake (`game/particles.ts`)
- **Responsive board** — `ResizeObserver` computes cell size dynamically to fill available height while maintaining the 10×20 aspect ratio
- **Scoped keyboard** — listeners attached to the game container (not `window`), so arrow keys / space / Enter don't steal input from ChatPanel or other panels
- **Persisted stats** — high score, games played, total lines via `useAppState`
- **Pi extension** — agent tool for querying game stats

### Documentation (`docs/apps-tutorial.md`)
- New **Keyboard events** convention — pattern for container-scoped listeners, `tabIndex`, auto-focus, focus redirection
- New **Responsive sizing** convention — `ResizeObserver` hook pattern for dynamic layout
- Two new **Troubleshooting** entries for keyboard conflicts and sizing issues
- Added Tetris as a **reference implementation** alongside Todo

## Testing
- Launch with `bash scripts/dev.sh`, click Tetris in sidebar
- Game fills available height and centres in the content area
- Keyboard works when game is focused; clicking into ChatPanel restores normal input
- Resizing sidebar/chat panel dynamically rescales the board