### PR TITLE
fix(desktop): persist context editor overrides per session

### DIFF
--- a/apps/desktop/electron/ipc/agent/core/agent-context-overrides.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-context-overrides.ts
@@ -1,0 +1,146 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { ContextOverrides, ContextToolInfo } from '../../../../src/types/ipc';
+import { setBaseSystemPrompt, stripDisabledSkills } from './agent-helpers';
+
+const CONTEXT_OVERRIDES_CUSTOM_TYPE = 'sero-context-overrides';
+
+export interface ContextOverrideSessionState {
+  session: AgentSession;
+  baseSystemPrompt: string;
+  baseTools: ContextToolInfo[];
+  contextOverrides: ContextOverrides | null;
+}
+
+function normalizeNames(value: unknown, allowed?: Set<string>): string[] {
+  if (!Array.isArray(value)) return [];
+
+  const result: string[] = [];
+  const seen = new Set<string>();
+
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const name = item.trim();
+    if (!name || seen.has(name)) continue;
+    if (allowed && !allowed.has(name)) continue;
+    seen.add(name);
+    result.push(name);
+  }
+
+  return result;
+}
+
+function normalizeContextOverrides(
+  value: unknown,
+  allowedToolNames?: Set<string>,
+): ContextOverrides | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'object') return null;
+
+  const raw = value as Record<string, unknown>;
+  const systemPrompt = typeof raw.systemPrompt === 'string' ? raw.systemPrompt : undefined;
+  const disabledTools = normalizeNames(raw.disabledTools, allowedToolNames);
+  const disabledSkills = normalizeNames(raw.disabledSkills);
+
+  if (systemPrompt === undefined && disabledTools.length === 0 && disabledSkills.length === 0) {
+    return null;
+  }
+
+  const overrides: ContextOverrides = {};
+
+  if (systemPrompt !== undefined) {
+    overrides.systemPrompt = systemPrompt;
+  }
+  if (disabledTools.length > 0) {
+    overrides.disabledTools = disabledTools;
+  }
+  if (disabledSkills.length > 0) {
+    overrides.disabledSkills = disabledSkills;
+  }
+
+  return overrides;
+}
+
+export function areContextOverridesEqual(
+  left: ContextOverrides | null,
+  right: ContextOverrides | null,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return !left && !right;
+
+  const leftPrompt = typeof left.systemPrompt === 'string' ? left.systemPrompt : undefined;
+  const rightPrompt = typeof right.systemPrompt === 'string' ? right.systemPrompt : undefined;
+  if (leftPrompt !== rightPrompt) return false;
+
+  const leftTools = left.disabledTools ?? [];
+  const rightTools = right.disabledTools ?? [];
+  if (leftTools.length !== rightTools.length) return false;
+  if (leftTools.some((name, index) => name !== rightTools[index])) return false;
+
+  const leftSkills = left.disabledSkills ?? [];
+  const rightSkills = right.disabledSkills ?? [];
+  if (leftSkills.length !== rightSkills.length) return false;
+  if (leftSkills.some((name, index) => name !== rightSkills[index])) return false;
+
+  return true;
+}
+
+export function readPersistedContextOverrides(
+  session: AgentSession,
+  toolNames: string[],
+): ContextOverrides | null {
+  const allowedToolNames = new Set(toolNames);
+  const entries = session.sessionManager.getEntries();
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.type !== 'custom' || entry.customType !== CONTEXT_OVERRIDES_CUSTOM_TYPE) {
+      continue;
+    }
+    return normalizeContextOverrides(entry.data, allowedToolNames);
+  }
+
+  return null;
+}
+
+export function persistContextOverrides(
+  session: AgentSession,
+  overrides: ContextOverrides | null,
+): void {
+  session.sessionManager.appendCustomEntry(CONTEXT_OVERRIDES_CUSTOM_TYPE, overrides);
+
+  const maybeRewriteFile = (session.sessionManager as unknown as { _rewriteFile?: () => void })._rewriteFile;
+  if (typeof maybeRewriteFile === 'function') {
+    maybeRewriteFile.call(session.sessionManager);
+  }
+}
+
+export function applyContextOverrides(
+  entry: ContextOverrideSessionState,
+  overrides: ContextOverrides | null,
+): ContextOverrides | null {
+  const normalized = normalizeContextOverrides(
+    overrides,
+    new Set(entry.baseTools.map((tool) => tool.name)),
+  );
+
+  const disabledTools = new Set(normalized?.disabledTools ?? []);
+  const activeToolNames = entry.baseTools
+    .map((tool) => tool.name)
+    .filter((name) => !disabledTools.has(name));
+
+  entry.session.setActiveToolsByName(activeToolNames);
+
+  let effectivePrompt =
+    typeof normalized?.systemPrompt === 'string'
+      ? normalized.systemPrompt
+      : entry.baseSystemPrompt;
+
+  if (normalized?.disabledSkills?.length) {
+    effectivePrompt = stripDisabledSkills(effectivePrompt, new Set(normalized.disabledSkills));
+  }
+
+  setBaseSystemPrompt(entry.session, effectivePrompt);
+  entry.contextOverrides = normalized;
+
+  return normalized;
+}

--- a/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
@@ -12,19 +12,22 @@ import type {
 } from '../../../../src/types/ipc';
 import {
   buildModelState,
-  getBaseSystemPrompt,
-  setBaseSystemPrompt,
-  stripDisabledSkills,
   validateProvider,
   validateThinkingLevel,
 } from './agent-helpers';
+import {
+  applyContextOverrides,
+  areContextOverridesEqual,
+  persistContextOverrides,
+} from './agent-context-overrides';
 import { getConfiguredModelFallbackChain } from '../../../shared/settings/model-fallback-chain';
 
 export interface AgentPoolContextEntry {
   session: AgentSession;
   loader: DefaultResourceLoader;
   contextOverrides: ContextOverrides | null;
-  originalToolNames: string[] | null;
+  baseSystemPrompt: string;
+  baseTools: ContextToolInfo[];
 }
 
 interface RegisterModelContextHandlersOptions {
@@ -196,14 +199,6 @@ export function registerAgentModelContextHandlers(
       const entry = getEntry(sessionId);
       if (!entry) return null;
 
-      const state = entry.session.agent.state;
-
-      const tools: ContextToolInfo[] = state.tools.map((t) => ({
-        name: t.name,
-        label: (t as any).label,
-        description: t.description,
-      }));
-
       const { skills: rawSkills } = entry.loader.getSkills();
       const skills: ContextSkillInfo[] = rawSkills.map((s) => ({
         name: s.name,
@@ -212,9 +207,10 @@ export function registerAgentModelContextHandlers(
       }));
 
       return {
-        systemPrompt: state.systemPrompt ?? '',
-        tools,
+        systemPrompt: entry.baseSystemPrompt,
+        tools: entry.baseTools,
         skills,
+        overrides: entry.contextOverrides,
       };
     },
   );
@@ -225,41 +221,11 @@ export function registerAgentModelContextHandlers(
       const entry = getEntry(sessionId);
       if (!entry) throw new Error(`No active session: ${sessionId}`);
 
-      const session = entry.session;
+      const previous = entry.contextOverrides;
+      const next = applyContextOverrides(entry, overrides);
 
-      if (!entry.originalToolNames) {
-        entry.originalToolNames = session.getActiveToolNames();
-      }
-
-      entry.contextOverrides = overrides;
-
-      if (!overrides) {
-        session.setActiveToolsByName(entry.originalToolNames!);
-        return;
-      }
-
-      const toolNames = entry.originalToolNames!.slice();
-      if (overrides.disabledTools?.length) {
-        const disabled = new Set(overrides.disabledTools);
-        session.setActiveToolsByName(toolNames.filter((n) => !disabled.has(n)));
-      } else {
-        session.setActiveToolsByName(toolNames);
-      }
-
-      if (
-        overrides.disabledSkills?.length &&
-        (overrides.systemPrompt === undefined || overrides.systemPrompt === null)
-      ) {
-        const disabled = new Set(overrides.disabledSkills);
-        const prompt = getBaseSystemPrompt(session);
-        if (typeof prompt === 'string') {
-          const filtered = stripDisabledSkills(prompt, disabled);
-          setBaseSystemPrompt(session, filtered);
-        }
-      }
-
-      if (overrides.systemPrompt !== undefined && overrides.systemPrompt !== null) {
-        setBaseSystemPrompt(session, overrides.systemPrompt);
+      if (!areContextOverridesEqual(previous, next)) {
+        persistContextOverrides(entry.session, next);
       }
     },
   );

--- a/apps/desktop/electron/ipc/agent/core/agent.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent.ts
@@ -19,6 +19,7 @@ import type {
   ContextUsageInfo,
   CompactResult,
   ContextOverrides,
+  ContextToolInfo,
   SeroSessionInfo,
 } from '../../../../src/types/ipc';
 import type { ChatCheckpointRef } from '../../../../src/types/checkpoints';
@@ -30,6 +31,7 @@ import {
   attachmentsToImages,
   readHiddenCommands,
   buildCommandList,
+  getBaseSystemPrompt,
 } from './agent-helpers';
 import { subscribeToSession } from './agent-subscription';
 import { readGlobalAgentsMd } from './global-agents';
@@ -48,6 +50,7 @@ import {
 import { createContainerTools } from '../../../features/container/tools';
 import type { ContainerState } from '../../../features/container';
 import { registerAgentModelContextHandlers } from './agent-model-context';
+import { applyContextOverrides, readPersistedContextOverrides } from './agent-context-overrides';
 import { createSeroUIContext } from '../../../features/apps/extensions/ui-context';
 import { installCliAgentBridge, noteCliTurnEnd } from '../../../cli/bridges';
 import { createWorkspaceCliTool, bridgeExtensionTools } from '../../../cli';
@@ -65,7 +68,8 @@ interface PoolEntry {
   /** Checkpoint from the most recently completed turn, to attach to the NEXT user message. */
   lastCompletedCheckpoint: ChatCheckpointRef | null;
   contextOverrides: ContextOverrides | null;
-  originalToolNames: string[] | null;
+  baseSystemPrompt: string;
+  baseTools: ContextToolInfo[];
 }
 
 const pool = new Map<string, PoolEntry>();
@@ -182,19 +186,40 @@ async function openSessionInternal(
   // Provide a real UIContext so extensions get working ctx.ui.notify()
   session.extensionRunner?.setUIContext(createSeroUIContext());
 
-  const unsubscribe = subscribeToSession(
-    sessionId, session,
-    () => pool.get(sessionId),
-    sendEvent,
+  const baseTools: ContextToolInfo[] = session.agent.state.tools.map((tool) => ({
+    name: tool.name,
+    label: (tool as { label?: string }).label,
+    description: tool.description,
+  }));
+  const baseSystemPrompt = getBaseSystemPrompt(session) ?? session.agent.state.systemPrompt ?? '';
+  const persistedOverrides = readPersistedContextOverrides(
+    session,
+    baseTools.map((tool) => tool.name),
   );
-  pool.set(sessionId, {
-    session, loader, unsubscribe, workspaceId,
+
+  const entry: PoolEntry = {
+    session,
+    loader,
+    unsubscribe: subscribeToSession(
+      sessionId,
+      session,
+      () => pool.get(sessionId),
+      sendEvent,
+    ),
+    workspaceId,
     currentAssistantId: null,
     lastSessionName: session.sessionName,
     lastCompletedCheckpoint: null,
     contextOverrides: null,
-    originalToolNames: null,
-  });
+    baseSystemPrompt,
+    baseTools,
+  };
+
+  if (persistedOverrides) {
+    applyContextOverrides(entry, persistedOverrides);
+  }
+
+  pool.set(sessionId, entry);
 
   return convertSessionMessages(session.messages, buildCheckpointMapByTurn(session, workspaceId));
 }

--- a/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
+++ b/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
@@ -33,7 +33,9 @@ export function ContextEditorMenuItem({
   disabled?: boolean;
 }) {
   const openEditor = useContextEditorStore((s) => s.open);
+  const loadedSessionId = useContextEditorStore((s) => s.loadedSessionId);
   const hasOverrides = useHasOverrides();
+  const showOverrideIndicator = !!sessionId && loadedSessionId === sessionId && hasOverrides;
 
   return (
     <PromptInputActionMenuItem
@@ -45,7 +47,7 @@ export function ContextEditorMenuItem({
     >
       <Settings2 className="mr-2 size-4" />
       Session context
-      {hasOverrides && (
+      {showOverrideIndicator && (
         <span className="ml-auto size-1.5 rounded-full bg-[var(--accent-primary)]" />
       )}
     </PromptInputActionMenuItem>

--- a/apps/desktop/src/components/layout/ContextEditor.tsx
+++ b/apps/desktop/src/components/layout/ContextEditor.tsx
@@ -118,7 +118,7 @@ export function ContextEditor({ sessionId }: { sessionId: string }) {
             Context Editor
           </DialogTitle>
           <DialogDescription className="text-xs">
-            Configure what is included in the LLM context for this session.
+            Configure what is included in the LLM context for this session. Changes are saved with the session.
           </DialogDescription>
         </DialogHeader>
 
@@ -155,7 +155,7 @@ export function ContextEditor({ sessionId }: { sessionId: string }) {
                 tint="blue"
                 badge={
                   systemPrompt !== null
-                    ? (systemPrompt === '' ? 'disabled' : 'modified')
+                    ? (systemPrompt === '' ? 'excluded' : 'custom')
                     : undefined
                 }
                 badgeVariant={
@@ -168,9 +168,11 @@ export function ContextEditor({ sessionId }: { sessionId: string }) {
                 <div className="space-y-2">
                   <div className="flex items-center justify-between">
                     <span className="text-[10px] text-[var(--text-muted)]">
-                      {systemPrompt !== null
-                        ? 'Using custom system prompt'
-                        : 'Using default system prompt'}
+                      {systemPrompt === null
+                        ? 'Using the session default system prompt'
+                        : systemPrompt === ''
+                          ? 'System prompt excluded from this session'
+                          : 'Using a custom system prompt for this session'}
                     </span>
                     {systemPrompt !== null && (
                       <button
@@ -187,6 +189,9 @@ export function ContextEditor({ sessionId }: { sessionId: string }) {
                     className="h-80 w-full resize-y rounded-md border border-border/30 bg-[var(--bg-base)] p-2 font-mono text-[11px] text-[var(--text-secondary)] placeholder:text-[var(--text-muted)] outline-none focus:border-[var(--accent-primary)]"
                     placeholder="Enter system prompt..."
                   />
+                  <p className="text-[10px] text-[var(--text-muted)]">
+                    Leave the prompt blank to exclude it entirely, or reset to use the session default.
+                  </p>
                 </div>
               </ContextSection>
 
@@ -361,26 +366,26 @@ function ToolsSection({
       tint="amber"
       count={tools.length}
       badge={
-        allDisabled
-          ? 'disabled'
-          : enabledCount < tools.length
-            ? `${enabledCount}/${tools.length}`
-            : undefined
+        tools.length > 0 && enabledCount < tools.length
+          ? `${enabledCount}/${tools.length} included`
+          : undefined
       }
       badgeVariant={badgeVariant}
       defaultOpen={false}
     >
       <div className="space-y-1">
-        <div className="flex items-center justify-between rounded-md border-b border-border/20 px-2 pb-2 mb-1">
-          <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-            Enable all tools
-          </span>
-          <Switch
-            size="sm"
-            checked={!allDisabled}
-            onCheckedChange={(checked) => onToggleAll(!checked)}
-          />
-        </div>
+        {tools.length > 0 && (
+          <div className="mb-1 flex items-center justify-between rounded-md border-b border-border/20 px-2 pb-2">
+            <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+              Include all tools
+            </span>
+            <Switch
+              size="sm"
+              checked={!allDisabled}
+              onCheckedChange={(checked) => onToggleAll(!checked)}
+            />
+          </div>
+        )}
 
         {tools.map((tool) => (
           <ToggleRow
@@ -432,11 +437,9 @@ function SkillsSection({
       tint="violet"
       count={skills.length}
       badge={
-        allDisabled
-          ? 'disabled'
-          : enabledCount < skills.length
-            ? `${enabledCount}/${skills.length}`
-            : undefined
+        skills.length > 0 && enabledCount < skills.length
+          ? `${enabledCount}/${skills.length} included`
+          : undefined
       }
       badgeVariant={badgeVariant}
       defaultOpen={false}
@@ -445,7 +448,7 @@ function SkillsSection({
         {skills.length > 0 && (
           <div className="flex items-center justify-between rounded-md border-b border-border/20 px-2 pb-2 mb-1">
             <span className="text-[11px] font-medium text-[var(--text-secondary)]">
-              Enable all skills
+              Include all skills
             </span>
             <Switch
               size="sm"

--- a/apps/desktop/src/stores/context-editor.ts
+++ b/apps/desktop/src/stores/context-editor.ts
@@ -26,10 +26,26 @@ const DEFAULT_PRESET: ContextPreset = {
 
 const BUILTIN_PRESETS: ContextPreset[] = [DEFAULT_PRESET, NONE_PRESET];
 
+function normalizeDisabledNames(
+  names: string[] | undefined,
+  availableNames: string[],
+): Set<string> {
+  const allowed = new Set(availableNames);
+  return new Set((names ?? []).filter((name) => allowed.has(name)));
+}
+
+function getAppliedSystemPrompt(overrides: ContextOverrides | null): string | null {
+  if (!overrides || !Object.prototype.hasOwnProperty.call(overrides, 'systemPrompt')) {
+    return null;
+  }
+  return typeof overrides.systemPrompt === 'string' ? overrides.systemPrompt : '';
+}
+
 // ── Store Types ───────────────────────────────────────────────
 
 interface ContextEditorState {
   isOpen: boolean;
+  loadedSessionId: string | null;
   availableContext: SessionContext | null;
 
   systemPrompt: string | null;
@@ -71,6 +87,7 @@ interface ContextEditorState {
 
 export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
   isOpen: false,
+  loadedSessionId: null,
   availableContext: null,
   systemPrompt: null,
   disabledTools: new Set(),
@@ -85,6 +102,7 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
   open: async (sessionId) => {
     set({
       isOpen: true,
+      loadedSessionId: sessionId,
       availableContext: null,
       systemPrompt: null,
       disabledTools: new Set(),
@@ -109,7 +127,26 @@ export const useContextEditorStore = create<ContextEditorState>((set, get) => ({
     try {
       const context = await window.sero.agent.getContext(sessionId);
       if (context) {
-        set({ availableContext: context });
+        const disabledTools = normalizeDisabledNames(
+          context.overrides?.disabledTools,
+          context.tools.map((tool) => tool.name),
+        );
+        const disabledSkills = normalizeDisabledNames(
+          context.overrides?.disabledSkills,
+          context.skills.map((skill) => skill.name),
+        );
+        const allToolsDisabled = context.tools.length > 0 && disabledTools.size >= context.tools.length;
+        const allSkillsDisabled = context.skills.length > 0 && disabledSkills.size >= context.skills.length;
+
+        set({
+          availableContext: context,
+          systemPrompt: getAppliedSystemPrompt(context.overrides),
+          disabledTools: allToolsDisabled ? new Set() : disabledTools,
+          disabledSkills: allSkillsDisabled ? new Set() : disabledSkills,
+          allToolsDisabled,
+          allSkillsDisabled,
+          activePresetId: context.overrides ? null : '__default__',
+        });
       }
     } catch (err) {
       console.error('[context-editor] Failed to load context:', err);

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -147,9 +147,9 @@ interface SeroAgentAPI {
   setModel(sessionId: string, provider: string, modelId: string): Promise<SessionModelState>;
   /** Set thinking/reasoning level for a session. */
   setThinkingLevel(sessionId: string, level: string): Promise<SessionModelState>;
-  /** Get session context (system prompt, tools, skills) for the context editor. */
+  /** Get session context (base system prompt, tools, skills, current overrides) for the context editor. */
   getContext(sessionId: string): Promise<SessionContext | null>;
-  /** Apply context overrides (disabled tools, system prompt override). Pass null to clear. */
+  /** Apply per-session context overrides (disabled tools/skills, system prompt override). Pass null to clear. */
   setContextOverrides(sessionId: string, overrides: ContextOverrides | null): Promise<void>;
   /**
    * Restore a session to a checkpoint: performs VCS file restore,

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -127,9 +127,14 @@ export interface ContextSkillInfo {
 
 /** Full session context returned by getSessionContext. */
 export interface SessionContext {
+  /** Base system prompt before any per-session overrides are applied. */
   systemPrompt: string;
+  /** Full tool list available to the session before per-session filtering. */
   tools: ContextToolInfo[];
+  /** Full skill list available to the session. */
   skills: ContextSkillInfo[];
+  /** Currently applied per-session overrides, if any. */
+  overrides: ContextOverrides | null;
 }
 
 /** Context overrides sent to the main process. */


### PR DESCRIPTION
## Summary\n- persist Context Editor overrides with each session and restore them on reopen/reload\n- load the editor from base session context plus applied overrides so tools/skills no longer disappear arbitrarily\n- clarify the UI with consistent "Include all" wording and clearer system prompt states\n\n## Testing\n- pnpm typecheck