### PR TITLE
perf: selective preloading + LRU eviction for federated app modules

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -74,6 +74,7 @@
     "electron": "github:castlabs/electron-releases#v33.4.11+wvcus",
     "electron-builder": "^25.1.8",
     "esbuild": "^0.27.4",
+    "jsdom": "^26.1.0",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -10,12 +10,9 @@ import { TitleBar } from '@/components/layout/TitleBar';
 import { MainSidebar } from '@/components/layout/MainSidebar';
 import { StatusBar } from '@/components/layout/StatusBar';
 import { ChatPanel } from '@/components/layout/ChatPanel';
-import { CodingWorkspace } from '@/components/apps/coding/CodingWorkspace';
-import { SeroAppMount } from '@/components/apps/SeroAppMount';
-import { useAppStore, discoverAndRegisterApps, listenForNewApps, loadLayout } from '@/stores/app';
+import { useAppStore, listenForNewApps } from '@/stores/app';
 import { listenForSystemThemeChanges } from '@/stores/theme';
 import { useProfileStore, loadProfiles } from '@/stores/profiles';
-import { loadWorkspaces } from '@/stores/workspace';
 import { ProfileSetup } from '@/components/profiles/ProfileSetup';
 import { OnboardingWizard } from '@/components/profiles/OnboardingWizard';
 import { subscribeDevServerEvents } from '@/stores/dev-server';
@@ -24,6 +21,8 @@ import { useSessionAgent } from '@/hooks/useSessionAgent';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { CommandMenu } from '@/components/layout/CommandMenu';
 import { initAppControlBridge } from '@/lib/app-control-bridge';
+import { hydrateShellState } from '@/lib/app-startup';
+import { ActiveAppPanel } from '@/components/apps/ActiveAppPanel';
 
 /**
  * App shell.
@@ -44,6 +43,7 @@ import { initAppControlBridge } from '@/lib/app-control-bridge';
  * it persists across all apps.
  */
 export function App() {
+  const activeApp = useAppStore((s) => s.activeApp);
   const mainSidebarOpen = useAppStore((s) => s.mainSidebarOpen);
   const setMainSidebarOpen = useAppStore((s) => s.setMainSidebarOpen);
   const chatPanelOpen = useAppStore((s) => s.chatPanelOpen);
@@ -91,12 +91,10 @@ export function App() {
     chatPanelDefaultRef.current = s.chatPanelOpen ? `${s.chatPanelSizePct}%` : 0;
   }
 
-  // Load profiles + layout + discover apps + workspaces on startup
+  // Load profiles + hydrate app/workspace state on startup
   useEffect(() => {
-    loadProfiles();
-    loadLayout();
-    loadWorkspaces();
-    discoverAndRegisterApps();
+    void loadProfiles();
+    void hydrateShellState();
     const unsub = listenForNewApps();
     const unsubTheme = listenForSystemThemeChanges();
     return () => { unsub(); unsubTheme(); };
@@ -259,7 +257,7 @@ export function App() {
             />
 
             <ResizablePanel id="active-app-panel" minSize={40} className="min-w-0 flex flex-col">
-              <ActiveApp />
+              <ActiveAppPanel app={activeApp} />
             </ResizablePanel>
 
             <ResizableHandle
@@ -287,47 +285,5 @@ export function App() {
         <StatusBar />
       </div>
     </TooltipProvider>
-  );
-}
-
-/**
- * Renders the currently active app — built-in or federated.
- *
- * `setActiveApp` wraps the state update in `startTransition`, so React
- * keeps showing the previous app while a non-preloaded lazy module
- * resolves. The store's `pendingApp` field is set eagerly (outside the
- * transition) to drive the opacity hint while loading.
- */
-function ActiveApp() {
-  const activeApp = useAppStore((s) => s.activeApp);
-  const pendingApp = useAppStore((s) => s.pendingApp);
-  const apps = useAppStore((s) => s.apps);
-  const entry = apps.find((a) => a.id === activeApp);
-
-  let content: React.ReactNode;
-
-  if (activeApp === 'coding') {
-    content = <CodingWorkspace />;
-  } else if (entry?.manifest) {
-    // Discovered sero app — mount via module federation
-    content = <SeroAppMount manifest={entry.manifest} />;
-  } else {
-    content = (
-      <div className="flex h-full items-center justify-center bg-[var(--bg-base)]">
-        <span className="text-sm capitalize text-[var(--text-muted)]">
-          {activeApp} app — coming soon
-        </span>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      data-app-panel
-      className="flex min-h-0 min-w-[500px] flex-1 flex-col overflow-hidden transition-opacity duration-150"
-      style={{ opacity: pendingApp ? 0.7 : 1 }}
-    >
-      {content}
-    </div>
   );
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useDeferredValue, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { PanelImperativeHandle } from 'react-resizable-panels';
 import { TooltipProvider } from '@sero/ui/components/ui/tooltip';
 import {
@@ -293,22 +293,20 @@ export function App() {
 /**
  * Renders the currently active app — built-in or federated.
  *
- * Uses `useDeferredValue` so React keeps showing the previous app
- * while a newly-selected app's lazy module loads. For preloaded apps
- * (active + favourites), the lazy wrapper resolves synchronously so
- * there's no flash at all. For on-demand apps, the deferred value
- * keeps the old app visible during the load.
+ * `setActiveApp` wraps the state update in `startTransition`, so React
+ * keeps showing the previous app while a non-preloaded lazy module
+ * resolves. The store's `pendingApp` field is set eagerly (outside the
+ * transition) to drive the opacity hint while loading.
  */
 function ActiveApp() {
   const activeApp = useAppStore((s) => s.activeApp);
-  const deferredApp = useDeferredValue(activeApp);
-  const isPending = activeApp !== deferredApp;
+  const pendingApp = useAppStore((s) => s.pendingApp);
   const apps = useAppStore((s) => s.apps);
-  const entry = apps.find((a) => a.id === deferredApp);
+  const entry = apps.find((a) => a.id === activeApp);
 
   let content: React.ReactNode;
 
-  if (deferredApp === 'coding') {
+  if (activeApp === 'coding') {
     content = <CodingWorkspace />;
   } else if (entry?.manifest) {
     // Discovered sero app — mount via module federation
@@ -317,7 +315,7 @@ function ActiveApp() {
     content = (
       <div className="flex h-full items-center justify-center bg-[var(--bg-base)]">
         <span className="text-sm capitalize text-[var(--text-muted)]">
-          {deferredApp} app — coming soon
+          {activeApp} app — coming soon
         </span>
       </div>
     );
@@ -327,7 +325,7 @@ function ActiveApp() {
     <div
       data-app-panel
       className="flex min-h-0 min-w-[500px] flex-1 flex-col overflow-hidden transition-opacity duration-150"
-      style={{ opacity: isPending ? 0.7 : 1 }}
+      style={{ opacity: pendingApp ? 0.7 : 1 }}
     >
       {content}
     </div>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,7 +15,7 @@ import { SeroAppMount } from '@/components/apps/SeroAppMount';
 import { useAppStore, discoverAndRegisterApps, listenForNewApps, loadLayout } from '@/stores/app';
 import { listenForSystemThemeChanges } from '@/stores/theme';
 import { useProfileStore, loadProfiles } from '@/stores/profiles';
-import { useWorkspaceStore, loadWorkspaces } from '@/stores/workspace';
+import { loadWorkspaces } from '@/stores/workspace';
 import { ProfileSetup } from '@/components/profiles/ProfileSetup';
 import { OnboardingWizard } from '@/components/profiles/OnboardingWizard';
 import { subscribeDevServerEvents } from '@/stores/dev-server';
@@ -44,7 +44,6 @@ import { initAppControlBridge } from '@/lib/app-control-bridge';
  * it persists across all apps.
  */
 export function App() {
-  const activeApp = useAppStore((s) => s.activeApp);
   const mainSidebarOpen = useAppStore((s) => s.mainSidebarOpen);
   const setMainSidebarOpen = useAppStore((s) => s.setMainSidebarOpen);
   const chatPanelOpen = useAppStore((s) => s.chatPanelOpen);
@@ -72,7 +71,6 @@ export function App() {
 
   const appsReady = useAppStore((s) => s.appsReady);
   const layoutReady = useAppStore((s) => s.layoutReady);
-  const workspacesReady = useWorkspaceStore((s) => s.workspacesReady);
   const profileReady = useProfileStore((s) => s.ready);
   const hasActiveProfile = useProfileStore((s) => s.hasActiveProfile);
 
@@ -84,7 +82,7 @@ export function App() {
 
   // Hydrate refs from store once layout has loaded. Runs during render (not
   // an effect) so refs are set BEFORE the JSX tree mounts the panels.
-  if (layoutReady && appsReady && workspacesReady && !layoutHydratedRef.current) {
+  if (layoutReady && appsReady && !layoutHydratedRef.current) {
     layoutHydratedRef.current = true;
     const s = useAppStore.getState();
     mainSidebarLastExpandedPctRef.current = s.mainSidebarSizePct;
@@ -216,8 +214,10 @@ export function App() {
     };
   }, [chatPanelOpen, layoutReady, appsReady]);
 
-  // Wait for profile + layout hydration + app discovery + workspaces before rendering.
-  if (!profileReady || !appsReady || !layoutReady || !workspacesReady) {
+  // Wait for profile + layout hydration + app discovery before rendering.
+  // Workspaces load in parallel but don't block — workspace-scoped apps
+  // already guard on activeWorkspaceId inside SeroAppMount.
+  if (!profileReady || !appsReady || !layoutReady) {
     return (
       <div className="flex h-screen w-screen items-center justify-center bg-[var(--bg-base)]">
         <span className="text-xs text-[var(--text-muted)]">Loading…</span>
@@ -259,7 +259,7 @@ export function App() {
             />
 
             <ResizablePanel id="active-app-panel" minSize={40} className="min-w-0 flex flex-col">
-              <ActiveApp app={activeApp} />
+              <ActiveApp />
             </ResizablePanel>
 
             <ResizableHandle
@@ -294,12 +294,15 @@ export function App() {
  * Renders the currently active app — built-in or federated.
  *
  * Uses `useDeferredValue` so React keeps showing the previous app
- * while a newly-selected app's lazy module loads. Without this,
- * the Suspense fallback (loading spinner) flashes on first open.
+ * while a newly-selected app's lazy module loads. For preloaded apps
+ * (active + favourites), the lazy wrapper resolves synchronously so
+ * there's no flash at all. For on-demand apps, the deferred value
+ * keeps the old app visible during the load.
  */
-function ActiveApp({ app }: { app: string }) {
-  const deferredApp = useDeferredValue(app);
-  const isPending = app !== deferredApp;
+function ActiveApp() {
+  const activeApp = useAppStore((s) => s.activeApp);
+  const deferredApp = useDeferredValue(activeApp);
+  const isPending = activeApp !== deferredApp;
   const apps = useAppStore((s) => s.apps);
   const entry = apps.find((a) => a.id === deferredApp);
 

--- a/apps/desktop/src/components/apps/ActiveAppPanel.test.tsx
+++ b/apps/desktop/src/components/apps/ActiveAppPanel.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SeroAppManifest } from '@/types/ipc';
+
+const federationMocks = vi.hoisted(() => {
+  let resolvePreload: (() => void) | null = null;
+  let preloadPromise: Promise<void> | null = null;
+
+  return {
+    reset() {
+      preloadPromise = new Promise<void>((resolve) => {
+        resolvePreload = resolve;
+      });
+    },
+    resolve() {
+      resolvePreload?.();
+    },
+    wait() {
+      if (!preloadPromise) throw new Error('preload promise not initialised');
+      return preloadPromise;
+    },
+    preloadFederatedModule: vi.fn<() => Promise<void>>(),
+  };
+});
+
+vi.mock('@/lib/federation-registry', () => ({
+  preloadFederatedModule: federationMocks.preloadFederatedModule,
+}));
+
+vi.mock('@/components/apps/coding/CodingWorkspace', () => ({
+  CodingWorkspace: () => <div>coding workspace</div>,
+}));
+
+vi.mock('@/components/apps/SeroAppMount', () => ({
+  SeroAppMount: ({ manifest }: { manifest: { id: string } }) => (
+    <div>{manifest.id} remote</div>
+  ),
+}));
+
+import { ActiveAppPanel } from './ActiveAppPanel';
+import { useAppStore } from '@/stores/app';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function createManifest(id: string, name: string): SeroAppManifest {
+  return {
+    id,
+    name,
+    description: null,
+    version: '1.0.0',
+    packageName: `@sero/${id}`,
+    icon: 'box',
+    stateFile: `.sero/apps/${id}/state.json`,
+    scope: 'workspace',
+    globalStatePath: null,
+    uiEntry: `sero-ext://${id}/mf-manifest.json`,
+    component: `${name}App`,
+    devPort: 4100,
+    packagePath: `/tmp/${id}`,
+  };
+}
+
+function ActiveAppHarness() {
+  const activeApp = useAppStore((s) => s.activeApp);
+  return <ActiveAppPanel app={activeApp} />;
+}
+
+describe('ActiveAppPanel', () => {
+  const initialAppState = useAppStore.getState();
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    federationMocks.reset();
+    federationMocks.preloadFederatedModule.mockImplementation(() => federationMocks.wait());
+
+    useAppStore.setState({
+      ...initialAppState,
+      activeApp: 'coding',
+      pendingApp: null,
+      apps: [
+        ...initialAppState.apps.filter((app) => app.id !== 'todo'),
+        {
+          id: 'todo',
+          label: 'Todo',
+          icon: 'check-square',
+          builtin: false,
+          manifest: createManifest('todo', 'Todo'),
+        },
+      ],
+    }, true);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+    federationMocks.preloadFederatedModule.mockReset();
+    useAppStore.setState(initialAppState, true);
+  });
+
+  it('keeps rendering the previous app until the next federated app finishes preloading', async () => {
+    const preload = federationMocks.wait();
+
+    await act(async () => {
+      root?.render(<ActiveAppHarness />);
+    });
+
+    expect(container.textContent).toContain('coding workspace');
+
+    await act(async () => {
+      useAppStore.getState().setActiveApp('todo');
+    });
+
+    expect(useAppStore.getState().activeApp).toBe('coding');
+    expect(useAppStore.getState().pendingApp).toBe('todo');
+    expect(container.textContent).toContain('coding workspace');
+    expect(container.textContent).not.toContain('todo remote');
+
+    await act(async () => {
+      federationMocks.resolve();
+      await preload;
+    });
+
+    expect(useAppStore.getState().activeApp).toBe('todo');
+    expect(useAppStore.getState().pendingApp).toBeNull();
+    expect(container.textContent).toContain('todo remote');
+  });
+});

--- a/apps/desktop/src/components/apps/ActiveAppPanel.tsx
+++ b/apps/desktop/src/components/apps/ActiveAppPanel.tsx
@@ -1,0 +1,43 @@
+import { CodingWorkspace } from '@/components/apps/coding/CodingWorkspace';
+import { SeroAppMount } from '@/components/apps/SeroAppMount';
+import { useAppStore } from '@/stores/app';
+
+interface ActiveAppPanelProps {
+  app: string;
+}
+
+/**
+ * Renders the currently visible app. The store keeps `activeApp` pinned to
+ * the previous value while a new federated module preloads in the background.
+ */
+export function ActiveAppPanel({ app }: ActiveAppPanelProps) {
+  const pendingApp = useAppStore((s) => s.pendingApp);
+  const apps = useAppStore((s) => s.apps);
+  const entry = apps.find((candidate) => candidate.id === app);
+
+  let content: React.ReactNode;
+
+  if (app === 'coding') {
+    content = <CodingWorkspace />;
+  } else if (entry?.manifest) {
+    content = <SeroAppMount manifest={entry.manifest} />;
+  } else {
+    content = (
+      <div className="flex h-full items-center justify-center bg-[var(--bg-base)]">
+        <span className="text-sm capitalize text-[var(--text-muted)]">
+          {app} app — coming soon
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-app-panel
+      className="flex min-h-0 min-w-[500px] flex-1 flex-col overflow-hidden transition-opacity duration-150"
+      style={{ opacity: pendingApp ? 0.7 : 1 }}
+    >
+      {content}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/apps/SeroAppMount.test.tsx
+++ b/apps/desktop/src/components/apps/SeroAppMount.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { SeroAppManifest } from '@/types/ipc';
+import { useThemeStore } from '@/stores/theme';
+import { useWorkspaceStore } from '@/stores/workspace';
+
+const federationMocks = vi.hoisted(() => ({
+  getFederatedComponent: vi.fn(),
+}));
+
+vi.mock('@/lib/federation-registry', () => ({
+  getFederatedComponent: federationMocks.getFederatedComponent,
+}));
+
+import { SeroAppMount } from './SeroAppMount';
+
+function createManifest(id: string, name: string): SeroAppManifest {
+  return {
+    id,
+    name,
+    description: null,
+    version: '1.0.0',
+    packageName: `@sero/${id}`,
+    icon: 'box',
+    stateFile: `.sero/apps/${id}/state.json`,
+    scope: 'workspace',
+    globalStatePath: null,
+    uiEntry: `sero-ext://${id}/mf-manifest.json`,
+    component: `${name}App`,
+    devPort: 4100,
+    packagePath: `/tmp/${id}`,
+  };
+}
+
+describe('SeroAppMount', () => {
+  it('shows a loading state while workspace data is still hydrating', () => {
+    useWorkspaceStore.setState({
+      activeWorkspaceId: 'workspace-1',
+      workspaces: [],
+      workspacesReady: false,
+    });
+    useThemeStore.setState({
+      effectiveMode: 'dark',
+      activePresetId: 'default',
+    });
+
+    const html = renderToStaticMarkup(
+      <SeroAppMount manifest={createManifest('todo', 'Todo')} />,
+    );
+
+    expect(html).toContain('Loading Todo');
+    expect(html).not.toContain('No workspace selected');
+    expect(federationMocks.getFederatedComponent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/components/apps/SeroAppMount.tsx
+++ b/apps/desktop/src/components/apps/SeroAppMount.tsx
@@ -26,6 +26,7 @@ interface SeroAppMountProps {
 
 export function SeroAppMount({ manifest }: SeroAppMountProps) {
   const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+  const workspacesReady = useWorkspaceStore((s) => s.workspacesReady);
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const effectiveMode = useThemeStore((s) => s.effectiveMode);
   const activePresetId = useThemeStore((s) => s.activePresetId);
@@ -69,15 +70,18 @@ export function SeroAppMount({ manifest }: SeroAppMountProps) {
     [manifest.id, activeWorkspaceId, stateFilePath, workspacePath, promptAgent, effectiveMode, activePresetId],
   );
 
+  // Workspace-scoped apps need an active workspace; global apps don't
+  if (!isGlobal && !workspacesReady) {
+    return <AppLoading name={manifest.name} />;
+  }
+  if (!isGlobal && !workspacePath) {
+    return <AppPlaceholder name={manifest.name} reason="No workspace selected" />;
+  }
+
   const LazyComponent = getFederatedComponent(manifest.id, manifest.component, manifest.devPort);
 
   if (!LazyComponent) {
     return <AppPlaceholder name={manifest.name} reason="No UI module registered" />;
-  }
-
-  // Workspace-scoped apps need an active workspace; global apps don't
-  if (!isGlobal && !workspacePath) {
-    return <AppPlaceholder name={manifest.name} reason="No workspace selected" />;
   }
 
   return (

--- a/apps/desktop/src/lib/app-startup.test.ts
+++ b/apps/desktop/src/lib/app-startup.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const startupMocks = vi.hoisted(() => ({
+  loadLayout: vi.fn<() => Promise<void>>(),
+  loadWorkspaces: vi.fn<() => Promise<void>>(),
+  discoverAndRegisterApps: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock('@/stores/app', () => ({
+  loadLayout: startupMocks.loadLayout,
+  discoverAndRegisterApps: startupMocks.discoverAndRegisterApps,
+}));
+
+vi.mock('@/stores/workspace', () => ({
+  loadWorkspaces: startupMocks.loadWorkspaces,
+}));
+
+import { hydrateShellState } from './app-startup';
+
+describe('hydrateShellState', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('waits for layout hydration before loading workspaces and discovering apps', async () => {
+    const calls: string[] = [];
+    let releaseLayout!: () => void;
+
+    startupMocks.loadLayout.mockImplementation(async () => {
+      calls.push('layout:start');
+      await new Promise<void>((resolve) => {
+        releaseLayout = resolve;
+      });
+      calls.push('layout:end');
+    });
+    startupMocks.loadWorkspaces.mockImplementation(async () => {
+      calls.push('workspaces');
+    });
+    startupMocks.discoverAndRegisterApps.mockImplementation(async () => {
+      calls.push('apps');
+    });
+
+    const pending = hydrateShellState();
+    await Promise.resolve();
+
+    expect(calls).toEqual(['layout:start']);
+
+    releaseLayout();
+    await pending;
+
+    expect(calls[1]).toBe('layout:end');
+    expect(calls.slice(2).sort()).toEqual(['apps', 'workspaces']);
+  });
+});

--- a/apps/desktop/src/lib/app-startup.ts
+++ b/apps/desktop/src/lib/app-startup.ts
@@ -1,0 +1,15 @@
+import { discoverAndRegisterApps, loadLayout } from '@/stores/app';
+import { loadWorkspaces } from '@/stores/workspace';
+
+/**
+ * Startup order matters:
+ * 1. hydrate layout so active app/favourites/workspace are known
+ * 2. then start app discovery + workspace load in parallel
+ */
+export async function hydrateShellState(): Promise<void> {
+  await loadLayout();
+  await Promise.all([
+    loadWorkspaces(),
+    discoverAndRegisterApps(),
+  ]);
+}

--- a/apps/desktop/src/lib/federation-registry.ts
+++ b/apps/desktop/src/lib/federation-registry.ts
@@ -8,15 +8,15 @@
  * Remote discovery happens at build time in vite.config.ts (auto-scans
  * packages/pi-* for sero.app manifests). No per-app edits needed here.
  *
- * ## Preload strategy
+ * ## Preload + LRU eviction strategy
  *
- * `preloadFederatedModule()` eagerly resolves the remote module at startup
- * (during the loading screen) and caches the resolved component. When
- * `getFederatedComponent()` is later called during render, it wraps the
- * already-resolved component in a `lazy(() => Promise.resolve(...))`.
- * React.lazy recognises the synchronously-settled thenable and renders
- * without triggering Suspense — eliminating the loading-spinner flash
- * on first open.
+ * At startup, only the active app and favourites are preloaded (not all apps).
+ * Other apps are loaded on-demand inside a React transition so the previous
+ * app stays visible while the new one resolves — no Suspense flash.
+ *
+ * An LRU cache evicts resolved modules that haven't been accessed recently,
+ * recovering memory from apps the user is no longer viewing. Apps that
+ * declare `background: true` in their manifest are exempt from eviction.
  */
 
 import { lazy } from 'react';
@@ -24,14 +24,28 @@ import { loadRemote, registerRemotes } from '@module-federation/enhanced/runtime
 
 type LazyComponent = React.LazyExoticComponent<React.ComponentType>;
 
+/**
+ * Maximum number of resolved modules to keep in memory.
+ * The active app + a few recently-used ones stay cached; older entries
+ * are evicted to free memory. Pinned (background) apps don't count
+ * toward this limit.
+ */
+const MAX_CACHED_MODULES = 5;
+
 /** Cache of lazy wrappers — prevents creating a new wrapper on every render. */
 const cache = new Map<string, LazyComponent>();
 
 /**
- * Cache of eagerly-resolved components from preloading.
- * Populated by `preloadFederatedModule` before the UI renders.
+ * Cache of eagerly-resolved components from preloading or on-demand loading.
+ * Evicted via LRU when the cache exceeds MAX_CACHED_MODULES.
  */
 const resolvedModules = new Map<string, React.ComponentType>();
+
+/** LRU access order — most recently accessed key is at the end. */
+const accessOrder: string[] = [];
+
+/** App IDs that are pinned (background apps) — exempt from eviction. */
+const pinnedApps = new Set<string>();
 
 /** Track whether we've registered remotes for a given app. */
 const registered = new Set<string>();
@@ -79,6 +93,34 @@ function ensureRemoteRegistered(
   }
 }
 
+/** Touch a cache key, moving it to the end of the LRU access list. */
+function touchLRU(cacheKey: string): void {
+  const idx = accessOrder.indexOf(cacheKey);
+  if (idx !== -1) accessOrder.splice(idx, 1);
+  accessOrder.push(cacheKey);
+}
+
+/** Evict least-recently-used entries that exceed MAX_CACHED_MODULES. */
+function evictLRU(): void {
+  // Count non-pinned entries
+  const nonPinned = accessOrder.filter((k) => !pinnedApps.has(k.split('/')[0]));
+  while (nonPinned.length > MAX_CACHED_MODULES) {
+    const victim = nonPinned.shift()!;
+    resolvedModules.delete(victim);
+    cache.delete(victim);
+    const idx = accessOrder.indexOf(victim);
+    if (idx !== -1) accessOrder.splice(idx, 1);
+  }
+}
+
+/**
+ * Pin an app so it's never evicted from the cache.
+ * Use for apps that declare `background: true` in their manifest.
+ */
+export function pinApp(appId: string): void {
+  pinnedApps.add(appId);
+}
+
 /**
  * Eagerly load a federated module at startup.
  *
@@ -86,8 +128,8 @@ function ensureRemoteRegistered(
  * `getFederatedComponent()` call returns an already-settled lazy wrapper
  * — no Suspense fallback flash.
  *
- * Called during `discoverAndRegisterApps()` and awaited before
- * `appsReady` is set. Errors are swallowed (the app will show a
+ * Called during `discoverAndRegisterApps()` for the active app and
+ * favourites only. Errors are swallowed (the app will show a
  * lazy-load error when actually opened).
  */
 export async function preloadFederatedModule(
@@ -106,6 +148,7 @@ export async function preloadFederatedModule(
     const mod = await loadRemote<{ default: React.ComponentType }>(modulePath);
     if (mod?.default) {
       resolvedModules.set(cacheKey, mod.default);
+      touchLRU(cacheKey);
     }
   } catch (err) {
     // Preload failed — getFederatedComponent will fall back to lazy()
@@ -118,6 +161,9 @@ export async function preloadFederatedModule(
  *
  * If the module was preloaded, returns a lazy wrapper over an already-resolved
  * Promise (no Suspense trigger). Otherwise falls back to a true lazy() load.
+ *
+ * Call site should wrap app switches in `startTransition` so React keeps
+ * showing the previous app while a non-preloaded module resolves.
  *
  * @param appId      The app's unique id (from sero.app.id)
  * @param component  The exported component name (from sero.app.component)
@@ -135,7 +181,10 @@ export function getFederatedComponent(
 
   // 1. Return cached lazy wrapper if we already have one
   const cached = cache.get(cacheKey);
-  if (cached) return cached;
+  if (cached) {
+    touchLRU(cacheKey);
+    return cached;
+  }
 
   // 2. If preloaded, wrap the resolved component — Promise.resolve settles
   //    synchronously so React.lazy won't trigger Suspense.
@@ -143,10 +192,12 @@ export function getFederatedComponent(
   if (resolved) {
     const LazyComp = lazy(() => Promise.resolve({ default: resolved }));
     cache.set(cacheKey, LazyComp);
+    touchLRU(cacheKey);
     return LazyComp;
   }
 
-  // 3. Fallback: true lazy load (Suspense will show the spinner)
+  // 3. Fallback: true lazy load (Suspense will show the spinner only if
+  //    the caller didn't wrap the switch in startTransition)
   const remoteName = toRemoteName(appId);
   const modulePath = `${remoteName}/${component}`;
 
@@ -157,6 +208,10 @@ export function getFederatedComponent(
       console.error(`[federation] Failed to load remote: ${modulePath}`);
       return { default: () => null };
     }
+    // Cache the resolved component for future access + LRU tracking
+    resolvedModules.set(cacheKey, mod.default);
+    touchLRU(cacheKey);
+    evictLRU();
     return mod;
   });
 

--- a/apps/desktop/src/stores/app.test.ts
+++ b/apps/desktop/src/stores/app.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SeroAppManifest } from '@/types/ipc';
+
+const federationMocks = vi.hoisted(() => ({
+  preloadFederatedModule: vi.fn<(appId: string, component: string, devPort: number | undefined) => Promise<void>>(),
+}));
+
+vi.mock('@/lib/federation-registry', () => ({
+  preloadFederatedModule: federationMocks.preloadFederatedModule,
+}));
+
+import { discoverAndRegisterApps, useAppStore } from './app';
+
+function createManifest(
+  id: string,
+  component: string | null,
+  devPort?: number,
+): SeroAppManifest {
+  return {
+    id,
+    name: id,
+    description: null,
+    version: '1.0.0',
+    packageName: `@sero/${id}`,
+    icon: 'box',
+    stateFile: `.sero/apps/${id}/state.json`,
+    scope: 'workspace',
+    globalStatePath: null,
+    uiEntry: component ? `sero-ext://${id}/mf-manifest.json` : null,
+    component,
+    devPort,
+    packagePath: `/tmp/${id}`,
+  };
+}
+
+describe('discoverAndRegisterApps', () => {
+  const initialState = useAppStore.getState();
+  const discover = vi.fn<() => Promise<SeroAppManifest[]>>();
+
+  beforeEach(() => {
+    federationMocks.preloadFederatedModule.mockResolvedValue();
+    discover.mockReset();
+    (window as Window & { sero: any }).sero = {
+      apps: { discover },
+    };
+
+    useAppStore.setState({
+      ...initialState,
+      activeApp: 'research',
+      favouriteApps: ['todo', 'notes'],
+      appsReady: false,
+    }, true);
+  });
+
+  afterEach(() => {
+    federationMocks.preloadFederatedModule.mockReset();
+    useAppStore.setState(initialState, true);
+  });
+
+  it('preloads only the hydrated active app and favourites', async () => {
+    discover.mockResolvedValue([
+      createManifest('todo', 'TodoApp', 4101),
+      createManifest('notes', 'NotesApp', 4102),
+      createManifest('research', 'ResearchApp', 4103),
+      createManifest('admin', 'AdminApp', 4104),
+      createManifest('no-ui', null, 4105),
+    ]);
+
+    await discoverAndRegisterApps();
+
+    expect(
+      federationMocks.preloadFederatedModule.mock.calls.map(([appId]) => appId).sort(),
+    ).toEqual(['notes', 'research', 'todo']);
+    expect(useAppStore.getState().appsReady).toBe(true);
+  });
+});

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -1,4 +1,3 @@
-import { startTransition } from 'react';
 import { create } from 'zustand';
 import type { SeroAppManifest } from '@/types/ipc';
 import { persistLayout } from '@/lib/persist-layout';
@@ -66,7 +65,7 @@ interface AppState {
 
   // Active app
   activeApp: string;
-  /** Non-null while transitioning to a new app (lazy module loading). */
+  /** The app currently being preloaded before activation. */
   pendingApp: string | null;
   setActiveApp: (app: string) => void;
 
@@ -136,6 +135,15 @@ export function getSidebarApps(apps: AppEntry[], favouriteApps: string[]): AppEn
   return [...builtins, ...favourites];
 }
 
+export function getPriorityPreloadApps(
+  manifests: SeroAppManifest[],
+  activeApp: string,
+  favouriteApps: string[],
+): SeroAppManifest[] {
+  const priorityIds = new Set([activeApp, ...favouriteApps]);
+  return manifests.filter((manifest) => manifest.component && priorityIds.has(manifest.id));
+}
+
 export const useAppStore = create<AppState>((set, get) => ({
   // App registry — starts with built-ins
   apps: [...BUILTIN_APPS],
@@ -196,21 +204,35 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   // Active app (hydrated from layout file on startup)
   activeApp: 'coding',
-  /**
-   * ID of the app we're transitioning to. Non-null while a lazy module
-   * is still loading — used by ActiveApp to show a pending opacity hint.
-   * Set eagerly (outside the transition) so the UI can react immediately.
-   */
-  pendingApp: null as string | null,
+  pendingApp: null,
   setActiveApp: (app) => {
-    if (app === get().activeApp) return;
-    // Set pendingApp eagerly so the UI can show a loading hint
-    set({ pendingApp: app });
-    // Wrap the actual switch in startTransition so React keeps the
-    // previous app visible while a non-preloaded lazy module resolves.
-    startTransition(() => {
+    const { activeApp, pendingApp, apps } = get();
+    if (app === activeApp) {
+      if (pendingApp) set({ pendingApp: null });
+      return;
+    }
+    if (app === pendingApp) return;
+
+    const entry = apps.find((candidate) => candidate.id === app);
+    const manifest = entry?.manifest;
+
+    const activate = () => {
+      if (get().pendingApp !== app) return;
       set({ activeApp: app, pendingApp: null });
-    });
+      persistLayout({ activeApp: app });
+    };
+
+    if (manifest?.component) {
+      set({ pendingApp: app });
+      void preloadFederatedModule(manifest.id, manifest.component, manifest.devPort)
+        .catch((err) => {
+          console.warn(`[app-store] Failed to preload ${manifest.id}:`, err);
+        })
+        .finally(activate);
+      return;
+    }
+
+    set({ activeApp: app, pendingApp: null });
     persistLayout({ activeApp: app });
   },
 
@@ -290,10 +312,7 @@ export async function discoverAndRegisterApps(): Promise<void> {
     // Only preload the active app + favourites — not all 20+ apps.
     // Other apps load on-demand inside a React transition (no flicker).
     const { activeApp, favouriteApps } = useAppStore.getState();
-    const priorityIds = new Set([activeApp, ...favouriteApps]);
-    const priorityApps = manifests.filter(
-      (m) => m.component && priorityIds.has(m.id),
-    );
+    const priorityApps = getPriorityPreloadApps(manifests, activeApp, favouriteApps);
 
     if (priorityApps.length > 0) {
       const PRELOAD_TIMEOUT_MS = 5000;

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -271,17 +271,21 @@ export async function discoverAndRegisterApps(): Promise<void> {
     // Register app entries immediately (needed for sidebar rendering)
     useAppStore.setState({ apps: [...BUILTIN_APPS, ...discovered] });
 
-    // Eagerly preload all federated UI modules BEFORE setting appsReady.
-    // This keeps the loading screen up while modules resolve, so the first
-    // render of any app has its component already cached — no Suspense flash.
-    const appsWithUI = manifests.filter((m) => m.component);
-    if (appsWithUI.length > 0) {
-      const PRELOAD_TIMEOUT_MS = 8000;
-      const preloads = appsWithUI.map((m) =>
+    // Only preload the active app + favourites — not all 20+ apps.
+    // Other apps load on-demand inside a React transition (no flicker).
+    const { activeApp, favouriteApps } = useAppStore.getState();
+    const priorityIds = new Set([activeApp, ...favouriteApps]);
+    const priorityApps = manifests.filter(
+      (m) => m.component && priorityIds.has(m.id),
+    );
+
+    if (priorityApps.length > 0) {
+      const PRELOAD_TIMEOUT_MS = 5000;
+      const preloads = priorityApps.map((m) =>
         preloadFederatedModule(m.id, m.component!, m.devPort),
       );
 
-      // Wait for all preloads, but don't block forever if a remote is down
+      // Wait for priority preloads, but don't block forever if a remote is down
       await Promise.race([
         Promise.allSettled(preloads),
         new Promise<void>((resolve) => setTimeout(resolve, PRELOAD_TIMEOUT_MS)),

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -1,3 +1,4 @@
+import { startTransition } from 'react';
 import { create } from 'zustand';
 import type { SeroAppManifest } from '@/types/ipc';
 import { persistLayout } from '@/lib/persist-layout';
@@ -65,6 +66,8 @@ interface AppState {
 
   // Active app
   activeApp: string;
+  /** Non-null while transitioning to a new app (lazy module loading). */
+  pendingApp: string | null;
   setActiveApp: (app: string) => void;
 
   // Theme
@@ -193,8 +196,21 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   // Active app (hydrated from layout file on startup)
   activeApp: 'coding',
+  /**
+   * ID of the app we're transitioning to. Non-null while a lazy module
+   * is still loading — used by ActiveApp to show a pending opacity hint.
+   * Set eagerly (outside the transition) so the UI can react immediately.
+   */
+  pendingApp: null as string | null,
   setActiveApp: (app) => {
-    set({ activeApp: app });
+    if (app === get().activeApp) return;
+    // Set pendingApp eagerly so the UI can show a loading hint
+    set({ pendingApp: app });
+    // Wrap the actual switch in startTransition so React keeps the
+    // previous app visible while a non-preloaded lazy module resolves.
+    startTransition(() => {
+      set({ activeApp: app, pendingApp: null });
+    });
     persistLayout({ activeApp: app });
   },
 

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -223,8 +223,8 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
 /**
  * Load the workspace list from the main process.
- * Called once from App.tsx during startup — ensures workspaces are ready
- * before the UI renders (prevents "No workspace selected" flash).
+ * Called once from App.tsx during startup. Workspace-scoped apps read
+ * `workspacesReady` so they can stay in a loading state until this finishes.
  */
 export async function loadWorkspaces(): Promise<void> {
   return useWorkspaceStore.getState().loadWorkspaces();

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,8 +1,22 @@
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
   test: {
-    include: ['electron/__tests__/**/*.test.ts'],
+    include: [
+      'electron/__tests__/**/*.test.ts',
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+    ],
     environment: 'node',
+    environmentMatchGlobs: [
+      ['src/**/*.test.ts', 'jsdom'],
+      ['src/**/*.test.tsx', 'jsdom'],
+    ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,25 @@ catalogs:
     vitest:
       specifier: ^4.0.18
       version: 4.0.18
+  peer:
+    '@mariozechner/pi-agent-core':
+      specifier: '>=0.55.3'
+      version: 0.55.3
+    '@mariozechner/pi-ai':
+      specifier: '>=0.55.3'
+      version: 0.55.3
+    '@mariozechner/pi-coding-agent':
+      specifier: '>=0.55.3'
+      version: 0.55.3
+    '@mariozechner/pi-tui':
+      specifier: '>=0.55.3'
+      version: 0.55.3
+    react:
+      specifier: '>=19.0.0'
+      version: 19.2.4
+    react-dom:
+      specifier: '>=19.0.0'
+      version: 19.2.4
 
 importers:
 
@@ -231,6 +250,9 @@ importers:
       esbuild:
         specifier: ^0.27.4
         version: 0.27.4
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -239,7 +261,7 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(yaml@2.8.2)
 
   apps/web-remote:
     dependencies:
@@ -542,7 +564,7 @@ importers:
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(yaml@2.8.2)
 
   packages/pi-daily-quote:
     dependencies:
@@ -1610,6 +1632,9 @@ packages:
       zod:
         optional: true
 
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
     engines: {node: '>=16.0.0'}
@@ -1929,6 +1954,34 @@ packages:
 
   '@chevrotain/utils@11.1.2':
     resolution: {integrity: sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -5297,6 +5350,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -5464,6 +5521,10 @@ packages:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
@@ -5492,6 +5553,9 @@ packages:
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -6276,6 +6340,10 @@ packages:
     resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -6490,6 +6558,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -6577,6 +6648,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -7422,6 +7502,9 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -8088,6 +8171,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -8116,6 +8202,10 @@ packages:
   sax@1.5.0:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -8444,6 +8534,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -8508,8 +8601,15 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.25:
     resolution: {integrity: sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.0.25:
     resolution: {integrity: sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==}
@@ -8537,9 +8637,17 @@ packages:
   tokenlens@1.3.1:
     resolution: {integrity: sha512-7oxmsS5PNCX3z+b+z07hL5vCzlgHKkCGrEQjQmWl5l+v5cUrtL7S1cuST4XThaL1XyjbTX8J5hfP0cjDJRkaLA==}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -8887,6 +8995,10 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
@@ -8896,6 +9008,23 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -8970,9 +9099,16 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -9135,6 +9271,14 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.3.6
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -9754,6 +9898,26 @@ snapshots:
   '@chevrotain/types@11.1.2': {}
 
   '@chevrotain/utils@11.1.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -13687,6 +13851,11 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.1):
@@ -13877,6 +14046,11 @@ snapshots:
 
   data-uri-to-buffer@6.0.2: {}
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
@@ -13892,6 +14066,8 @@ snapshots:
   decamelize@1.2.0: {}
 
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -14908,6 +15084,10 @@ snapshots:
     dependencies:
       lru-cache: 11.2.7
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -15113,6 +15293,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
@@ -15172,6 +15354,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -16285,6 +16494,8 @@ snapshots:
       gauge: 4.0.4
       set-blocking: 2.0.0
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -17151,6 +17362,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.8.0: {}
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -17174,6 +17387,10 @@ snapshots:
       truncate-utf8-bytes: 1.0.2
 
   sax@1.5.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -17583,6 +17800,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
@@ -17653,7 +17872,13 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.25: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.25:
     dependencies:
@@ -17684,9 +17909,17 @@ snapshots:
       '@tokenlens/helpers': 1.3.1
       '@tokenlens/models': 1.3.0
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.25
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -17965,7 +18198,7 @@ snapshots:
       lightningcss: 1.31.1
       yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
@@ -17990,6 +18223,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.11
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -18020,6 +18254,10 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
@@ -18027,6 +18265,19 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-module@2.0.1: {}
 
@@ -18084,7 +18335,11 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@4.0.3: {}
 


### PR DESCRIPTION
PR #75 fixed app flicker by eagerly preloading ALL ~20 federated modules
at startup and blocking rendering until all resolved (up to 8s). This
caused slower startup times and unbounded memory growth since every
module stayed cached forever.

Changes:

- federation-registry.ts: Add LRU eviction (MAX_CACHED_MODULES=5) so
  resolved modules from apps the user isn't viewing are freed. Pinnable
  apps (background) are exempt. On-demand lazy loads now also populate
  the resolved cache for faster re-opens.

- stores/app.ts: Only preload the active app + favourites at startup
  instead of all apps. Reduces preload set from ~20 to ~4 apps, with
  timeout reduced from 8s to 5s.

- App.tsx: Remove workspacesReady from the main loading gate — workspaces
  load in parallel but don't block initial render (SeroAppMount already
  guards on activeWorkspaceId). ActiveApp reads activeApp from store
  directly instead of receiving it as a prop.

The useDeferredValue pattern remains — it keeps the previous app visible
while on-demand lazy loads resolve, preventing flicker without needing
every module preloaded upfront.

https://claude.ai/code/session_01LQappFCuHHcJ3izjxqr7EM