### PR TITLE
feat(memory): migrate QMD integration from CLI to v2 SDK library

### DIFF
--- a/apps/desktop/electron/cli/commands/app-control.ts
+++ b/apps/desktop/electron/cli/commands/app-control.ts
@@ -5,7 +5,7 @@
  * sero-cli bridge (AD-020) — zero additional tool schema tokens.
  */
 
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, screen } from 'electron';
 import type { CliRegistry } from '../registry';
 import type { CliCommandContext } from '../types';
 import { fail, ok, parseFlags, requireFlagString, stringifyJson } from './utils';
@@ -34,10 +34,32 @@ async function captureAppScreenshot(): Promise<string | null> {
   if (!win) return null;
   const rect = await exec<AppPanelRect | null>('window.__appControl?.getAppRect() ?? null');
   if (!rect || rect.width <= 0 || rect.height <= 0) return null;
-  const image = await win.webContents.capturePage({
-    x: Math.round(rect.x), y: Math.round(rect.y),
-    width: Math.round(rect.width), height: Math.round(rect.height),
-  });
+
+  // getBoundingClientRect() returns CSS pixels, but capturePage() expects DIP
+  // coordinates (matching the window's content bounds). When there's display
+  // scaling or a zoom factor, CSS px ≠ DIP. The conversion ratio is:
+  //   DIP = CSS × (devicePixelRatio / nativeDisplayScale)
+  const dpr = await exec<number>('window.devicePixelRatio');
+  const display = screen.getDisplayMatching(win.getBounds());
+  const cssToDisplay = dpr / display.scaleFactor;
+
+  // Compute the DIP capture rect from the CSS rect, using edge coordinates
+  // to avoid accumulating rounding errors on x+width.
+  const x = Math.floor(rect.x * cssToDisplay);
+  const y = Math.floor(rect.y * cssToDisplay);
+  const right = Math.ceil((rect.x + rect.width) * cssToDisplay);
+  const bottom = Math.ceil((rect.y + rect.height) * cssToDisplay);
+
+  // Clamp to the content area to prevent out-of-bounds capture
+  const bounds = win.getContentBounds();
+  const captureRect = {
+    x,
+    y,
+    width: Math.min(right, bounds.width) - x,
+    height: Math.min(bottom, bounds.height) - y,
+  };
+
+  const image = await win.webContents.capturePage(captureRect);
   return image.toPNG().toString('base64');
 }
 
@@ -115,19 +137,28 @@ async function handleScreenshot(args: string[], ctx: CliCommandContext) {
   const base64 = await captureAppScreenshot();
   if (!base64) return fail('Screenshot failed — app panel not found or not visible.');
 
-  // If --save specified, write to disk and return the path
+  const description = `Screenshot of ${targetApp ?? 'active'} app`;
+
+  // If --save specified, also write to disk
   if (savePath) {
     const { writeFile, mkdir } = await import('fs/promises');
     const path = await import('path');
     const absPath = path.isAbsolute(savePath) ? savePath : path.join(ctx.cwd, savePath);
     await mkdir(path.dirname(absPath), { recursive: true });
     await writeFile(absPath, Buffer.from(base64, 'base64'));
-    return ok(`Screenshot saved: ${absPath} (${Math.round(base64.length * 0.75 / 1024)}KB)`);
+    // Still return the image inline so it displays in the chat
+    return {
+      output: JSON.stringify({
+        type: 'image', format: 'png', base64,
+        description: `${description}\nSaved: ${absPath} (${Math.round(base64.length * 0.75 / 1024)}KB)`,
+      }),
+      exitCode: 0,
+    };
   }
 
   // Return inline image for the agent to see
   return {
-    output: JSON.stringify({ type: 'image', format: 'png', base64, description: `Screenshot of ${targetApp ?? 'active'} app` }),
+    output: JSON.stringify({ type: 'image', format: 'png', base64, description }),
     exitCode: 0,
   };
 }

--- a/apps/desktop/electron/cli/commands/app-control.ts
+++ b/apps/desktop/electron/cli/commands/app-control.ts
@@ -5,7 +5,7 @@
  * sero-cli bridge (AD-020) — zero additional tool schema tokens.
  */
 
-import { BrowserWindow, screen } from 'electron';
+import { BrowserWindow } from 'electron';
 import type { CliRegistry } from '../registry';
 import type { CliCommandContext } from '../types';
 import { fail, ok, parseFlags, requireFlagString, stringifyJson } from './utils';
@@ -16,6 +16,7 @@ import type {
   AppPanelRect,
   AppRecordingStatus,
 } from '../../../src/types/ipc';
+import { captureRegion } from '../../utils/capture';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -34,33 +35,7 @@ async function captureAppScreenshot(): Promise<string | null> {
   if (!win) return null;
   const rect = await exec<AppPanelRect | null>('window.__appControl?.getAppRect() ?? null');
   if (!rect || rect.width <= 0 || rect.height <= 0) return null;
-
-  // getBoundingClientRect() returns CSS pixels, but capturePage() expects DIP
-  // coordinates (matching the window's content bounds). When there's display
-  // scaling or a zoom factor, CSS px ≠ DIP. The conversion ratio is:
-  //   DIP = CSS × (devicePixelRatio / nativeDisplayScale)
-  const dpr = await exec<number>('window.devicePixelRatio');
-  const display = screen.getDisplayMatching(win.getBounds());
-  const cssToDisplay = dpr / display.scaleFactor;
-
-  // Compute the DIP capture rect from the CSS rect, using edge coordinates
-  // to avoid accumulating rounding errors on x+width.
-  const x = Math.floor(rect.x * cssToDisplay);
-  const y = Math.floor(rect.y * cssToDisplay);
-  const right = Math.ceil((rect.x + rect.width) * cssToDisplay);
-  const bottom = Math.ceil((rect.y + rect.height) * cssToDisplay);
-
-  // Clamp to the content area to prevent out-of-bounds capture
-  const bounds = win.getContentBounds();
-  const captureRect = {
-    x,
-    y,
-    width: Math.min(right, bounds.width) - x,
-    height: Math.min(bottom, bounds.height) - y,
-  };
-
-  const image = await win.webContents.capturePage(captureRect);
-  return image.toPNG().toString('base64');
+  return captureRegion(win, rect);
 }
 
 // ── Main Router ──────────────────────────────────────────────

--- a/apps/desktop/electron/csp.ts
+++ b/apps/desktop/electron/csp.ts
@@ -40,8 +40,11 @@ function buildCSP(): string {
   ];
 
   // -- connect-src --
+  // blob: is required so the prompt-input can fetch() blob URLs to convert
+  // pasted/dropped images into data URIs before sending to the agent.
   const connectSrc = [
     "'self'",
+    'blob:',
     'https://*.spotify.com',   // Spotify Web API
     'https://*.scdn.co',       // Spotify CDN
     'https://api.spotify.com',

--- a/apps/desktop/electron/gateway/agent-bridge.ts
+++ b/apps/desktop/electron/gateway/agent-bridge.ts
@@ -13,7 +13,7 @@
  */
 
 import type { GatewayAgentOps } from './index';
-import type { GatewayPushEvent } from './protocol';
+import type { GatewayPushEvent, GatewayToolEndEvent } from './protocol';
 import type { CostTracker } from './cost-tracker';
 
 // ── Agent operations bridge ─────────────────────────────────
@@ -115,7 +115,7 @@ function mapAgentEvent(
         toolCallId: event.toolCallId as string,
         output: (event.output as string) ?? null,
         isError: (event.isError as boolean) ?? false,
-        images: (event as any).images,
+        images: Array.isArray(event.images) ? event.images as GatewayToolEndEvent['images'] : undefined,
       };
 
     default:

--- a/apps/desktop/electron/gateway/agent-bridge.ts
+++ b/apps/desktop/electron/gateway/agent-bridge.ts
@@ -115,6 +115,7 @@ function mapAgentEvent(
         toolCallId: event.toolCallId as string,
         output: (event.output as string) ?? null,
         isError: (event.isError as boolean) ?? false,
+        images: (event as any).images,
       };
 
     default:

--- a/apps/desktop/electron/gateway/channels/discord.ts
+++ b/apps/desktop/electron/gateway/channels/discord.ts
@@ -5,11 +5,34 @@
  * routes messages to the gateway, and streams responses back.
  */
 
+import { nativeImage, net } from 'electron';
+import type { ResponseLike } from '@discordjs/rest';
+
 import type { GatewayServer, GatewayAgentOps } from '../index';
 import type { GatewayPushEvent } from '../protocol';
 
 // discord.js is dynamically imported to avoid hard dependency at startup
 let Discord: typeof import('discord.js') | null = null;
+
+/**
+ * Use Electron/Chromium's HTTP stack for Discord REST API calls.
+ *
+ * undici (used by @discordjs/rest) has its TLS connections to Discord
+ * (Cloudflare) rejected in the Electron environment — "other side closed"
+ * with bytesWritten: 0. Chromium's networking works reliably.
+ *
+ * net.fetch returns a standard Web API Response whose types (Headers,
+ * ReadableStream) are runtime-identical to their Node.js counterparts
+ * but carry incompatible TS declarations. The cast to ResponseLike is
+ * safe — both implement the same web-standard interfaces.
+ */
+async function chromiumFetch(
+  url: string,
+  init: Record<string, unknown>,
+): Promise<ResponseLike> {
+  const response = await net.fetch(url, init as RequestInit);
+  return response as unknown as ResponseLike;
+}
 
 export interface DiscordAdapterConfig {
   /** Discord bot token. */
@@ -27,6 +50,8 @@ interface ActiveSession {
   responseBuffer: string;
   /** Timer to flush response buffer. */
   flushTimer: ReturnType<typeof setTimeout> | null;
+  /** True while the agent is actively processing (between agent_start/agent_end). */
+  isProcessing: boolean;
 }
 
 export class DiscordAdapter {
@@ -73,6 +98,10 @@ export class DiscordAdapter {
         GatewayIntentBits.MessageContent,
       ],
       partials: [Partials.Channel],
+      rest: {
+        timeout: 60_000,
+        makeRequest: chromiumFetch,
+      },
     });
 
     this.client.on('ready', () => {
@@ -164,18 +193,22 @@ export class DiscordAdapter {
       // Non-critical
     }
 
-    // Route to agent
+    // Route to agent — steer if already processing, otherwise prompt
     try {
-      session.responseBuffer = '';
-      if (session.flushTimer) clearTimeout(session.flushTimer);
+      if (session.isProcessing) {
+        await this.agentOps.steer(session.sessionId, text);
+      } else {
+        session.responseBuffer = '';
+        if (session.flushTimer) clearTimeout(session.flushTimer);
 
-      // Open a session (creates one if needed) and send the prompt.
-      // Events flow back via the gateway event bridge → handleGatewayEvent.
-      await this.agentOps.openSession(
-        session.sessionId,
-        this.config.defaultWorkspaceId,
-      );
-      await this.agentOps.prompt(session.sessionId, text);
+        // Open a session (creates one if needed) and send the prompt.
+        // Events flow back via the gateway event bridge → handleGatewayEvent.
+        await this.agentOps.openSession(
+          session.sessionId,
+          this.config.defaultWorkspaceId,
+        );
+        await this.agentOps.prompt(session.sessionId, text);
+      }
     } catch (err) {
       await msg.reply(
         `Error: ${err instanceof Error ? err.message : 'Something went wrong'}`,
@@ -225,6 +258,7 @@ export class DiscordAdapter {
         channelId,
         responseBuffer: '',
         flushTimer: null,
+        isProcessing: false,
       };
       this.sessions.set(channelId, session);
     }
@@ -264,12 +298,103 @@ export class DiscordAdapter {
     for (const [, session] of this.sessions) {
       if ('sessionId' in event && event.sessionId !== session.sessionId) continue;
 
-      if (event.type === 'text_delta') {
+      if (event.type === 'agent_start') {
+        session.isProcessing = true;
+      } else if (event.type === 'text_delta') {
         session.responseBuffer += event.delta;
         this.scheduleFlush(session);
       } else if (event.type === 'agent_end') {
+        session.isProcessing = false;
         this.flushBuffer(session);
+      } else if (event.type === 'tool_end') {
+        // Send tool result images (e.g. screenshots) as Discord attachments
+        if (event.images?.length) {
+          for (const img of event.images) {
+            const format = img.mimeType.replace('image/', '') || 'png';
+            void this.sendImage(session.channelId, img.data, format, img.description);
+          }
+        }
       }
+    }
+  }
+
+  /** Max dimension (width or height) before downscaling for Discord. */
+  private static readonly MAX_IMAGE_DIM = 1920;
+  /** JPEG quality for compressed Discord uploads (0–100). */
+  private static readonly JPEG_QUALITY = 90;
+
+  /**
+   * Downscale and compress an image buffer for Discord.
+   *
+   * - Images larger than MAX_IMAGE_DIM on either axis are downscaled
+   *   proportionally.
+   * - Output is always JPEG at JPEG_QUALITY — screenshots go from
+   *   5–10 MB PNG to ~200–500 KB, making uploads near-instant.
+   * - Falls back to the original buffer if nativeImage can't decode it.
+   */
+  private compressImage(raw: Buffer): { buffer: Buffer; ext: string } {
+    const image = nativeImage.createFromBuffer(raw);
+    if (image.isEmpty()) {
+      // Can't decode — send the original unchanged
+      return { buffer: raw, ext: 'png' };
+    }
+
+    const { width, height } = image.getSize();
+    const maxDim = Math.max(width, height);
+
+    let output = image;
+    if (maxDim > DiscordAdapter.MAX_IMAGE_DIM) {
+      const scale = DiscordAdapter.MAX_IMAGE_DIM / maxDim;
+      output = image.resize({
+        width: Math.round(width * scale),
+        height: Math.round(height * scale),
+      });
+    }
+
+    return { buffer: output.toJPEG(DiscordAdapter.JPEG_QUALITY), ext: 'jpg' };
+  }
+
+  /**
+   * Send a base64-encoded image to a Discord channel as a file attachment.
+   *
+   * The image is downscaled and JPEG-compressed before upload to keep
+   * file sizes small and uploads fast. Discord free-tier limit is 25 MB.
+   */
+  private async sendImage(
+    channelId: string,
+    base64: string,
+    format: string,
+    caption?: string,
+  ): Promise<void> {
+    if (!this.client) return;
+
+    const rawBuffer = Buffer.from(base64, 'base64');
+    const rawMB = rawBuffer.byteLength / (1024 * 1024);
+
+    const { buffer, ext } = this.compressImage(rawBuffer);
+    const finalMB = buffer.byteLength / (1024 * 1024);
+
+    console.log(
+      `[discord] Image: ${rawMB.toFixed(2)} MB (${format}) → ${finalMB.toFixed(2)} MB (${ext})`,
+    );
+
+    if (buffer.byteLength > 25 * 1024 * 1024) {
+      console.warn(
+        `[discord] Image still too large after compression (${finalMB.toFixed(1)} MB > 25 MB limit), skipping`,
+      );
+      return;
+    }
+
+    try {
+      const channel = await this.client.channels.fetch(channelId);
+      if (!channel || !('send' in channel)) return;
+      await (channel as any).send({
+        content: caption ?? undefined,
+        files: [{ attachment: buffer, name: `screenshot.${ext}` }],
+      });
+      console.log(`[discord] Image sent successfully (${finalMB.toFixed(2)} MB)`);
+    } catch (err) {
+      console.error('[discord] Failed to send image:', err);
     }
   }
 

--- a/apps/desktop/electron/gateway/channels/discord.ts
+++ b/apps/desktop/electron/gateway/channels/discord.ts
@@ -11,6 +11,15 @@ import type { ResponseLike } from '@discordjs/rest';
 import type { GatewayServer, GatewayAgentOps } from '../index';
 import type { GatewayPushEvent } from '../protocol';
 
+/** Minimal interface for discord.js channels that support sending messages. */
+interface SendableChannel {
+  send(options: string | { content?: string; files?: { attachment: Buffer; name: string }[] }): Promise<unknown>;
+}
+
+function isSendable(channel: unknown): channel is SendableChannel {
+  return !!channel && typeof channel === 'object' && 'send' in channel;
+}
+
 // discord.js is dynamically imported to avoid hard dependency at startup
 let Discord: typeof import('discord.js') | null = null;
 
@@ -387,8 +396,8 @@ export class DiscordAdapter {
 
     try {
       const channel = await this.client.channels.fetch(channelId);
-      if (!channel || !('send' in channel)) return;
-      await (channel as any).send({
+      if (!isSendable(channel)) return;
+      await channel.send({
         content: caption ?? undefined,
         files: [{ attachment: buffer, name: `screenshot.${ext}` }],
       });
@@ -420,12 +429,12 @@ export class DiscordAdapter {
 
     try {
       const channel = await this.client.channels.fetch(session.channelId);
-      if (!channel || !('send' in channel)) return;
+      if (!isSendable(channel)) return;
 
       // Discord has a 2000 character limit per message
       const chunks = splitMessage(text, 2000);
       for (const chunk of chunks) {
-        await (channel as any).send(chunk);
+        await channel.send(chunk);
       }
     } catch (err) {
       console.error('[discord] Failed to send message:', err);

--- a/apps/desktop/electron/gateway/protocol.ts
+++ b/apps/desktop/electron/gateway/protocol.ts
@@ -110,6 +110,8 @@ export interface GatewayToolEndEvent {
   toolCallId: string;
   output: string | null;
   isError: boolean;
+  /** Images returned by this tool call (e.g. screenshots). */
+  images?: Array<{ data: string; mimeType: string; description?: string }>;
 }
 
 export interface GatewayArtifactEvent {

--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -324,33 +324,8 @@ export function attachmentsToImages(attachments?: ChatAttachment[]): ImageConten
 
 // ── Provider metadata ────────────────────────────────────────
 
-/* eslint-disable @typescript-eslint/naming-convention -- provider ID keys */
-const PROVIDER_NAMES: Record<string, string> = {
-  anthropic: 'Anthropic', openai: 'OpenAI', 'openai-codex': 'OpenAI (Codex)',
-  google: 'Google', 'google-gemini-cli': 'Google (Gemini CLI)',
-  'google-antigravity': 'Antigravity', 'google-vertex': 'Google Vertex',
-  xai: 'xAI', openrouter: 'OpenRouter', groq: 'Groq', cerebras: 'Cerebras',
-  mistral: 'Mistral', 'github-copilot': 'GitHub Copilot',
-  'amazon-bedrock': 'Amazon Bedrock', 'azure-openai-responses': 'Azure OpenAI',
-  huggingface: 'Hugging Face', 'vercel-ai-gateway': 'Vercel AI Gateway',
-  zai: 'ZAI', opencode: 'OpenCode', 'kimi-coding': 'Kimi', minimax: 'MiniMax',
-  'minimax-cn': 'MiniMax CN',
-};
-const PROVIDER_LOGO_MAP: Record<string, string> = {
-  'openai-codex': 'openai', 'google-gemini-cli': 'google',
-  'google-antigravity': 'google', 'google-vertex': 'google-vertex',
-  'azure-openai-responses': 'azure', 'amazon-bedrock': 'amazon-bedrock',
-  'github-copilot': 'github-copilot', 'vercel-ai-gateway': 'vercel',
-  'kimi-coding': 'openai',
-};
-/* eslint-enable @typescript-eslint/naming-convention */
-
-export function providerLogo(provider: string): string {
-  return `https://models.dev/logos/${PROVIDER_LOGO_MAP[provider] ?? provider}.svg`;
-}
-export function providerDisplayName(provider: string): string {
-  return PROVIDER_NAMES[provider] ?? provider.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-}
+import { providerLogo, providerDisplayName } from './provider-metadata';
+export { providerLogo, providerDisplayName };
 
 // ── Model state builder ──────────────────────────────────────
 

--- a/apps/desktop/electron/ipc/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent-helpers.ts
@@ -15,9 +15,11 @@ import type {
   ChatToolCallMessage,
   SeroSlashCommandInfo,
   SessionModelState,
+  ToolResultImage,
 } from '../../src/types/ipc';
 import type { ChatCheckpointRef } from '../../src/types/checkpoints';
 import { resizeImageForApi } from '../utils/image-resize';
+import { tryParseImageJson } from './agent-subscription';
 import { extractOriginalCollaborationQuery } from './collaboration-message';
 
 // ── ID generation ────────────────────────────────────────────
@@ -181,6 +183,25 @@ export function convertSessionMessages(
               .join('\n');
       // Strip collaboration injection wrapper so the UI shows the original query
       const text = extractOriginalCollaborationQuery(rawText);
+
+      // Restore image attachments so they survive session reload.
+      // The Pi SDK stores user images as { type: 'image', data, mimeType } blocks.
+      let attachments: ChatAttachment[] | undefined;
+      if (typeof msg.content !== 'string') {
+        for (const block of msg.content) {
+          if (block.type !== 'image') continue;
+          const imgBlock = block as { type: 'image'; data: string; mimeType?: string };
+          if (!attachments) attachments = [];
+          const mime = imgBlock.mimeType ?? 'image/png';
+          attachments.push({
+            id: `att-${nextId()}`,
+            filename: 'Image',
+            mediaType: mime,
+            url: `data:${mime};base64,${imgBlock.data}`,
+          });
+        }
+      }
+
       // Shifted by one: user message N shows the checkpoint from the
       // *previous* turn (N-1). "Restore on message N" means "go back to
       // the state just before I sent message N", which is the end of turn N-1.
@@ -189,6 +210,7 @@ export function convertSessionMessages(
         type: 'user',
         id: nextId(),
         text,
+        attachments,
         checkpoint,
       } as ChatMessage);
     } else if (msg.role === 'assistant') {
@@ -217,12 +239,35 @@ export function convertSessionMessages(
         );
         let output: string | null = null;
         let isError = false;
+        let images: ToolResultImage[] | undefined;
+
         if (toolResult && toolResult.role === 'toolResult') {
-          output = toolResult.content
-            .filter((c: { type: string }): c is { type: 'text'; text: string } => c.type === 'text')
-            .map((c: { type: 'text'; text: string }) => c.text)
-            .join('\n') || null;
+          const textParts = toolResult.content
+            .filter((c: { type: string }): c is { type: 'text'; text: string } => c.type === 'text');
+          output = textParts.map((c) => c.text).join('\n') || null;
           isError = toolResult.isError;
+
+          // Extract image content blocks (screenshots, browser captures).
+          // toolResult.content items are a union; only image blocks have `data`.
+          for (const block of toolResult.content) {
+            if (block.type !== 'image') continue;
+            const imgBlock = block as { type: 'image'; data: string; mimeType?: string };
+            if (!images) images = [];
+            images.push({
+              data: imgBlock.data,
+              mimeType: imgBlock.mimeType ?? 'image/png',
+              description: output || undefined,
+            });
+          }
+
+          // Also check if text output is a JSON-encoded image (sero-cli screenshot)
+          if (!images && output) {
+            const parsed = tryParseImageJson(output);
+            if (parsed) {
+              images = [parsed];
+              output = parsed.description ?? null;
+            }
+          }
         }
 
         result.push({
@@ -233,7 +278,8 @@ export function convertSessionMessages(
           input: tc.arguments,
           output,
           isError,
-          state: output !== null ? (isError ? 'error' : 'completed') : 'completed',
+          state: output !== null || images ? (isError ? 'error' : 'completed') : 'completed',
+          images,
         });
       }
     } else if (msg.role === 'custom') {
@@ -264,7 +310,10 @@ export function attachmentsToImages(attachments?: ChatAttachment[]): ImageConten
     if (!mime.startsWith('image/')) continue;
 
     const match = att.url.match(/^data:[^;]+;base64,(.+)$/);
-    if (!match) continue;
+    if (!match) {
+      console.warn(`[agent] attachment skipped: url is not a data URI (${att.filename})`);
+      continue;
+    }
 
     const resized = resizeImageForApi(match[1], mime);
     images.push({ type: 'image', data: resized.data, mimeType: resized.mimeType });
@@ -275,46 +324,30 @@ export function attachmentsToImages(attachments?: ChatAttachment[]): ImageConten
 
 // ── Provider metadata ────────────────────────────────────────
 
+/* eslint-disable @typescript-eslint/naming-convention -- provider ID keys */
 const PROVIDER_NAMES: Record<string, string> = {
-  anthropic: 'Anthropic',
-  openai: 'OpenAI',
-  'openai-codex': 'OpenAI (Codex)',
-  google: 'Google',
-  'google-gemini-cli': 'Google (Gemini CLI)',
-  'google-antigravity': 'Antigravity',
-  'google-vertex': 'Google Vertex',
-  xai: 'xAI',
-  openrouter: 'OpenRouter',
-  groq: 'Groq',
-  cerebras: 'Cerebras',
-  mistral: 'Mistral',
-  'github-copilot': 'GitHub Copilot',
-  'amazon-bedrock': 'Amazon Bedrock',
-  'azure-openai-responses': 'Azure OpenAI',
-  huggingface: 'Hugging Face',
-  'vercel-ai-gateway': 'Vercel AI Gateway',
-  zai: 'ZAI',
-  opencode: 'OpenCode',
-  'kimi-coding': 'Kimi',
+  anthropic: 'Anthropic', openai: 'OpenAI', 'openai-codex': 'OpenAI (Codex)',
+  google: 'Google', 'google-gemini-cli': 'Google (Gemini CLI)',
+  'google-antigravity': 'Antigravity', 'google-vertex': 'Google Vertex',
+  xai: 'xAI', openrouter: 'OpenRouter', groq: 'Groq', cerebras: 'Cerebras',
+  mistral: 'Mistral', 'github-copilot': 'GitHub Copilot',
+  'amazon-bedrock': 'Amazon Bedrock', 'azure-openai-responses': 'Azure OpenAI',
+  huggingface: 'Hugging Face', 'vercel-ai-gateway': 'Vercel AI Gateway',
+  zai: 'ZAI', opencode: 'OpenCode', 'kimi-coding': 'Kimi', minimax: 'MiniMax',
+  'minimax-cn': 'MiniMax CN',
 };
-
 const PROVIDER_LOGO_MAP: Record<string, string> = {
-  'openai-codex': 'openai',
-  'google-gemini-cli': 'google',
-  'google-antigravity': 'google',
-  'google-vertex': 'google-vertex',
-  'azure-openai-responses': 'azure',
-  'amazon-bedrock': 'amazon-bedrock',
-  'github-copilot': 'github-copilot',
-  'vercel-ai-gateway': 'vercel',
+  'openai-codex': 'openai', 'google-gemini-cli': 'google',
+  'google-antigravity': 'google', 'google-vertex': 'google-vertex',
+  'azure-openai-responses': 'azure', 'amazon-bedrock': 'amazon-bedrock',
+  'github-copilot': 'github-copilot', 'vercel-ai-gateway': 'vercel',
   'kimi-coding': 'openai',
 };
+/* eslint-enable @typescript-eslint/naming-convention */
 
 export function providerLogo(provider: string): string {
-  const slug = PROVIDER_LOGO_MAP[provider] ?? provider;
-  return `https://models.dev/logos/${slug}.svg`;
+  return `https://models.dev/logos/${PROVIDER_LOGO_MAP[provider] ?? provider}.svg`;
 }
-
 export function providerDisplayName(provider: string): string {
   return PROVIDER_NAMES[provider] ?? provider.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/apps/desktop/electron/ipc/agent-subscription.ts
+++ b/apps/desktop/electron/ipc/agent-subscription.ts
@@ -10,6 +10,7 @@ import type {
   ChatAssistantMessage,
   ChatToolCallMessage,
   AgentStreamEvent,
+  ToolResultImage,
 } from '../../src/types/ipc';
 import type { ChatCheckpointRef } from '../../src/types/checkpoints';
 
@@ -157,23 +158,73 @@ export function subscribeToSession(
       case 'tool_execution_end': {
         const result = event.result;
         let text: string | null = null;
+        let images: ToolResultImage[] | undefined;
+
         if (result?.content && Array.isArray(result.content)) {
-          text = result.content
-            .filter((c: { type: string }) => c.type === 'text')
-            .map((c: { text: string }) => c.text)
-            .join('\n') || null;
+          const textParts = result.content.filter(
+            (c: { type: string }) => c.type === 'text',
+          );
+          const imageParts = result.content.filter(
+            (c: { type: string }) => c.type === 'image',
+          ) as { type: 'image'; data: string; mimeType?: string }[];
+
+          text = textParts.map((c: { text: string }) => c.text).join('\n') || null;
+
+          if (imageParts.length > 0) {
+            const description = text || undefined;
+            images = imageParts.map((img) => ({
+              data: img.data,
+              mimeType: img.mimeType ?? 'image/png',
+              description,
+            }));
+          }
         } else if (typeof result === 'string') {
-          text = result;
+          // Check if result is a JSON-encoded image (sero-cli screenshot output)
+          const parsed = tryParseImageJson(result);
+          if (parsed) {
+            images = [parsed];
+            text = parsed.description ?? null;
+          } else {
+            text = result;
+          }
         }
+
         sendEvent({
           type: 'tool_end',
           sessionId,
           toolCallId: event.toolCallId,
           output: text,
           isError: event.isError,
+          images,
         });
         break;
       }
     }
   });
+}
+
+// ── Helpers ───────────────────────────────────────────────────
+
+/**
+ * Try to parse a JSON string as a CLI-encoded image
+ * (e.g. `{ type: 'image', format: 'png', base64: '...' }`).
+ * Also used by agent-helpers.ts for history replay.
+ */
+export function tryParseImageJson(text: string): ToolResultImage | null {
+  try {
+    const parsed = JSON.parse(text);
+    if (parsed?.type === 'image' && typeof parsed.base64 === 'string') {
+      const mimeType = parsed.format
+        ? `image/${parsed.format}`
+        : 'image/png';
+      return {
+        data: parsed.base64,
+        mimeType,
+        description: parsed.description ?? parsed.message,
+      };
+    }
+  } catch {
+    /* not JSON — ignore */
+  }
+  return null;
 }

--- a/apps/desktop/electron/ipc/app-control.ts
+++ b/apps/desktop/electron/ipc/app-control.ts
@@ -7,7 +7,7 @@
  * `webContents.capturePage()`.
  */
 
-import { ipcMain, BrowserWindow, screen } from 'electron';
+import { ipcMain, BrowserWindow } from 'electron';
 import { writeFile, mkdir } from 'fs/promises';
 import path from 'path';
 import { tmpdir } from 'os';
@@ -19,6 +19,7 @@ import type {
   AppPanelRect,
   AppRecordingStatus,
 } from '../../src/types/ipc';
+import { captureRegion } from '../utils/capture';
 
 // ── Recording State ──────────────────────────────────────────
 
@@ -47,38 +48,10 @@ async function execRenderer<T>(code: string): Promise<T> {
   return win.webContents.executeJavaScript(code) as Promise<T>;
 }
 
-/**
- * Capture a region of the page. `rect` is in CSS pixels (from
- * getBoundingClientRect). capturePage() expects DIP coordinates, which can
- * differ when there's display scaling or a zoom factor (DPR ≠ native scale).
- */
 async function captureRect(rect: AppPanelRect): Promise<string | null> {
   const win = getMainWindow();
   if (!win) return null;
-  if (rect.width <= 0 || rect.height <= 0) return null;
-
-  // Convert CSS px → DIP: ratio = devicePixelRatio / nativeDisplayScale
-  const dpr = await execRenderer<number>('window.devicePixelRatio');
-  const display = screen.getDisplayMatching(win.getBounds());
-  const cssToDisplay = dpr / display.scaleFactor;
-
-  // Compute DIP rect from CSS edges to avoid rounding drift
-  const x = Math.floor(rect.x * cssToDisplay);
-  const y = Math.floor(rect.y * cssToDisplay);
-  const right = Math.ceil((rect.x + rect.width) * cssToDisplay);
-  const bottom = Math.ceil((rect.y + rect.height) * cssToDisplay);
-
-  // Clamp to content area
-  const bounds = win.getContentBounds();
-  const captureArea = {
-    x,
-    y,
-    width: Math.min(right, bounds.width) - x,
-    height: Math.min(bottom, bounds.height) - y,
-  };
-
-  const image = await win.webContents.capturePage(captureArea);
-  return image.toPNG().toString('base64');
+  return captureRegion(win, rect);
 }
 
 // ── Registration ─────────────────────────────────────────────

--- a/apps/desktop/electron/ipc/app-control.ts
+++ b/apps/desktop/electron/ipc/app-control.ts
@@ -7,7 +7,7 @@
  * `webContents.capturePage()`.
  */
 
-import { ipcMain, BrowserWindow } from 'electron';
+import { ipcMain, BrowserWindow, screen } from 'electron';
 import { writeFile, mkdir } from 'fs/promises';
 import path from 'path';
 import { tmpdir } from 'os';
@@ -47,18 +47,37 @@ async function execRenderer<T>(code: string): Promise<T> {
   return win.webContents.executeJavaScript(code) as Promise<T>;
 }
 
+/**
+ * Capture a region of the page. `rect` is in CSS pixels (from
+ * getBoundingClientRect). capturePage() expects DIP coordinates, which can
+ * differ when there's display scaling or a zoom factor (DPR ≠ native scale).
+ */
 async function captureRect(rect: AppPanelRect): Promise<string | null> {
   const win = getMainWindow();
   if (!win) return null;
   if (rect.width <= 0 || rect.height <= 0) return null;
 
-  const image = await win.webContents.capturePage({
-    x: Math.round(rect.x),
-    y: Math.round(rect.y),
-    width: Math.round(rect.width),
-    height: Math.round(rect.height),
-  });
+  // Convert CSS px → DIP: ratio = devicePixelRatio / nativeDisplayScale
+  const dpr = await execRenderer<number>('window.devicePixelRatio');
+  const display = screen.getDisplayMatching(win.getBounds());
+  const cssToDisplay = dpr / display.scaleFactor;
 
+  // Compute DIP rect from CSS edges to avoid rounding drift
+  const x = Math.floor(rect.x * cssToDisplay);
+  const y = Math.floor(rect.y * cssToDisplay);
+  const right = Math.ceil((rect.x + rect.width) * cssToDisplay);
+  const bottom = Math.ceil((rect.y + rect.height) * cssToDisplay);
+
+  // Clamp to content area
+  const bounds = win.getContentBounds();
+  const captureArea = {
+    x,
+    y,
+    width: Math.min(right, bounds.width) - x,
+    height: Math.min(bottom, bounds.height) - y,
+  };
+
+  const image = await win.webContents.capturePage(captureArea);
   return image.toPNG().toString('base64');
 }
 

--- a/apps/desktop/electron/ipc/provider-metadata.ts
+++ b/apps/desktop/electron/ipc/provider-metadata.ts
@@ -1,0 +1,52 @@
+/**
+ * Provider display names and logo mappings.
+ *
+ * Static metadata used by the model selector and session info display.
+ * Extracted from agent-helpers.ts to keep it under 500 LOC.
+ */
+
+const PROVIDER_NAMES: Record<string, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  'openai-codex': 'OpenAI (Codex)',
+  google: 'Google',
+  'google-gemini-cli': 'Google (Gemini CLI)',
+  'google-antigravity': 'Antigravity',
+  'google-vertex': 'Google Vertex',
+  xai: 'xAI',
+  openrouter: 'OpenRouter',
+  groq: 'Groq',
+  cerebras: 'Cerebras',
+  mistral: 'Mistral',
+  'github-copilot': 'GitHub Copilot',
+  'amazon-bedrock': 'Amazon Bedrock',
+  'azure-openai-responses': 'Azure OpenAI',
+  huggingface: 'Hugging Face',
+  'vercel-ai-gateway': 'Vercel AI Gateway',
+  zai: 'ZAI',
+  opencode: 'OpenCode',
+  'kimi-coding': 'Kimi',
+  minimax: 'MiniMax',
+  'minimax-cn': 'MiniMax CN',
+};
+
+const PROVIDER_LOGO_MAP: Record<string, string> = {
+  'openai-codex': 'openai',
+  'google-gemini-cli': 'google',
+  'google-antigravity': 'google',
+  'google-vertex': 'google-vertex',
+  'azure-openai-responses': 'azure',
+  'amazon-bedrock': 'amazon-bedrock',
+  'github-copilot': 'github-copilot',
+  'vercel-ai-gateway': 'vercel',
+  'kimi-coding': 'openai',
+};
+
+export function providerLogo(provider: string): string {
+  const slug = PROVIDER_LOGO_MAP[provider] ?? provider;
+  return `https://models.dev/logos/${slug}.svg`;
+}
+
+export function providerDisplayName(provider: string): string {
+  return PROVIDER_NAMES[provider] ?? provider.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/apps/desktop/electron/utils/capture.ts
+++ b/apps/desktop/electron/utils/capture.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared screen capture utility.
+ *
+ * Converts CSS pixel coordinates (from getBoundingClientRect) to DIP
+ * coordinates for Electron's capturePage(), handling display scaling
+ * and zoom factors. Used by both IPC handlers and CLI commands.
+ */
+
+import { BrowserWindow, screen } from 'electron';
+import type { AppPanelRect } from '../../src/types/ipc';
+
+/**
+ * Capture a region of the window as a PNG base64 string.
+ *
+ * `cssRect` is in CSS pixels (from getBoundingClientRect). capturePage()
+ * expects DIP coordinates, which can differ when there's display scaling
+ * or a zoom factor (DPR ≠ native scale). The conversion ratio is:
+ *   DIP = CSS × (devicePixelRatio / nativeDisplayScale)
+ */
+export async function captureRegion(
+  win: BrowserWindow,
+  cssRect: AppPanelRect,
+): Promise<string | null> {
+  if (cssRect.width <= 0 || cssRect.height <= 0) return null;
+
+  // Convert CSS px → DIP: ratio = devicePixelRatio / nativeDisplayScale
+  const dpr = await win.webContents.executeJavaScript('window.devicePixelRatio') as number;
+  const display = screen.getDisplayMatching(win.getBounds());
+  const cssToDisplay = dpr / display.scaleFactor;
+
+  // Compute DIP rect from CSS edges to avoid accumulating rounding errors
+  const x = Math.floor(cssRect.x * cssToDisplay);
+  const y = Math.floor(cssRect.y * cssToDisplay);
+  const right = Math.ceil((cssRect.x + cssRect.width) * cssToDisplay);
+  const bottom = Math.ceil((cssRect.y + cssRect.height) * cssToDisplay);
+
+  // Clamp to content area to prevent out-of-bounds capture
+  const bounds = win.getContentBounds();
+  const captureArea = {
+    x,
+    y,
+    width: Math.min(right, bounds.width) - x,
+    height: Math.min(bottom, bounds.height) - y,
+  };
+
+  const image = await win.webContents.capturePage(captureArea);
+  return image.toPNG().toString('base64');
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -97,6 +97,7 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
+    "@discordjs/rest": "^2.6.0",
     "@playwright/test": "^1.58.2",
     "@types/diff": "^8.0.0",
     "@types/node": "^22.19.9",

--- a/apps/desktop/src/components/layout/ChatAttachments.tsx
+++ b/apps/desktop/src/components/layout/ChatAttachments.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from 'react';
 import {
   Attachments,
   Attachment,
@@ -9,6 +10,7 @@ import {
   usePromptInputAttachments,
 } from '@sero/ui/components/ai-elements/prompt-input';
 import type { ChatAttachment } from '@/types/ipc';
+import { useLightbox, type LightboxImage } from './ImageLightbox';
 
 // ── Prompt input attachment bar (inline badges) ────────────────
 
@@ -48,8 +50,36 @@ interface MessageAttachmentsProps {
 /**
  * Renders attachments inside a user message bubble.
  * Uses the `grid` variant — visual thumbnails for images, icons for files.
+ * Clicking an image opens the lightbox preview.
  */
 export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
+  const showLightbox = useLightbox((s) => s.show);
+
+  // Build lightbox images for clickable image attachments
+  const lightboxImages: LightboxImage[] = useMemo(
+    () =>
+      attachments
+        .filter((a) => a.mediaType?.startsWith('image/'))
+        .map((a) => ({
+          src: a.url,
+          mimeType: a.mediaType,
+          alt: a.filename ?? 'Attachment',
+        })),
+    [attachments],
+  );
+
+  const handleImageClick = useCallback(
+    (attachmentId: string) => {
+      const imageIndex = attachments
+        .filter((a) => a.mediaType?.startsWith('image/'))
+        .findIndex((a) => a.id === attachmentId);
+      if (imageIndex >= 0) {
+        showLightbox(lightboxImages, imageIndex);
+      }
+    },
+    [attachments, lightboxImages, showLightbox],
+  );
+
   if (!attachments.length) return null;
 
   // Convert ChatAttachment → FileUIPart shape for ai-elements
@@ -63,11 +93,19 @@ export function MessageAttachments({ attachments }: MessageAttachmentsProps) {
 
   return (
     <Attachments variant="grid" className="mt-2">
-      {files.map((file) => (
-        <Attachment key={file.id} data={file}>
-          <AttachmentPreview />
-        </Attachment>
-      ))}
+      {files.map((file) => {
+        const isImage = file.mediaType.startsWith('image/');
+        return (
+          <Attachment
+            key={file.id}
+            data={file}
+            className={isImage ? 'cursor-pointer' : undefined}
+            onClick={isImage ? () => handleImageClick(file.id) : undefined}
+          >
+            <AttachmentPreview />
+          </Attachment>
+        );
+      })}
     </Attachments>
   );
 }

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -27,6 +27,7 @@ import { EmptyState } from './ChatPanelHelpers';
 import { CollaborationDetails } from './CollaborationResponse';
 import { CollaborationActivityPanel } from './CollaborationActivityPanel';
 import { ChatPromptArea } from './ChatPromptArea';
+import { ImageLightbox } from './ImageLightbox';
 
 /**
  * ChatPanel — agent chat panel wired to Pi SDK AgentSession pool.
@@ -229,6 +230,9 @@ export function ChatPanel() {
         onOpenChange={checkpoint.setDialogOpen}
         onConfirm={checkpoint.confirmRestore}
       />
+
+      {/* Global image lightbox — mounted once, controlled via useLightbox store */}
+      <ImageLightbox />
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/ImageLightbox.tsx
+++ b/apps/desktop/src/components/layout/ImageLightbox.tsx
@@ -125,10 +125,16 @@ export function ImageLightbox() {
 
   const src = useMemo(() => (current ? toDataUrl(current) : ''), [current]);
 
+  // Focus the overlay on mount so keyboard shortcuts work immediately
+  const focusRef = useCallback((node: HTMLDivElement | null) => {
+    if (node) requestAnimationFrame(() => node.focus());
+  }, []);
+
   return createPortal(
     <AnimatePresence>
       {open && current && (
         <motion.div
+          ref={focusRef}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}

--- a/apps/desktop/src/components/layout/ImageLightbox.tsx
+++ b/apps/desktop/src/components/layout/ImageLightbox.tsx
@@ -1,0 +1,235 @@
+/**
+ * ImageLightbox — full-screen modal overlay for previewing images.
+ *
+ * Supports:
+ * - Click-to-dismiss (click backdrop)
+ * - Escape to close
+ * - Open in new window (popout)
+ * - Zoom with scroll wheel
+ * - Multiple images with left/right navigation
+ *
+ * State is managed via a simple Zustand store (see useLightbox below).
+ */
+
+import { useCallback, useState, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { create } from 'zustand';
+import { AnimatePresence, motion } from 'motion/react';
+import {
+  X,
+  ExternalLink,
+  ChevronLeft,
+  ChevronRight,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
+import { cn } from '@sero/ui/lib/utils';
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface LightboxImage {
+  /** Data URL or base64 data (will be wrapped as data: URL if raw). */
+  src: string;
+  /** MIME type for base64 data. */
+  mimeType?: string;
+  /** Optional alt text / description. */
+  alt?: string;
+}
+
+// ── Zustand store ───────────────────────────────────────────
+
+interface LightboxState {
+  open: boolean;
+  images: LightboxImage[];
+  index: number;
+  show: (images: LightboxImage[], startIndex?: number) => void;
+  close: () => void;
+  next: () => void;
+  prev: () => void;
+}
+
+export const useLightbox = create<LightboxState>((set, get) => ({
+  open: false,
+  images: [],
+  index: 0,
+  show: (images, startIndex = 0) =>
+    set({ open: true, images, index: Math.min(startIndex, images.length - 1) }),
+  close: () => set({ open: false }),
+  next: () => set((s) => ({ index: Math.min(s.index + 1, s.images.length - 1) })),
+  prev: () => set((s) => ({ index: Math.max(s.index - 1, 0) })),
+}));
+
+// ── Helper: ensure src is a valid data URL ──────────────────
+
+function toDataUrl(image: LightboxImage): string {
+  if (image.src.startsWith('data:') || image.src.startsWith('http') || image.src.startsWith('blob:')) {
+    return image.src;
+  }
+  // Raw base64 — wrap with data URI
+  const mime = image.mimeType ?? 'image/png';
+  return `data:${mime};base64,${image.src}`;
+}
+
+// ── Popout helper ───────────────────────────────────────────
+
+function openInNewWindow(image: LightboxImage) {
+  const url = toDataUrl(image);
+  const win = window.open('', '_blank', 'width=900,height=700');
+  if (!win) return;
+  win.document.title = image.alt ?? 'Image Preview';
+  win.document.body.style.cssText = 'margin:0;background:#111;display:flex;align-items:center;justify-content:center;height:100vh;';
+  const img = win.document.createElement('img');
+  img.src = url;
+  img.alt = image.alt ?? 'Image';
+  img.style.cssText = 'max-width:100%;max-height:100%;object-fit:contain;';
+  win.document.body.appendChild(img);
+}
+
+// ── Main lightbox component ─────────────────────────────────
+
+export function ImageLightbox() {
+  const { open, images, index, close, next, prev } = useLightbox();
+  const current = images[index];
+  const hasMultiple = images.length > 1;
+  const [zoom, setZoom] = useState(1);
+
+  // Reset zoom when image changes
+  const resetZoom = useCallback(() => setZoom(1), []);
+
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    setZoom((z) => Math.max(0.25, Math.min(5, z - e.deltaY * 0.002)));
+  }, []);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        close();
+        resetZoom();
+      }
+    },
+    [close, resetZoom],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') { close(); resetZoom(); }
+      else if (e.key === 'ArrowRight' && hasMultiple) { next(); resetZoom(); }
+      else if (e.key === 'ArrowLeft' && hasMultiple) { prev(); resetZoom(); }
+      else if (e.key === '+' || e.key === '=') setZoom((z) => Math.min(5, z + 0.25));
+      else if (e.key === '-') setZoom((z) => Math.max(0.25, z - 0.25));
+      else if (e.key === '0') resetZoom();
+    },
+    [close, next, prev, hasMultiple, resetZoom],
+  );
+
+  const src = useMemo(() => (current ? toDataUrl(current) : ''), [current]);
+
+  return createPortal(
+    <AnimatePresence>
+      {open && current && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          onClick={handleBackdropClick}
+          onKeyDown={handleKeyDown}
+          tabIndex={0}
+          role="dialog"
+          aria-label="Image preview"
+        >
+          {/* Toolbar */}
+          <div className="absolute top-3 right-3 z-10 flex items-center gap-1">
+            <ToolbarButton onClick={() => setZoom((z) => Math.min(5, z + 0.5))} title="Zoom in">
+              <ZoomIn className="size-4" />
+            </ToolbarButton>
+            <ToolbarButton onClick={() => setZoom((z) => Math.max(0.25, z - 0.5))} title="Zoom out">
+              <ZoomOut className="size-4" />
+            </ToolbarButton>
+            <ToolbarButton onClick={() => openInNewWindow(current)} title="Open in new window">
+              <ExternalLink className="size-4" />
+            </ToolbarButton>
+            <ToolbarButton onClick={() => { close(); resetZoom(); }} title="Close (Esc)">
+              <X className="size-4" />
+            </ToolbarButton>
+          </div>
+
+          {/* Navigation arrows */}
+          {hasMultiple && index > 0 && (
+            <button
+              onClick={(e) => { e.stopPropagation(); prev(); resetZoom(); }}
+              className="absolute left-3 z-10 rounded-full bg-white/10 p-2 text-white/80 transition-colors hover:bg-white/20"
+            >
+              <ChevronLeft className="size-6" />
+            </button>
+          )}
+          {hasMultiple && index < images.length - 1 && (
+            <button
+              onClick={(e) => { e.stopPropagation(); next(); resetZoom(); }}
+              className="absolute right-3 z-10 rounded-full bg-white/10 p-2 text-white/80 transition-colors hover:bg-white/20"
+            >
+              <ChevronRight className="size-6" />
+            </button>
+          )}
+
+          {/* Image */}
+          <motion.img
+            key={`${index}-${src.slice(0, 40)}`}
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+            transition={{ duration: 0.15 }}
+            src={src}
+            alt={current.alt ?? 'Preview'}
+            className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
+            style={{ transform: `scale(${zoom})`, transition: 'transform 0.1s ease-out' }}
+            onWheel={handleWheel}
+            draggable={false}
+          />
+
+          {/* Caption + counter */}
+          <div className="absolute bottom-4 left-1/2 z-10 flex -translate-x-1/2 flex-col items-center gap-1">
+            {current.alt && (
+              <span className="rounded bg-black/60 px-2 py-0.5 text-xs text-white/80">
+                {current.alt}
+              </span>
+            )}
+            {hasMultiple && (
+              <span className="text-xs text-white/50">
+                {index + 1} / {images.length}
+              </span>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
+    document.body,
+  );
+}
+
+// ── Toolbar button ──────────────────────────────────────────
+
+function ToolbarButton({
+  onClick,
+  title,
+  children,
+}: {
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      title={title}
+      className={cn(
+        'rounded-md p-1.5 text-white/70 transition-colors',
+        'hover:bg-white/15 hover:text-white',
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/desktop/src/components/layout/ToolCallHelpers.tsx
+++ b/apps/desktop/src/components/layout/ToolCallHelpers.tsx
@@ -12,7 +12,8 @@ import {
   AlertCircle,
 } from 'lucide-react';
 import { cn } from '@sero/ui/lib/utils';
-import type { ChatToolCallMessage } from '@/types/ipc';
+import type { ChatToolCallMessage, ToolResultImage } from '@/types/ipc';
+import { useLightbox, type LightboxImage } from './ImageLightbox';
 import {
   Tool,
   ToolHeader,
@@ -175,6 +176,57 @@ export function ToolLine({
   );
 }
 
+// ── ToolImages (thumbnail strip for tool result images) ─────────
+
+function ToolImages({ images }: { images: ToolResultImage[] }) {
+  const showLightbox = useLightbox((s) => s.show);
+
+  const lightboxImages: LightboxImage[] = useMemo(
+    () =>
+      images.map((img) => ({
+        src: img.data,
+        mimeType: img.mimeType,
+        alt: img.description,
+      })),
+    [images],
+  );
+
+  const handleClick = useCallback(
+    (index: number) => showLightbox(lightboxImages, index),
+    [showLightbox, lightboxImages],
+  );
+
+  return (
+    <div className="flex flex-wrap gap-2 py-1">
+      {images.map((img, i) => {
+        const src = img.data.startsWith('data:')
+          ? img.data
+          : `data:${img.mimeType ?? 'image/png'};base64,${img.data}`;
+        return (
+          <button
+            key={i}
+            onClick={() => handleClick(i)}
+            className={cn(
+              'group/img relative overflow-hidden rounded-md border border-[var(--border-subtle)]',
+              'transition-all hover:border-[var(--accent-primary)] hover:shadow-md',
+              'cursor-pointer focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)]',
+            )}
+            title={img.description ?? 'Click to preview'}
+          >
+            <img
+              src={src}
+              alt={img.description ?? 'Tool result image'}
+              className="h-24 w-auto max-w-[200px] object-cover"
+              loading="lazy"
+            />
+            <div className="absolute inset-0 bg-black/0 transition-colors group-hover/img:bg-black/10" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 // ── ToolDetail (expanded single tool — full input/output) ───────
 
 export function ToolDetail({ tool }: { tool: ChatToolCallMessage }) {
@@ -189,6 +241,7 @@ export function ToolDetail({ tool }: { tool: ChatToolCallMessage }) {
       />
       <ToolContent>
         <ToolInput input={tool.input} />
+        {isComplete && tool.images?.length ? <ToolImages images={tool.images} /> : null}
         {isComplete && (
           <ToolOutput
             output={tool.output}
@@ -219,6 +272,7 @@ export function SingleToolCall({
   const isRunning = status === 'running';
   const isComplete = tool.state === 'completed' || tool.state === 'error';
   const isCancelled = tool.state === 'cancelled';
+  const hasImages = !!tool.images?.length;
   const [expanded, setExpanded] = useState(false);
 
   const summary = useMemo(() => extractToolSummary(tool.input), [tool.input]);
@@ -287,6 +341,13 @@ export function SingleToolCall({
         )}
       </button>
 
+      {/* Inline image thumbnails — always visible when tool has images */}
+      {hasImages && !expanded && (
+        <div className="border-t border-[var(--border-subtle)] px-3 py-2">
+          <ToolImages images={tool.images!} />
+        </div>
+      )}
+
       <AnimatePresence>
         {expanded && (
           <motion.div
@@ -298,6 +359,7 @@ export function SingleToolCall({
           >
             <div className="border-t border-[var(--border-subtle)] space-y-4 p-3">
               <ToolInput input={tool.input} />
+              {isComplete && hasImages ? <ToolImages images={tool.images!} /> : null}
               {isComplete && (
                 <ToolOutput
                   output={tool.output}

--- a/apps/desktop/src/lib/app-control-bridge.ts
+++ b/apps/desktop/src/lib/app-control-bridge.ts
@@ -184,6 +184,8 @@ export function initAppControlBridge(): () => void {
     getAppRect() {
       const el = document.querySelector(APP_PANEL_SELECTOR);
       if (!el) return null;
+      // Returns CSS pixel coordinates. The main process converts these to DIP
+      // coordinates before passing to capturePage() (see captureRect / captureAppScreenshot).
       const r = el.getBoundingClientRect();
       return { x: r.x, y: r.y, width: r.width, height: r.height };
     },

--- a/apps/desktop/src/stores/agent-utils.ts
+++ b/apps/desktop/src/stores/agent-utils.ts
@@ -199,7 +199,8 @@ export function handleAgentStreamEvent(
           messages: s.agents[sid].messages.map((m) =>
             m.type === 'tool' && m.toolCallId === event.toolCallId
               ? { ...m, output: event.output, isError: event.isError,
-                  state: event.isError ? 'error' : 'completed' } as ChatToolCallMessage
+                  state: event.isError ? 'error' : 'completed',
+                  images: event.images } as ChatToolCallMessage
               : m),
         } },
       }));

--- a/apps/desktop/src/types/agent.ts
+++ b/apps/desktop/src/types/agent.ts
@@ -1,0 +1,153 @@
+/**
+ * Agent, chat, and model type definitions.
+ *
+ * Extracted from ipc.ts to keep individual files under 500 LOC.
+ * Re-exported from ipc.ts so existing imports continue to work.
+ */
+
+import type { ChatCheckpointRef } from './checkpoints';
+
+// ── Chat Messages ──────────────────────────────────────────────
+
+/** Renderer-friendly message types for the ChatPanel. */
+export type ChatMessage =
+  | ChatUserMessage
+  | ChatAssistantMessage
+  | ChatToolCallMessage;
+
+/** File attachment metadata for user messages. */
+export interface ChatAttachment {
+  id: string;
+  filename?: string;
+  mediaType?: string;
+  /** Data URL (base64) or blob URL. */
+  url: string;
+}
+
+/** An image returned by a tool (e.g. screenshot, browser capture). */
+export interface ToolResultImage {
+  /** Raw base64-encoded image data (no data-URI prefix). */
+  data: string;
+  /** MIME type, e.g. "image/png" or "image/jpeg". */
+  mimeType: string;
+  /** Optional description (e.g. "Screenshot of todo app"). */
+  description?: string;
+}
+
+export interface ChatUserMessage {
+  type: 'user';
+  id: string;
+  text: string;
+  /** Optional file attachments included with the message. */
+  attachments?: ChatAttachment[];
+}
+
+export interface ChatAssistantMessage {
+  type: 'assistant';
+  id: string;
+  text: string;
+  /** True while this message is still receiving deltas. */
+  isStreaming: boolean;
+  /** Accumulated thinking/reasoning text (only present when model uses reasoning). */
+  thinking?: string;
+}
+
+export interface ChatToolCallMessage {
+  type: 'tool';
+  id: string;
+  toolCallId: string;
+  toolName: string;
+  input: Record<string, unknown>;
+  output: string | null;
+  isError: boolean;
+  state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+  /** Images returned by this tool call (e.g. screenshots). */
+  images?: ToolResultImage[];
+}
+
+/**
+ * Events pushed from main → renderer during agent streaming.
+ * Kept deliberately slim — only what the UI needs to render.
+ *
+ * Every event carries `sessionId` so the renderer can route events
+ * to the correct AgentInstance in a multi-session pool.
+ */
+export type AgentStreamEvent =
+  | { type: 'agent_start'; sessionId: string }
+  | { type: 'agent_end'; sessionId: string }
+  | { type: 'messages_loaded'; sessionId: string; messages: ChatMessage[] }
+  | { type: 'text_delta'; sessionId: string; messageId: string; delta: string }
+  | { type: 'thinking_delta'; sessionId: string; messageId: string; delta: string }
+  | { type: 'message_start'; sessionId: string; message: ChatMessage }
+  | { type: 'message_end'; sessionId: string; messageId: string; text: string; thinking?: string }
+  | { type: 'tool_start'; sessionId: string; tool: ChatToolCallMessage }
+  | { type: 'tool_end'; sessionId: string; toolCallId: string; output: string | null; isError: boolean; images?: ToolResultImage[] }
+  | { type: 'user_checkpoint'; sessionId: string; userMessageId: string; checkpoint: ChatCheckpointRef }
+  | { type: 'session_name'; sessionId: string; name: string }
+  | { type: 'model_change'; sessionId: string; state: SessionModelState }
+  | { type: 'error'; sessionId: string; error: string }
+  | { type: 'container_starting'; sessionId: string; workspaceId: string }
+  | { type: 'container_ready'; sessionId: string; workspaceId: string; ipAddress?: string }
+  | { type: 'container_error'; sessionId: string; workspaceId: string; error: string };
+
+// ── Model Info ─────────────────────────────────────────────────
+
+/** Serialisable model info for the renderer (no class instances). */
+export interface ModelInfo {
+  provider: string;
+  modelId: string;
+  name: string;
+  reasoning: boolean;
+}
+
+/** Current model + thinking level for a session. */
+export interface SessionModelState {
+  model: ModelInfo;
+  thinkingLevel: string;
+  availableThinkingLevels: string[];
+  supportsXhigh: boolean;
+  /** All models with auth, grouped by provider display name. */
+  availableModels: AvailableModelGroup[];
+}
+
+/** A group of models under a single provider, for the model selector. */
+export interface AvailableModelGroup {
+  provider: string;
+  displayName: string;
+  /** Logo URL (models.dev SVG). */
+  logo: string;
+  models: ModelInfo[];
+}
+
+// ── Usage Stats ────────────────────────────────────────────────
+
+/** Session usage stats returned by PI SDK's AgentSession.getSessionStats(). */
+export interface SessionUsageStats {
+  tokens: {
+    input: number;
+    output: number;
+    cacheRead: number;
+    cacheWrite: number;
+    total: number;
+  };
+  cost: number;
+  requestCount: number;
+}
+
+/** Context window usage info for the active session. Mirrors the Pi SDK's ContextUsage type. */
+export interface ContextUsageInfo {
+  /** Estimated context tokens, or null if unknown (e.g. right after compaction, before next LLM response). */
+  tokens: number | null;
+  /** Model's maximum context window size in tokens. */
+  contextWindow: number;
+  /** Usage percentage (0–100), or null if tokens is unknown. */
+  percent: number | null;
+}
+
+/** Result from manual compaction. */
+export interface CompactResult {
+  success: boolean;
+  /** Approximate context tokens before compaction (only present on success). */
+  tokensBefore?: number;
+  error?: string;
+}

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -170,88 +170,17 @@ export interface SeroSlashCommandInfo {
 import type { ChatCheckpointRef } from './checkpoints';
 export type { ChatCheckpointRef } from './checkpoints';
 
-// ── Agent ──────────────────────────────────────────────────────
+// ── Agent (extracted to agent.ts) ──────────────────────────────
 
-/** Renderer-friendly message types for the ChatPanel. */
-export type ChatMessage =
-  | ChatUserMessage
-  | ChatAssistantMessage
-  | ChatToolCallMessage;
-
-/** File attachment metadata for user messages. */
-export interface ChatAttachment {
-  id: string;
-  filename?: string;
-  mediaType?: string;
-  /** Data URL (base64) or blob URL. */
-  url: string;
-}
-
-/** An image returned by a tool (e.g. screenshot, browser capture). */
-export interface ToolResultImage {
-  /** Raw base64-encoded image data (no data-URI prefix). */
-  data: string;
-  /** MIME type, e.g. "image/png" or "image/jpeg". */
-  mimeType: string;
-  /** Optional description (e.g. "Screenshot of todo app"). */
-  description?: string;
-}
-
-export interface ChatUserMessage {
-  type: 'user';
-  id: string;
-  text: string;
-  /** Optional file attachments included with the message. */
-  attachments?: ChatAttachment[];
-}
-
-export interface ChatAssistantMessage {
-  type: 'assistant';
-  id: string;
-  text: string;
-  /** True while this message is still receiving deltas. */
-  isStreaming: boolean;
-  /** Accumulated thinking/reasoning text (only present when model uses reasoning). */
-  thinking?: string;
-}
-
-export interface ChatToolCallMessage {
-  type: 'tool';
-  id: string;
-  toolCallId: string;
-  toolName: string;
-  input: Record<string, unknown>;
-  output: string | null;
-  isError: boolean;
-  state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
-  /** Images returned by this tool call (e.g. screenshots). */
-  images?: ToolResultImage[];
-}
-
-/**
- * Events pushed from main → renderer during agent streaming.
- * Kept deliberately slim — only what the UI needs to render.
- *
- * Every event carries `sessionId` so the renderer can route events
- * to the correct AgentInstance in a multi-session pool.
- */
-export type AgentStreamEvent =
-  | { type: 'agent_start'; sessionId: string }
-  | { type: 'agent_end'; sessionId: string }
-  | { type: 'messages_loaded'; sessionId: string; messages: ChatMessage[] }
-  | { type: 'text_delta'; sessionId: string; messageId: string; delta: string }
-  | { type: 'thinking_delta'; sessionId: string; messageId: string; delta: string }
-  | { type: 'message_start'; sessionId: string; message: ChatMessage }
-  | { type: 'message_end'; sessionId: string; messageId: string; text: string; thinking?: string }
-  | { type: 'tool_start'; sessionId: string; tool: ChatToolCallMessage }
-  | { type: 'tool_end'; sessionId: string; toolCallId: string; output: string | null; isError: boolean; images?: ToolResultImage[] }
-  | { type: 'user_checkpoint'; sessionId: string; userMessageId: string; checkpoint: ChatCheckpointRef }
-  | { type: 'session_name'; sessionId: string; name: string }
-  | { type: 'model_change'; sessionId: string; state: SessionModelState }
-  | { type: 'error'; sessionId: string; error: string }
-  | { type: 'container_starting'; sessionId: string; workspaceId: string }
-  | { type: 'container_ready'; sessionId: string; workspaceId: string; ipAddress?: string }
-  | { type: 'container_error'; sessionId: string; workspaceId: string; error: string };
+export type {
+  ChatMessage,
+  ChatAttachment,
+  ToolResultImage,
+  ChatUserMessage,
+  ChatAssistantMessage,
+  ChatToolCallMessage,
+  AgentStreamEvent,
+} from './agent';
 
 // ── Container ──────────────────────────────────────────────────
 
@@ -292,67 +221,16 @@ export type DevServerEvent =
   | { type: 'status_changed'; serverId: string; status: DevServer['status'] }
   | { type: 'sync'; servers: DevServer[] };
 
-// ── Model Info ─────────────────────────────────────────────────
+// ── Model Info & Usage Stats (extracted to agent.ts) ───────────
 
-/** Serialisable model info for the renderer (no class instances). */
-export interface ModelInfo {
-  provider: string;
-  modelId: string;
-  name: string;
-  reasoning: boolean;
-}
-
-/** Current model + thinking level for a session. */
-export interface SessionModelState {
-  model: ModelInfo;
-  thinkingLevel: string;
-  availableThinkingLevels: string[];
-  supportsXhigh: boolean;
-  /** All models with auth, grouped by provider display name. */
-  availableModels: AvailableModelGroup[];
-}
-
-/** A group of models under a single provider, for the model selector. */
-export interface AvailableModelGroup {
-  provider: string;
-  displayName: string;
-  /** Logo URL (models.dev SVG). */
-  logo: string;
-  models: ModelInfo[];
-}
-
-// ── Usage Stats ────────────────────────────────────────────────
-
-/** Session usage stats returned by PI SDK's AgentSession.getSessionStats(). */
-export interface SessionUsageStats {
-  tokens: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-    total: number;
-  };
-  cost: number;
-  requestCount: number;
-}
-
-/** Context window usage info for the active session. Mirrors the Pi SDK's ContextUsage type. */
-export interface ContextUsageInfo {
-  /** Estimated context tokens, or null if unknown (e.g. right after compaction, before next LLM response). */
-  tokens: number | null;
-  /** Model's maximum context window size in tokens. */
-  contextWindow: number;
-  /** Usage percentage (0–100), or null if tokens is unknown. */
-  percent: number | null;
-}
-
-/** Result from manual compaction. */
-export interface CompactResult {
-  success: boolean;
-  /** Approximate context tokens before compaction (only present on success). */
-  tokensBefore?: number;
-  error?: string;
-}
+export type {
+  ModelInfo,
+  SessionModelState,
+  AvailableModelGroup,
+  SessionUsageStats,
+  ContextUsageInfo,
+  CompactResult,
+} from './agent';
 
 // ── Sero Apps ──────────────────────────────────────────────────
 

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -187,6 +187,16 @@ export interface ChatAttachment {
   url: string;
 }
 
+/** An image returned by a tool (e.g. screenshot, browser capture). */
+export interface ToolResultImage {
+  /** Raw base64-encoded image data (no data-URI prefix). */
+  data: string;
+  /** MIME type, e.g. "image/png" or "image/jpeg". */
+  mimeType: string;
+  /** Optional description (e.g. "Screenshot of todo app"). */
+  description?: string;
+}
+
 export interface ChatUserMessage {
   type: 'user';
   id: string;
@@ -214,6 +224,8 @@ export interface ChatToolCallMessage {
   output: string | null;
   isError: boolean;
   state: 'pending' | 'running' | 'completed' | 'error' | 'cancelled';
+  /** Images returned by this tool call (e.g. screenshots). */
+  images?: ToolResultImage[];
 }
 
 /**
@@ -232,7 +244,7 @@ export type AgentStreamEvent =
   | { type: 'message_start'; sessionId: string; message: ChatMessage }
   | { type: 'message_end'; sessionId: string; messageId: string; text: string; thinking?: string }
   | { type: 'tool_start'; sessionId: string; tool: ChatToolCallMessage }
-  | { type: 'tool_end'; sessionId: string; toolCallId: string; output: string | null; isError: boolean }
+  | { type: 'tool_end'; sessionId: string; toolCallId: string; output: string | null; isError: boolean; images?: ToolResultImage[] }
   | { type: 'user_checkpoint'; sessionId: string; userMessageId: string; checkpoint: ChatCheckpointRef }
   | { type: 'session_name'; sessionId: string; name: string }
   | { type: 'model_change'; sessionId: string; state: SessionModelState }

--- a/docs/guides/native-modules.md
+++ b/docs/guides/native-modules.md
@@ -1,0 +1,90 @@
+# Native Module Builds for Sero
+
+Sero runs in Electron, which bundles its own version of Node.js with a specific module ABI. Native Node.js addons (`.node` files) must be compiled against that ABI, not the system Node.js or Bun. Standard `npm rebuild` or `pnpm rebuild` will compile against the wrong runtime and produce an `ERR_DLOPEN_FAILED` error at startup.
+
+## TL;DR
+
+This is handled automatically. The `postinstall` script (`scripts/rebuild-better-sqlite3.mjs`) runs after every `pnpm install` and fixes the binary if needed. You shouldn't need to do anything manually.
+
+If you ever need to run it by hand:
+
+```bash
+cd ~/Documents/Dev/projects/sero/sero
+node scripts/rebuild-better-sqlite3.mjs
+```
+
+Or directly via `@electron/rebuild`:
+
+```bash
+npx @electron/rebuild \
+  --version 33.4.11 \
+  --module-dir node_modules/.pnpm/better-sqlite3@12.6.2/node_modules/better-sqlite3 \
+  --which-module better-sqlite3
+```
+
+## When a Manual Run Might Be Needed
+
+- The `postinstall` script is disabled or skipped (e.g. `pnpm install --ignore-scripts`)
+- Upgrading Electron (update `--version` in the script and the command above)
+- Upgrading `better-sqlite3` (update the module path)
+
+## Why
+
+| Runtime | Node module ABI |
+|---------|----------------|
+| System Node.js 22 | 127 |
+| Bun | 137 |
+| **Electron 33** | **different from both** |
+
+`better-sqlite3` is a native C++ addon. The binary compiled by a plain `npm rebuild` targets whichever Node.js is on your `PATH` — not the Electron-bundled one. `@electron/rebuild` fetches the correct Electron headers and compiles against those instead.
+
+## Checking the Electron Version
+
+```bash
+cat ~/Documents/Dev/projects/sero/sero/apps/desktop/package.json | grep '"electron"'
+# or
+cat ~/Documents/Dev/projects/sero/sero/node_modules/.pnpm/electron@*/node_modules/electron/package.json | grep '"version"'
+```
+
+## Affected Packages
+
+Only packages with native addons need this treatment. Currently:
+
+| Package | Path |
+|---------|------|
+| `better-sqlite3@12.6.2` | `node_modules/.pnpm/better-sqlite3@12.6.2/node_modules/better-sqlite3` |
+
+`better-sqlite3` is used by `@tobilu/qmd` (the memory search backend). If QMD fails to initialise and the error in the Electron log mentions `ERR_DLOPEN_FAILED` or `NODE_MODULE_VERSION`, this rebuild is the fix.
+
+## What the Error Looks Like
+
+In `/tmp/sero-electron.log`:
+
+```
+Error: The module '.../better-sqlite3/build/Release/better_sqlite3.node'
+was compiled against a different Node.js version using
+NODE_MODULE_VERSION X. This version of Node.js requires
+NODE_MODULE_VERSION Y.
+```
+
+Or:
+
+```
+Could not locate the bindings file. Tried:
+ → .../better-sqlite3/build/Release/better_sqlite3.node
+```
+
+## QMD-Specific Fix (also applied)
+
+The QMD SDK's `getDefaultDbPath()` function requires an internal `enableProductionMode()` call that the CLI makes at startup, but which is not exported from the public SDK. Without it, the function throws, and the memory search silently fails.
+
+The Sero extension (`packages/pi-memory-extension/extension/qmd.ts`) works around this by computing the path directly instead of calling `getDefaultDbPath()`:
+
+```ts
+function resolveQmdDbPath(): string {
+  const cacheDir = process.env.XDG_CACHE_HOME ?? join(homedir(), '.cache');
+  return join(cacheDir, 'qmd', 'index.sqlite');
+}
+```
+
+This is already in the codebase. No action needed unless QMD is upgraded and the workaround stops applying.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.11.0",
   "scripts": {
-    "postinstall": "node scripts/rebuild-node-pty.mjs",
+    "postinstall": "node scripts/rebuild-node-pty.mjs && node scripts/rebuild-better-sqlite3.mjs",
     "dev": "pnpm --filter @sero/desktop dev",
     "build": "turbo run build",
     "typecheck": "turbo run typecheck",

--- a/packages/pi-memory-extension/extension/qmd.ts
+++ b/packages/pi-memory-extension/extension/qmd.ts
@@ -9,8 +9,17 @@
  * return safe defaults (false, empty string, etc.).
  */
 
-import { createStore, getDefaultDbPath } from '@tobilu/qmd';
+import { homedir } from 'os';
+import { join } from 'path';
+
+import { createStore } from '@tobilu/qmd';
 import type { QMDStore, SearchResult, HybridQueryResult } from '@tobilu/qmd';
+
+/** Compute the QMD db path the same way the CLI does, without requiring enableProductionMode(). */
+function resolveQmdDbPath(): string {
+  const cacheDir = process.env.XDG_CACHE_HOME ?? join(homedir(), '.cache');
+  return join(cacheDir, 'qmd', 'index.sqlite');
+}
 
 import { resolveMemoryRoot } from './memory-manager';
 import { getResultPath, getResultText } from '../shared/types';
@@ -96,7 +105,7 @@ async function ensureCollection(): Promise<boolean> {
 
 export async function initQmd(): Promise<boolean> {
   try {
-    const dbPath = getDefaultDbPath();
+    const dbPath = resolveQmdDbPath();
     store = await createStore({ dbPath });
     qmdAvailable = true;
   } catch {

--- a/packages/pi-memory-extension/extension/qmd.ts
+++ b/packages/pi-memory-extension/extension/qmd.ts
@@ -1,18 +1,16 @@
 /**
- * QMD integration — detection, auto-install, collection management, search.
+ * QMD integration — library-based search using @tobilu/qmd v2 SDK.
  *
- * QMD is an external CLI tool providing BM25 keyword, vector semantic,
- * and hybrid search over markdown files. All interaction is via child
- * process (execFile) — same pattern as Sero's git integration.
+ * QMD provides BM25 keyword, vector semantic, and hybrid search over
+ * markdown files. As of v2, we use the SDK directly (createStore)
+ * rather than shelling out to the CLI.
  *
- * Graceful degradation: if QMD or Bun is missing, all functions
+ * Graceful degradation: if QMD cannot initialise, all functions
  * return safe defaults (false, empty string, etc.).
  */
 
-import { execFile } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
+import { createStore, getDefaultDbPath } from '@tobilu/qmd';
+import type { QMDStore, SearchResult, HybridQueryResult } from '@tobilu/qmd';
 
 import { resolveMemoryRoot } from './memory-manager';
 import { getResultPath, getResultText } from '../shared/types';
@@ -22,207 +20,133 @@ export type { QmdSearchResult } from '../shared/types';
 
 // ── State ──────────────────────────────────────────────────────
 
+let store: QMDStore | null = null;
 let qmdAvailable = false;
-let qmdPath = 'qmd';
-let bunPath = 'bun';
 let updateTimer: ReturnType<typeof setTimeout> | null = null;
 
 const QMD_COLLECTION = 'sero-memory';
-const QMD_PACKAGE = '@tobilu/qmd';
 const SEARCH_TIMEOUT_MS = 3_000;
 const UPDATE_DEBOUNCE_MS = 500;
 
-// ── Binary resolution ──────────────────────────────────────────
-
-/** Find a binary by checking common locations Electron might miss. */
-function findBinary(name: string): string {
-  const home = os.homedir();
-  const candidates = [
-    name, // on PATH already
-    path.join(home, '.bun', 'bin', name),
-    path.join(home, '.local', 'bin', name),
-    `/usr/local/bin/${name}`,
-    `/opt/homebrew/bin/${name}`,
-  ];
-  for (const candidate of candidates) {
-    if (candidate === name) continue; // skip bare name, test via exec
-    if (existsSync(candidate)) return candidate;
-  }
-  return name; // fallback to bare name
-}
-
-function resolvePaths(): void {
-  qmdPath = findBinary('qmd');
-  bunPath = findBinary('bun');
-}
-
-// ── Detection ──────────────────────────────────────────────────
+// ── Detection / availability ──────────────────────────────────
 
 export function isQmdAvailable(): boolean {
   return qmdAvailable;
 }
 
-export function detectQmd(): Promise<boolean> {
-  return new Promise((resolve) => {
-    execFile(qmdPath, ['status'], { timeout: 5_000 }, (err) => {
-      resolve(!err);
-    });
-  });
+// ── Result mapping ────────────────────────────────────────────
+
+/** Map a QMD SearchResult to our normalised QmdSearchResult shape. */
+function mapSearchResult(r: SearchResult): QmdSearchResult {
+  return {
+    path: r.displayPath ?? r.filepath,
+    file: r.filepath,
+    score: r.score,
+    content: r.body,
+  };
 }
 
-export function detectBun(): Promise<boolean> {
-  return new Promise((resolve) => {
-    execFile(bunPath, ['--version'], { timeout: 5_000 }, (err) => {
-      resolve(!err);
-    });
-  });
+/** Map a QMD HybridQueryResult to our normalised QmdSearchResult shape. */
+function mapHybridResult(r: HybridQueryResult): QmdSearchResult {
+  return {
+    path: r.displayPath ?? r.file,
+    file: r.file,
+    score: r.score,
+    content: r.bestChunk || r.body,
+    snippet: r.bestChunk,
+  };
 }
 
-// ── Auto-install ───────────────────────────────────────────────
+// ── Collection management ─────────────────────────────────────
 
-export async function tryInstallQmd(): Promise<boolean> {
-  const hasBun = await detectBun();
-  if (!hasBun) return false;
+async function ensureCollection(): Promise<boolean> {
+  if (!store) return false;
 
-  return new Promise((resolve) => {
-    execFile(
-      bunPath,
-      ['install', '-g', QMD_PACKAGE],
-      { timeout: 60_000 },
-      (err) => resolve(!err),
-    );
-  });
-}
-
-export function installInstructions(): string {
-  return [
-    'memory_search requires qmd (semantic search engine).',
-    '',
-    'Install (requires Bun):',
-    `  bun install -g ${QMD_PACKAGE}`,
-    '',
-    'Or install Bun first:',
-    '  curl -fsSL https://bun.sh/install | bash',
-    '',
-    'Then restart Sero — QMD will be auto-configured.',
-  ].join('\n');
-}
-
-// ── Collection management ──────────────────────────────────────
-
-export function checkCollection(): Promise<boolean> {
-  return new Promise((resolve) => {
-    execFile(qmdPath, ['collection', 'list', '--json'], { timeout: 10_000 }, (err, stdout) => {
-      if (err) { resolve(false); return; }
-      try {
-        const parsed = JSON.parse(stdout);
-        const collections = Array.isArray(parsed) ? parsed : [];
-        resolve(collections.some((e: unknown) => {
-          if (typeof e === 'string') return e === QMD_COLLECTION;
-          if (e && typeof e === 'object' && 'name' in e) {
-            return (e as { name?: string }).name === QMD_COLLECTION;
-          }
-          return false;
-        }));
-      } catch {
-        resolve(stdout.includes(QMD_COLLECTION));
-      }
-    });
-  });
-}
-
-export async function setupCollection(): Promise<boolean> {
-  const root = resolveMemoryRoot();
-
-  // Create collection
   try {
-    await execPromise(qmdPath, ['collection', 'add', root, '--name', QMD_COLLECTION], 10_000);
+    const collections = await store.listCollections();
+    const hasCollection = collections.some((c) => c.name === QMD_COLLECTION);
+
+    if (hasCollection) return true;
+
+    // Create collection pointing to the memory root
+    const root = resolveMemoryRoot();
+    await store.addCollection(QMD_COLLECTION, {
+      path: root,
+      pattern: '**/*.md',
+    });
+
+    // Add path contexts (best-effort)
+    const contexts: [string, string][] = [
+      ['/memory/daily', 'Daily append-only work logs organised by date'],
+      ['/', 'Curated long-term memory: decisions, preferences, facts, lessons'],
+    ];
+    for (const [ctxPath, desc] of contexts) {
+      try {
+        await store.addContext(QMD_COLLECTION, ctxPath, desc);
+      } catch { /* context may already exist */ }
+    }
+
+    return true;
   } catch {
     return false;
   }
-
-  // Add path contexts (best-effort)
-  const contexts: [string, string][] = [
-    ['/memory/daily', 'Daily append-only work logs organised by date'],
-    ['/', 'Curated long-term memory: decisions, preferences, facts, lessons'],
-  ];
-  for (const [ctxPath, desc] of contexts) {
-    try {
-      await execPromise(qmdPath, ['context', 'add', ctxPath, desc, '-c', QMD_COLLECTION], 10_000);
-    } catch { /* context may already exist */ }
-  }
-
-  return true;
 }
 
-// ── Initialisation (called on session_start) ───────────────────
+// ── Initialisation (called on session_start) ──────────────────
 
 export async function initQmd(): Promise<boolean> {
-  resolvePaths();
-  qmdAvailable = await detectQmd();
-
-  if (!qmdAvailable) {
-    // Try auto-install
-    const installed = await tryInstallQmd();
-    if (installed) {
-      // Re-resolve paths — qmd is now in ~/.bun/bin/ which findBinary checks
-      resolvePaths();
-      qmdAvailable = await detectQmd();
-    }
+  try {
+    const dbPath = getDefaultDbPath();
+    store = await createStore({ dbPath });
+    qmdAvailable = true;
+  } catch {
+    qmdAvailable = false;
+    return false;
   }
-
-  if (!qmdAvailable) return false;
 
   // Ensure collection exists
-  const hasCollection = await checkCollection();
-  if (!hasCollection) {
-    await setupCollection();
-  }
-
+  await ensureCollection();
   return true;
 }
 
-// ── Search ─────────────────────────────────────────────────────
+// ── Search ────────────────────────────────────────────────────
 
 export type QmdSearchMode = 'keyword' | 'semantic' | 'deep';
-
-function stripAnsi(text: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape sequences
-  return text.replace(/\u001b\[[0-9;]*[A-Za-z]/g, '').replace(/\u001b\][^\u0007]*(\u0007|\u001b\\)/g, '');
-}
-
-function parseQmdJson(stdout: string): unknown {
-  const trimmed = stdout.trim();
-  if (!trimmed || trimmed === 'No results found.' || trimmed === 'No results found') return [];
-
-  const cleaned = stripAnsi(stdout);
-  const lines = cleaned.split(/\r?\n/);
-  const startLine = lines.findIndex((l) => {
-    const s = l.trimStart();
-    return s.startsWith('[') || s.startsWith('{');
-  });
-  if (startLine === -1) return [];
-
-  const jsonText = lines.slice(startLine).join('\n').trim();
-  if (!jsonText) return [];
-  return JSON.parse(jsonText);
-}
 
 export async function runSearch(
   mode: QmdSearchMode,
   query: string,
   limit: number,
-): Promise<{ results: QmdSearchResult[]; stderr: string }> {
-  const subcommand = mode === 'keyword' ? 'search' : mode === 'semantic' ? 'vsearch' : 'query';
-  const args = [subcommand, '--json', '-c', QMD_COLLECTION, '-n', String(limit), query];
+): Promise<{ results: QmdSearchResult[]; needsEmbed: boolean }> {
+  if (!store) return { results: [], needsEmbed: false };
 
-  const { stdout, stderr } = await execPromise(qmdPath, args, 60_000);
-  const parsed = parseQmdJson(stdout);
-  const results = Array.isArray(parsed)
-    ? parsed
-    : ((parsed as Record<string, unknown>).results ?? (parsed as Record<string, unknown>).hits ?? []);
+  let needsEmbed = false;
 
-  return { results: results as QmdSearchResult[], stderr };
+  try {
+    if (mode === 'keyword') {
+      const raw = await store.searchLex(query, { collection: QMD_COLLECTION, limit });
+      return { results: raw.map(mapSearchResult), needsEmbed: false };
+    }
+
+    if (mode === 'semantic') {
+      const raw = await store.searchVector(query, { collection: QMD_COLLECTION, limit });
+      return { results: raw.map(mapSearchResult), needsEmbed: false };
+    }
+
+    // deep — hybrid with reranking
+    const raw = await store.search({
+      query,
+      collection: QMD_COLLECTION,
+      limit,
+    });
+    return { results: raw.map(mapHybridResult), needsEmbed: false };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/embed/i.test(msg)) {
+      needsEmbed = true;
+    }
+    return { results: [], needsEmbed };
+  }
 }
 
 /**
@@ -240,7 +164,7 @@ export async function searchRelevantMemories(prompt: string): Promise<string> {
   if (!sanitised) return '';
 
   try {
-    const hasCol = await checkCollection();
+    const hasCol = await ensureCollection();
     if (!hasCol) return '';
 
     let timeoutId: ReturnType<typeof setTimeout>;
@@ -270,20 +194,24 @@ export async function searchRelevantMemories(prompt: string): Promise<string> {
   }
 }
 
-// ── Re-indexing (debounced) ────────────────────────────────────
+// ── Re-indexing (debounced) ───────────────────────────────────
 
 export function scheduleQmdUpdate(): void {
-  if (!qmdAvailable) return;
+  if (!qmdAvailable || !store) return;
   if (updateTimer) clearTimeout(updateTimer);
-  updateTimer = setTimeout(() => {
+  updateTimer = setTimeout(async () => {
     updateTimer = null;
-    execFile(qmdPath, ['update'], { timeout: 30_000 }, () => {});
+    try {
+      await store!.update({ collections: [QMD_COLLECTION] });
+    } catch { /* best-effort */ }
   }, UPDATE_DEBOUNCE_MS);
 }
 
 export async function runQmdUpdateNow(): Promise<void> {
-  if (!qmdAvailable) return;
-  await execPromise(qmdPath, ['update'], 30_000).catch(() => {});
+  if (!qmdAvailable || !store) return;
+  try {
+    await store.update({ collections: [QMD_COLLECTION] });
+  } catch { /* best-effort */ }
 }
 
 export function clearUpdateTimer(): void {
@@ -291,19 +219,4 @@ export function clearUpdateTimer(): void {
     clearTimeout(updateTimer);
     updateTimer = null;
   }
-}
-
-// ── Helper ─────────────────────────────────────────────────────
-
-function execPromise(
-  cmd: string,
-  args: string[],
-  timeout: number,
-): Promise<{ stdout: string; stderr: string }> {
-  return new Promise((resolve, reject) => {
-    execFile(cmd, args, { timeout }, (err, stdout, stderr) => {
-      if (err) reject(new Error(stderr?.trim() || err.message));
-      else resolve({ stdout: stdout ?? '', stderr: stderr ?? '' });
-    });
-  });
 }

--- a/packages/pi-memory-extension/extension/search-tool.ts
+++ b/packages/pi-memory-extension/extension/search-tool.ts
@@ -17,11 +17,8 @@ import { Type } from '@sinclair/typebox';
 
 import {
   isQmdAvailable,
-  detectQmd,
+  initQmd,
   runSearch,
-  checkCollection,
-  setupCollection,
-  installInstructions,
 } from './qmd';
 import { getResultPath, getResultText } from '../shared/types';
 
@@ -66,25 +63,22 @@ export function registerSearchTool(pi: ExtensionAPI): void {
     parameters: SearchParams,
 
     async execute(_toolCallId, params) {
-      // Re-check on demand in case QMD was installed mid-session
+      // Re-check on demand in case QMD wasn't ready at session start
       let available = isQmdAvailable();
       if (!available) {
-        available = await detectQmd();
+        available = await initQmd();
       }
 
       if (!available) {
-        return text(installInstructions(), true);
-      }
-
-      // Ensure collection exists
-      let hasCol = await checkCollection();
-      if (!hasCol) {
-        const created = await setupCollection();
-        if (created) hasCol = true;
-      }
-      if (!hasCol) {
         return text(
-          'Could not set up QMD sero-memory collection. Check that QMD is working and the memory directory exists.',
+          [
+            'memory_search requires QMD (@tobilu/qmd) which could not be initialised.',
+            '',
+            'Ensure the package is installed:',
+            '  npm install @tobilu/qmd',
+            '',
+            'Then restart Sero — QMD will be auto-configured.',
+          ].join('\n'),
           true,
         );
       }
@@ -94,8 +88,7 @@ export function registerSearchTool(pi: ExtensionAPI): void {
       const query = params.query as string;
 
       try {
-        const { results, stderr } = await runSearch(mode, query, limit);
-        const needsEmbed = /need embeddings/i.test(stderr);
+        const { results, needsEmbed } = await runSearch(mode, query, limit);
 
         if (results.length === 0) {
           if (needsEmbed && (mode === 'semantic' || mode === 'deep')) {

--- a/packages/pi-memory-extension/package.json
+++ b/packages/pi-memory-extension/package.json
@@ -14,7 +14,8 @@
     ]
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.34.48"
+    "@sinclair/typebox": "^0.34.48",
+    "@tobilu/qmd": "^2.0.0"
   },
   "peerDependencies": {
     "@mariozechner/pi-ai": ">=0.55.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -817,6 +817,9 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.34.48
         version: 0.34.48
+      '@tobilu/qmd':
+        specifier: ^2.0.0
+        version: 2.0.1(typescript@5.9.3)
     devDependencies:
       '@types/node':
         specifier: ^22.19.11
@@ -2375,6 +2378,10 @@ packages:
     peerDependencies:
       react-hook-form: ^7.55.0
 
+  '@huggingface/jinja@0.5.6':
+    resolution: {integrity: sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==}
+    engines: {node: '>=18'}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -2424,6 +2431,10 @@ packages:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
 
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -2439,6 +2450,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
+
+  '@kwsites/promise-deferred@1.1.1':
+    resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
   '@malept/cross-spawn-promise@2.0.0':
     resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
@@ -2714,6 +2731,84 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@node-llama-cpp/linux-arm64@3.17.1':
+    resolution: {integrity: sha512-QK8opgd/AnGHvSQwIDXukrMNa760PLOxcu4OrxJn/CsHxiKucch0L4bDfu17XvlKiMoK41lXa6CKFm1kjVaGIQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64, x64]
+    os: [linux]
+
+  '@node-llama-cpp/linux-armv7l@3.17.1':
+    resolution: {integrity: sha512-KCLDVR1hayo/kSDUq6msT4BkBaEiudFsaT14EWFMw7V7JdEX/qBcHnthPa0eAtX0SVfKG7e2TafGuKpvr54GAw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm, x64]
+    os: [linux]
+
+  '@node-llama-cpp/linux-x64-cuda-ext@3.17.1':
+    resolution: {integrity: sha512-wlGASJIqs6yLIUd++d7KVQvrCsJrGgWKsA87wzOkkJsWEtWqtu1qCL5Pbvja5yv7OK4B4UJ/oruzccAyuBFeqQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-llama-cpp/linux-x64-cuda@3.17.1':
+    resolution: {integrity: sha512-DNTlf/x4y7eOodLrGIk2q8LL3lLrMZOG8ztUCVi802vXm3oyIO5x+ZqoRT8zbDx90wVdo3sSZhf8jvNli+JSEQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-llama-cpp/linux-x64-vulkan@3.17.1':
+    resolution: {integrity: sha512-M14roGcHYVHBNuPI6v3eNQkoBp2BsGYbyNoks6arAX5Tstl9XqJr8Zg5cEzRcYf0h5a54Ec99uM4T871j46wxg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-llama-cpp/linux-x64@3.17.1':
+    resolution: {integrity: sha512-/o/UoqAdslg4ExdKYyYPqbw+21Dr4cQ2JgouXg8Ji3opRKoTMrlUNfrMwIsYZfbDDJ8l7xFnwfGIwdlQ5RPwJg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@node-llama-cpp/mac-arm64-metal@3.17.1':
+    resolution: {integrity: sha512-oRq6/7qCMsazO2Cw0oCyiILZmMvejKJgLAIG60E00WOZWhpJGjh71JGnOybRycKA015mFPNDHzT3SDdUZtZBew==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64, x64]
+    os: [darwin]
+
+  '@node-llama-cpp/mac-x64@3.17.1':
+    resolution: {integrity: sha512-3L0nFVi70j+Qk7Xb8p/RQVMU0E28G0xXX0YL6Vzkirq3DazPYhWOLWUUs9MtGW2FrBg/6PLqyddmxwBfCpjm3w==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-llama-cpp/win-arm64@3.17.1':
+    resolution: {integrity: sha512-AStvEtvpwQoCFr6lc0OQgOs//WOS0288AN9WTTmhb4FloRj8HvGeKqlLEdhQBtIES8CXpuDXHcbYfFu4v+BXVQ==}
+    engines: {node: '>=20.0.0'}
+    cpu: [arm64, x64]
+    os: [win32]
+
+  '@node-llama-cpp/win-x64-cuda-ext@3.17.1':
+    resolution: {integrity: sha512-8ypciTUj1m1AYUbQehIj408a4w9hxNb6ddaW7dMiPH0Cqq9TFCspY/Pj2uXmJOH22VcijGNIvIQe5MPoAmYoUA==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-llama-cpp/win-x64-cuda@3.17.1':
+    resolution: {integrity: sha512-Gn08t64l3GHANoYwOnDzTA8Zp9BXZCQnTXHWIyc9pZ6pkDB4LAvZZIPgGuWTGSCipSk6Oi/hartehsRCin7Mhg==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-llama-cpp/win-x64-vulkan@3.17.1':
+    resolution: {integrity: sha512-HleDjYiJjL761U64eGo8Xe/U43zQ+xwzNSPw6Z82JCTnHjZ7tci33dmhJZHDl9NraG8hO15UnrDwgXzHwucDdw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-llama-cpp/win-x64@3.17.1':
+    resolution: {integrity: sha512-XDES1ublhDzw+so2ujg3qbxBopyPDJnYAr/nPyjA7Eu/HIlt2+qo682qapUXcyhV5U8wkfeMShMLzolwZ801Nw==}
+    engines: {node: '>=20.0.0'}
+    cpu: [x64]
+    os: [win32]
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3500,6 +3595,58 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
   '@remixicon/react@4.9.0':
     resolution: {integrity: sha512-5/jLDD4DtKxH2B4QVXTobvV1C2uL8ab9D5yAYNtFt+w80O0Ys1xFOrspqROL3fjrZi+7ElFUWE37hBfaAl6U+Q==}
     peerDependencies:
@@ -4076,6 +4223,17 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tinyhttp/content-disposition@2.2.4':
+    resolution: {integrity: sha512-5Kc5CM2Ysn3vTTArBs2vESUt0AQiWZA86yc1TI3B+lxXmtEq133C1nxXNOgnzhrivdPZIh3zLj5gDnZjoLL5GA==}
+    engines: {node: '>=12.17.0'}
+
+  '@tobilu/qmd@2.0.1':
+    resolution: {integrity: sha512-v0fqksHGk2qSo8ztSshIB8Mkfdtdk+qKdKoEvsZ972fgvU7UCO0DSI+6xQMiSznBEbf89PRQVhz30yTIgRG3iw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.9.3
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -4486,6 +4644,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@6.2.1:
+    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
+    engines: {node: '>=14.16'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -4579,6 +4741,9 @@ packages:
     resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
     engines: {node: '>=0.12.0'}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -4617,8 +4782,15 @@ packages:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
 
+  better-sqlite3@12.6.2:
+    resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -4766,15 +4938,29 @@ packages:
   chevrotain@11.0.3:
     resolution: {integrity: sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==}
 
+  chmodrp@1.0.2:
+    resolution: {integrity: sha512-TdngOlFV1FLTzU0o1w8MB6/BFywhtLC0SzRTGJU7T9lmdjlCWeMRt1iVo0Ki+ldwNk0BqNiKoc8xpLZEQ8mY1w==}
+
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   chromium-pickle-js@0.2.0:
     resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
   class-variance-authority@0.7.1:
@@ -4804,6 +4990,10 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
+
   cli-truncate@2.1.0:
     resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
     engines: {node: '>=8'}
@@ -4829,6 +5019,11 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmake-js@8.0.0:
+    resolution: {integrity: sha512-YbUP88RDwCvoQkZhRtGURYm9RIpWdtvZuhT87fKNoLjk8kIFIFeARpKfuZQGdwfH99GZpUmqSfcDrK62X7lTgg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
 
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
@@ -4856,6 +5051,10 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -5193,6 +5392,10 @@ packages:
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
 
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -5408,6 +5611,10 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  env-var@7.5.0:
+    resolution: {integrity: sha512-mKZOzLRN0ETzau2W2QXefbFjo5EF4yWq28OyKb9ICdeNhHJlOE/pHHnz4hdYJ9cNZXcJHo5xN4OT4pzuSHSNvA==}
+    engines: {node: '>=10'}
+
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
@@ -5498,6 +5705,9 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
     engines: {node: '>=18.0.0'}
@@ -5513,6 +5723,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
 
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
@@ -5602,8 +5816,19 @@ packages:
     resolution: {integrity: sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==}
     engines: {node: '>=20'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+
+  filename-reserved-regex@3.0.0:
+    resolution: {integrity: sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  filenamify@6.0.0:
+    resolution: {integrity: sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==}
+    engines: {node: '>=16'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -5780,6 +6005,9 @@ packages:
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -6076,6 +6304,11 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  ipull@3.9.5:
+    resolution: {integrity: sha512-5w/yZB5lXmTfsvNawmvkCjYo4SJNuKQz/av8TC1UiOyfOHyaM+DReqbpU2XpWYfmY+NIUbRRH8PUAWsxaS+IfA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -6112,6 +6345,10 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -6211,6 +6448,10 @@ packages:
   isexe@3.1.5:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
+
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
 
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
@@ -6354,6 +6595,12 @@ packages:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
 
+  lifecycle-utils@2.1.0:
+    resolution: {integrity: sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==}
+
+  lifecycle-utils@3.1.1:
+    resolution: {integrity: sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==}
+
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
     engines: {node: '>= 12.0.0'}
@@ -6439,6 +6686,9 @@ packages:
   lodash.clonedeepwith@4.5.0:
     resolution: {integrity: sha512-QRBRSxhbtsX1nc0baxSkkK5WlVTTm/s48DSukcGcWZwIyI8Zz+lB+kFiELJXtzfH4Aj6kMWQ1VWW4U5uUDgZMA==}
 
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
@@ -6468,6 +6718,10 @@ packages:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   log4js@6.9.1:
     resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
     engines: {node: '>=8.0'}
@@ -6484,6 +6738,10 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lowdb@7.0.1:
+    resolution: {integrity: sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==}
+    engines: {node: '>=18'}
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -6843,6 +7101,13 @@ packages:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
 
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
@@ -6904,6 +7169,9 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -6936,6 +7204,13 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-addon-api@8.6.0:
+    resolution: {integrity: sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==}
+    engines: {node: ^18 || ^20 || >= 21}
+
+  node-api-headers@1.8.0:
+    resolution: {integrity: sha512-jfnmiKWjRAGbdD1yQS28bknFM1tbHC1oucyuMPjmkEs+kpiu76aRs40WlTmBmyEgzDM76ge1DQ7XJ3R5deiVjQ==}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -6952,6 +7227,16 @@ packages:
     resolution: {integrity: sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==}
     engines: {node: ^12.13 || ^14.13 || >=16}
     hasBin: true
+
+  node-llama-cpp@3.17.1:
+    resolution: {integrity: sha512-f+eYXag3kFeMwLrTTSTtyt+4p2etJGvTPXEdipYy7EqSZha9ZFBpGYNftxZwbdTiqh/qyNSe3TeZve5tkq5OPQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
@@ -7053,6 +7338,10 @@ packages:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
 
+  ora@9.3.0:
+    resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
+    engines: {node: '>=20'}
+
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
@@ -7096,6 +7385,10 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-ms@3.0.0:
+    resolution: {integrity: sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==}
+    engines: {node: '>=12'}
 
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
@@ -7222,6 +7515,20 @@ packages:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
+  pretty-bytes@6.1.1:
+    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
+  pretty-ms@8.0.0:
+    resolution: {integrity: sha512-ASJqOugUF1bbzI35STMBUpZqdfYKlJugy6JBziGi2EE+AL5JPJGSzvpeVXojxrr0ViUYoToUjb5kjSEGf7Y83Q==}
+    engines: {node: '>=14.16'}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -7318,6 +7625,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-day-picker@9.13.2:
     resolution: {integrity: sha512-IMPiXfXVIAuR5Yk58DDPBC8QKClrhdXV+Tr/alBrwrHUw0qDDYB1m5zPNuTnnPIr/gmJ4ChMxmtqPdxm8+R4Eg==}
@@ -7552,6 +7863,10 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
@@ -7710,6 +8025,15 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  simple-git@3.33.0:
+    resolution: {integrity: sha512-D4V/tGC2sjsoNhoMybKyGoE+v8A60hRawKQ1iFRA1zwuDgGZCBJ4ByOzZ5J8joBbi4Oam0qiPH+GhzmSBwbJng==}
+
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
@@ -7717,9 +8041,20 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sleep-promise@9.1.0:
+    resolution: {integrity: sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==}
+
   slice-ansi@3.0.0:
     resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
     engines: {node: '>=8'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -7766,6 +8101,34 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  sqlite-vec-darwin-arm64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-raIATOqFYkeCHhb/t3r7W7Cf2lVYdf4J3ogJ6GFc8PQEgHCPEsi+bYnm2JT84MzLfTlSTIdxr4/NKv+zF7oLPw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  sqlite-vec-darwin-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-jeZEELsQjjRsVojsvU5iKxOvkaVuE+JYC8Y4Ma8U45aAERrDYmqZoHvgSG7cg1PXL3bMlumFTAmHynf1y4pOzA==}
+    cpu: [x64]
+    os: [darwin]
+
+  sqlite-vec-linux-arm64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-6Spj4Nfi7tG13jsUG+W7jnT0bCTWbyPImu2M8nWp20fNrd1SZ4g3CSlDAK8GBdavX7wRlbBHCZ+BDa++rbDewA==}
+    cpu: [arm64]
+    os: [linux]
+
+  sqlite-vec-linux-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-IcgrbHaDccTVhXDf8Orwdc2+hgDLAFORl6OBUhcvlmwswwBP1hqBTSEhovClG4NItwTOBNgpwOoQ7Qp3VDPWLg==}
+    cpu: [x64]
+    os: [linux]
+
+  sqlite-vec-windows-x64@0.1.7-alpha.2:
+    resolution: {integrity: sha512-TRP6hTjAcwvQ6xpCZvjP00pdlda8J38ArFy1lMYhtQWXiIBmWnhMaMbq4kaeCYwvTTddfidatRS+TJrwIKB/oQ==}
+    cpu: [x64]
+    os: [win32]
+
+  sqlite-vec@0.1.7-alpha.2:
+    resolution: {integrity: sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==}
+
   ssri@9.0.1:
     resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -7795,6 +8158,18 @@ packages:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
 
+  stdin-discarder@0.3.1:
+    resolution: {integrity: sha512-reExS1kSGoElkextOcPkel4NE99S0BWxjUHQeDFnR8S993JxpPX7KU4MNmO19NXhlJp+8dmdCbKQVNgLJh2teA==}
+    engines: {node: '>=18'}
+
+  stdout-update@4.0.1:
+    resolution: {integrity: sha512-wiS21Jthlvl1to+oorePvcyrIkiG/6M3D3VTmDUlJm7Cy6SbFhKkAvX+YBuHLxck/tO3mrdpC/cNesigQc3+UQ==}
+    engines: {node: '>=16.0.0'}
+
+  steno@4.0.2:
+    resolution: {integrity: sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==}
+    engines: {node: '>=18'}
+
   streamdown@2.2.0:
     resolution: {integrity: sha512-Y51o1I/sjpAy4Yn7j7R4TbUl9gcUZ7BTrHS+68IhrUBoYpNQZ28z06vww1MBFu4mSwvgF8xQIxIH2b9S9IHDyQ==}
     peerDependencies:
@@ -7818,6 +8193,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -7855,6 +8234,10 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
 
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
@@ -7905,6 +8288,9 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -7913,6 +8299,10 @@ packages:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
     deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tar@7.5.11:
+    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
+    engines: {node: '>=18'}
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
@@ -8011,6 +8401,9 @@ packages:
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
     engines: {node: '>=0.6.x'}
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   turbo-darwin-64@2.8.8:
     resolution: {integrity: sha512-7R/XRAleyNB8nIJuenRpS7EnmCM/kYFgcG1rW3F5DF57Nl4WyBO3DzxqwooRheuoXDD1UsJvDse0yRufgxjClA==}
@@ -8150,6 +8543,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
   use-callback-ref@1.3.3:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
@@ -8339,6 +8735,11 @@ packages:
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
+  which@6.0.1:
+    resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -8403,6 +8804,10 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
@@ -9549,6 +9954,8 @@ snapshots:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.71.1(react@19.2.4)
 
+  '@huggingface/jinja@0.5.6': {}
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.0':
@@ -9596,6 +10003,10 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9614,6 +10025,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@kwsites/promise-deferred@1.1.1': {}
 
   '@malept/cross-spawn-promise@2.0.0':
     dependencies:
@@ -9870,7 +10289,6 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@module-federation/bridge-react-webpack-plugin@2.0.1':
     dependencies:
@@ -10160,6 +10578,45 @@ snapshots:
       '@noble/hashes': 1.8.0
 
   '@noble/hashes@1.8.0': {}
+
+  '@node-llama-cpp/linux-arm64@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/linux-armv7l@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/linux-x64-cuda-ext@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/linux-x64-cuda@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/linux-x64-vulkan@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/linux-x64@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/mac-arm64-metal@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/mac-x64@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/win-arm64@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/win-x64-cuda-ext@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/win-x64-cuda@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/win-x64-vulkan@3.17.1':
+    optional: true
+
+  '@node-llama-cpp/win-x64@3.17.1':
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -10987,6 +11444,42 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+    optional: true
+
   '@remixicon/react@4.9.0(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -11599,6 +12092,29 @@ snapshots:
       tailwindcss: 4.1.18
       vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
+  '@tinyhttp/content-disposition@2.2.4': {}
+
+  '@tobilu/qmd@2.0.1(typescript@5.9.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.26.0(zod@4.3.6)
+      better-sqlite3: 12.6.2
+      fast-glob: 3.3.3
+      node-llama-cpp: 3.17.1(typescript@5.9.3)
+      picomatch: 4.0.3
+      sqlite-vec: 0.1.7-alpha.2
+      typescript: 5.9.3
+      yaml: 2.8.2
+      zod: 4.3.6
+    optionalDependencies:
+      sqlite-vec-darwin-arm64: 0.1.7-alpha.2
+      sqlite-vec-darwin-x64: 0.1.7-alpha.2
+      sqlite-vec-linux-arm64: 0.1.7-alpha.2
+      sqlite-vec-linux-x64: 0.1.7-alpha.2
+      sqlite-vec-windows-x64: 0.1.7-alpha.2
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -12083,6 +12599,8 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@6.2.1: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -12218,6 +12736,10 @@ snapshots:
 
   async-exit-hook@2.0.1: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -12248,7 +12770,16 @@ snapshots:
 
   basic-ftp@5.2.0: {}
 
+  better-sqlite3@12.6.2:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bignumber.js@9.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   bl@4.1.0:
     dependencies:
@@ -12448,11 +12979,19 @@ snapshots:
       '@chevrotain/utils': 11.0.3
       lodash-es: 4.17.21
 
+  chmodrp@1.0.2: {}
+
+  chownr@1.1.4: {}
+
   chownr@2.0.0: {}
+
+  chownr@3.0.0: {}
 
   chromium-pickle-js@0.2.0: {}
 
   ci-info@3.9.0: {}
+
+  ci-info@4.4.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -12480,6 +13019,8 @@ snapshots:
       yargs: 16.2.0
 
   cli-spinners@2.9.2: {}
+
+  cli-spinners@3.4.0: {}
 
   cli-truncate@2.1.0:
     dependencies:
@@ -12509,6 +13050,20 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cmake-js@8.0.0:
+    dependencies:
+      debug: 4.4.3
+      fs-extra: 11.3.3
+      node-api-headers: 1.8.0
+      rc: 1.2.8
+      semver: 7.7.4
+      tar: 7.5.11
+      url-join: 4.0.1
+      which: 6.0.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
@@ -12536,6 +13091,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
+
+  commander@10.0.1: {}
 
   commander@11.1.0: {}
 
@@ -12864,6 +13421,8 @@ snapshots:
 
   deep-equal@1.0.1: {}
 
+  deep-extend@0.6.0: {}
+
   deepmerge@4.3.1: {}
 
   default-browser-id@5.0.1: {}
@@ -13128,6 +13687,8 @@ snapshots:
 
   env-paths@2.2.1: {}
 
+  env-var@7.5.0: {}
+
   err-code@2.0.3: {}
 
   error-ex@1.3.4:
@@ -13249,6 +13810,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  eventemitter3@5.0.4: {}
+
   eventsource-parser@3.0.6: {}
 
   eventsource@3.0.7:
@@ -13281,6 +13844,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expand-template@2.0.3: {}
 
   expand-tilde@2.0.2:
     dependencies:
@@ -13401,9 +13966,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  file-uri-to-path@1.0.0: {}
+
   filelist@1.0.4:
     dependencies:
       minimatch: 5.1.9
+
+  filename-reserved-regex@3.0.0: {}
+
+  filenamify@6.0.0:
+    dependencies:
+      filename-reserved-regex: 3.0.0
 
   fill-range@7.1.1:
     dependencies:
@@ -13587,6 +14160,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -13997,6 +14572,30 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  ipull@3.9.5:
+    dependencies:
+      '@tinyhttp/content-disposition': 2.2.4
+      async-retry: 1.3.3
+      chalk: 5.6.2
+      ci-info: 4.4.0
+      cli-spinners: 2.9.2
+      commander: 10.0.1
+      eventemitter3: 5.0.4
+      filenamify: 6.0.0
+      fs-extra: 11.3.3
+      is-unicode-supported: 2.1.0
+      lifecycle-utils: 2.1.0
+      lodash.debounce: 4.0.8
+      lowdb: 7.0.1
+      pretty-bytes: 6.1.1
+      pretty-ms: 8.0.0
+      sleep-promise: 9.1.0
+      slice-ansi: 7.1.2
+      stdout-update: 4.0.1
+      strip-ansi: 7.1.2
+    optionalDependencies:
+      '@reflink/reflink': 0.1.19
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -14023,6 +14622,10 @@ snapshots:
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
 
   is-glob@4.0.3:
     dependencies:
@@ -14081,6 +14684,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
+
+  isexe@4.0.0: {}
 
   isomorphic-ws@5.0.0(ws@8.18.0):
     dependencies:
@@ -14231,6 +14836,10 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  lifecycle-utils@2.1.0: {}
+
+  lifecycle-utils@3.1.1: {}
+
   lightningcss-android-arm64@1.30.2:
     optional: true
 
@@ -14292,6 +14901,8 @@ snapshots:
 
   lodash.clonedeepwith@4.5.0: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.difference@4.5.0: {}
@@ -14316,6 +14927,11 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
@@ -14335,6 +14951,10 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lowdb@7.0.1:
+    dependencies:
+      steno: 4.0.2
 
   lowercase-keys@2.0.0: {}
 
@@ -14642,7 +15262,7 @@ snapshots:
 
   micromark-extension-cjk-friendly-util@2.1.1(micromark-util-types@2.0.2):
     dependencies:
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.5.0
       micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
     optionalDependencies:
@@ -14931,6 +15551,12 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.2
+
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@1.0.4: {}
 
   mlly@1.8.0:
@@ -14995,6 +15621,8 @@ snapshots:
 
   nanoid@5.1.6: {}
 
+  napi-build-utils@2.0.0: {}
+
   negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
@@ -15016,6 +15644,10 @@ snapshots:
     optional: true
 
   node-addon-api@7.1.1: {}
+
+  node-addon-api@8.6.0: {}
+
+  node-api-headers@1.8.0: {}
 
   node-api-version@0.2.1:
     dependencies:
@@ -15044,6 +15676,54 @@ snapshots:
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
+      - supports-color
+
+  node-llama-cpp@3.17.1(typescript@5.9.3):
+    dependencies:
+      '@huggingface/jinja': 0.5.6
+      async-retry: 1.3.3
+      bytes: 3.1.2
+      chalk: 5.6.2
+      chmodrp: 1.0.2
+      cmake-js: 8.0.0
+      cross-spawn: 7.0.6
+      env-var: 7.5.0
+      filenamify: 6.0.0
+      fs-extra: 11.3.3
+      ignore: 7.0.5
+      ipull: 3.9.5
+      is-unicode-supported: 2.1.0
+      lifecycle-utils: 3.1.1
+      log-symbols: 7.0.1
+      nanoid: 5.1.6
+      node-addon-api: 8.6.0
+      ora: 9.3.0
+      pretty-ms: 9.3.0
+      proper-lockfile: 4.1.2
+      semver: 7.7.4
+      simple-git: 3.33.0
+      slice-ansi: 8.0.0
+      stdout-update: 4.0.1
+      strip-ansi: 7.1.2
+      validate-npm-package-name: 7.0.2
+      which: 6.0.1
+      yargs: 17.7.2
+    optionalDependencies:
+      '@node-llama-cpp/linux-arm64': 3.17.1
+      '@node-llama-cpp/linux-armv7l': 3.17.1
+      '@node-llama-cpp/linux-x64': 3.17.1
+      '@node-llama-cpp/linux-x64-cuda': 3.17.1
+      '@node-llama-cpp/linux-x64-cuda-ext': 3.17.1
+      '@node-llama-cpp/linux-x64-vulkan': 3.17.1
+      '@node-llama-cpp/mac-arm64-metal': 3.17.1
+      '@node-llama-cpp/mac-x64': 3.17.1
+      '@node-llama-cpp/win-arm64': 3.17.1
+      '@node-llama-cpp/win-x64': 3.17.1
+      '@node-llama-cpp/win-x64-cuda': 3.17.1
+      '@node-llama-cpp/win-x64-cuda-ext': 3.17.1
+      '@node-llama-cpp/win-x64-vulkan': 3.17.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
       - supports-color
 
   node-pty@1.1.0:
@@ -15155,6 +15835,17 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.1.2
 
+  ora@9.3.0:
+    dependencies:
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.1
+      string-width: 8.2.0
+
   outvariant@1.4.3: {}
 
   p-cancelable@2.1.1: {}
@@ -15213,6 +15904,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-ms@3.0.0: {}
 
   parse-ms@4.0.0: {}
 
@@ -15315,6 +16008,27 @@ snapshots:
       source-map-js: 1.2.1
 
   powershell-utils@0.1.0: {}
+
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.87.0
+      pump: 3.0.3
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
+  pretty-bytes@6.1.1: {}
+
+  pretty-ms@8.0.0:
+    dependencies:
+      parse-ms: 3.0.0
 
   pretty-ms@9.3.0:
     dependencies:
@@ -15475,6 +16189,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-day-picker@9.13.2(react@19.2.4):
     dependencies:
@@ -15786,6 +16507,8 @@ snapshots:
 
   retry@0.12.0: {}
 
+  retry@0.13.1: {}
+
   rettime@0.10.1: {}
 
   reusify@1.1.0: {}
@@ -16038,11 +16761,29 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
+  simple-git@3.33.0:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      '@kwsites/promise-deferred': 1.1.1
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.4
 
   sisteransi@1.0.5: {}
+
+  sleep-promise@9.1.0: {}
 
   slice-ansi@3.0.0:
     dependencies:
@@ -16050,6 +16791,16 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
     optional: true
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   smart-buffer@4.2.0: {}
 
@@ -16097,6 +16848,29 @@ snapshots:
   sprintf-js@1.1.3:
     optional: true
 
+  sqlite-vec-darwin-arm64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-darwin-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-linux-arm64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-linux-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec-windows-x64@0.1.7-alpha.2:
+    optional: true
+
+  sqlite-vec@0.1.7-alpha.2:
+    optionalDependencies:
+      sqlite-vec-darwin-arm64: 0.1.7-alpha.2
+      sqlite-vec-darwin-x64: 0.1.7-alpha.2
+      sqlite-vec-linux-arm64: 0.1.7-alpha.2
+      sqlite-vec-linux-x64: 0.1.7-alpha.2
+      sqlite-vec-windows-x64: 0.1.7-alpha.2
+
   ssri@9.0.1:
     dependencies:
       minipass: 3.3.6
@@ -16114,6 +16888,17 @@ snapshots:
   std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
+
+  stdin-discarder@0.3.1: {}
+
+  stdout-update@4.0.1:
+    dependencies:
+      ansi-escapes: 6.2.1
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+
+  steno@4.0.2: {}
 
   streamdown@2.2.0(react@19.2.4):
     dependencies:
@@ -16161,7 +16946,12 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
-      get-east-asian-width: 1.4.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.1.2
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
   string_decoder@1.1.1:
@@ -16198,6 +16988,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  strip-json-comments@2.0.1: {}
 
   strnum@2.2.0: {}
 
@@ -16241,6 +17033,13 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.3
+      tar-stream: 2.2.0
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -16257,6 +17056,14 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
+
+  tar@7.5.11:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   temp-file@3.4.0:
     dependencies:
@@ -16349,6 +17156,10 @@ snapshots:
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo-darwin-64@2.8.8:
     optional: true
@@ -16478,6 +17289,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-join@4.0.1: {}
 
   use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
     dependencies:
@@ -16650,6 +17463,10 @@ snapshots:
     dependencies:
       isexe: 3.1.5
 
+  which@6.0.1:
+    dependencies:
+      isexe: 4.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -16695,6 +17512,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
 
   yaml@2.8.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
     devDependencies:
+      '@discordjs/rest':
+        specifier: ^2.6.0
+        version: 2.6.0
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2

--- a/scripts/rebuild-better-sqlite3.mjs
+++ b/scripts/rebuild-better-sqlite3.mjs
@@ -18,7 +18,7 @@
  * Called from root package.json `postinstall`.
  */
 
-import { execSync, execFileSync, spawnSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';

--- a/scripts/rebuild-better-sqlite3.mjs
+++ b/scripts/rebuild-better-sqlite3.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Ensures better-sqlite3's native binary matches the Electron ABI.
+ *
+ * WHY THIS EXISTS:
+ * Sero runs in Electron, which bundles its own Node.js with a specific module ABI.
+ * better-sqlite3 is a native addon used by @tobilu/qmd (the memory search backend).
+ * A plain `npm rebuild` or `pnpm rebuild` compiles against system Node.js (wrong ABI),
+ * producing ERR_DLOPEN_FAILED at runtime and silently disabling memory search.
+ *
+ * WHAT THIS DOES:
+ * 1. Locates better-sqlite3 in the pnpm store
+ * 2. Locates the Electron binary in node_modules
+ * 3. Runs a trivial smoke test via ELECTRON_RUN_AS_NODE=1 (tests the actual ABI)
+ * 4. If it fails → runs @electron/rebuild to compile against Electron's headers
+ * 5. If it works → exits immediately (no-op, fast)
+ *
+ * Called from root package.json `postinstall`.
+ */
+
+import { execSync, execFileSync, spawnSync } from 'child_process';
+import { existsSync, readdirSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const req = createRequire(import.meta.url);
+
+// ── Locate better-sqlite3 ─────────────────────────────────────────────────────
+
+const PNPM_STORE = resolve(ROOT, 'node_modules/.pnpm');
+
+function findBetterSqlite3() {
+  if (!existsSync(PNPM_STORE)) return null;
+  const entries = readdirSync(PNPM_STORE).filter(e => e.startsWith('better-sqlite3@'));
+  if (entries.length === 0) return null;
+  // Take the first (there should only be one version)
+  const pkgDir = resolve(PNPM_STORE, entries[0], 'node_modules/better-sqlite3');
+  return existsSync(pkgDir) ? pkgDir : null;
+}
+
+// ── Locate Electron binary ────────────────────────────────────────────────────
+
+function findElectronBinary() {
+  if (!existsSync(PNPM_STORE)) return null;
+  const entries = readdirSync(PNPM_STORE).filter(e => e.startsWith('electron@'));
+  for (const entry of entries) {
+    const bin = resolve(PNPM_STORE, entry, 'node_modules/electron/dist/Electron.app/Contents/MacOS/Electron');
+    if (existsSync(bin)) return bin;
+  }
+  return null;
+}
+
+function findElectronVersion() {
+  const entries = existsSync(PNPM_STORE)
+    ? readdirSync(PNPM_STORE).filter(e => e.startsWith('electron@'))
+    : [];
+  for (const entry of entries) {
+    const pkgJson = resolve(PNPM_STORE, entry, 'node_modules/electron/package.json');
+    if (existsSync(pkgJson)) {
+      try {
+        const { version } = req(pkgJson);
+        // Strip build metadata (e.g. "33.4.11+wvcus" → "33.4.11")
+        return version.split('+')[0];
+      } catch { /* continue */ }
+    }
+  }
+  return null;
+}
+
+// ── Smoke test via Electron runtime ───────────────────────────────────────────
+
+function testWithElectron(electronBin, sqlite3Dir) {
+  const script = `
+    try {
+      const bs3 = require(${JSON.stringify(sqlite3Dir)});
+      const db = new bs3(':memory:');
+      db.exec('CREATE TABLE t (x INTEGER)');
+      db.prepare('INSERT INTO t VALUES (?)').run(42);
+      const row = db.prepare('SELECT x FROM t').get();
+      process.exit(row && row.x === 42 ? 0 : 1);
+    } catch (e) {
+      process.stderr.write('better-sqlite3 test failed: ' + e.message + '\\n');
+      process.exit(1);
+    }
+  `;
+
+  const result = spawnSync(electronBin, ['-e', script], {
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    timeout: 15_000,
+    stdio: 'pipe',
+  });
+
+  return result.status === 0;
+}
+
+// ── Rebuild via @electron/rebuild ─────────────────────────────────────────────
+
+function rebuild(sqlite3Dir, electronVersion) {
+  console.log(`\x1b[33m  → Rebuilding better-sqlite3 for Electron ${electronVersion}...\x1b[0m`);
+  try {
+    execSync(
+      `npx @electron/rebuild --version "${electronVersion}" --module-dir "${sqlite3Dir}" --which-module better-sqlite3`,
+      { stdio: 'inherit', cwd: ROOT, timeout: 180_000 },
+    );
+    console.log('\x1b[32m  ✓ better-sqlite3 rebuilt successfully.\x1b[0m');
+    return true;
+  } catch {
+    console.error('\x1b[31m  ✗ better-sqlite3 rebuild failed. Memory search (QMD) will not work.\x1b[0m');
+    console.error(`    Run manually: npx @electron/rebuild --version "${electronVersion}" --module-dir "${sqlite3Dir}" --which-module better-sqlite3`);
+    return false;
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+function main() {
+  console.log('[better-sqlite3] Checking native binary for Electron...');
+
+  const sqlite3Dir = findBetterSqlite3();
+  if (!sqlite3Dir) {
+    console.log('[better-sqlite3] Not found in pnpm store — skipping.');
+    process.exit(0);
+  }
+
+  const electronBin = findElectronBinary();
+  if (!electronBin) {
+    console.log('[better-sqlite3] Electron binary not found — skipping (install apps/desktop first).');
+    process.exit(0);
+  }
+
+  const electronVersion = findElectronVersion();
+  if (!electronVersion) {
+    console.log('[better-sqlite3] Could not determine Electron version — skipping.');
+    process.exit(0);
+  }
+
+  if (testWithElectron(electronBin, sqlite3Dir)) {
+    console.log(`\x1b[32m[better-sqlite3] ✓ Binary works with Electron ${electronVersion}.\x1b[0m`);
+    process.exit(0);
+  }
+
+  console.log(`\x1b[33m[better-sqlite3] ✗ Binary does not work with Electron ${electronVersion}.\x1b[0m`);
+
+  const ok = rebuild(sqlite3Dir, electronVersion);
+  if (!ok) {
+    process.exit(1);
+  }
+
+  // Verify in a fresh process after rebuild
+  if (testWithElectron(electronBin, sqlite3Dir)) {
+    console.log('\x1b[32m[better-sqlite3] ✓ Verified: rebuild works.\x1b[0m');
+  } else {
+    console.error('\x1b[31m[better-sqlite3] ✗ Rebuild completed but binary still fails. Check output above.\x1b[0m');
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Changes

### Memory: QMD v2 SDK migration
Replace all child_process (execFile) CLI calls with direct use of the
@tobilu/qmd v2 SDK. The library API (createStore/QMDStore) eliminates
binary resolution, ANSI stripping, and JSON parsing overhead. Search
modes now use store.searchLex(), store.searchVector(), and
store.search() directly.

### Chat: Tool images & lightbox preview
Display agent-generated images (screenshots, browser captures) as clickable
thumbnails in the ChatPanel. Clicking opens a full-screen lightbox with zoom,
navigation, and popout support.

**Tool images:**
- Add `ToolResultImage` type and `images` field to `ChatToolCallMessage`
- Extract image content blocks from tool results in live streaming and history replay
- `sero app screenshot --save` now also returns image inline (thumbnails always visible)
- Tool call cards show clickable thumbnails without needing to expand

**Image lightbox (`ImageLightbox.tsx`):**
- Full-screen modal overlay with Zustand state management
- Scroll-to-zoom, keyboard shortcuts (+/-/Esc), navigation arrows for multi-image
- Open in new window (popout) button

**User attachment improvements:**
- User-pasted images in chat are now clickable → opens lightbox
- User-attached images persist after session reload (restored from Pi SDK history)

**Gateway:**
- Discord adapter and protocol updated to forward images via structured `images` field

---
https://claude.ai/code/session_01Htm1UmRi3vhsNy1GLUeZT2