### PR TITLE
feat: add multi-agent research orchestrator Sero app

### DIFF
--- a/apps/desktop/electron/subagent/index.ts
+++ b/apps/desktop/electron/subagent/index.ts
@@ -75,6 +75,7 @@ export class SubagentManager {
       maxConcurrent: settings?.maxConcurrent ?? 4,
       maxTotal: settings?.maxTotal ?? 8,
       timeoutMs: settings?.timeoutMs ?? 600_000,
+      toolStallTimeoutMs: settings?.toolStallTimeoutMs ?? 120_000,
       model: settings?.model ?? null,
       thinking: settings?.thinking ?? null,
       blockedExtensions: settings?.blockedExtensions ?? [],

--- a/apps/desktop/electron/subagent/resolve.ts
+++ b/apps/desktop/electron/subagent/resolve.ts
@@ -21,6 +21,7 @@ const HARDCODED_DEFAULTS = {
   model: 'claude-sonnet-4-6',
   thinking: 'high',
   timeoutMs: 600_000,
+  toolStallTimeoutMs: 120_000,
 } as const;
 
 export interface SessionDefaults {
@@ -38,7 +39,7 @@ export function resolveConfig(
   taskOverride?: TaskOverride,
   callOverride?: TaskOverride,
   agentConfig?: Pick<AgentConfig, 'model' | 'thinking' | 'timeoutMs'>,
-  settings?: Pick<SubagentSettings, 'model' | 'thinking' | 'timeoutMs'>,
+  settings?: Pick<SubagentSettings, 'model' | 'thinking' | 'timeoutMs' | 'toolStallTimeoutMs'>,
   sessionDefaults?: SessionDefaults,
 ): ResolvedConfig {
   const model = firstDefined(
@@ -67,7 +68,9 @@ export function resolveConfig(
     HARDCODED_DEFAULTS.timeoutMs,
   );
 
-  return { model, thinking, timeoutMs };
+  const toolStallTimeoutMs = settings?.toolStallTimeoutMs ?? HARDCODED_DEFAULTS.toolStallTimeoutMs;
+
+  return { model, thinking, timeoutMs, toolStallTimeoutMs };
 }
 
 /**

--- a/apps/desktop/electron/subagent/runner.ts
+++ b/apps/desktop/electron/subagent/runner.ts
@@ -158,6 +158,33 @@ export async function runSubagent(
     // Track usage, tool activity, live output + debug logging
     const { onToolActivity, onTextDelta, onUpdate: onStatusUpdate } = config;
     const usage: SubagentUsage = { ...EMPTY_USAGE };
+
+    // ── Per-tool stall detection ──────────────────────────────
+    // If a single tool call runs longer than toolStallTimeoutMs, abort.
+    const toolStallMs = resolved.toolStallTimeoutMs ?? 120_000;
+    let activeToolStallTimer: ReturnType<typeof setTimeout> | null = null;
+    let activeToolName: string | null = null;
+
+    function clearStallTimer(): void {
+      if (activeToolStallTimer) {
+        clearTimeout(activeToolStallTimer);
+        activeToolStallTimer = null;
+      }
+      activeToolName = null;
+    }
+
+    function startStallTimer(toolName: string): void {
+      clearStallTimer();
+      if (toolStallMs <= 0) return; // disabled
+      activeToolName = toolName;
+      activeToolStallTimer = setTimeout(() => {
+        const stallMsg = `Tool '${toolName}' stalled after ${Math.round(toolStallMs / 1000)}s — auto-aborting`;
+        console.warn(`[subagent/runner] ${stallMsg}`);
+        onStatusUpdate?.(`⚠️ ${stallMsg}`);
+        try { session?.abort(); } catch { /* ignore */ }
+      }, toolStallMs);
+    }
+
     const unsub = session.subscribe((event: Record<string, unknown>) => {
       // Forward all events to the debug log (same file as main sessions)
       logRawEvent(subagentSessionId, event);
@@ -166,18 +193,20 @@ export async function runSubagent(
         logTurnContext(subagentSessionId, session!);
       }
 
-      // Tool execution events → tool activity feed
+      // Tool execution events → tool activity feed + stall detection
       if (event.type === 'tool_execution_start') {
         const toolName = (event.toolName as string) ?? 'unknown';
         const args = event.args as Record<string, unknown> | undefined;
         const summary = extractToolArgsSummary(toolName, args);
         onToolActivity?.(toolName, summary, true);
         onStatusUpdate?.(`  📂 ${toolName}: ${summary}`);
+        startStallTimer(toolName);
       }
 
       if (event.type === 'tool_execution_end') {
         const toolName = (event.toolName as string) ?? 'unknown';
         onToolActivity?.(toolName, '', false);
+        clearStallTimer();
       }
 
       // Text deltas → live output stream
@@ -189,6 +218,7 @@ export async function runSubagent(
       }
 
       if (event.type === 'agent_end') {
+        clearStallTimer();
         try {
           const stats = session?.getSessionStats();
           if (stats) {
@@ -208,6 +238,7 @@ export async function runSubagent(
     await session.prompt(task);
 
     clearTimeout(timeoutId);
+    clearStallTimer();
     signal.removeEventListener('abort', abortHandler);
     unsub();
 
@@ -243,6 +274,7 @@ export async function runSubagent(
 
     return { response: '', usage: { ...EMPTY_USAGE }, error: errorMsg };
   } finally {
+    clearStallTimer();
     try { session?.dispose(); } catch { /* ignore */ }
   }
 }

--- a/apps/desktop/electron/subagent/types.ts
+++ b/apps/desktop/electron/subagent/types.ts
@@ -49,6 +49,12 @@ export interface SubagentSettings {
   maxTotal: number;
   /** Default timeout in ms. Default: 600_000 (10 min). */
   timeoutMs: number;
+  /**
+   * Per-tool stall timeout in ms. If a single tool call (especially bash)
+   * runs longer than this without completing, the subagent is auto-aborted.
+   * Default: 120_000 (2 min). Set to 0 to disable.
+   */
+  toolStallTimeoutMs: number;
   /** Default model if agent/call omit one. */
   model: string | null;
   /** Default thinking level if agent/call omit one. */
@@ -61,6 +67,7 @@ export const DEFAULT_SUBAGENT_SETTINGS: SubagentSettings = {
   maxConcurrent: 4,
   maxTotal: 8,
   timeoutMs: 600_000,
+  toolStallTimeoutMs: 120_000,
   model: null,
   thinking: null,
   blockedExtensions: [],
@@ -86,6 +93,8 @@ export interface ResolvedConfig {
   thinking: string;
   /** Concrete timeout in milliseconds. */
   timeoutMs: number;
+  /** Per-tool stall timeout in milliseconds. 0 = disabled. */
+  toolStallTimeoutMs: number;
 }
 
 // ── Runner Config (full config for a single run) ─────────────

--- a/apps/desktop/src/components/apps/coding/orchestration/SubagentCard.tsx
+++ b/apps/desktop/src/components/apps/coding/orchestration/SubagentCard.tsx
@@ -5,10 +5,11 @@
  * Matches the rounded-border card style from ToolCallGroup.
  */
 
-import { useState, useEffect, useRef, useMemo } from 'react';
-import { ChevronRight, Loader2, CheckCircle2, XCircle, AlertCircle, Clock } from 'lucide-react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { ChevronRight, Loader2, CheckCircle2, XCircle, AlertCircle, Clock, Square } from 'lucide-react';
 import { cn } from '@sero/ui/lib/utils';
 import type { SubagentEntry, SubagentToolActivity } from '@/types/ipc';
+import { useSubagentStore } from '@/stores/subagent';
 import { SubagentOutput } from './SubagentOutput';
 
 interface SubagentCardProps {
@@ -131,10 +132,14 @@ function LiveOutputPreview({ text }: { text: string }) {
 
 // ── Main Card ───────────────────────────────────────────────
 
+/** Threshold (ms) after which a running card shows a "may be stalled" hint. */
+const STALL_HINT_MS = 90_000;
+
 export function SubagentCard({ entry }: SubagentCardProps) {
   const isRunning = entry.status === 'running' || entry.status === 'queued';
   const isFailed = entry.status === 'failed' || entry.status === 'timed_out';
   const isAborted = entry.status === 'aborted';
+  const abort = useSubagentStore((s) => s.abort);
 
   // Ticking elapsed timer
   const [elapsed, setElapsed] = useState(entry.durationMs ?? 0);
@@ -148,6 +153,15 @@ export function SubagentCard({ entry }: SubagentCardProps) {
     const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [isRunning, entry.startedAt, entry.durationMs]);
+
+  // Stall hint: show when running and a tool has been active for a while
+  const mayBeStalled = isRunning
+    && elapsed > STALL_HINT_MS
+    && entry.toolActivity.some((t) => t.running);
+
+  const handleAbort = useCallback(() => {
+    abort(entry.id);
+  }, [abort, entry.id]);
 
   // Expand/collapse state
   const [expanded, setExpanded] = useState(false);
@@ -191,6 +205,21 @@ export function SubagentCard({ entry }: SubagentCardProps) {
             <span className="text-emerald-500">{formatCost(entry.usage.cost)}</span>
           )}
         </div>
+        {/* Stop button (running only) */}
+        {isRunning && (
+          <button
+            onClick={handleAbort}
+            className={cn(
+              'ml-1 flex items-center justify-center rounded p-1 transition-colors',
+              mayBeStalled
+                ? 'bg-red-500/20 text-red-400 hover:bg-red-500/30'
+                : 'text-[var(--text-muted)] hover:bg-[var(--bg-surface)] hover:text-red-400',
+            )}
+            title={mayBeStalled ? 'Stop — tool appears stalled' : 'Stop subagent'}
+          >
+            <Square className="size-3 fill-current" />
+          </button>
+        )}
       </div>
 
       {/* ── Task preview ───────────────────────────────── */}
@@ -202,6 +231,16 @@ export function SubagentCard({ entry }: SubagentCardProps) {
       {isRunning && entry.toolActivity.length > 0 && (
         <div className="px-3 pb-1">
           <ToolActivityFeed activity={entry.toolActivity} />
+        </div>
+      )}
+
+      {/* ── Stall warning ──────────────────────────────── */}
+      {mayBeStalled && (
+        <div className="flex items-center gap-1.5 border-t border-yellow-500/20 bg-yellow-500/[0.05] px-3 py-1">
+          <AlertCircle className="size-3 shrink-0 text-yellow-500" />
+          <span className="text-[10px] text-yellow-400">
+            Tool may be stalled — stop or wait for auto-timeout
+          </span>
         </div>
       )}
 

--- a/packages/pi-research-extension/extension/index.ts
+++ b/packages/pi-research-extension/extension/index.ts
@@ -1,0 +1,427 @@
+/**
+ * Research Orchestrator Extension — Multi-agent research with parallel workstreams.
+ *
+ * Decomposes research questions into 2-4 parallel agent workstreams,
+ * monitors progress at escalating intervals, handles stuck agents,
+ * and synthesizes results into a unified document.
+ *
+ * Tools: research (plan, approve, status, cancel)
+ * Commands: /research
+ */
+
+import path from 'node:path';
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import type { ResearchState, ResearchSession, ResearchAgent, ResearchPhase } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+import { resolveStatePath, readState, writeState, countLines, readFile, writeSkeletonFile } from './state-io';
+import { buildSkeletonFile, buildAgentSystemPrompt, buildAgentTaskPrompt, buildSynthesisPrompt } from './prompts';
+
+// ── Constants ──────────────────────────────────────────────────
+
+const RESEARCH_DIR_BASE = 'research';
+
+// Monitor intervals: 30s, 2min, 5min, then every 5min
+const MONITOR_INTERVALS_MS = [30_000, 120_000, 300_000];
+const MONITOR_REPEAT_MS = 300_000;
+const STUCK_THRESHOLD = 2; // unchanged line count for N check-ins → stuck
+
+// ── Tool parameters ─────────────────────────────────────────────
+
+const ResearchParams = Type.Object({
+  action: StringEnum(['plan', 'approve', 'status', 'cancel'] as const),
+  question: Type.Optional(Type.String({ description: 'Research question (for plan)' })),
+  agents: Type.Optional(Type.Array(
+    Type.Object({
+      name: Type.String({ description: 'Agent workstream name' }),
+      sections: Type.Array(Type.String(), { description: 'Section titles to research' }),
+    }),
+    { description: 'Agent definitions (for plan)' },
+  )),
+});
+
+// ── Extension ──────────────────────────────────────────────────
+
+export default function researchExtension(pi: ExtensionAPI): void {
+  let statePath = '';
+  let workspaceCwd = '';
+
+  function ensureStatePath(ctx?: { cwd?: string }): void {
+    if (!statePath && ctx?.cwd) {
+      statePath = resolveStatePath(ctx.cwd);
+      workspaceCwd = ctx.cwd;
+    }
+  }
+
+  async function syncState(state: ResearchState): Promise<void> {
+    if (!statePath) return;
+    await writeState(statePath, state);
+  }
+
+  function makeResult(text: string, error = false) {
+    return {
+      content: [{ type: 'text' as const, text }],
+      details: {},
+      ...(error && { isError: true }),
+    };
+  }
+
+  // ── Tool: research ─────────────────────────────────────────
+
+  pi.registerTool({
+    name: 'research',
+    label: 'Research',
+    description:
+      'Multi-agent research orchestrator. Actions:\n' +
+      '  plan — Decompose a question into research workstreams. Requires `question` and `agents` array.\n' +
+      '  approve — Launch the planned research workstreams.\n' +
+      '  status — Check progress of active research.\n' +
+      '  cancel — Cancel active research.',
+    parameters: ResearchParams,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      ensureStatePath(ctx);
+      if (!statePath) {
+        return makeResult('Error: no workspace cwd set', true);
+      }
+      const state = await readState(statePath);
+
+      switch (params.action) {
+        case 'plan':
+          return handlePlan(state, params);
+        case 'approve':
+          return handleApprove(state);
+        case 'status':
+          return handleStatus(state);
+        case 'cancel':
+          return handleCancel(state);
+        default:
+          return makeResult(`Unknown action: ${params.action}`, true);
+      }
+    },
+
+    renderCall(args, theme) {
+      let text = theme.fg('toolTitle', theme.bold('research '));
+      text += theme.fg('muted', args.action);
+      if (args.question) {
+        const q = args.question.length > 60
+          ? args.question.slice(0, 60) + '…'
+          : args.question;
+        text += ` ${theme.fg('dim', `"${q}"`)}`;
+      }
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const msg = result.content?.[0]?.type === 'text' ? result.content[0].text : '';
+      if (msg.startsWith('Error:')) return new Text(theme.fg('error', msg), 0, 0);
+      return new Text(theme.fg('success', '✓ ') + theme.fg('muted', msg), 0, 0);
+    },
+  });
+
+  // ── Action handlers ──────────────────────────────────────────
+
+  async function handlePlan(
+    state: ResearchState,
+    params: Record<string, unknown>,
+  ) {
+    const question = params.question as string | undefined;
+    const agents = params.agents as Array<{ name: string; sections: string[] }> | undefined;
+
+    if (!question) return makeResult('Error: question is required for plan', true);
+    if (!agents?.length) return makeResult('Error: agents array is required for plan', true);
+    if (agents.length < 2 || agents.length > 4) {
+      return makeResult('Error: provide 2-4 agent workstreams', true);
+    }
+
+    // Create sanitized directory name from question
+    const dirName = question
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 50);
+    const outputDir = path.join(RESEARCH_DIR_BASE, dirName);
+
+    // Build research session
+    const session: ResearchSession = {
+      question,
+      phase: 'awaiting_approval',
+      agents: agents.map((a, i) => ({
+        id: i + 1,
+        name: a.name,
+        sections: a.sections.map((s) => ({ title: s, completed: false })),
+        status: 'pending',
+        outputFile: path.join(outputDir, `agent-${i + 1}.md`),
+        lineCount: 0,
+        stuckChecks: 0,
+      })),
+      outputDir,
+      startedAt: new Date().toISOString(),
+      monitorCycles: 0,
+    };
+
+    state.current = session;
+    await syncState(state);
+
+    // Format plan for display
+    const planLines = session.agents.map((a) => {
+      const sectionList = a.sections.map((s) => `  - ${s.title}`).join('\n');
+      return `### Agent ${a.id}: ${a.name}\n${sectionList}`;
+    });
+
+    return makeResult(
+      `## Research Plan: ${question}\n\n` +
+      `${planLines.join('\n\n')}\n\n` +
+      `### Synthesis Agent\n` +
+      `Runs after all agents complete → unified document with cross-cutting insights\n\n` +
+      `Output: ${outputDir}/\n\n` +
+      `**Ready to launch ${session.agents.length} research agents.** ` +
+      `Call research(action: "approve") to begin.`,
+    );
+  }
+
+  async function handleApprove(state: ResearchState) {
+    if (!state.current) {
+      return makeResult('Error: no research plan to approve. Use action "plan" first.', true);
+    }
+    if (state.current.phase !== 'awaiting_approval') {
+      return makeResult(`Error: research is in phase "${state.current.phase}", not awaiting approval.`, true);
+    }
+
+    const session = state.current;
+    session.phase = 'researching';
+
+    // Create skeleton files for each agent
+    for (const agent of session.agents) {
+      const filePath = path.join(workspaceCwd, agent.outputFile);
+      const skeleton = buildSkeletonFile(agent, session);
+      await writeSkeletonFile(filePath, skeleton);
+      agent.status = 'running';
+      agent.startedAt = new Date().toISOString();
+    }
+
+    await syncState(state);
+
+    // Launch all agents in parallel using the subagent tool
+    const launchInstructions = buildLaunchInstructions(session);
+
+    return makeResult(
+      `Research launched! ${session.agents.length} agents are now working in parallel.\n\n` +
+      `Output directory: ${session.outputDir}/\n\n` +
+      `**IMPORTANT — You must now do the following:**\n\n` +
+      launchInstructions + '\n\n' +
+      `After launching, periodically call research(action: "status") to monitor progress.`,
+    );
+  }
+
+  async function handleStatus(state: ResearchState) {
+    if (!state.current) {
+      return makeResult('No active research session.');
+    }
+
+    const session = state.current;
+
+    // Update line counts for running agents
+    for (const agent of session.agents) {
+      if (agent.status === 'running' || agent.status === 'stuck') {
+        const filePath = path.join(workspaceCwd, agent.outputFile);
+        const prevCount = agent.lineCount;
+        agent.lineCount = await countLines(filePath);
+
+        // Check for completion marker
+        const content = await readFile(filePath);
+        if (content.includes('Status: COMPLETE')) {
+          agent.status = 'complete';
+          agent.completedAt = new Date().toISOString();
+          agent.sections.forEach((s) => { s.completed = true; });
+        } else if (agent.lineCount === prevCount && prevCount > 0) {
+          agent.stuckChecks++;
+          if (agent.stuckChecks >= STUCK_THRESHOLD) {
+            agent.status = 'stuck';
+          }
+        } else {
+          agent.stuckChecks = 0;
+          agent.status = 'running';
+        }
+      }
+    }
+
+    session.monitorCycles++;
+
+    // Check if all agents are done
+    const allComplete = session.agents.every(
+      (a) => a.status === 'complete' || a.status === 'failed',
+    );
+    const anyStuck = session.agents.some((a) => a.status === 'stuck');
+
+    if (allComplete && session.phase === 'researching') {
+      session.phase = 'synthesizing';
+    }
+
+    await syncState(state);
+
+    // Build status report
+    const agentStatuses = session.agents.map((a) => {
+      const icon = statusIcon(a.status);
+      const lines = a.lineCount > 0 ? ` (${a.lineCount} lines)` : '';
+      const stuck = a.status === 'stuck' ? ' ⚠️ STUCK — needs relaunch' : '';
+      return `${icon} Agent ${a.id}: ${a.name} — ${a.status}${lines}${stuck}`;
+    });
+
+    let instructions = '';
+    if (anyStuck) {
+      const stuckAgents = session.agents.filter((a) => a.status === 'stuck');
+      instructions = '\n\n**Stuck agents detected!** Relaunch them:\n' +
+        stuckAgents.map((a) =>
+          `- Agent ${a.id} (${a.name}): Kill and relaunch with the data already in ${a.outputFile}`,
+        ).join('\n') +
+        '\n\nUse the subagent tool to relaunch each stuck agent with its existing output pre-loaded.';
+    }
+
+    if (allComplete) {
+      instructions = '\n\n**All agents complete!** Now launch the synthesis agent.\n' +
+        buildSynthesisInstructions(session);
+    }
+
+    return makeResult(
+      `## Research Status: ${session.question}\n\n` +
+      `Phase: ${session.phase} | Cycle: ${session.monitorCycles}\n\n` +
+      agentStatuses.join('\n') +
+      instructions,
+    );
+  }
+
+  async function handleCancel(state: ResearchState) {
+    if (!state.current) {
+      return makeResult('No active research to cancel.');
+    }
+
+    const session = state.current;
+    session.phase = 'failed';
+    session.error = 'Cancelled by user';
+
+    // Move to history
+    state.history.unshift({
+      question: session.question,
+      outputDir: session.outputDir,
+      agentCount: session.agents.length,
+      completedAt: new Date().toISOString(),
+    });
+    state.current = null;
+    await syncState(state);
+
+    return makeResult('Research cancelled.');
+  }
+
+  // ── Helper: build subagent launch instructions ─────────────
+
+  function buildLaunchInstructions(session: ResearchSession): string {
+    const tasks = session.agents.map((agent) => {
+      const outputPath = agent.outputFile;
+      const systemPrompt = buildAgentSystemPrompt(agent, session);
+      const taskPrompt = buildAgentTaskPrompt(agent, outputPath);
+      return `{
+  "agent": "general-purpose research agent",
+  "task": ${JSON.stringify(taskPrompt)},
+  "systemPrompt": ${JSON.stringify(systemPrompt)}
+}`;
+    });
+
+    return `Use the **subagent** tool in **parallel mode** to launch all agents:\n\n` +
+      '```\n' +
+      `subagent({\n  tasks: [\n    ${tasks.join(',\n    ')}\n  ]\n})\n` +
+      '```';
+  }
+
+  function buildSynthesisInstructions(session: ResearchSession): string {
+    const agentFiles = session.agents.map((a) => a.outputFile);
+    return `\nRead all agent output files:\n` +
+      agentFiles.map((f) => `- ${f}`).join('\n') +
+      `\n\nThen use the **subagent** tool in single mode to run the synthesis:\n` +
+      '```\n' +
+      `subagent({\n` +
+      `  task: "Read the research outputs and create a synthesis document at ${session.outputDir}/synthesis.md",\n` +
+      `  systemPrompt: "<synthesis prompt with all agent outputs>"\n` +
+      `})\n` +
+      '```\n\n' +
+      'After synthesis is complete, call research(action: "status") to finalize.';
+  }
+
+  // ── Event: mark complete when synthesis done ────────────────
+
+  pi.on('agent_end', async (_event, ctx) => {
+    ensureStatePath(ctx);
+    if (!statePath) return;
+
+    const state = await readState(statePath);
+    if (!state.current || state.current.phase !== 'synthesizing') return;
+
+    const session = state.current;
+    const synthPath = path.join(workspaceCwd, session.outputDir, 'synthesis.md');
+    const content = await readFile(synthPath);
+
+    if (content.includes('Status: COMPLETE')) {
+      session.phase = 'complete';
+      session.completedAt = new Date().toISOString();
+      session.synthesisFile = path.join(session.outputDir, 'synthesis.md');
+
+      state.history.unshift({
+        question: session.question,
+        outputDir: session.outputDir,
+        agentCount: session.agents.length,
+        completedAt: session.completedAt,
+      });
+      state.current = null;
+      await syncState(state);
+    }
+  });
+
+  // ── Event: restore state on session start ──────────────────
+
+  pi.on('session_start', async (_event, ctx) => {
+    ensureStatePath(ctx);
+  });
+
+  pi.on('session_switch', async (_event, ctx) => {
+    ensureStatePath(ctx);
+  });
+
+  // ── Command: /research ─────────────────────────────────────
+
+  pi.registerCommand('research', {
+    description: 'Start a multi-agent research session on any topic',
+    handler: async (args, _ctx) => {
+      const question = args.trim();
+      if (question) {
+        pi.sendUserMessage(
+          `I want to research: "${question}"\n\n` +
+          `Please decompose this into 2-4 non-overlapping research workstreams. ` +
+          `For each workstream, identify the key sections to cover. ` +
+          `Then use the research tool with action "plan" to create the research plan, ` +
+          `providing the question and an agents array with name and sections for each workstream.`,
+        );
+      } else {
+        pi.sendUserMessage(
+          'I want to start a research session. Ask me what I want to research, ' +
+          'then decompose it into 2-4 non-overlapping workstreams using the research tool.',
+        );
+      }
+    },
+  });
+}
+
+// ── Utils ──────────────────────────────────────────────────────
+
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'pending': return '⏳';
+    case 'running': return '🔄';
+    case 'stuck': return '⚠️';
+    case 'complete': return '✅';
+    case 'failed': return '❌';
+    default: return '•';
+  }
+}

--- a/packages/pi-research-extension/extension/index.ts
+++ b/packages/pi-research-extension/extension/index.ts
@@ -282,7 +282,9 @@ export default function researchExtension(pi: ExtensionAPI): void {
     }
 
     if (allComplete) {
-      instructions = '\n\n**All agents complete!** Now launch the synthesis agent.\n' +
+      instructions = '\n\n**All agents complete!**\n' +
+        '⚠️ IMMEDIATE ACTION REQUIRED — do NOT ask the user for confirmation. ' +
+        'Proceed directly to synthesis now.\n' +
         buildSynthesisInstructions(session);
     }
 
@@ -324,7 +326,7 @@ export default function researchExtension(pi: ExtensionAPI): void {
       const systemPrompt = buildAgentSystemPrompt(agent, session);
       const taskPrompt = buildAgentTaskPrompt(agent, outputPath);
       return `{
-  "agent": "general-purpose research agent",
+  "agent": "researcher",
   "task": ${JSON.stringify(taskPrompt)},
   "systemPrompt": ${JSON.stringify(systemPrompt)}
 }`;
@@ -338,15 +340,22 @@ export default function researchExtension(pi: ExtensionAPI): void {
 
   function buildSynthesisInstructions(session: ResearchSession): string {
     const agentFiles = session.agents.map((a) => a.outputFile);
-    return `\nRead all agent output files:\n` +
-      agentFiles.map((f) => `- ${f}`).join('\n') +
-      `\n\nThen use the **subagent** tool in single mode to run the synthesis:\n` +
-      '```\n' +
-      `subagent({\n` +
-      `  task: "Read the research outputs and create a synthesis document at ${session.outputDir}/synthesis.md",\n` +
-      `  systemPrompt: "<synthesis prompt with all agent outputs>"\n` +
-      `})\n` +
+    const fileList = agentFiles.map((f) => `- ${f}`).join('\n');
+    const synthPath = `${session.outputDir}/synthesis.md`;
+
+    return `\nRead all agent output files:\n${fileList}\n\n` +
+      `Then launch the synthesis using the subagent tool with **exactly** this call ` +
+      `(use agent "research-analyst" — NOT "researcher" or any other agent):\n\n` +
+      '```json\n' +
+      `{\n` +
+      `  "agent": "research-analyst",\n` +
+      `  "task": "Read the research outputs and create a synthesis document at ${synthPath}. ` +
+      `The research files to read are: ${agentFiles.join(', ')}"\n` +
+      `}\n` +
       '```\n\n' +
+      'Optionally, if the research would benefit from diagrams, charts, or other visual aids, ' +
+      'you can use the **visual-explainer** skill to create visually compelling representations ' +
+      'of the findings (e.g. architecture diagrams, comparison tables, flow charts, data summaries).\n\n' +
       'After synthesis is complete, call research(action: "status") to finalize.';
   }
 
@@ -405,8 +414,10 @@ export default function researchExtension(pi: ExtensionAPI): void {
         );
       } else {
         pi.sendUserMessage(
-          'I want to start a research session. Ask me what I want to research, ' +
-          'then decompose it into 2-4 non-overlapping workstreams using the research tool.',
+          'I want to start a research session. Use the question tool to ask me what topic ' +
+          'I want to research (do NOT use the interview or questionnaire tool). ' +
+          'Once I provide a topic, decompose it into 2-4 non-overlapping workstreams ' +
+          'using the research tool.',
         );
       }
     },

--- a/packages/pi-research-extension/extension/prompts.ts
+++ b/packages/pi-research-extension/extension/prompts.ts
@@ -1,0 +1,131 @@
+/**
+ * Prompt templates for the research orchestrator.
+ */
+
+import type { ResearchAgent, ResearchSession } from '../shared/types';
+
+/**
+ * Build the system prompt for a research agent.
+ */
+export function buildAgentSystemPrompt(agent: ResearchAgent, session: ResearchSession): string {
+  const sectionList = agent.sections.map((s) => `- ${s.title}`).join('\n');
+
+  return `You are a deep research agent. Your job is to thoroughly research the assigned topic and write a comprehensive, well-sourced document.
+
+## Your Assignment
+Research Topic: "${session.question}"
+Your Workstream: "${agent.name}"
+
+## Sections to Cover
+${sectionList}
+
+## CRITICAL: Write Protocol
+You MUST follow this strict alternating pattern:
+1. Search for information (web search, read sources)
+2. IMMEDIATELY write findings to your output file
+3. Search again
+4. IMMEDIATELY write again
+
+NEVER do two searches in a row without writing. After every single search, write what you found to the file. This prevents you from losing information and getting stuck in loops.
+
+## Output Requirements
+- Write in markdown format
+- Cover each assigned section thoroughly
+- Cite every claim with an inline URL: [Source Title](url)
+- Use ## headers for each section
+- Be comprehensive — aim for 400+ lines of deeply sourced content
+- Include specific data, studies, and expert opinions where available
+
+## File Management
+- Your output file has been pre-created with section headers
+- Write your findings section by section, in order
+- After each section is complete, move to the next
+- When ALL sections are complete, add this exact line at the very end:
+
+Status: COMPLETE
+
+## Quality Standards
+- Every factual claim must have an inline citation
+- Prefer primary sources (academic papers, official reports) over secondary
+- Note when evidence is conflicting or uncertain
+- Include practical implications, not just theory`;
+}
+
+/**
+ * Build the task prompt for a research agent.
+ */
+export function buildAgentTaskPrompt(agent: ResearchAgent, outputPath: string): string {
+  return `Research and write about "${agent.name}".
+
+Your output file is: ${outputPath}
+
+Work through each section in order. Remember: search → write → search → write. Never do two searches without writing.
+
+Start by reading the skeleton file to see your section headers, then begin researching and writing Section 1.`;
+}
+
+/**
+ * Build the skeleton markdown file for a research agent.
+ */
+export function buildSkeletonFile(agent: ResearchAgent, session: ResearchSession): string {
+  const header = `# ${agent.name}\n\n> Research workstream for: ${session.question}\n\n`;
+  const sections = agent.sections
+    .map((s) => `## ${s.title}\n\n*Research pending...*\n`)
+    .join('\n');
+  return header + sections;
+}
+
+/**
+ * Build the synthesis agent prompt.
+ */
+export function buildSynthesisPrompt(session: ResearchSession, agentOutputs: string[]): string {
+  const outputList = agentOutputs
+    .map((content, i) => {
+      const agent = session.agents[i];
+      return `--- Agent ${agent.id}: ${agent.name} ---\n\n${content}`;
+    })
+    .join('\n\n');
+
+  return `You are a research synthesis specialist. Multiple research agents have independently investigated different aspects of the following question:
+
+"${session.question}"
+
+Below are their complete research outputs. Your job is to produce a unified synthesis document.
+
+## Research Outputs
+
+${outputList}
+
+## Your Task
+
+Create a synthesis document with these sections:
+
+### Executive Summary
+3-5 bullet points capturing the most important findings across all research.
+
+### Key Findings by Theme
+Organize findings by cross-cutting themes (NOT by agent). Identify patterns that span multiple workstreams.
+
+### Contradictions & Tensions
+Where do the research streams disagree or present tensions? Note specific claims that conflict.
+
+### Confidence Assessment
+Rate the confidence level of key findings:
+- **Well-supported**: Multiple independent sources, strong evidence
+- **Moderate**: Some evidence, but limited sources or scope
+- **Speculative**: Limited evidence, primarily theoretical or anecdotal
+
+### Recommended Next Steps
+Actionable recommendations based on the research. What should someone do with this information?
+
+## Output Requirements
+- Write in markdown format
+- Cite sources using inline URLs from the original research
+- Be specific and concrete — avoid generic advice
+- Aim for a comprehensive document (300+ lines)
+- Write to the synthesis output file
+
+When done, add this exact line at the very end:
+
+Status: COMPLETE`;
+}

--- a/packages/pi-research-extension/extension/prompts.ts
+++ b/packages/pi-research-extension/extension/prompts.ts
@@ -19,9 +19,37 @@ Your Workstream: "${agent.name}"
 ## Sections to Cover
 ${sectionList}
 
+Tavily web search and information gathering tools are available (tavily-ai-skills).
+Use them strategically to find high-quality information. Here are the key skills at your disposal:
+
+*search* - Search the web using Tavily's API
+- Returns relevant results with content snippets, scores, and metadata
+- Best for finding web content on any topic
+- No coding required
+
+*research* - AI-synthesized research on any topic
+- Provides comprehensive results with citations
+- Supports structured JSON output for pipelines
+- Grounded in web data
+- Best for deep-dive research questions
+
+*extract* - Extract content from specific URLs
+- Returns clean markdown/text from web pages
+- Use when you have specific URLs and need their content
+- Better than search when you know exactly where to look
+
+*crawl* - Crawl websites and save as local markdown
+- Download documentation, knowledge bases, or web content
+- Saves pages locally for offline access or analysis
+- Best for systematically capturing entire websites
+
+*tavily-best-practices* - Production-ready Tavily integration guide
+- Reference for building agentic workflows, RAG systems, or autonomous agents
+- Best practices for web search, extraction, crawling, and research
+
 ## CRITICAL: Write Protocol
 You MUST follow this strict alternating pattern:
-1. Search for information (web search, read sources)
+1. Search for information (web search using Tavily skill, read sources)
 2. IMMEDIATELY write findings to your output file
 3. Search again
 4. IMMEDIATELY write again

--- a/packages/pi-research-extension/extension/state-io.ts
+++ b/packages/pi-research-extension/extension/state-io.ts
@@ -1,0 +1,62 @@
+/**
+ * State file I/O helpers for the research extension.
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { ResearchState } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+
+const STATE_REL_PATH = path.join('.sero', 'apps', 'research', 'state.json');
+
+export function resolveStatePath(cwd: string): string {
+  return path.join(cwd, STATE_REL_PATH);
+}
+
+export async function readState(filePath: string): Promise<ResearchState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as ResearchState;
+  } catch {
+    return { ...DEFAULT_STATE, history: [] };
+  }
+}
+
+export async function writeState(filePath: string, state: ResearchState): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+/**
+ * Count lines in a file. Returns 0 if the file doesn't exist.
+ */
+export async function countLines(filePath: string): Promise<number> {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    return content.split('\n').length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Read file contents. Returns empty string if the file doesn't exist.
+ */
+export async function readFile(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Create a directory and write initial skeleton content to a file.
+ */
+export async function writeSkeletonFile(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf8');
+}

--- a/packages/pi-research-extension/package.json
+++ b/packages/pi-research-extension/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@sero/research",
+  "version": "0.1.0",
+  "description": "Multi-agent research orchestrator — decompose questions into parallel workstreams, monitor progress, and synthesize results",
+  "keywords": [
+    "pi-package"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+  },
+  "pi": {
+    "extensions": [
+      "./extension/index.ts"
+    ],
+    "skills": [
+      "./skills"
+    ]
+  },
+  "sero": {
+    "app": {
+      "id": "research",
+      "name": "Research",
+      "icon": "search",
+      "stateFile": ".sero/apps/research/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "ResearchApp",
+      "devPort": 5191
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-agent-core": ">=0.55.3",
+    "@mariozechner/pi-ai": ">=0.55.3",
+    "@mariozechner/pi-coding-agent": ">=0.55.3",
+    "@mariozechner/pi-tui": ">=0.55.3"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "^1.11.0",
+    "@sero/app-runtime": "workspace:*",
+    "@tailwindcss/vite": "^4.1.18",
+    "@types/node": "^22.19.11",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/packages/pi-research-extension/shared/types.ts
+++ b/packages/pi-research-extension/shared/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared state types for the Research Orchestrator.
+ *
+ * Both the Pi extension and the Sero web UI read/write JSON files
+ * matching these shapes. The extension writes; the UI reads via useAppState.
+ */
+
+// ── Agent workstream ────────────────────────────────────────
+
+export type AgentStatus = 'pending' | 'running' | 'stuck' | 'complete' | 'failed';
+
+export interface ResearchSection {
+  title: string;
+  completed: boolean;
+}
+
+export interface ResearchAgent {
+  /** Agent index (1-based). */
+  id: number;
+  /** Agent name/label (e.g. "Decision Science & Optimal Stopping"). */
+  name: string;
+  /** Sections this agent will research. */
+  sections: ResearchSection[];
+  /** Current status. */
+  status: AgentStatus;
+  /** Relative path to the agent's output file. */
+  outputFile: string;
+  /** Line count of the output file (for progress monitoring). */
+  lineCount: number;
+  /** Number of monitoring check-ins where lineCount was unchanged. */
+  stuckChecks: number;
+  /** Error message if failed. */
+  error?: string;
+  /** ISO timestamp when started. */
+  startedAt?: string;
+  /** ISO timestamp when completed. */
+  completedAt?: string;
+}
+
+// ── Research session ────────────────────────────────────────
+
+export type ResearchPhase =
+  | 'idle'
+  | 'planning'
+  | 'awaiting_approval'
+  | 'researching'
+  | 'synthesizing'
+  | 'complete'
+  | 'failed';
+
+export interface ResearchSession {
+  /** Original research question. */
+  question: string;
+  /** Current phase. */
+  phase: ResearchPhase;
+  /** Research agents (workstreams). */
+  agents: ResearchAgent[];
+  /** Relative path to the synthesis output file. */
+  synthesisFile?: string;
+  /** Output directory (relative to workspace). */
+  outputDir: string;
+  /** ISO timestamp when the session started. */
+  startedAt: string;
+  /** ISO timestamp when the session completed. */
+  completedAt?: string;
+  /** Error message if failed. */
+  error?: string;
+  /** Number of monitoring cycles completed. */
+  monitorCycles: number;
+}
+
+// ── Top-level state ─────────────────────────────────────────
+
+export interface ResearchState {
+  /** Current active research session (null if none). */
+  current: ResearchSession | null;
+  /** Completed research sessions (most recent first). */
+  history: ResearchHistoryEntry[];
+}
+
+export interface ResearchHistoryEntry {
+  question: string;
+  outputDir: string;
+  agentCount: number;
+  completedAt: string;
+}
+
+export const DEFAULT_STATE: ResearchState = {
+  current: null,
+  history: [],
+};

--- a/packages/pi-research-extension/skills/research/SKILL.md
+++ b/packages/pi-research-extension/skills/research/SKILL.md
@@ -95,12 +95,12 @@ If an agent gets stuck (line count unchanged for 2+ check-ins):
 
 When ALL research agents are complete:
 1. Read all agent output files
-2. Launch a synthesis agent using the **subagent** tool:
+2. Launch the synthesis using **exactly** this subagent call. You MUST use agent `"research-analyst"` — do NOT use `"researcher"` or any other agent:
 
 ```
 subagent({
-  task: "Read the research outputs and synthesize...",
-  systemPrompt: "[synthesis prompt]"
+  agent: "research-analyst",
+  task: "Read the research outputs at [file paths] and create a synthesis document at [output dir]/synthesis.md"
 })
 ```
 
@@ -118,8 +118,9 @@ Call `research({ action: "status" })` one final time to mark the session complet
 ## Key Rules
 
 1. **Always show the plan before launching** — never skip user approval
-2. **Write-after-every-search** — agents that research without writing get stuck
-3. **Kill and relaunch stuck agents** — don't wait for self-correction
-4. **Skeleton files first** — create output files with headers before launch
-5. **Non-overlapping workstreams** — each agent covers a distinct aspect
+2. **Auto-synthesize** — when all research agents complete, launch the synthesis agent IMMEDIATELY without asking the user. The entire pipeline (research → synthesis) is automatic after approval.
+3. **Write-after-every-search** — agents that research without writing get stuck
+4. **Kill and relaunch stuck agents** — don't wait for self-correction
+5. **Skeleton files first** — create output files with headers before launch
+6. **Non-overlapping workstreams** — each agent covers a distinct aspect
 6. **Cite everything** — every claim must have an inline source URL

--- a/packages/pi-research-extension/skills/research/SKILL.md
+++ b/packages/pi-research-extension/skills/research/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: research
+description: Multi-agent research orchestrator. Decomposes any research question into parallel agent workstreams, launches them simultaneously, monitors progress, and synthesizes results into a unified document. Trigger with /research [question].
+allowed-tools: Read Bash Subagent Research WebSearch WebFetch
+---
+
+# Multi-Agent Research Orchestrator
+
+You are the orchestrator for a multi-agent research system. When the user asks you to research a topic, you will decompose it into parallel workstreams, launch agents, monitor progress, and synthesize results.
+
+## Workflow
+
+### Step 1: Decompose the Question
+
+Analyze the user's research question and break it into 2-4 **non-overlapping** workstreams. Each workstream should:
+- Cover a distinct aspect of the question
+- Have 3-6 specific sections
+- Not duplicate coverage with other workstreams
+
+Good decomposition example for "psychology of dating in your mid-30s":
+1. **Decision Science & Optimal Stopping** — Secretary problem, satisficing vs maximizing, paradox of choice, decision fatigue, sunk cost in relationships
+2. **Relationship Science & Compatibility** — Gottman's research, attachment theory, compatibility factors, relationship satisfaction predictors
+3. **Dating Channels & Strategy** — Apps vs community, meeting method vs outcome quality, cognitive biases in dating, online vs offline dynamics
+
+Bad decomposition (overlapping):
+1. Dating apps — ❌ overlaps with strategy
+2. Dating psychology — ❌ too broad, overlaps with everything
+3. Finding a partner — ❌ overlaps with everything
+
+### Step 2: Present Plan for Approval
+
+Use the **research** tool with action `plan` to create the plan:
+
+```
+research({
+  action: "plan",
+  question: "the user's question",
+  agents: [
+    { name: "Workstream Name", sections: ["Section 1", "Section 2", "Section 3"] },
+    { name: "Another Workstream", sections: ["Section A", "Section B", "Section C"] }
+  ]
+})
+```
+
+Wait for user approval before proceeding.
+
+### Step 3: Approve and Launch
+
+When the user approves:
+
+1. Call `research({ action: "approve" })` to set up skeleton files
+2. Launch all agents in parallel using the **subagent** tool:
+
+```
+subagent({
+  tasks: [
+    {
+      task: "Research and write about [workstream name]. Output file: research/[topic]/agent-1.md. Work through each section. Search → write → search → write.",
+      systemPrompt: "[detailed system prompt for this agent]"
+    },
+    // ... one per agent
+  ]
+})
+```
+
+Each agent MUST follow the **write-after-every-search** protocol:
+- Search for information
+- IMMEDIATELY write findings to its output file
+- Search again
+- IMMEDIATELY write again
+- NEVER do two searches in a row without writing
+
+### Step 4: Monitor Progress
+
+After launching, monitor at escalating intervals:
+- First check: ~30 seconds after launch
+- Second check: ~2 minutes later
+- Third check: ~5 minutes later
+- Then every ~5 minutes
+
+Call `research({ action: "status" })` at each check-in. This will:
+- Update line counts for each agent
+- Detect stuck agents (line count unchanged between checks)
+- Report which agents are done
+
+### Step 5: Handle Stuck Agents
+
+If an agent gets stuck (line count unchanged for 2+ check-ins):
+1. Kill the stuck subagent
+2. Read its current output file to preserve progress
+3. Relaunch with the existing data pre-loaded in the task prompt:
+   "Continue researching [topic]. Here is what you've written so far: [existing content]. Pick up where you left off."
+
+### Step 6: Synthesize
+
+When ALL research agents are complete:
+1. Read all agent output files
+2. Launch a synthesis agent using the **subagent** tool:
+
+```
+subagent({
+  task: "Read the research outputs and synthesize...",
+  systemPrompt: "[synthesis prompt]"
+})
+```
+
+The synthesis agent produces:
+- **Executive Summary** (3-5 bullets)
+- **Key Findings by Theme** (cross-cutting, not per-agent)
+- **Contradictions & Tensions**
+- **Confidence Assessment** (well-supported vs. speculative)
+- **Recommended Next Steps**
+
+### Step 7: Finalize
+
+Call `research({ action: "status" })` one final time to mark the session complete.
+
+## Key Rules
+
+1. **Always show the plan before launching** — never skip user approval
+2. **Write-after-every-search** — agents that research without writing get stuck
+3. **Kill and relaunch stuck agents** — don't wait for self-correction
+4. **Skeleton files first** — create output files with headers before launch
+5. **Non-overlapping workstreams** — each agent covers a distinct aspect
+6. **Cite everything** — every claim must have an inline source URL

--- a/packages/pi-research-extension/ui/AgentActivityPanel.tsx
+++ b/packages/pi-research-extension/ui/AgentActivityPanel.tsx
@@ -1,0 +1,170 @@
+/**
+ * AgentActivityPanel — live tool activity feed for a research agent.
+ *
+ * Similar to the Kanban ActivityPanel but standalone — no motion dependency,
+ * inline styles, federated-module-safe.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import type { AgentActivity } from './useResearchActivity';
+
+// ── Tool icons ──────────────────────────────────────────────
+
+const TOOL_ICONS: Record<string, string> = {
+  read: '📖', bash: '📂', write: '✏️', edit: '✏️',
+  ls: '📁', find: '🔍', grep: '🔎', glob: '🔍',
+  search: '🌐', research: '🔬', extract: '📄', crawl: '🕷️',
+};
+
+function toolIcon(name: string): string {
+  return TOOL_ICONS[name] ?? '🔧';
+}
+
+function formatElapsed(startedAt: number): string {
+  const ms = Date.now() - startedAt;
+  if (ms >= 60000) return `${(ms / 60000).toFixed(1)}m`;
+  return `${Math.round(ms / 1000)}s`;
+}
+
+// ── Component ───────────────────────────────────────────────
+
+interface AgentActivityPanelProps {
+  activity: AgentActivity;
+}
+
+export function AgentActivityPanel({ activity }: AgentActivityPanelProps) {
+  const isRunning = activity.status === 'running' || activity.status === 'queued';
+  const isFailed = activity.status === 'failed' || activity.status === 'timed_out';
+
+  // Elapsed timer
+  const [elapsed, setElapsed] = useState('');
+  useEffect(() => {
+    if (!isRunning) return;
+    const tick = () => setElapsed(formatElapsed(activity.startedAt));
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [isRunning, activity.startedAt]);
+
+  const hasTools = activity.tools.length > 0;
+  const hasOutput = activity.liveOutput.length > 0;
+
+  const accentColor = isFailed ? 'var(--rs-danger)' : 'var(--rs-accent)';
+
+  return (
+    <div style={{
+      borderRadius: 6,
+      border: `1px solid ${isFailed ? 'rgba(248, 113, 113, 0.2)' : 'rgba(129, 140, 248, 0.15)'}`,
+      background: isFailed ? 'rgba(248, 113, 113, 0.04)' : 'rgba(129, 140, 248, 0.04)',
+      overflow: 'hidden',
+      marginTop: 6,
+    }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px' }}>
+        {isRunning && (
+          <span style={{
+            display: 'inline-block', width: 6, height: 6, borderRadius: '50%',
+            backgroundColor: accentColor,
+            animation: 'rs-pulse 2s ease-in-out infinite',
+            flexShrink: 0,
+          }} />
+        )}
+        <span style={{ fontSize: 11, fontWeight: 500, color: accentColor, flex: 1 }}>
+          {isFailed ? 'Failed' : isRunning ? 'Working…' : 'Completed'}
+        </span>
+        {elapsed && (
+          <span style={{ fontSize: 10, color: 'var(--rs-dim)', fontVariantNumeric: 'tabular-nums' }}>
+            {elapsed}
+          </span>
+        )}
+      </div>
+
+      {/* Tool feed */}
+      {hasTools && <ToolFeed tools={activity.tools} accentColor={accentColor} />}
+
+      {/* Live output snippet */}
+      {hasOutput && isRunning && <LiveOutputPreview text={activity.liveOutput} />}
+
+      {/* Error */}
+      {activity.error && (
+        <div style={{ padding: '6px 10px', fontSize: 11, color: 'var(--rs-danger)', lineHeight: 1.4 }}>
+          {activity.error}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!hasTools && !hasOutput && !activity.error && isRunning && (
+        <p style={{ fontSize: 11, color: 'var(--rs-dim)', padding: '0 10px 8px', lineHeight: 1.4 }}>
+          Waiting for first tool call…
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Tool feed ───────────────────────────────────────────────
+
+function ToolFeed({ tools, accentColor }: {
+  tools: Array<{ toolName: string; argsSummary: string; running: boolean }>;
+  accentColor: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.scrollTop = ref.current.scrollHeight;
+  }, [tools.length]);
+
+  return (
+    <div ref={ref} style={{
+      maxHeight: 130, overflowY: 'auto', padding: '2px 10px 6px',
+      borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+    }}>
+      {tools.map((t, i) => (
+        <div key={`${t.toolName}-${i}`} style={{
+          display: 'flex', alignItems: 'center', gap: 6, padding: '2px 0',
+        }}>
+          <span style={{
+            display: 'inline-block', width: 5, height: 5, borderRadius: '50%',
+            backgroundColor: t.running ? accentColor : 'var(--rs-success)',
+            animation: t.running ? 'rs-pulse 1.5s ease-in-out infinite' : undefined,
+            flexShrink: 0,
+          }} />
+          <span style={{ fontSize: 10, flexShrink: 0 }}>{toolIcon(t.toolName)}</span>
+          <span style={{ fontSize: 10, fontWeight: 500, color: 'var(--rs-dim)', flexShrink: 0 }}>
+            {t.toolName}
+          </span>
+          {t.argsSummary && (
+            <span style={{
+              fontSize: 10, color: 'rgba(139, 141, 151, 0.5)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0,
+            }}>
+              {t.argsSummary}
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Live output preview ─────────────────────────────────────
+
+function LiveOutputPreview({ text }: { text: string }) {
+  const ref = useRef<HTMLPreElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.scrollTop = ref.current.scrollHeight;
+  }, [text]);
+
+  const preview = text.length > 400 ? '…' + text.slice(-400) : text;
+
+  return (
+    <pre style={{
+      maxHeight: 80, overflowY: 'auto', margin: '0 10px 6px',
+      padding: 6, borderRadius: 4, fontSize: 10, lineHeight: 1.5,
+      background: 'var(--rs-bg)', color: 'rgba(139, 141, 151, 0.7)',
+      whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+      borderTop: '1px solid rgba(255, 255, 255, 0.04)',
+    }}>
+      {preview}
+    </pre>
+  );
+}

--- a/packages/pi-research-extension/ui/IdleView.tsx
+++ b/packages/pi-research-extension/ui/IdleView.tsx
@@ -1,0 +1,71 @@
+/**
+ * IdleView — empty state with research input and history list.
+ */
+
+import { useState, useCallback } from 'react';
+import type { ResearchHistoryEntry } from '../shared/types';
+
+interface IdleViewProps {
+  onStart: (question: string) => void;
+  history: ResearchHistoryEntry[];
+}
+
+export function IdleView({ onStart, history }: IdleViewProps) {
+  const [question, setQuestion] = useState('');
+
+  const handleSubmit = useCallback(() => {
+    const q = question.trim();
+    if (q) {
+      onStart(q);
+      setQuestion('');
+    }
+  }, [question, onStart]);
+
+  return (
+    <>
+      <div style={{ flex: '1 1 0%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 24px', textAlign: 'center' }}>
+        <div className="rs-empty-orb rs-animate-in" style={{ marginBottom: 20 }} />
+        <h2 style={{ margin: 0, fontSize: 18, fontWeight: 500, color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+          Multi-Agent Research
+        </h2>
+        <p style={{ margin: '8px 0 20px', maxWidth: 360, fontSize: 14, lineHeight: 1.6, color: 'var(--rs-muted)' }}>
+          Decompose any question into parallel workstreams. Multiple agents research simultaneously and synthesize results.
+        </p>
+        <div style={{ display: 'flex', gap: 8, width: '100%', maxWidth: 420 }}>
+          <input
+            className="rs-input"
+            value={question}
+            onChange={(e) => setQuestion(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+            placeholder="What do you want to research?"
+          />
+          <button
+            onClick={handleSubmit}
+            className="rs-button primary"
+            disabled={!question.trim()}
+          >
+            Research
+          </button>
+        </div>
+      </div>
+
+      {history.length > 0 && (
+        <div style={{ flexShrink: 0, borderTop: '1px solid var(--rs-border)', padding: '16px 20px' }}>
+          <div style={{ fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--rs-dim)', marginBottom: 8 }}>
+            History
+          </div>
+          {history.slice(0, 5).map((entry, i) => (
+            <div key={i} style={{ fontSize: 13, color: 'var(--rs-muted)', padding: '6px 0', borderBottom: i < Math.min(history.length, 5) - 1 ? '1px solid var(--rs-border)' : 'none' }}>
+              <div style={{ color: 'var(--rs-text)', fontWeight: 400 }}>
+                {entry.question.length > 70 ? entry.question.slice(0, 70) + '…' : entry.question}
+              </div>
+              <div style={{ fontSize: 11, marginTop: 2 }}>
+                {entry.agentCount} agents · {entry.outputDir}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/pi-research-extension/ui/ResearchApp.tsx
+++ b/packages/pi-research-extension/ui/ResearchApp.tsx
@@ -1,13 +1,17 @@
 /**
  * ResearchApp — Sero web UI for the multi-agent research orchestrator.
  *
- * Shows research progress: active workstreams, line counts, status, and history.
+ * Shows research progress: active workstreams, section detail, and history.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useState, useCallback, useContext } from 'react';
 import { useAppState, useAgentPrompt } from '@sero/app-runtime';
+import { AppContext } from '@sero/app-runtime';
 import type { ResearchState, ResearchSession, ResearchAgent, AgentStatus } from '../shared/types';
 import { DEFAULT_STATE } from '../shared/types';
+import { useResearchActivity, type AgentActivity } from './useResearchActivity';
+import { AgentActivityPanel } from './AgentActivityPanel';
+import { IdleView } from './IdleView';
 
 // ── Styles ───────────────────────────────────────────────────
 
@@ -51,8 +55,12 @@ const CUSTOM_STYLES = `
   .rs-progress-bar { height: 3px; border-radius: 2px; background: var(--rs-bg-elevated); overflow: hidden; margin-top: 12px; }
   .rs-progress-fill { height: 100%; border-radius: 2px; transition: width 0.3s ease; }
 
-  .rs-agent-card { padding: 14px 16px; border-radius: 8px; transition: background 0.15s; margin-bottom: 2px; }
+  .rs-agent-card { padding: 14px 16px; border-radius: 8px; transition: background 0.15s; margin-bottom: 2px; cursor: pointer; user-select: none; }
   .rs-agent-card:hover { background: var(--rs-bg-elevated); }
+
+  .rs-section-list { padding: 0 16px 10px 56px; }
+  .rs-section-item { display: flex; align-items: center; gap: 8px; padding: 3px 0; font-size: 12px; color: var(--rs-muted); }
+  .rs-section-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 
   .rs-badge { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; border-radius: 6px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
 
@@ -62,6 +70,12 @@ const CUSTOM_STYLES = `
   .rs-button.primary:hover:not(:disabled) { background: var(--rs-accent-hover); box-shadow: 0 0 20px var(--rs-accent-glow); }
   .rs-button.secondary { background: var(--rs-bg-elevated); color: var(--rs-muted); }
   .rs-button.secondary:hover:not(:disabled) { color: var(--rs-text); }
+  .rs-button.danger { background: rgba(248, 113, 113, 0.12); color: var(--rs-danger); }
+  .rs-button.danger:hover:not(:disabled) { background: rgba(248, 113, 113, 0.2); }
+
+  .rs-input { flex: 1; border: 1px solid var(--rs-border); border-radius: 8px; padding: 8px 14px; font-size: 14px; font-family: 'DM Sans', sans-serif; background: var(--rs-bg-elevated); color: var(--rs-text); outline: none; transition: border-color 0.15s; }
+  .rs-input::placeholder { color: var(--rs-dim); }
+  .rs-input:focus { border-color: var(--rs-accent); }
 
   .rs-empty-orb { width: 56px; height: 56px; border-radius: 50%; background: radial-gradient(circle at 40% 40%, var(--rs-accent) 0%, transparent 70%); opacity: 0.15; animation: rs-pulse 3s ease-in-out infinite; }
   @keyframes rs-pulse {
@@ -77,20 +91,60 @@ const CUSTOM_STYLES = `
 // ── Main Component ─────────────────────────────────────────
 
 export function ResearchApp() {
-  const [state] = useAppState<ResearchState>(DEFAULT_STATE);
+  const [state, updateState] = useAppState<ResearchState>(DEFAULT_STATE);
   const prompt = useAgentPrompt();
+  const ctx = useContext(AppContext);
+  const workspaceId = ctx?.workspaceId ?? '';
 
-  const startResearch = useCallback(() => {
-    prompt('/research');
+  // Track live subagent activity for running research agents
+  const agentActivity = useResearchActivity(
+    state.current?.agents ?? [],
+    workspaceId,
+  );
+
+  const startResearch = useCallback((question: string) => {
+    prompt(`/research ${question}`);
   }, [prompt]);
 
-  const checkStatus = useCallback(() => {
-    prompt('Check the status of the current research using the research tool with action "status".');
+  const approveResearch = useCallback(() => {
+    prompt(
+      'Approve the research plan and begin. Call research(action: "approve") ' +
+      'then follow the returned instructions to launch all agents in parallel using the subagent tool.',
+    );
   }, [prompt]);
 
   const cancelResearch = useCallback(() => {
-    prompt('Cancel the current research using the research tool with action "cancel".');
-  }, [prompt]);
+    // Immediate UI update — don't wait for agent to process
+    updateState((prev) => {
+      if (!prev.current) return prev;
+      return {
+        ...prev,
+        history: [{
+          question: prev.current.question,
+          outputDir: prev.current.outputDir,
+          agentCount: prev.current.agents.length,
+          completedAt: new Date().toISOString(),
+        }, ...prev.history],
+        current: null,
+      };
+    });
+  }, [updateState]);
+
+  const dismissResearch = useCallback(() => {
+    updateState((prev) => {
+      if (!prev.current) return prev;
+      return {
+        ...prev,
+        history: [{
+          question: prev.current.question,
+          outputDir: prev.current.outputDir,
+          agentCount: prev.current.agents.length,
+          completedAt: prev.current.completedAt || new Date().toISOString(),
+        }, ...prev.history],
+        current: null,
+      };
+    });
+  }, [updateState]);
 
   return (
     <>
@@ -98,7 +152,13 @@ export function ResearchApp() {
       <div className="rs-root" style={{ display: 'flex', height: '100%', width: '100%', flexDirection: 'column', overflow: 'hidden', padding: 24 }}>
         <div className="rs-card" style={{ display: 'flex', flex: '1 1 0%', flexDirection: 'column', overflow: 'hidden' }}>
           {state.current ? (
-            <ActiveResearch session={state.current} onCheckStatus={checkStatus} onCancel={cancelResearch} />
+            <ActiveResearch
+              session={state.current}
+              agentActivity={agentActivity}
+              onApprove={approveResearch}
+              onCancel={cancelResearch}
+              onDismiss={dismissResearch}
+            />
           ) : (
             <IdleView onStart={startResearch} history={state.history} />
           )}
@@ -110,12 +170,17 @@ export function ResearchApp() {
 
 // ── Active Research View ───────────────────────────────────
 
-function ActiveResearch({ session, onCheckStatus, onCancel }: {
+function ActiveResearch({ session, agentActivity, onApprove, onCancel, onDismiss }: {
   session: ResearchSession;
-  onCheckStatus: () => void;
+  agentActivity: Map<string, AgentActivity>;
+  onApprove: () => void;
   onCancel: () => void;
+  onDismiss: () => void;
 }) {
-  const completed = session.agents.filter((a) => a.status === 'complete').length;
+  // Count completions using effective status (live subagent data)
+  const completed = session.agents.filter((a) =>
+    deriveEffectiveStatus(a.status, agentActivity.get(a.name)) === 'complete',
+  ).length;
   const total = session.agents.length;
   const progress = total > 0 ? (completed / total) * 100 : 0;
 
@@ -125,15 +190,17 @@ function ActiveResearch({ session, onCheckStatus, onCancel }: {
       <div style={{ flex: '1 1 0%', overflowY: 'auto', padding: '8px 20px' }}>
         <div className="rs-animate-in">
           {session.agents.map((agent) => (
-            <AgentCard key={agent.id} agent={agent} />
+            <AgentCard key={agent.id} agent={agent} activity={agentActivity.get(agent.name)} />
           ))}
           {session.phase === 'synthesizing' && <SynthesisCard />}
         </div>
       </div>
-      <ActionBar phase={session.phase} onCheckStatus={onCheckStatus} onCancel={onCancel} />
+      <ActionBar phase={session.phase} onApprove={onApprove} onCancel={onCancel} onDismiss={onDismiss} />
     </>
   );
 }
+
+// ── Header ─────────────────────────────────────────────────
 
 function Header({ session, completed, total, progress }: {
   session: ResearchSession; completed: number; total: number; progress: number;
@@ -174,40 +241,77 @@ function Header({ session, completed, total, progress }: {
   );
 }
 
-function AgentCard({ agent }: { agent: ResearchAgent }) {
-  const icon = statusIconChar(agent.status);
-  const statusColor = statusColorVar(agent.status);
+// ── Agent Card (expandable sections) ───────────────────────
+
+function AgentCard({ agent, activity }: { agent: ResearchAgent; activity?: AgentActivity }) {
+  const [expanded, setExpanded] = useState(false);
+
+  // Derive effective status: prefer live subagent status over stale state file
+  const effectiveStatus: AgentStatus = deriveEffectiveStatus(agent.status, activity);
+  const isRunning = effectiveStatus === 'running';
+
+  const icon = statusIconChar(effectiveStatus);
+  const statusColor = statusColorVar(effectiveStatus);
 
   return (
-    <div className="rs-agent-card" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-      <div style={{
-        width: 28, height: 28, borderRadius: 8,
-        display: 'flex', alignItems: 'center', justifyContent: 'center',
-        fontSize: 14, flexShrink: 0,
-        background: `${statusColor}18`,
-        border: `1.5px solid ${statusColor}40`,
-      }}>
-        {agent.status === 'running' ? <Spinner size={14} /> : icon}
-      </div>
-      <div style={{ flex: '1 1 0%', minWidth: 0 }}>
-        <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--rs-text)' }}>
-          Agent {agent.id}: {agent.name}
+    <div>
+      <div className="rs-agent-card" style={{ display: 'flex', alignItems: 'center', gap: 12 }} onClick={() => setExpanded(!expanded)}>
+        <div style={{
+          width: 28, height: 28, borderRadius: 8,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 14, flexShrink: 0,
+          background: `${statusColor}18`,
+          border: `1.5px solid ${statusColor}40`,
+        }}>
+          {isRunning ? <Spinner size={14} /> : icon}
         </div>
-        <div style={{ fontSize: 12, color: 'var(--rs-muted)', marginTop: 2 }}>
-          {agent.sections.length} sections
-          {agent.lineCount > 0 && ` · ${agent.lineCount} lines`}
-          {agent.status === 'stuck' && ' · ⚠️ Stuck'}
+        <div style={{ flex: '1 1 0%', minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--rs-text)' }}>
+            Agent {agent.id}: {agent.name}
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--rs-muted)', marginTop: 2 }}>
+            {agent.sections.length} sections
+            {agent.lineCount > 0 && ` · ${agent.lineCount} lines`}
+            {effectiveStatus === 'stuck' && ' · ⚠️ Stuck'}
+          </div>
         </div>
+        <span className="rs-badge" style={{ background: `${statusColor}18`, color: statusColor }}>
+          {effectiveStatus}
+        </span>
+        <Chevron expanded={expanded} />
       </div>
-      <span className="rs-badge" style={{
-        background: `${statusColor}18`,
-        color: statusColor,
-      }}>
-        {agent.status}
-      </span>
+
+      {expanded && (
+        <div className="rs-section-list">
+          {isRunning ? (
+            /* When running: show only the activity panel */
+            activity ? (
+              <AgentActivityPanel activity={activity} />
+            ) : (
+              <p style={{ fontSize: 11, color: 'var(--rs-dim)', padding: '4px 0', lineHeight: 1.4 }}>
+                Waiting for agent to start…
+              </p>
+            )
+          ) : (
+            /* When not running: show sections */
+            agent.sections.map((s, i) => (
+              <div key={i} className="rs-section-item">
+                <div className="rs-section-dot" style={{
+                  background: s.completed ? 'var(--rs-success)' : 'var(--rs-dim)',
+                }} />
+                <span style={s.completed ? { color: 'var(--rs-success)' } : undefined}>
+                  {s.title}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
     </div>
   );
 }
+
+// ── Synthesis Card ─────────────────────────────────────────
 
 function SynthesisCard() {
   return (
@@ -234,6 +338,8 @@ function SynthesisCard() {
   );
 }
 
+// ── Phase Badge ────────────────────────────────────────────
+
 function PhaseBadge({ phase }: { phase: string }) {
   const config: Record<string, { label: string; bg: string; color: string }> = {
     idle: { label: 'Idle', bg: 'var(--rs-bg-elevated)', color: 'var(--rs-dim)' },
@@ -248,77 +354,63 @@ function PhaseBadge({ phase }: { phase: string }) {
   return <span className="rs-badge" style={{ background: bg, color }}>{label}</span>;
 }
 
-function ActionBar({ phase, onCheckStatus, onCancel }: {
-  phase: string; onCheckStatus: () => void; onCancel: () => void;
+// ── Action Bar ─────────────────────────────────────────────
+
+function ActionBar({ phase, onApprove, onCancel, onDismiss }: {
+  phase: string;
+  onApprove: () => void;
+  onCancel: () => void;
+  onDismiss: () => void;
 }) {
   return (
     <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '16px 20px', borderTop: '1px solid var(--rs-border)' }}>
-      {(phase === 'researching' || phase === 'synthesizing') && (
+      {phase === 'awaiting_approval' && (
         <>
-          <button onClick={onCheckStatus} className="rs-button primary">Check Status</button>
+          <button onClick={onApprove} className="rs-button primary">Approve &amp; Launch</button>
           <button onClick={onCancel} className="rs-button secondary">Cancel</button>
         </>
       )}
-      {phase === 'awaiting_approval' && (
-        <span style={{ fontSize: 12, color: 'var(--rs-warning)' }}>
-          Approve the plan in the chat to begin research
-        </span>
+      {(phase === 'researching' || phase === 'synthesizing') && (
+        <button onClick={onCancel} className="rs-button danger">Cancel Research</button>
       )}
-      {phase === 'complete' && (
-        <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--rs-success)' }}>
-          ✓ Research complete — check the output files
-        </span>
+      {(phase === 'complete' || phase === 'failed') && (
+        <>
+          {phase === 'complete' && (
+            <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--rs-success)', marginRight: 'auto' }}>
+              ✓ Research complete — check the output files
+            </span>
+          )}
+          {phase === 'failed' && (
+            <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--rs-danger)', marginRight: 'auto' }}>
+              Research failed or was cancelled
+            </span>
+          )}
+          <button onClick={onDismiss} className="rs-button secondary">Dismiss</button>
+        </>
       )}
     </div>
   );
 }
 
-// ── Idle View ───────────────────────────────────────────────
-
-function IdleView({ onStart, history }: {
-  onStart: () => void;
-  history: Array<{ question: string; outputDir: string; agentCount: number; completedAt: string }>;
-}) {
-  return (
-    <>
-      <div style={{ flex: '1 1 0%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 24px', textAlign: 'center' }}>
-        <div className="rs-empty-orb rs-animate-in" style={{ marginBottom: 20 }} />
-        <h2 style={{ margin: 0, fontSize: 18, fontWeight: 500, color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
-          Multi-Agent Research
-        </h2>
-        <p style={{ margin: '8px 0 20px', maxWidth: 300, fontSize: 14, lineHeight: 1.6, color: 'var(--rs-muted)' }}>
-          Decompose any question into parallel workstreams. Multiple agents research simultaneously and synthesize results.
-        </p>
-        <button onClick={onStart} className="rs-button primary">Start Research</button>
-      </div>
-
-      {history.length > 0 && (
-        <div style={{ flexShrink: 0, borderTop: '1px solid var(--rs-border)', padding: '16px 20px' }}>
-          <div style={{ fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--rs-dim)', marginBottom: 8 }}>
-            History
-          </div>
-          {history.slice(0, 5).map((entry, i) => (
-            <div key={i} style={{ fontSize: 13, color: 'var(--rs-muted)', padding: '6px 0', borderBottom: i < history.length - 1 ? '1px solid var(--rs-border)' : 'none' }}>
-              <div style={{ color: 'var(--rs-text)', fontWeight: 400 }}>
-                {entry.question.length > 70 ? entry.question.slice(0, 70) + '…' : entry.question}
-              </div>
-              <div style={{ fontSize: 11, marginTop: 2 }}>
-                {entry.agentCount} agents · {entry.outputDir}
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </>
-  );
-}
-
-// ── Icons ──────────────────────────────────────────────────
+// ── Icons & Utils ──────────────────────────────────────────
 
 function Spinner({ size = 14 }: { size?: number }) {
   return (
     <svg className="rs-spinner" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
       <path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function Chevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width={14} height={14} viewBox="0 0 24 24"
+      fill="none" stroke="var(--rs-dim)" strokeWidth={2}
+      strokeLinecap="round" strokeLinejoin="round"
+      style={{ transition: 'transform 0.15s', transform: expanded ? 'rotate(90deg)' : 'rotate(0)' }}
+    >
+      <path d="M9 18l6-6-6-6" />
     </svg>
   );
 }
@@ -341,6 +433,27 @@ function statusColorVar(status: AgentStatus): string {
     case 'complete': return 'var(--rs-success)';
     case 'failed': return 'var(--rs-danger)';
   }
+}
+
+/**
+ * Derive the effective agent status by combining the state file status
+ * with live subagent activity. The state file only updates on explicit
+ * status checks, so the subagent tracker is the source of truth for
+ * whether an agent has actually completed.
+ */
+function deriveEffectiveStatus(
+  stateStatus: AgentStatus,
+  activity?: AgentActivity,
+): AgentStatus {
+  if (!activity) return stateStatus;
+
+  // Map subagent statuses to research agent statuses
+  if (activity.status === 'completed') return 'complete';
+  if (activity.status === 'failed' || activity.status === 'timed_out') return 'failed';
+  if (activity.status === 'aborted') return 'failed';
+  if (activity.status === 'running' || activity.status === 'queued') return 'running';
+
+  return stateStatus;
 }
 
 export default ResearchApp;

--- a/packages/pi-research-extension/ui/ResearchApp.tsx
+++ b/packages/pi-research-extension/ui/ResearchApp.tsx
@@ -1,0 +1,346 @@
+/**
+ * ResearchApp — Sero web UI for the multi-agent research orchestrator.
+ *
+ * Shows research progress: active workstreams, line counts, status, and history.
+ */
+
+import { useCallback, useMemo } from 'react';
+import { useAppState, useAgentPrompt } from '@sero/app-runtime';
+import type { ResearchState, ResearchSession, ResearchAgent, AgentStatus } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+
+// ── Styles ───────────────────────────────────────────────────
+
+const CUSTOM_STYLES = `
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300;1,9..40,400&display=swap');
+
+  .rs-root {
+    --rs-bg: #0f1117;
+    --rs-bg-surface: #191b23;
+    --rs-bg-elevated: #22252f;
+    --rs-text: #e8e4df;
+    --rs-muted: #8b8d97;
+    --rs-dim: #5c5e6a;
+    --rs-accent: #818cf8;
+    --rs-accent-hover: #a5b4fc;
+    --rs-accent-glow: rgba(129, 140, 248, 0.12);
+    --rs-success: #34d399;
+    --rs-warning: #fbbf24;
+    --rs-danger: #f87171;
+    --rs-border: rgba(255, 255, 255, 0.07);
+    font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
+    background: var(--rs-bg);
+    color: var(--rs-text);
+  }
+  @supports (color: var(--bg-base)) {
+    .rs-root {
+      --rs-bg: var(--bg-base, #0f1117);
+      --rs-bg-surface: var(--bg-surface, #191b23);
+      --rs-bg-elevated: var(--bg-elevated, #22252f);
+      --rs-text: var(--text-primary, #e8e4df);
+      --rs-border: var(--border, rgba(255, 255, 255, 0.07));
+    }
+  }
+
+  .rs-card {
+    background: var(--rs-bg-surface);
+    border: 1px solid var(--rs-border);
+    border-radius: 12px;
+  }
+
+  .rs-progress-bar { height: 3px; border-radius: 2px; background: var(--rs-bg-elevated); overflow: hidden; margin-top: 12px; }
+  .rs-progress-fill { height: 100%; border-radius: 2px; transition: width 0.3s ease; }
+
+  .rs-agent-card { padding: 14px 16px; border-radius: 8px; transition: background 0.15s; margin-bottom: 2px; }
+  .rs-agent-card:hover { background: var(--rs-bg-elevated); }
+
+  .rs-badge { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; border-radius: 6px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; }
+
+  .rs-button { border: none; border-radius: 8px; padding: 8px 18px; font-size: 13px; font-weight: 500; font-family: 'DM Sans', sans-serif; cursor: pointer; transition: all 0.15s; white-space: nowrap; }
+  .rs-button:disabled { opacity: 0.35; cursor: default; }
+  .rs-button.primary { background: var(--rs-accent); color: #fff; }
+  .rs-button.primary:hover:not(:disabled) { background: var(--rs-accent-hover); box-shadow: 0 0 20px var(--rs-accent-glow); }
+  .rs-button.secondary { background: var(--rs-bg-elevated); color: var(--rs-muted); }
+  .rs-button.secondary:hover:not(:disabled) { color: var(--rs-text); }
+
+  .rs-empty-orb { width: 56px; height: 56px; border-radius: 50%; background: radial-gradient(circle at 40% 40%, var(--rs-accent) 0%, transparent 70%); opacity: 0.15; animation: rs-pulse 3s ease-in-out infinite; }
+  @keyframes rs-pulse {
+    0%, 100% { transform: scale(1); opacity: 0.15; }
+    50% { transform: scale(1.1); opacity: 0.25; }
+  }
+  @keyframes rs-fade-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }
+  .rs-animate-in { animation: rs-fade-in 0.3s ease-out both; }
+  @keyframes rs-spin { to { transform: rotate(360deg); } }
+  .rs-spinner { animation: rs-spin 0.8s linear infinite; }
+`;
+
+// ── Main Component ─────────────────────────────────────────
+
+export function ResearchApp() {
+  const [state] = useAppState<ResearchState>(DEFAULT_STATE);
+  const prompt = useAgentPrompt();
+
+  const startResearch = useCallback(() => {
+    prompt('/research');
+  }, [prompt]);
+
+  const checkStatus = useCallback(() => {
+    prompt('Check the status of the current research using the research tool with action "status".');
+  }, [prompt]);
+
+  const cancelResearch = useCallback(() => {
+    prompt('Cancel the current research using the research tool with action "cancel".');
+  }, [prompt]);
+
+  return (
+    <>
+      <style>{CUSTOM_STYLES}</style>
+      <div className="rs-root" style={{ display: 'flex', height: '100%', width: '100%', flexDirection: 'column', overflow: 'hidden', padding: 24 }}>
+        <div className="rs-card" style={{ display: 'flex', flex: '1 1 0%', flexDirection: 'column', overflow: 'hidden' }}>
+          {state.current ? (
+            <ActiveResearch session={state.current} onCheckStatus={checkStatus} onCancel={cancelResearch} />
+          ) : (
+            <IdleView onStart={startResearch} history={state.history} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Active Research View ───────────────────────────────────
+
+function ActiveResearch({ session, onCheckStatus, onCancel }: {
+  session: ResearchSession;
+  onCheckStatus: () => void;
+  onCancel: () => void;
+}) {
+  const completed = session.agents.filter((a) => a.status === 'complete').length;
+  const total = session.agents.length;
+  const progress = total > 0 ? (completed / total) * 100 : 0;
+
+  return (
+    <>
+      <Header session={session} completed={completed} total={total} progress={progress} />
+      <div style={{ flex: '1 1 0%', overflowY: 'auto', padding: '8px 20px' }}>
+        <div className="rs-animate-in">
+          {session.agents.map((agent) => (
+            <AgentCard key={agent.id} agent={agent} />
+          ))}
+          {session.phase === 'synthesizing' && <SynthesisCard />}
+        </div>
+      </div>
+      <ActionBar phase={session.phase} onCheckStatus={onCheckStatus} onCancel={onCancel} />
+    </>
+  );
+}
+
+function Header({ session, completed, total, progress }: {
+  session: ResearchSession; completed: number; total: number; progress: number;
+}) {
+  return (
+    <div style={{ flexShrink: 0, padding: '20px 20px 12px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h1 style={{ margin: 0, fontSize: 20, fontWeight: 500, letterSpacing: '-0.01em', color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+          Research
+        </h1>
+        <PhaseBadge phase={session.phase} />
+      </div>
+      <p style={{ margin: '8px 0 0', fontSize: 13, color: 'var(--rs-muted)', lineHeight: 1.4, maxWidth: 500 }}>
+        {session.question}
+      </p>
+      <div className="rs-progress-bar">
+        <div className="rs-progress-fill" style={{
+          width: `${progress}%`,
+          background: session.phase === 'complete' ? 'var(--rs-success)' : 'var(--rs-accent)',
+        }} />
+      </div>
+      <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 12, fontSize: 12, color: 'var(--rs-muted)' }}>
+        <span>
+          <strong style={{ fontVariantNumeric: 'tabular-nums', color: 'var(--rs-accent)' }}>{completed}</strong>
+          {' / '}{total} agents complete
+        </span>
+        {session.phase === 'researching' && (
+          <span style={{ color: 'var(--rs-success)' }}>● Researching</span>
+        )}
+        {session.phase === 'synthesizing' && (
+          <span style={{ color: 'var(--rs-warning)' }}>● Synthesizing</span>
+        )}
+        {session.phase === 'complete' && (
+          <span style={{ color: 'var(--rs-success)' }}>✓ Complete</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AgentCard({ agent }: { agent: ResearchAgent }) {
+  const icon = statusIconChar(agent.status);
+  const statusColor = statusColorVar(agent.status);
+
+  return (
+    <div className="rs-agent-card" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div style={{
+        width: 28, height: 28, borderRadius: 8,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 14, flexShrink: 0,
+        background: `${statusColor}18`,
+        border: `1.5px solid ${statusColor}40`,
+      }}>
+        {agent.status === 'running' ? <Spinner size={14} /> : icon}
+      </div>
+      <div style={{ flex: '1 1 0%', minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--rs-text)' }}>
+          Agent {agent.id}: {agent.name}
+        </div>
+        <div style={{ fontSize: 12, color: 'var(--rs-muted)', marginTop: 2 }}>
+          {agent.sections.length} sections
+          {agent.lineCount > 0 && ` · ${agent.lineCount} lines`}
+          {agent.status === 'stuck' && ' · ⚠️ Stuck'}
+        </div>
+      </div>
+      <span className="rs-badge" style={{
+        background: `${statusColor}18`,
+        color: statusColor,
+      }}>
+        {agent.status}
+      </span>
+    </div>
+  );
+}
+
+function SynthesisCard() {
+  return (
+    <div className="rs-agent-card" style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <div style={{
+        width: 28, height: 28, borderRadius: 8,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 14, flexShrink: 0,
+        background: 'rgba(251, 191, 36, 0.1)',
+        border: '1.5px solid rgba(251, 191, 36, 0.25)',
+      }}>
+        <Spinner size={14} />
+      </div>
+      <div style={{ flex: '1 1 0%' }}>
+        <div style={{ fontSize: 14, fontWeight: 500, color: 'var(--rs-text)' }}>Synthesis Agent</div>
+        <div style={{ fontSize: 12, color: 'var(--rs-muted)', marginTop: 2 }}>
+          Cross-cutting analysis in progress...
+        </div>
+      </div>
+      <span className="rs-badge" style={{ background: 'rgba(251, 191, 36, 0.12)', color: 'var(--rs-warning)' }}>
+        running
+      </span>
+    </div>
+  );
+}
+
+function PhaseBadge({ phase }: { phase: string }) {
+  const config: Record<string, { label: string; bg: string; color: string }> = {
+    idle: { label: 'Idle', bg: 'var(--rs-bg-elevated)', color: 'var(--rs-dim)' },
+    planning: { label: 'Planning', bg: 'rgba(129, 140, 248, 0.12)', color: 'var(--rs-accent)' },
+    awaiting_approval: { label: 'Awaiting Approval', bg: 'rgba(251, 191, 36, 0.12)', color: 'var(--rs-warning)' },
+    researching: { label: 'Researching', bg: 'rgba(52, 211, 153, 0.12)', color: 'var(--rs-success)' },
+    synthesizing: { label: 'Synthesizing', bg: 'rgba(251, 191, 36, 0.12)', color: 'var(--rs-warning)' },
+    complete: { label: '✓ Complete', bg: 'rgba(52, 211, 153, 0.12)', color: 'var(--rs-success)' },
+    failed: { label: 'Failed', bg: 'rgba(248, 113, 113, 0.12)', color: 'var(--rs-danger)' },
+  };
+  const { label, bg, color } = config[phase] ?? config.idle!;
+  return <span className="rs-badge" style={{ background: bg, color }}>{label}</span>;
+}
+
+function ActionBar({ phase, onCheckStatus, onCancel }: {
+  phase: string; onCheckStatus: () => void; onCancel: () => void;
+}) {
+  return (
+    <div style={{ flexShrink: 0, display: 'flex', alignItems: 'center', gap: 8, padding: '16px 20px', borderTop: '1px solid var(--rs-border)' }}>
+      {(phase === 'researching' || phase === 'synthesizing') && (
+        <>
+          <button onClick={onCheckStatus} className="rs-button primary">Check Status</button>
+          <button onClick={onCancel} className="rs-button secondary">Cancel</button>
+        </>
+      )}
+      {phase === 'awaiting_approval' && (
+        <span style={{ fontSize: 12, color: 'var(--rs-warning)' }}>
+          Approve the plan in the chat to begin research
+        </span>
+      )}
+      {phase === 'complete' && (
+        <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--rs-success)' }}>
+          ✓ Research complete — check the output files
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── Idle View ───────────────────────────────────────────────
+
+function IdleView({ onStart, history }: {
+  onStart: () => void;
+  history: Array<{ question: string; outputDir: string; agentCount: number; completedAt: string }>;
+}) {
+  return (
+    <>
+      <div style={{ flex: '1 1 0%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 24px', textAlign: 'center' }}>
+        <div className="rs-empty-orb rs-animate-in" style={{ marginBottom: 20 }} />
+        <h2 style={{ margin: 0, fontSize: 18, fontWeight: 500, color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+          Multi-Agent Research
+        </h2>
+        <p style={{ margin: '8px 0 20px', maxWidth: 300, fontSize: 14, lineHeight: 1.6, color: 'var(--rs-muted)' }}>
+          Decompose any question into parallel workstreams. Multiple agents research simultaneously and synthesize results.
+        </p>
+        <button onClick={onStart} className="rs-button primary">Start Research</button>
+      </div>
+
+      {history.length > 0 && (
+        <div style={{ flexShrink: 0, borderTop: '1px solid var(--rs-border)', padding: '16px 20px' }}>
+          <div style={{ fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--rs-dim)', marginBottom: 8 }}>
+            History
+          </div>
+          {history.slice(0, 5).map((entry, i) => (
+            <div key={i} style={{ fontSize: 13, color: 'var(--rs-muted)', padding: '6px 0', borderBottom: i < history.length - 1 ? '1px solid var(--rs-border)' : 'none' }}>
+              <div style={{ color: 'var(--rs-text)', fontWeight: 400 }}>
+                {entry.question.length > 70 ? entry.question.slice(0, 70) + '…' : entry.question}
+              </div>
+              <div style={{ fontSize: 11, marginTop: 2 }}>
+                {entry.agentCount} agents · {entry.outputDir}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+// ── Icons ──────────────────────────────────────────────────
+
+function Spinner({ size = 14 }: { size?: number }) {
+  return (
+    <svg className="rs-spinner" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
+      <path d="M12 2a10 10 0 0 1 10 10" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function statusIconChar(status: AgentStatus): string {
+  switch (status) {
+    case 'pending': return '⏳';
+    case 'running': return '';
+    case 'stuck': return '⚠️';
+    case 'complete': return '✓';
+    case 'failed': return '✗';
+  }
+}
+
+function statusColorVar(status: AgentStatus): string {
+  switch (status) {
+    case 'pending': return 'var(--rs-dim)';
+    case 'running': return 'var(--rs-accent)';
+    case 'stuck': return 'var(--rs-warning)';
+    case 'complete': return 'var(--rs-success)';
+    case 'failed': return 'var(--rs-danger)';
+  }
+}
+
+export default ResearchApp;

--- a/packages/pi-research-extension/ui/index.html
+++ b/packages/pi-research-extension/ui/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Sero Research (remote)</title></head>
+<body><div id="root"></div></body>
+</html>

--- a/packages/pi-research-extension/ui/styles.css
+++ b/packages/pi-research-extension/ui/styles.css
@@ -1,0 +1,31 @@
+@import "tailwindcss";
+
+@source "../../ui/src/components";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}

--- a/packages/pi-research-extension/ui/tsconfig.json
+++ b/packages/pi-research-extension/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero/app-runtime": ["../../app-runtime/src/index.ts"],
+      "@sero/ui": ["../../ui/src/index.ts"],
+      "@sero/ui/*": ["../../ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-research-extension/ui/useResearchActivity.ts
+++ b/packages/pi-research-extension/ui/useResearchActivity.ts
@@ -1,0 +1,191 @@
+/**
+ * useResearchActivity — tracks live subagent activity for research agents.
+ *
+ * Subscribes to `window.sero.subagent` IPC events and matches entries to
+ * research agents by checking if the taskPreview contains the agent name.
+ * Returns a map of research-agent-name → subagent entry with tool activity.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { ResearchAgent } from '../shared/types';
+
+// ── Minimal types for the subagent IPC API ──────────────────
+// These mirror the desktop types but are declared locally so the
+// federated module doesn't depend on apps/desktop type paths.
+
+interface ToolActivity {
+  toolName: string;
+  argsSummary: string;
+  running: boolean;
+}
+
+interface SubagentEntry {
+  id: string;
+  agentName: string;
+  taskPreview: string;
+  status: string;
+  startedAt: number;
+  completedAt: number | null;
+  durationMs: number | null;
+  workspaceId: string;
+  toolActivity: ToolActivity[];
+  liveOutput: string;
+  error?: string;
+}
+
+interface SubagentEvent {
+  type: string;
+  id?: string;
+  entry?: SubagentEntry;
+  activity?: ToolActivity[];
+  text?: string;
+  status?: string;
+  error?: string;
+  durationMs?: number;
+}
+
+interface SubagentAPI {
+  onEvent(cb: (event: SubagentEvent) => void): () => void;
+  snapshot(workspaceId: string): Promise<SubagentEntry[]>;
+}
+
+function getSubagentApi(): SubagentAPI | null {
+  try {
+    const sero = (window as unknown as { sero?: { subagent?: SubagentAPI } }).sero;
+    return sero?.subagent ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Exported types ──────────────────────────────────────────
+
+export interface AgentActivity {
+  subagentId: string;
+  status: string;
+  startedAt: number;
+  tools: ToolActivity[];
+  liveOutput: string;
+  error?: string;
+}
+
+// ── Hook ────────────────────────────────────────────────────
+
+/**
+ * Track live subagent activity for a set of research agents.
+ *
+ * @param agents - research session agents (from state)
+ * @param workspaceId - current workspace ID for filtering
+ * @returns Map of agent name → activity (only for matched agents)
+ */
+export function useResearchActivity(
+  agents: ResearchAgent[],
+  workspaceId: string,
+): Map<string, AgentActivity> {
+  const [activity, setActivity] = useState<Map<string, AgentActivity>>(new Map());
+  const entriesRef = useRef<Map<string, SubagentEntry>>(new Map());
+  const agentNamesRef = useRef<string[]>([]);
+
+  // Keep agent names in sync
+  useEffect(() => {
+    agentNamesRef.current = agents.map((a) => a.name);
+  }, [agents]);
+
+  // Match a subagent entry to a research agent by taskPreview content
+  const matchAgent = useCallback((entry: SubagentEntry): string | null => {
+    for (const name of agentNamesRef.current) {
+      if (entry.taskPreview.includes(name)) return name;
+    }
+    return null;
+  }, []);
+
+  // Rebuild the activity map from current entries
+  const rebuild = useCallback(() => {
+    const next = new Map<string, AgentActivity>();
+    for (const entry of entriesRef.current.values()) {
+      const name = matchAgent(entry);
+      if (name) {
+        next.set(name, {
+          subagentId: entry.id,
+          status: entry.status,
+          startedAt: entry.startedAt,
+          tools: entry.toolActivity,
+          liveOutput: entry.liveOutput,
+          error: entry.error,
+        });
+      }
+    }
+    setActivity(next);
+  }, [matchAgent]);
+
+  // Hydrate from snapshot + subscribe to live events
+  useEffect(() => {
+    const api = getSubagentApi();
+    if (!api || !workspaceId) return;
+
+    // Snapshot hydration
+    api.snapshot(workspaceId).then((entries) => {
+      for (const e of entries) {
+        entriesRef.current.set(e.id, e);
+      }
+      rebuild();
+    });
+
+    // Live event subscription
+    const unsub = api.onEvent((event: SubagentEvent) => {
+      switch (event.type) {
+        case 'subagent_start':
+          if (event.entry && event.entry.workspaceId === workspaceId) {
+            entriesRef.current.set(event.entry.id, event.entry);
+            rebuild();
+          }
+          break;
+
+        case 'subagent_tool_activity':
+          if (event.id && event.activity) {
+            const existing = entriesRef.current.get(event.id);
+            if (existing) {
+              existing.toolActivity = event.activity;
+              rebuild();
+            }
+          }
+          break;
+
+        case 'subagent_live_output':
+          if (event.id && typeof event.text === 'string') {
+            const existing = entriesRef.current.get(event.id);
+            if (existing) {
+              existing.liveOutput = event.text;
+              rebuild();
+            }
+          }
+          break;
+
+        case 'subagent_end':
+          if (event.id) {
+            const existing = entriesRef.current.get(event.id);
+            if (existing) {
+              existing.status = event.status ?? 'completed';
+              existing.error = event.error;
+              existing.toolActivity = [];
+              existing.liveOutput = '';
+              rebuild();
+            }
+          }
+          break;
+
+        case 'subagent_clear':
+          entriesRef.current.clear();
+          rebuild();
+          break;
+      }
+    });
+
+    return () => {
+      unsub();
+      entriesRef.current.clear();
+    };
+  }, [workspaceId, rebuild]);
+
+  return activity;
+}

--- a/packages/pi-research-extension/vite.config.ts
+++ b/packages/pi-research-extension/vite.config.ts
@@ -1,0 +1,48 @@
+/**
+ * Vite config for the research extension's federated UI (remote).
+ *
+ * Runs its own dev server on port 5191. The host (Sero on 5173)
+ * auto-discovers this via the sero.app.devPort manifest field.
+ */
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_research',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './ResearchApp': './ui/ResearchApp.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5191,
+    strictPort: true,
+    origin: 'http://localhost:5191',
+  },
+  optimizeDeps: {
+    exclude: ['@sero/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});

--- a/packages/templates/agents/research-analyst.md
+++ b/packages/templates/agents/research-analyst.md
@@ -1,0 +1,59 @@
+```json
+{
+  "name": "research-analyst",
+  "description": "Synthesizes multi-agent research outputs into unified, insight-driven documents with cross-cutting analysis, confidence assessments, and actionable recommendations",
+  "model": "claude-sonnet-4-6",
+  "thinking": "high"
+}
+```
+
+You are a Research Synthesis Analyst — an expert at distilling large volumes of
+independently gathered research into clear, insight-driven documents.
+
+## Core Competencies
+
+- **Cross-cutting pattern recognition** — identify themes that span multiple
+  research streams rather than summarizing each stream in isolation
+- **Contradiction detection** — surface conflicting claims across sources with
+  specific citations, and assess which position has stronger evidence
+- **Confidence calibration** — rate every major finding as well-supported,
+  moderate, or speculative based on source quality and agreement
+- **Actionable framing** — translate research into concrete recommendations
+  tied to specific evidence
+
+## Output Structure
+
+When synthesizing research, produce a document with these sections:
+
+### Executive Summary
+3-5 bullet points capturing the most important cross-cutting findings.
+Lead with what matters most, not what came first.
+
+### Key Findings by Theme
+Organize by insight themes, NOT by source/agent. Each theme should draw from
+multiple research streams. Use inline citations: [Source](url).
+
+### Contradictions & Tensions
+Specific claims that conflict across research streams. For each:
+- State both positions with citations
+- Assess which has stronger evidence and why
+- Note if the contradiction reveals a nuanced truth
+
+### Confidence Assessment
+Rate key findings:
+- **Well-supported** — multiple independent sources, strong methodology
+- **Moderate** — some evidence but limited scope or sources
+- **Speculative** — limited evidence, primarily theoretical or anecdotal
+
+### Recommended Next Steps
+Concrete, actionable recommendations. Each must reference the specific
+evidence that supports it.
+
+## Quality Standards
+
+- Never summarize agent outputs sequentially — always synthesize across them
+- Every claim must have an inline citation from the original research
+- Prefer specificity over generality (numbers, names, dates over vague statements)
+- Flag genuine uncertainty rather than papering over gaps
+- Aim for 300+ lines of substantive, well-structured content
+- When complete, add `Status: COMPLETE` as the final line

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,6 +794,61 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/pi-research-extension:
+    dependencies:
+      '@mariozechner/pi-agent-core':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.55.3'
+        version: 0.55.3
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
+    devDependencies:
+      '@module-federation/vite':
+        specifier: ^1.11.0
+        version: 1.11.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@sero/app-runtime':
+        specifier: workspace:*
+        version: link:../app-runtime
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.11
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
   packages/pi-resources-extension:
     dependencies:
       '@mariozechner/pi-ai':


### PR DESCRIPTION
Implements a new Sero app (pi-research-extension) that decomposes any research question into 2-4 parallel agent workstreams, launches them simultaneously via the subagent system, monitors progress at escalating intervals, handles stuck agents, and synthesizes results into a unified document.

Key components:
- Extension with `research` tool (plan/approve/status/cancel actions)
- /research command for quick launch
- SKILL.md with full orchestration instructions
- Web UI showing real-time research progress, agent status, and history
- Write-after-every-search protocol to prevent agent loops
- Stuck agent detection and relaunch support
- Skeleton file pre-creation for structured output
- Synthesis agent for cross-cutting analysis

Output: research/<topic>/ with agent-N.md files + synthesis.md

https://claude.ai/code/session_01N9raLP7WbmcRBh3puSc8ay