### PR TITLE
feat(desktop): workspace create/import flow with auto-session and container fixes

### DIFF
--- a/apps/desktop/electron/container/index.ts
+++ b/apps/desktop/electron/container/index.ts
@@ -49,6 +49,8 @@ export class ContainerManager {
   private containers = new Map<string, string>();
   /** workspaceId → container IP (cached for port forwarding) */
   private containerIps = new Map<string, string>();
+  /** workspaceId → in-flight ensure() promise (deduplicates concurrent calls) */
+  private ensureInflight = new Map<string, Promise<ContainerState>>();
 
   /** Terminal PTY management — use directly from IPC handlers. */
   readonly terminals: TerminalManager;
@@ -116,8 +118,25 @@ export class ContainerManager {
   /**
    * Ensure a workspace has a running container. Creates if needed.
    * This is the primary entry point — lazy creation on first use.
+   *
+   * Concurrent calls for the same workspace are deduplicated: if an ensure
+   * is already in-flight, the same promise is returned instead of racing.
    */
   async ensure(config: ContainerConfig): Promise<ContainerState> {
+    const wsId = config.workspaceId;
+
+    // Deduplicate: return the in-flight promise if one exists
+    const inflight = this.ensureInflight.get(wsId);
+    if (inflight) return inflight;
+
+    const promise = this.ensureOnce(config).finally(() => {
+      this.ensureInflight.delete(wsId);
+    });
+    this.ensureInflight.set(wsId, promise);
+    return promise;
+  }
+
+  private async ensureOnce(config: ContainerConfig): Promise<ContainerState> {
     let state: ContainerState;
     try {
       state = await this.ensureInternal(config);

--- a/apps/desktop/electron/container/lifecycle.ts
+++ b/apps/desktop/electron/container/lifecycle.ts
@@ -101,6 +101,30 @@ export async function clearGhostContainer(cid: string): Promise<void> {
 
 /* ── Container lifecycle ──────────────────────────────────── */
 
+/** Check whether a delete/force error is just "container not found" (harmless). */
+function isNotFoundError(err: unknown): boolean {
+  const msg = errorMessage(err);
+  return msg.includes('not found') || msg.includes('no such container') || msg.includes('does not exist');
+}
+
+/**
+ * Force-remove a container, escalating to ghost recovery only when necessary.
+ *
+ * - If `delete --force` succeeds → done.
+ * - If it fails with "not found" → the name is already free, done.
+ * - If it fails with a ghost error → clear storage + restart system.
+ * - Any other failure → also escalate (the name is stuck).
+ */
+async function forceRemoveContainer(cid: string): Promise<void> {
+  try {
+    await execFileAsync(CONTAINER_BIN, ['delete', '--force', cid], { timeout: 15_000 });
+  } catch (delErr: unknown) {
+    if (isNotFoundError(delErr)) return; // Already gone — nothing to do
+    console.warn(`[container] delete --force failed for ${cid}, escalating to ghost recovery`);
+    await clearGhostContainer(cid);
+  }
+}
+
 /**
  * Check if a container already exists and try to get it running.
  * Returns the container state if successful, null if we need to create fresh.
@@ -115,13 +139,13 @@ export async function resolveExistingContainer(
   try {
     existing = await inspectFn(workspaceId);
   } catch {
-    // Container doesn't exist — clean any stale name reservation
+    // Container doesn't exist — try cleaning any stale name reservation.
+    // This is a light-touch attempt; if delete fails with "not found"
+    // that's fine — the name is already free for creation.
     try {
       await execFileAsync(CONTAINER_BIN, ['delete', '--force', cid], { timeout: 15_000 });
-    } catch (delErr: unknown) {
-      if (isGhostError(delErr)) {
-        await clearGhostContainer(cid);
-      }
+    } catch {
+      // Ignore — if the container truly doesn't exist, nothing to delete.
     }
     return null;
   }
@@ -143,17 +167,9 @@ export async function resolveExistingContainer(
     console.warn(`[container] Failed to start ${cid}:`, errorMessage(startErr));
   }
 
-  // Start failed — delete and let caller create fresh
-  try {
-    await execFileAsync(CONTAINER_BIN, ['delete', '--force', cid], { timeout: 15_000 });
-    console.log(`[container] Deleted corrupted container ${cid}, will recreate`);
-  } catch (delErr: unknown) {
-    if (isGhostError(delErr)) {
-      await clearGhostContainer(cid);
-    } else {
-      console.warn(`[container] Delete failed for ${cid}:`, errorMessage(delErr));
-    }
-  }
+  // Start failed — force-remove (escalates to ghost recovery if needed)
+  console.log(`[container] Removing corrupted container ${cid}, will recreate`);
+  await forceRemoveContainer(cid);
 
   return null;
 }
@@ -229,8 +245,23 @@ export async function createFreshContainer(
   try {
     await execFileAsync(CONTAINER_BIN, args, { timeout: 60_000 });
   } catch (err: unknown) {
-    const e = err as Record<string, unknown>;
-    throw new Error(`Failed to create container ${cid}: ${e.stderr || errorMessage(err)}`);
+    const errStr = String((err as Record<string, unknown>).stderr || errorMessage(err));
+
+    // If a stale container with the same name exists (e.g. from a previous
+    // run that wasn't cleaned up), force-remove it (escalating to ghost
+    // recovery if needed) and retry once.
+    if (errStr.includes('already exists')) {
+      console.warn(`[container] Stale container ${cid} detected, force-removing and retrying...`);
+      await forceRemoveContainer(cid);
+      try {
+        await execFileAsync(CONTAINER_BIN, args, { timeout: 60_000 });
+      } catch (retryErr: unknown) {
+        const re = retryErr as Record<string, unknown>;
+        throw new Error(`Failed to create container ${cid} after cleanup: ${re.stderr || errorMessage(retryErr)}`);
+      }
+    } else {
+      throw new Error(`Failed to create container ${cid}: ${errStr}`);
+    }
   }
 
   containerMap.set(config.workspaceId, cid);

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -8,9 +8,6 @@ import {
   type SlashCommandInfo,
 } from '@mariozechner/pi-coding-agent';
 import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
-import { promises as fs } from 'fs';
-import path from 'path';
-
 import { IpcChannels } from '../../src/types/ipc';
 import type {
   ChatMessage,
@@ -35,6 +32,7 @@ import {
   buildCommandList,
 } from './agent-helpers';
 import { logRawEvent, logTurnContext } from './debug';
+import { readGlobalAgentsMd } from './global-agents';
 import { workspaceManager } from '../workspace';
 import { createSeroExtensionFactory } from '../sero-extension';
 import { SERO_AGENT_DIR } from '../env';
@@ -233,19 +231,6 @@ function subscribeToSession(sessionId: string, session: AgentSession): () => voi
   });
 }
 
-async function readGlobalAgentsMd(): Promise<{ path: string; content: string } | null> {
-  const globalPath = workspaceManager.getPath('global');
-  if (!globalPath) return null;
-
-  const filePath = path.join(globalPath, 'AGENTS.md');
-  try {
-    const content = await fs.readFile(filePath, 'utf8');
-    return { path: filePath, content };
-  } catch {
-    return null;
-  }
-}
-
 export function registerAgentHandlers(): void {
   ipcMain.handle(
     IpcChannels.agent.open,
@@ -299,7 +284,7 @@ export function registerAgentHandlers(): void {
         : undefined;
       const builtinTools = useContainer ? [] : createCodingTools(wsPath);
 
-      const globalAgentsFile = await readGlobalAgentsMd();
+      const globalAgentsFile = await readGlobalAgentsMd(workspaceId);
 
       const loader = new DefaultResourceLoader({
         cwd: wsPath,

--- a/apps/desktop/electron/ipc/global-agents.ts
+++ b/apps/desktop/electron/ipc/global-agents.ts
@@ -1,0 +1,42 @@
+/**
+ * Global workspace AGENTS.md injection.
+ *
+ * Reads the global workspace's AGENTS.md and prepends context when
+ * injecting into non-global sessions so the agent resolves relative
+ * file references (SOUL.md, MEMORY.md, etc.) against the global
+ * workspace path, not the current session's workspace.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { workspaceManager } from '../workspace';
+
+export async function readGlobalAgentsMd(
+  forWorkspaceId: string,
+): Promise<{ path: string; content: string } | null> {
+  const globalPath = workspaceManager.getPath('global');
+  if (!globalPath) return null;
+
+  const filePath = path.join(globalPath, 'AGENTS.md');
+  try {
+    let content = await fs.readFile(filePath, 'utf8');
+
+    // When injected into a non-global session, prepend context so the agent
+    // resolves relative file references (SOUL.md, MEMORY.md, etc.) against
+    // the global workspace, not the current session's workspace.
+    if (forWorkspaceId !== 'global') {
+      const header =
+        `> **Note:** The following instructions come from your global workspace ` +
+        `at \`${globalPath}\`. Any file references (SOUL.md, USER.md, MEMORY.md, ` +
+        `memory/, etc.) should be read from that directory using their full path, ` +
+        `e.g. \`${globalPath}/SOUL.md\`. Do NOT look for these files in the ` +
+        `current workspace.\n\n`;
+      content = header + content;
+    }
+
+    return { path: filePath, content };
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/electron/ipc/workspace.ts
+++ b/apps/desktop/electron/ipc/workspace.ts
@@ -24,11 +24,11 @@ export function registerWorkspaceHandlers(): void {
     },
   );
 
-  // ── Create a new workspace under ~/.sero-ui/workspaces/ ────
+  // ── Create a new workspace ──────────────────────────────────
   ipcMain.handle(
     IpcChannels.workspace.create,
-    async (_event, name: string): Promise<WorkspaceInfo> => {
-      return workspaceManager.create(name);
+    async (_event, name: string, parentPath?: string): Promise<WorkspaceInfo> => {
+      return workspaceManager.create(name, parentPath);
     },
   );
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -54,8 +54,8 @@ contextBridge.exposeInMainWorld('sero', {
     list: (): Promise<WorkspaceInfo[]> =>
       ipcRenderer.invoke(IpcChannels.workspace.list),
 
-    create: (name: string): Promise<WorkspaceInfo> =>
-      ipcRenderer.invoke(IpcChannels.workspace.create, name),
+    create: (name: string, parentPath?: string): Promise<WorkspaceInfo> =>
+      ipcRenderer.invoke(IpcChannels.workspace.create, name, parentPath),
 
     remove: (id: string): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.workspace.remove, id),

--- a/apps/desktop/electron/workspace.ts
+++ b/apps/desktop/electron/workspace.ts
@@ -10,6 +10,7 @@
  */
 
 import { promises as fs } from 'fs';
+import os from 'os';
 import path from 'path';
 
 import type {
@@ -276,6 +277,14 @@ export class WorkspaceManager {
    * (e.g. /Users/me/projects/my-app). Otherwise falls back to ~/.sero-ui/workspaces/.
    */
   async create(name: string, parentPath?: string): Promise<WorkspaceInfo> {
+    if (parentPath) {
+      const resolved = path.resolve(parentPath);
+      const home = os.homedir();
+      if (!resolved.startsWith(home + path.sep) && resolved !== home) {
+        throw new Error(`Workspace parent path must be under the user home directory (${home})`);
+      }
+    }
+
     const id = this.slugify(name);
     const uniqueId = this.ensureUniqueId(id);
     const wsPath = parentPath

--- a/apps/desktop/electron/workspace.ts
+++ b/apps/desktop/electron/workspace.ts
@@ -271,12 +271,16 @@ export class WorkspaceManager {
   }
 
   /**
-   * Create a new workspace under ~/.sero-ui/workspaces/.
+   * Create a new workspace.
+   * If `parentPath` is provided, the workspace directory is created there
+   * (e.g. /Users/me/projects/my-app). Otherwise falls back to ~/.sero-ui/workspaces/.
    */
-  async create(name: string): Promise<WorkspaceInfo> {
+  async create(name: string, parentPath?: string): Promise<WorkspaceInfo> {
     const id = this.slugify(name);
     const uniqueId = this.ensureUniqueId(id);
-    const wsPath = path.join(WORKSPACES_DIR, uniqueId);
+    const wsPath = parentPath
+      ? path.join(path.resolve(parentPath), uniqueId)
+      : path.join(WORKSPACES_DIR, uniqueId);
 
     await fs.mkdir(wsPath, { recursive: true });
 

--- a/apps/desktop/src/components/layout/AddWorkspaceViews.tsx
+++ b/apps/desktop/src/components/layout/AddWorkspaceViews.tsx
@@ -1,0 +1,134 @@
+import { FolderInput, FolderOpen, FolderPlus, Loader2, X } from 'lucide-react';
+import { Button } from '@sero/ui/components/ui/button';
+import { Input } from '@sero/ui/components/ui/input';
+import { cn } from '@sero/ui/lib/utils';
+
+/** Initial view — two action rows. */
+export function PickView({
+  onCreateNew,
+  onImportExisting,
+}: {
+  onCreateNew: () => void;
+  onImportExisting: () => void;
+}) {
+  return (
+    <div className="flex flex-col py-1">
+      <button
+        onClick={onCreateNew}
+        className="flex items-center gap-2.5 px-3 py-2 text-left text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+      >
+        <FolderPlus className="size-3.5 text-[var(--text-muted)]" />
+        Create New
+      </button>
+      <button
+        onClick={onImportExisting}
+        className="flex items-center gap-2.5 px-3 py-2 text-left text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+      >
+        <FolderInput className="size-3.5 text-[var(--text-muted)]" />
+        Import Existing
+      </button>
+    </div>
+  );
+}
+
+/** Create form view — name input, optional location, create button. */
+export function CreateView({
+  inputRef,
+  name,
+  onNameChange,
+  parentPath,
+  onPickLocation,
+  onClearLocation,
+  onBack,
+  onCreate,
+  isCreating,
+}: {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  name: string;
+  onNameChange: (v: string) => void;
+  parentPath: string | null;
+  onPickLocation: () => void;
+  onClearLocation: () => void;
+  onBack: () => void;
+  onCreate: () => void;
+  isCreating: boolean;
+}) {
+  const locationLabel = parentPath
+    ? parentPath.split('/').filter(Boolean).pop()
+    : null;
+
+  return (
+    <form
+      onSubmit={(e) => { e.preventDefault(); onCreate(); }}
+      className="flex flex-col gap-2.5 p-3"
+    >
+      {/* Name */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">
+          Name
+        </label>
+        <Input
+          ref={inputRef}
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder="My Project"
+          className="h-7 text-xs"
+          autoFocus
+        />
+      </div>
+
+      {/* Location */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">
+          Location
+        </label>
+        <button
+          type="button"
+          onClick={onPickLocation}
+          className={cn(
+            'flex h-7 w-full items-center gap-1.5 rounded-md border px-2 text-xs transition-colors',
+            'border-[var(--border-default)] bg-[var(--bg-base)] hover:bg-[var(--bg-elevated)]',
+            parentPath ? 'text-[var(--text-primary)]' : 'text-[var(--text-muted)]',
+          )}
+          title={parentPath ?? 'Default (~/.sero-ui/workspaces)'}
+        >
+          <FolderOpen className="size-3 shrink-0" />
+          <span className="min-w-0 flex-1 truncate text-left">
+            {locationLabel ?? 'Default'}
+          </span>
+          {parentPath && (
+            <span
+              role="button"
+              tabIndex={-1}
+              onClick={(e) => { e.stopPropagation(); onClearLocation(); }}
+              className="shrink-0 rounded p-0.5 hover:bg-[var(--bg-base)]"
+            >
+              <X className="size-2.5 text-[var(--text-muted)]" />
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* Actions */}
+      <div className="flex justify-between">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={onBack}
+        >
+          Back
+        </Button>
+        <Button
+          type="submit"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          disabled={!name.trim() || isCreating}
+        >
+          {isCreating ? <Loader2 className="size-3 animate-spin" /> : 'Create'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/apps/desktop/src/components/layout/SessionNode.tsx
+++ b/apps/desktop/src/components/layout/SessionNode.tsx
@@ -1,0 +1,130 @@
+import { useState } from 'react';
+import { Loader2, Trash2 } from 'lucide-react';
+import { useSessionStore } from '@/stores/sessions';
+import { useStreamingSessionIds } from '@/stores/agent';
+import { Button } from '@sero/ui/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@sero/ui/components/ui/popover';
+import type { SeroSessionInfo } from '@/types/ipc';
+import { cn } from '@sero/ui/lib/utils';
+
+// ── Session node ───────────────────────────────────────────────
+
+export function SessionNode({ session }: { session: SeroSessionInfo }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const activeSessionId = useSessionStore((s) => s.activeSessionId);
+  const setActiveSession = useSessionStore((s) => s.setActiveSession);
+  const deleteSession = useSessionStore((s) => s.deleteSession);
+  const streamingIds = useStreamingSessionIds();
+
+  const isActive = activeSessionId === session.id;
+  const isStreaming = streamingIds.includes(session.id);
+
+  const title = session.name || session.firstMessage || 'New chat';
+  const modified = formatRelativeDate(session.modified);
+
+  const handleDelete = async () => {
+    setConfirmOpen(false);
+    await deleteSession(session.path);
+  };
+
+  return (
+    <button
+      onClick={() => setActiveSession(session.id)}
+      className={cn(
+        'group flex w-full items-center gap-4 rounded-md px-2 py-1 text-left transition-colors',
+        isActive
+          ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+          : 'hover:bg-[var(--bg-elevated)]',
+      )}
+    >
+      {/* Streaming spinner — only visible when agent is working */}
+      <span className="flex size-3 shrink-0 items-center justify-center">
+        {isStreaming && (
+          <Loader2 className="size-3 animate-spin text-emerald-500" />
+        )}
+      </span>
+
+      {/* Title + metadata */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm font-medium text-[var(--text-primary)]">
+          {title}
+        </span>
+        <div className="flex items-center gap-1 text-xs text-[var(--text-muted)]">
+          <span>{modified}</span>
+          {session.messageCount > 0 && (
+            <>
+              <span>·</span>
+              <span>{session.messageCount} msg{session.messageCount !== 1 ? 's' : ''}</span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Delete with confirmation popover */}
+      <Popover open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <PopoverTrigger asChild>
+          <span
+            role="button"
+            tabIndex={-1}
+            onClick={(e) => { e.stopPropagation(); setConfirmOpen(true); }}
+            onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); setConfirmOpen(true); } }}
+            className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-[var(--bg-base)] group-hover:opacity-100"
+            title="Delete session"
+          >
+            <Trash2 className="size-3 text-[var(--text-muted)]" />
+          </span>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          side="right"
+          className="w-52 p-3"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <p className="mb-3 text-xs text-[var(--text-secondary)]">
+            Delete this session?
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 px-2 text-sm"
+              onClick={(e) => { e.stopPropagation(); setConfirmOpen(false); }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              className="h-6 px-2 text-sm"
+              onClick={(e) => { e.stopPropagation(); handleDelete(); }}
+            >
+              Delete
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </button>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────
+
+export function formatRelativeDate(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMins < 1) return 'Just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}

--- a/apps/desktop/src/components/layout/WorkspaceTree.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceTree.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Box,
   ChevronDown,
   ChevronRight,
   FolderOpen,
-  FolderPlus,
   Loader2,
   Minus,
   Monitor,
@@ -24,6 +23,8 @@ import {
 } from '@sero/ui/components/ui/popover';
 import type { WorkspaceInfo, SeroSessionInfo } from '@/types/ipc';
 import { cn } from '@sero/ui/lib/utils';
+import { SessionNode } from './SessionNode';
+import { PickView, CreateView } from './AddWorkspaceViews';
 
 /**
  * WorkspaceTree — tree view of workspaces → sessions.
@@ -41,25 +42,12 @@ export function WorkspaceTree() {
   const openWorkspaces = useOpenWorkspaces();
   const sessionsByWorkspace = useSessionsByWorkspace();
   const isLoadingWorkspaces = useWorkspaceStore((s) => s.isLoading);
-  const addFolder = useWorkspaceStore((s) => s.addFolder);
 
   // Load on mount
   useEffect(() => {
     loadWorkspaces();
     loadSessions();
   }, [loadWorkspaces, loadSessions]);
-
-  const handleAddFolder = async () => {
-    try {
-      const folderPath = await window.sero.workspace.pickFolder();
-      if (!folderPath) return; // User cancelled
-
-      await addFolder(folderPath);
-      await loadSessions(); // Refresh sessions for the new workspace
-    } catch (err) {
-      console.error('Failed to add folder:', err);
-    }
-  };
 
   if (isLoadingWorkspaces) {
     return (
@@ -76,13 +64,7 @@ export function WorkspaceTree() {
         <span className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
           Workspaces
         </span>
-        <button
-          onClick={handleAddFolder}
-          className="rounded-md p-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-          title="Add workspace folder"
-        >
-          <FolderPlus className="size-3.5" />
-        </button>
+        <AddWorkspaceMenu />
       </div>
 
       {/* Tree */}
@@ -104,6 +86,114 @@ export function WorkspaceTree() {
     </div>
   );
 }
+
+// ── Add Workspace menu ─────────────────────────────────────────
+
+type AddView = 'pick' | 'create';
+
+function AddWorkspaceMenu() {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<AddView>('pick');
+  const [newName, setNewName] = useState('');
+  const [parentPath, setParentPath] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Guards against Radix auto-closing the popover when a native dialog steals focus
+  const pickingFolderRef = useRef(false);
+  const createWorkspace = useWorkspaceStore((s) => s.createWorkspace);
+  const addFolder = useWorkspaceStore((s) => s.addFolder);
+  const loadSessions = useSessionStore((s) => s.loadSessions);
+
+  const reset = () => { setView('pick'); setNewName(''); setParentPath(null); };
+
+  const handleImportExisting = async () => {
+    setOpen(false);
+    pickingFolderRef.current = true;
+    try {
+      const folderPath = await window.sero.workspace.pickFolder();
+      if (!folderPath) return;
+      await addFolder(folderPath);
+      await loadSessions();
+    } catch (err) {
+      console.error('Failed to import workspace:', err);
+    } finally {
+      pickingFolderRef.current = false;
+    }
+  };
+
+  const handlePickLocation = async () => {
+    pickingFolderRef.current = true;
+    try {
+      const picked = await window.sero.workspace.pickFolder();
+      if (picked) setParentPath(picked);
+    } finally {
+      pickingFolderRef.current = false;
+    }
+  };
+
+  const handleCreate = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed || isCreating) return;
+    setIsCreating(true);
+    try {
+      await createWorkspace(trimmed, parentPath ?? undefined);
+      await loadSessions();
+      setOpen(false);
+    } catch (err) {
+      console.error('Failed to create workspace:', err);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={(o) => {
+      if (!o && pickingFolderRef.current) return; // Native dialog stole focus — don't close
+      setOpen(o);
+      if (!o) reset();
+    }}>
+      <PopoverTrigger asChild>
+        <button
+          className="rounded-md p-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+          title="Add workspace"
+        >
+          <Plus className="size-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="bottom"
+        className="w-64 p-0"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {view === 'pick' ? (
+          <PickView
+            onCreateNew={() => {
+              setView('create');
+              // Focus the input after the view transition renders
+              requestAnimationFrame(() => inputRef.current?.focus());
+            }}
+            onImportExisting={handleImportExisting}
+          />
+        ) : (
+          <CreateView
+            inputRef={inputRef}
+            name={newName}
+            onNameChange={setNewName}
+            parentPath={parentPath}
+            onPickLocation={handlePickLocation}
+            onClearLocation={() => setParentPath(null)}
+            onBack={() => { setView('pick'); setNewName(''); setParentPath(null); }}
+            onCreate={handleCreate}
+            isCreating={isCreating}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+
 
 // ── Workspace node ─────────────────────────────────────────────
 
@@ -315,120 +405,4 @@ function WorkspaceNode({
   );
 }
 
-// ── Session node ───────────────────────────────────────────────
 
-function SessionNode({ session }: { session: SeroSessionInfo }) {
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const activeSessionId = useSessionStore((s) => s.activeSessionId);
-  const setActiveSession = useSessionStore((s) => s.setActiveSession);
-  const deleteSession = useSessionStore((s) => s.deleteSession);
-  const streamingIds = useStreamingSessionIds();
-
-  const isActive = activeSessionId === session.id;
-  const isStreaming = streamingIds.includes(session.id);
-
-  const title = session.name || session.firstMessage || 'New chat';
-  const modified = formatRelativeDate(session.modified);
-
-  const handleDelete = async () => {
-    setConfirmOpen(false);
-    await deleteSession(session.path);
-  };
-
-  return (
-    <button
-      onClick={() => setActiveSession(session.id)}
-      className={cn(
-        'group flex w-full items-center gap-4 rounded-md px-2 py-1 text-left transition-colors',
-        isActive
-          ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
-          : 'hover:bg-[var(--bg-elevated)]',
-      )}
-    >
-      {/* Streaming spinner — only visible when agent is working */}
-      <span className="flex size-3 shrink-0 items-center justify-center">
-        {isStreaming && (
-          <Loader2 className="size-3 animate-spin text-emerald-500" />
-        )}
-      </span>
-
-      {/* Title + metadata */}
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate text-sm font-medium text-[var(--text-primary)]">
-          {title}
-        </span>
-        <div className="flex items-center gap-1 text-xs text-[var(--text-muted)]">
-          <span>{modified}</span>
-          {session.messageCount > 0 && (
-            <>
-              <span>·</span>
-              <span>{session.messageCount} msg{session.messageCount !== 1 ? 's' : ''}</span>
-            </>
-          )}
-        </div>
-      </div>
-
-      {/* Delete with confirmation popover */}
-      <Popover open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <PopoverTrigger asChild>
-          <span
-            role="button"
-            tabIndex={-1}
-            onClick={(e) => { e.stopPropagation(); setConfirmOpen(true); }}
-            onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); setConfirmOpen(true); } }}
-            className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-[var(--bg-base)] group-hover:opacity-100"
-            title="Delete session"
-          >
-            <Trash2 className="size-3 text-[var(--text-muted)]" />
-          </span>
-        </PopoverTrigger>
-        <PopoverContent
-          align="start"
-          side="right"
-          className="w-52 p-3"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <p className="mb-3 text-xs text-[var(--text-secondary)]">
-            Delete this session?
-          </p>
-          <div className="flex justify-end gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 px-2 text-sm"
-              onClick={(e) => { e.stopPropagation(); setConfirmOpen(false); }}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              className="h-6 px-2 text-sm"
-              onClick={(e) => { e.stopPropagation(); handleDelete(); }}
-            >
-              Delete
-            </Button>
-          </div>
-        </PopoverContent>
-      </Popover>
-    </button>
-  );
-}
-
-// ── Helpers ────────────────────────────────────────────────────
-
-function formatRelativeDate(iso: string): string {
-  const date = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60_000);
-  const diffHours = Math.floor(diffMs / 3_600_000);
-  const diffDays = Math.floor(diffMs / 86_400_000);
-
-  if (diffMins < 1) return 'Just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { WorkspaceInfo } from '@/types/ipc';
+import { useSessionStore } from '@/stores/sessions';
 
 // ── Store ──────────────────────────────────────────────────────
 
@@ -43,8 +44,8 @@ interface WorkspaceState {
   toggleCollapsed: (id: string) => void;
   /** Set the focused workspace. */
   setActiveWorkspace: (id: string | null) => void;
-  /** Create a new workspace under ~/.sero-ui/workspaces/. */
-  createWorkspace: (name: string) => Promise<WorkspaceInfo>;
+  /** Create a new workspace. Optionally specify a parent directory. */
+  createWorkspace: (name: string, parentPath?: string) => Promise<WorkspaceInfo>;
   /** Register an existing folder as a workspace (VSCode "Add Folder"). */
   addFolder: (folderPath: string, name?: string) => Promise<WorkspaceInfo>;
   /** Unregister a workspace. */
@@ -116,18 +117,21 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     set({ activeWorkspaceId: id });
   },
 
-  createWorkspace: async (name) => {
-    const workspace = await window.sero.workspace.create(name);
+  createWorkspace: async (name, parentPath) => {
+    const workspace = await window.sero.workspace.create(name, parentPath);
     set((s) => ({
       workspaces: [...s.workspaces, workspace],
       openWorkspaceIds: [...s.openWorkspaceIds, workspace.id],
       activeWorkspaceId: workspace.id,
     }));
+    // Auto-create and select a default session in the new workspace
+    await useSessionStore.getState().createSession(workspace.id);
     return workspace;
   },
 
   addFolder: async (folderPath, name) => {
     const workspace = await window.sero.workspace.addFolder(folderPath, name);
+    const isReopen = get().workspaces.some((w) => w.id === workspace.id);
     set((s) => {
       // Replace if already exists (re-added), otherwise append
       const existing = s.workspaces.findIndex((w) => w.id === workspace.id);
@@ -144,6 +148,10 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
         activeWorkspaceId: workspace.id,
       };
     });
+    // Auto-create and select a default session for newly imported workspaces
+    if (!isReopen) {
+      await useSessionStore.getState().createSession(workspace.id);
+    }
     return workspace;
   },
 

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -125,7 +125,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       activeWorkspaceId: workspace.id,
     }));
     // Auto-create and select a default session in the new workspace
-    await useSessionStore.getState().createSession(workspace.id);
+    try {
+      await useSessionStore.getState().createSession(workspace.id);
+    } catch (err) {
+      console.warn('Failed to auto-create session for new workspace:', err);
+    }
     return workspace;
   },
 
@@ -150,7 +154,11 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     });
     // Auto-create and select a default session for newly imported workspaces
     if (!isReopen) {
-      await useSessionStore.getState().createSession(workspace.id);
+      try {
+        await useSessionStore.getState().createSession(workspace.id);
+      } catch (err) {
+        console.warn('Failed to auto-create session for imported workspace:', err);
+      }
     }
     return workspace;
   },

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -46,8 +46,8 @@ import type {
 interface SeroWorkspaceAPI {
   /** List all registered workspaces (registry + config merged). */
   list(): Promise<WorkspaceInfo[]>;
-  /** Create a new workspace under ~/.sero-ui/workspaces/. */
-  create(name: string): Promise<WorkspaceInfo>;
+  /** Create a new workspace. Optionally specify a parent directory for the workspace folder. */
+  create(name: string, parentPath?: string): Promise<WorkspaceInfo>;
   /** Unregister a workspace (does not delete files). */
   remove(id: string): Promise<void>;
   /** Get full config for a workspace (.sero-workspace.json). */


### PR DESCRIPTION
## Summary

Replaces the single 'Add' workspace button with a proper Create New / Import Existing flow, fixes container lifecycle race conditions, and fixes global AGENTS.md injection for non-global workspaces.

## UI Changes

- **New workspace menu** — `+` button opens a single popover with two options:
  - **Create New** — inline form with name input and optional location picker (defaults to `~/.sero-ui/workspaces/`)
  - **Import Existing** — native folder picker (previous behavior)
- **Auto-session** — both flows auto-create and select a default session in the new workspace
- **Native dialog guard** — popover state is preserved when native folder picker steals focus (prevents Radix auto-dismiss from clearing form data)

## Workspace Creation

- `WorkspaceManager.create()` accepts optional `parentPath` to create workspaces outside the default directory
- Full IPC chain updated: handler → preload → `electron.d.ts` types → store

## Container Fixes

- **Race condition** — added per-workspace promise deduplication to `ContainerManager.ensure()`. Concurrent calls (from `useSessionAgent` hook + agent `open` handler) now share a single in-flight promise instead of racing
- **Ghost recovery escalation** — `forceRemoveContainer()` now distinguishes "not found" (harmless, container never existed) from real failures before escalating to ghost recovery (storage wipe + system restart). Previously, creating a brand-new workspace would trigger a full system restart
- **"Already exists" retry** — `createFreshContainer()` retries once after force-removing stale containers

## Global AGENTS.md

- When injecting the global workspace's `AGENTS.md` into non-global sessions, a context header is prepended telling the agent to resolve relative file references (`SOUL.md`, `MEMORY.md`, etc.) against the global workspace path — not the current session's cwd

## Code Organisation

- Extracted `SessionNode` → `SessionNode.tsx`
- Extracted `PickView` + `CreateView` → `AddWorkspaceViews.tsx`
- Extracted `readGlobalAgentsMd` → `global-agents.ts`
- All files under 500 LOC limit

## Testing

- `npx tsc --noEmit` passes clean
- Rebuilt `node-pty` from source (fixes `posix_spawnp` terminal errors)