### PR TITLE
feat: add ImageGen Sero app — Gemini Nano Banana image generation

### DIFF
--- a/apps/desktop/electron/agents/image-agent.ts
+++ b/apps/desktop/electron/agents/image-agent.ts
@@ -1,0 +1,152 @@
+/**
+ * Image generation agent — uses Pi SDK auth + @google/genai for Gemini image generation.
+ *
+ * Supports two Nano Banana models:
+ *   - gemini-2.5-flash-image  (Nano Banana — fast / efficient)
+ *   - gemini-3-pro-image-preview (Nano Banana Pro — high-fidelity)
+ *
+ * Uses the same @google/genai client that the Pi SDK uses internally,
+ * with auth resolved through Pi's AuthStorage.
+ */
+
+import { GoogleGenAI } from '@google/genai';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import { ensureInfra } from '../ipc/shared-infra';
+
+// ── Types (mirrored from shared/types.ts to avoid cross-package import) ──
+
+export type ImageModel = 'gemini-2.5-flash-image' | 'gemini-3-pro-image-preview';
+export type AspectRatio = '1:1' | '2:3' | '3:2' | '3:4' | '4:3' | '9:16' | '16:9';
+
+export interface ImageGenParams {
+  prompt: string;
+  model: ImageModel;
+  variations: number;
+  aspectRatio: AspectRatio;
+  negativePrompt?: string;
+}
+
+export interface GeneratedImageResult {
+  id: string;
+  filePath: string;
+  mimeType: string;
+}
+
+export interface ImageGenResult {
+  images: GeneratedImageResult[];
+  error?: string;
+}
+
+// ── Auth providers to try in order ──
+
+const AUTH_PROVIDERS = ['google-gemini-cli', 'google', 'google-vertex'] as const;
+
+async function resolveApiKey(): Promise<string> {
+  // 1. Prefer GEMINI_API_KEY env var — it's a real API key that works
+  //    with the standard generativelanguage.googleapis.com endpoint.
+  //    OAuth tokens (google-gemini-cli) target Cloud Code Assist and
+  //    are rejected by the standard endpoint as invalid API keys.
+  const envKey = process.env.GEMINI_API_KEY;
+  if (envKey) return envKey;
+
+  // 2. Try Pi SDK auth providers (API-key-based ones like 'google')
+  try {
+    const infra = await ensureInfra();
+    for (const provider of AUTH_PROVIDERS) {
+      const key = await infra.authStorage.getApiKey(provider);
+      if (key) return key;
+    }
+  } catch {
+    // Swallow — no providers available
+  }
+
+  throw new Error(
+    'No Google API key found. Set GEMINI_API_KEY or add a Google API key via /login.',
+  );
+}
+
+// ── Core generation ──
+
+export async function generateImages(
+  params: ImageGenParams,
+  imagesDir: string,
+): Promise<ImageGenResult> {
+  const apiKey = await resolveApiKey();
+  const client = new GoogleGenAI({ apiKey });
+
+  await fs.mkdir(imagesDir, { recursive: true });
+
+  const count = Math.min(Math.max(params.variations, 1), 4);
+  const results: GeneratedImageResult[] = [];
+  const errors: string[] = [];
+
+  // Run variations in parallel
+  const jobs = Array.from({ length: count }, async (_, i) => {
+    try {
+      const response = await client.models.generateContent({
+        model: params.model,
+        contents: [{ parts: [{ text: buildPrompt(params) }] }],
+        config: {
+          responseModalities: ['IMAGE', 'TEXT'],
+          imageConfig: {
+            aspectRatio: params.aspectRatio,
+          },
+        },
+      });
+
+      // Extract image data from response
+      const parts = response.candidates?.[0]?.content?.parts ?? [];
+      for (const part of parts) {
+        if (part.inlineData?.data) {
+          const ext = mimeToExt(part.inlineData.mimeType ?? 'image/png');
+          const id = crypto.randomUUID();
+          const fileName = `${id}.${ext}`;
+          const filePath = path.join(imagesDir, fileName);
+
+          await fs.writeFile(filePath, Buffer.from(part.inlineData.data, 'base64'));
+
+          results.push({
+            id,
+            filePath,
+            mimeType: part.inlineData.mimeType ?? 'image/png',
+          });
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[image-agent] Variation ${i + 1} failed:`, msg);
+      errors.push(msg);
+    }
+  });
+
+  await Promise.all(jobs);
+
+  if (results.length === 0 && errors.length > 0) {
+    return { images: [], error: errors[0] };
+  }
+
+  return { images: results, error: errors.length > 0 ? errors.join('; ') : undefined };
+}
+
+function buildPrompt(params: ImageGenParams): string {
+  let prompt = params.prompt;
+  if (params.negativePrompt) {
+    prompt += `\n\nAvoid: ${params.negativePrompt}`;
+  }
+  return prompt;
+}
+
+function mimeToExt(mime: string): string {
+  if (mime.includes('jpeg') || mime.includes('jpg')) return 'jpg';
+  if (mime.includes('webp')) return 'webp';
+  return 'png';
+}
+
+// ── Expose on globalThis for extension bridge ──
+
+export function exposeImageAgent(): void {
+  (globalThis as any).__seroImageGen = generateImages;
+}

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -386,6 +386,26 @@ export function registerAgentHandlers(): void {
   );
 
   ipcMain.handle(
+    IpcChannels.agent.steer,
+    async (
+      _event,
+      sessionId: string,
+      text: string,
+      clientMessageId?: string,
+    ): Promise<void> => {
+      const entry = pool.get(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+
+      // Emit the user message so the renderer can show it immediately
+      const userMessageId = clientMessageId?.trim() || nextId();
+      const userMsg: ChatMessage = { type: 'user', id: userMessageId, text };
+      sendEvent({ type: 'message_start', sessionId, message: userMsg });
+
+      await entry.session.steer(text);
+    },
+  );
+
+  ipcMain.handle(
     IpcChannels.agent.abort,
     async (_event, sessionId: string): Promise<void> => {
       const entry = pool.get(sessionId);

--- a/apps/desktop/electron/ipc/imagegen.ts
+++ b/apps/desktop/electron/ipc/imagegen.ts
@@ -1,0 +1,107 @@
+/**
+ * ImageGen IPC handlers — direct image generation + file reading from renderer.
+ *
+ * Two channels:
+ *   sero:imagegen:generate  — generate images via the image agent
+ *   sero:imagegen:read-image — read a saved image as a data URI
+ */
+
+import { ipcMain } from 'electron';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { IpcChannels } from '../../src/types/ipc';
+import { workspaceManager } from '../workspace';
+import {
+  generateImages,
+  exposeImageAgent,
+  type ImageGenParams,
+  type ImageGenResult,
+} from '../agents/image-agent';
+
+// ── State file helpers ──
+
+const STATE_REL = path.join('.sero', 'apps', 'imagegen', 'state.json');
+const IMAGES_REL = path.join('.sero', 'apps', 'imagegen', 'images');
+
+interface ImageGenState {
+  generations: any[];
+  nextId: number;
+}
+
+async function readState(statePath: string): Promise<ImageGenState> {
+  try {
+    const raw = await fs.readFile(statePath, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { generations: [], nextId: 1 };
+  }
+}
+
+async function writeState(statePath: string, state: ImageGenState): Promise<void> {
+  const dir = path.dirname(statePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = `${statePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmp, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmp, statePath);
+}
+
+// ── Registration ──
+
+export function registerImagegenHandlers(): void {
+  // Expose the image agent on globalThis for extension bridge
+  exposeImageAgent();
+
+  ipcMain.handle(
+    IpcChannels.imagegen.generate,
+    async (
+      _event,
+      workspaceId: string,
+      params: ImageGenParams,
+    ): Promise<{ generation: any; error?: string }> => {
+      const wsPath = workspaceManager.getPath(workspaceId);
+      if (!wsPath) throw new Error('No workspace path');
+
+      const imagesDir = path.join(wsPath, IMAGES_REL);
+      const statePath = path.join(wsPath, STATE_REL);
+
+      const result: ImageGenResult = await generateImages(params, imagesDir);
+
+      if (result.images.length === 0) {
+        return { generation: null, error: result.error ?? 'No images generated' };
+      }
+
+      // Build generation record and persist to state
+      const state = await readState(statePath);
+      const generation = {
+        id: state.nextId,
+        prompt: params.prompt,
+        negativePrompt: params.negativePrompt,
+        model: params.model,
+        aspectRatio: params.aspectRatio,
+        images: result.images,
+        createdAt: new Date().toISOString(),
+      };
+      state.generations.unshift(generation);
+      state.nextId++;
+      await writeState(statePath, state);
+
+      return { generation, error: result.error };
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.imagegen.readImage,
+    async (_event, filePath: string): Promise<string> => {
+      const data = await fs.readFile(filePath);
+      const ext = path.extname(filePath).slice(1).toLowerCase();
+      const mime =
+        ext === 'jpg' || ext === 'jpeg'
+          ? 'image/jpeg'
+          : ext === 'webp'
+            ? 'image/webp'
+            : 'image/png';
+      return `data:${mime};base64,${data.toString('base64')}`;
+    },
+  );
+}

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -27,6 +27,7 @@ import { registerContextPresetsHandlers } from './context-presets';
 import { registerVcsHandlers } from './vcs';
 import { registerGitHubHandlers } from './github';
 import { registerFeedbackHandlers } from './feedback';
+import { registerImagegenHandlers } from './imagegen';
 
 export function registerAllIpcHandlers(): void {
   registerWorkspaceHandlers();
@@ -50,4 +51,5 @@ export function registerAllIpcHandlers(): void {
   registerVcsHandlers();
   registerGitHubHandlers();
   registerFeedbackHandlers();
+  registerImagegenHandlers();
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -210,6 +210,13 @@ contextBridge.exposeInMainWorld('sero', {
       ipcRenderer.invoke(IpcChannels.appAgent.prompt, appId, workspaceId, text),
   },
 
+  imagegen: {
+    generate: (workspaceId: string, params: any): Promise<any> =>
+      ipcRenderer.invoke(IpcChannels.imagegen.generate, workspaceId, params),
+    readImage: (filePath: string): Promise<string> =>
+      ipcRenderer.invoke(IpcChannels.imagegen.readImage, filePath),
+  },
+
   voice: {
     status: (): Promise<VoiceTranscriptionStatus> =>
       ipcRenderer.invoke(IpcChannels.voice.status),

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -105,6 +105,13 @@ contextBridge.exposeInMainWorld('sero', {
     ): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.agent.prompt, sessionId, text, attachments, clientMessageId),
 
+    steer: (
+      sessionId: string,
+      text: string,
+      clientMessageId?: string,
+    ): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.agent.steer, sessionId, text, clientMessageId),
+
     abort: (sessionId: string): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.agent.abort, sessionId),
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",
+    "@google/genai": "^1.41.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/apps/desktop/scripts/build-electron.mjs
+++ b/apps/desktop/scripts/build-electron.mjs
@@ -11,7 +11,7 @@ const shared = {
   format: 'esm',
   bundle: true,
   sourcemap: true,
-  external: ['electron', 'node-pty', '@mariozechner/*', '@sinclair/typebox'],
+  external: ['electron', 'node-pty', '@mariozechner/*', '@sinclair/typebox', '@google/genai'],
   outdir: 'dist/electron',
   logLevel: 'info',
   // Keep import.meta.url working for ESM dependencies (pi SDK)

--- a/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
+++ b/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/stores/terminal';
 import { useWorkspaceCodingUi, useCodingUiStore } from '@/stores/coding-ui';
 import { useVcsStore } from '@/stores/vcs';
+import { useEditorBridge } from '@/stores/editor-bridge';
 
 /**
  * CodingWorkspace — the full coding app, mounted into the main area.
@@ -165,6 +166,20 @@ export function CodingWorkspace() {
     },
     [workspaceId, activePanel, sidebarOpen, terminalOpen, termTabs.length, setCodingUi],
   );
+
+  // ── Editor bridge: open files from ChatPanel ctrl+click ──
+  useEffect(() => {
+    const unsub = useEditorBridge.subscribe((state) => {
+      if (state.pendingOpen?.workspaceId === workspaceId) {
+        const { filePath } = state.pendingOpen;
+        useEditorBridge.getState().consumeOpenRequest();
+        // Use the tab open logic below
+        setEditorTabs((prev) => (prev.includes(filePath) ? prev : [...prev, filePath]));
+        setActiveTab(filePath);
+      }
+    });
+    return unsub;
+  }, [workspaceId]);
 
   // ── Editor tab handlers ──
   const handleOpenTab = useCallback((path: string) => {

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -60,9 +60,12 @@ export function ChatPanel() {
   const focused = useFocusedAgent();
   const commands = useFocusedCommands();
   const sendPrompt = useAgentStore((s) => s.sendPrompt);
+  const steerAgent = useAgentStore((s) => s.steerAgent);
   const abort = useAgentStore((s) => s.abort);
   const initEventListener = useAgentStore((s) => s.initEventListener);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  /** Tracks whether Ctrl/Meta was held on the most recent submit gesture. */
+  const modifierRef = useRef(false);
 
   // Subscribe to main-process events on mount
   useEffect(() => {
@@ -206,6 +209,12 @@ export function ChatPanel() {
   // ── Tab path completion ────────────────────────────────────
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Capture modifier state on Enter so handleSubmit can distinguish
+      // steer (default) from followUp (Ctrl/Meta+Enter).
+      if (e.key === 'Enter' && !e.shiftKey) {
+        modifierRef.current = e.ctrlKey || e.metaKey;
+      }
+
       // Tab completion: complete partial path when Tab is pressed
       if (e.key === 'Tab' && !e.shiftKey && !slashMenuOpen && !fileMenuOpen) {
         // Check if the text before cursor contains a partial path (after @ or standalone)
@@ -263,15 +272,22 @@ export function ChatPanel() {
           }))
         : undefined;
 
-      // If agent is streaming, queue the message instead of sending immediately
+      // During streaming: Ctrl/Meta → queue as follow-up; default → steer
       if (isStreaming) {
-        messageQueue.enqueue(text, attachments);
+        const wantsFollowUp = modifierRef.current;
+        modifierRef.current = false;
+        if (wantsFollowUp) {
+          messageQueue.enqueue(text, attachments);
+        } else {
+          steerAgent(sessionId, text);
+        }
         return;
       }
 
+      modifierRef.current = false;
       sendPrompt(sessionId, text, attachments);
     },
-    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, messageQueue],
+    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, steerAgent, messageQueue],
   );
 
   const handleTranscript = useCallback((text: string) => {
@@ -466,6 +482,11 @@ export function ChatPanel() {
                     {messageQueue.queue.length} queued
                   </span>
                 )}
+                <PromptInputSubmit
+                  disabled={!input.trim() || !hasSession}
+                  onClick={(e) => { modifierRef.current = e.ctrlKey || e.metaKey; }}
+                  title="Send to steer agent (⌘+click to queue as follow-up)"
+                />
                 <button
                   onClick={() => sessionId && abort(sessionId)}
                   className="rounded-md bg-destructive/10 px-2 py-1 font-medium text-sm text-destructive hover:bg-destructive/20"

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -477,11 +477,6 @@ export function ChatPanel() {
 
             {isStreaming ? (
               <div className="flex items-center gap-1.5">
-                {messageQueue.hasQueued && (
-                  <span className="text-[10px] text-blue-500">
-                    {messageQueue.queue.length} queued
-                  </span>
-                )}
                 <PromptInputSubmit
                   disabled={!input.trim() || !hasSession}
                   onClick={(e) => { modifierRef.current = e.ctrlKey || e.metaKey; }}

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
-import { Bot, MessageSquare, Loader2, AlertCircle, Settings2, Brain } from 'lucide-react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import { Bot, MessageSquare, Loader2, AlertCircle, Settings2, Brain, X } from 'lucide-react';
 import {
   Conversation,
   ConversationContent,
@@ -23,6 +23,7 @@ import {
 import { useAgentStore, useFocusedAgent, useFocusedCommands } from '@/stores/agent';
 import { useSessionStore } from '@/stores/sessions';
 import { SlashCommandMenu } from './SlashCommandMenu';
+import { FileReferenceMenu } from './FileReferenceMenu';
 import { PromptAttachmentsBar } from './ChatAttachments';
 import { UsageBadge } from './UsageBadge';
 import { ModelSelector } from './ModelSelector';
@@ -35,6 +36,10 @@ import { VoiceTranscriptionControl } from './VoiceTranscriptionControl';
 import { useContextEditorStore, useHasOverrides } from '@/stores/context-editor';
 import { useFeedbackStore } from '@/stores/feedback';
 import { useCheckpointRestore } from '@/hooks/useCheckpointRestore';
+import { useWorkspaceFiles, fuzzyMatchFiles } from '@/hooks/useWorkspaceFiles';
+import { useMessageQueue } from '@/hooks/useMessageQueue';
+import { useEditorBridge } from '@/stores/editor-bridge';
+import { createFilePathClickHandler } from './ClickableFilePath';
 import { cn } from '@sero/ui/lib/utils';
 import type { ChatAttachment, SeroSlashCommandInfo } from '@/types/ipc';
 
@@ -57,6 +62,7 @@ export function ChatPanel() {
   const sendPrompt = useAgentStore((s) => s.sendPrompt);
   const abort = useAgentStore((s) => s.abort);
   const initEventListener = useAgentStore((s) => s.initEventListener);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // Subscribe to main-process events on mount
   useEffect(() => {
@@ -79,6 +85,26 @@ export function ChatPanel() {
   const sessionId = focused?.sessionId ?? null;
   const focusedWorkspaceId = focused?.workspaceId ?? null;
   const checkpoint = useCheckpointRestore(focusedWorkspaceId, sessionId);
+
+  // ── Workspace files for @ fuzzy search ─────────────────────
+  const { files: workspaceFiles } = useWorkspaceFiles(focusedWorkspaceId);
+
+  // ── Follow-up message queue ────────────────────────────────
+  const messageQueue = useMessageQueue({
+    isStreaming,
+    sessionId,
+    sendPrompt,
+  });
+
+  // ── Ctrl+click file paths in conversation ──────────────────
+  const requestOpenFile = useEditorBridge((s) => s.requestOpenFile);
+  const conversationClickHandler = useMemo(
+    () =>
+      focusedWorkspaceId
+        ? createFilePathClickHandler(focusedWorkspaceId, requestOpenFile)
+        : undefined,
+    [focusedWorkspaceId, requestOpenFile],
+  );
 
   // Resolve session name for the header badge
   const sessions = useSessionStore((s) => s.sessions);
@@ -151,12 +177,65 @@ export function ChatPanel() {
     setInput('');
   }, []);
 
+  // ── @ file reference menu state ────────────────────────────
+  // Match @<non-space-text> at the end of input — user is typing a file ref
+  const atMatch = useMemo(() => {
+    if (slashMenuOpen) return null;
+    const m = input.match(/@([^\s@]*)$/);
+    return m;
+  }, [input, slashMenuOpen]);
+
+  const fileMenuOpen = !!atMatch && !!sessionId;
+  const fileFilter = atMatch?.[1] ?? '';
+
+  const handleFileSelect = useCallback(
+    (filePath: string) => {
+      // Replace @<partial> with @<full_path> followed by a space
+      setInput((prev) => prev.replace(/@[^\s@]*$/, `@${filePath} `));
+      // Re-focus textarea
+      textareaRef.current?.focus();
+    },
+    [],
+  );
+
+  const handleFileMenuClose = useCallback(() => {
+    // Remove the dangling @ trigger
+    setInput((prev) => prev.replace(/@[^\s@]*$/, ''));
+  }, []);
+
+  // ── Tab path completion ────────────────────────────────────
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Tab completion: complete partial path when Tab is pressed
+      if (e.key === 'Tab' && !e.shiftKey && !slashMenuOpen && !fileMenuOpen) {
+        // Check if the text before cursor contains a partial path (after @ or standalone)
+        const cursorPos = e.currentTarget.selectionStart ?? input.length;
+        const textBefore = input.slice(0, cursorPos);
+        const pathMatch = textBefore.match(/@?([^\s@]+)$/);
+
+        if (pathMatch) {
+          const partial = pathMatch[1];
+          const matches = fuzzyMatchFiles(workspaceFiles, partial, 1);
+          if (matches.length > 0) {
+            e.preventDefault();
+            const completed = matches[0].path;
+            const prefix = textBefore.slice(0, textBefore.length - pathMatch[0].length);
+            const hasAt = pathMatch[0].startsWith('@');
+            const after = input.slice(cursorPos);
+            setInput(`${prefix}${hasAt ? '@' : ''}${completed}${after ? '' : ' '}${after}`);
+          }
+        }
+      }
+    },
+    [input, slashMenuOpen, fileMenuOpen, workspaceFiles],
+  );
+
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
       const text = (message.text ?? input).trim();
       if ((!text && !message.files?.length) || !sessionId) return;
-      // Don't submit if slash menu is open (Enter selects from menu instead)
-      if (slashMenuOpen) return;
+      // Don't submit if slash menu or file menu is open (Enter selects from menu)
+      if (slashMenuOpen || fileMenuOpen) return;
 
       // Intercept /login and /logout commands — handle client-side
       if (text === '/login' || text.startsWith('/login ')) {
@@ -184,9 +263,15 @@ export function ChatPanel() {
           }))
         : undefined;
 
+      // If agent is streaming, queue the message instead of sending immediately
+      if (isStreaming) {
+        messageQueue.enqueue(text, attachments);
+        return;
+      }
+
       sendPrompt(sessionId, text, attachments);
     },
-    [input, sessionId, slashMenuOpen, sendPrompt],
+    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, messageQueue],
   );
 
   const handleTranscript = useCallback((text: string) => {
@@ -221,7 +306,8 @@ export function ChatPanel() {
 
       {/* ── Conversation ────────────────────────────────────── */}
       <Conversation key={sessionId} className="min-h-0 flex-1" initial="instant">
-        <ConversationContent className="gap-4 p-3">
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */}
+        <ConversationContent className="gap-4 p-3" onClick={conversationClickHandler}>
           {!hasSession ? (
             <EmptyState message="Select or create a chat to begin" />
           ) : messages.length === 0 && !isStreaming ? (
@@ -239,6 +325,7 @@ export function ChatPanel() {
                       key={item.id}
                       tools={item.tools}
                       isFinalized={isFinalized}
+                      workspaceId={focusedWorkspaceId}
                     />
                   );
                 }
@@ -298,22 +385,53 @@ export function ChatPanel() {
           open={slashMenuOpen}
         />
 
+        {/* @ file reference autocomplete menu */}
+        <FileReferenceMenu
+          files={workspaceFiles}
+          filter={fileFilter}
+          onSelect={handleFileSelect}
+          onClose={handleFileMenuClose}
+          open={fileMenuOpen}
+        />
+
         <PromptInput
           onSubmit={handleSubmit}
           className="w-full"
           multiple
           globalDrop={hasSession}
         >
-          {/* Queued attachments shown as inline badges above the textarea */}
+          {/* Queued attachments + queued follow-up messages */}
           <PromptInputHeader>
             <PromptAttachmentsBar />
+            {/* Follow-up message queue badges */}
+            {messageQueue.hasQueued && (
+              <div className="flex flex-wrap gap-1 px-1">
+                {messageQueue.queue.map((msg) => (
+                  <span
+                    key={msg.id}
+                    className="inline-flex items-center gap-1 rounded-full bg-blue-500/10 px-2 py-0.5 text-[11px] text-blue-600 dark:text-blue-400"
+                  >
+                    <span className="max-w-[150px] truncate">{msg.text}</span>
+                    <button
+                      onClick={() => messageQueue.dequeue(msg.id)}
+                      className="shrink-0 rounded-full p-0.5 hover:bg-blue-500/20"
+                      title="Remove queued message"
+                    >
+                      <X className="size-2.5" />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
           </PromptInputHeader>
 
           <PromptInputBody>
             <PromptInputTextarea
+              ref={textareaRef}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              placeholder={hasSession ? 'Ask Sero anything… (/ for commands)' : 'Select a chat first…'}
+              onKeyDown={handleKeyDown}
+              placeholder={hasSession ? 'Ask Sero anything… (/ for commands, @ for files)' : 'Select a chat first…'}
               disabled={!hasSession}
             />
           </PromptInputBody>
@@ -342,12 +460,19 @@ export function ChatPanel() {
             </PromptInputTools>
 
             {isStreaming ? (
-              <button
-                onClick={() => sessionId && abort(sessionId)}
-                className="rounded-md bg-destructive/10 px-2 py-1 font-medium text-sm text-destructive hover:bg-destructive/20"
-              >
-                Stop
-              </button>
+              <div className="flex items-center gap-1.5">
+                {messageQueue.hasQueued && (
+                  <span className="text-[10px] text-blue-500">
+                    {messageQueue.queue.length} queued
+                  </span>
+                )}
+                <button
+                  onClick={() => sessionId && abort(sessionId)}
+                  className="rounded-md bg-destructive/10 px-2 py-1 font-medium text-sm text-destructive hover:bg-destructive/20"
+                >
+                  Stop
+                </button>
+              </div>
             ) : (
               <PromptInputSubmit disabled={!input.trim() || !hasSession} />
             )}

--- a/apps/desktop/src/components/layout/ClickableFilePath.tsx
+++ b/apps/desktop/src/components/layout/ClickableFilePath.tsx
@@ -1,0 +1,102 @@
+/**
+ * ClickableFilePath — renders a file path as a ctrl+clickable link.
+ *
+ * When ctrl+clicked (or cmd+clicked on macOS), opens the file in the
+ * code editor via the editor-bridge store.
+ */
+
+import { useCallback } from 'react';
+import { useEditorBridge } from '@/stores/editor-bridge';
+
+interface ClickableFilePathProps {
+  /** Relative file path to display. */
+  path: string;
+  /** Workspace ID for opening the file. */
+  workspaceId: string;
+  /** Additional CSS classes. */
+  className?: string;
+}
+
+export function ClickableFilePath({
+  path,
+  workspaceId,
+  className,
+}: ClickableFilePathProps) {
+  const requestOpen = useEditorBridge((s) => s.requestOpenFile);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        // Normalize: ensure path starts with / for the editor
+        const filePath = path.startsWith('/') ? path : `/${path}`;
+        requestOpen(workspaceId, filePath);
+      }
+    },
+    [path, workspaceId, requestOpen],
+  );
+
+  return (
+    <span
+      onClick={handleClick}
+      className={`cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/40 underline-offset-2 hover:decoration-[var(--accent)] ${className ?? ''}`}
+      title="Ctrl+click to open in editor"
+    >
+      {path}
+    </span>
+  );
+}
+
+// ── Utility: detect file paths in tool call inputs/outputs ─────
+
+/**
+ * Regex to match file paths in text.
+ * Matches:
+ * - Absolute paths: /foo/bar/baz.ts
+ * - Relative paths: src/foo/bar.ts, ./foo/bar.ts
+ * - Paths with common extensions
+ */
+const FILE_PATH_RE =
+  /(?:^|[\s"'`([\]{,;:])((\.{0,2}\/)?(?:[\w.@-]+\/)*[\w.-]+\.[\w]+)/g;
+
+/**
+ * Check if a string looks like a file path.
+ */
+export function looksLikeFilePath(text: string): boolean {
+  // Must contain a dot (extension) or slash (directory separator)
+  if (!text.includes('/') && !text.includes('.')) return false;
+  // Must not be a URL
+  if (/^https?:\/\//.test(text)) return false;
+  // Must not be an email
+  if (text.includes('@') && !text.includes('/')) return false;
+  // Basic path pattern
+  return /^\.{0,2}\/|[\w.-]+\/[\w.-]+|[\w.-]+\.\w{1,10}$/.test(text);
+}
+
+/**
+ * Installs a delegated click handler on a container element that
+ * intercepts ctrl+clicks on file paths and opens them in the editor.
+ *
+ * Designed to be used with `useEffect` on a wrapper div around
+ * tool call or message content.
+ */
+export function createFilePathClickHandler(
+  workspaceId: string,
+  requestOpenFile: (workspaceId: string, filePath: string) => void,
+) {
+  return (e: React.MouseEvent) => {
+    if (!(e.ctrlKey || e.metaKey)) return;
+
+    const target = e.target as HTMLElement;
+    // Check if we clicked on text content that looks like a file path
+    const text = target.textContent?.trim() ?? '';
+
+    if (looksLikeFilePath(text)) {
+      e.preventDefault();
+      e.stopPropagation();
+      const filePath = text.startsWith('/') ? text : `/${text}`;
+      requestOpenFile(workspaceId, filePath);
+    }
+  };
+}

--- a/apps/desktop/src/components/layout/FileReferenceMenu.tsx
+++ b/apps/desktop/src/components/layout/FileReferenceMenu.tsx
@@ -1,0 +1,212 @@
+/**
+ * FileReferenceMenu — floating autocomplete for @file references.
+ *
+ * Appears above the chat input when the user types "@" followed by
+ * optional filter text.  Fuzzy-searches workspace files (excluding
+ * node_modules, .git, build dirs, etc.).
+ *
+ * Keyboard: ↑/↓ navigate, Enter/Tab selects, Escape dismisses.
+ */
+
+import { useEffect, useRef, useState, useCallback, useMemo } from 'react';
+import { FileIcon } from 'lucide-react';
+import { fuzzyMatchFiles, type FuzzyMatch } from '@/hooks/useWorkspaceFiles';
+
+// ── Types ──────────────────────────────────────────────────────
+
+interface FileReferenceMenuProps {
+  /** All available file paths (relative to workspace root). */
+  files: string[];
+  /** Current text after "@" for filtering. */
+  filter: string;
+  /** Called when a file is selected. Receives the relative path. */
+  onSelect: (filePath: string) => void;
+  /** Called when the menu should close (Escape). */
+  onClose: () => void;
+  /** Whether the menu is visible. */
+  open: boolean;
+}
+
+// ── Highlighted filename ──────────────────────────────────────
+
+function HighlightedPath({
+  path,
+  matchIndices,
+}: {
+  path: string;
+  matchIndices: number[];
+}) {
+  const indexSet = useMemo(() => new Set(matchIndices), [matchIndices]);
+
+  return (
+    <span className="min-w-0 truncate">
+      {path.split('').map((char, i) => (
+        <span
+          key={i}
+          className={indexSet.has(i) ? 'text-[var(--accent)] font-semibold' : undefined}
+        >
+          {char}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+// ── File extension icon color hint ────────────────────────────
+
+function fileIconColor(path: string): string {
+  const ext = path.split('.').pop()?.toLowerCase() ?? '';
+  switch (ext) {
+    case 'ts':
+    case 'tsx':
+      return 'text-blue-500';
+    case 'js':
+    case 'jsx':
+      return 'text-yellow-500';
+    case 'json':
+      return 'text-green-500';
+    case 'css':
+    case 'scss':
+      return 'text-purple-500';
+    case 'md':
+    case 'mdx':
+      return 'text-gray-400';
+    case 'py':
+      return 'text-emerald-500';
+    case 'rs':
+      return 'text-orange-500';
+    default:
+      return 'text-[var(--text-muted)]';
+  }
+}
+
+// ── Component ──────────────────────────────────────────────────
+
+export function FileReferenceMenu({
+  files,
+  filter,
+  onSelect,
+  onClose,
+  open,
+}: FileReferenceMenuProps) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+
+  // Fuzzy-match files against the filter
+  const matches: FuzzyMatch[] = useMemo(
+    () => fuzzyMatchFiles(files, filter, 20),
+    [files, filter],
+  );
+
+  // Reset selection when filter changes
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [filter]);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    const el = itemRefs.current.get(selectedIndex);
+    if (el) {
+      el.scrollIntoView({ block: 'nearest' });
+    }
+  }, [selectedIndex]);
+
+  // Keyboard handler — attached to document when open
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!open || matches.length === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          e.stopPropagation();
+          setSelectedIndex((i) => (i + 1) % matches.length);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          e.stopPropagation();
+          setSelectedIndex((i) => (i - 1 + matches.length) % matches.length);
+          break;
+        case 'Enter':
+        case 'Tab':
+          e.preventDefault();
+          e.stopPropagation();
+          if (matches[selectedIndex]) {
+            onSelect(matches[selectedIndex].path);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          e.stopPropagation();
+          onClose();
+          break;
+      }
+    },
+    [open, matches, selectedIndex, onSelect, onClose],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    // Capture phase so we intercept before the textarea handles Enter/Escape
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [open, handleKeyDown]);
+
+  if (!open || matches.length === 0) return null;
+
+  return (
+    <div
+      ref={listRef}
+      className="absolute bottom-full left-0 right-0 z-50 mb-1 max-h-64 overflow-y-auto rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)] shadow-lg"
+      role="listbox"
+    >
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-[var(--bg-surface)] px-2 py-1.5 text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        Files
+      </div>
+
+      {/* Items */}
+      {matches.map((match, idx) => {
+        const isSelected = idx === selectedIndex;
+        const filename = match.path.split('/').pop() ?? match.path;
+        const dir = match.path.includes('/')
+          ? match.path.slice(0, match.path.lastIndexOf('/'))
+          : '';
+
+        return (
+          <div
+            key={match.path}
+            ref={(el) => {
+              if (el) itemRefs.current.set(idx, el);
+              else itemRefs.current.delete(idx);
+            }}
+            role="option"
+            aria-selected={isSelected}
+            className={`flex cursor-pointer items-center gap-2 px-2 py-1.5 text-sm ${
+              isSelected
+                ? 'bg-accent text-accent-foreground'
+                : 'text-[var(--text-primary)] hover:bg-accent/50'
+            }`}
+            onMouseEnter={() => setSelectedIndex(idx)}
+            onMouseDown={(e) => {
+              e.preventDefault(); // Keep focus on textarea
+              onSelect(match.path);
+            }}
+          >
+            <FileIcon className={`size-3 shrink-0 ${fileIconColor(match.path)}`} />
+            <HighlightedPath
+              path={match.path}
+              matchIndices={match.matchIndices}
+            />
+            {dir && (
+              <span className="ml-auto shrink-0 truncate text-[10px] text-[var(--text-muted)]/60" style={{ maxWidth: '40%' }}>
+                {dir}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/FileReferenceMenu.tsx
+++ b/apps/desktop/src/components/layout/FileReferenceMenu.tsx
@@ -43,7 +43,7 @@ function HighlightedPath({
       {path.split('').map((char, i) => (
         <span
           key={i}
-          className={indexSet.has(i) ? 'text-[var(--accent)] font-semibold' : undefined}
+          className={indexSet.has(i) ? 'text-[var(--accent-code)] font-semibold' : undefined}
         >
           {char}
         </span>

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -20,6 +20,9 @@ import {
 import { useEditorBridge } from '@/stores/editor-bridge';
 import { looksLikeFilePath } from './ClickableFilePath';
 
+/** Tools whose summary arg is a real file path worth linking. */
+const FILE_PATH_TOOLS = new Set(['edit', 'read', 'write']);
+
 // ── Types ───────────────────────────────────────────────────────
 
 export type GroupedChatItem =
@@ -182,8 +185,8 @@ function ToolLine({
   }, [tool.input]);
 
   const isFilePath = useMemo(
-    () => !!summary && looksLikeFilePath(summary),
-    [summary],
+    () => !!summary && FILE_PATH_TOOLS.has(tool.toolName) && looksLikeFilePath(summary),
+    [summary, tool.toolName],
   );
 
   const handleSummaryClick = useCallback(
@@ -213,9 +216,9 @@ function ToolLine({
         <span
           onClick={handleSummaryClick}
           className={cn(
-            'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+            'min-w-0 truncate text-[11px] text-[var(--text-secondary)]',
             isFilePath && workspaceId &&
-              'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+              'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/60 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-primary)]',
           )}
           title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
         >
@@ -285,8 +288,8 @@ function SingleToolCall({
   }, [tool.input]);
 
   const isFilePath = useMemo(
-    () => !!summary && looksLikeFilePath(summary),
-    [summary],
+    () => !!summary && FILE_PATH_TOOLS.has(tool.toolName) && looksLikeFilePath(summary),
+    [summary, tool.toolName],
   );
 
   const handleSummaryClick = useCallback(
@@ -338,9 +341,9 @@ function SingleToolCall({
           <span
             onClick={handleSummaryClick}
             className={cn(
-              'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+              'min-w-0 truncate text-[11px] text-[var(--text-secondary)]',
               isFilePath && workspaceId &&
-                'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+                'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/60 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-primary)]',
             )}
             title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
           >
@@ -498,7 +501,7 @@ export function ToolCallGroup({
                         e.stopPropagation();
                         setShowDetails(true);
                       }}
-                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
                     >
                       Show full details
                     </button>
@@ -517,7 +520,7 @@ export function ToolCallGroup({
                         e.stopPropagation();
                         setShowDetails(false);
                       }}
-                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+                      className="text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
                     >
                       Collapse details
                     </button>

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
   ChevronRight,
@@ -17,6 +17,8 @@ import {
   ToolInput,
   ToolOutput,
 } from '@sero/ui/components/ai-elements/tool';
+import { useEditorBridge } from '@/stores/editor-bridge';
+import { looksLikeFilePath } from './ClickableFilePath';
 
 // ── Types ───────────────────────────────────────────────────────
 
@@ -154,7 +156,17 @@ function toolStatusDot(state: ChatToolCallMessage['state']) {
   }
 }
 
-function ToolLine({ tool, index }: { tool: ChatToolCallMessage; index: number }) {
+function ToolLine({
+  tool,
+  index,
+  workspaceId,
+}: {
+  tool: ChatToolCallMessage;
+  index: number;
+  workspaceId: string | null;
+}) {
+  const requestOpenFile = useEditorBridge((s) => s.requestOpenFile);
+
   const summary = useMemo(() => {
     const inp = tool.input;
     // Try to build a short summary from common tool input shapes
@@ -169,6 +181,23 @@ function ToolLine({ tool, index }: { tool: ChatToolCallMessage; index: number })
     return typeof first === 'string' ? first : '';
   }, [tool.input]);
 
+  const isFilePath = useMemo(
+    () => !!summary && looksLikeFilePath(summary),
+    [summary],
+  );
+
+  const handleSummaryClick = useCallback(
+    (e: React.MouseEvent) => {
+      if ((e.ctrlKey || e.metaKey) && isFilePath && workspaceId) {
+        e.preventDefault();
+        e.stopPropagation();
+        const filePath = summary.startsWith('/') ? summary : `/${summary}`;
+        requestOpenFile(workspaceId, filePath);
+      }
+    },
+    [isFilePath, workspaceId, summary, requestOpenFile],
+  );
+
   return (
     <motion.div
       initial={{ opacity: 0, y: -4 }}
@@ -181,7 +210,15 @@ function ToolLine({ tool, index }: { tool: ChatToolCallMessage; index: number })
         {tool.toolName}
       </span>
       {summary && (
-        <span className="min-w-0 truncate text-[11px] text-[var(--text-muted)]/60">
+        <span
+          onClick={handleSummaryClick}
+          className={cn(
+            'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+            isFilePath && workspaceId &&
+              'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+          )}
+          title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
+        >
           {summary}
         </span>
       )}
@@ -221,7 +258,14 @@ function ToolDetail({ tool }: { tool: ChatToolCallMessage }) {
 
 // ── Single tool call (matches group wrapper style) ──────────────
 
-function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
+function SingleToolCall({
+  tool,
+  workspaceId,
+}: {
+  tool: ChatToolCallMessage;
+  workspaceId: string | null;
+}) {
+  const requestOpenFile = useEditorBridge((s) => s.requestOpenFile);
   const status = deriveGroupStatus([tool]);
   const isRunning = status === 'running';
   const isComplete = tool.state === 'completed' || tool.state === 'error';
@@ -239,6 +283,23 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
     const first = Object.values(inp).find((v) => typeof v === 'string');
     return typeof first === 'string' ? first : '';
   }, [tool.input]);
+
+  const isFilePath = useMemo(
+    () => !!summary && looksLikeFilePath(summary),
+    [summary],
+  );
+
+  const handleSummaryClick = useCallback(
+    (e: React.MouseEvent) => {
+      if ((e.ctrlKey || e.metaKey) && isFilePath && workspaceId) {
+        e.preventDefault();
+        e.stopPropagation();
+        const filePath = summary.startsWith('/') ? summary : `/${summary}`;
+        requestOpenFile(workspaceId, filePath);
+      }
+    },
+    [isFilePath, workspaceId, summary, requestOpenFile],
+  );
 
   return (
     <motion.div
@@ -274,7 +335,15 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
           {tool.toolName}
         </span>
         {summary && (
-          <span className="min-w-0 truncate text-[11px] text-[var(--text-muted)]/60">
+          <span
+            onClick={handleSummaryClick}
+            className={cn(
+              'min-w-0 truncate text-[11px] text-[var(--text-muted)]/60',
+              isFilePath && workspaceId &&
+                'cursor-pointer underline decoration-dotted decoration-[var(--text-muted)]/30 underline-offset-2 hover:decoration-[var(--accent)] hover:text-[var(--text-secondary)]',
+            )}
+            title={isFilePath ? 'Ctrl+click to open in editor' : undefined}
+          >
             {summary}
           </span>
         )}
@@ -317,13 +386,16 @@ function SingleToolCall({ tool }: { tool: ChatToolCallMessage }) {
  * @param tools       — tool messages in this group
  * @param isFinalized — true when no more tools will be added to this group
  *                      (a non-tool message follows it, or the session stopped streaming)
+ * @param workspaceId — workspace ID for ctrl+click file path support
  */
 export function ToolCallGroup({
   tools,
   isFinalized = true,
+  workspaceId = null,
 }: {
   tools: ChatToolCallMessage[];
   isFinalized?: boolean;
+  workspaceId?: string | null;
 }) {
   const status = deriveGroupStatus(tools);
   const isRunning = status === 'running';
@@ -360,7 +432,7 @@ export function ToolCallGroup({
 
   // Single tool: render with matching group-style wrapper
   if (tools.length === 1) {
-    return <SingleToolCall tool={tools[0]} />;
+    return <SingleToolCall tool={tools[0]} workspaceId={workspaceId} />;
   }
 
   return (
@@ -417,7 +489,7 @@ export function ToolCallGroup({
                 <>
                   <div className="py-1">
                     {tools.map((tool, i) => (
-                      <ToolLine key={tool.id} tool={tool} index={i} />
+                      <ToolLine key={tool.id} tool={tool} index={i} workspaceId={workspaceId} />
                     ))}
                   </div>
                   <div className="border-t border-[var(--border-subtle)]/60 px-3 py-1.5">

--- a/apps/desktop/src/hooks/useMessageQueue.ts
+++ b/apps/desktop/src/hooks/useMessageQueue.ts
@@ -1,0 +1,81 @@
+/**
+ * useMessageQueue — manages a follow-up message queue for the ChatPanel.
+ *
+ * When the agent is streaming, additional messages are queued instead of
+ * being sent immediately.  When streaming ends, the next queued message
+ * is automatically sent (dequeued).
+ *
+ * The user can:
+ * - Queue a message while the agent is busy
+ * - Remove a queued message before it's sent
+ * - Edit a queued message (remove + re-queue)
+ * - "Steer" the agent by queueing an interruption message
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+import type { ChatAttachment } from '@/types/ipc';
+
+export interface QueuedMessage {
+  id: string;
+  text: string;
+  attachments?: ChatAttachment[];
+}
+
+interface UseMessageQueueOptions {
+  /** Whether the agent is currently streaming. */
+  isStreaming: boolean;
+  /** The session ID to send to. */
+  sessionId: string | null;
+  /** The send function to call when dequeuing. */
+  sendPrompt: (sessionId: string, text: string, attachments?: ChatAttachment[]) => void;
+}
+
+export function useMessageQueue({
+  isStreaming,
+  sessionId,
+  sendPrompt,
+}: UseMessageQueueOptions) {
+  const [queue, setQueue] = useState<QueuedMessage[]>([]);
+  const prevStreamingRef = useRef(isStreaming);
+
+  /** Add a message to the queue. */
+  const enqueue = useCallback((text: string, attachments?: ChatAttachment[]) => {
+    const id = `q-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    setQueue((prev) => [...prev, { id, text, attachments }]);
+  }, []);
+
+  /** Remove a queued message by ID. */
+  const dequeue = useCallback((id: string) => {
+    setQueue((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  /** Clear all queued messages. */
+  const clearQueue = useCallback(() => {
+    setQueue([]);
+  }, []);
+
+  // Auto-send the next queued message when streaming stops.
+  useEffect(() => {
+    if (prevStreamingRef.current && !isStreaming && sessionId) {
+      // Streaming just stopped — send next queued message
+      setQueue((prev) => {
+        if (prev.length === 0) return prev;
+        const [next, ...rest] = prev;
+        // Schedule the send asynchronously to avoid state update conflicts
+        setTimeout(() => {
+          sendPrompt(sessionId, next.text, next.attachments);
+        }, 100);
+        return rest;
+      });
+    }
+    prevStreamingRef.current = isStreaming;
+  }, [isStreaming, sessionId, sendPrompt]);
+
+  return {
+    queue,
+    enqueue,
+    dequeue,
+    clearQueue,
+    hasQueued: queue.length > 0,
+  };
+}

--- a/apps/desktop/src/hooks/useWorkspaceFiles.ts
+++ b/apps/desktop/src/hooks/useWorkspaceFiles.ts
@@ -24,6 +24,7 @@ const EXCLUDED_DIRS = [
   '.jj',
   '.svn',
   '.hg',
+  '.DS_Store',
 ];
 
 /** Max files to return (safety cap). */

--- a/apps/desktop/src/hooks/useWorkspaceFiles.ts
+++ b/apps/desktop/src/hooks/useWorkspaceFiles.ts
@@ -1,0 +1,168 @@
+/**
+ * useWorkspaceFiles — fetches and caches the list of project files
+ * for a workspace, excluding common build / dependency directories.
+ *
+ * Used by the FileReferenceMenu (@-mention) and Tab path completion.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+/** Directories excluded from file search results. */
+const EXCLUDED_DIRS = [
+  'node_modules',
+  '.git',
+  '.turbo',
+  'dist',
+  'build',
+  '.next',
+  '.cache',
+  '.output',
+  'coverage',
+  '__pycache__',
+  '.venv',
+  'target',
+  '.jj',
+  '.svn',
+  '.hg',
+];
+
+/** Max files to return (safety cap). */
+const MAX_FILES = 5000;
+
+/** Simple in-memory cache keyed by workspaceId. */
+const cache = new Map<string, { files: string[]; ts: number }>();
+const CACHE_TTL_MS = 30_000; // 30 seconds
+
+export function useWorkspaceFiles(workspaceId: string | null) {
+  const [files, setFiles] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef(0);
+
+  const loadFiles = useCallback(async () => {
+    if (!workspaceId) {
+      setFiles([]);
+      return;
+    }
+
+    // Check cache
+    const cached = cache.get(workspaceId);
+    if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+      setFiles(cached.files);
+      return;
+    }
+
+    const gen = ++abortRef.current;
+    setIsLoading(true);
+    try {
+      const pruneArgs = EXCLUDED_DIRS.map(
+        (d) => `-name '${d}' -prune`
+      ).join(' -o ');
+
+      const cmd = `find . \\( ${pruneArgs} \\) -o -type f -print | head -${MAX_FILES} | sort`;
+      const { stdout } = await window.sero.editor.exec(workspaceId, cmd);
+
+      if (gen !== abortRef.current) return; // stale
+
+      const paths = stdout
+        .split('\n')
+        .filter(Boolean)
+        .map((p) => (p.startsWith('./') ? p.slice(2) : p));
+
+      cache.set(workspaceId, { files: paths, ts: Date.now() });
+      setFiles(paths);
+    } catch (err) {
+      console.warn('[useWorkspaceFiles] Failed to load files:', err);
+      if (gen === abortRef.current) setFiles([]);
+    }
+    if (gen === abortRef.current) setIsLoading(false);
+  }, [workspaceId]);
+
+  useEffect(() => {
+    loadFiles();
+  }, [loadFiles]);
+
+  return { files, isLoading, refresh: loadFiles };
+}
+
+// ── Fuzzy matching ──────────────────────────────────────────────
+
+export interface FuzzyMatch {
+  path: string;
+  score: number;
+  /** Character indices in the path that matched the query. */
+  matchIndices: number[];
+}
+
+/**
+ * Fuzzy-match a query against a list of file paths.
+ * Returns up to `limit` results sorted by best score.
+ */
+export function fuzzyMatchFiles(
+  files: string[],
+  query: string,
+  limit = 20,
+): FuzzyMatch[] {
+  if (!query) {
+    // No query — return first `limit` files
+    return files.slice(0, limit).map((path) => ({
+      path,
+      score: 0,
+      matchIndices: [],
+    }));
+  }
+
+  const lowerQuery = query.toLowerCase();
+  const results: FuzzyMatch[] = [];
+
+  for (const path of files) {
+    const result = scorePath(path, lowerQuery);
+    if (result) results.push(result);
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results.slice(0, limit);
+}
+
+function scorePath(
+  path: string,
+  lowerQuery: string,
+): FuzzyMatch | null {
+  const lowerPath = path.toLowerCase();
+  const matchIndices: number[] = [];
+  let score = 0;
+  let qi = 0;
+
+  for (let pi = 0; pi < lowerPath.length && qi < lowerQuery.length; pi++) {
+    if (lowerPath[pi] === lowerQuery[qi]) {
+      matchIndices.push(pi);
+
+      // Bonus for matching at word boundaries
+      if (pi === 0 || '/._-'.includes(lowerPath[pi - 1])) {
+        score += 10;
+      }
+
+      // Bonus for consecutive matches
+      if (matchIndices.length > 1 && matchIndices[matchIndices.length - 2] === pi - 1) {
+        score += 5;
+      }
+
+      // Base match score
+      score += 1;
+      qi++;
+    }
+  }
+
+  // All query chars must match
+  if (qi < lowerQuery.length) return null;
+
+  // Bonus for filename match (last segment)
+  const filename = path.split('/').pop() ?? path;
+  if (filename.toLowerCase().includes(lowerQuery)) {
+    score += 20;
+  }
+
+  // Penalize longer paths slightly
+  score -= path.length * 0.1;
+
+  return { path, score, matchIndices };
+}

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -62,6 +62,8 @@ interface AgentState {
   closeSession: (sessionId: string) => Promise<void>;
   /** Send a prompt to a specific session, optionally with file attachments. */
   sendPrompt: (sessionId: string, text: string, attachments?: ChatAttachment[]) => Promise<void>;
+  /** Steer the agent mid-stream (interrupt after current tool, skip remaining). */
+  steerAgent: (sessionId: string, text: string) => Promise<void>;
   /** Abort a specific session. */
   abort: (sessionId: string) => Promise<void>;
   /** Focus a session in the ChatPanel. */
@@ -212,6 +214,38 @@ export const useAgentStore = create<AgentState>((set, get) => ({
             error: message,
             isStreaming: false,
           },
+        },
+      }));
+    }
+  },
+
+  steerAgent: async (sessionId, text) => {
+    const agent = get().agents[sessionId];
+    if (!agent) return;
+
+    // Optimistically add the user message (same as sendPrompt).
+    const userMessageId = `usr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const userMsg: ChatMessage = { type: 'user', id: userMessageId, text };
+    set((s) => ({
+      agents: {
+        ...s.agents,
+        [sessionId]: {
+          ...s.agents[sessionId],
+          error: null,
+          messages: [...s.agents[sessionId].messages, userMsg],
+        },
+      },
+    }));
+
+    try {
+      await window.sero.agent.steer(sessionId, text, userMessageId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Steer failed';
+      console.error('[agent] steerAgent failed:', err);
+      set((s) => ({
+        agents: {
+          ...s.agents,
+          [sessionId]: { ...s.agents[sessionId], error: message },
         },
       }));
     }

--- a/apps/desktop/src/stores/editor-bridge.ts
+++ b/apps/desktop/src/stores/editor-bridge.ts
@@ -1,0 +1,32 @@
+/**
+ * Editor bridge — lightweight event bus for "open file in editor" requests.
+ *
+ * Used by the ChatPanel / ToolCallGroup to request that the CodingWorkspace
+ * opens a specific file tab.  CodingWorkspace subscribes and handles the event.
+ */
+
+import { create } from 'zustand';
+
+interface EditorBridgeState {
+  /** Pending file-open request. Consumed by CodingWorkspace on the next tick. */
+  pendingOpen: { workspaceId: string; filePath: string } | null;
+
+  /** Request the editor to open a file. */
+  requestOpenFile: (workspaceId: string, filePath: string) => void;
+
+  /** Consume (and clear) the pending request. Returns it, or null. */
+  consumeOpenRequest: () => { workspaceId: string; filePath: string } | null;
+}
+
+export const useEditorBridge = create<EditorBridgeState>((set, get) => ({
+  pendingOpen: null,
+
+  requestOpenFile: (workspaceId, filePath) =>
+    set({ pendingOpen: { workspaceId, filePath } }),
+
+  consumeOpenRequest: () => {
+    const pending = get().pendingOpen;
+    if (pending) set({ pendingOpen: null });
+    return pending;
+  },
+}));

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -79,6 +79,8 @@ interface SeroAgentAPI {
   open(sessionId: string, sessionPath: string, workspaceId: string): Promise<ChatMessage[]>;
   /** Send a prompt to a specific session, optionally with file attachments. */
   prompt(sessionId: string, text: string, attachments?: ChatAttachment[], clientMessageId?: string): Promise<void>;
+  /** Steer the agent mid-stream: delivered after the current tool, skips remaining tools in the turn. */
+  steer(sessionId: string, text: string, clientMessageId?: string): Promise<void>;
   /** Abort a specific session's current operation. */
   abort(sessionId: string): Promise<void>;
   /** Close a specific session and dispose its AgentSession. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -89,6 +89,12 @@ export const IpcChannels = {
     /** Send a prompt to an app's dedicated agent session. Returns text response. */
     prompt: 'sero:app-agent:prompt',
   },
+  imagegen: {
+    /** Generate images via Gemini Nano Banana. Returns generation metadata. */
+    generate: 'sero:imagegen:generate',
+    /** Read a saved image file as a data URI. */
+    readImage: 'sero:imagegen:read-image',
+  },
   voice: {
     /** Check whether voice transcription is available (requires OPENAI_API_KEY). */
     status: 'sero:voice:status',

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -30,6 +30,8 @@ export const IpcChannels = {
   agent: {
     open: 'sero:agent:open',
     prompt: 'sero:agent:prompt',
+    /** Steer the agent mid-stream (interrupt after current tool, skip remaining). */
+    steer: 'sero:agent:steer',
     abort: 'sero:agent:abort',
     close: 'sero:agent:close',
     /** Get available slash commands for a session. */

--- a/packages/pi-imagegen-extension/extension/index.ts
+++ b/packages/pi-imagegen-extension/extension/index.ts
@@ -188,7 +188,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand('generate-image', {
     description: 'Generate an image with Gemini Nano Banana',
     handler: async (args, _ctx) => {
-      const prompt = args.join(' ').trim();
+      const prompt = args.trim();
       if (!prompt) {
         pi.sendUserMessage(
           'I want to generate an image. Ask me what I\'d like to create, then use the generate_image tool.',

--- a/packages/pi-imagegen-extension/extension/index.ts
+++ b/packages/pi-imagegen-extension/extension/index.ts
@@ -1,0 +1,203 @@
+/**
+ * ImageGen Pi extension — tool + command for Gemini Nano Banana image generation.
+ *
+ * Tool: generate_image — called by the LLM agent to create images.
+ * Command: /generate-image — user-invokable shortcut.
+ *
+ * When running inside Sero, delegates to the image agent via globalThis bridge.
+ * The bridge is registered by electron/ipc/imagegen.ts on startup.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import type { ImageGenState, Generation, GenerateParams } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+
+// ── Paths ──
+
+const STATE_REL = path.join('.sero', 'apps', 'imagegen', 'state.json');
+const IMAGES_REL = path.join('.sero', 'apps', 'imagegen', 'images');
+
+function resolveStatePath(cwd: string): string {
+  return path.join(cwd, STATE_REL);
+}
+
+// ── State I/O ──
+
+async function readState(filePath: string): Promise<ImageGenState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as ImageGenState;
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+async function writeState(filePath: string, state: ImageGenState): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmp, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmp, filePath);
+}
+
+// ── Tool parameters ──
+
+const Params = Type.Object({
+  prompt: Type.String({ description: 'Text description of the image to generate' }),
+  model: Type.Optional(
+    StringEnum(['flash', 'pro'] as const, {
+      description: 'Model: "flash" = Nano Banana (fast), "pro" = Nano Banana Pro (high-fidelity). Default: flash',
+    }),
+  ),
+  variations: Type.Optional(
+    Type.Number({ description: 'Number of image variations (1-4). Default: 1', minimum: 1, maximum: 4 }),
+  ),
+  aspect_ratio: Type.Optional(
+    StringEnum(['1:1', '2:3', '3:2', '3:4', '4:3', '9:16', '16:9'] as const, {
+      description: 'Aspect ratio. Default: 1:1',
+    }),
+  ),
+  negative_prompt: Type.Optional(
+    Type.String({ description: 'What to avoid in the image' }),
+  ),
+});
+
+type ModelAlias = 'flash' | 'pro';
+const MODEL_MAP: Record<ModelAlias, GenerateParams['model']> = {
+  flash: 'gemini-2.5-flash-image',
+  pro: 'gemini-3-pro-image-preview',
+};
+
+// ── Extension entry point ──
+
+export default function (pi: ExtensionAPI) {
+  let statePath = '';
+
+  pi.on('session_start', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+  pi.on('session_switch', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+
+  // ── Tool ──
+
+  pi.registerTool({
+    name: 'generate_image',
+    label: 'Generate Image',
+    description:
+      'Generate images using Google Gemini Nano Banana. ' +
+      'Supports two models: "flash" (fast, efficient) and "pro" (high-fidelity with thinking). ' +
+      'Can generate 1-4 variations. Supports aspect ratios: 1:1, 2:3, 3:2, 3:4, 4:3, 9:16, 16:9.',
+    parameters: Params,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const cwd = ctx?.cwd;
+      const resolvedPath = cwd ? resolveStatePath(cwd) : statePath;
+      if (!resolvedPath) {
+        return { content: [{ type: 'text', text: 'Error: no workspace cwd' }], details: {} };
+      }
+      statePath = resolvedPath;
+
+      const alias = (params.model ?? 'flash') as ModelAlias;
+      const genParams: GenerateParams = {
+        prompt: params.prompt,
+        model: MODEL_MAP[alias] ?? 'gemini-2.5-flash-image',
+        variations: params.variations ?? 1,
+        aspectRatio: (params.aspect_ratio as any) ?? '1:1',
+        negativePrompt: params.negative_prompt,
+      };
+
+      try {
+        const imagesDir = cwd
+          ? path.join(cwd, IMAGES_REL)
+          : path.join(path.dirname(resolvedPath), 'images');
+
+        // Use Sero image agent bridge if available, otherwise error
+        const seroGen = (globalThis as any).__seroImageGen;
+        if (!seroGen) {
+          return {
+            content: [{ type: 'text', text: 'Error: Image generation requires Sero desktop app.' }],
+            details: {},
+          };
+        }
+
+        const result = await seroGen(genParams, imagesDir);
+
+        if (!result.images || result.images.length === 0) {
+          return {
+            content: [{ type: 'text', text: `Error: ${result.error ?? 'No images generated'}` }],
+            details: {},
+          };
+        }
+
+        // Update state
+        const state = await readState(statePath);
+        const generation: Generation = {
+          id: state.nextId,
+          prompt: genParams.prompt,
+          negativePrompt: genParams.negativePrompt,
+          model: genParams.model,
+          aspectRatio: genParams.aspectRatio,
+          images: result.images,
+          createdAt: new Date().toISOString(),
+        };
+        state.generations.unshift(generation);
+        state.nextId++;
+        await writeState(statePath, state);
+
+        const count = result.images.length;
+        const modelName = alias === 'pro' ? 'Nano Banana Pro' : 'Nano Banana';
+        const text = `Generated ${count} image${count > 1 ? 's' : ''} with ${modelName} (${genParams.aspectRatio}).\nPrompt: "${genParams.prompt}"`;
+
+        return { content: [{ type: 'text', text }], details: {} };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: 'text', text: `Error: ${msg}` }], details: {} };
+      }
+    },
+
+    renderCall(args, theme) {
+      const model = args.model === 'pro' ? 'Pro' : 'Flash';
+      let text = theme.fg('toolTitle', theme.bold('generate_image '));
+      text += theme.fg('muted', `[${model}] `);
+      text += theme.fg('dim', `"${args.prompt}"`);
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const msg = result.content[0];
+      const text = msg?.type === 'text' ? msg.text : '';
+      return new Text(
+        text.startsWith('Error:')
+          ? theme.fg('error', text)
+          : theme.fg('success', '🎨 ') + theme.fg('muted', text),
+        0, 0,
+      );
+    },
+  });
+
+  // ── Command ──
+
+  pi.registerCommand('generate-image', {
+    description: 'Generate an image with Gemini Nano Banana',
+    handler: async (args, _ctx) => {
+      const prompt = args.join(' ').trim();
+      if (!prompt) {
+        pi.sendUserMessage(
+          'I want to generate an image. Ask me what I\'d like to create, then use the generate_image tool.',
+        );
+      } else {
+        pi.sendUserMessage(
+          `Generate an image with this prompt using the generate_image tool: "${prompt}"`,
+        );
+      }
+    },
+  });
+}

--- a/packages/pi-imagegen-extension/package.json
+++ b/packages/pi-imagegen-extension/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@sero/imagegen",
+  "version": "0.1.0",
+  "description": "Gemini Nano Banana image generation for Sero",
+  "keywords": ["pi-package"],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+  },
+  "pi": {
+    "extensions": ["./extension/index.ts"]
+  },
+  "sero": {
+    "app": {
+      "id": "imagegen",
+      "name": "ImageGen",
+      "icon": "image",
+      "stateFile": ".sero/apps/imagegen/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "ImageGenApp",
+      "devPort": 5181
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": ">=0.52.0",
+    "@mariozechner/pi-coding-agent": ">=0.52.0",
+    "@mariozechner/pi-tui": ">=0.52.0"
+  },
+  "devDependencies": {
+    "@sero/app-runtime": "workspace:*",
+    "@sero/ui": "workspace:*",
+    "@module-federation/vite": "^1.11.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "@tailwindcss/vite": "^4.1.18",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/packages/pi-imagegen-extension/shared/types.ts
+++ b/packages/pi-imagegen-extension/shared/types.ts
@@ -1,0 +1,45 @@
+// shared/types.ts — Single source of truth for ImageGen state + params.
+
+export type ImageModel = 'gemini-2.5-flash-image' | 'gemini-3-pro-image-preview';
+export type AspectRatio = '1:1' | '2:3' | '3:2' | '3:4' | '4:3' | '9:16' | '16:9';
+
+export interface GenerateParams {
+  prompt: string;
+  model: ImageModel;
+  variations: number;       // 1–4
+  aspectRatio: AspectRatio;
+  negativePrompt?: string;
+}
+
+export interface GeneratedImage {
+  id: string;
+  /** Absolute path to the PNG on disk. */
+  filePath: string;
+  mimeType: string;
+}
+
+export interface Generation {
+  id: number;
+  prompt: string;
+  negativePrompt?: string;
+  model: ImageModel;
+  aspectRatio: AspectRatio;
+  images: GeneratedImage[];
+  createdAt: string; // ISO
+}
+
+export interface ImageGenState {
+  generations: Generation[];
+  nextId: number;
+}
+
+export const DEFAULT_STATE: ImageGenState = {
+  generations: [],
+  nextId: 1,
+};
+
+/** Result returned by the image agent / IPC handler. */
+export interface GenerateResult {
+  generation: Generation;
+  error?: string;
+}

--- a/packages/pi-imagegen-extension/ui/ImageGenApp.tsx
+++ b/packages/pi-imagegen-extension/ui/ImageGenApp.tsx
@@ -1,0 +1,106 @@
+/**
+ * ImageGenApp — Sero app for Gemini Nano Banana image generation.
+ *
+ * Top: generation form. Below: bento gallery of generated images.
+ * Supports direct generation (via IPC) and agent-mediated (via chat).
+ */
+
+import { useState, useCallback, useRef, useEffect, useContext } from 'react';
+import { useAppState, AppContext } from '@sero/app-runtime';
+import { ScrollArea } from '@sero/ui/components/ui/scroll-area';
+import type { ImageGenState, GenerateParams } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+import { GenerateForm } from './components/GenerateForm';
+import { Gallery } from './components/Gallery';
+import { EmptyState } from './components/EmptyState';
+import './styles.css';
+
+interface SeroImagegenBridge {
+  generate(workspaceId: string, params: any): Promise<{ generation: any; error?: string }>;
+  readImage(filePath: string): Promise<string>;
+}
+
+function getBridge(): SeroImagegenBridge | null {
+  return (window as any).sero?.imagegen ?? null;
+}
+
+export function ImageGenApp() {
+  const [state] = useAppState<ImageGenState>(DEFAULT_STATE);
+  const ctx = useContext(AppContext);
+  const workspaceId = ctx?.workspaceId ?? '';
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    containerRef.current?.focus();
+  }, []);
+
+  const handleGenerate = useCallback(
+    async (params: GenerateParams) => {
+      const bridge = getBridge();
+      if (!bridge) {
+        setError('Image generation bridge not available');
+        return;
+      }
+      if (!workspaceId) {
+        setError('No workspace selected');
+        return;
+      }
+
+      setGenerating(true);
+      setError(null);
+
+      try {
+        const result = await bridge.generate(workspaceId, params);
+        if (result.error && !result.generation) {
+          setError(result.error);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Generation failed');
+      } finally {
+        setGenerating(false);
+      }
+    },
+    [workspaceId],
+  );
+
+  const hasGenerations = state.generations.length > 0;
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      className="flex h-full w-full flex-col bg-background outline-none"
+    >
+      {/* Header + Form */}
+      <div className="shrink-0 border-b border-border px-5 py-4">
+        <div className="mb-3 flex items-baseline gap-2">
+          <h1 className="text-base font-semibold text-foreground">ImageGen</h1>
+          <span className="text-xs text-muted-foreground">
+            Gemini Nano Banana
+          </span>
+        </div>
+        <GenerateForm onGenerate={handleGenerate} generating={generating} />
+        {error && (
+          <p className="mt-2 text-xs text-destructive animate-fade-in-up">
+            {error}
+          </p>
+        )}
+      </div>
+
+      {/* Gallery */}
+      <ScrollArea className="flex-1">
+        <div className="p-5">
+          {hasGenerations ? (
+            <Gallery generations={state.generations} />
+          ) : (
+            <EmptyState />
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}
+
+export default ImageGenApp;

--- a/packages/pi-imagegen-extension/ui/components/EmptyState.tsx
+++ b/packages/pi-imagegen-extension/ui/components/EmptyState.tsx
@@ -1,0 +1,14 @@
+/**
+ * EmptyState — shown when the gallery has no images yet.
+ */
+
+export function EmptyState() {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 py-20 animate-fade-in-up">
+      <div className="text-4xl">🎨</div>
+      <p className="text-sm text-muted-foreground">
+        No images yet — describe something to get started
+      </p>
+    </div>
+  );
+}

--- a/packages/pi-imagegen-extension/ui/components/Gallery.tsx
+++ b/packages/pi-imagegen-extension/ui/components/Gallery.tsx
@@ -1,0 +1,105 @@
+/**
+ * Gallery — bento-box layout of generated images.
+ *
+ * Assigns varying sizes based on image count and aspect ratio:
+ *   - Feature items (first, or single-image wide ratio) get 2-col span
+ *   - Montages (multi-image) get square cells
+ *   - Others fill 1-col slots
+ *
+ * Items animate in with staggered delays.
+ */
+
+import { useState, useMemo } from 'react';
+import { cn } from '@sero/ui/lib/utils';
+import type { Generation } from '../../shared/types';
+import { MontageCard } from './MontageCard';
+import { ImageViewer } from './ImageViewer';
+
+interface GalleryProps {
+  generations: Generation[];
+}
+
+type BentoSize = 'large' | 'tall' | 'wide' | 'normal';
+
+function computeBentoSize(gen: Generation, index: number): BentoSize {
+  const isWide = ['16:9', '3:2', '4:3'].includes(gen.aspectRatio);
+  const isTall = ['9:16', '2:3', '3:4'].includes(gen.aspectRatio);
+  const isMulti = gen.images.length > 1;
+
+  // First item or every 5th is featured
+  if (index === 0) return isWide ? 'wide' : 'large';
+  if (index % 5 === 0) return 'large';
+
+  if (isMulti) return 'normal';
+  if (isWide) return 'wide';
+  if (isTall) return 'tall';
+  return 'normal';
+}
+
+const sizeStyles: Record<BentoSize, string> = {
+  large: 'col-span-2 row-span-2',
+  wide: 'col-span-2 row-span-1',
+  tall: 'col-span-1 row-span-2',
+  normal: 'col-span-1 row-span-1',
+};
+
+const sizeHeights: Record<BentoSize, number> = {
+  large: 360,
+  wide: 200,
+  tall: 360,
+  normal: 200,
+};
+
+export function Gallery({ generations }: GalleryProps) {
+  const [viewer, setViewer] = useState<{ gen: Generation; index: number } | null>(null);
+
+  const items = useMemo(
+    () =>
+      generations.map((gen, i) => ({
+        generation: gen,
+        size: computeBentoSize(gen, i),
+      })),
+    [generations],
+  );
+
+  const openViewer = (gen: Generation, imgIndex: number) => {
+    setViewer({ gen, index: imgIndex });
+  };
+
+  return (
+    <>
+      <div
+        className={cn(
+          'grid auto-rows-[180px] gap-3',
+          'grid-cols-2 sm:grid-cols-3 lg:grid-cols-4',
+        )}
+      >
+        {items.map(({ generation, size }, i) => (
+          <div
+            key={generation.id}
+            className={cn(sizeStyles[size], 'animate-fade-in-up')}
+            style={{
+              animationDelay: `${Math.min(i * 60, 400)}ms`,
+              minHeight: sizeHeights[size],
+            }}
+          >
+            <MontageCard
+              generation={generation}
+              onClick={openViewer}
+              style={{ height: '100%' }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Full-size viewer overlay */}
+      {viewer && (
+        <ImageViewer
+          generation={viewer.gen}
+          initialIndex={viewer.index}
+          onClose={() => setViewer(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/pi-imagegen-extension/ui/components/GenerateForm.tsx
+++ b/packages/pi-imagegen-extension/ui/components/GenerateForm.tsx
@@ -1,0 +1,186 @@
+/**
+ * GenerateForm — prompt input + model/param controls for image generation.
+ */
+
+import { useState, useCallback } from 'react';
+import { cn } from '@sero/ui/lib/utils';
+import { Button } from '@sero/ui/components/ui/button';
+import type { ImageModel, AspectRatio, GenerateParams } from '../../shared/types';
+
+const ASPECT_RATIOS: { value: AspectRatio; label: string }[] = [
+  { value: '1:1', label: '1:1' },
+  { value: '3:4', label: '3:4' },
+  { value: '4:3', label: '4:3' },
+  { value: '9:16', label: '9:16' },
+  { value: '16:9', label: '16:9' },
+  { value: '2:3', label: '2:3' },
+  { value: '3:2', label: '3:2' },
+];
+
+interface GenerateFormProps {
+  onGenerate: (params: GenerateParams) => void;
+  generating: boolean;
+}
+
+export function GenerateForm({ onGenerate, generating }: GenerateFormProps) {
+  const [prompt, setPrompt] = useState('');
+  const [model, setModel] = useState<ImageModel>('gemini-2.5-flash-image');
+  const [aspectRatio, setAspectRatio] = useState<AspectRatio>('1:1');
+  const [variations, setVariations] = useState(1);
+  const [negativePrompt, setNegativePrompt] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!prompt.trim() || generating) return;
+      onGenerate({
+        prompt: prompt.trim(),
+        model,
+        aspectRatio,
+        variations,
+        negativePrompt: negativePrompt.trim() || undefined,
+      });
+    },
+    [prompt, model, aspectRatio, variations, negativePrompt, generating, onGenerate],
+  );
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+      {/* Prompt */}
+      <div className="relative">
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Describe the image you want to create…"
+          rows={2}
+          className={cn(
+            'w-full resize-none rounded-lg border border-input bg-background px-3 py-2.5',
+            'text-sm text-foreground placeholder:text-muted-foreground',
+            'focus:outline-none focus:ring-2 focus:ring-ring/50',
+            'transition-shadow duration-200',
+          )}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSubmit(e);
+          }}
+        />
+      </div>
+
+      {/* Controls row */}
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Model toggle */}
+        <div className="flex rounded-md border border-input p-0.5">
+          <button
+            type="button"
+            onClick={() => setModel('gemini-2.5-flash-image')}
+            className={cn(
+              'rounded-sm px-2.5 py-1 text-xs font-medium transition-all duration-150',
+              model === 'gemini-2.5-flash-image'
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            ⚡ Flash
+          </button>
+          <button
+            type="button"
+            onClick={() => setModel('gemini-3-pro-image-preview')}
+            className={cn(
+              'rounded-sm px-2.5 py-1 text-xs font-medium transition-all duration-150',
+              model === 'gemini-3-pro-image-preview'
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            ✨ Pro
+          </button>
+        </div>
+
+        {/* Aspect ratio pills */}
+        <div className="flex gap-1">
+          {ASPECT_RATIOS.slice(0, 5).map((ar) => (
+            <button
+              key={ar.value}
+              type="button"
+              onClick={() => setAspectRatio(ar.value)}
+              className={cn(
+                'rounded-md px-2 py-1 text-xs font-mono transition-all duration-150',
+                aspectRatio === ar.value
+                  ? 'bg-secondary text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50',
+              )}
+            >
+              {ar.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Variations */}
+        <div className="flex items-center gap-1.5 ml-auto">
+          <span className="text-xs text-muted-foreground">Variations</span>
+          <div className="flex rounded-md border border-input p-0.5">
+            {[1, 2, 3, 4].map((n) => (
+              <button
+                key={n}
+                type="button"
+                onClick={() => setVariations(n)}
+                className={cn(
+                  'w-6 h-6 rounded-sm text-xs font-medium transition-all duration-150',
+                  variations === n
+                    ? 'bg-secondary text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground',
+                )}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Advanced toggle */}
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(!showAdvanced)}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {showAdvanced ? '▾ Less' : '▸ More'}
+        </button>
+      </div>
+
+      {/* Advanced options */}
+      {showAdvanced && (
+        <div className="animate-fade-in-up">
+          <input
+            type="text"
+            value={negativePrompt}
+            onChange={(e) => setNegativePrompt(e.target.value)}
+            placeholder="Negative prompt — things to avoid…"
+            className={cn(
+              'w-full rounded-md border border-input bg-background px-3 py-1.5',
+              'text-sm text-foreground placeholder:text-muted-foreground',
+              'focus:outline-none focus:ring-1 focus:ring-ring/50',
+            )}
+          />
+        </div>
+      )}
+
+      {/* Generate button */}
+      <Button
+        type="submit"
+        disabled={!prompt.trim() || generating}
+        className="w-full"
+      >
+        {generating ? (
+          <span className="flex items-center gap-2">
+            <span className="inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            Generating…
+          </span>
+        ) : (
+          <span>
+            Generate {variations > 1 ? `${variations} images` : 'image'}
+          </span>
+        )}
+      </Button>
+    </form>
+  );
+}

--- a/packages/pi-imagegen-extension/ui/components/GenerateForm.tsx
+++ b/packages/pi-imagegen-extension/ui/components/GenerateForm.tsx
@@ -2,7 +2,7 @@
  * GenerateForm — prompt input + model/param controls for image generation.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { cn } from '@sero/ui/lib/utils';
 import { Button } from '@sero/ui/components/ui/button';
 import type { ImageModel, AspectRatio, GenerateParams } from '../../shared/types';
@@ -29,6 +29,18 @@ export function GenerateForm({ onGenerate, generating }: GenerateFormProps) {
   const [variations, setVariations] = useState(1);
   const [negativePrompt, setNegativePrompt] = useState('');
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-resize textarea: min 2 rows, max 10 rows, then scroll
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    const lineHeight = parseFloat(getComputedStyle(el).lineHeight) || 20;
+    const maxHeight = lineHeight * 10;
+    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    el.style.overflowY = el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }, [prompt]);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -50,6 +62,7 @@ export function GenerateForm({ onGenerate, generating }: GenerateFormProps) {
       {/* Prompt */}
       <div className="relative">
         <textarea
+          ref={textareaRef}
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           placeholder="Describe the image you want to create…"

--- a/packages/pi-imagegen-extension/ui/components/ImageViewer.tsx
+++ b/packages/pi-imagegen-extension/ui/components/ImageViewer.tsx
@@ -1,0 +1,142 @@
+/**
+ * ImageViewer — full-size overlay with backdrop blur and smooth transitions.
+ *
+ * Shows individual images from a generation. Arrow keys / click navigate
+ * between images. Click outside or Escape closes.
+ */
+
+import { useEffect, useCallback, useState } from 'react';
+import { cn } from '@sero/ui/lib/utils';
+import { Button } from '@sero/ui/components/ui/button';
+import type { Generation } from '../../shared/types';
+import { useImageLoader } from '../hooks/use-image-loader';
+
+interface ImageViewerProps {
+  generation: Generation;
+  initialIndex: number;
+  onClose: () => void;
+}
+
+export function ImageViewer({ generation, initialIndex, onClose }: ImageViewerProps) {
+  const [index, setIndex] = useState(initialIndex);
+  const [closing, setClosing] = useState(false);
+  const image = generation.images[index];
+  const { dataUri, loading } = useImageLoader(image?.filePath);
+  const total = generation.images.length;
+
+  const close = useCallback(() => {
+    setClosing(true);
+    setTimeout(onClose, 200);
+  }, [onClose]);
+
+  const prev = useCallback(() => {
+    setIndex((i) => (i - 1 + total) % total);
+  }, [total]);
+
+  const next = useCallback(() => {
+    setIndex((i) => (i + 1) % total);
+  }, [total]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') close();
+      else if (e.key === 'ArrowLeft') prev();
+      else if (e.key === 'ArrowRight') next();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [close, prev, next]);
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-xl',
+        closing ? 'animate-overlay-out' : 'animate-overlay-in',
+      )}
+      onClick={close}
+    >
+      {/* Close button */}
+      <button
+        onClick={close}
+        className="absolute right-4 top-4 z-10 rounded-full bg-white/10 p-2 text-white/70 backdrop-blur-sm transition-colors hover:bg-white/20 hover:text-white"
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      </button>
+
+      {/* Main image */}
+      <div
+        className="relative max-h-[85vh] max-w-[85vw] animate-viewer-image"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {loading ? (
+          <div className="flex h-64 w-64 items-center justify-center">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+          </div>
+        ) : dataUri ? (
+          <img
+            key={image.id}
+            src={dataUri}
+            alt={generation.prompt}
+            className="max-h-[85vh] max-w-[85vw] rounded-xl object-contain shadow-2xl animate-fade-in-scale"
+          />
+        ) : null}
+      </div>
+
+      {/* Navigation arrows */}
+      {total > 1 && (
+        <>
+          <button
+            onClick={(e) => { e.stopPropagation(); prev(); }}
+            className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-3 text-white/70 backdrop-blur-sm transition-all hover:bg-white/20 hover:text-white hover:scale-110"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M12 4L6 10L12 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); next(); }}
+            className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-3 text-white/70 backdrop-blur-sm transition-all hover:bg-white/20 hover:text-white hover:scale-110"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M8 4L14 10L8 16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </>
+      )}
+
+      {/* Bottom info bar */}
+      <div
+        className="absolute inset-x-0 bottom-0 flex items-center justify-between px-6 py-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="max-w-[60%]">
+          <p className="text-sm font-medium text-white/90 line-clamp-1">
+            {generation.prompt}
+          </p>
+          <p className="mt-0.5 text-xs text-white/50">
+            {generation.model.includes('pro') ? '✨ Nano Banana Pro' : '⚡ Nano Banana'}
+            {' · '}{generation.aspectRatio}
+          </p>
+        </div>
+        {total > 1 && (
+          <div className="flex items-center gap-1.5">
+            {generation.images.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setIndex(i)}
+                className={cn(
+                  'h-2 w-2 rounded-full transition-all duration-200',
+                  i === index
+                    ? 'bg-white w-4'
+                    : 'bg-white/30 hover:bg-white/50',
+                )}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/pi-imagegen-extension/ui/components/MontageCard.tsx
+++ b/packages/pi-imagegen-extension/ui/components/MontageCard.tsx
@@ -1,0 +1,91 @@
+/**
+ * MontageCard — displays a generation as a single tile or 2×2 montage.
+ *
+ * Single images show as a full card. Multi-image generations show a 2×2
+ * grid with a subtle count badge. Click opens the ImageViewer.
+ */
+
+import { cn } from '@sero/ui/lib/utils';
+import type { Generation } from '../../shared/types';
+import { useImageBatchLoader } from '../hooks/use-image-loader';
+
+interface MontageCardProps {
+  generation: Generation;
+  onClick: (generation: Generation, imageIndex: number) => void;
+  style?: React.CSSProperties;
+}
+
+function Skeleton() {
+  return <div className="absolute inset-0 animate-shimmer rounded-lg bg-secondary" />;
+}
+
+export function MontageCard({ generation, onClick, style }: MontageCardProps) {
+  const filePaths = generation.images.map((img) => img.filePath);
+  const { images, loading } = useImageBatchLoader(filePaths);
+  const count = generation.images.length;
+  const isMontage = count > 1;
+
+  return (
+    <div
+      className="group relative cursor-pointer overflow-hidden rounded-xl bg-card shadow-sm ring-1 ring-border/50 transition-all duration-300 hover:shadow-lg hover:ring-border hover:scale-[1.02]"
+      style={style}
+      onClick={() => onClick(generation, 0)}
+    >
+      {/* Image(s) */}
+      {isMontage ? (
+        <div className="grid grid-cols-2 grid-rows-2 gap-0.5 p-0.5 h-full">
+          {generation.images.slice(0, 4).map((img, i) => {
+            const uri = images.get(img.filePath);
+            return (
+              <div
+                key={img.id}
+                className="relative overflow-hidden rounded-md bg-secondary"
+                onClick={(e) => { e.stopPropagation(); onClick(generation, i); }}
+              >
+                {loading && !uri ? (
+                  <Skeleton />
+                ) : uri ? (
+                  <img
+                    src={uri}
+                    alt=""
+                    className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                  />
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="relative h-full w-full bg-secondary">
+          {loading ? (
+            <Skeleton />
+          ) : images.get(filePaths[0]) ? (
+            <img
+              src={images.get(filePaths[0])}
+              alt=""
+              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          ) : null}
+        </div>
+      )}
+
+      {/* Overlay info */}
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent px-3 py-2.5 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+        <p className="line-clamp-2 text-xs font-medium text-white/90">
+          {generation.prompt}
+        </p>
+        <div className="mt-1 flex items-center gap-2">
+          <span className="text-[10px] font-mono text-white/60">
+            {generation.model.includes('pro') ? '✨ Pro' : '⚡ Flash'}
+          </span>
+          <span className="text-[10px] text-white/40">{generation.aspectRatio}</span>
+          {isMontage && (
+            <span className="ml-auto rounded-full bg-white/20 px-1.5 py-0.5 text-[10px] font-medium text-white/80 backdrop-blur-sm">
+              {count} images
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/pi-imagegen-extension/ui/hooks/use-image-loader.ts
+++ b/packages/pi-imagegen-extension/ui/hooks/use-image-loader.ts
@@ -1,0 +1,122 @@
+/**
+ * Lazy image loader — reads image files via IPC and caches data URIs in memory.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+interface SeroImagegenBridge {
+  readImage(filePath: string): Promise<string>;
+}
+
+function getBridge(): SeroImagegenBridge | null {
+  return (window as any).sero?.imagegen ?? null;
+}
+
+const imageCache = new Map<string, string>();
+
+/** Load a single image by file path, returning a data URI. */
+export function useImageLoader(filePath: string | undefined): {
+  dataUri: string | null;
+  loading: boolean;
+} {
+  const [dataUri, setDataUri] = useState<string | null>(
+    filePath ? imageCache.get(filePath) ?? null : null,
+  );
+  const [loading, setLoading] = useState(!dataUri && !!filePath);
+
+  useEffect(() => {
+    if (!filePath) return;
+
+    const cached = imageCache.get(filePath);
+    if (cached) {
+      setDataUri(cached);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    const bridge = getBridge();
+    if (!bridge) {
+      setLoading(false);
+      return;
+    }
+
+    bridge.readImage(filePath).then((uri) => {
+      if (cancelled) return;
+      imageCache.set(filePath, uri);
+      setDataUri(uri);
+      setLoading(false);
+    }).catch(() => {
+      if (!cancelled) setLoading(false);
+    });
+
+    return () => { cancelled = true; };
+  }, [filePath]);
+
+  return { dataUri, loading };
+}
+
+/** Batch-load multiple images. Returns a map of filePath → dataUri. */
+export function useImageBatchLoader(filePaths: string[]): {
+  images: Map<string, string>;
+  loading: boolean;
+} {
+  const [images, setImages] = useState<Map<string, string>>(() => {
+    const initial = new Map<string, string>();
+    for (const fp of filePaths) {
+      const cached = imageCache.get(fp);
+      if (cached) initial.set(fp, cached);
+    }
+    return initial;
+  });
+  const [loading, setLoading] = useState(false);
+  const keyRef = useRef('');
+
+  const load = useCallback(async (paths: string[]) => {
+    const bridge = getBridge();
+    if (!bridge || paths.length === 0) return;
+
+    const missing = paths.filter((p) => !imageCache.has(p));
+    if (missing.length === 0) {
+      const result = new Map<string, string>();
+      for (const p of paths) result.set(p, imageCache.get(p)!);
+      setImages(result);
+      return;
+    }
+
+    setLoading(true);
+
+    const results = await Promise.allSettled(
+      missing.map(async (fp) => {
+        const uri = await bridge.readImage(fp);
+        imageCache.set(fp, uri);
+        return [fp, uri] as const;
+      }),
+    );
+
+    const newMap = new Map<string, string>();
+    for (const p of paths) {
+      const cached = imageCache.get(p);
+      if (cached) newMap.set(p, cached);
+    }
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
+        newMap.set(r.value[0], r.value[1]);
+      }
+    }
+
+    setImages(newMap);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    const key = filePaths.join('|');
+    if (key === keyRef.current) return;
+    keyRef.current = key;
+    load(filePaths);
+  }, [filePaths, load]);
+
+  return { images, loading };
+}

--- a/packages/pi-imagegen-extension/ui/index.html
+++ b/packages/pi-imagegen-extension/ui/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Sero ImageGen (remote)</title></head>
+<body><div id="root"></div></body>
+</html>

--- a/packages/pi-imagegen-extension/ui/styles.css
+++ b/packages/pi-imagegen-extension/ui/styles.css
@@ -1,0 +1,89 @@
+@import "tailwindcss";
+
+@source "../../ui/src/components";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+/* ── Gallery animations ── */
+
+@keyframes fade-in-up {
+  from { opacity: 0; transform: translateY(12px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes fade-in-scale {
+  from { opacity: 0; transform: scale(0.92); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes overlay-in {
+  from { opacity: 0; backdrop-filter: blur(0px); }
+  to   { opacity: 1; backdrop-filter: blur(20px); }
+}
+
+@keyframes overlay-out {
+  from { opacity: 1; backdrop-filter: blur(20px); }
+  to   { opacity: 0; backdrop-filter: blur(0px); }
+}
+
+@keyframes viewer-image-in {
+  from { opacity: 0; transform: scale(0.85); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+@keyframes shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+@utility animate-fade-in-up {
+  animation: fade-in-up 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@utility animate-fade-in-scale {
+  animation: fade-in-scale 0.35s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@utility animate-overlay-in {
+  animation: overlay-in 0.25s ease-out both;
+}
+
+@utility animate-overlay-out {
+  animation: overlay-out 0.2s ease-in both;
+}
+
+@utility animate-viewer-image {
+  animation: viewer-image-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+@utility animate-shimmer {
+  background: linear-gradient(90deg, transparent 25%, var(--muted) 50%, transparent 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}

--- a/packages/pi-imagegen-extension/ui/tsconfig.json
+++ b/packages/pi-imagegen-extension/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero/app-runtime": ["../../app-runtime/src/index.ts"],
+      "@sero/ui": ["../../ui/src/index.ts"],
+      "@sero/ui/*": ["../../ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-imagegen-extension/vite.config.ts
+++ b/packages/pi-imagegen-extension/vite.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_imagegen',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './ImageGenApp': './ui/ImageGenApp.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5181,
+    strictPort: true,
+    origin: 'http://localhost:5181',
+  },
+  optimizeDeps: {
+    exclude: ['@sero/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});

--- a/packages/pi-notes-extension/extension/index.ts
+++ b/packages/pi-notes-extension/extension/index.ts
@@ -297,9 +297,14 @@ export default function (pi: ExtensionAPI) {
   // ── Command: /notes ────────────────────────────────────────
 
   pi.registerCommand('notes', {
-    description: 'Show all notes',
-    handler: async (_args, _ctx) => {
-      pi.sendUserMessage('List all my notes using the notes tool.');
+    description: 'Show all notes (or pass instructions inline)',
+    handler: async (args, _ctx) => {
+      const instruction = args.trim();
+      if (instruction) {
+        pi.sendUserMessage(`Using the notes tool: ${instruction}`);
+      } else {
+        pi.sendUserMessage('List all my notes using the notes tool.');
+      }
     },
   });
 }

--- a/packages/pi-todo-extension/extension/index.ts
+++ b/packages/pi-todo-extension/extension/index.ts
@@ -189,12 +189,14 @@ export default function (pi: ExtensionAPI) {
   // ── Command: /todos ────────────────────────────────────────
 
   pi.registerCommand('todos', {
-    description: 'Show all workspace todos',
-    handler: async (_args, _ctx) => {
-      // Trigger the agent to list todos via the tool.
-      // This works in both Pi CLI and Sero — the agent calls
-      // the todo tool with action: list and renders the result.
-      pi.sendUserMessage('List all my current todos using the todo tool.');
+    description: 'Show all workspace todos (or pass instructions inline)',
+    handler: async (args, _ctx) => {
+      const instruction = args.trim();
+      if (instruction) {
+        pi.sendUserMessage(`Using the todo tool: ${instruction}`);
+      } else {
+        pi.sendUserMessage('List all my current todos using the todo tool.');
+      }
     },
   });
 }

--- a/packages/pi-weight-tracker/extension/index.ts
+++ b/packages/pi-weight-tracker/extension/index.ts
@@ -315,9 +315,14 @@ export default function (pi: ExtensionAPI) {
   // ── Command: /weight ────────────────────────────────────────
 
   pi.registerCommand('weight', {
-    description: 'Show weight tracking status and summary',
-    handler: async (_args, _ctx) => {
-      pi.sendUserMessage('Show my weight tracking status using the weight tool.');
+    description: 'Show weight tracking status (or pass instructions inline)',
+    handler: async (args, _ctx) => {
+      const instruction = args.trim();
+      if (instruction) {
+        pi.sendUserMessage(`Using the weight tool: ${instruction}`);
+      } else {
+        pi.sendUserMessage('Show my weight tracking status using the weight tool.');
+      }
     },
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@google/genai':
+        specifier: ^1.41.0
+        version: 1.41.0(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))
       '@headless-tree/core':
         specifier: ^1.6.3
         version: 1.6.3
@@ -357,6 +360,58 @@ importers:
       '@sero/app-runtime':
         specifier: workspace:*
         version: link:../app-runtime
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
+  packages/pi-imagegen-extension:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: '>=0.52.0'
+        version: 0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.52.0'
+        version: 0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.52.0'
+        version: 0.52.12
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
+    devDependencies:
+      '@module-federation/vite':
+        specifier: ^1.11.0
+        version: 1.11.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@sero/app-runtime':
+        specifier: workspace:*
+        version: link:../app-runtime
+      '@sero/ui':
+        specifier: workspace:*
+        version: link:../ui
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))


### PR DESCRIPTION
feat: add ImageGen Sero app — Gemini Nano Banana image generation
New Sero app (packages/pi-imagegen-extension/) with Pi extension + federated UI:

Extension:
- generate_image tool — prompt, model (flash/pro), variations (1-4),
  aspect ratio, negative prompt
- /generate-image command for ChatPanel

UI (bento gallery):
- GenerateForm with model toggle, aspect ratio pills, variation selector
- Bento-box gallery with dynamic sizing (featured, wide, tall, normal)
- MontageCard for multi-image variations (2x2 grid with drill-down)
- ImageViewer full-screen overlay with backdrop blur, arrow nav, animations
- Lazy image loading via IPC with in-memory cache

Backend:
- Custom image agent using Pi SDK AuthStorage + @google/genai
- Supports gemini-2.5-flash-image (Nano Banana) and
  gemini-3-pro-image-preview (Nano Banana Pro)
- GEMINI_API_KEY env var preferred, Pi SDK auth as fallback
- IPC handlers for direct UI generation + image file reading
- Images saved as PNGs, metadata in workspace state.json