### PR TITLE
feat: sero-cli tool — unified CLI for agent context reduction

### DIFF
--- a/apps/desktop/e2e/file-tree.spec.ts
+++ b/apps/desktop/e2e/file-tree.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test';
+import { launchSeroApp, layout, workspace, fileTree } from './helpers';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+/**
+ * File tree e2e tests.
+ *
+ * Verifies the file explorer shows workspace files immediately when
+ * a workspace is selected — without requiring a session to be clicked first.
+ *
+ * Regression test for: file tree empty until a session is selected.
+ */
+
+const SERO_TEST_HOME = path.resolve(__dirname, '../.sero-filetree-test');
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function cleanTestData() {
+  fs.rmSync(SERO_TEST_HOME, { recursive: true, force: true });
+}
+
+/** Create a temp directory with known test files. Returns absolute path. */
+function createTestWorkspaceDir(name: string, files: string[]): string {
+  const dir = path.join(os.tmpdir(), `sero-e2e-${name}-${Date.now()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const file of files) {
+    const filePath = path.join(dir, file);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, `// ${file}\n`, 'utf8');
+  }
+  return dir;
+}
+
+/** Remove a temp workspace directory. */
+function cleanWorkspaceDir(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/** Wait for the app shell to be visible (layout hydrated). */
+async function waitForShell(page: Page) {
+  await expect(page.locator(layout.appShell).first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator(layout.sidebarToggle)).toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Add a folder as a workspace via the IPC bridge, disable containers,
+ * and trigger a store refresh so the sidebar updates.
+ * Returns the workspace info object.
+ */
+async function addWorkspace(
+  page: Page,
+  folderPath: string,
+  name?: string,
+): Promise<{ id: string; name: string; path: string }> {
+  return page.evaluate(
+    async ({ folderPath, name }) => {
+      const sero = (window as any).sero;
+      // 1. Register folder via IPC
+      const ws = await sero.workspace.addFolder(folderPath, name);
+      // 2. Disable container mode so host filesystem is used directly
+      await sero.workspace.setContainer(ws.id, false);
+      // 3. Dispatch event to trigger Zustand store refresh in WorkspaceTree
+      window.dispatchEvent(new Event('sero:workspace-changed'));
+      return ws;
+    },
+    { folderPath, name },
+  );
+}
+
+/** Click a workspace header in the sidebar. */
+async function clickWorkspace(page: Page, wsId: string) {
+  const wsNode = page.locator(workspace.nodeById(wsId));
+  await expect(wsNode).toBeVisible({ timeout: 10_000 });
+  await wsNode.click();
+}
+
+/** Wait for the file tree container to be visible and contain items. */
+async function waitForFileTree(page: Page) {
+  const tree = page.locator(fileTree.container);
+  await expect(tree).toBeVisible({ timeout: 10_000 });
+  return tree;
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+test.describe('File tree — workspace click shows files', () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let wsDir: string;
+  let wsInfo: { id: string; name: string; path: string };
+
+  const TEST_FILES = [
+    'README.md',
+    'package.json',
+    'src/index.ts',
+    'src/utils.ts',
+  ];
+
+  test.beforeAll(async () => {
+    cleanTestData();
+    wsDir = createTestWorkspaceDir('filetree-test', TEST_FILES);
+
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+
+    // Add workspace and wait for sidebar to pick it up
+    wsInfo = await addWorkspace(page, wsDir, 'FileTreeTest');
+    await page.waitForTimeout(1000);
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    cleanTestData();
+    cleanWorkspaceDir(wsDir);
+  });
+
+  test('workspace node appears in sidebar', async () => {
+    const wsNode = page.locator(workspace.nodeById(wsInfo.id));
+    await expect(wsNode).toBeVisible({ timeout: 10_000 });
+    await expect(wsNode).toContainText('FileTreeTest');
+  });
+
+  test('clicking workspace shows file tree without selecting a session', async () => {
+    // Click the workspace header — sets it as active workspace.
+    // The file tree should populate in the Explorer panel without
+    // needing to select a session first.
+    await clickWorkspace(page, wsInfo.id);
+
+    const tree = await waitForFileTree(page);
+
+    // Root-level files should be listed
+    await expect(tree.locator('text=README.md')).toBeVisible({ timeout: 10_000 });
+    await expect(tree.locator('text=package.json')).toBeVisible({ timeout: 5000 });
+    // 'src' directory should also be visible
+    await expect(tree.locator('text=src')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('file tree items are interactive (expandable folders)', async () => {
+    const tree = page.locator(fileTree.container);
+
+    // Click 'src' folder to expand it
+    const srcFolder = tree.locator('text=src').first();
+    await srcFolder.click();
+
+    // Children should appear after expansion
+    await expect(tree.locator('text=index.ts')).toBeVisible({ timeout: 5000 });
+    await expect(tree.locator('text=utils.ts')).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe('File tree — switching workspaces updates file tree', () => {
+  let app: ElectronApplication;
+  let page: Page;
+  let wsDirA: string;
+  let wsDirB: string;
+  let wsInfoA: { id: string; name: string; path: string };
+  let wsInfoB: { id: string; name: string; path: string };
+
+  test.beforeAll(async () => {
+    cleanTestData();
+    wsDirA = createTestWorkspaceDir('ws-a', ['alpha.ts', 'bravo.ts']);
+    wsDirB = createTestWorkspaceDir('ws-b', ['charlie.ts', 'delta.ts']);
+
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+
+    // Add both workspaces, container disabled
+    wsInfoA = await addWorkspace(page, wsDirA, 'WorkspaceAlpha');
+    wsInfoB = await addWorkspace(page, wsDirB, 'WorkspaceBravo');
+
+    await page.waitForTimeout(1000);
+  });
+
+  test.afterAll(async () => {
+    await app?.close();
+    cleanTestData();
+    cleanWorkspaceDir(wsDirA);
+    cleanWorkspaceDir(wsDirB);
+  });
+
+  test('clicking workspace A shows its files', async () => {
+    await clickWorkspace(page, wsInfoA.id);
+
+    const tree = await waitForFileTree(page);
+    await expect(tree.locator('text=alpha.ts')).toBeVisible({ timeout: 10_000 });
+    await expect(tree.locator('text=bravo.ts')).toBeVisible({ timeout: 5000 });
+    // Should NOT show workspace B files
+    await expect(tree.locator('text=charlie.ts')).not.toBeVisible();
+    await expect(tree.locator('text=delta.ts')).not.toBeVisible();
+  });
+
+  test('switching to workspace B replaces file tree', async () => {
+    await clickWorkspace(page, wsInfoB.id);
+
+    const tree = await waitForFileTree(page);
+    await expect(tree.locator('text=charlie.ts')).toBeVisible({ timeout: 10_000 });
+    await expect(tree.locator('text=delta.ts')).toBeVisible({ timeout: 5000 });
+    // Should NOT show workspace A files
+    await expect(tree.locator('text=alpha.ts')).not.toBeVisible();
+    await expect(tree.locator('text=bravo.ts')).not.toBeVisible();
+  });
+
+  test('switching back to workspace A restores its files', async () => {
+    await clickWorkspace(page, wsInfoA.id);
+
+    const tree = await waitForFileTree(page);
+    await expect(tree.locator('text=alpha.ts')).toBeVisible({ timeout: 10_000 });
+    await expect(tree.locator('text=bravo.ts')).toBeVisible({ timeout: 5000 });
+  });
+});

--- a/apps/desktop/e2e/file-tree.spec.ts
+++ b/apps/desktop/e2e/file-tree.spec.ts
@@ -148,6 +148,27 @@ test.describe('File tree — workspace click shows files', () => {
     await expect(tree.locator('text=index.ts')).toBeVisible({ timeout: 5000 });
     await expect(tree.locator('text=utils.ts')).toBeVisible({ timeout: 5000 });
   });
+
+  test('clicking a file opens it in the editor with content', async () => {
+    const tree = page.locator(fileTree.container);
+
+    // Click package.json (non-markdown so it opens in Monaco, not preview)
+    await tree.locator('text=package.json').click();
+
+    // The file content should appear in the editor area.
+    // Our test file contains "// package.json" — look for that text.
+    const editorArea = page.locator('[data-testid="active-app-panel"]');
+    await expect(editorArea.getByText('package.json').last()).toBeVisible({ timeout: 10_000 });
+
+    // Also verify readFile works via IPC (the underlying fix)
+    const content = await page.evaluate(
+      async (wsId) => {
+        return (window as any).sero.editor.readFile(wsId, '/workspace/package.json');
+      },
+      wsInfo.id,
+    );
+    expect(content).toContain('// package.json');
+  });
 });
 
 test.describe('File tree — switching workspaces updates file tree', () => {

--- a/apps/desktop/e2e/helpers/index.ts
+++ b/apps/desktop/e2e/helpers/index.ts
@@ -1,3 +1,3 @@
 export { launchSeroApp, evaluateInMain, getWindowTitle, isWindowVisible } from './electron-app';
 export type { LaunchOptions } from './electron-app';
-export { layout, sidebar, chat, modelSelector, vcs, workspace, auth } from './selectors';
+export { layout, sidebar, chat, modelSelector, vcs, workspace, fileTree, auth } from './selectors';

--- a/apps/desktop/e2e/helpers/selectors.ts
+++ b/apps/desktop/e2e/helpers/selectors.ts
@@ -18,6 +18,22 @@ export const layout = {
   chatToggle: 'button[aria-label="Toggle agent"]',
   /** Status bar footer. */
   statusBar: 'footer',
+
+  // ── Resizable panels (data-testid from react-resizable-panels) ──
+  /** The top-level horizontal panel group in App.tsx. */
+  shellPanelGroup: '[data-testid="app-shell-panels"]',
+  /** Main sidebar panel (left, collapsible). */
+  sidebarPanel: '[data-testid="main-sidebar-panel"]',
+  /** Active app panel (center). */
+  activeAppPanel: '[data-testid="active-app-panel"]',
+  /** Chat panel (right, collapsible). */
+  chatPanel: '[data-testid="chat-panel"]',
+  /** Handle between sidebar and active-app. */
+  sidebarHandle: '[data-testid="app-shell-panels"] [data-separator]',
+  /** CodingWorkspace vertical panel group. */
+  codingVerticalGroup: '[data-testid="coding-vertical"]',
+  /** CodingWorkspace terminal panel. */
+  terminalPanel: '[data-testid="coding-terminal"]',
 } as const;
 
 // ── Sidebar ─────────────────────────────────────────────────────

--- a/apps/desktop/e2e/helpers/selectors.ts
+++ b/apps/desktop/e2e/helpers/selectors.ts
@@ -115,6 +115,19 @@ export const workspace = {
   addButton: 'button[title="Add workspace folder"]',
   /** Workspace node in sidebar — use `.filter({ hasText })` for specific workspace. */
   workspaceNode: '[data-testid="workspace-node"]',
+  /** Workspace node by ID — use workspace.nodeById(id). */
+  nodeById: (id: string) => `[data-testid="workspace-node-${id}"]`,
+} as const;
+
+// ── File Tree ───────────────────────────────────────────────────
+
+export const fileTree = {
+  /** The file tree container. */
+  container: '[data-testid="file-tree"]',
+  /** Sidebar content area (coding panel body). */
+  sidebarContent: '[data-testid="coding-sidebar-content"]',
+  /** File tree item by filename. */
+  itemByName: (name: string) => `[data-testid="file-tree-item-${name}"]`,
 } as const;
 
 // ── Auth ────────────────────────────────────────────────────────

--- a/apps/desktop/e2e/layout.spec.ts
+++ b/apps/desktop/e2e/layout.spec.ts
@@ -1,0 +1,476 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test';
+import { launchSeroApp, layout } from './helpers';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Layout e2e tests.
+ *
+ * Verifies panel toggle, resize, persistence, and reload behaviour
+ * for the main sidebar, chat panel, and CodingWorkspace terminal.
+ */
+
+const SERO_TEST_HOME = path.resolve(__dirname, '../.sero-layout-test');
+const LAYOUT_FILE = path.join(SERO_TEST_HOME, 'agent', 'layout.json');
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/** Read the persisted layout.json from disk. */
+function readLayoutFile(): Record<string, unknown> | null {
+  try {
+    return JSON.parse(fs.readFileSync(LAYOUT_FILE, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/** Write a layout.json seed before launching the app. */
+function seedLayout(state: Record<string, unknown>) {
+  fs.mkdirSync(path.dirname(LAYOUT_FILE), { recursive: true });
+  fs.writeFileSync(LAYOUT_FILE, JSON.stringify(state, null, 2), 'utf8');
+}
+
+/** Clean up the test data directory. */
+function cleanTestData() {
+  fs.rmSync(SERO_TEST_HOME, { recursive: true, force: true });
+}
+
+/** Get the bounding box width of a panel by selector. */
+async function panelWidth(page: Page, selector: string): Promise<number> {
+  const box = await page.locator(selector).first().boundingBox();
+  return box?.width ?? 0;
+}
+
+/** Get the bounding box height of a panel by selector. */
+async function panelHeight(page: Page, selector: string): Promise<number> {
+  const box = await page.locator(selector).first().boundingBox();
+  return box?.height ?? 0;
+}
+
+/** Wait for the app shell to be visible (layout hydrated). */
+async function waitForShell(page: Page) {
+  await expect(page.locator(layout.appShell).first()).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator(layout.sidebarToggle)).toBeVisible({ timeout: 10_000 });
+}
+
+/** Wait for a panel to reach a width threshold (polls instead of fixed timeout). */
+async function waitForPanelWidth(
+  page: Page,
+  selector: string,
+  predicate: (width: number) => boolean,
+  timeout = 3000,
+) {
+  await expect
+    .poll(async () => {
+      const w = await panelWidth(page, selector);
+      return predicate(w);
+    }, { timeout })
+    .toBe(true);
+}
+
+/** Wait for layout.json to exist and satisfy a predicate. */
+async function waitForLayoutFile(
+  test: (data: Record<string, unknown>) => boolean,
+  timeout = 3000,
+) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const data = readLayoutFile();
+    if (data && test(data)) return data;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  // Final attempt
+  const data = readLayoutFile();
+  expect(data).toBeTruthy();
+  expect(test(data!)).toBe(true);
+  return data!;
+}
+
+// ── Tests ───────────────────────────────────────────────────────
+
+test.describe('Layout — sidebar toggle', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    cleanTestData();
+    seedLayout({ mainSidebarOpen: true, chatPanelOpen: true });
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+  });
+
+  test.afterAll(async () => {
+    await app.close();
+    cleanTestData();
+  });
+
+  test('sidebar is visible when open', async () => {
+    const width = await panelWidth(page, layout.sidebarPanel);
+    expect(width).toBeGreaterThan(100);
+  });
+
+  test('toggling sidebar collapses it to ~0 width', async () => {
+    await page.click(layout.sidebarToggle);
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w < 5);
+  });
+
+  test('active app fills freed space (no gap)', async () => {
+    const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+    const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+    const chatBox = await page.locator(layout.chatPanel).first().boundingBox();
+    expect(shellBox).toBeTruthy();
+    expect(appBox).toBeTruthy();
+    expect(chatBox).toBeTruthy();
+    const usedWidth = appBox!.width + chatBox!.width;
+    expect(usedWidth).toBeGreaterThan(shellBox!.width - 10);
+  });
+
+  test('toggling sidebar back restores it', async () => {
+    await page.click(layout.sidebarToggle);
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w > 100);
+  });
+
+  test('sidebar open state is persisted to layout.json', async () => {
+    await page.click(layout.sidebarToggle);
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w < 5);
+    const data = await waitForLayoutFile((d) => d.mainSidebarOpen === false);
+    expect(data.mainSidebarOpen).toBe(false);
+
+    await page.click(layout.sidebarToggle);
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w > 100);
+    const data2 = await waitForLayoutFile((d) => d.mainSidebarOpen === true);
+    expect(data2.mainSidebarOpen).toBe(true);
+  });
+});
+
+test.describe('Layout — chat panel toggle', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    cleanTestData();
+    seedLayout({ mainSidebarOpen: true, chatPanelOpen: true });
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+  });
+
+  test.afterAll(async () => {
+    await app.close();
+    cleanTestData();
+  });
+
+  test('chat panel is visible when open', async () => {
+    const width = await panelWidth(page, layout.chatPanel);
+    expect(width).toBeGreaterThan(100);
+  });
+
+  test('toggling chat panel collapses it to ~0 width', async () => {
+    await page.click(layout.chatToggle);
+    await waitForPanelWidth(page, layout.chatPanel, (w) => w < 5);
+  });
+
+  test('active app fills freed space when chat collapses', async () => {
+    const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+    const sidebarBox = await page.locator(layout.sidebarPanel).first().boundingBox();
+    const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+    expect(shellBox).toBeTruthy();
+    expect(appBox).toBeTruthy();
+    const usedWidth = (sidebarBox?.width ?? 0) + appBox!.width;
+    expect(usedWidth).toBeGreaterThan(shellBox!.width - 10);
+  });
+
+  test('toggling chat panel back restores it', async () => {
+    await page.click(layout.chatToggle);
+    await waitForPanelWidth(page, layout.chatPanel, (w) => w > 100);
+  });
+
+  test('chat panel open state is persisted to layout.json', async () => {
+    await page.click(layout.chatToggle);
+    await waitForPanelWidth(page, layout.chatPanel, (w) => w < 5);
+    const data = await waitForLayoutFile((d) => d.chatPanelOpen === false);
+    expect(data.chatPanelOpen).toBe(false);
+
+    await page.click(layout.chatToggle);
+    await waitForPanelWidth(page, layout.chatPanel, (w) => w > 100);
+    const data2 = await waitForLayoutFile((d) => d.chatPanelOpen === true);
+    expect(data2.chatPanelOpen).toBe(true);
+  });
+});
+
+test.describe('Layout — both panels collapsed', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    cleanTestData();
+    seedLayout({ mainSidebarOpen: true, chatPanelOpen: true });
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+  });
+
+  test.afterAll(async () => {
+    await app.close();
+    cleanTestData();
+  });
+
+  test('active app fills full width when both panels collapsed', async () => {
+    // Collapse sidebar
+    await page.click(layout.sidebarToggle);
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w < 5);
+    // Collapse chat
+    await page.click(layout.chatToggle);
+    await waitForPanelWidth(page, layout.chatPanel, (w) => w < 5);
+
+    const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+    const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+    expect(shellBox).toBeTruthy();
+    expect(appBox).toBeTruthy();
+    // Active app should be nearly the full shell width
+    expect(appBox!.width).toBeGreaterThan(shellBox!.width - 10);
+  });
+});
+
+test.describe('Layout — size persistence across reload', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.afterAll(async () => {
+    await app?.close();
+    cleanTestData();
+  });
+
+  test('persisted sidebar size is restored on reload', async () => {
+    cleanTestData();
+    // Seed a specific sidebar size
+    seedLayout({
+      mainSidebarOpen: true,
+      chatPanelOpen: true,
+      mainSidebarSizePct: 25,
+      chatPanelSizePct: 35,
+    });
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+
+    const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+    const sidebarWidth = await panelWidth(page, layout.sidebarPanel);
+    expect(shellBox).toBeTruthy();
+    // Sidebar should be ~25% of shell width (±5% tolerance)
+    const actualPct = (sidebarWidth / shellBox!.width) * 100;
+    expect(actualPct).toBeGreaterThan(20);
+    expect(actualPct).toBeLessThan(30);
+
+    const chatWidth = await panelWidth(page, layout.chatPanel);
+    const chatPct = (chatWidth / shellBox!.width) * 100;
+    expect(chatPct).toBeGreaterThan(30);
+    expect(chatPct).toBeLessThan(40);
+  });
+
+  test('sidebar size is written to layout.json on drag', async () => {
+    // The sizes should already be persisted from the seeded launch
+    const data = readLayoutFile();
+    expect(data).toBeTruthy();
+    expect(typeof data!.mainSidebarSizePct).toBe('number');
+    expect(typeof data!.chatPanelSizePct).toBe('number');
+  });
+});
+
+test.describe('Layout — collapse + reopen preserves size', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    cleanTestData();
+    seedLayout({
+      mainSidebarOpen: true,
+      chatPanelOpen: true,
+      mainSidebarSizePct: 22,
+      chatPanelSizePct: 32,
+    });
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+  });
+
+  test.afterAll(async () => {
+    await app.close();
+    cleanTestData();
+  });
+
+  test('sidebar collapse + reopen restores previous size', async () => {
+    const beforeWidth = await panelWidth(page, layout.sidebarPanel);
+    expect(beforeWidth).toBeGreaterThan(100);
+
+    await page.click(layout.sidebarToggle);
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w < 5);
+
+    await page.click(layout.sidebarToggle);
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w > 100);
+    const afterWidth = await panelWidth(page, layout.sidebarPanel);
+
+    expect(Math.abs(afterWidth - beforeWidth)).toBeLessThan(20);
+  });
+
+  test('chat panel collapse + reopen restores previous size', async () => {
+    const beforeWidth = await panelWidth(page, layout.chatPanel);
+    expect(beforeWidth).toBeGreaterThan(100);
+
+    await page.click(layout.chatToggle);
+    await waitForPanelWidth(page, layout.chatPanel, (w) => w < 5);
+
+    await page.click(layout.chatToggle);
+    await waitForPanelWidth(page, layout.chatPanel, (w) => w > 100);
+    const afterWidth = await panelWidth(page, layout.chatPanel);
+
+    expect(Math.abs(afterWidth - beforeWidth)).toBeLessThan(20);
+  });
+});
+
+test.describe('Layout — closed panels restored from disk', () => {
+  test.afterEach(async ({ }, testInfo) => {
+    // Each test in this suite launches its own app
+    cleanTestData();
+  });
+
+  test('sidebar closed + chat open on load', async () => {
+    cleanTestData();
+    seedLayout({
+      mainSidebarOpen: false,
+      chatPanelOpen: true,
+      mainSidebarSizePct: 20,
+      chatPanelSizePct: 30,
+    });
+    const { app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME });
+    try {
+      await waitForShell(page);
+
+      const sidebarWidth = await panelWidth(page, layout.sidebarPanel);
+      expect(sidebarWidth).toBeLessThan(5);
+
+      const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+      const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+      const chatBox = await page.locator(layout.chatPanel).first().boundingBox();
+      expect(shellBox).toBeTruthy();
+      const usedWidth = appBox!.width + chatBox!.width;
+      expect(usedWidth).toBeGreaterThan(shellBox!.width - 10);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('chat closed + sidebar open on load', async () => {
+    cleanTestData();
+    seedLayout({
+      mainSidebarOpen: true,
+      chatPanelOpen: false,
+      mainSidebarSizePct: 20,
+      chatPanelSizePct: 30,
+    });
+    const { app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME });
+    try {
+      await waitForShell(page);
+
+      const chatWidth = await panelWidth(page, layout.chatPanel);
+      expect(chatWidth).toBeLessThan(5);
+
+      const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+      const sidebarBox = await page.locator(layout.sidebarPanel).first().boundingBox();
+      const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+      expect(shellBox).toBeTruthy();
+      const usedWidth = (sidebarBox?.width ?? 0) + appBox!.width;
+      expect(usedWidth).toBeGreaterThan(shellBox!.width - 10);
+    } finally {
+      await app.close();
+    }
+  });
+
+  test('BOTH panels closed on load — no gap, app fills full width', async () => {
+    cleanTestData();
+    seedLayout({
+      mainSidebarOpen: false,
+      chatPanelOpen: false,
+      mainSidebarSizePct: 20,
+      chatPanelSizePct: 30,
+    });
+    const { app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME });
+    try {
+      await waitForShell(page);
+
+      const sidebarWidth = await panelWidth(page, layout.sidebarPanel);
+      const chatWidth = await panelWidth(page, layout.chatPanel);
+      expect(sidebarWidth).toBeLessThan(5);
+      expect(chatWidth).toBeLessThan(5);
+
+      const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+      const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+      expect(shellBox).toBeTruthy();
+      expect(appBox!.width).toBeGreaterThan(shellBox!.width - 10);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+test.describe('Layout — first launch (no layout.json)', () => {
+  test('defaults to both panels open with no saved state', async () => {
+    cleanTestData();
+    // No seedLayout — layout.json does not exist
+    const { app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME });
+    try {
+      await waitForShell(page);
+
+      const sidebarWidth = await panelWidth(page, layout.sidebarPanel);
+      const chatWidth = await panelWidth(page, layout.chatPanel);
+      expect(sidebarWidth).toBeGreaterThan(100);
+      expect(chatWidth).toBeGreaterThan(100);
+
+      // All three panels should sum to shell width
+      const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+      const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+      expect(shellBox).toBeTruthy();
+      const totalUsed = sidebarWidth + appBox!.width + chatWidth;
+      expect(totalUsed).toBeGreaterThan(shellBox!.width - 10);
+    } finally {
+      await app.close();
+      cleanTestData();
+    }
+  });
+});
+
+test.describe('Layout — rapid toggle', () => {
+  let app: ElectronApplication;
+  let page: Page;
+
+  test.beforeAll(async () => {
+    cleanTestData();
+    seedLayout({ mainSidebarOpen: true, chatPanelOpen: true });
+    ({ app, page } = await launchSeroApp({ seroHome: SERO_TEST_HOME }));
+    await waitForShell(page);
+  });
+
+  test.afterAll(async () => {
+    await app.close();
+    cleanTestData();
+  });
+
+  test('rapid sidebar toggle settles to correct state', async () => {
+    // 6 toggles from open → ends at open (even count)
+    for (let i = 0; i < 6; i++) {
+      await page.click(layout.sidebarToggle);
+      await page.waitForTimeout(50);
+    }
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w > 100, 5000);
+
+    // 5 more toggles → ends at closed (odd count)
+    for (let i = 0; i < 5; i++) {
+      await page.click(layout.sidebarToggle);
+      await page.waitForTimeout(50);
+    }
+    await waitForPanelWidth(page, layout.sidebarPanel, (w) => w < 5, 5000);
+
+    // Active app fills freed space (no lingering gap)
+    const shellBox = await page.locator(layout.shellPanelGroup).first().boundingBox();
+    const appBox = await page.locator(layout.activeAppPanel).first().boundingBox();
+    const chatBox = await page.locator(layout.chatPanel).first().boundingBox();
+    const usedWidth = appBox!.width + chatBox!.width;
+    expect(usedWidth).toBeGreaterThan(shellBox!.width - 10);
+  });
+});

--- a/apps/desktop/electron/cli/agent-bridge.ts
+++ b/apps/desktop/electron/cli/agent-bridge.ts
@@ -1,0 +1,94 @@
+import type { AgentSession, DefaultResourceLoader } from '@mariozechner/pi-coding-agent';
+import type { AgentStreamEvent } from '../../src/types/ipc';
+import { installCliSessionBridge } from './session-bridge';
+
+const TURN_LIMIT = 50;
+let turnSeq = 0;
+const activeTurns = new Map<string, string>();
+const turnBudgets = new Map<string, { turnId: string; count: number }>();
+
+interface AgentPoolEntryLike {
+  session: AgentSession;
+  loader: DefaultResourceLoader;
+  workspaceId: string;
+  lastSessionName: string | undefined;
+}
+
+interface InstallCliAgentBridgeOptions {
+  getEntry: (sessionId: string) => AgentPoolEntryLike | undefined;
+  listEntries: () => Array<[string, AgentPoolEntryLike]>;
+  sendEvent: (event: AgentStreamEvent) => void;
+}
+
+function nextTurnId(): string {
+  turnSeq += 1;
+  return `turn-${Date.now()}-${turnSeq}`;
+}
+
+export function noteCliTurnStart(sessionId: string): void {
+  activeTurns.set(sessionId, nextTurnId());
+}
+
+export function noteCliTurnEnd(sessionId: string): void {
+  activeTurns.delete(sessionId);
+}
+
+export function installCliAgentBridge(options: InstallCliAgentBridgeOptions): void {
+  installCliSessionBridge({
+    getSessionEntry(sessionId) {
+      const entry = options.getEntry(sessionId);
+      if (!entry) return undefined;
+      return {
+        sessionId,
+        workspaceId: entry.workspaceId,
+        session: entry.session,
+        lastSessionName: entry.lastSessionName,
+      };
+    },
+
+    getActiveSessionForWorkspace(workspaceId) {
+      for (const [sessionId, entry] of options.listEntries()) {
+        if (entry.workspaceId !== workspaceId) continue;
+        if (!entry.session.agent.state.isStreaming) continue;
+        return { sessionId, workspaceId, session: entry.session, lastSessionName: entry.lastSessionName };
+      }
+      for (const [sessionId, entry] of options.listEntries()) {
+        if (entry.workspaceId === workspaceId) {
+          return { sessionId, workspaceId, session: entry.session, lastSessionName: entry.lastSessionName };
+        }
+      }
+      return undefined;
+    },
+
+    getActiveTurnId(sessionId) {
+      return activeTurns.get(sessionId) ?? null;
+    },
+
+    noteTurnStart: noteCliTurnStart,
+    noteTurnEnd: noteCliTurnEnd,
+
+    consumeTurnBudget(workspaceId, turnId) {
+      const key = workspaceId;
+      const current = turnBudgets.get(key);
+      if (!current || current.turnId !== turnId) {
+        turnBudgets.set(key, { turnId, count: 1 });
+        return { allowed: true, count: 1, limit: TURN_LIMIT };
+      }
+      if (current.count >= TURN_LIMIT) {
+        return { allowed: false, count: current.count, limit: TURN_LIMIT };
+      }
+      current.count += 1;
+      return { allowed: true, count: current.count, limit: TURN_LIMIT };
+    },
+
+    setSessionTitle(sessionId, title) {
+      const entry = options.getEntry(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+      entry.session.setSessionName(title);
+      if (entry.lastSessionName !== title) {
+        entry.lastSessionName = title;
+        options.sendEvent({ type: 'session_name', sessionId, name: title });
+      }
+    },
+  });
+}

--- a/apps/desktop/electron/cli/commands/appstate.ts
+++ b/apps/desktop/electron/cli/commands/appstate.ts
@@ -1,0 +1,50 @@
+import { appStateManager } from '../../app-state';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext } from '../types';
+import { fail, ok, parseFlags, requireFlagString, stringifyJson } from './utils';
+
+async function handleAppState(args: string[], _ctx: CliCommandContext) {
+  const [action, ...rest] = args;
+
+  try {
+    switch (action) {
+      case 'read': {
+        const filePath = rest[0];
+        if (!filePath) return fail('Usage: sero appstate read <path>');
+        return ok(stringifyJson(await appStateManager.read(filePath)));
+      }
+
+      case 'write': {
+        const filePath = rest[0];
+        if (!filePath) return fail('Usage: sero appstate write <path> --json <value>');
+        const { flags } = parseFlags(rest.slice(1));
+        const json = requireFlagString(flags, 'json');
+        if (!json) return fail('Missing --json payload');
+        await appStateManager.write(filePath, JSON.parse(json));
+        return ok(`Wrote app state: ${filePath}`);
+      }
+
+      default:
+        return fail('Usage: sero appstate <read|write> ...');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'App state command failed';
+    return fail(message);
+  }
+}
+
+export function registerAppStateCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'appstate',
+    summary: 'Read or write app state JSON files',
+    help:
+      'appstate — App state JSON helpers\n\n' +
+      'Usage: sero appstate <action> [args]\n\n' +
+      'Actions:\n' +
+      '  read <path>\n' +
+      '  write <path> --json <json>\n',
+    source: 'ipc',
+    group: 'App State',
+    execute: handleAppState,
+  });
+}

--- a/apps/desktop/electron/cli/commands/devserver.ts
+++ b/apps/desktop/electron/cli/commands/devserver.ts
@@ -1,0 +1,77 @@
+import { containerManager } from '../../ipc/shared-infra';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext } from '../types';
+import { fail, ok, parseFlags, requireFlagString } from './utils';
+
+async function handleDevServer(args: string[], ctx: CliCommandContext) {
+  const [action, ...rest] = args;
+  const registry = containerManager.devServers;
+
+  try {
+    switch (action) {
+      case 'list': {
+        const servers = registry.list(ctx.workspaceId);
+        if (servers.length === 0) return ok('No registered dev servers.');
+        return ok(
+          servers
+            .map((s) => `${s.id} [${s.status}] ${s.name} — ${s.url} (port ${s.port})`)
+            .join('\n'),
+        );
+      }
+
+      case 'register': {
+        const { positionals, flags } = parseFlags(rest);
+        const name = requireFlagString(flags, 'name') ?? positionals[0];
+        const portRaw = requireFlagString(flags, 'port') ?? positionals[1];
+        const command = requireFlagString(flags, 'command') ?? positionals.slice(2).join(' ');
+        const framework = requireFlagString(flags, 'framework') ?? undefined;
+
+        if (!name || !portRaw || !command) {
+          return fail('Usage: sero devserver register --name <name> --port <port> --command <cmd> [--framework <name>]');
+        }
+        const port = Number(portRaw);
+        if (!Number.isFinite(port)) return fail(`Invalid port: ${portRaw}`);
+
+        const server = registry.register({
+          workspaceId: ctx.workspaceId,
+          name,
+          port,
+          command,
+          framework,
+        });
+        return ok(`Registered ${server.name} (${server.id})\nURL: ${server.url}`);
+      }
+
+      case 'stop': {
+        const serverId = rest[0];
+        if (!serverId) return fail('Usage: sero devserver stop <id>');
+        const stopped = await registry.stop(serverId);
+        if (!stopped) return fail(`Failed to stop dev server: ${serverId}`);
+        return ok(`Stopped dev server: ${serverId}`);
+      }
+
+      default:
+        return fail('Usage: sero devserver <list|register|stop>');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Dev server command failed';
+    return fail(message);
+  }
+}
+
+export function registerDevServerCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'devserver',
+    summary: 'Manage dev servers (list, register, stop)',
+    help:
+      'devserver — Dev server registry\n\n' +
+      'Usage: sero devserver <action> [args]\n\n' +
+      'Actions:\n' +
+      '  list\n' +
+      '  register --name <name> --port <port> --command <cmd> [--framework <name>]\n' +
+      '  stop <id>\n',
+    source: 'ipc',
+    group: 'Dev Servers',
+    execute: handleDevServer,
+  });
+}

--- a/apps/desktop/electron/cli/commands/editor.ts
+++ b/apps/desktop/electron/cli/commands/editor.ts
@@ -1,0 +1,92 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { containerManager, workspaceManager } from '../../ipc/shared-infra';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext } from '../types';
+import { fail, ok } from './utils';
+
+const WORKSPACE_PREFIX = '/workspace';
+
+function toHostPath(workspacePath: string, filePath: string): string {
+  const raw = filePath.startsWith(WORKSPACE_PREFIX)
+    ? path.join(workspacePath, filePath.slice(WORKSPACE_PREFIX.length))
+    : path.join(workspacePath, filePath);
+
+  const resolved = path.resolve(raw);
+  const root = path.resolve(workspacePath);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+    throw new Error(`Path escapes workspace: ${filePath}`);
+  }
+  return resolved;
+}
+
+async function readFile(workspaceId: string, filePath: string): Promise<string> {
+  const useContainer = (await workspaceManager.isContainerEnabled(workspaceId)) && containerManager.hasContainer(workspaceId);
+  if (useContainer) return containerManager.readFile(workspaceId, filePath);
+
+  const wsPath = workspaceManager.getPath(workspaceId);
+  if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
+  return fs.readFile(toHostPath(wsPath, filePath), 'utf8');
+}
+
+async function listFiles(workspaceId: string, dirPath: string): Promise<string> {
+  const useContainer = (await workspaceManager.isContainerEnabled(workspaceId)) && containerManager.hasContainer(workspaceId);
+  if (useContainer) {
+    const entries = await containerManager.listFiles(workspaceId, dirPath);
+    return entries
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((e) => (e.type === 'directory' ? `${e.name}/` : e.name))
+      .join('\n') || '(empty directory)';
+  }
+
+  const wsPath = workspaceManager.getPath(workspaceId);
+  if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
+  const absDir = toHostPath(wsPath, dirPath);
+  const entries = await fs.readdir(absDir, { withFileTypes: true });
+  return entries
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((e) => (e.isDirectory() ? `${e.name}/` : e.name))
+    .join('\n') || '(empty directory)';
+}
+
+async function handleEditor(args: string[], _ctx: CliCommandContext) {
+  const [action, ...rest] = args;
+  const ctx = _ctx;
+
+  try {
+    switch (action) {
+      case 'read': {
+        const filePath = rest[0];
+        if (!filePath) return fail('Usage: sero editor read <path>');
+        return ok(await readFile(ctx.workspaceId, filePath));
+      }
+
+      case 'list': {
+        const dirPath = rest[0] ?? '/workspace';
+        return ok(await listFiles(ctx.workspaceId, dirPath));
+      }
+
+      default:
+        return fail('Usage: sero editor <read|list> ...');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Editor command failed';
+    return fail(message);
+  }
+}
+
+export function registerEditorCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'editor',
+    summary: 'Editor filesystem helpers (read, list)',
+    help:
+      'editor — File operations\n\n' +
+      'Usage: sero editor <action> [args]\n\n' +
+      'Actions:\n' +
+      '  read <path>            Read a file\n' +
+      '  list [dir]             List directory entries\n',
+    source: 'ipc',
+    group: 'Editor',
+    execute: handleEditor,
+  });
+}

--- a/apps/desktop/electron/cli/commands/session.ts
+++ b/apps/desktop/electron/cli/commands/session.ts
@@ -1,0 +1,74 @@
+import { buildModelState } from '../../ipc/agent-helpers';
+import { getCliSessionBridge } from '../session-bridge';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext } from '../types';
+import { fail, ok } from './utils';
+
+async function handleSession(args: string[], ctx: CliCommandContext) {
+  const [action = 'info'] = args;
+  if (action !== 'info') return fail('Usage: sero session info');
+
+  const bridge = getCliSessionBridge();
+  const sessionId = ctx.invocation.sessionId;
+  const entry = sessionId
+    ? bridge.getSessionEntry(sessionId)
+    : bridge.getActiveSessionForWorkspace(ctx.workspaceId);
+
+  if (!entry) {
+    return ok(`Workspace: ${ctx.workspaceId}\nNo active agent session.`);
+  }
+
+  const stats = entry.session.getSessionStats();
+  const modelState = buildModelState({ session: entry.session });
+  const activeTurnId = bridge.getActiveTurnId(entry.sessionId);
+
+  const lines = [
+    `Workspace: ${entry.workspaceId}`,
+    `Session ID: ${entry.sessionId}`,
+    `Session name: ${entry.session.sessionName || '(untitled)'}`,
+    `Model: ${modelState.model.provider}/${modelState.model.modelId}`,
+    `Thinking: ${modelState.thinkingLevel}`,
+    `Tokens: ${stats.tokens}`,
+    `Cost: ${stats.cost}`,
+    `Requests: ${stats.userMessages}`,
+    `Streaming: ${entry.session.agent.state.isStreaming ? 'yes' : 'no'}`,
+    `Active turn: ${activeTurnId ?? '(none)'}`,
+  ];
+
+  return ok(lines.join('\n'));
+}
+
+async function handleSetTitle(args: string[], ctx: CliCommandContext) {
+  const title = args.join(' ').trim();
+  if (!title) return fail('Usage: sero set-title <text>');
+  const sessionId = ctx.invocation.sessionId;
+  if (!sessionId) return fail('set-title requires an active agent session');
+
+  try {
+    getCliSessionBridge().setSessionTitle(sessionId, title);
+    return ok(`Session titled: ${title}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to set title';
+    return fail(message);
+  }
+}
+
+export function registerSessionCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'session',
+    summary: 'Session commands (info)',
+    help: 'session — Agent session info\n\nUsage: sero session info\n',
+    source: 'builtin',
+    group: 'Builtin',
+    execute: handleSession,
+  });
+
+  registry.register({
+    name: 'set-title',
+    summary: 'Set the current session title',
+    help: 'set-title — Set session title\n\nUsage: sero set-title <text>\n',
+    source: 'builtin',
+    group: 'Builtin',
+    execute: handleSetTitle,
+  });
+}

--- a/apps/desktop/electron/cli/commands/terminal.ts
+++ b/apps/desktop/electron/cli/commands/terminal.ts
@@ -1,0 +1,38 @@
+import { containerManager } from '../../ipc/shared-infra';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext } from '../types';
+import { fail, ok } from './utils';
+
+async function handleTerminal(args: string[], ctx: CliCommandContext) {
+  const [action = 'read', ...rest] = args;
+
+  try {
+    switch (action) {
+      case 'read': {
+        const linesRaw = rest[0];
+        const lines = linesRaw ? Number(linesRaw) : 80;
+        if (!Number.isFinite(lines) || lines <= 0) return fail(`Invalid line count: ${linesRaw}`);
+        const output = containerManager.terminals.readWorkspaceTerminalOutput(ctx.workspaceId, Math.floor(lines));
+        return ok(output);
+      }
+      default:
+        return fail('Usage: sero terminal read [lines]');
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Terminal command failed';
+    return fail(message);
+  }
+}
+
+export function registerTerminalCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'terminal',
+    summary: 'Read terminal output (read)',
+    help:
+      'terminal — Terminal helpers\n\n' +
+      'Usage: sero terminal read [lines]\n',
+    source: 'ipc',
+    group: 'Terminal',
+    execute: handleTerminal,
+  });
+}

--- a/apps/desktop/electron/cli/commands/utils.ts
+++ b/apps/desktop/electron/cli/commands/utils.ts
@@ -1,0 +1,56 @@
+import type { CliResult } from '../types';
+
+export function ok(output: string): CliResult {
+  return { output, exitCode: 0 };
+}
+
+export function fail(message: string, exitCode = 1): CliResult {
+  return { output: `ERROR: ${message}`, exitCode };
+}
+
+export function stringifyJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+export function parseFlags(args: string[]): {
+  positionals: string[];
+  flags: Map<string, string | true>;
+} {
+  const positionals: string[] = [];
+  const flags = new Map<string, string | true>();
+
+  for (let i = 0; i < args.length; i++) {
+    const token = args[i]!;
+    if (!token.startsWith('--')) {
+      positionals.push(token);
+      continue;
+    }
+
+    const keyValue = token.slice(2);
+    if (!keyValue) continue;
+
+    const eqIdx = keyValue.indexOf('=');
+    if (eqIdx !== -1) {
+      flags.set(keyValue.slice(0, eqIdx), keyValue.slice(eqIdx + 1));
+      continue;
+    }
+
+    const next = args[i + 1];
+    if (next && !next.startsWith('--')) {
+      flags.set(keyValue, next);
+      i++;
+    } else {
+      flags.set(keyValue, true);
+    }
+  }
+
+  return { positionals, flags };
+}
+
+export function requireFlagString(
+  flags: Map<string, string | true>,
+  key: string,
+): string | null {
+  const value = flags.get(key);
+  return typeof value === 'string' ? value : null;
+}

--- a/apps/desktop/electron/cli/commands/vcs.ts
+++ b/apps/desktop/electron/cli/commands/vcs.ts
@@ -1,0 +1,93 @@
+import { vcsManager, vcsOps } from '../../ipc/shared-infra';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext } from '../types';
+import { fail, ok, parseFlags } from './utils';
+
+async function handleVcs(args: string[], ctx: CliCommandContext) {
+  const [action, ...rest] = args;
+  if (!action) return fail('Usage: sero vcs <status|log|diff|checkpoint|bookmarks>');
+
+  try {
+    switch (action) {
+      case 'status': {
+        const status = await vcsOps.getStatus(ctx.workspaceId);
+        if (status.files.length === 0) {
+          return ok('Working copy clean.');
+        }
+        const lines = status.files.map((f) => `${f.status.padEnd(8)} ${f.path}`);
+        if (status.conflictCount > 0) lines.unshift(`Conflicts: ${status.conflictCount}`);
+        return ok(lines.join('\n'));
+      }
+
+      case 'log': {
+        const { flags } = parseFlags(rest);
+        const limitRaw = flags.get('limit');
+        const limit = typeof limitRaw === 'string' ? Number(limitRaw) : 10;
+        const entries = await vcsOps.getLogEntries(ctx.workspaceId, Number.isFinite(limit) ? limit : 10);
+        if (entries.length === 0) return ok('No changes yet.');
+        return ok(
+          entries
+            .map((e) => {
+              const head = e.isWorkingCopy ? '*' : '-';
+              const bookmarks = e.bookmarks.length ? ` [${e.bookmarks.join(', ')}]` : '';
+              return `${head} ${e.changeId} ${e.description || '(no description)'}${bookmarks}`;
+            })
+            .join('\n'),
+        );
+      }
+
+      case 'diff': {
+        const from = rest[0];
+        const to = rest[1];
+        if (!from) return fail('Usage: sero vcs diff <from> [to]');
+        const diff = await vcsManager.diff(ctx.workspaceId, from, to);
+        return ok(diff.trim() || '(empty diff)');
+      }
+
+      case 'checkpoint': {
+        const message = rest.join(' ').trim() || undefined;
+        const cp = await vcsManager.createCheckpoint(ctx.workspaceId, {
+          source: 'manual',
+          description: message,
+        });
+        if (!cp) return fail('No file changes to checkpoint.');
+        return ok(`Created checkpoint ${cp.changeId}${cp.description ? ` — ${cp.description}` : ''}`);
+      }
+
+      case 'bookmarks': {
+        const bookmarks = await vcsOps.listBookmarks(ctx.workspaceId);
+        if (bookmarks.length === 0) return ok('No bookmarks.');
+        return ok(
+          bookmarks
+            .map((b) => `${b.name} -> ${b.changeId}${b.isLocal ? ' (local)' : ''}`)
+            .join('\n'),
+        );
+      }
+
+      default:
+        return fail(`Unknown vcs action: ${action}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'VCS command failed';
+    return fail(message);
+  }
+}
+
+export function registerVcsCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'vcs',
+    summary: 'Version control commands (status, log, diff, checkpoint, bookmarks)',
+    help:
+      'vcs — Version control\n\n' +
+      'Usage: sero vcs <action> [args]\n\n' +
+      'Actions:\n' +
+      '  status                  Show working copy status\n' +
+      '  log [--limit N]         Show recent changes\n' +
+      '  diff <from> [to]        Show diff between revisions\n' +
+      '  checkpoint [message]    Create checkpoint\n' +
+      '  bookmarks               List bookmarks\n',
+    source: 'ipc',
+    group: 'Version Control',
+    execute: handleVcs,
+  });
+}

--- a/apps/desktop/electron/cli/commands/workspace.ts
+++ b/apps/desktop/electron/cli/commands/workspace.ts
@@ -1,0 +1,86 @@
+import { workspaceManager } from '../../ipc/shared-infra';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext } from '../types';
+import { fail, ok } from './utils';
+
+function formatWorkspaceList(currentWorkspaceId: string, openIds: Set<string>) {
+  return async () => {
+    const list = await workspaceManager.list();
+    if (list.length === 0) return 'No workspaces registered.';
+    return list
+      .map((ws) => {
+        const open = openIds.has(ws.id) ? '●' : '○';
+        const current = ws.id === currentWorkspaceId ? ' (current)' : '';
+        const container = ws.container ? 'container' : 'host';
+        return `${open} ${ws.name} (${ws.id}) [${container}]${current}\n  ${ws.path}`;
+      })
+      .join('\n');
+  };
+}
+
+async function handleWorkspaceCommand(args: string[], ctx: CliCommandContext) {
+  const [action = 'info', ...rest] = args;
+  const targetId = rest[0] || ctx.workspaceId;
+
+  try {
+    switch (action) {
+      case 'list': {
+        const openIds = new Set(workspaceManager.getOpenIds());
+        const output = await formatWorkspaceList(ctx.workspaceId, openIds)();
+        return ok(output);
+      }
+
+      case 'info': {
+        const config = await workspaceManager.getConfig(targetId);
+        const path = workspaceManager.getPath(targetId);
+        if (!config || !path) return fail(`Workspace not found: ${targetId}`);
+        const enabled = await workspaceManager.isContainerEnabled(targetId);
+        const lines = [
+          `Workspace: ${config.name} (${targetId})`,
+          `Path: ${path}`,
+          `Runtime: ${enabled ? 'container' : 'host filesystem'}`,
+        ];
+        if (config.description) lines.push(`Description: ${config.description}`);
+        if (config.contextHints?.length) lines.push(`Context hints: ${config.contextHints.join(', ')}`);
+        if (config.tags?.length) lines.push(`Tags: ${config.tags.join(', ')}`);
+        return ok(lines.join('\n'));
+      }
+
+      case 'open': {
+        if (!rest[0]) return fail('Usage: sero workspace open <id>');
+        await workspaceManager.open(rest[0]);
+        return ok(`Opened workspace: ${rest[0]}`);
+      }
+
+      case 'close': {
+        if (!rest[0]) return fail('Usage: sero workspace close <id>');
+        await workspaceManager.close(rest[0]);
+        return ok(`Closed workspace: ${rest[0]}`);
+      }
+
+      default:
+        return fail(`Unknown workspace action: ${action}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Workspace command failed';
+    return fail(message);
+  }
+}
+
+export function registerWorkspaceCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'workspace',
+    summary: 'Manage workspaces (list, info, open, close)',
+    help:
+      'workspace — Manage workspaces\n\n' +
+      'Usage: sero workspace <action> [args]\n\n' +
+      'Actions:\n' +
+      '  list                 List workspaces\n' +
+      '  info [id]            Show workspace details (default: current)\n' +
+      '  open <id>            Open a workspace\n' +
+      '  close <id>           Close a workspace\n',
+    source: 'ipc',
+    group: 'Builtin',
+    execute: handleWorkspaceCommand,
+  });
+}

--- a/apps/desktop/electron/cli/help.ts
+++ b/apps/desktop/electron/cli/help.ts
@@ -1,0 +1,65 @@
+import type { CliRegistry } from './registry';
+import type { CliCommandContext } from './types';
+import { fail, ok } from './commands/utils';
+
+function groupLabel(group?: string): string {
+  return (group ?? 'Other').toUpperCase();
+}
+
+export function renderCliHelpList(registry: CliRegistry): string {
+  const commands = registry.list().filter((c) => !c.hidden);
+  const grouped = new Map<string, typeof commands>();
+
+  for (const cmd of commands) {
+    const key = groupLabel(cmd.group);
+    const list = grouped.get(key) ?? [];
+    list.push(cmd);
+    grouped.set(key, list);
+  }
+
+  const sections: string[] = ['Sero CLI — Platform commands for the Sero agent'];
+  for (const [group, list] of [...grouped.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    sections.push('', group);
+    for (const cmd of list.sort((a, b) => a.name.localeCompare(b.name))) {
+      sections.push(`  ${cmd.name.padEnd(18)} ${cmd.summary}`);
+    }
+  }
+
+  sections.push('', 'Run `sero help <command>` for detailed usage.');
+  return sections.join('\n');
+}
+
+export function renderCliCommandHelp(registry: CliRegistry, query: string): string | null {
+  const cmd = registry.findHelpTarget(query);
+  if (!cmd) return null;
+  if (cmd.help?.trim()) return cmd.help.trim();
+
+  const lines = [`${cmd.name} — ${cmd.summary}`];
+  if (cmd.params?.length) {
+    lines.push('', 'Parameters:');
+    for (const p of cmd.params) {
+      lines.push(`  ${p.name}${p.required ? ' (required)' : ''} — ${p.description}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function registerHelpCliCommand(registry: CliRegistry): void {
+  registry.register({
+    name: 'help',
+    summary: 'Show available commands and usage',
+    help:
+      'help — Show CLI help\n\n' +
+      'Usage:\n' +
+      '  sero help\n' +
+      '  sero help <command>\n',
+    source: 'builtin',
+    group: 'Builtin',
+    execute: async (args: string[], _ctx: CliCommandContext) => {
+      if (!args.length) return ok(renderCliHelpList(registry));
+      const output = renderCliCommandHelp(registry, args.join(' '));
+      if (!output) return fail(`Unknown command: ${args.join(' ')}`);
+      return ok(output);
+    },
+  });
+}

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -1,0 +1,103 @@
+import type { LoadExtensionsResult } from '@mariozechner/pi-coding-agent';
+import { registerAppStateCliCommands } from './commands/appstate';
+import { registerDevServerCliCommands } from './commands/devserver';
+import { registerEditorCliCommands } from './commands/editor';
+import { registerSessionCliCommands } from './commands/session';
+import { registerTerminalCliCommands } from './commands/terminal';
+import { registerVcsCliCommands } from './commands/vcs';
+import { registerWorkspaceCliCommands } from './commands/workspace';
+import { registerHelpCliCommand } from './help';
+import { CliRegistry } from './registry';
+import { bridgeTool } from './schema-bridge';
+import { createSeroCliTool } from './tool';
+
+let registry: CliRegistry | null = null;
+
+function registerCoreCommands(target: CliRegistry): void {
+  registerWorkspaceCliCommands(target);
+  registerSessionCliCommands(target);
+  registerVcsCliCommands(target);
+  registerDevServerCliCommands(target);
+  registerEditorCliCommands(target);
+  registerAppStateCliCommands(target);
+  registerTerminalCliCommands(target);
+  registerHelpCliCommand(target);
+}
+
+export function getCliRegistry(): CliRegistry {
+  if (!registry) {
+    registry = new CliRegistry();
+    registerCoreCommands(registry);
+  }
+  return registry;
+}
+
+export function createWorkspaceCliTool(workspaceId: string, sessionId: string) {
+  return createSeroCliTool(getCliRegistry(), workspaceId, sessionId);
+}
+
+// ── Extension tool → CLI bridge ─────────────────────────────
+
+/**
+ * Tools to migrate from agent context into CLI commands.
+ * Add a tool name here to move it from the agent's tool list into
+ * the `sero-cli` help — zero per-tool code needed.
+ */
+const TOOLS_TO_BRIDGE = new Set([
+  'todo',
+  'notes',
+  'calc',
+  'daily_quote',
+  'weight',
+]);
+
+/**
+ * `extensionsOverride` callback for DefaultResourceLoader.
+ *
+ * After all extensions load, finds tools listed in TOOLS_TO_BRIDGE,
+ * wraps each into a CLI command (generic schema-driven parsing), and
+ * removes it from the extension so it no longer appears in the agent's
+ * tool context.
+ */
+export function bridgeExtensionTools(base: LoadExtensionsResult): LoadExtensionsResult {
+  const reg = getCliRegistry();
+
+  for (const ext of base.extensions) {
+    for (const [name, registered] of [...ext.tools]) {
+      if (!TOOLS_TO_BRIDGE.has(name)) continue;
+      // Skip if already registered (e.g. from a previous reload)
+      if (reg.get(name)) {
+        ext.tools.delete(name);
+        continue;
+      }
+      const command = bridgeTool(name, registered.definition);
+      reg.register(command);
+      ext.tools.delete(name);
+    }
+  }
+
+  return base;
+}
+
+// ── System prompt block ─────────────────────────────────────
+
+export function buildCliPromptBlock(): string {
+  return `
+
+## Sero CLI
+
+You have access to the \`sero-cli\` tool for Sero platform operations.
+Use it instead of asking the user to do platform actions manually.
+
+Quick reference (run \`sero help\` for full list):
+  sero todo list
+  sero notes list
+  sero workspace info
+  sero vcs status
+  sero devserver list
+
+Chain commands (one per line):
+  sero todo list
+  sero notes add "Summary" --body "..."
+`;
+}

--- a/apps/desktop/electron/cli/parser.ts
+++ b/apps/desktop/electron/cli/parser.ts
@@ -1,0 +1,80 @@
+export function splitCommandLines(input: string): string[] {
+  return input
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function tokenizeCliInput(input: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: 'single' | 'double' | null = null;
+  let escaping = false;
+
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = '';
+    }
+  };
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i]!;
+
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+
+    if (ch === '\\') {
+      escaping = true;
+      continue;
+    }
+
+    if (quote === 'single') {
+      if (ch === "'") {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (quote === 'double') {
+      if (ch === '"') {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      continue;
+    }
+
+    if (ch === "'") {
+      quote = 'single';
+      continue;
+    }
+
+    if (ch === '"') {
+      quote = 'double';
+      continue;
+    }
+
+    if (/\s/.test(ch)) {
+      pushCurrent();
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (escaping) {
+    current += '\\';
+  }
+  if (quote) {
+    throw new Error('Unterminated quoted string');
+  }
+
+  pushCurrent();
+  return tokens;
+}

--- a/apps/desktop/electron/cli/registry.ts
+++ b/apps/desktop/electron/cli/registry.ts
@@ -1,0 +1,84 @@
+import type { CliCommand, CliCommandContext, CliResolvedCommand } from './types';
+
+const BLACKLISTED_ROOTS = new Set([
+  'auth',
+  'safeStorage',
+  'net',
+  'layout',
+  'agent',
+  'github',
+]);
+
+function normalizeName(name: string): string {
+  return name.trim().replace(/\s+/g, ' ');
+}
+
+export class CliRegistry {
+  private commands = new Map<string, CliCommand>();
+
+  register(command: CliCommand): void {
+    const name = normalizeName(command.name);
+    if (!name) throw new Error('CLI command name is required');
+
+    const root = name.split(' ')[0];
+    if (root && BLACKLISTED_ROOTS.has(root)) {
+      throw new Error(`CLI command root is blacklisted: ${root}`);
+    }
+
+    this.commands.set(name, { ...command, name });
+  }
+
+  get(name: string): CliCommand | undefined {
+    return this.commands.get(normalizeName(name));
+  }
+
+  list(): CliCommand[] {
+    return [...this.commands.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  findHelpTarget(query: string): CliCommand | undefined {
+    const normalized = normalizeName(query);
+    if (!normalized) return undefined;
+    const exact = this.get(normalized);
+    if (exact) return exact;
+
+    const tokens = normalized.split(' ');
+    for (let len = tokens.length - 1; len >= 1; len--) {
+      const candidate = tokens.slice(0, len).join(' ');
+      const hit = this.get(candidate);
+      if (hit) return hit;
+    }
+
+    return undefined;
+  }
+
+  resolveTokens(tokens: string[]): CliResolvedCommand {
+    const normalizedTokens = [...tokens];
+    if (normalizedTokens[0] === 'sero') normalizedTokens.shift();
+    if (normalizedTokens.length === 0) {
+      throw new Error('No command provided');
+    }
+
+    for (let len = normalizedTokens.length; len >= 1; len--) {
+      const name = normalizedTokens.slice(0, len).join(' ');
+      const command = this.commands.get(name);
+      if (command) {
+        return {
+          command,
+          args: normalizedTokens.slice(len),
+          tokens: normalizedTokens,
+        };
+      }
+    }
+
+    throw new Error(`Unknown command: ${normalizedTokens.join(' ')}`);
+  }
+
+  executeResolved(
+    resolved: CliResolvedCommand,
+    args: string[],
+    context: CliCommandContext,
+  ) {
+    return resolved.command.execute(args, context);
+  }
+}

--- a/apps/desktop/electron/cli/schema-bridge.ts
+++ b/apps/desktop/electron/cli/schema-bridge.ts
@@ -1,0 +1,191 @@
+/**
+ * Schema Bridge — generic tool-to-CLI adapter.
+ *
+ * Converts Pi SDK ToolDefinitions into CLI commands automatically using
+ * the tool's TypeBox parameter schema for arg parsing, type coercion,
+ * and help generation. No per-tool custom parsing needed.
+ *
+ * Used by `extensionsOverride` in agent.ts to intercept extension tools
+ * and re-register them as CLI commands (removing them from agent context).
+ */
+
+import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { CliCommand, CliCommandContext, CliResult } from './types';
+import { parseFlags } from './commands/utils';
+
+// ── Schema introspection ────────────────────────────────────
+
+interface SchemaProp {
+  name: string;
+  type: string; // 'string' | 'number' | 'integer' | 'boolean'
+  description: string;
+  required: boolean;
+  enumValues?: string[];
+}
+
+function extractSchemaProps(schema: Record<string, unknown>): SchemaProp[] {
+  const properties = (schema as any)?.properties ?? {};
+  const required = new Set<string>((schema as any)?.required ?? []);
+  const props: SchemaProp[] = [];
+
+  for (const [name, prop] of Object.entries(properties)) {
+    const p = prop as Record<string, unknown>;
+
+    // Handle anyOf (TypeBox Optional wraps in { anyOf: [type, ...] })
+    let resolved = p;
+    if (Array.isArray(p.anyOf)) {
+      resolved = (p.anyOf as Record<string, unknown>[]).find(
+        (v) => typeof v === 'object' && v !== null && v.type !== undefined,
+      ) ?? p;
+    }
+
+    const enumValues = Array.isArray(resolved.enum)
+      ? (resolved.enum as string[])
+      : Array.isArray((resolved as any).anyOf)
+        ? (resolved as any).anyOf
+            .filter((v: any) => v?.const !== undefined)
+            .map((v: any) => String(v.const))
+        : undefined;
+
+    props.push({
+      name,
+      type: (resolved.type as string) ?? 'string',
+      description: (p.description as string) ?? (resolved.description as string) ?? '',
+      required: required.has(name),
+      enumValues: enumValues?.length ? enumValues : undefined,
+    });
+  }
+
+  return props;
+}
+
+// ── Arg parsing (schema-driven) ─────────────────────────────
+
+function coerceValue(value: string | true, prop: SchemaProp): unknown {
+  if (value === true) return true;
+  if (prop.type === 'number' || prop.type === 'integer') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : value;
+  }
+  if (prop.type === 'boolean') {
+    return value === 'true' || value === '1';
+  }
+  return value;
+}
+
+function schemaToParams(
+  props: SchemaProp[],
+  args: string[],
+): Record<string, unknown> {
+  const { positionals, flags } = parseFlags(args);
+  const result: Record<string, unknown> = {};
+
+  // 1. Map --flags to properties by name
+  for (const [key, val] of flags) {
+    const prop = props.find((p) => p.name === key);
+    if (prop) {
+      result[prop.name] = coerceValue(val, prop);
+    }
+  }
+
+  // 2. Map positionals to unmapped properties (required first, then optional)
+  const unmapped = props.filter((p) => !(p.name in result));
+  const ordered = [
+    ...unmapped.filter((p) => p.required),
+    ...unmapped.filter((p) => !p.required),
+  ];
+
+  for (let i = 0; i < positionals.length && i < ordered.length; i++) {
+    result[ordered[i]!.name] = coerceValue(positionals[i]!, ordered[i]!);
+  }
+
+  return result;
+}
+
+// ── Help generation ─────────────────────────────────────────
+
+function generateHelp(
+  name: string,
+  description: string,
+  props: SchemaProp[],
+): string {
+  const required = props.filter((p) => p.required);
+  const optional = props.filter((p) => !p.required);
+
+  // Usage line
+  const usageParts = required
+    .map((p) => `<${p.name}>`)
+    .concat(optional.map((p) => `[--${p.name} <value>]`));
+  const usageLine = `sero ${name} ${usageParts.join(' ')}`.trimEnd();
+
+  const lines = [`${name} — ${description}`, '', 'Usage:', `  ${usageLine}`];
+
+  if (required.length) {
+    lines.push('', 'Required:');
+    for (const p of required) {
+      const enumHint = p.enumValues ? ` {${p.enumValues.join(', ')}}` : '';
+      lines.push(`  ${p.name}${enumHint} — ${p.description || p.name}`);
+    }
+  }
+
+  if (optional.length) {
+    lines.push('', 'Options:');
+    for (const p of optional) {
+      const typeHint = p.type !== 'string' ? ` (${p.type})` : '';
+      lines.push(`  --${p.name}${typeHint} — ${p.description || p.name}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Tool result extraction ──────────────────────────────────
+
+function extractText(result: unknown): string {
+  const content = (result as any)?.content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter((c: any) => c?.type === 'text')
+    .map((c: any) => c.text)
+    .join('\n');
+}
+
+// ── Bridge a ToolDefinition into a CliCommand ───────────────
+
+export function bridgeTool(toolName: string, toolDef: ToolDefinition): CliCommand {
+  const props = extractSchemaProps(toolDef.parameters as Record<string, unknown>);
+  const summary = (toolDef.description ?? '').split(/\.\s/)[0]?.slice(0, 80) ?? toolName;
+  const help = generateHelp(toolName, toolDef.description ?? toolName, props);
+
+  return {
+    name: toolName,
+    summary,
+    help,
+    source: 'app',
+    group: 'Apps',
+    params: props.map((p) => ({
+      name: p.name,
+      description: p.description,
+      required: p.required,
+      type: p.type as 'string' | 'number' | 'boolean',
+    })),
+    execute: async (args: string[], ctx: CliCommandContext): Promise<CliResult> => {
+      try {
+        const params = schemaToParams(props, args);
+        const result = await toolDef.execute(
+          'cli-bridge',
+          params,
+          ctx.invocation.signal,
+          undefined,
+          { cwd: ctx.cwd } as any,
+        );
+        const text = extractText(result);
+        const isError = text.startsWith('Error:') || text.startsWith('ERROR:');
+        return { output: text, exitCode: isError ? 1 : 0 };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Command failed';
+        return { output: `ERROR: ${msg}`, exitCode: 1 };
+      }
+    },
+  };
+}

--- a/apps/desktop/electron/cli/session-bridge.ts
+++ b/apps/desktop/electron/cli/session-bridge.ts
@@ -1,0 +1,31 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+
+export interface CliSessionEntry {
+  sessionId: string;
+  workspaceId: string;
+  session: AgentSession;
+  lastSessionName?: string;
+}
+
+export interface CliSessionBridge {
+  getSessionEntry(sessionId: string): CliSessionEntry | undefined;
+  getActiveSessionForWorkspace(workspaceId: string): CliSessionEntry | undefined;
+  getActiveTurnId(sessionId: string): string | null;
+  noteTurnStart(sessionId: string): void;
+  noteTurnEnd(sessionId: string): void;
+  consumeTurnBudget(workspaceId: string, turnId: string): { allowed: boolean; count: number; limit: number };
+  setSessionTitle(sessionId: string, title: string): void;
+}
+
+let bridge: CliSessionBridge | null = null;
+
+export function installCliSessionBridge(next: CliSessionBridge): void {
+  bridge = next;
+}
+
+export function getCliSessionBridge(): CliSessionBridge {
+  if (!bridge) {
+    throw new Error('CLI session bridge is not installed');
+  }
+  return bridge;
+}

--- a/apps/desktop/electron/cli/tool.ts
+++ b/apps/desktop/electron/cli/tool.ts
@@ -1,0 +1,265 @@
+import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import { Type } from '@sinclair/typebox';
+import { containerManager, workspaceManager } from '../ipc/shared-infra';
+import { tokenizeCliInput, splitCommandLines } from './parser';
+import type { CliCommandContext, CliInvocation, CliResult } from './types';
+import type { CliRegistry } from './registry';
+import { getCliSessionBridge } from './session-bridge';
+
+const MAX_OUTPUT_BYTES = 50 * 1024;
+const MAX_OUTPUT_LINES = 2000;
+const DEFAULT_BATCH_TIMEOUT_SEC = 120;
+const MAX_PER_COMMAND_TIMEOUT_MS = 30_000;
+const TURN_COMMAND_LIMIT = 50;
+
+const SeroCliToolParams = Type.Object({
+  command: Type.String({
+    description:
+      'Sero CLI command string (e.g. "todo list"). Supports multi-line input for chaining (one command per line).',
+  }),
+  timeout: Type.Optional(
+    Type.Number({ description: 'Batch timeout in seconds (default: 120)' }),
+  ),
+});
+
+class CommandTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CommandTimeoutError';
+  }
+}
+
+interface CliBatchResult {
+  output: string;
+  exitCode: number;
+}
+
+function truncateOutput(text: string): string {
+  const lines = text.split('\n');
+  let outLines = lines;
+  let truncated = false;
+
+  if (lines.length > MAX_OUTPUT_LINES) {
+    outLines = lines.slice(0, MAX_OUTPUT_LINES);
+    truncated = true;
+  }
+
+  let out = outLines.join('\n');
+  while (Buffer.byteLength(out, 'utf8') > MAX_OUTPUT_BYTES && outLines.length > 1) {
+    outLines = outLines.slice(0, -1);
+    out = outLines.join('\n');
+    truncated = true;
+  }
+
+  if (!truncated) return out;
+  return `${out}\n\n[output truncated to 50KB / 2000 lines]`;
+}
+
+function timeoutForCommand(batchDeadline: number | null): number | null {
+  if (batchDeadline === null) return null;
+  const remaining = batchDeadline - Date.now();
+  if (remaining <= 0) throw new CommandTimeoutError('Batch timeout exceeded');
+  return Math.min(MAX_PER_COMMAND_TIMEOUT_MS, remaining);
+}
+
+async function runWithTimeout<T>(
+  fn: () => Promise<T>,
+  timeoutMs: number | null,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal?.aborted) throw new Error('Operation aborted');
+  if (!timeoutMs && !signal) return fn();
+
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let abortListener: (() => void) | null = null;
+
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      let settled = false;
+      const finish = (cb: () => void) => {
+        if (settled) return;
+        settled = true;
+        cb();
+      };
+
+      if (timeoutMs) {
+        timeout = setTimeout(() => {
+          finish(() => reject(new CommandTimeoutError(`Command timed out after ${Math.ceil(timeoutMs / 1000)}s`)));
+        }, timeoutMs);
+      }
+
+      if (signal) {
+        abortListener = () => finish(() => reject(new Error('Operation aborted')));
+        signal.addEventListener('abort', abortListener, { once: true });
+      }
+
+      fn().then(
+        (value) => finish(() => resolve(value)),
+        (error) => finish(() => reject(error)),
+      );
+    });
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    if (signal && abortListener) signal.removeEventListener('abort', abortListener);
+  }
+}
+
+function normalizeCliResult(result: CliResult): CliResult {
+  return {
+    output: typeof result.output === 'string' ? result.output : String(result.output ?? ''),
+    exitCode: result.exitCode ?? 0,
+  };
+}
+
+function isHelpCommand(name: string): boolean {
+  return name === 'help';
+}
+
+function formatBatchEntry(line: string, output: string): string {
+  if (!output.trim()) return `$ sero ${line}`;
+  return `$ sero ${line}\n${output}`;
+}
+
+export async function executeCliBatch(
+  registry: CliRegistry,
+  commandText: string,
+  context: CliCommandContext,
+  batchTimeoutSec?: number,
+): Promise<CliBatchResult> {
+  const lines = splitCommandLines(commandText);
+  if (lines.length === 0) {
+    return { output: 'ERROR: No command provided', exitCode: 1 };
+  }
+
+  const single = lines.length === 1;
+  const batchDeadline = context.invocation.source === 'terminal'
+    ? null
+    : Date.now() + Math.max(1, Math.floor(batchTimeoutSec ?? DEFAULT_BATCH_TIMEOUT_SEC)) * 1000;
+
+  const sections: string[] = [];
+  let finalExitCode = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    let result: CliResult;
+    let timedOut = false;
+
+    try {
+      const tokens = tokenizeCliInput(line);
+      const resolved = registry.resolveTokens(tokens);
+
+      const turnId = context.invocation.turnId;
+      if (
+        context.invocation.source !== 'terminal' &&
+        turnId &&
+        !isHelpCommand(resolved.command.name)
+      ) {
+        const budget = getCliSessionBridge().consumeTurnBudget(context.workspaceId, turnId);
+        if (!budget.allowed) {
+          result = {
+            output: `ERROR: Rate limit: ${TURN_COMMAND_LIMIT} CLI commands per turn exceeded. Wait for the next turn.`,
+            exitCode: 1,
+          };
+          finalExitCode = 1;
+          if (single) {
+            return { output: truncateOutput(result.output), exitCode: 1 };
+          }
+          sections.push(formatBatchEntry(line, result.output));
+          sections.push(`[command ${i + 1}/${lines.length} failed with exit code 1 — remaining commands skipped]`);
+          break;
+        }
+      }
+
+      const perCommandTimeout = context.invocation.source === 'terminal'
+        ? null
+        : timeoutForCommand(batchDeadline);
+      result = normalizeCliResult(
+        await runWithTimeout(
+          () => resolved.command.execute(resolved.args, context),
+          perCommandTimeout,
+          context.invocation.signal,
+        ),
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'CLI command failed';
+      timedOut = error instanceof CommandTimeoutError;
+      result = {
+        output: `ERROR: ${message}`,
+        exitCode: 1,
+      };
+    }
+
+    finalExitCode = result.exitCode ?? 0;
+
+    if (single) {
+      const output = context.invocation.source === 'terminal'
+        ? result.output
+        : truncateOutput(result.output);
+      return { output, exitCode: finalExitCode };
+    }
+
+    sections.push(formatBatchEntry(line, result.output));
+
+    if (finalExitCode !== 0) {
+      const suffix = timedOut
+        ? `[command ${i + 1}/${lines.length} timed out — remaining commands skipped]`
+        : `[command ${i + 1}/${lines.length} failed with exit code ${finalExitCode} — remaining commands skipped]`;
+      sections.push(suffix);
+      break;
+    }
+  }
+
+  const joined = sections.join('\n\n');
+  const output = context.invocation.source === 'terminal' ? joined : truncateOutput(joined);
+  return { output, exitCode: finalExitCode };
+}
+
+function buildInvocation(
+  workspaceId: string,
+  sessionId: string,
+  signal?: AbortSignal,
+): CliInvocation {
+  const bridge = getCliSessionBridge();
+  return {
+    workspaceId,
+    sessionId,
+    turnId: bridge.getActiveTurnId(sessionId),
+    source: 'tool',
+    signal,
+  };
+}
+
+export function createSeroCliTool(
+  registry: CliRegistry,
+  workspaceId: string,
+  sessionId: string,
+): ToolDefinition {
+  return {
+    name: 'sero-cli',
+    label: 'Sero CLI',
+    description:
+      'Execute Sero platform commands. Run `sero help` for commands. Supports multi-line input to chain commands (one per line).',
+    parameters: SeroCliToolParams,
+    async execute(_toolCallId, params, signal, _onUpdate, toolCtx) {
+      const cliParams = params as { command: string; timeout?: number };
+      const wsPath = workspaceManager.getPath(workspaceId);
+      if (!wsPath) {
+        return { content: [{ type: 'text', text: `ERROR: Workspace not found: ${workspaceId}` }], details: { exitCode: 1 } };
+      }
+
+      const context: CliCommandContext = {
+        workspaceId,
+        cwd: toolCtx?.cwd ?? wsPath,
+        invocation: buildInvocation(workspaceId, sessionId, signal),
+        workspaceManager,
+        containerManager,
+      };
+
+      const batch = await executeCliBatch(registry, cliParams.command, context, cliParams.timeout);
+      return {
+        content: [{ type: 'text', text: batch.output }],
+        details: { exitCode: batch.exitCode },
+      };
+    },
+  };
+}

--- a/apps/desktop/electron/cli/types.ts
+++ b/apps/desktop/electron/cli/types.ts
@@ -1,0 +1,50 @@
+import type { ContainerManager } from '../container';
+import type { WorkspaceManager } from '../workspace';
+
+export type CliSource = 'tool' | 'bash' | 'terminal';
+
+export interface CliInvocation {
+  workspaceId: string;
+  sessionId: string | null;
+  turnId: string | null;
+  source: CliSource;
+  signal?: AbortSignal;
+}
+
+export interface CliResult {
+  output: string;
+  exitCode?: number;
+}
+
+export interface CliParam {
+  name: string;
+  description: string;
+  required?: boolean;
+  type?: 'string' | 'number' | 'boolean';
+  default?: unknown;
+}
+
+export interface CliCommandContext {
+  workspaceId: string;
+  cwd: string;
+  invocation: CliInvocation;
+  workspaceManager: WorkspaceManager;
+  containerManager: ContainerManager;
+}
+
+export interface CliCommand {
+  name: string;
+  summary: string;
+  help?: string;
+  params?: CliParam[];
+  execute: (args: string[], context: CliCommandContext) => Promise<CliResult>;
+  source?: 'app' | 'ipc' | 'builtin';
+  group?: string;
+  hidden?: boolean;
+}
+
+export interface CliResolvedCommand {
+  command: CliCommand;
+  args: string[];
+  tokens: string[];
+}

--- a/apps/desktop/electron/container/system-prompt.ts
+++ b/apps/desktop/electron/container/system-prompt.ts
@@ -41,6 +41,7 @@ ${containerIp ? `- Container IP: ${containerIp} (accessible from the host)` : ''
   After each bash command, the tool output shows all detected server URLs — always tell
   the user the exact URL shown there (e.g. http://${containerIp ?? '<container-ip>'}:3000).
 - Any port is fine. Container servers never conflict with host services.
+- Whenever asked to start a dev server, ALWAYS check if it's running BEFORE responding. Sometimes dev servers can be stopped in the background.
 
 **CRITICAL — Starting background / long-running processes:**
 Each bash tool call runs in an isolated \`sh -c\` shell. To start a process that must outlive the command:

--- a/apps/desktop/electron/container/system-prompt.ts
+++ b/apps/desktop/electron/container/system-prompt.ts
@@ -56,15 +56,16 @@ Each bash tool call runs in an isolated \`sh -c\` shell. To start a process that
 
 **CRITICAL — Registering dev servers:**
 After successfully starting a dev server and confirming it is listening (via \`ss -tlnp\`),
-you MUST call the \`register_dev_server\` tool to register it with the host. This lets the
-user see the server in the Dev Servers panel (status bar) and stop/restart it from the UI.
+you MUST use the \`sero-cli\` tool to run \`devserver register\` so the host can track it.
+This lets the user see the server in the Dev Servers panel (status bar) and stop/restart it
+from the UI.
 Example:
   1. Start the server: \`setsid sh -c 'npx vite --host 0.0.0.0 --port 3000 > /tmp/vite.log 2>&1 &'\`
   2. Verify: \`ss -tlnp | grep 3000\`
-  3. Register: call \`register_dev_server\` with name, port, command, and framework
+  3. Register: call \`sero-cli\` with \`devserver register --name \"Vite\" --port 3000 --command \"npx vite --host 0.0.0.0 --port 3000\" --framework vite\`
 
 **Terminal awareness:**
 - The user may have interactive terminal sessions running in this container.
-- Use \`read_terminal\` to check terminal output for errors after starting dev servers.
+- Use the \`sero-cli\` tool with \`terminal read\` to check terminal output for errors after starting dev servers.
 - If you see errors, proactively fix them.`;
 }

--- a/apps/desktop/electron/container/tools.ts
+++ b/apps/desktop/electron/container/tools.ts
@@ -2,180 +2,14 @@
  * Container-proxied tool definitions for agent sessions.
  *
  * These replace Pi SDK's createCodingTools() — every tool executes
- * inside the workspace's container via `container exec`.
- *
- * Behaviour is aligned with Pi SDK tools (truncation, fuzzy edit
- * matching, actionable notices, etc.) so the agent gets a consistent
- * experience whether running on the host or inside a container.
- *
- * IMPORTANT: Errors are thrown (rejected), not returned with isError.
- * The Pi SDK agent-loop only sets isError=true when the tool rejects;
- * returning { isError: true } from a resolved promise is silently
- * ignored by the framework.
- *
- * Core coding tools (bash, read, write, edit) live in tools-coding.ts.
- * Workspace tools (ls, read_terminal, register_dev_server) live here.
+ * inside the workspace's container via `container exec`, except `sero-cli`
+ * which routes to host-side Sero commands.
  */
 
-import type { Static } from '@sinclair/typebox';
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
 import type { ContainerManager } from './index';
-import { DEFAULT_MAX_BYTES, formatSize, truncateHead } from './truncate';
-import {
-  WORKSPACE_DIR,
-  resolveContainerPath,
-  shellEscape,
-  LsParams,
-  ReadTerminalParams,
-  RegisterDevServerParams,
-} from './tool-schemas';
 import { createBash, createRead, createWrite, createEdit } from './tools-coding';
-
-// ── Workspace tool factories ────────────────────────────────
-
-function createLs(cm: ContainerManager, workspaceId: string): ToolDefinition {
-  return {
-    name: 'ls',
-    label: 'ls',
-    description:
-      `List directory contents. Returns entries sorted alphabetically, ` +
-      `with '/' suffix for directories. Includes dotfiles. Output is ` +
-      `truncated to ${DEFAULT_MAX_BYTES / 1024}KB.`,
-    parameters: LsParams,
-    execute: async (_toolCallId, params: Static<typeof LsParams>, signal?) => {
-      if (signal?.aborted) throw new Error('Operation aborted');
-
-      const absPath = params.path
-        ? resolveContainerPath(params.path)
-        : WORKSPACE_DIR;
-      const escaped = shellEscape(absPath);
-      const result = await cm.exec(workspaceId, `ls -1a '${escaped}'`);
-
-      if (result.exitCode !== 0) {
-        throw new Error(
-          result.stderr || `Cannot list directory: ${params.path ?? WORKSPACE_DIR}`,
-        );
-      }
-
-      const raw = result.stdout.trim();
-      if (!raw) {
-        return {
-          content: [{ type: 'text', text: '(empty directory)' }],
-          details: { path: absPath },
-        };
-      }
-
-      // Add '/' suffix for directories (batch stat)
-      const entries = raw.split('\n').filter((e) => e !== '.' && e !== '..');
-      const statCmd = entries
-        .map((e) => {
-          const full = shellEscape(`${absPath}/${e}`);
-          return `[ -d '${full}' ] && echo "${e}/" || echo "${e}"`;
-        })
-        .join('; ');
-      const statResult =
-        entries.length > 0 ? await cm.exec(workspaceId, statCmd) : null;
-      const formatted = statResult?.stdout?.trim() || raw;
-
-      // Sort alphabetically (case-insensitive)
-      const sorted = formatted
-        .split('\n')
-        .filter(Boolean)
-        .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-
-      const output = sorted.join('\n');
-      const truncation = truncateHead(output, {
-        maxLines: Number.MAX_SAFE_INTEGER,
-      });
-      let resultText = truncation.content;
-
-      if (truncation.truncated) {
-        resultText += `\n\n[${formatSize(DEFAULT_MAX_BYTES)} limit reached]`;
-      }
-
-      return {
-        content: [{ type: 'text', text: resultText }],
-        details: { path: absPath },
-      };
-    },
-  };
-}
-
-function createReadTerminal(
-  cm: ContainerManager,
-  workspaceId: string,
-): ToolDefinition {
-  return {
-    name: 'read_terminal',
-    label: 'Read Terminal',
-    description:
-      "Read the recent output from the workspace's terminal sessions. " +
-      'Use this to check dev server logs, build output, error messages, ' +
-      'or any other terminal output.',
-    parameters: ReadTerminalParams,
-    execute: async (
-      _toolCallId,
-      params: Static<typeof ReadTerminalParams>,
-      signal?,
-    ) => {
-      if (signal?.aborted) throw new Error('Operation aborted');
-
-      const output = cm.terminals.readWorkspaceTerminalOutput(
-        workspaceId,
-        params.lines ?? 80,
-      );
-      return { content: [{ type: 'text', text: output }], details: {} };
-    },
-  };
-}
-
-function createRegisterDevServer(
-  cm: ContainerManager,
-  workspaceId: string,
-): ToolDefinition {
-  return {
-    name: 'register_dev_server',
-    label: 'Register Dev Server',
-    description:
-      'Register a running dev server with the host so the user can see it ' +
-      'in the Dev Servers panel and stop/restart it from the UI. ' +
-      'Call this AFTER successfully starting a dev server and confirming ' +
-      'it is listening on a port.',
-    parameters: RegisterDevServerParams,
-    execute: async (
-      _toolCallId,
-      params: Static<typeof RegisterDevServerParams>,
-      signal?,
-    ) => {
-      if (signal?.aborted) throw new Error('Operation aborted');
-
-      const server = cm.devServers.register({
-        workspaceId,
-        name: params.name,
-        port: params.port,
-        command: params.command,
-        framework: params.framework,
-      });
-
-      return {
-        content: [
-          {
-            type: 'text',
-            text:
-              `✓ Dev server registered: ${server.name}\n` +
-              `  URL: ${server.url}\n` +
-              `  Port: ${server.port}\n` +
-              `  Status: ${server.status}\n` +
-              'The user can now manage this server from the Dev Servers panel.',
-          },
-        ],
-        details: { serverId: server.id, url: server.url },
-      };
-    },
-  };
-}
-
-// ── Public API ──────────────────────────────────────────────
+import { createWorkspaceCliTool } from '../cli';
 
 /**
  * Build all container tools for a workspace.
@@ -184,14 +18,13 @@ function createRegisterDevServer(
 export function createContainerTools(
   cm: ContainerManager,
   workspaceId: string,
+  sessionId: string,
 ): ToolDefinition[] {
   return [
     createBash(cm, workspaceId),
     createRead(cm, workspaceId),
     createWrite(cm, workspaceId),
     createEdit(cm, workspaceId),
-    createLs(cm, workspaceId),
-    createReadTerminal(cm, workspaceId),
-    createRegisterDevServer(cm, workspaceId),
+    createWorkspaceCliTool(workspaceId, sessionId),
   ];
 }

--- a/apps/desktop/electron/env.ts
+++ b/apps/desktop/electron/env.ts
@@ -16,8 +16,8 @@ import { readFileSync } from 'fs';
 import os from 'os';
 import path from 'path';
 
-/** Sero's root config directory. */
-export const SERO_HOME = path.join(os.homedir(), '.sero-ui');
+/** Sero's root config directory. Respects SERO_HOME env var for testing. */
+export const SERO_HOME = process.env.SERO_HOME || path.join(os.homedir(), '.sero-ui');
 
 /** Sero's agent directory — replaces ~/.pi/agent for all SDK calls. */
 export const SERO_AGENT_DIR = path.join(SERO_HOME, 'agent');

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -47,6 +47,8 @@ import {
 import { createContainerTools } from '../container/tools';
 import type { ContainerState } from '../container/index';
 import { registerAgentModelContextHandlers } from './agent-model-context';
+import { installCliAgentBridge, noteCliTurnEnd, noteCliTurnStart } from '../cli/agent-bridge';
+import { createWorkspaceCliTool, bridgeExtensionTools } from '../cli';
 
 interface PoolEntry {
   session: AgentSession;
@@ -72,6 +74,7 @@ function sendEvent(event: AgentStreamEvent): void {
 function closePoolEntry(sessionId: string): void {
   const entry = pool.get(sessionId);
   if (!entry) return;
+  noteCliTurnEnd(sessionId);
   entry.unsubscribe();
   entry.session.dispose();
   pool.delete(sessionId);
@@ -91,6 +94,7 @@ function subscribeToSession(sessionId: string, session: AgentSession): () => voi
     logRawEvent(sessionId, event);
 
     if (event.type === 'turn_start') {
+      noteCliTurnStart(sessionId);
       logTurnContext(sessionId, session);
     }
 
@@ -100,6 +104,7 @@ function subscribeToSession(sessionId: string, session: AgentSession): () => voi
         break;
 
       case 'agent_end':
+        noteCliTurnEnd(sessionId);
         sendEvent({ type: 'agent_end', sessionId });
         {
           // Store the checkpoint from the just-completed turn so it can be
@@ -182,8 +187,6 @@ function subscribeToSession(sessionId: string, session: AgentSession): () => voi
       }
 
       case 'tool_execution_start': {
-        if (event.toolName === 'set_session_title') break;
-
         const toolMsg: ChatToolCallMessage = {
           type: 'tool',
           id: nextId(),
@@ -199,15 +202,6 @@ function subscribeToSession(sessionId: string, session: AgentSession): () => voi
       }
 
       case 'tool_execution_end': {
-        if (event.toolName === 'set_session_title') {
-          const newName = entry.session.sessionName;
-          if (newName && newName !== entry.lastSessionName) {
-            entry.lastSessionName = newName;
-            sendEvent({ type: 'session_name', sessionId, name: newName });
-          }
-          break;
-        }
-
         const result = event.result;
         let text: string | null = null;
         if (result?.content && Array.isArray(result.content)) {
@@ -232,6 +226,11 @@ function subscribeToSession(sessionId: string, session: AgentSession): () => voi
 }
 
 export function registerAgentHandlers(): void {
+  installCliAgentBridge({
+    getEntry: (id) => pool.get(id),
+    listEntries: () => [...pool.entries()],
+    sendEvent,
+  });
   ipcMain.handle(
     IpcChannels.agent.open,
     async (_event, sessionId: string, sessionPath: string, workspaceId: string): Promise<ChatMessage[]> => {
@@ -280,8 +279,8 @@ export function registerAgentHandlers(): void {
 
       const useContainer = !!containerState;
       const containerTools = useContainer
-        ? createContainerTools(containerManager, workspaceId)
-        : undefined;
+        ? createContainerTools(containerManager, workspaceId, sessionId)
+        : [createWorkspaceCliTool(workspaceId, sessionId)];
       const builtinTools = useContainer ? [] : createCodingTools(wsPath);
 
       const globalAgentsFile = await readGlobalAgentsMd(workspaceId);
@@ -294,9 +293,11 @@ export function registerAgentHandlers(): void {
           createSeroExtensionFactory(
             workspaceManager,
             workspaceId,
+            sessionId,
             containerState ?? undefined,
           ),
         ],
+        extensionsOverride: bridgeExtensionTools,
         ...(globalAgentsFile && {
           agentsFilesOverride: (discovered) => ({
             agentsFiles: [globalAgentsFile, ...discovered.agentsFiles],

--- a/apps/desktop/electron/ipc/editor.ts
+++ b/apps/desktop/electron/ipc/editor.ts
@@ -119,8 +119,15 @@ export function registerEditorHandlers(): void {
   ipcMain.handle(
     IpcChannels.editor.readFile,
     async (_e, workspaceId: string, filePath: string) => {
-      if (await workspaceManager.isContainerEnabled(workspaceId)) {
-        return containerManager.readFile(workspaceId, filePath);
+      if (
+        await workspaceManager.isContainerEnabled(workspaceId) &&
+        containerManager.hasContainer(workspaceId)
+      ) {
+        try {
+          return await containerManager.readFile(workspaceId, filePath);
+        } catch {
+          // Container exec failed — fall through to host read
+        }
       }
       const wsPath = workspaceManager.getPath(workspaceId);
       if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
@@ -143,8 +150,18 @@ export function registerEditorHandlers(): void {
   ipcMain.handle(
     IpcChannels.editor.listFiles,
     async (_e, workspaceId: string, dirPath: string) => {
-      if (await workspaceManager.isContainerEnabled(workspaceId)) {
-        return containerManager.listFiles(workspaceId, dirPath);
+      // Use container listing only when the container is registered and running.
+      // Otherwise fall back to host listing so the file tree works before the
+      // container has been started (e.g. when clicking a workspace header).
+      if (
+        await workspaceManager.isContainerEnabled(workspaceId) &&
+        containerManager.hasContainer(workspaceId)
+      ) {
+        try {
+          return await containerManager.listFiles(workspaceId, dirPath);
+        } catch {
+          // Container exec failed — fall through to host listing
+        }
       }
       const wsPath = workspaceManager.getPath(workspaceId);
       if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);

--- a/apps/desktop/electron/ipc/layout.ts
+++ b/apps/desktop/electron/ipc/layout.ts
@@ -18,6 +18,9 @@ export interface LayoutState {
   mainSidebarOpen: boolean;
   chatPanelOpen: boolean;
   favouriteApps?: string[];
+  /** Persisted panel size percentages (0–100). */
+  mainSidebarSizePct?: number;
+  chatPanelSizePct?: number;
 }
 
 let writeQueue: Promise<void> = Promise.resolve();

--- a/apps/desktop/electron/sero-extension.ts
+++ b/apps/desktop/electron/sero-extension.ts
@@ -13,7 +13,6 @@
  */
 
 import path from 'path';
-import { Type } from '@sinclair/typebox';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import type { WorkspaceManager } from './workspace';
 import type { WorkspaceInfo } from '../src/types/ipc';
@@ -21,6 +20,7 @@ import type { ContainerState } from './container/index';
 import { buildContainerPromptBlock } from './container/system-prompt';
 import { registerSeroBuiltinCommands } from './sero-extension-commands';
 import { registerJjCheckpointFeatures } from './sero-extension-jj';
+import { buildCliPromptBlock } from './cli';
 
 /**
  * Creates an extension factory for a specific workspace session.
@@ -32,46 +32,18 @@ import { registerJjCheckpointFeatures } from './sero-extension-jj';
 export function createSeroExtensionFactory(
   wsManager: WorkspaceManager,
   currentWorkspaceId: string,
+  _sessionId: string,
   containerState?: ContainerState,
 ) {
   return (pi: ExtensionAPI) => {
-    // ── Session title generation ───────────────────────────────
-    //
-    // On the first turn, inject a system prompt instruction telling
-    // the agent to call set_session_title with a short title.
-    // The tool sets the session name via pi.setSessionName().
-
-    let titleSet = false;
-
-    pi.registerTool({
-      name: 'set_session_title',
-      label: 'Set Session Title',
-      description: 'Set a short title for the current chat session. Call this once after your first response.',
-      parameters: Type.Object({
-        title: Type.String({ description: 'Concise title, 3-6 words' }),
-      }),
-      execute: async (_toolCallId, params) => {
-        const title = params.title?.trim();
-        
-        if (title) {
-          pi.setSessionName(title);
-          titleSet = true;
-        }
-        return {
-          content: [{ type: 'text', text: title ? `Session titled: ${title}` : 'No title provided' }],
-          details: {},
-        };
-      },
-    });
-
     // ── Composite prompt injection ─────────────────────────────
     //
     // Before each agent turn, inject summaries of other open workspaces
     // into the system prompt so the AI has cross-workspace awareness.
-    // On the first turn, also ask the agent to generate a session title.
 
     pi.on('before_agent_start', async (event) => {
       let systemPrompt = event.systemPrompt;
+      systemPrompt += buildCliPromptBlock();
 
       // Inject container environment context if workspace is containerised
       if (containerState) {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -44,25 +44,24 @@ export function App() {
   const setChatPanelOpen = useAppStore((s) => s.setChatPanelOpen);
   const mainSidebarPanelRef = useRef<PanelImperativeHandle | null>(null);
   const chatPanelRef = useRef<PanelImperativeHandle | null>(null);
-  // Start true — blocks onResize events fired during initial render (before
-  // the sync effects run). Without this, the handler sees the panel at its
-  // defaultSize, detects !open && inPixels >= min, and immediately re-opens.
   const isMainSidebarProgrammaticRef = useRef(true);
   const isChatPanelProgrammaticRef = useRef(true);
-  const MAIN_SIDEBAR_DEFAULT_SIZE_PCT = 20;
-  const CHAT_PANEL_DEFAULT_SIZE_PCT = 30;
-  const mainSidebarLastExpandedPctRef = useRef(MAIN_SIDEBAR_DEFAULT_SIZE_PCT);
-  const chatPanelLastExpandedPctRef = useRef(CHAT_PANEL_DEFAULT_SIZE_PCT);
 
   const MAIN_SIDEBAR_MIN_WIDTH = 200;
   const CHAT_PANEL_MIN_WIDTH = 300;
-  const COLLAPSE_PULL_PAST_MIN = 100;
-
-  const mainSidebarCollapsedSize = Math.max(
-    0,
-    MAIN_SIDEBAR_MIN_WIDTH - COLLAPSE_PULL_PAST_MIN * 2,
-  );
+  const mainSidebarCollapsedSize = 0;
   const chatPanelCollapsedSize = 0;
+
+  const mainSidebarLastExpandedPctRef = useRef(20);
+  const chatPanelLastExpandedPctRef = useRef(30);
+  const mainSidebarDefaultRef = useRef<string | number>(0);
+  const chatPanelDefaultRef = useRef<string | number>(0);
+  // Debounce disk persist so we don't write on every pixel of drag.
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Hydrate once — refs capture persisted values on the FIRST render where
+  // layoutReady=true, which is the same render that first mounts the panels
+  // (because the loading guard returns early until then).
+  const layoutHydratedRef = useRef(false);
 
   const appsReady = useAppStore((s) => s.appsReady);
   const layoutReady = useAppStore((s) => s.layoutReady);
@@ -72,6 +71,17 @@ export function App() {
 
   // Global keyboard shortcuts (⌘B sidebar, ⌘L chat)
   useKeyboardShortcuts();
+
+  // Hydrate refs from store once layout has loaded. Runs during render (not
+  // an effect) so refs are set BEFORE the JSX tree mounts the panels.
+  if (layoutReady && appsReady && !layoutHydratedRef.current) {
+    layoutHydratedRef.current = true;
+    const s = useAppStore.getState();
+    mainSidebarLastExpandedPctRef.current = s.mainSidebarSizePct;
+    chatPanelLastExpandedPctRef.current = s.chatPanelSizePct;
+    mainSidebarDefaultRef.current = s.mainSidebarOpen ? `${s.mainSidebarSizePct}%` : 0;
+    chatPanelDefaultRef.current = s.chatPanelOpen ? `${s.chatPanelSizePct}%` : 0;
+  }
 
   // Load layout + discover apps on startup
   useEffect(() => {
@@ -96,13 +106,12 @@ export function App() {
       }
 
       mainSidebarLastExpandedPctRef.current = asPercentage;
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = setTimeout(() => {
+        useAppStore.getState().setMainSidebarSizePct(Math.round(asPercentage * 10) / 10);
+      }, 300);
     },
-    [
-      appsReady,
-      mainSidebarCollapsedSize,
-      layoutReady,
-      setMainSidebarOpen,
-    ],
+    [appsReady, layoutReady, setMainSidebarOpen],
   );
 
   const handleChatPanelResize = useCallback(
@@ -116,13 +125,12 @@ export function App() {
       }
 
       chatPanelLastExpandedPctRef.current = asPercentage;
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = setTimeout(() => {
+        useAppStore.getState().setChatPanelSizePct(Math.round(asPercentage * 10) / 10);
+      }, 300);
     },
-    [
-      appsReady,
-      chatPanelCollapsedSize,
-      layoutReady,
-      setChatPanelOpen,
-    ],
+    [appsReady, layoutReady, setChatPanelOpen],
   );
 
   // ── Panel sync effects ──────────────────────────────────────
@@ -144,10 +152,7 @@ export function App() {
       });
     } else {
       rafId = window.requestAnimationFrame(() => {
-        const targetPct = Math.max(
-          MAIN_SIDEBAR_DEFAULT_SIZE_PCT,
-          mainSidebarLastExpandedPctRef.current,
-        );
+        const targetPct = mainSidebarLastExpandedPctRef.current;
         mainSidebarPanelRef.current?.expand();
         mainSidebarPanelRef.current?.resize(`${targetPct}%`);
         rafId2 = window.requestAnimationFrame(() => {
@@ -161,7 +166,7 @@ export function App() {
       if (rafId2 !== null) window.cancelAnimationFrame(rafId2);
       isMainSidebarProgrammaticRef.current = false;
     };
-  }, [mainSidebarOpen, layoutReady, appsReady, MAIN_SIDEBAR_DEFAULT_SIZE_PCT]);
+  }, [mainSidebarOpen, layoutReady, appsReady]);
 
   useEffect(() => {
     if (!layoutReady || !appsReady) return;
@@ -176,10 +181,7 @@ export function App() {
       });
     } else {
       rafId = window.requestAnimationFrame(() => {
-        const targetPct = Math.max(
-          CHAT_PANEL_DEFAULT_SIZE_PCT,
-          chatPanelLastExpandedPctRef.current,
-        );
+        const targetPct = chatPanelLastExpandedPctRef.current;
         chatPanelRef.current?.expand();
         chatPanelRef.current?.resize(`${targetPct}%`);
         rafId2 = window.requestAnimationFrame(() => {
@@ -193,7 +195,7 @@ export function App() {
       if (rafId2 !== null) window.cancelAnimationFrame(rafId2);
       isChatPanelProgrammaticRef.current = false;
     };
-  }, [chatPanelOpen, layoutReady, appsReady, CHAT_PANEL_DEFAULT_SIZE_PCT]);
+  }, [chatPanelOpen, layoutReady, appsReady]);
 
   // Wait for layout hydration + app discovery before rendering.
   // Layout must load first so panels render at the correct size (no flash).
@@ -219,9 +221,7 @@ export function App() {
             <ResizablePanel
               id="main-sidebar-panel"
               panelRef={mainSidebarPanelRef}
-              defaultSize={
-                mainSidebarOpen ? `${MAIN_SIDEBAR_DEFAULT_SIZE_PCT}%` : mainSidebarCollapsedSize
-              }
+              defaultSize={mainSidebarDefaultRef.current}
               minSize={MAIN_SIDEBAR_MIN_WIDTH}
               collapsible
               collapsedSize={mainSidebarCollapsedSize}
@@ -247,7 +247,7 @@ export function App() {
             <ResizablePanel
               id="chat-panel"
               panelRef={chatPanelRef}
-              defaultSize={chatPanelOpen ? `${CHAT_PANEL_DEFAULT_SIZE_PCT}%` : chatPanelCollapsedSize}
+              defaultSize={chatPanelDefaultRef.current}
               minSize={CHAT_PANEL_MIN_WIDTH}
               collapsible
               collapsedSize={chatPanelCollapsedSize}

--- a/apps/desktop/src/components/apps/coding/CodingSidebar.tsx
+++ b/apps/desktop/src/components/apps/coding/CodingSidebar.tsx
@@ -45,7 +45,7 @@ export function CodingSidebar({ activePanel, workspaceId, fileTreeProps, onOpenD
       )}
 
       {/* ── Content ──────────────────────────────────────────── */}
-      <div className="flex flex-1 flex-col min-h-0 overflow-hidden">
+      <div className="flex flex-1 flex-col min-h-0 overflow-hidden" data-testid="coding-sidebar-content">
         {activePanel === 'explorer' && fileTreeProps ? (
           <FileTree {...fileTreeProps} />
         ) : activePanel === 'git' ? (

--- a/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
+++ b/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
@@ -40,7 +40,8 @@ export function CodingWorkspace() {
   const loadVcsWorkspace = useVcsStore((s) => s.loadWorkspace);
 
   // Per-workspace UI state
-  const { sidebarOpen, activePanel, terminalOpen } = useWorkspaceCodingUi(workspaceId);
+  const { sidebarOpen, activePanel, terminalOpen, codingSidebarSizePct, terminalSizePct } =
+    useWorkspaceCodingUi(workspaceId);
   const setCodingUi = useCodingUiStore((s) => s.set);
 
   // Terminal state
@@ -250,36 +251,101 @@ export function CodingWorkspace() {
 
   const sidebarPanelRef = useRef<PanelImperativeHandle | null>(null);
   const isSidebarProgrammaticRef = useRef(false);
+  const terminalPanelRef = useRef<PanelImperativeHandle | null>(null);
+  const isTerminalProgrammaticRef = useRef(true);
+  const TERMINAL_MIN_HEIGHT = 100;
+  const terminalLastExpandedPctRef = useRef(terminalSizePct || 30);
+  const terminalDefaultRef = useRef(
+    terminalOpen ? `${terminalSizePct || 30}%` : 0,
+  );
+  const codingSidebarLastExpandedPctRef = useRef(codingSidebarSizePct || 0);
 
   // Sync sidebar panel collapse/expand with sidebarOpen state
   useEffect(() => {
+    let rafId: number | null = null;
+    let rafId2: number | null = null;
     isSidebarProgrammaticRef.current = true;
-    const rafId = window.requestAnimationFrame(() => {
-      if (sidebarOpen) {
-        sidebarPanelRef.current?.expand();
-      } else {
-        sidebarPanelRef.current?.collapse();
-      }
-      window.requestAnimationFrame(() => {
+
+    if (!sidebarOpen) {
+      sidebarPanelRef.current?.collapse();
+      rafId = window.requestAnimationFrame(() => {
         isSidebarProgrammaticRef.current = false;
       });
-    });
+    } else {
+      rafId = window.requestAnimationFrame(() => {
+        sidebarPanelRef.current?.expand();
+        const target = codingSidebarLastExpandedPctRef.current;
+        if (target > 0) {
+          sidebarPanelRef.current?.resize(`${target}%`);
+        }
+        rafId2 = window.requestAnimationFrame(() => {
+          isSidebarProgrammaticRef.current = false;
+        });
+      });
+    }
+
     return () => {
-      window.cancelAnimationFrame(rafId);
+      if (rafId !== null) window.cancelAnimationFrame(rafId);
+      if (rafId2 !== null) window.cancelAnimationFrame(rafId2);
       isSidebarProgrammaticRef.current = false;
     };
   }, [sidebarOpen]);
 
   const handleSidebarResize = useCallback(
-    ({ inPixels }: { inPixels: number; asPercentage: number }) => {
+    ({ inPixels, asPercentage }: { inPixels: number; asPercentage: number }) => {
       if (isSidebarProgrammaticRef.current) return;
       if (inPixels <= 1) {
         setCodingUi(workspaceId, { sidebarOpen: false });
       } else if (!sidebarOpen && inPixels >= 120) {
         setCodingUi(workspaceId, { sidebarOpen: true });
+      } else {
+        codingSidebarLastExpandedPctRef.current = asPercentage;
+        setCodingUi(workspaceId, { codingSidebarSizePct: Math.round(asPercentage * 10) / 10 });
       }
     },
     [workspaceId, sidebarOpen, setCodingUi],
+  );
+
+  // Sync terminal panel collapse/expand with terminalOpen state
+  useEffect(() => {
+    let rafId: number | null = null;
+    let rafId2: number | null = null;
+    isTerminalProgrammaticRef.current = true;
+
+    if (!terminalOpen) {
+      terminalPanelRef.current?.collapse();
+      rafId = window.requestAnimationFrame(() => {
+        isTerminalProgrammaticRef.current = false;
+      });
+    } else {
+      rafId = window.requestAnimationFrame(() => {
+        const targetPct = terminalLastExpandedPctRef.current || 30;
+        terminalPanelRef.current?.expand();
+        terminalPanelRef.current?.resize(`${targetPct}%`);
+        rafId2 = window.requestAnimationFrame(() => {
+          isTerminalProgrammaticRef.current = false;
+        });
+      });
+    }
+
+    return () => {
+      if (rafId !== null) window.cancelAnimationFrame(rafId);
+      if (rafId2 !== null) window.cancelAnimationFrame(rafId2);
+      isTerminalProgrammaticRef.current = false;
+    };
+  }, [terminalOpen]);
+
+  const handleTerminalResize = useCallback(
+    ({ inPixels, asPercentage }: { inPixels: number; asPercentage: number }) => {
+      if (isTerminalProgrammaticRef.current) return;
+      if (inPixels <= 1) {
+        setCodingUi(workspaceId, { terminalOpen: false });
+      } else {
+        terminalLastExpandedPctRef.current = asPercentage;
+        setCodingUi(workspaceId, { terminalSizePct: Math.round(asPercentage * 10) / 10 });
+      }
+    },
+    [workspaceId, setCodingUi],
   );
 
   return (
@@ -291,7 +357,9 @@ export function CodingWorkspace() {
           terminalOpen={terminalOpen} onPanelClick={handlePanelClick}
         />
 
-        <ResizablePanelGroup id="coding-layout" orientation="horizontal" className="min-w-0 flex-1">
+        <ResizablePanelGroup id="coding-vertical" orientation="vertical" className="min-w-0 flex-1">
+          <ResizablePanel id="coding-main" minSize={20}>
+            <ResizablePanelGroup id="coding-layout" orientation="horizontal" className="h-full">
           <ResizablePanel
             id="coding-sidebar"
             panelRef={sidebarPanelRef}
@@ -356,30 +424,47 @@ export function CodingWorkspace() {
               )}
             </div>
           </ResizablePanel>
-        </ResizablePanelGroup>
-      </div>
+            </ResizablePanelGroup>
+          </ResizablePanel>
 
-      {/* ── Bottom: terminal spans full width ──────────────── */}
-      {terminalOpen && (
-        <div className="flex h-[250px] min-h-[100px] max-h-[60%] shrink-0 flex-col border-t border-[var(--border-default)]">
-          <TerminalTabs workspaceId={workspaceId} />
-          <div className="relative flex-1 min-h-0 bg-[#0a0a0b]">
-            {termTabs.map((tab) => (
-              <TerminalPanel
-                key={tab.id} terminalId={tab.id}
-                isActive={activeTerminalId === tab.id}
-              />
-            ))}
-            {termTabs.length === 0 && (
-              <div className="flex h-full items-center justify-center">
-                <span className="text-xs text-[var(--text-muted)]">
-                  No terminals — click + to create one
-                </span>
+          <ResizableHandle
+            disabled={!terminalOpen}
+            className={!terminalOpen ? 'pointer-events-none opacity-0' : undefined}
+          />
+
+          <ResizablePanel
+            id="coding-terminal"
+            panelRef={terminalPanelRef}
+            defaultSize={terminalDefaultRef.current}
+            minSize={TERMINAL_MIN_HEIGHT}
+            collapsible
+            collapsedSize={0}
+            onResize={handleTerminalResize}
+            style={{ overflow: 'hidden' }}
+          >
+            {terminalOpen && (
+              <div className="flex h-full flex-col border-t border-[var(--border-default)]">
+                <TerminalTabs workspaceId={workspaceId} />
+                <div className="relative flex-1 min-h-0 bg-[#0a0a0b]">
+                  {termTabs.map((tab) => (
+                    <TerminalPanel
+                      key={tab.id} terminalId={tab.id}
+                      isActive={activeTerminalId === tab.id}
+                    />
+                  ))}
+                  {termTabs.length === 0 && (
+                    <div className="flex h-full items-center justify-center">
+                      <span className="text-xs text-[var(--text-muted)]">
+                        No terminals — click + to create one
+                      </span>
+                    </div>
+                  )}
+                </div>
               </div>
             )}
-          </div>
-        </div>
-      )}
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
@@ -12,8 +12,6 @@ import type { editor as monacoEditor, IRange, IPosition } from 'monaco-editor';
 import { Code2, Eye } from 'lucide-react';
 import { EditorTabBar, type EditorTab } from './EditorTabBar';
 import { useLsp } from '@/lsp/use-lsp';
-import { useContainerStore } from '@/stores/container';
-import { useActiveWorkspace } from '@/stores/workspace';
 import { useAppStore } from '@/stores/app';
 import { Streamdown } from 'streamdown';
 import { code } from '@streamdown/code';
@@ -85,11 +83,6 @@ export function EditorPanel({
   const pendingGotoRef = useRef<{ path: string; selection: IRange | IPosition } | null>(null);
 
   const appTheme = useAppStore((s) => s.theme);
-  const containerStatus = useContainerStore((s) => s.containers[workspaceId]?.status ?? 'none');
-  const activeWorkspace = useActiveWorkspace();
-  const isContainerWorkspace = activeWorkspace?.container ?? true;
-  // Non-container workspaces are always ready; container workspaces must be running.
-  const isReady = isContainerWorkspace ? containerStatus === 'running' : true;
   const isMarkdownTab = !!activeTab && getLanguage(activeTab) === 'markdown';
   const isMarkdownPreview = isMarkdownTab && markdownViewMode === 'preview';
 
@@ -120,7 +113,6 @@ export function EditorPanel({
       schedulePendingGoto();
       return;
     }
-    if (!isReady) return;
 
     setContent('');
     setLanguage(getLanguage(activeTab));
@@ -141,7 +133,7 @@ export function EditorPanel({
       }
     })();
     return () => { cancelled = true; };
-  }, [workspaceId, activeTab, isReady]);
+  }, [workspaceId, activeTab]);
 
   // ── Default markdown files to preview mode when opened ──
   useEffect(() => {

--- a/apps/desktop/src/components/apps/coding/file-tree/FileTree.tsx
+++ b/apps/desktop/src/components/apps/coding/file-tree/FileTree.tsx
@@ -11,8 +11,7 @@ import { FileIcon } from './file-icons';
 import { FileTreeContextMenu } from './file-tree-context-menu';
 import { moveItem, renameItem } from './file-tree-ops';
 import { cn } from '@sero/ui/lib/utils';
-import { useContainerStore } from '@/stores/container';
-import { useActiveWorkspace } from '@/stores/workspace';
+
 
 /* ── Types ───────────────────────────────────────────────────── */
 
@@ -92,16 +91,6 @@ export function FileTree({
   const loadingRef = useRef<Set<string>>(new Set());
   const expandedRef = useRef<Set<string>>(new Set([rootId]));
 
-  // Container readiness — mirrors the pattern in EditorPanel.
-  // Non-container workspaces are always ready; container workspaces
-  // must wait for the container to reach "running" status.
-  const containerStatus = useContainerStore(
-    (s) => s.containers[workspaceId]?.status ?? 'none',
-  );
-  const activeWorkspace = useActiveWorkspace();
-  const isContainerWorkspace = activeWorkspace?.container ?? true;
-  const isReady = isContainerWorkspace ? containerStatus === 'running' : true;
-
   /* ── Reset state when workspace / root changes ────────────
    *
    * `items` is initialised once on mount. When the user switches to a
@@ -129,7 +118,6 @@ export function FileTree({
   /* ── Load directory ──────────────────────────────────────── */
 
   const loadDirectory = useCallback(async (dirPath: string) => {
-    if (!isReady) return; // Container not running yet — skip to avoid errors
     if (loadingRef.current.has(dirPath)) return;
     loadingRef.current.add(dirPath);
     try {
@@ -158,9 +146,9 @@ export function FileTree({
     } finally {
       loadingRef.current.delete(dirPath);
     }
-  }, [workspaceId, isReady]);
+  }, [workspaceId]);
 
-  /* ── Load root on mount / when container becomes ready ──── */
+  /* ── Load root on mount / workspace change ────────────── */
 
   useEffect(() => { loadDirectory(rootId); }, [loadDirectory, rootId]);
 
@@ -301,7 +289,7 @@ export function FileTree({
   /* ── Render ──────────────────────────────────────────────── */
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto overflow-x-hidden">
+    <div className="flex h-full flex-col overflow-y-auto overflow-x-hidden" data-testid="file-tree">
       <Tree indent={INDENT} tree={tree} className="py-1">
         <AssistiveTreeDescription tree={tree} />
         {tree.getItems().map((item) => (
@@ -313,6 +301,7 @@ export function FileTree({
           >
             <TreeItem
               item={item}
+              data-testid={`file-tree-item-${item.getItemData()?.name ?? 'unknown'}`}
               className="hover:bg-white/[0.06] data-[selected=true]:bg-white/[0.10]"
             >
               <TreeItemLabel className="!px-1.5 !py-[3px]">

--- a/apps/desktop/src/components/layout/AppStoreDialog.tsx
+++ b/apps/desktop/src/components/layout/AppStoreDialog.tsx
@@ -94,7 +94,7 @@ export function AppStoreDialog({
                 <p className="text-sm text-[var(--text-secondary)]">No apps match “{searchQuery}”.</p>
               </div>
             ) : (
-              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 2xl:grid-cols-3">
+              <div className="grid grid-cols-2 2xl:grid-cols-3 gap-3">
                 {filteredApps.map((app) => (
                   <AppStoreCard
                     key={app.id}

--- a/apps/desktop/src/components/layout/WorkspaceTree.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceTree.tsx
@@ -317,6 +317,7 @@ function WorkspaceNode({
     <div>
       {/* Workspace header */}
       <button
+        data-testid={`workspace-node-${workspace.id}`}
         onClick={handleHeaderClick}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}

--- a/apps/desktop/src/hooks/useSessionAgent.ts
+++ b/apps/desktop/src/hooks/useSessionAgent.ts
@@ -41,11 +41,13 @@ export function useSessionAgent() {
 
     if (!activeSession) return; // Sessions not loaded yet
 
-    // If already in the pool, just focus it
-    if (agents[activeSessionId]) {
+    // If fully initialized in the pool, just focus it.
+    // Partial entries (from events arriving before openSession) won't
+    // have a sessionId field — route those through openSession to repair.
+    if (agents[activeSessionId]?.sessionId) {
       focusSession(activeSessionId);
     } else {
-      // Opens in pool + focuses
+      // Opens in pool + focuses (also repairs partial entries)
       openSession(activeSessionId, activeSession.path, activeSession.workspaceId);
     }
   }, [activeSessionId, activeSession?.id]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -94,29 +94,36 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   showThinkingBlocks: false,
 
   openSession: async (sessionId, sessionPath, workspaceId) => {
-    // If already in pool, just focus it
-    if (get().agents[sessionId]) {
+    // If already fully initialized in pool, just focus it.
+    // Check for `sessionId` field — partial entries created by events
+    // (e.g. when a federated app calls agent.open via IPC directly)
+    // won't have it set and need to be repaired.
+    if (get().agents[sessionId]?.sessionId) {
       set({ focusedSessionId: sessionId });
       return;
     }
 
-    // Create placeholder immediately so UI shows loading state
-    set((s) => ({
-      agents: {
-        ...s.agents,
-        [sessionId]: {
-          sessionId,
-          sessionPath,
-          workspaceId,
-          messages: [],
-          isStreaming: false,
-          error: null,
-          commands: [],
-          modelState: null,
+    // Create or repair placeholder — preserve any messages/state
+    // accumulated from events before the store was properly initialized.
+    set((s) => {
+      const partial = s.agents[sessionId];
+      return {
+        agents: {
+          ...s.agents,
+          [sessionId]: {
+            sessionId,
+            sessionPath,
+            workspaceId,
+            messages: partial?.messages ?? [],
+            isStreaming: partial?.isStreaming ?? false,
+            error: partial?.error ?? null,
+            commands: partial?.commands ?? [],
+            modelState: partial?.modelState ?? null,
+          },
         },
-      },
-      focusedSessionId: sessionId,
-    }));
+        focusedSessionId: sessionId,
+      };
+    });
 
     try {
       const history = await window.sero.agent.open(sessionId, sessionPath, workspaceId);

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -23,6 +23,9 @@ interface PersistedLayoutState {
   mainSidebarOpen: boolean;
   chatPanelOpen: boolean;
   favouriteApps: string[];
+  /** Persisted panel size percentages (0–100). */
+  mainSidebarSizePct?: number;
+  chatPanelSizePct?: number;
 }
 
 // ── Theme ──────────────────────────────────────────────────────
@@ -51,6 +54,12 @@ interface AppState {
   chatPanelOpen: boolean;
   setChatPanelOpen: (open: boolean) => void;
   toggleChatPanel: () => void;
+
+  // Panel sizes (persisted percentages)
+  mainSidebarSizePct: number;
+  setMainSidebarSizePct: (pct: number) => void;
+  chatPanelSizePct: number;
+  setChatPanelSizePct: (pct: number) => void;
 
   // Favourites (sidebar-visible discovered apps)
   favouriteApps: string[];
@@ -115,8 +124,16 @@ function normaliseFavouriteApps(favouriteApps: string[] | undefined): string[] {
   return next;
 }
 
-/** Fire-and-forget save of layout state to disk. */
-function persistLayout(state: PersistedLayoutState) {
+/** Fire-and-forget save of full layout state to disk. */
+function persistLayout(partial: Partial<PersistedLayoutState>) {
+  const s = useAppStore.getState();
+  const state: PersistedLayoutState = {
+    mainSidebarOpen: partial.mainSidebarOpen ?? s.mainSidebarOpen,
+    chatPanelOpen: partial.chatPanelOpen ?? s.chatPanelOpen,
+    favouriteApps: partial.favouriteApps ?? s.favouriteApps,
+    mainSidebarSizePct: partial.mainSidebarSizePct ?? s.mainSidebarSizePct,
+    chatPanelSizePct: partial.chatPanelSizePct ?? s.chatPanelSizePct,
+  };
   window.sero.layout.save(state).catch((err) => {
     console.warn('[app-store] Failed to persist layout:', err);
   });
@@ -155,40 +172,36 @@ export const useAppStore = create<AppState>((set, get) => ({
   mainSidebarOpen: true,
   setMainSidebarOpen: (open) => {
     set({ mainSidebarOpen: open });
-    persistLayout({
-      mainSidebarOpen: open,
-      chatPanelOpen: get().chatPanelOpen,
-      favouriteApps: get().favouriteApps,
-    });
+    persistLayout({ mainSidebarOpen: open });
   },
   toggleMainSidebar: () => {
     const next = !get().mainSidebarOpen;
     set({ mainSidebarOpen: next });
-    persistLayout({
-      mainSidebarOpen: next,
-      chatPanelOpen: get().chatPanelOpen,
-      favouriteApps: get().favouriteApps,
-    });
+    persistLayout({ mainSidebarOpen: next });
   },
 
   // Chat panel — defaults to true; hydrated from disk by loadLayout()
   chatPanelOpen: true,
   setChatPanelOpen: (open) => {
     set({ chatPanelOpen: open });
-    persistLayout({
-      mainSidebarOpen: get().mainSidebarOpen,
-      chatPanelOpen: open,
-      favouriteApps: get().favouriteApps,
-    });
+    persistLayout({ chatPanelOpen: open });
   },
   toggleChatPanel: () => {
     const next = !get().chatPanelOpen;
     set({ chatPanelOpen: next });
-    persistLayout({
-      mainSidebarOpen: get().mainSidebarOpen,
-      chatPanelOpen: next,
-      favouriteApps: get().favouriteApps,
-    });
+    persistLayout({ chatPanelOpen: next });
+  },
+
+  // Panel sizes — defaults; hydrated from disk by loadLayout()
+  mainSidebarSizePct: 20,
+  setMainSidebarSizePct: (pct) => {
+    set({ mainSidebarSizePct: pct });
+    persistLayout({ mainSidebarSizePct: pct });
+  },
+  chatPanelSizePct: 30,
+  setChatPanelSizePct: (pct) => {
+    set({ chatPanelSizePct: pct });
+    persistLayout({ chatPanelSizePct: pct });
   },
 
   favouriteApps: [...DEFAULT_FAVOURITE_APP_IDS],
@@ -201,11 +214,7 @@ export const useAppStore = create<AppState>((set, get) => ({
       : [...current.favouriteApps, appId];
 
     set({ favouriteApps: next });
-    persistLayout({
-      mainSidebarOpen: current.mainSidebarOpen,
-      chatPanelOpen: current.chatPanelOpen,
-      favouriteApps: next,
-    });
+    persistLayout({ favouriteApps: next });
   },
   isFavourite: (appId) => get().favouriteApps.includes(appId),
 
@@ -236,12 +245,19 @@ export async function loadLayout(): Promise<void> {
   try {
     const state = await window.sero.layout.load();
     if (state) {
-      useAppStore.setState({
+      const update: Partial<AppState> & { layoutReady: true } = {
         mainSidebarOpen: state.mainSidebarOpen,
         chatPanelOpen: state.chatPanelOpen,
         favouriteApps: normaliseFavouriteApps(state.favouriteApps),
         layoutReady: true,
-      });
+      };
+      if (typeof state.mainSidebarSizePct === 'number' && state.mainSidebarSizePct > 0) {
+        update.mainSidebarSizePct = state.mainSidebarSizePct;
+      }
+      if (typeof state.chatPanelSizePct === 'number' && state.chatPanelSizePct > 0) {
+        update.chatPanelSizePct = state.chatPanelSizePct;
+      }
+      useAppStore.setState(update);
       return;
     }
   } catch (err) {

--- a/apps/desktop/src/stores/coding-ui.ts
+++ b/apps/desktop/src/stores/coding-ui.ts
@@ -14,12 +14,18 @@ export interface WorkspaceCodingUi {
   sidebarOpen: boolean;
   activePanel: CodingPanel;
   terminalOpen: boolean;
+  /** Last expanded size of the coding sidebar (explorer) as percentage. */
+  codingSidebarSizePct: number;
+  /** Last expanded size of the terminal panel as percentage. */
+  terminalSizePct: number;
 }
 
 const DEFAULT_CODING_UI: WorkspaceCodingUi = {
   sidebarOpen: true,
   activePanel: 'explorer',
   terminalOpen: false,
+  codingSidebarSizePct: 0,
+  terminalSizePct: 30,
 };
 
 interface CodingUiState {

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -228,9 +228,21 @@ interface SeroTerminalAPI {
 
 interface SeroLayoutAPI {
   /** Save UI layout state to disk. */
-  save(state: { mainSidebarOpen: boolean; chatPanelOpen: boolean; favouriteApps: string[] }): Promise<void>;
+  save(state: {
+    mainSidebarOpen: boolean;
+    chatPanelOpen: boolean;
+    favouriteApps: string[];
+    mainSidebarSizePct?: number;
+    chatPanelSizePct?: number;
+  }): Promise<void>;
   /** Load UI layout state from disk. Returns null if no saved state. */
-  load(): Promise<{ mainSidebarOpen: boolean; chatPanelOpen: boolean; favouriteApps?: string[] } | null>;
+  load(): Promise<{
+    mainSidebarOpen: boolean;
+    chatPanelOpen: boolean;
+    favouriteApps?: string[];
+    mainSidebarSizePct?: number;
+    chatPanelSizePct?: number;
+  } | null>;
 }
 
 interface SeroNetAPI {

--- a/docs/node-pty-setup.md
+++ b/docs/node-pty-setup.md
@@ -14,9 +14,32 @@ This error is misleading — it looks like a PATH or binary issue, but it's
 actually a **native module ABI mismatch**. The prebuilt `.node` file was
 compiled against a different Node ABI than the one running.
 
-## How to Fix
+### Root cause (why the bundled install script doesn't help)
 
-Rebuild node-pty from source against the current Node version:
+node-pty's own install script runs `node scripts/prebuild.js || node-gyp
+rebuild`. The `prebuild.js` checks whether `prebuilds/darwin-arm64/`
+**exists as a directory** — it does (it ships with the package), so the
+script exits 0 and `node-gyp rebuild` never runs. **The ABI of the binary
+inside that directory is never verified.** This is the upstream bug.
+
+## Automatic Fix (postinstall)
+
+The monorepo root `package.json` has a `postinstall` script that runs
+`scripts/rebuild-node-pty.mjs`. This script:
+
+1. Spawns a **subprocess** that `require()`s node-pty and tries a real
+   `pty.spawn()` (catches ABI mismatches that only surface at fork time).
+2. If the smoke test passes → exits immediately (~60ms no-op).
+3. If it fails → runs `node-gyp rebuild` and re-verifies in a fresh
+   subprocess.
+
+**This runs automatically after every `pnpm install`.** You should never
+need to rebuild manually unless the postinstall itself fails (see
+Troubleshooting).
+
+## Manual Fix
+
+If the automatic rebuild fails or you need to rebuild for another reason:
 
 ```bash
 cd /path/to/sero/sero   # monorepo root (where node_modules/.pnpm lives)
@@ -27,6 +50,12 @@ This compiles `pty.node` and `spawn-helper` for the exact Node ABI in use.
 The rebuilt binary lands in `node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/build/Release/pty.node`.
 
 ### Verify it works
+
+```bash
+node scripts/rebuild-node-pty.mjs
+```
+
+Or manually:
 
 ```bash
 cd apps/desktop
@@ -44,14 +73,15 @@ Should print `PTY_WORKS`. If you see `posix_spawnp failed`, the rebuild
 didn't work — check that `node-gyp`, Python 3, and Xcode command-line tools
 are installed.
 
-## When to Rebuild
+## When Rebuild Happens
 
-Rebuild is needed after:
+The postinstall script handles all of these automatically:
 
-- **Changing Node version** (e.g. Volta/nvm switch, Node upgrade)
 - **Running `pnpm install`** — pnpm may restore the prebuild, overwriting
-  the locally compiled binary
-- **Switching machines** — prebuilds are arch-specific
+  the locally compiled binary → postinstall detects and rebuilds
+- **Changing Node version** (e.g. Volta/nvm switch, Node upgrade) → next
+  `pnpm install` triggers postinstall
+- **Switching machines** — prebuilds are arch-specific → postinstall detects
 
 ## Why This Happens
 

--- a/docs/plans/cli-tool-management.md
+++ b/docs/plans/cli-tool-management.md
@@ -1,0 +1,978 @@
+# Sero CLI Tool Management — Specification
+
+> **Status:** Draft
+> **Date:** 2026-02-23
+> **Goal:** Replace the majority of agent tool definitions with a single `sero` CLI,
+> reducing context window bloat while giving the agent more power through
+> composable shell commands and programmatic control over Sero itself.
+
+---
+
+## 1. Motivation
+
+### The Problem
+
+Every tool registered with the agent gets serialised into the LLM context as a
+tool definition (name, description, JSON schema). As extensions grow, so does
+the tool list:
+
+| Category | Tools | Approx. tokens |
+|---|---|---|
+| Core coding (bash, read, write, edit) | 4 | ~800 |
+| Workspace (ls, read_terminal, register_dev_server) | 3 | ~400 |
+| System (set_session_title) | 1 | ~100 |
+| Extensions (notes, todo, calc, quote, weight, plan_todos, spotify, starling, slopzilla, generate_image, question, questionnaire, interview) | 13 | ~2,600 |
+| **Total** | **~21** | **~3,900** |
+
+Beyond raw token cost, every tool definition is noise that the model must reason
+over when deciding which tool to call. More tools → more ambiguity → worse tool
+selection → more wasted turns.
+
+### The Opportunity
+
+Container workspaces already execute everything via `bash`. The agent is fluent
+in shell commands. Instead of 21 tool definitions, we can provide:
+
+- **4 core tools** (bash, read, write, edit) — structured I/O that genuinely
+  benefits from typed schemas
+- **1 CLI** (`sero`) — everything else, discoverable via `sero help`
+
+This also unlocks:
+
+1. **Multi-step composition** — `sero notes add ... && sero todo add ...` in
+   one bash call eliminates intermediate round-trips
+2. **Self-documenting** — `sero help <command>` replaces static tool
+   descriptions with dynamic, detailed help text
+3. **Extensibility** — new commands don't change the tool schema
+4. **Sero meta-control** — the agent can programmatically control the app itself
+   (model switching, thinking level, workspace management, etc.)
+
+### Before & After
+
+```
+BEFORE (per turn):
+  System prompt: ...tools... [21 tool definitions, ~3,900 tokens]
+  Agent: calls notes({ action: "add", title: "...", body: "..." })
+  → round trip
+  Agent: calls todo({ action: "add", text: "..." })
+  → round trip
+  Agent: calls set_session_title({ title: "..." })
+  → round trip
+  (3 tool calls = 3 LLM round-trips)
+
+AFTER (per turn):
+  System prompt: ...tools... [4 tool definitions, ~800 tokens]
+  Agent: calls bash({
+    command: 'sero notes add --title "..." --body "..." && \
+             sero todo add "..." && \
+             sero title "..."'
+  })
+  → 1 round trip
+  (1 bash call = 1 LLM round-trip)
+```
+
+---
+
+## 2. Architecture Overview
+
+```
+┌─ Container ──────────────────────────────────┐
+│                                              │
+│  Agent (LLM)                                 │
+│    │                                         │
+│    ├─ bash tool ──► sero <command>           │
+│    ├─ read tool                              │
+│    ├─ write tool                             │
+│    └─ edit tool                              │
+│                                              │
+│  sero CLI binary                             │
+│    ├─ File-based commands ──► .sero/ state   │
+│    ├─ Host API commands ─────────────────────┼──► Sero Host API
+│    └─ Control commands ──────────────────────┼──► Sero Host API
+│                                              │
+└──────────────────────────────────────────────┘
+
+┌─ Electron Main Process ─────────────────────┐
+│                                              │
+│  Sero Host API (HTTP server)                 │
+│    ├─ /api/ext/*        Extension actions    │
+│    ├─ /api/control/*    App control (IPC)    │
+│    └─ /api/ask          User interaction     │
+│                                              │
+│  Existing IPC handlers                       │
+│    ├─ Agent pool                             │
+│    ├─ Workspace manager                      │
+│    └─ Container manager                      │
+│                                              │
+└──────────────────────────────────────────────┘
+```
+
+### Command Tiers
+
+The CLI organises commands into three tiers based on trust level:
+
+| Tier | Description | Auth | Examples |
+|---|---|---|---|
+| **Local** | File-based state, no host communication | None | `notes`, `todo`, `calc`, `weight`, `quote` |
+| **Host** | Requires host API call (external APIs, UI) | Session token | `spotify`, `image`, `starling`, `ask`, `terminal` |
+| **Control** | Mutates Sero app state via Electron IPC | Session token + permission guard | `control model`, `control thinking`, `control workspace`, `control tools` |
+
+---
+
+## 3. CLI Design
+
+### 3.1 Installation & Distribution
+
+The CLI is a self-contained Node.js script bundled as part of Sero. It is
+**mounted read-only** into containers alongside skills and prompts:
+
+```typescript
+// In buildContainerConfig():
+readOnlyMounts: [
+  path.join(SERO_AGENT_DIR, 'skills'),
+  path.join(SERO_AGENT_DIR, 'prompts'),
+  path.join(SERO_AGENT_DIR, 'cli'),       // ← NEW
+],
+```
+
+A symlink or shell wrapper at `/usr/local/bin/sero` inside the container points
+to the mounted script:
+
+```bash
+# Created during container setup (lifecycle.ts)
+ln -sf /path/to/mounted/cli/sero.mjs /usr/local/bin/sero
+```
+
+For **filesystem workspaces**, the same script runs directly on the host via
+Node.js. See §7 for details.
+
+### 3.2 Command Structure
+
+```
+sero <command> [subcommand] [args] [flags]
+sero help [command]
+sero --version
+```
+
+**Global flags:**
+
+| Flag | Description |
+|---|---|
+| `--help`, `-h` | Show help for the command |
+| `--json` | Output as JSON (for programmatic parsing) |
+| `--quiet`, `-q` | Suppress non-essential output |
+
+### 3.3 Help System
+
+The help system is the primary way the agent discovers CLI capabilities. It
+replaces static tool descriptions in the system prompt.
+
+#### Top-level help
+
+```
+$ sero help
+
+Sero CLI — workspace tools, integrations, and app control.
+
+USAGE
+  sero <command> [subcommand] [args] [flags]
+  sero help <command>
+
+COMMANDS
+  notes        Manage workspace notes (add, edit, list, pin, remove, show)
+  todo         Manage todo list (add, toggle, list, clear)
+  calc         Evaluate math expressions
+  quote        Daily inspirational quote
+  weight       Track weight over time
+  plan         Plan mode and task management
+  spotify      Control Spotify playback and playlists
+  image        Generate images with AI
+  starling     View Starling Bank account info
+  slopzilla    View SlopZilla history and bookmarks
+  ask          Ask the user a question with options
+  survey       Ask the user multiple questions
+  interview    Ask the user open-ended questions
+  title        Set the session title
+  terminal     Read recent terminal output
+  dev-server   Register a dev server with the host
+  control      Control Sero app settings (model, thinking, tools, workspace)
+
+GLOBAL FLAGS
+  --help, -h    Show help for a command
+  --json        Output as JSON
+  --quiet, -q   Suppress non-essential output
+
+EXAMPLES
+  sero notes add --title "API Design" --body "REST vs GraphQL comparison"
+  sero todo add "Fix login bug" && sero todo add "Write tests"
+  sero calc "sqrt(144) + 2^3"
+  sero control model set anthropic/claude-sonnet-4-6
+  sero help notes
+
+Run 'sero help <command>' for detailed usage of any command.
+```
+
+#### Command-level help
+
+Each command provides detailed help with all subcommands, flags, and examples:
+
+```
+$ sero help notes
+
+Manage workspace notes — create, edit, search, and organise notes.
+
+USAGE
+  sero notes <action> [flags]
+
+ACTIONS
+  list                List all notes (newest first)
+  add                 Create a new note
+  show <id>           Show full note content
+  edit <id>           Edit an existing note
+  remove <id>         Remove a note
+  pin <id>            Pin a note to the top
+  unpin <id>          Unpin a note
+
+FLAGS
+  --title <text>      Note title (required for add)
+  --body <text>       Note body (required for add, optional for edit)
+  --query <text>      Search filter (for list)
+  --id <number>       Note ID (alternative to positional arg)
+  --json              Output as JSON
+
+EXAMPLES
+  sero notes list
+  sero notes list --query "design"
+  sero notes add --title "Meeting Notes" --body "Discussed Q1 roadmap..."
+  sero notes show 3
+  sero notes edit 3 --body "Updated: added action items"
+  sero notes pin 1
+  sero notes remove 5
+```
+
+```
+$ sero help control
+
+Control Sero app settings — model, thinking level, tools, and workspaces.
+
+USAGE
+  sero control <resource> <action> [args]
+
+RESOURCES
+  model               Manage the active LLM model
+    show              Show current model (provider/id)
+    set <model>       Set model (e.g. "anthropic/claude-sonnet-4-6")
+    list              List available models
+
+  thinking            Manage thinking/reasoning level
+    show              Show current level
+    set <level>       Set level (off, minimal, low, medium, high, xhigh)
+
+  tools               Manage active tool set
+    list              List all tools with active/inactive status
+    enable <name>     Enable a tool
+    disable <name>    Disable a tool
+    reset             Reset to default tool set
+
+  workspace           Manage workspaces
+    list              List all workspaces with open/closed status
+    info [id]         Show workspace details (default: current)
+    open <id>         Open a workspace in sidebar
+    close <id>        Close a workspace from sidebar
+
+  session             Session information
+    info              Show session path, token usage, cost
+    title <text>      Set session display name
+    compact           Trigger context compaction
+
+  prompt              System prompt management
+    show              Display current system prompt
+    append <text>     Append text to system prompt for this session
+
+PERMISSIONS
+  Control commands require the SERO_CONTROL permission level.
+  Some actions (model set, tools disable) are guarded by the workspace
+  permission policy. See §6 for details.
+
+EXAMPLES
+  sero control model show
+  sero control model set anthropic/claude-sonnet-4-6
+  sero control thinking set high
+  sero control tools list
+  sero control tools disable starling
+  sero control workspace list
+  sero control session info
+  sero control session compact
+```
+
+### 3.4 Output Format
+
+**Default:** Human-readable text, designed for LLM consumption. Concise, no
+decoration, no colour codes.
+
+```
+$ sero notes list
+1. [pinned] API Design
+   REST vs GraphQL comparison...
+2. Meeting Notes
+   Discussed Q1 roadmap with team...
+3. Bug Triage
+   Login timeout issue on Safari...
+
+3 notes (1 pinned)
+```
+
+**JSON mode (`--json`):** Structured output for programmatic use.
+
+```json
+$ sero notes list --json
+{
+  "notes": [
+    { "id": 1, "title": "API Design", "pinned": true, "body": "REST vs GraphQL..." },
+    { "id": 2, "title": "Meeting Notes", "pinned": false, "body": "Discussed Q1..." }
+  ],
+  "count": 2
+}
+```
+
+### 3.5 Error Handling
+
+Errors use non-zero exit codes and write to stderr, consistent with Unix
+conventions and the existing bash tool behaviour (which throws on non-zero exit,
+surfacing the error to the agent):
+
+```
+$ sero notes show 999
+Error: Note 999 not found.
+$ echo $?
+1
+```
+
+```
+$ sero control model set nonexistent/model
+Error: Model "nonexistent/model" not found. Run 'sero control model list' to see available models.
+$ echo $?
+1
+```
+
+---
+
+## 4. Command Reference
+
+### 4.1 Local Commands (File-Based State)
+
+These commands read/write JSON state files in `.sero/apps/<name>/state.json`
+relative to the workspace root. They require no host communication.
+
+| Command | Replaces Tool | State Path |
+|---|---|---|
+| `sero notes <action>` | `notes` | `.sero/apps/notes/state.json` |
+| `sero todo <action>` | `todo` | `.sero/apps/todo/state.json` |
+| `sero calc <expression>` | `calc` | `.sero/apps/calc/state.json` |
+| `sero quote [get\|set]` | `daily_quote` | `.sero/apps/daily_quote/state.json` |
+| `sero weight <action>` | `weight` | `.sero/apps/weight/state.json` |
+| `sero plan <action>` | `plan_todos` | `.sero/apps/planmode/state.json` |
+| `sero slopzilla <action>` | `slopzilla` | `.sero/apps/slopzilla/state.json` |
+
+**State format compatibility:** The CLI uses the exact same JSON schema as the
+existing extensions. This means:
+
+- Existing state files work without migration
+- The UI components that read state (if any) continue to work
+- Extensions and CLI can coexist during migration
+
+### 4.2 Host API Commands
+
+These commands require communication with the Sero Electron main process via
+the Host API (see §5).
+
+| Command | Replaces Tool | Host Endpoint |
+|---|---|---|
+| `sero spotify <action>` | `spotify` | `POST /api/ext/spotify` |
+| `sero image generate <prompt>` | `generate_image` | `POST /api/ext/image` |
+| `sero starling <action>` | `starling` | `POST /api/ext/starling` |
+| `sero ask <question> --options ...` | `question` | `POST /api/ask` |
+| `sero survey --questions ...` | `questionnaire` | `POST /api/survey` |
+| `sero interview --questions ...` | `interview` | `POST /api/interview` |
+| `sero title <text>` | `set_session_title` | `POST /api/ext/title` |
+| `sero terminal [--lines N]` | `read_terminal` | `GET /api/ext/terminal` |
+| `sero dev-server register <name> ...` | `register_dev_server` | `POST /api/ext/dev-server` |
+
+#### User Interaction Commands
+
+The `ask`, `survey`, and `interview` commands are blocking — the CLI sends a
+request to the host, the host displays UI to the user, and the CLI waits for
+the response:
+
+```
+$ sero ask "Which database should we use?" --options "PostgreSQL" "SQLite" "MongoDB"
+> User selected: PostgreSQL
+PostgreSQL
+```
+
+The bash tool's timeout parameter provides a natural timeout mechanism. The host
+API also supports a `timeout` query parameter for server-side timeout.
+
+#### Image Generation
+
+Since CLI stdout is text-only, generated images are saved to disk:
+
+```
+$ sero image generate "A sunset over mountains" --output /workspace/sunset.png
+Image saved to /workspace/sunset.png (1024x1024, 245KB)
+```
+
+The agent can then use the `read` tool to view the image if needed.
+
+### 4.3 Control Commands (Sero App Control)
+
+These commands expose Electron IPC methods, giving the agent programmatic
+control over Sero itself. This is the most powerful tier and requires guards.
+
+| Command | IPC Channel | Guard Level |
+|---|---|---|
+| `sero control model show` | `agent:getModelState` | read |
+| `sero control model set <model>` | `agent:setModel` | write |
+| `sero control model list` | `agent:getModelState` | read |
+| `sero control thinking show` | `agent:getModelState` | read |
+| `sero control thinking set <level>` | `agent:setThinkingLevel` | write |
+| `sero control tools list` | `agent:getContext` | read |
+| `sero control tools enable <name>` | `agent:setContextOverrides` | write |
+| `sero control tools disable <name>` | `agent:setContextOverrides` | write |
+| `sero control tools reset` | `agent:setContextOverrides` | write |
+| `sero control workspace list` | `workspace:list` | read |
+| `sero control workspace info [id]` | `workspace:getConfig` | read |
+| `sero control workspace open <id>` | `workspace:open` | write |
+| `sero control workspace close <id>` | `workspace:close` | write |
+| `sero control session info` | `agent:getUsage` | read |
+| `sero control session compact` | internal | write |
+| `sero control prompt show` | `agent:getContext` | read |
+| `sero control prompt append <text>` | `before_agent_start` hook | write |
+
+#### Future Control Expansions
+
+The control tier is designed to grow. Potential future commands:
+
+- `sero control container restart` — restart the workspace container
+- `sero control extension reload` — hot-reload extensions
+- `sero control checkpoint create` — create a VCS checkpoint
+- `sero control checkpoint restore <id>` — restore to a checkpoint
+- `sero control window focus <panel>` — focus a UI panel
+
+---
+
+## 5. Host Communication
+
+### 5.1 Sero Host API Server
+
+The Electron main process runs a lightweight HTTP server accessible from
+containers. This is the bridge between the CLI and Sero's internals.
+
+#### Server Setup
+
+```typescript
+// New file: electron/api/server.ts
+
+import http from 'node:http';
+
+export interface HostApiOptions {
+  sessionId: string;
+  workspaceId: string;
+  containerManager: ContainerManager;
+  workspaceManager: WorkspaceManager;
+  agentPool: Map<string, PoolEntry>;
+  permissionPolicy: PermissionPolicy;
+}
+
+export function createHostApiServer(options: HostApiOptions): http.Server {
+  const server = http.createServer(async (req, res) => {
+    // Auth: validate session token from Authorization header
+    const token = req.headers.authorization?.replace('Bearer ', '');
+    if (token !== options.sessionToken) {
+      res.writeHead(401);
+      res.end('Unauthorized');
+      return;
+    }
+
+    // Route to handlers...
+  });
+
+  // Listen on random port, bind to localhost only
+  server.listen(0, '127.0.0.1');
+  return server;
+}
+```
+
+#### Environment Injection
+
+The API server URL and auth token are injected as environment variables during
+container creation and command execution:
+
+```typescript
+// In ContainerManager.exec():
+envParts.push(
+  `SERO_API_URL=http://host.containers.internal:${apiPort}`,
+  `SERO_API_TOKEN=${sessionToken}`,
+  `SERO_SESSION_ID=${sessionId}`,
+  `SERO_WORKSPACE_ID=${workspaceId}`,
+);
+```
+
+The CLI reads these from the environment:
+
+```typescript
+const apiUrl = process.env.SERO_API_URL;
+const apiToken = process.env.SERO_API_TOKEN;
+```
+
+### 5.2 API Protocol
+
+All endpoints accept/return JSON. Standard HTTP status codes.
+
+#### Extension Endpoints
+
+```
+POST /api/ext/:name
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{ "action": "list", "query": "design" }
+
+→ 200 OK
+{ "result": { "notes": [...], "count": 3 } }
+```
+
+Extension endpoints are generic — the `:name` maps to the extension name, and
+the body is passed to the extension's execute function.
+
+#### User Interaction Endpoints
+
+```
+POST /api/ask
+Content-Type: application/json
+
+{
+  "question": "Which database?",
+  "options": [
+    { "label": "PostgreSQL", "description": "Mature, full-featured" },
+    { "label": "SQLite", "description": "Lightweight, embedded" }
+  ],
+  "timeout": 60000
+}
+
+→ 200 OK (blocks until user responds)
+{ "answer": "PostgreSQL" }
+```
+
+#### Control Endpoints
+
+```
+POST /api/control/:resource/:action
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{ "value": "anthropic/claude-sonnet-4-6" }
+
+→ 200 OK
+{ "result": { "model": "claude-sonnet-4-6", "provider": "anthropic" } }
+
+→ 403 Forbidden (if permission denied)
+{ "error": "Action 'model.set' is not permitted by workspace policy" }
+```
+
+### 5.3 Error Responses
+
+```json
+{
+  "error": "Description of the error",
+  "code": "NOT_FOUND",
+  "details": {}
+}
+```
+
+Standard error codes: `UNAUTHORIZED`, `FORBIDDEN`, `NOT_FOUND`, `BAD_REQUEST`,
+`TIMEOUT`, `INTERNAL_ERROR`.
+
+---
+
+## 6. Permission & Guard System
+
+### 6.1 Rationale
+
+Exposing Electron IPC via CLI gives the agent significant power. Without guards,
+the agent could:
+
+- Switch to cheaper/weaker models mid-task
+- Disable safety-relevant tools
+- Close workspaces the user has open
+- Trigger expensive operations (mass compaction)
+
+The permission system provides defence-in-depth while keeping the default
+experience frictionless.
+
+### 6.2 Permission Policy
+
+Each workspace's `.sero-workspace.json` can define a CLI permission policy:
+
+```json
+{
+  "id": "my-project",
+  "name": "My Project",
+  "container": true,
+  "cli": {
+    "permissions": {
+      "control.model.set": "ask",
+      "control.thinking.set": "allow",
+      "control.tools.disable": "deny",
+      "control.workspace.close": "deny",
+      "control.session.compact": "allow",
+      "control.prompt.append": "allow"
+    }
+  }
+}
+```
+
+#### Permission Levels
+
+| Level | Behaviour |
+|---|---|
+| `allow` | Execute immediately, no confirmation |
+| `ask` | Show confirmation dialog to user before executing |
+| `deny` | Block with error message |
+
+#### Defaults
+
+If no policy is defined, sensible defaults apply:
+
+| Action Pattern | Default |
+|---|---|
+| `control.*.show`, `control.*.list`, `control.*.info` | `allow` |
+| `control.model.set` | `ask` |
+| `control.thinking.set` | `allow` |
+| `control.tools.enable` | `allow` |
+| `control.tools.disable` | `ask` |
+| `control.tools.reset` | `allow` |
+| `control.workspace.open` | `allow` |
+| `control.workspace.close` | `ask` |
+| `control.session.compact` | `allow` |
+| `control.prompt.append` | `allow` |
+| All extension commands | `allow` |
+| All local commands | `allow` |
+
+#### Guard Implementation
+
+```typescript
+// In host API server:
+async function checkPermission(
+  action: string,
+  policy: PermissionPolicy,
+  askUser: (question: string) => Promise<boolean>,
+): Promise<boolean> {
+  const level = policy[action] ?? getDefaultLevel(action);
+
+  switch (level) {
+    case 'allow': return true;
+    case 'deny': return false;
+    case 'ask': return askUser(`Agent wants to: ${describeAction(action)}`);
+  }
+}
+```
+
+When an `ask` action is triggered, the host shows a confirmation dialog in the
+Sero UI. The CLI blocks until the user responds.
+
+### 6.3 Audit Log
+
+All control commands are logged to `.sero/cli-audit.jsonl` in the workspace:
+
+```jsonl
+{"ts":"2026-02-23T10:30:00Z","action":"control.model.set","args":{"model":"claude-sonnet-4-6"},"result":"allowed"}
+{"ts":"2026-02-23T10:30:05Z","action":"control.tools.disable","args":{"tool":"starling"},"result":"denied","reason":"policy"}
+```
+
+This provides visibility into what the agent changed and when.
+
+---
+
+## 7. Workspace Type Support
+
+### 7.1 Container Workspaces (Primary)
+
+Container workspaces are the primary target for the CLI. The CLI binary is
+mounted read-only and symlinked into the PATH during container setup.
+
+**Advantages:**
+- Full isolation — CLI runs inside the sandbox
+- Environment variables injected automatically
+- All file-based state is within `/workspace/.sero/`
+- Host API accessible via `host.containers.internal`
+
+### 7.2 Filesystem Workspaces
+
+Filesystem workspaces currently run Pi SDK tools directly on the host. The CLI
+can also run on the host with the same security model.
+
+**Recommendation: Support CLI on filesystem workspaces.**
+
+Rationale:
+- The CLI performs the same operations as existing tools (read/write JSON, call
+  APIs) — it is no more dangerous than what `bash` already allows
+- For pure local commands (notes, todos, etc.), the CLI just reads/writes files
+  in `.sero/` — identical to what extensions do today
+- For host API commands, the CLI communicates with the same Electron process
+  that's already running
+- The control commands have the same permission guards regardless of workspace
+  type
+
+**Implementation for filesystem mode:**
+
+```typescript
+// In agent.ts, when container is disabled:
+const builtinTools = createCodingTools(wsPath);
+
+// Inject SERO_* env vars into the bash tool's environment so the
+// CLI can reach the host API when run via bash
+```
+
+The `SERO_API_URL` points to `http://127.0.0.1:<port>` (localhost) instead of
+`host.containers.internal`.
+
+### 7.3 Ad-hoc Container Approach (Not Recommended)
+
+The user asked about spinning up an ephemeral container just for CLI execution
+on filesystem workspaces. This is **not recommended** because:
+
+1. **Overhead** — Container startup adds 2-5 seconds per CLI call
+2. **State mismatch** — Container would need workspace mounted, adding complexity
+3. **No security benefit** — The CLI's operations (file I/O, HTTP calls) don't
+   benefit from container isolation
+4. **Complexity** — Managing ephemeral containers alongside long-lived workspace
+   containers adds significant code
+
+The host-direct approach for filesystem workspaces is simpler, faster, and
+equally safe.
+
+---
+
+## 8. System Prompt Changes
+
+### 8.1 Current System Prompt (Tool Section)
+
+Currently, all ~21 tool definitions are serialised into the system prompt by the
+LLM provider SDK. Each tool includes name, description, and full JSON schema.
+
+### 8.2 New System Prompt Addition
+
+The container system prompt (`system-prompt.ts`) gains a CLI section:
+
+```markdown
+## Sero CLI
+
+The `sero` command-line tool is available for workspace management,
+productivity tools, integrations, and Sero app control. Use it via bash.
+
+**Discovery:** Run `sero help` to see all available commands, or
+`sero help <command>` for detailed usage of a specific command.
+
+**Common commands:**
+- `sero notes`, `sero todo` — Workspace notes and todos
+- `sero ask "question" --options "A" "B"` — Ask the user a question
+- `sero control model set <model>` — Switch LLM model
+- `sero control session info` — View token usage and cost
+
+**Tips:**
+- Chain commands: `sero notes add --title "X" --body "Y" && sero todo add "Z"`
+- Use `--json` for structured output: `sero notes list --json`
+- Use `--quiet` to suppress non-essential output
+```
+
+This replaces ~3,100 tokens of tool definitions with ~200 tokens of guidance.
+The agent calls `sero help` on first use to discover the full command set (the
+output is cached across turns via normal context).
+
+### 8.3 Retained Native Tools
+
+Only 4 tools remain as native tool definitions:
+
+| Tool | Reason |
+|---|---|
+| `bash` | Vehicle for CLI calls; complex schema (command, timeout) |
+| `read` | Returns images as base64 content blocks; offset/limit pagination |
+| `write` | Atomic file creation with parent directories |
+| `edit` | Fuzzy text matching, diff output, BOM handling |
+
+These tools benefit from structured input/output that can't be replicated as
+effectively via CLI stdout.
+
+---
+
+## 9. Plan Mode Adaptation
+
+Plan mode (`pi-plan-mode-extension`) currently uses `pi.setActiveTools()` to
+restrict available tools. In the CLI model:
+
+### Option A: Keep plan mode as native extension (Recommended for MVP)
+
+Plan mode's core value is **tool filtering** — a meta-operation. The extension
+continues to call `pi.setActiveTools()` to restrict the 4 native tools. CLI
+commands don't need filtering because they're invoked via `bash`, and the bash
+tool can be disabled/enabled by the plan mode extension.
+
+When plan mode is active:
+- Native tools: `bash` (read-only commands only), `read`
+- CLI: Available via bash (but bash is restricted to safe commands)
+
+### Option B: CLI-native plan mode (Future)
+
+```bash
+$ sero plan start
+Plan mode enabled. Read-only tools active.
+
+$ sero plan set "Step 1: Analyse auth module" "Step 2: Refactor tokens"
+Plan created (2 steps)
+
+$ sero plan complete 1
+✓ Step 1 completed (1/2)
+
+$ sero plan execute
+Execution mode enabled. Full tool access restored.
+```
+
+The `sero plan start` command calls the host API to invoke
+`pi.setActiveTools()` on the agent session.
+
+---
+
+## 10. Extension Integration
+
+### 10.1 How Extensions Register CLI Commands
+
+Extensions that want to provide CLI commands register them via a new
+`pi.registerCliCommand()` API:
+
+```typescript
+// In an extension:
+pi.registerCliCommand('myext', {
+  description: 'My custom extension',
+  subcommands: {
+    list: { description: 'List items', handler: async (args) => { ... } },
+    add: { description: 'Add item', handler: async (args) => { ... } },
+  },
+});
+```
+
+The CLI discovers available commands by reading a manifest file written by the
+extension loader:
+
+```
+.sero/cli/manifest.json
+{
+  "commands": {
+    "notes": { "type": "local", "description": "..." },
+    "spotify": { "type": "host", "endpoint": "/api/ext/spotify", "description": "..." },
+    "myext": { "type": "host", "endpoint": "/api/ext/myext", "description": "..." }
+  }
+}
+```
+
+For the initial implementation, all built-in extension commands are hardcoded in
+the CLI. The manifest-based approach is a future enhancement for third-party
+extensions.
+
+### 10.2 Coexistence During Migration
+
+During the migration period, both tool and CLI interfaces can coexist:
+
+1. **Phase 1:** CLI is available alongside existing tools. Agent can use either.
+   System prompt mentions CLI as preferred.
+2. **Phase 2:** Extension tools are removed from the tool registry. Agent uses
+   CLI exclusively. Extensions still run server-side for host API handling.
+3. **Phase 3:** Extensions that are purely file-based (notes, todo, etc.) are
+   replaced entirely by the CLI. Extensions that need host APIs (spotify, image)
+   keep a thin server-side handler.
+
+---
+
+## 11. Implementation Plan
+
+### Phase 1: Core CLI + Local Commands
+
+**Scope:** File-based commands only, no host API.
+
+1. Create `packages/sero-cli/` package
+   - CLI entry point with command parser (no external deps — use Node built-ins)
+   - Help system with `sero help` and `sero help <command>`
+   - Local commands: `notes`, `todo`, `calc`, `quote`, `weight`, `slopzilla`
+   - State file I/O matching existing extension JSON schemas
+   - `--json` output mode
+2. Build step produces `sero.mjs` (single file, bundled)
+3. Mount into containers via `readOnlyMounts`
+4. Symlink in container PATH during setup
+5. Update system prompt to mention CLI
+6. **Do not remove existing tools yet** — coexistence period
+
+### Phase 2: Host API + Extension Commands
+
+**Scope:** Host API server, host-dependent commands.
+
+1. Create `electron/api/server.ts` — lightweight HTTP API server
+2. Start API server during app init, inject URL/token into containers
+3. Add host API commands: `spotify`, `image`, `starling`, `ask`, `survey`,
+   `interview`, `title`, `terminal`, `dev-server`
+4. Add user interaction flow (blocking ask/survey/interview)
+5. Test cross-container communication
+
+### Phase 3: Control Commands + Permission System
+
+**Scope:** Sero app control via CLI, permission guards.
+
+1. Implement control endpoints bridging to Electron IPC
+2. Add permission policy to `.sero-workspace.json`
+3. Implement `ask` permission level with UI confirmation dialog
+4. Add audit logging
+5. Control commands: `model`, `thinking`, `tools`, `workspace`, `session`,
+   `prompt`
+
+### Phase 4: Tool Removal + Optimisation
+
+**Scope:** Remove extension tools, optimise context.
+
+1. Remove extension tool registrations (notes, todo, calc, etc.)
+2. Remove container-specific tools that moved to CLI (ls, read_terminal,
+   register_dev_server, set_session_title)
+3. Update plan mode to work with CLI-only model
+4. Benchmark: measure context size reduction, turn count, latency
+5. Update system prompt to remove tool-specific instructions
+
+### Phase 5: Extension CLI Registration (Future)
+
+**Scope:** Dynamic command registration for third-party extensions.
+
+1. Add `pi.registerCliCommand()` API
+2. Manifest file generation during extension loading
+3. CLI reads manifest for dynamic command discovery
+4. Help system includes dynamically registered commands
+
+---
+
+## 12. Open Questions
+
+1. **Should `read` and `write` move to CLI too?** They benefit from structured
+   output (image base64, diff details), but `cat` and file redirection are
+   close equivalents. Keeping them as native tools feels right for now.
+
+2. **Cache `sero help` output?** The agent will call `sero help` on first use.
+   The output enters the context and is available for subsequent turns. Should
+   we inject it preemptively in the system prompt instead? Probably not — it's
+   better to let the agent pull it on demand.
+
+3. **Should the CLI support pipes?** e.g., `sero notes list | grep "design"`.
+   Since commands run in bash, pipes work naturally. No special support needed.
+
+4. **WebSocket vs HTTP for blocking commands?** HTTP long-polling is simpler and
+   sufficient. WebSocket would be needed only if we want bidirectional streaming,
+   which isn't required for v1.
+
+5. **Control command scope:** Should some control commands be session-scoped
+   (e.g., model changes apply only to the current session) or global? Currently,
+   model and thinking changes are session-scoped in Sero, which is correct.

--- a/docs/specs/sero-cli-tool-spec.md
+++ b/docs/specs/sero-cli-tool-spec.md
@@ -1,0 +1,747 @@
+# Sero CLI Tool — Specification
+
+**AD-020: CLI Tool for Agent Context Reduction**
+
+> Replace individual agent tools with a single `sero-cli` tool backed by a
+> distributed command registry. Reduces context window bloat, enables multi-step
+> command chaining, and gives the agent programmatic control over the Sero
+> platform itself.
+
+---
+
+## 1. Problem
+
+The agent currently has **21 tools** in its context window — each with a full
+JSON schema (name, description, parameters). As the app matures and more
+packages are added, this grows linearly. This is sub-optimal because:
+
+- **Cost** — every tool schema is sent with every API request, consuming input
+  tokens on every turn.
+- **Performance** — larger system prompts increase time-to-first-token.
+- **Decision quality** — models perform worse with too many tool options
+  (selection confusion, unnecessary tool calls).
+- **No chaining** — each tool call is a separate round-trip. An operation like
+  "check todos then create a note" requires two turns.
+
+### Current tool inventory
+
+| Category | Tools | Count |
+|---|---|---|
+| Core coding | bash, read, write, edit | 4 |
+| Workspace ops | ls, read_terminal, register_dev_server | 3 |
+| Sero extension | set_session_title | 1 |
+| Package extensions | calc, daily_quote, generate_image, notes, plan_todos, slopzilla, spotify, starling, todo, question, questionnaire, weight, interview | 13 |
+| **Total** | | **21** |
+
+## 2. Solution Overview
+
+Introduce a **single `sero-cli` tool** that replaces all non-core tools. The
+agent invokes `sero-cli` with a command string (e.g. `todo list`, `notes create
+"Meeting notes"`), and Sero routes it to the appropriate handler.
+
+After this change, the agent context contains **5 tools** instead of 21:
+
+| Tool | Source |
+|---|---|
+| `bash` | Pi SDK (native) |
+| `read` | Pi SDK (native) |
+| `write` | Pi SDK (native) |
+| `edit` | Pi SDK (native) |
+| `sero-cli` | Sero (new) |
+
+**Net reduction: 16 tools removed from context.**
+
+The agent can also chain multiple commands in a single tool call:
+
+```
+sero todo list
+sero notes create "Bug fix summary" --content "Fixed the auth race condition"
+```
+
+## 3. Architecture
+
+### 3.1 Execution Surface — The `sero-cli` Tool
+
+A single tool registered with the Pi SDK agent:
+
+```typescript
+{
+  name: 'sero-cli',
+  label: 'Sero CLI',
+  description:
+    'Execute Sero platform commands. Supports app operations (todo, notes, ' +
+    'spotify, etc.), workspace management, version control, and dev servers. ' +
+    'Run `sero help` for available commands. Chain multiple commands by ' +
+    'passing multi-line input (one command per line).',
+  parameters: {
+    command: string   // e.g. "todo list" or multi-line "todo list\nnotes search meeting"
+    timeout?: number  // optional timeout in seconds
+  }
+}
+```
+
+The tool handler:
+1. Splits the input by newlines into individual commands
+2. Executes each sequentially via the CLI command registry
+3. Aggregates output (with clear delimiters between commands)
+4. Returns the combined result
+
+### 3.2 Dual Runtime — Container vs Host
+
+The CLI must work for both container and filesystem workspaces:
+
+| Workspace Type | Runtime | How it works |
+|---|---|---|
+| **Container** | Native process in container | `sero-cli` binary installed in container image. Communicates with Electron host via a lightweight IPC socket (Unix domain socket mounted into the container). |
+| **Filesystem** | Host process (IPC bridge) | `sero-cli` tool handler runs directly in the Electron main process, calling the same command handlers without any subprocess. No separate binary needed. |
+
+**Container architecture:**
+
+```
+┌─────────────────────┐     Unix socket      ┌───────────────────┐
+│  Container          │ ◄──────────────────► │  Electron Host    │
+│                     │                       │                   │
+│  sero-cli binary    │   JSON-RPC over UDS   │  CLI RPC Server   │
+│  (called by agent   │                       │  (routes to       │
+│   bash or sero-cli  │                       │   command          │
+│   tool)             │                       │   registry)       │
+└─────────────────────┘                       └───────────────────┘
+```
+
+- The Electron host creates a Unix domain socket at a known path, bind-mounted
+  into the container (e.g. `/tmp/sero-cli.sock`).
+- The `sero-cli` binary in the container sends JSON-RPC requests over this socket.
+- The host-side server deserializes and routes to the command registry.
+
+**Filesystem architecture:**
+
+```
+┌──────────────────────────────────────────────────────┐
+│  Electron Main Process                               │
+│                                                      │
+│  sero-cli tool handler ──► CLI Command Registry      │
+│  (direct function call, no subprocess)               │
+└──────────────────────────────────────────────────────┘
+```
+
+No binary, no socket — the `sero-cli` tool's `execute` function directly
+calls the command registry in-process.
+
+### 3.3 Command Registry
+
+A central registry where commands are registered from anywhere in the app:
+
+```typescript
+// electron/cli/registry.ts
+
+interface CliCommand {
+  /** Command name (e.g. 'todo', 'workspace'). Dot notation for subcommands. */
+  name: string;
+  /** One-line description for `sero help` listing. */
+  summary: string;
+  /** Detailed help text shown by `sero help <command>`. */
+  help?: string;
+  /** Parameter definitions (for help generation and validation). */
+  params?: CliParam[];
+  /** The handler function. */
+  execute: (args: string[], context: CliContext) => Promise<CliResult>;
+  /** Optional: mark as IPC-exposed (for guardrail enforcement). */
+  source?: 'app' | 'ipc' | 'builtin';
+}
+
+interface CliParam {
+  name: string;
+  description: string;
+  required?: boolean;
+  type?: 'string' | 'number' | 'boolean';
+  default?: unknown;
+}
+
+interface CliContext {
+  workspaceId: string;
+  /** Access to the container manager (if container workspace). */
+  containerManager?: ContainerManager;
+  /** Access to workspace manager. */
+  workspaceManager: WorkspaceManager;
+}
+
+interface CliResult {
+  output: string;
+  exitCode?: number;  // 0 = success (default), non-zero = error
+}
+```
+
+### 3.4 Registration API — `registerCliTool`
+
+A new method on `ExtensionAPI` alongside the existing `registerTool`:
+
+```typescript
+// In ExtensionAPI (Pi SDK extension interface)
+interface ExtensionAPI {
+  // Existing
+  registerTool(def: ToolDefinition): void;
+  registerCommand(name: string, def: CommandDefinition): void;
+
+  // New
+  registerCliTool(def: CliToolDefinition): void;
+}
+
+interface CliToolDefinition {
+  /** CLI command name (e.g. 'todo'). Supports subcommands via spaces: 'todo list'. */
+  name: string;
+  /** One-line summary for compact help listing. */
+  summary: string;
+  /** Detailed help text with examples. Shown by `sero help <command>`. */
+  help?: string;
+  /** Parameter definitions. */
+  params?: CliParam[];
+  /** Handler — receives parsed args and returns output string. */
+  execute: (args: string[], context: CliContext) => Promise<CliResult>;
+}
+```
+
+**Migration example — pi-todo-extension:**
+
+```typescript
+// BEFORE (registerTool — adds tool to agent context)
+pi.registerTool({
+  name: 'todo',
+  description: 'Manage todo items: add, list, complete, remove...',
+  parameters: Type.Object({
+    action: Type.String({ ... }),
+    text: Type.Optional(Type.String({ ... })),
+    id: Type.Optional(Type.Number({ ... })),
+  }),
+  execute: async (_id, params) => { ... },
+});
+
+// AFTER (registerCliTool — no tool in context, available via `sero todo`)
+pi.registerCliTool({
+  name: 'todo',
+  summary: 'Manage todo items',
+  help: `Usage: sero todo <action> [args]
+
+Actions:
+  list              List all todos
+  add <text>        Add a new todo
+  complete <id>     Mark a todo as done
+  remove <id>       Remove a todo
+
+Examples:
+  sero todo list
+  sero todo add "Fix login bug"
+  sero todo complete 3`,
+  params: [
+    { name: 'action', description: 'Action to perform', required: true },
+    { name: 'text', description: 'Todo text (for add)', required: false },
+    { name: 'id', description: 'Todo ID (for complete/remove)', required: false, type: 'number' },
+  ],
+  execute: async (args, ctx) => {
+    const [action, ...rest] = args;
+    // ... same logic, different interface
+  },
+});
+```
+
+**Both APIs coexist.** Packages choose which to use. No breaking changes.
+Gradual migration on a per-package basis.
+
+### 3.5 System Prompt Injection
+
+The `sero-cli` tool alone isn't enough — the agent needs guidance on when
+and how to use it. A system prompt block is injected via `before_agent_start`:
+
+```
+## Sero CLI
+
+You have access to the `sero-cli` tool for platform operations. Use it instead
+of asking the user to perform actions manually.
+
+Quick reference (run `sero help` for full list):
+  sero todo list              — List todos
+  sero notes search <query>   — Search notes
+  sero workspace info         — Current workspace details
+  sero vcs status             — Version control status
+  sero devserver list         — List running dev servers
+
+Chain commands (one per line):
+  sero todo list
+  sero notes create "Summary" --content "..."
+
+For detailed help: sero help <command>
+```
+
+This is **much smaller** than 16 individual tool schemas.
+
+### 3.6 Built-in Commands
+
+These commands are always registered (not from packages):
+
+| Command | Summary | Source |
+|---|---|---|
+| `help` | Show available commands and usage | builtin |
+| `help <command>` | Detailed help for a specific command | builtin |
+| `workspace info` | Show current workspace details | builtin |
+| `workspace list` | List all workspaces | builtin |
+| `session info` | Show session stats (tokens, cost, model) | builtin |
+| `set-title <text>` | Set session title | builtin |
+
+### 3.7 IPC-Exposed Commands (Curated Safe Subset)
+
+Selected IPC methods are exposed as CLI commands, giving the agent
+programmatic control over Sero. **Only safe operations** are included:
+
+| CLI Command | IPC Method | Access |
+|---|---|---|
+| `workspace list` | `workspace.list` | read |
+| `workspace info [id]` | `workspace.getConfig` | read |
+| `workspace open <id>` | `workspace.open` | write |
+| `workspace close <id>` | `workspace.close` | write |
+| `vcs status` | `vcs.status` | read |
+| `vcs log [--limit N]` | `vcs.logEntries` | read |
+| `vcs diff <from> [to]` | `vcs.diff` | read |
+| `vcs checkpoint [msg]` | `vcs.create` | write |
+| `vcs bookmarks` | `vcs.bookmarks` | read |
+| `devserver list` | `devServer.list` | read |
+| `devserver register ...` | `devServer.register` (replaces register_dev_server tool) | write |
+| `devserver stop <id>` | `devServer.stop` | write |
+| `editor read <path>` | `editor.readFile` | read |
+| `editor list <dir>` | `editor.listFiles` | read |
+| `appstate read <path>` | `appState.read` | read |
+| `appstate write <path>` | `appState.write` | write |
+| `terminal read [lines]` | terminal buffer read | read |
+
+**Blacklisted** (never exposed):
+- `auth.*` — credential management
+- `safeStorage.*` — encryption keys
+- `net.fetch` — arbitrary network requests
+- `layout.*` — UI layout state
+- `agent.*` — agent session control (would be recursive)
+- `github.login/logout` — OAuth flows
+
+### 3.8 Help System
+
+**`sero help`** — compact listing:
+
+```
+Sero CLI — Platform commands for the Sero agent
+
+BUILTIN
+  help [command]        Show help for a command
+  workspace <action>    Manage workspaces (list, info, open, close)
+  session info          Show session stats
+  set-title <text>      Set session title
+
+VERSION CONTROL
+  vcs status            Working copy status
+  vcs log               Show change log
+  vcs diff <from> [to]  Show diff between changes
+  vcs checkpoint [msg]  Create a checkpoint
+  vcs bookmarks         List bookmarks
+
+DEV SERVERS
+  devserver list        List registered dev servers
+  devserver register    Register a new dev server
+  devserver stop <id>   Stop a dev server
+
+APPS
+  todo <action>         Manage todo items
+  notes <action>        Manage notes
+  spotify <action>      Control Spotify playback
+  calc <expr>           Evaluate a calculation
+  weight <action>       Track weight entries
+  ...
+
+Run `sero help <command>` for detailed usage.
+```
+
+**`sero help todo`** — detailed with examples:
+
+```
+todo — Manage todo items
+
+Usage: sero todo <action> [args]
+
+Actions:
+  list              List all todos
+  add <text>        Add a new todo
+  complete <id>     Mark a todo as done
+  remove <id>       Remove a todo
+
+Examples:
+  sero todo list
+  sero todo add "Fix login bug"
+  sero todo complete 3
+```
+
+## 4. Implementation Plan
+
+### Phase 1 — Core Infrastructure
+
+1. **`electron/cli/registry.ts`** — Command registry (register, lookup, execute)
+2. **`electron/cli/parser.ts`** — Argument parser (handles quoted strings,
+   flags, multi-line splitting)
+3. **`electron/cli/help.ts`** — Help command generator (compact + detailed)
+4. **`electron/cli/types.ts`** — Shared types (CliCommand, CliContext, CliResult, etc.)
+5. **`electron/cli/tool.ts`** — The `sero-cli` tool definition (ToolDefinition
+   for Pi SDK, wraps registry execution)
+6. **`electron/cli/index.ts`** — Public API: `createCliTool()`, `getCliRegistry()`
+
+### Phase 2 — IPC Bridge Commands
+
+7. **`electron/cli/commands/workspace.ts`** — workspace list/info/open/close
+8. **`electron/cli/commands/vcs.ts`** — vcs status/log/diff/checkpoint/bookmarks
+9. **`electron/cli/commands/devserver.ts`** — devserver list/register/stop
+10. **`electron/cli/commands/editor.ts`** — editor read/list
+11. **`electron/cli/commands/appstate.ts`** — appstate read/write
+12. **`electron/cli/commands/terminal.ts`** — terminal read
+13. **`electron/cli/commands/session.ts`** — session info, set-title
+
+### Phase 3 — Extension API + Migration
+
+14. **`registerCliTool` on ExtensionAPI** — Add the new registration method to
+    the Sero extension wrapper (not upstream Pi SDK — implemented as a Sero-side
+    adapter that intercepts the call and routes to the CLI registry)
+15. **Migrate package extensions** — Convert each `registerTool` call to
+    `registerCliTool` in:
+    - pi-todo-extension
+    - pi-notes-extension
+    - pi-calc-extension
+    - pi-daily-quote
+    - pi-weight-tracker
+    - pi-spotify-extension
+    - pi-starling-extension
+    - pi-slopzilla-extension
+    - pi-imagegen-extension
+    - pi-plan-mode-extension
+    - pi-user-feedback (question, questionnaire, interview)
+16. **Remove `set_session_title` tool** — Replace with builtin `set-title` CLI command
+17. **Remove `register_dev_server` tool** — Replace with `devserver register` CLI command
+18. **Remove `read_terminal` tool** — Replace with `terminal read` CLI command
+19. **Remove `ls` tool** — Agent can use `bash` for `ls` (or `sero editor list`)
+
+### Phase 4 — Container Binary (Container Workspaces)
+
+20. **`electron/cli/rpc-server.ts`** — JSON-RPC server over Unix domain socket,
+    started per-workspace when container launches
+21. **`cli-bin/sero-cli.ts`** — Lightweight Node.js binary that connects to the
+    UDS and forwards commands. Compiled to a standalone binary and baked into the
+    container image.
+22. **Container image update** — Add `sero-cli` binary to the Sero container image
+23. **Mount UDS** — Bind-mount the socket into the container at `/tmp/sero-cli.sock`
+
+### Phase 5 — System Prompt + Polish
+
+24. **Update `buildContainerPromptBlock()`** — Add CLI quick reference to
+    container system prompt
+25. **Update `before_agent_start` hook** — Inject CLI help summary for all workspaces
+26. **Update tool creation** — Remove migrated tools from `createContainerTools()`
+    and host tool lists
+27. **Testing** — End-to-end tests for CLI command execution in both container
+    and filesystem modes
+
+## 5. File Layout (New Files)
+
+```
+electron/
+  cli/
+    index.ts              — Public API
+    registry.ts           — Command registry
+    parser.ts             — Argument parser
+    help.ts               — Help generator
+    tool.ts               — sero-cli ToolDefinition
+    rpc-server.ts         — JSON-RPC over UDS (container IPC)
+    types.ts              — Shared types
+    commands/
+      workspace.ts        — workspace subcommands
+      vcs.ts              — vcs subcommands
+      devserver.ts        — devserver subcommands
+      editor.ts           — editor subcommands
+      appstate.ts         — appstate subcommands
+      terminal.ts         — terminal subcommands
+      session.ts          — session subcommands
+
+cli-bin/
+  sero-cli.ts             — Container-side binary (connects to UDS)
+  build.mjs               — Build script (esbuild → single binary)
+```
+
+## 6. IPC Data Flow (Updated)
+
+For container workspaces:
+
+```
+Agent prompt
+  → sero-cli tool handler (Electron main)
+    → CLI Command Registry
+      → [for IPC commands] existing IPC handler logic
+      → [for app commands] registerCliTool handler
+    → aggregated result string
+  → tool result returned to agent
+```
+
+For container workspaces where agent uses bash:
+
+```
+Agent bash tool call: `sero todo list`
+  → container exec → runs sero-cli binary in container
+    → UDS → JSON-RPC → Electron host
+      → CLI Command Registry → handler
+    → JSON-RPC response → sero-cli binary → stdout
+  → bash tool captures stdout → returns to agent
+```
+
+## 7. Invocation Identity Model
+
+Every CLI command execution carries an **invocation context** that identifies
+who is calling, from where, and under what constraints. This is critical because
+the same command registry serves three distinct callers with different trust
+levels.
+
+### 7.1 Invocation Context
+
+```typescript
+interface CliInvocation {
+  /** Which workspace the command targets. Always present. */
+  workspaceId: string;
+  /** Active agent session (null for user-terminal calls). */
+  sessionId: string | null;
+  /** Current agent turn (null for user-terminal / between turns). */
+  turnId: string | null;
+  /** How the command was invoked. */
+  source: CliSource;
+  /** AbortSignal from the parent tool call (for cancellation). */
+  signal?: AbortSignal;
+}
+
+type CliSource =
+  | 'tool'      // Agent called the sero-cli tool directly
+  | 'bash'      // Agent ran `sero <cmd>` via bash inside a container
+  | 'terminal'; // User typed `sero <cmd>` in an interactive terminal
+```
+
+### 7.2 How source is determined
+
+| Entry point | source | sessionId | turnId |
+|---|---|---|---|
+| `sero-cli` tool handler (§3.1) | `'tool'` | from pool entry | from active turn |
+| Container binary via UDS (§3.2) | `'bash'` | attached by RPC server from active session for that workspace | from active turn if streaming, else null |
+| User types in interactive terminal | `'terminal'` | null | null |
+
+The RPC server (host side of the Unix domain socket) resolves `sessionId` by
+looking up which agent session is currently active for the given `workspaceId`
+in the session pool. If no session is active (user just has a terminal open),
+`sessionId` is null.
+
+`turnId` is set only when the agent is mid-turn (streaming). The RPC server
+checks `session.agent.state.isStreaming` to decide. This matters for rate
+limiting (§7.3) which is per-turn.
+
+### 7.3 Guardrail enforcement by source
+
+| Guardrail | `tool` | `bash` | `terminal` |
+|---|---|---|---|
+| IPC blacklist (§3.7) | ✅ enforced | ✅ enforced | ✅ enforced |
+| Per-turn rate limit | ✅ enforced (50/turn) | ✅ enforced (shared budget) | ❌ no limit |
+| Per-command timeout | ✅ enforced | ✅ enforced | ❌ no timeout |
+| Output truncation | ✅ 50KB / 2000 lines | ✅ 50KB / 2000 lines | ❌ full output |
+| Write-command confirmation | ❌ no (agent has autonomy) | ❌ no | ❌ no |
+| Abort signal propagation | ✅ from tool signal | ✅ from active session abort | ❌ n/a |
+
+Key principle: **`tool` and `bash` share the same trust level** — both are the
+agent acting autonomously. The rate limit budget is shared: if the agent uses 30
+commands via `sero-cli` tool calls and then runs `sero todo list` via bash,
+that's 31 against the same 50/turn cap.
+
+`terminal` is the user themselves — no rate limiting, no truncation, no timeouts.
+
+### 7.4 Rate limiting mechanics
+
+```typescript
+// Tracked per workspace + turn, stored on the session pool entry
+interface TurnBudget {
+  turnId: string;
+  commandCount: number;
+}
+```
+
+- Budget resets when `turnId` changes (new agent turn).
+- When `commandCount >= 50`, commands return a hard error:
+  `"Rate limit: 50 CLI commands per turn exceeded. Wait for the next turn."`
+- The `help` command is exempt from rate limiting (read-only, necessary for
+  self-correction).
+
+## 8. Chain Semantics
+
+### 8.1 Multi-command execution model
+
+The `sero-cli` tool accepts multi-line input. Each non-empty line is one
+command. Commands execute **sequentially, top to bottom**.
+
+### 8.2 Error behaviour: fail-fast with partial output
+
+On the first command that returns a non-zero exit code, execution **stops**.
+The tool returns all output accumulated so far, including the failing command's
+error, so the agent has full context for self-correction.
+
+This matches the mental model of `set -e` in shell scripts and is consistent
+with how the existing bash tool treats non-zero exits (it throws, surfacing the
+error to the agent).
+
+**Rationale for fail-fast over continue-all:**
+- Commands in a chain are usually dependent (`sero vcs status` then
+  `sero vcs checkpoint "fix"` — no point checkpointing if status failed).
+- Continue-all would require the agent to parse a status table to find which
+  commands failed, adding complexity and error-prone parsing.
+- Fail-fast gives the agent a clear signal: "everything above this line
+  succeeded, this line failed, nothing below ran."
+
+### 8.3 Output format
+
+```
+$ sero todo list
+- [ ] Fix login bug (#1)
+- [x] Update README (#2)
+
+$ sero notes create "Summary"
+Created note: Summary (id: 42)
+
+$ sero vcs checkpoint "post-cleanup"
+ERROR: No file changes to checkpoint.
+[command 3/4 failed with exit code 1 — remaining commands skipped]
+```
+
+Rules:
+- Each command's output is prefixed with `$ sero <command>` (echoed input).
+- A blank line separates commands.
+- On failure, the error line is followed by a bracketed summary showing
+  position and skip count.
+- On full success (all commands pass), no summary footer is added — the
+  output speaks for itself.
+
+### 8.4 Single-command shorthand
+
+If the input contains no newlines, it is treated as a single command. The
+output has no `$ sero ...` prefix echo (unnecessary noise for one command).
+This keeps simple calls clean:
+
+```
+Input:  "todo list"
+Output: "- [ ] Fix login bug (#1)\n- [x] Update README (#2)"
+```
+
+## 9. Timeout Budget Model
+
+### 9.1 Two-level timeout hierarchy
+
+```
+┌─────────────────────────────────────────────┐
+│  Batch timeout (tool-level)                 │
+│  Default: 120s — set via tool `timeout` param│
+│                                             │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐    │
+│  │ cmd 1    │ │ cmd 2    │ │ cmd 3    │    │
+│  │ 30s max  │ │ 30s max  │ │ 30s max  │    │
+│  └──────────┘ └──────────┘ └──────────┘    │
+│                                             │
+│  Elapsed time is tracked. Each command gets │
+│  min(per_cmd_limit, batch_remaining).       │
+└─────────────────────────────────────────────┘
+```
+
+| Level | Default | Configurable | Source |
+|---|---|---|---|
+| **Batch** (entire tool call) | 120s | Yes — `timeout` param on the `sero-cli` tool | Agent chooses per-call |
+| **Per-command** | 30s | No (fixed cap) | Hardcoded |
+
+### 9.2 Timeout allocation algorithm
+
+```typescript
+function commandTimeout(
+  perCommandLimit: number,  // 30s
+  batchDeadline: number,    // absolute timestamp
+): number {
+  const batchRemaining = batchDeadline - Date.now();
+  if (batchRemaining <= 0) throw new TimeoutError('Batch timeout exceeded');
+  return Math.min(perCommandLimit * 1000, batchRemaining);
+}
+```
+
+For each command in a chain:
+1. Compute `batchRemaining = batchDeadline - now`.
+2. If `batchRemaining <= 0`, stop immediately with a timeout error (same
+   format as chain error — show partial output + timeout message).
+3. Otherwise, run the command with `timeout = min(30s, batchRemaining)`.
+4. If the command itself times out, treat as a non-zero exit and apply
+   fail-fast (§8.2).
+
+### 9.3 Examples
+
+| Scenario | Batch timeout | Commands | Behaviour |
+|---|---|---|---|
+| 3 fast commands | 120s (default) | Each takes <1s | All succeed, ~3s total |
+| 1 slow command | 120s | Takes 45s | Fails at 30s (per-command cap) |
+| 10 commands, tight batch | 20s via `timeout: 20` | Each takes 3s | Commands 1-6 succeed (18s), command 7 gets 2s remaining, may timeout |
+| Agent omits timeout | 120s (default) | Any | Normal operation |
+
+### 9.4 Timeout errors
+
+```
+$ sero some-slow-command
+ERROR: Command timed out after 30s
+[command 2/5 timed out — remaining commands skipped]
+```
+
+Timeout errors are **non-retriable within the same chain**. The agent can
+retry the individual command in a new `sero-cli` call if needed.
+
+### 9.5 Source-specific timeout behaviour
+
+| Source | Batch timeout | Per-command timeout |
+|---|---|---|
+| `tool` | From tool `timeout` param (default 120s) | 30s |
+| `bash` | Inherited from bash tool's own timeout | 30s |
+| `terminal` | None | None |
+
+When invoked via `bash`, the container binary itself has no timeout — it
+inherits whatever timeout the bash tool applied to the `container exec`
+call. The per-command 30s limit still applies on the host side (the RPC
+server enforces it).
+
+## 10. Guardrails Summary
+
+| # | Guardrail | Enforcement point |
+|---|---|---|
+| G1 | IPC namespace blacklist | Registry — `register()` rejects blacklisted prefixes |
+| G2 | Per-turn rate limit (50 commands) | Tool handler + RPC server, keyed by `(workspaceId, turnId)` |
+| G3 | Output truncation (50KB / 2000 lines) | Tool handler (for `tool` source), RPC response serializer (for `bash`) |
+| G4 | Batch timeout (default 120s) | Tool handler — wraps entire chain execution |
+| G5 | Per-command timeout (30s cap) | Registry `execute()` wrapper — enforced for all sources except `terminal` |
+| G6 | No recursive agent calls | Blacklist — `agent.*` namespace cannot be registered |
+| G7 | Abort signal propagation | Tool handler passes `signal` through invocation context |
+
+## 11. Migration Strategy
+
+**Phase 3 is non-breaking.** Both `registerTool` and `registerCliTool` work
+simultaneously. Packages migrate one at a time. During migration:
+
+- A package that still uses `registerTool` → tool appears in agent context as before
+- A package migrated to `registerCliTool` → tool removed from context, available via `sero <cmd>`
+- Both can coexist in the same session
+
+**Recommended migration order:**
+1. Low-risk apps first (todo, notes, calc, daily_quote, weight)
+2. Media apps (spotify, starling, slopzilla)
+3. Complex apps (imagegen, plan-mode, user-feedback)
+4. Builtin tools last (ls, read_terminal, register_dev_server, set_session_title)
+
+## 12. Open Questions
+
+1. **Container binary format** — Compile to a static binary via `pkg` or
+   `esbuild` + Node SEA? Or just install Node in the container and run the
+   script directly (simpler, Node is already in the image)?
+2. **Multi-line vs single-line** — Should the tool accept multi-line command
+   strings (one command per line) or an array of commands? Multi-line is more
+   natural for the LLM.
+3. **Streaming** — Should long-running CLI commands stream output back, or
+   buffer until complete? Buffering is simpler and matches current tool behaviour.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.11.0",
   "scripts": {
+    "postinstall": "node scripts/rebuild-node-pty.mjs",
     "dev": "pnpm --filter @sero/desktop dev",
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",

--- a/packages/pi-slopzilla-extension/ui/ConfigPhase.tsx
+++ b/packages/pi-slopzilla-extension/ui/ConfigPhase.tsx
@@ -11,15 +11,13 @@ import { TECH_OPTIONS } from '../shared/types';
 
 // ── Compact Godzilla ASCII ────────────────────────────────
 
-const GODZILLA_ART = `    ___
-   /   \\
-  | o o |
-  |  ^  |
-  | '-' |
- /|     |\\
-/ |\\___/| \\
-  |  |  |
- _|__|__|_`;
+const GODZILLA_ART = `      /\\/\\/\\
+     /  o    \\___
+    /    __   __/
+   |____/  \\_/
+     |      |
+    _|      |_
+   |__|    |__|`;
 
 const COMPLEXITY_DATA: { value: Complexity; label: string; kaiju: string; desc: string }[] = [
   {

--- a/packages/pi-slopzilla-extension/ui/GeneratingPhase.tsx
+++ b/packages/pi-slopzilla-extension/ui/GeneratingPhase.tsx
@@ -6,15 +6,13 @@
 
 import { useState, useEffect } from 'react';
 
-const KAIJU_ART = `    __
-   /  @\\
-  | \\__/|
-  /|    |\\
- / | /\\ | \\
-/__|/  \\|__\\
-   || ||
-   || ||
-  _||_||_`;
+const KAIJU_ART = `      /\\/\\/\\
+     /  @    \\___
+    /    __   __/
+   |____/  \\_/
+     |    |
+    _|  _ |_
+   |__|| |__|`;
 
 const FLAVORS = [
   'Consulting the ancient scrolls of Stack Overflow...',

--- a/packages/pi-slopzilla-extension/ui/LaunchPhase.tsx
+++ b/packages/pi-slopzilla-extension/ui/LaunchPhase.tsx
@@ -112,12 +112,13 @@ function LaunchingView({ idea, step }: { idea: AppIdea; step: LaunchStep }) {
         }}
         aria-hidden="true"
       >
-        {`   __
-  /  @>=========>
- | \\__/|
- /|    |\\
-/ | /\\ | \\
-  || ||`}
+        {`      /\\/\\/\\
+     /  @    \\___
+    /    __   __/>>=====>
+   |____/  \\_/
+     |      |
+    _|      |_
+   |__|    |__|`}
       </pre>
 
       {/* Fire beam */}
@@ -201,14 +202,13 @@ function SuccessView({ idea, onBack }: { idea: AppIdea; onBack: () => void }) {
         }}
         aria-hidden="true"
       >
-        {`    __
-   /  ^\\
-  | \\__/|  RAWR!
-  /|    |\\
- / |    | \\
-   |/\\/\\|
-   || ||
-  _||_||_`}
+        {`      /\\/\\/\\
+     /  ^    \\___
+    /    __   __/  RAWR!
+   |____/  \\_/
+     |\\    /|
+    _| \\  / |_
+   |__|  \\/|__|`}
       </pre>
 
       <h2
@@ -286,13 +286,13 @@ function ErrorView({
         style={{ color: 'var(--sz-red)' }}
         aria-hidden="true"
       >
-        {`    __
-   / x\\
-  | \\__/|
-  /|    |\\
- / | ~~ | \\
-   || ||
-  _||_||_`}
+        {`      /\\/\\/\\
+     /  x    \\___
+    /    __   __/
+   |____/  \\_/
+     |  ~~  |
+    _| ~~~~ |_
+   |__|    |__|`}
       </pre>
 
       <h2 className="sz-kaiju-text text-xl mb-2" style={{ color: 'var(--sz-red)' }}>

--- a/packages/pi-slopzilla-extension/ui/SlopZilla.tsx
+++ b/packages/pi-slopzilla-extension/ui/SlopZilla.tsx
@@ -47,7 +47,7 @@ class PhaseErrorBoundary extends Component<EBProps, EBState> {
             className="text-sm leading-tight font-mono select-none text-center mb-6"
             style={{ color: 'var(--sz-red)' }}
             aria-hidden="true"
-          >{`    __\n   / x\\\n  | \\__/|\n  /|    |\\\n / | ~~ | \\\n   || ||\n  _||_||_`}</pre>
+          >{`      /\\/\\/\\\n     /  x    \\___\n    /    __   __/\n   |____/  \\_/\n     |  ~~  |\n    _| ~~~~ |_\n   |__|    |__|`}</pre>
           <h2 className="sz-kaiju-text text-xl mb-2" style={{ color: 'var(--sz-red)' }}>
             KAIJU MALFUNCTION!
           </h2>

--- a/scripts/rebuild-node-pty.mjs
+++ b/scripts/rebuild-node-pty.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Ensures node-pty's native binary matches the current Node ABI.
+ *
+ * WHY THIS EXISTS:
+ * node-pty 1.1.0 ships prebuilt binaries for darwin-arm64, but they're
+ * compiled against an older Node ABI. Its install script
+ * (`node scripts/prebuild.js || node-gyp rebuild`) only checks whether
+ * the prebuild DIRECTORY exists — not whether the binary actually loads.
+ * So pnpm install sees the directory, skips the compile, and we get
+ * `posix_spawnp failed` at runtime.
+ *
+ * WHAT THIS DOES:
+ * 1. Tries to require() node-pty from the pnpm store
+ * 2. Spawns a trivial PTY to verify it actually works
+ * 3. If either step fails → runs node-gyp rebuild
+ * 4. If it already works → exits immediately (no-op)
+ *
+ * Called from root package.json `postinstall`.
+ */
+
+import { execSync, execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+// Find node-pty in the pnpm store (hoisted into apps/desktop/node_modules)
+const NODE_PTY_LINK = resolve(ROOT, 'apps/desktop/node_modules/node-pty');
+const NODE_PTY_PKG = resolve(ROOT, 'node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty');
+
+/** Resolve the actual node-pty directory (prefer symlink target). */
+function findNodePtyDir() {
+  if (existsSync(NODE_PTY_LINK)) return NODE_PTY_LINK;
+  if (existsSync(NODE_PTY_PKG)) return NODE_PTY_PKG;
+  return null;
+}
+
+/**
+ * Smoke-test node-pty in a **subprocess**.
+ *
+ * Native .node addons are cached permanently by Node's require — they
+ * cannot be reloaded in the same process after a rebuild. So we must
+ * always test in a fresh process to get an accurate result.
+ */
+function testNodePty(ptyDir) {
+  try {
+    const script = `
+      const pty = require(${JSON.stringify(ptyDir)});
+      const p = pty.spawn('/bin/echo', ['__pty_ok__'], {
+        name: 'xterm-256color', cols: 80, rows: 24, cwd: '/tmp',
+        env: { PATH: process.env.PATH || '/usr/bin:/bin' }
+      });
+      let out = '';
+      p.onData(d => { out += d; });
+      p.onExit(() => { process.exit(out.includes('__pty_ok__') ? 0 : 1); });
+      setTimeout(() => process.exit(1), 5000);
+    `;
+    execFileSync(process.execPath, ['-e', script], {
+      timeout: 10_000,
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Run node-gyp rebuild inside the node-pty package. */
+function rebuild(ptyDir) {
+  console.log(`\x1b[33m  → Rebuilding node-pty for Node ${process.version} (ABI ${process.versions.modules})...\x1b[0m`);
+  try {
+    execSync(`npx node-gyp rebuild --directory="${ptyDir}"`, {
+      stdio: 'inherit',
+      cwd: ROOT,
+      timeout: 120_000,
+    });
+    console.log('\x1b[32m  ✓ node-pty rebuilt successfully.\x1b[0m');
+    return true;
+  } catch (err) {
+    console.error('\x1b[31m  ✗ node-pty rebuild failed. Terminals will not work.\x1b[0m');
+    console.error('    Run manually: npx node-gyp rebuild --directory=node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty');
+    return false;
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────
+
+function main() {
+  console.log('[node-pty] Checking native binary...');
+
+  const ptyDir = findNodePtyDir();
+  if (!ptyDir) {
+    console.log('[node-pty] Not installed — skipping (not needed outside apps/desktop).');
+    process.exit(0);
+  }
+
+  if (testNodePty(ptyDir)) {
+    console.log(`\x1b[32m[node-pty] ✓ Binary works with Node ${process.version} (ABI ${process.versions.modules}).\x1b[0m`);
+    process.exit(0);
+  }
+
+  console.log(`\x1b[33m[node-pty] ✗ Binary does not work with Node ${process.version} (ABI ${process.versions.modules}).\x1b[0m`);
+
+  // Resolve the real package dir (not the symlink) for node-gyp
+  const realPtyDir = existsSync(NODE_PTY_PKG) ? NODE_PTY_PKG : ptyDir;
+  const ok = rebuild(realPtyDir);
+
+  if (ok) {
+    // Verify in a fresh subprocess (native addons can't be reloaded in-process)
+    if (testNodePty(ptyDir)) {
+      console.log('\x1b[32m[node-pty] ✓ Verified: rebuild works.\x1b[0m');
+    } else {
+      console.error('\x1b[31m[node-pty] ✗ Rebuild completed but binary still fails. Check node-gyp output above.\x1b[0m');
+      process.exit(1);
+    }
+  } else {
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Introduces a single `sero-cli` tool that replaces individual extension tools in the agent's context window, reducing token usage and improving tool selection quality.

### Core CLI Framework (`electron/cli/`)
- **Command registry** with blacklisted namespace protection
- **Parser** supporting quoted strings, escapes, multi-line chaining
- **Batch executor** with fail-fast semantics, per-command timeouts (30s), batch timeouts (120s default)
- **Rate limiting** — 50 CLI commands per agent turn
- **Output truncation** — 50KB / 2000 lines
- **Help system** with grouped listing and per-command detail

### IPC Bridge Commands
`workspace`, `vcs`, `devserver`, `editor`, `appstate`, `terminal`, `session`, `set-title`

### Schema-Driven Extension Bridge
Uses `DefaultResourceLoader.extensionsOverride` to intercept extension tools after loading and re-register them as CLI commands:

- **Generic schema-to-args parser** — positionals for required params, `--flags` for optional, auto type coercion from TypeBox schemas
- **Auto-generated help** from tool parameter schemas
- **Zero per-tool custom parsing** — just add the tool name to `TOOLS_TO_BRIDGE`
- **Package extensions unchanged** — they use `registerTool` as before; the Sero app layer handles migration transparently

### Bridged Tools
`todo`, `notes`, `calc`, `daily_quote`, `weight`

### Also Includes
- EditorPanel: removed container readiness gate from file loading
- ChatPanel: fixed partial agent entries for federated app messages
- Layout persistence fixes + e2e tests
- SlopZilla ASCII art refresh
- `postinstall` node-pty auto-rebuild script
- CLI tool management and CLI tool specs (`docs/specs/`)

### Context Reduction
5 tool schemas removed from agent context, replaced by one `sero-cli` tool with discoverable `sero help`.