### PR TITLE
feat(desktop): add file references, path completion, and message queue to ChatPanel

### DIFF
--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -386,6 +386,26 @@ export function registerAgentHandlers(): void {
   );
 
   ipcMain.handle(
+    IpcChannels.agent.steer,
+    async (
+      _event,
+      sessionId: string,
+      text: string,
+      clientMessageId?: string,
+    ): Promise<void> => {
+      const entry = pool.get(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+
+      // Emit the user message so the renderer can show it immediately
+      const userMessageId = clientMessageId?.trim() || nextId();
+      const userMsg: ChatMessage = { type: 'user', id: userMessageId, text };
+      sendEvent({ type: 'message_start', sessionId, message: userMsg });
+
+      await entry.session.steer(text);
+    },
+  );
+
+  ipcMain.handle(
     IpcChannels.agent.abort,
     async (_event, sessionId: string): Promise<void> => {
       const entry = pool.get(sessionId);

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -105,6 +105,13 @@ contextBridge.exposeInMainWorld('sero', {
     ): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.agent.prompt, sessionId, text, attachments, clientMessageId),
 
+    steer: (
+      sessionId: string,
+      text: string,
+      clientMessageId?: string,
+    ): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.agent.steer, sessionId, text, clientMessageId),
+
     abort: (sessionId: string): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.agent.abort, sessionId),
 

--- a/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
+++ b/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/stores/terminal';
 import { useWorkspaceCodingUi, useCodingUiStore } from '@/stores/coding-ui';
 import { useVcsStore } from '@/stores/vcs';
+import { useEditorBridge } from '@/stores/editor-bridge';
 
 /**
  * CodingWorkspace — the full coding app, mounted into the main area.
@@ -165,6 +166,20 @@ export function CodingWorkspace() {
     },
     [workspaceId, activePanel, sidebarOpen, terminalOpen, termTabs.length, setCodingUi],
   );
+
+  // ── Editor bridge: open files from ChatPanel ctrl+click ──
+  useEffect(() => {
+    const unsub = useEditorBridge.subscribe((state) => {
+      if (state.pendingOpen?.workspaceId === workspaceId) {
+        const { filePath } = state.pendingOpen;
+        useEditorBridge.getState().consumeOpenRequest();
+        // Use the tab open logic below
+        setEditorTabs((prev) => (prev.includes(filePath) ? prev : [...prev, filePath]));
+        setActiveTab(filePath);
+      }
+    });
+    return unsub;
+  }, [workspaceId]);
 
   // ── Editor tab handlers ──
   const handleOpenTab = useCallback((path: string) => {

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -60,9 +60,12 @@ export function ChatPanel() {
   const focused = useFocusedAgent();
   const commands = useFocusedCommands();
   const sendPrompt = useAgentStore((s) => s.sendPrompt);
+  const steerAgent = useAgentStore((s) => s.steerAgent);
   const abort = useAgentStore((s) => s.abort);
   const initEventListener = useAgentStore((s) => s.initEventListener);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  /** Tracks whether Ctrl/Meta was held on the most recent submit gesture. */
+  const modifierRef = useRef(false);
 
   // Subscribe to main-process events on mount
   useEffect(() => {
@@ -206,6 +209,12 @@ export function ChatPanel() {
   // ── Tab path completion ────────────────────────────────────
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Capture modifier state on Enter so handleSubmit can distinguish
+      // steer (default) from followUp (Ctrl/Meta+Enter).
+      if (e.key === 'Enter' && !e.shiftKey) {
+        modifierRef.current = e.ctrlKey || e.metaKey;
+      }
+
       // Tab completion: complete partial path when Tab is pressed
       if (e.key === 'Tab' && !e.shiftKey && !slashMenuOpen && !fileMenuOpen) {
         // Check if the text before cursor contains a partial path (after @ or standalone)
@@ -263,15 +272,22 @@ export function ChatPanel() {
           }))
         : undefined;
 
-      // If agent is streaming, queue the message instead of sending immediately
+      // During streaming: Ctrl/Meta → queue as follow-up; default → steer
       if (isStreaming) {
-        messageQueue.enqueue(text, attachments);
+        const wantsFollowUp = modifierRef.current;
+        modifierRef.current = false;
+        if (wantsFollowUp) {
+          messageQueue.enqueue(text, attachments);
+        } else {
+          steerAgent(sessionId, text);
+        }
         return;
       }
 
+      modifierRef.current = false;
       sendPrompt(sessionId, text, attachments);
     },
-    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, messageQueue],
+    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, steerAgent, messageQueue],
   );
 
   const handleTranscript = useCallback((text: string) => {
@@ -466,6 +482,11 @@ export function ChatPanel() {
                     {messageQueue.queue.length} queued
                   </span>
                 )}
+                <PromptInputSubmit
+                  disabled={!input.trim() || !hasSession}
+                  onClick={(e) => { modifierRef.current = e.ctrlKey || e.metaKey; }}
+                  title="Send to steer agent (⌘+click to queue as follow-up)"
+                />
                 <button
                   onClick={() => sessionId && abort(sessionId)}
                   className="rounded-md bg-destructive/10 px-2 py-1 font-medium text-sm text-destructive hover:bg-destructive/20"

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -477,11 +477,6 @@ export function ChatPanel() {
 
             {isStreaming ? (
               <div className="flex items-center gap-1.5">
-                {messageQueue.hasQueued && (
-                  <span className="text-[10px] text-blue-500">
-                    {messageQueue.queue.length} queued
-                  </span>
-                )}
                 <PromptInputSubmit
                   disabled={!input.trim() || !hasSession}
                   onClick={(e) => { modifierRef.current = e.ctrlKey || e.metaKey; }}

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
-import { Bot, MessageSquare, Loader2, AlertCircle, Settings2, Brain } from 'lucide-react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { Bot, MessageSquare, Loader2, AlertCircle, Settings2, Brain, X } from 'lucide-react';
 import {
   Conversation,
   ConversationContent,
@@ -23,6 +23,7 @@ import {
 import { useAgentStore, useFocusedAgent, useFocusedCommands } from '@/stores/agent';
 import { useSessionStore } from '@/stores/sessions';
 import { SlashCommandMenu } from './SlashCommandMenu';
+import { FileReferenceMenu } from './FileReferenceMenu';
 import { PromptAttachmentsBar } from './ChatAttachments';
 import { UsageBadge } from './UsageBadge';
 import { ModelSelector } from './ModelSelector';
@@ -35,6 +36,10 @@ import { VoiceTranscriptionControl } from './VoiceTranscriptionControl';
 import { useContextEditorStore, useHasOverrides } from '@/stores/context-editor';
 import { useFeedbackStore } from '@/stores/feedback';
 import { useCheckpointRestore } from '@/hooks/useCheckpointRestore';
+import { useWorkspaceFiles, fuzzyMatchFiles } from '@/hooks/useWorkspaceFiles';
+import { useMessageQueue } from '@/hooks/useMessageQueue';
+import { useEditorBridge } from '@/stores/editor-bridge';
+import { createFilePathClickHandler } from './ClickableFilePath';
 import { cn } from '@sero/ui/lib/utils';
 import type { ChatAttachment, SeroSlashCommandInfo } from '@/types/ipc';
 
@@ -57,6 +62,7 @@ export function ChatPanel() {
   const sendPrompt = useAgentStore((s) => s.sendPrompt);
   const abort = useAgentStore((s) => s.abort);
   const initEventListener = useAgentStore((s) => s.initEventListener);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Subscribe to main-process events on mount
   useEffect(() => {
@@ -79,6 +85,26 @@ export function ChatPanel() {
   const sessionId = focused?.sessionId ?? null;
   const focusedWorkspaceId = focused?.workspaceId ?? null;
   const checkpoint = useCheckpointRestore(focusedWorkspaceId, sessionId);
+
+  // ── Workspace files for @ fuzzy search ─────────────────────
+  const { files: workspaceFiles } = useWorkspaceFiles(focusedWorkspaceId);
+
+  // ── Follow-up message queue ────────────────────────────────
+  const messageQueue = useMessageQueue({
+    isStreaming,
+    sessionId,
+    sendPrompt,
+  });
+
+  // ── Ctrl+click file paths in conversation ──────────────────
+  const requestOpenFile = useEditorBridge((s) => s.requestOpenFile);
+  const conversationClickHandler = useMemo(
+    () =>
+      focusedWorkspaceId
+        ? createFilePathClickHandler(focusedWorkspaceId, requestOpenFile)
+        : undefined,
+    [focusedWorkspaceId, requestOpenFile],
+  );
 
   // Resolve session name for the header badge
   const sessions = useSessionStore((s) => s.sessions);
@@ -151,12 +177,65 @@ export function ChatPanel() {
     setInput('');
   }, []);
 
+  // ── @ file reference menu state ────────────────────────────
+  // Match @<non-space-text> at the end of input — user is typing a file ref
+  const atMatch = useMemo(() => {
+    if (slashMenuOpen) return null;
+    const m = input.match(/@([^\s@]*)$/);
+    return m;
+  }, [input, slashMenuOpen]);
+
+  const fileMenuOpen = !!atMatch && !!sessionId;
+  const fileFilter = atMatch?.[1] ?? '';
+
+  const handleFileSelect = useCallback(
+    (filePath: string) => {
+      // Replace @<partial> with @<full_path> followed by a space
+      setInput((prev) => prev.replace(/@[^\s@]*$/, `@${filePath} `));
+      // Re-focus textarea
+      textareaRef.current?.focus();
+    },
+    [],
+  );
+
+  const handleFileMenuClose = useCallback(() => {
+    // Remove the dangling @ trigger
+    setInput((prev) => prev.replace(/@[^\s@]*$/, ''));
+  }, []);
+
+  // ── Tab path completion ────────────────────────────────────
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Tab completion: complete partial path when Tab is pressed
+      if (e.key === 'Tab' && !e.shiftKey && !slashMenuOpen && !fileMenuOpen) {
+        // Check if the text before cursor contains a partial path (after @ or standalone)
+        const cursorPos = e.currentTarget.selectionStart ?? input.length;
+        const textBefore = input.slice(0, cursorPos);
+        const pathMatch = textBefore.match(/@?([^\s@]+)$/);
+
+        if (pathMatch) {
+          const partial = pathMatch[1];
+          const matches = fuzzyMatchFiles(workspaceFiles, partial, 1);
+          if (matches.length > 0) {
+            e.preventDefault();
+            const completed = matches[0].path;
+            const prefix = textBefore.slice(0, textBefore.length - pathMatch[0].length);
+            const hasAt = pathMatch[0].startsWith('@');
+            const after = input.slice(cursorPos);
+            setInput(`${prefix}${hasAt ? '@' : ''}${completed}${after ? '' : ' '}${after}`);
+          }
+        }
+      }
+    },
+    [input, slashMenuOpen, fileMenuOpen, workspaceFiles],
+  );
+
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
       const text = (message.text ?? input).trim();
       if ((!text && !message.files?.length) || !sessionId) return;
-      // Don't submit if slash menu is open (Enter selects from menu instead)
-      if (slashMenuOpen) return;
+      // Don't submit if slash menu or file menu is open (Enter selects from menu)
+      if (slashMenuOpen || fileMenuOpen) return;
 
       // Intercept /login and /logout commands — handle client-side
       if (text === '/login' || text.startsWith('/login ')) {
@@ -184,9 +263,15 @@ export function ChatPanel() {
           }))
         : undefined;
 
+      // If agent is streaming, queue the message instead of sending immediately
+      if (isStreaming) {
+        messageQueue.enqueue(text, attachments);
+        return;
+      }
+
       sendPrompt(sessionId, text, attachments);
     },
-    [input, sessionId, slashMenuOpen, sendPrompt],
+    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, messageQueue],
   );
 
   const handleTranscript = useCallback((text: string) => {
@@ -221,7 +306,8 @@ export function ChatPanel() {
 
       {/* ── Conversation ────────────────────────────────────── */}
       <Conversation key={sessionId} className="min-h-0 flex-1" initial="instant">
-        <ConversationContent className="gap-4 p-3">
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+        <ConversationContent className="gap-4 p-3" onClick={conversationClickHandler}>
           {!hasSession ? (
             <EmptyState message="Select or create a chat to begin" />
           ) : messages.length === 0 && !isStreaming ? (
@@ -239,6 +325,7 @@ export function ChatPanel() {
                       key={item.id}
                       tools={item.tools}
                       isFinalized={isFinalized}
+                      workspaceId={focusedWorkspaceId}
                     />
                   );
                 }
@@ -298,22 +385,53 @@ export function ChatPanel() {
           open={slashMenuOpen}
         />
 
+        {/* @ file reference autocomplete menu */}
+        <FileReferenceMenu
+          files={workspaceFiles}
+          filter={fileFilter}
+          onSelect={handleFileSelect}
+          onClose={handleFileMenuClose}
+          open={fileMenuOpen}
+        />
+
         <PromptInput
           onSubmit={handleSubmit}
           className="w-full"
           multiple
           globalDrop={hasSession}
         >
-          {/* Queued attachments shown as inline badges above the textarea */}
+          {/* Queued attachments + queued follow-up messages */}
           <PromptInputHeader>
             <PromptAttachmentsBar />
+            {/* Follow-up message queue badges */}
+            {messageQueue.hasQueued && (
+              <div className="flex flex-wrap gap-1 px-1">
+                {messageQueue.queue.map((msg) => (
+                  <span
+                    key={msg.id}
+                    className="inline-flex items-center gap-1 rounded-full bg-blue-500/10 px-2 py-0.5 text-[11px] text-blue-600 dark:text-blue-400"
+                  >
+                    <span className="max-w-[150px] truncate">{msg.text}</span>
+                    <button
+                      onClick={() => messageQueue.dequeue(msg.id)}
+                      className="shrink-0 rounded-full p-0.5 hover:bg-blue-500/20"
+                      title="Remove queued message"
+                    >
+                      <X className="size-2.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
           </PromptInputHeader>
 
           <PromptInputBody>
             <PromptInputTextarea
+              ref={textareaRef}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder={hasSession ? 'Ask Sero anything… (/ for commands)' : 'Select a chat first…'}
+              onKeyDown={handleKeyDown}
+              placeholder={hasSession ? 'Ask Sero anything… (/ for commands, @ for files)' : 'Select a chat first…'}
               disabled={!hasSession}
             />
           </PromptInputBody>
@@ -342,12 +460,19 @@ export function ChatPanel() {
             </PromptInputTools>
 
             {isStreaming ? (
-              <button
-                onClick={() => sessionId && abort(sessionId)}
-                className="rounded-md bg-destructive/10 px-2 py-1 font-medium text-sm text-destructive hover:bg-destructive/20"
-              >
-                Stop
-              </button>
+              <div className="flex items-center gap-1.5">
+                {messageQueue.hasQueued && (
+                  <span className="text-[10px] text-blue-500">
+                    {messageQueue.queue.length} queued
+                  </span>
+                )}
+                <button
+                  onClick={() => sessionId && abort(sessionId)}
+                  className="rounded-md bg-destructive/10 px-2 py-1 font-medium text-sm text-destructive hover:bg-destructive/20"
+                >
+                  Stop
+                </button>
+              </div>
             ) : (
               <PromptInputSubmit disabled={!input.trim() || !hasSession} />
             )}

--- a/apps/desktop/src/components/layout/ClickableFilePath.tsx
+++ b/apps/desktop/src/components/layout/ClickableFilePath.tsx
@@ -1,0 +1,102 @@
+/**
+ * ClickableFilePath — renders a file path as a ctrl+clickable link.
+ *
+ * When ctrl+clicked (or cmd+clicked on macOS), opens the file in the
+ * code editor via the editor-bridge store.
+ */
+
+import { useCallback } from 'react';
+import { useEditorBridge } from '@/stores/editor-bridge';
+
+interface ClickableFilePathProps {
+  /** Relative file path to display. */
+  path: string;
+  /** Workspace ID for opening the file. */
+  workspaceId: string;
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+export function ClickableFilePath({
+  path,
+  workspaceId,
+  className,
+}: ClickableFilePathProps) {
+  const requestOpen = useEditorBridge((s) => s.requestOpenFile);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        // Normalize: ensure path starts with / for the editor
+        const filePath = path.startsWith('/') ? path : `/${path}`;
+        requestOpen(workspaceId, filePath);
+      }
+    },
+    [path, workspaceId, requestOpen],
+  );
+
+  return (
+    <span
+      onClick={handleClick}
+      className={`cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/40 underline-offset-2 hover:decoration-[var(--accent)] ${className ?? ''}`}
+      title="Ctrl+click to open in editor"
+    >
+      {path}
+    </span>
+  );
+}
+
+// ── Utility: detect file paths in tool call inputs/outputs ─────
+
+/**
+ * Regex to match file paths in text.
+ * Matches:
+ * - Absolute paths: /foo/bar/baz.ts
+ * - Relative paths: src/foo/bar.ts, ./foo/bar.ts
+ * - Paths with common extensions
+ */
+const FILE_PATH_RE =
+  /(?:^|[\s"'`([\]{,;:])((\.{0,2}\/)?(?:[\w.@-]+\/)*[\w.-]+\.[\w]+)/g;
+
+/**
+ * Check if a string looks like a file path.
+ */
+export function looksLikeFilePath(text: string): boolean {
+  // Must contain a dot (extension) or slash (directory separator)
+  if (!text.includes('/') && !text.includes('.')) return false;
+  // Must not be a URL
+  if (/^https?:\/\//.test(text)) return false;
+  // Must not be an email
+  if (text.includes('@') && !text.includes('/')) return false;
+  // Basic path pattern
+  return /^\.{0,2}\/|[\w.-]+\/[\w.-]+|[\w.-]+\.\w{1,10}$/.test(text);
+}
+
+/**
+ * Installs a delegated click handler on a container element that
+ * intercepts ctrl+clicks on file paths and opens them in the editor.
+ *
+ * Designed to be used with `useEffect` on a wrapper div around
+ * tool call or message content.
+ */
+export function createFilePathClickHandler(
+  workspaceId: string,
+  requestOpenFile: (workspaceId: string, filePath: string) => void,
+) {
+  return (e: React.MouseEvent) => {
+    if (!(e.ctrlKey || e.metaKey)) return;
+
+    const target = e.target as HTMLElement;
+    // Check if we clicked on text content that looks like a file path
+    const text = target.textContent?.trim() ?? '';
+
+    if (looksLikeFilePath(text)) {
+      e.preventDefault();
+      e.stopPropagation();
+      const filePath = text.startsWith('/') ? text : `/${text}`;
+      requestOpenFile(workspaceId, filePath);
+    }
+  };
+}

--- a/apps/desktop/src/components/layout/FileReferenceMenu.tsx
+++ b/apps/desktop/src/components/layout/FileReferenceMenu.tsx
@@ -1,0 +1,212 @@
+/**
+ * FileReferenceMenu — floating autocomplete for @file references.
+ *
+ * Appears above the chat input when the user types "@" followed by
+ * optional filter text.  Fuzzy-searches workspace files (excluding
+ * node_modules, .git, build dirs, etc.).
+ *
+ * Keyboard: ↑/↓ navigate, Enter/Tab selects, Escape dismisses.
+ */
+
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { FileIcon } from 'lucide-react';
+import { fuzzyMatchFiles, type FuzzyMatch } from '@/hooks/useWorkspaceFiles';
+
+// ── Types ──────────────────────────────────────────────────────
+
+interface FileReferenceMenuProps {
+  /** All available file paths (relative to workspace root). */
+  files: string[];
+  /** Current text after "@" for filtering. */
+  filter: string;
+  /** Called when a file is selected. Receives the relative path. */
+  onSelect: (filePath: string) => void;
+  /** Called when the menu should close (Escape). */
+  onClose: () => void;
+  /** Whether the menu is visible. */
+  open: boolean;
+}
+
+// ── Highlighted filename ──────────────────────────────────────
+
+function HighlightedPath({
+  path,
+  matchIndices,
+}: {
+  path: string;
+  matchIndices: number[];
+}) {
+  const indexSet = useMemo(() => new Set(matchIndices), [matchIndices]);
+
+  return (
+    <span className="min-w-0 truncate">
+      {path.split('').map((char, i) => (
+        <span
+          key={i}
+          className={indexSet.has(i) ? 'text-[var(--accent)] font-semibold' : undefined}
+        >
+          {char}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+// ── File extension icon color hint ────────────────────────────
+
+function fileIconColor(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase() ?? '';
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+      return 'text-blue-500';
+    case 'js':
+    case 'jsx':
+      return 'text-yellow-500';
+    case 'json':
+      return 'text-green-500';
+    case 'css':
+    case 'scss':
+      return 'text-purple-500';
+    case 'md':
+    case 'mdx':
+      return 'text-gray-400';
+    case 'py':
+      return 'text-emerald-500';
+    case 'rs':
+      return 'text-orange-500';
+    default:
+      return 'text-[var(--text-muted)]';
+  }
+}
+
+// ── Component ──────────────────────────────────────────────────
+
+export function FileReferenceMenu({
+  files,
+  filter,
+  onSelect,
+  onClose,
+  open,
+}: FileReferenceMenuProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+  // Fuzzy-match files against the filter
+  const matches: FuzzyMatch[] = useMemo(
+    () => fuzzyMatchFiles(files, filter, 20),
+    [files, filter],
+  );
+
+  // Reset selection when filter changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [filter]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const el = itemRefs.current.get(selectedIndex);
+    if (el) {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [selectedIndex]);
+
+  // Keyboard handler — attached to document when open
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!open || matches.length === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          e.stopPropagation();
+          setSelectedIndex((i) => (i + 1) % matches.length);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          e.stopPropagation();
+          setSelectedIndex((i) => (i - 1 + matches.length) % matches.length);
+          break;
+        case 'Enter':
+        case 'Tab':
+          e.preventDefault();
+          e.stopPropagation();
+          if (matches[selectedIndex]) {
+            onSelect(matches[selectedIndex].path);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          e.stopPropagation();
+          onClose();
+          break;
+      }
+    },
+    [open, matches, selectedIndex, onSelect, onClose],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    // Capture phase so we intercept before the textarea handles Enter/Escape
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [open, handleKeyDown]);
+
+  if (!open || matches.length === 0) return null;
+
+  return (
+    <div
+      ref={listRef}
+      className="absolute bottom-full left-0 right-0 z-50 mb-1 max-h-64 overflow-y-auto rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] shadow-lg"
+      role="listbox"
+    >
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-[var(--bg-surface)] px-2 py-1.5 text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        Files
+      </div>
+
+      {/* Items */}
+      {matches.map((match, idx) => {
+        const isSelected = idx === selectedIndex;
+        const filename = match.path.split('/').pop() ?? match.path;
+        const dir = match.path.includes('/')
+          ? match.path.slice(0, match.path.lastIndexOf('/'))
+          : '';
+
+        return (
+          <div
+            key={match.path}
+            ref={(el) => {
+              if (el) itemRefs.current.set(idx, el);
+              else itemRefs.current.delete(idx);
+            }}
+            role="option"
+            aria-selected={isSelected}
+            className={`flex cursor-pointer items-center gap-2 px-2 py-1.5 text-sm ${
+              isSelected
+                ? 'bg-accent text-accent-foreground'
+                : 'text-[var(--text-primary)] hover:bg-accent/50'
+            }`}
+            onMouseEnter={() => setSelectedIndex(idx)}
+            onMouseDown={(e) => {
+              e.preventDefault(); // Keep focus on textarea
+              onSelect(match.path);
+            }}
+          >
+            <FileIcon className={`size-3 shrink-0 ${fileIconColor(match.path)}`} />
+            <HighlightedPath
+              path={match.path}
+              matchIndices={match.matchIndices}
+            />
+            {dir && (
+              <span className="ml-auto shrink-0 truncate text-[10px] text-[var(--text-muted)]/60" style={{ maxWidth: '40%' }}>
+                {dir}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/FileReferenceMenu.tsx
+++ b/apps/desktop/src/components/layout/FileReferenceMenu.tsx
@@ -43,7 +43,7 @@ function HighlightedPath({
       {path.split('').map((char, i) => (
         <span
           key={i}
-          className={indexSet.has(i) ? 'text-[var(--accent)] font-semibold' : undefined}
+          className={indexSet.has(i) ? 'text-[var(--accent-code)] font-semibold' : undefined}
         >
           {char}
         </span>

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -20,6 +20,9 @@ import {
 import { useEditorBridge } from '@/stores/editor-bridge';
 import { looksLikeFilePath } from './ClickableFilePath';
 
+/** Tools whose summary arg is a real file path worth linking. */
+const FILE_PATH_TOOLS = new Set(['edit', 'read', 'write']);
+
 // ── Types ───────────────────────────────────────────────────────
 
 export type GroupedChatItem =
@@ -182,8 +185,8 @@ function ToolLine({
   }, [tool.input]);
 
   const isFilePath = useMemo(
-    () => !!summary && looksLikeFilePath(summary),
-    [summary],
+    () => !!summary && FILE_PATH_TOOLS.has(tool.toolName) && looksLikeFilePath(summary),
+    [summary, tool.toolName],
   );
 
   const handleSummaryClick = useCallback(
@@ -213,9 +216,9 @@ function ToolLine({
         <span
           onClick={handleSummaryClick}
           className={cn(
-            'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+            'min-w-0 truncate text-[11px] text-[var(--text-secondary)]',
             isFilePath && workspaceId &&
-              'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+              'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/60 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-primary)]',
           )}
           title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
         >
@@ -285,8 +288,8 @@ function SingleToolCall({
   }, [tool.input]);
 
   const isFilePath = useMemo(
-    () => !!summary && looksLikeFilePath(summary),
-    [summary],
+    () => !!summary && FILE_PATH_TOOLS.has(tool.toolName) && looksLikeFilePath(summary),
+    [summary, tool.toolName],
   );
 
   const handleSummaryClick = useCallback(
@@ -338,9 +341,9 @@ function SingleToolCall({
           <span
             onClick={handleSummaryClick}
             className={cn(
-              'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+              'min-w-0 truncate text-[11px] text-[var(--text-secondary)]',
               isFilePath && workspaceId &&
-                'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+                'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/60 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-primary)]',
             )}
             title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
           >
@@ -498,7 +501,7 @@ export function ToolCallGroup({
                         e.stopPropagation();
                         setShowDetails(true);
                       }}
-                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
                     >
                       Show full details
                     </button>
@@ -517,7 +520,7 @@ export function ToolCallGroup({
                         e.stopPropagation();
                         setShowDetails(false);
                       }}
-                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
                     >
                       Collapse details
                     </button>

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
   ChevronRight,
@@ -17,6 +17,8 @@ import {
   ToolInput,
   ToolOutput,
 } from '@sero/ui/components/ai-elements/tool';
+import { useEditorBridge } from '@/stores/editor-bridge';
+import { looksLikeFilePath } from './ClickableFilePath';
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -154,7 +156,17 @@ function toolStatusDot(state: ChatToolCallMessage['state']) {
   }
 }
 
-function ToolLine({ tool, index }: { tool: ChatToolCallMessage; index: number }) {
+function ToolLine({
+  tool,
+  index,
+  workspaceId,
+}: {
+  tool: ChatToolCallMessage;
+  index: number;
+  workspaceId: string | null;
+}) {
+  const requestOpenFile = useEditorBridge((s) => s.requestOpenFile);
+
   const summary = useMemo(() => {
     const inp = tool.input;
     // Try to build a short summary from common tool input shapes
@@ -169,6 +181,23 @@ function ToolLine({ tool, index }: { tool: ChatToolCallMessage; index: number })
     return typeof first === 'string' ? first : '';
   }, [tool.input]);
 
+  const isFilePath = useMemo(
+    () => !!summary && looksLikeFilePath(summary),
+    [summary],
+  );
+
+  const handleSummaryClick = useCallback(
+    (e: React.MouseEvent) => {
+      if ((e.ctrlKey || e.metaKey) && isFilePath && workspaceId) {
+        e.preventDefault();
+        e.stopPropagation();
+        const filePath = summary.startsWith('/') ? summary : `/${summary}`;
+        requestOpenFile(workspaceId, filePath);
+      }
+    },
+    [isFilePath, workspaceId, summary, requestOpenFile],
+  );
+
   return (
     <motion.div
       initial={{ opacity: 0, y: -4 }}
@@ -181,7 +210,15 @@ function ToolLine({ tool, index }: { tool: ChatToolCallMessage; index: number })
         {tool.toolName}
       </span>
       {summary && (
-        <span className="min-w-0 truncate text-[11px] text-[var(--text-muted)]/60">
+        <span
+          onClick={handleSummaryClick}
+          className={cn(
+            'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+            isFilePath && workspaceId &&
+              'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+          )}
+          title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
+        >
           {summary}
         </span>
       )}
@@ -221,7 +258,14 @@ function ToolDetail({ tool }: { tool: ChatToolCallMessage }) {
 
 // ── Single tool call (matches group wrapper style) ──────────────
 
-function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
+function SingleToolCall({
+  tool,
+  workspaceId,
+}: {
+  tool: ChatToolCallMessage;
+  workspaceId: string | null;
+}) {
+  const requestOpenFile = useEditorBridge((s) => s.requestOpenFile);
   const status = deriveGroupStatus([tool]);
   const isRunning = status === 'running';
   const isComplete = tool.state === 'completed' || tool.state === 'error';
@@ -239,6 +283,23 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
     const first = Object.values(inp).find((v) => typeof v === 'string');
     return typeof first === 'string' ? first : '';
   }, [tool.input]);
+
+  const isFilePath = useMemo(
+    () => !!summary && looksLikeFilePath(summary),
+    [summary],
+  );
+
+  const handleSummaryClick = useCallback(
+    (e: React.MouseEvent) => {
+      if ((e.ctrlKey || e.metaKey) && isFilePath && workspaceId) {
+        e.preventDefault();
+        e.stopPropagation();
+        const filePath = summary.startsWith('/') ? summary : `/${summary}`;
+        requestOpenFile(workspaceId, filePath);
+      }
+    },
+    [isFilePath, workspaceId, summary, requestOpenFile],
+  );
 
   return (
     <motion.div
@@ -274,7 +335,15 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
           {tool.toolName}
         </span>
         {summary && (
-          <span className="min-w-0 truncate text-[11px] text-[var(--text-muted)]/60">
+          <span
+            onClick={handleSummaryClick}
+            className={cn(
+              'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+              isFilePath && workspaceId &&
+                'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+            )}
+            title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
+          >
             {summary}
           </span>
         )}
@@ -317,13 +386,16 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
  * @param tools       — tool messages in this group
  * @param isFinalized — true when no more tools will be added to this group
  *                      (a non-tool message follows it, or the session stopped streaming)
+ * @param workspaceId — workspace ID for ctrl+click file path support
  */
 export function ToolCallGroup({
   tools,
   isFinalized = true,
+  workspaceId = null,
 }: {
   tools: ChatToolCallMessage[];
   isFinalized?: boolean;
+  workspaceId?: string | null;
 }) {
   const status = deriveGroupStatus(tools);
   const isRunning = status === 'running';
@@ -360,7 +432,7 @@ export function ToolCallGroup({
 
   // Single tool: render with matching group-style wrapper
   if (tools.length === 1) {
-    return <SingleToolCall tool={tools[0]} />;
+    return <SingleToolCall tool={tools[0]} workspaceId={workspaceId} />;
   }
 
   return (
@@ -417,7 +489,7 @@ export function ToolCallGroup({
                 <>
                   <div className="py-1">
                     {tools.map((tool, i) => (
-                      <ToolLine key={tool.id} tool={tool} index={i} />
+                      <ToolLine key={tool.id} tool={tool} index={i} workspaceId={workspaceId} />
                     ))}
                   </div>
                   <div className="border-t border-[var(--border-subtle)]/60 px-3 py-1.5">

--- a/apps/desktop/src/hooks/useMessageQueue.ts
+++ b/apps/desktop/src/hooks/useMessageQueue.ts
@@ -1,0 +1,81 @@
+/**
+ * useMessageQueue — manages a follow-up message queue for the ChatPanel.
+ *
+ * When the agent is streaming, additional messages are queued instead of
+ * being sent immediately.  When streaming ends, the next queued message
+ * is automatically sent (dequeued).
+ *
+ * The user can:
+ * - Queue a message while the agent is busy
+ * - Remove a queued message before it's sent
+ * - Edit a queued message (remove + re-queue)
+ * - "Steer" the agent by queueing an interruption message
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { ChatAttachment } from '@/types/ipc';
+
+export interface QueuedMessage {
+  id: string;
+  text: string;
+  attachments?: ChatAttachment[];
+}
+
+interface UseMessageQueueOptions {
+  /** Whether the agent is currently streaming. */
+  isStreaming: boolean;
+  /** The session ID to send to. */
+  sessionId: string | null;
+  /** The send function to call when dequeuing. */
+  sendPrompt: (sessionId: string, text: string, attachments?: ChatAttachment[]) => void;
+}
+
+export function useMessageQueue({
+  isStreaming,
+  sessionId,
+  sendPrompt,
+}: UseMessageQueueOptions) {
+  const [queue, setQueue] = useState<QueuedMessage[]>([]);
+  const prevStreamingRef = useRef(isStreaming);
+
+  /** Add a message to the queue. */
+  const enqueue = useCallback((text: string, attachments?: ChatAttachment[]) => {
+    const id = `q-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    setQueue((prev) => [...prev, { id, text, attachments }]);
+  }, []);
+
+  /** Remove a queued message by ID. */
+  const dequeue = useCallback((id: string) => {
+    setQueue((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  /** Clear all queued messages. */
+  const clearQueue = useCallback(() => {
+    setQueue([]);
+  }, []);
+
+  // Auto-send the next queued message when streaming stops.
+  useEffect(() => {
+    if (prevStreamingRef.current && !isStreaming && sessionId) {
+      // Streaming just stopped — send next queued message
+      setQueue((prev) => {
+        if (prev.length === 0) return prev;
+        const [next, ...rest] = prev;
+        // Schedule the send asynchronously to avoid state update conflicts
+        setTimeout(() => {
+          sendPrompt(sessionId, next.text, next.attachments);
+        }, 100);
+        return rest;
+      });
+    }
+    prevStreamingRef.current = isStreaming;
+  }, [isStreaming, sessionId, sendPrompt]);
+
+  return {
+    queue,
+    enqueue,
+    dequeue,
+    clearQueue,
+    hasQueued: queue.length > 0,
+  };
+}

--- a/apps/desktop/src/hooks/useWorkspaceFiles.ts
+++ b/apps/desktop/src/hooks/useWorkspaceFiles.ts
@@ -24,6 +24,7 @@ const EXCLUDED_DIRS = [
   '.jj',
   '.svn',
   '.hg',
+  '.DS_Store',
 ];
 
 /** Max files to return (safety cap). */

--- a/apps/desktop/src/hooks/useWorkspaceFiles.ts
+++ b/apps/desktop/src/hooks/useWorkspaceFiles.ts
@@ -1,0 +1,168 @@
+/**
+ * useWorkspaceFiles — fetches and caches the list of project files
+ * for a workspace, excluding common build / dependency directories.
+ *
+ * Used by the FileReferenceMenu (@-mention) and Tab path completion.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+/** Directories excluded from file search results. */
+const EXCLUDED_DIRS = [
+  'node_modules',
+  '.git',
+  '.turbo',
+  'dist',
+  'build',
+  '.next',
+  '.cache',
+  '.output',
+  'coverage',
+  '__pycache__',
+  '.venv',
+  'target',
+  '.jj',
+  '.svn',
+  '.hg',
+];
+
+/** Max files to return (safety cap). */
+const MAX_FILES = 5000;
+
+/** Simple in-memory cache keyed by workspaceId. */
+const cache = new Map<string, { files: string[]; ts: number }>();
+const CACHE_TTL_MS = 30_000; // 30 seconds
+
+export function useWorkspaceFiles(workspaceId: string | null) {
+  const [files, setFiles] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef(0);
+
+  const loadFiles = useCallback(async () => {
+    if (!workspaceId) {
+      setFiles([]);
+      return;
+    }
+
+    // Check cache
+    const cached = cache.get(workspaceId);
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+      setFiles(cached.files);
+      return;
+    }
+
+    const gen = ++abortRef.current;
+    setIsLoading(true);
+    try {
+      const pruneArgs = EXCLUDED_DIRS.map(
+        (d) => `-name '${d}' -prune`
+      ).join(' -o ');
+
+      const cmd = `find . \\( ${pruneArgs} \\) -o -type f -print | head -${MAX_FILES} | sort`;
+      const { stdout } = await window.sero.editor.exec(workspaceId, cmd);
+
+      if (gen !== abortRef.current) return; // stale
+
+      const paths = stdout
+        .split('\n')
+        .filter(Boolean)
+        .map((p) => (p.startsWith('./') ? p.slice(2) : p));
+
+      cache.set(workspaceId, { files: paths, ts: Date.now() });
+      setFiles(paths);
+    } catch (err) {
+      console.warn('[useWorkspaceFiles] Failed to load files:', err);
+      if (gen === abortRef.current) setFiles([]);
+    }
+    if (gen === abortRef.current) setIsLoading(false);
+  }, [workspaceId]);
+
+  useEffect(() => {
+    loadFiles();
+  }, [loadFiles]);
+
+  return { files, isLoading, refresh: loadFiles };
+}
+
+// ── Fuzzy matching ──────────────────────────────────────────────
+
+export interface FuzzyMatch {
+  path: string;
+  score: number;
+  /** Character indices in the path that matched the query. */
+  matchIndices: number[];
+}
+
+/**
+ * Fuzzy-match a query against a list of file paths.
+ * Returns up to `limit` results sorted by best score.
+ */
+export function fuzzyMatchFiles(
+  files: string[],
+  query: string,
+  limit = 20,
+): FuzzyMatch[] {
+  if (!query) {
+    // No query — return first `limit` files
+    return files.slice(0, limit).map((path) => ({
+      path,
+      score: 0,
+      matchIndices: [],
+    }));
+  }
+
+  const lowerQuery = query.toLowerCase();
+  const results: FuzzyMatch[] = [];
+
+  for (const path of files) {
+    const result = scorePath(path, lowerQuery);
+    if (result) results.push(result);
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, limit);
+}
+
+function scorePath(
+  path: string,
+  lowerQuery: string,
+): FuzzyMatch | null {
+  const lowerPath = path.toLowerCase();
+  const matchIndices: number[] = [];
+  let score = 0;
+  let qi = 0;
+
+  for (let pi = 0; pi < lowerPath.length && qi < lowerQuery.length; pi++) {
+    if (lowerPath[pi] === lowerQuery[qi]) {
+      matchIndices.push(pi);
+
+      // Bonus for matching at word boundaries
+      if (pi === 0 || '/._-'.includes(lowerPath[pi - 1])) {
+        score += 10;
+      }
+
+      // Bonus for consecutive matches
+      if (matchIndices.length > 1 && matchIndices[matchIndices.length - 2] === pi - 1) {
+        score += 5;
+      }
+
+      // Base match score
+      score += 1;
+      qi++;
+    }
+  }
+
+  // All query chars must match
+  if (qi < lowerQuery.length) return null;
+
+  // Bonus for filename match (last segment)
+  const filename = path.split('/').pop() ?? path;
+  if (filename.toLowerCase().includes(lowerQuery)) {
+    score += 20;
+  }
+
+  // Penalize longer paths slightly
+  score -= path.length * 0.1;
+
+  return { path, score, matchIndices };
+}

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -62,6 +62,8 @@ interface AgentState {
   closeSession: (sessionId: string) => Promise<void>;
   /** Send a prompt to a specific session, optionally with file attachments. */
   sendPrompt: (sessionId: string, text: string, attachments?: ChatAttachment[]) => Promise<void>;
+  /** Steer the agent mid-stream (interrupt after current tool, skip remaining). */
+  steerAgent: (sessionId: string, text: string) => Promise<void>;
   /** Abort a specific session. */
   abort: (sessionId: string) => Promise<void>;
   /** Focus a session in the ChatPanel. */
@@ -212,6 +214,38 @@ export const useAgentStore = create<AgentState>((set, get) => ({
             error: message,
             isStreaming: false,
           },
+        },
+      }));
+    }
+  },
+
+  steerAgent: async (sessionId, text) => {
+    const agent = get().agents[sessionId];
+    if (!agent) return;
+
+    // Optimistically add the user message (same as sendPrompt).
+    const userMessageId = `usr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const userMsg: ChatMessage = { type: 'user', id: userMessageId, text };
+    set((s) => ({
+      agents: {
+        ...s.agents,
+        [sessionId]: {
+          ...s.agents[sessionId],
+          error: null,
+          messages: [...s.agents[sessionId].messages, userMsg],
+        },
+      },
+    }));
+
+    try {
+      await window.sero.agent.steer(sessionId, text, userMessageId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Steer failed';
+      console.error('[agent] steerAgent failed:', err);
+      set((s) => ({
+        agents: {
+          ...s.agents,
+          [sessionId]: { ...s.agents[sessionId], error: message },
         },
       }));
     }

--- a/apps/desktop/src/stores/editor-bridge.ts
+++ b/apps/desktop/src/stores/editor-bridge.ts
@@ -1,0 +1,32 @@
+/**
+ * Editor bridge — lightweight event bus for "open file in editor" requests.
+ *
+ * Used by the ChatPanel / ToolCallGroup to request that the CodingWorkspace
+ * opens a specific file tab.  CodingWorkspace subscribes and handles the event.
+ */
+
+import { create } from 'zustand';
+
+interface EditorBridgeState {
+  /** Pending file-open request. Consumed by CodingWorkspace on the next tick. */
+  pendingOpen: { workspaceId: string; filePath: string } | null;
+
+  /** Request the editor to open a file. */
+  requestOpenFile: (workspaceId: string, filePath: string) => void;
+
+  /** Consume (and clear) the pending request. Returns it, or null. */
+  consumeOpenRequest: () => { workspaceId: string; filePath: string } | null;
+}
+
+export const useEditorBridge = create<EditorBridgeState>((set, get) => ({
+  pendingOpen: null,
+
+  requestOpenFile: (workspaceId, filePath) =>
+    set({ pendingOpen: { workspaceId, filePath } }),
+
+  consumeOpenRequest: () => {
+    const pending = get().pendingOpen;
+    if (pending) set({ pendingOpen: null });
+    return pending;
+  },
+}));

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -79,6 +79,8 @@ interface SeroAgentAPI {
   open(sessionId: string, sessionPath: string, workspaceId: string): Promise<ChatMessage[]>;
   /** Send a prompt to a specific session, optionally with file attachments. */
   prompt(sessionId: string, text: string, attachments?: ChatAttachment[], clientMessageId?: string): Promise<void>;
+  /** Steer the agent mid-stream: delivered after the current tool, skips remaining tools in the turn. */
+  steer(sessionId: string, text: string, clientMessageId?: string): Promise<void>;
   /** Abort a specific session's current operation. */
   abort(sessionId: string): Promise<void>;
   /** Close a specific session and dispose its AgentSession. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -30,6 +30,8 @@ export const IpcChannels = {
   agent: {
     open: 'sero:agent:open',
     prompt: 'sero:agent:prompt',
+    /** Steer the agent mid-stream (interrupt after current tool, skip remaining). */
+    steer: 'sero:agent:steer',
     abort: 'sero:agent:abort',
     close: 'sero:agent:close',
     /** Get available slash commands for a session. */


### PR DESCRIPTION
- Add @ fuzzy-search: type @ in chat input to fuzzy-search project files
  (excludes node_modules, .git, .turbo, and other build directories)
- Add Tab path completion: press Tab to complete partial file paths
- Add follow-up message queue: messages submitted while agent is streaming
  are queued and auto-sent when streaming ends, with removable badge UI
- Add Ctrl+click file paths: ctrl+click on file paths in chat messages
  and ToolCallGroup summaries to open them in the code editor
- Create editor-bridge store for cross-component file open communication
- Wire CodingWorkspace to consume editor-bridge open requests

https://claude.ai/code/session_01V3C1R1r6udydePVzPwzPoF