### PR TITLE
Add Count Slopula: vampire-themed content generator app

### DIFF
--- a/packages/pi-count-slopula-extension/extension/index.ts
+++ b/packages/pi-count-slopula-extension/extension/index.ts
@@ -1,0 +1,142 @@
+/**
+ * Count Slopula Extension — Pi extension that tracks generated content pieces.
+ *
+ * The web UI is the primary interface — this extension provides a lightweight
+ * tool so the agent can query Count Slopula's history and entombed pieces,
+ * and a /count-slopula command to prompt the user to open the app.
+ *
+ * State: `~/.sero-ui/apps/count-slopula/state.json` (global scope)
+ * Tools: count_slopula (list history or entombed)
+ * Commands: /count-slopula
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import type { CountSlopulaState } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+
+// ── State file path ────────────────────────────────────────
+
+const STATE_REL_PATH = path.join('.sero', 'apps', 'count-slopula', 'state.json');
+
+function resolveStatePath(cwd: string): string {
+  const seroHome = process.env.SERO_HOME;
+  if (seroHome) {
+    return path.join(seroHome, 'apps', 'count-slopula', 'state.json');
+  }
+  return path.join(cwd, STATE_REL_PATH);
+}
+
+// ── File I/O ───────────────────────────────────────────────
+
+async function readState(filePath: string): Promise<CountSlopulaState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as CountSlopulaState;
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+// ── Tool parameters ────────────────────────────────────────
+
+const Params = Type.Object({
+  action: StringEnum(['history', 'entombed'] as const),
+});
+
+// ── Helpers ────────────────────────────────────────────────
+
+function formatHistory(state: CountSlopulaState): string {
+  if (state.history.length === 0) {
+    return 'No Count Slopula rituals performed yet. Open the Count Slopula app to summon gloriously cliched content from the crypt!';
+  }
+
+  const lines = state.history.map((h, i) => {
+    const status = h.status ?? 'launched';
+    return `${i + 1}. ${h.piece.name} (slop: ${h.piece.slopRating}/10, status: ${status}) — ${h.piece.tagline}\n   Genre: ${h.piece.genre}\n   Launched: ${h.launchedAt}`;
+  });
+  return `Count Slopula Ritual Log:\n\n${lines.join('\n\n')}`;
+}
+
+function formatEntombed(state: CountSlopulaState): string {
+  const saved = state.savedPieces ?? [];
+  if (saved.length === 0) {
+    return 'No entombed pieces. Open Count Slopula to summon content and entomb the best pieces for later!';
+  }
+
+  const lines = saved.map((s, i) =>
+    `${i + 1}. ${s.piece.name} (slop: ${s.piece.slopRating}/10) — ${s.piece.tagline}\n   ${s.piece.body.slice(0, 150)}...\n   Genre: ${s.piece.genre}\n   Entombed: ${s.savedAt}`,
+  );
+  return `Count Slopula Entombed Pieces (${saved.length}):\n\n${lines.join('\n\n')}`;
+}
+
+// ── Extension ──────────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+  let statePath = '';
+
+  pi.on('session_start', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+  pi.on('session_switch', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+
+  pi.registerTool({
+    name: 'count_slopula',
+    label: 'Count Slopula',
+    description:
+      'View Count Slopula data — previously launched content pieces or entombed/bookmarked pieces. Actions: history (list ritual log with status), entombed (list bookmarked pieces).',
+    parameters: Params,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : statePath;
+      if (!resolvedPath) {
+        return {
+          content: [{ type: 'text', text: 'Error: no workspace cwd' }],
+          details: {},
+        };
+      }
+      statePath = resolvedPath;
+
+      const { action } = params as { action: 'history' | 'entombed' };
+      const state = await readState(statePath);
+
+      const text =
+        action === 'history'
+          ? formatHistory(state)
+          : formatEntombed(state);
+
+      return { content: [{ type: 'text', text }], details: {} };
+    },
+
+    renderCall(args, theme) {
+      const { action } = args as { action: string };
+      return new Text(
+        theme.fg('toolTitle', theme.bold('count_slopula ')) +
+          theme.fg('muted', action ?? 'history'),
+        0, 0,
+      );
+    },
+
+    renderResult(result, _options, theme) {
+      const text = result.content[0];
+      const msg = text?.type === 'text' ? text.text : '';
+      return new Text(theme.fg('success', msg), 0, 0);
+    },
+  });
+
+  pi.registerCommand('count-slopula', {
+    description: 'Open Count Slopula — the vampire-themed cliche content generator',
+    handler: async (_args, _ctx) => {
+      pi.sendUserMessage(
+        'Show my Count Slopula history using the count_slopula tool.',
+      );
+    },
+  });
+}

--- a/packages/pi-count-slopula-extension/package.json
+++ b/packages/pi-count-slopula-extension/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@sero/count-slopula",
+  "version": "0.1.0",
+  "description": "Count Slopula — the vampire-themed random content generator for Sero",
+  "keywords": ["pi-package"],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+  },
+  "pi": {
+    "extensions": ["./extension/index.ts"]
+  },
+  "sero": {
+    "app": {
+      "id": "count-slopula",
+      "name": "Count Slopula",
+      "icon": "skull",
+      "scope": "global",
+      "stateFile": ".sero/apps/count-slopula/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "CountSlopula",
+      "devPort": 5186
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": ">=0.52.0",
+    "@mariozechner/pi-coding-agent": ">=0.52.0",
+    "@mariozechner/pi-tui": ">=0.52.0"
+  },
+  "devDependencies": {
+    "@sero/app-runtime": "workspace:*",
+    "@sero/ui": "workspace:*",
+    "@module-federation/vite": "^1.11.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "@tailwindcss/vite": "^4.1.18",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/packages/pi-count-slopula-extension/shared/types.ts
+++ b/packages/pi-count-slopula-extension/shared/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared state shape for Count Slopula.
+ *
+ * Both the Pi extension and the Sero web UI read/write a JSON file
+ * matching this shape.
+ */
+
+export type Intensity = 'nibble' | 'bite' | 'drain';
+
+export type Phase =
+  | 'config'
+  | 'generating'
+  | 'picking'
+  | 'remix'
+  | 'launching'
+  | 'launched';
+
+export interface ContentPiece {
+  id: number;
+  name: string;
+  tagline: string;
+  body: string;
+  genre: string;
+  slopRating: number; // 1–10 how cliched this content is
+}
+
+/** A piece bookmarked for later without launching. */
+export interface SavedPiece {
+  piece: ContentPiece;
+  savedAt: string; // ISO datetime
+}
+
+export type BuildStatus = 'launched' | 'complete' | 'failed';
+
+export interface HistoryEntry {
+  piece: ContentPiece;
+  launchedAt: string; // ISO datetime
+  workspaceId: string;
+  sessionId: string | null;
+  sessionPath: string | null;
+  status: BuildStatus;
+}
+
+export interface CountSlopulaState {
+  phase: Phase;
+  intensity: Intensity | null;
+  genres: string[];
+  pieces: ContentPiece[] | null;
+  chosenPiece: ContentPiece | null;
+  launchedWorkspaceId: string | null;
+  launchedSessionId: string | null;
+  history: HistoryEntry[];
+  savedPieces: SavedPiece[];
+}
+
+export const DEFAULT_STATE: CountSlopulaState = {
+  phase: 'config',
+  intensity: null,
+  genres: [],
+  pieces: null,
+  chosenPiece: null,
+  launchedWorkspaceId: null,
+  launchedSessionId: null,
+  history: [],
+  savedPieces: [],
+};
+
+/** Content genres the user can pick from. */
+export const GENRE_OPTIONS = [
+  'Motivational Drivel',
+  'Clickbait From The Crypt',
+  'LinkedIn Nightmares',
+  'Cursed Recipes',
+  'Conspiracy Corner',
+  'Horoscope Horror',
+  'Startup Seance',
+  'Dating Doom',
+  'Movie Mashup Mausoleum',
+  'Pirate Shanty Generator',
+  'Corporate Buzzword Salad',
+  'Passive-Aggressive Notes',
+] as const;

--- a/packages/pi-count-slopula-extension/ui/ConfigPhase.tsx
+++ b/packages/pi-count-slopula-extension/ui/ConfigPhase.tsx
@@ -1,0 +1,166 @@
+/**
+ * ConfigPhase — the Count Slopula landing screen (Summon tab).
+ *
+ * Gothic vampire ASCII art, intensity picker (coffin-shaped cards),
+ * genre picker, and the "SUMMON THE SLOP" CTA.
+ */
+
+import { useState, useCallback } from 'react';
+import type { Intensity } from '../shared/types';
+import { GENRE_OPTIONS } from '../shared/types';
+
+// ── Vampire ASCII art ──────────────────────────────────────
+
+const VAMPIRE_ART = `     /\\     /\\
+    {  \\   /  }
+     \\  \\_/  /
+      \\     /
+    .-'(o o)'-.
+   /    |||    \\
+  |    (|||)    |
+   \\   =====   /
+    '-._____.-'
+      |     |
+     _|     |_
+    |___|___|_|`;
+
+const INTENSITY_DATA: { value: Intensity; label: string; fang: string; desc: string }[] = [
+  {
+    value: 'nibble',
+    label: 'Mild Nibble',
+    fang: '^..^',
+    desc: 'A polite vampire. Cliches are there, but tasteful.',
+  },
+  {
+    value: 'bite',
+    label: 'Deep Bite',
+    fang: '^vv^',
+    desc: 'Fangs are out. Tropes stacked high. No apologies.',
+  },
+  {
+    value: 'drain',
+    label: 'FULL DRAIN',
+    fang: 'V\\/V',
+    desc: 'Every drop of originality drained. Pure concentrated slop.',
+  },
+];
+
+interface ConfigPhaseProps {
+  onGenerate: (intensity: Intensity, genres: string[]) => void;
+}
+
+export function ConfigPhase({ onGenerate }: ConfigPhaseProps) {
+  const [intensity, setIntensity] = useState<Intensity | null>(null);
+  const [selectedGenres, setSelectedGenres] = useState<Set<string>>(new Set());
+
+  const toggleGenre = useCallback((genre: string) => {
+    setSelectedGenres((prev) => {
+      const next = new Set(prev);
+      if (next.has(genre)) next.delete(genre);
+      else next.add(genre);
+      return next;
+    });
+  }, []);
+
+  const handleGenerate = useCallback(() => {
+    if (!intensity) return;
+    onGenerate(intensity, [...selectedGenres]);
+  }, [intensity, selectedGenres, onGenerate]);
+
+  return (
+    <div className="cs-animate-fade-up flex flex-col items-center justify-center h-full px-6 py-6 relative z-10">
+      {/* Hero — vampire art beside title */}
+      <div className="flex items-center gap-8 mb-8">
+        <pre
+          className="text-xs leading-tight select-none shrink-0 cs-animate-float"
+          style={{ color: 'var(--cs-crimson)', filter: 'drop-shadow(0 0 12px var(--cs-crimson-glow))' }}
+          aria-hidden="true"
+        >
+          {VAMPIRE_ART}
+        </pre>
+        <div>
+          <h1 className="cs-title cs-animate-flicker">Count Slopula</h1>
+          <p className="cs-subtitle mt-2">
+            &ldquo;I vant to drain... your originality!&rdquo;
+          </p>
+          <p className="mt-3 text-sm max-w-md" style={{ color: 'var(--cs-text-dim)' }}>
+            Choose the intensity of cliche, pick your genres, and let the
+            Count summon 3 pieces of gloriously unoriginal content from the crypt.
+          </p>
+        </div>
+      </div>
+
+      {/* Intensity picker */}
+      <div className="w-full max-w-2xl mb-8">
+        <h2
+          className="cs-vampire-text text-sm mb-4 text-center"
+          style={{ color: 'var(--cs-crimson-dim)' }}
+        >
+          Choose Your Bite Strength
+        </h2>
+        <div className="grid grid-cols-3 gap-4">
+          {INTENSITY_DATA.map((c) => (
+            <div
+              key={c.value}
+              className={`cs-intensity-card ${intensity === c.value ? 'selected' : ''}`}
+              onClick={() => setIntensity(c.value)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === 'Enter' && setIntensity(c.value)}
+            >
+              <div className="relative z-10">
+                <div
+                  className="text-2xl font-mono text-center mb-2 select-none"
+                  style={{ color: intensity === c.value ? 'var(--cs-crimson)' : 'var(--cs-text-dim)' }}
+                >
+                  {c.fang}
+                </div>
+                <h3
+                  className="cs-vampire-text text-center text-base mb-1"
+                  style={{ color: intensity === c.value ? 'var(--cs-crimson)' : 'var(--cs-text)' }}
+                >
+                  {c.label}
+                </h3>
+                <p className="text-xs text-center leading-relaxed" style={{ color: 'var(--cs-text-dim)' }}>
+                  {c.desc}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Genre picker */}
+      <div className="w-full max-w-2xl mb-8">
+        <h2
+          className="cs-vampire-text text-sm mb-3 text-center"
+          style={{ color: 'var(--cs-crimson-dim)' }}
+        >
+          Choose Your Genres (Optional)
+        </h2>
+        <div className="flex flex-wrap gap-2 justify-center">
+          {GENRE_OPTIONS.map((genre) => (
+            <button
+              key={genre}
+              className={`cs-genre-chip ${selectedGenres.has(genre) ? 'selected' : ''}`}
+              onClick={() => toggleGenre(genre)}
+            >
+              {genre}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Generate button */}
+      <button
+        className="cs-cta"
+        onClick={handleGenerate}
+        disabled={!intensity}
+      >
+        <span>
+          {intensity ? 'SUMMON THE SLOP' : 'Choose a bite strength first...'}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/packages/pi-count-slopula-extension/ui/CountSlopula.tsx
+++ b/packages/pi-count-slopula-extension/ui/CountSlopula.tsx
@@ -1,0 +1,366 @@
+/**
+ * CountSlopula — main Sero app component.
+ *
+ * Two-tab layout:
+ *   - Summon tab — config -> generating -> picking -> remix -> launching
+ *   - The Crypt tab — ritual log + entombed pieces
+ *
+ * State is persisted via useAppState so history & saved pieces survive.
+ */
+
+import { useCallback, useMemo, useState, Component } from 'react';
+import type { ReactNode, ErrorInfo } from 'react';
+import { useAppState, useAI } from '@sero/app-runtime';
+import type {
+  CountSlopulaState,
+  Intensity,
+  ContentPiece,
+  BuildStatus,
+} from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+import { SLOPULA_STYLES } from './slopula-styles';
+import { buildContentPrompt, parsePiecesResponse, padPieces } from './content-utils';
+import { ConfigPhase } from './ConfigPhase';
+import { GeneratingPhase } from './GeneratingPhase';
+import { PickingPhase } from './PickingPhase';
+import { RemixPhase } from './RemixPhase';
+import { LaunchPhase } from './LaunchPhase';
+import { HistoryDashboard } from './HistoryDashboard';
+import './styles.css';
+
+// ── Error Boundary ─────────────────────────────────────────
+
+interface EBProps { children: ReactNode; onReset?: () => void }
+interface EBState { error: Error | null }
+
+class PhaseErrorBoundary extends Component<EBProps, EBState> {
+  state: EBState = { error: null };
+  static getDerivedStateFromError(error: Error) { return { error }; }
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('[CountSlopula] Phase crashed:', error, info.componentStack);
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex flex-col items-center justify-center flex-1 px-6 py-12 relative z-10">
+          <pre
+            className="text-sm leading-tight font-mono select-none text-center mb-6"
+            style={{ color: 'var(--cs-crimson)' }}
+            aria-hidden="true"
+          >{`     /\\     /\\
+    {  \\   /  }
+     \\  \\_/  /
+      \\     /
+    .-'(x x)'-.
+   /    ~~~    \\
+  |  *garlic*  |
+   \\   =====   /
+    '-._____.-'`}</pre>
+          <h2 className="cs-vampire-text text-xl mb-2" style={{ color: 'var(--cs-crimson)' }}>
+            THE COUNT HAS FALLEN!
+          </h2>
+          <p className="text-sm text-center mb-2 italic" style={{ color: 'var(--cs-text)' }}>
+            Something went horribly wrong in the crypt.
+          </p>
+          <p className="text-xs text-center mb-6 max-w-sm italic" style={{ color: 'var(--cs-text-dim)' }}>
+            {this.state.error.message}
+          </p>
+          <button className="cs-cta" onClick={() => {
+            this.setState({ error: null });
+            this.props.onReset?.();
+          }}>
+            <span>Resurrect the Count</span>
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// ── Tab type ───────────────────────────────────────────────
+
+type Tab = 'summon' | 'crypt';
+
+// ── Main Component ─────────────────────────────────────────
+
+export function CountSlopula() {
+  const [state, updateState] = useAppState<CountSlopulaState>(DEFAULT_STATE);
+  const ai = useAI();
+
+  // Tab & phase
+  const [tab, setTab] = useState<Tab>('summon');
+  const [phase, setPhase] = useState(state.phase === 'launched' ? 'config' : state.phase);
+  const [pieces, setPieces] = useState<ContentPiece[] | null>(state.pieces);
+  const [chosenPiece, setChosenPiece] = useState<ContentPiece | null>(state.chosenPiece);
+  const [intensity, setIntensity] = useState<Intensity>(state.intensity || 'bite');
+  const [remixTwist, setRemixTwist] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const savedPieces = state.savedPieces ?? [];
+  const history = state.history ?? [];
+  const savedPieceNames = useMemo(
+    () => new Set(savedPieces.map((s) => s.piece.name)),
+    [savedPieces],
+  );
+
+  const historyCount = history.length;
+
+  // ── Generate content ──────────────────────────────────────
+
+  const handleGenerate = useCallback(
+    async (int: Intensity, genres: string[]) => {
+      setIntensity(int);
+      setPhase('generating');
+      setError(null);
+      updateState((prev) => ({
+        ...prev, phase: 'generating', intensity: int, genres, pieces: null,
+      }));
+      try {
+        const prompt = buildContentPrompt(int, genres, history);
+        const response = await ai.prompt(prompt);
+        const parsed = parsePiecesResponse(response);
+        if (parsed.length === 0) {
+          setError('Count Slopula could not parse the content. The ritual may need repeating!');
+          setPhase('config');
+          updateState((prev) => ({ ...prev, phase: 'config' }));
+          return;
+        }
+        const final = padPieces(parsed);
+        setPieces(final);
+        setPhase('picking');
+        updateState((prev) => ({ ...prev, phase: 'picking', pieces: final }));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'The summoning failed');
+        setPhase('config');
+        updateState((prev) => ({ ...prev, phase: 'config' }));
+      }
+    },
+    [ai, history, updateState],
+  );
+
+  // ── Pick / Remix / Save ─────────────────────────────────
+
+  const handlePick = useCallback(
+    (piece: ContentPiece) => {
+      setChosenPiece(piece);
+      setRemixTwist('');
+      setPhase('launching');
+      updateState((prev) => ({ ...prev, phase: 'launching', chosenPiece: piece }));
+    },
+    [updateState],
+  );
+
+  const handleStartRemix = useCallback(
+    (piece: ContentPiece) => {
+      setChosenPiece(piece);
+      setPhase('remix');
+      updateState((prev) => ({ ...prev, phase: 'remix', chosenPiece: piece }));
+    },
+    [updateState],
+  );
+
+  const handleRemixLaunch = useCallback(
+    (remixed: ContentPiece, twist: string) => {
+      setChosenPiece(remixed);
+      setRemixTwist(twist);
+      setPhase('launching');
+      updateState((prev) => ({ ...prev, phase: 'launching', chosenPiece: remixed }));
+    },
+    [updateState],
+  );
+
+  const handleSave = useCallback(
+    (piece: ContentPiece) => {
+      updateState((prev) => {
+        const list = prev.savedPieces ?? [];
+        const exists = list.some((s) => s.piece.name === piece.name);
+        if (exists) return { ...prev, savedPieces: list.filter((s) => s.piece.name !== piece.name) };
+        return {
+          ...prev,
+          savedPieces: [...list, { piece, savedAt: new Date().toISOString() }].slice(-20),
+        };
+      });
+    },
+    [updateState],
+  );
+
+  const handleDeleteSaved = useCallback(
+    (piece: ContentPiece) => {
+      updateState((prev) => ({
+        ...prev,
+        savedPieces: (prev.savedPieces ?? []).filter((s) => s.piece.name !== piece.name),
+      }));
+    },
+    [updateState],
+  );
+
+  const handleLaunchSaved = useCallback(
+    (piece: ContentPiece) => {
+      setChosenPiece(piece);
+      setRemixTwist('');
+      setPhase('launching');
+      setTab('summon');
+      updateState((prev) => ({
+        ...prev,
+        phase: 'launching',
+        chosenPiece: piece,
+        savedPieces: (prev.savedPieces ?? []).filter((s) => s.piece.name !== piece.name),
+      }));
+    },
+    [updateState],
+  );
+
+  // ── Launch completed / status ───────────────────────────
+
+  const handleLaunched = useCallback(
+    (workspaceId: string, sessionId: string, sessionPath: string) => {
+      updateState((prev) => {
+        const newHistory = chosenPiece
+          ? [...prev.history, {
+              piece: chosenPiece,
+              launchedAt: new Date().toISOString(),
+              workspaceId,
+              sessionId,
+              sessionPath,
+              status: 'launched' as const,
+            }].slice(-10)
+          : prev.history;
+        return {
+          ...prev,
+          phase: 'launched' as const,
+          launchedWorkspaceId: workspaceId,
+          launchedSessionId: sessionId,
+          history: newHistory,
+        };
+      });
+    },
+    [chosenPiece, updateState],
+  );
+
+  const handleStatusChange = useCallback(
+    (workspaceId: string, status: BuildStatus) => {
+      updateState((prev) => ({
+        ...prev,
+        history: prev.history.map((h) =>
+          h.workspaceId === workspaceId ? { ...h, status } : h,
+        ),
+      }));
+    },
+    [updateState],
+  );
+
+  // ── Reset / navigation ──────────────────────────────────
+
+  const handleBack = useCallback(() => {
+    setPhase('config');
+    setPieces(null);
+    setChosenPiece(null);
+    setRemixTwist('');
+    setError(null);
+    updateState((prev) => ({
+      ...prev, phase: 'config', pieces: null, chosenPiece: null,
+      launchedWorkspaceId: null, launchedSessionId: null,
+    }));
+  }, [updateState]);
+
+  const handleBackToPicking = useCallback(() => {
+    setPhase('picking');
+    setChosenPiece(null);
+    setRemixTwist('');
+    updateState((prev) => ({ ...prev, phase: 'picking', chosenPiece: null }));
+  }, [updateState]);
+
+  // ── Render ──────────────────────────────────────────────
+
+  return (
+    <>
+      <style>{SLOPULA_STYLES}</style>
+      <div className="cs-root cs-mist flex h-full w-full flex-col overflow-hidden relative">
+        <div className="cs-atmosphere" />
+
+        {/* Tab bar */}
+        <div className="cs-tab-bar relative z-10">
+          <button
+            className={`cs-tab ${tab === 'summon' ? 'active' : ''}`}
+            onClick={() => setTab('summon')}
+          >
+            Summon
+          </button>
+          <button
+            className={`cs-tab ${tab === 'crypt' ? 'active' : ''}`}
+            onClick={() => setTab('crypt')}
+          >
+            The Crypt
+            {historyCount > 0 && (
+              <span className="cs-tab-badge">{historyCount}</span>
+            )}
+          </button>
+        </div>
+
+        {/* Scrollable content area */}
+        <div className="flex-1 overflow-y-auto relative flex flex-col">
+          {error && (
+            <div
+              className="mx-6 mt-3 px-4 py-2 rounded text-sm relative z-10 italic"
+              style={{
+                background: 'rgba(220, 20, 60, 0.1)',
+                border: '1px solid rgba(220, 20, 60, 0.3)',
+                color: 'var(--cs-crimson)',
+              }}
+            >
+              {error}
+            </div>
+          )}
+
+          {tab === 'summon' && (
+            <PhaseErrorBoundary onReset={handleBack}>
+              {phase === 'config' && (
+                <ConfigPhase onGenerate={handleGenerate} />
+              )}
+              {phase === 'generating' && <GeneratingPhase />}
+              {phase === 'picking' && pieces && (
+                <PickingPhase
+                  pieces={pieces}
+                  onPick={handlePick}
+                  onRemix={handleStartRemix}
+                  onSave={handleSave}
+                  savedPieceNames={savedPieceNames}
+                  onRegenerate={() => handleGenerate(intensity, state.genres)}
+                />
+              )}
+              {phase === 'remix' && chosenPiece && (
+                <RemixPhase
+                  piece={chosenPiece}
+                  onLaunch={handleRemixLaunch}
+                  onBack={handleBackToPicking}
+                />
+              )}
+              {phase === 'launching' && chosenPiece && (
+                <LaunchPhase
+                  piece={chosenPiece}
+                  intensity={intensity}
+                  twist={remixTwist || undefined}
+                  onLaunched={handleLaunched}
+                  onBack={handleBack}
+                />
+              )}
+            </PhaseErrorBoundary>
+          )}
+
+          {tab === 'crypt' && (
+            <HistoryDashboard
+              history={history}
+              savedPieces={savedPieces}
+              onStatusChange={handleStatusChange}
+              onLaunchSaved={handleLaunchSaved}
+              onDeleteSaved={handleDeleteSaved}
+            />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default CountSlopula;

--- a/packages/pi-count-slopula-extension/ui/GeneratingPhase.tsx
+++ b/packages/pi-count-slopula-extension/ui/GeneratingPhase.tsx
@@ -1,0 +1,113 @@
+/**
+ * GeneratingPhase — animated loading screen while the AI generates content.
+ *
+ * Shows a floating bat, blood drip animation, and dramatic flavor text.
+ */
+
+import { useState, useEffect } from 'react';
+
+const BAT_ART = `   _       _
+  /_\\     /_\\
+ //  \\_V_/  \\\\
+ \\\\   o o   //
+  \\\\  ^^^  //
+   '-------'`;
+
+const FLAVORS = [
+  'Raiding the cliche vaults...',
+  'Draining originality from innocent content...',
+  'Consulting the ancient scrolls of BuzzFeed...',
+  'Counting tropes... one, two, three, ah ah ah...',
+  'Resurrecting dead memes from their graves...',
+  'Mixing metaphors in a cauldron of cringe...',
+  'Polishing the most overused phrases...',
+  'Summoning the spirit of every LinkedIn influencer...',
+  'Harvesting inspirational quotes from cursed posters...',
+  'Distilling pure, weapons-grade cliche...',
+];
+
+function FlavorText() {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setIndex((i) => (i + 1) % FLAVORS.length);
+    }, 2500);
+    return () => clearInterval(timer);
+  }, []);
+
+  return (
+    <p
+      className="mt-8 text-xs italic text-center"
+      style={{ color: 'var(--cs-text-dim)', opacity: 0.7 }}
+    >
+      {FLAVORS[index]}
+    </p>
+  );
+}
+
+export function GeneratingPhase() {
+  return (
+    <div className="cs-animate-fade-up flex flex-col items-center justify-center flex-1 px-6 py-12 relative z-10">
+      {/* Floating bat */}
+      <div className="cs-animate-bat mb-8">
+        <pre
+          className="text-sm leading-tight font-mono select-none text-center"
+          style={{
+            color: 'var(--cs-crimson)',
+            filter: 'drop-shadow(0 0 12px var(--cs-crimson-glow-strong))',
+          }}
+          aria-hidden="true"
+        >
+          {BAT_ART}
+        </pre>
+      </div>
+
+      {/* Blood drip animation */}
+      <div className="flex gap-4 mb-8">
+        <div
+          className="w-1 h-8 rounded-full"
+          style={{
+            background: 'linear-gradient(180deg, var(--cs-crimson), transparent)',
+            animation: 'cs-blood-drip 2s ease-in infinite',
+          }}
+        />
+        <div
+          className="w-1 h-8 rounded-full"
+          style={{
+            background: 'linear-gradient(180deg, var(--cs-crimson), transparent)',
+            animation: 'cs-blood-drip 2s ease-in infinite 0.5s',
+          }}
+        />
+        <div
+          className="w-1 h-8 rounded-full"
+          style={{
+            background: 'linear-gradient(180deg, var(--cs-crimson), transparent)',
+            animation: 'cs-blood-drip 2s ease-in infinite 1s',
+          }}
+        />
+      </div>
+
+      {/* Loading text */}
+      <h2
+        className="cs-vampire-text text-xl mb-4 text-center cs-animate-heartbeat"
+        style={{ color: 'var(--cs-crimson)' }}
+      >
+        DRAINING ORIGINALITY...
+      </h2>
+
+      <p className="text-sm text-center mb-6 italic" style={{ color: 'var(--cs-text-dim)' }}>
+        The Count is rummaging through the crypt of cliches
+      </p>
+
+      {/* Loading drops */}
+      <div className="flex gap-3">
+        <div className="cs-loading-drop" />
+        <div className="cs-loading-drop" />
+        <div className="cs-loading-drop" />
+      </div>
+
+      <FlavorText />
+    </div>
+  );
+}

--- a/packages/pi-count-slopula-extension/ui/HistoryDashboard.tsx
+++ b/packages/pi-count-slopula-extension/ui/HistoryDashboard.tsx
@@ -1,0 +1,300 @@
+/**
+ * HistoryDashboard — The Crypt tab.
+ *
+ * Two sections:
+ *   1. Ritual Log — launched content pieces with status + open
+ *   2. Entombed — bookmarked pieces with launch / delete actions
+ */
+
+import type { HistoryEntry, BuildStatus, SavedPiece, ContentPiece } from '../shared/types';
+
+// ── Open session via CustomEvent ────────────────────────────
+
+function openSession(entry: HistoryEntry) {
+  window.dispatchEvent(
+    new CustomEvent('sero:open-session', {
+      detail: {
+        sessionId: entry.sessionId,
+        sessionPath: entry.sessionPath,
+        workspaceId: entry.workspaceId,
+      },
+    }),
+  );
+}
+
+// ── Status helpers ─────────────────────────────────────────
+
+const STATUS_CFG: Record<BuildStatus, { label: string; color: string; dot: string }> = {
+  launched: { label: 'Launched', color: 'var(--cs-crimson)', dot: '~' },
+  complete: { label: 'Complete', color: 'var(--cs-ghost)',   dot: '+' },
+  failed:   { label: 'Failed',   color: 'var(--cs-crimson)', dot: 'x' },
+};
+
+function bloodColor(rating: number): string {
+  if (rating <= 3) return 'var(--cs-ghost)';
+  if (rating <= 6) return 'var(--cs-gold)';
+  return 'var(--cs-crimson)';
+}
+
+// ── Compact history row ────────────────────────────────────
+
+function HistoryRow({
+  entry,
+  onStatusChange,
+}: {
+  entry: HistoryEntry;
+  onStatusChange: (id: string, s: BuildStatus) => void;
+}) {
+  const { piece, launchedAt, workspaceId } = entry;
+  const status = entry.status ?? 'launched';
+  const cfg = STATUS_CFG[status];
+  const date = new Date(launchedAt).toLocaleDateString();
+
+  return (
+    <div
+      className="flex items-center gap-3 px-3 py-2 rounded transition-all group"
+      style={{ background: 'var(--cs-bg-surface)', border: '1px solid var(--cs-border)' }}
+    >
+      {/* Status dot */}
+      <span
+        className="shrink-0 text-[10px] font-bold"
+        style={{ color: cfg.color }}
+        title={cfg.label}
+      >
+        {cfg.dot}
+      </span>
+
+      {/* Name + tagline */}
+      <div className="flex-1 min-w-0 flex items-center gap-2">
+        <span className="cs-vampire-text text-xs truncate" style={{ color: 'var(--cs-crimson)' }}>
+          {piece.name}
+        </span>
+        <span className="text-[10px] font-mono font-bold shrink-0" style={{ color: bloodColor(piece.slopRating) }}>
+          {piece.slopRating}/10
+        </span>
+        <span className="text-[10px] italic truncate hidden sm:inline" style={{ color: 'var(--cs-text-dim)' }}>
+          — {piece.tagline}
+        </span>
+      </div>
+
+      {/* Date */}
+      <span className="shrink-0 text-[10px] hidden sm:block italic" style={{ color: 'var(--cs-text-dim)' }}>
+        {date}
+      </span>
+
+      {/* Status select */}
+      <select
+        className="shrink-0 text-[10px] rounded px-1.5 py-0.5 outline-none cursor-pointer italic"
+        style={{ background: 'var(--cs-bg)', color: cfg.color, border: `1px solid ${cfg.color}40` }}
+        value={status}
+        onChange={(e) => onStatusChange(workspaceId, e.target.value as BuildStatus)}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <option value="launched">Launched</option>
+        <option value="complete">Complete</option>
+        <option value="failed">Failed</option>
+      </select>
+
+      {/* Open */}
+      <button
+        className="shrink-0 text-[10px] font-medium tracking-wider px-2 py-1 rounded transition-all opacity-50 group-hover:opacity-100 italic"
+        style={{ color: 'var(--cs-crimson)', border: '1px solid var(--cs-border)' }}
+        onClick={() => openSession(entry)}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.borderColor = 'var(--cs-crimson)';
+          e.currentTarget.style.background = 'var(--cs-crimson-subtle)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.borderColor = 'var(--cs-border)';
+          e.currentTarget.style.background = 'transparent';
+        }}
+      >
+        Open
+      </button>
+    </div>
+  );
+}
+
+// ── Compact saved piece row ─────────────────────────────────
+
+function SavedRow({
+  entry,
+  onLaunch,
+  onDelete,
+}: {
+  entry: SavedPiece;
+  onLaunch: (piece: ContentPiece) => void;
+  onDelete: (piece: ContentPiece) => void;
+}) {
+  const { piece, savedAt } = entry;
+  const date = new Date(savedAt).toLocaleDateString();
+
+  return (
+    <div
+      className="flex items-center gap-3 px-3 py-2 rounded transition-all group"
+      style={{ background: 'var(--cs-bg-surface)', border: '1px solid var(--cs-border)' }}
+    >
+      <span className="shrink-0 text-[10px]" style={{ color: 'var(--cs-gold)' }}>~</span>
+
+      {/* Name + tagline */}
+      <div className="flex-1 min-w-0 flex items-center gap-2">
+        <span className="cs-vampire-text text-xs truncate" style={{ color: 'var(--cs-crimson)' }}>
+          {piece.name}
+        </span>
+        <span className="text-[10px] font-mono font-bold shrink-0" style={{ color: bloodColor(piece.slopRating) }}>
+          {piece.slopRating}/10
+        </span>
+        <span className="text-[10px] italic truncate hidden sm:inline" style={{ color: 'var(--cs-text-dim)' }}>
+          — {piece.tagline}
+        </span>
+      </div>
+
+      <span className="shrink-0 text-[10px] hidden sm:block italic" style={{ color: 'var(--cs-text-dim)' }}>
+        {date}
+      </span>
+
+      {/* Delete */}
+      <button
+        className="shrink-0 text-[10px] font-medium tracking-wider px-2 py-1 rounded transition-all opacity-50 group-hover:opacity-100 italic"
+        style={{ color: 'var(--cs-text-dim)', border: '1px solid var(--cs-border)' }}
+        onClick={() => onDelete(piece)}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.borderColor = 'var(--cs-crimson)';
+          e.currentTarget.style.color = 'var(--cs-crimson)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.borderColor = 'var(--cs-border)';
+          e.currentTarget.style.color = 'var(--cs-text-dim)';
+        }}
+      >
+        Exhume
+      </button>
+
+      {/* Launch */}
+      <button
+        className="shrink-0 text-[10px] font-medium tracking-wider px-2 py-1 rounded transition-all opacity-50 group-hover:opacity-100"
+        style={{
+          color: 'var(--cs-crimson)',
+          border: '1px solid var(--cs-crimson)',
+          background: 'var(--cs-crimson-subtle)',
+          fontFamily: "'Creepster', fantasy",
+        }}
+        onClick={() => onLaunch(piece)}
+        onMouseEnter={(e) => { e.currentTarget.style.boxShadow = '0 0 8px var(--cs-crimson-glow)'; }}
+        onMouseLeave={(e) => { e.currentTarget.style.boxShadow = 'none'; }}
+      >
+        Build
+      </button>
+    </div>
+  );
+}
+
+// ── Empty state ────────────────────────────────────────────
+
+function EmptyCrypt() {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 relative z-10">
+      <pre
+        className="text-xs leading-tight font-mono select-none text-center mb-4"
+        style={{ color: 'var(--cs-text-dim)', opacity: 0.3 }}
+        aria-hidden="true"
+      >{`   _____
+  /     \\
+ |  R.I.P |
+ | Here   |
+ | lies   |
+ | nothing|
+ |  yet   |
+ |________|
+ |        |`}</pre>
+      <p className="text-sm italic" style={{ color: 'var(--cs-text-dim)' }}>
+        The crypt is empty.
+      </p>
+      <p className="text-xs mt-1 italic" style={{ color: 'var(--cs-text-dim)', opacity: 0.5 }}>
+        Summon and launch some content to fill it with glorious slop.
+      </p>
+    </div>
+  );
+}
+
+// ── Main Component ─────────────────────────────────────────
+
+interface HistoryDashboardProps {
+  history: HistoryEntry[];
+  savedPieces: SavedPiece[];
+  onStatusChange: (workspaceId: string, status: BuildStatus) => void;
+  onLaunchSaved: (piece: ContentPiece) => void;
+  onDeleteSaved: (piece: ContentPiece) => void;
+}
+
+export function HistoryDashboard({
+  history,
+  savedPieces,
+  onStatusChange,
+  onLaunchSaved,
+  onDeleteSaved,
+}: HistoryDashboardProps) {
+  const isEmpty = history.length === 0 && savedPieces.length === 0;
+
+  if (isEmpty) return <EmptyCrypt />;
+
+  const counts = {
+    launched: history.filter((h) => (h.status ?? 'launched') === 'launched').length,
+    complete: history.filter((h) => h.status === 'complete').length,
+    failed: history.filter((h) => h.status === 'failed').length,
+  };
+
+  return (
+    <div className="px-5 py-4 relative z-10 flex flex-col gap-5">
+      {/* Ritual Log */}
+      {history.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="cs-vampire-text text-xs" style={{ color: 'var(--cs-crimson-dim)' }}>
+              Ritual Log ({history.length}/10)
+            </h3>
+            <div className="flex gap-2">
+              {counts.launched > 0 && (
+                <span className="text-[10px] italic" style={{ color: 'var(--cs-crimson)' }}>~ {counts.launched}</span>
+              )}
+              {counts.complete > 0 && (
+                <span className="text-[10px] italic" style={{ color: 'var(--cs-ghost)' }}>+ {counts.complete}</span>
+              )}
+              {counts.failed > 0 && (
+                <span className="text-[10px] italic" style={{ color: 'var(--cs-crimson)' }}>x {counts.failed}</span>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            {[...history].reverse().map((entry) => (
+              <HistoryRow
+                key={`${entry.workspaceId}-${entry.launchedAt}`}
+                entry={entry}
+                onStatusChange={onStatusChange}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Entombed pieces */}
+      {savedPieces.length > 0 && (
+        <div>
+          <h3 className="cs-vampire-text text-xs mb-2" style={{ color: 'var(--cs-gold)' }}>
+            Entombed ({savedPieces.length})
+          </h3>
+          <div className="flex flex-col gap-1.5">
+            {savedPieces.map((entry) => (
+              <SavedRow
+                key={`${entry.piece.name}-${entry.savedAt}`}
+                entry={entry}
+                onLaunch={onLaunchSaved}
+                onDelete={onDeleteSaved}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/pi-count-slopula-extension/ui/LaunchPhase.tsx
+++ b/packages/pi-count-slopula-extension/ui/LaunchPhase.tsx
@@ -1,0 +1,329 @@
+/**
+ * LaunchPhase — creating the workspace and kicking off the agent.
+ *
+ * Shows a dramatic vampire ritual sequence, then a success state
+ * with the option to go back and summon more content.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { ContentPiece, Intensity } from '../shared/types';
+import { launchPiece } from './sero-launcher';
+import type { LaunchStep } from './sero-launcher';
+import { buildLaunchPrompt } from './content-utils';
+
+// ── Phase states ───────────────────────────────────────────
+
+type LaunchState = 'launching' | 'success' | 'error';
+
+interface LaunchPhaseProps {
+  piece: ContentPiece;
+  intensity: Intensity;
+  twist?: string;
+  onLaunched: (workspaceId: string, sessionId: string, sessionPath: string) => void;
+  onBack: () => void;
+}
+
+export function LaunchPhase({ piece, intensity, twist, onLaunched, onBack }: LaunchPhaseProps) {
+  const [state, setState] = useState<LaunchState>('launching');
+  const [step, setStep] = useState<LaunchStep>('creating-workspace');
+  const [error, setError] = useState<string | null>(null);
+  const hasLaunched = useRef(false);
+
+  const onLaunchedRef = useRef(onLaunched);
+  onLaunchedRef.current = onLaunched;
+
+  const doLaunch = useCallback(async () => {
+    setState('launching');
+    setStep('creating-workspace');
+    setError(null);
+
+    try {
+      let prompt = buildLaunchPrompt(piece, intensity);
+      if (twist) {
+        prompt += `\n\n## Dark Twist\nThe user specifically requested this twist: "${twist}"\nWeave it into the creation!`;
+      }
+      const result = await launchPiece(piece.name, prompt, setStep);
+      setState('success');
+      onLaunchedRef.current(result.workspaceId, result.sessionId, result.sessionPath);
+    } catch (err) {
+      setState('error');
+      setError(err instanceof Error ? err.message : 'The ritual failed. The Count is displeased.');
+    }
+  }, [piece, intensity, twist]);
+
+  useEffect(() => {
+    if (hasLaunched.current) return;
+    hasLaunched.current = true;
+    doLaunch();
+  }, [doLaunch]);
+
+  if (state === 'launching') {
+    return <LaunchingView piece={piece} step={step} />;
+  }
+
+  if (state === 'error') {
+    const handleRetry = () => {
+      hasLaunched.current = false;
+      doLaunch();
+    };
+    return <ErrorView error={error} onRetry={handleRetry} onBack={onBack} />;
+  }
+
+  return <SuccessView piece={piece} onBack={onBack} />;
+}
+
+// ── Launch step labels & order ─────────────────────────────
+
+const STEP_ORDER: LaunchStep[] = [
+  'creating-workspace',
+  'opening-workspace',
+  'creating-session',
+  'opening-agent',
+  'sending-prompt',
+  'done',
+];
+
+const STEP_LABELS: Record<LaunchStep, string> = {
+  'creating-workspace': 'Digging the crypt',
+  'opening-workspace': 'Opening the coffin',
+  'creating-session': 'Lighting the candles',
+  'opening-agent': 'Summoning the vampire',
+  'sending-prompt': 'Performing the ritual',
+  'done': 'The slop rises!',
+};
+
+// ── Launching animation ────────────────────────────────────
+
+function LaunchingView({ piece, step }: { piece: ContentPiece; step: LaunchStep }) {
+  const currentIdx = STEP_ORDER.indexOf(step);
+
+  return (
+    <div className="cs-animate-fade-up flex flex-col items-center justify-center flex-1 px-6 py-12 relative z-10">
+      {/* Ritual circle ASCII */}
+      <pre
+        className="text-sm leading-tight font-mono select-none text-center mb-4 cs-animate-heartbeat"
+        style={{
+          color: 'var(--cs-crimson)',
+          filter: 'drop-shadow(0 0 16px var(--cs-crimson-glow-strong))',
+        }}
+        aria-hidden="true"
+      >
+        {`     .  *  .  *  .
+   *    _____    *
+  .   /     \\   .
+ *   | () () |   *
+  .  |  vvv  |  .
+   * |       | *
+  .   \\_____/   .
+   *    |||    *
+     .  *  .  *  .`}
+      </pre>
+
+      <h2
+        className="cs-vampire-text text-xl mb-2 text-center cs-animate-flicker"
+        style={{ color: 'var(--cs-crimson)' }}
+      >
+        THE RITUAL BEGINS
+      </h2>
+
+      <p className="text-sm text-center mb-4 italic" style={{ color: 'var(--cs-text)' }}>
+        Building a page for <strong style={{ color: 'var(--cs-crimson)' }}>{piece.name}</strong>
+      </p>
+
+      {/* Step-by-step progress */}
+      <div className="flex flex-col gap-1.5 mb-6 w-64">
+        {STEP_ORDER.slice(0, -1).map((s, i) => {
+          const isDone = i < currentIdx;
+          const isActive = i === currentIdx;
+          return (
+            <div key={s} className="flex items-center gap-2 text-xs">
+              <span
+                className="shrink-0 size-4 flex items-center justify-center rounded-full text-[10px] font-bold"
+                style={{
+                  background: isDone
+                    ? 'var(--cs-crimson)'
+                    : isActive
+                      ? 'var(--cs-crimson-subtle)'
+                      : 'transparent',
+                  color: isDone
+                    ? 'var(--cs-bg)'
+                    : isActive
+                      ? 'var(--cs-crimson)'
+                      : 'var(--cs-text-dim)',
+                  border: isDone
+                    ? 'none'
+                    : `1px solid ${isActive ? 'var(--cs-crimson)' : 'var(--cs-border)'}`,
+                  boxShadow: isActive ? '0 0 8px var(--cs-crimson-glow)' : 'none',
+                }}
+              >
+                {isDone ? '~' : i + 1}
+              </span>
+              <span
+                className="italic"
+                style={{
+                  color: isDone
+                    ? 'var(--cs-crimson-dim)'
+                    : isActive
+                      ? 'var(--cs-crimson)'
+                      : 'var(--cs-text-dim)',
+                  opacity: isDone ? 0.6 : 1,
+                  fontFamily: "'Crimson Text', serif",
+                }}
+              >
+                {STEP_LABELS[s]}
+                {isActive && (
+                  <span className="cs-animate-flicker ml-1">...</span>
+                )}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Success view ───────────────────────────────────────────
+
+function SuccessView({ piece, onBack }: { piece: ContentPiece; onBack: () => void }) {
+  return (
+    <div className="cs-animate-fade-up flex flex-col items-center justify-center flex-1 px-6 py-12 relative z-10">
+      {/* Victory vampire */}
+      <pre
+        className="text-sm leading-tight font-mono select-none text-center mb-6"
+        style={{
+          color: 'var(--cs-crimson)',
+          filter: 'drop-shadow(0 0 20px var(--cs-crimson-glow-strong))',
+        }}
+        aria-hidden="true"
+      >
+        {`     /\\     /\\
+    {  \\   /  }
+     \\  \\_/  /
+      \\  ^  /
+    .-'(o o)'-.
+   /    ~~~    \\
+  |   BLEH!!   |
+   \\   =====   /
+    '-._____.-'`}
+      </pre>
+
+      <h2
+        className="cs-vampire-text text-2xl mb-2 text-center"
+        style={{ color: 'var(--cs-crimson)' }}
+      >
+        THE SLOP RISES!
+      </h2>
+
+      <p className="text-sm text-center mb-2 italic" style={{ color: 'var(--cs-text)' }}>
+        <strong style={{ color: 'var(--cs-crimson)' }}>{piece.name}</strong> has been unleashed upon the world!
+      </p>
+
+      <p className="text-xs text-center mb-8 max-w-sm italic" style={{ color: 'var(--cs-text-dim)' }}>
+        A new workspace has been created and the Sero Agent is now building your
+        glorious cliche-ridden page. Check the sidebar to watch the dark magic unfold.
+      </p>
+
+      {/* Stats */}
+      <div
+        className="rounded px-6 py-4 mb-8 text-center"
+        style={{
+          background: 'var(--cs-crimson-subtle)',
+          border: '1px solid var(--cs-border)',
+        }}
+      >
+        <div className="text-xs tracking-wider italic mb-2" style={{ color: 'var(--cs-crimson-dim)' }}>
+          Ritual Statistics
+        </div>
+        <div className="flex gap-8 justify-center">
+          <div>
+            <div className="cs-vampire-text text-lg" style={{ color: 'var(--cs-crimson)' }}>
+              {piece.slopRating}/10
+            </div>
+            <div className="text-xs italic" style={{ color: 'var(--cs-text-dim)' }}>Slop Rating</div>
+          </div>
+          <div>
+            <div className="cs-vampire-text text-lg" style={{ color: 'var(--cs-ghost)' }}>
+              {piece.genre}
+            </div>
+            <div className="text-xs italic" style={{ color: 'var(--cs-text-dim)' }}>Genre</div>
+          </div>
+          <div>
+            <div className="cs-vampire-text text-lg" style={{ color: 'var(--cs-gold)' }}>
+              100%
+            </div>
+            <div className="text-xs italic" style={{ color: 'var(--cs-text-dim)' }}>Cliche</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Back button */}
+      <button className="cs-cta" onClick={onBack}>
+        <span>SUMMON MORE SLOP</span>
+      </button>
+    </div>
+  );
+}
+
+// ── Error view ─────────────────────────────────────────────
+
+function ErrorView({
+  error,
+  onRetry,
+  onBack,
+}: {
+  error: string | null;
+  onRetry: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="cs-animate-fade-up flex flex-col items-center justify-center flex-1 px-6 py-12 relative z-10">
+      <pre
+        className="text-sm leading-tight font-mono select-none text-center mb-6 cs-animate-shake"
+        style={{ color: 'var(--cs-crimson)' }}
+        aria-hidden="true"
+      >
+        {`     /\\     /\\
+    {  \\   /  }
+     \\  \\_/  /
+      \\     /
+    .-'(x x)'-.
+   /    ~~~    \\
+  |   *cough*  |
+   \\   =====   /
+    '-._____.-'`}
+      </pre>
+
+      <h2 className="cs-vampire-text text-xl mb-2" style={{ color: 'var(--cs-crimson)' }}>
+        THE RITUAL FAILED!
+      </h2>
+
+      <p className="text-sm text-center mb-2 italic" style={{ color: 'var(--cs-text)' }}>
+        Count Slopula choked on a garlic breadstick
+      </p>
+
+      {error && (
+        <p className="text-xs text-center mb-6 max-w-sm italic" style={{ color: 'var(--cs-text-dim)' }}>
+          {error}
+        </p>
+      )}
+
+      <div className="flex gap-4">
+        <button className="cs-cta" onClick={onRetry}>
+          <span>Try the Ritual Again</span>
+        </button>
+        <button
+          className="text-sm px-4 py-2 rounded italic"
+          style={{
+            color: 'var(--cs-text-dim)',
+            border: '1px solid var(--cs-border)',
+            fontFamily: "'Crimson Text', serif",
+          }}
+          onClick={onBack}
+        >
+          Retreat to the Crypt
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/pi-count-slopula-extension/ui/PickingPhase.tsx
+++ b/packages/pi-count-slopula-extension/ui/PickingPhase.tsx
@@ -1,0 +1,266 @@
+/**
+ * PickingPhase — displays 3 generated content pieces as gothic scroll cards.
+ *
+ * Each card shows the content name, tagline, body preview, genre,
+ * and a "blood meter" rating. User can build, remix, or save each piece.
+ */
+
+import type { ContentPiece } from '../shared/types';
+
+// ── Blood meter gradient color ──────────────────────────────
+
+function bloodColor(rating: number): string {
+  if (rating <= 3) return 'var(--cs-ghost)';
+  if (rating <= 6) return 'var(--cs-gold)';
+  return 'var(--cs-crimson)';
+}
+
+function bloodLabel(rating: number): string {
+  if (rating <= 2) return 'Mild Nibble';
+  if (rating <= 4) return 'Getting Bitey';
+  if (rating <= 6) return 'Deep Bite';
+  if (rating <= 8) return 'Full Drain';
+  return 'TRANSCENDENT SLOP';
+}
+
+// ── Content Card ──────────────────────────────────────────────
+
+function ContentCard({
+  piece,
+  index,
+  onPick,
+  onRemix,
+  onSave,
+  isSaved,
+}: {
+  piece: ContentPiece;
+  index: number;
+  onPick: (piece: ContentPiece) => void;
+  onRemix: (piece: ContentPiece) => void;
+  onSave: (piece: ContentPiece) => void;
+  isSaved: boolean;
+}) {
+  const animClass = `cs-card-enter-${index + 1}`;
+  const color = bloodColor(piece.slopRating);
+
+  return (
+    <div
+      className={`cs-content-card ${animClass}`}
+      role="button"
+      tabIndex={0}
+      onClick={() => onPick(piece)}
+      onKeyDown={(e) => e.key === 'Enter' && onPick(piece)}
+    >
+      {/* Card number badge */}
+      <div
+        className="absolute top-3 right-3 w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold"
+        style={{
+          background: 'var(--cs-crimson-subtle)',
+          color: 'var(--cs-crimson)',
+          border: '1px solid var(--cs-border)',
+        }}
+      >
+        {index + 1}
+      </div>
+
+      {/* Genre tag */}
+      <div
+        className="inline-block text-[10px] italic px-2 py-0.5 rounded mb-2"
+        style={{
+          background: 'var(--cs-purple-glow)',
+          color: 'var(--cs-ghost)',
+          border: '1px solid rgba(107, 33, 168, 0.3)',
+        }}
+      >
+        {piece.genre}
+      </div>
+
+      {/* Name & tagline */}
+      <h3
+        className="cs-vampire-text text-lg mb-1 pr-10"
+        style={{ color: 'var(--cs-crimson)' }}
+      >
+        {piece.name}
+      </h3>
+      <p className="text-sm italic mb-3" style={{ color: 'var(--cs-text-dim)' }}>
+        &ldquo;{piece.tagline}&rdquo;
+      </p>
+
+      {/* Body preview */}
+      <p className="text-sm leading-relaxed mb-4 line-clamp-4" style={{ color: 'var(--cs-text)' }}>
+        {piece.body}
+      </p>
+
+      {/* Blood meter */}
+      <div className="mb-4">
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-medium italic" style={{ color }}>
+            {bloodLabel(piece.slopRating)}
+          </span>
+          <span className="text-xs font-mono" style={{ color }}>
+            {piece.slopRating}/10
+          </span>
+        </div>
+        <div className="cs-blood-meter">
+          <div
+            className="cs-blood-fill"
+            style={{
+              width: `${piece.slopRating * 10}%`,
+              background: `linear-gradient(90deg, var(--cs-purple), ${color})`,
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div
+        className="flex items-center justify-between pt-3"
+        style={{ borderTop: '1px solid var(--cs-border)' }}
+      >
+        {/* Save for later */}
+        <button
+          className="text-xs font-medium tracking-wider px-3 py-1.5 rounded transition-all"
+          style={{
+            color: isSaved ? 'var(--cs-gold)' : 'var(--cs-text-dim)',
+            border: `1px solid ${isSaved ? 'var(--cs-gold)' : 'var(--cs-border)'}`,
+            background: isSaved ? 'var(--cs-gold-glow)' : 'transparent',
+            fontFamily: "'Crimson Text', serif",
+            fontStyle: 'italic',
+          }}
+          onClick={(e) => { e.stopPropagation(); onSave(piece); }}
+          onMouseEnter={(e) => {
+            if (!isSaved) {
+              e.currentTarget.style.borderColor = 'var(--cs-gold)';
+              e.currentTarget.style.color = 'var(--cs-gold)';
+            }
+          }}
+          onMouseLeave={(e) => {
+            if (!isSaved) {
+              e.currentTarget.style.borderColor = 'var(--cs-border)';
+              e.currentTarget.style.color = 'var(--cs-text-dim)';
+            }
+          }}
+        >
+          {isSaved ? '~ Entombed' : '~ Entomb'}
+        </button>
+
+        <div className="flex gap-2">
+          {/* Remix */}
+          <button
+            className="text-xs font-medium tracking-wider px-3 py-1.5 rounded transition-all italic"
+            style={{
+              color: 'var(--cs-ghost)',
+              border: '1px solid var(--cs-ghost)',
+              background: 'rgba(201, 177, 255, 0.06)',
+              fontFamily: "'Crimson Text', serif",
+            }}
+            onClick={(e) => { e.stopPropagation(); onRemix(piece); }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.boxShadow = '0 0 12px var(--cs-purple-glow)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.boxShadow = 'none';
+            }}
+          >
+            Remix
+          </button>
+
+          {/* Build */}
+          <button
+            className="text-xs font-medium tracking-wider px-3 py-1.5 rounded transition-all"
+            style={{
+              color: 'var(--cs-crimson)',
+              border: '1px solid var(--cs-crimson)',
+              background: 'var(--cs-crimson-subtle)',
+              fontFamily: "'Creepster', fantasy",
+              letterSpacing: '0.05em',
+            }}
+            onClick={(e) => { e.stopPropagation(); onPick(piece); }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.boxShadow = '0 0 12px var(--cs-crimson-glow)';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.boxShadow = 'none';
+            }}
+          >
+            Build
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main Component ─────────────────────────────────────────
+
+interface PickingPhaseProps {
+  pieces: ContentPiece[];
+  onPick: (piece: ContentPiece) => void;
+  onRemix: (piece: ContentPiece) => void;
+  onSave: (piece: ContentPiece) => void;
+  savedPieceNames: Set<string>;
+  onRegenerate: () => void;
+}
+
+export function PickingPhase({
+  pieces,
+  onPick,
+  onRemix,
+  onSave,
+  savedPieceNames,
+  onRegenerate,
+}: PickingPhaseProps) {
+  return (
+    <div className="flex flex-col items-center px-6 py-8 relative z-10">
+      {/* Header */}
+      <div className="text-center mb-8">
+        <h2
+          className="cs-vampire-text text-2xl mb-2"
+          style={{ color: 'var(--cs-crimson)' }}
+        >
+          CHOOSE YOUR SLOP
+        </h2>
+        <p className="text-sm italic" style={{ color: 'var(--cs-text-dim)' }}>
+          The Count has summoned 3 pieces from the crypt. Build one, remix it, or entomb it for later.
+        </p>
+      </div>
+
+      {/* Content cards */}
+      <div className="w-full max-w-6xl grid grid-cols-1 md:grid-cols-3 gap-5 mb-8">
+        {pieces.map((piece, i) => (
+          <ContentCard
+            key={piece.id}
+            piece={piece}
+            index={i}
+            onPick={onPick}
+            onRemix={onRemix}
+            onSave={onSave}
+            isSaved={savedPieceNames.has(piece.name)}
+          />
+        ))}
+      </div>
+
+      {/* Regenerate */}
+      <button
+        className="text-xs font-medium tracking-wider px-4 py-2 rounded transition-all italic"
+        style={{
+          color: 'var(--cs-text-dim)',
+          border: '1px solid var(--cs-border)',
+          background: 'transparent',
+          fontFamily: "'Crimson Text', serif",
+        }}
+        onClick={onRegenerate}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.borderColor = 'var(--cs-border-bright)';
+          e.currentTarget.style.color = 'var(--cs-crimson)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.borderColor = 'var(--cs-border)';
+          e.currentTarget.style.color = 'var(--cs-text-dim)';
+        }}
+      >
+        Not cliched enough? Summon again...
+      </button>
+    </div>
+  );
+}

--- a/packages/pi-count-slopula-extension/ui/RemixPhase.tsx
+++ b/packages/pi-count-slopula-extension/ui/RemixPhase.tsx
@@ -1,0 +1,232 @@
+/**
+ * RemixPhase — tweak a content piece before launching.
+ *
+ * User can edit name, tagline, body, adjust slop rating,
+ * and add a custom twist. Changes are applied directly
+ * (no AI re-generation) so it's instant.
+ */
+
+import { useState, useCallback } from 'react';
+import type { ContentPiece } from '../shared/types';
+import { GENRE_OPTIONS } from '../shared/types';
+import { clampRating } from './content-utils';
+
+// ── Slop rating labels ──────────────────────────────────────
+
+function bloodLabel(rating: number): string {
+  if (rating <= 2) return 'Mild Nibble';
+  if (rating <= 4) return 'Getting Bitey';
+  if (rating <= 6) return 'Deep Bite';
+  if (rating <= 8) return 'Full Drain';
+  return 'TRANSCENDENT SLOP';
+}
+
+function bloodColor(rating: number): string {
+  if (rating <= 3) return 'var(--cs-ghost)';
+  if (rating <= 6) return 'var(--cs-gold)';
+  return 'var(--cs-crimson)';
+}
+
+// ── Editable field ─────────────────────────────────────────
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+  multiline,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  multiline?: boolean;
+}) {
+  const shared = {
+    value,
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      onChange(e.target.value),
+    placeholder,
+    className: 'w-full rounded px-3 py-2 text-sm outline-none transition-all',
+    style: {
+      background: 'var(--cs-bg-surface)',
+      border: '1px solid var(--cs-border)',
+      color: 'var(--cs-text)',
+      fontFamily: "'Crimson Text', serif",
+    } as React.CSSProperties,
+    onFocus: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      e.currentTarget.style.borderColor = 'var(--cs-crimson)';
+      e.currentTarget.style.boxShadow = '0 0 8px var(--cs-crimson-glow)';
+    },
+    onBlur: (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      e.currentTarget.style.borderColor = 'var(--cs-border)';
+      e.currentTarget.style.boxShadow = 'none';
+    },
+  };
+
+  return (
+    <div>
+      <label
+        className="block text-xs font-medium mb-1.5 tracking-wider italic"
+        style={{ color: 'var(--cs-crimson-dim)' }}
+      >
+        {label}
+      </label>
+      {multiline ? (
+        <textarea {...shared} rows={4} />
+      ) : (
+        <input {...shared} type="text" />
+      )}
+    </div>
+  );
+}
+
+// ── Props ──────────────────────────────────────────────────
+
+interface RemixPhaseProps {
+  piece: ContentPiece;
+  onLaunch: (remixed: ContentPiece, twist: string) => void;
+  onBack: () => void;
+}
+
+// ── Main Component ─────────────────────────────────────────
+
+export function RemixPhase({ piece, onLaunch, onBack }: RemixPhaseProps) {
+  const [name, setName] = useState(piece.name);
+  const [tagline, setTagline] = useState(piece.tagline);
+  const [body, setBody] = useState(piece.body);
+  const [slopRating, setSlopRating] = useState(piece.slopRating);
+  const [genre, setGenre] = useState(piece.genre);
+  const [twist, setTwist] = useState('');
+
+  const handleLaunch = useCallback(() => {
+    const remixed: ContentPiece = {
+      ...piece,
+      name: name.trim() || piece.name,
+      tagline: tagline.trim() || piece.tagline,
+      body: body.trim() || piece.body,
+      genre: genre || piece.genre,
+      slopRating: clampRating(slopRating),
+    };
+    onLaunch(remixed, twist.trim());
+  }, [piece, name, tagline, body, genre, slopRating, twist, onLaunch]);
+
+  const color = bloodColor(slopRating);
+
+  return (
+    <div className="cs-animate-fade-up flex flex-col items-center px-6 py-8 relative z-10">
+      {/* Header */}
+      <div className="text-center mb-8">
+        <h2
+          className="cs-vampire-text text-2xl mb-2"
+          style={{ color: 'var(--cs-ghost)' }}
+        >
+          Remix the Slop
+        </h2>
+        <p className="text-sm italic" style={{ color: 'var(--cs-text-dim)' }}>
+          Tweak the content before the Count builds it. Change whatever you dare.
+        </p>
+      </div>
+
+      {/* Edit form */}
+      <div className="w-full max-w-lg flex flex-col gap-4 mb-8">
+        <Field label="Title" value={name} onChange={setName} placeholder="Content title" />
+        <Field label="Tagline" value={tagline} onChange={setTagline} placeholder="Punny subtitle" />
+        <Field
+          label="Body"
+          value={body}
+          onChange={setBody}
+          placeholder="The actual content..."
+          multiline
+        />
+
+        {/* Genre picker */}
+        <div>
+          <label
+            className="block text-xs font-medium mb-1.5 tracking-wider italic"
+            style={{ color: 'var(--cs-crimson-dim)' }}
+          >
+            Genre
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {GENRE_OPTIONS.map((g) => (
+              <button
+                key={g}
+                className={`cs-genre-chip ${genre === g ? 'selected' : ''}`}
+                onClick={() => setGenre(g)}
+                style={{ fontSize: '12px', padding: '4px 10px' }}
+              >
+                {g}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Slop rating slider */}
+        <div>
+          <label
+            className="block text-xs font-medium mb-1.5 tracking-wider italic"
+            style={{ color: 'var(--cs-crimson-dim)' }}
+          >
+            Slop Rating
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={1}
+              max={10}
+              value={slopRating}
+              onChange={(e) => setSlopRating(Number(e.target.value))}
+              className="cs-slop-slider flex-1"
+              style={{ accentColor: color }}
+            />
+            <div className="flex flex-col items-end">
+              <span className="text-lg font-mono font-bold" style={{ color }}>
+                {slopRating}/10
+              </span>
+              <span className="text-[10px] italic" style={{ color }}>
+                {bloodLabel(slopRating)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Custom twist */}
+        <Field
+          label="Add a Dark Twist (optional)"
+          value={twist}
+          onChange={setTwist}
+          placeholder='e.g. "written by a pirate" or "but it rhymes"'
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-4">
+        <button
+          className="text-sm px-5 py-2.5 rounded transition-all italic"
+          style={{
+            color: 'var(--cs-text-dim)',
+            border: '1px solid var(--cs-border)',
+            background: 'transparent',
+            fontFamily: "'Crimson Text', serif",
+          }}
+          onClick={onBack}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.borderColor = 'var(--cs-border-bright)';
+            e.currentTarget.style.color = 'var(--cs-text)';
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.borderColor = 'var(--cs-border)';
+            e.currentTarget.style.color = 'var(--cs-text-dim)';
+          }}
+        >
+          Back to the Crypt
+        </button>
+
+        <button className="cs-cta" onClick={handleLaunch}>
+          <span>UNLEASH REMIXED SLOP</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/pi-count-slopula-extension/ui/content-utils.ts
+++ b/packages/pi-count-slopula-extension/ui/content-utils.ts
@@ -1,0 +1,187 @@
+/**
+ * Content generation utilities for Count Slopula.
+ *
+ * Prompt building, response parsing, and all the dark arts
+ * of summoning the most cliched content known to humankind.
+ */
+
+import type { ContentPiece, Intensity, CountSlopulaState } from '../shared/types';
+
+// ── Score helpers ──────────────────────────────────────────
+
+export function clampRating(n: number): number {
+  return Math.max(1, Math.min(10, Math.round(n)));
+}
+
+// ── Parse AI response into content pieces ──────────────────
+
+export function parsePiecesResponse(response: string): ContentPiece[] {
+  try {
+    const jsonMatch = response.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      const parsed = JSON.parse(jsonMatch[0]);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        return parsed.map((item: Record<string, unknown>, i: number) => ({
+          id: i + 1,
+          name: String(item.name || `Content ${i + 1}`),
+          tagline: String(item.tagline || ''),
+          body: String(item.body || ''),
+          genre: String(item.genre || 'Unknown'),
+          slopRating: clampRating(Number(item.slopRating) || 5),
+        }));
+      }
+    }
+  } catch {
+    // Fall through to manual parsing
+  }
+
+  return parseFallback(response);
+}
+
+function parseFallback(text: string): ContentPiece[] {
+  const pieces: ContentPiece[] = [];
+  const blocks = text.split(/\n(?=\d+[\.\)]\s)/);
+
+  for (const block of blocks) {
+    const nameMatch = block.match(
+      /\*\*(.+?)\*\*|"(.+?)"|(?:Name:\s*)(.+?)(?:\n|$)/i,
+    );
+    const name = nameMatch?.[1] || nameMatch?.[2] || nameMatch?.[3];
+    if (!name) continue;
+
+    const taglineMatch = block.match(
+      /(?:Tagline|Subtitle):\s*(.+?)(?:\n|$)/i,
+    );
+    const bodyMatch = block.match(
+      /(?:Body|Content|Text):\s*([\s\S]+?)(?:\n\n|\n(?=[A-Z]))/i,
+    );
+    const slopMatch = block.match(/(?:Slop|Rating|Score):\s*(\d+)/i);
+    const genreMatch = block.match(/(?:Genre|Type|Category):\s*(.+?)(?:\n|$)/i);
+
+    pieces.push({
+      id: pieces.length + 1,
+      name: name.trim(),
+      tagline: taglineMatch?.[1]?.trim() || 'Freshly drained from the crypt',
+      body: bodyMatch?.[1]?.trim() || block.slice(0, 400).trim(),
+      genre: genreMatch?.[1]?.trim() || 'Unknown',
+      slopRating: clampRating(Number(slopMatch?.[1]) || 5),
+    });
+  }
+
+  return pieces.slice(0, 3);
+}
+
+// ── Pad pieces to exactly 3 ────────────────────────────────
+
+export function padPieces(pieces: ContentPiece[]): ContentPiece[] {
+  const final = pieces.slice(0, 3);
+  while (final.length < 3) {
+    final.push({
+      id: final.length + 1,
+      name: `Mystery From The Crypt ${final.length + 1}`,
+      tagline: 'Even Count Slopula doesn\'t know what this is',
+      body: 'This content was found in a dusty coffin in the deepest reaches of the crypt. It defies categorization. It defies taste. It might defy the laws of physics. Only the bravest dare to build it into a webpage.',
+      genre: 'Eldritch Mystery',
+      slopRating: 7,
+    });
+  }
+  return final;
+}
+
+// ── AI prompt builder ──────────────────────────────────────
+
+const INTENSITY_DESC: Record<Intensity, string> = {
+  nibble: 'Mild and approachable — the content should be recognizably cliched but still somewhat tasteful. Like a vampire that says "please" before biting.',
+  bite: 'Moderately unhinged — lean into the tropes hard. Every cliche should be cranked to 7/10. The content should make people groan and laugh simultaneously.',
+  drain: 'MAXIMUM SLOP. Drain every last drop of originality. Stack cliches on top of cliches. Mix metaphors like a blender full of buzzwords. Make it so over-the-top it loops back around to being art.',
+};
+
+export function buildContentPrompt(
+  intensity: Intensity,
+  genres: string[],
+  history: CountSlopulaState['history'],
+): string {
+  const genreClause =
+    genres.length > 0
+      ? `\n\nThe user wants content in these genres: ${genres.join(', ')}. Generate one piece for each selected genre (up to 3). If fewer than 3 genres selected, fill the remaining slots with your most inspired cliche-ridden genres.`
+      : '\n\nPick 3 different genres from this list and generate one piece for each: Motivational Drivel, Clickbait From The Crypt, LinkedIn Nightmares, Cursed Recipes, Conspiracy Corner, Horoscope Horror, Startup Seance, Dating Doom, Movie Mashup Mausoleum, Pirate Shanty Generator, Corporate Buzzword Salad, Passive-Aggressive Notes.';
+
+  const historyClause =
+    history.length > 0
+      ? `\n\nIMPORTANT — The user has already generated these pieces previously. Do NOT generate content that is the same or very similar:\n${history.map((h) => `- "${h.piece.name}": ${h.piece.tagline}`).join('\n')}\n\nCome up with completely different, fresh content.`
+      : '';
+
+  return `You are Count Slopula, a centuries-old vampire who feeds not on blood, but on originality. You drain all creativity from content and replace it with the most glorious, shameless, turbo-charged CLICHES, TROPES, MEMES, and STEREOTYPES ever conceived.
+
+Your mission: Generate exactly 3 pieces of hilariously cliched content. Use the most overused tropes, the most tired memes, the most beaten-to-death stereotypes. Lean into every single cliche with zero shame. Mix references from different decades and genres. Stack puns on top of puns. Reference memes both ancient and modern. Include the most overused stock photo descriptions. Channel the energy of a 2010 motivational poster crossed with a 2024 LinkedIn influencer crossed with a medieval vampire.
+
+Intensity level: ${intensity.toUpperCase()}
+${INTENSITY_DESC[intensity]}${genreClause}${historyClause}
+
+GENRE GUIDELINES (use these for inspiration, pick the relevant ones):
+- Motivational Drivel: "Live Laugh Love" energy meets fortune cookie meets gym bro motivation meets corporate wellness poster. Reference sunsets, mountains, eagles, and "the grind."
+- Clickbait From The Crypt: "You Won't BELIEVE What Happened Next" energy. Numbered lists, shocking revelations, doctors who HATE this one weird trick.
+- LinkedIn Nightmares: "I was fired and it was the BEST thing that happened to me" energy. Humble brags, "agree?", inspirational CEO stories, "I don't usually post about my personal life BUT..."
+- Cursed Recipes: Fusion food gone wrong. "Deconstructed" everything. Putting sriracha on things that should never have sriracha. "My grandmother's recipe (with a twist)."
+- Conspiracy Corner: Flat earth meets birds aren't real meets the mattress store conspiracy. Completely unhinged but delivered with absolute sincerity.
+- Horoscope Horror: Absurdly specific predictions. "Mercury is in retrograde and that's why your toast burned." Include crystals, energy, vibes, and alignment.
+- Startup Seance: "It's like Uber but for..." energy. Blockchain everything. AI everything. Disrupting industries that don't need disrupting.
+- Dating Doom: "I'm fluent in sarcasm" meets "looking for my partner in crime" meets "not here for hookups" meets "I probably swiped right for your dog."
+- Movie Mashup Mausoleum: Combine 2-3 movie genres that should never be combined. Include all the tropes from each.
+- Pirate Shanty Generator: Sea shanties about modern problems. "Yo ho ho and a bottle of oat milk." Corporate pirate life.
+- Corporate Buzzword Salad: "Synergize cross-functional deliverables to leverage our core competencies and move the needle on stakeholder alignment."
+- Passive-Aggressive Notes: Office kitchen notes, roommate notes, neighbor notes. "To WHOEVER keeps stealing my clearly labeled yogurt..."
+
+Respond with a JSON array of exactly 3 objects. Each object must have these fields:
+- "name": string (catchy title for this content piece, 2-5 words)
+- "tagline": string (punny one-liner subtitle, max 12 words)
+- "body": string (the actual content — 3-6 sentences of PURE CONCENTRATED SLOP. Make it detailed, funny, and packed with cliches)
+- "genre": string (which genre this falls under)
+- "slopRating": number (1-10, how absurdly cliched this is — higher = more concentrated slop)
+
+Make each piece distinct. One should be mildly cliched (slopRating 2-4), one should be solidly tropey (slopRating 5-7), and one should be WEAPONS-GRADE SLOP (slopRating 8-10).
+
+Respond ONLY with the JSON array, no other text.`;
+}
+
+// ── Build prompt for launching as a web page ────────────────
+
+const BUILD_INTENSITY_DESC: Record<Intensity, string> = {
+  nibble: 'Keep it simple and clean — a single polished page that presents the content with mild vampire theming.',
+  bite: 'Build a proper page with personality — gothic styling, dramatic animations, and some interactive elements. Make it fun to share.',
+  drain: 'GO ABSOLUTELY WILD. Maximum theatrics. Animations everywhere. Sound effects if possible. Easter eggs. The page should be an experience, not just content. Think "what if a vampire designed a GeoCities page in 2024."',
+};
+
+export function buildLaunchPrompt(
+  piece: ContentPiece,
+  intensity: Intensity,
+): string {
+  return `# Count Slopula Build Request
+
+You are building a web page for content generated by Count Slopula, the vampire-themed cliche content generator. Build this with dramatic flair!
+
+## Content
+**Title:** ${piece.name}
+**Tagline:** ${piece.tagline}
+**Genre:** ${piece.genre}
+**Content:** ${piece.body}
+**Slop Rating:** ${piece.slopRating}/10
+
+## Intensity Level: ${intensity.toUpperCase()}
+${BUILD_INTENSITY_DESC[intensity]}
+
+## Instructions
+1. Create a single-page web app that showcases this content beautifully
+2. Use a gothic/vampire theme — dark backgrounds, deep reds and purples, dramatic typography
+3. Use Google Fonts "Creepster" for headings and "Crimson Text" for body text
+4. Add atmospheric effects — fog, blood drips, bat silhouettes, candlelight flickers
+5. Make the page shareable — it should look amazing as a screenshot
+6. Include the "Slop Rating" as a visual blood meter element
+7. Add some vampire-themed commentary or framing around the content
+8. Make it responsive and visually stunning
+9. Include a footer crediting "Count Slopula" as the creator
+
+Don't use a subfolder for the app - put all the code in the root of the workspace.
+
+Embrace the darkness! This is Count Slopula's masterwork — make it gloriously gothic and delightfully cliched.`;
+}

--- a/packages/pi-count-slopula-extension/ui/index.html
+++ b/packages/pi-count-slopula-extension/ui/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Count Slopula (remote)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Creepster&family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400&display=swap"
+  />
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./main.tsx"></script>
+</body>
+</html>

--- a/packages/pi-count-slopula-extension/ui/main.tsx
+++ b/packages/pi-count-slopula-extension/ui/main.tsx
@@ -1,0 +1,20 @@
+/**
+ * Standalone entry point for Count Slopula dev mode.
+ *
+ * When running `pnpm dev`, Vite serves this as the root entry so
+ * the app can be previewed in a browser at localhost:5186.
+ * In production the host loads Count Slopula via Module Federation.
+ */
+
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { CountSlopula } from './CountSlopula';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('Missing #root element');
+
+createRoot(root).render(
+  <StrictMode>
+    <CountSlopula />
+  </StrictMode>,
+);

--- a/packages/pi-count-slopula-extension/ui/sero-launcher.ts
+++ b/packages/pi-count-slopula-extension/ui/sero-launcher.ts
@@ -1,0 +1,100 @@
+/**
+ * Typed access to Sero IPC APIs for creating workspaces,
+ * sessions, and launching the agent.
+ *
+ * These APIs live on `window.sero` (exposed by the Electron preload)
+ * but aren't part of @sero/app-runtime — they're shell-level APIs.
+ */
+
+interface WorkspaceInfo {
+  id: string;
+  name: string;
+  path: string;
+}
+
+interface SessionInfo {
+  path: string;
+  id: string;
+  cwd: string;
+  workspaceId: string;
+  created: string;
+  modified: string;
+  messageCount: number;
+  firstMessage: string;
+}
+
+interface SeroShellApi {
+  workspace: {
+    create: (name: string, parentPath?: string) => Promise<WorkspaceInfo>;
+    open: (id: string) => Promise<void>;
+  };
+  sessions: {
+    create: (workspaceId?: string) => Promise<SessionInfo>;
+  };
+  agent: {
+    open: (sessionId: string, sessionPath: string, workspaceId: string) => Promise<unknown>;
+    prompt: (
+      sessionId: string,
+      text: string,
+      attachments?: unknown[],
+      clientMessageId?: string,
+    ) => Promise<void>;
+  };
+}
+
+function getShellApi(): SeroShellApi {
+  const sero = (window as unknown as { sero?: SeroShellApi }).sero;
+  if (!sero) {
+    throw new Error('[count-slopula] window.sero not available');
+  }
+  return sero;
+}
+
+// ── Launch steps ───────────────────────────────────────────
+
+export type LaunchStep =
+  | 'creating-workspace'
+  | 'opening-workspace'
+  | 'creating-session'
+  | 'opening-agent'
+  | 'sending-prompt'
+  | 'done';
+
+export type OnProgress = (step: LaunchStep) => void;
+
+function notifyWorkspaceChanged() {
+  window.dispatchEvent(new CustomEvent('sero:workspace-changed'));
+}
+
+/**
+ * Create a new workspace, open a session, and kick off the agent
+ * with a prompt to build the chosen content piece into a web page.
+ */
+export async function launchPiece(
+  pieceName: string,
+  buildPrompt: string,
+  onProgress?: OnProgress,
+): Promise<{ workspaceId: string; sessionId: string; sessionPath: string }> {
+  const api = getShellApi();
+
+  onProgress?.('creating-workspace');
+  const wsName = `slopula-${pieceName.toLowerCase().replace(/[^a-z0-9]+/g, '-').slice(0, 30)}`;
+  const workspace = await api.workspace.create(wsName);
+
+  onProgress?.('opening-workspace');
+  await api.workspace.open(workspace.id);
+  notifyWorkspaceChanged();
+
+  onProgress?.('creating-session');
+  const session = await api.sessions.create(workspace.id);
+
+  onProgress?.('opening-agent');
+  await api.agent.open(session.id, session.path, workspace.id);
+  notifyWorkspaceChanged();
+
+  onProgress?.('sending-prompt');
+  await api.agent.prompt(session.id, buildPrompt);
+
+  onProgress?.('done');
+  return { workspaceId: workspace.id, sessionId: session.id, sessionPath: session.path };
+}

--- a/packages/pi-count-slopula-extension/ui/slopula-styles.ts
+++ b/packages/pi-count-slopula-extension/ui/slopula-styles.ts
@@ -1,0 +1,498 @@
+/**
+ * Count Slopula custom CSS — gothic vampire crypt aesthetic.
+ *
+ * Deep crimsons, spectral purples, fog effects, dripping text,
+ * coffin-shaped cards, and bat-wing animations. A horror movie
+ * poster made of pure CSS.
+ */
+
+export const SLOPULA_STYLES = `
+  .cs-root {
+    --cs-bg: var(--bg-base, #0d0a1a);
+    --cs-bg-surface: var(--bg-surface, #13101f);
+    --cs-crimson: #dc143c;
+    --cs-crimson-dim: #8b0a1e;
+    --cs-crimson-glow: rgba(220, 20, 60, 0.2);
+    --cs-crimson-glow-strong: rgba(220, 20, 60, 0.4);
+    --cs-crimson-subtle: rgba(220, 20, 60, 0.08);
+    --cs-purple: #6b21a8;
+    --cs-purple-glow: rgba(107, 33, 168, 0.25);
+    --cs-ghost: #c9b1ff;
+    --cs-gold: #d4a833;
+    --cs-gold-glow: rgba(212, 168, 51, 0.2);
+    --cs-text: #f0e6ff;
+    --cs-text-dim: #8b7da8;
+    --cs-border: rgba(220, 20, 60, 0.15);
+    --cs-border-bright: rgba(220, 20, 60, 0.4);
+    --cs-fog: rgba(201, 177, 255, 0.04);
+
+    font-family: 'Crimson Text', Georgia, 'Times New Roman', serif;
+    color: var(--cs-text);
+    background: var(--cs-bg);
+  }
+
+  /* ── Tab bar ── */
+
+  .cs-tab-bar {
+    display: flex;
+    gap: 0;
+    padding: 0 20px;
+    border-bottom: 1px solid var(--cs-border);
+    background: var(--cs-bg);
+    flex-shrink: 0;
+  }
+
+  .cs-tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 20px;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+    color: var(--cs-text-dim);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s;
+    font-family: 'Crimson Text', serif;
+  }
+
+  .cs-tab:hover {
+    color: var(--cs-text);
+  }
+
+  .cs-tab.active {
+    color: var(--cs-crimson);
+    border-bottom-color: var(--cs-crimson);
+  }
+
+  .cs-tab-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 9px;
+    font-size: 10px;
+    font-weight: 700;
+    background: var(--cs-crimson-subtle);
+    color: var(--cs-crimson-dim);
+    border: 1px solid var(--cs-border);
+  }
+
+  .cs-tab.active .cs-tab-badge {
+    background: var(--cs-crimson-glow);
+    color: var(--cs-crimson);
+    border-color: var(--cs-crimson);
+  }
+
+  /* ── Gothic typography ── */
+
+  .cs-vampire-text {
+    font-family: 'Creepster', Impact, fantasy;
+    letter-spacing: 0.06em;
+  }
+
+  .cs-title {
+    font-family: 'Creepster', Impact, fantasy;
+    font-size: clamp(2.5rem, 6vw, 4.5rem);
+    letter-spacing: 0.08em;
+    background: linear-gradient(180deg, var(--cs-crimson) 0%, #6b0020 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    filter: drop-shadow(0 0 20px var(--cs-crimson-glow-strong))
+            drop-shadow(0 4px 8px rgba(0, 0, 0, 0.5));
+    line-height: 1.1;
+  }
+
+  .cs-subtitle {
+    font-size: 1.05rem;
+    font-weight: 400;
+    font-style: italic;
+    letter-spacing: 0.06em;
+    color: var(--cs-text-dim);
+  }
+
+  /* ── Fog / atmosphere ── */
+
+  .cs-atmosphere {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .cs-atmosphere::before {
+    content: '';
+    position: absolute;
+    top: -20%;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 140%;
+    height: 70%;
+    background: radial-gradient(
+      ellipse at center,
+      var(--cs-crimson-glow) 0%,
+      transparent 55%
+    );
+    animation: cs-fog-drift 6s ease-in-out infinite;
+  }
+
+  .cs-atmosphere::after {
+    content: '';
+    position: absolute;
+    bottom: -15%;
+    right: -15%;
+    width: 60%;
+    height: 60%;
+    background: radial-gradient(
+      circle,
+      var(--cs-purple-glow) 0%,
+      transparent 55%
+    );
+    animation: cs-fog-drift 8s ease-in-out infinite reverse;
+  }
+
+  /* ── Mist overlay (instead of scanlines) ── */
+
+  .cs-mist::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(ellipse at 20% 80%, var(--cs-fog) 0%, transparent 50%),
+      radial-gradient(ellipse at 80% 20%, var(--cs-fog) 0%, transparent 50%);
+    pointer-events: none;
+    z-index: 50;
+    animation: cs-mist-shift 12s ease-in-out infinite;
+  }
+
+  /* ── Intensity cards (coffin-shaped) ── */
+
+  .cs-intensity-card {
+    position: relative;
+    border: 1px solid var(--cs-border);
+    border-radius: 4px 4px 12px 12px;
+    padding: 20px;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    background: var(--cs-bg-surface);
+    overflow: hidden;
+    clip-path: polygon(15% 0%, 85% 0%, 100% 8%, 100% 100%, 50% 96%, 0% 100%, 0% 8%);
+  }
+
+  .cs-intensity-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, var(--cs-crimson-subtle), transparent);
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+
+  .cs-intensity-card:hover::before {
+    opacity: 1;
+  }
+
+  .cs-intensity-card:hover {
+    border-color: var(--cs-border-bright);
+    transform: translateY(-3px);
+    box-shadow: 0 8px 40px var(--cs-crimson-glow);
+  }
+
+  .cs-intensity-card.selected {
+    border-color: var(--cs-crimson);
+    box-shadow: 0 0 25px var(--cs-crimson-glow), inset 0 0 25px var(--cs-crimson-subtle);
+  }
+
+  .cs-intensity-card.selected::before {
+    opacity: 1;
+  }
+
+  /* ── Genre chip ── */
+
+  .cs-genre-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 7px 16px;
+    border: 1px solid var(--cs-border);
+    border-radius: 4px;
+    font-size: 14px;
+    font-weight: 400;
+    font-style: italic;
+    cursor: pointer;
+    transition: all 0.2s;
+    background: transparent;
+    color: var(--cs-text-dim);
+    user-select: none;
+    font-family: 'Crimson Text', serif;
+  }
+
+  .cs-genre-chip:hover {
+    border-color: var(--cs-border-bright);
+    color: var(--cs-text);
+  }
+
+  .cs-genre-chip.selected {
+    border-color: var(--cs-crimson);
+    color: var(--cs-crimson);
+    background: var(--cs-crimson-subtle);
+  }
+
+  /* ── Content card ── */
+
+  .cs-content-card {
+    position: relative;
+    border: 1px solid var(--cs-border);
+    border-radius: 4px;
+    padding: 24px;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    background: var(--cs-bg-surface);
+    overflow: hidden;
+  }
+
+  .cs-content-card::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, var(--cs-crimson), transparent);
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+
+  .cs-content-card:hover {
+    border-color: var(--cs-border-bright);
+    transform: translateY(-4px) scale(1.01);
+    box-shadow: 0 12px 50px var(--cs-crimson-glow);
+  }
+
+  .cs-content-card:hover::after {
+    opacity: 1;
+  }
+
+  /* ── Blood meter (slop rating) ── */
+
+  .cs-blood-meter {
+    height: 6px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.06);
+    overflow: hidden;
+  }
+
+  .cs-blood-fill {
+    height: 100%;
+    border-radius: 3px;
+    transition: width 0.8s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  /* ── CTA button ── */
+
+  .cs-cta {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 14px 36px;
+    border: 1px solid var(--cs-crimson);
+    border-radius: 4px;
+    font-size: 17px;
+    font-weight: 700;
+    font-family: 'Creepster', fantasy;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    color: var(--cs-crimson);
+    background: transparent;
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    overflow: hidden;
+  }
+
+  .cs-cta::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, var(--cs-crimson-glow-strong), var(--cs-crimson-subtle));
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+
+  .cs-cta:hover:not(:disabled)::before {
+    opacity: 1;
+  }
+
+  .cs-cta:hover:not(:disabled) {
+    box-shadow: 0 0 40px var(--cs-crimson-glow), inset 0 0 30px var(--cs-crimson-subtle);
+    transform: translateY(-2px);
+    text-shadow: 0 0 20px var(--cs-crimson-glow-strong);
+  }
+
+  .cs-cta:disabled {
+    opacity: 0.3;
+    cursor: default;
+  }
+
+  .cs-cta span {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* ── Animations ── */
+
+  @keyframes cs-fog-drift {
+    0%, 100% { opacity: 0.5; transform: translateX(-50%) scale(1); }
+    50% { opacity: 0.9; transform: translateX(-48%) scale(1.05); }
+  }
+
+  @keyframes cs-mist-shift {
+    0%, 100% { opacity: 0.3; }
+    33% { opacity: 0.6; }
+    66% { opacity: 0.2; }
+  }
+
+  @keyframes cs-rise-from-grave {
+    from { opacity: 0; transform: translateY(40px) scale(0.95); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+  }
+
+  @keyframes cs-fade-up {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  @keyframes cs-fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  @keyframes cs-blood-drip {
+    0% { transform: translateY(-100%); opacity: 0; }
+    10% { opacity: 1; }
+    90% { opacity: 1; }
+    100% { transform: translateY(300%); opacity: 0; }
+  }
+
+  @keyframes cs-bat-flap {
+    0%, 100% { transform: scaleX(1) translateY(0); }
+    25% { transform: scaleX(0.7) translateY(-8px); }
+    50% { transform: scaleX(1.1) translateY(-4px); }
+    75% { transform: scaleX(0.8) translateY(-10px); }
+  }
+
+  @keyframes cs-float {
+    0%, 100% { transform: translateY(0px) rotate(0deg); }
+    33% { transform: translateY(-6px) rotate(1deg); }
+    66% { transform: translateY(-3px) rotate(-1deg); }
+  }
+
+  @keyframes cs-heartbeat {
+    0%, 100% { transform: scale(1); }
+    14% { transform: scale(1.1); }
+    28% { transform: scale(1); }
+    42% { transform: scale(1.05); }
+    56% { transform: scale(1); }
+  }
+
+  @keyframes cs-flicker {
+    0%, 100% { opacity: 1; }
+    3% { opacity: 0.4; }
+    6% { opacity: 1; }
+    7% { opacity: 0.6; }
+    9% { opacity: 1; }
+    50% { opacity: 1; }
+    52% { opacity: 0.7; }
+    53% { opacity: 1; }
+  }
+
+  @keyframes cs-dot-pulse {
+    0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
+    40% { opacity: 1; transform: scale(1.3); }
+  }
+
+  @keyframes cs-coffin-open {
+    from { opacity: 0; transform: perspective(400px) rotateX(-15deg) translateY(30px); }
+    to { opacity: 1; transform: perspective(400px) rotateX(0deg) translateY(0); }
+  }
+
+  @keyframes cs-shake {
+    0%, 100% { transform: translateX(0); }
+    10%, 30%, 50%, 70%, 90% { transform: translateX(-3px); }
+    20%, 40%, 60%, 80% { transform: translateX(3px); }
+  }
+
+  .cs-animate-float { animation: cs-float 4s ease-in-out infinite; }
+  .cs-animate-fade-up { animation: cs-fade-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) both; }
+  .cs-animate-heartbeat { animation: cs-heartbeat 2s ease-in-out infinite; }
+  .cs-animate-flicker { animation: cs-flicker 4s ease-in-out infinite; }
+  .cs-animate-bat { animation: cs-bat-flap 1.2s ease-in-out infinite; }
+  .cs-animate-shake { animation: cs-shake 0.6s ease-in-out; }
+
+  .cs-card-enter-1 { animation: cs-coffin-open 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.1s both; }
+  .cs-card-enter-2 { animation: cs-coffin-open 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.3s both; }
+  .cs-card-enter-3 { animation: cs-coffin-open 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.5s both; }
+
+  /* ── Loading drops (blood drip) ── */
+
+  .cs-loading-drop {
+    width: 6px;
+    height: 10px;
+    border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+    background: var(--cs-crimson);
+    animation: cs-dot-pulse 1.4s ease-in-out infinite;
+  }
+
+  .cs-loading-drop:nth-child(2) { animation-delay: 0.2s; }
+  .cs-loading-drop:nth-child(3) { animation-delay: 0.4s; }
+
+  /* ── Slop slider (remix phase) ── */
+
+  .cs-slop-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    height: 6px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.06);
+    outline: none;
+    cursor: pointer;
+  }
+
+  .cs-slop-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--cs-crimson);
+    border: 2px solid var(--cs-bg);
+    box-shadow: 0 0 8px var(--cs-crimson-glow);
+    cursor: pointer;
+    transition: box-shadow 0.2s;
+  }
+
+  .cs-slop-slider::-webkit-slider-thumb:hover {
+    box-shadow: 0 0 16px var(--cs-crimson-glow-strong);
+  }
+
+  /* ── Line clamp utility ── */
+
+  .line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .line-clamp-4 {
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+`;

--- a/packages/pi-count-slopula-extension/ui/styles.css
+++ b/packages/pi-count-slopula-extension/ui/styles.css
@@ -1,0 +1,36 @@
+@import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Creepster&family=Crimson+Text:ital,wght@0,400;0,600;0,700;1,400&display=swap');
+
+/* Scan @sero/ui component sources so Tailwind generates CSS for shared components */
+@source "../../ui/src/components";
+
+@custom-variant dark (&:is(.dark *));
+
+/*
+ * Theme tokens — maps Sero/shadcn CSS variables to Tailwind utilities.
+ */
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}

--- a/packages/pi-count-slopula-extension/ui/tsconfig.json
+++ b/packages/pi-count-slopula-extension/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero/app-runtime": ["../../app-runtime/src/index.ts"],
+      "@sero/ui": ["../../ui/src/index.ts"],
+      "@sero/ui/*": ["../../ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-count-slopula-extension/vite.config.ts
+++ b/packages/pi-count-slopula-extension/vite.config.ts
@@ -1,0 +1,48 @@
+/**
+ * Vite config for Count Slopula's federated UI (remote).
+ *
+ * Runs its own dev server on port 5186. The host (Sero on 5173)
+ * declares this as a remote and imports components via MF.
+ */
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_count_slopula',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './CountSlopula': './ui/CountSlopula.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5186,
+    strictPort: true,
+    origin: 'http://localhost:5186',
+  },
+  optimizeDeps: {
+    exclude: ['@sero/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary

Introduces Count Slopula, a new Sero app that generates gloriously clichéd content pieces with a gothic vampire aesthetic. The app features a two-tab interface for summoning content and tracking history, with dramatic CSS animations, AI-powered generation, and workspace integration.

## Key Changes

- **New Sero App Package** (`@sero/count-slopula`)
  - Federated UI component built with React + Vite
  - Pi extension for agent integration and state management
  - Global-scoped state persistence via JSON file

- **UI Components & Phases**
  - `ConfigPhase`: Landing screen with intensity picker (nibble/bite/drain) and genre selection
  - `GeneratingPhase`: Animated loading screen while AI generates content
  - `PickingPhase`: Displays 3 generated content pieces as gothic cards with blood meter ratings
  - `RemixPhase`: Allows editing name, tagline, body, and adding custom twists before launch
  - `LaunchPhase`: Creates workspace/session and kicks off agent with dramatic ritual sequence
  - `HistoryDashboard`: "The Crypt" tab showing ritual log and bookmarked pieces

- **Gothic Aesthetic**
  - Custom CSS stylesheet with crimson/purple color scheme, fog effects, and bat animations
  - Coffin-shaped intensity cards with clip-path borders
  - Dripping text effects, heartbeat animations, and flicker transitions
  - Custom fonts (Creepster for headers, Crimson Text for body)

- **Content Generation**
  - AI prompt building with intensity levels and genre filtering
  - Response parsing with fallback strategies for malformed JSON
  - Content piece model with name, tagline, body, genre, and "slop rating" (1-10 cliché score)

- **State Management**
  - Shared TypeScript types for content pieces, history entries, and app state
  - Persistent state via `useAppState` hook
  - History tracking with launch timestamps and build status
  - Bookmarking system for saving pieces without launching

- **Agent Integration**
  - Pi extension tool (`count_slopula`) for querying history and entombed pieces
  - `/count-slopula` command to prompt users to open the app
  - Workspace/session creation via Sero shell APIs
  - Prompt injection with user-selected twists

## Notable Implementation Details

- Error boundary wrapping phase components with vampire-themed error UI
- Tab-based navigation between "Summon" (generation) and "Crypt" (history) sections
- Intensity levels affect prompt engineering to control cliché density
- Content cards use CSS animations for entrance effects and hover states
- Launch process shows step-by-step progress (creating workspace → opening agent → sending prompt)
- Fallback content generation when AI response parsing fails

https://claude.ai/code/session_01YLWGFFGzr8q6iNL1avnxEu