### PR TITLE
Add app store dialog and sidebar favourites

### DIFF
--- a/apps/desktop/electron/app-discovery.ts
+++ b/apps/desktop/electron/app-discovery.ts
@@ -32,6 +32,8 @@ interface PkgSeroApp {
 
 interface PkgJson {
   name?: string;
+  description?: string;
+  version?: string;
   sero?: { app?: PkgSeroApp };
 }
 
@@ -52,6 +54,9 @@ function parseManifest(pkgJson: PkgJson, packagePath: string): SeroAppManifest |
   return {
     id: app.id,
     name: app.name,
+    description: typeof pkgJson.description === 'string' ? pkgJson.description : null,
+    version: typeof pkgJson.version === 'string' ? pkgJson.version : null,
+    packageName: typeof pkgJson.name === 'string' ? pkgJson.name : null,
     icon: app.icon || 'box',
     stateFile: app.stateFile,
     scope,

--- a/apps/desktop/electron/ipc/layout.ts
+++ b/apps/desktop/electron/ipc/layout.ts
@@ -17,6 +17,7 @@ const LAYOUT_FILE = path.join(SERO_AGENT_DIR, 'layout.json');
 export interface LayoutState {
   mainSidebarOpen: boolean;
   chatPanelOpen: boolean;
+  favouriteApps?: string[];
 }
 
 let writeQueue: Promise<void> = Promise.resolve();
@@ -24,9 +25,12 @@ let writeQueue: Promise<void> = Promise.resolve();
 function isLayoutState(value: unknown): value is LayoutState {
   if (!value || typeof value !== 'object') return false;
   const candidate = value as Partial<LayoutState>;
+  const favouriteAppsValid = candidate.favouriteApps === undefined ||
+    Array.isArray(candidate.favouriteApps);
   return (
     typeof candidate.mainSidebarOpen === 'boolean' &&
-    typeof candidate.chatPanelOpen === 'boolean'
+    typeof candidate.chatPanelOpen === 'boolean' &&
+    favouriteAppsValid
   );
 }
 
@@ -34,7 +38,12 @@ function isLayoutState(value: unknown): value is LayoutState {
 function parseLayoutState(raw: string): LayoutState | null {
   try {
     const parsed = JSON.parse(raw.trim());
-    return isLayoutState(parsed) ? parsed : null;
+    if (!isLayoutState(parsed)) return null;
+    if (!Array.isArray(parsed.favouriteApps)) return parsed;
+    return {
+      ...parsed,
+      favouriteApps: parsed.favouriteApps.filter((id): id is string => typeof id === 'string'),
+    };
   } catch {
     return null;
   }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -422,9 +422,9 @@ contextBridge.exposeInMainWorld('sero', {
   },
 
   layout: {
-    save: (state: { mainSidebarOpen: boolean; chatPanelOpen: boolean }): Promise<void> =>
+    save: (state: { mainSidebarOpen: boolean; chatPanelOpen: boolean; favouriteApps: string[] }): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.layout.save, state),
-    load: (): Promise<{ mainSidebarOpen: boolean; chatPanelOpen: boolean } | null> =>
+    load: (): Promise<{ mainSidebarOpen: boolean; chatPanelOpen: boolean; favouriteApps?: string[] } | null> =>
       ipcRenderer.invoke(IpcChannels.layout.load),
   },
 

--- a/apps/desktop/src/components/layout/AppStoreCard.tsx
+++ b/apps/desktop/src/components/layout/AppStoreCard.tsx
@@ -1,0 +1,102 @@
+import type { KeyboardEvent } from 'react';
+import { Star } from 'lucide-react';
+import { Badge } from '@sero/ui/components/ui/badge';
+import { Button } from '@sero/ui/components/ui/button';
+import { cn } from '@sero/ui/lib/utils';
+import { getAppIcon } from '@/lib/app-icons';
+import type { AppEntry } from '@/stores/app';
+
+interface AppStoreCardProps {
+  entry: AppEntry;
+  active: boolean;
+  favourite: boolean;
+  onActivate: () => void;
+  onToggleFavourite: () => void;
+}
+
+export function AppStoreCard({
+  entry,
+  active,
+  favourite,
+  onActivate,
+  onToggleFavourite,
+}: AppStoreCardProps) {
+  const manifest = entry.manifest;
+  const Icon = getAppIcon(entry.icon);
+
+  if (!manifest) return null;
+
+  const handleCardKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.currentTarget !== event.target) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    onActivate();
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onActivate}
+      onKeyDown={handleCardKeyDown}
+      className={cn(
+        'group rounded-xl border p-3 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--border-strong)]',
+        active
+          ? 'border-[var(--border-strong)] bg-[var(--bg-elevated)]'
+          : 'border-[var(--border-default)] bg-[var(--bg-surface)] hover:bg-[var(--bg-elevated)]',
+      )}
+      aria-label={`Open ${entry.label}`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-[var(--bg-base)] text-[var(--text-secondary)]">
+          <Icon className="size-4" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-[var(--text-primary)]">
+              {entry.label}
+            </span>
+            {manifest.version ? (
+              <span className="shrink-0 text-[11px] text-[var(--text-muted)]">
+                v{manifest.version}
+              </span>
+            ) : null}
+          </div>
+          <p className="truncate text-xs text-[var(--text-muted)]">
+            {manifest.packageName ?? 'Unknown package'}
+          </p>
+        </div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label={favourite ? `Remove ${entry.label} from favourites` : `Add ${entry.label} to favourites`}
+          aria-pressed={favourite}
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleFavourite();
+          }}
+        >
+          <Star className={cn('size-4', favourite ? 'fill-current text-amber-500' : 'text-[var(--text-muted)]')} />
+        </Button>
+      </div>
+
+      <p className="mt-3 min-h-10 text-xs leading-5 text-[var(--text-secondary)]">
+        {manifest.description ?? 'No description available.'}
+      </p>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="text-[11px] capitalize">
+          {manifest.scope}
+        </Badge>
+        {active ? (
+          <Badge variant="secondary" className="text-[11px]">
+            Open
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/AppStoreDialog.tsx
+++ b/apps/desktop/src/components/layout/AppStoreDialog.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { Search, Store } from 'lucide-react';
+import { Input } from '@sero/ui/components/ui/input';
+import { ScrollArea } from '@sero/ui/components/ui/scroll-area';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@sero/ui/components/ui/dialog';
+import type { AppEntry } from '@/stores/app';
+import { AppStoreCard } from './AppStoreCard';
+
+interface AppStoreDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  apps: AppEntry[];
+  activeApp: string;
+  isFavourite: (appId: string) => boolean;
+  onToggleFavourite: (appId: string) => void;
+  onActivateApp: (appId: string) => void;
+}
+
+export function AppStoreDialog({
+  open,
+  onOpenChange,
+  apps,
+  activeApp,
+  isFavourite,
+  onToggleFavourite,
+  onActivateApp,
+}: AppStoreDialogProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const query = searchQuery.trim().toLowerCase();
+  const filteredApps = apps
+    .filter((app) => {
+      if (!query) return true;
+      const manifest = app.manifest;
+      const haystack = [
+        app.label,
+        manifest?.description ?? '',
+        manifest?.packageName ?? '',
+      ].join('\n').toLowerCase();
+      return haystack.includes(query);
+    })
+    .slice()
+    .sort((a, b) => {
+      const favDelta = Number(isFavourite(b.id)) - Number(isFavourite(a.id));
+      if (favDelta !== 0) return favDelta;
+      return a.label.localeCompare(b.label);
+    });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (!nextOpen) setSearchQuery('');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="flex h-[min(82vh,44rem)] max-w-5xl flex-col gap-0 p-0 sm:max-w-5xl">
+        <DialogHeader className="border-b border-[var(--border-default)] px-4 py-3 pr-12">
+          <DialogTitle className="flex items-center gap-2 text-base">
+            <Store className="size-4" />
+            App Store
+          </DialogTitle>
+          <DialogDescription>
+            Browse installed Sero apps and choose which ones appear in the sidebar.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="border-b border-[var(--border-default)] px-4 py-3">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
+            <Input
+              autoFocus
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search apps by name or description…"
+              className="pl-9"
+            />
+          </div>
+        </div>
+
+        <ScrollArea className="min-h-0 flex-1">
+          <div className="p-4">
+            {apps.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-[var(--border-default)] p-6 text-center">
+                <p className="text-sm text-[var(--text-secondary)]">No discovered apps yet.</p>
+              </div>
+            ) : filteredApps.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-[var(--border-default)] p-6 text-center">
+                <p className="text-sm text-[var(--text-secondary)]">No apps match “{searchQuery}”.</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 2xl:grid-cols-3">
+                {filteredApps.map((app) => (
+                  <AppStoreCard
+                    key={app.id}
+                    entry={app}
+                    active={activeApp === app.id}
+                    favourite={isFavourite(app.id)}
+                    onToggleFavourite={() => onToggleFavourite(app.id)}
+                    onActivate={() => {
+                      onActivateApp(app.id);
+                      handleOpenChange(false);
+                    }}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/layout/MainSidebar.tsx
+++ b/apps/desktop/src/components/layout/MainSidebar.tsx
@@ -1,52 +1,91 @@
-import { Search } from 'lucide-react';
+import { useState } from 'react';
+import { Grid2x2Plus, Search } from 'lucide-react';
+import { Button } from '@sero/ui/components/ui/button';
 import { Input } from '@sero/ui/components/ui/input';
 import { Separator } from '@sero/ui/components/ui/separator';
-import { useAppStore, type AppEntry } from '@/stores/app';
+import {
+  getDiscoveredApps,
+  getSidebarApps,
+  useAppStore,
+  type AppEntry,
+} from '@/stores/app';
 import { useSessionStore } from '@/stores/sessions';
+import { getAppIcon } from '@/lib/app-icons';
 import { WorkspaceTree } from './WorkspaceTree';
 import { cn } from '@sero/ui/lib/utils';
+import { AppStoreDialog } from './AppStoreDialog';
 
 /**
  * MainSidebar — the primary navigation sidebar.
  *
- * Top section: list of apps (built-in + discovered sero apps)
+ * Top section: sidebar-visible apps (built-ins + favourited discovered apps)
  * Bottom section: workspace → session tree loaded from Pi SDK
  */
 export function MainSidebar() {
+  const [appStoreOpen, setAppStoreOpen] = useState(false);
   const open = useAppStore((s) => s.mainSidebarOpen);
   const apps = useAppStore((s) => s.apps);
+  const favouriteApps = useAppStore((s) => s.favouriteApps);
+  const toggleFavourite = useAppStore((s) => s.toggleFavourite);
+  const isFavourite = useAppStore((s) => s.isFavourite);
   const activeApp = useAppStore((s) => s.activeApp);
   const setActiveApp = useAppStore((s) => s.setActiveApp);
+
+  const sidebarApps = getSidebarApps(apps, favouriteApps);
+  const discoveredApps = getDiscoveredApps(apps);
 
   if (!open) return null;
 
   return (
-    <aside className="flex h-full w-full min-w-0 flex-col border-r border-[var(--border-default)] bg-[var(--bg-surface)]">
-      {/* ── Apps ──────────────────────────────────────────────── */}
-      <div className="flex flex-col gap-0.5 p-2">
-        <span className="px-2 pb-1 text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          Apps
-        </span>
-        {apps.map((app) => (
-          <AppItem
-            key={app.id}
-            entry={app}
-            active={activeApp === app.id}
-            onClick={() => setActiveApp(app.id)}
-          />
-        ))}
-      </div>
+    <>
+      <aside className="flex h-full w-full min-w-0 flex-col border-r border-[var(--border-default)] bg-[var(--bg-surface)]">
+        {/* ── Apps ──────────────────────────────────────────────── */}
+        <div className="flex flex-col gap-0.5 p-2">
+          <div className="flex items-center justify-between px-2 pb-1">
+            <span className="text-sm font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+              Apps
+            </span>
+            <Button
+              type="button"
+              size="icon-xs"
+              variant="ghost"
+              aria-label="Open App Store"
+              onClick={() => setAppStoreOpen(true)}
+            >
+              <Grid2x2Plus className="size-3.5" />
+            </Button>
+          </div>
+          {sidebarApps.map((app) => (
+            <AppItem
+              key={app.id}
+              entry={app}
+              active={activeApp === app.id}
+              onClick={() => setActiveApp(app.id)}
+            />
+          ))}
+        </div>
 
-      <Separator className="mx-2" />
+        <Separator className="mx-2" />
 
-      {/* ── Search ────────────────────────────────────────────── */}
-      <SearchBar />
+        {/* ── Search ────────────────────────────────────────────── */}
+        <SearchBar />
 
-      {/* ── Workspace → Session tree ──────────────────────────── */}
-      <div className="flex min-h-0 flex-1 flex-col gap-1 p-2">
-        <WorkspaceTree />
-      </div>
-    </aside>
+        {/* ── Workspace → Session tree ──────────────────────────── */}
+        <div className="flex min-h-0 flex-1 flex-col gap-1 p-2">
+          <WorkspaceTree />
+        </div>
+      </aside>
+
+      <AppStoreDialog
+        open={appStoreOpen}
+        onOpenChange={setAppStoreOpen}
+        apps={discoveredApps}
+        activeApp={activeApp}
+        isFavourite={isFavourite}
+        onToggleFavourite={toggleFavourite}
+        onActivateApp={setActiveApp}
+      />
+    </>
   );
 }
 
@@ -73,16 +112,6 @@ function SearchBar() {
 
 // ── App list item ──────────────────────────────────────────────
 
-/** Map Lucide icon names to emoji for discovered apps (simple fallback). */
-const ICON_MAP: Record<string, string> = {
-  'check-square': '✅',
-  code: '💻',
-  calendar: '📅',
-  activity: '💪',
-  'piggy-bank': '🏦',
-  box: '📦',
-};
-
 function AppItem({
   entry,
   active,
@@ -92,8 +121,7 @@ function AppItem({
   active: boolean;
   onClick: () => void;
 }) {
-  // Built-in apps use their emoji directly; discovered apps map the Lucide name
-  const icon = entry.builtin ? entry.icon : (ICON_MAP[entry.icon] ?? '📦');
+  const Icon = getAppIcon(entry.icon);
 
   return (
     <button
@@ -105,7 +133,7 @@ function AppItem({
           : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]',
       )}
     >
-      <span className="text-sm">{icon}</span>
+      <Icon className="size-4 shrink-0" />
       <span className="truncate">{entry.label}</span>
     </button>
   );

--- a/apps/desktop/src/lib/app-icons.ts
+++ b/apps/desktop/src/lib/app-icons.ts
@@ -1,0 +1,39 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+  Box,
+  Calculator,
+  CheckSquare,
+  ClipboardList,
+  Code,
+  Flame,
+  Gamepad2,
+  HeartPulse,
+  Image,
+  Landmark,
+  MessageCircleQuestion,
+  Music2,
+  NotebookPen,
+  Sparkles,
+} from 'lucide-react';
+
+const ICON_REGISTRY: Record<string, LucideIcon> = {
+  box: Box,
+  calculator: Calculator,
+  'check-square': CheckSquare,
+  'clipboard-list': ClipboardList,
+  code: Code,
+  flame: Flame,
+  'gamepad-2': Gamepad2,
+  'heart-pulse': HeartPulse,
+  image: Image,
+  landmark: Landmark,
+  'message-circle-question': MessageCircleQuestion,
+  'music-2': Music2,
+  'notebook-pen': NotebookPen,
+  sparkles: Sparkles,
+};
+
+export function getAppIcon(iconName: string | null | undefined): LucideIcon {
+  if (!iconName) return Box;
+  return ICON_REGISTRY[iconName] ?? Box;
+}

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -14,8 +14,16 @@ export interface AppEntry {
 }
 
 const BUILTIN_APPS: AppEntry[] = [
-  { id: 'coding', label: 'Coding', icon: '💻', builtin: true, manifest: null },
+  { id: 'coding', label: 'Coding', icon: 'code', builtin: true, manifest: null },
 ];
+const BUILTIN_APP_IDS = new Set(BUILTIN_APPS.map((app) => app.id));
+const DEFAULT_FAVOURITE_APP_IDS = ['todo', 'notes', 'planmode'] as const;
+
+interface PersistedLayoutState {
+  mainSidebarOpen: boolean;
+  chatPanelOpen: boolean;
+  favouriteApps: string[];
+}
 
 // ── Theme ──────────────────────────────────────────────────────
 export type Theme = 'dark' | 'light';
@@ -43,6 +51,11 @@ interface AppState {
   chatPanelOpen: boolean;
   setChatPanelOpen: (open: boolean) => void;
   toggleChatPanel: () => void;
+
+  // Favourites (sidebar-visible discovered apps)
+  favouriteApps: string[];
+  toggleFavourite: (appId: string) => void;
+  isFavourite: (appId: string) => boolean;
 
   // Active app
   activeApp: string;
@@ -86,11 +99,48 @@ function manifestToEntry(m: SeroAppManifest): AppEntry {
   };
 }
 
+function normaliseFavouriteApps(favouriteApps: string[] | undefined): string[] {
+  if (favouriteApps === undefined) return [...DEFAULT_FAVOURITE_APP_IDS];
+
+  const seen = new Set<string>();
+  const next: string[] = [];
+  for (const id of favouriteApps) {
+    const normalized = id.trim();
+    if (!normalized) continue;
+    if (BUILTIN_APP_IDS.has(normalized)) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    next.push(normalized);
+  }
+  return next;
+}
+
 /** Fire-and-forget save of layout state to disk. */
-function persistLayout(state: { mainSidebarOpen: boolean; chatPanelOpen: boolean }) {
+function persistLayout(state: PersistedLayoutState) {
   window.sero.layout.save(state).catch((err) => {
     console.warn('[app-store] Failed to persist layout:', err);
   });
+}
+
+export function getDiscoveredApps(apps: AppEntry[]): AppEntry[] {
+  return apps.filter((app) => !app.builtin);
+}
+
+export function getSidebarApps(apps: AppEntry[], favouriteApps: string[]): AppEntry[] {
+  const builtins = apps.filter((app) => app.builtin);
+  const discoveredById = new Map<string, AppEntry>();
+  for (const app of apps) {
+    if (app.builtin) continue;
+    discoveredById.set(app.id, app);
+  }
+
+  const favourites: AppEntry[] = [];
+  for (const id of favouriteApps) {
+    const app = discoveredById.get(id);
+    if (app) favourites.push(app);
+  }
+
+  return [...builtins, ...favourites];
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -105,25 +155,59 @@ export const useAppStore = create<AppState>((set, get) => ({
   mainSidebarOpen: true,
   setMainSidebarOpen: (open) => {
     set({ mainSidebarOpen: open });
-    persistLayout({ mainSidebarOpen: open, chatPanelOpen: get().chatPanelOpen });
+    persistLayout({
+      mainSidebarOpen: open,
+      chatPanelOpen: get().chatPanelOpen,
+      favouriteApps: get().favouriteApps,
+    });
   },
   toggleMainSidebar: () => {
     const next = !get().mainSidebarOpen;
     set({ mainSidebarOpen: next });
-    persistLayout({ mainSidebarOpen: next, chatPanelOpen: get().chatPanelOpen });
+    persistLayout({
+      mainSidebarOpen: next,
+      chatPanelOpen: get().chatPanelOpen,
+      favouriteApps: get().favouriteApps,
+    });
   },
 
   // Chat panel — defaults to true; hydrated from disk by loadLayout()
   chatPanelOpen: true,
   setChatPanelOpen: (open) => {
     set({ chatPanelOpen: open });
-    persistLayout({ mainSidebarOpen: get().mainSidebarOpen, chatPanelOpen: open });
+    persistLayout({
+      mainSidebarOpen: get().mainSidebarOpen,
+      chatPanelOpen: open,
+      favouriteApps: get().favouriteApps,
+    });
   },
   toggleChatPanel: () => {
     const next = !get().chatPanelOpen;
     set({ chatPanelOpen: next });
-    persistLayout({ mainSidebarOpen: get().mainSidebarOpen, chatPanelOpen: next });
+    persistLayout({
+      mainSidebarOpen: get().mainSidebarOpen,
+      chatPanelOpen: next,
+      favouriteApps: get().favouriteApps,
+    });
   },
+
+  favouriteApps: [...DEFAULT_FAVOURITE_APP_IDS],
+  toggleFavourite: (appId) => {
+    if (BUILTIN_APP_IDS.has(appId)) return;
+
+    const current = get();
+    const next = current.favouriteApps.includes(appId)
+      ? current.favouriteApps.filter((id) => id !== appId)
+      : [...current.favouriteApps, appId];
+
+    set({ favouriteApps: next });
+    persistLayout({
+      mainSidebarOpen: current.mainSidebarOpen,
+      chatPanelOpen: current.chatPanelOpen,
+      favouriteApps: next,
+    });
+  },
+  isFavourite: (appId) => get().favouriteApps.includes(appId),
 
   // Active app (persisted across reloads via sessionStorage)
   activeApp: sessionStorage.getItem('sero:activeApp') ?? 'coding',
@@ -155,6 +239,7 @@ export async function loadLayout(): Promise<void> {
       useAppStore.setState({
         mainSidebarOpen: state.mainSidebarOpen,
         chatPanelOpen: state.chatPanelOpen,
+        favouriteApps: normaliseFavouriteApps(state.favouriteApps),
         layoutReady: true,
       });
       return;

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -228,9 +228,9 @@ interface SeroTerminalAPI {
 
 interface SeroLayoutAPI {
   /** Save UI layout state to disk. */
-  save(state: { mainSidebarOpen: boolean; chatPanelOpen: boolean }): Promise<void>;
+  save(state: { mainSidebarOpen: boolean; chatPanelOpen: boolean; favouriteApps: string[] }): Promise<void>;
   /** Load UI layout state from disk. Returns null if no saved state. */
-  load(): Promise<{ mainSidebarOpen: boolean; chatPanelOpen: boolean } | null>;
+  load(): Promise<{ mainSidebarOpen: boolean; chatPanelOpen: boolean; favouriteApps?: string[] } | null>;
 }
 
 interface SeroNetAPI {

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -292,6 +292,12 @@ export interface SeroAppManifest {
   id: string;
   /** Display name. */
   name: string;
+  /** Package description from package.json. */
+  description: string | null;
+  /** Package version from package.json. */
+  version: string | null;
+  /** npm package name from package.json. */
+  packageName: string | null;
   /** Lucide icon name (e.g. "check-square"). */
   icon: string;
   /** State file path relative to workspace root (workspace-scoped apps). */

--- a/docs/plans/app-store-prd.md
+++ b/docs/plans/app-store-prd.md
@@ -1,0 +1,392 @@
+# PRD: App Store & Favourites for MainSidebar
+
+**Status:** Draft
+**Author:** Claude (AI)
+**Date:** 2026-02-23
+
+---
+
+## 1. Problem Statement
+
+The MainSidebar Apps section currently renders a flat list of **every** discovered
+app. With 10+ apps already and the number growing, this creates several problems:
+
+1. **Clutter** — Users see apps they never use (Tetris, Calculator) alongside
+   daily-drivers (Notes, Plan Mode), making the sidebar noisy.
+2. **No personalisation** — There's no way to control which apps appear or their
+   order. Every user sees the same list.
+3. **Poor iconography** — Icons use a hardcoded `ICON_MAP` that maps Lucide icon
+   names to emoji. Most apps fall through to a generic 📦. The mapping is
+   incomplete (only 6 entries) and aesthetically inconsistent.
+4. **No metadata visibility** — The sidebar shows only a name and emoji. Users
+   can't see what an app does without clicking into it. The `description`,
+   `version`, and `scope` from each app's `package.json` are available but not
+   surfaced.
+
+## 2. Goal
+
+Replace the flat "all apps" list with a **favourites-based sidebar** and an
+**App Store overlay** where users can browse, inspect, and favourite/unfavourite
+apps. Use proper **Lucide React icons** instead of emoji.
+
+## 3. User Stories
+
+| # | Story | Priority |
+|---|-------|----------|
+| U1 | As a user, I want only my favourite apps in the sidebar so I can access them quickly without scrolling past apps I don't use. | P0 |
+| U2 | As a user, I want to open an "App Store" view to browse all available apps with their descriptions. | P0 |
+| U3 | As a user, I want to favourite/unfavourite apps so I can control what appears in the sidebar. | P0 |
+| U4 | As a user, I want each app to show a proper icon (not emoji) that matches its identity. | P0 |
+| U5 | As a user, I want to see an app's description, version, scope, and package name before adding it. | P1 |
+| U6 | As a user, I want the Coding app (built-in) to always appear in the sidebar, regardless of favourites. | P0 |
+| U7 | As a user, I want my favourites to persist across restarts. | P0 |
+| U8 | As a user, I want to click on an app in the App Store to activate it (open it in the main area), even if it isn't favourited. | P1 |
+
+## 4. Design
+
+### 4.1 Sidebar Changes
+
+**Before (current):**
+```
+┌──────────────────┐
+│ APPS             │
+│ 💻 Coding        │
+│ ✅ Todo           │
+│ 📦 Calculator     │
+│ 📦 Notes          │
+│ 📦 Weight         │
+│ 📦 Tetris         │
+│ 📦 Daily Quote    │
+│ 📦 Plan Mode      │
+│ 📦 Messenger      │
+│ 📦 ImageGen       │
+│ 📦 User Feedback  │
+├──────────────────┤
+│ Search sessions… │
+│ Workspaces…      │
+└──────────────────┘
+```
+
+**After:**
+```
+┌──────────────────┐
+│ APPS        [⊞]  │  ← [⊞] button opens App Store
+│ <> Coding        │  ← built-in, always shown
+│ 📋 Plan Mode     │  ← Lucide icon, favourited
+│ 📝 Notes         │  ← Lucide icon, favourited
+│ ✓  Todo          │  ← Lucide icon, favourited
+├──────────────────┤
+│ Search sessions… │
+│ Workspaces…      │
+└──────────────────┘
+```
+
+**Key changes:**
+- Only **favourited** apps and **built-in** apps appear in the sidebar list.
+- A small `+` / grid button next to the "APPS" header opens the App Store overlay.
+- Each app renders its **Lucide React icon component** (not emoji).
+- First launch: a sensible default set of favourites is applied (e.g. Coding,
+  Notes, Todo, Plan Mode) so the sidebar isn't empty.
+- Sidebar ordering is deterministic: built-ins first (pinned), then favourited
+  apps in the order of the `favouriteApps` array.
+
+### 4.2 App Store Overlay
+
+The App Store is a **modal/dialog overlay** (not a separate page or app) that
+opens on top of the current view. It shows all discovered apps in a grid or
+list layout.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  App Store                                             [✕]  │
+├─────────────────────────────────────────────────────────────┤
+│  Search apps…                                               │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌────────────┐  │
+│  │ ★ ☐ Todo        │  │ ★ 📝 Notes      │  │ ☆ 🎮 Tetris│  │
+│  │ v0.1.0          │  │ v0.1.0          │  │ v0.1.0     │  │
+│  │ Todo app for    │  │ Note-taking app │  │ Tetris     │  │
+│  │ Sero — Pi ext…  │  │ for Sero — …    │  │ game for…  │  │
+│  │                 │  │                 │  │            │  │
+│  │ 🏠 workspace    │  │ 🌐 global       │  │ 🏠 workspace│ │
+│  └─────────────────┘  └─────────────────┘  └────────────┘  │
+│                                                             │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌────────────┐  │
+│  │ ★ 💪 Weight     │  │ ☆ 🧮 Calculator │  │ ★ 📋 Plan  │  │
+│  │ v0.1.0          │  │ v0.1.0          │  │ v0.1.0     │  │
+│  │ Weight tracker  │  │ Modern calc…    │  │ Plan mode  │  │
+│  │ app for Sero …  │  │                 │  │ for Sero…  │  │
+│  │                 │  │                 │  │            │  │
+│  │ 🌐 global       │  │ 🌐 global       │  │ 🏠 workspace│ │
+│  └─────────────────┘  └─────────────────┘  └────────────┘  │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Each app card shows:**
+
+| Field | Source | Example |
+|-------|--------|---------|
+| Icon | Lucide icon from `sero.app.icon` | `<Calculator />` |
+| Name | `sero.app.name` | "Calculator" |
+| Favourite toggle | User preference (★ filled / ☆ outline) | ★ |
+| Version | `package.json → version` | "0.1.0" |
+| Description | `package.json → description` | "Modern calculator app for Sero" |
+| Scope badge | `sero.app.scope` | "global" or "workspace" |
+| Package name | `package.json → name` | "@sero/calc" |
+
+**Interactions:**
+- **Click the star** → toggle favourite (add/remove from sidebar).
+- **Click the star** does **not** activate the app card (stop event propagation).
+- **Click the card** → activate the app (switch to it in main area) and close
+  the overlay.
+- **Search** → filter apps by name or description.
+
+### 4.3 Icon System
+
+**Current (broken):** A `ICON_MAP` of 6 entries maps Lucide string names to emoji.
+Most apps get the fallback `📦`.
+
+**Proposed:** Use actual **Lucide React icon components** rendered from the icon
+name string in the manifest.
+
+Implementation approach — a **dynamic icon resolver** utility:
+
+```tsx
+// src/lib/app-icons.ts
+import {
+  CheckSquare, Calculator, NotebookPen, HeartPulse,
+  Gamepad2, Sparkles, ClipboardList, Radio, Image,
+  MessageCircleQuestion, Code, Box,
+} from 'lucide-react';
+
+const ICON_REGISTRY: Record<string, React.ComponentType<{ className?: string }>> = {
+  'check-square': CheckSquare,
+  'calculator': Calculator,
+  'notebook-pen': NotebookPen,
+  'heart-pulse': HeartPulse,
+  'gamepad-2': Gamepad2,
+  'sparkles': Sparkles,
+  'clipboard-list': ClipboardList,
+  'radio': Radio,
+  'image': Image,
+  'message-circle-question': MessageCircleQuestion,
+  'code': Code,
+  'box': Box,
+};
+
+export function getAppIcon(iconName: string) {
+  return ICON_REGISTRY[iconName] ?? Box;
+}
+```
+
+This is a static map — each known Lucide name maps to the imported component.
+Unknown icons fall back to `Box`. The map is extended whenever a new app is
+added. Tree-shaking keeps the bundle lean.
+
+Built-in apps should also use Lucide names in state (e.g. `coding` uses
+`"code"`) so sidebar rendering can use a single icon path for built-in and
+discovered apps.
+
+> **Why not dynamic `import()`?** Lucide has 1500+ icons. A dynamic
+> `import(`lucide-react/icons/${name}`)` would either bloat the bundle or
+> require async loading with layout shift. A static registry of the ~15 icons
+> actually used is simpler and instant.
+
+### 4.4 Favourites Persistence
+
+Favourites are stored as an array of app IDs in `~/.sero-ui/layout.json`
+(the same file that persists `mainSidebarOpen` and `chatPanelOpen`).
+
+```json
+{
+  "mainSidebarOpen": true,
+  "chatPanelOpen": true,
+  "favouriteApps": ["todo", "notes", "planmode", "weight-tracker"]
+}
+```
+
+**IPC additions:**
+
+| Layer | Change |
+|-------|--------|
+| `layout.json` schema | Add optional `favouriteApps: string[]` field (for backward compatibility with existing files) |
+| `electron/ipc/layout.ts` | Extend `LayoutState`, parser/validator, and save/load handlers to preserve and validate `favouriteApps` |
+| `electron/preload.ts` | Update `window.sero.layout.save/load` TypeScript signatures to include `favouriteApps` |
+| `src/types/electron.d.ts` | Update `SeroLayoutAPI` `save/load` signatures to include `favouriteApps` |
+| Zustand `app.ts` | Add `favouriteApps: string[]`, `toggleFavourite(id)`, `isFavourite(id)`, and derived sidebar filtering (without mutating the full `apps` registry) |
+
+**Default favourites:** On first launch (when `favouriteApps` is missing from
+`layout.json`), apply a default set: `["todo", "notes", "planmode"]`. The
+built-in `coding` app is always shown regardless — it doesn't need to be in
+the favourites array.
+
+**Normalisation rules (load-time):**
+- `favouriteApps` missing → apply defaults.
+- `favouriteApps: []` → respect empty list (show only built-ins).
+- Non-array / malformed entries → ignore invalid values and normalise to a
+  string array.
+- Duplicate IDs → de-duplicate while preserving first occurrence order.
+- Unknown IDs (app currently unavailable) → keep in `favouriteApps` so they can
+  reappear if the app is reinstalled.
+
+### 4.5 Manifest Enrichment
+
+The current `SeroAppManifest` type doesn't include `description` or `version`
+from `package.json`. These need to be added:
+
+```typescript
+// Addition to SeroAppManifest in src/types/ipc.ts
+export interface SeroAppManifest {
+  // ... existing fields ...
+
+  /** Package description from package.json. */
+  description: string | null;
+  /** Package version from package.json. */
+  version: string | null;
+  /** npm package name from package.json. */
+  packageName: string | null;
+}
+```
+
+The `parseManifest` function in `electron/app-discovery.ts` already reads the
+full `package.json` — it just needs to extract these additional fields.
+
+`author` metadata is out of scope for v1. Most current app packages do not set
+an `author` field, so the App Store should not reserve UI space for it yet.
+
+## 5. Component Breakdown
+
+### New Files
+
+| File | Purpose | LOC est. |
+|------|---------|----------|
+| `src/lib/app-icons.ts` | Lucide icon registry + `getAppIcon()` | ~40 |
+| `src/components/layout/AppStoreDialog.tsx` | The App Store overlay (dialog + grid + search) | ~200 |
+| `src/components/layout/AppStoreCard.tsx` | Individual app card within the store | ~80 |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `src/components/layout/MainSidebar.tsx` | Replace flat app list with favourites-only + "open store" button. Replace emoji with `getAppIcon()`. |
+| `src/stores/app.ts` | Add `favouriteApps`, `toggleFavourite()`, `isFavourite()`. Keep `apps` as the full registry and derive sidebar-visible apps from favourites + built-ins. Persist via `layout.save()`. |
+| `src/types/ipc.ts` | Add `description`, `version`, `packageName` to `SeroAppManifest`. |
+| `electron/app-discovery.ts` | Extract `description`, `version`, `name` from `package.json` into manifest. |
+| `electron/ipc/layout.ts` | Extend `LayoutState` schema + parser/validator for `favouriteApps`. |
+| `electron/preload.ts` | Update layout bridge types for `favouriteApps`. |
+| `src/types/electron.d.ts` | Update `SeroLayoutAPI` typings for `favouriteApps`. |
+
+### No Changes Required
+
+| File | Why |
+|------|-----|
+| `electron/ipc/apps.ts` | Discovery IPC unchanged — just returns richer manifests |
+| `vite.config.ts` | No federation changes |
+| `dev.sh` | No changes |
+
+## 6. Data Flow
+
+```
+App Store open
+  → user clicks ★ on "Calculator"
+  → AppStoreDialog calls store.toggleFavourite("calc")
+  → Zustand updates favouriteApps: [..., "calc"]
+  → persistLayout() writes typed layout state to ~/.sero-ui/layout.json
+  → MainSidebar re-renders (reads favouriteApps from store)
+  → Calculator now appears in sidebar
+```
+
+```
+App startup
+  → loadLayout() reads layout.json (includes favouriteApps)
+  → loadLayout() normalises favouriteApps (defaults only when field missing)
+  → discoverAndRegisterApps() fetches manifests (now with description, version)
+  → Zustand hydrates: apps = full registry, favouriteApps = persisted list
+  → MainSidebar derives sidebar apps = built-ins + favourited discovered apps
+```
+
+## 7. Edge Cases
+
+| Case | Behaviour |
+|------|-----------|
+| Favourited app is uninstalled | App ID stays in `favouriteApps` but no matching `AppEntry` exists → silently skipped in sidebar |
+| New app discovered while app is running | `NewAppBanner` fires; app list is not hot-refreshed in v1, so the new app appears after restart |
+| Empty favourites | Sidebar shows only the built-in Coding app + the "open store" button |
+| Unknown icon name in manifest | Falls back to `Box` icon from Lucide |
+| First launch (no layout.json) | Default favourites applied: `["todo", "notes", "planmode"]` |
+| Existing layout.json without `favouriteApps` | Backward compatible: default favourites applied |
+| `favouriteApps` contains duplicates/invalid values | Values are normalised (invalid removed, duplicates deduped, order preserved) |
+| Active app is not favourited | App remains active in main area but is not shown in sidebar |
+
+## 8. Out of Scope (Future)
+
+- **App categories / tags** — Grouping apps by type (productivity, games, etc.).
+  Would require adding a `category` field to the manifest.
+- **App install/uninstall from the store** — Currently all apps are
+  auto-discovered from packages. Future: `pi install` / `pi uninstall` from the
+  UI.
+- **Drag-to-reorder favourites** — Sidebar order matches the order in the
+  `favouriteApps` array. Reordering via drag-and-drop is a future enhancement.
+- **App screenshots/previews** — Rich media in the store cards.
+- **App ratings or usage stats** — Tracking which apps are used most.
+- **Custom user icons** — Letting users override the manifest icon.
+- **Author metadata display** — Add if/when package manifests consistently
+  provide `author`.
+
+## 9. Implementation Plan
+
+### Phase 1: Icon System + Manifest Enrichment
+1. Create `src/lib/app-icons.ts` with the Lucide icon registry.
+2. Add `description`, `version`, `packageName` to `SeroAppManifest` type.
+3. Update `electron/app-discovery.ts` `parseManifest()` to extract new fields.
+4. Update built-in app icon values (e.g. `coding` → `"code"`) so all apps use
+   Lucide icon names consistently.
+5. Update `MainSidebar.tsx` `AppItem` to use `getAppIcon()` instead of emoji.
+
+### Phase 2: Favourites
+1. Add `favouriteApps`, `toggleFavourite()`, `isFavourite()` to the app store.
+2. Extend `electron/ipc/layout.ts` schema/parser/validator for `favouriteApps`
+   (backward-compatible).
+3. Update `electron/preload.ts` and `src/types/electron.d.ts` layout API types.
+4. Extend `loadLayout()` to hydrate + normalise favourites (defaults only when
+   field missing).
+5. Keep `apps` as the full registry; derive sidebar-visible apps from
+   favourites + built-ins.
+6. Update `MainSidebar.tsx` to render the derived sidebar app list.
+7. Add the "open store" button to the sidebar header.
+
+### Phase 3: App Store Dialog
+1. Build `AppStoreCard.tsx` — icon, name, description, version, scope badge,
+   favourite toggle.
+2. Build `AppStoreDialog.tsx` — search input, responsive grid of cards, close
+   button.
+3. Wire the "open store" button in `MainSidebar` to open the dialog.
+4. Wire star click to toggle favourite without activating the card.
+5. Wire card click to activate the app + close the dialog.
+
+### Phase 4: Polish
+1. Default favourites for first launch.
+2. Handle edge cases (uninstalled favourites, empty state).
+3. Verify active-unfavourited-app behaviour is intentional (main content active,
+   no sidebar row).
+4. Verify keyboard/focus behaviour (`Esc` closes dialog, focus trap, star/card
+   interactions are accessible).
+5. Verify dark/light theme consistency.
+6. Ensure all files stay under 500 LOC.
+
+## 10. Acceptance Criteria / Verification Checklist
+
+- Existing users with an old `~/.sero-ui/layout.json` (no `favouriteApps`) do
+  not lose layout settings and receive default favourites.
+- `favouriteApps: []` persists and renders only the built-in Coding app.
+- Toggling favourites updates the sidebar immediately and persists across app
+  restart.
+- Clicking a star in the App Store does not open/activate the app.
+- Clicking an unfavourited app card activates it and closes the dialog (the app
+  may remain absent from the sidebar).
+- Unknown manifest icon names render the Lucide `Box` fallback without crashing.
+- App Store search filters by app name and description.
+- New app detection banner behavior is unchanged in v1 (restart required before
+  app appears in the App Store/sidebar).


### PR DESCRIPTION
## Summary
- add a favourites-based app sidebar with persistent `favouriteApps` layout state
- add an App Store dialog with search, app metadata, and favourite toggles
- switch sidebar app icons to Lucide components and enrich discovered manifests with package metadata
- update the app-store PRD with implementation details, migration rules, and acceptance criteria

## Testing
- `cd apps/desktop && npx tsc --noEmit`
