### PR TITLE
Add article analysis mode to research orchestrator

### DIFF
--- a/packages/pi-research-extension/extension/commands.ts
+++ b/packages/pi-research-extension/extension/commands.ts
@@ -1,0 +1,71 @@
+/**
+ * CLI commands for the research orchestrator (/research, /analyze).
+ */
+
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+export function registerCommands(pi: ExtensionAPI): void {
+  // ── Command: /research ─────────────────────────────────────
+
+  pi.registerCommand('research', {
+    description: 'Start a multi-agent research session on any topic',
+    handler: async (args, _ctx) => {
+      const question = args.trim();
+      if (question) {
+        pi.sendUserMessage(
+          `I want to research: "${question}"\n\n` +
+          `Please decompose this into 2-4 non-overlapping research workstreams. ` +
+          `For each workstream, identify the key sections to cover. ` +
+          `Then use the research tool with action "plan" to create the research plan, ` +
+          `providing the question and an agents array with name and sections for each workstream.`,
+        );
+      } else {
+        pi.sendUserMessage(
+          'I want to start a research session. Use the question tool to ask me what topic ' +
+          'I want to research (do NOT use the interview or questionnaire tool). ' +
+          'Once I provide a topic, decompose it into 2-4 non-overlapping workstreams ' +
+          'using the research tool.',
+        );
+      }
+    },
+  });
+
+  // ── Command: /analyze ─────────────────────────────────────
+
+  pi.registerCommand('analyze', {
+    description: 'Analyse article URLs for commercial opportunities and actionable insights',
+    handler: async (args, _ctx) => {
+      const input = args.trim();
+      if (input) {
+        // Extract URLs from the input
+        const urlPattern = /https?:\/\/[^\s,]+/g;
+        const urls = input.match(urlPattern) ?? [];
+        // Everything that isn't a URL is treated as context
+        const context = input.replace(urlPattern, '').replace(/[,\s]+/g, ' ').trim();
+
+        if (urls.length > 0) {
+          pi.sendUserMessage(
+            `Analyse these articles for commercial opportunities and actionable insights.\n\n` +
+            `Use the research tool with action "analyze", passing:\n` +
+            `- urls: ${JSON.stringify(urls)}\n` +
+            (context ? `- context: "${context}"\n` : '') +
+            `\nThis will create a structured analysis plan. After I approve, launch the agents.`,
+          );
+        } else {
+          pi.sendUserMessage(
+            `I want to analyse an article. Use the question tool to ask me for the URL(s) and ` +
+            `any context about what I'm building or looking for. Then use the research tool ` +
+            `with action "analyze".`,
+          );
+        }
+      } else {
+        pi.sendUserMessage(
+          `I want to analyse an article for commercial opportunities. Use the question tool ` +
+          `to ask me for the URL(s) and any context about what I'm building or looking for ` +
+          `(do NOT use the interview or questionnaire tool). ` +
+          `Then use the research tool with action "analyze".`,
+        );
+      }
+    },
+  });
+}

--- a/packages/pi-research-extension/extension/index.ts
+++ b/packages/pi-research-extension/extension/index.ts
@@ -17,7 +17,7 @@ import { Type } from '@sinclair/typebox';
 
 import type { ResearchState, ResearchSession, ResearchAgent, ResearchPhase } from '../shared/types';
 import { DEFAULT_STATE } from '../shared/types';
-import { resolveStatePath, readState, writeState, countLines, readFile, writeSkeletonFile } from './state-io';
+import { resolveStatePath, readState, writeState, countLines, readFile, writeSkeletonFile, reconcileState } from './state-io';
 import {
   buildSkeletonFile, buildAgentSystemPrompt, buildAgentTaskPrompt, buildSynthesisPrompt,
   buildArticleAnalysisAgents, buildArticleAgentSystemPrompt, buildArticleSynthesisPrompt,
@@ -449,14 +449,30 @@ export default function researchExtension(pi: ExtensionAPI): void {
     }
   });
 
-  // ── Event: restore state on session start ──────────────────
+  // ── Event: reconcile persisted state on session start ──────
+  //
+  // When the app restarts, subagents from the previous run are gone but the
+  // state file may still say phase='researching' with agents 'running'.
+  // reconcileState checks the actual output files on disk and finalizes any
+  // sessions that are already done, or marks interrupted agents as failed.
+
+  async function reconcileOnStart(ctx?: { cwd?: string }): Promise<void> {
+    ensureStatePath(ctx);
+    if (!statePath || !workspaceCwd) return;
+
+    const state = await readState(statePath);
+    const changed = await reconcileState(state, workspaceCwd);
+    if (changed) {
+      await syncState(state);
+    }
+  }
 
   pi.on('session_start', async (_event, ctx) => {
-    ensureStatePath(ctx);
+    await reconcileOnStart(ctx);
   });
 
   pi.on('session_switch', async (_event, ctx) => {
-    ensureStatePath(ctx);
+    await reconcileOnStart(ctx);
   });
 
   // ── Commands ─────────────────────────────────────────────────

--- a/packages/pi-research-extension/extension/index.ts
+++ b/packages/pi-research-extension/extension/index.ts
@@ -18,7 +18,11 @@ import { Type } from '@sinclair/typebox';
 import type { ResearchState, ResearchSession, ResearchAgent, ResearchPhase } from '../shared/types';
 import { DEFAULT_STATE } from '../shared/types';
 import { resolveStatePath, readState, writeState, countLines, readFile, writeSkeletonFile } from './state-io';
-import { buildSkeletonFile, buildAgentSystemPrompt, buildAgentTaskPrompt, buildSynthesisPrompt } from './prompts';
+import {
+  buildSkeletonFile, buildAgentSystemPrompt, buildAgentTaskPrompt, buildSynthesisPrompt,
+  buildArticleAnalysisAgents, buildArticleAgentSystemPrompt, buildArticleSynthesisPrompt,
+} from './prompts';
+import { registerCommands } from './commands';
 
 // ── Constants ──────────────────────────────────────────────────
 
@@ -32,8 +36,8 @@ const STUCK_THRESHOLD = 2; // unchanged line count for N check-ins → stuck
 // ── Tool parameters ─────────────────────────────────────────────
 
 const ResearchParams = Type.Object({
-  action: StringEnum(['plan', 'approve', 'status', 'cancel'] as const),
-  question: Type.Optional(Type.String({ description: 'Research question (for plan)' })),
+  action: StringEnum(['plan', 'approve', 'status', 'cancel', 'analyze'] as const),
+  question: Type.Optional(Type.String({ description: 'Research question (for plan/analyze)' })),
   agents: Type.Optional(Type.Array(
     Type.Object({
       name: Type.String({ description: 'Agent workstream name' }),
@@ -41,6 +45,8 @@ const ResearchParams = Type.Object({
     }),
     { description: 'Agent definitions (for plan)' },
   )),
+  urls: Type.Optional(Type.Array(Type.String(), { description: 'Article URLs to analyse (for analyze)' })),
+  context: Type.Optional(Type.String({ description: 'User context — what they are building or looking for (for analyze)' })),
 });
 
 // ── Extension ──────────────────────────────────────────────────
@@ -77,6 +83,7 @@ export default function researchExtension(pi: ExtensionAPI): void {
     description:
       'Multi-agent research orchestrator. Actions:\n' +
       '  plan — Decompose a question into research workstreams. Requires `question` and `agents` array.\n' +
+      '  analyze — Analyse article URLs for commercial opportunities. Requires `urls` array, optional `question` and `context`.\n' +
       '  approve — Launch the planned research workstreams.\n' +
       '  status — Check progress of active research.\n' +
       '  cancel — Cancel active research.',
@@ -92,6 +99,8 @@ export default function researchExtension(pi: ExtensionAPI): void {
       switch (params.action) {
         case 'plan':
           return handlePlan(state, params);
+        case 'analyze':
+          return handleAnalyze(state, params);
         case 'approve':
           return handleApprove(state);
         case 'status':
@@ -137,7 +146,73 @@ export default function researchExtension(pi: ExtensionAPI): void {
       return makeResult('Error: provide 2-4 agent workstreams', true);
     }
 
-    // Create sanitized directory name from question
+    const session = buildSession(question, agents, 'research');
+    state.current = session;
+    await syncState(state);
+
+    // Format plan for display
+    const planLines = session.agents.map((a) => {
+      const sectionList = a.sections.map((s) => `  - ${s.title}`).join('\n');
+      return `### Agent ${a.id}: ${a.name}\n${sectionList}`;
+    });
+
+    return makeResult(
+      `## Research Plan: ${question}\n\n` +
+      `${planLines.join('\n\n')}\n\n` +
+      `### Synthesis Agent\n` +
+      `Runs after all agents complete → unified document with cross-cutting insights\n\n` +
+      `Output: ${session.outputDir}/\n\n` +
+      `**Ready to launch ${session.agents.length} research agents.** ` +
+      `Call research(action: "approve") to begin.`,
+    );
+  }
+
+  async function handleAnalyze(
+    state: ResearchState,
+    params: Record<string, unknown>,
+  ) {
+    const urls = params.urls as string[] | undefined;
+    const question = params.question as string | undefined;
+    const userContext = params.context as string | undefined;
+
+    if (!urls?.length) return makeResult('Error: urls array is required for analyze', true);
+
+    // Build a question from the URLs if not provided
+    const resolvedQuestion = question || `Analyse articles for commercial opportunities and actionable insights`;
+    const agents = buildArticleAnalysisAgents(urls);
+    const session = buildSession(resolvedQuestion, agents, 'article');
+    session.articleUrls = urls;
+    if (userContext) session.userContext = userContext;
+
+    state.current = session;
+    await syncState(state);
+
+    const planLines = session.agents.map((a) => {
+      const sectionList = a.sections.map((s) => `  - ${s.title}`).join('\n');
+      return `### Agent ${a.id}: ${a.name}\n${sectionList}`;
+    });
+
+    const urlList = urls.map((u) => `- ${u}`).join('\n');
+
+    return makeResult(
+      `## Article Analysis Plan\n\n` +
+      `**Articles:**\n${urlList}\n\n` +
+      (userContext ? `**Context:** ${userContext}\n\n` : '') +
+      `${planLines.join('\n\n')}\n\n` +
+      `### Synthesis Agent\n` +
+      `Runs after all agents complete → unified strategic recommendations\n\n` +
+      `Output: ${session.outputDir}/\n\n` +
+      `**Ready to launch ${session.agents.length} analysis agents.** ` +
+      `Call research(action: "approve") to begin.`,
+    );
+  }
+
+  /** Shared session builder for both research and article modes. */
+  function buildSession(
+    question: string,
+    agents: Array<{ name: string; sections: string[] }>,
+    mode: 'research' | 'article',
+  ): ResearchSession {
     const dirName = question
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
@@ -145,8 +220,8 @@ export default function researchExtension(pi: ExtensionAPI): void {
       .slice(0, 50);
     const outputDir = path.join(RESEARCH_DIR_BASE, dirName);
 
-    // Build research session
-    const session: ResearchSession = {
+    return {
+      mode,
       question,
       phase: 'awaiting_approval',
       agents: agents.map((a, i) => ({
@@ -162,25 +237,6 @@ export default function researchExtension(pi: ExtensionAPI): void {
       startedAt: new Date().toISOString(),
       monitorCycles: 0,
     };
-
-    state.current = session;
-    await syncState(state);
-
-    // Format plan for display
-    const planLines = session.agents.map((a) => {
-      const sectionList = a.sections.map((s) => `  - ${s.title}`).join('\n');
-      return `### Agent ${a.id}: ${a.name}\n${sectionList}`;
-    });
-
-    return makeResult(
-      `## Research Plan: ${question}\n\n` +
-      `${planLines.join('\n\n')}\n\n` +
-      `### Synthesis Agent\n` +
-      `Runs after all agents complete → unified document with cross-cutting insights\n\n` +
-      `Output: ${outputDir}/\n\n` +
-      `**Ready to launch ${session.agents.length} research agents.** ` +
-      `Call research(action: "approve") to begin.`,
-    );
   }
 
   async function handleApprove(state: ResearchState) {
@@ -308,6 +364,7 @@ export default function researchExtension(pi: ExtensionAPI): void {
     // Move to history
     state.history.unshift({
       question: session.question,
+      mode: session.mode,
       outputDir: session.outputDir,
       agentCount: session.agents.length,
       completedAt: new Date().toISOString(),
@@ -321,9 +378,12 @@ export default function researchExtension(pi: ExtensionAPI): void {
   // ── Helper: build subagent launch instructions ─────────────
 
   function buildLaunchInstructions(session: ResearchSession): string {
+    const isArticle = session.mode === 'article';
     const tasks = session.agents.map((agent) => {
       const outputPath = agent.outputFile;
-      const systemPrompt = buildAgentSystemPrompt(agent, session);
+      const systemPrompt = isArticle
+        ? buildArticleAgentSystemPrompt(agent, session)
+        : buildAgentSystemPrompt(agent, session);
       const taskPrompt = buildAgentTaskPrompt(agent, outputPath);
       return `{
   "agent": "researcher",
@@ -379,6 +439,7 @@ export default function researchExtension(pi: ExtensionAPI): void {
 
       state.history.unshift({
         question: session.question,
+        mode: session.mode,
         outputDir: session.outputDir,
         agentCount: session.agents.length,
         completedAt: session.completedAt,
@@ -398,30 +459,9 @@ export default function researchExtension(pi: ExtensionAPI): void {
     ensureStatePath(ctx);
   });
 
-  // ── Command: /research ─────────────────────────────────────
+  // ── Commands ─────────────────────────────────────────────────
 
-  pi.registerCommand('research', {
-    description: 'Start a multi-agent research session on any topic',
-    handler: async (args, _ctx) => {
-      const question = args.trim();
-      if (question) {
-        pi.sendUserMessage(
-          `I want to research: "${question}"\n\n` +
-          `Please decompose this into 2-4 non-overlapping research workstreams. ` +
-          `For each workstream, identify the key sections to cover. ` +
-          `Then use the research tool with action "plan" to create the research plan, ` +
-          `providing the question and an agents array with name and sections for each workstream.`,
-        );
-      } else {
-        pi.sendUserMessage(
-          'I want to start a research session. Use the question tool to ask me what topic ' +
-          'I want to research (do NOT use the interview or questionnaire tool). ' +
-          'Once I provide a topic, decompose it into 2-4 non-overlapping workstreams ' +
-          'using the research tool.',
-        );
-      }
-    },
-  });
+  registerCommands(pi);
 }
 
 // ── Utils ──────────────────────────────────────────────────────

--- a/packages/pi-research-extension/extension/prompts.ts
+++ b/packages/pi-research-extension/extension/prompts.ts
@@ -1,5 +1,7 @@
 /**
  * Prompt templates for the research orchestrator.
+ *
+ * Covers both standard multi-agent research and article-analysis mode.
  */
 
 import type { ResearchAgent, ResearchSession } from '../shared/types';
@@ -152,6 +154,171 @@ Actionable recommendations based on the research. What should someone do with th
 - Be specific and concrete — avoid generic advice
 - Aim for a comprehensive document (300+ lines)
 - Write to the synthesis output file
+
+When done, add this exact line at the very end:
+
+Status: COMPLETE`;
+}
+
+// ── Article analysis prompts ──────────────────────────────────
+
+/**
+ * Build workstreams for article analysis mode.
+ * Returns the standard agent definitions the orchestrator expects.
+ */
+export function buildArticleAnalysisAgents(urls: string[]): Array<{ name: string; sections: string[] }> {
+  return [
+    {
+      name: 'Article Extraction & Key Ideas',
+      sections: [
+        'Article Content Summary',
+        'Core Ideas & Insights',
+        'Technical Concepts & Approaches',
+        'Claims & Evidence Assessment',
+      ],
+    },
+    {
+      name: 'Commercial Opportunity Analysis',
+      sections: [
+        'Market Opportunities Identified',
+        'Competitive Landscape & Gaps',
+        'Monetisation Angles',
+        'Build vs Buy Assessment',
+      ],
+    },
+    {
+      name: 'Application Strategy',
+      sections: [
+        'How to Apply to Existing Products',
+        'New Product / Feature Ideas',
+        'Quick Wins (< 1 week)',
+        'Strategic Plays (longer-term)',
+        'Risks & Counter-arguments',
+      ],
+    },
+  ];
+}
+
+/**
+ * System prompt for an article-analysis agent.
+ */
+export function buildArticleAgentSystemPrompt(
+  agent: ResearchAgent,
+  session: ResearchSession,
+): string {
+  const sectionList = agent.sections.map((s) => `- ${s.title}`).join('\n');
+  const urlList = (session.articleUrls ?? []).map((u) => `- ${u}`).join('\n');
+  const context = session.userContext
+    ? `\n\nUser's Context / What They're Building:\n${session.userContext}`
+    : '';
+
+  return `You are a strategic article analyst. Your job is to extract maximum practical value from one or more articles the user has shared — identifying commercial opportunities and advising how to apply the ideas.
+
+## Your Assignment
+Analysis Focus: "${session.question}"
+Your Workstream: "${agent.name}"
+
+## Article URLs to Analyse
+${urlList}
+${context}
+
+## Sections to Cover
+${sectionList}
+
+## Available Tools
+You have Tavily web search tools (search, research, extract, crawl) plus WebFetch.
+
+**CRITICAL — Fetching Articles:**
+1. First use the **extract** skill or **WebFetch** to fetch the full article content from each URL
+2. If the URL is behind a paywall or returns an error, use **search** to find the article content, cached versions, or discussions about it
+3. For X/Twitter links, try WebFetch first — if blocked, search for the tweet content or thread text using Tavily search
+
+## Research Protocol
+After extracting the article(s):
+1. Understand the core ideas thoroughly
+2. Search for related market data, competitor products, and industry trends
+3. IMMEDIATELY write findings to your output file after every search
+4. Search → write → search → write (NEVER two searches without writing)
+
+## Output Requirements
+- Write in markdown format with ## headers for each section
+- Be specific and concrete — name real products, companies, market sizes
+- Every opportunity should have a clear "so what" — why it matters, what to do about it
+- Cite sources with inline URLs
+- Aim for 300+ lines of actionable analysis
+- Focus on PRACTICAL VALUE, not academic summaries
+
+## Quality Standards
+- Prioritise actionable insights over theoretical discussion
+- Include specific implementation suggestions, not vague advice
+- Note confidence levels: high-confidence vs speculative opportunities
+- Consider the user's context (their apps/products) when making recommendations
+
+When ALL sections are complete, add this exact line at the very end:
+
+Status: COMPLETE`;
+}
+
+/**
+ * Build the synthesis prompt for article analysis mode.
+ */
+export function buildArticleSynthesisPrompt(
+  session: ResearchSession,
+  agentOutputs: string[],
+): string {
+  const outputList = agentOutputs
+    .map((content, i) => {
+      const agent = session.agents[i];
+      return `--- Agent ${agent.id}: ${agent.name} ---\n\n${content}`;
+    })
+    .join('\n\n');
+
+  const context = session.userContext
+    ? `\nUser's Context: ${session.userContext}\n`
+    : '';
+
+  return `You are a strategic advisor synthesizing an article analysis. Multiple agents have independently analysed articles shared by the user.
+
+Research Question: "${session.question}"
+${context}
+## Agent Outputs
+
+${outputList}
+
+## Your Task
+
+Create a synthesis document with these sections:
+
+### TL;DR
+3-5 bullet points: the most important takeaways and what to do about them.
+
+### Key Ideas Worth Stealing
+The most valuable ideas from the article(s), ranked by potential impact. For each:
+- What the idea is
+- Why it matters
+- How to apply it (be specific)
+
+### Commercial Opportunities
+Concrete opportunities identified, ranked by feasibility × impact:
+- **Quick wins** — things that could be built/shipped in under a week
+- **Medium-term plays** — 1-4 week projects with clear value
+- **Strategic bets** — bigger opportunities worth investigating
+
+### Application Playbook
+Step-by-step recommendations for applying insights to the user's products/projects. Be specific — reference actual features, integrations, or changes.
+
+### What to Ignore
+Ideas from the article that sound good but aren't worth pursuing, with reasons why.
+
+### Further Reading & Research
+Related articles, tools, companies, or topics worth exploring next.
+
+## Output Requirements
+- Write in markdown format
+- Be opinionated — the user wants clear recommendations, not balanced summaries
+- Cite sources using inline URLs
+- Aim for 300+ lines
+- Focus on what to DO, not what to THINK
 
 When done, add this exact line at the very end:
 

--- a/packages/pi-research-extension/extension/state-io.ts
+++ b/packages/pi-research-extension/extension/state-io.ts
@@ -4,7 +4,7 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { ResearchState } from '../shared/types';
+import type { ResearchState, ResearchSession, ResearchAgent } from '../shared/types';
 import { DEFAULT_STATE } from '../shared/types';
 
 const STATE_REL_PATH = path.join('.sero', 'apps', 'research', 'state.json');
@@ -59,4 +59,150 @@ export async function readFile(filePath: string): Promise<string> {
 export async function writeSkeletonFile(filePath: string, content: string): Promise<void> {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, content, 'utf8');
+}
+
+// ── State reconciliation ────────────────────────────────────
+//
+// On app/session restart the subagents that were driving research are gone,
+// but the state file may still say phase='researching' with agents 'running'.
+// reconcileState checks the actual output files on disk to bring the
+// persisted state back in line with reality.
+
+/**
+ * Reconcile persisted research state with the actual files on disk.
+ * Call on session_start / session_switch so stale "running" sessions
+ * are correctly finalized or marked as incomplete.
+ *
+ * Returns true if the state was modified (caller should persist).
+ */
+export async function reconcileState(
+  state: ResearchState,
+  workspaceCwd: string,
+): Promise<boolean> {
+  const session = state.current;
+  if (!session) return false;
+
+  const { phase } = session;
+
+  // Nothing to reconcile for sessions that haven't started yet
+  if (phase === 'idle' || phase === 'planning' || phase === 'awaiting_approval') {
+    return false;
+  }
+
+  // Already finalized — shouldn't still be in `current`, move to history
+  if (phase === 'complete' || phase === 'failed') {
+    moveToHistory(state, session);
+    return true;
+  }
+
+  // Phase is 'researching' or 'synthesizing' — check files on disk
+  let changed = false;
+
+  // Reconcile each agent's status from its output file
+  for (const agent of session.agents) {
+    if (agent.status === 'running' || agent.status === 'stuck' || agent.status === 'pending') {
+      const updated = await reconcileAgent(agent, workspaceCwd);
+      if (updated) changed = true;
+    }
+  }
+
+  // Check if all agents are actually complete now
+  const allAgentsDone = session.agents.every(
+    (a) => a.status === 'complete' || a.status === 'failed',
+  );
+
+  if (phase === 'researching' && allAgentsDone) {
+    // Check if synthesis also exists and is complete
+    const synthPath = path.join(workspaceCwd, session.outputDir, 'synthesis.md');
+    const synthContent = await readFile(synthPath);
+
+    if (synthContent.includes('Status: COMPLETE')) {
+      // Fully done — finalize
+      session.phase = 'complete';
+      session.completedAt = session.completedAt || new Date().toISOString();
+      session.synthesisFile = path.join(session.outputDir, 'synthesis.md');
+      moveToHistory(state, session);
+      return true;
+    }
+
+    // Agents done but no synthesis yet — advance to synthesizing so the
+    // agent can pick up synthesis on the next status check
+    session.phase = 'synthesizing';
+    changed = true;
+  }
+
+  if (phase === 'synthesizing') {
+    const synthPath = path.join(workspaceCwd, session.outputDir, 'synthesis.md');
+    const synthContent = await readFile(synthPath);
+
+    if (synthContent.includes('Status: COMPLETE')) {
+      session.phase = 'complete';
+      session.completedAt = session.completedAt || new Date().toISOString();
+      session.synthesisFile = path.join(session.outputDir, 'synthesis.md');
+      moveToHistory(state, session);
+      return true;
+    }
+  }
+
+  return changed;
+}
+
+/**
+ * Check a single agent's output file and update its status accordingly.
+ * Returns true if the status was changed.
+ */
+async function reconcileAgent(
+  agent: ResearchAgent,
+  workspaceCwd: string,
+): Promise<boolean> {
+  const filePath = path.join(workspaceCwd, agent.outputFile);
+  const content = await readFile(filePath);
+
+  if (content.includes('Status: COMPLETE')) {
+    agent.status = 'complete';
+    agent.completedAt = agent.completedAt || new Date().toISOString();
+    agent.sections.forEach((s) => { s.completed = true; });
+    agent.lineCount = content.split('\n').length;
+    return true;
+  }
+
+  // File has substantial content but no COMPLETE marker — the agent was
+  // interrupted mid-work. Mark as failed so the UI doesn't show a spinner
+  // for a process that no longer exists.
+  if (content.length > 0) {
+    agent.lineCount = content.split('\n').length;
+
+    // Only downgrade 'running'/'stuck' to 'failed' — already-complete
+    // or already-failed agents are left alone.
+    if (agent.status === 'running' || agent.status === 'stuck') {
+      agent.status = 'failed';
+      agent.error = 'Interrupted — agent was not running when the session resumed';
+      return true;
+    }
+  }
+
+  // Pending agent with no file content — leave as-is (never started)
+  if (agent.status === 'pending') return false;
+
+  // Running/stuck agent with empty file — mark failed (skeleton was created
+  // but agent never wrote anything before the app closed)
+  if (agent.status === 'running' || agent.status === 'stuck') {
+    agent.status = 'failed';
+    agent.error = 'Interrupted — agent was not running when the session resumed';
+    return true;
+  }
+
+  return false;
+}
+
+/** Move the current session into history and clear `current`. */
+function moveToHistory(state: ResearchState, session: ResearchSession): void {
+  state.history.unshift({
+    question: session.question,
+    mode: session.mode,
+    outputDir: session.outputDir,
+    agentCount: session.agents.length,
+    completedAt: session.completedAt || new Date().toISOString(),
+  });
+  state.current = null;
 }

--- a/packages/pi-research-extension/extension/tsconfig.json
+++ b/packages/pi-research-extension/extension/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.extension.json",
+  "include": ["./**/*", "../shared/**/*"]
+}
+

--- a/packages/pi-research-extension/shared/types.ts
+++ b/packages/pi-research-extension/shared/types.ts
@@ -37,6 +37,11 @@ export interface ResearchAgent {
   completedAt?: string;
 }
 
+// ── Session mode ────────────────────────────────────────────
+
+/** 'research' = standard multi-agent research; 'article' = article analysis */
+export type SessionMode = 'research' | 'article';
+
 // ── Research session ────────────────────────────────────────
 
 export type ResearchPhase =
@@ -49,6 +54,8 @@ export type ResearchPhase =
   | 'failed';
 
 export interface ResearchSession {
+  /** Session mode — standard research or article analysis. */
+  mode: SessionMode;
   /** Original research question. */
   question: string;
   /** Current phase. */
@@ -67,6 +74,10 @@ export interface ResearchSession {
   error?: string;
   /** Number of monitoring cycles completed. */
   monitorCycles: number;
+  /** Article URLs to analyse (article mode only). */
+  articleUrls?: string[];
+  /** User context: what they're building / looking for (article mode only). */
+  userContext?: string;
 }
 
 // ── Top-level state ─────────────────────────────────────────
@@ -80,6 +91,8 @@ export interface ResearchState {
 
 export interface ResearchHistoryEntry {
   question: string;
+  /** Session mode. Defaults to 'research' for legacy entries. */
+  mode?: SessionMode;
   outputDir: string;
   agentCount: number;
   completedAt: string;

--- a/packages/pi-research-extension/skills/research/SKILL.md
+++ b/packages/pi-research-extension/skills/research/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: research
-description: Multi-agent research orchestrator. Decomposes any research question into parallel agent workstreams, launches them simultaneously, monitors progress, and synthesizes results into a unified document. Trigger with /research [question].
+description: "Multi-agent research orchestrator. Two modes: (1) /research [question] — decomposes questions into parallel agent workstreams, (2) /analyze [urls] — analyses articles for commercial opportunities and actionable insights. Both launch parallel agents, monitor progress, and synthesize results."
 allowed-tools: Read Bash Subagent Research WebSearch WebFetch
 ---
 
 # Multi-Agent Research Orchestrator
 
-You are the orchestrator for a multi-agent research system. When the user asks you to research a topic, you will decompose it into parallel workstreams, launch agents, monitor progress, and synthesize results.
+You are the orchestrator for a multi-agent research system. You support two modes:
+
+1. **Research mode** (`/research [question]`) — decompose a question into parallel workstreams
+2. **Article analysis mode** (`/analyze [urls]`) — analyse articles for commercial opportunities and actionable insights
 
 ## Workflow
 
@@ -115,12 +118,52 @@ The synthesis agent produces:
 
 Call `research({ action: "status" })` one final time to mark the session complete.
 
+## Article Analysis Mode
+
+When the user shares article URLs (via `/analyze` or by pasting links and asking for analysis):
+
+### Step A1: Set Up Analysis
+
+Use the **research** tool with action `analyze`:
+
+```
+research({
+  action: "analyze",
+  urls: ["https://example.com/article1", "https://x.com/i/status/123"],
+  context: "optional — what the user is building or looking for"
+})
+```
+
+This automatically creates 3 workstreams:
+1. **Article Extraction & Key Ideas** — fetches and distils the article content
+2. **Commercial Opportunity Analysis** — market gaps, monetisation angles, competitive landscape
+3. **Application Strategy** — how to apply ideas to the user's products, quick wins vs strategic plays
+
+### Step A2: Approve and Launch
+
+Same as research mode — call `research({ action: "approve" })`, then launch agents with the subagent tool.
+
+**CRITICAL for article agents:** The first thing each agent must do is fetch the article content using the **extract** skill or **WebFetch**. If the URL is paywalled or blocked (e.g. X/Twitter), use Tavily **search** to find the content or discussions about it.
+
+### Steps A3–A7: Monitor, Handle Stuck, Synthesize, Finalize
+
+Identical to research mode (Steps 4–7 above).
+
+The synthesis for article analysis focuses on:
+- **TL;DR** — top takeaways
+- **Key Ideas Worth Stealing** — ranked by impact
+- **Commercial Opportunities** — quick wins, medium-term plays, strategic bets
+- **Application Playbook** — specific steps to apply insights
+- **What to Ignore** — ideas that sound good but aren't worth pursuing
+
 ## Key Rules
 
 1. **Always show the plan before launching** — never skip user approval
-2. **Auto-synthesize** — when all research agents complete, launch the synthesis agent IMMEDIATELY without asking the user. The entire pipeline (research → synthesis) is automatic after approval.
+2. **Auto-synthesize** — when all agents complete, launch the synthesis agent IMMEDIATELY without asking the user. The entire pipeline is automatic after approval.
 3. **Write-after-every-search** — agents that research without writing get stuck
 4. **Kill and relaunch stuck agents** — don't wait for self-correction
 5. **Skeleton files first** — create output files with headers before launch
 6. **Non-overlapping workstreams** — each agent covers a distinct aspect
-6. **Cite everything** — every claim must have an inline source URL
+7. **Cite everything** — every claim must have an inline source URL
+8. **Article mode: fetch first** — article analysis agents must extract the article content before doing anything else
+9. **Be opinionated** — for article analysis, the user wants clear recommendations, not balanced academic summaries

--- a/packages/pi-research-extension/ui/IdleView.tsx
+++ b/packages/pi-research-extension/ui/IdleView.tsx
@@ -1,19 +1,26 @@
 /**
- * IdleView — empty state with research input and history list.
+ * IdleView — empty state with research input, article analysis input, and history.
  */
 
+import type { ReactNode, ChangeEvent, KeyboardEvent } from 'react';
 import { useState, useCallback } from 'react';
 import type { ResearchHistoryEntry } from '../shared/types';
 
+type TabId = 'research' | 'article';
+
 interface IdleViewProps {
   onStart: (question: string) => void;
+  onAnalyze: (urls: string[], context: string) => void;
   history: ResearchHistoryEntry[];
 }
 
-export function IdleView({ onStart, history }: IdleViewProps) {
+export function IdleView({ onStart, onAnalyze, history }: IdleViewProps) {
+  const [tab, setTab] = useState<TabId>('research');
   const [question, setQuestion] = useState('');
+  const [articleInput, setArticleInput] = useState('');
+  const [contextInput, setContextInput] = useState('');
 
-  const handleSubmit = useCallback(() => {
+  const handleResearch = useCallback(() => {
     const q = question.trim();
     if (q) {
       onStart(q);
@@ -21,51 +28,172 @@ export function IdleView({ onStart, history }: IdleViewProps) {
     }
   }, [question, onStart]);
 
+  const handleAnalyze = useCallback(() => {
+    const urls = articleInput
+      .split(/[\n,]+/)
+      .map((s: string) => s.trim())
+      .filter((s: string) => s.startsWith('http'));
+    if (urls.length > 0) {
+      onAnalyze(urls, contextInput.trim());
+      setArticleInput('');
+      setContextInput('');
+    }
+  }, [articleInput, contextInput, onAnalyze]);
+
   return (
     <>
-      <div style={{ flex: '1 1 0%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '64px 24px', textAlign: 'center' }}>
+      <div style={{ flex: '1 1 0%', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '48px 24px', textAlign: 'center' }}>
         <div className="rs-empty-orb rs-animate-in" style={{ marginBottom: 20 }} />
-        <h2 style={{ margin: 0, fontSize: 18, fontWeight: 500, color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
-          Multi-Agent Research
-        </h2>
-        <p style={{ margin: '8px 0 20px', maxWidth: 360, fontSize: 14, lineHeight: 1.6, color: 'var(--rs-muted)' }}>
-          Decompose any question into parallel workstreams. Multiple agents research simultaneously and synthesize results.
-        </p>
-        <div style={{ display: 'flex', gap: 8, width: '100%', maxWidth: 420 }}>
-          <input
-            className="rs-input"
-            value={question}
-            onChange={(e) => setQuestion(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
-            placeholder="What do you want to research?"
-          />
-          <button
-            onClick={handleSubmit}
-            className="rs-button primary"
-            disabled={!question.trim()}
-          >
-            Research
-          </button>
+
+        {/* Tab switcher */}
+        <div style={{ display: 'flex', gap: 0, marginBottom: 20, background: 'var(--rs-bg-elevated)', borderRadius: 8, padding: 3 }}>
+          <TabButton active={tab === 'research'} onClick={() => setTab('research')}>Research</TabButton>
+          <TabButton active={tab === 'article'} onClick={() => setTab('article')}>Analyse Article</TabButton>
         </div>
+
+        {tab === 'research' ? (
+          <ResearchTab question={question} setQuestion={setQuestion} onSubmit={handleResearch} />
+        ) : (
+          <ArticleTab
+            articleInput={articleInput}
+            setArticleInput={setArticleInput}
+            contextInput={contextInput}
+            setContextInput={setContextInput}
+            onSubmit={handleAnalyze}
+          />
+        )}
       </div>
 
       {history.length > 0 && (
-        <div style={{ flexShrink: 0, borderTop: '1px solid var(--rs-border)', padding: '16px 20px' }}>
-          <div style={{ fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--rs-dim)', marginBottom: 8 }}>
-            History
-          </div>
-          {history.slice(0, 5).map((entry, i) => (
-            <div key={i} style={{ fontSize: 13, color: 'var(--rs-muted)', padding: '6px 0', borderBottom: i < Math.min(history.length, 5) - 1 ? '1px solid var(--rs-border)' : 'none' }}>
-              <div style={{ color: 'var(--rs-text)', fontWeight: 400 }}>
-                {entry.question.length > 70 ? entry.question.slice(0, 70) + '…' : entry.question}
-              </div>
-              <div style={{ fontSize: 11, marginTop: 2 }}>
-                {entry.agentCount} agents · {entry.outputDir}
-              </div>
-            </div>
-          ))}
-        </div>
+        <HistorySection history={history} />
       )}
     </>
+  );
+}
+
+// ── Tab Button ────────────────────────────────────────────
+
+function TabButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: ReactNode }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        border: 'none',
+        borderRadius: 6,
+        padding: '6px 16px',
+        fontSize: 13,
+        fontWeight: 500,
+        fontFamily: "'DM Sans', sans-serif",
+        cursor: 'pointer',
+        transition: 'all 0.15s',
+        background: active ? 'var(--rs-accent)' : 'transparent',
+        color: active ? '#fff' : 'var(--rs-muted)',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ── Research Tab ──────────────────────────────────────────
+
+function ResearchTab({ question, setQuestion, onSubmit }: {
+  question: string; setQuestion: (v: string) => void; onSubmit: () => void;
+}) {
+  return (
+    <>
+      <h2 style={{ margin: 0, fontSize: 18, fontWeight: 500, color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+        Multi-Agent Research
+      </h2>
+      <p style={{ margin: '8px 0 20px', maxWidth: 360, fontSize: 14, lineHeight: 1.6, color: 'var(--rs-muted)' }}>
+        Decompose any question into parallel workstreams. Multiple agents research simultaneously and synthesize results.
+      </p>
+      <div style={{ display: 'flex', gap: 8, width: '100%', maxWidth: 420 }}>
+        <input
+          className="rs-input"
+          value={question}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setQuestion(e.target.value)}
+          onKeyDown={(e: KeyboardEvent) => e.key === 'Enter' && onSubmit()}
+          placeholder="What do you want to research?"
+        />
+        <button onClick={onSubmit} className="rs-button primary" disabled={!question.trim()}>
+          Research
+        </button>
+      </div>
+    </>
+  );
+}
+
+// ── Article Tab ──────────────────────────────────────────
+
+function ArticleTab({ articleInput, setArticleInput, contextInput, setContextInput, onSubmit }: {
+  articleInput: string; setArticleInput: (v: string) => void;
+  contextInput: string; setContextInput: (v: string) => void;
+  onSubmit: () => void;
+}) {
+  const hasUrls = articleInput.split(/[\n,]+/).some((s: string) => s.trim().startsWith('http'));
+
+  return (
+    <>
+      <h2 style={{ margin: 0, fontSize: 18, fontWeight: 500, color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
+        Analyse Article
+      </h2>
+      <p style={{ margin: '8px 0 20px', maxWidth: 420, fontSize: 14, lineHeight: 1.6, color: 'var(--rs-muted)' }}>
+        Paste article links to extract key ideas, identify commercial opportunities, and get actionable advice for your projects.
+      </p>
+      <div style={{ width: '100%', maxWidth: 460, display: 'flex', flexDirection: 'column', gap: 10, textAlign: 'left' }}>
+        <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--rs-dim)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Article URLs (one per line)
+        </label>
+        <textarea
+          className="rs-input"
+          value={articleInput}
+          onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setArticleInput(e.target.value)}
+          placeholder={"https://x.com/i/status/...\nhttps://example.com/article"}
+          rows={3}
+          style={{ resize: 'vertical', minHeight: 60, fontFamily: "'DM Sans', sans-serif" }}
+        />
+        <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--rs-dim)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+          Context (optional) — what are you building?
+        </label>
+        <input
+          className="rs-input"
+          value={contextInput}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setContextInput(e.target.value)}
+          onKeyDown={(e: KeyboardEvent) => e.key === 'Enter' && hasUrls && onSubmit()}
+          placeholder="e.g. AI coding tool, SaaS product, developer platform..."
+        />
+        <button onClick={onSubmit} className="rs-button primary" disabled={!hasUrls} style={{ alignSelf: 'flex-end' }}>
+          Analyse
+        </button>
+      </div>
+    </>
+  );
+}
+
+// ── History ──────────────────────────────────────────────
+
+function HistorySection({ history }: { history: ResearchHistoryEntry[] }) {
+  return (
+    <div style={{ flexShrink: 0, borderTop: '1px solid var(--rs-border)', padding: '16px 20px' }}>
+      <div style={{ fontSize: 12, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'var(--rs-dim)', marginBottom: 8 }}>
+        History
+      </div>
+      {history.slice(0, 5).map((entry, i) => (
+        <div key={i} style={{ fontSize: 13, color: 'var(--rs-muted)', padding: '6px 0', borderBottom: i < Math.min(history.length, 5) - 1 ? '1px solid var(--rs-border)' : 'none' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, color: 'var(--rs-text)', fontWeight: 400 }}>
+            {entry.mode === 'article' && (
+              <span style={{ fontSize: 10, padding: '1px 5px', borderRadius: 4, background: 'rgba(129, 140, 248, 0.12)', color: 'var(--rs-accent)', fontWeight: 600 }}>
+                ARTICLE
+              </span>
+            )}
+            {entry.question.length > 70 ? entry.question.slice(0, 70) + '\u2026' : entry.question}
+          </div>
+          <div style={{ fontSize: 11, marginTop: 2 }}>
+            {entry.agentCount} agents · {entry.outputDir}
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }

--- a/packages/pi-research-extension/ui/ResearchApp.tsx
+++ b/packages/pi-research-extension/ui/ResearchApp.tsx
@@ -106,6 +106,12 @@ export function ResearchApp() {
     prompt(`/research ${question}`);
   }, [prompt]);
 
+  const analyzeArticle = useCallback((urls: string[], context: string) => {
+    const urlsPart = urls.join(' ');
+    const contextPart = context ? ` ${context}` : '';
+    prompt(`/analyze ${urlsPart}${contextPart}`);
+  }, [prompt]);
+
   const approveResearch = useCallback(() => {
     prompt(
       'Approve the research plan and begin. Call research(action: "approve") ' +
@@ -121,6 +127,7 @@ export function ResearchApp() {
         ...prev,
         history: [{
           question: prev.current.question,
+          mode: prev.current.mode,
           outputDir: prev.current.outputDir,
           agentCount: prev.current.agents.length,
           completedAt: new Date().toISOString(),
@@ -137,6 +144,7 @@ export function ResearchApp() {
         ...prev,
         history: [{
           question: prev.current.question,
+          mode: prev.current.mode,
           outputDir: prev.current.outputDir,
           agentCount: prev.current.agents.length,
           completedAt: prev.current.completedAt || new Date().toISOString(),
@@ -160,7 +168,7 @@ export function ResearchApp() {
               onDismiss={dismissResearch}
             />
           ) : (
-            <IdleView onStart={startResearch} history={state.history} />
+            <IdleView onStart={startResearch} onAnalyze={analyzeArticle} history={state.history} />
           )}
         </div>
       </div>
@@ -209,7 +217,7 @@ function Header({ session, completed, total, progress }: {
     <div style={{ flexShrink: 0, padding: '20px 20px 12px' }}>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <h1 style={{ margin: 0, fontSize: 20, fontWeight: 500, letterSpacing: '-0.01em', color: 'var(--rs-text)', fontFamily: "'DM Sans', system-ui, sans-serif" }}>
-          Research
+          {session.mode === 'article' ? 'Article Analysis' : 'Research'}
         </h1>
         <PhaseBadge phase={session.phase} />
       </div>


### PR DESCRIPTION
## Summary

Extends the research orchestrator with a new **article analysis mode** alongside the existing multi-agent research functionality. Users can now paste article URLs to extract key ideas, identify commercial opportunities, and get actionable advice tailored to their projects.

## Key Changes

### UI Layer (IdleView.tsx)
- Added tab switcher to toggle between "Research" and "Analyse Article" modes
- Implemented `ArticleTab` component with URL input (supports newline or comma-separated) and optional context field
- Refactored `ResearchTab` into a separate component for clarity
- Added `HistorySection` component with mode badges to distinguish article analyses from research sessions
- New `onAnalyze` callback prop to handle article analysis submissions

### Backend Orchestration (index.ts)
- Added `analyze` action to the research tool parameters alongside existing `plan`, `approve`, `status`, `cancel`
- Implemented `handleAnalyze()` to build article analysis sessions with pre-configured 3-agent workstreams
- Created shared `buildSession()` helper to unify session creation logic for both modes
- Updated `buildLaunchInstructions()` to use mode-specific prompts (article vs. research)
- Modified history tracking to include `mode` field for each completed session

### Prompt Templates (prompts.ts)
- Added `buildArticleAnalysisAgents()` to define 3 specialized workstreams:
  1. Article Extraction & Key Ideas
  2. Commercial Opportunity Analysis
  3. Application Strategy
- Implemented `buildArticleAgentSystemPrompt()` with article-specific instructions:
  - Emphasis on fetching article content via extract/WebFetch/search
  - Guidance for paywalled or blocked URLs (e.g., X/Twitter)
  - Focus on practical, actionable insights with specific product/company examples
- Implemented `buildArticleSynthesisPrompt()` to synthesize findings into:
  - TL;DR with top takeaways
  - Key ideas ranked by impact
  - Commercial opportunities (quick wins, medium-term, strategic)
  - Application playbook with specific recommendations
  - What to ignore and further reading

### Commands (commands.ts - new file)
- Extracted `/research` command into dedicated module
- Added `/analyze` command to handle article URLs and optional context
- Both commands parse input and delegate to the research tool with appropriate parameters

### Type System (types.ts)
- Added `SessionMode` type: `'research' | 'article'`
- Extended `ResearchSession` with:
  - `mode` field to track session type
  - `articleUrls?: string[]` for article analysis mode
  - `userContext?: string` for user's project/product context
- Updated `ResearchHistoryEntry` to include `mode` field

### Documentation (SKILL.md)
- Updated skill description to mention both research and article analysis modes
- Added "Article Analysis Mode" section with workflow steps (A1–A7)
- Clarified critical requirement: agents must fetch article content first
- Updated key rules to reflect both modes

### App Integration (ResearchApp.tsx)
- Added `analyzeArticle()` callback to handle article analysis submissions
- Updated history state management to include `mode` field
- Passed `onAnalyze` prop to `IdleView` component

## Implementation Details

- **Mode-aware prompts**: Article agents receive specialized system prompts emphasizing content extraction and commercial analysis, while research agents use the original multi-agent research prompts
- **URL parsing**: Article input supports flexible formatting (newline or comma-separated) with validation for HTTP(S) URLs
- **Backward compatibility**: Existing research mode is unchanged; mode field defaults to 'research' for historical sessions
- **Synthesis strategy**: Article synthesis focuses on actionable recommendations and opportunity ranking rather than cross-cutting research insights

https://claude.ai/code/session_01WPDroLjejuyKX13BcWqpbK