### PR TITLE
feat: implement security audit hardening (13 of 19 findings fixed)

### DIFF
--- a/apps/desktop/electron/ext-protocol.ts
+++ b/apps/desktop/electron/ext-protocol.ts
@@ -61,6 +61,11 @@ export function setupExtProtocol(): void {
     const appId = url.hostname;
     let filePath = decodeURIComponent(url.pathname);
 
+    // Security: reject null bytes
+    if (filePath.includes('\0')) {
+      return new Response('Forbidden', { status: 403 });
+    }
+
     // Strip leading slash
     if (filePath.startsWith('/')) filePath = filePath.slice(1);
     if (!filePath) filePath = 'mf-manifest.json';
@@ -71,11 +76,11 @@ export function setupExtProtocol(): void {
     }
 
     // Resolve to the dist/ui directory in the package
-    const distDir = path.join(manifest.packagePath, 'dist', 'ui');
-    const fullPath = path.join(distDir, filePath);
+    const distDir = path.resolve(manifest.packagePath, 'dist', 'ui');
+    const fullPath = path.resolve(distDir, filePath);
 
-    // Security: ensure resolved path is within dist dir
-    if (!fullPath.startsWith(distDir)) {
+    // Security: ensure resolved path is within dist dir (prevents traversal)
+    if (!fullPath.startsWith(distDir + path.sep) && fullPath !== distDir) {
       return new Response('Forbidden', { status: 403 });
     }
 

--- a/apps/desktop/electron/ext-protocol.ts
+++ b/apps/desktop/electron/ext-protocol.ts
@@ -13,6 +13,7 @@
 
 import { protocol, net } from 'electron';
 import path from 'path';
+import { realpathSync } from 'fs';
 import type { SeroAppManifest } from '../src/types/ipc';
 
 // ── App registry (populated by discovery) ────────────────────
@@ -82,6 +83,18 @@ export function setupExtProtocol(): void {
     // Security: ensure resolved path is within dist dir (prevents traversal)
     if (!fullPath.startsWith(distDir + path.sep) && fullPath !== distDir) {
       return new Response('Forbidden', { status: 403 });
+    }
+
+    // Security: resolve symlinks to catch symlink escape attacks
+    // (e.g., a symlink inside dist/ui/ pointing to /etc/passwd)
+    try {
+      const realPath = realpathSync(fullPath);
+      const realDistDir = realpathSync(distDir);
+      if (!realPath.startsWith(realDistDir + path.sep) && realPath !== realDistDir) {
+        return new Response('Forbidden', { status: 403 });
+      }
+    } catch {
+      // File doesn't exist — let net.fetch handle the 404 below
     }
 
     try {

--- a/apps/desktop/electron/gateway/channels/discord.ts
+++ b/apps/desktop/electron/gateway/channels/discord.ts
@@ -45,6 +45,15 @@ export class DiscordAdapter {
   }
 
   async start(): Promise<void> {
+    // Security: fail-closed — refuse to start if no user whitelist
+    if (this.config.allowedUsers.length === 0) {
+      console.warn(
+        '[discord] SERO_DISCORD_USERS is empty — Discord adapter disabled for security. ' +
+        'Set SERO_DISCORD_USERS to a comma-separated list of Discord user IDs to enable.',
+      );
+      return;
+    }
+
     try {
       Discord = await import('discord.js');
     } catch {
@@ -98,11 +107,11 @@ export class DiscordAdapter {
     // Ignore bot messages
     if (msg.author.bot) return;
 
-    // Access control
-    if (
-      this.config.allowedUsers.length > 0 &&
-      !this.config.allowedUsers.includes(msg.author.id)
-    ) {
+    // Access control — fail-closed: if no allowedUsers configured, deny all
+    if (this.config.allowedUsers.length === 0) {
+      return;
+    }
+    if (!this.config.allowedUsers.includes(msg.author.id)) {
       return;
     }
 

--- a/apps/desktop/electron/gateway/channels/discord.ts
+++ b/apps/desktop/electron/gateway/channels/discord.ts
@@ -49,7 +49,7 @@ export class DiscordAdapter {
     if (this.config.allowedUsers.length === 0) {
       console.warn(
         '[discord] SERO_DISCORD_USERS is empty — Discord adapter disabled for security. ' +
-        'Set SERO_DISCORD_USERS to a comma-separated list of Discord user IDs to enable.',
+        'Set SERO_DISCORD_USERS to a comma-separated list of Discord usernames or user IDs to enable.',
       );
       return;
     }
@@ -111,7 +111,20 @@ export class DiscordAdapter {
     if (this.config.allowedUsers.length === 0) {
       return;
     }
-    if (!this.config.allowedUsers.includes(msg.author.id)) {
+    // Match by numeric user ID, username, or legacy tag (User#1234).
+    // This lets SERO_DISCORD_USERS accept either format.
+    const isAllowed = this.config.allowedUsers.some((allowed) => {
+      const lower = allowed.toLowerCase();
+      return (
+        msg.author.id === allowed ||
+        msg.author.username.toLowerCase() === lower ||
+        msg.author.tag.toLowerCase() === lower
+      );
+    });
+    if (!isAllowed) {
+      console.warn(
+        `[discord] Message rejected from unauthorized user: ${msg.author.tag} (${msg.author.id})`,
+      );
       return;
     }
 

--- a/apps/desktop/electron/gateway/channels/web.ts
+++ b/apps/desktop/electron/gateway/channels/web.ts
@@ -28,6 +28,10 @@ export class WebChatServer {
     if (this.server) return;
 
     this.server = http.createServer((req, res) => {
+      // Security: prevent token leakage via Referer headers
+      res.setHeader('Referrer-Policy', 'no-referrer');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+
       if (req.url === '/' || req.url === '/index.html') {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(this.buildHtml());
@@ -156,7 +160,10 @@ const GW_URL = (function() {
   return wsProto + '//' + loc.host;
 })();
 let ws = null;
-let token = new URLSearchParams(location.search).get('token') || '';
+// Security: never read token from URL query string — it leaks via
+// Referer headers, browser history, and server logs. Users must enter
+// the token via the auth overlay password field.
+let token = '';
 let sessionId = 'web-' + Date.now();
 let workspaceId = '';
 let currentAgentMsg = null;
@@ -251,20 +258,15 @@ function sendMessage() {
   input.style.height = 'auto';
 }
 
-// Auth
-if (token) {
-  authOverlay.style.display = 'none';
-  connect();
-} else {
-  $('#auth-btn').onclick = () => {
-    token = $('#token-input').value.trim();
-    if (token) {
-      authOverlay.style.display = 'none';
-      connect();
-    }
-  };
-  $('#token-input').onkeydown = (e) => { if (e.key === 'Enter') $('#auth-btn').click(); };
-}
+// Auth — always require manual token entry via the overlay
+$('#auth-btn').onclick = () => {
+  token = $('#token-input').value.trim();
+  if (token) {
+    authOverlay.style.display = 'none';
+    connect();
+  }
+};
+$('#token-input').onkeydown = (e) => { if (e.key === 'Enter') $('#auth-btn').click(); };
 
 // Input handling
 sendBtn.onclick = sendMessage;

--- a/apps/desktop/electron/gateway/index.ts
+++ b/apps/desktop/electron/gateway/index.ts
@@ -23,6 +23,7 @@ import http from 'http';
 
 import { GatewayAuth } from './auth';
 import { RateLimiter } from './rate-limiter';
+import { sendResponse, routeAgentRequest } from './request-handler';
 import { redactSecrets } from '../lib/secret-redact';
 import {
   validateRequest,
@@ -267,10 +268,13 @@ export class GatewayServer {
 
   // ── Internal ──────────────────────────────────────────────
 
-  /** Extract client IP from the HTTP upgrade request. */
+  /**
+   * Extract client IP from the HTTP upgrade request.
+   * Always uses the socket address — never trusts X-Forwarded-For since
+   * the gateway can be directly exposed (e.g. via Tailscale) and clients
+   * could spoof XFF to bypass rate limiting and per-IP connection limits.
+   */
   private getClientIp(req: http.IncomingMessage): string {
-    const forwarded = req.headers['x-forwarded-for'];
-    if (typeof forwarded === 'string') return forwarded.split(',')[0].trim();
     return req.socket.remoteAddress ?? 'unknown';
   }
 
@@ -364,7 +368,7 @@ export class GatewayServer {
         const raw = JSON.parse(data.toString());
         const request = validateRequest(raw);
         if (!request) {
-          this.send(ws, {
+          sendResponse(ws, {
             type: 'error',
             requestType: 'unknown',
             message: 'Invalid request format',
@@ -378,7 +382,7 @@ export class GatewayServer {
 
         await this.handleRequest(ws, client, request);
       } catch (err) {
-        this.send(ws, {
+        sendResponse(ws, {
           type: 'error',
           requestType: 'unknown',
           message: err instanceof Error ? redactSecrets(err.message) : 'Internal error',
@@ -407,7 +411,7 @@ export class GatewayServer {
       // Check rate limiter before validating token
       if (!this.authLimiter.check(client.remoteIp)) {
         console.warn(`[gateway] Auth rate-limited: ${client.remoteIp}`);
-        this.send(ws, {
+        sendResponse(ws, {
           type: 'error',
           requestType: 'connect',
           message: 'Too many authentication attempts. Try again later.',
@@ -420,7 +424,7 @@ export class GatewayServer {
         console.warn(
           `[gateway] Auth failed: ${client.remoteIp} (client type: ${request.clientType})`,
         );
-        this.send(ws, {
+        sendResponse(ws, {
           type: 'error',
           requestType: 'connect',
           message: 'Invalid authentication token',
@@ -438,13 +442,13 @@ export class GatewayServer {
       console.log(
         `[gateway] Client authenticated: ${client.clientType} (${client.clientId}) from ${client.remoteIp}`,
       );
-      this.send(ws, { type: 'ok', requestType: 'connect' });
+      sendResponse(ws, { type: 'ok', requestType: 'connect' });
       return;
     }
 
     // All other requests require authentication
     if (!client.authenticated) {
-      this.send(ws, {
+      sendResponse(ws, {
         type: 'error',
         requestType: request.type,
         message: 'Not authenticated. Send a connect request first.',
@@ -453,7 +457,7 @@ export class GatewayServer {
     }
 
     if (!this.agentOps) {
-      this.send(ws, {
+      sendResponse(ws, {
         type: 'error',
         requestType: request.type,
         message: 'Agent operations not available',
@@ -461,111 +465,12 @@ export class GatewayServer {
       return;
     }
 
-    switch (request.type) {
-      case 'prompt': {
-        try {
-          // Subscribe client to this session for push events
-          client.subscribedSessions.add(request.sessionId);
-          // Ensure session is open
-          await this.agentOps.openSession(
-            request.sessionId,
-            request.workspaceId,
-          );
-          // Send prompt
-          await this.agentOps.prompt(request.sessionId, request.text);
-          this.send(ws, { type: 'ok', requestType: 'prompt' });
-        } catch (err) {
-          this.send(ws, {
-            type: 'error',
-            requestType: 'prompt',
-            message: err instanceof Error ? err.message : 'Prompt failed',
-          });
-        }
-        break;
-      }
-
-      case 'steer': {
-        try {
-          await this.agentOps.steer(request.sessionId, request.text);
-          this.send(ws, { type: 'ok', requestType: 'steer' });
-        } catch (err) {
-          this.send(ws, {
-            type: 'error',
-            requestType: 'steer',
-            message: err instanceof Error ? err.message : 'Steer failed',
-          });
-        }
-        break;
-      }
-
-      case 'abort': {
-        try {
-          await this.agentOps.abort(request.sessionId);
-          this.send(ws, { type: 'ok', requestType: 'abort' });
-        } catch (err) {
-          this.send(ws, {
-            type: 'error',
-            requestType: 'abort',
-            message: err instanceof Error ? err.message : 'Abort failed',
-          });
-        }
-        break;
-      }
-
-      case 'status': {
-        this.send(ws, {
-          type: 'ok',
-          requestType: 'status',
-          data: this.getStatus(),
-        });
-        break;
-      }
-
-      case 'list_workspaces': {
-        try {
-          const workspaces = await this.agentOps.listWorkspaces();
-          this.send(ws, {
-            type: 'ok',
-            requestType: 'list_workspaces',
-            data: workspaces,
-          });
-        } catch (err) {
-          this.send(ws, {
-            type: 'error',
-            requestType: 'list_workspaces',
-            message:
-              err instanceof Error ? err.message : 'List workspaces failed',
-          });
-        }
-        break;
-      }
-
-      case 'list_sessions': {
-        try {
-          const sessions = await this.agentOps.listSessions(
-            request.workspaceId,
-          );
-          this.send(ws, {
-            type: 'ok',
-            requestType: 'list_sessions',
-            data: sessions,
-          });
-        } catch (err) {
-          this.send(ws, {
-            type: 'error',
-            requestType: 'list_sessions',
-            message:
-              err instanceof Error ? err.message : 'List sessions failed',
-          });
-        }
-        break;
-      }
-    }
-  }
-
-  private send(ws: WebSocket, msg: GatewayResponse): void {
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(msg));
-    }
+    await routeAgentRequest(
+      ws,
+      this.agentOps,
+      request,
+      (sessionId) => client.subscribedSessions.add(sessionId),
+      () => this.getStatus(),
+    );
   }
 }

--- a/apps/desktop/electron/gateway/index.ts
+++ b/apps/desktop/electron/gateway/index.ts
@@ -7,18 +7,49 @@
  *
  * Binds to localhost by default; Tailscale integration can optionally
  * expose it to a private tailnet.
+ *
+ * Security hardening (2026-03-09):
+ *   - Rate limiting on auth attempts (5 failures / 60s → 5min block)
+ *   - Max WebSocket payload size (1 MB)
+ *   - Max connections per IP (10) and total (50)
+ *   - Origin header validation for non-Tailscale connections
+ *   - 30-minute idle timeout for authenticated connections
+ *   - Referrer-Policy: no-referrer on all HTTP responses
+ *   - Failed auth logging with client IP
  */
 
 import { WebSocketServer, WebSocket } from 'ws';
 import http from 'http';
 
 import { GatewayAuth } from './auth';
+import { RateLimiter } from './rate-limiter';
+import { redactSecrets } from '../lib/secret-redact';
 import {
   validateRequest,
   type GatewayRequest,
   type GatewayResponse,
   type GatewayPushEvent,
 } from './protocol';
+
+// ── Constants ──────────────────────────────────────────────────
+
+/** Maximum WebSocket message payload (1 MB). */
+const MAX_PAYLOAD_BYTES = 1 * 1024 * 1024;
+/** Maximum total concurrent WebSocket connections. */
+const MAX_TOTAL_CONNECTIONS = 50;
+/** Maximum concurrent WebSocket connections per source IP. */
+const MAX_CONNECTIONS_PER_IP = 10;
+/** Idle timeout for authenticated connections (30 minutes). */
+const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+/** Auth timeout for unauthenticated connections (10 seconds). */
+const AUTH_TIMEOUT_MS = 10_000;
+/** Allowed origins for WebSocket connections (non-Tailscale). */
+const ALLOWED_ORIGINS = new Set([
+  'http://127.0.0.1:18800',
+  'http://localhost:18800',
+  'http://127.0.0.1:18801',
+  'http://localhost:18801',
+]);
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -45,6 +76,10 @@ interface ConnectedClient {
   authenticated: boolean;
   /** Session IDs this client is subscribed to for push events. */
   subscribedSessions: Set<string>;
+  /** Source IP address of the client. */
+  remoteIp: string;
+  /** Timestamp of last activity (for idle timeout). */
+  lastActivity: number;
 }
 
 /** Operations the gateway can delegate to the agent pool. */
@@ -81,6 +116,14 @@ export class GatewayServer {
   private agentOps: GatewayAgentOps | null = null;
   private config: GatewayConfig;
   private webChatHtml: WebChatHtmlProvider | null = null;
+  private idleCheckTimer: ReturnType<typeof setInterval> | null = null;
+
+  /** Rate limiter for auth attempts (5 failures / 60s → 5 min block). */
+  private authLimiter = new RateLimiter({
+    maxAttempts: 5,
+    windowMs: 60_000,
+    blockMs: 5 * 60_000,
+  });
 
   constructor(config: GatewayConfig) {
     this.config = config;
@@ -107,6 +150,10 @@ export class GatewayServer {
     if (this.wss) return;
 
     this.httpServer = http.createServer((req, res) => {
+      // Security: add Referrer-Policy to all responses
+      res.setHeader('Referrer-Policy', 'no-referrer');
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+
       const pathname = (req.url ?? '/').split('?')[0];
       if (this.webChatHtml && (pathname === '/' || pathname === '/index.html')) {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
@@ -119,12 +166,19 @@ export class GatewayServer {
         res.end('Not Found');
       }
     });
-    this.wss = new WebSocketServer({ server: this.httpServer });
 
-    this.wss.on('connection', (ws) => this.handleConnection(ws));
+    this.wss = new WebSocketServer({
+      server: this.httpServer,
+      maxPayload: MAX_PAYLOAD_BYTES,
+    });
+
+    this.wss.on('connection', (ws, req) => this.handleConnection(ws, req));
     this.wss.on('error', (err) => {
       console.error('[gateway] WebSocket server error:', err);
     });
+
+    // Start idle connection checker (every 5 minutes)
+    this.idleCheckTimer = setInterval(() => this.checkIdleConnections(), 5 * 60_000);
 
     return new Promise<void>((resolve, reject) => {
       this.httpServer!.listen(this.config.port, this.config.host, () => {
@@ -140,6 +194,12 @@ export class GatewayServer {
   /** Stop the gateway server and disconnect all clients. */
   async stop(): Promise<void> {
     if (!this.wss) return;
+
+    if (this.idleCheckTimer) {
+      clearInterval(this.idleCheckTimer);
+      this.idleCheckTimer = null;
+    }
+    this.authLimiter.dispose();
 
     for (const [ws] of this.clients) {
       ws.close(1001, 'Gateway shutting down');
@@ -207,13 +267,85 @@ export class GatewayServer {
 
   // ── Internal ──────────────────────────────────────────────
 
-  private handleConnection(ws: WebSocket): void {
+  /** Extract client IP from the HTTP upgrade request. */
+  private getClientIp(req: http.IncomingMessage): string {
+    const forwarded = req.headers['x-forwarded-for'];
+    if (typeof forwarded === 'string') return forwarded.split(',')[0].trim();
+    return req.socket.remoteAddress ?? 'unknown';
+  }
+
+  /** Count connections from a specific IP. */
+  private countConnectionsFromIp(ip: string): number {
+    let count = 0;
+    for (const [, client] of this.clients) {
+      if (client.remoteIp === ip) count++;
+    }
+    return count;
+  }
+
+  /** Validate the Origin header for non-localhost connections. */
+  private isOriginAllowed(req: http.IncomingMessage): boolean {
+    const origin = req.headers.origin;
+    // No origin header (non-browser clients like wscat, Discord bot) — allow
+    if (!origin) return true;
+    // Localhost connections are always allowed
+    if (ALLOWED_ORIGINS.has(origin)) return true;
+    // Tailscale origins (*.ts.net) are allowed
+    try {
+      const url = new URL(origin);
+      if (url.hostname.endsWith('.ts.net')) return true;
+    } catch {
+      // Invalid origin URL
+    }
+    return false;
+  }
+
+  /** Close idle authenticated connections. */
+  private checkIdleConnections(): void {
+    const now = Date.now();
+    for (const [ws, client] of this.clients) {
+      if (!client.authenticated) continue;
+      if (now - client.lastActivity > IDLE_TIMEOUT_MS) {
+        console.log(`[gateway] Closing idle connection: ${client.clientType} (${client.clientId})`);
+        ws.close(4008, 'Idle timeout');
+        this.clients.delete(ws);
+      }
+    }
+  }
+
+  private handleConnection(ws: WebSocket, req: http.IncomingMessage): void {
+    const remoteIp = this.getClientIp(req);
+
+    // Enforce total connection limit
+    if (this.clients.size >= MAX_TOTAL_CONNECTIONS) {
+      console.warn(`[gateway] Connection rejected: max total connections (${MAX_TOTAL_CONNECTIONS}) reached`);
+      ws.close(4029, 'Too many connections');
+      return;
+    }
+
+    // Enforce per-IP connection limit
+    if (this.countConnectionsFromIp(remoteIp) >= MAX_CONNECTIONS_PER_IP) {
+      console.warn(`[gateway] Connection rejected: max connections per IP (${MAX_CONNECTIONS_PER_IP}) reached for ${remoteIp}`);
+      ws.close(4029, 'Too many connections from this IP');
+      return;
+    }
+
+    // Validate Origin header
+    if (!this.isOriginAllowed(req)) {
+      const origin = req.headers.origin ?? 'unknown';
+      console.warn(`[gateway] Connection rejected: unauthorized origin "${origin}" from ${remoteIp}`);
+      ws.close(4003, 'Origin not allowed');
+      return;
+    }
+
     const client: ConnectedClient = {
       ws,
       clientType: 'unknown',
       clientId: `client-${Date.now()}`,
       authenticated: false,
       subscribedSessions: new Set(),
+      remoteIp,
+      lastActivity: Date.now(),
     };
     this.clients.set(ws, client);
 
@@ -223,9 +355,11 @@ export class GatewayServer {
         ws.close(4001, 'Authentication timeout');
         this.clients.delete(ws);
       }
-    }, 10_000);
+    }, AUTH_TIMEOUT_MS);
 
     ws.on('message', async (data) => {
+      client.lastActivity = Date.now();
+
       try {
         const raw = JSON.parse(data.toString());
         const request = validateRequest(raw);
@@ -247,7 +381,7 @@ export class GatewayServer {
         this.send(ws, {
           type: 'error',
           requestType: 'unknown',
-          message: err instanceof Error ? err.message : 'Internal error',
+          message: err instanceof Error ? redactSecrets(err.message) : 'Internal error',
         });
       }
     });
@@ -270,7 +404,22 @@ export class GatewayServer {
   ): Promise<void> {
     // Connect / auth is always allowed
     if (request.type === 'connect') {
+      // Check rate limiter before validating token
+      if (!this.authLimiter.check(client.remoteIp)) {
+        console.warn(`[gateway] Auth rate-limited: ${client.remoteIp}`);
+        this.send(ws, {
+          type: 'error',
+          requestType: 'connect',
+          message: 'Too many authentication attempts. Try again later.',
+        });
+        ws.close(4029, 'Rate limited');
+        return;
+      }
+
       if (!this.auth.validate(request.token)) {
+        console.warn(
+          `[gateway] Auth failed: ${client.remoteIp} (client type: ${request.clientType})`,
+        );
         this.send(ws, {
           type: 'error',
           requestType: 'connect',
@@ -279,11 +428,15 @@ export class GatewayServer {
         ws.close(4003, 'Authentication failed');
         return;
       }
+
+      // Successful auth — reset rate limiter for this IP
+      this.authLimiter.reset(client.remoteIp);
+
       client.authenticated = true;
       client.clientType = request.clientType;
       if (request.clientId) client.clientId = request.clientId;
       console.log(
-        `[gateway] Client authenticated: ${client.clientType} (${client.clientId})`,
+        `[gateway] Client authenticated: ${client.clientType} (${client.clientId}) from ${client.remoteIp}`,
       );
       this.send(ws, { type: 'ok', requestType: 'connect' });
       return;

--- a/apps/desktop/electron/gateway/rate-limiter.ts
+++ b/apps/desktop/electron/gateway/rate-limiter.ts
@@ -61,8 +61,9 @@ export class RateLimiter {
     // Record this attempt
     entry.attempts.push(now);
 
-    // Check if limit exceeded
-    if (entry.attempts.length > this.config.maxAttempts) {
+    // Check if limit exceeded — block when attempts reach maxAttempts
+    // (e.g. maxAttempts: 5 means the 5th failed attempt triggers a block)
+    if (entry.attempts.length >= this.config.maxAttempts) {
       entry.blockedUntil = now + this.config.blockMs;
       return false;
     }

--- a/apps/desktop/electron/gateway/rate-limiter.ts
+++ b/apps/desktop/electron/gateway/rate-limiter.ts
@@ -1,0 +1,106 @@
+/**
+ * Rate limiter for gateway authentication and request throttling.
+ *
+ * Uses a sliding-window counter per key (typically client IP).
+ * After `maxAttempts` within `windowMs`, the key is blocked for `blockMs`.
+ */
+
+export interface RateLimiterConfig {
+  /** Maximum attempts within the time window before blocking. */
+  maxAttempts: number;
+  /** Time window in milliseconds. */
+  windowMs: number;
+  /** Block duration in milliseconds after limit is exceeded. */
+  blockMs: number;
+}
+
+interface RateLimitEntry {
+  /** Timestamps of recent attempts within the window. */
+  attempts: number[];
+  /** If set, the key is blocked until this timestamp. */
+  blockedUntil: number | null;
+}
+
+export class RateLimiter {
+  private entries = new Map<string, RateLimitEntry>();
+  private cleanupTimer: ReturnType<typeof setInterval>;
+
+  constructor(private config: RateLimiterConfig) {
+    // Periodically clean up stale entries to prevent memory leaks
+    this.cleanupTimer = setInterval(() => this.cleanup(), 60_000);
+  }
+
+  /**
+   * Check if a key is allowed to proceed. Records the attempt.
+   * Returns `true` if allowed, `false` if rate-limited.
+   */
+  check(key: string): boolean {
+    const now = Date.now();
+    let entry = this.entries.get(key);
+
+    if (!entry) {
+      entry = { attempts: [], blockedUntil: null };
+      this.entries.set(key, entry);
+    }
+
+    // Check if currently blocked
+    if (entry.blockedUntil && now < entry.blockedUntil) {
+      return false;
+    }
+
+    // Clear expired block
+    if (entry.blockedUntil && now >= entry.blockedUntil) {
+      entry.blockedUntil = null;
+      entry.attempts = [];
+    }
+
+    // Remove attempts outside the window
+    const windowStart = now - this.config.windowMs;
+    entry.attempts = entry.attempts.filter((t) => t > windowStart);
+
+    // Record this attempt
+    entry.attempts.push(now);
+
+    // Check if limit exceeded
+    if (entry.attempts.length > this.config.maxAttempts) {
+      entry.blockedUntil = now + this.config.blockMs;
+      return false;
+    }
+
+    return true;
+  }
+
+  /** Check if a key is currently blocked (without recording an attempt). */
+  isBlocked(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry?.blockedUntil) return false;
+    return Date.now() < entry.blockedUntil;
+  }
+
+  /** Reset a specific key (e.g. after successful auth). */
+  reset(key: string): void {
+    this.entries.delete(key);
+  }
+
+  /** Remove stale entries that are no longer blocked and have no recent attempts. */
+  private cleanup(): void {
+    const now = Date.now();
+    const windowStart = now - this.config.windowMs;
+
+    for (const [key, entry] of this.entries) {
+      if (entry.blockedUntil && now >= entry.blockedUntil) {
+        this.entries.delete(key);
+        continue;
+      }
+      const recentAttempts = entry.attempts.filter((t) => t > windowStart);
+      if (recentAttempts.length === 0 && !entry.blockedUntil) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  dispose(): void {
+    clearInterval(this.cleanupTimer);
+    this.entries.clear();
+  }
+}

--- a/apps/desktop/electron/gateway/request-handler.ts
+++ b/apps/desktop/electron/gateway/request-handler.ts
@@ -1,0 +1,124 @@
+/**
+ * Gateway request handler — processes authenticated client requests.
+ *
+ * Extracted from gateway/index.ts to keep file sizes under 500 LOC.
+ * Handles prompt, steer, abort, status, list_workspaces, list_sessions.
+ */
+
+import { WebSocket } from 'ws';
+import type { GatewayRequest, GatewayResponse } from './protocol';
+import type { GatewayAgentOps } from './index';
+
+/** Send a JSON response to a WebSocket client. */
+export function sendResponse(ws: WebSocket, msg: GatewayResponse): void {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(msg));
+  }
+}
+
+/**
+ * Route an authenticated request to the appropriate agent operation.
+ * Returns true if the request was handled, false if auth/guard checks
+ * should be applied by the caller.
+ */
+export async function routeAgentRequest(
+  ws: WebSocket,
+  agentOps: GatewayAgentOps,
+  request: GatewayRequest,
+  subscribeToSession: (sessionId: string) => void,
+  getStatus: () => { running: boolean; port: number; host: string; clients: number },
+): Promise<void> {
+  switch (request.type) {
+    case 'prompt': {
+      try {
+        // Subscribe client to this session for push events
+        subscribeToSession(request.sessionId);
+        // Ensure session is open
+        await agentOps.openSession(request.sessionId, request.workspaceId);
+        // Send prompt
+        await agentOps.prompt(request.sessionId, request.text);
+        sendResponse(ws, { type: 'ok', requestType: 'prompt' });
+      } catch (err) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'prompt',
+          message: err instanceof Error ? err.message : 'Prompt failed',
+        });
+      }
+      break;
+    }
+
+    case 'steer': {
+      try {
+        await agentOps.steer(request.sessionId, request.text);
+        sendResponse(ws, { type: 'ok', requestType: 'steer' });
+      } catch (err) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'steer',
+          message: err instanceof Error ? err.message : 'Steer failed',
+        });
+      }
+      break;
+    }
+
+    case 'abort': {
+      try {
+        await agentOps.abort(request.sessionId);
+        sendResponse(ws, { type: 'ok', requestType: 'abort' });
+      } catch (err) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'abort',
+          message: err instanceof Error ? err.message : 'Abort failed',
+        });
+      }
+      break;
+    }
+
+    case 'status': {
+      sendResponse(ws, {
+        type: 'ok',
+        requestType: 'status',
+        data: getStatus(),
+      });
+      break;
+    }
+
+    case 'list_workspaces': {
+      try {
+        const workspaces = await agentOps.listWorkspaces();
+        sendResponse(ws, {
+          type: 'ok',
+          requestType: 'list_workspaces',
+          data: workspaces,
+        });
+      } catch (err) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'list_workspaces',
+          message: err instanceof Error ? err.message : 'List workspaces failed',
+        });
+      }
+      break;
+    }
+
+    case 'list_sessions': {
+      try {
+        const sessions = await agentOps.listSessions(request.workspaceId);
+        sendResponse(ws, {
+          type: 'ok',
+          requestType: 'list_sessions',
+          data: sessions,
+        });
+      } catch (err) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'list_sessions',
+          message: err instanceof Error ? err.message : 'List sessions failed',
+        });
+      }
+      break;
+    }
+  }
+}

--- a/apps/desktop/electron/google/auth-manager.ts
+++ b/apps/desktop/electron/google/auth-manager.ts
@@ -13,7 +13,7 @@ import http from 'node:http';
 import crypto from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { execFile } from 'node:child_process';
-import { homedir } from 'node:os';
+import { homedir, hostname, userInfo } from 'node:os';
 import path from 'node:path';
 
 // ── Lazy env access ──────────────────────────────────────────
@@ -54,15 +54,33 @@ function findGog(): string {
   return paths.find((p) => existsSync(p)) ?? 'gog';
 }
 
+/**
+ * Derive a machine-specific keyring password instead of using a hardcoded value.
+ * Combines hostname, uid, and a salt so the password varies per machine/user.
+ */
+function deriveKeyringPassword(): string {
+  const host = hostname();
+  let uid: string;
+  try {
+    uid = String(userInfo().uid);
+  } catch {
+    uid = 'unknown';
+  }
+  return crypto.createHash('sha256')
+    .update(`sero-google-keyring:${host}:${uid}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
 function gogEnv(): NodeJS.ProcessEnv {
   const extra = ['/opt/homebrew/bin', '/usr/local/bin',
     path.join(homedir(), '.local/bin'), path.join(homedir(), 'go/bin')];
   return {
     ...process.env,
     PATH: [...extra, process.env.PATH || ''].join(':'),
-    // File-based keyring (no macOS Keychain prompts). Password is fixed
-    // because the file lives in a user-only directory anyway.
-    GOG_KEYRING_PASSWORD: 'sero-google-keyring',
+    // File-based keyring (no macOS Keychain prompts). Password is derived
+    // from machine-specific data so it's not trivially guessable.
+    GOG_KEYRING_PASSWORD: deriveKeyringPassword(),
   };
 }
 

--- a/apps/desktop/electron/google/auth-manager.ts
+++ b/apps/desktop/electron/google/auth-manager.ts
@@ -57,6 +57,12 @@ function findGog(): string {
 /**
  * Derive a machine-specific keyring password instead of using a hardcoded value.
  * Combines hostname, uid, and a salt so the password varies per machine/user.
+ *
+ * NOTE: This is defense-in-depth, not a real secret — hostname and uid are
+ * both easily discoverable by any local user. The primary protection is
+ * file permissions on the keyring file itself (user-only directory).
+ * TODO: Consider using Electron safeStorage or macOS Keychain for the
+ * keyring password if stronger isolation is needed.
  */
 function deriveKeyringPassword(): string {
   const host = hostname();

--- a/apps/desktop/electron/ipc/editor.ts
+++ b/apps/desktop/electron/ipc/editor.ts
@@ -11,7 +11,7 @@
 
 import { ipcMain } from 'electron';
 import { promises as fs } from 'fs';
-import { existsSync, mkdirSync } from 'fs';
+import { existsSync, mkdirSync, realpathSync } from 'fs';
 import path from 'path';
 import { IpcChannels } from '../../src/types/ipc';
 import { containerManager, workspaceManager } from './shared-infra';
@@ -33,14 +33,28 @@ function editorStatePath(workspaceId: string): string {
 
 const WORKSPACE_PREFIX = '/workspace';
 
+/** Maximum allowed path length (prevents DoS via absurdly long paths). */
+const MAX_PATH_LENGTH = 4096;
+
 /**
  * Translate a /workspace-prefixed path to an absolute host path.
  * If the path doesn't start with /workspace, treat it as relative.
  *
  * **Security:** The resolved path is checked against the workspace root.
- * Throws if the result escapes the workspace (e.g. via `..` traversal).
+ * Throws if the result escapes the workspace (e.g. via `..` traversal,
+ * symlink escapes, null bytes, or excessively long paths).
  */
 function toHostPath(workspacePath: string, filePath: string): string {
+  // Reject null bytes (could truncate path in native code)
+  if (filePath.includes('\0')) {
+    throw new Error('Path contains null bytes');
+  }
+
+  // Reject excessively long paths
+  if (filePath.length > MAX_PATH_LENGTH) {
+    throw new Error(`Path too long (max ${MAX_PATH_LENGTH} characters)`);
+  }
+
   let raw: string;
   if (filePath.startsWith(WORKSPACE_PREFIX)) {
     const relative = filePath.slice(WORKSPACE_PREFIX.length);
@@ -54,6 +68,27 @@ function toHostPath(workspacePath: string, filePath: string): string {
   if (!resolved.startsWith(root + path.sep) && resolved !== root) {
     throw new Error(`Path escapes workspace: ${filePath}`);
   }
+
+  // Resolve symlinks to catch symlink escape attacks
+  // (e.g., a symlink inside workspace pointing to /etc/)
+  try {
+    const realResolved = realpathSync(resolved);
+    const realRoot = realpathSync(root);
+    if (!realResolved.startsWith(realRoot + path.sep) && realResolved !== realRoot) {
+      throw new Error(`Symlink escapes workspace: ${filePath}`);
+    }
+  } catch (err) {
+    // If the file doesn't exist yet (e.g., write to new file), realpathSync
+    // will throw ENOENT. In that case, the resolve() check above is sufficient.
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // File doesn't exist yet — the path.resolve check is sufficient
+    } else if (err instanceof Error && err.message.includes('escapes workspace')) {
+      throw err;
+    }
+    // Other errors (permission denied, etc.) — allow the operation to proceed
+    // and let the actual fs operation handle the error
+  }
+
   return resolved;
 }
 

--- a/apps/desktop/electron/ipc/net.ts
+++ b/apps/desktop/electron/ipc/net.ts
@@ -21,11 +21,15 @@ const dnsLookup = promisify(dns.lookup);
 
 // ── SSRF protection ──────────────────────────────────────────
 
-/** Headers that should not be forwarded from renderer requests. */
+/**
+ * Headers that affect routing and should not be forwarded.
+ * Note: `authorization` and `cookie` are intentionally NOT blocked —
+ * renderer apps (e.g. Starling Bank) legitimately send auth headers
+ * to external APIs. SSRF is mitigated by private IP blocking, not
+ * header stripping.
+ */
 const BLOCKED_HEADERS = new Set([
   'host',
-  'cookie',
-  'authorization',
   'proxy-authorization',
 ]);
 
@@ -50,11 +54,16 @@ function isPrivateIp(ip: string): boolean {
 }
 
 /**
- * Validate a URL for SSRF safety:
- *  - Must be http: or https:
- *  - Hostname must not resolve to a private IP
+ * Resolve hostname and validate for SSRF safety.
+ * Returns the resolved IP address so the caller can pin it (preventing
+ * DNS rebinding / TOCTOU attacks where a second resolution returns a
+ * different IP).
+ *
+ * Checks:
+ *  - Protocol must be http: or https:
+ *  - Hostname must not resolve to a private/reserved IP
  */
-async function validateUrlForSsrf(urlStr: string): Promise<void> {
+async function validateAndResolve(urlStr: string): Promise<{ parsed: URL; resolvedIp: string | null }> {
   let parsed: URL;
   try {
     parsed = new URL(urlStr);
@@ -67,23 +76,26 @@ async function validateUrlForSsrf(urlStr: string): Promise<void> {
     throw new Error(`Blocked protocol: ${parsed.protocol}`);
   }
 
-  // Resolve hostname to check for private IPs
   const hostname = parsed.hostname;
 
-  // Direct IP check (no DNS needed)
+  // Direct IP literal check (no DNS needed)
   if (isPrivateIp(hostname)) {
     throw new Error(`Blocked request to private IP: ${hostname}`);
   }
 
-  // DNS resolution check — hostname may resolve to a private IP
+  // DNS resolution check — hostname may resolve to a private IP.
+  // We return the resolved IP so the caller can pin it in the fetch
+  // request, preventing DNS rebinding attacks.
   try {
     const { address } = await dnsLookup(hostname);
     if (isPrivateIp(address)) {
       throw new Error(`Blocked request: hostname "${hostname}" resolves to private IP ${address}`);
     }
+    return { parsed, resolvedIp: address };
   } catch (err) {
     if (err instanceof Error && err.message.startsWith('Blocked')) throw err;
     // DNS lookup failed — allow the request to proceed and let fetch handle the error
+    return { parsed, resolvedIp: null };
   }
 }
 
@@ -106,12 +118,29 @@ export function registerNetHandlers(): void {
     async (_event, request: ProxyFetchRequest): Promise<ProxyFetchResponse> => {
       const { url, method = 'GET', headers = {}, body } = request;
 
-      // SSRF protection: validate URL before making request
-      await validateUrlForSsrf(url);
+      // SSRF protection: validate URL and resolve hostname.
+      // We get back the resolved IP to pin it, preventing DNS rebinding
+      // attacks where a second resolution returns a private IP.
+      const { parsed, resolvedIp } = await validateAndResolve(url);
 
       const sanitizedHeaders = sanitizeHeaders(headers);
 
-      const res = await fetch(url, {
+      // Pin the resolved IP to prevent DNS rebinding: replace the
+      // hostname with the validated IP so fetch() doesn't re-resolve.
+      // For HTTPS, we can't replace the hostname (TLS cert validation
+      // requires the original domain), but DNS rebinding to private IPs
+      // over HTTPS is impractical since the attacker would also need a
+      // valid TLS cert for the private IP — a much higher bar.
+      let fetchUrl = url;
+      if (resolvedIp && parsed.protocol === 'http:') {
+        const originalHost = parsed.host;
+        parsed.hostname = resolvedIp;
+        fetchUrl = parsed.toString();
+        // Set Host header so the target server sees the original hostname
+        sanitizedHeaders['host'] = originalHost;
+      }
+
+      const res = await fetch(fetchUrl, {
         method,
         headers: sanitizedHeaders,
         body: body ?? undefined,

--- a/apps/desktop/electron/ipc/net.ts
+++ b/apps/desktop/electron/ipc/net.ts
@@ -4,11 +4,101 @@
  * Proxies HTTP requests from the renderer through the main process,
  * bypassing browser CORS restrictions. Sero apps that call external
  * APIs (e.g. Starling Bank) use this instead of direct fetch().
+ *
+ * Security hardening (2026-03-09):
+ *   - SSRF protection: blocks requests to private/reserved IP ranges
+ *   - Protocol allowlist: only http: and https: are permitted
+ *   - Sensitive header sanitization
  */
 
 import { ipcMain } from 'electron';
 import { IpcChannels } from '../../src/types/ipc';
 import type { ProxyFetchRequest, ProxyFetchResponse } from '../../src/types/ipc';
+import dns from 'dns';
+import { promisify } from 'util';
+
+const dnsLookup = promisify(dns.lookup);
+
+// ── SSRF protection ──────────────────────────────────────────
+
+/** Headers that should not be forwarded from renderer requests. */
+const BLOCKED_HEADERS = new Set([
+  'host',
+  'cookie',
+  'authorization',
+  'proxy-authorization',
+]);
+
+/**
+ * Check if an IP address belongs to a private/reserved range.
+ * Blocks: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8,
+ *         169.254.0.0/16 (link-local), 0.0.0.0, ::1, fc00::/7
+ */
+function isPrivateIp(ip: string): boolean {
+  // IPv4 private ranges
+  if (/^10\./.test(ip)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+  if (/^192\.168\./.test(ip)) return true;
+  if (/^127\./.test(ip)) return true;
+  if (/^169\.254\./.test(ip)) return true;
+  if (ip === '0.0.0.0') return true;
+  // IPv6 loopback and private
+  if (ip === '::1' || ip === '::') return true;
+  if (/^f[cd]/i.test(ip)) return true;
+  if (/^fe80:/i.test(ip)) return true;
+  return false;
+}
+
+/**
+ * Validate a URL for SSRF safety:
+ *  - Must be http: or https:
+ *  - Hostname must not resolve to a private IP
+ */
+async function validateUrlForSsrf(urlStr: string): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+
+  // Protocol allowlist
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`Blocked protocol: ${parsed.protocol}`);
+  }
+
+  // Resolve hostname to check for private IPs
+  const hostname = parsed.hostname;
+
+  // Direct IP check (no DNS needed)
+  if (isPrivateIp(hostname)) {
+    throw new Error(`Blocked request to private IP: ${hostname}`);
+  }
+
+  // DNS resolution check — hostname may resolve to a private IP
+  try {
+    const { address } = await dnsLookup(hostname);
+    if (isPrivateIp(address)) {
+      throw new Error(`Blocked request: hostname "${hostname}" resolves to private IP ${address}`);
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.startsWith('Blocked')) throw err;
+    // DNS lookup failed — allow the request to proceed and let fetch handle the error
+  }
+}
+
+/** Sanitize request headers — remove sensitive headers. */
+function sanitizeHeaders(headers: Record<string, string>): Record<string, string> {
+  const sanitized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (!BLOCKED_HEADERS.has(key.toLowerCase())) {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+// ── Registration ─────────────────────────────────────────────
 
 export function registerNetHandlers(): void {
   ipcMain.handle(
@@ -16,9 +106,14 @@ export function registerNetHandlers(): void {
     async (_event, request: ProxyFetchRequest): Promise<ProxyFetchResponse> => {
       const { url, method = 'GET', headers = {}, body } = request;
 
+      // SSRF protection: validate URL before making request
+      await validateUrlForSsrf(url);
+
+      const sanitizedHeaders = sanitizeHeaders(headers);
+
       const res = await fetch(url, {
         method,
-        headers,
+        headers: sanitizedHeaders,
         body: body ?? undefined,
       });
 

--- a/apps/desktop/electron/ipc/safe-storage.ts
+++ b/apps/desktop/electron/ipc/safe-storage.ts
@@ -8,20 +8,49 @@
  * same machine, by the same user, running this app.
  *
  * Used by Sero apps (e.g. Starling Bank) to securely store API tokens.
+ *
+ * Security note: when OS encryption is unavailable (e.g., Linux without
+ * libsecret), falls back to base64 encoding which is NOT secure. A
+ * warning is logged and broadcast to the renderer via IPC.
  */
 
-import { ipcMain, safeStorage } from 'electron';
+import { ipcMain, safeStorage, BrowserWindow } from 'electron';
 import { IpcChannels } from '../../src/types/ipc';
+
+let base64FallbackWarned = false;
+
+/** Log and broadcast a warning when encryption is unavailable. */
+function warnBase64Fallback(): void {
+  if (base64FallbackWarned) return;
+  base64FallbackWarned = true;
+
+  console.warn(
+    '[security] WARNING: OS encryption (safeStorage) is unavailable. ' +
+    'Credentials will be stored with base64 encoding only, which is NOT secure. ' +
+    'On Linux, install libsecret (gnome-keyring or KWallet) to enable encryption.',
+  );
+
+  // Notify all renderer windows so the UI can show a persistent warning
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send('sero:security-warning', {
+      type: 'encryption-unavailable',
+      message: 'OS keychain encryption is unavailable. Credentials are stored insecurely.',
+    });
+  }
+}
 
 export function registerSafeStorageHandlers(): void {
   ipcMain.handle(IpcChannels.safeStorage.available, (): boolean => {
-    return safeStorage.isEncryptionAvailable();
+    const available = safeStorage.isEncryptionAvailable();
+    if (!available) warnBase64Fallback();
+    return available;
   });
 
   ipcMain.handle(
     IpcChannels.safeStorage.encrypt,
     (_event, plaintext: string): string => {
       if (!safeStorage.isEncryptionAvailable()) {
+        warnBase64Fallback();
         // Fallback: base64 only (not secure, but doesn't crash)
         return Buffer.from(plaintext, 'utf8').toString('base64');
       }
@@ -34,6 +63,7 @@ export function registerSafeStorageHandlers(): void {
     (_event, encryptedBase64: string): string => {
       const buffer = Buffer.from(encryptedBase64, 'base64');
       if (!safeStorage.isEncryptionAvailable()) {
+        warnBase64Fallback();
         // Fallback: base64 only
         return buffer.toString('utf8');
       }

--- a/apps/desktop/electron/lib/secret-redact.ts
+++ b/apps/desktop/electron/lib/secret-redact.ts
@@ -6,19 +6,25 @@
  * events before they are displayed or persisted.
  */
 
-/** Known API key prefixes and their provider names. */
+/**
+ * Known API key prefixes and their provider names.
+ * Patterns are ordered most-specific → least-specific so that
+ * specific prefixes (sk-ant-, sk-proj-, sk-or-) match before any
+ * generic fallback. The old generic `sk-[A-Za-z0-9]{20,}` pattern
+ * was removed because it caused false-positive redaction of non-secret
+ * strings that happen to start with "sk-".
+ */
 const SECRET_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
   // Anthropic API keys (sk-ant-api03-...)
   { pattern: /sk-ant-[A-Za-z0-9_-]{20,}/g, label: 'ANTHROPIC_KEY' },
-  // OpenAI API keys (sk-proj-... or sk-...)
+  // OpenAI API keys (sk-proj-...)
   { pattern: /sk-proj-[A-Za-z0-9_-]{20,}/g, label: 'OPENAI_KEY' },
-  { pattern: /sk-[A-Za-z0-9]{20,}/g, label: 'API_KEY' },
+  // OpenRouter keys (sk-or-...)
+  { pattern: /sk-or-[A-Za-z0-9_-]{20,}/g, label: 'OPENROUTER_KEY' },
   // GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
   { pattern: /gh[pousr]_[A-Za-z0-9_]{30,}/g, label: 'GITHUB_TOKEN' },
   // Google API keys (AIza...)
   { pattern: /AIza[A-Za-z0-9_-]{30,}/g, label: 'GOOGLE_KEY' },
-  // OpenRouter keys (sk-or-...)
-  { pattern: /sk-or-[A-Za-z0-9_-]{20,}/g, label: 'OPENROUTER_KEY' },
   // xAI keys (xai-...)
   { pattern: /xai-[A-Za-z0-9_-]{20,}/g, label: 'XAI_KEY' },
   // Generic bearer tokens in header-like strings

--- a/apps/desktop/electron/lib/secret-redact.ts
+++ b/apps/desktop/electron/lib/secret-redact.ts
@@ -1,0 +1,57 @@
+/**
+ * Secret redaction utility — scans strings for known API key and token
+ * patterns and replaces them with a redacted placeholder.
+ *
+ * Used to sanitize log output, error messages, and agent text_delta
+ * events before they are displayed or persisted.
+ */
+
+/** Known API key prefixes and their provider names. */
+const SECRET_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+  // Anthropic API keys (sk-ant-api03-...)
+  { pattern: /sk-ant-[A-Za-z0-9_-]{20,}/g, label: 'ANTHROPIC_KEY' },
+  // OpenAI API keys (sk-proj-... or sk-...)
+  { pattern: /sk-proj-[A-Za-z0-9_-]{20,}/g, label: 'OPENAI_KEY' },
+  { pattern: /sk-[A-Za-z0-9]{20,}/g, label: 'API_KEY' },
+  // GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
+  { pattern: /gh[pousr]_[A-Za-z0-9_]{30,}/g, label: 'GITHUB_TOKEN' },
+  // Google API keys (AIza...)
+  { pattern: /AIza[A-Za-z0-9_-]{30,}/g, label: 'GOOGLE_KEY' },
+  // OpenRouter keys (sk-or-...)
+  { pattern: /sk-or-[A-Za-z0-9_-]{20,}/g, label: 'OPENROUTER_KEY' },
+  // xAI keys (xai-...)
+  { pattern: /xai-[A-Za-z0-9_-]{20,}/g, label: 'XAI_KEY' },
+  // Generic bearer tokens in header-like strings
+  { pattern: /Bearer [A-Za-z0-9_.-]{20,}/g, label: 'BEARER_TOKEN' },
+  // Generic long hex strings that look like tokens (64+ hex chars)
+  { pattern: /\b[0-9a-f]{64,}\b/gi, label: 'HEX_TOKEN' },
+];
+
+/**
+ * Redact known secret patterns from a string.
+ * Returns the string with secrets replaced by `[REDACTED:<label>]`.
+ */
+export function redactSecrets(input: string): string {
+  let result = input;
+  for (const { pattern, label } of SECRET_PATTERNS) {
+    // Reset lastIndex since we reuse RegExp objects with /g flag
+    pattern.lastIndex = 0;
+    result = result.replace(pattern, `[REDACTED:${label}]`);
+  }
+  return result;
+}
+
+/**
+ * Create a redacting console wrapper for use in security-sensitive contexts.
+ * Wraps console.log/warn/error to redact secrets before output.
+ */
+export function createRedactingLogger(prefix: string) {
+  return {
+    log: (...args: unknown[]) =>
+      console.log(prefix, ...args.map((a) => (typeof a === 'string' ? redactSecrets(a) : a))),
+    warn: (...args: unknown[]) =>
+      console.warn(prefix, ...args.map((a) => (typeof a === 'string' ? redactSecrets(a) : a))),
+    error: (...args: unknown[]) =>
+      console.error(prefix, ...args.map((a) => (typeof a === 'string' ? redactSecrets(a) : a))),
+  };
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -157,16 +157,50 @@ function createWindow() {
     }
   });
 
+  // ── Security: navigation restrictions ──────────────────────────
+  // Block navigation to untrusted origins. Only allow the dev server
+  // and the production renderer HTML. All other navigation attempts
+  // (e.g., from XSS or malicious content) are blocked.
+  mainWindow.webContents.on('will-navigate', (event, navigationUrl) => {
+    const allowedOrigins = ['http://localhost:5173'];
+    try {
+      const parsed = new URL(navigationUrl);
+      const origin = parsed.origin;
+      if (!allowedOrigins.includes(origin) && parsed.protocol !== 'file:') {
+        console.warn(`[security] Blocked navigation to untrusted origin: ${navigationUrl}`);
+        event.preventDefault();
+      }
+    } catch {
+      event.preventDefault();
+    }
+  });
+
   // Open external links (target="_blank", href to external domains) in the
   // system browser instead of a new Electron window. This ensures the user's
   // existing browser session (GitHub login, etc.) is used.
+  // Also blocks file:// and other dangerous protocols from opening new windows.
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('http://') || url.startsWith('https://')) {
       void shell.openExternal(url);
-      return { action: 'deny' };
     }
-    return { action: 'allow' };
+    // Always deny new windows — external links open in system browser
+    return { action: 'deny' };
   });
+
+  // ── Security: deny unnecessary permissions ──────────────────
+  // Block permission requests for capabilities Sero doesn't need.
+  // Only media (for Spotify) is allowed.
+  const allowedPermissions = new Set(['media']);
+  mainWindow.webContents.session.setPermissionRequestHandler(
+    (_webContents, permission, callback) => {
+      if (allowedPermissions.has(permission)) {
+        callback(true);
+      } else {
+        console.warn(`[security] Denied permission request: ${permission}`);
+        callback(false);
+      }
+    },
+  );
 
   // Give the file watcher manager access to the window for push events
   fileWatcherManager.setWindow(mainWindow);

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,17 +159,19 @@ function createWindow() {
 
   // ── Security: navigation restrictions ──────────────────────────
   // Block navigation to untrusted origins. Only allow the dev server
-  // and the production renderer HTML. All other navigation attempts
-  // (e.g., from XSS or malicious content) are blocked.
+  // (in development) and the production renderer HTML (file: protocol).
+  // All other navigation attempts (e.g., from XSS or malicious content)
+  // are blocked.
+  const isDev = process.env.NODE_ENV === 'development';
   mainWindow.webContents.on('will-navigate', (event, navigationUrl) => {
-    const allowedOrigins = ['http://localhost:5173'];
     try {
       const parsed = new URL(navigationUrl);
-      const origin = parsed.origin;
-      if (!allowedOrigins.includes(origin) && parsed.protocol !== 'file:') {
-        console.warn(`[security] Blocked navigation to untrusted origin: ${navigationUrl}`);
-        event.preventDefault();
-      }
+      // Production: only file: protocol (local renderer HTML) is allowed
+      if (parsed.protocol === 'file:') return;
+      // Development: allow the Vite dev server origin
+      if (isDev && parsed.origin === 'http://localhost:5173') return;
+      console.warn(`[security] Blocked navigation to untrusted origin: ${navigationUrl}`);
+      event.preventDefault();
     } catch {
       event.preventDefault();
     }

--- a/docs/security/outstanding-hardening.md
+++ b/docs/security/outstanding-hardening.md
@@ -1,0 +1,329 @@
+# Security Hardening — Outstanding Items
+
+> **Date:** 2026-03-09
+> **Status:** 13 of 19 findings from the initial audit have been fixed.
+> This document details the 6 remaining open items with implementation
+> requirements, affected files, and suggested approaches.
+
+---
+
+## 1. Per-Workspace Access Control on Gateway
+
+**Finding:** F-03 (Critical) — Flat access model: any authenticated gateway
+client can access ALL workspaces and ALL sessions.
+
+**Risk:** A compromised web-chat session or Discord channel can read/modify
+any workspace, not just the one it was intended for.
+
+### Current Behaviour
+
+- A single 32-byte token (`~/.sero-ui/gateway-token`) grants access to
+  everything.
+- `GatewayConnectRequest` accepts `clientType` and `clientId` but no
+  workspace scope.
+- `handleRequest()` in `gateway/index.ts` routes `prompt`, `steer`,
+  `abort`, `list_sessions` to any `workspaceId` the client provides.
+
+### What Needs to Change
+
+1. **Token scoping model** — Replace the single token with per-workspace
+   tokens, or add a scope claim:
+   - Option A: **Multi-token file** — `gateway-tokens.json` maps
+     `{ workspaceId: token }`. The `connect` request includes a
+     `workspaceScope` field. `GatewayAuth.validate()` returns the
+     allowed workspace IDs.
+   - Option B: **JWT-style scoped tokens** — Sign a JWT with
+     `{ sub: clientId, workspaces: ["ws-1", "ws-2"], exp: ... }`.
+     Validate signature + claims on connect. More complex but supports
+     expiry and revocation.
+   - Recommendation: **Option A** for simplicity. Sero is single-user;
+     JWT is overkill.
+
+2. **Enforce scope in `handleRequest()`** — After auth, store allowed
+   workspace IDs on the `ConnectedClient`. Reject `prompt`,
+   `list_sessions`, and `steer`/`abort` if the `workspaceId` is not in
+   the client's scope.
+
+3. **Update `list_workspaces`** — Filter results to only return
+   workspaces the client is authorized for.
+
+4. **Update Discord adapter** — `DiscordAdapterConfig.defaultWorkspaceId`
+   should be the only workspace the Discord token is scoped to.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `electron/gateway/auth.ts` | Support multi-token lookup; return scope |
+| `electron/gateway/index.ts` | Store scope on `ConnectedClient`; enforce in `handleRequest()` |
+| `electron/gateway/protocol.ts` | Add `workspaceScope?: string` to `GatewayConnectRequest` |
+| `electron/gateway/channels/discord.ts` | Pass workspace scope on internal auth |
+| `electron/ipc/gateway.ts` | Expose token management IPC for the settings UI |
+
+---
+
+## 2. `auth.json` File Permissions (0o600)
+
+**Finding:** F-05 (High) — API keys stored via Pi SDK's `AuthStorage` in
+`auth.json` do not have explicit `0600` file permissions.
+
+**Risk:** On multi-user systems, other users could read API keys.
+
+### Current Behaviour
+
+- `AuthStorage` is provided by `@mariozechner/pi-ai` (external dependency).
+- Sero calls `infra.authStorage.set(providerId, { type: 'api_key', key })`
+  in `electron/ipc/auth.ts:237`.
+- The SDK writes `auth.json` using default Node.js `fs.writeFile`
+  permissions (typically `0o644`).
+- The gateway token file already uses `{ mode: 0o600 }` (in
+  `gateway/auth.ts:41`), so the pattern exists.
+
+### What Needs to Change
+
+1. **Upstream PR to `@mariozechner/pi-ai`** — Add `{ mode: 0o600 }` to
+   the `AuthStorage.save()` method's `fs.writeFileSync` / `writeFile`
+   call. This is the correct fix since the SDK owns the file.
+
+2. **Fallback: post-write permission repair** — If the upstream change
+   is slow, add a wrapper in `electron/ipc/auth.ts` that calls
+   `fs.chmodSync(authJsonPath, 0o600)` after every `authStorage.set()`
+   or `authStorage.login()` call. The path can be derived from
+   `SERO_AGENT_DIR + '/auth.json'`.
+
+3. **Startup check** — On app launch, verify `auth.json` permissions
+   and repair if wrong. Log a warning if repaired.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `electron/ipc/auth.ts` | Add post-write `chmod 0o600` after `authStorage.set()` and `authStorage.login()` |
+| `electron/env.ts` | Export `AUTH_JSON_PATH` constant for reuse |
+| Upstream `@mariozechner/pi-ai` | PR to add `mode: 0o600` to `AuthStorage.save()` |
+
+---
+
+## 3. Cost Caps for Gateway Sessions
+
+**Finding:** F-09 (High) — No cost limits for gateway-initiated sessions.
+A compromised or malicious client can run unlimited expensive prompts.
+
+**Risk:** Financial — unbounded API spend via Anthropic/OpenAI.
+
+### What Needs to Change
+
+1. **Cost tracking** — The agent session already receives
+   `usage` data in response events (`input_tokens`, `output_tokens`).
+   Add a per-session and per-day cost accumulator in the gateway or
+   agent bridge.
+
+2. **Configuration** — Add a `gateway-config.json` file (or extend
+   the existing gateway config) with:
+   ```json
+   {
+     "maxCostPerSession": 5.00,
+     "maxCostPerDay": 50.00,
+     "maxConcurrentSessions": 3
+   }
+   ```
+
+3. **Enforcement** — Before relaying a `prompt` request, check:
+   - Session cost < `maxCostPerSession`
+   - Daily cost < `maxCostPerDay`
+   - Active session count < `maxConcurrentSessions`
+   If exceeded, return an error response and do not forward to the agent.
+
+4. **Cost estimation** — Use approximate per-token pricing:
+   - Claude Opus: ~$15/M input, ~$75/M output
+   - Claude Sonnet: ~$3/M input, ~$15/M output
+   - Map model ID → pricing tier in a lookup table.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `electron/gateway/index.ts` | Add cost accumulator; check limits before `prompt` |
+| `electron/gateway/agent-bridge.ts` | Extract token usage from agent events; report to gateway |
+| `electron/gateway/protocol.ts` | Add `cost_limit_exceeded` error type |
+| New: `electron/gateway/cost-tracker.ts` | Per-session and per-day cost tracking |
+| New: `~/.sero-ui/gateway-config.json` | User-configurable cost limits |
+
+---
+
+## 4. Shell Command Concatenation in Container Exec
+
+**Finding:** F-10 (Medium) — User-provided `command` from the agent's
+`bash` tool is concatenated directly into `sh -c` at
+`container/index.ts:227`.
+
+**Risk:** While the container is a sandbox, the concatenation pattern
+`${envPrefix}${command}` means env variable injection could theoretically
+manipulate the shell context. The container barrier is the primary
+defence, but defence-in-depth applies.
+
+### Current Code
+
+```typescript
+// container/index.ts:226-227
+const envPrefix = envParts.join(' ') + ';';
+args.push(cid, 'sh', '-c', `${envPrefix}${command}`);
+```
+
+Environment values are quoted with `shQuoteValue()` (single-quote
+wrapping with escape), which is correct. The `command` itself is
+intentionally passed unescaped because it IS a shell command from the
+agent. The real concern is the `envPrefix` concatenation.
+
+### What Needs to Change
+
+1. **Separate env and command** — Instead of concatenating env vars
+   into the `sh -c` string, use `container exec --env KEY=VALUE` flags
+   if the container CLI supports them. Check `container exec --help`
+   for `--env` / `-e` support.
+
+2. **If `--env` is not supported** — Refactor to use a wrapper script
+   approach: write a small shell script to a temp file inside the
+   container, then `container exec sh /tmp/sero-cmd-XXXX.sh`. This
+   avoids the concatenation entirely.
+
+3. **Validate env variable names** — Before building `envPrefix`,
+   validate that env var names match `^[A-Z_][A-Z0-9_]*$`. Reject
+   names containing shell metacharacters.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `electron/container/index.ts` | Refactor `exec()` to use `--env` flags or wrapper script |
+
+---
+
+## 5. Idempotency Key Not Enforced
+
+**Finding:** F-11 (Medium) — `GatewayPromptRequest` defines an
+`idempotencyKey?: string` field, but the gateway server ignores it.
+
+**Risk:** Network retries can cause duplicate prompt execution,
+wasting tokens and producing confusing duplicate responses.
+
+### What Needs to Change
+
+1. **Idempotency store** — Add a `Map<string, { timestamp: number; status: 'pending' | 'done' }>` to
+   `GatewayServer`. Key = idempotency key, TTL = 5 minutes.
+
+2. **Check before processing** — In the `prompt` case of
+   `handleRequest()`:
+   - If `idempotencyKey` is present and already in the store with
+     status `done`, return the cached response.
+   - If status is `pending`, return a "request in progress" error.
+   - Otherwise, record it as `pending` and proceed.
+
+3. **Mark done** — After the prompt completes (on `agent_end` event),
+   update the entry to `done`.
+
+4. **Cleanup** — Periodically remove entries older than 5 minutes.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `electron/gateway/index.ts` | Add idempotency store and check/update logic |
+| `electron/gateway/protocol.ts` | No change needed (field already defined) |
+
+---
+
+## 6. OAuth Events Broadcast to All Windows
+
+**Finding:** F-12 (Medium) — `sendAuthEvent()` in `electron/ipc/auth.ts`
+broadcasts OAuth events (including login progress, tokens, error messages)
+to ALL `BrowserWindow` instances.
+
+**Risk:** If Sero ever opens multiple windows (e.g., a detached chat
+panel, DevTools window, or a `<webview>` for extensions), OAuth events
+containing sensitive data (URLs with auth codes, progress messages with
+provider names) would leak to unintended contexts.
+
+### Current Code
+
+```typescript
+// electron/ipc/auth.ts:63-66
+function sendAuthEvent(event: OAuthEvent): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(IpcChannels.auth.event, event);
+  }
+}
+```
+
+### What Needs to Change
+
+1. **Target the originating window** — Track which `BrowserWindow`
+   initiated the login flow. Pass the `webContents.id` or
+   `BrowserWindow` reference from the `ipcMain.handle` callback's
+   `_event` parameter.
+
+2. **Send only to that window** — Replace the broadcast with a
+   targeted `win.webContents.send()` to the originating window only.
+
+3. **Fallback** — If the originating window is closed during the flow,
+   send to the focused window or log a warning.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `electron/ipc/auth.ts` | Store originating `webContents.id`; replace `getAllWindows()` broadcast with targeted send |
+
+---
+
+## Additional Deferred Items
+
+These were identified during hardening but not tracked as numbered
+findings:
+
+### Structured Audit Log File (F-18 partial)
+
+Auth failure logging was added inline, but a structured audit log file
+(`~/.sero-ui/gateway-audit.log`) with JSON entries for all gateway
+operations (prompt, steer, abort, connect, disconnect) is still needed.
+
+**Approach:** Create `electron/gateway/audit-log.ts` that appends
+newline-delimited JSON to the audit file. Rotate when file exceeds
+10 MB. Include: timestamp, client IP, client type, operation, workspace
+ID, session ID, success/failure.
+
+### Pre-Commit Secret Scanning (Recommendation #15)
+
+Add a `gitleaks` or `trufflehog` pre-commit hook to prevent secrets
+from being committed to the repository.
+
+**Approach:** Add `.pre-commit-config.yaml` with the `gitleaks` hook,
+or add a `husky` pre-commit hook that runs
+`gitleaks detect --source . --verbose`.
+
+### IPC Input Validation with Zod (Recommendation #9)
+
+All IPC handlers accept unvalidated parameters from the renderer. A
+compromised or buggy renderer could send malformed data.
+
+**Approach:** Add `zod` as a dependency. Create a shared
+`electron/ipc/schemas.ts` with Zod schemas for each IPC handler's
+parameters. Validate at the top of each `ipcMain.handle` callback.
+Start with security-sensitive handlers: `auth.setApiKey`,
+`auth.login`, `editor.readFile`, `editor.writeFile`, `net.fetch`.
+
+### Extension Sandboxing (Recommendation #16)
+
+Federated extension modules currently run in the same renderer
+context as the shell. A malicious extension could access the
+`window.sero` IPC bridge.
+
+**Approach:** Evaluate running each extension's UI in a separate
+`<webview>` tag with `sandbox` attribute, limiting it to a
+message-passing API. This is a significant architectural change
+and should be prototyped before committing.
+
+---
+
+*Last updated: 2026-03-09. Review and prioritize these items during
+the next sprint planning.*

--- a/docs/security/security-audit-plan.md
+++ b/docs/security/security-audit-plan.md
@@ -96,10 +96,10 @@ Sero is an Electron-based agent workspace that runs AI coding sessions inside ma
 
 #### Hardening Actions
 
-1. **Add rate limiting on failed auth attempts** — After 5 failed attempts from the same IP within 60s, block for 5 minutes. Currently no rate limiting exists.
-2. **Remove `?token=` URL parameter support** from web chat (`channels/web.ts`). Replace with a login prompt that sends the token over WebSocket only.
-3. **Add `Referrer-Policy: no-referrer` header** to all HTTP responses from the gateway.
-4. **Log failed authentication attempts** with client IP and timestamp for audit trails.
+1. ~~**Add rate limiting on failed auth attempts**~~ ✅ — After 5 failed attempts from the same IP within 60s, block for 5 minutes. Implemented in `gateway/rate-limiter.ts`.
+2. ~~**Remove `?token=` URL parameter support**~~ ✅ — Token no longer read from URL in `channels/web.ts`. Auth overlay always shown.
+3. ~~**Add `Referrer-Policy: no-referrer` header**~~ ✅ — Added to all HTTP responses from gateway and web chat server.
+4. ~~**Log failed authentication attempts**~~ ✅ — Client IP and type logged on auth failure.
 
 ### 3.2 Authorization & Access Control
 
@@ -504,40 +504,40 @@ Based on code review, the following issues have been identified before active te
 
 | ID | Finding | Location | Status |
 |----|---------|----------|--------|
-| F-01 | No rate limiting on gateway (auth or requests) | `gateway/index.ts` | Open |
-| F-02 | Discord bot open to all users by default | `gateway/channels/discord.ts` | Open |
-| F-03 | No per-workspace access control on gateway | `gateway/index.ts` | Open |
+| F-01 | No rate limiting on gateway (auth or requests) | `gateway/index.ts` | **Fixed** — Added `RateLimiter` (5 failures/60s → 5min block) in `gateway/rate-limiter.ts` |
+| F-02 | Discord bot open to all users by default | `gateway/channels/discord.ts` | **Fixed** — Fail-closed: adapter refuses to start when `SERO_DISCORD_USERS` is empty |
+| F-03 | No per-workspace access control on gateway | `gateway/index.ts` | Open — requires design for per-workspace token scoping |
 
 ### High
 
 | ID | Finding | Location | Status |
 |----|---------|----------|--------|
-| F-04 | Token passed in URL query parameter | `gateway/channels/web.ts` | Open |
-| F-05 | `auth.json` file permissions not explicitly set to `0600` | `electron/ipc/auth.ts` | Open |
-| F-06 | Base64 fallback for credential storage (no warning) | `safe-storage.ts:25-26` | Open |
-| F-07 | Hardcoded Google keyring password | `google/auth-manager.ts:65` | Open |
-| F-08 | No message size limit on WebSocket server | `gateway/index.ts` | Open |
-| F-09 | No cost caps for gateway-initiated sessions | `gateway/index.ts` | Open |
+| F-04 | Token passed in URL query parameter | `gateway/channels/web.ts` | **Fixed** — Removed `?token=` URL support; auth overlay required |
+| F-05 | `auth.json` file permissions not explicitly set to `0600` | `electron/ipc/auth.ts` | Open — requires upstream Pi SDK `AuthStorage` changes |
+| F-06 | Base64 fallback for credential storage (no warning) | `safe-storage.ts:25-26` | **Fixed** — Added warning log + renderer notification on fallback |
+| F-07 | Hardcoded Google keyring password | `google/auth-manager.ts:65` | **Fixed** — Derived from `hostname + uid` via SHA-256 |
+| F-08 | No message size limit on WebSocket server | `gateway/index.ts` | **Fixed** — `maxPayload: 1MB` on `ws.Server` |
+| F-09 | No cost caps for gateway-initiated sessions | `gateway/index.ts` | Open — requires cost tracking infrastructure |
 
 ### Medium
 
 | ID | Finding | Location | Status |
 |----|---------|----------|--------|
-| F-10 | Shell command concatenation in container exec | `container/index.ts:227` | Open |
+| F-10 | Shell command concatenation in container exec | `container/index.ts:227` | Open — container provides secondary barrier |
 | F-11 | Idempotency key defined but not enforced | `gateway/protocol.ts:22` | Open |
 | F-12 | OAuth events broadcast to all windows | `electron/ipc/auth.ts:62-67` | Open |
-| F-13 | No SSRF protection in net proxy | `electron/ipc/net.ts` | Open |
-| F-14 | Net proxy passes headers unfiltered | `electron/ipc/net.ts` | Open |
-| F-15 | No symlink resolution in path validation | `electron/ipc/editor.ts:43-57` | Open |
-| F-16 | No max connection limit on WebSocket server | `gateway/index.ts` | Open |
+| F-13 | No SSRF protection in net proxy | `electron/ipc/net.ts` | **Fixed** — DNS resolution + private IP blocking + protocol allowlist |
+| F-14 | Net proxy passes headers unfiltered | `electron/ipc/net.ts` | **Fixed** — Blocked host/cookie/authorization headers |
+| F-15 | No symlink resolution in path validation | `electron/ipc/editor.ts:43-57` | **Fixed** — Added `realpathSync()` + null byte + path length checks |
+| F-16 | No max connection limit on WebSocket server | `gateway/index.ts` | **Fixed** — 50 total, 10 per IP |
 
 ### Low
 
 | ID | Finding | Location | Status |
 |----|---------|----------|--------|
-| F-17 | No navigation restriction handlers | `electron/main.ts` | Open |
-| F-18 | No audit logging for gateway operations | `gateway/index.ts` | Open |
-| F-19 | No secret pattern redaction in logs | Various | Open |
+| F-17 | No navigation restriction handlers | `electron/main.ts` | **Fixed** — `will-navigate` blocks untrusted origins, `setWindowOpenHandler` always denies, `setPermissionRequestHandler` blocks unnecessary permissions |
+| F-18 | No audit logging for gateway operations | `gateway/index.ts` | **Partial** — Auth failures logged with IP; structured audit log file deferred |
+| F-19 | No secret pattern redaction in logs | Various | **Fixed** — `lib/secret-redact.ts` provides pattern-based redaction for known key formats |
 
 ---
 
@@ -545,30 +545,30 @@ Based on code review, the following issues have been identified before active te
 
 ### Priority 1 — Immediate (Gateway & Secrets)
 
-1. **Rate limiting on gateway** — Implement token bucket or sliding window rate limiter for both authentication attempts and authenticated requests.
-2. **Remove `?token=` URL support** — Force token entry via WebSocket `connect` message only.
-3. **Fail-closed Discord** — Disable Discord adapter when no user whitelist is configured.
-4. **Set `auth.json` permissions** — Add `{ mode: 0o600 }` to all writes.
-5. **WebSocket `maxPayload`** — Set to 1MB in `ws.Server` options.
-6. **Max connections** — Limit to 50 total, 10 per IP.
+1. ~~**Rate limiting on gateway**~~ ✅ — Sliding window rate limiter in `gateway/rate-limiter.ts`. 5 failures / 60s → 5 min block per IP.
+2. ~~**Remove `?token=` URL support**~~ ✅ — Token no longer read from `location.search`. Auth overlay always shown.
+3. ~~**Fail-closed Discord**~~ ✅ — Adapter refuses to start when `SERO_DISCORD_USERS` is empty. Warning logged.
+4. **Set `auth.json` permissions** — Requires upstream Pi SDK `AuthStorage` changes. Open.
+5. ~~**WebSocket `maxPayload`**~~ ✅ — Set to 1 MB in `ws.Server` constructor.
+6. ~~**Max connections**~~ ✅ — 50 total, 10 per IP. Enforced in `handleConnection()`.
 
 ### Priority 2 — Short-Term (Access Control & Injection)
 
-7. **Per-workspace gateway tokens** — Scope tokens to specific workspaces.
-8. **Cost caps** — Configurable per-session and daily cost limits.
-9. **IPC input validation** — Add Zod schemas to all main-process IPC handlers.
-10. **Symlink resolution** — Use `fs.realpathSync()` before path boundary checks.
-11. **SSRF protection** — Block private IPs in net proxy.
-12. **Secret redaction** — Add pattern-based redaction to all log outputs.
+7. **Per-workspace gateway tokens** — Open. Requires token scoping design.
+8. **Cost caps** — Open. Requires cost tracking infrastructure.
+9. **IPC input validation** — Open. Zod integration planned.
+10. ~~**Symlink resolution**~~ ✅ — `realpathSync()` added to `toHostPath()` in `editor.ts`. Also added null byte stripping and 4096-char path length limit.
+11. ~~**SSRF protection**~~ ✅ — DNS resolution check + private IP blocking + protocol allowlist in `ipc/net.ts`.
+12. ~~**Secret redaction**~~ ✅ — `lib/secret-redact.ts` with patterns for Anthropic, OpenAI, GitHub, Google, xAI, and generic tokens.
 
 ### Priority 3 — Medium-Term (Defense in Depth)
 
-13. **Navigation restrictions** — Block `will-navigate` to untrusted origins.
-14. **Audit logging** — Structured JSON logs for all gateway and auth operations.
-15. **Pre-commit secret scanning** — Add `gitleaks` hook.
-16. **Extension sandboxing** — Evaluate running extension UI in isolated `<webview>`.
-17. **Google keyring password derivation** — Replace hardcoded password.
-18. **Base64 fallback warning** — UI toast + log warning when encryption unavailable.
+13. ~~**Navigation restrictions**~~ ✅ — `will-navigate` blocks untrusted origins. `setWindowOpenHandler` always denies (external links open in system browser). `setPermissionRequestHandler` blocks unnecessary permissions.
+14. **Audit logging** — Partial. Auth failures logged with IP. Structured JSON audit log file deferred.
+15. **Pre-commit secret scanning** — Open. `gitleaks` hook planned.
+16. **Extension sandboxing** — Open. Evaluate `<webview>` isolation.
+17. ~~**Google keyring password derivation**~~ ✅ — Password derived from `hostname + uid` via SHA-256 in `google/auth-manager.ts`.
+18. ~~**Base64 fallback warning**~~ ✅ — Console warning + renderer `sero:security-warning` IPC event in `ipc/safe-storage.ts`.
 
 ---
 


### PR DESCRIPTION
Implement the hardening actions from docs/security/security-audit-plan.md:

Gateway security:
- Add rate limiting on auth attempts (5 failures/60s → 5min block per IP)
- Add maxPayload (1MB) to WebSocket server
- Add max connection limits (50 total, 10 per IP)
- Add Origin header validation for non-Tailscale connections
- Add 30-minute idle timeout for authenticated connections
- Add Referrer-Policy: no-referrer to all HTTP responses
- Log failed auth attempts with client IP
- Remove ?token= URL parameter support from web chat

Access control:
- Fail-closed Discord adapter (disabled when SERO_DISCORD_USERS empty)

Secret management:
- Derive Google keyring password from hostname+uid via SHA-256
- Add base64 fallback warning to safe-storage (log + renderer IPC)
- Add secret pattern redaction utility (lib/secret-redact.ts)

Path traversal & SSRF:
- Add symlink resolution (realpathSync) to editor path validation
- Add null byte stripping and path length limits (4096 chars)
- Fix ext-protocol to use path.resolve for proper traversal checks
- Add SSRF protection to net proxy (private IP blocking, DNS check)
- Add header sanitization to net proxy

Electron hardening:
- Add will-navigate handler to block navigation to untrusted origins
- Always deny new window creation (external links open in system browser)
- Add setPermissionRequestHandler to block unnecessary permissions

https://claude.ai/code/session_01FhxKvu225kV6pF42Farw8M