### PR TITLE
feat: add error boundaries to prevent full-screen crashes

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -24,6 +24,7 @@ import { initAppControlBridge } from '@/lib/app-control-bridge';
 import { hydrateShellState } from '@/lib/app-startup';
 import { ActiveAppPanel } from '@/components/apps/ActiveAppPanel';
 import { useAgentStore } from '@/stores/agent';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 /**
  * App shell.
@@ -262,7 +263,11 @@ export function App() {
               collapsedSize={mainSidebarCollapsedSize}
               onResize={handleMainSidebarResize}
             >
-              {mainSidebarOpen ? <MainSidebar /> : null}
+              {mainSidebarOpen ? (
+                <ErrorBoundary region="Sidebar" compact>
+                  <MainSidebar />
+                </ErrorBoundary>
+              ) : null}
             </ResizablePanel>
 
             <ResizableHandle
@@ -271,7 +276,9 @@ export function App() {
             />
 
             <ResizablePanel id="active-app-panel" minSize={40} className="min-w-0 flex flex-col">
-              <ActiveAppPanel app={activeApp} />
+              <ErrorBoundary key={activeApp} region="Plugin">
+                <ActiveAppPanel app={activeApp} />
+              </ErrorBoundary>
             </ResizablePanel>
 
             <ResizableHandle
@@ -288,7 +295,11 @@ export function App() {
               collapsedSize={chatPanelCollapsedSize}
               onResize={handleChatPanelResize}
             >
-              {chatPanelOpen ? <ChatPanel /> : null}
+              {chatPanelOpen ? (
+                <ErrorBoundary region="Chat" compact>
+                  <ChatPanel />
+                </ErrorBoundary>
+              ) : null}
             </ResizablePanel>
           </ResizablePanelGroup>
         </div>

--- a/apps/desktop/src/components/ErrorBoundary.test.tsx
+++ b/apps/desktop/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { ErrorBoundary } from './ErrorBoundary';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function CrashyPanel({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error('boom');
+  }
+  return <div>healthy panel</div>;
+}
+
+describe('ErrorBoundary', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleErrorSpy.mockRestore();
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    container.remove();
+  });
+
+  it('recovers when the keyed region identity changes after a crash', async () => {
+    await act(async () => {
+      root?.render(
+        <ErrorBoundary key="broken-app" region="Plugin">
+          <CrashyPanel shouldThrow />
+        </ErrorBoundary>,
+      );
+    });
+
+    expect(container.textContent).toContain('Plugin crashed');
+    expect(container.textContent).toContain('Copy error');
+
+    await act(async () => {
+      root?.render(
+        <ErrorBoundary key="healthy-app" region="Plugin">
+          <CrashyPanel shouldThrow={false} />
+        </ErrorBoundary>,
+      );
+    });
+
+    expect(container.textContent).toContain('healthy panel');
+    expect(container.textContent).not.toContain('Plugin crashed');
+  });
+});

--- a/apps/desktop/src/components/ErrorBoundary.tsx
+++ b/apps/desktop/src/components/ErrorBoundary.tsx
@@ -1,0 +1,122 @@
+import { Component } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { AlertTriangle, RotateCcw, Copy, Check } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Label shown in the fallback UI to identify which region crashed. */
+  region?: string;
+  /**
+   * Compact mode renders a minimal inline fallback instead of a centered card.
+   * Useful for sidebar-sized panels where space is limited.
+   */
+  compact?: boolean;
+  /** Optional callback invoked when an error is caught. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+  copied: boolean;
+}
+
+/**
+ * React error boundary that catches render errors and displays a recoverable
+ * fallback UI instead of a blank screen. Place around major shell regions
+ * (sidebar, active app, chat panel) so a crash in one area doesn't take down
+ * the entire app.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null, copied: false };
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(`[ErrorBoundary${this.props.region ? `:${this.props.region}` : ''}]`, error, errorInfo);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  private handleRetry = () => {
+    this.setState({ error: null, copied: false });
+  };
+
+  private handleCopy = () => {
+    const { error } = this.state;
+    if (!error) return;
+    const text = `${error.name}: ${error.message}\n${error.stack ?? ''}`;
+    navigator.clipboard.writeText(text).then(() => {
+      this.setState({ copied: true });
+      setTimeout(() => this.setState({ copied: false }), 2000);
+    });
+  };
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    const { error, copied } = this.state;
+    const { region, compact } = this.props;
+
+    if (compact) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-2 p-4 text-center">
+          <AlertTriangle className="size-5 text-[var(--text-muted)]" />
+          <p className="text-xs text-[var(--text-muted)]">
+            {region ? `${region} crashed` : 'Something went wrong'}
+          </p>
+          <Button variant="ghost" size="xs" onClick={this.handleRetry}>
+            <RotateCcw className="size-3" />
+            Retry
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-full items-center justify-center bg-[var(--bg-base)] p-6">
+        <div className="flex max-w-lg flex-col gap-4 rounded-lg border border-[var(--border-default)] bg-[var(--bg-surface)] p-6">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 size-5 shrink-0 text-[var(--text-danger)]" />
+            <div className="min-w-0">
+              <h3 className="text-sm font-medium text-[var(--text-default)]">
+                {region ? `${region} crashed` : 'Something went wrong'}
+              </h3>
+              <p className="mt-1 text-xs text-[var(--text-muted)]">
+                An unhandled error occurred. You can retry to recover, or copy
+                the error details for debugging.
+              </p>
+            </div>
+          </div>
+
+          <pre className="max-h-40 overflow-auto rounded-md bg-[var(--bg-inset)] p-3 text-[11px] leading-relaxed text-[var(--text-muted)]">
+            {error.name}: {error.message}
+            {error.stack && (
+              <>
+                {'\n'}
+                {error.stack
+                  .split('\n')
+                  .slice(1, 8)
+                  .join('\n')}
+              </>
+            )}
+          </pre>
+
+          <div className="flex items-center gap-2">
+            <Button variant="outline" size="sm" onClick={this.handleRetry}>
+              <RotateCcw className="size-3.5" />
+              Retry
+            </Button>
+            <Button variant="ghost" size="sm" onClick={this.handleCopy}>
+              {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+              {copied ? 'Copied' : 'Copy error'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,9 +1,14 @@
 
 import ReactDOM from 'react-dom/client';
 import { App } from './App';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import './styles/global.css';
 
 // No StrictMode — it double-mounts components in dev, which creates
 // duplicate PTY sessions, terminal connections, and agent subscriptions.
-ReactDOM.createRoot(document.getElementById('root')!).render(<App />);
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <ErrorBoundary region="Sero">
+    <App />
+  </ErrorBoundary>,
+);
 


### PR DESCRIPTION
Unhandled React errors were turning the entire screen black with no
recovery path. This adds an ErrorBoundary class component at three
strategic levels:

- Top-level (main.tsx): catches anything that escapes inner boundaries
- Per-panel (App.tsx): isolates Sidebar, Plugin, and Chat crashes so
  the rest of the shell remains functional

The fallback UI shows the error details, a copy button for debugging,
and a retry button to re-mount the crashed region.

https://claude.ai/code/session_01TUuQcCnZ64DB7JL5WRkzVA