### PR TITLE
feat: multi-select session deletion (⌘+click, Shift+click)

### DIFF
--- a/apps/desktop/src/components/layout/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/AddWorkspaceMenu.tsx
@@ -1,0 +1,132 @@
+import { useRef, useState } from 'react';
+import { Plus } from 'lucide-react';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { useSessionStore } from '@/stores/sessions';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@sero/ui/components/ui/popover';
+import type { WorkspaceInfo } from '@/types/ipc';
+import { PickView, CreateView } from './AddWorkspaceViews';
+import { RemoteOriginManager } from './RemoteOriginManager';
+
+// ── Add Workspace menu ─────────────────────────────────────────
+
+type AddView = 'pick' | 'create';
+
+export function AddWorkspaceMenu() {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<AddView>('pick');
+  const [newName, setNewName] = useState('');
+  const [parentPath, setParentPath] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Guards against Radix auto-closing the popover when a native dialog steals focus
+  const pickingFolderRef = useRef(false);
+  const createWorkspace = useWorkspaceStore((s) => s.createWorkspace);
+  const addFolder = useWorkspaceStore((s) => s.addFolder);
+  const loadSessions = useSessionStore((s) => s.loadSessions);
+
+  const reset = () => { setView('pick'); setNewName(''); setParentPath(null); };
+
+  const handleImportExisting = async () => {
+    setOpen(false);
+    pickingFolderRef.current = true;
+    try {
+      const folderPath = await window.sero.workspace.pickFolder();
+      if (!folderPath) return;
+      await addFolder(folderPath);
+      await loadSessions();
+    } catch (err) {
+      console.error('Failed to import workspace:', err);
+    } finally {
+      pickingFolderRef.current = false;
+    }
+  };
+
+  const handlePickLocation = async () => {
+    pickingFolderRef.current = true;
+    try {
+      const picked = await window.sero.workspace.pickFolder();
+      if (picked) setParentPath(picked);
+    } finally {
+      pickingFolderRef.current = false;
+    }
+  };
+
+  const handleCreate = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed || isCreating) return;
+    setIsCreating(true);
+    try {
+      const ws = await createWorkspace(trimmed, parentPath ?? undefined);
+      await loadSessions();
+      setOpen(false);
+      // Prompt user to set up remote origin for the new workspace
+      setNewWorkspace(ws);
+    } catch (err) {
+      console.error('Failed to create workspace:', err);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <>
+    <Popover open={open} onOpenChange={(o) => {
+      if (!o && pickingFolderRef.current) return; // Native dialog stole focus — don't close
+      setOpen(o);
+      if (!o) reset();
+    }}>
+      <PopoverTrigger asChild>
+        <button
+          className="rounded-md p-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+          title="Add workspace"
+        >
+          <Plus className="size-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        side="bottom"
+        className="w-64 p-0"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        {view === 'pick' ? (
+          <PickView
+            onCreateNew={() => {
+              setView('create');
+              // Focus the input after the view transition renders
+              requestAnimationFrame(() => inputRef.current?.focus());
+            }}
+            onImportExisting={handleImportExisting}
+          />
+        ) : (
+          <CreateView
+            inputRef={inputRef}
+            name={newName}
+            onNameChange={setNewName}
+            parentPath={parentPath}
+            onPickLocation={handlePickLocation}
+            onClearLocation={() => setParentPath(null)}
+            onBack={() => { setView('pick'); setNewName(''); setParentPath(null); }}
+            onCreate={handleCreate}
+            isCreating={isCreating}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+
+    {/* Prompt to set up remote origin after workspace creation */}
+    {newWorkspace && (
+      <RemoteOriginManager
+        open={!!newWorkspace}
+        onOpenChange={(o) => { if (!o) setNewWorkspace(null); }}
+        workspace={newWorkspace}
+      />
+    )}
+    </>
+  );
+}

--- a/apps/desktop/src/components/layout/SessionNode.tsx
+++ b/apps/desktop/src/components/layout/SessionNode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Loader2, Pencil, Trash2 } from 'lucide-react';
+import { Check, Loader2, Pencil, Trash2 } from 'lucide-react';
 import { useSessionStore } from '@/stores/sessions';
 import { useStreamingSessionIds } from '@/stores/agent-selectors';
 import { Button } from '@sero/ui/components/ui/button';
@@ -13,7 +13,14 @@ import { cn } from '@sero/ui/lib/utils';
 
 // ── Session node ───────────────────────────────────────────────
 
-export function SessionNode({ session }: { session: SeroSessionInfo }) {
+export function SessionNode({
+  session,
+  workspaceSessions,
+}: {
+  session: SeroSessionInfo;
+  /** All sessions in this workspace — needed for Shift+click range selection. */
+  workspaceSessions: SeroSessionInfo[];
+}) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState('');
@@ -24,6 +31,13 @@ export function SessionNode({ session }: { session: SeroSessionInfo }) {
   const deleteSession = useSessionStore((s) => s.deleteSession);
   const renameSession = useSessionStore((s) => s.renameSession);
   const streamingIds = useStreamingSessionIds();
+
+  // Multi-select
+  const isSelected = useSessionStore((s) => s.selectedSessionIds.has(session.id));
+  const hasSelection = useSessionStore((s) => s.selectedSessionIds.size > 0);
+  const toggleSelectSession = useSessionStore((s) => s.toggleSelectSession);
+  const selectSessionRange = useSessionStore((s) => s.selectSessionRange);
+  const clearSelection = useSessionStore((s) => s.clearSelection);
 
   const isActive = activeSessionId === session.id;
   const isStreaming = streamingIds.includes(session.id);
@@ -64,22 +78,42 @@ export function SessionNode({ session }: { session: SeroSessionInfo }) {
     await deleteSession(session.path);
   };
 
+  const handleClick = (e: React.MouseEvent) => {
+    if (e.shiftKey) {
+      // Shift+click — range select
+      e.preventDefault();
+      selectSessionRange(session.id, workspaceSessions);
+    } else if (e.metaKey || e.ctrlKey) {
+      // Ctrl/Cmd+click — toggle individual
+      e.preventDefault();
+      toggleSelectSession(session.id);
+    } else {
+      // Normal click — activate session and clear selection
+      if (hasSelection) clearSelection();
+      setActiveSession(session.id);
+    }
+  };
+
   return (
     <button
-      onClick={() => setActiveSession(session.id)}
+      onClick={handleClick}
       onDoubleClick={(e) => { e.stopPropagation(); startRename(); }}
       className={cn(
         'group flex w-full items-center gap-4 rounded-md px-2 py-1 text-left transition-colors',
-        isActive
-          ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
-          : 'hover:bg-[var(--bg-elevated)]',
+        isSelected
+          ? 'bg-[var(--accent-muted)]/15 ring-1 ring-[var(--accent-primary)]/30 text-[var(--text-primary)]'
+          : isActive
+            ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+            : 'hover:bg-[var(--bg-elevated)]',
       )}
     >
-      {/* Streaming spinner — only visible when agent is working */}
+      {/* Leading indicator: checkmark when selected, spinner when streaming */}
       <span className="flex size-3 shrink-0 items-center justify-center">
-        {isStreaming && (
+        {isSelected ? (
+          <Check className="size-3 text-[var(--accent-primary)]" />
+        ) : isStreaming ? (
           <Loader2 className="size-3 animate-spin text-[var(--status-success)]" />
-        )}
+        ) : null}
       </span>
 
       {/* Title + metadata */}
@@ -114,8 +148,11 @@ export function SessionNode({ session }: { session: SeroSessionInfo }) {
         </div>
       </div>
 
-      {/* Actions: rename + delete */}
-      <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+      {/* Actions: rename + delete (hidden during multi-select — bulk actions live on workspace header) */}
+      <span className={cn(
+        'flex shrink-0 items-center gap-0.5 transition-opacity',
+        hasSelection ? 'opacity-0 pointer-events-none' : 'opacity-0 group-hover:opacity-100',
+      )}>
         <span
           role="button"
           tabIndex={-1}

--- a/apps/desktop/src/components/layout/WorkspaceTree.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceTree.tsx
@@ -63,7 +63,7 @@ export function WorkspaceTree() {
   // Escape key clears multi-select
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && hasSelection) {
+      if (e.key === 'Escape' && hasSelection && !e.defaultPrevented) {
         clearSelection();
       }
     };
@@ -246,7 +246,7 @@ function WorkspaceNode({
 
   const handleBulkDelete = async () => {
     setConfirmBulkDelete(false);
-    await deleteSelectedSessions();
+    await deleteSelectedSessions(workspace.id);
   };
 
   return (

--- a/apps/desktop/src/components/layout/WorkspaceTree.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceTree.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Box,
   ChevronsDownUp,
@@ -10,6 +10,7 @@ import {
   Minus,
   Monitor,
   Plus,
+  Trash2,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useWorkspaceStore, useOpenWorkspaces } from '@/stores/workspace';
@@ -19,14 +20,18 @@ import { useAppStore } from '@/stores/app';
 import { useWorkspaceContainer, type ContainerStatus } from '@/stores/container';
 import { Button } from '@sero/ui/components/ui/button';
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@sero/ui/components/ui/popover';
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@sero/ui/components/ui/dialog';
+
 import type { WorkspaceInfo, SeroSessionInfo } from '@/types/ipc';
 import { cn } from '@sero/ui/lib/utils';
 import { SessionNode } from './SessionNode';
-import { PickView, CreateView } from './AddWorkspaceViews';
+import { AddWorkspaceMenu } from './AddWorkspaceMenu';
 import { WorkspaceReferencesMenu } from './WorkspaceReferencesMenu';
 import { RemoteOriginManager } from './RemoteOriginManager';
 
@@ -46,12 +51,25 @@ export function WorkspaceTree() {
   const openWorkspaces = useOpenWorkspaces();
   const sessionsByWorkspace = useSessionsByWorkspace();
   const isLoadingWorkspaces = useWorkspaceStore((s) => s.isLoading);
+  const clearSelection = useSessionStore((s) => s.clearSelection);
+  const hasSelection = useSessionStore((s) => s.selectedSessionIds.size > 0);
 
   // Load on mount
   useEffect(() => {
     loadWorkspaces();
     loadSessions();
   }, [loadWorkspaces, loadSessions]);
+
+  // Escape key clears multi-select
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && hasSelection) {
+        clearSelection();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [clearSelection, hasSelection]);
 
   // Refresh when a federated app (e.g. SlopZilla) creates a workspace
   useEffect(() => {
@@ -147,126 +165,6 @@ function CollapseAllButton() {
   );
 }
 
-// ── Add Workspace menu ─────────────────────────────────────────
-
-type AddView = 'pick' | 'create';
-
-function AddWorkspaceMenu() {
-  const [open, setOpen] = useState(false);
-  const [view, setView] = useState<AddView>('pick');
-  const [newName, setNewName] = useState('');
-  const [parentPath, setParentPath] = useState<string | null>(null);
-  const [isCreating, setIsCreating] = useState(false);
-  const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  // Guards against Radix auto-closing the popover when a native dialog steals focus
-  const pickingFolderRef = useRef(false);
-  const createWorkspace = useWorkspaceStore((s) => s.createWorkspace);
-  const addFolder = useWorkspaceStore((s) => s.addFolder);
-  const loadSessions = useSessionStore((s) => s.loadSessions);
-
-  const reset = () => { setView('pick'); setNewName(''); setParentPath(null); };
-
-  const handleImportExisting = async () => {
-    setOpen(false);
-    pickingFolderRef.current = true;
-    try {
-      const folderPath = await window.sero.workspace.pickFolder();
-      if (!folderPath) return;
-      await addFolder(folderPath);
-      await loadSessions();
-    } catch (err) {
-      console.error('Failed to import workspace:', err);
-    } finally {
-      pickingFolderRef.current = false;
-    }
-  };
-
-  const handlePickLocation = async () => {
-    pickingFolderRef.current = true;
-    try {
-      const picked = await window.sero.workspace.pickFolder();
-      if (picked) setParentPath(picked);
-    } finally {
-      pickingFolderRef.current = false;
-    }
-  };
-
-  const handleCreate = async () => {
-    const trimmed = newName.trim();
-    if (!trimmed || isCreating) return;
-    setIsCreating(true);
-    try {
-      const ws = await createWorkspace(trimmed, parentPath ?? undefined);
-      await loadSessions();
-      setOpen(false);
-      // Prompt user to set up remote origin for the new workspace
-      setNewWorkspace(ws);
-    } catch (err) {
-      console.error('Failed to create workspace:', err);
-    } finally {
-      setIsCreating(false);
-    }
-  };
-
-  return (
-    <>
-    <Popover open={open} onOpenChange={(o) => {
-      if (!o && pickingFolderRef.current) return; // Native dialog stole focus — don't close
-      setOpen(o);
-      if (!o) reset();
-    }}>
-      <PopoverTrigger asChild>
-        <button
-          className="rounded-md p-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-          title="Add workspace"
-        >
-          <Plus className="size-3.5" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="end"
-        side="bottom"
-        className="w-64 p-0"
-        onOpenAutoFocus={(e) => e.preventDefault()}
-      >
-        {view === 'pick' ? (
-          <PickView
-            onCreateNew={() => {
-              setView('create');
-              // Focus the input after the view transition renders
-              requestAnimationFrame(() => inputRef.current?.focus());
-            }}
-            onImportExisting={handleImportExisting}
-          />
-        ) : (
-          <CreateView
-            inputRef={inputRef}
-            name={newName}
-            onNameChange={setNewName}
-            parentPath={parentPath}
-            onPickLocation={handlePickLocation}
-            onClearLocation={() => setParentPath(null)}
-            onBack={() => { setView('pick'); setNewName(''); setParentPath(null); }}
-            onCreate={handleCreate}
-            isCreating={isCreating}
-          />
-        )}
-      </PopoverContent>
-    </Popover>
-
-    {/* Prompt to set up remote origin after workspace creation */}
-    {newWorkspace && (
-      <RemoteOriginManager
-        open={!!newWorkspace}
-        onOpenChange={(o) => { if (!o) setNewWorkspace(null); }}
-        workspace={newWorkspace}
-      />
-    )}
-    </>
-  );
-}
-
 // ── Workspace node ─────────────────────────────────────────────
 
 /** Tiny container/host status indicator dot. */
@@ -305,13 +203,20 @@ function WorkspaceNode({
 }) {
   const [hovered, setHovered] = useState(false);
   const [remoteManagerOpen, setRemoteManagerOpen] = useState(false);
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
   const toggleCollapsed = useWorkspaceStore((s) => s.toggleCollapsed);
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
   const setActiveWorkspace = useWorkspaceStore((s) => s.setActiveWorkspace);
   const closeWorkspace = useWorkspaceStore((s) => s.closeWorkspace);
   const toggleContainer = useWorkspaceStore((s) => s.toggleContainer);
   const createSession = useSessionStore((s) => s.createSession);
+  const deleteSelectedSessions = useSessionStore((s) => s.deleteSelectedSessions);
+  const clearSelection = useSessionStore((s) => s.clearSelection);
+  const selectedSessionIds = useSessionStore((s) => s.selectedSessionIds);
   const streamingIds = useStreamingSessionIds();
+
+  // Count how many selected sessions belong to this workspace
+  const selectedInWorkspace = sessions.filter((s) => selectedSessionIds.has(s.id)).length;
 
   const expanded = workspace.open;
   const isActive = activeWorkspaceId === workspace.id;
@@ -337,6 +242,11 @@ function WorkspaceNode({
   const handleClose = (e: React.MouseEvent) => {
     e.stopPropagation();
     closeWorkspace(workspace.id);
+  };
+
+  const handleBulkDelete = async () => {
+    setConfirmBulkDelete(false);
+    await deleteSelectedSessions();
   };
 
   return (
@@ -375,6 +285,34 @@ function WorkspaceNode({
 
         {/* Right side: crossfade between count and actions */}
         <span className="relative ml-auto flex h-5 shrink-0 items-center justify-end">
+          {/* Bulk delete badge — always visible when sessions are selected in this workspace */}
+          {selectedInWorkspace > 0 ? (
+            <span className="flex items-center gap-1">
+              <span className="text-xs font-medium text-[var(--accent-primary)]">
+                {selectedInWorkspace}
+              </span>
+              <span
+                role="button"
+                tabIndex={-1}
+                onClick={(e) => { e.stopPropagation(); setConfirmBulkDelete(true); }}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); setConfirmBulkDelete(true); } }}
+                className="rounded p-0.5 hover:bg-[var(--status-error)]/15"
+                title={`Delete ${selectedInWorkspace} selected session${selectedInWorkspace > 1 ? 's' : ''}`}
+              >
+                <Trash2 className="size-3 text-[var(--status-error)]" />
+              </span>
+              <span
+                role="button"
+                tabIndex={-1}
+                onClick={(e) => { e.stopPropagation(); clearSelection(); }}
+                onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); clearSelection(); } }}
+                className="rounded p-0.5 text-xs text-[var(--text-muted)] hover:bg-[var(--bg-base)] hover:text-[var(--text-primary)]"
+                title="Clear selection (Esc)"
+              >
+                ✕
+              </span>
+            </span>
+          ) : (
           <AnimatePresence mode="wait" initial={false}>
             {hovered ? (
               <motion.span
@@ -455,6 +393,7 @@ function WorkspaceNode({
               </motion.span>
             )}
           </AnimatePresence>
+          )}
         </span>
       </button>
 
@@ -467,11 +406,33 @@ function WorkspaceNode({
             </span>
           ) : (
             sessions.map((session) => (
-              <SessionNode key={session.id} session={session} />
+              <SessionNode key={session.id} session={session} workspaceSessions={sessions} />
             ))
           )}
         </div>
       )}
+
+      {/* Bulk delete confirmation */}
+      <Dialog open={confirmBulkDelete} onOpenChange={setConfirmBulkDelete}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Delete {selectedInWorkspace} session{selectedInWorkspace > 1 ? 's' : ''}?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete {selectedInWorkspace === 1 ? 'this session' : `these ${selectedInWorkspace} sessions`} from{' '}
+              <span className="font-medium text-[var(--text-primary)]">{workspace.name}</span>.
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setConfirmBulkDelete(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" size="sm" onClick={handleBulkDelete}>
+              Delete {selectedInWorkspace} session{selectedInWorkspace > 1 ? 's' : ''}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Remote origin manager */}
       <RemoteOriginManager

--- a/apps/desktop/src/stores/sessions.ts
+++ b/apps/desktop/src/stores/sessions.ts
@@ -28,8 +28,8 @@ interface SessionsState {
   /** Create a session bound to a workspace. Defaults to global. */
   createSession: (workspaceId?: string) => Promise<SeroSessionInfo>;
   deleteSession: (sessionPath: string) => Promise<void>;
-  /** Bulk-delete all selected sessions. Returns count of deleted sessions. */
-  deleteSelectedSessions: () => Promise<number>;
+  /** Bulk-delete selected sessions in a workspace. Returns count of deleted sessions. */
+  deleteSelectedSessions: (workspaceId: string) => Promise<number>;
   setActiveSession: (id: string | null) => void;
   setSearchQuery: (q: string) => void;
   /** Update a session's display name in-memory (e.g., from agent title generation). */
@@ -180,26 +180,49 @@ export const useSessionStore = create<SessionsState>((set, get) => ({
     set({ selectedSessionIds: new Set<string>(), lastClickedSessionId: null });
   },
 
-  deleteSelectedSessions: async () => {
+  deleteSelectedSessions: async (workspaceId) => {
     const { selectedSessionIds, sessions, activeSessionId } = get();
     if (selectedSessionIds.size === 0) return 0;
 
-    // Delete all selected sessions via IPC
-    const toDelete = sessions.filter((s) => selectedSessionIds.has(s.id));
-    await Promise.all(toDelete.map((s) => window.sero.sessions.delete(s.path)));
+    // Only delete selected sessions that belong to the target workspace
+    const toDelete = sessions.filter(
+      (s) => selectedSessionIds.has(s.id) && s.workspaceId === workspaceId,
+    );
+    if (toDelete.length === 0) return 0;
 
-    const remaining = sessions.filter((s) => !selectedSessionIds.has(s.id));
-    const clearActive = activeSessionId && selectedSessionIds.has(activeSessionId);
+    // Use allSettled so partial failures don't leave inconsistent state
+    const results = await Promise.allSettled(
+      toDelete.map((s) => window.sero.sessions.delete(s.path)),
+    );
+
+    const deletedIds = new Set<string>();
+    for (let i = 0; i < results.length; i++) {
+      if (results[i].status === 'fulfilled') {
+        deletedIds.add(toDelete[i].id);
+      } else {
+        console.error('[sessions] failed to delete session:', toDelete[i].id, results[i]);
+      }
+    }
+
+    if (deletedIds.size === 0) return 0;
+
+    const remaining = sessions.filter((s) => !deletedIds.has(s.id));
+    const clearActive = activeSessionId != null && deletedIds.has(activeSessionId);
     if (clearActive) persistLayout({ activeSessionId: null });
+
+    // Remove deleted IDs from selection; keep selections in other workspaces
+    const nextSelected = new Set(selectedSessionIds);
+    for (const id of deletedIds) nextSelected.delete(id);
 
     set({
       sessions: remaining,
       activeSessionId: clearActive ? null : activeSessionId,
-      selectedSessionIds: new Set<string>(),
-      lastClickedSessionId: null,
+      selectedSessionIds: nextSelected,
+      lastClickedSessionId:
+        nextSelected.size === 0 ? null : get().lastClickedSessionId,
     });
 
-    return toDelete.length;
+    return deletedIds.size;
   },
 }));
 

--- a/apps/desktop/src/stores/sessions.ts
+++ b/apps/desktop/src/stores/sessions.ts
@@ -17,17 +17,31 @@ interface SessionsState {
   /** Last error message, if any. */
   error: string | null;
 
+  // ── Multi-select ───────────────────────────────────────────
+  /** Session IDs currently selected for bulk actions (Ctrl/Cmd+click, Shift+click). */
+  selectedSessionIds: Set<string>;
+  /** The last session ID that was clicked — anchor for Shift+click range selection. */
+  lastClickedSessionId: string | null;
+
   // ── Actions ────────────────────────────────────────────────
   loadSessions: () => Promise<void>;
   /** Create a session bound to a workspace. Defaults to global. */
   createSession: (workspaceId?: string) => Promise<SeroSessionInfo>;
   deleteSession: (sessionPath: string) => Promise<void>;
+  /** Bulk-delete all selected sessions. Returns count of deleted sessions. */
+  deleteSelectedSessions: () => Promise<number>;
   setActiveSession: (id: string | null) => void;
   setSearchQuery: (q: string) => void;
   /** Update a session's display name in-memory (e.g., from agent title generation). */
   updateSessionName: (sessionId: string, name: string) => void;
   /** Rename a session via IPC (persists to session file). */
   renameSession: (sessionId: string, name: string) => Promise<void>;
+  /** Toggle a single session in/out of the multi-select set. */
+  toggleSelectSession: (sessionId: string) => void;
+  /** Select a contiguous range of sessions (Shift+click). Uses `lastClickedSessionId` as anchor. */
+  selectSessionRange: (sessionId: string, workspaceSessions: SeroSessionInfo[]) => void;
+  /** Clear all multi-select state. */
+  clearSelection: () => void;
 }
 
 /** Sort sessions by modified date, newest first. */
@@ -45,6 +59,8 @@ export const useSessionStore = create<SessionsState>((set, get) => ({
   searchQuery: '',
   isLoading: false,
   error: null,
+  selectedSessionIds: new Set<string>(),
+  lastClickedSessionId: null,
 
   loadSessions: async () => {
     set({ isLoading: true, error: null });
@@ -111,6 +127,79 @@ export const useSessionStore = create<SessionsState>((set, get) => ({
         sess.id === sessionId ? { ...sess, name } : sess,
       ),
     }));
+  },
+
+  // ── Multi-select actions ─────────────────────────────────
+
+  toggleSelectSession: (sessionId) => {
+    const { selectedSessionIds } = get();
+    const next = new Set(selectedSessionIds);
+    if (next.has(sessionId)) {
+      next.delete(sessionId);
+    } else {
+      next.add(sessionId);
+    }
+    set({ selectedSessionIds: next, lastClickedSessionId: sessionId });
+  },
+
+  selectSessionRange: (sessionId, workspaceSessions) => {
+    const { lastClickedSessionId, selectedSessionIds } = get();
+    if (!lastClickedSessionId) {
+      // No anchor — just select this one
+      set({
+        selectedSessionIds: new Set([sessionId]),
+        lastClickedSessionId: sessionId,
+      });
+      return;
+    }
+
+    const anchorIdx = workspaceSessions.findIndex((s) => s.id === lastClickedSessionId);
+    const targetIdx = workspaceSessions.findIndex((s) => s.id === sessionId);
+    if (anchorIdx === -1 || targetIdx === -1) {
+      // Anchor is in a different workspace — start fresh
+      set({
+        selectedSessionIds: new Set([sessionId]),
+        lastClickedSessionId: sessionId,
+      });
+      return;
+    }
+
+    const start = Math.min(anchorIdx, targetIdx);
+    const end = Math.max(anchorIdx, targetIdx);
+    const rangeIds = workspaceSessions.slice(start, end + 1).map((s) => s.id);
+
+    // Merge with existing selection (add range on top)
+    const next = new Set(selectedSessionIds);
+    for (const id of rangeIds) next.add(id);
+
+    set({ selectedSessionIds: next });
+    // Keep lastClickedSessionId as the anchor — don't update it on shift+click
+  },
+
+  clearSelection: () => {
+    set({ selectedSessionIds: new Set<string>(), lastClickedSessionId: null });
+  },
+
+  deleteSelectedSessions: async () => {
+    const { selectedSessionIds, sessions, activeSessionId } = get();
+    if (selectedSessionIds.size === 0) return 0;
+
+    // Delete all selected sessions via IPC
+    const toDelete = sessions.filter((s) => selectedSessionIds.has(s.id));
+    await Promise.all(toDelete.map((s) => window.sero.sessions.delete(s.path)));
+
+    const remaining = sessions.filter((s) => !selectedSessionIds.has(s.id));
+    const clearActive = activeSessionId && selectedSessionIds.has(activeSessionId);
+    if (clearActive) persistLayout({ activeSessionId: null });
+
+    set({
+      sessions: remaining,
+      activeSessionId: clearActive ? null : activeSessionId,
+      selectedSessionIds: new Set<string>(),
+      lastClickedSessionId: null,
+    });
+
+    return toDelete.length;
   },
 }));
 


### PR DESCRIPTION
## Summary

Add the ability to select multiple sessions in the workspace sidebar and delete them in bulk.

### Interactions

| Action | Behavior |
|---|---|
| **⌘/Ctrl + click** | Toggle individual sessions in/out of selection |
| **Shift + click** | Select a contiguous range from the last-clicked session |
| **Normal click** | Activate session as before (clears any selection) |
| **Escape** | Clear selection |

### Visual feedback

- Selected sessions get an accent-colored ring + background highlight
- A ✓ checkmark replaces the streaming spinner in the leading indicator
- Per-session rename/delete buttons are hidden during multi-select

### Bulk delete

- When sessions are selected, the workspace header shows: count + 🗑️ delete + ✕ clear
- Clicking the trash icon opens a confirmation dialog
- Deletes all selected sessions in parallel via IPC
- Clears `activeSessionId` if it was in the deleted set

### Files changed

| File | Change |
|---|---|
| `src/stores/sessions.ts` | `selectedSessionIds`, `lastClickedSessionId`, `toggleSelectSession`, `selectSessionRange`, `clearSelection`, `deleteSelectedSessions` |
| `src/components/layout/SessionNode.tsx` | Multi-select click handling, visual selected state, hides per-item actions during selection |
| `src/components/layout/WorkspaceTree.tsx` | Escape key handler, bulk delete badge + confirmation Dialog on workspace header |
| `src/components/layout/AddWorkspaceMenu.tsx` | **New** — extracted from WorkspaceTree to stay under 500 LOC |

### Typecheck

```
Tasks:    25 successful, 25 total
Cached:   24 cached, 25 total
```