### PR TITLE
feat(cron): recover missed jobs and reminders on scheduler start

### DIFF
--- a/packages/pi-cron-extension/extension/actions.ts
+++ b/packages/pi-cron-extension/extension/actions.ts
@@ -29,6 +29,7 @@ interface ActionParams {
   prompt?: string;
   channel?: string;
   model?: string;
+  run_if_missed?: boolean;
 }
 
 // ── List ────────────────────────────────────────────────────────
@@ -49,7 +50,8 @@ export function handleList(deps: ActionDeps): string {
         : '✅ active';
     const ch = j.channel !== 'cron' ? ` [${j.channel}]` : '';
     const mdl = j.model ? ` (${j.model})` : '';
-    return `- **${j.name}** \`${j.schedule}\` ${status}${ch}${mdl}\n  ${j.prompt.slice(0, 80)}`;
+    const recover = j.runIfMissed ? ' 🔄recover' : '';
+    return `- **${j.name}** \`${j.schedule}\` ${status}${ch}${mdl}${recover}\n  ${j.prompt.slice(0, 80)}`;
   });
 
   const note = scheduler?.isRunning()
@@ -85,6 +87,7 @@ export async function handleAdd(
     disabled: false,
   };
   if (params.model) newJob.model = params.model;
+  if (params.run_if_missed) newJob.runIfMissed = true;
 
   state.jobs.push(newJob);
   await writeState(statePath, state);
@@ -114,6 +117,7 @@ export async function handleUpdate(
   if (params.prompt) job.prompt = params.prompt;
   if (params.channel) job.channel = params.channel;
   if (params.model !== undefined) job.model = params.model || undefined;
+  if (params.run_if_missed !== undefined) job.runIfMissed = params.run_if_missed;
 
   await writeState(statePath, state);
   scheduler?.updateJobs(state.jobs);

--- a/packages/pi-cron-extension/extension/index.ts
+++ b/packages/pi-cron-extension/extension/index.ts
@@ -18,7 +18,7 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Text } from '@mariozechner/pi-tui';
 import { Type } from '@sinclair/typebox';
 
-import type { CronRunResult, CronState, Reminder } from '../shared/types';
+import type { CronRunResult, CronState, NotificationSettings, Reminder } from '../shared/types';
 import { MAX_RUN_RESULTS } from '../shared/types';
 import { resolveStatePath, withStateLock, readState, writeState } from './state-io';
 import { CronScheduler } from './scheduler';
@@ -34,6 +34,7 @@ import {
   handleReminderRemove, handleReminderSnooze, handleReminderComplete,
   handleReminderToggle, type ReminderActionDeps,
 } from './reminder-actions';
+import { detectMissedItems } from './recovery';
 
 // ── Module-level singleton state ───────────────────────────────
 // Shared across all invocations of the default export (multiple sessions).
@@ -66,6 +67,45 @@ function createAndStartScheduler(state: CronState): void {
     state.reminders,
     getSchedulerStartOpts(state),
   );
+  // Run missed-job/reminder recovery after scheduler starts
+  runRecovery(state).catch((err) => {
+    console.error('[cron] recovery failed:', err);
+  });
+}
+
+// ── Recovery (missed jobs/reminders on start) ───────────────────
+
+async function runRecovery(state: CronState): Promise<void> {
+  const { missedJobs, missedReminders } = detectMissedItems(state);
+
+  // Fire missed reminders as notifications
+  if (missedReminders.length > 0) {
+    const notifSettings = state.notificationSettings ?? undefined;
+    for (const { reminder, missedAt } of missedReminders) {
+      notifyMissedReminder(reminder, missedAt, notifSettings);
+    }
+  }
+
+  // Run missed cron jobs (fire-and-forget, same as runNow)
+  if (missedJobs.length > 0 && scheduler) {
+    for (const job of missedJobs) {
+      info('recovery:run-job', { job: job.name });
+      scheduler.runNow(job.name);
+    }
+  }
+}
+
+function notifyMissedReminder(
+  reminder: Reminder,
+  missedAt: Date,
+  settings?: NotificationSettings,
+): void {
+  const time = missedAt.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+  const body = reminder.notes
+    ? `(Missed at ${time}) ${reminder.title}\n${reminder.notes}`
+    : `(Missed at ${time}) ${reminder.title}`;
+  notifyReminder({ ...reminder, notes: body }, settings);
+  info('recovery:notify-reminder', { id: reminder.id, title: reminder.title, missedAt: missedAt.toISOString() });
 }
 
 // ── Scheduler helpers (module-level, use singleton state) ──────
@@ -182,6 +222,7 @@ async function stopScheduler(): Promise<string> {
   stateWatcher = null;
   const state = await readState(statePath);
   state.lastTickMinute = scheduler.getLastTickMinute();
+  state.lastSchedulerShutdown = new Date().toISOString();
   state.schedulerActive = false;
   scheduler.stop();
   scheduler = null;
@@ -200,6 +241,9 @@ const CronParams = Type.Object({
   prompt: Type.Optional(Type.String({ description: 'Prompt to send to the agent when the job fires' })),
   channel: Type.Optional(Type.String({ description: 'Channel tag for grouping (default: "cron")' })),
   model: Type.Optional(Type.String({ description: 'Model pattern or ID. Omit for default.' })),
+  run_if_missed: Type.Optional(Type.Boolean({
+    description: 'If true, run this job once on startup if it was missed since midnight today. Default: false.',
+  })),
 });
 
 const ReminderParams = Type.Object({
@@ -214,6 +258,9 @@ const ReminderParams = Type.Object({
   })),
   schedule: Type.Optional(Type.String({ description: 'Cron expression for recurring reminders' })),
   snooze_minutes: Type.Optional(Type.Number({ description: 'Snooze duration in minutes (default: 15). -1 for tomorrow 9am.' })),
+  recover_if_missed: Type.Optional(Type.Boolean({
+    description: 'If true, show a notification on startup for reminders missed while Sero was closed. Default: false.',
+  })),
 });
 
 // ── Extension factory (called per session) ─────────────────────
@@ -279,6 +326,7 @@ export default function (pi: ExtensionAPI) {
         if (statePath) {
           const state = await readState(statePath);
           state.lastTickMinute = scheduler.getLastTickMinute();
+          state.lastSchedulerShutdown = new Date().toISOString();
           await writeState(statePath, state);
         }
         scheduler.stop();

--- a/packages/pi-cron-extension/extension/recovery.ts
+++ b/packages/pi-cron-extension/extension/recovery.ts
@@ -1,0 +1,189 @@
+/**
+ * Missed job/reminder recovery on scheduler start.
+ *
+ * When Sero wasn't running, cron jobs and reminders can be missed.
+ * This module detects missed items and either runs them (jobs) or
+ * shows a notification (reminders).
+ *
+ * Recovery is opt-in per job/reminder via `runIfMissed` / `recoverIfMissed`.
+ * Jobs are only recovered if missed since midnight (00:00) of the current day.
+ */
+
+import type { CronJob, CronState, Reminder, NotificationSettings } from '../shared/types';
+import { matchesCron } from '../shared/cron';
+import { info, warn } from './logger';
+
+// ── Missed window computation ──────────────────────────────────
+
+/**
+ * Compute the recovery window: from max(lastShutdown, today 00:00) to now.
+ * Returns null if no recovery is needed (e.g. shutdown was today and recent).
+ */
+export function computeRecoveryWindow(
+  lastShutdown: string | undefined,
+  now: Date,
+): { from: Date; to: Date } | null {
+  if (!lastShutdown) return null;
+
+  const shutdownTime = new Date(lastShutdown);
+  if (isNaN(shutdownTime.getTime())) return null;
+
+  // Only recover for same-day misses (since midnight)
+  const midnight = new Date(now);
+  midnight.setHours(0, 0, 0, 0);
+
+  const windowStart = shutdownTime.getTime() > midnight.getTime()
+    ? shutdownTime
+    : midnight;
+
+  // If the window is less than 2 minutes, skip (scheduler was just restarted)
+  if (now.getTime() - windowStart.getTime() < 2 * 60_000) return null;
+
+  return { from: windowStart, to: now };
+}
+
+// ── Cron job recovery ──────────────────────────────────────────
+
+/**
+ * Check if a cron schedule would have matched at any minute in the window.
+ * Returns true on first match (we only need to know if it was missed at all).
+ */
+export function wouldHaveMatched(
+  schedule: string,
+  from: Date,
+  to: Date,
+): boolean {
+  // Iterate minute by minute through the window
+  const cursor = new Date(from);
+  // Align to next full minute
+  cursor.setSeconds(0, 0);
+  if (cursor.getTime() < from.getTime()) {
+    cursor.setMinutes(cursor.getMinutes() + 1);
+  }
+
+  const toTime = to.getTime();
+  while (cursor.getTime() < toTime) {
+    try {
+      if (matchesCron(schedule, cursor)) return true;
+    } catch {
+      return false;
+    }
+    cursor.setMinutes(cursor.getMinutes() + 1);
+  }
+  return false;
+}
+
+/**
+ * Find cron jobs that were missed during the recovery window.
+ * Only returns jobs with `runIfMissed: true` that are not disabled.
+ */
+export function findMissedJobs(
+  jobs: CronJob[],
+  window: { from: Date; to: Date },
+): CronJob[] {
+  const missed: CronJob[] = [];
+  for (const job of jobs) {
+    if (job.disabled || !job.runIfMissed) continue;
+    if (wouldHaveMatched(job.schedule, window.from, window.to)) {
+      missed.push(job);
+    }
+  }
+  return missed;
+}
+
+// ── Reminder recovery ──────────────────────────────────────────
+
+export interface MissedReminder {
+  reminder: Reminder;
+  /** Approximate time the reminder should have fired. */
+  missedAt: Date;
+}
+
+/**
+ * Find reminders that were missed during the recovery window.
+ * Only returns reminders with `recoverIfMissed: true`.
+ */
+export function findMissedReminders(
+  reminders: Reminder[],
+  window: { from: Date; to: Date },
+): MissedReminder[] {
+  const missed: MissedReminder[] = [];
+
+  for (const r of reminders) {
+    if (!r.recoverIfMissed) continue;
+    if (r.status === 'completed' || r.status === 'disabled') continue;
+
+    // One-time reminders: check if fireAt falls in the window
+    if (r.type === 'once' && r.fireAt && !r.lastFiredAt) {
+      const fireTime = new Date(r.fireAt);
+      if (
+        fireTime.getTime() >= window.from.getTime() &&
+        fireTime.getTime() < window.to.getTime()
+      ) {
+        missed.push({ reminder: r, missedAt: fireTime });
+      }
+      continue;
+    }
+
+    // Recurring reminders: check if cron would have matched
+    if (r.type === 'recurring' && r.schedule) {
+      const cursor = new Date(window.from);
+      cursor.setSeconds(0, 0);
+      if (cursor.getTime() < window.from.getTime()) {
+        cursor.setMinutes(cursor.getMinutes() + 1);
+      }
+      const toTime = window.to.getTime();
+      while (cursor.getTime() < toTime) {
+        try {
+          if (matchesCron(r.schedule, cursor)) {
+            missed.push({ reminder: r, missedAt: new Date(cursor) });
+            break; // One notification per reminder is enough
+          }
+        } catch {
+          break;
+        }
+        cursor.setMinutes(cursor.getMinutes() + 1);
+      }
+    }
+  }
+
+  return missed;
+}
+
+// ── Recovery orchestrator ──────────────────────────────────────
+
+export interface RecoveryResult {
+  missedJobs: CronJob[];
+  missedReminders: MissedReminder[];
+}
+
+/**
+ * Detect all missed jobs and reminders based on the scheduler shutdown time.
+ * Does NOT execute anything — the caller decides what to do with the results.
+ */
+export function detectMissedItems(state: CronState): RecoveryResult {
+  const now = new Date();
+  const window = computeRecoveryWindow(state.lastSchedulerShutdown, now);
+
+  if (!window) {
+    return { missedJobs: [], missedReminders: [] };
+  }
+
+  info('recovery:check', {
+    from: window.from.toISOString(),
+    to: window.to.toISOString(),
+    windowMinutes: Math.round((window.to.getTime() - window.from.getTime()) / 60_000),
+  });
+
+  const missedJobs = findMissedJobs(state.jobs, window);
+  const missedReminders = findMissedReminders(state.reminders, window);
+
+  if (missedJobs.length > 0 || missedReminders.length > 0) {
+    info('recovery:found', {
+      missedJobs: missedJobs.map((j) => j.name),
+      missedReminders: missedReminders.map((m) => m.reminder.title),
+    });
+  }
+
+  return { missedJobs, missedReminders };
+}

--- a/packages/pi-cron-extension/extension/reminder-actions.ts
+++ b/packages/pi-cron-extension/extension/reminder-actions.ts
@@ -32,6 +32,7 @@ export interface ReminderParams {
   fire_at?: string;
   schedule?: string;
   snooze_minutes?: number;
+  recover_if_missed?: boolean;
 }
 
 // ── List ────────────────────────────────────────────────────────
@@ -135,6 +136,7 @@ export async function handleReminderAdd(
 
   if (type === 'once') reminder.fireAt = params.fire_at;
   if (type === 'recurring') reminder.schedule = params.schedule;
+  if (params.recover_if_missed) reminder.recoverIfMissed = true;
 
   if (!state.reminders) state.reminders = [];
   state.reminders.push(reminder);
@@ -168,6 +170,10 @@ export async function handleReminderUpdate(
     const chResult = validateChannel(params.channel);
     if (!chResult.ok) return chResult.error;
     reminder.channel = chResult.channel;
+  }
+
+  if (params.recover_if_missed !== undefined) {
+    reminder.recoverIfMissed = params.recover_if_missed;
   }
 
   if (params.fire_at) {

--- a/packages/pi-cron-extension/shared/types.ts
+++ b/packages/pi-cron-extension/shared/types.ts
@@ -26,6 +26,11 @@ export interface CronJob {
    * When unset, the job uses whatever default is in your Pi settings.
    */
   model?: string;
+  /**
+   * If true, the job will run once on scheduler start if it was missed
+   * since midnight (00:00) of the current day. Opt-in, defaults to false.
+   */
+  runIfMissed?: boolean;
 }
 
 export interface CronRunResult {
@@ -70,6 +75,11 @@ export interface Reminder {
   lastFiredAt?: string;
   /** ISO datetime — when the reminder was completed/dismissed */
   completedAt?: string;
+  /**
+   * If true, a notification will be shown on scheduler start for reminders
+   * that were missed while Sero was not running. Opt-in, defaults to false.
+   */
+  recoverIfMissed?: boolean;
 }
 
 /** Predefined snooze durations in minutes */
@@ -114,6 +124,8 @@ export interface CronState {
   autostart: boolean;
   /** Last scheduler tick minute key, used to avoid same-minute re-fires after restart. */
   lastTickMinute?: string;
+  /** ISO timestamp of when the scheduler was last shut down (used for missed-job recovery). */
+  lastSchedulerShutdown?: string;
   /** Recent execution results (capped at 50) */
   lastRunResults: CronRunResult[];
   /** Notification preferences */

--- a/packages/pi-cron-extension/ui/components/JobCard.tsx
+++ b/packages/pi-cron-extension/ui/components/JobCard.tsx
@@ -85,6 +85,16 @@ export function JobCard({
               {job.model}
             </Badge>
           )}
+
+          {job.runIfMissed && (
+            <Badge
+              variant="outline"
+              className="border-blue-500/30 text-[10px] text-blue-500"
+              title="This job will run on startup if missed since midnight"
+            >
+              Recover
+            </Badge>
+          )}
         </div>
 
         {/* Schedule */}

--- a/packages/pi-cron-extension/ui/components/JobForm.tsx
+++ b/packages/pi-cron-extension/ui/components/JobForm.tsx
@@ -33,6 +33,7 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
   const [prompt, setPrompt] = useState('');
   const [channel, setChannel] = useState('cron');
   const [model, setModel] = useState('');
+  const [runIfMissed, setRunIfMissed] = useState(false);
   const [nameError, setNameError] = useState<string | null>(null);
   const [scheduleError, setScheduleError] = useState<string | null>(null);
 
@@ -45,12 +46,14 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
         setPrompt(editingJob.prompt);
         setChannel(editingJob.channel);
         setModel(editingJob.model ?? '');
+        setRunIfMissed(editingJob.runIfMissed ?? false);
       } else {
         setName('');
         setSchedule('');
         setPrompt('');
         setChannel('cron');
         setModel('');
+        setRunIfMissed(false);
       }
       setNameError(null);
       setScheduleError(null);
@@ -101,6 +104,7 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
       disabled: editingJob?.disabled ?? false,
     };
     if (model.trim()) job.model = model.trim();
+    if (runIfMissed) job.runIfMissed = true;
     onSave(job);
     onClose();
   }, [canSave, name, schedule, prompt, channel, model, editingJob, onSave, onClose]);
@@ -235,6 +239,24 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
               Choose a model or leave as default.
             </p>
           </div>
+
+          {/* Run if missed */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={runIfMissed}
+              onChange={(e) => setRunIfMissed(e.target.checked)}
+              className="h-4 w-4 rounded border-input accent-primary"
+            />
+            <div>
+              <span className="text-xs font-medium text-foreground">
+                Run if missed
+              </span>
+              <p className="text-[11px] text-muted-foreground">
+                Run once on startup if this job was missed since midnight today
+              </p>
+            </div>
+          </label>
         </form>
 
         <DialogFooter>

--- a/packages/pi-cron-extension/ui/components/ReminderCard.tsx
+++ b/packages/pi-cron-extension/ui/components/ReminderCard.tsx
@@ -62,6 +62,15 @@ export function ReminderCard({
             </span>
             <StatusBadge status={reminder.status} />
             <TypeBadge type={reminder.type} />
+            {reminder.recoverIfMissed && (
+              <Badge
+                variant="outline"
+                className="border-blue-500/30 text-[10px] text-blue-500"
+                title="Notification will be shown on startup if missed"
+              >
+                Recover
+              </Badge>
+            )}
             {reminder.channel === 'email' && (
               <Badge variant="outline" className="border-blue-500/30 text-[10px] text-blue-500">
                 📧 email

--- a/packages/pi-cron-extension/ui/components/ReminderForm.tsx
+++ b/packages/pi-cron-extension/ui/components/ReminderForm.tsx
@@ -47,6 +47,7 @@ export function ReminderForm({
   const [type, setType] = useState<ReminderType>('once');
   const [fireAt, setFireAt] = useState('');
   const [schedule, setSchedule] = useState('');
+  const [recoverIfMissed, setRecoverIfMissed] = useState(false);
   const [scheduleError, setScheduleError] = useState<string | null>(null);
 
   // Reset form when opening
@@ -59,6 +60,7 @@ export function ReminderForm({
       setType(editingReminder.type);
       setFireAt(editingReminder.fireAt ? toLocalDatetime(editingReminder.fireAt) : '');
       setSchedule(editingReminder.schedule ?? '');
+      setRecoverIfMissed(editingReminder.recoverIfMissed ?? false);
     } else {
       setTitle('');
       setNotes('');
@@ -66,6 +68,7 @@ export function ReminderForm({
       setType('once');
       setFireAt(defaultFireAt());
       setSchedule('');
+      setRecoverIfMissed(false);
     }
     setScheduleError(null);
   }, [open, editingReminder]);
@@ -105,6 +108,7 @@ export function ReminderForm({
     if (type === 'recurring') {
       reminder.schedule = schedule.trim();
     }
+    if (recoverIfMissed) reminder.recoverIfMissed = true;
 
     // Preserve history fields when editing
     if (editingReminder) {
@@ -243,6 +247,24 @@ export function ReminderForm({
               </div>
             </div>
           )}
+
+          {/* Recover if missed */}
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={recoverIfMissed}
+              onChange={(e) => setRecoverIfMissed(e.target.checked)}
+              className="h-4 w-4 rounded border-input accent-primary"
+            />
+            <div>
+              <span className="text-xs font-medium text-foreground">
+                Recover if missed
+              </span>
+              <p className="text-[11px] text-muted-foreground">
+                Show notification on startup if this reminder was missed while Sero was closed
+              </p>
+            </div>
+          </label>
 
           {/* Channel */}
           <div>


### PR DESCRIPTION
Add opt-in recovery for cron jobs and reminders that were missed while
Sero was not running. Jobs with `runIfMissed` enabled will execute once
on startup if their schedule matched since midnight. Reminders with
`recoverIfMissed` enabled will show a notification indicating the miss.

- Add `runIfMissed` field to CronJob, `recoverIfMissed` to Reminder
- Track `lastSchedulerShutdown` in CronState for recovery window
- New `recovery.ts` module detects missed items on scheduler start
- Update tool schemas, action handlers, and UI forms with toggles
- Show "Recover" badge on job/reminder cards when enabled

https://claude.ai/code/session_01QHG6RNiQAAFQ8uAr4ugXgN