### PR TITLE
Harden web remote gateway reconnect flow

### DIFF
--- a/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/coding/editor/EditorPanel.tsx
@@ -11,6 +11,7 @@ import Editor from '@monaco-editor/react';
 import type { editor as monacoEditor, IRange, IPosition } from 'monaco-editor';
 import { EditorTabBar, type EditorTab } from './EditorTabBar';
 import { ImagePreview, isImageFile } from './ImagePreview';
+import { VideoPreview, isVideoFile } from './VideoPreview';
 import { HtmlPreview, isHtmlFile } from './HtmlPreview';
 import { DevServerPreview, isDevServerTab } from './DevServerPreview';
 import { ViewModeToggle, type ViewMode } from './ViewModeToggle';
@@ -91,6 +92,7 @@ export function EditorPanel({
   const isPreviewableTab = isMarkdownTab || isHtmlTab;
   const isPreview = isPreviewableTab && viewMode === 'preview';
   const isImageTab = !!activeTab && isImageFile(activeTab);
+  const isVideoTab = !!activeTab && isVideoFile(activeTab);
 
   // ── LSP integration ──
   const { sendDidSave } = useLsp({
@@ -101,8 +103,8 @@ export function EditorPanel({
   // ── Load file when activeTab changes ──
   useEffect(() => {
     if (!activeTab) { setContent(''); return; }
-    // Image files and dev server previews don't need text loading
-    if (isImageFile(activeTab) || isDevServerTab(activeTab)) { setContent(''); setLanguage('plaintext'); return; }
+    // Image/video files and dev server previews don't need text loading
+    if (isImageFile(activeTab) || isVideoFile(activeTab) || isDevServerTab(activeTab)) { setContent(''); setLanguage('plaintext'); return; }
 
     // Apply a stored go-to-definition position after content is ready.
     const schedulePendingGoto = () => {
@@ -433,6 +435,8 @@ export function EditorPanel({
             <DevServerPreview key={activeTab} tabPath={activeTab} />
           ) : isImageTab ? (
             <ImagePreview workspaceId={workspaceId} filePath={activeTab} />
+          ) : isVideoTab ? (
+            <VideoPreview workspaceId={workspaceId} filePath={activeTab} />
           ) : isHtmlTab && isPreview ? (
             <HtmlPreview content={content} filePath={activeTab} />
           ) : isMarkdownTab && isPreview ? (

--- a/apps/desktop/src/components/apps/coding/editor/VideoPreview.tsx
+++ b/apps/desktop/src/components/apps/coding/editor/VideoPreview.tsx
@@ -1,0 +1,147 @@
+/**
+ * VideoPreview — renders video files (mp4, webm, mov, etc.)
+ * as a centred player instead of garbled binary in the code editor.
+ *
+ * Loads the file as base64 via the `readBinaryFile` IPC, converts to a
+ * Blob → blob URL (more memory-efficient than data URLs for larger files),
+ * and renders a native <video> element with controls.
+ */
+
+import { useEffect, useState, useRef } from 'react';
+import { Video, Loader2, AlertCircle } from 'lucide-react';
+
+const VIDEO_EXTENSIONS = new Set([
+  'mp4', 'webm', 'mov', 'ogg', 'avi',
+]);
+
+const MIME_MAP: Record<string, string> = {
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  ogg: 'video/ogg',
+  avi: 'video/x-msvideo',
+};
+
+/** Check if a file path is a video based on its extension. */
+export function isVideoFile(filePath: string): boolean {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  return VIDEO_EXTENSIONS.has(ext);
+}
+
+function getMimeType(filePath: string): string {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  return MIME_MAP[ext] ?? 'video/mp4';
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+interface Props {
+  workspaceId: string;
+  filePath: string;
+}
+
+export function VideoPreview({ workspaceId, filePath }: Props) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [fileSize, setFileSize] = useState<number | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setBlobUrl(null);
+    setFileSize(null);
+
+    // Revoke previous blob URL if any
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
+    }
+
+    (async () => {
+      try {
+        const base64 = await window.sero.editor.readBinaryFile(workspaceId, filePath);
+        if (cancelled) return;
+
+        // Decode base64 to bytes
+        const binaryStr = atob(base64);
+        const bytes = new Uint8Array(binaryStr.length);
+        for (let i = 0; i < binaryStr.length; i++) {
+          bytes[i] = binaryStr.charCodeAt(i);
+        }
+
+        const mime = getMimeType(filePath);
+        const blob = new Blob([bytes], { type: mime });
+        const url = URL.createObjectURL(blob);
+
+        blobUrlRef.current = url;
+        setBlobUrl(url);
+        setFileSize(bytes.byteLength);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : 'Failed to load video');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+        blobUrlRef.current = null;
+      }
+    };
+  }, [workspaceId, filePath]);
+
+  const fileName = filePath.split('/').pop() ?? filePath;
+
+  if (loading) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-[var(--text-muted)]">
+        <Loader2 className="size-6 animate-spin" />
+        <p className="text-sm">Loading video…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 text-[var(--text-muted)]">
+        <AlertCircle className="size-6 text-destructive" />
+        <p className="text-sm">Failed to load video</p>
+        <p className="text-xs opacity-60">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col items-center overflow-auto bg-[var(--bg-base)]">
+      {/* Metadata bar */}
+      <div className="flex w-full items-center gap-3 border-b border-[var(--border)] px-4 py-2 text-xs text-[var(--text-muted)]">
+        <Video className="size-3.5 shrink-0" />
+        <span className="font-medium text-[var(--text-secondary)]">{fileName}</span>
+        {fileSize !== null && (
+          <span>{formatBytes(fileSize)}</span>
+        )}
+      </div>
+
+      {/* Video player — centred */}
+      <div className="flex flex-1 items-center justify-center p-8">
+        {blobUrl && (
+          <video
+            src={blobUrl}
+            controls
+            className="max-h-full max-w-full rounded-md shadow-lg"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-remote/package.json
+++ b/apps/web-remote/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -29,9 +30,11 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.2.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
-    "vite": "^6.4.1"
+    "vite": "^6.4.1",
+    "vitest": "catalog:"
   }
 }

--- a/apps/web-remote/src/App.tsx
+++ b/apps/web-remote/src/App.tsx
@@ -11,16 +11,42 @@ import { Layout } from '@/components/Layout';
 
 export function App() {
   const connectionState = useConnectionState();
-  const autoConnect = useConnectionStore((s) => s.autoConnect);
+  const initialize = useConnectionStore((s) => s.initialize);
+  const retryConnection = useConnectionStore((s) => s.retry);
+  const token = useConnectionStore((s) => s.token);
+  const isBootstrapping = useConnectionStore((s) => s.isBootstrapping);
+  const isInitialized = useConnectionStore((s) => s.isInitialized);
+  const authError = useConnectionStore((s) => s.authError);
+  const disconnectReason = useConnectionStore((s) => s.disconnectReason);
   const fetchWorkspaces = useWorkspaceStore((s) => s.fetchWorkspaces);
 
   // Set up the central message dispatcher (external WS source — valid useEffect)
   useGatewayDispatcher();
 
-  // Try auto-connect from stored token on mount (one-shot init — valid useEffect)
+  // Try auto-connect from stored token on mount and wake reconnects on resume.
   useEffect(() => {
-    autoConnect();
-  }, [autoConnect]);
+    void initialize();
+
+    const retry = () => {
+      retryConnection();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        retry();
+      }
+    };
+
+    window.addEventListener('online', retry);
+    window.addEventListener('pageshow', retry);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('online', retry);
+      window.removeEventListener('pageshow', retry);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [initialize, retryConnection]);
 
   // Fetch workspaces when connected (external event — valid useEffect)
   useEffect(() => {
@@ -29,11 +55,18 @@ export function App() {
     }
   }, [connectionState, fetchWorkspaces]);
 
+  const hasToken = token !== null;
   const showAuth = connectionState !== 'connected';
+  const showReconnectState = !isInitialized || isBootstrapping || hasToken;
 
   return (
     <>
-      {showAuth && <AuthScreen />}
+      {showAuth && (
+        <AuthScreen
+          mode={showReconnectState ? 'reconnecting' : 'auth'}
+          statusMessage={authError ?? disconnectReason}
+        />
+      )}
       <Layout />
     </>
   );

--- a/apps/web-remote/src/components/AuthScreen.tsx
+++ b/apps/web-remote/src/components/AuthScreen.tsx
@@ -1,5 +1,5 @@
 /**
- * Auth screen — token entry with auto-connect from stored token.
+ * Connection screen — token entry plus reconnect state for saved pairings.
  */
 
 import { useState, useCallback } from 'react';
@@ -8,13 +8,21 @@ import { Button } from '@sero/ui/components/ui/button';
 import { Input } from '@sero/ui/components/ui/input';
 import { Loader2, Lock } from 'lucide-react';
 
-export function AuthScreen() {
+interface AuthScreenProps {
+  mode: 'auth' | 'reconnecting';
+  statusMessage?: string | null;
+}
+
+export function AuthScreen({ mode, statusMessage }: AuthScreenProps) {
   const [tokenInput, setTokenInput] = useState('');
   const connect = useConnectionStore((s) => s.connect);
+  const retry = useConnectionStore((s) => s.retry);
+  const disconnect = useConnectionStore((s) => s.disconnect);
   const state = useConnectionStore((s) => s.state);
   const authError = useConnectionStore((s) => s.authError);
 
   const isConnecting = state === 'connecting' || state === 'authenticating';
+  const isReconnecting = state === 'reconnecting';
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
@@ -26,6 +34,42 @@ export function AuthScreen() {
     },
     [tokenInput, connect],
   );
+
+  if (mode === 'reconnecting') {
+    const title = authError ? 'Connect to Sero' : 'Reconnecting to Sero';
+    const description = authError
+      ? 'Your saved token needs to be replaced.'
+      : 'Using your saved device token.';
+
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+        <div className="w-[360px] max-w-[90vw] rounded-xl border border-border bg-card p-6 shadow-xl">
+          <div className="mb-4 flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+              <p className="text-sm text-muted-foreground">{description}</p>
+            </div>
+          </div>
+
+          <p className="rounded-lg border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
+            {statusMessage ?? 'Trying to restore your previous connection now.'}
+          </p>
+
+          <div className="mt-4 flex flex-col gap-3">
+            <Button onClick={retry} disabled={isConnecting} className="w-full">
+              {isConnecting ? 'Retrying...' : isReconnecting ? 'Reconnect Now' : 'Retry Now'}
+            </Button>
+            <Button onClick={disconnect} variant="outline" className="w-full">
+              Use Different Token
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-background/80 backdrop-blur-sm z-50">
@@ -52,6 +96,9 @@ export function AuthScreen() {
 
           {authError && (
             <p className="text-sm text-destructive">{authError}</p>
+          )}
+          {!authError && statusMessage && (
+            <p className="text-sm text-muted-foreground">{statusMessage}</p>
           )}
 
           <Button

--- a/apps/web-remote/src/components/StatusBar.tsx
+++ b/apps/web-remote/src/components/StatusBar.tsx
@@ -21,6 +21,7 @@ export function StatusBar() {
     disconnected: 'text-destructive',
     connecting: 'text-yellow-500',
     authenticating: 'text-yellow-500',
+    reconnecting: 'text-yellow-500',
     connected: 'text-green-500',
   }[state];
 
@@ -28,6 +29,7 @@ export function StatusBar() {
     disconnected: 'Disconnected',
     connecting: 'Connecting...',
     authenticating: 'Authenticating...',
+    reconnecting: 'Reconnecting...',
     connected: 'Connected',
   }[state];
 

--- a/apps/web-remote/src/lib/connect-errors.ts
+++ b/apps/web-remote/src/lib/connect-errors.ts
@@ -1,0 +1,9 @@
+const INVALID_AUTH_TOKEN_RE = /invalid authentication token/i;
+
+export function isInvalidAuthTokenMessage(message: string): boolean {
+  return INVALID_AUTH_TOKEN_RE.test(message);
+}
+
+export function shouldReconnectAfterConnectError(message: string): boolean {
+  return !isInvalidAuthTokenMessage(message);
+}

--- a/apps/web-remote/src/lib/gateway-client.test.ts
+++ b/apps/web-remote/src/lib/gateway-client.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GatewayClient } from '@/lib/gateway-client';
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code = 1000, reason = ''): void {
+    this.emitClose(code, reason);
+  }
+
+  emitOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
+  }
+
+  emitMessage(message: unknown): void {
+    this.onmessage?.(
+      new MessageEvent('message', {
+        data: JSON.stringify(message),
+      }),
+    );
+  }
+
+  emitClose(code = 1000, reason = ''): void {
+    if (this.readyState === MockWebSocket.CLOSED) return;
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.(new CloseEvent('close', { code, reason }));
+  }
+
+  static reset(): void {
+    MockWebSocket.instances = [];
+  }
+}
+
+describe('GatewayClient', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.reset();
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    MockWebSocket.reset();
+  });
+
+  it('keeps reconnects enabled after transient connect errors and retries immediately', () => {
+    const client = new GatewayClient('ws://gateway.test');
+    const disconnectEvents: Array<{ code: number; reason: string; willReconnect: boolean }> = [];
+
+    client.onDisconnect((event) => {
+      disconnectEvents.push(event);
+    });
+
+    client.connect('saved-token');
+
+    const firstSocket = MockWebSocket.instances[0];
+    expect(firstSocket).toBeDefined();
+
+    firstSocket!.emitOpen();
+    expect(JSON.parse(firstSocket!.sent[0])).toMatchObject({
+      type: 'connect',
+      token: 'saved-token',
+      clientType: 'web',
+    });
+
+    firstSocket!.emitMessage({
+      type: 'error',
+      requestType: 'connect',
+      message: 'Too many authentication attempts. Try again later.',
+    });
+    firstSocket!.emitClose(4029, 'Rate limited');
+
+    expect(client.state).toBe('reconnecting');
+    expect(disconnectEvents).toEqual([
+      { code: 4029, reason: 'Rate limited', willReconnect: true },
+    ]);
+
+    client.retryNow();
+
+    const secondSocket = MockWebSocket.instances[1];
+    expect(secondSocket).toBeDefined();
+
+    secondSocket!.emitOpen();
+    expect(JSON.parse(secondSocket!.sent[0])).toMatchObject({
+      type: 'connect',
+      token: 'saved-token',
+      clientType: 'web',
+    });
+
+    vi.advanceTimersByTime(3000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it('stops reconnecting after invalid authentication tokens', () => {
+    const client = new GatewayClient('ws://gateway.test');
+    const disconnectEvents: Array<{ code: number; reason: string; willReconnect: boolean }> = [];
+
+    client.onDisconnect((event) => {
+      disconnectEvents.push(event);
+    });
+
+    client.connect('bad-token');
+
+    const socket = MockWebSocket.instances[0];
+    expect(socket).toBeDefined();
+
+    socket!.emitOpen();
+    socket!.emitMessage({
+      type: 'error',
+      requestType: 'connect',
+      message: 'Invalid authentication token',
+    });
+    socket!.emitClose(4003, 'Authentication failed');
+
+    expect(client.state).toBe('disconnected');
+    expect(disconnectEvents).toEqual([
+      { code: 4003, reason: 'Authentication failed', willReconnect: false },
+    ]);
+
+    client.retryNow();
+    vi.advanceTimersByTime(3000);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/apps/web-remote/src/lib/gateway-client.ts
+++ b/apps/web-remote/src/lib/gateway-client.ts
@@ -36,7 +36,18 @@ export interface GatewayPushEvent {
 
 export type GatewayMessage = GatewayResponse | GatewayPushEvent;
 
-export type ConnectionState = 'disconnected' | 'connecting' | 'authenticating' | 'connected';
+export type ConnectionState =
+  | 'disconnected'
+  | 'connecting'
+  | 'authenticating'
+  | 'reconnecting'
+  | 'connected';
+
+export interface DisconnectEvent {
+  code: number;
+  reason: string;
+  willReconnect: boolean;
+}
 
 export type MessageHandler = (msg: GatewayMessage) => void;
 
@@ -61,6 +72,7 @@ export class GatewayClient {
   private shouldReconnect = false;
   private messageHandlers = new Set<MessageHandler>();
   private stateHandlers = new Set<(state: ConnectionState) => void>();
+  private disconnectHandlers = new Set<(event: DisconnectEvent) => void>();
   private _state: ConnectionState = 'disconnected';
 
   constructor(url?: string) {
@@ -114,6 +126,12 @@ export class GatewayClient {
     return () => this.messageHandlers.delete(handler);
   }
 
+  /** Subscribe to socket close events. Returns unsubscribe function. */
+  onDisconnect(handler: (event: DisconnectEvent) => void): () => void {
+    this.disconnectHandlers.add(handler);
+    return () => this.disconnectHandlers.delete(handler);
+  }
+
   /** Connect to the gateway with the given token. */
   connect(token: string): void {
     this.token = token;
@@ -134,6 +152,20 @@ export class GatewayClient {
       this.ws = null;
     }
     this.setState('disconnected');
+  }
+
+  /** Trigger an immediate reconnect if the client has a saved token. */
+  retryNow(): void {
+    if (!this.shouldReconnect) return;
+    if (this._state === 'connected' || this._state === 'connecting' || this._state === 'authenticating') {
+      return;
+    }
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.reconnectDelay = RECONNECT_DELAY_MS;
+    this.doConnect();
   }
 
   /** Send a request to the gateway. */
@@ -255,13 +287,19 @@ export class GatewayClient {
       }
     };
 
-    this.ws.onclose = () => {
+    this.ws.onclose = (event) => {
       this.ws = null;
-      // Always reset to disconnected when the socket closes, regardless of
-      // which state we were in (connecting, authenticating, or connected).
-      if (this._state !== 'disconnected') {
+      const willReconnect = this.shouldReconnect;
+      if (willReconnect) {
+        this.setState('reconnecting');
+      } else if (this._state !== 'disconnected') {
         this.setState('disconnected');
       }
+      this.emitDisconnect({
+        code: event.code,
+        reason: event.reason,
+        willReconnect,
+      });
       this.scheduleReconnect();
     };
 
@@ -302,5 +340,15 @@ export class GatewayClient {
 
     // Exponential backoff with cap
     this.reconnectDelay = Math.min(this.reconnectDelay * 1.5, MAX_RECONNECT_DELAY_MS);
+  }
+
+  private emitDisconnect(event: DisconnectEvent): void {
+    for (const handler of this.disconnectHandlers) {
+      try {
+        handler(event);
+      } catch (err) {
+        console.error('[gateway-client] Disconnect handler error:', err);
+      }
+    }
   }
 }

--- a/apps/web-remote/src/lib/gateway-client.ts
+++ b/apps/web-remote/src/lib/gateway-client.ts
@@ -1,3 +1,8 @@
+import {
+  isInvalidAuthTokenMessage,
+  shouldReconnectAfterConnectError,
+} from '@/lib/connect-errors';
+
 /**
  * WebSocket client wrapper for the Sero gateway.
  *
@@ -314,9 +319,17 @@ export class GatewayClient {
       this.setState('connected');
       this.reconnectDelay = RECONNECT_DELAY_MS;
     } else if (msg.type === 'error' && 'requestType' in msg && msg.requestType === 'connect') {
-      // Auth failed — don't reconnect with the same bad token
-      this.shouldReconnect = false;
-      this.setState('disconnected');
+      const { message } = msg;
+      const shouldReconnect = shouldReconnectAfterConnectError(message);
+
+      this.shouldReconnect = shouldReconnect;
+
+      if (!shouldReconnect) {
+        if (isInvalidAuthTokenMessage(message)) {
+          this.token = '';
+        }
+        this.setState('disconnected');
+      }
     }
 
     // Dispatch to all handlers

--- a/apps/web-remote/src/stores/connection.test.ts
+++ b/apps/web-remote/src/stores/connection.test.ts
@@ -92,6 +92,18 @@ function createStorage(loadValue: string | null = null) {
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
 describe('connection store', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -168,6 +180,33 @@ describe('connection store', () => {
     expect(store.getState().disconnectReason).toBe(
       'Too many authentication attempts. Try again later.',
     );
+  });
+
+  it('does not restore a stored token after the user switches tokens mid-bootstrap', async () => {
+    const client = new FakeGatewayClient();
+    const deferred = createDeferred<string | null>();
+    const storage = {
+      save: vi.fn(async () => {}),
+      load: vi.fn(() => deferred.promise),
+      clear: vi.fn(async () => {}),
+    };
+    const store = createConnectionStore(client, storage);
+
+    const initializePromise = store.getState().initialize();
+
+    expect(store.getState().isBootstrapping).toBe(true);
+
+    store.getState().disconnect();
+    store.getState().connect('manual-token');
+
+    deferred.resolve('stored-token');
+    await initializePromise;
+
+    expect(storage.clear).toHaveBeenCalledTimes(1);
+    expect(client.connectCalls).toEqual(['manual-token']);
+    expect(store.getState().token).toBe('manual-token');
+    expect(store.getState().isInitialized).toBe(true);
+    expect(store.getState().isBootstrapping).toBe(false);
   });
 
   it('stays in reconnect mode after transport loss and supports immediate retry', () => {

--- a/apps/web-remote/src/stores/connection.test.ts
+++ b/apps/web-remote/src/stores/connection.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createConnectionStore,
+  type GatewayClientLike,
+} from '@/stores/connection';
+import type {
+  ConnectionState,
+  DisconnectEvent,
+  GatewayMessage,
+} from '@/lib/gateway-client';
+
+class FakeGatewayClient implements GatewayClientLike {
+  private stateHandlers = new Set<(state: ConnectionState) => void>();
+  private messageHandlers = new Set<(msg: GatewayMessage) => void>();
+  private disconnectHandlers = new Set<(event: DisconnectEvent) => void>();
+
+  connectCalls: string[] = [];
+  disconnectCalls = 0;
+  retryCalls = 0;
+
+  onStateChange(handler: (state: ConnectionState) => void): () => void {
+    this.stateHandlers.add(handler);
+    return () => this.stateHandlers.delete(handler);
+  }
+
+  onMessage(handler: (msg: GatewayMessage) => void): () => void {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onDisconnect(handler: (event: DisconnectEvent) => void): () => void {
+    this.disconnectHandlers.add(handler);
+    return () => this.disconnectHandlers.delete(handler);
+  }
+
+  connect(token: string): void {
+    this.connectCalls.push(token);
+  }
+
+  disconnect(): void {
+    this.disconnectCalls += 1;
+  }
+
+  retryNow(): void {
+    this.retryCalls += 1;
+  }
+
+  sendPrompt(): void {}
+
+  requestWorkspaces(): void {}
+
+  requestSessions(): void {}
+
+  createSession(): void {}
+
+  abortSession(): void {}
+
+  requestSessionHistory(): void {}
+
+  listFiles(): void {}
+
+  readFile(): void {}
+
+  listArtifacts(): void {}
+
+  getArtifact(): void {}
+
+  emitState(state: ConnectionState): void {
+    for (const handler of this.stateHandlers) {
+      handler(state);
+    }
+  }
+
+  emitMessage(message: GatewayMessage): void {
+    for (const handler of this.messageHandlers) {
+      handler(message);
+    }
+  }
+
+  emitDisconnect(event: DisconnectEvent): void {
+    for (const handler of this.disconnectHandlers) {
+      handler(event);
+    }
+  }
+}
+
+function createStorage(loadValue: string | null = null) {
+  return {
+    save: vi.fn(async () => {}),
+    load: vi.fn(async () => loadValue),
+    clear: vi.fn(async () => {}),
+  };
+}
+
+describe('connection store', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('bootstraps from a stored token and connects once', async () => {
+    const client = new FakeGatewayClient();
+    const storage = createStorage('stored-token');
+    const store = createConnectionStore(client, storage);
+
+    await store.getState().initialize();
+
+    expect(storage.load).toHaveBeenCalledTimes(1);
+    expect(client.connectCalls).toEqual(['stored-token']);
+    expect(store.getState().token).toBe('stored-token');
+    expect(store.getState().isInitialized).toBe(true);
+    expect(store.getState().isBootstrapping).toBe(false);
+  });
+
+  it('prefers a QR token from the URL and removes it from the address bar', async () => {
+    const client = new FakeGatewayClient();
+    const storage = createStorage('stored-token');
+    const store = createConnectionStore(client, storage);
+
+    window.history.replaceState({}, '', '/remote?foo=bar&token=url-token#chat');
+
+    await store.getState().initialize();
+
+    expect(storage.load).not.toHaveBeenCalled();
+    expect(client.connectCalls).toEqual(['url-token']);
+    expect(store.getState().token).toBe('url-token');
+    expect(window.location.search).toBe('?foo=bar');
+    expect(window.location.hash).toBe('#chat');
+  });
+
+  it('saves the token on successful auth and clears invalid tokens on auth failure', async () => {
+    const client = new FakeGatewayClient();
+    const storage = createStorage();
+    const store = createConnectionStore(client, storage);
+
+    store.getState().connect('valid-token');
+    client.emitMessage({ type: 'ok', requestType: 'connect' });
+
+    expect(storage.save).toHaveBeenCalledWith('valid-token');
+
+    store.getState().connect('bad-token');
+    client.emitMessage({
+      type: 'error',
+      requestType: 'connect',
+      message: 'Invalid authentication token',
+    });
+
+    expect(storage.clear).toHaveBeenCalledTimes(1);
+    expect(store.getState().token).toBeNull();
+    expect(store.getState().authError).toBe('Invalid authentication token');
+  });
+
+  it('keeps the saved token when connect fails for a transient reason', () => {
+    const client = new FakeGatewayClient();
+    const storage = createStorage();
+    const store = createConnectionStore(client, storage);
+
+    store.getState().connect('saved-token');
+    client.emitMessage({
+      type: 'error',
+      requestType: 'connect',
+      message: 'Too many authentication attempts. Try again later.',
+    });
+
+    expect(storage.clear).not.toHaveBeenCalled();
+    expect(store.getState().token).toBe('saved-token');
+    expect(store.getState().authError).toBeNull();
+    expect(store.getState().disconnectReason).toBe(
+      'Too many authentication attempts. Try again later.',
+    );
+  });
+
+  it('stays in reconnect mode after transport loss and supports immediate retry', () => {
+    const client = new FakeGatewayClient();
+    const storage = createStorage();
+    const store = createConnectionStore(client, storage);
+
+    store.getState().connect('saved-token');
+    client.emitState('reconnecting');
+    client.emitDisconnect({ code: 1006, reason: '', willReconnect: true });
+
+    expect(store.getState().token).toBe('saved-token');
+    expect(store.getState().state).toBe('reconnecting');
+    expect(store.getState().disconnectReason).toBe(
+      'Connection lost. Reconnecting automatically...',
+    );
+
+    store.getState().retry();
+
+    expect(client.retryCalls).toBe(1);
+    expect(store.getState().disconnectReason).toBeNull();
+  });
+});

--- a/apps/web-remote/src/stores/connection.ts
+++ b/apps/web-remote/src/stores/connection.ts
@@ -1,88 +1,236 @@
 /**
- * Connection store — WebSocket state, authentication, and token management.
+ * Connection store — WebSocket state, authentication, token management,
+ * and reconnect UX state for the remote gateway.
  */
 
 import { create } from 'zustand';
-import { GatewayClient, type ConnectionState, type GatewayMessage } from '@/lib/gateway-client';
+import {
+  GatewayClient,
+  type ConnectionState,
+  type DisconnectEvent,
+  type GatewayMessage,
+} from '@/lib/gateway-client';
 import { saveToken, loadToken, clearToken } from '@/lib/token-storage';
+
+interface TokenStorageAdapter {
+  save: (token: string) => Promise<void>;
+  load: () => Promise<string | null>;
+  clear: () => Promise<void>;
+}
+
+export interface GatewayClientLike {
+  onStateChange: (handler: (state: ConnectionState) => void) => () => void;
+  onMessage: (handler: (msg: GatewayMessage) => void) => () => void;
+  onDisconnect: (handler: (event: DisconnectEvent) => void) => () => void;
+  connect: (token: string) => void;
+  disconnect: () => void;
+  retryNow: () => void;
+  sendPrompt: (
+    workspaceId: string,
+    sessionId: string,
+    text: string,
+    images?: Array<{ data: string; mimeType: string }>,
+  ) => void;
+  requestWorkspaces: () => void;
+  requestSessions: (workspaceId: string) => void;
+  createSession: (workspaceId: string, name?: string) => void;
+  abortSession: (sessionId: string) => void;
+  requestSessionHistory: (workspaceId: string, sessionId: string) => void;
+  listFiles: (workspaceId: string, filePath: string) => void;
+  readFile: (workspaceId: string, filePath: string) => void;
+  listArtifacts: (sessionId: string) => void;
+  getArtifact: (artifactId: string) => void;
+}
 
 interface ConnectionStore {
   state: ConnectionState;
-  client: GatewayClient;
+  client: GatewayClientLike;
   token: string | null;
   authError: string | null;
+  disconnectReason: string | null;
+  isBootstrapping: boolean;
+  isInitialized: boolean;
 
-  /** Connect with a token (manual entry). */
+  /** Connect with a token (manual entry or QR pairing). */
   connect: (token: string) => void;
-  /** Try auto-connect from stored token. */
-  autoConnect: () => Promise<void>;
-  /** Disconnect and clear stored token. */
+  /** Load an existing token from URL or IndexedDB and connect once. */
+  initialize: () => Promise<void>;
+  /** Retry immediately without asking for the token again. */
+  retry: () => void;
+  /** Disconnect and forget the saved pairing token. */
   disconnect: () => void;
   /** Called internally when a message arrives. */
   handleMessage: (msg: GatewayMessage) => void;
 }
 
-const client = new GatewayClient();
+const defaultTokenStorage: TokenStorageAdapter = {
+  save: saveToken,
+  load: loadToken,
+  clear: clearToken,
+};
 
-export const useConnectionStore = create<ConnectionStore>((set, get) => {
-  // Wire up state change listener
-  client.onStateChange((state) => {
-    set({ state });
-  });
+function consumeTokenFromUrl(): string | null {
+  const url = new URL(window.location.href);
+  const token = url.searchParams.get('token')?.trim();
+  if (!token) return null;
 
-  // Wire up message handler
-  client.onMessage((msg) => {
-    get().handleMessage(msg);
-  });
+  url.searchParams.delete('token');
+  const nextPath = `${url.pathname}${url.search}${url.hash}`;
+  window.history.replaceState({}, '', nextPath || '/');
 
-  return {
-    state: 'disconnected',
-    client,
-    token: null,
-    authError: null,
+  return token;
+}
 
-    connect: (token: string) => {
-      set({ authError: null, token });
-      client.connect(token);
-      // Save token on successful auth (handled in handleMessage)
-    },
+export function getDisconnectMessage(event: DisconnectEvent): string {
+  switch (event.code) {
+    case 4008:
+      return 'Connection went idle. Reconnecting automatically...';
+    case 1012:
+      return 'Sero is restarting. Reconnecting automatically...';
+    case 1013:
+      return 'Sero is temporarily unavailable. Retrying shortly...';
+    default:
+      break;
+  }
 
-    autoConnect: async () => {
-      // Check URL params first (e.g. from QR code: ?token=...)
-      const urlParams = new URLSearchParams(window.location.search);
-      const urlToken = urlParams.get('token');
-      if (urlToken) {
-        // Clean up the URL so the token isn't visible in the address bar
-        const cleanUrl = window.location.pathname + window.location.hash;
-        window.history.replaceState({}, '', cleanUrl);
-        set({ token: urlToken, authError: null });
-        client.connect(urlToken);
+  if (event.reason) {
+    return `${event.reason}. Reconnecting automatically...`;
+  }
+
+  return 'Connection lost. Reconnecting automatically...';
+}
+
+function shouldForgetToken(message: string): boolean {
+  return /invalid authentication token/i.test(message);
+}
+
+export function createConnectionStore(
+  client: GatewayClientLike,
+  tokenStorage: TokenStorageAdapter = defaultTokenStorage,
+) {
+  return create<ConnectionStore>((set, get) => {
+    client.onStateChange((state) => {
+      if (state === 'connecting' || state === 'authenticating' || state === 'connected') {
+        set({ state, disconnectReason: null });
         return;
       }
-      // Fall back to stored token
-      const stored = await loadToken();
-      if (stored) {
-        set({ token: stored, authError: null });
-        client.connect(stored);
-      }
-    },
+      set({ state });
+    });
 
-    disconnect: () => {
-      client.disconnect();
-      clearToken();
-      set({ token: null, authError: null });
-    },
+    client.onDisconnect((event) => {
+      if (!event.willReconnect) return;
+      if (get().authError) return;
+      set({ disconnectReason: getDisconnectMessage(event) });
+    });
 
-    handleMessage: (msg: GatewayMessage) => {
-      if (msg.type === 'ok' && 'requestType' in msg && msg.requestType === 'connect') {
-        // Auth succeeded — persist token
-        const { token } = get();
-        if (token) {
-          saveToken(token);
+    client.onMessage((msg) => {
+      get().handleMessage(msg);
+    });
+
+    return {
+      state: 'disconnected',
+      client,
+      token: null,
+      authError: null,
+      disconnectReason: null,
+      isBootstrapping: false,
+      isInitialized: false,
+
+      connect: (token: string) => {
+        const trimmed = token.trim();
+        if (!trimmed) return;
+        set({
+          token: trimmed,
+          authError: null,
+          disconnectReason: null,
+          isBootstrapping: false,
+          isInitialized: true,
+        });
+        client.connect(trimmed);
+      },
+
+      initialize: async () => {
+        if (get().isBootstrapping || get().isInitialized) return;
+
+        set({
+          isBootstrapping: true,
+          authError: null,
+          disconnectReason: null,
+        });
+
+        const finalize = (token: string | null) => {
+          set({
+            token,
+            authError: null,
+            disconnectReason: null,
+            isBootstrapping: false,
+            isInitialized: true,
+          });
+          if (token) {
+            client.connect(token);
+          }
+        };
+
+        try {
+          const urlToken = consumeTokenFromUrl();
+          if (urlToken) {
+            finalize(urlToken);
+            return;
+          }
+
+          const storedToken = await tokenStorage.load();
+          finalize(storedToken);
+        } catch {
+          finalize(null);
         }
-      } else if (msg.type === 'error' && 'requestType' in msg && msg.requestType === 'connect') {
-        set({ authError: (msg as { message: string }).message });
-      }
-    },
-  };
-});
+      },
+
+      retry: () => {
+        set({ authError: null, disconnectReason: null });
+        client.retryNow();
+      },
+
+      disconnect: () => {
+        client.disconnect();
+        void tokenStorage.clear();
+        set({
+          token: null,
+          authError: null,
+          disconnectReason: null,
+          isBootstrapping: false,
+          isInitialized: true,
+        });
+      },
+
+      handleMessage: (msg: GatewayMessage) => {
+        if (msg.type === 'ok' && 'requestType' in msg && msg.requestType === 'connect') {
+          const { token } = get();
+          set({ authError: null, disconnectReason: null });
+          if (token) {
+            void tokenStorage.save(token);
+          }
+          return;
+        }
+
+        if (msg.type === 'error' && 'requestType' in msg && msg.requestType === 'connect') {
+          const message = (msg as { message: string }).message;
+          const forgetToken = shouldForgetToken(message);
+          if (forgetToken) {
+            void tokenStorage.clear();
+          }
+          set({
+            token: forgetToken ? null : get().token,
+            authError: forgetToken ? message : null,
+            disconnectReason: forgetToken ? null : message,
+            isBootstrapping: false,
+            isInitialized: true,
+          });
+        }
+      },
+    };
+  });
+}
+
+const client = new GatewayClient();
+
+export const useConnectionStore = createConnectionStore(client);

--- a/apps/web-remote/src/stores/connection.ts
+++ b/apps/web-remote/src/stores/connection.ts
@@ -10,6 +10,7 @@ import {
   type DisconnectEvent,
   type GatewayMessage,
 } from '@/lib/gateway-client';
+import { isInvalidAuthTokenMessage } from '@/lib/connect-errors';
 import { saveToken, loadToken, clearToken } from '@/lib/token-storage';
 
 interface TokenStorageAdapter {
@@ -100,10 +101,6 @@ export function getDisconnectMessage(event: DisconnectEvent): string {
   return 'Connection lost. Reconnecting automatically...';
 }
 
-function shouldForgetToken(message: string): boolean {
-  return /invalid authentication token/i.test(message);
-}
-
 export function createConnectionStore(
   client: GatewayClientLike,
   tokenStorage: TokenStorageAdapter = defaultTokenStorage,
@@ -159,6 +156,9 @@ export function createConnectionStore(
         });
 
         const finalize = (token: string | null) => {
+          const state = get();
+          if (!state.isBootstrapping || state.isInitialized) return;
+
           set({
             token,
             authError: null,
@@ -214,7 +214,7 @@ export function createConnectionStore(
 
         if (msg.type === 'error' && 'requestType' in msg && msg.requestType === 'connect') {
           const message = (msg as { message: string }).message;
-          const forgetToken = shouldForgetToken(message);
+          const forgetToken = isInvalidAuthTokenMessage(message);
           if (forgetToken) {
             void tokenStorage.clear();
           }

--- a/apps/web-remote/vitest.config.ts
+++ b/apps/web-remote/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    environment: 'jsdom',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,6 +332,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.7.0
         version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.1
@@ -344,6 +347,9 @@ importers:
       vite:
         specifier: ^6.4.1
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(yaml@2.8.2)
 
   packages/app-runtime:
     dependencies:
@@ -13115,6 +13121,15 @@ snapshots:
       msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
       vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
 
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@22.19.15)(typescript@5.9.3)
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+
   '@vitest/pretty-format@4.0.18':
     dependencies:
       tinyrainbow: 3.1.0
@@ -18305,6 +18320,45 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 22.19.11
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(yaml@2.8.2):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.15
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Summary
- harden the web remote connection store so saved pairings survive bootstrap, reconnect backoff, and transient transport failures without dropping to token entry
- add explicit reconnect handling in the gateway client and wake reconnects on mobile resume, page restore, and network regain
- add focused web-remote tests for stored-token bootstrap, URL-token pairing, invalid token cleanup, and transient reconnect failures

## Testing
- pnpm --dir apps/web-remote test
- pnpm --dir apps/web-remote build
- pnpm typecheck
