### PR TITLE
docs: add Sero CLI tool management specification

### DIFF
--- a/apps/desktop/electron/container/lifecycle.ts
+++ b/apps/desktop/electron/container/lifecycle.ts
@@ -287,6 +287,22 @@ export async function createFreshContainer(
     /* non-fatal — proxy handles DNS when available */
   }
 
+  // Symlink the Sero CLI into PATH so 'sero' is available as a command.
+  // The CLI bundle is mounted read-only via readOnlyMounts.
+  for (const mountDir of config.readOnlyMounts ?? []) {
+    if (mountDir.endsWith('/cli')) {
+      try {
+        await execFn(
+          config.workspaceId,
+          `ln -sf ${mountDir}/sero.mjs /usr/local/bin/sero`,
+        );
+      } catch {
+        /* non-fatal — agent can still use 'node <path>/sero.mjs' */
+      }
+      break;
+    }
+  }
+
   // Initialize workspace as a colocated JJ+Git repo (idempotent)
   try {
     await execFn(

--- a/apps/desktop/electron/container/system-prompt.ts
+++ b/apps/desktop/electron/container/system-prompt.ts
@@ -65,5 +65,26 @@ Example:
 **Terminal awareness:**
 - The user may have interactive terminal sessions running in this container.
 - Use \`read_terminal\` to check terminal output for errors after starting dev servers.
-- If you see errors, proactively fix them.`;
+- If you see errors, proactively fix them.
+
+## Sero CLI
+
+The \`sero\` command-line tool is available for workspace management,
+productivity tools, integrations, and Sero app control. Use it via bash.
+
+**Discovery:** Run \`sero help\` to see all available commands, or
+\`sero help <command>\` for detailed usage of a specific command.
+
+**Common commands:**
+- \`sero notes\`, \`sero todo\` — Workspace notes and todos
+- \`sero calc\` — Evaluate math expressions
+- \`sero quote\` — Daily inspirational quote
+- \`sero weight\` — Track weight over time
+- \`sero plan\` — Task plan management
+- \`sero slopzilla\` — View SlopZilla history and bookmarks
+
+**Tips:**
+- Chain commands: \`sero notes add --title "X" --body "Y" && sero todo add "Z"\`
+- Use \`--json\` for structured output: \`sero notes list --json\`
+- Use \`--quiet\` to suppress non-essential output`;
 }

--- a/apps/desktop/electron/ipc/shared-infra.ts
+++ b/apps/desktop/electron/ipc/shared-infra.ts
@@ -128,6 +128,7 @@ export async function buildContainerConfig(
     readOnlyMounts: [
       path.join(SERO_AGENT_DIR, 'skills'),
       path.join(SERO_AGENT_DIR, 'prompts'),
+      path.join(SERO_AGENT_DIR, 'cli'),
     ],
     writableMounts,
   };

--- a/docs/plans/cli-tool-management.md
+++ b/docs/plans/cli-tool-management.md
@@ -1,0 +1,978 @@
+# Sero CLI Tool Management — Specification
+
+> **Status:** Draft
+> **Date:** 2026-02-23
+> **Goal:** Replace the majority of agent tool definitions with a single `sero` CLI,
+> reducing context window bloat while giving the agent more power through
+> composable shell commands and programmatic control over Sero itself.
+
+---
+
+## 1. Motivation
+
+### The Problem
+
+Every tool registered with the agent gets serialised into the LLM context as a
+tool definition (name, description, JSON schema). As extensions grow, so does
+the tool list:
+
+| Category | Tools | Approx. tokens |
+|---|---|---|
+| Core coding (bash, read, write, edit) | 4 | ~800 |
+| Workspace (ls, read_terminal, register_dev_server) | 3 | ~400 |
+| System (set_session_title) | 1 | ~100 |
+| Extensions (notes, todo, calc, quote, weight, plan_todos, spotify, starling, slopzilla, generate_image, question, questionnaire, interview) | 13 | ~2,600 |
+| **Total** | **~21** | **~3,900** |
+
+Beyond raw token cost, every tool definition is noise that the model must reason
+over when deciding which tool to call. More tools → more ambiguity → worse tool
+selection → more wasted turns.
+
+### The Opportunity
+
+Container workspaces already execute everything via `bash`. The agent is fluent
+in shell commands. Instead of 21 tool definitions, we can provide:
+
+- **4 core tools** (bash, read, write, edit) — structured I/O that genuinely
+  benefits from typed schemas
+- **1 CLI** (`sero`) — everything else, discoverable via `sero help`
+
+This also unlocks:
+
+1. **Multi-step composition** — `sero notes add ... && sero todo add ...` in
+   one bash call eliminates intermediate round-trips
+2. **Self-documenting** — `sero help <command>` replaces static tool
+   descriptions with dynamic, detailed help text
+3. **Extensibility** — new commands don't change the tool schema
+4. **Sero meta-control** — the agent can programmatically control the app itself
+   (model switching, thinking level, workspace management, etc.)
+
+### Before & After
+
+```
+BEFORE (per turn):
+  System prompt: ...tools... [21 tool definitions, ~3,900 tokens]
+  Agent: calls notes({ action: "add", title: "...", body: "..." })
+  → round trip
+  Agent: calls todo({ action: "add", text: "..." })
+  → round trip
+  Agent: calls set_session_title({ title: "..." })
+  → round trip
+  (3 tool calls = 3 LLM round-trips)
+
+AFTER (per turn):
+  System prompt: ...tools... [4 tool definitions, ~800 tokens]
+  Agent: calls bash({
+    command: 'sero notes add --title "..." --body "..." && \
+             sero todo add "..." && \
+             sero title "..."'
+  })
+  → 1 round trip
+  (1 bash call = 1 LLM round-trip)
+```
+
+---
+
+## 2. Architecture Overview
+
+```
+┌─ Container ──────────────────────────────────┐
+│                                              │
+│  Agent (LLM)                                 │
+│    │                                         │
+│    ├─ bash tool ──► sero <command>           │
+│    ├─ read tool                              │
+│    ├─ write tool                             │
+│    └─ edit tool                              │
+│                                              │
+│  sero CLI binary                             │
+│    ├─ File-based commands ──► .sero/ state   │
+│    ├─ Host API commands ─────────────────────┼──► Sero Host API
+│    └─ Control commands ──────────────────────┼──► Sero Host API
+│                                              │
+└──────────────────────────────────────────────┘
+
+┌─ Electron Main Process ─────────────────────┐
+│                                              │
+│  Sero Host API (HTTP server)                 │
+│    ├─ /api/ext/*        Extension actions    │
+│    ├─ /api/control/*    App control (IPC)    │
+│    └─ /api/ask          User interaction     │
+│                                              │
+│  Existing IPC handlers                       │
+│    ├─ Agent pool                             │
+│    ├─ Workspace manager                      │
+│    └─ Container manager                      │
+│                                              │
+└──────────────────────────────────────────────┘
+```
+
+### Command Tiers
+
+The CLI organises commands into three tiers based on trust level:
+
+| Tier | Description | Auth | Examples |
+|---|---|---|---|
+| **Local** | File-based state, no host communication | None | `notes`, `todo`, `calc`, `weight`, `quote` |
+| **Host** | Requires host API call (external APIs, UI) | Session token | `spotify`, `image`, `starling`, `ask`, `terminal` |
+| **Control** | Mutates Sero app state via Electron IPC | Session token + permission guard | `control model`, `control thinking`, `control workspace`, `control tools` |
+
+---
+
+## 3. CLI Design
+
+### 3.1 Installation & Distribution
+
+The CLI is a self-contained Node.js script bundled as part of Sero. It is
+**mounted read-only** into containers alongside skills and prompts:
+
+```typescript
+// In buildContainerConfig():
+readOnlyMounts: [
+  path.join(SERO_AGENT_DIR, 'skills'),
+  path.join(SERO_AGENT_DIR, 'prompts'),
+  path.join(SERO_AGENT_DIR, 'cli'),       // ← NEW
+],
+```
+
+A symlink or shell wrapper at `/usr/local/bin/sero` inside the container points
+to the mounted script:
+
+```bash
+# Created during container setup (lifecycle.ts)
+ln -sf /path/to/mounted/cli/sero.mjs /usr/local/bin/sero
+```
+
+For **filesystem workspaces**, the same script runs directly on the host via
+Node.js. See §7 for details.
+
+### 3.2 Command Structure
+
+```
+sero <command> [subcommand] [args] [flags]
+sero help [command]
+sero --version
+```
+
+**Global flags:**
+
+| Flag | Description |
+|---|---|
+| `--help`, `-h` | Show help for the command |
+| `--json` | Output as JSON (for programmatic parsing) |
+| `--quiet`, `-q` | Suppress non-essential output |
+
+### 3.3 Help System
+
+The help system is the primary way the agent discovers CLI capabilities. It
+replaces static tool descriptions in the system prompt.
+
+#### Top-level help
+
+```
+$ sero help
+
+Sero CLI — workspace tools, integrations, and app control.
+
+USAGE
+  sero <command> [subcommand] [args] [flags]
+  sero help <command>
+
+COMMANDS
+  notes        Manage workspace notes (add, edit, list, pin, remove, show)
+  todo         Manage todo list (add, toggle, list, clear)
+  calc         Evaluate math expressions
+  quote        Daily inspirational quote
+  weight       Track weight over time
+  plan         Plan mode and task management
+  spotify      Control Spotify playback and playlists
+  image        Generate images with AI
+  starling     View Starling Bank account info
+  slopzilla    View SlopZilla history and bookmarks
+  ask          Ask the user a question with options
+  survey       Ask the user multiple questions
+  interview    Ask the user open-ended questions
+  title        Set the session title
+  terminal     Read recent terminal output
+  dev-server   Register a dev server with the host
+  control      Control Sero app settings (model, thinking, tools, workspace)
+
+GLOBAL FLAGS
+  --help, -h    Show help for a command
+  --json        Output as JSON
+  --quiet, -q   Suppress non-essential output
+
+EXAMPLES
+  sero notes add --title "API Design" --body "REST vs GraphQL comparison"
+  sero todo add "Fix login bug" && sero todo add "Write tests"
+  sero calc "sqrt(144) + 2^3"
+  sero control model set anthropic/claude-sonnet-4-6
+  sero help notes
+
+Run 'sero help <command>' for detailed usage of any command.
+```
+
+#### Command-level help
+
+Each command provides detailed help with all subcommands, flags, and examples:
+
+```
+$ sero help notes
+
+Manage workspace notes — create, edit, search, and organise notes.
+
+USAGE
+  sero notes <action> [flags]
+
+ACTIONS
+  list                List all notes (newest first)
+  add                 Create a new note
+  show <id>           Show full note content
+  edit <id>           Edit an existing note
+  remove <id>         Remove a note
+  pin <id>            Pin a note to the top
+  unpin <id>          Unpin a note
+
+FLAGS
+  --title <text>      Note title (required for add)
+  --body <text>       Note body (required for add, optional for edit)
+  --query <text>      Search filter (for list)
+  --id <number>       Note ID (alternative to positional arg)
+  --json              Output as JSON
+
+EXAMPLES
+  sero notes list
+  sero notes list --query "design"
+  sero notes add --title "Meeting Notes" --body "Discussed Q1 roadmap..."
+  sero notes show 3
+  sero notes edit 3 --body "Updated: added action items"
+  sero notes pin 1
+  sero notes remove 5
+```
+
+```
+$ sero help control
+
+Control Sero app settings — model, thinking level, tools, and workspaces.
+
+USAGE
+  sero control <resource> <action> [args]
+
+RESOURCES
+  model               Manage the active LLM model
+    show              Show current model (provider/id)
+    set <model>       Set model (e.g. "anthropic/claude-sonnet-4-6")
+    list              List available models
+
+  thinking            Manage thinking/reasoning level
+    show              Show current level
+    set <level>       Set level (off, minimal, low, medium, high, xhigh)
+
+  tools               Manage active tool set
+    list              List all tools with active/inactive status
+    enable <name>     Enable a tool
+    disable <name>    Disable a tool
+    reset             Reset to default tool set
+
+  workspace           Manage workspaces
+    list              List all workspaces with open/closed status
+    info [id]         Show workspace details (default: current)
+    open <id>         Open a workspace in sidebar
+    close <id>        Close a workspace from sidebar
+
+  session             Session information
+    info              Show session path, token usage, cost
+    title <text>      Set session display name
+    compact           Trigger context compaction
+
+  prompt              System prompt management
+    show              Display current system prompt
+    append <text>     Append text to system prompt for this session
+
+PERMISSIONS
+  Control commands require the SERO_CONTROL permission level.
+  Some actions (model set, tools disable) are guarded by the workspace
+  permission policy. See §6 for details.
+
+EXAMPLES
+  sero control model show
+  sero control model set anthropic/claude-sonnet-4-6
+  sero control thinking set high
+  sero control tools list
+  sero control tools disable starling
+  sero control workspace list
+  sero control session info
+  sero control session compact
+```
+
+### 3.4 Output Format
+
+**Default:** Human-readable text, designed for LLM consumption. Concise, no
+decoration, no colour codes.
+
+```
+$ sero notes list
+1. [pinned] API Design
+   REST vs GraphQL comparison...
+2. Meeting Notes
+   Discussed Q1 roadmap with team...
+3. Bug Triage
+   Login timeout issue on Safari...
+
+3 notes (1 pinned)
+```
+
+**JSON mode (`--json`):** Structured output for programmatic use.
+
+```json
+$ sero notes list --json
+{
+  "notes": [
+    { "id": 1, "title": "API Design", "pinned": true, "body": "REST vs GraphQL..." },
+    { "id": 2, "title": "Meeting Notes", "pinned": false, "body": "Discussed Q1..." }
+  ],
+  "count": 2
+}
+```
+
+### 3.5 Error Handling
+
+Errors use non-zero exit codes and write to stderr, consistent with Unix
+conventions and the existing bash tool behaviour (which throws on non-zero exit,
+surfacing the error to the agent):
+
+```
+$ sero notes show 999
+Error: Note 999 not found.
+$ echo $?
+1
+```
+
+```
+$ sero control model set nonexistent/model
+Error: Model "nonexistent/model" not found. Run 'sero control model list' to see available models.
+$ echo $?
+1
+```
+
+---
+
+## 4. Command Reference
+
+### 4.1 Local Commands (File-Based State)
+
+These commands read/write JSON state files in `.sero/apps/<name>/state.json`
+relative to the workspace root. They require no host communication.
+
+| Command | Replaces Tool | State Path |
+|---|---|---|
+| `sero notes <action>` | `notes` | `.sero/apps/notes/state.json` |
+| `sero todo <action>` | `todo` | `.sero/apps/todo/state.json` |
+| `sero calc <expression>` | `calc` | `.sero/apps/calc/state.json` |
+| `sero quote [get\|set]` | `daily_quote` | `.sero/apps/daily_quote/state.json` |
+| `sero weight <action>` | `weight` | `.sero/apps/weight/state.json` |
+| `sero plan <action>` | `plan_todos` | `.sero/apps/planmode/state.json` |
+| `sero slopzilla <action>` | `slopzilla` | `.sero/apps/slopzilla/state.json` |
+
+**State format compatibility:** The CLI uses the exact same JSON schema as the
+existing extensions. This means:
+
+- Existing state files work without migration
+- The UI components that read state (if any) continue to work
+- Extensions and CLI can coexist during migration
+
+### 4.2 Host API Commands
+
+These commands require communication with the Sero Electron main process via
+the Host API (see §5).
+
+| Command | Replaces Tool | Host Endpoint |
+|---|---|---|
+| `sero spotify <action>` | `spotify` | `POST /api/ext/spotify` |
+| `sero image generate <prompt>` | `generate_image` | `POST /api/ext/image` |
+| `sero starling <action>` | `starling` | `POST /api/ext/starling` |
+| `sero ask <question> --options ...` | `question` | `POST /api/ask` |
+| `sero survey --questions ...` | `questionnaire` | `POST /api/survey` |
+| `sero interview --questions ...` | `interview` | `POST /api/interview` |
+| `sero title <text>` | `set_session_title` | `POST /api/ext/title` |
+| `sero terminal [--lines N]` | `read_terminal` | `GET /api/ext/terminal` |
+| `sero dev-server register <name> ...` | `register_dev_server` | `POST /api/ext/dev-server` |
+
+#### User Interaction Commands
+
+The `ask`, `survey`, and `interview` commands are blocking — the CLI sends a
+request to the host, the host displays UI to the user, and the CLI waits for
+the response:
+
+```
+$ sero ask "Which database should we use?" --options "PostgreSQL" "SQLite" "MongoDB"
+> User selected: PostgreSQL
+PostgreSQL
+```
+
+The bash tool's timeout parameter provides a natural timeout mechanism. The host
+API also supports a `timeout` query parameter for server-side timeout.
+
+#### Image Generation
+
+Since CLI stdout is text-only, generated images are saved to disk:
+
+```
+$ sero image generate "A sunset over mountains" --output /workspace/sunset.png
+Image saved to /workspace/sunset.png (1024x1024, 245KB)
+```
+
+The agent can then use the `read` tool to view the image if needed.
+
+### 4.3 Control Commands (Sero App Control)
+
+These commands expose Electron IPC methods, giving the agent programmatic
+control over Sero itself. This is the most powerful tier and requires guards.
+
+| Command | IPC Channel | Guard Level |
+|---|---|---|
+| `sero control model show` | `agent:getModelState` | read |
+| `sero control model set <model>` | `agent:setModel` | write |
+| `sero control model list` | `agent:getModelState` | read |
+| `sero control thinking show` | `agent:getModelState` | read |
+| `sero control thinking set <level>` | `agent:setThinkingLevel` | write |
+| `sero control tools list` | `agent:getContext` | read |
+| `sero control tools enable <name>` | `agent:setContextOverrides` | write |
+| `sero control tools disable <name>` | `agent:setContextOverrides` | write |
+| `sero control tools reset` | `agent:setContextOverrides` | write |
+| `sero control workspace list` | `workspace:list` | read |
+| `sero control workspace info [id]` | `workspace:getConfig` | read |
+| `sero control workspace open <id>` | `workspace:open` | write |
+| `sero control workspace close <id>` | `workspace:close` | write |
+| `sero control session info` | `agent:getUsage` | read |
+| `sero control session compact` | internal | write |
+| `sero control prompt show` | `agent:getContext` | read |
+| `sero control prompt append <text>` | `before_agent_start` hook | write |
+
+#### Future Control Expansions
+
+The control tier is designed to grow. Potential future commands:
+
+- `sero control container restart` — restart the workspace container
+- `sero control extension reload` — hot-reload extensions
+- `sero control checkpoint create` — create a VCS checkpoint
+- `sero control checkpoint restore <id>` — restore to a checkpoint
+- `sero control window focus <panel>` — focus a UI panel
+
+---
+
+## 5. Host Communication
+
+### 5.1 Sero Host API Server
+
+The Electron main process runs a lightweight HTTP server accessible from
+containers. This is the bridge between the CLI and Sero's internals.
+
+#### Server Setup
+
+```typescript
+// New file: electron/api/server.ts
+
+import http from 'node:http';
+
+export interface HostApiOptions {
+  sessionId: string;
+  workspaceId: string;
+  containerManager: ContainerManager;
+  workspaceManager: WorkspaceManager;
+  agentPool: Map<string, PoolEntry>;
+  permissionPolicy: PermissionPolicy;
+}
+
+export function createHostApiServer(options: HostApiOptions): http.Server {
+  const server = http.createServer(async (req, res) => {
+    // Auth: validate session token from Authorization header
+    const token = req.headers.authorization?.replace('Bearer ', '');
+    if (token !== options.sessionToken) {
+      res.writeHead(401);
+      res.end('Unauthorized');
+      return;
+    }
+
+    // Route to handlers...
+  });
+
+  // Listen on random port, bind to localhost only
+  server.listen(0, '127.0.0.1');
+  return server;
+}
+```
+
+#### Environment Injection
+
+The API server URL and auth token are injected as environment variables during
+container creation and command execution:
+
+```typescript
+// In ContainerManager.exec():
+envParts.push(
+  `SERO_API_URL=http://host.containers.internal:${apiPort}`,
+  `SERO_API_TOKEN=${sessionToken}`,
+  `SERO_SESSION_ID=${sessionId}`,
+  `SERO_WORKSPACE_ID=${workspaceId}`,
+);
+```
+
+The CLI reads these from the environment:
+
+```typescript
+const apiUrl = process.env.SERO_API_URL;
+const apiToken = process.env.SERO_API_TOKEN;
+```
+
+### 5.2 API Protocol
+
+All endpoints accept/return JSON. Standard HTTP status codes.
+
+#### Extension Endpoints
+
+```
+POST /api/ext/:name
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{ "action": "list", "query": "design" }
+
+→ 200 OK
+{ "result": { "notes": [...], "count": 3 } }
+```
+
+Extension endpoints are generic — the `:name` maps to the extension name, and
+the body is passed to the extension's execute function.
+
+#### User Interaction Endpoints
+
+```
+POST /api/ask
+Content-Type: application/json
+
+{
+  "question": "Which database?",
+  "options": [
+    { "label": "PostgreSQL", "description": "Mature, full-featured" },
+    { "label": "SQLite", "description": "Lightweight, embedded" }
+  ],
+  "timeout": 60000
+}
+
+→ 200 OK (blocks until user responds)
+{ "answer": "PostgreSQL" }
+```
+
+#### Control Endpoints
+
+```
+POST /api/control/:resource/:action
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{ "value": "anthropic/claude-sonnet-4-6" }
+
+→ 200 OK
+{ "result": { "model": "claude-sonnet-4-6", "provider": "anthropic" } }
+
+→ 403 Forbidden (if permission denied)
+{ "error": "Action 'model.set' is not permitted by workspace policy" }
+```
+
+### 5.3 Error Responses
+
+```json
+{
+  "error": "Description of the error",
+  "code": "NOT_FOUND",
+  "details": {}
+}
+```
+
+Standard error codes: `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `BAD_REQUEST`,
+`TIMEOUT`, `INTERNAL_ERROR`.
+
+---
+
+## 6. Permission & Guard System
+
+### 6.1 Rationale
+
+Exposing Electron IPC via CLI gives the agent significant power. Without guards,
+the agent could:
+
+- Switch to cheaper/weaker models mid-task
+- Disable safety-relevant tools
+- Close workspaces the user has open
+- Trigger expensive operations (mass compaction)
+
+The permission system provides defence-in-depth while keeping the default
+experience frictionless.
+
+### 6.2 Permission Policy
+
+Each workspace's `.sero-workspace.json` can define a CLI permission policy:
+
+```json
+{
+  "id": "my-project",
+  "name": "My Project",
+  "container": true,
+  "cli": {
+    "permissions": {
+      "control.model.set": "ask",
+      "control.thinking.set": "allow",
+      "control.tools.disable": "deny",
+      "control.workspace.close": "deny",
+      "control.session.compact": "allow",
+      "control.prompt.append": "allow"
+    }
+  }
+}
+```
+
+#### Permission Levels
+
+| Level | Behaviour |
+|---|---|
+| `allow` | Execute immediately, no confirmation |
+| `ask` | Show confirmation dialog to user before executing |
+| `deny` | Block with error message |
+
+#### Defaults
+
+If no policy is defined, sensible defaults apply:
+
+| Action Pattern | Default |
+|---|---|
+| `control.*.show`, `control.*.list`, `control.*.info` | `allow` |
+| `control.model.set` | `ask` |
+| `control.thinking.set` | `allow` |
+| `control.tools.enable` | `allow` |
+| `control.tools.disable` | `ask` |
+| `control.tools.reset` | `allow` |
+| `control.workspace.open` | `allow` |
+| `control.workspace.close` | `ask` |
+| `control.session.compact` | `allow` |
+| `control.prompt.append` | `allow` |
+| All extension commands | `allow` |
+| All local commands | `allow` |
+
+#### Guard Implementation
+
+```typescript
+// In host API server:
+async function checkPermission(
+  action: string,
+  policy: PermissionPolicy,
+  askUser: (question: string) => Promise<boolean>,
+): Promise<boolean> {
+  const level = policy[action] ?? getDefaultLevel(action);
+
+  switch (level) {
+    case 'allow': return true;
+    case 'deny': return false;
+    case 'ask': return askUser(`Agent wants to: ${describeAction(action)}`);
+  }
+}
+```
+
+When an `ask` action is triggered, the host shows a confirmation dialog in the
+Sero UI. The CLI blocks until the user responds.
+
+### 6.3 Audit Log
+
+All control commands are logged to `.sero/cli-audit.jsonl` in the workspace:
+
+```jsonl
+{"ts":"2026-02-23T10:30:00Z","action":"control.model.set","args":{"model":"claude-sonnet-4-6"},"result":"allowed"}
+{"ts":"2026-02-23T10:30:05Z","action":"control.tools.disable","args":{"tool":"starling"},"result":"denied","reason":"policy"}
+```
+
+This provides visibility into what the agent changed and when.
+
+---
+
+## 7. Workspace Type Support
+
+### 7.1 Container Workspaces (Primary)
+
+Container workspaces are the primary target for the CLI. The CLI binary is
+mounted read-only and symlinked into the PATH during container setup.
+
+**Advantages:**
+- Full isolation — CLI runs inside the sandbox
+- Environment variables injected automatically
+- All file-based state is within `/workspace/.sero/`
+- Host API accessible via `host.containers.internal`
+
+### 7.2 Filesystem Workspaces
+
+Filesystem workspaces currently run Pi SDK tools directly on the host. The CLI
+can also run on the host with the same security model.
+
+**Recommendation: Support CLI on filesystem workspaces.**
+
+Rationale:
+- The CLI performs the same operations as existing tools (read/write JSON, call
+  APIs) — it is no more dangerous than what `bash` already allows
+- For pure local commands (notes, todos, etc.), the CLI just reads/writes files
+  in `.sero/` — identical to what extensions do today
+- For host API commands, the CLI communicates with the same Electron process
+  that's already running
+- The control commands have the same permission guards regardless of workspace
+  type
+
+**Implementation for filesystem mode:**
+
+```typescript
+// In agent.ts, when container is disabled:
+const builtinTools = createCodingTools(wsPath);
+
+// Inject SERO_* env vars into the bash tool's environment so the
+// CLI can reach the host API when run via bash
+```
+
+The `SERO_API_URL` points to `http://127.0.0.1:<port>` (localhost) instead of
+`host.containers.internal`.
+
+### 7.3 Ad-hoc Container Approach (Not Recommended)
+
+The user asked about spinning up an ephemeral container just for CLI execution
+on filesystem workspaces. This is **not recommended** because:
+
+1. **Overhead** — Container startup adds 2-5 seconds per CLI call
+2. **State mismatch** — Container would need workspace mounted, adding complexity
+3. **No security benefit** — The CLI's operations (file I/O, HTTP calls) don't
+   benefit from container isolation
+4. **Complexity** — Managing ephemeral containers alongside long-lived workspace
+   containers adds significant code
+
+The host-direct approach for filesystem workspaces is simpler, faster, and
+equally safe.
+
+---
+
+## 8. System Prompt Changes
+
+### 8.1 Current System Prompt (Tool Section)
+
+Currently, all ~21 tool definitions are serialised into the system prompt by the
+LLM provider SDK. Each tool includes name, description, and full JSON schema.
+
+### 8.2 New System Prompt Addition
+
+The container system prompt (`system-prompt.ts`) gains a CLI section:
+
+```markdown
+## Sero CLI
+
+The `sero` command-line tool is available for workspace management,
+productivity tools, integrations, and Sero app control. Use it via bash.
+
+**Discovery:** Run `sero help` to see all available commands, or
+`sero help <command>` for detailed usage of a specific command.
+
+**Common commands:**
+- `sero notes`, `sero todo` — Workspace notes and todos
+- `sero ask "question" --options "A" "B"` — Ask the user a question
+- `sero control model set <model>` — Switch LLM model
+- `sero control session info` — View token usage and cost
+
+**Tips:**
+- Chain commands: `sero notes add --title "X" --body "Y" && sero todo add "Z"`
+- Use `--json` for structured output: `sero notes list --json`
+- Use `--quiet` to suppress non-essential output
+```
+
+This replaces ~3,100 tokens of tool definitions with ~200 tokens of guidance.
+The agent calls `sero help` on first use to discover the full command set (the
+output is cached across turns via normal context).
+
+### 8.3 Retained Native Tools
+
+Only 4 tools remain as native tool definitions:
+
+| Tool | Reason |
+|---|---|
+| `bash` | Vehicle for CLI calls; complex schema (command, timeout) |
+| `read` | Returns images as base64 content blocks; offset/limit pagination |
+| `write` | Atomic file creation with parent directories |
+| `edit` | Fuzzy text matching, diff output, BOM handling |
+
+These tools benefit from structured input/output that can't be replicated as
+effectively via CLI stdout.
+
+---
+
+## 9. Plan Mode Adaptation
+
+Plan mode (`pi-plan-mode-extension`) currently uses `pi.setActiveTools()` to
+restrict available tools. In the CLI model:
+
+### Option A: Keep plan mode as native extension (Recommended for MVP)
+
+Plan mode's core value is **tool filtering** — a meta-operation. The extension
+continues to call `pi.setActiveTools()` to restrict the 4 native tools. CLI
+commands don't need filtering because they're invoked via `bash`, and the bash
+tool can be disabled/enabled by the plan mode extension.
+
+When plan mode is active:
+- Native tools: `bash` (read-only commands only), `read`
+- CLI: Available via bash (but bash is restricted to safe commands)
+
+### Option B: CLI-native plan mode (Future)
+
+```bash
+$ sero plan start
+Plan mode enabled. Read-only tools active.
+
+$ sero plan set "Step 1: Analyse auth module" "Step 2: Refactor tokens"
+Plan created (2 steps)
+
+$ sero plan complete 1
+✓ Step 1 completed (1/2)
+
+$ sero plan execute
+Execution mode enabled. Full tool access restored.
+```
+
+The `sero plan start` command calls the host API to invoke
+`pi.setActiveTools()` on the agent session.
+
+---
+
+## 10. Extension Integration
+
+### 10.1 How Extensions Register CLI Commands
+
+Extensions that want to provide CLI commands register them via a new
+`pi.registerCliCommand()` API:
+
+```typescript
+// In an extension:
+pi.registerCliCommand('myext', {
+  description: 'My custom extension',
+  subcommands: {
+    list: { description: 'List items', handler: async (args) => { ... } },
+    add: { description: 'Add item', handler: async (args) => { ... } },
+  },
+});
+```
+
+The CLI discovers available commands by reading a manifest file written by the
+extension loader:
+
+```
+.sero/cli/manifest.json
+{
+  "commands": {
+    "notes": { "type": "local", "description": "..." },
+    "spotify": { "type": "host", "endpoint": "/api/ext/spotify", "description": "..." },
+    "myext": { "type": "host", "endpoint": "/api/ext/myext", "description": "..." }
+  }
+}
+```
+
+For the initial implementation, all built-in extension commands are hardcoded in
+the CLI. The manifest-based approach is a future enhancement for third-party
+extensions.
+
+### 10.2 Coexistence During Migration
+
+During the migration period, both tool and CLI interfaces can coexist:
+
+1. **Phase 1:** CLI is available alongside existing tools. Agent can use either.
+   System prompt mentions CLI as preferred.
+2. **Phase 2:** Extension tools are removed from the tool registry. Agent uses
+   CLI exclusively. Extensions still run server-side for host API handling.
+3. **Phase 3:** Extensions that are purely file-based (notes, todo, etc.) are
+   replaced entirely by the CLI. Extensions that need host APIs (spotify, image)
+   keep a thin server-side handler.
+
+---
+
+## 11. Implementation Plan
+
+### Phase 1: Core CLI + Local Commands
+
+**Scope:** File-based commands only, no host API.
+
+1. Create `packages/sero-cli/` package
+   - CLI entry point with command parser (no external deps — use Node built-ins)
+   - Help system with `sero help` and `sero help <command>`
+   - Local commands: `notes`, `todo`, `calc`, `quote`, `weight`, `slopzilla`
+   - State file I/O matching existing extension JSON schemas
+   - `--json` output mode
+2. Build step produces `sero.mjs` (single file, bundled)
+3. Mount into containers via `readOnlyMounts`
+4. Symlink in container PATH during setup
+5. Update system prompt to mention CLI
+6. **Do not remove existing tools yet** — coexistence period
+
+### Phase 2: Host API + Extension Commands
+
+**Scope:** Host API server, host-dependent commands.
+
+1. Create `electron/api/server.ts` — lightweight HTTP API server
+2. Start API server during app init, inject URL/token into containers
+3. Add host API commands: `spotify`, `image`, `starling`, `ask`, `survey`,
+   `interview`, `title`, `terminal`, `dev-server`
+4. Add user interaction flow (blocking ask/survey/interview)
+5. Test cross-container communication
+
+### Phase 3: Control Commands + Permission System
+
+**Scope:** Sero app control via CLI, permission guards.
+
+1. Implement control endpoints bridging to Electron IPC
+2. Add permission policy to `.sero-workspace.json`
+3. Implement `ask` permission level with UI confirmation dialog
+4. Add audit logging
+5. Control commands: `model`, `thinking`, `tools`, `workspace`, `session`,
+   `prompt`
+
+### Phase 4: Tool Removal + Optimisation
+
+**Scope:** Remove extension tools, optimise context.
+
+1. Remove extension tool registrations (notes, todo, calc, etc.)
+2. Remove container-specific tools that moved to CLI (ls, read_terminal,
+   register_dev_server, set_session_title)
+3. Update plan mode to work with CLI-only model
+4. Benchmark: measure context size reduction, turn count, latency
+5. Update system prompt to remove tool-specific instructions
+
+### Phase 5: Extension CLI Registration (Future)
+
+**Scope:** Dynamic command registration for third-party extensions.
+
+1. Add `pi.registerCliCommand()` API
+2. Manifest file generation during extension loading
+3. CLI reads manifest for dynamic command discovery
+4. Help system includes dynamically registered commands
+
+---
+
+## 12. Open Questions
+
+1. **Should `read` and `write` move to CLI too?** They benefit from structured
+   output (image base64, diff details), but `cat` and file redirection are
+   close equivalents. Keeping them as native tools feels right for now.
+
+2. **Cache `sero help` output?** The agent will call `sero help` on first use.
+   The output enters the context and is available for subsequent turns. Should
+   we inject it preemptively in the system prompt instead? Probably not — it's
+   better to let the agent pull it on demand.
+
+3. **Should the CLI support pipes?** e.g., `sero notes list | grep "design"`.
+   Since commands run in bash, pipes work naturally. No special support needed.
+
+4. **WebSocket vs HTTP for blocking commands?** HTTP long-polling is simpler and
+   sufficient. WebSocket would be needed only if we want bidirectional streaming,
+   which isn't required for v1.
+
+5. **Control command scope:** Should some control commands be session-scoped
+   (e.g., model changes apply only to the current session) or global? Currently,
+   model and thinking changes are session-scoped in Sero, which is correct.

--- a/packages/sero-cli/.gitignore
+++ b/packages/sero-cli/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/packages/sero-cli/build.mjs
+++ b/packages/sero-cli/build.mjs
@@ -1,0 +1,30 @@
+/**
+ * Build the Sero CLI into a single self-contained ESM file.
+ *
+ * Output: dist/sero.mjs — ready to mount into containers or run directly.
+ */
+
+import { build } from 'esbuild';
+import { chmod } from 'node:fs/promises';
+import path from 'node:path';
+
+const outfile = path.resolve('dist', 'sero.mjs');
+
+await build({
+  entryPoints: ['src/main.ts'],
+  bundle: true,
+  outfile,
+  format: 'esm',
+  platform: 'node',
+  target: 'node22',
+  minify: false, // Keep readable for debugging
+  banner: {
+    js: '#!/usr/bin/env node\n',
+  },
+  external: [], // No external deps — fully self-contained
+});
+
+// Make executable
+await chmod(outfile, 0o755);
+
+console.log(`Built: ${outfile}`);

--- a/packages/sero-cli/package.json
+++ b/packages/sero-cli/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@sero/cli",
+  "version": "0.1.0",
+  "description": "Sero CLI — workspace tools, integrations, and app control",
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/sero-cli/src/commands/calc.ts
+++ b/packages/sero-cli/src/commands/calc.ts
@@ -1,0 +1,175 @@
+/**
+ * sero calc — evaluate math expressions.
+ *
+ * State: global-scoped.
+ * Safe evaluation using Function constructor (same as extension).
+ */
+
+import type { CommandDef, Flags } from '../main.js';
+import { resolveGlobalStatePath, readState, writeState } from '../state.js';
+
+interface HistoryEntry {
+  id: number;
+  expression: string;
+  result: string;
+  createdAt: string;
+}
+
+interface CalcState {
+  display: string;
+  expression: string;
+  history: HistoryEntry[];
+  nextId: number;
+}
+
+const DEFAULT: CalcState = {
+  display: '0',
+  expression: '',
+  history: [],
+  nextId: 1,
+};
+
+function statePath(): string {
+  return resolveGlobalStatePath('calc');
+}
+
+function safeEval(expr: string): string {
+  // Allow numbers, operators, parens, decimal points, spaces, and common math funcs
+  const sanitised = expr.replace(/\s/g, '');
+
+  // Support named functions: sqrt, sin, cos, tan, log, abs, ceil, floor, round, pow, min, max, PI, E
+  const withMath = sanitised
+    .replace(/\bsqrt\b/g, 'Math.sqrt')
+    .replace(/\bsin\b/g, 'Math.sin')
+    .replace(/\bcos\b/g, 'Math.cos')
+    .replace(/\btan\b/g, 'Math.tan')
+    .replace(/\blog\b/g, 'Math.log')
+    .replace(/\babs\b/g, 'Math.abs')
+    .replace(/\bceil\b/g, 'Math.ceil')
+    .replace(/\bfloor\b/g, 'Math.floor')
+    .replace(/\bround\b/g, 'Math.round')
+    .replace(/\bpow\b/g, 'Math.pow')
+    .replace(/\bmin\b/g, 'Math.min')
+    .replace(/\bmax\b/g, 'Math.max')
+    .replace(/\bPI\b/g, 'Math.PI')
+    .replace(/\bE\b/g, 'Math.E');
+
+  // After replacing math functions, validate: only allow Math.xxx, digits, operators, parens
+  if (!/^[a-zA-Z.\d+\-*/().%^,\s]+$/.test(withMath)) {
+    throw new Error(`Invalid expression: ${expr}`);
+  }
+
+  // Ensure no unexpected identifiers (only Math.xxx allowed)
+  const stripped = withMath.replace(/Math\.\w+/g, '0').replace(/[\d.+\-*/()%^,\s]/g, '');
+  if (stripped.length > 0) {
+    throw new Error(`Invalid expression: ${expr}`);
+  }
+
+  // Replace ^ with ** for exponentiation
+  const jsExpr = withMath.replace(/\^/g, '**');
+
+  const fn = new Function(`"use strict"; return (${jsExpr});`);
+  const result = fn() as number;
+
+  if (!Number.isFinite(result)) {
+    throw new Error('Result is not a finite number');
+  }
+
+  return Number.isInteger(result) ? result.toString() : parseFloat(result.toFixed(10)).toString();
+}
+
+async function run(args: string[], flags: Flags): Promise<void> {
+  const action = args[0];
+  if (!action) throw new Error('No action or expression specified. Run \'sero help calc\' for usage.');
+
+  const fp = statePath();
+
+  // sero calc history
+  if (action === 'history') {
+    const state = await readState<CalcState>(fp, DEFAULT);
+    if (state.history.length === 0) {
+      process.stdout.write('No calculation history.\n');
+      return;
+    }
+    if (flags.json) {
+      process.stdout.write(JSON.stringify({ history: state.history.slice(0, 20) }, null, 2) + '\n');
+      return;
+    }
+    const lines = state.history
+      .slice(0, 20)
+      .map((h) => `${h.expression} = ${h.result}`);
+    process.stdout.write(lines.join('\n') + '\n');
+    return;
+  }
+
+  // sero calc clear
+  if (action === 'clear') {
+    await writeState(fp, { ...DEFAULT });
+    process.stdout.write('Calculator cleared.\n');
+    return;
+  }
+
+  // sero calc <expression>  or  sero calc evaluate <expression>
+  let expression: string;
+  if (action === 'evaluate') {
+    expression = args.slice(1).join(' ').trim();
+  } else {
+    // The whole args is the expression
+    expression = args.join(' ').trim();
+  }
+
+  if (!expression) throw new Error('Expression is required.');
+
+  const result = safeEval(expression);
+  const state = await readState<CalcState>(fp, DEFAULT);
+  const entry: HistoryEntry = {
+    id: state.nextId,
+    expression,
+    result,
+    createdAt: new Date().toISOString(),
+  };
+  state.history.unshift(entry);
+  state.nextId++;
+  state.display = result;
+  state.expression = expression;
+  await writeState(fp, state);
+
+  if (flags.json) {
+    process.stdout.write(JSON.stringify({ expression, result }, null, 2) + '\n');
+  } else {
+    process.stdout.write(`${expression} = ${result}\n`);
+  }
+}
+
+export const calcCommand: CommandDef = {
+  description: 'Evaluate math expressions',
+  helpText: `Evaluate math expressions with history tracking.
+
+USAGE
+  sero calc <expression>
+  sero calc evaluate <expression>
+  sero calc history
+  sero calc clear
+
+ACTIONS
+  <expression>        Evaluate a math expression (default action)
+  evaluate <expr>     Evaluate a math expression (explicit)
+  history             Show recent calculations (last 20)
+  clear               Clear calculator history
+
+SUPPORTED OPERATIONS
+  Basic:    + - * / % ^
+  Functions: sqrt, sin, cos, tan, log, abs, ceil, floor, round, pow, min, max
+  Constants: PI, E
+
+FLAGS
+  --json              Output as JSON
+
+EXAMPLES
+  sero calc "2 + 3 * 4"
+  sero calc "sqrt(144) + 2^3"
+  sero calc "sin(PI/2)"
+  sero calc history
+  sero calc clear`,
+  run,
+};

--- a/packages/sero-cli/src/commands/notes.ts
+++ b/packages/sero-cli/src/commands/notes.ts
@@ -1,0 +1,217 @@
+/**
+ * sero notes — manage workspace notes.
+ *
+ * State: global-scoped, reads/writes the same JSON as pi-notes-extension.
+ */
+
+import type { CommandDef, Flags } from '../main.js';
+import { resolveGlobalStatePath, readState, writeState } from '../state.js';
+
+interface Note {
+  id: number;
+  title: string;
+  body: string;
+  pinned: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface NotesState {
+  notes: Note[];
+  nextId: number;
+}
+
+const DEFAULT: NotesState = { notes: [], nextId: 1 };
+
+function statePath(): string {
+  return resolveGlobalStatePath('notes');
+}
+
+function parseNamedArgs(args: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      const key = arg.slice(2);
+      result[key] = args[++i];
+    } else if (!result._positional) {
+      result._positional = arg;
+    }
+  }
+  return result;
+}
+
+async function run(args: string[], flags: Flags): Promise<void> {
+  const action = args[0];
+  if (!action) throw new Error('No action specified. Run \'sero help notes\' for usage.');
+
+  const fp = statePath();
+  const state = await readState<NotesState>(fp, DEFAULT);
+  const named = parseNamedArgs(args.slice(1));
+
+  switch (action) {
+    case 'list': {
+      let notes = state.notes;
+      const query = named.query;
+      if (query) {
+        const q = query.toLowerCase();
+        notes = notes.filter(
+          (n) => n.title.toLowerCase().includes(q) || n.body.toLowerCase().includes(q),
+        );
+      }
+      if (notes.length === 0) {
+        process.stdout.write(query ? 'No notes matching that query.\n' : 'No notes yet.\n');
+        return;
+      }
+      // Sort: pinned first, then by updatedAt desc
+      const sorted = [...notes].sort((a, b) => {
+        if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+        return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+      });
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({ notes: sorted, count: sorted.length }, null, 2) + '\n');
+        return;
+      }
+
+      const lines = sorted.map((n) => {
+        const pin = n.pinned ? '[pinned] ' : '';
+        const preview = n.body.length > 60 ? n.body.slice(0, 60) + '...' : n.body;
+        return `${n.id}. ${pin}${n.title}\n   ${preview || '(empty)'}`;
+      });
+      process.stdout.write(lines.join('\n') + `\n\n${sorted.length} notes` +
+        (sorted.some((n) => n.pinned) ? ` (${sorted.filter((n) => n.pinned).length} pinned)` : '') + '\n');
+      return;
+    }
+
+    case 'add': {
+      const title = named.title;
+      if (!title) throw new Error('--title is required for add.');
+      const now = new Date().toISOString();
+      const note: Note = {
+        id: state.nextId,
+        title,
+        body: named.body ?? '',
+        pinned: false,
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.notes.push(note);
+      state.nextId++;
+      await writeState(fp, state);
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(note, null, 2) + '\n');
+      } else {
+        process.stdout.write(`Created note #${note.id}: ${note.title}\n`);
+      }
+      return;
+    }
+
+    case 'show': {
+      const id = Number(named._positional ?? named.id);
+      if (!id || isNaN(id)) throw new Error('Note ID is required. Usage: sero notes show <id>');
+      const note = state.notes.find((n) => n.id === id);
+      if (!note) throw new Error(`Note ${id} not found.`);
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(note, null, 2) + '\n');
+      } else {
+        const pin = note.pinned ? ' [pinned]' : '';
+        process.stdout.write(`# ${note.title}${pin}\n\n${note.body || '(empty)'}\n\n` +
+          `Created: ${note.createdAt}\nUpdated: ${note.updatedAt}\n`);
+      }
+      return;
+    }
+
+    case 'edit': {
+      const id = Number(named._positional ?? named.id);
+      if (!id || isNaN(id)) throw new Error('Note ID is required. Usage: sero notes edit <id>');
+      const note = state.notes.find((n) => n.id === id);
+      if (!note) throw new Error(`Note ${id} not found.`);
+      if (named.title !== undefined) note.title = named.title;
+      if (named.body !== undefined) note.body = named.body;
+      note.updatedAt = new Date().toISOString();
+      await writeState(fp, state);
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(note, null, 2) + '\n');
+      } else {
+        process.stdout.write(`Updated note #${note.id}: ${note.title}\n`);
+      }
+      return;
+    }
+
+    case 'remove': {
+      const id = Number(named._positional ?? named.id);
+      if (!id || isNaN(id)) throw new Error('Note ID is required. Usage: sero notes remove <id>');
+      const idx = state.notes.findIndex((n) => n.id === id);
+      if (idx === -1) throw new Error(`Note ${id} not found.`);
+      state.notes.splice(idx, 1);
+      await writeState(fp, state);
+      process.stdout.write(`Removed note #${id}\n`);
+      return;
+    }
+
+    case 'pin': {
+      const id = Number(named._positional ?? named.id);
+      if (!id || isNaN(id)) throw new Error('Note ID is required. Usage: sero notes pin <id>');
+      const note = state.notes.find((n) => n.id === id);
+      if (!note) throw new Error(`Note ${id} not found.`);
+      note.pinned = true;
+      note.updatedAt = new Date().toISOString();
+      await writeState(fp, state);
+      process.stdout.write(`Pinned note #${note.id}: ${note.title}\n`);
+      return;
+    }
+
+    case 'unpin': {
+      const id = Number(named._positional ?? named.id);
+      if (!id || isNaN(id)) throw new Error('Note ID is required. Usage: sero notes unpin <id>');
+      const note = state.notes.find((n) => n.id === id);
+      if (!note) throw new Error(`Note ${id} not found.`);
+      note.pinned = false;
+      note.updatedAt = new Date().toISOString();
+      await writeState(fp, state);
+      process.stdout.write(`Unpinned note #${note.id}: ${note.title}\n`);
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown action "${action}". Run 'sero help notes' for usage.`);
+  }
+}
+
+export const notesCommand: CommandDef = {
+  description: 'Manage workspace notes (add, edit, list, pin, remove, show)',
+  helpText: `Manage workspace notes — create, edit, search, and organise notes.
+
+USAGE
+  sero notes <action> [flags]
+
+ACTIONS
+  list                List all notes (newest first)
+  add                 Create a new note
+  show <id>           Show full note content
+  edit <id>           Edit an existing note
+  remove <id>         Remove a note
+  pin <id>            Pin a note to the top
+  unpin <id>          Unpin a note
+
+FLAGS
+  --title <text>      Note title (required for add)
+  --body <text>       Note body (required for add, optional for edit)
+  --query <text>      Search filter (for list)
+  --id <number>       Note ID (alternative to positional arg)
+  --json              Output as JSON
+
+EXAMPLES
+  sero notes list
+  sero notes list --query "design"
+  sero notes add --title "Meeting Notes" --body "Discussed Q1 roadmap..."
+  sero notes show 3
+  sero notes edit 3 --body "Updated: added action items"
+  sero notes pin 1
+  sero notes remove 5`,
+  run,
+};

--- a/packages/sero-cli/src/commands/plan.ts
+++ b/packages/sero-cli/src/commands/plan.ts
@@ -1,0 +1,231 @@
+/**
+ * sero plan — plan mode and task management.
+ *
+ * State: workspace-scoped.
+ * Compatible with pi-plan-mode-extension state files.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { CommandDef, Flags } from '../main.js';
+import { resolveWorkspaceStatePath, readState, writeState } from '../state.js';
+
+interface PlanStep {
+  step: number;
+  text: string;
+  completed: boolean;
+}
+
+type PlanMode = 'normal' | 'plan' | 'execute';
+
+interface PlanModeState {
+  mode: PlanMode;
+  steps: PlanStep[];
+}
+
+interface PlanIndexEntry {
+  filename: string;
+  completedAt: string;
+  stepCount: number;
+  summary: string;
+}
+
+interface PlanIndex {
+  plans: PlanIndexEntry[];
+}
+
+interface ArchivedPlan {
+  completedAt: string;
+  steps: PlanStep[];
+}
+
+const DEFAULT: PlanModeState = { mode: 'normal', steps: [] };
+
+const PLANMODE_DIR = path.join('.sero', 'apps', 'planmode');
+
+function statePath(): string {
+  return resolveWorkspaceStatePath('planmode');
+}
+
+function indexPath(): string {
+  return path.join(process.cwd(), PLANMODE_DIR, 'index.json');
+}
+
+function planDir(): string {
+  return path.join(process.cwd(), PLANMODE_DIR);
+}
+
+async function run(args: string[], flags: Flags): Promise<void> {
+  const action = args[0];
+  if (!action) throw new Error('No action specified. Run \'sero help plan\' for usage.');
+
+  const fp = statePath();
+  const state = await readState<PlanModeState>(fp, DEFAULT);
+
+  switch (action) {
+    case 'list': {
+      if (state.steps.length === 0) {
+        process.stdout.write('No plan steps yet.\n');
+        return;
+      }
+      const done = state.steps.filter((s) => s.completed).length;
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({
+          mode: state.mode,
+          steps: state.steps,
+          completed: done,
+          total: state.steps.length,
+        }, null, 2) + '\n');
+        return;
+      }
+
+      const list = state.steps
+        .map((s) => `${s.step}. ${s.completed ? '[x]' : '[ ]'} ${s.text}`)
+        .join('\n');
+      process.stdout.write(`Plan (${done}/${state.steps.length} complete):\n${list}\n`);
+      return;
+    }
+
+    case 'set': {
+      // sero plan set "Step 1" "Step 2" "Step 3"
+      const stepTexts = args.slice(1);
+      if (stepTexts.length === 0) throw new Error('At least one step is required. Usage: sero plan set "Step 1" "Step 2"');
+
+      state.steps = stepTexts.map((text, i) => ({
+        step: i + 1,
+        text,
+        completed: false,
+      }));
+      await writeState(fp, state);
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({ steps: state.steps }, null, 2) + '\n');
+        return;
+      }
+
+      const list = state.steps.map((s) => `${s.step}. [ ] ${s.text}`).join('\n');
+      process.stdout.write(`Plan created (${state.steps.length} steps):\n${list}\n`);
+      return;
+    }
+
+    case 'complete': {
+      const stepNum = Number(args[1]);
+      if (!stepNum || isNaN(stepNum)) throw new Error('Step number is required. Usage: sero plan complete <step>');
+      const item = state.steps.find((s) => s.step === stepNum);
+      if (!item) throw new Error(`Step ${stepNum} not found.`);
+      item.completed = true;
+      await writeState(fp, state);
+
+      const done = state.steps.filter((s) => s.completed).length;
+
+      // Auto-archive if all steps complete
+      if (state.steps.every((s) => s.completed)) {
+        await archivePlan(state.steps);
+        state.mode = 'normal';
+        state.steps = [];
+        await writeState(fp, state);
+        process.stdout.write(`Step ${stepNum} completed: ${item.text} (${done}/${done})\nAll steps complete! Plan archived.\n`);
+        return;
+      }
+
+      process.stdout.write(`Step ${stepNum} completed: ${item.text} (${done}/${state.steps.length})\n`);
+      return;
+    }
+
+    case 'archive': {
+      // Show archived plans
+      const idxPath = indexPath();
+      let index: PlanIndex;
+      try {
+        const raw = await fs.readFile(idxPath, 'utf8');
+        index = JSON.parse(raw) as PlanIndex;
+      } catch {
+        index = { plans: [] };
+      }
+
+      if (index.plans.length === 0) {
+        process.stdout.write('No archived plans.\n');
+        return;
+      }
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(index, null, 2) + '\n');
+        return;
+      }
+
+      const lines = index.plans.map((p, i) =>
+        `${i + 1}. ${p.summary} (${p.stepCount} steps, completed ${p.completedAt})`,
+      );
+      process.stdout.write(`Archived plans:\n${lines.join('\n')}\n`);
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown action "${action}". Run 'sero help plan' for usage.`);
+  }
+}
+
+async function archivePlan(steps: PlanStep[]): Promise<void> {
+  const dir = planDir();
+  const now = new Date();
+  const ts = now.toISOString().replace(/[:.]/g, '-');
+  const filename = `plan-${ts}.json`;
+  const filePath = path.join(dir, filename);
+
+  const archive: ArchivedPlan = {
+    completedAt: now.toISOString(),
+    steps: [...steps],
+  };
+
+  await fs.mkdir(dir, { recursive: true });
+  const tmp = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmp, JSON.stringify(archive, null, 2), 'utf8');
+  await fs.rename(tmp, filePath);
+
+  // Update index
+  const idxPath = indexPath();
+  let index: PlanIndex;
+  try {
+    const raw = await fs.readFile(idxPath, 'utf8');
+    index = JSON.parse(raw) as PlanIndex;
+  } catch {
+    index = { plans: [] };
+  }
+
+  index.plans.unshift({
+    filename,
+    completedAt: now.toISOString(),
+    stepCount: steps.length,
+    summary: steps[0]?.text.slice(0, 120) ?? '',
+  });
+
+  const idxTmp = `${idxPath}.tmp.${Date.now()}`;
+  await fs.writeFile(idxTmp, JSON.stringify(index, null, 2), 'utf8');
+  await fs.rename(idxTmp, idxPath);
+}
+
+export const planCommand: CommandDef = {
+  description: 'Plan mode and task management',
+  helpText: `Manage task plans — create, track, and archive step-by-step plans.
+
+USAGE
+  sero plan <action> [args]
+
+ACTIONS
+  list                Show current plan steps with completion status
+  set <steps...>      Create/replace plan with given steps
+  complete <step>     Mark a step as completed (1-indexed)
+  archive             Show archived (completed) plans
+
+FLAGS
+  --json              Output as JSON
+
+EXAMPLES
+  sero plan set "Analyse auth module" "Refactor token handling" "Add tests"
+  sero plan list
+  sero plan complete 1
+  sero plan complete 2
+  sero plan archive`,
+  run,
+};

--- a/packages/sero-cli/src/commands/quote.ts
+++ b/packages/sero-cli/src/commands/quote.ts
@@ -1,0 +1,108 @@
+/**
+ * sero quote — daily inspirational quote.
+ *
+ * State: global-scoped. The agent generates quotes and stores them via 'set'.
+ */
+
+import type { CommandDef, Flags } from '../main.js';
+import { resolveGlobalStatePath, readState, writeState } from '../state.js';
+
+interface Quote {
+  text: string;
+  author: string;
+  generatedAt: string;
+}
+
+interface DailyQuoteState {
+  quote: Quote | null;
+  lastRefreshDate: string | null;
+}
+
+const DEFAULT: DailyQuoteState = {
+  quote: null,
+  lastRefreshDate: null,
+};
+
+function statePath(): string {
+  return resolveGlobalStatePath('daily-quote');
+}
+
+function parseNamedArgs(args: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      result[arg.slice(2)] = args[++i];
+    }
+  }
+  return result;
+}
+
+async function run(args: string[], flags: Flags): Promise<void> {
+  const action = args[0] ?? 'get';
+  const fp = statePath();
+
+  switch (action) {
+    case 'get': {
+      const state = await readState<DailyQuoteState>(fp, DEFAULT);
+      if (!state.quote) {
+        process.stdout.write('No quote yet. Generate one with: sero quote set --quote "..." --author "..."\n');
+        return;
+      }
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(state, null, 2) + '\n');
+        return;
+      }
+      process.stdout.write(`"${state.quote.text}"\n— ${state.quote.author}\n(${state.lastRefreshDate})\n`);
+      return;
+    }
+
+    case 'set': {
+      const named = parseNamedArgs(args.slice(1));
+      if (!named.quote || !named.author) {
+        throw new Error('--quote and --author are required for set.');
+      }
+      const state = await readState<DailyQuoteState>(fp, DEFAULT);
+      state.quote = {
+        text: named.quote,
+        author: named.author,
+        generatedAt: new Date().toISOString(),
+      };
+      state.lastRefreshDate = new Date().toISOString().split('T')[0];
+      await writeState(fp, state);
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(state, null, 2) + '\n');
+      } else {
+        process.stdout.write(`"${named.quote}"\n— ${named.author}\n`);
+      }
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown action "${action}". Run 'sero help quote' for usage.`);
+  }
+}
+
+export const quoteCommand: CommandDef = {
+  description: 'Daily inspirational quote',
+  helpText: `Manage the daily inspirational quote.
+
+USAGE
+  sero quote [action] [flags]
+
+ACTIONS
+  get                 Show current quote (default)
+  set                 Store a new quote
+
+FLAGS
+  --quote <text>      Quote text (required for set)
+  --author <text>     Quote author (required for set)
+  --json              Output as JSON
+
+EXAMPLES
+  sero quote
+  sero quote get
+  sero quote set --quote "The only way to do great work is to love what you do." --author "Steve Jobs"`,
+  run,
+};

--- a/packages/sero-cli/src/commands/slopzilla.ts
+++ b/packages/sero-cli/src/commands/slopzilla.ts
@@ -1,0 +1,138 @@
+/**
+ * sero slopzilla — view SlopZilla history and saved ideas.
+ *
+ * State: global-scoped, read-only from CLI perspective.
+ */
+
+import type { CommandDef, Flags } from '../main.js';
+import { resolveGlobalStatePath, readState } from '../state.js';
+
+interface AppIdea {
+  id: number;
+  name: string;
+  tagline: string;
+  description: string;
+  techStack: string[];
+  slopScore: number;
+}
+
+interface SavedIdea {
+  idea: AppIdea;
+  savedAt: string;
+}
+
+type BuildStatus = 'launched' | 'complete' | 'failed';
+
+interface HistoryEntry {
+  idea: AppIdea;
+  launchedAt: string;
+  workspaceId: string;
+  sessionId: string | null;
+  sessionPath: string | null;
+  status: BuildStatus;
+}
+
+interface SlopZillaState {
+  phase: string;
+  complexity: string | null;
+  technologies: string[];
+  ideas: AppIdea[] | null;
+  chosenIdea: AppIdea | null;
+  launchedWorkspaceId: string | null;
+  launchedSessionId: string | null;
+  history: HistoryEntry[];
+  savedIdeas: SavedIdea[];
+}
+
+const DEFAULT: SlopZillaState = {
+  phase: 'config',
+  complexity: null,
+  technologies: [],
+  ideas: null,
+  chosenIdea: null,
+  launchedWorkspaceId: null,
+  launchedSessionId: null,
+  history: [],
+  savedIdeas: [],
+};
+
+function statePath(): string {
+  return resolveGlobalStatePath('slopzilla');
+}
+
+async function run(args: string[], flags: Flags): Promise<void> {
+  const action = args[0] ?? 'history';
+  const fp = statePath();
+  const state = await readState<SlopZillaState>(fp, DEFAULT);
+
+  switch (action) {
+    case 'history': {
+      if (state.history.length === 0) {
+        process.stdout.write('No SlopZilla launches yet.\n');
+        return;
+      }
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({ history: state.history }, null, 2) + '\n');
+        return;
+      }
+
+      const lines = state.history.map((h, i) => {
+        const status = h.status ?? 'launched';
+        return `${i + 1}. ${h.idea.name} (slop: ${h.idea.slopScore}/10, status: ${status})\n` +
+          `   ${h.idea.tagline}\n` +
+          `   Tech: ${h.idea.techStack.join(', ')}\n` +
+          `   Launched: ${h.launchedAt}`;
+      });
+      process.stdout.write(`SlopZilla Launch History:\n\n${lines.join('\n\n')}\n`);
+      return;
+    }
+
+    case 'saved': {
+      const saved = state.savedIdeas ?? [];
+      if (saved.length === 0) {
+        process.stdout.write('No saved ideas.\n');
+        return;
+      }
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({ savedIdeas: saved }, null, 2) + '\n');
+        return;
+      }
+
+      const lines = saved.map((s, i) =>
+        `${i + 1}. ${s.idea.name} (slop: ${s.idea.slopScore}/10)\n` +
+        `   ${s.idea.tagline}\n` +
+        `   ${s.idea.description}\n` +
+        `   Tech: ${s.idea.techStack.join(', ')}\n` +
+        `   Saved: ${s.savedAt}`,
+      );
+      process.stdout.write(`SlopZilla Saved Ideas (${saved.length}):\n\n${lines.join('\n\n')}\n`);
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown action "${action}". Run 'sero help slopzilla' for usage.`);
+  }
+}
+
+export const slopzillaCommand: CommandDef = {
+  description: 'View SlopZilla history and bookmarks',
+  helpText: `View SlopZilla launch history and bookmarked ideas.
+
+USAGE
+  sero slopzilla [action]
+
+ACTIONS
+  history             List launched apps with status (default)
+  saved               List bookmarked ideas
+
+FLAGS
+  --json              Output as JSON
+
+EXAMPLES
+  sero slopzilla
+  sero slopzilla history
+  sero slopzilla saved`,
+  run,
+};

--- a/packages/sero-cli/src/commands/todo.ts
+++ b/packages/sero-cli/src/commands/todo.ts
@@ -1,0 +1,122 @@
+/**
+ * sero todo — manage workspace todos.
+ *
+ * State: workspace-scoped (relative to cwd).
+ */
+
+import type { CommandDef, Flags } from '../main.js';
+import { resolveWorkspaceStatePath, readState, writeState } from '../state.js';
+
+interface Todo {
+  id: number;
+  text: string;
+  done: boolean;
+  createdAt: string;
+}
+
+interface TodoState {
+  todos: Todo[];
+  nextId: number;
+}
+
+const DEFAULT: TodoState = { todos: [], nextId: 1 };
+
+function statePath(): string {
+  return resolveWorkspaceStatePath('todo');
+}
+
+async function run(args: string[], flags: Flags): Promise<void> {
+  const action = args[0];
+  if (!action) throw new Error('No action specified. Run \'sero help todo\' for usage.');
+
+  const fp = statePath();
+  const state = await readState<TodoState>(fp, DEFAULT);
+
+  switch (action) {
+    case 'list': {
+      if (state.todos.length === 0) {
+        process.stdout.write('No todos yet.\n');
+        return;
+      }
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({ todos: state.todos, count: state.todos.length }, null, 2) + '\n');
+        return;
+      }
+
+      const lines = state.todos.map(
+        (t) => `[${t.done ? 'x' : ' '}] #${t.id}: ${t.text}`,
+      );
+      process.stdout.write(lines.join('\n') + '\n');
+      return;
+    }
+
+    case 'add': {
+      // Everything after 'add' is the text
+      const text = args.slice(1).join(' ').trim();
+      if (!text) throw new Error('Text is required. Usage: sero todo add "your task"');
+      const todo: Todo = {
+        id: state.nextId,
+        text,
+        done: false,
+        createdAt: new Date().toISOString(),
+      };
+      state.todos.push(todo);
+      state.nextId++;
+      await writeState(fp, state);
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(todo, null, 2) + '\n');
+      } else {
+        process.stdout.write(`Added todo #${todo.id}: ${todo.text}\n`);
+      }
+      return;
+    }
+
+    case 'toggle': {
+      const id = Number(args[1]);
+      if (!id || isNaN(id)) throw new Error('Todo ID is required. Usage: sero todo toggle <id>');
+      const todo = state.todos.find((t) => t.id === id);
+      if (!todo) throw new Error(`Todo ${id} not found.`);
+      todo.done = !todo.done;
+      await writeState(fp, state);
+      process.stdout.write(`Todo #${todo.id} ${todo.done ? 'completed' : 'uncompleted'}\n`);
+      return;
+    }
+
+    case 'clear': {
+      const count = state.todos.length;
+      await writeState(fp, { ...DEFAULT });
+      process.stdout.write(`Cleared ${count} todos\n`);
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown action "${action}". Run 'sero help todo' for usage.`);
+  }
+}
+
+export const todoCommand: CommandDef = {
+  description: 'Manage todo list (add, toggle, list, clear)',
+  helpText: `Manage workspace todo list — add, toggle, list, and clear tasks.
+
+USAGE
+  sero todo <action> [args]
+
+ACTIONS
+  list                List all todos
+  add <text>          Add a new todo
+  toggle <id>         Toggle todo completion
+  clear               Remove all todos
+
+FLAGS
+  --json              Output as JSON
+
+EXAMPLES
+  sero todo list
+  sero todo add "Fix login bug"
+  sero todo add "Write tests" && sero todo add "Deploy to staging"
+  sero todo toggle 1
+  sero todo clear`,
+  run,
+};

--- a/packages/sero-cli/src/commands/weight.ts
+++ b/packages/sero-cli/src/commands/weight.ts
@@ -1,0 +1,234 @@
+/**
+ * sero weight — track weight over time.
+ *
+ * State: global-scoped.
+ */
+
+import type { CommandDef, Flags } from '../main.js';
+import { resolveGlobalStatePath, readState, writeState } from '../state.js';
+
+type WeightUnit = 'kg' | 'lbs' | 'st';
+
+interface WeightEntry {
+  id: number;
+  weight: number;
+  date: string;
+  note?: string;
+  createdAt: string;
+}
+
+interface WeightGoal {
+  target: number;
+  startWeight: number;
+  startDate: string;
+}
+
+interface WeightTrackerState {
+  entries: WeightEntry[];
+  nextId: number;
+  unit: WeightUnit;
+  goal: WeightGoal | null;
+}
+
+const DEFAULT: WeightTrackerState = {
+  entries: [],
+  nextId: 1,
+  unit: 'kg',
+  goal: null,
+};
+
+function statePath(): string {
+  return resolveGlobalStatePath('weight-tracker');
+}
+
+function formatWeight(weight: number, unit: WeightUnit): string {
+  if (unit === 'st') {
+    const stones = Math.floor(weight / 6.35029);
+    const lbs = Math.round((weight % 6.35029) / 0.453592);
+    return `${stones}st ${lbs}lbs`;
+  }
+  if (unit === 'lbs') return `${Math.round(weight * 2.20462 * 10) / 10} lbs`;
+  return `${Math.round(weight * 10) / 10} kg`;
+}
+
+function todayISO(): string {
+  return new Date().toISOString().split('T')[0];
+}
+
+function parseNamedArgs(args: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--') && i + 1 < args.length) {
+      result[arg.slice(2)] = args[++i];
+    } else if (!result._positional) {
+      result._positional = arg;
+    }
+  }
+  return result;
+}
+
+async function run(args: string[], flags: Flags): Promise<void> {
+  const action = args[0];
+  if (!action) throw new Error('No action specified. Run \'sero help weight\' for usage.');
+
+  const fp = statePath();
+  const state = await readState<WeightTrackerState>(fp, DEFAULT);
+  const named = parseNamedArgs(args.slice(1));
+
+  // Update unit if specified
+  if (named.unit && ['kg', 'lbs', 'st'].includes(named.unit)) {
+    state.unit = named.unit as WeightUnit;
+  }
+
+  switch (action) {
+    case 'log': {
+      const weight = Number(named._positional ?? named.weight);
+      if (!weight || isNaN(weight)) throw new Error('Weight value is required. Usage: sero weight log <value>');
+      const entry: WeightEntry = {
+        id: state.nextId,
+        weight,
+        date: named.date || todayISO(),
+        note: named.note,
+        createdAt: new Date().toISOString(),
+      };
+      state.entries.push(entry);
+      state.nextId++;
+      await writeState(fp, state);
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify(entry, null, 2) + '\n');
+      } else {
+        process.stdout.write(`Logged ${formatWeight(entry.weight, state.unit)} on ${entry.date}\n`);
+      }
+      return;
+    }
+
+    case 'list': {
+      if (state.entries.length === 0) {
+        process.stdout.write('No weight entries yet. Log your first one!\n');
+        return;
+      }
+      const sorted = [...state.entries].sort((a, b) => a.date.localeCompare(b.date));
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({ entries: sorted, unit: state.unit }, null, 2) + '\n');
+        return;
+      }
+
+      const lines = sorted.map((e) => {
+        let line = `#${e.id}: ${e.date} — ${formatWeight(e.weight, state.unit)}`;
+        if (e.note) line += ` (${e.note})`;
+        return line;
+      });
+      process.stdout.write(lines.join('\n') + '\n');
+      return;
+    }
+
+    case 'remove': {
+      const id = Number(named._positional ?? named.id);
+      if (!id || isNaN(id)) throw new Error('Entry ID is required. Usage: sero weight remove <id>');
+      const before = state.entries.length;
+      state.entries = state.entries.filter((e) => e.id !== id);
+      if (state.entries.length === before) throw new Error(`Entry #${id} not found.`);
+      await writeState(fp, state);
+      process.stdout.write(`Removed entry #${id}\n`);
+      return;
+    }
+
+    case 'goal': {
+      const target = Number(named._positional ?? named.weight);
+      if (!target || isNaN(target)) throw new Error('Target weight is required. Usage: sero weight goal <value>');
+      const latestEntry = [...state.entries].sort((a, b) => b.date.localeCompare(a.date))[0];
+      state.goal = {
+        target,
+        startWeight: latestEntry?.weight ?? target,
+        startDate: todayISO(),
+      };
+      await writeState(fp, state);
+      process.stdout.write(`Goal set: ${formatWeight(target, state.unit)}\n`);
+      return;
+    }
+
+    case 'status': {
+      if (state.entries.length === 0) {
+        process.stdout.write('No entries yet — log your weight to get started!\n');
+        return;
+      }
+      const sorted = [...state.entries].sort((a, b) => a.date.localeCompare(b.date));
+      const latest = sorted[sorted.length - 1];
+      const first = sorted[0];
+      const totalChange = latest.weight - first.weight;
+      const sign = totalChange <= 0 ? '' : '+';
+
+      if (flags.json) {
+        process.stdout.write(JSON.stringify({
+          current: latest.weight,
+          currentDate: latest.date,
+          totalChange,
+          entryCount: state.entries.length,
+          unit: state.unit,
+          goal: state.goal,
+        }, null, 2) + '\n');
+        return;
+      }
+
+      let text = `Current: ${formatWeight(latest.weight, state.unit)} (${latest.date})\n`;
+      text += `Total change: ${sign}${formatWeight(Math.abs(totalChange), state.unit)}\n`;
+      text += `Entries: ${state.entries.length}\n`;
+
+      if (state.goal) {
+        const remaining = latest.weight - state.goal.target;
+        if (remaining > 0) {
+          text += `Goal: ${formatWeight(state.goal.target, state.unit)} (${formatWeight(remaining, state.unit)} to go)\n`;
+        } else {
+          text += `Goal reached! Target was ${formatWeight(state.goal.target, state.unit)}\n`;
+        }
+      }
+      process.stdout.write(text);
+      return;
+    }
+
+    case 'clear': {
+      const count = state.entries.length;
+      await writeState(fp, { ...DEFAULT });
+      process.stdout.write(`Cleared ${count} weight entries\n`);
+      return;
+    }
+
+    default:
+      throw new Error(`Unknown action "${action}". Run 'sero help weight' for usage.`);
+  }
+}
+
+export const weightCommand: CommandDef = {
+  description: 'Track weight over time',
+  helpText: `Track body weight over time with goals and status reports.
+
+USAGE
+  sero weight <action> [args] [flags]
+
+ACTIONS
+  log <weight>        Log a weight entry
+  list                Show all entries (chronological)
+  remove <id>         Remove an entry
+  goal <weight>       Set a target weight
+  status              Summary with progress toward goal
+  clear               Remove all entries
+
+FLAGS
+  --date <YYYY-MM-DD> Date for log entry (defaults to today)
+  --note <text>       Optional note for log entry
+  --unit <kg|lbs|st>  Set display unit (persisted)
+  --json              Output as JSON
+
+EXAMPLES
+  sero weight log 75.5
+  sero weight log 74.2 --date 2026-02-24 --note "After morning run"
+  sero weight list
+  sero weight goal 70 --unit kg
+  sero weight status
+  sero weight remove 3
+  sero weight clear`,
+  run,
+};

--- a/packages/sero-cli/src/main.ts
+++ b/packages/sero-cli/src/main.ts
@@ -1,0 +1,153 @@
+/**
+ * Sero CLI — workspace tools, integrations, and app control.
+ *
+ * Self-contained Node.js script with zero external dependencies.
+ * Commands are organised into tiers:
+ *   - Local: file-based state, no host communication
+ *   - Host: requires host API call (future Phase 2)
+ *   - Control: mutates Sero app state (future Phase 3)
+ */
+
+import { notesCommand } from './commands/notes.js';
+import { todoCommand } from './commands/todo.js';
+import { calcCommand } from './commands/calc.js';
+import { quoteCommand } from './commands/quote.js';
+import { weightCommand } from './commands/weight.js';
+import { planCommand } from './commands/plan.js';
+import { slopzillaCommand } from './commands/slopzilla.js';
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface CommandDef {
+  description: string;
+  helpText: string;
+  run: (args: string[], flags: Flags) => Promise<void>;
+}
+
+export interface Flags {
+  json: boolean;
+  quiet: boolean;
+  help: boolean;
+}
+
+// ── Command registry ────────────────────────────────────────
+
+const commands: Record<string, CommandDef> = {
+  notes: notesCommand,
+  todo: todoCommand,
+  calc: calcCommand,
+  quote: quoteCommand,
+  weight: weightCommand,
+  plan: planCommand,
+  slopzilla: slopzillaCommand,
+};
+
+// ── Flag parsing ────────────────────────────────────────────
+
+function parseFlags(argv: string[]): { args: string[]; flags: Flags } {
+  const flags: Flags = { json: false, quiet: false, help: false };
+  const args: string[] = [];
+
+  for (const arg of argv) {
+    if (arg === '--json') flags.json = true;
+    else if (arg === '--quiet' || arg === '-q') flags.quiet = true;
+    else if (arg === '--help' || arg === '-h') flags.help = true;
+    else args.push(arg);
+  }
+
+  return { args, flags };
+}
+
+// ── Help text ───────────────────────────────────────────────
+
+const TOP_LEVEL_HELP = `Sero CLI — workspace tools, integrations, and app control.
+
+USAGE
+  sero <command> [subcommand] [args] [flags]
+  sero help <command>
+
+COMMANDS
+  notes        Manage workspace notes (add, edit, list, pin, remove, show)
+  todo         Manage todo list (add, toggle, list, clear)
+  calc         Evaluate math expressions
+  quote        Daily inspirational quote
+  weight       Track weight over time
+  plan         Plan mode and task management
+  slopzilla    View SlopZilla history and bookmarks
+
+GLOBAL FLAGS
+  --help, -h    Show help for a command
+  --json        Output as JSON
+  --quiet, -q   Suppress non-essential output
+
+EXAMPLES
+  sero notes add --title "API Design" --body "REST vs GraphQL comparison"
+  sero todo add "Fix login bug" && sero todo add "Write tests"
+  sero calc "sqrt(144) + 2^3"
+  sero help notes
+
+Run 'sero help <command>' for detailed usage of any command.`;
+
+// ── Main ────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const rawArgs = process.argv.slice(2);
+  const { args, flags } = parseFlags(rawArgs);
+
+  if (args.length === 0 || flags.help && args.length === 0) {
+    process.stdout.write(TOP_LEVEL_HELP + '\n');
+    return;
+  }
+
+  // sero --version
+  if (args[0] === '--version') {
+    process.stdout.write('sero 0.1.0\n');
+    return;
+  }
+
+  // sero help [command]
+  if (args[0] === 'help') {
+    const cmdName = args[1];
+    if (!cmdName) {
+      process.stdout.write(TOP_LEVEL_HELP + '\n');
+      return;
+    }
+    const cmd = commands[cmdName];
+    if (!cmd) {
+      process.stderr.write(`Error: Unknown command "${cmdName}". Run 'sero help' to see available commands.\n`);
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write(cmd.helpText + '\n');
+    return;
+  }
+
+  // sero <command> [subcommand] [args]
+  const cmdName = args[0];
+  const cmd = commands[cmdName];
+
+  if (!cmd) {
+    process.stderr.write(`Error: Unknown command "${cmdName}". Run 'sero help' to see available commands.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  // sero <command> --help
+  if (flags.help) {
+    process.stdout.write(cmd.helpText + '\n');
+    return;
+  }
+
+  try {
+    await cmd.run(args.slice(1), flags);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Error: ${msg}\n`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${err instanceof Error ? err.message : err}\n`);
+  process.exitCode = 1;
+});

--- a/packages/sero-cli/src/state.ts
+++ b/packages/sero-cli/src/state.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared state file I/O for local CLI commands.
+ *
+ * Matches the exact patterns used by existing extensions:
+ * - Atomic writes via tmp file + rename
+ * - SERO_HOME-based resolution for global-scoped apps
+ * - Workspace-relative resolution for workspace-scoped apps
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Resolve state file path for a global-scoped app.
+ * - SERO_HOME set: ~/.sero-ui/apps/<appId>/state.json
+ * - Fallback: <cwd>/.sero/apps/<appId>/state.json
+ */
+export function resolveGlobalStatePath(appId: string): string {
+  const seroHome = process.env.SERO_HOME;
+  if (seroHome) {
+    return path.join(seroHome, 'apps', appId, 'state.json');
+  }
+  return path.join(process.cwd(), '.sero', 'apps', appId, 'state.json');
+}
+
+/**
+ * Resolve state file path for a workspace-scoped app.
+ * Always relative to cwd.
+ */
+export function resolveWorkspaceStatePath(appId: string): string {
+  return path.join(process.cwd(), '.sero', 'apps', appId, 'state.json');
+}
+
+/** Read and parse a JSON state file. Returns the default if not found. */
+export async function readState<T>(filePath: string, defaultState: T): Promise<T> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return { ...defaultState };
+  }
+}
+
+/** Atomic write: write to temp file, then rename. */
+export async function writeState<T>(filePath: string, state: T): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}

--- a/packages/sero-cli/tsconfig.json
+++ b/packages/sero-cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,6 +884,15 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/sero-cli:
+    devDependencies:
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/ui:
     dependencies:
       '@base-ui/react':


### PR DESCRIPTION
Comprehensive plan to replace individual agent tool definitions with a
unified `sero` CLI, reducing context window bloat (~3,100 tokens saved)
and enabling multi-step command composition via bash.

Key design decisions:
- 4 native tools retained (bash, read, write, edit)
- 3-tier CLI: local (file state), host API, control (Electron IPC)
- Permission guard system for control commands (allow/ask/deny)
- Support both container and filesystem workspaces
- Help system as primary agent discovery mechanism
- Phased migration preserving extension coexistence

https://claude.ai/code/session_01XjYiHVfV9FgPNMqQKJDpVw