### PR TITLE
feat: Google Workspace app — Gmail + Calendar with OAuth2

### DIFF
--- a/apps/desktop/electron/cli/commands/google.ts
+++ b/apps/desktop/electron/cli/commands/google.ts
@@ -1,0 +1,508 @@
+/**
+ * Google CLI commands — wraps gogcli (https://github.com/steipete/gogcli)
+ * to give Sero agents access to Gmail, Calendar, and Google auth.
+ *
+ * All commands delegate to the `gog` binary running inside the workspace
+ * container via `containerManager.exec()`.
+ */
+
+import { containerManager } from '../../ipc/shared-infra';
+import type { CliRegistry } from '../registry';
+import type { CliCommandContext, CliResult } from '../types';
+import { fail, ok, parseFlags, requireFlagString } from './utils';
+
+// ── Shell helpers ────────────────────────────────────────────
+
+/** Single-quote a value for safe inclusion in a sh -c command string. */
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/** Build a shell-safe command string from an array of arguments. */
+function buildCommand(args: string[]): string {
+  return args.map(shQuote).join(' ');
+}
+
+// ── gog execution ────────────────────────────────────────────
+
+const GOG_TIMEOUT_MS = 30_000;
+const GOG_AUTH_TIMEOUT_MS = 60_000;
+
+interface GogResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runGog(
+  gogArgs: string[],
+  ctx: CliCommandContext,
+  opts?: { json?: boolean; account?: string; timeoutMs?: number; noInput?: boolean },
+): Promise<GogResult> {
+  const parts = ['gog'];
+  if (opts?.account) parts.push('--account', opts.account);
+  if (opts?.json) parts.push('--json');
+  if (opts?.noInput !== false) parts.push('--no-input');
+  parts.push(...gogArgs);
+
+  const command = buildCommand(parts);
+  const timeout = opts?.timeoutMs ?? GOG_TIMEOUT_MS;
+
+  return containerManager.exec(ctx.workspaceId, command, undefined, timeout);
+}
+
+function gogResultToCliResult(result: GogResult): CliResult {
+  if (result.exitCode === 127) {
+    return fail(
+      'gogcli (gog) not found in container. Install it: brew install steipete/tap/gogcli\n' +
+      'See https://github.com/steipete/gogcli for details.',
+    );
+  }
+
+  const output = result.stdout.trim();
+  const stderr = result.stderr.trim();
+
+  if (result.exitCode !== 0) {
+    // Surface the most useful error message
+    const errorText = stderr || output || 'Command failed';
+    if (errorText.includes('no authenticated accounts') || errorText.includes('not authenticated')) {
+      return fail(`${errorText}\n\nHint: Run "sero google auth add <email>" to authenticate a Google account.`);
+    }
+    return fail(errorText);
+  }
+
+  // Combine stdout (primary) with any stderr warnings
+  const parts = [output];
+  if (stderr && !stderr.startsWith('{')) {
+    parts.push(`\n[stderr] ${stderr}`);
+  }
+  return ok(parts.join(''));
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Extract --account flag from args, returning the cleaned args and account. */
+function extractAccount(args: string[]): { cleaned: string[]; account?: string } {
+  const { positionals, flags } = parseFlags(args);
+  const account = requireFlagString(flags, 'account') ?? undefined;
+
+  // Rebuild args without --account (pass all other flags through)
+  const cleaned: string[] = [...positionals];
+  for (const [key, value] of flags) {
+    if (key === 'account') continue;
+    if (value === true) {
+      cleaned.push(`--${key}`);
+    } else {
+      cleaned.push(`--${key}`, value);
+    }
+  }
+  return { cleaned, account };
+}
+
+// ── Auth commands ────────────────────────────────────────────
+
+async function handleAuth(args: string[], ctx: CliCommandContext): Promise<CliResult> {
+  const [action, ...rest] = args;
+  if (!action) {
+    return fail(
+      'Usage: sero google auth <action>\n\n' +
+      'Actions:\n' +
+      '  credentials <path>     Import OAuth client credentials JSON\n' +
+      '  add <email>            Authorize a Google account\n' +
+      '  remove <email>         Remove an authorized account\n' +
+      '  list [--check]         List authorized accounts\n' +
+      '  status                 Show auth status and services\n' +
+      '  services               Show available Google services\n' +
+      '  alias set <n> <email>  Set an account alias\n' +
+      '  alias list             List aliases\n' +
+      '  alias unset <name>     Remove an alias',
+    );
+  }
+
+  const { cleaned, account } = extractAccount(rest);
+
+  switch (action) {
+    case 'credentials': {
+      const path = cleaned[0];
+      if (!path) return fail('Usage: sero google auth credentials <path-to-credentials.json>');
+      return gogResultToCliResult(
+        await runGog(['auth', 'credentials', path], ctx, { account, timeoutMs: GOG_AUTH_TIMEOUT_MS }),
+      );
+    }
+
+    case 'add': {
+      const email = cleaned[0];
+      if (!email) return fail('Usage: sero google auth add <email>');
+      // auth add may need longer timeout for OAuth flow
+      return gogResultToCliResult(
+        await runGog(['auth', 'add', email, ...cleaned.slice(1)], ctx, {
+          account,
+          timeoutMs: GOG_AUTH_TIMEOUT_MS,
+          noInput: false, // auth flow may need interaction
+        }),
+      );
+    }
+
+    case 'remove': {
+      const email = cleaned[0];
+      if (!email) return fail('Usage: sero google auth remove <email>');
+      return gogResultToCliResult(
+        await runGog(['auth', 'remove', email, '--force'], ctx, { account, timeoutMs: GOG_AUTH_TIMEOUT_MS }),
+      );
+    }
+
+    case 'list':
+      return gogResultToCliResult(
+        await runGog(['auth', 'list', ...cleaned], ctx, { account }),
+      );
+
+    case 'status':
+      return gogResultToCliResult(
+        await runGog(['auth', 'status'], ctx, { account }),
+      );
+
+    case 'services':
+      return gogResultToCliResult(
+        await runGog(['auth', 'services'], ctx, { account }),
+      );
+
+    case 'alias': {
+      const [aliasAction, ...aliasRest] = cleaned;
+      if (!aliasAction || !['set', 'list', 'unset'].includes(aliasAction)) {
+        return fail('Usage: sero google auth alias <set|list|unset> [args]');
+      }
+      return gogResultToCliResult(
+        await runGog(['auth', 'alias', aliasAction, ...aliasRest], ctx, { account }),
+      );
+    }
+
+    default:
+      return fail(`Unknown auth action: ${action}. Run "sero google auth" for usage.`);
+  }
+}
+
+// ── Gmail commands ───────────────────────────────────────────
+
+async function handleGmail(args: string[], ctx: CliCommandContext): Promise<CliResult> {
+  const [action, ...rest] = args;
+  if (!action) {
+    return fail(
+      'Usage: sero google gmail <action>\n\n' +
+      'Actions:\n' +
+      '  search \'<query>\' [--max N]  Search emails\n' +
+      '  get <messageId>             Get a message\n' +
+      '  thread <threadId>           Get a thread\n' +
+      '  send [flags]                Send an email\n' +
+      '  labels list                 List labels\n' +
+      '  labels modify <threadId>    Modify thread labels\n' +
+      '  drafts list                 List drafts\n' +
+      '  drafts create [flags]       Create a draft\n' +
+      '  drafts send <draftId>       Send a draft\n' +
+      '  url <threadId>              Get web URL for thread',
+    );
+  }
+
+  const { cleaned, account } = extractAccount(rest);
+
+  switch (action) {
+    case 'search': {
+      const query = cleaned[0];
+      if (!query) return fail('Usage: sero google gmail search \'<query>\' [--max N]');
+      const gogArgs = ['gmail', 'search', query];
+      // Pass through remaining flags
+      for (let i = 1; i < cleaned.length; i++) gogArgs.push(cleaned[i]!);
+      return gogResultToCliResult(
+        await runGog(gogArgs, ctx, { json: true, account }),
+      );
+    }
+
+    case 'get': {
+      const messageId = cleaned[0];
+      if (!messageId) return fail('Usage: sero google gmail get <messageId>');
+      return gogResultToCliResult(
+        await runGog(['gmail', 'get', messageId, ...cleaned.slice(1)], ctx, { json: true, account }),
+      );
+    }
+
+    case 'thread': {
+      const threadId = cleaned[0];
+      if (!threadId) return fail('Usage: sero google gmail thread <threadId>');
+      return gogResultToCliResult(
+        await runGog(['gmail', 'thread', 'get', threadId, ...cleaned.slice(1)], ctx, { json: true, account }),
+      );
+    }
+
+    case 'send': {
+      if (cleaned.length === 0) {
+        return fail(
+          'Usage: sero google gmail send --to <email> --subject "<s>" --body "<b>"\n' +
+          '       sero google gmail send --reply-to-message-id <id> --body "<b>" [--quote]',
+        );
+      }
+      return gogResultToCliResult(
+        await runGog(['gmail', 'send', ...cleaned], ctx, { json: true, account }),
+      );
+    }
+
+    case 'labels': {
+      const [labelAction, ...labelRest] = cleaned;
+      if (!labelAction) return fail('Usage: sero google gmail labels <list|modify|create|delete>');
+
+      switch (labelAction) {
+        case 'list':
+          return gogResultToCliResult(
+            await runGog(['gmail', 'labels', 'list', ...labelRest], ctx, { json: true, account }),
+          );
+        case 'modify':
+          if (!labelRest[0]) return fail('Usage: sero google gmail labels modify <threadId> --add <label> --remove <label>');
+          return gogResultToCliResult(
+            await runGog(['gmail', 'labels', 'modify', ...labelRest], ctx, { json: true, account }),
+          );
+        case 'create':
+          if (!labelRest[0]) return fail('Usage: sero google gmail labels create "<name>"');
+          return gogResultToCliResult(
+            await runGog(['gmail', 'labels', 'create', ...labelRest], ctx, { json: true, account }),
+          );
+        case 'delete':
+          if (!labelRest[0]) return fail('Usage: sero google gmail labels delete <labelId>');
+          return gogResultToCliResult(
+            await runGog(['gmail', 'labels', 'delete', ...labelRest], ctx, { account }),
+          );
+        default:
+          return fail(`Unknown labels action: ${labelAction}. Use: list, modify, create, delete`);
+      }
+    }
+
+    case 'drafts': {
+      const [draftAction, ...draftRest] = cleaned;
+      if (!draftAction) return fail('Usage: sero google gmail drafts <list|create|send>');
+
+      switch (draftAction) {
+        case 'list':
+          return gogResultToCliResult(
+            await runGog(['gmail', 'drafts', 'list', ...draftRest], ctx, { json: true, account }),
+          );
+        case 'create':
+          return gogResultToCliResult(
+            await runGog(['gmail', 'drafts', 'create', ...draftRest], ctx, { json: true, account }),
+          );
+        case 'send': {
+          const draftId = draftRest[0];
+          if (!draftId) return fail('Usage: sero google gmail drafts send <draftId>');
+          return gogResultToCliResult(
+            await runGog(['gmail', 'drafts', 'send', ...draftRest], ctx, { json: true, account }),
+          );
+        }
+        default:
+          return fail(`Unknown drafts action: ${draftAction}. Use: list, create, send`);
+      }
+    }
+
+    case 'url': {
+      const threadId = cleaned[0];
+      if (!threadId) return fail('Usage: sero google gmail url <threadId>');
+      return gogResultToCliResult(
+        await runGog(['gmail', 'url', threadId], ctx, { account }),
+      );
+    }
+
+    default:
+      return fail(`Unknown gmail action: ${action}. Run "sero google gmail" for usage.`);
+  }
+}
+
+// ── Calendar commands ────────────────────────────────────────
+
+async function handleCalendar(args: string[], ctx: CliCommandContext): Promise<CliResult> {
+  const [action, ...rest] = args;
+  if (!action) {
+    return fail(
+      'Usage: sero google calendar <action>\n\n' +
+      'Actions:\n' +
+      '  calendars                       List calendars\n' +
+      '  events [calId] [--today|--week] List events\n' +
+      '  search "<query>" [--today]      Search events\n' +
+      '  event <calId> <eventId>         Get event details\n' +
+      '  create <calId> [flags]          Create an event\n' +
+      '  update <calId> <eventId> [fl.]  Update an event\n' +
+      '  delete <calId> <eventId>        Delete an event\n' +
+      '  respond <calId> <eventId> [fl.] Respond to invitation\n' +
+      '  freebusy [flags]                Check availability\n' +
+      '  conflicts [flags]               Show scheduling conflicts',
+    );
+  }
+
+  const { cleaned, account } = extractAccount(rest);
+
+  switch (action) {
+    case 'calendars':
+      return gogResultToCliResult(
+        await runGog(['calendar', 'calendars', ...cleaned], ctx, { json: true, account }),
+      );
+
+    case 'events': {
+      // If first positional looks like a flag, assume default calendar
+      const gogArgs = ['calendar', 'events', ...cleaned];
+      return gogResultToCliResult(
+        await runGog(gogArgs, ctx, { json: true, account }),
+      );
+    }
+
+    case 'search': {
+      const query = cleaned[0];
+      if (!query) return fail('Usage: sero google calendar search "<query>" [--today|--week|--days N]');
+      return gogResultToCliResult(
+        await runGog(['calendar', 'search', query, ...cleaned.slice(1)], ctx, { json: true, account }),
+      );
+    }
+
+    case 'event': {
+      const calId = cleaned[0];
+      const eventId = cleaned[1];
+      if (!calId || !eventId) return fail('Usage: sero google calendar event <calendarId> <eventId>');
+      return gogResultToCliResult(
+        await runGog(['calendar', 'event', calId, eventId, ...cleaned.slice(2)], ctx, { json: true, account }),
+      );
+    }
+
+    case 'create': {
+      const calId = cleaned[0];
+      if (!calId) {
+        return fail(
+          'Usage: sero google calendar create <calendarId> --summary "<title>" --from <time> --to <time>\n' +
+          'Options: --attendees "<emails>" --location "<loc>" --description "<desc>"',
+        );
+      }
+      return gogResultToCliResult(
+        await runGog(['calendar', 'create', ...cleaned], ctx, { json: true, account }),
+      );
+    }
+
+    case 'update': {
+      const calId = cleaned[0];
+      const eventId = cleaned[1];
+      if (!calId || !eventId) return fail('Usage: sero google calendar update <calendarId> <eventId> [flags]');
+      return gogResultToCliResult(
+        await runGog(['calendar', 'update', ...cleaned], ctx, { json: true, account }),
+      );
+    }
+
+    case 'delete': {
+      const calId = cleaned[0];
+      const eventId = cleaned[1];
+      if (!calId || !eventId) return fail('Usage: sero google calendar delete <calendarId> <eventId>');
+      return gogResultToCliResult(
+        await runGog(['calendar', 'delete', calId, eventId, ...cleaned.slice(2)], ctx, { account }),
+      );
+    }
+
+    case 'respond': {
+      const calId = cleaned[0];
+      const eventId = cleaned[1];
+      if (!calId || !eventId) {
+        return fail('Usage: sero google calendar respond <calendarId> <eventId> --status accepted|declined|tentative');
+      }
+      return gogResultToCliResult(
+        await runGog(['calendar', 'respond', ...cleaned], ctx, { json: true, account }),
+      );
+    }
+
+    case 'freebusy':
+      return gogResultToCliResult(
+        await runGog(['calendar', 'freebusy', ...cleaned], ctx, { json: true, account }),
+      );
+
+    case 'conflicts':
+      return gogResultToCliResult(
+        await runGog(['calendar', 'conflicts', ...cleaned], ctx, { json: true, account }),
+      );
+
+    default:
+      return fail(`Unknown calendar action: ${action}. Run "sero google calendar" for usage.`);
+  }
+}
+
+// ── Top-level router ─────────────────────────────────────────
+
+async function handleGoogle(args: string[], ctx: CliCommandContext): Promise<CliResult> {
+  const [service, ...rest] = args;
+  if (!service) {
+    return fail(
+      'Usage: sero google <service> <action> [args]\n\n' +
+      'Services:\n' +
+      '  auth       Manage Google account authentication\n' +
+      '  gmail      Search, read, send, and manage email\n' +
+      '  calendar   View, create, and manage calendar events\n\n' +
+      'Global flags:\n' +
+      '  --account <email|alias>   Select Google account\n\n' +
+      'Examples:\n' +
+      '  sero google auth list\n' +
+      '  sero google gmail search \'newer_than:1d\'\n' +
+      '  sero google calendar events primary --today',
+    );
+  }
+
+  switch (service) {
+    case 'auth':
+      return handleAuth(rest, ctx);
+    case 'gmail':
+      return handleGmail(rest, ctx);
+    case 'calendar':
+      return handleCalendar(rest, ctx);
+    default:
+      return fail(
+        `Unknown Google service: ${service}. Available: auth, gmail, calendar`,
+      );
+  }
+}
+
+// ── Registration ─────────────────────────────────────────────
+
+export function registerGoogleCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'google',
+    summary: 'Google Workspace commands — Gmail, Calendar, auth (via gogcli)',
+    help:
+      'google — Google Workspace (powered by gogcli)\n\n' +
+      'Usage: sero google <service> <action> [args] [--flags]\n\n' +
+      'Services:\n' +
+      '  auth                          Account authentication\n' +
+      '    credentials <path>          Import OAuth client credentials\n' +
+      '    add <email>                 Authorize a Google account\n' +
+      '    remove <email>              Remove account\n' +
+      '    list [--check]              List authorized accounts\n' +
+      '    status                      Show auth status\n' +
+      '    services                    Show available services\n' +
+      '    alias set|list|unset        Manage account aliases\n\n' +
+      '  gmail                         Email operations\n' +
+      '    search \'<query>\' [--max N]  Search emails\n' +
+      '    get <messageId>             Read a message\n' +
+      '    thread <threadId>           Read a thread\n' +
+      '    send [flags]                Send an email\n' +
+      '    labels list|modify|create   Manage labels\n' +
+      '    drafts list|create|send     Manage drafts\n' +
+      '    url <threadId>              Get web URL\n\n' +
+      '  calendar                      Calendar operations\n' +
+      '    calendars                   List calendars\n' +
+      '    events [calId] [--today]    List events\n' +
+      '    search "<query>"            Search events\n' +
+      '    event <calId> <eventId>     Get event details\n' +
+      '    create <calId> [flags]      Create event\n' +
+      '    update <calId> <eId> [fl.]  Update event\n' +
+      '    delete <calId> <eventId>    Delete event\n' +
+      '    respond <calId> <eId> [fl.] RSVP to invitation\n' +
+      '    freebusy [flags]            Check availability\n' +
+      '    conflicts [flags]           Show conflicts\n\n' +
+      'Global flags:\n' +
+      '  --account <email|alias>       Select Google account\n\n' +
+      'Examples:\n' +
+      '  sero google auth list\n' +
+      '  sero google gmail search \'from:boss newer_than:1d\'\n' +
+      '  sero google gmail send --to user@example.com --subject "Hi" --body "Hello"\n' +
+      '  sero google calendar events primary --today\n' +
+      '  sero google calendar create primary --summary "Standup" --from 9:00 --to 9:30\n',
+    source: 'builtin',
+    group: 'Google',
+    execute: handleGoogle,
+  });
+}

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -3,6 +3,7 @@ import { registerAppStateCliCommands } from './commands/appstate';
 import { registerArtifactCliCommands } from './commands/artifacts';
 import { registerDevServerCliCommands } from './commands/devserver';
 import { registerEditorCliCommands } from './commands/editor';
+import { registerGoogleCliCommands } from './commands/google';
 import { registerSessionCliCommands } from './commands/session';
 import { registerTerminalCliCommands } from './commands/terminal';
 import { registerVcsCliCommands } from './commands/vcs';
@@ -23,6 +24,7 @@ function registerCoreCommands(target: CliRegistry): void {
   registerEditorCliCommands(target);
   registerAppStateCliCommands(target);
   registerTerminalCliCommands(target);
+  registerGoogleCliCommands(target);
   registerHelpCliCommand(target);
 }
 
@@ -97,6 +99,9 @@ Quick reference (run \`sero help\` for full list):
   sero workspace info
   sero vcs status
   sero devserver list
+  sero google auth list
+  sero google gmail search 'newer_than:1d'
+  sero google calendar events primary --today
 
 Chain commands (one per line):
   sero todo list

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -53,6 +53,8 @@ const TOOLS_TO_BRIDGE = new Set([
   'calc',
   'daily_quote',
   'weight',
+  'gmail',
+  'gcal',
 ]);
 
 /**
@@ -99,6 +101,8 @@ Quick reference (run \`sero help\` for full list):
   sero workspace info
   sero vcs status
   sero devserver list
+  sero gmail search --query "newer_than:3d"
+  sero gcal today
   sero google auth list
   sero google gmail search 'newer_than:1d'
   sero google calendar events primary --today

--- a/apps/desktop/electron/google/auth-manager.ts
+++ b/apps/desktop/electron/google/auth-manager.ts
@@ -1,0 +1,241 @@
+/**
+ * GoogleAuthManager — OAuth2 Authorization Code + PKCE.
+ *
+ * Flow: click "Sign in" → browser opens → Google account chooser →
+ * user approves → redirect to localhost → token exchange → done.
+ *
+ * After auth, the refresh token is imported into gogcli's keychain
+ * so all `gog gmail/calendar` commands work natively.
+ */
+
+import { shell } from 'electron';
+import http from 'node:http';
+import crypto from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+// ── Lazy env access ──────────────────────────────────────────
+function getClientId(): string { return process.env.GOOGLE_CLIENT_ID ?? ''; }
+function getClientSecret(): string { return process.env.GOOGLE_CLIENT_SECRET ?? ''; }
+
+const AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const USERINFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
+const LOOPBACK = '127.0.0.1';
+
+const SCOPES = [
+  'openid',
+  'https://www.googleapis.com/auth/userinfo.email',
+  'https://mail.google.com/',
+  'https://www.googleapis.com/auth/calendar',
+].join(' ');
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface GoogleAuthStatus {
+  configured: boolean;
+  authenticated: boolean;
+  email?: string;
+}
+
+export interface GoogleAuthProgress {
+  type: 'browser' | 'waiting' | 'success' | 'error';
+  message: string;
+  email?: string;
+}
+
+// ── Binary helpers (inlined to avoid circular imports) ────────
+
+function findGog(): string {
+  const paths = ['/opt/homebrew/bin/gog', '/usr/local/bin/gog',
+    path.join(homedir(), '.local/bin/gog'), path.join(homedir(), 'go/bin/gog')];
+  return paths.find((p) => existsSync(p)) ?? 'gog';
+}
+
+function gogEnv(): NodeJS.ProcessEnv {
+  const extra = ['/opt/homebrew/bin', '/usr/local/bin',
+    path.join(homedir(), '.local/bin'), path.join(homedir(), 'go/bin')];
+  return {
+    ...process.env,
+    PATH: [...extra, process.env.PATH || ''].join(':'),
+    // File-based keyring (no macOS Keychain prompts). Password is fixed
+    // because the file lives in a user-only directory anyway.
+    GOG_KEYRING_PASSWORD: 'sero-google-keyring',
+  };
+}
+
+function pipeToGog(args: string[], stdin: string): Promise<{ ok: boolean; out: string }> {
+  return new Promise((resolve) => {
+    const child = execFile(findGog(), args, { env: gogEnv(), timeout: 10_000 },
+      (err, stdout, stderr) => {
+        if (err) console.warn(`[google-auth] gog ${args.slice(0, 3).join(' ')} failed:`, stderr?.trim() || err.message);
+        resolve({ ok: !err, out: (stdout ?? '').trim() });
+      });
+    child.stdin?.write(stdin);
+    child.stdin?.end();
+    child.on('error', (e) => resolve({ ok: false, out: e.message }));
+  });
+}
+
+// ── Manager ──────────────────────────────────────────────────
+
+export class GoogleAuthManager {
+  private email: string | null = null;
+  private credsImported = false;
+
+  isConfigured(): boolean { return !!getClientId() && !!getClientSecret(); }
+  getEmail(): string | null { return this.email; }
+
+  async getStatus(): Promise<GoogleAuthStatus> {
+    if (!this.isConfigured()) return { configured: false, authenticated: false };
+
+    // Check gogcli for stored tokens
+    const result = await this.gogExec(['--json', 'auth', 'tokens', 'list']);
+    if (result) {
+      try {
+        const keys: string[] = (JSON.parse(result) as { keys?: string[] }).keys ?? [];
+        const tok = keys.find((k) => k.startsWith('token:'));
+        if (tok) {
+          this.email = tok.split(':').slice(2).join(':');
+          return { configured: true, authenticated: true, email: this.email };
+        }
+      } catch { /* parse error */ }
+    }
+    return { configured: true, authenticated: false };
+  }
+
+  /**
+   * Full OAuth2 sign-in. Opens browser, waits for callback.
+   * No email input needed — Google's account chooser handles it.
+   */
+  async login(onProgress: (e: GoogleAuthProgress) => void): Promise<void> {
+    if (!this.isConfigured()) {
+      throw new Error('Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in ~/.sero-ui/agent/.env');
+    }
+
+    // PKCE
+    const verifier = crypto.randomBytes(32).toString('base64url');
+    const challenge = crypto.createHash('sha256').update(verifier).digest('base64url');
+
+    // Loopback server
+    const { port, getCode, server } = await this.startServer();
+    const redirect = `http://${LOOPBACK}:${port}`;
+
+    const params = new URLSearchParams({
+      client_id: getClientId(), redirect_uri: redirect,
+      response_type: 'code', scope: SCOPES,
+      access_type: 'offline', prompt: 'consent',
+      code_challenge: challenge, code_challenge_method: 'S256',
+    });
+
+    onProgress({ type: 'browser', message: 'Opening Google sign-in…' });
+    void shell.openExternal(`${AUTH_URL}?${params}`);
+    onProgress({ type: 'waiting', message: 'Waiting for authorization…' });
+
+    let code: string;
+    try { code = await getCode; } finally { server.close(); }
+
+    // Exchange code → tokens
+    const tokens = await this.exchangeCode(code, redirect, verifier);
+    if (!tokens.refresh_token) {
+      throw new Error('No refresh token. Revoke access at myaccount.google.com/permissions and retry.');
+    }
+
+    // Get email from Google
+    const email = await this.fetchEmail(tokens.access_token);
+    this.email = email;
+
+    // Import into gogcli
+    await this.importToGogcli(email, tokens.refresh_token);
+
+    onProgress({ type: 'success', message: `Signed in as ${email}`, email });
+  }
+
+  async logout(): Promise<void> {
+    if (this.email) {
+      await pipeToGog(['auth', 'tokens', 'delete', this.email, '--force'], '');
+      this.email = null;
+    }
+  }
+
+  // ── OAuth helpers ──────────────────────────────────────────
+
+  private startServer(): Promise<{ port: number; getCode: Promise<string>; server: http.Server }> {
+    return new Promise((resolve, reject) => {
+      const server = http.createServer();
+      const getCode = new Promise<string>((ok, fail) => {
+        server.on('request', (req, res) => {
+          const url = new URL(req.url ?? '/', `http://${LOOPBACK}`);
+          const code = url.searchParams.get('code');
+          const error = url.searchParams.get('error');
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+          if (code) {
+            res.end('<html><head><script>window.close()</script></head><body><p>Signed in. You can close this tab.</p></body></html>');
+            ok(code);
+          } else {
+            res.end(`<h2>Error</h2><p>${error ?? 'Unknown'}</p>`);
+            fail(new Error(error ?? 'Authorization denied'));
+          }
+        });
+      });
+      server.listen(0, LOOPBACK, () => {
+        const addr = server.address();
+        if (!addr || typeof addr === 'string') { reject(new Error('Listen failed')); return; }
+        resolve({ port: addr.port, getCode, server });
+      });
+      server.on('error', reject);
+    });
+  }
+
+  private async exchangeCode(code: string, redirect: string, verifier: string) {
+    const resp = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        code, client_id: getClientId(), client_secret: getClientSecret(),
+        redirect_uri: redirect, grant_type: 'authorization_code', code_verifier: verifier,
+      }),
+    });
+    if (!resp.ok) throw new Error(`Token exchange failed: ${resp.status} ${await resp.text()}`);
+    return (await resp.json()) as { access_token: string; refresh_token?: string; expires_in: number };
+  }
+
+  private async fetchEmail(accessToken: string): Promise<string> {
+    const resp = await fetch(USERINFO_URL, { headers: { Authorization: `Bearer ${accessToken}` } });
+    if (!resp.ok) throw new Error(`Userinfo failed: ${resp.status}`);
+    return ((await resp.json()) as { email: string }).email;
+  }
+
+  // ── gogcli integration ─────────────────────────────────────
+
+  private async importToGogcli(email: string, refreshToken: string): Promise<void> {
+    // 1. Import OAuth client credentials
+    await this.ensureCredentials();
+
+    // 2. Import refresh token into keychain
+    const r = await pipeToGog(['auth', 'tokens', 'import', '-'],
+      JSON.stringify({ email, refresh_token: refreshToken }));
+    if (r.ok) console.log('[google-auth] Token imported into gogcli for', email);
+    else console.warn('[google-auth] Token import failed:', r.out);
+  }
+
+  private async ensureCredentials(): Promise<void> {
+    if (this.credsImported) return;
+    const r = await pipeToGog(['auth', 'credentials', 'set', '-'], JSON.stringify({
+      installed: {
+        client_id: getClientId(), client_secret: getClientSecret(),
+        auth_uri: AUTH_URL, token_uri: TOKEN_URL, redirect_uris: ['http://localhost'],
+      },
+    }));
+    if (r.ok) this.credsImported = true;
+  }
+
+  private gogExec(args: string[]): Promise<string | null> {
+    return new Promise((resolve) => {
+      execFile(findGog(), args, { env: gogEnv(), timeout: 10_000 },
+        (err, stdout) => resolve(err ? null : (stdout ?? '')));
+    });
+  }
+}

--- a/apps/desktop/electron/ipc/google-api.ts
+++ b/apps/desktop/electron/ipc/google-api.ts
@@ -1,0 +1,120 @@
+/**
+ * Google API IPC handlers.
+ *
+ * Two concerns:
+ *   1. Auth — Google OAuth2 via GoogleAuthManager (like GitHub auth)
+ *   2. Data — execute gogcli (gog) commands for Gmail/Calendar
+ *
+ * PATH resolution: Electron on macOS doesn't inherit the shell
+ * PATH when launched from Finder/Dock. We probe common locations.
+ */
+
+import { ipcMain, BrowserWindow } from 'electron';
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import { IpcChannels } from '../../src/types/ipc';
+import { GoogleAuthManager } from '../google/auth-manager';
+
+// ── Types ────────────────────────────────────────────────────
+
+export interface GogExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+// ── Binary resolution ────────────────────────────────────────
+
+const GOG_SEARCH_PATHS = [
+  '/opt/homebrew/bin/gog',
+  '/usr/local/bin/gog',
+  path.join(homedir(), '.local/bin/gog'),
+  path.join(homedir(), 'go/bin/gog'),
+];
+
+let _resolvedGogPath: string | null | undefined;
+
+export function findGogBinary(): string {
+  if (_resolvedGogPath !== undefined) return _resolvedGogPath ?? 'gog';
+  for (const p of GOG_SEARCH_PATHS) {
+    if (existsSync(p)) { _resolvedGogPath = p; return p; }
+  }
+  _resolvedGogPath = null;
+  return 'gog';
+}
+
+export function buildEnhancedPath(): string {
+  const existing = process.env.PATH || '';
+  const extra = ['/opt/homebrew/bin', '/usr/local/bin',
+    path.join(homedir(), '.local/bin'), path.join(homedir(), 'go/bin')];
+  return [...new Set([...extra, ...existing.split(':')])].join(':');
+}
+
+// ── gogcli execution ─────────────────────────────────────────
+
+const GOG_TIMEOUT_MS = 30_000;
+
+function runGog(args: string[], email?: string): Promise<GogExecResult> {
+  return new Promise((resolve) => {
+    const accountArgs = email ? ['--account', email] : [];
+    const fullArgs = ['--json', '--no-input', ...accountArgs, ...args];
+    const child = execFile(findGogBinary(), fullArgs, {
+      timeout: GOG_TIMEOUT_MS,
+      maxBuffer: 10 * 1024 * 1024,
+      env: { ...process.env, PATH: buildEnhancedPath(), GOG_KEYRING_PASSWORD: 'sero-google-keyring' },
+    }, (error, stdout, stderr) => {
+      if (error && (error as any).code === 'ENOENT') {
+        resolve({ stdout: '', stderr: 'gog binary not found', exitCode: 127 });
+        return;
+      }
+      resolve({
+        stdout: stdout ?? '', stderr: stderr ?? '',
+        exitCode: error ? ((error as any).status ?? 1) : 0,
+      });
+    });
+    child.on('error', (err) => {
+      resolve({ stdout: '', stderr: err.message, exitCode: 127 });
+    });
+  });
+}
+
+// ── Registration ─────────────────────────────────────────────
+
+let googleAuth: GoogleAuthManager;
+
+export function getGoogleAuthManager(): GoogleAuthManager {
+  if (!googleAuth) googleAuth = new GoogleAuthManager();
+  return googleAuth;
+}
+
+export function registerGoogleApiHandlers(): void {
+  const auth = getGoogleAuthManager();
+
+  /** Execute a gogcli data command — auto-injects --account from auth. */
+  ipcMain.handle(
+    IpcChannels.google.execute,
+    async (_event, service: string, subArgs: string[]): Promise<GogExecResult> => {
+      return runGog([service, ...subArgs], auth.getEmail() ?? undefined);
+    },
+  );
+
+  /** Get auth status. */
+  ipcMain.handle(IpcChannels.google.authStatus, async () => {
+    return auth.getStatus();
+  });
+
+  /** Start OAuth2 sign-in flow (opens browser). */
+  ipcMain.handle(IpcChannels.google.login, async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    await auth.login((progress) => {
+      win?.webContents.send(IpcChannels.google.authEvent, progress);
+    });
+  });
+
+  /** Logout. */
+  ipcMain.handle(IpcChannels.google.logout, async () => {
+    auth.logout();
+  });
+}

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -32,6 +32,7 @@ import { registerNetHandlers } from './net';
 import { registerSafeStorageHandlers } from './safe-storage';
 import { registerUserFeedbackQuestionHandlers } from './user-feedback-questions';
 import { registerGatewayHandlers } from './gateway';
+import { registerGoogleApiHandlers } from './google-api';
 
 export function registerAllIpcHandlers(): void {
   registerWorkspaceHandlers();
@@ -60,4 +61,5 @@ export function registerAllIpcHandlers(): void {
   registerSafeStorageHandlers();
   registerUserFeedbackQuestionHandlers();
   registerGatewayHandlers();
+  registerGoogleApiHandlers();
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -49,7 +49,6 @@ import type {
 
 contextBridge.exposeInMainWorld('sero', {
   platform: process.platform,
-
   shell: {
     showItemInFolder: (fullPath: string): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.shell.showItemInFolder, fullPath),
@@ -90,10 +89,8 @@ contextBridge.exposeInMainWorld('sero', {
   sessions: {
     list: (workspaceId?: string): Promise<SeroSessionInfo[]> =>
       ipcRenderer.invoke(IpcChannels.sessions.list, workspaceId),
-
     create: (workspaceId?: string): Promise<SeroSessionInfo> =>
       ipcRenderer.invoke(IpcChannels.sessions.create, workspaceId),
-
     delete: (sessionPath: string): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.sessions.delete, sessionPath),
   },
@@ -213,6 +210,18 @@ contextBridge.exposeInMainWorld('sero', {
   appAgent: {
     prompt: (appId: string, workspaceId: string, text: string): Promise<string> =>
       ipcRenderer.invoke(IpcChannels.appAgent.prompt, appId, workspaceId, text),
+  },
+
+  google: {
+    execute: (service: string, subArgs: string[]) => ipcRenderer.invoke(IpcChannels.google.execute, service, subArgs),
+    authStatus: () => ipcRenderer.invoke(IpcChannels.google.authStatus),
+    login: () => ipcRenderer.invoke(IpcChannels.google.login),
+    logout: () => ipcRenderer.invoke(IpcChannels.google.logout),
+    onAuthEvent: (cb: (event: any) => void) => {
+      const handler = (_e: IpcRendererEvent, event: any) => cb(event);
+      ipcRenderer.on(IpcChannels.google.authEvent, handler);
+      return () => { ipcRenderer.removeListener(IpcChannels.google.authEvent, handler); };
+    },
   },
 
   imagegen: {
@@ -427,7 +436,6 @@ contextBridge.exposeInMainWorld('sero', {
     load: (): Promise<{ mainSidebarOpen: boolean; chatPanelOpen: boolean; favouriteApps?: string[] } | null> =>
       ipcRenderer.invoke(IpcChannels.layout.load),
   },
-
   net: {
     fetch: (request: ProxyFetchRequest): Promise<ProxyFetchResponse> =>
       ipcRenderer.invoke(IpcChannels.net.fetch, request),
@@ -470,30 +478,22 @@ contextBridge.exposeInMainWorld('sero', {
       ipcRenderer.invoke(IpcChannels.editor.getRootPath, workspaceId),
     isContainer: (workspaceId: string): Promise<boolean> =>
       ipcRenderer.invoke(IpcChannels.editor.isContainer, workspaceId),
-    rename: (workspaceId: string, oldPath: string, newPath: string): Promise<boolean> =>
-      ipcRenderer.invoke(IpcChannels.editor.rename, workspaceId, oldPath, newPath),
-    delete: (workspaceId: string, itemPath: string): Promise<boolean> =>
-      ipcRenderer.invoke(IpcChannels.editor.delete, workspaceId, itemPath),
-    createFile: (workspaceId: string, filePath: string): Promise<boolean> =>
-      ipcRenderer.invoke(IpcChannels.editor.createFile, workspaceId, filePath),
-    createDir: (workspaceId: string, dirPath: string): Promise<boolean> =>
-      ipcRenderer.invoke(IpcChannels.editor.createDir, workspaceId, dirPath),
+    rename: (wId: string, o: string, n: string): Promise<boolean> => ipcRenderer.invoke(IpcChannels.editor.rename, wId, o, n),
+    delete: (wId: string, p: string): Promise<boolean> => ipcRenderer.invoke(IpcChannels.editor.delete, wId, p),
+    createFile: (wId: string, p: string): Promise<boolean> => ipcRenderer.invoke(IpcChannels.editor.createFile, wId, p),
+    createDir: (wId: string, p: string): Promise<boolean> => ipcRenderer.invoke(IpcChannels.editor.createDir, wId, p),
   },
 
   filetree: {
-    watch: (workspaceId: string): Promise<void> =>
-      ipcRenderer.invoke(IpcChannels.filetree.watch, workspaceId),
-    unwatch: (workspaceId: string): Promise<void> =>
-      ipcRenderer.invoke(IpcChannels.filetree.unwatch, workspaceId),
-    onChanged: (callback: (data: { workspaceId: string; directories: string[] }) => void): (() => void) => {
-      const handler = (_e: IpcRendererEvent, data: { workspaceId: string; directories: string[] }) => callback(data);
-      ipcRenderer.on(IpcChannels.filetree.changed, handler);
-      return () => { ipcRenderer.removeListener(IpcChannels.filetree.changed, handler); };
+    watch: (wId: string): Promise<void> => ipcRenderer.invoke(IpcChannels.filetree.watch, wId),
+    unwatch: (wId: string): Promise<void> => ipcRenderer.invoke(IpcChannels.filetree.unwatch, wId),
+    onChanged: (cb: (d: { workspaceId: string; directories: string[] }) => void): (() => void) => {
+      const h = (_e: IpcRendererEvent, d: { workspaceId: string; directories: string[] }) => cb(d);
+      ipcRenderer.on(IpcChannels.filetree.changed, h);
+      return () => { ipcRenderer.removeListener(IpcChannels.filetree.changed, h); };
     },
   },
 
   debug: debugBridge,
-
   lsp: lspBridge,
-
 });

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -149,6 +149,37 @@ interface SeroAppsAPI {
   onNewAppDetected(callback: (appName: string) => void): () => void;
 }
 
+interface GogExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+interface GoogleAuthStatus {
+  configured: boolean;
+  authenticated: boolean;
+  email?: string;
+}
+
+interface GoogleAuthEvent {
+  type: 'browser' | 'waiting' | 'success' | 'error';
+  message: string;
+  email?: string;
+}
+
+interface SeroGoogleAPI {
+  /** Execute a gogcli data command: gog --json --no-input <service> <args>. */
+  execute(service: string, subArgs: string[]): Promise<GogExecResult>;
+  /** Get current auth status. */
+  authStatus(): Promise<GoogleAuthStatus>;
+  /** Start OAuth2 sign-in (opens browser). Resolves when complete. */
+  login(): Promise<void>;
+  /** Sign out. */
+  logout(): Promise<void>;
+  /** Subscribe to auth flow progress events. Returns unsubscribe. */
+  onAuthEvent(callback: (event: GoogleAuthEvent) => void): () => void;
+}
+
 interface SeroAppAgentAPI {
   /**
    * Send a prompt to an app's dedicated agent session.
@@ -410,6 +441,7 @@ interface SeroAPI {
   appState: SeroAppStateAPI;
   apps: SeroAppsAPI;
   appAgent: SeroAppAgentAPI;
+  google: SeroGoogleAPI;
   voice: SeroVoiceAPI;
   auth: SeroAuthAPI;
   container: SeroContainerAPI;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -274,6 +274,18 @@ export const IpcChannels = {
     /** Proxy an HTTP fetch through the main process (bypasses CORS). */
     fetch: 'sero:net:fetch',
   },
+  google: {
+    /** Execute a gogcli data command (gog --json --no-input <service> <args>). */
+    execute: 'sero:google:execute',
+    /** Get Google auth status (configured, authenticated, email). */
+    authStatus: 'sero:google:auth-status',
+    /** Start Google OAuth2 sign-in flow (opens browser). */
+    login: 'sero:google:login',
+    /** Sign out of Google. */
+    logout: 'sero:google:logout',
+    /** Main → renderer push: auth flow progress events. */
+    authEvent: 'sero:google:auth-event',
+  },
   safeStorage: {
     /** Encrypt a string via OS keychain (macOS Keychain / DPAPI). */
     encrypt: 'sero:safe-storage:encrypt',

--- a/docs/google-integration.md
+++ b/docs/google-integration.md
@@ -1,0 +1,238 @@
+# Google Integration
+
+Sero's Google Workspace app provides Gmail and Google Calendar access
+via [gogcli](https://github.com/steipete/gogcli), with native OAuth2
+authentication handled entirely in Electron.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Renderer (React)                                               │
+│  ┌──────────────┐  ┌───────────────┐  ┌──────────────────────┐ │
+│  │  AuthSetup    │  │  MailView     │  │  CalendarView        │ │
+│  │  (sign-in UI) │  │  MailThread   │  │  MiniCalendar        │ │
+│  │               │  │  (HTML email) │  │  EventDetail         │ │
+│  └──────┬───────┘  └──────┬────────┘  └──────────┬───────────┘ │
+│         │     useGoogleApi hook                   │             │
+│         └──────────────┬──────────────────────────┘             │
+│                        │ window.sero.google.*                   │
+├────────────────────────┼────────────────────────────────────────┤
+│  Preload (IPC bridge)  │                                        │
+│  google.execute()      │  google.authStatus()                   │
+│  google.login()        │  google.logout()                       │
+│  google.onAuthEvent()  │                                        │
+├────────────────────────┼────────────────────────────────────────┤
+│  Main Process          │                                        │
+│  ┌─────────────────────┴──────────────────────────────────────┐ │
+│  │  google-api.ts (IPC handlers)                              │ │
+│  │    ↓ auth         ↓ data                                   │ │
+│  │  GoogleAuthManager    runGog() → execFile(gog --json ...)  │ │
+│  │  (OAuth2 + PKCE)      --account auto-injected              │ │
+│  └────────────────────────────────────────────────────────────┘ │
+│                        │                                        │
+│                     gogcli                                       │
+│                  (file keyring)                                   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Setup (One-Time)
+
+### 1. Google Cloud OAuth Credentials
+
+1. Go to [console.cloud.google.com/apis/credentials](https://console.cloud.google.com/apis/credentials)
+2. Create Credentials → **OAuth client ID** → **Desktop app**
+3. Enable **Gmail API** and **Google Calendar API** in APIs & Services → Library
+4. Under [OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent), add yourself as a **Test user** (required while in "Testing" mode)
+5. Add to `~/.sero-ui/agent/.env`:
+
+```env
+GOOGLE_CLIENT_ID=<your-client-id>.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=GOCSPX-<your-secret>
+```
+
+### 2. Install gogcli
+
+```bash
+brew install steipete/tap/gogcli
+# or download from https://github.com/steipete/gogcli/releases
+```
+
+If Homebrew fails (e.g. outdated Xcode CLT), download the binary manually
+and place it in `~/.local/bin/gog`.
+
+### 3. Restart Sero
+
+The Google app auto-discovers via the `sero.app` manifest in
+`packages/pi-google-extension/package.json`. No manual registration needed.
+
+## Authentication
+
+### OAuth2 Flow
+
+The sign-in flow is handled by `GoogleAuthManager` in
+`apps/desktop/electron/google/auth-manager.ts`:
+
+1. User clicks **Sign in with Google** (no email input — Google's account
+   chooser handles that)
+2. Electron starts a loopback HTTP server on a random port
+3. Opens the browser with Google's OAuth2 URL (Authorization Code + PKCE)
+4. User picks their Google account and approves
+5. Google redirects to `http://127.0.0.1:<port>` — the loopback server
+   captures the authorization code
+6. Electron exchanges the code for access + refresh tokens
+7. Fetches the user's email via Google's userinfo API
+8. Auto-imports OAuth client credentials + refresh token into gogcli
+
+After sign-in, all gogcli commands work natively — the token is stored
+in gogcli's file-based keyring.
+
+### gogcli Configuration
+
+The auth manager auto-configures gogcli on every sign-in:
+
+- **Credentials**: piped to `gog auth credentials set -` (OAuth client JSON)
+- **Token**: piped to `gog auth tokens import -` (`{email, refresh_token}`)
+- **Keyring backend**: set to `file` (avoids macOS Keychain permission prompts)
+- **`GOG_KEYRING_PASSWORD`**: set automatically in all gogcli process environments
+
+### Auth Status Detection
+
+On mount, the app checks `gog auth tokens list --json` for stored tokens.
+If a token key like `token:default:user@gmail.com` exists, the user is
+authenticated. The email is extracted from the key.
+
+### Environment Variables
+
+All credentials live in `~/.sero-ui/agent/.env`, loaded at startup by
+`electron/env.ts`. The auth manager reads them lazily via functions
+(not module-level constants) because env loading happens after module import.
+
+## IPC Channels
+
+| Channel | Direction | Purpose |
+|---|---|---|
+| `sero:google:execute` | renderer → main | Run `gog --json --no-input --account <email> <service> <args>` |
+| `sero:google:authStatus` | renderer → main | Get `{configured, authenticated, email}` |
+| `sero:google:login` | renderer → main | Start OAuth2 flow (opens browser) |
+| `sero:google:logout` | renderer → main | Delete token from gogcli keyring |
+| `sero:google:authEvent` | main → renderer | Auth progress events (`browser`, `waiting`, `success`, `error`) |
+
+The `execute` channel auto-injects `--account <email>` from the cached
+auth email, so the UI never needs to pass it.
+
+## Gmail
+
+### Data Flow
+
+```
+MailView → useGoogleApi.fetchInbox() → gog gmail search <query> --max 15
+         → useGoogleApi.fetchThread() → gog gmail thread get <id>
+         → gmail-parser.ts → parseGmailMessage()
+```
+
+### Gmail API Message Parsing
+
+gogcli returns raw Gmail API format. The parser (`gmail-parser.ts`) handles:
+
+- **Headers**: extracts Subject, From, To, Date from `payload.headers[]`
+- **Body**: recursively finds `text/html` and `text/plain` parts in
+  `payload.parts[]`, decodes base64url data via `atob()` + `TextDecoder`
+  (critical for UTF-8 multi-byte characters like `'` and `…`)
+- **Snippets**: decodes HTML entities (`&#39;` → `'`)
+
+### HTML Email Rendering
+
+`MailThread.tsx` renders HTML emails in a sandboxed iframe:
+
+- `sandbox="allow-same-origin"` (no scripts)
+- Dark theme CSS injected: light text on transparent background
+- Single-message threads: iframe fills available space, content scrolls
+  inside (header stays pinned)
+- Multi-message threads: collapsible cards with auto-sizing iframes
+- Images constrained to `max-width: 100%`
+
+## Calendar
+
+### Data Flow
+
+```
+CalendarView → useGoogleApi.fetchEvents('today'|'week')
+             → gog calendar events primary --today|--week
+
+MiniCalendar month change → useGoogleApi.fetchEventsRange(from, to)
+                          → gog calendar events primary --from <date> --to <date> --max 50
+```
+
+### Components
+
+- **MiniCalendar**: compact month grid with Monday start, today highlight,
+  selected date highlight, event dots. Month navigation with ← → arrows.
+  Clicking a day filters the event list.
+- **CalendarView**: split layout — mini calendar sidebar (180px) + event
+  list or detail panel. Today/This Week toggle. Date filter chip.
+- **EventDetail**: rich event view matching Google Calendar:
+  - Multi-day date ranges (corrects Google's exclusive end date)
+  - Location as Google Maps link
+  - Attendees with RSVP status icons (✓ accepted, ✕ declined, ? tentative)
+  - Reminders (converts minutes to human-readable)
+  - Source link for `fromGmail` events ("View confirmation")
+  - Visibility indicator (🔒 "Only me" for private events)
+  - Strips auto-generated Google boilerplate from descriptions
+  - URLs in descriptions are clickable
+
+### Event Fields
+
+The fetcher captures all available fields from gogcli:
+
+```typescript
+interface CalendarEvent {
+  id, calendarId, summary, start, end, location, description,
+  attendees, isAllDay, status, htmlLink, visibility, eventType,
+  sourceUrl, reminders, created, updated
+}
+```
+
+## File Structure
+
+```
+packages/pi-google-extension/
+├── package.json            # sero.app manifest (id: "google", port: 5186)
+├── shared/types.ts         # GoogleAppState, GmailThread, GmailMessage, CalendarEvent
+├── extension/
+│   ├── index.ts            # Pi extension: gmail + gcal tools, TUI rendering
+│   └── gogcli.ts           # runGog() / runGogJson() with PATH probing
+├── ui/
+│   ├── GoogleApp.tsx        # Root: tabbed Mail/Calendar, auth check, auto-fetch
+│   ├── hooks/useGoogleApi.ts # IPC hook: auth, inbox, thread, events, calendars
+│   ├── components/
+│   │   ├── AuthSetup.tsx    # Sign-in button, status banners
+│   │   ├── MailView.tsx     # Inbox list with search
+│   │   ├── MailThread.tsx   # HTML email rendering (iframe)
+│   │   ├── CalendarView.tsx # Mini cal + event list + detail
+│   │   ├── MiniCalendar.tsx # Month grid with event dots
+│   │   ├── EventDetail.tsx  # Rich event view
+│   │   ├── gmail-parser.ts  # Gmail API message decoder
+│   │   └── format-utils.ts  # Dates, names, event grouping
+│   ├── styles.css
+│   ├── index.html
+│   └── tsconfig.json
+└── vite.config.ts          # Module federation (port 5186)
+
+apps/desktop/electron/
+├── google/
+│   └── auth-manager.ts     # GoogleAuthManager (OAuth2 + PKCE + gogcli import)
+└── ipc/
+    └── google-api.ts       # IPC handlers, gogcli execution, binary resolution
+```
+
+## Known Limitations
+
+- **Rich Gmail event details** (hotel check-in/out, flight info, confirmation
+  numbers) are not available via gogcli — Google parses these from email
+  content using internal APIs that third-party tools can't access.
+- **OAuth consent screen** must be in "Testing" mode with the user added as
+  a test user, or the app must complete Google's verification process.
+- **gogcli binary** must be installed separately — it's not bundled with Sero.
+- **Single account only** — the current implementation tracks one Google
+  account. Multi-account support would require UI for account switching.

--- a/packages/pi-google-extension/extension/gogcli.ts
+++ b/packages/pi-google-extension/extension/gogcli.ts
@@ -1,0 +1,101 @@
+/**
+ * gogcli execution helper — spawns `gog` with --json --no-input.
+ *
+ * Works on the host (Pi CLI or Sero main process). Probes common
+ * install locations since Electron may not inherit the shell PATH.
+ * Install via: brew install steipete/tap/gogcli
+ */
+
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+export interface GogResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+const GOG_TIMEOUT_MS = 30_000;
+
+const GOG_SEARCH_PATHS = [
+  '/opt/homebrew/bin/gog',
+  '/usr/local/bin/gog',
+  path.join(homedir(), '.local/bin/gog'),
+  path.join(homedir(), 'go/bin/gog'),
+];
+
+let _gogPath: string | null | undefined;
+
+function findGog(): string {
+  if (_gogPath !== undefined) return _gogPath ?? 'gog';
+  for (const p of GOG_SEARCH_PATHS) {
+    if (existsSync(p)) { _gogPath = p; return p; }
+  }
+  _gogPath = null;
+  return 'gog';
+}
+
+function enhancedPath(): string {
+  const existing = process.env.PATH || '';
+  const extra = ['/opt/homebrew/bin', '/usr/local/bin', path.join(homedir(), '.local/bin')];
+  return [...new Set([...extra, ...existing.split(':')])].join(':');
+}
+
+/**
+ * Run a gogcli command and return raw output.
+ */
+export function runGog(
+  args: string[],
+  opts?: { account?: string; timeoutMs?: number; json?: boolean },
+): Promise<GogResult> {
+  return new Promise((resolve) => {
+    const fullArgs: string[] = [];
+    if (opts?.account) fullArgs.push('--account', opts.account);
+    if (opts?.json !== false) fullArgs.push('--json');
+    fullArgs.push('--no-input', ...args);
+
+    const child = execFile(findGog(), fullArgs, {
+      timeout: opts?.timeoutMs ?? GOG_TIMEOUT_MS,
+      maxBuffer: 10 * 1024 * 1024,
+      env: { ...process.env, PATH: enhancedPath() },
+    }, (error, stdout, stderr) => {
+      if (error && (error as any).code === 'ENOENT') {
+        resolve({ stdout: '', stderr: 'gog binary not found', exitCode: 127 });
+        return;
+      }
+      resolve({
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        exitCode: error ? ((error as any).status ?? 1) : 0,
+      });
+    });
+
+    child.on('error', (err) => {
+      resolve({ stdout: '', stderr: err.message, exitCode: 127 });
+    });
+  });
+}
+
+/**
+ * Run gogcli and parse the JSON output. Returns null on failure.
+ */
+export async function runGogJson<T = unknown>(
+  args: string[],
+  opts?: { account?: string; timeoutMs?: number },
+): Promise<{ data: T | null; error: string | null }> {
+  const result = await runGog(args, { ...opts, json: true });
+
+  if (result.exitCode === 127) {
+    return { data: null, error: 'gogcli (gog) not found. Install: brew install steipete/tap/gogcli' };
+  }
+  if (result.exitCode !== 0) {
+    return { data: null, error: result.stderr.trim() || result.stdout.trim() || 'Command failed' };
+  }
+  try {
+    return { data: JSON.parse(result.stdout) as T, error: null };
+  } catch {
+    return { data: null, error: result.stdout.trim() || 'Failed to parse output' };
+  }
+}

--- a/packages/pi-google-extension/extension/index.ts
+++ b/packages/pi-google-extension/extension/index.ts
@@ -1,0 +1,335 @@
+/**
+ * Google Workspace Pi extension — Gmail + Calendar tools.
+ *
+ * Wraps gogcli to give the agent access to Gmail and Calendar.
+ * Results are written to the app state file so the Sero web UI
+ * can display them instantly via file watching.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import type { GoogleAppState } from '../shared/types';
+import { DEFAULT_GOOGLE_STATE } from '../shared/types';
+import { runGog, runGogJson } from './gogcli';
+
+// ── State I/O ────────────────────────────────────────────────
+
+function resolveStatePath(cwd: string): string {
+  const seroHome = process.env.SERO_HOME;
+  if (seroHome) {
+    return path.join(seroHome, 'apps', 'google', 'state.json');
+  }
+  return path.join(cwd, '.sero', 'apps', 'google', 'state.json');
+}
+
+async function readState(filePath: string): Promise<GoogleAppState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as GoogleAppState;
+  } catch {
+    return { ...DEFAULT_GOOGLE_STATE };
+  }
+}
+
+async function writeState(filePath: string, state: GoogleAppState): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+// ── Tool parameters ──────────────────────────────────────────
+
+const GmailParams = Type.Object({
+  action: StringEnum([
+    'search', 'read_thread', 'send', 'archive', 'labels',
+  ] as const),
+  query: Type.Optional(Type.String({ description: 'Gmail search query (for search)' })),
+  thread_id: Type.Optional(Type.String({ description: 'Thread ID (for read_thread, archive)' })),
+  to: Type.Optional(Type.String({ description: 'Recipient email (for send)' })),
+  subject: Type.Optional(Type.String({ description: 'Email subject (for send)' })),
+  body: Type.Optional(Type.String({ description: 'Email body (for send)' })),
+  max: Type.Optional(Type.Number({ description: 'Max results (for search, default 10)' })),
+});
+
+const CalendarParams = Type.Object({
+  action: StringEnum([
+    'today', 'week', 'search', 'create', 'delete', 'calendars',
+  ] as const),
+  query: Type.Optional(Type.String({ description: 'Search query (for search)' })),
+  calendar_id: Type.Optional(Type.String({ description: 'Calendar ID (default: primary)' })),
+  event_id: Type.Optional(Type.String({ description: 'Event ID (for delete)' })),
+  summary: Type.Optional(Type.String({ description: 'Event title (for create)' })),
+  from: Type.Optional(Type.String({ description: 'Start time ISO or natural (for create)' })),
+  to: Type.Optional(Type.String({ description: 'End time ISO or natural (for create)' })),
+  location: Type.Optional(Type.String({ description: 'Event location (for create)' })),
+  attendees: Type.Optional(Type.String({ description: 'Comma-separated emails (for create)' })),
+});
+
+// ── Extension entry point ────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+  let statePath = '';
+
+  pi.on('session_start', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+  pi.on('session_switch', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+
+  // ── Gmail tool ─────────────────────────────────────────────
+
+  pi.registerTool({
+    name: 'gmail',
+    label: 'Gmail',
+    description:
+      'Access Gmail. Actions: search (query emails), read_thread (get thread details), ' +
+      'send (compose email), archive (remove from inbox), labels (list labels).',
+    parameters: GmailParams,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const resolved = ctx ? resolveStatePath(ctx.cwd) : statePath;
+      if (!resolved) return { content: [{ type: 'text', text: 'Error: no workspace' }], details: {} };
+      statePath = resolved;
+
+      const state = await readState(statePath);
+
+      switch (params.action) {
+        case 'search': {
+          const q = params.query || 'newer_than:3d';
+          const max = params.max || 10;
+          const result = await runGog(
+            ['gmail', 'search', q, '--max', String(max)],
+            { json: true },
+          );
+          if (result.exitCode !== 0) {
+            return { content: [{ type: 'text', text: result.stderr || 'Search failed' }], details: {} };
+          }
+          // Store in state for UI
+          try {
+            const data = JSON.parse(result.stdout);
+            state.gmail.threads = (data.threads || []).map((t: any) => ({
+              id: t.id || '',
+              snippet: t.snippet || '',
+              subject: t.messages?.[0]?.subject || t.subject || '(no subject)',
+              from: t.messages?.[0]?.from || t.from || '',
+              date: t.messages?.[0]?.date || t.date || '',
+              labelIds: t.messages?.[0]?.labels || t.labelIds || [],
+              isUnread: (t.messages?.[0]?.labels || t.labelIds || []).includes('UNREAD'),
+              messageCount: t.messages?.length || t.messageCount || 1,
+            }));
+            state.gmail.lastQuery = q;
+            state.gmail.lastFetchedAt = new Date().toISOString();
+            await writeState(statePath, state);
+          } catch { /* output is still returned below */ }
+          return { content: [{ type: 'text', text: result.stdout }], details: {} };
+        }
+
+        case 'read_thread': {
+          if (!params.thread_id) return { content: [{ type: 'text', text: 'Error: thread_id required' }], details: {} };
+          const result = await runGog(['gmail', 'thread', 'get', params.thread_id], { json: true });
+          if (result.exitCode !== 0) {
+            return { content: [{ type: 'text', text: result.stderr || 'Failed to read thread' }], details: {} };
+          }
+          try {
+            const data = JSON.parse(result.stdout);
+            state.gmail.selectedThreadId = params.thread_id;
+            state.gmail.selectedMessages = (data.thread?.messages || data.messages || []).map((m: any) => ({
+              id: m.id || '',
+              threadId: m.threadId || params.thread_id,
+              from: m.from || '',
+              to: m.to || '',
+              subject: m.subject || '',
+              date: m.date || '',
+              body: m.body || m.snippet || '',
+              snippet: m.snippet || '',
+            }));
+            await writeState(statePath, state);
+          } catch { /* pass */ }
+          return { content: [{ type: 'text', text: result.stdout }], details: {} };
+        }
+
+        case 'send': {
+          if (!params.to) return { content: [{ type: 'text', text: 'Error: to required' }], details: {} };
+          const args = ['gmail', 'send', '--to', params.to];
+          if (params.subject) args.push('--subject', params.subject);
+          if (params.body) args.push('--body', params.body);
+          const result = await runGog(args, { json: true });
+          const text = result.exitCode === 0 ? 'Email sent successfully' : (result.stderr || 'Send failed');
+          return { content: [{ type: 'text', text }], details: {} };
+        }
+
+        case 'archive': {
+          if (!params.thread_id) return { content: [{ type: 'text', text: 'Error: thread_id required' }], details: {} };
+          const result = await runGog(
+            ['gmail', 'labels', 'modify', params.thread_id, '--remove', 'INBOX'],
+            { json: true },
+          );
+          const text = result.exitCode === 0 ? `Archived thread ${params.thread_id}` : (result.stderr || 'Archive failed');
+          return { content: [{ type: 'text', text }], details: {} };
+        }
+
+        case 'labels': {
+          const result = await runGog(['gmail', 'labels', 'list'], { json: true });
+          return { content: [{ type: 'text', text: result.stdout || result.stderr }], details: {} };
+        }
+
+        default:
+          return { content: [{ type: 'text', text: `Unknown gmail action: ${params.action}` }], details: {} };
+      }
+    },
+
+    renderCall(args, theme) {
+      let text = theme.fg('toolTitle', theme.bold('gmail '));
+      text += theme.fg('muted', args.action);
+      if (args.query) text += ` ${theme.fg('dim', `"${args.query}"`)}`;
+      if (args.to) text += ` ${theme.fg('dim', `→ ${args.to}`)}`;
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const first = result.content[0];
+      const msg = first?.type === 'text' ? first.text : '';
+      const short = msg.length > 120 ? msg.slice(0, 120) + '…' : msg;
+      return new Text(
+        msg.startsWith('Error') ? theme.fg('error', short) : theme.fg('success', '✓ ') + theme.fg('muted', short),
+        0, 0,
+      );
+    },
+  });
+
+  // ── Calendar tool ──────────────────────────────────────────
+
+  pi.registerTool({
+    name: 'gcal',
+    label: 'Google Calendar',
+    description:
+      'Access Google Calendar. Actions: today (today\'s events), week (this week), ' +
+      'search (find events), create (new event), delete (remove event), calendars (list).',
+    parameters: CalendarParams,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const resolved = ctx ? resolveStatePath(ctx.cwd) : statePath;
+      if (!resolved) return { content: [{ type: 'text', text: 'Error: no workspace' }], details: {} };
+      statePath = resolved;
+
+      const state = await readState(statePath);
+      const calId = params.calendar_id || 'primary';
+
+      switch (params.action) {
+        case 'today':
+        case 'week': {
+          const flag = params.action === 'today' ? '--today' : '--week';
+          const result = await runGog(['calendar', 'events', calId, flag], { json: true });
+          if (result.exitCode !== 0) {
+            return { content: [{ type: 'text', text: result.stderr || 'Failed to fetch events' }], details: {} };
+          }
+          try {
+            const data = JSON.parse(result.stdout);
+            state.calendar.events = (data.events || []).map((e: any) => ({
+              id: e.id || '',
+              calendarId: calId,
+              summary: e.summary || '(no title)',
+              start: e.start?.dateTime || e.start?.date || e.startLocal || '',
+              end: e.end?.dateTime || e.end?.date || e.endLocal || '',
+              startLocal: e.startLocal || '',
+              endLocal: e.endLocal || '',
+              location: e.location || '',
+              description: e.description || '',
+              attendees: e.attendees?.map((a: any) => a.email || a) || [],
+              isAllDay: !!e.start?.date && !e.start?.dateTime,
+              status: e.status || '',
+            }));
+            state.calendar.view = params.action;
+            state.calendar.lastFetchedAt = new Date().toISOString();
+            await writeState(statePath, state);
+          } catch { /* pass */ }
+          return { content: [{ type: 'text', text: result.stdout }], details: {} };
+        }
+
+        case 'search': {
+          if (!params.query) return { content: [{ type: 'text', text: 'Error: query required' }], details: {} };
+          const result = await runGog(['calendar', 'search', params.query], { json: true });
+          return { content: [{ type: 'text', text: result.stdout || result.stderr }], details: {} };
+        }
+
+        case 'create': {
+          if (!params.summary || !params.from || !params.to) {
+            return { content: [{ type: 'text', text: 'Error: summary, from, to required' }], details: {} };
+          }
+          const args = ['calendar', 'create', calId, '--summary', params.summary, '--from', params.from, '--to', params.to];
+          if (params.location) args.push('--location', params.location);
+          if (params.attendees) args.push('--attendees', params.attendees);
+          const result = await runGog(args, { json: true });
+          const text = result.exitCode === 0 ? `Created: ${params.summary}` : (result.stderr || 'Create failed');
+          return { content: [{ type: 'text', text }], details: {} };
+        }
+
+        case 'delete': {
+          if (!params.event_id) return { content: [{ type: 'text', text: 'Error: event_id required' }], details: {} };
+          const result = await runGog(['calendar', 'delete', calId, params.event_id], { json: false });
+          const text = result.exitCode === 0 ? `Deleted event ${params.event_id}` : (result.stderr || 'Delete failed');
+          return { content: [{ type: 'text', text }], details: {} };
+        }
+
+        case 'calendars': {
+          const result = await runGog(['calendar', 'calendars'], { json: true });
+          try {
+            const data = JSON.parse(result.stdout);
+            state.calendar.calendars = (data.calendars || []).map((c: any) => ({
+              id: c.id || '',
+              summary: c.summary || c.id || '',
+              primary: !!c.primary,
+            }));
+            await writeState(statePath, state);
+          } catch { /* pass */ }
+          return { content: [{ type: 'text', text: result.stdout || result.stderr }], details: {} };
+        }
+
+        default:
+          return { content: [{ type: 'text', text: `Unknown calendar action: ${params.action}` }], details: {} };
+      }
+    },
+
+    renderCall(args, theme) {
+      let text = theme.fg('toolTitle', theme.bold('gcal '));
+      text += theme.fg('muted', args.action);
+      if (args.summary) text += ` ${theme.fg('dim', `"${args.summary}"`)}`;
+      if (args.query) text += ` ${theme.fg('dim', `"${args.query}"`)}`;
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const first = result.content[0];
+      const msg = first?.type === 'text' ? first.text : '';
+      const short = msg.length > 120 ? msg.slice(0, 120) + '…' : msg;
+      return new Text(
+        msg.startsWith('Error') ? theme.fg('error', short) : theme.fg('success', '✓ ') + theme.fg('muted', short),
+        0, 0,
+      );
+    },
+  });
+
+  // ── Commands ───────────────────────────────────────────────
+
+  pi.registerCommand('gmail', {
+    description: 'Search recent Gmail inbox',
+    handler: async () => {
+      pi.sendUserMessage('Search my recent Gmail inbox using the gmail tool with action search.');
+    },
+  });
+
+  pi.registerCommand('gcal', {
+    description: 'Show today\'s calendar events',
+    handler: async () => {
+      pi.sendUserMessage('Show today\'s calendar events using the gcal tool with action today.');
+    },
+  });
+}

--- a/packages/pi-google-extension/package.json
+++ b/packages/pi-google-extension/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@sero/google",
+  "version": "0.1.0",
+  "description": "Google Workspace app for Sero — Gmail & Calendar with gogcli",
+  "keywords": ["pi-package"],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+  },
+  "pi": {
+    "extensions": ["./extension/index.ts"]
+  },
+  "sero": {
+    "app": {
+      "id": "google",
+      "name": "Google",
+      "icon": "mail",
+      "scope": "global",
+      "stateFile": ".sero/apps/google/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "GoogleApp",
+      "devPort": 5186
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": ">=0.52.0",
+    "@mariozechner/pi-coding-agent": ">=0.52.0",
+    "@mariozechner/pi-tui": ">=0.52.0"
+  },
+  "devDependencies": {
+    "@sero/app-runtime": "workspace:*",
+    "@sero/ui": "workspace:*",
+    "@module-federation/vite": "^1.11.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "@tailwindcss/vite": "^4.1.18",
+    "lucide-react": "^0.563.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/packages/pi-google-extension/shared/types.ts
+++ b/packages/pi-google-extension/shared/types.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared state shape for the Google Workspace app.
+ *
+ * Both the Pi extension and the Sero web UI read/write a JSON file
+ * matching this shape. Gmail threads and calendar events are cached
+ * from gogcli JSON output.
+ */
+
+// ── Gmail types ──────────────────────────────────────────────
+
+export interface GmailThread {
+  id: string;
+  snippet: string;
+  subject: string;
+  from: string;
+  date: string;
+  labelIds: string[];
+  isUnread: boolean;
+  messageCount: number;
+}
+
+export interface GmailMessage {
+  id: string;
+  threadId: string;
+  from: string;
+  to: string;
+  subject: string;
+  date: string;
+  /** Plain-text body. */
+  body: string;
+  /** HTML body (if available). */
+  bodyHtml: string;
+  snippet: string;
+}
+
+// ── Calendar types ───────────────────────────────────────────
+
+export interface CalendarEvent {
+  id: string;
+  calendarId: string;
+  summary: string;
+  start: string;
+  end: string;
+  startLocal?: string;
+  endLocal?: string;
+  location?: string;
+  description?: string;
+  attendees?: string[];
+  isAllDay: boolean;
+  status?: string;
+  htmlLink?: string;
+  visibility?: string;
+  eventType?: string;
+  sourceUrl?: string;
+  reminders?: { method: string; minutes: number }[];
+  created?: string;
+  updated?: string;
+}
+
+export interface CalendarInfo {
+  id: string;
+  summary: string;
+  primary: boolean;
+}
+
+// ── App state ────────────────────────────────────────────────
+
+export interface GoogleAppState {
+  /** Active tab in the UI. */
+  activeTab: 'mail' | 'calendar';
+
+  /** Gmail cached data. */
+  gmail: {
+    threads: GmailThread[];
+    selectedThreadId: string | null;
+    selectedMessages: GmailMessage[];
+    lastQuery: string;
+    lastFetchedAt: string | null;
+  };
+
+  /** Calendar cached data. */
+  calendar: {
+    events: CalendarEvent[];
+    calendars: CalendarInfo[];
+    view: 'today' | 'week';
+    lastFetchedAt: string | null;
+  };
+
+  /** Active Google account email (from gogcli auth). */
+  activeAccount: string | null;
+}
+
+export const DEFAULT_GOOGLE_STATE: GoogleAppState = {
+  activeTab: 'mail',
+  gmail: {
+    threads: [],
+    selectedThreadId: null,
+    selectedMessages: [],
+    lastQuery: 'newer_than:3d',
+    lastFetchedAt: null,
+  },
+  calendar: {
+    events: [],
+    calendars: [],
+    view: 'today',
+    lastFetchedAt: null,
+  },
+  activeAccount: null,
+};

--- a/packages/pi-google-extension/ui/GoogleApp.tsx
+++ b/packages/pi-google-extension/ui/GoogleApp.tsx
@@ -1,0 +1,156 @@
+/**
+ * GoogleApp — main Sero web UI for Gmail + Google Calendar.
+ *
+ * Tabbed layout switching between MailView and CalendarView.
+ * Includes auth setup flow for first-time Google account connection.
+ * Uses gogcli via the window.sero.google IPC bridge for direct
+ * data fetching, and useAppState for persistent cached state.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { useAppState } from '@sero/app-runtime';
+import { Mail, CalendarDays, RefreshCw } from 'lucide-react';
+import type { GoogleAppState } from '../shared/types';
+import { DEFAULT_GOOGLE_STATE } from '../shared/types';
+import { MailView } from './components/MailView';
+import { CalendarView } from './components/CalendarView';
+import { AuthSetup } from './components/AuthSetup';
+import { useGoogleApi } from './hooks/useGoogleApi';
+import './styles.css';
+
+export function GoogleApp() {
+  const [state, updateState] = useAppState<GoogleAppState>(DEFAULT_GOOGLE_STATE);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const google = useGoogleApi(updateState);
+
+  // Auto-focus container for keyboard events
+  useEffect(() => { containerRef.current?.focus(); }, []);
+
+  // Check auth on mount
+  const initialized = useRef(false);
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+    google.checkAuth();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-fetch data once authenticated (and stale)
+  const hasFetched = useRef(false);
+  useEffect(() => {
+    if (hasFetched.current) return;
+    if (google.auth.status !== 'authenticated') return;
+    hasFetched.current = true;
+
+    const staleMs = 5 * 60 * 1000;
+    const tab = state.activeTab;
+    const lastFetch = tab === 'mail' ? state.gmail.lastFetchedAt : state.calendar.lastFetchedAt;
+
+    if (!lastFetch || Date.now() - new Date(lastFetch).getTime() > staleMs) {
+      if (tab === 'mail') google.fetchInbox(state.gmail.lastQuery || 'newer_than:3d');
+      else google.fetchEvents(state.calendar.view);
+    }
+  }, [google.auth.status]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const setTab = useCallback((tab: 'mail' | 'calendar') => {
+    updateState((prev) => ({ ...prev, activeTab: tab }));
+  }, [updateState]);
+
+  const handleRefresh = useCallback(() => {
+    if (state.activeTab === 'mail') {
+      google.fetchInbox(state.gmail.lastQuery || 'newer_than:3d');
+    } else {
+      google.fetchEvents(state.calendar.view);
+    }
+  }, [state.activeTab, state.gmail.lastQuery, state.calendar.view, google]);
+
+  const isReady = google.auth.status === 'authenticated';
+
+  return (
+    <div
+      ref={containerRef}
+      tabIndex={0}
+      className="flex h-full w-full flex-col overflow-hidden bg-[var(--bg-base)] outline-none"
+    >
+      {/* Tab bar */}
+      <div className="flex shrink-0 items-center gap-1 border-b border-[var(--border-subtle)] px-3 py-1.5">
+        <TabButton
+          active={state.activeTab === 'mail'}
+          onClick={() => setTab('mail')}
+          icon={<Mail className="size-3.5" />}
+          label="Mail"
+        />
+        <TabButton
+          active={state.activeTab === 'calendar'}
+          onClick={() => setTab('calendar')}
+          icon={<CalendarDays className="size-3.5" />}
+          label="Calendar"
+        />
+
+        <div className="flex-1" />
+
+        {/* Refresh button — only when authenticated */}
+        {isReady && (
+          <button
+            onClick={handleRefresh}
+            disabled={google.loading}
+            className="flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]/80 hover:text-[var(--text-primary)] disabled:opacity-40"
+          >
+            <RefreshCw className={`size-3 ${google.loading ? 'animate-spin' : ''}`} />
+            {google.loading ? 'Syncing…' : 'Sync'}
+          </button>
+        )}
+
+        {/* Error indicator */}
+        {google.error && isReady && (
+          <span className="max-w-[200px] truncate text-[11px] text-red-400" title={google.error}>
+            {google.error}
+          </span>
+        )}
+      </div>
+
+      {/* Auth: sign-in form when not authenticated, account banner when signed in */}
+      <AuthSetup auth={google.auth} google={google} />
+
+      {/* Active view — only when authenticated */}
+      <div className="flex-1 overflow-hidden">
+        {isReady ? (
+          state.activeTab === 'mail' ? (
+            <MailView state={state} updateState={updateState} google={google} />
+          ) : (
+            <CalendarView state={state} updateState={updateState} google={google} />
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// ── Tab button ───────────────────────────────────────────────
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors ${
+        active
+          ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+          : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)]/60 hover:text-[var(--text-secondary)]'
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+export default GoogleApp;

--- a/packages/pi-google-extension/ui/components/AuthSetup.tsx
+++ b/packages/pi-google-extension/ui/components/AuthSetup.tsx
@@ -1,0 +1,107 @@
+/**
+ * AuthSetup — Google sign-in UI.
+ *
+ * Just a "Sign in with Google" button. Google's own account
+ * chooser handles email selection in the browser.
+ */
+
+import { CheckCircle2, Loader2, LogIn, LogOut, AlertTriangle } from 'lucide-react';
+import type { AuthInfo, GoogleApi } from '../hooks/useGoogleApi';
+
+interface AuthSetupProps {
+  auth: AuthInfo;
+  google: GoogleApi;
+}
+
+export function AuthSetup({ auth, google }: AuthSetupProps) {
+  // Authenticated — compact banner with sign-out
+  if (auth.status === 'authenticated' && auth.email) {
+    return (
+      <div className="mx-2 mt-2 flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.03] px-3 py-1.5">
+        <CheckCircle2 className="size-3.5 text-emerald-500" />
+        <span className="flex-1 text-[11px] text-[var(--text-secondary)]">{auth.email}</span>
+        <button
+          onClick={google.signOut}
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <LogOut className="size-2.5" />
+          Sign out
+        </button>
+      </div>
+    );
+  }
+
+  // Signing in — spinner
+  if (auth.status === 'signing-in') {
+    return (
+      <div className="mx-2 mt-2 flex items-center gap-2.5 rounded-lg border border-blue-500/20 bg-blue-500/[0.03] px-3 py-3">
+        <Loader2 className="size-4 animate-spin text-blue-400" />
+        <div>
+          <p className="text-[12px] font-medium text-[var(--text-primary)]">Waiting for Google sign-in…</p>
+          <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">Complete the sign-in in your browser</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Not configured
+  if (auth.status === 'not-configured') {
+    return (
+      <div className="mx-2 mt-2 rounded-lg border border-yellow-500/20 bg-yellow-500/[0.03] px-3 py-3">
+        <div className="flex items-start gap-2.5">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-yellow-500" />
+          <div>
+            <p className="text-[12px] font-medium text-[var(--text-primary)]">Google OAuth not configured</p>
+            <p className="mt-0.5 text-[11px] leading-relaxed text-[var(--text-muted)]">
+              Set <code className="rounded bg-[var(--bg-base)] px-1 text-[10px]">GOOGLE_CLIENT_ID</code> and{' '}
+              <code className="rounded bg-[var(--bg-base)] px-1 text-[10px]">GOOGLE_CLIENT_SECRET</code> in{' '}
+              <code className="rounded bg-[var(--bg-base)] px-1 text-[10px]">~/.sero-ui/agent/.env</code>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Checking
+  if (auth.status === 'checking') {
+    return (
+      <div className="mx-2 mt-2 flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50 px-3 py-2.5">
+        <Loader2 className="size-3.5 animate-spin text-[var(--text-muted)]" />
+        <span className="text-[12px] text-[var(--text-muted)]">Checking…</span>
+      </div>
+    );
+  }
+
+  // Signed out — one button
+  return (
+    <div className="mx-2 mt-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50 px-3 py-3">
+      <div className="flex items-center gap-3">
+        <GoogleLogo />
+        <div className="flex-1">
+          <p className="text-[12px] font-medium text-[var(--text-primary)]">Connect your Google account</p>
+          <p className="text-[11px] text-[var(--text-muted)]">Access Gmail and Calendar</p>
+        </div>
+        <button
+          onClick={() => google.signIn()}
+          className="flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-base)] px-3 py-1.5 text-[12px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)] active:scale-[0.98]"
+        >
+          <LogIn className="size-3.5" />
+          Sign in with Google
+        </button>
+      </div>
+      {auth.error && <p className="mt-2 text-[11px] text-red-400">{auth.error}</p>}
+    </div>
+  );
+}
+
+function GoogleLogo() {
+  return (
+    <svg viewBox="0 0 24 24" className="size-5 shrink-0" xmlns="http://www.w3.org/2000/svg">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+    </svg>
+  );
+}

--- a/packages/pi-google-extension/ui/components/CalendarView.tsx
+++ b/packages/pi-google-extension/ui/components/CalendarView.tsx
@@ -1,0 +1,236 @@
+/**
+ * CalendarView — Google Calendar with mini calendar + event list + detail panel.
+ *
+ * Layout: mini calendar on the left, event list in the center.
+ * Clicking an event opens its detail view in place of the list.
+ */
+
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { Clock, MapPin, Users, CalendarDays } from 'lucide-react';
+import type { GoogleAppState, CalendarEvent } from '../../shared/types';
+import type { GoogleApi } from '../hooks/useGoogleApi';
+import { formatRelativeDate, formatTimeRange, groupEventsByDay } from './format-utils';
+import { MiniCalendar } from './MiniCalendar';
+import { EventDetail } from './EventDetail';
+
+type StateUpdater = (fn: (prev: GoogleAppState) => GoogleAppState) => void;
+
+interface CalendarViewProps {
+  state: GoogleAppState;
+  updateState: StateUpdater;
+  google: GoogleApi;
+}
+
+function toDateKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+export function CalendarView({ state, updateState, google }: CalendarViewProps) {
+  const { events, view, lastFetchedAt } = state.calendar;
+  const [calMonth, setCalMonth] = useState(() => new Date());
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+
+  const setView = useCallback((v: 'today' | 'week') => {
+    updateState((prev) => ({ ...prev, calendar: { ...prev.calendar, view: v } }));
+    google.fetchEvents(v);
+    setSelectedEvent(null);
+  }, [updateState, google]);
+
+  // Dates that have events (for mini calendar dots)
+  const eventDates = useMemo(() => {
+    const dates = new Set<string>();
+    for (const e of events) {
+      const d = new Date(e.start || e.startLocal || '');
+      if (!isNaN(d.getTime())) dates.add(toDateKey(d));
+    }
+    return dates;
+  }, [events]);
+
+  // Filter events to selected date, or show all
+  const displayEvents = useMemo(() => {
+    if (!selectedDate) return events;
+    return events.filter((e) => {
+      const d = new Date(e.start || e.startLocal || '');
+      return !isNaN(d.getTime()) && toDateKey(d) === selectedDate;
+    });
+  }, [events, selectedDate]);
+
+  const groupedEvents = useMemo(() => groupEventsByDay(displayEvents), [displayEvents]);
+
+  const handleSelectDate = useCallback((date: string) => {
+    setSelectedDate((prev) => prev === date ? null : date);
+    setSelectedEvent(null);
+  }, []);
+
+  const handleChangeMonth = useCallback((delta: number) => {
+    setCalMonth((prev) => {
+      const d = new Date(prev);
+      d.setMonth(d.getMonth() + delta);
+      return d;
+    });
+  }, []);
+
+  // Fetch events for the visible month when it changes
+  const lastFetchedMonth = useRef('');
+  useEffect(() => {
+    const year = calMonth.getFullYear();
+    const mo = calMonth.getMonth();
+    const key = `${year}-${mo}`;
+    if (key === lastFetchedMonth.current) return;
+    lastFetchedMonth.current = key;
+
+    const from = `${year}-${String(mo + 1).padStart(2, '0')}-01`;
+    const nextMo = new Date(year, mo + 1, 1);
+    const to = `${nextMo.getFullYear()}-${String(nextMo.getMonth() + 1).padStart(2, '0')}-01`;
+    google.fetchEventsRange(from, to);
+  }, [calMonth, google]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* View toggle bar */}
+      <div className="flex shrink-0 items-center gap-1 border-b border-[var(--border-subtle)] px-3 py-1.5">
+        <ViewToggle active={view === 'today'} label="Today" onClick={() => setView('today')} />
+        <ViewToggle active={view === 'week'} label="This Week" onClick={() => setView('week')} />
+        {selectedDate && (
+          <button
+            onClick={() => { setSelectedDate(null); setSelectedEvent(null); }}
+            className="ml-1 rounded-md bg-blue-500/10 px-2 py-0.5 text-[10px] text-blue-400 hover:bg-blue-500/20"
+          >
+            {new Date(selectedDate + 'T00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ✕
+          </button>
+        )}
+        <div className="flex-1" />
+        {lastFetchedAt && (
+          <span className="text-[10px] text-[var(--text-muted)]">{formatRelativeDate(lastFetchedAt)}</span>
+        )}
+      </div>
+
+      {/* Main area: mini calendar + events/detail */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Mini calendar sidebar */}
+        <div className="w-[180px] shrink-0 border-r border-[var(--border-subtle)] p-2">
+          <MiniCalendar
+            month={calMonth}
+            selectedDate={selectedDate}
+            eventDates={eventDates}
+            onSelectDate={handleSelectDate}
+            onChangeMonth={handleChangeMonth}
+          />
+        </div>
+
+        {/* Events or detail */}
+        <div className="flex-1 overflow-hidden">
+          {selectedEvent ? (
+            <EventDetail event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+          ) : displayEvents.length === 0 ? (
+            <EmptyCalendar loading={google.loading} error={google.error} />
+          ) : (
+            <div className="h-full overflow-y-auto p-2 space-y-3">
+              {groupedEvents.map(([dayLabel, dayEvents]) => (
+                <DayGroup key={dayLabel} label={dayLabel} events={dayEvents} onSelect={setSelectedEvent} />
+              ))}
+              <div className="px-1 pb-1 text-[10px] text-[var(--text-muted)]">
+                {displayEvents.length} event{displayEvents.length !== 1 ? 's' : ''}
+                {' · last synced '}{formatRelativeDate(lastFetchedAt || '')}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Subcomponents ────────────────────────────────────────────
+
+function ViewToggle({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors ${
+        active ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+          : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)]/60 hover:text-[var(--text-secondary)]'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+function DayGroup({ label, events, onSelect }: { label: string; events: CalendarEvent[]; onSelect: (e: CalendarEvent) => void }) {
+  return (
+    <div>
+      <div className="mb-1 px-1 text-[11px] font-medium text-[var(--text-muted)]">{label}</div>
+      <div className="space-y-1">
+        {events.map((event, i) => (
+          <EventCard key={event.id} event={event} index={i} onClick={() => onSelect(event)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EventCard({ event, index, onClick }: { event: CalendarEvent; index: number; onClick: () => void }) {
+  const timeRange = formatTimeRange(event.start, event.end, event.isAllDay);
+  const isPast = !event.isAllDay && new Date(event.end) < new Date();
+
+  return (
+    <button
+      onClick={onClick}
+      className={`animate-g-fade-in w-full overflow-hidden rounded-lg border text-left transition-colors hover:border-blue-500/30 ${
+        isPast ? 'border-[var(--border-subtle)]/50 bg-[var(--bg-elevated)]/25' : 'border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50'
+      }`}
+      style={{ animationDelay: `${index * 20}ms` }}
+    >
+      <div className="flex items-start gap-2.5 px-3 py-2">
+        <div className="mt-1 flex shrink-0 flex-col items-center">
+          <span className={`size-1.5 rounded-full ${event.isAllDay ? 'bg-blue-400' : isPast ? 'bg-[var(--text-muted)]/40' : 'bg-emerald-500'}`} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <span className={`text-[12px] font-medium ${isPast ? 'text-[var(--text-muted)]' : 'text-[var(--text-primary)]'}`}>
+            {event.summary}
+          </span>
+          <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+            <span className="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+              <Clock className="size-2.5" />{timeRange}
+            </span>
+            {event.location && (
+              <span className="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+                <MapPin className="size-2.5" /><span className="max-w-[150px] truncate">{event.location}</span>
+              </span>
+            )}
+            {event.attendees && event.attendees.length > 0 && (
+              <span className="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
+                <Users className="size-2.5" />{event.attendees.length}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function EmptyCalendar({ loading, error }: { loading: boolean; error: string | null }) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center text-center">
+      {loading ? (
+        <>
+          <div className="size-8 rounded-full border-2 border-[var(--border-subtle)] border-t-blue-500 animate-spin mb-3" />
+          <p className="text-[12px] text-[var(--text-muted)]">Fetching events…</p>
+        </>
+      ) : error ? (
+        <>
+          <CalendarDays className="size-6 text-red-400/60 mb-3" />
+          <p className="text-[12px] text-red-400">{error}</p>
+        </>
+      ) : (
+        <>
+          <CalendarDays className="size-6 text-[var(--text-muted)]/40 mb-3" />
+          <p className="text-[12px] text-[var(--text-muted)]">No events</p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/pi-google-extension/ui/components/EventDetail.tsx
+++ b/packages/pi-google-extension/ui/components/EventDetail.tsx
@@ -1,0 +1,278 @@
+/**
+ * EventDetail — rich event view matching Google Calendar's detail panel.
+ *
+ * Shows: date range, time, location (Maps link), attendees with RSVP,
+ * cleaned description, reminders, source, visibility.
+ */
+
+import {
+  Clock, MapPin, Users, ExternalLink, X, CheckCircle2, HelpCircle,
+  XCircle, Bell, Link2, Lock, Globe,
+} from 'lucide-react';
+import type { CalendarEvent } from '../../shared/types';
+import { formatTimeRange } from './format-utils';
+
+interface EventDetailProps {
+  event: CalendarEvent;
+  onClose: () => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Format multi-day or single-day date labels. */
+function formatDateRange(start: string, end: string, isAllDay: boolean): string {
+  const s = new Date(start);
+  const fmt = (d: Date) => d.toLocaleDateString(undefined, {
+    weekday: 'long', month: 'long', day: 'numeric', year: 'numeric',
+  });
+  if (isAllDay && end) {
+    const e = new Date(end);
+    // Google's all-day end date is exclusive (Feb 26 means through Feb 25)
+    e.setDate(e.getDate() - 1);
+    if (s.toDateString() === e.toDateString()) return fmt(s);
+    const sFmt = s.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
+    const eFmt = e.toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
+    return `${sFmt} – ${eFmt}`;
+  }
+  return fmt(s);
+}
+
+/** Convert reminder minutes to human-readable text. */
+function formatReminder(method: string, minutes: number): string {
+  const icon = method === 'email' ? 'Email' : 'Notification';
+  if (minutes < 60) return `${icon}: ${minutes} minute${minutes !== 1 ? 's' : ''} before`;
+  if (minutes < 1440) {
+    const h = Math.floor(minutes / 60);
+    return `${icon}: ${h} hour${h !== 1 ? 's' : ''} before`;
+  }
+  const d = Math.floor(minutes / 1440);
+  const rem = minutes % 1440;
+  if (rem === 0) return `${icon}: ${d} day${d !== 1 ? 's' : ''} before`;
+  const hRem = Math.floor(rem / 60);
+  return `${icon}: ${d} day${d !== 1 ? 's' : ''}, ${hRem}h before`;
+}
+
+/** Strip Google boilerplate but keep real content. */
+function cleanDescription(desc: string): string | null {
+  if (!desc) return null;
+  const lines = desc.split('\n').filter((line) => {
+    const l = line.trim();
+    if (!l) return false;
+    if (l.startsWith('To see detailed information for automatically created events')) return false;
+    if (l.startsWith('This event was created from an email you received in Gmail')) return false;
+    if (/^https?:\/\/(g\.co|mail\.google\.com|calendar\.google\.com)\b/.test(l)) return false;
+    return true;
+  });
+  return lines.join('\n').trim() || null;
+}
+
+function parseAttendee(raw: string): { name: string; status: string; isSelf: boolean } {
+  const isSelf = raw.endsWith(' — you');
+  const stripped = isSelf ? raw.replace(' — you', '') : raw;
+  const match = stripped.match(/^(.+?)\s*\((\w+)\)$/);
+  if (match) return { name: match[1].trim(), status: match[2], isSelf };
+  return { name: stripped, status: '', isSelf };
+}
+
+const STATUS_ICONS: Record<string, React.ReactNode> = {
+  accepted: <CheckCircle2 className="size-3 text-emerald-500" />,
+  declined: <XCircle className="size-3 text-red-400" />,
+  tentative: <HelpCircle className="size-3 text-yellow-400" />,
+  needsAction: <HelpCircle className="size-3 text-[var(--text-muted)]" />,
+};
+
+// ── Component ────────────────────────────────────────────────
+
+export function EventDetail({ event, onClose }: EventDetailProps) {
+  const timeRange = formatTimeRange(event.start, event.end, event.isAllDay);
+  const dateRange = formatDateRange(event.start, event.end, event.isAllDay);
+  const description = cleanDescription(event.description || '');
+  const allAttendees = (event.attendees || []).map(parseAttendee);
+  const nonSelfAttendees = allAttendees.filter((a) => !a.isSelf);
+  const selfAttendee = allAttendees.find((a) => a.isSelf);
+  const rsvpCount = allAttendees.filter((a) => a.status === 'accepted').length;
+  const reminders = event.reminders?.filter((r) => r.minutes > 0) || [];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex shrink-0 items-start gap-2.5 border-b border-[var(--border-subtle)] px-3 py-3">
+        <div className="mt-1.5 size-3 shrink-0 rounded-sm bg-blue-500" />
+        <div className="min-w-0 flex-1">
+          <h3 className="text-[15px] font-semibold text-[var(--text-primary)] leading-snug">
+            {event.summary}
+          </h3>
+          <p className="mt-0.5 text-[12px] text-[var(--text-muted)]">{dateRange}</p>
+        </div>
+        <button
+          onClick={onClose}
+          className="shrink-0 rounded p-1 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-3 py-2.5 space-y-3">
+        {/* Time (skip for all-day single-day — already shown in header) */}
+        {!event.isAllDay && (
+          <Row icon={<Clock className="size-3.5" />}>
+            <span className="text-[12px] text-[var(--text-primary)]">{timeRange}</span>
+          </Row>
+        )}
+
+        {/* Location */}
+        {event.location && (
+          <Row icon={<MapPin className="size-3.5" />}>
+            <a
+              href={`https://maps.google.com/?q=${encodeURIComponent(event.location)}`}
+              target="_blank" rel="noopener noreferrer"
+              className="text-[12px] text-blue-400 hover:underline leading-snug"
+            >
+              {event.location}
+            </a>
+          </Row>
+        )}
+
+        {/* Attendees */}
+        {allAttendees.length > 0 && (
+          <Row icon={<Users className="size-3.5" />}>
+            <div>
+              <div className="text-[12px] text-[var(--text-primary)]">
+                {allAttendees.length} guest{allAttendees.length !== 1 ? 's' : ''}
+              </div>
+              {rsvpCount > 0 && (
+                <div className="text-[10px] text-[var(--text-muted)] mb-1">
+                  {rsvpCount} yes
+                </div>
+              )}
+              <div className="space-y-1 mt-1">
+                {/* Self first */}
+                {selfAttendee && (
+                  <AttendeeRow name={selfAttendee.name} status={selfAttendee.status} role="Organizer" />
+                )}
+                {nonSelfAttendees.map((a, i) => (
+                  <AttendeeRow key={i} name={a.name} status={a.status} />
+                ))}
+              </div>
+            </div>
+          </Row>
+        )}
+
+        {/* Description */}
+        {description && (
+          <Row icon={<DescIcon />}>
+            <div className="whitespace-pre-wrap text-[12px] leading-relaxed text-[var(--text-secondary)]">
+              <Linkify text={description} />
+            </div>
+          </Row>
+        )}
+
+        {/* Reminders */}
+        {reminders.length > 0 && (
+          <Row icon={<Bell className="size-3.5" />}>
+            <div className="space-y-0.5">
+              {reminders.map((r, i) => (
+                <div key={i} className="text-[12px] text-[var(--text-secondary)]">
+                  {formatReminder(r.method, r.minutes)}
+                </div>
+              ))}
+            </div>
+          </Row>
+        )}
+
+        {/* Source (fromGmail) */}
+        {event.eventType === 'fromGmail' && (
+          <Row icon={<Link2 className="size-3.5" />}>
+            <div>
+              <div className="text-[12px] text-[var(--text-secondary)]">
+                This was automatically created from an email.
+              </div>
+              {event.sourceUrl && (
+                <a
+                  href={event.sourceUrl} target="_blank" rel="noopener noreferrer"
+                  className="text-[11px] text-blue-400 hover:underline"
+                >
+                  View confirmation
+                </a>
+              )}
+            </div>
+          </Row>
+        )}
+
+        {/* Visibility */}
+        {event.visibility && event.visibility !== 'default' && (
+          <Row icon={event.visibility === 'private'
+            ? <Lock className="size-3.5" />
+            : <Globe className="size-3.5" />
+          }>
+            <span className="text-[12px] text-[var(--text-secondary)]">
+              {event.visibility === 'private' ? 'Only me' : event.visibility}
+            </span>
+          </Row>
+        )}
+
+        {/* Open in Google Calendar */}
+        {event.htmlLink && (
+          <div className="pt-1">
+            <a
+              href={event.htmlLink} target="_blank" rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-subtle)] px-2.5 py-1.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+            >
+              <ExternalLink className="size-3" />
+              Open in Google Calendar
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Subcomponents ────────────────────────────────────────────
+
+function Row({ icon, children }: { icon: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-3">
+      <div className="mt-0.5 shrink-0 text-[var(--text-muted)]">{icon}</div>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
+function AttendeeRow({ name, status, role }: { name: string; status: string; role?: string }) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex size-5 shrink-0 items-center justify-center rounded-full bg-blue-500/15 text-[9px] font-semibold text-blue-400">
+        {name.charAt(0).toUpperCase()}
+      </div>
+      {STATUS_ICONS[status] || null}
+      <div className="min-w-0">
+        <span className="text-[11px] text-[var(--text-secondary)]">{name}</span>
+        {role && <span className="ml-1 text-[10px] text-[var(--text-muted)]">{role}</span>}
+      </div>
+    </div>
+  );
+}
+
+function DescIcon() {
+  return (
+    <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="12" x2="18" y2="12" /><line x1="3" y1="18" x2="14" y2="18" />
+    </svg>
+  );
+}
+
+function Linkify({ text }: { text: string }) {
+  const parts = text.split(/(https?:\/\/[^\s]+)/g);
+  return (
+    <>
+      {parts.map((part, i) =>
+        /^https?:\/\//.test(part) ? (
+          <a key={i} href={part} target="_blank" rel="noopener noreferrer"
+            className="text-blue-400 hover:underline break-all">{part}</a>
+        ) : <span key={i}>{part}</span>,
+      )}
+    </>
+  );
+}

--- a/packages/pi-google-extension/ui/components/MailThread.tsx
+++ b/packages/pi-google-extension/ui/components/MailThread.tsx
@@ -1,0 +1,246 @@
+/**
+ * MailThread — expanded email thread view.
+ *
+ * Renders HTML emails in sandboxed iframes that auto-resize.
+ * Falls back to plain text when no HTML body is available.
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { GmailMessage } from '../../shared/types';
+import { formatRelativeDate, extractName } from './format-utils';
+
+interface MailThreadProps {
+  messages: GmailMessage[];
+  onBack: () => void;
+}
+
+export function MailThread({ messages, onBack }: MailThreadProps) {
+  const subject = messages[0]?.subject || '(no subject)';
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Thread header */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-subtle)] px-3 py-2">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <ChevronLeft className="size-3.5" />
+          Back
+        </button>
+        <div className="min-w-0 flex-1">
+          <h2 className="truncate text-[13px] font-medium text-[var(--text-primary)]">
+            {subject}
+          </h2>
+          <span className="text-[10px] text-[var(--text-muted)]">
+            {messages.length} message{messages.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </div>
+
+      {/* Messages — single message fills space, multi-message scrolls list */}
+      {messages.length === 1 ? (
+        <SingleMessage message={messages[0]} />
+      ) : (
+        <div className="flex-1 space-y-1 overflow-y-auto p-2">
+          {messages.map((msg, i) => (
+            <MessageCard
+              key={msg.id}
+              message={msg}
+              defaultExpanded={i === messages.length - 1}
+              index={i}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Single message (fills space, content scrolls) ────────────
+
+function SingleMessage({ message }: { message: GmailMessage }) {
+  const senderName = extractName(message.from);
+  const senderInitial = senderName.charAt(0).toUpperCase() || '?';
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      {/* Sender header — pinned */}
+      <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-subtle)] px-3 py-2">
+        <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-blue-500/15 text-[10px] font-semibold text-blue-400">
+          {senderInitial}
+        </div>
+        <div className="min-w-0 flex-1">
+          <span className="text-[12px] font-medium text-[var(--text-primary)]">{senderName}</span>
+          <div className="flex items-center gap-2 text-[10px] text-[var(--text-muted)]">
+            <span className="truncate">{message.from}</span>
+            {message.to && <><span>→</span><span className="truncate">{message.to}</span></>}
+          </div>
+        </div>
+        <span className="shrink-0 text-[10px] text-[var(--text-muted)]">
+          {formatRelativeDate(message.date)}
+        </span>
+      </div>
+
+      {/* Body — fills remaining space */}
+      <div className="flex-1 overflow-hidden">
+        {message.bodyHtml ? (
+          <HtmlBody html={message.bodyHtml} fill />
+        ) : (
+          <div className="h-full overflow-y-auto px-3 py-2 whitespace-pre-wrap text-[12px] leading-relaxed text-[var(--text-secondary)]">
+            {message.body || message.snippet || '(empty)'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Collapsible message card (multi-message threads) ─────────
+
+function MessageCard({
+  message,
+  defaultExpanded,
+  index,
+}: {
+  message: GmailMessage;
+  defaultExpanded: boolean;
+  index: number;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const senderName = extractName(message.from);
+  const senderInitial = senderName.charAt(0).toUpperCase() || '?';
+
+  return (
+    <div
+      className="animate-g-fade-in overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50"
+      style={{ animationDelay: `${index * 30}ms` }}
+    >
+      {/* Header bar */}
+      <button
+        onClick={() => setExpanded((p) => !p)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--bg-elevated)]/80"
+      >
+        <ChevronRight
+          className={`size-3.5 shrink-0 text-[var(--text-muted)] transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}
+        />
+        <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-blue-500/15 text-[10px] font-semibold text-blue-400">
+          {senderInitial}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2">
+            <span className="truncate text-[12px] font-medium text-[var(--text-primary)]">
+              {senderName}
+            </span>
+            <span className="ml-auto shrink-0 text-[10px] text-[var(--text-muted)]">
+              {formatRelativeDate(message.date)}
+            </span>
+          </div>
+          {!expanded && message.snippet && (
+            <p className="mt-0.5 truncate text-[11px] text-[var(--text-muted)]">
+              {message.snippet}
+            </p>
+          )}
+        </div>
+      </button>
+
+      {/* Expanded body */}
+      {expanded && (
+        <div className="border-t border-[var(--border-subtle)]">
+          {/* Meta line */}
+          <div className="flex items-center gap-3 px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
+            <span className="truncate">{message.from}</span>
+            {message.to && (
+              <>
+                <span className="shrink-0">→</span>
+                <span className="truncate">{message.to}</span>
+              </>
+            )}
+          </div>
+          {/* Body */}
+          {message.bodyHtml ? (
+            <HtmlBody html={message.bodyHtml} />
+          ) : (
+            <div className="px-3 py-2 whitespace-pre-wrap text-[12px] leading-relaxed text-[var(--text-secondary)]">
+              {message.body || message.snippet || '(empty)'}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── HTML email renderer (sandboxed iframe) ───────────────────
+
+const EMAIL_STYLES = `
+  body {
+    margin: 0; padding: 12px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-size: 13px; line-height: 1.5;
+    color: #e0e0e0; background: transparent;
+    word-break: break-word;
+  }
+  a { color: #60a5fa; }
+  img { max-width: 100%; height: auto; }
+  table { max-width: 100% !important; }
+  * { max-width: 100% !important; box-sizing: border-box; }
+`;
+
+/**
+ * HtmlBody — renders HTML email in a sandboxed iframe.
+ * fill=true: 100% height, content scrolls inside iframe.
+ * fill=false: auto-sizes to content height (for multi-message cards).
+ */
+function HtmlBody({ html, fill = false }: { html: string; fill?: boolean }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(200);
+
+  const writeContent = useCallback((iframe: HTMLIFrameElement) => {
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+    const overflow = fill ? 'overflow-y: auto; overflow-x: hidden;' : 'overflow: hidden;';
+    doc.open();
+    doc.write(`<!DOCTYPE html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>${EMAIL_STYLES} body { ${overflow} }</style>
+</head><body>${html}</body></html>`);
+    doc.close();
+
+    if (!fill) {
+      // Auto-size: measure after images load
+      const resize = () => {
+        const h = doc.body?.scrollHeight ?? 0;
+        if (h > 0) setHeight(Math.min(h + 16, 2000));
+      };
+      const imgs = doc.querySelectorAll('img');
+      let pending = imgs.length;
+      if (pending === 0) { resize(); return; }
+      imgs.forEach((img) => {
+        if (img.complete) { pending--; if (!pending) resize(); }
+        else { img.onload = img.onerror = () => { pending--; if (!pending) resize(); }; }
+      });
+      resize();
+    }
+  }, [html, fill]);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (iframe) writeContent(iframe);
+  }, [writeContent]);
+
+  return (
+    <iframe
+      ref={iframeRef}
+      sandbox="allow-same-origin"
+      title="Email content"
+      style={{
+        width: '100%',
+        height: fill ? '100%' : height,
+        border: 'none',
+        display: 'block',
+      }}
+    />
+  );
+}

--- a/packages/pi-google-extension/ui/components/MailView.tsx
+++ b/packages/pi-google-extension/ui/components/MailView.tsx
@@ -1,0 +1,216 @@
+/**
+ * MailView — Gmail inbox list and thread detail.
+ *
+ * Styled to match ToolCallGroup: compact cards, collapsible groups,
+ * status dots, small text, CSS variable colors.
+ */
+
+import { useState, useCallback } from 'react';
+import { ChevronRight, ChevronLeft, Search, Archive, Mail, Inbox } from 'lucide-react';
+import type { GoogleAppState, GmailThread } from '../../shared/types';
+import type { GoogleApi } from '../hooks/useGoogleApi';
+import { MailThread } from './MailThread';
+import { formatRelativeDate, extractName } from './format-utils';
+
+type StateUpdater = (fn: (prev: GoogleAppState) => GoogleAppState) => void;
+
+interface MailViewProps {
+  state: GoogleAppState;
+  updateState: StateUpdater;
+  google: GoogleApi;
+}
+
+export function MailView({ state, updateState, google }: MailViewProps) {
+  const [searchQuery, setSearchQuery] = useState(state.gmail.lastQuery || '');
+  const { threads, selectedThreadId, selectedMessages } = state.gmail;
+
+  const handleSearch = useCallback((e: React.FormEvent) => {
+    e.preventDefault();
+    if (searchQuery.trim()) {
+      google.fetchInbox(searchQuery.trim());
+    }
+  }, [searchQuery, google]);
+
+  const selectThread = useCallback((threadId: string) => {
+    google.fetchThread(threadId);
+  }, [google]);
+
+  const clearSelection = useCallback(() => {
+    updateState((prev) => ({
+      ...prev,
+      gmail: { ...prev.gmail, selectedThreadId: null, selectedMessages: [] },
+    }));
+  }, [updateState]);
+
+  const handleArchive = useCallback(async (threadId: string) => {
+    const ok = await google.archiveThread(threadId);
+    if (ok) {
+      updateState((prev) => ({
+        ...prev,
+        gmail: {
+          ...prev.gmail,
+          threads: prev.gmail.threads.filter((t) => t.id !== threadId),
+          selectedThreadId: prev.gmail.selectedThreadId === threadId ? null : prev.gmail.selectedThreadId,
+          selectedMessages: prev.gmail.selectedThreadId === threadId ? [] : prev.gmail.selectedMessages,
+        },
+      }));
+    }
+  }, [google, updateState]);
+
+  // Thread detail view
+  if (selectedThreadId && selectedMessages.length > 0) {
+    return (
+      <MailThread
+        messages={selectedMessages}
+        onBack={clearSelection}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Search bar */}
+      <form onSubmit={handleSearch} className="flex shrink-0 items-center gap-2 border-b border-[var(--border-subtle)] px-3 py-1.5">
+        <Search className="size-3.5 text-[var(--text-muted)]" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search Gmail…  (e.g. newer_than:7d, from:boss)"
+          className="flex-1 bg-transparent text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]/60 outline-none"
+        />
+        <button
+          type="submit"
+          disabled={!searchQuery.trim() || google.loading}
+          className="rounded px-2 py-0.5 text-[11px] font-medium text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)] disabled:opacity-40"
+        >
+          Search
+        </button>
+      </form>
+
+      {/* Thread list */}
+      <div className="flex-1 overflow-y-auto">
+        {threads.length === 0 ? (
+          <EmptyInbox loading={google.loading} error={google.error} />
+        ) : (
+          <div className="py-1">
+            {threads.map((thread, i) => (
+              <ThreadRow
+                key={thread.id}
+                thread={thread}
+                index={i}
+                onSelect={selectThread}
+                onArchive={handleArchive}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Status bar */}
+      {threads.length > 0 && (
+        <div className="shrink-0 border-t border-[var(--border-subtle)]/60 px-3 py-1">
+          <span className="text-[11px] text-[var(--text-muted)]">
+            {threads.length} threads · last synced {state.gmail.lastFetchedAt ? formatRelativeDate(state.gmail.lastFetchedAt) : 'never'}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Thread row (ToolCallGroup style) ─────────────────────────
+
+function ThreadRow({
+  thread,
+  index,
+  onSelect,
+  onArchive,
+}: {
+  thread: GmailThread;
+  index: number;
+  onSelect: (id: string) => void;
+  onArchive: (id: string) => void;
+}) {
+  return (
+    <div
+      className="animate-g-fade-in group flex cursor-pointer items-start gap-2 px-3 py-2 transition-colors hover:bg-[var(--bg-elevated)]/60"
+      style={{ animationDelay: `${index * 20}ms` }}
+      onClick={() => onSelect(thread.id)}
+    >
+      {/* Unread dot */}
+      <div className="mt-1.5 flex shrink-0 items-center">
+        {thread.isUnread ? (
+          <span className="size-1.5 rounded-full bg-blue-500" />
+        ) : (
+          <span className="size-1.5 rounded-full bg-transparent" />
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className={`shrink-0 truncate text-[12px] ${thread.isUnread ? 'font-semibold text-[var(--text-primary)]' : 'font-medium text-[var(--text-secondary)]'}`}>
+            {extractName(thread.from)}
+          </span>
+          {thread.messageCount > 1 && (
+            <span className="shrink-0 text-[10px] text-[var(--text-muted)]">
+              ({thread.messageCount})
+            </span>
+          )}
+          <span className="ml-auto shrink-0 text-[10px] text-[var(--text-muted)]">
+            {formatRelativeDate(thread.date)}
+          </span>
+        </div>
+        <div className={`truncate text-[11px] ${thread.isUnread ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'}`}>
+          {thread.subject}
+        </div>
+        <div className="truncate text-[11px] text-[var(--text-muted)]">
+          {thread.snippet}
+        </div>
+      </div>
+
+      {/* Actions (visible on hover) */}
+      <div className="mt-1 flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+        <button
+          onClick={(e) => { e.stopPropagation(); onArchive(thread.id); }}
+          className="rounded p-1 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+          title="Archive"
+        >
+          <Archive className="size-3" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Empty state ──────────────────────────────────────────────
+
+function EmptyInbox({ loading, error }: { loading: boolean; error: string | null }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      {loading ? (
+        <>
+          <div className="size-8 rounded-full border-2 border-[var(--border-subtle)] border-t-blue-500 animate-spin mb-3" />
+          <p className="text-[12px] text-[var(--text-muted)]">Fetching your inbox…</p>
+        </>
+      ) : error ? (
+        <>
+          <Mail className="size-6 text-red-400/60 mb-3" />
+          <p className="text-[12px] text-red-400">{error}</p>
+          <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+            Make sure gogcli is installed and authenticated
+          </p>
+        </>
+      ) : (
+        <>
+          <Inbox className="size-6 text-[var(--text-muted)]/40 mb-3" />
+          <p className="text-[12px] text-[var(--text-muted)]">No emails found</p>
+          <p className="mt-1 text-[11px] text-[var(--text-muted)]/60">
+            Try a different search query or click Sync
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/pi-google-extension/ui/components/MiniCalendar.tsx
+++ b/packages/pi-google-extension/ui/components/MiniCalendar.tsx
@@ -1,0 +1,118 @@
+/**
+ * MiniCalendar — compact month grid with day selection.
+ *
+ * Highlights today, selected day, and days with events.
+ */
+
+import { useMemo } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface MiniCalendarProps {
+  /** Currently viewed month (any date in that month). */
+  month: Date;
+  /** Currently selected date (YYYY-MM-DD). */
+  selectedDate: string | null;
+  /** Set of dates that have events (YYYY-MM-DD). */
+  eventDates: Set<string>;
+  onSelectDate: (date: string) => void;
+  onChangeMonth: (delta: number) => void;
+}
+
+const WEEKDAYS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+
+function toKey(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function todayKey(): string { return toKey(new Date()); }
+
+export function MiniCalendar({ month, selectedDate, eventDates, onSelectDate, onChangeMonth }: MiniCalendarProps) {
+  const today = todayKey();
+
+  const { weeks, monthLabel } = useMemo(() => {
+    const year = month.getFullYear();
+    const mo = month.getMonth();
+    const label = month.toLocaleDateString(undefined, { month: 'long', year: 'numeric' });
+
+    // First day of month, adjust to Monday start
+    const first = new Date(year, mo, 1);
+    let startDay = first.getDay() - 1;
+    if (startDay < 0) startDay = 6; // Sunday → 6
+
+    const daysInMonth = new Date(year, mo + 1, 0).getDate();
+    const cells: (number | null)[] = [];
+    for (let i = 0; i < startDay; i++) cells.push(null);
+    for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+    while (cells.length % 7 !== 0) cells.push(null);
+
+    const rows: (number | null)[][] = [];
+    for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+
+    return { weeks: rows, monthLabel: label };
+  }, [month]);
+
+  const year = month.getFullYear();
+  const mo = month.getMonth();
+
+  return (
+    <div className="w-full select-none">
+      {/* Month nav */}
+      <div className="flex items-center justify-between px-1 pb-1.5">
+        <button
+          onClick={() => onChangeMonth(-1)}
+          className="rounded p-0.5 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <ChevronLeft className="size-3" />
+        </button>
+        <span className="text-[11px] font-medium text-[var(--text-secondary)]">{monthLabel}</span>
+        <button
+          onClick={() => onChangeMonth(1)}
+          className="rounded p-0.5 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <ChevronRight className="size-3" />
+        </button>
+      </div>
+
+      {/* Weekday header */}
+      <div className="grid grid-cols-7 gap-0">
+        {WEEKDAYS.map((d) => (
+          <div key={d} className="py-0.5 text-center text-[9px] font-medium text-[var(--text-muted)]">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      {weeks.map((week, wi) => (
+        <div key={wi} className="grid grid-cols-7 gap-0">
+          {week.map((day, di) => {
+            if (day === null) return <div key={di} />;
+            const key = `${year}-${String(mo + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+            const isToday = key === today;
+            const isSelected = key === selectedDate;
+            const hasEvent = eventDates.has(key);
+
+            return (
+              <button
+                key={di}
+                onClick={() => onSelectDate(key)}
+                className={`relative mx-auto flex size-6 items-center justify-center rounded-full text-[10px] transition-colors
+                  ${isSelected
+                    ? 'bg-blue-500 text-white font-semibold'
+                    : isToday
+                      ? 'bg-blue-500/15 text-blue-400 font-semibold'
+                      : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]'
+                  }`}
+              >
+                {day}
+                {hasEvent && !isSelected && (
+                  <span className="absolute bottom-0.5 left-1/2 size-[3px] -translate-x-1/2 rounded-full bg-blue-400" />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/pi-google-extension/ui/components/format-utils.ts
+++ b/packages/pi-google-extension/ui/components/format-utils.ts
@@ -1,0 +1,128 @@
+/**
+ * Formatting utilities for the Google app UI.
+ *
+ * Date formatting, name extraction, and event grouping helpers
+ * used by both MailView and CalendarView components.
+ */
+
+import type { CalendarEvent } from '../../shared/types';
+
+// ── Date formatting ──────────────────────────────────────────
+
+/**
+ * Format a date string into a relative label (e.g. "2m ago", "3h ago", "Yesterday").
+ */
+export function formatRelativeDate(dateStr: string): string {
+  if (!dateStr) return '';
+
+  try {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMin = Math.floor(diffMs / 60_000);
+    const diffHr = Math.floor(diffMs / 3_600_000);
+    const diffDay = Math.floor(diffMs / 86_400_000);
+
+    if (diffMin < 1) return 'just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    if (diffHr < 24) return `${diffHr}h ago`;
+    if (diffDay === 1) return 'Yesterday';
+    if (diffDay < 7) return `${diffDay}d ago`;
+
+    // Format as short date
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+/**
+ * Format a time range for calendar events.
+ */
+export function formatTimeRange(start: string, end: string, isAllDay: boolean): string {
+  if (isAllDay) return 'All day';
+  if (!start) return '';
+
+  try {
+    const startDate = new Date(start);
+    const endDate = end ? new Date(end) : null;
+
+    const fmt = (d: Date) =>
+      d.toLocaleTimeString(undefined, {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      });
+
+    if (endDate) {
+      return `${fmt(startDate)} – ${fmt(endDate)}`;
+    }
+    return fmt(startDate);
+  } catch {
+    return start;
+  }
+}
+
+// ── Name extraction ──────────────────────────────────────────
+
+/**
+ * Extract display name from an email "Name <email>" string.
+ */
+export function extractName(fromStr: string): string {
+  if (!fromStr) return 'Unknown';
+
+  // "John Doe <john@example.com>" → "John Doe"
+  const match = fromStr.match(/^(.+?)\s*<.+>$/);
+  if (match) {
+    return match[1].replace(/^["']|["']$/g, '').trim();
+  }
+
+  // "john@example.com" → "john"
+  if (fromStr.includes('@')) {
+    return fromStr.split('@')[0] || fromStr;
+  }
+
+  return fromStr;
+}
+
+// ── Event grouping ───────────────────────────────────────────
+
+/**
+ * Group calendar events by day label ("Today", "Tomorrow", "Mon Jan 20", etc.).
+ */
+export function groupEventsByDay(events: CalendarEvent[]): [string, CalendarEvent[]][] {
+  const groups = new Map<string, CalendarEvent[]>();
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  for (const event of events) {
+    const eventDate = new Date(event.start || event.startLocal || '');
+    eventDate.setHours(0, 0, 0, 0);
+
+    let label: string;
+    if (eventDate.getTime() === today.getTime()) {
+      label = 'Today';
+    } else if (eventDate.getTime() === tomorrow.getTime()) {
+      label = 'Tomorrow';
+    } else {
+      label = eventDate.toLocaleDateString(undefined, {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      });
+    }
+
+    const existing = groups.get(label) || [];
+    existing.push(event);
+    groups.set(label, existing);
+  }
+
+  return Array.from(groups.entries());
+}

--- a/packages/pi-google-extension/ui/components/gmail-parser.ts
+++ b/packages/pi-google-extension/ui/components/gmail-parser.ts
@@ -1,0 +1,91 @@
+/**
+ * gmail-parser — decode Gmail API raw message payloads.
+ *
+ * Gmail API returns headers in payload.headers[], body parts in
+ * payload.parts[].body.data (base64url-encoded). This module
+ * extracts human-readable fields from that structure.
+ */
+
+import type { GmailMessage } from '../../shared/types';
+
+/** Extract a header value by name (case-insensitive). */
+function getHeader(headers: { name: string; value: string }[], name: string): string {
+  const lower = name.toLowerCase();
+  return headers.find((h) => h.name.toLowerCase() === lower)?.value ?? '';
+}
+
+/** Decode base64url string to UTF-8 text. */
+function decodeBase64Url(data: string): string {
+  try {
+    // base64url → base64
+    const base64 = data.replace(/-/g, '+').replace(/_/g, '/');
+    // Decode to binary bytes, then UTF-8
+    const binary = atob(base64);
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    return new TextDecoder('utf-8').decode(bytes);
+  } catch {
+    return '';
+  }
+}
+
+/** Recursively find the best body part (prefer text/html, fallback text/plain). */
+function findBodyParts(
+  payload: any,
+): { text: string; html: string } {
+  const result = { text: '', html: '' };
+  if (!payload) return result;
+
+  const mimeType: string = payload.mimeType ?? '';
+  const bodyData: string = payload.body?.data ?? '';
+
+  // Leaf node with data
+  if (bodyData) {
+    const decoded = decodeBase64Url(bodyData);
+    if (mimeType === 'text/html') result.html = decoded;
+    else if (mimeType === 'text/plain') result.text = decoded;
+    return result;
+  }
+
+  // Recurse into parts
+  const parts: any[] = payload.parts ?? [];
+  for (const part of parts) {
+    const sub = findBodyParts(part);
+    if (sub.html && !result.html) result.html = sub.html;
+    if (sub.text && !result.text) result.text = sub.text;
+  }
+
+  return result;
+}
+
+/** Decode HTML entities in snippet (e.g. &#39; → '). */
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'");
+}
+
+/**
+ * Parse a raw Gmail API message object into our GmailMessage shape.
+ */
+export function parseGmailMessage(raw: any, fallbackThreadId: string): GmailMessage {
+  const payload = raw.payload ?? {};
+  const headers: { name: string; value: string }[] = payload.headers ?? [];
+  const { text, html } = findBodyParts(payload);
+  const snippet = decodeHtmlEntities(raw.snippet ?? '');
+
+  return {
+    id: raw.id ?? '',
+    threadId: raw.threadId ?? fallbackThreadId,
+    from: getHeader(headers, 'From'),
+    to: getHeader(headers, 'To'),
+    subject: getHeader(headers, 'Subject'),
+    date: getHeader(headers, 'Date'),
+    body: text || snippet,
+    bodyHtml: html,
+    snippet,
+  };
+}

--- a/packages/pi-google-extension/ui/hooks/useGoogleApi.ts
+++ b/packages/pi-google-extension/ui/hooks/useGoogleApi.ts
@@ -1,0 +1,243 @@
+/**
+ * useGoogleApi — hook for Google auth + data fetching.
+ *
+ * Auth: calls window.sero.google.login() for OAuth2 sign-in
+ * Data: calls window.sero.google.execute() for gogcli commands
+ */
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import type { GoogleAppState, GmailThread, CalendarEvent } from '../../shared/types';
+import { parseGmailMessage } from '../components/gmail-parser';
+
+type StateUpdater = (fn: (prev: GoogleAppState) => GoogleAppState) => void;
+
+interface SeroGoogleBridge {
+  execute: (service: string, args: string[]) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  authStatus: () => Promise<{ configured: boolean; authenticated: boolean; email?: string }>;
+  login: () => Promise<void>;
+  logout: () => Promise<void>;
+  onAuthEvent: (cb: (event: { type: string; message: string; email?: string }) => void) => () => void;
+}
+
+function getSeroGoogle(): SeroGoogleBridge | null {
+  return (window as any).sero?.google ?? null;
+}
+
+// ── Auth types ───────────────────────────────────────────────
+
+export type AuthStatus = 'unknown' | 'checking' | 'not-configured' | 'signed-out' | 'signing-in' | 'authenticated';
+
+export interface AuthInfo {
+  status: AuthStatus;
+  email: string | null;
+  error: string | null;
+}
+
+// ── API interface ────────────────────────────────────────────
+
+export interface GoogleApi {
+  loading: boolean;
+  error: string | null;
+  auth: AuthInfo;
+  checkAuth: () => Promise<void>;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+  fetchInbox: (query: string, max?: number) => Promise<void>;
+  fetchThread: (threadId: string) => Promise<void>;
+  fetchEvents: (view: 'today' | 'week') => Promise<void>;
+  fetchEventsRange: (from: string, to: string) => Promise<void>;
+  fetchCalendars: () => Promise<void>;
+  sendEmail: (to: string, subject: string, body: string) => Promise<boolean>;
+  archiveThread: (threadId: string) => Promise<boolean>;
+}
+
+// ── Hook ─────────────────────────────────────────────────────
+
+export function useGoogleApi(updateState: StateUpdater): GoogleApi {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [auth, setAuth] = useState<AuthInfo>({ status: 'unknown', email: null, error: null });
+
+  // Subscribe to auth progress events
+  useEffect(() => {
+    const api = getSeroGoogle();
+    if (!api) return;
+    const unsub = api.onAuthEvent((event) => {
+      if (event.type === 'success') {
+        setAuth({ status: 'authenticated', email: event.email ?? null, error: null });
+      } else if (event.type === 'error') {
+        setAuth((a) => ({ ...a, status: 'signed-out', error: event.message }));
+      }
+    });
+    return unsub;
+  }, []);
+
+  // ── Auth ───────────────────────────────────────────────────
+
+  const checkAuth = useCallback(async () => {
+    setAuth((a) => ({ ...a, status: 'checking', error: null }));
+    const api = getSeroGoogle();
+    if (!api) { setAuth({ status: 'unknown', email: null, error: 'Bridge unavailable' }); return; }
+
+    try {
+      const status = await api.authStatus();
+      if (!status.configured) {
+        setAuth({ status: 'not-configured', email: null, error: null });
+      } else if (status.authenticated) {
+        setAuth({ status: 'authenticated', email: status.email ?? null, error: null });
+        updateState((prev) => ({ ...prev, activeAccount: status.email ?? null }));
+      } else {
+        setAuth({ status: 'signed-out', email: null, error: null });
+      }
+    } catch (err) {
+      setAuth({ status: 'unknown', email: null, error: String(err) });
+    }
+  }, [updateState]);
+
+  const signIn = useCallback(async () => {
+    const api = getSeroGoogle();
+    if (!api) return;
+    setAuth((a) => ({ ...a, status: 'signing-in', error: null }));
+    try {
+      await api.login();
+      // Success handled by onAuthEvent listener
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setAuth((a) => ({ ...a, status: 'signed-out', error: msg }));
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    const api = getSeroGoogle();
+    if (!api) return;
+    await api.logout();
+    setAuth({ status: 'signed-out', email: null, error: null });
+    updateState((prev) => ({ ...prev, activeAccount: null }));
+  }, [updateState]);
+
+  // ── Data command executor ──────────────────────────────────
+
+  const exec = useCallback(async (service: string, args: string[]): Promise<any | null> => {
+    setLoading(true);
+    setError(null);
+    try {
+      const api = getSeroGoogle();
+      if (!api) { setError('Bridge unavailable'); return null; }
+      const result = await api.execute(service, args);
+      if (result.exitCode === 127) { setError('gogcli not found'); return null; }
+      if (result.exitCode !== 0) {
+        const msg = result.stderr.trim() || result.stdout.trim() || 'Command failed';
+        setError(msg.length > 120 ? msg.slice(0, 120) + '…' : msg);
+        return null;
+      }
+      try { return JSON.parse(result.stdout); } catch { return result.stdout.trim(); }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // ── Data fetchers ──────────────────────────────────────────
+
+  const fetchInbox = useCallback(async (query: string, max = 15) => {
+    const data = await exec('gmail', ['search', query, '--max', String(max)]);
+    if (!data) return;
+    const threads: GmailThread[] = (data.threads || []).map((t: any) => ({
+      id: t.id || '', snippet: t.snippet || '',
+      subject: t.messages?.[0]?.subject || t.subject || '(no subject)',
+      from: t.messages?.[0]?.from || t.from || '',
+      date: t.messages?.[0]?.date || t.date || '',
+      labelIds: t.messages?.[0]?.labels || t.labelIds || [],
+      isUnread: (t.messages?.[0]?.labels || t.labelIds || []).includes('UNREAD'),
+      messageCount: t.messages?.length || t.messageCount || 1,
+    }));
+    updateState((prev) => ({
+      ...prev,
+      gmail: { ...prev.gmail, threads, lastQuery: query, lastFetchedAt: new Date().toISOString() },
+    }));
+  }, [exec, updateState]);
+
+  const fetchThread = useCallback(async (threadId: string) => {
+    const data = await exec('gmail', ['thread', 'get', threadId]);
+    if (!data) return;
+    const rawMessages: any[] = data.thread?.messages || data.messages || [];
+    const messages = rawMessages.map((m) => parseGmailMessage(m, threadId));
+    updateState((prev) => ({
+      ...prev,
+      gmail: { ...prev.gmail, selectedThreadId: threadId, selectedMessages: messages },
+    }));
+  }, [exec, updateState]);
+
+  const mapEvent = (e: any): CalendarEvent => ({
+    id: e.id || '', calendarId: e.organizer?.displayName || 'primary',
+    summary: e.summary || '(no title)',
+    start: e.start?.dateTime || e.start?.date || e.startLocal || '',
+    end: e.end?.dateTime || e.end?.date || e.endLocal || '',
+    startLocal: e.startLocal || '', endLocal: e.endLocal || '',
+    location: e.location || '', description: e.description || '',
+    attendees: (e.attendees || []).map((a: any) => {
+      const name = a.displayName || a.email || '';
+      const status = a.responseStatus ? ` (${a.responseStatus})` : '';
+      return a.self ? `${name}${status} — you` : `${name}${status}`;
+    }),
+    isAllDay: !!e.start?.date && !e.start?.dateTime,
+    status: e.status || '', htmlLink: e.htmlLink || '',
+    visibility: e.visibility || '', eventType: e.eventType || '',
+    sourceUrl: e.source?.url || '',
+    reminders: (e.reminders?.overrides || []).map((r: any) => ({
+      method: r.method || 'popup', minutes: r.minutes || 0,
+    })),
+    created: e.created || '', updated: e.updated || '',
+  });
+
+  const fetchEvents = useCallback(async (view: 'today' | 'week') => {
+    const flag = view === 'today' ? '--today' : '--week';
+    const data = await exec('calendar', ['events', 'primary', flag]);
+    if (!data) return;
+    const events = (data.events || []).map(mapEvent);
+    updateState((prev) => ({
+      ...prev,
+      calendar: { ...prev.calendar, events, view, lastFetchedAt: new Date().toISOString() },
+    }));
+  }, [exec, updateState]);
+
+  const fetchEventsRange = useCallback(async (from: string, to: string) => {
+    const data = await exec('calendar', ['events', 'primary', '--from', from, '--to', to, '--max', '50']);
+    if (!data) return;
+    const events = (data.events || []).map(mapEvent);
+    updateState((prev) => ({
+      ...prev,
+      calendar: { ...prev.calendar, events, lastFetchedAt: new Date().toISOString() },
+    }));
+  }, [exec, updateState]);
+
+  const fetchCalendars = useCallback(async () => {
+    const data = await exec('calendar', ['calendars']);
+    if (!data) return;
+    updateState((prev) => ({
+      ...prev,
+      calendar: {
+        ...prev.calendar,
+        calendars: (data.calendars || []).map((c: any) => ({
+          id: c.id || '', summary: c.summary || c.id || '', primary: !!c.primary,
+        })),
+      },
+    }));
+  }, [exec, updateState]);
+
+  const sendEmail = useCallback(async (to: string, subject: string, body: string): Promise<boolean> => {
+    return (await exec('gmail', ['send', '--to', to, '--subject', subject, '--body', body])) !== null;
+  }, [exec]);
+
+  const archiveThread = useCallback(async (threadId: string): Promise<boolean> => {
+    return (await exec('gmail', ['labels', 'modify', threadId, '--remove', 'INBOX'])) !== null;
+  }, [exec]);
+
+  return useMemo(() => ({
+    loading, error, auth, checkAuth, signIn, signOut,
+    fetchInbox, fetchThread, fetchEvents, fetchEventsRange, fetchCalendars, sendEmail, archiveThread,
+  }), [loading, error, auth, checkAuth, signIn, signOut,
+    fetchInbox, fetchThread, fetchEvents, fetchEventsRange, fetchCalendars, sendEmail, archiveThread]);
+}

--- a/packages/pi-google-extension/ui/index.html
+++ b/packages/pi-google-extension/ui/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Sero Google (remote)</title></head>
+<body><div id="root"></div></body>
+</html>

--- a/packages/pi-google-extension/ui/styles.css
+++ b/packages/pi-google-extension/ui/styles.css
@@ -1,0 +1,61 @@
+@import "tailwindcss";
+
+/* Scan @sero/ui component sources so Tailwind generates their utility classes */
+@source "../../ui/src/components";
+
+@custom-variant dark (&:is(.dark *));
+
+/*
+ * Theme tokens — maps Sero/shadcn CSS variables to Tailwind utilities.
+ * The CSS variables themselves are provided by the host shell at runtime.
+ */
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+/* ── Google app animations ──────────────────────────────────── */
+
+@keyframes g-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes g-slide-in {
+  from { opacity: 0; height: 0; }
+  to { opacity: 1; height: var(--expanded-height, auto); }
+}
+
+@keyframes g-pulse-dot {
+  0%, 100% { opacity: 0.4; }
+  50% { opacity: 1; }
+}
+
+@utility animate-g-fade-in {
+  animation: g-fade-in 0.2s ease-out both;
+}
+
+@utility animate-g-pulse {
+  animation: g-pulse-dot 2s ease-in-out infinite;
+}

--- a/packages/pi-google-extension/ui/tsconfig.json
+++ b/packages/pi-google-extension/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero/app-runtime": ["../../app-runtime/src/index.ts"],
+      "@sero/ui": ["../../ui/src/index.ts"],
+      "@sero/ui/*": ["../../ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-google-extension/vite.config.ts
+++ b/packages/pi-google-extension/vite.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_google',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './GoogleApp': './ui/GoogleApp.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5186,
+    strictPort: true,
+    origin: 'http://localhost:5186',
+  },
+  optimizeDeps: {
+    exclude: ['@sero/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,61 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/pi-google-extension:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: '>=0.52.0'
+        version: 0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.52.0'
+        version: 0.52.12(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.52.0'
+        version: 0.52.12
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
+    devDependencies:
+      '@module-federation/vite':
+        specifier: ^1.11.0
+        version: 1.11.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@sero/app-runtime':
+        specifier: workspace:*
+        version: link:../app-runtime
+      '@sero/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      lucide-react:
+        specifier: ^0.563.0
+        version: 0.563.0(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
   packages/pi-imagegen-extension:
     dependencies:
       '@mariozechner/pi-ai':


### PR DESCRIPTION
## Google Workspace App for Sero

Full Sero app (`pi-google-extension`) integrating Gmail and Google Calendar via [gogcli](https://github.com/steipete/gogcli).

### Auth
- **One-click OAuth2 sign-in** — click "Sign in with Google" → browser opens account chooser → done
- Authorization Code + PKCE flow in Electron, refresh token auto-imported into gogcli
- File-based keyring (no macOS Keychain prompts)
- Credentials from `~/.sero-ui/agent/.env` (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`)

### Gmail
- Inbox with search, thread list with relative dates
- Full **HTML email rendering** in sandboxed iframe with dark theme
- Proper Gmail API parsing (headers, base64url body, UTF-8)
- Pinned sender header with scrollable email content

### Calendar
- **Mini calendar** sidebar with month navigation + event dot indicators
- Event list grouped by day, Today/This Week toggle
- Auto-fetches events when navigating months
- **Rich event detail**: date ranges, Maps-linked locations, attendees with RSVP icons, reminders, visibility, source links
- Strips Google auto-generated boilerplate from descriptions

### IPC Layer
- `sero:google:execute` — gogcli data commands with `--account` auto-injection
- `sero:google:authStatus/login/logout/authEvent` — auth lifecycle
- PATH probing for gogcli binary on macOS

### Setup
1. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in `~/.sero-ui/agent/.env`
2. Install gogcli: `brew install steipete/tap/gogcli` or download from releases
3. Restart Sero — the Google app auto-discovers via `sero.app` manifest