### PR TITLE
Add right-click context menu to editor tabs with Close, Close Others,…

### DIFF
--- a/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
+++ b/apps/desktop/src/components/apps/coding/CodingWorkspace.tsx
@@ -201,6 +201,16 @@ export function CodingWorkspace() {
     });
   }, []);
 
+  const handleCloseOtherTabs = useCallback((keepPath: string) => {
+    setEditorTabs([keepPath]);
+    setActiveTab(keepPath);
+  }, []);
+
+  const handleCloseAllTabs = useCallback(() => {
+    setEditorTabs([]);
+    setActiveTab(null);
+  }, []);
+
   const handleReorderTabs = useCallback((newOrder: string[]) => {
     setEditorTabs(newOrder);
   }, []);
@@ -420,6 +430,7 @@ export function CodingWorkspace() {
                   workspaceId={workspaceId}
                   tabs={editorTabs} activeTab={activeTab}
                   onOpenTab={handleOpenTab} onCloseTab={handleCloseTab}
+                  onCloseOtherTabs={handleCloseOtherTabs} onCloseAllTabs={handleCloseAllTabs}
                   onReorderTabs={handleReorderTabs} onTabsChange={handleTabsChange}
                 />
               )}

--- a/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
@@ -26,6 +26,8 @@ interface Props {
   activeTab: string | null;
   onOpenTab: (path: string) => void;
   onCloseTab: (path: string) => void;
+  onCloseOtherTabs: (path: string) => void;
+  onCloseAllTabs: () => void;
   onReorderTabs: (paths: string[]) => void;
   onTabsChange: (tabs: string[], activeTab: string | null) => void;
 }
@@ -62,7 +64,7 @@ function getLanguage(filePath: string): string {
 }
 
 export function EditorPanel({
-  workspaceId, tabs, activeTab, onOpenTab, onCloseTab, onReorderTabs, onTabsChange,
+  workspaceId, tabs, activeTab, onOpenTab, onCloseTab, onCloseOtherTabs, onCloseAllTabs, onReorderTabs, onTabsChange,
 }: Props) {
   type MarkdownViewMode = 'code' | 'preview';
 
@@ -216,6 +218,36 @@ export function EditorPanel({
       setContent('');
     }
   }, [tabs, activeTab, onCloseTab]);
+
+  // ── Close other / all tabs ──
+  const cleanupTabRefs = useCallback((path: string) => {
+    contentMapRef.current.delete(path);
+    savedContentRef.current.delete(path);
+    viewStateMapRef.current.delete(path);
+    setDirtyPaths((prev) => { if (!prev.has(path)) return prev; const next = new Set(prev); next.delete(path); return next; });
+    if (monacoRef.current) {
+      const uri = monacoRef.current.Uri.parse(path);
+      monacoRef.current.editor.getModel(uri)?.dispose();
+    }
+  }, []);
+
+  const handleCloseOtherTabs = useCallback((keepPath: string) => {
+    if (activeTab && editorRef.current) {
+      viewStateMapRef.current.set(activeTab, editorRef.current.saveViewState());
+    }
+    for (const p of tabs) {
+      if (p !== keepPath) cleanupTabRefs(p);
+    }
+    onCloseOtherTabs(keepPath);
+    setContent(contentMapRef.current.get(keepPath) ?? '');
+    setLanguage(getLanguage(keepPath));
+  }, [tabs, activeTab, onCloseOtherTabs, cleanupTabRefs]);
+
+  const handleCloseAllTabs = useCallback(() => {
+    for (const p of tabs) cleanupTabRefs(p);
+    onCloseAllTabs();
+    setContent('');
+  }, [tabs, onCloseAllTabs, cleanupTabRefs]);
 
   // ── Keyboard shortcuts ──
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -383,6 +415,7 @@ export function EditorPanel({
       <EditorTabBar
         tabs={tabDescriptors} activeTab={activeTab}
         onSelectTab={handleOpenTab} onCloseTab={handleCloseTab}
+        onCloseOtherTabs={handleCloseOtherTabs} onCloseAllTabs={handleCloseAllTabs}
         onReorderTabs={onReorderTabs}
         rightSlot={isMarkdownTab ? (
           <div className="flex h-full items-center overflow-hidden">

--- a/apps/desktop/src/components/apps/coding/editor/EditorTabBar.tsx
+++ b/apps/desktop/src/components/apps/coding/editor/EditorTabBar.tsx
@@ -12,6 +12,10 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@sero/ui/lib/utils';
+import {
+  ContextMenu, ContextMenuTrigger, ContextMenuContent,
+  ContextMenuItem, ContextMenuSeparator,
+} from '@sero/ui/components/ui/context-menu';
 import { FileIcon } from '../file-tree/file-icons';
 
 export interface EditorTab {
@@ -24,15 +28,18 @@ interface Props {
   activeTab: string | null;
   onSelectTab: (path: string) => void;
   onCloseTab: (path: string) => void;
+  onCloseOtherTabs: (path: string) => void;
+  onCloseAllTabs: () => void;
   onReorderTabs: (paths: string[]) => void;
   rightSlot?: React.ReactNode;
 }
 
 /* ── Single sortable tab ──────────────────────────────────── */
 
-function SortableEditorTab({ tab, isActive, onSelect, onClose, onMiddleClick }: {
+function SortableEditorTab({ tab, isActive, onSelect, onClose, onCloseOthers, onCloseAll, onMiddleClick }: {
   tab: EditorTab; isActive: boolean;
   onSelect: () => void; onClose: () => void;
+  onCloseOthers: () => void; onCloseAll: () => void;
   onMiddleClick: (e: React.MouseEvent) => void;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.path });
@@ -45,41 +52,50 @@ function SortableEditorTab({ tab, isActive, onSelect, onClose, onMiddleClick }: 
   const fileName = tab.path.split('/').pop() ?? tab.path;
 
   return (
-    <div
-      ref={setNodeRef} style={style}
-      className={cn(
-        'flex items-center gap-1 px-2.5 h-full cursor-pointer shrink-0 select-none',
-        'border-r border-[var(--border-subtle)] text-xs whitespace-nowrap transition-colors',
-        'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
-        isActive && 'bg-[var(--bg-elevated)] text-[var(--text-primary)] relative',
-      )}
-      data-tab-path={tab.path}
-      {...attributes} {...listeners}
-      onClick={onSelect} onMouseDown={onMiddleClick} title={tab.path}
-    >
-      <FileIcon fileName={fileName} extension={fileName.split('.').pop()?.toLowerCase()} className="size-3.5 shrink-0 text-[var(--text-muted)]" />
-      <span className={cn('font-normal', isActive && 'font-medium')}>{fileName}</span>
-      {tab.dirty && <span className="text-[9px] text-[var(--accent)] ml-0.5 shrink-0">●</span>}
-      <button
-        className={cn(
-          'flex items-center justify-center size-4 border-none bg-transparent',
-          'text-[var(--text-muted)] text-sm leading-none cursor-pointer rounded-sm',
-          'ml-0.5 opacity-0 transition-opacity shrink-0',
-          'group-hover:opacity-60 hover:!opacity-100 hover:bg-[var(--bg-muted)] hover:text-[var(--text-primary)]',
-          (isActive) && 'opacity-60',
-        )}
-        onClick={(e) => { e.stopPropagation(); onClose(); }}
-        onMouseDown={(e) => e.stopPropagation()}
-        title="Close"
-      >×</button>
-      {isActive && <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--accent)]" />}
-    </div>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          ref={setNodeRef} style={style}
+          className={cn(
+            'flex items-center gap-1 px-2.5 h-full cursor-pointer shrink-0 select-none',
+            'border-r border-[var(--border-subtle)] text-xs whitespace-nowrap transition-colors',
+            'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+            isActive && 'bg-[var(--bg-elevated)] text-[var(--text-primary)] relative',
+          )}
+          data-tab-path={tab.path}
+          {...attributes} {...listeners}
+          onClick={onSelect} onMouseDown={onMiddleClick} title={tab.path}
+        >
+          <FileIcon fileName={fileName} extension={fileName.split('.').pop()?.toLowerCase()} className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+          <span className={cn('font-normal', isActive && 'font-medium')}>{fileName}</span>
+          {tab.dirty && <span className="text-[9px] text-[var(--accent)] ml-0.5 shrink-0">●</span>}
+          <button
+            className={cn(
+              'flex items-center justify-center size-4 border-none bg-transparent',
+              'text-[var(--text-muted)] text-sm leading-none cursor-pointer rounded-sm',
+              'ml-0.5 opacity-0 transition-opacity shrink-0',
+              'group-hover:opacity-60 hover:!opacity-100 hover:bg-[var(--bg-muted)] hover:text-[var(--text-primary)]',
+              (isActive) && 'opacity-60',
+            )}
+            onClick={(e) => { e.stopPropagation(); onClose(); }}
+            onMouseDown={(e) => e.stopPropagation()}
+            title="Close"
+          >×</button>
+          {isActive && <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--accent)]" />}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-44">
+        <ContextMenuItem onSelect={onClose}>Close</ContextMenuItem>
+        <ContextMenuItem onSelect={onCloseOthers}>Close Others</ContextMenuItem>
+        <ContextMenuItem onSelect={onCloseAll}>Close All</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
 /* ── Tab bar ──────────────────────────────────────────────── */
 
-export function EditorTabBar({ tabs, activeTab, onSelectTab, onCloseTab, onReorderTabs, rightSlot }: Props) {
+export function EditorTabBar({ tabs, activeTab, onSelectTab, onCloseTab, onCloseOtherTabs, onCloseAllTabs, onReorderTabs, rightSlot }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [overflowLeft, setOverflowLeft] = useState(false);
   const [overflowRight, setOverflowRight] = useState(false);
@@ -139,6 +155,8 @@ export function EditorTabBar({ tabs, activeTab, onSelectTab, onCloseTab, onReord
                   key={tab.path} tab={tab} isActive={tab.path === activeTab}
                   onSelect={() => onSelectTab(tab.path)}
                   onClose={() => onCloseTab(tab.path)}
+                  onCloseOthers={() => onCloseOtherTabs(tab.path)}
+                  onCloseAll={onCloseAllTabs}
                   onMiddleClick={(e) => handleMiddleClick(e, tab.path)}
                 />
               ))}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -632,6 +632,61 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/pi-kanban-extension:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.55.3'
+        version: 0.55.3
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
+    devDependencies:
+      '@module-federation/vite':
+        specifier: ^1.11.0
+        version: 1.11.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@sero/app-runtime':
+        specifier: workspace:*
+        version: link:../app-runtime
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.11
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      motion:
+        specifier: ^12.34.0
+        version: 12.34.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
   packages/pi-notes-extension:
     dependencies:
       '@mariozechner/pi-ai':


### PR DESCRIPTION
… Close All

Wraps each editor tab in a Radix ContextMenu providing three actions:
- Close: closes the right-clicked tab (same as the × button)
- Close Others: closes all tabs except the right-clicked one
- Close All: closes every open tab

https://claude.ai/code/session_01DmPSaED9SEjJU6omViTqhY