### PR TITLE
Humanizer: redesign UI with presets, view transitions, and master-detail history

### DIFF
--- a/packages/pi-humanizer-extension/shared/types.ts
+++ b/packages/pi-humanizer-extension/shared/types.ts
@@ -13,12 +13,22 @@ export interface HumanizeEntry {
   createdAt: string; // ISO string
 }
 
+/** A user-created instruction preset. */
+export interface InstructionPreset {
+  id: string;
+  label: string;
+  prompt: string;
+  builtIn?: boolean;
+}
+
 export interface HumanizerState {
   entries: HumanizeEntry[];
   nextId: number;
+  customPresets: InstructionPreset[];
 }
 
 export const DEFAULT_STATE: HumanizerState = {
   entries: [],
   nextId: 1,
+  customPresets: [],
 };

--- a/packages/pi-humanizer-extension/shared/types.ts
+++ b/packages/pi-humanizer-extension/shared/types.ts
@@ -24,7 +24,8 @@ export interface InstructionPreset {
 export interface HumanizerState {
   entries: HumanizeEntry[];
   nextId: number;
-  customPresets: InstructionPreset[];
+  /** Optional for backwards-compat with existing state.json files. */
+  customPresets?: InstructionPreset[];
 }
 
 export const DEFAULT_STATE: HumanizerState = {

--- a/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
+++ b/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
@@ -1,44 +1,92 @@
 /**
  * HumanizerApp — main Sero app component.
  *
- * Provides a text input area, optional instructions field, and a
- * humanize button that calls the LLM via useAI() to remove AI
- * writing patterns from the provided text.
+ * Two layout modes driven by View Transitions API:
+ *  - Input mode: full-width textarea filling the space
+ *  - Result mode: side-by-side split — original left, humanized right
+ *
+ * The transition between modes is animated via named view-transition
+ * elements so the input pane smoothly shrinks while output slides in.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useAppState, useAI } from '@sero/app-runtime';
 import { cn } from '@sero/ui/lib/utils';
 import { Button } from '@sero/ui/components/ui/button';
-import type { HumanizerState, HumanizeEntry } from '../shared/types';
+import { ScrollArea } from '@sero/ui/components/ui/scroll-area';
+import type { HumanizerState, HumanizeEntry, InstructionPreset } from '../shared/types';
 import { DEFAULT_STATE } from '../shared/types';
 import { buildHumanizePrompt } from './humanize-prompt';
+import { InstructionPresets } from './components/InstructionPresets';
+import { HistoryPanel } from './components/HistoryPanel';
+import { StatsRow } from './components/StatsRow';
+import { PanelActions } from './components/PanelActions';
+import { BUILT_IN_PRESETS } from './lib/presets';
+import { withViewTransition } from './lib/view-transition';
 import './styles.css';
+
+type View = 'editor' | 'history';
 
 export function HumanizerApp() {
   const [state, updateState] = useAppState<HumanizerState>(DEFAULT_STATE);
   const ai = useAI();
 
+  const [view, setView] = useState<View>('editor');
   const [inputText, setInputText] = useState('');
-  const [instructions, setInstructions] = useState('');
   const [outputText, setOutputText] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
-  const [showHistory, setShowHistory] = useState(false);
+  const [activePresetIds, setActivePresetIds] = useState<Set<string>>(new Set());
 
-  const outputRef = useRef<HTMLTextAreaElement>(null);
+  const allPresets = useMemo(
+    () => [...BUILT_IN_PRESETS, ...(state.customPresets ?? [])],
+    [state.customPresets],
+  );
 
-  // Auto-resize textareas
-  const autoResize = useCallback((el: HTMLTextAreaElement | null) => {
-    if (!el) return;
-    el.style.height = 'auto';
-    el.style.height = `${el.scrollHeight}px`;
+  const combinedInstructions = useMemo(() => {
+    if (activePresetIds.size === 0) return '';
+    return allPresets
+      .filter((p) => activePresetIds.has(p.id))
+      .map((p) => p.prompt)
+      .join(' ');
+  }, [activePresetIds, allPresets]);
+
+  // ── Preset management ────────────────────────────────────
+
+  const handleTogglePreset = useCallback((id: string) => {
+    setActivePresetIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
   }, []);
 
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  useEffect(() => autoResize(inputRef.current), [inputText, autoResize]);
-  useEffect(() => autoResize(outputRef.current), [outputText, autoResize]);
+  const handleAddCustomPreset = useCallback(
+    (preset: InstructionPreset) => {
+      updateState((prev) => ({
+        ...prev,
+        customPresets: [...(prev.customPresets ?? []), preset],
+      }));
+    },
+    [updateState],
+  );
+
+  const handleRemoveCustomPreset = useCallback(
+    (id: string) => {
+      setActivePresetIds((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      updateState((prev) => ({
+        ...prev,
+        customPresets: (prev.customPresets ?? []).filter((p) => p.id !== id),
+      }));
+    },
+    [updateState],
+  );
 
   // ── Humanize ─────────────────────────────────────────────
 
@@ -52,20 +100,24 @@ export function HumanizerApp() {
     setCopied(false);
 
     try {
-      const prompt = buildHumanizePrompt(text, instructions.trim() || undefined);
+      const prompt = buildHumanizePrompt(text, combinedInstructions || undefined);
       const response = await ai.prompt(prompt);
-      setOutputText(response);
 
-      // Save to history
+      // Animate the layout shift with View Transitions
+      withViewTransition(() => {
+        setOutputText(response);
+      });
+
       updateState((prev) => {
         const entry: HumanizeEntry = {
           id: prev.nextId,
           inputText: text,
-          instructions: instructions.trim(),
+          instructions: combinedInstructions,
           outputText: response,
           createdAt: new Date().toISOString(),
         };
         return {
+          ...prev,
           entries: [...prev.entries.slice(-19), entry],
           nextId: prev.nextId + 1,
         };
@@ -75,9 +127,9 @@ export function HumanizerApp() {
     } finally {
       setLoading(false);
     }
-  }, [inputText, instructions, ai, updateState]);
+  }, [inputText, combinedInstructions, ai, updateState]);
 
-  // ── Copy output ──────────────────────────────────────────
+  // ── Actions ──────────────────────────────────────────────
 
   const handleCopy = useCallback(async () => {
     if (!outputText) return;
@@ -90,218 +142,323 @@ export function HumanizerApp() {
     }
   }, [outputText]);
 
-  // ── Clear ────────────────────────────────────────────────
+  const handleUseAsInput = useCallback(() => {
+    withViewTransition(() => {
+      setInputText(outputText);
+      setOutputText('');
+      setCopied(false);
+    });
+  }, [outputText]);
 
   const handleClear = useCallback(() => {
-    setInputText('');
-    setInstructions('');
-    setOutputText('');
-    setError(null);
-    setCopied(false);
+    withViewTransition(() => {
+      setInputText('');
+      setOutputText('');
+      setError(null);
+      setCopied(false);
+    });
   }, []);
-
-  // ── Load from history ────────────────────────────────────
 
   const handleLoadEntry = useCallback((entry: HumanizeEntry) => {
-    setInputText(entry.inputText);
-    setInstructions(entry.instructions);
-    setOutputText(entry.outputText);
-    setShowHistory(false);
+    withViewTransition(() => {
+      setInputText(entry.inputText);
+      setOutputText(entry.outputText);
+      setView('editor');
+    });
   }, []);
 
-  // ── Render ───────────────────────────────────────────────
+  const handleClearHistory = useCallback(() => {
+    updateState((prev) => ({
+      ...prev,
+      entries: [],
+    }));
+    withViewTransition(() => setView('editor'));
+  }, [updateState]);
+
+  const hasInput = inputText.trim().length > 0;
+  const hasOutput = !!outputText;
+
+  // ── History view ─────────────────────────────────────────
+
+  if (view === 'history') {
+    return (
+      <div className="flex h-full flex-col overflow-hidden bg-background">
+        <Header
+          historyCount={state.entries.length}
+          isHistory
+          onToggleView={() => withViewTransition(() => setView('editor'))}
+        />
+        <HistoryPanel
+          entries={state.entries}
+          onLoad={handleLoadEntry}
+          onClearHistory={handleClearHistory}
+        />
+      </div>
+    );
+  }
+
+  // ── Editor view ──────────────────────────────────────────
 
   return (
     <div className="flex h-full flex-col overflow-hidden bg-background">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-5 py-3">
-        <div>
-          <h1 className="text-base font-semibold text-foreground">Humanizer</h1>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Remove AI writing patterns from your text
-          </p>
-        </div>
-        {state.entries.length > 0 && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-xs text-muted-foreground"
-            onClick={() => setShowHistory(!showHistory)}
-          >
-            {showHistory ? 'Back' : `History (${state.entries.length})`}
-          </Button>
-        )}
-      </div>
+      <Header
+        historyCount={state.entries.length}
+        isHistory={false}
+        onToggleView={() => withViewTransition(() => setView('history'))}
+      />
 
-      {/* History panel */}
-      {showHistory ? (
-        <HistoryPanel entries={state.entries} onLoad={handleLoadEntry} />
-      ) : (
-        <div className="flex-1 overflow-y-auto">
-          <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 p-5">
-            {/* Input area */}
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-muted-foreground">
-                Text to humanize
-              </label>
-              <textarea
-                ref={inputRef}
-                value={inputText}
-                onChange={(e) => setInputText(e.target.value)}
-                placeholder="Paste your AI-generated text or markdown here..."
-                className={cn(
-                  'min-h-[160px] w-full resize-none rounded-lg border border-input',
-                  'bg-card px-3.5 py-2.5 text-sm leading-relaxed text-foreground',
-                  'placeholder:text-muted-foreground',
-                  'focus:outline-none focus:ring-1 focus:ring-ring',
-                )}
-              />
-            </div>
+      {/* Toolbar: presets + action button */}
+      <Toolbar
+        activePresetIds={activePresetIds}
+        customPresets={state.customPresets ?? []}
+        onTogglePreset={handleTogglePreset}
+        onAddCustom={handleAddCustomPreset}
+        onRemoveCustom={handleRemoveCustomPreset}
+        hasInput={hasInput}
+        loading={loading}
+        onHumanize={handleHumanize}
+        onClear={handleClear}
+        error={error}
+      />
 
-            {/* Instructions */}
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-muted-foreground">
-                Instructions{' '}
-                <span className="font-normal text-muted-foreground/60">
-                  (optional)
-                </span>
-              </label>
-              <input
-                type="text"
-                value={instructions}
-                onChange={(e) => setInstructions(e.target.value)}
-                placeholder="e.g. Keep a formal tone, preserve technical terms..."
-                className={cn(
-                  'w-full rounded-lg border border-input bg-card px-3.5 py-2',
-                  'text-sm text-foreground placeholder:text-muted-foreground',
-                  'focus:outline-none focus:ring-1 focus:ring-ring',
-                )}
-              />
-            </div>
-
-            {/* Actions */}
-            <div className="flex items-center gap-2">
-              <Button
-                size="sm"
-                disabled={!inputText.trim() || loading}
-                onClick={handleHumanize}
-              >
-                {loading ? 'Humanizing...' : 'Humanize'}
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="text-muted-foreground"
-                onClick={handleClear}
-                disabled={loading}
-              >
-                Clear
-              </Button>
-            </div>
-
-            {/* Error */}
-            {error && (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3.5 py-2 text-sm text-destructive">
-                {error}
-              </div>
-            )}
-
-            {/* Loading indicator */}
-            {loading && (
-              <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
-                <LoadingDots />
-                <span>Analyzing and rewriting your text...</span>
-              </div>
-            )}
-
-            {/* Output */}
-            {outputText && (
-              <div className="flex flex-col gap-1.5">
-                <div className="flex items-center justify-between">
-                  <label className="text-xs font-medium text-muted-foreground">
-                    Humanized output
-                  </label>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-6 text-xs text-muted-foreground"
-                    onClick={handleCopy}
-                  >
-                    {copied ? 'Copied!' : 'Copy'}
-                  </Button>
-                </div>
+      {/* Main content area */}
+      <div className="flex min-h-0 flex-1">
+        {hasOutput ? (
+          /* ── Side-by-side split ────────────────────────── */
+          <div className="flex min-h-0 flex-1">
+            {/* Input pane */}
+            <div
+              className="vt-input-pane flex min-h-0 flex-1 flex-col border-r border-border/30"
+            >
+              <PaneHeader label="Original" variant="muted" />
+              <ScrollArea className="min-h-0 flex-1">
                 <textarea
-                  ref={outputRef}
-                  value={outputText}
-                  readOnly
+                  value={inputText}
+                  onChange={(e) => setInputText(e.target.value)}
                   className={cn(
-                    'min-h-[160px] w-full resize-none rounded-lg border border-input',
-                    'bg-secondary/30 px-3.5 py-2.5 text-sm leading-relaxed text-foreground',
-                    'focus:outline-none focus:ring-1 focus:ring-ring',
+                    'humanizer-textarea field-sizing-content',
+                    'w-full min-h-[120px] resize-none bg-transparent',
+                    'px-4 py-3',
+                    'text-[13.5px] leading-[1.75] text-foreground/60',
                   )}
                 />
-              </div>
-            )}
+              </ScrollArea>
+              <PaneFooter text={inputText} />
+            </div>
+
+            {/* Output pane */}
+            <div
+              className="vt-output-pane flex min-h-0 flex-1 flex-col humanizer-output-pane"
+            >
+              <PaneHeader label="Humanized" variant="accent">
+                <PanelActions
+                  copied={copied}
+                  onCopy={handleCopy}
+                  onRefine={handleUseAsInput}
+                />
+              </PaneHeader>
+              <ScrollArea className="min-h-0 flex-1">
+                <div
+                  className={cn(
+                    'whitespace-pre-wrap px-4 py-3',
+                    'text-[13.5px] leading-[1.75] text-foreground',
+                    'selection:bg-emerald-500/20',
+                  )}
+                >
+                  {outputText}
+                </div>
+              </ScrollArea>
+              <PaneFooter text={outputText} />
+            </div>
           </div>
+        ) : (
+          /* ── Full-width input ──────────────────────────── */
+          <div
+            className="vt-input-pane flex min-h-0 flex-1 flex-col"
+          >
+            <ScrollArea className="min-h-0 flex-1">
+              <textarea
+                value={inputText}
+                onChange={(e) => setInputText(e.target.value)}
+                placeholder="Paste your AI-generated text here…"
+                className={cn(
+                  'humanizer-textarea field-sizing-content',
+                  'w-full min-h-[200px] resize-none bg-transparent',
+                  'px-5 py-4',
+                  'text-[13.5px] leading-[1.75] text-foreground',
+                  'placeholder:text-muted-foreground/30',
+                )}
+              />
+            </ScrollArea>
+            {hasInput && <PaneFooter text={inputText} />}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Header ─────────────────────────────────────────────────
+
+function Header({
+  historyCount,
+  isHistory,
+  onToggleView,
+}: {
+  historyCount: number;
+  isHistory: boolean;
+  onToggleView: () => void;
+}) {
+  return (
+    <div className="vt-header flex items-center justify-between border-b border-border/50 px-4 py-2.5">
+      <div className="flex items-center gap-2.5">
+        <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-emerald-500/15">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-emerald-400">
+            <path d="M12 20h9" /><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z" />
+          </svg>
+        </div>
+        <h1 className="text-sm font-semibold text-foreground">Humanizer</h1>
+      </div>
+      {historyCount > 0 && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'h-7 rounded-lg px-2.5 text-xs',
+            isHistory
+              ? 'text-foreground'
+              : 'text-muted-foreground/60 hover:text-foreground',
+          )}
+          onClick={onToggleView}
+        >
+          {isHistory ? '← Back' : `History · ${historyCount}`}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ── Toolbar ────────────────────────────────────────────────
+
+function Toolbar({
+  activePresetIds,
+  customPresets,
+  onTogglePreset,
+  onAddCustom,
+  onRemoveCustom,
+  hasInput,
+  loading,
+  onHumanize,
+  onClear,
+  error,
+}: {
+  activePresetIds: Set<string>;
+  customPresets: InstructionPreset[];
+  onTogglePreset: (id: string) => void;
+  onAddCustom: (preset: InstructionPreset) => void;
+  onRemoveCustom: (id: string) => void;
+  hasInput: boolean;
+  loading: boolean;
+  onHumanize: () => void;
+  onClear: () => void;
+  error: string | null;
+}) {
+  return (
+    <div className="vt-toolbar flex flex-col gap-2.5 border-b border-border/40 px-4 py-3">
+      <div className="flex items-start gap-4">
+        <div className="min-w-0 flex-1">
+          <InstructionPresets
+            activeIds={activePresetIds}
+            customPresets={customPresets}
+            onToggle={onTogglePreset}
+            onAddCustom={onAddCustom}
+            onRemoveCustom={onRemoveCustom}
+          />
+        </div>
+
+        <div className="flex shrink-0 items-center gap-3 pt-0.5">
+          {hasInput && !loading && (
+            <button
+              type="button"
+              onClick={onClear}
+              className="rounded-md px-2 py-1 text-[11px] text-muted-foreground/50 transition-colors hover:bg-secondary hover:text-muted-foreground"
+            >
+              Clear
+            </button>
+          )}
+          <Button
+            size="sm"
+            disabled={!hasInput || loading}
+            onClick={onHumanize}
+            className={cn(
+              'humanizer-button',
+              'h-8 rounded-lg px-5 text-xs font-medium',
+              'bg-emerald-600 text-white hover:bg-emerald-500',
+              'transition-all duration-200',
+              !loading && hasInput && 'shadow-[0_0_20px_rgba(16,185,129,0.3)]',
+            )}
+          >
+            {loading ? (
+              <span className="flex items-center gap-2">
+                <LoadingSpinner />
+                Working…
+              </span>
+            ) : (
+              'Humanize'
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+          {error}
         </div>
       )}
     </div>
   );
 }
 
-// ── Loading dots animation ─────────────────────────────────
+// ── Pane header / footer ───────────────────────────────────
 
-function LoadingDots() {
+function PaneHeader({
+  label,
+  variant,
+  children,
+}: {
+  label: string;
+  variant: 'muted' | 'accent';
+  children?: React.ReactNode;
+}) {
   return (
-    <span className="inline-flex gap-0.5">
-      <span className="humanizer-dot h-1.5 w-1.5 rounded-full bg-muted-foreground" />
-      <span className="humanizer-dot h-1.5 w-1.5 rounded-full bg-muted-foreground [animation-delay:150ms]" />
-      <span className="humanizer-dot h-1.5 w-1.5 rounded-full bg-muted-foreground [animation-delay:300ms]" />
-    </span>
+    <div className="flex items-center justify-between border-b border-border/30 px-4 py-1.5">
+      <span
+        className={cn(
+          'text-[11px] font-semibold tracking-wider uppercase',
+          variant === 'accent' ? 'text-emerald-400' : 'text-muted-foreground/40',
+        )}
+      >
+        {label}
+      </span>
+      {children}
+    </div>
   );
 }
 
-// ── History panel ──────────────────────────────────────────
-
-function HistoryPanel({
-  entries,
-  onLoad,
-}: {
-  entries: HumanizeEntry[];
-  onLoad: (entry: HumanizeEntry) => void;
-}) {
-  const sorted = [...entries].reverse();
-
+function PaneFooter({ text }: { text: string }) {
   return (
-    <div className="flex-1 overflow-y-auto">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-2 p-5">
-        {sorted.map((entry) => (
-          <button
-            key={entry.id}
-            type="button"
-            className={cn(
-              'flex flex-col gap-1 rounded-lg border border-border bg-card px-4 py-3',
-              'text-left transition-colors hover:bg-secondary/50',
-            )}
-            onClick={() => onLoad(entry)}
-          >
-            <div className="flex items-center justify-between">
-              <span className="text-xs text-muted-foreground">
-                {new Date(entry.createdAt).toLocaleString()}
-              </span>
-              {entry.instructions && (
-                <span className="max-w-[200px] truncate text-xs text-muted-foreground/60">
-                  {entry.instructions}
-                </span>
-              )}
-            </div>
-            <p className="line-clamp-2 text-sm text-foreground">
-              {entry.inputText}
-            </p>
-          </button>
-        ))}
-      </div>
+    <div className="border-t border-border/30 px-4 py-1.5">
+      <StatsRow text={text} />
     </div>
+  );
+}
+
+function LoadingSpinner() {
+  return (
+    <svg className="h-3.5 w-3.5 animate-spin" viewBox="0 0 16 16" fill="none">
+      <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" className="opacity-20" />
+      <path d="M14 8a6 6 0 0 0-6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
   );
 }
 

--- a/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
+++ b/packages/pi-humanizer-extension/ui/HumanizerApp.tsx
@@ -210,7 +210,7 @@ export function HumanizerApp() {
       {/* Toolbar: presets + action button */}
       <Toolbar
         activePresetIds={activePresetIds}
-        customPresets={state.customPresets ?? []}
+        allPresets={allPresets}
         onTogglePreset={handleTogglePreset}
         onAddCustom={handleAddCustomPreset}
         onRemoveCustom={handleRemoveCustomPreset}
@@ -342,7 +342,7 @@ function Header({
 
 function Toolbar({
   activePresetIds,
-  customPresets,
+  allPresets,
   onTogglePreset,
   onAddCustom,
   onRemoveCustom,
@@ -353,7 +353,7 @@ function Toolbar({
   error,
 }: {
   activePresetIds: Set<string>;
-  customPresets: InstructionPreset[];
+  allPresets: InstructionPreset[];
   onTogglePreset: (id: string) => void;
   onAddCustom: (preset: InstructionPreset) => void;
   onRemoveCustom: (id: string) => void;
@@ -369,7 +369,7 @@ function Toolbar({
         <div className="min-w-0 flex-1">
           <InstructionPresets
             activeIds={activePresetIds}
-            customPresets={customPresets}
+            allPresets={allPresets}
             onToggle={onTogglePreset}
             onAddCustom={onAddCustom}
             onRemoveCustom={onRemoveCustom}

--- a/packages/pi-humanizer-extension/ui/components/HistoryPanel.tsx
+++ b/packages/pi-humanizer-extension/ui/components/HistoryPanel.tsx
@@ -6,7 +6,7 @@
  * Much more usable than a wall of text or a flat list.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { cn } from '@sero/ui/lib/utils';
 import { Button } from '@sero/ui/components/ui/button';
 import { ScrollArea } from '@sero/ui/components/ui/scroll-area';
@@ -24,16 +24,25 @@ export function HistoryPanel({ entries, onLoad, onClearHistory }: HistoryPanelPr
     sorted.length > 0 ? sorted[0].id : null,
   );
   const [confirmClear, setConfirmClear] = useState(false);
+  const confirmTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Clear the auto-reset timer on unmount to avoid setState on unmounted component
+  useEffect(() => {
+    return () => {
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
+    };
+  }, []);
 
   const selected = sorted.find((e) => e.id === selectedId) ?? null;
 
   const handleClear = useCallback(() => {
     if (confirmClear) {
+      if (confirmTimerRef.current) clearTimeout(confirmTimerRef.current);
       onClearHistory();
       setConfirmClear(false);
     } else {
       setConfirmClear(true);
-      setTimeout(() => setConfirmClear(false), 3000);
+      confirmTimerRef.current = setTimeout(() => setConfirmClear(false), 3000);
     }
   }, [confirmClear, onClearHistory]);
 
@@ -51,54 +60,54 @@ export function HistoryPanel({ entries, onLoad, onClearHistory }: HistoryPanelPr
       <div className="flex min-h-0 flex-1">
         {/* Left: entry list */}
         <ScrollArea className="w-[220px] shrink-0 border-r border-border/15">
-            <div className="flex flex-col py-1">
-              {sorted.map((entry) => (
-                <button
-                  key={entry.id}
-                  type="button"
-                  onClick={() => setSelectedId(entry.id)}
+          <div className="flex flex-col py-1">
+            {sorted.map((entry) => (
+              <button
+                key={entry.id}
+                type="button"
+                onClick={() => setSelectedId(entry.id)}
+                className={cn(
+                  'flex flex-col gap-0.5 px-3 py-2.5 text-left',
+                  'transition-colors duration-100',
+                  entry.id === selectedId
+                    ? 'bg-emerald-500/10'
+                    : 'hover:bg-background/30',
+                )}
+              >
+                <span
                   className={cn(
-                    'flex flex-col gap-0.5 px-3 py-2.5 text-left',
-                    'transition-colors duration-100',
+                    'text-[10px]',
                     entry.id === selectedId
-                      ? 'bg-emerald-500/10'
-                      : 'hover:bg-background/30',
+                      ? 'text-emerald-400/70'
+                      : 'text-muted-foreground/35',
                   )}
                 >
-                  <span
-                    className={cn(
-                      'text-[10px]',
-                      entry.id === selectedId
-                        ? 'text-emerald-400/70'
-                        : 'text-muted-foreground/35',
-                    )}
-                  >
-                    {formatRelativeTime(entry.createdAt)}
-                  </span>
-                  <span
-                    className={cn(
-                      'truncate text-[12px] leading-snug',
-                      entry.id === selectedId
-                        ? 'text-foreground/90'
-                        : 'text-foreground/50',
-                    )}
-                  >
-                    {firstLine(entry.inputText)}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </ScrollArea>
+                  {formatRelativeTime(entry.createdAt)}
+                </span>
+                <span
+                  className={cn(
+                    'truncate text-[12px] leading-snug',
+                    entry.id === selectedId
+                      ? 'text-foreground/90'
+                      : 'text-foreground/50',
+                  )}
+                >
+                  {firstLine(entry.inputText)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </ScrollArea>
 
-          {/* Right: detail preview */}
-          {selected ? (
-            <DetailPane entry={selected} onLoad={onLoad} />
-          ) : (
-            <div className="flex flex-1 items-center justify-center">
-              <p className="text-xs text-muted-foreground/30">Select an entry</p>
-            </div>
-          )}
-        </div>
+        {/* Right: detail preview */}
+        {selected ? (
+          <DetailPane entry={selected} onLoad={onLoad} />
+        ) : (
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-xs text-muted-foreground/30">Select an entry</p>
+          </div>
+        )}
+      </div>
 
       {/* Footer */}
       <div className="flex items-center justify-center border-t border-border/10 py-2">

--- a/packages/pi-humanizer-extension/ui/components/HistoryPanel.tsx
+++ b/packages/pi-humanizer-extension/ui/components/HistoryPanel.tsx
@@ -1,0 +1,211 @@
+/**
+ * HistoryPanel — master-detail layout inside a card.
+ *
+ * Left: compact scrollable list of entries (time + short preview).
+ * Right: full before/after preview of the selected entry with actions.
+ * Much more usable than a wall of text or a flat list.
+ */
+
+import { useState, useCallback } from 'react';
+import { cn } from '@sero/ui/lib/utils';
+import { Button } from '@sero/ui/components/ui/button';
+import { ScrollArea } from '@sero/ui/components/ui/scroll-area';
+import type { HumanizeEntry } from '../../shared/types';
+
+interface HistoryPanelProps {
+  entries: HumanizeEntry[];
+  onLoad: (entry: HumanizeEntry) => void;
+  onClearHistory: () => void;
+}
+
+export function HistoryPanel({ entries, onLoad, onClearHistory }: HistoryPanelProps) {
+  const sorted = [...entries].reverse();
+  const [selectedId, setSelectedId] = useState<number | null>(
+    sorted.length > 0 ? sorted[0].id : null,
+  );
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  const selected = sorted.find((e) => e.id === selectedId) ?? null;
+
+  const handleClear = useCallback(() => {
+    if (confirmClear) {
+      onClearHistory();
+      setConfirmClear(false);
+    } else {
+      setConfirmClear(true);
+      setTimeout(() => setConfirmClear(false), 3000);
+    }
+  }, [confirmClear, onClearHistory]);
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-sm text-muted-foreground/30">No humanizations yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      {/* Master-detail body */}
+      <div className="flex min-h-0 flex-1">
+        {/* Left: entry list */}
+        <ScrollArea className="w-[220px] shrink-0 border-r border-border/15">
+            <div className="flex flex-col py-1">
+              {sorted.map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => setSelectedId(entry.id)}
+                  className={cn(
+                    'flex flex-col gap-0.5 px-3 py-2.5 text-left',
+                    'transition-colors duration-100',
+                    entry.id === selectedId
+                      ? 'bg-emerald-500/10'
+                      : 'hover:bg-background/30',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'text-[10px]',
+                      entry.id === selectedId
+                        ? 'text-emerald-400/70'
+                        : 'text-muted-foreground/35',
+                    )}
+                  >
+                    {formatRelativeTime(entry.createdAt)}
+                  </span>
+                  <span
+                    className={cn(
+                      'truncate text-[12px] leading-snug',
+                      entry.id === selectedId
+                        ? 'text-foreground/90'
+                        : 'text-foreground/50',
+                    )}
+                  >
+                    {firstLine(entry.inputText)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+
+          {/* Right: detail preview */}
+          {selected ? (
+            <DetailPane entry={selected} onLoad={onLoad} />
+          ) : (
+            <div className="flex flex-1 items-center justify-center">
+              <p className="text-xs text-muted-foreground/30">Select an entry</p>
+            </div>
+          )}
+        </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-center border-t border-border/10 py-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleClear}
+          className={cn(
+            'h-7 rounded-lg px-3 text-[11px] transition-all duration-200',
+            confirmClear
+              ? 'text-red-400 hover:bg-red-500/10 hover:text-red-400'
+              : 'text-muted-foreground/25 hover:text-muted-foreground/50',
+          )}
+        >
+          {confirmClear ? 'Click again to confirm' : 'Clear history'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ── Detail pane ────────────────────────────────────────────
+
+function DetailPane({
+  entry,
+  onLoad,
+}: {
+  entry: HumanizeEntry;
+  onLoad: (entry: HumanizeEntry) => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Instruction badge + load button */}
+      <div className="flex items-center justify-between border-b border-border/10 px-4 py-2">
+        <div className="flex items-center gap-2">
+          {entry.instructions ? (
+            <span className="rounded-md bg-indigo-500/10 px-2 py-0.5 text-[10px] font-medium text-indigo-400/70">
+              {entry.instructions}
+            </span>
+          ) : (
+            <span className="text-[10px] text-muted-foreground/30">No instructions</span>
+          )}
+        </div>
+        <Button
+          size="sm"
+          onClick={() => onLoad(entry)}
+          className="h-7 rounded-lg bg-emerald-600 px-3 text-[11px] text-white hover:bg-emerald-500"
+        >
+          Load in editor
+        </Button>
+      </div>
+
+      {/* Before / After split */}
+      <div className="flex min-h-0 flex-1">
+        {/* Original */}
+        <div className="flex min-h-0 flex-1 flex-col border-r border-border/10">
+          <div className="px-4 py-1.5">
+            <span className="text-[10px] font-semibold tracking-wider uppercase text-muted-foreground/35">
+              Original
+            </span>
+          </div>
+          <ScrollArea className="min-h-0 flex-1">
+            <p className="px-4 pb-4 text-[12.5px] leading-[1.7] text-foreground/55">
+              {entry.inputText}
+            </p>
+          </ScrollArea>
+        </div>
+
+        {/* Humanized */}
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="px-4 py-1.5">
+            <span className="text-[10px] font-semibold tracking-wider uppercase text-emerald-400/60">
+              Humanized
+            </span>
+          </div>
+          <ScrollArea className="min-h-0 flex-1">
+            <p className="px-4 pb-4 text-[12.5px] leading-[1.7] text-foreground/80">
+              {entry.outputText}
+            </p>
+          </ScrollArea>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────
+
+/** Extract first sentence or first ~60 chars as a short label. */
+function firstLine(text: string): string {
+  const first = text.split(/[.!?\n]/)[0]?.trim() ?? text.trim();
+  if (first.length <= 60) return first;
+  return first.slice(0, 57) + '…';
+}
+
+function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+
+  return new Date(iso).toLocaleDateString();
+}

--- a/packages/pi-humanizer-extension/ui/components/InstructionPresets.tsx
+++ b/packages/pi-humanizer-extension/ui/components/InstructionPresets.tsx
@@ -1,0 +1,197 @@
+/**
+ * InstructionPresets — bold chip selector with emerald/indigo accents.
+ *
+ * Active chips glow with color. The active instructions description
+ * is prominent and readable, not ghost text. Custom presets persist in state.
+ */
+
+import { useState } from 'react';
+import { cn } from '@sero/ui/lib/utils';
+import { Button } from '@sero/ui/components/ui/button';
+import { Input } from '@sero/ui/components/ui/input';
+import { Textarea } from '@sero/ui/components/ui/textarea';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@sero/ui/components/ui/dialog';
+import type { InstructionPreset } from '../../shared/types';
+import { BUILT_IN_PRESETS } from '../lib/presets';
+
+interface InstructionPresetsProps {
+  activeIds: Set<string>;
+  customPresets: InstructionPreset[];
+  onToggle: (id: string) => void;
+  onAddCustom: (preset: InstructionPreset) => void;
+  onRemoveCustom: (id: string) => void;
+}
+
+export function InstructionPresets({
+  activeIds,
+  customPresets,
+  onToggle,
+  onAddCustom,
+  onRemoveCustom,
+}: InstructionPresetsProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [newPrompt, setNewPrompt] = useState('');
+
+  const allPresets = [...BUILT_IN_PRESETS, ...customPresets];
+
+  const activePresets = allPresets.filter((p) => activeIds.has(p.id));
+
+  const handleSave = () => {
+    const label = newLabel.trim();
+    const prompt = newPrompt.trim();
+    if (!label || !prompt) return;
+
+    const id = `custom-${Date.now()}`;
+    onAddCustom({ id, label, prompt, builtIn: false });
+    setNewLabel('');
+    setNewPrompt('');
+    setDialogOpen(false);
+    onToggle(id);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* Chips row */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {allPresets.map((preset) => {
+          const isActive = activeIds.has(preset.id);
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => onToggle(preset.id)}
+              className={cn(
+                'humanizer-chip',
+                'inline-flex items-center gap-1 rounded-lg',
+                'px-2.5 py-1 text-xs font-medium',
+                'border transition-all duration-200',
+                'select-none',
+                isActive
+                  ? [
+                      'border-indigo-500/40 bg-indigo-500/15 text-indigo-300',
+                      'shadow-[0_0_12px_rgba(99,102,241,0.15)]',
+                    ]
+                  : [
+                      'border-border/30 text-muted-foreground/50',
+                      'hover:border-border/60 hover:text-muted-foreground/80',
+                      'hover:bg-white/[0.02]',
+                    ],
+              )}
+            >
+              {preset.label}
+              {!preset.builtIn && (
+                <span
+                  role="button"
+                  className={cn(
+                    'ml-0.5 text-[10px] leading-none transition-colors',
+                    isActive
+                      ? 'text-indigo-400/50 hover:text-indigo-300'
+                      : 'text-muted-foreground/30 hover:text-destructive',
+                  )}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemoveCustom(preset.id);
+                  }}
+                >
+                  ×
+                </span>
+              )}
+            </button>
+          );
+        })}
+
+        {/* Add custom */}
+        <button
+          type="button"
+          onClick={() => setDialogOpen(true)}
+          className={cn(
+            'humanizer-chip',
+            'inline-flex items-center gap-1 rounded-lg',
+            'border border-dashed border-border/30',
+            'px-2 py-1 text-[11px] text-muted-foreground/30',
+            'transition-all hover:border-indigo-500/30 hover:text-indigo-400/60',
+          )}
+        >
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+          Custom
+        </button>
+      </div>
+
+      {/* Active instructions — bold and readable */}
+      {activePresets.length > 0 && (
+        <div
+          className={cn(
+            'rounded-lg px-3 py-2',
+            'border border-indigo-500/15 bg-indigo-500/[0.06]',
+          )}
+        >
+          <div className="flex flex-wrap gap-x-1.5 gap-y-0.5">
+            {activePresets.map((p, i) => (
+              <span key={p.id} className="text-[12.5px] leading-relaxed text-indigo-300/90">
+                {p.prompt}
+                {i < activePresets.length - 1 && (
+                  <span className="text-indigo-500/30"> · </span>
+                )}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Create dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>New instruction preset</DialogTitle>
+            <DialogDescription>
+              Create a reusable style to apply to any humanization.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3 py-2">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">Name</label>
+              <Input
+                value={newLabel}
+                onChange={(e) => setNewLabel(e.target.value)}
+                placeholder="e.g. Blog post"
+                className="h-8"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-xs font-medium text-muted-foreground">Instructions</label>
+              <Textarea
+                value={newPrompt}
+                onChange={(e) => setNewPrompt(e.target.value)}
+                placeholder="e.g. Write in a warm, personal blog style. Use first person."
+                className="min-h-[80px] resize-none"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={!newLabel.trim() || !newPrompt.trim()}
+              className="bg-indigo-600 text-white hover:bg-indigo-500"
+            >
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/pi-humanizer-extension/ui/components/InstructionPresets.tsx
+++ b/packages/pi-humanizer-extension/ui/components/InstructionPresets.tsx
@@ -19,11 +19,10 @@ import {
   DialogFooter,
 } from '@sero/ui/components/ui/dialog';
 import type { InstructionPreset } from '../../shared/types';
-import { BUILT_IN_PRESETS } from '../lib/presets';
 
 interface InstructionPresetsProps {
   activeIds: Set<string>;
-  customPresets: InstructionPreset[];
+  allPresets: InstructionPreset[];
   onToggle: (id: string) => void;
   onAddCustom: (preset: InstructionPreset) => void;
   onRemoveCustom: (id: string) => void;
@@ -31,7 +30,7 @@ interface InstructionPresetsProps {
 
 export function InstructionPresets({
   activeIds,
-  customPresets,
+  allPresets,
   onToggle,
   onAddCustom,
   onRemoveCustom,
@@ -39,8 +38,6 @@ export function InstructionPresets({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [newLabel, setNewLabel] = useState('');
   const [newPrompt, setNewPrompt] = useState('');
-
-  const allPresets = [...BUILT_IN_PRESETS, ...customPresets];
 
   const activePresets = allPresets.filter((p) => activeIds.has(p.id));
 
@@ -88,10 +85,10 @@ export function InstructionPresets({
             >
               {preset.label}
               {!preset.builtIn && (
-                <span
-                  role="button"
+                <button
+                  type="button"
                   className={cn(
-                    'ml-0.5 text-[10px] leading-none transition-colors',
+                    'ml-0.5 bg-transparent border-none p-0 text-[10px] leading-none transition-colors cursor-pointer',
                     isActive
                       ? 'text-indigo-400/50 hover:text-indigo-300'
                       : 'text-muted-foreground/30 hover:text-destructive',
@@ -102,7 +99,7 @@ export function InstructionPresets({
                   }}
                 >
                   ×
-                </span>
+                </button>
               )}
             </button>
           );

--- a/packages/pi-humanizer-extension/ui/components/PanelActions.tsx
+++ b/packages/pi-humanizer-extension/ui/components/PanelActions.tsx
@@ -1,0 +1,73 @@
+/**
+ * PanelActions — copy + refine buttons for the output pane header.
+ */
+
+import { cn } from '@sero/ui/lib/utils';
+import { Button } from '@sero/ui/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@sero/ui/components/ui/tooltip';
+
+interface PanelActionsProps {
+  copied: boolean;
+  onCopy: () => void;
+  onRefine: () => void;
+}
+
+export function PanelActions({ copied, onCopy, onRefine }: PanelActionsProps) {
+  return (
+    <TooltipProvider>
+      <div className="flex items-center gap-1">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 rounded-md px-2 text-[11px] text-muted-foreground/50 hover:text-foreground"
+              onClick={onRefine}
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mr-1">
+                <polyline points="1 4 1 10 7 10" />
+                <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+              </svg>
+              Refine
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Move to input for another pass</TooltipContent>
+        </Tooltip>
+
+        <Button
+          variant={copied ? 'default' : 'ghost'}
+          size="sm"
+          className={cn(
+            'h-6 rounded-md px-2.5 text-[11px] transition-all duration-200',
+            copied
+              ? 'bg-emerald-600 text-white hover:bg-emerald-600'
+              : 'text-muted-foreground/50 hover:text-foreground',
+          )}
+          onClick={onCopy}
+        >
+          {copied ? (
+            <span className="flex items-center gap-1">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              Copied
+            </span>
+          ) : (
+            <span className="flex items-center gap-1">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+                <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+              </svg>
+              Copy
+            </span>
+          )}
+        </Button>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/packages/pi-humanizer-extension/ui/components/StatsRow.tsx
+++ b/packages/pi-humanizer-extension/ui/components/StatsRow.tsx
@@ -1,0 +1,26 @@
+/**
+ * StatsRow — inline word/char/reading-time display.
+ *
+ * Compact single-line stats shown beneath text areas.
+ */
+
+import { computeStats } from '../lib/text-stats';
+
+interface StatsRowProps {
+  text: string;
+}
+
+export function StatsRow({ text }: StatsRowProps) {
+  const stats = computeStats(text);
+  if (stats.words === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-muted-foreground/40">
+      <span>{stats.words} words</span>
+      <span className="text-border/60">·</span>
+      <span>{stats.chars} chars</span>
+      <span className="text-border/60">·</span>
+      <span>{stats.readingTime} read</span>
+    </div>
+  );
+}

--- a/packages/pi-humanizer-extension/ui/lib/presets.ts
+++ b/packages/pi-humanizer-extension/ui/lib/presets.ts
@@ -1,0 +1,53 @@
+/**
+ * Built-in instruction presets for the humanizer.
+ *
+ * These are always available and cannot be deleted.
+ * Users can create additional custom presets that persist in state.
+ */
+
+import type { InstructionPreset } from '../../shared/types';
+
+export const BUILT_IN_PRESETS: InstructionPreset[] = [
+  {
+    id: 'casual',
+    label: 'Casual',
+    prompt: 'Use a relaxed, conversational tone. Write like you\'re explaining to a friend.',
+    builtIn: true,
+  },
+  {
+    id: 'academic',
+    label: 'Academic',
+    prompt: 'Maintain a formal academic register. Use precise language and cite-ready phrasing. Avoid first person.',
+    builtIn: true,
+  },
+  {
+    id: 'technical',
+    label: 'Technical',
+    prompt: 'Preserve all technical terms, code references, and domain-specific jargon exactly. Only humanize the surrounding prose.',
+    builtIn: true,
+  },
+  {
+    id: 'concise',
+    label: 'Concise',
+    prompt: 'Be ruthlessly concise. Cut every unnecessary word. Prefer short sentences.',
+    builtIn: true,
+  },
+  {
+    id: 'british',
+    label: 'British English',
+    prompt: 'Use British English spelling and conventions (colour, organisation, whilst, etc.).',
+    builtIn: true,
+  },
+  {
+    id: 'opinionated',
+    label: 'Opinionated',
+    prompt: 'Write with a clear point of view. Have opinions. Don\'t hedge everything. Let personality come through.',
+    builtIn: true,
+  },
+  {
+    id: 'minimal',
+    label: 'Minimal edits',
+    prompt: 'Make the fewest changes possible. Only fix the most obvious AI tells — leave everything else untouched.',
+    builtIn: true,
+  },
+];

--- a/packages/pi-humanizer-extension/ui/lib/text-stats.ts
+++ b/packages/pi-humanizer-extension/ui/lib/text-stats.ts
@@ -3,19 +3,17 @@
 export interface TextStats {
   words: number;
   chars: number;
-  sentences: number;
   readingTime: string; // e.g. "< 1 min", "2 min"
 }
 
 export function computeStats(text: string): TextStats {
   const trimmed = text.trim();
-  if (!trimmed) return { words: 0, chars: 0, sentences: 0, readingTime: '0 min' };
+  if (!trimmed) return { words: 0, chars: 0, readingTime: '0 min' };
 
   const words = trimmed.split(/\s+/).length;
   const chars = trimmed.length;
-  const sentences = (trimmed.match(/[.!?]+/g) || []).length || (words > 0 ? 1 : 0);
-  const minutes = Math.ceil(words / 200);
+  const minutes = Math.floor(words / 200);
   const readingTime = minutes < 1 ? '< 1 min' : `${minutes} min`;
 
-  return { words, chars, sentences, readingTime };
+  return { words, chars, readingTime };
 }

--- a/packages/pi-humanizer-extension/ui/lib/text-stats.ts
+++ b/packages/pi-humanizer-extension/ui/lib/text-stats.ts
@@ -1,0 +1,21 @@
+/** Compute simple text statistics for display. */
+
+export interface TextStats {
+  words: number;
+  chars: number;
+  sentences: number;
+  readingTime: string; // e.g. "< 1 min", "2 min"
+}
+
+export function computeStats(text: string): TextStats {
+  const trimmed = text.trim();
+  if (!trimmed) return { words: 0, chars: 0, sentences: 0, readingTime: '0 min' };
+
+  const words = trimmed.split(/\s+/).length;
+  const chars = trimmed.length;
+  const sentences = (trimmed.match(/[.!?]+/g) || []).length || (words > 0 ? 1 : 0);
+  const minutes = Math.ceil(words / 200);
+  const readingTime = minutes < 1 ? '< 1 min' : `${minutes} min`;
+
+  return { words, chars, sentences, readingTime };
+}

--- a/packages/pi-humanizer-extension/ui/lib/view-transition.ts
+++ b/packages/pi-humanizer-extension/ui/lib/view-transition.ts
@@ -1,0 +1,26 @@
+/**
+ * View Transitions helper.
+ *
+ * Wraps state updates in `document.startViewTransition()` when available
+ * (Chromium 111+, which Electron supports). Falls back to immediate update.
+ * Uses `flushSync` to ensure React commits the DOM change synchronously
+ * within the transition callback — required for the browser to capture
+ * correct before/after snapshots.
+ */
+
+import { flushSync } from 'react-dom';
+
+/**
+ * Run a state-updating callback inside a View Transition.
+ * The callback MUST call React setState (or similar) to trigger a DOM change.
+ */
+export function withViewTransition(callback: () => void): void {
+  if (!document.startViewTransition) {
+    callback();
+    return;
+  }
+
+  document.startViewTransition(() => {
+    flushSync(callback);
+  });
+}

--- a/packages/pi-humanizer-extension/ui/styles.css
+++ b/packages/pi-humanizer-extension/ui/styles.css
@@ -1,6 +1,8 @@
 @import "tailwindcss";
 
 @source "../../ui/src/components";
+@source "./components";
+@source "./lib";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -30,12 +32,138 @@
   --color-ring: var(--ring);
 }
 
-/* Loading dots animation */
-@keyframes humanizer-pulse {
-  0%, 100% { opacity: 0.3; }
-  50% { opacity: 1; }
+/* ── View Transition names ──────────────────────────────── */
+/* Named elements get individually tracked by the browser's
+   view transition engine — each gets its own morph animation
+   instead of the default full-page crossfade. */
+
+.vt-header   { view-transition-name: humanizer-header; }
+.vt-toolbar  { view-transition-name: humanizer-toolbar; }
+.vt-input-pane  { view-transition-name: humanizer-input; }
+.vt-output-pane { view-transition-name: humanizer-output; }
+
+/* ── View Transition animations ─────────────────────────── */
+
+/* Header + toolbar stay put (no animation, just morph) */
+::view-transition-old(humanizer-header),
+::view-transition-new(humanizer-header),
+::view-transition-old(humanizer-toolbar),
+::view-transition-new(humanizer-toolbar) {
+  animation-duration: 0.35s;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.humanizer-dot {
-  animation: humanizer-pulse 1s ease-in-out infinite;
+/* Input pane morphs (shrinks from full → half width) */
+::view-transition-old(humanizer-input) {
+  animation: vt-input-out 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+::view-transition-new(humanizer-input) {
+  animation: vt-input-in 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes vt-input-out {
+  to { opacity: 0.3; }
+}
+@keyframes vt-input-in {
+  from { opacity: 0.3; }
+  to { opacity: 1; }
+}
+
+/* Output pane slides in from right with emerald glow */
+::view-transition-old(humanizer-output) {
+  animation: vt-output-exit 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+::view-transition-new(humanizer-output) {
+  animation: vt-output-enter 0.5s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes vt-output-enter {
+  from {
+    opacity: 0;
+    transform: translateX(40px);
+    filter: blur(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+    filter: blur(0);
+  }
+}
+
+@keyframes vt-output-exit {
+  to {
+    opacity: 0;
+    transform: translateX(40px);
+    filter: blur(4px);
+  }
+}
+
+/* Default page-level transition (for history toggle, etc.) */
+::view-transition-old(root) {
+  animation: vt-fade-out 0.25s ease;
+}
+::view-transition-new(root) {
+  animation: vt-fade-in 0.3s ease;
+}
+
+@keyframes vt-fade-out {
+  to { opacity: 0; transform: scale(0.98); }
+}
+@keyframes vt-fade-in {
+  from { opacity: 0; transform: scale(0.98); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+/* ── Output pane glow ─────────────────────────────────── */
+
+.humanizer-output-pane {
+  background: linear-gradient(
+    135deg,
+    rgba(16, 185, 129, 0.03) 0%,
+    transparent 50%,
+    rgba(99, 102, 241, 0.02) 100%
+  );
+}
+
+/* ── Textarea polish ──────────────────────────────────── */
+
+.humanizer-textarea {
+  font-feature-settings: 'kern' 1, 'liga' 1;
+  -webkit-font-smoothing: antialiased;
+  /* Kill the global :focus-visible outline from Sero's base CSS */
+  outline: none !important;
+}
+
+.humanizer-textarea:focus-visible {
+  outline: none !important;
+}
+
+.humanizer-textarea::selection {
+  background: rgba(16, 185, 129, 0.2);
+}
+
+/* ── Chip press effect ────────────────────────────────── */
+
+.humanizer-chip:active {
+  transform: scale(0.95);
+  transition-duration: 80ms;
+}
+
+/* ── Button glow pulse while loading ──────────────────── */
+
+.humanizer-button:disabled {
+  opacity: 1;
+}
+
+.humanizer-button:disabled:has(svg) {
+  animation: humanizer-glow 2s ease-in-out infinite;
+}
+
+@keyframes humanizer-glow {
+  0%, 100% {
+    box-shadow: 0 0 16px rgba(16, 185, 129, 0.15);
+  }
+  50% {
+    box-shadow: 0 0 28px rgba(16, 185, 129, 0.35);
+  }
 }


### PR DESCRIPTION
## Summary

Redesigns the Humanizer app from a basic text-in/text-out form into a polished, feature-rich tool with Sero's emerald/indigo visual identity.

## Changes

### Instruction Presets
- 7 built-in style presets (Casual, Academic, Technical, Concise, British English, Opinionated, Minimal edits)
- Custom presets via dialog — persist in `state.json`
- Multiple presets can be active simultaneously; prompts combine
- Indigo-accented chips with glow on active state, tooltip previews removed in favor of inline description

### Layout & View Transitions
- **Input mode**: full-width textarea filling the viewport
- **Result mode**: side-by-side split — original left, humanized right
- Transitions between modes animated via the **View Transitions API** (`document.startViewTransition` + `flushSync`)
- Named transition elements: input pane morphs width, output pane slides in from right with blur-to-sharp reveal
- History/editor toggle uses root-level scale+fade transition

### Iterative Refinement
- **Refine** button moves output back to input for another humanization pass
- Copy button with emerald checkmark confirmation state

### History (master-detail)
- Compact entry list on the left (first sentence + relative time)
- Full before/after preview on the right when an entry is selected
- "Load in editor" button to restore any previous humanization
- Clear history with 2-click confirmation, auto-resets after 3s

### Visual Identity
- Emerald Humanize button with pulsing glow shadow while loading
- Indigo chips for active presets, indigo-tinted instruction description
- Emerald "Humanized" pane header, subtle gradient output background
- Emerald header icon

### Fixes
- Added `@source ./components` and `@source ./lib` to `styles.css` — the remote's own Tailwind build was missing classes from its component files
- Killed the global purple focus ring (`:focus-visible`) on textareas with `outline: none !important`
- Proper padding on textareas (`px-5 py-4` / `px-4 py-3`)
- Fixed button gap between Clear and Humanize

### New Files
| File | Purpose |
|------|---------|
| `ui/components/InstructionPresets.tsx` | Chip selector + create dialog |
| `ui/components/PanelActions.tsx` | Copy/Refine buttons for output pane |
| `ui/components/StatsRow.tsx` | Word/char/reading time display |
| `ui/components/HistoryPanel.tsx` | Master-detail history browser |
| `ui/lib/presets.ts` | 7 built-in instruction presets |
| `ui/lib/text-stats.ts` | Text statistics calculator |
| `ui/lib/view-transition.ts` | View Transitions API wrapper |

### Types
- Added `InstructionPreset` interface and `customPresets` field to `HumanizerState`

## Checklist
- [x] `pnpm typecheck` passes (23/23 packages)
- [x] All source files under 500 LOC
- [x] No `localStorage`/`sessionStorage` usage
- [x] No `@ts-ignore` or `any` casts