### PR TITLE
feat(cron): reminders, notifications, and scheduler reliability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,16 @@ the feature appears to work in the UI but silently fails at the agent.
   (e.g. for federated modules in `@sero/app-runtime`) is passed via context
   providers or the `window.sero` IPC bridge — never via `localStorage`.
 
+### Desktop Notifications (`sero:notify` EventBus)
+
+Extensions show native desktop notifications via the shared Pi SDK EventBus —
+no `require('electron')` needed.
+
+- **Extension emits:** `pi.events.emit('sero:notify', { message, type?, source?, sound?, subtitle? })`
+- **Host listens:** `electron/sero-extension.ts` → calls `showNotification()` from `electron/notifications.ts`
+- `sound` — `true` (default chime), a macOS sound name (`"Glass"`, `"Hero"`, etc.), or `false` (silent)
+- `type` — `'info'` | `'warning'` | `'error'` (default: `'info'`)
+
 ### Container Integration (AD-018)
 
 Every workspace runs inside a native macOS container (Apple Containerization

--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -307,12 +307,12 @@ const PROVIDER_LOGO_MAP: Record<string, string> = {
   'kimi-coding': 'openai',
 };
 
-function providerLogo(provider: string): string {
+export function providerLogo(provider: string): string {
   const slug = PROVIDER_LOGO_MAP[provider] ?? provider;
   return `https://models.dev/logos/${slug}.svg`;
 }
 
-function providerDisplayName(provider: string): string {
+export function providerDisplayName(provider: string): string {
   return PROVIDER_NAMES[provider] ?? provider.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
 

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -33,6 +33,7 @@ import { registerSafeStorageHandlers } from './safe-storage';
 import { registerUserFeedbackQuestionHandlers } from './user-feedback-questions';
 import { registerGatewayHandlers } from './gateway';
 import { registerGoogleApiHandlers } from './google-api';
+import { registerModelsHandlers } from './models';
 
 export function registerAllIpcHandlers(): void {
   registerWorkspaceHandlers();
@@ -62,4 +63,5 @@ export function registerAllIpcHandlers(): void {
   registerUserFeedbackQuestionHandlers();
   registerGatewayHandlers();
   registerGoogleApiHandlers();
+  registerModelsHandlers();
 }

--- a/apps/desktop/electron/ipc/models.ts
+++ b/apps/desktop/electron/ipc/models.ts
@@ -1,0 +1,49 @@
+/**
+ * Models IPC handler — session-independent model listing.
+ *
+ * Provides available models directly from the ModelRegistry,
+ * without requiring an active agent session. Used by federated
+ * app modules (e.g. cron job model picker) via the sero bridge.
+ */
+
+import { ipcMain } from 'electron';
+import { IpcChannels } from '../../src/types/ipc';
+import type { AvailableModelGroup } from '../../src/types/ipc';
+import { ensureInfra } from './shared-infra';
+import {
+  providerDisplayName,
+  providerLogo,
+} from './agent-helpers';
+
+export function registerModelsHandlers(): void {
+  ipcMain.handle(
+    IpcChannels.models.list,
+    async (): Promise<AvailableModelGroup[]> => {
+      const { modelRegistry } = await ensureInfra();
+
+      // Reload auth so newly-added keys are picked up
+      modelRegistry.authStorage.reload();
+      const available = modelRegistry.getAvailable();
+
+      // Group by provider
+      const grouped = new Map<string, typeof available>();
+      for (const m of available) {
+        const list = grouped.get(m.provider) ?? [];
+        list.push(m);
+        grouped.set(m.provider, list);
+      }
+
+      return [...grouped.entries()].map(([provider, models]) => ({
+        provider,
+        displayName: providerDisplayName(provider),
+        logo: providerLogo(provider),
+        models: models.map((m) => ({
+          provider: m.provider,
+          modelId: m.id,
+          name: m.name,
+          reasoning: m.reasoning,
+        })),
+      }));
+    },
+  );
+}

--- a/apps/desktop/electron/notifications.ts
+++ b/apps/desktop/electron/notifications.ts
@@ -1,13 +1,39 @@
 /**
  * Desktop notification system for Sero.
  *
- * Provides native macOS notifications via Electron's Notification API,
- * compatible with the Pi SDK's `ctx.ui.notify(message, type)` interface.
+ * Provides native macOS notifications via Electron's Notification API.
+ * Used by the ExtensionUIContext and the 'sero:notify' EventBus channel.
+ *
+ * Sound names are macOS system sounds from /System/Library/Sounds/:
+ *   Glass, Hero, Ping, Pop, Purr, Submarine, Tink, Basso, Blow, Bottle,
+ *   Frog, Funk, Morse, Sosumi
+ *
+ * Persistence (auto-close) on macOS is controlled per-app in:
+ *   System Settings > Notifications > Electron (or Sero when packaged)
+ *   Set style to "Alerts" for notifications that stay until dismissed.
  */
 
 import { Notification } from 'electron';
 
 export type NotificationType = 'info' | 'warning' | 'error';
+
+export interface NotificationOptions {
+  /** Notification message body. */
+  message: string;
+  /** Severity — affects default icon prefix. */
+  type?: NotificationType;
+  /** Source label shown in the notification title (e.g. "Reminder"). */
+  source?: string;
+  /**
+   * macOS system sound name (e.g. "Glass", "Hero", "Ping").
+   * Set to `true` for the default system sound, `false` or omit for silent.
+   */
+  sound?: string | boolean;
+  /**
+   * Subtitle line (macOS only), displayed between title and body.
+   */
+  subtitle?: string;
+}
 
 const TYPE_PREFIXES: Record<NotificationType, string> = {
   info: 'ℹ️',
@@ -15,25 +41,51 @@ const TYPE_PREFIXES: Record<NotificationType, string> = {
   error: '❌',
 };
 
+const DEFAULT_SOUND = 'Glass';
+
 /**
  * Show a native desktop notification.
  *
- * This is the single entry point for all extension notifications in Sero.
- * Called by the ExtensionUIContext's `notify()` implementation.
+ * Single entry point for all notifications in Sero.
  */
+export function showNotification(opts: NotificationOptions): void;
+/** @deprecated Use the options-object overload. */
+export function showNotification(message: string, type?: NotificationType, source?: string): void;
 export function showNotification(
-  message: string,
-  type: NotificationType = 'info',
+  messageOrOpts: string | NotificationOptions,
+  type?: NotificationType,
   source?: string,
 ): void {
   if (!Notification.isSupported()) return;
 
-  const prefix = TYPE_PREFIXES[type];
-  const title = source ? `Sero — ${source}` : 'Sero';
+  // Normalise to options object
+  const opts: NotificationOptions =
+    typeof messageOrOpts === 'string'
+      ? { message: messageOrOpts, type, source }
+      : messageOrOpts;
 
-  new Notification({
+  const nType = opts.type ?? 'info';
+  const prefix = TYPE_PREFIXES[nType];
+  const title = opts.source ? `Sero — ${opts.source}` : 'Sero';
+
+  // Resolve sound
+  let silent = true;
+  let soundName: string | undefined;
+  if (opts.sound === true) {
+    silent = false;
+    soundName = DEFAULT_SOUND;
+  } else if (typeof opts.sound === 'string') {
+    silent = false;
+    soundName = opts.sound;
+  }
+
+  const notification = new Notification({
     title,
-    body: `${prefix} ${message}`,
-    silent: type === 'info',
-  }).show();
+    subtitle: opts.subtitle,
+    body: `${prefix} ${opts.message}`,
+    silent,
+    ...(soundName ? { sound: soundName } : {}),
+  });
+
+  notification.show();
 }

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -212,6 +212,11 @@ contextBridge.exposeInMainWorld('sero', {
       ipcRenderer.invoke(IpcChannels.appAgent.prompt, appId, workspaceId, text),
   },
 
+  models: {
+    list: (): Promise<import('../src/types/ipc').AvailableModelGroup[]> =>
+      ipcRenderer.invoke(IpcChannels.models.list),
+  },
+
   google: {
     execute: (service: string, subArgs: string[]) => ipcRenderer.invoke(IpcChannels.google.execute, service, subArgs),
     authStatus: () => ipcRenderer.invoke(IpcChannels.google.authStatus),

--- a/apps/desktop/electron/sero-extension.ts
+++ b/apps/desktop/electron/sero-extension.ts
@@ -7,6 +7,7 @@
  * Provides:
  *   - Container + CLI prompt injection (before_agent_start)
  *   - @ws:id/path expansion in user input (input event)
+ *   - sero:notify event bus → desktop notifications (all extensions)
  *   - /workspace command (list, info, open, close)
  *   - /pwd command (print workspace-relative cwd)
  *   - PI CLI built-in equivalents: /reload, /compact, /name, /session, /model, /thinking
@@ -20,6 +21,7 @@ import { buildContainerPromptBlock } from './container/system-prompt';
 import { registerSeroBuiltinCommands } from './sero-extension-commands';
 import { buildCliPromptBlock } from './cli';
 import { registerGitCheckpointFeatures } from './sero-extension-git';
+import { showNotification, type NotificationType } from './notifications';
 
 /**
  * Creates an extension factory for a specific workspace session.
@@ -52,6 +54,28 @@ export function createSeroExtensionFactory(
       if (systemPrompt !== event.systemPrompt) {
         return { systemPrompt };
       }
+    });
+
+    // ── sero:notify — shared notification bus ───────────────────
+    //
+    // Any extension can emit 'sero:notify' on pi.events to show a
+    // native desktop notification. This keeps extensions decoupled
+    // from Electron — they use the Pi SDK EventBus, the host handles
+    // the platform-specific display.
+    //
+    // Payload: { message, type?, source?, sound?, subtitle? }
+
+    pi.events.on('sero:notify', (data: unknown) => {
+      const p = data as Record<string, unknown> | undefined;
+      if (!p?.message || typeof p.message !== 'string') return;
+      showNotification({
+        message: p.message,
+        type: (['info', 'warning', 'error'].includes(p.type as string)
+          ? p.type : 'info') as NotificationType,
+        source: typeof p.source === 'string' ? p.source : undefined,
+        sound: typeof p.sound === 'string' || typeof p.sound === 'boolean' ? p.sound : undefined,
+        subtitle: typeof p.subtitle === 'string' ? p.subtitle : undefined,
+      });
     });
 
     // ── @ws: path expansion ────────────────────────────────────

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -89,6 +89,10 @@ export const IpcChannels = {
     /** Send a prompt to an app's dedicated agent session. Returns text response. */
     prompt: 'sero:app-agent:prompt',
   },
+  models: {
+    /** List all available models (session-independent). Returns AvailableModelGroup[]. */
+    list: 'sero:models:list',
+  },
   imagegen: {
     /** Generate images via Gemini Nano Banana. Returns generation metadata. */
     generate: 'sero:imagegen:generate',

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -10,3 +10,5 @@ export { useAppState } from './use-app-state';
 export { useAppInfo } from './use-app-info';
 export { useAgentPrompt } from './use-agent-prompt';
 export { useAI, type AppAI } from './use-ai';
+export { useAvailableModels, type UseAvailableModelsResult } from './use-available-models';
+export type { AppModelInfo, AppModelGroup } from './sero-bridge';

--- a/packages/app-runtime/src/sero-bridge.ts
+++ b/packages/app-runtime/src/sero-bridge.ts
@@ -22,9 +22,32 @@ export interface SeroAppAgentBridge {
   prompt(appId: string, workspaceId: string, text: string): Promise<string>;
 }
 
+// ── Model types (subset of desktop's ipc types) ──────────────
+
+/** Serialisable model info for app modules. */
+export interface AppModelInfo {
+  provider: string;
+  modelId: string;
+  name: string;
+  reasoning: boolean;
+}
+
+/** A group of models under a single provider. */
+export interface AppModelGroup {
+  provider: string;
+  displayName: string;
+  logo: string;
+  models: AppModelInfo[];
+}
+
+export interface SeroModelsBridge {
+  list(): Promise<AppModelGroup[]>;
+}
+
 export interface SeroBridge {
   appState: SeroAppStateBridge;
   appAgent: SeroAppAgentBridge;
+  models?: SeroModelsBridge;
 }
 
 /**

--- a/packages/app-runtime/src/use-available-models.ts
+++ b/packages/app-runtime/src/use-available-models.ts
@@ -1,0 +1,58 @@
+/**
+ * useAvailableModels — fetches the list of available models from the
+ * Sero host's ModelRegistry. Session-independent: apps don't need an
+ * active agent session to enumerate models.
+ *
+ * Returns { groups, loading, error, refresh }.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { getSeroApi, type AppModelGroup } from './sero-bridge';
+
+export interface UseAvailableModelsResult {
+  /** Model groups, grouped by provider. */
+  groups: AppModelGroup[];
+  /** True while the initial fetch is in flight. */
+  loading: boolean;
+  /** Error message if the fetch failed. */
+  error: string | null;
+  /** Manually re-fetch the list (e.g. after adding auth). */
+  refresh: () => void;
+}
+
+export function useAvailableModels(): UseAvailableModelsResult {
+  const [groups, setGroups] = useState<AppModelGroup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    const api = getSeroApi();
+    if (!api.models) {
+      setError('Model listing not available in this Sero version');
+      setLoading(false);
+      return;
+    }
+
+    api.models
+      .list()
+      .then((result) => {
+        setGroups(result);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to fetch models');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { groups, loading, error, refresh: fetch };
+}

--- a/packages/pi-cron-extension/README.md
+++ b/packages/pi-cron-extension/README.md
@@ -15,10 +15,18 @@ React UI is Sero-only.
   mum") or create them from the UI.
 - **Snooze** — snooze fired reminders for 5 min, 15 min, 30 min, 1 hour,
   3 hours, or until tomorrow 9am.
+- **Configurable notification sounds** — pick from 14 macOS system sounds
+  (Glass, Hero, Ping, Pop, etc.) or disable sound entirely. Settings
+  accessible via the 🔔 button in the scheduler bar.
+- **Job completion notifications** — desktop notification when any cron job
+  finishes (✅ success or ❌ failure with duration).
 - **Visual dashboard** — three tabs (Reminders, Jobs, History) for managing
   everything. Live cron expression validation with human-readable previews.
-- **Agent tools** — two LLM-callable tools (`reminder` and `cron`) so you
-  can manage everything through natural conversation.
+- **Run output capture** — agent responses from cron job runs are saved and
+  viewable in the History tab. Latest result auto-expands; older results
+  show an inline preview with a toggle to expand.
+- **Agent tools** — three LLM-callable tools (`current_time`, `reminder`,
+  and `cron`) so you can manage everything through natural conversation.
 - **No database** — all state is stored as JSON in a single file. Both the
   UI and the extension read/write the same file; changes sync instantly.
 - **Scheduler off by default** — nothing runs until you start it. Toggle from
@@ -27,7 +35,8 @@ React UI is Sero-only.
   subprocess with a 10-minute timeout. Jobs can't interfere with each other
   or with your active chat.
 - **Run history** — the last 50 cron job execution results (pass/fail,
-  duration, errors) are visible in the History tab.
+  duration, output, errors) are visible in the History tab. Clear history
+  with one click.
 - **Global scope** — jobs and reminders are personal, not per-workspace.
   Your schedule persists across all projects.
 
@@ -49,7 +58,7 @@ Click **Cron** (🕐) in the Sero sidebar. The dashboard has three tabs:
 |-----|---------------|
 | **Reminders** | All reminders with status filters, snooze, and management |
 | **Jobs** | Configured cron jobs with status, schedule, and actions |
-| **History** | Recent cron job execution results with pass/fail and timing |
+| **History** | Recent cron job execution results with expandable output |
 
 ---
 
@@ -59,7 +68,8 @@ Click **Cron** (🕐) in the Sero sidebar. The dashboard has three tabs:
 
 **From the chat (recommended):**
 
-Ask the agent naturally — it will use the `reminder` tool:
+Ask the agent naturally — it will use the `current_time` and `reminder`
+tools:
 
 ```
 Set a reminder for 1 hour to phone mum
@@ -261,12 +271,60 @@ time you start it. The scheduler also stops automatically when Sero quits.
 
 Toggle the **Autostart** switch in the status bar to have the scheduler
 start automatically whenever Sero launches. When enabled, the extension
-boots the scheduler on session start (as long as at least one job or
-reminder exists). The setting persists across restarts.
+boots the scheduler eagerly at extension load time (no need to open a chat
+or send a message first). The setting persists across restarts.
+
+#### Notification sound settings
+
+Click the **🔔** icon in the scheduler bar to configure notification sounds:
+
+- **Play sound** — toggle on/off
+- **Sound** — choose from 14 macOS system sounds: Glass, Hero, Ping, Pop,
+  Purr, Submarine, Tink, Basso, Blow, Bottle, Frog, Funk, Morse, Sosumi
+
+Sound settings apply to both reminder notifications and job completion
+notifications. The setting persists in `state.json`.
+
+> **macOS notification persistence:** To make notifications stay on screen
+> until dismissed (instead of auto-closing), go to **System Settings →
+> Notifications → Electron** (or **Sero** when packaged) and set the
+> notification style to **Alerts**.
+
+---
+
+### Run History
+
+The History tab shows the last 50 job execution results.
+
+Each row shows the job name, duration, a status indicator (green = success,
+red = failure), and how long ago it ran.
+
+**Viewing output:** Rows with captured output show a `▸ Output` button.
+Click to expand and see the agent's full response. The most recent result
+auto-expands if it has output. When collapsed, a truncated preview of the
+first line is shown inline.
+
+**Clearing history:** Click the **Clear** button in the top-right corner
+of the History tab to remove all run results.
 
 ---
 
 ## Agent Tool Reference
+
+### `current_time` tool
+
+Returns the current date and time. The LLM should call this **before**
+creating reminders with relative times (e.g. "in 5 minutes", "in 1 hour")
+to compute an accurate `fire_at` value.
+
+**Returns:**
+
+```
+Current time: 2026-03-01T13:45:00.000Z
+Local: Saturday, 1 March 2026 at 13:45:00 GMT
+Timezone: UTC+0:00
+Unix: 1772541900000
+```
 
 ### `reminder` tool
 
@@ -293,7 +351,7 @@ the `sero-cli` tool automatically.
 | `notes` | Optional extra details |
 | `channel` | `"notification"` (desktop, default) or `"email"` (not yet implemented) |
 | `type` | `"once"` (default) — fires at `fire_at`; `"recurring"` — fires on `schedule` |
-| `fire_at` | ISO datetime for one-time reminders (e.g. `"2025-03-15T14:30:00"`) |
+| `fire_at` | ISO datetime for one-time reminders. Call `current_time` first for accurate values. |
 | `schedule` | Cron expression for recurring (e.g. `"0 9 * * 5"` = Fridays at 9am) |
 | `snooze_minutes` | Minutes to snooze (default 15). Use `-1` for "tomorrow 9am". |
 
@@ -329,29 +387,32 @@ name with a thinking-level suffix (`sonnet:high`).
 
 ```
 packages/pi-cron-extension/
-├── package.json                # Pi + Sero manifest (global scope, port 5188)
-├── vite.config.ts              # Module Federation remote config
+├── package.json                 # Pi + Sero manifest (global scope, port 5188)
+├── vite.config.ts               # Module Federation remote config
 ├── shared/
-│   ├── types.ts                # CronJob, Reminder, CronState, CronRunResult
-│   ├── cron.ts                 # 5-field parser, validator, cronToHuman
+│   ├── types.ts                 # CronJob, Reminder, NotificationSettings, CronState
+│   ├── cron.ts                  # 5-field parser, validator, cronToHuman
 │   └── reminder-utils.ts       # Fire-time checks, snooze, status helpers
 ├── extension/
-│   ├── index.ts                # Tools (cron + reminder), /cron cmd, lifecycle
-│   ├── scheduler.ts            # CronScheduler — tick loop, jobs + reminders
-│   ├── actions.ts              # Cron job action handlers
-│   ├── reminder-actions.ts     # Reminder action handlers (CRUD + snooze)
-│   ├── notifier.ts             # Desktop notification delivery
-│   └── logger.ts               # File-based structured logger
+│   ├── index.ts                 # Singleton scheduler, tools, /cron cmd, lifecycle
+│   ├── state-io.ts              # Path resolution, atomic read/write, mutex
+│   ├── state-watcher.ts         # Directory-based fs.watch → scheduler sync
+│   ├── scheduler.ts             # CronScheduler — tick loop, jobs + reminders
+│   ├── actions.ts               # Cron job action handlers
+│   ├── reminder-actions.ts      # Reminder action handlers (CRUD + snooze)
+│   ├── notifier.ts              # sero:notify EventBus emitter
+│   └── logger.ts                # File-based structured logger
 └── ui/
     ├── CronApp.tsx              # Root — tabs (Reminders, Jobs, History)
     ├── components/
-    │   ├── SchedulerBar.tsx     # Status indicator + start/stop + autostart
+    │   ├── SchedulerBar.tsx     # Status + notification settings + start/stop
+    │   ├── NotificationSettings.tsx # Sound toggle + sound picker popover
     │   ├── ReminderCard.tsx     # Single reminder with snooze dropdown
     │   ├── ReminderForm.tsx     # Add/edit reminder dialog
     │   ├── ReminderList.tsx     # Filterable reminder list with sorting
     │   ├── JobCard.tsx          # Single job display with actions
     │   ├── JobForm.tsx          # Add/edit job dialog with presets
-    │   └── RunHistory.tsx       # Recent cron execution results
+    │   └── RunHistory.tsx       # Execution results with expandable output
     ├── lib/
     │   └── cron-utils.ts        # Presets, formatDuration, timeAgo
     ├── styles.css               # Tailwind + theme tokens + animations
@@ -368,7 +429,7 @@ packages/pi-cron-extension/
                  │                 │
            Pi Extension        React UI
            (cron + reminder    (useAppState)
-            tools)                 │
+            + current_time)        │
                  │                 ▼
                  ▼            Dashboard
            CronScheduler      ├─ Reminders tab
@@ -376,7 +437,7 @@ packages/pi-cron-extension/
            ├─ cron matching   └─ History tab
            ├─ reminder checks
            ├─ snooze expiry
-           └─ notifications
+           └─ sero:notify → desktop notifications
 ```
 
 Both sides read and write the same JSON file. The file IS the API:
@@ -384,11 +445,34 @@ Both sides read and write the same JSON file. The file IS the API:
 - **Extension → file**: tool calls and scheduler events write to
   `state.json` with atomic writes (temp + rename) protected by an
   async mutex.
-- **File → UI**: Sero's `AppStateManager` watches the file with `fs.watch`
-  and pushes updates to the renderer via IPC. React re-renders instantly.
+- **File → scheduler**: a directory-based `fs.watch` detects changes
+  (including atomic renames) and syncs updated jobs/reminders into the
+  scheduler's in-memory state.
+- **File → UI**: Sero's `AppStateManager` watches the file and pushes
+  updates to the renderer via IPC. React re-renders instantly.
 - **UI → file**: `useAppState` calls write through IPC to the main process,
-  which performs the same atomic write. The extension picks up changes on
-  its next read.
+  which performs the same atomic write.
+
+### Notifications
+
+The extension uses the **`sero:notify` EventBus pattern** for
+notifications. This keeps extensions decoupled from Electron:
+
+1. The extension emits `pi.events.emit('sero:notify', { message, type, sound, source })`
+2. The Sero host extension factory listens on `pi.events.on('sero:notify', ...)`
+3. The listener calls `showNotification()` which uses Electron's native
+   `Notification` API with configurable macOS system sounds.
+
+Any Pi extension can use this pattern — no `require('electron')` needed.
+In the Pi CLI (where the Sero host isn't present), notifications fall back
+to `console.log`.
+
+### Singleton scheduler
+
+The scheduler is a **module-level singleton**. The extension's default
+export may be called multiple times (once per Sero session), but all
+invocations share the same `initialized` flag, `scheduler` instance, and
+`stateWatcher`. This prevents duplicate job execution.
 
 ### State shape
 
@@ -399,6 +483,7 @@ interface CronState {
   schedulerActive: boolean;
   autostart: boolean;
   lastRunResults: CronRunResult[];  // Capped at 50
+  notificationSettings?: NotificationSettings;
 }
 
 interface CronJob {
@@ -431,6 +516,12 @@ interface CronRunResult {
   durationMs: number;
   ok: boolean;
   error?: string;
+  output?: string;     // Agent response (extension noise stripped)
+}
+
+interface NotificationSettings {
+  soundEnabled: boolean;     // Whether to play a sound
+  soundName: string;         // macOS sound name (default: "Glass")
 }
 ```
 
@@ -441,7 +532,7 @@ Jobs and reminders are personal, not project-specific. State lives at
 In the Pi CLI (where `SERO_HOME` is unset), the extension falls back to
 `.sero/apps/cron/state.json` relative to the working directory.
 
-### Scheduler
+### Scheduler internals
 
 The scheduler is an in-memory `setInterval` loop that ticks every 30 seconds.
 
@@ -451,7 +542,9 @@ The scheduler is an in-memory `setInterval` loop that ticks every 30 seconds.
 2. Matches each job's cron expression against the current local time.
 3. For matches, spawns `pi -p --no-session <prompt>` as a child process
    with a 10-minute timeout.
-4. Appends the result to `lastRunResults` in the state file.
+4. Captures the agent's response (stripping extension loading noise).
+5. Appends the result (with output) to `lastRunResults` in the state file.
+6. Fires a desktop notification on completion.
 
 **Reminders** (checked every tick):
 
@@ -459,21 +552,10 @@ The scheduler is an in-memory `setInterval` loop that ticks every 30 seconds.
 2. **Active one-time**: fires if `fireAt ≤ now` and hasn't fired yet.
 3. **Active recurring**: fires if cron expression matches (once per minute).
 4. **Snoozed**: fires if `snoozedUntil ≤ now`.
-5. On fire: shows desktop notification, updates `lastFiredAt`, and
-   transitions status (one-time → completed, recurring → stays active,
-   snoozed → completed or active depending on type).
-
-### Notifications
-
-Desktop notifications use Electron's `Notification` API when running
-inside Sero. In the Pi CLI (where Electron is unavailable), notifications
-fall back to `console.log`.
-
-> **Email channel**: The `email` channel is accepted as a configuration
-> option on reminders but is **not yet functional**. When selected, the
-> extension logs a warning and falls back to a desktop notification with
-> a "(email pending)" prefix. Implementing email delivery will require
-> SMTP configuration or an email API integration in a future release.
+5. On fire: shows desktop notification (with configured sound), updates
+   `lastFiredAt`, and transitions status (one-time → completed,
+   recurring → stays active, snoozed → completed or active depending on
+   type).
 
 ---
 
@@ -525,10 +607,12 @@ extension for the Sero platform. Key differences:
 |---|---|---|
 | **Storage** | `~/.pi/agent/pi-cron.tab` (custom text format) | `~/.sero-ui/apps/cron/state.json` (JSON) |
 | **UI** | Vanilla HTML/CSS/JS served via pi-webserver | React + Tailwind via Module Federation |
-| **State sync** | File watcher on `.tab` file reloads scheduler | `useAppState` + `fs.watch` syncs UI and extension |
+| **State sync** | File watcher on `.tab` file reloads scheduler | Directory-based `fs.watch` + `useAppState` |
 | **Scope** | Tied to `~/.pi/agent/` | Global (`~/.sero-ui/`) with Pi CLI fallback |
-| **Lock file** | PID lock at `~/.pi/agent/pi-cron.lock` | Not needed — single Electron process |
+| **Lock file** | PID lock at `~/.pi/agent/pi-cron.lock` | Not needed — singleton scheduler in Electron process |
 | **Web server** | Mounts on pi-webserver (`/cron`, `/api/cron`) | Not needed — federated UI is embedded |
 | **Settings** | `settings.json` → `pi-cron` key | State file only (scheduler toggled via UI or command) |
 | **Reminders** | Not supported | One-time + recurring reminders with snooze and notifications |
+| **Notifications** | Not supported | `sero:notify` EventBus → Electron Notification API with configurable sounds |
+| **Output capture** | Not supported | Agent responses saved in run results, viewable in History tab |
 | **Event API** | `cron:*` events for inter-extension communication | Not ported — apps communicate via shared state |

--- a/packages/pi-cron-extension/README.md
+++ b/packages/pi-cron-extension/README.md
@@ -1,8 +1,8 @@
 # @sero/cron
 
-Cron scheduler for [Sero](../../README.md) — schedule recurring agent prompts
-that run as isolated `pi -p` subprocesses. Manage jobs from the dashboard UI
-or ask the agent to create them for you.
+Cron scheduler and reminders for [Sero](../../README.md) — schedule recurring
+agent prompts and set reminders with desktop notifications. Manage everything
+from the dashboard UI or ask the agent naturally.
 
 Adapted from [@e9n/pi-cron](https://github.com/espennilsen/pi/tree/main/extensions/pi-cron)
 for the Sero platform. The Pi extension works standalone in the Pi CLI; the
@@ -10,21 +10,32 @@ React UI is Sero-only.
 
 ## Features
 
-- **Visual dashboard** — add, edit, enable/disable, and remove jobs from the
-  Sero UI. Live cron expression validation with human-readable previews.
-- **Agent tool** — the LLM can manage jobs through the `cron` tool, so you
-  can say "schedule a daily standup reminder at 9am" and it just works.
-- **No database** — jobs are stored as JSON in a single state file. Both the
+- **Reminders** — set one-time or recurring reminders with desktop
+  notifications. Ask the agent naturally ("Remind me in 1 hour to phone
+  mum") or create them from the UI.
+- **Snooze** — snooze fired reminders for 5 min, 15 min, 30 min, 1 hour,
+  3 hours, or until tomorrow 9am.
+- **Visual dashboard** — three tabs (Reminders, Jobs, History) for managing
+  everything. Live cron expression validation with human-readable previews.
+- **Agent tools** — two LLM-callable tools (`reminder` and `cron`) so you
+  can manage everything through natural conversation.
+- **No database** — all state is stored as JSON in a single file. Both the
   UI and the extension read/write the same file; changes sync instantly.
 - **Scheduler off by default** — nothing runs until you start it. Toggle from
   the UI or with `/cron on`.
-- **Isolated execution** — each job runs as a `pi -p --no-session` subprocess
-  with a 10-minute timeout. Jobs can't interfere with each other or with your
-  active chat.
-- **Run history** — the last 50 execution results (pass/fail, duration, errors)
-  are visible in the History tab.
-- **Global scope** — jobs are personal, not per-workspace. Your schedule
-  persists across all projects.
+- **Isolated job execution** — each cron job runs as a `pi -p --no-session`
+  subprocess with a 10-minute timeout. Jobs can't interfere with each other
+  or with your active chat.
+- **Run history** — the last 50 cron job execution results (pass/fail,
+  duration, errors) are visible in the History tab.
+- **Global scope** — jobs and reminders are personal, not per-workspace.
+  Your schedule persists across all projects.
+
+> **Note — Email notifications:** The reminder channel option includes
+> `email` alongside `notification` (desktop). However, **email delivery is
+> not yet implemented**. Selecting the email channel currently falls back to
+> a desktop notification with a "(email pending)" prefix. Email support
+> will require SMTP or API configuration in a future update.
 
 ---
 
@@ -32,34 +43,139 @@ React UI is Sero-only.
 
 ### Opening the app
 
-Click **Cron** (🕐) in the Sero sidebar. The dashboard has two tabs:
+Click **Cron** (🕐) in the Sero sidebar. The dashboard has three tabs:
 
 | Tab | What it shows |
 |-----|---------------|
-| **Jobs** | All configured cron jobs with status, schedule, and actions |
-| **History** | Recent execution results with pass/fail status and timing |
+| **Reminders** | All reminders with status filters, snooze, and management |
+| **Jobs** | Configured cron jobs with status, schedule, and actions |
+| **History** | Recent cron job execution results with pass/fail and timing |
 
-### Creating a job
+---
+
+### Reminders
+
+#### Creating a reminder
+
+**From the chat (recommended):**
+
+Ask the agent naturally — it will use the `reminder` tool:
+
+```
+Set a reminder for 1 hour to phone mum
+```
+
+```
+Remind me on Tuesday at 11am to wash the car
+```
+
+```
+Create a reminder every Friday morning to pay the cleaner
+```
+
+You can also specify a notification channel:
+
+```
+Remind me at 5pm to pick up the parcel, send it by email
+```
 
 **From the UI:**
 
-1. Click **+ New Job** (top-right corner or empty-state button).
+1. Click **+ Reminder** (top-right, visible when on the Reminders tab).
 2. Fill in the form:
+   - **Title** — what to remind you about (e.g. "Phone mum").
+   - **Notes** — optional extra details.
+   - **Type** — **One-time** (fires once at a specific datetime) or
+     **Recurring** (fires on a cron schedule).
+   - **When** (one-time) — pick a date and time with the datetime picker.
+     Defaults to 1 hour from now.
+   - **Schedule** (recurring) — a 5-field cron expression, or click a
+     preset pill (e.g. "Every Friday morning", "Weekday mornings").
+   - **Channel** — Desktop notification (default) or Email (coming soon).
+3. Click **Set Reminder**.
+
+#### Snoozing a reminder
+
+When a reminder fires, a desktop notification appears. You can snooze it
+from the Sero UI:
+
+1. Open the Reminders tab.
+2. Find the reminder (snoozed/recently fired reminders sort to the top).
+3. Click **💤 Snooze** and pick a duration:
+
+| Option | Behaviour |
+|--------|-----------|
+| 5 minutes | Re-fires in 5 min |
+| 15 minutes | Re-fires in 15 min |
+| 30 minutes | Re-fires in 30 min |
+| 1 hour | Re-fires in 1 hour |
+| 3 hours | Re-fires in 3 hours |
+| Tomorrow 9am | Re-fires at 9:00 AM tomorrow |
+
+Snoozing can also be done via the agent:
+
+```
+Snooze the reminder abc12345 for 30 minutes
+```
+
+#### Managing reminders
+
+Each reminder card has these actions:
+
+| Action | What it does |
+|--------|--------------|
+| **Edit** | Opens the form pre-filled with current values |
+| **⏸ Disable / ▶ Enable** | Pauses or resumes without removing |
+| **💤 Snooze** | Delays the next notification |
+| **✓ Done** | Marks the reminder as completed |
+| **Remove** | Permanently deletes the reminder |
+
+**Filter chips** above the list let you filter by status: All, Active,
+Snoozed, Done, or Paused. Reminders are sorted by urgency — snoozed
+reminders appear first, then active (soonest fire time first), then
+disabled, then completed.
+
+#### Reminder statuses
+
+| Status | Meaning |
+|--------|---------|
+| 🔔 **Active** | Scheduled and will fire when due |
+| 💤 **Snoozed** | Fired but user snoozed — will re-fire at the snooze expiry |
+| ✅ **Done** | Completed/dismissed (one-time auto-completes after firing) |
+| ⏸ **Paused** | User-disabled — won't fire until re-enabled |
+
+#### How reminder scheduling works
+
+- **One-time**: fires when the `fireAt` datetime passes, then auto-completes.
+- **Recurring**: uses cron matching (same as cron jobs) — fires every time
+  the schedule matches, stays active indefinitely.
+- **Snoozed**: the scheduler checks `snoozedUntil` every 30 seconds and
+  re-fires the notification when the snooze expires.
+
+---
+
+### Cron Jobs
+
+#### Creating a job
+
+**From the UI:**
+
+1. Switch to the **Jobs** tab.
+2. Click **+ Job** (top-right corner or empty-state button).
+3. Fill in the form:
    - **Name** — unique identifier, no spaces (e.g. `daily-standup`).
    - **Schedule** — a standard 5-field cron expression, or click a preset
-     pill to fill one in. The form validates in real time and shows a
-     human-readable description (e.g. "Weekdays at 09:00").
+     pill. The form validates in real time and shows a human-readable
+     description (e.g. "Weekdays at 09:00").
    - **Prompt** — the message sent to the agent when the job fires.
    - **Channel** — optional grouping tag (defaults to `cron`).
    - **Model** — optional model pattern or ID for this job
      (e.g. `sonnet`, `openai/gpt-4o`, `gemini:high`). Supports the
      `provider/id` shorthand and optional `:<thinking>` suffix. Leave
      blank to use whatever default is in your Pi settings.
-3. Click **Add Job**.
+4. Click **Add Job**.
 
 **From the chat:**
-
-Ask the agent naturally — it will use the `cron` tool:
 
 ```
 Schedule a job called "daily-standup" that runs at 9am on weekdays
@@ -73,7 +189,7 @@ Add a cron job called "cheap-health-check" that runs every 15 minutes
 using the model "flash" with the prompt "Check system health"
 ```
 
-### Cron expression syntax
+#### Cron expression syntax
 
 Schedules use standard 5-field cron format:
 
@@ -110,10 +226,23 @@ Schedules use standard 5-field cron format:
 | `0 0 1 * *` | Monthly on the 1st at midnight |
 | `30 8,12,17 * * *` | 8:30 AM, 12:30 PM, and 5:30 PM daily |
 
-### Starting the scheduler
+#### Managing jobs
 
-Jobs are stored immediately when created, but they only **execute** when
-the scheduler is running.
+Each job card in the Jobs tab has four actions:
+
+| Action | What it does |
+|--------|--------------|
+| **Edit** | Opens the job form pre-filled with current values. Name cannot be changed. |
+| **⏸ Disable / ▶ Enable** | Pauses or resumes a job without removing it. |
+| **▶ Run** | Triggers the job immediately (requires the scheduler to be active). |
+| **Remove** | Permanently deletes the job. |
+
+---
+
+### Scheduler
+
+Jobs and reminders are stored immediately when created, but they only
+**execute** when the scheduler is running.
 
 **From the UI:** Click the **▶ Start** button in the status bar at the top
 of the dashboard.
@@ -121,64 +250,56 @@ of the dashboard.
 **From the chat:** Type `/cron on` or ask the agent to start it.
 
 The status bar shows a green dot and "Scheduler Active" when running. It
-also displays job counts (total, active, paused).
+also displays counts for jobs, active jobs, paused jobs, and active
+reminders.
 
-### Autostart
+**Stopping:** Click **⏸ Stop** in the status bar or type `/cron off`.
+Stopping does not remove any jobs or reminders — they'll resume next
+time you start it. The scheduler also stops automatically when Sero quits.
+
+#### Autostart
 
 Toggle the **Autostart** switch in the status bar to have the scheduler
 start automatically whenever Sero launches. When enabled, the extension
-boots the scheduler on session start (as long as at least one job exists).
-The setting persists across restarts — flip it once and forget about it.
-
-### Managing jobs
-
-Each job card in the Jobs tab has four actions:
-
-| Action | What it does |
-|--------|--------------|
-| **Edit** | Opens the job form pre-filled with current values. Name cannot be changed. |
-| **⏸ Disable / ▶ Enable** | Pauses or resumes a job without removing it. Disabled jobs stay in the list but won't fire on schedule. |
-| **▶ Run** | Triggers the job immediately (requires the scheduler to be active). |
-| **Remove** | Permanently deletes the job. |
-
-All of these can also be done via the agent:
-
-```
-Disable the daily-standup cron job
-```
-
-```
-Remove the health-check job
-```
-
-### Viewing history
-
-Switch to the **History** tab to see recent executions. Each entry shows:
-
-- ● Green dot (success) or red dot (failure)
-- Job name
-- Duration badge
-- Error message (if failed)
-- Relative timestamp ("2m ago", "1h ago")
-
-The last 50 results are kept. History is stored in the same state file and
-persists across sessions.
-
-### Stopping the scheduler
-
-**From the UI:** Click **⏸ Stop** in the status bar.
-
-**From the chat:** Type `/cron off`.
-
-Stopping the scheduler does not remove any jobs — they'll resume next time
-you start it. The scheduler also stops automatically when Sero quits.
+boots the scheduler on session start (as long as at least one job or
+reminder exists). The setting persists across restarts.
 
 ---
 
 ## Agent Tool Reference
 
-The `cron` tool is available to the LLM in both Sero and the Pi CLI. In
-Sero it's bridged through the `sero-cli` tool automatically.
+### `reminder` tool
+
+Manage reminders with desktop notifications. In Sero it's bridged through
+the `sero-cli` tool automatically.
+
+| Action | Required params | Optional params | Description |
+|--------|----------------|-----------------|-------------|
+| `list` | — | — | Show all reminders grouped by status |
+| `add` | `title` | `notes`, `channel`, `type`, `fire_at`, `schedule` | Create a reminder |
+| `update` | `id` | `title`, `notes`, `channel`, `fire_at`, `schedule` | Modify a reminder |
+| `remove` | `id` | — | Delete a reminder |
+| `snooze` | `id` | `snooze_minutes` | Snooze (default 15 min, use -1 for tomorrow 9am) |
+| `complete` | `id` | — | Mark as done/dismiss |
+| `enable` | `id` | — | Re-enable a disabled reminder |
+| `disable` | `id` | — | Pause a reminder without removing it |
+
+**Parameter details:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `id` | 8-character reminder ID (shown in list output) |
+| `title` | What to remind about |
+| `notes` | Optional extra details |
+| `channel` | `"notification"` (desktop, default) or `"email"` (not yet implemented) |
+| `type` | `"once"` (default) — fires at `fire_at`; `"recurring"` — fires on `schedule` |
+| `fire_at` | ISO datetime for one-time reminders (e.g. `"2025-03-15T14:30:00"`) |
+| `schedule` | Cron expression for recurring (e.g. `"0 9 * * 5"` = Fridays at 9am) |
+| `snooze_minutes` | Minutes to snooze (default 15). Use `-1` for "tomorrow 9am". |
+
+### `cron` tool
+
+Manage scheduled cron jobs.
 
 | Action | Required params | Optional params | Description |
 |--------|----------------|-----------------|-------------|
@@ -192,16 +313,15 @@ Sero it's bridged through the `sero-cli` tool automatically.
 
 The `model` parameter accepts any value that `pi --model` accepts: a model
 name (`sonnet`, `flash`), a `provider/id` pair (`openai/gpt-4o`), or a
-name with a thinking-level suffix (`sonnet:high`). When omitted, the job
-uses your default model.
+name with a thinking-level suffix (`sonnet:high`).
 
-## Commands
+### Commands
 
 | Command | Description |
 |---------|-------------|
 | `/cron on` | Start the scheduler |
 | `/cron off` | Stop the scheduler |
-| `/cron` | Show status (active/inactive, job count) |
+| `/cron` | Show status (active/inactive, job count, reminder count) |
 
 ---
 
@@ -209,24 +329,32 @@ uses your default model.
 
 ```
 packages/pi-cron-extension/
-├── package.json              # Pi + Sero manifest (global scope, port 5188)
-├── vite.config.ts            # Module Federation remote config
+├── package.json                # Pi + Sero manifest (global scope, port 5188)
+├── vite.config.ts              # Module Federation remote config
 ├── shared/
-│   ├── types.ts              # CronJob, CronState, CronRunResult
-│   └── cron.ts               # 5-field parser, validator, cronToHuman
+│   ├── types.ts                # CronJob, Reminder, CronState, CronRunResult
+│   ├── cron.ts                 # 5-field parser, validator, cronToHuman
+│   └── reminder-utils.ts       # Fire-time checks, snooze, status helpers
 ├── extension/
-│   ├── index.ts              # Tool, /cron command, scheduler lifecycle
-│   └── scheduler.ts          # CronScheduler — tick loop + subprocess runner
+│   ├── index.ts                # Tools (cron + reminder), /cron cmd, lifecycle
+│   ├── scheduler.ts            # CronScheduler — tick loop, jobs + reminders
+│   ├── actions.ts              # Cron job action handlers
+│   ├── reminder-actions.ts     # Reminder action handlers (CRUD + snooze)
+│   ├── notifier.ts             # Desktop notification delivery
+│   └── logger.ts               # File-based structured logger
 └── ui/
-    ├── CronApp.tsx            # Root component — tabs, job list, status
+    ├── CronApp.tsx              # Root — tabs (Reminders, Jobs, History)
     ├── components/
-    │   ├── SchedulerBar.tsx   # Status indicator + start/stop toggle
-    │   ├── JobCard.tsx        # Single job display with actions
-    │   ├── JobForm.tsx        # Add/edit dialog with presets + validation
-    │   └── RunHistory.tsx     # Recent execution results
+    │   ├── SchedulerBar.tsx     # Status indicator + start/stop + autostart
+    │   ├── ReminderCard.tsx     # Single reminder with snooze dropdown
+    │   ├── ReminderForm.tsx     # Add/edit reminder dialog
+    │   ├── ReminderList.tsx     # Filterable reminder list with sorting
+    │   ├── JobCard.tsx          # Single job display with actions
+    │   ├── JobForm.tsx          # Add/edit job dialog with presets
+    │   └── RunHistory.tsx       # Recent cron execution results
     ├── lib/
-    │   └── cron-utils.ts      # Presets, formatDuration, timeAgo
-    ├── styles.css             # Tailwind + theme tokens
+    │   └── cron-utils.ts        # Presets, formatDuration, timeAgo
+    ├── styles.css               # Tailwind + theme tokens + animations
     ├── tsconfig.json
     └── index.html
 ```
@@ -239,19 +367,23 @@ packages/pi-cron-extension/
                  ┌────────┴────────┐
                  │                 │
            Pi Extension        React UI
-           (cron tool)         (useAppState)
-                 │                 │
-                 ▼                 ▼
-           CronScheduler      Dashboard
-           ticks every 30s    add/edit/remove
-           spawns pi -p       toggle scheduler
-           appends results    view history
+           (cron + reminder    (useAppState)
+            tools)                 │
+                 │                 ▼
+                 ▼            Dashboard
+           CronScheduler      ├─ Reminders tab
+           ticks every 30s    ├─ Jobs tab
+           ├─ cron matching   └─ History tab
+           ├─ reminder checks
+           ├─ snooze expiry
+           └─ notifications
 ```
 
 Both sides read and write the same JSON file. The file IS the API:
 
-- **Extension → file**: tool calls (add, remove, etc.) and scheduler run
-  results write directly to `state.json` with atomic writes (temp + rename).
+- **Extension → file**: tool calls and scheduler events write to
+  `state.json` with atomic writes (temp + rename) protected by an
+  async mutex.
 - **File → UI**: Sero's `AppStateManager` watches the file with `fs.watch`
   and pushes updates to the renderer via IPC. React re-renders instantly.
 - **UI → file**: `useAppState` calls write through IPC to the main process,
@@ -261,34 +393,50 @@ Both sides read and write the same JSON file. The file IS the API:
 ### State shape
 
 ```typescript
+interface CronState {
+  jobs: CronJob[];
+  reminders: Reminder[];
+  schedulerActive: boolean;
+  autostart: boolean;
+  lastRunResults: CronRunResult[];  // Capped at 50
+}
+
 interface CronJob {
   name: string;        // Unique identifier
   schedule: string;    // 5-field cron expression
   prompt: string;      // Agent prompt
   channel: string;     // Grouping tag (default: "cron")
-  disabled: boolean;   // Paused — won't fire on schedule
+  disabled: boolean;
   model?: string;      // Model pattern (e.g. "sonnet", "openai/gpt-4o")
+}
+
+interface Reminder {
+  id: string;          // 8-char unique ID
+  title: string;
+  notes?: string;
+  channel: 'notification' | 'email';
+  type: 'once' | 'recurring';
+  fireAt?: string;     // ISO datetime (one-time)
+  schedule?: string;   // Cron expression (recurring)
+  status: 'active' | 'snoozed' | 'completed' | 'disabled';
+  snoozedUntil?: string;  // ISO datetime
+  createdAt: string;
+  lastFiredAt?: string;
+  completedAt?: string;
 }
 
 interface CronRunResult {
   jobName: string;
-  startedAt: string;   // ISO timestamp
+  startedAt: string;
   durationMs: number;
   ok: boolean;
   error?: string;
-}
-
-interface CronState {
-  jobs: CronJob[];
-  schedulerActive: boolean;
-  autostart: boolean;               // Start scheduler on launch
-  lastRunResults: CronRunResult[];  // Capped at 50
 }
 ```
 
 ### Global scope
 
-Cron jobs are personal, not project-specific. State lives at
+Jobs and reminders are personal, not project-specific. State lives at
 `~/.sero-ui/apps/cron/state.json` regardless of which workspace is active.
 In the Pi CLI (where `SERO_HOME` is unset), the extension falls back to
 `.sero/apps/cron/state.json` relative to the working directory.
@@ -296,18 +444,36 @@ In the Pi CLI (where `SERO_HOME` is unset), the extension falls back to
 ### Scheduler
 
 The scheduler is an in-memory `setInterval` loop that ticks every 30 seconds.
-On each tick it:
 
-1. Deduplicates by minute (only fires once per calendar minute).
-2. Iterates all non-disabled jobs.
-3. Matches each job's cron expression against the current local time.
-4. For matches, spawns `pi -p --no-session --no-extensions <prompt>` as a
-   child process with a 10-minute timeout.
-5. Appends the result (pass/fail, duration, error) to `lastRunResults` in
-   the state file.
+**Cron jobs** (checked once per minute):
 
-The scheduler resets to inactive on startup — it does not survive process
-restarts. Start it explicitly each session.
+1. Iterates all non-disabled jobs.
+2. Matches each job's cron expression against the current local time.
+3. For matches, spawns `pi -p --no-session <prompt>` as a child process
+   with a 10-minute timeout.
+4. Appends the result to `lastRunResults` in the state file.
+
+**Reminders** (checked every tick):
+
+1. Iterates all reminders.
+2. **Active one-time**: fires if `fireAt ≤ now` and hasn't fired yet.
+3. **Active recurring**: fires if cron expression matches (once per minute).
+4. **Snoozed**: fires if `snoozedUntil ≤ now`.
+5. On fire: shows desktop notification, updates `lastFiredAt`, and
+   transitions status (one-time → completed, recurring → stays active,
+   snoozed → completed or active depending on type).
+
+### Notifications
+
+Desktop notifications use Electron's `Notification` API when running
+inside Sero. In the Pi CLI (where Electron is unavailable), notifications
+fall back to `console.log`.
+
+> **Email channel**: The `email` channel is accepted as a configuration
+> option on reminders but is **not yet functional**. When selected, the
+> extension logs a warning and falls back to a desktop notification with
+> a "(email pending)" prefix. Implementing email delivery will require
+> SMTP configuration or an email API integration in a future release.
 
 ---
 
@@ -344,7 +510,8 @@ pnpm --filter @sero/cron typecheck
 | File | Contents |
 |------|----------|
 | `/tmp/sero-remote-cron.log` | Cron remote Vite dev server |
-| `/tmp/sero-electron.log` | Extension loading, scheduler events |
+| `/tmp/sero-electron.log` | Extension loading, scheduler events, reminder fires |
+| `~/.sero-ui/apps/cron/cron.log` | Structured extension log (rotates at 1 MB) |
 
 ---
 
@@ -362,5 +529,6 @@ extension for the Sero platform. Key differences:
 | **Scope** | Tied to `~/.pi/agent/` | Global (`~/.sero-ui/`) with Pi CLI fallback |
 | **Lock file** | PID lock at `~/.pi/agent/pi-cron.lock` | Not needed — single Electron process |
 | **Web server** | Mounts on pi-webserver (`/cron`, `/api/cron`) | Not needed — federated UI is embedded |
-| **Settings** | `settings.json` → `pi-cron` key (autostart, activeHours, etc.) | State file only (scheduler toggled via UI or command) |
+| **Settings** | `settings.json` → `pi-cron` key | State file only (scheduler toggled via UI or command) |
+| **Reminders** | Not supported | One-time + recurring reminders with snooze and notifications |
 | **Event API** | `cron:*` events for inter-extension communication | Not ported — apps communicate via shared state |

--- a/packages/pi-cron-extension/extension/actions.ts
+++ b/packages/pi-cron-extension/extension/actions.ts
@@ -7,7 +7,7 @@
 
 import type { CronState, CronJob, CronRunResult } from '../shared/types';
 import { validateCron } from '../shared/cron';
-import type { CronScheduler } from './scheduler';
+import { type CronScheduler, stripExtensionNoise } from './scheduler';
 import { runPiSubprocess } from './scheduler';
 import { info, error as logError } from './logger';
 
@@ -188,11 +188,13 @@ export function handleRun(
     .then(async (sub) => {
       const durationMs = Date.now() - startedAt.getTime();
       const ok = sub.exitCode === 0 || !!sub.stdout;
+      const output = stripExtensionNoise(sub.stdout);
       const runResult: CronRunResult = {
         jobName: runJob.name,
         startedAt: startedAt.toISOString(),
         durationMs,
         ok,
+        output: output.slice(0, 4000),
         error: ok
           ? undefined
           : (sub.stderr || `Exit code ${sub.exitCode}`).slice(0, 2000),

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -37,12 +37,16 @@ import {
 
 // ── Module-level singleton state ───────────────────────────────
 // Shared across all invocations of the default export (multiple sessions).
+// The scheduler is ref-counted: each session_start increments, each
+// session_shutdown decrements. The scheduler only stops when all sessions
+// have shut down (refCount reaches 0).
 
 let statePath = '';
 let workspaceCwd = '';
 let scheduler: CronScheduler | null = null;
 let stateWatcher: StateWatcher | null = null;
 let initialized = false;
+let sessionRefCount = 0;
 
 function getStatePath(): string { return statePath; }
 function getScheduler(): CronScheduler | null { return scheduler; }
@@ -121,10 +125,10 @@ async function ensureInitialized(cwd: string): Promise<void> {
     info('scheduler:autostart', { jobs: state.jobs.length, reminders: state.reminders.length });
     scheduler = createScheduler();
     scheduler.start(state.jobs, workspaceCwd, state.reminders);
-    startStateWatcher();
-    stateWatcher?.markOwnWrite();
     state.schedulerActive = true;
+    // Write first to ensure the directory exists before arming the watcher
     await writeState(statePath, state);
+    startStateWatcher();
   } else if (state.schedulerActive) {
     info('scheduler:reset-stale-flag');
     state.schedulerActive = false;
@@ -144,9 +148,10 @@ async function startScheduler(): Promise<string> {
   const state = await readState(statePath);
   scheduler = createScheduler();
   scheduler.start(state.jobs, workspaceCwd, state.reminders);
-  startStateWatcher();
   state.schedulerActive = true;
+  // Write first to ensure the directory exists before arming the watcher
   await writeState(statePath, state);
+  startStateWatcher();
   const activeReminders = state.reminders.filter(
     (r) => r.status === 'active' || r.status === 'snoozed',
   ).length;
@@ -227,20 +232,40 @@ export default function (pi: ExtensionAPI) {
   pi.on('session_start', async (_event, ctx) => {
     if (!initialized) initLogger(pi, resolveStatePath(ctx.cwd));
     await ensureInitialized(ctx.cwd);
-    info('session:start', { cwd: ctx.cwd });
+    sessionRefCount++;
+    info('session:start', { cwd: ctx.cwd, refCount: sessionRefCount });
   });
 
   pi.on('session_switch', async (_event, ctx) => {
-    statePath = resolveStatePath(ctx.cwd);
-    setLogPath(statePath);
+    // Only update the global statePath if it resolves to the same location.
+    // In Sero mode (SERO_HOME set) all sessions share one path. In Pi CLI
+    // mode different cwds would resolve differently — don't overwrite so
+    // the scheduler keeps writing to the original state file.
+    const newPath = resolveStatePath(ctx.cwd);
+    if (newPath === statePath) {
+      setLogPath(statePath);
+    } else {
+      warn('session:switch-path-mismatch', {
+        current: statePath,
+        requested: newPath,
+        hint: 'Ignoring — scheduler bound to original state path',
+      });
+    }
     info('session:switch', { cwd: ctx.cwd });
   });
 
   pi.on('session_shutdown', async () => {
-    info('session:shutdown', { schedulerWasRunning: scheduler?.isRunning() ?? false });
-    stateWatcher?.stop();
-    stateWatcher = null;
-    if (scheduler?.isRunning()) { scheduler.stop(); scheduler = null; }
+    sessionRefCount = Math.max(0, sessionRefCount - 1);
+    info('session:shutdown', { refCount: sessionRefCount, schedulerRunning: scheduler?.isRunning() ?? false });
+
+    // Only tear down the singleton when the last session exits
+    if (sessionRefCount === 0) {
+      stateWatcher?.stop();
+      stateWatcher = null;
+      if (scheduler?.isRunning()) { scheduler.stop(); scheduler = null; }
+      // Allow re-initialization if a new session starts later
+      initialized = false;
+    }
   });
 
   // ── Command: /cron ─────────────────────────────────────────

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -1,208 +1,233 @@
 /**
- * Cron Extension — Pi extension for managing scheduled cron jobs.
+ * Cron Extension — Pi extension for managing scheduled cron jobs and reminders.
  *
  * Global-scoped: state at ~/.sero-ui/apps/cron/state.json (Sero)
  * or .sero/apps/cron/state.json relative to cwd (Pi CLI fallback).
  *
- * Tools (LLM-callable): cron (list, add, update, remove, enable, disable, run)
- * Commands (user): /cron
+ * Tools: current_time, cron, reminder
+ * Commands: /cron
+ *
+ * IMPORTANT: The scheduler is a MODULE-LEVEL singleton. The default export
+ * may be called multiple times (once per Sero session), but only one
+ * scheduler exists per process. This prevents double job execution.
  */
 
-import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { StringEnum } from '@mariozechner/pi-ai';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Text } from '@mariozechner/pi-tui';
 import { Type } from '@sinclair/typebox';
 
-import type { CronState, CronRunResult } from '../shared/types';
-import { DEFAULT_CRON_STATE, MAX_RUN_RESULTS } from '../shared/types';
+import type { CronRunResult, Reminder } from '../shared/types';
+import { MAX_RUN_RESULTS } from '../shared/types';
+import { resolveStatePath, withStateLock, readState, writeState } from './state-io';
 import { CronScheduler } from './scheduler';
+import { StateWatcher } from './state-watcher';
 import { initLogger, setLogPath, info, warn, error as logError } from './logger';
+import { initNotifier, notifyReminder, notifyJobComplete } from './notifier';
 import {
   handleList, handleAdd, handleUpdate, handleRemove,
-  handleToggle, handleRun,
-  type ActionDeps,
+  handleToggle, handleRun, type ActionDeps,
 } from './actions';
+import {
+  handleReminderList, handleReminderAdd, handleReminderUpdate,
+  handleReminderRemove, handleReminderSnooze, handleReminderComplete,
+  handleReminderToggle, type ReminderActionDeps,
+} from './reminder-actions';
 
-// ── State file path ────────────────────────────────────────────
+// ── Module-level singleton state ───────────────────────────────
+// Shared across all invocations of the default export (multiple sessions).
 
-const STATE_REL_PATH = path.join('.sero', 'apps', 'cron', 'state.json');
+let statePath = '';
+let workspaceCwd = '';
+let scheduler: CronScheduler | null = null;
+let stateWatcher: StateWatcher | null = null;
+let initialized = false;
 
-function resolveStatePath(cwd: string): string {
-  const seroHome = process.env.SERO_HOME;
-  if (seroHome) {
-    return path.join(seroHome, 'apps', 'cron', 'state.json');
+function getStatePath(): string { return statePath; }
+function getScheduler(): CronScheduler | null { return scheduler; }
+function getCwd(): string { return workspaceCwd; }
+
+// ── Scheduler helpers (module-level, use singleton state) ──────
+
+async function appendRunResult(result: CronRunResult): Promise<void> {
+  if (!statePath) return;
+  await withStateLock(async () => {
+    const state = await readState(statePath);
+    state.lastRunResults.unshift(result);
+    if (state.lastRunResults.length > MAX_RUN_RESULTS) {
+      state.lastRunResults = state.lastRunResults.slice(0, MAX_RUN_RESULTS);
+    }
+    stateWatcher?.markOwnWrite();
+    await writeState(statePath, state);
+  });
+}
+
+async function persistReminderUpdate(updated: Reminder): Promise<void> {
+  if (!statePath) return;
+  await withStateLock(async () => {
+    const state = await readState(statePath);
+    const idx = state.reminders.findIndex((r) => r.id === updated.id);
+    if (idx >= 0) {
+      state.reminders[idx] = updated;
+      stateWatcher?.markOwnWrite();
+      await writeState(statePath, state);
+    }
+  });
+}
+
+function createScheduler(): CronScheduler {
+  return new CronScheduler({
+    onJobComplete: async (result) => {
+      await appendRunResult(result).catch(() => {});
+      const state = statePath ? await readState(statePath) : null;
+      notifyJobComplete(result.jobName, result.ok, result.durationMs, state?.notificationSettings ?? undefined);
+    },
+    onReminderFire: async (reminder) => {
+      const state = statePath ? await readState(statePath) : null;
+      notifyReminder(reminder, state?.notificationSettings ?? undefined);
+    },
+    onReminderUpdate: (updated) => { persistReminderUpdate(updated).catch(() => {}); },
+  });
+}
+
+function startStateWatcher(): void {
+  stateWatcher?.stop();
+  if (!statePath) return;
+  stateWatcher = new StateWatcher(statePath, () => scheduler);
+  stateWatcher.start();
+}
+
+// ── Initialization (runs once per process) ─────────────────────
+
+async function ensureInitialized(cwd: string): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+
+  statePath = resolveStatePath(cwd);
+  workspaceCwd = cwd;
+  // Logger init needs a pi ref — deferred to first pi.on or tool call
+  info('init', { cwd, statePath });
+
+  if (process.env.SERO_CRON_SUBPROCESS) {
+    info('init:subprocess-mode');
+    return;
   }
-  return path.join(cwd, STATE_REL_PATH);
-}
 
-// ── File I/O (atomic writes with mutex) ────────────────────────
+  const state = await readState(statePath);
+  const hasWork = state.jobs.length > 0 || (state.reminders?.length ?? 0) > 0;
 
-/**
- * Simple async mutex to serialise read-modify-write cycles on state.json.
- * Prevents concurrent tool calls or scheduler callbacks from clobbering
- * each other's writes.
- */
-let stateMutexQueue: Promise<void> = Promise.resolve();
-
-function withStateLock<T>(fn: () => Promise<T>): Promise<T> {
-  const prev = stateMutexQueue;
-  let resolve: () => void;
-  stateMutexQueue = new Promise<void>((r) => { resolve = r; });
-  return prev.then(fn).finally(() => resolve!());
-}
-
-async function readState(filePath: string): Promise<CronState> {
-  try {
-    const raw = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(raw) as CronState;
-  } catch {
-    return { ...DEFAULT_CRON_STATE, jobs: [], lastRunResults: [] };
+  if (state.autostart && hasWork) {
+    info('scheduler:autostart', { jobs: state.jobs.length, reminders: state.reminders.length });
+    scheduler = createScheduler();
+    scheduler.start(state.jobs, workspaceCwd, state.reminders);
+    startStateWatcher();
+    stateWatcher?.markOwnWrite();
+    state.schedulerActive = true;
+    await writeState(statePath, state);
+  } else if (state.schedulerActive) {
+    info('scheduler:reset-stale-flag');
+    state.schedulerActive = false;
+    await writeState(statePath, state);
   }
 }
 
-async function writeState(
-  filePath: string,
-  state: CronState,
-): Promise<void> {
-  const dir = path.dirname(filePath);
-  await fs.mkdir(dir, { recursive: true });
-
-  const tmpPath = `${filePath}.tmp.${Date.now()}`;
-  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
-  await fs.rename(tmpPath, filePath);
+async function startScheduler(): Promise<string> {
+  if (scheduler?.isRunning()) {
+    warn('scheduler:start-skipped', { reason: 'already running' });
+    return 'Scheduler is already running.';
+  }
+  if (!statePath) {
+    logError('scheduler:start-failed', { reason: 'no state path' });
+    return 'Error: no state path resolved.';
+  }
+  const state = await readState(statePath);
+  scheduler = createScheduler();
+  scheduler.start(state.jobs, workspaceCwd, state.reminders);
+  startStateWatcher();
+  state.schedulerActive = true;
+  await writeState(statePath, state);
+  const activeReminders = state.reminders.filter(
+    (r) => r.status === 'active' || r.status === 'snoozed',
+  ).length;
+  info('scheduler:started', { jobs: state.jobs.length, activeReminders });
+  return `✓ Scheduler started (${state.jobs.length} jobs, ${activeReminders} reminders)`;
 }
 
-// ── Tool parameters ────────────────────────────────────────────
+async function stopScheduler(): Promise<string> {
+  if (!scheduler?.isRunning()) {
+    warn('scheduler:stop-skipped', { reason: 'not running' });
+    return 'Scheduler is not running.';
+  }
+  stateWatcher?.stop();
+  stateWatcher = null;
+  scheduler.stop();
+  scheduler = null;
+  if (statePath) {
+    const state = await readState(statePath);
+    state.schedulerActive = false;
+    await writeState(statePath, state);
+  }
+  return '✓ Scheduler stopped';
+}
+
+// ── Tool parameter schemas ─────────────────────────────────────
 
 const CronParams = Type.Object({
-  action: StringEnum([
-    'list', 'add', 'update', 'remove',
-    'enable', 'disable', 'run',
-  ] as const),
-  name: Type.Optional(
-    Type.String({ description: 'Job name (required for all except list)' }),
-  ),
-  schedule: Type.Optional(
-    Type.String({
-      description:
-        'Cron expression: "min hour dom month dow". Example: "0 9 * * 1-5" = weekdays at 9am',
-    }),
-  ),
-  prompt: Type.Optional(
-    Type.String({
-      description: 'Prompt to send to the agent when the job fires',
-    }),
-  ),
-  channel: Type.Optional(
-    Type.String({ description: 'Channel tag for grouping (default: "cron")' }),
-  ),
-  model: Type.Optional(
-    Type.String({
-      description:
-        'Model pattern or ID for this job (e.g. "sonnet", "openai/gpt-4o"). ' +
-        'Supports "provider/id" and optional ":<thinking>" suffix. ' +
-        'Omit to use the default model.',
-    }),
-  ),
+  action: StringEnum(['list', 'add', 'update', 'remove', 'enable', 'disable', 'run'] as const),
+  name: Type.Optional(Type.String({ description: 'Job name (required for all except list)' })),
+  schedule: Type.Optional(Type.String({
+    description: 'Cron expression: "min hour dom month dow". Example: "0 9 * * 1-5" = weekdays at 9am',
+  })),
+  prompt: Type.Optional(Type.String({ description: 'Prompt to send to the agent when the job fires' })),
+  channel: Type.Optional(Type.String({ description: 'Channel tag for grouping (default: "cron")' })),
+  model: Type.Optional(Type.String({ description: 'Model pattern or ID. Omit for default.' })),
 });
 
-// ── Extension ──────────────────────────────────────────────────
+const ReminderParams = Type.Object({
+  action: StringEnum(['list', 'add', 'update', 'remove', 'snooze', 'complete', 'enable', 'disable'] as const),
+  id: Type.Optional(Type.String({ description: 'Reminder ID (required for all except list/add)' })),
+  title: Type.Optional(Type.String({ description: 'Reminder title (required for add)' })),
+  notes: Type.Optional(Type.String({ description: 'Optional notes or details' })),
+  channel: Type.Optional(Type.String({ description: 'Delivery channel: "notification" (default) or "email"' })),
+  type: Type.Optional(Type.String({ description: '"once" (default) or "recurring"' })),
+  fire_at: Type.Optional(Type.String({
+    description: 'ISO datetime for one-time reminders. IMPORTANT: call current_time first to get the accurate current time.',
+  })),
+  schedule: Type.Optional(Type.String({ description: 'Cron expression for recurring reminders' })),
+  snooze_minutes: Type.Optional(Type.Number({ description: 'Snooze duration in minutes (default: 15). -1 for tomorrow 9am.' })),
+});
+
+// ── Extension factory (called per session) ─────────────────────
 
 export default function (pi: ExtensionAPI) {
   console.log('[cron] extension loaded');
-  let statePath = '';
-  let workspaceCwd = '';
-  let scheduler: CronScheduler | null = null;
 
-  // ── Scheduler callbacks ────────────────────────────────────
+  // Wire notification emitter (last writer wins — all pi instances share the same EventBus)
+  initNotifier(pi.events.emit.bind(pi.events));
 
-  async function appendRunResult(result: CronRunResult): Promise<void> {
-    if (!statePath) return;
-    await withStateLock(async () => {
-      const state = await readState(statePath);
-      state.lastRunResults.unshift(result);
-      if (state.lastRunResults.length > MAX_RUN_RESULTS) {
-        state.lastRunResults = state.lastRunResults.slice(0, MAX_RUN_RESULTS);
-      }
-      await writeState(statePath, state);
+  // Initialize logger with pi ref (needed for console prefix)
+  // Only the first call sets the file path; subsequent calls update the pi ref.
+  if (statePath) {
+    initLogger(pi, statePath);
+  }
+
+  // Eagerly initialize in Sero mode (once per process)
+  const seroHome = process.env.SERO_HOME;
+  if (seroHome && !process.env.SERO_CRON_SUBPROCESS && !initialized) {
+    const globalCwd = path.join(seroHome, 'workspaces', 'global');
+    initLogger(pi, resolveStatePath(globalCwd));
+    ensureInitialized(globalCwd).catch((err) => {
+      console.error('[cron] eager init failed:', err);
     });
-  }
-
-  function createScheduler(): CronScheduler {
-    return new CronScheduler({
-      onJobComplete: (result) => {
-        appendRunResult(result).catch(() => {});
-      },
-    });
-  }
-
-  async function startScheduler(): Promise<string> {
-    if (scheduler?.isRunning()) {
-      warn('scheduler:start-skipped', { reason: 'already running' });
-      return 'Scheduler is already running.';
-    }
-    if (!statePath) {
-      logError('scheduler:start-failed', { reason: 'no state path' });
-      return 'Error: no state path resolved.';
-    }
-
-    const state = await readState(statePath);
-    scheduler = createScheduler();
-    scheduler.start(state.jobs, workspaceCwd);
-
-    state.schedulerActive = true;
-    await writeState(statePath, state);
-
-    return `✓ Cron scheduler started (${state.jobs.length} jobs loaded)`;
-  }
-
-  async function stopScheduler(): Promise<string> {
-    if (!scheduler?.isRunning()) {
-      warn('scheduler:stop-skipped', { reason: 'not running' });
-      return 'Scheduler is not running.';
-    }
-    scheduler.stop();
-    scheduler = null;
-
-    if (statePath) {
-      const state = await readState(statePath);
-      state.schedulerActive = false;
-      await writeState(statePath, state);
-    }
-
-    return '✓ Cron scheduler stopped';
   }
 
   // ── Lifecycle ──────────────────────────────────────────────
 
   pi.on('session_start', async (_event, ctx) => {
-    statePath = resolveStatePath(ctx.cwd);
-    workspaceCwd = ctx.cwd;
-    initLogger(pi, statePath);
-    info('session:start', { cwd: ctx.cwd, statePath });
-
-    // Skip scheduler in cron subprocess to prevent fork-bomb recursion.
-    // The subprocess only needs the tool registrations, not the scheduler.
-    if (process.env.SERO_CRON_SUBPROCESS) {
-      info('session:start:subprocess-mode');
-      return;
-    }
-
-    const state = await readState(statePath);
-
-    if (state.autostart && state.jobs.length > 0) {
-      info('scheduler:autostart', { jobs: state.jobs.length });
-      scheduler = createScheduler();
-      scheduler.start(state.jobs, workspaceCwd);
-      state.schedulerActive = true;
-      await writeState(statePath, state);
-    } else if (state.schedulerActive) {
-      info('scheduler:reset-stale-flag');
-      state.schedulerActive = false;
-      await writeState(statePath, state);
-    }
+    if (!initialized) initLogger(pi, resolveStatePath(ctx.cwd));
+    await ensureInitialized(ctx.cwd);
+    info('session:start', { cwd: ctx.cwd });
   });
 
   pi.on('session_switch', async (_event, ctx) => {
@@ -213,111 +238,142 @@ export default function (pi: ExtensionAPI) {
 
   pi.on('session_shutdown', async () => {
     info('session:shutdown', { schedulerWasRunning: scheduler?.isRunning() ?? false });
-    if (scheduler?.isRunning()) {
-      scheduler.stop();
-      scheduler = null;
-    }
+    stateWatcher?.stop();
+    stateWatcher = null;
+    if (scheduler?.isRunning()) { scheduler.stop(); scheduler = null; }
   });
 
   // ── Command: /cron ─────────────────────────────────────────
 
   pi.registerCommand('cron', {
-    description: 'Toggle cron scheduler: /cron on | /cron off | /cron status',
+    description: 'Toggle scheduler: /cron on | /cron off | /cron status',
     handler: async (args, ctx) => {
+      if (ctx.cwd) await ensureInitialized(ctx.cwd);
       const arg = args?.trim().toLowerCase();
-
       if (arg === 'on' || arg === 'start') {
-        const result = await startScheduler();
-        ctx.ui?.notify(result, result.startsWith('✓') ? 'info' : 'error');
+        const r = await startScheduler();
+        ctx.ui?.notify(r, r.startsWith('✓') ? 'info' : 'error');
       } else if (arg === 'off' || arg === 'stop') {
-        const result = await stopScheduler();
-        ctx.ui?.notify(result, result.startsWith('✓') ? 'info' : 'error');
+        const r = await stopScheduler();
+        ctx.ui?.notify(r, r.startsWith('✓') ? 'info' : 'error');
       } else {
         const active = scheduler?.isRunning() ?? false;
         const state = await readState(statePath);
-        const lines = [
-          `Scheduler: ${active ? '✅ active' : '⏸ inactive'}`,
-          `Jobs: ${state.jobs.length}`,
-        ];
-        ctx.ui?.notify(lines.join(' · '), 'info');
+        const remCount = state.reminders.filter((r) => r.status === 'active' || r.status === 'snoozed').length;
+        ctx.ui?.notify(`Scheduler: ${active ? '✅ active' : '⏸ inactive'} · Jobs: ${state.jobs.length} · Reminders: ${remCount}`, 'info');
       }
+    },
+  });
+
+  // ── Tool: current_time ─────────────────────────────────────
+
+  pi.registerTool({
+    name: 'current_time',
+    label: 'Current Time',
+    description: 'Get the current date and time. Call this BEFORE creating reminders with relative times.',
+    parameters: Type.Object({}),
+    async execute() {
+      const now = new Date();
+      const iso = now.toISOString();
+      const local = now.toLocaleString('en-GB', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit', timeZoneName: 'short' });
+      const offset = -now.getTimezoneOffset();
+      const offsetStr = `UTC${offset >= 0 ? '+' : ''}${Math.floor(offset / 60)}:${String(Math.abs(offset) % 60).padStart(2, '0')}`;
+      return { content: [{ type: 'text' as const, text: `Current time: ${iso}\nLocal: ${local}\nTimezone: ${offsetStr}\nUnix: ${now.getTime()}` }], details: {} };
+    },
+    renderCall(_args, theme) { return new Text(theme.fg('toolTitle', theme.bold('current_time')), 0, 0); },
+    renderResult(result, _o, theme) {
+      const msg = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      return new Text(theme.fg('muted', `🕐 ${msg.split('\n')[0]?.replace('Current time: ', '') ?? ''}`), 0, 0);
     },
   });
 
   // ── Tool: cron ─────────────────────────────────────────────
 
+  registerCronTool(pi);
+
+  // ── Tool: reminder ─────────────────────────────────────────
+
+  registerReminderTool(pi);
+}
+
+// ── Tool registrations ─────────────────────────────────────────
+
+function registerCronTool(pi: ExtensionAPI) {
   pi.registerTool({
-    name: 'cron',
-    label: 'Cron',
-    description:
-      'Manage scheduled cron jobs. ' +
-      'Actions: list, add, update, remove, enable, disable, run. ' +
-      'Jobs are stored globally and persist across sessions.',
+    name: 'cron', label: 'Cron',
+    description: 'Manage scheduled cron jobs. Actions: list, add, update, remove, enable, disable, run.',
     parameters: CronParams,
-
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : statePath;
-      if (!resolvedPath) {
-        logError('tool:no-state-path');
-        return {
-          content: [{ type: 'text', text: 'Error: no state path' }],
-          details: {},
-        };
-      }
-      statePath = resolvedPath;
-      initLogger(pi, statePath);
-      info('tool:execute', { action: params.action, name: params.name });
-
-      // Serialise state mutations to prevent concurrent read-modify-write races
+      if (ctx?.cwd) await ensureInitialized(ctx.cwd);
+      const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : getStatePath();
+      if (!resolvedPath) return { content: [{ type: 'text', text: 'Error: no state path' }], details: {} };
       const result = await withStateLock(async () => {
-        const state = await readState(statePath);
-        const deps: ActionDeps = {
-          state,
-          statePath,
-          scheduler,
-          workspaceCwd,
-          writeState,
-          appendRunResult,
-          ctxCwd: ctx?.cwd,
-        };
-
+        const state = await readState(resolvedPath);
+        const deps: ActionDeps = { state, statePath: resolvedPath, scheduler: getScheduler(), workspaceCwd: getCwd(), writeState, appendRunResult, ctxCwd: ctx?.cwd };
         switch (params.action) {
-          case 'list':    return handleList(deps);
-          case 'add':     return handleAdd(params, deps);
-          case 'update':  return handleUpdate(params, deps);
-          case 'remove':  return handleRemove(params, deps);
-          case 'enable':  return handleToggle(params, deps, false);
+          case 'list': return handleList(deps);
+          case 'add': return handleAdd(params, deps);
+          case 'update': return handleUpdate(params, deps);
+          case 'remove': return handleRemove(params, deps);
+          case 'enable': return handleToggle(params, deps, false);
           case 'disable': return handleToggle(params, deps, true);
-          case 'run':     return handleRun(params, deps);
-          default:        return `Unknown action: ${params.action}`;
+          case 'run': return handleRun(params, deps);
+          default: return `Unknown action: ${params.action}`;
         }
       });
-
-      return {
-        content: [{ type: 'text' as const, text: result }],
-        details: {},
-      };
+      return { content: [{ type: 'text' as const, text: result }], details: {} };
     },
-
     renderCall(args, theme) {
-      let text = theme.fg('toolTitle', theme.bold('cron '));
-      text += theme.fg('muted', args.action);
-      if (args.name) text += ` ${theme.fg('accent', args.name)}`;
-      if (args.schedule) text += ` ${theme.fg('dim', args.schedule)}`;
-      return new Text(text, 0, 0);
+      let t = theme.fg('toolTitle', theme.bold('cron ')); t += theme.fg('muted', args.action);
+      if (args.name) t += ` ${theme.fg('accent', args.name)}`;
+      return new Text(t, 0, 0);
     },
+    renderResult(result, _o, theme) {
+      const msg = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      return new Text(msg.startsWith('Error:') ? theme.fg('error', msg) : theme.fg('success', '✓ ') + theme.fg('muted', msg), 0, 0);
+    },
+  });
+}
 
-    renderResult(result, _options, theme) {
-      const text = result.content[0];
-      const msg = text?.type === 'text' ? text.text : '';
-      if (msg.startsWith('Error:') || msg.includes('not found')) {
-        return new Text(theme.fg('error', msg), 0, 0);
-      }
-      return new Text(
-        theme.fg('success', '✓ ') + theme.fg('muted', msg),
-        0,
-        0,
-      );
+function registerReminderTool(pi: ExtensionAPI) {
+  pi.registerTool({
+    name: 'reminder', label: 'Reminder',
+    description: 'Manage reminders with desktop notifications. Actions: list, add, update, remove, snooze, complete, enable, disable. ' +
+      'IMPORTANT: For relative times, call current_time first to get accurate time, then compute fire_at.',
+    parameters: ReminderParams,
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      if (ctx?.cwd) await ensureInitialized(ctx.cwd);
+      const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : getStatePath();
+      if (!resolvedPath) return { content: [{ type: 'text', text: 'Error: no state path' }], details: {} };
+      const result = await withStateLock(async () => {
+        const state = await readState(resolvedPath);
+        const deps: ReminderActionDeps = { state, statePath: resolvedPath, writeState };
+        let res: string;
+        switch (params.action) {
+          case 'list': res = handleReminderList(deps); break;
+          case 'add': res = await handleReminderAdd(params, deps); break;
+          case 'update': res = await handleReminderUpdate(params, deps); break;
+          case 'remove': res = await handleReminderRemove(params, deps); break;
+          case 'snooze': res = await handleReminderSnooze(params, deps); break;
+          case 'complete': res = await handleReminderComplete(params, deps); break;
+          case 'enable': res = await handleReminderToggle(params, deps, false); break;
+          case 'disable': res = await handleReminderToggle(params, deps, true); break;
+          default: res = `Unknown action: ${params.action}`;
+        }
+        getScheduler()?.updateReminders(state.reminders);
+        return res;
+      });
+      return { content: [{ type: 'text' as const, text: result }], details: {} };
+    },
+    renderCall(args, theme) {
+      let t = theme.fg('toolTitle', theme.bold('reminder ')); t += theme.fg('muted', args.action);
+      if (args.title) t += ` ${theme.fg('dim', `"${args.title}"`)}`;
+      if (args.id) t += ` ${theme.fg('accent', args.id)}`;
+      return new Text(t, 0, 0);
+    },
+    renderResult(result, _o, theme) {
+      const msg = result.content[0]?.type === 'text' ? result.content[0].text : '';
+      return new Text(msg.startsWith('Error:') ? theme.fg('error', msg) : msg.startsWith('✓') ? theme.fg('success', '✓ ') + theme.fg('muted', msg.slice(2)) : theme.fg('muted', msg), 0, 0);
     },
   });
 }

--- a/packages/pi-cron-extension/extension/notifier.ts
+++ b/packages/pi-cron-extension/extension/notifier.ts
@@ -1,0 +1,122 @@
+/**
+ * Reminder notification delivery.
+ *
+ * Emits 'sero:notify' on the Pi SDK EventBus. The Sero host's
+ * extension factory listens for these events and routes them to
+ * Electron's native Notification API.
+ *
+ * This keeps the extension decoupled from Electron — it only uses
+ * the Pi SDK's standard EventBus, which also works in Pi CLI
+ * (where the host can choose its own notification strategy).
+ *
+ * Email channel is accepted but not yet implemented — logs a warning
+ * and falls back to desktop notification.
+ */
+
+import type { Reminder, ReminderChannel, NotificationSettings } from '../shared/types';
+import { DEFAULT_NOTIFICATION_SETTINGS } from '../shared/types';
+import { info, warn } from './logger';
+
+// ── EventBus emitter ───────────────────────────────────────────
+
+/** Stored reference to pi.events.emit — set by initNotifier(). */
+let emitFn: ((channel: string, data: unknown) => void) | null = null;
+
+/**
+ * Wire up the notification emitter. Call once from the extension's
+ * default export with `initNotifier(pi.events.emit.bind(pi.events))`.
+ */
+export function initNotifier(
+  emit: (channel: string, data: unknown) => void,
+): void {
+  emitFn = emit;
+  info('notifier:init', { method: 'event-bus' });
+}
+
+// ── Desktop notification ───────────────────────────────────────
+
+function showDesktopNotification(
+  title: string,
+  body: string,
+  settings: NotificationSettings,
+): void {
+  if (emitFn) {
+    emitFn('sero:notify', {
+      message: body !== title ? body : title,
+      subtitle: body !== title ? title : undefined,
+      type: 'info',
+      source: '🔔 Reminder',
+      sound: settings.soundEnabled ? settings.soundName : false,
+    });
+    info('notifier:desktop', { title, sound: settings.soundEnabled ? settings.soundName : 'off' });
+    return;
+  }
+
+  // Fallback: console only (visible in /tmp/sero-electron.log)
+  console.log(`[reminder] 🔔 ${title}: ${body}`);
+  warn('notifier:no-emitter', {
+    title,
+    hint: 'initNotifier() not called — call from extension setup',
+  });
+}
+
+// ── Email notification (stub) ──────────────────────────────────
+
+function showEmailNotification(
+  title: string,
+  body: string,
+  settings: NotificationSettings,
+): void {
+  warn('notifier:email-not-implemented', { title });
+  showDesktopNotification(title, `(email pending) ${body}`, settings);
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+/**
+ * Fire a notification when a cron job completes.
+ */
+export function notifyJobComplete(
+  jobName: string,
+  ok: boolean,
+  durationMs: number,
+  settings?: NotificationSettings,
+): void {
+  if (!emitFn) return;
+  const effectiveSettings = settings ?? DEFAULT_NOTIFICATION_SETTINGS;
+  const status = ok ? '✅' : '❌';
+  const secs = (durationMs / 1000).toFixed(1);
+  emitFn('sero:notify', {
+    message: `${status} Job "${jobName}" ${ok ? 'completed' : 'failed'} (${secs}s)`,
+    type: ok ? 'info' : 'error',
+    source: 'Cron',
+    sound: effectiveSettings.soundEnabled ? effectiveSettings.soundName : false,
+  });
+  info('notifier:job-complete', { jobName, ok });
+}
+
+/**
+ * Fire a notification for a reminder using its configured channel.
+ * Pass notification settings from CronState to control sound.
+ */
+export function notifyReminder(
+  reminder: Reminder,
+  settings?: NotificationSettings,
+): void {
+  const effectiveSettings = settings ?? DEFAULT_NOTIFICATION_SETTINGS;
+  const body = reminder.notes
+    ? `${reminder.title}\n${reminder.notes}`
+    : reminder.title;
+
+  const channel: ReminderChannel = reminder.channel ?? 'notification';
+
+  switch (channel) {
+    case 'email':
+      showEmailNotification(reminder.title, body, effectiveSettings);
+      break;
+    case 'notification':
+    default:
+      showDesktopNotification(reminder.title, body, effectiveSettings);
+      break;
+  }
+}

--- a/packages/pi-cron-extension/extension/reminder-actions.ts
+++ b/packages/pi-cron-extension/extension/reminder-actions.ts
@@ -119,14 +119,15 @@ export async function handleReminderAdd(
     if (err) return `Error: invalid cron expression — ${err}`;
   }
 
-  const channel = validateChannel(params.channel);
+  const chResult = validateChannel(params.channel);
+  if (!chResult.ok) return chResult.error;
   const id = generateId();
 
   const reminder: Reminder = {
     id,
     title: params.title,
     notes: params.notes,
-    channel,
+    channel: chResult.channel,
     type,
     status: 'active',
     createdAt: new Date().toISOString(),
@@ -163,7 +164,11 @@ export async function handleReminderUpdate(
 
   if (params.title) reminder.title = params.title;
   if (params.notes !== undefined) reminder.notes = params.notes || undefined;
-  if (params.channel) reminder.channel = validateChannel(params.channel);
+  if (params.channel) {
+    const chResult = validateChannel(params.channel);
+    if (!chResult.ok) return chResult.error;
+    reminder.channel = chResult.channel;
+  }
 
   if (params.fire_at) {
     const d = new Date(params.fire_at);
@@ -275,9 +280,9 @@ export async function handleReminderToggle(
 
 // ── Helpers ─────────────────────────────────────────────────────
 
-function validateChannel(ch?: string): 'notification' | 'email' {
-  if (ch === 'email') return 'email';
-  return 'notification';
+function validateChannel(ch?: string): { ok: true; channel: 'notification' | 'email' } | { ok: false; error: string } {
+  if (ch === 'email') return { ok: false, error: 'Error: email channel is not yet supported. Use "notification" (desktop) instead.' };
+  return { ok: true, channel: 'notification' };
 }
 
 function pruneCompleted(state: CronState): void {

--- a/packages/pi-cron-extension/extension/reminder-actions.ts
+++ b/packages/pi-cron-extension/extension/reminder-actions.ts
@@ -1,0 +1,299 @@
+/**
+ * Reminder tool action handlers.
+ *
+ * Each handler receives the current state + tool params and returns
+ * a result message string. State writes happen here.
+ */
+
+import type { CronState, Reminder, ReminderChannel } from '../shared/types';
+import { MAX_COMPLETED_REMINDERS } from '../shared/types';
+import {
+  generateId,
+  snoozeReminder,
+  statusLabel,
+  nextFireDescription,
+} from '../shared/reminder-utils';
+import { cronToHuman, validateCron } from '../shared/cron';
+import { info } from './logger';
+
+export interface ReminderActionDeps {
+  state: CronState;
+  statePath: string;
+  writeState: (filePath: string, state: CronState) => Promise<void>;
+}
+
+export interface ReminderParams {
+  action: string;
+  id?: string;
+  title?: string;
+  notes?: string;
+  channel?: string;
+  type?: string;
+  fire_at?: string;
+  schedule?: string;
+  snooze_minutes?: number;
+}
+
+// ── List ────────────────────────────────────────────────────────
+
+export function handleReminderList(deps: ReminderActionDeps): string {
+  const { state } = deps;
+  const reminders = state.reminders ?? [];
+
+  if (reminders.length === 0) {
+    return 'No reminders set.';
+  }
+
+  const active = reminders.filter(
+    (r) => r.status === 'active' || r.status === 'snoozed',
+  );
+  const completed = reminders.filter((r) => r.status === 'completed');
+  const disabled = reminders.filter((r) => r.status === 'disabled');
+
+  const lines: string[] = [];
+
+  if (active.length > 0) {
+    lines.push(`**Active Reminders (${active.length}):**`);
+    for (const r of active) {
+      const ch = r.channel !== 'notification' ? ` [${r.channel}]` : '';
+      const sched = r.type === 'recurring' && r.schedule
+        ? ` \`${r.schedule}\``
+        : '';
+      lines.push(
+        `- **${r.title}** (${r.id}) ${statusLabel(r.status)}${ch}${sched}` +
+        `\n  Next: ${nextFireDescription(r)}`,
+      );
+    }
+  }
+
+  if (disabled.length > 0) {
+    lines.push(`\n**Disabled (${disabled.length}):**`);
+    for (const r of disabled) {
+      lines.push(`- ${r.title} (${r.id})`);
+    }
+  }
+
+  if (completed.length > 0) {
+    lines.push(`\n**Completed (${completed.length}):**`);
+    for (const r of completed.slice(0, 5)) {
+      lines.push(`- ${r.title} (${r.id})`);
+    }
+    if (completed.length > 5) {
+      lines.push(`  ...and ${completed.length - 5} more`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+// ── Add ─────────────────────────────────────────────────────────
+
+export async function handleReminderAdd(
+  params: ReminderParams,
+  deps: ReminderActionDeps,
+): Promise<string> {
+  const { state, statePath, writeState } = deps;
+
+  if (!params.title) {
+    return 'Error: title is required.';
+  }
+
+  const type = (params.type as 'once' | 'recurring') ?? 'once';
+
+  // Validate scheduling
+  if (type === 'once') {
+    if (!params.fire_at) {
+      return 'Error: fire_at (ISO datetime) is required for one-time reminders.';
+    }
+    const fireDate = new Date(params.fire_at);
+    if (isNaN(fireDate.getTime())) {
+      return `Error: invalid fire_at datetime "${params.fire_at}".`;
+    }
+    // Normalize to ISO UTC (the agent may omit the Z suffix)
+    params.fire_at = fireDate.toISOString();
+  } else if (type === 'recurring') {
+    if (!params.schedule) {
+      return 'Error: schedule (cron expression) is required for recurring reminders.';
+    }
+    const err = validateCron(params.schedule);
+    if (err) return `Error: invalid cron expression — ${err}`;
+  }
+
+  const channel = validateChannel(params.channel);
+  const id = generateId();
+
+  const reminder: Reminder = {
+    id,
+    title: params.title,
+    notes: params.notes,
+    channel,
+    type,
+    status: 'active',
+    createdAt: new Date().toISOString(),
+  };
+
+  if (type === 'once') reminder.fireAt = params.fire_at;
+  if (type === 'recurring') reminder.schedule = params.schedule;
+
+  if (!state.reminders) state.reminders = [];
+  state.reminders.push(reminder);
+  await writeState(statePath, state);
+
+  info('reminder:add', { id, title: params.title, type, channel });
+
+  const when = type === 'once'
+    ? `at ${params.fire_at}`
+    : `on schedule ${params.schedule} (${cronToHuman(params.schedule!)})`;
+
+  return `✓ Reminder set: "${params.title}" ${when} [${channel}] (id: ${id})`;
+}
+
+// ── Update ──────────────────────────────────────────────────────
+
+export async function handleReminderUpdate(
+  params: ReminderParams,
+  deps: ReminderActionDeps,
+): Promise<string> {
+  const { state, statePath, writeState } = deps;
+
+  if (!params.id) return 'Error: id is required.';
+
+  const reminder = (state.reminders ?? []).find((r) => r.id === params.id);
+  if (!reminder) return `Error: reminder "${params.id}" not found.`;
+
+  if (params.title) reminder.title = params.title;
+  if (params.notes !== undefined) reminder.notes = params.notes || undefined;
+  if (params.channel) reminder.channel = validateChannel(params.channel);
+
+  if (params.fire_at) {
+    const d = new Date(params.fire_at);
+    if (isNaN(d.getTime())) return `Error: invalid fire_at "${params.fire_at}".`;
+    reminder.fireAt = d.toISOString(); // Normalize to ISO UTC
+  }
+
+  if (params.schedule) {
+    const err = validateCron(params.schedule);
+    if (err) return `Error: invalid cron expression — ${err}`;
+    reminder.schedule = params.schedule;
+  }
+
+  await writeState(statePath, state);
+  info('reminder:update', { id: params.id });
+
+  return `✓ Updated reminder "${reminder.title}" (${params.id})`;
+}
+
+// ── Remove ──────────────────────────────────────────────────────
+
+export async function handleReminderRemove(
+  params: ReminderParams,
+  deps: ReminderActionDeps,
+): Promise<string> {
+  const { state, statePath, writeState } = deps;
+
+  if (!params.id) return 'Error: id is required.';
+
+  const idx = (state.reminders ?? []).findIndex((r) => r.id === params.id);
+  if (idx === -1) return `Error: reminder "${params.id}" not found.`;
+
+  const removed = state.reminders.splice(idx, 1)[0];
+  await writeState(statePath, state);
+  info('reminder:remove', { id: params.id, title: removed.title });
+
+  return `✓ Removed reminder "${removed.title}" (${params.id})`;
+}
+
+// ── Snooze ──────────────────────────────────────────────────────
+
+export async function handleReminderSnooze(
+  params: ReminderParams,
+  deps: ReminderActionDeps,
+): Promise<string> {
+  const { state, statePath, writeState } = deps;
+
+  if (!params.id) return 'Error: id is required.';
+  const minutes = params.snooze_minutes ?? 15;
+
+  const idx = (state.reminders ?? []).findIndex((r) => r.id === params.id);
+  if (idx === -1) return `Error: reminder "${params.id}" not found.`;
+
+  state.reminders[idx] = snoozeReminder(state.reminders[idx], minutes);
+  await writeState(statePath, state);
+  info('reminder:snooze', { id: params.id, minutes });
+
+  const until = state.reminders[idx].snoozedUntil;
+  return `✓ Snoozed "${state.reminders[idx].title}" until ${until}`;
+}
+
+// ── Complete / Dismiss ──────────────────────────────────────────
+
+export async function handleReminderComplete(
+  params: ReminderParams,
+  deps: ReminderActionDeps,
+): Promise<string> {
+  const { state, statePath, writeState } = deps;
+
+  if (!params.id) return 'Error: id is required.';
+
+  const reminder = (state.reminders ?? []).find((r) => r.id === params.id);
+  if (!reminder) return `Error: reminder "${params.id}" not found.`;
+
+  reminder.status = 'completed';
+  reminder.completedAt = new Date().toISOString();
+  reminder.snoozedUntil = undefined;
+
+  // Trim completed reminders
+  pruneCompleted(state);
+  await writeState(statePath, state);
+  info('reminder:complete', { id: params.id });
+
+  return `✓ Completed "${reminder.title}" (${params.id})`;
+}
+
+// ── Enable / Disable ────────────────────────────────────────────
+
+export async function handleReminderToggle(
+  params: ReminderParams,
+  deps: ReminderActionDeps,
+  disable: boolean,
+): Promise<string> {
+  const { state, statePath, writeState } = deps;
+
+  if (!params.id) return 'Error: id is required.';
+
+  const reminder = (state.reminders ?? []).find((r) => r.id === params.id);
+  if (!reminder) return `Error: reminder "${params.id}" not found.`;
+
+  reminder.status = disable ? 'disabled' : 'active';
+  if (!disable) reminder.snoozedUntil = undefined;
+
+  await writeState(statePath, state);
+  info('reminder:toggle', { id: params.id, disabled: disable });
+
+  return `✓ ${disable ? 'Disabled' : 'Enabled'} "${reminder.title}" (${params.id})`;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function validateChannel(ch?: string): 'notification' | 'email' {
+  if (ch === 'email') return 'email';
+  return 'notification';
+}
+
+function pruneCompleted(state: CronState): void {
+  const completed = (state.reminders ?? []).filter(
+    (r) => r.status === 'completed',
+  );
+  if (completed.length > MAX_COMPLETED_REMINDERS) {
+    // Sort by completedAt desc, keep newest
+    completed.sort(
+      (a, b) =>
+        new Date(b.completedAt ?? 0).getTime() -
+        new Date(a.completedAt ?? 0).getTime(),
+    );
+    const toRemove = new Set(
+      completed.slice(MAX_COMPLETED_REMINDERS).map((r) => r.id),
+    );
+    state.reminders = state.reminders.filter((r) => !toRemove.has(r.id));
+  }
+}

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -1,13 +1,14 @@
 /**
  * Cron scheduler — ticks every 30s, matches jobs against local time,
- * and spawns isolated `pi -p` subprocesses.
+ * spawns isolated `pi -p` subprocesses, and fires reminders.
  *
  * Adapted from pi-cron for Sero's JSON state format.
  */
 
 import { spawn } from 'node:child_process';
-import type { CronJob, CronRunResult } from '../shared/types';
+import type { CronJob, CronRunResult, Reminder } from '../shared/types';
 import { matchesCron } from '../shared/cron';
+import { shouldFire, statusAfterFire } from '../shared/reminder-utils';
 import { info, warn, error as logError } from './logger';
 
 // ── Subprocess runner ───────────────────────────────────────────
@@ -104,6 +105,10 @@ export function runPiSubprocess(
 export interface SchedulerCallbacks {
   onJobStart?: (job: CronJob) => void;
   onJobComplete?: (result: CronRunResult) => void;
+  /** Called when a reminder fires — the callback should show the notification. */
+  onReminderFire?: (reminder: Reminder) => void;
+  /** Called after a reminder fires with the updated reminder (for state persistence). */
+  onReminderUpdate?: (updated: Reminder) => void;
 }
 
 // ── Scheduler ───────────────────────────────────────────────────
@@ -115,8 +120,10 @@ export class CronScheduler {
   private lastTickMinute = '';
   private running = new Set<string>();
   private jobs: CronJob[] = [];
+  private reminders: Reminder[] = [];
   private callbacks: SchedulerCallbacks;
   private cwd: string | undefined;
+  private tickCount = 0;
 
   constructor(callbacks?: SchedulerCallbacks) {
     this.callbacks = callbacks ?? {};
@@ -124,12 +131,16 @@ export class CronScheduler {
 
   // ── Lifecycle ───────────────────────────────────────────
 
-  start(jobs: CronJob[], cwd?: string): void {
+  start(jobs: CronJob[], cwd?: string, reminders?: Reminder[]): void {
     if (this.timer) return;
     this.jobs = jobs;
+    this.reminders = reminders ?? [];
     this.cwd = cwd;
     const enabled = jobs.filter((j) => !j.disabled).length;
-    info('scheduler:start', { totalJobs: jobs.length, enabled, cwd });
+    const activeReminders = this.reminders.filter(
+      (r) => r.status === 'active' || r.status === 'snoozed',
+    ).length;
+    info('scheduler:start', { totalJobs: jobs.length, enabled, activeReminders, cwd });
     this.tick();
     this.timer = setInterval(() => this.tick(), TICK_INTERVAL_MS);
   }
@@ -149,6 +160,27 @@ export class CronScheduler {
   /** Update the jobs list (called when state changes externally). */
   updateJobs(jobs: CronJob[]): void {
     this.jobs = jobs;
+  }
+
+  /** Update the reminders list (called when state changes externally). */
+  updateReminders(reminders: Reminder[]): void {
+    const prev = this.reminders.length;
+    this.reminders = reminders;
+    const active = reminders.filter(
+      (r) => r.status === 'active' || r.status === 'snoozed',
+    ).length;
+    if (prev !== reminders.length || active > 0) {
+      info('scheduler:reminders-updated', {
+        previous: prev,
+        current: reminders.length,
+        active,
+      });
+    }
+  }
+
+  /** Get the count of in-memory reminders (for diagnostics). */
+  getReminderCount(): number {
+    return this.reminders.length;
   }
 
   /** Get names of currently executing jobs. */
@@ -176,29 +208,93 @@ export class CronScheduler {
 
   private tick(): void {
     const now = new Date();
+    this.tickCount++;
     const currentMinute = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}`;
 
-    // Only fire once per minute
-    if (currentMinute === this.lastTickMinute) return;
-    this.lastTickMinute = currentMinute;
+    // Only fire cron jobs once per minute (reminders checked every tick)
+    const isNewMinute = currentMinute !== this.lastTickMinute;
+    if (isNewMinute) this.lastTickMinute = currentMinute;
 
-    for (const job of this.jobs) {
-      if (job.disabled || this.running.has(job.name)) continue;
+    // ── Heartbeat log (every ~5 min = 10 ticks) ──────────
+    if (this.tickCount % 10 === 0) {
+      const activeReminders = this.reminders.filter(
+        (r) => r.status === 'active' || r.status === 'snoozed',
+      ).length;
+      info('scheduler:heartbeat', {
+        tick: this.tickCount,
+        jobs: this.jobs.length,
+        reminders: this.reminders.length,
+        activeReminders,
+        running: [...this.running],
+      });
+    }
 
-      try {
-        if (!matchesCron(job.schedule, now)) continue;
-      } catch (err) {
-        warn('job:bad-schedule', {
-          job: job.name,
-          schedule: job.schedule,
-          error: err instanceof Error ? err.message : 'parse error',
-        });
-        continue;
+    // ── Cron jobs (once per minute) ───────────────────────
+    if (isNewMinute) {
+      for (const job of this.jobs) {
+        if (job.disabled || this.running.has(job.name)) continue;
+
+        try {
+          if (!matchesCron(job.schedule, now)) continue;
+        } catch (err) {
+          warn('job:bad-schedule', {
+            job: job.name,
+            schedule: job.schedule,
+            error: err instanceof Error ? err.message : 'parse error',
+          });
+          continue;
+        }
+
+        info('job:trigger-scheduled', { job: job.name, schedule: job.schedule });
+        this.running.add(job.name);
+        this.execute(job).finally(() => this.running.delete(job.name));
+      }
+    }
+
+    // ── Reminders (every tick — important for snoozed/once) ─
+    this.tickReminders(now);
+  }
+
+  private tickReminders(now: Date): void {
+    if (this.reminders.length === 0) return;
+
+    for (const reminder of this.reminders) {
+      const fires = shouldFire(reminder, now);
+
+      // Log first check for each reminder (diagnostics)
+      if (reminder.status === 'active' || reminder.status === 'snoozed') {
+        if (this.tickCount <= 2 || this.tickCount % 10 === 0) {
+          info('reminder:check', {
+            id: reminder.id,
+            status: reminder.status,
+            type: reminder.type,
+            fireAt: reminder.fireAt,
+            snoozedUntil: reminder.snoozedUntil,
+            now: now.toISOString(),
+            shouldFire: fires,
+          });
+        }
       }
 
-      info('job:trigger-scheduled', { job: job.name, schedule: job.schedule });
-      this.running.add(job.name);
-      this.execute(job).finally(() => this.running.delete(job.name));
+      if (!fires) continue;
+
+      info('reminder:fire', {
+        id: reminder.id,
+        title: reminder.title,
+        type: reminder.type,
+        channel: reminder.channel,
+      });
+
+      // Notify
+      this.callbacks.onReminderFire?.(reminder);
+
+      // Compute post-fire state
+      const updated = statusAfterFire(reminder);
+      this.callbacks.onReminderUpdate?.(updated);
+
+      // Update in-memory list so we don't re-fire this tick
+      const idx = this.reminders.findIndex((r) => r.id === reminder.id);
+      if (idx >= 0) this.reminders[idx] = updated;
     }
   }
 
@@ -224,12 +320,14 @@ export class CronScheduler {
         );
       }
 
-      info('job:complete', { job: job.name, durationMs, ok: true });
+      const output = stripExtensionNoise(result.stdout);
+      info('job:complete', { job: job.name, durationMs, ok: true, outputLen: output.length });
       this.callbacks.onJobComplete?.({
         jobName: job.name,
         startedAt: startedAt.toISOString(),
         durationMs,
         ok: true,
+        output: output.slice(0, 4000), // cap at 4KB
       });
     } catch (err: unknown) {
       const durationMs = Date.now() - startedAt.getTime();
@@ -251,4 +349,26 @@ export class CronScheduler {
       });
     }
   }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Strip extension loading noise from subprocess stdout.
+ * Lines like "[cron] ...", "[plan-mode] ..." are internal logs,
+ * not the agent's actual response.
+ */
+export function stripExtensionNoise(stdout: string): string {
+  return stdout
+    .split('\n')
+    .filter((line) => {
+      if (!line.trim()) return false;
+      // Skip extension console.log noise
+      if (/^\[[\w-]+\]/.test(line)) return false;
+      // Skip Pi SDK startup messages
+      if (line.startsWith('Loading') || line.startsWith('Loaded')) return false;
+      return true;
+    })
+    .join('\n')
+    .trim();
 }

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -123,7 +123,6 @@ export class CronScheduler {
   private reminders: Reminder[] = [];
   private callbacks: SchedulerCallbacks;
   private cwd: string | undefined;
-  private tickCount = 0;
 
   constructor(callbacks?: SchedulerCallbacks) {
     this.callbacks = callbacks ?? {};
@@ -208,26 +207,11 @@ export class CronScheduler {
 
   private tick(): void {
     const now = new Date();
-    this.tickCount++;
     const currentMinute = `${now.getFullYear()}-${now.getMonth() + 1}-${now.getDate()}-${now.getHours()}-${now.getMinutes()}`;
 
     // Only fire cron jobs once per minute (reminders checked every tick)
     const isNewMinute = currentMinute !== this.lastTickMinute;
     if (isNewMinute) this.lastTickMinute = currentMinute;
-
-    // ── Heartbeat log (every ~5 min = 10 ticks) ──────────
-    if (this.tickCount % 10 === 0) {
-      const activeReminders = this.reminders.filter(
-        (r) => r.status === 'active' || r.status === 'snoozed',
-      ).length;
-      info('scheduler:heartbeat', {
-        tick: this.tickCount,
-        jobs: this.jobs.length,
-        reminders: this.reminders.length,
-        activeReminders,
-        running: [...this.running],
-      });
-    }
 
     // ── Cron jobs (once per minute) ───────────────────────
     if (isNewMinute) {
@@ -259,24 +243,7 @@ export class CronScheduler {
     if (this.reminders.length === 0) return;
 
     for (const reminder of this.reminders) {
-      const fires = shouldFire(reminder, now);
-
-      // Log first check for each reminder (diagnostics)
-      if (reminder.status === 'active' || reminder.status === 'snoozed') {
-        if (this.tickCount <= 2 || this.tickCount % 10 === 0) {
-          info('reminder:check', {
-            id: reminder.id,
-            status: reminder.status,
-            type: reminder.type,
-            fireAt: reminder.fireAt,
-            snoozedUntil: reminder.snoozedUntil,
-            now: now.toISOString(),
-            shouldFire: fires,
-          });
-        }
-      }
-
-      if (!fires) continue;
+      if (!shouldFire(reminder, now)) continue;
 
       info('reminder:fire', {
         id: reminder.id,
@@ -355,16 +322,18 @@ export class CronScheduler {
 
 /**
  * Strip extension loading noise from subprocess stdout.
- * Lines like "[cron] ...", "[plan-mode] ..." are internal logs,
- * not the agent's actual response.
+ * Matches known Pi extension log prefixes — avoids stripping
+ * legitimate output like Markdown checkboxes or bracketed references.
  */
+const KNOWN_EXT_PREFIXES = /^\[(cron|plan-mode|sero|git|container|workspace|terminal|auth)\]/;
+
 export function stripExtensionNoise(stdout: string): string {
   return stdout
     .split('\n')
     .filter((line) => {
       if (!line.trim()) return false;
-      // Skip extension console.log noise
-      if (/^\[[\w-]+\]/.test(line)) return false;
+      // Skip known extension console.log noise
+      if (KNOWN_EXT_PREFIXES.test(line)) return false;
       // Skip Pi SDK startup messages
       if (line.startsWith('Loading') || line.startsWith('Loaded')) return false;
       return true;

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -275,7 +275,16 @@ export class CronScheduler {
     this.callbacks.onJobStart?.(job);
 
     try {
-      const result = await runPiSubprocess(job.prompt, {
+      // Prepend workspace context so the agent knows the real working
+      // directory and never tries to use container paths like /workspace.
+      const prompt = this.cwd
+        ? `[Your working directory is ${this.cwd}. ` +
+          `Use relative paths (e.g. "daily-reports/file.md") to save files here. ` +
+          `The path "/workspace" does not exist — always prefer relative paths.]\n\n` +
+          job.prompt
+        : job.prompt;
+
+      const result = await runPiSubprocess(prompt, {
         model: job.model,
         cwd: this.cwd,
       });

--- a/packages/pi-cron-extension/extension/state-io.ts
+++ b/packages/pi-cron-extension/extension/state-io.ts
@@ -1,0 +1,52 @@
+/**
+ * State file I/O — path resolution, reading, writing, and mutex.
+ *
+ * Extracted from index.ts to keep the main file under 500 LOC.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { CronState } from '../shared/types';
+import { DEFAULT_CRON_STATE } from '../shared/types';
+
+// ── Path resolution ────────────────────────────────────────────
+
+const STATE_REL_PATH = path.join('.sero', 'apps', 'cron', 'state.json');
+
+export function resolveStatePath(cwd: string): string {
+  const seroHome = process.env.SERO_HOME;
+  if (seroHome) return path.join(seroHome, 'apps', 'cron', 'state.json');
+  return path.join(cwd, STATE_REL_PATH);
+}
+
+// ── Mutex ──────────────────────────────────────────────────────
+
+let stateMutexQueue: Promise<void> = Promise.resolve();
+
+export function withStateLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = stateMutexQueue;
+  let resolve: () => void;
+  stateMutexQueue = new Promise<void>((r) => { resolve = r; });
+  return prev.then(fn).finally(() => resolve!());
+}
+
+// ── Read / Write ───────────────────────────────────────────────
+
+export async function readState(filePath: string): Promise<CronState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as CronState;
+    if (!parsed.reminders) parsed.reminders = [];
+    return parsed;
+  } catch {
+    return { ...DEFAULT_CRON_STATE, jobs: [], reminders: [], lastRunResults: [] };
+  }
+}
+
+export async function writeState(filePath: string, state: CronState): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}

--- a/packages/pi-cron-extension/extension/state-watcher.ts
+++ b/packages/pi-cron-extension/extension/state-watcher.ts
@@ -1,0 +1,117 @@
+/**
+ * State file watcher — keeps the scheduler in sync with state.json.
+ *
+ * When the UI (or any external process) writes to state.json, the
+ * watcher detects the change and pushes updated jobs + reminders into
+ * the scheduler's in-memory lists.
+ *
+ * Uses DIRECTORY watch instead of file watch because state.json is
+ * written atomically (tmp + rename). On macOS, fs.watch tracks the
+ * inode, so after a rename the file watcher is orphaned. Watching
+ * the parent directory detects rename events reliably.
+ */
+
+import { watch, promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { FSWatcher } from 'node:fs';
+import type { CronState } from '../shared/types';
+import type { CronScheduler } from './scheduler';
+import { info, warn } from './logger';
+
+const DEBOUNCE_MS = 500;
+
+export class StateWatcher {
+  private watcher: FSWatcher | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private filePath: string;
+  private dirPath: string;
+  private fileName: string;
+  private getScheduler: () => CronScheduler | null;
+  /** Track our own writes to avoid feedback loops. */
+  private ignoreUntil = 0;
+
+  constructor(filePath: string, getScheduler: () => CronScheduler | null) {
+    this.filePath = filePath;
+    this.dirPath = path.dirname(filePath);
+    this.fileName = path.basename(filePath);
+    this.getScheduler = getScheduler;
+  }
+
+  /**
+   * Call before writing state.json from the extension to suppress
+   * the watcher from re-reading our own write.
+   */
+  markOwnWrite(): void {
+    this.ignoreUntil = Date.now() + DEBOUNCE_MS + 200;
+  }
+
+  start(): void {
+    if (this.watcher) return;
+
+    try {
+      // Watch the DIRECTORY, not the file. Atomic writes (rename) change
+      // the file's inode, but the directory inode stays stable.
+      this.watcher = watch(this.dirPath, { persistent: false }, (_event, filename) => {
+        // Filter: only react to changes to the state file (or its tmp files)
+        if (filename === this.fileName || filename?.startsWith(this.fileName + '.tmp')) {
+          this.scheduleSync();
+        }
+      });
+
+      this.watcher.on('error', (err) => {
+        warn('state-watcher:error', { error: err.message });
+        this.stop();
+      });
+
+      info('state-watcher:start', { path: this.filePath, mode: 'directory' });
+    } catch (err) {
+      warn('state-watcher:start-failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  stop(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+      info('state-watcher:stop');
+    }
+  }
+
+  private scheduleSync(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.sync(), DEBOUNCE_MS);
+  }
+
+  private async sync(): Promise<void> {
+    // Skip if this is our own write
+    if (Date.now() < this.ignoreUntil) return;
+
+    const scheduler = this.getScheduler();
+    if (!scheduler?.isRunning()) return;
+
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf8');
+      const state: CronState = JSON.parse(raw);
+      if (!state.reminders) state.reminders = [];
+
+      scheduler.updateJobs(state.jobs ?? []);
+      scheduler.updateReminders(state.reminders);
+
+      info('state-watcher:sync', {
+        jobs: state.jobs?.length ?? 0,
+        reminders: state.reminders.length,
+      });
+    } catch (err) {
+      // File might be mid-write (temp → rename); ignore transient errors
+      warn('state-watcher:sync-failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/packages/pi-cron-extension/package.json
+++ b/packages/pi-cron-extension/package.json
@@ -18,7 +18,7 @@
   "sero": {
     "app": {
       "id": "cron",
-      "name": "Cron",
+      "name": "Scheduler & Reminders",
       "icon": "clock",
       "scope": "global",
       "stateFile": ".sero/apps/cron/state.json",

--- a/packages/pi-cron-extension/shared/reminder-utils.ts
+++ b/packages/pi-cron-extension/shared/reminder-utils.ts
@@ -1,0 +1,214 @@
+/**
+ * Reminder utility functions shared between the extension and the UI.
+ *
+ * Handles fire-time checks, snooze computation, status display,
+ * and next-fire-time calculation.
+ */
+
+import { matchesCron } from './cron';
+import type { Reminder, ReminderStatus } from './types';
+import { SNOOZE_OPTIONS } from './types';
+
+// ── Fire-time checks ───────────────────────────────────────────
+
+/**
+ * Check whether a reminder should fire right now.
+ * Called by the scheduler tick (every 30s).
+ */
+export function shouldFire(reminder: Reminder, now: Date): boolean {
+  if (reminder.status === 'completed' || reminder.status === 'disabled') {
+    return false;
+  }
+
+  // Snoozed: fire when snooze expires
+  if (reminder.status === 'snoozed' && reminder.snoozedUntil) {
+    return new Date(reminder.snoozedUntil).getTime() <= now.getTime();
+  }
+
+  // Active
+  if (reminder.status !== 'active') return false;
+
+  if (reminder.type === 'once' && reminder.fireAt) {
+    // One-time: fire if fireAt has passed and hasn't fired yet
+    const fireTime = new Date(reminder.fireAt).getTime();
+    if (fireTime > now.getTime()) return false;
+    // Don't re-fire if already fired for this fireAt
+    if (reminder.lastFiredAt) {
+      const lastFired = new Date(reminder.lastFiredAt).getTime();
+      if (lastFired >= fireTime) return false;
+    }
+    return true;
+  }
+
+  if (reminder.type === 'recurring' && reminder.schedule) {
+    // Recurring: use cron matching (same as cron jobs)
+    try {
+      if (!matchesCron(reminder.schedule, now)) return false;
+    } catch {
+      return false;
+    }
+    // Don't fire twice in the same minute
+    if (reminder.lastFiredAt) {
+      const last = new Date(reminder.lastFiredAt);
+      if (
+        last.getFullYear() === now.getFullYear() &&
+        last.getMonth() === now.getMonth() &&
+        last.getDate() === now.getDate() &&
+        last.getHours() === now.getHours() &&
+        last.getMinutes() === now.getMinutes()
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+// ── Snooze computation ─────────────────────────────────────────
+
+/**
+ * Compute the snoozedUntil datetime for a given snooze option.
+ * Returns an ISO string.
+ */
+export function computeSnoozeUntil(minutes: number): string {
+  if (minutes === -1) {
+    // Special: "Tomorrow 9am"
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    tomorrow.setHours(9, 0, 0, 0);
+    return tomorrow.toISOString();
+  }
+  const until = new Date(Date.now() + minutes * 60_000);
+  return until.toISOString();
+}
+
+/**
+ * Apply snooze to a reminder, returning the updated reminder.
+ */
+export function snoozeReminder(
+  reminder: Reminder,
+  minutes: number,
+): Reminder {
+  return {
+    ...reminder,
+    status: 'snoozed' as ReminderStatus,
+    snoozedUntil: computeSnoozeUntil(minutes),
+  };
+}
+
+// ── Post-fire status ───────────────────────────────────────────
+
+/**
+ * Compute the new status after a reminder fires.
+ */
+export function statusAfterFire(reminder: Reminder): Reminder {
+  const now = new Date().toISOString();
+
+  if (reminder.type === 'once') {
+    return {
+      ...reminder,
+      status: 'completed',
+      lastFiredAt: now,
+      completedAt: now,
+      snoozedUntil: undefined,
+    };
+  }
+
+  // Recurring: stays active, clear snooze
+  return {
+    ...reminder,
+    status: 'active',
+    lastFiredAt: now,
+    snoozedUntil: undefined,
+  };
+}
+
+// ── Display helpers ────────────────────────────────────────────
+
+const STATUS_LABELS: Record<ReminderStatus, string> = {
+  active: '🔔 Active',
+  snoozed: '💤 Snoozed',
+  completed: '✅ Done',
+  disabled: '⏸ Disabled',
+};
+
+export function statusLabel(status: ReminderStatus): string {
+  return STATUS_LABELS[status] ?? status;
+}
+
+/**
+ * Get a human-readable description of when the reminder will fire next.
+ */
+export function nextFireDescription(reminder: Reminder): string {
+  if (reminder.status === 'completed') return 'Completed';
+  if (reminder.status === 'disabled') return 'Disabled';
+
+  if (reminder.status === 'snoozed' && reminder.snoozedUntil) {
+    return `Snoozed until ${formatDateTime(reminder.snoozedUntil)}`;
+  }
+
+  if (reminder.type === 'once' && reminder.fireAt) {
+    const fireTime = new Date(reminder.fireAt);
+    if (fireTime.getTime() <= Date.now()) return 'Due now';
+    return formatDateTime(reminder.fireAt);
+  }
+
+  if (reminder.type === 'recurring' && reminder.schedule) {
+    return `Recurring: ${reminder.schedule}`;
+  }
+
+  return 'Unknown';
+}
+
+/** Format an ISO string as a friendly datetime. */
+export function formatDateTime(iso: string): string {
+  const d = new Date(iso);
+  const now = new Date();
+  const diffMs = d.getTime() - now.getTime();
+
+  // If within 24 hours, show relative
+  if (Math.abs(diffMs) < 86_400_000) {
+    if (diffMs < 0) return formatTimeAgo(-diffMs);
+    return `in ${formatTimeAgo(diffMs)}`;
+  }
+
+  // Otherwise show date + time
+  return d.toLocaleDateString('en-GB', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function formatTimeAgo(ms: number): string {
+  const mins = Math.floor(ms / 60_000);
+  if (mins < 1) return 'less than a minute';
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ${mins % 60}m`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+/**
+ * Generate a short unique ID for reminders (8 chars).
+ */
+export function generateId(): string {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let id = '';
+  for (let i = 0; i < 8; i++) {
+    id += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return id;
+}
+
+/**
+ * Get snooze options with their labels and minute values.
+ */
+export function getSnoozeOptions(): Array<{ label: string; minutes: number }> {
+  return [...SNOOZE_OPTIONS];
+}

--- a/packages/pi-cron-extension/shared/types.ts
+++ b/packages/pi-cron-extension/shared/types.ts
@@ -8,6 +8,8 @@
  * (shared across all workspaces).
  */
 
+// ── Cron Jobs ──────────────────────────────────────────────────
+
 export interface CronJob {
   name: string;
   /** 5-field cron expression: min hour dom month dow */
@@ -32,23 +34,101 @@ export interface CronRunResult {
   durationMs: number;
   ok: boolean;
   error?: string;
+  /** Agent response text (extension loading noise stripped). */
+  output?: string;
 }
+
+// ── Reminders ──────────────────────────────────────────────────
+
+export type ReminderStatus = 'active' | 'snoozed' | 'completed' | 'disabled';
+export type ReminderType = 'once' | 'recurring';
+export type ReminderChannel = 'notification' | 'email';
+
+export interface Reminder {
+  id: string;
+  title: string;
+  /** Optional extra details / notes */
+  notes?: string;
+  /** Delivery channel: desktop notification (default) or email */
+  channel: ReminderChannel;
+
+  // ── Scheduling ─────────────────────────────────────────
+  type: ReminderType;
+  /** ISO datetime — when to fire (one-time reminders) */
+  fireAt?: string;
+  /** 5-field cron expression (recurring reminders) */
+  schedule?: string;
+
+  // ── Status ─────────────────────────────────────────────
+  status: ReminderStatus;
+  /** ISO datetime — snooze expiry (fires again when reached) */
+  snoozedUntil?: string;
+
+  // ── History ────────────────────────────────────────────
+  createdAt: string;
+  /** ISO datetime — last time the notification was fired */
+  lastFiredAt?: string;
+  /** ISO datetime — when the reminder was completed/dismissed */
+  completedAt?: string;
+}
+
+/** Predefined snooze durations in minutes */
+export const SNOOZE_OPTIONS = [
+  { label: '5 minutes', minutes: 5 },
+  { label: '15 minutes', minutes: 15 },
+  { label: '30 minutes', minutes: 30 },
+  { label: '1 hour', minutes: 60 },
+  { label: '3 hours', minutes: 180 },
+  { label: 'Tomorrow 9am', minutes: -1 }, // special: computed dynamically
+] as const;
+
+// ── Notification Settings ──────────────────────────────────────
+
+/** macOS system sounds from /System/Library/Sounds/ */
+export const NOTIFICATION_SOUNDS = [
+  'Glass', 'Hero', 'Ping', 'Pop', 'Purr', 'Submarine',
+  'Tink', 'Basso', 'Blow', 'Bottle', 'Frog', 'Funk', 'Morse', 'Sosumi',
+] as const;
+
+export type NotificationSoundName = (typeof NOTIFICATION_SOUNDS)[number];
+
+export interface NotificationSettings {
+  /** Whether to play a sound on reminder notifications */
+  soundEnabled: boolean;
+  /** macOS sound name (default: "Glass") */
+  soundName: NotificationSoundName;
+}
+
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  soundEnabled: true,
+  soundName: 'Glass',
+};
+
+// ── Combined State ─────────────────────────────────────────────
 
 export interface CronState {
   jobs: CronJob[];
+  reminders: Reminder[];
   schedulerActive: boolean;
   /** Start the scheduler automatically when Sero launches */
   autostart: boolean;
   /** Recent execution results (capped at 50) */
   lastRunResults: CronRunResult[];
+  /** Notification preferences */
+  notificationSettings?: NotificationSettings;
 }
 
 export const DEFAULT_CRON_STATE: CronState = {
   jobs: [],
+  reminders: [],
   schedulerActive: false,
   autostart: false,
   lastRunResults: [],
+  notificationSettings: DEFAULT_NOTIFICATION_SETTINGS,
 };
 
 /** Maximum number of run results to keep */
 export const MAX_RUN_RESULTS = 50;
+
+/** Maximum number of completed reminders to keep */
+export const MAX_COMPLETED_REMINDERS = 100;

--- a/packages/pi-cron-extension/ui/CronApp.tsx
+++ b/packages/pi-cron-extension/ui/CronApp.tsx
@@ -1,6 +1,8 @@
 /**
  * CronApp — Sero web UI for the cron scheduler extension.
  *
+ * Tabs: Jobs | Reminders | History
+ *
  * Uses useAppState to read/write the same state.json the Pi extension
  * writes. Changes from either direction are reflected instantly.
  */
@@ -9,112 +11,157 @@ import { useState, useCallback, useMemo } from 'react';
 import { useAppState, useAgentPrompt } from '@sero/app-runtime';
 import { Button } from '@sero/ui/components/ui/button';
 import { Card } from '@sero/ui/components/ui/card';
-import type { CronState, CronJob } from '../shared/types';
-import { DEFAULT_CRON_STATE } from '../shared/types';
+import type { CronState, CronJob, Reminder, NotificationSettings } from '../shared/types';
+import { DEFAULT_CRON_STATE, DEFAULT_NOTIFICATION_SETTINGS } from '../shared/types';
+import { snoozeReminder } from '../shared/reminder-utils';
 import { SchedulerBar } from './components/SchedulerBar';
 import { JobCard } from './components/JobCard';
 import { JobForm } from './components/JobForm';
 import { RunHistory } from './components/RunHistory';
+import { ReminderList } from './components/ReminderList';
+import { ReminderForm } from './components/ReminderForm';
 import './styles.css';
 
-type Tab = 'jobs' | 'history';
+type Tab = 'jobs' | 'reminders' | 'history';
 
 export function CronApp() {
   const [state, updateState] = useAppState<CronState>(DEFAULT_CRON_STATE);
   const prompt = useAgentPrompt();
 
-  const [showForm, setShowForm] = useState(false);
+  const [showJobForm, setShowJobForm] = useState(false);
   const [editingJob, setEditingJob] = useState<CronJob | null>(null);
-  const [activeTab, setActiveTab] = useState<Tab>('jobs');
+  const [showReminderForm, setShowReminderForm] = useState(false);
+  const [editingReminder, setEditingReminder] = useState<Reminder | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('reminders');
+
+  // Ensure reminders array exists (migration)
+  const reminders = state.reminders ?? [];
 
   // ── Derived stats ────────────────────────────────────────
 
   const stats = useMemo(() => {
-    const total = state.jobs.length;
-    const active = state.jobs.filter((j) => !j.disabled).length;
-    const disabled = total - active;
-    return { total, active, disabled };
-  }, [state.jobs]);
+    const totalJobs = state.jobs.length;
+    const activeJobs = state.jobs.filter((j) => !j.disabled).length;
+    const disabledJobs = totalJobs - activeJobs;
+    const totalReminders = reminders.length;
+    const activeReminders = reminders.filter(
+      (r) => r.status === 'active' || r.status === 'snoozed',
+    ).length;
+    return { totalJobs, activeJobs, disabledJobs, totalReminders, activeReminders };
+  }, [state.jobs, reminders]);
 
-  // ── Scheduler toggle (via agent) ─────────────────────────
+  // ── Scheduler toggle ─────────────────────────────────────
 
   const toggleScheduler = useCallback(() => {
-    if (state.schedulerActive) {
-      prompt('Stop the cron scheduler using /cron off');
-    } else {
-      prompt('Start the cron scheduler using /cron on');
-    }
+    prompt(state.schedulerActive
+      ? 'Stop the cron scheduler using /cron off'
+      : 'Start the cron scheduler using /cron on');
   }, [state.schedulerActive, prompt]);
 
-  // ── Autostart toggle ─────────────────────────────────────
-
   const handleAutostartChange = useCallback(
-    (enabled: boolean) => {
-      updateState((prev) => ({ ...prev, autostart: enabled }));
-    },
+    (enabled: boolean) => updateState((prev) => ({ ...prev, autostart: enabled })),
+    [updateState],
+  );
+
+  const handleNotificationSettingsChange = useCallback(
+    (settings: NotificationSettings) =>
+      updateState((prev) => ({ ...prev, notificationSettings: settings })),
     [updateState],
   );
 
   // ── Job CRUD ─────────────────────────────────────────────
 
-  const handleAddJob = useCallback(() => {
-    setEditingJob(null);
-    setShowForm(true);
+  const handleAddJob = useCallback(() => { setEditingJob(null); setShowJobForm(true); }, []);
+
+  const handleEditJob = useCallback((name: string) => {
+    const job = state.jobs.find((j) => j.name === name);
+    if (job) { setEditingJob(job); setShowJobForm(true); }
+  }, [state.jobs]);
+
+  const handleSaveJob = useCallback((job: CronJob) => {
+    updateState((prev) => {
+      const idx = prev.jobs.findIndex((j) => j.name === job.name);
+      const jobs = idx >= 0
+        ? prev.jobs.map((j) => (j.name === job.name ? job : j))
+        : [...prev.jobs, job];
+      return { ...prev, jobs };
+    });
+  }, [updateState]);
+
+  const handleToggleJobEnabled = useCallback((name: string) => {
+    updateState((prev) => ({
+      ...prev,
+      jobs: prev.jobs.map((j) => j.name === name ? { ...j, disabled: !j.disabled } : j),
+    }));
+  }, [updateState]);
+
+  const handleRemoveJob = useCallback((name: string) => {
+    updateState((prev) => ({ ...prev, jobs: prev.jobs.filter((j) => j.name !== name) }));
+  }, [updateState]);
+
+  const handleRunJob = useCallback((name: string) => {
+    prompt(`Run the cron job "${name}" immediately using the cron tool with action run.`);
+  }, [prompt]);
+
+  // ── Reminder CRUD ────────────────────────────────────────
+
+  const handleAddReminder = useCallback(() => {
+    setEditingReminder(null); setShowReminderForm(true);
   }, []);
 
-  const handleEditJob = useCallback(
-    (name: string) => {
-      const job = state.jobs.find((j) => j.name === name);
-      if (job) {
-        setEditingJob(job);
-        setShowForm(true);
-      }
-    },
-    [state.jobs],
-  );
+  const handleEditReminder = useCallback((id: string) => {
+    const r = reminders.find((rem) => rem.id === id);
+    if (r) { setEditingReminder(r); setShowReminderForm(true); }
+  }, [reminders]);
 
-  const handleSaveJob = useCallback(
-    (job: CronJob) => {
-      updateState((prev) => {
-        const existing = prev.jobs.findIndex((j) => j.name === job.name);
-        const jobs =
-          existing >= 0
-            ? prev.jobs.map((j) => (j.name === job.name ? job : j))
-            : [...prev.jobs, job];
-        return { ...prev, jobs };
-      });
-    },
-    [updateState],
-  );
+  const handleSaveReminder = useCallback((reminder: Reminder) => {
+    updateState((prev) => {
+      const list = prev.reminders ?? [];
+      const idx = list.findIndex((r) => r.id === reminder.id);
+      const updated = idx >= 0
+        ? list.map((r) => (r.id === reminder.id ? reminder : r))
+        : [...list, reminder];
+      return { ...prev, reminders: updated };
+    });
+  }, [updateState]);
 
-  const handleToggleEnabled = useCallback(
-    (name: string) => {
-      updateState((prev) => ({
-        ...prev,
-        jobs: prev.jobs.map((j) =>
-          j.name === name ? { ...j, disabled: !j.disabled } : j,
-        ),
-      }));
-    },
-    [updateState],
-  );
+  const handleRemoveReminder = useCallback((id: string) => {
+    updateState((prev) => ({
+      ...prev,
+      reminders: (prev.reminders ?? []).filter((r) => r.id !== id),
+    }));
+  }, [updateState]);
 
-  const handleRemoveJob = useCallback(
-    (name: string) => {
-      updateState((prev) => ({
-        ...prev,
-        jobs: prev.jobs.filter((j) => j.name !== name),
-      }));
-    },
-    [updateState],
-  );
+  const handleSnoozeReminder = useCallback((id: string, minutes: number) => {
+    updateState((prev) => ({
+      ...prev,
+      reminders: (prev.reminders ?? []).map((r) =>
+        r.id === id ? snoozeReminder(r, minutes) : r,
+      ),
+    }));
+  }, [updateState]);
 
-  const handleRunJob = useCallback(
-    (name: string) => {
-      prompt(`Run the cron job "${name}" immediately using the cron tool with action run.`);
-    },
-    [prompt],
-  );
+  const handleCompleteReminder = useCallback((id: string) => {
+    updateState((prev) => ({
+      ...prev,
+      reminders: (prev.reminders ?? []).map((r) =>
+        r.id === id
+          ? { ...r, status: 'completed' as const, completedAt: new Date().toISOString(), snoozedUntil: undefined }
+          : r,
+      ),
+    }));
+  }, [updateState]);
+
+  const handleToggleReminderEnabled = useCallback((id: string) => {
+    updateState((prev) => ({
+      ...prev,
+      reminders: (prev.reminders ?? []).map((r) =>
+        r.id === id
+          ? { ...r, status: r.status === 'disabled' ? 'active' as const : 'disabled' as const, snoozedUntil: undefined }
+          : r,
+      ),
+    }));
+  }, [updateState]);
 
   // ── Render ───────────────────────────────────────────────
 
@@ -124,15 +171,20 @@ export function CronApp() {
       <div className="mb-3 flex items-center justify-between">
         <div>
           <h1 className="text-lg font-semibold text-foreground">
-            ⏰ Cron Scheduler
+            ⏰ Scheduler & Reminders
           </h1>
           <p className="mt-0.5 text-xs text-muted-foreground">
-            Schedule recurring agent prompts
+            Cron jobs, reminders, and notifications
           </p>
         </div>
-        <Button size="sm" onClick={handleAddJob}>
-          + New Job
-        </Button>
+        <div className="flex gap-2">
+          {activeTab === 'reminders' && (
+            <Button size="sm" onClick={handleAddReminder}>+ Reminder</Button>
+          )}
+          {activeTab === 'jobs' && (
+            <Button size="sm" onClick={handleAddJob}>+ Job</Button>
+          )}
+        </div>
       </div>
 
       {/* Scheduler status bar */}
@@ -140,73 +192,90 @@ export function CronApp() {
         <SchedulerBar
           active={state.schedulerActive}
           autostart={state.autostart}
-          jobCount={stats.total}
-          activeCount={stats.active}
-          disabledCount={stats.disabled}
+          jobCount={stats.totalJobs}
+          activeCount={stats.activeJobs}
+          disabledCount={stats.disabledJobs}
+          reminderCount={stats.activeReminders}
+          notificationSettings={state.notificationSettings ?? DEFAULT_NOTIFICATION_SETTINGS}
           onToggle={toggleScheduler}
           onAutostartChange={handleAutostartChange}
+          onNotificationSettingsChange={handleNotificationSettingsChange}
         />
       </div>
 
       {/* Tab bar */}
       <div className="mb-3 flex gap-1 border-b border-border">
-        {(['jobs', 'history'] as const).map((tab) => (
+        {([
+          { key: 'reminders' as const, label: `Reminders (${stats.totalReminders})` },
+          { key: 'jobs' as const, label: `Jobs (${stats.totalJobs})` },
+          { key: 'history' as const, label: `History (${state.lastRunResults.length})` },
+        ]).map((tab) => (
           <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
             className={`border-b-2 px-3 py-1.5 text-xs font-medium transition-colors ${
-              activeTab === tab
+              activeTab === tab.key
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-muted-foreground hover:text-foreground'
             }`}
           >
-            {tab === 'jobs'
-              ? `Jobs (${stats.total})`
-              : `History (${state.lastRunResults.length})`}
+            {tab.label}
           </button>
         ))}
       </div>
 
       {/* Content */}
       <div className="flex-1 overflow-y-auto">
-        {activeTab === 'jobs' ? (
+        {activeTab === 'reminders' && (
+          <ReminderList
+            reminders={reminders}
+            onEdit={handleEditReminder}
+            onRemove={handleRemoveReminder}
+            onSnooze={handleSnoozeReminder}
+            onComplete={handleCompleteReminder}
+            onToggleEnabled={handleToggleReminderEnabled}
+            onAdd={handleAddReminder}
+          />
+        )}
+        {activeTab === 'jobs' && (
           <JobsTab
             jobs={state.jobs}
             schedulerActive={state.schedulerActive}
             onEdit={handleEditJob}
-            onToggleEnabled={handleToggleEnabled}
+            onToggleEnabled={handleToggleJobEnabled}
             onRemove={handleRemoveJob}
             onRun={handleRunJob}
             onAdd={handleAddJob}
           />
-        ) : (
+        )}
+        {activeTab === 'history' && (
           <Card className="gap-0 py-0 shadow-none">
             <RunHistory results={state.lastRunResults} />
           </Card>
         )}
       </div>
 
-      {/* Add/Edit dialog */}
+      {/* Dialogs */}
       <JobForm
-        open={showForm}
-        onClose={() => setShowForm(false)}
+        open={showJobForm}
+        onClose={() => setShowJobForm(false)}
         onSave={handleSaveJob}
         editingJob={editingJob}
+      />
+      <ReminderForm
+        open={showReminderForm}
+        onClose={() => setShowReminderForm(false)}
+        onSave={handleSaveReminder}
+        editingReminder={editingReminder}
       />
     </div>
   );
 }
 
-// ── Sub-component ──────────────────────────────────────────────
+// ── Jobs sub-component ─────────────────────────────────────────
 
 function JobsTab({
-  jobs,
-  schedulerActive,
-  onEdit,
-  onToggleEnabled,
-  onRemove,
-  onRun,
-  onAdd,
+  jobs, schedulerActive, onEdit, onToggleEnabled, onRemove, onRun, onAdd,
 }: {
   jobs: CronJob[];
   schedulerActive: boolean;
@@ -220,16 +289,11 @@ function JobsTab({
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center animate-cron-fade-in">
         <div className="mb-4 text-4xl">⏰</div>
-        <h2 className="text-base font-medium text-foreground">
-          No cron jobs yet
-        </h2>
+        <h2 className="text-base font-medium text-foreground">No cron jobs yet</h2>
         <p className="mt-1.5 max-w-[240px] text-xs leading-relaxed text-muted-foreground">
-          Create a job to schedule recurring agent prompts, or ask the agent to
-          set one up for you.
+          Create a job to schedule recurring agent prompts.
         </p>
-        <Button size="sm" className="mt-4" onClick={onAdd}>
-          + New Job
-        </Button>
+        <Button size="sm" className="mt-4" onClick={onAdd}>+ New Job</Button>
       </div>
     );
   }

--- a/packages/pi-cron-extension/ui/CronApp.tsx
+++ b/packages/pi-cron-extension/ui/CronApp.tsx
@@ -163,6 +163,12 @@ export function CronApp() {
     }));
   }, [updateState]);
 
+  // ── History ───────────────────────────────────────────────
+
+  const handleClearHistory = useCallback(() => {
+    updateState((prev) => ({ ...prev, lastRunResults: [] }));
+  }, [updateState]);
+
   // ── Render ───────────────────────────────────────────────
 
   return (
@@ -183,6 +189,11 @@ export function CronApp() {
           )}
           {activeTab === 'jobs' && (
             <Button size="sm" onClick={handleAddJob}>+ Job</Button>
+          )}
+          {activeTab === 'history' && state.lastRunResults.length > 0 && (
+            <Button size="sm" variant="ghost" className="text-muted-foreground" onClick={handleClearHistory}>
+              Clear
+            </Button>
           )}
         </div>
       </div>

--- a/packages/pi-cron-extension/ui/components/JobCard.tsx
+++ b/packages/pi-cron-extension/ui/components/JobCard.tsx
@@ -156,7 +156,7 @@ export function JobCard({
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
-            className="bg-destructive text-white hover:bg-destructive/90"
+            className="bg-red-600 text-white hover:bg-red-700"
             onClick={() => onRemove(job.name)}
           >
             Remove

--- a/packages/pi-cron-extension/ui/components/JobForm.tsx
+++ b/packages/pi-cron-extension/ui/components/JobForm.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from '@sero/ui/lib/utils';
 import { validateCron, cronToHuman } from '../../shared/cron';
 import { CRON_PRESETS } from '../lib/cron-utils';
+import { ModelPicker } from './ModelPicker';
 import type { CronJob } from '../../shared/types';
 
 interface JobFormProps {
@@ -229,16 +230,9 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
             <label className="mb-1 block text-xs font-medium text-muted-foreground">
               Model
             </label>
-            <input
-              type="text"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              placeholder="sonnet"
-              className={cn(inputCls, 'font-mono')}
-            />
+            <ModelPicker value={model} onChange={setModel} />
             <p className="mt-1 text-[11px] text-muted-foreground">
-              Model pattern or ID — e.g. "sonnet", "openai/gpt-4o",
-              "gemini:high". Leave blank for default.
+              Choose a model or leave as default.
             </p>
           </div>
         </form>

--- a/packages/pi-cron-extension/ui/components/ModelPicker.tsx
+++ b/packages/pi-cron-extension/ui/components/ModelPicker.tsx
@@ -1,0 +1,307 @@
+/**
+ * ModelPicker — dropdown for selecting a model from available providers.
+ *
+ * Uses @sero/app-runtime's useAvailableModels() to fetch session-independent
+ * model listings from the host's ModelRegistry. The selected value is stored
+ * as a "provider/modelId" string matching the `pi --model` flag format.
+ */
+
+import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import {
+  useAvailableModels,
+  type AppModelInfo,
+  type AppModelGroup,
+} from '@sero/app-runtime';
+import { cn } from '@sero/ui/lib/utils';
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface ModelPickerProps {
+  /** Current model string (e.g. "anthropic/claude-sonnet-4-20250514"). */
+  value: string;
+  /** Called with the new model string, or empty string for "default". */
+  onChange: (value: string) => void;
+  /** CSS class override for the outer container. */
+  className?: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Convert a ModelInfo to the pi --model string format. */
+function toModelString(model: AppModelInfo): string {
+  return `${model.provider}/${model.modelId}`;
+}
+
+/** Find a model across all groups matching a value string. */
+function findModel(
+  groups: AppModelGroup[],
+  value: string,
+): { model: AppModelInfo; group: AppModelGroup } | null {
+  for (const group of groups) {
+    for (const model of group.models) {
+      if (toModelString(model) === value) return { model, group };
+      // Also match on just modelId for backwards compat
+      if (model.modelId === value) return { model, group };
+    }
+  }
+  return null;
+}
+
+/** Filter groups by query, matching on name or modelId. */
+function filterGroups(groups: AppModelGroup[], query: string): AppModelGroup[] {
+  if (!query) return groups;
+  const q = query.toLowerCase();
+  const filtered: AppModelGroup[] = [];
+  for (const group of groups) {
+    const matches = group.models.filter(
+      (m) => m.name.toLowerCase().includes(q) || m.modelId.toLowerCase().includes(q),
+    );
+    if (matches.length) filtered.push({ ...group, models: matches });
+  }
+  return filtered;
+}
+
+// ── Component ────────────────────────────────────────────────────
+
+export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
+  const { groups, loading, error } = useAvailableModels();
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Resolve current selection
+  const resolved = useMemo(() => findModel(groups, value), [groups, value]);
+
+  // Filtered groups for search
+  const filtered = useMemo(() => filterGroups(groups, filter), [groups, filter]);
+  const totalFiltered = useMemo(
+    () => filtered.reduce((n, g) => n + g.models.length, 0),
+    [filtered],
+  );
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // Focus search input when opening
+  useEffect(() => {
+    if (open) {
+      setFilter('');
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const handleSelect = useCallback(
+    (model: AppModelInfo) => {
+      onChange(toModelString(model));
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  const handleClear = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      onChange('');
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  return (
+    <div ref={containerRef} className={cn('relative', className)}>
+      {/* Trigger */}
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground transition-colors',
+          'hover:bg-secondary/50 focus:outline-none focus:ring-1 focus:ring-ring',
+          open && 'ring-1 ring-ring',
+        )}
+      >
+        {resolved ? (
+          <>
+            <img
+              src={resolved.group.logo}
+              alt={resolved.group.displayName}
+              className="size-4 rounded-sm dark:invert"
+            />
+            <span className="flex-1 truncate text-left font-medium">
+              {resolved.model.name}
+            </span>
+            {resolved.model.reasoning && (
+              <span className="text-[10px] text-amber-500">✦</span>
+            )}
+          </>
+        ) : value ? (
+          <span className="flex-1 truncate text-left font-mono text-muted-foreground">
+            {value}
+          </span>
+        ) : (
+          <span className="flex-1 text-left text-muted-foreground">
+            Default model
+          </span>
+        )}
+
+        {/* Clear / chevron */}
+        {value ? (
+          <button
+            type="button"
+            onClick={handleClear}
+            className="ml-1 rounded p-0.5 text-muted-foreground hover:text-foreground"
+            title="Reset to default"
+          >
+            ✕
+          </button>
+        ) : (
+          <svg className="size-3 text-muted-foreground" viewBox="0 0 12 12" fill="none">
+            <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </button>
+
+      {/* Dropdown — opens upward to avoid overflowing the dialog */}
+      {open && (
+        <div className="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-lg border border-border bg-background shadow-lg">
+          {/* Search */}
+          <div className="flex items-center gap-2 border-b border-border px-3 py-1">
+            <svg className="size-3.5 shrink-0 text-muted-foreground" viewBox="0 0 16 16" fill="none">
+              <circle cx="7" cy="7" r="5.5" stroke="currentColor" strokeWidth="1.5" />
+              <path d="M11 11l3.5 3.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+            <input
+              ref={inputRef}
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Search models…"
+              className="h-7 w-full bg-transparent text-xs text-foreground placeholder:text-muted-foreground"
+              style={{ outline: 'none', border: 'none', boxShadow: 'none' }}
+            />
+          </div>
+
+          {/* Model list */}
+          <div className="max-h-[240px] overflow-y-auto py-1">
+            {loading ? (
+              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                Loading models…
+              </div>
+            ) : error ? (
+              <div className="px-3 py-4 text-center text-xs text-destructive">
+                {error}
+              </div>
+            ) : groups.length === 0 ? (
+              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                No models available. Run <code className="rounded bg-muted px-1 font-mono">pi auth</code> to add a provider.
+              </div>
+            ) : totalFiltered === 0 ? (
+              <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                No models matching "{filter}"
+              </div>
+            ) : (
+              filtered.map((group, i) => (
+                <ProviderGroup
+                  key={group.provider}
+                  group={group}
+                  selectedValue={value}
+                  onSelect={handleSelect}
+                  showDivider={i > 0}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Default option */}
+          <div className="border-t border-border px-1 py-1">
+            <button
+              type="button"
+              onClick={() => { onChange(''); setOpen(false); }}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors',
+                !value
+                  ? 'bg-secondary text-foreground'
+                  : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground',
+              )}
+            >
+              <span className="size-4 text-center text-[10px]">⚙</span>
+              <span className="font-medium">Use default model</span>
+              {!value && <span className="ml-auto text-emerald-500 text-[11px]">✓</span>}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────────────────
+
+function ProviderGroup({
+  group,
+  selectedValue,
+  onSelect,
+  showDivider,
+}: {
+  group: AppModelGroup;
+  selectedValue: string;
+  onSelect: (model: AppModelInfo) => void;
+  showDivider: boolean;
+}) {
+  return (
+    <div>
+      {showDivider && <div className="mx-3 border-t border-border" />}
+      <div className="flex items-center gap-2 px-3 pb-0.5 pt-2">
+        <img
+          src={group.logo}
+          alt={group.displayName}
+          className="size-3.5 rounded-sm dark:invert"
+        />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {group.displayName}
+        </span>
+      </div>
+      <div className="px-1">
+        {group.models.map((model) => {
+          const modelStr = toModelString(model);
+          const isSelected = selectedValue === modelStr || selectedValue === model.modelId;
+          return (
+            <button
+              key={modelStr}
+              type="button"
+              onClick={() => onSelect(model)}
+              className={cn(
+                'flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-xs transition-colors',
+                isSelected
+                  ? 'bg-secondary text-foreground'
+                  : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground',
+              )}
+            >
+              <span className="size-3.5 text-center text-[11px]">
+                {isSelected ? (
+                  <span className="text-emerald-500">✓</span>
+                ) : (
+                  <span className="inline-block size-1.5 rounded-full bg-border" />
+                )}
+              </span>
+              <span className="flex-1 truncate font-medium">{model.name}</span>
+              {model.reasoning && (
+                <span className="text-[10px] text-amber-500/60">✦</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default ModelPicker;

--- a/packages/pi-cron-extension/ui/components/NotificationSettings.tsx
+++ b/packages/pi-cron-extension/ui/components/NotificationSettings.tsx
@@ -1,0 +1,93 @@
+/**
+ * NotificationSettings — inline settings for notification sound.
+ *
+ * Rendered in the SchedulerBar area. Lets users toggle sound
+ * on/off and pick a macOS system sound.
+ */
+
+import { useState } from 'react';
+import { Button } from '@sero/ui/components/ui/button';
+import { Switch } from '@sero/ui/components/ui/switch';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@sero/ui/components/ui/popover';
+import type { NotificationSettings as Settings } from '../../shared/types';
+import {
+  DEFAULT_NOTIFICATION_SETTINGS,
+  NOTIFICATION_SOUNDS,
+} from '../../shared/types';
+
+interface NotificationSettingsProps {
+  settings: Settings;
+  onChange: (settings: Settings) => void;
+}
+
+export function NotificationSettings({
+  settings,
+  onChange,
+}: NotificationSettingsProps) {
+  const [open, setOpen] = useState(false);
+  const effective = { ...DEFAULT_NOTIFICATION_SETTINGS, ...settings };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
+          title="Notification settings"
+        >
+          {effective.soundEnabled ? '🔔' : '🔕'}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="end"
+        className="w-56 p-3"
+      >
+        <div className="space-y-3">
+          <p className="text-xs font-medium text-foreground">
+            Notification Sound
+          </p>
+
+          {/* Sound enabled toggle */}
+          <label className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">Play sound</span>
+            <Switch
+              checked={effective.soundEnabled}
+              onCheckedChange={(enabled) =>
+                onChange({ ...effective, soundEnabled: enabled })
+              }
+              className="scale-75"
+            />
+          </label>
+
+          {/* Sound picker */}
+          {effective.soundEnabled && (
+            <div className="space-y-1.5">
+              <span className="text-[11px] text-muted-foreground">Sound</span>
+              <div className="grid grid-cols-2 gap-1">
+                {NOTIFICATION_SOUNDS.map((sound) => (
+                  <button
+                    key={sound}
+                    onClick={() => onChange({ ...effective, soundName: sound })}
+                    className={`rounded px-2 py-1 text-left text-xs transition-colors ${
+                      effective.soundName === sound
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    }`}
+                  >
+                    {sound}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/pi-cron-extension/ui/components/ReminderCard.tsx
+++ b/packages/pi-cron-extension/ui/components/ReminderCard.tsx
@@ -1,0 +1,254 @@
+/**
+ * ReminderCard — displays a single reminder with status, schedule, and actions.
+ */
+
+import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@sero/ui/components/ui/alert-dialog';
+import { Badge } from '@sero/ui/components/ui/badge';
+import { Button } from '@sero/ui/components/ui/button';
+import { Card } from '@sero/ui/components/ui/card';
+import { cn } from '@sero/ui/lib/utils';
+import type { Reminder } from '../../shared/types';
+import { SNOOZE_OPTIONS } from '../../shared/types';
+import {
+  statusLabel,
+  nextFireDescription,
+  formatDateTime,
+} from '../../shared/reminder-utils';
+import { cronToHuman } from '../../shared/cron';
+
+interface ReminderCardProps {
+  reminder: Reminder;
+  onEdit: (id: string) => void;
+  onRemove: (id: string) => void;
+  onSnooze: (id: string, minutes: number) => void;
+  onComplete: (id: string) => void;
+  onToggleEnabled: (id: string) => void;
+}
+
+export function ReminderCard({
+  reminder,
+  onEdit,
+  onRemove,
+  onSnooze,
+  onComplete,
+  onToggleEnabled,
+}: ReminderCardProps) {
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+  const [showSnoozeMenu, setShowSnoozeMenu] = useState(false);
+
+  const isCompleted = reminder.status === 'completed';
+  const isDisabled = reminder.status === 'disabled';
+  const isSnoozed = reminder.status === 'snoozed';
+  const dimmed = isCompleted || isDisabled;
+
+  return (
+    <>
+      <Card className={cn('gap-0 py-0 shadow-none transition-colors', dimmed && 'opacity-50')}>
+        <div className="px-4 py-3">
+          {/* Header: title + badges */}
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-sm font-semibold text-foreground">
+              {reminder.title}
+            </span>
+            <StatusBadge status={reminder.status} />
+            <TypeBadge type={reminder.type} />
+            {reminder.channel === 'email' && (
+              <Badge variant="outline" className="border-blue-500/30 text-[10px] text-blue-500">
+                📧 email
+              </Badge>
+            )}
+          </div>
+
+          {/* Schedule / fire time */}
+          <div className="mb-1.5 flex items-center gap-2 text-xs text-muted-foreground">
+            {reminder.type === 'recurring' && reminder.schedule && (
+              <>
+                <code className="rounded bg-secondary px-2 py-0.5 text-foreground">
+                  {reminder.schedule}
+                </code>
+                <span>{cronToHuman(reminder.schedule)}</span>
+              </>
+            )}
+            {reminder.type === 'once' && reminder.fireAt && (
+              <span>🕐 {formatDateTime(reminder.fireAt)}</span>
+            )}
+            {isSnoozed && reminder.snoozedUntil && (
+              <span className="text-amber-500">
+                💤 Until {formatDateTime(reminder.snoozedUntil)}
+              </span>
+            )}
+          </div>
+
+          {/* Notes */}
+          {reminder.notes && (
+            <p className="mb-2 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+              {reminder.notes}
+            </p>
+          )}
+
+          {/* Next fire info */}
+          <p className="mb-3 text-[11px] text-muted-foreground">
+            {nextFireDescription(reminder)}
+            {reminder.lastFiredAt && (
+              <> · Last fired: {formatDateTime(reminder.lastFiredAt)}</>
+            )}
+          </p>
+
+          {/* Actions */}
+          <div className="flex flex-wrap items-center gap-1.5">
+            {!isCompleted && (
+              <>
+                <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onEdit(reminder.id)}>
+                  Edit
+                </Button>
+                <Button
+                  variant="ghost" size="sm" className="h-7 text-xs"
+                  onClick={() => onToggleEnabled(reminder.id)}
+                >
+                  {isDisabled ? '▶ Enable' : '⏸ Disable'}
+                </Button>
+                {!isDisabled && (
+                  <div className="relative">
+                    <Button
+                      variant="ghost" size="sm"
+                      className="h-7 text-xs text-amber-500 hover:text-amber-600"
+                      onClick={() => setShowSnoozeMenu(!showSnoozeMenu)}
+                    >
+                      💤 Snooze
+                    </Button>
+                    {showSnoozeMenu && (
+                      <SnoozeDropdown
+                        onSelect={(mins) => { onSnooze(reminder.id, mins); setShowSnoozeMenu(false); }}
+                        onClose={() => setShowSnoozeMenu(false)}
+                      />
+                    )}
+                  </div>
+                )}
+                <Button
+                  variant="ghost" size="sm"
+                  className="h-7 text-xs text-emerald-500 hover:text-emerald-600"
+                  onClick={() => onComplete(reminder.id)}
+                >
+                  ✓ Done
+                </Button>
+              </>
+            )}
+            <div className="flex-1" />
+            <Button
+              variant="ghost" size="sm"
+              className="h-7 text-xs text-destructive hover:text-destructive"
+              onClick={() => setShowRemoveConfirm(true)}
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      {/* Remove confirmation */}
+      <AlertDialog open={showRemoveConfirm} onOpenChange={setShowRemoveConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove reminder?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the reminder "{reminder.title}".
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 text-white hover:bg-red-700"
+              onClick={() => onRemove(reminder.id)}
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+// ── Sub-components ──────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: Reminder['status'] }) {
+  switch (status) {
+    case 'active':
+      return (
+        <Badge variant="outline" className="border-emerald-500/30 text-[10px] text-emerald-500">
+          🔔 Active
+        </Badge>
+      );
+    case 'snoozed':
+      return (
+        <Badge variant="outline" className="border-amber-500/30 text-[10px] text-amber-500">
+          💤 Snoozed
+        </Badge>
+      );
+    case 'completed':
+      return (
+        <Badge variant="secondary" className="text-[10px]">
+          ✅ Done
+        </Badge>
+      );
+    case 'disabled':
+      return (
+        <Badge variant="secondary" className="text-[10px]">
+          ⏸ Paused
+        </Badge>
+      );
+    default:
+      return null;
+  }
+}
+
+function TypeBadge({ type }: { type: Reminder['type'] }) {
+  if (type === 'recurring') {
+    return (
+      <Badge variant="outline" className="border-primary/30 text-[10px] text-primary">
+        🔄 Recurring
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="border-muted-foreground/30 text-[10px] text-muted-foreground">
+      Once
+    </Badge>
+  );
+}
+
+function SnoozeDropdown({
+  onSelect,
+  onClose,
+}: {
+  onSelect: (minutes: number) => void;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      {/* Backdrop to close dropdown */}
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+      <div className="absolute left-0 top-full z-50 mt-1 min-w-[160px] rounded-md border border-border bg-popover p-1 shadow-md">
+        {SNOOZE_OPTIONS.map((opt) => (
+          <button
+            key={opt.minutes}
+            className="w-full rounded-sm px-3 py-1.5 text-left text-xs text-popover-foreground hover:bg-accent"
+            onClick={() => onSelect(opt.minutes)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/packages/pi-cron-extension/ui/components/ReminderForm.tsx
+++ b/packages/pi-cron-extension/ui/components/ReminderForm.tsx
@@ -1,0 +1,308 @@
+/**
+ * ReminderForm — dialog for adding or editing a reminder.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Button } from '@sero/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@sero/ui/components/ui/dialog';
+import { cn } from '@sero/ui/lib/utils';
+import { validateCron, cronToHuman } from '../../shared/cron';
+import { generateId } from '../../shared/reminder-utils';
+import type { Reminder, ReminderChannel, ReminderType } from '../../shared/types';
+
+interface ReminderFormProps {
+  open: boolean;
+  onClose: () => void;
+  onSave: (reminder: Reminder) => void;
+  editingReminder?: Reminder | null;
+}
+
+const RECURRING_PRESETS = [
+  { label: 'Every morning (9am)', value: '0 9 * * *' },
+  { label: 'Weekday mornings', value: '0 9 * * 1-5' },
+  { label: 'Every Friday morning', value: '0 9 * * 5' },
+  { label: 'Every Monday 9am', value: '0 9 * * 1' },
+  { label: 'Daily at noon', value: '0 12 * * *' },
+  { label: 'Weekly (Sun 10am)', value: '0 10 * * 0' },
+  { label: 'Monthly 1st at 9am', value: '0 9 1 * *' },
+] as const;
+
+export function ReminderForm({
+  open,
+  onClose,
+  onSave,
+  editingReminder,
+}: ReminderFormProps) {
+  const isEditing = !!editingReminder;
+
+  const [title, setTitle] = useState('');
+  const [notes, setNotes] = useState('');
+  const [channel, setChannel] = useState<ReminderChannel>('notification');
+  const [type, setType] = useState<ReminderType>('once');
+  const [fireAt, setFireAt] = useState('');
+  const [schedule, setSchedule] = useState('');
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
+
+  // Reset form when opening
+  useEffect(() => {
+    if (!open) return;
+    if (editingReminder) {
+      setTitle(editingReminder.title);
+      setNotes(editingReminder.notes ?? '');
+      setChannel(editingReminder.channel);
+      setType(editingReminder.type);
+      setFireAt(editingReminder.fireAt ? toLocalDatetime(editingReminder.fireAt) : '');
+      setSchedule(editingReminder.schedule ?? '');
+    } else {
+      setTitle('');
+      setNotes('');
+      setChannel('notification');
+      setType('once');
+      setFireAt(defaultFireAt());
+      setSchedule('');
+    }
+    setScheduleError(null);
+  }, [open, editingReminder]);
+
+  // Validate cron
+  useEffect(() => {
+    if (type !== 'recurring' || !schedule.trim()) {
+      setScheduleError(null);
+      return;
+    }
+    setScheduleError(validateCron(schedule.trim()));
+  }, [schedule, type]);
+
+  const canSave = (() => {
+    if (!title.trim()) return false;
+    if (type === 'once' && !fireAt) return false;
+    if (type === 'recurring' && (!schedule.trim() || scheduleError)) return false;
+    return true;
+  })();
+
+  const handleSave = useCallback(() => {
+    if (!canSave) return;
+
+    const reminder: Reminder = {
+      id: editingReminder?.id ?? generateId(),
+      title: title.trim(),
+      notes: notes.trim() || undefined,
+      channel,
+      type,
+      status: editingReminder?.status ?? 'active',
+      createdAt: editingReminder?.createdAt ?? new Date().toISOString(),
+    };
+
+    if (type === 'once') {
+      reminder.fireAt = new Date(fireAt).toISOString();
+    }
+    if (type === 'recurring') {
+      reminder.schedule = schedule.trim();
+    }
+
+    // Preserve history fields when editing
+    if (editingReminder) {
+      reminder.lastFiredAt = editingReminder.lastFiredAt;
+      reminder.completedAt = editingReminder.completedAt;
+      reminder.snoozedUntil = editingReminder.snoozedUntil;
+    }
+
+    onSave(reminder);
+    onClose();
+  }, [canSave, title, notes, channel, type, fireAt, schedule, editingReminder, onSave, onClose]);
+
+  const inputCls =
+    'w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-md max-h-[85vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? 'Edit Reminder' : 'New Reminder'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => { e.preventDefault(); handleSave(); }}
+          className="flex flex-col gap-4 py-2"
+        >
+          {/* Title */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Title *
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Phone mum"
+              className={inputCls}
+              autoFocus
+            />
+          </div>
+
+          {/* Notes */}
+          <div>
+            <label className="mb-1 block text-xs font-medium text-muted-foreground">
+              Notes
+            </label>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Optional details…"
+              rows={2}
+              className={cn(inputCls, 'resize-y')}
+            />
+          </div>
+
+          {/* Type toggle */}
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Type *
+            </label>
+            <div className="flex gap-2">
+              {(['once', 'recurring'] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => setType(t)}
+                  className={cn(
+                    'flex-1 rounded-md border px-3 py-2 text-xs font-medium transition-colors',
+                    type === t
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : 'border-border text-muted-foreground hover:bg-secondary',
+                  )}
+                >
+                  {t === 'once' ? '🕐 One-time' : '🔄 Recurring'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* One-time: datetime picker */}
+          {type === 'once' && (
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                When *
+              </label>
+              <input
+                type="datetime-local"
+                value={fireAt}
+                onChange={(e) => setFireAt(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+          )}
+
+          {/* Recurring: cron expression */}
+          {type === 'recurring' && (
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                Schedule (cron) *
+              </label>
+              <input
+                type="text"
+                value={schedule}
+                onChange={(e) => setSchedule(e.target.value)}
+                placeholder="0 9 * * 5"
+                className={cn(inputCls, 'font-mono')}
+              />
+              {scheduleError ? (
+                <p className="mt-1 text-[11px] text-destructive">{scheduleError}</p>
+              ) : schedule.trim() ? (
+                <p className="mt-1 text-[11px] text-emerald-500">
+                  ✓ {cronToHuman(schedule.trim())}
+                </p>
+              ) : (
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  min hour dom month dow
+                </p>
+              )}
+              {/* Presets */}
+              <div className="mt-2 flex flex-wrap gap-1">
+                {RECURRING_PRESETS.map((p) => (
+                  <button
+                    key={p.value}
+                    type="button"
+                    onClick={() => setSchedule(p.value)}
+                    className={cn(
+                      'rounded-full border border-border px-2 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground',
+                      schedule === p.value && 'border-primary bg-primary/10 text-primary',
+                    )}
+                  >
+                    {p.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Channel */}
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Notification Channel
+            </label>
+            <div className="flex gap-2">
+              {([
+                { value: 'notification' as const, label: '🖥 Desktop', desc: 'System notification' },
+                { value: 'email' as const, label: '📧 Email', desc: 'Coming soon' },
+              ]).map((ch) => (
+                <button
+                  key={ch.value}
+                  type="button"
+                  onClick={() => setChannel(ch.value)}
+                  className={cn(
+                    'flex-1 rounded-md border px-3 py-2 text-left transition-colors',
+                    channel === ch.value
+                      ? 'border-primary bg-primary/10'
+                      : 'border-border hover:bg-secondary',
+                  )}
+                >
+                  <span className={cn(
+                    'block text-xs font-medium',
+                    channel === ch.value ? 'text-primary' : 'text-foreground',
+                  )}>
+                    {ch.label}
+                  </span>
+                  <span className="block text-[10px] text-muted-foreground">
+                    {ch.desc}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </form>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button onClick={handleSave} disabled={!canSave}>
+            {isEditing ? 'Save Changes' : 'Set Reminder'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────
+
+/** Default fire-at: 1 hour from now, rounded to next 5 min. */
+function defaultFireAt(): string {
+  const d = new Date(Date.now() + 3_600_000);
+  d.setMinutes(Math.ceil(d.getMinutes() / 5) * 5, 0, 0);
+  return toLocalDatetime(d.toISOString());
+}
+
+/** Convert ISO string to `datetime-local` input format. */
+function toLocalDatetime(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/packages/pi-cron-extension/ui/components/ReminderList.tsx
+++ b/packages/pi-cron-extension/ui/components/ReminderList.tsx
@@ -1,0 +1,179 @@
+/**
+ * ReminderList — filterable list of reminders with empty state.
+ */
+
+import { useState, useMemo } from 'react';
+import { Button } from '@sero/ui/components/ui/button';
+import { Badge } from '@sero/ui/components/ui/badge';
+import { cn } from '@sero/ui/lib/utils';
+import type { Reminder, ReminderStatus } from '../../shared/types';
+import { ReminderCard } from './ReminderCard';
+
+type FilterKey = 'all' | 'active' | 'snoozed' | 'completed' | 'disabled';
+
+const FILTERS: Array<{ key: FilterKey; label: string }> = [
+  { key: 'all', label: 'All' },
+  { key: 'active', label: 'Active' },
+  { key: 'snoozed', label: 'Snoozed' },
+  { key: 'completed', label: 'Done' },
+  { key: 'disabled', label: 'Paused' },
+];
+
+interface ReminderListProps {
+  reminders: Reminder[];
+  onEdit: (id: string) => void;
+  onRemove: (id: string) => void;
+  onSnooze: (id: string, minutes: number) => void;
+  onComplete: (id: string) => void;
+  onToggleEnabled: (id: string) => void;
+  onAdd: () => void;
+}
+
+export function ReminderList({
+  reminders,
+  onEdit,
+  onRemove,
+  onSnooze,
+  onComplete,
+  onToggleEnabled,
+  onAdd,
+}: ReminderListProps) {
+  const [filter, setFilter] = useState<FilterKey>('all');
+
+  // Count per filter
+  const counts = useMemo(() => {
+    const c: Record<FilterKey, number> = {
+      all: reminders.length,
+      active: 0,
+      snoozed: 0,
+      completed: 0,
+      disabled: 0,
+    };
+    for (const r of reminders) {
+      if (r.status in c) c[r.status as FilterKey]++;
+    }
+    return c;
+  }, [reminders]);
+
+  // Filtered + sorted
+  const filtered = useMemo(() => {
+    let list = reminders;
+    if (filter !== 'all') {
+      list = list.filter((r) => r.status === filter);
+    }
+    return sortReminders(list);
+  }, [reminders, filter]);
+
+  if (reminders.length === 0) {
+    return <EmptyState onAdd={onAdd} />;
+  }
+
+  return (
+    <div className="flex flex-col gap-3 animate-cron-fade-in">
+      {/* Filter chips */}
+      <div className="flex flex-wrap gap-1.5">
+        {FILTERS.map((f) => {
+          const count = counts[f.key];
+          if (f.key !== 'all' && count === 0) return null;
+          return (
+            <button
+              key={f.key}
+              onClick={() => setFilter(f.key)}
+              className={cn(
+                'flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium transition-colors',
+                filter === f.key
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border text-muted-foreground hover:bg-secondary hover:text-foreground',
+              )}
+            >
+              {f.label}
+              <Badge
+                variant="secondary"
+                className="ml-0.5 h-4 min-w-[16px] px-1 text-[10px]"
+              >
+                {count}
+              </Badge>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Reminder cards */}
+      {filtered.length === 0 ? (
+        <div className="py-8 text-center text-xs text-muted-foreground">
+          No {filter} reminders
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {filtered.map((reminder) => (
+            <ReminderCard
+              key={reminder.id}
+              reminder={reminder}
+              onEdit={onEdit}
+              onRemove={onRemove}
+              onSnooze={onSnooze}
+              onComplete={onComplete}
+              onToggleEnabled={onToggleEnabled}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Sorting ──────────────────────────────────────────────────────
+
+const STATUS_ORDER: Record<ReminderStatus, number> = {
+  snoozed: 0,
+  active: 1,
+  disabled: 2,
+  completed: 3,
+};
+
+function sortReminders(list: Reminder[]): Reminder[] {
+  return [...list].sort((a, b) => {
+    // Status order first
+    const sa = STATUS_ORDER[a.status] ?? 9;
+    const sb = STATUS_ORDER[b.status] ?? 9;
+    if (sa !== sb) return sa - sb;
+
+    // Then by next fire time (soonest first)
+    const ta = getNextFireTime(a);
+    const tb = getNextFireTime(b);
+    if (ta !== tb) return ta - tb;
+
+    // Then by creation date (newest first)
+    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+  });
+}
+
+function getNextFireTime(r: Reminder): number {
+  if (r.status === 'snoozed' && r.snoozedUntil) {
+    return new Date(r.snoozedUntil).getTime();
+  }
+  if (r.type === 'once' && r.fireAt) {
+    return new Date(r.fireAt).getTime();
+  }
+  return Infinity; // recurring without specific next time
+}
+
+// ── Empty state ──────────────────────────────────────────────────
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center animate-cron-fade-in">
+      <div className="mb-4 text-4xl">🔔</div>
+      <h2 className="text-base font-medium text-foreground">
+        No reminders yet
+      </h2>
+      <p className="mt-1.5 max-w-[280px] text-xs leading-relaxed text-muted-foreground">
+        Create a reminder to get notified at a specific time, or ask the agent
+        something like "Remind me in 1 hour to phone mum".
+      </p>
+      <Button size="sm" className="mt-4" onClick={onAdd}>
+        + New Reminder
+      </Button>
+    </div>
+  );
+}

--- a/packages/pi-cron-extension/ui/components/RunHistory.tsx
+++ b/packages/pi-cron-extension/ui/components/RunHistory.tsx
@@ -1,8 +1,10 @@
 /**
- * RunHistory — shows recent cron job execution results.
+ * RunHistory — shows recent cron job execution results with expandable output.
  */
 
+import { useState } from 'react';
 import { Badge } from '@sero/ui/components/ui/badge';
+import { Button } from '@sero/ui/components/ui/button';
 import { cn } from '@sero/ui/lib/utils';
 import type { CronRunResult } from '../../shared/types';
 import { formatDuration, timeAgo } from '../lib/cron-utils';
@@ -23,44 +25,103 @@ export function RunHistory({ results }: RunHistoryProps) {
   return (
     <div className="flex flex-col">
       {results.map((r, i) => (
-        <div
+        <RunResultRow
           key={`${r.jobName}-${r.startedAt}`}
-          className={cn(
-            'flex items-center gap-3 px-4 py-2 text-xs',
-            i < results.length - 1 && 'border-b border-border',
-          )}
-        >
-          {/* Status dot */}
-          <span
-            className={cn(
-              'h-1.5 w-1.5 shrink-0 rounded-full',
-              r.ok ? 'bg-emerald-500' : 'bg-destructive',
-            )}
-          />
-
-          {/* Job name */}
-          <span className="font-medium text-foreground">{r.jobName}</span>
-
-          {/* Duration */}
-          <Badge variant="secondary" className="text-[10px]">
-            {formatDuration(r.durationMs)}
-          </Badge>
-
-          {/* Error (if any) */}
-          {r.error && (
-            <span className="line-clamp-1 flex-1 text-destructive">
-              {r.error}
-            </span>
-          )}
-
-          <div className="flex-1" />
-
-          {/* Time ago */}
-          <span className="shrink-0 text-muted-foreground">
-            {timeAgo(r.startedAt)}
-          </span>
-        </div>
+          result={r}
+          isLast={i === results.length - 1}
+          defaultExpanded={i === 0 && !!(r.output?.trim())}
+        />
       ))}
+    </div>
+  );
+}
+
+function RunResultRow({
+  result: r,
+  isLast,
+  defaultExpanded,
+}: {
+  result: CronRunResult;
+  isLast: boolean;
+  defaultExpanded: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const hasOutput = !!r.output?.trim();
+  const hasError = !!r.error;
+  const hasExpandable = hasOutput || hasError;
+
+  // First line preview for inline display
+  const preview = r.output?.trim().split('\n')[0]?.slice(0, 80) ?? '';
+
+  return (
+    <div className={cn('px-4 py-2.5 text-xs', !isLast && 'border-b border-border')}>
+      {/* Summary row */}
+      <div className="flex items-center gap-3">
+        {/* Status dot */}
+        <span
+          className={cn(
+            'h-1.5 w-1.5 shrink-0 rounded-full',
+            r.ok ? 'bg-emerald-500' : 'bg-destructive',
+          )}
+        />
+
+        {/* Job name */}
+        <span className="font-medium text-foreground">{r.jobName}</span>
+
+        {/* Duration */}
+        <Badge variant="secondary" className="text-[10px]">
+          {formatDuration(r.durationMs)}
+        </Badge>
+
+        {/* Inline preview (when collapsed and has output) */}
+        {!expanded && hasOutput && (
+          <span className="line-clamp-1 flex-1 text-muted-foreground">
+            {preview}{preview.length >= 80 ? '…' : ''}
+          </span>
+        )}
+
+        {/* Error hint (when no output) */}
+        {!expanded && hasError && !hasOutput && (
+          <span className="line-clamp-1 flex-1 text-destructive">
+            {r.error}
+          </span>
+        )}
+
+        <div className="flex-1" />
+
+        {/* Expand toggle */}
+        {hasExpandable && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setExpanded(!expanded)}
+            className="h-6 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+          >
+            {expanded ? '▾ Hide' : '▸ Output'}
+          </Button>
+        )}
+
+        {/* Time ago */}
+        <span className="shrink-0 text-muted-foreground">
+          {timeAgo(r.startedAt)}
+        </span>
+      </div>
+
+      {/* Expanded output */}
+      {expanded && hasExpandable && (
+        <div className="mt-2 rounded-md border border-border bg-muted/30 p-3">
+          {hasOutput && (
+            <pre className="whitespace-pre-wrap break-words text-[11px] leading-relaxed text-foreground/80">
+              {r.output}
+            </pre>
+          )}
+          {hasError && (
+            <pre className="mt-1 whitespace-pre-wrap break-words text-[11px] leading-relaxed text-destructive">
+              {r.error}
+            </pre>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/pi-cron-extension/ui/components/SchedulerBar.tsx
+++ b/packages/pi-cron-extension/ui/components/SchedulerBar.tsx
@@ -1,11 +1,14 @@
 /**
- * SchedulerBar — status indicator, autostart toggle, and start/stop button.
+ * SchedulerBar — status indicator, autostart toggle, notification settings,
+ * and start/stop button.
  */
 
 import { Badge } from '@sero/ui/components/ui/badge';
 import { Button } from '@sero/ui/components/ui/button';
 import { Switch } from '@sero/ui/components/ui/switch';
 import { cn } from '@sero/ui/lib/utils';
+import type { NotificationSettings as NotifSettings } from '../../shared/types';
+import { NotificationSettings } from './NotificationSettings';
 
 interface SchedulerBarProps {
   active: boolean;
@@ -13,8 +16,11 @@ interface SchedulerBarProps {
   jobCount: number;
   activeCount: number;
   disabledCount: number;
+  reminderCount?: number;
+  notificationSettings?: NotifSettings;
   onToggle: () => void;
   onAutostartChange: (enabled: boolean) => void;
+  onNotificationSettingsChange?: (settings: NotifSettings) => void;
 }
 
 export function SchedulerBar({
@@ -23,8 +29,11 @@ export function SchedulerBar({
   jobCount,
   activeCount,
   disabledCount,
+  reminderCount,
+  notificationSettings,
   onToggle,
   onAutostartChange,
+  onNotificationSettingsChange,
 }: SchedulerBarProps) {
   return (
     <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-2.5">
@@ -64,9 +73,25 @@ export function SchedulerBar({
             {disabledCount} paused
           </Badge>
         )}
+        {(reminderCount ?? 0) > 0 && (
+          <Badge
+            variant="outline"
+            className="border-amber-500/30 text-xs text-amber-500"
+          >
+            🔔 {reminderCount} reminder{reminderCount === 1 ? '' : 's'}
+          </Badge>
+        )}
       </div>
 
       <div className="flex-1" />
+
+      {/* Notification sound settings */}
+      {onNotificationSettingsChange && notificationSettings && (
+        <NotificationSettings
+          settings={notificationSettings}
+          onChange={onNotificationSettingsChange}
+        />
+      )}
 
       {/* Autostart toggle */}
       <label className="flex items-center gap-1.5">


### PR DESCRIPTION
## Summary

Adds reminder functionality, a proper notification system, and fixes several scheduler reliability issues in the cron extension.

## Reminders

- **Reminder tool** — full CRUD via `reminder` tool (list, add, update, remove, snooze, complete, enable/disable)
- **Desktop notifications** with configurable macOS system sounds (Glass, Hero, Ping, etc.)
- **Snooze support** — 5m, 15m, 30m, 1h, 3h, tomorrow 9am
- **`current_time` tool** — gives the LLM accurate timestamps for computing `fire_at` values
- **UI** — ReminderCard, ReminderForm, ReminderList with status badges, filter chips, and sorting

## Notification System

- **`sero:notify` EventBus pattern** — extensions emit events on `pi.events`, the Sero host extension factory listens and routes to Electron `Notification` API. Any extension can use this; no `require('electron')` needed.
- **`NotificationSettings` UI** — sound toggle + sound picker popover in the SchedulerBar
- **Job completion notifications** — desktop notification on job success/failure
- **`showNotification()` options** — added `sound` (system sound name or boolean) and `subtitle` support

## Scheduler Fixes

- **Singleton scheduler** — moved scheduler state to module scope. The extension factory is called multiple times (once per Sero session), but only one scheduler exists per process. Fixes double job execution.
- **Eager initialization** — scheduler starts at extension load when `SERO_HOME` is set, instead of waiting for `session_start` (which may never fire on restored sessions)
- **Directory-based state watcher** — `fs.watch` on macOS tracks inodes; after an atomic rename the file watcher was orphaned. Now watches the parent directory, which has a stable inode across renames.
- **Output capture** — `CronRunResult.output` field captures the agent's response (extension loading noise stripped)

## History UX

- **Expandable output** — run history rows have `▸ Output` toggle; latest result auto-expands
- **Inline preview** — first line of output shown when collapsed
- **Destructive button contrast** — `bg-red-600` instead of theme `bg-destructive` for Remove dialogs

## Files Changed

### Sero Host
- `apps/desktop/electron/notifications.ts` — sound/subtitle options
- `apps/desktop/electron/sero-extension.ts` — `sero:notify` EventBus listener

### Cron Extension
- `extension/index.ts` — singleton scheduler, eager init, tool registrations
- `extension/state-io.ts` — extracted path resolution, read/write, mutex
- `extension/state-watcher.ts` — directory-based watcher
- `extension/notifier.ts` — EventBus notification emitter
- `extension/reminder-actions.ts` — reminder CRUD handlers
- `extension/scheduler.ts` — output capture, `stripExtensionNoise()`
- `shared/types.ts` — Reminder, NotificationSettings types
- `shared/reminder-utils.ts` — shouldFire, snooze, display helpers
- `ui/` — ReminderCard, ReminderForm, ReminderList, NotificationSettings, RunHistory, SchedulerBar updates