### PR TITLE
refactor(desktop): rename SERO_DEV_APPS to SERO_DEV_PLUGINS, default to no dev servers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ sero/
 
 ```bash
 cd apps/desktop
-bash scripts/dev.sh                # Start everything (remote + host + Electron)
+bash scripts/dev.sh                # Start host + Electron (set SERO_DEV_PLUGINS for remote dev servers)
 pkill -f "vite"; pkill -f "electron"  # Kill
 ```
 
@@ -91,7 +91,7 @@ tools live in one window. React 19 + Tailwind 4 + shadcn/ui + Zustand.
 ```bash
 cd apps/desktop                    # All commands run from here
 node scripts/build-electron.mjs   # Build Electron main + preload
-bash scripts/dev.sh                # Start remote + host + Electron
+bash scripts/dev.sh                # Start host + Electron (set SERO_DEV_PLUGINS for remote dev servers)
 pkill -f "vite"; pkill -f "electron"  # Kill
 ```
 
@@ -99,7 +99,7 @@ Logs: `/tmp/sero-vite.log`, `/tmp/sero-remote-<app-id>.log`, `/tmp/sero-electron
 
 ### Selective Dev Mode
 
-- `SERO_DEV_APPS=todo,kanban bash scripts/dev.sh` starts dev servers only for listed plugins; skipped plugins load from their built `dist/ui` bundles via `sero-ext://`.
+- `SERO_DEV_PLUGINS=admin,kanban bash scripts/dev.sh` starts dev servers only for listed plugins; by default no plugins run in dev mode and everything else loads from their built `dist/ui` bundles via `sero-ext://`.
 - When testing skipped plugins, rebuild the remotes first with `pnpm build` so their `dist/ui` assets are current.
 
 ### Typecheck

--- a/apps/desktop/electron/__tests__/app-discovery.test.ts
+++ b/apps/desktop/electron/__tests__/app-discovery.test.ts
@@ -4,8 +4,9 @@ import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 const originalNodeEnv = process.env.NODE_ENV;
-const originalDevApps = process.env.SERO_DEV_APPS;
+const originalDevPlugins = process.env.SERO_DEV_PLUGINS;
 const originalHomeOverride = process.env.SERO_HOME_OVERRIDE;
+const builtinPluginPath = '/Users/test/dev/sero/plugins/sero-admin-plugin';
 
 async function importAppDiscovery() {
   return import('../app-discovery');
@@ -15,12 +16,20 @@ describe('app discovery devPort handling', () => {
   beforeEach(() => {
     vi.resetModules();
     process.env.NODE_ENV = 'development';
-    process.env.SERO_DEV_APPS = 'all';
+    delete process.env.SERO_DEV_PLUGINS;
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv;
-    process.env.SERO_DEV_APPS = originalDevApps;
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+    if (originalDevPlugins === undefined) {
+      delete process.env.SERO_DEV_PLUGINS;
+    } else {
+      process.env.SERO_DEV_PLUGINS = originalDevPlugins;
+    }
     if (originalHomeOverride === undefined) {
       delete process.env.SERO_HOME_OVERRIDE;
     } else {
@@ -28,30 +37,39 @@ describe('app discovery devPort handling', () => {
     }
   });
 
-  it('suppresses devPort for installed plugins under ~/.sero-ui/agent/packages', async () => {
-    const { getManifestDevPort, isInstalledPluginPackagePath } = await importAppDiscovery();
-    const pluginPath = path.join('/tmp/fake-sero-home', 'agent', 'packages', 'todo');
+  it('omits devPort by default for built-in plugins during development', async () => {
+    const { getManifestDevPort } = await importAppDiscovery();
 
-    expect(isInstalledPluginPackagePath(pluginPath)).toBe(false);
-
-    const actualPluginPath = path.join(process.env.HOME ?? '/Users/test', '.sero-ui', 'agent', 'packages', 'todo');
-    expect(isInstalledPluginPackagePath(actualPluginPath)).toBe(true);
-    expect(getManifestDevPort('todo', actualPluginPath, 5174)).toBeUndefined();
+    expect(getManifestDevPort('admin', builtinPluginPath, 5193)).toBeUndefined();
   });
 
-  it('keeps devPort for built-in monorepo packages during development', async () => {
-    const { getManifestDevPort } = await importAppDiscovery();
-    const builtinPath = '/Users/test/dev/sero/packages/pi-todo-extension';
+  it('keeps devPort for plugins listed in SERO_DEV_PLUGINS', async () => {
+    process.env.SERO_DEV_PLUGINS = 'admin';
 
-    expect(getManifestDevPort('todo', builtinPath, 5174)).toBe(5174);
+    const { getManifestDevPort } = await importAppDiscovery();
+
+    expect(getManifestDevPort('admin', builtinPluginPath, 5193)).toBe(5193);
+  });
+
+  it('suppresses devPort for installed plugins under ~/.sero-ui/agent/packages', async () => {
+    process.env.SERO_DEV_PLUGINS = 'admin';
+
+    const { getManifestDevPort, isInstalledPluginPackagePath } = await importAppDiscovery();
+    const pluginPath = path.join('/tmp/fake-sero-home', 'agent', 'packages', 'admin');
+    const actualPluginPath = path.join(process.env.HOME ?? '/Users/test', '.sero-ui', 'agent', 'packages', 'admin');
+
+    expect(isInstalledPluginPackagePath(pluginPath)).toBe(false);
+    expect(isInstalledPluginPackagePath(actualPluginPath)).toBe(true);
+    expect(getManifestDevPort('admin', actualPluginPath, 5193)).toBeUndefined();
   });
 
   it('discovers devPort from agent packages without requiring a listening dev server', async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-app-discovery-'));
     process.env.SERO_HOME_OVERRIDE = tempRoot;
+    process.env.SERO_DEV_PLUGINS = 'admin';
 
     try {
-      const packageDir = path.join(tempRoot, 'apps', 'todo');
+      const packageDir = path.join(tempRoot, 'apps', 'admin');
       await mkdir(packageDir, { recursive: true });
       await mkdir(path.join(tempRoot, 'agent'), { recursive: true });
       await writeFile(
@@ -61,16 +79,16 @@ describe('app discovery devPort handling', () => {
       await writeFile(
         path.join(packageDir, 'package.json'),
         JSON.stringify({
-          name: 'todo',
+          name: 'admin',
           version: '1.0.0',
           sero: {
             app: {
-              id: 'todo',
-              name: 'Todo',
-              icon: 'check-square',
-              stateFile: '.sero/apps/todo/state.json',
-              component: 'TodoApp',
-              devPort: 5174,
+              id: 'admin',
+              name: 'Admin',
+              icon: 'shield',
+              stateFile: '.sero/apps/admin/state.json',
+              component: 'AdminApp',
+              devPort: 5193,
             },
           },
         }, null, 2),
@@ -78,9 +96,9 @@ describe('app discovery devPort handling', () => {
 
       const { discoverApps } = await importAppDiscovery();
       const apps = await discoverApps();
-      const todo = apps.find((app) => app.id === 'todo');
+      const admin = apps.find((app) => app.id === 'admin');
 
-      expect(todo?.devPort).toBe(5174);
+      expect(admin?.devPort).toBe(5193);
     } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }

--- a/apps/desktop/electron/app-discovery.ts
+++ b/apps/desktop/electron/app-discovery.ts
@@ -52,19 +52,25 @@ interface PkgJson {
   sero?: { app?: PkgSeroApp; plugin?: PkgSeroPlugin };
 }
 
-// ── Selective dev mode ────────────────────────────────────────
+// ── Selective plugin dev mode ─────────────────────────────────
+// SERO_DEV_PLUGINS controls which plugin manifests get dev ports.
+// Unset / ""     → no plugins run in dev mode (all use pre-built bundles)
+// "all"          → every plugin runs in dev mode
+// "admin,kanban" → only listed plugins run in dev mode
 // Keep in sync with the equivalent filter in vite.config.ts (Vite build process).
 
-const devAppsEnv = process.env.SERO_DEV_APPS?.trim();
-const selectiveDevFilter: Set<string> | 'all' =
-  !devAppsEnv || devAppsEnv === 'all'
-    ? 'all'
-    : new Set(devAppsEnv.split(',').map((entry) => entry.trim()).filter(Boolean));
+const devPluginsEnv = process.env.SERO_DEV_PLUGINS?.trim();
+const devPluginsFilter: Set<string> | 'all' =
+  !devPluginsEnv
+    ? new Set<string>()
+    : devPluginsEnv === 'all'
+      ? 'all'
+      : new Set(devPluginsEnv.split(',').map((entry) => entry.trim()).filter(Boolean));
 
 function isAppInDevMode(appId: string): boolean {
   if (process.env.NODE_ENV !== 'development') return false;
-  if (selectiveDevFilter === 'all') return true;
-  return selectiveDevFilter.has(appId);
+  if (devPluginsFilter === 'all') return true;
+  return devPluginsFilter.has(appId);
 }
 
 export function isInstalledPluginPackagePath(packagePath: string): boolean {

--- a/apps/desktop/electron/app-discovery.ts
+++ b/apps/desktop/electron/app-discovery.ts
@@ -67,7 +67,7 @@ const devPluginsFilter: Set<string> | 'all' =
       ? 'all'
       : new Set(devPluginsEnv.split(',').map((entry) => entry.trim()).filter(Boolean));
 
-function isAppInDevMode(appId: string): boolean {
+function isPluginInDevMode(appId: string): boolean {
   if (process.env.NODE_ENV !== 'development') return false;
   if (devPluginsFilter === 'all') return true;
   return devPluginsFilter.has(appId);
@@ -85,7 +85,7 @@ export function isInstalledPluginPackagePath(packagePath: string): boolean {
 export function getManifestDevPort(appId: string, packagePath: string, devPort: number | undefined): number | undefined {
   if (!devPort) return undefined;
   if (isInstalledPluginPackagePath(packagePath)) return undefined;
-  return isAppInDevMode(appId) ? devPort : undefined;
+  return isPluginInDevMode(appId) ? devPort : undefined;
 }
 
 function parsePluginMeta(plugin: PkgSeroPlugin | undefined): PluginMeta | null {

--- a/apps/desktop/scripts/dev.sh
+++ b/apps/desktop/scripts/dev.sh
@@ -7,20 +7,19 @@
 #
 # ── Selective dev mode ────────────────────────────────────────
 #
-# By default, ALL discovered apps start dev servers. To run only specific
-# apps in dev mode (and load the rest from pre-built bundles via sero-ext://),
-# set SERO_DEV_APPS to a comma-separated list of app IDs:
+# By default, NO plugins start in dev mode. To run only specific plugins in
+# dev mode (and load the rest from pre-built bundles via sero-ext://), set
+# SERO_DEV_PLUGINS to a comma-separated list of plugin IDs:
 #
-#   SERO_DEV_APPS=todo,kanban bash scripts/dev.sh
+#   SERO_DEV_PLUGINS=admin,kanban bash scripts/dev.sh
 #
-# Apps not in the list must have been built first (pnpm build in their dir).
-# Use SERO_DEV_APPS=none to skip all remote dev servers entirely.
+# Use SERO_DEV_PLUGINS=all to run every remote dev server.
 #
 cd "$(dirname "$0")/.."
 
 PACKAGES_DIR="$(cd ../../packages && pwd)"
 PLUGINS_DIR="$(cd ../../plugins && pwd)"
-SERO_DEV_APPS="${SERO_DEV_APPS:-}"
+SERO_DEV_PLUGINS="${SERO_DEV_PLUGINS:-}"
 
 # ── Cleanup trap ────────────────────────────────────────────
 CHILD_PIDS=()
@@ -82,28 +81,32 @@ for pkg_json in "${PACKAGE_JSONS[@]}"; do
   ALL_PORTS+=("$PORT")
 done
 
-# ── Filter by SERO_DEV_APPS ─────────────────────────────────
+# ── Filter by SERO_DEV_PLUGINS ───────────────────────────────
 REMOTE_NAMES=()
 REMOTE_DIRS=()
 REMOTE_PORTS=()
 SKIPPED_NAMES=()
 
-if [ -n "$SERO_DEV_APPS" ] && [ "$SERO_DEV_APPS" != "all" ]; then
-  IFS=',' read -ra DEV_LIST <<< "$SERO_DEV_APPS"
+if [ -z "$SERO_DEV_PLUGINS" ]; then
+  SKIPPED_NAMES=("${ALL_NAMES[@]}")
+elif [ "$SERO_DEV_PLUGINS" = "all" ]; then
+  REMOTE_NAMES=("${ALL_NAMES[@]}")
+  REMOTE_DIRS=("${ALL_DIRS[@]}")
+  REMOTE_PORTS=("${ALL_PORTS[@]}")
+else
+  IFS=',' read -ra DEV_LIST <<< "$SERO_DEV_PLUGINS"
 
   for i in "${!ALL_NAMES[@]}"; do
     name="${ALL_NAMES[$i]}"
     matched=false
 
-    if [ "$SERO_DEV_APPS" != "none" ]; then
-      for dev_app in "${DEV_LIST[@]}"; do
-        dev_app="$(echo "$dev_app" | xargs)"
-        if [ "$dev_app" = "$name" ]; then
-          matched=true
-          break
-        fi
-      done
-    fi
+    for dev_plugin in "${DEV_LIST[@]}"; do
+      dev_plugin="$(echo "$dev_plugin" | xargs)"
+      if [ "$dev_plugin" = "$name" ]; then
+        matched=true
+        break
+      fi
+    done
 
     if $matched; then
       REMOTE_NAMES+=("$name")
@@ -113,10 +116,6 @@ if [ -n "$SERO_DEV_APPS" ] && [ "$SERO_DEV_APPS" != "all" ]; then
       SKIPPED_NAMES+=("$name")
     fi
   done
-else
-  REMOTE_NAMES=("${ALL_NAMES[@]}")
-  REMOTE_DIRS=("${ALL_DIRS[@]}")
-  REMOTE_PORTS=("${ALL_PORTS[@]}")
 fi
 
 # ── Kill existing instances ───────────────────────────────────
@@ -160,7 +159,7 @@ if [ ${#REMOTE_PORTS[@]} -gt 0 ]; then
   done
 fi
 
-SERO_DEV_APPS="$SERO_DEV_APPS" npx vite > /tmp/sero-vite.log 2>&1 &
+SERO_DEV_PLUGINS="$SERO_DEV_PLUGINS" npx vite > /tmp/sero-vite.log 2>&1 &
 VITE_PID=$!
 CHILD_PIDS+=($VITE_PID)
 
@@ -169,7 +168,7 @@ for attempt in {1..10}; do
   sleep 1
 done
 
-SERO_DEV_APPS="$SERO_DEV_APPS" NODE_ENV=development npx electron . > /tmp/sero-electron.log 2>&1 &
+SERO_DEV_PLUGINS="$SERO_DEV_PLUGINS" NODE_ENV=development npx electron . > /tmp/sero-electron.log 2>&1 &
 ELECTRON_PID=$!
 CHILD_PIDS+=($ELECTRON_PID)
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -8,22 +8,24 @@ import { readFileSync } from 'fs';
 
 const isDev = process.env.NODE_ENV !== 'production';
 
-// ── Selective dev mode ───────────────────────────────────────
-// SERO_DEV_APPS controls which apps get dev servers (HMR, live reload).
-// Unset / "all"  → every app runs in dev mode (original behavior)
-// "none"         → no apps run in dev mode (all use pre-built bundles)
-// "todo,kanban"  → only listed apps run in dev mode
+// ── Selective plugin dev mode ─────────────────────────────────
+// SERO_DEV_PLUGINS controls which plugin remotes get dev servers (HMR, live reload).
+// Unset / ""     → no plugins run in dev mode (all use pre-built bundles)
+// "all"          → every plugin runs in dev mode
+// "admin,kanban" → only listed plugins run in dev mode
 // Keep in sync with the equivalent filter in electron/app-discovery.ts (Electron main process).
-const devAppsEnv = process.env.SERO_DEV_APPS?.trim();
-const devAppsFilter: Set<string> | 'all' =
-  !devAppsEnv || devAppsEnv === 'all'
-    ? 'all'
-    : new Set(devAppsEnv.split(',').map((s) => s.trim()).filter(Boolean));
+const devPluginsEnv = process.env.SERO_DEV_PLUGINS?.trim();
+const devPluginsFilter: Set<string> | 'all' =
+  !devPluginsEnv
+    ? new Set<string>()
+    : devPluginsEnv === 'all'
+      ? 'all'
+      : new Set(devPluginsEnv.split(',').map((s) => s.trim()).filter(Boolean));
 
-function isAppInDevMode(appId: string): boolean {
+function isPluginInDevMode(appId: string): boolean {
   if (!isDev) return false;
-  if (devAppsFilter === 'all') return true;
-  return devAppsFilter.has(appId);
+  if (devPluginsFilter === 'all') return true;
+  return devPluginsFilter.has(appId);
 }
 
 // ── Auto-discover Sero app manifests from workspace packages ──────────
@@ -101,7 +103,7 @@ function discoverSeroApps(): SeroAppDef[] {
 function buildRemotesConfig(apps: SeroAppDef[]): Record<string, string> {
   const remotes: Record<string, string> = {};
   for (const app of apps) {
-    remotes[app.remoteName] = isAppInDevMode(app.id)
+    remotes[app.remoteName] = isPluginInDevMode(app.id)
       ? `http://localhost:${app.devPort}/mf-manifest.json`
       : `sero-ext://${app.id}/mf-manifest.json`;
   }
@@ -114,11 +116,11 @@ function watchRemotes(): Plugin {
   const remoteDirs = discoverAppPackageJsonPaths()
     .map((pkgPath) => path.join(path.dirname(pkgPath), 'ui'))
     .filter((dir) => {
-      if (devAppsFilter === 'all') return true;
+      if (devPluginsFilter === 'all') return true;
       try {
         const pkgPath = path.join(path.dirname(dir), 'package.json');
         const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-        return pkg.sero?.app?.id && devAppsFilter.has(pkg.sero.app.id);
+        return pkg.sero?.app?.id && devPluginsFilter.has(pkg.sero.app.id);
       } catch {
         return false;
       }
@@ -153,11 +155,11 @@ function watchRemotes(): Plugin {
 const seroApps = discoverSeroApps();
 const remotesConfig = buildRemotesConfig(seroApps);
 
-const devApps = seroApps.filter((a) => isAppInDevMode(a.id));
-const builtApps = seroApps.filter((a) => !isAppInDevMode(a.id));
+const devPlugins = seroApps.filter((a) => isPluginInDevMode(a.id));
+const builtPlugins = seroApps.filter((a) => !isPluginInDevMode(a.id));
 console.log(`[sero] Discovered ${seroApps.length} app remotes`);
-if (devApps.length > 0) console.log(`[sero]   Dev mode: ${devApps.map((a) => a.id).join(', ')}`);
-if (builtApps.length > 0) console.log(`[sero]   Pre-built: ${builtApps.map((a) => a.id).join(', ')}`);
+if (devPlugins.length > 0) console.log(`[sero]   Dev plugins: ${devPlugins.map((a) => a.id).join(', ')}`);
+if (builtPlugins.length > 0) console.log(`[sero]   Pre-built: ${builtPlugins.map((a) => a.id).join(', ')}`);
 
 export default defineConfig({
   plugins: [

--- a/docs/apps-tutorial.md
+++ b/docs/apps-tutorial.md
@@ -774,7 +774,7 @@ before restarting Sero:**
 pnpm install
 pnpm --filter @sero/myapp build
 
-# Then restart the dev server:
+# Then restart the dev server (set SERO_DEV_PLUGINS=myapp for HMR):
 cd apps/desktop
 bash scripts/dev.sh
 ```
@@ -783,9 +783,9 @@ bash scripts/dev.sh
 > after creating a new app package.** `pnpm install` links the workspace
 > dependencies (including `@sero-ai/app-runtime`). The build step produces
 > `dist/ui/remoteEntry.js` which the host needs for production mode and
-> which validates that the MF config is correct. In dev mode the remote
-> Vite server serves the UI live, but the initial build catches errors
-> early.
+> which validates that the MF config is correct. To run the UI in dev mode,
+> start `dev.sh` with `SERO_DEV_PLUGINS=<plugin-id>`; otherwise the host
+> loads the built bundle. The initial build catches errors early.
 
 On startup:
 
@@ -793,7 +793,8 @@ On startup:
    manifests and builds the Module Federation remotes map from `id` +
    `devPort`.
 2. **`dev.sh`** discovers the same packages and starts a Vite dev server
-   for each one on its `devPort`.
+   only for the plugin IDs listed in `SERO_DEV_PLUGINS`; everything else
+   loads from pre-built bundles.
 3. **`electron/main.ts`** scans packages and registers their paths for
    app discovery + adds them to `~/.sero-ui/agent/settings.json` so the
    agent loads the extension tools.
@@ -830,7 +831,7 @@ full install/publish documentation.
 
 ```bash
 cd apps/desktop
-bash scripts/dev.sh
+SERO_DEV_PLUGINS=myapp bash scripts/dev.sh
 ```
 
 1. Click your app in the sidebar → the federated UI loads.
@@ -1533,23 +1534,27 @@ cd apps/desktop
 bash scripts/dev.sh
 ```
 
+To get HMR for a plugin's UI, start `dev.sh` with `SERO_DEV_PLUGINS`
+set to that plugin's ID(s).
+
 This starts:
-1. Each remote's Vite dev server (one per app with a UI)
+1. The Vite dev servers for the plugins listed in `SERO_DEV_PLUGINS`
 2. The host Vite dev server (port 5173)
 3. Electron
 
 ### Live reload for remote apps
 
-The host includes a `watchRemotes` Vite plugin that monitors all
-`packages/pi-*/ui/` directories. When you edit a remote app's UI code:
+The host includes a `watchRemotes` Vite plugin that monitors the `ui/`
+directories for plugins running in dev mode. When you edit a remote app's UI
+code:
 
 1. The remote's Vite dev server detects the change and rebuilds (~50ms)
 2. The host's watcher detects the same file change (300ms debounce)
 3. The host sends `full-reload` via Vite's WebSocket
 4. The Electron renderer reloads with the updated code
 
-This gives **near-instant feedback** (~300–500ms) when editing app UI code.
-No manual restart needed.
+This gives **near-instant feedback** (~300–500ms) when editing app UI code
+for plugins that are running in dev mode. No manual restart needed.
 
 > **Note:** Changes to the Pi extension (`extension/index.ts`) or
 > `shared/types.ts` require restarting the Electron main process

--- a/plugins/sero-context-plugin/README.md
+++ b/plugins/sero-context-plugin/README.md
@@ -56,9 +56,9 @@ The UI watches this file and renders the graph in real time.
 pnpm install
 pnpm --filter @sero-ai/plugin-context build
 
-# Start everything
+# Start the context plugin in dev mode
 cd apps/desktop
-bash scripts/dev.sh
+SERO_DEV_PLUGINS=context bash scripts/dev.sh
 ```
 
 The Context app appears in the sidebar. Click it to see the dashboard.

--- a/plugins/sero-cron-plugin/README.md
+++ b/plugins/sero-cron-plugin/README.md
@@ -589,12 +589,12 @@ pnpm --filter @sero-ai/plugin-cron build
 
 ```bash
 cd apps/desktop
-bash scripts/dev.sh          # Starts all remotes + host + Electron
+SERO_DEV_PLUGINS=cron bash scripts/dev.sh          # Starts cron in dev mode + host + Electron
 ```
 
-The cron remote runs on port **5188**. Edits to files in `ui/` trigger
-live reload (~300ms). Extension changes (`extension/`) require a full
-restart.
+When started with `SERO_DEV_PLUGINS=cron`, the cron remote runs on port
+**5188**. Edits to files in `ui/` trigger live reload (~300ms). Extension
+changes (`extension/`) require a full restart.
 
 ### Tests
 


### PR DESCRIPTION
## What

Renames the `SERO_DEV_APPS` env var to `SERO_DEV_PLUGINS` and changes the default from "all plugins run dev servers" to "no plugins run dev servers unless explicitly listed".

## Why

The old name (`SERO_DEV_APPS`) was a leftover from before the apps→plugins rename. The old default (every plugin gets a Vite dev server) slowed down startup when you only care about the host — most of the time you don't need HMR on plugin UIs.

## Changes

- **`apps/desktop/electron/app-discovery.ts`** — rename env parsing (`devPluginsEnv`, `devPluginsFilter`, `isPluginInDevMode`); empty/unset now produces an empty `Set` instead of `"all"`
- **`apps/desktop/vite.config.ts`** — same filter rename; `buildRemotesConfig` and `watchRemotes` use the new filter
- **`apps/desktop/scripts/dev.sh`** — rename env var; restructure filter logic (`if empty / elif all / else csv`); remove the old `"none"` special case
- **`apps/desktop/electron/__tests__/app-discovery.test.ts`** — update to new env var; add "omits devPort by default" test; switch fixture from `todo` to `admin`
- **`AGENTS.md`**, **`docs/apps-tutorial.md`**, **plugin READMEs** — update all references and examples

## Usage

```bash
# Default — no plugin dev servers, everything loads from pre-built bundles
bash scripts/dev.sh

# Specific plugins in dev mode
SERO_DEV_PLUGINS=admin,kanban bash scripts/dev.sh

# All plugins in dev mode (old behaviour)
SERO_DEV_PLUGINS=all bash scripts/dev.sh
```

## Verification

```bash
pnpm typecheck
cd apps/desktop && pnpm exec vitest run electron/__tests__/app-discovery.test.ts
```