### PR TITLE
Fix repo remote setup, kanban planning rules, and subagent permission hangs

### DIFF
--- a/apps/desktop/electron/__tests__/kanban/contracts.test.ts
+++ b/apps/desktop/electron/__tests__/kanban/contracts.test.ts
@@ -78,18 +78,18 @@ describe('validateTransition: backlog → planning', () => {
     expect(result.errors.some((e) => e.includes('description'))).toBe(true);
   });
 
-  it('fails when acceptance criteria are missing', () => {
+  it('allows planning to start without acceptance criteria', () => {
     const card = makeCard({ acceptance: [] });
     const result = validateTransition(card, 'planning');
-    expect(result.valid).toBe(false);
-    expect(result.errors.some((e) => e.includes('acceptance'))).toBe(true);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
   });
 
   it('collects all errors at once', () => {
     const card = makeCard({ title: '', description: '', acceptance: [] });
     const result = validateTransition(card, 'planning');
     expect(result.valid).toBe(false);
-    expect(result.errors.length).toBe(3);
+    expect(result.errors.length).toBe(2);
   });
 
   it('blocks when card has unmet dependencies', () => {

--- a/apps/desktop/electron/github/repo-ops.ts
+++ b/apps/desktop/electron/github/repo-ops.ts
@@ -39,6 +39,10 @@ export class GitHubRepoOps {
 
     const addRemote = input.addRemote !== false;
 
+    if (addRemote) {
+      await this.runner.ensureRepoInitialized(workspaceId);
+    }
+
     // Check if 'origin' remote already exists
     const existingOrigin = addRemote ? await this.getOriginUrl(workspaceId) : null;
 

--- a/apps/desktop/electron/kanban/contracts.ts
+++ b/apps/desktop/electron/kanban/contracts.ts
@@ -96,15 +96,10 @@ const BACKLOG_TO_PLANNING: StageContract = {
       validation: 'non-empty',
       message: 'Card must have a description (at least a sentence explaining the intent)',
     },
-    {
-      field: 'acceptance',
-      validation: 'min-items',
-      minItems: 1,
-      message: 'Card must have at least 1 acceptance criterion',
-    },
   ],
   expectedOutputs: [
     { field: 'plan', description: 'Prose implementation approach' },
+    { field: 'acceptance', description: 'Acceptance criteria refined or generated during planning' },
     { field: 'subtasks', description: 'Decomposed work items with dependency graph' },
   ],
   qualityGates: [],

--- a/apps/desktop/electron/vcs/git-runner.ts
+++ b/apps/desktop/electron/vcs/git-runner.ts
@@ -137,4 +137,14 @@ export class GitRunner {
   async run(workspaceId: string, args: string[], timeoutMs = 30_000): Promise<GitResult> {
     return this.runCommand(workspaceId, 'git', args, timeoutMs);
   }
+
+  async ensureRepoInitialized(workspaceId: string): Promise<void> {
+    const root = await this.run(workspaceId, ['rev-parse', '--git-dir']);
+    if (root.exitCode === 0) return;
+
+    const init = await this.run(workspaceId, ['init']);
+    if (init.exitCode !== 0) {
+      throw new Error(init.stderr || 'Failed to initialize Git repository');
+    }
+  }
 }

--- a/apps/desktop/electron/vcs/vcs-manager.ts
+++ b/apps/desktop/electron/vcs/vcs-manager.ts
@@ -33,13 +33,7 @@ export class VcsManager extends EventEmitter {
   }
 
   private async ensureRepoInitialized(workspaceId: string): Promise<void> {
-    const root = await this.runner.run(workspaceId, ['rev-parse', '--git-dir']);
-    if (root.exitCode === 0) return;
-
-    const init = await this.runner.run(workspaceId, ['init']);
-    if (init.exitCode !== 0) {
-      throw new Error(init.stderr || 'Failed to initialize Git repository');
-    }
+    await this.runner.ensureRepoInitialized(workspaceId);
   }
 
   async getCurrentChangeId(workspaceId: string): Promise<string | null> {

--- a/apps/desktop/electron/vcs/vcs-ops.ts
+++ b/apps/desktop/electron/vcs/vcs-ops.ts
@@ -176,6 +176,7 @@ export class VcsOps {
     name: string,
     url: string,
   ): Promise<void> {
+    await this.runner.ensureRepoInitialized(workspaceId);
     const result = await this.runner.run(workspaceId, ['remote', 'add', name, url]);
     if (result.exitCode !== 0) {
       throw new Error(result.stderr || `Failed to add remote '${name}'`);

--- a/apps/desktop/src/stores/user-feedback-store.ts
+++ b/apps/desktop/src/stores/user-feedback-store.ts
@@ -64,15 +64,18 @@ export const useUserFeedbackStore = create<UserFeedbackState>((set, get) => ({
   },
 
   initListeners() {
-    // New question arrived from an extension tool — add to pending
-    // and auto-switch to User Feedback app so the user sees it immediately.
+    // New question arrived from an extension tool — add to pending.
+    // Only multi-step forms switch to the User Feedback app; single
+    // questions and permission prompts stay in the chat panel.
     const unsubQuestion = window.sero.userFeedback.onQuestion((data) => {
       set((state) => {
         const next = new Map(state.pending);
         next.set(data.id, data);
         return { pending: next };
       });
-      useAppStore.getState().setActiveApp('userfeedback');
+      if (data.type === 'questionnaire' || data.type === 'interview') {
+        useAppStore.getState().setActiveApp('userfeedback');
+      }
     });
 
     // Main process cancelled a question (e.g. tool aborted)

--- a/packages/pi-kanban-extension/shared/validation.ts
+++ b/packages/pi-kanban-extension/shared/validation.ts
@@ -40,9 +40,6 @@ export function validateCardTransition(
     if (!card.description.trim()) {
       errors.push('Card must have a description (at least a sentence explaining the intent)');
     }
-    if (card.acceptance.length < 1) {
-      errors.push('Card must have at least 1 acceptance criterion');
-    }
     // Card-to-card dependencies
     const unmet = getUnmetDependencies(card, state);
     if (unmet.length > 0) {

--- a/packages/pi-user-feedback/extension/permission-gate.ts
+++ b/packages/pi-user-feedback/extension/permission-gate.ts
@@ -3,6 +3,8 @@
  *
  * Hooks `tool_call` events for the `bash` tool and checks the command against
  * a set of dangerous patterns. When matched:
+ *   - Simple workspace-scoped `rm -r/-rf` cleanup commands are auto-allowed
+ *   - Everything else goes through the approval flow
  *   - Pi CLI mode: shows a warning-styled TUI confirmation via ctx.ui.custom()
  *   - Sero mode:   sends a 'permission' question via the IPC bridge
  *
@@ -10,10 +12,12 @@
  * If the bus has listeners for 'question-request', we use the IPC bridge.
  * Otherwise we fall back to the TUI prompt.
  *
- * Blocked commands return { block: true, reason: "..." } to the agent.
+ * Sero permission prompts auto-timeout and block so background subagents
+ * do not hang forever waiting for an answer.
  */
 
 import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import path from 'path';
 import { nextQuestionId, askQuestion, hasSeroIPCBridge } from './ipc-bridge';
 import { showPermissionWarningTUI } from './tui-permission-warning';
 
@@ -27,12 +31,20 @@ const DANGEROUS_PATTERNS = [
   /\b(shutdown|reboot|halt|poweroff)\b/i,
 ];
 
+const PERMISSION_PROMPT_TIMEOUT_MS = 30_000;
+const SHELL_CONTROL_CHARS = /[;&|`$<>()\n]/;
+const GLOB_CHARS = /[*?[\]{}]/;
+
 /** Register the permission gate on the `tool_call` event. */
 export function registerPermissionGate(pi: ExtensionAPI) {
   pi.on('tool_call', async (event, ctx) => {
     if (event.toolName !== 'bash') return undefined;
 
     const command = event.input.command as string;
+    if (isWorkspaceScopedRecursiveDelete(command, ctx.cwd)) {
+      return undefined;
+    }
+
     const isDangerous = DANGEROUS_PATTERNS.some((p) => p.test(command));
     if (!isDangerous) return undefined;
 
@@ -50,6 +62,13 @@ async function askPermissionViaSero(
   toolCallId: string,
   command: string,
 ): Promise<{ block: true; reason: string } | undefined> {
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, PERMISSION_PROMPT_TIMEOUT_MS);
+
   const id = nextQuestionId();
   const response = await askQuestion(
     {
@@ -70,10 +89,18 @@ async function askPermissionViaSero(
       ],
       timestamp: new Date().toISOString(),
     },
-  );
+    controller.signal,
+  ).finally(() => {
+    clearTimeout(timeoutId);
+  });
 
   if (response.cancelled || response.answers.length === 0) {
-    return { block: true, reason: 'Blocked by user — cancelled' };
+    return {
+      block: true,
+      reason: timedOut
+        ? `Dangerous command blocked — approval timed out after ${Math.round(PERMISSION_PROMPT_TIMEOUT_MS / 1000)}s`
+        : 'Blocked by user — cancelled',
+    };
   }
 
   if (response.answers[0].value !== 'allow') {
@@ -81,6 +108,138 @@ async function askPermissionViaSero(
   }
 
   return undefined;
+}
+
+function isWorkspaceScopedRecursiveDelete(command: string, cwd?: string): boolean {
+  if (!cwd) return false;
+
+  const tokens = tokenizeSimpleShellCommand(command);
+  if (!tokens || tokens.length === 0) return false;
+
+  const executable = path.basename(tokens[0]).toLowerCase();
+  if (executable !== 'rm') return false;
+
+  let recursive = false;
+  let sawDoubleDash = false;
+  const targets: string[] = [];
+
+  for (const token of tokens.slice(1)) {
+    if (!sawDoubleDash && token === '--') {
+      sawDoubleDash = true;
+      continue;
+    }
+
+    if (!sawDoubleDash && token.startsWith('-')) {
+      if (token === '--recursive') {
+        recursive = true;
+        continue;
+      }
+
+      if (/^-[A-Za-z]+$/.test(token)) {
+        if (/[rR]/.test(token)) recursive = true;
+        continue;
+      }
+
+      return false;
+    }
+
+    targets.push(token);
+  }
+
+  if (!recursive || targets.length === 0) return false;
+
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  return targets.every((target) => isAllowedWorkspaceDeleteTarget(target, cwd, workspaceRoot));
+}
+
+function tokenizeSimpleShellCommand(command: string): string[] | null {
+  if (SHELL_CONTROL_CHARS.test(command)) return null;
+
+  const tokens: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (const char of command.trim()) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaped || quote) return null;
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function resolveWorkspaceRoot(cwd: string): string {
+  const resolved = path.resolve(cwd);
+  const worktreeMarker = `${path.sep}.sero${path.sep}worktrees${path.sep}`;
+  const worktreeIndex = resolved.indexOf(worktreeMarker);
+  if (worktreeIndex >= 0) {
+    return resolved.slice(0, worktreeIndex);
+  }
+
+  if (resolved === '/workspace' || resolved.startsWith(`/workspace${path.sep}`)) {
+    return '/workspace';
+  }
+
+  return resolved;
+}
+
+function isAllowedWorkspaceDeleteTarget(target: string, cwd: string, workspaceRoot: string): boolean {
+  if (!target || GLOB_CHARS.test(target)) return false;
+
+  const resolved = path.isAbsolute(target)
+    ? path.resolve(target)
+    : path.resolve(cwd, target);
+
+  if (resolved === workspaceRoot) return false;
+
+  const rel = path.relative(workspaceRoot, resolved);
+  if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return false;
+
+  const normalizedRel = rel.split(path.sep).join('/');
+  if (
+    normalizedRel === '.git' ||
+    normalizedRel.startsWith('.git/') ||
+    normalizedRel.includes('/.git/') ||
+    normalizedRel.endsWith('/.git')
+  ) {
+    return false;
+  }
+
+  return true;
 }
 
 // ── Pi CLI mode: TUI warning ─────────────────────────────────


### PR DESCRIPTION
## Summary
- initialize Git repositories before adding/updating remotes or creating GitHub repos so brand new workspaces can connect to an existing remote without failing with "not a git repository"
- relax Kanban backlog → planning validation so cards no longer require acceptance criteria before planning starts; planning now treats acceptance criteria as an expected output to refine/generate
- auto-allow simple workspace-scoped recursive delete commands so container/worktree cleanup like `rm -rf /workspace/dist` does not trigger the permission gate
- add a timeout to Sero permission prompts so background subagents fail cleanly instead of hanging forever when no approval arrives
- keep permission prompts in the chat panel by only auto-switching to the User Feedback app for questionnaire/interview flows

## Testing
- pnpm typecheck
- packages/pi-user-feedback/node_modules/.bin/tsc --noEmit -p packages/pi-user-feedback/extension/tsconfig.json