### PR TITLE
Add Model Manager with favourites, visibility, and provider filters

### DIFF
--- a/apps/desktop/electron/ipc/layout.ts
+++ b/apps/desktop/electron/ipc/layout.ts
@@ -10,23 +10,36 @@ import { promises as fs } from 'fs';
 import { existsSync, mkdirSync } from 'fs';
 import path from 'path';
 import { IpcChannels } from '../../src/types/ipc';
-import type { LayoutState } from '../../src/types/layout';
+import type { LayoutState, LoadedLayoutState } from '../../src/types/layout';
 import { SERO_AGENT_DIR } from '../env';
 
-export type { LayoutState };
+export type { LayoutState, LoadedLayoutState };
 
 const LAYOUT_FILE = path.join(SERO_AGENT_DIR, 'layout.json');
 
 let writeQueue: Promise<void> = Promise.resolve();
 
-function isLayoutState(value: unknown): value is LayoutState {
+function isOptionalArray(value: unknown): boolean {
+  return value === undefined || Array.isArray(value);
+}
+
+function sanitizeStringArray(values: string[] | undefined): string[] | undefined {
+  return Array.isArray(values)
+    ? values.filter((value): value is string => typeof value === 'string')
+    : undefined;
+}
+
+function isLayoutState(value: unknown): value is LoadedLayoutState {
   if (!value || typeof value !== 'object') return false;
   const c = value as Record<string, unknown>;
   // Required booleans
   if (typeof c.mainSidebarOpen !== 'boolean') return false;
   if (typeof c.chatPanelOpen !== 'boolean') return false;
-  // Optional array
-  if (c.favouriteApps !== undefined && !Array.isArray(c.favouriteApps)) return false;
+  // Optional arrays
+  if (!isOptionalArray(c.favouriteApps)) return false;
+  if (!isOptionalArray(c.favouriteModels)) return false;
+  if (!isOptionalArray(c.hiddenModels)) return false;
+  if (!isOptionalArray(c.hiddenProviders)) return false;
   // Optional strings — reject wrong types to prevent garbage propagation
   if (c.theme !== undefined && typeof c.theme !== 'string') return false;
   if (c.activeApp !== undefined && typeof c.activeApp !== 'string') return false;
@@ -38,14 +51,16 @@ function isLayoutState(value: unknown): value is LayoutState {
 }
 
 /** Parse layout JSON. Returns the state if valid, null otherwise. */
-function parseLayoutState(raw: string): LayoutState | null {
+function parseLayoutState(raw: string): LoadedLayoutState | null {
   try {
     const parsed = JSON.parse(raw.trim());
     if (!isLayoutState(parsed)) return null;
-    if (!Array.isArray(parsed.favouriteApps)) return parsed;
     return {
       ...parsed,
-      favouriteApps: parsed.favouriteApps.filter((id): id is string => typeof id === 'string'),
+      favouriteApps: sanitizeStringArray(parsed.favouriteApps),
+      favouriteModels: sanitizeStringArray(parsed.favouriteModels),
+      hiddenModels: sanitizeStringArray(parsed.hiddenModels),
+      hiddenProviders: sanitizeStringArray(parsed.hiddenProviders),
     };
   } catch {
     return null;

--- a/apps/desktop/src/components/layout/ModelSelector.tsx
+++ b/apps/desktop/src/components/layout/ModelSelector.tsx
@@ -1,9 +1,10 @@
 import { useState, useCallback, useMemo, useRef, useEffect, memo } from 'react';
-import { ChevronDown, Check, Brain, Sparkles, Search } from 'lucide-react';
+import { ChevronDown, Check, Brain, Sparkles, Search, Settings2, Star } from 'lucide-react';
 import { motion } from 'motion/react';
 import { Popover, PopoverContent, PopoverTrigger } from '@sero/ui/components/ui/popover';
 import { useAgentStore } from '@/stores/agent';
 import { useFocusedModelState, useFocusedSessionId } from '@/stores/agent-selectors';
+import { useModelPreferences, modelKey } from '@/stores/model-preferences';
 import {
   THINKING_LEVELS,
   THINKING_LABELS,
@@ -11,6 +12,7 @@ import {
   findGroup,
   type ThinkingLevel,
 } from './model-config';
+import { ModelManagerDialog } from './model-manager';
 import type { ModelInfo, AvailableModelGroup } from '@/types/ipc';
 
 // ── Trigger Button ─────────────────────────────────────────────
@@ -119,8 +121,8 @@ function ThinkingPicker({
 
 // ── Model Item ─────────────────────────────────────────────────
 
-const ModelItem = memo(function ModelItem({ model, isSelected, onSelect }: {
-  model: ModelInfo; isSelected: boolean; onSelect: (model: ModelInfo) => void;
+const ModelItem = memo(function ModelItem({ model, isSelected, isFavourite, onSelect }: {
+  model: ModelInfo; isSelected: boolean; isFavourite: boolean; onSelect: (model: ModelInfo) => void;
 }) {
   return (
     <button
@@ -134,6 +136,8 @@ const ModelItem = memo(function ModelItem({ model, isSelected, onSelect }: {
       <div className="flex size-4 shrink-0 items-center justify-center">
         {isSelected ? (
           <Check className="size-3.5 text-[var(--status-success)] transition-transform duration-150 scale-100" />
+        ) : isFavourite ? (
+          <Star className="size-3 text-amber-400" fill="currentColor" />
         ) : (
           <div className="size-1.5 rounded-full bg-[var(--border-default)] transition-colors group-hover:bg-[var(--text-muted)]" />
         )}
@@ -148,10 +152,11 @@ const ModelItem = memo(function ModelItem({ model, isSelected, onSelect }: {
 
 // ── Provider Group ─────────────────────────────────────────────
 
-const ProviderSection = memo(function ProviderSection({ group, selectedProvider, selectedModelId, onSelect }: {
+const ProviderSection = memo(function ProviderSection({ group, selectedProvider, selectedModelId, favouriteKeys, onSelect }: {
   group: AvailableModelGroup;
   selectedProvider: string | null;
   selectedModelId: string | null;
+  favouriteKeys: Set<string>;
   onSelect: (model: ModelInfo) => void;
 }) {
   return (
@@ -172,6 +177,7 @@ const ProviderSection = memo(function ProviderSection({ group, selectedProvider,
               selectedProvider === model.provider &&
               selectedModelId === model.modelId
             }
+            isFavourite={favouriteKeys.has(modelKey(model.provider, model.modelId))}
             onSelect={onSelect}
           />
         ))}
@@ -180,7 +186,7 @@ const ProviderSection = memo(function ProviderSection({ group, selectedProvider,
   );
 });
 
-// ── Main Component ─────────────────────────────────────────────
+// ── Helpers ────────────────────────────────────────────────────
 
 /** Filter groups by search query, matching on model name or model ID. */
 function filterGroups(groups: AvailableModelGroup[], query: string): AvailableModelGroup[] {
@@ -196,8 +202,46 @@ function filterGroups(groups: AvailableModelGroup[], query: string): AvailableMo
   return filtered;
 }
 
+/** Remove hidden models/providers and extract favourite models into a separate section. */
+function applyPreferences(
+  groups: AvailableModelGroup[],
+  hiddenModels: Set<string>,
+  hiddenProviders: Set<string>,
+): AvailableModelGroup[] {
+  const result: AvailableModelGroup[] = [];
+  for (const group of groups) {
+    if (hiddenProviders.has(group.provider)) continue;
+    const visible = group.models.filter(
+      (m) => !hiddenModels.has(modelKey(m.provider, m.modelId)),
+    );
+    if (visible.length) result.push({ ...group, models: visible });
+  }
+  return result;
+}
+
+/** Build a favourites section from groups + favourite keys. */
+function buildFavourites(
+  groups: AvailableModelGroup[],
+  favouriteKeys: string[],
+): { model: ModelInfo; group: AvailableModelGroup }[] {
+  if (!favouriteKeys.length) return [];
+  const favSet = new Set(favouriteKeys);
+  const result: { model: ModelInfo; group: AvailableModelGroup }[] = [];
+  for (const group of groups) {
+    for (const model of group.models) {
+      if (favSet.has(modelKey(model.provider, model.modelId))) {
+        result.push({ model, group });
+      }
+    }
+  }
+  return result;
+}
+
+// ── Main Component ─────────────────────────────────────────────
+
 export function ModelSelector({ disabled }: { disabled: boolean }) {
   const [open, setOpen] = useState(false);
+  const [managerOpen, setManagerOpen] = useState(false);
   const [filter, setFilter] = useState('');
   const [isPrimed, setIsPrimed] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -206,14 +250,30 @@ export function ModelSelector({ disabled }: { disabled: boolean }) {
   const setModel = useAgentStore((s) => s.setModel);
   const setThinkingLevel = useAgentStore((s) => s.setThinkingLevel);
 
-  const groups = ms?.availableModels ?? [];
+  const prefs = useModelPreferences();
+  const favouriteKeys = useMemo(() => new Set(prefs.favouriteModels), [prefs.favouriteModels]);
+  const hiddenModelKeys = useMemo(() => new Set(prefs.hiddenModels), [prefs.hiddenModels]);
+  const hiddenProviderKeys = useMemo(() => new Set(prefs.hiddenProviders), [prefs.hiddenProviders]);
+
+  const allGroups = ms?.availableModels ?? [];
   const selectedProvider = ms?.model.provider ?? null;
   const selectedModelId = ms?.model.modelId ?? null;
 
-  const filteredGroups = useMemo(() => filterGroups(groups, filter), [groups, filter]);
+  // Apply visibility preferences then search filter
+  const visibleGroups = useMemo(
+    () => applyPreferences(allGroups, hiddenModelKeys, hiddenProviderKeys),
+    [allGroups, hiddenModelKeys, hiddenProviderKeys],
+  );
+  const filteredGroups = useMemo(() => filterGroups(visibleGroups, filter), [visibleGroups, filter]);
   const totalFiltered = useMemo(
     () => filteredGroups.reduce((n, g) => n + g.models.length, 0),
     [filteredGroups],
+  );
+
+  // Build favourites section (only when not searching)
+  const favourites = useMemo(
+    () => filter ? [] : buildFavourites(visibleGroups, prefs.favouriteModels),
+    [visibleGroups, prefs.favouriteModels, filter],
   );
 
   const primePopover = useCallback(() => {
@@ -224,7 +284,6 @@ export function ModelSelector({ disabled }: { disabled: boolean }) {
   useEffect(() => {
     if (open) {
       setFilter('');
-      // Small delay so popover is rendered before focusing
       requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [open]);
@@ -266,66 +325,116 @@ export function ModelSelector({ disabled }: { disabled: boolean }) {
     setOpen(nextOpen);
   }, []);
 
-  return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <ModelTrigger disabled={disabled} onPrime={primePopover} />
-      <PopoverContent
-        forceMount={isPrimed ? true : undefined}
-        side="top"
-        align="start"
-        sideOffset={8}
-        className="w-[300px] overflow-hidden rounded-xl border-[var(--border-subtle)] bg-[var(--bg-surface)] p-0 shadow-2xl shadow-black/40 duration-150 data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-100 data-[state=closed]:zoom-out-100 data-[side=top]:slide-in-from-bottom-0 data-[side=bottom]:slide-in-from-top-0 data-[side=left]:slide-in-from-right-0 data-[side=right]:slide-in-from-left-0"
-      >
-        <div>
+  const handleOpenManager = useCallback(() => {
+    setOpen(false);
+    setManagerOpen(true);
+  }, []);
 
-          {/* Search input */}
-          <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] px-3">
-            <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
-            <input
-              ref={inputRef}
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-              placeholder="Search models…"
-              data-slot="model-filter"
-              className="h-9 w-full bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus-visible:outline-none"
+  return (
+    <>
+      <Popover open={open} onOpenChange={handleOpenChange}>
+        <ModelTrigger disabled={disabled} onPrime={primePopover} />
+        <PopoverContent
+          forceMount={isPrimed ? true : undefined}
+          side="top"
+          align="start"
+          sideOffset={8}
+          className="w-[300px] overflow-hidden rounded-xl border-[var(--border-subtle)] bg-[var(--bg-surface)] p-0 shadow-2xl shadow-black/40 duration-150 data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-100 data-[state=closed]:zoom-out-100 data-[side=top]:slide-in-from-bottom-0 data-[side=bottom]:slide-in-from-top-0 data-[side=left]:slide-in-from-right-0 data-[side=right]:slide-in-from-left-0"
+        >
+          <div>
+
+            {/* Search input + settings gear */}
+            <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] px-3">
+              <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+              <input
+                ref={inputRef}
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Search models…"
+                data-slot="model-filter"
+                className="h-9 w-full bg-transparent text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)] outline-none focus-visible:outline-none"
+              />
+              <button
+                onClick={handleOpenManager}
+                title="Manage models"
+                className="shrink-0 rounded-md p-1 text-[var(--text-muted)] transition-colors
+                  hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+              >
+                <Settings2 className="size-3.5" />
+              </button>
+            </div>
+
+            {/* Model List */}
+            <div className="max-h-[320px] overflow-y-auto py-1">
+              {allGroups.length === 0 ? (
+                <div className="px-3 py-4 text-center text-xs text-[var(--text-muted)]">
+                  No models available. Run <code className="rounded bg-[var(--bg-muted)] px-1 font-mono">pi auth</code> to add a provider.
+                </div>
+              ) : totalFiltered === 0 && favourites.length === 0 ? (
+                <div className="px-3 py-4 text-center text-xs text-[var(--text-muted)]">
+                  No models matching "<span className="text-[var(--text-secondary)]">{filter}</span>"
+                </div>
+              ) : (
+                <>
+                  {/* Favourites section */}
+                  {favourites.length > 0 && (
+                    <div className="py-1">
+                      <div className="flex items-center gap-2 px-3 pb-1 pt-2">
+                        <Star className="size-3 text-amber-400" fill="currentColor" />
+                        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                          Favourites
+                        </span>
+                      </div>
+                      <div className="px-1">
+                        {favourites.map(({ model }) => (
+                          <ModelItem
+                            key={`fav-${model.provider}/${model.modelId}`}
+                            model={model}
+                            isSelected={
+                              selectedProvider === model.provider &&
+                              selectedModelId === model.modelId
+                            }
+                            isFavourite
+                            onSelect={handleModelSelect}
+                          />
+                        ))}
+                      </div>
+                      <div className="mx-3 mt-1 border-t border-[var(--border-subtle)]" />
+                    </div>
+                  )}
+
+                  {/* Provider groups */}
+                  {filteredGroups.map((group, i) => (
+                    <div key={group.provider}>
+                      {(i > 0 || favourites.length > 0) && i > 0 && (
+                        <div className="mx-3 border-t border-[var(--border-subtle)]" />
+                      )}
+                      <ProviderSection
+                        group={group}
+                        selectedProvider={selectedProvider}
+                        selectedModelId={selectedModelId}
+                        favouriteKeys={favouriteKeys}
+                        onSelect={handleModelSelect}
+                      />
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+
+            {/* Thinking Level Picker — always shown, disabled when model has no reasoning */}
+            <ThinkingPicker
+              current={ms?.thinkingLevel ?? 'off'}
+              available={ms?.availableThinkingLevels ?? []}
+              supportsXhigh={ms?.supportsXhigh ?? false}
+              disabled={!ms?.model.reasoning}
+              onSelect={handleThinkingSelect}
             />
           </div>
+        </PopoverContent>
+      </Popover>
 
-          {/* Model List */}
-          <div className="max-h-[320px] overflow-y-auto py-1">
-            {groups.length === 0 ? (
-              <div className="px-3 py-4 text-center text-xs text-[var(--text-muted)]">
-                No models available. Run <code className="rounded bg-[var(--bg-muted)] px-1 font-mono">pi auth</code> to add a provider.
-              </div>
-            ) : totalFiltered === 0 ? (
-              <div className="px-3 py-4 text-center text-xs text-[var(--text-muted)]">
-                No models matching "<span className="text-[var(--text-secondary)]">{filter}</span>"
-              </div>
-            ) : (
-              filteredGroups.map((group, i) => (
-                <div key={group.provider}>
-                  {i > 0 && <div className="mx-3 border-t border-[var(--border-subtle)]" />}
-                  <ProviderSection
-                    group={group}
-                    selectedProvider={selectedProvider}
-                    selectedModelId={selectedModelId}
-                    onSelect={handleModelSelect}
-                  />
-                </div>
-              ))
-            )}
-          </div>
-
-          {/* Thinking Level Picker — always shown, disabled when model has no reasoning */}
-          <ThinkingPicker
-            current={ms?.thinkingLevel ?? 'off'}
-            available={ms?.availableThinkingLevels ?? []}
-            supportsXhigh={ms?.supportsXhigh ?? false}
-            disabled={!ms?.model.reasoning}
-            onSelect={handleThinkingSelect}
-          />
-        </div>
-      </PopoverContent>
-    </Popover>
+      <ModelManagerDialog open={managerOpen} onOpenChange={setManagerOpen} />
+    </>
   );
 }

--- a/apps/desktop/src/components/layout/ModelSelector.tsx
+++ b/apps/desktop/src/components/layout/ModelSelector.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo, useRef, useEffect, memo } from 'react';
+// Note: useEffect is retained only for the idle-callback popover priming below.
 import { ChevronDown, Check, Brain, Sparkles, Search, Settings2, Star } from 'lucide-react';
 import { motion } from 'motion/react';
 import { Popover, PopoverContent, PopoverTrigger } from '@sero/ui/components/ui/popover';
@@ -280,14 +281,7 @@ export function ModelSelector({ disabled }: { disabled: boolean }) {
     setIsPrimed(true);
   }, []);
 
-  // Reset filter & autofocus when popover opens
-  useEffect(() => {
-    if (open) {
-      setFilter('');
-      requestAnimationFrame(() => inputRef.current?.focus());
-    }
-  }, [open]);
-
+  // Idle-callback popover priming — external browser API, useEffect is appropriate
   useEffect(() => {
     if (isPrimed) return;
     let idleId: number | null = null;
@@ -321,7 +315,11 @@ export function ModelSelector({ disabled }: { disabled: boolean }) {
   );
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
-    if (nextOpen) setIsPrimed(true);
+    if (nextOpen) {
+      setIsPrimed(true);
+      setFilter('');
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
     setOpen(nextOpen);
   }, []);
 
@@ -406,7 +404,7 @@ export function ModelSelector({ disabled }: { disabled: boolean }) {
                   {/* Provider groups */}
                   {filteredGroups.map((group, i) => (
                     <div key={group.provider}>
-                      {(i > 0 || favourites.length > 0) && i > 0 && (
+                      {i > 0 && (
                         <div className="mx-3 border-t border-[var(--border-subtle)]" />
                       )}
                       <ProviderSection

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
@@ -169,14 +169,32 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
     };
   }, [groups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
 
-  // Bulk actions — "Hide all" hides every model currently visible in the
-  // list (respects search filter), "Show all" clears all hidden state.
-  const handleHideAll = useCallback(() => {
-    const keys = filteredGroups.flatMap((g) =>
+  // Bulk actions — "Hide all" skips favourited models, "Hide all incl.
+  // favourites" hides everything. Both respect the search filter.
+  const allVisibleKeys = useMemo(
+    () => filteredGroups.flatMap((g) =>
       g.models.map((m) => modelKey(m.provider, m.modelId)),
-    );
+    ),
+    [filteredGroups],
+  );
+
+  const hasFavouritesInView = useMemo(
+    () => {
+      const favSet = new Set(prefs.favouriteModels);
+      return allVisibleKeys.some((k) => favSet.has(k));
+    },
+    [allVisibleKeys, prefs.favouriteModels],
+  );
+
+  const handleHideAll = useCallback(() => {
+    const favSet = new Set(prefs.favouriteModels);
+    const keys = allVisibleKeys.filter((k) => !favSet.has(k));
     if (keys.length) hideAll(keys);
-  }, [filteredGroups, hideAll]);
+  }, [allVisibleKeys, prefs.favouriteModels, hideAll]);
+
+  const handleHideAllIncludingFavourites = useCallback(() => {
+    if (allVisibleKeys.length) hideAll(allVisibleKeys);
+  }, [allVisibleKeys, hideAll]);
 
   const handleShowAll = useCallback(() => {
     showAll();
@@ -264,7 +282,7 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
 
         {/* Bulk actions bar — context-sensitive per tab */}
         {activeTab === 'all' && displayGroups.length > 0 && (
-          <div className="flex items-center justify-end border-b border-[var(--border-subtle)] px-4 py-1.5">
+          <div className="flex items-center justify-end gap-1 border-b border-[var(--border-subtle)] px-4 py-1.5">
             <button
               onClick={handleHideAll}
               className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
@@ -274,6 +292,17 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
               <EyeOff className="size-3" />
               {filter ? 'Hide matches' : 'Hide all'}
             </button>
+            {hasFavouritesInView && (
+              <button
+                onClick={handleHideAllIncludingFavourites}
+                className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
+                  text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
+                  hover:text-[var(--text-secondary)]"
+              >
+                <EyeOff className="size-3" />
+                {filter ? 'incl. favourites' : 'Hide all incl. favourites'}
+              </button>
+            )}
           </div>
         )}
         {activeTab === 'hidden' && displayGroups.length > 0 && (

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
@@ -1,0 +1,294 @@
+/**
+ * Model Manager — full-screen dialog for managing model visibility
+ * and favourites. Opened from the ModelSelector gear icon.
+ */
+
+import { useState, useMemo, useCallback, useRef, useEffect, memo } from 'react';
+import { Search, Star, EyeOff, Layers, X } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@sero/ui/components/ui/dialog';
+import { useFocusedModelState } from '@/stores/agent-selectors';
+import { useModelPreferences, modelKey } from '@/stores/model-preferences';
+import type { AvailableModelGroup, ManagerTab } from './types';
+import { ModelManagerProvider } from './ModelManagerProvider';
+import { ModelManagerItem } from './ModelManagerItem';
+
+/** Filter groups by search query. */
+function filterManagerGroups(
+  groups: AvailableModelGroup[],
+  query: string,
+): AvailableModelGroup[] {
+  if (!query) return groups;
+  const q = query.toLowerCase();
+  const filtered: AvailableModelGroup[] = [];
+  for (const group of groups) {
+    const matches = group.models.filter(
+      (m) =>
+        m.name.toLowerCase().includes(q) ||
+        m.modelId.toLowerCase().includes(q) ||
+        group.displayName.toLowerCase().includes(q),
+    );
+    if (matches.length) filtered.push({ ...group, models: matches });
+  }
+  return filtered;
+}
+
+const TAB_CONFIG: { id: ManagerTab; label: string; icon: typeof Star }[] = [
+  { id: 'all', label: 'All Models', icon: Layers },
+  { id: 'favourites', label: 'Favourites', icon: Star },
+  { id: 'hidden', label: 'Hidden', icon: EyeOff },
+];
+
+interface ModelManagerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** Stable tab bar with animated indicator. */
+const TabBar = memo(function TabBar({
+  activeTab,
+  onTabChange,
+  counts,
+}: {
+  activeTab: ManagerTab;
+  onTabChange: (tab: ManagerTab) => void;
+  counts: Record<ManagerTab, number>;
+}) {
+  return (
+    <div className="flex gap-1 rounded-lg bg-[var(--bg-base)] p-1">
+      {TAB_CONFIG.map((tab) => {
+        const Icon = tab.icon;
+        const active = activeTab === tab.id;
+        return (
+          <button
+            key={tab.id}
+            onClick={() => onTabChange(tab.id)}
+            className={`relative flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors duration-150 ${
+              active
+                ? 'text-[var(--text-primary)]'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+            }`}
+          >
+            {active && (
+              <motion.div
+                layoutId="manager-tab-bg"
+                className="absolute inset-0 rounded-md bg-[var(--bg-elevated)]"
+                transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+              />
+            )}
+            <span className="relative z-10 flex items-center gap-1.5">
+              <Icon className="size-3.5" />
+              {tab.label}
+              {counts[tab.id] > 0 && (
+                <span className="rounded-full bg-[var(--bg-muted)] px-1.5 py-px text-[10px] font-semibold text-[var(--text-muted)]">
+                  {counts[tab.id]}
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+});
+
+export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogProps) {
+  const [activeTab, setActiveTab] = useState<ManagerTab>('all');
+  const [filter, setFilter] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const ms = useFocusedModelState();
+  const groups = ms?.availableModels ?? [];
+
+  const prefs = useModelPreferences();
+  const { toggleFavourite, toggleHidden, toggleProviderHidden } = prefs;
+
+  // Stable lookup callbacks for memoized children
+  const isFavourite = useCallback(
+    (key: string) => prefs.favouriteModels.includes(key),
+    [prefs.favouriteModels],
+  );
+  const isHidden = useCallback(
+    (key: string) => prefs.hiddenModels.includes(key),
+    [prefs.hiddenModels],
+  );
+  const isProviderHidden = useCallback(
+    (provider: string) => prefs.hiddenProviders.includes(provider),
+    [prefs.hiddenProviders],
+  );
+
+  // Filtered groups based on search
+  const filteredGroups = useMemo(
+    () => filterManagerGroups(groups, filter),
+    [groups, filter],
+  );
+
+  // Build tab-specific model lists
+  const { favouriteGroups, hiddenGroups } = useMemo(() => {
+    const favKeys = new Set(prefs.favouriteModels);
+    const hidKeys = new Set(prefs.hiddenModels);
+    const hidProviders = new Set(prefs.hiddenProviders);
+
+    const favGroups: AvailableModelGroup[] = [];
+    const hidGroups: AvailableModelGroup[] = [];
+
+    for (const group of filteredGroups) {
+      const favModels = group.models.filter(
+        (m) => favKeys.has(modelKey(m.provider, m.modelId)),
+      );
+      const hidModels = group.models.filter(
+        (m) =>
+          hidKeys.has(modelKey(m.provider, m.modelId)) ||
+          hidProviders.has(m.provider),
+      );
+      if (favModels.length) favGroups.push({ ...group, models: favModels });
+      if (hidModels.length) hidGroups.push({ ...group, models: hidModels });
+    }
+    return { favouriteGroups: favGroups, hiddenGroups: hidGroups };
+  }, [filteredGroups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
+
+  const counts: Record<ManagerTab, number> = useMemo(() => ({
+    all: groups.reduce((n, g) => n + g.models.length, 0),
+    favourites: prefs.favouriteModels.length,
+    hidden: prefs.hiddenModels.length + groups.filter(
+      (g) => prefs.hiddenProviders.includes(g.provider),
+    ).reduce((n, g) => n + g.models.length, 0),
+  }), [groups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
+
+  // Focus search on open
+  useEffect(() => {
+    if (open) {
+      setFilter('');
+      setActiveTab('all');
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  const displayGroups =
+    activeTab === 'favourites'
+      ? favouriteGroups
+      : activeTab === 'hidden'
+        ? hiddenGroups
+        : filteredGroups;
+
+  const emptyMessage =
+    activeTab === 'favourites'
+      ? 'No favourite models yet. Click the star icon to add favourites.'
+      : activeTab === 'hidden'
+        ? 'No hidden models. Click the eye icon to hide models from the selector.'
+        : filter
+          ? `No models matching "${filter}"`
+          : 'No models available.';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="!max-w-[520px] !rounded-2xl border-[var(--border-subtle)] !bg-[var(--bg-surface)]
+          !p-0 shadow-2xl shadow-black/50 sm:!max-w-[520px]"
+      >
+        <DialogTitle className="sr-only">Model Manager</DialogTitle>
+
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-[var(--border-subtle)] px-4 pt-4 pb-3">
+          <div>
+            <h2 className="text-sm font-semibold text-[var(--text-primary)]">
+              Model Manager
+            </h2>
+            <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+              Manage favourites and visibility for {counts.all} models
+            </p>
+          </div>
+          <button
+            onClick={() => onOpenChange(false)}
+            className="rounded-lg p-1.5 text-[var(--text-muted)] transition-colors
+              hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {/* Tabs + Search */}
+        <div className="flex flex-col gap-3 border-b border-[var(--border-subtle)] px-4 py-3">
+          <TabBar activeTab={activeTab} onTabChange={setActiveTab} counts={counts} />
+          <div className="flex items-center gap-2 rounded-lg bg-[var(--bg-base)] px-3">
+            <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+            <input
+              ref={inputRef}
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Search models, providers…"
+              className="h-8 w-full bg-transparent text-xs text-[var(--text-primary)]
+                placeholder:text-[var(--text-muted)] outline-none"
+            />
+            {filter && (
+              <button
+                onClick={() => setFilter('')}
+                className="rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+              >
+                <X className="size-3" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Model list */}
+        <div className="max-h-[400px] min-h-[200px] overflow-y-auto px-2 py-1">
+          <AnimatePresence mode="popLayout">
+            {displayGroups.length === 0 ? (
+              <motion.div
+                key="empty"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="flex items-center justify-center px-4 py-10 text-center text-xs text-[var(--text-muted)]"
+              >
+                {emptyMessage}
+              </motion.div>
+            ) : activeTab === 'favourites' ? (
+              // Flat list for favourites tab — no provider grouping
+              favouriteGroups.flatMap((group) =>
+                group.models.map((model) => {
+                  const key = modelKey(model.provider, model.modelId);
+                  return (
+                    <ModelManagerItem
+                      key={key}
+                      model={model}
+                      providerLogo={group.logo}
+                      providerName={group.displayName}
+                      isFavourite={isFavourite(key)}
+                      isHidden={isHidden(key)}
+                      onToggleFavourite={toggleFavourite}
+                      onToggleHidden={toggleHidden}
+                    />
+                  );
+                }),
+              )
+            ) : (
+              displayGroups.map((group, i) => (
+                <div key={group.provider}>
+                  {i > 0 && (
+                    <div className="mx-3 my-1 border-t border-[var(--border-subtle)]" />
+                  )}
+                  <ModelManagerProvider
+                    group={group}
+                    isProviderHidden={isProviderHidden(group.provider)}
+                    isFavourite={isFavourite}
+                    isHidden={isHidden}
+                    onToggleFavourite={toggleFavourite}
+                    onToggleHidden={toggleHidden}
+                    onToggleProvider={toggleProviderHidden}
+                  />
+                </div>
+              ))
+            )}
+          </AnimatePresence>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
@@ -344,7 +344,8 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
                       providerLogo={group.logo}
                       providerName={group.displayName}
                       isFavourite={isFavourite(key)}
-                      isHidden={isHidden(key)}
+                      isHidden={isProviderHidden(group.provider) || isHidden(key)}
+                      isHiddenByProvider={isProviderHidden(group.provider)}
                       onToggleFavourite={toggleFavourite}
                       onToggleHidden={toggleHidden}
                     />

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useMemo, useCallback, useRef, memo } from 'react';
-import { Search, Star, EyeOff, Layers, X } from 'lucide-react';
+import { Search, Star, Eye, EyeOff, Layers, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
   Dialog,
@@ -105,7 +105,7 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
   const groups = ms?.availableModels ?? [];
 
   const prefs = useModelPreferences();
-  const { toggleFavourite, toggleHidden, toggleProviderHidden } = prefs;
+  const { toggleFavourite, toggleHidden, toggleProviderHidden, hideAll, showAll } = prefs;
 
   // Stable lookup callbacks for memoized children
   const isFavourite = useCallback(
@@ -168,6 +168,19 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
       hidden: hiddenSet.size,
     };
   }, [groups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
+
+  // Bulk actions — "Hide all" hides every model currently visible in the
+  // list (respects search filter), "Show all" clears all hidden state.
+  const handleHideAll = useCallback(() => {
+    const keys = filteredGroups.flatMap((g) =>
+      g.models.map((m) => modelKey(m.provider, m.modelId)),
+    );
+    if (keys.length) hideAll(keys);
+  }, [filteredGroups, hideAll]);
+
+  const handleShowAll = useCallback(() => {
+    showAll();
+  }, [showAll]);
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -248,6 +261,34 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
             )}
           </div>
         </div>
+
+        {/* Bulk actions bar — context-sensitive per tab */}
+        {activeTab === 'all' && displayGroups.length > 0 && (
+          <div className="flex items-center justify-end border-b border-[var(--border-subtle)] px-4 py-1.5">
+            <button
+              onClick={handleHideAll}
+              className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
+                text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
+                hover:text-[var(--text-secondary)]"
+            >
+              <EyeOff className="size-3" />
+              {filter ? 'Hide matches' : 'Hide all'}
+            </button>
+          </div>
+        )}
+        {activeTab === 'hidden' && displayGroups.length > 0 && (
+          <div className="flex items-center justify-end border-b border-[var(--border-subtle)] px-4 py-1.5">
+            <button
+              onClick={handleShowAll}
+              className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
+                text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
+                hover:text-[var(--text-secondary)]"
+            >
+              <Eye className="size-3" />
+              Show all
+            </button>
+          </div>
+        )}
 
         {/* Model list */}
         <div className="max-h-[400px] min-h-[200px] overflow-y-auto px-2 py-1">

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
@@ -3,7 +3,7 @@
  * and favourites. Opened from the ModelSelector gear icon.
  */
 
-import { useState, useMemo, useCallback, useRef, useEffect, memo } from 'react';
+import { useState, useMemo, useCallback, useRef, memo } from 'react';
 import { Search, Star, EyeOff, Layers, X } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
@@ -151,22 +151,35 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
     return { favouriteGroups: favGroups, hiddenGroups: hidGroups };
   }, [filteredGroups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
 
-  const counts: Record<ManagerTab, number> = useMemo(() => ({
-    all: groups.reduce((n, g) => n + g.models.length, 0),
-    favourites: prefs.favouriteModels.length,
-    hidden: prefs.hiddenModels.length + groups.filter(
-      (g) => prefs.hiddenProviders.includes(g.provider),
-    ).reduce((n, g) => n + g.models.length, 0),
-  }), [groups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
-
-  // Focus search on open
-  useEffect(() => {
-    if (open) {
-      setFilter('');
-      setActiveTab('all');
-      requestAnimationFrame(() => inputRef.current?.focus());
+  const counts: Record<ManagerTab, number> = useMemo(() => {
+    // Deduplicate: a model individually hidden whose provider is also hidden
+    // should only be counted once.
+    const hiddenSet = new Set(prefs.hiddenModels);
+    for (const group of groups) {
+      if (prefs.hiddenProviders.includes(group.provider)) {
+        for (const m of group.models) {
+          hiddenSet.add(modelKey(m.provider, m.modelId));
+        }
+      }
     }
-  }, [open]);
+    return {
+      all: groups.reduce((n, g) => n + g.models.length, 0),
+      favourites: prefs.favouriteModels.length,
+      hidden: hiddenSet.size,
+    };
+  }, [groups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        setFilter('');
+        setActiveTab('all');
+        requestAnimationFrame(() => inputRef.current?.focus());
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange],
+  );
 
   const displayGroups =
     activeTab === 'favourites'
@@ -185,7 +198,7 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
           : 'No models available.';
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         showCloseButton={false}
         className="!max-w-[520px] !rounded-2xl border-[var(--border-subtle)] !bg-[var(--bg-surface)]

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerItem.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerItem.tsx
@@ -1,0 +1,104 @@
+/**
+ * Individual model row in the Model Manager.
+ * Shows model name, provider, favourite star, and visibility toggle.
+ */
+
+import { memo, useCallback } from 'react';
+import { Star, Eye, EyeOff, Sparkles } from 'lucide-react';
+import { motion } from 'motion/react';
+import type { ModelInfo } from './types';
+
+interface ModelManagerItemProps {
+  model: ModelInfo;
+  providerLogo: string;
+  providerName: string;
+  isFavourite: boolean;
+  isHidden: boolean;
+  onToggleFavourite: (key: string) => void;
+  onToggleHidden: (key: string) => void;
+}
+
+const ModelManagerItem = memo(function ModelManagerItem({
+  model,
+  providerLogo,
+  providerName,
+  isFavourite,
+  isHidden,
+  onToggleFavourite,
+  onToggleHidden,
+}: ModelManagerItemProps) {
+  const key = `${model.provider}/${model.modelId}`;
+
+  const handleFavourite = useCallback(() => onToggleFavourite(key), [key, onToggleFavourite]);
+  const handleHidden = useCallback(() => onToggleHidden(key), [key, onToggleHidden]);
+
+  return (
+    <motion.div
+      layout="position"
+      layoutId={key}
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: isHidden ? 0.5 : 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={{ duration: 0.15, ease: 'easeOut' }}
+      className="group flex items-center gap-3 rounded-lg px-3 py-2 transition-colors duration-100
+        hover:bg-[var(--bg-elevated)]/60"
+      style={{ contain: 'layout style' }}
+    >
+      {/* Provider logo + model name */}
+      <img
+        src={providerLogo}
+        alt={providerName}
+        className="size-4 shrink-0 rounded-sm dark:invert"
+      />
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className={`truncate text-xs font-medium ${
+          isHidden ? 'text-[var(--text-muted)]' : 'text-[var(--text-primary)]'
+        }`}>
+          {model.name}
+        </span>
+        {model.reasoning && (
+          <Sparkles className="size-3 shrink-0 text-[var(--status-warning)]/60" />
+        )}
+        <span className="hidden truncate text-[10px] text-[var(--text-muted)] group-hover:inline">
+          {providerName}
+        </span>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center gap-1">
+        <button
+          onClick={handleFavourite}
+          title={isFavourite ? 'Remove from favourites' : 'Add to favourites'}
+          className={`rounded-md p-1 transition-all duration-150 ${
+            isFavourite
+              ? 'text-amber-400 hover:text-amber-300'
+              : 'text-[var(--text-muted)] opacity-0 group-hover:opacity-100 hover:text-amber-400'
+          }`}
+        >
+          <Star
+            className="size-3.5"
+            fill={isFavourite ? 'currentColor' : 'none'}
+          />
+        </button>
+
+        <button
+          onClick={handleHidden}
+          title={isHidden ? 'Show in selector' : 'Hide from selector'}
+          className={`rounded-md p-1 transition-all duration-150 ${
+            isHidden
+              ? 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+              : 'text-[var(--text-muted)] opacity-0 group-hover:opacity-100 hover:text-[var(--text-secondary)]'
+          }`}
+        >
+          {isHidden ? (
+            <EyeOff className="size-3.5" />
+          ) : (
+            <Eye className="size-3.5" />
+          )}
+        </button>
+      </div>
+    </motion.div>
+  );
+});
+
+export { ModelManagerItem };

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerItem.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerItem.tsx
@@ -6,6 +6,7 @@
 import { memo, useCallback } from 'react';
 import { Star, Eye, EyeOff, Sparkles } from 'lucide-react';
 import { motion } from 'motion/react';
+import { modelKey } from '@/stores/model-preferences';
 import type { ModelInfo } from './types';
 
 interface ModelManagerItemProps {
@@ -27,7 +28,7 @@ const ModelManagerItem = memo(function ModelManagerItem({
   onToggleFavourite,
   onToggleHidden,
 }: ModelManagerItemProps) {
-  const key = `${model.provider}/${model.modelId}`;
+  const key = modelKey(model.provider, model.modelId);
 
   const handleFavourite = useCallback(() => onToggleFavourite(key), [key, onToggleFavourite]);
   const handleHidden = useCallback(() => onToggleHidden(key), [key, onToggleHidden]);

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerItem.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerItem.tsx
@@ -15,6 +15,7 @@ interface ModelManagerItemProps {
   providerName: string;
   isFavourite: boolean;
   isHidden: boolean;
+  isHiddenByProvider: boolean;
   onToggleFavourite: (key: string) => void;
   onToggleHidden: (key: string) => void;
 }
@@ -25,13 +26,23 @@ const ModelManagerItem = memo(function ModelManagerItem({
   providerName,
   isFavourite,
   isHidden,
+  isHiddenByProvider,
   onToggleFavourite,
   onToggleHidden,
 }: ModelManagerItemProps) {
   const key = modelKey(model.provider, model.modelId);
+  const hideActionDisabled = isHiddenByProvider;
+  const hideActionTitle = hideActionDisabled
+    ? 'Hidden by provider — use the provider toggle to show these models'
+    : isHidden
+      ? 'Show in selector'
+      : 'Hide from selector';
 
   const handleFavourite = useCallback(() => onToggleFavourite(key), [key, onToggleFavourite]);
-  const handleHidden = useCallback(() => onToggleHidden(key), [key, onToggleHidden]);
+  const handleHidden = useCallback(() => {
+    if (hideActionDisabled) return;
+    onToggleHidden(key);
+  }, [hideActionDisabled, key, onToggleHidden]);
 
   return (
     <motion.div
@@ -84,11 +95,14 @@ const ModelManagerItem = memo(function ModelManagerItem({
 
         <button
           onClick={handleHidden}
-          title={isHidden ? 'Show in selector' : 'Hide from selector'}
+          disabled={hideActionDisabled}
+          title={hideActionTitle}
           className={`rounded-md p-1 transition-all duration-150 ${
-            isHidden
-              ? 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-              : 'text-[var(--text-muted)] opacity-0 group-hover:opacity-100 hover:text-[var(--text-secondary)]'
+            hideActionDisabled
+              ? 'cursor-not-allowed text-[var(--text-muted)] opacity-60'
+              : isHidden
+                ? 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+                : 'text-[var(--text-muted)] opacity-0 group-hover:opacity-100 hover:text-[var(--text-secondary)]'
           }`}
         >
           {isHidden ? (

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerProvider.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerProvider.tsx
@@ -1,0 +1,118 @@
+/**
+ * Provider section in the Model Manager — collapsible group with
+ * a visibility toggle for the entire provider.
+ */
+
+import { memo, useState, useCallback } from 'react';
+import { ChevronRight, EyeOff } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import type { ModelInfo, AvailableModelGroup } from './types';
+import { ModelManagerItem } from './ModelManagerItem';
+
+interface ModelManagerProviderProps {
+  group: AvailableModelGroup;
+  isProviderHidden: boolean;
+  isFavourite: (key: string) => boolean;
+  isHidden: (key: string) => boolean;
+  onToggleFavourite: (key: string) => void;
+  onToggleHidden: (key: string) => void;
+  onToggleProvider: (provider: string) => void;
+  /** If set, only show these models (for search filtering). */
+  visibleModels?: ModelInfo[];
+}
+
+const ModelManagerProvider = memo(function ModelManagerProvider({
+  group,
+  isProviderHidden,
+  isFavourite,
+  isHidden,
+  onToggleFavourite,
+  onToggleHidden,
+  onToggleProvider,
+  visibleModels,
+}: ModelManagerProviderProps) {
+  const [expanded, setExpanded] = useState(true);
+  const models = visibleModels ?? group.models;
+
+  const handleToggleProvider = useCallback(
+    () => onToggleProvider(group.provider),
+    [group.provider, onToggleProvider],
+  );
+
+  return (
+    <div className="py-0.5">
+      {/* Provider header */}
+      <div className="flex items-center gap-2 px-3 py-1.5">
+        <button
+          onClick={() => setExpanded((p) => !p)}
+          className="flex flex-1 items-center gap-2 text-left"
+        >
+          <motion.div
+            animate={{ rotate: expanded ? 90 : 0 }}
+            transition={{ duration: 0.15 }}
+          >
+            <ChevronRight className="size-3 text-[var(--text-muted)]" />
+          </motion.div>
+          <img
+            src={group.logo}
+            alt={group.displayName}
+            className="size-3.5 rounded-sm dark:invert"
+          />
+          <span className={`text-[11px] font-semibold uppercase tracking-wider ${
+            isProviderHidden ? 'text-[var(--text-muted)]' : 'text-[var(--text-secondary)]'
+          }`}>
+            {group.displayName}
+          </span>
+          <span className="text-[10px] text-[var(--text-muted)]">
+            {models.length}
+          </span>
+        </button>
+
+        {/* Provider-wide visibility toggle */}
+        <button
+          onClick={handleToggleProvider}
+          title={isProviderHidden ? 'Show provider' : 'Hide entire provider'}
+          className={`rounded-md p-1 transition-colors duration-150 ${
+            isProviderHidden
+              ? 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+              : 'text-[var(--text-muted)] opacity-0 hover:text-[var(--text-secondary)] group-hover:opacity-100'
+          }`}
+          style={{ opacity: isProviderHidden ? 1 : undefined }}
+        >
+          <EyeOff className="size-3" />
+        </button>
+      </div>
+
+      {/* Model list (collapsible) */}
+      <AnimatePresence initial={false}>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="overflow-hidden pl-2"
+          >
+            {models.map((model) => {
+              const key = `${model.provider}/${model.modelId}`;
+              return (
+                <ModelManagerItem
+                  key={key}
+                  model={model}
+                  providerLogo={group.logo}
+                  providerName={group.displayName}
+                  isFavourite={isFavourite(key)}
+                  isHidden={isProviderHidden || isHidden(key)}
+                  onToggleFavourite={onToggleFavourite}
+                  onToggleHidden={onToggleHidden}
+                />
+              );
+            })}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+});
+
+export { ModelManagerProvider };

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerProvider.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerProvider.tsx
@@ -6,7 +6,8 @@
 import { memo, useState, useCallback } from 'react';
 import { ChevronRight, EyeOff } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
-import type { ModelInfo, AvailableModelGroup } from './types';
+import { modelKey } from '@/stores/model-preferences';
+import type { AvailableModelGroup } from './types';
 import { ModelManagerItem } from './ModelManagerItem';
 
 interface ModelManagerProviderProps {
@@ -17,8 +18,6 @@ interface ModelManagerProviderProps {
   onToggleFavourite: (key: string) => void;
   onToggleHidden: (key: string) => void;
   onToggleProvider: (provider: string) => void;
-  /** If set, only show these models (for search filtering). */
-  visibleModels?: ModelInfo[];
 }
 
 const ModelManagerProvider = memo(function ModelManagerProvider({
@@ -29,10 +28,9 @@ const ModelManagerProvider = memo(function ModelManagerProvider({
   onToggleFavourite,
   onToggleHidden,
   onToggleProvider,
-  visibleModels,
 }: ModelManagerProviderProps) {
   const [expanded, setExpanded] = useState(true);
-  const models = visibleModels ?? group.models;
+  const models = group.models;
 
   const handleToggleProvider = useCallback(
     () => onToggleProvider(group.provider),
@@ -40,7 +38,7 @@ const ModelManagerProvider = memo(function ModelManagerProvider({
   );
 
   return (
-    <div className="py-0.5">
+    <div className="group/provider py-0.5">
       {/* Provider header */}
       <div className="flex items-center gap-2 px-3 py-1.5">
         <button
@@ -75,9 +73,8 @@ const ModelManagerProvider = memo(function ModelManagerProvider({
           className={`rounded-md p-1 transition-colors duration-150 ${
             isProviderHidden
               ? 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-              : 'text-[var(--text-muted)] opacity-0 hover:text-[var(--text-secondary)] group-hover:opacity-100'
+              : 'text-[var(--text-muted)] opacity-0 hover:text-[var(--text-secondary)] group-hover/provider:opacity-100'
           }`}
-          style={{ opacity: isProviderHidden ? 1 : undefined }}
         >
           <EyeOff className="size-3" />
         </button>
@@ -94,7 +91,7 @@ const ModelManagerProvider = memo(function ModelManagerProvider({
             className="overflow-hidden pl-2"
           >
             {models.map((model) => {
-              const key = `${model.provider}/${model.modelId}`;
+              const key = modelKey(model.provider, model.modelId);
               return (
                 <ModelManagerItem
                   key={key}

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerProvider.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerProvider.tsx
@@ -92,6 +92,7 @@ const ModelManagerProvider = memo(function ModelManagerProvider({
           >
             {models.map((model) => {
               const key = modelKey(model.provider, model.modelId);
+              const isModelHidden = isHidden(key);
               return (
                 <ModelManagerItem
                   key={key}
@@ -99,7 +100,8 @@ const ModelManagerProvider = memo(function ModelManagerProvider({
                   providerLogo={group.logo}
                   providerName={group.displayName}
                   isFavourite={isFavourite(key)}
-                  isHidden={isProviderHidden || isHidden(key)}
+                  isHidden={isProviderHidden || isModelHidden}
+                  isHiddenByProvider={isProviderHidden}
                   onToggleFavourite={onToggleFavourite}
                   onToggleHidden={onToggleHidden}
                 />

--- a/apps/desktop/src/components/layout/model-manager/index.ts
+++ b/apps/desktop/src/components/layout/model-manager/index.ts
@@ -1,0 +1,1 @@
+export { ModelManagerDialog } from './ModelManagerDialog';

--- a/apps/desktop/src/components/layout/model-manager/types.ts
+++ b/apps/desktop/src/components/layout/model-manager/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Types for the model manager dialog.
+ */
+
+import type { ModelInfo, AvailableModelGroup } from '@/types/ipc';
+
+export type { ModelInfo, AvailableModelGroup };
+
+export type ManagerTab = 'all' | 'favourites' | 'hidden';

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -20,6 +20,7 @@ import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useSessionStore } from '@/stores/sessions';
+import { useModelPreferences } from '@/stores/model-preferences';
 
 // Re-export the canonical type so callers don't need a second import.
 export type { LayoutState };
@@ -44,6 +45,9 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
     activeSessionId: partial.activeSessionId !== undefined
       ? partial.activeSessionId
       : sess.activeSessionId,
+    favouriteModels: partial.favouriteModels ?? useModelPreferences.getState().favouriteModels,
+    hiddenModels: partial.hiddenModels ?? useModelPreferences.getState().hiddenModels,
+    hiddenProviders: partial.hiddenProviders ?? useModelPreferences.getState().hiddenProviders,
   };
 }
 

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -5,6 +5,7 @@ import { preloadFederatedModule } from '@/lib/federation-registry';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useSessionStore } from '@/stores/sessions';
 import { useThemeStore, hydrateThemeStore } from '@/stores/theme';
+import { useModelPreferences } from '@/stores/model-preferences';
 
 // ── Built-in apps (always present) ────────────────────────────
 
@@ -287,6 +288,12 @@ export async function loadLayout(): Promise<void> {
       if (state.activeSessionId !== undefined) {
         useSessionStore.setState({ activeSessionId: state.activeSessionId ?? null });
       }
+      // Hydrate model preferences
+      useModelPreferences.getState().hydrate({
+        favouriteModels: state.favouriteModels,
+        hiddenModels: state.hiddenModels,
+        hiddenProviders: state.hiddenProviders,
+      });
       return;
     }
   } catch (err) {

--- a/apps/desktop/src/stores/model-preferences.ts
+++ b/apps/desktop/src/stores/model-preferences.ts
@@ -24,11 +24,8 @@ interface ModelPreferencesState {
   hiddenProviders: string[];
 
   toggleFavourite: (key: ModelKey) => void;
-  isFavourite: (key: ModelKey) => boolean;
   toggleHidden: (key: ModelKey) => void;
-  isHidden: (key: ModelKey) => boolean;
   toggleProviderHidden: (provider: string) => void;
-  isProviderHidden: (provider: string) => boolean;
 
   /** Bulk-set from loaded layout state. */
   hydrate: (data: {
@@ -57,10 +54,8 @@ export const useModelPreferences = create<ModelPreferencesState>((set, get) => (
       ? current.filter((k) => k !== key)
       : [...current, key];
     set({ favouriteModels: next });
-    persistModelPrefs({ ...get(), favouriteModels: next });
+    persistModelPrefs(get());
   },
-
-  isFavourite: (key) => get().favouriteModels.includes(key),
 
   toggleHidden: (key) => {
     const current = get().hiddenModels;
@@ -72,10 +67,8 @@ export const useModelPreferences = create<ModelPreferencesState>((set, get) => (
       ? get().favouriteModels.filter((k) => k !== key)
       : get().favouriteModels;
     set({ hiddenModels: next, favouriteModels: favs });
-    persistModelPrefs({ ...get(), hiddenModels: next, favouriteModels: favs });
+    persistModelPrefs(get());
   },
-
-  isHidden: (key) => get().hiddenModels.includes(key),
 
   toggleProviderHidden: (provider) => {
     const current = get().hiddenProviders;
@@ -83,10 +76,8 @@ export const useModelPreferences = create<ModelPreferencesState>((set, get) => (
       ? current.filter((p) => p !== provider)
       : [...current, provider];
     set({ hiddenProviders: next });
-    persistModelPrefs({ ...get(), hiddenProviders: next });
+    persistModelPrefs(get());
   },
-
-  isProviderHidden: (provider) => get().hiddenProviders.includes(provider),
 
   hydrate: (data) => {
     set({

--- a/apps/desktop/src/stores/model-preferences.ts
+++ b/apps/desktop/src/stores/model-preferences.ts
@@ -1,0 +1,98 @@
+/**
+ * Model preferences store — manages favourite and hidden models.
+ *
+ * Preferences are keyed by `provider/modelId` strings. Persisted to
+ * ~/.sero-ui/layout.json via the shared `persistLayout` helper.
+ */
+
+import { create } from 'zustand';
+import { persistLayout } from '@/lib/persist-layout';
+
+/** Canonical key for a model: "provider/modelId". */
+export type ModelKey = string;
+
+export function modelKey(provider: string, modelId: string): ModelKey {
+  return `${provider}/${modelId}`;
+}
+
+interface ModelPreferencesState {
+  /** Models pinned to the top of the selector. */
+  favouriteModels: ModelKey[];
+  /** Models hidden from the selector list. */
+  hiddenModels: ModelKey[];
+  /** Provider IDs that are entirely hidden from the selector. */
+  hiddenProviders: string[];
+
+  toggleFavourite: (key: ModelKey) => void;
+  isFavourite: (key: ModelKey) => boolean;
+  toggleHidden: (key: ModelKey) => void;
+  isHidden: (key: ModelKey) => boolean;
+  toggleProviderHidden: (provider: string) => void;
+  isProviderHidden: (provider: string) => boolean;
+
+  /** Bulk-set from loaded layout state. */
+  hydrate: (data: {
+    favouriteModels?: ModelKey[];
+    hiddenModels?: ModelKey[];
+    hiddenProviders?: string[];
+  }) => void;
+}
+
+function persistModelPrefs(state: Pick<ModelPreferencesState, 'favouriteModels' | 'hiddenModels' | 'hiddenProviders'>) {
+  persistLayout({
+    favouriteModels: state.favouriteModels,
+    hiddenModels: state.hiddenModels,
+    hiddenProviders: state.hiddenProviders,
+  });
+}
+
+export const useModelPreferences = create<ModelPreferencesState>((set, get) => ({
+  favouriteModels: [],
+  hiddenModels: [],
+  hiddenProviders: [],
+
+  toggleFavourite: (key) => {
+    const current = get().favouriteModels;
+    const next = current.includes(key)
+      ? current.filter((k) => k !== key)
+      : [...current, key];
+    set({ favouriteModels: next });
+    persistModelPrefs({ ...get(), favouriteModels: next });
+  },
+
+  isFavourite: (key) => get().favouriteModels.includes(key),
+
+  toggleHidden: (key) => {
+    const current = get().hiddenModels;
+    const next = current.includes(key)
+      ? current.filter((k) => k !== key)
+      : [...current, key];
+    // Also remove from favourites if hiding
+    const favs = next.includes(key)
+      ? get().favouriteModels.filter((k) => k !== key)
+      : get().favouriteModels;
+    set({ hiddenModels: next, favouriteModels: favs });
+    persistModelPrefs({ ...get(), hiddenModels: next, favouriteModels: favs });
+  },
+
+  isHidden: (key) => get().hiddenModels.includes(key),
+
+  toggleProviderHidden: (provider) => {
+    const current = get().hiddenProviders;
+    const next = current.includes(provider)
+      ? current.filter((p) => p !== provider)
+      : [...current, provider];
+    set({ hiddenProviders: next });
+    persistModelPrefs({ ...get(), hiddenProviders: next });
+  },
+
+  isProviderHidden: (provider) => get().hiddenProviders.includes(provider),
+
+  hydrate: (data) => {
+    set({
+      favouriteModels: data.favouriteModels ?? [],
+      hiddenModels: data.hiddenModels ?? [],
+      hiddenProviders: data.hiddenProviders ?? [],
+    });
+  },
+}));

--- a/apps/desktop/src/stores/model-preferences.ts
+++ b/apps/desktop/src/stores/model-preferences.ts
@@ -27,6 +27,11 @@ interface ModelPreferencesState {
   toggleHidden: (key: ModelKey) => void;
   toggleProviderHidden: (provider: string) => void;
 
+  /** Hide multiple models at once. Also removes them from favourites. */
+  hideAll: (keys: ModelKey[]) => void;
+  /** Unhide everything — clears both hiddenModels and hiddenProviders. */
+  showAll: () => void;
+
   /** Bulk-set from loaded layout state. */
   hydrate: (data: {
     favouriteModels?: ModelKey[];
@@ -76,6 +81,21 @@ export const useModelPreferences = create<ModelPreferencesState>((set, get) => (
       ? current.filter((p) => p !== provider)
       : [...current, provider];
     set({ hiddenProviders: next });
+    persistModelPrefs(get());
+  },
+
+  hideAll: (keys) => {
+    const hidSet = new Set(get().hiddenModels);
+    for (const k of keys) hidSet.add(k);
+    const hiddenModels = [...hidSet];
+    // Remove newly hidden models from favourites
+    const favs = get().favouriteModels.filter((k) => !hidSet.has(k));
+    set({ hiddenModels, favouriteModels: favs });
+    persistModelPrefs(get());
+  },
+
+  showAll: () => {
+    set({ hiddenModels: [], hiddenProviders: [] });
     persistModelPrefs(get());
   },
 

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -24,6 +24,12 @@ export interface LayoutState {
   activeApp?: string;
   /** Last active session ID. */
   activeSessionId?: string | null;
+  /** Favourite model keys ("provider/modelId"). */
+  favouriteModels?: string[];
+  /** Hidden model keys ("provider/modelId"). */
+  hiddenModels?: string[];
+  /** Provider IDs entirely hidden from the model selector. */
+  hiddenProviders?: string[];
 }
 
 /**


### PR DESCRIPTION
Introduces a dedicated Model Manager dialog accessible via a gear icon
in the ModelSelector. Users can star favourite models (shown at the top
of the selector), hide individual models or entire providers, and search
across all available models. Preferences persist to layout.json.

https://claude.ai/code/session_019YAFF4QC6BQSSzZt19psXC