### PR TITLE
feat(desktop): add local LLM management UI for Ollama, LM Studio, vLLM

### DIFF
--- a/apps/desktop/electron/ipc/agent/core/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-helpers.ts
@@ -6,7 +6,7 @@
 
 import type { AgentSession, DefaultResourceLoader } from '@mariozechner/pi-coding-agent';
 import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
-import type { ImageContent, KnownProvider } from '@mariozechner/pi-ai';
+import type { ImageContent } from '@mariozechner/pi-ai';
 import { promises as fs } from 'fs';
 import type {
   ChatMessage,
@@ -148,18 +148,12 @@ export function validateThinkingLevel(level: string): ThinkingLevel {
   );
 }
 
-const KNOWN_PROVIDERS: KnownProvider[] = [
-  'amazon-bedrock', 'anthropic', 'google', 'google-gemini-cli', 'google-antigravity',
-  'google-vertex', 'openai', 'azure-openai-responses', 'openai-codex', 'github-copilot',
-  'xai', 'groq', 'cerebras', 'openrouter', 'vercel-ai-gateway', 'zai', 'mistral',
-  'minimax', 'minimax-cn', 'huggingface', 'opencode', 'kimi-coding',
-];
-
-export function validateProvider(provider: string): KnownProvider {
-  if (KNOWN_PROVIDERS.includes(provider as KnownProvider)) {
-    return provider as KnownProvider;
+export function validateProvider(provider: string): string {
+  const normalized = provider.trim();
+  if (!normalized) {
+    throw new Error('Provider is required');
   }
-  throw new Error(`Unknown provider: "${provider}". Available: ${KNOWN_PROVIDERS.join(', ')}`);
+  return normalized;
 }
 
 // ── Message conversion ───────────────────────────────────────

--- a/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
@@ -18,6 +18,7 @@ import {
   validateProvider,
   validateThinkingLevel,
 } from './agent-helpers';
+import { getConfiguredModelFallbackChain } from '../../../shared/settings/model-fallback-chain';
 
 export interface AgentPoolContextEntry {
   session: AgentSession;
@@ -31,6 +32,97 @@ interface RegisterModelContextHandlersOptions {
   sendEvent: (event: AgentStreamEvent) => void;
 }
 
+function findAvailableModelByProviderAndId(
+  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
+  provider: string | undefined,
+  modelId: string | undefined,
+) {
+  if (!provider || !modelId) return undefined;
+  return availableModels.find((model) => model.provider === provider && model.id === modelId);
+}
+
+function findAvailableModelByReference(
+  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
+  reference: string,
+  preferredProvider?: string,
+) {
+  const trimmed = reference.trim();
+  if (!trimmed) return undefined;
+
+  const slashIndex = trimmed.indexOf('/');
+  if (slashIndex !== -1) {
+    const provider = trimmed.slice(0, slashIndex).trim();
+    const modelId = trimmed.slice(slashIndex + 1).trim();
+    return findAvailableModelByProviderAndId(availableModels, provider, modelId);
+  }
+
+  const lowerId = trimmed.toLowerCase();
+  const matches = availableModels.filter((model) => model.id.toLowerCase() === lowerId);
+  if (matches.length === 0) return undefined;
+  if (matches.length === 1) return matches[0];
+
+  if (preferredProvider) {
+    const preferredMatch = matches.find((model) => model.provider === preferredProvider);
+    if (preferredMatch) return preferredMatch;
+  }
+
+  return matches[0];
+}
+
+function pickFallbackModel(
+  session: AgentSession,
+  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
+) {
+  session.settingsManager.reload();
+
+  const preferredProvider = session.settingsManager.getDefaultProvider();
+  const savedDefaultModel = findAvailableModelByProviderAndId(
+    availableModels,
+    preferredProvider,
+    session.settingsManager.getDefaultModel(),
+  );
+  if (savedDefaultModel) return savedDefaultModel;
+
+  const globalSettings = session.settingsManager.getGlobalSettings() as Record<string, unknown>;
+  const fallbackChain = getConfiguredModelFallbackChain(globalSettings);
+  for (const candidate of fallbackChain) {
+    const model = findAvailableModelByReference(availableModels, candidate, preferredProvider);
+    if (model) return model;
+  }
+
+  return availableModels[0];
+}
+
+async function ensureSessionHasAvailableModel(session: AgentSession): Promise<boolean> {
+  session.modelRegistry.authStorage.reload();
+
+  const currentModel = session.model;
+  const refreshedModel = currentModel
+    ? session.modelRegistry.find(currentModel.provider, currentModel.id)
+    : undefined;
+
+  if (currentModel && refreshedModel && refreshedModel !== currentModel) {
+    session.agent.setModel(refreshedModel);
+  }
+
+  const availableModels = session.modelRegistry.getAvailable();
+  const currentProvider = refreshedModel?.provider ?? currentModel?.provider;
+  const currentModelId = refreshedModel?.id ?? currentModel?.id;
+  const currentStillAvailable = !!findAvailableModelByProviderAndId(
+    availableModels,
+    currentProvider,
+    currentModelId,
+  );
+
+  if (currentStillAvailable) return false;
+
+  const fallbackModel = pickFallbackModel(session, availableModels);
+  if (!fallbackModel) return false;
+
+  await session.setModel(fallbackModel);
+  return true;
+}
+
 export function registerAgentModelContextHandlers(
   options: RegisterModelContextHandlersOptions,
 ): void {
@@ -41,7 +133,12 @@ export function registerAgentModelContextHandlers(
     async (_event, sessionId: string): Promise<SessionModelState | null> => {
       const entry = getEntry(sessionId);
       if (!entry) return null;
-      return buildModelState(entry);
+      const changed = await ensureSessionHasAvailableModel(entry.session);
+      const state = buildModelState(entry);
+      if (changed) {
+        sendEvent({ type: 'model_change', sessionId, state });
+      }
+      return state;
     },
   );
 

--- a/apps/desktop/electron/ipc/agent/handlers/local-models.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/local-models.ts
@@ -5,25 +5,247 @@
  * and provides helpers for testing connectivity and fetching remote model lists.
  */
 
+import { execSync } from 'child_process';
 import { ipcMain } from 'electron';
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { mkdir, readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import { IpcChannels } from '../../../../src/types/ipc';
-import type { LocalModelsConfig } from '../../../../src/types/ipc';
+import type {
+  LocalModelApi,
+  LocalModelsConfig,
+  LocalModelsConnectionRequest,
+  LocalRemoteModelInfo,
+} from '../../../../src/types/ipc';
 import { ensureInfra } from '../../../shared/infra/shared-infra';
 import { SERO_AGENT_DIR } from '../../../platform/env';
 
 const MODELS_JSON_PATH = path.join(SERO_AGENT_DIR, 'models.json');
+const ANTHROPIC_VERSION = '2023-06-01';
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isMissingFileError(error: unknown): error is NodeJS.ErrnoException {
+  return !!error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT';
+}
+
+function resolveConfigValue(config?: string): string | undefined {
+  if (!config) return undefined;
+  if (config.startsWith('!')) {
+    try {
+      const output = execSync(config.slice(1), {
+        encoding: 'utf8',
+        timeout: 10000,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      return output.trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return process.env[config] || config;
+}
+
+function resolveHeaders(headers?: Record<string, string>): Record<string, string> | undefined {
+  if (!headers) return undefined;
+  const resolved: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const resolvedValue = resolveConfigValue(value);
+    if (resolvedValue) resolved[key] = resolvedValue;
+  }
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
+function joinUrl(baseUrl: string, pathname: string): string {
+  try {
+    const url = new URL(baseUrl);
+    const basePath = url.pathname.replace(/\/+$/, '');
+    const nextPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+    url.pathname = `${basePath}${nextPath}`;
+    return url.toString();
+  } catch {
+    return `${baseUrl.replace(/\/+$/, '')}/${pathname.replace(/^\/+/, '')}`;
+  }
+}
+
+function appendQueryParam(urlString: string, key: string, value: string): string {
+  try {
+    const url = new URL(urlString);
+    if (!url.searchParams.has(key)) url.searchParams.set(key, value);
+    return url.toString();
+  } catch {
+    const separator = urlString.includes('?') ? '&' : '?';
+    return `${urlString}${separator}${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
+  }
+}
+
+function buildRequestHeaders(request: LocalModelsConnectionRequest): Record<string, string> | undefined {
+  const headers = { ...(resolveHeaders(request.headers) ?? {}) };
+  const apiKey = resolveConfigValue(request.apiKey);
+
+  switch (request.api) {
+    case 'openai-completions':
+    case 'openai-responses': {
+      const shouldAttachBearer = request.authHeader ?? true;
+      if (apiKey && apiKey !== 'none' && shouldAttachBearer && !headers.Authorization) {
+        headers.Authorization = `Bearer ${apiKey}`;
+      }
+      break;
+    }
+    case 'anthropic-messages':
+      if (apiKey && apiKey !== 'none' && !headers['x-api-key']) {
+        headers['x-api-key'] = apiKey;
+      }
+      if (!headers['anthropic-version']) {
+        headers['anthropic-version'] = ANTHROPIC_VERSION;
+      }
+      headers.accept ??= 'application/json';
+      break;
+    case 'google-generative-ai':
+      if (apiKey && apiKey !== 'none' && !headers['x-goog-api-key']) {
+        headers['x-goog-api-key'] = apiKey;
+      }
+      break;
+  }
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+function buildModelsEndpoint(request: LocalModelsConnectionRequest): string {
+  const modelsUrl = joinUrl(request.baseUrl, '/models');
+  if (request.api !== 'google-generative-ai') return modelsUrl;
+
+  const apiKey = resolveConfigValue(request.apiKey);
+  return apiKey && apiKey !== 'none'
+    ? appendQueryParam(modelsUrl, 'key', apiKey)
+    : modelsUrl;
+}
+
+async function fetchJson(
+  url: string,
+  headers: Record<string, string> | undefined,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const res = await fetch(url, { headers, signal });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+  }
+  return res.json();
+}
+
+function parseOpenAiModels(data: unknown): LocalRemoteModelInfo[] {
+  if (!data || typeof data !== 'object' || !('data' in data) || !Array.isArray(data.data)) {
+    return [];
+  }
+  return data.data.flatMap((model) => {
+    if (!model || typeof model !== 'object' || !('id' in model) || typeof model.id !== 'string') {
+      return [];
+    }
+    return [{
+      id: model.id,
+      name:
+        ('name' in model && typeof model.name === 'string' ? model.name : undefined)
+        ?? ('display_name' in model && typeof model.display_name === 'string'
+          ? model.display_name
+          : undefined),
+    }];
+  });
+}
+
+function parseOllamaModels(data: unknown): LocalRemoteModelInfo[] {
+  if (!data || typeof data !== 'object' || !('models' in data) || !Array.isArray(data.models)) {
+    return [];
+  }
+  return data.models.flatMap((model) => {
+    if (!model || typeof model !== 'object') return [];
+    const id =
+      ('model' in model && typeof model.model === 'string' ? model.model : undefined)
+      ?? ('name' in model && typeof model.name === 'string' ? model.name : undefined);
+    if (!id) return [];
+    return [{
+      id,
+      name: 'name' in model && typeof model.name === 'string' ? model.name : undefined,
+    }];
+  });
+}
+
+function parseGoogleModels(data: unknown): LocalRemoteModelInfo[] {
+  if (!data || typeof data !== 'object' || !('models' in data) || !Array.isArray(data.models)) {
+    return [];
+  }
+  return data.models.flatMap((model) => {
+    if (!model || typeof model !== 'object' || !('name' in model) || typeof model.name !== 'string') {
+      return [];
+    }
+    const id = model.name.replace(/^models\//, '');
+    return [{
+      id,
+      name: 'displayName' in model && typeof model.displayName === 'string'
+        ? model.displayName
+        : id,
+    }];
+  });
+}
+
+async function fetchOpenAiCompatibleModels(
+  request: LocalModelsConnectionRequest,
+  signal: AbortSignal,
+): Promise<LocalRemoteModelInfo[]> {
+  const headers = buildRequestHeaders(request);
+  const modelsUrl = buildModelsEndpoint(request);
+  let primaryError: string | null = null;
+
+  try {
+    const data = await fetchJson(modelsUrl, headers, signal);
+    return parseOpenAiModels(data);
+  } catch (error) {
+    primaryError = toErrorMessage(error);
+  }
+
+  const ollamaBaseUrl = request.baseUrl.replace(/\/v1\/?$/, '');
+  const ollamaTagsUrl = joinUrl(ollamaBaseUrl, '/api/tags');
+  try {
+    const data = await fetchJson(ollamaTagsUrl, headers, signal);
+    return parseOllamaModels(data);
+  } catch (error) {
+    const fallbackError = toErrorMessage(error);
+    throw new Error(primaryError ? `${primaryError}; ${fallbackError}` : fallbackError);
+  }
+}
+
+async function fetchAnthropicModels(
+  request: LocalModelsConnectionRequest,
+  signal: AbortSignal,
+): Promise<LocalRemoteModelInfo[]> {
+  const data = await fetchJson(buildModelsEndpoint(request), buildRequestHeaders(request), signal);
+  return parseOpenAiModels(data);
+}
+
+async function fetchGoogleModels(
+  request: LocalModelsConnectionRequest,
+  signal: AbortSignal,
+): Promise<LocalRemoteModelInfo[]> {
+  const data = await fetchJson(buildModelsEndpoint(request), buildRequestHeaders(request), signal);
+  return parseGoogleModels(data);
+}
 
 /** Read models.json from disk. Returns empty config if not found. */
 async function readModelsConfig(): Promise<LocalModelsConfig> {
+  let raw: string | null = null;
   try {
-    const raw = await readFile(MODELS_JSON_PATH, 'utf8');
-    const parsed = JSON.parse(raw);
-    return { providers: parsed.providers ?? {} };
-  } catch {
-    return { providers: {} };
+    raw = await readFile(MODELS_JSON_PATH, 'utf8');
+  } catch (error) {
+    if (!isMissingFileError(error)) throw error;
   }
+
+  const { modelRegistry } = await ensureInfra();
+  modelRegistry.refresh();
+  const loadError = modelRegistry.getError();
+  if (loadError) throw new Error(loadError);
+
+  if (raw === null) return { providers: {} };
+  return JSON.parse(raw) as LocalModelsConfig;
 }
 
 /** Write models.json to disk and refresh the model registry. */
@@ -31,75 +253,63 @@ async function writeModelsConfig(config: LocalModelsConfig): Promise<void> {
   await mkdir(path.dirname(MODELS_JSON_PATH), { recursive: true });
   await writeFile(MODELS_JSON_PATH, JSON.stringify(config, null, 2) + '\n', 'utf8');
 
-  // Refresh the ModelRegistry so new models are immediately available
   const { modelRegistry } = await ensureInfra();
   modelRegistry.refresh();
+  const loadError = modelRegistry.getError();
+  if (loadError) throw new Error(loadError);
 }
 
-/** Test connectivity to a base URL by hitting the OpenAI-compatible /models endpoint. */
-async function testConnection(baseUrl: string): Promise<{ ok: boolean; error?: string }> {
+/** Test connectivity using the selected API and auth settings. */
+async function testConnection(
+  request: LocalModelsConnectionRequest,
+): Promise<{ ok: boolean; error?: string }> {
   try {
-    const url = baseUrl.replace(/\/+$/, '');
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 5000);
     try {
-      const res = await fetch(`${url}/models`, { signal: controller.signal });
-      if (res.ok) return { ok: true };
-      return { ok: false, error: `HTTP ${res.status}: ${res.statusText}` };
+      await fetchRemoteModels(request, controller.signal);
+      return { ok: true };
     } finally {
       clearTimeout(timeout);
     }
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    return { ok: false, error: msg };
+  } catch (error) {
+    return { ok: false, error: toErrorMessage(error) };
   }
-}
-
-interface RemoteModelInfo {
-  id: string;
-  name?: string;
 }
 
 /**
  * Fetch available models from a provider's API.
- * Supports OpenAI-compatible /models and Ollama /api/tags.
+ * Supports OpenAI-compatible /models, Anthropic /models,
+ * Google Generative AI /models, and Ollama /api/tags.
  */
-async function fetchRemoteModels(baseUrl: string): Promise<RemoteModelInfo[]> {
-  const url = baseUrl.replace(/\/+$/, '');
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10000);
+async function fetchRemoteModels(
+  request: LocalModelsConnectionRequest,
+  signal?: AbortSignal,
+): Promise<LocalRemoteModelInfo[]> {
+  const controller = signal ? null : new AbortController();
+  const activeSignal = signal ?? controller!.signal;
+  const timeout = controller ? setTimeout(() => controller.abort(), 10000) : null;
 
   try {
-    // Try OpenAI-compatible /models first
-    const res = await fetch(`${url}/models`, { signal: controller.signal });
-    if (res.ok) {
-      const data = await res.json();
-      if (Array.isArray(data?.data)) {
-        return data.data.map((m: { id: string; name?: string }) => ({
-          id: m.id,
-          name: m.name,
-        }));
+    const trimmedBaseUrl = request.baseUrl.trim();
+    if (!trimmedBaseUrl) throw new Error('Base URL is required');
+
+    const normalizedRequest = { ...request, baseUrl: trimmedBaseUrl };
+    switch (normalizedRequest.api) {
+      case 'openai-completions':
+      case 'openai-responses':
+        return fetchOpenAiCompatibleModels(normalizedRequest, activeSignal);
+      case 'anthropic-messages':
+        return fetchAnthropicModels(normalizedRequest, activeSignal);
+      case 'google-generative-ai':
+        return fetchGoogleModels(normalizedRequest, activeSignal);
+      default: {
+        const unsupportedApi: never = normalizedRequest.api;
+        throw new Error(`Unsupported API type: ${unsupportedApi as LocalModelApi}`);
       }
     }
-
-    // Try Ollama /api/tags (baseUrl might be http://localhost:11434/v1)
-    const ollamaBase = url.replace(/\/v1$/, '');
-    const ollamaRes = await fetch(`${ollamaBase}/api/tags`, { signal: controller.signal });
-    if (ollamaRes.ok) {
-      const data = await ollamaRes.json();
-      if (Array.isArray(data?.models)) {
-        return data.models.map((m: { name: string; model?: string }) => ({
-          id: m.name ?? m.model,
-          name: m.name,
-        }));
-      }
-    }
-
-    return [];
-  } catch {
-    return [];
   } finally {
-    clearTimeout(timeout);
+    if (timeout) clearTimeout(timeout);
   }
 }
 
@@ -120,15 +330,18 @@ export function registerLocalModelsHandlers(): void {
 
   ipcMain.handle(
     IpcChannels.localModels.testConnection,
-    async (_event, baseUrl: string): Promise<{ ok: boolean; error?: string }> => {
-      return testConnection(baseUrl);
+    async (
+      _event,
+      request: LocalModelsConnectionRequest,
+    ): Promise<{ ok: boolean; error?: string }> => {
+      return testConnection(request);
     },
   );
 
   ipcMain.handle(
     IpcChannels.localModels.fetchRemoteModels,
-    async (_event, baseUrl: string): Promise<RemoteModelInfo[]> => {
-      return fetchRemoteModels(baseUrl);
+    async (_event, request: LocalModelsConnectionRequest): Promise<LocalRemoteModelInfo[]> => {
+      return fetchRemoteModels(request);
     },
   );
 }

--- a/apps/desktop/electron/ipc/agent/handlers/local-models.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/local-models.ts
@@ -1,0 +1,134 @@
+/**
+ * Local model management IPC handlers.
+ *
+ * Reads/writes ~/.sero-ui/agent/models.json (Pi SDK custom models config)
+ * and provides helpers for testing connectivity and fetching remote model lists.
+ */
+
+import { ipcMain } from 'electron';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import path from 'path';
+import { IpcChannels } from '../../../../src/types/ipc';
+import type { LocalModelsConfig } from '../../../../src/types/ipc';
+import { ensureInfra } from '../../../shared/infra/shared-infra';
+import { SERO_AGENT_DIR } from '../../../platform/env';
+
+const MODELS_JSON_PATH = path.join(SERO_AGENT_DIR, 'models.json');
+
+/** Read models.json from disk. Returns empty config if not found. */
+async function readModelsConfig(): Promise<LocalModelsConfig> {
+  try {
+    const raw = await readFile(MODELS_JSON_PATH, 'utf8');
+    const parsed = JSON.parse(raw);
+    return { providers: parsed.providers ?? {} };
+  } catch {
+    return { providers: {} };
+  }
+}
+
+/** Write models.json to disk and refresh the model registry. */
+async function writeModelsConfig(config: LocalModelsConfig): Promise<void> {
+  await mkdir(path.dirname(MODELS_JSON_PATH), { recursive: true });
+  await writeFile(MODELS_JSON_PATH, JSON.stringify(config, null, 2) + '\n', 'utf8');
+
+  // Refresh the ModelRegistry so new models are immediately available
+  const { modelRegistry } = await ensureInfra();
+  modelRegistry.refresh();
+}
+
+/** Test connectivity to a base URL by hitting the OpenAI-compatible /models endpoint. */
+async function testConnection(baseUrl: string): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const url = baseUrl.replace(/\/+$/, '');
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const res = await fetch(`${url}/models`, { signal: controller.signal });
+      if (res.ok) return { ok: true };
+      return { ok: false, error: `HTTP ${res.status}: ${res.statusText}` };
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg };
+  }
+}
+
+interface RemoteModelInfo {
+  id: string;
+  name?: string;
+}
+
+/**
+ * Fetch available models from a provider's API.
+ * Supports OpenAI-compatible /models and Ollama /api/tags.
+ */
+async function fetchRemoteModels(baseUrl: string): Promise<RemoteModelInfo[]> {
+  const url = baseUrl.replace(/\/+$/, '');
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  try {
+    // Try OpenAI-compatible /models first
+    const res = await fetch(`${url}/models`, { signal: controller.signal });
+    if (res.ok) {
+      const data = await res.json();
+      if (Array.isArray(data?.data)) {
+        return data.data.map((m: { id: string; name?: string }) => ({
+          id: m.id,
+          name: m.name,
+        }));
+      }
+    }
+
+    // Try Ollama /api/tags (baseUrl might be http://localhost:11434/v1)
+    const ollamaBase = url.replace(/\/v1$/, '');
+    const ollamaRes = await fetch(`${ollamaBase}/api/tags`, { signal: controller.signal });
+    if (ollamaRes.ok) {
+      const data = await ollamaRes.json();
+      if (Array.isArray(data?.models)) {
+        return data.models.map((m: { name: string; model?: string }) => ({
+          id: m.name ?? m.model,
+          name: m.name,
+        }));
+      }
+    }
+
+    return [];
+  } catch {
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function registerLocalModelsHandlers(): void {
+  ipcMain.handle(
+    IpcChannels.localModels.getConfig,
+    async (): Promise<LocalModelsConfig> => {
+      return readModelsConfig();
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.localModels.saveConfig,
+    async (_event, config: LocalModelsConfig): Promise<void> => {
+      await writeModelsConfig(config);
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.localModels.testConnection,
+    async (_event, baseUrl: string): Promise<{ ok: boolean; error?: string }> => {
+      return testConnection(baseUrl);
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.localModels.fetchRemoteModels,
+    async (_event, baseUrl: string): Promise<RemoteModelInfo[]> => {
+      return fetchRemoteModels(baseUrl);
+    },
+  );
+}

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -36,6 +36,7 @@ import { registerUserFeedbackQuestionHandlers } from './platform/ui';
 import { registerGatewayHandlers } from './gateway';
 import { registerGoogleApiHandlers } from './integrations/google-api';
 import { registerModelsHandlers } from './agent/handlers/models';
+import { registerLocalModelsHandlers } from './agent/handlers/local-models';
 import { registerSubagentHandlers } from './subagent';
 import { registerSkillHandlers } from './agent/handlers/skills';
 import { registerPromptHandlers } from './agent/handlers/prompts';
@@ -75,6 +76,7 @@ export function registerAllIpcHandlers(): void {
   registerGatewayHandlers();
   registerGoogleApiHandlers();
   registerModelsHandlers();
+  registerLocalModelsHandlers();
   registerSubagentHandlers();
   registerSkillHandlers();
   registerPromptHandlers();

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -29,6 +29,10 @@ import { containerManager, fileWatcherManager, lspManager, vcsManager, gatewaySe
 import { startGateway, stopGateway } from './ipc/gateway';
 import { setupContentSecurityPolicy } from './platform/security/csp';
 import { discoverBuiltinPackagePaths, discoverBuiltinPluginPaths } from './platform/protocols/builtin-resources';
+import {
+  ensureConfiguredModelFallbackChain,
+  getDefaultModelFallbackChain,
+} from './shared/settings/model-fallback-chain';
 
 // Register custom protocol BEFORE app.whenReady()
 registerExtProtocolScheme();
@@ -63,6 +67,9 @@ function bootstrapAgentDir(): void {
       defaultModel: 'claude-opus-4-6',
       defaultThinkingLevel: 'high',
       packages: workspacePackages,
+      sero: {
+        modelFallbackChain: getDefaultModelFallbackChain(),
+      },
     };
     writeFileSync(settingsPath, JSON.stringify(defaults, null, 2) + '\n');
     console.log('[sero] Created default settings at', settingsPath);
@@ -91,6 +98,9 @@ function ensureBuiltinPackages(): void {
   const workspacePackages = getWorkspaceAppPaths();
 
   let changed = false;
+  const fallbackSettings = ensureConfiguredModelFallbackChain(settings);
+  settings = fallbackSettings.settings;
+  if (fallbackSettings.changed) changed = true;
   for (const p of workspacePackages) {
     const hasPackagePath = packages.some((entry) =>
       (typeof entry === 'string' ? entry : entry.source) === p,

--- a/apps/desktop/electron/preload/agent/local-models.ts
+++ b/apps/desktop/electron/preload/agent/local-models.ts
@@ -1,0 +1,26 @@
+/**
+ * Preload bridge — local model management IPC.
+ */
+
+import { ipcRenderer } from 'electron';
+import { IpcChannels } from '../../../src/types/ipc';
+import type { LocalModelsConfig } from '../../../src/types/ipc';
+
+export interface RemoteModelInfo {
+  id: string;
+  name?: string;
+}
+
+export const localModelsBridge = {
+  getConfig: (): Promise<LocalModelsConfig> =>
+    ipcRenderer.invoke(IpcChannels.localModels.getConfig),
+
+  saveConfig: (config: LocalModelsConfig): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.localModels.saveConfig, config),
+
+  testConnection: (baseUrl: string): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.localModels.testConnection, baseUrl),
+
+  fetchRemoteModels: (baseUrl: string): Promise<RemoteModelInfo[]> =>
+    ipcRenderer.invoke(IpcChannels.localModels.fetchRemoteModels, baseUrl),
+};

--- a/apps/desktop/electron/preload/agent/local-models.ts
+++ b/apps/desktop/electron/preload/agent/local-models.ts
@@ -4,12 +4,11 @@
 
 import { ipcRenderer } from 'electron';
 import { IpcChannels } from '../../../src/types/ipc';
-import type { LocalModelsConfig } from '../../../src/types/ipc';
-
-export interface RemoteModelInfo {
-  id: string;
-  name?: string;
-}
+import type {
+  LocalModelsConfig,
+  LocalModelsConnectionRequest,
+  LocalRemoteModelInfo,
+} from '../../../src/types/ipc';
 
 export const localModelsBridge = {
   getConfig: (): Promise<LocalModelsConfig> =>
@@ -18,9 +17,9 @@ export const localModelsBridge = {
   saveConfig: (config: LocalModelsConfig): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.localModels.saveConfig, config),
 
-  testConnection: (baseUrl: string): Promise<{ ok: boolean; error?: string }> =>
-    ipcRenderer.invoke(IpcChannels.localModels.testConnection, baseUrl),
+  testConnection: (request: LocalModelsConnectionRequest): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.localModels.testConnection, request),
 
-  fetchRemoteModels: (baseUrl: string): Promise<RemoteModelInfo[]> =>
-    ipcRenderer.invoke(IpcChannels.localModels.fetchRemoteModels, baseUrl),
+  fetchRemoteModels: (request: LocalModelsConnectionRequest): Promise<LocalRemoteModelInfo[]> =>
+    ipcRenderer.invoke(IpcChannels.localModels.fetchRemoteModels, request),
 };

--- a/apps/desktop/electron/preload/api.ts
+++ b/apps/desktop/electron/preload/api.ts
@@ -7,6 +7,7 @@ import { skillsBridge } from './agent/skills';
 import { promptsBridge } from './agent/prompts';
 import { collaborationBridge } from './collaboration';
 import { modelsBridge } from './agent/models';
+import { localModelsBridge } from './agent/local-models';
 import { googleBridge, imagegenBridge } from './integrations/google-imagegen';
 import {
   appStateBridge,
@@ -263,6 +264,7 @@ export const seroPreloadApi = {
   appControl: appControlBridge,
 
   models: modelsBridge,
+  localModels: localModelsBridge,
 
   google: googleBridge,
   imagegen: imagegenBridge,

--- a/apps/desktop/electron/shared/infra/shared-infra.ts
+++ b/apps/desktop/electron/shared/infra/shared-infra.ts
@@ -141,7 +141,7 @@ export function applyRuntimeSettings(
 export async function ensureInfra(): Promise<SharedInfra> {
   if (!_authStorage) {
     _authStorage = AuthStorage.create(`${SERO_AGENT_DIR}/auth.json`);
-    _modelRegistry = new ModelRegistry(_authStorage);
+    _modelRegistry = new ModelRegistry(_authStorage, `${SERO_AGENT_DIR}/models.json`);
     _settingsManager = SettingsManager.create(
       SERO_AGENT_DIR,
       SERO_AGENT_DIR,

--- a/apps/desktop/electron/shared/settings/model-fallback-chain.ts
+++ b/apps/desktop/electron/shared/settings/model-fallback-chain.ts
@@ -1,0 +1,70 @@
+/**
+ * Helpers for Sero's configurable model fallback chain in settings.json.
+ *
+ * Runtime selection reads only from settings.json. On startup, Sero seeds a
+ * sensible default chain if the setting is missing so users can override it.
+ */
+
+const DEFAULT_FALLBACK_CHAIN = [
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+  'gpt-5.4',
+  'gpt-5',
+  'gemini-3-flash-preview',
+  'gemini-3-flash',
+  'gemini-2.5-flash',
+] as const;
+
+function normalizeFallbackChain(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== 'string') continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const raw = settings.sero;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return { ...(raw as Record<string, unknown>) };
+  }
+  return {};
+}
+
+export function getDefaultModelFallbackChain(): string[] {
+  return [...DEFAULT_FALLBACK_CHAIN];
+}
+
+export function getConfiguredModelFallbackChain(settings: Record<string, unknown>): string[] {
+  const sero = getSeroSettings(settings);
+  return normalizeFallbackChain(sero.modelFallbackChain);
+}
+
+export function ensureConfiguredModelFallbackChain(settings: Record<string, unknown>): {
+  settings: Record<string, unknown>;
+  changed: boolean;
+} {
+  const sero = getSeroSettings(settings);
+  const currentChain = normalizeFallbackChain(sero.modelFallbackChain);
+  const nextChain = currentChain.length > 0 ? currentChain : getDefaultModelFallbackChain();
+
+  const nextSettings = {
+    ...settings,
+    sero: {
+      ...sero,
+      modelFallbackChain: nextChain,
+    },
+  };
+
+  const changed = JSON.stringify(sero.modelFallbackChain ?? null) !== JSON.stringify(nextChain);
+  return { settings: nextSettings, changed };
+}

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useMemo, useCallback, useRef, memo } from 'react';
-import { Search, Star, Eye, EyeOff, Layers, X } from 'lucide-react';
+import { Search, Star, Eye, EyeOff, Layers, X, Server } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
   Dialog,
@@ -16,6 +16,7 @@ import { useModelPreferences, modelKey } from '@/stores/model-preferences';
 import type { AvailableModelGroup, ManagerTab } from './types';
 import { ModelManagerProvider } from './ModelManagerProvider';
 import { ModelManagerItem } from './ModelManagerItem';
+import { LocalModelsPanel, useLocalModels } from './local-models';
 
 /** Filter groups by search query. */
 function filterManagerGroups(
@@ -41,6 +42,7 @@ const TAB_CONFIG: { id: ManagerTab; label: string; icon: typeof Star }[] = [
   { id: 'all', label: 'All Models', icon: Layers },
   { id: 'favourites', label: 'Favourites', icon: Star },
   { id: 'hidden', label: 'Hidden', icon: EyeOff },
+  { id: 'local', label: 'Local', icon: Server },
 ];
 
 interface ModelManagerDialogProps {
@@ -104,6 +106,9 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
   const ms = useFocusedModelState();
   const groups = ms?.availableModels ?? [];
 
+  const localModels = useLocalModels();
+  const localProviderCount = Object.keys(localModels.config?.providers ?? {}).length;
+
   const prefs = useModelPreferences();
   const { toggleFavourite, toggleHidden, toggleProviderHidden, hideAll, showAll } = prefs;
 
@@ -166,8 +171,9 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
       all: groups.reduce((n, g) => n + g.models.length, 0),
       favourites: prefs.favouriteModels.length,
       hidden: hiddenSet.size,
+      local: localProviderCount,
     };
-  }, [groups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders]);
+  }, [groups, prefs.favouriteModels, prefs.hiddenModels, prefs.hiddenProviders, localProviderCount]);
 
   // Bulk actions — "Hide all" skips favourited models, "Hide all incl.
   // favourites" hides everything. Both respect the search filter.
@@ -205,11 +211,12 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
       if (nextOpen) {
         setFilter('');
         setActiveTab('all');
+        localModels.reload();
         requestAnimationFrame(() => inputRef.current?.focus());
       }
       onOpenChange(nextOpen);
     },
-    [onOpenChange],
+    [onOpenChange, localModels],
   );
 
   const displayGroups =
@@ -259,119 +266,130 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
         {/* Tabs + Search */}
         <div className="flex flex-col gap-3 border-b border-[var(--border-subtle)] px-4 py-3">
           <TabBar activeTab={activeTab} onTabChange={setActiveTab} counts={counts} />
-          <div className="flex items-center gap-2 rounded-lg bg-[var(--bg-base)] px-3">
-            <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
-            <input
-              ref={inputRef}
-              value={filter}
-              onChange={(e) => setFilter(e.target.value)}
-              placeholder="Search models, providers…"
-              className="h-8 w-full bg-transparent text-xs text-[var(--text-primary)]
-                placeholder:text-[var(--text-muted)] outline-none"
-            />
-            {filter && (
-              <button
-                onClick={() => setFilter('')}
-                className="rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-              >
-                <X className="size-3" />
-              </button>
-            )}
-          </div>
+          {activeTab !== 'local' && (
+            <div className="flex items-center gap-2 rounded-lg bg-[var(--bg-base)] px-3">
+              <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+              <input
+                ref={inputRef}
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                placeholder="Search models, providers…"
+                className="h-8 w-full bg-transparent text-xs text-[var(--text-primary)]
+                  placeholder:text-[var(--text-muted)] outline-none"
+              />
+              {filter && (
+                <button
+                  onClick={() => setFilter('')}
+                  className="rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                >
+                  <X className="size-3" />
+                </button>
+              )}
+            </div>
+          )}
         </div>
 
-        {/* Bulk actions bar — context-sensitive per tab */}
-        {activeTab === 'all' && displayGroups.length > 0 && (
-          <div className="flex items-center justify-end gap-1 border-b border-[var(--border-subtle)] px-4 py-1.5">
-            <button
-              onClick={handleHideAll}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
-                text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
-                hover:text-[var(--text-secondary)]"
-            >
-              <EyeOff className="size-3" />
-              {filter ? 'Hide matches' : 'Hide all'}
-            </button>
-            {hasFavouritesInView && (
-              <button
-                onClick={handleHideAllIncludingFavourites}
-                className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
-                  text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
-                  hover:text-[var(--text-secondary)]"
-              >
-                <EyeOff className="size-3" />
-                {filter ? 'incl. favourites' : 'Hide all incl. favourites'}
-              </button>
+        {/* Local tab: full custom panel, no search/bulk actions */}
+        {activeTab === 'local' ? (
+          <div className="max-h-[400px] min-h-[200px] overflow-y-auto">
+            <LocalModelsPanel localModels={localModels} />
+          </div>
+        ) : (
+          <>
+            {/* Bulk actions bar — context-sensitive per tab */}
+            {activeTab === 'all' && displayGroups.length > 0 && (
+              <div className="flex items-center justify-end gap-1 border-b border-[var(--border-subtle)] px-4 py-1.5">
+                <button
+                  onClick={handleHideAll}
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
+                    text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
+                    hover:text-[var(--text-secondary)]"
+                >
+                  <EyeOff className="size-3" />
+                  {filter ? 'Hide matches' : 'Hide all'}
+                </button>
+                {hasFavouritesInView && (
+                  <button
+                    onClick={handleHideAllIncludingFavourites}
+                    className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
+                      text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
+                      hover:text-[var(--text-secondary)]"
+                  >
+                    <EyeOff className="size-3" />
+                    {filter ? 'incl. favourites' : 'Hide all incl. favourites'}
+                  </button>
+                )}
+              </div>
             )}
-          </div>
-        )}
-        {activeTab === 'hidden' && displayGroups.length > 0 && (
-          <div className="flex items-center justify-end border-b border-[var(--border-subtle)] px-4 py-1.5">
-            <button
-              onClick={handleShowAll}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
-                text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
-                hover:text-[var(--text-secondary)]"
-            >
-              <Eye className="size-3" />
-              Show all
-            </button>
-          </div>
-        )}
+            {activeTab === 'hidden' && displayGroups.length > 0 && (
+              <div className="flex items-center justify-end border-b border-[var(--border-subtle)] px-4 py-1.5">
+                <button
+                  onClick={handleShowAll}
+                  className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium
+                    text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)]
+                    hover:text-[var(--text-secondary)]"
+                >
+                  <Eye className="size-3" />
+                  Show all
+                </button>
+              </div>
+            )}
 
-        {/* Model list */}
-        <div className="max-h-[400px] min-h-[200px] overflow-y-auto px-2 py-1">
-          <AnimatePresence mode="popLayout">
-            {displayGroups.length === 0 ? (
-              <motion.div
-                key="empty"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="flex items-center justify-center px-4 py-10 text-center text-xs text-[var(--text-muted)]"
-              >
-                {emptyMessage}
-              </motion.div>
-            ) : activeTab === 'favourites' ? (
-              // Flat list for favourites tab — no provider grouping
-              favouriteGroups.flatMap((group) =>
-                group.models.map((model) => {
-                  const key = modelKey(model.provider, model.modelId);
-                  return (
-                    <ModelManagerItem
-                      key={key}
-                      model={model}
-                      providerLogo={group.logo}
-                      providerName={group.displayName}
-                      isFavourite={isFavourite(key)}
-                      isHidden={isProviderHidden(group.provider) || isHidden(key)}
-                      isHiddenByProvider={isProviderHidden(group.provider)}
-                      onToggleFavourite={toggleFavourite}
-                      onToggleHidden={toggleHidden}
-                    />
-                  );
-                }),
-              )
-            ) : (
-              displayGroups.map((group, i) => (
-                <div key={group.provider}>
-                  {i > 0 && (
-                    <div className="mx-3 my-1 border-t border-[var(--border-subtle)]" />
-                  )}
-                  <ModelManagerProvider
-                    group={group}
-                    isProviderHidden={isProviderHidden(group.provider)}
-                    isFavourite={isFavourite}
-                    isHidden={isHidden}
-                    onToggleFavourite={toggleFavourite}
-                    onToggleHidden={toggleHidden}
-                    onToggleProvider={toggleProviderHidden}
-                  />
-                </div>
-              ))
-            )}
-          </AnimatePresence>
-        </div>
+            {/* Model list */}
+            <div className="max-h-[400px] min-h-[200px] overflow-y-auto px-2 py-1">
+              <AnimatePresence mode="popLayout">
+                {displayGroups.length === 0 ? (
+                  <motion.div
+                    key="empty"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    className="flex items-center justify-center px-4 py-10 text-center text-xs text-[var(--text-muted)]"
+                  >
+                    {emptyMessage}
+                  </motion.div>
+                ) : activeTab === 'favourites' ? (
+                  // Flat list for favourites tab — no provider grouping
+                  favouriteGroups.flatMap((group) =>
+                    group.models.map((model) => {
+                      const key = modelKey(model.provider, model.modelId);
+                      return (
+                        <ModelManagerItem
+                          key={key}
+                          model={model}
+                          providerLogo={group.logo}
+                          providerName={group.displayName}
+                          isFavourite={isFavourite(key)}
+                          isHidden={isProviderHidden(group.provider) || isHidden(key)}
+                          isHiddenByProvider={isProviderHidden(group.provider)}
+                          onToggleFavourite={toggleFavourite}
+                          onToggleHidden={toggleHidden}
+                        />
+                      );
+                    }),
+                  )
+                ) : (
+                  displayGroups.map((group, i) => (
+                    <div key={group.provider}>
+                      {i > 0 && (
+                        <div className="mx-3 my-1 border-t border-[var(--border-subtle)]" />
+                      )}
+                      <ModelManagerProvider
+                        group={group}
+                        isProviderHidden={isProviderHidden(group.provider)}
+                        isFavourite={isFavourite}
+                        isHidden={isHidden}
+                        onToggleFavourite={toggleFavourite}
+                        onToggleHidden={toggleHidden}
+                        onToggleProvider={toggleProviderHidden}
+                      />
+                    </div>
+                  ))
+                )}
+              </AnimatePresence>
+            </div>
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
+++ b/apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx
@@ -3,7 +3,7 @@
  * and favourites. Opened from the ModelSelector gear icon.
  */
 
-import { useState, useMemo, useCallback, useRef, memo } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect, memo } from 'react';
 import { Search, Star, Eye, EyeOff, Layers, X, Server } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
@@ -11,7 +11,8 @@ import {
   DialogContent,
   DialogTitle,
 } from '@sero-ai/ui/components/ui/dialog';
-import { useFocusedModelState } from '@/stores/agent-selectors';
+import { useAgentStore } from '@/stores/agent';
+import { useFocusedModelState, useFocusedSessionId } from '@/stores/agent-selectors';
 import { useModelPreferences, modelKey } from '@/stores/model-preferences';
 import type { AvailableModelGroup, ManagerTab } from './types';
 import { ModelManagerProvider } from './ModelManagerProvider';
@@ -104,9 +105,16 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
   const inputRef = useRef<HTMLInputElement>(null);
 
   const ms = useFocusedModelState();
+  const focusedSessionId = useFocusedSessionId();
+  const fetchModelState = useAgentStore((s) => s.fetchModelState);
   const groups = ms?.availableModels ?? [];
 
-  const localModels = useLocalModels();
+  const refreshFocusedModels = useCallback(async () => {
+    if (!focusedSessionId) return;
+    await fetchModelState(focusedSessionId);
+  }, [focusedSessionId, fetchModelState]);
+
+  const localModels = useLocalModels({ onSaved: refreshFocusedModels });
   const localProviderCount = Object.keys(localModels.config?.providers ?? {}).length;
 
   const prefs = useModelPreferences();
@@ -206,17 +214,19 @@ export function ModelManagerDialog({ open, onOpenChange }: ModelManagerDialogPro
     showAll();
   }, [showAll]);
 
+  useEffect(() => {
+    if (!open) return;
+    setFilter('');
+    setActiveTab('all');
+    void localModels.reload();
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, [open, localModels.reload]);
+
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
-      if (nextOpen) {
-        setFilter('');
-        setActiveTab('all');
-        localModels.reload();
-        requestAnimationFrame(() => inputRef.current?.focus());
-      }
       onOpenChange(nextOpen);
     },
-    [onOpenChange, localModels],
+    [onOpenChange],
   );
 
   const displayGroups =

--- a/apps/desktop/src/components/layout/model-manager/local-models/LocalModelsPanel.tsx
+++ b/apps/desktop/src/components/layout/model-manager/local-models/LocalModelsPanel.tsx
@@ -1,0 +1,243 @@
+/**
+ * Local models management panel — shows configured local LLM providers
+ * and allows adding, editing, and removing them.
+ *
+ * Appears as the "Local" tab in the Model Manager dialog.
+ */
+
+import { useState, useCallback, memo } from 'react';
+import { Plus, Settings2, Trash2, Server, ChevronRight } from 'lucide-react';
+import { motion, AnimatePresence } from 'motion/react';
+import type { LocalProviderConfig } from '@/types/local-models';
+import type { UseLocalModelsReturn } from './use-local-models';
+import { LocalProviderForm } from './LocalProviderForm';
+
+interface LocalModelsPanelProps {
+  localModels: UseLocalModelsReturn;
+}
+
+/** A single configured provider row. */
+const ProviderRow = memo(function ProviderRow({
+  name,
+  config,
+  onEdit,
+  onRemove,
+}: {
+  name: string;
+  config: LocalProviderConfig;
+  onEdit: (name: string) => void;
+  onRemove: (name: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="rounded-lg border border-[var(--border-subtle)] transition-colors hover:border-[var(--border-default)]">
+      {/* Provider header */}
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <button
+          onClick={() => setExpanded((p) => !p)}
+          className="flex flex-1 items-center gap-2.5 text-left"
+        >
+          <Server className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="truncate text-xs font-medium text-[var(--text-primary)]">{name}</span>
+            <span className="truncate text-[10px] text-[var(--text-muted)]">{config.baseUrl}</span>
+          </div>
+          <span className="shrink-0 rounded-full bg-[var(--bg-muted)] px-1.5 py-px text-[10px] font-semibold text-[var(--text-muted)]">
+            {config.models.length} {config.models.length === 1 ? 'model' : 'models'}
+          </span>
+          <motion.div animate={{ rotate: expanded ? 90 : 0 }} transition={{ duration: 0.15 }}>
+            <ChevronRight className="size-3 text-[var(--text-muted)]" />
+          </motion.div>
+        </button>
+
+        <div className="flex items-center gap-0.5">
+          <button
+            onClick={() => onEdit(name)}
+            title="Edit provider"
+            className="rounded-md p-1 text-[var(--text-muted)] transition-colors
+              hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+          >
+            <Settings2 className="size-3.5" />
+          </button>
+          <button
+            onClick={() => onRemove(name)}
+            title="Remove provider"
+            className="rounded-md p-1 text-[var(--text-muted)] transition-colors
+              hover:bg-[var(--bg-elevated)] hover:text-[var(--status-error)]"
+          >
+            <Trash2 className="size-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded model list */}
+      <AnimatePresence initial={false}>
+        {expanded && config.models.length > 0 && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="overflow-hidden border-t border-[var(--border-subtle)]"
+          >
+            <div className="px-3 py-1.5">
+              {config.models.map((m) => (
+                <div key={m.id} className="flex items-center gap-2 py-1">
+                  <div className="size-1.5 rounded-full bg-[var(--border-default)]" />
+                  <span className="text-xs text-[var(--text-secondary)]">{m.name ?? m.id}</span>
+                  {m.reasoning && (
+                    <span className="text-[10px] text-[var(--status-warning)]">reasoning</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+});
+
+export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
+  const { config, loading, error } = localModels;
+  const [view, setView] = useState<'list' | 'add' | 'edit'>('list');
+  const [editingProvider, setEditingProvider] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+
+  const providers = config?.providers ?? {};
+  const providerNames = Object.keys(providers);
+
+  const handleEdit = useCallback((name: string) => {
+    setEditingProvider(name);
+    setView('edit');
+  }, []);
+
+  const handleRemove = useCallback(async (name: string) => {
+    if (confirmRemove === name) {
+      await localModels.removeProvider(name);
+      setConfirmRemove(null);
+    } else {
+      setConfirmRemove(name);
+      // Auto-clear confirmation after 3s
+      setTimeout(() => setConfirmRemove((cur) => cur === name ? null : cur), 3000);
+    }
+  }, [confirmRemove, localModels]);
+
+  const handleSaveProvider = useCallback(async (name: string, providerConfig: LocalProviderConfig) => {
+    if (view === 'edit' && editingProvider) {
+      if (editingProvider !== name) {
+        await localModels.renameProvider(editingProvider, name);
+      }
+      await localModels.updateProvider(name, providerConfig);
+    } else {
+      await localModels.addProvider(name, providerConfig);
+    }
+    setView('list');
+    setEditingProvider(null);
+  }, [view, editingProvider, localModels]);
+
+  const handleCancel = useCallback(() => {
+    setView('list');
+    setEditingProvider(null);
+  }, []);
+
+  // Show form when adding/editing
+  if (view === 'add' || view === 'edit') {
+    const existing = view === 'edit' && editingProvider && providers[editingProvider]
+      ? { name: editingProvider, config: providers[editingProvider] }
+      : null;
+
+    return (
+      <LocalProviderForm
+        existing={existing}
+        existingNames={providerNames}
+        onSave={handleSaveProvider}
+        onCancel={handleCancel}
+        onTestConnection={localModels.testConnection}
+        onFetchModels={localModels.fetchRemoteModels}
+      />
+    );
+  }
+
+  // List view
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      {/* Header + Add button */}
+      <div className="flex items-center justify-between">
+        <p className="text-[11px] text-[var(--text-muted)]">
+          {providerNames.length === 0
+            ? 'Add a local LLM server to use models from Ollama, LM Studio, vLLM, or any OpenAI-compatible endpoint.'
+            : `${providerNames.length} local ${providerNames.length === 1 ? 'provider' : 'providers'} configured`}
+        </p>
+        <button
+          onClick={() => setView('add')}
+          className="flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-subtle)]
+            px-2.5 text-[11px] font-medium text-[var(--text-secondary)]
+            transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <Plus className="size-3" />
+          Add Provider
+        </button>
+      </div>
+
+      {/* Loading / error states */}
+      {loading && (
+        <div className="py-6 text-center text-xs text-[var(--text-muted)]">Loading...</div>
+      )}
+      {error && (
+        <div className="rounded-lg bg-[var(--status-error)]/10 px-3 py-2 text-xs text-[var(--status-error)]">
+          {error}
+        </div>
+      )}
+
+      {/* Provider list */}
+      {!loading && providerNames.length === 0 && (
+        <EmptyState onAdd={() => setView('add')} />
+      )}
+
+      {!loading && providerNames.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {providerNames.map((name) => (
+            <div key={name}>
+              <ProviderRow
+                name={name}
+                config={providers[name]}
+                onEdit={handleEdit}
+                onRemove={handleRemove}
+              />
+              {confirmRemove === name && (
+                <p className="mt-1 text-center text-[10px] text-[var(--status-error)]">
+                  Click remove again to confirm
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-8">
+      <Server className="size-8 text-[var(--text-muted)]/40" />
+      <div className="text-center">
+        <p className="text-xs font-medium text-[var(--text-secondary)]">No local providers</p>
+        <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+          Connect Ollama, LM Studio, vLLM, or any OpenAI-compatible server
+        </p>
+      </div>
+      <button
+        onClick={onAdd}
+        className="flex h-8 items-center gap-1.5 rounded-md bg-[var(--banner-primary)]
+          px-3 text-xs font-medium text-white transition-colors
+          hover:bg-[var(--banner-primary)]/80"
+      >
+        <Plus className="size-3.5" />
+        Add Provider
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/model-manager/local-models/LocalModelsPanel.tsx
+++ b/apps/desktop/src/components/layout/model-manager/local-models/LocalModelsPanel.tsx
@@ -6,14 +6,19 @@
  */
 
 import { useState, useCallback, memo } from 'react';
-import { Plus, Settings2, Trash2, Server, ChevronRight } from 'lucide-react';
+import { Plus, RefreshCw, Settings2, Trash2, Server, ChevronRight } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
+import { useDebouncedCallback } from '@/hooks/useDebouncedCallback';
 import type { LocalProviderConfig } from '@/types/local-models';
 import type { UseLocalModelsReturn } from './use-local-models';
 import { LocalProviderForm } from './LocalProviderForm';
 
 interface LocalModelsPanelProps {
   localModels: UseLocalModelsReturn;
+}
+
+function getProviderModels(config: LocalProviderConfig) {
+  return config.models ?? [];
 }
 
 /** A single configured provider row. */
@@ -29,6 +34,7 @@ const ProviderRow = memo(function ProviderRow({
   onRemove: (name: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const models = getProviderModels(config);
 
   return (
     <div className="rounded-lg border border-[var(--border-subtle)] transition-colors hover:border-[var(--border-default)]">
@@ -41,10 +47,12 @@ const ProviderRow = memo(function ProviderRow({
           <Server className="size-3.5 shrink-0 text-[var(--text-muted)]" />
           <div className="flex min-w-0 flex-1 flex-col">
             <span className="truncate text-xs font-medium text-[var(--text-primary)]">{name}</span>
-            <span className="truncate text-[10px] text-[var(--text-muted)]">{config.baseUrl}</span>
+            <span className="truncate text-[10px] text-[var(--text-muted)]">
+              {config.baseUrl ?? 'Override-only provider'}
+            </span>
           </div>
           <span className="shrink-0 rounded-full bg-[var(--bg-muted)] px-1.5 py-px text-[10px] font-semibold text-[var(--text-muted)]">
-            {config.models.length} {config.models.length === 1 ? 'model' : 'models'}
+            {models.length} {models.length === 1 ? 'model' : 'models'}
           </span>
           <motion.div animate={{ rotate: expanded ? 90 : 0 }} transition={{ duration: 0.15 }}>
             <ChevronRight className="size-3 text-[var(--text-muted)]" />
@@ -73,7 +81,7 @@ const ProviderRow = memo(function ProviderRow({
 
       {/* Expanded model list */}
       <AnimatePresence initial={false}>
-        {expanded && config.models.length > 0 && (
+        {expanded && models.length > 0 && (
           <motion.div
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
@@ -82,7 +90,7 @@ const ProviderRow = memo(function ProviderRow({
             className="overflow-hidden border-t border-[var(--border-subtle)]"
           >
             <div className="px-3 py-1.5">
-              {config.models.map((m) => (
+              {models.map((m) => (
                 <div key={m.id} className="flex items-center gap-2 py-1">
                   <div className="size-1.5 rounded-full bg-[var(--border-default)]" />
                   <span className="text-xs text-[var(--text-secondary)]">{m.name ?? m.id}</span>
@@ -105,6 +113,10 @@ export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
 
+  const clearConfirmRemove = useDebouncedCallback((name: string) => {
+    setConfirmRemove((current) => current === name ? null : current);
+  }, 3000);
+
   const providers = config?.providers ?? {};
   const providerNames = Object.keys(providers);
 
@@ -117,12 +129,11 @@ export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
     if (confirmRemove === name) {
       await localModels.removeProvider(name);
       setConfirmRemove(null);
-    } else {
-      setConfirmRemove(name);
-      // Auto-clear confirmation after 3s
-      setTimeout(() => setConfirmRemove((cur) => cur === name ? null : cur), 3000);
+      return;
     }
-  }, [confirmRemove, localModels]);
+    setConfirmRemove(name);
+    clearConfirmRemove(name);
+  }, [clearConfirmRemove, confirmRemove, localModels]);
 
   const handleSaveProvider = useCallback(async (name: string, providerConfig: LocalProviderConfig) => {
     if (view === 'edit' && editingProvider) {
@@ -135,12 +146,16 @@ export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
     }
     setView('list');
     setEditingProvider(null);
-  }, [view, editingProvider, localModels]);
+  }, [editingProvider, localModels, view]);
 
   const handleCancel = useCallback(() => {
     setView('list');
     setEditingProvider(null);
   }, []);
+
+  if (error) {
+    return <ErrorState error={error} onRetry={localModels.reload} />;
+  }
 
   // Show form when adding/editing
   if (view === 'add' || view === 'edit') {
@@ -164,7 +179,7 @@ export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
   return (
     <div className="flex flex-col gap-3 p-3">
       {/* Header + Add button */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <p className="text-[11px] text-[var(--text-muted)]">
           {providerNames.length === 0
             ? 'Add a local LLM server to use models from Ollama, LM Studio, vLLM, or any OpenAI-compatible endpoint.'
@@ -172,7 +187,7 @@ export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
         </p>
         <button
           onClick={() => setView('add')}
-          className="flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-subtle)]
+          className="flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-[var(--border-subtle)]
             px-2.5 text-[11px] font-medium text-[var(--text-secondary)]
             transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
         >
@@ -181,17 +196,10 @@ export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
         </button>
       </div>
 
-      {/* Loading / error states */}
       {loading && (
         <div className="py-6 text-center text-xs text-[var(--text-muted)]">Loading...</div>
       )}
-      {error && (
-        <div className="rounded-lg bg-[var(--status-error)]/10 px-3 py-2 text-xs text-[var(--status-error)]">
-          {error}
-        </div>
-      )}
 
-      {/* Provider list */}
       {!loading && providerNames.length === 0 && (
         <EmptyState onAdd={() => setView('add')} />
       )}
@@ -215,6 +223,28 @@ export function LocalModelsPanel({ localModels }: LocalModelsPanelProps) {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function ErrorState({ error, onRetry }: { error: string; onRetry: () => Promise<void> }) {
+  return (
+    <div className="flex flex-col gap-3 p-3">
+      <div className="rounded-lg bg-[var(--status-error)]/10 px-3 py-2 text-xs text-[var(--status-error)]">
+        {error}
+      </div>
+      <p className="text-[11px] text-[var(--text-muted)]">
+        Fix the invalid models.json entry before adding or editing providers here.
+      </p>
+      <button
+        onClick={() => { void onRetry(); }}
+        className="flex h-8 items-center gap-1.5 self-start rounded-md border border-[var(--border-subtle)]
+          px-3 text-xs font-medium text-[var(--text-secondary)] transition-colors
+          hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+      >
+        <RefreshCw className="size-3.5" />
+        Retry
+      </button>
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/model-manager/local-models/LocalProviderForm.tsx
+++ b/apps/desktop/src/components/layout/model-manager/local-models/LocalProviderForm.tsx
@@ -8,8 +8,11 @@ import { ArrowLeft, Loader2, CheckCircle2, XCircle, Plus, Download } from 'lucid
 import type {
   LocalProviderConfig,
   LocalModelApi,
+  LocalModelCompat,
   LocalModelEntry,
+  LocalModelsConnectionRequest,
   LocalProviderPreset,
+  LocalRemoteModelInfo,
 } from '@/types/local-models';
 import { PROVIDER_PRESETS, PRESET_ORDER } from './presets';
 
@@ -27,8 +30,39 @@ interface LocalProviderFormProps {
   existingNames: string[];
   onSave: (name: string, config: LocalProviderConfig) => Promise<void>;
   onCancel: () => void;
-  onTestConnection: (baseUrl: string) => Promise<{ ok: boolean; error?: string }>;
-  onFetchModels: (baseUrl: string) => Promise<{ id: string; name?: string }[]>;
+  onTestConnection: (request: LocalModelsConnectionRequest) => Promise<{ ok: boolean; error?: string }>;
+  onFetchModels: (request: LocalModelsConnectionRequest) => Promise<LocalRemoteModelInfo[]>;
+}
+
+function hasAdvancedCompat(compat?: LocalModelCompat): boolean {
+  if (!compat) return false;
+  return Object.keys(compat).some(
+    (key) => key !== 'supportsDeveloperRole' && key !== 'supportsReasoningEffort',
+  );
+}
+
+function hasAdvancedSettings(config?: LocalProviderConfig | null): boolean {
+  if (!config) return false;
+  if (config.headers || config.authHeader || config.modelOverrides || hasAdvancedCompat(config.compat)) {
+    return true;
+  }
+  return (config.models ?? []).some((model) => !!model.headers || hasAdvancedCompat(model.compat));
+}
+
+function buildCompat(
+  existingCompat: LocalModelCompat | undefined,
+  supportsDeveloperRole: boolean,
+  supportsReasoningEffort: boolean,
+): LocalModelCompat | undefined {
+  const compat: LocalModelCompat = { ...(existingCompat ?? {}) };
+
+  if (supportsDeveloperRole) delete compat.supportsDeveloperRole;
+  else compat.supportsDeveloperRole = false;
+
+  if (supportsReasoningEffort) delete compat.supportsReasoningEffort;
+  else compat.supportsReasoningEffort = false;
+
+  return Object.keys(compat).length > 0 ? compat : undefined;
 }
 
 export function LocalProviderForm({
@@ -40,18 +74,20 @@ export function LocalProviderForm({
   onFetchModels,
 }: LocalProviderFormProps) {
   const isEditing = !!existing;
+  const existingConfig = existing?.config;
+  const showsAdvancedNotice = hasAdvancedSettings(existingConfig);
 
   const [name, setName] = useState(existing?.name ?? '');
-  const [baseUrl, setBaseUrl] = useState(existing?.config.baseUrl ?? '');
-  const [api, setApi] = useState<LocalModelApi>(existing?.config.api ?? 'openai-completions');
-  const [apiKey, setApiKey] = useState(existing?.config.apiKey ?? '');
+  const [baseUrl, setBaseUrl] = useState(existingConfig?.baseUrl ?? '');
+  const [api, setApi] = useState<LocalModelApi>(existingConfig?.api ?? 'openai-completions');
+  const [apiKey, setApiKey] = useState(existingConfig?.apiKey ?? '');
   const [supportsDeveloperRole, setSupportsDeveloperRole] = useState(
-    existing?.config.compat?.supportsDeveloperRole ?? true,
+    existingConfig?.compat?.supportsDeveloperRole ?? true,
   );
   const [supportsReasoningEffort, setSupportsReasoningEffort] = useState(
-    existing?.config.compat?.supportsReasoningEffort ?? true,
+    existingConfig?.compat?.supportsReasoningEffort ?? true,
   );
-  const [models, setModels] = useState<LocalModelEntry[]>(existing?.config.models ?? []);
+  const [models, setModels] = useState<LocalModelEntry[]>(existingConfig?.models ?? []);
   const [newModelId, setNewModelId] = useState('');
 
   const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'ok' | 'error'>('idle');
@@ -59,6 +95,14 @@ export function LocalProviderForm({
   const [fetchingModels, setFetchingModels] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
+
+  const buildConnectionRequest = useCallback((): LocalModelsConnectionRequest => ({
+    baseUrl: baseUrl.trim(),
+    api,
+    apiKey: apiKey.trim() || undefined,
+    headers: existingConfig?.headers,
+    authHeader: existingConfig?.authHeader,
+  }), [api, apiKey, baseUrl, existingConfig]);
 
   const applyPreset = useCallback((preset: LocalProviderPreset) => {
     const cfg = PROVIDER_PRESETS[preset];
@@ -73,40 +117,52 @@ export function LocalProviderForm({
     setSupportsDeveloperRole(cfg.compat?.supportsDeveloperRole ?? true);
     setSupportsReasoningEffort(cfg.compat?.supportsReasoningEffort ?? true);
     setConnectionStatus('idle');
+    setConnectionError(null);
   }, [name]);
 
   const handleTestConnection = useCallback(async () => {
-    if (!baseUrl) return;
+    if (!baseUrl.trim()) return;
     setConnectionStatus('testing');
     setConnectionError(null);
-    const result = await onTestConnection(baseUrl);
-    setConnectionStatus(result.ok ? 'ok' : 'error');
-    setConnectionError(result.error ?? null);
-  }, [baseUrl, onTestConnection]);
+    try {
+      const result = await onTestConnection(buildConnectionRequest());
+      setConnectionStatus(result.ok ? 'ok' : 'error');
+      setConnectionError(result.error ?? null);
+    } catch (err) {
+      setConnectionStatus('error');
+      setConnectionError(err instanceof Error ? err.message : String(err));
+    }
+  }, [baseUrl, buildConnectionRequest, onTestConnection]);
 
   const handleFetchModels = useCallback(async () => {
-    if (!baseUrl) return;
+    if (!baseUrl.trim()) return;
     setFetchingModels(true);
-    const remote = await onFetchModels(baseUrl);
-    if (remote.length > 0) {
-      const existingIds = new Set(models.map((m) => m.id));
-      const newModels = remote.filter((m) => !existingIds.has(m.id));
-      if (newModels.length > 0) {
-        setModels((prev) => [
-          ...prev,
-          ...newModels.map((m) => ({ id: m.id, name: m.name })),
-        ]);
+    setConnectionError(null);
+    try {
+      const remote = await onFetchModels(buildConnectionRequest());
+      if (remote.length > 0) {
+        const existingIds = new Set(models.map((m) => m.id));
+        const newModels = remote.filter((m) => !existingIds.has(m.id));
+        if (newModels.length > 0) {
+          setModels((prev) => [
+            ...prev,
+            ...newModels.map((m) => ({ id: m.id, name: m.name })),
+          ]);
+        }
       }
+    } catch (err) {
+      setConnectionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setFetchingModels(false);
     }
-    setFetchingModels(false);
-  }, [baseUrl, models, onFetchModels]);
+  }, [baseUrl, buildConnectionRequest, models, onFetchModels]);
 
   const handleAddModel = useCallback(() => {
     const id = newModelId.trim();
     if (!id || models.some((m) => m.id === id)) return;
     setModels((prev) => [...prev, { id }]);
     setNewModelId('');
-  }, [newModelId, models]);
+  }, [models, newModelId]);
 
   const handleRemoveModel = useCallback((id: string) => {
     setModels((prev) => prev.filter((m) => m.id !== id));
@@ -120,19 +176,18 @@ export function LocalProviderForm({
       return;
     }
 
-    const compat: LocalProviderConfig['compat'] =
-      !supportsDeveloperRole || !supportsReasoningEffort
-        ? {
-            ...(!supportsDeveloperRole ? { supportsDeveloperRole: false } : {}),
-            ...(!supportsReasoningEffort ? { supportsReasoningEffort: false } : {}),
-          }
-        : undefined;
+    const compat = buildCompat(
+      existingConfig?.compat,
+      supportsDeveloperRole,
+      supportsReasoningEffort,
+    );
 
     const config: LocalProviderConfig = {
-      baseUrl: baseUrl.trim(),
+      ...existingConfig,
+      baseUrl: baseUrl.trim() || undefined,
       api,
-      apiKey: apiKey.trim() || 'none',
-      ...(compat ? { compat } : {}),
+      apiKey: apiKey.trim() || undefined,
+      compat,
       models,
     };
 
@@ -144,7 +199,19 @@ export function LocalProviderForm({
       setSaveError(err instanceof Error ? err.message : String(err));
       setSaving(false);
     }
-  }, [name, baseUrl, api, apiKey, supportsDeveloperRole, supportsReasoningEffort, models, isEditing, existingNames, onSave]);
+  }, [
+    api,
+    apiKey,
+    baseUrl,
+    existingConfig,
+    existingNames,
+    isEditing,
+    models,
+    name,
+    onSave,
+    supportsDeveloperRole,
+    supportsReasoningEffort,
+  ]);
 
   const isValid = name.trim() && baseUrl.trim();
 
@@ -162,6 +229,12 @@ export function LocalProviderForm({
           {isEditing ? 'Edit Provider' : 'Add Local Provider'}
         </h3>
       </div>
+
+      {showsAdvancedNotice && (
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)] px-3 py-2 text-[11px] text-[var(--text-muted)]">
+          Advanced models.json fields are preserved on save, but they still need to be edited directly in the file.
+        </div>
+      )}
 
       {/* Presets */}
       {!isEditing && (
@@ -207,7 +280,11 @@ export function LocalProviderForm({
         <div className="flex gap-2">
           <input
             value={baseUrl}
-            onChange={(e) => { setBaseUrl(e.target.value); setConnectionStatus('idle'); }}
+            onChange={(e) => {
+              setBaseUrl(e.target.value);
+              setConnectionStatus('idle');
+              setConnectionError(null);
+            }}
             placeholder="http://localhost:11434/v1"
             className="h-8 flex-1 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-base)]
               px-2.5 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)]
@@ -250,7 +327,7 @@ export function LocalProviderForm({
       </Field>
 
       {/* API Key */}
-      <Field label="API Key" hint="Required but often ignored by local servers">
+      <Field label="API Key" hint="Literal value, env var name, or !command">
         <input
           value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}

--- a/apps/desktop/src/components/layout/model-manager/local-models/LocalProviderForm.tsx
+++ b/apps/desktop/src/components/layout/model-manager/local-models/LocalProviderForm.tsx
@@ -1,0 +1,402 @@
+/**
+ * Form for adding or editing a local LLM provider.
+ * Shows preset buttons for quick setup, connection test, and model fetching.
+ */
+
+import { useState, useCallback } from 'react';
+import { ArrowLeft, Loader2, CheckCircle2, XCircle, Plus, Download } from 'lucide-react';
+import type {
+  LocalProviderConfig,
+  LocalModelApi,
+  LocalModelEntry,
+  LocalProviderPreset,
+} from '@/types/local-models';
+import { PROVIDER_PRESETS, PRESET_ORDER } from './presets';
+
+const API_OPTIONS: { value: LocalModelApi; label: string }[] = [
+  { value: 'openai-completions', label: 'OpenAI Completions' },
+  { value: 'openai-responses', label: 'OpenAI Responses' },
+  { value: 'anthropic-messages', label: 'Anthropic Messages' },
+  { value: 'google-generative-ai', label: 'Google Generative AI' },
+];
+
+interface LocalProviderFormProps {
+  /** Existing provider to edit, or null for new. */
+  existing?: { name: string; config: LocalProviderConfig } | null;
+  /** Provider names already in use (for validation). */
+  existingNames: string[];
+  onSave: (name: string, config: LocalProviderConfig) => Promise<void>;
+  onCancel: () => void;
+  onTestConnection: (baseUrl: string) => Promise<{ ok: boolean; error?: string }>;
+  onFetchModels: (baseUrl: string) => Promise<{ id: string; name?: string }[]>;
+}
+
+export function LocalProviderForm({
+  existing,
+  existingNames,
+  onSave,
+  onCancel,
+  onTestConnection,
+  onFetchModels,
+}: LocalProviderFormProps) {
+  const isEditing = !!existing;
+
+  const [name, setName] = useState(existing?.name ?? '');
+  const [baseUrl, setBaseUrl] = useState(existing?.config.baseUrl ?? '');
+  const [api, setApi] = useState<LocalModelApi>(existing?.config.api ?? 'openai-completions');
+  const [apiKey, setApiKey] = useState(existing?.config.apiKey ?? '');
+  const [supportsDeveloperRole, setSupportsDeveloperRole] = useState(
+    existing?.config.compat?.supportsDeveloperRole ?? true,
+  );
+  const [supportsReasoningEffort, setSupportsReasoningEffort] = useState(
+    existing?.config.compat?.supportsReasoningEffort ?? true,
+  );
+  const [models, setModels] = useState<LocalModelEntry[]>(existing?.config.models ?? []);
+  const [newModelId, setNewModelId] = useState('');
+
+  const [connectionStatus, setConnectionStatus] = useState<'idle' | 'testing' | 'ok' | 'error'>('idle');
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [fetchingModels, setFetchingModels] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const applyPreset = useCallback((preset: LocalProviderPreset) => {
+    const cfg = PROVIDER_PRESETS[preset];
+    if (!name || name === PROVIDER_PRESETS.ollama.label.toLowerCase() ||
+        name === PROVIDER_PRESETS['lm-studio'].label.toLowerCase() ||
+        name === PROVIDER_PRESETS.vllm.label.toLowerCase()) {
+      setName(cfg.label.toLowerCase().replace(/\s+/g, '-'));
+    }
+    setBaseUrl(cfg.baseUrl);
+    setApi(cfg.api);
+    setApiKey(cfg.apiKey);
+    setSupportsDeveloperRole(cfg.compat?.supportsDeveloperRole ?? true);
+    setSupportsReasoningEffort(cfg.compat?.supportsReasoningEffort ?? true);
+    setConnectionStatus('idle');
+  }, [name]);
+
+  const handleTestConnection = useCallback(async () => {
+    if (!baseUrl) return;
+    setConnectionStatus('testing');
+    setConnectionError(null);
+    const result = await onTestConnection(baseUrl);
+    setConnectionStatus(result.ok ? 'ok' : 'error');
+    setConnectionError(result.error ?? null);
+  }, [baseUrl, onTestConnection]);
+
+  const handleFetchModels = useCallback(async () => {
+    if (!baseUrl) return;
+    setFetchingModels(true);
+    const remote = await onFetchModels(baseUrl);
+    if (remote.length > 0) {
+      const existingIds = new Set(models.map((m) => m.id));
+      const newModels = remote.filter((m) => !existingIds.has(m.id));
+      if (newModels.length > 0) {
+        setModels((prev) => [
+          ...prev,
+          ...newModels.map((m) => ({ id: m.id, name: m.name })),
+        ]);
+      }
+    }
+    setFetchingModels(false);
+  }, [baseUrl, models, onFetchModels]);
+
+  const handleAddModel = useCallback(() => {
+    const id = newModelId.trim();
+    if (!id || models.some((m) => m.id === id)) return;
+    setModels((prev) => [...prev, { id }]);
+    setNewModelId('');
+  }, [newModelId, models]);
+
+  const handleRemoveModel = useCallback((id: string) => {
+    setModels((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const trimmedName = name.trim().toLowerCase().replace(/\s+/g, '-');
+    if (!trimmedName) return;
+    if (!isEditing && existingNames.includes(trimmedName)) {
+      setSaveError(`Provider "${trimmedName}" already exists`);
+      return;
+    }
+
+    const compat: LocalProviderConfig['compat'] =
+      !supportsDeveloperRole || !supportsReasoningEffort
+        ? {
+            ...(!supportsDeveloperRole ? { supportsDeveloperRole: false } : {}),
+            ...(!supportsReasoningEffort ? { supportsReasoningEffort: false } : {}),
+          }
+        : undefined;
+
+    const config: LocalProviderConfig = {
+      baseUrl: baseUrl.trim(),
+      api,
+      apiKey: apiKey.trim() || 'none',
+      ...(compat ? { compat } : {}),
+      models,
+    };
+
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await onSave(trimmedName, config);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : String(err));
+      setSaving(false);
+    }
+  }, [name, baseUrl, api, apiKey, supportsDeveloperRole, supportsReasoningEffort, models, isEditing, existingNames, onSave]);
+
+  const isValid = name.trim() && baseUrl.trim();
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <button
+          onClick={onCancel}
+          className="rounded-md p-1 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+        >
+          <ArrowLeft className="size-4" />
+        </button>
+        <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+          {isEditing ? 'Edit Provider' : 'Add Local Provider'}
+        </h3>
+      </div>
+
+      {/* Presets */}
+      {!isEditing && (
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+            Quick Setup
+          </label>
+          <div className="grid grid-cols-4 gap-1.5">
+            {PRESET_ORDER.map((preset) => {
+              const cfg = PROVIDER_PRESETS[preset];
+              return (
+                <button
+                  key={preset}
+                  onClick={() => applyPreset(preset)}
+                  className="rounded-lg border border-[var(--border-subtle)] px-2 py-2
+                    text-center text-[11px] font-medium text-[var(--text-secondary)]
+                    transition-colors hover:border-[var(--border-default)]
+                    hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                >
+                  {cfg.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Provider Name */}
+      <Field label="Provider Name">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. ollama, lm-studio"
+          disabled={isEditing}
+          className="h-8 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--bg-base)]
+            px-2.5 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)]
+            outline-none focus:border-[var(--border-focus)] disabled:opacity-50"
+        />
+      </Field>
+
+      {/* Base URL + Test button */}
+      <Field label="Base URL">
+        <div className="flex gap-2">
+          <input
+            value={baseUrl}
+            onChange={(e) => { setBaseUrl(e.target.value); setConnectionStatus('idle'); }}
+            placeholder="http://localhost:11434/v1"
+            className="h-8 flex-1 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-base)]
+              px-2.5 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)]
+              outline-none focus:border-[var(--border-focus)]"
+          />
+          <button
+            onClick={handleTestConnection}
+            disabled={!baseUrl.trim() || connectionStatus === 'testing'}
+            className="flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-subtle)]
+              px-2.5 text-[11px] font-medium text-[var(--text-secondary)]
+              transition-colors hover:bg-[var(--bg-elevated)] disabled:opacity-40"
+          >
+            {connectionStatus === 'testing' ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : connectionStatus === 'ok' ? (
+              <CheckCircle2 className="size-3 text-[var(--status-success)]" />
+            ) : connectionStatus === 'error' ? (
+              <XCircle className="size-3 text-[var(--status-error)]" />
+            ) : null}
+            Test
+          </button>
+        </div>
+        {connectionError && (
+          <p className="mt-1 text-[10px] text-[var(--status-error)]">{connectionError}</p>
+        )}
+      </Field>
+
+      {/* API Type */}
+      <Field label="API Type">
+        <select
+          value={api}
+          onChange={(e) => setApi(e.target.value as LocalModelApi)}
+          className="h-8 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--bg-base)]
+            px-2 text-xs text-[var(--text-primary)] outline-none focus:border-[var(--border-focus)]"
+        >
+          {API_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </Field>
+
+      {/* API Key */}
+      <Field label="API Key" hint="Required but often ignored by local servers">
+        <input
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="ollama"
+          className="h-8 w-full rounded-md border border-[var(--border-subtle)] bg-[var(--bg-base)]
+            px-2.5 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)]
+            outline-none focus:border-[var(--border-focus)]"
+        />
+      </Field>
+
+      {/* Compatibility */}
+      <Field label="Compatibility">
+        <div className="flex flex-col gap-2">
+          <label className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+            <input
+              type="checkbox"
+              checked={supportsDeveloperRole}
+              onChange={(e) => setSupportsDeveloperRole(e.target.checked)}
+              className="rounded"
+            />
+            Supports developer role
+          </label>
+          <label className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+            <input
+              type="checkbox"
+              checked={supportsReasoningEffort}
+              onChange={(e) => setSupportsReasoningEffort(e.target.checked)}
+              className="rounded"
+            />
+            Supports reasoning effort
+          </label>
+        </div>
+      </Field>
+
+      {/* Models */}
+      <Field label="Models">
+        <div className="flex flex-col gap-2">
+          {/* Fetch button */}
+          <button
+            onClick={handleFetchModels}
+            disabled={!baseUrl.trim() || fetchingModels}
+            className="flex h-7 items-center gap-1.5 self-start rounded-md border
+              border-[var(--border-subtle)] px-2.5 text-[11px] font-medium
+              text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)]
+              disabled:opacity-40"
+          >
+            {fetchingModels ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <Download className="size-3" />
+            )}
+            Fetch from server
+          </button>
+
+          {/* Model list */}
+          {models.length > 0 && (
+            <div className="flex flex-col gap-1 rounded-lg border border-[var(--border-subtle)] p-1.5">
+              {models.map((m) => (
+                <div
+                  key={m.id}
+                  className="group flex items-center justify-between rounded-md px-2 py-1
+                    hover:bg-[var(--bg-elevated)]"
+                >
+                  <span className="text-xs text-[var(--text-primary)]">
+                    {m.name ?? m.id}
+                    {m.name && m.name !== m.id && (
+                      <span className="ml-1.5 text-[var(--text-muted)]">{m.id}</span>
+                    )}
+                  </span>
+                  <button
+                    onClick={() => handleRemoveModel(m.id)}
+                    className="text-[10px] text-[var(--text-muted)] opacity-0
+                      transition-opacity group-hover:opacity-100 hover:text-[var(--status-error)]"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Add model manually */}
+          <div className="flex gap-1.5">
+            <input
+              value={newModelId}
+              onChange={(e) => setNewModelId(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleAddModel()}
+              placeholder="Model ID (e.g. llama3.1:8b)"
+              className="h-7 flex-1 rounded-md border border-[var(--border-subtle)] bg-[var(--bg-base)]
+                px-2 text-xs text-[var(--text-primary)] placeholder:text-[var(--text-muted)]
+                outline-none focus:border-[var(--border-focus)]"
+            />
+            <button
+              onClick={handleAddModel}
+              disabled={!newModelId.trim()}
+              className="flex h-7 items-center gap-1 rounded-md border border-[var(--border-subtle)]
+                px-2 text-[11px] font-medium text-[var(--text-secondary)]
+                transition-colors hover:bg-[var(--bg-elevated)] disabled:opacity-40"
+            >
+              <Plus className="size-3" />
+              Add
+            </button>
+          </div>
+        </div>
+      </Field>
+
+      {/* Save / Cancel */}
+      {saveError && (
+        <p className="text-[11px] text-[var(--status-error)]">{saveError}</p>
+      )}
+      <div className="flex justify-end gap-2 border-t border-[var(--border-subtle)] pt-3">
+        <button
+          onClick={onCancel}
+          className="h-8 rounded-md px-3 text-xs font-medium text-[var(--text-secondary)]
+            transition-colors hover:bg-[var(--bg-elevated)]"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={!isValid || saving}
+          className="flex h-8 items-center gap-1.5 rounded-md bg-[var(--banner-primary)]
+            px-3 text-xs font-medium text-white transition-colors
+            hover:bg-[var(--banner-primary)]/80 disabled:opacity-40"
+        >
+          {saving && <Loader2 className="size-3 animate-spin" />}
+          {isEditing ? 'Save Changes' : 'Add Provider'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Reusable field wrapper. */
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline gap-2">
+        <label className="text-[11px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+          {label}
+        </label>
+        {hint && (
+          <span className="text-[10px] text-[var(--text-muted)]">{hint}</span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/model-manager/local-models/index.ts
+++ b/apps/desktop/src/components/layout/model-manager/local-models/index.ts
@@ -1,0 +1,2 @@
+export { LocalModelsPanel } from './LocalModelsPanel';
+export { useLocalModels } from './use-local-models';

--- a/apps/desktop/src/components/layout/model-manager/local-models/presets.ts
+++ b/apps/desktop/src/components/layout/model-manager/local-models/presets.ts
@@ -1,0 +1,50 @@
+/**
+ * Preset configurations for common local LLM servers.
+ */
+
+import type { LocalProviderPreset, LocalProviderPresetConfig } from '@/types/local-models';
+
+export const PROVIDER_PRESETS: Record<LocalProviderPreset, LocalProviderPresetConfig> = {
+  ollama: {
+    label: 'Ollama',
+    description: 'Local LLM server with model management',
+    baseUrl: 'http://localhost:11434/v1',
+    api: 'openai-completions',
+    apiKey: 'ollama',
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    },
+  },
+  'lm-studio': {
+    label: 'LM Studio',
+    description: 'Local model server with GUI',
+    baseUrl: 'http://localhost:1234/v1',
+    api: 'openai-completions',
+    apiKey: 'lm-studio',
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    },
+  },
+  vllm: {
+    label: 'vLLM',
+    description: 'High-throughput inference server',
+    baseUrl: 'http://localhost:8000/v1',
+    api: 'openai-completions',
+    apiKey: 'vllm',
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+    },
+  },
+  custom: {
+    label: 'Custom',
+    description: 'Any OpenAI-compatible server',
+    baseUrl: 'http://localhost:8080/v1',
+    api: 'openai-completions',
+    apiKey: 'none',
+  },
+};
+
+export const PRESET_ORDER: LocalProviderPreset[] = ['ollama', 'lm-studio', 'vllm', 'custom'];

--- a/apps/desktop/src/components/layout/model-manager/local-models/use-local-models.ts
+++ b/apps/desktop/src/components/layout/model-manager/local-models/use-local-models.ts
@@ -8,8 +8,10 @@
 import { useState, useCallback } from 'react';
 import type {
   LocalModelsConfig,
+  LocalModelsConnectionRequest,
   LocalProviderConfig,
   LocalModelEntry,
+  LocalRemoteModelInfo,
 } from '@/types/local-models';
 
 /** Load config from main process. */
@@ -20,6 +22,10 @@ async function loadConfig(): Promise<LocalModelsConfig> {
 /** Save config to main process (writes models.json + refreshes ModelRegistry). */
 async function saveConfig(config: LocalModelsConfig): Promise<void> {
   return window.sero.localModels.saveConfig(config);
+}
+
+export interface UseLocalModelsOptions {
+  onSaved?: () => Promise<void> | void;
 }
 
 export interface UseLocalModelsReturn {
@@ -34,14 +40,22 @@ export interface UseLocalModelsReturn {
   addModel: (providerName: string, model: LocalModelEntry) => Promise<void>;
   updateModel: (providerName: string, modelId: string, model: LocalModelEntry) => Promise<void>;
   removeModel: (providerName: string, modelId: string) => Promise<void>;
-  testConnection: (baseUrl: string) => Promise<{ ok: boolean; error?: string }>;
-  fetchRemoteModels: (baseUrl: string) => Promise<{ id: string; name?: string }[]>;
+  testConnection: (request: LocalModelsConnectionRequest) => Promise<{ ok: boolean; error?: string }>;
+  fetchRemoteModels: (request: LocalModelsConnectionRequest) => Promise<LocalRemoteModelInfo[]>;
 }
 
-export function useLocalModels(): UseLocalModelsReturn {
+export function useLocalModels(options: UseLocalModelsOptions = {}): UseLocalModelsReturn {
+  const { onSaved } = options;
   const [config, setConfig] = useState<LocalModelsConfig | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const getEditableConfig = useCallback((): LocalModelsConfig => {
+    if (error) {
+      throw new Error('Fix the existing models.json error before editing local providers.');
+    }
+    return config ?? { providers: {} };
+  }, [config, error]);
 
   const reload = useCallback(async () => {
     setLoading(true);
@@ -50,6 +64,7 @@ export function useLocalModels(): UseLocalModelsReturn {
       const cfg = await loadConfig();
       setConfig(cfg);
     } catch (err) {
+      setConfig(null);
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
@@ -59,85 +74,94 @@ export function useLocalModels(): UseLocalModelsReturn {
   const persist = useCallback(async (cfg: LocalModelsConfig) => {
     await saveConfig(cfg);
     setConfig(cfg);
-  }, []);
+    setError(null);
+    try {
+      await onSaved?.();
+    } catch (err) {
+      console.error('[local-models] post-save refresh failed:', err);
+    }
+  }, [onSaved]);
 
   const addProvider = useCallback(async (name: string, provider: LocalProviderConfig) => {
-    const cfg = config ?? { providers: {} };
+    const cfg = getEditableConfig();
     if (cfg.providers[name]) throw new Error(`Provider "${name}" already exists`);
     await persist({ providers: { ...cfg.providers, [name]: provider } });
-  }, [config, persist]);
+  }, [getEditableConfig, persist]);
 
   const updateProvider = useCallback(async (name: string, provider: LocalProviderConfig) => {
-    const cfg = config ?? { providers: {} };
+    const cfg = getEditableConfig();
     await persist({ providers: { ...cfg.providers, [name]: provider } });
-  }, [config, persist]);
+  }, [getEditableConfig, persist]);
 
   const removeProvider = useCallback(async (name: string) => {
-    const cfg = config ?? { providers: {} };
+    const cfg = getEditableConfig();
     const { [name]: _, ...rest } = cfg.providers;
     await persist({ providers: rest });
-  }, [config, persist]);
+  }, [getEditableConfig, persist]);
 
   const renameProvider = useCallback(async (oldName: string, newName: string) => {
-    const cfg = config ?? { providers: {} };
+    const cfg = getEditableConfig();
     if (cfg.providers[newName]) throw new Error(`Provider "${newName}" already exists`);
     const provider = cfg.providers[oldName];
     if (!provider) throw new Error(`Provider "${oldName}" not found`);
     const { [oldName]: _, ...rest } = cfg.providers;
     await persist({ providers: { ...rest, [newName]: provider } });
-  }, [config, persist]);
+  }, [getEditableConfig, persist]);
 
   const addModel = useCallback(async (providerName: string, model: LocalModelEntry) => {
-    const cfg = config ?? { providers: {} };
+    const cfg = getEditableConfig();
     const provider = cfg.providers[providerName];
     if (!provider) throw new Error(`Provider "${providerName}" not found`);
-    if (provider.models.some((m) => m.id === model.id)) {
+    const models = provider.models ?? [];
+    if (models.some((m) => m.id === model.id)) {
       throw new Error(`Model "${model.id}" already exists in "${providerName}"`);
     }
     await persist({
       providers: {
         ...cfg.providers,
-        [providerName]: { ...provider, models: [...provider.models, model] },
+        [providerName]: { ...provider, models: [...models, model] },
       },
     });
-  }, [config, persist]);
+  }, [getEditableConfig, persist]);
 
   const updateModel = useCallback(async (providerName: string, modelId: string, model: LocalModelEntry) => {
-    const cfg = config ?? { providers: {} };
+    const cfg = getEditableConfig();
     const provider = cfg.providers[providerName];
     if (!provider) throw new Error(`Provider "${providerName}" not found`);
+    const models = provider.models ?? [];
     await persist({
       providers: {
         ...cfg.providers,
         [providerName]: {
           ...provider,
-          models: provider.models.map((m) => m.id === modelId ? model : m),
+          models: models.map((m) => m.id === modelId ? model : m),
         },
       },
     });
-  }, [config, persist]);
+  }, [getEditableConfig, persist]);
 
   const removeModel = useCallback(async (providerName: string, modelId: string) => {
-    const cfg = config ?? { providers: {} };
+    const cfg = getEditableConfig();
     const provider = cfg.providers[providerName];
     if (!provider) throw new Error(`Provider "${providerName}" not found`);
+    const models = provider.models ?? [];
     await persist({
       providers: {
         ...cfg.providers,
         [providerName]: {
           ...provider,
-          models: provider.models.filter((m) => m.id !== modelId),
+          models: models.filter((m) => m.id !== modelId),
         },
       },
     });
-  }, [config, persist]);
+  }, [getEditableConfig, persist]);
 
-  const testConnection = useCallback(async (baseUrl: string) => {
-    return window.sero.localModels.testConnection(baseUrl);
+  const testConnection = useCallback(async (request: LocalModelsConnectionRequest) => {
+    return window.sero.localModels.testConnection(request);
   }, []);
 
-  const fetchRemoteModels = useCallback(async (baseUrl: string) => {
-    return window.sero.localModels.fetchRemoteModels(baseUrl);
+  const fetchRemoteModels = useCallback(async (request: LocalModelsConnectionRequest) => {
+    return window.sero.localModels.fetchRemoteModels(request);
   }, []);
 
   return {

--- a/apps/desktop/src/components/layout/model-manager/local-models/use-local-models.ts
+++ b/apps/desktop/src/components/layout/model-manager/local-models/use-local-models.ts
@@ -1,0 +1,158 @@
+/**
+ * Hook for managing local model provider configuration.
+ *
+ * Reads/writes models.json through IPC and provides helpers
+ * for adding, editing, and removing providers and models.
+ */
+
+import { useState, useCallback } from 'react';
+import type {
+  LocalModelsConfig,
+  LocalProviderConfig,
+  LocalModelEntry,
+} from '@/types/local-models';
+
+/** Load config from main process. */
+async function loadConfig(): Promise<LocalModelsConfig> {
+  return window.sero.localModels.getConfig();
+}
+
+/** Save config to main process (writes models.json + refreshes ModelRegistry). */
+async function saveConfig(config: LocalModelsConfig): Promise<void> {
+  return window.sero.localModels.saveConfig(config);
+}
+
+export interface UseLocalModelsReturn {
+  config: LocalModelsConfig | null;
+  loading: boolean;
+  error: string | null;
+  reload: () => Promise<void>;
+  addProvider: (name: string, provider: LocalProviderConfig) => Promise<void>;
+  updateProvider: (name: string, provider: LocalProviderConfig) => Promise<void>;
+  removeProvider: (name: string) => Promise<void>;
+  renameProvider: (oldName: string, newName: string) => Promise<void>;
+  addModel: (providerName: string, model: LocalModelEntry) => Promise<void>;
+  updateModel: (providerName: string, modelId: string, model: LocalModelEntry) => Promise<void>;
+  removeModel: (providerName: string, modelId: string) => Promise<void>;
+  testConnection: (baseUrl: string) => Promise<{ ok: boolean; error?: string }>;
+  fetchRemoteModels: (baseUrl: string) => Promise<{ id: string; name?: string }[]>;
+}
+
+export function useLocalModels(): UseLocalModelsReturn {
+  const [config, setConfig] = useState<LocalModelsConfig | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const cfg = await loadConfig();
+      setConfig(cfg);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const persist = useCallback(async (cfg: LocalModelsConfig) => {
+    await saveConfig(cfg);
+    setConfig(cfg);
+  }, []);
+
+  const addProvider = useCallback(async (name: string, provider: LocalProviderConfig) => {
+    const cfg = config ?? { providers: {} };
+    if (cfg.providers[name]) throw new Error(`Provider "${name}" already exists`);
+    await persist({ providers: { ...cfg.providers, [name]: provider } });
+  }, [config, persist]);
+
+  const updateProvider = useCallback(async (name: string, provider: LocalProviderConfig) => {
+    const cfg = config ?? { providers: {} };
+    await persist({ providers: { ...cfg.providers, [name]: provider } });
+  }, [config, persist]);
+
+  const removeProvider = useCallback(async (name: string) => {
+    const cfg = config ?? { providers: {} };
+    const { [name]: _, ...rest } = cfg.providers;
+    await persist({ providers: rest });
+  }, [config, persist]);
+
+  const renameProvider = useCallback(async (oldName: string, newName: string) => {
+    const cfg = config ?? { providers: {} };
+    if (cfg.providers[newName]) throw new Error(`Provider "${newName}" already exists`);
+    const provider = cfg.providers[oldName];
+    if (!provider) throw new Error(`Provider "${oldName}" not found`);
+    const { [oldName]: _, ...rest } = cfg.providers;
+    await persist({ providers: { ...rest, [newName]: provider } });
+  }, [config, persist]);
+
+  const addModel = useCallback(async (providerName: string, model: LocalModelEntry) => {
+    const cfg = config ?? { providers: {} };
+    const provider = cfg.providers[providerName];
+    if (!provider) throw new Error(`Provider "${providerName}" not found`);
+    if (provider.models.some((m) => m.id === model.id)) {
+      throw new Error(`Model "${model.id}" already exists in "${providerName}"`);
+    }
+    await persist({
+      providers: {
+        ...cfg.providers,
+        [providerName]: { ...provider, models: [...provider.models, model] },
+      },
+    });
+  }, [config, persist]);
+
+  const updateModel = useCallback(async (providerName: string, modelId: string, model: LocalModelEntry) => {
+    const cfg = config ?? { providers: {} };
+    const provider = cfg.providers[providerName];
+    if (!provider) throw new Error(`Provider "${providerName}" not found`);
+    await persist({
+      providers: {
+        ...cfg.providers,
+        [providerName]: {
+          ...provider,
+          models: provider.models.map((m) => m.id === modelId ? model : m),
+        },
+      },
+    });
+  }, [config, persist]);
+
+  const removeModel = useCallback(async (providerName: string, modelId: string) => {
+    const cfg = config ?? { providers: {} };
+    const provider = cfg.providers[providerName];
+    if (!provider) throw new Error(`Provider "${providerName}" not found`);
+    await persist({
+      providers: {
+        ...cfg.providers,
+        [providerName]: {
+          ...provider,
+          models: provider.models.filter((m) => m.id !== modelId),
+        },
+      },
+    });
+  }, [config, persist]);
+
+  const testConnection = useCallback(async (baseUrl: string) => {
+    return window.sero.localModels.testConnection(baseUrl);
+  }, []);
+
+  const fetchRemoteModels = useCallback(async (baseUrl: string) => {
+    return window.sero.localModels.fetchRemoteModels(baseUrl);
+  }, []);
+
+  return {
+    config,
+    loading,
+    error,
+    reload,
+    addProvider,
+    updateProvider,
+    removeProvider,
+    renameProvider,
+    addModel,
+    updateModel,
+    removeModel,
+    testConnection,
+    fetchRemoteModels,
+  };
+}

--- a/apps/desktop/src/components/layout/model-manager/types.ts
+++ b/apps/desktop/src/components/layout/model-manager/types.ts
@@ -6,4 +6,4 @@ import type { ModelInfo, AvailableModelGroup } from '@/types/ipc';
 
 export type { ModelInfo, AvailableModelGroup };
 
-export type ManagerTab = 'all' | 'favourites' | 'hidden';
+export type ManagerTab = 'all' | 'favourites' | 'hidden' | 'local';

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -68,6 +68,7 @@ import type {
   AppRecordingResult,
   CreateGitHubRepoInput,
   CreateGitHubRepoResult,
+  LocalModelsConfig,
 } from './ipc';
 
 interface SeroWorkspaceAPI {
@@ -407,6 +408,17 @@ interface SeroGatewayAPI {
   getQrLoginData(expiryDays?: number): Promise<QrLoginData>;
 }
 
+interface SeroLocalModelsAPI {
+  /** Read the current models.json config. Returns empty config if file doesn't exist. */
+  getConfig(): Promise<LocalModelsConfig>;
+  /** Write the full models.json config to disk and refresh the model registry. */
+  saveConfig(config: LocalModelsConfig): Promise<void>;
+  /** Test connectivity to a local provider's base URL. */
+  testConnection(baseUrl: string): Promise<{ ok: boolean; error?: string }>;
+  /** Fetch available models from a provider's API (e.g. Ollama /api/tags). */
+  fetchRemoteModels(baseUrl: string): Promise<{ id: string; name?: string }[]>;
+}
+
 interface SeroAPI {
   platform: string;
   shell: SeroShellAPI;
@@ -444,6 +456,7 @@ interface SeroAPI {
   prompts: SeroPromptsAPI;
   github: SeroGitHubAPI;
   plugins: SeroPluginsAPI;
+  localModels: SeroLocalModelsAPI;
 }
 
 // ── GitHub Auth ──────────────────────────────────────────────

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -69,6 +69,8 @@ import type {
   CreateGitHubRepoInput,
   CreateGitHubRepoResult,
   LocalModelsConfig,
+  LocalModelsConnectionRequest,
+  LocalRemoteModelInfo,
 } from './ipc';
 
 interface SeroWorkspaceAPI {
@@ -413,10 +415,10 @@ interface SeroLocalModelsAPI {
   getConfig(): Promise<LocalModelsConfig>;
   /** Write the full models.json config to disk and refresh the model registry. */
   saveConfig(config: LocalModelsConfig): Promise<void>;
-  /** Test connectivity to a local provider's base URL. */
-  testConnection(baseUrl: string): Promise<{ ok: boolean; error?: string }>;
-  /** Fetch available models from a provider's API (e.g. Ollama /api/tags). */
-  fetchRemoteModels(baseUrl: string): Promise<{ id: string; name?: string }[]>;
+  /** Test connectivity to a local provider using its selected API + auth settings. */
+  testConnection(request: LocalModelsConnectionRequest): Promise<{ ok: boolean; error?: string }>;
+  /** Fetch available models from a provider's API (OpenAI, Anthropic, Google, Ollama). */
+  fetchRemoteModels(request: LocalModelsConnectionRequest): Promise<LocalRemoteModelInfo[]>;
 }
 
 interface SeroAPI {

--- a/apps/desktop/src/types/ipc-channels-local-models.ts
+++ b/apps/desktop/src/types/ipc-channels-local-models.ts
@@ -1,0 +1,11 @@
+/** Local model management IPC channels. */
+export const localModelsIpcChannels = {
+  /** Read the current models.json config. Returns LocalModelsConfig. */
+  getConfig: 'sero:local-models:get-config',
+  /** Write the full models.json config. */
+  saveConfig: 'sero:local-models:save-config',
+  /** Test connectivity to a local provider's base URL. */
+  testConnection: 'sero:local-models:test-connection',
+  /** Fetch available models from a provider's API (e.g. Ollama /api/tags). */
+  fetchRemoteModels: 'sero:local-models:fetch-remote-models',
+} as const;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -4,6 +4,9 @@
  * Shared by Electron main process, preload, and renderer.
  * Extracted from ipc.ts to keep that file under 500 LOC.
  */
+
+import { localModelsIpcChannels } from './ipc-channels-local-models';
+
 export const IpcChannels = {
   workspace: {
     list: 'sero:workspace:list',
@@ -122,16 +125,7 @@ export const IpcChannels = {
     /** List all available models (session-independent). Returns AvailableModelGroup[]. */
     list: 'sero:models:list',
   },
-  localModels: {
-    /** Read the current models.json config. Returns LocalModelsConfig. */
-    getConfig: 'sero:local-models:get-config',
-    /** Write the full models.json config. */
-    saveConfig: 'sero:local-models:save-config',
-    /** Test connectivity to a local provider's base URL. */
-    testConnection: 'sero:local-models:test-connection',
-    /** Fetch available models from a provider's API (e.g. Ollama /api/tags). */
-    fetchRemoteModels: 'sero:local-models:fetch-remote-models',
-  },
+  localModels: localModelsIpcChannels,
   imagegen: {
     /** Generate images via Gemini Nano Banana. Returns generation metadata. */
     generate: 'sero:imagegen:generate',

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -122,6 +122,16 @@ export const IpcChannels = {
     /** List all available models (session-independent). Returns AvailableModelGroup[]. */
     list: 'sero:models:list',
   },
+  localModels: {
+    /** Read the current models.json config. Returns LocalModelsConfig. */
+    getConfig: 'sero:local-models:get-config',
+    /** Write the full models.json config. */
+    saveConfig: 'sero:local-models:save-config',
+    /** Test connectivity to a local provider's base URL. */
+    testConnection: 'sero:local-models:test-connection',
+    /** Fetch available models from a provider's API (e.g. Ollama /api/tags). */
+    fetchRemoteModels: 'sero:local-models:fetch-remote-models',
+  },
   imagegen: {
     /** Generate images via Gemini Nano Banana. Returns generation metadata. */
     generate: 'sero:imagegen:generate',

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -247,8 +247,11 @@ export type {
   LocalModelCost,
   LocalModelCompat,
   LocalModelEntry,
+  LocalModelOverride,
   LocalProviderConfig,
   LocalModelsConfig,
+  LocalModelsConnectionRequest,
+  LocalRemoteModelInfo,
   LocalProviderPreset,
   LocalProviderPresetConfig,
 } from './local-models';

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -240,6 +240,19 @@ export type {
   CompactResult,
 } from './agent';
 
+// ── Local Models ─────────────────────────────────────────────────
+
+export type {
+  LocalModelApi,
+  LocalModelCost,
+  LocalModelCompat,
+  LocalModelEntry,
+  LocalProviderConfig,
+  LocalModelsConfig,
+  LocalProviderPreset,
+  LocalProviderPresetConfig,
+} from './local-models';
+
 // ── Sero Apps ──────────────────────────────────────────────────
 
 export type { SettingsPackageSource, SeroAppManifest, SeroWidgetManifest } from './sero-apps';

--- a/apps/desktop/src/types/local-models.ts
+++ b/apps/desktop/src/types/local-models.ts
@@ -1,0 +1,75 @@
+/**
+ * Types for managing local LLM providers (Ollama, LM Studio, vLLM, etc.)
+ * via the Pi SDK's models.json configuration.
+ *
+ * Shared by Electron main process and renderer.
+ */
+
+/** Supported API types for local model providers. */
+export type LocalModelApi =
+  | 'openai-completions'
+  | 'openai-responses'
+  | 'anthropic-messages'
+  | 'google-generative-ai';
+
+/** Cost configuration per million tokens. */
+export interface LocalModelCost {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** OpenAI compatibility overrides. */
+export interface LocalModelCompat {
+  supportsDeveloperRole?: boolean;
+  supportsReasoningEffort?: boolean;
+  supportsUsageInStreaming?: boolean;
+  maxTokensField?: 'max_completion_tokens' | 'max_tokens';
+  requiresToolResultName?: boolean;
+  requiresAssistantAfterToolResult?: boolean;
+  requiresThinkingAsText?: boolean;
+  thinkingFormat?: 'reasoning_effort' | 'zai' | 'qwen' | 'qwen-chat-template';
+  supportsStrictMode?: boolean;
+  supportsStore?: boolean;
+}
+
+/** A single model entry within a local provider. */
+export interface LocalModelEntry {
+  id: string;
+  name?: string;
+  api?: LocalModelApi;
+  reasoning?: boolean;
+  input?: ('text' | 'image')[];
+  contextWindow?: number;
+  maxTokens?: number;
+  cost?: LocalModelCost;
+  compat?: LocalModelCompat;
+}
+
+/** A local provider configuration. */
+export interface LocalProviderConfig {
+  baseUrl: string;
+  api: LocalModelApi;
+  apiKey: string;
+  compat?: LocalModelCompat;
+  models: LocalModelEntry[];
+}
+
+/** The full models.json structure. */
+export interface LocalModelsConfig {
+  providers: Record<string, LocalProviderConfig>;
+}
+
+/** Provider preset templates for quick setup. */
+export type LocalProviderPreset = 'ollama' | 'lm-studio' | 'vllm' | 'custom';
+
+/** Preset configuration for common local LLM servers. */
+export interface LocalProviderPresetConfig {
+  label: string;
+  description: string;
+  baseUrl: string;
+  api: LocalModelApi;
+  apiKey: string;
+  compat?: LocalModelCompat;
+}

--- a/apps/desktop/src/types/local-models.ts
+++ b/apps/desktop/src/types/local-models.ts
@@ -5,6 +5,8 @@
  * Shared by Electron main process and renderer.
  */
 
+import type { OpenAICompletionsCompat } from '@mariozechner/pi-ai';
+
 /** Supported API types for local model providers. */
 export type LocalModelApi =
   | 'openai-completions'
@@ -20,45 +22,66 @@ export interface LocalModelCost {
   cacheWrite: number;
 }
 
-/** OpenAI compatibility overrides. */
-export interface LocalModelCompat {
-  supportsDeveloperRole?: boolean;
-  supportsReasoningEffort?: boolean;
-  supportsUsageInStreaming?: boolean;
-  maxTokensField?: 'max_completion_tokens' | 'max_tokens';
-  requiresToolResultName?: boolean;
-  requiresAssistantAfterToolResult?: boolean;
-  requiresThinkingAsText?: boolean;
-  thinkingFormat?: 'reasoning_effort' | 'zai' | 'qwen' | 'qwen-chat-template';
-  supportsStrictMode?: boolean;
-  supportsStore?: boolean;
-}
+/** OpenAI compatibility overrides supported by models.json. */
+export type LocalModelCompat = OpenAICompletionsCompat;
 
 /** A single model entry within a local provider. */
 export interface LocalModelEntry {
   id: string;
   name?: string;
   api?: LocalModelApi;
+  baseUrl?: string;
   reasoning?: boolean;
   input?: ('text' | 'image')[];
   contextWindow?: number;
   maxTokens?: number;
   cost?: LocalModelCost;
+  headers?: Record<string, string>;
   compat?: LocalModelCompat;
 }
 
-/** A local provider configuration. */
-export interface LocalProviderConfig {
-  baseUrl: string;
-  api: LocalModelApi;
-  apiKey: string;
+/** Per-model override for built-in provider models. */
+export interface LocalModelOverride {
+  name?: string;
+  reasoning?: boolean;
+  input?: ('text' | 'image')[];
+  cost?: Partial<LocalModelCost>;
+  contextWindow?: number;
+  maxTokens?: number;
+  headers?: Record<string, string>;
   compat?: LocalModelCompat;
-  models: LocalModelEntry[];
+}
+
+/** A local provider configuration. Mirrors Pi's models.json schema. */
+export interface LocalProviderConfig {
+  baseUrl?: string;
+  api?: LocalModelApi;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  compat?: LocalModelCompat;
+  authHeader?: boolean;
+  models?: LocalModelEntry[];
+  modelOverrides?: Record<string, LocalModelOverride>;
 }
 
 /** The full models.json structure. */
 export interface LocalModelsConfig {
   providers: Record<string, LocalProviderConfig>;
+}
+
+/** Connection parameters used by the UI for test/discovery calls. */
+export interface LocalModelsConnectionRequest {
+  baseUrl: string;
+  api: LocalModelApi;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  authHeader?: boolean;
+}
+
+/** Model info returned by remote discovery helpers. */
+export interface LocalRemoteModelInfo {
+  id: string;
+  name?: string;
 }
 
 /** Provider preset templates for quick setup. */


### PR DESCRIPTION
Wire ModelRegistry to ~/.sero-ui/agent/models.json so custom local models
are available across all agents (main + subagents). Add a "Local" tab to
the Model Manager dialog with:

- Provider presets (Ollama, LM Studio, vLLM, Custom)
- Connection testing and model auto-discovery from server
- Manual model addition with inline editing
- Provider CRUD with confirmation on delete
- Compatibility toggles (developer role, reasoning effort)

Backend: IPC handlers for reading/writing models.json, testing connectivity,
and fetching remote model lists from OpenAI-compatible and Ollama endpoints.

Follow-up fixes after review:

- Preserve advanced `models.json` fields (`headers`, `authHeader`, `modelOverrides`, richer compat settings) instead of dropping them when editing providers in the UI
- Surface invalid `models.json` parse/schema errors in the Local tab instead of silently treating them as an empty config
- Support auth-aware connection testing and model discovery for OpenAI-compatible, Ollama, Anthropic, and Google endpoints
- Allow selecting custom provider IDs (for example `lm-studio`) from the ModelSelector
- Refresh session model state immediately after local provider changes and when reopening the Model Manager
- Auto-fallback away from removed local models using settings-driven `sero.modelFallbackChain`, seeded with default values that users can override in `settings.json`

https://claude.ai/code/session_01S2LXZJQ5xtdCjqFGAD91hW
