### PR TITLE
feat: Humanizer app + fix app agent skill loading & global app support

### DIFF
--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -76,6 +76,8 @@ const TOOLS_TO_BRIDGE = new Set([
   // Planning & context
   'plan_todos',
   'slopzilla',
+  // Text tools
+  'humanize',
   // NOT bridged — complex schemas (arrays of objects) that need structured params:
   // 'question', 'questionnaire', 'interview'
   // NOT bridged — these depend on ctx.sessionManager (SDK internals):

--- a/apps/desktop/electron/ipc/app-agent.ts
+++ b/apps/desktop/electron/ipc/app-agent.ts
@@ -72,13 +72,22 @@ async function resolveAppSkillPaths(packagePath: string): Promise<string[]> {
 /**
  * Find an app's package path by its id using app discovery.
  * Result is cached after first call.
+ *
+ * TODO: Wire up clearAppManifestCache() to hot-install events so
+ * newly added apps are picked up without an Electron restart.
  */
 let appManifestCache: Map<string, string> | null = null;
 
 async function getAppPackagePath(appId: string): Promise<string | null> {
   if (!appManifestCache) {
-    const apps = await discoverApps();
-    appManifestCache = new Map(apps.map((a) => [a.id, a.packagePath]));
+    try {
+      const apps = await discoverApps();
+      appManifestCache = new Map(apps.map((a) => [a.id, a.packagePath]));
+    } catch (err) {
+      console.error('[app-agent] Failed to discover apps for skill resolution:', err);
+      // Return null so the session still starts (just without skills)
+      return null;
+    }
   }
   return appManifestCache.get(appId) ?? null;
 }

--- a/apps/desktop/electron/ipc/app-agent.ts
+++ b/apps/desktop/electron/ipc/app-agent.ts
@@ -8,16 +8,20 @@
  * App sessions are:
  *   - Created lazily on first use (keyed by appId + workspaceId)
  *   - In-memory only (no session persistence — apps store state in their own files)
- *   - Tool-free by default (pure text completion — apps that need tools can register them)
+ *   - Have a Read tool so skills can be loaded on-demand (Pi's progressive disclosure)
  *   - Share the same auth, model, and settings as chat sessions
+ *   - Load skills from the app's package via a dedicated ResourceLoader
  *
  * The renderer calls `window.sero.appAgent.prompt(appId, workspaceId, text)`
  * and receives a plain string response (the LLM's text output).
  */
 
 import { app, ipcMain } from 'electron';
+import { promises as fs } from 'fs';
 import {
   createAgentSession,
+  createReadTool,
+  DefaultResourceLoader,
   SessionManager,
   type AgentSession,
 } from '@mariozechner/pi-coding-agent';
@@ -27,6 +31,7 @@ import path from 'path';
 import { IpcChannels } from '../../src/types/ipc';
 import { workspaceManager } from '../workspace';
 import { SERO_AGENT_DIR } from '../env';
+import { discoverApps } from '../app-discovery';
 import { ensureInfra } from './shared-infra';
 
 // ── App Session Pool ─────────────────────────────────────────
@@ -47,6 +52,44 @@ function poolKey(appId: string, workspaceId: string): string {
   return `${appId}:${workspaceId}`;
 }
 
+// ── Skill path resolution ────────────────────────────────────
+
+/**
+ * Read the `pi.skills` array from a package's package.json and
+ * resolve each entry to an absolute path.
+ */
+async function resolveAppSkillPaths(packagePath: string): Promise<string[]> {
+  try {
+    const raw = await fs.readFile(path.join(packagePath, 'package.json'), 'utf8');
+    const pkg = JSON.parse(raw);
+    const skillEntries: string[] = pkg.pi?.skills ?? [];
+    return skillEntries.map((s) => path.resolve(packagePath, s));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find an app's package path by its id using app discovery.
+ * Result is cached after first call.
+ */
+let appManifestCache: Map<string, string> | null = null;
+
+async function getAppPackagePath(appId: string): Promise<string | null> {
+  if (!appManifestCache) {
+    const apps = await discoverApps();
+    appManifestCache = new Map(apps.map((a) => [a.id, a.packagePath]));
+  }
+  return appManifestCache.get(appId) ?? null;
+}
+
+/** Invalidate the manifest cache (e.g. when new apps are installed). */
+export function clearAppManifestCache(): void {
+  appManifestCache = null;
+}
+
+// ── Session creation ─────────────────────────────────────────
+
 /** Get or create a lightweight session for an app. */
 async function getOrCreateAppSession(
   appId: string,
@@ -62,6 +105,29 @@ async function getOrCreateAppSession(
   const wsPath = workspaceManager.getPath(workspaceId)
     ?? path.join(os.homedir(), '.sero-ui');
 
+  // Resolve skill paths from the app's package
+  const packagePath = await getAppPackagePath(appId);
+  const skillPaths = packagePath ? await resolveAppSkillPaths(packagePath) : [];
+
+  // Create a resource loader scoped to this app's skills only.
+  // No extensions, prompt templates, or themes — just skills.
+  const loader = new DefaultResourceLoader({
+    cwd: wsPath,
+    agentDir: SERO_AGENT_DIR,
+    settingsManager: infra.settingsManager,
+    noExtensions: true,
+    noSkills: true,
+    noPromptTemplates: true,
+    noThemes: true,
+    additionalSkillPaths: skillPaths,
+  });
+  await loader.reload();
+
+  // Read tool is required so the agent can load skill files on-demand
+  // (Pi skills use progressive disclosure — only name/description are
+  // in the system prompt, the agent reads the full SKILL.md when needed).
+  const readTool = createReadTool(wsPath);
+
   const { session } = await createAgentSession({
     cwd: wsPath,
     agentDir: SERO_AGENT_DIR,
@@ -69,7 +135,8 @@ async function getOrCreateAppSession(
     thinkingLevel: 'high',
     authStorage: infra.authStorage,
     modelRegistry: infra.modelRegistry,
-    tools: [], // No tools — pure text completion
+    tools: [readTool],
+    resourceLoader: loader,
     sessionManager: SessionManager.inMemory(wsPath),
     settingsManager: infra.settingsManager,
   });

--- a/apps/desktop/src/components/apps/SeroAppMount.tsx
+++ b/apps/desktop/src/components/apps/SeroAppMount.tsx
@@ -53,7 +53,10 @@ export function SeroAppMount({ manifest }: SeroAppMountProps) {
   const contextValue = useMemo<AppContextValue>(
     () => ({
       appId: manifest.id,
-      workspaceId: isGlobal ? (activeWorkspaceId || 'global') : (activeWorkspaceId ?? ''),
+      // Global apps use 'global' as a stable key when no workspace is selected.
+      // Workspace-scoped apps are guarded by the `!isGlobal && !workspacePath`
+      // check below — they never render without an activeWorkspaceId.
+      workspaceId: isGlobal ? (activeWorkspaceId || 'global') : activeWorkspaceId!,
       workspacePath,
       stateFilePath,
       promptAgent,

--- a/apps/desktop/src/components/apps/SeroAppMount.tsx
+++ b/apps/desktop/src/components/apps/SeroAppMount.tsx
@@ -53,7 +53,7 @@ export function SeroAppMount({ manifest }: SeroAppMountProps) {
   const contextValue = useMemo<AppContextValue>(
     () => ({
       appId: manifest.id,
-      workspaceId: activeWorkspaceId ?? '',
+      workspaceId: isGlobal ? (activeWorkspaceId || 'global') : (activeWorkspaceId ?? ''),
       workspacePath,
       stateFilePath,
       promptAgent,

--- a/packages/pi-humanizer-extension/extension/index.ts
+++ b/packages/pi-humanizer-extension/extension/index.ts
@@ -1,0 +1,175 @@
+/**
+ * Humanizer Extension — Pi extension for humanizing AI-generated text.
+ *
+ * Provides a lightweight tool so the agent can query humanization history,
+ * and registers the humanizer skill so the agent can apply it directly.
+ *
+ * State: `~/.sero-ui/apps/humanizer/state.json` (global scope)
+ * Skills: `skills/humanizer/SKILL.md`
+ * Tools: humanize (list history)
+ * Commands: /humanize
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import type { HumanizerState, HumanizeEntry } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+
+// ── State file path ────────────────────────────────────────
+
+const STATE_REL_PATH = path.join('.sero', 'apps', 'humanizer', 'state.json');
+
+function resolveStatePath(cwd: string): string {
+  const seroHome = process.env.SERO_HOME;
+  if (seroHome) {
+    return path.join(seroHome, 'apps', 'humanizer', 'state.json');
+  }
+  return path.join(cwd, STATE_REL_PATH);
+}
+
+// ── File I/O ───────────────────────────────────────────────
+
+async function readState(filePath: string): Promise<HumanizerState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as HumanizerState;
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+async function writeState(filePath: string, state: HumanizerState): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+// ── Tool parameters ────────────────────────────────────────
+
+const Params = Type.Object({
+  action: StringEnum(['list', 'save'] as const),
+  input: Type.Optional(Type.String({ description: 'Original text (for save)' })),
+  output: Type.Optional(Type.String({ description: 'Humanized text (for save)' })),
+  instructions: Type.Optional(Type.String({ description: 'Instructions used (for save)' })),
+});
+
+// ── Helpers ────────────────────────────────────────────────
+
+function formatHistory(state: HumanizerState): string {
+  if (state.entries.length === 0) {
+    return 'No humanizations yet. Use the Humanizer app or ask me to humanize some text.';
+  }
+  const lines = state.entries.slice(-10).map((e, i) => {
+    const preview = e.inputText.slice(0, 80).replace(/\n/g, ' ');
+    const instr = e.instructions ? ` (instructions: ${e.instructions.slice(0, 40)})` : '';
+    return `${i + 1}. [${e.createdAt}]${instr}\n   Input: "${preview}..."`;
+  });
+  return `Recent humanizations (${state.entries.length} total):\n\n${lines.join('\n\n')}`;
+}
+
+// ── Extension ──────────────────────────────────────────────
+
+export default function (pi: ExtensionAPI) {
+  let statePath = '';
+
+  pi.on('session_start', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+  pi.on('session_switch', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+
+  pi.registerTool({
+    name: 'humanize',
+    label: 'Humanize',
+    description:
+      'Manage humanized text history. Actions: list (show recent humanizations), save (store a humanization result — requires input + output).',
+    parameters: Params,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : statePath;
+      if (!resolvedPath) {
+        return {
+          content: [{ type: 'text', text: 'Error: no workspace cwd' }],
+          details: {},
+        };
+      }
+      statePath = resolvedPath;
+      const state = await readState(statePath);
+
+      switch (params.action) {
+        case 'list': {
+          return {
+            content: [{ type: 'text', text: formatHistory(state) }],
+            details: {},
+          };
+        }
+
+        case 'save': {
+          if (!params.input || !params.output) {
+            return {
+              content: [{ type: 'text', text: 'Error: input and output are required for save' }],
+              details: {},
+            };
+          }
+          const entry: HumanizeEntry = {
+            id: state.nextId,
+            inputText: params.input,
+            instructions: params.instructions ?? '',
+            outputText: params.output,
+            createdAt: new Date().toISOString(),
+          };
+          state.entries = [...state.entries.slice(-19), entry]; // keep last 20
+          state.nextId++;
+          await writeState(statePath, state);
+          return {
+            content: [{ type: 'text', text: `Saved humanization #${entry.id}` }],
+            details: {},
+          };
+        }
+
+        default:
+          return {
+            content: [{ type: 'text', text: `Unknown action: ${params.action}` }],
+            details: {},
+          };
+      }
+    },
+
+    renderCall(args, theme) {
+      const action = (args as { action?: string }).action ?? 'list';
+      return new Text(
+        theme.fg('toolTitle', theme.bold('humanize ')) +
+          theme.fg('muted', action),
+        0, 0,
+      );
+    },
+
+    renderResult(result, _options, theme) {
+      const text = result.content[0];
+      const msg = text?.type === 'text' ? text.text : '';
+      return new Text(
+        msg.startsWith('Error:')
+          ? theme.fg('error', msg)
+          : theme.fg('success', '✓ ') + theme.fg('muted', msg),
+        0, 0,
+      );
+    },
+  });
+
+  pi.registerCommand('humanize', {
+    description: 'Open the Humanizer — remove AI writing patterns from text',
+    handler: async (_args, _ctx) => {
+      pi.sendUserMessage(
+        'Show my recent humanizations using the humanize tool with action list.',
+      );
+    },
+  });
+}

--- a/packages/pi-humanizer-extension/extension/index.ts
+++ b/packages/pi-humanizer-extension/extension/index.ts
@@ -22,14 +22,12 @@ import { DEFAULT_STATE } from '../shared/types';
 
 // ── State file path ────────────────────────────────────────
 
-const STATE_REL_PATH = path.join('.sero', 'apps', 'humanizer', 'state.json');
-
-function resolveStatePath(cwd: string): string {
+function statePath(): string {
   const seroHome = process.env.SERO_HOME;
-  if (seroHome) {
-    return path.join(seroHome, 'apps', 'humanizer', 'state.json');
+  if (!seroHome) {
+    throw new Error('SERO_HOME is not set — humanizer requires the Sero desktop environment');
   }
-  return path.join(cwd, STATE_REL_PATH);
+  return path.join(seroHome, 'apps', 'humanizer', 'state.json');
 }
 
 // ── File I/O ───────────────────────────────────────────────
@@ -77,15 +75,6 @@ function formatHistory(state: HumanizerState): string {
 // ── Extension ──────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
-  let statePath = '';
-
-  pi.on('session_start', async (_event, ctx) => {
-    statePath = resolveStatePath(ctx.cwd);
-  });
-  pi.on('session_switch', async (_event, ctx) => {
-    statePath = resolveStatePath(ctx.cwd);
-  });
-
   pi.registerTool({
     name: 'humanize',
     label: 'Humanize',
@@ -93,16 +82,9 @@ export default function (pi: ExtensionAPI) {
       'Manage humanized text history. Actions: list (show recent humanizations), save (store a humanization result — requires input + output).',
     parameters: Params,
 
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const resolvedPath = ctx ? resolveStatePath(ctx.cwd) : statePath;
-      if (!resolvedPath) {
-        return {
-          content: [{ type: 'text', text: 'Error: no workspace cwd' }],
-          details: {},
-        };
-      }
-      statePath = resolvedPath;
-      const state = await readState(statePath);
+    async execute(_toolCallId, params) {
+      const filePath = statePath();
+      const state = await readState(filePath);
 
       switch (params.action) {
         case 'list': {
@@ -128,7 +110,7 @@ export default function (pi: ExtensionAPI) {
           };
           state.entries = [...state.entries.slice(-19), entry]; // keep last 20
           state.nextId++;
-          await writeState(statePath, state);
+          await writeState(filePath, state);
           return {
             content: [{ type: 'text', text: `Saved humanization #${entry.id}` }],
             details: {},

--- a/packages/pi-humanizer-extension/package.json
+++ b/packages/pi-humanizer-extension/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@sero/humanizer",
+  "version": "0.1.0",
+  "description": "Humanizer — remove AI writing patterns from text",
+  "keywords": [
+    "pi-package",
+    "pi-skill"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+  },
+  "pi": {
+    "extensions": [
+      "./extension/index.ts"
+    ],
+    "skills": [
+      "./skills"
+    ]
+  },
+  "sero": {
+    "app": {
+      "id": "humanizer",
+      "name": "Humanizer",
+      "icon": "pen-line",
+      "scope": "global",
+      "stateFile": ".sero/apps/humanizer/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "HumanizerApp",
+      "devPort": 5192
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": ">=0.55.3",
+    "@mariozechner/pi-coding-agent": ">=0.55.3",
+    "@mariozechner/pi-tui": ">=0.55.3"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "^1.11.0",
+    "@sero/app-runtime": "workspace:*",
+    "@sero/ui": "workspace:*",
+    "@tailwindcss/vite": "^4.1.18",
+    "@types/node": "^22.19.11",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^6.4.1"
+  }
+}

--- a/packages/pi-humanizer-extension/shared/types.ts
+++ b/packages/pi-humanizer-extension/shared/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared state shape for the Humanizer app.
+ *
+ * Both the Pi extension and the Sero web UI import this.
+ * State is global-scoped (~/.sero-ui/apps/humanizer/state.json).
+ */
+
+export interface HumanizeEntry {
+  id: number;
+  inputText: string;
+  instructions: string;
+  outputText: string;
+  createdAt: string; // ISO string
+}
+
+export interface HumanizerState {
+  entries: HumanizeEntry[];
+  nextId: number;
+}
+
+export const DEFAULT_STATE: HumanizerState = {
+  entries: [],
+  nextId: 1,
+};

--- a/packages/pi-humanizer-extension/skills/humanizer/SKILL.md
+++ b/packages/pi-humanizer-extension/skills/humanizer/SKILL.md
@@ -1,0 +1,488 @@
+---
+name: humanizer
+version: 2.2.0
+description: |
+  Remove signs of AI-generated writing from text. Use when editing or reviewing
+  text to make it sound more natural and human-written. Based on Wikipedia's
+  comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
+  inflated symbolism, promotional language, superficial -ing analyses, vague
+  attributions, em dash overuse, rule of three, AI vocabulary words, negative
+  parallelisms, and excessive conjunctive phrases.
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+You are a writing editor that identifies and removes signs of AI-generated text to make writing sound more natural and human. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+## Your Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** - Scan for the patterns listed below
+2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
+3. **Preserve meaning** - Keep the core message intact
+4. **Maintain voice** - Match the intended tone (formal, casual, technical, etc.)
+5. **Add soul** - Don't just remove bad patterns; inject actual personality
+6. **Do a final anti-AI pass** - Prompt: "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then prompt: "Now make it not obviously AI generated." and revise
+
+---
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop. Good writing has a human behind it.
+
+### Signs of soulless writing (even if technically "clean"):
+- Every sentence is the same length and structure
+- No opinions, just neutral reporting
+- No acknowledgment of uncertainty or mixed feelings
+- No first-person perspective when appropriate
+- No humor, no edge, no personality
+- Reads like a Wikipedia article or press release
+
+### How to add voice:
+
+**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+
+**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+
+**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
+
+**Use "I" when it fits.** First person isn't unprofessional - it's honest. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
+
+**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+
+**Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+
+### Before (clean but soulless):
+> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+
+### After (has a pulse):
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
+
+---
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+
+**Before:**
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+
+**After:**
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+---
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+**After:**
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+---
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+
+**Before:**
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+
+**After:**
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+---
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+
+**Before:**
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+**After:**
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+---
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+
+**Before:**
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+---
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+
+**Before:**
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+
+**After:**
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+---
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+
+**Before:**
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+
+**After:**
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+---
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+
+**Before:**
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+**After:**
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+---
+
+### 9. Negative Parallelisms
+
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused.
+
+**Before:**
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+
+**After:**
+> The heavy beat adds to the aggressive tone.
+
+---
+
+### 10. Rule of Three Overuse
+
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+---
+
+### 11. Elegant Variation (Synonym Cycling)
+
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+
+**Before:**
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+---
+
+### 12. False Ranges
+
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+
+**Before:**
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+---
+
+## STYLE PATTERNS
+
+### 13. Em Dash Overuse
+
+**Problem:** LLMs use em dashes (—) more than humans, mimicking "punchy" sales writing.
+
+**Before:**
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+
+**After:**
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+---
+
+### 14. Overuse of Boldface
+
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+
+**Before:**
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+---
+
+### 15. Inline-Header Vertical Lists
+
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+
+**Before:**
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+**After:**
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+---
+
+### 16. Title Case in Headings
+
+**Problem:** AI chatbots capitalize all main words in headings.
+
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+> ## Strategic negotiations and global partnerships
+
+---
+
+### 17. Emojis
+
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+---
+
+### 18. Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes (“...”) instead of straight quotes ("...").
+
+**Before:**
+> He said “the project is on track” but others disagreed.
+
+**After:**
+> He said "the project is on track" but others disagreed.
+
+---
+
+## COMMUNICATION PATTERNS
+
+### 19. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+---
+
+### 20. Knowledge-Cutoff Disclaimers
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
+
+**Problem:** AI disclaimers about incomplete information get left in text.
+
+**Before:**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+> The company was founded in 1994, according to its registration documents.
+
+---
+
+### 21. Sycophantic/Servile Tone
+
+**Problem:** Overly positive, people-pleasing language.
+
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+
+**After:**
+> The economic factors you mentioned are relevant here.
+
+---
+
+## FILLER AND HEDGING
+
+### 22. Filler Phrases
+
+**Before → After:**
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+---
+
+### 23. Excessive Hedging
+
+**Problem:** Over-qualifying statements.
+
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+> The policy may affect outcomes.
+
+---
+
+### 24. Generic Positive Conclusions
+
+**Problem:** Vague upbeat endings.
+
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+**After:**
+> The company plans to open two more locations next year.
+
+---
+
+## Process
+
+1. Read the input text carefully
+2. Identify all instances of the patterns above
+3. Rewrite each problematic section
+4. Ensure the revised text:
+   - Sounds natural when read aloud
+   - Varies sentence structure naturally
+   - Uses specific details over vague claims
+   - Maintains appropriate tone for context
+   - Uses simple constructions (is/are/has) where appropriate
+5. Present a draft humanized version
+6. Prompt: "What makes the below so obviously AI generated?"
+7. Answer briefly with the remaining tells (if any)
+8. Prompt: "Now make it not obviously AI generated."
+9. Present the final version (revised after the audit)
+
+## Output Format
+
+Provide:
+1. Draft rewrite
+2. "What makes the below so obviously AI generated?" (brief bullets)
+3. Final rewrite
+4. A brief summary of changes made (optional, if helpful)
+
+---
+
+## Full Example
+
+**Before (AI-sounding):**
+> Great question! Here is an essay on this topic. I hope this helps!
+>
+> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
+>
+> At its core, the value proposition is clear: streamlining processes, enhancing collaboration, and fostering alignment. It's not just about autocomplete; it's about unlocking creativity at scale, ensuring that organizations can remain agile while delivering seamless, intuitive, and powerful experiences to users. The tool serves as a catalyst. The assistant functions as a partner. The system stands as a foundation for innovation.
+>
+> Industry observers have noted that adoption has accelerated from hobbyist experiments to enterprise-wide rollouts, from solo developers to cross-functional teams. The technology has been featured in The New York Times, Wired, and The Verge. Additionally, the ability to generate documentation, tests, and refactors showcases how AI can contribute to better outcomes, highlighting the intricate interplay between automation and human judgment.
+>
+> - 💡 **Speed:** Code generation is significantly faster, reducing friction and empowering developers.
+> - 🚀 **Quality:** Output quality has been enhanced through improved training, contributing to higher standards.
+> - ✅ **Adoption:** Usage continues to grow, reflecting broader industry trends.
+>
+> While specific details are limited based on available information, it could potentially be argued that these tools might have some positive effect. Despite challenges typical of emerging technologies—including hallucinations, bias, and accountability—the ecosystem continues to thrive. In order to fully realize this potential, teams must align with best practices.
+>
+> In conclusion, the future looks bright. Exciting times lie ahead as we continue this journey toward excellence. Let me know if you’d like me to expand on any section!
+
+**Draft rewrite:**
+> AI coding assistants speed up some tasks. In a 2024 study by Google, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
+>
+> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong. I have mass-accepted suggestions that compiled, passed lint, and still did the wrong thing because I stopped paying attention.
+>
+> Mira, an engineer at a fintech startup I interviewed, said she uses Copilot "like autocomplete for boring code" but reviews every line before committing. Jake, a senior dev at a larger company, disabled it after it kept suggesting patterns from a deprecated internal library.
+>
+> The productivity claims are hard to verify. GitHub says Copilot users "accept 30% of suggestions," but acceptance is not correctness, and correctness is not value. The 2024 Uplevel study found no statistically significant difference in pull-request throughput between teams with and without AI assistants.
+>
+> None of this means the tools are useless. It means they are tools. They do not replace judgment, and they do not eliminate the need for tests. If you do not have tests, you cannot tell whether the suggestion is right.
+
+**What makes the below so obviously AI generated?**
+- The rhythm is still a bit too tidy (clean contrasts, evenly paced paragraphs).
+- The named people and study citations can read like plausible-but-made-up placeholders unless they're real and sourced.
+- The closer leans a touch slogan-y ("If you do not have tests...") rather than sounding like a person talking.
+
+**Now make it not obviously AI generated.**
+> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
+>
+> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
+>
+> People I talk to tend to land in two camps. Some use it like autocomplete for chores and review every line. Others disable it after it keeps suggesting patterns they don't want. Both feel reasonable.
+>
+> The productivity metrics are slippery. GitHub can say Copilot users "accept 30% of suggestions," but acceptance isn't correctness, and correctness isn't value. If you don't have tests, you're basically guessing.
+
+**Changes made:**
+- Removed chatbot artifacts ("Great question!", "I hope this helps!", "Let me know if...")
+- Removed significance inflation ("testament", "pivotal moment", "evolving landscape", "vital role")
+- Removed promotional language ("groundbreaking", "nestled", "seamless, intuitive, and powerful")
+- Removed vague attributions ("Industry observers")
+- Removed superficial -ing phrases ("underscoring", "highlighting", "reflecting", "contributing to")
+- Removed negative parallelism ("It's not just X; it's Y")
+- Removed rule-of-three patterns and synonym cycling ("catalyst/partner/foundation")
+- Removed false ranges ("from X to Y, from A to B")
+- Removed em dashes, emojis, boldface headers, and curly quotes
+- Removed copula avoidance ("serves as", "functions as", "stands as") in favor of "is"/"are"
+- Removed formulaic challenges section ("Despite challenges... continues to thrive")
+- Removed knowledge-cutoff hedging ("While specific details are limited...")
+- Removed excessive hedging ("could potentially be argued that... might have some")
+- Removed filler phrases ("In order to", "At its core")
+- Removed generic positive conclusion ("the future looks bright", "exciting times lie ahead")
+- Made the voice more personal and less "assembled" (varied rhythm, fewer placeholders)
+
+---
+
+## Reference
+
+This skill is based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup. The patterns documented there come from observations of thousands of instances of AI-generated text on Wikipedia.
+
+Key insight from Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
+++ b/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
@@ -305,4 +305,4 @@ function HistoryPanel({
   );
 }
 
-export default HumanizerApp;
+

--- a/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
+++ b/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
@@ -1,0 +1,308 @@
+/**
+ * HumanizerApp — main Sero app component.
+ *
+ * Provides a text input area, optional instructions field, and a
+ * humanize button that calls the LLM via useAI() to remove AI
+ * writing patterns from the provided text.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useAppState, useAI } from '@sero/app-runtime';
+import { cn } from '@sero/ui/lib/utils';
+import { Button } from '@sero/ui/components/ui/button';
+import type { HumanizerState, HumanizeEntry } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+import { buildHumanizePrompt } from './humanize-prompt';
+import './styles.css';
+
+export function HumanizerApp() {
+  const [state, updateState] = useAppState<HumanizerState>(DEFAULT_STATE);
+  const ai = useAI();
+
+  const [inputText, setInputText] = useState('');
+  const [instructions, setInstructions] = useState('');
+  const [outputText, setOutputText] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+
+  const outputRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-resize textareas
+  const autoResize = useCallback((el: HTMLTextAreaElement | null) => {
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => autoResize(inputRef.current), [inputText, autoResize]);
+  useEffect(() => autoResize(outputRef.current), [outputText, autoResize]);
+
+  // ── Humanize ─────────────────────────────────────────────
+
+  const handleHumanize = useCallback(async () => {
+    const text = inputText.trim();
+    if (!text) return;
+
+    setLoading(true);
+    setError(null);
+    setOutputText('');
+    setCopied(false);
+
+    try {
+      const prompt = buildHumanizePrompt(text, instructions.trim() || undefined);
+      const response = await ai.prompt(prompt);
+      setOutputText(response);
+
+      // Save to history
+      updateState((prev) => {
+        const entry: HumanizeEntry = {
+          id: prev.nextId,
+          inputText: text,
+          instructions: instructions.trim(),
+          outputText: response,
+          createdAt: new Date().toISOString(),
+        };
+        return {
+          entries: [...prev.entries.slice(-19), entry],
+          nextId: prev.nextId + 1,
+        };
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Humanization failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [inputText, instructions, ai, updateState]);
+
+  // ── Copy output ──────────────────────────────────────────
+
+  const handleCopy = useCallback(async () => {
+    if (!outputText) return;
+    try {
+      await navigator.clipboard.writeText(outputText);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Failed to copy to clipboard');
+    }
+  }, [outputText]);
+
+  // ── Clear ────────────────────────────────────────────────
+
+  const handleClear = useCallback(() => {
+    setInputText('');
+    setInstructions('');
+    setOutputText('');
+    setError(null);
+    setCopied(false);
+  }, []);
+
+  // ── Load from history ────────────────────────────────────
+
+  const handleLoadEntry = useCallback((entry: HumanizeEntry) => {
+    setInputText(entry.inputText);
+    setInstructions(entry.instructions);
+    setOutputText(entry.outputText);
+    setShowHistory(false);
+  }, []);
+
+  // ── Render ───────────────────────────────────────────────
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-background">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-5 py-3">
+        <div>
+          <h1 className="text-base font-semibold text-foreground">Humanizer</h1>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Remove AI writing patterns from your text
+          </p>
+        </div>
+        {state.entries.length > 0 && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-xs text-muted-foreground"
+            onClick={() => setShowHistory(!showHistory)}
+          >
+            {showHistory ? 'Back' : `History (${state.entries.length})`}
+          </Button>
+        )}
+      </div>
+
+      {/* History panel */}
+      {showHistory ? (
+        <HistoryPanel entries={state.entries} onLoad={handleLoadEntry} />
+      ) : (
+        <div className="flex-1 overflow-y-auto">
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-5">
+            {/* Input area */}
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">
+                Text to humanize
+              </label>
+              <textarea
+                ref={inputRef}
+                value={inputText}
+                onChange={(e) => setInputText(e.target.value)}
+                placeholder="Paste your AI-generated text or markdown here..."
+                className={cn(
+                  'min-h-[160px] w-full resize-none rounded-lg border border-input',
+                  'bg-card px-3.5 py-2.5 text-sm leading-relaxed text-foreground',
+                  'placeholder:text-muted-foreground',
+                  'focus:outline-none focus:ring-1 focus:ring-ring',
+                )}
+              />
+            </div>
+
+            {/* Instructions */}
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">
+                Instructions{' '}
+                <span className="font-normal text-muted-foreground/60">
+                  (optional)
+                </span>
+              </label>
+              <input
+                type="text"
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="e.g. Keep a formal tone, preserve technical terms..."
+                className={cn(
+                  'w-full rounded-lg border border-input bg-card px-3.5 py-2',
+                  'text-sm text-foreground placeholder:text-muted-foreground',
+                  'focus:outline-none focus:ring-1 focus:ring-ring',
+                )}
+              />
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                disabled={!inputText.trim() || loading}
+                onClick={handleHumanize}
+              >
+                {loading ? 'Humanizing...' : 'Humanize'}
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-muted-foreground"
+                onClick={handleClear}
+                disabled={loading}
+              >
+                Clear
+              </Button>
+            </div>
+
+            {/* Error */}
+            {error && (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3.5 py-2 text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {/* Loading indicator */}
+            {loading && (
+              <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+                <LoadingDots />
+                <span>Analyzing and rewriting your text...</span>
+              </div>
+            )}
+
+            {/* Output */}
+            {outputText && (
+              <div className="flex flex-col gap-1.5">
+                <div className="flex items-center justify-between">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    Humanized output
+                  </label>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 text-xs text-muted-foreground"
+                    onClick={handleCopy}
+                  >
+                    {copied ? 'Copied!' : 'Copy'}
+                  </Button>
+                </div>
+                <textarea
+                  ref={outputRef}
+                  value={outputText}
+                  readOnly
+                  className={cn(
+                    'min-h-[160px] w-full resize-none rounded-lg border border-input',
+                    'bg-secondary/30 px-3.5 py-2.5 text-sm leading-relaxed text-foreground',
+                    'focus:outline-none focus:ring-1 focus:ring-ring',
+                  )}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Loading dots animation ─────────────────────────────────
+
+function LoadingDots() {
+  return (
+    <span className="inline-flex gap-0.5">
+      <span className="humanizer-dot h-1.5 w-1.5 rounded-full bg-muted-foreground" />
+      <span className="humanizer-dot h-1.5 w-1.5 rounded-full bg-muted-foreground [animation-delay:150ms]" />
+      <span className="humanizer-dot h-1.5 w-1.5 rounded-full bg-muted-foreground [animation-delay:300ms]" />
+    </span>
+  );
+}
+
+// ── History panel ──────────────────────────────────────────
+
+function HistoryPanel({
+  entries,
+  onLoad,
+}: {
+  entries: HumanizeEntry[];
+  onLoad: (entry: HumanizeEntry) => void;
+}) {
+  const sorted = [...entries].reverse();
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 p-5">
+        {sorted.map((entry) => (
+          <button
+            key={entry.id}
+            type="button"
+            className={cn(
+              'flex flex-col gap-1 rounded-lg border border-border bg-card px-4 py-3',
+              'text-left transition-colors hover:bg-secondary/50',
+            )}
+            onClick={() => onLoad(entry)}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted-foreground">
+                {new Date(entry.createdAt).toLocaleString()}
+              </span>
+              {entry.instructions && (
+                <span className="max-w-[200px] truncate text-xs text-muted-foreground/60">
+                  {entry.instructions}
+                </span>
+              )}
+            </div>
+            <p className="line-clamp-2 text-sm text-foreground">
+              {entry.inputText}
+            </p>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default HumanizerApp;

--- a/packages/pi-humanizer-extension/ui/humanize-prompt.ts
+++ b/packages/pi-humanizer-extension/ui/humanize-prompt.ts
@@ -1,0 +1,21 @@
+/**
+ * Builds the LLM prompt for humanizing text.
+ *
+ * Explicitly instructs the agent to read the humanizer skill file
+ * before applying it — Pi skills use progressive disclosure, so
+ * the agent must load the full SKILL.md via the Read tool.
+ */
+
+export function buildHumanizePrompt(text: string, instructions?: string): string {
+  const parts: string[] = [
+    'First, read the humanizer skill file using the read tool to load its full instructions. Then apply those instructions to rewrite the following text. Return ONLY the final humanized text with no preamble or commentary.',
+  ];
+
+  if (instructions) {
+    parts.push(`\nAdditional instructions: ${instructions}`);
+  }
+
+  parts.push(`\nText to humanize:\n\n${text}`);
+
+  return parts.join('');
+}

--- a/packages/pi-humanizer-extension/ui/index.html
+++ b/packages/pi-humanizer-extension/ui/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Sero Humanizer (remote)</title></head>
+<body><div id="root"></div></body>
+</html>

--- a/packages/pi-humanizer-extension/ui/styles.css
+++ b/packages/pi-humanizer-extension/ui/styles.css
@@ -1,0 +1,41 @@
+@import "tailwindcss";
+
+@source "../../ui/src/components";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+/* Loading dots animation */
+@keyframes humanizer-pulse {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+.humanizer-dot {
+  animation: humanizer-pulse 1s ease-in-out infinite;
+}

--- a/packages/pi-humanizer-extension/ui/tsconfig.json
+++ b/packages/pi-humanizer-extension/ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero/app-runtime": ["../../app-runtime/src/index.ts"],
+      "@sero/ui": ["../../ui/src/index.ts"],
+      "@sero/ui/*": ["../../ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/pi-humanizer-extension/vite.config.ts
+++ b/packages/pi-humanizer-extension/vite.config.ts
@@ -1,0 +1,48 @@
+/**
+ * Vite config for the humanizer extension's federated UI (remote).
+ *
+ * Runs its own dev server on port 5192. The host (Sero on 5173)
+ * declares this as a remote and imports components via MF.
+ */
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_humanizer',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './HumanizerApp': './ui/HumanizerApp.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5192,
+    strictPort: true,
+    origin: 'http://localhost:5192',
+  },
+  optimizeDeps: {
+    exclude: ['@sero/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,6 +577,61 @@ importers:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  packages/pi-humanizer-extension:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: '>=0.55.3'
+        version: 0.55.3(@modelcontextprotocol/sdk@1.26.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: '>=0.55.3'
+        version: 0.55.3
+      '@sinclair/typebox':
+        specifier: ^0.34.48
+        version: 0.34.48
+    devDependencies:
+      '@module-federation/vite':
+        specifier: ^1.11.0
+        version: 1.11.0(rollup@4.57.1)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@sero/app-runtime':
+        specifier: workspace:*
+        version: link:../app-runtime
+      '@sero/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@types/node':
+        specifier: ^22.19.11
+        version: 22.19.11
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.1.18
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+
   packages/pi-imagegen-extension:
     dependencies:
       '@mariozechner/pi-ai':


### PR DESCRIPTION
## New: Humanizer App (`packages/pi-humanizer-extension/`)

A Sero app that removes AI writing patterns from text using a configurable skill file.

- **UI**: Text input area, optional instructions field, Humanize button, output with copy
- **Skill**: `skills/humanizer/SKILL.md` — comprehensive rules based on Wikipedia's "Signs of AI writing" guide
- **Extension**: `humanize` tool (list/save history), `/humanize` command, skill registered via `pi.skills`
- **State**: Global scope (`~/.sero-ui/apps/humanizer/state.json`), keeps last 20 humanizations
- **Port**: 5192

## Host Fixes

### App agent skill loading (`electron/ipc/app-agent.ts`)
App agent sessions (used by `useAI()`) previously had no resource loader and no tools — skills were listed in the system prompt but the LLM couldn't read them.

Now each app agent session gets:
- A **dedicated `DefaultResourceLoader`** scoped to the app's own skills (read from `pi.skills` in `package.json`)
- A **Read tool** so the LLM can load skill files on-demand (Pi's progressive disclosure model)

### Global app `workspaceId` fix (`SeroAppMount.tsx`)
Global-scoped apps got `workspaceId: ''` when no workspace was selected, causing `useAI()` to throw. Now they get `'global'` as fallback.

### Tool bridge (`electron/cli/index.ts`)
Added `'humanize'` to `TOOLS_TO_BRIDGE`.