### PR TITLE
feat: harden kanban review and feedback flows

### DIFF
--- a/apps/desktop/electron/__tests__/github/repo-ops.test.ts
+++ b/apps/desktop/electron/__tests__/github/repo-ops.test.ts
@@ -1,0 +1,100 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { GitHubRepoOps } from '../../github/repo-ops';
+import type { GitRunner } from '../../vcs/git-runner';
+import type { WorkspaceManager } from '../../workspace';
+
+function ok(stdout = '', stderr = '') {
+  return { exitCode: 0, stdout, stderr };
+}
+
+function fail(stderr: string) {
+  return { exitCode: 1, stdout: '', stderr };
+}
+
+describe('GitHubRepoOps', () => {
+  let tmpDir: string | null = null;
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  it('bootstraps and pushes main for a fresh workspace before first PRs exist', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'repo-ops-'));
+
+    let headChecks = 0;
+    const run = vi.fn(async (_workspaceId: string, args: string[], _timeoutMs?: number) => {
+      const command = args.join(' ');
+
+      if (command === 'rev-parse HEAD') {
+        headChecks += 1;
+        return headChecks === 1 ? fail('fatal: ambiguous argument HEAD') : ok('abc123\n');
+      }
+      if (command === 'remote get-url origin') return fail('no origin');
+      if (command === 'symbolic-ref HEAD refs/heads/main') return ok();
+      if (command === 'add -- .gitignore') return ok();
+      if (command === 'commit --allow-empty -m Initial commit') return ok('[main (root-commit) abc123] Initial commit');
+      if (command === 'rev-parse --verify main') return ok('abc123\n');
+      if (command === 'push -u origin main') return ok();
+      if (command === 'remote set-head origin main') return ok();
+      throw new Error(`Unexpected git command: ${command}`);
+    });
+
+    const runCommand = vi.fn(async (_workspaceId: string, program: string, args: string[]) => {
+      if (program !== 'gh') {
+        throw new Error(`Unexpected command: ${program}`);
+      }
+
+      if (args.slice(0, 2).join(' ') === 'repo create') {
+        return ok('https://github.com/monobyte/helloworld3\n');
+      }
+      if (args.slice(0, 2).join(' ') === 'repo edit') {
+        return ok();
+      }
+      if (args.slice(0, 2).join(' ') === 'repo view') {
+        return ok('https://github.com/monobyte/helloworld3\n');
+      }
+
+      throw new Error(`Unexpected gh command: ${args.join(' ')}`);
+    });
+
+    const runner = {
+      ensureRepoInitialized: vi.fn().mockResolvedValue(undefined),
+      run,
+      runCommand,
+    } as unknown as GitRunner;
+
+    const workspaceManager = {
+      getPath: vi.fn().mockReturnValue(tmpDir),
+    } as unknown as WorkspaceManager;
+
+    const ops = new GitHubRepoOps(runner, workspaceManager);
+    const result = await ops.createRepo('helloworld3', {
+      name: 'helloworld3',
+      visibility: 'private',
+      addRemote: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(runner.ensureRepoInitialized).toHaveBeenCalledWith('helloworld3');
+    expect(run).toHaveBeenCalledWith('helloworld3', ['add', '--', '.gitignore'], 10_000);
+    expect(run).toHaveBeenCalledWith('helloworld3', ['push', '-u', 'origin', 'main'], 60_000);
+    expect(runCommand).toHaveBeenCalledWith(
+      'helloworld3',
+      'gh',
+      ['repo', 'edit', '--default-branch', 'main'],
+      30_000,
+    );
+
+    const gitignore = await fs.readFile(path.join(tmpDir, '.gitignore'), 'utf8');
+    expect(gitignore).toContain('.sero-workspace.json');
+    expect(gitignore).toContain('.sero/');
+  });
+});

--- a/apps/desktop/electron/__tests__/kanban/prompts.test.ts
+++ b/apps/desktop/electron/__tests__/kanban/prompts.test.ts
@@ -9,6 +9,7 @@ import {
   buildSubtaskPrompt,
   buildSubtaskGenerationPrompt,
   buildReviewPrompt,
+  buildReviewRevisionPrompt,
   buildSpecReviewPrompt,
 } from '../../kanban/prompts';
 import type { Card } from '../../kanban/types';
@@ -120,6 +121,15 @@ describe('parseReviewResult', () => {
     expect(result.verdict).toBe('fix-first');
   });
 
+  it('normalizes object issues from the legacy issues array', () => {
+    const raw = '```json\n{"approved": false, "summary": "Issues found", "issues": [{"description": "Missing import", "severity": "critical", "file": "src/App.tsx", "line": 3}], "verdict": "fix-first", "prTitle": "fix: bugs", "prBody": "Fix"}\n```';
+    const result = parseReviewResult(raw);
+    expect(result.issues).toEqual(['Missing import']);
+    expect(result.categorizedIssues).toHaveLength(1);
+    expect(result.categorizedIssues![0].severity).toBe('critical');
+    expect(result.approved).toBe(false);
+  });
+
   it('handles missing categorizedIssues', () => {
     const raw = '```json\n{"approved": true, "summary": "OK", "issues": [], "prTitle": "T", "prBody": "B"}\n```';
     const result = parseReviewResult(raw);
@@ -143,6 +153,13 @@ describe('parseReviewResult', () => {
   it('uses card title in fallback prTitle', () => {
     const result = parseReviewResult('No JSON here', 'Add user dashboard');
     expect(result.prTitle).toBe('feat: add user dashboard');
+  });
+
+  it('detects raw markdown verdicts when JSON is missing', () => {
+    const result = parseReviewResult('Verdict: `fix-first`\n1. Missing import in src/App.tsx');
+    expect(result.verdict).toBe('fix-first');
+    expect(result.approved).toBe(false);
+    expect(result.issues).toContain('Missing import in src/App.tsx');
   });
 
   it('defaults approved to true when field is missing', () => {
@@ -176,6 +193,17 @@ describe('buildSubtaskPrompt', () => {
     const prompt = buildSubtaskPrompt(card, '2');
     expect(prompt).toContain('✅ Setup');
     expect(prompt).toContain('src/init.ts');
+  });
+
+  it('explains that non-empty worktrees are expected for scaffolders', () => {
+    const card = makeCard({
+      subtasks: [
+        { id: '1', title: 'Scaffold project', description: 'Init Vite app', status: 'pending', dependsOn: [] },
+      ],
+    });
+    const prompt = buildSubtaskPrompt(card, '1');
+    expect(prompt).toContain('worktree directory is not empty');
+    expect(prompt).toContain('normal workaround');
   });
 
   it('includes TDD instructions when enabled', () => {
@@ -235,12 +263,39 @@ describe('buildReviewPrompt', () => {
     expect(prompt).toContain('do not flag missing test coverage');
   });
 
+  it('includes the explicit review JSON schema', () => {
+    const card = makeCard();
+    const prompt = buildReviewPrompt(card, 'diff', 'files');
+    expect(prompt).toContain('"categorizedIssues"');
+    expect(prompt).toContain('Return ONLY valid JSON with this exact shape');
+  });
+
   it('truncates long diffs', () => {
     const card = makeCard();
     const longDiff = 'x'.repeat(50000);
     const prompt = buildReviewPrompt(card, longDiff, 'files');
     expect(prompt).toContain('truncated');
     expect(prompt.length).toBeLessThan(50000);
+  });
+});
+
+describe('buildReviewRevisionPrompt', () => {
+  it('focuses the implementer on critical issues only', () => {
+    const card = makeCard({ column: 'review' });
+    const prompt = buildReviewRevisionPrompt(card, [
+      {
+        description: 'Import is missing',
+        severity: 'critical',
+        file: 'src/App.tsx',
+        line: 3,
+        suggestion: 'Add the missing import at the top of the file.',
+      },
+    ], 'Reviewer found one blocking issue.');
+
+    expect(prompt).toContain('Critical Issues To Fix');
+    expect(prompt).toContain('Import is missing');
+    expect(prompt).toContain('src/App.tsx:3');
+    expect(prompt).toContain('Fix ONLY the critical issues listed above');
   });
 });
 

--- a/apps/desktop/electron/__tests__/kanban/verification.test.ts
+++ b/apps/desktop/electron/__tests__/kanban/verification.test.ts
@@ -5,7 +5,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { detectVerificationCommands, detectPackageManager } from '../../kanban/verification';
+import {
+  detectVerificationCommands,
+  detectPackageManager,
+  runVerificationCommands,
+  summarizeVerificationFailure,
+} from '../../kanban/verification';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -134,5 +139,35 @@ describe('detectVerificationCommands', () => {
     );
     const commands = await detectVerificationCommands(tmpDir);
     expect(commands.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('runVerificationCommands', () => {
+  it('uses the injected command runner', async () => {
+    const runCommand = vi.fn().mockResolvedValue({
+      stdout: 'ok',
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const result = await runVerificationCommands(tmpDir, ['npm test'], 45_000, { runCommand });
+
+    expect(result.success).toBe(true);
+    expect(runCommand).toHaveBeenCalledWith('npm test', tmpDir, 45_000);
+  });
+});
+
+describe('summarizeVerificationFailure', () => {
+  it('collapses native dependency mismatch errors into a short summary', () => {
+    const summary = summarizeVerificationFailure({
+      command: 'npm test',
+      success: false,
+      stdout: '',
+      stderr: 'Error: Cannot find native binding. npm has a bug related to optional dependencies',
+      durationMs: 100,
+    });
+
+    expect(summary).toContain('native dependency mismatch');
+    expect(summary).toContain('npm test');
   });
 });

--- a/apps/desktop/electron/container/singleton.ts
+++ b/apps/desktop/electron/container/singleton.ts
@@ -1,0 +1,3 @@
+import { ContainerManager } from './index';
+
+export const containerManager = new ContainerManager();

--- a/apps/desktop/electron/container/system-prompt.ts
+++ b/apps/desktop/electron/container/system-prompt.ts
@@ -12,13 +12,22 @@
 export function buildContainerPromptBlock(
   workspaceId: string,
   containerIp?: string,
+  opts?: { currentWorkingDir?: string },
 ): string {
+  const currentWorkingDir = opts?.currentWorkingDir ?? '/workspace';
+  const cwdNote = currentWorkingDir === '/workspace'
+    ? 'Your current working directory is also /workspace.'
+    : `Your current working directory for this session is ${currentWorkingDir}.`;
+
   return `
 
 ## Container Environment
 
 You are operating inside a sandboxed Linux container for workspace "${workspaceId}".
-Your workspace directory is /workspace — all project files live here.
+Your workspace root is /workspace — all project files live under this mount.
+${cwdNote}
+Prefer relative paths and keep your work inside the current working directory unless the task explicitly requires another location.
+If this session is running inside a git worktree subdirectory, do NOT reset yourself with \`cd /workspace\` before making changes.
 
 **Container details:**
 - Base image: node:22-slim (Debian-based)
@@ -41,6 +50,8 @@ ${containerIp ? `- Container IP: ${containerIp} (accessible from the host)` : ''
 **Cross-workspace access:**
 - Other open workspaces (including the global workspace) are mounted into this container at their original host paths.
 - You CAN read and write files using their absolute host paths (e.g. /Users/.../workspaces/global/MEMORY.md).
+- For the CURRENT workspace, stay in the current working directory (or under /workspace) instead of switching to its host absolute path.
+- Only use absolute host paths when you intentionally need to access a DIFFERENT workspace.
 - This means cross-workspace operations like saving memories to the global workspace work normally — use \`sero workspace list\` to find workspace paths.
 
 **CRITICAL — Dev servers and networking:**
@@ -57,7 +68,7 @@ ${containerIp ? `- Container IP: ${containerIp} (accessible from the host)` : ''
 **CRITICAL — Starting background / long-running processes:**
 Each bash tool call runs in an isolated \`sh -c\` shell. To start a process that must outlive the command:
 1. ALWAYS use \`setsid\` to detach from the parent session:
-   \`setsid sh -c 'cd /workspace/myapp && npx vite --host 0.0.0.0 --port 3000 > /tmp/vite.log 2>&1 &'\`
+   \`setsid sh -c 'cd ${currentWorkingDir}/myapp && npx vite --host 0.0.0.0 --port 3000 > /tmp/vite.log 2>&1 &'\`
 2. Redirect stdout/stderr to a log file.
 3. After starting, verify the port is listening with \`ss -tlnp | grep <port>\`.
 4. If verification fails, check the log file for errors.

--- a/apps/desktop/electron/container/workspace-container-config.ts
+++ b/apps/desktop/electron/container/workspace-container-config.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+
+import { SERO_AGENT_DIR } from '../env';
+import type { WorkspaceManager } from '../workspace';
+import type { ContainerConfig } from './types';
+
+export async function buildWorkspaceContainerConfig(
+  workspaceManager: WorkspaceManager,
+  workspaceId: string,
+  hostPath: string,
+  opts?: { isolated?: boolean },
+): Promise<ContainerConfig> {
+  let writableMounts: string[] = [];
+
+  if (!opts?.isolated) {
+    const refs = await workspaceManager.getReferences(workspaceId);
+    for (const refId of refs) {
+      const refPath = workspaceManager.getPath(refId);
+      if (refPath && path.resolve(refPath) !== path.resolve(hostPath)) {
+        writableMounts.push(refPath);
+      }
+    }
+
+    const extraMounts = await workspaceManager.getMounts(workspaceId);
+    for (const mountPath of extraMounts) {
+      if (path.resolve(mountPath) !== path.resolve(hostPath) && !writableMounts.includes(mountPath)) {
+        writableMounts.push(mountPath);
+      }
+    }
+  }
+
+  return {
+    workspaceId,
+    hostPath,
+    readOnlyMounts: [
+      path.join(SERO_AGENT_DIR, 'skills'),
+      path.join(SERO_AGENT_DIR, 'prompts'),
+    ],
+    writableMounts,
+  };
+}

--- a/apps/desktop/electron/github/repo-ops.ts
+++ b/apps/desktop/electron/github/repo-ops.ts
@@ -6,10 +6,15 @@
  */
 
 import type { GitRunner } from '../vcs/git-runner';
+import type { WorkspaceManager } from '../workspace';
 import type { CreateGitHubRepoInput, CreateGitHubRepoResult } from '../../src/types/ipc';
+import { ensureBootstrapGitignore } from '../vcs/bootstrap-gitignore';
 
 export class GitHubRepoOps {
-  constructor(private readonly runner: GitRunner) {}
+  constructor(
+    private readonly runner: GitRunner,
+    private readonly workspaceManager: WorkspaceManager,
+  ) {}
 
   /**
    * Create a GitHub repository and optionally set it as the 'origin' remote.
@@ -40,8 +45,19 @@ export class GitHubRepoOps {
     const addRemote = input.addRemote !== false;
 
     if (addRemote) {
-      await this.runner.ensureRepoInitialized(workspaceId);
+      try {
+        await this.runner.ensureRepoInitialized(workspaceId);
+        await this.ensureBootstrapCommit(workspaceId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          message: `Failed to prepare the local repository.\n${message}`,
+        };
+      }
     }
+
+    const hasLocalCommits = addRemote ? await this.hasLocalCommits(workspaceId) : false;
 
     // Check if 'origin' remote already exists
     const existingOrigin = addRemote ? await this.getOriginUrl(workspaceId) : null;
@@ -71,6 +87,17 @@ export class GitHubRepoOps {
 
     const url = await this.resolveCreatedRepoUrl(workspaceId, name, result.stdout, result.stderr);
 
+    if (addRemote && !existingOrigin && hasLocalCommits) {
+      const bootstrap = await this.pushInitialBranch(workspaceId);
+      if (!bootstrap.success) {
+        return {
+          success: false,
+          message: `Repository created on GitHub, but failed to push the initial branch.\n${bootstrap.message}`,
+          url,
+        };
+      }
+    }
+
     // If origin already existed and user wants the remote updated, set-url now.
     if (addRemote && existingOrigin && url) {
       const update = await this.runner.run(workspaceId, ['remote', 'set-url', 'origin', url]);
@@ -92,12 +119,107 @@ export class GitHubRepoOps {
     };
   }
 
+  private async hasLocalCommits(workspaceId: string): Promise<boolean> {
+    const result = await this.runner.run(workspaceId, ['rev-parse', 'HEAD']);
+    return result.exitCode === 0;
+  }
+
   /** Get the current 'origin' remote URL, or null if none exists. */
   private async getOriginUrl(workspaceId: string): Promise<string | null> {
     const result = await this.runner.run(workspaceId, ['remote', 'get-url', 'origin']);
     if (result.exitCode !== 0) return null;
     const url = result.stdout.trim();
     return url || null;
+  }
+
+  private async ensureBootstrapCommit(workspaceId: string): Promise<void> {
+    if (await this.hasLocalCommits(workspaceId)) return;
+
+    const workspacePath = this.workspaceManager.getPath(workspaceId);
+    if (!workspacePath) {
+      throw new Error(`Workspace not found: ${workspaceId}`);
+    }
+
+    await ensureBootstrapGitignore(workspacePath);
+    await this.setBootstrapHead(workspaceId, 'main');
+
+    const add = await this.runner.run(workspaceId, ['add', '--', '.gitignore'], 10_000);
+    if (add.exitCode !== 0) {
+      throw new Error(add.stderr || add.stdout || 'Failed to stage bootstrap .gitignore');
+    }
+
+    const commit = await this.runner.run(
+      workspaceId,
+      ['commit', '--allow-empty', '-m', 'Initial commit'],
+      10_000,
+    );
+    if (commit.exitCode !== 0) {
+      throw new Error(commit.stderr || commit.stdout || 'Failed to create bootstrap commit');
+    }
+  }
+
+  private async setBootstrapHead(workspaceId: string, branch: string): Promise<void> {
+    const setHead = await this.runner.run(workspaceId, ['symbolic-ref', 'HEAD', `refs/heads/${branch}`]);
+    if (setHead.exitCode === 0) return;
+
+    const rename = await this.runner.run(workspaceId, ['branch', '-M', branch]);
+    if (rename.exitCode === 0) return;
+
+    throw new Error(
+      rename.stderr
+      || rename.stdout
+      || setHead.stderr
+      || setHead.stdout
+      || `Failed to set bootstrap branch '${branch}'.`,
+    );
+  }
+
+  private async pushInitialBranch(
+    workspaceId: string,
+  ): Promise<{ success: true } | { success: false; message: string }> {
+    const branch = await this.resolveBootstrapBranch(workspaceId);
+    if (!branch) return { success: true };
+
+    const push = await this.runner.run(workspaceId, ['push', '-u', 'origin', branch], 60_000);
+    if (push.exitCode !== 0) {
+      return {
+        success: false,
+        message: push.stderr || push.stdout || `Failed to push initial branch '${branch}'.`,
+      };
+    }
+
+    const edit = await this.runner.runCommand(
+      workspaceId,
+      'gh',
+      ['repo', 'edit', '--default-branch', branch],
+      30_000,
+    );
+    if (edit.exitCode !== 0) {
+      console.warn(
+        `[github-repo-ops] Failed to set default branch to ${branch}: ${edit.stderr || edit.stdout}`,
+      );
+    }
+
+    const setHead = await this.runner.run(workspaceId, ['remote', 'set-head', 'origin', branch]);
+    if (setHead.exitCode !== 0) {
+      console.warn(
+        `[github-repo-ops] Failed to set origin/HEAD to ${branch}: ${setHead.stderr || setHead.stdout}`,
+      );
+    }
+
+    return { success: true };
+  }
+
+  private async resolveBootstrapBranch(workspaceId: string): Promise<string | null> {
+    for (const branch of ['main', 'master']) {
+      const result = await this.runner.run(workspaceId, ['rev-parse', '--verify', branch]);
+      if (result.exitCode === 0) return branch;
+    }
+
+    const current = await this.runner.run(workspaceId, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    if (current.exitCode !== 0) return null;
+    const branch = current.stdout.trim();
+    return branch && branch !== 'HEAD' ? branch : null;
   }
 
   private async resolveCreatedRepoUrl(

--- a/apps/desktop/electron/ipc/shared-infra.ts
+++ b/apps/desktop/electron/ipc/shared-infra.ts
@@ -22,7 +22,8 @@ import { getModel, type Model, type Api } from '@mariozechner/pi-ai';
 
 import { SERO_AGENT_DIR, SERO_HOME } from '../env';
 import type { ContainerConfig } from '../container/types';
-import { ContainerManager } from '../container/index';
+import { containerManager } from '../container/singleton';
+import { buildWorkspaceContainerConfig } from '../container/workspace-container-config';
 import { GatewayServer } from '../gateway/index';
 import { WebChatServer } from '../gateway/channels/web';
 import { TailscaleIntegration } from '../gateway/tailscale';
@@ -39,8 +40,7 @@ import { ArtifactRegistry } from '../container/artifact-registry';
 export const githubAuth = new GitHubAuthManager();
 
 // ── Container Manager (singleton) ────────────────────────────
-
-export const containerManager = new ContainerManager();
+export { containerManager };
 
 // Wire GitHub auth env vars into container exec so GH_TOKEN + git
 // credential config are available in every container command.
@@ -50,7 +50,7 @@ const gitRunner = new GitRunner(workspaceManager, containerManager, githubAuth);
 export const vcsManager = new VcsManager(workspaceManager, gitRunner);
 export const vcsOps = new VcsOps(gitRunner);
 export const vcsPrOps = new VcsPullRequestOps(gitRunner);
-export const githubRepoOps = new GitHubRepoOps(gitRunner);
+export const githubRepoOps = new GitHubRepoOps(gitRunner, workspaceManager);
 
 // ── Artifact Registry (singleton) ────────────────────────────
 
@@ -208,34 +208,5 @@ export async function buildContainerConfig(
   hostPath: string,
   opts?: { isolated?: boolean },
 ): Promise<ContainerConfig> {
-  let writableMounts: string[] = [];
-
-  if (!opts?.isolated) {
-    // Mount explicitly referenced workspaces
-    const refs = await workspaceManager.getReferences(workspaceId);
-    for (const refId of refs) {
-      const refPath = workspaceManager.getPath(refId);
-      if (refPath && path.resolve(refPath) !== path.resolve(hostPath)) {
-        writableMounts.push(refPath);
-      }
-    }
-
-    // Mount arbitrary host folders
-    const extraMounts = await workspaceManager.getMounts(workspaceId);
-    for (const mp of extraMounts) {
-      if (path.resolve(mp) !== path.resolve(hostPath) && !writableMounts.includes(mp)) {
-        writableMounts.push(mp);
-      }
-    }
-  }
-
-  return {
-    workspaceId,
-    hostPath,
-    readOnlyMounts: [
-      path.join(SERO_AGENT_DIR, 'skills'),
-      path.join(SERO_AGENT_DIR, 'prompts'),
-    ],
-    writableMounts,
-  };
+  return buildWorkspaceContainerConfig(workspaceManager, workspaceId, hostPath, opts);
 }

--- a/apps/desktop/electron/kanban/base-progress.ts
+++ b/apps/desktop/electron/kanban/base-progress.ts
@@ -11,6 +11,7 @@ import type { Card, PlanningToolEntry } from './types';
 
 const MAX_RECENT_TOOLS = 15;
 const MAX_LOG_LINES = 20;
+const MAX_LIVE_OUTPUT_CHARS = 1200;
 const PROGRESS_FLUSH_MS = 800;
 
 export type WriteCardFn = (
@@ -26,6 +27,12 @@ export interface BaseProgress {
   agents: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools: PlanningToolEntry[];
   log: string[];
+  liveOutput?: string;
+  liveOutputSource?: string;
+}
+
+export interface LiveOutputSink {
+  setLiveOutput(source: string, text: string): void;
 }
 
 /**
@@ -57,6 +64,14 @@ export abstract class BaseProgressTracker<T extends BaseProgress> {
 
   addAgent(name: string): void {
     this.progress.agents.push({ name, status: 'running' });
+    this.scheduleDirtyFlush();
+  }
+
+  setLiveOutput(source: string, text: string): void {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    this.progress.liveOutputSource = source;
+    this.progress.liveOutput = trimmed.slice(-MAX_LIVE_OUTPUT_CHARS);
     this.scheduleDirtyFlush();
   }
 

--- a/apps/desktop/electron/kanban/implementation-progress.ts
+++ b/apps/desktop/electron/kanban/implementation-progress.ts
@@ -18,6 +18,8 @@ export class ImplementationProgressTracker extends BaseProgressTracker<Implement
       agents: [],
       recentTools: [],
       log: [],
+      liveOutput: '',
+      liveOutputSource: undefined,
     });
   }
 

--- a/apps/desktop/electron/kanban/live-output-bridge.ts
+++ b/apps/desktop/electron/kanban/live-output-bridge.ts
@@ -1,0 +1,37 @@
+/**
+ * Bridge subagent live-output events into kanban phase progress trackers.
+ *
+ * This lets card detail panels show the same streamed text users see in the
+ * orchestration sidebar without introducing a second renderer-side subscription.
+ */
+
+import type { LiveOutputSink } from './base-progress';
+import type { SubagentEntry } from '../subagent/types';
+import type { SubagentManager } from '../subagent/index';
+
+function matchesRun(
+  entry: Pick<SubagentEntry, 'workspaceId' | 'parentSessionId'>,
+  workspaceId: string,
+  parentSessionId: string,
+): boolean {
+  return entry.workspaceId === workspaceId && entry.parentSessionId === parentSessionId;
+}
+
+export function bridgeSubagentLiveOutput(
+  subagentManager: SubagentManager,
+  workspaceId: string,
+  parentSessionId: string,
+  sink: LiveOutputSink,
+): () => void {
+  const handleLiveOutput = (id: string, text: string) => {
+    const entry = subagentManager.tracker.get(id);
+    if (!entry || !matchesRun(entry, workspaceId, parentSessionId)) return;
+    sink.setLiveOutput(entry.agentName, text);
+  };
+
+  subagentManager.tracker.on('subagent_live_output', handleLiveOutput);
+
+  return () => {
+    subagentManager.tracker.off('subagent_live_output', handleLiveOutput);
+  };
+}

--- a/apps/desktop/electron/kanban/orchestrator.ts
+++ b/apps/desktop/electron/kanban/orchestrator.ts
@@ -7,6 +7,8 @@ import { PlanningProgressTracker } from './planning-progress';
 import { ImplementationProgressTracker } from './implementation-progress';
 import { ReviewProgressTracker } from './review-progress';
 import { executeReview } from './review-executor';
+import { getPullRequestMergeError } from './pr-merge-status';
+import { collectPersistedCardFixes } from './persisted-state-reconcile';
 import { executePlanning } from './planning-executor';
 import { resolveExecutionWaves } from './wave-resolver';
 import { executeWaves } from './subtask-executor';
@@ -14,16 +16,8 @@ import { updateCard, readCard } from './state-helpers';
 import { validateTransition, getNewlyUnblockedCards, getAllReadyBacklogCards } from './contracts';
 import { appStateManager } from '../app-state';
 import type { SubagentManager } from '../subagent/index';
-
-// ── Helpers ──────────────────────────────────────────────────
-
 const RETRYABLE_COLUMNS = new Set<Column>(['planning', 'in-progress', 'review']);
-
-function isRetryableColumn(column: Column): boolean {
-  return RETRYABLE_COLUMNS.has(column);
-}
-
-// ── Types ────────────────────────────────────────────────────
+function isRetryableColumn(column: Column): boolean { return RETRYABLE_COLUMNS.has(column); }
 
 interface OrchestratorDeps {
   subagentManager: SubagentManager;
@@ -37,8 +31,6 @@ interface WatchedWorkspace {
   lastColumnMap: Map<string, Column>;
 }
 
-// ── Orchestrator ─────────────────────────────────────────────
-
 export class KanbanOrchestrator {
   private readonly worktreeManager = new WorktreeManager();
   private deps: OrchestratorDeps | null = null;
@@ -49,7 +41,6 @@ export class KanbanOrchestrator {
 
   setDeps(deps: OrchestratorDeps): void { this.deps = deps; }
 
-  /** Scan for cards stuck in `agent-working` after restart and re-trigger their phase. */
   async recoverStuckCards(workspaces: Array<{ id: string; path: string }>): Promise<void> {
     if (!this.deps) return;
 
@@ -71,7 +62,6 @@ export class KanbanOrchestrator {
       );
       if (stuckCards.length === 0) continue;
 
-      // Ensure workspace is watched before retrying
       if (!this.watched.has(ws.id)) {
         await this.watchWorkspace(ws.id, ws.path);
       }
@@ -100,6 +90,7 @@ export class KanbanOrchestrator {
     this.watched.set(workspaceId, { workspaceId, stateFilePath, lastColumnMap });
     appStateManager.watch(stateFilePath);
     console.log(`[kanban-orchestrator] Watching workspace ${workspaceId}`);
+    await this.reconcilePersistedState(this.watched.get(workspaceId)!, initial);
   }
 
   unwatchWorkspace(workspaceId: string): void {
@@ -121,11 +112,9 @@ export class KanbanOrchestrator {
       const prevColumn = workspace.lastColumnMap.get(card.id);
 
       if (prevColumn && prevColumn !== card.column) {
-        // Real column transition
         console.log(`[kanban-orchestrator] Transition: #${card.id} ${prevColumn} → ${card.column}`);
         await this.handleTransition(workspace, card, prevColumn, card.column);
       } else if (!prevColumn) {
-        // New card that appeared already in an active column
         if (card.column === 'planning' && card.status === 'agent-working') {
           await this.handleTransition(workspace, card, 'backlog', 'planning');
         } else if (card.column === 'in-progress' && card.status === 'idle') {
@@ -136,7 +125,6 @@ export class KanbanOrchestrator {
         && isRetryableColumn(card.column)
         && !this.isCurrentlyProcessing(card.id)
       ) {
-        // Retry: card in active column needs processing (restart recovery or manual retry)
         console.log(`[kanban-orchestrator] Retry: #${card.id} in ${card.column}`);
         await this.handleTransition(workspace, card, card.column, card.column);
       }
@@ -185,7 +173,7 @@ export class KanbanOrchestrator {
         await this.runImplementationPhase(workspace, card);
         break;
       case 'review':
-        await this.runReviewPhase(workspace, card);
+        if (card.status !== 'waiting-input') await this.runReviewPhase(workspace, card);
         break;
       case 'done':
         await this.runDoneCleanup(workspace, card);
@@ -383,7 +371,7 @@ export class KanbanOrchestrator {
 
     try {
       console.log(`[kanban-orchestrator] Starting review for card #${card.id}`);
-      await updateCard(workspace.stateFilePath, card.id, { status: 'agent-working' });
+      await updateCard(workspace.stateFilePath, card.id, { status: 'agent-working', error: undefined });
 
       const reviewState = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
       const result = await executeReview(
@@ -398,7 +386,7 @@ export class KanbanOrchestrator {
 
       if (result.success) {
         const yolo = await this.isYoloMode(workspace.stateFilePath);
-        const prUpdate = { prUrl: result.prUrl, prNumber: result.prNumber, reviewFilePath: result.reviewFilePath, reviewProgress: undefined };
+        const prUpdate = { prUrl: result.prUrl, prNumber: result.prNumber, reviewFilePath: result.reviewFilePath, reviewProgress: undefined, error: undefined };
 
         if (yolo) {
           await updateCard(workspace.stateFilePath, card.id, { ...prUpdate, status: 'idle', column: 'done', completedAt: new Date().toISOString() });
@@ -413,6 +401,8 @@ export class KanbanOrchestrator {
         await updateCard(workspace.stateFilePath, card.id, {
           status: 'failed',
           error: result.error ?? 'Review failed',
+          prUrl: undefined,
+          prNumber: undefined,
           // Persist the review cache path even on failure so retry skips the subagent
           ...(result.reviewFilePath ? { reviewFilePath: result.reviewFilePath } : {}),
           reviewProgress: undefined,
@@ -425,6 +415,8 @@ export class KanbanOrchestrator {
       await updateCard(workspace.stateFilePath, card.id, {
         status: 'failed',
         error: `Review failed: ${errMsg}`,
+        prUrl: undefined,
+        prNumber: undefined,
         reviewProgress: undefined,
       });
     } finally {
@@ -438,11 +430,22 @@ export class KanbanOrchestrator {
 
     const currentState = await appStateManager.read(workspace.stateFilePath) as KanbanState | null;
     if (!currentState) return;
+    const freshCard = currentState.cards.find((c) => c.id === card.id) ?? card;
+
+    if (freshCard.prNumber && freshCard.worktreePath) {
+      const mergeError = await getPullRequestMergeError(freshCard.worktreePath, freshCard.prNumber);
+      if (mergeError) {
+        workspace.lastColumnMap.set(card.id, 'review');
+        await updateCard(workspace.stateFilePath, card.id, { column: 'review', status: 'waiting-input', completedAt: undefined, error: mergeError });
+        return;
+      }
+    }
 
     // Mark card done — keep worktree alive until user confirms cleanup
     await updateCard(workspace.stateFilePath, card.id, {
       status: 'idle',
       completedAt: new Date().toISOString(),
+      error: undefined,
       reviewProgress: undefined,
       implementationProgress: undefined,
       planningProgress: undefined,
@@ -474,6 +477,12 @@ export class KanbanOrchestrator {
 
   private async isYoloMode(p: string): Promise<boolean> {
     return ((await appStateManager.read(p) as KanbanState | null)?.settings?.yoloMode) === true;
+  }
+  private async reconcilePersistedState(workspace: WatchedWorkspace, state: KanbanState | null): Promise<void> {
+    for (const fix of await collectPersistedCardFixes(state)) {
+      if (fix.update.column) workspace.lastColumnMap.set(fix.id, fix.update.column);
+      await updateCard(workspace.stateFilePath, fix.id, fix.update);
+    }
   }
   private isCurrentlyProcessing(cardId: string): boolean {
     return (

--- a/apps/desktop/electron/kanban/persisted-state-reconcile.ts
+++ b/apps/desktop/electron/kanban/persisted-state-reconcile.ts
@@ -1,0 +1,46 @@
+import type { Card, KanbanState } from './types';
+import { getPullRequestMergeError } from './pr-merge-status';
+
+export interface PersistedCardFix {
+  id: string;
+  update: Partial<Card>;
+}
+
+export async function collectPersistedCardFixes(
+  state: KanbanState | null,
+): Promise<PersistedCardFix[]> {
+  if (!state?.cards?.length) return [];
+
+  const fixes: PersistedCardFix[] = [];
+
+  for (const card of state.cards) {
+    if (
+      card.column === 'review'
+      && card.status === 'waiting-input'
+      && card.prUrl
+      && isMalformedReviewError(card.error)
+    ) {
+      fixes.push({ id: card.id, update: { error: undefined } });
+    }
+
+    if (card.column !== 'done' || !card.prNumber || !card.worktreePath) continue;
+    const mergeError = await getPullRequestMergeError(card.worktreePath, card.prNumber);
+    if (!mergeError) continue;
+    fixes.push({
+      id: card.id,
+      update: {
+        column: 'review',
+        status: 'waiting-input',
+        completedAt: undefined,
+        error: mergeError,
+      },
+    });
+  }
+
+  return fixes;
+}
+
+function isMalformedReviewError(error: string | undefined): boolean {
+  if (!error) return false;
+  return error.includes('[object Object]') || /verdict[:\s`*-]+(merge|fix-first|reject)/i.test(error);
+}

--- a/apps/desktop/electron/kanban/planning-executor.ts
+++ b/apps/desktop/electron/kanban/planning-executor.ts
@@ -18,6 +18,7 @@ import {
   parsePlanResult,
 } from './prompts';
 import type { PlanGenerationOptions } from './prompts';
+import { bridgeSubagentLiveOutput } from './live-output-bridge';
 import type { SubagentManager } from '../subagent/index';
 
 export interface PlanningExecutorDeps {
@@ -41,44 +42,54 @@ export async function executePlanning(
   const { subagentManager, workspaceId } = deps;
   const parentSessionId = `kanban-card-${card.id}`;
   const taskDescription = buildPlanningPrompt(card);
-
-  let reconResult: string;
-
-  if (greenfield) {
-    // Greenfield: no codebase to analyse — provide context directly
-    reconResult = buildGreenfieldContext(card);
-    tracker.setPhase('Planning new project');
-    tracker.addAgent('planner');
-    await tracker.flush();
-  } else {
-    // Existing project: parallel reconnaissance
-    reconResult = await runReconnaissance(
-      deps, parentSessionId, taskDescription, tracker,
-    );
-
-    tracker.setPhase('Generating plan');
-    tracker.addAgent('planner');
-    await tracker.flush();
-  }
-
-  // Plan generation — uses the planner agent template (packages/templates/agents/planner.md)
-  const planResult = await subagentManager.runSingle({
-    agent: 'planner',
-    task: buildSubtaskGenerationPrompt(card, reconResult, deps.planOptions),
-    parentSessionId,
+  const detachLiveOutput = bridgeSubagentLiveOutput(
+    subagentManager,
     workspaceId,
-    isolated: true,
-    onUpdate: (text) => tracker.addLogLine(text),
-  });
+    parentSessionId,
+    tracker,
+  );
 
-  tracker.completeAgent('planner');
-  await tracker.flush();
+  try {
+    let reconResult: string;
 
-  const parsed = parsePlanResult(planResult);
-  if (parsed.warnings.length > 0) {
-    console.warn(`[planning-executor] Plan warnings: ${parsed.warnings.join('; ')}`);
+    if (greenfield) {
+      // Greenfield: no codebase to analyse — provide context directly
+      reconResult = buildGreenfieldContext(card);
+      tracker.setPhase('Planning new project');
+      tracker.addAgent('planner');
+      await tracker.flush();
+    } else {
+      // Existing project: parallel reconnaissance
+      reconResult = await runReconnaissance(
+        deps, parentSessionId, taskDescription, tracker,
+      );
+
+      tracker.setPhase('Generating plan');
+      tracker.addAgent('planner');
+      await tracker.flush();
+    }
+
+    // Plan generation — uses the planner agent template (packages/templates/agents/planner.md)
+    const planResult = await subagentManager.runSingle({
+      agent: 'planner',
+      task: buildSubtaskGenerationPrompt(card, reconResult, deps.planOptions),
+      parentSessionId,
+      workspaceId,
+      isolated: true,
+      onUpdate: (text) => tracker.addLogLine(text),
+    });
+
+    tracker.completeAgent('planner');
+    await tracker.flush();
+
+    const parsed = parsePlanResult(planResult);
+    if (parsed.warnings.length > 0) {
+      console.warn(`[planning-executor] Plan warnings: ${parsed.warnings.join('; ')}`);
+    }
+    return { plan: parsed.plan, subtasks: parsed.subtasks };
+  } finally {
+    detachLiveOutput();
   }
-  return { plan: parsed.plan, subtasks: parsed.subtasks };
 }
 
 // ── Reconnaissance (existing projects only) ──────────────────

--- a/apps/desktop/electron/kanban/planning-progress.ts
+++ b/apps/desktop/electron/kanban/planning-progress.ts
@@ -15,6 +15,8 @@ export class PlanningProgressTracker extends BaseProgressTracker<PlanningProgres
       agents: [],
       recentTools: [],
       log: [],
+      liveOutput: '',
+      liveOutputSource: undefined,
     });
   }
 

--- a/apps/desktop/electron/kanban/pr-merge-status.ts
+++ b/apps/desktop/electron/kanban/pr-merge-status.ts
@@ -1,0 +1,37 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+export type PullRequestMergeState = 'merged' | 'open' | 'closed' | 'unknown';
+
+export async function getPullRequestMergeState(
+  worktreePath: string,
+  prNumber: number,
+): Promise<PullRequestMergeState> {
+  try {
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['pr', 'view', String(prNumber), '--json', 'state,mergedAt'],
+      { cwd: worktreePath, timeout: 15_000 },
+    );
+    const parsed = JSON.parse(stdout) as { state?: string; mergedAt?: string | null };
+    if (parsed.mergedAt) return 'merged';
+    if (parsed.state === 'OPEN') return 'open';
+    if (parsed.state === 'CLOSED') return 'closed';
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+export async function getPullRequestMergeError(
+  worktreePath: string,
+  prNumber: number,
+): Promise<string | null> {
+  const mergeState = await getPullRequestMergeState(worktreePath, prNumber);
+  if (mergeState === 'merged') return null;
+  if (mergeState === 'open') return `PR #${prNumber} is still open. Merge it before marking this card done.`;
+  if (mergeState === 'closed') return `PR #${prNumber} was closed without merging. Re-open or create a new PR before marking this card done.`;
+  return `Could not verify whether PR #${prNumber} was merged.`;
+}

--- a/apps/desktop/electron/kanban/prompts.ts
+++ b/apps/desktop/electron/kanban/prompts.ts
@@ -138,6 +138,7 @@ ${completedSubtasks ? `## Already Completed\n${completedSubtasks}\n` : ''}
 - Focus ONLY on this subtask — do not implement other subtasks
 - Write clean, well-typed code following existing project conventions
 - Create or modify files as needed for this subtask
+- If a scaffolder/init tool refuses to run because the worktree directory is not empty, treat that as expected for git worktrees: scaffold in a temporary directory and describe it as a normal workaround, not as a failure
 - Do not run the dev server or start any long-running processes
 - When done, provide a brief summary of what you implemented`;
 }
@@ -190,7 +191,64 @@ PR FORMAT — this is a FEATURE PR, not a review report:
 
 Do NOT use browser automation to test interactive/real-time features (games, animations, etc.) — it is too slow. Note them for manual testing instead.
 
-Output valid JSON as specified in your instructions.`;
+Return ONLY valid JSON with this exact shape:
+
+\`\`\`json
+{
+  "approved": false,
+  "summary": "Short overall assessment",
+  "verdict": "merge | fix-first | reject",
+  "categorizedIssues": [
+    {
+      "description": "What is wrong",
+      "severity": "critical | important | minor",
+      "file": "src/path.ts",
+      "line": 12,
+      "suggestion": "Concrete fix"
+    }
+  ],
+  "issues": ["Optional legacy string issue list"],
+  "prTitle": "feat: what was built",
+  "prBody": "## Summary\\n...\\n\\n## Changes\\n...\\n\\n## Review Notes\\n...\\n\\n## Manual Testing\\n..."
+}
+\`\`\`
+
+Rules:
+- Set "approved" to false for "fix-first" or "reject"
+- Use "critical" only for merge-blocking issues
+- If there are no issues, return an empty categorizedIssues array
+- Do not wrap the JSON in prose or markdown commentary`;
+}
+
+export function buildReviewRevisionPrompt(
+  card: Card,
+  criticalIssues: ReviewIssue[],
+  summary?: string,
+): string {
+  const issueBlock = criticalIssues.map((issue, index) => {
+    const location = issue.file
+      ? ` (${issue.file}${issue.line ? `:${issue.line}` : ''})`
+      : '';
+    const suggestion = issue.suggestion ? `\n  Suggested fix: ${issue.suggestion}` : '';
+    return `${index + 1}. ${issue.description}${location}${suggestion}`;
+  }).join('\n');
+
+  return `You are fixing merge-blocking review feedback for an existing feature branch.
+
+# Card: ${card.title}
+${card.description ? `\nDescription: ${card.description}` : ''}
+${card.plan ? `\nImplementation Plan:\n${card.plan}` : ''}
+${summary ? `\nReview Summary:\n${summary}` : ''}
+
+## Critical Issues To Fix
+${issueBlock}
+
+## Instructions
+- Fix ONLY the critical issues listed above in this pass
+- Keep the existing feature intent intact
+- Do not start dev servers or long-running processes
+- Run only the checks needed to validate your fixes
+- When done, briefly summarize what you changed to address the review`;
 }
 
 export interface ReviewIssue {
@@ -230,7 +288,9 @@ export function parseReviewResult(raw: string, cardTitle?: string): ReviewResult
     prBody: raw.slice(0, 2000),
   };
 
-  if (!jsonMatch) return fb;
+  if (!jsonMatch) {
+    return buildRawReviewFallback(raw, fb);
+  }
 
   try {
     const jsonStr = jsonMatch[1] || jsonMatch[0];
@@ -241,14 +301,16 @@ export function parseReviewResult(raw: string, cardTitle?: string): ReviewResult
     if (Array.isArray(parsed.categorizedIssues)) {
       categorizedIssues = parsed.categorizedIssues
         .filter((i: unknown) => i && typeof i === 'object')
-        .map((i: Record<string, unknown>) => ({
-          description: String(i.description ?? ''),
-          severity: (['critical', 'important', 'minor'].includes(i.severity as string)
-            ? i.severity : 'minor') as ReviewIssue['severity'],
-          file: typeof i.file === 'string' ? i.file : undefined,
-          line: typeof i.line === 'number' ? i.line : undefined,
-          suggestion: typeof i.suggestion === 'string' ? i.suggestion : undefined,
-        }));
+        .map((i: Record<string, unknown>) => normalizeReviewIssue(i));
+    }
+
+    if ((!categorizedIssues || categorizedIssues.length === 0) && Array.isArray(parsed.issues)) {
+      const objectIssues = parsed.issues
+        .filter((issue: unknown) => issue && typeof issue === 'object')
+        .map((issue: Record<string, unknown>) => normalizeReviewIssue(issue));
+      if (objectIssues.length > 0) {
+        categorizedIssues = objectIssues;
+      }
     }
 
     // Parse verdict
@@ -256,9 +318,9 @@ export function parseReviewResult(raw: string, cardTitle?: string): ReviewResult
     const verdict = validVerdicts.has(parsed.verdict) ? parsed.verdict : undefined;
 
     return {
-      approved: parsed.approved !== false,
+      approved: parsed.approved !== false && verdict !== 'fix-first' && verdict !== 'reject',
       summary: typeof parsed.summary === 'string' ? parsed.summary : fb.summary,
-      issues: Array.isArray(parsed.issues) ? parsed.issues.map(String) : [],
+      issues: Array.isArray(parsed.issues) ? parsed.issues.map(normalizeReviewIssueText) : [],
       categorizedIssues,
       verdict,
       prTitle: typeof parsed.prTitle === 'string'
@@ -267,8 +329,59 @@ export function parseReviewResult(raw: string, cardTitle?: string): ReviewResult
       prBody: typeof parsed.prBody === 'string' ? parsed.prBody : fb.prBody,
     };
   } catch {
-    return fb;
+    return buildRawReviewFallback(raw, fb);
   }
+}
+
+function buildRawReviewFallback(raw: string, fb: ReviewResult): ReviewResult {
+  const verdict = parseRawVerdict(raw);
+  const issues = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^[-*]\s+/.test(line) || /^\d+\.\s+/.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, '').replace(/^\d+\.\s+/, ''))
+    .filter(Boolean)
+    .slice(0, 5);
+
+  return {
+    ...fb,
+    approved: verdict ? verdict === 'merge' : true,
+    verdict,
+    issues,
+  };
+}
+
+function parseRawVerdict(raw: string): ReviewResult['verdict'] | undefined {
+  const match = raw.match(/verdict[:\s`*-]+(merge|fix-first|reject)/i);
+  return match ? match[1].toLowerCase() as ReviewResult['verdict'] : undefined;
+}
+
+function normalizeReviewIssueText(issue: unknown): string {
+  if (typeof issue === 'string') return issue;
+  if (issue && typeof issue === 'object') {
+    const value = issue as Record<string, unknown>;
+    return typeof value.description === 'string'
+      ? value.description
+      : JSON.stringify(value);
+  }
+  return String(issue);
+}
+
+function normalizeReviewIssue(issue: Record<string, unknown>): ReviewIssue {
+  return {
+    description: typeof issue.description === 'string' ? issue.description : normalizeReviewIssueText(issue),
+    severity: normalizeReviewSeverity(issue.severity),
+    file: typeof issue.file === 'string' ? issue.file : undefined,
+    line: typeof issue.line === 'number' ? issue.line : undefined,
+    suggestion: typeof issue.suggestion === 'string' ? issue.suggestion : undefined,
+  };
+}
+
+function normalizeReviewSeverity(raw: unknown): ReviewIssue['severity'] {
+  const severity = typeof raw === 'string' ? raw.toLowerCase() : '';
+  if (severity === 'critical') return 'critical';
+  if (severity === 'important' || severity === 'warning') return 'important';
+  return 'minor';
 }
 
 // ── Plan Parser ──────────────────────────────────────────────

--- a/apps/desktop/electron/kanban/review-executor.ts
+++ b/apps/desktop/electron/kanban/review-executor.ts
@@ -13,13 +13,20 @@ import { promisify } from 'util';
 
 import type { Card } from './types';
 import type { ReviewProgressTracker } from './review-progress';
-import type { ReviewResult } from './prompts';
+import type { ReviewResult, ReviewIssue } from './prompts';
 import {
   buildReviewPrompt,
+  buildReviewRevisionPrompt,
   parseReviewResult,
 } from './prompts';
 import type { ReviewPromptOptions } from './prompts';
-import { detectVerificationCommands, runVerificationCommands } from './verification';
+import { bridgeSubagentLiveOutput } from './live-output-bridge';
+import {
+  detectVerificationCommands,
+  runVerificationCommands,
+  summarizeVerificationFailure,
+} from './verification';
+import { runWorkspaceCommand } from './workspace-command-runner';
 import type { KanbanSettings } from './types';
 import {
   createCheckpointInWorktree,
@@ -33,6 +40,7 @@ import { getContract } from './contracts';
 import type { SubagentManager } from '../subagent/index';
 
 const execFileAsync = promisify(execFile);
+const MAX_CRITICAL_REVISIONS = 1;
 
 export interface ReviewExecutorDeps {
   subagentManager: SubagentManager;
@@ -63,101 +71,155 @@ export async function executeReview(
   branchName: string,
   tracker: ReviewProgressTracker,
 ): Promise<ReviewExecutorResult> {
+  const parentSessionId = `kanban-review-${card.id}`;
+  const detachLiveOutput = bridgeSubagentLiveOutput(
+    deps.subagentManager,
+    deps.workspaceId,
+    parentSessionId,
+    tracker,
+  );
+
+  try {
   // Derive workspace root (worktree is at <ws>/.sero/worktrees/card-<id>)
-  const workspaceRoot = path.resolve(worktreePath, '..', '..', '..');
-  const reviewDir = path.join(workspaceRoot, '.sero', 'apps', 'kanban', 'reviews');
-  const reviewFile = path.join(reviewDir, `card-${card.id}.json`);
-  const reviewRelPath = path.relative(workspaceRoot, reviewFile);
+    const workspaceRoot = path.resolve(worktreePath, '..', '..', '..');
+    const reviewDir = path.join(workspaceRoot, '.sero', 'apps', 'kanban', 'reviews');
+    const reviewFile = path.join(reviewDir, `card-${card.id}.json`);
+    const reviewRelPath = path.relative(workspaceRoot, reviewFile);
 
-  // ── Try to load cached review ──────────────────────────
-  console.log(`[review-executor] Checking for cached review at ${reviewFile}`);
-  const cached = await loadCachedReview(reviewFile);
-  if (cached) {
-    console.log(`[review-executor] Resuming from cached review for card #${card.id} — skipping to push`);
-    return resumeFromReview(cached, reviewRelPath, worktreePath, branchName, tracker);
-  }
-  console.log(`[review-executor] No cached review found — running full review pipeline`);
+    // ── Try to load cached review ──────────────────────────
+    console.log(`[review-executor] Checking for cached review at ${reviewFile}`);
+    const cached = await loadCachedReview(reviewFile);
+    if (cached) {
+      console.log(`[review-executor] Resuming from cached review for card #${card.id} — skipping to push`);
+      return resumeFromReview(cached, reviewRelPath, worktreePath, branchName, tracker);
+    }
+    console.log(`[review-executor] No cached review found — running full review pipeline`);
 
-  // ── Step 1: Check diff ─────────────────────────────────
-  tracker.setPhase('Checking changes');
-  await tracker.flush();
+    const expectedPaths = card.subtasks.flatMap((subtask) => subtask.filePaths ?? []);
+    const preflightRecovered = await recoverWorkspaceRootChanges(worktreePath, {
+      expectedPaths,
+    });
+    if (preflightRecovered) {
+      tracker.setPhase('Recovering misplaced changes');
+      await tracker.flush();
+    }
+    const verifyCommands = await detectVerificationCommands(worktreePath, {
+      testingEnabled: deps.settings?.testingEnabled,
+    });
+    const reviewOpts: ReviewPromptOptions = { testingEnabled: deps.settings?.testingEnabled };
 
-  await createCheckpointInWorktree(worktreePath, `feat: ${card.title}`);
+    for (let revisionPass = 0; revisionPass <= MAX_CRITICAL_REVISIONS; revisionPass++) {
+      const passLabel = revisionPass === 0 ? 'changes' : 'revised changes';
+      tracker.setPhase(`Checking ${passLabel}`);
+      await tracker.flush();
 
-  let [diff, fileSummary] = await Promise.all([
-    getWorktreeDiff(worktreePath),
-    getWorktreeDiffSummary(worktreePath),
-  ]);
-
-  // Recovery: files may have landed in the workspace root (legacy CWD bug)
-  if (!diff.trim()) {
-    tracker.setPhase('Recovering files');
-    await tracker.flush();
-
-    const recovered = await recoverOrphanedFiles(worktreePath);
-    if (recovered) {
       await createCheckpointInWorktree(worktreePath, `feat: ${card.title}`);
-      [diff, fileSummary] = await Promise.all([
+
+      let [diff, fileSummary] = await Promise.all([
         getWorktreeDiff(worktreePath),
         getWorktreeDiffSummary(worktreePath),
       ]);
+
+      if (!diff.trim()) {
+        tracker.setPhase('Recovering files');
+        await tracker.flush();
+
+        const recovered = await recoverWorkspaceRootChanges(worktreePath, {
+          expectedPaths,
+          allowAllDirty: true,
+        });
+        if (recovered) {
+          await createCheckpointInWorktree(worktreePath, `feat: ${card.title}`);
+          [diff, fileSummary] = await Promise.all([
+            getWorktreeDiff(worktreePath),
+            getWorktreeDiffSummary(worktreePath),
+          ]);
+        }
+      }
+
+      if (!diff.trim()) {
+        return { success: false, error: 'No changes to review — diff is empty.' };
+      }
+
+      if (verifyCommands.length > 0) {
+        tracker.setPhase('Running verification');
+        await tracker.flush();
+
+        const verifyResult = await runVerificationCommands(worktreePath, verifyCommands, undefined, {
+          runCommand: (command, cwd, timeoutMs) =>
+            runWorkspaceCommand(deps.workspaceId, cwd, command, timeoutMs, { isolated: true }),
+        });
+        if (!verifyResult.success) {
+          const failed = verifyResult.results.find((r) => !r.success);
+          const errOutput = failed ? summarizeVerificationFailure(failed) : 'Unknown verification failure';
+          return { success: false, error: `Pre-review verification failed:\n${errOutput}` };
+        }
+      }
+
+      const reviewerLabel = revisionPass === 0 ? 'reviewer' : `reviewer (${revisionPass + 1})`;
+      tracker.setPhase(revisionPass === 0 ? 'Reviewing changes' : `Re-reviewing changes (${revisionPass + 1})`);
+      tracker.addAgent(reviewerLabel);
+      await tracker.flush();
+
+      const rawReview = await deps.subagentManager.runSingleStructured({
+        agent: 'reviewer',
+        task: buildReviewPrompt(card, diff, fileSummary, reviewOpts),
+        parentSessionId,
+        workspaceId: deps.workspaceId,
+        cwd: worktreePath,
+        isolated: true,
+        onUpdate: (text) => tracker.addLogLine(text),
+      });
+      if (rawReview.error) {
+        tracker.completeAgent(reviewerLabel, 'failed');
+        return { success: false, error: `Reviewer failed: ${rawReview.error}` };
+      }
+
+      const review = parseReviewResult(rawReview.response, card.title);
+      tracker.completeAgent(reviewerLabel);
+
+      const reviewFailure = requiresReviewerApproval()
+        ? getBlockingReviewFailure(review)
+        : null;
+      const criticalIssues = getCriticalIssues(review);
+
+      if (!reviewFailure) {
+        await saveCachedReview(reviewFile, review);
+        console.log(`[review-executor] Saved review to ${reviewRelPath}`);
+        return pushAndCreatePr(review, reviewRelPath, worktreePath, branchName, card, tracker);
+      }
+
+      if (revisionPass >= MAX_CRITICAL_REVISIONS || criticalIssues.length === 0) {
+        await saveCachedReview(reviewFile, review);
+        console.log(`[review-executor] Saved review to ${reviewRelPath}`);
+        return { success: false, error: reviewFailure };
+      }
+
+      const reviserLabel = `implementer (${revisionPass + 1})`;
+      tracker.setPhase(`Fixing critical review feedback (${revisionPass + 1}/${MAX_CRITICAL_REVISIONS})`);
+      tracker.addAgent(reviserLabel);
+      await tracker.flush();
+
+      const revisionResult = await deps.subagentManager.runSingleStructured({
+        agent: 'implementer',
+        task: buildReviewRevisionPrompt(card, criticalIssues, review.summary),
+        parentSessionId,
+        workspaceId: deps.workspaceId,
+        cwd: worktreePath,
+        isolated: true,
+        onUpdate: (text) => tracker.addLogLine(text),
+      });
+
+      tracker.completeAgent(reviserLabel, revisionResult.error ? 'failed' : 'completed');
+      if (revisionResult.error) {
+        return { success: false, error: `Critical review revision failed: ${revisionResult.error}` };
+      }
     }
+
+    return { success: false, error: 'Review failed to produce a final result.' };
+  } finally {
+    detachLiveOutput();
   }
-
-  if (!diff.trim()) {
-    return { success: false, error: 'No changes to review — diff is empty.' };
-  }
-
-  // ── Step 1b: Pre-review verification ────────────────────
-  const verifyCommands = await detectVerificationCommands(worktreePath, {
-    testingEnabled: deps.settings?.testingEnabled,
-  });
-  if (verifyCommands.length > 0) {
-    tracker.setPhase('Running verification');
-    await tracker.flush();
-
-    const verifyResult = await runVerificationCommands(worktreePath, verifyCommands);
-    if (!verifyResult.success) {
-      const failed = verifyResult.results.find((r) => !r.success);
-      const errOutput = failed
-        ? `${failed.command}: ${failed.stderr}\n${failed.stdout}`.trim().slice(-2000)
-        : 'Unknown verification failure';
-      return { success: false, error: `Pre-review verification failed:\n${errOutput}` };
-    }
-  }
-
-  // ── Step 2: Reviewer subagent ─────────────────────────
-  tracker.setPhase('Reviewing changes');
-  tracker.addAgent('reviewer');
-  await tracker.flush();
-
-  const reviewOpts: ReviewPromptOptions = { testingEnabled: deps.settings?.testingEnabled };
-  const reviewPrompt = buildReviewPrompt(card, diff, fileSummary, reviewOpts);
-  // Uses the reviewer agent template (packages/templates/agents/reviewer.md)
-  const rawReview = await deps.subagentManager.runSingle({
-    agent: 'reviewer',
-    task: reviewPrompt,
-    parentSessionId: `kanban-review-${card.id}`,
-    workspaceId: deps.workspaceId,
-    cwd: worktreePath,
-    isolated: true,
-    onUpdate: (text) => tracker.addLogLine(text),
-  });
-
-  const review = parseReviewResult(rawReview, card.title);
-  tracker.completeAgent('reviewer');
-
-  const reviewFailure = requiresReviewerApproval()
-    ? getBlockingReviewFailure(review)
-    : null;
-  await saveCachedReview(reviewFile, review);
-  console.log(`[review-executor] Saved review to ${reviewRelPath}`);
-  if (reviewFailure) {
-    return { success: false, error: reviewFailure };
-  }
-
-  // ── Steps 3–4: Push + PR ──────────────────────────────
-  return pushAndCreatePr(review, reviewRelPath, worktreePath, branchName, card, tracker);
 }
 
 // ── Push + PR (shared by fresh run and resume) ──────────────
@@ -239,7 +301,7 @@ async function loadCachedReview(filePath: string): Promise<ReviewResult | null> 
   try {
     const raw = await fs.readFile(filePath, 'utf8');
     const data = JSON.parse(raw) as Partial<ReviewResult>;
-    if (typeof data.prTitle === 'string' && typeof data.prBody === 'string') {
+    if (typeof data.prTitle === 'string' && typeof data.prBody === 'string' && !hasMalformedLegacyIssues(data)) {
       const review = data as ReviewResult;
       return getBlockingReviewFailure(review) ? null : review;
     }
@@ -252,6 +314,14 @@ async function loadCachedReview(filePath: string): Promise<ReviewResult | null> 
 async function saveCachedReview(filePath: string, review: ReviewResult): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, JSON.stringify(review, null, 2), 'utf8');
+}
+
+function hasMalformedLegacyIssues(review: Partial<ReviewResult>): boolean {
+  return Array.isArray(review.issues)
+    && review.issues.some((issue) => (
+      typeof issue !== 'string'
+      || issue.includes('[object Object]')
+    ));
 }
 
 function getBlockingReviewFailure(review: ReviewResult): string | null {
@@ -285,6 +355,10 @@ function requiresReviewerApproval(): boolean {
   )) === true;
 }
 
+function getCriticalIssues(review: ReviewResult): ReviewIssue[] {
+  return review.categorizedIssues?.filter((issue) => issue.severity === 'critical') ?? [];
+}
+
 // ── Orphaned-file recovery ──────────────────────────────────
 
 /**
@@ -296,7 +370,10 @@ function requiresReviewerApproval(): boolean {
  *
  * @returns true if any files were recovered.
  */
-async function recoverOrphanedFiles(worktreePath: string): Promise<boolean> {
+async function recoverWorkspaceRootChanges(
+  worktreePath: string,
+  opts?: { expectedPaths?: string[]; allowAllDirty?: boolean },
+): Promise<boolean> {
   const workspaceRoot = path.resolve(worktreePath, '..', '..', '..');
 
   try {
@@ -305,33 +382,47 @@ async function recoverOrphanedFiles(worktreePath: string): Promise<boolean> {
     return false;
   }
 
-  let untrackedRaw: string;
+  let statusRaw: string;
   try {
     const result = await execFileAsync(
-      'git', ['ls-files', '--others', '--exclude-standard'],
+      'git', ['status', '--porcelain', '--untracked-files=all'],
       { cwd: workspaceRoot, timeout: 15_000 },
     );
-    untrackedRaw = result.stdout.trim();
+    statusRaw = result.stdout.trim();
   } catch {
     return false;
   }
 
-  if (!untrackedRaw) return false;
+  if (!statusRaw) return false;
 
-  const orphaned = untrackedRaw
+  const expectedPathSet = new Set(opts?.expectedPaths ?? []);
+  const dirtyFiles = statusRaw
     .split('\n')
-    .filter((f) => f && !f.startsWith('.sero/'));
+    .map((line) => parseStatusPath(line))
+    .filter((filePath): filePath is string => !!filePath)
+    .filter((filePath) => !filePath.startsWith('.sero/'))
+    .filter((filePath) => (
+      opts?.allowAllDirty
+      || expectedPathSet.size === 0
+      || expectedPathSet.has(filePath)
+    ));
 
-  if (orphaned.length === 0) return false;
+  if (dirtyFiles.length === 0) return false;
 
   console.log(
-    `[review-executor] Recovering ${orphaned.length} orphaned file(s) from workspace root to worktree`,
+    `[review-executor] Recovering ${dirtyFiles.length} workspace file(s) into worktree`,
   );
 
-  for (const relFile of orphaned) {
+  for (const relFile of dirtyFiles) {
     const src = path.join(workspaceRoot, relFile);
     const dest = path.join(worktreePath, relFile);
     try {
+      const sourceStat = await fs.stat(src).catch(() => null);
+      if (!sourceStat) {
+        await fs.rm(dest, { force: true });
+        continue;
+      }
+      if (!sourceStat.isFile()) continue;
       await fs.mkdir(path.dirname(dest), { recursive: true });
       await fs.copyFile(src, dest);
     } catch (err: unknown) {
@@ -340,4 +431,16 @@ async function recoverOrphanedFiles(worktreePath: string): Promise<boolean> {
   }
 
   return true;
+}
+
+function parseStatusPath(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  const pathPart = line.slice(3).trim();
+  if (!pathPart) return null;
+  if (pathPart.includes(' -> ')) {
+    const [, dest] = pathPart.split(' -> ');
+    return dest?.trim() || null;
+  }
+  return pathPart;
 }

--- a/apps/desktop/electron/kanban/review-progress.ts
+++ b/apps/desktop/electron/kanban/review-progress.ts
@@ -15,6 +15,8 @@ export class ReviewProgressTracker extends BaseProgressTracker<ReviewProgress> {
       agents: [],
       recentTools: [],
       log: [],
+      liveOutput: '',
+      liveOutputSource: undefined,
     });
   }
 

--- a/apps/desktop/electron/kanban/subtask-executor.ts
+++ b/apps/desktop/electron/kanban/subtask-executor.ts
@@ -10,8 +10,10 @@ import type { Card, KanbanState, KanbanSettings, Subtask } from './types';
 import type { ImplementationProgressTracker } from './implementation-progress';
 import { buildSubtaskPrompt } from './prompts';
 import type { SubtaskPromptOptions } from './prompts';
+import { bridgeSubagentLiveOutput } from './live-output-bridge';
 import { createCheckpointInWorktree } from './worktree-git';
-import { detectVerificationCommands, runVerificationCommands } from './verification';
+import { detectVerificationCommands, runVerificationCommands, summarizeVerificationFailure } from './verification';
+import { runWorkspaceCommand } from './workspace-command-runner';
 import { appStateManager } from '../app-state';
 import type { SubagentManager } from '../subagent/index';
 
@@ -35,47 +37,57 @@ export async function executeWaves(
 ): Promise<void> {
   const parentSessionId = `kanban-impl-${card.id}`;
   let liveCard = card;
+  const detachLiveOutput = bridgeSubagentLiveOutput(
+    deps.subagentManager,
+    deps.workspaceId,
+    parentSessionId,
+    tracker,
+  );
 
-  for (let waveIdx = 0; waveIdx < waves.length; waveIdx++) {
-    const wave = waves[waveIdx];
-    const waveLabel = `Wave ${waveIdx + 1}/${waves.length}`;
-    tracker.setPhase(waveLabel);
-    console.log(`[kanban-executor] Card #${card.id} ${waveLabel}: subtasks [${wave.join(', ')}]`);
+  try {
+    for (let waveIdx = 0; waveIdx < waves.length; waveIdx++) {
+      const wave = waves[waveIdx];
+      const waveLabel = `Wave ${waveIdx + 1}/${waves.length}`;
+      tracker.setPhase(waveLabel);
+      console.log(`[kanban-executor] Card #${card.id} ${waveLabel}: subtasks [${wave.join(', ')}]`);
 
-    // Mark wave subtasks as in-progress
-    await updateSubtaskStatuses(stateFilePath, card.id, wave, 'in-progress');
-    for (const stId of wave) {
-      const st = liveCard.subtasks.find((s) => s.id === stId);
-      tracker.addAgent(st?.title ?? stId);
+      // Mark wave subtasks as in-progress
+      await updateSubtaskStatuses(stateFilePath, card.id, wave, 'in-progress');
+      for (const stId of wave) {
+        const st = liveCard.subtasks.find((s) => s.id === stId);
+        tracker.addAgent(st?.title ?? stId);
+      }
+      await tracker.flush();
+
+      if (wave.length === 1) {
+        await executeSingleSubtask(
+          deps, stateFilePath, card, wave[0], worktreePath, parentSessionId, tracker,
+        );
+      } else {
+        await executeParallelSubtasks(
+          deps, stateFilePath, card, wave, worktreePath, parentSessionId, tracker,
+        );
+      }
+
+      // Re-read card to get updated subtask statuses
+      const fresh = await appStateManager.read(stateFilePath) as KanbanState | null;
+      liveCard = fresh?.cards.find((c) => c.id === card.id) ?? card;
+
+      // Check for failures in this wave
+      const failedInWave = liveCard.subtasks
+        .filter((s) => wave.includes(s.id) && s.status === 'failed');
+
+      if (failedInWave.length > 0) {
+        throw new Error(
+          `Subtask(s) failed: ${failedInWave.map((s) => `"${s.title}"`).join(', ')}`,
+        );
+      }
+
+      // Wave-level verification (typecheck, tests) — catches integration issues early
+      await runWaveVerification(deps.workspaceId, worktreePath, waveLabel, tracker, deps.settings);
     }
-    await tracker.flush();
-
-    if (wave.length === 1) {
-      await executeSingleSubtask(
-        deps, stateFilePath, card, wave[0], worktreePath, parentSessionId, tracker,
-      );
-    } else {
-      await executeParallelSubtasks(
-        deps, stateFilePath, card, wave, worktreePath, parentSessionId, tracker,
-      );
-    }
-
-    // Re-read card to get updated subtask statuses
-    const fresh = await appStateManager.read(stateFilePath) as KanbanState | null;
-    liveCard = fresh?.cards.find((c) => c.id === card.id) ?? card;
-
-    // Check for failures in this wave
-    const failedInWave = liveCard.subtasks
-      .filter((s) => wave.includes(s.id) && s.status === 'failed');
-
-    if (failedInWave.length > 0) {
-      throw new Error(
-        `Subtask(s) failed: ${failedInWave.map((s) => `"${s.title}"`).join(', ')}`,
-      );
-    }
-
-    // Wave-level verification (typecheck, tests) — catches integration issues early
-    await runWaveVerification(worktreePath, waveLabel, tracker, deps.settings);
+  } finally {
+    detachLiveOutput();
   }
 }
 
@@ -242,6 +254,7 @@ async function markSubtaskCompleted(
 // ── Wave-level Verification ─────────────────────────────────
 
 async function runWaveVerification(
+  workspaceId: string,
   worktreePath: string,
   waveLabel: string,
   tracker: ImplementationProgressTracker,
@@ -255,11 +268,13 @@ async function runWaveVerification(
   tracker.setPhase(`${waveLabel} — verifying`);
   await tracker.flush();
 
-  const result = await runVerificationCommands(worktreePath, commands);
+  const result = await runVerificationCommands(worktreePath, commands, undefined, {
+    runCommand: (command, cwd, timeoutMs) =>
+      runWorkspaceCommand(workspaceId, cwd, command, timeoutMs, { isolated: true }),
+  });
   if (!result.success) {
     const failed = result.results.find((r) => !r.success);
-    const errOutput = failed ? `${failed.stderr}\n${failed.stdout}`.trim().slice(-1000) : 'unknown';
-    throw new Error(`Wave verification failed (${failed?.command}): ${errOutput}`);
+    throw new Error(failed ? `Wave verification failed: ${summarizeVerificationFailure(failed)}` : 'Wave verification failed.');
   }
 }
 

--- a/apps/desktop/electron/kanban/types.ts
+++ b/apps/desktop/electron/kanban/types.ts
@@ -46,6 +46,8 @@ export interface PlanningProgress {
   agents: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools: PlanningToolEntry[];
   log: string[];
+  liveOutput?: string;
+  liveOutputSource?: string;
 }
 
 export interface ImplementationProgress {
@@ -56,6 +58,8 @@ export interface ImplementationProgress {
   agents: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools: PlanningToolEntry[];
   log: string[];
+  liveOutput?: string;
+  liveOutputSource?: string;
 }
 
 export interface ReviewProgress {
@@ -64,6 +68,8 @@ export interface ReviewProgress {
   agents: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools: PlanningToolEntry[];
   log: string[];
+  liveOutput?: string;
+  liveOutputSource?: string;
 }
 
 export interface Card {

--- a/apps/desktop/electron/kanban/verification.ts
+++ b/apps/desktop/electron/kanban/verification.ts
@@ -99,6 +99,18 @@ export interface CommandResult {
   durationMs: number;
 }
 
+export interface VerificationCommandRunner {
+  (command: string, cwd: string, timeoutMs: number): Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+  }>;
+}
+
+interface RunVerificationOptions {
+  runCommand?: VerificationCommandRunner;
+}
+
 /**
  * Run verification commands sequentially. Stops on first failure.
  */
@@ -106,16 +118,25 @@ export async function runVerificationCommands(
   cwd: string,
   commands: string[],
   timeoutMs = 120_000,
+  options?: RunVerificationOptions,
 ): Promise<VerificationResult> {
   const results: CommandResult[] = [];
+  const runCommand = options?.runCommand ?? runHostCommand;
 
   for (const cmd of commands) {
     const start = Date.now();
     try {
-      const { stdout, stderr } = await execFileAsync(
-        'sh', ['-c', cmd],
-        { cwd, timeout: timeoutMs, maxBuffer: 5 * 1024 * 1024 },
-      );
+      const { stdout, stderr, exitCode } = await runCommand(cmd, cwd, timeoutMs);
+      if (exitCode !== 0) {
+        results.push({
+          command: cmd,
+          success: false,
+          stdout: stdout.slice(-4000),
+          stderr: stderr.slice(-2000),
+          durationMs: Date.now() - start,
+        });
+        return { success: false, results };
+      }
       results.push({
         command: cmd,
         success: true,
@@ -140,7 +161,27 @@ export async function runVerificationCommands(
   return { success: true, results };
 }
 
+export function summarizeVerificationFailure(result: CommandResult): string {
+  const output = sanitizeVerificationOutput(`${result.stderr}\n${result.stdout}`.trim());
+  if (looksLikeNativeDependencyMismatch(output)) {
+    return `${result.command}: native dependency mismatch between verification and installed dependencies. Run verification in the same workspace environment used for install/build.`;
+  }
+  return `${result.command}: ${output || 'command failed with no output'}`;
+}
+
 // ── Helpers ──────────────────────────────────────────────────
+
+async function runHostCommand(
+  command: string,
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const { stdout, stderr } = await execFileAsync(
+    'sh', ['-c', command],
+    { cwd, timeout: timeoutMs, maxBuffer: 5 * 1024 * 1024 },
+  );
+  return { stdout, stderr, exitCode: 0 };
+}
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -160,4 +201,21 @@ async function readPackageJson(
   } catch {
     return null;
   }
+}
+
+function sanitizeVerificationOutput(output: string): string {
+  return output
+    .replace(/\u001b\[[0-9;]*m/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(-800);
+}
+
+function looksLikeNativeDependencyMismatch(output: string): boolean {
+  return (
+    output.includes('Cannot find native binding') ||
+    (output.includes('MODULE_NOT_FOUND') && output.includes('@rolldown/binding-')) ||
+    output.includes('optional dependencies') ||
+    (output.includes('MODULE_NOT_FOUND') && output.includes('/node_modules/rolldown/'))
+  );
 }

--- a/apps/desktop/electron/kanban/workspace-command-runner.ts
+++ b/apps/desktop/electron/kanban/workspace-command-runner.ts
@@ -1,0 +1,82 @@
+import { execFile } from 'child_process';
+import path from 'path';
+import { promisify } from 'util';
+
+import { WORKSPACE_MOUNT, type ExecResult } from '../container/types';
+import { containerManager } from '../container/singleton';
+import { buildWorkspaceContainerConfig } from '../container/workspace-container-config';
+import { workspaceManager } from '../workspace';
+
+const execFileAsync = promisify(execFile);
+
+interface RunWorkspaceCommandOptions {
+  isolated?: boolean;
+}
+
+export async function runWorkspaceCommand(
+  workspaceId: string,
+  cwd: string,
+  command: string,
+  timeoutMs = 120_000,
+  options?: RunWorkspaceCommandOptions,
+): Promise<ExecResult> {
+  const workspacePath = workspaceManager.getPath(workspaceId);
+  if (!workspacePath) {
+    return {
+      stdout: '',
+      stderr: `Workspace not found: ${workspaceId}`,
+      exitCode: 1,
+    };
+  }
+
+  const useContainer = await workspaceManager.isContainerEnabled(workspaceId);
+  if (useContainer) {
+    try {
+      const containerConfig = await buildWorkspaceContainerConfig(
+        workspaceManager,
+        workspaceId,
+        workspacePath,
+        { isolated: options?.isolated },
+      );
+      await containerManager.ensure(containerConfig);
+      const containerCwd = toContainerPath(workspacePath, cwd);
+      if (!containerCwd) {
+        return {
+          stdout: '',
+          stderr: `Cannot run command outside workspace root in container mode: ${cwd}`,
+          exitCode: 1,
+        };
+      }
+      return containerManager.exec(workspaceId, command, containerCwd, timeoutMs);
+    } catch (err: unknown) {
+      return {
+        stdout: '',
+        stderr: err instanceof Error ? err.message : String(err),
+        exitCode: 1,
+      };
+    }
+  }
+
+  try {
+    const { stdout, stderr } = await execFileAsync('sh', ['-c', command], {
+      cwd,
+      timeout: timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (err: unknown) {
+    const execErr = err as { code?: number; stdout?: string; stderr?: string; message?: string };
+    return {
+      stdout: String(execErr.stdout ?? ''),
+      stderr: String(execErr.stderr ?? execErr.message ?? 'command failed'),
+      exitCode: typeof execErr.code === 'number' ? execErr.code : 1,
+    };
+  }
+}
+
+function toContainerPath(workspacePath: string, cwd: string): string | null {
+  const rel = path.relative(workspacePath, cwd);
+  if (rel.startsWith('..')) return null;
+  if (!rel || rel === '.') return WORKSPACE_MOUNT;
+  return path.posix.join(WORKSPACE_MOUNT, ...rel.split(path.sep));
+}

--- a/apps/desktop/electron/kanban/worktree-git.ts
+++ b/apps/desktop/electron/kanban/worktree-git.ts
@@ -4,6 +4,7 @@ import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { promisify } from 'util';
+export { ensureRemoteDefaultBranch, createPrFromWorktree } from './worktree-pr';
 
 const execFileAsync = promisify(execFile);
 
@@ -246,208 +247,6 @@ export async function getWorktreeDiff(worktreePath: string): Promise<string> {
   }
 }
 
-/** Fetch remote refs so origin/* is up to date for merge-base checks. */
-async function fetchRemoteRefs(worktreePath: string): Promise<void> {
-  try {
-    await execFileAsync('git', ['fetch', 'origin'], {
-      cwd: worktreePath,
-      timeout: 30_000,
-    });
-  } catch {
-    // Best-effort — remote may not exist yet
-  }
-}
-
-/** Ensure the remote has a default branch to serve as PR base. */
-export async function ensureRemoteDefaultBranch(worktreePath: string): Promise<string> {
-  await fetchRemoteRefs(worktreePath);
-
-  // 1. Look for a remote default branch with shared history
-  for (const branch of ['main', 'master']) {
-    try {
-      const r = await execFileAsync('git', ['ls-remote', '--heads', 'origin', branch], {
-        cwd: worktreePath,
-        timeout: 15_000,
-      });
-      if (!r.stdout.trim()) continue;
-
-      // Verify shared history — merge-base exits non-zero if none
-      await execFileAsync('git', ['merge-base', `origin/${branch}`, 'HEAD'], {
-        cwd: worktreePath,
-        timeout: 10_000,
-      });
-      return branch;
-    } catch { /* no shared history or doesn't exist — try next */ }
-  }
-
-  // 2. Remote branch exists but has no shared history — check if it
-  //    contains real work before overwriting. A branch with >1 commit
-  //    likely has meaningful content we should not destroy.
-  for (const branch of ['main', 'master']) {
-    try {
-      const r = await execFileAsync('git', ['ls-remote', '--heads', 'origin', branch], {
-        cwd: worktreePath,
-        timeout: 15_000,
-      });
-      if (!r.stdout.trim()) continue;
-
-      // Count commits on the remote branch
-      const countResult = await execFileAsync('git', [
-        'rev-list', '--count', `origin/${branch}`,
-      ], { cwd: worktreePath, timeout: 10_000 });
-      const commitCount = parseInt(countResult.stdout.trim(), 10);
-
-      if (commitCount > 1) {
-        // Remote branch has real work — do NOT overwrite. Use it as-is
-        // even though history is disconnected; the PR may show a large
-        // diff but we avoid data loss.
-        console.warn(
-          `[worktree-git] Remote '${branch}' has ${commitCount} commits but no shared history with HEAD. ` +
-          `Using it as PR base to avoid overwriting existing work.`,
-        );
-        return branch;
-      }
-      // Single commit (likely orphan/placeholder) — safe to overwrite below
-    } catch { /* doesn't exist or fetch failed — try next */ }
-  }
-
-  // 3. No usable remote branch, or it's a single-commit orphan.
-  //    Push the feature branch's root commit as 'main'.
-  console.log('[worktree-git] Setting up remote main from feature branch root commit');
-  try {
-    const rootResult = await execFileAsync('git', ['rev-list', '--max-parents=0', 'HEAD'], {
-      cwd: worktreePath,
-      timeout: 10_000,
-    });
-    const rootCommit = rootResult.stdout.trim().split('\n')[0];
-
-    if (rootCommit) {
-      await execFileAsync('git', ['update-ref', 'refs/heads/main', rootCommit], {
-        cwd: worktreePath,
-        timeout: 5_000,
-      });
-      // Use --force-with-lease for safety (fails if remote was updated since fetch)
-      await execFileAsync('git', ['push', '--force-with-lease', '-u', 'origin', 'main'], {
-        cwd: worktreePath,
-        timeout: 30_000,
-      });
-      console.log(`[worktree-git] Created main at root commit ${rootCommit.slice(0, 12)} and pushed`);
-      return 'main';
-    }
-  } catch (err: unknown) {
-    console.error('[worktree-git] Failed to create default branch:', execError(err).message);
-  }
-
-  return 'main';
-}
-
-/**
- * Resolve the default branch name for PR base (must be a real branch, not a SHA).
- * Falls back to 'main' since GitHub defaults to that for new repos.
- */
-async function resolveDefaultBranch(worktreePath: string): Promise<string> {
-  // Try the remote's HEAD (most reliable)
-  try {
-    const r = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
-      cwd: worktreePath,
-      timeout: 5_000,
-    });
-    const ref = r.stdout.trim(); // e.g. refs/remotes/origin/main
-    const branch = ref.split('/').pop();
-    if (branch) return branch;
-  } catch { /* no remote HEAD */ }
-
-  // Check if main or master exist locally or on remote
-  for (const branch of ['main', 'master']) {
-    try {
-      await execFileAsync('git', ['rev-parse', '--verify', `origin/${branch}`], {
-        cwd: worktreePath,
-        timeout: 5_000,
-      });
-      return branch;
-    } catch { /* try next */ }
-    try {
-      await execFileAsync('git', ['rev-parse', '--verify', branch], {
-        cwd: worktreePath,
-        timeout: 5_000,
-      });
-      return branch;
-    } catch { /* try next */ }
-  }
-
-  // Last resort — GitHub defaults to 'main'
-  return 'main';
-}
-
-/**
- * Create a PR using the `gh` CLI directly from a worktree.
- *
- * @returns Object with url + number if successful, or error message.
- */
-export async function createPrFromWorktree(
-  worktreePath: string,
-  opts: { title: string; body: string; baseBranch?: string; draft?: boolean },
-): Promise<{ success: true; url: string; number: number } | { success: false; error: string }> {
-  const base = opts.baseBranch ?? await resolveDefaultBranch(worktreePath);
-
-  const args = ['pr', 'create', '--base', base, '--title', opts.title, '--body', opts.body];
-  if (opts.draft) args.push('--draft');
-
-  try {
-    const result = await execFileAsync('gh', args, {
-      cwd: worktreePath,
-      timeout: 120_000,
-    });
-
-    const url = extractGithubPrUrl(result.stdout) ?? extractGithubPrUrl(result.stderr);
-    const prNumber = url ? extractPrNumber(url) : undefined;
-
-    if (url && prNumber) {
-      console.log(`[worktree-git] Created PR #${prNumber}: ${url}`);
-      return { success: true, url, number: prNumber };
-    }
-    return { success: true, url: result.stdout.trim(), number: 0 };
-  } catch (err: unknown) {
-    const { stderr, message } = execError(err);
-    const errorDetail = stderr || message || 'Unknown error';
-
-    // Check if a PR already exists
-    if (errorDetail.includes('already exists')) {
-      const existing = await findExistingPr(worktreePath);
-      if (existing) return { success: true, ...existing };
-    }
-
-    console.error('[worktree-git] PR creation failed:', errorDetail);
-    return { success: false, error: errorDetail };
-  }
-}
-
-/** Find an existing open PR for the current branch. */
-async function findExistingPr(
-  worktreePath: string,
-): Promise<{ url: string; number: number } | null> {
-  try {
-    const result = await execFileAsync('gh', [
-      'pr', 'view', '--json', 'url,number',
-    ], { cwd: worktreePath, timeout: 30_000 });
-
-    const parsed = JSON.parse(result.stdout) as { url?: string; number?: number };
-    if (parsed.url && typeof parsed.number === 'number') {
-      return { url: parsed.url, number: parsed.number };
-    }
-  } catch { /* no existing PR */ }
-  return null;
-}
-
-function extractGithubPrUrl(text: string): string | undefined {
-  return text.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)?.[0];
-}
-
-function extractPrNumber(url: string): number | undefined {
-  const match = url.match(/\/pull\/(\d+)/);
-  return match ? parseInt(match[1], 10) : undefined;
-}
-
 // ── Gitignore ────────────────────────────────────────────────
 
 /**
@@ -464,6 +263,7 @@ const COMMON_IGNORE_PATTERNS = [
   '.env.local',
   'coverage/',
   '.sero/',
+  '.sero-workspace.json',
   '__pycache__/',
   '*.pyc',
   'target/',

--- a/apps/desktop/electron/kanban/worktree-manager.ts
+++ b/apps/desktop/electron/kanban/worktree-manager.ts
@@ -5,8 +5,9 @@
  * giving it an isolated working directory and branch while sharing the
  * repo's `.git` object store. This enables true parallel card execution.
  *
- * Worktrees are created when a card enters the planning phase and removed
- * when the card reaches done or is cancelled.
+ * Worktrees are created when a card enters the planning phase and kept
+ * around through review so the branch can be revised or merged. They are
+ * removed later during explicit cleanup (or cancellation).
  */
 
 import { execFile } from 'child_process';
@@ -15,6 +16,7 @@ import path from 'path';
 import { promisify } from 'util';
 
 import { inferConventionalType, slugifyBranchLabel } from '../vcs/branch-naming';
+import { ensureBootstrapGitignore } from '../vcs/bootstrap-gitignore';
 
 const execFileAsync = promisify(execFile);
 
@@ -43,21 +45,12 @@ export async function ensureGitReady(workspacePath: string): Promise<boolean> {
   }
 
   // Ensure comprehensive .gitignore exists BEFORE the initial commit
-  // so node_modules, dist, .DS_Store, etc. are never tracked
-  const gitignorePath = path.join(workspacePath, '.gitignore');
+  // so node_modules, dist, .DS_Store, etc. are never tracked.
   try {
-    const content = await fs.readFile(gitignorePath, 'utf8').catch(() => '');
-    const required = [
-      'node_modules/', 'dist/', 'build/', '.DS_Store', '*.log',
-      '.env', '.env.local', 'coverage/', '.sero/', '__pycache__/',
-      '*.pyc', 'target/', '.next/', '.nuxt/', '.turbo/',
-    ];
-    const missing = required.filter((p) => !content.includes(p));
-    if (missing.length > 0) {
-      const sep = content && !content.endsWith('\n') ? '\n' : '';
-      await fs.writeFile(gitignorePath, content + sep + missing.join('\n') + '\n', 'utf8');
-    }
-  } catch { /* best-effort */ }
+    await ensureBootstrapGitignore(workspacePath);
+  } catch {
+    // Best-effort.
+  }
 
   // Check if there are any commits
   try {
@@ -71,7 +64,7 @@ export async function ensureGitReady(workspacePath: string): Promise<boolean> {
     try {
       await execFileAsync('git', ['branch', '-M', 'main'], { cwd: workspacePath, timeout: 5_000 });
     } catch { /* branch may not exist yet — that's fine, init -b main handles it */ }
-    await execFileAsync('git', ['add', '-A'], { cwd: workspacePath, timeout: 10_000 });
+    await execFileAsync('git', ['add', '--', '.gitignore'], { cwd: workspacePath, timeout: 10_000 });
     await execFileAsync('git', [
       'commit', '--allow-empty', '-m', 'Initial commit',
     ], { cwd: workspacePath, timeout: 10_000 });

--- a/apps/desktop/electron/kanban/worktree-pr.ts
+++ b/apps/desktop/electron/kanban/worktree-pr.ts
@@ -1,0 +1,252 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+function execError(err: unknown): { stderr: string; message: string } {
+  if (err && typeof err === 'object') {
+    const e = err as { stderr?: unknown; message?: unknown };
+    return {
+      stderr: typeof e.stderr === 'string' ? e.stderr : '',
+      message: typeof e.message === 'string' ? e.message : String(err),
+    };
+  }
+  return { stderr: '', message: String(err) };
+}
+
+async function fetchRemoteRefs(worktreePath: string): Promise<void> {
+  try {
+    await execFileAsync('git', ['fetch', 'origin'], {
+      cwd: worktreePath,
+      timeout: 30_000,
+    });
+  } catch {
+    // Best-effort — remote may not exist yet
+  }
+}
+
+async function getGithubDefaultBranch(worktreePath: string): Promise<string | null> {
+  try {
+    const result = await execFileAsync('gh', [
+      'repo', 'view', '--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name',
+    ], {
+      cwd: worktreePath,
+      timeout: 30_000,
+    });
+    const branch = result.stdout.trim();
+    return branch || null;
+  } catch {
+    return null;
+  }
+}
+
+async function setLocalRemoteHead(worktreePath: string, branch: string): Promise<void> {
+  try {
+    await execFileAsync('git', ['remote', 'set-head', 'origin', branch], {
+      cwd: worktreePath,
+      timeout: 10_000,
+    });
+  } catch {
+    // Best-effort — local origin/HEAD can be stale without breaking PR creation
+  }
+}
+
+async function ensureGithubDefaultBranch(worktreePath: string, branch: string): Promise<void> {
+  try {
+    const current = await getGithubDefaultBranch(worktreePath);
+    if (current === branch) {
+      await setLocalRemoteHead(worktreePath, branch);
+      return;
+    }
+
+    await execFileAsync('gh', ['repo', 'edit', '--default-branch', branch], {
+      cwd: worktreePath,
+      timeout: 30_000,
+    });
+    await setLocalRemoteHead(worktreePath, branch);
+    console.log(`[worktree-git] Set GitHub default branch to ${branch}`);
+  } catch (err: unknown) {
+    console.warn(
+      `[worktree-git] Failed to set GitHub default branch to ${branch}: ${execError(err).message}`,
+    );
+  }
+}
+
+async function useRemoteDefaultBranch(worktreePath: string, branch: string): Promise<string> {
+  await ensureGithubDefaultBranch(worktreePath, branch);
+  return branch;
+}
+
+export async function ensureRemoteDefaultBranch(worktreePath: string): Promise<string> {
+  await fetchRemoteRefs(worktreePath);
+
+  for (const branch of ['main', 'master']) {
+    try {
+      const r = await execFileAsync('git', ['ls-remote', '--heads', 'origin', branch], {
+        cwd: worktreePath,
+        timeout: 15_000,
+      });
+      if (!r.stdout.trim()) continue;
+
+      await execFileAsync('git', ['merge-base', `origin/${branch}`, 'HEAD'], {
+        cwd: worktreePath,
+        timeout: 10_000,
+      });
+      return useRemoteDefaultBranch(worktreePath, branch);
+    } catch {
+      // no shared history or branch doesn't exist
+    }
+  }
+
+  for (const branch of ['main', 'master']) {
+    try {
+      const r = await execFileAsync('git', ['ls-remote', '--heads', 'origin', branch], {
+        cwd: worktreePath,
+        timeout: 15_000,
+      });
+      if (!r.stdout.trim()) continue;
+
+      const countResult = await execFileAsync('git', [
+        'rev-list', '--count', `origin/${branch}`,
+      ], { cwd: worktreePath, timeout: 10_000 });
+      const commitCount = parseInt(countResult.stdout.trim(), 10);
+
+      if (commitCount > 1) {
+        console.warn(
+          `[worktree-git] Remote '${branch}' has ${commitCount} commits but no shared history with HEAD. ` +
+          `Using it as PR base to avoid overwriting existing work.`,
+        );
+        return useRemoteDefaultBranch(worktreePath, branch);
+      }
+    } catch {
+      // branch doesn't exist or fetch failed
+    }
+  }
+
+  console.log('[worktree-git] Setting up remote main from feature branch root commit');
+  try {
+    const rootResult = await execFileAsync('git', ['rev-list', '--max-parents=0', 'HEAD'], {
+      cwd: worktreePath,
+      timeout: 10_000,
+    });
+    const rootCommit = rootResult.stdout.trim().split('\n')[0];
+
+    if (rootCommit) {
+      await execFileAsync('git', ['update-ref', 'refs/heads/main', rootCommit], {
+        cwd: worktreePath,
+        timeout: 5_000,
+      });
+      await execFileAsync('git', ['push', '--force-with-lease', '-u', 'origin', 'main'], {
+        cwd: worktreePath,
+        timeout: 30_000,
+      });
+      await ensureGithubDefaultBranch(worktreePath, 'main');
+      console.log(`[worktree-git] Created main at root commit ${rootCommit.slice(0, 12)} and pushed`);
+      return 'main';
+    }
+  } catch (err: unknown) {
+    console.error('[worktree-git] Failed to create default branch:', execError(err).message);
+  }
+
+  return 'main';
+}
+
+async function resolveDefaultBranch(worktreePath: string): Promise<string> {
+  try {
+    const r = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+      cwd: worktreePath,
+      timeout: 5_000,
+    });
+    const ref = r.stdout.trim();
+    const branch = ref.split('/').pop();
+    if (branch) return branch;
+  } catch {
+    // no remote HEAD
+  }
+
+  for (const branch of ['main', 'master']) {
+    try {
+      await execFileAsync('git', ['rev-parse', '--verify', `origin/${branch}`], {
+        cwd: worktreePath,
+        timeout: 5_000,
+      });
+      return branch;
+    } catch {
+      // try local branch next
+    }
+    try {
+      await execFileAsync('git', ['rev-parse', '--verify', branch], {
+        cwd: worktreePath,
+        timeout: 5_000,
+      });
+      return branch;
+    } catch {
+      // try next branch
+    }
+  }
+
+  return 'main';
+}
+
+export async function createPrFromWorktree(
+  worktreePath: string,
+  opts: { title: string; body: string; baseBranch?: string; draft?: boolean },
+): Promise<{ success: true; url: string; number: number } | { success: false; error: string }> {
+  const base = opts.baseBranch ?? await resolveDefaultBranch(worktreePath);
+  const args = ['pr', 'create', '--base', base, '--title', opts.title, '--body', opts.body];
+  if (opts.draft) args.push('--draft');
+
+  try {
+    const result = await execFileAsync('gh', args, {
+      cwd: worktreePath,
+      timeout: 120_000,
+    });
+
+    const url = extractGithubPrUrl(result.stdout) ?? extractGithubPrUrl(result.stderr);
+    const prNumber = url ? extractPrNumber(url) : undefined;
+
+    if (url && prNumber) {
+      console.log(`[worktree-git] Created PR #${prNumber}: ${url}`);
+      return { success: true, url, number: prNumber };
+    }
+    return { success: true, url: result.stdout.trim(), number: 0 };
+  } catch (err: unknown) {
+    const { stderr, message } = execError(err);
+    const errorDetail = stderr || message || 'Unknown error';
+
+    if (errorDetail.includes('already exists')) {
+      const existing = await findExistingPr(worktreePath);
+      if (existing) return { success: true, ...existing };
+    }
+
+    console.error('[worktree-git] PR creation failed:', errorDetail);
+    return { success: false, error: errorDetail };
+  }
+}
+
+async function findExistingPr(
+  worktreePath: string,
+): Promise<{ url: string; number: number } | null> {
+  try {
+    const result = await execFileAsync('gh', [
+      'pr', 'view', '--json', 'url,number',
+    ], { cwd: worktreePath, timeout: 30_000 });
+
+    const parsed = JSON.parse(result.stdout) as { url?: string; number?: number };
+    if (parsed.url && typeof parsed.number === 'number') {
+      return { url: parsed.url, number: parsed.number };
+    }
+  } catch {
+    // no existing PR
+  }
+  return null;
+}
+
+function extractGithubPrUrl(text: string): string | undefined {
+  return text.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/)?.[0];
+}
+
+function extractPrNumber(url: string): number | undefined {
+  const match = url.match(/\/pull\/(\d+)/);
+  return match ? parseInt(match[1], 10) : undefined;
+}

--- a/apps/desktop/electron/subagent/loader.ts
+++ b/apps/desktop/electron/subagent/loader.ts
@@ -30,6 +30,7 @@ export function createSubagentExtensionFactory(
   currentWorkspaceId: string,
   _sessionId: string,
   containerState?: ContainerState,
+  containerCwd?: string,
 ) {
   return (pi: ExtensionAPI) => {
     // ── System prompt injection (CLI + container) ─────────────
@@ -41,6 +42,7 @@ export function createSubagentExtensionFactory(
         systemPrompt += buildContainerPromptBlock(
           currentWorkspaceId,
           containerState.ipAddress,
+          { currentWorkingDir: containerCwd },
         );
       }
 

--- a/apps/desktop/electron/subagent/runner.ts
+++ b/apps/desktop/electron/subagent/runner.ts
@@ -104,7 +104,13 @@ export async function runSubagent(
     agentDir: SERO_AGENT_DIR,
     settingsManager: infra.settingsManager,
     extensionFactories: [
-      createSubagentExtensionFactory(workspaceManager, workspaceId, subagentSessionId, containerState ?? undefined),
+      createSubagentExtensionFactory(
+        workspaceManager,
+        workspaceId,
+        subagentSessionId,
+        containerState ?? undefined,
+        containerCwd,
+      ),
     ],
   });
   await loader.reload();

--- a/apps/desktop/electron/vcs/bootstrap-gitignore.ts
+++ b/apps/desktop/electron/vcs/bootstrap-gitignore.ts
@@ -1,0 +1,32 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export const WORKSPACE_BOOTSTRAP_GITIGNORE_PATTERNS = [
+  'node_modules/',
+  'dist/',
+  'build/',
+  '.DS_Store',
+  '*.log',
+  '.env',
+  '.env.local',
+  'coverage/',
+  '.sero/',
+  '.sero-workspace.json',
+  '__pycache__/',
+  '*.pyc',
+  'target/',
+  '.next/',
+  '.nuxt/',
+  '.turbo/',
+];
+
+export async function ensureBootstrapGitignore(workspacePath: string): Promise<void> {
+  const gitignorePath = path.join(workspacePath, '.gitignore');
+  const content = await fs.readFile(gitignorePath, 'utf8').catch(() => '');
+  const missing = WORKSPACE_BOOTSTRAP_GITIGNORE_PATTERNS.filter((pattern) => !content.includes(pattern));
+
+  if (missing.length === 0) return;
+
+  const separator = content && !content.endsWith('\n') ? '\n' : '';
+  await fs.writeFile(gitignorePath, content + separator + missing.join('\n') + '\n', 'utf8');
+}

--- a/apps/desktop/electron/vcs/git-runner.ts
+++ b/apps/desktop/electron/vcs/git-runner.ts
@@ -6,8 +6,8 @@ import { promisify } from 'util';
 
 import type { WorkspaceManager } from '../workspace';
 import type { ContainerManager } from '../container/index';
+import { buildWorkspaceContainerConfig } from '../container/workspace-container-config';
 import type { GitHubAuthManager } from '../github/auth-manager';
-import { buildContainerConfig } from '../ipc/shared-infra';
 import type { GitResult } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -57,7 +57,11 @@ export class GitRunner {
   ) {}
 
   private async ensureContainer(workspaceId: string, workspacePath: string): Promise<void> {
-    const config = await buildContainerConfig(workspaceId, workspacePath);
+    const config = await buildWorkspaceContainerConfig(
+      this.workspaceManager,
+      workspaceId,
+      workspacePath,
+    );
     await this.containerManager.ensure(config);
   }
 
@@ -142,9 +146,21 @@ export class GitRunner {
     const root = await this.run(workspaceId, ['rev-parse', '--git-dir']);
     if (root.exitCode === 0) return;
 
-    const init = await this.run(workspaceId, ['init']);
-    if (init.exitCode !== 0) {
+    const init = await this.run(workspaceId, ['init', '-b', 'main']);
+    if (init.exitCode === 0) return;
+
+    const supportsInitialBranch = !/(unknown switch|unknown option|usage: git init)/i.test(
+      init.stderr || init.stdout,
+    );
+    if (supportsInitialBranch) {
       throw new Error(init.stderr || 'Failed to initialize Git repository');
     }
+
+    const fallback = await this.run(workspaceId, ['init']);
+    if (fallback.exitCode !== 0) {
+      throw new Error(fallback.stderr || fallback.stdout || 'Failed to initialize Git repository');
+    }
+
+    await this.run(workspaceId, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
   }
 }

--- a/docs/kanban-first-pr-stability-task-list.md
+++ b/docs/kanban-first-pr-stability-task-list.md
@@ -1,0 +1,17 @@
+# Kanban First-PR Stability Task List
+
+Date: 2026-03-15
+
+Context:
+- Fresh repo `monobyte/helloworld1` ended up with GitHub default branch `feat/create-a-hello-world-app-3` instead of `main`.
+- The local git history is sane: `main` contains the initial commit and the feature branch contains the card work.
+- The broken remote default branch makes the repo UI look wrong and risks confusing PR/base-branch logic.
+- Review-stage UX was also misleading because an open PR could look like a broken "Mark Done" action instead of an explicit "still waiting on merge" state.
+
+Tasks:
+- [x] Confirm the exact failure mode in the `helloworld1` workspace, local git history, kanban state, and GitHub repo metadata.
+- [x] Fix GitHub repo creation so a brand-new repo pushes its initial branch when commits already exist, preventing the first feature branch push from becoming the remote default branch.
+- [x] Harden kanban PR bootstrap so first-PR flows repair the remote default branch to `main` after creating/pushing it, even for repos already created in a bad state.
+- [x] Keep review-stage PR status explicit in the UI so "still open" and "recheck" states are obvious.
+- [x] Repair the current `helloworld1` repo/workspace state if needed and verify the resulting branch/default-branch/PR behavior.
+- [x] Run verification (`pnpm typecheck` and targeted checks) and document residual risks.

--- a/packages/pi-kanban-extension/shared/types.ts
+++ b/packages/pi-kanban-extension/shared/types.ts
@@ -41,6 +41,8 @@ export interface PlanningProgress {
   agents: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools: PlanningToolEntry[];  // Last ~15 tool calls
   log: string[];               // Recent onUpdate lines (last ~20)
+  liveOutput?: string;         // Latest streamed subagent output preview
+  liveOutputSource?: string;   // Agent name that produced the latest preview
 }
 
 export interface ImplementationProgress {
@@ -51,6 +53,8 @@ export interface ImplementationProgress {
   agents: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools: PlanningToolEntry[];  // Last ~15 tool calls
   log: string[];               // Recent onUpdate lines (last ~20)
+  liveOutput?: string;         // Latest streamed subagent output preview
+  liveOutputSource?: string;   // Agent name that produced the latest preview
 }
 
 export interface ReviewProgress {
@@ -59,6 +63,8 @@ export interface ReviewProgress {
   agents: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools: PlanningToolEntry[];  // Last ~15 tool calls
   log: string[];               // Recent onUpdate lines (last ~20)
+  liveOutput?: string;         // Latest streamed subagent output preview
+  liveOutputSource?: string;   // Agent name that produced the latest preview
 }
 
 export interface Card {

--- a/packages/pi-kanban-extension/ui/components/ActivityPanel.tsx
+++ b/packages/pi-kanban-extension/ui/components/ActivityPanel.tsx
@@ -9,6 +9,8 @@
 
 import { useEffect, useRef, useState } from 'react';
 import type { PlanningToolEntry } from '../../shared/types';
+import { formatActivityLogLine } from './activity-panel-log';
+import { PhaseLiveOutputPreview } from './PhaseLiveOutputPreview';
 
 // ── Tool icons ──────────────────────────────────────────────
 
@@ -16,6 +18,7 @@ const TOOL_ICONS: Record<string, string> = {
   read: '📖', bash: '📂', write: '✏️', edit: '✏️',
   ls: '📁', find: '🔍', grep: '🔎', glob: '🔍',
 };
+const TOOL_LOG_PATTERN = /\s*\S+\s+(\w+):\s*(.+)/;
 
 function toolIcon(name: string): string {
   return TOOL_ICONS[name] ?? '🔧';
@@ -47,6 +50,9 @@ export interface ActivityPanelData {
   startedAt?: number;
   agents?: { name: string; status: 'running' | 'completed' | 'failed' }[];
   recentTools?: PlanningToolEntry[];
+  log?: string[];
+  liveOutput?: string;
+  liveOutputSource?: string;
 }
 
 interface ActivityPanelProps {
@@ -62,6 +68,10 @@ interface ActivityPanelProps {
   headerExtra?: React.ReactNode;
   /** Max height for the tool feed. Default: 160. */
   feedMaxHeight?: number;
+  /** Render textual status updates from `data.log`. */
+  showLogFeed?: boolean;
+  /** Max height for the text update feed. Default: 120. */
+  logFeedMaxHeight?: number;
 }
 
 // ── Component ───────────────────────────────────────────────
@@ -74,6 +84,8 @@ export function ActivityPanel({
   headerSlot,
   headerExtra,
   feedMaxHeight = 160,
+  showLogFeed = false,
+  logFeedMaxHeight = 120,
 }: ActivityPanelProps) {
   const [elapsed, setElapsed] = useState('');
   useEffect(() => {
@@ -85,14 +97,29 @@ export function ActivityPanel({
   }, [data?.startedAt]);
 
   const feedRef = useRef<HTMLDivElement>(null);
+  const latestTool = data?.recentTools?.[data.recentTools.length - 1];
   useEffect(() => {
     if (feedRef.current) {
       feedRef.current.scrollTop = feedRef.current.scrollHeight;
     }
-  }, [data?.recentTools?.length]);
+  }, [data?.recentTools?.length, latestTool?.tool, latestTool?.args, latestTool?.running]);
+
+  const logFeedRef = useRef<HTMLDivElement>(null);
+  const narrativeEntries = showLogFeed
+    ? (data?.log ?? []).filter((entry) => entry.trim() && !TOOL_LOG_PATTERN.test(entry))
+    : [];
+  const latestNarrativeEntry = narrativeEntries[narrativeEntries.length - 1];
+
+  useEffect(() => {
+    if (logFeedRef.current) {
+      logFeedRef.current.scrollTop = logFeedRef.current.scrollHeight;
+    }
+  }, [narrativeEntries.length, latestNarrativeEntry]);
 
   const hasAgents = (data?.agents?.length ?? 0) > 0;
   const hasTools = (data?.recentTools?.length ?? 0) > 0;
+  const hasNarrativeEntries = narrativeEntries.length > 0;
+  const hasLiveOutput = !!data?.liveOutput?.trim();
 
   return (
     <div
@@ -150,6 +177,23 @@ export function ActivityPanel({
         </div>
       )}
 
+      {hasLiveOutput && (
+        <PhaseLiveOutputPreview
+          source={data?.liveOutputSource}
+          text={data?.liveOutput}
+          theme={theme}
+        />
+      )}
+
+      {hasNarrativeEntries && (
+        <NarrativeFeed
+          feedRef={logFeedRef}
+          entries={narrativeEntries}
+          theme={theme}
+          maxHeight={logFeedMaxHeight}
+        />
+      )}
+
       {/* Tool activity feed */}
       {hasTools && (
         <ToolFeed
@@ -161,7 +205,7 @@ export function ActivityPanel({
       )}
 
       {/* Fallback */}
-      {(!data || (!hasTools && !hasAgents)) && (
+      {(!data || (!hasTools && !hasNarrativeEntries && !hasLiveOutput)) && (
         <p style={{ fontSize: '11px', color: '#5c5e6a', lineHeight: 1.4, padding: '0 14px 12px' }}>
           {fallbackText}
         </p>
@@ -289,4 +333,109 @@ function ToolFeed({
       ))}
     </div>
   );
+}
+
+// ── Narrative status feed ───────────────────────────────────
+
+function NarrativeFeed({
+  feedRef,
+  entries,
+  theme,
+  maxHeight,
+}: {
+  feedRef: React.RefObject<HTMLDivElement | null>;
+  entries: string[];
+  theme: ActivityPanelTheme;
+  maxHeight: number;
+}) {
+  return (
+    <div
+      ref={feedRef}
+      style={{
+        maxHeight: `${maxHeight}px`,
+        overflowY: 'auto',
+        borderTop: '1px solid rgba(255, 255, 255, 0.05)',
+        padding: '8px 14px 2px',
+      }}
+      className="kb-scrollbar"
+    >
+      {entries.map((entry, i) => (
+        <NarrativeEntry
+          key={`${entry}-${i}`}
+          entry={entry}
+          theme={theme}
+        />
+      ))}
+    </div>
+  );
+}
+
+function NarrativeEntry({
+  entry,
+  theme,
+}: {
+  entry: string;
+  theme: ActivityPanelTheme;
+}) {
+  const formattedEntry = formatActivityLogLine(entry);
+  const tone = resolveLogTone(formattedEntry);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '8px',
+        padding: '0 0 6px',
+      }}
+    >
+      <span
+        style={{
+          display: 'inline-block',
+          width: '6px',
+          height: '6px',
+          borderRadius: '50%',
+          backgroundColor: tone === 'running'
+            ? theme.primary
+            : tone === 'success'
+              ? '#34d399'
+              : tone === 'error'
+                ? '#f87171'
+                : tone === 'warning'
+                  ? '#f59e0b'
+                  : 'rgba(255, 255, 255, 0.18)',
+          animation: tone === 'running' ? 'kb-pulse 1.8s ease-in-out infinite' : undefined,
+          flexShrink: 0,
+          marginTop: '4px',
+        }}
+      />
+      <p
+        className="whitespace-pre-wrap break-words"
+        style={{
+          fontSize: '10px',
+          lineHeight: 1.45,
+          color: tone === 'success'
+            ? '#86efac'
+            : tone === 'error'
+              ? '#fca5a5'
+              : tone === 'warning'
+                ? '#fcd34d'
+                : tone === 'running'
+                  ? theme.primaryText
+                  : '#8b8d97',
+          minWidth: 0,
+        }}
+      >
+        {formattedEntry}
+      </p>
+    </div>
+  );
+}
+
+function resolveLogTone(entry: string): 'running' | 'success' | 'error' | 'warning' | 'neutral' {
+  if (entry.startsWith('🔄')) return 'running';
+  if (entry.startsWith('✅')) return 'success';
+  if (entry.startsWith('❌')) return 'error';
+  if (entry.startsWith('⚠️')) return 'warning';
+  return 'neutral';
 }

--- a/packages/pi-kanban-extension/ui/components/CardDetail.tsx
+++ b/packages/pi-kanban-extension/ui/components/CardDetail.tsx
@@ -20,6 +20,7 @@ import { PlanApprovalPanel } from './PlanApprovalPanel';
 import { DescriptionEditor } from './DescriptionEditor';
 import { CardDetailFooter } from './CardDetailFooter';
 import { applyManualMove, applyWorkflowTransition } from '../lib/card-workflow';
+import { isReviewMergeStatusMessage } from '../lib/review-pr-status';
 import { getManualMoveTargets } from '../../shared/validation';
 
 export function CardDetail({
@@ -64,7 +65,7 @@ export function CardDetail({
     onUpdate((prev) => applyWorkflowTransition(prev, card.id, 'in-progress'));
   }, [card, onUpdate]);
 
-  const handleComplete = useCallback(() => {
+  const handleCheckMergeStatus = useCallback(() => {
     if (!card) return;
     onUpdate((prev) => applyWorkflowTransition(prev, card.id, 'done'));
   }, [card, onUpdate]);
@@ -344,11 +345,16 @@ export function CardDetail({
 
               {/* PR ready — awaiting user completion */}
               {card.column === 'review' && card.status === 'waiting-input' && card.prUrl && (
-                <ReviewStatusPanel card={card} onComplete={handleComplete} />
+                <ReviewStatusPanel card={card} onCheckMerge={handleCheckMergeStatus} />
               )}
 
               {/* Error */}
-              {card.error && (
+              {card.error && !(
+                card.column === 'review'
+                && card.status === 'waiting-input'
+                && card.prUrl
+                && isReviewMergeStatusMessage(card.error)
+              ) && (
                 <div
                   style={{
                     borderRadius: '8px',
@@ -370,7 +376,12 @@ export function CardDetail({
                   >
                     Error
                   </h3>
-                  <p className="text-xs leading-relaxed" style={{ color: '#fca5a5' }}>{card.error}</p>
+                  <p
+                    className="text-xs leading-relaxed"
+                    style={{ color: '#fca5a5', whiteSpace: 'pre-wrap' }}
+                  >
+                    {card.error}
+                  </p>
                 </div>
               )}
 

--- a/packages/pi-kanban-extension/ui/components/CardView.tsx
+++ b/packages/pi-kanban-extension/ui/components/CardView.tsx
@@ -10,6 +10,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import type { Card } from '../../shared/types';
 import { CardStatusDot, SubtaskStatusDot } from './StatusDot';
 import { PriorityBadge } from './PriorityBadge';
+import { getReviewPrStatus } from '../lib/review-pr-status';
 
 function cn(...classes: (string | false | undefined | null)[]): string {
   return classes.filter(Boolean).join(' ');
@@ -23,6 +24,9 @@ export function CardView({
   onSelect: (card: Card) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const reviewPrStatus = card.column === 'review' && card.status === 'waiting-input' && card.prUrl
+    ? getReviewPrStatus(card)
+    : null;
 
   const progress =
     card.subtasks.length > 0
@@ -121,18 +125,18 @@ export function CardView({
             </span>
           </div>
         )}
-        {card.column === 'review' && card.status === 'waiting-input' && card.prUrl && (
+        {reviewPrStatus && (
           <div className="mt-1.5 ml-4">
             <span
               className="inline-flex items-center rounded-md text-[10px] font-medium leading-none"
               style={{
                 padding: '3px 7px',
-                backgroundColor: 'rgba(52, 211, 153, 0.1)',
-                color: '#34d399',
-                border: '1px solid rgba(52, 211, 153, 0.2)',
+                backgroundColor: reviewPrStatus.tone.background,
+                color: reviewPrStatus.tone.accent,
+                border: `1px solid ${reviewPrStatus.tone.border}`,
               }}
             >
-              PR ready — merge &amp; mark done
+              {reviewPrStatus.title}
             </span>
           </div>
         )}

--- a/packages/pi-kanban-extension/ui/components/PhaseLiveOutputPreview.tsx
+++ b/packages/pi-kanban-extension/ui/components/PhaseLiveOutputPreview.tsx
@@ -1,0 +1,68 @@
+import type { ActivityPanelTheme } from './ActivityPanel';
+import { formatLiveOutputText } from './activity-panel-log';
+
+export function PhaseLiveOutputPreview({
+  source,
+  text,
+  theme,
+}: {
+  source?: string;
+  text?: string;
+  theme: ActivityPanelTheme;
+}) {
+  if (!text?.trim()) return null;
+
+  const formatted = formatLiveOutputText(text);
+  const preview = formatted.length > 700 ? `…${formatted.slice(-700)}` : formatted;
+
+  return (
+    <div
+      style={{
+        padding: '8px 14px 0',
+      }}
+    >
+      <div
+        style={{
+          borderRadius: '7px',
+          border: `1px solid ${theme.border}`,
+          backgroundColor: 'rgba(0, 0, 0, 0.18)',
+          padding: '8px 10px',
+        }}
+      >
+        <div
+          className="flex items-center gap-2"
+          style={{ marginBottom: '6px' }}
+        >
+          <span
+            style={{
+              fontSize: '10px',
+              fontWeight: 600,
+              color: theme.primaryText,
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+            }}
+          >
+            {source ? `${source} live output` : 'Live output'}
+          </span>
+          <span style={{ color: theme.primary, fontSize: '10px', animation: 'kb-pulse 1.6s ease-in-out infinite' }}>
+            █
+          </span>
+        </div>
+        <pre
+          className="kb-scrollbar whitespace-pre-wrap break-words"
+          style={{
+            maxHeight: '132px',
+            overflowY: 'auto',
+            fontSize: '10px',
+            lineHeight: 1.55,
+            color: '#b7b9c5',
+            margin: 0,
+            fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+          }}
+        >
+          {preview}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/packages/pi-kanban-extension/ui/components/PlanningActivityPanel.tsx
+++ b/packages/pi-kanban-extension/ui/components/PlanningActivityPanel.tsx
@@ -22,6 +22,7 @@ export function PlanningActivityPanel({ progress }: { progress?: PlanningProgres
       data={progress}
       defaultPhase="Planning in progress…"
       fallbackText="Analysing codebase and generating implementation plan with subtasks."
+      showLogFeed
     />
   );
 }

--- a/packages/pi-kanban-extension/ui/components/ReviewStatusPanel.tsx
+++ b/packages/pi-kanban-extension/ui/components/ReviewStatusPanel.tsx
@@ -4,32 +4,35 @@
  */
 
 import type { Card } from '../../shared/types';
+import { getReviewPrStatus } from '../lib/review-pr-status';
 
 export function ReviewStatusPanel({
   card,
-  onComplete,
+  onCheckMerge,
 }: {
   card: Card;
-  onComplete: () => void;
+  onCheckMerge: () => void;
 }) {
+  const status = getReviewPrStatus(card);
+
   return (
     <div style={{ marginBottom: '20px' }}>
       <div
         style={{
           padding: '14px',
           borderRadius: '8px',
-          border: '1px solid rgba(52, 211, 153, 0.2)',
-          backgroundColor: 'rgba(52, 211, 153, 0.04)',
+          border: `1px solid ${status.tone.border}`,
+          backgroundColor: status.tone.background,
           marginBottom: '12px',
         }}
       >
         <div className="flex items-center" style={{ gap: '10px', marginBottom: '8px' }}>
-          <span style={{ fontSize: '12px', fontWeight: 500, color: '#34d399' }}>
-            PR #{card.prNumber} created
+          <span style={{ fontSize: '12px', fontWeight: 500, color: status.tone.accent }}>
+            {status.title}
           </span>
         </div>
-        <p style={{ fontSize: '11px', color: '#8b8d97', lineHeight: 1.4, marginBottom: '8px' }}>
-          Review and merge the PR, then mark this card as done.
+        <p style={{ fontSize: '11px', color: status.tone.text, lineHeight: 1.4, marginBottom: '8px' }}>
+          {status.description}
         </p>
         {card.prUrl && (
           <a
@@ -48,21 +51,21 @@ export function ReviewStatusPanel({
         )}
       </div>
       <button
-        onClick={onComplete}
+        onClick={onCheckMerge}
         style={{
           width: '100%',
           padding: '10px 16px',
           borderRadius: '8px',
           border: 'none',
-          backgroundColor: '#34d399',
-          color: '#0f1117',
+          backgroundColor: status.tone.buttonBackground,
+          color: status.tone.buttonText,
           fontSize: '13px',
           fontWeight: 600,
           cursor: 'pointer',
           transition: 'all 0.15s',
         }}
       >
-        Mark Done
+        {status.actionLabel}
       </button>
     </div>
   );

--- a/packages/pi-kanban-extension/ui/components/activity-panel-log.ts
+++ b/packages/pi-kanban-extension/ui/components/activity-panel-log.ts
@@ -1,0 +1,49 @@
+const COMPLETION_LINE_PATTERN = /^(✅|❌)\s+(.+?)\s+(completed|failed)\s+\(([^,]+),\s+([\d,]+)\s+tokens\)$/;
+const START_LINE_PATTERN = /^🔄\s+(.+?)\s+started\s+—\s+".*"$/;
+const FAILURE_LINE_PATTERN = /^❌\s+(.+?)\s+failed\s+—\s+(.+)$/;
+const EXPECTED_SCAFFOLD_PATTERN = /The scaffolder cancelled because existing files are present\./gi;
+const EXPECTED_SCAFFOLD_WORKAROUND_PATTERN = /Let me work around this by scaffolding to a temp directory and moving files over\./gi;
+
+function formatTokenCount(raw: string): string {
+  const count = Number.parseInt(raw.replaceAll(',', ''), 10);
+  if (!Number.isFinite(count)) return raw;
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(count >= 10_000_000 ? 0 : 1)}M`;
+  if (count >= 10_000) return `${Math.round(count / 1_000)}k`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return count.toLocaleString();
+}
+
+export function formatActivityLogLine(entry: string): string {
+  const trimmed = entry.trim();
+  const completionMatch = trimmed.match(COMPLETION_LINE_PATTERN);
+  if (completionMatch) {
+    const [, prefix, agent, status, duration, tokens] = completionMatch;
+    const outcome = status === 'completed' ? 'finished' : 'failed';
+    return `${prefix} ${agent} ${outcome} in ${duration}, ${formatTokenCount(tokens)} tokens`;
+  }
+
+  const startMatch = trimmed.match(START_LINE_PATTERN);
+  if (startMatch) {
+    return `🔄 ${startMatch[1]} started`;
+  }
+
+  const failureMatch = trimmed.match(FAILURE_LINE_PATTERN);
+  if (failureMatch) {
+    return `❌ ${failureMatch[1]} failed: ${failureMatch[2]}`;
+  }
+
+  return trimmed;
+}
+
+export function formatLiveOutputText(entry: string): string {
+  return entry
+    .replace(
+      EXPECTED_SCAFFOLD_PATTERN,
+      'The worktree already has repo metadata, so I am scaffolding in a temporary directory instead.',
+    )
+    .replace(
+      EXPECTED_SCAFFOLD_WORKAROUND_PATTERN,
+      'This is expected for kanban worktrees; the generated files will be copied into place.',
+    )
+    .trim();
+}

--- a/packages/pi-kanban-extension/ui/lib/review-pr-status.ts
+++ b/packages/pi-kanban-extension/ui/lib/review-pr-status.ts
@@ -1,0 +1,97 @@
+import type { Card } from '../../shared/types';
+
+export type ReviewPrState = 'awaiting-merge' | 'open' | 'closed' | 'unknown';
+
+interface ReviewPrStatus {
+  state: ReviewPrState;
+  title: string;
+  description: string;
+  actionLabel: string;
+  tone: {
+    border: string;
+    background: string;
+    accent: string;
+    text: string;
+    buttonBackground: string;
+    buttonText: string;
+  };
+}
+
+const OPEN_MESSAGE = /still open/i;
+const CLOSED_MESSAGE = /closed without merging/i;
+const UNKNOWN_MESSAGE = /could not verify whether pr/i;
+
+export function getReviewPrStatus(card: Pick<Card, 'prNumber' | 'error'>): ReviewPrStatus {
+  const prLabel = card.prNumber ? `PR #${card.prNumber}` : 'PR';
+
+  if (card.error && OPEN_MESSAGE.test(card.error)) {
+    return {
+      state: 'open',
+      title: `${prLabel} still open`,
+      description: 'GitHub still shows this pull request as open. Merge it first, then recheck the status here.',
+      actionLabel: 'Recheck Merge Status',
+      tone: {
+        border: 'rgba(245, 158, 11, 0.24)',
+        background: 'rgba(245, 158, 11, 0.06)',
+        accent: '#f59e0b',
+        text: '#fcd34d',
+        buttonBackground: '#f59e0b',
+        buttonText: '#0f1117',
+      },
+    };
+  }
+
+  if (card.error && CLOSED_MESSAGE.test(card.error)) {
+    return {
+      state: 'closed',
+      title: `${prLabel} closed without merge`,
+      description: 'This pull request was closed without being merged. Re-open it or create a replacement PR before finishing the card.',
+      actionLabel: 'Recheck Merge Status',
+      tone: {
+        border: 'rgba(248, 113, 113, 0.24)',
+        background: 'rgba(248, 113, 113, 0.05)',
+        accent: '#f87171',
+        text: '#fca5a5',
+        buttonBackground: '#f87171',
+        buttonText: '#0f1117',
+      },
+    };
+  }
+
+  if (card.error && UNKNOWN_MESSAGE.test(card.error)) {
+    return {
+      state: 'unknown',
+      title: `${prLabel} merge status unknown`,
+      description: 'Sero could not confirm the GitHub merge state. Recheck once GitHub is reachable and the PR is merged.',
+      actionLabel: 'Recheck Merge Status',
+      tone: {
+        border: 'rgba(129, 140, 248, 0.24)',
+        background: 'rgba(129, 140, 248, 0.06)',
+        accent: '#818cf8',
+        text: '#c7d2fe',
+        buttonBackground: '#818cf8',
+        buttonText: '#0f1117',
+      },
+    };
+  }
+
+  return {
+    state: 'awaiting-merge',
+    title: `${prLabel} awaiting merge`,
+    description: 'Merge the pull request on GitHub, then check its status here to move the card to Done and unlock dependent work.',
+    actionLabel: 'Check Merge Status',
+    tone: {
+      border: 'rgba(52, 211, 153, 0.2)',
+      background: 'rgba(52, 211, 153, 0.04)',
+      accent: '#34d399',
+      text: '#8b8d97',
+      buttonBackground: '#34d399',
+      buttonText: '#0f1117',
+    },
+  };
+}
+
+export function isReviewMergeStatusMessage(error: string | undefined): boolean {
+  if (!error) return false;
+  return OPEN_MESSAGE.test(error) || CLOSED_MESSAGE.test(error) || UNKNOWN_MESSAGE.test(error);
+}


### PR DESCRIPTION
## Summary
- surface live phase output more prominently across planning, implementation, and review
- add review auto-revision, merge-status reconciliation, and clearer PR state UX in kanban
- fix first-repo bootstrap so fresh workspaces create and push a real main branch before PRs
- run kanban verification in the workspace execution environment and tighten worktree/container prompts

## Testing
- pnpm --filter @sero/desktop test -- --run electron/__tests__/github/repo-ops.test.ts
- pnpm typecheck