### PR TITLE
feat: Cron scheduler app + desktop notification system

### DIFF
--- a/apps/desktop/.sero/apps/planmode/state.json
+++ b/apps/desktop/.sero/apps/planmode/state.json
@@ -1,0 +1,4 @@
+{
+  "mode": "normal",
+  "steps": []
+}

--- a/apps/desktop/.sero/apps/planmode/state.json
+++ b/apps/desktop/.sero/apps/planmode/state.json
@@ -1,4 +1,0 @@
-{
-  "mode": "normal",
-  "steps": []
-}

--- a/apps/desktop/electron/cli/schema-bridge.ts
+++ b/apps/desktop/electron/cli/schema-bridge.ts
@@ -15,6 +15,7 @@
 import type { ToolDefinition, RegisteredCommand } from '@mariozechner/pi-coding-agent';
 import type { CliCommand, CliCommandContext, CliResult } from './types';
 import { parseFlags } from './commands/utils';
+import { showNotification } from '../notifications';
 
 // ── Schema introspection ────────────────────────────────────
 
@@ -213,6 +214,32 @@ export function bridgeTool(toolName: string, toolDef: ToolDefinition): CliComman
  * Side effects (pi.sendMessage, pi.setActiveTools, etc.) work through
  * the extension's closure-captured `pi` reference.
  */
+/**
+ * Minimal ExtensionCommandContext for bridged commands.
+ *
+ * The Pi SDK command handler expects `ctx.ui.notify()` etc. We provide
+ * a lightweight shim so extensions don't crash when called via the CLI
+ * bridge. `notify` is real (shows desktop notification); everything
+ * else is a safe no-op.
+ */
+function buildCommandContext(ctx: CliCommandContext): Record<string, unknown> {
+  return {
+    cwd: ctx.cwd,
+    hasUI: true,
+    ui: {
+      select: async () => undefined,
+      confirm: async () => false,
+      input: async () => undefined,
+      notify: (message: string, type?: 'info' | 'warning' | 'error') => {
+        showNotification(message, type ?? 'info');
+      },
+      onTerminalInput: () => () => {},
+      setStatus: () => {},
+      setWorkingMessage: () => {},
+    },
+  };
+}
+
 export function bridgeCommand(name: string, cmd: RegisteredCommand): CliCommand {
   return {
     name,
@@ -221,7 +248,7 @@ export function bridgeCommand(name: string, cmd: RegisteredCommand): CliCommand 
     group: 'App Commands',
     execute: async (args: string[], ctx: CliCommandContext): Promise<CliResult> => {
       try {
-        await cmd.handler(args.join(' '), { cwd: ctx.cwd } as any);
+        await cmd.handler(args.join(' '), buildCommandContext(ctx) as any);
         return { output: `/${name} executed`, exitCode: 0 };
       } catch (error) {
         const msg = error instanceof Error ? error.message : 'Command failed';

--- a/apps/desktop/electron/cli/schema-bridge.ts
+++ b/apps/desktop/electron/cli/schema-bridge.ts
@@ -15,7 +15,7 @@
 import type { ToolDefinition, RegisteredCommand } from '@mariozechner/pi-coding-agent';
 import type { CliCommand, CliCommandContext, CliResult } from './types';
 import { parseFlags } from './commands/utils';
-import { showNotification } from '../notifications';
+import { createSeroUIContext } from '../extension-ui-context';
 
 // ── Schema introspection ────────────────────────────────────
 
@@ -215,29 +215,13 @@ export function bridgeTool(toolName: string, toolDef: ToolDefinition): CliComman
  * the extension's closure-captured `pi` reference.
  */
 /**
- * Minimal ExtensionCommandContext for bridged commands.
+ * Build a minimal ExtensionCommandContext for bridged commands.
  *
- * The Pi SDK command handler expects `ctx.ui.notify()` etc. We provide
- * a lightweight shim so extensions don't crash when called via the CLI
- * bridge. `notify` is real (shows desktop notification); everything
- * else is a safe no-op.
+ * Reuses the canonical `createSeroUIContext()` so there's a single
+ * source of truth for the UIContext shim across Sero.
  */
 function buildCommandContext(ctx: CliCommandContext): Record<string, unknown> {
-  return {
-    cwd: ctx.cwd,
-    hasUI: true,
-    ui: {
-      select: async () => undefined,
-      confirm: async () => false,
-      input: async () => undefined,
-      notify: (message: string, type?: 'info' | 'warning' | 'error') => {
-        showNotification(message, type ?? 'info');
-      },
-      onTerminalInput: () => () => {},
-      setStatus: () => {},
-      setWorkingMessage: () => {},
-    },
-  };
+  return { cwd: ctx.cwd, hasUI: true, ui: createSeroUIContext() };
 }
 
 export function bridgeCommand(name: string, cmd: RegisteredCommand): CliCommand {

--- a/apps/desktop/electron/extension-ui-context.ts
+++ b/apps/desktop/electron/extension-ui-context.ts
@@ -1,0 +1,75 @@
+/**
+ * Sero's ExtensionUIContext implementation.
+ *
+ * Provides a real `notify()` that shows desktop notifications.
+ * All other methods are no-ops for now — Sero's UI is React-based,
+ * not TUI-based, so TUI-specific methods (setWidget, setFooter, etc.)
+ * don't apply. They can be wired up to IPC in the future if needed.
+ *
+ * Compatible with the Pi SDK's ExtensionUIContext interface.
+ */
+
+import type { ExtensionUIContext } from '@mariozechner/pi-coding-agent';
+import { showNotification } from './notifications';
+
+/**
+ * Create an ExtensionUIContext for Sero sessions.
+ *
+ * Call `session.extensionRunner?.setUIContext(createSeroUIContext())`
+ * after creating the session so all extension event handlers and
+ * command contexts receive a working `ctx.ui`.
+ */
+export function createSeroUIContext(): ExtensionUIContext {
+  return {
+    // ── Dialogs (no-op — would need IPC to renderer) ─────
+
+    select: async () => undefined,
+    confirm: async () => false,
+    input: async () => undefined,
+
+    // ── Notifications (real implementation) ──────────────
+
+    notify(message: string, type?: 'info' | 'warning' | 'error'): void {
+      showNotification(message, type ?? 'info');
+    },
+
+    // ── Terminal input (not applicable in Sero) ──────────
+
+    onTerminalInput: () => () => {},
+
+    // ── Status / UI (no-op for now) ──────────────────────
+
+    setStatus: () => {},
+    setWorkingMessage: () => {},
+    setWidget: () => {},
+    setFooter: () => {},
+    setHeader: () => {},
+    setTitle: () => {},
+
+    // ── Custom components (no-op) ────────────────────────
+
+    custom: async () => undefined as never,
+
+    // ── Editor (no-op) ───────────────────────────────────
+
+    pasteToEditor: () => {},
+    setEditorText: () => {},
+    getEditorText: () => '',
+    editor: async () => undefined,
+    setEditorComponent: () => {},
+
+    // ── Theme (stubs) ────────────────────────────────────
+
+    get theme(): any {
+      return {};
+    },
+    getAllThemes: () => [],
+    getTheme: () => undefined,
+    setTheme: () => ({ success: false, error: 'Not supported in Sero' }),
+
+    // ── Tool expansion (no-op) ───────────────────────────
+
+    getToolsExpanded: () => false,
+    setToolsExpanded: () => {},
+  };
+}

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -48,6 +48,7 @@ import {
 import { createContainerTools } from '../container/tools';
 import type { ContainerState } from '../container/index';
 import { registerAgentModelContextHandlers } from './agent-model-context';
+import { createSeroUIContext } from '../extension-ui-context';
 import { installCliAgentBridge, noteCliTurnEnd, noteCliTurnStart } from '../cli/agent-bridge';
 import { createWorkspaceCliTool, bridgeExtensionTools } from '../cli';
 import { installGatewayAgentOps, forwardEventToGateway } from '../gateway/agent-bridge';
@@ -298,6 +299,9 @@ async function openSessionInternal(
     sessionManager: SessionManager.open(sessionPath, SERO_SESSION_DIR),
     settingsManager: infra.settingsManager,
   });
+
+  // Provide a real UIContext so extensions get working ctx.ui.notify()
+  session.extensionRunner?.setUIContext(createSeroUIContext());
 
   const unsubscribe = subscribeToSession(sessionId, session);
   pool.set(sessionId, {

--- a/apps/desktop/electron/notifications.ts
+++ b/apps/desktop/electron/notifications.ts
@@ -3,22 +3,11 @@
  *
  * Provides native macOS notifications via Electron's Notification API,
  * compatible with the Pi SDK's `ctx.ui.notify(message, type)` interface.
- *
- * Also forwards notifications to the renderer via IPC so the UI can
- * show in-app toasts in the future.
  */
 
-import { Notification, BrowserWindow } from 'electron';
-import { IpcChannels } from '../src/types/ipc';
+import { Notification } from 'electron';
 
 export type NotificationType = 'info' | 'warning' | 'error';
-
-export interface SeroNotification {
-  message: string;
-  type: NotificationType;
-  source?: string;
-  timestamp: string;
-}
 
 const TYPE_PREFIXES: Record<NotificationType, string> = {
   info: 'ℹ️',
@@ -27,7 +16,7 @@ const TYPE_PREFIXES: Record<NotificationType, string> = {
 };
 
 /**
- * Show a desktop notification and forward to the renderer.
+ * Show a native desktop notification.
  *
  * This is the single entry point for all extension notifications in Sero.
  * Called by the ExtensionUIContext's `notify()` implementation.
@@ -37,29 +26,14 @@ export function showNotification(
   type: NotificationType = 'info',
   source?: string,
 ): void {
-  // ── Desktop notification ───────────────────────────────
+  if (!Notification.isSupported()) return;
 
-  if (Notification.isSupported()) {
-    const prefix = TYPE_PREFIXES[type];
-    const title = source ? `Sero — ${source}` : 'Sero';
+  const prefix = TYPE_PREFIXES[type];
+  const title = source ? `Sero — ${source}` : 'Sero';
 
-    new Notification({
-      title,
-      body: `${prefix} ${message}`,
-      silent: type === 'info',
-    }).show();
-  }
-
-  // ── Forward to renderer (for future in-app toasts) ─────
-
-  const event: SeroNotification = {
-    message,
-    type,
-    source,
-    timestamp: new Date().toISOString(),
-  };
-
-  for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send(IpcChannels.notification, event);
-  }
+  new Notification({
+    title,
+    body: `${prefix} ${message}`,
+    silent: type === 'info',
+  }).show();
 }

--- a/apps/desktop/electron/notifications.ts
+++ b/apps/desktop/electron/notifications.ts
@@ -1,0 +1,65 @@
+/**
+ * Desktop notification system for Sero.
+ *
+ * Provides native macOS notifications via Electron's Notification API,
+ * compatible with the Pi SDK's `ctx.ui.notify(message, type)` interface.
+ *
+ * Also forwards notifications to the renderer via IPC so the UI can
+ * show in-app toasts in the future.
+ */
+
+import { Notification, BrowserWindow } from 'electron';
+import { IpcChannels } from '../src/types/ipc';
+
+export type NotificationType = 'info' | 'warning' | 'error';
+
+export interface SeroNotification {
+  message: string;
+  type: NotificationType;
+  source?: string;
+  timestamp: string;
+}
+
+const TYPE_PREFIXES: Record<NotificationType, string> = {
+  info: 'ℹ️',
+  warning: '⚠️',
+  error: '❌',
+};
+
+/**
+ * Show a desktop notification and forward to the renderer.
+ *
+ * This is the single entry point for all extension notifications in Sero.
+ * Called by the ExtensionUIContext's `notify()` implementation.
+ */
+export function showNotification(
+  message: string,
+  type: NotificationType = 'info',
+  source?: string,
+): void {
+  // ── Desktop notification ───────────────────────────────
+
+  if (Notification.isSupported()) {
+    const prefix = TYPE_PREFIXES[type];
+    const title = source ? `Sero — ${source}` : 'Sero';
+
+    new Notification({
+      title,
+      body: `${prefix} ${message}`,
+      silent: type === 'info',
+    }).show();
+  }
+
+  // ── Forward to renderer (for future in-app toasts) ─────
+
+  const event: SeroNotification = {
+    message,
+    type,
+    source,
+    timestamp: new Date().toISOString(),
+  };
+
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(IpcChannels.notification, event);
+  }
+}

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -61,6 +61,8 @@ export const IpcChannels = {
     /** Save all user context editor presets to disk. */
     save: 'sero:context-presets:save',
   },
+  /** Main → renderer push: extension notification (toast / desktop). */
+  notification: 'sero:notification',
   shell: {
     /** Open a path in the native file explorer. */
     showItemInFolder: 'sero:shell:show-item-in-folder',

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -61,8 +61,6 @@ export const IpcChannels = {
     /** Save all user context editor presets to disk. */
     save: 'sero:context-presets:save',
   },
-  /** Main → renderer push: extension notification (toast / desktop). */
-  notification: 'sero:notification',
   shell: {
     /** Open a path in the native file explorer. */
     showItemInFolder: 'sero:shell:show-item-in-folder',

--- a/packages/pi-cron-extension/README.md
+++ b/packages/pi-cron-extension/README.md
@@ -1,0 +1,366 @@
+# @sero/cron
+
+Cron scheduler for [Sero](../../README.md) — schedule recurring agent prompts
+that run as isolated `pi -p` subprocesses. Manage jobs from the dashboard UI
+or ask the agent to create them for you.
+
+Adapted from [@e9n/pi-cron](https://github.com/espennilsen/pi/tree/main/extensions/pi-cron)
+for the Sero platform. The Pi extension works standalone in the Pi CLI; the
+React UI is Sero-only.
+
+## Features
+
+- **Visual dashboard** — add, edit, enable/disable, and remove jobs from the
+  Sero UI. Live cron expression validation with human-readable previews.
+- **Agent tool** — the LLM can manage jobs through the `cron` tool, so you
+  can say "schedule a daily standup reminder at 9am" and it just works.
+- **No database** — jobs are stored as JSON in a single state file. Both the
+  UI and the extension read/write the same file; changes sync instantly.
+- **Scheduler off by default** — nothing runs until you start it. Toggle from
+  the UI or with `/cron on`.
+- **Isolated execution** — each job runs as a `pi -p --no-session` subprocess
+  with a 10-minute timeout. Jobs can't interfere with each other or with your
+  active chat.
+- **Run history** — the last 50 execution results (pass/fail, duration, errors)
+  are visible in the History tab.
+- **Global scope** — jobs are personal, not per-workspace. Your schedule
+  persists across all projects.
+
+---
+
+## User Guide
+
+### Opening the app
+
+Click **Cron** (🕐) in the Sero sidebar. The dashboard has two tabs:
+
+| Tab | What it shows |
+|-----|---------------|
+| **Jobs** | All configured cron jobs with status, schedule, and actions |
+| **History** | Recent execution results with pass/fail status and timing |
+
+### Creating a job
+
+**From the UI:**
+
+1. Click **+ New Job** (top-right corner or empty-state button).
+2. Fill in the form:
+   - **Name** — unique identifier, no spaces (e.g. `daily-standup`).
+   - **Schedule** — a standard 5-field cron expression, or click a preset
+     pill to fill one in. The form validates in real time and shows a
+     human-readable description (e.g. "Weekdays at 09:00").
+   - **Prompt** — the message sent to the agent when the job fires.
+   - **Channel** — optional grouping tag (defaults to `cron`).
+   - **Model** — optional model pattern or ID for this job
+     (e.g. `sonnet`, `openai/gpt-4o`, `gemini:high`). Supports the
+     `provider/id` shorthand and optional `:<thinking>` suffix. Leave
+     blank to use whatever default is in your Pi settings.
+3. Click **Add Job**.
+
+**From the chat:**
+
+Ask the agent naturally — it will use the `cron` tool:
+
+```
+Schedule a job called "daily-standup" that runs at 9am on weekdays
+and asks "Review my todo tasks and summarize what's open"
+```
+
+You can also specify a model:
+
+```
+Add a cron job called "cheap-health-check" that runs every 15 minutes
+using the model "flash" with the prompt "Check system health"
+```
+
+### Cron expression syntax
+
+Schedules use standard 5-field cron format:
+
+```
+┌───────────── minute (0–59)
+│ ┌─────────── hour (0–23)
+│ │ ┌───────── day of month (1–31)
+│ │ │ ┌─────── month (1–12)
+│ │ │ │ ┌───── day of week (0–6, Sun=0)
+│ │ │ │ │
+* * * * *
+```
+
+**Operators:**
+
+| Operator | Example | Meaning |
+|----------|---------|---------|
+| `*` | `* * * * *` | Every unit (every minute) |
+| `,` | `0,30 * * * *` | List — minute 0 and 30 |
+| `-` | `1-5` (in dow) | Range — Monday through Friday |
+| `/` | `*/15 * * * *` | Step — every 15 minutes |
+
+**Common schedules:**
+
+| Expression | Description |
+|------------|-------------|
+| `* * * * *` | Every minute |
+| `*/5 * * * *` | Every 5 minutes |
+| `*/15 * * * *` | Every 15 minutes |
+| `0 * * * *` | Every hour (at :00) |
+| `0 9 * * *` | Daily at 9:00 AM |
+| `0 9 * * 1-5` | Weekdays at 9:00 AM |
+| `0 0 * * 0` | Weekly on Sunday at midnight |
+| `0 0 1 * *` | Monthly on the 1st at midnight |
+| `30 8,12,17 * * *` | 8:30 AM, 12:30 PM, and 5:30 PM daily |
+
+### Starting the scheduler
+
+Jobs are stored immediately when created, but they only **execute** when
+the scheduler is running.
+
+**From the UI:** Click the **▶ Start** button in the status bar at the top
+of the dashboard.
+
+**From the chat:** Type `/cron on` or ask the agent to start it.
+
+The status bar shows a green dot and "Scheduler Active" when running. It
+also displays job counts (total, active, paused).
+
+### Autostart
+
+Toggle the **Autostart** switch in the status bar to have the scheduler
+start automatically whenever Sero launches. When enabled, the extension
+boots the scheduler on session start (as long as at least one job exists).
+The setting persists across restarts — flip it once and forget about it.
+
+### Managing jobs
+
+Each job card in the Jobs tab has four actions:
+
+| Action | What it does |
+|--------|--------------|
+| **Edit** | Opens the job form pre-filled with current values. Name cannot be changed. |
+| **⏸ Disable / ▶ Enable** | Pauses or resumes a job without removing it. Disabled jobs stay in the list but won't fire on schedule. |
+| **▶ Run** | Triggers the job immediately (requires the scheduler to be active). |
+| **Remove** | Permanently deletes the job. |
+
+All of these can also be done via the agent:
+
+```
+Disable the daily-standup cron job
+```
+
+```
+Remove the health-check job
+```
+
+### Viewing history
+
+Switch to the **History** tab to see recent executions. Each entry shows:
+
+- ● Green dot (success) or red dot (failure)
+- Job name
+- Duration badge
+- Error message (if failed)
+- Relative timestamp ("2m ago", "1h ago")
+
+The last 50 results are kept. History is stored in the same state file and
+persists across sessions.
+
+### Stopping the scheduler
+
+**From the UI:** Click **⏸ Stop** in the status bar.
+
+**From the chat:** Type `/cron off`.
+
+Stopping the scheduler does not remove any jobs — they'll resume next time
+you start it. The scheduler also stops automatically when Sero quits.
+
+---
+
+## Agent Tool Reference
+
+The `cron` tool is available to the LLM in both Sero and the Pi CLI. In
+Sero it's bridged through the `sero-cli` tool automatically.
+
+| Action | Required params | Optional params | Description |
+|--------|----------------|-----------------|-------------|
+| `list` | — | — | Show all jobs with status |
+| `add` | `name`, `schedule`, `prompt` | `channel`, `model` | Create a new job |
+| `update` | `name` | `schedule`, `prompt`, `channel`, `model` | Modify an existing job |
+| `remove` | `name` | — | Delete a job |
+| `enable` | `name` | — | Re-enable a disabled job |
+| `disable` | `name` | — | Pause a job without removing it |
+| `run` | `name` | — | Trigger a job immediately (scheduler must be active) |
+
+The `model` parameter accepts any value that `pi --model` accepts: a model
+name (`sonnet`, `flash`), a `provider/id` pair (`openai/gpt-4o`), or a
+name with a thinking-level suffix (`sonnet:high`). When omitted, the job
+uses your default model.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/cron on` | Start the scheduler |
+| `/cron off` | Stop the scheduler |
+| `/cron` | Show status (active/inactive, job count) |
+
+---
+
+## Architecture
+
+```
+packages/pi-cron-extension/
+├── package.json              # Pi + Sero manifest (global scope, port 5188)
+├── vite.config.ts            # Module Federation remote config
+├── shared/
+│   ├── types.ts              # CronJob, CronState, CronRunResult
+│   └── cron.ts               # 5-field parser, validator, cronToHuman
+├── extension/
+│   ├── index.ts              # Tool, /cron command, scheduler lifecycle
+│   └── scheduler.ts          # CronScheduler — tick loop + subprocess runner
+└── ui/
+    ├── CronApp.tsx            # Root component — tabs, job list, status
+    ├── components/
+    │   ├── SchedulerBar.tsx   # Status indicator + start/stop toggle
+    │   ├── JobCard.tsx        # Single job display with actions
+    │   ├── JobForm.tsx        # Add/edit dialog with presets + validation
+    │   └── RunHistory.tsx     # Recent execution results
+    ├── lib/
+    │   └── cron-utils.ts      # Presets, formatDuration, timeAgo
+    ├── styles.css             # Tailwind + theme tokens
+    ├── tsconfig.json
+    └── index.html
+```
+
+### How it works
+
+```
+                   state.json
+                 (~/.sero-ui/apps/cron/)
+                 ┌────────┴────────┐
+                 │                 │
+           Pi Extension        React UI
+           (cron tool)         (useAppState)
+                 │                 │
+                 ▼                 ▼
+           CronScheduler      Dashboard
+           ticks every 30s    add/edit/remove
+           spawns pi -p       toggle scheduler
+           appends results    view history
+```
+
+Both sides read and write the same JSON file. The file IS the API:
+
+- **Extension → file**: tool calls (add, remove, etc.) and scheduler run
+  results write directly to `state.json` with atomic writes (temp + rename).
+- **File → UI**: Sero's `AppStateManager` watches the file with `fs.watch`
+  and pushes updates to the renderer via IPC. React re-renders instantly.
+- **UI → file**: `useAppState` calls write through IPC to the main process,
+  which performs the same atomic write. The extension picks up changes on
+  its next read.
+
+### State shape
+
+```typescript
+interface CronJob {
+  name: string;        // Unique identifier
+  schedule: string;    // 5-field cron expression
+  prompt: string;      // Agent prompt
+  channel: string;     // Grouping tag (default: "cron")
+  disabled: boolean;   // Paused — won't fire on schedule
+  model?: string;      // Model pattern (e.g. "sonnet", "openai/gpt-4o")
+}
+
+interface CronRunResult {
+  jobName: string;
+  startedAt: string;   // ISO timestamp
+  durationMs: number;
+  ok: boolean;
+  error?: string;
+}
+
+interface CronState {
+  jobs: CronJob[];
+  schedulerActive: boolean;
+  autostart: boolean;               // Start scheduler on launch
+  lastRunResults: CronRunResult[];  // Capped at 50
+}
+```
+
+### Global scope
+
+Cron jobs are personal, not project-specific. State lives at
+`~/.sero-ui/apps/cron/state.json` regardless of which workspace is active.
+In the Pi CLI (where `SERO_HOME` is unset), the extension falls back to
+`.sero/apps/cron/state.json` relative to the working directory.
+
+### Scheduler
+
+The scheduler is an in-memory `setInterval` loop that ticks every 30 seconds.
+On each tick it:
+
+1. Deduplicates by minute (only fires once per calendar minute).
+2. Iterates all non-disabled jobs.
+3. Matches each job's cron expression against the current local time.
+4. For matches, spawns `pi -p --no-session --no-extensions <prompt>` as a
+   child process with a 10-minute timeout.
+5. Appends the result (pass/fail, duration, error) to `lastRunResults` in
+   the state file.
+
+The scheduler resets to inactive on startup — it does not survive process
+restarts. Start it explicitly each session.
+
+---
+
+## Development
+
+### Prerequisites
+
+From the monorepo root:
+
+```bash
+pnpm install
+pnpm --filter @sero/cron build
+```
+
+### Dev server
+
+```bash
+cd apps/desktop
+bash scripts/dev.sh          # Starts all remotes + host + Electron
+```
+
+The cron remote runs on port **5188**. Edits to files in `ui/` trigger
+live reload (~300ms). Extension changes (`extension/`) require a full
+restart.
+
+### Typecheck
+
+```bash
+pnpm --filter @sero/cron typecheck
+```
+
+### Logs
+
+| File | Contents |
+|------|----------|
+| `/tmp/sero-remote-cron.log` | Cron remote Vite dev server |
+| `/tmp/sero-electron.log` | Extension loading, scheduler events |
+
+---
+
+## Differences from @e9n/pi-cron
+
+This package is adapted from the original
+[pi-cron](https://github.com/espennilsen/pi/tree/main/extensions/pi-cron)
+extension for the Sero platform. Key differences:
+
+| | @e9n/pi-cron | @sero/cron |
+|---|---|---|
+| **Storage** | `~/.pi/agent/pi-cron.tab` (custom text format) | `~/.sero-ui/apps/cron/state.json` (JSON) |
+| **UI** | Vanilla HTML/CSS/JS served via pi-webserver | React + Tailwind via Module Federation |
+| **State sync** | File watcher on `.tab` file reloads scheduler | `useAppState` + `fs.watch` syncs UI and extension |
+| **Scope** | Tied to `~/.pi/agent/` | Global (`~/.sero-ui/`) with Pi CLI fallback |
+| **Lock file** | PID lock at `~/.pi/agent/pi-cron.lock` | Not needed — single Electron process |
+| **Web server** | Mounts on pi-webserver (`/cron`, `/api/cron`) | Not needed — federated UI is embedded |
+| **Settings** | `settings.json` → `pi-cron` key (autostart, activeHours, etc.) | State file only (scheduler toggled via UI or command) |
+| **Event API** | `cron:*` events for inter-extension communication | Not ported — apps communicate via shared state |

--- a/packages/pi-cron-extension/extension/actions.ts
+++ b/packages/pi-cron-extension/extension/actions.ts
@@ -1,0 +1,218 @@
+/**
+ * Cron tool action handlers — extracted from index.ts to stay under 500 LOC.
+ *
+ * Each handler receives the current state, tool params, and dependencies,
+ * then returns the result message string. State writes happen here.
+ */
+
+import type { CronState, CronJob, CronRunResult } from '../shared/types';
+import { validateCron } from '../shared/cron';
+import type { CronScheduler } from './scheduler';
+import { runPiSubprocess } from './scheduler';
+import { info, error as logError } from './logger';
+
+export interface ActionDeps {
+  state: CronState;
+  statePath: string;
+  scheduler: CronScheduler | null;
+  workspaceCwd: string;
+  writeState: (filePath: string, state: CronState) => Promise<void>;
+  appendRunResult: (result: CronRunResult) => Promise<void>;
+  /** Tool execution context cwd (may differ from workspaceCwd). */
+  ctxCwd?: string;
+}
+
+interface ActionParams {
+  action: string;
+  name?: string;
+  schedule?: string;
+  prompt?: string;
+  channel?: string;
+  model?: string;
+}
+
+// ── List ────────────────────────────────────────────────────────
+
+export function handleList(deps: ActionDeps): string {
+  const { state, scheduler } = deps;
+
+  if (state.jobs.length === 0) {
+    return 'No cron jobs configured.';
+  }
+
+  const running = scheduler?.getRunningNames() ?? [];
+  const lines = state.jobs.map((j) => {
+    const status = j.disabled
+      ? '⏸ disabled'
+      : running.includes(j.name)
+        ? '🔄 running'
+        : '✅ active';
+    const ch = j.channel !== 'cron' ? ` [${j.channel}]` : '';
+    const mdl = j.model ? ` (${j.model})` : '';
+    return `- **${j.name}** \`${j.schedule}\` ${status}${ch}${mdl}\n  ${j.prompt.slice(0, 80)}`;
+  });
+
+  const note = scheduler?.isRunning()
+    ? ''
+    : '\n\n⚠️ Scheduler is inactive. Use `/cron on` to start.';
+
+  return `**Cron Jobs (${state.jobs.length}):**\n\n${lines.join('\n\n')}${note}`;
+}
+
+// ── Add ─────────────────────────────────────────────────────────
+
+export async function handleAdd(
+  params: ActionParams,
+  deps: ActionDeps,
+): Promise<string> {
+  const { state, statePath, scheduler, writeState } = deps;
+
+  if (!params.name || !params.schedule || !params.prompt) {
+    return 'Missing required fields: name, schedule, and prompt.';
+  }
+  const err = validateCron(params.schedule);
+  if (err) return `Invalid cron expression: ${err}`;
+
+  if (state.jobs.find((j) => j.name === params.name)) {
+    return `Job "${params.name}" already exists.`;
+  }
+
+  const newJob: CronJob = {
+    name: params.name,
+    schedule: params.schedule,
+    prompt: params.prompt,
+    channel: params.channel ?? 'cron',
+    disabled: false,
+  };
+  if (params.model) newJob.model = params.model;
+
+  state.jobs.push(newJob);
+  await writeState(statePath, state);
+  scheduler?.updateJobs(state.jobs);
+
+  return `✓ Added cron job "${params.name}" (${params.schedule})`;
+}
+
+// ── Update ──────────────────────────────────────────────────────
+
+export async function handleUpdate(
+  params: ActionParams,
+  deps: ActionDeps,
+): Promise<string> {
+  const { state, statePath, scheduler, writeState } = deps;
+
+  if (!params.name) return 'Missing required field: name';
+
+  const job = state.jobs.find((j) => j.name === params.name);
+  if (!job) return `Job "${params.name}" not found.`;
+
+  if (params.schedule) {
+    const err = validateCron(params.schedule);
+    if (err) return `Invalid cron expression: ${err}`;
+    job.schedule = params.schedule;
+  }
+  if (params.prompt) job.prompt = params.prompt;
+  if (params.channel) job.channel = params.channel;
+  if (params.model !== undefined) job.model = params.model || undefined;
+
+  await writeState(statePath, state);
+  scheduler?.updateJobs(state.jobs);
+
+  return `✓ Updated "${params.name}"`;
+}
+
+// ── Remove ──────────────────────────────────────────────────────
+
+export async function handleRemove(
+  params: ActionParams,
+  deps: ActionDeps,
+): Promise<string> {
+  const { state, statePath, scheduler, writeState } = deps;
+
+  if (!params.name) return 'Missing required field: name';
+
+  const idx = state.jobs.findIndex((j) => j.name === params.name);
+  if (idx === -1) return `Job "${params.name}" not found.`;
+
+  state.jobs.splice(idx, 1);
+  await writeState(statePath, state);
+  scheduler?.updateJobs(state.jobs);
+
+  return `✓ Removed "${params.name}"`;
+}
+
+// ── Enable / Disable ────────────────────────────────────────────
+
+export async function handleToggle(
+  params: ActionParams,
+  deps: ActionDeps,
+  disable: boolean,
+): Promise<string> {
+  const { state, statePath, scheduler, writeState } = deps;
+
+  if (!params.name) return 'Missing required field: name';
+
+  const job = state.jobs.find((j) => j.name === params.name);
+  if (!job) return `Job "${params.name}" not found.`;
+
+  job.disabled = disable;
+  await writeState(statePath, state);
+  scheduler?.updateJobs(state.jobs);
+
+  return `✓ ${disable ? 'Disabled' : 'Enabled'} "${params.name}"`;
+}
+
+// ── Run (ad-hoc) ────────────────────────────────────────────────
+
+export function handleRun(
+  params: ActionParams,
+  deps: ActionDeps,
+): string {
+  const { state, appendRunResult } = deps;
+
+  if (!params.name) return 'Missing required field: name';
+
+  const runJob = state.jobs.find((j) => j.name === params.name);
+  if (!runJob) return `Job "${params.name}" not found.`;
+
+  const runCwd = deps.ctxCwd || deps.workspaceCwd;
+  info('job:trigger-adhoc', {
+    job: runJob.name,
+    model: runJob.model ?? 'default',
+    cwd: runCwd,
+  });
+
+  // Fire-and-forget: spawn subprocess + record result
+  const startedAt = new Date();
+  runPiSubprocess(runJob.prompt, { model: runJob.model, cwd: runCwd })
+    .then(async (sub) => {
+      const durationMs = Date.now() - startedAt.getTime();
+      const ok = sub.exitCode === 0 || !!sub.stdout;
+      const runResult: CronRunResult = {
+        jobName: runJob.name,
+        startedAt: startedAt.toISOString(),
+        durationMs,
+        ok,
+        error: ok
+          ? undefined
+          : (sub.stderr || `Exit code ${sub.exitCode}`).slice(0, 2000),
+      };
+      if (ok) {
+        info('job:adhoc-complete', { job: runJob.name, durationMs });
+      } else {
+        logError('job:adhoc-failed', {
+          job: runJob.name,
+          durationMs,
+          error: runResult.error?.slice(0, 500),
+        });
+      }
+      await appendRunResult(runResult);
+    })
+    .catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      logError('job:adhoc-crash', { job: runJob.name, error: msg });
+      console.error(`[cron] adhoc run crashed: ${runJob.name}`, err);
+    });
+
+  return `✓ Triggered "${params.name}" — running in background`;
+}

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -95,6 +95,7 @@ const CronParams = Type.Object({
 export default function (pi: ExtensionAPI) {
   console.log('[cron] extension loaded');
   let statePath = '';
+  let workspaceCwd = '';
   let scheduler: CronScheduler | null = null;
 
   // ── Scheduler callbacks ────────────────────────────────────
@@ -129,7 +130,7 @@ export default function (pi: ExtensionAPI) {
 
     const state = await readState(statePath);
     scheduler = createScheduler();
-    scheduler.start(state.jobs);
+    scheduler.start(state.jobs, workspaceCwd);
 
     state.schedulerActive = true;
     await writeState(statePath, state);
@@ -158,15 +159,23 @@ export default function (pi: ExtensionAPI) {
 
   pi.on('session_start', async (_event, ctx) => {
     statePath = resolveStatePath(ctx.cwd);
+    workspaceCwd = ctx.cwd;
     initLogger(pi, statePath);
     info('session:start', { cwd: ctx.cwd, statePath });
+
+    // Skip scheduler in cron subprocess to prevent fork-bomb recursion.
+    // The subprocess only needs the tool registrations, not the scheduler.
+    if (process.env.SERO_CRON_SUBPROCESS) {
+      info('session:start:subprocess-mode');
+      return;
+    }
 
     const state = await readState(statePath);
 
     if (state.autostart && state.jobs.length > 0) {
       info('scheduler:autostart', { jobs: state.jobs.length });
       scheduler = createScheduler();
-      scheduler.start(state.jobs);
+      scheduler.start(state.jobs, workspaceCwd);
       state.schedulerActive = true;
       await writeState(statePath, state);
     } else if (state.schedulerActive) {
@@ -385,15 +394,18 @@ export default function (pi: ExtensionAPI) {
           }
           // Run directly — no scheduler required. The scheduler is for
           // timed execution; ad-hoc "run now" just spawns the subprocess.
+          // Use ctx.cwd if available (tool context), fall back to stored workspace cwd
+          const runCwd = (ctx ? ctx.cwd : workspaceCwd) || workspaceCwd;
           info('job:trigger-adhoc', {
             job: runJob.name,
             model: runJob.model ?? 'default',
+            cwd: runCwd,
           });
           result = `✓ Triggered "${params.name}" — running in background`;
           {
             // Fire-and-forget: spawn subprocess + record result
             const startedAt = new Date();
-            runPiSubprocess(runJob.prompt, runJob.model)
+            runPiSubprocess(runJob.prompt, { model: runJob.model, cwd: runCwd })
               .then(async (sub) => {
                 const durationMs = Date.now() - startedAt.getTime();
                 const ok = sub.exitCode === 0 || !!sub.stdout;

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -1,0 +1,400 @@
+/**
+ * Cron Extension — Pi extension for managing scheduled cron jobs.
+ *
+ * Global-scoped: state at ~/.sero-ui/apps/cron/state.json (Sero)
+ * or .sero/apps/cron/state.json relative to cwd (Pi CLI fallback).
+ *
+ * Tools (LLM-callable): cron (list, add, update, remove, enable, disable, run)
+ * Commands (user): /cron
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import type { CronState, CronJob, CronRunResult } from '../shared/types';
+import { DEFAULT_CRON_STATE, MAX_RUN_RESULTS } from '../shared/types';
+import { validateCron } from '../shared/cron';
+import { CronScheduler } from './scheduler';
+
+// ── State file path ────────────────────────────────────────────
+
+const STATE_REL_PATH = path.join('.sero', 'apps', 'cron', 'state.json');
+
+function resolveStatePath(cwd: string): string {
+  const seroHome = process.env.SERO_HOME;
+  if (seroHome) {
+    return path.join(seroHome, 'apps', 'cron', 'state.json');
+  }
+  return path.join(cwd, STATE_REL_PATH);
+}
+
+// ── File I/O (atomic writes) ───────────────────────────────────
+
+async function readState(filePath: string): Promise<CronState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as CronState;
+  } catch {
+    return { ...DEFAULT_CRON_STATE, jobs: [], lastRunResults: [] };
+  }
+}
+
+async function writeState(
+  filePath: string,
+  state: CronState,
+): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+// ── Tool parameters ────────────────────────────────────────────
+
+const CronParams = Type.Object({
+  action: StringEnum([
+    'list', 'add', 'update', 'remove',
+    'enable', 'disable', 'run',
+  ] as const),
+  name: Type.Optional(
+    Type.String({ description: 'Job name (required for all except list)' }),
+  ),
+  schedule: Type.Optional(
+    Type.String({
+      description:
+        'Cron expression: "min hour dom month dow". Example: "0 9 * * 1-5" = weekdays at 9am',
+    }),
+  ),
+  prompt: Type.Optional(
+    Type.String({
+      description: 'Prompt to send to the agent when the job fires',
+    }),
+  ),
+  channel: Type.Optional(
+    Type.String({ description: 'Channel tag for grouping (default: "cron")' }),
+  ),
+  model: Type.Optional(
+    Type.String({
+      description:
+        'Model pattern or ID for this job (e.g. "sonnet", "openai/gpt-4o"). ' +
+        'Supports "provider/id" and optional ":<thinking>" suffix. ' +
+        'Omit to use the default model.',
+    }),
+  ),
+});
+
+// ── Extension ──────────────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+  let statePath = '';
+  let scheduler: CronScheduler | null = null;
+
+  // ── Scheduler callbacks ────────────────────────────────────
+
+  async function appendRunResult(result: CronRunResult): Promise<void> {
+    if (!statePath) return;
+    const state = await readState(statePath);
+    state.lastRunResults.unshift(result);
+    if (state.lastRunResults.length > MAX_RUN_RESULTS) {
+      state.lastRunResults = state.lastRunResults.slice(0, MAX_RUN_RESULTS);
+    }
+    await writeState(statePath, state);
+  }
+
+  function createScheduler(): CronScheduler {
+    return new CronScheduler({
+      onJobComplete: (result) => {
+        appendRunResult(result).catch(() => {});
+      },
+    });
+  }
+
+  async function startScheduler(): Promise<string> {
+    if (scheduler?.isRunning()) return 'Scheduler is already running.';
+    if (!statePath) return 'Error: no state path resolved.';
+
+    const state = await readState(statePath);
+    scheduler = createScheduler();
+    scheduler.start(state.jobs);
+
+    state.schedulerActive = true;
+    await writeState(statePath, state);
+
+    return `✓ Cron scheduler started (${state.jobs.length} jobs loaded)`;
+  }
+
+  async function stopScheduler(): Promise<string> {
+    if (!scheduler?.isRunning()) return 'Scheduler is not running.';
+    scheduler.stop();
+    scheduler = null;
+
+    if (statePath) {
+      const state = await readState(statePath);
+      state.schedulerActive = false;
+      await writeState(statePath, state);
+    }
+
+    return '✓ Cron scheduler stopped';
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────
+
+  pi.on('session_start', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+    const state = await readState(statePath);
+
+    if (state.autostart && state.jobs.length > 0) {
+      // Autostart: boot the scheduler immediately
+      scheduler = createScheduler();
+      scheduler.start(state.jobs);
+      state.schedulerActive = true;
+      await writeState(statePath, state);
+    } else if (state.schedulerActive) {
+      // Reset stale flag (scheduler doesn't survive restarts)
+      state.schedulerActive = false;
+      await writeState(statePath, state);
+    }
+  });
+
+  pi.on('session_switch', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+
+  pi.on('session_shutdown', async () => {
+    if (scheduler?.isRunning()) {
+      scheduler.stop();
+      scheduler = null;
+    }
+  });
+
+  // ── Command: /cron ─────────────────────────────────────────
+
+  pi.registerCommand('cron', {
+    description: 'Toggle cron scheduler: /cron on | /cron off | /cron status',
+    handler: async (args, ctx) => {
+      const arg = args?.trim().toLowerCase();
+
+      if (arg === 'on' || arg === 'start') {
+        const result = await startScheduler();
+        ctx.ui?.notify(result, result.startsWith('✓') ? 'info' : 'error');
+      } else if (arg === 'off' || arg === 'stop') {
+        const result = await stopScheduler();
+        ctx.ui?.notify(result, result.startsWith('✓') ? 'info' : 'error');
+      } else {
+        const active = scheduler?.isRunning() ?? false;
+        const state = await readState(statePath);
+        const lines = [
+          `Scheduler: ${active ? '✅ active' : '⏸ inactive'}`,
+          `Jobs: ${state.jobs.length}`,
+        ];
+        ctx.ui?.notify(lines.join(' · '), 'info');
+      }
+    },
+  });
+
+  // ── Tool: cron ─────────────────────────────────────────────
+
+  pi.registerTool({
+    name: 'cron',
+    label: 'Cron',
+    description:
+      'Manage scheduled cron jobs. ' +
+      'Actions: list, add, update, remove, enable, disable, run. ' +
+      'Jobs are stored globally and persist across sessions.',
+    parameters: CronParams,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : statePath;
+      if (!resolvedPath) {
+        return {
+          content: [{ type: 'text', text: 'Error: no state path' }],
+          details: {},
+        };
+      }
+      statePath = resolvedPath;
+      const state = await readState(statePath);
+      let result: string;
+
+      switch (params.action) {
+        case 'list': {
+          if (state.jobs.length === 0) {
+            result = 'No cron jobs configured.';
+          } else {
+            const running = scheduler?.getRunningNames() ?? [];
+            const lines = state.jobs.map((j) => {
+              const status = j.disabled
+                ? '⏸ disabled'
+                : running.includes(j.name)
+                  ? '🔄 running'
+                  : '✅ active';
+              const ch = j.channel !== 'cron' ? ` [${j.channel}]` : '';
+              const mdl = j.model ? ` (${j.model})` : '';
+              return `- **${j.name}** \`${j.schedule}\` ${status}${ch}${mdl}\n  ${j.prompt.slice(0, 80)}`;
+            });
+            const note = scheduler?.isRunning()
+              ? ''
+              : '\n\n⚠️ Scheduler is inactive. Use `/cron on` to start.';
+            result = `**Cron Jobs (${state.jobs.length}):**\n\n${lines.join('\n\n')}${note}`;
+          }
+          break;
+        }
+
+        case 'add': {
+          if (!params.name || !params.schedule || !params.prompt) {
+            result = 'Missing required fields: name, schedule, and prompt.';
+            break;
+          }
+          const err = validateCron(params.schedule);
+          if (err) {
+            result = `Invalid cron expression: ${err}`;
+            break;
+          }
+          if (state.jobs.find((j) => j.name === params.name)) {
+            result = `Job "${params.name}" already exists.`;
+            break;
+          }
+          const newJob: CronJob = {
+            name: params.name,
+            schedule: params.schedule,
+            prompt: params.prompt,
+            channel: params.channel ?? 'cron',
+            disabled: false,
+          };
+          if (params.model) newJob.model = params.model;
+          state.jobs.push(newJob);
+          await writeState(statePath, state);
+          scheduler?.updateJobs(state.jobs);
+          result = `✓ Added cron job "${params.name}" (${params.schedule})`;
+          break;
+        }
+
+        case 'update': {
+          if (!params.name) {
+            result = 'Missing required field: name';
+            break;
+          }
+          const job = state.jobs.find((j) => j.name === params.name);
+          if (!job) {
+            result = `Job "${params.name}" not found.`;
+            break;
+          }
+          if (params.schedule) {
+            const err = validateCron(params.schedule);
+            if (err) {
+              result = `Invalid cron expression: ${err}`;
+              break;
+            }
+            job.schedule = params.schedule;
+          }
+          if (params.prompt) job.prompt = params.prompt;
+          if (params.channel) job.channel = params.channel;
+          if (params.model !== undefined) job.model = params.model || undefined;
+          await writeState(statePath, state);
+          scheduler?.updateJobs(state.jobs);
+          result = `✓ Updated "${params.name}"`;
+          break;
+        }
+
+        case 'remove': {
+          if (!params.name) {
+            result = 'Missing required field: name';
+            break;
+          }
+          const idx = state.jobs.findIndex((j) => j.name === params.name);
+          if (idx === -1) {
+            result = `Job "${params.name}" not found.`;
+            break;
+          }
+          state.jobs.splice(idx, 1);
+          await writeState(statePath, state);
+          scheduler?.updateJobs(state.jobs);
+          result = `✓ Removed "${params.name}"`;
+          break;
+        }
+
+        case 'enable': {
+          if (!params.name) {
+            result = 'Missing required field: name';
+            break;
+          }
+          const job = state.jobs.find((j) => j.name === params.name);
+          if (!job) {
+            result = `Job "${params.name}" not found.`;
+            break;
+          }
+          job.disabled = false;
+          await writeState(statePath, state);
+          scheduler?.updateJobs(state.jobs);
+          result = `✓ Enabled "${params.name}"`;
+          break;
+        }
+
+        case 'disable': {
+          if (!params.name) {
+            result = 'Missing required field: name';
+            break;
+          }
+          const job = state.jobs.find((j) => j.name === params.name);
+          if (!job) {
+            result = `Job "${params.name}" not found.`;
+            break;
+          }
+          job.disabled = true;
+          await writeState(statePath, state);
+          scheduler?.updateJobs(state.jobs);
+          result = `✓ Disabled "${params.name}"`;
+          break;
+        }
+
+        case 'run': {
+          if (!params.name) {
+            result = 'Missing required field: name';
+            break;
+          }
+          if (!scheduler?.isRunning()) {
+            result =
+              'Scheduler is not active. Use `/cron on` to start it first.';
+            break;
+          }
+          result = scheduler.runNow(params.name);
+          break;
+        }
+
+        default:
+          result = `Unknown action: ${params.action}`;
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: result }],
+        details: {},
+      };
+    },
+
+    renderCall(args, theme) {
+      let text = theme.fg('toolTitle', theme.bold('cron '));
+      text += theme.fg('muted', args.action);
+      if (args.name) text += ` ${theme.fg('accent', args.name)}`;
+      if (args.schedule) text += ` ${theme.fg('dim', args.schedule)}`;
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const text = result.content[0];
+      const msg = text?.type === 'text' ? text.text : '';
+      if (msg.startsWith('Error:') || msg.includes('not found')) {
+        return new Text(theme.fg('error', msg), 0, 0);
+      }
+      return new Text(
+        theme.fg('success', '✓ ') + theme.fg('muted', msg),
+        0,
+        0,
+      );
+    },
+  });
+}

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -413,10 +413,9 @@ export default function (pi: ExtensionAPI) {
                 await appendRunResult(runResult);
               })
               .catch((err) => {
-                logError('job:adhoc-crash', {
-                  job: runJob.name,
-                  error: err instanceof Error ? err.message : 'unknown',
-                });
+                const msg = err instanceof Error ? err.message : String(err);
+                logError('job:adhoc-crash', { job: runJob.name, error: msg });
+                console.error(`[cron] adhoc run crashed: ${runJob.name}`, err);
               });
           }
           break;

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -18,7 +18,7 @@ import { Type } from '@sinclair/typebox';
 import type { CronState, CronJob, CronRunResult } from '../shared/types';
 import { DEFAULT_CRON_STATE, MAX_RUN_RESULTS } from '../shared/types';
 import { validateCron } from '../shared/cron';
-import { CronScheduler } from './scheduler';
+import { CronScheduler, runPiSubprocess } from './scheduler';
 
 // ── State file path ────────────────────────────────────────────
 
@@ -357,12 +357,32 @@ export default function (pi: ExtensionAPI) {
             result = 'Missing required field: name';
             break;
           }
-          if (!scheduler?.isRunning()) {
-            result =
-              'Scheduler is not active. Use `/cron on` to start it first.';
+          const runJob = state.jobs.find((j) => j.name === params.name);
+          if (!runJob) {
+            result = `Job "${params.name}" not found.`;
             break;
           }
-          result = scheduler.runNow(params.name);
+          // Run directly — no scheduler required. The scheduler is for
+          // timed execution; ad-hoc "run now" just spawns the subprocess.
+          result = `✓ Triggered "${params.name}" — running in background`;
+          {
+            // Fire-and-forget: spawn subprocess + record result
+            const startedAt = new Date();
+            runPiSubprocess(runJob.prompt, runJob.model)
+              .then(async (sub) => {
+                const durationMs = Date.now() - startedAt.getTime();
+                const ok = sub.exitCode === 0 || !!sub.stdout;
+                const runResult: CronRunResult = {
+                  jobName: runJob.name,
+                  startedAt: startedAt.toISOString(),
+                  durationMs,
+                  ok,
+                  error: ok ? undefined : (sub.stderr || `Exit code ${sub.exitCode}`).slice(0, 2000),
+                };
+                await appendRunResult(runResult);
+              })
+              .catch(() => {});
+          }
           break;
         }
 

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -19,6 +19,7 @@ import type { CronState, CronJob, CronRunResult } from '../shared/types';
 import { DEFAULT_CRON_STATE, MAX_RUN_RESULTS } from '../shared/types';
 import { validateCron } from '../shared/cron';
 import { CronScheduler, runPiSubprocess } from './scheduler';
+import { initLogger, setLogPath, info, warn, error as logError } from './logger';
 
 // ── State file path ────────────────────────────────────────────
 
@@ -116,8 +117,14 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function startScheduler(): Promise<string> {
-    if (scheduler?.isRunning()) return 'Scheduler is already running.';
-    if (!statePath) return 'Error: no state path resolved.';
+    if (scheduler?.isRunning()) {
+      warn('scheduler:start-skipped', { reason: 'already running' });
+      return 'Scheduler is already running.';
+    }
+    if (!statePath) {
+      logError('scheduler:start-failed', { reason: 'no state path' });
+      return 'Error: no state path resolved.';
+    }
 
     const state = await readState(statePath);
     scheduler = createScheduler();
@@ -130,7 +137,10 @@ export default function (pi: ExtensionAPI) {
   }
 
   async function stopScheduler(): Promise<string> {
-    if (!scheduler?.isRunning()) return 'Scheduler is not running.';
+    if (!scheduler?.isRunning()) {
+      warn('scheduler:stop-skipped', { reason: 'not running' });
+      return 'Scheduler is not running.';
+    }
     scheduler.stop();
     scheduler = null;
 
@@ -147,16 +157,19 @@ export default function (pi: ExtensionAPI) {
 
   pi.on('session_start', async (_event, ctx) => {
     statePath = resolveStatePath(ctx.cwd);
+    initLogger(pi, statePath);
+    info('session:start', { cwd: ctx.cwd, statePath });
+
     const state = await readState(statePath);
 
     if (state.autostart && state.jobs.length > 0) {
-      // Autostart: boot the scheduler immediately
+      info('scheduler:autostart', { jobs: state.jobs.length });
       scheduler = createScheduler();
       scheduler.start(state.jobs);
       state.schedulerActive = true;
       await writeState(statePath, state);
     } else if (state.schedulerActive) {
-      // Reset stale flag (scheduler doesn't survive restarts)
+      info('scheduler:reset-stale-flag');
       state.schedulerActive = false;
       await writeState(statePath, state);
     }
@@ -164,9 +177,12 @@ export default function (pi: ExtensionAPI) {
 
   pi.on('session_switch', async (_event, ctx) => {
     statePath = resolveStatePath(ctx.cwd);
+    setLogPath(statePath);
+    info('session:switch', { cwd: ctx.cwd });
   });
 
   pi.on('session_shutdown', async () => {
+    info('session:shutdown', { schedulerWasRunning: scheduler?.isRunning() ?? false });
     if (scheduler?.isRunning()) {
       scheduler.stop();
       scheduler = null;
@@ -212,12 +228,14 @@ export default function (pi: ExtensionAPI) {
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : statePath;
       if (!resolvedPath) {
+        logError('tool:no-state-path');
         return {
           content: [{ type: 'text', text: 'Error: no state path' }],
           details: {},
         };
       }
       statePath = resolvedPath;
+      info('tool:execute', { action: params.action, name: params.name });
       const state = await readState(statePath);
       let result: string;
 
@@ -364,6 +382,10 @@ export default function (pi: ExtensionAPI) {
           }
           // Run directly — no scheduler required. The scheduler is for
           // timed execution; ad-hoc "run now" just spawns the subprocess.
+          info('job:trigger-adhoc', {
+            job: runJob.name,
+            model: runJob.model ?? 'default',
+          });
           result = `✓ Triggered "${params.name}" — running in background`;
           {
             // Fire-and-forget: spawn subprocess + record result
@@ -379,9 +401,23 @@ export default function (pi: ExtensionAPI) {
                   ok,
                   error: ok ? undefined : (sub.stderr || `Exit code ${sub.exitCode}`).slice(0, 2000),
                 };
+                if (ok) {
+                  info('job:adhoc-complete', { job: runJob.name, durationMs });
+                } else {
+                  logError('job:adhoc-failed', {
+                    job: runJob.name,
+                    durationMs,
+                    error: runResult.error?.slice(0, 500),
+                  });
+                }
                 await appendRunResult(runResult);
               })
-              .catch(() => {});
+              .catch((err) => {
+                logError('job:adhoc-crash', {
+                  job: runJob.name,
+                  error: err instanceof Error ? err.message : 'unknown',
+                });
+              });
           }
           break;
         }

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -93,6 +93,7 @@ const CronParams = Type.Object({
 // ── Extension ──────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
+  console.log('[cron] extension loaded');
   let statePath = '';
   let scheduler: CronScheduler | null = null;
 
@@ -235,6 +236,8 @@ export default function (pi: ExtensionAPI) {
         };
       }
       statePath = resolvedPath;
+      // Ensure logger is initialised (session_start may not have fired yet)
+      initLogger(pi, statePath);
       info('tool:execute', { action: params.action, name: params.name });
       const state = await readState(statePath);
       let result: string;

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -15,11 +15,15 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Text } from '@mariozechner/pi-tui';
 import { Type } from '@sinclair/typebox';
 
-import type { CronState, CronJob, CronRunResult } from '../shared/types';
+import type { CronState, CronRunResult } from '../shared/types';
 import { DEFAULT_CRON_STATE, MAX_RUN_RESULTS } from '../shared/types';
-import { validateCron } from '../shared/cron';
-import { CronScheduler, runPiSubprocess } from './scheduler';
+import { CronScheduler } from './scheduler';
 import { initLogger, setLogPath, info, warn, error as logError } from './logger';
+import {
+  handleList, handleAdd, handleUpdate, handleRemove,
+  handleToggle, handleRun,
+  type ActionDeps,
+} from './actions';
 
 // ── State file path ────────────────────────────────────────────
 
@@ -33,7 +37,21 @@ function resolveStatePath(cwd: string): string {
   return path.join(cwd, STATE_REL_PATH);
 }
 
-// ── File I/O (atomic writes) ───────────────────────────────────
+// ── File I/O (atomic writes with mutex) ────────────────────────
+
+/**
+ * Simple async mutex to serialise read-modify-write cycles on state.json.
+ * Prevents concurrent tool calls or scheduler callbacks from clobbering
+ * each other's writes.
+ */
+let stateMutexQueue: Promise<void> = Promise.resolve();
+
+function withStateLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = stateMutexQueue;
+  let resolve: () => void;
+  stateMutexQueue = new Promise<void>((r) => { resolve = r; });
+  return prev.then(fn).finally(() => resolve!());
+}
 
 async function readState(filePath: string): Promise<CronState> {
   try {
@@ -102,12 +120,14 @@ export default function (pi: ExtensionAPI) {
 
   async function appendRunResult(result: CronRunResult): Promise<void> {
     if (!statePath) return;
-    const state = await readState(statePath);
-    state.lastRunResults.unshift(result);
-    if (state.lastRunResults.length > MAX_RUN_RESULTS) {
-      state.lastRunResults = state.lastRunResults.slice(0, MAX_RUN_RESULTS);
-    }
-    await writeState(statePath, state);
+    await withStateLock(async () => {
+      const state = await readState(statePath);
+      state.lastRunResults.unshift(result);
+      if (state.lastRunResults.length > MAX_RUN_RESULTS) {
+        state.lastRunResults = state.lastRunResults.slice(0, MAX_RUN_RESULTS);
+      }
+      await writeState(statePath, state);
+    });
   }
 
   function createScheduler(): CronScheduler {
@@ -245,200 +265,33 @@ export default function (pi: ExtensionAPI) {
         };
       }
       statePath = resolvedPath;
-      // Ensure logger is initialised (session_start may not have fired yet)
       initLogger(pi, statePath);
       info('tool:execute', { action: params.action, name: params.name });
-      const state = await readState(statePath);
-      let result: string;
 
-      switch (params.action) {
-        case 'list': {
-          if (state.jobs.length === 0) {
-            result = 'No cron jobs configured.';
-          } else {
-            const running = scheduler?.getRunningNames() ?? [];
-            const lines = state.jobs.map((j) => {
-              const status = j.disabled
-                ? '⏸ disabled'
-                : running.includes(j.name)
-                  ? '🔄 running'
-                  : '✅ active';
-              const ch = j.channel !== 'cron' ? ` [${j.channel}]` : '';
-              const mdl = j.model ? ` (${j.model})` : '';
-              return `- **${j.name}** \`${j.schedule}\` ${status}${ch}${mdl}\n  ${j.prompt.slice(0, 80)}`;
-            });
-            const note = scheduler?.isRunning()
-              ? ''
-              : '\n\n⚠️ Scheduler is inactive. Use `/cron on` to start.';
-            result = `**Cron Jobs (${state.jobs.length}):**\n\n${lines.join('\n\n')}${note}`;
-          }
-          break;
+      // Serialise state mutations to prevent concurrent read-modify-write races
+      const result = await withStateLock(async () => {
+        const state = await readState(statePath);
+        const deps: ActionDeps = {
+          state,
+          statePath,
+          scheduler,
+          workspaceCwd,
+          writeState,
+          appendRunResult,
+          ctxCwd: ctx?.cwd,
+        };
+
+        switch (params.action) {
+          case 'list':    return handleList(deps);
+          case 'add':     return handleAdd(params, deps);
+          case 'update':  return handleUpdate(params, deps);
+          case 'remove':  return handleRemove(params, deps);
+          case 'enable':  return handleToggle(params, deps, false);
+          case 'disable': return handleToggle(params, deps, true);
+          case 'run':     return handleRun(params, deps);
+          default:        return `Unknown action: ${params.action}`;
         }
-
-        case 'add': {
-          if (!params.name || !params.schedule || !params.prompt) {
-            result = 'Missing required fields: name, schedule, and prompt.';
-            break;
-          }
-          const err = validateCron(params.schedule);
-          if (err) {
-            result = `Invalid cron expression: ${err}`;
-            break;
-          }
-          if (state.jobs.find((j) => j.name === params.name)) {
-            result = `Job "${params.name}" already exists.`;
-            break;
-          }
-          const newJob: CronJob = {
-            name: params.name,
-            schedule: params.schedule,
-            prompt: params.prompt,
-            channel: params.channel ?? 'cron',
-            disabled: false,
-          };
-          if (params.model) newJob.model = params.model;
-          state.jobs.push(newJob);
-          await writeState(statePath, state);
-          scheduler?.updateJobs(state.jobs);
-          result = `✓ Added cron job "${params.name}" (${params.schedule})`;
-          break;
-        }
-
-        case 'update': {
-          if (!params.name) {
-            result = 'Missing required field: name';
-            break;
-          }
-          const job = state.jobs.find((j) => j.name === params.name);
-          if (!job) {
-            result = `Job "${params.name}" not found.`;
-            break;
-          }
-          if (params.schedule) {
-            const err = validateCron(params.schedule);
-            if (err) {
-              result = `Invalid cron expression: ${err}`;
-              break;
-            }
-            job.schedule = params.schedule;
-          }
-          if (params.prompt) job.prompt = params.prompt;
-          if (params.channel) job.channel = params.channel;
-          if (params.model !== undefined) job.model = params.model || undefined;
-          await writeState(statePath, state);
-          scheduler?.updateJobs(state.jobs);
-          result = `✓ Updated "${params.name}"`;
-          break;
-        }
-
-        case 'remove': {
-          if (!params.name) {
-            result = 'Missing required field: name';
-            break;
-          }
-          const idx = state.jobs.findIndex((j) => j.name === params.name);
-          if (idx === -1) {
-            result = `Job "${params.name}" not found.`;
-            break;
-          }
-          state.jobs.splice(idx, 1);
-          await writeState(statePath, state);
-          scheduler?.updateJobs(state.jobs);
-          result = `✓ Removed "${params.name}"`;
-          break;
-        }
-
-        case 'enable': {
-          if (!params.name) {
-            result = 'Missing required field: name';
-            break;
-          }
-          const job = state.jobs.find((j) => j.name === params.name);
-          if (!job) {
-            result = `Job "${params.name}" not found.`;
-            break;
-          }
-          job.disabled = false;
-          await writeState(statePath, state);
-          scheduler?.updateJobs(state.jobs);
-          result = `✓ Enabled "${params.name}"`;
-          break;
-        }
-
-        case 'disable': {
-          if (!params.name) {
-            result = 'Missing required field: name';
-            break;
-          }
-          const job = state.jobs.find((j) => j.name === params.name);
-          if (!job) {
-            result = `Job "${params.name}" not found.`;
-            break;
-          }
-          job.disabled = true;
-          await writeState(statePath, state);
-          scheduler?.updateJobs(state.jobs);
-          result = `✓ Disabled "${params.name}"`;
-          break;
-        }
-
-        case 'run': {
-          if (!params.name) {
-            result = 'Missing required field: name';
-            break;
-          }
-          const runJob = state.jobs.find((j) => j.name === params.name);
-          if (!runJob) {
-            result = `Job "${params.name}" not found.`;
-            break;
-          }
-          // Run directly — no scheduler required. The scheduler is for
-          // timed execution; ad-hoc "run now" just spawns the subprocess.
-          // Use ctx.cwd if available (tool context), fall back to stored workspace cwd
-          const runCwd = (ctx ? ctx.cwd : workspaceCwd) || workspaceCwd;
-          info('job:trigger-adhoc', {
-            job: runJob.name,
-            model: runJob.model ?? 'default',
-            cwd: runCwd,
-          });
-          result = `✓ Triggered "${params.name}" — running in background`;
-          {
-            // Fire-and-forget: spawn subprocess + record result
-            const startedAt = new Date();
-            runPiSubprocess(runJob.prompt, { model: runJob.model, cwd: runCwd })
-              .then(async (sub) => {
-                const durationMs = Date.now() - startedAt.getTime();
-                const ok = sub.exitCode === 0 || !!sub.stdout;
-                const runResult: CronRunResult = {
-                  jobName: runJob.name,
-                  startedAt: startedAt.toISOString(),
-                  durationMs,
-                  ok,
-                  error: ok ? undefined : (sub.stderr || `Exit code ${sub.exitCode}`).slice(0, 2000),
-                };
-                if (ok) {
-                  info('job:adhoc-complete', { job: runJob.name, durationMs });
-                } else {
-                  logError('job:adhoc-failed', {
-                    job: runJob.name,
-                    durationMs,
-                    error: runResult.error?.slice(0, 500),
-                  });
-                }
-                await appendRunResult(runResult);
-              })
-              .catch((err) => {
-                const msg = err instanceof Error ? err.message : String(err);
-                logError('job:adhoc-crash', { job: runJob.name, error: msg });
-                console.error(`[cron] adhoc run crashed: ${runJob.name}`, err);
-              });
-          }
-          break;
-        }
-
-        default:
-          result = `Unknown action: ${params.action}`;
-      }
+      });
 
       return {
         content: [{ type: 'text' as const, text: result }],

--- a/packages/pi-cron-extension/extension/logger.ts
+++ b/packages/pi-cron-extension/extension/logger.ts
@@ -1,0 +1,92 @@
+/**
+ * File-based logger for the cron extension.
+ *
+ * Writes structured log lines to ~/.sero-ui/apps/cron/cron.log (Sero)
+ * or .sero/apps/cron/cron.log (Pi CLI fallback). Rotates at 1 MB.
+ *
+ * Also emits to the Pi event bus (channel: "cron") so other extensions
+ * or the host can subscribe.
+ */
+
+import { appendFileSync, statSync, renameSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
+
+const CHANNEL = 'cron';
+const MAX_LOG_SIZE = 1_048_576; // 1 MB
+
+let logFilePath: string | null = null;
+let piRef: ExtensionAPI | null = null;
+
+// ── Setup ──────────────────────────────────────────────────────
+
+/** Initialise the logger. Call once from the extension entry point. */
+export function initLogger(pi: ExtensionAPI, statePath: string): void {
+  piRef = pi;
+  logFilePath = path.join(path.dirname(statePath), 'cron.log');
+
+  // Ensure directory exists
+  try {
+    mkdirSync(path.dirname(logFilePath), { recursive: true });
+  } catch {
+    // ignore — directory may already exist
+  }
+}
+
+/** Update the log path (e.g. on session_switch). */
+export function setLogPath(statePath: string): void {
+  logFilePath = path.join(path.dirname(statePath), 'cron.log');
+}
+
+// ── Core ───────────────────────────────────────────────────────
+
+/** Write a structured log entry. */
+export function log(
+  level: LogLevel,
+  event: string,
+  data?: Record<string, unknown>,
+): void {
+  const ts = new Date().toISOString();
+  const payload = data ? ` ${JSON.stringify(data)}` : '';
+  const line = `${ts} [${level}] ${event}${payload}\n`;
+
+  // ── File ──────────────────────────────────────────────────
+  if (logFilePath) {
+    try {
+      rotateIfNeeded();
+      appendFileSync(logFilePath, line, 'utf8');
+    } catch {
+      // Swallow — logging must never crash the extension
+    }
+  }
+
+  // ── Event bus (for host / other extensions) ───────────────
+  piRef?.events.emit('log', { channel: CHANNEL, event, level, data });
+}
+
+// ── Rotation ───────────────────────────────────────────────────
+
+function rotateIfNeeded(): void {
+  if (!logFilePath) return;
+  try {
+    const { size } = statSync(logFilePath);
+    if (size >= MAX_LOG_SIZE) {
+      renameSync(logFilePath, `${logFilePath}.1`);
+    }
+  } catch {
+    // File may not exist yet — that's fine
+  }
+}
+
+// ── Convenience helpers ────────────────────────────────────────
+
+export const info = (event: string, data?: Record<string, unknown>) =>
+  log('INFO', event, data);
+
+export const warn = (event: string, data?: Record<string, unknown>) =>
+  log('WARN', event, data);
+
+export const error = (event: string, data?: Record<string, unknown>) =>
+  log('ERROR', event, data);

--- a/packages/pi-cron-extension/extension/logger.ts
+++ b/packages/pi-cron-extension/extension/logger.ts
@@ -4,8 +4,8 @@
  * Writes structured log lines to ~/.sero-ui/apps/cron/cron.log (Sero)
  * or .sero/apps/cron/cron.log (Pi CLI fallback). Rotates at 1 MB.
  *
- * Also emits to the Pi event bus (channel: "cron") so other extensions
- * or the host can subscribe.
+ * Always logs to console as well so errors appear in
+ * /tmp/sero-electron.log even if the file logger isn't initialised.
  */
 
 import { appendFileSync, statSync, renameSync, mkdirSync } from 'node:fs';
@@ -14,6 +14,7 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
 export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
 
+const TAG = '[cron]';
 const CHANNEL = 'cron';
 const MAX_LOG_SIZE = 1_048_576; // 1 MB
 
@@ -27,11 +28,10 @@ export function initLogger(pi: ExtensionAPI, statePath: string): void {
   piRef = pi;
   logFilePath = path.join(path.dirname(statePath), 'cron.log');
 
-  // Ensure directory exists
   try {
     mkdirSync(path.dirname(logFilePath), { recursive: true });
   } catch {
-    // ignore — directory may already exist
+    // directory may already exist
   }
 }
 
@@ -50,20 +50,34 @@ export function log(
 ): void {
   const ts = new Date().toISOString();
   const payload = data ? ` ${JSON.stringify(data)}` : '';
-  const line = `${ts} [${level}] ${event}${payload}\n`;
+  const line = `${ts} [${level}] ${event}${payload}`;
+
+  // ── Console (always — shows up in /tmp/sero-electron.log) ─
+  const consoleLine = `${TAG} ${line}`;
+  if (level === 'ERROR') {
+    console.error(consoleLine);
+  } else if (level === 'WARN') {
+    console.warn(consoleLine);
+  } else {
+    console.log(consoleLine);
+  }
 
   // ── File ──────────────────────────────────────────────────
   if (logFilePath) {
     try {
       rotateIfNeeded();
-      appendFileSync(logFilePath, line, 'utf8');
+      appendFileSync(logFilePath, line + '\n', 'utf8');
     } catch {
       // Swallow — logging must never crash the extension
     }
   }
 
   // ── Event bus (for host / other extensions) ───────────────
-  piRef?.events.emit('log', { channel: CHANNEL, event, level, data });
+  try {
+    piRef?.events.emit('log', { channel: CHANNEL, event, level, data });
+  } catch {
+    // event bus may not be ready
+  }
 }
 
 // ── Rotation ───────────────────────────────────────────────────

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -17,7 +17,7 @@ interface RunResult {
   exitCode: number;
 }
 
-function runPiSubprocess(
+export function runPiSubprocess(
   prompt: string,
   model?: string,
   timeoutMs = 600_000,

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -1,0 +1,178 @@
+/**
+ * Cron scheduler — ticks every 30s, matches jobs against local time,
+ * and spawns isolated `pi -p` subprocesses.
+ *
+ * Adapted from pi-cron for Sero's JSON state format.
+ */
+
+import { spawn } from 'node:child_process';
+import type { CronJob, CronRunResult } from '../shared/types';
+import { matchesCron } from '../shared/cron';
+
+// ── Subprocess runner ───────────────────────────────────────────
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+function runPiSubprocess(
+  prompt: string,
+  model?: string,
+  timeoutMs = 600_000,
+): Promise<RunResult> {
+  return new Promise((resolve) => {
+    const args = ['-p', '--no-session', '--no-extensions'];
+    if (model) args.push('--model', model);
+    args.push(prompt);
+
+    const child = spawn('pi', args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+      timeout: timeoutMs,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+
+    child.on('error', (err) => {
+      resolve({ stdout, stderr: `${stderr}\n${err.message}`, exitCode: 1 });
+    });
+  });
+}
+
+// ── Event types ─────────────────────────────────────────────────
+
+export interface SchedulerCallbacks {
+  onJobStart?: (job: CronJob) => void;
+  onJobComplete?: (result: CronRunResult) => void;
+}
+
+// ── Scheduler ───────────────────────────────────────────────────
+
+const TICK_INTERVAL_MS = 30_000;
+
+export class CronScheduler {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private lastTickMinute = '';
+  private running = new Set<string>();
+  private jobs: CronJob[] = [];
+  private callbacks: SchedulerCallbacks;
+
+  constructor(callbacks?: SchedulerCallbacks) {
+    this.callbacks = callbacks ?? {};
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────
+
+  start(jobs: CronJob[]): void {
+    if (this.timer) return;
+    this.jobs = jobs;
+    this.tick();
+    this.timer = setInterval(() => this.tick(), TICK_INTERVAL_MS);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  isRunning(): boolean {
+    return this.timer !== null;
+  }
+
+  /** Update the jobs list (called when state changes externally). */
+  updateJobs(jobs: CronJob[]): void {
+    this.jobs = jobs;
+  }
+
+  /** Get names of currently executing jobs. */
+  getRunningNames(): string[] {
+    return [...this.running];
+  }
+
+  // ── Run now ─────────────────────────────────────────────
+
+  runNow(name: string): string {
+    const job = this.jobs.find((j) => j.name === name);
+    if (!job) return `Job "${name}" not found.`;
+    if (this.running.has(name)) return `Job "${name}" is already running.`;
+
+    this.running.add(name);
+    this.execute(job).finally(() => this.running.delete(name));
+    return `✓ Triggered "${name}"`;
+  }
+
+  // ── Tick ──────────────────────────────────────────────────
+
+  private tick(): void {
+    const now = new Date();
+    const currentMinute = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}`;
+
+    // Only fire once per minute
+    if (currentMinute === this.lastTickMinute) return;
+    this.lastTickMinute = currentMinute;
+
+    for (const job of this.jobs) {
+      if (job.disabled || this.running.has(job.name)) continue;
+
+      try {
+        if (!matchesCron(job.schedule, now)) continue;
+      } catch {
+        continue;
+      }
+
+      this.running.add(job.name);
+      this.execute(job).finally(() => this.running.delete(job.name));
+    }
+  }
+
+  private async execute(job: CronJob): Promise<void> {
+    const startedAt = new Date();
+    this.callbacks.onJobStart?.(job);
+
+    try {
+      const result = await runPiSubprocess(job.prompt, job.model);
+      const durationMs = Date.now() - startedAt.getTime();
+
+      if (result.exitCode !== 0 && !result.stdout) {
+        throw new Error(
+          result.stderr || `Process exited with code ${result.exitCode}`,
+        );
+      }
+
+      this.callbacks.onJobComplete?.({
+        jobName: job.name,
+        startedAt: startedAt.toISOString(),
+        durationMs,
+        ok: true,
+      });
+    } catch (err: unknown) {
+      const durationMs = Date.now() - startedAt.getTime();
+      const message =
+        err instanceof Error ? err.message.slice(0, 2000) : 'Unknown error';
+
+      this.callbacks.onJobComplete?.({
+        jobName: job.name,
+        startedAt: startedAt.toISOString(),
+        durationMs,
+        ok: false,
+        error: message,
+      });
+    }
+  }
+}

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -12,6 +12,9 @@ import { info, warn, error as logError } from './logger';
 
 // ── Subprocess runner ───────────────────────────────────────────
 
+/** Maximum buffer size per stream (1 MB). Prevents OOM on chatty jobs. */
+const MAX_BUFFER = 1_048_576;
+
 interface RunResult {
   stdout: string;
   stderr: string;
@@ -63,10 +66,16 @@ export function runPiSubprocess(
     let stderr = '';
 
     child.stdout.on('data', (chunk: Buffer) => {
-      stdout += chunk.toString();
+      if (stdout.length < MAX_BUFFER) {
+        stdout += chunk.toString();
+        if (stdout.length > MAX_BUFFER) stdout = stdout.slice(0, MAX_BUFFER);
+      }
     });
     child.stderr.on('data', (chunk: Buffer) => {
-      stderr += chunk.toString();
+      if (stderr.length < MAX_BUFFER) {
+        stderr += chunk.toString();
+        if (stderr.length > MAX_BUFFER) stderr = stderr.slice(0, MAX_BUFFER);
+      }
     });
 
     child.on('close', (code) => {

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -32,13 +32,23 @@ export function runPiSubprocess(
       model: model ?? 'default',
       promptLen: prompt.length,
       timeoutMs,
+      args: args.slice(0, -1), // log flags, not the full prompt
     });
 
-    const child = spawn('pi', args, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env },
-      timeout: timeoutMs,
-    });
+    let child;
+    try {
+      child = spawn('pi', args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+        timeout: timeoutMs,
+      });
+    } catch (err) {
+      // spawn can throw synchronously (e.g. ENOENT before event loop)
+      const msg = err instanceof Error ? err.message : String(err);
+      logError('subprocess:spawn-failed', { error: msg });
+      resolve({ stdout: '', stderr: msg, exitCode: 1 });
+      return;
+    }
 
     let stdout = '';
     let stderr = '';

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -8,6 +8,7 @@
 import { spawn } from 'node:child_process';
 import type { CronJob, CronRunResult } from '../shared/types';
 import { matchesCron } from '../shared/cron';
+import { info, warn, error as logError } from './logger';
 
 // ── Subprocess runner ───────────────────────────────────────────
 
@@ -27,6 +28,12 @@ export function runPiSubprocess(
     if (model) args.push('--model', model);
     args.push(prompt);
 
+    info('subprocess:spawn', {
+      model: model ?? 'default',
+      promptLen: prompt.length,
+      timeoutMs,
+    });
+
     const child = spawn('pi', args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env },
@@ -44,10 +51,18 @@ export function runPiSubprocess(
     });
 
     child.on('close', (code) => {
+      const level = code === 0 || stdout ? 'ok' : 'fail';
+      info('subprocess:exit', {
+        exitCode: code ?? 1,
+        level,
+        stdoutLen: stdout.length,
+        stderrLen: stderr.length,
+      });
       resolve({ stdout, stderr, exitCode: code ?? 1 });
     });
 
     child.on('error', (err) => {
+      logError('subprocess:error', { error: err.message });
       resolve({ stdout, stderr: `${stderr}\n${err.message}`, exitCode: 1 });
     });
   });
@@ -80,6 +95,8 @@ export class CronScheduler {
   start(jobs: CronJob[]): void {
     if (this.timer) return;
     this.jobs = jobs;
+    const enabled = jobs.filter((j) => !j.disabled).length;
+    info('scheduler:start', { totalJobs: jobs.length, enabled });
     this.tick();
     this.timer = setInterval(() => this.tick(), TICK_INTERVAL_MS);
   }
@@ -88,6 +105,7 @@ export class CronScheduler {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+      info('scheduler:stop', { runningJobs: [...this.running] });
     }
   }
 
@@ -110,8 +128,12 @@ export class CronScheduler {
   runNow(name: string): string {
     const job = this.jobs.find((j) => j.name === name);
     if (!job) return `Job "${name}" not found.`;
-    if (this.running.has(name)) return `Job "${name}" is already running.`;
+    if (this.running.has(name)) {
+      warn('job:already-running', { job: name });
+      return `Job "${name}" is already running.`;
+    }
 
+    info('job:trigger-manual', { job: name });
     this.running.add(name);
     this.execute(job).finally(() => this.running.delete(name));
     return `✓ Triggered "${name}"`;
@@ -132,10 +154,16 @@ export class CronScheduler {
 
       try {
         if (!matchesCron(job.schedule, now)) continue;
-      } catch {
+      } catch (err) {
+        warn('job:bad-schedule', {
+          job: job.name,
+          schedule: job.schedule,
+          error: err instanceof Error ? err.message : 'parse error',
+        });
         continue;
       }
 
+      info('job:trigger-scheduled', { job: job.name, schedule: job.schedule });
       this.running.add(job.name);
       this.execute(job).finally(() => this.running.delete(job.name));
     }
@@ -143,6 +171,11 @@ export class CronScheduler {
 
   private async execute(job: CronJob): Promise<void> {
     const startedAt = new Date();
+    info('job:start', {
+      job: job.name,
+      model: job.model ?? 'default',
+      promptLen: job.prompt.length,
+    });
     this.callbacks.onJobStart?.(job);
 
     try {
@@ -155,6 +188,7 @@ export class CronScheduler {
         );
       }
 
+      info('job:complete', { job: job.name, durationMs, ok: true });
       this.callbacks.onJobComplete?.({
         jobName: job.name,
         startedAt: startedAt.toISOString(),
@@ -166,6 +200,12 @@ export class CronScheduler {
       const message =
         err instanceof Error ? err.message.slice(0, 2000) : 'Unknown error';
 
+      logError('job:complete', {
+        job: job.name,
+        durationMs,
+        ok: false,
+        error: message.slice(0, 500),
+      });
       this.callbacks.onJobComplete?.({
         jobName: job.name,
         startedAt: startedAt.toISOString(),

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -18,18 +18,26 @@ interface RunResult {
   exitCode: number;
 }
 
+export interface SubprocessOptions {
+  model?: string;
+  cwd?: string;
+  timeoutMs?: number;
+}
+
 export function runPiSubprocess(
   prompt: string,
-  model?: string,
-  timeoutMs = 600_000,
+  opts: SubprocessOptions = {},
 ): Promise<RunResult> {
+  const { model, cwd, timeoutMs = 600_000 } = opts;
+
   return new Promise((resolve) => {
-    const args = ['-p', '--no-session', '--no-extensions'];
+    const args = ['-p', '--no-session'];
     if (model) args.push('--model', model);
     args.push(prompt);
 
     info('subprocess:spawn', {
       model: model ?? 'default',
+      cwd: cwd ?? process.cwd(),
       promptLen: prompt.length,
       timeoutMs,
       args: args.slice(0, -1), // log flags, not the full prompt
@@ -39,7 +47,8 @@ export function runPiSubprocess(
     try {
       child = spawn('pi', args, {
         stdio: ['ignore', 'pipe', 'pipe'],
-        env: { ...process.env },
+        env: { ...process.env, SERO_CRON_SUBPROCESS: '1' },
+        cwd: cwd || undefined,
         timeout: timeoutMs,
       });
     } catch (err) {
@@ -61,12 +70,15 @@ export function runPiSubprocess(
     });
 
     child.on('close', (code) => {
-      const level = code === 0 || stdout ? 'ok' : 'fail';
+      const ok = code === 0 || !!stdout;
       info('subprocess:exit', {
         exitCode: code ?? 1,
-        level,
+        ok,
         stdoutLen: stdout.length,
         stderrLen: stderr.length,
+        // Log first 500 chars of output for debugging
+        stdoutPreview: stdout.slice(0, 500),
+        ...(stderr && { stderrPreview: stderr.slice(0, 500) }),
       });
       resolve({ stdout, stderr, exitCode: code ?? 1 });
     });
@@ -95,6 +107,7 @@ export class CronScheduler {
   private running = new Set<string>();
   private jobs: CronJob[] = [];
   private callbacks: SchedulerCallbacks;
+  private cwd: string | undefined;
 
   constructor(callbacks?: SchedulerCallbacks) {
     this.callbacks = callbacks ?? {};
@@ -102,11 +115,12 @@ export class CronScheduler {
 
   // ── Lifecycle ───────────────────────────────────────────
 
-  start(jobs: CronJob[]): void {
+  start(jobs: CronJob[], cwd?: string): void {
     if (this.timer) return;
     this.jobs = jobs;
+    this.cwd = cwd;
     const enabled = jobs.filter((j) => !j.disabled).length;
-    info('scheduler:start', { totalJobs: jobs.length, enabled });
+    info('scheduler:start', { totalJobs: jobs.length, enabled, cwd });
     this.tick();
     this.timer = setInterval(() => this.tick(), TICK_INTERVAL_MS);
   }
@@ -189,7 +203,10 @@ export class CronScheduler {
     this.callbacks.onJobStart?.(job);
 
     try {
-      const result = await runPiSubprocess(job.prompt, job.model);
+      const result = await runPiSubprocess(job.prompt, {
+        model: job.model,
+        cwd: this.cwd,
+      });
       const durationMs = Date.now() - startedAt.getTime();
 
       if (result.exitCode !== 0 && !result.stdout) {

--- a/packages/pi-cron-extension/extension/tsconfig.json
+++ b/packages/pi-cron-extension/extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023"]
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-cron-extension/package.json
+++ b/packages/pi-cron-extension/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@sero/cron",
+  "version": "0.1.0",
+  "description": "Cron scheduler for Sero — schedule recurring agent prompts",
+  "keywords": [
+    "pi-package"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+  },
+  "pi": {
+    "extensions": [
+      "./extension/index.ts"
+    ]
+  },
+  "sero": {
+    "app": {
+      "id": "cron",
+      "name": "Cron",
+      "icon": "clock",
+      "scope": "global",
+      "stateFile": ".sero/apps/cron/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "CronApp",
+      "devPort": 5188
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": ">=0.55.3",
+    "@mariozechner/pi-coding-agent": ">=0.55.3",
+    "@mariozechner/pi-tui": ">=0.55.3"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "^1.11.0",
+    "@sero/app-runtime": "workspace:*",
+    "@sero/ui": "workspace:*",
+    "@tailwindcss/vite": "^4.1.18",
+    "@types/node": "^22.19.11",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/packages/pi-cron-extension/shared/cron.ts
+++ b/packages/pi-cron-extension/shared/cron.ts
@@ -1,0 +1,112 @@
+/**
+ * Cron expression parser, validator, and human-readable formatter.
+ *
+ * Supports standard 5-field cron: min hour dom month dow
+ * Features: ranges (1-5), steps, lists (1,3,5), wildcards
+ *
+ * Shared between the Pi extension and the web UI.
+ */
+
+// ── Field parser ──────────────────────────────────────────────
+
+function parseField(field: string, min: number, max: number): Set<number> {
+  const values = new Set<number>();
+
+  for (const part of field.split(',')) {
+    const [rangeStr, stepStr] = part.split('/');
+    const step = stepStr ? parseInt(stepStr, 10) : 1;
+
+    if (step < 1 || isNaN(step)) {
+      throw new Error(`Invalid step "${stepStr}" in field "${field}"`);
+    }
+
+    let lo: number;
+    let hi: number;
+
+    if (rangeStr === '*') {
+      lo = min;
+      hi = max;
+    } else if (rangeStr.includes('-')) {
+      const [a, b] = rangeStr.split('-');
+      lo = parseInt(a, 10);
+      hi = parseInt(b, 10);
+    } else {
+      lo = parseInt(rangeStr, 10);
+      hi = lo;
+    }
+
+    if (isNaN(lo) || isNaN(hi)) {
+      throw new Error(`Invalid value in field "${field}"`);
+    }
+    if (lo < min || hi > max) {
+      throw new Error(`Value out of range in "${field}" (allowed ${min}-${max})`);
+    }
+
+    for (let i = lo; i <= hi; i += step) {
+      values.add(i);
+    }
+  }
+
+  return values;
+}
+
+// ── Matcher ───────────────────────────────────────────────────
+
+export function matchesCron(expr: string, date: Date): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error(`Invalid cron expression (need 5 fields): "${expr}"`);
+  }
+
+  return (
+    parseField(fields[0], 0, 59).has(date.getMinutes()) &&
+    parseField(fields[1], 0, 23).has(date.getHours()) &&
+    parseField(fields[2], 1, 31).has(date.getDate()) &&
+    parseField(fields[3], 1, 12).has(date.getMonth() + 1) &&
+    parseField(fields[4], 0, 6).has(date.getDay())
+  );
+}
+
+// ── Validator ─────────────────────────────────────────────────
+
+/** Returns null if valid, error message if invalid. */
+export function validateCron(expr: string): string | null {
+  try {
+    matchesCron(expr, new Date());
+    return null;
+  } catch (err: unknown) {
+    return err instanceof Error ? err.message : 'Invalid cron expression';
+  }
+}
+
+// ── Human-readable format ─────────────────────────────────────
+
+const DOW_NAMES: Record<string, string> = {
+  '0': 'Sun', '1': 'Mon', '2': 'Tue', '3': 'Wed',
+  '4': 'Thu', '5': 'Fri', '6': 'Sat',
+};
+
+export function cronToHuman(expr: string): string {
+  const parts = expr.split(/\s+/);
+  if (parts.length !== 5) return expr;
+
+  const [min, hour, dom, month, dow] = parts;
+
+  if (expr === '* * * * *') return 'Every minute';
+  if (min.startsWith('*/')) return `Every ${min.slice(2)} min`;
+
+  const time = `${hour.padStart(2, '0')}:${min.padStart(2, '0')}`;
+
+  if (hour === '*' && dom === '*' && month === '*' && dow === '*') {
+    return `Minute ${min}, every hour`;
+  }
+  if (dom === '*' && month === '*' && dow === '*') return `Daily at ${time}`;
+  if (dom === '*' && month === '*' && dow === '1-5') return `Weekdays at ${time}`;
+  if (dom === '*' && month === '*' && dow === '0,6') return `Weekends at ${time}`;
+  if (dom === '1' && month === '*' && dow === '*') return `Monthly 1st at ${time}`;
+  if (dom === '*' && month === '*' && DOW_NAMES[dow]) {
+    return `${DOW_NAMES[dow]} at ${time}`;
+  }
+
+  return expr;
+}

--- a/packages/pi-cron-extension/shared/types.ts
+++ b/packages/pi-cron-extension/shared/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared state shape for the Cron app.
+ *
+ * Single source of truth — both the Pi extension and the Sero web UI
+ * read/write a JSON file matching this shape.
+ *
+ * Global-scoped: state lives at ~/.sero-ui/apps/cron/state.json
+ * (shared across all workspaces).
+ */
+
+export interface CronJob {
+  name: string;
+  /** 5-field cron expression: min hour dom month dow */
+  schedule: string;
+  /** Prompt sent to the agent when the job fires */
+  prompt: string;
+  /** Grouping tag (default: "cron") */
+  channel: string;
+  /** Whether the job is disabled (won't execute on schedule) */
+  disabled: boolean;
+  /**
+   * Model pattern or ID (e.g. "sonnet", "openai/gpt-4o", "gemini:high").
+   * Supports "provider/id" shorthand and optional ":<thinking>" suffix.
+   * When unset, the job uses whatever default is in your Pi settings.
+   */
+  model?: string;
+}
+
+export interface CronRunResult {
+  jobName: string;
+  startedAt: string; // ISO string
+  durationMs: number;
+  ok: boolean;
+  error?: string;
+}
+
+export interface CronState {
+  jobs: CronJob[];
+  schedulerActive: boolean;
+  /** Start the scheduler automatically when Sero launches */
+  autostart: boolean;
+  /** Recent execution results (capped at 50) */
+  lastRunResults: CronRunResult[];
+}
+
+export const DEFAULT_CRON_STATE: CronState = {
+  jobs: [],
+  schedulerActive: false,
+  autostart: false,
+  lastRunResults: [],
+};
+
+/** Maximum number of run results to keep */
+export const MAX_RUN_RESULTS = 50;

--- a/packages/pi-cron-extension/ui/CronApp.tsx
+++ b/packages/pi-cron-extension/ui/CronApp.tsx
@@ -1,0 +1,254 @@
+/**
+ * CronApp — Sero web UI for the cron scheduler extension.
+ *
+ * Uses useAppState to read/write the same state.json the Pi extension
+ * writes. Changes from either direction are reflected instantly.
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { useAppState, useAgentPrompt } from '@sero/app-runtime';
+import { Button } from '@sero/ui/components/ui/button';
+import { Card } from '@sero/ui/components/ui/card';
+import type { CronState, CronJob } from '../shared/types';
+import { DEFAULT_CRON_STATE } from '../shared/types';
+import { SchedulerBar } from './components/SchedulerBar';
+import { JobCard } from './components/JobCard';
+import { JobForm } from './components/JobForm';
+import { RunHistory } from './components/RunHistory';
+import './styles.css';
+
+type Tab = 'jobs' | 'history';
+
+export function CronApp() {
+  const [state, updateState] = useAppState<CronState>(DEFAULT_CRON_STATE);
+  const prompt = useAgentPrompt();
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingJob, setEditingJob] = useState<CronJob | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('jobs');
+
+  // ── Derived stats ────────────────────────────────────────
+
+  const stats = useMemo(() => {
+    const total = state.jobs.length;
+    const active = state.jobs.filter((j) => !j.disabled).length;
+    const disabled = total - active;
+    return { total, active, disabled };
+  }, [state.jobs]);
+
+  // ── Scheduler toggle (via agent) ─────────────────────────
+
+  const toggleScheduler = useCallback(() => {
+    if (state.schedulerActive) {
+      prompt('Stop the cron scheduler using /cron off');
+    } else {
+      prompt('Start the cron scheduler using /cron on');
+    }
+  }, [state.schedulerActive, prompt]);
+
+  // ── Autostart toggle ─────────────────────────────────────
+
+  const handleAutostartChange = useCallback(
+    (enabled: boolean) => {
+      updateState((prev) => ({ ...prev, autostart: enabled }));
+    },
+    [updateState],
+  );
+
+  // ── Job CRUD ─────────────────────────────────────────────
+
+  const handleAddJob = useCallback(() => {
+    setEditingJob(null);
+    setShowForm(true);
+  }, []);
+
+  const handleEditJob = useCallback(
+    (name: string) => {
+      const job = state.jobs.find((j) => j.name === name);
+      if (job) {
+        setEditingJob(job);
+        setShowForm(true);
+      }
+    },
+    [state.jobs],
+  );
+
+  const handleSaveJob = useCallback(
+    (job: CronJob) => {
+      updateState((prev) => {
+        const existing = prev.jobs.findIndex((j) => j.name === job.name);
+        const jobs =
+          existing >= 0
+            ? prev.jobs.map((j) => (j.name === job.name ? job : j))
+            : [...prev.jobs, job];
+        return { ...prev, jobs };
+      });
+    },
+    [updateState],
+  );
+
+  const handleToggleEnabled = useCallback(
+    (name: string) => {
+      updateState((prev) => ({
+        ...prev,
+        jobs: prev.jobs.map((j) =>
+          j.name === name ? { ...j, disabled: !j.disabled } : j,
+        ),
+      }));
+    },
+    [updateState],
+  );
+
+  const handleRemoveJob = useCallback(
+    (name: string) => {
+      updateState((prev) => ({
+        ...prev,
+        jobs: prev.jobs.filter((j) => j.name !== name),
+      }));
+    },
+    [updateState],
+  );
+
+  const handleRunJob = useCallback(
+    (name: string) => {
+      prompt(`Run the cron job "${name}" immediately using the cron tool with action run.`);
+    },
+    [prompt],
+  );
+
+  // ── Render ───────────────────────────────────────────────
+
+  return (
+    <div className="flex h-full flex-col bg-background p-4">
+      {/* Header */}
+      <div className="mb-3 flex items-center justify-between">
+        <div>
+          <h1 className="text-lg font-semibold text-foreground">
+            ⏰ Cron Scheduler
+          </h1>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Schedule recurring agent prompts
+          </p>
+        </div>
+        <Button size="sm" onClick={handleAddJob}>
+          + New Job
+        </Button>
+      </div>
+
+      {/* Scheduler status bar */}
+      <div className="mb-3">
+        <SchedulerBar
+          active={state.schedulerActive}
+          autostart={state.autostart}
+          jobCount={stats.total}
+          activeCount={stats.active}
+          disabledCount={stats.disabled}
+          onToggle={toggleScheduler}
+          onAutostartChange={handleAutostartChange}
+        />
+      </div>
+
+      {/* Tab bar */}
+      <div className="mb-3 flex gap-1 border-b border-border">
+        {(['jobs', 'history'] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`border-b-2 px-3 py-1.5 text-xs font-medium transition-colors ${
+              activeTab === tab
+                ? 'border-primary text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {tab === 'jobs'
+              ? `Jobs (${stats.total})`
+              : `History (${state.lastRunResults.length})`}
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto">
+        {activeTab === 'jobs' ? (
+          <JobsTab
+            jobs={state.jobs}
+            schedulerActive={state.schedulerActive}
+            onEdit={handleEditJob}
+            onToggleEnabled={handleToggleEnabled}
+            onRemove={handleRemoveJob}
+            onRun={handleRunJob}
+            onAdd={handleAddJob}
+          />
+        ) : (
+          <Card className="gap-0 py-0 shadow-none">
+            <RunHistory results={state.lastRunResults} />
+          </Card>
+        )}
+      </div>
+
+      {/* Add/Edit dialog */}
+      <JobForm
+        open={showForm}
+        onClose={() => setShowForm(false)}
+        onSave={handleSaveJob}
+        editingJob={editingJob}
+      />
+    </div>
+  );
+}
+
+// ── Sub-component ──────────────────────────────────────────────
+
+function JobsTab({
+  jobs,
+  schedulerActive,
+  onEdit,
+  onToggleEnabled,
+  onRemove,
+  onRun,
+  onAdd,
+}: {
+  jobs: CronJob[];
+  schedulerActive: boolean;
+  onEdit: (name: string) => void;
+  onToggleEnabled: (name: string) => void;
+  onRemove: (name: string) => void;
+  onRun: (name: string) => void;
+  onAdd: () => void;
+}) {
+  if (jobs.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center animate-cron-fade-in">
+        <div className="mb-4 text-4xl">⏰</div>
+        <h2 className="text-base font-medium text-foreground">
+          No cron jobs yet
+        </h2>
+        <p className="mt-1.5 max-w-[240px] text-xs leading-relaxed text-muted-foreground">
+          Create a job to schedule recurring agent prompts, or ask the agent to
+          set one up for you.
+        </p>
+        <Button size="sm" className="mt-4" onClick={onAdd}>
+          + New Job
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 animate-cron-fade-in">
+      {jobs.map((job) => (
+        <JobCard
+          key={job.name}
+          job={job}
+          onEdit={onEdit}
+          onToggleEnabled={onToggleEnabled}
+          onRemove={onRemove}
+          onRun={onRun}
+          schedulerActive={schedulerActive}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default CronApp;

--- a/packages/pi-cron-extension/ui/components/JobCard.tsx
+++ b/packages/pi-cron-extension/ui/components/JobCard.tsx
@@ -2,6 +2,17 @@
  * JobCard — displays a single cron job with actions.
  */
 
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@sero/ui/components/ui/alert-dialog';
 import { Badge } from '@sero/ui/components/ui/badge';
 import { Button } from '@sero/ui/components/ui/button';
 import { Card } from '@sero/ui/components/ui/card';
@@ -26,9 +37,11 @@ export function JobCard({
   onRun,
   schedulerActive,
 }: JobCardProps) {
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
   const human = cronToHuman(job.schedule);
 
   return (
+    <>
     <Card
       className={cn(
         'gap-0 py-0 shadow-none transition-colors',
@@ -122,12 +135,35 @@ export function JobCard({
             variant="ghost"
             size="sm"
             className="h-7 text-xs text-destructive hover:text-destructive"
-            onClick={() => onRemove(job.name)}
+            onClick={() => setShowRemoveConfirm(true)}
           >
             Remove
           </Button>
         </div>
       </div>
     </Card>
+
+    {/* Remove confirmation */}
+    <AlertDialog open={showRemoveConfirm} onOpenChange={setShowRemoveConfirm}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove "{job.name}"?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete the cron job. This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-white hover:bg-destructive/90"
+            onClick={() => onRemove(job.name)}
+          >
+            Remove
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+    </>
   );
 }

--- a/packages/pi-cron-extension/ui/components/JobCard.tsx
+++ b/packages/pi-cron-extension/ui/components/JobCard.tsx
@@ -1,0 +1,133 @@
+/**
+ * JobCard — displays a single cron job with actions.
+ */
+
+import { Badge } from '@sero/ui/components/ui/badge';
+import { Button } from '@sero/ui/components/ui/button';
+import { Card } from '@sero/ui/components/ui/card';
+import { cn } from '@sero/ui/lib/utils';
+import { cronToHuman } from '../../shared/cron';
+import type { CronJob } from '../../shared/types';
+
+interface JobCardProps {
+  job: CronJob;
+  onEdit: (name: string) => void;
+  onToggleEnabled: (name: string) => void;
+  onRemove: (name: string) => void;
+  onRun: (name: string) => void;
+  schedulerActive: boolean;
+}
+
+export function JobCard({
+  job,
+  onEdit,
+  onToggleEnabled,
+  onRemove,
+  onRun,
+  schedulerActive,
+}: JobCardProps) {
+  const human = cronToHuman(job.schedule);
+
+  return (
+    <Card
+      className={cn(
+        'gap-0 py-0 shadow-none transition-colors',
+        job.disabled && 'opacity-50',
+      )}
+    >
+      <div className="px-4 py-3">
+        {/* Header row: name + badges */}
+        <div className="mb-2 flex items-center gap-2">
+          <span className="text-sm font-semibold text-foreground">
+            {job.name}
+          </span>
+
+          {job.disabled ? (
+            <Badge variant="secondary" className="text-[10px]">
+              Paused
+            </Badge>
+          ) : (
+            <Badge
+              variant="outline"
+              className="border-emerald-500/30 text-[10px] text-emerald-500"
+            >
+              Active
+            </Badge>
+          )}
+
+          {job.channel !== 'cron' && (
+            <Badge
+              variant="outline"
+              className="border-primary/30 text-[10px] text-primary"
+            >
+              {job.channel}
+            </Badge>
+          )}
+
+          {job.model && (
+            <Badge
+              variant="outline"
+              className="border-amber-500/30 text-[10px] font-mono text-amber-500"
+            >
+              {job.model}
+            </Badge>
+          )}
+        </div>
+
+        {/* Schedule */}
+        <div className="mb-1.5 flex items-center gap-2">
+          <code className="rounded bg-secondary px-2 py-0.5 text-xs text-foreground">
+            {job.schedule}
+          </code>
+          <span className="text-xs text-muted-foreground">{human}</span>
+        </div>
+
+        {/* Prompt (truncated) */}
+        <p className="mb-3 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+          {job.prompt}
+        </p>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => onEdit(job.name)}
+          >
+            Edit
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => onToggleEnabled(job.name)}
+          >
+            {job.disabled ? '▶ Enable' : '⏸ Disable'}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => onRun(job.name)}
+            disabled={!schedulerActive}
+            title={
+              schedulerActive ? 'Run now' : 'Start scheduler first'
+            }
+          >
+            ▶ Run
+          </Button>
+          <div className="flex-1" />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 text-xs text-destructive hover:text-destructive"
+            onClick={() => onRemove(job.name)}
+          >
+            Remove
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/packages/pi-cron-extension/ui/components/JobForm.tsx
+++ b/packages/pi-cron-extension/ui/components/JobForm.tsx
@@ -32,6 +32,7 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
   const [prompt, setPrompt] = useState('');
   const [channel, setChannel] = useState('cron');
   const [model, setModel] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
   const [scheduleError, setScheduleError] = useState<string | null>(null);
 
   // Reset form when opening
@@ -50,9 +51,27 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
         setChannel('cron');
         setModel('');
       }
+      setNameError(null);
       setScheduleError(null);
     }
   }, [open, editingJob]);
+
+  // Validate name on change
+  useEffect(() => {
+    if (!name.trim()) {
+      setNameError(null);
+      return;
+    }
+    if (/\s/.test(name)) {
+      setNameError('Name must not contain spaces');
+      return;
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      setNameError('Only letters, numbers, hyphens, and underscores allowed');
+      return;
+    }
+    setNameError(null);
+  }, [name]);
 
   // Validate schedule on change
   useEffect(() => {
@@ -66,6 +85,7 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
 
   const canSave =
     name.trim() &&
+    !nameError &&
     schedule.trim() &&
     prompt.trim() &&
     !scheduleError;
@@ -82,7 +102,7 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
     if (model.trim()) job.model = model.trim();
     onSave(job);
     onClose();
-  }, [canSave, name, schedule, prompt, channel, editingJob, onSave, onClose]);
+  }, [canSave, name, schedule, prompt, channel, model, editingJob, onSave, onClose]);
 
   const inputCls =
     'w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
@@ -117,9 +137,15 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
               disabled={isEditing}
               autoFocus={!isEditing}
             />
-            <p className="mt-1 text-[11px] text-muted-foreground">
-              Unique identifier, no spaces
-            </p>
+            {nameError ? (
+              <p className="mt-1 text-[11px] text-destructive">
+                {nameError}
+              </p>
+            ) : (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                Unique identifier — letters, numbers, hyphens, underscores only
+              </p>
+            )}
           </div>
 
           {/* Schedule */}

--- a/packages/pi-cron-extension/ui/components/JobForm.tsx
+++ b/packages/pi-cron-extension/ui/components/JobForm.tsx
@@ -1,0 +1,231 @@
+/**
+ * JobForm — dialog for adding or editing a cron job.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@sero/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@sero/ui/components/ui/dialog';
+import { cn } from '@sero/ui/lib/utils';
+import { validateCron, cronToHuman } from '../../shared/cron';
+import { CRON_PRESETS } from '../lib/cron-utils';
+import type { CronJob } from '../../shared/types';
+
+interface JobFormProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (job: CronJob) => void;
+  /** If set, we're editing an existing job. */
+  editingJob?: CronJob | null;
+}
+
+export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
+  const isEditing = !!editingJob;
+
+  const [name, setName] = useState('');
+  const [schedule, setSchedule] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [channel, setChannel] = useState('cron');
+  const [model, setModel] = useState('');
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
+
+  // Reset form when opening
+  useEffect(() => {
+    if (open) {
+      if (editingJob) {
+        setName(editingJob.name);
+        setSchedule(editingJob.schedule);
+        setPrompt(editingJob.prompt);
+        setChannel(editingJob.channel);
+        setModel(editingJob.model ?? '');
+      } else {
+        setName('');
+        setSchedule('');
+        setPrompt('');
+        setChannel('cron');
+        setModel('');
+      }
+      setScheduleError(null);
+    }
+  }, [open, editingJob]);
+
+  // Validate schedule on change
+  useEffect(() => {
+    if (!schedule.trim()) {
+      setScheduleError(null);
+      return;
+    }
+    const err = validateCron(schedule.trim());
+    setScheduleError(err);
+  }, [schedule]);
+
+  const canSave =
+    name.trim() &&
+    schedule.trim() &&
+    prompt.trim() &&
+    !scheduleError;
+
+  const handleSave = useCallback(() => {
+    if (!canSave) return;
+    const job: CronJob = {
+      name: name.trim(),
+      schedule: schedule.trim(),
+      prompt: prompt.trim(),
+      channel: channel.trim() || 'cron',
+      disabled: editingJob?.disabled ?? false,
+    };
+    if (model.trim()) job.model = model.trim();
+    onSave(job);
+    onClose();
+  }, [canSave, name, schedule, prompt, channel, editingJob, onSave, onClose]);
+
+  const inputCls =
+    'w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? 'Edit Cron Job' : 'New Cron Job'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSave();
+          }}
+          className="flex flex-col gap-4 py-2"
+        >
+          {/* Name */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Name *
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="daily-standup"
+              className={inputCls}
+              disabled={isEditing}
+              autoFocus={!isEditing}
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Unique identifier, no spaces
+            </p>
+          </div>
+
+          {/* Schedule */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Schedule *
+            </label>
+            <input
+              type="text"
+              value={schedule}
+              onChange={(e) => setSchedule(e.target.value)}
+              placeholder="0 9 * * 1-5"
+              className={cn(inputCls, 'font-mono')}
+              autoFocus={isEditing}
+            />
+            {scheduleError ? (
+              <p className="mt-1 text-[11px] text-destructive">
+                {scheduleError}
+              </p>
+            ) : schedule.trim() ? (
+              <p className="mt-1 text-[11px] text-emerald-500">
+                ✓ {cronToHuman(schedule.trim())}
+              </p>
+            ) : (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                min hour dom month dow
+              </p>
+            )}
+
+            {/* Presets */}
+            <div className="mt-2 flex flex-wrap gap-1">
+              {CRON_PRESETS.map((p) => (
+                <button
+                  key={p.value}
+                  type="button"
+                  onClick={() => setSchedule(p.value)}
+                  className={cn(
+                    'rounded-full border border-border px-2 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground',
+                    schedule === p.value && 'border-primary bg-primary/10 text-primary',
+                  )}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Prompt */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Prompt *
+            </label>
+            <textarea
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="What should the agent do when this job fires?"
+              rows={3}
+              className={cn(inputCls, 'resize-y')}
+            />
+          </div>
+
+          {/* Channel */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Channel
+            </label>
+            <input
+              type="text"
+              value={channel}
+              onChange={(e) => setChannel(e.target.value)}
+              placeholder="cron"
+              className={inputCls}
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Grouping tag (default: cron)
+            </p>
+          </div>
+
+          {/* Model */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Model
+            </label>
+            <input
+              type="text"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder="sonnet"
+              className={cn(inputCls, 'font-mono')}
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Model pattern or ID — e.g. "sonnet", "openai/gpt-4o",
+              "gemini:high". Leave blank for default.
+            </p>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave}>
+            {isEditing ? 'Save Changes' : 'Add Job'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/pi-cron-extension/ui/components/RunHistory.tsx
+++ b/packages/pi-cron-extension/ui/components/RunHistory.tsx
@@ -1,0 +1,66 @@
+/**
+ * RunHistory — shows recent cron job execution results.
+ */
+
+import { Badge } from '@sero/ui/components/ui/badge';
+import { cn } from '@sero/ui/lib/utils';
+import type { CronRunResult } from '../../shared/types';
+import { formatDuration, timeAgo } from '../lib/cron-utils';
+
+interface RunHistoryProps {
+  results: CronRunResult[];
+}
+
+export function RunHistory({ results }: RunHistoryProps) {
+  if (results.length === 0) {
+    return (
+      <div className="py-8 text-center text-xs text-muted-foreground">
+        No executions yet
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      {results.slice(0, 20).map((r, i) => (
+        <div
+          key={`${r.jobName}-${r.startedAt}`}
+          className={cn(
+            'flex items-center gap-3 px-4 py-2 text-xs',
+            i < results.length - 1 && 'border-b border-border',
+          )}
+        >
+          {/* Status dot */}
+          <span
+            className={cn(
+              'h-1.5 w-1.5 shrink-0 rounded-full',
+              r.ok ? 'bg-emerald-500' : 'bg-destructive',
+            )}
+          />
+
+          {/* Job name */}
+          <span className="font-medium text-foreground">{r.jobName}</span>
+
+          {/* Duration */}
+          <Badge variant="secondary" className="text-[10px]">
+            {formatDuration(r.durationMs)}
+          </Badge>
+
+          {/* Error (if any) */}
+          {r.error && (
+            <span className="line-clamp-1 flex-1 text-destructive">
+              {r.error}
+            </span>
+          )}
+
+          <div className="flex-1" />
+
+          {/* Time ago */}
+          <span className="shrink-0 text-muted-foreground">
+            {timeAgo(r.startedAt)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/pi-cron-extension/ui/components/RunHistory.tsx
+++ b/packages/pi-cron-extension/ui/components/RunHistory.tsx
@@ -22,7 +22,7 @@ export function RunHistory({ results }: RunHistoryProps) {
 
   return (
     <div className="flex flex-col">
-      {results.slice(0, 20).map((r, i) => (
+      {results.map((r, i) => (
         <div
           key={`${r.jobName}-${r.startedAt}`}
           className={cn(

--- a/packages/pi-cron-extension/ui/components/SchedulerBar.tsx
+++ b/packages/pi-cron-extension/ui/components/SchedulerBar.tsx
@@ -1,0 +1,96 @@
+/**
+ * SchedulerBar — status indicator, autostart toggle, and start/stop button.
+ */
+
+import { Badge } from '@sero/ui/components/ui/badge';
+import { Button } from '@sero/ui/components/ui/button';
+import { Switch } from '@sero/ui/components/ui/switch';
+import { cn } from '@sero/ui/lib/utils';
+
+interface SchedulerBarProps {
+  active: boolean;
+  autostart: boolean;
+  jobCount: number;
+  activeCount: number;
+  disabledCount: number;
+  onToggle: () => void;
+  onAutostartChange: (enabled: boolean) => void;
+}
+
+export function SchedulerBar({
+  active,
+  autostart,
+  jobCount,
+  activeCount,
+  disabledCount,
+  onToggle,
+  onAutostartChange,
+}: SchedulerBarProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5">
+      {/* Status dot + label */}
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'h-2.5 w-2.5 rounded-full',
+            active
+              ? 'bg-emerald-500 shadow-[0_0_6px_rgba(16,185,129,0.4)]'
+              : 'bg-muted-foreground/40',
+          )}
+        />
+        <span className="text-sm font-medium text-foreground">
+          {active ? 'Scheduler Active' : 'Scheduler Inactive'}
+        </span>
+      </div>
+
+      {/* Stats */}
+      <div className="flex items-center gap-2">
+        <Badge variant="secondary" className="text-xs">
+          {jobCount} {jobCount === 1 ? 'job' : 'jobs'}
+        </Badge>
+        {activeCount > 0 && (
+          <Badge
+            variant="outline"
+            className="border-emerald-500/30 text-xs text-emerald-500"
+          >
+            {activeCount} active
+          </Badge>
+        )}
+        {disabledCount > 0 && (
+          <Badge
+            variant="outline"
+            className="text-xs text-muted-foreground"
+          >
+            {disabledCount} paused
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex-1" />
+
+      {/* Autostart toggle */}
+      <label className="flex items-center gap-1.5">
+        <span className="text-[11px] text-muted-foreground">Autostart</span>
+        <Switch
+          checked={autostart}
+          onCheckedChange={onAutostartChange}
+          className="scale-75"
+        />
+      </label>
+
+      {/* Start / Stop button */}
+      <Button
+        variant={active ? 'destructive' : 'default'}
+        size="sm"
+        onClick={onToggle}
+        className={cn(
+          'text-xs',
+          !active &&
+            'bg-emerald-600 text-white hover:bg-emerald-700',
+        )}
+      >
+        {active ? '⏸ Stop' : '▶ Start'}
+      </Button>
+    </div>
+  );
+}

--- a/packages/pi-cron-extension/ui/index.html
+++ b/packages/pi-cron-extension/ui/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Sero Cron (remote)</title></head>
+<body><div id="root"></div></body>
+</html>

--- a/packages/pi-cron-extension/ui/lib/cron-utils.ts
+++ b/packages/pi-cron-extension/ui/lib/cron-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * UI-specific cron helpers.
+ * Core parsing/validation lives in shared/cron.ts.
+ */
+
+/** Common cron presets for the UI quick-pick. */
+export const CRON_PRESETS = [
+  { label: 'Every minute', value: '* * * * *' },
+  { label: 'Every 5 minutes', value: '*/5 * * * *' },
+  { label: 'Every 15 minutes', value: '*/15 * * * *' },
+  { label: 'Every hour', value: '0 * * * *' },
+  { label: 'Daily at 9am', value: '0 9 * * *' },
+  { label: 'Weekdays at 9am', value: '0 9 * * 1-5' },
+  { label: 'Weekly (Sun midnight)', value: '0 0 * * 0' },
+  { label: 'Monthly (1st midnight)', value: '0 0 1 * *' },
+] as const;
+
+/** Format milliseconds as a human-readable duration. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const secs = ms / 1000;
+  if (secs < 60) return `${secs.toFixed(1)}s`;
+  const mins = Math.floor(secs / 60);
+  const remainSecs = Math.floor(secs % 60);
+  return `${mins}m ${remainSecs}s`;
+}
+
+/** Format an ISO date string as relative time (e.g. "2m ago"). */
+export function timeAgo(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  const secs = Math.floor(diff / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/packages/pi-cron-extension/ui/styles.css
+++ b/packages/pi-cron-extension/ui/styles.css
@@ -1,0 +1,53 @@
+@import "tailwindcss";
+
+/* Scan @sero/ui component sources so Tailwind generates CSS
+   for utility classes used inside shared components. */
+@source "../../ui/src/components";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+/* ── Cron-specific animations ─────────────────────────── */
+
+@keyframes cron-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+@utility animate-cron-pulse {
+  animation: cron-pulse 2s ease-in-out infinite;
+}
+
+@keyframes cron-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@utility animate-cron-fade-in {
+  animation: cron-fade-in 0.25s ease-out both;
+}

--- a/packages/pi-cron-extension/ui/styles.css
+++ b/packages/pi-cron-extension/ui/styles.css
@@ -1,7 +1,11 @@
 @import "tailwindcss";
 
 /* Scan @sero/ui component sources so Tailwind generates CSS
-   for utility classes used inside shared components. */
+   for utility classes used inside shared components (e.g. Button,
+   Badge, Dialog). Without this, classes used only in @sero/ui
+   won't be included in the bundle since Tailwind doesn't scan
+   node_modules by default. Path is relative to this file and
+   resolves to packages/ui/src/components within the monorepo. */
 @source "../../ui/src/components";
 
 @custom-variant dark (&:is(.dark *));

--- a/packages/pi-cron-extension/ui/tsconfig.json
+++ b/packages/pi-cron-extension/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero/app-runtime": ["../../app-runtime/src/index.ts"],
+      "@sero/ui": ["../../ui/src/index.ts"],
+      "@sero/ui/*": ["../../ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-cron-extension/vite.config.ts
+++ b/packages/pi-cron-extension/vite.config.ts
@@ -1,0 +1,48 @@
+/**
+ * Vite config for the cron extension's federated UI (remote).
+ *
+ * Runs its own dev server on port 5188. The host (Sero on 5173)
+ * declares this as a remote and imports components via MF.
+ */
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_cron',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './CronApp': './ui/CronApp.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5188,
+    strictPort: true,
+    origin: 'http://localhost:5188',
+  },
+  optimizeDeps: {
+    exclude: ['@sero/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,61 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/pi-cron-extension:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.55.3'
+        version: 0.55.3
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
+    devDependencies:
+      '@module-federation/vite':
+        specifier: ^1.11.0
+        version: 1.11.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@sero/app-runtime':
+        specifier: workspace:*
+        version: link:../app-runtime
+      '@sero/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.11
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
   packages/pi-daily-quote:
     dependencies:
       '@mariozechner/pi-ai':


### PR DESCRIPTION
## Cron Scheduler App

New Sero app (`packages/pi-cron-extension/`) adapted from [`@e9n/pi-cron`](https://github.com/espennilsen/pi/tree/main/extensions/pi-cron) for the Sero platform.

### Features

- **Global-scoped** — jobs persist across all workspaces (`~/.sero-ui/apps/cron/`)
- **Agent tool** — `cron` tool with actions: list, add, update, remove, enable, disable, run
- **React dashboard UI**:
  - Job list with status badges, cron expression preview, and per-job actions
  - Add/edit dialog with live cron validation, human-readable preview, and preset pills
  - Scheduler status bar with start/stop button and autostart toggle
  - Run history tab showing recent execution results (pass/fail, duration, errors)
- **Per-job model selection** — each job can specify a model (`sonnet`, `openai/gpt-4o`, etc.) via `--model` flag
- **Autostart** — toggle in the UI to auto-start the scheduler on Sero launch
- **Scheduler** — ticks every 30s, spawns isolated `pi -p --no-session` subprocesses per job

### Architecture

```
packages/pi-cron-extension/
├── shared/types.ts, cron.ts    # Shared state shape + cron parser/validator
├── extension/index.ts          # Tool, /cron command, scheduler lifecycle
├── extension/scheduler.ts      # CronScheduler — tick loop + subprocess runner
└── ui/                         # React dashboard (MF remote on port 5188)
```

---

## Desktop Notification System

New `ExtensionUIContext` implementation so `ctx.ui.notify()` works in Sero.

### What changed

| File | Change |
|------|--------|
| `electron/notifications.ts` | `showNotification()` — native macOS notifications via Electron `Notification` API + IPC forward to renderer |
| `electron/extension-ui-context.ts` | `createSeroUIContext()` — full `ExtensionUIContext` impl with real `notify()`, safe no-ops for TUI methods |
| `electron/ipc/agent.ts` | Sets UIContext on `ExtensionRunner` after session creation |
| `electron/cli/schema-bridge.ts` | **Bugfix**: `bridgeCommand()` was passing `{ cwd } as any` — `ctx.ui` was `undefined`, crashing on `notify()`. Now passes a proper context shim. |
| `src/types/ipc-channels.ts` | Added `sero:notification` IPC channel |

### Impact

All Pi extensions that call `ctx.ui.notify()` (pi-cron, pi-heartbeat, pi-channels, etc.) now show native desktop notifications in Sero instead of silently no-op'ing.