### PR TITLE
feat: add pi-memory-extension — persistent memory system

### DIFF
--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -63,6 +63,7 @@ const TOOLS_TO_BRIDGE = new Set([
   'calc',
   'daily_quote',
   'weight',
+  'memory',
   // Google
   'gmail',
   'gcal',

--- a/docs/memory-integration-analysis.md
+++ b/docs/memory-integration-analysis.md
@@ -1,0 +1,165 @@
+# Memory System Integration Analysis
+
+## Reference: `@zhafron/pi-memory` Extension
+
+The example extension provides four capabilities:
+1. **Memory files** — `MEMORY.md`, `IDENTITY.md`, `USER.md`, `daily/YYYY-MM-DD.md`
+2. **Context injection** — auto-injects memory/identity/user into the system prompt via `before_agent_start`
+3. **Tool** — unified `memory` tool for read/write/search/list operations
+4. **Bootstrap flow** — first-run setup that creates template files and walks the user through personalisation
+
+---
+
+## What Sero Already Has
+
+The global workspace (`~/.sero-ui/workspaces/global/`) already has:
+- `USER.md` — user profile (name, timezone, preferences, coding style)
+- `AGENTS.md` — workspace-level agent instructions
+- `.git` repo — full version history via Sero's git checkpoint system
+- `.sero/apps/` — per-app state files (kanban, todo, etc.)
+
+Key infrastructure already in place:
+- **`before_agent_start` hook** — used by `sero-extension.ts` (CLI prompt, container prompt, subagent prompt) and `pi-plan-mode-extension` (plan context injection)
+- **Sero CLI bridge** (AD-020) — all extension tools collapsed into `sero-cli` to save token budget
+- **VCS integration** — `sero-extension-git.ts` handles checkpoints, git command blocking, bookmarks, via `vcsManager`
+- **Workspace manager** — `@ws:global/path` expansion, `sero workspace list` command, cross-workspace file access in containers
+
+---
+
+## Recommended Architecture
+
+### Storage Location
+
+```
+~/.sero-ui/workspaces/global/
+├── MEMORY.md          # Long-term memory (facts, decisions, preferences)
+├── IDENTITY.md        # Agent identity/persona rules
+├── USER.md            # Already exists — user profile
+├── AGENTS.md          # Already exists — workspace agent instructions
+└── memory/
+    └── daily/
+        └── YYYY-MM-DD.md   # Daily logs
+```
+
+**Rationale:**
+- Reuse the existing `USER.md` (already populated) — don't duplicate it
+- `MEMORY.md` and `IDENTITY.md` are new files at the workspace root (visible, editable, git-tracked)
+- Daily logs go in `memory/daily/` to keep the root clean
+- Everything is git-tracked via Sero's existing checkpoint system (no separate git logic needed)
+- The reference extension stores in `~/.pi/agent/memory/` — but Sero already has the global workspace as its personal knowledge base, so use that instead
+
+### Package Structure
+
+Create `packages/pi-memory-extension/` following the standard Sero extension pattern:
+
+```
+packages/pi-memory-extension/
+├── package.json
+├── extension/
+│   ├── index.ts           # Extension entry — registers hooks + tool
+│   ├── memory-manager.ts  # File I/O (read/write/search/list)
+│   ├── context-injector.ts # System prompt injection
+│   └── tsconfig.json
+└── shared/
+    └── types.ts           # MemoryTarget, WriteMode, etc.
+```
+
+No `ui/` directory needed initially — memory is purely agent-side. A UI could be added later (markdown viewer for memory files).
+
+### Context Injection
+
+The extension hooks into `before_agent_start` to inject memory context into the system prompt. This is the **same pattern** used by `pi-plan-mode-extension`.
+
+```
+systemPrompt += memoryContextBlock
+```
+
+The block includes:
+- Contents of `MEMORY.md` (if non-empty)
+- Contents of `IDENTITY.md` (if non-empty)
+- Contents of `USER.md` (if non-empty)
+- Brief instructions on how to use the `memory` CLI command
+
+**Important:** The injection must happen in the **extension**, not in `sero-extension.ts`. The `before_agent_start` hook supports multiple listeners — the Pi SDK merges their `systemPrompt` returns. The Sero extension injects CLI/container/subagent context; the memory extension injects memory context. They compose cleanly.
+
+### Tool → CLI Bridge
+
+Following AD-020, the `memory` tool is:
+1. Registered via `pi.registerTool()` in the extension
+2. Added to `TOOLS_TO_BRIDGE` in `electron/cli/index.ts`
+3. Automatically bridged into `sero-cli` by `bridgeExtensionTools()`
+
+The agent invokes it as:
+```
+sero memory read --target memory
+sero memory write --target daily --content "Implemented auth module"
+sero memory search --query "PostgreSQL"
+sero memory list
+```
+
+This is zero per-tool custom code — the schema bridge handles arg parsing, type coercion, and help generation from the TypeBox schema.
+
+### Resolving the Workspace Path
+
+The key difference from the reference extension: the memory directory is **not** a fixed `~/.pi/agent/memory` path. It's the global workspace path, which is dynamic.
+
+**Approach:** Use `ctx.cwd` in `session_start`/`session_switch` events (same pattern as kanban/plan-mode), BUT with a fallback to look up the global workspace path via the environment:
+
+```typescript
+// In the extension
+function resolveMemoryRoot(ctx?: { cwd?: string }): string {
+  // The global workspace path is always available as an env var
+  // set by Sero's workspace manager, or we can derive it
+  const seroHome = process.env.SERO_HOME || path.join(os.homedir(), '.sero-ui');
+  return path.join(seroHome, 'workspaces', 'global');
+}
+```
+
+This means memory is **always** stored in the global workspace regardless of which workspace the session is running in. The container system already mounts the global workspace at its original host path, so cross-workspace access works.
+
+### Git Integration — Leverage Existing VCS
+
+The reference extension has no git integration. Sero's is free:
+
+- **Auto-checkpoints** — `sero-extension-git.ts` already creates git checkpoints after every agent turn that mutates files. Memory writes trigger `write` tool calls → `agentRunHasMutatingToolCalls = true` → checkpoint on `agent_end`. Memory changes are automatically version-controlled.
+- **Mutating git blocking** — The agent can't `git commit` or `git push` directly (blocked by the git extension). All version control goes through `sero vcs checkpoint/restore/diff`.
+- **Diff & restore** — `sero vcs diff` and `sero vcs restore` work on memory files like any other workspace file.
+- **No separate memory versioning needed** — the reference extension doesn't version memory. Sero gets it for free.
+
+### Bootstrap Flow
+
+Questionnaire-driven setup using the existing `questionnaire` tool:
+
+1. On `session_start`, check if `MEMORY.md` exists in the global workspace
+2. If not, `before_agent_start` injects bootstrap instructions containing
+   three pre-defined questionnaire payloads (identity, user, memory)
+3. The agent calls the `questionnaire` tool for each step, collects answers,
+   then writes the results to memory files via `sero memory write`
+4. Existing `USER.md` content is detected — the agent confirms it with the
+   user rather than re-asking
+5. Once `MEMORY.md` exists, subsequent turns switch to normal context injection
+
+### What NOT to Do
+
+- **Don't modify `sero-extension.ts`** — the memory extension is self-contained
+- **Don't modify `buildContainerPromptBlock`** — memory context is injected separately via `before_agent_start`
+- **Don't add git logic to the memory extension** — Sero's git checkpoint system handles it
+- **Don't use `localStorage`** — markdown files on disk, git-tracked
+- **Don't create a standalone tool schema** — bridge through `sero-cli` per AD-020
+
+---
+
+## Implementation Checklist
+
+1. **Create `packages/pi-memory-extension/`** — standard extension package structure
+2. **`shared/types.ts`** — `MemoryTarget`, `WriteMode`, `MemoryAction` types
+3. **`extension/memory-manager.ts`** — file I/O adapted for Sero paths (global workspace root, not `~/.pi/agent/memory/`)
+4. **`extension/context-injector.ts`** — `before_agent_start` hook that reads memory files and appends to system prompt
+5. **`extension/index.ts`** — wires everything together, registers the `memory` tool with TypeBox schema
+6. **Add `'memory'` to `TOOLS_TO_BRIDGE`** in `electron/cli/index.ts`
+7. **Bootstrap logic** — first-run detection + template creation, preserving existing `USER.md`
+8. **`pnpm install`** — auto-discovers the new package (no manual registration needed per AGENTS.md)
+
+### Token Budget Consideration
+
+The context injection adds ~200-500 tokens per turn (memory file contents). This is comparable to what the CLI prompt block adds. For large memory files, consider truncating to the first N lines or adding a size cap with a "use `sero memory read` for full content" fallback.

--- a/packages/pi-memory-extension/extension/bootstrap.ts
+++ b/packages/pi-memory-extension/extension/bootstrap.ts
@@ -1,0 +1,186 @@
+/**
+ * Bootstrap — first-run setup for the memory system.
+ *
+ * On first run (no MEMORY.md), creates empty template files and
+ * provides questionnaire definitions for the agent to ask the user.
+ * The agent uses the `questionnaire` tool to collect answers, then
+ * writes results to memory files via `sero memory write`.
+ */
+
+import {
+  resolveMemoryRoot,
+  ensureDirectories,
+  getMemoryPath,
+  getIdentityPath,
+  getUserPath,
+  fileExists,
+  readFile,
+} from './memory-manager';
+
+// ── Questionnaire definitions ──────────────────────────────────
+//
+// These are injected into the system prompt so the agent knows
+// exactly what to ask via the `questionnaire` tool.
+
+export const IDENTITY_QUESTIONS = `{
+  "questions": [
+    {
+      "id": "agent_name",
+      "label": "Name",
+      "prompt": "What should the AI assistant call itself?",
+      "options": [
+        { "value": "Sero", "label": "Sero" },
+        { "value": "Assistant", "label": "Assistant" },
+        { "value": "Claude", "label": "Claude" }
+      ],
+      "allowOther": true
+    },
+    {
+      "id": "personality",
+      "label": "Personality",
+      "prompt": "What personality style should the AI have?",
+      "options": [
+        { "value": "direct", "label": "Direct & concise", "description": "Straight to the point, minimal filler" },
+        { "value": "friendly", "label": "Friendly & conversational", "description": "Warm, natural, collaborative tone" },
+        { "value": "professional", "label": "Professional & formal", "description": "Structured, precise, business-like" },
+        { "value": "casual", "label": "Casual & relaxed", "description": "Laid-back, informal, natural" }
+      ],
+      "allowOther": true
+    },
+    {
+      "id": "rules",
+      "label": "Rules",
+      "prompt": "Any specific behavioural rules for the AI?",
+      "options": [
+        { "value": "none", "label": "No special rules" },
+        { "value": "british", "label": "Use British English spellings" },
+        { "value": "no-emoji", "label": "Avoid emoji" },
+        { "value": "concise", "label": "Keep responses short" }
+      ],
+      "allowOther": true
+    }
+  ]
+}`;
+
+export const USER_QUESTIONS = `{
+  "questions": [
+    {
+      "id": "name",
+      "label": "Name",
+      "prompt": "What's your name (how should the AI address you)?",
+      "options": [],
+      "allowOther": true
+    },
+    {
+      "id": "role",
+      "label": "Role",
+      "prompt": "What's your role or profession?",
+      "options": [
+        { "value": "software-engineer", "label": "Software Engineer" },
+        { "value": "designer", "label": "Designer" },
+        { "value": "product-manager", "label": "Product Manager" },
+        { "value": "student", "label": "Student" }
+      ],
+      "allowOther": true
+    },
+    {
+      "id": "location",
+      "label": "Location",
+      "prompt": "Where are you based? (for timezone context)",
+      "options": [],
+      "allowOther": true
+    },
+    {
+      "id": "stack",
+      "label": "Tech Stack",
+      "prompt": "What's your primary tech stack?",
+      "options": [
+        { "value": "ts-react", "label": "TypeScript + React" },
+        { "value": "python", "label": "Python" },
+        { "value": "rust", "label": "Rust" },
+        { "value": "go", "label": "Go" },
+        { "value": "fullstack-js", "label": "Full-stack JavaScript" }
+      ],
+      "allowOther": true
+    },
+    {
+      "id": "communication",
+      "label": "Comms Style",
+      "prompt": "How do you prefer the AI to communicate?",
+      "options": [
+        { "value": "direct", "label": "Direct — no waffle, just answers" },
+        { "value": "explanatory", "label": "Explanatory — teach me as we go" },
+        { "value": "collaborative", "label": "Collaborative — discuss options together" }
+      ],
+      "allowOther": true
+    }
+  ]
+}`;
+
+export const MEMORY_QUESTIONS = `{
+  "questions": [
+    {
+      "id": "tech_knowledge",
+      "label": "Technical",
+      "prompt": "Any crucial technical knowledge to remember? (frameworks, patterns, configs)",
+      "options": [
+        { "value": "none", "label": "Nothing specific right now" }
+      ],
+      "allowOther": true
+    },
+    {
+      "id": "coding_prefs",
+      "label": "Coding",
+      "prompt": "Any coding preferences or conventions?",
+      "options": [
+        { "value": "functional", "label": "Prefer functional patterns over classes" },
+        { "value": "oop", "label": "Prefer OOP / class-based" },
+        { "value": "none", "label": "No strong preference" }
+      ],
+      "allowOther": true
+    },
+    {
+      "id": "projects",
+      "label": "Projects",
+      "prompt": "Any active projects or contexts the AI should know about?",
+      "options": [
+        { "value": "none", "label": "Nothing specific right now" }
+      ],
+      "allowOther": true
+    }
+  ]
+}`;
+
+// ── Bootstrap logic ────────────────────────────────────────────
+
+/**
+ * Check whether the memory system needs bootstrapping.
+ * Creates directories if needed. Does NOT create any template files —
+ * those are written by the agent after collecting questionnaire answers.
+ *
+ * Returns an object describing what the agent should do.
+ */
+export async function checkBootstrapStatus(): Promise<{
+  needsBootstrap: boolean;
+  existingUserContent: string | null;
+}> {
+  const root = resolveMemoryRoot();
+  await ensureDirectories(root);
+
+  const memoryPath = getMemoryPath(root);
+  const memoryExists = await fileExists(memoryPath);
+
+  if (memoryExists) {
+    return { needsBootstrap: false, existingUserContent: null };
+  }
+
+  // Check if USER.md already has content (common in existing setups)
+  const userPath = getUserPath(root);
+  const userContent = await readFile(userPath);
+  const hasUserContent = !!userContent?.trim();
+
+  return {
+    needsBootstrap: true,
+    existingUserContent: hasUserContent ? userContent!.trim() : null,
+  };
+}

--- a/packages/pi-memory-extension/extension/bootstrap.ts
+++ b/packages/pi-memory-extension/extension/bootstrap.ts
@@ -7,11 +7,12 @@
  * writes results to memory files via `sero memory write`.
  */
 
+import type { QuestionnairePayload } from '../shared/types';
+
 import {
   resolveMemoryRoot,
   ensureDirectories,
   getMemoryPath,
-  getIdentityPath,
   getUserPath,
   fileExists,
   readFile,
@@ -19,151 +20,151 @@ import {
 
 // ── Questionnaire definitions ──────────────────────────────────
 //
-// These are injected into the system prompt so the agent knows
-// exactly what to ask via the `questionnaire` tool.
+// Typed objects — serialised to JSON when injected into the system
+// prompt. Compile-time validated via QuestionnairePayload.
 
-export const IDENTITY_QUESTIONS = `{
-  "questions": [
+export const IDENTITY_QUESTIONS: QuestionnairePayload = {
+  questions: [
     {
-      "id": "agent_name",
-      "label": "Name",
-      "prompt": "What should the AI assistant call itself?",
-      "options": [
-        { "value": "Sero", "label": "Sero" },
-        { "value": "Assistant", "label": "Assistant" },
-        { "value": "Claude", "label": "Claude" }
+      id: 'agent_name',
+      label: 'Name',
+      prompt: 'What should the AI assistant call itself?',
+      options: [
+        { value: 'Sero', label: 'Sero' },
+        { value: 'Assistant', label: 'Assistant' },
+        { value: 'Claude', label: 'Claude' },
       ],
-      "allowOther": true
+      allowOther: true,
     },
     {
-      "id": "personality",
-      "label": "Personality",
-      "prompt": "What personality style should the AI have?",
-      "options": [
-        { "value": "direct", "label": "Direct & concise", "description": "Straight to the point, minimal filler" },
-        { "value": "friendly", "label": "Friendly & conversational", "description": "Warm, natural, collaborative tone" },
-        { "value": "professional", "label": "Professional & formal", "description": "Structured, precise, business-like" },
-        { "value": "casual", "label": "Casual & relaxed", "description": "Laid-back, informal, natural" }
+      id: 'personality',
+      label: 'Personality',
+      prompt: 'What personality style should the AI have?',
+      options: [
+        { value: 'direct', label: 'Direct & concise', description: 'Straight to the point, minimal filler' },
+        { value: 'friendly', label: 'Friendly & conversational', description: 'Warm, natural, collaborative tone' },
+        { value: 'professional', label: 'Professional & formal', description: 'Structured, precise, business-like' },
+        { value: 'casual', label: 'Casual & relaxed', description: 'Laid-back, informal, natural' },
       ],
-      "allowOther": true
+      allowOther: true,
     },
     {
-      "id": "rules",
-      "label": "Rules",
-      "prompt": "Any specific behavioural rules for the AI?",
-      "options": [
-        { "value": "none", "label": "No special rules" },
-        { "value": "british", "label": "Use British English spellings" },
-        { "value": "no-emoji", "label": "Avoid emoji" },
-        { "value": "concise", "label": "Keep responses short" }
+      id: 'rules',
+      label: 'Rules',
+      prompt: 'Any specific behavioural rules for the AI?',
+      options: [
+        { value: 'none', label: 'No special rules' },
+        { value: 'british', label: 'Use British English spellings' },
+        { value: 'no-emoji', label: 'Avoid emoji' },
+        { value: 'concise', label: 'Keep responses short' },
       ],
-      "allowOther": true
-    }
-  ]
-}`;
+      allowOther: true,
+    },
+  ],
+};
 
-export const USER_QUESTIONS = `{
-  "questions": [
+export const USER_QUESTIONS: QuestionnairePayload = {
+  questions: [
     {
-      "id": "name",
-      "label": "Name",
-      "prompt": "What's your name (how should the AI address you)?",
-      "options": [],
-      "allowOther": true
+      id: 'name',
+      label: 'Name',
+      prompt: "What's your name (how should the AI address you)?",
+      options: [],
+      allowOther: true,
     },
     {
-      "id": "role",
-      "label": "Role",
-      "prompt": "What's your role or profession?",
-      "options": [
-        { "value": "software-engineer", "label": "Software Engineer" },
-        { "value": "designer", "label": "Designer" },
-        { "value": "product-manager", "label": "Product Manager" },
-        { "value": "student", "label": "Student" }
+      id: 'role',
+      label: 'Role',
+      prompt: "What's your role or profession?",
+      options: [
+        { value: 'software-engineer', label: 'Software Engineer' },
+        { value: 'designer', label: 'Designer' },
+        { value: 'product-manager', label: 'Product Manager' },
+        { value: 'student', label: 'Student' },
       ],
-      "allowOther": true
+      allowOther: true,
     },
     {
-      "id": "location",
-      "label": "Location",
-      "prompt": "Where are you based? (for timezone context)",
-      "options": [],
-      "allowOther": true
+      id: 'location',
+      label: 'Location',
+      prompt: 'Where are you based? (for timezone context)',
+      options: [],
+      allowOther: true,
     },
     {
-      "id": "stack",
-      "label": "Tech Stack",
-      "prompt": "What's your primary tech stack?",
-      "options": [
-        { "value": "ts-react", "label": "TypeScript + React" },
-        { "value": "python", "label": "Python" },
-        { "value": "rust", "label": "Rust" },
-        { "value": "go", "label": "Go" },
-        { "value": "fullstack-js", "label": "Full-stack JavaScript" }
+      id: 'stack',
+      label: 'Tech Stack',
+      prompt: "What's your primary tech stack?",
+      options: [
+        { value: 'ts-react', label: 'TypeScript + React' },
+        { value: 'python', label: 'Python' },
+        { value: 'rust', label: 'Rust' },
+        { value: 'go', label: 'Go' },
+        { value: 'fullstack-js', label: 'Full-stack JavaScript' },
       ],
-      "allowOther": true
+      allowOther: true,
     },
     {
-      "id": "communication",
-      "label": "Comms Style",
-      "prompt": "How do you prefer the AI to communicate?",
-      "options": [
-        { "value": "direct", "label": "Direct — no waffle, just answers" },
-        { "value": "explanatory", "label": "Explanatory — teach me as we go" },
-        { "value": "collaborative", "label": "Collaborative — discuss options together" }
+      id: 'communication',
+      label: 'Comms Style',
+      prompt: 'How do you prefer the AI to communicate?',
+      options: [
+        { value: 'direct', label: 'Direct — no waffle, just answers' },
+        { value: 'explanatory', label: 'Explanatory — teach me as we go' },
+        { value: 'collaborative', label: 'Collaborative — discuss options together' },
       ],
-      "allowOther": true
-    }
-  ]
-}`;
+      allowOther: true,
+    },
+  ],
+};
 
-export const MEMORY_QUESTIONS = `{
-  "questions": [
+export const MEMORY_QUESTIONS: QuestionnairePayload = {
+  questions: [
     {
-      "id": "tech_knowledge",
-      "label": "Technical",
-      "prompt": "Any crucial technical knowledge to remember? (frameworks, patterns, configs)",
-      "options": [
-        { "value": "none", "label": "Nothing specific right now" }
+      id: 'tech_knowledge',
+      label: 'Technical',
+      prompt: 'Any crucial technical knowledge to remember? (frameworks, patterns, configs)',
+      options: [
+        { value: 'none', label: 'Nothing specific right now' },
       ],
-      "allowOther": true
+      allowOther: true,
     },
     {
-      "id": "coding_prefs",
-      "label": "Coding",
-      "prompt": "Any coding preferences or conventions?",
-      "options": [
-        { "value": "functional", "label": "Prefer functional patterns over classes" },
-        { "value": "oop", "label": "Prefer OOP / class-based" },
-        { "value": "none", "label": "No strong preference" }
+      id: 'coding_prefs',
+      label: 'Coding',
+      prompt: 'Any coding preferences or conventions?',
+      options: [
+        { value: 'functional', label: 'Prefer functional patterns over classes' },
+        { value: 'oop', label: 'Prefer OOP / class-based' },
+        { value: 'none', label: 'No strong preference' },
       ],
-      "allowOther": true
+      allowOther: true,
     },
     {
-      "id": "projects",
-      "label": "Projects",
-      "prompt": "Any active projects or contexts the AI should know about?",
-      "options": [
-        { "value": "none", "label": "Nothing specific right now" }
+      id: 'projects',
+      label: 'Projects',
+      prompt: 'Any active projects or contexts the AI should know about?',
+      options: [
+        { value: 'none', label: 'Nothing specific right now' },
       ],
-      "allowOther": true
-    }
-  ]
-}`;
+      allowOther: true,
+    },
+  ],
+};
 
 // ── Bootstrap logic ────────────────────────────────────────────
+
+export interface BootstrapStatus {
+  needsBootstrap: boolean;
+  existingUserContent: string | null;
+}
 
 /**
  * Check whether the memory system needs bootstrapping.
  * Creates directories if needed. Does NOT create any template files —
  * those are written by the agent after collecting questionnaire answers.
- *
- * Returns an object describing what the agent should do.
  */
-export async function checkBootstrapStatus(): Promise<{
-  needsBootstrap: boolean;
-  existingUserContent: string | null;
-}> {
+export async function checkBootstrapStatus(): Promise<BootstrapStatus> {
   const root = resolveMemoryRoot();
   await ensureDirectories(root);
 

--- a/packages/pi-memory-extension/extension/context-injector.ts
+++ b/packages/pi-memory-extension/extension/context-injector.ts
@@ -7,6 +7,9 @@
  * On first run (no MEMORY.md), injects bootstrap instructions that
  * tell the agent to use the `questionnaire` tool to collect answers,
  * then write results to memory files.
+ *
+ * Bootstrap status is cached after the first check and reset on
+ * each `session_start` to avoid redundant filesystem I/O per turn.
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
@@ -21,10 +24,35 @@ import {
   USER_QUESTIONS,
   MEMORY_QUESTIONS,
 } from './bootstrap';
+import type { BootstrapStatus } from './bootstrap';
 
 // ── Max injection size (tokens are ~4 chars) ───────────────────
 
 const MAX_INJECTION_CHARS = 4000;
+
+// ── Bootstrap status cache ─────────────────────────────────────
+//
+// Avoid checking the filesystem on every `before_agent_start`.
+// Reset on `session_start` so a new session re-checks once.
+
+let cachedStatus: BootstrapStatus | null = null;
+
+async function getCachedBootstrapStatus(): Promise<BootstrapStatus> {
+  if (!cachedStatus) {
+    cachedStatus = await checkBootstrapStatus();
+  }
+  return cachedStatus;
+}
+
+/** Call on session_start to re-check bootstrap state. */
+export function resetBootstrapCache(): void {
+  cachedStatus = null;
+}
+
+/** Call after the agent writes memory files during bootstrap. */
+export function markBootstrapDone(): void {
+  cachedStatus = { needsBootstrap: false, existingUserContent: null };
+}
 
 // ── Normal mode: build context from existing files ─────────────
 
@@ -72,6 +100,10 @@ function getMemoryInstructions(): string {
 // ── Bootstrap mode: questionnaire-driven setup ─────────────────
 
 function buildBootstrapInstructions(existingUserContent: string | null): string {
+  const identityJson = JSON.stringify(IDENTITY_QUESTIONS, null, 2);
+  const userJson = JSON.stringify(USER_QUESTIONS, null, 2);
+  const memoryJson = JSON.stringify(MEMORY_QUESTIONS, null, 2);
+
   const userNote = existingUserContent
     ? `\n\nNote: USER.md already has content:\n\`\`\`\n${existingUserContent}\n\`\`\`\nConfirm this is correct with the user rather than re-asking. Skip the user questionnaire if the content looks good.`
     : '';
@@ -84,7 +116,7 @@ Use the \`questionnaire\` tool to ask the user three rounds of questions, then w
 
 ### Step 1: Identity Setup
 Call the \`questionnaire\` tool with these questions to configure the agent persona:
-${IDENTITY_QUESTIONS}
+${identityJson}
 
 After receiving answers, write IDENTITY.md:
 \`sero memory write --target identity --mode overwrite --content "# Identity\\n\\n- **Name:** <agent_name answer>\\n- **Style:** <personality answer>\\n- **Rules:** <rules answer>"\`
@@ -93,7 +125,7 @@ After receiving answers, write IDENTITY.md:
 ${existingUserContent
     ? 'Ask the user if the existing USER.md content above is correct. If they want changes, ask what to update. Only rewrite if needed.'
     : `Call the \`questionnaire\` tool with these questions:
-${USER_QUESTIONS}
+${userJson}
 
 After receiving answers, write USER.md:
 \`sero memory write --target user --mode overwrite --content "# User\\n\\n- **Name:** <name>\\n- **Role:** <role>\\n- **Location:** <location>\\n- **Tech Stack:** <stack>\\n- **Communication:** <communication>"\``
@@ -101,7 +133,7 @@ After receiving answers, write USER.md:
 
 ### Step 3: Long-term Memory
 Call the \`questionnaire\` tool with these questions:
-${MEMORY_QUESTIONS}
+${memoryJson}
 
 After receiving answers, write MEMORY.md:
 \`sero memory write --target memory --mode overwrite --content "# Memory\\n\\n## Technical Knowledge\\n\\n<tech_knowledge>\\n\\n## Coding Preferences\\n\\n<coding_prefs>\\n\\n## Active Projects\\n\\n<projects>"\`
@@ -116,8 +148,13 @@ After receiving answers, write MEMORY.md:
 // ── Register hooks ─────────────────────────────────────────────
 
 export function registerContextInjection(pi: ExtensionAPI): void {
+  // Reset cache on each new session so bootstrap status is re-checked once
+  pi.on('session_start', () => {
+    resetBootstrapCache();
+  });
+
   pi.on('before_agent_start', async (event) => {
-    const status = await checkBootstrapStatus();
+    const status = await getCachedBootstrapStatus();
 
     let addition: string;
     if (status.needsBootstrap) {

--- a/packages/pi-memory-extension/extension/context-injector.ts
+++ b/packages/pi-memory-extension/extension/context-injector.ts
@@ -1,0 +1,137 @@
+/**
+ * ContextInjector — injects memory files into the system prompt.
+ *
+ * Hooks into `before_agent_start` so that MEMORY.md, IDENTITY.md,
+ * and USER.md are available to the agent at the start of every turn.
+ *
+ * On first run (no MEMORY.md), injects bootstrap instructions that
+ * tell the agent to use the `questionnaire` tool to collect answers,
+ * then write results to memory files.
+ */
+
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+import {
+  resolveMemoryRoot,
+  getContextFiles,
+} from './memory-manager';
+import {
+  checkBootstrapStatus,
+  IDENTITY_QUESTIONS,
+  USER_QUESTIONS,
+  MEMORY_QUESTIONS,
+} from './bootstrap';
+
+// ── Max injection size (tokens are ~4 chars) ───────────────────
+
+const MAX_INJECTION_CHARS = 4000;
+
+// ── Normal mode: build context from existing files ─────────────
+
+async function buildContextBlock(root: string): Promise<string> {
+  const files = await getContextFiles(root);
+  if (files.length === 0) return '';
+
+  const sections: string[] = [];
+  let totalChars = 0;
+
+  for (const file of files) {
+    const section = `### ${file.name}\n\n${file.content}`;
+    if (totalChars + section.length > MAX_INJECTION_CHARS) {
+      const remaining = MAX_INJECTION_CHARS - totalChars;
+      if (remaining > 100) {
+        const truncated = file.content.slice(0, remaining - 80);
+        const target = file.name.replace('.md', '').toLowerCase();
+        sections.push(
+          `### ${file.name}\n\n${truncated}\n\n_[truncated — use \`sero memory read --target ${target}\` for full content]_`,
+        );
+      }
+      break;
+    }
+    sections.push(section);
+    totalChars += section.length;
+  }
+
+  return `\n\n## Memory\n\nThe following memory files are loaded from the global workspace. Use the \`sero-cli\` tool with \`memory\` commands to manage them.\n\n${sections.join('\n\n---\n\n')}`;
+}
+
+function getMemoryInstructions(): string {
+  return [
+    '\n\n**Memory commands:**',
+    '- `sero memory write --target memory --content "..."` — save a long-term fact or decision',
+    '- `sero memory write --target daily --content "..."` — log something to today\'s daily note',
+    '- `sero memory read --target memory|identity|user|daily` — read a memory file',
+    '- `sero memory search --query "..."` — search across all memory files',
+    '- `sero memory list` — list all memory files',
+    '',
+    'Proactively save important facts, user preferences, and decisions to memory.',
+    'When the user shares something worth remembering, write it to the appropriate target.',
+  ].join('\n');
+}
+
+// ── Bootstrap mode: questionnaire-driven setup ─────────────────
+
+function buildBootstrapInstructions(existingUserContent: string | null): string {
+  const userNote = existingUserContent
+    ? `\n\nNote: USER.md already has content:\n\`\`\`\n${existingUserContent}\n\`\`\`\nConfirm this is correct with the user rather than re-asking. Skip the user questionnaire if the content looks good.`
+    : '';
+
+  return `
+## Memory Setup Required
+
+The memory system is not yet initialised. You MUST set it up now before doing anything else.
+Use the \`questionnaire\` tool to ask the user three rounds of questions, then write the answers to memory files.${userNote}
+
+### Step 1: Identity Setup
+Call the \`questionnaire\` tool with these questions to configure the agent persona:
+${IDENTITY_QUESTIONS}
+
+After receiving answers, write IDENTITY.md:
+\`sero memory write --target identity --mode overwrite --content "# Identity\\n\\n- **Name:** <agent_name answer>\\n- **Style:** <personality answer>\\n- **Rules:** <rules answer>"\`
+
+### Step 2: User Profile${existingUserContent ? ' (verify existing)' : ''}
+${existingUserContent
+    ? 'Ask the user if the existing USER.md content above is correct. If they want changes, ask what to update. Only rewrite if needed.'
+    : `Call the \`questionnaire\` tool with these questions:
+${USER_QUESTIONS}
+
+After receiving answers, write USER.md:
+\`sero memory write --target user --mode overwrite --content "# User\\n\\n- **Name:** <name>\\n- **Role:** <role>\\n- **Location:** <location>\\n- **Tech Stack:** <stack>\\n- **Communication:** <communication>"\``
+}
+
+### Step 3: Long-term Memory
+Call the \`questionnaire\` tool with these questions:
+${MEMORY_QUESTIONS}
+
+After receiving answers, write MEMORY.md:
+\`sero memory write --target memory --mode overwrite --content "# Memory\\n\\n## Technical Knowledge\\n\\n<tech_knowledge>\\n\\n## Coding Preferences\\n\\n<coding_prefs>\\n\\n## Active Projects\\n\\n<projects>"\`
+
+### Important
+- Run each questionnaire step in order — don't skip steps.
+- Use the exact tool calls shown above.
+- After writing all three files, confirm to the user that memory is set up.
+- Be friendly and natural between steps — this is a first-time experience.`;
+}
+
+// ── Register hooks ─────────────────────────────────────────────
+
+export function registerContextInjection(pi: ExtensionAPI): void {
+  pi.on('before_agent_start', async (event) => {
+    const status = await checkBootstrapStatus();
+
+    let addition: string;
+    if (status.needsBootstrap) {
+      addition = buildBootstrapInstructions(status.existingUserContent);
+    } else {
+      const root = resolveMemoryRoot();
+      const contextBlock = await buildContextBlock(root);
+      addition = contextBlock + getMemoryInstructions();
+    }
+
+    if (!addition.trim()) return;
+
+    return {
+      systemPrompt: event.systemPrompt + addition,
+    };
+  });
+}

--- a/packages/pi-memory-extension/extension/index.ts
+++ b/packages/pi-memory-extension/extension/index.ts
@@ -1,0 +1,56 @@
+/**
+ * Memory Extension — persistent memory for Sero.
+ *
+ * Stores long-term facts (MEMORY.md), agent identity (IDENTITY.md),
+ * user profile (USER.md), and daily logs in the global workspace.
+ * All files are git-tracked via Sero's existing checkpoint system.
+ *
+ * On first run, the agent uses the `questionnaire` tool to ask the
+ * user setup questions, then writes answers to memory files.
+ *
+ * Tools (LLM-callable): memory (read, write, search, list)
+ * Hooks: before_agent_start (context injection + bootstrap)
+ */
+
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+import { checkBootstrapStatus } from './bootstrap';
+import { registerContextInjection } from './context-injector';
+import { registerMemoryTool } from './memory-tool';
+
+export default function memoryExtension(pi: ExtensionAPI): void {
+  // Notify the user on first run (directories are created, but files
+  // are written by the agent after collecting questionnaire answers)
+  pi.on('session_start', async () => {
+    const status = await checkBootstrapStatus();
+    if (status.needsBootstrap) {
+      pi.sendMessage(
+        {
+          customType: 'memory-bootstrap',
+          content: 'Memory system detected — starting setup.',
+          display: true,
+        },
+        { triggerTurn: false },
+      );
+    }
+  });
+
+  // Inject memory context (or bootstrap instructions) into the system prompt
+  registerContextInjection(pi);
+
+  // Register the memory tool (bridged into sero-cli via AD-020)
+  registerMemoryTool(pi);
+
+  // /memory slash command for the user
+  pi.registerCommand('memory', {
+    description: 'Show memory files or manage them (pass instructions inline)',
+    handler: async (args) => {
+      const instruction = args.trim();
+      if (instruction) {
+        pi.sendUserMessage(`Using the memory tool: ${instruction}`);
+      } else {
+        pi.sendUserMessage('List all memory files using the memory tool.');
+      }
+    },
+  });
+}

--- a/packages/pi-memory-extension/extension/index.ts
+++ b/packages/pi-memory-extension/extension/index.ts
@@ -15,12 +15,11 @@
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
 import { checkBootstrapStatus } from './bootstrap';
-import { registerContextInjection } from './context-injector';
+import { registerContextInjection, markBootstrapDone } from './context-injector';
 import { registerMemoryTool } from './memory-tool';
 
 export default function memoryExtension(pi: ExtensionAPI): void {
-  // Notify the user on first run (directories are created, but files
-  // are written by the agent after collecting questionnaire answers)
+  // Warm the bootstrap cache on session start and notify on first run
   pi.on('session_start', async () => {
     const status = await checkBootstrapStatus();
     if (status.needsBootstrap) {
@@ -32,6 +31,17 @@ export default function memoryExtension(pi: ExtensionAPI): void {
         },
         { triggerTurn: false },
       );
+    }
+  });
+
+  // After each agent turn, if bootstrap was in progress and
+  // memory files are now written, update the cache so subsequent
+  // turns switch to normal context injection.
+  pi.on('agent_end', async () => {
+    // Re-check; if MEMORY.md now exists, mark bootstrap done
+    const status = await checkBootstrapStatus();
+    if (!status.needsBootstrap) {
+      markBootstrapDone();
     }
   });
 

--- a/packages/pi-memory-extension/extension/memory-manager.ts
+++ b/packages/pi-memory-extension/extension/memory-manager.ts
@@ -17,6 +17,11 @@ import os from 'node:os';
 
 import type { MemorySearchResult, MemoryFileList } from '../shared/types';
 
+// ── Constants ──────────────────────────────────────────────────
+
+/** Only these root-level .md files are managed by the memory system. */
+const MEMORY_ROOT_FILES = new Set(['MEMORY.md', 'IDENTITY.md', 'USER.md']);
+
 // ── Path resolution ────────────────────────────────────────────
 
 /** Resolve the global workspace root, where all memory files live. */
@@ -141,7 +146,10 @@ export async function searchFiles(
       continue;
     }
 
-    const mdFiles = entries.filter((f) => f.endsWith('.md')).sort();
+    // At the root level, only search known memory files (not AGENTS.md etc.)
+    const mdFiles = entries
+      .filter((f) => (prefix ? f.endsWith('.md') : MEMORY_ROOT_FILES.has(f)))
+      .sort();
 
     for (const file of mdFiles) {
       if (results.length >= maxResults) break;
@@ -174,7 +182,8 @@ export async function listFiles(root: string): Promise<MemoryFileList> {
 
   try {
     const entries = await fs.readdir(root);
-    for (const f of entries.filter((e) => e.endsWith('.md')).sort()) {
+    // Only list known memory files (not AGENTS.md, README.md, etc.)
+    for (const f of entries.filter((e) => MEMORY_ROOT_FILES.has(e)).sort()) {
       rootFiles.push(f);
     }
   } catch {

--- a/packages/pi-memory-extension/extension/memory-manager.ts
+++ b/packages/pi-memory-extension/extension/memory-manager.ts
@@ -1,0 +1,217 @@
+/**
+ * MemoryManager — file I/O for the memory system.
+ *
+ * All memory files live in the global workspace root:
+ *   ~/.sero-ui/workspaces/global/
+ *
+ * Layout:
+ *   MEMORY.md         — long-term facts, decisions, preferences
+ *   IDENTITY.md       — agent persona and behavioural rules
+ *   USER.md           — user profile (already exists in most setups)
+ *   memory/daily/     — daily log files (YYYY-MM-DD.md)
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+import type { MemorySearchResult, MemoryFileList } from '../shared/types';
+
+// ── Path resolution ────────────────────────────────────────────
+
+/** Resolve the global workspace root, where all memory files live. */
+export function resolveMemoryRoot(): string {
+  const seroHome = process.env.SERO_HOME || path.join(os.homedir(), '.sero-ui');
+  return path.join(seroHome, 'workspaces', 'global');
+}
+
+// ── File paths ─────────────────────────────────────────────────
+
+export function getMemoryPath(root: string): string {
+  return path.join(root, 'MEMORY.md');
+}
+
+export function getIdentityPath(root: string): string {
+  return path.join(root, 'IDENTITY.md');
+}
+
+export function getUserPath(root: string): string {
+  return path.join(root, 'USER.md');
+}
+
+export function getDailyDir(root: string): string {
+  return path.join(root, 'memory', 'daily');
+}
+
+export function getDailyPath(root: string, date: string): string {
+  return path.join(getDailyDir(root), `${date}.md`);
+}
+
+export function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ── Directory setup ────────────────────────────────────────────
+
+export async function ensureDirectories(root: string): Promise<void> {
+  await fs.mkdir(getDailyDir(root), { recursive: true });
+}
+
+// ── Read / Write / Append ──────────────────────────────────────
+
+export async function readFile(filePath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+export async function writeFile(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf-8');
+}
+
+export async function appendFile(filePath: string, content: string): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const existing = await readFile(filePath);
+  const separator = existing?.trim() ? '\n\n' : '';
+  const timestamp = new Date()
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d+Z$/, '');
+  const stamped = `<!-- ${timestamp} -->\n${content}`;
+  await fs.writeFile(filePath, (existing ?? '') + separator + stamped, 'utf-8');
+}
+
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Context files (for system prompt injection) ────────────────
+
+export async function getContextFiles(
+  root: string,
+): Promise<{ name: string; content: string }[]> {
+  const files: { name: string; content: string }[] = [];
+
+  const pairs: [string, string][] = [
+    ['MEMORY.md', getMemoryPath(root)],
+    ['IDENTITY.md', getIdentityPath(root)],
+    ['USER.md', getUserPath(root)],
+  ];
+
+  for (const [name, filePath] of pairs) {
+    const content = await readFile(filePath);
+    if (content?.trim()) {
+      files.push({ name, content: content.trim() });
+    }
+  }
+
+  return files;
+}
+
+// ── Search ─────────────────────────────────────────────────────
+
+export async function searchFiles(
+  root: string,
+  query: string,
+  maxResults: number,
+): Promise<MemorySearchResult[]> {
+  const results: MemorySearchResult[] = [];
+  const needle = query.toLowerCase();
+
+  const searchDirs: { dir: string; prefix: string }[] = [
+    { dir: root, prefix: '' },
+    { dir: getDailyDir(root), prefix: 'memory/daily' },
+  ];
+
+  for (const { dir, prefix } of searchDirs) {
+    if (results.length >= maxResults) break;
+
+    let entries: string[];
+    try {
+      entries = await fs.readdir(dir);
+    } catch {
+      continue;
+    }
+
+    const mdFiles = entries.filter((f) => f.endsWith('.md')).sort();
+
+    for (const file of mdFiles) {
+      if (results.length >= maxResults) break;
+
+      const filePath = path.join(dir, file);
+      const content = await readFile(filePath);
+      if (!content) continue;
+
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length && results.length < maxResults; i++) {
+        if (lines[i]!.toLowerCase().includes(needle)) {
+          results.push({
+            file: prefix ? `${prefix}/${file}` : file,
+            line: i + 1,
+            text: lines[i]!.trimEnd(),
+          });
+        }
+      }
+    }
+  }
+
+  return results;
+}
+
+// ── List ───────────────────────────────────────────────────────
+
+export async function listFiles(root: string): Promise<MemoryFileList> {
+  const rootFiles: string[] = [];
+  const dailyFiles: string[] = [];
+
+  try {
+    const entries = await fs.readdir(root);
+    for (const f of entries.filter((e) => e.endsWith('.md')).sort()) {
+      rootFiles.push(f);
+    }
+  } catch {
+    // directory may not exist
+  }
+
+  try {
+    const entries = await fs.readdir(getDailyDir(root));
+    for (const f of entries.filter((e) => e.endsWith('.md')).sort().reverse()) {
+      dailyFiles.push(f);
+    }
+  } catch {
+    // directory may not exist
+  }
+
+  return { root: rootFiles, daily: dailyFiles };
+}
+
+// ── Target → file path resolution ─────────────────────────────
+
+export function resolveTargetPath(
+  root: string,
+  target: string,
+  date?: string,
+): { path: string; displayName: string } | null {
+  switch (target) {
+    case 'memory':
+      return { path: getMemoryPath(root), displayName: 'MEMORY.md' };
+    case 'identity':
+      return { path: getIdentityPath(root), displayName: 'IDENTITY.md' };
+    case 'user':
+      return { path: getUserPath(root), displayName: 'USER.md' };
+    case 'daily': {
+      const d = date || todayStr();
+      return { path: getDailyPath(root, d), displayName: `memory/daily/${d}.md` };
+    }
+    default:
+      return null;
+  }
+}

--- a/packages/pi-memory-extension/extension/memory-tool.ts
+++ b/packages/pi-memory-extension/extension/memory-tool.ts
@@ -11,6 +11,7 @@ import { StringEnum } from '@mariozechner/pi-ai';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Text } from '@mariozechner/pi-tui';
 import { Type } from '@sinclair/typebox';
+import type { Static } from '@sinclair/typebox';
 
 import {
   resolveMemoryRoot,
@@ -47,6 +48,8 @@ const MemoryParams = Type.Object({
     Type.Number({ description: 'Max search results (default: 20)' }),
   ),
 });
+
+type MemoryParamsType = Static<typeof MemoryParams>;
 
 // ── Helpers ─────────────────────────────────────────────────────
 
@@ -155,15 +158,7 @@ export function registerMemoryTool(pi: ExtensionAPI): void {
       const root = resolveMemoryRoot();
       await ensureDirectories(root);
 
-      const p = params as {
-        action: string;
-        target?: string;
-        content?: string;
-        mode?: string;
-        date?: string;
-        query?: string;
-        max_results?: number;
-      };
+      const p = params as MemoryParamsType;
 
       switch (p.action) {
         case 'read':

--- a/packages/pi-memory-extension/extension/memory-tool.ts
+++ b/packages/pi-memory-extension/extension/memory-tool.ts
@@ -1,0 +1,204 @@
+/**
+ * Memory tool — unified read/write/search/list for memory files.
+ *
+ * Registered via `pi.registerTool()` and bridged into `sero-cli`
+ * by the schema bridge (AD-020). The agent invokes it as:
+ *   sero memory read --target memory
+ *   sero memory write --target daily --content "..."
+ */
+
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import {
+  resolveMemoryRoot,
+  ensureDirectories,
+  readFile,
+  writeFile,
+  appendFile,
+  resolveTargetPath,
+  searchFiles,
+  listFiles,
+  todayStr,
+} from './memory-manager';
+
+// ── Tool parameters ────────────────────────────────────────────
+
+const MemoryParams = Type.Object({
+  action: StringEnum(['read', 'write', 'search', 'list'] as const),
+  target: Type.Optional(
+    StringEnum(['memory', 'identity', 'user', 'daily'] as const),
+  ),
+  content: Type.Optional(
+    Type.String({ description: 'Content to write (for write action)' }),
+  ),
+  mode: Type.Optional(
+    StringEnum(['append', 'overwrite'] as const),
+  ),
+  date: Type.Optional(
+    Type.String({ description: 'Date for daily log (YYYY-MM-DD), defaults to today' }),
+  ),
+  query: Type.Optional(
+    Type.String({ description: 'Search query (for search action)' }),
+  ),
+  max_results: Type.Optional(
+    Type.Number({ description: 'Max search results (default: 20)' }),
+  ),
+});
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function text(t: string) {
+  return { content: [{ type: 'text' as const, text: t }], details: {} };
+}
+
+// ── Action handlers ────────────────────────────────────────────
+
+async function handleRead(
+  root: string,
+  target?: string,
+  date?: string,
+) {
+  if (!target) return handleList(root);
+
+  const resolved = resolveTargetPath(root, target, date);
+  if (!resolved) return text(`Unknown target: ${target}`);
+
+  const content = await readFile(resolved.path);
+  if (!content) return text(`${resolved.displayName} not found or empty.`);
+
+  return text(content);
+}
+
+async function handleWrite(
+  root: string,
+  target?: string,
+  content?: string,
+  mode?: string,
+  date?: string,
+) {
+  if (!content) return text('Error: content is required for write action.');
+  if (!target) return text('Error: target is required for write action.');
+
+  const resolved = resolveTargetPath(root, target, date);
+  if (!resolved) {
+    return text(`Unknown target: ${target}. Use 'memory', 'identity', 'user', or 'daily'.`);
+  }
+
+  if (mode === 'overwrite') {
+    const timestamp = new Date()
+      .toISOString()
+      .replace('T', ' ')
+      .replace(/\.\d+Z$/, '');
+    await writeFile(resolved.path, `<!-- last updated: ${timestamp} -->\n${content}`);
+  } else {
+    await appendFile(resolved.path, content);
+  }
+
+  const verb = mode === 'overwrite' ? 'Wrote to' : 'Appended to';
+  return text(`${verb} ${resolved.displayName}`);
+}
+
+async function handleSearch(
+  root: string,
+  query?: string,
+  maxResults?: number,
+) {
+  if (!query) return text('Error: query is required for search action.');
+
+  const results = await searchFiles(root, query, maxResults ?? 20);
+  if (results.length === 0) return text(`No results for "${query}".`);
+
+  const output = results.map((r) => `${r.file}:${r.line}: ${r.text}`).join('\n');
+  return text(`Found ${results.length} results:\n\n${output}`);
+}
+
+async function handleList(root: string) {
+  const files = await listFiles(root);
+  const parts: string[] = [];
+
+  if (files.root.length > 0) {
+    parts.push(`Root files:\n${files.root.map((f) => `- ${f}`).join('\n')}`);
+  }
+
+  if (files.daily.length > 0) {
+    const shown = files.daily.slice(0, 10);
+    const more = files.daily.length > 10
+      ? `\n  ... and ${files.daily.length - 10} more`
+      : '';
+    parts.push(
+      `Daily logs (${files.daily.length}):\n${shown.map((f) => `- memory/daily/${f}`).join('\n')}${more}`,
+    );
+  }
+
+  if (parts.length === 0) return text('No memory files found.');
+  return text(parts.join('\n\n'));
+}
+
+// ── Register ───────────────────────────────────────────────────
+
+export function registerMemoryTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: 'memory',
+    label: 'Memory',
+    description: [
+      'Manage persistent memory files for long-term context across sessions.',
+      '',
+      'Actions: read, write, search, list.',
+      'Targets: memory (MEMORY.md), identity (IDENTITY.md), user (USER.md), daily (daily log).',
+    ].join('\n'),
+    parameters: MemoryParams,
+
+    async execute(_toolCallId, params) {
+      const root = resolveMemoryRoot();
+      await ensureDirectories(root);
+
+      const p = params as {
+        action: string;
+        target?: string;
+        content?: string;
+        mode?: string;
+        date?: string;
+        query?: string;
+        max_results?: number;
+      };
+
+      switch (p.action) {
+        case 'read':
+          return handleRead(root, p.target, p.date);
+        case 'write':
+          return handleWrite(root, p.target, p.content, p.mode, p.date);
+        case 'search':
+          return handleSearch(root, p.query, p.max_results);
+        case 'list':
+          return handleList(root);
+        default:
+          return text(`Unknown action: ${p.action}`);
+      }
+    },
+
+    renderCall(args, theme) {
+      let t = theme.fg('toolTitle', theme.bold('memory '));
+      t += theme.fg('muted', args.action);
+      if (args.target) t += ` ${theme.fg('accent', args.target)}`;
+      if (args.query) t += ` ${theme.fg('dim', `"${args.query}"`)}`;
+      if (args.content) {
+        const preview = args.content.length > 60
+          ? args.content.slice(0, 57) + '...'
+          : args.content;
+        t += ` ${theme.fg('dim', `"${preview}"`)}`;
+      }
+      return new Text(t, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const msg = result.content?.[0]?.type === 'text' ? result.content[0].text : '';
+      if (msg.startsWith('Error:')) {
+        return new Text(theme.fg('error', msg), 0, 0);
+      }
+      return new Text(theme.fg('success', '✓ ') + theme.fg('muted', msg), 0, 0);
+    },
+  });
+}

--- a/packages/pi-memory-extension/extension/tsconfig.json
+++ b/packages/pi-memory-extension/extension/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.extension.json",
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-memory-extension/package.json
+++ b/packages/pi-memory-extension/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@sero/memory",
+  "version": "0.1.0",
+  "description": "Persistent memory system for Sero — long-term facts, identity, user profile, and daily logs",
+  "keywords": [
+    "pi-package"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit -p extension/tsconfig.json"
+  },
+  "pi": {
+    "extensions": [
+      "./extension/index.ts"
+    ]
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": ">=0.55.3",
+    "@mariozechner/pi-coding-agent": ">=0.55.3",
+    "@mariozechner/pi-tui": ">=0.55.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.11",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/pi-memory-extension/shared/types.ts
+++ b/packages/pi-memory-extension/shared/types.ts
@@ -1,0 +1,21 @@
+/** Which memory file to target. */
+export type MemoryTarget = 'memory' | 'identity' | 'user' | 'daily';
+
+/** How to write to a memory file. */
+export type WriteMode = 'append' | 'overwrite';
+
+/** Available memory tool actions. */
+export type MemoryAction = 'read' | 'write' | 'search' | 'list';
+
+/** A single search result. */
+export interface MemorySearchResult {
+  file: string;
+  line: number;
+  text: string;
+}
+
+/** Listing of memory files by category. */
+export interface MemoryFileList {
+  root: string[];
+  daily: string[];
+}

--- a/packages/pi-memory-extension/shared/types.ts
+++ b/packages/pi-memory-extension/shared/types.ts
@@ -19,3 +19,23 @@ export interface MemoryFileList {
   root: string[];
   daily: string[];
 }
+
+// ── Questionnaire types (matches Pi SDK `questionnaire` tool) ──
+
+export interface QuestionOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface QuestionDef {
+  id: string;
+  label?: string;
+  prompt: string;
+  options: QuestionOption[];
+  allowOther?: boolean;
+}
+
+export interface QuestionnairePayload {
+  questions: QuestionDef[];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -687,6 +687,28 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/pi-memory-extension:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.55.3'
+        version: 0.55.3
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.11
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/pi-notes-extension:
     dependencies:
       '@mariozechner/pi-ai':


### PR DESCRIPTION
## Summary

Adds a persistent memory system for the agent, stored as markdown files in the global workspace.

### Memory files
| File | Purpose |
|------|---------|
| `MEMORY.md` | Long-term facts, decisions, preferences |
| `IDENTITY.md` | Agent persona and behavioural rules |
| `USER.md` | User profile (preserves existing content) |
| `memory/daily/YYYY-MM-DD.md` | Daily logs |

### How it works

**Context injection** — On every turn, `MEMORY.md`, `IDENTITY.md`, and `USER.md` are injected into the system prompt via a `before_agent_start` hook (capped at 4000 chars with truncation fallback).

**Questionnaire-driven bootstrap** — On first run (no `MEMORY.md`), the agent uses the `questionnaire` tool to walk the user through three setup steps: identity, user profile, and long-term memory. Existing `USER.md` content is detected and confirmed rather than re-asked.

**CLI integration** — The `memory` tool is bridged into `sero-cli` per AD-020:
```
sero memory read --target memory
sero memory write --target daily --content "Shipped the auth module"
sero memory search --query "PostgreSQL"
sero memory list
```

**Git versioning** — Free via Sero's existing checkpoint system. Every memory write triggers an auto-checkpoint on `agent_end`. Full diff/restore support.

### Changes
- **New:** `packages/pi-memory-extension/` — extension + shared types (6 source files, all <220 LOC)
- **Modified:** `apps/desktop/electron/cli/index.ts` — added `'memory'` to `TOOLS_TO_BRIDGE`
- **New:** `docs/memory-integration-analysis.md` — design analysis

### Setup
1. Add the package path to `~/.sero-ui/agent/settings.json` under `"packages"`
2. Rebuild Electron (`node scripts/build-electron.mjs`)
3. Restart — the bootstrap questionnaire runs on the first session

### Design reference
Based on [`@zhafron/pi-memory`](https://github.com/tickernelz/pi-memory), adapted for Sero's workspace model, CLI bridge pattern, and git checkpoint system. See `docs/memory-integration-analysis.md` for the full analysis.