### PR TITLE
fix: reduce context bloat with session-scoped plugin bridging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,11 +180,19 @@ all `plugins/sero-*-plugin/` directories that have a `sero.app` manifest in thei
 If the remote Vite config uses `root: 'ui'`, the package must include
 `ui/index.html` or `vite build` will fail.
 
-**Tool bridging (AD-020):** All extension tools are automatically bridged into
-the single `sero-cli` tool — they do NOT appear as standalone tool schemas.
-Always use `pi.registerTool()` in extensions, never `customTools` in
-`createAgentSession()`. New tools must be added to `TOOLS_TO_BRIDGE` in
-`electron/cli/index.ts`. See [docs/decisions.md](docs/decisions.md) AD-020.
+**Tool bridging (AD-020):** App/extension tools are bridged into the single
+`sero-cli` tool — they do NOT appear as standalone tool schemas. Always use
+`pi.registerTool()` in extensions, never `customTools` in
+`createAgentSession()`.
+
+- Plugin packages with `sero.plugin` bridge **all tools by default**.
+- Use `sero.plugin.bridgeTools` only when you need to disable bridging or
+  bridge a selective subset.
+- Bridged tools/commands execute against the **current session's** loaded
+  extension instance, so do not rely on registration-scoped captured `pi`
+  objects for session-specific behavior inside bridged execution paths.
+
+See [docs/decisions.md](docs/decisions.md) AD-020.
 
 ### IPC Data Flow (IMPORTANT)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ pnpm typecheck             # Typecheck all (turbo)
 ## Shared Packages & Plugins
 
 - **`@sero-ai/app-runtime`** — React hooks (`useAppState`, `useAppInfo`, `useAgentPrompt`) + `AppProvider` context for federated plugin modules
+- **`@sero/common`** — shared renderer-safe types/utilities for code that should be reused across the desktop app, web/remotes, and plugins. Prefer moving neutral cross-package code here instead of duplicating it, as long as it does not depend on Electron, Node-only APIs, or desktop-only internals. When adding a new shared contract, put it under `packages/common/src/`, re-export it from `packages/common/src/index.ts`, and consume it via `import type { ... } from '@sero/common'` from apps/plugins that need it.
 
 Find all the Sero Plugins in: `plugins/sero-*-plugin`;
 The most comprehensive examples are:

--- a/apps/desktop/electron/__tests__/agent/token-baseline.test.ts
+++ b/apps/desktop/electron/__tests__/agent/token-baseline.test.ts
@@ -196,7 +196,8 @@ describe('Token Baseline Benchmark', () => {
   it('CLI prompt block', () => {
     const block = buildCliPromptBlock();
     const tokens = measure('cli_block', block);
-    expect(tokens).toBeLessThan(400);
+    // Includes per-command summaries (saves sero help round-trips)
+    expect(tokens).toBeLessThan(600);
   });
 
   it('Skills listing', () => {

--- a/apps/desktop/electron/__tests__/cli/command-timeouts.test.ts
+++ b/apps/desktop/electron/__tests__/cli/command-timeouts.test.ts
@@ -56,6 +56,41 @@ describe('CLI bridged command timeouts', () => {
     expect(resolveCommandTimeoutMs(deadline, getBridgedToolTimeoutMs('notes'))).toBe(DEFAULT_PER_COMMAND_TIMEOUT_MS);
   });
 
+  it('skips per-command timeout for interactive commands', async () => {
+    const registry = new CliRegistry();
+    let resolveCommand: ((value: { output: string; exitCode: number }) => void) | null = null;
+
+    registry.register({
+      name: 'question',
+      summary: 'Ask the user',
+      interactive: true,
+      execute: async () => {
+        // Simulate waiting for user input — resolves via external trigger
+        return new Promise<{ output: string; exitCode: number }>((resolve) => {
+          resolveCommand = resolve;
+        });
+      },
+    });
+
+    const pending = executeCliBatch(registry, 'question', {
+      workspaceId: 'ws-1',
+      cwd: '/tmp/ws-1',
+      invocation: { workspaceId: 'ws-1', sessionId: 's-1', turnId: null, source: 'tool' },
+      workspaceManager: {} as never,
+      containerManager: {} as never,
+    });
+
+    // Advance past the default 30s per-command timeout
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Command should NOT have timed out — it's interactive
+    resolveCommand!({ output: 'User answered', exitCode: 0 });
+
+    const result = await pending;
+    expect(result.output).toBe('User answered');
+    expect(result.exitCode).toBe(0);
+  });
+
   it('returns a deterministic timeout error and suppresses late updates after cancellation', async () => {
     const registry = new CliRegistry();
     const onUpdate = vi.fn();

--- a/apps/desktop/electron/__tests__/cli/context-dedup.test.ts
+++ b/apps/desktop/electron/__tests__/cli/context-dedup.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Context deduplication tests.
+ *
+ * Verifies that memory instructions are not duplicated across the
+ * system prompt sources: AGENTS.md template, memory-instructions.ts,
+ * CLI prompt block, and container prompt block.
+ *
+ * See docs/analysis/context-bloat-reduction.md for the full analysis.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { buildCliPromptBlock } from '../../cli';
+import { buildContainerPromptBlock } from '../../features/container/tools/system-prompt';
+import { getMemoryInstructions } from '../../../../../plugins/sero-memory-plugin/extension/memory-instructions';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let pos = 0;
+  while ((pos = haystack.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+/** Load the AGENTS.md template (the source, not a user's copy). */
+function loadAgentsTemplate(): string {
+  return readFileSync(
+    path.resolve(__dirname, '../../../../../packages/templates/profile/AGENTS.md'),
+    'utf8',
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('System prompt deduplication — memory instructions', () => {
+  const memoryInstructions = getMemoryInstructions();
+  const cliBlock = buildCliPromptBlock();
+  const containerBlock = buildContainerPromptBlock('test-ws', '192.168.64.2');
+  const agentsTemplate = loadAgentsTemplate();
+
+  it('memory-instructions.ts is the single source of truth for memory rules', () => {
+    // The canonical rules MUST be in memory-instructions.ts
+    expect(memoryInstructions).toContain('## Memory System');
+    expect(memoryInstructions).toContain('### Retrieval');
+    expect(memoryInstructions).toContain('### Storage');
+    expect(memoryInstructions).toContain('sero memory_search');
+    expect(memoryInstructions).toContain('sero memory write');
+  });
+
+  it('AGENTS.md template does NOT duplicate detailed memory instructions', () => {
+    // The template should be a brief pointer, not a duplication
+    expect(agentsTemplate.length).toBeLessThan(500);
+
+    // Must NOT contain detailed tool syntax or full command examples
+    expect(agentsTemplate).not.toContain('sero memory write');
+    expect(agentsTemplate).not.toContain('memory read --target');
+    expect(agentsTemplate).not.toContain('### When to use each memory tool');
+    expect(agentsTemplate).not.toContain('### Save to `memory`');
+    expect(agentsTemplate).not.toContain('### Retrieval habits');
+    expect(agentsTemplate).not.toContain('### Writing habits');
+  });
+
+  it('CLI prompt block does NOT duplicate memory routing rules', () => {
+    expect(cliBlock).not.toContain('High-priority routing');
+    expect(cliBlock).not.toContain('Sero memory system files and history');
+    expect(cliBlock).not.toContain('MEMORY.md');
+    expect(cliBlock).not.toContain('IDENTITY.md');
+    expect(cliBlock).not.toContain('memory_search');
+  });
+
+  it('container prompt block uses a brief memory reference, not full rules', () => {
+    // Should reference the Memory System section, not restate it
+    expect(containerBlock).toContain('Memory System section');
+    // Should NOT contain the full instruction block
+    expect(containerBlock).not.toContain('Direct file access bypasses IDs, timestamps');
+    expect(containerBlock).not.toContain('search indexing is unavailable');
+    // Should still mention the tools concisely
+    expect(containerBlock).toContain('sero memory');
+  });
+
+  it('managed file list appears once in memory-instructions, not in other sources', () => {
+    // memory-instructions.ts lists them
+    expect(memoryInstructions).toContain('MEMORY.md');
+    expect(memoryInstructions).toContain('IDENTITY.md');
+    expect(memoryInstructions).toContain('SCRATCHPAD.md');
+    expect(memoryInstructions).toContain('memory/daily/');
+
+    // CLI block should not list them
+    expect(cliBlock).not.toContain('MEMORY.md');
+    expect(cliBlock).not.toContain('IDENTITY.md');
+
+    // Container block should not fully list them
+    expect(containerBlock).not.toContain('SCRATCHPAD.md');
+  });
+});
+
+describe('System prompt deduplication — overall budget', () => {
+  it('"never use bash on memory files" has minimal repetition across all sources', () => {
+    const combined = [
+      loadAgentsTemplate(),
+      getMemoryInstructions(),
+      buildCliPromptBlock(),
+      buildContainerPromptBlock('test-ws', '192.168.64.2'),
+    ].join('\n');
+
+    // The core prohibition should appear at most twice across all sources
+    // (once in memory-instructions as canonical, once brief in AGENTS.md)
+    const bashWarnings = countOccurrences(combined, 'never') +
+      countOccurrences(combined, 'Never');
+    // Allow up to 3 total "never" mentions across all sources combined
+    // (the word appears in different contexts too)
+    expect(bashWarnings).toBeLessThanOrEqual(5);
+  });
+});

--- a/apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  AgentSession,
+  ExtensionContext,
+  LoadExtensionsResult,
+  RegisteredCommand,
+  ToolDefinition,
+} from '@mariozechner/pi-coding-agent';
+import { Type } from '@sinclair/typebox';
+
+import {
+  bridgeExtensionTools,
+  getCliRegistry,
+  resetCliRegistryForTests,
+} from '../../cli';
+import { CliRegistry } from '../../cli/core/registry';
+import { bridgeTool } from '../../cli/core/schema-bridge';
+import { createSeroCliTool } from '../../cli/core/tool';
+import type { CliSessionRuntime } from '../../cli/core/types';
+import { replaceBridgedExtensionSessionItems } from '../../cli/bridges/extension-session-bridge';
+import { installCliSessionBridge } from '../../cli/bridges/session-bridge';
+import { workspaceManager } from '../../shared/infra/shared-infra';
+
+function installSessionBridge(sessionIds: string[], sendUserMessage = vi.fn(), sendCustomMessage = vi.fn()) {
+  installCliSessionBridge({
+    getSessionEntry: (sessionId) => {
+      if (!sessionIds.includes(sessionId)) return undefined;
+      return {
+        sessionId,
+        workspaceId: 'ws-1',
+        session: {
+          sendUserMessage,
+          sendCustomMessage,
+        } as unknown as AgentSession,
+        lastSessionName: undefined,
+      };
+    },
+    getActiveSessionForWorkspace: () => undefined,
+    getActiveTurnId: () => null,
+    noteTurnStart: () => {},
+    noteTurnEnd: () => {},
+    consumeTurnBudget: () => ({ allowed: true, count: 0, limit: 50 }),
+    setSessionTitle: () => {},
+  });
+
+  return { sendUserMessage, sendCustomMessage };
+}
+
+function makeLoadExtensionsResult(options: {
+  extensionPath: string;
+  tools?: ToolDefinition[];
+  commands?: RegisteredCommand[];
+}): LoadExtensionsResult {
+  return {
+    extensions: [
+      {
+        path: options.extensionPath,
+        resolvedPath: options.extensionPath,
+        handlers: new Map(),
+        tools: new Map((options.tools ?? []).map((definition) => [
+          definition.name,
+          {
+            definition,
+            extensionPath: options.extensionPath,
+          },
+        ])),
+        messageRenderers: new Map(),
+        commands: new Map((options.commands ?? []).map((command) => [command.name, command])),
+        flags: new Map(),
+        shortcuts: new Map(),
+      },
+    ],
+    errors: [],
+    runtime: {} as LoadExtensionsResult['runtime'],
+  };
+}
+
+describe('bridged extension sessions', () => {
+  beforeEach(() => {
+    resetCliRegistryForTests();
+    vi.spyOn(workspaceManager, 'getPath').mockReturnValue('/tmp/ws-1');
+  });
+
+  it('executes the current session tool definition instead of the first registered session', async () => {
+    installSessionBridge(['session-1', 'session-2']);
+
+    const session1Spy = vi.fn();
+    const session2Spy = vi.fn();
+
+    const tool1: ToolDefinition = {
+      name: 'shared_tool',
+      label: 'Shared Tool',
+      description: 'Shared test tool.',
+      parameters: Type.Object({ action: Type.String() }),
+      execute: async () => {
+        session1Spy();
+        return { content: [{ type: 'text', text: 'session-1 tool' }], details: null };
+      },
+    };
+
+    const tool2: ToolDefinition = {
+      ...tool1,
+      execute: async () => {
+        session2Spy();
+        return { content: [{ type: 'text', text: 'session-2 tool' }], details: null };
+      },
+    };
+
+    const registry = new CliRegistry();
+    registry.register(bridgeTool('shared_tool', tool1));
+    replaceBridgedExtensionSessionItems(
+      'session-1',
+      makeLoadExtensionsResult({
+        extensionPath: '/tmp/plugin-a/extension/index.ts',
+        tools: [tool1],
+      }).extensions,
+    );
+    replaceBridgedExtensionSessionItems(
+      'session-2',
+      makeLoadExtensionsResult({
+        extensionPath: '/tmp/plugin-a/extension/index.ts',
+        tools: [tool2],
+      }).extensions,
+    );
+
+    const tool = createSeroCliTool(registry, 'ws-1', 'session-2');
+    const result = await tool.execute(
+      'tool-1',
+      { command: 'shared_tool run' },
+      undefined,
+      undefined,
+      { cwd: '/tmp/ws-1' } as never,
+    );
+
+    expect(session1Spy).not.toHaveBeenCalled();
+    expect(session2Spy).toHaveBeenCalledOnce();
+    expect(result.content).toEqual([{ type: 'text', text: 'session-2 tool' }]);
+  });
+
+  it('executes the current session command handler instead of the first registered session', async () => {
+    installSessionBridge(['session-1', 'session-2']);
+
+    const session1Spy = vi.fn();
+    const session2Spy = vi.fn();
+
+    const command1: RegisteredCommand = {
+      name: 'shared_command',
+      description: 'Shared command.',
+      handler: async (args) => {
+        session1Spy(args);
+      },
+    };
+
+    const command2: RegisteredCommand = {
+      ...command1,
+      handler: async (args) => {
+        session2Spy(args);
+      },
+    };
+
+    bridgeExtensionTools(
+      makeLoadExtensionsResult({
+        extensionPath: '/tmp/plugin-b/extension/index.ts',
+        commands: [command1],
+      }),
+      { sessionId: 'session-1' },
+    );
+    bridgeExtensionTools(
+      makeLoadExtensionsResult({
+        extensionPath: '/tmp/plugin-b/extension/index.ts',
+        commands: [command2],
+      }),
+      { sessionId: 'session-2' },
+    );
+
+    const tool = createSeroCliTool(getCliRegistry(), 'ws-1', 'session-2');
+    const result = await tool.execute(
+      'tool-1',
+      { command: 'shared_command refresh status' },
+      undefined,
+      undefined,
+      { cwd: '/tmp/ws-1' } as never,
+    );
+
+    expect(session1Spy).not.toHaveBeenCalled();
+    expect(session2Spy).toHaveBeenCalledWith('refresh status');
+    expect(result.content).toEqual([{ type: 'text', text: '/shared_command executed' }]);
+  });
+
+  it('injects sessionRuntime into bridged command contexts', async () => {
+    const { sendUserMessage } = installSessionBridge(['session-1']);
+
+    const command: RegisteredCommand = {
+      name: 'runtime_command',
+      description: 'Runtime command.',
+      handler: async (_args, ctx) => {
+        const runtime = (ctx as ExtensionContext & { sessionRuntime?: CliSessionRuntime }).sessionRuntime;
+        await runtime?.sendUserMessage('/memory list', { deliverAs: 'followUp' });
+      },
+    };
+
+    bridgeExtensionTools(
+      makeLoadExtensionsResult({
+        extensionPath: '/tmp/plugin-c/extension/index.ts',
+        commands: [command],
+      }),
+      { sessionId: 'session-1' },
+    );
+
+    const tool = createSeroCliTool(getCliRegistry(), 'ws-1', 'session-1');
+    await tool.execute(
+      'tool-1',
+      { command: 'runtime_command' },
+      undefined,
+      undefined,
+      { cwd: '/tmp/ws-1' } as never,
+    );
+
+    expect(sendUserMessage).toHaveBeenCalledWith('/memory list', { deliverAs: 'followUp' });
+  });
+});

--- a/apps/desktop/electron/__tests__/cli/interactive-help.test.ts
+++ b/apps/desktop/electron/__tests__/cli/interactive-help.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Interactive tool help text tests.
+ *
+ * Verifies that the schema bridge auto-generates rich help for tools
+ * with nested JSON parameters (question, questionnaire, interview).
+ * The help is generated from the TypeBox schemas defined in the
+ * sero-user-feedback-plugin — no manual overrides needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Type } from '@sinclair/typebox';
+import { bridgeTool } from '../../cli/core/schema-bridge';
+
+// ── Replicate the schemas from sero-user-feedback-plugin ────
+
+const OptionSchema = Type.Object({
+  label: Type.String({ description: 'Display label for the option' }),
+  value: Type.Optional(Type.String({ description: 'Value returned when selected (defaults to label)' })),
+  description: Type.Optional(Type.String({ description: 'Optional description shown below label' })),
+  exclusive: Type.Optional(Type.Boolean({ description: 'In multi-select mode, this option clears other selections' })),
+});
+
+const QuestionParams = Type.Object({
+  question: Type.String({ description: 'The question to ask the user' }),
+  options: Type.Array(OptionSchema, { description: 'Options for the user to choose from' }),
+});
+
+const QuestionnaireQuestionSchema = Type.Object({
+  id: Type.String({ description: 'Unique identifier for this question' }),
+  label: Type.Optional(Type.String({ description: 'Short label for tab/step' })),
+  prompt: Type.String({ description: 'The full question text to display' }),
+  options: Type.Array(OptionSchema, { description: 'Available options' }),
+  allowOther: Type.Optional(Type.Boolean({ description: 'Allow custom text input (default: true)' })),
+  multiSelect: Type.Optional(Type.Boolean({ description: 'Allow selecting multiple options' })),
+});
+
+const QuestionnaireParams = Type.Object({
+  questions: Type.Array(QuestionnaireQuestionSchema, { description: 'Questions to ask' }),
+});
+
+const InterviewQuestionSchema = Type.Object({
+  id: Type.String({ description: 'Unique identifier for this question' }),
+  prompt: Type.String({ description: 'The interview question to ask the user' }),
+});
+
+const InterviewParams = Type.Object({
+  questions: Type.Array(InterviewQuestionSchema, { description: 'Open-ended interview questions' }),
+});
+
+const noop = async () => ({ content: [{ type: 'text' as const, text: 'ok' }], details: undefined });
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('Schema bridge auto-generated help for nested params', () => {
+  describe('question', () => {
+    const cmd = bridgeTool('question', {
+      name: 'question', label: 'Question',
+      description: 'Ask the user a question with selectable options.',
+      parameters: QuestionParams, execute: noop,
+    });
+
+    it('documents the options JSON shape with field descriptions', () => {
+      expect(cmd.help).toContain('JSON shape for options');
+      expect(cmd.help).toContain('label (required, string)');
+      expect(cmd.help).toContain('value (optional, string)');
+      expect(cmd.help).toContain('description (optional, string)');
+      expect(cmd.help).toContain('exclusive (optional, boolean)');
+    });
+
+    it('includes a JSON example for options', () => {
+      expect(cmd.help).toContain('Example options:');
+      expect(cmd.help).toMatch(/"label"/);
+    });
+  });
+
+  describe('questionnaire', () => {
+    const cmd = bridgeTool('questionnaire', {
+      name: 'questionnaire', label: 'Questionnaire',
+      description: 'Ask the user one or more questions in a step-based form.',
+      parameters: QuestionnaireParams, execute: noop,
+    });
+
+    it('documents the questions JSON shape', () => {
+      expect(cmd.help).toContain('JSON shape for questions');
+      expect(cmd.help).toContain('id (required, string)');
+      expect(cmd.help).toContain('prompt (required, string)');
+      expect(cmd.help).toContain('options (required, array)');
+      expect(cmd.help).toContain('allowOther (optional, boolean)');
+      expect(cmd.help).toContain('multiSelect (optional, boolean)');
+    });
+
+    it('documents nested option fields within questions', () => {
+      expect(cmd.help).toContain('JSON shape for options (nested');
+      expect(cmd.help).toContain('label (required, string)');
+    });
+
+    it('includes a JSON example for questions', () => {
+      expect(cmd.help).toContain('Example questions:');
+      expect(cmd.help).toMatch(/"id"/);
+      expect(cmd.help).toMatch(/"prompt"/);
+    });
+  });
+
+  describe('interview', () => {
+    const cmd = bridgeTool('interview', {
+      name: 'interview', label: 'Interview',
+      description: 'Ask open-ended interview questions with free-text responses.',
+      parameters: InterviewParams, execute: noop,
+    });
+
+    it('documents the questions JSON shape', () => {
+      expect(cmd.help).toContain('JSON shape for questions');
+      expect(cmd.help).toContain('id (required, string)');
+      expect(cmd.help).toContain('prompt (required, string)');
+    });
+
+    it('includes a JSON example', () => {
+      expect(cmd.help).toContain('Example questions:');
+      expect(cmd.help).toMatch(/"id"/);
+    });
+
+    it('does NOT document nested option fields (interview has none)', () => {
+      expect(cmd.help).not.toContain('nested array');
+    });
+  });
+
+  describe('simple tools are unaffected', () => {
+    const cmd = bridgeTool('calc', {
+      name: 'calc', label: 'Calculator',
+      description: 'Evaluate a calculation.',
+      parameters: Type.Object({ expr: Type.String({ description: 'Expression to evaluate' }) }),
+      execute: noop,
+    });
+
+    it('does NOT include JSON shape section for flat params', () => {
+      expect(cmd.help).not.toContain('JSON shape');
+      expect(cmd.help).not.toContain('Example');
+    });
+  });
+});

--- a/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
+++ b/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
@@ -4,27 +4,57 @@ import { CliRegistry } from '../../cli/core';
 import { buildCliPromptBlock } from '../../cli';
 
 describe('CLI prompt block', () => {
-  it('includes memory routing rules when memory commands are registered', () => {
+  it('lists commands with summaries grouped by source', () => {
     const registry = new CliRegistry();
     const execute = async () => ({ output: 'ok', exitCode: 0 });
 
     registry.register({
       name: 'memory',
-      summary: 'memory',
+      summary: 'Manage long-term memory',
       group: 'Apps',
       source: 'app',
       execute,
     });
     registry.register({
       name: 'memory_search',
-      summary: 'memory search',
+      summary: 'Search memory and transcripts',
       group: 'Apps',
       source: 'app',
       execute,
     });
     registry.register({
       name: 'scratchpad',
-      summary: 'scratchpad',
+      summary: 'Active working notes',
+      group: 'Apps',
+      source: 'app',
+      execute,
+    });
+    registry.register({
+      name: 'workspace',
+      summary: 'Manage workspaces',
+      group: 'Builtin',
+      source: 'builtin',
+      execute,
+    });
+
+    const prompt = buildCliPromptBlock(registry);
+
+    // Commands are grouped with summaries
+    expect(prompt).toContain('Apps:');
+    expect(prompt).toContain('memory — Manage long-term memory');
+    expect(prompt).toContain('memory_search — Search memory and transcripts');
+    expect(prompt).toContain('scratchpad — Active working notes');
+    expect(prompt).toContain('Builtin:');
+    expect(prompt).toContain('workspace — Manage workspaces');
+  });
+
+  it('does NOT include memory routing rules (owned by memory-instructions.ts)', () => {
+    const registry = new CliRegistry();
+    const execute = async () => ({ output: 'ok', exitCode: 0 });
+
+    registry.register({
+      name: 'memory',
+      summary: 'Manage long-term memory',
       group: 'Apps',
       source: 'app',
       execute,
@@ -32,9 +62,61 @@ describe('CLI prompt block', () => {
 
     const prompt = buildCliPromptBlock(registry);
 
-    expect(prompt).toContain('High-priority routing:');
-    expect(prompt).toContain('Sero memory system files and history');
-    expect(prompt).toContain('Start with one precise `sero memory_search` query');
-    expect(prompt).toContain('Never use bash/read/write/edit');
+    // Memory routing is the memory plugin's responsibility, not the CLI block's
+    expect(prompt).not.toContain('High-priority routing');
+    expect(prompt).not.toContain('Sero memory system files and history');
+    expect(prompt).not.toContain('MEMORY.md');
+    expect(prompt).not.toContain('IDENTITY.md');
+  });
+
+  it('instructs to check help before calling commands with JSON parameters', () => {
+    const registry = new CliRegistry();
+    const prompt = buildCliPromptBlock(registry);
+
+    expect(prompt).toContain('sero help <command>');
+    expect(prompt).toContain('JSON parameters');
+    expect(prompt).toContain('exact schema');
+  });
+
+  it('includes app interaction guidance', () => {
+    const registry = new CliRegistry();
+    const prompt = buildCliPromptBlock(registry);
+
+    expect(prompt).toContain('sero help app');
+    expect(prompt).toContain('app click');
+  });
+
+  it('excludes hidden commands and help from the listing', () => {
+    const registry = new CliRegistry();
+    const execute = async () => ({ output: 'ok', exitCode: 0 });
+
+    registry.register({
+      name: 'help',
+      summary: 'Show help',
+      group: 'Builtin',
+      source: 'builtin',
+      execute,
+    });
+    registry.register({
+      name: 'secret',
+      summary: 'Hidden command',
+      group: 'Internal',
+      source: 'builtin',
+      hidden: true,
+      execute,
+    });
+    registry.register({
+      name: 'visible',
+      summary: 'Visible command',
+      group: 'Apps',
+      source: 'app',
+      execute,
+    });
+
+    const prompt = buildCliPromptBlock(registry);
+
+    expect(prompt).toContain('visible — Visible command');
+    expect(prompt).not.toContain('secret');
+    expect(prompt).not.toContain('help — Show help');
   });
 });

--- a/apps/desktop/electron/__tests__/cli/session-runtime-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/session-runtime-bridge.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentSession, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import { Type } from '@sinclair/typebox';
+
+import { CliRegistry } from '../../cli/core/registry';
+import { bridgeTool } from '../../cli/core/schema-bridge';
+import { createSeroCliTool } from '../../cli/core/tool';
+import type { CliSessionRuntime } from '../../cli/core/types';
+import { installCliSessionBridge } from '../../cli/bridges/session-bridge';
+import { workspaceManager } from '../../shared/infra/shared-infra';
+
+describe('CLI session runtime bridge', () => {
+  beforeEach(() => {
+    vi.spyOn(workspaceManager, 'getPath').mockReturnValue('/tmp/ws-1');
+  });
+
+  it('lets bridged tools send user messages through the current session runtime', async () => {
+    const sendUserMessage = vi.fn().mockResolvedValue(undefined);
+    const sendCustomMessage = vi.fn().mockResolvedValue(undefined);
+
+    installCliSessionBridge({
+      getSessionEntry: () => ({
+        sessionId: 'session-1',
+        workspaceId: 'ws-1',
+        session: {
+          sendUserMessage,
+          sendCustomMessage,
+        } as unknown as AgentSession,
+        lastSessionName: undefined,
+      }),
+      getActiveSessionForWorkspace: () => undefined,
+      getActiveTurnId: () => null,
+      noteTurnStart: () => {},
+      noteTurnEnd: () => {},
+      consumeTurnBudget: () => ({ allowed: true, count: 0, limit: 50 }),
+      setSessionTitle: () => {},
+    });
+
+    const registry = new CliRegistry();
+    registry.register(bridgeTool('kanban', {
+      name: 'kanban',
+      label: 'Kanban',
+      description: 'Manage the kanban board.',
+      parameters: Type.Object({ action: Type.String() }),
+      execute: async (_toolCallId, _params, _signal, _onUpdate, ctx) => {
+        const runtime = (ctx as ExtensionContext & { sessionRuntime?: CliSessionRuntime }).sessionRuntime;
+        await runtime?.sendUserMessage('/brainstorm', { deliverAs: 'followUp' });
+        return {
+          content: [{ type: 'text', text: 'queued' }],
+          details: null,
+        };
+      },
+    }));
+
+    const tool = createSeroCliTool(registry, 'ws-1', 'session-1');
+    const result = await tool.execute(
+      'tool-1',
+      { command: 'kanban brainstorm' },
+      undefined,
+      undefined,
+      { cwd: '/tmp/ws-1' } as never,
+    );
+
+    expect(sendUserMessage).toHaveBeenCalledWith('/brainstorm', { deliverAs: 'followUp' });
+    expect(result.content).toEqual([{ type: 'text', text: 'queued' }]);
+  });
+
+  it('lets bridged tools send custom messages through the current session runtime', async () => {
+    const sendUserMessage = vi.fn().mockResolvedValue(undefined);
+    const sendCustomMessage = vi.fn().mockResolvedValue(undefined);
+
+    installCliSessionBridge({
+      getSessionEntry: () => ({
+        sessionId: 'session-1',
+        workspaceId: 'ws-1',
+        session: {
+          sendUserMessage,
+          sendCustomMessage,
+        } as unknown as AgentSession,
+        lastSessionName: undefined,
+      }),
+      getActiveSessionForWorkspace: () => undefined,
+      getActiveTurnId: () => null,
+      noteTurnStart: () => {},
+      noteTurnEnd: () => {},
+      consumeTurnBudget: () => ({ allowed: true, count: 0, limit: 50 }),
+      setSessionTitle: () => {},
+    });
+
+    const registry = new CliRegistry();
+    registry.register(bridgeTool('kanban', {
+      name: 'kanban',
+      label: 'Kanban',
+      description: 'Manage the kanban board.',
+      parameters: Type.Object({ action: Type.String() }),
+      execute: async (_toolCallId, _params, _signal, _onUpdate, ctx) => {
+        const runtime = (ctx as ExtensionContext & { sessionRuntime?: CliSessionRuntime }).sessionRuntime;
+        await runtime?.sendMessage(
+          {
+            customType: 'kanban-status',
+            content: 'Retrospective queued',
+            display: true,
+            details: { source: 'kanban' },
+          },
+          { triggerTurn: false, deliverAs: 'followUp' },
+        );
+        return {
+          content: [{ type: 'text', text: 'done' }],
+          details: null,
+        };
+      },
+    }));
+
+    const tool = createSeroCliTool(registry, 'ws-1', 'session-1');
+    await tool.execute(
+      'tool-1',
+      { command: 'kanban retrospective' },
+      undefined,
+      undefined,
+      { cwd: '/tmp/ws-1' } as never,
+    );
+
+    expect(sendCustomMessage).toHaveBeenCalledWith(
+      {
+        customType: 'kanban-status',
+        content: 'Retrospective queued',
+        display: true,
+        details: { source: 'kanban' },
+      },
+      { triggerTurn: false, deliverAs: 'followUp' },
+    );
+  });
+});

--- a/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
+++ b/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
@@ -8,10 +8,10 @@
  * intercepted vs which remain standalone.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { Type, type TSchema } from '@sinclair/typebox';
 import type { LoadExtensionsResult, ToolDefinition, RegisteredCommand } from '@mariozechner/pi-coding-agent';
-import { bridgeExtensionTools, getCliRegistry } from '../../cli';
+import { bridgeExtensionTools, getCliRegistry, resetCliRegistryForTests } from '../../cli';
 
 // ── Helpers ─────────────────────────────────────────────────
 
@@ -44,15 +44,16 @@ function makeExtResult(tools: ToolDefinition[]): LoadExtensionsResult {
 // ── Tests ───────────────────────────────────────────────────
 
 describe('Tool bridge policy', () => {
-  it('bridges kanban tool (removed from NEVER_BRIDGE)', () => {
+  beforeEach(() => {
+    resetCliRegistryForTests();
+  });
+
+  it('does NOT bridge kanban tool (kept standalone for session-bound follow-up actions)', () => {
     const ext = makeExtResult([makeTool('kanban')]);
     const result = bridgeExtensionTools(ext);
-    // kanban should be removed from extension tools (bridged to CLI)
-    expect(result.extensions[0]!.tools.has('kanban')).toBe(false);
 
-    // And should be available in the CLI registry
-    const reg = getCliRegistry();
-    expect(reg.get('kanban')).toBeTruthy();
+    expect(result.extensions[0]!.tools.has('kanban')).toBe(true);
+    expect(getCliRegistry().get('kanban')).toBeFalsy();
   });
 
   it('bridges create_agent tool (moved to CORE_TOOLS_TO_BRIDGE)', () => {

--- a/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
+++ b/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tool bridge policy tests.
+ *
+ * Verifies that the CORE_TOOLS_TO_BRIDGE and NEVER_BRIDGE_TO_CLI
+ * sets are configured correctly per the context-bloat-reduction plan.
+ *
+ * These tests import the bridge function and check which tools get
+ * intercepted vs which remain standalone.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Type, type TSchema } from '@sinclair/typebox';
+import type { LoadExtensionsResult, ToolDefinition, RegisteredCommand } from '@mariozechner/pi-coding-agent';
+import { bridgeExtensionTools, getCliRegistry } from '../../cli';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function makeTool(name: string, params?: TSchema): ToolDefinition {
+  return {
+    name,
+    label: name,
+    description: `${name} tool`,
+    parameters: params ?? Type.Object({ action: Type.String() }),
+    execute: async () => ({ content: [{ type: 'text' as const, text: 'ok' }], details: undefined }),
+  };
+}
+
+function makeExtResult(tools: ToolDefinition[]): LoadExtensionsResult {
+  const toolMap = new Map<string, { definition: ToolDefinition }>();
+  for (const t of tools) {
+    toolMap.set(t.name, { definition: t });
+  }
+
+  return {
+    extensions: [{
+      name: 'test-ext',
+      resolvedPath: '/test/extension',
+      tools: toolMap,
+      commands: new Map<string, RegisteredCommand>(),
+    }],
+  } as unknown as LoadExtensionsResult;
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('Tool bridge policy', () => {
+  it('bridges kanban tool (removed from NEVER_BRIDGE)', () => {
+    const ext = makeExtResult([makeTool('kanban')]);
+    const result = bridgeExtensionTools(ext);
+    // kanban should be removed from extension tools (bridged to CLI)
+    expect(result.extensions[0]!.tools.has('kanban')).toBe(false);
+
+    // And should be available in the CLI registry
+    const reg = getCliRegistry();
+    expect(reg.get('kanban')).toBeTruthy();
+  });
+
+  it('bridges create_agent tool (moved to CORE_TOOLS_TO_BRIDGE)', () => {
+    const ext = makeExtResult([makeTool('create_agent')]);
+    const result = bridgeExtensionTools(ext);
+    expect(result.extensions[0]!.tools.has('create_agent')).toBe(false);
+
+    const reg = getCliRegistry();
+    expect(reg.get('create_agent')).toBeTruthy();
+  });
+
+  it('bridges question as interactive (timeout-exempt)', () => {
+    const ext = makeExtResult([makeTool('question')]);
+    bridgeExtensionTools(ext);
+    expect(ext.extensions[0]!.tools.has('question')).toBe(false);
+    const cmd = getCliRegistry().get('question');
+    expect(cmd).toBeTruthy();
+    expect(cmd!.interactive).toBe(true);
+  });
+
+  it('bridges questionnaire as interactive (timeout-exempt)', () => {
+    const ext = makeExtResult([makeTool('questionnaire')]);
+    bridgeExtensionTools(ext);
+    expect(ext.extensions[0]!.tools.has('questionnaire')).toBe(false);
+    const cmd = getCliRegistry().get('questionnaire');
+    expect(cmd).toBeTruthy();
+    expect(cmd!.interactive).toBe(true);
+  });
+
+  it('bridges interview as interactive (timeout-exempt)', () => {
+    const ext = makeExtResult([makeTool('interview')]);
+    bridgeExtensionTools(ext);
+    expect(ext.extensions[0]!.tools.has('interview')).toBe(false);
+    const cmd = getCliRegistry().get('interview');
+    expect(cmd).toBeTruthy();
+    expect(cmd!.interactive).toBe(true);
+  });
+
+  it('does NOT bridge research', () => {
+    const ext = makeExtResult([makeTool('research')]);
+    const result = bridgeExtensionTools(ext);
+    expect(result.extensions[0]!.tools.has('research')).toBe(true);
+  });
+
+  it('bridges memory tools (existing behaviour)', () => {
+    const ext = makeExtResult([
+      makeTool('memory'),
+      makeTool('memory_search'),
+      makeTool('scratchpad'),
+    ]);
+    const result = bridgeExtensionTools(ext);
+    expect(result.extensions[0]!.tools.has('memory')).toBe(false);
+    expect(result.extensions[0]!.tools.has('memory_search')).toBe(false);
+    expect(result.extensions[0]!.tools.has('scratchpad')).toBe(false);
+  });
+});

--- a/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
+++ b/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
@@ -48,12 +48,12 @@ describe('Tool bridge policy', () => {
     resetCliRegistryForTests();
   });
 
-  it('does NOT bridge kanban tool (kept standalone for session-bound follow-up actions)', () => {
+  it('bridges kanban tool through sero-cli', () => {
     const ext = makeExtResult([makeTool('kanban')]);
     const result = bridgeExtensionTools(ext);
 
-    expect(result.extensions[0]!.tools.has('kanban')).toBe(true);
-    expect(getCliRegistry().get('kanban')).toBeFalsy();
+    expect(result.extensions[0]!.tools.has('kanban')).toBe(false);
+    expect(getCliRegistry().get('kanban')).toBeTruthy();
   });
 
   it('bridges create_agent tool (moved to CORE_TOOLS_TO_BRIDGE)', () => {

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
@@ -9,6 +9,7 @@ import {
   bridgeExtensionTools,
   clearPluginBridgePolicyCache,
   getCliRegistry,
+  resetCliRegistryForTests,
 } from '../../../cli';
 
 function createLoadExtensionsResult(
@@ -52,11 +53,13 @@ describe('plugin CLI bridging', () => {
   let tmpDir = '';
 
   beforeEach(async () => {
+    resetCliRegistryForTests();
     clearPluginBridgePolicyCache();
     tmpDir = await mkdtemp(path.join(os.tmpdir(), 'plugin-cli-bridge-'));
   });
 
   afterEach(async () => {
+    resetCliRegistryForTests();
     clearPluginBridgePolicyCache();
     await rm(tmpDir, { recursive: true, force: true });
   });
@@ -86,6 +89,33 @@ describe('plugin CLI bridging', () => {
 
     expect(base.extensions[0]?.tools.has('plugin_all_default')).toBe(false);
     expect(getCliRegistry().get('plugin_all_default')).toBeTruthy();
+  });
+
+  it('keeps kanban standalone even when plugin manifest defaults to bridge all tools', async () => {
+    const pluginDir = path.join(tmpDir, 'plugin-kanban');
+    const extensionPath = path.join(pluginDir, 'extension', 'index.js');
+    await mkdir(path.dirname(extensionPath), { recursive: true });
+    await writeFile(extensionPath, 'export default {}\n', 'utf8');
+    await writeFile(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify({
+        name: '@test/plugin-kanban',
+        version: '1.0.0',
+        sero: {
+          plugin: {
+            category: 'productivity',
+            tags: [],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    const base = createLoadExtensionsResult(extensionPath, ['kanban']);
+    bridgeExtensionTools(base);
+
+    expect(base.extensions[0]?.tools.has('kanban')).toBe(true);
+    expect(getCliRegistry().get('kanban')).toBeFalsy();
   });
 
   it('does not bridge plugin tools when sero.plugin.bridgeTools is false', async () => {

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
@@ -91,7 +91,7 @@ describe('plugin CLI bridging', () => {
     expect(getCliRegistry().get('plugin_all_default')).toBeTruthy();
   });
 
-  it('keeps kanban standalone even when plugin manifest defaults to bridge all tools', async () => {
+  it('bridges kanban when plugin manifest defaults to bridge all tools', async () => {
     const pluginDir = path.join(tmpDir, 'plugin-kanban');
     const extensionPath = path.join(pluginDir, 'extension', 'index.js');
     await mkdir(path.dirname(extensionPath), { recursive: true });
@@ -114,8 +114,8 @@ describe('plugin CLI bridging', () => {
     const base = createLoadExtensionsResult(extensionPath, ['kanban']);
     bridgeExtensionTools(base);
 
-    expect(base.extensions[0]?.tools.has('kanban')).toBe(true);
-    expect(getCliRegistry().get('kanban')).toBeFalsy();
+    expect(base.extensions[0]?.tools.has('kanban')).toBe(false);
+    expect(getCliRegistry().get('kanban')).toBeTruthy();
   });
 
   it('does not bridge plugin tools when sero.plugin.bridgeTools is false', async () => {

--- a/apps/desktop/electron/__tests__/ipc/app-state-settings-reload.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-state-settings-reload.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const state = {
+    fileChangeListener: null as ((filePath: string, data: unknown) => void) | null,
+    ipcHandle: vi.fn(),
+    settingsReload: vi.fn(),
+    reloadAllSessionResources: vi.fn().mockResolvedValue(undefined),
+    ensureInfra: vi.fn(),
+    applyRuntimeSettings: vi.fn(),
+    kanbanOnStateChange: vi.fn(),
+    kanbanWatchWorkspace: vi.fn(),
+    workspaceFindByPath: vi.fn(),
+    gitWatchStateFile: vi.fn(),
+    appStateManager: {
+      onFileChange: vi.fn((listener: (filePath: string, data: unknown) => void) => {
+        state.fileChangeListener = listener;
+      }),
+      watch: vi.fn(),
+      read: vi.fn(),
+      readText: vi.fn(),
+      remove: vi.fn(),
+      write: vi.fn(),
+    },
+  };
+
+  state.ensureInfra.mockResolvedValue({
+    settingsManager: {
+      reload: state.settingsReload,
+    },
+  });
+
+  return state;
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: mocks.ipcHandle,
+  },
+}));
+
+vi.mock('../../features/apps/state/manager', () => ({
+  appStateManager: mocks.appStateManager,
+}));
+
+vi.mock('../../shared/infra/shared-infra', () => ({
+  SERO_CONFIG_PATH: '/tmp/sero-settings.json',
+  ensureInfra: mocks.ensureInfra,
+  applyRuntimeSettings: mocks.applyRuntimeSettings,
+  kanbanOrchestrator: {
+    onStateChange: mocks.kanbanOnStateChange,
+    watchWorkspace: mocks.kanbanWatchWorkspace,
+  },
+  workspaceManager: {
+    findByPath: mocks.workspaceFindByPath,
+  },
+}));
+
+vi.mock('../../ipc/agent', () => ({
+  reloadAllSessionResources: mocks.reloadAllSessionResources,
+}));
+
+vi.mock('../../features/apps/git-app/manager', () => ({
+  gitWorkspaceStateManager: {
+    isGitStateFile: () => false,
+    watchStateFile: mocks.gitWatchStateFile,
+  },
+}));
+
+describe('app-state settings reload', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.fileChangeListener = null;
+    mocks.ipcHandle.mockClear();
+    mocks.settingsReload.mockClear();
+    mocks.reloadAllSessionResources.mockClear();
+    mocks.ensureInfra.mockClear();
+    mocks.applyRuntimeSettings.mockClear();
+    mocks.kanbanOnStateChange.mockClear();
+    mocks.kanbanWatchWorkspace.mockClear();
+    mocks.workspaceFindByPath.mockClear();
+    mocks.gitWatchStateFile.mockClear();
+    mocks.appStateManager.onFileChange.mockClear();
+    mocks.appStateManager.watch.mockClear();
+    mocks.appStateManager.read.mockClear();
+    mocks.appStateManager.readText.mockClear();
+    mocks.appStateManager.remove.mockClear();
+    mocks.appStateManager.write.mockClear();
+  });
+
+  it('watches settings.json and reloads session resources when it changes on disk', async () => {
+    const { registerAppStateHandlers } = await import('../../ipc/apps/app-state');
+
+    registerAppStateHandlers();
+
+    expect(mocks.appStateManager.watch).toHaveBeenCalledWith('/tmp/sero-settings.json');
+    expect(mocks.fileChangeListener).toBeTypeOf('function');
+
+    mocks.fileChangeListener?.('/tmp/sero-settings.json', { packages: ['/tmp/todo'] });
+    await vi.waitFor(() => {
+      expect(mocks.ensureInfra).toHaveBeenCalledOnce();
+      expect(mocks.settingsReload).toHaveBeenCalledOnce();
+      expect(mocks.applyRuntimeSettings).toHaveBeenCalledOnce();
+      expect(mocks.reloadAllSessionResources).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('ignores unrelated file changes', async () => {
+    const { registerAppStateHandlers } = await import('../../ipc/apps/app-state');
+
+    registerAppStateHandlers();
+    mocks.fileChangeListener?.('/tmp/not-settings.json', {});
+
+    await Promise.resolve();
+
+    expect(mocks.ensureInfra).not.toHaveBeenCalled();
+    expect(mocks.settingsReload).not.toHaveBeenCalled();
+    expect(mocks.applyRuntimeSettings).not.toHaveBeenCalled();
+    expect(mocks.reloadAllSessionResources).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/app-state-settings-reload.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-state-settings-reload.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IpcChannels } from '../../../src/types/ipc';
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -67,9 +68,10 @@ vi.mock('../../features/apps/git-app/manager', () => ({
   },
 }));
 
-describe('app-state settings reload', () => {
+describe('app-state settings reload coalescing', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.useFakeTimers();
     mocks.fileChangeListener = null;
     mocks.ipcHandle.mockClear();
     mocks.settingsReload.mockClear();
@@ -88,7 +90,12 @@ describe('app-state settings reload', () => {
     mocks.appStateManager.write.mockClear();
   });
 
-  it('watches settings.json and reloads session resources when it changes on disk', async () => {
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+  });
+
+  it('watches settings.json and reloads session resources after the coalescing window', async () => {
     const { registerAppStateHandlers } = await import('../../ipc/apps/app-state');
 
     registerAppStateHandlers();
@@ -97,12 +104,38 @@ describe('app-state settings reload', () => {
     expect(mocks.fileChangeListener).toBeTypeOf('function');
 
     mocks.fileChangeListener?.('/tmp/sero-settings.json', { packages: ['/tmp/todo'] });
-    await vi.waitFor(() => {
-      expect(mocks.ensureInfra).toHaveBeenCalledOnce();
-      expect(mocks.settingsReload).toHaveBeenCalledOnce();
-      expect(mocks.applyRuntimeSettings).toHaveBeenCalledOnce();
-      expect(mocks.reloadAllSessionResources).toHaveBeenCalledOnce();
-    });
+
+    expect(mocks.ensureInfra).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(80);
+
+    expect(mocks.ensureInfra).toHaveBeenCalledOnce();
+    expect(mocks.settingsReload).toHaveBeenCalledOnce();
+    expect(mocks.applyRuntimeSettings).toHaveBeenCalledOnce();
+    expect(mocks.reloadAllSessionResources).toHaveBeenCalledOnce();
+  });
+
+  it('coalesces duplicate write-path and watcher notifications into one reload', async () => {
+    const { registerAppStateHandlers } = await import('../../ipc/apps/app-state');
+
+    registerAppStateHandlers();
+
+    const writeHandler = mocks.ipcHandle.mock.calls.find(
+      ([channel]) => channel === IpcChannels.appState.write,
+    )?.[1] as ((event: unknown, filePath: string, data: unknown) => Promise<void>) | undefined;
+
+    expect(writeHandler).toBeTypeOf('function');
+
+    const writePromise = writeHandler?.({}, '/tmp/sero-settings.json', { packages: ['/tmp/todo'] });
+    mocks.fileChangeListener?.('/tmp/sero-settings.json', { packages: ['/tmp/todo'] });
+
+    await vi.advanceTimersByTimeAsync(80);
+    await writePromise;
+
+    expect(mocks.ensureInfra).toHaveBeenCalledOnce();
+    expect(mocks.settingsReload).toHaveBeenCalledOnce();
+    expect(mocks.applyRuntimeSettings).toHaveBeenCalledOnce();
+    expect(mocks.reloadAllSessionResources).toHaveBeenCalledOnce();
   });
 
   it('ignores unrelated file changes', async () => {
@@ -111,7 +144,7 @@ describe('app-state settings reload', () => {
     registerAppStateHandlers();
     mocks.fileChangeListener?.('/tmp/not-settings.json', {});
 
-    await Promise.resolve();
+    await vi.runOnlyPendingTimersAsync();
 
     expect(mocks.ensureInfra).not.toHaveBeenCalled();
     expect(mocks.settingsReload).not.toHaveBeenCalled();

--- a/apps/desktop/electron/__tests__/plugins/memory-auto-retrieve.test.ts
+++ b/apps/desktop/electron/__tests__/plugins/memory-auto-retrieve.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Auto-retrieve configuration tests.
+ *
+ * Verifies the auto_retrieve setting in memory config and the
+ * handleMemoryConfig admin function.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  getAutoRetrieveModeSync,
+  setAutoRetrieveModeSync,
+  describeAutoRetrieveMode,
+  getMemorySnapshotModeSync,
+} from '../../../../../plugins/sero-memory-plugin/extension/memory-config';
+import { handleMemoryConfig } from '../../../../../plugins/sero-memory-plugin/extension/memory-tool-admin';
+
+let tmpDir: string;
+const originalSeroHome = process.env.SERO_HOME;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-auto-retrieve-'));
+  process.env.SERO_HOME = tmpDir;
+});
+
+beforeEach(async () => {
+  // Clean config between tests
+  const configDir = path.join(tmpDir, 'state', 'memory');
+  await fs.rm(configDir, { recursive: true, force: true });
+});
+
+afterAll(async () => {
+  process.env.SERO_HOME = originalSeroHome;
+  await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('Auto-retrieve config', () => {
+  it('defaults to on', () => {
+    expect(getAutoRetrieveModeSync()).toBe('on');
+  });
+
+  it('can be set to off', () => {
+    const result = setAutoRetrieveModeSync('off');
+    expect(result).toBe('off');
+    expect(getAutoRetrieveModeSync()).toBe('off');
+  });
+
+  it('can be toggled back to on', () => {
+    setAutoRetrieveModeSync('off');
+    setAutoRetrieveModeSync('on');
+    expect(getAutoRetrieveModeSync()).toBe('on');
+  });
+
+  it('normalizes invalid values to default', () => {
+    const result = setAutoRetrieveModeSync('invalid' as any);
+    expect(result).toBe('on');
+  });
+
+  it('respects SERO_MEMORY_AUTO_RETRIEVE env var', () => {
+    process.env.SERO_MEMORY_AUTO_RETRIEVE = 'off';
+    try {
+      expect(getAutoRetrieveModeSync()).toBe('off');
+    } finally {
+      delete process.env.SERO_MEMORY_AUTO_RETRIEVE;
+    }
+  });
+
+  it('has descriptive labels', () => {
+    expect(describeAutoRetrieveMode('on')).toContain('auto-retrieved');
+    expect(describeAutoRetrieveMode('off')).toContain('memory_search');
+  });
+});
+
+describe('handleMemoryConfig with auto_retrieve', () => {
+  it('shows current config when called with no args', () => {
+    const result = handleMemoryConfig(undefined, undefined);
+    const text = result.content[0]!.text;
+    expect(text).toContain('snapshot');
+    expect(text).toContain('Auto-retrieve');
+  });
+
+  it('sets auto_retrieve independently', () => {
+    const result = handleMemoryConfig(undefined, 'off');
+    const text = result.content[0]!.text;
+    expect(text).toContain('Auto-retrieve set to off');
+    expect(getAutoRetrieveModeSync()).toBe('off');
+  });
+
+  it('sets both snapshot and auto_retrieve together', () => {
+    const result = handleMemoryConfig('live', 'off');
+    const text = result.content[0]!.text;
+    expect(text).toContain('live');
+    expect(text).toContain('Auto-retrieve set to off');
+    expect(getMemorySnapshotModeSync()).toBe('live');
+    expect(getAutoRetrieveModeSync()).toBe('off');
+  });
+});

--- a/apps/desktop/electron/__tests__/plugins/memory-context-injection.test.ts
+++ b/apps/desktop/electron/__tests__/plugins/memory-context-injection.test.ts
@@ -158,8 +158,8 @@ describe('Memory instructions — bash prevention (Issue 3)', () => {
   it('instructs to use sero-cli memory commands instead of direct file access', () => {
     const instructions = getMemoryInstructions();
 
-    expect(instructions).toContain('Run the commands below through the `sero-cli` tool');
-    expect(instructions).toContain('never read/write/grep those files directly');
+    expect(instructions).toContain('sero-cli');
+    expect(instructions).toContain('never read/write/grep managed files');
     expect(instructions).toContain('SCRATCHPAD.md');
     expect(instructions).toContain('bash');
   });
@@ -167,11 +167,10 @@ describe('Memory instructions — bash prevention (Issue 3)', () => {
   it('still routes recall queries through memory_search when QMD is unavailable', () => {
     const instructions = getMemoryInstructions();
 
-    expect(instructions).toContain('### Retrieving information');
+    expect(instructions).toContain('### Retrieval');
     expect(instructions).toContain('sero memory_search');
-    expect(instructions).toContain('ONE precise search query');
-    expect(instructions).toContain('Only run a second search when the first search misses, is ambiguous, or needs broader recall');
-    expect(instructions).toContain('do NOT fall back to bash/read on managed memory files');
+    expect(instructions).toContain('ONE precise query');
+    expect(instructions).toContain('do NOT fall back to bash/read');
     expect(instructions).toContain('sero scratchpad list');
   });
 

--- a/apps/desktop/electron/__tests__/plugins/memory-context-injector-auto-retrieve.test.ts
+++ b/apps/desktop/electron/__tests__/plugins/memory-context-injector-auto-retrieve.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  checkBootstrapStatus: vi.fn(async () => ({ needsBootstrap: false, existingUserContent: null })),
+  getAutoRetrieveModeSync: vi.fn((): 'on' | 'off' => 'on'),
+  getMemorySnapshotModeSync: vi.fn(() => 'live' as const),
+  buildPriorityContextSplit: vi.fn(),
+  clearPriorityContextCache: vi.fn(),
+  isQmdAvailable: vi.fn(() => true),
+  runQmdUpdateNow: vi.fn(async () => {}),
+  runPhase1Migration: vi.fn(async () => ({ changed: false, notes: [] })),
+  flushPendingStats: vi.fn(async () => {}),
+  getMemoryInstructions: vi.fn(() => '\n\n## Memory System'),
+  logMemoryPromptAgentStart: vi.fn(),
+  logMemoryPromptBeforeAgentStart: vi.fn(),
+  info: vi.fn(),
+  error: vi.fn(),
+  errorDetails: vi.fn(() => ({ message: 'boom' })),
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/bootstrap', () => ({
+  checkBootstrapStatus: mocks.checkBootstrapStatus,
+  IDENTITY_QUESTIONS: [],
+  MEMORY_QUESTIONS: [],
+  USER_QUESTIONS: [],
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/memory-manager', () => ({
+  resolveMemoryRoot: () => '/tmp/memory-root',
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/memory-config', () => ({
+  getAutoRetrieveModeSync: mocks.getAutoRetrieveModeSync,
+  getMemorySnapshotModeSync: mocks.getMemorySnapshotModeSync,
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/priority-context', () => ({
+  buildPriorityContextSplit: mocks.buildPriorityContextSplit,
+  clearPriorityContextCache: mocks.clearPriorityContextCache,
+  buildPriorityContext: vi.fn(),
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/qmd', () => ({
+  isQmdAvailable: mocks.isQmdAvailable,
+  runQmdUpdateNow: mocks.runQmdUpdateNow,
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/logger', () => ({
+  info: mocks.info,
+  error: mocks.error,
+  errorDetails: mocks.errorDetails,
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/migration', () => ({
+  runPhase1Migration: mocks.runPhase1Migration,
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/memory-scoring', () => ({
+  flushPendingStats: mocks.flushPendingStats,
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/memory-instructions', () => ({
+  getMemoryInstructions: mocks.getMemoryInstructions,
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/prompt-debug', () => ({
+  clearMemoryPromptDebugState: vi.fn(),
+  logMemoryPromptAgentStart: mocks.logMemoryPromptAgentStart,
+  logMemoryPromptBeforeAgentStart: mocks.logMemoryPromptBeforeAgentStart,
+}));
+
+import {
+  registerContextInjection,
+  resetBootstrapCache,
+} from '../../../../../plugins/sero-memory-plugin/extension/context-injector';
+
+function createFakePi() {
+  const handlers = new Map<string, Array<(event: unknown, ctx: unknown) => Promise<unknown> | unknown>>();
+  return {
+    handlers,
+    sendMessage: vi.fn(),
+    on(event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown> | unknown) {
+      const list = handlers.get(event) ?? [];
+      list.push(handler);
+      handlers.set(event, list);
+    },
+  };
+}
+
+function getHandler(
+  pi: ReturnType<typeof createFakePi>,
+  event: string,
+): (event: unknown, ctx: unknown) => Promise<unknown> | unknown {
+  const handler = pi.handlers.get(event)?.[0];
+  if (!handler) {
+    throw new Error(`Missing handler for ${event}`);
+  }
+  return handler;
+}
+
+describe('context injector auto-retrieve gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetBootstrapCache();
+    mocks.getMemorySnapshotModeSync.mockReturnValue('live');
+    mocks.getMemoryInstructions.mockReturnValue('\n\n## Memory System');
+    mocks.buildPriorityContextSplit.mockImplementation(async (
+      _root: string,
+      _prompt: string,
+      _sessionId: string,
+      _snapshotMode: string,
+      options?: { includeSearch?: boolean },
+    ) => ({
+      staticContext: '\n\n## Memory\n\nSTATIC',
+      searchContext: options?.includeSearch === false ? '' : 'SEARCH RESULT',
+    }));
+  });
+
+  it('passes includeSearch=false when auto-retrieve is off', async () => {
+    mocks.getAutoRetrieveModeSync.mockReturnValue('off');
+
+    const pi = createFakePi();
+    registerContextInjection(pi as any);
+
+    const beforeAgentStart = getHandler(pi, 'before_agent_start');
+    const result = await beforeAgentStart(
+      { prompt: 'What did we decide before?', systemPrompt: 'BASE' },
+      {
+        sessionManager: { getSessionId: () => 'session-off' },
+        getSystemPrompt: () => 'BASE',
+      },
+    );
+
+    expect(mocks.buildPriorityContextSplit).toHaveBeenCalledWith(
+      '/tmp/memory-root',
+      'What did we decide before?',
+      'session-off',
+      'live',
+      { includeSearch: false },
+    );
+    expect(pi.sendMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      systemPrompt: 'BASE\n\n## Memory\n\nSTATIC\n\n## Memory System',
+    });
+  });
+
+  it('passes includeSearch=true and sends per-turn search context when auto-retrieve is on', async () => {
+    mocks.getAutoRetrieveModeSync.mockReturnValue('on');
+
+    const pi = createFakePi();
+    registerContextInjection(pi as any);
+
+    const beforeAgentStart = getHandler(pi, 'before_agent_start');
+    await beforeAgentStart(
+      { prompt: 'What did we decide before?', systemPrompt: 'BASE' },
+      {
+        sessionManager: { getSessionId: () => 'session-on' },
+        getSystemPrompt: () => 'BASE',
+      },
+    );
+
+    expect(mocks.buildPriorityContextSplit).toHaveBeenCalledWith(
+      '/tmp/memory-root',
+      'What did we decide before?',
+      'session-on',
+      'live',
+      { includeSearch: true },
+    );
+    expect(pi.sendMessage).toHaveBeenCalledWith(
+      { customType: 'memory-search-context', content: 'SEARCH RESULT', display: false },
+      { triggerTurn: false },
+    );
+  });
+});

--- a/apps/desktop/electron/__tests__/plugins/memory-search-gating.test.ts
+++ b/apps/desktop/electron/__tests__/plugins/memory-search-gating.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const qmdMocks = vi.hoisted(() => ({
+  searchRelevantMemories: vi.fn(),
+}));
+
+vi.mock('../../../../../plugins/sero-memory-plugin/extension/qmd', () => ({
+  isQmdAvailable: () => true,
+  searchRelevantMemories: qmdMocks.searchRelevantMemories,
+}));
+
+import { buildPriorityContextSplit } from '../../../../../plugins/sero-memory-plugin/extension/priority-context';
+
+let root: string;
+const originalSeroHome = process.env.SERO_HOME;
+
+beforeAll(async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-search-gating-'));
+  root = path.join(tmp, 'workspaces', 'global');
+  await fs.mkdir(root, { recursive: true });
+  process.env.SERO_HOME = tmp;
+});
+
+beforeEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+  await fs.mkdir(root, { recursive: true });
+  qmdMocks.searchRelevantMemories.mockReset();
+});
+
+afterAll(async () => {
+  process.env.SERO_HOME = originalSeroHome;
+  await fs.rm(path.dirname(path.dirname(root)), { recursive: true, force: true }).catch(() => {});
+});
+
+describe('priority context search gating', () => {
+  it('skips QMD retrieval entirely when includeSearch is false', async () => {
+    qmdMocks.searchRelevantMemories.mockResolvedValue({
+      formatted: 'should not be used',
+      results: [],
+    });
+
+    const result = await buildPriorityContextSplit(
+      root,
+      'find prior discussion about state management',
+      'session-1',
+      'live',
+      { includeSearch: false },
+    );
+
+    expect(qmdMocks.searchRelevantMemories).not.toHaveBeenCalled();
+    expect(result.searchContext).toBe('');
+  });
+
+  it('runs QMD retrieval when includeSearch is true', async () => {
+    qmdMocks.searchRelevantMemories.mockResolvedValue({
+      formatted: '### Result 1\n\nUse Zustand for app state.',
+      results: [],
+    });
+
+    const result = await buildPriorityContextSplit(
+      root,
+      'find prior discussion about state management',
+      'session-2',
+      'live',
+      { includeSearch: true },
+    );
+
+    expect(qmdMocks.searchRelevantMemories).toHaveBeenCalledTimes(1);
+    expect(qmdMocks.searchRelevantMemories).toHaveBeenCalledWith(
+      'find prior discussion about state management',
+    );
+    expect(result.searchContext).toContain('Relevant memories');
+    expect(result.searchContext).toContain('Use Zustand for app state.');
+  });
+});

--- a/apps/desktop/electron/__tests__/plugins/memory-split-context.test.ts
+++ b/apps/desktop/electron/__tests__/plugins/memory-split-context.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Split context injection tests.
+ *
+ * Verifies that buildPriorityContextSplit correctly separates
+ * static memory context (for system prompt) from dynamic QMD
+ * search results (for per-turn message injection).
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  buildPriorityContext,
+  buildPriorityContextSplit,
+} from '../../../../../plugins/sero-memory-plugin/extension/priority-context';
+import {
+  serializeMemoryEntries,
+  nowTimestamp,
+} from '../../../../../plugins/sero-memory-plugin/extension/memory-format';
+
+let root: string;
+const originalSeroHome = process.env.SERO_HOME;
+const originalNoSearch = process.env.SERO_MEMORY_NO_SEARCH;
+
+beforeAll(async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-split-ctx-'));
+  root = path.join(tmp, 'workspaces', 'global');
+  await fs.mkdir(root, { recursive: true });
+  process.env.SERO_HOME = tmp;
+  // Disable QMD search in tests — no binary available
+  process.env.SERO_MEMORY_NO_SEARCH = '1';
+});
+
+beforeEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+  await fs.mkdir(root, { recursive: true });
+});
+
+afterAll(async () => {
+  process.env.SERO_HOME = originalSeroHome;
+  process.env.SERO_MEMORY_NO_SEARCH = originalNoSearch;
+  await fs.rm(path.dirname(path.dirname(root)), { recursive: true, force: true }).catch(() => {});
+});
+
+async function writeFile(relativePath: string, content: string): Promise<void> {
+  const filePath = path.join(root, relativePath);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content, 'utf8');
+}
+
+async function seedMemory(entries: Array<{ type: string; text: string }>): Promise<void> {
+  const parsed = entries.map((e, i) => ({
+    id: `mem-split${String(i).padStart(3, '0')}`,
+    hasId: true,
+    type: e.type,
+    text: e.text,
+    line: i,
+    raw: '',
+  }));
+  await writeFile('MEMORY.md', serializeMemoryEntries(parsed, nowTimestamp()));
+}
+
+describe('buildPriorityContextSplit', () => {
+  it('returns static context with IDENTITY and MEMORY but no search section', async () => {
+    await writeFile('IDENTITY.md', '<!-- last updated: 2026-04-01 -->\n# Identity\n\n- **Name:** Sero');
+    await seedMemory([{ type: 'fact', text: 'Uses TypeScript' }]);
+
+    const { staticContext, searchContext } = await buildPriorityContextSplit(root, 'hello');
+
+    expect(staticContext).toContain('IDENTITY.md');
+    expect(staticContext).toContain('Sero');
+    expect(staticContext).toContain('MEMORY.md');
+    expect(staticContext).toContain('TypeScript');
+    // No QMD available in tests, so search is empty
+    expect(searchContext).toBe('');
+  });
+
+  it('returns empty search context when QMD is unavailable', async () => {
+    await seedMemory([{ type: 'fact', text: 'Some fact' }]);
+    const { searchContext } = await buildPriorityContextSplit(root, 'find me something');
+    expect(searchContext).toBe('');
+  });
+
+  it('static context does NOT contain "auto-retrieved" search results header', async () => {
+    await writeFile('IDENTITY.md', '<!-- last updated: 2026-04-01 -->\n# Identity\n\n- **Name:** Sero');
+    await seedMemory([{ type: 'fact', text: 'A fact' }]);
+
+    const { staticContext } = await buildPriorityContextSplit(root, 'hello');
+
+    expect(staticContext).not.toContain('auto-retrieved');
+    expect(staticContext).not.toContain('Relevant memories');
+  });
+
+  it('returns empty strings when no memory files exist', async () => {
+    const { staticContext, searchContext } = await buildPriorityContextSplit(root, 'hello');
+    expect(staticContext).toBe('');
+    expect(searchContext).toBe('');
+  });
+});
+
+describe('buildPriorityContext compatibility', () => {
+  it('returns combined output matching split parts', async () => {
+    await writeFile('IDENTITY.md', '<!-- last updated: 2026-04-01 -->\n# Identity\n\n- **Name:** Sero');
+    await seedMemory([{ type: 'preference', text: 'Prefers dark mode' }]);
+
+    const combined = await buildPriorityContext(root, 'hello');
+    const { staticContext } = await buildPriorityContextSplit(root, 'hello');
+
+    // With no search results, combined should equal static context
+    expect(combined).toBe(staticContext);
+  });
+
+  it('returns empty string when no memory files exist', async () => {
+    const combined = await buildPriorityContext(root, 'hello');
+    expect(combined.trim()).toBe('');
+  });
+});

--- a/apps/desktop/electron/cli/bridges/extension-session-bridge.ts
+++ b/apps/desktop/electron/cli/bridges/extension-session-bridge.ts
@@ -1,0 +1,72 @@
+import type {
+  Extension,
+  RegisteredCommand,
+  RegisteredTool,
+} from '@mariozechner/pi-coding-agent';
+
+import type { CliCommandContext } from '../core/types';
+import { getCliSessionBridge } from './session-bridge';
+
+interface BridgedExtensionSessionItems {
+  tools: Map<string, RegisteredTool>;
+  commands: Map<string, RegisteredCommand>;
+}
+
+const sessionItems = new Map<string, BridgedExtensionSessionItems>();
+
+function resolveSessionId(
+  context: Pick<CliCommandContext, 'workspaceId' | 'invocation'>,
+): string | null {
+  if (context.invocation.sessionId) return context.invocation.sessionId;
+
+  try {
+    return getCliSessionBridge().getActiveSessionForWorkspace(context.workspaceId)?.sessionId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function replaceBridgedExtensionSessionItems(
+  sessionId: string,
+  extensions: Extension[],
+): void {
+  const tools = new Map<string, RegisteredTool>();
+  const commands = new Map<string, RegisteredCommand>();
+
+  for (const ext of extensions) {
+    for (const [name, registered] of ext.tools) {
+      tools.set(name, registered);
+    }
+    for (const [name, registered] of ext.commands) {
+      commands.set(name, registered);
+    }
+  }
+
+  sessionItems.set(sessionId, { tools, commands });
+}
+
+export function getBridgedExtensionTool(
+  name: string,
+  context: Pick<CliCommandContext, 'workspaceId' | 'invocation'>,
+): RegisteredTool | undefined {
+  const sessionId = resolveSessionId(context);
+  if (!sessionId) return undefined;
+  return sessionItems.get(sessionId)?.tools.get(name);
+}
+
+export function getBridgedExtensionCommand(
+  name: string,
+  context: Pick<CliCommandContext, 'workspaceId' | 'invocation'>,
+): RegisteredCommand | undefined {
+  const sessionId = resolveSessionId(context);
+  if (!sessionId) return undefined;
+  return sessionItems.get(sessionId)?.commands.get(name);
+}
+
+export function clearBridgedExtensionSessionItemsForSession(sessionId: string): void {
+  sessionItems.delete(sessionId);
+}
+
+export function clearBridgedExtensionSessionItems(): void {
+  sessionItems.clear();
+}

--- a/apps/desktop/electron/cli/core/schema-bridge.ts
+++ b/apps/desktop/electron/cli/core/schema-bridge.ts
@@ -39,6 +39,26 @@ interface SchemaProp {
   description: string;
   required: boolean;
   enumValues?: string[];
+  /** For array types: the raw JSON Schema of the items element. */
+  itemsSchema?: Record<string, unknown>;
+}
+
+function resolveAnyOf(p: Record<string, unknown>): Record<string, unknown> {
+  if (!Array.isArray(p.anyOf)) return p;
+  return (p.anyOf as Record<string, unknown>[]).find(
+    (v) => typeof v === 'object' && v !== null && v.type !== undefined,
+  ) ?? p;
+}
+
+function extractEnumValues(resolved: Record<string, unknown>): string[] | undefined {
+  if (Array.isArray(resolved.enum)) return resolved.enum as string[];
+  if (Array.isArray((resolved as any).anyOf)) {
+    const vals = (resolved as any).anyOf
+      .filter((v: any) => v?.const !== undefined)
+      .map((v: any) => String(v.const));
+    return vals.length ? vals : undefined;
+  }
+  return undefined;
 }
 
 function extractSchemaProps(schema: Record<string, unknown>): SchemaProp[] {
@@ -48,29 +68,22 @@ function extractSchemaProps(schema: Record<string, unknown>): SchemaProp[] {
 
   for (const [name, prop] of Object.entries(properties)) {
     const p = prop as Record<string, unknown>;
+    const resolved = resolveAnyOf(p);
+    const type = (resolved.type as string) ?? 'string';
 
-    // Handle anyOf (TypeBox Optional wraps in { anyOf: [type, ...] })
-    let resolved = p;
-    if (Array.isArray(p.anyOf)) {
-      resolved = (p.anyOf as Record<string, unknown>[]).find(
-        (v) => typeof v === 'object' && v !== null && v.type !== undefined,
-      ) ?? p;
+    // Capture items schema for arrays with object items
+    let itemsSchema: Record<string, unknown> | undefined;
+    if (type === 'array' && resolved.items && typeof resolved.items === 'object') {
+      itemsSchema = resolved.items as Record<string, unknown>;
     }
-
-    const enumValues = Array.isArray(resolved.enum)
-      ? (resolved.enum as string[])
-      : Array.isArray((resolved as any).anyOf)
-        ? (resolved as any).anyOf
-            .filter((v: any) => v?.const !== undefined)
-            .map((v: any) => String(v.const))
-        : undefined;
 
     props.push({
       name,
-      type: (resolved.type as string) ?? 'string',
+      type,
       description: (p.description as string) ?? (resolved.description as string) ?? '',
       required: required.has(name),
-      enumValues: enumValues?.length ? enumValues : undefined,
+      enumValues: extractEnumValues(resolved),
+      itemsSchema,
     });
   }
 
@@ -128,6 +141,55 @@ function schemaToParams(
 
 // ── Help generation ─────────────────────────────────────────
 
+/**
+ * Describe the fields of a JSON Schema object for help text.
+ * Returns lines like: `  label (required, string) — Display text`
+ */
+function describeObjectFields(schema: Record<string, unknown>, indent: string): string[] {
+  const properties = (schema as any)?.properties ?? {};
+  const requiredSet = new Set<string>((schema as any)?.required ?? []);
+  const lines: string[] = [];
+
+  for (const [fieldName, fieldDef] of Object.entries(properties)) {
+    const f = fieldDef as Record<string, unknown>;
+    const resolved = resolveAnyOf(f);
+    const type = (resolved.type as string) ?? 'string';
+    const desc = (f.description as string) ?? (resolved.description as string) ?? '';
+    const req = requiredSet.has(fieldName) ? 'required' : 'optional';
+    const enumVals = extractEnumValues(resolved);
+    const enumHint = enumVals ? ` {${enumVals.join(', ')}}` : '';
+    lines.push(`${indent}${fieldName} (${req}, ${type}${enumHint}) — ${desc}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Build a minimal JSON example from a schema object.
+ * Shows required fields with placeholder values, omits optional fields.
+ */
+function buildJsonExample(schema: Record<string, unknown>): Record<string, unknown> {
+  const properties = (schema as any)?.properties ?? {};
+  const requiredSet = new Set<string>((schema as any)?.required ?? []);
+  const example: Record<string, unknown> = {};
+
+  for (const [fieldName, fieldDef] of Object.entries(properties)) {
+    const f = fieldDef as Record<string, unknown>;
+    const resolved = resolveAnyOf(f);
+    const type = (resolved.type as string) ?? 'string';
+    // Only include required fields + first optional for context
+    if (!requiredSet.has(fieldName) && Object.keys(example).length >= requiredSet.size) continue;
+
+    if (type === 'string') example[fieldName] = `<${fieldName}>`;
+    else if (type === 'number' || type === 'integer') example[fieldName] = 0;
+    else if (type === 'boolean') example[fieldName] = false;
+    else if (type === 'array') example[fieldName] = [];
+    else example[fieldName] = {};
+  }
+
+  return example;
+}
+
 function generateHelp(
   name: string,
   description: string,
@@ -161,6 +223,31 @@ function generateHelp(
       const typeHint = isComplex ? ' (JSON)' : p.type !== 'string' ? ` (${p.type})` : '';
       lines.push(`  --${p.name}${typeHint} — ${p.description || p.name}`);
     }
+  }
+
+  // Document nested JSON shapes for array/object params
+  const complexProps = props.filter(
+    (p) => p.type === 'array' && p.itemsSchema && (p.itemsSchema as any).type === 'object',
+  );
+  for (const p of complexProps) {
+    const itemSchema = p.itemsSchema!;
+    lines.push('', `JSON shape for ${p.name} (array of objects):`);
+    lines.push(...describeObjectFields(itemSchema, '  '));
+
+    // Recurse one level into nested array-of-object fields
+    const nestedProps = (itemSchema as any)?.properties ?? {};
+    for (const [nestedName, nestedDef] of Object.entries(nestedProps)) {
+      const nd = nestedDef as Record<string, unknown>;
+      const resolved = resolveAnyOf(nd);
+      if (resolved.type === 'array' && resolved.items && (resolved.items as any).type === 'object') {
+        lines.push('', `  JSON shape for ${nestedName} (nested array of objects):`);
+        lines.push(...describeObjectFields(resolved.items as Record<string, unknown>, '    '));
+      }
+    }
+
+    // Generate a compact example
+    const example = buildJsonExample(itemSchema);
+    lines.push('', `Example ${p.name}: '[${JSON.stringify(example)}]'`);
   }
 
   return lines.join('\n');
@@ -199,7 +286,12 @@ function extractText(content: CliContentBlock[]): string {
 
 // ── Bridge a ToolDefinition into a CliCommand ───────────────
 
-export function bridgeTool(toolName: string, toolDef: ToolDefinition): CliCommand {
+export interface BridgeToolOptions {
+  /** Mark this command as interactive (disables per-command timeout). */
+  interactive?: boolean;
+}
+
+export function bridgeTool(toolName: string, toolDef: ToolDefinition, options?: BridgeToolOptions): CliCommand {
   const props = extractSchemaProps(toolDef.parameters as Record<string, unknown>);
   const summary = (toolDef.description ?? '').split(/\.\s/)[0]?.slice(0, 80) ?? toolName;
   const help = generateHelp(toolName, toolDef.description ?? toolName, props);
@@ -210,6 +302,7 @@ export function bridgeTool(toolName: string, toolDef: ToolDefinition): CliComman
     help,
     source: 'app',
     group: 'Apps',
+    interactive: options?.interactive,
     timeoutMs: getBridgedToolTimeoutMs(toolName),
     params: props.map((p) => ({
       name: p.name,

--- a/apps/desktop/electron/cli/core/schema-bridge.ts
+++ b/apps/desktop/electron/cli/core/schema-bridge.ts
@@ -12,9 +12,10 @@
  * and re-register them as CLI commands (removing them from agent context).
  */
 
-import type { ToolDefinition, RegisteredCommand, ExtensionContext } from '@mariozechner/pi-coding-agent';
-import type { CliCommand, CliCommandContext, CliContentBlock, CliResult } from './types';
+import type { ToolDefinition, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { CliCommand, CliCommandContext, CliContentBlock, CliResult, CliSessionRuntime } from './types';
 import { parseFlags } from '../lib/utils';
+import { getBridgedExtensionCommand, getBridgedExtensionTool } from '../bridges/extension-session-bridge';
 import { createSeroUIContext } from '../../features/apps/extensions/ui-context';
 
 const TOOL_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
@@ -315,17 +316,22 @@ export function bridgeTool(toolName: string, toolDef: ToolDefinition, options?: 
         const params = schemaToParams(props, args);
         // Forward agent context (model, modelRegistry, etc.) when available
         // so bridged tools like `memory consolidate` can call LLMs.
+        // We also inject a narrow execution-scoped `sessionRuntime` so bridged
+        // tools can perform current-session side effects without capturing `pi`.
         // When agentContext exists, recombining with cwd produces a full ExtensionContext.
         // When it doesn't (standalone CLI), we provide a bare {cwd} — extension tools
         // must handle missing fields gracefully (e.g. ctx.model === undefined).
-        const toolContext: ExtensionContext = ctx.agentContext
-          ? { ...ctx.agentContext, cwd: ctx.cwd }
-          : { cwd: ctx.cwd } as ExtensionContext;
-        const result = await toolDef.execute(
+        const activeToolDef = getBridgedExtensionTool(toolName, ctx)?.definition ?? toolDef;
+        const toolContext = (ctx.agentContext
+          ? { ...ctx.agentContext, cwd: ctx.cwd, sessionRuntime: ctx.sessionRuntime }
+          : { cwd: ctx.cwd, sessionRuntime: ctx.sessionRuntime }) as ExtensionContext & {
+            sessionRuntime?: CliSessionRuntime;
+          };
+        const result = await activeToolDef.execute(
           'cli-bridge',
           params,
           ctx.invocation.signal,
-          onUpdate as Parameters<typeof toolDef.execute>[3],
+          onUpdate as Parameters<typeof activeToolDef.execute>[3],
           toolContext,
         );
         const content = extractContent(result);
@@ -352,30 +358,41 @@ export function bridgeTool(toolName: string, toolDef: ToolDefinition, options?: 
  * Wraps a Pi extension command (registered via `pi.registerCommand()`)
  * into a CLI command so the agent can invoke it via `sero <name> [args]`.
  *
- * The command handler receives `{ cwd }` as context — it can use
- * `ctx.cwd` but not session-level APIs like `ctx.sessionManager`.
- * Side effects (pi.sendMessage, pi.setActiveTools, etc.) work through
- * the extension's closure-captured `pi` reference.
+ * The concrete command handler is resolved from the active session at
+ * execute time, so bridged plugin commands never reuse another session's
+ * closure-captured `pi` or extension-local state.
  */
 /**
  * Build a minimal ExtensionCommandContext for bridged commands.
  *
  * Reuses the canonical `createSeroUIContext()` so there's a single
- * source of truth for the UIContext shim across Sero.
+ * source of truth for the UIContext shim across Sero. When agent context
+ * is available, we forward it and add `sessionRuntime` for current-session
+ * side effects.
  */
 function buildCommandContext(ctx: CliCommandContext): Record<string, unknown> {
-  return { cwd: ctx.cwd, hasUI: true, ui: createSeroUIContext() };
+  return {
+    ...(ctx.agentContext ? { ...ctx.agentContext } : {}),
+    cwd: ctx.cwd,
+    hasUI: true,
+    ui: createSeroUIContext(),
+    sessionRuntime: ctx.sessionRuntime,
+  };
 }
 
-export function bridgeCommand(name: string, cmd: RegisteredCommand): CliCommand {
+export function bridgeCommand(name: string, description?: string): CliCommand {
   return {
     name,
-    summary: cmd.description ?? name,
+    summary: description ?? name,
     source: 'app',
     group: 'App Commands',
     execute: async (args: string[], ctx: CliCommandContext): Promise<CliResult> => {
       try {
-        await cmd.handler(args.join(' '), buildCommandContext(ctx) as any);
+        const registered = getBridgedExtensionCommand(name, ctx);
+        if (!registered) {
+          return { output: 'ERROR: This command requires an active agent session.', exitCode: 1 };
+        }
+        await registered.handler(args.join(' '), buildCommandContext(ctx) as any);
         return { output: `/${name} executed`, exitCode: 0 };
       } catch (error) {
         const msg = error instanceof Error ? error.message : 'Command failed';

--- a/apps/desktop/electron/cli/core/tool.ts
+++ b/apps/desktop/electron/cli/core/tool.ts
@@ -2,7 +2,14 @@ import type { ToolDefinition, ExtensionContext } from '@mariozechner/pi-coding-a
 import { Type } from '@sinclair/typebox';
 import { containerManager, workspaceManager } from '../../shared/infra/shared-infra';
 import { tokenizeCliInput, splitCommandLines } from './parser';
-import type { BridgedAgentContext, CliCommandContext, CliContentBlock, CliInvocation, CliResult } from './types';
+import type {
+  BridgedAgentContext,
+  CliCommandContext,
+  CliContentBlock,
+  CliInvocation,
+  CliResult,
+  CliSessionRuntime,
+} from './types';
 import type { CliRegistry } from './registry';
 import { getCliSessionBridge } from '../bridges/session-bridge';
 import {
@@ -346,6 +353,26 @@ function buildInvocation(
   };
 }
 
+function buildSessionRuntime(context: Pick<CliCommandContext, 'workspaceId' | 'invocation'>): CliSessionRuntime | undefined {
+  let bridge: ReturnType<typeof getCliSessionBridge>;
+  try {
+    bridge = getCliSessionBridge();
+  } catch {
+    return undefined;
+  }
+
+  const entry = context.invocation.sessionId
+    ? bridge.getSessionEntry(context.invocation.sessionId) ?? bridge.getActiveSessionForWorkspace(context.workspaceId)
+    : bridge.getActiveSessionForWorkspace(context.workspaceId);
+  if (!entry) return undefined;
+
+  return {
+    sessionId: entry.sessionId,
+    sendUserMessage: (content, options) => entry.session.sendUserMessage(content, options),
+    sendMessage: (message, options) => entry.session.sendCustomMessage(message, options),
+  };
+}
+
 export function createSeroCliTool(
   registry: CliRegistry,
   workspaceId: string,
@@ -364,14 +391,16 @@ export function createSeroCliTool(
         return { content: [{ type: 'text', text: `ERROR: Workspace not found: ${workspaceId}` }], details: { exitCode: 1 } };
       }
 
+      const invocation = buildInvocation(workspaceId, sessionId, signal);
       const context: CliCommandContext = {
         workspaceId,
         cwd: toolCtx?.cwd ?? wsPath,
-        invocation: buildInvocation(workspaceId, sessionId, signal),
+        invocation,
         workspaceManager,
         containerManager,
         // Forward agent context so bridged tools can access model, modelRegistry, etc.
         agentContext: toolCtx ? extractAgentContext(toolCtx as ExtensionContext) : undefined,
+        sessionRuntime: buildSessionRuntime({ workspaceId, invocation }),
       };
 
       const batch = await executeCliBatch(registry, cliParams.command, context, cliParams.timeout, onUpdate as any);

--- a/apps/desktop/electron/cli/core/tool.ts
+++ b/apps/desktop/electron/cli/core/tool.ts
@@ -247,7 +247,9 @@ export async function executeCliBatch(
         }
       }
 
-      const perCommandTimeout = context.invocation.source === 'terminal'
+      // Interactive commands (user input tools) skip timeout entirely,
+      // same as terminal-invoked commands.
+      const perCommandTimeout = context.invocation.source === 'terminal' || resolved.command.interactive
         ? null
         : timeoutForCommand(batchDeadline, resolved.command.timeoutMs);
       const commandOnUpdate = withBatchUpdateContext(onUpdate, line, i + 1, lines.length);

--- a/apps/desktop/electron/cli/core/types.ts
+++ b/apps/desktop/electron/cli/core/types.ts
@@ -1,3 +1,4 @@
+import type { ImageContent, TextContent } from '@mariozechner/pi-ai';
 import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
 import type { ContainerManager } from '../../features/container';
 import type { WorkspaceManager } from '../../features/workspace/manager';
@@ -38,6 +39,25 @@ export interface CliParam {
   default?: unknown;
 }
 
+export interface CliCustomMessage {
+  customType: string;
+  content: string | (TextContent | ImageContent)[];
+  display: boolean;
+  details?: unknown;
+}
+
+export interface CliSessionRuntime {
+  sessionId: string;
+  sendUserMessage: (
+    content: string | (TextContent | ImageContent)[],
+    options?: { deliverAs?: 'steer' | 'followUp' },
+  ) => void | Promise<void>;
+  sendMessage: (
+    message: CliCustomMessage,
+    options?: { triggerTurn?: boolean; deliverAs?: 'steer' | 'followUp' | 'nextTurn' },
+  ) => void | Promise<void>;
+}
+
 export interface CliCommandContext {
   workspaceId: string;
   cwd: string;
@@ -50,6 +70,11 @@ export interface CliCommandContext {
    * Undefined for direct/standalone CLI invocations.
    */
   agentContext?: BridgedAgentContext;
+  /**
+   * Narrow execution-scoped runtime for session side effects.
+   * Lets bridged tools interact with the current session without capturing `pi`.
+   */
+  sessionRuntime?: CliSessionRuntime;
 }
 
 export interface CliCommandUpdate {

--- a/apps/desktop/electron/cli/core/types.ts
+++ b/apps/desktop/electron/cli/core/types.ts
@@ -1,5 +1,8 @@
-import type { ImageContent, TextContent } from '@mariozechner/pi-ai';
 import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type {
+  ExtensionRuntimeMessage,
+  ExtensionSessionRuntime,
+} from '@sero/common';
 import type { ContainerManager } from '../../features/container';
 import type { WorkspaceManager } from '../../features/workspace/manager';
 
@@ -39,23 +42,10 @@ export interface CliParam {
   default?: unknown;
 }
 
-export interface CliCustomMessage {
-  customType: string;
-  content: string | (TextContent | ImageContent)[];
-  display: boolean;
-  details?: unknown;
-}
+export type CliCustomMessage = ExtensionRuntimeMessage;
 
-export interface CliSessionRuntime {
+export interface CliSessionRuntime extends ExtensionSessionRuntime {
   sessionId: string;
-  sendUserMessage: (
-    content: string | (TextContent | ImageContent)[],
-    options?: { deliverAs?: 'steer' | 'followUp' },
-  ) => void | Promise<void>;
-  sendMessage: (
-    message: CliCustomMessage,
-    options?: { triggerTurn?: boolean; deliverAs?: 'steer' | 'followUp' | 'nextTurn' },
-  ) => void | Promise<void>;
 }
 
 export interface CliCommandContext {

--- a/apps/desktop/electron/cli/core/types.ts
+++ b/apps/desktop/electron/cli/core/types.ts
@@ -72,6 +72,11 @@ export interface CliCommand {
   hidden?: boolean;
   /** Optional per-command timeout override for non-terminal invocations. */
   timeoutMs?: number;
+  /**
+   * When true, per-command and batch timeouts are disabled for this command.
+   * Use for tools that block on user input (question, questionnaire, interview).
+   */
+  interactive?: boolean;
 }
 
 export interface CliResolvedCommand {

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -81,6 +81,13 @@ const CORE_TOOLS_TO_BRIDGE = new Set([
   // Planning & context
   'plan_todos',
   'slopzilla',
+  // Kanban & agent management
+  'kanban',
+  'create_agent',
+  // User input — interactive (timeout-exempt via INTERACTIVE_TOOLS)
+  'question',
+  'questionnaire',
+  'interview',
   // Scheduling
   'current_time',
   'cron',
@@ -100,18 +107,24 @@ const CORE_TOOLS_TO_BRIDGE = new Set([
 /**
  * Tool names that must NEVER be bridged into `sero-cli`.
  *
- * These tools either:
- * - require nested structured params that are awkward/error-prone in shell syntax
- * - wait on interactive user input and therefore must not inherit the CLI's
- *   per-command timeout behavior
+ * Only tools that genuinely cannot work through the CLI bridge belong here:
+ * - `research` — external skill with its own streaming/timeout model
+ *
+ * User-interactive tools (question, questionnaire, interview) are now bridged
+ * with `interactive: true` which disables the per-command timeout.
  */
 const NEVER_BRIDGE_TO_CLI = new Set([
+  'research',
+]);
+
+/**
+ * Tools that block on user input and need indefinite wait time.
+ * Bridged into sero-cli with `interactive: true` (timeout-exempt).
+ */
+const INTERACTIVE_TOOLS = new Set([
   'question',
   'questionnaire',
   'interview',
-  'create_agent',
-  'kanban',
-  'research',
 ]);
 
 /**
@@ -170,7 +183,9 @@ export function bridgeExtensionTools(base: LoadExtensionsResult): LoadExtensions
         ext.tools.delete(name);
         continue;
       }
-      const command = bridgeTool(name, registered.definition);
+      const command = bridgeTool(name, registered.definition, {
+        interactive: INTERACTIVE_TOOLS.has(name),
+      });
       reg.register(command);
       ext.tools.delete(name);
     }
@@ -197,29 +212,23 @@ export function bridgeExtensionTools(base: LoadExtensionsResult): LoadExtensions
 export function buildCliPromptBlock(reg: CliRegistry = getCliRegistry()): string {
   const commands = reg.list().filter((c) => !c.hidden && c.name !== 'help');
 
-  const grouped = new Map<string, string[]>();
+  // Group commands and include per-command summaries
+  const grouped = new Map<string, Array<{ name: string; summary: string }>>();
   for (const cmd of commands) {
     const group = cmd.group ?? 'Other';
     const list = grouped.get(group) ?? [];
-    list.push(cmd.name);
+    list.push({ name: cmd.name, summary: cmd.summary });
     grouped.set(group, list);
   }
 
   const sections = [...grouped.entries()]
     .sort((a, b) => a[0].localeCompare(b[0]))
-    .map(([group, names]) => `- ${group}: ${names.sort().join(', ')}`);
-
-  const hasMemoryCommands = Boolean(reg.get('memory') || reg.get('memory_search') || reg.get('scratchpad'));
-  const memoryRoutingSection = hasMemoryCommands
-    ? [
-        '',
-        'High-priority routing:',
-        '- Sero memory system files and history (`MEMORY.md`, `IDENTITY.md`, `USER.md`, `SCRATCHPAD.md`, `memory/daily/`, `memory/sessions/`) must go through `sero memory`, `sero memory_search`, or `sero scratchpad`.',
-        '- Start with one precise `sero memory_search` query. If it already answers the question, stop and answer. Only broaden/rephrase if the first search misses or is ambiguous.',
-        '- Never use bash/read/write/edit to inspect or modify those managed memory files. If memory search is unavailable, report that instead of working around it with filesystem tools.',
-        '- Use `question`, `questionnaire`, and `interview` as standalone tools when available — do not try to run them through `sero-cli`.',
-      ].join('\n')
-    : '';
+    .map(([group, cmds]) => {
+      const lines = cmds
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((c) => `  ${c.name} — ${c.summary}`);
+      return `${group}:\n${lines.join('\n')}`;
+    });
 
   return `
 
@@ -227,17 +236,11 @@ export function buildCliPromptBlock(reg: CliRegistry = getCliRegistry()): string
 
 Use \`sero-cli\` for Sero platform actions instead of asking the user to do them manually.
 
-Commands by group:
 ${sections.join('\n')}
 
-Run \`sero help <command>\` for details. You can send multiple commands separated by newlines.${memoryRoutingSection}
+Run \`sero help <command>\` for details. Chain multiple commands (one per line).
+**Before calling any command that takes JSON parameters (e.g. \`question\`, \`questionnaire\`, \`interview\`, \`kanban\`), run \`sero help <command>\` first to check the exact schema.**
 
-For \`sero app\` interactions:
-- If unsure, run \`sero help app\` before acting.
-- Use \`app click <selector>\` or \`app click --x <n> --y <n>\`; click coordinates are relative to the active app screenshot, not the full Sero window.
-- Do NOT pass bare labels like \`app click 42\` or comma pairs like \`app click 214,692\`.
-- \`app type\` only works for real text inputs or contenteditable fields.
-- \`app record stop\` already saves into \`<workspace>/sero-recordings/\` by default; only use \`--save\` if the user explicitly asks for a custom location.
-- There is no \`app press\` command. For button grids like Calculator, take a screenshot and use coordinate clicks.
+For \`sero app\`: run \`sero help app\` first. Use \`app click <selector>\` or \`app click --x <n> --y <n>\` (coordinates relative to the active app screenshot). \`app type\` only works for text inputs/contenteditable. No \`app press\` command — use coordinate clicks.
 `;
 }

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -24,6 +24,12 @@ import { clearPluginBridgePolicyCache, getPluginBridgePolicy } from '../features
 
 let registry: CliRegistry | null = null;
 
+/** @internal Test helper: reset the singleton registry between tests. */
+export function resetCliRegistryForTests(): void {
+  registry = null;
+  clearPluginBridgePolicyCache();
+}
+
 function registerCoreCommands(target: CliRegistry): void {
   registerAppControlCliCommands(target);
   registerWorkspaceCliCommands(target);
@@ -81,8 +87,7 @@ const CORE_TOOLS_TO_BRIDGE = new Set([
   // Planning & context
   'plan_todos',
   'slopzilla',
-  // Kanban & agent management
-  'kanban',
+  // Agent management
   'create_agent',
   // User input — interactive (timeout-exempt via INTERACTIVE_TOOLS)
   'question',
@@ -108,12 +113,14 @@ const CORE_TOOLS_TO_BRIDGE = new Set([
  * Tool names that must NEVER be bridged into `sero-cli`.
  *
  * Only tools that genuinely cannot work through the CLI bridge belong here:
+ * - `kanban` — some actions enqueue follow-up chat work through a session-bound `pi`
  * - `research` — external skill with its own streaming/timeout model
  *
  * User-interactive tools (question, questionnaire, interview) are now bridged
  * with `interactive: true` which disables the per-command timeout.
  */
 const NEVER_BRIDGE_TO_CLI = new Set([
+  'kanban',
   'research',
 ]);
 
@@ -239,7 +246,7 @@ Use \`sero-cli\` for Sero platform actions instead of asking the user to do them
 ${sections.join('\n')}
 
 Run \`sero help <command>\` for details. Chain multiple commands (one per line).
-**Before calling any command that takes JSON parameters (e.g. \`question\`, \`questionnaire\`, \`interview\`, \`kanban\`), run \`sero help <command>\` first to check the exact schema.**
+**Before calling any command that takes JSON parameters (e.g. \`question\`, \`questionnaire\`, \`interview\`), run \`sero help <command>\` first to check the exact schema.**
 
 For \`sero app\`: run \`sero help app\` first. Use \`app click <selector>\` or \`app click --x <n> --y <n>\` (coordinates relative to the active app screenshot). \`app type\` only works for text inputs/contenteditable. No \`app press\` command — use coordinate clicks.
 `;

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -20,6 +20,11 @@ import {
   bridgeTool,
   createSeroCliTool,
 } from './core';
+import {
+  clearBridgedExtensionSessionItems,
+  clearBridgedExtensionSessionItemsForSession,
+  replaceBridgedExtensionSessionItems,
+} from './bridges/extension-session-bridge';
 import { clearPluginBridgePolicyCache, getPluginBridgePolicy } from '../features/plugins/bridge-policy';
 
 let registry: CliRegistry | null = null;
@@ -28,6 +33,7 @@ let registry: CliRegistry | null = null;
 export function resetCliRegistryForTests(): void {
   registry = null;
   clearPluginBridgePolicyCache();
+  clearBridgedExtensionSessionItems();
 }
 
 function registerCoreCommands(target: CliRegistry): void {
@@ -62,10 +68,10 @@ export function createWorkspaceCliTool(workspaceId: string, sessionId: string) {
  * Core tools to always bridge into the single `sero-cli` tool.
  * Every app/extension tool should be listed here — only core coding
  * tools (bash, read, write, edit, browser) and tools that depend on
- * SDK internals (ctx.sessionManager) remain as standalone tools.
+ * unavailable SDK internals remain as standalone tools.
  *
- * DO NOT bridge tools that use ctx.sessionManager, ctx.getContextUsage,
- * or other SDK context — the CLI bridge only passes { cwd }.
+ * Bridged tools receive `{ cwd }`, forwarded agent context, and a narrow
+ * execution-scoped `sessionRuntime` for current-session side effects.
  */
 const CORE_TOOLS_TO_BRIDGE = new Set([
   // Data & productivity
@@ -87,7 +93,8 @@ const CORE_TOOLS_TO_BRIDGE = new Set([
   // Planning & context
   'plan_todos',
   'slopzilla',
-  // Agent management
+  // Kanban & agent management
+  'kanban',
   'create_agent',
   // User input — interactive (timeout-exempt via INTERACTIVE_TOOLS)
   'question',
@@ -113,14 +120,12 @@ const CORE_TOOLS_TO_BRIDGE = new Set([
  * Tool names that must NEVER be bridged into `sero-cli`.
  *
  * Only tools that genuinely cannot work through the CLI bridge belong here:
- * - `kanban` — some actions enqueue follow-up chat work through a session-bound `pi`
  * - `research` — external skill with its own streaming/timeout model
  *
  * User-interactive tools (question, questionnaire, interview) are now bridged
  * with `interactive: true` which disables the per-command timeout.
  */
 const NEVER_BRIDGE_TO_CLI = new Set([
-  'kanban',
   'research',
 ]);
 
@@ -155,7 +160,11 @@ function shouldBridgeTool(name: string, extensionPath: string): boolean {
   return pluginPolicy.bridgeAll || pluginPolicy.toolNames.has(name);
 }
 
-export { clearPluginBridgePolicyCache };
+export {
+  clearBridgedExtensionSessionItems,
+  clearBridgedExtensionSessionItemsForSession,
+  clearPluginBridgePolicyCache,
+};
 
 /**
  * Sero built-in commands (registered by the sero extension factory).
@@ -179,8 +188,15 @@ const BUILTIN_COMMANDS = new Set([
  *    wraps each into a CLI command so the agent can invoke them.
  *    Commands stay registered in extensions (user can still type /plan).
  */
-export function bridgeExtensionTools(base: LoadExtensionsResult): LoadExtensionsResult {
+export function bridgeExtensionTools(
+  base: LoadExtensionsResult,
+  options?: { sessionId?: string },
+): LoadExtensionsResult {
   const reg = getCliRegistry();
+
+  if (options?.sessionId) {
+    replaceBridgedExtensionSessionItems(options.sessionId, base.extensions);
+  }
 
   for (const ext of base.extensions) {
     // Bridge tools → CLI (removes from agent tool list)
@@ -201,7 +217,7 @@ export function bridgeExtensionTools(base: LoadExtensionsResult): LoadExtensions
     for (const [name, registered] of ext.commands) {
       if (BUILTIN_COMMANDS.has(name)) continue;
       if (reg.get(name)) continue;
-      reg.register(bridgeCommand(name, registered));
+      reg.register(bridgeCommand(name, registered.description));
     }
   }
 
@@ -246,7 +262,7 @@ Use \`sero-cli\` for Sero platform actions instead of asking the user to do them
 ${sections.join('\n')}
 
 Run \`sero help <command>\` for details. Chain multiple commands (one per line).
-**Before calling any command that takes JSON parameters (e.g. \`question\`, \`questionnaire\`, \`interview\`), run \`sero help <command>\` first to check the exact schema.**
+**Before calling any command that takes JSON parameters (e.g. \`question\`, \`questionnaire\`, \`interview\`, \`kanban\`), run \`sero help <command>\` first to check the exact schema.**
 
 For \`sero app\`: run \`sero help app\` first. Use \`app click <selector>\` or \`app click --x <n> --y <n>\` (coordinates relative to the active app screenshot). \`app type\` only works for text inputs/contenteditable. No \`app press\` command — use coordinate clicks.
 `;

--- a/apps/desktop/electron/features/container/tools/system-prompt.ts
+++ b/apps/desktop/electron/features/container/tools/system-prompt.ts
@@ -44,7 +44,7 @@ ${containerIp ? `- Container IP: ${containerIp} (accessible from the host)` : ''
 **Cross-workspace access**
 - Other open workspaces (including the global workspace) are mounted at their original host paths.
 - You CAN read and write cross-workspace **project files** via absolute host paths.
-- **Exception: memory files** (MEMORY.md, IDENTITY.md, USER.md, SCRATCHPAD.md, daily logs, session transcripts). Always use the \`sero memory\`, \`sero memory_search\`, or \`sero scratchpad\` commands for these — never access them directly with bash, read, write, or edit tools. Direct file access bypasses IDs, capacity limits, transcript export, and search indexing. If memory search is unavailable, report that limitation instead of falling back to filesystem tools.
+- **Memory files** — always use \`sero memory\`/\`memory_search\`/\`scratchpad\` commands (see Memory System section), never direct file access.
 - For the CURRENT workspace, stay in the current working directory or under \`/workspace\`, not its host absolute path.
 - Use absolute host paths only when you intentionally need a DIFFERENT workspace.
 - Use \`sero-cli\` with \`workspace list\` to discover workspace paths.

--- a/apps/desktop/electron/ipc/agent/core/agent.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent.ts
@@ -54,7 +54,11 @@ import { registerAgentModelContextHandlers } from './agent-model-context';
 import { applyContextOverrides, readPersistedContextOverrides } from './agent-context-overrides';
 import { createSeroUIContext } from '../../../features/apps/extensions/ui-context';
 import { installCliAgentBridge, noteCliTurnEnd } from '../../../cli/bridges';
-import { createWorkspaceCliTool, bridgeExtensionTools } from '../../../cli';
+import {
+  createWorkspaceCliTool,
+  bridgeExtensionTools,
+  clearBridgedExtensionSessionItemsForSession,
+} from '../../../cli';
 import { installGatewayAgentOps, forwardEventToGateway } from '../../../features/gateway/bridge/agent-bridge';
 import { createSkillVisibilityOverride } from '../../../features/apps/extensions/skill-visibility';
 import { buildGatewayOps } from '../../gateway/gateway-ops';
@@ -114,6 +118,7 @@ async function closePoolEntry(sessionId: string): Promise<void> {
   entry.unsubscribe();
   entry.session.dispose();
   pool.delete(sessionId);
+  clearBridgedExtensionSessionItemsForSession(sessionId);
 }
 
 export async function disposeAllAgentSessions(): Promise<void> {
@@ -170,7 +175,7 @@ async function openSessionInternal(
       }),
     ],
     skillsOverride: createSkillVisibilityOverride(infra.settingsManager),
-    extensionsOverride: bridgeExtensionTools,
+    extensionsOverride: (base) => bridgeExtensionTools(base, { sessionId }),
     ...(globalAgentsFile && {
       agentsFilesOverride: (discovered: { agentsFiles: Array<{ path: string; content: string }> }) => ({
         agentsFiles: [

--- a/apps/desktop/electron/ipc/apps/app-state.ts
+++ b/apps/desktop/electron/ipc/apps/app-state.ts
@@ -21,6 +21,10 @@ import { reloadAllSessionResources } from '../agent';
 
 const KANBAN_STATE_SUFFIX = '/apps/kanban/state.json';
 const KANBAN_WORKSPACE_SUFFIX = '/.sero/apps/kanban/state.json';
+const SETTINGS_RELOAD_COALESCE_MS = 75;
+
+let runtimeSettingsReloadPending = false;
+let runtimeSettingsReloadTask: Promise<void> | null = null;
 
 /** Notify the orchestrator immediately if this is a kanban state file. */
 function notifyKanbanOrchestrator(filePath: string, data: unknown): void {
@@ -42,17 +46,47 @@ async function primeKanbanWorkspaceWatch(filePath: string, data: unknown): Promi
   }
 }
 
+async function runRuntimeSettingsReload(): Promise<void> {
+  const infra = await ensureInfra();
+  infra.settingsManager.reload();
+  applyRuntimeSettings(infra.settingsManager);
+  await reloadAllSessionResources();
+}
+
+/**
+ * Coalesce repeated settings.json notifications from both the direct IPC write
+ * path and the file watcher. The short coalescing window collapses back-to-back
+ * events for the same logical change, and any additional notifications that
+ * arrive during a reload trigger one more pass before the task settles.
+ */
+function queueCoalescedRuntimeSettingsReload(): Promise<void> {
+  runtimeSettingsReloadPending = true;
+
+  if (runtimeSettingsReloadTask) {
+    return runtimeSettingsReloadTask;
+  }
+
+  runtimeSettingsReloadTask = (async () => {
+    await new Promise((resolve) => setTimeout(resolve, SETTINGS_RELOAD_COALESCE_MS));
+
+    while (runtimeSettingsReloadPending) {
+      runtimeSettingsReloadPending = false;
+      try {
+        await runRuntimeSettingsReload();
+      } catch (err) {
+        console.error('[app-state] Failed to reload runtime settings:', err);
+      }
+    }
+  })().finally(() => {
+    runtimeSettingsReloadTask = null;
+  });
+
+  return runtimeSettingsReloadTask;
+}
+
 async function refreshRuntimeSettingsIfNeeded(filePath: string): Promise<void> {
   if (path.resolve(filePath) !== path.resolve(SERO_CONFIG_PATH)) return;
-
-  try {
-    const infra = await ensureInfra();
-    infra.settingsManager.reload();
-    applyRuntimeSettings(infra.settingsManager);
-    await reloadAllSessionResources();
-  } catch (err) {
-    console.error('[app-state] Failed to reload runtime settings:', err);
-  }
+  await queueCoalescedRuntimeSettingsReload();
 }
 
 export function registerAppStateHandlers(): void {

--- a/apps/desktop/electron/ipc/apps/app-state.ts
+++ b/apps/desktop/electron/ipc/apps/app-state.ts
@@ -65,7 +65,15 @@ export function registerAppStateHandlers(): void {
         .then(() => kanbanOrchestrator.onStateChange(filePath, data as KanbanState))
         .catch((err) => console.error('[app-state] Kanban orchestrator listener error:', err));
     }
+
+    refreshRuntimeSettingsIfNeeded(filePath).catch((err) => {
+      console.error('[app-state] Settings change reload failed:', err);
+    });
   });
+
+  // Watch settings.json so direct edits or package-manager writes that bypass
+  // the IPC layer still refresh session resources and CLI-bridged tools.
+  appStateManager.watch(SERO_CONFIG_PATH);
 
   // Read state file
   ipcMain.handle(

--- a/docs/analysis/context-bloat-reduction.md
+++ b/docs/analysis/context-bloat-reduction.md
@@ -1,0 +1,415 @@
+# Context Bloat Reduction — Analysis & Plan
+
+**Date:** 2026-04-03
+**Source:** `~/.sero-ui/profiles/dantestprofile/debug/turn_context.json`
+
+---
+
+## 1. Current State
+
+A minimal "tell me a joke" turn sends **~14,450 chars of system prompt** and
+**~11,930 chars of tool definitions** before a single user message.
+
+### 1.1 System Prompt Breakdown
+
+| Section | Chars | Source |
+|---|---:|---|
+| Pi base prompt | 2,535 | Pi SDK default |
+| AGENTS.md (global workspace) | 3,228 | `~/.sero-ui/.../workspaces/global/AGENTS.md` |
+| Memory snapshot (IDENTITY + USER + MEMORY) | 2,410 | `context-injector.ts` → `buildPriorityContext()` |
+| Memory instructions | 3,462 | `memory-instructions.ts` → `getMemoryInstructions()` |
+| CLI prompt block | 2,068 | `cli/index.ts` → `buildCliPromptBlock()` |
+| Subagents block | 747 | `create-sero-extension.ts` → `buildSubagentPromptBlock()` |
+| **Total system prompt** | **14,450** | |
+
+### 1.2 Tool Definition Breakdown
+
+| Tool | Chars | Bridged? | Why standalone |
+|---|---:|---|---|
+| **kanban** | 3,405 | ❌ `NEVER_BRIDGE` | "nested structured params" |
+| **subagent** | 1,765 | ❌ standalone | AD-021 exception |
+| **questionnaire** | 1,492 | ❌ `NEVER_BRIDGE` | "user input, no CLI timeout" |
+| **interview** | 994 | ❌ `NEVER_BRIDGE` | "user input, no CLI timeout" |
+| **question** | 892 | ❌ `NEVER_BRIDGE` | "user input, no CLI timeout" |
+| **create_agent** | 678 | ❌ `NEVER_BRIDGE` | listed alongside kanban |
+| read | 689 | n/a | core coding tool |
+| edit | 557 | n/a | core coding tool |
+| sero-cli | 503 | n/a | the bridge itself |
+| bash | 496 | n/a | core coding tool |
+| write | 437 | n/a | core coding tool |
+| **Total** | **11,930** | | |
+| *Unbridged non-core* | *9,226* | | *78% of tool context* |
+
+### 1.3 Message-Level Duplication
+
+The memory snapshot (IDENTITY + USER + MEMORY) is sent **three ways simultaneously**:
+
+1. **In the system prompt** — injected by `context-injector.ts` `before_agent_start`
+2. **As `memory-context` custom messages** — sent by `pi.sendMessage()` in the same handler
+3. **Repeated per turn** — a new `memory-context` message is injected before each user turn
+
+In the analysed session (3 user turns), 3 identical 2,408-char `memory-context`
+messages appear in the message history, each a full duplicate of content already
+in the system prompt. That's **~7,224 chars of pure waste** in the messages array.
+
+---
+
+## 2. Problem 1 — System Prompt Duplication
+
+Memory-related instructions are stated **across four independent sources**, each
+injecting into the system prompt with no coordination:
+
+### Source Map
+
+| Source | What it says | Chars |
+|---|---|---:|
+| **AGENTS.md** (global workspace) | "Memory Habits" — managed files, when to use each tool, save/don't-save guidelines, retrieval/writing habits | 3,228 |
+| **Memory instructions** (`memory-instructions.ts`) | "Memory System" — managed files, retrieval instructions, storage instructions, exact CLI syntax | 3,462 |
+| **CLI prompt block** (`buildCliPromptBlock`) | "High-priority routing" — use memory tools, search-first rule, never use bash on managed files | ~400 |
+| **Container prompt** (`system-prompt.ts`) | "Cross-workspace access" exception — use memory tools not bash for memory files | ~340 |
+
+### Specific Duplications Found
+
+| Concept | Occurrences | Locations |
+|---|---:|---|
+| "Never use bash/read/write/edit on memory files" | 4× | AGENTS.md, memory-instructions.ts, CLI block, container prompt |
+| "Use `memory_search` for past conversations" | 5× | AGENTS.md (2×), memory-instructions.ts (2×), CLI block |
+| "Start with one precise search query" | 3× | AGENTS.md, memory-instructions.ts, CLI block |
+| Managed file list (MEMORY.md, IDENTITY.md, etc.) | 5× | AGENTS.md, memory-instructions.ts (2×), CLI block, container prompt |
+| "Direct file access bypasses IDs/timestamps..." | 2× | memory-instructions.ts, container prompt |
+| When to save to memory vs daily | 2× | AGENTS.md, memory-instructions.ts (implied via guidelines) |
+
+### Root Cause
+
+These four sources were written at different times and have no mechanism to
+detect or prevent overlap:
+
+- **AGENTS.md** was written first as a workspace-level instruction file
+- **memory-instructions.ts** was added later as the "canonical" memory guide
+- **CLI prompt block** added routing rules independently when the CLI bridge was built
+- **Container prompt** added its own memory exception within the cross-workspace section
+
+Each author assumed the LLM needed reminding. The result is ~3,000 chars of
+pure duplication.
+
+---
+
+## 3. Problem 2 — Unbridged Tool Schemas
+
+Six tools remain standalone (outside `sero-cli`) consuming **9,226 chars** of
+tool definitions. The original `NEVER_BRIDGE_TO_CLI` rationale was:
+
+> Tools that either require nested structured params that are awkward/error-prone
+> in shell syntax, or wait on interactive user input and therefore must not
+> inherit the CLI's per-command timeout behavior.
+
+### Per-Tool Analysis
+
+| Tool | Chars | Real Blocker | Can Bridge? |
+|---|---:|---|---|
+| **kanban** | 3,405 | Has arrays (`blockedBy`, `acceptance`, `filePaths`) and enums — but all params are simple strings/arrays, not deeply nested. The schema bridge already handles `Type.Array(Type.String())` via JSON parsing. | ✅ Yes — arrays of strings work fine with `--param '["a","b"]'` |
+| **question** | 892 | Waits on user input (indefinite). Options array has nested objects. | ⚠️ Timeout is the real issue, not schema complexity |
+| **questionnaire** | 1,492 | Waits on user input. Deeply nested: array of question objects, each with array of option objects. | ⚠️ Timeout + genuinely complex nesting |
+| **interview** | 994 | Waits on user input. Array of `{id, prompt}` objects. | ⚠️ Timeout is the real issue |
+| **create_agent** | 678 | All flat string params. No user input wait. No complex nesting. | ✅ Yes — should have been bridged already |
+| **subagent** | 1,765 | AD-021 exception. Has nested task arrays with per-task model overrides. | ❌ Intentional — structured params essential for orchestration |
+
+### The Two Distinct Blockers
+
+1. **Schema complexity** — the CLI bridge converts TypeBox schemas to
+   positional args + `--flags`. Arrays/objects are passed as JSON strings and
+   auto-parsed. This already works for tools like `memory` and `kanban`. The
+   only tools where this genuinely breaks are those with **arrays of objects
+   with heterogeneous fields** (questionnaire options, subagent task arrays).
+
+2. **Timeout incompatibility** — `question`, `questionnaire`, and `interview`
+   block indefinitely waiting for user input. The CLI bridge enforces a 30s
+   per-command timeout. Bridging these tools would cause them to time out
+   before the user could respond.
+
+### What Can Be Done
+
+**Bridgeable now (no code changes to bridge infrastructure):**
+- `kanban` — all params are flat strings, string enums, or `string[]`. The
+  schema bridge handles these correctly. Move from `NEVER_BRIDGE` to
+  `CORE_TOOLS_TO_BRIDGE`.
+- `create_agent` — all flat string params. Trivially bridgeable.
+
+**Savings:** ~4,083 chars removed from tool definitions.
+
+**Bridgeable with timeout exemption:**
+- `question`, `questionnaire`, `interview` — these could be bridged if the CLI
+  bridge supported a **timeout exemption** for user-interactive tools. The
+  schema bridge can handle the parameter shapes (the nested options are passed
+  as JSON). The blocker is purely the 30s per-command timeout.
+
+  **Proposed solution:** Add an `interactive: true` flag to `CliCommand` that
+  disables the per-command timeout (like `source: 'terminal'` already does).
+  This preserves the bridge's rate limiting and output truncation while
+  allowing indefinite-wait tools.
+
+  However, the nested object arrays in `questionnaire` options would need the
+  LLM to construct valid JSON strings in the CLI command. This is more
+  error-prone than structured tool parameters. For these three tools,
+  **keeping them standalone is the pragmatic choice** — they're user-facing
+  UX tools where parameter correctness matters more than context savings.
+
+**Cannot bridge:**
+- `subagent` — intentional AD-021 exception. Nested task arrays with per-task
+  model/thinking overrides are essential for orchestration quality.
+
+### CLI Prompt Block — Missing Command Summaries
+
+The current `buildCliPromptBlock()` output lists commands grouped but gives
+**no summaries** — just bare names:
+
+```
+Commands by group:
+- App Commands: context, git, google-account, interview, kanban, memory-log
+- Apps: code_search, context_checkout, context_log, ...
+```
+
+This forces the LLM to call `sero help <command>` on every turn to discover
+what a command does, wasting a tool call. Adding a one-line summary per
+command would let the LLM route correctly on the first attempt.
+
+---
+
+## 4. Problem 3 — Memory Context Message Duplication
+
+The `context-injector.ts` `before_agent_start` handler both:
+1. Appends the memory snapshot to the **system prompt** (via `return { systemPrompt }`)
+2. Sends it as a **`memory-context` custom message** (via `pi.sendMessage()`)
+
+The code comment says:
+> Non-fatal — the same content is already injected into the system prompt.
+
+This is intentional redundancy (system prompt for reliability, message for
+conversation-level visibility), but it means the LLM sees the same ~2,400
+chars twice per turn — and the messages accumulate. In a 3-turn conversation,
+there are 3 `memory-context` messages (7,224 chars total) that are all
+identical to the system prompt content.
+
+---
+
+## 5. Proposed Solutions
+
+### 5.1 Deduplicate Memory Instructions (System Prompt)
+
+**Approach:** Establish a single source of truth for each memory concept.
+Remove duplication by assigning ownership:
+
+| Concept | Single Owner | Remove From |
+|---|---|---|
+| Full memory tool syntax + guidelines | `memory-instructions.ts` | AGENTS.md, CLI block, container prompt |
+| "Use memory tools, not bash" | `memory-instructions.ts` (one sentence) | AGENTS.md, CLI block, container prompt |
+| "Use memory_search for recall" | `memory-instructions.ts` | AGENTS.md, CLI block |
+| Managed file list | `memory-instructions.ts` | AGENTS.md, CLI block, container prompt |
+| When to save (memory vs daily) | `memory-instructions.ts` | AGENTS.md |
+| Retrieval/writing habits | `memory-instructions.ts` | AGENTS.md |
+
+**Changes:**
+
+1. **`AGENTS.md` (global workspace)** — Strip the entire "Memory Habits"
+   section. Replace with a 1-line pointer:
+   ```
+   Memory tools and habits are documented in the system prompt's Memory System
+   section. Always use `sero memory`, `sero memory_search`, or `sero scratchpad`
+   — never bash/read/write/edit on managed files.
+   ```
+   _Note: AGENTS.md is user-editable per-workspace. The memory plugin should
+   detect whether the workspace AGENTS.md contains memory instructions and skip
+   injecting if it finds them, OR better — the AGENTS.md template for new
+   workspaces should reference the system section instead of duplicating it._
+
+2. **`buildCliPromptBlock()`** — Remove the "High-priority routing" memory
+   subsection entirely. Memory routing is the memory plugin's responsibility.
+   Keep only the one line about `question`/`questionnaire`/`interview` being
+   standalone tools (but move it to a "Notes" section).
+
+3. **`buildContainerPromptBlock()`** — Shorten the cross-workspace memory
+   exception from 4 lines to 1 line referencing the Memory System section:
+   ```
+   - **Memory files** — always use `sero memory`/`memory_search`/`scratchpad`
+     commands (see Memory System section above), never direct file access.
+   ```
+
+4. **`memory-instructions.ts`** — This becomes the canonical single source.
+   Tighten the text to remove redundancy within the file itself (the
+   "retrieving" and "storing" sections repeat some concepts). Target: reduce
+   from 3,462 to ~2,200 chars.
+
+**Estimated savings:** ~3,000 chars removed from system prompt.
+
+### 5.2 Bridge `kanban` and `create_agent` into sero-cli
+
+**Changes:**
+
+1. Remove `kanban` and `create_agent` from `NEVER_BRIDGE_TO_CLI` in
+   `electron/cli/index.ts`.
+
+2. For `kanban`: add to `CORE_TOOLS_TO_BRIDGE` or let the plugin manifest
+   `bridgeTools: true` handle it. The schema bridge already handles all its
+   parameter types (strings, string enums, `Type.Array(Type.String())`).
+
+3. For `create_agent`: already uses all flat string params. Add to
+   `CORE_TOOLS_TO_BRIDGE`.
+
+4. Update the `kanban` tool description to be more concise — the current
+   3,405 chars include verbose per-action documentation that belongs in
+   `sero help kanban`, not in every LLM turn.
+
+**Estimated savings:** ~4,083 chars removed from tool definitions.
+
+### 5.3 Add Summaries to CLI Prompt Block
+
+**Change:** Modify `buildCliPromptBlock()` to include each command's
+`summary` field (already available on every `CliCommand`) alongside its name.
+
+Current:
+```
+- Apps: code_search, context_checkout, context_log, cron, ...
+```
+
+Proposed:
+```
+- Apps:
+  code_search — Search code across the workspace
+  context_checkout — Restore a tagged context snapshot
+  context_log — View context tag history
+  cron — Manage scheduled jobs
+  ...
+```
+
+This adds ~1,000 chars but saves the LLM from needing `sero help` calls,
+which is a net win in practice (each `sero help` call costs a full tool
+round-trip plus the help output in the response).
+
+**Trade-off:** The CLI block grows from ~2,068 to ~3,000 chars, but total
+system prompt still shrinks due to deduplication savings from 5.1.
+
+### 5.4 Split Context Injection + Auto-Retrieve
+
+The old code sent the entire `buildPriorityContext()` output (static memory +
+QMD search results) in both the system prompt AND as a `memory-context`
+message — full duplication.
+
+**New approach — split injection:**
+
+| Content | Destination | When |
+|---|---|---|
+| Static memory (IDENTITY, USER, SCRATCHPAD, MEMORY.md) | System prompt | Every turn |
+| Memory instructions (retrieval/storage commands) | System prompt | Every turn |
+| QMD search results (prompt-specific) | Per-turn `memory-search-context` message | Only when auto-retrieve is on AND results found |
+
+**Changes:**
+- `buildPriorityContextSplit()` returns `{ staticContext, searchContext }`
+  separately instead of combining them
+- `context-injector.ts` appends `staticContext + instructions` to system
+  prompt, sends `searchContext` as a message (type `memory-search-context`)
+- `context` event filter strips prior-turn search messages so only the latest
+  reaches the LLM
+- New `auto_retrieve` config: `sero memory config --auto_retrieve on|off`
+  (default: on). Agent can disable when search results are unhelpful.
+- `buildPriorityContext()` preserved as a compatibility wrapper that combines both parts
+
+**Savings vs old approach:**
+- Static memory no longer duplicated in messages (~2,400 chars/turn removed)
+- Search results are only sent as a message (not also in system prompt), eliminating the
+  remaining duplication
+- When QMD has no results or auto-retrieve is off, zero message overhead
+
+### 5.5 Keep `question`/`questionnaire`/`interview`/`subagent` Standalone
+
+These tools should remain standalone (not bridged) for different reasons:
+
+- **question/questionnaire/interview** — User-interactive tools that wait
+  indefinitely. The CLI timeout model is incompatible. Additionally,
+  `questionnaire` has genuinely complex nested parameters (arrays of objects
+  with nested option arrays) that would be error-prone as JSON strings in CLI
+  syntax. The cost is 3,378 chars — acceptable for tools that the LLM needs
+  precise control over.
+
+- **subagent** — Intentional AD-021 exception. Structured nested parameters
+  are essential for orchestration quality. 1,765 chars is acceptable.
+
+---
+
+## 6. Impact Summary
+
+| Change | System Prompt | Tool Defs | Messages/Turn |
+|---|---:|---:|---:|
+| 5.1 Deduplicate memory instructions | **−3,000** | — | — |
+| 5.2 Bridge kanban + create_agent | — | **−4,083** | — |
+| 5.3 Add CLI command summaries | +1,000 | — | — |
+| 5.4 Remove duplicate memory messages | — | — | **−2,400** |
+| **Net change** | **−2,000** | **−4,083** | **−2,400/turn** |
+
+**Before:** 14,450 (system) + 11,930 (tools) + 2,400×N (messages) = ~28,780+ chars on turn 1
+**After:** ~12,450 (system) + 7,847 (tools) + 0 (messages) = ~20,297 chars on turn 1
+
+**~30% reduction in per-turn context overhead.**
+
+Over a multi-turn session, the message deduplication compounds — a 10-turn
+session avoids ~24,000 chars of redundant memory snapshots in messages.
+
+---
+
+## 7. Implementation Order
+
+| Phase | Change | Risk | Effort |
+|---|---|---|---|
+| 1 | 5.4 Remove duplicate memory messages | Low — just delete the `sendMessage` call | ~30 min |
+| 2 | 5.1 Deduplicate memory instructions | Medium — multiple files, test memory behaviour | ~2 hrs |
+| 3 | 5.2 Bridge kanban + create_agent | Low — move between sets, verify schema bridge handles params | ~1 hr |
+| 4 | 5.3 Add CLI command summaries | Low — modify `buildCliPromptBlock()` output format | ~1 hr |
+
+Each phase is independently shippable and testable. Phase 1 is zero-risk
+and gives immediate savings.
+
+---
+
+## 8. Implementation Status
+
+**All four phases implemented.** Changes:
+
+| File | Change |
+|---|---|
+| `plugins/sero-memory-plugin/extension/context-injector.ts` | Split injection: static memory → system prompt, QMD search → per-turn message. `context` filter strips prior-turn search messages. |
+| `plugins/sero-memory-plugin/extension/priority-context.ts` | Added `buildPriorityContextSplit()` returning `{ staticContext, searchContext }` separately |
+| `plugins/sero-memory-plugin/extension/memory-config.ts` | Added `autoRetrieve` setting (`on`/`off`, default: `on`) with getter/setter/describer |
+| `plugins/sero-memory-plugin/extension/memory-tool-admin.ts` | `handleMemoryConfig` now accepts `auto_retrieve` param alongside `snapshot` |
+| `plugins/sero-memory-plugin/extension/memory-tool.ts` | Added `auto_retrieve` param to MemoryParams schema |
+| `plugins/sero-memory-plugin/extension/memory-instructions.ts` | Tightened to single source of truth; renamed sections to `### Retrieval` / `### Storage` |
+| `apps/desktop/electron/cli/index.ts` | Moved `kanban` + `create_agent` to `CORE_TOOLS_TO_BRIDGE`; removed from `NEVER_BRIDGE_TO_CLI`; rewrote `buildCliPromptBlock()` with per-command summaries; removed memory routing duplication |
+| `apps/desktop/electron/features/container/tools/system-prompt.ts` | Shortened memory exception to 1-line reference |
+| `packages/templates/profile/AGENTS.md` | Replaced 60-line memory habits section with 3-line pointer |
+
+### New tests
+
+| File | Tests | Covers |
+|---|---|---|
+| `electron/__tests__/cli/context-dedup.test.ts` | 6 | Verifies no duplication across AGENTS.md, memory-instructions, CLI block, container block |
+| `electron/__tests__/cli/tool-bridge-policy.test.ts` | 7 | Verifies kanban/create_agent are bridged, question/questionnaire/interview are not |
+| `electron/__tests__/plugins/memory-auto-retrieve.test.ts` | 9 | Auto-retrieve config: defaults, toggle, env var, handleMemoryConfig integration |
+| `electron/__tests__/plugins/memory-split-context.test.ts` | 6 | Split context: static vs search separation, empty states, compatibility wrapper |
+
+### Updated tests
+
+| File | Change |
+|---|---|
+| `electron/__tests__/cli/prompt-block.test.ts` | Rewritten to test summaries format and absence of memory routing |
+| `electron/__tests__/plugins/memory-context-injection.test.ts` | Updated assertions for new section headers |
+| `electron/__tests__/agent/token-baseline.test.ts` | Adjusted CLI block budget from 400 → 600 (summaries add ~80 tokens) |
+
+## 9. Validation
+
+To verify after deployment, regenerate `turn_context.json` (send a test
+prompt in the debug profile) and check:
+
+1. System prompt char count decreased (~2,000 chars reduction)
+2. Tool definitions: `kanban` and `create_agent` no longer appear as standalone tools
+3. No `memory-context` custom messages in the messages array
+4. `sero kanban list` works via sero-cli
+5. `sero help` shows command summaries
+6. Memory tools still work (save, recall, search)

--- a/docs/apps-tutorial.md
+++ b/docs/apps-tutorial.md
@@ -15,7 +15,7 @@ working agent tool + live web UI.
 - [Step 2: Define the Shared State](#step-2-define-the-shared-state)
 - [Step 3: Build the Pi Extension](#step-3-build-the-pi-extension)
 - [Step 4: Build the Web UI](#step-4-build-the-web-ui)
-- [Step 5: Install and Restart](#step-5-install-and-restart)
+- [Step 5: Build and Start](#step-5-build-and-start)
 - [Step 6: Run and Test](#step-6-run-and-test)
 - [Converting an Existing Pi Extension](#converting-an-existing-pi-extension)
 - [App Runtime API Reference](#app-runtime-api-reference)
@@ -92,16 +92,17 @@ Key properties:
 
 ## Step 1: Create the Package
 
-Create a new directory under `packages/`:
+Create a new directory under `plugins/`:
 
 ```
-packages/pi-myapp-extension/
+plugins/sero-myapp-plugin/
 ├── package.json
 ├── vite.config.ts          ← root-level, uses root: 'ui'
 ├── shared/
 │   └── types.ts
 ├── extension/
-│   └── index.ts
+│   ├── index.ts
+│   └── tsconfig.json
 ├── ui/
 │   ├── MyApp.tsx
 │   ├── styles.css
@@ -112,18 +113,19 @@ packages/pi-myapp-extension/
 
 ### `package.json`
 
-The package.json serves double duty: Pi manifest + Sero app manifest.
+The package.json serves triple duty: Pi manifest + Sero app manifest + Sero
+plugin manifest.
 
 ```json
 {
-  "name": "@sero/myapp",
+  "name": "@sero-ai/plugin-myapp",
   "version": "0.1.0",
   "description": "My app for Sero",
   "keywords": ["pi-package"],
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit -p ui/tsconfig.json"
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json"
   },
   "pi": {
     "extensions": ["./extension/index.ts"]
@@ -137,49 +139,60 @@ The package.json serves double duty: Pi manifest + Sero app manifest.
       "ui": "./dist/ui/remoteEntry.js",
       "component": "MyApp",
       "devPort": 5175
+    },
+    "plugin": {
+      "category": "productivity",
+      "tags": ["myapp", "example"],
+      "minSeroVersion": "0.1.0"
     }
   },
   "dependencies": {
-    "@sinclair/typebox": "^0.34.48"
+    "@sinclair/typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": ">=0.52.0",
-    "@mariozechner/pi-coding-agent": ">=0.52.0",
-    "@mariozechner/pi-tui": ">=0.52.0"
+    "@mariozechner/pi-ai": "catalog:peer",
+    "@mariozechner/pi-coding-agent": "catalog:peer",
+    "@mariozechner/pi-tui": "catalog:peer",
+    "zod": "catalog:peer"
   },
   "devDependencies": {
     "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",
     "@sero-ai/ui": "workspace:*",
-    "@module-federation/vite": "^1.11.0",
-    "@vitejs/plugin-react": "^4.7.0",
-    "@tailwindcss/vite": "^4.1.18",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "tailwindcss": "^4.1.18",
-    "typescript": "^5.9.3",
-    "vite": "^6.4.1"
+    "@module-federation/vite": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "@tailwindcss/vite": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
   }
 }
 ```
 
 **Important notes:**
 
-- `"keywords": ["pi-package"]` makes it discoverable by Pi.
-- `"pi"` section is standard Pi — see
-  [Pi Packages](../docs/libs/pi-coding-agent/packages.md) for full
-  options.
-- `"sero"` section is ignored by Pi CLI. Sero reads it for app discovery.
-- Pi SDK packages (`@mariozechner/*`, `@sinclair/typebox`) go in
-  `peerDependencies` — they're provided by the Pi runtime. See
+- Built-in Sero apps in this monorepo live under `plugins/sero-*-plugin/`.
+  The host auto-discovers them — no manual registration files to edit.
+- `"keywords": ["pi-package"]` keeps the package compatible with Pi tooling.
+- `"pi"` is standard Pi metadata — see
+  [Pi Packages](../docs/libs/pi-coding-agent/packages.md) for full options.
+- `"sero.app"` is the Sero app manifest used for sidebar discovery, app state,
+  and module federation.
+- `"sero.plugin"` marks the package as a plugin-style app. Omit
+  `bridgeTools` to bridge **all** plugin tools into `sero-cli` by default; use
+  `false` or a string array only if you need to opt out or be selective.
+- Pi SDK packages (`@mariozechner/*`, `@sinclair/typebox`) stay in
+  `peerDependencies` — the Pi runtime provides them. See
   [Extension Dependencies](../docs/libs/pi-coding-agent/packages.md#dependencies).
 - `@sero-ai/app-runtime` is a `devDependency` because it's shared via module
   federation at runtime — the host provides the singleton.
 - `@sero-ai/ui` is a `devDependency` that provides shared shadcn/ui components
   (`Button`, `Card`, etc.) and utilities (`cn`). Components are bundled into
   your app at build time — no MF sharing needed.
-- `"devPort"` must be a unique port (see [Port conventions](#port-conventions)).
-  The host auto-discovers this at build time — no manual Vite config edits
-  needed.
+- `"devPort"` must be unique (see [Port conventions](#port-conventions)). The
+  host auto-discovers it from the manifest — no central registry or Vite remotes
+  file to update.
 
 ## Step 2: Define the Shared State
 
@@ -427,37 +440,40 @@ export default function (pi: ExtensionAPI) {
 - Extension tools should keep output concise. See
   [Output Truncation](../docs/libs/pi-coding-agent/extensions.md#output-truncation).
 
-> **⚠️ Tool bridging — no standalone tool schemas in Sero.**
+> **⚠️ Tool bridging — no standalone app tool schemas in Sero.**
 >
-> All extension tools are automatically bridged into the single `sero-cli`
-> tool at runtime (see [AD-020](../docs/decisions.md#ad-020)). Your tool's
-> JSON schema is **removed** from the agent's tool list and re-registered
-> as a CLI subcommand (e.g. `sero myapp list`, `sero myapp add "title"`).
+> App/plugin tools are bridged into the single `sero-cli` tool at runtime (see
+> [AD-020](../docs/decisions.md#ad-020)). In Sero, your tool schema is removed
+> from the agent's direct tool list and re-registered as a CLI subcommand
+> (for example `sero myapp list`, `sero myapp add --title "Test"`).
 >
 > **What this means for you:**
-> - Write your `pi.registerTool()` exactly as shown above — no changes needed.
-> - The bridge is automatic: any tool registered by a Pi extension is
->   intercepted and moved into `sero-cli`.
-> - The tool name becomes a CLI command. Params map to positional args
->   (required first) and `--flags` (optional). Array/object params accept
->   JSON strings.
-> - If your tool returns mixed content, **single-command** `sero-cli`
->   invocations preserve `text`, `image`, and `details` blocks end-to-end.
->   **Multi-command** batches are text-only by design; if one command emits
->   rich content, Sero adds a fallback notice and sets
->   `details.richOutputFallback = true` so the agent can rerun that command
->   alone when it needs the image payload.
-> - Your tool works unchanged in the **Pi CLI** (where it remains a
->   standalone tool). The bridging is Sero-only.
-> - **Do NOT** register tools directly as `customTools` in `createAgentSession`
->   — those bypass the bridge and waste token budget. All app tools must go
->   through Pi extension `registerTool()`.
+> - Keep writing normal Pi extensions with `pi.registerTool()`.
+> - Built-in/core tool names may still be matched by a static allowlist, but
+>   plugin packages with `sero.plugin` bridge **all tools by default**.
+>   Use `sero.plugin.bridgeTools` only when you need to disable bridging or
+>   bridge a selective subset.
+> - The tool name becomes a CLI command. Required params come first; optional
+>   params become `--flags`. Array/object params accept JSON strings.
+> - **Single-command** `sero-cli` invocations preserve `text`, `image`, and
+>   `details` blocks end-to-end. **Multi-command** batches are text-only by
+>   design and set `details.richOutputFallback = true` when rich content must
+>   be rerun alone.
+> - Bridged tools execute against the **current session's loaded extension
+>   instance**, not the first session that registered the command.
+> - If a bridged tool needs current-session side effects (for example queueing
+>   follow-up messages or sending custom status messages), depend on the
+>   execution context passed into the tool instead of capturing a registration-
+>   scoped `pi` object inside tool logic.
+> - Your tool still works unchanged in the **Pi CLI** where it remains a normal
+>   standalone Pi tool. The bridging behavior is Sero-only.
+> - **Do NOT** register app tools directly as `customTools` in
+>   `createAgentSession()` — those bypass the bridge and waste token budget.
 >
-> **Why:** Each standalone tool schema costs ~200–400 tokens. With 15+
-> extensions, that's 3,000–5,000 tokens of tool schemas on every turn —
-> before the user even sends a message. The `sero-cli` bridge collapses
-> all app tools into one schema (just `command` + `timeout`), saving
-> thousands of tokens per session. See [AD-020](../docs/decisions.md#ad-020).
+> **Why:** Each standalone tool schema costs ~200–400 tokens. With many
+> extensions, that adds thousands of tokens before the user even sends a
+> message. `sero-cli` collapses app tools into one compact schema (`command`
+> + `timeout`), saving a large chunk of context budget every session.
 
 ### Profile-aware config and cache paths
 
@@ -799,51 +815,52 @@ You can add app-specific `@keyframes` and `@utility` rules to this file too.
 </html>
 ```
 
-## Step 5: Build, Install, and Restart
+## Step 5: Build and Start
 
-App registration is **fully automatic**. The host auto-discovers all
-`packages/pi-*/` directories that have a `sero.app` manifest. No manual
-edits to any `apps/desktop/` file are needed.
+App registration is **fully automatic**. For built-in monorepo apps, the host
+auto-discovers all `plugins/sero-*-plugin/` directories that have a `sero.app`
+manifest. No manual edits to Vite remotes, federation registries, Electron
+startup, or CLI bridge files are needed.
 
-**After creating your package, run these commands from the monorepo root
-before restarting Sero:**
+**After creating a new built-in plugin, run these commands from the monorepo
+root before starting or restarting the desktop dev server:**
 
 ```bash
-# From the monorepo root — install deps + build the new package:
 pnpm install
-pnpm --filter @sero/myapp build
+pnpm --filter @sero-ai/plugin-myapp build
+pnpm --filter @sero-ai/plugin-myapp typecheck
 
-# Then restart the dev server (set SERO_DEV_PLUGINS=myapp for HMR):
 cd apps/desktop
-bash scripts/dev.sh
+SERO_DEV_PLUGINS=myapp bash scripts/dev.sh
 ```
 
-> **You MUST run `pnpm install` and `pnpm --filter <package-name> build`
-> after creating a new app package.** `pnpm install` links the workspace
-> dependencies (including `@sero-ai/app-runtime`). The build step produces
-> `dist/ui/remoteEntry.js` which the host needs for production mode and
-> which validates that the MF config is correct. To run the UI in dev mode,
-> start `dev.sh` with `SERO_DEV_PLUGINS=<plugin-id>`; otherwise the host
-> loads the built bundle. The initial build catches errors early.
+> **You MUST run `pnpm install`, `build`, and `typecheck` after creating a new
+> app package.** `pnpm install` links workspace dependencies. The build step
+> produces `dist/ui/remoteEntry.js`, which validates the MF setup and is used
+> whenever the plugin is not running in dev mode. `typecheck` catches extension
+> and UI errors early. For UI HMR, include your app ID in `SERO_DEV_PLUGINS`;
+> otherwise the host loads the built bundle.
 
-On startup:
+On startup (and on profile settings reload for installed plugins):
 
-1. **`vite.config.ts`** scans `packages/pi-*/package.json` for `sero.app`
-   manifests and builds the Module Federation remotes map from `id` +
-   `devPort`.
-2. **`dev.sh`** discovers the same packages and starts a Vite dev server
-   only for the plugin IDs listed in `SERO_DEV_PLUGINS`; everything else
-   loads from pre-built bundles.
-3. **`electron/main.ts`** scans packages and registers their paths for
-   app discovery + adds them to `~/.sero-ui/agent/settings.json` so the
-   agent loads the extension tools.
-4. **`federation-registry.ts`** uses MF's `loadRemote()` at runtime —
-   it derives the module path from the manifest's `id` and `component`
-   fields. No static per-app imports needed.
+1. **`vite.config.ts`** scans `plugins/sero-*-plugin/package.json` for
+   `sero.app` manifests and builds the Module Federation remotes map from
+   `id` + `devPort`.
+2. **`dev.sh`** discovers the same packages and starts Vite dev servers only
+   for the plugin IDs listed in `SERO_DEV_PLUGINS`; everything else loads from
+   pre-built bundles.
+3. **`electron/main.ts`** registers built-in plugin paths in the active
+   profile's `settings.json` so the Pi resource loader sees their extensions.
+4. **`app-state.ts`** watches that `settings.json`; when it changes (for
+   example after installing an external plugin), Sero reloads active session
+   resources so new `sero-cli` commands appear without a manual restart.
+5. **`federation-registry.ts`** uses MF's `loadRemote()` at runtime — it
+   derives the module path from the manifest's `id` and `component` fields.
+   No static per-app imports are needed.
 
 ### How auto-discovery works
 
-The host reads three fields from each package's `sero.app` manifest:
+The host reads three fields from each plugin's `sero.app` manifest:
 
 | Field | Used by | Example |
 |-------|---------|---------|
@@ -854,17 +871,12 @@ The host reads three fields from each package's `sero.app` manifest:
 All other fields (`name`, `icon`, `stateFile`, `ui`) are used for sidebar
 display and app state management — they don't affect the federation wiring.
 
-### Production
+### External / installed plugins
 
-In production, apps are discovered via `pi install`:
-
-```bash
-pi install npm:@sero/myapp        # from npm
-pi install ./packages/pi-myapp-extension  # local path
-```
-
-See [Pi Packages](../docs/libs/pi-coding-agent/packages.md) for
-full install/publish documentation.
+For plugins distributed outside the monorepo, package and install them via the
+Sero plugin flow described in [plugins-guide.md](plugins-guide.md). Installed
+plugins are added to the active profile's `settings.json` and their tools,
+commands, and UI refresh into running sessions automatically.
 
 ## Step 6: Run and Test
 
@@ -1650,20 +1662,28 @@ Pi CLI it's unset, so the extension falls back to the workspace-relative path
 
 **All app tools go through the `sero-cli` bridge.** Never add app tools as
 `customTools` in `createAgentSession()` — always use `pi.registerTool()` in
-your extension. The bridge in `electron/cli/index.ts` (`TOOLS_TO_BRIDGE`)
-automatically intercepts extension tools, removes their schemas from the
-agent's tool context, and re-registers them as CLI subcommands.
+your extension.
 
-If you add a new extension tool and it appears as a standalone tool in the
-agent (visible in the system prompt's tool list alongside bash/read/write/edit),
-add its name to `TOOLS_TO_BRIDGE` in `apps/desktop/electron/cli/index.ts`.
+For plugin packages with `sero.plugin`, tool bridging is now **manifest-driven**:
+
+- omit `sero.plugin.bridgeTools` or set it to `true` to bridge all tools
+- set it to `false` to keep all plugin tools standalone in Sero
+- set it to `string[]` to bridge only selected tool names
+
+Sero resolves bridged tools and bridged extension commands against the
+**current session's loaded extension instance**, so session-local plugin state
+and command behavior stay correct across workspaces and sessions.
+
+If a bridged tool needs to perform current-session side effects (for example
+queueing follow-up messages), make that dependency explicit in the execution
+context instead of relying on a registration-time captured `pi` object.
 
 ### Naming
 
 - **Built-in plugin:** `plugins/sero-<name>-plugin/` (auto-discovered,
   not installed/uninstalled)
-- **Standalone package:** `packages/pi-<name>-extension/` (installable
-  via `pi install`)
+- **External distribution package:** publishable bundle/source derived from
+  your plugin (see [plugins-guide.md](plugins-guide.md))
 - MF remote name: `sero_<id>` (underscore, not hyphen — MF requires valid JS
   identifiers)
 - Exposed module: `./<Component>` (e.g. `./MyApp`)
@@ -1857,7 +1877,8 @@ for plugins that are running in dev mode. No manual restart needed.
 
 Each app's `devPort` in `package.json` must be unique. The dev script and
 Vite config both read it automatically — no central port registry to maintain.
-Current assignments: Todo=5174, Calc=5175, Weight=5176, Quote=5177.
+Check the existing plugin manifests under `plugins/sero-*-plugin/package.json`
+before picking a new port.
 
 ### Logs
 
@@ -1878,19 +1899,24 @@ Current assignments: Todo=5174, Calc=5175, Weight=5176, Quote=5177.
 
 **App doesn't appear in sidebar:**
 - Check that `sero.app.id` and `sero.app.name` are set in `package.json`.
-- Verify the package directory is under `packages/` and starts with `pi-`.
+- Verify the package directory is under `plugins/` and matches
+  `sero-<name>-plugin/`.
 - Check that `pnpm install` was run after creating the package.
 - Check the electron log for `[app-discovery]` messages.
 
 **Agent doesn't have the tool:**
-- The host auto-registers packages in `~/.sero-ui/agent/settings.json` on
-  startup. Restart Sero after adding a new package.
+- For a **new built-in monorepo plugin**, restart the desktop dev server after
+  adding the package so startup discovery and Vite remotes pick it up.
+- For an **installed/external plugin**, a manual restart should not be needed:
+  changes to the active profile's `settings.json` are watched and active
+  session resources reload automatically.
 - Verify the package's `pi.extensions` field points to the correct file.
+- Run `sero help <tool-name>` to confirm the CLI bridge sees the tool.
 
 **UI changes don't appear after editing:**
 - Check that the remote Vite dev server is running (look for its log file).
 - The host's `watchRemotes` plugin triggers reload on file saves to
-  `packages/pi-*/ui/`. Check `/tmp/sero-vite.log` for
+  `plugins/sero-*/ui/`. Check `/tmp/sero-vite.log` for
   `[sero-watch-remotes]` messages.
 - Extension code changes (in `extension/`) require a full restart.
 
@@ -1938,50 +1964,53 @@ Current assignments: Todo=5174, Calc=5175, Weight=5176, Quote=5177.
 
 ## Reference Implementations
 
-The **Calculator app** (`packages/pi-calc-extension/`) is the best reference
-for using `@sero-ai/ui` components with Tailwind:
+The **Git plugin** (`plugins/sero-git-plugin/`) is a strong reference for a
+clean, focused app with a single core tool and a substantial UI:
 
 | File | What to learn |
 |------|---------------|
-| `ui/CalcApp.tsx` | `Button` and `Card` from `@sero-ai/ui`, `cn()` usage, container-scoped keyboard events |
-| `ui/styles.css` | Minimal Tailwind + `@theme inline` setup for remote apps |
-| `ui/calc-engine.ts` | Pure logic separated from React (testable, no side effects) |
-| `package.json` | `@sero-ai/ui` as workspace devDependency |
+| `package.json` | Modern built-in plugin manifest shape (`sero.app` + `sero.plugin`) |
+| `extension/index.ts` | Single-tool extension structure with cached workspace state |
+| `ui/GitApp.tsx` | `useAppState`, app composition, renderer-side state derivation |
+| `ui/components/CommitGraph.tsx` | Larger UI broken into focused sub-components |
+| `ui/lib/graph-layout.ts` | Pure UI logic extracted from React |
 
-The **Todo app** (`packages/pi-todo-extension/`) is the canonical reference
-for app structure:
-
-| File | What to learn |
-|------|---------------|
-| `package.json` | Dual Pi + Sero manifest, scripts, dependency structure |
-| `vite.config.ts` | MF remote configuration, `root: 'ui'` pattern, shared singletons |
-| `shared/types.ts` | Shared state shape pattern |
-| `extension/index.ts` | Tool registration, atomic file I/O, TUI rendering |
-| `ui/TodoApp.tsx` | `useAppState` usage, Tailwind styling, sub-components |
-
-The **Tetris app** (`packages/pi-tetris-extension/`) demonstrates patterns
-for interactive/game-style apps:
+The **Kanban plugin** (`plugins/sero-kanban-plugin/`) is the canonical full
+reference for a rich Sero app:
 
 | File | What to learn |
 |------|---------------|
-| `ui/TetrisApp.tsx` | Dynamic sizing with `ResizeObserver`, container-scoped keyboard events, `tabIndex` focus management |
-| `ui/game/useGame.ts` | Game loop hook with scoped keyboard listener (accepts `containerRef`), `setInterval` lifecycle |
-| `ui/game/engine.ts` | Pure game logic separated from React (testable, no side effects) |
-| `shared/types.ts` | Persisted stats (high score) vs. ephemeral game state (board, current piece) |
+| `package.json` | Built-in plugin manifest, prompts, widgets, and dependency setup |
+| `shared/types.ts` | Shared state + helper functions used by extension and UI |
+| `extension/index.ts` | Entry point wiring, session lifecycle, and tool registration |
+| `extension/workflow-actions.ts` | Extracting complex tool behavior into focused modules |
+| `extension/session-runtime.ts` | Adapting current-session runtime capabilities for bridged execution |
+| `ui/KanbanApp.tsx` | Main app shell with `useAppState`, derived board state, and composition |
+| `ui/components/*` | Splitting a large app into maintainable UI modules under the 500 LOC rule |
+| `ui/widgets/KanbanWidget.tsx` | Dashboard widget integration |
 
 The **Web Access plugin** (`plugins/sero-web-plugin/`) demonstrates converting
 an existing Pi extension into a self-contained Sero plugin:
 
 | File | What to learn |
 |------|---------------|
-| `extension/index.ts` | Entry point with session handlers, state sync, tool delegation |
+| `extension/index.ts` | Entry point with session handlers, state sync, and delegated tool modules |
+| `extension/commands.ts` | Slash commands that route users toward tool-driven workflows |
 | `extension/tools-search.ts` | Extracted tool registration as a standalone module |
-| `extension/state-sync.ts` | Atomic state file writes, session entry conversion |
-| `extension/exa.ts` + `exa-mcp.ts` | Splitting an oversized provider file |
-| `extension/extract.ts` + `http-extract.ts` | Splitting extraction orchestrator from HTTP logic |
+| `extension/tools-fetch.ts` | Rich output, progress updates, and persisted fetch history |
+| `extension/state-sync.ts` | Atomic state file writes and session-entry conversion |
 | `ui/WebApp.tsx` | Web UI replacing TUI widgets (search history, provider status) |
+| `ui/components/*` | Real-world use of `@sero-ai/ui` primitives inside a remote app |
 | `ui/widgets/WebWidget.tsx` | Dashboard widget showing recent activity |
-| `shared/types.ts` | Lightweight state shape for UI (stripped from agent-facing data) |
+
+The **Cron plugin** (`plugins/sero-cron-plugin/`) is a good reference for
+background jobs and command-oriented plugins:
+
+| File | What to learn |
+|------|---------------|
+| `extension/index.ts` | Long-lived service initialization with session lifecycle hooks |
+| `extension/state-io.ts` | Isolated persistence helpers |
+| `extension/notifier.ts` | Separating delivery/integration code from core logic |
 
 ### Related documentation
 

--- a/docs/apps-tutorial.md
+++ b/docs/apps-tutorial.md
@@ -157,6 +157,7 @@ plugin manifest.
   },
   "devDependencies": {
     "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",
+    "@sero/common": "workspace:*",
     "@sero-ai/ui": "workspace:*",
     "@module-federation/vite": "catalog:",
     "@vitejs/plugin-react": "catalog:",
@@ -190,14 +191,25 @@ plugin manifest.
 - `@sero-ai/ui` is a `devDependency` that provides shared shadcn/ui components
   (`Button`, `Card`, etc.) and utilities (`cn`). Components are bundled into
   your app at build time — no MF sharing needed.
+- `@sero/common` is the place for **renderer-safe shared contracts** used across
+  desktop, remotes, and plugins **inside this monorepo**. If a type/helper
+  stops being app-local, move it into `packages/common/src/`, re-export it
+  from `packages/common/src/index.ts`, add `@sero/common` to the consuming
+  package's `devDependencies`, and import it via `@sero/common`.
 - `"devPort"` must be unique (see [Port conventions](#port-conventions)). The
   host auto-discovers it from the manifest — no central registry or Vite remotes
   file to update.
 
 ## Step 2: Define the Shared State
 
-Create `shared/types.ts` — the single source of truth for your state shape.
-Both the Pi extension and the web UI import this.
+Create `shared/types.ts` — the single source of truth for your app-local
+state shape. Both the Pi extension and the web UI import this.
+
+If a type/helper needs to be shared more broadly across the desktop app,
+multiple plugins, or web/remotes **in this monorepo**, move that neutral
+contract into `@sero/common` instead of duplicating it. Keep `@sero/common`
+renderer-safe, re-export new types from `packages/common/src/index.ts`, and
+then import them from each consumer via `@sero/common`.
 
 ```typescript
 // shared/types.ts

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -237,23 +237,28 @@ request. With 15+ extensions, tool schemas alone consumed ~3,000–5,000 tokens
 per turn — before the user even sent a message. Combined with the system
 prompt, a "tell me a joke" session started at 13k+ tokens.
 
-**Decision:** All extension/app tools are bridged into the single `sero-cli`
-tool at runtime. The bridge (`electron/cli/index.ts` → `TOOLS_TO_BRIDGE`)
-intercepts tools during `extensionsOverride`, removes their schemas from the
-agent's tool list, and re-registers them as CLI subcommands under `sero-cli`.
+**Decision:** All app/extension tools are bridged into the single `sero-cli`
+tool at runtime. In addition, extension slash commands are exposed as CLI
+commands for agent use while remaining available to the user as slash
+commands.
 
 **Mechanism:**
 - `bridgeExtensionTools()` runs during `DefaultResourceLoader` setup.
-- For each tool in `TOOLS_TO_BRIDGE`, the generic schema bridge
-  (`electron/cli/schema-bridge.ts`) converts the TypeBox parameter schema
-  into CLI-style arg parsing (positionals + `--flags`).
+- The generic schema bridge (`electron/cli/schema-bridge.ts`) converts a
+  tool's TypeBox schema into CLI-style arg parsing (positionals + `--flags`).
 - Array/object parameters accept JSON strings and are parsed automatically.
-- The tool's `execute()` function is called unchanged — only the invocation
-  path differs.
+- Plugin tools are bridged **manifest-first** via `sero.plugin.bridgeTools`:
+  - `undefined` / `true` → bridge all tools from that plugin
+  - `false` → bridge none
+  - `string[]` → bridge only selected tool names
+- Bridged tools and bridged extension commands resolve against the
+  **current session's loaded extension instance** at execute time, not the
+  first session that registered the command.
+- Bridged execution contexts include a narrow execution-scoped
+  `sessionRuntime` capability (`sendUserMessage`, `sendMessage`) for
+  current-session side effects without exposing raw `pi`.
 - **Single-command bridged results preserve rich content** (`text` + `image`
-  blocks) and `details` through `sero-cli`, so the chat stream and history
-  replay can render tool-produced images the same way they do for direct tool
-  calls.
+  blocks) and `details` through `sero-cli`.
 - **Multi-command CLI batches stay text-only by design.** If any bridged
   command in a batch returns non-text blocks, `sero-cli` returns the combined
   textual transcript plus `details.richOutputFallback = true` and a fallback
@@ -265,9 +270,11 @@ browser, sero-cli) instead of 16+. Saves ~2,000–3,000 tokens per session.
 **Rules:**
 - **All app/extension tools MUST use `pi.registerTool()`** — never add them
   as `customTools` in `createAgentSession()` (those bypass the bridge).
-- **New extension tools** must be added to `TOOLS_TO_BRIDGE` in
-  `electron/cli/index.ts`. If a tool appears as a standalone schema in the
-  agent, it's missing from the bridge list.
+- **Plugin authors do not edit a central allowlist** just to bridge a normal
+  plugin tool. Use `sero.plugin.bridgeTools` only when you need to opt out or
+  bridge selectively.
+- **Tools that need session side effects** must depend on execution-scoped
+  runtime capabilities, not on registration-scoped captured extension objects.
 - **Core coding tools** (bash, read, write, edit, browser) remain standalone
   because models are trained to use them with structured parameters.
 - Tools work unchanged in the **Pi CLI** — the bridge is Sero-only.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -218,15 +218,17 @@ QMD provides semantic search via the `@tobilu/qmd` SDK (not CLI).
 | `SERO_HOME` | `~/.sero-ui` | Base directory for all Sero state |
 | `SERO_MEMORY_NO_SEARCH` | unset | Set to `1` to disable QMD selective injection |
 
-## Adding to TOOLS_TO_BRIDGE
+## CLI bridge registration
 
-All memory tools are already in `TOOLS_TO_BRIDGE` in `apps/desktop/electron/cli/index.ts`:
+The memory extension registers its tools normally via `pi.registerTool()`:
 - `memory`
 - `memory_search`
 - `scratchpad`
 
-No manual registration is needed — the extension auto-registers tools via
-`pi.registerTool()` and the CLI bridge picks them up.
+In Sero, plugin tool bridging is manifest-driven. Because the memory plugin is a
+`sero.plugin` package and does not opt out via `bridgeTools`, these tools are
+picked up automatically by the `sero-cli` bridge. No manual allowlist edit is
+required for normal plugin tools.
 
 ## Key Design Decisions
 

--- a/docs/plugins-guide.md
+++ b/docs/plugins-guide.md
@@ -128,6 +128,17 @@ my-plugin/
 └── vite.config.ts        # Module Federation remote config
 ```
 
+Keep app-local state/types in `shared/types.ts`. For **monorepo-shared**
+contracts used across desktop, remotes, and multiple built-in plugins, move
+that neutral code into `packages/common/src/`, re-export it from
+`packages/common/src/index.ts`, and consume it via
+`import type { ... } from '@sero/common'`. Keep `@sero/common` renderer-safe —
+no Electron, Node-only APIs, or desktop-only internals.
+
+If you later extract/publish the plugin outside this monorepo, vendor or
+publish any shared code it still depends on instead of assuming the workspace
+package will exist in the installed plugin environment.
+
 ### 2. Add plugin metadata
 
 Add a `sero.plugin` key to your `package.json` alongside `sero.app`:

--- a/docs/plugins-guide.md
+++ b/docs/plugins-guide.md
@@ -31,7 +31,7 @@ tools, commands, hooks). The only difference is where they're stored:
 
 | | Core app | Plugin |
 |---|----------|--------|
-| **Location** | `packages/pi-*` in the monorepo | `~/.sero-ui/agent/packages/<id>/` |
+| **Location** | `plugins/sero-*-plugin/` in the monorepo | `~/.sero-ui/agent/packages/<id>/` |
 | **Ships with Sero** | Yes | No — installed separately |
 | **Removable** | No | Yes |
 | **Source** | Monorepo | npm, git, or local path |
@@ -162,40 +162,43 @@ Add a `sero.plugin` key to your `package.json` alongside `sero.app`:
 For **npm distribution**, build a ready-to-install plugin bundle:
 
 ```bash
-bash scripts/build-plugin.sh packages/pi-my-app-extension
+bash scripts/build-plugin.sh plugins/sero-my-app-plugin
 ```
 
 This produces a publishable bundle at:
 
 ```
-packages/pi-my-app-extension/dist/plugin/
+plugins/sero-my-app-plugin/dist/plugin/
 ```
 
 For **GitHub source distribution**, export a standalone source repo:
 
 ```bash
-bash scripts/export-plugin-source.sh packages/pi-my-app-extension
+bash scripts/export-plugin-source.sh plugins/sero-my-app-plugin
 ```
 
 This produces a source repo at:
 
 ```
-packages/pi-my-app-extension/dist/plugin-source/
+plugins/sero-my-app-plugin/dist/plugin-source/
 ```
 
 Install either locally from the Sero renderer console:
 
 ```typescript
 await window.sero.plugins.install(
-  '/absolute/path/to/packages/pi-my-app-extension/dist/plugin'
+  '/absolute/path/to/plugins/sero-my-app-plugin/dist/plugin'
 );
 
 await window.sero.plugins.install(
-  '/absolute/path/to/packages/pi-my-app-extension/dist/plugin-source'
+  '/absolute/path/to/plugins/sero-my-app-plugin/dist/plugin-source'
 );
 ```
 
 The plugin should appear in the sidebar immediately — no restart required.
+Active chat sessions also reload their resource loaders, so `sero help <tool>`
+and other CLI-bridged plugin commands become available without manually
+restarting Sero.
 
 ## Plugin Manifest Reference
 
@@ -319,7 +322,7 @@ Push the contents of `dist/plugin-source/` to a public repository. Tag it with
 the **`sero-agent-plugin`** topic for discoverability.
 
 ```bash
-bash scripts/export-plugin-source.sh packages/pi-my-app-extension
+bash scripts/export-plugin-source.sh plugins/sero-my-app-plugin
 ```
 
 Users install with:
@@ -367,15 +370,17 @@ To maximize discoverability:
 
 ### Can I develop a plugin inside the monorepo?
 
-Yes. During development, your plugin lives in `packages/pi-*` like any other
-app. When ready to extract, add the `sero.plugin` metadata, build it, and
-publish. The `sero.plugin` key in `package.json` marks it as extractable.
+Yes. During development, built-in plugins live in `plugins/sero-*-plugin/`
+like any other shipped Sero app. When ready to distribute one externally,
+keep the same package self-contained, add or keep the `sero.plugin` metadata,
+build it, and publish the extracted bundle/source package.
 
 ### Do plugins auto-update?
 
 Not yet. Users manually update by re-installing from the same source.
 If the app ID matches an existing installed plugin, Sero replaces that plugin
-in place and hot-loads the updated UI/tools without a restart.
+in place and hot-loads the updated UI, tools, and active-session CLI bridge
+state without a restart.
 Auto-update support is planned for a future release.
 
 ### What happens to my data if I uninstall a plugin?

--- a/docs/plugins-technical.md
+++ b/docs/plugins-technical.md
@@ -257,7 +257,7 @@ its `package.json`. This lets the renderer distinguish core apps from plugins
 
 ### Build-time (Vite config)
 
-`vite.config.ts` scans `packages/pi-*` for sero.app manifests and builds
+`vite.config.ts` scans `plugins/sero-*-plugin/` for `sero.app` manifests and builds
 the MF remotes config. Plugins installed at `~/.sero-ui/agent/packages/`
 are NOT known at build time — they use pre-built bundles.
 
@@ -283,8 +283,14 @@ registerDynamicRemote(appId);
 invalidateRemote(appId);
 ```
 
-The install IPC path also disposes any app-agent sessions for that app ID so
-plugin-local extensions, prompts, and skills refresh immediately after update.
+The install IPC path also disposes any app-agent sessions for that app ID and
+reloads active chat-session ResourceLoaders so plugin-local extensions,
+prompts, skills, tools, and bridged CLI commands refresh immediately after
+install/update.
+
+Additionally, `electron/ipc/apps/app-state.ts` watches the active profile's
+`settings.json`. If package paths are added or removed outside the install IPC
+path, Sero still reloads running session resources automatically.
 
 ### `sero-ext://` Protocol
 
@@ -299,11 +305,12 @@ registry. The protocol:
 
 ## Tool Bridging
 
-### Core tools (hardcoded)
+### Core tools (static policy)
 
-`CORE_TOOLS_TO_BRIDGE` in `electron/cli/index.ts` lists tool names that are
-always bridged from extension tools into `sero-cli` commands. This saves
-tokens by collapsing individual tool schemas into one CLI tool.
+`CORE_TOOLS_TO_BRIDGE` in `electron/cli/index.ts` still exists for non-plugin
+or legacy tool names that Sero always wants to expose through `sero-cli`.
+Core coding tools like `bash`, `read`, `write`, `edit`, and `browser` remain
+standalone.
 
 ### Plugin tools (manifest-driven)
 
@@ -316,7 +323,26 @@ checks `sero.plugin.bridgeTools`:
 - `string[]` → bridge only the listed tool names
 
 This means plugin tools get bridged into `sero-cli` automatically without
-editing the core allowlist.
+editing a core allowlist.
+
+### Session-scoped execution
+
+The bridge is not just schema translation. It also preserves **session
+correctness**:
+
+- `bridgeExtensionTools()` records the loaded tools and commands for each
+  active agent session.
+- A bridged `sero <tool>` invocation resolves the **current session's**
+  registered tool definition at execute time.
+- Bridged extension commands do the same for the **current session's** command
+  handler.
+- Bridged tool/command contexts include a narrow execution-scoped
+  `sessionRuntime` capability for current-session side effects such as:
+  - `sendUserMessage(...)`
+  - `sendMessage(...)`
+
+This prevents session leakage when plugin logic depends on extension-local
+state or on session-bound messaging behavior.
 
 ## IPC Surface
 

--- a/docs/plugins-technical.md
+++ b/docs/plugins-technical.md
@@ -176,13 +176,22 @@ standard `sero.app` manifest:
 
 ### Types
 
-Defined in `packages/common/src/plugins.ts` and re-exported to the renderer via
-`src/types/plugins.ts` / `src/types/ipc.ts`:
+Shared cross-package contracts live in `packages/common/src/` and should be
+re-exported from `packages/common/src/index.ts` so desktop, remotes, and
+plugins can consume them via `@sero/common`.
+
+Current plugin-system types are defined in `packages/common/src/plugins.ts` and
+re-exported to the renderer via `src/types/plugins.ts` / `src/types/ipc.ts`:
 
 - **`PluginCategory`** — Union of category string literals
 - **`PluginMeta`** — Shape of `sero.plugin` from package.json
 - **`InstalledPlugin`** — Renderer-safe info about an installed plugin
 - **`PluginRegistryEntry`** — Entry from the remote plugin registry
+
+Rules for `@sero/common`:
+- keep it renderer-safe (`type`/utility code only; no Electron or Node-only imports)
+- use it for neutral contracts shared across multiple packages
+- keep app-local state in the app/plugin's own `shared/` directory instead of promoting everything prematurely
 
 ## Installation Flow
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -12,3 +12,12 @@ export type {
   PluginRegistryEntry,
   DiscoveredPlugin,
 } from './plugins';
+
+export type {
+  ExtensionRuntimeTextContent,
+  ExtensionRuntimeImageContent,
+  ExtensionRuntimeContentBlock,
+  ExtensionRuntimeContent,
+  ExtensionRuntimeMessage,
+  ExtensionSessionRuntime,
+} from './session-runtime';

--- a/packages/common/src/session-runtime.ts
+++ b/packages/common/src/session-runtime.ts
@@ -1,0 +1,43 @@
+/**
+ * Session-runtime bridge types shared between the desktop host and plugins.
+ * Keep renderer-safe and free of desktop-/Electron-specific imports.
+ */
+
+export interface ExtensionRuntimeTextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ExtensionRuntimeImageContent {
+  type: 'image';
+  data: string;
+  mimeType: string;
+}
+
+export type ExtensionRuntimeContentBlock =
+  | ExtensionRuntimeTextContent
+  | ExtensionRuntimeImageContent;
+
+export type ExtensionRuntimeContent = string | ExtensionRuntimeContentBlock[];
+
+export interface ExtensionRuntimeMessage {
+  customType: string;
+  content: ExtensionRuntimeContent;
+  display: boolean;
+  details?: unknown;
+}
+
+/**
+ * Narrow execution-scoped runtime forwarded into bridged extension execution.
+ * This stays intentionally small so plugins do not depend on raw host internals.
+ */
+export interface ExtensionSessionRuntime {
+  sendUserMessage: (
+    content: ExtensionRuntimeContent,
+    options?: { deliverAs?: 'steer' | 'followUp' },
+  ) => void | Promise<void>;
+  sendMessage: (
+    message: ExtensionRuntimeMessage,
+    options?: { triggerTurn?: boolean; deliverAs?: 'steer' | 'followUp' | 'nextTurn' },
+  ) => void | Promise<void>;
+}

--- a/packages/templates/profile/AGENTS.md
+++ b/packages/templates/profile/AGENTS.md
@@ -2,63 +2,7 @@
 
 This folder is home. Treat it that way.
 
-## Memory Habits
+## Memory
 
-Save memories proactively, but always use the managed memory tools.
-
-### Managed memory files
-
-These locations are part of Sero's managed memory system:
-
-- `MEMORY.md`
-- `IDENTITY.md`
-- `USER.md`
-- `SCRATCHPAD.md`
-- `memory/daily/`
-- `memory/sessions/`
-
-**Never access or modify those files directly with `bash`, `read`, `write`, or `edit`.**
-Use the `sero-cli` tool with `sero memory`, `sero memory_search`, or
-`sero scratchpad` instead.
-
-### When to use each memory tool
-
-- Use `sero memory_search` when the user asks about past conversations,
-  previous decisions, stored preferences, or anything that might already be in
-  memory
-- Use `sero memory read --target memory --with_ids true` before replacing or
-  removing long-term entries
-- Use `sero memory write --target memory` for durable facts, decisions,
-  preferences, lessons, and project conventions
-- Use `sero memory write --target daily` for progress updates, unfinished work,
-  and day-specific context
-- Use `sero scratchpad` for active working notes and checklist items
-
-### Save to `memory` (long-term) when:
-- The user shares a durable preference, opinion, or pet peeve
-- A technical decision is made
-- You learn something stable about the codebase or project structure
-- The user corrects you in a way worth not repeating
-- A workflow or convention becomes established
-
-### Save to `daily` when:
-- A meaningful task or feature is completed
-- Something is started but left unfinished
-- There is context that will matter later but is not permanent knowledge
-
-### Don't save:
-- Trivial back-and-forth or small talk
-- Information already captured in managed memory files
-- Temporary debugging steps or throwaway experiments unless they matter later
-
-### Retrieval habits
-
-- Start with one precise `memory_search` query before broadening
-- If the first search answers the question, stop and answer
-- Prefer `memory_search` over filesystem tools for recall and history
-
-### Writing habits
-
-- Keep entries concise; one or two sentences is usually enough
-- Prefer updating or removing stale long-term memory instead of duplicating it
-- Let the memory tools manage IDs, timestamps, duplicate checks, and capacity
+Memory tools and guidelines are provided in the system prompt's **Memory System** section.
+Always use `sero memory`, `sero memory_search`, or `sero scratchpad` — never bash/read/write/edit on managed memory files.

--- a/plugins/sero-kanban-plugin/extension/__tests__/workflow-actions.test.ts
+++ b/plugins/sero-kanban-plugin/extension/__tests__/workflow-actions.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { KanbanSessionRuntime } from '../session-runtime';
 
 describe('workflow actions', () => {
   it('queues the brainstorm prompt template as a follow-up', async () => {
     const { handleBrainstorm } = await import('../workflow-actions');
-    const sendUserMessage = vi.fn();
-    const pi = { sendUserMessage } as unknown as ExtensionAPI;
+    const runtime: KanbanSessionRuntime = {
+      sendUserMessage: vi.fn(),
+      sendMessage: vi.fn(),
+    };
 
-    const result = handleBrainstorm(pi);
+    const result = await handleBrainstorm(runtime);
 
-    expect(sendUserMessage).toHaveBeenCalledWith('/brainstorm', { deliverAs: 'followUp' });
+    expect(runtime.sendUserMessage).toHaveBeenCalledWith('/brainstorm', { deliverAs: 'followUp' });
     expect(result.content[0]?.text).toBe('Queued the /brainstorm workflow in the chat session.');
   });
 });

--- a/plugins/sero-kanban-plugin/extension/index.ts
+++ b/plugins/sero-kanban-plugin/extension/index.ts
@@ -25,6 +25,7 @@ import {
   handleReportError, handleErrorLog, handleRetrospective,
 } from './workflow-actions';
 import { handleRequestRevisions, handleCancelPR } from './review-actions';
+import { createKanbanSessionRuntime, getKanbanSessionRuntime } from './session-runtime';
 
 // ── Tool parameters ────────────────────────────────────────────
 
@@ -52,6 +53,7 @@ const KanbanParams = Type.Object({
 
 export default function (pi: ExtensionAPI) {
   let statePath = '';
+  const extensionRuntime = createKanbanSessionRuntime(pi);
 
   pi.on('session_start', async (_event, ctx) => {
     statePath = resolveStatePath(ctx.cwd);
@@ -81,6 +83,7 @@ export default function (pi: ExtensionAPI) {
       const workspacePath = ctx?.cwd ?? resolveWorkspacePathFromStatePath(statePath);
 
       const state = await readState(statePath);
+      const sessionRuntime = getKanbanSessionRuntime(ctx) ?? extensionRuntime;
 
       switch (params.action) {
         case 'list': {
@@ -295,7 +298,7 @@ export default function (pi: ExtensionAPI) {
           return handleRetry(statePath, state, params.id);
 
         case 'brainstorm':
-          return handleBrainstorm(pi);
+          return handleBrainstorm(sessionRuntime);
 
         case 'settings':
           return handleSettings(statePath, state, params.setting, params.value);
@@ -327,7 +330,7 @@ export default function (pi: ExtensionAPI) {
           return handleErrorLog(statePath, params.id);
 
         case 'retrospective':
-          return handleRetrospective(statePath, pi);
+          return handleRetrospective(statePath, sessionRuntime);
 
         default:
           return {

--- a/plugins/sero-kanban-plugin/extension/session-runtime.ts
+++ b/plugins/sero-kanban-plugin/extension/session-runtime.ts
@@ -1,21 +1,7 @@
-import type { ImageContent, TextContent } from '@mariozechner/pi-ai';
 import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ExtensionSessionRuntime } from '@sero/common';
 
-export interface KanbanSessionRuntime {
-  sendUserMessage: (
-    content: string | (TextContent | ImageContent)[],
-    options?: { deliverAs?: 'steer' | 'followUp' },
-  ) => void | Promise<void>;
-  sendMessage: (
-    message: {
-      customType: string;
-      content: string | (TextContent | ImageContent)[];
-      display: boolean;
-      details?: unknown;
-    },
-    options?: { triggerTurn?: boolean; deliverAs?: 'steer' | 'followUp' | 'nextTurn' },
-  ) => void | Promise<void>;
-}
+export type KanbanSessionRuntime = ExtensionSessionRuntime;
 
 type RuntimeAwareExtensionContext = ExtensionContext & {
   sessionRuntime?: KanbanSessionRuntime;

--- a/plugins/sero-kanban-plugin/extension/session-runtime.ts
+++ b/plugins/sero-kanban-plugin/extension/session-runtime.ts
@@ -1,0 +1,37 @@
+import type { ImageContent, TextContent } from '@mariozechner/pi-ai';
+import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
+
+export interface KanbanSessionRuntime {
+  sendUserMessage: (
+    content: string | (TextContent | ImageContent)[],
+    options?: { deliverAs?: 'steer' | 'followUp' },
+  ) => void | Promise<void>;
+  sendMessage: (
+    message: {
+      customType: string;
+      content: string | (TextContent | ImageContent)[];
+      display: boolean;
+      details?: unknown;
+    },
+    options?: { triggerTurn?: boolean; deliverAs?: 'steer' | 'followUp' | 'nextTurn' },
+  ) => void | Promise<void>;
+}
+
+type RuntimeAwareExtensionContext = ExtensionContext & {
+  sessionRuntime?: KanbanSessionRuntime;
+};
+
+export function createKanbanSessionRuntime(
+  api: Pick<ExtensionAPI, 'sendUserMessage' | 'sendMessage'>,
+): KanbanSessionRuntime {
+  return {
+    sendUserMessage: (content, options) => api.sendUserMessage(content, options),
+    sendMessage: (message, options) => api.sendMessage(message, options),
+  };
+}
+
+export function getKanbanSessionRuntime(
+  ctx: ExtensionContext | undefined,
+): KanbanSessionRuntime | undefined {
+  return (ctx as RuntimeAwareExtensionContext | undefined)?.sessionRuntime;
+}

--- a/plugins/sero-kanban-plugin/extension/workflow-actions.ts
+++ b/plugins/sero-kanban-plugin/extension/workflow-actions.ts
@@ -4,9 +4,8 @@
  * Extracted from index.ts for file size compliance.
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-
 import type { KanbanState, Column, ErrorSeverity } from '../shared/types';
+import type { KanbanSessionRuntime } from './session-runtime';
 import { COLUMN_LABELS } from '../shared/types';
 import { validateCardTransition } from '../shared/validation';
 import { writeState } from './state-io';
@@ -134,8 +133,8 @@ export async function handleRetry(
 
 // ── Brainstorm ───────────────────────────────────────────────
 
-export function handleBrainstorm(pi: ExtensionAPI): ToolResult {
-  pi.sendUserMessage('/brainstorm', { deliverAs: 'followUp' });
+export async function handleBrainstorm(runtime: KanbanSessionRuntime): Promise<ToolResult> {
+  await runtime.sendUserMessage('/brainstorm', { deliverAs: 'followUp' });
   return text('Queued the /brainstorm workflow in the chat session.');
 }
 
@@ -289,7 +288,7 @@ export async function handleErrorLog(statePath: string, cardId?: string): Promis
 
 export async function handleRetrospective(
   statePath: string,
-  pi: ExtensionAPI,
+  runtime: KanbanSessionRuntime,
 ): Promise<ToolResult> {
   const log = await readErrorLog(statePath);
   if (log.errors.length === 0) {
@@ -303,7 +302,7 @@ export async function handleRetrospective(
   await writeErrorLog(statePath, log);
 
   // Send the retrospective data to the agent for analysis
-  pi.sendUserMessage(
+  await runtime.sendUserMessage(
     'Perform a retrospective analysis on the Kanban board errors below. '
     + 'Identify root causes, recurring patterns, and suggest concrete process '
     + 'improvements to prevent these errors in future. Group your findings by:\n'

--- a/plugins/sero-kanban-plugin/package.json
+++ b/plugins/sero-kanban-plugin/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@module-federation/vite": "catalog:",
     "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",
+    "@sero/common": "workspace:*",
     "@tailwindcss/vite": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/plugins/sero-memory-plugin/extension/context-injector.ts
+++ b/plugins/sero-memory-plugin/extension/context-injector.ts
@@ -26,6 +26,7 @@ import {
 import type { BootstrapStatus } from './bootstrap';
 import { resolveMemoryRoot } from './memory-manager';
 import { getAutoRetrieveModeSync, getMemorySnapshotModeSync } from './memory-config';
+import type { AutoRetrieveMode } from './memory-config';
 import { buildPriorityContextSplit, clearPriorityContextCache } from './priority-context';
 import { isQmdAvailable, runQmdUpdateNow } from './qmd';
 import { error, errorDetails, info } from './logger';
@@ -123,6 +124,7 @@ After receiving answers, write MEMORY.md:
 async function buildTurnContext(
   prompt: string,
   sessionId: string,
+  autoRetrieveMode: AutoRetrieveMode,
 ): Promise<{
   systemPromptAddition: string;
   searchContext: string;
@@ -132,7 +134,11 @@ async function buildTurnContext(
   const root = resolveMemoryRoot();
   const snapshotMode = getMemorySnapshotModeSync();
   const { staticContext, searchContext } = await buildPriorityContextSplit(
-    root, prompt, sessionId, snapshotMode,
+    root,
+    prompt,
+    sessionId,
+    snapshotMode,
+    { includeSearch: autoRetrieveMode === 'on' },
   );
   const memoryInstructions = getMemoryInstructions();
   const systemPromptAddition = staticContext + memoryInstructions;
@@ -186,6 +192,7 @@ export function registerContextInjection(pi: ExtensionAPI): void {
     try {
       const status = await getCachedBootstrapStatus();
       const sessionId = ctx.sessionManager.getSessionId();
+      const autoRetrieveMode = getAutoRetrieveModeSync();
 
       let addition = '';
       let contextBlock = '';
@@ -215,7 +222,7 @@ export function registerContextInjection(pi: ExtensionAPI): void {
         if (needsBootstrap) {
           addition = buildBootstrapInstructions(refreshedStatus.existingUserContent);
         } else {
-          const turn = await buildTurnContext(event.prompt ?? '', sessionId);
+          const turn = await buildTurnContext(event.prompt ?? '', sessionId, autoRetrieveMode);
           addition = turn.systemPromptAddition;
           contextBlock = turn.contextBlock;
           memoryInstructions = turn.memoryInstructions;
@@ -224,7 +231,7 @@ export function registerContextInjection(pi: ExtensionAPI): void {
       }
 
       if (!needsBootstrap && !addition) {
-        const turn = await buildTurnContext(event.prompt ?? '', sessionId);
+        const turn = await buildTurnContext(event.prompt ?? '', sessionId, autoRetrieveMode);
         addition = turn.systemPromptAddition;
         contextBlock = turn.contextBlock;
         memoryInstructions = turn.memoryInstructions;
@@ -247,7 +254,7 @@ export function registerContextInjection(pi: ExtensionAPI): void {
       info('before_agent_start', {
         needsBootstrap,
         snapshotMode: getMemorySnapshotModeSync(),
-        autoRetrieve: getAutoRetrieveModeSync(),
+        autoRetrieve: autoRetrieveMode,
         promptChars: event.prompt?.length ?? 0,
         contextChars: contextBlock.length,
         searchChars: searchContext.length,
@@ -257,7 +264,7 @@ export function registerContextInjection(pi: ExtensionAPI): void {
       // Inject QMD search results as a per-turn message when auto-retrieve is on.
       // The `context` event filter strips these from prior turns so only the
       // latest search results reach the LLM.
-      if (searchContext.trim() && getAutoRetrieveModeSync() === 'on') {
+      if (searchContext.trim() && autoRetrieveMode === 'on') {
         try {
           pi.sendMessage(
             { customType: SEARCH_CONTEXT_TYPE, content: searchContext.trim(), display: false },

--- a/plugins/sero-memory-plugin/extension/context-injector.ts
+++ b/plugins/sero-memory-plugin/extension/context-injector.ts
@@ -1,11 +1,18 @@
 /**
- * ContextInjector — injects memory context into the system prompt.
+ * ContextInjector — injects memory context into the agent's context.
  *
- * Priority ordering (8K total budget):
- *   1. IDENTITY.md + USER.md  — persona, never fully dropped
- *   2. Open scratchpad items  — active work context
- *   3. QMD search results     — auto-retrieved relevant memories
- *   4. MEMORY.md              — curated long-term memory
+ * Split injection model:
+ *   System prompt (static, per-session or per-turn depending on snapshot mode):
+ *     - IDENTITY.md + USER.md — persona
+ *     - SCRATCHPAD.md — active work items
+ *     - MEMORY.md — curated long-term memory
+ *     - Memory instructions — retrieval/storage commands
+ *
+ *   Per-turn message (dynamic, only when auto-retrieve is on):
+ *     - QMD search results — memories relevant to the current user prompt
+ *
+ * The `context` event strips prior-turn search messages so only the
+ * latest search results reach the LLM.
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
@@ -18,8 +25,8 @@ import {
 } from './bootstrap';
 import type { BootstrapStatus } from './bootstrap';
 import { resolveMemoryRoot } from './memory-manager';
-import { getMemorySnapshotModeSync } from './memory-config';
-import { buildPriorityContext, clearPriorityContextCache } from './priority-context';
+import { getAutoRetrieveModeSync, getMemorySnapshotModeSync } from './memory-config';
+import { buildPriorityContextSplit, clearPriorityContextCache } from './priority-context';
 import { isQmdAvailable, runQmdUpdateNow } from './qmd';
 import { error, errorDetails, info } from './logger';
 import { runPhase1Migration } from './migration';
@@ -30,6 +37,9 @@ import {
   logMemoryPromptAgentStart,
   logMemoryPromptBeforeAgentStart,
 } from './prompt-debug';
+
+/** Custom message type for auto-retrieved search results. */
+const SEARCH_CONTEXT_TYPE = 'memory-search-context';
 
 let cachedStatus: BootstrapStatus | null = null;
 let migrationChecked = false;
@@ -102,6 +112,38 @@ After receiving answers, write MEMORY.md:
 - Be friendly and natural between steps — this is a first-time experience.`;
 }
 
+/**
+ * Build the memory context for a normal (non-bootstrap) turn.
+ *
+ * Returns:
+ *   - `systemPromptAddition`: static memory + instructions for the system prompt
+ *   - `searchContext`: dynamic QMD search results for message injection
+ *   - `contextBlock`: full combined context (for debug logging)
+ */
+async function buildTurnContext(
+  prompt: string,
+  sessionId: string,
+): Promise<{
+  systemPromptAddition: string;
+  searchContext: string;
+  contextBlock: string;
+  memoryInstructions: string;
+}> {
+  const root = resolveMemoryRoot();
+  const snapshotMode = getMemorySnapshotModeSync();
+  const { staticContext, searchContext } = await buildPriorityContextSplit(
+    root, prompt, sessionId, snapshotMode,
+  );
+  const memoryInstructions = getMemoryInstructions();
+  const systemPromptAddition = staticContext + memoryInstructions;
+  // Full combined context for debug logging
+  const contextBlock = searchContext
+    ? (staticContext ? `${staticContext}\n\n---\n\n${searchContext}` : searchContext)
+    : staticContext;
+
+  return { systemPromptAddition, searchContext, contextBlock, memoryInstructions };
+}
+
 export function registerContextInjection(pi: ExtensionAPI): void {
   pi.on('session_start', (_event, ctx) => {
     const sessionId = ctx.sessionManager.getSessionId();
@@ -119,11 +161,12 @@ export function registerContextInjection(pi: ExtensionAPI): void {
     resetBootstrapCache();
   });
 
+  // Strip prior-turn search context messages so only the latest reaches the LLM.
   pi.on('context', async (event) => {
     return {
       messages: event.messages.filter((message) => {
         const custom = message as unknown as Record<string, unknown>;
-        return custom.customType !== 'memory-context';
+        return custom.customType !== SEARCH_CONTEXT_TYPE;
       }),
     };
   });
@@ -143,11 +186,11 @@ export function registerContextInjection(pi: ExtensionAPI): void {
     try {
       const status = await getCachedBootstrapStatus();
       const sessionId = ctx.sessionManager.getSessionId();
-      const snapshotMode = getMemorySnapshotModeSync();
 
       let addition = '';
       let contextBlock = '';
       let memoryInstructions = '';
+      let searchContext = '';
       let needsBootstrap = status.needsBootstrap;
 
       if (needsBootstrap) {
@@ -172,18 +215,20 @@ export function registerContextInjection(pi: ExtensionAPI): void {
         if (needsBootstrap) {
           addition = buildBootstrapInstructions(refreshedStatus.existingUserContent);
         } else {
-          const root = resolveMemoryRoot();
-          contextBlock = await buildPriorityContext(root, event.prompt ?? '', sessionId, snapshotMode);
-          memoryInstructions = getMemoryInstructions();
-          addition = contextBlock + memoryInstructions;
+          const turn = await buildTurnContext(event.prompt ?? '', sessionId);
+          addition = turn.systemPromptAddition;
+          contextBlock = turn.contextBlock;
+          memoryInstructions = turn.memoryInstructions;
+          searchContext = turn.searchContext;
         }
       }
 
       if (!needsBootstrap && !addition) {
-        const root = resolveMemoryRoot();
-        contextBlock = await buildPriorityContext(root, event.prompt ?? '', sessionId, snapshotMode);
-        memoryInstructions = getMemoryInstructions();
-        addition = contextBlock + memoryInstructions;
+        const turn = await buildTurnContext(event.prompt ?? '', sessionId);
+        addition = turn.systemPromptAddition;
+        contextBlock = turn.contextBlock;
+        memoryInstructions = turn.memoryInstructions;
+        searchContext = turn.searchContext;
       }
 
       logMemoryPromptBeforeAgentStart({
@@ -194,27 +239,32 @@ export function registerContextInjection(pi: ExtensionAPI): void {
         memoryInstructions,
         addition,
         needsBootstrap,
-        snapshotMode,
+        snapshotMode: getMemorySnapshotModeSync(),
         qmdAvailable: isQmdAvailable(),
         skipSearch: process.env.SERO_MEMORY_NO_SEARCH === '1',
       });
 
       info('before_agent_start', {
         needsBootstrap,
-        snapshotMode,
+        snapshotMode: getMemorySnapshotModeSync(),
+        autoRetrieve: getAutoRetrieveModeSync(),
         promptChars: event.prompt?.length ?? 0,
         contextChars: contextBlock.length,
+        searchChars: searchContext.length,
         additionChars: addition.length,
       });
 
-      if (contextBlock.trim()) {
+      // Inject QMD search results as a per-turn message when auto-retrieve is on.
+      // The `context` event filter strips these from prior turns so only the
+      // latest search results reach the LLM.
+      if (searchContext.trim() && getAutoRetrieveModeSync() === 'on') {
         try {
           pi.sendMessage(
-            { customType: 'memory-context', content: contextBlock.trim(), display: false },
+            { customType: SEARCH_CONTEXT_TYPE, content: searchContext.trim(), display: false },
             { triggerTurn: false },
           );
         } catch {
-          // Non-fatal — the same content is already injected into the system prompt.
+          // Non-fatal — search results are supplementary context, not critical.
         }
       }
 

--- a/plugins/sero-memory-plugin/extension/memory-config.ts
+++ b/plugins/sero-memory-plugin/extension/memory-config.ts
@@ -7,13 +7,16 @@ import os from 'node:os';
 import path from 'node:path';
 
 export type MemorySnapshotMode = 'frozen' | 'live';
+export type AutoRetrieveMode = 'on' | 'off';
 
 interface MemoryConfigState {
   snapshotMode?: MemorySnapshotMode;
+  autoRetrieve?: AutoRetrieveMode;
 }
 
 const DEFAULT_CONFIG: MemoryConfigState = {};
 const DEFAULT_SNAPSHOT_MODE: MemorySnapshotMode = 'frozen';
+const DEFAULT_AUTO_RETRIEVE: AutoRetrieveMode = 'on';
 
 function resolveSeroHome(): string {
   return process.env.SERO_HOME || path.join(os.homedir(), '.sero-ui');
@@ -75,5 +78,34 @@ export function describeMemorySnapshotMode(mode: MemorySnapshotMode): string {
       return 'frozen — identity, user, and long-term memory stay fixed for the session';
     case 'live':
       return 'live — memory context is rebuilt each turn';
+  }
+}
+
+// ── Auto-retrieve ───────────────────────────────────────────
+
+function normalizeAutoRetrieve(value: unknown): AutoRetrieveMode {
+  return value === 'on' || value === 'off' ? value : DEFAULT_AUTO_RETRIEVE;
+}
+
+export function getAutoRetrieveModeSync(): AutoRetrieveMode {
+  const env = process.env.SERO_MEMORY_AUTO_RETRIEVE?.trim().toLowerCase();
+  if (env === 'on' || env === 'off') return env;
+  return normalizeAutoRetrieve(readConfigSync().autoRetrieve);
+}
+
+export function setAutoRetrieveModeSync(mode: AutoRetrieveMode): AutoRetrieveMode {
+  const nextMode = normalizeAutoRetrieve(mode);
+  const state = readConfigSync();
+  if (state.autoRetrieve === nextMode) return nextMode;
+  writeConfigSync({ ...state, autoRetrieve: nextMode });
+  return nextMode;
+}
+
+export function describeAutoRetrieveMode(mode: AutoRetrieveMode): string {
+  switch (mode) {
+    case 'on':
+      return 'on — relevant memories are auto-retrieved each turn based on the user prompt';
+    case 'off':
+      return 'off — no automatic memory retrieval; use `sero memory_search` manually';
   }
 }

--- a/plugins/sero-memory-plugin/extension/memory-instructions.ts
+++ b/plugins/sero-memory-plugin/extension/memory-instructions.ts
@@ -2,10 +2,9 @@
  * Memory system prompt instructions — injected into the agent's system prompt
  * on every turn via the context injector's `before_agent_start` hook.
  *
- * These instructions teach the agent:
- * 1. To ALWAYS use memory commands instead of bash/grep/find/read for memory files
- * 2. When to use `memory_search` vs `memory read` vs `memory search`
- * 3. How to write/replace/remove memory entries correctly
+ * This is the SINGLE SOURCE OF TRUTH for memory-related agent instructions.
+ * Other prompt sources (AGENTS.md, CLI block, container block) should reference
+ * this section — not duplicate its content.
  */
 
 import { isQmdAvailable } from './qmd';
@@ -18,8 +17,7 @@ export function getMemoryInstructions(): string {
   return [
     '\n\n## Memory System',
     '',
-    `All memory files live in \`${root}\`. Run the commands below through the \`sero-cli\` tool. **Always use these memory commands** — never read/write/grep those files directly with bash, read, or edit tools. Direct file access bypasses IDs, timestamps, capacity limits, duplicate detection, transcript export, and search indexing.`,
-    'Managed files include `MEMORY.md`, `IDENTITY.md`, `USER.md`, `SCRATCHPAD.md`, `memory/daily/`, and `memory/sessions/`.',
+    `All memory files live in \`${root}\`. **Always use \`sero memory\`, \`sero memory_search\`, or \`sero scratchpad\` via \`sero-cli\`** — never read/write/grep managed files (\`MEMORY.md\`, \`IDENTITY.md\`, \`USER.md\`, \`SCRATCHPAD.md\`, \`memory/daily/\`, \`memory/sessions/\`) directly with bash, read, write, or edit tools. Direct access bypasses IDs, timestamps, capacity limits, duplicate detection, and search indexing.`,
     '',
     ...getMemoryRetrievalInstructions(hasSearch),
     '',
@@ -28,66 +26,50 @@ export function getMemoryInstructions(): string {
 }
 
 /**
- * Instructions for retrieving/searching memory — the "when to reach for memory" rules.
- *
- * These tell the agent to prefer memory_search over bash/grep/find
- * for any question about past context, conversations, or stored knowledge.
+ * Retrieval instructions — when and how to search memory.
  */
 function getMemoryRetrievalInstructions(hasSearch: boolean): string[] {
   const lines: string[] = [
-    '### Retrieving information',
+    '### Retrieval',
     '',
-    '**When the user asks about past conversations, previous decisions, what was discussed, or anything that might be in memory — use `sero memory_search`, not bash/grep/find/read.**',
+    'For past conversations, decisions, preferences, or stored knowledge — use `sero memory_search`, not bash/grep/find.',
+    '- `sero memory_search --query "X"` — ranked search across memory + transcripts (default `--scope all`)',
+    '- `sero memory_search --query "X" --scope sessions` — search transcripts only',
+    '- `sero memory_search --query "X" --scope memory` — search memory files only',
     '',
-    '`sero memory_search` is the canonical recall/search path for Sero memory. It searches across long-term memory files AND exported session transcripts with ranked results. Bash tools cannot do this reliably — they miss transcripts, lack semantic matching, bypass indexing, and return raw file content instead of ranked excerpts.',
-    '',
-    'Use `memory_search` for:',
-    '- "What did we discuss about X?" → `sero memory_search --query "X" --scope sessions`',
-    '- "Do I have any memory about Y?" → `sero memory_search --query "Y" --scope memory`',
-    '- "Search for Z across everything" → `sero memory_search --query "Z"` (defaults to `--scope all`)',
-    '- Any question about past context, decisions, preferences, or conversation history',
-    '',
-    'Efficiency rule: start with ONE precise search query. If that first search already returns a direct answer, stop and answer the user. Only run a second search when the first search misses, is ambiguous, or needs broader recall.',
-    '',
+    'Start with ONE precise query. If it answers the question, stop. Only broaden if the first search misses.',
   ];
 
   if (hasSearch) {
-    lines.push('Modes: `keyword` (fast, default) → `semantic` (conceptual matching) → `deep` (hybrid reranking). Escalate only if the first mode misses or stays ambiguous.');
+    lines.push('Modes: `keyword` (default) → `semantic` → `deep`. Escalate only if needed.');
   } else {
-    lines.push('If `memory_search` reports that search indexing is unavailable, surface that limitation to the user and do NOT fall back to bash/read on managed memory files.');
+    lines.push('If search indexing is unavailable, report that to the user — do NOT fall back to bash/read.');
   }
 
   lines.push(
     '',
-    'Use `sero memory read` to view the full contents of a specific managed file:',
-    '- `sero memory read --target memory [--with_ids true]` — view MEMORY.md (use --with_ids before replace/remove)',
-    '- `sero memory read --target identity|user|daily`',
-    '',
-    'Use `sero memory search --query "..."` only for quick text grep across memory files (no transcripts, no ranked recall).',
-    'Use `sero scratchpad list` to view SCRATCHPAD.md instead of reading it directly.',
+    'To view full file contents: `sero memory read --target memory|identity|user|daily` (add `--with_ids true` before replace/remove).',
+    'For quick text grep (no transcripts): `sero memory search --query "..."`.',
+    'For scratchpad: `sero scratchpad list`.',
   );
 
   return lines;
 }
 
-/** Instructions for writing/updating memory. */
+/** Storage instructions — how to write/update memory. */
 function getMemoryStorageInstructions(): string[] {
   return [
-    '### Storing information',
+    '### Storage',
     '',
     '- `sero memory write --target memory|daily|user|identity --content "..." [--type fact|decision|preference|lesson|question|hypothesis] [--mode append|overwrite]`',
     '- `sero memory replace --target memory --entry_id "mem-..." --content "..."`',
     '- `sero memory remove --target memory --entry_id "mem-..."`',
-    '- `sero memory consolidate [--schedule daily|weekly|off]` — run or configure automatic memory consolidation',
-    '- `sero memory config [--snapshot frozen|live]` — control whether long-term memory is frozen per session or rebuilt each turn',
+    '- `sero memory consolidate [--schedule daily|weekly|off]`',
+    '- `sero memory config [--snapshot frozen|live] [--auto_retrieve on|off]`',
     '- `sero scratchpad add|done "..."`',
     '',
-    'Guidelines:',
-    '- Save durable preferences, decisions, project facts, and corrections to `memory`',
-    '- Save session-specific progress, blockers, and follow-ups to `daily`',
-    '- Read with IDs before updating memory so you replace stale entries instead of duplicating them',
-    '- Use type tags: [fact], [decision], [preference], [lesson], [question], [hypothesis] — decisions and preferences are preserved first when memory is truncated',
-    '- The memory tool assigns stable entry IDs automatically; do not edit raw files to manage them',
-    '- If a file is near capacity, replace or remove stale memory instead of appending more',
+    'Save durable facts, decisions, preferences, corrections → `memory`. Session progress, blockers → `daily`.',
+    'Read with IDs before updating to avoid duplicates. Use type tags ([fact], [decision], [preference], etc.).',
+    'Near capacity? Replace or remove stale entries instead of appending.',
   ];
 }

--- a/plugins/sero-memory-plugin/extension/memory-tool-admin.ts
+++ b/plugins/sero-memory-plugin/extension/memory-tool-admin.ts
@@ -6,9 +6,13 @@ import {
   type AutoConsolidationCadence,
 } from './automation-state';
 import {
+  describeAutoRetrieveMode,
   describeMemorySnapshotMode,
+  getAutoRetrieveModeSync,
   getMemorySnapshotModeSync,
+  setAutoRetrieveModeSync,
   setMemorySnapshotModeSync,
+  type AutoRetrieveMode,
   type MemorySnapshotMode,
 } from './memory-config';
 import {
@@ -66,21 +70,39 @@ export async function handleMemoryConsolidate(
 
 export function handleMemoryConfig(
   snapshot: MemorySnapshotMode | undefined,
+  autoRetrieve: AutoRetrieveMode | undefined,
 ): ToolTextResult {
+  const lines: string[] = [];
+
   if (snapshot) {
     const nextMode = setMemorySnapshotModeSync(snapshot);
-    return text([
+    lines.push(
       `Memory snapshot mode set to ${nextMode}.`,
       describeMemorySnapshotMode(nextMode),
       nextMode === 'frozen'
         ? 'Mid-session writes to IDENTITY.md, USER.md, and MEMORY.md will appear in the next session.'
         : 'Memory context will be rebuilt on every turn.',
-    ].join('\n'));
+    );
   }
 
-  const currentMode = getMemorySnapshotModeSync();
-  return text([
-    `Memory snapshot mode: ${currentMode}.`,
-    describeMemorySnapshotMode(currentMode),
-  ].join('\n'));
+  if (autoRetrieve) {
+    const nextMode = setAutoRetrieveModeSync(autoRetrieve);
+    if (lines.length > 0) lines.push('');
+    lines.push(
+      `Auto-retrieve set to ${nextMode}.`,
+      describeAutoRetrieveMode(nextMode),
+    );
+  }
+
+  // No arguments — show current config
+  if (!snapshot && !autoRetrieve) {
+    const currentSnapshot = getMemorySnapshotModeSync();
+    const currentAutoRetrieve = getAutoRetrieveModeSync();
+    lines.push(
+      `Memory snapshot mode: ${currentSnapshot} — ${describeMemorySnapshotMode(currentSnapshot)}`,
+      `Auto-retrieve: ${currentAutoRetrieve} — ${describeAutoRetrieveMode(currentAutoRetrieve)}`,
+    );
+  }
+
+  return text(lines.join('\n'));
 }

--- a/plugins/sero-memory-plugin/extension/memory-tool.ts
+++ b/plugins/sero-memory-plugin/extension/memory-tool.ts
@@ -44,7 +44,7 @@ import {
 } from './memory-tool-admin';
 import type { AutoConsolidationCadence } from './automation-state';
 import type { ConsolidationTrigger } from './consolidation';
-import type { MemorySnapshotMode } from './memory-config';
+import type { AutoRetrieveMode, MemorySnapshotMode } from './memory-config';
 
 const MemoryParams = Type.Object({
   action: StringEnum(['read', 'write', 'replace', 'remove', 'search', 'list', 'consolidate', 'config'] as const),
@@ -61,6 +61,7 @@ const MemoryParams = Type.Object({
   schedule: Type.Optional(StringEnum(['daily', 'weekly', 'off'] as const)),
   trigger: Type.Optional(StringEnum(['manual', 'cron', 'auto'] as const)),
   snapshot: Type.Optional(StringEnum(['frozen', 'live'] as const)),
+  auto_retrieve: Type.Optional(StringEnum(['on', 'off'] as const)),
 });
 
 type MemoryParamsType = Static<typeof MemoryParams>;
@@ -422,7 +423,10 @@ export function registerMemoryTool(pi: ExtensionAPI): void {
               ctx,
             );
           case 'config':
-            return handleMemoryConfig(p.snapshot as MemorySnapshotMode | undefined);
+            return handleMemoryConfig(
+              p.snapshot as MemorySnapshotMode | undefined,
+              p.auto_retrieve as AutoRetrieveMode | undefined,
+            );
           default:
             return text(`Unknown action: ${p.action}`);
         }
@@ -444,6 +448,7 @@ export function registerMemoryTool(pi: ExtensionAPI): void {
       if (args.entry_id) output += ` ${theme.fg('accent', args.entry_id)}`;
       if (args.schedule) output += ` ${theme.fg('accent', `schedule:${args.schedule}`)}`;
       if (args.snapshot) output += ` ${theme.fg('accent', `snapshot:${args.snapshot}`)}`;
+      if (args.auto_retrieve) output += ` ${theme.fg('accent', `auto_retrieve:${args.auto_retrieve}`)}`;
       if (args.query) output += ` ${theme.fg('dim', `"${args.query}"`)}`;
       if (args.content) {
         const preview = args.content.length > 60 ? `${args.content.slice(0, 57)}...` : args.content;

--- a/plugins/sero-memory-plugin/extension/priority-context.ts
+++ b/plugins/sero-memory-plugin/extension/priority-context.ts
@@ -256,19 +256,37 @@ export function clearPriorityContextCache(sessionId: string): void {
   clearCache(sessionId);
 }
 
-export async function buildPriorityContext(
+/**
+ * Result of building priority context with search results separated out.
+ * `staticContext` goes into the system prompt.
+ * `searchContext` can be injected as a per-turn message (if auto-retrieve is on).
+ */
+export interface PriorityContextResult {
+  /** Static memory sections (IDENTITY, USER, SCRATCHPAD, MEMORY.md) for the system prompt. */
+  staticContext: string;
+  /** Dynamic QMD search results for the current prompt. Empty if no results or QMD unavailable. */
+  searchContext: string;
+}
+
+/**
+ * Build priority context with search results returned separately.
+ *
+ * Use this when you need to inject static context into the system prompt
+ * and optionally send search results as a per-turn message.
+ */
+export async function buildPriorityContextSplit(
   root: string,
   prompt: string,
   sessionId?: string,
   snapshotMode: MemorySnapshotMode = 'live',
-): Promise<string> {
-  const sections: string[] = [];
+): Promise<PriorityContextResult> {
+  const staticSections: string[] = [];
   let totalChars = 0;
 
   function addSection(section: string): void {
     if (!section.trim()) return;
     if (totalChars + section.length > BUDGET_TOTAL) return;
-    sections.push(section);
+    staticSections.push(section);
     totalChars += section.length;
   }
 
@@ -279,9 +297,33 @@ export async function buildPriorityContext(
   addSection(frozenSnapshot?.identitySection ?? await buildIdentitySection(root));
   addSection(frozenSnapshot?.userSection ?? await buildUserSection(root));
   addSection(await buildScratchpadSection(root));
-  addSection(await buildSearchSection(prompt, sessionId));
   addSection(frozenSnapshot?.memorySection ?? await buildMemorySection(root));
 
-  if (sections.length === 0) return '';
-  return `\n\n## Memory\n\n${sections.join('\n\n---\n\n')}`;
+  const searchSection = await buildSearchSection(prompt, sessionId);
+
+  const staticContext = staticSections.length > 0
+    ? `\n\n## Memory\n\n${staticSections.join('\n\n---\n\n')}`
+    : '';
+
+  return { staticContext, searchContext: searchSection };
+}
+
+/**
+ * Build the full priority context as a single string.
+ * Combines static memory + search results.
+ * Used by tests and as a compatibility wrapper.
+ */
+export async function buildPriorityContext(
+  root: string,
+  prompt: string,
+  sessionId?: string,
+  snapshotMode: MemorySnapshotMode = 'live',
+): Promise<string> {
+  const { staticContext, searchContext } = await buildPriorityContextSplit(root, prompt, sessionId, snapshotMode);
+  if (!staticContext && !searchContext) return '';
+  if (!searchContext) return staticContext;
+  // Append search results after the static sections
+  return staticContext
+    ? `${staticContext}\n\n---\n\n${searchContext}`
+    : `\n\n## Memory\n\n${searchContext}`;
 }

--- a/plugins/sero-memory-plugin/extension/priority-context.ts
+++ b/plugins/sero-memory-plugin/extension/priority-context.ts
@@ -268,6 +268,11 @@ export interface PriorityContextResult {
   searchContext: string;
 }
 
+export interface BuildPriorityContextOptions {
+  /** When false, skip prompt-specific QMD retrieval entirely. */
+  includeSearch?: boolean;
+}
+
 /**
  * Build priority context with search results returned separately.
  *
@@ -279,6 +284,7 @@ export async function buildPriorityContextSplit(
   prompt: string,
   sessionId?: string,
   snapshotMode: MemorySnapshotMode = 'live',
+  options: BuildPriorityContextOptions = {},
 ): Promise<PriorityContextResult> {
   const staticSections: string[] = [];
   let totalChars = 0;
@@ -299,7 +305,9 @@ export async function buildPriorityContextSplit(
   addSection(await buildScratchpadSection(root));
   addSection(frozenSnapshot?.memorySection ?? await buildMemorySection(root));
 
-  const searchSection = await buildSearchSection(prompt, sessionId);
+  const searchSection = options.includeSearch === false
+    ? ''
+    : await buildSearchSection(prompt, sessionId);
 
   const staticContext = staticSections.length > 0
     ? `\n\n## Memory\n\n${staticSections.join('\n\n---\n\n')}`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,6 +783,9 @@ importers:
       '@sero-ai/app-runtime':
         specifier: workspace:@sero-ai/app-runtime@*
         version: link:../../packages/app-runtime
+      '@sero/common':
+        specifier: workspace:*
+        version: link:../../packages/common
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))


### PR DESCRIPTION
## Problem

A minimal "tell me a joke" turn still carried too much prompt/tool overhead, and the first round of fixes exposed several deeper architectural issues:

1. **Memory guidance and context injection were still doing more work than needed**
   - memory routing rules were duplicated across multiple prompt sources
   - `auto_retrieve=off` still executed QMD retrieval work and only skipped message injection
2. **The CLI bridge was not session-correct for plugin tools/commands**
   - bridging through a singleton registry could leak the first session's extension instance
   - `kanban` surfaced this first because actions like `brainstorm` / `retrospective` need current-session follow-up messaging
   - other built-in and external plugins could hit the same class of bug if they captured session-bound state
3. **Installed plugins could remain stale in existing chat sessions**
   - package discovery worked, but active session resource loaders / CLI bridge state were not always refreshed after `settings.json` changed
   - this showed up in practice with Todo not becoming available to `sero-cli` in an already-running session
4. **Shared runtime contracts were at risk of drifting across packages**
   - the capability-based session runtime shape was intentionally small, but it was duplicated between desktop and Kanban
5. **Plugin/app docs had drifted from the current runtime model**
   - the docs still referenced old `packages/pi-*` locations and outdated bridge guidance
   - there was no explicit guidance on when to keep code app-local vs move neutral contracts into `@sero/common`

## Solution

### Deduplicate memory instructions and truly gate auto-retrieve
- Keep `memory-instructions.ts` as the single source of truth for memory rules
- Remove duplicated routing guidance from the CLI/container prompt path
- Update `buildPriorityContextSplit(..., options)` to accept `includeSearch`
- When `auto_retrieve=off`, skip QMD retrieval entirely — no search execution, no cache churn, no hit recording, no message injection

### Make plugin CLI bridging session-scoped instead of registration-scoped
- Add a general session-scoped extension item bridge for tools and commands
- Resolve bridged tools and bridged extension commands against the **current session's loaded extension instance** at execute time
- Inject a narrow execution-scoped `sessionRuntime` capability for current-session side effects such as:
  - `sendUserMessage(...)`
  - `sendMessage(...)`
- Keep the bridge capability-based instead of exposing raw `pi`
- Refactor Kanban workflow actions to use runtime capabilities instead of captured extension objects

### Coalesce runtime-settings reloads for active sessions
- Watch the active profile's `settings.json`
- On change, reload runtime settings and reload all active session resources
- Coalesce duplicate notifications from both the direct IPC write path and the file watcher into a single reload pass
- If another settings change arrives during a reload, queue one more pass before settling
- This refreshes tools, commands, prompts, skills, and bridged CLI availability for installed/updated plugins without a manual restart

### Move the shared runtime contract into `@sero/common`
- Add `packages/common/src/session-runtime.ts`
- Re-export it from `packages/common/src/index.ts`
- Update desktop CLI runtime typing and Kanban to use the same shared `ExtensionSessionRuntime` contract
- Keep a local `KanbanSessionRuntime` alias for readability while removing the duplicate shape

### Update docs to match the new model
- `docs/apps-tutorial.md`
- `docs/plugins-guide.md`
- `docs/plugins-technical.md`
- `docs/decisions.md`
- `docs/memory.md`
- `AGENTS.md`

The docs now describe:
- built-in plugins under `plugins/sero-*-plugin/`
- manifest-driven plugin bridging via `sero.plugin.bridgeTools`
- current-session execution semantics for bridged tools/commands
- when built-in plugin restarts are still needed vs when installed plugins hot-refresh automatically
- how to add/update shared renderer-safe contracts in `@sero/common`
- when to keep state/types app-local in `shared/` vs promote neutral contracts into `packages/common/src/`

## Impact

- Lower prompt/tool overhead without losing plugin capabilities
- `auto_retrieve=off` now means **zero automatic retrieval work**
- No custom one-off exception model is needed for Kanban or similar plugins
- Built-in and external plugins now benefit from the same session-correct bridge architecture
- Installed plugins become available to active sessions after settings reload instead of waiting for a fresh session
- Duplicate settings-write + watcher notifications no longer trigger redundant resource reloads
- Shared session-runtime types now have a single source of truth in `@sero/common`
- The plugin/app docs now reflect the current architecture and shared-type workflow

## Tests

Validated with:

- `pnpm --filter @sero/desktop test` → **85 files / 514 tests passed**
- `pnpm --filter @sero-ai/plugin-kanban test` → **3 files / 6 tests passed**
- `pnpm typecheck` → **14 packages passed**

New/updated coverage includes:

- `electron/__tests__/plugins/memory-search-gating.test.ts`
- `electron/__tests__/plugins/memory-context-injector-auto-retrieve.test.ts`
- `electron/__tests__/cli/tool-bridge-policy.test.ts`
- `electron/__tests__/features/plugins/plugin-cli-bridge.test.ts`
- `electron/__tests__/cli/session-runtime-bridge.test.ts`
- `electron/__tests__/cli/extension-session-bridge.test.ts`
- `electron/__tests__/ipc/app-state-settings-reload.test.ts`
- `plugins/sero-kanban-plugin/extension/__tests__/workflow-actions.test.ts`

## Analysis

Full analysis document: `docs/analysis/context-bloat-reduction.md`
