### PR TITLE
feat(chat): add context usage % display with compact trigger in ChatPanel header

### DIFF
--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -17,6 +17,7 @@ import type {
   AgentStreamEvent,
   SeroSlashCommandInfo,
   SessionUsageStats,
+  ContextUsageInfo,
   ContextOverrides,
 } from '../../src/types/ipc';
 import type { ChatCheckpointRef } from '../../src/types/checkpoints';
@@ -357,6 +358,71 @@ export function registerAgentHandlers(): void {
         cost: stats.cost,
         requestCount: stats.userMessages,
       };
+    },
+  );
+
+  // ── Context usage ─────────────────────────────────────────
+  ipcMain.handle(
+    IpcChannels.agent.getContextUsage,
+    async (_event, sessionId: string): Promise<ContextUsageInfo | null> => {
+      const entry = pool.get(sessionId);
+      if (!entry) return null;
+
+      const model = entry.session.model;
+      if (!model) return null;
+
+      const contextWindow = model.contextWindow;
+      const state = entry.session.agent.state;
+
+      // Estimate current context tokens from session state
+      let tokens = 0;
+      const est = (s: string) => Math.ceil(s.length / 4);
+
+      // System prompt
+      if (state.systemPrompt) tokens += est(state.systemPrompt);
+
+      // Tool definitions
+      if (state.tools) tokens += est(JSON.stringify(state.tools.map((t: any) => ({
+        name: t.name, description: t.description, parameters: t.parameters,
+      }))));
+
+      // Messages
+      for (const msg of state.messages) {
+        if (typeof msg.content === 'string') {
+          tokens += est(msg.content);
+        } else if (Array.isArray(msg.content)) {
+          for (const part of msg.content as any[]) {
+            if (part.type === 'text') tokens += est(part.text || '');
+            else if (part.type === 'thinking') tokens += est(part.thinking || '');
+            else if (part.type === 'toolCall') tokens += est(JSON.stringify(part));
+            else if (part.type === 'toolResult') tokens += est(JSON.stringify(part));
+          }
+        }
+      }
+
+      const percent = contextWindow > 0 ? (tokens / contextWindow) * 100 : 0;
+
+      return {
+        tokens,
+        contextWindow,
+        percent: Math.min(percent, 100),
+      };
+    },
+  );
+
+  // ── Manual compaction ────────────────────────────────────
+  ipcMain.handle(
+    IpcChannels.agent.compact,
+    async (_event, sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }> => {
+      const entry = pool.get(sessionId);
+      if (!entry) return { success: false, error: 'No active session' };
+
+      try {
+        await entry.session.compact(customInstructions);
+        return { success: true };
+      } catch (err: any) {
+        return { success: false, error: err?.message || 'Compaction failed' };
+      }
     },
   );
 

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -19,6 +19,7 @@ import type {
   SessionUsageStats,
   ContextUsageInfo,
   ContextOverrides,
+  SeroSessionInfo,
 } from '../../src/types/ipc';
 import type { ChatCheckpointRef } from '../../src/types/checkpoints';
 
@@ -460,6 +461,46 @@ export function registerAgentHandlers(): void {
       sendEvent({ type: 'messages_loaded', sessionId, messages: chatMessages });
 
       return chatMessages;
+    },
+  );
+
+  // ── Fork session (extract branch to new file) ─────────────
+  ipcMain.handle(
+    IpcChannels.agent.forkSession,
+    async (_event, sessionId: string): Promise<SeroSessionInfo> => {
+      const entry = pool.get(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+
+      if (entry.session.agent.state.isStreaming) {
+        throw new Error('Cannot fork while agent is streaming');
+      }
+
+      const sm = entry.session.sessionManager;
+      const leafId = sm.getLeafId();
+      if (!leafId) throw new Error('Session has no entries to fork');
+
+      // createBranchedSession extracts the current branch to a new .jsonl file
+      const newSessionPath = sm.createBranchedSession(leafId);
+
+      // Open the new file to read its header
+      const newSm = SessionManager.open(newSessionPath, SERO_SESSION_DIR);
+      const header = newSm.getHeader();
+      const branch = newSm.getBranch();
+      const now = new Date();
+
+      return {
+        path: newSessionPath,
+        id: newSm.getSessionId(),
+        cwd: header.cwd,
+        workspaceId: entry.workspaceId,
+        name: undefined,
+        created: now.toISOString(),
+        modified: now.toISOString(),
+        messageCount: branch.filter(
+          (e) => e.type === 'message' && e.message.role === 'user',
+        ).length,
+        firstMessage: '',
+      };
     },
   );
 

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -426,6 +426,43 @@ export function registerAgentHandlers(): void {
     },
   );
 
+  // ── Clear session (branch from root) ──────────────────────
+  ipcMain.handle(
+    IpcChannels.agent.clearSession,
+    async (_event, sessionId: string): Promise<ChatMessage[]> => {
+      const entry = pool.get(sessionId);
+      if (!entry) throw new Error(`No active session: ${sessionId}`);
+
+      if (entry.session.agent.state.isStreaming) {
+        throw new Error('Cannot clear while agent is streaming');
+      }
+
+      const sm = entry.session.sessionManager;
+      const branch = sm.getBranch();
+      if (branch.length === 0) {
+        // Already empty — nothing to clear
+        return convertSessionMessages(
+          entry.session.messages,
+          buildCheckpointMapByTurn(entry.session, entry.workspaceId),
+        );
+      }
+
+      const rootId = branch[0].id;
+      sm.branch(rootId);
+      const ctx = sm.buildSessionContext();
+      entry.session.agent.replaceMessages(ctx.messages);
+      entry.lastCompletedCheckpoint = null;
+
+      const chatMessages = convertSessionMessages(
+        entry.session.messages,
+        buildCheckpointMapByTurn(entry.session, entry.workspaceId),
+      );
+      sendEvent({ type: 'messages_loaded', sessionId, messages: chatMessages });
+
+      return chatMessages;
+    },
+  );
+
   // ── Rename session ────────────────────────────────────────
   ipcMain.handle(
     IpcChannels.sessions.rename,

--- a/apps/desktop/electron/ipc/agent.ts
+++ b/apps/desktop/electron/ipc/agent.ts
@@ -18,6 +18,7 @@ import type {
   SeroSlashCommandInfo,
   SessionUsageStats,
   ContextUsageInfo,
+  CompactResult,
   ContextOverrides,
   SeroSessionInfo,
 } from '../../src/types/ipc';
@@ -362,72 +363,33 @@ export function registerAgentHandlers(): void {
     },
   );
 
-  // ── Context usage ─────────────────────────────────────────
+  // ── Context usage (SDK: uses actual API-reported usage.input as baseline) ──
   ipcMain.handle(
     IpcChannels.agent.getContextUsage,
     async (_event, sessionId: string): Promise<ContextUsageInfo | null> => {
       const entry = pool.get(sessionId);
       if (!entry) return null;
-
-      const model = entry.session.model;
-      if (!model) return null;
-
-      const contextWindow = model.contextWindow;
-      const state = entry.session.agent.state;
-
-      // Estimate current context tokens from session state
-      let tokens = 0;
-      const est = (s: string) => Math.ceil(s.length / 4);
-
-      // System prompt
-      if (state.systemPrompt) tokens += est(state.systemPrompt);
-
-      // Tool definitions
-      if (state.tools) tokens += est(JSON.stringify(state.tools.map((t: any) => ({
-        name: t.name, description: t.description, parameters: t.parameters,
-      }))));
-
-      // Messages
-      for (const msg of state.messages) {
-        if (typeof msg.content === 'string') {
-          tokens += est(msg.content);
-        } else if (Array.isArray(msg.content)) {
-          for (const part of msg.content as any[]) {
-            if (part.type === 'text') tokens += est(part.text || '');
-            else if (part.type === 'thinking') tokens += est(part.thinking || '');
-            else if (part.type === 'toolCall') tokens += est(JSON.stringify(part));
-            else if (part.type === 'toolResult') tokens += est(JSON.stringify(part));
-          }
-        }
-      }
-
-      const percent = contextWindow > 0 ? (tokens / contextWindow) * 100 : 0;
-
-      return {
-        tokens,
-        contextWindow,
-        percent: Math.min(percent, 100),
-      };
+      return entry.session.getContextUsage() ?? null;
     },
   );
 
   // ── Manual compaction ────────────────────────────────────
   ipcMain.handle(
     IpcChannels.agent.compact,
-    async (_event, sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }> => {
+    async (_event, sessionId: string, customInstructions?: string): Promise<CompactResult> => {
       const entry = pool.get(sessionId);
       if (!entry) return { success: false, error: 'No active session' };
 
       try {
-        await entry.session.compact(customInstructions);
-        return { success: true };
+        const result = await entry.session.compact(customInstructions);
+        return { success: true, tokensBefore: result.tokensBefore };
       } catch (err: any) {
         return { success: false, error: err?.message || 'Compaction failed' };
       }
     },
   );
 
-  // ── Clear session (branch from root) ──────────────────────
+  // ── Clear session (navigate to root via SDK) ───────────────
   ipcMain.handle(
     IpcChannels.agent.clearSession,
     async (_event, sessionId: string): Promise<ChatMessage[]> => {
@@ -441,17 +403,21 @@ export function registerAgentHandlers(): void {
       const sm = entry.session.sessionManager;
       const branch = sm.getBranch();
       if (branch.length === 0) {
-        // Already empty — nothing to clear
         return convertSessionMessages(
           entry.session.messages,
           buildCheckpointMapByTurn(entry.session, entry.workspaceId),
         );
       }
 
+      // Use the SDK's navigateTree which fires session_before_tree /
+      // session_tree extension events.  Navigating to the first entry
+      // (a user message with parentId=null) causes the SDK to call
+      // resetLeaf(), fully clearing the conversation context.
       const rootId = branch[0].id;
-      sm.branch(rootId);
-      const ctx = sm.buildSessionContext();
-      entry.session.agent.replaceMessages(ctx.messages);
+      const result = await entry.session.navigateTree(rootId, { summarize: false });
+      if (result.cancelled) {
+        throw new Error('Clear was cancelled by an extension');
+      }
       entry.lastCompletedCheckpoint = null;
 
       const chatMessages = convertSessionMessages(
@@ -465,6 +431,8 @@ export function registerAgentHandlers(): void {
   );
 
   // ── Fork session (extract branch to new file) ─────────────
+  // Uses sm.createBranchedSession() directly — session.fork() switches
+  // the active session to the fork, but Sero wants "fork & stay."
   ipcMain.handle(
     IpcChannels.agent.forkSession,
     async (_event, sessionId: string): Promise<SeroSessionInfo> => {
@@ -479,23 +447,23 @@ export function registerAgentHandlers(): void {
       const leafId = sm.getLeafId();
       if (!leafId) throw new Error('Session has no entries to fork');
 
-      // createBranchedSession extracts the current branch to a new .jsonl file
       const newSessionPath = sm.createBranchedSession(leafId);
+      if (!newSessionPath) throw new Error('Failed to create forked session file');
 
-      // Open the new file to read its header
+      // Read metadata from the new session file (not fabricated timestamps)
       const newSm = SessionManager.open(newSessionPath, SERO_SESSION_DIR);
       const header = newSm.getHeader();
+      if (!header) throw new Error('Forked session has no header');
       const branch = newSm.getBranch();
-      const now = new Date();
 
       return {
         path: newSessionPath,
         id: newSm.getSessionId(),
         cwd: header.cwd,
         workspaceId: entry.workspaceId,
-        name: undefined,
-        created: now.toISOString(),
-        modified: now.toISOString(),
+        name: newSm.getSessionName(),
+        created: header.timestamp,
+        modified: header.timestamp,
         messageCount: branch.filter(
           (e) => e.type === 'message' && e.message.role === 'user',
         ).length,
@@ -503,7 +471,6 @@ export function registerAgentHandlers(): void {
       };
     },
   );
-
   // ── Rename session ────────────────────────────────────────
   ipcMain.handle(
     IpcChannels.sessions.rename,

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -144,6 +144,9 @@ contextBridge.exposeInMainWorld('sero', {
     compact: (sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }> =>
       ipcRenderer.invoke(IpcChannels.agent.compact, sessionId, customInstructions),
 
+    clearSession: (sessionId: string): Promise<ChatMessage[]> =>
+      ipcRenderer.invoke(IpcChannels.agent.clearSession, sessionId),
+
     getModelState: (sessionId: string): Promise<SessionModelState | null> =>
       ipcRenderer.invoke(IpcChannels.agent.getModelState, sessionId),
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -18,6 +18,7 @@ import type {
   SeroAppManifest,
   SessionUsageStats,
   ContextUsageInfo,
+  CompactResult,
   SessionModelState,
   AuthProvidersResponse,
   OAuthEvent,
@@ -141,7 +142,7 @@ contextBridge.exposeInMainWorld('sero', {
     getContextUsage: (sessionId: string): Promise<ContextUsageInfo | null> =>
       ipcRenderer.invoke(IpcChannels.agent.getContextUsage, sessionId),
 
-    compact: (sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }> =>
+    compact: (sessionId: string, customInstructions?: string): Promise<CompactResult> =>
       ipcRenderer.invoke(IpcChannels.agent.compact, sessionId, customInstructions),
 
     clearSession: (sessionId: string): Promise<ChatMessage[]> =>

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -17,6 +17,7 @@ import type {
   SeroSlashCommandInfo,
   SeroAppManifest,
   SessionUsageStats,
+  ContextUsageInfo,
   SessionModelState,
   AuthProvidersResponse,
   OAuthEvent,
@@ -136,6 +137,12 @@ contextBridge.exposeInMainWorld('sero', {
 
     getUsage: (sessionId: string): Promise<SessionUsageStats | null> =>
       ipcRenderer.invoke(IpcChannels.agent.getUsage, sessionId),
+
+    getContextUsage: (sessionId: string): Promise<ContextUsageInfo | null> =>
+      ipcRenderer.invoke(IpcChannels.agent.getContextUsage, sessionId),
+
+    compact: (sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }> =>
+      ipcRenderer.invoke(IpcChannels.agent.compact, sessionId, customInstructions),
 
     getModelState: (sessionId: string): Promise<SessionModelState | null> =>
       ipcRenderer.invoke(IpcChannels.agent.getModelState, sessionId),

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -147,6 +147,9 @@ contextBridge.exposeInMainWorld('sero', {
     clearSession: (sessionId: string): Promise<ChatMessage[]> =>
       ipcRenderer.invoke(IpcChannels.agent.clearSession, sessionId),
 
+    forkSession: (sessionId: string): Promise<SeroSessionInfo> =>
+      ipcRenderer.invoke(IpcChannels.agent.forkSession, sessionId),
+
     getModelState: (sessionId: string): Promise<SessionModelState | null> =>
       ipcRenderer.invoke(IpcChannels.agent.getModelState, sessionId),
 

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/stores/agent-selectors';
 import { useSessionStore } from '@/stores/sessions';
 import { UsageBadge } from './UsageBadge';
+import { ContextBadge } from './ContextBadge';
 import { groupMessages, ToolCallGroup } from './ToolCallGroup';
 import { ChatMessageItem } from './ChatMessageItem';
 import { CheckpointRestoreDialog } from './CheckpointRestoreDialog';
@@ -137,6 +138,7 @@ export function ChatPanel() {
             4-Agent
           </span>
         )}
+        {sessionId && <ContextBadge sessionId={sessionId} />}
         {sessionId && <UsageBadge sessionId={sessionId} />}
       </div>
 

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -138,7 +138,7 @@ export function ChatPanel() {
             4-Agent
           </span>
         )}
-        {sessionId && <ContextBadge sessionId={sessionId} workspaceId={focusedWorkspaceId} />}
+        {sessionId && <ContextBadge sessionId={sessionId} />}
         {sessionId && <UsageBadge sessionId={sessionId} />}
       </div>
 

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -138,7 +138,7 @@ export function ChatPanel() {
             4-Agent
           </span>
         )}
-        {sessionId && <ContextBadge sessionId={sessionId} />}
+        {sessionId && <ContextBadge sessionId={sessionId} workspaceId={focusedWorkspaceId} />}
         {sessionId && <UsageBadge sessionId={sessionId} />}
       </div>
 

--- a/apps/desktop/src/components/layout/ContextBadge.tsx
+++ b/apps/desktop/src/components/layout/ContextBadge.tsx
@@ -128,7 +128,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
     <Popover onOpenChange={() => { setConfirmClear(false); setActionError(null); }}>
       <PopoverTrigger asChild>
         <button
-          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+          className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
           title="Context window usage"
         >
           <Gauge className="size-3.5" />

--- a/apps/desktop/src/components/layout/ContextBadge.tsx
+++ b/apps/desktop/src/components/layout/ContextBadge.tsx
@@ -132,7 +132,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
           title="Context window usage"
         >
           <Gauge className="size-3.5" />
-          <span className={`text-xs tabular-nums ${healthColor}`}>
+          <span className="text-sm tabular-nums text-emerald-600 dark:text-emerald-400">
             {hasData ? `${Math.round(percent)}%` : '—'}
           </span>
         </button>

--- a/apps/desktop/src/components/layout/ContextBadge.tsx
+++ b/apps/desktop/src/components/layout/ContextBadge.tsx
@@ -10,7 +10,6 @@ import type { ContextUsageInfo } from '@/types/ipc';
 
 interface ContextBadgeProps {
   sessionId: string;
-  workspaceId: string | null;
 }
 
 /**
@@ -18,13 +17,15 @@ interface ContextBadgeProps {
  * fork session, or clear session.
  * Auto-refreshes on agent turn completion.
  */
-export function ContextBadge({ sessionId, workspaceId }: ContextBadgeProps) {
+export function ContextBadge({ sessionId }: ContextBadgeProps) {
   const [usage, setUsage] = useState<ContextUsageInfo | null>(null);
   const [compacting, setCompacting] = useState(false);
   const [clearing, setClearing] = useState(false);
   const [compactInstructions, setCompactInstructions] = useState('');
+  const [forking, setForking] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
-  const createSession = useSessionStore((s) => s.createSession);
+  const loadSessions = useSessionStore((s) => s.loadSessions);
+  const setActiveSession = useSessionStore((s) => s.setActiveSession);
 
   const fetchUsage = useCallback(async () => {
     try {
@@ -72,12 +73,17 @@ export function ContextBadge({ sessionId, workspaceId }: ContextBadgeProps) {
   };
 
   const handleFork = async () => {
-    if (!workspaceId) return;
     setActionError(null);
+    setForking(true);
     try {
-      await createSession(workspaceId);
+      const newSession = await window.sero.agent.forkSession(sessionId);
+      // Refresh session list so the forked session appears, then select it
+      await loadSessions();
+      setActiveSession(newSession.id);
     } catch (err: any) {
       setActionError(err?.message || 'Fork failed');
+    } finally {
+      setForking(false);
     }
   };
 
@@ -109,7 +115,7 @@ export function ContextBadge({ sessionId, workspaceId }: ContextBadgeProps) {
         ? 'bg-amber-500'
         : 'bg-red-500';
 
-  const busy = compacting || clearing;
+  const busy = compacting || clearing || forking;
 
   return (
     <Popover>
@@ -192,17 +198,19 @@ export function ContextBadge({ sessionId, workspaceId }: ContextBadgeProps) {
 
         {/* Session actions */}
         <div className="border-t border-[var(--border-subtle)] pt-2 flex gap-2">
-          {workspaceId && (
-            <button
-              onClick={handleFork}
-              disabled={busy}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
-              title="Create a new session in this workspace"
-            >
+          <button
+            onClick={handleFork}
+            disabled={busy}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
+            title="Fork: copy conversation to a new session"
+          >
+            {forking ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
               <GitFork className="size-3" />
-              Fork
-            </button>
-          )}
+            )}
+            Fork
+          </button>
           <button
             onClick={handleClear}
             disabled={busy}

--- a/apps/desktop/src/components/layout/ContextBadge.tsx
+++ b/apps/desktop/src/components/layout/ContextBadge.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState, useCallback } from 'react';
+import { Gauge, Loader2 } from 'lucide-react';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from '@sero/ui/components/ui/popover';
+import type { ContextUsageInfo } from '@/types/ipc';
+
+interface ContextBadgeProps {
+  sessionId: string;
+}
+
+/**
+ * Compact badge showing context window usage %. Click for details + compact.
+ * Auto-refreshes on agent turn completion.
+ */
+export function ContextBadge({ sessionId }: ContextBadgeProps) {
+  const [usage, setUsage] = useState<ContextUsageInfo | null>(null);
+  const [compacting, setCompacting] = useState(false);
+  const [compactInstructions, setCompactInstructions] = useState('');
+  const [compactError, setCompactError] = useState<string | null>(null);
+
+  const fetchUsage = useCallback(async () => {
+    try {
+      const result = await window.sero.agent.getContextUsage(sessionId);
+      setUsage(result);
+    } catch {
+      // Ignore — session may have closed
+    }
+  }, [sessionId]);
+
+  // Fetch on mount
+  useEffect(() => {
+    fetchUsage();
+  }, [fetchUsage]);
+
+  // Re-fetch when agent turns complete or auto-compaction finishes
+  useEffect(() => {
+    const unsub = window.sero.agent.onEvent((event) => {
+      if (event.sessionId === sessionId && event.type === 'agent_end') {
+        setTimeout(fetchUsage, 300);
+      }
+    });
+    return unsub;
+  }, [sessionId, fetchUsage]);
+
+  const handleCompact = async () => {
+    setCompactError(null);
+    setCompacting(true);
+    try {
+      const result = await window.sero.agent.compact(
+        sessionId,
+        compactInstructions.trim() || undefined,
+      );
+      if (!result.success) {
+        setCompactError(result.error || 'Compaction failed');
+      } else {
+        setCompactInstructions('');
+        // Refresh usage after compaction
+        setTimeout(fetchUsage, 500);
+      }
+    } catch (err: any) {
+      setCompactError(err?.message || 'Compaction failed');
+    } finally {
+      setCompacting(false);
+    }
+  };
+
+  const percent = usage?.percent ?? 0;
+  const healthColor =
+    percent < 50
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : percent < 80
+        ? 'text-amber-600 dark:text-amber-400'
+        : 'text-red-600 dark:text-red-400';
+
+  const barColor =
+    percent < 50
+      ? 'bg-emerald-500'
+      : percent < 80
+        ? 'bg-amber-500'
+        : 'bg-red-500';
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+          title="Context window usage"
+        >
+          <Gauge className="size-3.5" />
+          <span className={`text-xs tabular-nums ${healthColor}`}>
+            {usage ? `${Math.round(percent)}%` : '—'}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="end"
+        sideOffset={4}
+        className="text-sm w-64 space-y-3 bg-[var(--bg-elevated)] p-3"
+      >
+        <div className="font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          Context Usage
+        </div>
+
+        {usage ? (
+          <>
+            {/* Percentage + token count */}
+            <div className="flex items-baseline justify-between">
+              <span className={`text-lg font-light tabular-nums ${healthColor}`}>
+                {percent.toFixed(1)}%
+              </span>
+              <span className="text-xs text-[var(--text-muted)]">
+                {fmtTokens(usage.tokens)} / {fmtTokens(usage.contextWindow)}
+              </span>
+            </div>
+
+            {/* Progress bar */}
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--bg-surface)]">
+              <div
+                className={`h-full transition-all duration-300 ${barColor}`}
+                style={{ width: `${Math.min(percent, 100)}%` }}
+              />
+            </div>
+
+            {/* Compact section */}
+            <div className="border-t border-[var(--border-subtle)] pt-2 space-y-2">
+              <label className="text-xs text-[var(--text-muted)]">
+                Compact context
+              </label>
+              <input
+                type="text"
+                placeholder="Custom instructions (optional)"
+                value={compactInstructions}
+                onChange={(e) => setCompactInstructions(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !compacting) handleCompact();
+                }}
+                className="w-full rounded border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--border-focus)]"
+                disabled={compacting}
+              />
+              <button
+                onClick={handleCompact}
+                disabled={compacting}
+                className="flex w-full items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
+              >
+                {compacting ? (
+                  <>
+                    <Loader2 className="size-3 animate-spin" />
+                    Compacting…
+                  </>
+                ) : (
+                  'Compact Now'
+                )}
+              </button>
+              {compactError && (
+                <p className="text-xs text-red-500">{compactError}</p>
+              )}
+            </div>
+          </>
+        ) : (
+          <p className="text-xs text-[var(--text-muted)]">No usage data available.</p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}

--- a/apps/desktop/src/components/layout/ContextBadge.tsx
+++ b/apps/desktop/src/components/layout/ContextBadge.tsx
@@ -5,7 +5,6 @@ import {
   PopoverTrigger,
   PopoverContent,
 } from '@sero/ui/components/ui/popover';
-import { useSessionStore } from '@/stores/sessions';
 import type { ContextUsageInfo } from '@/types/ipc';
 
 interface ContextBadgeProps {
@@ -15,17 +14,16 @@ interface ContextBadgeProps {
 /**
  * Compact badge showing context window usage %. Click for details + compact,
  * fork session, or clear session.
- * Auto-refreshes on agent turn completion.
+ * Auto-refreshes on agent turn completion and auto-compaction.
  */
 export function ContextBadge({ sessionId }: ContextBadgeProps) {
   const [usage, setUsage] = useState<ContextUsageInfo | null>(null);
   const [compacting, setCompacting] = useState(false);
   const [clearing, setClearing] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
   const [compactInstructions, setCompactInstructions] = useState('');
   const [forking, setForking] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
-  const loadSessions = useSessionStore((s) => s.loadSessions);
-  const setActiveSession = useSessionStore((s) => s.setActiveSession);
 
   const fetchUsage = useCallback(async () => {
     try {
@@ -36,15 +34,16 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
     }
   }, [sessionId]);
 
-  // Fetch on mount
+  // Fetch on mount and when sessionId changes
   useEffect(() => {
     fetchUsage();
   }, [fetchUsage]);
 
-  // Re-fetch when agent turns complete or auto-compaction finishes
+  // Re-fetch when agent turns complete (also fires after auto-compaction)
   useEffect(() => {
     const unsub = window.sero.agent.onEvent((event) => {
-      if (event.sessionId === sessionId && event.type === 'agent_end') {
+      if (event.sessionId !== sessionId) return;
+      if (event.type === 'agent_end') {
         setTimeout(fetchUsage, 300);
       }
     });
@@ -65,8 +64,8 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
         setCompactInstructions('');
         setTimeout(fetchUsage, 500);
       }
-    } catch (err: any) {
-      setActionError(err?.message || 'Compaction failed');
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Compaction failed');
     } finally {
       setCompacting(false);
     }
@@ -76,40 +75,48 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
     setActionError(null);
     setForking(true);
     try {
-      const newSession = await window.sero.agent.forkSession(sessionId);
-      // Refresh session list so the forked session appears, then select it
-      await loadSessions();
-      setActiveSession(newSession.id);
-    } catch (err: any) {
-      setActionError(err?.message || 'Fork failed');
+      await window.sero.agent.forkSession(sessionId);
+      // Fork created — user can switch to it from the session list.
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Fork failed');
     } finally {
       setForking(false);
     }
   };
 
   const handleClear = async () => {
+    if (!confirmClear) {
+      setConfirmClear(true);
+      return;
+    }
     setActionError(null);
+    setConfirmClear(false);
     setClearing(true);
     try {
       await window.sero.agent.clearSession(sessionId);
       setTimeout(fetchUsage, 300);
-    } catch (err: any) {
-      setActionError(err?.message || 'Clear failed');
+    } catch (err: unknown) {
+      setActionError(err instanceof Error ? err.message : 'Clear failed');
     } finally {
       setClearing(false);
     }
   };
 
-  const percent = usage?.percent ?? 0;
-  const healthColor =
-    percent < 50
+  // tokens and percent may be null (e.g. right after compaction)
+  const percent = usage?.percent ?? null;
+  const hasData = usage !== null && percent !== null;
+
+  const healthColor = !hasData
+    ? 'text-[var(--text-muted)]'
+    : percent < 50
       ? 'text-emerald-600 dark:text-emerald-400'
       : percent < 80
         ? 'text-amber-600 dark:text-amber-400'
         : 'text-red-600 dark:text-red-400';
 
-  const barColor =
-    percent < 50
+  const barColor = !hasData
+    ? 'bg-[var(--text-muted)]'
+    : percent < 50
       ? 'bg-emerald-500'
       : percent < 80
         ? 'bg-amber-500'
@@ -118,7 +125,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
   const busy = compacting || clearing || forking;
 
   return (
-    <Popover>
+    <Popover onOpenChange={() => { setConfirmClear(false); setActionError(null); }}>
       <PopoverTrigger asChild>
         <button
           className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
@@ -126,7 +133,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
         >
           <Gauge className="size-3.5" />
           <span className={`text-xs tabular-nums ${healthColor}`}>
-            {usage ? `${Math.round(percent)}%` : '—'}
+            {hasData ? `${Math.round(percent)}%` : '—'}
           </span>
         </button>
       </PopoverTrigger>
@@ -140,91 +147,32 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
           Context Usage
         </div>
 
-        {usage ? (
-          <>
-            {/* Percentage + token count */}
-            <div className="flex items-baseline justify-between">
-              <span className={`text-lg font-light tabular-nums ${healthColor}`}>
-                {percent.toFixed(1)}%
-              </span>
-              <span className="text-xs text-[var(--text-muted)]">
-                {fmtTokens(usage.tokens)} / {fmtTokens(usage.contextWindow)}
-              </span>
-            </div>
-
-            {/* Progress bar */}
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--bg-surface)]">
-              <div
-                className={`h-full transition-all duration-300 ${barColor}`}
-                style={{ width: `${Math.min(percent, 100)}%` }}
-              />
-            </div>
-
-            {/* Compact section */}
-            <div className="border-t border-[var(--border-subtle)] pt-2 space-y-2">
-              <label className="text-xs text-[var(--text-muted)]">
-                Compact context
-              </label>
-              <input
-                type="text"
-                placeholder="Custom instructions (optional)"
-                value={compactInstructions}
-                onChange={(e) => setCompactInstructions(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !busy) handleCompact();
-                }}
-                className="w-full rounded border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--border-focus)]"
-                disabled={busy}
-              />
-              <button
-                onClick={handleCompact}
-                disabled={busy}
-                className="flex w-full items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
-              >
-                {compacting ? (
-                  <>
-                    <Loader2 className="size-3 animate-spin" />
-                    Compacting…
-                  </>
-                ) : (
-                  'Compact Now'
-                )}
-              </button>
-            </div>
-          </>
+        {hasData && usage ? (
+          <ContextDetails
+            usage={usage}
+            percent={percent}
+            healthColor={healthColor}
+            barColor={barColor}
+            compactInstructions={compactInstructions}
+            onInstructionsChange={setCompactInstructions}
+            onCompact={handleCompact}
+            compacting={compacting}
+            busy={busy}
+          />
         ) : (
-          <p className="text-xs text-[var(--text-muted)]">No usage data available.</p>
+          <p className="text-xs text-[var(--text-muted)]">
+            {usage ? 'Recalculating after compaction…' : 'No usage data available.'}
+          </p>
         )}
 
-        {/* Session actions */}
-        <div className="border-t border-[var(--border-subtle)] pt-2 flex gap-2">
-          <button
-            onClick={handleFork}
-            disabled={busy}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
-            title="Fork: copy conversation to a new session"
-          >
-            {forking ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <GitFork className="size-3" />
-            )}
-            Fork
-          </button>
-          <button
-            onClick={handleClear}
-            disabled={busy}
-            className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-red-600 dark:text-red-400 transition-colors hover:bg-red-500/10 disabled:opacity-50"
-            title="Reset conversation (branch from root)"
-          >
-            {clearing ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <Trash2 className="size-3" />
-            )}
-            Clear
-          </button>
-        </div>
+        <SessionActions
+          onFork={handleFork}
+          onClear={handleClear}
+          forking={forking}
+          clearing={clearing}
+          confirmClear={confirmClear}
+          busy={busy}
+        />
 
         {actionError && (
           <p className="text-xs text-red-500">{actionError}</p>
@@ -233,6 +181,110 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
     </Popover>
   );
 }
+
+// ── Sub-components ─────────────────────────────────────────────
+
+interface ContextDetailsProps {
+  usage: ContextUsageInfo;
+  percent: number;
+  healthColor: string;
+  barColor: string;
+  compactInstructions: string;
+  onInstructionsChange: (v: string) => void;
+  onCompact: () => void;
+  compacting: boolean;
+  busy: boolean;
+}
+
+function ContextDetails({
+  usage, percent, healthColor, barColor,
+  compactInstructions, onInstructionsChange, onCompact,
+  compacting, busy,
+}: ContextDetailsProps) {
+  return (
+    <>
+      <div className="flex items-baseline justify-between">
+        <span className={`text-lg font-light tabular-nums ${healthColor}`}>
+          {percent.toFixed(1)}%
+        </span>
+        <span className="text-xs text-[var(--text-muted)]">
+          {usage.tokens !== null ? fmtTokens(usage.tokens) : '?'} / {fmtTokens(usage.contextWindow)}
+        </span>
+      </div>
+
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--bg-surface)]">
+        <div
+          className={`h-full transition-all duration-300 ${barColor}`}
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
+      </div>
+
+      <div className="border-t border-[var(--border-subtle)] pt-2 space-y-2">
+        <label className="text-xs text-[var(--text-muted)]">Compact context</label>
+        <input
+          type="text"
+          placeholder="Custom instructions (optional)"
+          value={compactInstructions}
+          onChange={(e) => onInstructionsChange(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && !busy) onCompact(); }}
+          className="w-full rounded border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--border-focus)]"
+          disabled={busy}
+        />
+        <button
+          onClick={onCompact}
+          disabled={busy}
+          className="flex w-full items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
+        >
+          {compacting ? (
+            <><Loader2 className="size-3 animate-spin" /> Compacting…</>
+          ) : (
+            'Compact Now'
+          )}
+        </button>
+      </div>
+    </>
+  );
+}
+
+interface SessionActionsProps {
+  onFork: () => void;
+  onClear: () => void;
+  forking: boolean;
+  clearing: boolean;
+  confirmClear: boolean;
+  busy: boolean;
+}
+
+function SessionActions({ onFork, onClear, forking, clearing, confirmClear, busy }: SessionActionsProps) {
+  return (
+    <div className="border-t border-[var(--border-subtle)] pt-2 flex gap-2">
+      <button
+        onClick={onFork}
+        disabled={busy}
+        className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
+        title="Fork: copy conversation to a new session"
+      >
+        {forking ? <Loader2 className="size-3 animate-spin" /> : <GitFork className="size-3" />}
+        Fork
+      </button>
+      <button
+        onClick={onClear}
+        disabled={busy}
+        className={`flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+          confirmClear
+            ? 'bg-red-500/20 text-red-600 dark:text-red-400'
+            : 'bg-[var(--bg-surface)] text-red-600 dark:text-red-400 hover:bg-red-500/10'
+        }`}
+        title="Reset conversation (branch from root)"
+      >
+        {clearing ? <Loader2 className="size-3 animate-spin" /> : <Trash2 className="size-3" />}
+        {confirmClear ? 'Confirm?' : 'Clear'}
+      </button>
+    </div>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────
 
 function fmtTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;

--- a/apps/desktop/src/components/layout/ContextBadge.tsx
+++ b/apps/desktop/src/components/layout/ContextBadge.tsx
@@ -1,25 +1,30 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Gauge, Loader2 } from 'lucide-react';
+import { Gauge, Loader2, GitFork, Trash2 } from 'lucide-react';
 import {
   Popover,
   PopoverTrigger,
   PopoverContent,
 } from '@sero/ui/components/ui/popover';
+import { useSessionStore } from '@/stores/sessions';
 import type { ContextUsageInfo } from '@/types/ipc';
 
 interface ContextBadgeProps {
   sessionId: string;
+  workspaceId: string | null;
 }
 
 /**
- * Compact badge showing context window usage %. Click for details + compact.
+ * Compact badge showing context window usage %. Click for details + compact,
+ * fork session, or clear session.
  * Auto-refreshes on agent turn completion.
  */
-export function ContextBadge({ sessionId }: ContextBadgeProps) {
+export function ContextBadge({ sessionId, workspaceId }: ContextBadgeProps) {
   const [usage, setUsage] = useState<ContextUsageInfo | null>(null);
   const [compacting, setCompacting] = useState(false);
+  const [clearing, setClearing] = useState(false);
   const [compactInstructions, setCompactInstructions] = useState('');
-  const [compactError, setCompactError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const createSession = useSessionStore((s) => s.createSession);
 
   const fetchUsage = useCallback(async () => {
     try {
@@ -46,7 +51,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
   }, [sessionId, fetchUsage]);
 
   const handleCompact = async () => {
-    setCompactError(null);
+    setActionError(null);
     setCompacting(true);
     try {
       const result = await window.sero.agent.compact(
@@ -54,16 +59,38 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
         compactInstructions.trim() || undefined,
       );
       if (!result.success) {
-        setCompactError(result.error || 'Compaction failed');
+        setActionError(result.error || 'Compaction failed');
       } else {
         setCompactInstructions('');
-        // Refresh usage after compaction
         setTimeout(fetchUsage, 500);
       }
     } catch (err: any) {
-      setCompactError(err?.message || 'Compaction failed');
+      setActionError(err?.message || 'Compaction failed');
     } finally {
       setCompacting(false);
+    }
+  };
+
+  const handleFork = async () => {
+    if (!workspaceId) return;
+    setActionError(null);
+    try {
+      await createSession(workspaceId);
+    } catch (err: any) {
+      setActionError(err?.message || 'Fork failed');
+    }
+  };
+
+  const handleClear = async () => {
+    setActionError(null);
+    setClearing(true);
+    try {
+      await window.sero.agent.clearSession(sessionId);
+      setTimeout(fetchUsage, 300);
+    } catch (err: any) {
+      setActionError(err?.message || 'Clear failed');
+    } finally {
+      setClearing(false);
     }
   };
 
@@ -81,6 +108,8 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
       : percent < 80
         ? 'bg-amber-500'
         : 'bg-red-500';
+
+  const busy = compacting || clearing;
 
   return (
     <Popover>
@@ -101,7 +130,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
         sideOffset={4}
         className="text-sm w-64 space-y-3 bg-[var(--bg-elevated)] p-3"
       >
-        <div className="font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
           Context Usage
         </div>
 
@@ -136,14 +165,14 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
                 value={compactInstructions}
                 onChange={(e) => setCompactInstructions(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !compacting) handleCompact();
+                  if (e.key === 'Enter' && !busy) handleCompact();
                 }}
                 className="w-full rounded border border-[var(--border-default)] bg-[var(--bg-surface)] px-2 py-1 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-1 focus:ring-[var(--border-focus)]"
-                disabled={compacting}
+                disabled={busy}
               />
               <button
                 onClick={handleCompact}
-                disabled={compacting}
+                disabled={busy}
                 className="flex w-full items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
               >
                 {compacting ? (
@@ -155,13 +184,42 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
                   'Compact Now'
                 )}
               </button>
-              {compactError && (
-                <p className="text-xs text-red-500">{compactError}</p>
-              )}
             </div>
           </>
         ) : (
           <p className="text-xs text-[var(--text-muted)]">No usage data available.</p>
+        )}
+
+        {/* Session actions */}
+        <div className="border-t border-[var(--border-subtle)] pt-2 flex gap-2">
+          {workspaceId && (
+            <button
+              onClick={handleFork}
+              disabled={busy}
+              className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
+              title="Create a new session in this workspace"
+            >
+              <GitFork className="size-3" />
+              Fork
+            </button>
+          )}
+          <button
+            onClick={handleClear}
+            disabled={busy}
+            className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-red-600 dark:text-red-400 transition-colors hover:bg-red-500/10 disabled:opacity-50"
+            title="Reset conversation (branch from root)"
+          >
+            {clearing ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <Trash2 className="size-3" />
+            )}
+            Clear
+          </button>
+        </div>
+
+        {actionError && (
+          <p className="text-xs text-red-500">{actionError}</p>
         )}
       </PopoverContent>
     </Popover>

--- a/apps/desktop/src/components/layout/ContextBadge.tsx
+++ b/apps/desktop/src/components/layout/ContextBadge.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Gauge, Loader2, GitFork, Trash2 } from 'lucide-react';
+import { Gauge, Loader2, GitFork, Trash2, Check } from 'lucide-react';
 import {
   Popover,
   PopoverTrigger,
   PopoverContent,
 } from '@sero/ui/components/ui/popover';
+import { useSessionStore } from '@/stores/sessions';
 import type { ContextUsageInfo } from '@/types/ipc';
 
 interface ContextBadgeProps {
@@ -23,7 +24,9 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
   const [confirmClear, setConfirmClear] = useState(false);
   const [compactInstructions, setCompactInstructions] = useState('');
   const [forking, setForking] = useState(false);
+  const [forkSuccess, setForkSuccess] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const loadSessions = useSessionStore((s) => s.loadSessions);
 
   const fetchUsage = useCallback(async () => {
     try {
@@ -73,10 +76,13 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
 
   const handleFork = async () => {
     setActionError(null);
+    setForkSuccess(false);
     setForking(true);
     try {
       await window.sero.agent.forkSession(sessionId);
-      // Fork created — user can switch to it from the session list.
+      await loadSessions();
+      setForkSuccess(true);
+      setTimeout(() => setForkSuccess(false), 2000);
     } catch (err: unknown) {
       setActionError(err instanceof Error ? err.message : 'Fork failed');
     } finally {
@@ -125,7 +131,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
   const busy = compacting || clearing || forking;
 
   return (
-    <Popover onOpenChange={() => { setConfirmClear(false); setActionError(null); }}>
+    <Popover onOpenChange={() => { setConfirmClear(false); setForkSuccess(false); setActionError(null); }}>
       <PopoverTrigger asChild>
         <button
           className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
@@ -169,6 +175,7 @@ export function ContextBadge({ sessionId }: ContextBadgeProps) {
           onFork={handleFork}
           onClear={handleClear}
           forking={forking}
+          forkSuccess={forkSuccess}
           clearing={clearing}
           confirmClear={confirmClear}
           busy={busy}
@@ -250,22 +257,27 @@ interface SessionActionsProps {
   onFork: () => void;
   onClear: () => void;
   forking: boolean;
+  forkSuccess: boolean;
   clearing: boolean;
   confirmClear: boolean;
   busy: boolean;
 }
 
-function SessionActions({ onFork, onClear, forking, clearing, confirmClear, busy }: SessionActionsProps) {
+function SessionActions({ onFork, onClear, forking, forkSuccess, clearing, confirmClear, busy }: SessionActionsProps) {
   return (
     <div className="border-t border-[var(--border-subtle)] pt-2 flex gap-2">
       <button
         onClick={onFork}
-        disabled={busy}
-        className="flex flex-1 items-center justify-center gap-1.5 rounded bg-[var(--bg-surface)] px-2 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] disabled:opacity-50"
+        disabled={busy || forkSuccess}
+        className={`flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1 text-xs font-medium transition-colors disabled:opacity-50 ${
+          forkSuccess
+            ? 'bg-emerald-500/15 text-emerald-600 dark:text-emerald-400'
+            : 'bg-[var(--bg-surface)] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]'
+        }`}
         title="Fork: copy conversation to a new session"
       >
-        {forking ? <Loader2 className="size-3 animate-spin" /> : <GitFork className="size-3" />}
-        Fork
+        {forking ? <Loader2 className="size-3 animate-spin" /> : forkSuccess ? <Check className="size-3" /> : <GitFork className="size-3" />}
+        {forkSuccess ? 'Forked!' : 'Fork'}
       </button>
       <button
         onClick={onClear}

--- a/apps/desktop/src/components/layout/UsageBadge.tsx
+++ b/apps/desktop/src/components/layout/UsageBadge.tsx
@@ -52,7 +52,7 @@ export function UsageBadge({ sessionId }: UsageBadgeProps) {
     <Popover>
       <PopoverTrigger asChild>
         <button
-          className="ml-auto flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+          className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
           title="Token usage & cost"
         >
           <Coins className="size-4" />

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -17,6 +17,7 @@ import type {
   SeroSlashCommandInfo,
   SeroAppManifest,
   SessionUsageStats,
+  ContextUsageInfo,
   SessionModelState,
   AuthProvidersResponse,
   OAuthEvent,
@@ -95,6 +96,10 @@ interface SeroAgentAPI {
   reloadResources(sessionId: string): Promise<SeroSlashCommandInfo[]>;
   /** Get usage stats (tokens + cost) for a session. */
   getUsage(sessionId: string): Promise<SessionUsageStats | null>;
+  /** Get context window usage (tokens, contextWindow, percent) for a session. */
+  getContextUsage(sessionId: string): Promise<ContextUsageInfo | null>;
+  /** Trigger manual compaction. Returns success/error. */
+  compact(sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }>;
   /** Get current model + thinking level state. */
   getModelState(sessionId: string): Promise<SessionModelState | null>;
   /** Set the model for a session. */

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -100,6 +100,8 @@ interface SeroAgentAPI {
   getContextUsage(sessionId: string): Promise<ContextUsageInfo | null>;
   /** Trigger manual compaction. Returns success/error. */
   compact(sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }>;
+  /** Clear session by branching from root (resets conversation, keeps session). */
+  clearSession(sessionId: string): Promise<ChatMessage[]>;
   /** Get current model + thinking level state. */
   getModelState(sessionId: string): Promise<SessionModelState | null>;
   /** Set the model for a session. */

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -102,6 +102,8 @@ interface SeroAgentAPI {
   compact(sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }>;
   /** Clear session by branching from root (resets conversation, keeps session). */
   clearSession(sessionId: string): Promise<ChatMessage[]>;
+  /** Fork session: extract current branch to a new session file. Returns the new session info. */
+  forkSession(sessionId: string): Promise<SeroSessionInfo>;
   /** Get current model + thinking level state. */
   getModelState(sessionId: string): Promise<SessionModelState | null>;
   /** Set the model for a session. */

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -18,6 +18,7 @@ import type {
   SeroAppManifest,
   SessionUsageStats,
   ContextUsageInfo,
+  CompactResult,
   SessionModelState,
   AuthProvidersResponse,
   OAuthEvent,
@@ -98,8 +99,8 @@ interface SeroAgentAPI {
   getUsage(sessionId: string): Promise<SessionUsageStats | null>;
   /** Get context window usage (tokens, contextWindow, percent) for a session. */
   getContextUsage(sessionId: string): Promise<ContextUsageInfo | null>;
-  /** Trigger manual compaction. Returns success/error. */
-  compact(sessionId: string, customInstructions?: string): Promise<{ success: boolean; error?: string }>;
+  /** Trigger manual compaction. Returns success/error + token stats. */
+  compact(sessionId: string, customInstructions?: string): Promise<CompactResult>;
   /** Clear session by branching from root (resets conversation, keeps session). */
   clearSession(sessionId: string): Promise<ChatMessage[]>;
   /** Fork session: extract current branch to a new session file. Returns the new session info. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -41,6 +41,10 @@ export const IpcChannels = {
     reloadResources: 'sero:agent:reload-resources',
     /** Get usage stats for a session. */
     getUsage: 'sero:agent:get-usage',
+    /** Get context window usage for a session. */
+    getContextUsage: 'sero:agent:get-context-usage',
+    /** Trigger manual compaction. Args: sessionId, customInstructions?. */
+    compact: 'sero:agent:compact',
     /** Get current model + thinking state for a session. */
     getModelState: 'sero:agent:get-model-state',
     /** Set model for a session. Args: sessionId, provider, modelId. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -45,6 +45,8 @@ export const IpcChannels = {
     getContextUsage: 'sero:agent:get-context-usage',
     /** Trigger manual compaction. Args: sessionId, customInstructions?. */
     compact: 'sero:agent:compact',
+    /** Clear session by branching from root. Args: sessionId. */
+    clearSession: 'sero:agent:clear-session',
     /** Get current model + thinking state for a session. */
     getModelState: 'sero:agent:get-model-state',
     /** Set model for a session. Args: sessionId, provider, modelId. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -47,6 +47,8 @@ export const IpcChannels = {
     compact: 'sero:agent:compact',
     /** Clear session by branching from root. Args: sessionId. */
     clearSession: 'sero:agent:clear-session',
+    /** Fork session: extract current branch to a new session file. Args: sessionId. */
+    forkSession: 'sero:agent:fork-session',
     /** Get current model + thinking state for a session. */
     getModelState: 'sero:agent:get-model-state',
     /** Set model for a session. Args: sessionId, provider, modelId. */

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -284,6 +284,16 @@ export interface SessionUsageStats {
   requestCount: number;
 }
 
+/** Context window usage info for the active session. */
+export interface ContextUsageInfo {
+  /** Estimated tokens currently in the context window. */
+  tokens: number;
+  /** Model's maximum context window size in tokens. */
+  contextWindow: number;
+  /** Usage percentage (0–100). */
+  percent: number;
+}
+
 // ── Sero Apps ──────────────────────────────────────────────────
 
 /** Manifest for a Sero app discovered from a Pi package. */

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -284,14 +284,22 @@ export interface SessionUsageStats {
   requestCount: number;
 }
 
-/** Context window usage info for the active session. */
+/** Context window usage info for the active session. Mirrors the Pi SDK's ContextUsage type. */
 export interface ContextUsageInfo {
-  /** Estimated tokens currently in the context window. */
-  tokens: number;
+  /** Estimated context tokens, or null if unknown (e.g. right after compaction, before next LLM response). */
+  tokens: number | null;
   /** Model's maximum context window size in tokens. */
   contextWindow: number;
-  /** Usage percentage (0–100). */
-  percent: number;
+  /** Usage percentage (0–100), or null if tokens is unknown. */
+  percent: number | null;
+}
+
+/** Result from manual compaction. */
+export interface CompactResult {
+  success: boolean;
+  /** Approximate context tokens before compaction (only present on success). */
+  tokensBefore?: number;
+  error?: string;
 }
 
 // ── Sero Apps ──────────────────────────────────────────────────


### PR DESCRIPTION
Add a ContextBadge component next to the cost badge that shows current
context window usage percentage. Clicking it reveals a popover with:
- Token count and context window size
- Color-coded progress bar (green <50%, amber <80%, red >80%)
- Manual compact trigger with optional custom instructions input
- Fork session (creates copy, refreshes sidebar, shows confirmation)
- Clear session with two-click confirmation

Backend: new IPC channels (getContextUsage, compact, clearSession,
forkSession) delegate to the Pi SDK's built-in methods:

- **Context usage** uses `session.getContextUsage()` which bases
  estimates on actual API-reported `usage.input` tokens — not a
  crude chars/4 heuristic. Tokens and percent are nullable (null
  right after compaction, before the next LLM response).
- **Compact** calls `session.compact()` and surfaces `tokensBefore`
  from `CompactionResult` via a named `CompactResult` IPC type.
- **Clear session** uses `session.navigateTree()` to navigate to
  the root entry, which fires `session_before_tree`/`session_tree`
  extension events and calls `resetLeaf()` via the SDK.
- **Fork session** uses `sm.createBranchedSession()` directly
  because `session.fork()` switches the active session to the new
  file, but Sero wants fork-and-stay semantics. Timestamps are
  read from the session header (not fabricated). The session list
  is refreshed after forking so the new session appears immediately.

UI polish:
- ContextBadge and UsageBadge are right-aligned together in the
  ChatPanel header with matching text size and color.
- ContextBadge is split into sub-components (ContextDetails,
  SessionActions) to keep the file well-structured.
- Clear requires a two-click confirmation to prevent accidental loss.
- Fork shows a brief "Forked!" confirmation with green highlight.
- Nullable context data shows "Recalculating after compaction…"
  instead of stale numbers.