### PR TITLE
feat: kanban workflow improvements — stage contracts, quality gates, brainstorm pipeline, YOLO mode

### DIFF
--- a/apps/desktop/electron/__tests__/kanban/contracts.test.ts
+++ b/apps/desktop/electron/__tests__/kanban/contracts.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for stage contracts — transition validation logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  validateTransition,
+  getContract,
+  getUnmetDependencies,
+  getNewlyUnblockedCards,
+} from '../../kanban/contracts';
+import type { Card, KanbanState } from '../../kanban/types';
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: '1',
+    title: 'Test card',
+    description: 'A test card',
+    acceptance: ['It works'],
+    priority: 'medium',
+    column: 'backlog',
+    status: 'idle',
+    subtasks: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeState(cards: Card[]): KanbanState {
+  return {
+    cards,
+    nextId: cards.length + 1,
+    settings: {
+      autoAdvance: true,
+      maxConcurrentCards: 3,
+      requireApproval: { plan: true, pr: true },
+      reviewLevel: 'per-wave',
+      testingEnabled: true,
+      yoloMode: false,
+    },
+  };
+}
+
+describe('getContract', () => {
+  it('returns contract for known transitions', () => {
+    expect(getContract('backlog', 'planning')).not.toBeNull();
+    expect(getContract('planning', 'in-progress')).not.toBeNull();
+    expect(getContract('in-progress', 'review')).not.toBeNull();
+    expect(getContract('review', 'done')).not.toBeNull();
+  });
+
+  it('returns null for unknown transitions', () => {
+    expect(getContract('done', 'backlog')).toBeNull();
+    expect(getContract('backlog', 'done')).toBeNull();
+  });
+});
+
+describe('validateTransition: backlog → planning', () => {
+  it('passes with complete card', () => {
+    const card = makeCard();
+    const result = validateTransition(card, 'planning');
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails when title is empty', () => {
+    const card = makeCard({ title: '' });
+    const result = validateTransition(card, 'planning');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('title'))).toBe(true);
+  });
+
+  it('fails when description is empty', () => {
+    const card = makeCard({ description: '' });
+    const result = validateTransition(card, 'planning');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('description'))).toBe(true);
+  });
+
+  it('fails when acceptance criteria are missing', () => {
+    const card = makeCard({ acceptance: [] });
+    const result = validateTransition(card, 'planning');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('acceptance'))).toBe(true);
+  });
+
+  it('collects all errors at once', () => {
+    const card = makeCard({ title: '', description: '', acceptance: [] });
+    const result = validateTransition(card, 'planning');
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBe(3);
+  });
+
+  it('blocks when card has unmet dependencies', () => {
+    const blocker = makeCard({ id: '2', column: 'in-progress' });
+    const card = makeCard({ id: '1', blockedBy: ['2'] });
+    const state = makeState([card, blocker]);
+    const result = validateTransition(card, 'planning', state);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('#2'))).toBe(true);
+  });
+
+  it('passes when blocking card is done', () => {
+    const blocker = makeCard({ id: '2', column: 'done' });
+    const card = makeCard({ id: '1', blockedBy: ['2'] });
+    const state = makeState([card, blocker]);
+    const result = validateTransition(card, 'planning', state);
+    expect(result.valid).toBe(true);
+  });
+
+  it('treats non-existent blocking cards as unmet', () => {
+    const card = makeCard({ blockedBy: ['999'] });
+    const state = makeState([card]);
+    const result = validateTransition(card, 'planning', state);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('#999'))).toBe(true);
+  });
+});
+
+describe('validateTransition: planning → in-progress', () => {
+  it('passes with plan, subtasks, and waiting-input status', () => {
+    const card = makeCard({
+      column: 'planning',
+      status: 'waiting-input',
+      plan: 'Do the thing',
+      subtasks: [{ id: '1', title: 'Sub', description: '', status: 'pending', dependsOn: [] }],
+    });
+    const result = validateTransition(card, 'in-progress');
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails without plan', () => {
+    const card = makeCard({
+      column: 'planning',
+      status: 'waiting-input',
+      subtasks: [{ id: '1', title: 'Sub', description: '', status: 'pending', dependsOn: [] }],
+    });
+    const result = validateTransition(card, 'in-progress');
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('plan'))).toBe(true);
+  });
+
+  it('fails without subtasks', () => {
+    const card = makeCard({
+      column: 'planning',
+      status: 'waiting-input',
+      plan: 'Do it',
+    });
+    const result = validateTransition(card, 'in-progress');
+    expect(result.valid).toBe(false);
+  });
+
+  it('fails when status is not waiting-input', () => {
+    const card = makeCard({
+      column: 'planning',
+      status: 'agent-working',
+      plan: 'Do it',
+      subtasks: [{ id: '1', title: 'Sub', description: '', status: 'pending', dependsOn: [] }],
+    });
+    const result = validateTransition(card, 'in-progress');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateTransition: review → done', () => {
+  it('passes when card is waiting-input', () => {
+    const card = makeCard({ column: 'review', status: 'waiting-input' });
+    const result = validateTransition(card, 'done');
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails when card is not waiting-input', () => {
+    const card = makeCard({ column: 'review', status: 'agent-working' });
+    const result = validateTransition(card, 'done');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateTransition: unknown transitions', () => {
+  it('allows moves that have no contract (e.g. done → backlog)', () => {
+    const card = makeCard({ column: 'done' });
+    const result = validateTransition(card, 'backlog');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('getUnmetDependencies', () => {
+  it('returns empty when no blockedBy', () => {
+    const card = makeCard();
+    const state = makeState([card]);
+    expect(getUnmetDependencies(card, state)).toEqual([]);
+  });
+
+  it('returns unmet deps that are not in done', () => {
+    const card = makeCard({ blockedBy: ['2', '3'] });
+    const dep2 = makeCard({ id: '2', column: 'in-progress' });
+    const dep3 = makeCard({ id: '3', column: 'done' });
+    const state = makeState([card, dep2, dep3]);
+    expect(getUnmetDependencies(card, state)).toEqual(['2']);
+  });
+});
+
+describe('getNewlyUnblockedCards', () => {
+  it('finds cards unblocked by completed card', () => {
+    const blocker = makeCard({ id: '1', column: 'done' });
+    const blocked = makeCard({ id: '2', column: 'backlog', blockedBy: ['1'] });
+    const state = makeState([blocker, blocked]);
+    const unblocked = getNewlyUnblockedCards('1', state);
+    expect(unblocked).toHaveLength(1);
+    expect(unblocked[0].id).toBe('2');
+  });
+
+  it('does not include cards with other unmet deps', () => {
+    const done1 = makeCard({ id: '1', column: 'done' });
+    const notDone = makeCard({ id: '3', column: 'in-progress' });
+    const blocked = makeCard({ id: '2', column: 'backlog', blockedBy: ['1', '3'] });
+    const state = makeState([done1, notDone, blocked]);
+    expect(getNewlyUnblockedCards('1', state)).toHaveLength(0);
+  });
+
+  it('only considers backlog cards', () => {
+    const blocker = makeCard({ id: '1', column: 'done' });
+    const alreadyMoving = makeCard({ id: '2', column: 'planning', blockedBy: ['1'] });
+    const state = makeState([blocker, alreadyMoving]);
+    expect(getNewlyUnblockedCards('1', state)).toHaveLength(0);
+  });
+});

--- a/apps/desktop/electron/__tests__/kanban/prompts.test.ts
+++ b/apps/desktop/electron/__tests__/kanban/prompts.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for prompt builders and parsers — plan parsing, review parsing, prompt generation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  parsePlanResult,
+  parseReviewResult,
+  buildSubtaskPrompt,
+  buildSubtaskGenerationPrompt,
+  buildReviewPrompt,
+  buildSpecReviewPrompt,
+} from '../../kanban/prompts';
+import type { Card } from '../../kanban/types';
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: '1',
+    title: 'Test feature',
+    description: 'Implement test feature',
+    acceptance: ['Feature works', 'Tests pass'],
+    priority: 'medium',
+    column: 'planning',
+    status: 'waiting-input',
+    subtasks: [
+      { id: '1', title: 'Setup', description: 'Project setup', status: 'completed', dependsOn: [] },
+      { id: '2', title: 'Implement', description: 'Core logic', status: 'pending', dependsOn: ['1'] },
+    ],
+    plan: 'Build it step by step',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ── parsePlanResult ──────────────────────────────────────────
+
+describe('parsePlanResult', () => {
+  it('parses valid JSON with plan and subtasks', () => {
+    const raw = '```json\n{"plan": "Do X then Y", "subtasks": [{"id": "1", "title": "First", "description": "Do first thing", "dependsOn": []}]}\n```';
+    const result = parsePlanResult(raw);
+    expect(result.plan).toBe('Do X then Y');
+    expect(result.subtasks).toHaveLength(1);
+    expect(result.subtasks[0].title).toBe('First');
+    expect(result.subtasks[0].status).toBe('pending');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('parses new TDD/file fields', () => {
+    const raw = '```json\n{"plan": "TDD approach", "subtasks": [{"id": "1", "title": "Tests", "description": "Write tests", "dependsOn": [], "tddDesignation": "tdd", "filePaths": ["src/utils.ts", "src/utils.test.ts"], "complexity": "medium"}]}\n```';
+    const result = parsePlanResult(raw);
+    expect(result.subtasks[0].tddDesignation).toBe('tdd');
+    expect(result.subtasks[0].filePaths).toEqual(['src/utils.ts', 'src/utils.test.ts']);
+    expect(result.subtasks[0].complexity).toBe('medium');
+  });
+
+  it('ignores invalid TDD designation values', () => {
+    const raw = '```json\n{"plan": "X", "subtasks": [{"id": "1", "title": "T", "description": "D", "dependsOn": [], "tddDesignation": "invalid"}]}\n```';
+    const result = parsePlanResult(raw);
+    expect(result.subtasks[0].tddDesignation).toBeUndefined();
+  });
+
+  it('ignores invalid complexity values', () => {
+    const raw = '```json\n{"plan": "X", "subtasks": [{"id": "1", "title": "T", "description": "D", "dependsOn": [], "complexity": "extreme"}]}\n```';
+    const result = parsePlanResult(raw);
+    expect(result.subtasks[0].complexity).toBeUndefined();
+  });
+
+  it('returns warnings for invalid dependency references', () => {
+    const raw = '```json\n{"plan": "X", "subtasks": [{"id": "1", "title": "T", "description": "D", "dependsOn": ["99"]}]}\n```';
+    const result = parsePlanResult(raw);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain('99');
+  });
+
+  it('handles no JSON block gracefully', () => {
+    const result = parsePlanResult('Just some random text without JSON');
+    expect(result.plan).toBe('Just some random text without JSON');
+    expect(result.subtasks).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('handles malformed JSON gracefully', () => {
+    const result = parsePlanResult('```json\n{invalid json}\n```');
+    expect(result.subtasks).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('generates IDs when missing from subtasks', () => {
+    const raw = '```json\n{"plan": "X", "subtasks": [{"title": "A", "description": "D1", "dependsOn": []}, {"title": "B", "description": "D2", "dependsOn": []}]}\n```';
+    const result = parsePlanResult(raw);
+    expect(result.subtasks[0].id).toBe('1');
+    expect(result.subtasks[1].id).toBe('2');
+  });
+
+  it('defaults subtask status to pending', () => {
+    const raw = '```json\n{"plan": "X", "subtasks": [{"id": "1", "title": "T", "description": "D", "dependsOn": [], "status": "completed"}]}\n```';
+    const result = parsePlanResult(raw);
+    expect(result.subtasks[0].status).toBe('pending');
+  });
+});
+
+// ── parseReviewResult ────────────────────────────────────────
+
+describe('parseReviewResult', () => {
+  it('parses valid review JSON', () => {
+    const raw = '```json\n{"approved": true, "summary": "Good", "issues": [], "prTitle": "feat: add X", "prBody": "## Summary\\nDoes X"}\n```';
+    const result = parseReviewResult(raw);
+    expect(result.approved).toBe(true);
+    expect(result.prTitle).toBe('feat: add X');
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('parses structured categorized issues', () => {
+    const raw = '```json\n{"approved": false, "summary": "Issues found", "issues": ["Bug"], "categorizedIssues": [{"description": "Bug in foo", "severity": "critical", "file": "src/foo.ts", "line": 42}], "verdict": "fix-first", "prTitle": "fix: bugs", "prBody": "Fix"}\n```';
+    const result = parseReviewResult(raw);
+    expect(result.categorizedIssues).toHaveLength(1);
+    expect(result.categorizedIssues![0].severity).toBe('critical');
+    expect(result.categorizedIssues![0].file).toBe('src/foo.ts');
+    expect(result.verdict).toBe('fix-first');
+  });
+
+  it('handles missing categorizedIssues', () => {
+    const raw = '```json\n{"approved": true, "summary": "OK", "issues": [], "prTitle": "T", "prBody": "B"}\n```';
+    const result = parseReviewResult(raw);
+    expect(result.categorizedIssues).toBeUndefined();
+    expect(result.verdict).toBeUndefined();
+  });
+
+  it('clamps prTitle to 72 chars', () => {
+    const longTitle = 'a'.repeat(100);
+    const raw = `\`\`\`json\n{"approved": true, "summary": "X", "issues": [], "prTitle": "${longTitle}", "prBody": "B"}\n\`\`\``;
+    const result = parseReviewResult(raw);
+    expect(result.prTitle.length).toBe(72);
+  });
+
+  it('defaults to approved when no JSON found', () => {
+    const result = parseReviewResult('No JSON here');
+    expect(result.approved).toBe(true);
+    expect(result.prTitle).toBe('feat: implementation');
+  });
+
+  it('uses card title in fallback prTitle', () => {
+    const result = parseReviewResult('No JSON here', 'Add user dashboard');
+    expect(result.prTitle).toBe('feat: add user dashboard');
+  });
+
+  it('defaults approved to true when field is missing', () => {
+    const raw = '```json\n{"summary": "OK", "issues": [], "prTitle": "T", "prBody": "B"}\n```';
+    const result = parseReviewResult(raw);
+    expect(result.approved).toBe(true);
+  });
+
+  it('rejects invalid verdict values', () => {
+    const raw = '```json\n{"approved": true, "summary": "X", "issues": [], "prTitle": "T", "prBody": "B", "verdict": "maybe"}\n```';
+    const result = parseReviewResult(raw);
+    expect(result.verdict).toBeUndefined();
+  });
+});
+
+// ── buildSubtaskPrompt ───────────────────────────────────────
+
+describe('buildSubtaskPrompt', () => {
+  it('throws for non-existent subtask', () => {
+    const card = makeCard();
+    expect(() => buildSubtaskPrompt(card, '999')).toThrow('Subtask 999 not found');
+  });
+
+  it('includes completed subtask context with file paths', () => {
+    const card = makeCard({
+      subtasks: [
+        { id: '1', title: 'Setup', description: 'Init', status: 'completed', dependsOn: [], filePaths: ['src/init.ts'] },
+        { id: '2', title: 'Build', description: 'Core', status: 'pending', dependsOn: ['1'] },
+      ],
+    });
+    const prompt = buildSubtaskPrompt(card, '2');
+    expect(prompt).toContain('✅ Setup');
+    expect(prompt).toContain('src/init.ts');
+  });
+
+  it('includes TDD instructions when enabled', () => {
+    const card = makeCard({
+      subtasks: [
+        { id: '1', title: 'Test', description: 'Write tests', status: 'pending', dependsOn: [], tddDesignation: 'tdd' },
+      ],
+    });
+    const prompt = buildSubtaskPrompt(card, '1', { testingEnabled: true });
+    expect(prompt).toContain('tdd');
+    expect(prompt).toContain('failing test first');
+  });
+
+  it('omits TDD instructions when testing disabled', () => {
+    const card = makeCard({
+      subtasks: [
+        { id: '1', title: 'Test', description: 'Write tests', status: 'pending', dependsOn: [], tddDesignation: 'tdd' },
+      ],
+    });
+    const prompt = buildSubtaskPrompt(card, '1', { testingEnabled: false });
+    expect(prompt).toContain('disabled');
+  });
+});
+
+// ── buildSubtaskGenerationPrompt ─────────────────────────────
+
+describe('buildSubtaskGenerationPrompt', () => {
+  it('includes TDD instructions when enabled', () => {
+    const card = makeCard();
+    const prompt = buildSubtaskGenerationPrompt(card, 'analysis...', { testingEnabled: true });
+    expect(prompt).toContain('tddDesignation');
+    expect(prompt).toContain('tdd');
+  });
+
+  it('disables TDD when testing is off', () => {
+    const card = makeCard();
+    const prompt = buildSubtaskGenerationPrompt(card, 'analysis...', { testingEnabled: false });
+    expect(prompt).toContain('no-test');
+    expect(prompt).toContain('disabled');
+  });
+});
+
+// ── buildReviewPrompt ────────────────────────────────────────
+
+describe('buildReviewPrompt', () => {
+  it('includes subtask summary in review', () => {
+    const card = makeCard();
+    const prompt = buildReviewPrompt(card, 'diff...', 'file summary...');
+    expect(prompt).toContain('Subtask Summary');
+    expect(prompt).toContain('Setup');
+  });
+
+  it('includes testing disabled note when testing is off', () => {
+    const card = makeCard();
+    const prompt = buildReviewPrompt(card, 'diff', 'files', { testingEnabled: false });
+    expect(prompt).toContain('disabled');
+    expect(prompt).toContain('do not flag missing test coverage');
+  });
+
+  it('truncates long diffs', () => {
+    const card = makeCard();
+    const longDiff = 'x'.repeat(50000);
+    const prompt = buildReviewPrompt(card, longDiff, 'files');
+    expect(prompt).toContain('truncated');
+    expect(prompt.length).toBeLessThan(50000);
+  });
+});
+
+// ── buildSpecReviewPrompt ────────────────────────────────────
+
+describe('buildSpecReviewPrompt', () => {
+  it('throws for non-existent subtask', () => {
+    const card = makeCard();
+    expect(() => buildSpecReviewPrompt(card, '999', 'diff')).toThrow();
+  });
+
+  it('includes subtask spec and file paths', () => {
+    const card = makeCard({
+      subtasks: [
+        { id: '1', title: 'Build', description: 'Build the thing', status: 'completed', dependsOn: [], filePaths: ['src/thing.ts'] },
+      ],
+    });
+    const prompt = buildSpecReviewPrompt(card, '1', 'diff data');
+    expect(prompt).toContain('Build the thing');
+    expect(prompt).toContain('src/thing.ts');
+  });
+});

--- a/apps/desktop/electron/__tests__/kanban/verification.test.ts
+++ b/apps/desktop/electron/__tests__/kanban/verification.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for verification command detection.
+ *
+ * Tests the detection logic using mock filesystem — does NOT execute commands.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectVerificationCommands, detectPackageManager } from '../../kanban/verification';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kanban-verify-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('detectPackageManager', () => {
+  it('detects pnpm from pnpm-lock.yaml', async () => {
+    await fs.writeFile(path.join(tmpDir, 'pnpm-lock.yaml'), '');
+    expect(detectPackageManager(tmpDir)).toBe('pnpm');
+  });
+
+  it('detects pnpm from pnpm-workspace.yaml', async () => {
+    await fs.writeFile(path.join(tmpDir, 'pnpm-workspace.yaml'), '');
+    expect(detectPackageManager(tmpDir)).toBe('pnpm');
+  });
+
+  it('detects yarn from yarn.lock', async () => {
+    await fs.writeFile(path.join(tmpDir, 'yarn.lock'), '');
+    expect(detectPackageManager(tmpDir)).toBe('yarn');
+  });
+
+  it('defaults to npm when no lock file found', () => {
+    expect(detectPackageManager(tmpDir)).toBe('npm');
+  });
+});
+
+describe('detectVerificationCommands', () => {
+  it('detects TypeScript project with typecheck script', async () => {
+    await fs.writeFile(path.join(tmpDir, 'tsconfig.json'), '{}');
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { typecheck: 'tsc --noEmit' } }),
+    );
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands).toContain('npm run typecheck');
+  });
+
+  it('skips typecheck when tsconfig exists but no typecheck script', async () => {
+    await fs.writeFile(path.join(tmpDir, 'tsconfig.json'), '{}');
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { dev: 'vite' } }),
+    );
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands.some((c) => c.includes('typecheck'))).toBe(false);
+  });
+
+  it('uses correct package manager for typecheck', async () => {
+    await fs.writeFile(path.join(tmpDir, 'tsconfig.json'), '{}');
+    await fs.writeFile(path.join(tmpDir, 'pnpm-lock.yaml'), '');
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { typecheck: 'tsc --noEmit' } }),
+    );
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands).toContain('pnpm run typecheck');
+  });
+
+  it('detects test script in package.json', async () => {
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { test: 'vitest' } }),
+    );
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands.some((c) => c.includes('test'))).toBe(true);
+  });
+
+  it('ignores default npm test stub', async () => {
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { test: 'echo "Error: no test specified" && exit 1' } }),
+    );
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands.some((c) => c.includes('test'))).toBe(false);
+  });
+
+  it('detects Cargo project', async () => {
+    await fs.writeFile(path.join(tmpDir, 'Cargo.toml'), '');
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands).toContain('cargo check');
+    expect(commands).toContain('cargo test');
+  });
+
+  it('detects Python project', async () => {
+    await fs.writeFile(path.join(tmpDir, 'pyproject.toml'), '');
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands).toContain('pytest');
+  });
+
+  it('excludes test commands when testing is disabled', async () => {
+    await fs.writeFile(path.join(tmpDir, 'tsconfig.json'), '{}');
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { typecheck: 'tsc --noEmit', test: 'vitest' } }),
+    );
+    await fs.writeFile(path.join(tmpDir, 'Cargo.toml'), '');
+
+    const commands = await detectVerificationCommands(tmpDir, { testingEnabled: false });
+    // Typecheck should still be included (correctness, not testing)
+    expect(commands.some((c) => c.includes('typecheck'))).toBe(true);
+    // Test commands should be excluded
+    expect(commands.some((c) => c.includes('test') && !c.includes('typecheck'))).toBe(false);
+    expect(commands.some((c) => c.includes('cargo'))).toBe(false);
+    expect(commands.some((c) => c.includes('pytest'))).toBe(false);
+  });
+
+  it('returns empty for vanilla directory', async () => {
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands).toHaveLength(0);
+  });
+
+  it('detects multiple project types simultaneously', async () => {
+    await fs.writeFile(path.join(tmpDir, 'tsconfig.json'), '{}');
+    await fs.writeFile(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ scripts: { typecheck: 'tsc --noEmit', test: 'vitest' } }),
+    );
+    const commands = await detectVerificationCommands(tmpDir);
+    expect(commands.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/desktop/electron/__tests__/kanban/wave-resolver.test.ts
+++ b/apps/desktop/electron/__tests__/kanban/wave-resolver.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for wave-resolver — dependency-ordered execution wave grouping.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveExecutionWaves } from '../../kanban/wave-resolver';
+import type { Subtask } from '../../kanban/types';
+
+function makeSubtask(id: string, dependsOn: string[] = []): Subtask {
+  return { id, title: `Task ${id}`, description: '', status: 'pending', dependsOn };
+}
+
+describe('resolveExecutionWaves', () => {
+  it('returns empty array for no subtasks', () => {
+    expect(resolveExecutionWaves([])).toEqual([]);
+  });
+
+  it('puts all independent subtasks in one wave', () => {
+    const subtasks = [makeSubtask('1'), makeSubtask('2'), makeSubtask('3')];
+    const waves = resolveExecutionWaves(subtasks);
+    expect(waves).toEqual([['1', '2', '3']]);
+  });
+
+  it('respects linear dependency chain', () => {
+    const subtasks = [
+      makeSubtask('1'),
+      makeSubtask('2', ['1']),
+      makeSubtask('3', ['2']),
+    ];
+    const waves = resolveExecutionWaves(subtasks);
+    expect(waves).toEqual([['1'], ['2'], ['3']]);
+  });
+
+  it('groups parallel subtasks with shared dependency', () => {
+    const subtasks = [
+      makeSubtask('1'),
+      makeSubtask('2', ['1']),
+      makeSubtask('3', ['1']),
+      makeSubtask('4', ['2', '3']),
+    ];
+    const waves = resolveExecutionWaves(subtasks);
+    expect(waves).toEqual([['1'], ['2', '3'], ['4']]);
+  });
+
+  it('handles diamond dependency pattern', () => {
+    // 1 → 2, 1 → 3, 2 → 4, 3 → 4
+    const subtasks = [
+      makeSubtask('1'),
+      makeSubtask('2', ['1']),
+      makeSubtask('3', ['1']),
+      makeSubtask('4', ['2', '3']),
+    ];
+    const waves = resolveExecutionWaves(subtasks);
+    expect(waves[0]).toEqual(['1']);
+    expect(waves[1]).toContain('2');
+    expect(waves[1]).toContain('3');
+    expect(waves[2]).toEqual(['4']);
+  });
+
+  it('handles circular dependencies by forcing remaining into final wave', () => {
+    const subtasks = [
+      makeSubtask('1', ['2']),
+      makeSubtask('2', ['1']),
+    ];
+    const waves = resolveExecutionWaves(subtasks);
+    // Should force both into a single wave rather than infinite loop
+    expect(waves.length).toBeGreaterThanOrEqual(1);
+    const allIds = waves.flat();
+    expect(allIds).toContain('1');
+    expect(allIds).toContain('2');
+  });
+
+  it('ignores dependencies that reference non-existent subtasks', () => {
+    const subtasks = [
+      makeSubtask('1', ['999']),
+      makeSubtask('2', ['1']),
+    ];
+    const waves = resolveExecutionWaves(subtasks);
+    // '999' doesn't exist, so '1' should have no real deps
+    expect(waves[0]).toEqual(['1']);
+    expect(waves[1]).toEqual(['2']);
+  });
+
+  it('handles single subtask', () => {
+    const waves = resolveExecutionWaves([makeSubtask('1')]);
+    expect(waves).toEqual([['1']]);
+  });
+
+  it('handles complex multi-wave scenario', () => {
+    // Wave 1: A, B (no deps)
+    // Wave 2: C (depends on A), D (depends on B)
+    // Wave 3: E (depends on C, D)
+    const subtasks = [
+      makeSubtask('A'),
+      makeSubtask('B'),
+      makeSubtask('C', ['A']),
+      makeSubtask('D', ['B']),
+      makeSubtask('E', ['C', 'D']),
+    ];
+    const waves = resolveExecutionWaves(subtasks);
+    expect(waves.length).toBe(3);
+    expect(waves[0]).toContain('A');
+    expect(waves[0]).toContain('B');
+    expect(waves[1]).toContain('C');
+    expect(waves[1]).toContain('D');
+    expect(waves[2]).toEqual(['E']);
+  });
+});

--- a/apps/desktop/electron/app-state.ts
+++ b/apps/desktop/electron/app-state.ts
@@ -30,9 +30,21 @@ interface WatcherEntry {
 
 // ── AppStateManager ──────────────────────────────────────────
 
+type ChangeListener = (filePath: string, data: unknown) => void;
+
 class AppStateManager {
   private watchers = new Map<string, WatcherEntry>();
   private writeQueues = new Map<string, Promise<void>>();
+  private changeListeners: ChangeListener[] = [];
+
+  /**
+   * Register a listener for file change events (from fs.watch).
+   * Used by the kanban orchestrator to react to state changes
+   * from ANY source (extension direct writes, IPC writes, etc.).
+   */
+  onFileChange(listener: ChangeListener): void {
+    this.changeListeners.push(listener);
+  }
 
   // ── Read ─────────────────────────────────────────────────
 
@@ -230,6 +242,14 @@ class AppStateManager {
   private pushChange(filePath: string, data: unknown): void {
     for (const win of BrowserWindow.getAllWindows()) {
       win.webContents.send(IpcChannels.appState.change, filePath, data);
+    }
+    // Notify registered listeners (e.g. kanban orchestrator)
+    for (const listener of this.changeListeners) {
+      try {
+        listener(filePath, data);
+      } catch (err) {
+        console.error('[AppStateManager] Listener error:', err);
+      }
     }
   }
 

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -148,34 +148,27 @@ export function buildCliPromptBlock(): string {
   const reg = getCliRegistry();
   const commands = reg.list().filter((c) => !c.hidden && c.name !== 'help');
 
-  // Group by source label
   const grouped = new Map<string, string[]>();
   for (const cmd of commands) {
     const group = cmd.group ?? 'Other';
     const list = grouped.get(group) ?? [];
-    list.push(`  sero ${cmd.name.padEnd(22)} ${cmd.summary}`);
+    list.push(cmd.name);
     grouped.set(group, list);
   }
 
-  const sections: string[] = [];
-  for (const [group, lines] of [...grouped.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-    sections.push(`  ${group}:`, ...lines);
-  }
+  const sections = [...grouped.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([group, names]) => `- ${group}: ${names.sort().join(', ')}`);
 
   return `
 
 ## Sero CLI
 
-You have access to the \`sero-cli\` tool for Sero platform operations.
-Use it instead of asking the user to do platform actions manually.
+Use \`sero-cli\` for Sero platform actions instead of asking the user to do them manually.
 
-Available commands:
+Commands by group:
 ${sections.join('\n')}
 
-Run \`sero help <command>\` for detailed usage of any command.
-
-Chain commands (one per line):
-  sero todo list
-  sero notes add "Summary" --body "..."
+Run \`sero help <command>\` for details. You can send multiple commands separated by newlines.
 `;
 }

--- a/apps/desktop/electron/ipc/app-state.ts
+++ b/apps/desktop/electron/ipc/app-state.ts
@@ -19,21 +19,27 @@ import { SERO_HOME } from '../env';
 
 const KANBAN_STATE_SUFFIX = '/apps/kanban/state.json';
 
-/** Notify the orchestrator if this is a kanban state file. */
+/** Notify the orchestrator immediately if this is a kanban state file. */
 function notifyKanbanOrchestrator(filePath: string, data: unknown): void {
   if (filePath.endsWith(KANBAN_STATE_SUFFIX) && data) {
-    console.log(`[app-state] Kanban state file written: ${filePath} — notifying orchestrator`);
-    // Ensure shared infrastructure is initialised (deps injected) before
-    // forwarding the state change. Fire-and-forget — don't block the write.
     ensureInfra()
       .then(() => kanbanOrchestrator.onStateChange(filePath, data as KanbanState))
-      .catch((err) => {
-        console.error('[app-state] Kanban orchestrator error:', err);
-      });
+      .catch((err) => console.error('[app-state] Kanban orchestrator error:', err));
   }
 }
 
 export function registerAppStateHandlers(): void {
+  // Register file-watcher listener so the orchestrator gets notified
+  // for ALL state changes — including direct writes from Pi extensions
+  // that bypass the IPC layer.
+  appStateManager.onFileChange((filePath, data) => {
+    if (filePath.endsWith(KANBAN_STATE_SUFFIX) && data) {
+      ensureInfra()
+        .then(() => kanbanOrchestrator.onStateChange(filePath, data as KanbanState))
+        .catch((err) => console.error('[app-state] Kanban orchestrator listener error:', err));
+    }
+  });
+
   // Read state file
   ipcMain.handle(
     IpcChannels.appState.read,
@@ -71,6 +77,7 @@ export function registerAppStateHandlers(): void {
     IpcChannels.appState.write,
     async (_event, filePath: string, data: unknown): Promise<void> => {
       await appStateManager.write(filePath, data);
+      // Immediate notification for IPC-originated writes (no file watcher delay)
       notifyKanbanOrchestrator(filePath, data);
     },
   );

--- a/apps/desktop/electron/kanban/contracts.ts
+++ b/apps/desktop/electron/kanban/contracts.ts
@@ -1,0 +1,290 @@
+/**
+ * Stage contracts — defines input requirements, expected outputs, and quality
+ * gates for each kanban column transition.
+ *
+ * The orchestrator and extension call `validateTransition()` before allowing
+ * a card to move between columns. Contracts are pure application logic —
+ * they do NOT reference prompt templates or agent system prompts.
+ */
+
+import type { Card, Column, KanbanState } from './types';
+
+// ── Contract Types ───────────────────────────────────────────
+
+export interface StageContract {
+  /** Which column transition this contract governs */
+  transition: `${Column}->${Column}`;
+
+  /** Fields that must be populated on the card before entering */
+  requiredInputs: RequiredInput[];
+
+  /** What this stage produces (documentation + validation) */
+  expectedOutputs: ExpectedOutput[];
+
+  /** Quality gates that must pass before the card advances */
+  qualityGates: QualityGate[];
+}
+
+export interface RequiredInput {
+  field: keyof Card;
+  validation: 'non-empty' | 'min-items' | 'custom';
+  /** Minimum item count when validation is 'min-items' */
+  minItems?: number;
+  /** Custom validation function name (resolved at runtime) */
+  customFn?: string;
+  /** Error shown if validation fails */
+  message: string;
+}
+
+export interface ExpectedOutput {
+  field: keyof Card;
+  description: string;
+}
+
+export interface QualityGate {
+  name: string;
+  type: 'agent-review' | 'command' | 'field-check';
+  /** For 'command': shell command to run (e.g., 'pnpm typecheck') */
+  command?: string;
+  /** For 'agent-review': which agent template to dispatch */
+  agent?: string;
+  /** For 'field-check': card field that must be truthy */
+  field?: string;
+  /** Whether failure blocks advancement or is advisory */
+  blocking: boolean;
+}
+
+// ── Validation Result ────────────────────────────────────────
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+// ── Contract Definitions ─────────────────────────────────────
+
+const BACKLOG_TO_PLANNING: StageContract = {
+  transition: 'backlog->planning',
+  requiredInputs: [
+    {
+      field: 'title',
+      validation: 'non-empty',
+      message: 'Card must have a title before starting planning',
+    },
+    {
+      field: 'description',
+      validation: 'non-empty',
+      message: 'Card must have a description (at least a sentence explaining the intent)',
+    },
+    {
+      field: 'acceptance',
+      validation: 'min-items',
+      minItems: 1,
+      message: 'Card must have at least 1 acceptance criterion',
+    },
+  ],
+  expectedOutputs: [
+    { field: 'plan', description: 'Prose implementation approach' },
+    { field: 'subtasks', description: 'Decomposed work items with dependency graph' },
+  ],
+  qualityGates: [],
+};
+
+const PLANNING_TO_IN_PROGRESS: StageContract = {
+  transition: 'planning->in-progress',
+  requiredInputs: [
+    {
+      field: 'plan',
+      validation: 'non-empty',
+      message: 'Card must have a plan before starting implementation',
+    },
+    {
+      field: 'subtasks',
+      validation: 'min-items',
+      minItems: 1,
+      message: 'Card must have at least 1 subtask',
+    },
+    {
+      field: 'status',
+      validation: 'custom',
+      customFn: 'isWaitingInput',
+      message: 'Card must be awaiting approval (status: waiting-input)',
+    },
+  ],
+  expectedOutputs: [
+    { field: 'subtasks', description: 'All subtasks completed' },
+    { field: 'worktreePath', description: 'Code changes committed in worktree' },
+  ],
+  qualityGates: [],
+};
+
+const IN_PROGRESS_TO_REVIEW: StageContract = {
+  transition: 'in-progress->review',
+  requiredInputs: [
+    {
+      field: 'subtasks',
+      validation: 'custom',
+      customFn: 'allSubtasksCompleted',
+      message: 'All subtasks must be completed before review',
+    },
+    {
+      field: 'worktreePath',
+      validation: 'non-empty',
+      message: 'Card must have a worktree with changes',
+    },
+  ],
+  expectedOutputs: [
+    { field: 'prUrl', description: 'Pull request URL' },
+    { field: 'prNumber', description: 'Pull request number' },
+  ],
+  qualityGates: [
+    {
+      name: 'reviewer-approval',
+      type: 'agent-review',
+      agent: 'reviewer',
+      blocking: true,
+    },
+  ],
+};
+
+const REVIEW_TO_DONE: StageContract = {
+  transition: 'review->done',
+  requiredInputs: [
+    {
+      field: 'status',
+      validation: 'custom',
+      customFn: 'isWaitingInput',
+      message: 'Card must be awaiting human confirmation (status: waiting-input)',
+    },
+  ],
+  expectedOutputs: [
+    { field: 'completedAt', description: 'Completion timestamp' },
+  ],
+  qualityGates: [],
+};
+
+// ── Contract Registry ────────────────────────────────────────
+
+const CONTRACTS: Record<string, StageContract> = {
+  'backlog->planning': BACKLOG_TO_PLANNING,
+  'planning->in-progress': PLANNING_TO_IN_PROGRESS,
+  'in-progress->review': IN_PROGRESS_TO_REVIEW,
+  'review->done': REVIEW_TO_DONE,
+};
+
+export function getContract(from: Column, to: Column): StageContract | null {
+  return CONTRACTS[`${from}->${to}`] ?? null;
+}
+
+// ── Custom Validators ────────────────────────────────────────
+
+const CUSTOM_VALIDATORS: Record<string, (card: Card) => boolean> = {
+  isWaitingInput: (card) => card.status === 'waiting-input',
+  allSubtasksCompleted: (card) =>
+    card.subtasks.length > 0 && card.subtasks.every((s) => s.status === 'completed'),
+};
+
+// ── Validation ───────────────────────────────────────────────
+
+/**
+ * Validate whether a card meets the requirements to transition to `targetColumn`.
+ *
+ * Also checks card-to-card dependencies (blockedBy) when moving to planning.
+ */
+export function validateTransition(
+  card: Card,
+  targetColumn: Column,
+  state?: KanbanState,
+): ValidationResult {
+  const errors: string[] = [];
+
+  // Determine the transition key
+  const contract = getContract(card.column, targetColumn);
+
+  // No contract means the transition is always allowed (e.g. manual moves)
+  if (!contract) return { valid: true, errors: [] };
+
+  // Check required inputs
+  for (const req of contract.requiredInputs) {
+    if (!validateInput(card, req)) {
+      errors.push(req.message);
+    }
+  }
+
+  // Check card-to-card dependencies when starting planning
+  if (targetColumn === 'planning' && card.blockedBy && card.blockedBy.length > 0 && state) {
+    const unmetDeps = getUnmetDependencies(card, state);
+    if (unmetDeps.length > 0) {
+      errors.push(
+        `Blocked by card(s) not yet done: ${unmetDeps.map((id) => `#${id}`).join(', ')}`,
+      );
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+function validateInput(card: Card, req: RequiredInput): boolean {
+  const value = card[req.field];
+
+  switch (req.validation) {
+    case 'non-empty':
+      if (typeof value === 'string') return value.trim().length > 0;
+      if (Array.isArray(value)) return value.length > 0;
+      return value != null;
+
+    case 'min-items':
+      return Array.isArray(value) && value.length >= (req.minItems ?? 1);
+
+    case 'custom':
+      if (req.customFn && CUSTOM_VALIDATORS[req.customFn]) {
+        return CUSTOM_VALIDATORS[req.customFn](card);
+      }
+      return true;
+
+    default:
+      return true;
+  }
+}
+
+// ── Dependency Helpers ───────────────────────────────────────
+
+/**
+ * Returns IDs of cards in the blockedBy list that are NOT in the 'done' column.
+ */
+export function getUnmetDependencies(card: Card, state: KanbanState): string[] {
+  if (!card.blockedBy || card.blockedBy.length === 0) return [];
+
+  return card.blockedBy.filter((depId) => {
+    const depCard = state.cards.find((c) => c.id === depId);
+    // If the blocking card doesn't exist, treat as unmet (safety)
+    return !depCard || depCard.column !== 'done';
+  });
+}
+
+/**
+ * Find cards that were blocked by the given card and are now unblocked
+ * (all their blockedBy dependencies are in 'done').
+ */
+export function getNewlyUnblockedCards(
+  completedCardId: string,
+  state: KanbanState,
+): Card[] {
+  return state.cards.filter((c) => {
+    if (!c.blockedBy?.includes(completedCardId)) return false;
+    if (c.column !== 'backlog') return false;
+    return getUnmetDependencies(c, state).length === 0;
+  });
+}
+
+/**
+ * Find ALL backlog cards that are ready to start (all dependencies met).
+ * Used by YOLO mode to sweep the entire backlog after any card completes.
+ */
+export function getAllReadyBacklogCards(state: KanbanState): Card[] {
+  return state.cards.filter((c) => {
+    if (c.column !== 'backlog') return false;
+    if (c.status !== 'idle') return false;
+    return getUnmetDependencies(c, state).length === 0;
+  });
+}

--- a/apps/desktop/electron/kanban/contracts.ts
+++ b/apps/desktop/electron/kanban/contracts.ts
@@ -2,12 +2,39 @@
  * Stage contracts — defines input requirements, expected outputs, and quality
  * gates for each kanban column transition.
  *
- * The orchestrator and extension call `validateTransition()` before allowing
- * a card to move between columns. Contracts are pure application logic —
- * they do NOT reference prompt templates or agent system prompts.
+ * Validation logic is NOT duplicated here — it lives in the shared module:
+ *   packages/pi-kanban-extension/shared/validation.ts
+ * This file re-exports `validateTransition` from there and adds
+ * orchestrator-specific helpers (unblocked card scanning, contract metadata).
  */
 
 import type { Card, Column, KanbanState } from './types';
+
+// ── Single source of truth for validation ────────────────────
+// Uses structural typing — host Card and shared Card have identical shapes.
+
+import {
+  validateCardTransition,
+  getUnmetDependencies as _getUnmetDeps,
+} from '../../../../packages/pi-kanban-extension/shared/validation';
+import type { ValidationResult } from '../../../../packages/pi-kanban-extension/shared/validation';
+
+export type { ValidationResult };
+
+/**
+ * Validate whether a card meets the requirements to transition to `targetColumn`.
+ * Delegates to the shared validation module (single source of truth).
+ */
+export const validateTransition: (
+  card: Card, targetColumn: Column, state?: KanbanState,
+) => ValidationResult = validateCardTransition;
+
+/**
+ * Returns IDs of cards in the blockedBy list that are NOT in the 'done' column.
+ */
+export const getUnmetDependencies: (
+  card: Card, state?: KanbanState,
+) => string[] = _getUnmetDeps;
 
 // ── Contract Types ───────────────────────────────────────────
 
@@ -52,13 +79,6 @@ export interface QualityGate {
   field?: string;
   /** Whether failure blocks advancement or is advisory */
   blocking: boolean;
-}
-
-// ── Validation Result ────────────────────────────────────────
-
-export interface ValidationResult {
-  valid: boolean;
-  errors: string[];
 }
 
 // ── Contract Definitions ─────────────────────────────────────
@@ -176,91 +196,7 @@ export function getContract(from: Column, to: Column): StageContract | null {
   return CONTRACTS[`${from}->${to}`] ?? null;
 }
 
-// ── Custom Validators ────────────────────────────────────────
-
-const CUSTOM_VALIDATORS: Record<string, (card: Card) => boolean> = {
-  isWaitingInput: (card) => card.status === 'waiting-input',
-  allSubtasksCompleted: (card) =>
-    card.subtasks.length > 0 && card.subtasks.every((s) => s.status === 'completed'),
-};
-
-// ── Validation ───────────────────────────────────────────────
-
-/**
- * Validate whether a card meets the requirements to transition to `targetColumn`.
- *
- * Also checks card-to-card dependencies (blockedBy) when moving to planning.
- */
-export function validateTransition(
-  card: Card,
-  targetColumn: Column,
-  state?: KanbanState,
-): ValidationResult {
-  const errors: string[] = [];
-
-  // Determine the transition key
-  const contract = getContract(card.column, targetColumn);
-
-  // No contract means the transition is always allowed (e.g. manual moves)
-  if (!contract) return { valid: true, errors: [] };
-
-  // Check required inputs
-  for (const req of contract.requiredInputs) {
-    if (!validateInput(card, req)) {
-      errors.push(req.message);
-    }
-  }
-
-  // Check card-to-card dependencies when starting planning
-  if (targetColumn === 'planning' && card.blockedBy && card.blockedBy.length > 0 && state) {
-    const unmetDeps = getUnmetDependencies(card, state);
-    if (unmetDeps.length > 0) {
-      errors.push(
-        `Blocked by card(s) not yet done: ${unmetDeps.map((id) => `#${id}`).join(', ')}`,
-      );
-    }
-  }
-
-  return { valid: errors.length === 0, errors };
-}
-
-function validateInput(card: Card, req: RequiredInput): boolean {
-  const value = card[req.field];
-
-  switch (req.validation) {
-    case 'non-empty':
-      if (typeof value === 'string') return value.trim().length > 0;
-      if (Array.isArray(value)) return value.length > 0;
-      return value != null;
-
-    case 'min-items':
-      return Array.isArray(value) && value.length >= (req.minItems ?? 1);
-
-    case 'custom':
-      if (req.customFn && CUSTOM_VALIDATORS[req.customFn]) {
-        return CUSTOM_VALIDATORS[req.customFn](card);
-      }
-      return true;
-
-    default:
-      return true;
-  }
-}
-
-// ── Dependency Helpers ───────────────────────────────────────
-
-/**
- * Returns IDs of cards in the blockedBy list that are NOT in the 'done' column.
- */
-export function getUnmetDependencies(card: Card, state: KanbanState): string[] {
-  if (!card.blockedBy || card.blockedBy.length === 0) return [];
-
-  return card.blockedBy.filter((depId) => {
-    const depCard = state.cards.find((c) => c.id === depId);
-    // If the blocking card doesn't exist, treat as unmet (safety)
-    return !depCard || depCard.column !== 'done';
-  });
-}
+// ── Orchestrator-only Helpers ────────────────────────────────
 
 /**
  * Find cards that were blocked by the given card and are now unblocked

--- a/apps/desktop/electron/kanban/index.ts
+++ b/apps/desktop/electron/kanban/index.ts
@@ -7,6 +7,20 @@ export { WorktreeManager, ensureGitReady } from './worktree-manager';
 export { resolveExecutionWaves } from './wave-resolver';
 export { updateCard, readCard } from './state-helpers';
 export {
+  validateTransition,
+  getContract,
+  getUnmetDependencies,
+  getNewlyUnblockedCards,
+  getAllReadyBacklogCards,
+} from './contracts';
+export type { StageContract, QualityGate, ValidationResult } from './contracts';
+export {
+  detectVerificationCommands,
+  detectPackageManager,
+  runVerificationCommands,
+} from './verification';
+export type { VerificationResult, CommandResult } from './verification';
+export {
   createCheckpointInWorktree,
   getWorktreeDiff,
   getWorktreeDiffSummary,

--- a/apps/desktop/electron/kanban/orchestrator.ts
+++ b/apps/desktop/electron/kanban/orchestrator.ts
@@ -1,16 +1,6 @@
-/**
- * KanbanOrchestrator — state machine that reacts to card column transitions.
- *
- * Watches the kanban state file for column changes and triggers:
- * - Planning phase (backlog → planning): analyse codebase, generate subtasks
- * - Implementation phase (planning → in-progress): execute subtasks in worktree
- * - Review phase (in-progress → review): review diff, push, create PR
- *
- * Runs in the Electron main process, operates on the state file directly.
- */
+/** KanbanOrchestrator — reacts to card column transitions, triggers automated phases. */
 
 import path from 'path';
-
 import type { KanbanState, Card, Column } from './types';
 import { WorktreeManager } from './worktree-manager';
 import { PlanningProgressTracker } from './planning-progress';
@@ -21,6 +11,7 @@ import { executePlanning } from './planning-executor';
 import { resolveExecutionWaves } from './wave-resolver';
 import { executeWaves } from './subtask-executor';
 import { updateCard, readCard } from './state-helpers';
+import { validateTransition, getNewlyUnblockedCards, getAllReadyBacklogCards } from './contracts';
 import { appStateManager } from '../app-state';
 import type { SubagentManager } from '../subagent/index';
 
@@ -56,19 +47,9 @@ export class KanbanOrchestrator {
   private implementationInProgress = new Set<string>();
   private reviewInProgress = new Set<string>();
 
-  setDeps(deps: OrchestratorDeps): void {
-    this.deps = deps;
-    console.log('[kanban-orchestrator] Dependencies injected');
-  }
+  setDeps(deps: OrchestratorDeps): void { this.deps = deps; }
 
-  // ── Startup Recovery ────────────────────────────────────
-
-  /**
-   * Scan all kanban state files for cards stuck in `agent-working` status
-   * after an app restart. Re-triggers the appropriate phase for each.
-   *
-   * Must be called after setDeps() and after workspaces are loaded.
-   */
+  /** Scan for cards stuck in `agent-working` after restart and re-trigger their phase. */
   async recoverStuckCards(workspaces: Array<{ id: string; path: string }>): Promise<void> {
     if (!this.deps) return;
 
@@ -107,8 +88,6 @@ export class KanbanOrchestrator {
     }
   }
 
-  // ── Workspace Watching ──────────────────────────────────
-
   async watchWorkspace(workspaceId: string, workspacePath: string): Promise<void> {
     const stateFilePath = path.join(workspacePath, '.sero', 'apps', 'kanban', 'state.json');
     const initial = await appStateManager.read(stateFilePath) as KanbanState | null;
@@ -130,8 +109,6 @@ export class KanbanOrchestrator {
       this.watched.delete(workspaceId);
     }
   }
-
-  // ── State Change Handler ────────────────────────────────
 
   async onStateChange(stateFilePath: string, newState: KanbanState): Promise<void> {
     if (!this.deps) return;
@@ -188,14 +165,11 @@ export class KanbanOrchestrator {
     const ws = this.deps.findWorkspaceByPath(workspacePath);
     if (!ws) return null;
 
-    console.log(`[kanban-orchestrator] Auto-watching workspace "${ws.id}"`);
-    const emptyBaseline = new Map<string, Column>();
-    this.watched.set(ws.id, { workspaceId: ws.id, stateFilePath, lastColumnMap: emptyBaseline });
+    console.log(`[kanban-orchestrator] Auto-watching "${ws.id}"`);
+    this.watched.set(ws.id, { workspaceId: ws.id, stateFilePath, lastColumnMap: new Map() });
     appStateManager.watch(stateFilePath);
     return this.watched.get(ws.id) ?? null;
   }
-
-  // ── Transition Router ─────────────────────────────────
 
   private async handleTransition(
     workspace: WatchedWorkspace,
@@ -219,14 +193,27 @@ export class KanbanOrchestrator {
     }
   }
 
-  // ── Planning Phase ────────────────────────────────────
-
   private async runPlanningPhase(workspace: WatchedWorkspace, card: Card): Promise<void> {
     if (!this.deps || this.planningInProgress.has(card.id)) return;
     this.planningInProgress.add(card.id);
 
     const workspacePath = this.deps.getWorkspacePath(workspace.workspaceId);
     if (!workspacePath) { this.planningInProgress.delete(card.id); return; }
+
+    // Validate stage contract (card-to-card deps, required fields)
+    const currentState = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
+    if (currentState) {
+      const validation = validateTransition(card, 'planning', currentState);
+      if (!validation.valid) {
+        await updateCard(workspace.stateFilePath, card.id, {
+          status: 'failed',
+          column: 'backlog',
+          error: `Cannot start planning: ${validation.errors.join('; ')}`,
+        });
+        this.planningInProgress.delete(card.id);
+        return;
+      }
+    }
 
     const tracker = new PlanningProgressTracker(
       workspace.stateFilePath, card.id,
@@ -244,13 +231,22 @@ export class KanbanOrchestrator {
       const planResult = await this.runPlanningAgents(workspace, card, tracker, greenfield);
 
       await tracker.clear();
-      await updateCard(workspace.stateFilePath, card.id, {
-        status: 'waiting-input',
-        plan: planResult.plan,
-        subtasks: planResult.subtasks,
-        planningProgress: undefined,
-      });
-      console.log(`[kanban-orchestrator] Card #${card.id} planning complete — waiting for approval`);
+
+      const yolo = await this.isYoloMode(workspace.stateFilePath);
+      const planUpdate = { plan: planResult.plan, subtasks: planResult.subtasks, planningProgress: undefined };
+
+      if (yolo) {
+        await updateCard(workspace.stateFilePath, card.id, { ...planUpdate, status: 'idle', column: 'in-progress' });
+        console.log(`[kanban-orchestrator] Card #${card.id} planning complete — YOLO auto-approved`);
+        const approved = await readCard(workspace.stateFilePath, card.id);
+        if (approved) {
+          workspace.lastColumnMap.set(card.id, 'in-progress');
+          await this.handleTransition(workspace, approved, 'planning', 'in-progress');
+        }
+      } else {
+        await updateCard(workspace.stateFilePath, card.id, { ...planUpdate, status: 'waiting-input' });
+        console.log(`[kanban-orchestrator] Card #${card.id} planning complete — waiting for approval`);
+      }
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       console.error(`[kanban-orchestrator] Planning failed for card #${card.id}:`, errMsg);
@@ -269,15 +265,17 @@ export class KanbanOrchestrator {
     tracker: PlanningProgressTracker,
     greenfield = false,
   ): Promise<{ plan: string; subtasks: Card['subtasks'] }> {
+    // Read settings for testingEnabled propagation
+    const stateForSettings = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
+    const planOptions = { testingEnabled: stateForSettings?.settings?.testingEnabled };
+
     return executePlanning(
-      { subagentManager: this.deps!.subagentManager, workspaceId: workspace.workspaceId },
+      { subagentManager: this.deps!.subagentManager, workspaceId: workspace.workspaceId, planOptions },
       card,
       tracker,
       greenfield,
     );
   }
-
-  // ── Implementation Phase ──────────────────────────────
 
   private async runImplementationPhase(workspace: WatchedWorkspace, card: Card): Promise<void> {
     if (!this.deps || this.implementationInProgress.has(card.id)) return;
@@ -316,8 +314,12 @@ export class KanbanOrchestrator {
       const waves = resolveExecutionWaves(subtasks);
       console.log(`[kanban-orchestrator] Card #${card.id}: ${waves.length} waves, ${subtasks.length} subtasks`);
 
+      // Read settings for testing/review config
+      const stateForSettings = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
+      const settings = stateForSettings?.settings;
+
       await executeWaves(
-        { subagentManager: this.deps.subagentManager, workspaceId: workspace.workspaceId },
+        { subagentManager: this.deps.subagentManager, workspaceId: workspace.workspaceId, settings },
         workspace.stateFilePath,
         freshCard,
         worktreePath,
@@ -332,11 +334,8 @@ export class KanbanOrchestrator {
         column: 'review',
         implementationProgress: undefined,
       });
-      console.log(`[kanban-orchestrator] Card #${card.id} implementation complete → Review`);
-
-      // Directly chain to review phase. The updateCard above writes via
-      // appStateManager.write() which bypasses IPC, so onStateChange is
-      // never called. We must trigger the next phase explicitly.
+      console.log(`[kanban-orchestrator] Card #${card.id} impl complete → Review`);
+      // Chain to review — updateCard bypasses IPC so we must trigger explicitly
       const reviewCard = await readCard(workspace.stateFilePath, card.id);
       if (reviewCard) {
         workspace.lastColumnMap.set(card.id, 'review');
@@ -355,8 +354,6 @@ export class KanbanOrchestrator {
       this.implementationInProgress.delete(card.id);
     }
   }
-
-  // ── Review Phase ───────────────────────────────────────
 
   private async runReviewPhase(workspace: WatchedWorkspace, card: Card): Promise<void> {
     if (!this.deps || this.reviewInProgress.has(card.id)) return;
@@ -388,8 +385,9 @@ export class KanbanOrchestrator {
       console.log(`[kanban-orchestrator] Starting review for card #${card.id}`);
       await updateCard(workspace.stateFilePath, card.id, { status: 'agent-working' });
 
+      const reviewState = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
       const result = await executeReview(
-        { subagentManager: this.deps.subagentManager, workspaceId: workspace.workspaceId },
+        { subagentManager: this.deps.subagentManager, workspaceId: workspace.workspaceId, settings: reviewState?.settings },
         freshCard,
         worktreePath,
         branchName,
@@ -399,14 +397,18 @@ export class KanbanOrchestrator {
       await tracker.clear();
 
       if (result.success) {
-        await updateCard(workspace.stateFilePath, card.id, {
-          status: 'waiting-input',
-          prUrl: result.prUrl,
-          prNumber: result.prNumber,
-          reviewFilePath: result.reviewFilePath,
-          reviewProgress: undefined,
-        });
-        console.log(`[kanban-orchestrator] Card #${card.id} PR created: ${result.prUrl}`);
+        const yolo = await this.isYoloMode(workspace.stateFilePath);
+        const prUpdate = { prUrl: result.prUrl, prNumber: result.prNumber, reviewFilePath: result.reviewFilePath, reviewProgress: undefined };
+
+        if (yolo) {
+          await updateCard(workspace.stateFilePath, card.id, { ...prUpdate, status: 'idle', column: 'done', completedAt: new Date().toISOString() });
+          console.log(`[kanban-orchestrator] Card #${card.id} YOLO auto-completed: ${result.prUrl}`);
+          workspace.lastColumnMap.set(card.id, 'done');
+          await this.runDoneCleanup(workspace, card);
+        } else {
+          await updateCard(workspace.stateFilePath, card.id, { ...prUpdate, status: 'waiting-input' });
+          console.log(`[kanban-orchestrator] Card #${card.id} PR created: ${result.prUrl}`);
+        }
       } else {
         await updateCard(workspace.stateFilePath, card.id, {
           status: 'failed',
@@ -430,39 +432,49 @@ export class KanbanOrchestrator {
     }
   }
 
-  // ── Done Cleanup ──────────────────────────────────────
-
   private async runDoneCleanup(workspace: WatchedWorkspace, card: Card): Promise<void> {
     const workspacePath = this.deps?.getWorkspacePath(workspace.workspaceId);
     if (!workspacePath) return;
 
-    // Re-read card for latest worktree info
     const currentState = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
-    const freshCard = currentState?.cards.find((c) => c.id === card.id);
-    if (!freshCard) return;
+    if (!currentState) return;
 
-    try {
-      // Remove worktree if it exists
-      if (freshCard.worktreePath) {
-        await this.worktreeManager.remove(workspacePath, card.id, { deleteBranch: false });
-        console.log(`[kanban-orchestrator] Cleaned up worktree for card #${card.id}`);
-      }
+    // Mark card done — keep worktree alive until user confirms cleanup
+    await updateCard(workspace.stateFilePath, card.id, {
+      status: 'idle',
+      completedAt: new Date().toISOString(),
+      reviewProgress: undefined,
+      implementationProgress: undefined,
+      planningProgress: undefined,
+    });
 
-      await updateCard(workspace.stateFilePath, card.id, {
-        status: 'idle',
-        worktreePath: undefined,
-        completedAt: new Date().toISOString(),
-        reviewProgress: undefined,
-        implementationProgress: undefined,
-        planningProgress: undefined,
-      });
-    } catch (err) {
-      console.warn(`[kanban-orchestrator] Worktree cleanup failed for card #${card.id}:`, err);
+    // Check if ALL cards are now done — if so, notify user to clean up worktrees
+    const freshState = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
+    if (!freshState) return;
+    const allDone = freshState.cards.length > 0 && freshState.cards.every((c) => c.column === 'done');
+    if (allDone) {
+      console.log('[kanban-orchestrator] All cards done — worktrees preserved, awaiting user cleanup');
+    }
+
+    // YOLO: sweep ALL ready backlog cards. Normal: only cards blocked by this specific card.
+    const toStart = freshState.settings.yoloMode
+      ? getAllReadyBacklogCards(freshState)
+      : freshState.settings.autoAdvance
+        ? getNewlyUnblockedCards(card.id, freshState)
+        : [];
+
+    for (const ready of toStart) {
+      if (this.isCurrentlyProcessing(ready.id)) continue;
+      console.log(`[kanban-orchestrator] Auto-starting card #${ready.id} "${ready.title}"`);
+      await updateCard(workspace.stateFilePath, ready.id, { column: 'planning', status: 'agent-working' });
+      workspace.lastColumnMap.set(ready.id, 'planning');
+      await this.handleTransition(workspace, ready, 'backlog', 'planning');
     }
   }
 
-  // ── Retry Helpers ──────────────────────────────────────
-
+  private async isYoloMode(p: string): Promise<boolean> {
+    return ((await appStateManager.read(p) as KanbanState | null)?.settings?.yoloMode) === true;
+  }
   private isCurrentlyProcessing(cardId: string): boolean {
     return (
       this.planningInProgress.has(cardId)
@@ -470,8 +482,6 @@ export class KanbanOrchestrator {
       || this.reviewInProgress.has(cardId)
     );
   }
-
-  // ── Cleanup ───────────────────────────────────────────
 
   dispose(): void {
     for (const [workspaceId] of this.watched) {

--- a/apps/desktop/electron/kanban/planning-executor.ts
+++ b/apps/desktop/electron/kanban/planning-executor.ts
@@ -15,14 +15,15 @@ import type { PlanningProgressTracker } from './planning-progress';
 import {
   buildPlanningPrompt,
   buildSubtaskGenerationPrompt,
-  PLANNER_SYSTEM_PROMPT,
   parsePlanResult,
 } from './prompts';
+import type { PlanGenerationOptions } from './prompts';
 import type { SubagentManager } from '../subagent/index';
 
 export interface PlanningExecutorDeps {
   subagentManager: SubagentManager;
   workspaceId: string;
+  planOptions?: PlanGenerationOptions;
 }
 
 /**
@@ -60,10 +61,10 @@ export async function executePlanning(
     await tracker.flush();
   }
 
-  // Plan generation (same for both modes — prompt includes greenfield context)
+  // Plan generation — uses the planner agent template (packages/templates/agents/planner.md)
   const planResult = await subagentManager.runSingle({
-    task: buildSubtaskGenerationPrompt(card, reconResult),
-    systemPrompt: PLANNER_SYSTEM_PROMPT,
+    agent: 'planner',
+    task: buildSubtaskGenerationPrompt(card, reconResult, deps.planOptions),
     parentSessionId,
     workspaceId,
     isolated: true,
@@ -73,7 +74,11 @@ export async function executePlanning(
   tracker.completeAgent('planner');
   await tracker.flush();
 
-  return parsePlanResult(planResult);
+  const parsed = parsePlanResult(planResult);
+  if (parsed.warnings.length > 0) {
+    console.warn(`[planning-executor] Plan warnings: ${parsed.warnings.join('; ')}`);
+  }
+  return { plan: parsed.plan, subtasks: parsed.subtasks };
 }
 
 // ── Reconnaissance (existing projects only) ──────────────────

--- a/apps/desktop/electron/kanban/prompts.ts
+++ b/apps/desktop/electron/kanban/prompts.ts
@@ -9,13 +9,6 @@
 
 import type { Card } from './types';
 
-// ── Workspace Isolation ──────────────────────────────────────
-
-const WORKSPACE_SCOPE_DIRECTIVE = `
-IMPORTANT: You are scoped to THIS workspace only. Do NOT access, read, write,
-or reference files outside the current working directory. Never use absolute
-paths to other workspaces or home directories.`.trim();
-
 // ── Planning Prompts ─────────────────────────────────────────
 
 export function buildPlanningPrompt(card: Card): string {
@@ -37,7 +30,24 @@ export function buildPlanningPrompt(card: Card): string {
   return prompt;
 }
 
-export function buildSubtaskGenerationPrompt(card: Card, analysisResults: string): string {
+export interface PlanGenerationOptions {
+  testingEnabled?: boolean;
+}
+
+export function buildSubtaskGenerationPrompt(
+  card: Card,
+  analysisResults: string,
+  options?: PlanGenerationOptions,
+): string {
+  const testingEnabled = options?.testingEnabled !== false;
+  const tddBlock = testingEnabled
+    ? `- Designate each subtask's testing approach:
+  - "tdd": Write tests first, then implement (for core logic, utilities, data transformations)
+  - "test-after": Implement first, then write tests (for integration, UI wiring)
+  - "no-test": No tests needed (for config, scaffolding, documentation)
+- Include a dedicated test-writing subtask when the feature has testable logic`
+    : `- Set tddDesignation to "no-test" for all subtasks (testing is disabled for this workspace)`;
+
   return `Based on the following codebase analysis, create a detailed implementation plan with subtasks for this card:
 
 # Card: ${card.title}
@@ -58,42 +68,59 @@ Generate a structured implementation plan. Output ONLY a JSON object with this e
       "id": "1",
       "title": "Short title for this subtask",
       "description": "What this subtask involves",
-      "dependsOn": []
+      "dependsOn": [],
+      "tddDesignation": "tdd | test-after | no-test",
+      "filePaths": ["src/path/to/file.ts"],
+      "complexity": "low | medium | high"
     }
   ]
 }
 \`\`\`
 
 Rules for subtasks:
-- 2-8 subtasks is ideal
+- 2-8 subtasks is ideal, each scoped to 15-30 minutes of agent work
 - Each subtask should be independently implementable where possible
 - Use dependsOn to specify ordering constraints (array of subtask IDs)
 - Parallelisable subtasks should have empty dependsOn arrays
-- Include a final "write tests" subtask if applicable
+- List exact file paths each subtask creates or modifies (for parallel conflict detection)
+- Estimate complexity: low (~15min), medium (~30min), high (~45min+)
+${tddBlock}
 - Keep descriptions concise but specific`;
 }
 
-export const PLANNER_SYSTEM_PROMPT = `You are a senior software architect specialising in breaking down development tasks into implementable subtasks.
-
-You analyse codebase context and produce structured implementation plans with:
-- Clear subtask breakdown with dependencies
-- Non-overlapping file scopes per subtask (for parallel execution)
-- Realistic scope estimates
-
-Always output valid JSON matching the requested schema. No markdown outside the JSON block.
-
-${WORKSPACE_SCOPE_DIRECTIVE}`;
-
 // ── Implementation Prompts ───────────────────────────────────
 
-export function buildSubtaskPrompt(card: Card, subtaskId: string): string {
+export interface SubtaskPromptOptions {
+  testingEnabled?: boolean;
+}
+
+export function buildSubtaskPrompt(
+  card: Card,
+  subtaskId: string,
+  options?: SubtaskPromptOptions,
+): string {
   const subtask = card.subtasks.find((s) => s.id === subtaskId);
   if (!subtask) throw new Error(`Subtask ${subtaskId} not found on card #${card.id}`);
 
+  const testingEnabled = options?.testingEnabled !== false;
+
   const completedSubtasks = card.subtasks
     .filter((s) => s.status === 'completed')
-    .map((s) => `- ✅ ${s.title}: ${s.description}`)
+    .map((s) => {
+      const files = s.filePaths?.length ? ` (files: ${s.filePaths.join(', ')})` : '';
+      return `- ✅ ${s.title}: ${s.description}${files}`;
+    })
     .join('\n');
+
+  const tddBlock = testingEnabled && subtask.tddDesignation && subtask.tddDesignation !== 'no-test'
+    ? `\n## Testing Approach: ${subtask.tddDesignation}\n${subtask.tddDesignation === 'tdd'
+      ? 'Write a failing test first, then implement to make it pass.'
+      : 'Implement first, then write tests covering the core logic.'}\n`
+    : testingEnabled ? '' : '\nNote: Testing is disabled for this workspace — do not write tests.\n';
+
+  const filePathsBlock = subtask.filePaths?.length
+    ? `\nExpected file paths: ${subtask.filePaths.join(', ')}\n`
+    : '';
 
   return `You are implementing a specific subtask as part of a larger feature.
 
@@ -105,7 +132,7 @@ ${card.plan ?? '(no plan provided)'}
 ## Your Subtask
 **${subtask.title}**
 ${subtask.description}
-
+${filePathsBlock}${tddBlock}
 ${completedSubtasks ? `## Already Completed\n${completedSubtasks}\n` : ''}
 ## Instructions
 - Focus ONLY on this subtask — do not implement other subtasks
@@ -117,37 +144,29 @@ ${completedSubtasks ? `## Already Completed\n${completedSubtasks}\n` : ''}
 
 // ── Review Prompts ───────────────────────────────────────────
 
-export const REVIEWER_SYSTEM_PROMPT = `You are a senior code reviewer. You review diffs thoroughly and produce a structured review with a PR title and description.
-
-${WORKSPACE_SCOPE_DIRECTIVE}
-
-Your review covers:
-1. Code quality and correctness
-2. Adherence to existing patterns and conventions
-3. Potential bugs or edge cases
-4. Test coverage gaps
-5. Performance concerns
-
-Output ONLY valid JSON with this exact shape:
-\`\`\`json
-{
-  "approved": true,
-  "summary": "Brief overall assessment",
-  "issues": ["Issue 1 description", "Issue 2 description"],
-  "prTitle": "conventional-commit style PR title (max 72 chars)",
-  "prBody": "Markdown PR description with Summary, Changes, and Testing sections"
-}
-\`\`\`
-
-If the code is acceptable, set approved to true with an empty issues array.
-If there are blocking issues, set approved to false.`;
-
 const DIFF_PATCH_LIMIT = 32_000;
 
-export function buildReviewPrompt(card: Card, diff: string, fileSummary: string): string {
+export interface ReviewPromptOptions {
+  testingEnabled?: boolean;
+}
+
+export function buildReviewPrompt(
+  card: Card,
+  diff: string,
+  fileSummary: string,
+  options?: ReviewPromptOptions,
+): string {
   const patch = diff.length > DIFF_PATCH_LIMIT
     ? `${diff.slice(0, DIFF_PATCH_LIMIT)}\n\n...[patch truncated at ${DIFF_PATCH_LIMIT} chars]`
     : diff;
+
+  const testNote = options?.testingEnabled === false
+    ? '\nNote: Testing is disabled for this workspace — do not flag missing test coverage.\n'
+    : '';
+
+  const subtaskSummary = card.subtasks.length > 0
+    ? `\n## Subtask Summary\n${card.subtasks.map((s) => `- ${s.title} (${s.status})`).join('\n')}\n`
+    : '';
 
   return `Review the following implementation for this card:
 
@@ -155,69 +174,120 @@ export function buildReviewPrompt(card: Card, diff: string, fileSummary: string)
 ${card.description ? `\nDescription: ${card.description}` : ''}
 ${card.acceptance.length > 0 ? `\nAcceptance Criteria:\n${card.acceptance.map((a) => `- ${a}`).join('\n')}` : ''}
 ${card.plan ? `\nImplementation Plan:\n${card.plan}` : ''}
-
+${subtaskSummary}
 # Changed Files
 ${fileSummary || '(no files changed)'}
 
 # Diff
 ${patch || '(no diff available)'}
+${testNote}
+Categorise each issue as Critical (blocks merge), Important (should fix but doesn't block), or Minor (nice-to-have).
+Provide an explicit verdict: "merge" (ready), "fix-first" (has critical issues), or "reject" (fundamentally wrong approach).
 
-Review the code and generate a PR title and description. Output valid JSON as specified.`;
+PR FORMAT — this is a FEATURE PR, not a review report:
+- prTitle: "feat: <what was built>" (e.g. "feat: core snake game with canvas rendering and input handling")
+- prBody sections: ## Summary (what this delivers to the user), ## Changes (per subtask, what was implemented), ## Review Notes (any issues found), ## Manual Testing (what the user should verify — especially interactive/real-time features that can't be tested via automation)
+
+Do NOT use browser automation to test interactive/real-time features (games, animations, etc.) — it is too slow. Note them for manual testing instead.
+
+Output valid JSON as specified in your instructions.`;
+}
+
+export interface ReviewIssue {
+  description: string;
+  severity: 'critical' | 'important' | 'minor';
+  file?: string;
+  line?: number;
+  suggestion?: string;
 }
 
 export interface ReviewResult {
   approved: boolean;
   summary: string;
+  /** Legacy flat issues list (backward compat) */
   issues: string[];
+  /** Structured issue categories */
+  categorizedIssues?: ReviewIssue[];
+  /** Explicit verdict: 'merge' | 'fix-first' | 'reject' */
+  verdict?: 'merge' | 'fix-first' | 'reject';
   prTitle: string;
   prBody: string;
 }
 
-export function parseReviewResult(raw: string): ReviewResult {
+export function parseReviewResult(raw: string, cardTitle?: string): ReviewResult {
   const jsonMatch = raw.match(/```json\s*([\s\S]*?)```/)
     || raw.match(/\{[\s\S]*"prTitle"[\s\S]*"prBody"[\s\S]*\}/);
 
-  const fallback: ReviewResult = {
+  const fallbackTitle = cardTitle
+    ? `feat: ${cardTitle.toLowerCase().slice(0, 65)}`
+    : 'feat: implementation';
+
+  const fb: ReviewResult = {
     approved: true,
     summary: raw.slice(0, 500),
     issues: [],
-    prTitle: 'chore: update from kanban card',
+    prTitle: fallbackTitle,
     prBody: raw.slice(0, 2000),
   };
 
-  if (!jsonMatch) return fallback;
+  if (!jsonMatch) return fb;
 
   try {
     const jsonStr = jsonMatch[1] || jsonMatch[0];
     const parsed = JSON.parse(jsonStr);
 
+    // Parse structured issues if present
+    let categorizedIssues: ReviewIssue[] | undefined;
+    if (Array.isArray(parsed.categorizedIssues)) {
+      categorizedIssues = parsed.categorizedIssues
+        .filter((i: unknown) => i && typeof i === 'object')
+        .map((i: Record<string, unknown>) => ({
+          description: String(i.description ?? ''),
+          severity: (['critical', 'important', 'minor'].includes(i.severity as string)
+            ? i.severity : 'minor') as ReviewIssue['severity'],
+          file: typeof i.file === 'string' ? i.file : undefined,
+          line: typeof i.line === 'number' ? i.line : undefined,
+          suggestion: typeof i.suggestion === 'string' ? i.suggestion : undefined,
+        }));
+    }
+
+    // Parse verdict
+    const validVerdicts = new Set(['merge', 'fix-first', 'reject']);
+    const verdict = validVerdicts.has(parsed.verdict) ? parsed.verdict : undefined;
+
     return {
       approved: parsed.approved !== false,
-      summary: typeof parsed.summary === 'string' ? parsed.summary : fallback.summary,
+      summary: typeof parsed.summary === 'string' ? parsed.summary : fb.summary,
       issues: Array.isArray(parsed.issues) ? parsed.issues.map(String) : [],
+      categorizedIssues,
+      verdict,
       prTitle: typeof parsed.prTitle === 'string'
         ? parsed.prTitle.slice(0, 72)
-        : fallback.prTitle,
-      prBody: typeof parsed.prBody === 'string' ? parsed.prBody : fallback.prBody,
+        : fb.prTitle,
+      prBody: typeof parsed.prBody === 'string' ? parsed.prBody : fb.prBody,
     };
   } catch {
-    return fallback;
+    return fb;
   }
 }
 
 // ── Plan Parser ──────────────────────────────────────────────
 
-export function parsePlanResult(raw: string): {
+const VALID_TDD = new Set(['tdd', 'test-after', 'no-test']);
+const VALID_COMPLEXITY = new Set(['low', 'medium', 'high']);
+
+export interface PlanResult {
   plan: string;
   subtasks: Card['subtasks'];
-} {
+  /** Validation warnings (non-blocking) about the plan structure */
+  warnings: string[];
+}
+
+export function parsePlanResult(raw: string): PlanResult {
   const jsonMatch = raw.match(/```json\s*([\s\S]*?)```/) || raw.match(/\{[\s\S]*"plan"[\s\S]*"subtasks"[\s\S]*\}/);
 
   if (!jsonMatch) {
-    return {
-      plan: raw.slice(0, 2000),
-      subtasks: [],
-    };
+    return { plan: raw.slice(0, 2000), subtasks: [], warnings: ['No JSON block found in planner output'] };
   }
 
   try {
@@ -226,24 +296,83 @@ export function parsePlanResult(raw: string): {
 
     const plan = typeof parsed.plan === 'string' ? parsed.plan : raw.slice(0, 2000);
     const subtasks: Card['subtasks'] = [];
+    const warnings: string[] = [];
 
     if (Array.isArray(parsed.subtasks)) {
       for (const st of parsed.subtasks) {
+        const tdd = VALID_TDD.has(st.tddDesignation) ? st.tddDesignation : undefined;
+        const complexity = VALID_COMPLEXITY.has(st.complexity) ? st.complexity : undefined;
+        const filePaths = Array.isArray(st.filePaths) ? st.filePaths.map(String) : undefined;
+
         subtasks.push({
           id: String(st.id || subtasks.length + 1),
           title: String(st.title || 'Untitled subtask'),
           description: String(st.description || ''),
           status: 'pending',
           dependsOn: Array.isArray(st.dependsOn) ? st.dependsOn.map(String) : [],
+          tddDesignation: tdd,
+          filePaths,
+          complexity,
         });
       }
     }
 
-    return { plan, subtasks };
+    // Validate plan structure
+    const validIds = new Set(subtasks.map((s) => s.id));
+    for (const st of subtasks) {
+      for (const dep of st.dependsOn) {
+        if (!validIds.has(dep)) {
+          warnings.push(`Subtask "${st.id}" depends on non-existent subtask "${dep}"`);
+        }
+      }
+    }
+
+    return { plan, subtasks, warnings };
   } catch {
-    return {
-      plan: raw.slice(0, 2000),
-      subtasks: [],
-    };
+    return { plan: raw.slice(0, 2000), subtasks: [], warnings: ['Failed to parse planner JSON output'] };
   }
+}
+
+// ── Spec & Quality Review Prompts ────────────────────────────
+
+export function buildSpecReviewPrompt(card: Card, subtaskId: string, diff: string): string {
+  const subtask = card.subtasks.find((s) => s.id === subtaskId);
+  if (!subtask) throw new Error(`Subtask ${subtaskId} not found on card #${card.id}`);
+
+  const patch = diff.length > DIFF_PATCH_LIMIT
+    ? `${diff.slice(0, DIFF_PATCH_LIMIT)}\n\n...[truncated]`
+    : diff;
+
+  return `Compare this implementation against the subtask specification:
+
+# Subtask: ${subtask.title}
+${subtask.description}
+${subtask.filePaths?.length ? `\nExpected files: ${subtask.filePaths.join(', ')}` : ''}
+
+# Parent Card: ${card.title}
+${card.acceptance.length > 0 ? `Acceptance Criteria:\n${card.acceptance.map((a) => `- ${a}`).join('\n')}` : ''}
+
+# Implementation Diff
+${patch || '(no diff)'}
+
+Review for spec compliance. Output valid JSON as specified in your instructions.`;
+}
+
+export function buildQualityReviewPrompt(card: Card, diff: string, fileSummary: string): string {
+  const patch = diff.length > DIFF_PATCH_LIMIT
+    ? `${diff.slice(0, DIFF_PATCH_LIMIT)}\n\n...[truncated]`
+    : diff;
+
+  return `Review this implementation for code quality:
+
+# Card: ${card.title}
+${card.description ? `\nDescription: ${card.description}` : ''}
+
+# Changed Files
+${fileSummary || '(no files changed)'}
+
+# Implementation Diff
+${patch || '(no diff)'}
+
+Review for code quality concerns. Output valid JSON as specified in your instructions.`;
 }

--- a/apps/desktop/electron/kanban/review-executor.ts
+++ b/apps/desktop/electron/kanban/review-executor.ts
@@ -16,9 +16,11 @@ import type { ReviewProgressTracker } from './review-progress';
 import type { ReviewResult } from './prompts';
 import {
   buildReviewPrompt,
-  REVIEWER_SYSTEM_PROMPT,
   parseReviewResult,
 } from './prompts';
+import type { ReviewPromptOptions } from './prompts';
+import { detectVerificationCommands, runVerificationCommands } from './verification';
+import type { KanbanSettings } from './types';
 import {
   createCheckpointInWorktree,
   ensureRemoteDefaultBranch,
@@ -34,6 +36,7 @@ const execFileAsync = promisify(execFile);
 export interface ReviewExecutorDeps {
   subagentManager: SubagentManager;
   workspaceId: string;
+  settings?: KanbanSettings;
 }
 
 export interface ReviewExecutorResult {
@@ -104,15 +107,35 @@ export async function executeReview(
     return { success: false, error: 'No changes to review — diff is empty.' };
   }
 
+  // ── Step 1b: Pre-review verification ────────────────────
+  const verifyCommands = await detectVerificationCommands(worktreePath, {
+    testingEnabled: deps.settings?.testingEnabled,
+  });
+  if (verifyCommands.length > 0) {
+    tracker.setPhase('Running verification');
+    await tracker.flush();
+
+    const verifyResult = await runVerificationCommands(worktreePath, verifyCommands);
+    if (!verifyResult.success) {
+      const failed = verifyResult.results.find((r) => !r.success);
+      const errOutput = failed
+        ? `${failed.command}: ${failed.stderr}\n${failed.stdout}`.trim().slice(-2000)
+        : 'Unknown verification failure';
+      return { success: false, error: `Pre-review verification failed:\n${errOutput}` };
+    }
+  }
+
   // ── Step 2: Reviewer subagent ─────────────────────────
   tracker.setPhase('Reviewing changes');
   tracker.addAgent('reviewer');
   await tracker.flush();
 
-  const reviewPrompt = buildReviewPrompt(card, diff, fileSummary);
+  const reviewOpts: ReviewPromptOptions = { testingEnabled: deps.settings?.testingEnabled };
+  const reviewPrompt = buildReviewPrompt(card, diff, fileSummary, reviewOpts);
+  // Uses the reviewer agent template (packages/templates/agents/reviewer.md)
   const rawReview = await deps.subagentManager.runSingle({
+    agent: 'reviewer',
     task: reviewPrompt,
-    systemPrompt: REVIEWER_SYSTEM_PROMPT,
     parentSessionId: `kanban-review-${card.id}`,
     workspaceId: deps.workspaceId,
     cwd: worktreePath,
@@ -120,7 +143,7 @@ export async function executeReview(
     onUpdate: (text) => tracker.addLogLine(text),
   });
 
-  const review = parseReviewResult(rawReview);
+  const review = parseReviewResult(rawReview, card.title);
   tracker.completeAgent('reviewer');
 
   // Save review to file so restarts can skip re-running the subagent
@@ -170,6 +193,8 @@ async function pushAndCreatePr(
 
   if (prResult.success) {
     console.log(`[review-executor] PR created for card #${card.id}: ${prResult.url}`);
+    // Worktrees are kept alive until the user explicitly cleans up
+    // (via done cleanup) — never auto-delete work that hasn't been confirmed
     return {
       success: true,
       prUrl: prResult.url,

--- a/apps/desktop/electron/kanban/review-executor.ts
+++ b/apps/desktop/electron/kanban/review-executor.ts
@@ -29,6 +29,7 @@ import {
   pushWorktreeBranch,
   createPrFromWorktree,
 } from './worktree-git';
+import { getContract } from './contracts';
 import type { SubagentManager } from '../subagent/index';
 
 const execFileAsync = promisify(execFile);
@@ -146,9 +147,14 @@ export async function executeReview(
   const review = parseReviewResult(rawReview, card.title);
   tracker.completeAgent('reviewer');
 
-  // Save review to file so restarts can skip re-running the subagent
+  const reviewFailure = requiresReviewerApproval()
+    ? getBlockingReviewFailure(review)
+    : null;
   await saveCachedReview(reviewFile, review);
   console.log(`[review-executor] Saved review to ${reviewRelPath}`);
+  if (reviewFailure) {
+    return { success: false, error: reviewFailure };
+  }
 
   // ── Steps 3–4: Push + PR ──────────────────────────────
   return pushAndCreatePr(review, reviewRelPath, worktreePath, branchName, card, tracker);
@@ -234,7 +240,8 @@ async function loadCachedReview(filePath: string): Promise<ReviewResult | null> 
     const raw = await fs.readFile(filePath, 'utf8');
     const data = JSON.parse(raw) as Partial<ReviewResult>;
     if (typeof data.prTitle === 'string' && typeof data.prBody === 'string') {
-      return data as ReviewResult;
+      const review = data as ReviewResult;
+      return getBlockingReviewFailure(review) ? null : review;
     }
   } catch {
     // No cached review or invalid file — run from scratch
@@ -245,6 +252,37 @@ async function loadCachedReview(filePath: string): Promise<ReviewResult | null> 
 async function saveCachedReview(filePath: string, review: ReviewResult): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, JSON.stringify(review, null, 2), 'utf8');
+}
+
+function getBlockingReviewFailure(review: ReviewResult): string | null {
+  const criticalIssues = review.categorizedIssues?.filter((issue) => issue.severity === 'critical') ?? [];
+  const verdictBlocks = review.verdict === 'fix-first' || review.verdict === 'reject';
+  const reviewBlocks = review.approved === false || verdictBlocks || criticalIssues.length > 0;
+
+  if (!reviewBlocks) return null;
+
+  const issueLines = criticalIssues.length > 0
+    ? criticalIssues
+      .slice(0, 3)
+      .map((issue) => {
+        const location = issue.file
+          ? ` (${issue.file}${issue.line ? `:${issue.line}` : ''})`
+          : '';
+        return `- ${issue.description}${location}`;
+      })
+      .join('\n')
+    : review.issues.slice(0, 3).map((issue) => `- ${issue}`).join('\n');
+
+  const summary = review.summary.trim() || 'Reviewer did not approve this implementation.';
+  return issueLines ? `${summary}\n${issueLines}` : summary;
+}
+
+function requiresReviewerApproval(): boolean {
+  return getContract('in-progress', 'review')?.qualityGates.some((gate) => (
+    gate.type === 'agent-review'
+    && gate.agent === 'reviewer'
+    && gate.blocking
+  )) === true;
 }
 
 // ── Orphaned-file recovery ──────────────────────────────────

--- a/apps/desktop/electron/kanban/state-helpers.ts
+++ b/apps/desktop/electron/kanban/state-helpers.ts
@@ -17,6 +17,9 @@ function fallbackState(): KanbanState {
       autoAdvance: true,
       maxConcurrentCards: 3,
       requireApproval: { plan: true, pr: true },
+      reviewLevel: 'per-wave',
+      testingEnabled: true,
+      yoloMode: false,
     },
   };
 }

--- a/apps/desktop/electron/kanban/subtask-executor.ts
+++ b/apps/desktop/electron/kanban/subtask-executor.ts
@@ -6,16 +6,19 @@
  * implementation phase.
  */
 
-import type { Card, KanbanState, Subtask } from './types';
+import type { Card, KanbanState, KanbanSettings, Subtask } from './types';
 import type { ImplementationProgressTracker } from './implementation-progress';
 import { buildSubtaskPrompt } from './prompts';
+import type { SubtaskPromptOptions } from './prompts';
 import { createCheckpointInWorktree } from './worktree-git';
+import { detectVerificationCommands, runVerificationCommands } from './verification';
 import { appStateManager } from '../app-state';
 import type { SubagentManager } from '../subagent/index';
 
 export interface SubtaskExecutorDeps {
   subagentManager: SubagentManager;
   workspaceId: string;
+  settings?: KanbanSettings;
 }
 
 /**
@@ -70,6 +73,9 @@ export async function executeWaves(
         `Subtask(s) failed: ${failedInWave.map((s) => `"${s.title}"`).join(', ')}`,
       );
     }
+
+    // Wave-level verification (typecheck, tests) — catches integration issues early
+    await runWaveVerification(worktreePath, waveLabel, tracker, deps.settings);
   }
 }
 
@@ -85,7 +91,8 @@ async function executeSingleSubtask(
   tracker: ImplementationProgressTracker,
 ): Promise<void> {
   const subtask = card.subtasks.find((s) => s.id === subtaskId);
-  const taskPrompt = buildSubtaskPrompt(card, subtaskId);
+  const promptOpts: SubtaskPromptOptions = { testingEnabled: deps.settings?.testingEnabled };
+  const taskPrompt = buildSubtaskPrompt(card, subtaskId, promptOpts);
 
   try {
     const result = await deps.subagentManager.runSingleStructured({
@@ -138,9 +145,10 @@ async function executeParallelSubtasks(
     return { stId, title: subtask?.title ?? stId };
   });
 
+  const promptOpts: SubtaskPromptOptions = { testingEnabled: deps.settings?.testingEnabled };
   const results = await Promise.allSettled(
     tasks.map(async (t) => {
-      const taskPrompt = buildSubtaskPrompt(card, t.stId);
+      const taskPrompt = buildSubtaskPrompt(card, t.stId, promptOpts);
 
       const result = await deps.subagentManager.runSingleStructured({
         agent: 'implementer',
@@ -187,7 +195,7 @@ async function updateSubtaskStatuses(
   status: 'pending' | 'in-progress' | 'completed' | 'failed',
 ): Promise<void> {
   await appStateManager.update<KanbanState>(stateFilePath, (raw) => {
-    if (!raw) return { cards: [], nextId: 1, settings: { autoAdvance: true, maxConcurrentCards: 3, requireApproval: { plan: true, pr: true } } };
+    if (!raw) return fallback();
     return {
       ...raw,
       cards: raw.cards.map((c) => {
@@ -211,7 +219,7 @@ async function markSubtaskCompleted(
   checkpointId: string | null,
 ): Promise<void> {
   await appStateManager.update<KanbanState>(stateFilePath, (raw) => {
-    if (!raw) return { cards: [], nextId: 1, settings: { autoAdvance: true, maxConcurrentCards: 3, requireApproval: { plan: true, pr: true } } };
+    if (!raw) return fallback();
     return {
       ...raw,
       cards: raw.cards.map((c) => {
@@ -229,4 +237,43 @@ async function markSubtaskCompleted(
       }),
     };
   });
+}
+
+// ── Wave-level Verification ─────────────────────────────────
+
+async function runWaveVerification(
+  worktreePath: string,
+  waveLabel: string,
+  tracker: ImplementationProgressTracker,
+  settings?: KanbanSettings,
+): Promise<void> {
+  const commands = await detectVerificationCommands(worktreePath, {
+    testingEnabled: settings?.testingEnabled,
+  });
+  if (commands.length === 0) return;
+
+  tracker.setPhase(`${waveLabel} — verifying`);
+  await tracker.flush();
+
+  const result = await runVerificationCommands(worktreePath, commands);
+  if (!result.success) {
+    const failed = result.results.find((r) => !r.success);
+    const errOutput = failed ? `${failed.stderr}\n${failed.stdout}`.trim().slice(-1000) : 'unknown';
+    throw new Error(`Wave verification failed (${failed?.command}): ${errOutput}`);
+  }
+}
+
+function fallback(): KanbanState {
+  return {
+    cards: [],
+    nextId: 1,
+    settings: {
+      autoAdvance: true,
+      maxConcurrentCards: 3,
+      requireApproval: { plan: true, pr: true },
+      reviewLevel: 'per-wave',
+      testingEnabled: true,
+      yoloMode: false,
+    },
+  };
 }

--- a/apps/desktop/electron/kanban/types.ts
+++ b/apps/desktop/electron/kanban/types.ts
@@ -19,6 +19,16 @@ export interface Subtask {
   description: string;
   status: 'pending' | 'in-progress' | 'completed' | 'failed';
   dependsOn: string[];
+  /** TDD scenario designation: 'tdd' = write tests first, 'test-after' = tests after, 'no-test' = skip */
+  tddDesignation?: 'tdd' | 'test-after' | 'no-test';
+  /** File paths this subtask creates or modifies */
+  filePaths?: string[];
+  /** Estimated complexity: low (~15min), medium (~30min), high (~45min+) */
+  complexity?: 'low' | 'medium' | 'high';
+  /** Spec review status (per-subtask review mode) */
+  specReviewStatus?: 'pending' | 'passed' | 'failed';
+  /** Quality review status (per-subtask review mode) */
+  qualityReviewStatus?: 'pending' | 'passed' | 'failed';
   agentRunId?: string;
   checkpointId?: string;
 }
@@ -63,6 +73,8 @@ export interface Card {
   priority: Priority;
   column: Column;
   status: CardStatus;
+  /** IDs of cards that must be in 'done' before this card can start */
+  blockedBy?: string[];
   branch?: string;
   worktreePath?: string;
   sessionId?: string;
@@ -88,6 +100,12 @@ export interface KanbanSettings {
     plan: boolean;
     pr: boolean;
   };
+  /** Review rigour: 'per-wave' (default) or 'per-subtask' (two-stage) */
+  reviewLevel: 'per-wave' | 'per-subtask';
+  /** Whether TDD and testing are enabled (default: true). false = POC mode */
+  testingEnabled: boolean;
+  /** YOLO mode: auto-start, auto-approve, auto-complete — no human gates */
+  yoloMode: boolean;
 }
 
 export interface KanbanState {

--- a/apps/desktop/electron/kanban/types.ts
+++ b/apps/desktop/electron/kanban/types.ts
@@ -2,8 +2,9 @@
  * Kanban types — host-side state definitions.
  *
  * These types mirror the extension's shared/types.ts but are owned by
- * the host. The extension package must NEVER be imported into the host
- * (dependency flows host → app, not app → host).
+ * the host. The extension package should NOT be imported into the host
+ * except for pure validation logic in shared/validation.ts (which has
+ * no side effects and is the single source of truth for transition rules).
  *
  * If you change the state shape here, update
  * packages/pi-kanban-extension/shared/types.ts to match.

--- a/apps/desktop/electron/kanban/verification.ts
+++ b/apps/desktop/electron/kanban/verification.ts
@@ -1,0 +1,163 @@
+/**
+ * Verification command detection and execution.
+ *
+ * Auto-detects project-appropriate verification commands (typecheck, tests, etc.)
+ * from workspace files. Zero-config — just point it at a workspace.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+// ── Detection ────────────────────────────────────────────────
+
+/**
+ * Detect the package manager used in a workspace.
+ */
+export function detectPackageManager(workspacePath: string): 'pnpm' | 'npm' | 'yarn' {
+  try {
+    // Synchronous check is fine for detection — called once per card
+    const files = require('fs').readdirSync(workspacePath) as string[];
+    if (files.includes('pnpm-lock.yaml') || files.includes('pnpm-workspace.yaml')) return 'pnpm';
+    if (files.includes('yarn.lock')) return 'yarn';
+  } catch {
+    // Fall through to default
+  }
+  return 'npm';
+}
+
+interface DetectOptions {
+  /** When false, exclude test commands (POC mode) */
+  testingEnabled?: boolean;
+}
+
+/**
+ * Auto-detect verification commands from workspace project files.
+ * Returns an ordered list of commands to run (typecheck first, then tests).
+ */
+export async function detectVerificationCommands(
+  workspacePath: string,
+  options?: DetectOptions,
+): Promise<string[]> {
+  const commands: string[] = [];
+  const testingEnabled = options?.testingEnabled !== false;
+  const pm = detectPackageManager(workspacePath);
+
+  // Read package.json once for script checks
+  const pkg = await readPackageJson(workspacePath);
+
+  // TypeScript → only if a typecheck script actually exists in package.json
+  if (await fileExists(path.join(workspacePath, 'tsconfig.json'))) {
+    if (pkg?.scripts?.typecheck) {
+      commands.push(`${pm} run typecheck`);
+    } else if (pkg?.scripts?.['type-check']) {
+      commands.push(`${pm} run type-check`);
+    }
+    // No typecheck script → skip (don't assume `tsc --noEmit` is available)
+  }
+
+  if (testingEnabled) {
+    // Node project with test script
+    if (pkg?.scripts?.test && pkg.scripts.test !== 'echo "Error: no test specified" && exit 1') {
+      commands.push(`${pm} test`);
+    }
+
+    // Cargo project → cargo check + cargo test
+    if (await fileExists(path.join(workspacePath, 'Cargo.toml'))) {
+      commands.push('cargo check', 'cargo test');
+    }
+
+    // Python project
+    if (
+      await fileExists(path.join(workspacePath, 'pyproject.toml'))
+      || await fileExists(path.join(workspacePath, 'setup.py'))
+    ) {
+      commands.push('pytest');
+    }
+  }
+
+  return commands;
+}
+
+// ── Execution ────────────────────────────────────────────────
+
+export interface VerificationResult {
+  success: boolean;
+  /** Results per command */
+  results: CommandResult[];
+}
+
+export interface CommandResult {
+  command: string;
+  success: boolean;
+  stdout: string;
+  stderr: string;
+  /** Elapsed time in ms */
+  durationMs: number;
+}
+
+/**
+ * Run verification commands sequentially. Stops on first failure.
+ */
+export async function runVerificationCommands(
+  cwd: string,
+  commands: string[],
+  timeoutMs = 120_000,
+): Promise<VerificationResult> {
+  const results: CommandResult[] = [];
+
+  for (const cmd of commands) {
+    const start = Date.now();
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        'sh', ['-c', cmd],
+        { cwd, timeout: timeoutMs, maxBuffer: 5 * 1024 * 1024 },
+      );
+      results.push({
+        command: cmd,
+        success: true,
+        stdout: stdout.slice(-4000),
+        stderr: stderr.slice(-2000),
+        durationMs: Date.now() - start,
+      });
+    } catch (err: unknown) {
+      const execErr = err as { stdout?: string; stderr?: string };
+      results.push({
+        command: cmd,
+        success: false,
+        stdout: (execErr.stdout ?? '').slice(-4000),
+        stderr: (execErr.stderr ?? '').slice(-2000),
+        durationMs: Date.now() - start,
+      });
+      // Stop on first failure
+      return { success: false, results };
+    }
+  }
+
+  return { success: true, results };
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPackageJson(
+  dir: string,
+): Promise<{ scripts?: Record<string, string> } | null> {
+  try {
+    const raw = await fs.readFile(path.join(dir, 'package.json'), 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/electron/kanban/verification.ts
+++ b/apps/desktop/electron/kanban/verification.ts
@@ -5,7 +5,7 @@
  * from workspace files. Zero-config — just point it at a workspace.
  */
 
-import { promises as fs } from 'fs';
+import { promises as fs, readdirSync } from 'fs';
 import path from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
@@ -20,7 +20,7 @@ const execFileAsync = promisify(execFile);
 export function detectPackageManager(workspacePath: string): 'pnpm' | 'npm' | 'yarn' {
   try {
     // Synchronous check is fine for detection — called once per card
-    const files = require('fs').readdirSync(workspacePath) as string[];
+    const files = readdirSync(workspacePath);
     if (files.includes('pnpm-lock.yaml') || files.includes('pnpm-workspace.yaml')) return 'pnpm';
     if (files.includes('yarn.lock')) return 'yarn';
   } catch {

--- a/apps/desktop/electron/kanban/worktree-git.ts
+++ b/apps/desktop/electron/kanban/worktree-git.ts
@@ -1,15 +1,14 @@
-/**
- * Worktree git helpers — VCS operations scoped to a worktree directory.
- *
- * Unlike the main VcsManager which resolves cwd from workspaceId,
- * these functions take an explicit cwd (the worktree path) and
- * run git commands directly there.
- */
+/** Worktree git helpers — VCS operations scoped to a worktree directory. */
 
 import { execFile } from 'child_process';
+import { promises as fs } from 'fs';
+import path from 'path';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
+
+/** Max buffer for git diff output (50MB — diffs can be large for greenfield projects). */
+const DIFF_MAX_BUFFER = 50 * 1024 * 1024;
 
 /** Extract stderr and message from an execFile error. */
 function execError(err: unknown): { stderr: string; message: string } {
@@ -32,6 +31,20 @@ export async function createCheckpointInWorktree(
   worktreePath: string,
   message: string,
 ): Promise<string | null> {
+  // Ensure common patterns are in .gitignore BEFORE checking status
+  await ensureGitignore(worktreePath);
+
+  // Remove .DS_Store from tracking if present (safe, targeted removal)
+  try {
+    await execFileAsync('git', ['rm', '-r', '--cached', '--ignore-unmatch', '.DS_Store'], {
+      cwd: worktreePath, timeout: 10_000,
+    });
+    // Also check subdirectories
+    await execFileAsync('git', ['rm', '-r', '--cached', '--ignore-unmatch', '**/.DS_Store'], {
+      cwd: worktreePath, timeout: 10_000,
+    });
+  } catch { /* not tracked — fine */ }
+
   // Check if there are changes to commit
   const status = await execFileAsync('git', ['status', '--porcelain'], {
     cwd: worktreePath,
@@ -176,12 +189,7 @@ async function resolveBaseBranch(worktreePath: string): Promise<string> {
   }
 }
 
-/**
- * Get the diff of all changes in a worktree from the branch base.
- *
- * Handles the empty-repo case (no commits yet) by diffing against
- * the git empty tree SHA.
- */
+/** Get the diff of all changes in a worktree from the branch base. */
 export async function getWorktreeDiff(worktreePath: string): Promise<string> {
   if (!await hasCommits(worktreePath)) {
     // No commits — diff all files against the empty tree
@@ -199,7 +207,7 @@ export async function getWorktreeDiff(worktreePath: string): Promise<string> {
       const diff = await execFileAsync('git', ['diff', '--cached', emptyTree.stdout.trim()], {
         cwd: worktreePath,
         timeout: 30_000,
-        maxBuffer: 10 * 1024 * 1024,
+        maxBuffer: DIFF_MAX_BUFFER,
       });
       // Unstage to avoid side effects
       await execFileAsync('git', ['reset'], { cwd: worktreePath, timeout: 10_000 }).catch(() => {});
@@ -219,16 +227,17 @@ export async function getWorktreeDiff(worktreePath: string): Promise<string> {
     const diff = await execFileAsync('git', ['diff', diffSpec], {
       cwd: worktreePath,
       timeout: 30_000,
-      maxBuffer: 10 * 1024 * 1024,
+      maxBuffer: DIFF_MAX_BUFFER,
     });
     return diff.stdout;
-  } catch {
+  } catch (err) {
+    console.warn(`[worktree-git] git diff ${diffSpec} failed:`, (err as Error)?.message?.slice(0, 200));
     // Fallback: diff working tree against HEAD
     try {
       const diff = await execFileAsync('git', ['diff', 'HEAD'], {
         cwd: worktreePath,
         timeout: 30_000,
-        maxBuffer: 10 * 1024 * 1024,
+        maxBuffer: DIFF_MAX_BUFFER,
       });
       return diff.stdout;
     } catch {
@@ -249,17 +258,7 @@ async function fetchRemoteRefs(worktreePath: string): Promise<void> {
   }
 }
 
-/**
- * Ensure the remote has a default branch to serve as PR base.
- *
- * Strategy:
- * 1. Remote has main/master with shared history → use it.
- * 2. Remote has main/master but no shared history → check if it
- *    contains real work (multiple commits). If so, abort rather
- *    than overwrite someone's branch.
- * 3. Remote has no default branch at all, or it's an empty/orphan
- *    branch → push main from the feature branch's root commit.
- */
+/** Ensure the remote has a default branch to serve as PR base. */
 export async function ensureRemoteDefaultBranch(worktreePath: string): Promise<string> {
   await fetchRemoteRefs(worktreePath);
 
@@ -447,4 +446,51 @@ function extractGithubPrUrl(text: string): string | undefined {
 function extractPrNumber(url: string): number | undefined {
   const match = url.match(/\/pull\/(\d+)/);
   return match ? parseInt(match[1], 10) : undefined;
+}
+
+// ── Gitignore ────────────────────────────────────────────────
+
+/**
+ * Common .gitignore patterns that should always be present.
+ * Prevents massive diffs from committed node_modules, dist, etc.
+ */
+const COMMON_IGNORE_PATTERNS = [
+  'node_modules/',
+  'dist/',
+  'build/',
+  '.DS_Store',
+  '*.log',
+  '.env',
+  '.env.local',
+  'coverage/',
+  '.sero/',
+  '__pycache__/',
+  '*.pyc',
+  'target/',
+  '.next/',
+  '.nuxt/',
+  '.turbo/',
+];
+
+/**
+ * Ensure common patterns are in the worktree's .gitignore.
+ * Only ADDS patterns — never removes tracked files from the index.
+ * The dangerous `git rm --cached` approach was removed because if
+ * the re-add fails, it nukes all source files from the commit.
+ */
+async function ensureGitignore(worktreePath: string): Promise<void> {
+  const gitignorePath = path.join(worktreePath, '.gitignore');
+  let existing = '';
+  try {
+    existing = await fs.readFile(gitignorePath, 'utf8');
+  } catch { /* file doesn't exist yet */ }
+
+  const missing = COMMON_IGNORE_PATTERNS.filter(
+    (pattern) => !existing.includes(pattern),
+  );
+  if (missing.length === 0) return;
+
+  const separator = existing && !existing.endsWith('\n') ? '\n' : '';
+  const additions = `${separator}# Auto-added by kanban orchestrator\n${missing.join('\n')}\n`;
+  await fs.writeFile(gitignorePath, existing + additions, 'utf8');
 }

--- a/apps/desktop/electron/kanban/worktree-manager.ts
+++ b/apps/desktop/electron/kanban/worktree-manager.ts
@@ -42,13 +42,20 @@ export async function ensureGitReady(workspacePath: string): Promise<boolean> {
     bootstrapped = true;
   }
 
-  // Ensure .sero/ is in .gitignore
+  // Ensure comprehensive .gitignore exists BEFORE the initial commit
+  // so node_modules, dist, .DS_Store, etc. are never tracked
   const gitignorePath = path.join(workspacePath, '.gitignore');
   try {
     const content = await fs.readFile(gitignorePath, 'utf8').catch(() => '');
-    if (!content.includes('.sero/')) {
-      const line = content.endsWith('\n') || content === '' ? '.sero/\n' : '\n.sero/\n';
-      await fs.writeFile(gitignorePath, content + line, 'utf8');
+    const required = [
+      'node_modules/', 'dist/', 'build/', '.DS_Store', '*.log',
+      '.env', '.env.local', 'coverage/', '.sero/', '__pycache__/',
+      '*.pyc', 'target/', '.next/', '.nuxt/', '.turbo/',
+    ];
+    const missing = required.filter((p) => !content.includes(p));
+    if (missing.length > 0) {
+      const sep = content && !content.endsWith('\n') ? '\n' : '';
+      await fs.writeFile(gitignorePath, content + sep + missing.join('\n') + '\n', 'utf8');
     }
   } catch { /* best-effort */ }
 
@@ -60,6 +67,10 @@ export async function ensureGitReady(workspacePath: string): Promise<boolean> {
     });
   } catch {
     console.log('[worktree] Creating initial commit (greenfield project)');
+    // Ensure default branch is 'main' (not 'master')
+    try {
+      await execFileAsync('git', ['branch', '-M', 'main'], { cwd: workspacePath, timeout: 5_000 });
+    } catch { /* branch may not exist yet — that's fine, init -b main handles it */ }
     await execFileAsync('git', ['add', '-A'], { cwd: workspacePath, timeout: 10_000 });
     await execFileAsync('git', [
       'commit', '--allow-empty', '-m', 'Initial commit',

--- a/apps/desktop/tsconfig.electron.json
+++ b/apps/desktop/tsconfig.electron.json
@@ -9,7 +9,10 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "outDir": "dist/electron",
-    "rootDir": ".",
+    /* Widened to monorepo root so contracts.ts can import shared validation
+       from packages/pi-kanban-extension/shared/. Safe: this tsconfig is only
+       used for `tsc --noEmit` type checking — the actual build uses esbuild. */
+    "rootDir": "../..",
     "lib": ["ES2022"],
     "baseUrl": ".",
     "paths": {

--- a/docs/plans/2026-03-14-kanban-workflow-improvements.md
+++ b/docs/plans/2026-03-14-kanban-workflow-improvements.md
@@ -1,0 +1,578 @@
+# Kanban Workflow Improvements — High-Level Plan
+
+## Goal
+
+Transform the Kanban from a simple card-tracking board into a structured, end-to-end development workflow where ideas are brainstormed into well-formed cards, each stage has defined input/output contracts, and execution flows automatically through quality-gated phases with human checkpoints.
+
+---
+
+## How Things Work Today
+
+Three distinct mechanisms drive the kanban automation. All enhancements in this plan build on them — no new loading systems or parallel abstractions.
+
+### 1. Agent Templates (`packages/templates/agents/*.md`)
+
+Define **subagent personas** — model, thinking level, tools, and a system prompt body. Installed to `~/.sero-ui/agent/agents/` at runtime and discovered by `SubagentManager.resolveAgent()` → `discoverAgents()`.
+
+```
+packages/templates/agents/
+├── analyst.md        # Codebase analysis — used by planning-executor
+├── scout.md          # Fast recon — used by planning-executor
+├── implementer.md    # Subtask execution — used by subtask-executor
+├── planner.md        # Plan generation — EXISTS but NOT used (see §0)
+├── reviewer.md       # Code review — EXISTS but NOT used (see §0)
+├── test-writer.md    # Test generation — not yet used by kanban
+└── ...
+```
+
+**How they're consumed:** `subagentManager.runSingle({ agent: 'analyst', task: '...' })` — the subagent system resolves the `.md` file, reads frontmatter (model/thinking/tools) and body (system prompt), then creates a transient `AgentSession`.
+
+### 2. Prompt Builder Functions (`electron/kanban/prompts.ts`)
+
+Construct the **user message** (the `task` parameter) sent to subagents. These contain dynamic card context — title, description, acceptance criteria, analysis results, diffs.
+
+- `buildPlanningPrompt(card)` — card context for analyst/scout
+- `buildSubtaskGenerationPrompt(card, analysis)` — card + analysis for planner
+- `buildSubtaskPrompt(card, subtaskId)` — card + subtask context for implementer
+- `buildReviewPrompt(card, diff, fileSummary)` — card + diff for reviewer
+
+Also contains two **inline system prompts** that bypass agent templates:
+- `PLANNER_SYSTEM_PROMPT` — used instead of `planner.md` template ← **bug, fixed in §0**
+- `REVIEWER_SYSTEM_PROMPT` — used instead of `reviewer.md` template ← **bug, fixed in §0**
+
+### 3. PI SDK Primitives
+
+| Primitive | What it is | Where it lives | How it's loaded |
+|-----------|-----------|----------------|-----------------|
+| **Agent Templates** | Subagent persona (model, thinking, system prompt body) | `~/.sero-ui/agent/agents/*.md` | `discoverAgents()` in `subagent/discovery.ts` |
+| **Prompt Templates** | User-facing `/slash` commands that expand into user messages | `~/.pi/agent/prompts/`, `.pi/prompts/` | `ResourceLoader.getPrompts()` |
+| **Skills** | On-demand capability packages loaded by the agent when tasks match | `~/.pi/agent/skills/`, `.pi/skills/` | `ResourceLoader.getSkills()` |
+| **Extensions** | Register tools, commands, events via `pi.registerTool()` | `~/.pi/agent/extensions/`, `.pi/extensions/` | `ResourceLoader.getExtensions()` |
+| **Context Files** | `AGENTS.md` project instructions injected into system prompt | Walking up from `cwd` | `ResourceLoader.getAgentsFiles()` |
+
+**Key rule:** subagent system prompts are defined in **agent templates**. Task-specific context with dynamic data is constructed by **prompt builder functions** in TypeScript. User-facing conversational flows use **PI SDK Prompt Templates** loaded via `ResourceLoader`. This plan does not introduce any new loading or resolution mechanisms.
+
+---
+
+## Current State
+
+The kanban already has:
+- 5 columns: **Backlog → Planning → In-Progress → Review → Done**
+- An orchestrator (`electron/kanban/`) that drives automation via subagents
+- Git worktree isolation per card, wave-based subtask execution
+- Progress tracking with live activity feeds in the UI
+- Human approval gates at planning→impl and review→done
+
+**What's missing:**
+- No brainstorming → card creation pipeline (cards are created manually with minimal structure)
+- No defined contracts for what each stage requires as input or produces as output
+- No quality gates between subtasks (no TDD enforcement, no spec review, no verification step)
+- The orchestrator agent instructions are basic — no structured plan format, no two-stage review
+- No card-to-card dependencies (only subtask dependencies within a card)
+- Skills like brainstorming, writing-plans, subagent-driven-development, verification-before-completion are not integrated
+- Planner and reviewer agent templates exist but are bypassed by hardcoded inline prompts
+
+---
+
+## Plan Overview — Four Workstreams
+
+### Phase 0: Fix Agent Template Bypass (prerequisite)
+### Workstream 1: Brainstorm → Cards Pipeline
+### Workstream 2: Stage Contracts & Quality Gates
+### Workstream 3: Enhanced Orchestrator
+
+Phase 0 is a prerequisite — it fixes an existing inconsistency. Workstreams 1–3 are ordered by dependency: contracts must be defined before the orchestrator can enforce them, and the brainstorm pipeline produces cards that conform to the contracts.
+
+---
+
+## Phase 0: Fix Agent Template Bypass
+
+**Problem:** The kanban orchestrator uses named agent templates for `analyst`, `scout`, and `implementer`, but bypasses the existing `planner.md` and `reviewer.md` templates with hardcoded inline system prompts (`PLANNER_SYSTEM_PROMPT` and `REVIEWER_SYSTEM_PROMPT` in `prompts.ts`).
+
+```typescript
+// Uses agent template ✅
+subagentManager.runParallel({ tasks: [{ agent: 'analyst', ... }, { agent: 'scout', ... }] })
+
+// Bypasses agent template ❌ — should use agent: 'planner'
+subagentManager.runSingle({ task: ..., systemPrompt: PLANNER_SYSTEM_PROMPT })
+
+// Bypasses agent template ❌ — should use agent: 'reviewer'
+subagentManager.runSingle({ task: ..., systemPrompt: REVIEWER_SYSTEM_PROMPT })
+```
+
+**Fix:**
+1. Merge the richer instructions from `PLANNER_SYSTEM_PROMPT` and `REVIEWER_SYSTEM_PROMPT` into the body of `packages/templates/agents/planner.md` and `packages/templates/agents/reviewer.md`
+2. Switch `planning-executor.ts` to use `agent: 'planner'` instead of `systemPrompt: PLANNER_SYSTEM_PROMPT`
+3. Switch `review-executor.ts` to use `agent: 'reviewer'` instead of `systemPrompt: REVIEWER_SYSTEM_PROMPT`
+4. Remove `PLANNER_SYSTEM_PROMPT` and `REVIEWER_SYSTEM_PROMPT` from `prompts.ts`
+
+After this, all five kanban subagents (analyst, scout, planner, implementer, reviewer) consistently use agent templates. This is the foundation for all enhancements in Workstreams 1–3.
+
+---
+
+## Workstream 1: Brainstorm → Cards Pipeline
+
+**Problem:** Today, cards are created ad-hoc via `kanban add "title"` or the inline form — no structured process to refine ideas into well-scoped, implementable cards.
+
+**Approach:** Add a `kanban brainstorm` tool action that launches a conversational brainstorming flow, inspired by the `brainstorming` skill but adapted for Sero's architecture.
+
+### 1A. New `brainstorm` tool action
+
+Add a `brainstorm` action to the kanban extension tool. This triggers a **conversational brainstorming flow** in the ChatPanel (decision D1).
+
+When invoked, the agent follows the brainstorm prompt template:
+1. **Read workspace context** — recent commits, project structure, existing cards on the board
+2. **Probe the idea** — ask questions one at a time (prefer multiple choice), focus on purpose, constraints, success criteria, scope
+3. **Propose approaches** — present 2-3 options with trade-offs, lead with recommendation
+4. **Validate incrementally** — present the design in 200-300 word sections, check after each section
+5. **Generate cards** — once the design is validated, output a structured set of cards
+
+The output format is a JSON array of card specs:
+```json
+[
+  {
+    "title": "...",
+    "description": "...",
+    "acceptance": ["...", "..."],
+    "priority": "medium",
+    "blockedBy": ["card-ref"]
+  }
+]
+```
+
+The tool action creates all cards in Backlog and sets up any inter-card `blockedBy` relationships (see §2D). The brainstorming conversation is preserved in the chat session for reference.
+
+### 1B. Brainstorm prompt template (PI SDK Prompt Template)
+
+Brainstorming happens in the **main chat session** (ChatPanel), not a subagent. The brainstorm instructions are a **PI SDK Prompt Template** — a `.md` file discoverable via `ResourceLoader` and invocable as a `/brainstorm` slash command.
+
+**Location:** Ship `brainstorm.md` inside the kanban extension package's `prompts/` directory so it's auto-discovered by `ResourceLoader` when the extension loads.
+
+**Content codifies:**
+- Read the workspace context first (recent commits, project structure, existing kanban cards)
+- Ask questions one at a time, prefer multiple choice
+- Propose 2-3 approaches with trade-offs
+- Validate incrementally (present design in sections)
+- YAGNI — don't over-engineer the card scope
+- Output structured cards with acceptance criteria
+- Use the `kanban` tool to create the cards at the end
+
+**Invocation:** The `kanban brainstorm` tool action triggers the flow via `pi.sendUserMessage()` with the expanded template content. Users can also invoke `/brainstorm` directly from the chat editor.
+
+### 1C. UI: Brainstorm entry point
+
+Add a "Brainstorm" action to the Kanban header or empty state that sends a `kanban brainstorm` command into the active chat session (via `useAgentPrompt`). The brainstorming conversation happens in the ChatPanel — the kanban board updates as cards are created.
+
+Optionally: a "Brainstorm" button on the CardDetail for an individual card that needs refinement before starting.
+
+---
+
+## Workstream 2: Stage Contracts & Quality Gates
+
+**Problem:** There's no definition of what a card must contain before entering a stage, what a stage produces, or what validation must pass before advancing.
+
+**Approach:** Define a `StageContract` schema for each column transition. These contracts codify required inputs, expected outputs, and validation rules. They live as structured data so the orchestrator can enforce them.
+
+### 2A. Stage contract schema
+
+The `StageContract` is pure application logic — kanban-specific validation that lives in the orchestrator. It does **not** reference prompt templates or agent system prompts (those are handled separately by agent templates and prompt builders).
+
+```typescript
+interface StageContract {
+  /** Which column transition this contract governs */
+  transition: `${Column}->${Column}`;
+
+  /** Fields that must be populated on the card before entering */
+  requiredInputs: {
+    field: keyof Card;
+    validation: 'non-empty' | 'min-items' | 'custom';
+    message: string;  // Error shown if validation fails
+  }[];
+
+  /** What this stage produces (documentation + validation) */
+  expectedOutputs: {
+    field: keyof Card;
+    description: string;
+  }[];
+
+  /** Quality gates that must pass before the card advances */
+  qualityGates: QualityGate[];
+}
+
+interface QualityGate {
+  name: string;
+  type: 'agent-review' | 'command' | 'field-check';
+  /** For 'command': shell command to run (e.g., 'pnpm typecheck') */
+  command?: string;
+  /** For 'agent-review': which agent template to dispatch */
+  agent?: string;
+  /** For 'field-check': card field that must be truthy */
+  field?: string;
+  /** Whether failure blocks advancement or is advisory */
+  blocking: boolean;
+}
+```
+
+Note: the `QualityGate.agent` field references an **agent template name** (e.g. `'spec-reviewer'`), not a prompt file. The orchestrator dispatches it via `subagentManager.runSingle({ agent: gateName, task: ... })`.
+
+### 2B. Contracts per transition
+
+#### Backlog → Planning (`start`)
+
+**Required inputs:**
+- `title` — non-empty
+- `description` — non-empty (at least a sentence explaining the intent)
+- `acceptance` — at least 1 acceptance criterion
+
+**Expected outputs:** (produced by the planning phase)
+- `plan` — prose implementation approach
+- `subtasks` — decomposed work items with dependency graph
+
+**Quality gates:** None (human initiates this transition)
+
+**Agents used:** `analyst` + `scout` (parallel reconnaissance), then `planner` (plan generation). All three are existing agent templates enhanced with richer instructions (see §3A):
+- Plans include TDD scenario designation per subtask
+- Plans include exact file paths (create/modify/test)
+- Plans include dependency ordering and wave grouping rationale
+- 2-8 subtasks, each scoped to 15-30 minutes of agent work
+
+#### Planning → In-Progress (`approve`)
+
+**Required inputs:**
+- `plan` — non-empty
+- `subtasks` — at least 1 subtask
+- `status` = `waiting-input` (human has reviewed)
+
+**Expected outputs:** (produced by the implementation phase)
+- All subtasks completed
+- Code changes committed in worktree
+- Tests passing (if applicable)
+
+**Quality gates:**
+- Per-subtask (opt-in): spec compliance review via `spec-reviewer` agent template
+- Per-subtask (opt-in): code quality review via `quality-reviewer` agent template
+- Per-wave: verification command (configurable — e.g., `pnpm typecheck`)
+
+**Agent used:** `implementer` (enhanced with TDD instructions and self-review checklist — see §3B)
+
+#### In-Progress → Review (automatic)
+
+**Required inputs:**
+- All subtasks `completed`
+- Non-empty diff in worktree
+
+**Expected outputs:**
+- Code review result (issues categorised as critical/important/minor)
+- PR with structured description (summary, changes, testing sections)
+- `prUrl` and `prNumber` set
+
+**Quality gates:**
+- Verification command runs before review (e.g., tests, typecheck)
+- `reviewer` agent approval (blocking if critical issues found)
+- Branch pushed, PR created
+
+**Agent used:** `reviewer` (enhanced with structured issue categories and assessment verdict — see §3C)
+
+#### Review → Done (`complete`)
+
+**Required inputs:**
+- `prUrl` — non-empty (PR exists)
+- `status` = `waiting-input` (human has merged/reviewed)
+
+**Expected outputs:**
+- `completedAt` timestamp
+- Worktree cleaned up
+
+**Quality gates:** None beyond human confirmation
+
+### 2C. Validation enforcement
+
+Add a `validateTransition(card, targetColumn)` function to the orchestrator that checks the relevant `StageContract.requiredInputs` before allowing a column change. The `kanban` tool actions (`start`, `approve`, `complete`, `move`) call this function and return a clear error message listing what's missing.
+
+The UI can also call validation to show readiness indicators on cards (e.g., a green/amber/red dot showing whether a card is ready for the next stage).
+
+### 2D. Card-to-card dependencies
+
+**(Decision D3: Full dependency tracking)**
+
+Add a `blockedBy: string[]` field to the `Card` interface — an array of card IDs that must be in `done` before this card can be started.
+
+**Orchestrator enforcement:**
+- `validateTransition(card, 'planning')` checks that all `blockedBy` cards are in `done`
+- The `start` tool action returns a clear error listing which blocking cards aren't done yet
+- Auto-execution: when a card moves to `done`, the orchestrator checks if any blocked cards are now unblocked and can auto-start (if `autoAdvance` is enabled)
+
+**Tool actions:**
+- `kanban add` — accepts optional `blockedBy` parameter
+- `kanban update` — can set/clear `blockedBy`
+- `kanban brainstorm` — sets `blockedBy` when creating a batch of related cards
+
+**UI:**
+- Cards in Backlog with unmet dependencies show a blocked indicator (lock icon + "Blocked by #X, #Y")
+- CardDetail shows dependency section with links to blocking cards
+- Column counts distinguish between "ready" and "blocked" cards in backlog
+
+---
+
+## Workstream 3: Enhanced Orchestrator
+
+**Problem:** The current orchestrator has basic agent instructions and no quality gates between subtasks. The external skills define a much more rigorous process (two-stage review, TDD enforcement, verification before completion) that isn't leveraged.
+
+**Approach:** Enhance the orchestrator's three phases by improving existing agent templates and prompt builders. No new loading systems — all changes go into `packages/templates/agents/*.md` (agent persona/instructions) and `electron/kanban/prompts.ts` (dynamic task context).
+
+### 3A. Enhanced planning phase
+
+**Current:** analyst + scout (parallel) → planner → wait for approval.
+
+**Enhanced:**
+1. **Analyst + Scout** (parallel, unchanged) — codebase reconnaissance
+2. **Planner** — enhance the `planner.md` agent template to produce:
+   - Prose plan (2-4 paragraphs)
+   - Subtasks with: TDD scenario designation, file paths (create/modify/test), dependency graph, estimated complexity
+   - The plan format matches `writing-plans` patterns but without step-by-step granularity (the implementer handles that)
+3. **Plan validation** — automated check that the plan has valid structure (subtasks with IDs, dependencies reference valid IDs, no orphaned dependencies)
+4. **Human approval** (unchanged) — but now the UI shows a richer plan with file paths and TDD designations
+
+**What changes where:**
+- `packages/templates/agents/planner.md` — enhanced system prompt body with structured output instructions
+- `prompts.ts` → `buildSubtaskGenerationPrompt()` — enhanced to include TDD designation instructions and file path requirements in the task message
+- `prompts.ts` → `parsePlanResult()` — updated to parse new fields (TDD designation, file paths)
+
+### 3B. Enhanced implementation phase — configurable review rigour
+
+**(Decision D2: Configurable — default wave-level, opt-in per-subtask)**
+
+**Current:** Implementer subagent per subtask → checkpoint → next wave. No review between subtasks.
+
+**Enhanced — two tiers:**
+
+#### Default: Wave-level review
+
+For each subtask in the wave:
+1. **`implementer` agent** — enhance `implementer.md` to include:
+   - TDD instructions (three-scenario model from `test-driven-development`)
+   - Self-review checklist
+   - Context from completed subtasks (summaries, file paths produced)
+   - Explicit constraint: "Focus ONLY on this subtask"
+2. **Checkpoint** — git commit after each subtask
+
+After all subtasks in the wave complete:
+3. **Wave-level verification** — auto-detected commands (typecheck, tests — see §3E)
+4. **Combined review** — `reviewer` agent reviews all changes in the wave together:
+   - Structured issue categories (Critical / Important / Minor)
+   - If Critical issues → dispatch fix subagent → re-review (max 2 retries)
+   - Important issues are logged but don't block advancement
+
+#### Opt-in: Per-subtask two-stage review
+
+Enabled via `KanbanSettings.reviewLevel: 'per-subtask'` (default: `'per-wave'`):
+
+For each subtask:
+1. **`implementer` agent** (same as above)
+2. **`spec-reviewer` agent** (new agent template) — compares implementation against subtask spec:
+   - Missing items? Extra items? Misunderstood requirements?
+   - If issues found → implementer fixes → re-review (max 2 retries)
+3. **`quality-reviewer` agent** (new agent template) — only after spec compliance passes
+4. **Checkpoint** — git commit only after both reviews pass
+
+After each wave:
+5. **Wave-level verification** — auto-detected commands
+
+**New agent templates to create:**
+- `packages/templates/agents/spec-reviewer.md` — system prompt for spec compliance review
+- `packages/templates/agents/quality-reviewer.md` — system prompt for code quality review
+
+**New settings fields:**
+```typescript
+interface KanbanSettings {
+  // ... existing fields ...
+  reviewLevel: 'per-wave' | 'per-subtask';  // default: 'per-wave'
+  testingEnabled: boolean;                   // default: true (see §3F)
+}
+```
+
+**State tracking:** Add review status to the `Subtask` type:
+```typescript
+interface Subtask {
+  // ... existing fields ...
+  specReviewStatus?: 'pending' | 'passed' | 'failed';
+  qualityReviewStatus?: 'pending' | 'passed' | 'failed';
+}
+```
+
+**Progress tracking:** The existing `ImplementationProgressTracker` already tracks agents and tools. Extend it to show the current phase per subtask (implementing → spec review → quality review → complete).
+
+### 3C. Enhanced review phase — verification before PR
+
+**Current:** Diff → reviewer subagent → push → create PR.
+
+**Enhanced (incorporating `verification-before-completion` and `finishing-a-development-branch` patterns):**
+
+1. **Pre-review verification** — run verification commands in the worktree before the review:
+   - Configurable per-workspace (default: test suite if detected, typecheck if detected)
+   - If verification fails → card goes to `failed` with clear error message
+2. **`reviewer` agent** — enhance `reviewer.md` template with:
+   - Structured issue categories (Critical / Important / Minor)
+   - Explicit assessment: "Ready to merge? Yes / No / With fixes"
+   - If reviewer finds Critical issues → implementation retry (re-enter in-progress phase with specific fix instructions)
+3. **Push + PR creation** (unchanged)
+4. **PR description** follows the structured template from `requesting-code-review`:
+   - Summary, Changes (per subtask), Testing sections
+
+**What changes where:**
+- `packages/templates/agents/reviewer.md` — enhanced system prompt body with structured review output format
+- `prompts.ts` → `buildReviewPrompt()` — enhanced task message with structured output instructions
+- `prompts.ts` → `parseReviewResult()` — updated to parse issue categories and assessment verdict
+
+### 3D. Enhanced agent templates and prompt builders
+
+**(Decision D4: Enhance existing primitives, no new loading system)**
+
+All orchestrator improvements in §3A–3C are delivered by enhancing the existing mechanisms:
+
+**Agent templates** (`packages/templates/agents/*.md`) — enhanced system prompt bodies:
+
+| Template | Enhancement |
+|----------|-------------|
+| `planner.md` | Structured plan output with TDD designations, file paths, dependency rationale |
+| `implementer.md` | TDD instructions, self-review checklist, subtask-scoping directive |
+| `reviewer.md` | Structured issue categories, assessment verdict, PR description format |
+| `spec-reviewer.md` **(new)** | Spec compliance review — compares implementation against subtask spec |
+| `quality-reviewer.md` **(new)** | Code quality review — style, patterns, performance, maintainability |
+
+**Prompt builder functions** (`electron/kanban/prompts.ts`) — enhanced task messages:
+
+| Builder | Enhancement |
+|---------|-------------|
+| `buildSubtaskGenerationPrompt()` | TDD fields, file path requirements, complexity estimates |
+| `buildSubtaskPrompt()` | Context from completed subtasks, TDD scenario from plan |
+| `buildReviewPrompt()` | Structured output instructions, issue category schema |
+| `buildSpecReviewPrompt()` **(new)** | Subtask spec + implementation diff for compliance review |
+| `buildQualityReviewPrompt()` **(new)** | Implementation diff for quality review |
+
+**PI SDK Prompt Templates** (for user-facing flows, loaded via `ResourceLoader`):
+
+| Template | Purpose |
+|----------|---------|
+| `brainstorm.md` **(new)** | `/brainstorm` slash command for conversational card creation |
+| `card-enhance.md` **(new)** | `/card-enhance` for refining an existing card's description |
+
+These ship in the kanban extension's `prompts/` directory and are auto-discovered by `ResourceLoader`.
+
+**Testing mode propagation (§3F):** The orchestrator reads `settings.testingEnabled` and conditionally includes/excludes TDD instructions when calling prompt builder functions. This is a code-level conditional in the orchestrator, not a template engine feature.
+
+### 3E. Auto-detected verification commands
+
+**(Decision D5: Auto-detect from project, zero-config)**
+
+The orchestrator auto-detects verification commands from the workspace:
+
+```typescript
+function detectVerificationCommands(workspacePath: string): string[] {
+  const commands: string[] = [];
+
+  // TypeScript project → typecheck
+  if (exists(join(workspacePath, 'tsconfig.json'))) {
+    commands.push(detectPackageManager(workspacePath) + ' typecheck');
+  }
+
+  // Test script in package.json → test suite
+  const pkg = readPackageJson(workspacePath);
+  if (pkg?.scripts?.test) {
+    commands.push(detectPackageManager(workspacePath) + ' test');
+  }
+
+  // Cargo project → cargo check + cargo test
+  if (exists(join(workspacePath, 'Cargo.toml'))) {
+    commands.push('cargo check', 'cargo test');
+  }
+
+  // Python project with pytest
+  if (exists(join(workspacePath, 'pyproject.toml')) || exists(join(workspacePath, 'setup.py'))) {
+    commands.push('pytest');
+  }
+
+  return commands;
+}
+```
+
+These run at:
+- **Wave boundaries** — between implementation waves to catch integration issues early
+- **Before review phase** — verification must pass before the reviewer agent is dispatched
+- **Failure handling** — if verification fails, the card status is set to `failed` with the command output as the error message. The user can fix and retry.
+
+### 3F. Testing mode toggle (POC vs Production)
+
+**(Decision D6: Per-workspace toggle)**
+
+A `testingEnabled` boolean in `KanbanSettings` (default: `true`) that controls whether testing is part of the workflow. This lets users work in "POC mode" for fast iteration, then flip to "production mode" when they want to harden the code.
+
+**When `testingEnabled: false` (POC mode):**
+
+| Area | Behaviour |
+|------|-----------|
+| **Planning** | `buildSubtaskGenerationPrompt()` omits TDD designation instructions and "write tests" subtask guidance |
+| **Implementation** | `buildSubtaskPrompt()` omits TDD instructions. Tells implementer "tests are not required for this task" |
+| **Verification** | Test suite commands are excluded from auto-detected verification. Typecheck still runs (correctness, not testing) |
+| **Review** | `buildReviewPrompt()` tells reviewer not to flag missing test coverage |
+| **Spec review** | `buildSpecReviewPrompt()` doesn't check for test presence |
+
+**When `testingEnabled: true` (Production mode — default):**
+
+Everything works as described in the rest of this plan: TDD instructions in implementer prompts, "write tests" subtasks in plans, test suite in verification commands, reviewer flags missing coverage.
+
+**Switching mid-flight:** Flipping the toggle only affects *future* card phases. A card already in `in-progress` continues with whatever context it was started with. A card still in `backlog` or `planning` will pick up the new setting when its phase starts.
+
+**How it propagates:** The orchestrator reads `settings.testingEnabled` from the kanban state when calling prompt builder functions. The builders conditionally include/exclude TDD-related content based on this flag. This is a code-level conditional — not a template engine.
+
+---
+
+## What We're NOT Changing
+
+- **Architecture:** File-based state bridge stays. No new IPC protocols, no WebSocket between extension and UI.
+- **Column structure:** Still 5 columns (backlog → planning → in-progress → review → done). No new columns.
+- **Extension registration:** Same `pi.registerTool()` pattern, same sero.app manifest. New actions are added to the existing `kanban` tool.
+- **UI framework:** Same React + Tailwind + Motion stack. New UI is additive (new panels, enhanced cards).
+- **Session model:** Subagents are still transient, orchestrator still lives in the Electron host.
+- **Loading systems:** No new prompt/template loading mechanisms. Agent templates are discovered via `discoverAgents()`. PI SDK Prompt Templates are discovered via `ResourceLoader`. Dynamic task context is built by prompt builder functions in `prompts.ts`.
+
+---
+
+## Implementation Order (suggested)
+
+| Phase | Section | What | Why this order |
+|-------|---------|------|----------------|
+| 0 | §0 | Fix planner/reviewer template bypass | Prerequisite — all subsequent work assumes consistent agent template usage |
+| 1 | §2A-2C | Stage contracts & validation | Foundation — defines the contracts everything else depends on |
+| 2 | §2D | Card-to-card dependencies | Data model change — add `blockedBy` to Card, validation logic, orchestrator enforcement |
+| 3 | §3A | Enhanced planning phase | Enhance `planner.md` template + prompt builders → better plans → better subtasks |
+| 4 | §3E | Auto-detected verification commands | Needed by phases 5 and 6 for wave-level and pre-review verification gates |
+| 5 | §3B | Configurable review + new agent templates | The biggest quality improvement — wave-level review + optional per-subtask. Creates `spec-reviewer.md` and `quality-reviewer.md` |
+| 6 | §3C | Enhanced review phase | Quality gates before PR creation. Uses verification commands from phase 4 |
+| 7 | §1A-1B | Brainstorm tool action + PI SDK Prompt Template | Now that contracts define card requirements and card deps exist, brainstorm can produce well-formed, linked cards |
+| 8 | §1C | Brainstorm UI entry point | Polish — the workflow works via chat first, UI adds discoverability |
+
+---
+
+## Design Decisions
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| D1 | Brainstorming UX | **Conversational in ChatPanel** | Full back-and-forth dialogue — agent probes the idea, validates sections, then creates cards at the end. Richer output than one-shot. |
+| D2 | Review rigour | **Configurable** | Default to wave-level review (single combined review after each wave). Users can upgrade to per-subtask two-stage review via `KanbanSettings`. Balances speed vs thoroughness. |
+| D3 | Card dependencies | **Full dependency tracking** | Cards can block other cards. Orchestrator respects this for auto-execution ordering. UI shows dependency indicators. Brainstorm pipeline can set these. |
+| D4 | Agent instructions | **Enhance existing agent templates + prompt builders** | Agent system prompts live in `packages/templates/agents/*.md`. Dynamic task context is built by prompt builder functions in `prompts.ts`. New reviewer variants are new agent templates (`spec-reviewer.md`, `quality-reviewer.md`). User-facing flows are PI SDK Prompt Templates loaded via `ResourceLoader`. No custom loading system. |
+| D5 | Verification commands | **Auto-detect from project** | Detect `tsconfig.json` → typecheck, `package.json` test script → tests, etc. No user config needed. Keep it zero-config. |
+| D6 | Testing mode | **Per-workspace toggle** | `testingEnabled` setting controls whether TDD is enforced, test-writing subtasks are generated, and test verification commands run. Off = POC mode (fast iteration), On = production mode (full TDD). Can be flipped at any time — existing cards aren't retroactively affected. |
+
+---
+
+## Appendix: Primitive Usage Map
+
+| Need | Primitive | Location |
+|------|-----------|----------|
+| Define subagent persona (model, thinking, system prompt) | **Agent Template** `.md` | `packages/templates/agents/planner.md` etc. |
+| Construct task-specific context with dynamic card data | **Prompt builder function** | `electron/kanban/prompts.ts` |
+| User-facing conversational flow in main chat | **PI SDK Prompt Template** | Extension's `prompts/` dir, loaded via `ResourceLoader` |
+| Kanban-specific validation and workflow rules | **Application code** in orchestrator | `validateTransition()`, quality gates |
+| Project-level instructions for all agents | **Context file** (`AGENTS.md`) | Walking up from workspace `cwd` |

--- a/packages/pi-kanban-extension/extension/index.ts
+++ b/packages/pi-kanban-extension/extension/index.ts
@@ -16,6 +16,7 @@ import { Type } from '@sinclair/typebox';
 
 import type { Column, Priority } from '../shared/types';
 import { COLUMNS, COLUMN_LABELS, createCard } from '../shared/types';
+import { validateManualMove } from '../shared/validation';
 import { resolveStatePath, readState, writeState, formatCard, formatBoard } from './state-io';
 import {
   handleStart, handleApprove, handleComplete,
@@ -138,20 +139,27 @@ export default function (pi: ExtensionAPI) {
           }
           const fromCol = card.column;
           const toCol = params.column as Column;
-          // Enforce workflow — use 'start', 'approve', 'complete' for managed transitions
-          const managedTransitions = ['planning', 'in-progress', 'done'] as const;
-          if (managedTransitions.includes(toCol as typeof managedTransitions[number]) && fromCol !== toCol) {
+          const validation = validateManualMove(card, toCol);
+          if (!validation.valid) {
             return {
               content: [
                 {
                   type: 'text',
-                  text: `Cannot move to "${COLUMN_LABELS[toCol]}" directly. Use the proper workflow action:\n  • backlog→planning: use "start"\n  • planning→in-progress: use "approve"\n  • review→done: use "complete"\n  • To move backward: move to "backlog" first`,
+                  text: `Cannot move to "${COLUMN_LABELS[toCol]}" directly.\n${validation.errors.map((error) => `  • ${error}`).join('\n')}`,
                 },
               ],
               details: {},
             };
           }
           card.column = toCol;
+          card.status = 'idle';
+          card.error = undefined;
+          if (toCol === 'backlog') {
+            card.completedAt = undefined;
+            card.planningProgress = undefined;
+            card.implementationProgress = undefined;
+            card.reviewProgress = undefined;
+          }
           card.updatedAt = new Date().toISOString();
           await writeState(statePath, state);
           return {

--- a/packages/pi-kanban-extension/extension/index.ts
+++ b/packages/pi-kanban-extension/extension/index.ts
@@ -17,16 +17,24 @@ import { Type } from '@sinclair/typebox';
 import type { Column, Priority } from '../shared/types';
 import { COLUMNS, COLUMN_LABELS, createCard } from '../shared/types';
 import { resolveStatePath, readState, writeState, formatCard, formatBoard } from './state-io';
+import {
+  handleStart, handleApprove, handleComplete,
+  handleRetry, handleBrainstorm, handleSettings, handleCleanup,
+} from './workflow-actions';
 
 // ── Tool parameters ────────────────────────────────────────────
 
 const KanbanParams = Type.Object({
-  action: StringEnum(['list', 'add', 'move', 'update', 'delete', 'show', 'start', 'approve', 'complete', 'retry'] as const),
+  action: StringEnum(['list', 'add', 'move', 'update', 'delete', 'show', 'start', 'approve', 'complete', 'retry', 'brainstorm', 'settings', 'cleanup'] as const),
   title: Type.Optional(Type.String({ description: 'Card title (for add)' })),
   id: Type.Optional(Type.String({ description: 'Card ID' })),
   column: Type.Optional(StringEnum(COLUMNS)),
   priority: Type.Optional(StringEnum(['critical', 'high', 'medium', 'low'] as const)),
   description: Type.Optional(Type.String({ description: 'Card description' })),
+  blockedBy: Type.Optional(Type.Array(Type.String(), { description: 'IDs of cards that must be done before this card can start' })),
+  acceptance: Type.Optional(Type.Array(Type.String(), { description: 'Acceptance criteria' })),
+  setting: Type.Optional(Type.String({ description: 'Setting name for settings action (testingEnabled, reviewLevel)' })),
+  value: Type.Optional(Type.String({ description: 'Setting value for settings action' })),
 });
 
 // ── Extension ──────────────────────────────────────────────────
@@ -47,7 +55,7 @@ export default function (pi: ExtensionAPI) {
     name: 'kanban',
     label: 'Kanban',
     description:
-      'Manage the workspace Kanban board. Actions: list (show board), add (requires title), move (requires id + column), update (requires id, optional title/description/priority), delete (requires id), show (requires id, detailed view), start (requires id — move card to planning and trigger automated analysis), approve (requires id — approve plan and advance card to in-progress), complete (requires id — mark card as done, clean up worktree), retry (requires id — re-trigger the current phase for a stuck or failed card).',
+      'Manage the workspace Kanban board. IMPORTANT: Cards are implemented by automated orchestrator subagents — do NOT implement card work yourself. Your role is to manage the board, brainstorm, and approve. Actions: list (show board), add (requires title; optional description, priority, acceptance, blockedBy), move (requires id + column — for backward moves only), update (requires id; optional title/description/priority/acceptance/blockedBy), delete (requires id), show (requires id, detailed view), start (requires id — move card to planning, triggers automated agents), approve (requires id — approve plan and advance to in-progress), complete (requires id — only from review, mark as done), retry (requires id — re-trigger current phase), brainstorm (start collaborative card creation session), settings (view/update board settings).',
     parameters: KanbanParams,
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -78,15 +86,32 @@ export default function (pi: ExtensionAPI) {
             };
           }
           const id = String(state.nextId);
+          // Validate blockedBy references if provided
+          if (params.blockedBy?.length) {
+            const missing = params.blockedBy.filter(
+              (depId) => !state.cards.some((c) => c.id === depId),
+            );
+            if (missing.length > 0) {
+              return {
+                content: [{ type: 'text', text: `Error: blockedBy references non-existent card(s): ${missing.map((id) => `#${id}`).join(', ')}` }],
+                details: {},
+              };
+            }
+          }
           const card = createCard(id, params.title, {
             description: params.description,
             priority: params.priority as Priority | undefined,
+            acceptance: params.acceptance,
+            blockedBy: params.blockedBy,
           });
           state.cards.push(card);
           state.nextId++;
           await writeState(statePath, state);
+          const blockedInfo = card.blockedBy?.length
+            ? ` (blocked by ${card.blockedBy.map((d) => `#${d}`).join(', ')})`
+            : '';
           return {
-            content: [{ type: 'text', text: `Added card #${id}: ${card.title} → Backlog` }],
+            content: [{ type: 'text', text: `Added card #${id}: ${card.title} → Backlog${blockedInfo}` }],
             details: {},
           };
         }
@@ -112,11 +137,22 @@ export default function (pi: ExtensionAPI) {
             };
           }
           const fromCol = card.column;
-          card.column = params.column as Column;
-          card.updatedAt = new Date().toISOString();
-          if (params.column === 'done' && !card.completedAt) {
-            card.completedAt = new Date().toISOString();
+          const toCol = params.column as Column;
+          // Enforce workflow — use 'start', 'approve', 'complete' for managed transitions
+          const managedTransitions = ['planning', 'in-progress', 'done'] as const;
+          if (managedTransitions.includes(toCol as typeof managedTransitions[number]) && fromCol !== toCol) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Cannot move to "${COLUMN_LABELS[toCol]}" directly. Use the proper workflow action:\n  • backlog→planning: use "start"\n  • planning→in-progress: use "approve"\n  • review→done: use "complete"\n  • To move backward: move to "backlog" first`,
+                },
+              ],
+              details: {},
+            };
           }
+          card.column = toCol;
+          card.updatedAt = new Date().toISOString();
           await writeState(statePath, state);
           return {
             content: [
@@ -155,6 +191,14 @@ export default function (pi: ExtensionAPI) {
           if (params.priority) {
             card.priority = params.priority as Priority;
             changes.push(`priority=${params.priority}`);
+          }
+          if (params.acceptance) {
+            card.acceptance = params.acceptance;
+            changes.push(`acceptance (${params.acceptance.length} criteria)`);
+          }
+          if (params.blockedBy) {
+            card.blockedBy = params.blockedBy;
+            changes.push(`blockedBy=[${params.blockedBy.map((d) => `#${d}`).join(', ')}]`);
           }
           card.updatedAt = new Date().toISOString();
           await writeState(statePath, state);
@@ -211,179 +255,30 @@ export default function (pi: ExtensionAPI) {
           };
         }
 
-        case 'start': {
-          if (!params.id) {
-            return {
-              content: [{ type: 'text', text: 'Error: id is required for start' }],
-              details: {},
-            };
-          }
-          const card = state.cards.find((c) => c.id === params.id);
-          if (!card) {
-            return {
-              content: [{ type: 'text', text: `Card #${params.id} not found` }],
-              details: {},
-            };
-          }
-          if (card.column !== 'backlog') {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: `Card #${card.id} is in "${COLUMN_LABELS[card.column]}" — only backlog cards can be started`,
-                },
-              ],
-              details: {},
-            };
-          }
-          card.column = 'planning';
-          card.status = 'agent-working';
-          card.updatedAt = new Date().toISOString();
-          await writeState(statePath, state);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Started #${card.id} "${card.title}" → Planning. Automated analysis will begin shortly.`,
-              },
-            ],
-            details: {},
-          };
-        }
+        case 'start':
+          if (!params.id) return { content: [{ type: 'text', text: 'Error: id is required for start' }], details: {} };
+          return handleStart(statePath, state, params.id);
 
-        case 'approve': {
-          if (!params.id) {
-            return {
-              content: [{ type: 'text', text: 'Error: id is required for approve' }],
-              details: {},
-            };
-          }
-          const card = state.cards.find((c) => c.id === params.id);
-          if (!card) {
-            return {
-              content: [{ type: 'text', text: `Card #${params.id} not found` }],
-              details: {},
-            };
-          }
-          if (card.column !== 'planning' || card.status !== 'waiting-input') {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: `Card #${card.id} is not awaiting approval (column: ${card.column}, status: ${card.status})`,
-                },
-              ],
-              details: {},
-            };
-          }
-          card.column = 'in-progress';
-          card.status = 'idle';
-          card.updatedAt = new Date().toISOString();
-          await writeState(statePath, state);
+        case 'approve':
+          if (!params.id) return { content: [{ type: 'text', text: 'Error: id is required for approve' }], details: {} };
+          return handleApprove(statePath, state, params.id);
 
-          const subtaskInfo = card.subtasks.length > 0
-            ? ` with ${card.subtasks.length} subtasks`
-            : '';
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Approved #${card.id} "${card.title}" → In Progress${subtaskInfo}`,
-              },
-            ],
-            details: {},
-          };
-        }
+        case 'complete':
+          if (!params.id) return { content: [{ type: 'text', text: 'Error: id is required for complete' }], details: {} };
+          return handleComplete(statePath, state, params.id);
 
-        case 'retry': {
-          if (!params.id) {
-            return {
-              content: [{ type: 'text', text: 'Error: id is required for retry' }],
-              details: {},
-            };
-          }
-          const card = state.cards.find((c) => c.id === params.id);
-          if (!card) {
-            return {
-              content: [{ type: 'text', text: `Card #${params.id} not found` }],
-              details: {},
-            };
-          }
-          const retryableColumns: Column[] = ['planning', 'in-progress', 'review'];
-          if (!retryableColumns.includes(card.column)) {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: `Card #${card.id} is in "${COLUMN_LABELS[card.column]}" — retry only works for planning, in-progress, or review cards`,
-                },
-              ],
-              details: {},
-            };
-          }
-          if (card.status === 'agent-working') {
-            return {
-              content: [
-                {
-                  type: 'text',
-                  text: `Card #${card.id} is already being processed (status: agent-working)`,
-                },
-              ],
-              details: {},
-            };
-          }
-          card.status = 'agent-working';
-          card.error = undefined;
-          card.updatedAt = new Date().toISOString();
-          await writeState(statePath, state);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Retrying #${card.id} "${card.title}" in ${COLUMN_LABELS[card.column]}. Orchestrator will pick it up shortly.`,
-              },
-            ],
-            details: {},
-          };
-        }
+        case 'retry':
+          if (!params.id) return { content: [{ type: 'text', text: 'Error: id is required for retry' }], details: {} };
+          return handleRetry(statePath, state, params.id);
 
-        case 'complete': {
-          if (!params.id) {
-            return {
-              content: [{ type: 'text', text: 'Error: id is required for complete' }],
-              details: {},
-            };
-          }
-          const card = state.cards.find((c) => c.id === params.id);
-          if (!card) {
-            return {
-              content: [{ type: 'text', text: `Card #${params.id} not found` }],
-              details: {},
-            };
-          }
-          if (card.column === 'done') {
-            return {
-              content: [{ type: 'text', text: `Card #${card.id} is already done` }],
-              details: {},
-            };
-          }
-          card.column = 'done';
-          card.status = 'idle';
-          card.completedAt = card.completedAt ?? new Date().toISOString();
-          card.updatedAt = new Date().toISOString();
-          await writeState(statePath, state);
+        case 'brainstorm':
+          return handleBrainstorm(pi);
 
-          const prInfo = card.prUrl ? ` (PR: ${card.prUrl})` : '';
-          return {
-            content: [
-              {
-                type: 'text',
-                text: `Completed #${card.id} "${card.title}" → Done${prInfo}`,
-              },
-            ],
-            details: {},
-          };
-        }
+        case 'settings':
+          return handleSettings(statePath, state, params.setting, params.value);
+
+        case 'cleanup':
+          return handleCleanup(statePath, state, resolvedPath);
 
         default:
           return {

--- a/packages/pi-kanban-extension/extension/state-io.ts
+++ b/packages/pi-kanban-extension/extension/state-io.ts
@@ -52,11 +52,17 @@ export function formatCard(card: Card, verbose = false): string {
     card.status === 'waiting-input' ? ' [waiting]' :
     card.status === 'paused' ? ' [paused]' :
     card.status === 'failed' ? ' [FAILED]' : '';
+  const blocked = card.blockedBy?.length
+    ? ` 🔒 blocked by ${card.blockedBy.map((d) => `#${d}`).join(', ')}`
+    : '';
 
-  let line = `#${card.id} ${priority ? `(${priority}) ` : ''}${card.title} — ${COLUMN_LABELS[card.column]}${status}`;
+  let line = `#${card.id} ${priority ? `(${priority}) ` : ''}${card.title} — ${COLUMN_LABELS[card.column]}${status}${blocked}`;
 
   if (verbose) {
     if (card.description) line += `\n   ${card.description}`;
+    if (card.acceptance.length > 0) {
+      line += `\n   Acceptance: ${card.acceptance.map((a) => `✓ ${a}`).join('; ')}`;
+    }
     if (card.subtasks.length > 0) {
       const done = card.subtasks.filter((s) => s.status === 'completed').length;
       line += `\n   Subtasks: ${done}/${card.subtasks.length}`;

--- a/packages/pi-kanban-extension/extension/workflow-actions.ts
+++ b/packages/pi-kanban-extension/extension/workflow-actions.ts
@@ -1,0 +1,212 @@
+/**
+ * Kanban workflow action handlers — start, approve, complete, retry, brainstorm, settings.
+ *
+ * Extracted from index.ts for file size compliance.
+ */
+
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+import { promises as fsPromises } from 'node:fs';
+import path from 'node:path';
+
+import type { KanbanState, Column } from '../shared/types';
+import { COLUMN_LABELS } from '../shared/types';
+import { validateCardTransition } from '../shared/validation';
+import { readState, writeState } from './state-io';
+
+type ToolResult = { content: { type: 'text'; text: string }[]; details: Record<string, never> };
+
+function text(msg: string): ToolResult {
+  return { content: [{ type: 'text', text: msg }], details: {} };
+}
+
+// ── Start ────────────────────────────────────────────────────
+
+export async function handleStart(
+  statePath: string, state: KanbanState, id: string,
+): Promise<ToolResult> {
+  const card = state.cards.find((c) => c.id === id);
+  if (!card) return text(`Card #${id} not found`);
+
+  if (card.column !== 'backlog') {
+    return text(`Card #${card.id} is in "${COLUMN_LABELS[card.column]}" — only backlog cards can be started`);
+  }
+
+  const validation = validateCardTransition(card, 'planning', state);
+  if (!validation.valid) {
+    return text(`Cannot start card #${card.id}:\n${validation.errors.map((e) => `  • ${e}`).join('\n')}`);
+  }
+
+  card.column = 'planning';
+  card.status = 'agent-working';
+  card.updatedAt = new Date().toISOString();
+  await writeState(statePath, state);
+  return text(`Started #${card.id} "${card.title}" → Planning. Automated analysis will begin shortly.`);
+}
+
+// ── Approve ──────────────────────────────────────────────────
+
+export async function handleApprove(
+  statePath: string, state: KanbanState, id: string,
+): Promise<ToolResult> {
+  const card = state.cards.find((c) => c.id === id);
+  if (!card) return text(`Card #${id} not found`);
+
+  const validation = validateCardTransition(card, 'in-progress');
+  if (!validation.valid) {
+    return text(`Cannot approve card #${card.id}:\n${validation.errors.map((e) => `  • ${e}`).join('\n')}`);
+  }
+
+  card.column = 'in-progress';
+  card.status = 'idle';
+  card.updatedAt = new Date().toISOString();
+  await writeState(statePath, state);
+
+  const subtaskInfo = card.subtasks.length > 0 ? ` with ${card.subtasks.length} subtasks` : '';
+  return text(`Approved #${card.id} "${card.title}" → In Progress${subtaskInfo}`);
+}
+
+// ── Complete ─────────────────────────────────────────────────
+
+export async function handleComplete(
+  statePath: string, state: KanbanState, id: string,
+): Promise<ToolResult> {
+  const card = state.cards.find((c) => c.id === id);
+  if (!card) return text(`Card #${id} not found`);
+
+  if (card.column === 'done') return text(`Card #${card.id} is already done`);
+
+  // Cards must go through the full workflow — only review→done is allowed
+  if (card.column !== 'review') {
+    return text(
+      `Card #${card.id} is in "${COLUMN_LABELS[card.column]}" — only cards in Review can be completed. `
+      + 'Cards must go through the full workflow: Backlog → Planning → In Progress → Review → Done.',
+    );
+  }
+
+  const validation = validateCardTransition(card, 'done');
+  if (!validation.valid) {
+    return text(`Cannot complete card #${card.id}:\n${validation.errors.map((e) => `  • ${e}`).join('\n')}`);
+  }
+
+  card.column = 'done';
+  card.status = 'idle';
+  card.completedAt = card.completedAt ?? new Date().toISOString();
+  card.updatedAt = new Date().toISOString();
+  await writeState(statePath, state);
+
+  const prInfo = card.prUrl ? ` (PR: ${card.prUrl})` : '';
+  return text(`Completed #${card.id} "${card.title}" → Done${prInfo}`);
+}
+
+// ── Retry ────────────────────────────────────────────────────
+
+export async function handleRetry(
+  statePath: string, state: KanbanState, id: string,
+): Promise<ToolResult> {
+  const card = state.cards.find((c) => c.id === id);
+  if (!card) return text(`Card #${id} not found`);
+
+  const retryableColumns: Column[] = ['planning', 'in-progress', 'review'];
+  if (!retryableColumns.includes(card.column)) {
+    return text(`Card #${card.id} is in "${COLUMN_LABELS[card.column]}" — retry only works for planning, in-progress, or review cards`);
+  }
+  if (card.status === 'agent-working') {
+    return text(`Card #${card.id} is already being processed (status: agent-working)`);
+  }
+
+  card.status = 'agent-working';
+  card.error = undefined;
+  card.updatedAt = new Date().toISOString();
+  await writeState(statePath, state);
+  return text(`Retrying #${card.id} "${card.title}" in ${COLUMN_LABELS[card.column]}. Orchestrator will pick it up shortly.`);
+}
+
+// ── Brainstorm ───────────────────────────────────────────────
+
+export function handleBrainstorm(pi: ExtensionAPI): ToolResult {
+  pi.sendUserMessage(
+    'I want to brainstorm new features for this project. '
+    + 'Follow the /brainstorm workflow: read the workspace context, '
+    + 'ask me questions one at a time to refine the idea, propose approaches, '
+    + 'and create well-scoped kanban cards when we\'re done. '
+    + 'IMPORTANT: After creating the cards, your job is DONE. '
+    + 'Do NOT implement any code yourself — the kanban orchestrator\'s '
+    + 'automated subagents handle all implementation. Just use "kanban start" '
+    + 'to kick off the first card and let the automation take over.',
+  );
+  return text('Brainstorming session started — check the chat panel.');
+}
+
+// ── Settings ─────────────────────────────────────────────────
+
+export async function handleSettings(
+  statePath: string,
+  state: KanbanState,
+  setting?: string,
+  value?: string,
+): Promise<ToolResult> {
+  if (!setting) {
+    const s = state.settings;
+    return text(
+      `## Board Settings\n- yoloMode: ${s.yoloMode} (auto-start, auto-approve, auto-complete)\n`
+      + `- testingEnabled: ${s.testingEnabled} (TDD and test generation)\n`
+      + `- reviewLevel: ${s.reviewLevel} (per-wave or per-subtask)\n`
+      + `- autoAdvance: ${s.autoAdvance}\n- maxConcurrentCards: ${s.maxConcurrentCards}`,
+    );
+  }
+
+  if (setting === 'yoloMode') {
+    state.settings.yoloMode = value !== 'false';
+    await writeState(statePath, state);
+    return text(`YOLO mode ${state.settings.yoloMode ? 'ON — full auto, no human gates' : 'OFF — human approval required'}`);
+  }
+  if (setting === 'testingEnabled') {
+    state.settings.testingEnabled = value !== 'false';
+    await writeState(statePath, state);
+    return text(`Mode: ${state.settings.testingEnabled ? 'Production (TDD enabled)' : 'Prototype (testing disabled)'}`);
+  }
+  if (setting === 'reviewLevel' && (value === 'per-wave' || value === 'per-subtask')) {
+    state.settings.reviewLevel = value;
+    await writeState(statePath, state);
+    return text(`Review level set to: ${value}`);
+  }
+
+  return text(`Unknown setting "${setting}". Available: yoloMode, testingEnabled, reviewLevel`);
+}
+
+// ── Cleanup ──────────────────────────────────────────────────
+
+export async function handleCleanup(
+  statePath: string,
+  state: KanbanState,
+  cwd: string,
+): Promise<ToolResult> {
+  const doneCards = state.cards.filter((c) => c.column === 'done' && c.worktreePath);
+  if (doneCards.length === 0) {
+    return text('No worktrees to clean up — all done cards already cleaned.');
+  }
+
+  const notDone = state.cards.filter((c) => c.column !== 'done');
+  if (notDone.length > 0) {
+    return text(
+      `Cannot clean up worktrees — ${notDone.length} card(s) still in progress:\n`
+      + notDone.map((c) => `  • #${c.id} "${c.title}" (${COLUMN_LABELS[c.column]})`).join('\n')
+      + '\n\nWait until all cards are done before cleaning up.',
+    );
+  }
+
+  // All cards done — remove worktrees
+  const cleaned: string[] = [];
+  for (const card of doneCards) {
+    if (!card.worktreePath) continue;
+    try {
+      await fsPromises.rm(card.worktreePath, { recursive: true, force: true });
+      card.worktreePath = undefined;
+      cleaned.push(`#${card.id}`);
+    } catch { /* already gone */ }
+  }
+
+  await writeState(statePath, state);
+  return text(`Cleaned up ${cleaned.length} worktree(s): ${cleaned.join(', ')}`);
+}

--- a/packages/pi-kanban-extension/extension/workflow-actions.ts
+++ b/packages/pi-kanban-extension/extension/workflow-actions.ts
@@ -6,8 +6,9 @@
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
+import { execFile } from 'node:child_process';
 import { promises as fsPromises } from 'node:fs';
-import path from 'node:path';
+import { promisify } from 'node:util';
 
 import type { KanbanState, Column } from '../shared/types';
 import { COLUMN_LABELS } from '../shared/types';
@@ -15,6 +16,8 @@ import { validateCardTransition } from '../shared/validation';
 import { readState, writeState } from './state-io';
 
 type ToolResult = { content: { type: 'text'; text: string }[]; details: Record<string, never> };
+
+const execFileAsync = promisify(execFile);
 
 function text(msg: string): ToolResult {
   return { content: [{ type: 'text', text: msg }], details: {} };
@@ -201,10 +204,24 @@ export async function handleCleanup(
   for (const card of doneCards) {
     if (!card.worktreePath) continue;
     try {
+      await execFileAsync('git', ['worktree', 'remove', card.worktreePath, '--force'], {
+        cwd,
+        timeout: 15_000,
+      });
+      await execFileAsync('git', ['worktree', 'prune'], {
+        cwd,
+        timeout: 10_000,
+      }).catch(() => {});
+    } catch {
       await fsPromises.rm(card.worktreePath, { recursive: true, force: true });
+      await execFileAsync('git', ['worktree', 'prune'], {
+        cwd,
+        timeout: 10_000,
+      }).catch(() => {});
+    } finally {
       card.worktreePath = undefined;
       cleaned.push(`#${card.id}`);
-    } catch { /* already gone */ }
+    }
   }
 
   await writeState(statePath, state);

--- a/packages/pi-kanban-extension/extension/workflow-actions.ts
+++ b/packages/pi-kanban-extension/extension/workflow-actions.ts
@@ -13,7 +13,7 @@ import { promisify } from 'node:util';
 import type { KanbanState, Column } from '../shared/types';
 import { COLUMN_LABELS } from '../shared/types';
 import { validateCardTransition } from '../shared/validation';
-import { readState, writeState } from './state-io';
+import { writeState } from './state-io';
 
 type ToolResult = { content: { type: 'text'; text: string }[]; details: Record<string, never> };
 
@@ -160,12 +160,12 @@ export async function handleSettings(
   }
 
   if (setting === 'yoloMode') {
-    state.settings.yoloMode = value !== 'false';
+    state.settings.yoloMode = value === 'true';
     await writeState(statePath, state);
     return text(`YOLO mode ${state.settings.yoloMode ? 'ON — full auto, no human gates' : 'OFF — human approval required'}`);
   }
   if (setting === 'testingEnabled') {
-    state.settings.testingEnabled = value !== 'false';
+    state.settings.testingEnabled = value === 'true';
     await writeState(statePath, state);
     return text(`Mode: ${state.settings.testingEnabled ? 'Production (TDD enabled)' : 'Prototype (testing disabled)'}`);
   }

--- a/packages/pi-kanban-extension/package.json
+++ b/packages/pi-kanban-extension/package.json
@@ -13,6 +13,10 @@
   "pi": {
     "extensions": [
       "./extension/index.ts"
+    ],
+    "prompts": [
+      "./prompts/brainstorm.md",
+      "./prompts/card-enhance.md"
     ]
   },
   "sero": {

--- a/packages/pi-kanban-extension/prompts/brainstorm.md
+++ b/packages/pi-kanban-extension/prompts/brainstorm.md
@@ -1,0 +1,62 @@
+---
+name: brainstorm
+description: Brainstorm new features and create well-scoped kanban cards
+---
+
+You are starting a brainstorming session to help the user refine an idea into well-scoped, implementable kanban cards.
+
+## Process
+
+### 1. Read Workspace Context
+Before asking questions, quickly assess:
+- Recent git commits (last 10) to understand current momentum
+- Project structure (top-level files and directories)
+- Existing kanban cards (use the `kanban list` tool)
+
+### 2. Probe the Idea
+Use the **`questionnaire`** tool to ask the user questions — it presents a clean multi-tab interface for structured input. Group related questions together in a single questionnaire call (2-4 questions per call is ideal). Each question should have concrete options to pick from plus an "other" free-text option.
+
+Key areas to cover:
+- **Purpose**: What problem does this solve? Who benefits?
+- **Constraints**: What must NOT change? What's out of scope?
+- **Success criteria**: How will we know it's done?
+- **Scope**: What's the minimal viable version?
+
+Do NOT use the `question` tool — always use `questionnaire` for structured multi-option input.
+
+### 3. Propose Approaches
+Present 2-3 implementation approaches with trade-offs:
+- Lead with your recommendation
+- Keep each option to 2-3 sentences
+- Note which is simplest, most scalable, most maintainable
+
+### 4. Validate Incrementally
+Once an approach is chosen:
+- Present the design in 200-300 word sections
+- Check after each section before continuing
+- Apply YAGNI — don't over-engineer
+
+### 5. Generate Cards
+Once the design is validated, create kanban cards using the `kanban` tool:
+- Each card should have a clear title, description, and acceptance criteria
+- Set priority based on the discussion
+- Use `blockedBy` to model dependencies between cards
+- Cards should be independently implementable where possible
+- Aim for cards scoped to 1-4 hours of work each
+
+Use the `kanban add` action with `title`, `description`, `acceptance`, `priority`, and `blockedBy` parameters to create each card.
+
+## After Creating Cards
+Once you've created the cards using the kanban tool:
+1. Use `kanban start` on the first unblocked card to kick off automated planning
+2. Tell the user you're done — the orchestrator will handle implementation
+3. **STOP** — do NOT write any code, create any files, or implement anything yourself
+4. The kanban orchestrator has automated subagents (analyst, scout, planner, implementer, reviewer) that handle the entire development lifecycle
+5. Your role is board management only — brainstorm, create cards, start them, approve plans
+
+## Guidelines
+- Be concise — this is a working session, not a document
+- Challenge assumptions — ask "do we really need X?"
+- Suggest simpler alternatives when the scope grows
+- Keep the conversation moving — don't repeat what's been agreed
+- NEVER implement card work yourself — that's what the automated pipeline is for

--- a/packages/pi-kanban-extension/prompts/card-enhance.md
+++ b/packages/pi-kanban-extension/prompts/card-enhance.md
@@ -1,0 +1,26 @@
+---
+name: card-enhance
+description: Refine and improve an existing kanban card's description and acceptance criteria
+---
+
+You are helping the user refine an existing kanban card to make it more implementable.
+
+## Process
+
+1. **Read the card** using `kanban show <id>` to see current state
+2. **Assess gaps**: What's missing or vague in the description and acceptance criteria?
+3. **Ask focused questions** to fill gaps (one at a time, prefer multiple choice)
+4. **Update the card** using `kanban update` with improved description and acceptance criteria
+
+## Quality Checklist
+A well-formed card has:
+- [ ] Clear, specific title (what, not how)
+- [ ] Description explaining the problem/need (2-4 sentences)
+- [ ] At least 3 acceptance criteria (testable, specific)
+- [ ] Appropriate priority level
+- [ ] Dependencies identified (blockedBy set if needed)
+
+## Guidelines
+- Don't rewrite from scratch — enhance what's there
+- Keep acceptance criteria testable ("User can X" not "X works well")
+- Flag if the card is too large and suggest splitting

--- a/packages/pi-kanban-extension/shared/types.ts
+++ b/packages/pi-kanban-extension/shared/types.ts
@@ -15,6 +15,16 @@ export interface Subtask {
   description: string;
   status: 'pending' | 'in-progress' | 'completed' | 'failed';
   dependsOn: string[]; // IDs of subtasks that must complete first
+  /** TDD scenario designation: 'tdd' = write tests first, 'test-after' = tests after, 'no-test' = skip */
+  tddDesignation?: 'tdd' | 'test-after' | 'no-test';
+  /** File paths this subtask creates or modifies */
+  filePaths?: string[];
+  /** Estimated complexity: low (~15min), medium (~30min), high (~45min+) */
+  complexity?: 'low' | 'medium' | 'high';
+  /** Spec review status (per-subtask review mode) */
+  specReviewStatus?: 'pending' | 'passed' | 'failed';
+  /** Quality review status (per-subtask review mode) */
+  qualityReviewStatus?: 'pending' | 'passed' | 'failed';
   agentRunId?: string; // Subagent entry ID (for progress tracking)
   checkpointId?: string; // VCS checkpoint after completion
 }
@@ -59,6 +69,8 @@ export interface Card {
   priority: Priority;
   column: Column;
   status: CardStatus;
+  /** IDs of cards that must be in 'done' before this card can start */
+  blockedBy?: string[];
   branch?: string; // Git branch name
   worktreePath?: string; // Absolute path to git worktree for this card
   sessionId?: string; // Sero session driving work
@@ -84,6 +96,12 @@ export interface KanbanSettings {
     plan: boolean; // Pause after planning for approval
     pr: boolean; // Pause before creating PR
   };
+  /** Review rigour: 'per-wave' (default) or 'per-subtask' (two-stage) */
+  reviewLevel: 'per-wave' | 'per-subtask';
+  /** Whether TDD and testing are enabled (default: true). false = POC mode */
+  testingEnabled: boolean;
+  /** YOLO mode: auto-start, auto-approve, auto-complete — no human gates */
+  yoloMode: boolean;
 }
 
 export interface KanbanState {
@@ -119,13 +137,16 @@ export const DEFAULT_KANBAN_STATE: KanbanState = {
       plan: true,
       pr: true,
     },
+    reviewLevel: 'per-wave',
+    testingEnabled: true,
+    yoloMode: false,
   },
 };
 
 export function createCard(
   id: string,
   title: string,
-  opts?: Partial<Pick<Card, 'description' | 'priority' | 'acceptance'>>,
+  opts?: Partial<Pick<Card, 'description' | 'priority' | 'acceptance' | 'blockedBy'>>,
 ): Card {
   const now = new Date().toISOString();
   return {
@@ -136,6 +157,7 @@ export function createCard(
     priority: opts?.priority ?? 'medium',
     column: 'backlog',
     status: 'idle',
+    blockedBy: opts?.blockedBy ?? [],
     subtasks: [],
     createdAt: now,
     updatedAt: now,

--- a/packages/pi-kanban-extension/shared/validation.ts
+++ b/packages/pi-kanban-extension/shared/validation.ts
@@ -1,8 +1,13 @@
 /**
- * Lightweight transition validation for kanban cards.
+ * Kanban transition validation — SINGLE SOURCE OF TRUTH.
  *
- * Shared between the Pi extension (CLI) and can be used by the web UI.
- * Mirrors the host-side contracts logic without importing host modules.
+ * Used by:
+ * - Extension CLI (workflow-actions.ts)
+ * - Web UI (card-workflow.ts, CardDetail.tsx)
+ * - Host orchestrator (contracts.ts re-exports from here)
+ *
+ * If you change validation rules here, the host-side contracts.ts will
+ * pick them up automatically — do NOT duplicate rules elsewhere.
  */
 
 import type { Card, Column, KanbanState } from './types';
@@ -12,8 +17,13 @@ export interface ValidationResult {
   errors: string[];
 }
 
+// ── Transition Validation ────────────────────────────────────
+
 /**
  * Validate whether a card meets the requirements to transition to `targetColumn`.
+ *
+ * Returns `{ valid: true }` for transitions that have no contract
+ * (e.g. manual moves back to backlog).
  */
 export function validateCardTransition(
   card: Card,
@@ -33,15 +43,10 @@ export function validateCardTransition(
     if (card.acceptance.length < 1) {
       errors.push('Card must have at least 1 acceptance criterion');
     }
-    // Check card-to-card dependencies
-    if (card.blockedBy && card.blockedBy.length > 0 && state) {
-      const unmet = card.blockedBy.filter((depId) => {
-        const dep = state.cards.find((c) => c.id === depId);
-        return !dep || dep.column !== 'done';
-      });
-      if (unmet.length > 0) {
-        errors.push(`Blocked by card(s) not yet done: ${unmet.map((id) => `#${id}`).join(', ')}`);
-      }
+    // Card-to-card dependencies
+    const unmet = getUnmetDependencies(card, state);
+    if (unmet.length > 0) {
+      errors.push(`Blocked by card(s) not yet done: ${unmet.map((id) => `#${id}`).join(', ')}`);
     }
   }
 
@@ -57,6 +62,15 @@ export function validateCardTransition(
     }
   }
 
+  if (from === 'in-progress' && targetColumn === 'review') {
+    if (card.subtasks.length === 0 || !card.subtasks.every((s) => s.status === 'completed')) {
+      errors.push('All subtasks must be completed before review');
+    }
+    if (!card.worktreePath) {
+      errors.push('Card must have a worktree with changes');
+    }
+  }
+
   if (from === 'review' && targetColumn === 'done') {
     if (card.status !== 'waiting-input') {
       errors.push('Card must be awaiting human confirmation (status: waiting-input)');
@@ -65,6 +79,24 @@ export function validateCardTransition(
 
   return { valid: errors.length === 0, errors };
 }
+
+// ── Dependency Helpers ───────────────────────────────────────
+
+/**
+ * Returns IDs of cards in the blockedBy list that are NOT in the 'done' column.
+ * If no state is provided, returns empty (can't check).
+ */
+export function getUnmetDependencies(card: Card, state?: KanbanState): string[] {
+  if (!card.blockedBy || card.blockedBy.length === 0 || !state) return [];
+
+  return card.blockedBy.filter((depId) => {
+    const depCard = state.cards.find((c) => c.id === depId);
+    // If the blocking card doesn't exist, treat as unmet (safety)
+    return !depCard || depCard.column !== 'done';
+  });
+}
+
+// ── Manual Move Validation ───────────────────────────────────
 
 /**
  * Manual moves are intentionally limited to moving a card back to backlog.

--- a/packages/pi-kanban-extension/shared/validation.ts
+++ b/packages/pi-kanban-extension/shared/validation.ts
@@ -1,0 +1,67 @@
+/**
+ * Lightweight transition validation for kanban cards.
+ *
+ * Shared between the Pi extension (CLI) and can be used by the web UI.
+ * Mirrors the host-side contracts logic without importing host modules.
+ */
+
+import type { Card, Column, KanbanState } from './types';
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate whether a card meets the requirements to transition to `targetColumn`.
+ */
+export function validateCardTransition(
+  card: Card,
+  targetColumn: Column,
+  state?: KanbanState,
+): ValidationResult {
+  const errors: string[] = [];
+  const from = card.column;
+
+  if (from === 'backlog' && targetColumn === 'planning') {
+    if (!card.title.trim()) {
+      errors.push('Card must have a title before starting planning');
+    }
+    if (!card.description.trim()) {
+      errors.push('Card must have a description (at least a sentence explaining the intent)');
+    }
+    if (card.acceptance.length < 1) {
+      errors.push('Card must have at least 1 acceptance criterion');
+    }
+    // Check card-to-card dependencies
+    if (card.blockedBy && card.blockedBy.length > 0 && state) {
+      const unmet = card.blockedBy.filter((depId) => {
+        const dep = state.cards.find((c) => c.id === depId);
+        return !dep || dep.column !== 'done';
+      });
+      if (unmet.length > 0) {
+        errors.push(`Blocked by card(s) not yet done: ${unmet.map((id) => `#${id}`).join(', ')}`);
+      }
+    }
+  }
+
+  if (from === 'planning' && targetColumn === 'in-progress') {
+    if (!card.plan?.trim()) {
+      errors.push('Card must have a plan before starting implementation');
+    }
+    if (card.subtasks.length < 1) {
+      errors.push('Card must have at least 1 subtask');
+    }
+    if (card.status !== 'waiting-input') {
+      errors.push('Card must be awaiting approval (status: waiting-input)');
+    }
+  }
+
+  if (from === 'review' && targetColumn === 'done') {
+    if (card.status !== 'waiting-input') {
+      errors.push('Card must be awaiting human confirmation (status: waiting-input)');
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}

--- a/packages/pi-kanban-extension/shared/validation.ts
+++ b/packages/pi-kanban-extension/shared/validation.ts
@@ -65,3 +65,30 @@ export function validateCardTransition(
 
   return { valid: errors.length === 0, errors };
 }
+
+/**
+ * Manual moves are intentionally limited to moving a card back to backlog.
+ * Forward workflow transitions must use the dedicated start/approve/complete
+ * actions so validation and orchestration stay consistent.
+ */
+export function getManualMoveTargets(card: Card): Column[] {
+  return card.column === 'backlog' ? [] : ['backlog'];
+}
+
+export function validateManualMove(card: Card, targetColumn: Column): ValidationResult {
+  if (targetColumn === card.column) {
+    return { valid: true, errors: [] };
+  }
+
+  if (targetColumn === 'backlog' && card.column !== 'backlog') {
+    return { valid: true, errors: [] };
+  }
+
+  return {
+    valid: false,
+    errors: [
+      'Manual moves only support sending a card back to Backlog. '
+      + 'Use the workflow actions for Start, Approve, and Complete.',
+    ],
+  };
+}

--- a/packages/pi-kanban-extension/ui/KanbanApp.tsx
+++ b/packages/pi-kanban-extension/ui/KanbanApp.tsx
@@ -20,6 +20,7 @@ import {
   PRIORITY_ORDER,
   createCard,
 } from '../shared/types';
+import { applyManualMove } from './lib/card-workflow';
 import { ColumnView } from './components/ColumnView';
 import { CardDetail } from './components/CardDetail';
 
@@ -154,21 +155,11 @@ export function KanbanApp() {
 
   const handleDropCard = useCallback(
     (cardId: string, toColumn: Column) => {
-      updateState((prev) => ({
-        ...prev,
-        cards: prev.cards.map((c) =>
-          c.id === cardId
-            ? {
-                ...c,
-                column: toColumn,
-                updatedAt: new Date().toISOString(),
-                ...(toColumn === 'done' && !c.completedAt
-                  ? { completedAt: new Date().toISOString() }
-                  : {}),
-              }
-            : c,
-        ),
-      }));
+      updateState((prev) => {
+        const card = prev.cards.find((entry) => entry.id === cardId);
+        if (!card || card.column === toColumn) return prev;
+        return applyManualMove(prev, cardId, toColumn);
+      });
     },
     [updateState],
   );

--- a/packages/pi-kanban-extension/ui/KanbanApp.tsx
+++ b/packages/pi-kanban-extension/ui/KanbanApp.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { motion } from 'motion/react';
-import { useAppState } from '@sero/app-runtime';
+import { useAppState, useAgentPrompt } from '@sero/app-runtime';
 import type { KanbanState, Card, Column, Priority } from '../shared/types';
 import {
   DEFAULT_KANBAN_STATE,
@@ -181,6 +181,12 @@ export function KanbanApp() {
     setSelectedCard(null);
   }, []);
 
+  // Brainstorm — sends command to the agent via ChatPanel
+  const promptAgent = useAgentPrompt();
+  const handleBrainstorm = useCallback(() => {
+    promptAgent('Using the kanban tool: brainstorm');
+  }, [promptAgent]);
+
   // Summary stats
   const totalCards = state.cards.length;
   const activeCards = state.cards.filter(
@@ -207,6 +213,51 @@ export function KanbanApp() {
                 <Stat label="done" value={doneCards} color="text-emerald-400" />
               </div>
             )}
+          </div>
+          <div className="flex items-center gap-2">
+            {/* YOLO mode toggle */}
+            <button
+              onClick={() => updateState((prev) => ({
+                ...prev,
+                settings: { ...prev.settings, yoloMode: !prev.settings.yoloMode },
+              }))}
+              className={`px-2.5 py-1.5 text-[11px] font-medium rounded-md border cursor-pointer
+                transition-colors duration-150
+                ${state.settings.yoloMode
+                  ? 'bg-red-500/15 text-red-400 border-red-500/30 hover:bg-red-500/25'
+                  : 'bg-zinc-500/10 text-zinc-400 border-zinc-500/20 hover:bg-zinc-500/15'}`}
+              title={state.settings.yoloMode
+                ? 'YOLO mode ON — auto-starts, auto-approves, auto-completes. Click to disable.'
+                : 'YOLO mode OFF — human approval required at each stage. Click to enable.'}
+            >
+              {state.settings.yoloMode ? '🔥 YOLO' : '🔒 YOLO'}
+            </button>
+            {/* Mode toggle */}
+            <button
+              onClick={() => updateState((prev) => ({
+                ...prev,
+                settings: { ...prev.settings, testingEnabled: !prev.settings.testingEnabled },
+              }))}
+              className={`px-2.5 py-1.5 text-[11px] font-medium rounded-md border cursor-pointer
+                transition-colors duration-150
+                ${state.settings.testingEnabled
+                  ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30 hover:bg-emerald-500/20'
+                  : 'bg-amber-500/10 text-amber-400 border-amber-500/30 hover:bg-amber-500/20'}`}
+              title={state.settings.testingEnabled
+                ? 'Production mode — TDD and test generation enabled'
+                : 'Prototype mode — testing disabled for fast iteration'}
+            >
+              Mode: {state.settings.testingEnabled ? 'Production' : 'Prototype'}
+            </button>
+            <button
+              onClick={handleBrainstorm}
+              className="px-3 py-1.5 text-xs font-medium rounded-md
+                bg-[var(--kb-accent-glow)] text-[var(--kb-accent)] border border-[var(--kb-border)]
+                hover:bg-[var(--kb-accent)] hover:text-white
+                transition-colors duration-150 cursor-pointer"
+            >
+              ✨ Brainstorm
+            </button>
           </div>
         </div>
 

--- a/packages/pi-kanban-extension/ui/components/CardDetail.tsx
+++ b/packages/pi-kanban-extension/ui/components/CardDetail.tsx
@@ -328,7 +328,16 @@ export function CardDetail({
                     )}
                     {card.prUrl && (
                       <p>
-                        PR: <span className="font-medium" style={{ color: '#34d399' }}>#{card.prNumber}</span>
+                        PR:{' '}
+                        <a
+                          href={card.prUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-medium"
+                          style={{ color: '#34d399', textDecoration: 'underline', textUnderlineOffset: '2px' }}
+                        >
+                          #{card.prNumber}
+                        </a>
                       </p>
                     )}
                   </div>

--- a/packages/pi-kanban-extension/ui/components/CardDetail.tsx
+++ b/packages/pi-kanban-extension/ui/components/CardDetail.tsx
@@ -19,6 +19,8 @@ import { ReviewStatusPanel } from './ReviewStatusPanel';
 import { PlanApprovalPanel } from './PlanApprovalPanel';
 import { DescriptionEditor } from './DescriptionEditor';
 import { CardDetailFooter } from './CardDetailFooter';
+import { applyManualMove, applyWorkflowTransition } from '../lib/card-workflow';
+import { getManualMoveTargets } from '../../shared/validation';
 
 export function CardDetail({
   card,
@@ -32,21 +34,7 @@ export function CardDetail({
   const handleMove = useCallback(
     (column: Column) => {
       if (!card) return;
-      onUpdate((prev) => ({
-        ...prev,
-        cards: prev.cards.map((c) =>
-          c.id === card.id
-            ? {
-                ...c,
-                column,
-                updatedAt: new Date().toISOString(),
-                ...(column === 'done' && !c.completedAt
-                  ? { completedAt: new Date().toISOString() }
-                  : {}),
-              }
-            : c,
-        ),
-      }));
+      onUpdate((prev) => applyManualMove(prev, card.id, column));
     },
     [card, onUpdate],
   );
@@ -68,54 +56,17 @@ export function CardDetail({
 
   const handleStartPlanning = useCallback(() => {
     if (!card) return;
-    onUpdate((prev) => ({
-      ...prev,
-      cards: prev.cards.map((c) =>
-        c.id === card.id
-          ? {
-              ...c,
-              column: 'planning' as Column,
-              status: 'agent-working' as const,
-              updatedAt: new Date().toISOString(),
-            }
-          : c,
-      ),
-    }));
+    onUpdate((prev) => applyWorkflowTransition(prev, card.id, 'planning'));
   }, [card, onUpdate]);
 
   const handleApprovePlan = useCallback(() => {
     if (!card) return;
-    onUpdate((prev) => ({
-      ...prev,
-      cards: prev.cards.map((c) =>
-        c.id === card.id
-          ? {
-              ...c,
-              column: 'in-progress' as Column,
-              status: 'idle' as const,
-              updatedAt: new Date().toISOString(),
-            }
-          : c,
-      ),
-    }));
+    onUpdate((prev) => applyWorkflowTransition(prev, card.id, 'in-progress'));
   }, [card, onUpdate]);
 
   const handleComplete = useCallback(() => {
     if (!card) return;
-    onUpdate((prev) => ({
-      ...prev,
-      cards: prev.cards.map((c) =>
-        c.id === card.id
-          ? {
-              ...c,
-              column: 'done' as Column,
-              status: 'idle' as const,
-              completedAt: c.completedAt ?? new Date().toISOString(),
-              updatedAt: new Date().toISOString(),
-            }
-          : c,
-      ),
-    }));
+    onUpdate((prev) => applyWorkflowTransition(prev, card.id, 'done'));
   }, [card, onUpdate]);
 
   const handleRetry = useCallback(() => {
@@ -456,6 +407,7 @@ export function CardDetail({
             {/* Footer actions */}
             <CardDetailFooter
               card={card}
+              moveTargets={getManualMoveTargets(card)}
               onMove={handleMove}
               onPriorityChange={handlePriorityChange}
               onDelete={handleDelete}

--- a/packages/pi-kanban-extension/ui/components/CardDetailFooter.tsx
+++ b/packages/pi-kanban-extension/ui/components/CardDetailFooter.tsx
@@ -60,14 +60,13 @@ export function CardDetailFooter({
         </div>
       </div>
 
-      {/* Priority + Delete */}
+      {/* Priority (read-only) + Delete */}
       <div className="flex items-center justify-between">
         <div className="flex" style={{ gap: '4px' }}>
           {(['critical', 'high', 'medium', 'low'] as const).map((p) => (
-            <button
+            <span
               key={p}
-              onClick={() => onPriorityChange(p)}
-              className="rounded-md font-medium transition-colors"
+              className="rounded-md font-medium"
               style={{
                 fontSize: '10px',
                 padding: '4px 8px',
@@ -76,7 +75,7 @@ export function CardDetailFooter({
               }}
             >
               {p}
-            </button>
+            </span>
           ))}
         </div>
         <button

--- a/packages/pi-kanban-extension/ui/components/CardDetailFooter.tsx
+++ b/packages/pi-kanban-extension/ui/components/CardDetailFooter.tsx
@@ -5,15 +5,17 @@
  */
 
 import type { Card, Column, Priority } from '../../shared/types';
-import { COLUMNS, COLUMN_LABELS } from '../../shared/types';
+import { COLUMN_LABELS } from '../../shared/types';
 
 export function CardDetailFooter({
   card,
+  moveTargets,
   onMove,
   onPriorityChange,
   onDelete,
 }: {
   card: Card;
+  moveTargets: Column[];
   onMove: (column: Column) => void;
   onPriorityChange: (priority: Priority) => void;
   onDelete: () => void;
@@ -27,38 +29,40 @@ export function CardDetailFooter({
       }}
     >
       {/* Move to */}
-      <div style={{ marginBottom: '14px' }}>
-        <span
-          style={{
-            display: 'block',
-            fontSize: '10px',
-            fontWeight: 600,
-            textTransform: 'uppercase',
-            letterSpacing: '0.05em',
-            color: '#5c5e6a',
-            marginBottom: '8px',
-          }}
-        >
-          Move to
-        </span>
-        <div className="flex flex-wrap" style={{ gap: '6px' }}>
-          {COLUMNS.filter((c) => c !== card.column).map((col) => (
-            <button
-              key={col}
-              onClick={() => onMove(col)}
-              className="rounded-md text-xs transition-all"
-              style={{
-                border: '1px solid rgba(255, 255, 255, 0.08)',
-                backgroundColor: '#22252f',
-                padding: '6px 12px',
-                color: '#8b8d97',
-              }}
-            >
-              {COLUMN_LABELS[col]}
-            </button>
-          ))}
+      {moveTargets.length > 0 && (
+        <div style={{ marginBottom: '14px' }}>
+          <span
+            style={{
+              display: 'block',
+              fontSize: '10px',
+              fontWeight: 600,
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              color: '#5c5e6a',
+              marginBottom: '8px',
+            }}
+          >
+            Move to
+          </span>
+          <div className="flex flex-wrap" style={{ gap: '6px' }}>
+            {moveTargets.map((col) => (
+              <button
+                key={col}
+                onClick={() => onMove(col)}
+                className="rounded-md text-xs transition-all"
+                style={{
+                  border: '1px solid rgba(255, 255, 255, 0.08)',
+                  backgroundColor: '#22252f',
+                  padding: '6px 12px',
+                  color: '#8b8d97',
+                }}
+              >
+                {COLUMN_LABELS[col]}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Priority (read-only) + Delete */}
       <div className="flex items-center justify-between">

--- a/packages/pi-kanban-extension/ui/lib/card-workflow.ts
+++ b/packages/pi-kanban-extension/ui/lib/card-workflow.ts
@@ -1,0 +1,100 @@
+import type { Card, Column, KanbanState } from '../../shared/types';
+import { validateCardTransition, validateManualMove } from '../../shared/validation';
+
+function patchCard(
+  state: KanbanState,
+  cardId: string,
+  updater: (card: Card, now: string) => Card,
+): KanbanState {
+  const now = new Date().toISOString();
+  return {
+    ...state,
+    cards: state.cards.map((card) => (
+      card.id === cardId ? updater(card, now) : card
+    )),
+  };
+}
+
+function setCardError(state: KanbanState, cardId: string, error: string): KanbanState {
+  return patchCard(state, cardId, (card, now) => ({ ...card, error, updatedAt: now }));
+}
+
+function formatErrors(prefix: string, cardId: string, errors: string[]): string {
+  return `${prefix} #${cardId}:\n${errors.map((error) => `  • ${error}`).join('\n')}`;
+}
+
+export function applyManualMove(
+  state: KanbanState,
+  cardId: string,
+  targetColumn: Column,
+): KanbanState {
+  const card = state.cards.find((entry) => entry.id === cardId);
+  if (!card) return state;
+
+  const validation = validateManualMove(card, targetColumn);
+  if (!validation.valid) {
+    return setCardError(state, cardId, formatErrors('Cannot move card', cardId, validation.errors));
+  }
+
+  return patchCard(state, cardId, (entry, now) => ({
+    ...entry,
+    column: targetColumn,
+    status: 'idle',
+    completedAt: targetColumn === 'backlog' ? undefined : entry.completedAt,
+    planningProgress: undefined,
+    implementationProgress: undefined,
+    reviewProgress: undefined,
+    error: undefined,
+    updatedAt: now,
+  }));
+}
+
+export function applyWorkflowTransition(
+  state: KanbanState,
+  cardId: string,
+  targetColumn: Extract<Column, 'planning' | 'in-progress' | 'done'>,
+): KanbanState {
+  const card = state.cards.find((entry) => entry.id === cardId);
+  if (!card) return state;
+
+  const validation = validateCardTransition(card, targetColumn, state);
+  if (!validation.valid) {
+    return setCardError(
+      state,
+      cardId,
+      formatErrors('Cannot advance card', cardId, validation.errors),
+    );
+  }
+
+  return patchCard(state, cardId, (entry, now) => {
+    if (targetColumn === 'planning') {
+      return {
+        ...entry,
+        column: 'planning',
+        status: 'agent-working',
+        error: undefined,
+        updatedAt: now,
+      };
+    }
+
+    if (targetColumn === 'in-progress') {
+      return {
+        ...entry,
+        column: 'in-progress',
+        status: 'idle',
+        error: undefined,
+        updatedAt: now,
+      };
+    }
+
+    return {
+      ...entry,
+      column: 'done',
+      status: 'idle',
+      completedAt: entry.completedAt ?? now,
+      reviewProgress: undefined,
+      error: undefined,
+      updatedAt: now,
+    };
+  });
+}

--- a/packages/templates/agents/implementer.md
+++ b/packages/templates/agents/implementer.md
@@ -14,13 +14,35 @@ You work methodically:
 1. Read relevant existing files to understand patterns and conventions
 2. Plan the minimal changes needed for your subtask
 3. Implement with clean, well-typed code
-4. Verify your changes are consistent with the codebase
+4. Run a self-review checklist before declaring done
+
+## Self-Review Checklist (run mentally before finishing)
+
+- [ ] All files I created/modified compile without errors
+- [ ] I followed existing code style and patterns
+- [ ] I didn't modify files outside my subtask's scope
+- [ ] Edge cases are handled (null/undefined, empty arrays, error paths)
+- [ ] No debugging artifacts left (console.log, TODO, commented-out code)
+- [ ] Types are specific — no unnecessary `any` or `as` casts
+
+## TDD Instructions (when applicable)
+
+If your subtask has a TDD designation:
+- **tdd**: Write a failing test first, then implement to make it pass, then refine
+- **test-after**: Implement first, then write tests covering the core logic
+- **no-test**: No tests needed — focus on implementation only
+
+Use the project's existing test framework and patterns. Tests should cover:
+1. Happy path (expected inputs → expected outputs)
+2. Edge cases (empty inputs, boundary values)
+3. Error paths (invalid inputs, missing data)
 
 Key rules:
 - Stay focused on your assigned subtask only
 - Follow existing code style and patterns
 - Create well-structured, readable code
 - Do not start dev servers or long-running processes
+- Provide a brief summary of what you implemented when done
 
 IMPORTANT: You are scoped to THIS workspace only. Do NOT access, read, write,
 or reference files outside the current working directory. Never use absolute

--- a/packages/templates/agents/planner.md
+++ b/packages/templates/agents/planner.md
@@ -8,16 +8,33 @@
 }
 ```
 
-You are a senior software architect. Your job is to analyse a development task
-and produce a structured implementation plan with subtasks.
+You are a senior software architect specialising in breaking down development tasks into implementable subtasks.
+
+You analyse codebase context and produce structured implementation plans with:
+- Clear subtask breakdown with dependencies
+- Non-overlapping file scopes per subtask (for parallel execution)
+- TDD scenario designations per subtask
+- Exact file paths (create/modify/test) per subtask
+- Realistic complexity estimates
 
 When planning:
 1. Review the codebase analysis provided by scout/analyst agents
 2. Identify the minimal set of changes needed
 3. Break the work into 2–8 independent subtasks
 4. Assign non-overlapping file scopes where possible (for parallel execution)
-5. Model dependencies between subtasks accurately
-6. Include test writing as a final step when appropriate
+5. Model dependencies between subtasks accurately — explain WHY each dependency exists
+6. Designate each subtask's testing approach (tdd / test-after / no-test)
+7. List exact file paths each subtask will create or modify
+8. Estimate complexity (low ~15min, medium ~30min, high ~45min+)
 
-Your output must be valid JSON matching the requested schema. Be precise about
-file paths and module boundaries. Prefer small, focused subtasks over large ones.
+Each subtask should be scoped to 15–30 minutes of focused agent work. If a subtask
+would take longer, split it further.
+
+Always output valid JSON matching the requested schema. No markdown outside the JSON block.
+
+Be precise about file paths and module boundaries. Prefer small, focused subtasks
+over large ones.
+
+IMPORTANT: You are scoped to THIS workspace only. Do NOT access, read, write,
+or reference files outside the current working directory. Never use absolute
+paths to other workspaces or home directories.

--- a/packages/templates/agents/quality-reviewer.md
+++ b/packages/templates/agents/quality-reviewer.md
@@ -1,0 +1,44 @@
+```json
+{
+  "name": "quality-reviewer",
+  "description": "Code quality reviewer — style, patterns, performance, maintainability",
+  "model": "claude-sonnet-4-6",
+  "thinking": "medium",
+  "tools": ["read", "bash", "grep", "find"]
+}
+```
+
+You are a code quality reviewer. You review implementation diffs for quality
+concerns that go beyond spec compliance.
+
+Focus areas:
+1. **Style consistency** — does the code follow existing project patterns?
+2. **Type safety** — are types properly used? Any `any` casts or unsafe assertions?
+3. **Error handling** — are errors caught and handled appropriately?
+4. **Performance** — any obvious performance concerns (N+1 queries, unnecessary re-renders)?
+5. **Maintainability** — is the code readable and well-structured?
+6. **Edge cases** — are boundary conditions handled?
+
+Output ONLY valid JSON:
+```json
+{
+  "passed": true,
+  "issues": [
+    {
+      "category": "style | types | errors | performance | maintainability | edge-case",
+      "description": "What's wrong",
+      "file": "path/to/file.ts",
+      "line": 42,
+      "severity": "critical | important | minor",
+      "suggestion": "How to fix it"
+    }
+  ],
+  "summary": "Brief quality assessment"
+}
+```
+
+Set `passed` to true only if there are no critical issues.
+Be thorough but not pedantic — focus on issues that genuinely matter.
+
+IMPORTANT: You are scoped to THIS workspace only. Do NOT access files outside
+the current working directory.

--- a/packages/templates/agents/reviewer.md
+++ b/packages/templates/agents/reviewer.md
@@ -8,8 +8,14 @@
 }
 ```
 
-You are a senior code reviewer. Analyse code for correctness, performance,
-security, and maintainability.
+You are a senior code reviewer. You review diffs thoroughly and produce a structured review with a feature-focused PR title and description.
+
+Your review covers:
+1. Code quality and correctness
+2. Adherence to existing patterns and conventions
+3. Potential bugs or edge cases
+4. Test coverage gaps (if testing is enabled)
+5. Performance concerns
 
 For each issue found:
 - Cite the file and line number
@@ -17,5 +23,33 @@ For each issue found:
 - Suggest a concrete fix
 - Rate severity: critical, warning, or suggestion
 
+IMPORTANT — Browser Testing:
+- Do NOT attempt to test interactive/real-time features (games, animations, drag-and-drop) via browser automation — it is too slow to capture fast-moving action
+- Instead, note in the PR body that the user should manually validate interactive behaviour
+- Focus your review on code correctness, not runtime testing
+
+PR Title and Body:
+- The PR title should be a `feat:` conventional commit describing WHAT WAS BUILT (not "chore: update from kanban card")
+- The PR body should focus on what was DELIVERED — it is a feature PR, not a review report
+- Include a brief review summary, but lead with the feature description
+
+Output ONLY valid JSON with this exact shape:
+```json
+{
+  "approved": true,
+  "summary": "Brief overall assessment",
+  "issues": ["Issue 1 description", "Issue 2 description"],
+  "prTitle": "feat: descriptive title of what was built (max 72 chars)",
+  "prBody": "Markdown PR description: ## Summary (what this delivers), ## Changes (per subtask), ## Review Notes (issues found), ## Manual Testing (what to verify)"
+}
+```
+
+If the code is acceptable, set approved to true with an empty issues array.
+If there are blocking issues, set approved to false.
+
 Be thorough but not pedantic. Focus on real issues that affect correctness or
 maintainability.
+
+IMPORTANT: You are scoped to THIS workspace only. Do NOT access, read, write,
+or reference files outside the current working directory. Never use absolute
+paths to other workspaces or home directories.

--- a/packages/templates/agents/spec-reviewer.md
+++ b/packages/templates/agents/spec-reviewer.md
@@ -1,0 +1,42 @@
+```json
+{
+  "name": "spec-reviewer",
+  "description": "Spec compliance reviewer — compares implementation against subtask spec",
+  "model": "claude-sonnet-4-6",
+  "thinking": "medium",
+  "tools": ["read", "bash", "grep", "find"]
+}
+```
+
+You are a spec compliance reviewer. Your job is to compare an implementation
+against its subtask specification and determine whether the spec has been
+fulfilled.
+
+For each subtask spec, check:
+1. **Completeness** — are all required changes present?
+2. **Correctness** — does the implementation match what was specified?
+3. **Missing items** — anything in the spec that wasn't implemented?
+4. **Extra items** — anything implemented that wasn't in the spec (scope creep)?
+5. **Misunderstandings** — was the spec interpreted incorrectly?
+
+Output ONLY valid JSON:
+```json
+{
+  "passed": true,
+  "issues": [
+    {
+      "type": "missing | extra | incorrect",
+      "description": "What's wrong",
+      "file": "path/to/file.ts",
+      "severity": "critical | important | minor"
+    }
+  ],
+  "summary": "Brief assessment"
+}
+```
+
+Set `passed` to true only if there are no critical or important issues.
+Be precise — cite file paths and specific code when reporting issues.
+
+IMPORTANT: You are scoped to THIS workspace only. Do NOT access files outside
+the current working directory.


### PR DESCRIPTION
## Summary

Transforms the Kanban from a simple card-tracking board into a structured, end-to-end development workflow with quality-gated phases, automated orchestration, and a brainstorming pipeline.

## Changes

### Phase 0: Agent Template Consistency
- Merged inline system prompts into `planner.md` and `reviewer.md` agent templates
- All 5 kanban subagents now consistently use agent templates (no more inline `systemPrompt` overrides)

### Workstream 1: Brainstorm → Cards Pipeline
- `kanban brainstorm` tool action launches conversational card creation in ChatPanel
- PI SDK prompt templates: `brainstorm.md` (structured idea refinement using `questionnaire` tool) and `card-enhance.md`
- ✨ Brainstorm button in Kanban header
- Agent is explicitly told not to implement code — orchestrator handles everything

### Workstream 2: Stage Contracts & Quality Gates
- `StageContract` schema with required inputs, expected outputs, and quality gates per transition
- `validateTransition()` enforced in extension (start/approve/complete) and orchestrator
- `blockedBy` card-to-card dependencies with validation, auto-unblock on completion
- `kanban complete` locked to review→done only; `kanban move` blocks forward skipping

### Workstream 3: Enhanced Orchestrator
- **Planning**: TDD designations, file paths, complexity estimates per subtask
- **Implementation**: Wave-level verification (auto-detected typecheck/tests), TDD-aware prompts
- **Review**: Pre-review verification, structured issue categories (Critical/Important/Minor), feature-focused PR titles and bodies
- New agent templates: `spec-reviewer.md`, `quality-reviewer.md`
- Enhanced `implementer.md` with self-review checklist

### YOLO Mode 🔥
- Toggle in header: auto-starts backlog cards, auto-approves plans, auto-completes reviews
- Sweeps ALL ready backlog cards after any completion (full DAG traversal)

### Settings & UI
- Mode toggle: `Production` / `Prototype` (controls TDD and test generation)
- `kanban settings` tool action for yoloMode, testingEnabled, reviewLevel
- Priority indicators read-only in CardDetail
- Clickable PR link in CardDetail
- `kanban cleanup` action — prunes worktrees only when ALL cards are done

### Infrastructure & Safety
- `appStateManager.onFileChange()` listener so orchestrator reacts to extension writes (not just IPC)
- Comprehensive `.gitignore` from initial commit (prevents committing `node_modules`, `.DS_Store`, etc.)
- Safe `.DS_Store` removal from tracking (targeted, never `git rm --cached .`)
- Worktrees preserved until user explicitly cleans up — no auto-deletion of work
- Default branch set to `main` for greenfield projects
- Verification only runs `typecheck` if `package.json` actually has the script

## Tests

73 unit tests across 4 test files:
- `wave-resolver.test.ts` — dependency wave grouping, circular deps, edge cases
- `contracts.test.ts` — transition validation, blockedBy enforcement, unblocking
- `prompts.test.ts` — plan/review parsing, TDD propagation, prompt generation
- `verification.test.ts` — project type detection, package manager detection, testing toggle

## Files Changed

35 files: 3,021 insertions, 404 deletions

**New files:** contracts.ts, verification.ts, validation.ts, workflow-actions.ts, brainstorm.md, card-enhance.md, spec-reviewer.md, quality-reviewer.md, 4 test files
**Modified:** orchestrator, prompts, planning/review/subtask executors, worktree-git, worktree-manager, types (host + extension), extension index, KanbanApp, CardDetail, CardDetailFooter, agent templates, app-state, package.json