### PR TITLE
feat(vcs): migrate from Jujutsu (JJ) to standard Git

### DIFF
--- a/apps/desktop/e2e/vcs.spec.ts
+++ b/apps/desktop/e2e/vcs.spec.ts
@@ -4,7 +4,7 @@ import { launchSeroApp, vcs } from './helpers';
 /**
  * VCS (Version Control System) functionality e2e tests.
  *
- * Tests the Jujutsu-based checkpoint system: listing checkpoints,
+ * Tests the Git-based checkpoint system: listing checkpoints,
  * creating manual checkpoints, viewing diffs, and restoring state.
  */
 
@@ -78,7 +78,7 @@ test.describe('VCS - Workspace State', () => {
       }
     }, workspaces[0].id);
 
-    // State may be null if jj is not installed in the test environment
+    // State may be null if git is not available in the test environment
     if (state !== null) {
       expect(state).toHaveProperty('workspaceId');
       expect(state).toHaveProperty('checkpoints');
@@ -141,7 +141,7 @@ test.describe('VCS - Checkpoint Lifecycle', () => {
       }
     }, testWorkspaceId);
 
-    // Checkpoint creation may fail if jj is not available
+    // Checkpoint creation may fail if git is not available
     if (checkpoint !== null) {
       expect(checkpoint).toHaveProperty('changeId');
       expect(checkpoint).toHaveProperty('description');
@@ -222,7 +222,7 @@ test.describe('VCS - Watch/Unwatch', () => {
       }
     }, wsId);
 
-    // Results depend on whether jj is available, but neither should crash the app
+    // Results depend on whether git is available, but neither should crash the app
     expect(typeof watchResult).toBe('string');
     expect(typeof unwatchResult).toBe('string');
   });

--- a/apps/desktop/electron/container/lifecycle.ts
+++ b/apps/desktop/electron/container/lifecycle.ts
@@ -287,11 +287,11 @@ export async function createFreshContainer(
     /* non-fatal — proxy handles DNS when available */
   }
 
-  // Initialize workspace as a colocated JJ+Git repo (idempotent)
+  // Initialize workspace as a Git repo (idempotent)
   try {
     await execFn(
       config.workspaceId,
-      'cd /workspace && [ -d .jj ] || (jj git init --colocate >/dev/null 2>&1 || jj init >/dev/null 2>&1)',
+      'cd /workspace && [ -d .git ] || git init >/dev/null 2>&1',
     );
   } catch {
     /* non-fatal */

--- a/apps/desktop/electron/github/auth-manager.ts
+++ b/apps/desktop/electron/github/auth-manager.ts
@@ -2,7 +2,7 @@
  * GitHubAuthManager — OAuth Device Flow for unified GitHub authentication.
  *
  * Login once from the Electron host, get a token that authenticates both
- * `gh` CLI (via GH_TOKEN) and git/jj push/fetch (via GIT_ASKPASS=gh).
+ * `gh` CLI (via GH_TOKEN) and git push/fetch (via GIT_ASKPASS=gh).
  *
  * Uses GitHub's Device Flow:
  *   1. POST /login/device/code → get user_code + verification_uri
@@ -140,7 +140,7 @@ export class GitHubAuthManager {
   }
 
   /**
-   * Build environment variables that authenticate both `gh` and git/jj.
+   * Build environment variables that authenticate both `gh` and git.
    * Returns empty object if not authenticated.
    */
   getAuthEnvVars(): Record<string, string> {

--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -55,10 +55,10 @@ export function formatCustomMessage(msg: {
   return prefixed.trim() ? prefixed : null;
 }
 
-const CHECKPOINT_ENTRY = 'jj-checkpoint';
+const CHECKPOINT_ENTRY = 'git-checkpoint';
 
 /**
- * Find the session entry ID of a `jj-checkpoint` custom entry by changeId.
+ * Find the session entry ID of a `git-checkpoint` custom entry by changeId.
  *
  * With the shifted checkpoint mapping (user message N displays the checkpoint
  * from turn N-1), branching to the checkpoint entry itself keeps turns 0..N-1

--- a/apps/desktop/electron/ipc/shared-infra.ts
+++ b/apps/desktop/electron/ipc/shared-infra.ts
@@ -27,7 +27,7 @@ import { GitHubAuthManager } from '../github/auth-manager';
 import { workspaceManager } from '../workspace';
 import { FileWatcherManager } from '../file-watcher';
 import { LspManager } from '../lsp/lsp-manager';
-import { JjRunner, VcsManager, VcsOps, VcsPullRequestOps } from '../vcs';
+import { GitRunner, VcsManager, VcsOps, VcsPullRequestOps } from '../vcs';
 
 // ── GitHub Auth Manager (singleton) ──────────────────────────
 
@@ -41,10 +41,10 @@ export const containerManager = new ContainerManager();
 // credential config are available in every container command.
 containerManager.getExtraEnvVars = () => githubAuth.getAuthEnvVars();
 
-const jjRunner = new JjRunner(workspaceManager, containerManager, githubAuth);
-export const vcsManager = new VcsManager(workspaceManager, jjRunner);
-export const vcsOps = new VcsOps(jjRunner);
-export const vcsPrOps = new VcsPullRequestOps(jjRunner);
+const gitRunner = new GitRunner(workspaceManager, containerManager, githubAuth);
+export const vcsManager = new VcsManager(workspaceManager, gitRunner);
+export const vcsOps = new VcsOps(gitRunner);
+export const vcsPrOps = new VcsPullRequestOps(gitRunner);
 
 // ── Workspace Manager (re-export singleton) ──────────────────
 

--- a/apps/desktop/electron/sero-extension-git.ts
+++ b/apps/desktop/electron/sero-extension-git.ts
@@ -2,8 +2,8 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
 import { vcsManager } from './ipc/shared-infra';
 
-const WORKSPACE_LINK_ENTRY = 'jj-workspace-link';
-const CHECKPOINT_ENTRY = 'jj-checkpoint';
+const WORKSPACE_LINK_ENTRY = 'git-workspace-link';
+const CHECKPOINT_ENTRY = 'git-checkpoint';
 
 type MixedEditCheckpointPolicy = 'merge-working-copy' | 'require-manual-first';
 
@@ -12,40 +12,53 @@ type MixedEditCheckpointPolicy = 'merge-working-copy' | 'require-manual-first';
 // create a single turn checkpoint that includes the full resulting workspace state.
 const MIXED_EDIT_CHECKPOINT_POLICY: MixedEditCheckpointPolicy = 'merge-working-copy';
 
-const GIT_COMMANDS_PATTERN =
-  /(^|&&|\|\||;|\|)\s*git\s+(commit|push|pull|checkout|branch|merge|rebase|status|diff|log|add|reset|stash|clone|init|fetch|tag|show|rm|mv|restore|switch|remote|config|clean|cherry-pick|revert|bisect|blame|grep|shortlog|describe|archive|bundle|submodule|worktree|reflog)/;
+/** Mutating git commands that the agent should not run directly. */
+const MUTATING_GIT_SUBCOMMANDS = new Set([
+  'add',
+  'commit',
+  'push',
+  'pull',
+  'checkout',
+  'switch',
+  'branch',
+  'merge',
+  'rebase',
+  'reset',
+  'stash',
+  'clone',
+  'init',
+  'tag',
+  'rm',
+  'mv',
+  'restore',
+  'remote',
+  'config',
+  'clean',
+  'cherry-pick',
+  'revert',
+  'bisect',
+  'submodule',
+  'worktree',
+]);
 
-const READ_ONLY_JJ = new Set([
+/** Read-only git commands the agent is allowed to use. */
+const READ_ONLY_GIT_SUBCOMMANDS = new Set([
   'status',
-  'st',
   'log',
   'diff',
   'show',
-  'file',
-  'workspace',
-  'op',
-  'help',
-  'version',
-  'config',
-  'root',
-]);
-
-const MUTATING_JJ = new Set([
-  'new',
-  'commit',
-  'ci',
+  'blame',
+  'grep',
+  'shortlog',
   'describe',
-  'desc',
-  'squash',
-  'split',
-  'rebase',
-  'abandon',
-  'edit',
-  'bookmark',
-  'undo',
-  'restore',
-  'resolve',
-  'git',
+  'rev-parse',
+  'ls-files',
+  'ls-tree',
+  'cat-file',
+  'reflog',
+  'branch', // read-only when used without flags
+  'remote', // read-only when used without add/remove
+  'fetch',  // fetch is safe to allow as read-only
 ]);
 
 const READ_ONLY_SHELL_COMMANDS = new Set([
@@ -85,7 +98,7 @@ function extractTextContent(content: unknown): string {
     .trim();
 }
 
-function extractJjSubcommands(command: string): string[] {
+function extractGitSubcommands(command: string): string[] {
   const segments = command
     .split(/&&|\|\||;|\|/)
     .map((s) => s.trim())
@@ -93,17 +106,18 @@ function extractJjSubcommands(command: string): string[] {
 
   const subs: string[] = [];
   for (const segment of segments) {
-    const match = segment.match(/(?:^|\s)jj\s+([a-zA-Z-]+)/);
+    const match = segment.match(/(?:^|\s)git\s+([a-zA-Z-]+)/);
     if (match?.[1]) subs.push(match[1]);
   }
   return subs;
 }
 
-function hasMutatingJj(command: string): boolean {
-  const subcommands = extractJjSubcommands(command);
+function hasMutatingGit(command: string): boolean {
+  const subcommands = extractGitSubcommands(command);
   for (const sub of subcommands) {
-    if (MUTATING_JJ.has(sub)) return true;
-    if (!READ_ONLY_JJ.has(sub)) return true;
+    if (MUTATING_GIT_SUBCOMMANDS.has(sub)) return true;
+    // If it's an unknown git subcommand, treat as mutating by default
+    if (!READ_ONLY_GIT_SUBCOMMANDS.has(sub)) return true;
   }
   return false;
 }
@@ -118,14 +132,14 @@ function isLikelyReadOnlySegment(segment: string): boolean {
 
   const tokens = withoutEnv.split(/\s+/);
   const cmd = tokens[0] ?? '';
-  const args = tokens.slice(1);
   if (!cmd) return true;
 
-  if (cmd === 'jj') {
-    return !hasMutatingJj(withoutEnv);
+  if (cmd === 'git') {
+    return !hasMutatingGit(withoutEnv);
   }
 
   if (cmd === 'sed') {
+    const args = tokens.slice(1);
     return args.includes('-n') && !args.includes('-i');
   }
 
@@ -160,7 +174,7 @@ function summarizeAgentRun(messages: unknown): string {
   return 'checkpoint: turn';
 }
 
-export function registerJjCheckpointFeatures(
+export function registerGitCheckpointFeatures(
   pi: ExtensionAPI,
   workspaceId: string,
 ): void {
@@ -213,7 +227,6 @@ export function registerJjCheckpointFeatures(
     try {
       hadWorkingCopyChangesAtAgentStart = await vcsManager.hasWorkingCopyChanges(workspaceId);
     } catch {
-      // Non-fatal: if detection fails, do not block automatic turn checkpointing.
       hadWorkingCopyChangesAtAgentStart = false;
     }
   });
@@ -229,17 +242,11 @@ export function registerJjCheckpointFeatures(
     const command = String((event.input as { command?: string }).command ?? '');
     if (!command.trim()) return;
 
-    if (GIT_COMMANDS_PATTERN.test(command)) {
+    // Block mutating git commands — checkpoint management is handled by Sero
+    if (hasMutatingGit(command)) {
       return {
         block: true,
-        reason: 'Git commands are blocked for agent tool calls. Use JJ-backed checkpoint tools and read-only jj commands.',
-      };
-    }
-
-    if (hasMutatingJj(command)) {
-      return {
-        block: true,
-        reason: 'Mutating jj commands are blocked in agent bash calls. Use read-only jj commands (status/log/diff/show).',
+        reason: 'Mutating git commands (commit, push, checkout, reset, etc.) are managed by Sero. Use read-only git commands (status, log, diff, show) instead.',
       };
     }
 
@@ -268,7 +275,7 @@ export function registerJjCheckpointFeatures(
   });
 
   pi.registerCommand('checkpoint', {
-    description: 'Create a JJ checkpoint from the current workspace state',
+    description: 'Create a Git checkpoint from the current workspace state',
     handler: async (args) => {
       const description = args?.trim() || undefined;
       try {
@@ -279,7 +286,7 @@ export function registerJjCheckpointFeatures(
 
         if (!checkpoint) {
           pi.sendMessage({
-            customType: 'jj-checkpoint',
+            customType: 'git-checkpoint',
             content: 'No file changes to checkpoint.',
             display: true,
           });
@@ -288,14 +295,14 @@ export function registerJjCheckpointFeatures(
 
         appendCheckpointEntry(checkpoint);
         pi.sendMessage({
-          customType: 'jj-checkpoint',
+          customType: 'git-checkpoint',
           content: `Checkpoint created: **${checkpoint.changeId}**`,
           display: true,
           details: checkpoint,
         });
       } catch (err) {
         pi.sendMessage({
-          customType: 'jj-checkpoint',
+          customType: 'git-checkpoint',
           content: `Checkpoint failed: ${err instanceof Error ? err.message : 'unknown error'}`,
           display: true,
         });
@@ -304,7 +311,7 @@ export function registerJjCheckpointFeatures(
   });
 
   pi.registerCommand('checkpoints', {
-    description: 'List recent JJ checkpoints',
+    description: 'List recent Git checkpoints',
     handler: async (args) => {
       const parsed = Number.parseInt(args?.trim() || '10', 10);
       const limit = Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 50) : 10;
@@ -313,7 +320,7 @@ export function registerJjCheckpointFeatures(
         const checkpoints = await vcsManager.listCheckpoints(workspaceId, limit);
         if (!checkpoints.length) {
           pi.sendMessage({
-            customType: 'jj-checkpoint',
+            customType: 'git-checkpoint',
             content: 'No checkpoints found.',
             display: true,
           });
@@ -322,13 +329,13 @@ export function registerJjCheckpointFeatures(
 
         const lines = checkpoints.map((cp) => `- \`${cp.changeId}\` ${cp.description}`);
         pi.sendMessage({
-          customType: 'jj-checkpoint',
+          customType: 'git-checkpoint',
           content: `**Recent checkpoints (${checkpoints.length})**\n${lines.join('\n')}`,
           display: true,
         });
       } catch (err) {
         pi.sendMessage({
-          customType: 'jj-checkpoint',
+          customType: 'git-checkpoint',
           content: `Failed to list checkpoints: ${err instanceof Error ? err.message : 'unknown error'}`,
           display: true,
         });
@@ -337,13 +344,13 @@ export function registerJjCheckpointFeatures(
   });
 
   pi.registerCommand('restore', {
-    description: 'Restore the workspace files to a checkpoint: /restore <change-id>',
+    description: 'Restore the workspace files to a checkpoint: /restore <commit-sha>',
     handler: async (args) => {
       const changeId = args?.trim();
       if (!changeId) {
         pi.sendMessage({
-          customType: 'jj-checkpoint',
-          content: 'Usage: /restore <change-id>',
+          customType: 'git-checkpoint',
+          content: 'Usage: /restore <commit-sha>',
           display: true,
         });
         return;
@@ -353,13 +360,13 @@ export function registerJjCheckpointFeatures(
         await vcsManager.restoreCheckpoint(workspaceId, changeId);
         appendWorkspaceLink(changeId);
         pi.sendMessage({
-          customType: 'jj-checkpoint',
+          customType: 'git-checkpoint',
           content: `Workspace restored to **${changeId}**.`,
           display: true,
         });
       } catch (err) {
         pi.sendMessage({
-          customType: 'jj-checkpoint',
+          customType: 'git-checkpoint',
           content: `Restore failed: ${err instanceof Error ? err.message : 'unknown error'}`,
           display: true,
         });
@@ -376,8 +383,8 @@ export function registerJjCheckpointFeatures(
 
       if (!from) {
         pi.sendMessage({
-          customType: 'jj-checkpoint',
-          content: 'Usage: /diffcp <from-change-id> [to-change-id]',
+          customType: 'git-checkpoint',
+          content: 'Usage: /diffcp <from-commit-sha> [to-commit-sha]',
           display: true,
         });
         return;
@@ -386,14 +393,14 @@ export function registerJjCheckpointFeatures(
       try {
         const diff = await vcsManager.diff(workspaceId, from, to);
         pi.sendMessage({
-          customType: 'jj-checkpoint-diff',
+          customType: 'git-checkpoint-diff',
           content: diff || '(no diff output)',
           display: true,
-          details: { from, to: to ?? '@' },
+          details: { from, to: to ?? 'HEAD' },
         });
       } catch (err) {
         pi.sendMessage({
-          customType: 'jj-checkpoint',
+          customType: 'git-checkpoint',
           content: `Diff failed: ${err instanceof Error ? err.message : 'unknown error'}`,
           display: true,
         });

--- a/apps/desktop/electron/sero-extension.ts
+++ b/apps/desktop/electron/sero-extension.ts
@@ -19,8 +19,8 @@ import type { WorkspaceInfo } from '../src/types/ipc';
 import type { ContainerState } from './container/index';
 import { buildContainerPromptBlock } from './container/system-prompt';
 import { registerSeroBuiltinCommands } from './sero-extension-commands';
-import { registerJjCheckpointFeatures } from './sero-extension-jj';
 import { buildCliPromptBlock } from './cli';
+import { registerGitCheckpointFeatures } from './sero-extension-git';
 
 /**
  * Creates an extension factory for a specific workspace session.
@@ -198,9 +198,9 @@ export function createSeroExtensionFactory(
       },
     });
 
-    // Re-implement PI CLI built-ins for SDK mode and register JJ checkpoint hooks.
+    // Re-implement PI CLI built-ins for SDK mode and register Git checkpoint hooks.
     registerSeroBuiltinCommands(pi, currentWorkspaceId);
-    registerJjCheckpointFeatures(pi, currentWorkspaceId);
+    registerGitCheckpointFeatures(pi, currentWorkspaceId);
   };
 }
 

--- a/apps/desktop/electron/vcs/git-runner.ts
+++ b/apps/desktop/electron/vcs/git-runner.ts
@@ -5,7 +5,7 @@ import type { WorkspaceManager } from '../workspace';
 import type { ContainerManager } from '../container/index';
 import type { GitHubAuthManager } from '../github/auth-manager';
 import { buildContainerConfig } from '../ipc/shared-infra';
-import type { JjResult } from './types';
+import type { GitResult } from './types';
 
 const execFileAsync = promisify(execFile);
 
@@ -13,7 +13,7 @@ function shQuote(input: string): string {
   return `'${input.replace(/'/g, `'"'"'`)}'`;
 }
 
-export class JjRunner {
+export class GitRunner {
   constructor(
     private readonly workspaceManager: WorkspaceManager,
     private readonly containerManager: ContainerManager,
@@ -30,7 +30,7 @@ export class JjRunner {
     program: string,
     args: string[],
     timeoutMs = 30_000,
-  ): Promise<JjResult> {
+  ): Promise<GitResult> {
     const workspacePath = this.workspaceManager.getPath(workspaceId);
     if (!workspacePath) {
       return {
@@ -46,7 +46,6 @@ export class JjRunner {
       await this.ensureContainer(workspaceId, workspacePath);
       // GitHub auth env vars (GH_TOKEN, GIT_ASKPASS, URL rewrites) are injected
       // by ContainerManager.exec() via its getExtraEnvVars callback.
-      // No SSH workaround needed — all git traffic uses HTTPS with token auth.
       const command = `${shQuote(program)} ${args.map(shQuote).join(' ')}`;
       return this.containerManager.exec(workspaceId, command, '/workspace', timeoutMs);
     }
@@ -71,12 +70,12 @@ export class JjRunner {
       return {
         exitCode: code,
         stdout: String(err?.stdout ?? ''),
-        stderr: String(err?.stderr ?? err?.message ?? 'jj command failed'),
+        stderr: String(err?.stderr ?? err?.message ?? 'git command failed'),
       };
     }
   }
 
-  async run(workspaceId: string, args: string[], timeoutMs = 30_000): Promise<JjResult> {
-    return this.runCommand(workspaceId, 'jj', args, timeoutMs);
+  async run(workspaceId: string, args: string[], timeoutMs = 30_000): Promise<GitResult> {
+    return this.runCommand(workspaceId, 'git', args, timeoutMs);
   }
 }

--- a/apps/desktop/electron/vcs/git-runner.ts
+++ b/apps/desktop/electron/vcs/git-runner.ts
@@ -1,4 +1,7 @@
 import { execFile } from 'child_process';
+import { existsSync } from 'fs';
+import { homedir } from 'os';
+import path from 'path';
 import { promisify } from 'util';
 
 import type { WorkspaceManager } from '../workspace';
@@ -8,6 +11,39 @@ import { buildContainerConfig } from '../ipc/shared-infra';
 import type { GitResult } from './types';
 
 const execFileAsync = promisify(execFile);
+
+/**
+ * Check if the host likely has SSH keys that can authenticate with GitHub.
+ * Cached after first check for the process lifetime.
+ */
+let _sshAvailable: boolean | null = null;
+async function isHostSshAvailable(): Promise<boolean> {
+  if (_sshAvailable !== null) return _sshAvailable;
+
+  // Quick check: do SSH key files exist?
+  const sshDir = path.join(homedir(), '.ssh');
+  const hasKeys = ['id_ed25519', 'id_rsa', 'id_ecdsa'].some((k) =>
+    existsSync(path.join(sshDir, k)),
+  );
+  if (!hasKeys) {
+    _sshAvailable = false;
+    return false;
+  }
+
+  // Verify SSH actually authenticates with GitHub
+  try {
+    const { stderr } = await execFileAsync('ssh', ['-T', '-o', 'StrictHostKeyChecking=accept-new', '-o', 'ConnectTimeout=5', 'git@github.com'], {
+      timeout: 10_000,
+    }).catch((err: any) => {
+      // ssh -T exits with code 1 on success ("You've successfully authenticated")
+      return { stdout: String(err?.stdout ?? ''), stderr: String(err?.stderr ?? '') };
+    });
+    _sshAvailable = stderr.includes('successfully authenticated');
+  } catch {
+    _sshAvailable = false;
+  }
+  return _sshAvailable;
+}
 
 function shQuote(input: string): string {
   return `'${input.replace(/'/g, `'"'"'`)}'`;
@@ -50,11 +86,23 @@ export class GitRunner {
       return this.containerManager.exec(workspaceId, command, '/workspace', timeoutMs);
     }
 
-    // Host execution — inject GitHub auth env vars into the process environment
+    // Host execution — inject GitHub auth env vars into the process environment.
+    // If the host has working SSH keys, skip the HTTPS URL rewrite so git uses
+    // SSH natively. SSH is more reliable for large pushes and avoids HTTP 400
+    // errors caused by payload size limits during HTTPS ref negotiation.
     const env = { ...process.env };
     if (this.githubAuth) {
       const authVars = this.githubAuth.getAuthEnvVars();
-      Object.assign(env, authVars);
+      const sshWorks = await isHostSshAvailable();
+      if (sshWorks) {
+        // Keep GH_TOKEN (for gh CLI) but drop the SSH→HTTPS rewrite + ASKPASS
+        // so git uses native SSH transport.
+        if (authVars.GH_TOKEN) {
+          env.GH_TOKEN = authVars.GH_TOKEN;
+        }
+      } else {
+        Object.assign(env, authVars);
+      }
     }
 
     try {

--- a/apps/desktop/electron/vcs/index.ts
+++ b/apps/desktop/electron/vcs/index.ts
@@ -6,7 +6,7 @@ export type {
   CreateCheckpointOptions,
 } from './types';
 
-export { JjRunner } from './jj-runner';
+export { GitRunner } from './git-runner';
 export { VcsManager } from './vcs-manager';
 export { VcsOps } from './vcs-ops';
 export { VcsPullRequestOps } from './pr-ops';

--- a/apps/desktop/electron/vcs/parsers.ts
+++ b/apps/desktop/electron/vcs/parsers.ts
@@ -1,8 +1,8 @@
 /**
- * JJ CLI output parsers.
+ * Git CLI output parsers.
  *
- * Parses structured template output from `jj log`, `jj status`,
- * `jj bookmark list`, `jj git remote list`, and `jj diff --summary`.
+ * Parses structured output from `git log`, `git status`,
+ * `git branch`, `git remote`, and `git diff --name-status`.
  */
 
 import type {
@@ -16,93 +16,132 @@ import type {
   OperationEntry,
 } from '../../src/types/vcs';
 
-// ── Separator used in JJ templates for unambiguous parsing ───
+// ── Separator used in Git format strings for unambiguous parsing ───
 
 const FIELD_SEP = '\x1f'; // ASCII Unit Separator
 const RECORD_SEP = '\x1e'; // ASCII Record Separator
 
-// ── JJ Log Template ─────────────────────────────────────────
+// ── Git Log Format ─────────────────────────────────────────
 
 /**
- * Template string for `jj log --no-graph -T <template>`.
- * Outputs one record per revision, fields separated by \x1f, records by \x1e.
+ * Format string for `git log --format=<format>`.
+ * Outputs one record per commit, fields separated by \x1f, records by \x1e.
+ *
+ * Fields: commitShort, commitFull, authorName, authorEmail, timestamp, subject,
+ *         refnames (branches + tags)
  */
-export const LOG_TEMPLATE = [
-  'change_id.short(12)',
-  'commit_id.short(12)',
-  'author.name()',
-  'author.email()',
-  'author.timestamp().utc().format("%Y-%m-%dT%H:%M:%SZ")',
-  'description.first_line()',
-  'empty',
-  'conflict',
-  'immutable',
-  'if(self.current_working_copy(), "true", "false")',
-  'bookmarks.map(|b| b.name()).join(",")',
-  'tags.map(|t| t.name()).join(",")',
-].join(` ++ "${FIELD_SEP}" ++ `) + ` ++ "${RECORD_SEP}"`;
+export const LOG_FORMAT = [
+  '%h',             // abbreviated commit hash
+  '%H',             // full commit hash
+  '%an',            // author name
+  '%ae',            // author email
+  '%aI',            // author date (ISO 8601)
+  '%s',             // subject (first line)
+  '%D',             // ref names (branches, tags)
+].join(FIELD_SEP) + RECORD_SEP;
 
 export function parseLogEntries(stdout: string): ChangeEntry[] {
   const entries: ChangeEntry[] = [];
   const records = stdout.split(RECORD_SEP);
-  console.log('[vcs-parser] parseLogEntries: %d records, first 500 chars:\n%s', records.length, stdout.slice(0, 500));
 
   for (const record of records) {
     const trimmed = record.trim();
     if (!trimmed) continue;
 
     const fields = trimmed.split(FIELD_SEP);
-    if (fields.length < 12) continue;
+    if (fields.length < 7) continue;
+
+    const refNames = fields[6].trim();
+    const { bookmarks, tags, isHead } = parseRefNames(refNames);
 
     entries.push({
       changeId: fields[0].trim(),
-      commitId: fields[1].trim(),
+      commitId: fields[1].trim().slice(0, 12),
       author: fields[2].trim(),
       email: fields[3].trim(),
       timestamp: fields[4].trim(),
       description: fields[5].trim() || '(no description)',
-      empty: fields[6].trim() === 'true',
-      conflict: fields[7].trim() === 'true',
-      immutable: fields[8].trim() === 'true',
-      isWorkingCopy: fields[9].trim() === 'true',
-      bookmarks: fields[10].trim() ? fields[10].trim().split(',') : [],
-      tags: fields[11].trim() ? fields[11].trim().split(',') : [],
+      empty: false,
+      conflict: false,
+      immutable: false,
+      isWorkingCopy: isHead,
+      bookmarks,
+      tags,
     });
   }
 
   return entries;
 }
 
-// ── Status parser ────────────────────────────────────────────
+/** Parse git's %D ref decoration into branches and tags. */
+function parseRefNames(refNames: string): { bookmarks: string[]; tags: string[]; isHead: boolean } {
+  const bookmarks: string[] = [];
+  const tags: string[] = [];
+  let isHead = false;
 
-function parseStatusLine(line: string): StatusFile | null {
-  const trimmed = line.trim();
-  if (!trimmed) return null;
+  if (!refNames) return { bookmarks, tags, isHead };
 
-  // JJ status format:  "M path/to/file" or "A path" or "D path" or "C path"
-  // Also: "R {old => new}"
-  const match = trimmed.match(/^([MADRC])\s+(.+)$/);
-  if (!match) {
-    console.log('[vcs-parser] parseStatusLine NO MATCH: %j', trimmed);
-    return null;
+  for (const ref of refNames.split(',')) {
+    const trimmed = ref.trim();
+    if (!trimmed) continue;
+
+    if (trimmed === 'HEAD') {
+      isHead = true;
+      continue;
+    }
+
+    // "HEAD -> main" means HEAD points to branch "main"
+    const headArrow = trimmed.match(/^HEAD -> (.+)$/);
+    if (headArrow) {
+      isHead = true;
+      bookmarks.push(headArrow[1].trim());
+      continue;
+    }
+
+    if (trimmed.startsWith('tag: ')) {
+      tags.push(trimmed.slice(5).trim());
+      continue;
+    }
+
+    // Skip remote tracking refs (origin/main, etc.) — we only show local branches
+    if (trimmed.includes('/')) continue;
+
+    bookmarks.push(trimmed);
   }
 
-  const [, code, rest] = match;
+  return { bookmarks, tags, isHead };
+}
+
+// ── Status parser ────────────────────────────────────────────
+
+function parseGitStatusLine(line: string): StatusFile | null {
+  if (line.length < 4) return null;
+
+  // Git porcelain v1: "XY path" or "XY old -> new"
+  const indexStatus = line[0];
+  const workTreeStatus = line[1];
+  const rest = line.slice(3);
+
+  // Use the most significant status (index takes priority if staged)
+  const code = indexStatus !== ' ' && indexStatus !== '?' ? indexStatus : workTreeStatus;
+
   const statusMap: Record<string, FileStatus> = {
     M: 'modified',
     A: 'added',
     D: 'deleted',
     R: 'renamed',
-    C: 'conflict',
+    C: 'copied',
+    U: 'conflict',
+    '?': 'added', // untracked → treat as added
   };
 
   const status = statusMap[code] || 'modified';
 
-  // Handle rename: "{old => new}"
-  if (status === 'renamed') {
-    const renameMatch = rest.match(/\{(.+?)\s+=>\s+(.+?)\}/);
-    if (renameMatch) {
-      return { path: renameMatch[2].trim(), status, oldPath: renameMatch[1].trim() };
+  // Handle rename: "old -> new"
+  if (status === 'renamed' || status === 'copied') {
+    const parts = rest.split(' -> ');
+    if (parts.length === 2) {
+      return { path: parts[1].trim(), status, oldPath: parts[0].trim() };
     }
   }
 
@@ -113,84 +152,66 @@ export function parseStatus(stdout: string): WorkingCopyStatus {
   const files: StatusFile[] = [];
   const lines = stdout.split('\n');
   let conflictCount = 0;
-  const parentChangeIds: string[] = [];
-  console.log('[vcs-parser] parseStatus input (%d lines):\n%s', lines.length, stdout.slice(0, 600));
 
-  // Extract parent info from "Working copy  : <id>" or "Parent commit: <id>"
   for (const line of lines) {
-    const parentMatch = line.match(/Parent commit:\s+(\S+)/);
-    if (parentMatch) {
-      parentChangeIds.push(parentMatch[1]);
-    }
+    if (!line) continue;
 
-    const wcMatch = line.match(/Working copy\s+:\s+(\S+)/);
-    if (wcMatch) {
-      // This is the working copy change, not a parent
+    const file = parseGitStatusLine(line);
+    if (file) {
+      files.push(file);
+      if (file.status === 'conflict') conflictCount++;
     }
   }
 
-  // Parse file status lines (they appear after the header section)
-  let inFileSection = false;
-  for (const line of lines) {
-    if (line.startsWith('Working copy changes:') || line.startsWith('Untracked paths:')) {
-      inFileSection = true;
-      continue;
-    }
-
-    if (inFileSection && line.trim()) {
-      const file = parseStatusLine(line);
-      if (file) {
-        files.push(file);
-        if (file.status === 'conflict') conflictCount++;
-      }
-    }
-  }
-
-  return { files, conflictCount, parentChangeIds };
+  return { files, conflictCount, parentChangeIds: [] };
 }
 
 // ── Diff summary parser ──────────────────────────────────────
 
+/** Parse output of `git diff --name-status`. */
 export function parseDiffSummary(stdout: string): FileDiffEntry[] {
   const entries: FileDiffEntry[] = [];
-  console.log('[vcs-parser] parseDiffSummary input:\n%s', stdout.slice(0, 600));
 
   for (const line of stdout.split('\n')) {
-    const file = parseStatusLine(line);
-    if (file) {
-      entries.push({ path: file.path, status: file.status, oldPath: file.oldPath });
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Format: "M\tpath" or "R100\told\tnew"
+    const parts = trimmed.split('\t');
+    if (parts.length < 2) continue;
+
+    const code = parts[0].charAt(0);
+    const statusMap: Record<string, FileStatus> = {
+      M: 'modified',
+      A: 'added',
+      D: 'deleted',
+      R: 'renamed',
+      C: 'copied',
+      U: 'conflict',
+    };
+    const status = statusMap[code] || 'modified';
+
+    if ((status === 'renamed' || status === 'copied') && parts.length >= 3) {
+      entries.push({ path: parts[2].trim(), status, oldPath: parts[1].trim() });
+    } else {
+      entries.push({ path: parts[1].trim(), status });
     }
   }
 
-  console.log('[vcs-parser] parseDiffSummary result: %d files', entries.length);
   return entries;
 }
 
-// ── Bookmark parser ──────────────────────────────────────────
+// ── Branch parser ────────────────────────────────────────────
 
 /**
- * Keep bookmark templates compatible with older JJ versions in containers
- * (e.g. 0.28.x), where `json()` and `synced` aren't available.
+ * Format string for `git branch --format=<format>`.
+ * For local branches.
  */
-const BOOKMARK_TEMPLATE = [
-  'name',
-  'if(remote, remote, "local")',
-  // `normal_target` is a keyword in older JJ versions (not a callable).
-  'if(normal_target, normal_target.change_id().short(12), "")',
-  // `tracked` is available across 0.28+ and helps future sync UX decisions.
-  'if(tracked, "true", "false")',
-].join(` ++ "${FIELD_SEP}" ++ `) + ` ++ "${RECORD_SEP}"`;
+export const BRANCH_FORMAT =
+  `%(refname:short)${FIELD_SEP}%(objectname:short)${FIELD_SEP}%(upstream:short)${FIELD_SEP}%(upstream:track)${RECORD_SEP}`;
 
-export { BOOKMARK_TEMPLATE };
-
-interface BookmarkAccumulator {
-  name: string;
-  localChangeId?: string;
-  remoteTargets: Array<{ remote: string; changeId: string; tracked: boolean }>;
-}
-
-export function parseBookmarks(stdout: string): Bookmark[] {
-  const byName = new Map<string, BookmarkAccumulator>();
+export function parseBranches(stdout: string): Bookmark[] {
+  const bookmarks: Bookmark[] = [];
   const records = stdout.split(RECORD_SEP);
 
   for (const record of records) {
@@ -198,40 +219,26 @@ export function parseBookmarks(stdout: string): Bookmark[] {
     if (!trimmed) continue;
 
     const fields = trimmed.split(FIELD_SEP);
-    if (fields.length < 3) continue;
+    if (fields.length < 2) continue;
 
     const name = fields[0].trim();
-    const remote = fields[1].trim();
-    const changeId = fields[2].trim();
-    const tracked = fields[3]?.trim() === 'true';
-    const isLocal = remote === 'local';
+    const commitId = fields[1].trim();
+    const upstream = fields[2]?.trim() || '';
+    const trackingStatus = fields[3]?.trim() || '';
 
     if (!name) continue;
 
-    const acc = byName.get(name) ?? { name, remoteTargets: [] };
-    if (isLocal) {
-      acc.localChangeId = changeId || acc.localChangeId || '';
-    } else {
-      acc.remoteTargets.push({ remote, changeId, tracked });
+    const remoteStatuses: Bookmark['remoteStatuses'] = [];
+    if (upstream) {
+      const remoteName = upstream.split('/')[0] || 'origin';
+      const synced = !trackingStatus || trackingStatus === '';
+      remoteStatuses.push({ remote: remoteName, synced });
     }
-    byName.set(name, acc);
-  }
-
-  const bookmarks: Bookmark[] = [];
-  for (const acc of byName.values()) {
-    const localChangeId = acc.localChangeId ?? '';
-    const fallbackChangeId = acc.remoteTargets[0]?.changeId ?? '';
-    const effectiveChangeId = localChangeId || fallbackChangeId;
-
-    const remoteStatuses = acc.remoteTargets.map(({ remote, changeId }) => ({
-      remote,
-      synced: Boolean(localChangeId) && changeId === localChangeId,
-    }));
 
     bookmarks.push({
-      name: acc.name,
-      changeId: effectiveChangeId,
-      isLocal: Boolean(localChangeId),
+      name,
+      changeId: commitId,
+      isLocal: true,
       remoteStatuses,
     });
   }
@@ -242,33 +249,31 @@ export function parseBookmarks(stdout: string): Bookmark[] {
 // ── Remote parser ────────────────────────────────────────────
 
 export function parseRemotes(stdout: string): Remote[] {
-  const remotes: Remote[] = [];
+  const remoteMap = new Map<string, string>();
 
   for (const line of stdout.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
 
-    // Format: "name url"  (space-separated)
-    const parts = trimmed.split(/\s+/);
-    if (parts.length >= 2) {
-      remotes.push({ name: parts[0], url: parts.slice(1).join(' ') });
+    // Format: "name\turl (fetch|push)"
+    const match = trimmed.match(/^(\S+)\s+(\S+)\s+\((fetch|push)\)$/);
+    if (match) {
+      // Prefer the fetch URL, but any will do
+      if (!remoteMap.has(match[1]) || match[3] === 'fetch') {
+        remoteMap.set(match[1], match[2]);
+      }
     }
   }
 
-  return remotes;
+  return Array.from(remoteMap, ([name, url]) => ({ name, url }));
 }
 
-// ── Operation log parser ─────────────────────────────────────
+// ── Reflog parser (replaces JJ operation log) ────────────────
 
-const OP_LOG_TEMPLATE = [
-  'self.id().short(12)',
-  'self.time().start().utc().format("%Y-%m-%dT%H:%M:%SZ")',
-  'self.description().first_line()',
-].join(` ++ "${FIELD_SEP}" ++ `) + ` ++ "${RECORD_SEP}"`;
+export const REFLOG_FORMAT =
+  `%h${FIELD_SEP}%aI${FIELD_SEP}%gs${RECORD_SEP}`;
 
-export { OP_LOG_TEMPLATE };
-
-export function parseOperationLog(stdout: string): OperationEntry[] {
+export function parseReflog(stdout: string): OperationEntry[] {
   const entries: OperationEntry[] = [];
   const records = stdout.split(RECORD_SEP);
 

--- a/apps/desktop/electron/vcs/pr-ops.ts
+++ b/apps/desktop/electron/vcs/pr-ops.ts
@@ -1,5 +1,5 @@
-import type { JjRunner } from './jj-runner';
-import { BOOKMARK_TEMPLATE, parseBookmarks, parseDiffSummary, parseRemotes } from './parsers';
+import type { GitRunner } from './git-runner';
+import { BRANCH_FORMAT, parseBranches, parseDiffSummary, parseRemotes } from './parsers';
 import type {
   Bookmark,
   CreatePullRequestInput,
@@ -26,22 +26,19 @@ export interface PullRequestDraftContext {
 }
 
 export class VcsPullRequestOps {
-  constructor(private readonly runner: JjRunner) {}
+  constructor(private readonly runner: GitRunner) {}
 
-  private async listBookmarks(workspaceId: string): Promise<Bookmark[]> {
+  private async listBranches(workspaceId: string): Promise<Bookmark[]> {
     const result = await this.runner.run(workspaceId, [
-      'bookmark',
-      'list',
-      '--all-remotes',
-      '-T',
-      BOOKMARK_TEMPLATE,
+      'branch',
+      `--format=${BRANCH_FORMAT}`,
     ]);
     if (result.exitCode !== 0) return [];
-    return parseBookmarks(result.stdout);
+    return parseBranches(result.stdout);
   }
 
   private async resolveRemote(workspaceId: string): Promise<string | undefined> {
-    const result = await this.runner.run(workspaceId, ['git', 'remote', 'list']);
+    const result = await this.runner.run(workspaceId, ['remote', '-v']);
     if (result.exitCode !== 0) return undefined;
     const remotes = parseRemotes(result.stdout);
     return remotes.find((r) => r.name === 'origin')?.name ?? remotes[0]?.name;
@@ -76,10 +73,10 @@ export class VcsPullRequestOps {
   }
 
   async getState(workspaceId: string): Promise<PullRequestState> {
-    const bookmarks = await this.listBookmarks(workspaceId);
+    const branches = await this.listBranches(workspaceId);
     const sourceBranches = Array.from(
       new Set(
-        bookmarks
+        branches
           .filter((b) => b.isLocal)
           .map((b) => b.name.trim())
           .filter(Boolean),
@@ -87,7 +84,7 @@ export class VcsPullRequestOps {
     ).sort((a, b) => a.localeCompare(b));
 
     const allBranchNames = new Set<string>();
-    for (const bm of bookmarks) {
+    for (const bm of branches) {
       const name = bm.name.trim();
       if (name) allBranchNames.add(name);
     }
@@ -126,33 +123,29 @@ export class VcsPullRequestOps {
     sourceBranch: string,
     targetBranch: string,
   ): Promise<DiffResult> {
-    const remote = await this.resolveRemote(workspaceId);
-    const candidates = new Set<string>([targetBranch]);
-    if (remote && !targetBranch.includes('@')) {
-      candidates.add(`${targetBranch}@${remote}`);
+    // Use the merge-base for three-dot diff semantics
+    const mergeBase = await this.runner.run(workspaceId, [
+      'merge-base',
+      targetBranch,
+      sourceBranch,
+    ]);
+
+    const base = mergeBase.exitCode === 0 ? mergeBase.stdout.trim() : targetBranch;
+
+    const result = await this.runner.run(workspaceId, [
+      'diff',
+      '--name-status',
+      `${base}..${sourceBranch}`,
+    ]);
+
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Failed to diff ${targetBranch}..${sourceBranch}`);
     }
 
-    let lastErr = '';
-    for (const candidate of candidates) {
-      const result = await this.runner.run(workspaceId, [
-        'diff',
-        '--summary',
-        '--from',
-        candidate,
-        '--to',
-        sourceBranch,
-      ]);
-
-      if (result.exitCode === 0) {
-        return {
-          files: parseDiffSummary(result.stdout),
-          comparisonBase: candidate,
-        };
-      }
-      lastErr = result.stderr || `Failed to diff ${candidate}..${sourceBranch}`;
-    }
-
-    throw new Error(lastErr || `Failed to compare ${targetBranch} and ${sourceBranch}`);
+    return {
+      files: parseDiffSummary(result.stdout),
+      comparisonBase: base,
+    };
   }
 
   private async findExistingOpenPr(
@@ -232,7 +225,7 @@ export class VcsPullRequestOps {
         hasChanges: false,
         changedFiles: 0,
         files: [],
-        blockingReason: `Branch '${source}' is not a local bookmark. Push from a local branch first.`,
+        blockingReason: `Branch '${source}' is not a local branch. Push from a local branch first.`,
       };
     }
 
@@ -311,7 +304,7 @@ export class VcsPullRequestOps {
   ): Promise<string> {
     const result = await this.runner.run(
       workspaceId,
-      ['diff', '--git', '--from', comparisonBase, '--to', sourceBranch],
+      ['diff', `${comparisonBase}..${sourceBranch}`],
       120_000,
     );
     if (result.exitCode !== 0) return '';
@@ -381,11 +374,10 @@ export class VcsPullRequestOps {
       };
     }
 
-    // Verify the source branch has been pushed — gh pr create will fail with a
-    // confusing GitHub API error if the branch only exists locally.
-    const bookmarks = await this.listBookmarks(workspaceId);
-    const sourceBm = bookmarks.find((b) => b.name === preview.sourceBranch);
-    if (sourceBm && sourceBm.remoteStatuses.length === 0) {
+    // Verify the source branch has been pushed
+    const branches = await this.listBranches(workspaceId);
+    const sourceBr = branches.find((b) => b.name === preview.sourceBranch);
+    if (sourceBr && sourceBr.remoteStatuses.length === 0) {
       return {
         success: false,
         message: `Branch '${preview.sourceBranch}' has not been pushed to a remote. Push the branch first, then create the PR.`,
@@ -444,4 +436,3 @@ function extractGithubPrUrl(text: string): string | undefined {
   const match = text.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/);
   return match?.[0];
 }
-

--- a/apps/desktop/electron/vcs/types.ts
+++ b/apps/desktop/electron/vcs/types.ts
@@ -1,5 +1,5 @@
 // Re-export shared VCS types from the canonical renderer location.
-// Electron-only types (JjResult, CreateCheckpointOptions) are defined below.
+// Electron-only types (GitResult, CreateCheckpointOptions) are defined below.
 import type { VcsCheckpointSource } from '../../src/types/vcs';
 
 export type {
@@ -20,7 +20,7 @@ export type {
   PushPreview,
 } from '../../src/types/vcs';
 
-export interface JjResult {
+export interface GitResult {
   exitCode: number;
   stdout: string;
   stderr: string;

--- a/apps/desktop/electron/vcs/vcs-manager.ts
+++ b/apps/desktop/electron/vcs/vcs-manager.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 
 import type { WorkspaceManager } from '../workspace';
 import type { CreateCheckpointOptions, VcsCheckpoint, VcsCheckpointSource, VcsEvent, VcsWorkspaceState } from './types';
-import { JjRunner } from './jj-runner';
+import { GitRunner } from './git-runner';
 
 function nowIso(): string {
   return new Date().toISOString();
@@ -14,16 +14,15 @@ function parseSourceFromDescription(description: string): VcsCheckpointSource {
   if (description.startsWith('checkpoint: filesystem')) return 'fs';
   if (description.startsWith('checkpoint: restore') || description.startsWith('restore:')) return 'restore';
   if (description.startsWith('checkpoint: manual')) return 'manual';
-  if (description.startsWith('wip:')) return parseSourceFromDescription(`checkpoint: ${description.slice(4).trim()}`);
   return 'manual';
 }
 
 export class VcsManager extends EventEmitter {
-  private readonly runner: JjRunner;
+  private readonly runner: GitRunner;
 
   constructor(
     private readonly workspaceManager: WorkspaceManager,
-    runner: JjRunner,
+    runner: GitRunner,
   ) {
     super();
     this.runner = runner;
@@ -34,15 +33,12 @@ export class VcsManager extends EventEmitter {
   }
 
   private async ensureRepoInitialized(workspaceId: string): Promise<void> {
-    const root = await this.runner.run(workspaceId, ['root']);
+    const root = await this.runner.run(workspaceId, ['rev-parse', '--git-dir']);
     if (root.exitCode === 0) return;
 
-    const init = await this.runner.run(workspaceId, ['git', 'init', '--colocate']);
-    if (init.exitCode === 0) return;
-
-    const fallback = await this.runner.run(workspaceId, ['init']);
-    if (fallback.exitCode !== 0) {
-      throw new Error(init.stderr || fallback.stderr || 'Failed to initialize JJ repository');
+    const init = await this.runner.run(workspaceId, ['init']);
+    if (init.exitCode !== 0) {
+      throw new Error(init.stderr || 'Failed to initialize Git repository');
     }
   }
 
@@ -50,16 +46,17 @@ export class VcsManager extends EventEmitter {
     await this.ensureRepoInitialized(workspaceId);
 
     const result = await this.runner.run(workspaceId, [
-      'log',
-      '-r',
-      '@',
-      '--no-graph',
-      '-T',
-      'change_id.short(12)',
+      'rev-parse',
+      '--short=12',
+      'HEAD',
     ]);
 
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || 'Failed to resolve current change id');
+      // No commits yet — empty repo
+      if (result.stderr.includes('unknown revision') || result.stderr.includes('ambiguous argument')) {
+        return null;
+      }
+      throw new Error(result.stderr || 'Failed to resolve current commit');
     }
 
     const id = result.stdout.trim();
@@ -70,10 +67,8 @@ export class VcsManager extends EventEmitter {
     await this.ensureRepoInitialized(workspaceId);
 
     const result = await this.runner.run(workspaceId, [
-      'diff',
-      '-r',
-      '@',
-      '--summary',
+      'status',
+      '--porcelain',
     ]);
 
     if (result.exitCode !== 0) {
@@ -86,15 +81,14 @@ export class VcsManager extends EventEmitter {
   async listCheckpoints(workspaceId: string, limit = 40): Promise<VcsCheckpoint[]> {
     await this.ensureRepoInitialized(workspaceId);
 
-    // Template outputs: changeId<TAB>timestamp<TAB>description per line.
-    // author.timestamp() gives us the real commit time.
+    // Check for any commits at all
+    const hasCommits = await this.runner.run(workspaceId, ['rev-parse', 'HEAD']);
+    if (hasCommits.exitCode !== 0) return [];
+
     const result = await this.runner.run(workspaceId, [
       'log',
-      '--no-graph',
-      '--limit',
-      String(limit),
-      '-T',
-      'change_id.short(12) ++ "\\t" ++ author.timestamp().utc().format("%Y-%m-%dT%H:%M:%SZ") ++ "\\t" ++ description.first_line() ++ "\\n"',
+      `--max-count=${limit}`,
+      '--format=%h\t%aI\t%s',
     ]);
 
     if (result.exitCode !== 0) {
@@ -160,30 +154,27 @@ export class VcsManager extends EventEmitter {
     const hasChanges = await this.hasWorkingCopyChanges(workspaceId);
     if (!hasChanges) return null;
 
-    const currentChangeId = await this.getCurrentChangeId(workspaceId);
-    if (!currentChangeId) {
-      throw new Error('Unable to resolve current JJ change');
-    }
-
     const source: VcsCheckpointSource = options.source === 'fs' ? 'manual' : options.source;
     const description = (options.description?.trim() || this.buildDefaultDescription(source)).slice(0, 300);
 
-    const describe = await this.runner.run(workspaceId, ['describe', '-m', description]);
-    if (describe.exitCode !== 0) {
-      throw new Error(describe.stderr || 'Failed to describe checkpoint');
+    // Stage all changes
+    const add = await this.runner.run(workspaceId, ['add', '-A']);
+    if (add.exitCode !== 0) {
+      throw new Error(add.stderr || 'Failed to stage changes');
     }
 
-    const newWork = await this.runner.run(workspaceId, [
-      'new',
-      '-m',
-      `wip: ${source}`,
-    ]);
-    if (newWork.exitCode !== 0) {
-      throw new Error(newWork.stderr || 'Failed to advance to next working change');
+    // Commit
+    const commit = await this.runner.run(workspaceId, ['commit', '-m', description]);
+    if (commit.exitCode !== 0) {
+      throw new Error(commit.stderr || 'Failed to create checkpoint commit');
     }
+
+    // Get the SHA of the commit we just created
+    const sha = await this.runner.run(workspaceId, ['rev-parse', '--short=12', 'HEAD']);
+    const changeId = sha.exitCode === 0 ? sha.stdout.trim() : 'unknown';
 
     const checkpoint: VcsCheckpoint = {
-      changeId: currentChangeId,
+      changeId,
       description,
       source,
       createdAt: nowIso(),
@@ -201,21 +192,37 @@ export class VcsManager extends EventEmitter {
   /**
    * Restore workspace files to the state at the given checkpoint.
    *
-   * Uses `jj new <changeId>` (not `jj restore`) to create a new change
-   * on top of the target, keeping the timeline linear and intact.
+   * Uses `git checkout <sha> -- .` to restore all files to the checkpoint
+   * state, then stages and commits as a restore point to keep history linear.
    */
   async restoreCheckpoint(workspaceId: string, changeId: string): Promise<void> {
     await this.ensureRepoInitialized(workspaceId);
 
-    const restore = await this.runner.run(workspaceId, [
-      'new',
+    // Restore all files to the checkpoint state
+    const checkout = await this.runner.run(workspaceId, [
+      'checkout',
       changeId,
-      '-m',
-      `restore: ${changeId}`,
+      '--',
+      '.',
     ]);
 
-    if (restore.exitCode !== 0) {
-      throw new Error(restore.stderr || `Failed to restore checkpoint ${changeId}`);
+    if (checkout.exitCode !== 0) {
+      throw new Error(checkout.stderr || `Failed to restore checkpoint ${changeId}`);
+    }
+
+    // Also clean untracked files that didn't exist at the checkpoint
+    await this.runner.run(workspaceId, ['clean', '-fd']);
+
+    // Stage everything and commit the restore
+    await this.runner.run(workspaceId, ['add', '-A']);
+
+    const hasChanges = await this.hasWorkingCopyChanges(workspaceId);
+    if (hasChanges) {
+      await this.runner.run(workspaceId, [
+        'commit',
+        '-m',
+        `restore: ${changeId}`,
+      ]);
     }
 
     this.emitEvent({
@@ -228,11 +235,13 @@ export class VcsManager extends EventEmitter {
   async diff(workspaceId: string, fromChangeId: string, toChangeId?: string): Promise<string> {
     await this.ensureRepoInitialized(workspaceId);
 
-    const args = ['diff', '--from', fromChangeId];
+    const args = ['diff'];
     if (toChangeId?.trim()) {
-      args.push('--to', toChangeId.trim());
+      args.push(`${fromChangeId}..${toChangeId.trim()}`);
+    } else {
+      // Diff from the given commit to the current working tree
+      args.push(fromChangeId);
     }
-    args.push('--git');
 
     const diff = await this.runner.run(workspaceId, args, 60_000);
     if (diff.exitCode !== 0) {
@@ -244,7 +253,6 @@ export class VcsManager extends EventEmitter {
 
   watchWorkspace(workspaceId: string): void {
     // Explicit checkpoint mode: no automatic filesystem-based checkpointing.
-    // Keep API for compatibility with existing callers.
     void this.workspaceManager.getPath(workspaceId);
   }
 

--- a/apps/desktop/electron/vcs/vcs-ops.ts
+++ b/apps/desktop/electron/vcs/vcs-ops.ts
@@ -1,14 +1,14 @@
-import type { JjRunner } from './jj-runner';
+import type { GitRunner } from './git-runner';
 import {
-  LOG_TEMPLATE,
-  BOOKMARK_TEMPLATE,
-  OP_LOG_TEMPLATE,
+  LOG_FORMAT,
+  BRANCH_FORMAT,
+  REFLOG_FORMAT,
   parseLogEntries,
   parseStatus,
   parseDiffSummary,
-  parseBookmarks,
+  parseBranches,
   parseRemotes,
-  parseOperationLog,
+  parseReflog,
 } from './parsers';
 import { isAutoPushBookmark, inferConventionalType, slugifyBranchLabel } from './branch-naming';
 import type {
@@ -22,26 +22,30 @@ import type {
   PushPreview,
 } from '../../src/types/vcs';
 
-const DEFAULT_PRIMARY_BOOKMARK = 'main';
+const DEFAULT_PRIMARY_BRANCH = 'main';
 
 export class VcsOps {
-  constructor(private readonly runner: JjRunner) {}
+  constructor(private readonly runner: GitRunner) {}
 
   async getLogEntries(
     workspaceId: string,
     limit = 40,
     revset?: string,
   ): Promise<ChangeEntry[]> {
-    const args = ['log', '--no-graph', '-T', LOG_TEMPLATE, '--limit', String(limit)];
-    if (revset) args.push('-r', revset);
+    const args = ['log', `--format=${LOG_FORMAT}`, `--max-count=${limit}`];
+    if (revset) args.push(revset);
 
     const result = await this.runner.run(workspaceId, args);
-    if (result.exitCode !== 0) throw new Error(result.stderr || 'Failed to load change log');
+    if (result.exitCode !== 0) {
+      // Empty repo — no commits yet
+      if (result.stderr.includes('does not have any commits')) return [];
+      throw new Error(result.stderr || 'Failed to load commit log');
+    }
     return parseLogEntries(result.stdout);
   }
 
   async getStatus(workspaceId: string): Promise<WorkingCopyStatus> {
-    const result = await this.runner.run(workspaceId, ['status']);
+    const result = await this.runner.run(workspaceId, ['status', '--porcelain']);
     if (result.exitCode !== 0) throw new Error(result.stderr || 'Failed to get status');
     return parseStatus(result.stdout);
   }
@@ -52,8 +56,8 @@ export class VcsOps {
     to?: string,
   ): Promise<FileDiffEntry[]> {
     const args = to
-      ? ['diff', '--summary', '--from', from, '--to', to]
-      : ['diff', '--summary', '-r', from];
+      ? ['diff', '--name-status', `${from}..${to}`]
+      : ['diff', '--name-status', from];
 
     const result = await this.runner.run(workspaceId, args);
     if (result.exitCode !== 0) throw new Error(result.stderr || 'Failed to get diff summary');
@@ -67,12 +71,12 @@ export class VcsOps {
   ): Promise<string> {
     const result = await this.runner.run(
       workspaceId,
-      ['file', 'show', '-r', revset, path],
+      ['show', `${revset}:${path}`],
       60_000,
     );
     if (result.exitCode !== 0) {
       // File might not exist at this revision — return empty
-      if (result.stderr.includes('No such path')) return '';
+      if (result.stderr.includes('does not exist') || result.stderr.includes('not exist in')) return '';
       throw new Error(result.stderr || 'Failed to read file at revision');
     }
 
@@ -84,56 +88,61 @@ export class VcsOps {
     changeId: string,
     message: string,
   ): Promise<void> {
+    // Git can only amend the HEAD commit's message directly.
+    const head = await this.runner.run(workspaceId, ['rev-parse', '--short', 'HEAD']);
+    const headSha = head.stdout.trim();
+
+    if (!headSha.startsWith(changeId.slice(0, headSha.length))) {
+      throw new Error('Can only edit the description of the most recent commit (HEAD)');
+    }
+
     const result = await this.runner.run(workspaceId, [
-      'describe',
-      '-r',
-      changeId,
+      'commit',
+      '--amend',
       '-m',
       message,
     ]);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || 'Failed to describe change');
+      throw new Error(result.stderr || 'Failed to update commit message');
     }
   }
 
   async listBookmarks(workspaceId: string): Promise<Bookmark[]> {
     const result = await this.runner.run(workspaceId, [
-      'bookmark',
-      'list',
-      '--all-remotes',
-      '-T',
-      BOOKMARK_TEMPLATE,
+      'branch',
+      `--format=${BRANCH_FORMAT}`,
     ]);
     if (result.exitCode !== 0) {
-      // No bookmarks yet is fine
-      if (result.stderr.includes('No bookmarks')) return [];
-      throw new Error(result.stderr || 'Failed to list bookmarks');
+      // No branches yet is fine (empty repo)
+      return [];
     }
 
-    return parseBookmarks(result.stdout);
+    return parseBranches(result.stdout);
   }
 
   async createBookmark(
     workspaceId: string,
     name: string,
-    revision = '@',
+    revision = 'HEAD',
   ): Promise<void> {
     const result = await this.runner.run(workspaceId, [
-      'bookmark',
-      'create',
+      'branch',
       name,
-      '-r',
       revision,
     ]);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `Failed to create bookmark '${name}'`);
+      throw new Error(result.stderr || `Failed to create branch '${name}'`);
     }
   }
 
   async deleteBookmark(workspaceId: string, name: string): Promise<void> {
-    const result = await this.runner.run(workspaceId, ['bookmark', 'delete', name]);
+    const result = await this.runner.run(workspaceId, ['branch', '-d', name]);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `Failed to delete bookmark '${name}'`);
+      // Try force delete
+      const force = await this.runner.run(workspaceId, ['branch', '-D', name]);
+      if (force.exitCode !== 0) {
+        throw new Error(force.stderr || `Failed to delete branch '${name}'`);
+      }
     }
   }
 
@@ -143,19 +152,18 @@ export class VcsOps {
     toRevision: string,
   ): Promise<void> {
     const result = await this.runner.run(workspaceId, [
-      'bookmark',
-      'move',
+      'branch',
+      '-f',
       name,
-      '--to',
       toRevision,
     ]);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `Failed to move bookmark '${name}'`);
+      throw new Error(result.stderr || `Failed to move branch '${name}'`);
     }
   }
 
   async listRemotes(workspaceId: string): Promise<Remote[]> {
-    const result = await this.runner.run(workspaceId, ['git', 'remote', 'list']);
+    const result = await this.runner.run(workspaceId, ['remote', '-v']);
     if (result.exitCode !== 0) {
       return [];
     }
@@ -168,91 +176,78 @@ export class VcsOps {
     name: string,
     url: string,
   ): Promise<void> {
-    const result = await this.runner.run(workspaceId, ['git', 'remote', 'add', name, url]);
+    const result = await this.runner.run(workspaceId, ['remote', 'add', name, url]);
     if (result.exitCode !== 0) {
       throw new Error(result.stderr || `Failed to add remote '${name}'`);
     }
   }
 
   async removeRemote(workspaceId: string, name: string): Promise<void> {
-    const result = await this.runner.run(workspaceId, ['git', 'remote', 'remove', name]);
+    const result = await this.runner.run(workspaceId, ['remote', 'remove', name]);
     if (result.exitCode !== 0) {
       throw new Error(result.stderr || `Failed to remove remote '${name}'`);
     }
   }
 
-  private async getChangeDescription(
+  private async getCommitDescription(
     workspaceId: string,
     changeId: string,
   ): Promise<string> {
     const result = await this.runner.run(workspaceId, [
       'log',
-      '--no-graph',
-      '-r',
+      '--format=%s',
+      '-1',
       changeId,
-      '-T',
-      'description.first_line()',
     ]);
 
     if (result.exitCode !== 0) return '';
     return result.stdout.trim();
   }
 
-  private async suggestPushBookmarkForChange(
+  private async suggestPushBranchForCommit(
     workspaceId: string,
     changeId: string,
     bookmarks: Bookmark[],
   ): Promise<string> {
-    // 1. Prefer an existing bookmark already pointing at this exact change
+    // 1. Prefer an existing branch already pointing at this exact commit
     const localAtTarget = bookmarks
       .filter((bm) => bm.isLocal && bm.changeId === changeId)
       .map((bm) => bm.name);
 
-    const preferredAtTarget = localAtTarget.find((name) => name === DEFAULT_PRIMARY_BOOKMARK)
+    const preferredAtTarget = localAtTarget.find((name) => name === DEFAULT_PRIMARY_BRANCH)
       ?? localAtTarget.find((name) => !isAutoPushBookmark(name));
     if (preferredAtTarget) return preferredAtTarget;
 
-    // 2. Generate a descriptive feature branch name.
-    //    Never fall back to moving shared branches (e.g. main) to an arbitrary
-    //    change — that would silently rewrite shared history.
-    const description = await this.getChangeDescription(workspaceId, changeId);
+    // 2. Generate a descriptive feature branch name
+    const description = await this.getCommitDescription(workspaceId, changeId);
     const type = inferConventionalType(description);
     const label = slugifyBranchLabel(description);
     return `${type}/${label}-${changeId.slice(0, 8)}`;
   }
 
-  private async ensureBookmarkAtChange(
+  private async ensureBranchAtCommit(
     workspaceId: string,
-    bookmark: string,
+    branch: string,
     changeId: string,
   ): Promise<void> {
+    // Try creating the branch
     const create = await this.runner.run(workspaceId, [
-      'bookmark',
-      'create',
-      bookmark,
-      '-r',
+      'branch',
+      branch,
       changeId,
     ]);
     if (create.exitCode === 0) return;
 
-    const createErr = create.stderr.toLowerCase();
-    if (!createErr.includes('already exists')) {
-      throw new Error(create.stderr || `Failed to create bookmark '${bookmark}'`);
-    }
-
+    // Branch already exists — force move it
     const move = await this.runner.run(workspaceId, [
-      'bookmark',
-      'move',
-      bookmark,
-      '--to',
+      'branch',
+      '-f',
+      branch,
       changeId,
     ]);
 
     if (move.exitCode !== 0) {
-      const moveErr = move.stderr.toLowerCase();
-      if (!moveErr.includes('already points') && !moveErr.includes('already at')) {
-        throw new Error(move.stderr || `Failed to move bookmark '${bookmark}'`);
-      }
+      throw new Error(move.stderr || `Failed to set branch '${branch}' to ${changeId}`);
     }
   }
 
@@ -266,14 +261,10 @@ export class VcsOps {
     }
   }
 
-  private isStaleRemotePushError(stderr: string): boolean {
-    const msg = stderr.toLowerCase();
-    return msg.includes('unexpectedly moved on the remote') || msg.includes('stale info');
-  }
-
   async fetch(workspaceId: string, remote?: string): Promise<SyncResult> {
-    const args = ['git', 'fetch'];
-    if (remote) args.push('--remote', remote);
+    const args = ['fetch'];
+    if (remote) args.push(remote);
+    else args.push('--all');
 
     const result = await this.runner.run(workspaceId, args, 120_000);
     if (result.exitCode !== 0) {
@@ -288,27 +279,26 @@ export class VcsOps {
     bookmark?: string,
     changeId?: string,
   ): Promise<PushPreview> {
-    let resolvedBookmark = bookmark;
-    if (!resolvedBookmark && changeId) {
+    let resolvedBranch = bookmark;
+    if (!resolvedBranch && changeId) {
       try {
         const bookmarks = await this.listBookmarks(workspaceId);
-        resolvedBookmark = await this.suggestPushBookmarkForChange(workspaceId, changeId, bookmarks);
+        resolvedBranch = await this.suggestPushBranchForCommit(workspaceId, changeId, bookmarks);
       } catch (err) {
-        console.warn('[vcs-ops] Dry-run bookmark suggestion failed (best-effort):', err);
+        console.warn('[vcs-ops] Dry-run branch suggestion failed (best-effort):', err);
       }
     }
 
     const pushRemote = await this.resolvePushRemote(workspaceId);
-    const args = ['git', 'push', '--dry-run'];
-    if (pushRemote) args.push('--remote', pushRemote);
-    if (resolvedBookmark) args.push('--bookmark', resolvedBookmark);
-    else if (changeId) args.push('--change', changeId);
+    const args = ['push', '--dry-run'];
+    if (pushRemote) args.push(pushRemote);
+    if (resolvedBranch) args.push(resolvedBranch);
 
     const result = await this.runner.run(workspaceId, args, 60_000);
     const output = result.stdout + '\n' + result.stderr;
 
     return {
-      bookmarks: resolvedBookmark ? [resolvedBookmark] : [],
+      bookmarks: resolvedBranch ? [resolvedBranch] : [],
       willCreate: [],
       message: output.trim(),
     };
@@ -319,51 +309,46 @@ export class VcsOps {
     bookmark?: string,
     changeId?: string,
   ): Promise<SyncResult> {
-    let resolvedBookmark = bookmark;
-    if (resolvedBookmark && changeId) {
+    let resolvedBranch = bookmark;
+    if (resolvedBranch && changeId) {
       try {
-        await this.ensureBookmarkAtChange(workspaceId, resolvedBookmark, changeId);
+        await this.ensureBranchAtCommit(workspaceId, resolvedBranch, changeId);
       } catch (err) {
         return {
           success: false,
-          message: err instanceof Error ? err.message : 'Failed to move push bookmark',
+          message: err instanceof Error ? err.message : 'Failed to set push branch',
         };
       }
     }
-    if (!resolvedBookmark && changeId) {
+    if (!resolvedBranch && changeId) {
       try {
         const bookmarks = await this.listBookmarks(workspaceId);
-        resolvedBookmark = await this.suggestPushBookmarkForChange(workspaceId, changeId, bookmarks);
-        await this.ensureBookmarkAtChange(workspaceId, resolvedBookmark, changeId);
+        resolvedBranch = await this.suggestPushBranchForCommit(workspaceId, changeId, bookmarks);
+        await this.ensureBranchAtCommit(workspaceId, resolvedBranch, changeId);
       } catch (err) {
         return {
           success: false,
-          message: err instanceof Error ? err.message : 'Failed to prepare push bookmark',
+          message: err instanceof Error ? err.message : 'Failed to prepare push branch',
         };
       }
     }
 
     const pushRemote = await this.resolvePushRemote(workspaceId);
     const buildPushArgs = (): string[] => {
-      const args = ['git', 'push'];
-      if (pushRemote) args.push('--remote', pushRemote);
-      if (resolvedBookmark) args.push('--bookmark', resolvedBookmark);
-      else if (changeId) args.push('--change', changeId);
+      const args = ['push', '-u'];
+      if (pushRemote) args.push(pushRemote);
+      if (resolvedBranch) args.push(resolvedBranch);
       return args;
     };
 
-    let result = await this.runner.run(workspaceId, buildPushArgs(), 120_000);
-    if (result.exitCode !== 0 && this.isStaleRemotePushError(result.stderr || '')) {
-      await this.fetch(workspaceId, pushRemote);
-      result = await this.runner.run(workspaceId, buildPushArgs(), 120_000);
-    }
+    const result = await this.runner.run(workspaceId, buildPushArgs(), 120_000);
     if (result.exitCode !== 0) {
       return { success: false, message: result.stderr || 'Push failed' };
     }
 
     const output = result.stderr || result.stdout;
-    if (resolvedBookmark) {
-      const summary = `Pushed bookmark '${resolvedBookmark}'`;
+    if (resolvedBranch) {
+      const summary = `Pushed branch '${resolvedBranch}'`;
       return {
         success: true,
         message: output?.trim() ? `${summary}\n${output.trim()}` : summary,
@@ -374,16 +359,25 @@ export class VcsOps {
   }
 
   async undo(workspaceId: string): Promise<void> {
-    const result = await this.runner.run(workspaceId, ['undo']);
+    // Undo last commit by soft-resetting to HEAD~1 (keeps changes staged)
+    const result = await this.runner.run(workspaceId, ['reset', '--soft', 'HEAD~1']);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || 'Undo failed');
+      throw new Error(result.stderr || 'Undo failed — no commits to undo');
     }
   }
 
   async abandon(workspaceId: string, changeId: string): Promise<void> {
-    const result = await this.runner.run(workspaceId, ['abandon', changeId]);
+    // "Abandon" = drop a commit. Only supported for HEAD in a non-interactive flow.
+    const head = await this.runner.run(workspaceId, ['rev-parse', '--short', 'HEAD']);
+    const headSha = head.stdout.trim();
+
+    if (!headSha.startsWith(changeId.slice(0, headSha.length))) {
+      throw new Error('Can only drop the most recent commit (HEAD). Use interactive rebase for older commits.');
+    }
+
+    const result = await this.runner.run(workspaceId, ['reset', '--hard', 'HEAD~1']);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `Failed to abandon ${changeId}`);
+      throw new Error(result.stderr || `Failed to drop commit ${changeId}`);
     }
   }
 
@@ -392,13 +386,17 @@ export class VcsOps {
     from?: string,
     into?: string,
   ): Promise<void> {
-    const args = ['squash'];
-    if (from) args.push('--from', from);
-    if (into) args.push('--into', into);
+    void from;
+    void into;
 
-    const result = await this.runner.run(workspaceId, args);
-    if (result.exitCode !== 0) {
-      throw new Error(result.stderr || 'Squash failed');
+    const soft = await this.runner.run(workspaceId, ['reset', '--soft', 'HEAD~1']);
+    if (soft.exitCode !== 0) {
+      throw new Error(soft.stderr || 'Squash failed — cannot reset');
+    }
+
+    const amend = await this.runner.run(workspaceId, ['commit', '--amend', '--no-edit']);
+    if (amend.exitCode !== 0) {
+      throw new Error(amend.stderr || 'Squash failed — cannot amend');
     }
   }
 
@@ -407,18 +405,15 @@ export class VcsOps {
     limit = 20,
   ): Promise<OperationEntry[]> {
     const result = await this.runner.run(workspaceId, [
-      'operation',
-      'log',
-      '--no-graph',
-      '-T',
-      OP_LOG_TEMPLATE,
-      '--limit',
+      'reflog',
+      `--format=${REFLOG_FORMAT}`,
+      `-n`,
       String(limit),
     ]);
     if (result.exitCode !== 0) {
-      throw new Error(result.stderr || 'Failed to read operation log');
+      return [];
     }
 
-    return parseOperationLog(result.stdout);
+    return parseReflog(result.stdout);
   }
 }

--- a/apps/desktop/images/Dockerfile.sero-node
+++ b/apps/desktop/images/Dockerfile.sero-node
@@ -13,26 +13,10 @@ RUN apt-get update -qq && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# JJ (Jujutsu) — version control used by Sero for checkpointing, bookmarking,
-# forking, and undo. Pinned version for stability (JJ is pre-1.0).
-# Installed via official GitHub release binary (static, no deps).
-ARG JJ_VERSION=0.38.0
-RUN ARCH=$(dpkg --print-architecture) && \
-    case "$ARCH" in \
-      amd64) JJ_ARCH="x86_64" ;; \
-      arm64) JJ_ARCH="aarch64" ;; \
-      *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
-    esac && \
-    curl -fsSL "https://github.com/jj-vcs/jj/releases/download/v${JJ_VERSION}/jj-v${JJ_VERSION}-${JJ_ARCH}-unknown-linux-musl.tar.gz" \
-      | tar xz --strip-components=0 -C /usr/local/bin ./jj && \
-    chmod +x /usr/local/bin/jj && \
-    jj --version
-
-# Configure JJ defaults for non-interactive agent use
-RUN jj config set --user ui.color never && \
-    jj config set --user ui.paginate never && \
-    jj config set --user user.name "Sero" && \
-    jj config set --user user.email "sero@local"
+# Configure Git defaults for non-interactive agent use
+RUN git config --global user.name "Sero" && \
+    git config --global user.email "sero@local" && \
+    git config --global init.defaultBranch main
 
 # Playwright + Chromium — used by agent for screenshot validation & web testing
 RUN pip3 install --break-system-packages playwright && \

--- a/apps/desktop/src/components/apps/coding/vcs/BookmarksSection.tsx
+++ b/apps/desktop/src/components/apps/coding/vcs/BookmarksSection.tsx
@@ -1,5 +1,5 @@
 /**
- * BookmarksSection — JJ bookmark list with remote tracking indicators.
+ * BookmarksSection — Git branch list with remote tracking indicators.
  */
 
 import { useCallback, useState } from 'react';
@@ -51,7 +51,7 @@ export function BookmarksSection({
       setNewName('');
       setShowCreate(false);
     } catch (err) {
-      showToast(err instanceof Error ? err.message : 'Failed to create bookmark');
+      showToast(err instanceof Error ? err.message : 'Failed to create branch');
     }
   }, [workspaceId, newName, store]);
 
@@ -87,7 +87,7 @@ export function BookmarksSection({
 
   return (
     <VcsSection
-      title="Bookmarks"
+      title="Branches"
       count={bookmarks.length}
       actions={
         <div className="flex items-center gap-0.5">
@@ -108,14 +108,14 @@ export function BookmarksSection({
               </SectionAction>
             </>
           )}
-          <SectionAction onClick={() => setShowCreate((v) => !v)} title="Create bookmark">
+          <SectionAction onClick={() => setShowCreate((v) => !v)} title="Create branch">
             <Plus className="size-3" />
           </SectionAction>
         </div>
       }
     >
       <div className="pb-1.5">
-        {/* Create bookmark inline form */}
+        {/* Create branch inline form */}
         <AnimatePresence>
           {showCreate && (
             <motion.div
@@ -159,10 +159,10 @@ export function BookmarksSection({
           )}
         </AnimatePresence>
 
-        {/* Bookmark list */}
+        {/* Branch list */}
         {bookmarks.length === 0 ? (
           <div className="px-3 py-1.5 text-[11px] text-[var(--text-muted)]/60">
-            No bookmarks
+            No branches
           </div>
         ) : (
           bookmarks.map((bm, i) => (
@@ -197,7 +197,7 @@ export function BookmarksSection({
   );
 }
 
-// ── Bookmark row ─────────────────────────────────────────────
+// ── Branch row ───────────────────────────────────────────────
 
 function BookmarkRow({
   bookmark,

--- a/apps/desktop/src/components/apps/coding/vcs/ChangeLog.tsx
+++ b/apps/desktop/src/components/apps/coding/vcs/ChangeLog.tsx
@@ -1,7 +1,7 @@
 /**
  * ChangeLog — dense, paginated change history.
  *
- * Each row: glyph · changeId · age · description · [bookmarks]
+ * Each row: glyph · commitSha · age · description · [branches]
  * Click to expand inline detail. Context menu for actions.
  */
 
@@ -37,11 +37,11 @@ export function ChangeLog({ workspaceId, entries, hasMore, onOpenDiff }: Props) 
   }, [workspaceId, loadMore]);
 
   return (
-    <VcsSection title="Changes" count={entries.length} defaultOpen>
+    <VcsSection title="Commits" count={entries.length} defaultOpen>
       <div className="pb-1">
         {entries.length === 0 ? (
           <div className="px-3 py-2 text-[11px] text-[var(--text-muted)]/60">
-            No changes yet
+            No commits yet
           </div>
         ) : (
           entries.map((entry, i) => (

--- a/apps/desktop/src/components/apps/coding/vcs/VcsPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/vcs/VcsPanel.tsx
@@ -1,7 +1,7 @@
 /**
- * VcsPanel — rich JJ source control panel.
+ * VcsPanel — rich Git source control panel.
  *
- * Sections: Working Copy Status, Bookmarks, Change Log, Remotes.
+ * Sections: Working Copy Status, Branches, Commit Log, Remotes.
  * Each section is a collapsible animated group.
  */
 
@@ -55,7 +55,7 @@ export function VcsPanel({ workspaceId, onOpenDiff }: VcsPanelProps) {
           <HeaderButton
             onClick={handleUndo}
             loading={undoing}
-            title="Undo last JJ operation"
+            title="Undo last operation"
           >
             <Undo2 className="size-3.5" />
           </HeaderButton>

--- a/apps/desktop/src/components/apps/coding/vcs/WorkingCopySection.tsx
+++ b/apps/desktop/src/components/apps/coding/vcs/WorkingCopySection.tsx
@@ -105,7 +105,7 @@ export function WorkingCopySection({ workspaceId, status, currentChangeId, onOpe
           <button
             onClick={handleCheckpoint}
             disabled={creating}
-            title="Create checkpoint"
+            title="Create commit"
             className={cn(
               'flex h-6 items-center gap-1 rounded px-2 text-[11px] font-medium',
               'bg-[var(--bg-elevated)] text-[var(--text-secondary)]',

--- a/apps/desktop/src/stores/vcs.ts
+++ b/apps/desktop/src/stores/vcs.ts
@@ -195,7 +195,7 @@ export const useVcsStore = create<VcsStore>((set, get) => ({
       const status = await window.sero.vcs.status(wsId);
       updateWs(set, wsId, { wcStatus: status });
     } catch (err) {
-      console.debug('[vcs] Failed to load status (may not have JJ repo yet):', err);
+      console.debug('[vcs] Failed to load status (may not have Git repo yet):', err);
     }
   },
 

--- a/docs/jj-to-git-migration.md
+++ b/docs/jj-to-git-migration.md
@@ -1,0 +1,219 @@
+# Migrating a JJ (Jujutsu) Colocated Workspace to Git
+
+Guide for converting a Sero workspace from JJ-managed version control to plain Git. Based on real migration experience.
+
+## Background
+
+Sero workspaces use Jujutsu (JJ) colocated with Git — meaning both `.jj/` and `.git/` exist in the repo. JJ manages the Git objects behind the scenes. This guide covers removing JJ and switching to native Git.
+
+## Prerequisites
+
+- The workspace has both `.jj/` and `.git/` directories (colocated mode)
+- You have `trash` available (preferred over `rm` for recoverability)
+
+---
+
+## Migration Steps
+
+### 1. Move bookmarks to the desired commits
+
+JJ bookmarks are the equivalent of Git branches, but they **don't auto-advance** with new commits. Before removing JJ, make sure all bookmarks point where you want the Git branches to end up.
+
+```bash
+# Check current state
+jj log --limit 15
+
+# Move a bookmark to the working copy
+jj bookmark move main --to @
+
+# Or move to a specific change
+jj bookmark move main --to <change-id>
+```
+
+**Verify the Git branch matches:**
+
+```bash
+cat .git/refs/heads/main
+```
+
+This should show the commit hash you expect. JJ writes to Git refs in real-time in colocated mode, so moving a bookmark immediately updates the Git branch.
+
+### 2. Remove the JJ directory
+
+```bash
+trash .jj
+```
+
+Use `trash` instead of `rm -rf` so you can recover if something goes wrong.
+
+### 3. Fix the detached HEAD
+
+JJ operates with a detached HEAD internally — it doesn't keep `.git/HEAD` pointed at a branch ref. After removing JJ, Git will think you're in a detached HEAD state:
+
+```
+$ git status
+HEAD detached from c6a08cf
+```
+
+**Fix it by writing the branch ref directly:**
+
+```bash
+echo "ref: refs/heads/main" > .git/HEAD
+```
+
+Replace `main` with whatever branch you want to be checked out.
+
+**Verify:**
+
+```bash
+git status
+# Should show: On branch main
+```
+
+### 4. Clean up JJ keep refs
+
+JJ creates internal references under `.git/refs/jj/keep/` to prevent Git from garbage-collecting commits that JJ is tracking. These can accumulate significantly (60+ refs is common).
+
+**These refs cause problems:**
+
+- During `git push`, Git sends all known refs to the remote for negotiation
+- The remote doesn't understand `refs/jj/keep/*` refs
+- This can trigger **HTTP 400 errors** during push:
+  ```
+  error: RPC failed; HTTP 400 curl 22 The requested URL returned error: 400
+  send-pack: unexpected disconnect while reading sideband packet
+  fatal: the remote end hung up unexpectedly
+  ```
+
+**Clean them up:**
+
+```bash
+rm -rf .git/refs/jj
+```
+
+This is safe to do after JJ has been removed — these refs only existed to serve JJ's internal tracking.
+
+### 5. Verify the final state
+
+```bash
+# Should show "On branch main" (or your chosen branch)
+git status
+
+# Should show your expected commit history
+git log --oneline -10
+
+# Should list only real branches
+git branch -a
+
+# No jj refs remaining
+find .git/refs/jj -type f 2>/dev/null | wc -l
+# Expected: 0
+
+# Test push works
+git push origin <branch-name>
+```
+
+---
+
+## Complete Migration Checklist
+
+```
+[ ] 1. Move all JJ bookmarks to correct positions
+[ ] 2. Verify .git/refs/heads/* match expected commits
+[ ] 3. Remove .jj/ directory (use trash)
+[ ] 4. Fix .git/HEAD → "ref: refs/heads/<branch>"
+[ ] 5. Remove .git/refs/jj/ directory
+[ ] 6. Verify git status shows correct branch
+[ ] 7. Test git push works
+```
+
+---
+
+## Gotchas & Troubleshooting
+
+### Bookmark vs Branch confusion
+
+JJ bookmarks ≠ Git branches in behavior. Bookmarks don't auto-advance, so if you've been committing in JJ without moving the bookmark, the Git branch will be stuck at an old commit. Always check and move bookmarks before removing JJ.
+
+### Large file warnings during bookmark move
+
+JJ may show warnings like:
+```
+Warning: Refused to snapshot some files:
+  image.png: 1.5MiB; the maximum size allowed is 1.0MiB
+```
+
+These warnings are about JJ's snapshot system and **don't prevent the bookmark move**. The Git commit tree already contains these files regardless of JJ's snapshot limit.
+
+### "Everything up-to-date" combined with push errors
+
+If you see both an HTTP 400 error AND "Everything up-to-date", it's almost certainly the `refs/jj/keep/*` refs polluting the push negotiation. Clean them up per step 4.
+
+### Sero's git command restrictions
+
+Sero may block mutating git commands (`commit`, `push`, `checkout`, `reset`) via a shell wrapper when it detects a managed workspace. After removing `.jj/`, the workspace VCS detection may need to refresh. You can still run git commands directly from an external terminal.
+
+### Multiple branches/bookmarks
+
+If the workspace had multiple JJ bookmarks (e.g., `main`, `feat/my-branch`, `chore/wip-manual`), each becomes a Git branch. Check all of them:
+
+```bash
+find .git/refs/heads -type f -exec echo {} \; -exec cat {} \;
+```
+
+Remove any you don't need:
+
+```bash
+git branch -d <unwanted-branch>
+```
+
+### Sero features that stop working
+
+After removing JJ, these Sero features will no longer work:
+- **Automatic checkpoints** (JJ-based snapshot after agent turns)
+- **Checkpoint restore** (uses `jj restore`)
+- **Source Control panel** JJ-specific features (bookmark management, JJ log)
+
+Standard Git operations through Sero's UI should continue to work.
+
+---
+
+## Sero VCS UI Push Failures (SSH→HTTPS Rewrite)
+
+### The Problem
+
+After migration, pushing from Sero's VCS UI could fail with:
+```
+error: RPC failed; HTTP 400 curl 22 The requested URL returned error: 400
+send-pack: unexpected disconnect while reading sideband packet
+fatal: the remote end hung up unexpectedly
+Everything up-to-date
+```
+
+Meanwhile, the same push works fine from the terminal.
+
+### Root Cause
+
+Sero's `GitHubAuthManager.getAuthEnvVars()` rewrites SSH remotes (`git@github.com:`) to HTTPS (`https://github.com/`) so it can authenticate with `GH_TOKEN` via `GIT_ASKPASS=gh`. This HTTPS transport is less tolerant of:
+
+1. **Large ref counts** — leftover `refs/jj/keep/*` refs (60+) bloat the ref negotiation payload
+2. **Large pack files** — HTTPS has stricter payload limits than SSH for push data
+
+SSH (used by the terminal) handles both of these without issue.
+
+### The Fix
+
+**`git-runner.ts`** now detects whether the host has working SSH keys for GitHub. If SSH works, it skips the HTTPS URL rewrite and lets git use SSH natively for push/fetch. The `GH_TOKEN` is still set for `gh` CLI operations (PRs, etc.).
+
+- SSH check is cached for the process lifetime (one `ssh -T git@github.com` call)
+- Falls back to HTTPS rewrite if no SSH keys are found (e.g., containers)
+- Container execution still uses HTTPS rewrite (containers rarely have SSH keys)
+
+### Preventing Future Issues
+
+When migrating workspaces, always clean up JJ keep refs (step 4) **before** attempting any push — even if you plan to use SSH. The refs can cause subtle issues with both transports.
+
+## Related
+
+- [JJ Versioning Strategy](./jj-versioning/strategy.md)
+- [Jujutsu Documentation](https://martinvonz.github.io/jj/)


### PR DESCRIPTION
## Summary

Replace the entire JJ-based VCS layer with native Git commands. This removes the Jujutsu dependency and uses standard Git for all version control operations.

## Changes

### Backend (`electron/vcs/`)
- **`jj-runner.ts` → `git-runner.ts`** — new `GitRunner` class wrapping Git CLI
- **`vcs-manager.ts`** — rewritten to use `git rev-parse`, `git status`, `git add/commit`, `git checkout/clean` for checkpoints
- **`parsers.ts`** — rewritten for `git log/status/branch/reflog` output formats
- **`vcs-ops.ts`** — all operations rewritten with Git equivalents
- **`pr-ops.ts`** — uses Git branches instead of JJ bookmarks
- **`sero-extension-jj.ts` → `sero-extension-git.ts`** — guards mutating Git commands while allowing read-only access

### Infrastructure
- **Dockerfile** — removed JJ installation, added Git config defaults
- **Container lifecycle** — uses `git init` instead of `jj git init`
- **`shared-infra.ts` / `agent-helpers.ts`** — updated for Git types/constants

### UI (`src/components/apps/coding/vcs/`)
- Renamed "Bookmarks" → "Branches", "Changes" → "Commits" in VCS panel
- Updated terminology in `ChangeLog`, `BookmarksSection`, `WorkingCopySection`

### Docs
- Added `docs/jj-to-git-migration.md` — migration guide and rationale

### Tests
- Updated e2e test comments for Git terminology

## Stats
- **21 files changed**, 761 insertions, 505 deletions
