### PR TITLE
feat(memory): QMD semantic search, scratchpad & session lifecycle

### DIFF
--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -64,6 +64,8 @@ const TOOLS_TO_BRIDGE = new Set([
   'daily_quote',
   'weight',
   'memory',
+  'memory_search',
+  'scratchpad',
   // Google
   'gmail',
   'gcal',

--- a/docs/qmd-semantic-memory-spec.md
+++ b/docs/qmd-semantic-memory-spec.md
@@ -1,0 +1,168 @@
+# QMD Semantic Memory — Specification
+
+## Overview
+
+- **Problem**: The existing memory extension (MEMORY.md, IDENTITY.md, USER.md, daily logs) uses basic grep search and injects full file contents up to a 4K cap. As memory grows, relevant older entries get truncated away. There's no way to surface buried decisions or old daily logs that match the current conversation.
+- **Solution**: Add a QMD-powered semantic search layer to the existing memory system. QMD provides BM25 keyword, vector semantic, and hybrid search across all markdown memory files. Before each agent turn, the user's prompt is searched and relevant results are injected alongside the standard context.
+- **Success Criteria**: Relevant past memories surface automatically without the agent explicitly searching. Old daily log entries (3+ days) are discoverable. Graceful degradation when QMD is unavailable.
+- **Key Stakeholders**: End users (get better memory recall), the agent (sees relevant context per turn), maintainers (Sero team).
+
+## Decisions from Interview
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| QMD installation | CLI dependency with auto-install via Bun | QMD is a full search engine (SQLite FTS5 + embeddings); not practical to vendor. Same pattern as git — shell out, parse JSON. |
+| QMD location | Host only | Global workspace is not containerised; memory files live on host filesystem |
+| Scratchpad | Yes — add SCRATCHPAD.md | Highest-priority working context; checklist of things to fix/remember |
+| Scratchpad location | Global workspace root | `~/.sero-ui/workspaces/global/SCRATCHPAD.md` alongside MEMORY.md |
+| Search tool | Separate `memory_search` tool, bridged into sero-cli | Distinct from basic `sero memory search` (grep); supports keyword/semantic/deep modes |
+| Selective injection | On by default, `SERO_MEMORY_NO_SEARCH=1` to disable | Surfaces relevant past context automatically; fail-safe with 3s timeout |
+| Context budget | 8K chars total | Double current 4K; room for search results without dominating prompt |
+| Daily log injection | Don't inject directly; rely on QMD search | Selective injection surfaces relevant daily entries; avoids wasting budget on stale content |
+| Identity/User priority | Highest (before scratchpad) | Persona/prefs should never be truncated |
+| Session handoff | Yes — auto-capture on compaction | Write open scratchpad + recent context to daily log on `session_before_compact` |
+| Exit summary | Yes — LLM-powered session summary on exit | Appended to daily log; uses `reasoning_effort: low` for cost control |
+| Tags & links | Yes — encourage `#tags` and `[[links]]` | Free with full-text search; improves keyword recall |
+| QMD re-indexing | Debounced background (500ms) | Non-blocking, fire-and-forget after writes |
+
+## Detailed Requirements
+
+### Functional Requirements
+
+1. **QMD auto-install**: On first session start, detect QMD on PATH. If missing, attempt `bun install -g https://github.com/tobi/qmd`. If Bun is missing, show install instructions and degrade gracefully.
+2. **QMD collection auto-setup**: On session start (if QMD available), ensure `sero-memory` collection exists pointing at the global workspace memory root. Create path contexts for `/memory/daily` and `/` (root).
+3. **`memory_search` tool**: New tool with keyword (BM25, ~30ms), semantic (vector, ~2s), and deep (hybrid + reranking, ~10s) modes. Bridged into CLI as `sero memory_search --query "..." --mode keyword`.
+4. **Selective injection**: Before each agent turn, search memory using the user's prompt (keyword mode, 3s timeout, top 3 results). Inject formatted results into system prompt under "Relevant memories" section.
+5. **SCRATCHPAD.md**: New file at global workspace root. Tool actions: add, done, undo, clear_done, list. Open items injected into system prompt at second-highest priority.
+6. **Session handoff**: On `session_before_compact`, auto-write open scratchpad items + recent daily log tail to today's daily log as a handoff entry.
+7. **Exit summary**: On `session_shutdown`, generate LLM summary (decisions, lessons, notes, follow-ups) and append to daily log. Use `reasoning_effort: low`.
+8. **Debounced QMD re-index**: After every memory/scratchpad write, schedule `qmd update` with 500ms debounce. Fire-and-forget, non-blocking.
+9. **Tags & links**: Update system prompt instructions to encourage `#tags` and `[[wiki-links]]` in memory content.
+10. **Graceful degradation**: All QMD features fail silently. Core memory tools (read/write/list) work without QMD.
+
+### Non-Functional Requirements
+
+- Selective injection must complete within 3 seconds or be skipped silently
+- QMD re-index must not block tool responses
+- Exit summary must not block session shutdown (best-effort)
+- All new files under 500 LOC per project rules
+
+## Technical Design
+
+### New Context Injection Priority Order
+
+```
+Priority    Section                      Budget    Truncation
+--------    -------                      ------    ----------
+1 (high)    IDENTITY.md + USER.md        2.0K      from start
+2           Open scratchpad items        1.5K      from start
+3           QMD search results           2.5K      from start
+4           MEMORY.md (long-term)        2.0K      from middle
+                                        ------
+                                         8.0K (total cap)
+```
+
+Daily logs are NOT injected directly — they're surfaced through selective injection (priority 3) when relevant to the current prompt.
+
+### New Files
+
+```
+packages/pi-memory-extension/
+├── extension/
+│   ├── index.ts              # Updated — register new tools + hooks
+│   ├── context-injector.ts   # Updated — priority ordering + search results
+│   ├── memory-manager.ts     # Unchanged
+│   ├── memory-tool.ts        # Unchanged
+│   ├── bootstrap.ts          # Unchanged
+│   ├── qmd.ts                # NEW — QMD detection, install, collection setup, search
+│   ├── scratchpad.ts         # NEW — scratchpad tool + parse/serialize
+│   ├── search-tool.ts        # NEW — memory_search tool registration
+│   ├── session-lifecycle.ts  # NEW — handoff on compact, exit summary on shutdown
+│   └── tsconfig.json
+├── shared/
+│   └── types.ts              # Updated — add scratchpad + search types
+└── package.json
+```
+
+### QMD Integration (`qmd.ts`)
+
+- `detectQmd()` — check if `qmd` is on PATH via `qmd status`
+- `installQmd()` — run `bun install -g https://github.com/tobi/qmd`
+- `detectBun()` — check if `bun` is on PATH
+- `setupCollection()` — `qmd collection add <path> --name sero-memory`
+- `runSearch(mode, query, limit)` — execute `qmd search|vsearch|query` and parse JSON
+- `scheduleUpdate()` — debounced `qmd update` (500ms)
+- `searchRelevantMemories(prompt)` — sanitise + keyword search + format results (3s timeout)
+
+All QMD interaction is via `execFile` (child process), same as the reference extension.
+Collection name: `sero-memory` (not `pi-memory`).
+
+### Scratchpad (`scratchpad.ts`)
+
+- Parse/serialize `SCRATCHPAD.md` (markdown checklist format)
+- Tool: `scratchpad` with actions: add, done, undo, clear_done, list
+- Bridged into sero-cli: `sero scratchpad add "Fix auth bug"`
+
+### CLI Bridge Updates
+
+Add to `TOOLS_TO_BRIDGE` in `electron/cli/index.ts`:
+- `memory_search`
+- `scratchpad`
+
+### Modified Files
+
+- `electron/cli/index.ts` — add `memory_search` + `scratchpad` to TOOLS_TO_BRIDGE
+- `extension/context-injector.ts` — new priority ordering, accept search results, inject scratchpad
+- `extension/index.ts` — register new tools/hooks, QMD lifecycle
+- `shared/types.ts` — add ScratchpadItem, QmdSearchResult types
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Bun not installed on user's system | QMD can't be auto-installed | Show clear install instructions; all core features degrade gracefully |
+| QMD search latency on cold start | Selective injection exceeds 3s timeout | Fail silently; agent proceeds without search results |
+| QMD collection gets corrupted | Search returns errors | Re-create collection on next session start; `qmd update` rebuilds index |
+| Exit summary API call fails | No summary in daily log | Fallback to "Auto-summary unavailable" placeholder |
+| 8K context budget too large for some models | Wastes tokens on small-context models | Individual section caps ensure proportional use; truncation from lowest priority up |
+
+## Implementation Phases
+
+### Phase 1: QMD Integration Core
+1. `qmd.ts` — detection, auto-install, collection setup, search, update
+2. `search-tool.ts` — `memory_search` tool registration
+3. Update `context-injector.ts` — selective injection + new priority ordering
+4. Update `electron/cli/index.ts` — bridge `memory_search`
+5. Update `shared/types.ts` — search types
+
+### Phase 2: Scratchpad
+1. `scratchpad.ts` — parse/serialize + tool
+2. Update `context-injector.ts` — inject open items
+3. Update `electron/cli/index.ts` — bridge `scratchpad`
+
+### Phase 3: Session Lifecycle
+1. `session-lifecycle.ts` — handoff on compact + exit summary
+2. Update `index.ts` — register lifecycle hooks
+
+### Phase 4: Polish
+1. Tags & links guidance in system prompt ✅
+2. Env var support (`SERO_MEMORY_NO_SEARCH`) ✅
+3. Testing + verification
+
+## Implementation Status
+
+All phases implemented. Files created/modified:
+
+**New files:**
+- `extension/qmd.ts` (291 LOC) — QMD detection, auto-install, collection setup, search, re-indexing
+- `extension/search-tool.ts` (164 LOC) — memory_search tool (keyword/semantic/deep)
+- `extension/scratchpad.ts` (189 LOC) — scratchpad tool + parse/serialize + injection helpers
+- `extension/session-lifecycle.ts` (197 LOC) — compaction handoff + exit summary
+
+**Modified files:**
+- `extension/context-injector.ts` — new priority ordering (8K budget), selective injection
+- `extension/index.ts` — wires QMD init, search, scratchpad, lifecycle hooks
+- `extension/memory-tool.ts` — added QMD re-index on writes
+- `extension/memory-manager.ts` — added SCRATCHPAD.md to root files set
+- `shared/types.ts` — added ScratchpadItem type
+- `apps/desktop/electron/cli/index.ts` — added memory_search + scratchpad to TOOLS_TO_BRIDGE

--- a/packages/pi-memory-extension/extension/context-injector.ts
+++ b/packages/pi-memory-extension/extension/context-injector.ts
@@ -1,22 +1,26 @@
 /**
- * ContextInjector — injects memory files into the system prompt.
+ * ContextInjector — injects memory context into the system prompt.
  *
- * Hooks into `before_agent_start` so that MEMORY.md, IDENTITY.md,
- * and USER.md are available to the agent at the start of every turn.
+ * Priority ordering (8K total budget):
+ *   1. IDENTITY.md + USER.md      (2.0K) — persona, never truncated
+ *   2. Open scratchpad items      (1.5K) — active work context
+ *   3. QMD search results         (2.5K) — auto-retrieved relevant memories
+ *   4. MEMORY.md (long-term)      (2.0K) — curated facts, middle-truncated
  *
- * On first run (no MEMORY.md), injects bootstrap instructions that
- * tell the agent to use the `questionnaire` tool to collect answers,
- * then write results to memory files.
+ * Daily logs are NOT injected directly — they're surfaced through
+ * selective injection (priority 3) when relevant to the current prompt.
  *
- * Bootstrap status is cached after the first check and reset on
- * each `session_start` to avoid redundant filesystem I/O per turn.
+ * On first run (no MEMORY.md), injects bootstrap instructions instead.
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
 import {
   resolveMemoryRoot,
-  getContextFiles,
+  readFile,
+  getMemoryPath,
+  getIdentityPath,
+  getUserPath,
 } from './memory-manager';
 import {
   checkBootstrapStatus,
@@ -25,15 +29,18 @@ import {
   MEMORY_QUESTIONS,
 } from './bootstrap';
 import type { BootstrapStatus } from './bootstrap';
+import { getOpenScratchpadItems, formatScratchpadForInjection } from './scratchpad';
+import { searchRelevantMemories, isQmdAvailable } from './qmd';
 
-// ── Max injection size (tokens are ~4 chars) ───────────────────
+// ── Budget constants ───────────────────────────────────────────
 
-const MAX_INJECTION_CHARS = 4000;
+const BUDGET_IDENTITY_USER = 2_000;
+const BUDGET_SCRATCHPAD    = 1_500;
+const BUDGET_SEARCH        = 2_500;
+const BUDGET_MEMORY        = 2_000;
+const BUDGET_TOTAL         = 8_000;
 
 // ── Bootstrap status cache ─────────────────────────────────────
-//
-// Avoid checking the filesystem on every `before_agent_start`.
-// Reset on `session_start` so a new session re-checks once.
 
 let cachedStatus: BootstrapStatus | null = null;
 
@@ -44,60 +51,108 @@ async function getCachedBootstrapStatus(): Promise<BootstrapStatus> {
   return cachedStatus;
 }
 
-/** Call on session_start to re-check bootstrap state. */
 export function resetBootstrapCache(): void {
   cachedStatus = null;
 }
 
-/** Call after the agent writes memory files during bootstrap. */
 export function markBootstrapDone(): void {
   cachedStatus = { needsBootstrap: false, existingUserContent: null };
 }
 
-// ── Normal mode: build context from existing files ─────────────
+// ── Truncation helpers ─────────────────────────────────────────
 
-async function buildContextBlock(root: string): Promise<string> {
-  const files = await getContextFiles(root);
-  if (files.length === 0) return '';
+function truncateStart(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return text.slice(0, maxChars - 30) + '\n\n_[truncated]_';
+}
 
+function truncateMiddle(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const marker = '\n\n... (truncated) ...\n\n';
+  const keep = maxChars - marker.length;
+  if (keep <= 0) return text.slice(0, maxChars);
+  const head = Math.ceil(keep / 2);
+  const tail = Math.floor(keep / 2);
+  return text.slice(0, head) + marker + text.slice(text.length - tail);
+}
+
+// ── Build normal-mode context ──────────────────────────────────
+
+async function buildPriorityContext(
+  root: string,
+  prompt: string,
+): Promise<string> {
   const sections: string[] = [];
   let totalChars = 0;
 
-  for (const file of files) {
-    const section = `### ${file.name}\n\n${file.content}`;
-    if (totalChars + section.length > MAX_INJECTION_CHARS) {
-      const remaining = MAX_INJECTION_CHARS - totalChars;
-      if (remaining > 100) {
-        const truncated = file.content.slice(0, remaining - 80);
-        const target = file.name.replace('.md', '').toLowerCase();
-        sections.push(
-          `### ${file.name}\n\n${truncated}\n\n_[truncated — use \`sero memory read --target ${target}\` for full content]_`,
-        );
-      }
-      break;
-    }
-    sections.push(section);
-    totalChars += section.length;
+  function addSection(content: string): boolean {
+    if (!content.trim()) return false;
+    if (totalChars + content.length > BUDGET_TOTAL) return false;
+    sections.push(content);
+    totalChars += content.length;
+    return true;
   }
 
-  return `\n\n## Memory\n\nThe following memory files are loaded from the global workspace. Use the \`sero-cli\` tool with \`memory\` commands to manage them.\n\n${sections.join('\n\n---\n\n')}`;
+  // Priority 1: IDENTITY.md + USER.md (combined budget)
+  const identityContent = await readFile(getIdentityPath(root));
+  const userContent = await readFile(getUserPath(root));
+  const identityParts: string[] = [];
+  if (identityContent?.trim()) identityParts.push(`### IDENTITY.md\n\n${identityContent.trim()}`);
+  if (userContent?.trim()) identityParts.push(`### USER.md\n\n${userContent.trim()}`);
+  if (identityParts.length > 0) {
+    addSection(truncateStart(identityParts.join('\n\n---\n\n'), BUDGET_IDENTITY_USER));
+  }
+
+  // Priority 2: Open scratchpad items
+  const openItems = await getOpenScratchpadItems();
+  if (openItems.length > 0) {
+    const scratchpadBlock = formatScratchpadForInjection(openItems);
+    addSection(truncateStart(scratchpadBlock, BUDGET_SCRATCHPAD));
+  }
+
+  // Priority 3: QMD selective injection (search results)
+  const skipSearch = process.env.SERO_MEMORY_NO_SEARCH === '1';
+  if (!skipSearch && isQmdAvailable() && prompt) {
+    const searchResults = await searchRelevantMemories(prompt);
+    if (searchResults.trim()) {
+      const searchBlock = `## Relevant memories (auto-retrieved)\n\n${searchResults}`;
+      addSection(truncateStart(searchBlock, BUDGET_SEARCH));
+    }
+  }
+
+  // Priority 4: MEMORY.md (long-term)
+  const memoryContent = await readFile(getMemoryPath(root));
+  if (memoryContent?.trim()) {
+    const memoryBlock = `## MEMORY.md (long-term)\n\n${memoryContent.trim()}`;
+    addSection(truncateMiddle(memoryBlock, BUDGET_MEMORY));
+  }
+
+  if (sections.length === 0) return '';
+  return `\n\n## Memory\n\n${sections.join('\n\n---\n\n')}`;
 }
 
 function getMemoryInstructions(): string {
+  const searchLine = isQmdAvailable()
+    ? '- `sero memory_search --query "..." [--mode keyword|semantic|deep]` — semantic search across all memory files'
+    : '';
+
   return [
     '\n\n**Memory commands:**',
     '- `sero memory write --target memory --content "..."` — save a long-term fact or decision',
     '- `sero memory write --target daily --content "..."` — log something to today\'s daily note',
     '- `sero memory read --target memory|identity|user|daily` — read a memory file',
-    '- `sero memory search --query "..."` — search across all memory files',
+    '- `sero memory search --query "..."` — grep search across memory files',
+    searchLine,
+    '- `sero scratchpad add "..."` — add item to scratchpad checklist',
     '- `sero memory list` — list all memory files',
     '',
+    'Use #tags (e.g. #decision, #preference) and [[links]] (e.g. [[auth-strategy]]) in memory content to improve search recall.',
     'Proactively save important facts, user preferences, and decisions to memory.',
     'When the user shares something worth remembering, write it to the appropriate target.',
-  ].join('\n');
+  ].filter(Boolean).join('\n');
 }
 
-// ── Bootstrap mode: questionnaire-driven setup ─────────────────
+// ── Bootstrap mode ─────────────────────────────────────────────
 
 function buildBootstrapInstructions(existingUserContent: string | null): string {
   const identityJson = JSON.stringify(IDENTITY_QUESTIONS, null, 2);
@@ -148,7 +203,6 @@ After receiving answers, write MEMORY.md:
 // ── Register hooks ─────────────────────────────────────────────
 
 export function registerContextInjection(pi: ExtensionAPI): void {
-  // Reset cache on each new session so bootstrap status is re-checked once
   pi.on('session_start', () => {
     resetBootstrapCache();
   });
@@ -161,7 +215,7 @@ export function registerContextInjection(pi: ExtensionAPI): void {
       addition = buildBootstrapInstructions(status.existingUserContent);
     } else {
       const root = resolveMemoryRoot();
-      const contextBlock = await buildContextBlock(root);
+      const contextBlock = await buildPriorityContext(root, event.prompt ?? '');
       addition = contextBlock + getMemoryInstructions();
     }
 

--- a/packages/pi-memory-extension/extension/context-injector.ts
+++ b/packages/pi-memory-extension/extension/context-injector.ts
@@ -32,13 +32,13 @@ import type { BootstrapStatus } from './bootstrap';
 import { getOpenScratchpadItems, formatScratchpadForInjection } from './scratchpad';
 import { searchRelevantMemories, isQmdAvailable } from './qmd';
 
-// ── Budget constants ───────────────────────────────────────────
+// ── Budget constants (character limits, ~4 chars per token) ────
 
-const BUDGET_IDENTITY_USER = 2_000;
-const BUDGET_SCRATCHPAD    = 1_500;
-const BUDGET_SEARCH        = 2_500;
-const BUDGET_MEMORY        = 2_000;
-const BUDGET_TOTAL         = 8_000;
+const BUDGET_IDENTITY_USER = 2_000; // ~500 tokens
+const BUDGET_SCRATCHPAD    = 1_500; // ~375 tokens
+const BUDGET_SEARCH        = 2_500; // ~625 tokens
+const BUDGET_MEMORY        = 2_000; // ~500 tokens
+const BUDGET_TOTAL         = 8_000; // ~2K tokens — safety cap (sub-budgets sum to this)
 
 // ── Bootstrap status cache ─────────────────────────────────────
 

--- a/packages/pi-memory-extension/extension/index.ts
+++ b/packages/pi-memory-extension/extension/index.ts
@@ -1,15 +1,16 @@
 /**
- * Memory Extension — persistent memory for Sero.
+ * Memory Extension — persistent memory for Sero with QMD semantic search.
  *
  * Stores long-term facts (MEMORY.md), agent identity (IDENTITY.md),
- * user profile (USER.md), and daily logs in the global workspace.
- * All files are git-tracked via Sero's existing checkpoint system.
+ * user profile (USER.md), scratchpad (SCRATCHPAD.md), and daily logs
+ * in the global workspace. All files are git-tracked via Sero's
+ * existing checkpoint system.
  *
- * On first run, the agent uses the `questionnaire` tool to ask the
- * user setup questions, then writes answers to memory files.
+ * QMD provides keyword, semantic, and hybrid search across all files.
+ * Selective injection surfaces relevant past memories before each turn.
  *
- * Tools (LLM-callable): memory (read, write, search, list)
- * Hooks: before_agent_start (context injection + bootstrap)
+ * Tools: memory (read/write/search/list), memory_search, scratchpad
+ * Hooks: before_agent_start (context injection), session lifecycle
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
@@ -17,9 +18,14 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { checkBootstrapStatus } from './bootstrap';
 import { registerContextInjection, markBootstrapDone } from './context-injector';
 import { registerMemoryTool } from './memory-tool';
+import { registerSearchTool } from './search-tool';
+import { registerScratchpadTool } from './scratchpad';
+import { registerSessionLifecycle } from './session-lifecycle';
+import { initQmd, isQmdAvailable } from './qmd';
 
 export default function memoryExtension(pi: ExtensionAPI): void {
-  // Warm the bootstrap cache on session start and notify on first run
+  // ── Session start: bootstrap check + QMD init ──────────────
+
   pi.on('session_start', async () => {
     const status = await checkBootstrapStatus();
     if (status.needsBootstrap) {
@@ -32,26 +38,40 @@ export default function memoryExtension(pi: ExtensionAPI): void {
         { triggerTurn: false },
       );
     }
+
+    // Init QMD (detect → auto-install → setup collection)
+    const qmdReady = await initQmd();
+    if (!qmdReady) {
+      // Non-fatal: core memory works without QMD
+      console.log('[memory] QMD not available — semantic search disabled');
+    }
   });
 
-  // After each agent turn, if bootstrap was in progress and
-  // memory files are now written, update the cache so subsequent
-  // turns switch to normal context injection.
+  // ── Post-turn: detect bootstrap completion ─────────────────
+
   pi.on('agent_end', async () => {
-    // Re-check; if MEMORY.md now exists, mark bootstrap done
     const status = await checkBootstrapStatus();
     if (!status.needsBootstrap) {
       markBootstrapDone();
     }
   });
 
-  // Inject memory context (or bootstrap instructions) into the system prompt
+  // ── Context injection (priority-ordered + selective search) ─
+
   registerContextInjection(pi);
 
-  // Register the memory tool (bridged into sero-cli via AD-020)
-  registerMemoryTool(pi);
+  // ── Tools (all bridged into sero-cli via AD-020) ───────────
 
-  // /memory slash command for the user
+  registerMemoryTool(pi);
+  registerSearchTool(pi);
+  registerScratchpadTool(pi);
+
+  // ── Session lifecycle (handoff + exit summary) ─────────────
+
+  registerSessionLifecycle(pi);
+
+  // ── Slash commands ─────────────────────────────────────────
+
   pi.registerCommand('memory', {
     description: 'Show memory files or manage them (pass instructions inline)',
     handler: async (args) => {
@@ -60,6 +80,18 @@ export default function memoryExtension(pi: ExtensionAPI): void {
         pi.sendUserMessage(`Using the memory tool: ${instruction}`);
       } else {
         pi.sendUserMessage('List all memory files using the memory tool.');
+      }
+    },
+  });
+
+  pi.registerCommand('scratchpad', {
+    description: 'Show scratchpad or manage items (pass instructions inline)',
+    handler: async (args) => {
+      const instruction = args.trim();
+      if (instruction) {
+        pi.sendUserMessage(`Using the scratchpad tool: ${instruction}`);
+      } else {
+        pi.sendUserMessage('List all scratchpad items using the scratchpad tool.');
       }
     },
   });

--- a/packages/pi-memory-extension/extension/memory-manager.ts
+++ b/packages/pi-memory-extension/extension/memory-manager.ts
@@ -20,7 +20,7 @@ import type { MemorySearchResult, MemoryFileList } from '../shared/types';
 // ── Constants ──────────────────────────────────────────────────
 
 /** Only these root-level .md files are managed by the memory system. */
-const MEMORY_ROOT_FILES = new Set(['MEMORY.md', 'IDENTITY.md', 'USER.md']);
+const MEMORY_ROOT_FILES = new Set(['MEMORY.md', 'IDENTITY.md', 'USER.md', 'SCRATCHPAD.md']);
 
 // ── Path resolution ────────────────────────────────────────────
 

--- a/packages/pi-memory-extension/extension/memory-tool.ts
+++ b/packages/pi-memory-extension/extension/memory-tool.ts
@@ -24,6 +24,7 @@ import {
   listFiles,
   todayStr,
 } from './memory-manager';
+import { scheduleQmdUpdate } from './qmd';
 
 // ── Tool parameters ────────────────────────────────────────────
 
@@ -100,6 +101,7 @@ async function handleWrite(
     await appendFile(resolved.path, content);
   }
 
+  scheduleQmdUpdate();
   const verb = mode === 'overwrite' ? 'Wrote to' : 'Appended to';
   return text(`${verb} ${resolved.displayName}`);
 }

--- a/packages/pi-memory-extension/extension/qmd.ts
+++ b/packages/pi-memory-extension/extension/qmd.ts
@@ -1,0 +1,321 @@
+/**
+ * QMD integration — detection, auto-install, collection management, search.
+ *
+ * QMD is an external CLI tool providing BM25 keyword, vector semantic,
+ * and hybrid search over markdown files. All interaction is via child
+ * process (execFile) — same pattern as Sero's git integration.
+ *
+ * Graceful degradation: if QMD or Bun is missing, all functions
+ * return safe defaults (false, empty string, etc.).
+ */
+
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveMemoryRoot } from './memory-manager';
+
+// ── State ──────────────────────────────────────────────────────
+
+let qmdAvailable = false;
+let qmdPath = 'qmd';
+let bunPath = 'bun';
+let updateTimer: ReturnType<typeof setTimeout> | null = null;
+
+const QMD_COLLECTION = 'sero-memory';
+const QMD_PACKAGE = '@tobilu/qmd';
+const SEARCH_TIMEOUT_MS = 3_000;
+const UPDATE_DEBOUNCE_MS = 500;
+
+// ── Binary resolution ──────────────────────────────────────────
+
+/** Find a binary by checking common locations Electron might miss. */
+function findBinary(name: string): string {
+  const home = os.homedir();
+  const candidates = [
+    name, // on PATH already
+    path.join(home, '.bun', 'bin', name),
+    path.join(home, '.local', 'bin', name),
+    `/usr/local/bin/${name}`,
+    `/opt/homebrew/bin/${name}`,
+  ];
+  for (const candidate of candidates) {
+    if (candidate === name) continue; // skip bare name, test via exec
+    if (existsSync(candidate)) return candidate;
+  }
+  return name; // fallback to bare name
+}
+
+function resolvePaths(): void {
+  qmdPath = findBinary('qmd');
+  bunPath = findBinary('bun');
+}
+
+// ── Detection ──────────────────────────────────────────────────
+
+export function isQmdAvailable(): boolean {
+  return qmdAvailable;
+}
+
+export function detectQmd(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(qmdPath, ['status'], { timeout: 5_000 }, (err) => {
+      resolve(!err);
+    });
+  });
+}
+
+export function detectBun(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(bunPath, ['--version'], { timeout: 5_000 }, (err) => {
+      resolve(!err);
+    });
+  });
+}
+
+// ── Auto-install ───────────────────────────────────────────────
+
+export async function tryInstallQmd(): Promise<boolean> {
+  const hasBun = await detectBun();
+  if (!hasBun) return false;
+
+  return new Promise((resolve) => {
+    execFile(
+      bunPath,
+      ['install', '-g', QMD_PACKAGE],
+      { timeout: 60_000 },
+      (err) => resolve(!err),
+    );
+  });
+}
+
+export function installInstructions(): string {
+  const root = resolveMemoryRoot();
+  return [
+    'memory_search requires qmd (semantic search engine).',
+    '',
+    'Install (requires Bun):',
+    `  bun install -g ${QMD_PACKAGE}`,
+    '',
+    'Or install Bun first:',
+    '  curl -fsSL https://bun.sh/install | bash',
+    '',
+    'Then restart Sero — QMD will be auto-configured.',
+  ].join('\n');
+}
+
+// ── Collection management ──────────────────────────────────────
+
+export function checkCollection(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(qmdPath, ['collection', 'list', '--json'], { timeout: 10_000 }, (err, stdout) => {
+      if (err) { resolve(false); return; }
+      try {
+        const parsed = JSON.parse(stdout);
+        const collections = Array.isArray(parsed) ? parsed : [];
+        resolve(collections.some((e: unknown) => {
+          if (typeof e === 'string') return e === QMD_COLLECTION;
+          if (e && typeof e === 'object' && 'name' in e) {
+            return (e as { name?: string }).name === QMD_COLLECTION;
+          }
+          return false;
+        }));
+      } catch {
+        resolve(stdout.includes(QMD_COLLECTION));
+      }
+    });
+  });
+}
+
+export async function setupCollection(): Promise<boolean> {
+  const root = resolveMemoryRoot();
+
+  // Create collection
+  try {
+    await execPromise(qmdPath, ['collection', 'add', root, '--name', QMD_COLLECTION], 10_000);
+  } catch {
+    return false;
+  }
+
+  // Add path contexts (best-effort)
+  const contexts: [string, string][] = [
+    ['/memory/daily', 'Daily append-only work logs organised by date'],
+    ['/', 'Curated long-term memory: decisions, preferences, facts, lessons'],
+  ];
+  for (const [ctxPath, desc] of contexts) {
+    try {
+      await execPromise(qmdPath, ['context', 'add', ctxPath, desc, '-c', QMD_COLLECTION], 10_000);
+    } catch { /* context may already exist */ }
+  }
+
+  return true;
+}
+
+// ── Initialisation (called on session_start) ───────────────────
+
+export async function initQmd(): Promise<boolean> {
+  resolvePaths();
+  qmdAvailable = await detectQmd();
+
+  if (!qmdAvailable) {
+    // Try auto-install
+    const installed = await tryInstallQmd();
+    if (installed) {
+      qmdAvailable = await detectQmd();
+    }
+  }
+
+  if (!qmdAvailable) return false;
+
+  // Ensure collection exists
+  const hasCollection = await checkCollection();
+  if (!hasCollection) {
+    await setupCollection();
+  }
+
+  return true;
+}
+
+// ── Search ─────────────────────────────────────────────────────
+
+export type QmdSearchMode = 'keyword' | 'semantic' | 'deep';
+
+export interface QmdSearchResult {
+  path?: string;
+  file?: string;
+  score?: number;
+  content?: string;
+  chunk?: string;
+  snippet?: string;
+  [key: string]: unknown;
+}
+
+function getResultPath(r: QmdSearchResult): string | undefined {
+  return r.path ?? r.file;
+}
+
+function getResultText(r: QmdSearchResult): string {
+  return r.content ?? r.chunk ?? r.snippet ?? '';
+}
+
+function stripAnsi(text: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
+  return text.replace(/\u001b\[[0-9;]*[A-Za-z]/g, '').replace(/\u001b\][^\u0007]*(\u0007|\u001b\\)/g, '');
+}
+
+function parseQmdJson(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  if (!trimmed || trimmed === 'No results found.' || trimmed === 'No results found') return [];
+
+  const cleaned = stripAnsi(stdout);
+  const lines = cleaned.split(/\r?\n/);
+  const startLine = lines.findIndex((l) => {
+    const s = l.trimStart();
+    return s.startsWith('[') || s.startsWith('{');
+  });
+  if (startLine === -1) return [];
+
+  const jsonText = lines.slice(startLine).join('\n').trim();
+  if (!jsonText) return [];
+  return JSON.parse(jsonText);
+}
+
+export async function runSearch(
+  mode: QmdSearchMode,
+  query: string,
+  limit: number,
+): Promise<{ results: QmdSearchResult[]; stderr: string }> {
+  const subcommand = mode === 'keyword' ? 'search' : mode === 'semantic' ? 'vsearch' : 'query';
+  const args = [subcommand, '--json', '-c', QMD_COLLECTION, '-n', String(limit), query];
+
+  const { stdout, stderr } = await execPromise(qmdPath, args, 60_000);
+  const parsed = parseQmdJson(stdout);
+  const results = Array.isArray(parsed)
+    ? parsed
+    : ((parsed as Record<string, unknown>).results ?? (parsed as Record<string, unknown>).hits ?? []);
+
+  return { results: results as QmdSearchResult[], stderr };
+}
+
+/**
+ * Search for memories relevant to a user prompt.
+ * Used for selective injection (before_agent_start).
+ * Returns formatted markdown or empty string on error.
+ */
+export async function searchRelevantMemories(prompt: string): Promise<string> {
+  if (!qmdAvailable || !prompt.trim()) return '';
+
+  const sanitised = prompt
+    .replace(/[\x00-\x1f\x7f]/g, ' ')
+    .trim()
+    .slice(0, 200);
+  if (!sanitised) return '';
+
+  try {
+    const hasCol = await checkCollection();
+    if (!hasCol) return '';
+
+    const { results } = await Promise.race([
+      runSearch('keyword', sanitised, 3),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('timeout')), SEARCH_TIMEOUT_MS),
+      ),
+    ]);
+
+    if (!results || results.length === 0) return '';
+
+    const snippets = results
+      .map((r) => {
+        const text = getResultText(r);
+        if (!text.trim()) return null;
+        const filePath = getResultPath(r);
+        const filePart = filePath ? `_${filePath}_` : '';
+        return filePart ? `${filePart}\n${text.trim()}` : text.trim();
+      })
+      .filter(Boolean);
+
+    if (snippets.length === 0) return '';
+    return snippets.join('\n\n---\n\n');
+  } catch {
+    return '';
+  }
+}
+
+// ── Re-indexing (debounced) ────────────────────────────────────
+
+export function scheduleQmdUpdate(): void {
+  if (!qmdAvailable) return;
+  if (updateTimer) clearTimeout(updateTimer);
+  updateTimer = setTimeout(() => {
+    updateTimer = null;
+    execFile(qmdPath, ['update'], { timeout: 30_000 }, () => {});
+  }, UPDATE_DEBOUNCE_MS);
+}
+
+export async function runQmdUpdateNow(): Promise<void> {
+  if (!qmdAvailable) return;
+  await execPromise(qmdPath, ['update'], 30_000).catch(() => {});
+}
+
+export function clearUpdateTimer(): void {
+  if (updateTimer) {
+    clearTimeout(updateTimer);
+    updateTimer = null;
+  }
+}
+
+// ── Helper ─────────────────────────────────────────────────────
+
+function execPromise(
+  cmd: string,
+  args: string[],
+  timeout: number,
+): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { timeout }, (err, stdout, stderr) => {
+      if (err) reject(new Error(stderr?.trim() || err.message));
+      else resolve({ stdout: stdout ?? '', stderr: stderr ?? '' });
+    });
+  });
+}

--- a/packages/pi-memory-extension/extension/qmd.ts
+++ b/packages/pi-memory-extension/extension/qmd.ts
@@ -15,6 +15,10 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { resolveMemoryRoot } from './memory-manager';
+import { getResultPath, getResultText } from '../shared/types';
+import type { QmdSearchResult } from '../shared/types';
+// Re-export so consumers can import from './qmd'
+export type { QmdSearchResult } from '../shared/types';
 
 // ── State ──────────────────────────────────────────────────────
 
@@ -91,7 +95,6 @@ export async function tryInstallQmd(): Promise<boolean> {
 }
 
 export function installInstructions(): string {
-  const root = resolveMemoryRoot();
   return [
     'memory_search requires qmd (semantic search engine).',
     '',
@@ -162,6 +165,8 @@ export async function initQmd(): Promise<boolean> {
     // Try auto-install
     const installed = await tryInstallQmd();
     if (installed) {
+      // Re-resolve paths — qmd is now in ~/.bun/bin/ which findBinary checks
+      resolvePaths();
       qmdAvailable = await detectQmd();
     }
   }
@@ -180,24 +185,6 @@ export async function initQmd(): Promise<boolean> {
 // ── Search ─────────────────────────────────────────────────────
 
 export type QmdSearchMode = 'keyword' | 'semantic' | 'deep';
-
-export interface QmdSearchResult {
-  path?: string;
-  file?: string;
-  score?: number;
-  content?: string;
-  chunk?: string;
-  snippet?: string;
-  [key: string]: unknown;
-}
-
-function getResultPath(r: QmdSearchResult): string | undefined {
-  return r.path ?? r.file;
-}
-
-function getResultText(r: QmdSearchResult): string {
-  return r.content ?? r.chunk ?? r.snippet ?? '';
-}
 
 function stripAnsi(text: string): string {
   // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
@@ -256,11 +243,12 @@ export async function searchRelevantMemories(prompt: string): Promise<string> {
     const hasCol = await checkCollection();
     if (!hasCol) return '';
 
+    let timeoutId: ReturnType<typeof setTimeout>;
     const { results } = await Promise.race([
-      runSearch('keyword', sanitised, 3),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('timeout')), SEARCH_TIMEOUT_MS),
-      ),
+      runSearch('keyword', sanitised, 3).finally(() => clearTimeout(timeoutId)),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error('timeout')), SEARCH_TIMEOUT_MS);
+      }),
     ]);
 
     if (!results || results.length === 0) return '';

--- a/packages/pi-memory-extension/extension/scratchpad.ts
+++ b/packages/pi-memory-extension/extension/scratchpad.ts
@@ -1,0 +1,189 @@
+/**
+ * Scratchpad — a persistent checklist of things to fix/remember.
+ *
+ * Stored at ~/.sero-ui/workspaces/global/SCRATCHPAD.md as a
+ * markdown checklist. Open items are injected into the system
+ * prompt at high priority (after identity/user).
+ *
+ * Tool actions: add, done, undo, clear_done, list.
+ * Bridged into sero-cli as `sero scratchpad add "Fix auth bug"`.
+ */
+
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import { resolveMemoryRoot, readFile, writeFile } from './memory-manager';
+import { scheduleQmdUpdate } from './qmd';
+import type { ScratchpadItem } from '../shared/types';
+import path from 'node:path';
+
+// ── Path ───────────────────────────────────────────────────────
+
+export function getScratchpadPath(): string {
+  return path.join(resolveMemoryRoot(), 'SCRATCHPAD.md');
+}
+
+// ── Parse / Serialize ──────────────────────────────────────────
+
+export function parseScratchpad(content: string): ScratchpadItem[] {
+  const items: ScratchpadItem[] = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    const match = line.match(/^- \[([ xX])\] (.+)$/);
+    if (match) {
+      let meta = '';
+      if (i > 0 && lines[i - 1]!.match(/^<!--.*-->$/)) {
+        meta = lines[i - 1]!;
+      }
+      items.push({
+        done: match[1]!.toLowerCase() === 'x',
+        text: match[2]!,
+        meta,
+      });
+    }
+  }
+
+  return items;
+}
+
+export function serializeScratchpad(items: ScratchpadItem[]): string {
+  const lines: string[] = ['# Scratchpad', ''];
+  for (const item of items) {
+    if (item.meta) lines.push(item.meta);
+    const checkbox = item.done ? '[x]' : '[ ]';
+    lines.push(`- ${checkbox} ${item.text}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+// ── Read open items (for context injection) ────────────────────
+
+export async function getOpenScratchpadItems(): Promise<ScratchpadItem[]> {
+  const content = await readFile(getScratchpadPath());
+  if (!content?.trim()) return [];
+  return parseScratchpad(content).filter((i) => !i.done);
+}
+
+export function formatScratchpadForInjection(items: ScratchpadItem[]): string {
+  if (items.length === 0) return '';
+  const lines = items.map((i) => `- [ ] ${i.text}`);
+  return `## Scratchpad (${items.length} open)\n\n${lines.join('\n')}`;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function text(t: string) {
+  return { content: [{ type: 'text' as const, text: t }], details: {} };
+}
+
+function nowTimestamp(): string {
+  return new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+}
+
+// ── Tool parameters ────────────────────────────────────────────
+
+const ScratchpadParams = Type.Object({
+  action: StringEnum(['add', 'done', 'undo', 'clear_done', 'list'] as const),
+  text: Type.Optional(
+    Type.String({ description: 'Item text for add, or substring to match for done/undo' }),
+  ),
+});
+
+// ── Register ───────────────────────────────────────────────────
+
+export function registerScratchpadTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: 'scratchpad',
+    label: 'Scratchpad',
+    description: [
+      'Manage a persistent checklist of things to fix or keep in mind.',
+      "- 'add': Add a new item (requires text)",
+      "- 'done': Mark an item as done (match by substring)",
+      "- 'undo': Uncheck a done item (match by substring)",
+      "- 'clear_done': Remove all checked items",
+      "- 'list': Show all items",
+    ].join('\n'),
+    parameters: ScratchpadParams,
+
+    async execute(_toolCallId, params) {
+      const filePath = getScratchpadPath();
+      const existing = await readFile(filePath);
+      let items = existing?.trim() ? parseScratchpad(existing) : [];
+      const ts = nowTimestamp();
+
+      const action = params.action as string;
+      const itemText = params.text as string | undefined;
+
+      switch (action) {
+        case 'list': {
+          if (items.length === 0) return text('Scratchpad is empty.');
+          const serialised = serializeScratchpad(items);
+          const open = items.filter((i) => !i.done).length;
+          return text(`${serialised}\n(${open} open, ${items.length - open} done)`);
+        }
+
+        case 'add': {
+          if (!itemText) return text('Error: text is required for add.');
+          items.push({ done: false, text: itemText, meta: `<!-- ${ts} -->` });
+          await writeFile(filePath, serializeScratchpad(items));
+          scheduleQmdUpdate();
+          return text(`Added: - [ ] ${itemText}`);
+        }
+
+        case 'done':
+        case 'undo': {
+          if (!itemText) return text(`Error: text is required for ${action}.`);
+          const needle = itemText.toLowerCase();
+          const targetDone = action === 'done';
+          let matched = false;
+
+          for (const item of items) {
+            if (item.done !== targetDone && item.text.toLowerCase().includes(needle)) {
+              item.done = targetDone;
+              matched = true;
+              break;
+            }
+          }
+
+          if (!matched) {
+            return text(`No matching ${targetDone ? 'open' : 'done'} item for: "${itemText}"`);
+          }
+
+          await writeFile(filePath, serializeScratchpad(items));
+          scheduleQmdUpdate();
+          const verb = targetDone ? 'Completed' : 'Reopened';
+          return text(`${verb} item matching "${itemText}".`);
+        }
+
+        case 'clear_done': {
+          const before = items.length;
+          items = items.filter((i) => !i.done);
+          const removed = before - items.length;
+          await writeFile(filePath, serializeScratchpad(items));
+          scheduleQmdUpdate();
+          return text(`Cleared ${removed} done item(s). ${items.length} remaining.`);
+        }
+
+        default:
+          return text(`Unknown action: ${action}`);
+      }
+    },
+
+    renderCall(args, theme) {
+      let t = theme.fg('toolTitle', theme.bold('scratchpad '));
+      t += theme.fg('muted', args.action);
+      if (args.text) t += ` ${theme.fg('dim', `"${args.text}"`)}`;
+      return new Text(t, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const msg = result.content?.[0]?.type === 'text' ? result.content[0].text : '';
+      if (msg.startsWith('Error:')) return new Text(theme.fg('error', msg), 0, 0);
+      return new Text(theme.fg('success', '✓ ') + theme.fg('muted', msg), 0, 0);
+    },
+  });
+}

--- a/packages/pi-memory-extension/extension/search-tool.ts
+++ b/packages/pi-memory-extension/extension/search-tool.ts
@@ -1,0 +1,164 @@
+/**
+ * memory_search tool — QMD-powered search across all memory files.
+ *
+ * Supports three modes:
+ *   keyword  (~30ms)  — BM25 full-text search, best for specific terms, #tags, [[links]]
+ *   semantic (~2s)    — vector search, finds related concepts with different wording
+ *   deep     (~10s)   — hybrid search with reranking
+ *
+ * Bridged into sero-cli as `sero memory_search --query "..." --mode keyword`.
+ * Falls back to install instructions when QMD is unavailable.
+ */
+
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import {
+  isQmdAvailable,
+  detectQmd,
+  runSearch,
+  checkCollection,
+  setupCollection,
+  installInstructions,
+} from './qmd';
+import type { QmdSearchResult } from './qmd';
+
+// ── Parameters ─────────────────────────────────────────────────
+
+const SearchParams = Type.Object({
+  query: Type.String({ description: 'Search query' }),
+  mode: Type.Optional(
+    StringEnum(['keyword', 'semantic', 'deep'] as const),
+  ),
+  limit: Type.Optional(
+    Type.Number({ description: 'Max results (default: 5)' }),
+  ),
+});
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function getResultPath(r: QmdSearchResult): string | undefined {
+  return r.path ?? r.file;
+}
+
+function getResultText(r: QmdSearchResult): string {
+  return r.content ?? r.chunk ?? r.snippet ?? '';
+}
+
+function text(t: string, isError = false) {
+  return {
+    content: [{ type: 'text' as const, text: t }],
+    details: {},
+    ...(isError && { isError: true }),
+  };
+}
+
+// ── Register ───────────────────────────────────────────────────
+
+export function registerSearchTool(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: 'memory_search',
+    label: 'Memory Search',
+    description: [
+      'Search across all memory files (MEMORY.md, SCRATCHPAD.md, daily logs).',
+      'Modes:',
+      "- 'keyword' (default, ~30ms): BM25 search. Best for specific terms, #tags, [[links]].",
+      "- 'semantic' (~2s): Vector search. Finds related concepts with different wording.",
+      "- 'deep' (~10s): Hybrid + reranking. Use when other modes miss.",
+      '',
+      'If the first search misses, try rephrasing or switching modes.',
+      'Use #tags and [[links]] in memory content to improve keyword recall.',
+    ].join('\n'),
+    parameters: SearchParams,
+
+    async execute(_toolCallId, params) {
+      // Re-check on demand in case QMD was installed mid-session
+      let available = isQmdAvailable();
+      if (!available) {
+        available = await detectQmd();
+      }
+
+      if (!available) {
+        return text(installInstructions(), true);
+      }
+
+      // Ensure collection exists
+      let hasCol = await checkCollection();
+      if (!hasCol) {
+        const created = await setupCollection();
+        if (created) hasCol = true;
+      }
+      if (!hasCol) {
+        return text(
+          'Could not set up QMD sero-memory collection. Check that QMD is working and the memory directory exists.',
+          true,
+        );
+      }
+
+      const mode = (params.mode as 'keyword' | 'semantic' | 'deep') ?? 'keyword';
+      const limit = (params.limit as number) ?? 5;
+      const query = params.query as string;
+
+      try {
+        const { results, stderr } = await runSearch(mode, query, limit);
+        const needsEmbed = /need embeddings/i.test(stderr);
+
+        if (results.length === 0) {
+          if (needsEmbed && (mode === 'semantic' || mode === 'deep')) {
+            return text([
+              `No results for "${query}" (mode: ${mode}).`,
+              '',
+              'QMD reports missing vector embeddings.',
+              'Run once, then retry:',
+              '  qmd embed',
+            ].join('\n'));
+          }
+          return text(`No results for "${query}" (mode: ${mode}).`);
+        }
+
+        const formatted = results
+          .map((r, i) => {
+            const parts: string[] = [`### Result ${i + 1}`];
+            const filePath = getResultPath(r);
+            if (filePath) parts.push(`**File:** ${filePath}`);
+            if (r.score != null) parts.push(`**Score:** ${r.score}`);
+            const resultText = getResultText(r);
+            if (resultText) parts.push(`\n${resultText}`);
+            return parts.join('\n');
+          })
+          .join('\n\n---\n\n');
+
+        return {
+          content: [{ type: 'text', text: formatted }],
+          details: { mode, query, count: results.length, needsEmbed },
+        };
+      } catch (err) {
+        return text(
+          `memory_search error: ${err instanceof Error ? err.message : String(err)}`,
+          true,
+        );
+      }
+    },
+
+    renderCall(args, theme) {
+      let t = theme.fg('toolTitle', theme.bold('memory_search '));
+      t += theme.fg('dim', `"${args.query}"`);
+      if (args.mode && args.mode !== 'keyword') t += ` ${theme.fg('accent', args.mode)}`;
+      return new Text(t, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const msg = result.content?.[0]?.type === 'text' ? result.content[0].text : '';
+      if (msg.startsWith('memory_search error:') || msg.startsWith('Could not')) {
+        return new Text(theme.fg('error', msg.split('\n')[0]!), 0, 0);
+      }
+      const count = (result.details as Record<string, unknown>)?.count;
+      return new Text(
+        theme.fg('success', '✓ ') + theme.fg('muted', `${count ?? 0} results`),
+        0, 0,
+      );
+    },
+  });
+}

--- a/packages/pi-memory-extension/extension/search-tool.ts
+++ b/packages/pi-memory-extension/extension/search-tool.ts
@@ -23,7 +23,7 @@ import {
   setupCollection,
   installInstructions,
 } from './qmd';
-import type { QmdSearchResult } from './qmd';
+import { getResultPath, getResultText } from '../shared/types';
 
 // ── Parameters ─────────────────────────────────────────────────
 
@@ -38,14 +38,6 @@ const SearchParams = Type.Object({
 });
 
 // ── Helpers ─────────────────────────────────────────────────────
-
-function getResultPath(r: QmdSearchResult): string | undefined {
-  return r.path ?? r.file;
-}
-
-function getResultText(r: QmdSearchResult): string {
-  return r.content ?? r.chunk ?? r.snippet ?? '';
-}
 
 function text(t: string, isError = false) {
   return {

--- a/packages/pi-memory-extension/extension/session-lifecycle.ts
+++ b/packages/pi-memory-extension/extension/session-lifecycle.ts
@@ -1,0 +1,197 @@
+/**
+ * Session lifecycle hooks — compaction handoff and exit summary.
+ *
+ * - session_before_compact: auto-captures open scratchpad items +
+ *   recent daily log context as a handoff entry in today's daily log.
+ *   This survives context window resets.
+ *
+ * - session_shutdown: generates an LLM-powered session summary
+ *   (decisions, lessons, notes, follow-ups) and appends it to the
+ *   daily log. Uses reasoning_effort: low for cost control.
+ */
+
+import type { ExtensionAPI, SessionEntry } from '@mariozechner/pi-coding-agent';
+import { complete, type Message } from '@mariozechner/pi-ai';
+import { convertToLlm, serializeConversation } from '@mariozechner/pi-coding-agent';
+
+import {
+  resolveMemoryRoot,
+  readFile,
+  getDailyPath,
+  todayStr,
+} from './memory-manager';
+import { getOpenScratchpadItems } from './scratchpad';
+import { runQmdUpdateNow, clearUpdateTimer } from './qmd';
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+// ── Constants ──────────────────────────────────────────────────
+
+const SUMMARY_MAX_CHARS = 80_000;
+
+const SUMMARY_SYSTEM_PROMPT = [
+  'You are a session recap assistant.',
+  'Read the conversation and extract key decisions, lessons learned, notes, and follow-ups.',
+  'Return ONLY markdown in the specified format, without any extra commentary.',
+].join('\n');
+
+// ── Helpers ────────────────────────────────────────────────────
+
+function nowTimestamp(): string {
+  return new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+}
+
+async function appendToDaily(content: string): Promise<void> {
+  const root = resolveMemoryRoot();
+  const filePath = getDailyPath(root, todayStr());
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+
+  const existing = await readFile(filePath);
+  const separator = existing?.trim() ? '\n\n' : '';
+  await fs.writeFile(filePath, (existing ?? '') + separator + content, 'utf-8');
+}
+
+function truncateText(text: string, maxChars: number): { text: string; truncated: boolean } {
+  if (text.length <= maxChars) return { text, truncated: false };
+  return { text: text.slice(-maxChars), truncated: true };
+}
+
+function buildSummaryFallback(error?: string): string {
+  const note = error ? `- Auto-summary unavailable: ${error}.` : '- Auto-summary unavailable.';
+  return [
+    '### Decisions', '- None.',
+    '### Lessons Learned', '- None.',
+    '### Notes', note,
+    '### Follow-ups', '- None.',
+  ].join('\n');
+}
+
+// ── Register hooks ─────────────────────────────────────────────
+
+export function registerSessionLifecycle(pi: ExtensionAPI): void {
+  // ── Compaction handoff ─────────────────────────────────────
+
+  pi.on('session_before_compact', async () => {
+    const parts: string[] = [];
+
+    // Open scratchpad items
+    const openItems = await getOpenScratchpadItems();
+    if (openItems.length > 0) {
+      parts.push('**Open scratchpad items:**');
+      for (const item of openItems) {
+        parts.push(`- [ ] ${item.text}`);
+      }
+    }
+
+    // Recent daily log context (tail)
+    const root = resolveMemoryRoot();
+    const todayContent = await readFile(getDailyPath(root, todayStr()));
+    if (todayContent?.trim()) {
+      const lines = todayContent.trim().split('\n');
+      const tail = lines.slice(-15).join('\n');
+      parts.push(`**Recent daily log context:**\n${tail}`);
+    }
+
+    if (parts.length === 0) return;
+
+    const ts = nowTimestamp();
+    const handoff = [
+      `<!-- HANDOFF ${ts} -->`,
+      '## Session Handoff',
+      ...parts,
+    ].join('\n');
+
+    await appendToDaily(handoff);
+  });
+
+  // ── Exit summary ───────────────────────────────────────────
+
+  pi.on('session_shutdown', async (_event, ctx) => {
+    try {
+      // Extract conversation messages
+      const branch = ctx.sessionManager.getBranch();
+      const messages = branch
+        .filter((entry: SessionEntry) => entry.type === 'message')
+        .map((entry: SessionEntry & { type: 'message' }) => entry.message);
+
+      if (messages.length === 0) return;
+      if (!ctx.model) return;
+
+      const apiKey = await ctx.modelRegistry.getApiKey(ctx.model);
+      if (!apiKey) return;
+
+      // Serialise and truncate conversation
+      const llmMessages = convertToLlm(messages);
+      const conversationText = serializeConversation(llmMessages);
+      const { text: truncated, truncated: wasTruncated } = truncateText(
+        conversationText.trim(),
+        SUMMARY_MAX_CHARS,
+      );
+      if (!truncated) return;
+
+      // Build prompt
+      const promptLines = [
+        'Review the conversation and extract important decisions, lessons learned, notes, and follow-ups for a daily log.',
+        'Return markdown only with these exact headings:',
+        '### Decisions',
+        '### Lessons Learned',
+        '### Notes',
+        '### Follow-ups',
+        'Use bullet points under each heading. If there is nothing, write "None.".',
+      ];
+      if (wasTruncated) {
+        promptLines.push(
+          `Note: Conversation was truncated to the most recent ${truncated.length} of ${conversationText.length} characters.`,
+        );
+      }
+      promptLines.push('', '<conversation>', truncated, '</conversation>');
+
+      const summaryMessages: Message[] = [{
+        role: 'user',
+        content: [{ type: 'text', text: promptLines.join('\n') }],
+        timestamp: Date.now(),
+      }];
+
+      const response = await complete(
+        ctx.model,
+        { systemPrompt: SUMMARY_SYSTEM_PROMPT, messages: summaryMessages },
+        { apiKey, reasoningEffort: 'low' },
+      );
+
+      const summaryText = response.content
+        .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+        .map((c) => c.text)
+        .join('\n')
+        .trim();
+
+      const summary = summaryText || buildSummaryFallback('Summary was empty');
+      const ts = nowTimestamp();
+      const entry = [
+        `<!-- ${ts} -->`,
+        '## Session Summary (auto)',
+        '',
+        summary,
+      ].join('\n');
+
+      await appendToDaily(entry);
+      await runQmdUpdateNow();
+    } catch (err) {
+      // Best-effort: write fallback
+      const ts = nowTimestamp();
+      const fallback = buildSummaryFallback(
+        err instanceof Error ? err.message : 'unknown error',
+      );
+      const entry = [
+        `<!-- ${ts} -->`,
+        '## Session Summary (auto)',
+        '',
+        fallback,
+      ].join('\n');
+      await appendToDaily(entry).catch(() => {});
+    } finally {
+      clearUpdateTimer();
+    }
+  });
+}

--- a/packages/pi-memory-extension/extension/session-lifecycle.ts
+++ b/packages/pi-memory-extension/extension/session-lifecycle.ts
@@ -10,7 +10,7 @@
  *   daily log. Uses reasoning_effort: low for cost control.
  */
 
-import type { ExtensionAPI, SessionEntry } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI, SessionMessageEntry } from '@mariozechner/pi-coding-agent';
 import { complete, type Message } from '@mariozechner/pi-ai';
 import { convertToLlm, serializeConversation } from '@mariozechner/pi-coding-agent';
 
@@ -110,11 +110,12 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
 
   pi.on('session_shutdown', async (_event, ctx) => {
     try {
-      // Extract conversation messages
+      // Extract conversation messages using the SDK's discriminated union
       const branch = ctx.sessionManager.getBranch();
-      const messages = branch
-        .filter((entry: SessionEntry) => entry.type === 'message')
-        .map((entry: SessionEntry & { type: 'message' }) => entry.message);
+      const messageEntries = branch.filter(
+        (entry): entry is SessionMessageEntry => entry.type === 'message',
+      );
+      const messages = messageEntries.map((entry) => entry.message);
 
       if (messages.length === 0) return;
       if (!ctx.model) return;

--- a/packages/pi-memory-extension/shared/types.ts
+++ b/packages/pi-memory-extension/shared/types.ts
@@ -20,6 +20,29 @@ export interface MemoryFileList {
   daily: string[];
 }
 
+// ── QMD search ─────────────────────────────────────────────────
+
+/** A single QMD search result (keyword, semantic, or deep). */
+export interface QmdSearchResult {
+  path?: string;
+  file?: string;
+  score?: number;
+  content?: string;
+  chunk?: string;
+  snippet?: string;
+  [key: string]: unknown;
+}
+
+/** Extract the file path from a QMD result (normalises path/file fields). */
+export function getResultPath(r: QmdSearchResult): string | undefined {
+  return r.path ?? r.file;
+}
+
+/** Extract the text content from a QMD result (normalises content/chunk/snippet fields). */
+export function getResultText(r: QmdSearchResult): string {
+  return r.content ?? r.chunk ?? r.snippet ?? '';
+}
+
 // ── Scratchpad ─────────────────────────────────────────────────
 
 export interface ScratchpadItem {

--- a/packages/pi-memory-extension/shared/types.ts
+++ b/packages/pi-memory-extension/shared/types.ts
@@ -7,7 +7,7 @@ export type WriteMode = 'append' | 'overwrite';
 /** Available memory tool actions. */
 export type MemoryAction = 'read' | 'write' | 'search' | 'list';
 
-/** A single search result. */
+/** A single grep search result. */
 export interface MemorySearchResult {
   file: string;
   line: number;
@@ -18,6 +18,14 @@ export interface MemorySearchResult {
 export interface MemoryFileList {
   root: string[];
   daily: string[];
+}
+
+// ── Scratchpad ─────────────────────────────────────────────────
+
+export interface ScratchpadItem {
+  done: boolean;
+  text: string;
+  meta: string; // <!-- timestamp --> comment line
 }
 
 // ── Questionnaire types (matches Pi SDK `questionnaire` tool) ──


### PR DESCRIPTION
## Summary

Adds QMD-powered semantic search, a persistent scratchpad, and session lifecycle hooks to the memory extension. Builds on top of the basic markdown memory system from #47.

### New files

| File | LOC | Purpose |
|------|-----|---------|
| `extension/qmd.ts` | 321 | QMD detection with PATH resolution for Electron (`~/.bun/bin`, `/usr/local/bin`, etc.), auto-install via `bun install -g @tobilu/qmd`, `sero-memory` collection setup, keyword/semantic/deep search, debounced re-indexing (500ms), selective injection helper (3s timeout) |
| `extension/search-tool.ts` | 164 | `memory_search` tool — keyword (~30ms BM25), semantic (~2s vector), deep (~10s hybrid+rerank) |
| `extension/scratchpad.ts` | 189 | `scratchpad` tool (add/done/undo/clear_done/list), `SCRATCHPAD.md` parse/serialize, open items formatted for system prompt injection |
| `extension/session-lifecycle.ts` | 197 | `session_before_compact`: writes handoff entry to daily log; `session_shutdown`: LLM exit summary appended to daily log (`reasoning_effort: low`) |

### Modified files

| File | Change |
|------|--------|
| `extension/context-injector.ts` | New 8K priority ordering: identity+user (2K) → scratchpad (1.5K) → QMD results (2.5K) → MEMORY.md (2K). `SERO_MEMORY_NO_SEARCH=1` env var support. `#tags` and `[[links]]` guidance in system prompt. |
| `extension/index.ts` | Wires QMD init, search/scratchpad tools, lifecycle hooks, `/scratchpad` slash command |
| `extension/memory-tool.ts` | Triggers `scheduleQmdUpdate()` after writes |
| `extension/memory-manager.ts` | Added `SCRATCHPAD.md` to root files set |
| `shared/types.ts` | Added `ScratchpadItem` type |
| `apps/desktop/electron/cli/index.ts` | Bridged `memory_search` + `scratchpad` into `sero-cli` |

### How it works

1. **Session start** → resolve QMD binary → if missing, try `bun install -g @tobilu/qmd` → ensure `sero-memory` collection
2. **Each turn** → keyword-search user prompt against memory (3s timeout, fail silently) → inject top 3 results alongside identity, scratchpad, and MEMORY.md
3. **Memory writes** → debounced `qmd update` re-indexes in background
4. **Context compaction** → open scratchpad items + recent daily log tail written as handoff entry
5. **Session end** → LLM generates summary → appended to daily log
6. **Graceful degradation** → core memory works without QMD; search returns install instructions

### Spec
Full spec at `docs/qmd-semantic-memory-spec.md`
