### PR TITLE
feat: 4-agent collaboration framework with two-phase fan-out

### DIFF
--- a/apps/desktop/electron/collaboration/agents.ts
+++ b/apps/desktop/electron/collaboration/agents.ts
@@ -1,0 +1,166 @@
+/**
+ * Built-in agent definitions for the 4-agent collaboration framework.
+ *
+ * Each agent has a specialized role, system prompt, and tool restrictions.
+ * These are used as inline ad-hoc agents (no .md files on disk required).
+ */
+
+import type { AgentConfig } from '../subagent/types';
+
+/** Role identifiers for the four collaboration agents. */
+export type CollaborationRole = 'coordinator' | 'researcher' | 'analyst' | 'visionary';
+
+/** Map of role → tool names the agent is allowed to use. */
+export const ROLE_TOOL_RESTRICTIONS: Record<CollaborationRole, string[] | undefined> = {
+  // Coordinator: synthesis only — no direct tool use (reads specialist outputs)
+  coordinator: undefined,
+  // Researcher: search, web, file reading
+  researcher: ['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch'],
+  // Analyst: code execution, file read/write, shell
+  analyst: ['Read', 'Glob', 'Grep', 'Bash', 'Edit', 'Write'],
+  // Visionary: read-only exploration for creative divergence
+  visionary: ['Read', 'Glob', 'Grep', 'WebSearch'],
+};
+
+/** Create an inline AgentConfig for a collaboration role. */
+function makeAgent(
+  role: CollaborationRole,
+  name: string,
+  description: string,
+  systemPrompt: string,
+): AgentConfig {
+  return {
+    name,
+    description,
+    systemPrompt,
+    tools: ROLE_TOOL_RESTRICTIONS[role],
+    source: 'global',
+    filePath: '',
+  };
+}
+
+// ── Agent Definitions ──────────────────────────────────────────
+
+export const RESEARCHER_AGENT = makeAgent(
+  'researcher',
+  'collab-researcher',
+  'Fact-checking and evidence gathering specialist',
+  `You are The Researcher — a fact-checking and evidence-gathering specialist within a 4-agent collaboration framework.
+
+## Your Role
+You verify claims, gather real-time information, and ground answers in current evidence to minimize hallucinations. You are methodical, thorough, and skeptical.
+
+## Your Responsibilities
+- Gather relevant information from available sources (files, web, codebase)
+- Verify factual claims and identify potential inaccuracies
+- Cite sources and evidence for every assertion you make
+- Flag areas of uncertainty or where evidence is insufficient
+- Provide a structured summary of your findings
+
+## Output Format
+Structure your response as:
+1. **Key Findings** — verified facts relevant to the query
+2. **Evidence** — sources, references, and supporting data
+3. **Uncertainties** — areas where evidence is weak or conflicting
+4. **Corrections** — any common misconceptions about the topic
+
+Be concise but thorough. Focus on accuracy over completeness.`,
+);
+
+export const ANALYST_AGENT = makeAgent(
+  'analyst',
+  'collab-analyst',
+  'Logic, math, and code reasoning specialist',
+  `You are The Analyst — a rigorous logical reasoning and code specialist within a 4-agent collaboration framework.
+
+## Your Role
+You perform step-by-step reasoning, mathematical proofs, coding tasks, and stress-test logical consistency. You are precise, systematic, and uncompromising on correctness.
+
+## Your Responsibilities
+- Break down complex problems into clear logical steps
+- Write, review, and debug code when the task involves programming
+- Perform mathematical calculations and verify quantitative claims
+- Identify logical fallacies, edge cases, and potential failure modes
+- Stress-test proposed solutions against corner cases
+
+## Output Format
+Structure your response as:
+1. **Analysis** — step-by-step logical breakdown of the problem
+2. **Solution** — your proposed answer with reasoning
+3. **Code** (if applicable) — well-structured, tested code
+4. **Edge Cases** — potential issues, limitations, and failure modes
+
+Show your work. Every conclusion must follow from explicit reasoning steps.`,
+);
+
+export const VISIONARY_AGENT = makeAgent(
+  'visionary',
+  'collab-visionary',
+  'Creative and divergent thinking specialist',
+  `You are The Visionary — a creative and divergent thinking specialist within a 4-agent collaboration framework.
+
+## Your Role
+You provide novel ideas, alternative perspectives, and creative synthesis. You challenge conventional thinking and explore unconventional approaches.
+
+## Your Responsibilities
+- Propose creative, non-obvious approaches to the problem
+- Consider the problem from multiple stakeholder perspectives
+- Identify opportunities that a purely analytical approach might miss
+- Challenge assumptions in the query and suggest reframing
+- Synthesize ideas from different domains for cross-pollination
+
+## Output Format
+Structure your response as:
+1. **Fresh Perspectives** — alternative ways to frame the problem
+2. **Creative Approaches** — novel or unconventional solutions
+3. **Cross-Domain Insights** — relevant ideas from other fields
+4. **Provocations** — assumptions worth challenging, risks worth taking
+
+Be bold and imaginative. Your value is in expanding the solution space.`,
+);
+
+/** Build the Coordinator's synthesis prompt with the specialists' outputs. */
+export function buildCoordinatorSynthesisPrompt(
+  originalQuery: string,
+  researcherOutput: string,
+  analystOutput: string,
+  visionaryOutput: string,
+): string {
+  return `You are The Coordinator — the lead synthesizer in a 4-agent collaboration framework.
+
+Three specialist agents have independently analyzed the following user query. Your job is to synthesize their outputs into a single, coherent, high-quality response.
+
+## Original User Query
+${originalQuery}
+
+## Specialist Outputs
+
+### The Researcher (Fact-Checking)
+${researcherOutput}
+
+### The Analyst (Logic / Math / Code)
+${analystOutput}
+
+### The Visionary (Creative / Divergent)
+${visionaryOutput}
+
+## Your Task
+1. **Cross-check** — identify any conflicts or disagreements between the specialists
+2. **Resolve** — where specialists disagree, determine the most accurate/useful position
+3. **Synthesize** — merge the best elements from all three into a unified response
+4. **Polish** — ensure the final answer is clear, well-structured, and directly addresses the user's query
+
+## Rules
+- Produce ONE cohesive response as if you are a single expert answering the user
+- Do NOT mention the collaboration framework, specialists, or internal process to the user
+- Prefer the Researcher's facts, the Analyst's logic, and the Visionary's framing
+- If specialists provide code, use the Analyst's version as the primary and incorporate any Visionary improvements
+- The response should feel natural and authoritative, not committee-written`;
+}
+
+/** The three specialist agents (run in parallel). */
+export const SPECIALIST_AGENTS = [
+  { role: 'researcher' as const, agent: RESEARCHER_AGENT },
+  { role: 'analyst' as const, agent: ANALYST_AGENT },
+  { role: 'visionary' as const, agent: VISIONARY_AGENT },
+];

--- a/apps/desktop/electron/collaboration/agents.ts
+++ b/apps/desktop/electron/collaboration/agents.ts
@@ -6,8 +6,8 @@
  * agent names and provides the Coordinator's synthesis prompt builder.
  */
 
-/** Role identifiers for the four collaboration agents. */
-export type CollaborationRole = 'coordinator' | 'researcher' | 'analyst' | 'visionary';
+import type { CollaborationRole } from '../../src/types/collaboration';
+export type { CollaborationRole } from '../../src/types/collaboration';
 
 /**
  * Map of collaboration role → discovered agent name (from .md frontmatter).

--- a/apps/desktop/electron/collaboration/agents.ts
+++ b/apps/desktop/electron/collaboration/agents.ts
@@ -25,8 +25,8 @@ export const ROLE_AGENT_NAMES: Record<CollaborationRole, string> = {
   visionary: 'visionary',
 };
 
-/** The three specialist roles (run in parallel before coordination). */
-export const SPECIALIST_ROLES: CollaborationRole[] = ['researcher', 'analyst', 'visionary'];
+/** Phase 2 specialists that run in parallel after the researcher. */
+export const PARALLEL_SPECIALIST_ROLES: CollaborationRole[] = ['analyst', 'visionary'];
 
 /** Human-readable labels for UI display. */
 export const ROLE_LABELS: Record<CollaborationRole, string> = {

--- a/apps/desktop/electron/collaboration/agents.ts
+++ b/apps/desktop/electron/collaboration/agents.ts
@@ -1,123 +1,40 @@
 /**
- * Built-in agent definitions for the 4-agent collaboration framework.
+ * Agent role definitions for the 4-agent collaboration framework.
  *
- * Each agent has a specialized role, system prompt, and tool restrictions.
- * These are used as inline ad-hoc agents (no .md files on disk required).
+ * Agents are defined as proper .md template files in packages/templates/agents/
+ * and discovered by the SubagentManager at runtime. This module maps roles to
+ * agent names and provides the Coordinator's synthesis prompt builder.
  */
-
-import type { AgentConfig } from '../subagent/types';
 
 /** Role identifiers for the four collaboration agents. */
 export type CollaborationRole = 'coordinator' | 'researcher' | 'analyst' | 'visionary';
 
-/** Map of role → tool names the agent is allowed to use. */
-export const ROLE_TOOL_RESTRICTIONS: Record<CollaborationRole, string[] | undefined> = {
-  // Coordinator: synthesis only — no direct tool use (reads specialist outputs)
-  coordinator: undefined,
-  // Researcher: search, web, file reading
-  researcher: ['Read', 'Glob', 'Grep', 'WebFetch', 'WebSearch'],
-  // Analyst: code execution, file read/write, shell
-  analyst: ['Read', 'Glob', 'Grep', 'Bash', 'Edit', 'Write'],
-  // Visionary: read-only exploration for creative divergence
-  visionary: ['Read', 'Glob', 'Grep', 'WebSearch'],
+/**
+ * Map of collaboration role → discovered agent name (from .md frontmatter).
+ *
+ * These names must match the "name" field in the corresponding template:
+ * - packages/templates/agents/researcher.md
+ * - packages/templates/agents/collab-analyst.md  (avoids clash with kanban analyst)
+ * - packages/templates/agents/visionary.md
+ * - packages/templates/agents/coordinator.md
+ */
+export const ROLE_AGENT_NAMES: Record<CollaborationRole, string> = {
+  coordinator: 'coordinator',
+  researcher: 'researcher',
+  analyst: 'collab-analyst',
+  visionary: 'visionary',
 };
 
-/** Create an inline AgentConfig for a collaboration role. */
-function makeAgent(
-  role: CollaborationRole,
-  name: string,
-  description: string,
-  systemPrompt: string,
-): AgentConfig {
-  return {
-    name,
-    description,
-    systemPrompt,
-    tools: ROLE_TOOL_RESTRICTIONS[role],
-    source: 'global',
-    filePath: '',
-  };
-}
+/** The three specialist roles (run in parallel before coordination). */
+export const SPECIALIST_ROLES: CollaborationRole[] = ['researcher', 'analyst', 'visionary'];
 
-// ── Agent Definitions ──────────────────────────────────────────
-
-export const RESEARCHER_AGENT = makeAgent(
-  'researcher',
-  'collab-researcher',
-  'Fact-checking and evidence gathering specialist',
-  `You are The Researcher — a fact-checking and evidence-gathering specialist within a 4-agent collaboration framework.
-
-## Your Role
-You verify claims, gather real-time information, and ground answers in current evidence to minimize hallucinations. You are methodical, thorough, and skeptical.
-
-## Your Responsibilities
-- Gather relevant information from available sources (files, web, codebase)
-- Verify factual claims and identify potential inaccuracies
-- Cite sources and evidence for every assertion you make
-- Flag areas of uncertainty or where evidence is insufficient
-- Provide a structured summary of your findings
-
-## Output Format
-Structure your response as:
-1. **Key Findings** — verified facts relevant to the query
-2. **Evidence** — sources, references, and supporting data
-3. **Uncertainties** — areas where evidence is weak or conflicting
-4. **Corrections** — any common misconceptions about the topic
-
-Be concise but thorough. Focus on accuracy over completeness.`,
-);
-
-export const ANALYST_AGENT = makeAgent(
-  'analyst',
-  'collab-analyst',
-  'Logic, math, and code reasoning specialist',
-  `You are The Analyst — a rigorous logical reasoning and code specialist within a 4-agent collaboration framework.
-
-## Your Role
-You perform step-by-step reasoning, mathematical proofs, coding tasks, and stress-test logical consistency. You are precise, systematic, and uncompromising on correctness.
-
-## Your Responsibilities
-- Break down complex problems into clear logical steps
-- Write, review, and debug code when the task involves programming
-- Perform mathematical calculations and verify quantitative claims
-- Identify logical fallacies, edge cases, and potential failure modes
-- Stress-test proposed solutions against corner cases
-
-## Output Format
-Structure your response as:
-1. **Analysis** — step-by-step logical breakdown of the problem
-2. **Solution** — your proposed answer with reasoning
-3. **Code** (if applicable) — well-structured, tested code
-4. **Edge Cases** — potential issues, limitations, and failure modes
-
-Show your work. Every conclusion must follow from explicit reasoning steps.`,
-);
-
-export const VISIONARY_AGENT = makeAgent(
-  'visionary',
-  'collab-visionary',
-  'Creative and divergent thinking specialist',
-  `You are The Visionary — a creative and divergent thinking specialist within a 4-agent collaboration framework.
-
-## Your Role
-You provide novel ideas, alternative perspectives, and creative synthesis. You challenge conventional thinking and explore unconventional approaches.
-
-## Your Responsibilities
-- Propose creative, non-obvious approaches to the problem
-- Consider the problem from multiple stakeholder perspectives
-- Identify opportunities that a purely analytical approach might miss
-- Challenge assumptions in the query and suggest reframing
-- Synthesize ideas from different domains for cross-pollination
-
-## Output Format
-Structure your response as:
-1. **Fresh Perspectives** — alternative ways to frame the problem
-2. **Creative Approaches** — novel or unconventional solutions
-3. **Cross-Domain Insights** — relevant ideas from other fields
-4. **Provocations** — assumptions worth challenging, risks worth taking
-
-Be bold and imaginative. Your value is in expanding the solution space.`,
-);
+/** Human-readable labels for UI display. */
+export const ROLE_LABELS: Record<CollaborationRole, string> = {
+  coordinator: 'Coordinator',
+  researcher: 'Researcher',
+  analyst: 'Analyst',
+  visionary: 'Visionary',
+};
 
 /** Build the Coordinator's synthesis prompt with the specialists' outputs. */
 export function buildCoordinatorSynthesisPrompt(
@@ -126,9 +43,7 @@ export function buildCoordinatorSynthesisPrompt(
   analystOutput: string,
   visionaryOutput: string,
 ): string {
-  return `You are The Coordinator — the lead synthesizer in a 4-agent collaboration framework.
-
-Three specialist agents have independently analyzed the following user query. Your job is to synthesize their outputs into a single, coherent, high-quality response.
+  return `Three specialist agents have independently analyzed the following user query. Synthesize their outputs into a single, coherent, high-quality response.
 
 ## Original User Query
 ${originalQuery}
@@ -144,23 +59,5 @@ ${analystOutput}
 ### The Visionary (Creative / Divergent)
 ${visionaryOutput}
 
-## Your Task
-1. **Cross-check** — identify any conflicts or disagreements between the specialists
-2. **Resolve** — where specialists disagree, determine the most accurate/useful position
-3. **Synthesize** — merge the best elements from all three into a unified response
-4. **Polish** — ensure the final answer is clear, well-structured, and directly addresses the user's query
-
-## Rules
-- Produce ONE cohesive response as if you are a single expert answering the user
-- Do NOT mention the collaboration framework, specialists, or internal process to the user
-- Prefer the Researcher's facts, the Analyst's logic, and the Visionary's framing
-- If specialists provide code, use the Analyst's version as the primary and incorporate any Visionary improvements
-- The response should feel natural and authoritative, not committee-written`;
+Produce ONE cohesive response. Do NOT mention the specialists or internal process.`;
 }
-
-/** The three specialist agents (run in parallel). */
-export const SPECIALIST_AGENTS = [
-  { role: 'researcher' as const, agent: RESEARCHER_AGENT },
-  { role: 'analyst' as const, agent: ANALYST_AGENT },
-  { role: 'visionary' as const, agent: VISIONARY_AGENT },
-];

--- a/apps/desktop/electron/collaboration/index.ts
+++ b/apps/desktop/electron/collaboration/index.ts
@@ -1,0 +1,146 @@
+/**
+ * CollaborationEngine — orchestrates the 4-agent collaboration framework.
+ *
+ * Flow:
+ * 1. Three specialists (Researcher, Analyst, Visionary) run in parallel
+ * 2. Their outputs are collected
+ * 3. The Coordinator synthesizes them into one unified response
+ *
+ * Leverages the existing SubagentManager for execution.
+ */
+
+import { randomUUID } from 'crypto';
+import type { SubagentManager } from '../subagent';
+import {
+  SPECIALIST_AGENTS,
+  buildCoordinatorSynthesisPrompt,
+  type CollaborationRole,
+} from './agents';
+
+export interface CollaborationResult {
+  /** The final synthesized response from the Coordinator. */
+  finalResponse: string;
+  /** Individual specialist outputs for transparency. */
+  specialistOutputs: {
+    role: CollaborationRole;
+    agentName: string;
+    response: string;
+    error?: string;
+    durationMs: number;
+  }[];
+  /** Total duration including synthesis. */
+  totalDurationMs: number;
+  /** Whether any specialist failed. */
+  hasErrors: boolean;
+}
+
+export interface CollaborationCallbacks {
+  /** Called when each phase starts. */
+  onPhaseStart?: (phase: 'specialists' | 'synthesis') => void;
+  /** Called when a specialist starts. */
+  onSpecialistStart?: (role: CollaborationRole, agentName: string) => void;
+  /** Called when a specialist completes. */
+  onSpecialistEnd?: (role: CollaborationRole, agentName: string, response: string, error?: string) => void;
+  /** Called with live text deltas from the synthesis phase. */
+  onSynthesisDelta?: (delta: string) => void;
+  /** General status updates. */
+  onUpdate?: (text: string) => void;
+}
+
+/**
+ * Run the 4-agent collaboration framework for a user query.
+ *
+ * Phase 1: Run Researcher, Analyst, and Visionary in parallel
+ * Phase 2: Feed their outputs to the Coordinator for synthesis
+ */
+export async function runCollaboration(
+  query: string,
+  parentSessionId: string,
+  workspaceId: string,
+  manager: SubagentManager,
+  callbacks?: CollaborationCallbacks,
+): Promise<CollaborationResult> {
+  const startTime = Date.now();
+  const specialistOutputs: CollaborationResult['specialistOutputs'] = [];
+
+  // ── Phase 1: Run specialists in parallel ─────────────────────
+
+  callbacks?.onPhaseStart?.('specialists');
+  callbacks?.onUpdate?.('Starting 4-agent collaboration — running specialists in parallel...');
+
+  const specialistResults = await Promise.allSettled(
+    SPECIALIST_AGENTS.map(async ({ role, agent }) => {
+      const specStart = Date.now();
+      callbacks?.onSpecialistStart?.(role, agent.name);
+
+      const result = await manager.runSingleStructured({
+        task: query,
+        systemPrompt: agent.systemPrompt,
+        parentSessionId,
+        workspaceId,
+        onUpdate: callbacks?.onUpdate,
+      });
+
+      const durationMs = Date.now() - specStart;
+      const output = {
+        role,
+        agentName: agent.name,
+        response: result.response,
+        error: result.error,
+        durationMs,
+      };
+
+      callbacks?.onSpecialistEnd?.(role, agent.name, result.response, result.error);
+      return output;
+    }),
+  );
+
+  // Collect results
+  for (const result of specialistResults) {
+    if (result.status === 'fulfilled') {
+      specialistOutputs.push(result.value);
+    } else {
+      specialistOutputs.push({
+        role: 'researcher', // fallback — shouldn't happen
+        agentName: 'unknown',
+        response: '',
+        error: result.reason?.message ?? 'Unknown error',
+        durationMs: 0,
+      });
+    }
+  }
+
+  // Extract outputs by role
+  const researcherOutput = specialistOutputs.find((s) => s.role === 'researcher');
+  const analystOutput = specialistOutputs.find((s) => s.role === 'analyst');
+  const visionaryOutput = specialistOutputs.find((s) => s.role === 'visionary');
+
+  // ── Phase 2: Coordinator synthesis ───────────────────────────
+
+  callbacks?.onPhaseStart?.('synthesis');
+  callbacks?.onUpdate?.('Specialists complete — Coordinator synthesizing final response...');
+
+  const synthesisPrompt = buildCoordinatorSynthesisPrompt(
+    query,
+    researcherOutput?.response || '(Researcher failed to produce output)',
+    analystOutput?.response || '(Analyst failed to produce output)',
+    visionaryOutput?.response || '(Visionary failed to produce output)',
+  );
+
+  const synthesisResult = await manager.runSingleStructured({
+    task: synthesisPrompt,
+    parentSessionId,
+    workspaceId,
+    onUpdate: callbacks?.onUpdate,
+  });
+
+  const totalDurationMs = Date.now() - startTime;
+  const hasErrors = specialistOutputs.some((s) => !!s.error) || !!synthesisResult.error;
+
+  return {
+    finalResponse: synthesisResult.response || '(Collaboration failed to produce a synthesis)',
+    specialistOutputs,
+    totalDurationMs,
+    hasErrors,
+  };
+}

--- a/apps/desktop/electron/collaboration/index.ts
+++ b/apps/desktop/electron/collaboration/index.ts
@@ -19,25 +19,9 @@ import {
   PARALLEL_SPECIALIST_ROLES,
   ROLE_AGENT_NAMES,
   buildCoordinatorSynthesisPrompt,
-  type CollaborationRole,
 } from './agents';
-
-export interface CollaborationResult {
-  /** The final synthesized response from the Coordinator. */
-  finalResponse: string;
-  /** Individual specialist outputs for transparency. */
-  specialistOutputs: {
-    role: CollaborationRole;
-    agentName: string;
-    response: string;
-    error?: string;
-    durationMs: number;
-  }[];
-  /** Total duration including synthesis. */
-  totalDurationMs: number;
-  /** Whether any specialist failed. */
-  hasErrors: boolean;
-}
+import type { CollaborationRole, CollaborationResult } from '../../src/types/collaboration';
+export type { CollaborationResult } from '../../src/types/collaboration';
 
 export interface CollaborationCallbacks {
   /** Called when each phase starts. */
@@ -45,7 +29,7 @@ export interface CollaborationCallbacks {
   /** Called when a specialist starts. */
   onSpecialistStart?: (role: CollaborationRole, agentName: string) => void;
   /** Called when a specialist completes. */
-  onSpecialistEnd?: (role: CollaborationRole, agentName: string, response: string, error?: string) => void;
+  onSpecialistEnd?: (role: CollaborationRole, agentName: string, response: string, durationMs: number, error?: string) => void;
   /** General status updates. */
   onUpdate?: (text: string) => void;
 }
@@ -75,7 +59,7 @@ async function runSpecialist(
   });
 
   const durationMs = Date.now() - specStart;
-  callbacks?.onSpecialistEnd?.(role, agentName, result.response, result.error);
+  callbacks?.onSpecialistEnd?.(role, agentName, result.response, durationMs, result.error);
 
   return {
     role,

--- a/apps/desktop/electron/collaboration/index.ts
+++ b/apps/desktop/electron/collaboration/index.ts
@@ -6,13 +6,15 @@
  * 2. Their outputs are collected
  * 3. The Coordinator synthesizes them into one unified response
  *
- * Leverages the existing SubagentManager for execution.
+ * Agents are discovered from .md files by the SubagentManager (same pattern
+ * as the kanban planning-executor and review-executor).
  */
 
-import { randomUUID } from 'crypto';
 import type { SubagentManager } from '../subagent';
 import {
-  SPECIALIST_AGENTS,
+  SPECIALIST_ROLES,
+  ROLE_AGENT_NAMES,
+  ROLE_LABELS,
   buildCoordinatorSynthesisPrompt,
   type CollaborationRole,
 } from './agents';
@@ -41,8 +43,6 @@ export interface CollaborationCallbacks {
   onSpecialistStart?: (role: CollaborationRole, agentName: string) => void;
   /** Called when a specialist completes. */
   onSpecialistEnd?: (role: CollaborationRole, agentName: string, response: string, error?: string) => void;
-  /** Called with live text deltas from the synthesis phase. */
-  onSynthesisDelta?: (delta: string) => void;
   /** General status updates. */
   onUpdate?: (text: string) => void;
 }
@@ -69,13 +69,16 @@ export async function runCollaboration(
   callbacks?.onUpdate?.('Starting 4-agent collaboration — running specialists in parallel...');
 
   const specialistResults = await Promise.allSettled(
-    SPECIALIST_AGENTS.map(async ({ role, agent }) => {
+    SPECIALIST_ROLES.map(async (role) => {
+      const agentName = ROLE_AGENT_NAMES[role];
+      const label = ROLE_LABELS[role];
       const specStart = Date.now();
-      callbacks?.onSpecialistStart?.(role, agent.name);
+
+      callbacks?.onSpecialistStart?.(role, agentName);
 
       const result = await manager.runSingleStructured({
+        agent: agentName,
         task: query,
-        systemPrompt: agent.systemPrompt,
         parentSessionId,
         workspaceId,
         onUpdate: callbacks?.onUpdate,
@@ -84,25 +87,26 @@ export async function runCollaboration(
       const durationMs = Date.now() - specStart;
       const output = {
         role,
-        agentName: agent.name,
+        agentName,
         response: result.response,
         error: result.error,
         durationMs,
       };
 
-      callbacks?.onSpecialistEnd?.(role, agent.name, result.response, result.error);
+      callbacks?.onSpecialistEnd?.(role, agentName, result.response, result.error);
       return output;
     }),
   );
 
-  // Collect results
-  for (const result of specialistResults) {
+  // Collect results, preserving role ordering
+  for (let i = 0; i < specialistResults.length; i++) {
+    const result = specialistResults[i];
     if (result.status === 'fulfilled') {
       specialistOutputs.push(result.value);
     } else {
       specialistOutputs.push({
-        role: 'researcher', // fallback — shouldn't happen
-        agentName: 'unknown',
+        role: SPECIALIST_ROLES[i],
+        agentName: ROLE_AGENT_NAMES[SPECIALIST_ROLES[i]],
         response: '',
         error: result.reason?.message ?? 'Unknown error',
         durationMs: 0,
@@ -120,6 +124,7 @@ export async function runCollaboration(
   callbacks?.onPhaseStart?.('synthesis');
   callbacks?.onUpdate?.('Specialists complete — Coordinator synthesizing final response...');
 
+  const coordinatorName = ROLE_AGENT_NAMES['coordinator'];
   const synthesisPrompt = buildCoordinatorSynthesisPrompt(
     query,
     researcherOutput?.response || '(Researcher failed to produce output)',
@@ -128,6 +133,7 @@ export async function runCollaboration(
   );
 
   const synthesisResult = await manager.runSingleStructured({
+    agent: coordinatorName,
     task: synthesisPrompt,
     parentSessionId,
     workspaceId,

--- a/apps/desktop/electron/collaboration/index.ts
+++ b/apps/desktop/electron/collaboration/index.ts
@@ -1,10 +1,14 @@
 /**
  * CollaborationEngine — orchestrates the 4-agent collaboration framework.
  *
- * Flow:
- * 1. Three specialists (Researcher, Analyst, Visionary) run in parallel
- * 2. Their outputs are collected
- * 3. The Coordinator synthesizes them into one unified response
+ * Two-phase fan-out flow:
+ * 1. Researcher runs first to gather facts and evidence
+ * 2. Analyst + Visionary run in parallel, each receiving the research as context
+ * 3. Coordinator synthesizes all three outputs into one unified response
+ *
+ * This lets the analyst reason about real findings and the visionary
+ * riff on concrete research, producing higher-quality collaboration
+ * than fully parallel execution.
  *
  * Agents are discovered from .md files by the SubagentManager (same pattern
  * as the kanban planning-executor and review-executor).
@@ -12,9 +16,8 @@
 
 import type { SubagentManager } from '../subagent';
 import {
-  SPECIALIST_ROLES,
+  PARALLEL_SPECIALIST_ROLES,
   ROLE_AGENT_NAMES,
-  ROLE_LABELS,
   buildCoordinatorSynthesisPrompt,
   type CollaborationRole,
 } from './agents';
@@ -38,7 +41,7 @@ export interface CollaborationResult {
 
 export interface CollaborationCallbacks {
   /** Called when each phase starts. */
-  onPhaseStart?: (phase: 'specialists' | 'synthesis') => void;
+  onPhaseStart?: (phase: 'research' | 'specialists' | 'synthesis') => void;
   /** Called when a specialist starts. */
   onSpecialistStart?: (role: CollaborationRole, agentName: string) => void;
   /** Called when a specialist completes. */
@@ -48,10 +51,63 @@ export interface CollaborationCallbacks {
 }
 
 /**
+ * Run a single specialist agent and return its output.
+ */
+async function runSpecialist(
+  role: CollaborationRole,
+  task: string,
+  parentSessionId: string,
+  workspaceId: string,
+  manager: SubagentManager,
+  callbacks?: CollaborationCallbacks,
+): Promise<CollaborationResult['specialistOutputs'][number]> {
+  const agentName = ROLE_AGENT_NAMES[role];
+  const specStart = Date.now();
+
+  callbacks?.onSpecialistStart?.(role, agentName);
+
+  const result = await manager.runSingleStructured({
+    agent: agentName,
+    task,
+    parentSessionId,
+    workspaceId,
+    onUpdate: callbacks?.onUpdate,
+  });
+
+  const durationMs = Date.now() - specStart;
+  callbacks?.onSpecialistEnd?.(role, agentName, result.response, result.error);
+
+  return {
+    role,
+    agentName,
+    response: result.response,
+    error: result.error,
+    durationMs,
+  };
+}
+
+/**
+ * Build the task prompt for a phase-2 specialist, including
+ * the researcher's findings as context.
+ */
+function buildResearchAwareTask(query: string, researchOutput: string): string {
+  return `## Research Findings
+The following research has been gathered by a dedicated researcher agent. Use these findings to inform your analysis.
+
+${researchOutput}
+
+---
+
+## Original Query
+${query}`;
+}
+
+/**
  * Run the 4-agent collaboration framework for a user query.
  *
- * Phase 1: Run Researcher, Analyst, and Visionary in parallel
- * Phase 2: Feed their outputs to the Coordinator for synthesis
+ * Phase 1: Researcher gathers facts and evidence
+ * Phase 2: Analyst + Visionary run in parallel with research as context
+ * Phase 3: Coordinator synthesizes all outputs
  */
 export async function runCollaboration(
   query: string,
@@ -63,50 +119,51 @@ export async function runCollaboration(
   const startTime = Date.now();
   const specialistOutputs: CollaborationResult['specialistOutputs'] = [];
 
-  // ── Phase 1: Run specialists in parallel ─────────────────────
+  // ── Phase 1: Researcher runs first ───────────────────────────
+
+  callbacks?.onPhaseStart?.('research');
+  callbacks?.onUpdate?.('Starting 4-agent collaboration — Researcher gathering facts...');
+
+  let researcherOutput: CollaborationResult['specialistOutputs'][number];
+  try {
+    researcherOutput = await runSpecialist(
+      'researcher', query, parentSessionId, workspaceId, manager, callbacks,
+    );
+  } catch (err: unknown) {
+    researcherOutput = {
+      role: 'researcher',
+      agentName: ROLE_AGENT_NAMES['researcher'],
+      response: '',
+      error: err instanceof Error ? err.message : 'Unknown error',
+      durationMs: 0,
+    };
+  }
+  specialistOutputs.push(researcherOutput);
+
+  const researchText = researcherOutput.response || '(Researcher failed to produce output)';
+
+  // ── Phase 2: Analyst + Visionary in parallel (with research) ─
 
   callbacks?.onPhaseStart?.('specialists');
-  callbacks?.onUpdate?.('Starting 4-agent collaboration — running specialists in parallel...');
+  callbacks?.onUpdate?.('Research complete — Analyst and Visionary analyzing in parallel...');
 
-  const specialistResults = await Promise.allSettled(
-    SPECIALIST_ROLES.map(async (role) => {
-      const agentName = ROLE_AGENT_NAMES[role];
-      const label = ROLE_LABELS[role];
-      const specStart = Date.now();
+  const researchAwareTask = buildResearchAwareTask(query, researchText);
 
-      callbacks?.onSpecialistStart?.(role, agentName);
-
-      const result = await manager.runSingleStructured({
-        agent: agentName,
-        task: query,
-        parentSessionId,
-        workspaceId,
-        onUpdate: callbacks?.onUpdate,
-      });
-
-      const durationMs = Date.now() - specStart;
-      const output = {
-        role,
-        agentName,
-        response: result.response,
-        error: result.error,
-        durationMs,
-      };
-
-      callbacks?.onSpecialistEnd?.(role, agentName, result.response, result.error);
-      return output;
-    }),
+  const parallelResults = await Promise.allSettled(
+    PARALLEL_SPECIALIST_ROLES.map((role) =>
+      runSpecialist(role, researchAwareTask, parentSessionId, workspaceId, manager, callbacks),
+    ),
   );
 
-  // Collect results, preserving role ordering
-  for (let i = 0; i < specialistResults.length; i++) {
-    const result = specialistResults[i];
+  for (let i = 0; i < parallelResults.length; i++) {
+    const result = parallelResults[i];
     if (result.status === 'fulfilled') {
       specialistOutputs.push(result.value);
     } else {
+      const role = PARALLEL_SPECIALIST_ROLES[i];
       specialistOutputs.push({
-        role: SPECIALIST_ROLES[i],
-        agentName: ROLE_AGENT_NAMES[SPECIALIST_ROLES[i]],
+        role,
+        agentName: ROLE_AGENT_NAMES[role],
         response: '',
         error: result.reason?.message ?? 'Unknown error',
         durationMs: 0,
@@ -115,19 +172,18 @@ export async function runCollaboration(
   }
 
   // Extract outputs by role
-  const researcherOutput = specialistOutputs.find((s) => s.role === 'researcher');
   const analystOutput = specialistOutputs.find((s) => s.role === 'analyst');
   const visionaryOutput = specialistOutputs.find((s) => s.role === 'visionary');
 
-  // ── Phase 2: Coordinator synthesis ───────────────────────────
+  // ── Phase 3: Coordinator synthesis ───────────────────────────
 
   callbacks?.onPhaseStart?.('synthesis');
-  callbacks?.onUpdate?.('Specialists complete — Coordinator synthesizing final response...');
+  callbacks?.onUpdate?.('All specialists complete — Coordinator synthesizing final response...');
 
   const coordinatorName = ROLE_AGENT_NAMES['coordinator'];
   const synthesisPrompt = buildCoordinatorSynthesisPrompt(
     query,
-    researcherOutput?.response || '(Researcher failed to produce output)',
+    researchText,
     analystOutput?.response || '(Analyst failed to produce output)',
     visionaryOutput?.response || '(Visionary failed to produce output)',
   );

--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../src/types/ipc';
 import type { ChatCheckpointRef } from '../../src/types/checkpoints';
 import { resizeImageForApi } from '../utils/image-resize';
+import { extractOriginalCollaborationQuery } from './collaboration-message';
 
 // ── ID generation ────────────────────────────────────────────
 
@@ -159,19 +160,6 @@ export function validateProvider(provider: string): KnownProvider {
   throw new Error(`Unknown provider: "${provider}". Available: ${KNOWN_PROVIDERS.join(', ')}`);
 }
 
-// ── Collaboration injection detection ────────────────────────
-
-/**
- * Detect collaboration injection prompts and extract the original user query.
- * The injection prompt wraps the original query in <user-query> tags.
- */
-const COLLAB_INJECTION_RE = /^A multi-agent collaboration team[\s\S]*?<user-query>([\s\S]*?)<\/user-query>/;
-
-function extractOriginalQuery(text: string): string {
-  const match = text.match(COLLAB_INJECTION_RE);
-  return match ? match[1].trim() : text;
-}
-
 // ── Message conversion ───────────────────────────────────────
 
 export function convertSessionMessages(
@@ -192,7 +180,7 @@ export function convertSessionMessages(
               .map((c) => c.text)
               .join('\n');
       // Strip collaboration injection wrapper so the UI shows the original query
-      const text = extractOriginalQuery(rawText);
+      const text = extractOriginalCollaborationQuery(rawText);
       // Shifted by one: user message N shows the checkpoint from the
       // *previous* turn (N-1). "Restore on message N" means "go back to
       // the state just before I sent message N", which is the end of turn N-1.

--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -159,6 +159,19 @@ export function validateProvider(provider: string): KnownProvider {
   throw new Error(`Unknown provider: "${provider}". Available: ${KNOWN_PROVIDERS.join(', ')}`);
 }
 
+// ── Collaboration injection detection ────────────────────────
+
+/**
+ * Detect collaboration injection prompts and extract the original user query.
+ * The injection prompt wraps the original query in <user-query> tags.
+ */
+const COLLAB_INJECTION_RE = /^A multi-agent collaboration team[\s\S]*?<user-query>([\s\S]*?)<\/user-query>/;
+
+function extractOriginalQuery(text: string): string {
+  const match = text.match(COLLAB_INJECTION_RE);
+  return match ? match[1].trim() : text;
+}
+
 // ── Message conversion ───────────────────────────────────────
 
 export function convertSessionMessages(
@@ -171,13 +184,15 @@ export function convertSessionMessages(
   for (const msg of messages) {
     if (msg.role === 'user') {
       userTurn++;
-      const text =
+      const rawText =
         typeof msg.content === 'string'
           ? msg.content
           : msg.content
               .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
               .map((c) => c.text)
               .join('\n');
+      // Strip collaboration injection wrapper so the UI shows the original query
+      const text = extractOriginalQuery(rawText);
       // Shifted by one: user message N shows the checkpoint from the
       // *previous* turn (N-1). "Restore on message N" means "go back to
       // the state just before I sent message N", which is the end of turn N-1.

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -67,6 +67,15 @@ interface PoolEntry {
 const pool = new Map<string, PoolEntry>();
 
 /**
+ * Get a pool entry by session ID.
+ * Used by the collaboration handler to feed synthesized results
+ * back through the main agent session.
+ */
+export function getAgentPoolEntry(sessionId: string): PoolEntry | undefined {
+  return pool.get(sessionId);
+}
+
+/**
  * Reload the ResourceLoader for every active session in the pool.
  * Called after prompt template / skill edits so changes take
  * effect without restarting Sero.

--- a/apps/desktop/electron/ipc/collaboration-message.ts
+++ b/apps/desktop/electron/ipc/collaboration-message.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared helpers for collaboration wrapper prompts.
+ */
+
+const COLLAB_INJECTION_RE = /^A multi-agent collaboration team[\s\S]*?<user-query>([\s\S]*?)<\/user-query>/;
+
+/**
+ * If the input is a collaboration injection prompt, return the original user query.
+ * Otherwise, return the input unchanged.
+ */
+export function extractOriginalCollaborationQuery(text: string): string {
+  const match = text.match(COLLAB_INJECTION_RE);
+  return match ? match[1].trim() : text;
+}

--- a/apps/desktop/electron/ipc/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration.ts
@@ -1,0 +1,60 @@
+/**
+ * IPC handlers for the 4-agent collaboration framework.
+ *
+ * Registers a single `sero:collaboration:prompt` handler that
+ * orchestrates the collaboration and pushes lifecycle events
+ * to the renderer via `sero:collaboration:event`.
+ */
+
+import { ipcMain, BrowserWindow } from 'electron';
+import { IpcChannels } from '../../src/types/ipc';
+import type { CollaborationEvent } from '../../src/types/collaboration';
+import { runCollaboration } from '../collaboration/index';
+import { subagentManager } from './shared-infra';
+
+function sendCollabEvent(event: CollaborationEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(IpcChannels.collaboration.event, event);
+  }
+}
+
+export function registerCollaborationHandlers(): void {
+  ipcMain.handle(
+    IpcChannels.collaboration.prompt,
+    async (_event, sessionId: string, workspaceId: string, query: string) => {
+      if (!subagentManager.isInitialized) {
+        sendCollabEvent({ type: 'collab_error', sessionId, error: 'Subagent system not initialized' });
+        return;
+      }
+
+      sendCollabEvent({ type: 'collab_start', sessionId });
+
+      try {
+        const result = await runCollaboration(
+          query,
+          sessionId,
+          workspaceId,
+          subagentManager,
+          {
+            onPhaseStart: (phase) => {
+              sendCollabEvent({ type: 'collab_phase', sessionId, phase });
+            },
+            onSpecialistStart: (role, agentName) => {
+              sendCollabEvent({ type: 'collab_specialist_start', sessionId, role, agentName });
+            },
+            onSpecialistEnd: (role, agentName, response, error) => {
+              sendCollabEvent({ type: 'collab_specialist_end', sessionId, role, agentName, response, error });
+            },
+          },
+        );
+
+        sendCollabEvent({ type: 'collab_end', sessionId, result });
+        return result;
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        sendCollabEvent({ type: 'collab_error', sessionId, error: msg });
+        throw err;
+      }
+    },
+  );
+}

--- a/apps/desktop/electron/ipc/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration.ts
@@ -14,16 +14,7 @@ import type { CollaborationEvent } from '../../src/types/collaboration';
 import { runCollaboration } from '../collaboration/index';
 import { subagentManager } from './shared-infra';
 import { getAgentPoolEntry } from './agent';
-
-/**
- * Detect collaboration injection prompts and extract the original user query.
- * Reused from agent-helpers but kept local to avoid circular imports.
- */
-const COLLAB_INJECTION_RE = /^A multi-agent collaboration team[\s\S]*?<user-query>([\s\S]*?)<\/user-query>/;
-function stripCollabInjection(text: string): string {
-  const match = text.match(COLLAB_INJECTION_RE);
-  return match ? match[1].trim() : text;
-}
+import { extractOriginalCollaborationQuery } from './collaboration-message';
 
 function sendCollabEvent(event: CollaborationEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -56,7 +47,7 @@ function extractConversationContext(
     if (!text) continue;
 
     // Strip collaboration injection wrappers so specialists see clean queries
-    const cleaned = msg.role === 'user' ? stripCollabInjection(text) : text;
+    const cleaned = msg.role === 'user' ? extractOriginalCollaborationQuery(text) : text;
 
     // Truncate long messages to keep context window reasonable
     const truncated = cleaned.length > 1500 ? cleaned.slice(0, 1500) + '…' : cleaned;

--- a/apps/desktop/electron/ipc/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration.ts
@@ -91,7 +91,6 @@ export function registerCollaborationHandlers(): void {
       sessionId: string,
       workspaceId: string,
       query: string,
-      clientMessageId?: string,
     ) => {
       if (!subagentManager.isInitialized) {
         sendCollabEvent({ type: 'collab_error', sessionId, error: 'Subagent system not initialized' });
@@ -125,8 +124,8 @@ export function registerCollaborationHandlers(): void {
             onSpecialistStart: (role, agentName) => {
               sendCollabEvent({ type: 'collab_specialist_start', sessionId, role, agentName });
             },
-            onSpecialistEnd: (role, agentName, response, error) => {
-              sendCollabEvent({ type: 'collab_specialist_end', sessionId, role, agentName, response, error });
+            onSpecialistEnd: (role, agentName, response, durationMs, error) => {
+              sendCollabEvent({ type: 'collab_specialist_end', sessionId, role, agentName, response, durationMs, error });
             },
           },
         );

--- a/apps/desktop/electron/ipc/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration.ts
@@ -1,16 +1,23 @@
 /**
  * IPC handlers for the 4-agent collaboration framework.
  *
- * Registers a single `sero:collaboration:prompt` handler that
- * orchestrates the collaboration and pushes lifecycle events
- * to the renderer via `sero:collaboration:event`.
+ * The collaboration prompt handler:
+ * 1. Runs the 4-agent collaboration (specialists + coordinator)
+ * 2. Feeds the synthesized result back through the MAIN agent session
+ *    so the conversation is persisted and follow-up queries have context.
+ *
+ * This means the main session's AgentSession sees the user message and
+ * generates a response informed by the collaboration — preserving full
+ * session history for follow-ups.
  */
 
 import { ipcMain, BrowserWindow } from 'electron';
 import { IpcChannels } from '../../src/types/ipc';
 import type { CollaborationEvent } from '../../src/types/collaboration';
+import type { ChatMessage, ChatAttachment } from '../../src/types/ipc';
 import { runCollaboration } from '../collaboration/index';
 import { subagentManager } from './shared-infra';
+import { getAgentPoolEntry } from './agent';
 
 function sendCollabEvent(event: CollaborationEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -18,10 +25,31 @@ function sendCollabEvent(event: CollaborationEvent): void {
   }
 }
 
+/**
+ * Build a prompt for the main session that includes the collaboration
+ * synthesis as context. The main agent will present the result naturally,
+ * and the full exchange is persisted to the session file.
+ */
+function buildInjectionPrompt(originalQuery: string, synthesis: string): string {
+  return `A multi-agent collaboration team (Researcher, Analyst, Visionary, Coordinator) has just analysed the following query in parallel and produced a synthesized answer. Present this answer to the user — you may lightly reformulate for clarity or add brief commentary, but preserve the substance. Do NOT mention the collaboration process.
+
+<user-query>${originalQuery}</user-query>
+
+<collaboration-synthesis>
+${synthesis}
+</collaboration-synthesis>`;
+}
+
 export function registerCollaborationHandlers(): void {
   ipcMain.handle(
     IpcChannels.collaboration.prompt,
-    async (_event, sessionId: string, workspaceId: string, query: string) => {
+    async (
+      _event,
+      sessionId: string,
+      workspaceId: string,
+      query: string,
+      clientMessageId?: string,
+    ) => {
       if (!subagentManager.isInitialized) {
         sendCollabEvent({ type: 'collab_error', sessionId, error: 'Subagent system not initialized' });
         return;
@@ -30,6 +58,7 @@ export function registerCollaborationHandlers(): void {
       sendCollabEvent({ type: 'collab_start', sessionId });
 
       try {
+        // Phase 1+2: Run specialists in parallel, then coordinator synthesis
         const result = await runCollaboration(
           query,
           sessionId,
@@ -49,6 +78,16 @@ export function registerCollaborationHandlers(): void {
         );
 
         sendCollabEvent({ type: 'collab_end', sessionId, result });
+
+        // Phase 3: Feed the synthesis through the main agent session so the
+        // conversation is persisted. The main session's response will stream
+        // back through the normal agent event channel.
+        const entry = getAgentPoolEntry(sessionId);
+        if (entry) {
+          const injectionPrompt = buildInjectionPrompt(query, result.finalResponse);
+          await entry.session.prompt(injectionPrompt);
+        }
+
         return result;
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/apps/desktop/electron/ipc/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration.ts
@@ -121,7 +121,7 @@ export function registerCollaborationHandlers(): void {
         // Build the contextualised query for specialists
         const specialistQuery = buildSpecialistQuery(query, conversationContext);
 
-        // Phase 1+2: Run specialists in parallel, then coordinator synthesis
+        // Run two-phase fan-out: researcher first, then analyst+visionary, then synthesis
         const result = await runCollaboration(
           specialistQuery,
           sessionId,

--- a/apps/desktop/electron/ipc/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration.ts
@@ -2,19 +2,15 @@
  * IPC handlers for the 4-agent collaboration framework.
  *
  * The collaboration prompt handler:
- * 1. Runs the 4-agent collaboration (specialists + coordinator)
- * 2. Feeds the synthesized result back through the MAIN agent session
+ * 1. Extracts conversation history from the main session for context
+ * 2. Runs the 4-agent collaboration (specialists + coordinator)
+ * 3. Feeds the synthesized result back through the MAIN agent session
  *    so the conversation is persisted and follow-up queries have context.
- *
- * This means the main session's AgentSession sees the user message and
- * generates a response informed by the collaboration — preserving full
- * session history for follow-ups.
  */
 
 import { ipcMain, BrowserWindow } from 'electron';
 import { IpcChannels } from '../../src/types/ipc';
 import type { CollaborationEvent } from '../../src/types/collaboration';
-import type { ChatMessage, ChatAttachment } from '../../src/types/ipc';
 import { runCollaboration } from '../collaboration/index';
 import { subagentManager } from './shared-infra';
 import { getAgentPoolEntry } from './agent';
@@ -23,6 +19,49 @@ function sendCollabEvent(event: CollaborationEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
     win.webContents.send(IpcChannels.collaboration.event, event);
   }
+}
+
+/**
+ * Extract a concise conversation summary from the main session's messages
+ * so specialists have context for follow-up queries.
+ *
+ * Returns empty string if this is the first message (no history needed).
+ */
+function extractConversationContext(
+  messages: Array<{ role: string; content: Array<{ type: string; text?: string }> }>,
+): string {
+  if (!messages || messages.length === 0) return '';
+
+  // Build a condensed history from the last few turns (max ~6 messages)
+  const recent = messages.slice(-6);
+  const lines: string[] = [];
+
+  for (const msg of recent) {
+    const role = msg.role === 'user' ? 'User' : 'Assistant';
+    const text = msg.content
+      .filter((c): c is { type: 'text'; text: string } => c.type === 'text' && typeof c.text === 'string')
+      .map((c) => c.text)
+      .join('');
+
+    if (!text) continue;
+
+    // Truncate long messages to keep context window reasonable
+    const truncated = text.length > 1500 ? text.slice(0, 1500) + '…' : text;
+    lines.push(`[${role}]: ${truncated}`);
+  }
+
+  if (lines.length === 0) return '';
+
+  return `## Prior Conversation Context\nThe following is the recent conversation history. The user's new message below is a follow-up.\n\n${lines.join('\n\n')}\n\n---\n\n`;
+}
+
+/**
+ * Build the task prompt for specialists, including conversation history
+ * when this is a follow-up query.
+ */
+function buildSpecialistQuery(query: string, conversationContext: string): string {
+  if (!conversationContext) return query;
+  return `${conversationContext}## Current Query\n${query}`;
 }
 
 /**
@@ -58,9 +97,20 @@ export function registerCollaborationHandlers(): void {
       sendCollabEvent({ type: 'collab_start', sessionId });
 
       try {
+        // Extract conversation history from the main session so specialists
+        // have context for follow-up queries.
+        const entry = getAgentPoolEntry(sessionId);
+        let conversationContext = '';
+        if (entry) {
+          conversationContext = extractConversationContext(entry.session.messages);
+        }
+
+        // Build the contextualised query for specialists
+        const specialistQuery = buildSpecialistQuery(query, conversationContext);
+
         // Phase 1+2: Run specialists in parallel, then coordinator synthesis
         const result = await runCollaboration(
-          query,
+          specialistQuery,
           sessionId,
           workspaceId,
           subagentManager,
@@ -82,7 +132,6 @@ export function registerCollaborationHandlers(): void {
         // Phase 3: Feed the synthesis through the main agent session so the
         // conversation is persisted. The main session's response will stream
         // back through the normal agent event channel.
-        const entry = getAgentPoolEntry(sessionId);
         if (entry) {
           const injectionPrompt = buildInjectionPrompt(query, result.finalResponse);
           await entry.session.prompt(injectionPrompt);

--- a/apps/desktop/electron/ipc/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration.ts
@@ -15,6 +15,16 @@ import { runCollaboration } from '../collaboration/index';
 import { subagentManager } from './shared-infra';
 import { getAgentPoolEntry } from './agent';
 
+/**
+ * Detect collaboration injection prompts and extract the original user query.
+ * Reused from agent-helpers but kept local to avoid circular imports.
+ */
+const COLLAB_INJECTION_RE = /^A multi-agent collaboration team[\s\S]*?<user-query>([\s\S]*?)<\/user-query>/;
+function stripCollabInjection(text: string): string {
+  const match = text.match(COLLAB_INJECTION_RE);
+  return match ? match[1].trim() : text;
+}
+
 function sendCollabEvent(event: CollaborationEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
     win.webContents.send(IpcChannels.collaboration.event, event);
@@ -45,8 +55,11 @@ function extractConversationContext(
 
     if (!text) continue;
 
+    // Strip collaboration injection wrappers so specialists see clean queries
+    const cleaned = msg.role === 'user' ? stripCollabInjection(text) : text;
+
     // Truncate long messages to keep context window reasonable
-    const truncated = text.length > 1500 ? text.slice(0, 1500) + '…' : text;
+    const truncated = cleaned.length > 1500 ? cleaned.slice(0, 1500) + '…' : cleaned;
     lines.push(`[${role}]: ${truncated}`);
   }
 

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -37,6 +37,7 @@ import { registerModelsHandlers } from './models';
 import { registerSubagentHandlers } from './subagent';
 import { registerSkillHandlers } from './skills';
 import { registerPromptHandlers } from './prompts';
+import { registerCollaborationHandlers } from './collaboration';
 
 export function registerAllIpcHandlers(): void {
   registerWorkspaceHandlers();
@@ -70,4 +71,5 @@ export function registerAllIpcHandlers(): void {
   registerSubagentHandlers();
   registerSkillHandlers();
   registerPromptHandlers();
+  registerCollaborationHandlers();
 }

--- a/apps/desktop/electron/ipc/sessions.ts
+++ b/apps/desktop/electron/ipc/sessions.ts
@@ -18,6 +18,7 @@ import { IpcChannels } from '../../src/types/ipc';
 import type { SeroSessionInfo } from '../../src/types/ipc';
 import { workspaceManager } from '../workspace';
 import { SERO_SESSION_DIR } from './shared-infra';
+import { extractOriginalCollaborationQuery } from './collaboration-message';
 
 /**
  * Legacy cwd used before workspaces existed.
@@ -68,7 +69,7 @@ function toSeroSessionInfo(info: {
     created: info.created.toISOString(),
     modified: info.modified.toISOString(),
     messageCount: info.messageCount,
-    firstMessage: info.firstMessage,
+    firstMessage: extractOriginalCollaborationQuery(info.firstMessage),
   };
 }
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -5,6 +5,9 @@ import { debugBridge, lspBridge } from './preload/debug-lsp';
 import { subagentBridge } from './preload/subagent';
 import { skillsBridge } from './preload/skills';
 import { promptsBridge } from './preload/prompts';
+import { collaborationBridge } from './preload/collaboration';
+import { modelsBridge } from './preload/models';
+import { googleBridge, imagegenBridge } from './preload/google-imagegen';
 import type {
   WorkspaceInfo,
   WorkspaceConfig,
@@ -217,31 +220,10 @@ contextBridge.exposeInMainWorld('sero', {
       ipcRenderer.invoke(IpcChannels.appAgent.prompt, appId, workspaceId, text),
   },
 
-  models: {
-    list: (): Promise<import('../src/types/ipc').AvailableModelGroup[]> =>
-      ipcRenderer.invoke(IpcChannels.models.list),
-  },
+  models: modelsBridge,
 
-  google: {
-    execute: (service: string, subArgs: string[]) => ipcRenderer.invoke(IpcChannels.google.execute, service, subArgs),
-    authStatus: () => ipcRenderer.invoke(IpcChannels.google.authStatus),
-    login: () => ipcRenderer.invoke(IpcChannels.google.login),
-    logout: () => ipcRenderer.invoke(IpcChannels.google.logout),
-    onAuthEvent: (cb: (event: any) => void) => {
-      const handler = (_e: IpcRendererEvent, event: any) => cb(event);
-      ipcRenderer.on(IpcChannels.google.authEvent, handler);
-      return () => { ipcRenderer.removeListener(IpcChannels.google.authEvent, handler); };
-    },
-  },
-
-  imagegen: {
-    generate: (workspaceId: string, params: any): Promise<any> =>
-      ipcRenderer.invoke(IpcChannels.imagegen.generate, workspaceId, params),
-    readImage: (filePath: string): Promise<string> =>
-      ipcRenderer.invoke(IpcChannels.imagegen.readImage, filePath),
-    deleteImage: (workspaceId: string, generationId: number, singleImageId?: string): Promise<{ ok: boolean; error?: string }> =>
-      ipcRenderer.invoke(IpcChannels.imagegen.deleteImage, workspaceId, generationId, singleImageId),
-  },
+  google: googleBridge,
+  imagegen: imagegenBridge,
 
   voice: {
     status: (): Promise<VoiceTranscriptionStatus> =>
@@ -469,20 +451,7 @@ contextBridge.exposeInMainWorld('sero', {
       ipcRenderer.invoke(IpcChannels.feedback.remove, messageId),
   },
 
-  collaboration: {
-    prompt: (sessionId: string, workspaceId: string, query: string, clientMessageId?: string): Promise<unknown> =>
-      ipcRenderer.invoke(IpcChannels.collaboration.prompt, sessionId, workspaceId, query, clientMessageId),
-
-    onEvent: (callback: (event: import('../src/types/collaboration').CollaborationEvent) => void): (() => void) => {
-      const handler = (_event: Electron.IpcRendererEvent, data: import('../src/types/collaboration').CollaborationEvent) => {
-        callback(data);
-      };
-      ipcRenderer.on(IpcChannels.collaboration.event, handler);
-      return () => {
-        ipcRenderer.removeListener(IpcChannels.collaboration.event, handler);
-      };
-    },
-  },
+  collaboration: collaborationBridge,
 
   subagent: subagentBridge,
   skills: skillsBridge,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -470,8 +470,8 @@ contextBridge.exposeInMainWorld('sero', {
   },
 
   collaboration: {
-    prompt: (sessionId: string, workspaceId: string, query: string): Promise<unknown> =>
-      ipcRenderer.invoke(IpcChannels.collaboration.prompt, sessionId, workspaceId, query),
+    prompt: (sessionId: string, workspaceId: string, query: string, clientMessageId?: string): Promise<unknown> =>
+      ipcRenderer.invoke(IpcChannels.collaboration.prompt, sessionId, workspaceId, query, clientMessageId),
 
     onEvent: (callback: (event: import('../src/types/collaboration').CollaborationEvent) => void): (() => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: import('../src/types/collaboration').CollaborationEvent) => {

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -469,6 +469,21 @@ contextBridge.exposeInMainWorld('sero', {
       ipcRenderer.invoke(IpcChannels.feedback.remove, messageId),
   },
 
+  collaboration: {
+    prompt: (sessionId: string, workspaceId: string, query: string): Promise<unknown> =>
+      ipcRenderer.invoke(IpcChannels.collaboration.prompt, sessionId, workspaceId, query),
+
+    onEvent: (callback: (event: import('../src/types/collaboration').CollaborationEvent) => void): (() => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: import('../src/types/collaboration').CollaborationEvent) => {
+        callback(data);
+      };
+      ipcRenderer.on(IpcChannels.collaboration.event, handler);
+      return () => {
+        ipcRenderer.removeListener(IpcChannels.collaboration.event, handler);
+      };
+    },
+  },
+
   subagent: subagentBridge,
   skills: skillsBridge,
   prompts: promptsBridge,

--- a/apps/desktop/electron/preload/collaboration.ts
+++ b/apps/desktop/electron/preload/collaboration.ts
@@ -1,0 +1,28 @@
+/**
+ * Preload bridge — 4-agent collaboration IPC.
+ *
+ * Extracted from preload.ts to keep it under 500 LOC.
+ */
+
+import { ipcRenderer } from 'electron';
+import { IpcChannels } from '../../src/types/ipc';
+import type { CollaborationResult, CollaborationEvent } from '../../src/types/collaboration';
+
+export const collaborationBridge = {
+  prompt: (
+    sessionId: string,
+    workspaceId: string,
+    query: string,
+  ): Promise<CollaborationResult> =>
+    ipcRenderer.invoke(IpcChannels.collaboration.prompt, sessionId, workspaceId, query),
+
+  onEvent: (callback: (event: CollaborationEvent) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, data: CollaborationEvent) => {
+      callback(data);
+    };
+    ipcRenderer.on(IpcChannels.collaboration.event, handler);
+    return () => {
+      ipcRenderer.removeListener(IpcChannels.collaboration.event, handler);
+    };
+  },
+};

--- a/apps/desktop/electron/preload/google-imagegen.ts
+++ b/apps/desktop/electron/preload/google-imagegen.ts
@@ -1,0 +1,36 @@
+/**
+ * Preload bridge — Google + image generation IPC.
+ *
+ * Extracted from preload.ts to keep it under 500 LOC.
+ */
+
+import { ipcRenderer, type IpcRendererEvent } from 'electron';
+import { IpcChannels } from '../../src/types/ipc';
+
+export const googleBridge = {
+  execute: (service: string, subArgs: string[]) =>
+    ipcRenderer.invoke(IpcChannels.google.execute, service, subArgs),
+  authStatus: () => ipcRenderer.invoke(IpcChannels.google.authStatus),
+  login: () => ipcRenderer.invoke(IpcChannels.google.login),
+  logout: () => ipcRenderer.invoke(IpcChannels.google.logout),
+  onAuthEvent: (cb: (event: any) => void) => {
+    const handler = (_e: IpcRendererEvent, event: any) => cb(event);
+    ipcRenderer.on(IpcChannels.google.authEvent, handler);
+    return () => {
+      ipcRenderer.removeListener(IpcChannels.google.authEvent, handler);
+    };
+  },
+};
+
+export const imagegenBridge = {
+  generate: (workspaceId: string, params: any): Promise<any> =>
+    ipcRenderer.invoke(IpcChannels.imagegen.generate, workspaceId, params),
+  readImage: (filePath: string): Promise<string> =>
+    ipcRenderer.invoke(IpcChannels.imagegen.readImage, filePath),
+  deleteImage: (
+    workspaceId: string,
+    generationId: number,
+    singleImageId?: string,
+  ): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.imagegen.deleteImage, workspaceId, generationId, singleImageId),
+};

--- a/apps/desktop/electron/preload/models.ts
+++ b/apps/desktop/electron/preload/models.ts
@@ -1,0 +1,14 @@
+/**
+ * Preload bridge — model listing IPC.
+ *
+ * Extracted from preload.ts to keep it under 500 LOC.
+ */
+
+import { ipcRenderer } from 'electron';
+import { IpcChannels } from '../../src/types/ipc';
+import type { AvailableModelGroup } from '../../src/types/ipc';
+
+export const modelsBridge = {
+  list: (): Promise<AvailableModelGroup[]> =>
+    ipcRenderer.invoke(IpcChannels.models.list),
+};

--- a/apps/desktop/electron/subagent/setup.ts
+++ b/apps/desktop/electron/subagent/setup.ts
@@ -2,11 +2,11 @@
  * First-launch agent template setup.
  *
  * Copies built-in agent templates to ~/.sero-ui/agent/agents/
- * if the directory is empty or doesn't exist. Preserves user edits
- * on subsequent launches.
+ * if they don't already exist. Preserves user edits — only copies
+ * templates whose filename is missing from the target directory.
  */
 
-import { readdir, copyFile, mkdir } from 'fs/promises';
+import { readdir, copyFile, mkdir, access } from 'fs/promises';
 import path from 'path';
 import { SERO_AGENT_DIR } from '../env';
 
@@ -25,23 +25,19 @@ function getTemplatesDir(): string {
 }
 
 /**
- * Copy default agent templates if the user's agents directory is empty.
+ * Copy default agent templates, adding any missing ones.
  *
- * Call once from electron/main.ts at startup. Fast no-op if agents exist.
+ * Call once from electron/main.ts at startup. Only copies templates
+ * whose filename doesn't already exist in the user's agents directory,
+ * so user edits are never overwritten.
  */
 export async function ensureDefaultAgents(): Promise<void> {
   try {
     // Ensure the directory exists
     await mkdir(AGENTS_DIR, { recursive: true });
 
-    // Check if there are any existing .md files
-    const existing = await readdir(AGENTS_DIR);
-    const hasMdFiles = existing.some((f) => f.endsWith('.md'));
-
-    if (hasMdFiles) {
-      console.log('[subagent/setup] Agents directory already has .md files, skipping copy');
-      return;
-    }
+    // Get existing files
+    const existing = new Set(await readdir(AGENTS_DIR));
 
     // Copy templates
     const templatesDir = getTemplatesDir();
@@ -54,14 +50,21 @@ export async function ensureDefaultAgents(): Promise<void> {
     }
 
     const mdFiles = templateFiles.filter((f) => f.endsWith('.md'));
+    let copied = 0;
+
     for (const file of mdFiles) {
+      if (existing.has(file)) continue; // Don't overwrite user edits
+
       const src = path.join(templatesDir, file);
       const dest = path.join(AGENTS_DIR, file);
       await copyFile(src, dest);
       console.log(`[subagent/setup] Copied template: ${file}`);
+      copied++;
     }
 
-    console.log(`[subagent/setup] Copied ${mdFiles.length} agent templates to ${AGENTS_DIR}`);
+    if (copied > 0) {
+      console.log(`[subagent/setup] Copied ${copied} new agent template(s) to ${AGENTS_DIR}`);
+    }
   } catch (err) {
     console.warn('[subagent/setup] Failed to copy agent templates:', err);
   }

--- a/apps/desktop/src/components/apps/coding/orchestration/OrchestrationPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/orchestration/OrchestrationPanel.tsx
@@ -5,12 +5,14 @@
  * subagent list + summary bar, or an empty state placeholder.
  */
 
-import { useEffect, useMemo } from 'react';
-import { Network } from 'lucide-react';
+import { useEffect, useMemo, useCallback } from 'react';
+import { Network, X } from 'lucide-react';
 import { useSubagentStore } from '@/stores/subagent';
 import { SubagentList } from './SubagentList';
 import { SubagentSummary } from './SubagentSummary';
 import type { SubagentEntry } from '@/types/ipc';
+
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'aborted', 'timed_out']);
 
 const STATUS_SORT_ORDER: Record<string, number> = {
   running: 0,
@@ -38,6 +40,7 @@ export function OrchestrationPanel({ workspaceId }: OrchestrationPanelProps) {
   const hydrate = useSubagentStore((s) => s.hydrate);
   const hydrated = useSubagentStore((s) => s.hydrated);
   const initListeners = useSubagentStore((s) => s.initListeners);
+  const clearCompleted = useSubagentStore((s) => s.clearCompleted);
   const entries = useSubagentStore((s) => s.entries);
 
   // Derive filtered + sorted entries — stable unless `entries` record changes
@@ -48,6 +51,15 @@ export function OrchestrationPanel({ workspaceId }: OrchestrationPanelProps) {
       ),
     [entries, workspaceId],
   );
+
+  const hasCompleted = useMemo(
+    () => filtered.some((e) => TERMINAL_STATUSES.has(e.status)),
+    [filtered],
+  );
+
+  const handleClearCompleted = useCallback(() => {
+    clearCompleted(workspaceId);
+  }, [clearCompleted, workspaceId]);
 
   // Hydrate on mount and workspace change
   useEffect(() => {
@@ -63,7 +75,7 @@ export function OrchestrationPanel({ workspaceId }: OrchestrationPanelProps) {
   if (!hydrated) {
     return (
       <div className="flex h-full flex-col">
-        <Header />
+        <Header showClear={false} onClear={handleClearCompleted} />
         <div className="flex flex-1 items-center justify-center">
           <span className="text-xs text-[var(--text-muted)]">Loading…</span>
         </div>
@@ -74,7 +86,7 @@ export function OrchestrationPanel({ workspaceId }: OrchestrationPanelProps) {
   if (filtered.length === 0) {
     return (
       <div className="flex h-full flex-col">
-        <Header />
+        <Header showClear={false} onClear={handleClearCompleted} />
         <div className="flex flex-1 flex-col items-center justify-center gap-2 p-4">
           <Network className="size-8 text-[var(--text-muted)] opacity-40" />
           <span className="text-xs text-[var(--text-muted)]">No subagent activity</span>
@@ -85,7 +97,7 @@ export function OrchestrationPanel({ workspaceId }: OrchestrationPanelProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <Header />
+      <Header showClear={hasCompleted} onClear={handleClearCompleted} />
       <div className="flex-1 overflow-y-auto min-h-0">
         <SubagentList entries={filtered} />
       </div>
@@ -94,12 +106,22 @@ export function OrchestrationPanel({ workspaceId }: OrchestrationPanelProps) {
   );
 }
 
-function Header() {
+function Header({ showClear, onClear }: { showClear: boolean; onClear: () => void }) {
   return (
-    <div className="flex h-7 shrink-0 items-center px-4">
+    <div className="flex h-7 shrink-0 items-center justify-between px-4">
       <span className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
         Orchestration
       </span>
+      {showClear && (
+        <button
+          onClick={onClear}
+          className="flex items-center gap-1 text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
+          title="Clear completed runs"
+        >
+          <X className="size-3" />
+          <span>Clear</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/apps/coding/orchestration/OrchestrationPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/orchestration/OrchestrationPanel.tsx
@@ -8,11 +8,10 @@
 import { useEffect, useMemo, useCallback } from 'react';
 import { Network, X } from 'lucide-react';
 import { useSubagentStore } from '@/stores/subagent';
+import { TERMINAL_STATUSES } from '@/stores/subagent-constants';
 import { SubagentList } from './SubagentList';
 import { SubagentSummary } from './SubagentSummary';
 import type { SubagentEntry } from '@/types/ipc';
-
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'aborted', 'timed_out']);
 
 const STATUS_SORT_ORDER: Record<string, number> = {
   running: 0,

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -18,7 +18,11 @@ import {
   PromptInputActionMenuContent,
   PromptInputActionAddAttachments,
 } from '@sero/ui/components/ai-elements/prompt-input';
-import { useAgentStore, useFocusedAgent } from '@/stores/agent';
+import { useAgentStore } from '@/stores/agent';
+import {
+  useFocusedAgent,
+  useFocusedCollaborationMode,
+} from '@/stores/agent-selectors';
 import { useSessionStore } from '@/stores/sessions';
 import { SlashCommandMenu } from './SlashCommandMenu';
 import { FileReferenceMenu } from './FileReferenceMenu';
@@ -53,7 +57,7 @@ export function ChatPanel() {
   const focused = useFocusedAgent();
   const sendPrompt = useAgentStore((s) => s.sendPrompt);
   const sendCollaborationPrompt = useAgentStore((s) => s.sendCollaborationPrompt);
-  const collaborationMode = useAgentStore((s) => s.collaborationMode);
+  const collaborationMode = useFocusedCollaborationMode();
   const steerAgent = useAgentStore((s) => s.steerAgent);
   const abort = useAgentStore((s) => s.abort);
   const initEventListener = useAgentStore((s) => s.initEventListener);

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -40,7 +40,8 @@ import { useChatPromptInput } from '@/hooks/useChatPromptInput';
 import { createFilePathClickHandler } from './ClickableFilePath';
 import { PendingQuestionCard } from './PendingQuestionCard';
 import { QuestionnaireNotice } from './QuestionnaireNotice';
-import { ContextEditorMenuItem, ThinkingBlocksToggle, EmptyState } from './ChatPanelHelpers';
+import { ContextEditorMenuItem, ThinkingBlocksToggle, CollaborationToggle, EmptyState } from './ChatPanelHelpers';
+import { CollaborationStatusBanner, CollaborationDetails } from './CollaborationResponse';
 
 /**
  * ChatPanel — agent chat panel wired to Pi SDK AgentSession pool.
@@ -51,15 +52,24 @@ import { ContextEditorMenuItem, ThinkingBlocksToggle, EmptyState } from './ChatP
 export function ChatPanel() {
   const focused = useFocusedAgent();
   const sendPrompt = useAgentStore((s) => s.sendPrompt);
+  const sendCollaborationPrompt = useAgentStore((s) => s.sendCollaborationPrompt);
+  const collaborationMode = useAgentStore((s) => s.collaborationMode);
   const steerAgent = useAgentStore((s) => s.steerAgent);
   const abort = useAgentStore((s) => s.abort);
   const initEventListener = useAgentStore((s) => s.initEventListener);
+  const initCollaborationListener = useAgentStore((s) => s.initCollaborationListener);
 
   // Subscribe to main-process events on mount
   useEffect(() => {
     const unsub = initEventListener();
     return unsub;
   }, [initEventListener]);
+
+  // Subscribe to collaboration events on mount
+  useEffect(() => {
+    const unsub = initCollaborationListener();
+    return unsub;
+  }, [initCollaborationListener]);
 
   // Initialize feedback store (load ratings from disk)
   const initFeedback = useFeedbackStore((s) => s.init);
@@ -98,6 +108,8 @@ export function ChatPanel() {
     isStreaming,
     focusedWorkspaceId,
     sendPrompt,
+    sendCollaborationPrompt,
+    collaborationMode,
     steerAgent,
     messageQueue,
     onLoginRequest,
@@ -159,6 +171,11 @@ export function ChatPanel() {
         {sessionLabel && (
           <span className="truncate text-xs rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[var(--text-muted)]" style={{ maxWidth: '60%' }}>
             {sessionLabel}
+          </span>
+        )}
+        {collaborationMode && (
+          <span className="rounded bg-violet-500/15 px-1.5 py-0.5 text-[10px] font-medium text-violet-600 dark:text-violet-400">
+            4-Agent
           </span>
         )}
         {sessionId && <UsageBadge sessionId={sessionId} />}
@@ -246,6 +263,10 @@ export function ChatPanel() {
         <ConversationScrollButton />
       </Conversation>
 
+      {/* ── Collaboration status + expandable details ──────── */}
+      <CollaborationStatusBanner />
+      <CollaborationDetails />
+
       {/* ── Pending question card (single questions only) ──── */}
       <PendingQuestionCard />
 
@@ -302,7 +323,7 @@ export function ChatPanel() {
               value={prompt.input}
               onChange={(e) => prompt.setInput(e.target.value)}
               onKeyDown={prompt.handleKeyDown}
-              placeholder={hasSession ? 'Ask Sero anything… (/ for commands, @ for files)' : 'Select a chat first…'}
+              placeholder={hasSession ? (collaborationMode ? '4-Agent Collaboration active — ask a complex question…' : 'Ask Sero anything… (/ for commands, @ for files)') : 'Select a chat first…'}
               disabled={!hasSession}
             />
           </PromptInputBody>
@@ -323,6 +344,7 @@ export function ChatPanel() {
                 disabled={!hasSession || isStreaming}
                 onTranscript={handleTranscript}
               />
+              <CollaborationToggle disabled={!hasSession} />
               <ThinkingBlocksToggle disabled={!hasSession} />
               <ModelSelector disabled={!hasSession} />
             </PromptInputTools>

--- a/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
+++ b/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
@@ -6,7 +6,7 @@
  * - EmptyState — placeholder when no session / no messages
  */
 
-import { Settings2, Brain, MessageSquare } from 'lucide-react';
+import { Settings2, Brain, MessageSquare, Users } from 'lucide-react';
 import {
   PromptInputActionMenuItem,
 } from '@sero/ui/components/ai-elements/prompt-input';
@@ -68,6 +68,30 @@ export function ThinkingBlocksToggle({ disabled }: { disabled: boolean }) {
       )}
     >
       <Brain className="size-3.5" />
+    </button>
+  );
+}
+
+// ── Collaboration mode toggle ──────────────────────────────────
+
+export function CollaborationToggle({ disabled }: { disabled: boolean }) {
+  const isActive = useAgentStore((s) => s.collaborationMode);
+  const toggle = useAgentStore((s) => s.toggleCollaborationMode);
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={disabled}
+      title={isActive ? 'Disable 4-agent collaboration mode' : 'Enable 4-agent collaboration mode'}
+      className={cn(
+        'rounded-md p-1.5 transition-colors duration-150',
+        isActive
+          ? 'bg-violet-500/15 text-violet-600 dark:text-violet-400'
+          : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+        'disabled:pointer-events-none disabled:opacity-40',
+      )}
+    >
+      <Users className="size-3.5" />
     </button>
   );
 }

--- a/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
+++ b/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
@@ -10,7 +10,11 @@ import { Settings2, Brain, MessageSquare, Users } from 'lucide-react';
 import {
   PromptInputActionMenuItem,
 } from '@sero/ui/components/ai-elements/prompt-input';
-import { useAgentStore, useFocusedAgent } from '@/stores/agent';
+import { useAgentStore } from '@/stores/agent';
+import {
+  useFocusedAgent,
+  useFocusedCollaborationMode,
+} from '@/stores/agent-selectors';
 import { useContextEditorStore, useHasOverrides } from '@/stores/context-editor';
 import { cn } from '@sero/ui/lib/utils';
 
@@ -75,7 +79,7 @@ export function ThinkingBlocksToggle({ disabled }: { disabled: boolean }) {
 // ── Collaboration mode toggle ──────────────────────────────────
 
 export function CollaborationToggle({ disabled }: { disabled: boolean }) {
-  const isActive = useAgentStore((s) => s.collaborationMode);
+  const isActive = useFocusedCollaborationMode();
   const toggle = useAgentStore((s) => s.toggleCollaborationMode);
 
   return (

--- a/apps/desktop/src/components/layout/CollaborationResponse.tsx
+++ b/apps/desktop/src/components/layout/CollaborationResponse.tsx
@@ -1,0 +1,117 @@
+/**
+ * CollaborationResponse — expandable display of specialist agent outputs.
+ *
+ * Shown below the synthesized response when collaboration mode produced the answer.
+ * Each specialist's output is collapsible for transparency.
+ */
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Search, BarChart3, Lightbulb, Loader2, Users } from 'lucide-react';
+import { useAgentStore } from '@/stores/agent';
+import { cn } from '@sero/ui/lib/utils';
+import type { CollaborationRole, CollaborationSpecialistOutput } from '@/types/collaboration';
+
+const ROLE_META: Record<CollaborationRole, { label: string; icon: typeof Search; color: string }> = {
+  coordinator: { label: 'Coordinator', icon: Users, color: 'text-violet-500' },
+  researcher: { label: 'Researcher', icon: Search, color: 'text-blue-500' },
+  analyst: { label: 'Analyst', icon: BarChart3, color: 'text-emerald-500' },
+  visionary: { label: 'Visionary', icon: Lightbulb, color: 'text-amber-500' },
+};
+
+function SpecialistCard({ output }: { output: CollaborationSpecialistOutput }) {
+  const [expanded, setExpanded] = useState(false);
+  const meta = ROLE_META[output.role];
+  const Icon = meta.icon;
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div className="rounded-md border border-[var(--border-default)] bg-[var(--bg-surface)]">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-[var(--bg-elevated)]"
+      >
+        <Chevron className="size-3 text-[var(--text-muted)]" />
+        <Icon className={cn('size-3.5', meta.color)} />
+        <span className="font-medium text-[var(--text-primary)]">{meta.label}</span>
+        {output.error ? (
+          <span className="ml-auto text-destructive">Failed</span>
+        ) : (
+          <span className="ml-auto text-[var(--text-muted)]">
+            {output.durationMs > 0 ? `${Math.round(output.durationMs / 1000)}s` : ''}
+          </span>
+        )}
+      </button>
+      {expanded && (
+        <div className="border-t border-[var(--border-default)] px-3 py-2">
+          {output.error ? (
+            <p className="text-xs text-destructive">{output.error}</p>
+          ) : (
+            <div className="prose prose-sm dark:prose-invert max-w-none text-xs whitespace-pre-wrap">
+              {output.response}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Collaboration status indicator shown during active collaboration.
+ */
+export function CollaborationStatusBanner() {
+  const status = useAgentStore((s) => s.collaborationStatus);
+  const specialists = useAgentStore((s) => s.collaborationSpecialists);
+
+  if (status === 'idle' || status === 'complete') return null;
+
+  const completedCount = specialists.length;
+
+  return (
+    <div className="mx-3 mb-2 flex items-center gap-2 rounded-md bg-violet-500/10 px-3 py-2 text-xs text-violet-600 dark:text-violet-400">
+      <Loader2 className="size-3.5 animate-spin" />
+      {status === 'specialists' && (
+        <span>4-Agent Collaboration: Running specialists ({completedCount}/3 complete)...</span>
+      )}
+      {status === 'synthesis' && (
+        <span>4-Agent Collaboration: Coordinator synthesizing final response...</span>
+      )}
+      {status === 'error' && (
+        <span>4-Agent Collaboration: An error occurred</span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Expandable specialist outputs panel.
+ * Rendered below the assistant message that was produced by collaboration.
+ */
+export function CollaborationDetails() {
+  const result = useAgentStore((s) => s.collaborationResult);
+  const [expanded, setExpanded] = useState(false);
+
+  if (!result) return null;
+
+  return (
+    <div className="mx-1 mt-1">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1.5 rounded px-2 py-1 text-[11px] text-violet-600 hover:bg-violet-500/10 dark:text-violet-400"
+      >
+        <Users className="size-3" />
+        {expanded ? 'Hide' : 'Show'} specialist outputs
+        <span className="text-[var(--text-muted)]">
+          ({Math.round(result.totalDurationMs / 1000)}s total)
+        </span>
+      </button>
+      {expanded && (
+        <div className="mt-1.5 flex flex-col gap-1.5">
+          {result.specialistOutputs.map((output) => (
+            <SpecialistCard key={output.role} output={output} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/CollaborationResponse.tsx
+++ b/apps/desktop/src/components/layout/CollaborationResponse.tsx
@@ -71,7 +71,9 @@ export function CollaborationStatusBanner() {
 
   if (status === 'idle' || status === 'complete') return null;
 
-  const completedCount = specialists.length;
+  // Phase 2 runs analyst + visionary (2 agents). The researcher from phase 1
+  // is already in the list, so subtract 1 to get the phase-2 completion count.
+  const phase2Completed = Math.max(0, specialists.length - 1);
 
   return (
     <div className="mx-3 mb-2 flex items-center gap-2 rounded-md bg-violet-500/10 px-3 py-2 text-xs text-violet-600 dark:text-violet-400">
@@ -80,7 +82,7 @@ export function CollaborationStatusBanner() {
         <span>4-Agent Collaboration: Researcher gathering facts...</span>
       )}
       {status === 'specialists' && (
-        <span>4-Agent Collaboration: Analyst &amp; Visionary analyzing research ({completedCount}/3 complete)...</span>
+        <span>4-Agent Collaboration: Research ✓ — Analyst &amp; Visionary analyzing ({phase2Completed}/2 complete)...</span>
       )}
       {status === 'synthesis' && (
         <span>4-Agent Collaboration: Coordinator synthesizing final response...</span>

--- a/apps/desktop/src/components/layout/CollaborationResponse.tsx
+++ b/apps/desktop/src/components/layout/CollaborationResponse.tsx
@@ -70,8 +70,11 @@ export function CollaborationStatusBanner() {
   return (
     <div className="mx-3 mb-2 flex items-center gap-2 rounded-md bg-violet-500/10 px-3 py-2 text-xs text-violet-600 dark:text-violet-400">
       <Loader2 className="size-3.5 animate-spin" />
+      {status === 'research' && (
+        <span>4-Agent Collaboration: Researcher gathering facts...</span>
+      )}
       {status === 'specialists' && (
-        <span>4-Agent Collaboration: Running specialists ({completedCount}/3 complete)...</span>
+        <span>4-Agent Collaboration: Analyst &amp; Visionary analyzing research ({completedCount}/3 complete)...</span>
       )}
       {status === 'synthesis' && (
         <span>4-Agent Collaboration: Coordinator synthesizing final response...</span>

--- a/apps/desktop/src/components/layout/CollaborationResponse.tsx
+++ b/apps/desktop/src/components/layout/CollaborationResponse.tsx
@@ -7,7 +7,11 @@
 
 import { useState } from 'react';
 import { ChevronDown, ChevronRight, Search, BarChart3, Lightbulb, Loader2, Users } from 'lucide-react';
-import { useAgentStore } from '@/stores/agent';
+import {
+  useFocusedCollaborationResult,
+  useFocusedCollaborationSpecialists,
+  useFocusedCollaborationStatus,
+} from '@/stores/agent-selectors';
 import { cn } from '@sero/ui/lib/utils';
 import type { CollaborationRole, CollaborationSpecialistOutput } from '@/types/collaboration';
 
@@ -46,8 +50,10 @@ function SpecialistCard({ output }: { output: CollaborationSpecialistOutput }) {
           {output.error ? (
             <p className="text-xs text-destructive">{output.error}</p>
           ) : (
-            <div className="prose prose-sm dark:prose-invert max-w-none text-xs whitespace-pre-wrap">
-              {output.response}
+            <div className="max-h-[min(50vh,28rem)] overflow-y-auto overscroll-contain pr-1">
+              <div className="prose prose-sm dark:prose-invert max-w-none break-words text-xs whitespace-pre-wrap">
+                {output.response}
+              </div>
             </div>
           )}
         </div>
@@ -60,8 +66,8 @@ function SpecialistCard({ output }: { output: CollaborationSpecialistOutput }) {
  * Collaboration status indicator shown during active collaboration.
  */
 export function CollaborationStatusBanner() {
-  const status = useAgentStore((s) => s.collaborationStatus);
-  const specialists = useAgentStore((s) => s.collaborationSpecialists);
+  const status = useFocusedCollaborationStatus();
+  const specialists = useFocusedCollaborationSpecialists();
 
   if (status === 'idle' || status === 'complete') return null;
 
@@ -91,7 +97,7 @@ export function CollaborationStatusBanner() {
  * Rendered below the assistant message that was produced by collaboration.
  */
 export function CollaborationDetails() {
-  const result = useAgentStore((s) => s.collaborationResult);
+  const result = useFocusedCollaborationResult();
   const [expanded, setExpanded] = useState(false);
 
   if (!result) return null;

--- a/apps/desktop/src/components/layout/ModelSelector.tsx
+++ b/apps/desktop/src/components/layout/ModelSelector.tsx
@@ -2,7 +2,8 @@ import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { ChevronDown, Check, Brain, Zap, Sparkles, Search } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { Popover, PopoverContent, PopoverTrigger } from '@sero/ui/components/ui/popover';
-import { useAgentStore, useFocusedAgent } from '@/stores/agent';
+import { useAgentStore } from '@/stores/agent';
+import { useFocusedAgent } from '@/stores/agent-selectors';
 import {
   THINKING_LEVELS,
   THINKING_LABELS,

--- a/apps/desktop/src/components/layout/SessionNode.tsx
+++ b/apps/desktop/src/components/layout/SessionNode.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Loader2, Pencil, Trash2 } from 'lucide-react';
 import { useSessionStore } from '@/stores/sessions';
-import { useStreamingSessionIds } from '@/stores/agent';
+import { useStreamingSessionIds } from '@/stores/agent-selectors';
 import { Button } from '@sero/ui/components/ui/button';
 import {
   Popover,

--- a/apps/desktop/src/components/layout/WorkspaceTree.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceTree.tsx
@@ -13,7 +13,7 @@ import {
 import { AnimatePresence, motion } from 'motion/react';
 import { useWorkspaceStore, useOpenWorkspaces } from '@/stores/workspace';
 import { useSessionStore, useSessionsByWorkspace } from '@/stores/sessions';
-import { useStreamingSessionIds } from '@/stores/agent';
+import { useStreamingSessionIds } from '@/stores/agent-selectors';
 import { useAppStore } from '@/stores/app';
 import { useWorkspaceContainer, type ContainerStatus } from '@/stores/container';
 import { Button } from '@sero/ui/components/ui/button';
@@ -440,5 +440,4 @@ function WorkspaceNode({
     </div>
   );
 }
-
 

--- a/apps/desktop/src/hooks/useChatPromptInput.ts
+++ b/apps/desktop/src/hooks/useChatPromptInput.ts
@@ -6,7 +6,7 @@
  */
 
 import { useState, useCallback, useMemo, useRef } from 'react';
-import { useFocusedCommands } from '@/stores/agent';
+import { useFocusedCommands } from '@/stores/agent-selectors';
 import { useWorkspaceFiles, fuzzyMatchFiles } from '@/hooks/useWorkspaceFiles';
 import type { SeroSlashCommandInfo, ChatAttachment } from '@/types/ipc';
 import type { PromptInputMessage } from '@sero/ui/components/ai-elements/prompt-input';

--- a/apps/desktop/src/hooks/useChatPromptInput.ts
+++ b/apps/desktop/src/hooks/useChatPromptInput.ts
@@ -22,6 +22,8 @@ interface UseChatPromptInputOptions {
   isStreaming: boolean;
   focusedWorkspaceId: string | null;
   sendPrompt: (sessionId: string, text: string, attachments?: ChatAttachment[]) => void;
+  sendCollaborationPrompt: (sessionId: string, text: string) => void;
+  collaborationMode: boolean;
   steerAgent: (sessionId: string, text: string) => void;
   messageQueue: { enqueue: (text: string, attachments?: ChatAttachment[]) => void };
   onLoginRequest: (mode: 'login' | 'logout') => void;
@@ -32,6 +34,8 @@ export function useChatPromptInput({
   isStreaming,
   focusedWorkspaceId,
   sendPrompt,
+  sendCollaborationPrompt,
+  collaborationMode,
   steerAgent,
   messageQueue,
   onLoginRequest,
@@ -166,9 +170,15 @@ export function useChatPromptInput({
       }
 
       modifierRef.current = false;
-      sendPrompt(sessionId, text, attachments);
+
+      // Route through 4-agent collaboration framework when enabled
+      if (collaborationMode && !attachments?.length) {
+        sendCollaborationPrompt(sessionId, text);
+      } else {
+        sendPrompt(sessionId, text, attachments);
+      }
     },
-    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, steerAgent, messageQueue, onLoginRequest],
+    [input, sessionId, slashMenuOpen, fileMenuOpen, isStreaming, sendPrompt, sendCollaborationPrompt, collaborationMode, steerAgent, messageQueue, onLoginRequest],
   );
 
   return {

--- a/apps/desktop/src/stores/agent-collaboration.ts
+++ b/apps/desktop/src/stores/agent-collaboration.ts
@@ -131,7 +131,7 @@ export function applyCollaborationEvent(
               agentName: event.agentName,
               response: event.response,
               error: event.error,
-              durationMs: 0,
+              durationMs: event.durationMs,
             },
           ],
         },
@@ -155,7 +155,15 @@ export function applyCollaborationEvent(
           status: 'error',
         },
       };
-  }
 
-  return collaborations;
+    case 'collab_specialist_start':
+      // No state change needed — specialist progress is tracked via collab_specialist_end.
+      return collaborations;
+
+    default: {
+      // Exhaustive check — ensures all event types are handled at compile time.
+      const _exhaustive: never = event;
+      return collaborations;
+    }
+  }
 }

--- a/apps/desktop/src/stores/agent-collaboration.ts
+++ b/apps/desktop/src/stores/agent-collaboration.ts
@@ -1,0 +1,161 @@
+import type {
+  CollaborationEvent,
+  CollaborationResult,
+  CollaborationSpecialistOutput,
+  CollaborationStatus,
+} from '@/types/collaboration';
+
+export interface CollaborationSessionState {
+  mode: boolean;
+  status: CollaborationStatus;
+  result: CollaborationResult | null;
+  specialists: CollaborationSpecialistOutput[];
+}
+
+export type CollaborationSessionMap = Record<string, CollaborationSessionState>;
+
+export function createCollaborationSessionState(): CollaborationSessionState {
+  return {
+    mode: false,
+    status: 'idle',
+    result: null,
+    specialists: [],
+  };
+}
+
+function getSessionState(
+  collaborations: CollaborationSessionMap,
+  sessionId: string,
+): CollaborationSessionState {
+  return collaborations[sessionId] ?? createCollaborationSessionState();
+}
+
+export function resetCollaborationSession(
+  collaborations: CollaborationSessionMap,
+  sessionId: string,
+): CollaborationSessionMap {
+  return {
+    ...collaborations,
+    [sessionId]: createCollaborationSessionState(),
+  };
+}
+
+export function removeCollaborationSession(
+  collaborations: CollaborationSessionMap,
+  sessionId: string,
+): CollaborationSessionMap {
+  const { [sessionId]: _removed, ...rest } = collaborations;
+  return rest;
+}
+
+export function toggleCollaborationModeForSession(
+  collaborations: CollaborationSessionMap,
+  sessionId: string,
+): CollaborationSessionMap {
+  const current = getSessionState(collaborations, sessionId);
+  return {
+    ...collaborations,
+    [sessionId]: {
+      ...current,
+      mode: !current.mode,
+    },
+  };
+}
+
+export function startCollaborationForSession(
+  collaborations: CollaborationSessionMap,
+  sessionId: string,
+): CollaborationSessionMap {
+  const current = getSessionState(collaborations, sessionId);
+  return {
+    ...collaborations,
+    [sessionId]: {
+      ...current,
+      status: 'research',
+      result: null,
+      specialists: [],
+    },
+  };
+}
+
+export function setCollaborationErrorForSession(
+  collaborations: CollaborationSessionMap,
+  sessionId: string,
+): CollaborationSessionMap {
+  const current = getSessionState(collaborations, sessionId);
+  return {
+    ...collaborations,
+    [sessionId]: {
+      ...current,
+      status: 'error',
+    },
+  };
+}
+
+export function applyCollaborationEvent(
+  collaborations: CollaborationSessionMap,
+  event: CollaborationEvent,
+): CollaborationSessionMap {
+  const current = getSessionState(collaborations, event.sessionId);
+
+  switch (event.type) {
+    case 'collab_start':
+      return {
+        ...collaborations,
+        [event.sessionId]: {
+          ...current,
+          status: 'research',
+          result: null,
+          specialists: [],
+        },
+      };
+
+    case 'collab_phase':
+      return {
+        ...collaborations,
+        [event.sessionId]: {
+          ...current,
+          status: event.phase,
+        },
+      };
+
+    case 'collab_specialist_end':
+      return {
+        ...collaborations,
+        [event.sessionId]: {
+          ...current,
+          specialists: [
+            ...current.specialists,
+            {
+              role: event.role,
+              agentName: event.agentName,
+              response: event.response,
+              error: event.error,
+              durationMs: 0,
+            },
+          ],
+        },
+      };
+
+    case 'collab_end':
+      return {
+        ...collaborations,
+        [event.sessionId]: {
+          ...current,
+          status: 'complete',
+          result: event.result,
+        },
+      };
+
+    case 'collab_error':
+      return {
+        ...collaborations,
+        [event.sessionId]: {
+          ...current,
+          status: 'error',
+        },
+      };
+  }
+
+  return collaborations;
+}

--- a/apps/desktop/src/stores/agent-selectors.ts
+++ b/apps/desktop/src/stores/agent-selectors.ts
@@ -1,0 +1,59 @@
+import type { SeroSlashCommandInfo } from '@/types/ipc';
+import { useAgentStore } from '@/stores/agent';
+import type { AgentInstance } from '@/stores/agent-types';
+
+const EMPTY_SPECIALISTS: [] = [];
+
+export function useFocusedAgent(): AgentInstance | null {
+  const agents = useAgentStore((s) => s.agents);
+  const focusedId = useAgentStore((s) => s.focusedSessionId);
+  if (!focusedId) return null;
+  return agents[focusedId] ?? null;
+}
+
+export function useStreamingSessionIds(): string[] {
+  const agents = useAgentStore((s) => s.agents);
+  return Object.values(agents)
+    .filter((a) => a.isStreaming)
+    .map((a) => a.sessionId);
+}
+
+export function useActiveAgentCount(): number {
+  const agents = useAgentStore((s) => s.agents);
+  return Object.keys(agents).length;
+}
+
+export function useIsSessionActive(sessionId: string): boolean {
+  return useAgentStore((s) => !!s.agents[sessionId]);
+}
+
+export function useFocusedCommands(): SeroSlashCommandInfo[] {
+  const agents = useAgentStore((s) => s.agents);
+  const focusedId = useAgentStore((s) => s.focusedSessionId);
+  if (!focusedId) return [];
+  return agents[focusedId]?.commands ?? [];
+}
+
+export function useFocusedCollaborationMode(): boolean {
+  return useAgentStore((s) =>
+    s.focusedSessionId ? (s.collaborations[s.focusedSessionId]?.mode ?? false) : false,
+  );
+}
+
+export function useFocusedCollaborationStatus() {
+  return useAgentStore((s) =>
+    s.focusedSessionId ? (s.collaborations[s.focusedSessionId]?.status ?? 'idle') : 'idle',
+  );
+}
+
+export function useFocusedCollaborationResult() {
+  return useAgentStore((s) =>
+    s.focusedSessionId ? (s.collaborations[s.focusedSessionId]?.result ?? null) : null,
+  );
+}
+
+export function useFocusedCollaborationSpecialists() {
+  return useAgentStore((s) =>
+    s.focusedSessionId ? (s.collaborations[s.focusedSessionId]?.specialists ?? EMPTY_SPECIALISTS) : EMPTY_SPECIALISTS,
+  );
+}

--- a/apps/desktop/src/stores/agent-types.ts
+++ b/apps/desktop/src/stores/agent-types.ts
@@ -1,0 +1,64 @@
+import type {
+  ChatAttachment,
+  ChatMessage,
+  SessionModelState,
+  SeroSlashCommandInfo,
+} from '@/types/ipc';
+import type { CollaborationSessionMap } from '@/stores/agent-collaboration';
+
+/** State for a single agent session in the pool. */
+export interface AgentInstance {
+  sessionId: string;
+  sessionPath: string;
+  workspaceId: string;
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  error: string | null;
+  /** Available slash commands for this session (fetched on open). */
+  commands: SeroSlashCommandInfo[];
+  /** Current model + thinking level state. */
+  modelState: SessionModelState | null;
+}
+
+export interface AgentState {
+  /** All active agent instances, keyed by session ID. */
+  agents: Record<string, AgentInstance>;
+  /** Which session is currently shown in the ChatPanel. */
+  focusedSessionId: string | null;
+  /** Whether to display thinking/reasoning blocks in the chat. */
+  showThinkingBlocks: boolean;
+  /** Collaboration UI state, keyed by session ID. */
+  collaborations: CollaborationSessionMap;
+  /** Open a session — creates an AgentSession in the main-process pool. */
+  openSession: (sessionId: string, sessionPath: string, workspaceId: string) => Promise<void>;
+  /** Close a session — disposes its AgentSession. */
+  closeSession: (sessionId: string) => Promise<void>;
+  /** Send a prompt to a specific session, optionally with file attachments. */
+  sendPrompt: (sessionId: string, text: string, attachments?: ChatAttachment[]) => Promise<void>;
+  /** Steer the agent mid-stream (interrupt after current tool, skip remaining). */
+  steerAgent: (sessionId: string, text: string) => Promise<void>;
+  /** Abort a specific session. */
+  abort: (sessionId: string) => Promise<void>;
+  /** Focus a session in the ChatPanel. */
+  focusSession: (sessionId: string) => void;
+  /** Clear focus (no session shown in the ChatPanel). */
+  clearFocus: () => void;
+  /** Reload resources (skills, prompts, extensions) for a session. */
+  reloadResources: (sessionId: string) => Promise<void>;
+  /** Set the model for a session. */
+  setModel: (sessionId: string, provider: string, modelId: string) => Promise<void>;
+  /** Set thinking level for a session. */
+  setThinkingLevel: (sessionId: string, level: string) => Promise<void>;
+  /** Fetch model state for a session. */
+  fetchModelState: (sessionId: string) => Promise<void>;
+  /** Toggle visibility of thinking/reasoning blocks. */
+  toggleThinkingBlocks: () => void;
+  /** Toggle 4-agent collaboration mode on/off for the focused session. */
+  toggleCollaborationMode: () => void;
+  /** Send a prompt through the collaboration framework. */
+  sendCollaborationPrompt: (sessionId: string, text: string) => Promise<void>;
+  /** Subscribe to main-process events. Returns cleanup function. */
+  initEventListener: () => () => void;
+  /** Subscribe to collaboration events. Returns cleanup function. */
+  initCollaborationListener: () => () => void;
+}

--- a/apps/desktop/src/stores/agent-utils.ts
+++ b/apps/desktop/src/stores/agent-utils.ts
@@ -1,0 +1,19 @@
+import type { ChatAssistantMessage } from '@/types/ipc';
+import type { AgentInstance } from '@/stores/agent-types';
+
+export function patchAssistant(
+  agents: Record<string, AgentInstance>,
+  sessionId: string,
+  messageId: string,
+  patch: (message: ChatAssistantMessage) => ChatAssistantMessage,
+) {
+  return {
+    ...agents,
+    [sessionId]: {
+      ...agents[sessionId],
+      messages: agents[sessionId].messages.map((message) =>
+        message.type === 'assistant' && message.id === messageId ? patch(message) : message,
+      ),
+    },
+  };
+}

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -6,127 +6,39 @@ import type {
   AgentStreamEvent,
   SeroSlashCommandInfo,
   SessionModelState,
-  ChatAssistantMessage,
 } from '@/types/ipc';
-import type {
-  CollaborationEvent,
-  CollaborationStatus,
-  CollaborationResult,
-  CollaborationSpecialistOutput,
-} from '@/types/collaboration';
+import type { CollaborationEvent } from '@/types/collaboration';
 import { useSessionStore } from '@/stores/sessions';
 import { useContainerStore } from '@/stores/container';
-
-// ── Helpers ────────────────────────────────────────────────────
-
-/** Patch a single field on an assistant message by ID. */
-function patchAssistant(
-  agents: Record<string, AgentInstance>,
-  sid: string,
-  messageId: string,
-  patch: (msg: ChatAssistantMessage) => ChatAssistantMessage,
-) {
-  return {
-    ...agents,
-    [sid]: {
-      ...agents[sid],
-      messages: agents[sid].messages.map((m) =>
-        m.type === 'assistant' && m.id === messageId ? patch(m) : m,
-      ),
-    },
-  };
-}
-
-// ── Types ──────────────────────────────────────────────────────
-
-/** State for a single agent session in the pool. */
-export interface AgentInstance {
-  sessionId: string;
-  sessionPath: string;
-  workspaceId: string;
-  messages: ChatMessage[];
-  isStreaming: boolean;
-  error: string | null;
-  /** Available slash commands for this session (fetched on open). */
-  commands: SeroSlashCommandInfo[];
-  /** Current model + thinking level state. */
-  modelState: SessionModelState | null;
-}
-
-interface AgentState {
-  /** All active agent instances, keyed by session ID. */
-  agents: Record<string, AgentInstance>;
-  /** Which session is currently shown in the ChatPanel. */
-  focusedSessionId: string | null;
-  /** Whether to display thinking/reasoning blocks in the chat. */
-  showThinkingBlocks: boolean;
-  /** Whether 4-agent collaboration mode is enabled. */
-  collaborationMode: boolean;
-  /** Current collaboration status for the focused session. */
-  collaborationStatus: CollaborationStatus;
-  /** Last collaboration result (specialist outputs for expandable display). */
-  collaborationResult: CollaborationResult | null;
-  /** Live specialist outputs as they complete (before final result). */
-  collaborationSpecialists: CollaborationSpecialistOutput[];
-
-  // ── Actions ────────────────────────────────────────────────
-
-  /** Open a session — creates an AgentSession in the main-process pool. */
-  openSession: (sessionId: string, sessionPath: string, workspaceId: string) => Promise<void>;
-  /** Close a session — disposes its AgentSession. */
-  closeSession: (sessionId: string) => Promise<void>;
-  /** Send a prompt to a specific session, optionally with file attachments. */
-  sendPrompt: (sessionId: string, text: string, attachments?: ChatAttachment[]) => Promise<void>;
-  /** Steer the agent mid-stream (interrupt after current tool, skip remaining). */
-  steerAgent: (sessionId: string, text: string) => Promise<void>;
-  /** Abort a specific session. */
-  abort: (sessionId: string) => Promise<void>;
-  /** Focus a session in the ChatPanel. */
-  focusSession: (sessionId: string) => void;
-  /** Clear focus (no session shown in ChatPanel). */
-  clearFocus: () => void;
-  /** Reload resources (skills, prompts, extensions) for a session. */
-  reloadResources: (sessionId: string) => Promise<void>;
-  /** Set the model for a session. */
-  setModel: (sessionId: string, provider: string, modelId: string) => Promise<void>;
-  /** Set thinking level for a session. */
-  setThinkingLevel: (sessionId: string, level: string) => Promise<void>;
-  /** Fetch model state for a session. */
-  fetchModelState: (sessionId: string) => Promise<void>;
-  /** Toggle visibility of thinking/reasoning blocks. */
-  toggleThinkingBlocks: () => void;
-  /** Toggle 4-agent collaboration mode on/off. */
-  toggleCollaborationMode: () => void;
-  /** Send a prompt through the collaboration framework. */
-  sendCollaborationPrompt: (sessionId: string, text: string) => Promise<void>;
-
-  /** Subscribe to main-process events. Returns cleanup function. */
-  initEventListener: () => () => void;
-  /** Subscribe to collaboration events. Returns cleanup function. */
-  initCollaborationListener: () => () => void;
-}
-
-// ── Store ──────────────────────────────────────────────────────
+import {
+  applyCollaborationEvent,
+  removeCollaborationSession,
+  resetCollaborationSession,
+  setCollaborationErrorForSession,
+  startCollaborationForSession,
+  toggleCollaborationModeForSession,
+} from '@/stores/agent-collaboration';
+import type { AgentState } from '@/stores/agent-types';
+import { patchAssistant } from '@/stores/agent-utils';
 
 export const useAgentStore = create<AgentState>((set, get) => ({
   agents: {},
   focusedSessionId: null,
   showThinkingBlocks: false,
-  collaborationMode: false,
-  collaborationStatus: 'idle',
-  collaborationResult: null,
-  collaborationSpecialists: [],
+  collaborations: {},
 
   openSession: async (sessionId, sessionPath, workspaceId) => {
-    // Reset collaboration mode when switching sessions
-    set({ collaborationMode: false, collaborationStatus: 'idle', collaborationResult: null, collaborationSpecialists: [] });
+    // Reset collaboration mode when switching sessions.
+    set((s) => ({
+      focusedSessionId: sessionId,
+      collaborations: resetCollaborationSession(s.collaborations, sessionId),
+    }));
 
-    // If already fully initialized in pool, just focus it.
+    // If already fully initialized in the pool, just focus it.
     // Check for `sessionId` field — partial entries created by events
     // (e.g. when a federated app calls agent.open via IPC directly)
     // won't have it set and need to be repaired.
     if (get().agents[sessionId]?.sessionId) {
-      set({ focusedSessionId: sessionId });
       return;
     }
 
@@ -148,14 +60,13 @@ export const useAgentStore = create<AgentState>((set, get) => ({
             modelState: partial?.modelState ?? null,
           },
         },
-        focusedSessionId: sessionId,
       };
     });
 
     try {
       const history = await window.sero.agent.open(sessionId, sessionPath, workspaceId);
 
-      // Fetch available slash commands for this session (non-blocking on failure)
+      // Fetch available slash commands for this session (non-blocking on failure).
       let commands: SeroSlashCommandInfo[] = [];
       try {
         commands = await window.sero.agent.getCommands(sessionId);
@@ -163,14 +74,13 @@ export const useAgentStore = create<AgentState>((set, get) => ({
         console.warn('[agent] Failed to fetch commands:', cmdErr);
       }
 
-      // Fetch initial model state (non-blocking)
+      // Fetch initial model state (non-blocking).
       let modelState: SessionModelState | null = null;
       try {
         modelState = await window.sero.agent.getModelState(sessionId);
       } catch (err) {
         console.warn('[agent] Failed to fetch model state:', err);
       }
-
       set((s) => ({
         agents: {
           ...s.agents,
@@ -190,12 +100,12 @@ export const useAgentStore = create<AgentState>((set, get) => ({
         return {
           agents: rest,
           focusedSessionId: s.focusedSessionId === sessionId ? null : s.focusedSessionId,
-          // Note: error is stored per-agent, but since we're removing it, we just log
+          // Note: error is stored per-agent, but since we're removing it, we just log.
+          collaborations: removeCollaborationSession(s.collaborations, sessionId),
         };
       });
     }
   },
-
   closeSession: async (sessionId) => {
     try {
       await window.sero.agent.close(sessionId);
@@ -207,10 +117,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       return {
         agents: rest,
         focusedSessionId: s.focusedSessionId === sessionId ? null : s.focusedSessionId,
+        collaborations: removeCollaborationSession(s.collaborations, sessionId),
       };
     });
   },
-
   sendPrompt: async (sessionId, text, attachments) => {
     const agent = get().agents[sessionId];
     if (!agent) return;
@@ -253,7 +163,6 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       }));
     }
   },
-
   steerAgent: async (sessionId, text) => {
     const agent = get().agents[sessionId];
     if (!agent) return;
@@ -285,7 +194,6 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       }));
     }
   },
-
   abort: async (sessionId) => {
     try {
       await window.sero.agent.abort(sessionId);
@@ -293,11 +201,12 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       console.error('[agent] abort failed:', err);
     }
   },
-
-  focusSession: (sessionId) => set({ focusedSessionId: sessionId }),
-
+  focusSession: (sessionId) =>
+    set((s) => ({
+      focusedSessionId: sessionId,
+      collaborations: resetCollaborationSession(s.collaborations, sessionId),
+    })),
   clearFocus: () => set({ focusedSessionId: null }),
-
   reloadResources: async (sessionId) => {
     try {
       const commands = await window.sero.agent.reloadResources(sessionId);
@@ -315,7 +224,6 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       console.error('[agent] reloadResources failed:', err);
     }
   },
-
   setModel: async (sessionId, provider, modelId) => {
     try {
       const state = await window.sero.agent.setModel(sessionId, provider, modelId);
@@ -328,7 +236,6 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       console.error('[agent] setModel failed:', err);
     }
   },
-
   setThinkingLevel: async (sessionId, level) => {
     try {
       const state = await window.sero.agent.setThinkingLevel(sessionId, level);
@@ -357,25 +264,23 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   toggleThinkingBlocks: () => set((s) => ({ showThinkingBlocks: !s.showThinkingBlocks })),
 
-  toggleCollaborationMode: () => set((s) => ({ collaborationMode: !s.collaborationMode })),
+  toggleCollaborationMode: () =>
+    set((s) => {
+      if (!s.focusedSessionId) return s;
+      return {
+        collaborations: toggleCollaborationModeForSession(s.collaborations, s.focusedSessionId),
+      };
+    }),
 
   sendCollaborationPrompt: async (sessionId, text) => {
     const agent = get().agents[sessionId];
     if (!agent) return;
 
-    // Reset collaboration state
-    set({
-      collaborationStatus: 'research',
-      collaborationResult: null,
-      collaborationSpecialists: [],
-    });
-
-    // Optimistically add the user message so it appears immediately.
-    // The main session will also emit a message_start for the user message
-    // but those are skipped in the event handler (same as sendPrompt).
+    // Reset collaboration state for this session before the new run starts.
     const userMessageId = `usr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const userMsg: ChatMessage = { type: 'user', id: userMessageId, text };
     set((s) => ({
+      collaborations: startCollaborationForSession(s.collaborations, sessionId),
       agents: {
         ...s.agents,
         [sessionId]: {
@@ -396,13 +301,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       await window.sero.collaboration.prompt(
         sessionId, agent.workspaceId, text, userMessageId,
       );
-
-      // The collaboration result is set via the collab_end event listener,
-      // and isStreaming is cleared by the agent_end event from the main session.
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Collaboration failed';
       set((s) => ({
-        collaborationStatus: 'error',
+        collaborations: setCollaborationErrorForSession(s.collaborations, sessionId),
         agents: {
           ...s.agents,
           [sessionId]: {
@@ -420,7 +322,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       const { agents } = get();
       const sid = event.sessionId;
 
-      // Ignore events for sessions we don't track (already closed)
+      // Ignore events for sessions we don't track (already closed).
       if (!agents[sid] && event.type !== 'agent_start' && event.type !== 'message_start') {
         return;
       }
@@ -439,7 +341,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
           set((s) => {
             const agent = s.agents[sid];
             if (!agent) return s;
-            // Mark any in-flight tools as cancelled (they'll never receive a tool_end)
+            // Mark any in-flight tools as cancelled (they'll never receive a tool_end).
             const messages = agent.messages.map((m) =>
               m.type === 'tool' && (m.state === 'pending' || m.state === 'running')
                 ? { ...m, state: 'cancelled' as const }
@@ -561,7 +463,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
           }));
           break;
 
-        // Container lifecycle events — update container store
+        // Container lifecycle events — update container store.
         case 'container_starting':
           useContainerStore.getState().setStarting(event.workspaceId);
           break;
@@ -578,72 +480,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   },
 
   initCollaborationListener: () => {
-    const unsubscribe = window.sero.collaboration.onEvent((event: CollaborationEvent) => {
-      switch (event.type) {
-        case 'collab_start':
-          set({ collaborationStatus: 'research', collaborationSpecialists: [], collaborationResult: null });
-          break;
-
-        case 'collab_phase':
-          set({ collaborationStatus: event.phase });
-          break;
-
-        case 'collab_specialist_end':
-          set((s) => ({
-            collaborationSpecialists: [
-              ...s.collaborationSpecialists,
-              { role: event.role, agentName: event.agentName, response: event.response, error: event.error, durationMs: 0 },
-            ],
-          }));
-          break;
-
-        case 'collab_end':
-          set({ collaborationStatus: 'complete', collaborationResult: event.result });
-          break;
-
-        case 'collab_error':
-          set({ collaborationStatus: 'error' });
-          break;
-      }
+    return window.sero.collaboration.onEvent((event: CollaborationEvent) => {
+      set((s) => ({
+        collaborations: applyCollaborationEvent(s.collaborations, event),
+      }));
     });
-
-    return unsubscribe;
   },
 }));
-
-// ── Selectors ──────────────────────────────────────────────────
-
-/** The focused agent instance (shown in ChatPanel), or null. */
-export function useFocusedAgent(): AgentInstance | null {
-  const agents = useAgentStore((s) => s.agents);
-  const focusedId = useAgentStore((s) => s.focusedSessionId);
-  if (!focusedId) return null;
-  return agents[focusedId] ?? null;
-}
-
-/** IDs of sessions currently streaming (for sidebar active indicators). */
-export function useStreamingSessionIds(): string[] {
-  const agents = useAgentStore((s) => s.agents);
-  return Object.values(agents)
-    .filter((a) => a.isStreaming)
-    .map((a) => a.sessionId);
-}
-
-/** Count of active agent sessions in the pool. */
-export function useActiveAgentCount(): number {
-  const agents = useAgentStore((s) => s.agents);
-  return Object.keys(agents).length;
-}
-
-/** Check if a specific session has an active agent. */
-export function useIsSessionActive(sessionId: string): boolean {
-  return useAgentStore((s) => !!s.agents[sessionId]);
-}
-
-/** Slash commands available for the focused session. */
-export function useFocusedCommands(): SeroSlashCommandInfo[] {
-  const agents = useAgentStore((s) => s.agents);
-  const focusedId = useAgentStore((s) => s.focusedSessionId);
-  if (!focusedId) return [];
-  return agents[focusedId]?.commands ?? [];
-}

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -8,6 +8,12 @@ import type {
   SessionModelState,
   ChatAssistantMessage,
 } from '@/types/ipc';
+import type {
+  CollaborationEvent,
+  CollaborationStatus,
+  CollaborationResult,
+  CollaborationSpecialistOutput,
+} from '@/types/collaboration';
 import { useSessionStore } from '@/stores/sessions';
 import { useContainerStore } from '@/stores/container';
 
@@ -54,6 +60,14 @@ interface AgentState {
   focusedSessionId: string | null;
   /** Whether to display thinking/reasoning blocks in the chat. */
   showThinkingBlocks: boolean;
+  /** Whether 4-agent collaboration mode is enabled. */
+  collaborationMode: boolean;
+  /** Current collaboration status for the focused session. */
+  collaborationStatus: CollaborationStatus;
+  /** Last collaboration result (specialist outputs for expandable display). */
+  collaborationResult: CollaborationResult | null;
+  /** Live specialist outputs as they complete (before final result). */
+  collaborationSpecialists: CollaborationSpecialistOutput[];
 
   // ── Actions ────────────────────────────────────────────────
 
@@ -81,9 +95,15 @@ interface AgentState {
   fetchModelState: (sessionId: string) => Promise<void>;
   /** Toggle visibility of thinking/reasoning blocks. */
   toggleThinkingBlocks: () => void;
+  /** Toggle 4-agent collaboration mode on/off. */
+  toggleCollaborationMode: () => void;
+  /** Send a prompt through the collaboration framework. */
+  sendCollaborationPrompt: (sessionId: string, text: string) => Promise<void>;
 
   /** Subscribe to main-process events. Returns cleanup function. */
   initEventListener: () => () => void;
+  /** Subscribe to collaboration events. Returns cleanup function. */
+  initCollaborationListener: () => () => void;
 }
 
 // ── Store ──────────────────────────────────────────────────────
@@ -92,6 +112,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   agents: {},
   focusedSessionId: null,
   showThinkingBlocks: false,
+  collaborationMode: false,
+  collaborationStatus: 'idle',
+  collaborationResult: null,
+  collaborationSpecialists: [],
 
   openSession: async (sessionId, sessionPath, workspaceId) => {
     // If already fully initialized in pool, just focus it.
@@ -330,6 +354,74 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   toggleThinkingBlocks: () => set((s) => ({ showThinkingBlocks: !s.showThinkingBlocks })),
 
+  toggleCollaborationMode: () => set((s) => ({ collaborationMode: !s.collaborationMode })),
+
+  sendCollaborationPrompt: async (sessionId, text) => {
+    const agent = get().agents[sessionId];
+    if (!agent) return;
+
+    // Reset collaboration state
+    set({
+      collaborationStatus: 'specialists',
+      collaborationResult: null,
+      collaborationSpecialists: [],
+    });
+
+    // Optimistically add the user message
+    const userMessageId = `usr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const userMsg: ChatMessage = { type: 'user', id: userMessageId, text };
+    set((s) => ({
+      agents: {
+        ...s.agents,
+        [sessionId]: {
+          ...s.agents[sessionId],
+          error: null,
+          isStreaming: true,
+          messages: [...s.agents[sessionId].messages, userMsg],
+        },
+      },
+    }));
+
+    try {
+      const result = await window.sero.collaboration.prompt(sessionId, agent.workspaceId, text);
+
+      // Add the synthesized response as an assistant message
+      const collabResult = result as CollaborationResult;
+      const assistantMsg: ChatMessage = {
+        type: 'assistant',
+        id: `collab-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        text: collabResult.finalResponse,
+        isStreaming: false,
+      };
+
+      set((s) => ({
+        collaborationStatus: 'complete',
+        collaborationResult: collabResult,
+        agents: {
+          ...s.agents,
+          [sessionId]: {
+            ...s.agents[sessionId],
+            isStreaming: false,
+            messages: [...s.agents[sessionId].messages, assistantMsg],
+          },
+        },
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Collaboration failed';
+      set((s) => ({
+        collaborationStatus: 'error',
+        agents: {
+          ...s.agents,
+          [sessionId]: {
+            ...s.agents[sessionId],
+            error: message,
+            isStreaming: false,
+          },
+        },
+      }));
+    }
+  },
+
   initEventListener: () => {
     const unsubscribe = window.sero.agent.onEvent((event: AgentStreamEvent) => {
       const { agents } = get();
@@ -485,6 +577,39 @@ export const useAgentStore = create<AgentState>((set, get) => ({
           break;
         case 'container_error':
           useContainerStore.getState().setError(event.workspaceId, event.error);
+          break;
+      }
+    });
+
+    return unsubscribe;
+  },
+
+  initCollaborationListener: () => {
+    const unsubscribe = window.sero.collaboration.onEvent((event: CollaborationEvent) => {
+      switch (event.type) {
+        case 'collab_start':
+          set({ collaborationStatus: 'specialists', collaborationSpecialists: [], collaborationResult: null });
+          break;
+
+        case 'collab_phase':
+          set({ collaborationStatus: event.phase === 'synthesis' ? 'synthesis' : 'specialists' });
+          break;
+
+        case 'collab_specialist_end':
+          set((s) => ({
+            collaborationSpecialists: [
+              ...s.collaborationSpecialists,
+              { role: event.role, agentName: event.agentName, response: event.response, error: event.error, durationMs: 0 },
+            ],
+          }));
+          break;
+
+        case 'collab_end':
+          set({ collaborationStatus: 'complete', collaborationResult: event.result });
+          break;
+
+        case 'collab_error':
+          set({ collaborationStatus: 'error' });
           break;
       }
     });

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -362,7 +362,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
     // Reset collaboration state
     set({
-      collaborationStatus: 'specialists',
+      collaborationStatus: 'research',
       collaborationResult: null,
       collaborationSpecialists: [],
     });
@@ -578,11 +578,11 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     const unsubscribe = window.sero.collaboration.onEvent((event: CollaborationEvent) => {
       switch (event.type) {
         case 'collab_start':
-          set({ collaborationStatus: 'specialists', collaborationSpecialists: [], collaborationResult: null });
+          set({ collaborationStatus: 'research', collaborationSpecialists: [], collaborationResult: null });
           break;
 
         case 'collab_phase':
-          set({ collaborationStatus: event.phase === 'synthesis' ? 'synthesis' : 'specialists' });
+          set({ collaborationStatus: event.phase });
           break;
 
         case 'collab_specialist_end':

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -118,6 +118,9 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   collaborationSpecialists: [],
 
   openSession: async (sessionId, sessionPath, workspaceId) => {
+    // Reset collaboration mode when switching sessions
+    set({ collaborationMode: false, collaborationStatus: 'idle', collaborationResult: null, collaborationSpecialists: [] });
+
     // If already fully initialized in pool, just focus it.
     // Check for `sessionId` field — partial entries created by events
     // (e.g. when a federated app calls agent.open via IPC directly)

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -106,6 +106,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       });
     }
   },
+
   closeSession: async (sessionId) => {
     try {
       await window.sero.agent.close(sessionId);
@@ -121,6 +122,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       };
     });
   },
+
   sendPrompt: async (sessionId, text, attachments) => {
     const agent = get().agents[sessionId];
     if (!agent) return;
@@ -163,6 +165,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       }));
     }
   },
+
   steerAgent: async (sessionId, text) => {
     const agent = get().agents[sessionId];
     if (!agent) return;
@@ -194,6 +197,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       }));
     }
   },
+
   abort: async (sessionId) => {
     try {
       await window.sero.agent.abort(sessionId);
@@ -201,12 +205,15 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       console.error('[agent] abort failed:', err);
     }
   },
+
   focusSession: (sessionId) =>
     set((s) => ({
       focusedSessionId: sessionId,
       collaborations: resetCollaborationSession(s.collaborations, sessionId),
     })),
+
   clearFocus: () => set({ focusedSessionId: null }),
+
   reloadResources: async (sessionId) => {
     try {
       const commands = await window.sero.agent.reloadResources(sessionId);
@@ -224,6 +231,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       console.error('[agent] reloadResources failed:', err);
     }
   },
+
   setModel: async (sessionId, provider, modelId) => {
     try {
       const state = await window.sero.agent.setModel(sessionId, provider, modelId);
@@ -236,6 +244,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       console.error('[agent] setModel failed:', err);
     }
   },
+
   setThinkingLevel: async (sessionId, level) => {
     try {
       const state = await window.sero.agent.setThinkingLevel(sessionId, level);
@@ -298,9 +307,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       // back via the normal agent event channel (message_start, text_delta,
       // message_end), so the conversation is fully persisted and follow-ups
       // have context. We do NOT manually add the assistant message here.
-      await window.sero.collaboration.prompt(
-        sessionId, agent.workspaceId, text, userMessageId,
-      );
+      await window.sero.collaboration.prompt(sessionId, agent.workspaceId, text);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Collaboration failed';
       set((s) => ({

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -367,7 +367,9 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       collaborationSpecialists: [],
     });
 
-    // Optimistically add the user message
+    // Optimistically add the user message so it appears immediately.
+    // The main session will also emit a message_start for the user message
+    // but those are skipped in the event handler (same as sendPrompt).
     const userMessageId = `usr-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const userMsg: ChatMessage = { type: 'user', id: userMessageId, text };
     set((s) => ({
@@ -383,29 +385,17 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     }));
 
     try {
-      const result = await window.sero.collaboration.prompt(sessionId, agent.workspaceId, text);
+      // This runs the 4-agent collaboration AND then feeds the synthesis
+      // through the main agent session. The main session's response streams
+      // back via the normal agent event channel (message_start, text_delta,
+      // message_end), so the conversation is fully persisted and follow-ups
+      // have context. We do NOT manually add the assistant message here.
+      await window.sero.collaboration.prompt(
+        sessionId, agent.workspaceId, text, userMessageId,
+      );
 
-      // Add the synthesized response as an assistant message
-      const collabResult = result as CollaborationResult;
-      const assistantMsg: ChatMessage = {
-        type: 'assistant',
-        id: `collab-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        text: collabResult.finalResponse,
-        isStreaming: false,
-      };
-
-      set((s) => ({
-        collaborationStatus: 'complete',
-        collaborationResult: collabResult,
-        agents: {
-          ...s.agents,
-          [sessionId]: {
-            ...s.agents[sessionId],
-            isStreaming: false,
-            messages: [...s.agents[sessionId].messages, assistantMsg],
-          },
-        },
-      }));
+      // The collaboration result is set via the collab_end event listener,
+      // and isStreaming is cleared by the agent_end event from the main session.
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Collaboration failed';
       set((s) => ({

--- a/apps/desktop/src/stores/subagent-constants.ts
+++ b/apps/desktop/src/stores/subagent-constants.ts
@@ -1,0 +1,2 @@
+/** Terminal statuses that count as "done" for subagent entries. */
+export const TERMINAL_STATUSES = new Set(['completed', 'failed', 'aborted', 'timed_out']);

--- a/apps/desktop/src/stores/subagent.ts
+++ b/apps/desktop/src/stores/subagent.ts
@@ -14,6 +14,9 @@ import type {
 
 // ── Store ────────────────────────────────────────────────────
 
+/** Terminal statuses that count as "done". */
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'aborted', 'timed_out']);
+
 interface SubagentState {
   /** All entries keyed by run ID. */
   entries: Record<string, SubagentEntry>;
@@ -27,6 +30,9 @@ interface SubagentState {
 
   /** Abort a specific subagent. */
   abort(subagentId: string): Promise<void>;
+
+  /** Remove all finished entries for a workspace. */
+  clearCompleted(workspaceId: string): void;
 
   /** Initialize IPC event listeners. Returns cleanup function. */
   initListeners(): () => void;
@@ -54,6 +60,19 @@ export const useSubagentStore = create<SubagentState>((set, get) => ({
 
   async abort(subagentId: string) {
     await window.sero.subagent.abort(subagentId);
+  },
+
+  clearCompleted(workspaceId: string) {
+    set((state) => {
+      const next: Record<string, SubagentEntry> = {};
+      for (const [id, entry] of Object.entries(state.entries)) {
+        if (entry.workspaceId === workspaceId && TERMINAL_STATUSES.has(entry.status)) {
+          continue; // drop it
+        }
+        next[id] = entry;
+      }
+      return { entries: next };
+    });
   },
 
   initListeners() {

--- a/apps/desktop/src/stores/subagent.ts
+++ b/apps/desktop/src/stores/subagent.ts
@@ -11,11 +11,9 @@ import type {
   SubagentEvent,
   SubagentAgentSummary,
 } from '@/types/ipc';
+import { TERMINAL_STATUSES } from './subagent-constants';
 
 // ── Store ────────────────────────────────────────────────────
-
-/** Terminal statuses that count as "done". */
-const TERMINAL_STATUSES = new Set(['completed', 'failed', 'aborted', 'timed_out']);
 
 interface SubagentState {
   /** All entries keyed by run ID. */

--- a/apps/desktop/src/types/collaboration.ts
+++ b/apps/desktop/src/types/collaboration.ts
@@ -30,6 +30,6 @@ export type CollaborationEvent =
   | { type: 'collab_start'; sessionId: string }
   | { type: 'collab_phase'; sessionId: string; phase: 'research' | 'specialists' | 'synthesis' }
   | { type: 'collab_specialist_start'; sessionId: string; role: CollaborationRole; agentName: string }
-  | { type: 'collab_specialist_end'; sessionId: string; role: CollaborationRole; agentName: string; response: string; error?: string }
+  | { type: 'collab_specialist_end'; sessionId: string; role: CollaborationRole; agentName: string; response: string; durationMs: number; error?: string }
   | { type: 'collab_end'; sessionId: string; result: CollaborationResult }
   | { type: 'collab_error'; sessionId: string; error: string };

--- a/apps/desktop/src/types/collaboration.ts
+++ b/apps/desktop/src/types/collaboration.ts
@@ -1,0 +1,35 @@
+/**
+ * Collaboration framework IPC types — shared by Electron main process and renderer.
+ */
+
+/** Role identifiers for the four collaboration agents. */
+export type CollaborationRole = 'coordinator' | 'researcher' | 'analyst' | 'visionary';
+
+/** Status of the collaboration run. */
+export type CollaborationStatus = 'idle' | 'specialists' | 'synthesis' | 'complete' | 'error';
+
+/** A single specialist's output for display in the UI. */
+export interface CollaborationSpecialistOutput {
+  role: CollaborationRole;
+  agentName: string;
+  response: string;
+  error?: string;
+  durationMs: number;
+}
+
+/** Full collaboration result sent to the renderer. */
+export interface CollaborationResult {
+  finalResponse: string;
+  specialistOutputs: CollaborationSpecialistOutput[];
+  totalDurationMs: number;
+  hasErrors: boolean;
+}
+
+/** Events pushed from main → renderer during collaboration. */
+export type CollaborationEvent =
+  | { type: 'collab_start'; sessionId: string }
+  | { type: 'collab_phase'; sessionId: string; phase: 'specialists' | 'synthesis' }
+  | { type: 'collab_specialist_start'; sessionId: string; role: CollaborationRole; agentName: string }
+  | { type: 'collab_specialist_end'; sessionId: string; role: CollaborationRole; agentName: string; response: string; error?: string }
+  | { type: 'collab_end'; sessionId: string; result: CollaborationResult }
+  | { type: 'collab_error'; sessionId: string; error: string };

--- a/apps/desktop/src/types/collaboration.ts
+++ b/apps/desktop/src/types/collaboration.ts
@@ -6,7 +6,7 @@
 export type CollaborationRole = 'coordinator' | 'researcher' | 'analyst' | 'visionary';
 
 /** Status of the collaboration run. */
-export type CollaborationStatus = 'idle' | 'specialists' | 'synthesis' | 'complete' | 'error';
+export type CollaborationStatus = 'idle' | 'research' | 'specialists' | 'synthesis' | 'complete' | 'error';
 
 /** A single specialist's output for display in the UI. */
 export interface CollaborationSpecialistOutput {
@@ -28,7 +28,7 @@ export interface CollaborationResult {
 /** Events pushed from main → renderer during collaboration. */
 export type CollaborationEvent =
   | { type: 'collab_start'; sessionId: string }
-  | { type: 'collab_phase'; sessionId: string; phase: 'specialists' | 'synthesis' }
+  | { type: 'collab_phase'; sessionId: string; phase: 'research' | 'specialists' | 'synthesis' }
   | { type: 'collab_specialist_start'; sessionId: string; role: CollaborationRole; agentName: string }
   | { type: 'collab_specialist_end'; sessionId: string; role: CollaborationRole; agentName: string; response: string; error?: string }
   | { type: 'collab_end'; sessionId: string; result: CollaborationResult }

--- a/apps/desktop/src/types/electron-workspace.d.ts
+++ b/apps/desktop/src/types/electron-workspace.d.ts
@@ -1,0 +1,138 @@
+/**
+ * Window API types — workspace tools (editor, filetree, LSP, debug, VCS).
+ *
+ * Split from electron.d.ts to keep each file under 500 LOC.
+ */
+
+import type {
+  VcsCheckpoint,
+  VcsEvent,
+  VcsWorkspaceState,
+  ChangeEntry,
+  WorkingCopyStatus,
+  FileDiffEntry,
+  Bookmark,
+  Remote,
+  OperationEntry,
+  SyncResult,
+  PushPreview,
+  PullRequestState,
+  PullRequestPreview,
+  PullRequestDraft,
+  CreatePullRequestInput,
+  CreatePullRequestResult,
+} from './vcs';
+
+interface SeroEditorAPI {
+  /** Read a file from the workspace (dual-mode: container or host). */
+  readFile(workspaceId: string, filePath: string): Promise<string>;
+  /** Write a file to the workspace (dual-mode: container or host). */
+  writeFile(workspaceId: string, filePath: string, content: string): Promise<void>;
+  /** List files in a directory (dual-mode: container or host). */
+  listFiles(workspaceId: string, dirPath: string): Promise<Array<{ name: string; type: 'file' | 'directory'; size: number }>>;
+  /** Execute a shell command in the workspace (dual-mode). */
+  exec(workspaceId: string, command: string): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  /** Save editor state (open tabs, active tab) for a workspace. */
+  saveState(workspaceId: string, state: { openTabs: string[]; activeTab: string | null }): Promise<void>;
+  /** Load editor state for a workspace. */
+  loadState(workspaceId: string): Promise<{ openTabs: string[]; activeTab: string | null } | null>;
+  /** Get the root path for the file tree (e.g. /workspace or host path). */
+  getRootPath(workspaceId: string): Promise<string>;
+  /** Check if a workspace uses containers. */
+  isContainer(workspaceId: string): Promise<boolean>;
+  /** Rename/move a file or directory. Returns true on success. */
+  rename(workspaceId: string, oldPath: string, newPath: string): Promise<boolean>;
+  /** Delete a file or directory recursively. Returns true on success. */
+  delete(workspaceId: string, itemPath: string): Promise<boolean>;
+  /** Create an empty file. Returns true on success. */
+  createFile(workspaceId: string, filePath: string): Promise<boolean>;
+  /** Create a directory (recursive). Returns true on success. */
+  createDir(workspaceId: string, dirPath: string): Promise<boolean>;
+}
+
+interface SeroFileTreeAPI {
+  /** Start watching a workspace directory for changes. */
+  watch(workspaceId: string): Promise<void>;
+  /** Stop watching a workspace directory. */
+  unwatch(workspaceId: string): Promise<void>;
+  /** Subscribe to file tree change events. Returns unsubscribe. */
+  onChanged(callback: (data: { workspaceId: string; directories: string[] }) => void): () => void;
+}
+
+interface SeroLspAPI {
+  /** Start a language server for a workspace/language. */
+  start(workspaceId: string, languageId: string): Promise<{ capabilities: Record<string, unknown>; language: string }>;
+  /** Stop a language server. */
+  stop(workspaceId: string, language: string): Promise<void>;
+  /** Send an LSP request. */
+  request(workspaceId: string, language: string, method: string, params?: unknown): Promise<unknown>;
+  /** Send an LSP notification (fire-and-forget, no response). */
+  notify(workspaceId: string, language: string, method: string, params?: unknown): void;
+  /** Check if a server is running for a workspace/language. */
+  hasServer(workspaceId: string, language: string): Promise<boolean>;
+  /** Subscribe to LSP notifications (diagnostics etc.). Returns unsubscribe. */
+  onNotification(callback: (data: { workspaceId: string; language: string; notification: any }) => void): () => void;
+  /** Subscribe to LSP server stopped events. Returns unsubscribe. */
+  onServerStopped(callback: (data: { workspaceId: string; language: string }) => void): () => void;
+}
+
+interface SeroDebugAPI {
+  /** Toggle debug logging on/off. Returns new enabled state. */
+  toggle(): Promise<boolean>;
+  /** Get current debug logging state. */
+  getState(): Promise<boolean>;
+  /** Open the log file in the native file explorer. */
+  openLog(): Promise<void>;
+  /** Clear the log file. */
+  clearLog(): Promise<void>;
+  /** Subscribe to debug state changes. Returns unsubscribe. */
+  onStateChanged(callback: (enabled: boolean) => void): () => void;
+}
+
+interface SeroVcsAPI {
+  /** List recent checkpoints for a workspace. */
+  listCheckpoints(workspaceId: string, limit?: number): Promise<VcsCheckpoint[]>;
+  /** Get current workspace VCS state (current change + checkpoint list). */
+  getState(workspaceId: string, limit?: number): Promise<VcsWorkspaceState>;
+  /** Create a checkpoint for the workspace. */
+  createCheckpoint(
+    workspaceId: string,
+    description?: string,
+    source?: 'manual' | 'turn' | 'fs' | 'restore',
+  ): Promise<VcsCheckpoint | null>;
+  /** Restore files to a prior checkpoint snapshot. */
+  restore(workspaceId: string, checkpointId: string): Promise<void>;
+  /** Get a rich git-format diff between checkpoints. */
+  diff(workspaceId: string, fromChangeId: string, toChangeId?: string): Promise<string>;
+  /** Start workspace filesystem checkpoint watcher. */
+  watch(workspaceId: string): Promise<void>;
+  /** Stop workspace filesystem checkpoint watcher. */
+  unwatch(workspaceId: string): Promise<void>;
+  /** Subscribe to VCS events. Returns unsubscribe. */
+  onEvent(callback: (event: VcsEvent) => void): () => void;
+
+  // ── Rich VCS ops ──────────────────────────────────────────
+  logEntries(wsId: string, limit?: number, revset?: string): Promise<ChangeEntry[]>;
+  status(wsId: string): Promise<WorkingCopyStatus>;
+  fileDiffSummary(wsId: string, from: string, to?: string): Promise<FileDiffEntry[]>;
+  fileContent(wsId: string, rev: string, path: string): Promise<string>;
+  describe(wsId: string, changeId: string, msg: string): Promise<void>;
+  bookmarks(wsId: string): Promise<Bookmark[]>;
+  createBookmark(wsId: string, name: string, rev?: string): Promise<void>;
+  deleteBookmark(wsId: string, name: string): Promise<void>;
+  moveBookmark(wsId: string, name: string, toRev: string): Promise<void>;
+  remotes(wsId: string): Promise<Remote[]>;
+  addRemote(wsId: string, name: string, url: string): Promise<void>;
+  removeRemote(wsId: string, name: string): Promise<void>;
+  fetch(wsId: string, remote?: string): Promise<SyncResult>;
+  push(wsId: string, bookmark?: string, changeId?: string): Promise<SyncResult>;
+  pushDryRun(wsId: string, bookmark?: string, changeId?: string): Promise<PushPreview>;
+  prState(wsId: string): Promise<PullRequestState>;
+  prPreview(wsId: string, sourceBranch?: string, targetBranch?: string): Promise<PullRequestPreview>;
+  prGenerateDraft(wsId: string, sourceBranch: string, targetBranch?: string): Promise<PullRequestDraft>;
+  prCreate(wsId: string, input: CreatePullRequestInput): Promise<CreatePullRequestResult>;
+  undo(wsId: string): Promise<void>;
+  abandon(wsId: string, changeId: string): Promise<void>;
+  squash(wsId: string, from?: string, into?: string): Promise<void>;
+  opLog(wsId: string, limit?: number): Promise<OperationEntry[]>;
+}

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -483,7 +483,7 @@ interface SeroPromptsAPI {
 
 interface SeroCollaborationAPI {
   /** Send a prompt through the 4-agent collaboration framework. */
-  prompt(sessionId: string, workspaceId: string, query: string): Promise<CollaborationResult>;
+  prompt(sessionId: string, workspaceId: string, query: string, clientMessageId?: string): Promise<CollaborationResult>;
   /** Subscribe to collaboration lifecycle events. Returns unsubscribe. */
   onEvent(callback: (event: CollaborationEvent) => void): () => void;
 }

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -1,4 +1,11 @@
-/** Types for the `window.sero` API exposed by the preload script. */
+/**
+ * Types for the `window.sero` API exposed by the preload script.
+ *
+ * Workspace tool interfaces (editor, filetree, LSP, debug, VCS) are in
+ * electron-workspace.d.ts to keep each file under 500 LOC.
+ */
+
+/// <reference path="./electron-workspace.d.ts" />
 
 import type {
   WorkspaceInfo,
@@ -37,24 +44,6 @@ import type {
   CollaborationResult,
   CollaborationEvent,
 } from './ipc';
-import type {
-  VcsCheckpoint,
-  VcsEvent,
-  VcsWorkspaceState,
-  ChangeEntry,
-  WorkingCopyStatus,
-  FileDiffEntry,
-  Bookmark,
-  Remote,
-  OperationEntry,
-  SyncResult,
-  PushPreview,
-  PullRequestState,
-  PullRequestPreview,
-  PullRequestDraft,
-  CreatePullRequestInput,
-  CreatePullRequestResult,
-} from './vcs';
 
 interface SeroWorkspaceAPI {
   /** List all registered workspaces (registry + config merged). */
@@ -328,119 +317,7 @@ interface SeroUserFeedbackAPI {
   onCancel(callback: (data: { id: string }) => void): () => void;
 }
 
-interface SeroEditorAPI {
-  /** Read a file from the workspace (dual-mode: container or host). */
-  readFile(workspaceId: string, filePath: string): Promise<string>;
-  /** Write a file to the workspace (dual-mode: container or host). */
-  writeFile(workspaceId: string, filePath: string, content: string): Promise<void>;
-  /** List files in a directory (dual-mode: container or host). */
-  listFiles(workspaceId: string, dirPath: string): Promise<Array<{ name: string; type: 'file' | 'directory'; size: number }>>;
-  /** Execute a shell command in the workspace (dual-mode). */
-  exec(workspaceId: string, command: string): Promise<{ exitCode: number; stdout: string; stderr: string }>;
-  /** Save editor state (open tabs, active tab) for a workspace. */
-  saveState(workspaceId: string, state: { openTabs: string[]; activeTab: string | null }): Promise<void>;
-  /** Load editor state for a workspace. */
-  loadState(workspaceId: string): Promise<{ openTabs: string[]; activeTab: string | null } | null>;
-  /** Get the root path for the file tree (e.g. /workspace or host path). */
-  getRootPath(workspaceId: string): Promise<string>;
-  /** Check if a workspace uses containers. */
-  isContainer(workspaceId: string): Promise<boolean>;
-  /** Rename/move a file or directory. Returns true on success. */
-  rename(workspaceId: string, oldPath: string, newPath: string): Promise<boolean>;
-  /** Delete a file or directory recursively. Returns true on success. */
-  delete(workspaceId: string, itemPath: string): Promise<boolean>;
-  /** Create an empty file. Returns true on success. */
-  createFile(workspaceId: string, filePath: string): Promise<boolean>;
-  /** Create a directory (recursive). Returns true on success. */
-  createDir(workspaceId: string, dirPath: string): Promise<boolean>;
-}
-
-interface SeroFileTreeAPI {
-  /** Start watching a workspace directory for changes. */
-  watch(workspaceId: string): Promise<void>;
-  /** Stop watching a workspace directory. */
-  unwatch(workspaceId: string): Promise<void>;
-  /** Subscribe to file tree change events. Returns unsubscribe. */
-  onChanged(callback: (data: { workspaceId: string; directories: string[] }) => void): () => void;
-}
-
-interface SeroLspAPI {
-  /** Start a language server for a workspace/language. */
-  start(workspaceId: string, languageId: string): Promise<{ capabilities: Record<string, unknown>; language: string }>;
-  /** Stop a language server. */
-  stop(workspaceId: string, language: string): Promise<void>;
-  /** Send an LSP request. */
-  request(workspaceId: string, language: string, method: string, params?: unknown): Promise<unknown>;
-  /** Send an LSP notification (fire-and-forget, no response). */
-  notify(workspaceId: string, language: string, method: string, params?: unknown): void;
-  /** Check if a server is running for a workspace/language. */
-  hasServer(workspaceId: string, language: string): Promise<boolean>;
-  /** Subscribe to LSP notifications (diagnostics etc.). Returns unsubscribe. */
-  onNotification(callback: (data: { workspaceId: string; language: string; notification: any }) => void): () => void;
-  /** Subscribe to LSP server stopped events. Returns unsubscribe. */
-  onServerStopped(callback: (data: { workspaceId: string; language: string }) => void): () => void;
-}
-
-interface SeroDebugAPI {
-  /** Toggle debug logging on/off. Returns new enabled state. */
-  toggle(): Promise<boolean>;
-  /** Get current debug logging state. */
-  getState(): Promise<boolean>;
-  /** Open the log file in the native file explorer. */
-  openLog(): Promise<void>;
-  /** Clear the log file. */
-  clearLog(): Promise<void>;
-  /** Subscribe to debug state changes. Returns unsubscribe. */
-  onStateChanged(callback: (enabled: boolean) => void): () => void;
-}
-
-interface SeroVcsAPI {
-  /** List recent checkpoints for a workspace. */
-  listCheckpoints(workspaceId: string, limit?: number): Promise<VcsCheckpoint[]>;
-  /** Get current workspace VCS state (current change + checkpoint list). */
-  getState(workspaceId: string, limit?: number): Promise<VcsWorkspaceState>;
-  /** Create a checkpoint for the workspace. */
-  createCheckpoint(
-    workspaceId: string,
-    description?: string,
-    source?: 'manual' | 'turn' | 'fs' | 'restore',
-  ): Promise<VcsCheckpoint | null>;
-  /** Restore files to a prior checkpoint snapshot. */
-  restore(workspaceId: string, checkpointId: string): Promise<void>;
-  /** Get a rich git-format diff between checkpoints. */
-  diff(workspaceId: string, fromChangeId: string, toChangeId?: string): Promise<string>;
-  /** Start workspace filesystem checkpoint watcher. */
-  watch(workspaceId: string): Promise<void>;
-  /** Stop workspace filesystem checkpoint watcher. */
-  unwatch(workspaceId: string): Promise<void>;
-  /** Subscribe to VCS events. Returns unsubscribe. */
-  onEvent(callback: (event: VcsEvent) => void): () => void;
-
-  // ── Rich VCS ops ──────────────────────────────────────────
-  logEntries(wsId: string, limit?: number, revset?: string): Promise<ChangeEntry[]>;
-  status(wsId: string): Promise<WorkingCopyStatus>;
-  fileDiffSummary(wsId: string, from: string, to?: string): Promise<FileDiffEntry[]>;
-  fileContent(wsId: string, rev: string, path: string): Promise<string>;
-  describe(wsId: string, changeId: string, msg: string): Promise<void>;
-  bookmarks(wsId: string): Promise<Bookmark[]>;
-  createBookmark(wsId: string, name: string, rev?: string): Promise<void>;
-  deleteBookmark(wsId: string, name: string): Promise<void>;
-  moveBookmark(wsId: string, name: string, toRev: string): Promise<void>;
-  remotes(wsId: string): Promise<Remote[]>;
-  addRemote(wsId: string, name: string, url: string): Promise<void>;
-  removeRemote(wsId: string, name: string): Promise<void>;
-  fetch(wsId: string, remote?: string): Promise<SyncResult>;
-  push(wsId: string, bookmark?: string, changeId?: string): Promise<SyncResult>;
-  pushDryRun(wsId: string, bookmark?: string, changeId?: string): Promise<PushPreview>;
-  prState(wsId: string): Promise<PullRequestState>;
-  prPreview(wsId: string, sourceBranch?: string, targetBranch?: string): Promise<PullRequestPreview>;
-  prGenerateDraft(wsId: string, sourceBranch: string, targetBranch?: string): Promise<PullRequestDraft>;
-  prCreate(wsId: string, input: CreatePullRequestInput): Promise<CreatePullRequestResult>;
-  undo(wsId: string): Promise<void>;
-  abandon(wsId: string, changeId: string): Promise<void>;
-  squash(wsId: string, from?: string, into?: string): Promise<void>;
-  opLog(wsId: string, limit?: number): Promise<OperationEntry[]>;
-}
+// Editor, FileTree, LSP, Debug, and VCS interfaces are in electron-workspace.d.ts
 
 interface SeroSubagentAPI {
   /** Subscribe to live subagent events. Returns unsubscribe function. */
@@ -483,7 +360,7 @@ interface SeroPromptsAPI {
 
 interface SeroCollaborationAPI {
   /** Send a prompt through the 4-agent collaboration framework. */
-  prompt(sessionId: string, workspaceId: string, query: string, clientMessageId?: string): Promise<CollaborationResult>;
+  prompt(sessionId: string, workspaceId: string, query: string): Promise<CollaborationResult>;
   /** Subscribe to collaboration lifecycle events. Returns unsubscribe. */
   onEvent(callback: (event: CollaborationEvent) => void): () => void;
 }

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -34,6 +34,8 @@ import type {
   SkillFileData,
   PromptTemplateSummary,
   PromptTemplateFileData,
+  CollaborationResult,
+  CollaborationEvent,
 } from './ipc';
 import type {
   VcsCheckpoint,
@@ -479,6 +481,13 @@ interface SeroPromptsAPI {
   deletePrompt(filePath: string): Promise<void>;
 }
 
+interface SeroCollaborationAPI {
+  /** Send a prompt through the 4-agent collaboration framework. */
+  prompt(sessionId: string, workspaceId: string, query: string): Promise<CollaborationResult>;
+  /** Subscribe to collaboration lifecycle events. Returns unsubscribe. */
+  onEvent(callback: (event: CollaborationEvent) => void): () => void;
+}
+
 interface SeroAPI {
   platform: string;
   shell: SeroShellAPI;
@@ -486,6 +495,7 @@ interface SeroAPI {
   workspace: SeroWorkspaceAPI;
   sessions: SeroSessionsAPI;
   agent: SeroAgentAPI;
+  collaboration: SeroCollaborationAPI;
   appState: SeroAppStateAPI;
   apps: SeroAppsAPI;
   appAgent: SeroAppAgentAPI;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -350,6 +350,12 @@ export const IpcChannels = {
     /** Main → renderer push channel for artifact events. */
     event: 'sero:artifacts:event',
   },
+  collaboration: {
+    /** Send a prompt through the 4-agent collaboration framework. */
+    prompt: 'sero:collaboration:prompt',
+    /** Main → renderer push channel for collaboration lifecycle events. */
+    event: 'sero:collaboration:event',
+  },
   gateway: {
     /** Get gateway server status (running, port, clients). */
     getStatus: 'sero:gateway:get-status',

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -477,6 +477,16 @@ export type {
   SubagentEvent,
 } from './subagent';
 
+// ── Collaboration Framework ────────────────────────────────────
+
+export type {
+  CollaborationRole,
+  CollaborationStatus,
+  CollaborationSpecialistOutput,
+  CollaborationResult,
+  CollaborationEvent,
+} from './collaboration';
+
 export type { SkillSource, SkillSummary, SkillFileData } from './skills';
 export type { PromptTemplateSummary, PromptTemplateFileData } from './prompts';
 

--- a/packages/templates/agents/collab-analyst.md
+++ b/packages/templates/agents/collab-analyst.md
@@ -1,0 +1,35 @@
+```json
+{
+  "name": "collab-analyst",
+  "description": "Logic, math, and code reasoning for 4-agent collaboration",
+  "model": "claude-sonnet-4-6",
+  "thinking": "high",
+  "tools": ["read", "bash", "grep", "find", "ls", "edit", "write"]
+}
+```
+
+You are The Analyst — a rigorous logical reasoning and code specialist within
+a 4-agent collaboration framework.
+
+Your job is to perform step-by-step reasoning, mathematical proofs, coding tasks,
+and stress-test logical consistency. You are precise, systematic, and uncompromising
+on correctness.
+
+## Responsibilities
+
+- Break down complex problems into clear logical steps
+- Write, review, and debug code when the task involves programming
+- Perform mathematical calculations and verify quantitative claims
+- Identify logical fallacies, edge cases, and potential failure modes
+- Stress-test proposed solutions against corner cases
+
+## Output Format
+
+Structure your response as:
+
+1. **Analysis** — step-by-step logical breakdown of the problem
+2. **Solution** — your proposed answer with reasoning
+3. **Code** (if applicable) — well-structured, tested code
+4. **Edge Cases** — potential issues, limitations, and failure modes
+
+Show your work. Every conclusion must follow from explicit reasoning steps.

--- a/packages/templates/agents/coordinator.md
+++ b/packages/templates/agents/coordinator.md
@@ -1,0 +1,32 @@
+```json
+{
+  "name": "coordinator",
+  "description": "Lead synthesizer for 4-agent collaboration",
+  "model": "claude-sonnet-4-6",
+  "thinking": "high"
+}
+```
+
+You are The Coordinator — the lead synthesizer in a 4-agent collaboration
+framework.
+
+When specialist agents (Researcher, Analyst, Visionary) have independently
+analysed a query, you synthesize their outputs into a single, coherent,
+high-quality response.
+
+## Your Process
+
+1. **Cross-check** — identify conflicts or disagreements between specialists
+2. **Resolve** — where specialists disagree, determine the most accurate position
+3. **Synthesize** — merge the best elements from all three into a unified response
+4. **Polish** — ensure the final answer is clear, well-structured, and directly
+   addresses the user's query
+
+## Rules
+
+- Produce ONE cohesive response as if you are a single expert answering the user
+- Do NOT mention the collaboration framework, specialists, or internal process
+- Prefer the Researcher's facts, the Analyst's logic, and the Visionary's framing
+- If specialists provide code, use the Analyst's version as the primary and
+  incorporate any Visionary improvements
+- The response should feel natural and authoritative, not committee-written

--- a/packages/templates/agents/researcher.md
+++ b/packages/templates/agents/researcher.md
@@ -1,0 +1,34 @@
+```json
+{
+  "name": "researcher",
+  "description": "Fact-checking and evidence gathering for 4-agent collaboration",
+  "model": "claude-sonnet-4-6",
+  "thinking": "medium",
+  "tools": ["read", "bash", "grep", "find", "ls"]
+}
+```
+
+You are The Researcher — a fact-checking and evidence-gathering specialist within
+a 4-agent collaboration framework.
+
+Your job is to verify claims, gather information, and ground answers in current
+evidence to minimize hallucinations. You are methodical, thorough, and skeptical.
+
+## Responsibilities
+
+- Gather relevant information from available sources (files, web, codebase)
+- Verify factual claims and identify potential inaccuracies
+- Cite sources and evidence for every assertion you make
+- Flag areas of uncertainty or where evidence is insufficient
+- Provide a structured summary of your findings
+
+## Output Format
+
+Structure your response as:
+
+1. **Key Findings** — verified facts relevant to the query
+2. **Evidence** — sources, references, and supporting data
+3. **Uncertainties** — areas where evidence is weak or conflicting
+4. **Corrections** — any common misconceptions about the topic
+
+Be concise but thorough. Focus on accuracy over completeness.

--- a/packages/templates/agents/researcher.md
+++ b/packages/templates/agents/researcher.md
@@ -2,7 +2,7 @@
 {
   "name": "researcher",
   "description": "Fact-checking and evidence gathering for 4-agent collaboration",
-  "model": "claude-sonnet-4-6",
+  "model": "claude-haiku-4-5",
   "thinking": "medium",
   "tools": ["read", "bash", "grep", "find", "ls"]
 }
@@ -21,6 +21,34 @@ evidence to minimize hallucinations. You are methodical, thorough, and skeptical
 - Cite sources and evidence for every assertion you make
 - Flag areas of uncertainty or where evidence is insufficient
 - Provide a structured summary of your findings
+
+## Tools
+When you need up-to-date information, Tavily web search and information gathering tools are available:
+
+*search* - Search the web using Tavily's API
+- Returns relevant results with content snippets, scores, and metadata
+- Best for finding web content on any topic
+- No coding required
+
+*research* - AI-synthesized research on any topic
+- Provides comprehensive results with citations
+- Supports structured JSON output for pipelines
+- Grounded in web data
+- Best for deep-dive research questions
+
+*extract* - Extract content from specific URLs
+- Returns clean markdown/text from web pages
+- Use when you have specific URLs and need their content
+- Better than search when you know exactly where to look
+
+*crawl* - Crawl websites and save as local markdown
+- Download documentation, knowledge bases, or web content
+- Saves pages locally for offline access or analysis
+- Best for systematically capturing entire websites
+
+*tavily-best-practices* - Production-ready Tavily integration guide
+- Reference for building agentic workflows, RAG systems, or autonomous agents
+- Best practices for web search, extraction, crawling, and research
 
 ## Output Format
 

--- a/packages/templates/agents/researcher.md
+++ b/packages/templates/agents/researcher.md
@@ -21,10 +21,9 @@ evidence to minimize hallucinations. You are methodical, thorough, and skeptical
 - Cite sources and evidence for every assertion you make
 - Flag areas of uncertainty or where evidence is insufficient
 - Provide a structured summary of your findings
-CRITICAL: You *MUST* use the 'tavily-ai-skills' to search for new information and to validate existing knowledge.
 
 ## Tools
-When you need up-to-date information, Tavily web search and information gathering tools are available:
+When you need up-to-date information, Tavily web search and information gathering tools may be available (if installed):
 
 *search* - Search the web using Tavily's API
 - Returns relevant results with content snippets, scores, and metadata

--- a/packages/templates/agents/researcher.md
+++ b/packages/templates/agents/researcher.md
@@ -2,7 +2,7 @@
 {
   "name": "researcher",
   "description": "Fact-checking and evidence gathering for 4-agent collaboration",
-  "model": "claude-haiku-4-5",
+  "model": "claude-sonnet-4-6",
   "thinking": "medium",
   "tools": ["read", "bash", "grep", "find", "ls"]
 }
@@ -14,13 +14,14 @@ a 4-agent collaboration framework.
 Your job is to verify claims, gather information, and ground answers in current
 evidence to minimize hallucinations. You are methodical, thorough, and skeptical.
 
-## Responsibilities
 
+## Responsibilities
 - Gather relevant information from available sources (files, web, codebase)
 - Verify factual claims and identify potential inaccuracies
 - Cite sources and evidence for every assertion you make
 - Flag areas of uncertainty or where evidence is insufficient
 - Provide a structured summary of your findings
+CRITICAL: You *MUST* use the 'tavily-ai-skills' to search for new information and to validate existing knowledge.
 
 ## Tools
 When you need up-to-date information, Tavily web search and information gathering tools are available:

--- a/packages/templates/agents/visionary.md
+++ b/packages/templates/agents/visionary.md
@@ -1,0 +1,35 @@
+```json
+{
+  "name": "visionary",
+  "description": "Creative and divergent thinking for 4-agent collaboration",
+  "model": "claude-sonnet-4-6",
+  "thinking": "medium",
+  "tools": ["read", "bash", "grep", "find", "ls"]
+}
+```
+
+You are The Visionary — a creative and divergent thinking specialist within
+a 4-agent collaboration framework.
+
+Your job is to provide novel ideas, alternative perspectives, and creative
+synthesis. You challenge conventional thinking and explore unconventional
+approaches.
+
+## Responsibilities
+
+- Propose creative, non-obvious approaches to the problem
+- Consider the problem from multiple stakeholder perspectives
+- Identify opportunities that a purely analytical approach might miss
+- Challenge assumptions in the query and suggest reframing
+- Synthesize ideas from different domains for cross-pollination
+
+## Output Format
+
+Structure your response as:
+
+1. **Fresh Perspectives** — alternative ways to frame the problem
+2. **Creative Approaches** — novel or unconventional solutions
+3. **Cross-Domain Insights** — relevant ideas from other fields
+4. **Provocations** — assumptions worth challenging, risks worth taking
+
+Be bold and imaginative. Your value is in expanding the solution space.


### PR DESCRIPTION
## Summary

- Adds a **4-agent collaboration mode** toggle in the chat toolbar that routes prompts through a multi-agent pipeline: Researcher → Analyst + Visionary (parallel) → Coordinator synthesis
- **Two-phase fan-out**: Researcher runs first to gather facts, then Analyst and Visionary run in parallel with the research as shared context — producing higher quality than fully parallel execution
- Uses **proper named agent definitions** (`.md` template files) rather than ad-hoc agents, with role-based tool restrictions
- **Session persistence**: collaboration synthesis is fed through the main agent session so conversations persist across restarts, with the original user query displayed cleanly (injection wrapper stripped on load)
- **Follow-up context**: conversation history from the main session is extracted and provided to specialists so follow-up queries work naturally
- Collaboration mode **resets when switching sessions** to avoid unexpected behavior

### Agent roles
| Role | Agent file | Phase | Purpose |
|------|-----------|-------|---------|
| Researcher | `researcher.md` | 1 (solo) | Fact-checking, evidence gathering |
| Analyst | `collab-analyst.md` | 2 (parallel) | Logic, math, code analysis — informed by research |
| Visionary | `visionary.md` | 2 (parallel) | Creative, divergent thinking — informed by research |
| Coordinator | `coordinator.md` | 3 (solo) | Synthesizes all outputs into one response |

### UI
- Violet toggle button in chat toolbar
- Status banner showing current phase (Research → Specialists → Synthesis)
- Expandable specialist outputs below the synthesized response
- Header badge when collaboration mode is active

## Test plan
- [ ] Toggle collaboration mode on/off — verify badge and placeholder text update
- [ ] Send a prompt with collaboration enabled — verify 3-phase progress banner
- [ ] Verify researcher output appears in analyst/visionary specialist cards (research-aware)
- [ ] Expand specialist outputs — verify all three roles have responses
- [ ] Send a follow-up question — verify specialists have prior conversation context
- [ ] Restart Sero — verify original user query (not injection XML) shows in chat history
- [ ] Switch sessions — verify collaboration mode resets to off