### PR TITLE
feat(plugins): add plugin discovery via GitHub topic and npm keyword search

### DIFF
--- a/apps/desktop/electron/__tests__/features/plugins/discovery.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/discovery.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { InstalledPlugin } from '@sero/common';
+
+vi.mock('../../../features/plugins/manager', () => ({
+  listInstalledPlugins: vi.fn(),
+}));
+
+import { searchPlugins } from '../../../features/plugins/discovery';
+import { listInstalledPlugins } from '../../../features/plugins/manager';
+
+const mockListInstalledPlugins = vi.mocked(listInstalledPlugins);
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+  } as Response;
+}
+
+function createInstalledPlugin(
+  overrides: Partial<InstalledPlugin> = {},
+): InstalledPlugin {
+  return {
+    id: 'todo',
+    name: 'Todo',
+    description: null,
+    version: '1.0.0',
+    icon: 'box',
+    category: 'utilities',
+    tags: [],
+    source: 'npm:@acme/sero-todo-plugin',
+    installedAt: '2026-03-30T00:00:00.000Z',
+    packagePath: '/tmp/todo',
+    hasUI: true,
+    ...overrides,
+  };
+}
+
+describe('plugin discovery', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    mockListInstalledPlugins.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('merges npm packages whose repository uses git+https URLs', async () => {
+    fetchMock.mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+
+      if (url.includes('api.github.com')) {
+        return jsonResponse({
+          items: [
+            {
+              full_name: 'acme/sero-todo-plugin',
+              name: 'sero-todo-plugin',
+              description: 'GitHub description',
+              html_url: 'https://github.com/acme/sero-todo-plugin',
+              stargazers_count: 42,
+              owner: { login: 'acme' },
+            },
+          ],
+        });
+      }
+
+      if (url.includes('registry.npmjs.org')) {
+        return jsonResponse({
+          objects: [
+            {
+              package: {
+                name: '@acme/sero-todo-plugin',
+                version: '1.2.3',
+                description: 'npm description',
+                links: {
+                  repository: 'git+https://github.com/acme/sero-todo-plugin.git',
+                },
+                publisher: { username: 'acme' },
+              },
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    const results = await searchPlugins('todo');
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      npmPackage: '@acme/sero-todo-plugin',
+      installSource: 'npm:@acme/sero-todo-plugin',
+      githubUrl: 'https://github.com/acme/sero-todo-plugin',
+      installed: false,
+      installedPluginId: null,
+    });
+  });
+
+  it('marks versioned npm installs as installed', async () => {
+    mockListInstalledPlugins.mockResolvedValue([
+      createInstalledPlugin({
+        source: 'npm:@acme/sero-todo-plugin@latest',
+      }),
+    ]);
+
+    fetchMock.mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+
+      if (url.includes('api.github.com')) {
+        return jsonResponse({ items: [] });
+      }
+
+      if (url.includes('registry.npmjs.org')) {
+        return jsonResponse({
+          objects: [
+            {
+              package: {
+                name: '@acme/sero-todo-plugin',
+                version: '1.2.3',
+                description: 'npm description',
+                publisher: { username: 'acme' },
+              },
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    const results = await searchPlugins('todo');
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      installSource: 'npm:@acme/sero-todo-plugin',
+      installed: true,
+      installedPluginId: 'todo',
+    });
+  });
+});

--- a/apps/desktop/electron/features/plugins/discovery.ts
+++ b/apps/desktop/electron/features/plugins/discovery.ts
@@ -1,0 +1,202 @@
+/**
+ * Plugin Discovery — search for public Sero plugins on GitHub and npm.
+ *
+ * GitHub repos are discovered via the "sero-ai-plugin" topic.
+ * npm packages are discovered via the "sero-ai-plugin" keyword.
+ * Results are merged by matching GitHub repo URLs in npm metadata.
+ */
+
+import type { DiscoveredPlugin } from '@sero/common';
+import { listInstalledPlugins } from './manager';
+
+const GITHUB_TOPIC = 'sero-ai-plugin';
+const NPM_KEYWORD = 'sero-ai-plugin';
+
+// ── GitHub types ───────────────────────────────────────────
+
+interface GitHubRepo {
+  full_name: string;
+  name: string;
+  description: string | null;
+  html_url: string;
+  stargazers_count: number;
+  owner: { login: string };
+}
+
+interface GitHubSearchResponse {
+  items: GitHubRepo[];
+}
+
+// ── npm types ──────────────────────────────────────────────
+
+interface NpmPackage {
+  name: string;
+  version: string;
+  description?: string;
+  links?: { repository?: string; npm?: string };
+  publisher?: { username: string };
+  keywords?: string[];
+}
+
+interface NpmSearchResponse {
+  objects: Array<{ package: NpmPackage }>;
+}
+
+// ── Search functions ───────────────────────────────────────
+
+async function searchGitHub(query: string): Promise<GitHubRepo[]> {
+  const q = query
+    ? `topic:${GITHUB_TOPIC} ${query} in:name,description`
+    : `topic:${GITHUB_TOPIC}`;
+  const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(q)}&sort=stars&order=desc&per_page=30`;
+
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'Sero-Desktop',
+    },
+  });
+
+  if (!res.ok) {
+    console.warn(`[plugin-discovery] GitHub search failed: ${res.status} ${res.statusText}`);
+    return [];
+  }
+
+  const data = (await res.json()) as GitHubSearchResponse;
+  return data.items ?? [];
+}
+
+async function searchNpm(query: string): Promise<NpmPackage[]> {
+  const text = query
+    ? `keywords:${NPM_KEYWORD} ${query}`
+    : `keywords:${NPM_KEYWORD}`;
+  const url = `https://registry.npmjs.org/-/v1/search?text=${encodeURIComponent(text)}&size=30`;
+
+  const res = await fetch(url, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!res.ok) {
+    console.warn(`[plugin-discovery] npm search failed: ${res.status} ${res.statusText}`);
+    return [];
+  }
+
+  const data = (await res.json()) as NpmSearchResponse;
+  return data.objects?.map((o) => o.package) ?? [];
+}
+
+// ── Merge & deduplicate ────────────────────────────────────
+
+function normalizeGitHubUrl(url: string | undefined): string | null {
+  if (!url) return null;
+  // Strip .git suffix and trailing slashes, lowercase for comparison
+  return url
+    .replace(/\.git$/, '')
+    .replace(/\/$/, '')
+    .toLowerCase();
+}
+
+/**
+ * Search for public Sero plugins across GitHub and npm.
+ * Results are merged: if a GitHub repo matches an npm package's repository
+ * URL, they are combined into a single entry with npm as the preferred
+ * install source.
+ */
+export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> {
+  const [githubRepos, npmPackages, installed] = await Promise.all([
+    searchGitHub(query),
+    searchNpm(query),
+    listInstalledPlugins(),
+  ]);
+
+  const installedSources = new Set(installed.map((p) => p.source));
+  const installedNames = new Set(installed.map((p) => p.name));
+
+  // Index npm packages by normalized GitHub URL for merging
+  const npmByRepoUrl = new Map<string, NpmPackage>();
+  const npmUsed = new Set<string>();
+  for (const pkg of npmPackages) {
+    const repoUrl = normalizeGitHubUrl(pkg.links?.repository);
+    if (repoUrl) {
+      npmByRepoUrl.set(repoUrl, pkg);
+    }
+  }
+
+  const results: DiscoveredPlugin[] = [];
+
+  // Process GitHub repos first, merging with npm matches
+  for (const repo of githubRepos) {
+    const normalizedUrl = normalizeGitHubUrl(repo.html_url);
+    const matchedNpm = normalizedUrl ? npmByRepoUrl.get(normalizedUrl) : undefined;
+
+    if (matchedNpm) {
+      npmUsed.add(matchedNpm.name);
+    }
+
+    const npmName = matchedNpm?.name ?? null;
+    const installSource = npmName ? `npm:${npmName}` : `git:${repo.html_url}.git`;
+
+    results.push({
+      name: npmName ?? repo.full_name,
+      displayName: formatRepoName(repo.name),
+      description: repo.description ?? matchedNpm?.description ?? '',
+      author: repo.owner.login,
+      version: matchedNpm?.version ?? null,
+      githubUrl: repo.html_url,
+      npmPackage: npmName,
+      stars: repo.stargazers_count,
+      installSource,
+      installed: isInstalled(installSource, npmName, installedSources, installedNames),
+    });
+  }
+
+  // Add npm-only packages (not matched to a GitHub repo)
+  for (const pkg of npmPackages) {
+    if (npmUsed.has(pkg.name)) continue;
+
+    const repoUrl = pkg.links?.repository ?? null;
+
+    results.push({
+      name: pkg.name,
+      displayName: formatNpmName(pkg.name),
+      description: pkg.description ?? '',
+      author: pkg.publisher?.username ?? '',
+      version: pkg.version,
+      githubUrl: repoUrl,
+      npmPackage: pkg.name,
+      stars: 0,
+      installSource: `npm:${pkg.name}`,
+      installed: isInstalled(`npm:${pkg.name}`, pkg.name, installedSources, installedNames),
+    });
+  }
+
+  return results;
+}
+
+// ── Helpers ────────────────────────────────────────────────
+
+function isInstalled(
+  source: string,
+  npmName: string | null,
+  installedSources: Set<string>,
+  installedNames: Set<string>,
+): boolean {
+  if (installedSources.has(source)) return true;
+  if (npmName && installedNames.has(npmName)) return true;
+  return false;
+}
+
+function formatRepoName(name: string): string {
+  return name
+    .replace(/^sero-/, '')
+    .replace(/-plugin$/, '')
+    .split('-')
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(' ');
+}
+
+function formatNpmName(name: string): string {
+  // Strip scope (@org/) and common prefixes/suffixes
+  const bare = name.replace(/^@[^/]+\//, '');
+  return formatRepoName(bare);
+}

--- a/apps/desktop/electron/features/plugins/discovery.ts
+++ b/apps/desktop/electron/features/plugins/discovery.ts
@@ -3,7 +3,7 @@
  *
  * GitHub repos are discovered via the "sero-ai-plugin" topic.
  * npm packages are discovered via the "sero-ai-plugin" keyword.
- * Results are merged by matching GitHub repo URLs in npm metadata.
+ * Results are merged by matching GitHub repos referenced in npm metadata.
  */
 
 import type { DiscoveredPlugin } from '@sero/common';
@@ -87,20 +87,67 @@ async function searchNpm(query: string): Promise<NpmPackage[]> {
 
 // ── Merge & deduplicate ────────────────────────────────────
 
-function normalizeGitHubUrl(url: string | undefined): string | null {
-  if (!url) return null;
-  // Strip .git suffix and trailing slashes, lowercase for comparison
-  return url
-    .replace(/\.git$/, '')
-    .replace(/\/$/, '')
-    .toLowerCase();
+function extractGitHubRepoKey(value: string | null | undefined): string | null {
+  if (!value) return null;
+
+  const normalized = value
+    .trim()
+    .replace(/^git\+/, '')
+    .replace(/^git:(?=(?:https?:\/\/github\.com\/|git@github\.com:))/i, '')
+    .replace(/^github:/i, 'https://github.com/')
+    .replace(/^git@github\.com:/i, 'https://github.com/')
+    .replace(/^ssh:\/\/git@github\.com\//i, 'https://github.com/');
+
+  if (!normalized) return null;
+
+  try {
+    const candidate = normalized.includes('://') ? normalized : `https://${normalized.replace(/^\/+/, '')}`;
+    const url = new URL(candidate);
+    const hostname = url.hostname.toLowerCase();
+    if (hostname !== 'github.com' && hostname !== 'www.github.com') {
+      return null;
+    }
+
+    const segments = url.pathname.replace(/^\/+|\/+$/g, '').split('/');
+    const [owner, repo] = segments;
+    if (!owner || !repo) return null;
+
+    return `${owner}/${repo.replace(/\.git$/i, '')}`.toLowerCase();
+  } catch {
+    const match = normalized.match(
+      /^(?:github\.com\/)?([^/]+)\/([^/#?]+?)(?:\.git)?(?:[/?#].*)?$/i,
+    );
+    if (!match) return null;
+    return `${match[1]}/${match[2]}`.toLowerCase();
+  }
+}
+
+function toGitHubRepoUrl(repoKey: string | null): string | null {
+  return repoKey ? `https://github.com/${repoKey}` : null;
+}
+
+function extractNpmPackageName(source: string): string | null {
+  if (!source.startsWith('npm:')) return null;
+
+  const spec = source.slice(4).trim();
+  if (!spec) return null;
+
+  if (spec.startsWith('@')) {
+    const scopeSeparator = spec.indexOf('/');
+    if (scopeSeparator === -1) return null;
+    const versionSeparator = spec.indexOf('@', scopeSeparator + 1);
+    return (versionSeparator === -1 ? spec : spec.slice(0, versionSeparator)).trim() || null;
+  }
+
+  const versionSeparator = spec.indexOf('@');
+  return (versionSeparator === -1 ? spec : spec.slice(0, versionSeparator)).trim() || null;
 }
 
 /**
  * Search for public Sero plugins across GitHub and npm.
- * Results are merged: if a GitHub repo matches an npm package's repository
- * URL, they are combined into a single entry with npm as the preferred
- * install source.
+ * Results are merged: if a GitHub repo matches exactly one npm package's
+ * repository URL, they are combined into a single entry with npm as the
+ * preferred install source.
  */
 export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> {
   const [githubRepos, npmPackages, installed] = await Promise.all([
@@ -109,25 +156,42 @@ export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> 
     listInstalledPlugins(),
   ]);
 
-  const installedSources = new Set(installed.map((p) => p.source));
-  const installedNames = new Set(installed.map((p) => p.name));
+  const installedSources = new Map(installed.map((plugin) => [plugin.source, plugin.id]));
+  const installedNpmPackages = new Map<string, string>();
+  const installedGitHubRepos = new Map<string, string>();
 
-  // Index npm packages by normalized GitHub URL for merging
-  const npmByRepoUrl = new Map<string, NpmPackage>();
+  for (const plugin of installed) {
+    const npmPackage = extractNpmPackageName(plugin.source);
+    if (npmPackage && !installedNpmPackages.has(npmPackage)) {
+      installedNpmPackages.set(npmPackage, plugin.id);
+    }
+
+    const repoKey = extractGitHubRepoKey(plugin.source);
+    if (repoKey && !installedGitHubRepos.has(repoKey)) {
+      installedGitHubRepos.set(repoKey, plugin.id);
+    }
+  }
+
+  // Index npm packages by normalized GitHub repo for merging.
+  // If multiple npm packages point at the same repo, leave them as npm-only
+  // results rather than merging the repo with an arbitrary package.
+  const npmByRepoKey = new Map<string, NpmPackage[]>();
   const npmUsed = new Set<string>();
   for (const pkg of npmPackages) {
-    const repoUrl = normalizeGitHubUrl(pkg.links?.repository);
-    if (repoUrl) {
-      npmByRepoUrl.set(repoUrl, pkg);
-    }
+    const repoKey = extractGitHubRepoKey(pkg.links?.repository);
+    if (!repoKey) continue;
+    const existing = npmByRepoKey.get(repoKey) ?? [];
+    existing.push(pkg);
+    npmByRepoKey.set(repoKey, existing);
   }
 
   const results: DiscoveredPlugin[] = [];
 
-  // Process GitHub repos first, merging with npm matches
+  // Process GitHub repos first, merging with npm matches when unambiguous.
   for (const repo of githubRepos) {
-    const normalizedUrl = normalizeGitHubUrl(repo.html_url);
-    const matchedNpm = normalizedUrl ? npmByRepoUrl.get(normalizedUrl) : undefined;
+    const repoKey = extractGitHubRepoKey(repo.html_url);
+    const matchedPackages = repoKey ? (npmByRepoKey.get(repoKey) ?? []) : [];
+    const matchedNpm = matchedPackages.length === 1 ? matchedPackages[0] : undefined;
 
     if (matchedNpm) {
       npmUsed.add(matchedNpm.name);
@@ -135,6 +199,14 @@ export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> 
 
     const npmName = matchedNpm?.name ?? null;
     const installSource = npmName ? `npm:${npmName}` : `git:${repo.html_url}.git`;
+    const installedPluginId = getInstalledPluginId({
+      source: installSource,
+      npmPackage: npmName,
+      repoKey,
+      installedSources,
+      installedNpmPackages,
+      installedGitHubRepos,
+    });
 
     results.push({
       name: npmName ?? repo.full_name,
@@ -146,7 +218,8 @@ export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> 
       npmPackage: npmName,
       stars: repo.stargazers_count,
       installSource,
-      installed: isInstalled(installSource, npmName, installedSources, installedNames),
+      installed: installedPluginId !== null,
+      installedPluginId,
     });
   }
 
@@ -154,7 +227,17 @@ export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> 
   for (const pkg of npmPackages) {
     if (npmUsed.has(pkg.name)) continue;
 
-    const repoUrl = pkg.links?.repository ?? null;
+    const repoKey = extractGitHubRepoKey(pkg.links?.repository);
+
+    const installSource = `npm:${pkg.name}`;
+    const installedPluginId = getInstalledPluginId({
+      source: installSource,
+      npmPackage: pkg.name,
+      repoKey,
+      installedSources,
+      installedNpmPackages,
+      installedGitHubRepos,
+    });
 
     results.push({
       name: pkg.name,
@@ -162,11 +245,12 @@ export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> 
       description: pkg.description ?? '',
       author: pkg.publisher?.username ?? '',
       version: pkg.version,
-      githubUrl: repoUrl,
+      githubUrl: toGitHubRepoUrl(repoKey),
       npmPackage: pkg.name,
       stars: 0,
-      installSource: `npm:${pkg.name}`,
-      installed: isInstalled(`npm:${pkg.name}`, pkg.name, installedSources, installedNames),
+      installSource,
+      installed: installedPluginId !== null,
+      installedPluginId,
     });
   }
 
@@ -175,15 +259,25 @@ export async function searchPlugins(query: string): Promise<DiscoveredPlugin[]> 
 
 // ── Helpers ────────────────────────────────────────────────
 
-function isInstalled(
-  source: string,
-  npmName: string | null,
-  installedSources: Set<string>,
-  installedNames: Set<string>,
-): boolean {
-  if (installedSources.has(source)) return true;
-  if (npmName && installedNames.has(npmName)) return true;
-  return false;
+function getInstalledPluginId({
+  source,
+  npmPackage,
+  repoKey,
+  installedSources,
+  installedNpmPackages,
+  installedGitHubRepos,
+}: {
+  source: string;
+  npmPackage: string | null;
+  repoKey: string | null;
+  installedSources: Map<string, string>;
+  installedNpmPackages: Map<string, string>;
+  installedGitHubRepos: Map<string, string>;
+}): string | null {
+  return installedSources.get(source)
+    ?? (npmPackage ? installedNpmPackages.get(npmPackage) : null)
+    ?? (repoKey ? installedGitHubRepos.get(repoKey) : null)
+    ?? null;
 }
 
 function formatRepoName(name: string): string {
@@ -191,7 +285,7 @@ function formatRepoName(name: string): string {
     .replace(/^sero-/, '')
     .replace(/-plugin$/, '')
     .split('-')
-    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
     .join(' ');
 }
 

--- a/apps/desktop/electron/features/plugins/types.ts
+++ b/apps/desktop/electron/features/plugins/types.ts
@@ -10,4 +10,5 @@ export type {
   PluginCategory,
   PluginMeta,
   PluginRegistryEntry,
+  DiscoveredPlugin,
 } from '@sero/common';

--- a/apps/desktop/electron/ipc/integrations/plugins.ts
+++ b/apps/desktop/electron/ipc/integrations/plugins.ts
@@ -4,13 +4,14 @@
 
 import { BrowserWindow, ipcMain } from 'electron';
 import { IpcChannels } from '../../../src/types/ipc';
-import type { SeroAppManifest, InstalledPlugin, PluginChangeEvent } from '../../../src/types/ipc';
+import type { SeroAppManifest, InstalledPlugin, PluginChangeEvent, DiscoveredPlugin } from '../../../src/types/ipc';
 import {
   installPlugin,
   uninstallPlugin,
   listInstalledPlugins,
   isInstalledPlugin,
 } from '../../features/plugins/manager';
+import { searchPlugins } from '../../features/plugins/discovery';
 import { reloadAllSessionResources } from '../agent';
 import { disposeAppSessionsForApp } from '../agent/handlers/app-agent';
 
@@ -57,6 +58,13 @@ export function registerPluginHandlers(): void {
     IpcChannels.plugins.isPlugin,
     async (_event, pluginId: string): Promise<boolean> => {
       return isInstalledPlugin(pluginId);
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.plugins.search,
+    async (_event, query: string): Promise<DiscoveredPlugin[]> => {
+      return searchPlugins(query ?? '');
     },
   );
 }

--- a/apps/desktop/electron/preload/integrations/plugins.ts
+++ b/apps/desktop/electron/preload/integrations/plugins.ts
@@ -4,7 +4,7 @@
 
 import { ipcRenderer } from 'electron';
 import { IpcChannels } from '../../../src/types/ipc';
-import type { SeroAppManifest, InstalledPlugin, PluginChangeEvent } from '../../../src/types/ipc';
+import type { SeroAppManifest, InstalledPlugin, PluginChangeEvent, DiscoveredPlugin } from '../../../src/types/ipc';
 
 export const pluginsBridge = {
   install: (source: string): Promise<SeroAppManifest> =>
@@ -18,6 +18,9 @@ export const pluginsBridge = {
 
   isPlugin: (pluginId: string): Promise<boolean> =>
     ipcRenderer.invoke(IpcChannels.plugins.isPlugin, pluginId),
+
+  search: (query: string): Promise<DiscoveredPlugin[]> =>
+    ipcRenderer.invoke(IpcChannels.plugins.search, query),
 
   onChanged: (callback: (event: PluginChangeEvent) => void): (() => void) => {
     const handler = (_event: Electron.IpcRendererEvent, data: PluginChangeEvent) => {

--- a/apps/desktop/src/components/layout/AppStoreDialog.tsx
+++ b/apps/desktop/src/components/layout/AppStoreDialog.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
-import { Search, Store } from 'lucide-react';
+import { useState, useCallback } from 'react';
+import { Search, Store, Loader2, Globe } from 'lucide-react';
 import { Input } from '@sero-ai/ui/components/ui/input';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@sero-ai/ui/components/ui/tabs';
 import {
   Dialog,
   DialogContent,
@@ -10,7 +11,10 @@ import {
   DialogTitle,
 } from '@sero-ai/ui/components/ui/dialog';
 import type { AppEntry } from '@/stores/app';
+import type { DiscoveredPlugin } from '@/types/ipc';
+import { useDebouncedCallback } from '@/hooks/useDebouncedCallback';
 import { AppStoreCard } from './AppStoreCard';
+import { DiscoverPluginCard } from './DiscoverPluginCard';
 
 interface AppStoreDialogProps {
   open: boolean;
@@ -50,6 +54,13 @@ export function AppStoreDialog({
   onActivateApp,
 }: AppStoreDialogProps) {
   const [searchQuery, setSearchQuery] = useState('');
+  const [activeTab, setActiveTab] = useState('installed');
+
+  // Discover tab state
+  const [discoverQuery, setDiscoverQuery] = useState('');
+  const [discoverResults, setDiscoverResults] = useState<DiscoveredPlugin[]>([]);
+  const [discoverLoading, setDiscoverLoading] = useState(false);
+  const [discoverSearched, setDiscoverSearched] = useState(false);
 
   const query = searchQuery.trim().toLowerCase();
   const filteredApps = apps
@@ -64,9 +75,47 @@ export function AppStoreDialog({
       return a.label.localeCompare(b.label);
     });
 
+  const runDiscoverSearch = useCallback(async (q: string) => {
+    setDiscoverLoading(true);
+    setDiscoverSearched(true);
+    try {
+      const results = await window.sero.plugins.search(q);
+      setDiscoverResults(results);
+    } catch (err) {
+      console.error('[AppStore] Plugin search failed:', err);
+      setDiscoverResults([]);
+    } finally {
+      setDiscoverLoading(false);
+    }
+  }, []);
+
+  const debouncedSearch = useDebouncedCallback((q: string) => {
+    runDiscoverSearch(q);
+  }, 400);
+
+  const handleDiscoverQueryChange = (value: string) => {
+    setDiscoverQuery(value);
+    debouncedSearch(value);
+  };
+
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+    // Auto-search on first visit to discover tab
+    if (tab === 'discover' && !discoverSearched) {
+      runDiscoverSearch('');
+    }
+  };
+
+  const handleInstallPlugin = async (plugin: DiscoveredPlugin) => {
+    await window.sero.plugins.install(plugin.installSource);
+  };
+
   const handleOpenChange = (nextOpen: boolean) => {
     onOpenChange(nextOpen);
-    if (!nextOpen) setSearchQuery('');
+    if (!nextOpen) {
+      setSearchQuery('');
+      setActiveTab('installed');
+    }
   };
 
   return (
@@ -78,53 +127,111 @@ export function AppStoreDialog({
             App Store
           </DialogTitle>
           <DialogDescription>
-            Browse installed Sero apps and choose which ones appear in the sidebar.
+            Browse installed apps or discover new plugins from the community.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="border-b border-[var(--border-default)] px-4 py-3">
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
-            <Input
-              autoFocus
-              value={searchQuery}
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder="Search apps…"
-              className="pl-9"
-            />
+        <Tabs value={activeTab} onValueChange={handleTabChange} className="flex min-h-0 flex-1 flex-col">
+          <div className="border-b border-[var(--border-default)] px-4">
+            <TabsList variant="line" className="h-9">
+              <TabsTrigger value="installed" className="text-xs">
+                Installed
+              </TabsTrigger>
+              <TabsTrigger value="discover" className="text-xs">
+                <Globe className="mr-1 size-3" />
+                Discover
+              </TabsTrigger>
+            </TabsList>
           </div>
-        </div>
 
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="p-4">
-            {apps.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-[var(--border-default)] p-6 text-center">
-                <p className="text-sm text-[var(--text-secondary)]">No discovered apps yet.</p>
+          <TabsContent value="installed" className="mt-0 flex min-h-0 flex-1 flex-col">
+            <div className="border-b border-[var(--border-default)] px-4 py-3">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
+                <Input
+                  autoFocus
+                  value={searchQuery}
+                  onChange={(event) => setSearchQuery(event.target.value)}
+                  placeholder="Search installed apps…"
+                  className="pl-9"
+                />
               </div>
-            ) : filteredApps.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-[var(--border-default)] p-6 text-center">
-                <p className="text-sm text-[var(--text-secondary)]">No apps match “{searchQuery}”.</p>
+            </div>
+
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="p-4">
+                {apps.length === 0 ? (
+                  <EmptyState message="No discovered apps yet." />
+                ) : filteredApps.length === 0 ? (
+                  <EmptyState message={`No apps match "${searchQuery}".`} />
+                ) : (
+                  <div className="grid gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+                    {filteredApps.map((app) => (
+                      <AppStoreCard
+                        key={app.id}
+                        entry={app}
+                        active={activeApp === app.id}
+                        favourite={isFavourite(app.id)}
+                        onToggleFavourite={() => onToggleFavourite(app.id)}
+                        onActivate={() => {
+                          onActivateApp(app.id);
+                          handleOpenChange(false);
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
               </div>
-            ) : (
-              <div className="grid gap-3 sm:grid-cols-2 2xl:grid-cols-3">
-                {filteredApps.map((app) => (
-                  <AppStoreCard
-                    key={app.id}
-                    entry={app}
-                    active={activeApp === app.id}
-                    favourite={isFavourite(app.id)}
-                    onToggleFavourite={() => onToggleFavourite(app.id)}
-                    onActivate={() => {
-                      onActivateApp(app.id);
-                      handleOpenChange(false);
-                    }}
-                  />
-                ))}
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="discover" className="mt-0 flex min-h-0 flex-1 flex-col">
+            <div className="border-b border-[var(--border-default)] px-4 py-3">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
+                <Input
+                  value={discoverQuery}
+                  onChange={(event) => handleDiscoverQueryChange(event.target.value)}
+                  placeholder="Search public plugins…"
+                  className="pl-9"
+                />
               </div>
-            )}
-          </div>
-        </ScrollArea>
+            </div>
+
+            <ScrollArea className="min-h-0 flex-1">
+              <div className="p-4">
+                {discoverLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Loader2 className="size-5 animate-spin text-[var(--text-muted)]" />
+                  </div>
+                ) : !discoverSearched ? (
+                  <EmptyState message="Search for community plugins above." />
+                ) : discoverResults.length === 0 ? (
+                  <EmptyState message={discoverQuery ? `No plugins found for "${discoverQuery}".` : 'No public plugins found.'} />
+                ) : (
+                  <div className="grid gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+                    {discoverResults.map((plugin) => (
+                      <DiscoverPluginCard
+                        key={plugin.installSource}
+                        plugin={plugin}
+                        onInstall={handleInstallPlugin}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-[var(--border-default)] p-6 text-center">
+      <p className="text-sm text-[var(--text-secondary)]">{message}</p>
+    </div>
   );
 }

--- a/apps/desktop/src/components/layout/AppStoreDialog.tsx
+++ b/apps/desktop/src/components/layout/AppStoreDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Search, Store, Loader2, Globe } from 'lucide-react';
 import { Input } from '@sero-ai/ui/components/ui/input';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
@@ -62,6 +62,11 @@ export function AppStoreDialog({
   const [discoverLoading, setDiscoverLoading] = useState(false);
   const [discoverSearched, setDiscoverSearched] = useState(false);
 
+  const discoverRequestIdRef = useRef(0);
+  const discoverSessionRef = useRef(0);
+  const dialogOpenRef = useRef(open);
+  dialogOpenRef.current = open;
+
   const query = searchQuery.trim().toLowerCase();
   const filteredApps = apps
     .filter((app) => {
@@ -75,46 +80,91 @@ export function AppStoreDialog({
       return a.label.localeCompare(b.label);
     });
 
-  const runDiscoverSearch = useCallback(async (q: string) => {
+  const runDiscoverSearch = useCallback(async (q: string, sessionId: number) => {
+    if (!dialogOpenRef.current || sessionId !== discoverSessionRef.current) return;
+
+    const requestId = ++discoverRequestIdRef.current;
     setDiscoverLoading(true);
     setDiscoverSearched(true);
+
     try {
       const results = await window.sero.plugins.search(q);
+      if (
+        requestId !== discoverRequestIdRef.current ||
+        sessionId !== discoverSessionRef.current ||
+        !dialogOpenRef.current
+      ) {
+        return;
+      }
       setDiscoverResults(results);
     } catch (err) {
+      if (
+        requestId !== discoverRequestIdRef.current ||
+        sessionId !== discoverSessionRef.current ||
+        !dialogOpenRef.current
+      ) {
+        return;
+      }
       console.error('[AppStore] Plugin search failed:', err);
       setDiscoverResults([]);
     } finally {
-      setDiscoverLoading(false);
+      if (
+        requestId === discoverRequestIdRef.current &&
+        sessionId === discoverSessionRef.current &&
+        dialogOpenRef.current
+      ) {
+        setDiscoverLoading(false);
+      }
     }
   }, []);
 
-  const debouncedSearch = useDebouncedCallback((q: string) => {
-    runDiscoverSearch(q);
+  const debouncedSearch = useDebouncedCallback((q: string, sessionId: number) => {
+    void runDiscoverSearch(q, sessionId);
   }, 400);
 
   const handleDiscoverQueryChange = (value: string) => {
     setDiscoverQuery(value);
-    debouncedSearch(value);
+    debouncedSearch(value, discoverSessionRef.current);
   };
 
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
-    // Auto-search on first visit to discover tab
     if (tab === 'discover' && !discoverSearched) {
-      runDiscoverSearch('');
+      void runDiscoverSearch('', discoverSessionRef.current);
     }
   };
 
   const handleInstallPlugin = async (plugin: DiscoveredPlugin) => {
-    await window.sero.plugins.install(plugin.installSource);
+    const manifest = await window.sero.plugins.install(plugin.installSource);
+    if (!dialogOpenRef.current) return;
+
+    setDiscoverResults((results) => markPluginInstalled(results, plugin, manifest.id));
+  };
+
+  const handleUninstallPlugin = async (plugin: DiscoveredPlugin) => {
+    if (!plugin.installedPluginId) {
+      throw new Error('Could not determine which installed plugin to uninstall.');
+    }
+
+    await window.sero.plugins.uninstall(plugin.installedPluginId);
+    if (!dialogOpenRef.current) return;
+
+    setDiscoverResults((results) => markPluginUninstalled(results, plugin));
   };
 
   const handleOpenChange = (nextOpen: boolean) => {
+    dialogOpenRef.current = nextOpen;
     onOpenChange(nextOpen);
+
     if (!nextOpen) {
+      discoverRequestIdRef.current += 1;
+      discoverSessionRef.current += 1;
       setSearchQuery('');
       setActiveTab('installed');
+      setDiscoverQuery('');
+      setDiscoverResults([]);
+      setDiscoverLoading(false);
+      setDiscoverSearched(false);
     }
   };
 
@@ -215,6 +265,7 @@ export function AppStoreDialog({
                         key={plugin.installSource}
                         plugin={plugin}
                         onInstall={handleInstallPlugin}
+                        onUninstall={handleUninstallPlugin}
                       />
                     ))}
                   </div>
@@ -234,4 +285,47 @@ function EmptyState({ message }: { message: string }) {
       <p className="text-sm text-[var(--text-secondary)]">{message}</p>
     </div>
   );
+}
+
+function markPluginInstalled(
+  results: DiscoveredPlugin[],
+  installedPlugin: DiscoveredPlugin,
+  installedPluginId: string,
+): DiscoveredPlugin[] {
+  return results.map((plugin) => {
+    if (!isSameDiscoveredPlugin(plugin, installedPlugin)) return plugin;
+    return { ...plugin, installed: true, installedPluginId };
+  });
+}
+
+function markPluginUninstalled(
+  results: DiscoveredPlugin[],
+  uninstalledPlugin: DiscoveredPlugin,
+): DiscoveredPlugin[] {
+  return results.map((plugin) => {
+    if (!isSameDiscoveredPlugin(plugin, uninstalledPlugin)) return plugin;
+    return { ...plugin, installed: false, installedPluginId: null };
+  });
+}
+
+function isSameDiscoveredPlugin(
+  plugin: DiscoveredPlugin,
+  target: DiscoveredPlugin,
+): boolean {
+  const pluginRepoKey = getGitHubRepoKey(plugin.githubUrl);
+  const targetRepoKey = getGitHubRepoKey(target.githubUrl);
+
+  return (
+    plugin.installSource === target.installSource ||
+    (plugin.npmPackage !== null && plugin.npmPackage === target.npmPackage) ||
+    (pluginRepoKey !== null && pluginRepoKey === targetRepoKey)
+  );
+}
+
+function getGitHubRepoKey(url: string | null): string | null {
+  if (!url) return null;
+
+  const match = url.match(/github\.com\/([^/]+)\/([^/#?]+)/i);
+  if (!match) return null;
+  return `${match[1]}/${match[2].replace(/\.git$/i, '')}`.toLowerCase();
 }

--- a/apps/desktop/src/components/layout/DiscoverPluginCard.tsx
+++ b/apps/desktop/src/components/layout/DiscoverPluginCard.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Download, Check, Loader2, Star, Github, Package } from 'lucide-react';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import type { DiscoveredPlugin } from '@/types/ipc';
+
+interface DiscoverPluginCardProps {
+  key?: string;
+  plugin: DiscoveredPlugin;
+  onInstall: (plugin: DiscoveredPlugin) => Promise<void>;
+}
+
+export function DiscoverPluginCard({ plugin, onInstall }: DiscoverPluginCardProps) {
+  const [installing, setInstalling] = useState(false);
+  const [installed, setInstalled] = useState(plugin.installed);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleInstall = async () => {
+    setInstalling(true);
+    setError(null);
+    try {
+      await onInstall(plugin);
+      setInstalled(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Install failed');
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  return (
+    <div className="group rounded-xl border border-[var(--border-default)] bg-[var(--bg-surface)] p-3 text-left transition-colors hover:bg-[var(--bg-elevated)]">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-[var(--bg-base)] text-[var(--text-secondary)]">
+          <Package className="size-4" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-sm font-medium text-[var(--text-primary)]">
+              {plugin.displayName}
+            </span>
+            {plugin.version ? (
+              <span className="shrink-0 text-[11px] text-[var(--text-muted)]">
+                v{plugin.version}
+              </span>
+            ) : null}
+          </div>
+          <p className="truncate text-xs text-[var(--text-muted)]">
+            {plugin.author}
+          </p>
+        </div>
+
+        {installed ? (
+          <Button type="button" variant="ghost" size="icon-sm" disabled>
+            <Check className="size-4 text-[var(--status-success)]" />
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Install ${plugin.displayName}`}
+            disabled={installing}
+            onClick={handleInstall}
+          >
+            {installing ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Download className="size-4 text-[var(--text-muted)]" />
+            )}
+          </Button>
+        )}
+      </div>
+
+      <p className="mt-3 min-h-10 text-xs leading-5 text-[var(--text-secondary)]">
+        {plugin.description || 'No description available.'}
+      </p>
+
+      {error ? (
+        <p className="mt-1 text-xs text-[var(--status-error)]">{error}</p>
+      ) : null}
+
+      <div className="mt-3 flex items-center gap-2">
+        {plugin.stars > 0 ? (
+          <Badge
+            variant="outline"
+            className="gap-1 text-[11px] border-[var(--border-default)] text-[var(--text-muted)]"
+          >
+            <Star className="size-3" />
+            {plugin.stars}
+          </Badge>
+        ) : null}
+        {plugin.npmPackage ? (
+          <Badge
+            variant="outline"
+            className="gap-1 text-[11px] border-[var(--status-error-border)] bg-[var(--status-error-muted)] text-[var(--status-error)]"
+          >
+            <Package className="size-3" />
+            npm
+          </Badge>
+        ) : null}
+        {plugin.githubUrl ? (
+          <Badge
+            variant="outline"
+            className="gap-1 text-[11px] border-[var(--border-default)] text-[var(--text-muted)]"
+          >
+            <Github className="size-3" />
+            GitHub
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/DiscoverPluginCard.tsx
+++ b/apps/desktop/src/components/layout/DiscoverPluginCard.tsx
@@ -1,37 +1,76 @@
 import { useState } from 'react';
-import { Download, Check, Loader2, Star, Github, Package } from 'lucide-react';
+import {
+  Download,
+  Loader2,
+  Star,
+  Github,
+  Package,
+  Trash2,
+} from 'lucide-react';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { Button } from '@sero-ai/ui/components/ui/button';
+import { cn } from '@sero-ai/ui/lib/utils';
 import type { DiscoveredPlugin } from '@/types/ipc';
 
 interface DiscoverPluginCardProps {
-  key?: string;
   plugin: DiscoveredPlugin;
   onInstall: (plugin: DiscoveredPlugin) => Promise<void>;
+  onUninstall: (plugin: DiscoveredPlugin) => Promise<void>;
 }
 
-export function DiscoverPluginCard({ plugin, onInstall }: DiscoverPluginCardProps) {
-  const [installing, setInstalling] = useState(false);
-  const [installed, setInstalled] = useState(plugin.installed);
+export function DiscoverPluginCard({
+  plugin,
+  onInstall,
+  onUninstall,
+}: DiscoverPluginCardProps) {
+  const [pendingAction, setPendingAction] = useState<'install' | 'uninstall' | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const handleInstall = async () => {
-    setInstalling(true);
+    setPendingAction('install');
     setError(null);
     try {
       await onInstall(plugin);
-      setInstalled(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Install failed');
     } finally {
-      setInstalling(false);
+      setPendingAction(null);
     }
   };
 
+  const handleUninstall = async () => {
+    setPendingAction('uninstall');
+    setError(null);
+    try {
+      await onUninstall(plugin);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Uninstall failed');
+    } finally {
+      setPendingAction(null);
+    }
+  };
+
+  const isInstalling = pendingAction === 'install';
+  const isUninstalling = pendingAction === 'uninstall';
+
   return (
-    <div className="group rounded-xl border border-[var(--border-default)] bg-[var(--bg-surface)] p-3 text-left transition-colors hover:bg-[var(--bg-elevated)]">
+    <div
+      className={cn(
+        'group rounded-xl border p-3 text-left transition-colors',
+        plugin.installed
+          ? 'border-[var(--status-success-border)] bg-[var(--status-success-faint)] hover:bg-[var(--status-success-subtle)]'
+          : 'border-[var(--border-default)] bg-[var(--bg-surface)] hover:bg-[var(--bg-elevated)]',
+      )}
+    >
       <div className="flex items-start gap-3">
-        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-[var(--bg-base)] text-[var(--text-secondary)]">
+        <div
+          className={cn(
+            'mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md',
+            plugin.installed
+              ? 'bg-[var(--status-success-muted)] text-[var(--status-success)]'
+              : 'bg-[var(--bg-base)] text-[var(--text-secondary)]',
+          )}
+        >
           <Package className="size-4" />
         </div>
 
@@ -46,69 +85,81 @@ export function DiscoverPluginCard({ plugin, onInstall }: DiscoverPluginCardProp
               </span>
             ) : null}
           </div>
-          <p className="truncate text-xs text-[var(--text-muted)]">
-            {plugin.author}
-          </p>
+          <p className="truncate text-xs text-[var(--text-muted)]">{plugin.author}</p>
         </div>
 
-        {installed ? (
-          <Button type="button" variant="ghost" size="icon-sm" disabled>
-            <Check className="size-4 text-[var(--status-success)]" />
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label={`Install ${plugin.displayName}`}
-            disabled={installing}
-            onClick={handleInstall}
-          >
-            {installing ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <Download className="size-4 text-[var(--text-muted)]" />
-            )}
-          </Button>
-        )}
       </div>
 
       <p className="mt-3 min-h-10 text-xs leading-5 text-[var(--text-secondary)]">
         {plugin.description || 'No description available.'}
       </p>
 
-      {error ? (
-        <p className="mt-1 text-xs text-[var(--status-error)]">{error}</p>
-      ) : null}
+      {error ? <p className="mt-1 text-xs text-[var(--status-error)]">{error}</p> : null}
 
-      <div className="mt-3 flex items-center gap-2">
-        {plugin.stars > 0 ? (
-          <Badge
+      <div className="mt-3 flex items-end justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          {plugin.stars > 0 ? (
+            <Badge
+              variant="outline"
+              className="gap-1 border-[var(--border-default)] text-[11px] text-[var(--text-muted)]"
+            >
+              <Star className="size-3" />
+              {plugin.stars}
+            </Badge>
+          ) : null}
+          {plugin.npmPackage ? (
+            <Badge
+              variant="outline"
+              className="gap-1 border-[var(--status-error-border)] bg-[var(--status-error-muted)] text-[11px] text-[var(--status-error)]"
+            >
+              <Package className="size-3" />
+              npm
+            </Badge>
+          ) : null}
+          {plugin.githubUrl ? (
+            <Badge
+              variant="outline"
+              className="gap-1 border-[var(--border-default)] text-[11px] text-[var(--text-muted)]"
+            >
+              <Github className="size-3" />
+              GitHub
+            </Badge>
+          ) : null}
+        </div>
+
+        {plugin.installed ? (
+          <Button
+            type="button"
             variant="outline"
-            className="gap-1 text-[11px] border-[var(--border-default)] text-[var(--text-muted)]"
+            size="icon-xs"
+            aria-label={`Uninstall ${plugin.displayName}`}
+            disabled={isUninstalling}
+            onClick={handleUninstall}
+            className="h-7 w-7 shrink-0 border-[var(--status-error-border)] bg-[var(--status-error-muted)] text-[var(--status-error)] hover:bg-[var(--status-error-subtle)]"
           >
-            <Star className="size-3" />
-            {plugin.stars}
-          </Badge>
-        ) : null}
-        {plugin.npmPackage ? (
-          <Badge
+            {isUninstalling ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <Trash2 className="size-3" />
+            )}
+          </Button>
+        ) : (
+          <Button
+            type="button"
             variant="outline"
-            className="gap-1 text-[11px] border-[var(--status-error-border)] bg-[var(--status-error-muted)] text-[var(--status-error)]"
+            size="xs"
+            disabled={isInstalling}
+            onClick={handleInstall}
+            className="h-7 shrink-0 border-[var(--status-success-border)] bg-[var(--status-success-muted)] px-2.5 text-[var(--status-success)] hover:bg-[var(--status-success-subtle)]"
           >
-            <Package className="size-3" />
-            npm
-          </Badge>
-        ) : null}
-        {plugin.githubUrl ? (
-          <Badge
-            variant="outline"
-            className="gap-1 text-[11px] border-[var(--border-default)] text-[var(--text-muted)]"
-          >
-            <Github className="size-3" />
-            GitHub
-          </Badge>
-        ) : null}
+            {isInstalling ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <Download className="size-3" />
+            )}
+            Install
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -50,6 +50,7 @@ import type {
   SubagentEntry,
   InstalledPlugin,
   PluginChangeEvent,
+  DiscoveredPlugin,
   SkillSummary,
   AvailableSkillSummary,
   SkillFileData,
@@ -397,6 +398,8 @@ interface SeroPluginsAPI {
   list(): Promise<InstalledPlugin[]>;
   /** Check whether an app ID is an installed plugin (vs core). */
   isPlugin(pluginId: string): Promise<boolean>;
+  /** Search for public plugins on GitHub (topic) and npm (keyword). */
+  search(query: string): Promise<DiscoveredPlugin[]>;
   /** Subscribe to plugin install/uninstall events. */
   onChanged(callback: (event: PluginChangeEvent) => void): () => void;
 }

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -445,6 +445,8 @@ export const IpcChannels = {
     list: 'sero:plugins:list',
     /** Check if a specific app is an installed plugin. */
     isPlugin: 'sero:plugins:is-plugin',
+    /** Search for public plugins on GitHub (topic) and npm (keyword). */
+    search: 'sero:plugins:search',
     /** Main → renderer push: plugin installed or uninstalled. */
     event: 'sero:plugins:event',
   },

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -267,7 +267,7 @@ export type { SettingsPackageSource, SeroAppManifest, SeroWidgetManifest } from 
 
 // ── Plugins ─────────────────────────────────────────────────
 
-export type { InstalledPlugin, PluginCategory, PluginMeta, PluginChangeEvent } from './plugins';
+export type { InstalledPlugin, PluginCategory, PluginMeta, PluginChangeEvent, DiscoveredPlugin } from './plugins';
 
 // ── Voice Transcription ──────────────────────────────────────
 

--- a/apps/desktop/src/types/plugins.ts
+++ b/apps/desktop/src/types/plugins.ts
@@ -1,6 +1,6 @@
 import type { SeroAppManifest } from './ipc';
 
-export type { InstalledPlugin, PluginCategory, PluginMeta } from '@sero/common';
+export type { InstalledPlugin, PluginCategory, PluginMeta, DiscoveredPlugin } from '@sero/common';
 
 /** Events pushed from main → renderer when plugin installation state changes. */
 export type PluginChangeEvent =

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -10,4 +10,5 @@ export type {
   PluginCategory,
   PluginMeta,
   PluginRegistryEntry,
+  DiscoveredPlugin,
 } from './plugins';

--- a/packages/common/src/plugins.ts
+++ b/packages/common/src/plugins.ts
@@ -86,4 +86,6 @@ export interface DiscoveredPlugin {
   installSource: string;
   /** Whether this plugin is already installed locally. */
   installed: boolean;
+  /** Installed plugin ID, used for uninstall actions in discovery UI. */
+  installedPluginId: string | null;
 }

--- a/packages/common/src/plugins.ts
+++ b/packages/common/src/plugins.ts
@@ -63,3 +63,27 @@ export interface PluginRegistryEntry {
   author: string;
   verified?: boolean;
 }
+
+/** A plugin discovered via GitHub topic / npm keyword search. */
+export interface DiscoveredPlugin {
+  /** npm package name (if on npm), otherwise GitHub repo full_name. */
+  name: string;
+  /** Human-readable display name. */
+  displayName: string;
+  /** Package description. */
+  description: string;
+  /** Author / owner name. */
+  author: string;
+  /** Latest version (from npm, if available). */
+  version: string | null;
+  /** GitHub repo URL. */
+  githubUrl: string | null;
+  /** npm package name (if published to npm). */
+  npmPackage: string | null;
+  /** GitHub star count. */
+  stars: number;
+  /** Install source string for installPlugin(). */
+  installSource: string;
+  /** Whether this plugin is already installed locally. */
+  installed: boolean;
+}


### PR DESCRIPTION
Add a "Discover" tab to the App Store dialog that searches for public
Sero plugins using the "sero-ai-plugin" GitHub topic and npm keyword.
Results from both sources are merged/deduplicated, and plugins can be
installed directly from the discovery UI.

https://claude.ai/code/session_01EdSZWqX6HduHJ2CfhgJLEq