### PR TITLE
Add transient session runner for cron jobs in Sero mode

### DIFF
--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -21,7 +21,8 @@ import { Type } from '@sinclair/typebox';
 import type { CronRunResult, Reminder } from '../shared/types';
 import { MAX_RUN_RESULTS } from '../shared/types';
 import { resolveStatePath, withStateLock, readState, writeState } from './state-io';
-import { CronScheduler } from './scheduler';
+import { CronScheduler, type JobRunner } from './scheduler';
+import { runTransientJob } from './transient-session';
 import { StateWatcher } from './state-watcher';
 import { initLogger, setLogPath, info, warn, error as logError } from './logger';
 import { initNotifier, notifyReminder, notifyJobComplete } from './notifier';
@@ -80,19 +81,36 @@ async function persistReminderUpdate(updated: Reminder): Promise<void> {
   });
 }
 
+/**
+ * Resolve the job runner for this environment.
+ * In Sero mode (SERO_HOME set), use transient in-memory sessions so
+ * jobs run independently of user sessions and clean up after themselves.
+ * In Pi CLI mode, fall back to the subprocess runner.
+ */
+function resolveJobRunner(): JobRunner | undefined {
+  if (process.env.SERO_HOME) {
+    info('scheduler:using-transient-sessions');
+    return runTransientJob;
+  }
+  return undefined; // uses default subprocess runner
+}
+
 function createScheduler(): CronScheduler {
-  return new CronScheduler({
-    onJobComplete: async (result) => {
-      await appendRunResult(result).catch(() => {});
-      const state = statePath ? await readState(statePath) : null;
-      notifyJobComplete(result.jobName, result.ok, result.durationMs, state?.notificationSettings ?? undefined);
+  return new CronScheduler(
+    {
+      onJobComplete: async (result) => {
+        await appendRunResult(result).catch(() => {});
+        const state = statePath ? await readState(statePath) : null;
+        notifyJobComplete(result.jobName, result.ok, result.durationMs, state?.notificationSettings ?? undefined);
+      },
+      onReminderFire: async (reminder) => {
+        const state = statePath ? await readState(statePath) : null;
+        notifyReminder(reminder, state?.notificationSettings ?? undefined);
+      },
+      onReminderUpdate: (updated) => { persistReminderUpdate(updated).catch(() => {}); },
     },
-    onReminderFire: async (reminder) => {
-      const state = statePath ? await readState(statePath) : null;
-      notifyReminder(reminder, state?.notificationSettings ?? undefined);
-    },
-    onReminderUpdate: (updated) => { persistReminderUpdate(updated).catch(() => {}); },
-  });
+    resolveJobRunner(),
+  );
 }
 
 function startStateWatcher(): void {

--- a/packages/pi-cron-extension/extension/scheduler.ts
+++ b/packages/pi-cron-extension/extension/scheduler.ts
@@ -11,16 +11,28 @@ import { matchesCron } from '../shared/cron';
 import { shouldFire, statusAfterFire } from '../shared/reminder-utils';
 import { info, warn, error as logError } from './logger';
 
-// ── Subprocess runner ───────────────────────────────────────────
+// ── Job runner types ────────────────────────────────────────────
 
-/** Maximum buffer size per stream (1 MB). Prevents OOM on chatty jobs. */
-const MAX_BUFFER = 1_048_576;
-
-interface RunResult {
+export interface RunResult {
   stdout: string;
   stderr: string;
   exitCode: number;
 }
+
+/**
+ * A function that executes a prompt and returns the result.
+ * The scheduler uses this to run jobs — callers can inject a transient
+ * session runner (Sero) or fall back to the subprocess runner (Pi CLI).
+ */
+export type JobRunner = (
+  prompt: string,
+  opts: SubprocessOptions,
+) => Promise<RunResult>;
+
+// ── Subprocess runner (default / Pi CLI fallback) ───────────────
+
+/** Maximum buffer size per stream (1 MB). Prevents OOM on chatty jobs. */
+const MAX_BUFFER = 1_048_576;
 
 export interface SubprocessOptions {
   model?: string;
@@ -122,10 +134,12 @@ export class CronScheduler {
   private jobs: CronJob[] = [];
   private reminders: Reminder[] = [];
   private callbacks: SchedulerCallbacks;
+  private jobRunner: JobRunner;
   private cwd: string | undefined;
 
-  constructor(callbacks?: SchedulerCallbacks) {
+  constructor(callbacks?: SchedulerCallbacks, jobRunner?: JobRunner) {
     this.callbacks = callbacks ?? {};
+    this.jobRunner = jobRunner ?? runPiSubprocess;
   }
 
   // ── Lifecycle ───────────────────────────────────────────
@@ -284,7 +298,7 @@ export class CronScheduler {
           job.prompt
         : job.prompt;
 
-      const result = await runPiSubprocess(prompt, {
+      const result = await this.jobRunner(prompt, {
         model: job.model,
         cwd: this.cwd,
       });

--- a/packages/pi-cron-extension/extension/transient-session.ts
+++ b/packages/pi-cron-extension/extension/transient-session.ts
@@ -1,0 +1,190 @@
+/**
+ * Transient session runner for cron jobs.
+ *
+ * Creates a fresh in-memory AgentSession for each job, runs the prompt,
+ * collects the output, and disposes the session. No persistent session
+ * files are created — this avoids orphaned sessions from repeated cron
+ * runs and removes the dependency on an active user session.
+ *
+ * Uses the same Pi SDK infrastructure (auth, models, coding tools) as
+ * the main Sero app, resolved from SERO_HOME/agent/.
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+import {
+  createAgentSession,
+  SessionManager,
+  createCodingTools,
+  AuthStorage,
+  ModelRegistry,
+  SettingsManager,
+} from '@mariozechner/pi-coding-agent';
+import { getModel, type Model, type Api } from '@mariozechner/pi-ai';
+import type { RunResult } from './scheduler';
+import { info, warn, error as logError } from './logger';
+
+// ── Cached infrastructure (singleton per process) ──────────────
+
+interface CronInfra {
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+  settingsManager: ReturnType<typeof SettingsManager.create>;
+  defaultModel: Model<Api>;
+  agentDir: string;
+}
+
+let _infra: CronInfra | null = null;
+
+function getAgentDir(): string {
+  const seroHome = process.env.SERO_HOME || path.join(os.homedir(), '.sero-ui');
+  return path.join(seroHome, 'agent');
+}
+
+async function ensureCronInfra(): Promise<CronInfra> {
+  if (_infra) return _infra;
+
+  const agentDir = getAgentDir();
+  const authStorage = AuthStorage.create(path.join(agentDir, 'auth.json'));
+  const modelRegistry = new ModelRegistry(authStorage);
+  const settingsManager = SettingsManager.create(agentDir, agentDir);
+
+  // Use a capable but cost-effective default for background jobs
+  const defaultModel = getModel('anthropic', 'claude-sonnet-4-5');
+  if (!defaultModel) {
+    throw new Error('Default cron model (claude-sonnet-4-5) not found in registry');
+  }
+
+  _infra = { authStorage, modelRegistry, settingsManager, defaultModel, agentDir };
+  info('transient-session:infra-ready', { agentDir });
+  return _infra;
+}
+
+// ── Model resolution ───────────────────────────────────────────
+
+function resolveModel(
+  pattern: string,
+  registry: ModelRegistry,
+  fallback: Model<Api>,
+): Model<Api> {
+  const available = registry.getAvailable();
+
+  // Exact match on model ID
+  const exact = available.find((m) => m.id === pattern);
+  if (exact) return exact;
+
+  // provider/modelId format (e.g. "anthropic/claude-sonnet-4-5")
+  if (pattern.includes('/')) {
+    const [provider, modelId] = pattern.split('/', 2);
+    const match = available.find((m) => m.provider === provider && m.id === modelId);
+    if (match) return match;
+  }
+
+  // Partial match (e.g. "sonnet" matches "claude-sonnet-4-5")
+  const partial = available.find((m) => m.id.includes(pattern));
+  if (partial) return partial;
+
+  warn('transient-session:model-fallback', { pattern, reason: 'no match found' });
+  return fallback;
+}
+
+// ── Transient job runner ───────────────────────────────────────
+
+export interface TransientJobOptions {
+  model?: string;
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+/**
+ * Run a prompt in a transient in-memory agent session.
+ *
+ * Creates a fresh session with coding tools (file read/write, bash, etc.),
+ * executes the prompt, collects the text output, then disposes everything.
+ * The session exists only for the duration of this call.
+ */
+export async function runTransientJob(
+  prompt: string,
+  opts: TransientJobOptions = {},
+): Promise<RunResult> {
+  const { cwd, timeoutMs = 600_000 } = opts;
+  const workDir = cwd || process.cwd();
+
+  let infra: CronInfra;
+  try {
+    infra = await ensureCronInfra();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logError('transient-session:infra-failed', { error: msg });
+    return { stdout: '', stderr: msg, exitCode: 1 };
+  }
+
+  // Resolve model
+  const model = opts.model
+    ? resolveModel(opts.model, infra.modelRegistry, infra.defaultModel)
+    : infra.defaultModel;
+
+  info('transient-session:create', {
+    model: model.id,
+    cwd: workDir,
+    promptLen: prompt.length,
+    timeoutMs,
+  });
+
+  const tools = createCodingTools(workDir);
+  let session: Awaited<ReturnType<typeof createAgentSession>>['session'] | null = null;
+
+  try {
+    const result = await createAgentSession({
+      cwd: workDir,
+      agentDir: infra.agentDir,
+      model,
+      thinkingLevel: 'high',
+      authStorage: infra.authStorage,
+      modelRegistry: infra.modelRegistry,
+      tools,
+      sessionManager: SessionManager.inMemory(workDir),
+      settingsManager: infra.settingsManager,
+    });
+    session = result.session;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logError('transient-session:create-failed', { error: msg });
+    return { stdout: '', stderr: msg, exitCode: 1 };
+  }
+
+  // Collect text output
+  let text = '';
+  const unsub = session.subscribe((event) => {
+    if (event.type === 'message_update') {
+      const ame = event.assistantMessageEvent;
+      if (ame.type === 'text_delta') text += ame.delta;
+    }
+  });
+
+  try {
+    await Promise.race([
+      session.prompt(prompt),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Cron job timed out')), timeoutMs),
+      ),
+    ]);
+
+    info('transient-session:complete', {
+      model: model.id,
+      outputLen: text.length,
+    });
+
+    return { stdout: text, stderr: '', exitCode: 0 };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logError('transient-session:error', { error: msg, outputLen: text.length });
+    return { stdout: text, stderr: msg, exitCode: 1 };
+  } finally {
+    unsub();
+    // Abort any in-flight work then dispose the session entirely
+    await session.abort().catch(() => {});
+    session.dispose();
+    info('transient-session:disposed', { model: model.id });
+  }
+}


### PR DESCRIPTION
## Summary
Adds support for running cron jobs in transient in-memory agent sessions when running under Sero (SERO_HOME set), eliminating the need for persistent session files and removing dependency on active user sessions. Falls back to the existing subprocess runner in Pi CLI mode.

## Key Changes
- **New `transient-session.ts` module**: Implements `runTransientJob()` which creates fresh in-memory `AgentSession` instances for each job execution, collects output, and disposes the session immediately after completion. Includes:
  - Singleton infrastructure caching (auth, models, settings) per process
  - Flexible model resolution supporting exact match, provider/modelId format, and partial matching
  - Timeout support and proper cleanup with session abort/dispose
  
- **Updated `scheduler.ts`**: 
  - Exports `RunResult` and new `JobRunner` type for pluggable job execution
  - `CronScheduler` now accepts optional `jobRunner` parameter in constructor
  - Defaults to `runPiSubprocess` (existing behavior) when no runner provided
  - Uses injected runner for all job execution via `this.jobRunner()`

- **Updated `index.ts`**:
  - Adds `resolveJobRunner()` function that returns `runTransientJob` when `SERO_HOME` is set, otherwise `undefined` (uses default)
  - Passes resolved runner to `CronScheduler` constructor
  - Maintains backward compatibility with existing Pi CLI deployments

## Implementation Details
- Transient sessions use the same Pi SDK infrastructure (auth, models, coding tools) as the main Sero app, resolved from `SERO_HOME/agent/`
- Default model is Claude Sonnet 4.5 (cost-effective for background jobs)
- Sessions are created with `thinkingLevel: 'high'` and in-memory session manager
- Text output is collected via session subscription to `message_update` events with `text_delta` type
- Proper error handling and logging at each stage (infra setup, session creation, execution, disposal)

https://claude.ai/code/session_01Ny1aqAw1i8UnRkjqU11ua8