### PR TITLE
feat: improve onboarding setup and welcome flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,9 @@ test-results/
 playwright-report/
 .playwright-cli/
 .sero-test-data/
+
+# Local agent scratch data
+.superpowers/
+
 apps/desktop/release/
 apps/desktop/sero-desktop-*.tgz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,105 +19,66 @@ sero/
 └── package.json          # Root — workspace scripts
 ```
 
-## Quick Start
+## Quick Start & Commands
 
 ```bash
 cd apps/desktop
-bash scripts/dev.sh                # Start host + Electron (set SERO_DEV_PLUGINS for remote dev servers)
+bash scripts/dev.sh                # Start host + Electron (set SERO_DEV_PLUGINS for selective remote plugins)
 pkill -f "vite"; pkill -f "electron"  # Kill
 ```
 
-## Monorepo Commands
-
+**Monorepo (root):**
 ```bash
-pnpm install               # Install all workspace deps
-pnpm dev                   # Dev the desktop app (alias)
-pnpm build                 # Build all (turbo)
-pnpm typecheck             # Typecheck all (turbo)
+pnpm install
+pnpm dev                   # Desktop app
+pnpm build                 # turbo build all
+pnpm typecheck             # turbo typecheck all
 ```
+
+**Typecheck (CRITICAL)**: Run `pnpm typecheck` from the monorepo root **before every commit**. All packages (renderer + electron main process via `tsconfig.electron.json`) must pass with zero errors. Never commit with `@ts-ignore`, `@ts-expect-error`, or `any` casts unless unavoidable (leave explanatory comment).
 
 ## Shared Packages & Plugins
 
-- **`@sero-ai/app-runtime`** — React hooks (`useAppState`, `useAppInfo`, `useAgentPrompt`) + `AppProvider` context for federated plugin modules
-- **`@sero/common`** — shared renderer-safe types/utilities for code that should be reused across the desktop app, web/remotes, and plugins. Prefer moving neutral cross-package code here instead of duplicating it, as long as it does not depend on Electron, Node-only APIs, or desktop-only internals. When adding a new shared contract, put it under `packages/common/src/`, re-export it from `packages/common/src/index.ts`, and consume it via `import type { ... } from '@sero/common'` from apps/plugins that need it.
+- **`@sero-ai/app-runtime`** — React hooks (`useAppState`, `useAppInfo`, `useAgentPrompt`) + `AppProvider` for federated plugin modules
+- **`@sero/common`** — shared renderer-safe types/utilities. Prefer moving neutral cross-package code here (no Electron/Node-only dependencies).
 
-Find all the Sero Plugins in: `plugins/sero-*-plugin`;
-The most comprehensive examples are:
-- `plugins/sero-kanban-plugin` - Deep integration with subagents
-- `plugins/sero-cron-plugin` - Background jobs and reminders
-- `plugins/sero-admin-plugin` - Config editor, log viewer, and session browser
-- `plugins/sero-memory-plugin` - Persistent memory system and daily logs
+Plugins live in `plugins/sero-*-plugin/`. Most complete examples:
+- `sero-kanban-plugin` — deep subagent integration
+- `sero-cron-plugin` — background jobs & reminders
+- `sero-admin-plugin` — config editor, log viewer, session browser
+- `sero-memory-plugin` — persistent memory system & daily logs
 
-## Documentation (read when needed)
+## Documentation
 
 - [docs/sero.md](docs/sero.md) — vision, platform constraints, Pi SDK philosophy
 - [docs/architecture.md](docs/architecture.md) — shell layout, component hierarchy
-- [docs/decisions.md](docs/decisions.md) — numbered architecture decisions with rationale
-- [docs/features/memory.md](docs/features/memory.md) — memory system architecture, tools, context injection, proactive logging
-- [docs/reference/state-and-folders.md](docs/reference/state-and-folders.md) — config/state locations and rationale
-- [docs/node-pty-setup.md](docs/node-pty-setup.md) — node-pty native module rebuild guide (MUST READ if terminals fail)
-- [docs/themes/README.md](docs/themes/README.md) — theming and style guide
-- [docs/plugins/guide.md](docs/plugins/guide.md) — creating, distributing, and installing Sero plugins
-- [docs/plugins/technical.md](docs/plugins/technical.md) — plugin system internals (architecture, IPC, file layout)
-
-## Typecheck Before Commit (CRITICAL)
-
-**You MUST run `pnpm typecheck` from the monorepo root before committing any code.** This runs `turbo run typecheck` across all packages (renderer, electron main process, and every app/extension).
-
-- **All packages must pass with zero errors.** Do not commit code that introduces type errors.
-- **Do not ignore, suppress, or work around failures** with `@ts-ignore`, `@ts-expect-error`, or `any` casts unless there is no other viable fix — and even then, leave a comment explaining why.
-- **If typecheck fails, fix the errors before committing.** Do not defer fixes to a follow-up commit.
-- **The desktop app runs two tsconfigs:** `tsc --noEmit` (renderer/src) and `tsc -p tsconfig.electron.json --noEmit` (electron main process). Both must pass.
-
----
+- [docs/decisions.md](docs/decisions.md) — numbered architecture decisions (see AD-018, AD-020)
+- [docs/features/memory.md](docs/features/memory.md) — memory system, tools, context injection
+- [docs/reference/state-and-folders.md](docs/reference/state-and-folders.md) — config/state locations
+- [docs/node-pty-setup.md](docs/node-pty-setup.md) — node-pty rebuild guide (MUST READ if terminals fail)
+- [docs/themes/README.md](docs/themes/README.md) — theming & style guide
+- [docs/plugins/guide.md](docs/plugins/guide.md) — creating, distributing, installing plugins
+- [docs/plugins/technical.md](docs/plugins/technical.md) — plugin system internals
 
 ## File Size Rules (CRITICAL)
 
-1. **NEVER let a source file exceed 500 lines of code.** If a source file you are creating or editing grows beyond 500 LOC, you **MUST** refactor it immediately — split the code into smaller modules grouped by related functionality. - This doesn't apply to documentation.
-Don't just trim blank lines to get under 500 LOC, extract code into separate files proactively.
-2. **Before finishing any task**, check the line count of every source file you touched. If any exceed 500 LOC, refactor before marking the task complete.
-3. **Preferred split strategies:** extract helper functions into `utils/` or `lib/` files, break large components into sub-components, move types/interfaces into dedicated `types.ts` files, and separate business logic from UI rendering.
-
----
+**Never exceed 500 LOC in any source file** (docs excluded). If a file grows beyond 500 lines, **refactor immediately** — split into smaller modules, extract helpers to `utils/` or `lib/`, break components into sub-components, or move types to dedicated `types.ts` files. Always check line count of every touched file before marking a task complete.
 
 ## Desktop App (`apps/desktop/`)
 
-macOS Electron desktop app — an agent-first workspace where coding, chat, and
-tools live in one window. React 19 + Tailwind 4 + shadcn/ui + Zustand.
+macOS Electron app — React 19 + Tailwind 4 + shadcn/ui + Zustand. Agent-first workspace.
 
-### Build & Run
-
+**Build & Run** (from `apps/desktop/`):
 ```bash
-cd apps/desktop                    # All commands run from here
-node scripts/build-electron.mjs   # Build Electron main + preload
-bash scripts/dev.sh                # Start host + Electron (set SERO_DEV_PLUGINS for remote dev servers)
-pkill -f "vite"; pkill -f "electron"  # Kill
+node scripts/build-electron.mjs
+bash scripts/dev.sh
 ```
 
 Logs: `/tmp/sero-vite.log`, `/tmp/sero-remote-<app-id>.log`, `/tmp/sero-electron.log`
 
-### Selective Dev Mode
+**Selective Dev**: `SERO_DEV_PLUGINS=admin,kanban bash scripts/dev.sh` (rebuild skipped plugins first with `pnpm build`).
 
-- `SERO_DEV_PLUGINS=admin,kanban bash scripts/dev.sh` starts dev servers only for listed plugins; by default no plugins run in dev mode and everything else loads from their built `dist/ui` bundles via `sero-ext://`.
-- When testing skipped plugins, rebuild the remotes first with `pnpm build` so their `dist/ui` assets are current.
-
-### Typecheck
-
-```bash
-cd apps/desktop && npx tsc --noEmit
-```
-
-### Development Approach
-
-Build incrementally. New components start as **named placeholders with a label**
-— get the layout and data flow right first, then fill in real functionality one
-piece at a time.
-
-### Key Architecture
-
-Shell + mountable plugins. See [docs/architecture.md](docs/architecture.md) for
-layout diagrams, component hierarchy, and state management.
-
+**Key Architecture**
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │  TitleBar (⊞ sidebar toggle … plugin name … ⌘K … ⊟ chat)   │
@@ -132,245 +93,56 @@ layout diagrams, component hierarchy, and state management.
 ```
 
 - **MainSidebar** (left, collapsible) — plugin list + chat sessions
-- **ChatPanel** (right, collapsible + resizable) — global agent, persists across the workspace
-- **Active Plugin** — currently CodingWorkspace; others are placeholders
+- **ChatPanel** (right, collapsible + resizable) — global agent
+- **Active Plugin** — currently CodingWorkspace (others are placeholders)
 
-### Agent Directory (IMPORTANT)
+**Agent Directory (IMPORTANT)**  
+Sero uses **`~/.sero-ui/agent/`** (set via `PI_CODING_AGENT_DIR` in `electron/env.ts`). Never use `~/.pi/agent/`. Single source of truth: `electron/env.ts` exports `SERO_HOME` and `SERO_AGENT_DIR`.
 
-Sero uses **`~/.sero-ui/agent/`** as its agent directory, **not** `~/.pi/agent/`.
-This is set via `PI_CODING_AGENT_DIR` in `electron/env.ts` before any SDK imports.
-
-- **All paths** (`auth.json`, `settings.json`, `sessions/`, `skills/`, `extensions/`, `packages/`) resolve under `~/.sero-ui/agent/`.
-- **`~/.pi/agent/`** is the Pi CLI's independent directory — Sero does not read from or write to it.
-- **Single source of truth** for paths: `electron/env.ts` exports `SERO_HOME` and `SERO_AGENT_DIR`. Import from there — never hardcode paths.
-- **Plugin packages** are registered in `~/.sero-ui/agent/settings.json` under `"packages"`.
-
-### Key Conventions
-
-- `src/components/layout/` — shell-level (TitleBar, MainSidebar, ChatPanel, StatusBar)
+**Key Conventions**
+- `src/components/layout/` — shell-level components
 - `src/components/apps/<name>/` — self-contained app components
 - `src/components/ui/` — shadcn/ui primitives
-- `src/components/ai-elements/` — Vercel ai-elements chat components (source, not node_modules)
+- `src/components/ai-elements/` — Vercel ai-elements chat components
+- Always use top-level imports (no inline `import('...')` type expressions)
 
-- **Always use top-level imports.** Never use inline `import('...')` type
-  expressions (e.g. `param: import('./types').Foo`). Add a proper
-  `import type { Foo } from './types'` at the top of the file instead. The only
-  exception is native addons that **must** use `require()` at runtime — wrap
-  those in a typed helper module (see `electron/lib/native-pty.ts`).
+**Creating a Sero Plugin (IMPORTANT)**  
+Follow the `sero-plugin` skill process exactly (package structure, shared types, Pi extension, web UI, module federation, dev workflow). Registration is automatic for any `plugins/sero-*-plugin/` containing `sero.app` in its `package.json`. Built-in plugins do not appear in Plugin Manager.
 
-### Creating a Sero Plugin (IMPORTANT)
+Production remotes must use relative `base: './'`. Tools are bridged via `pi.registerTool()` (see AD-020 in decisions.md).
 
-**When asked to create a new Sero plugin, you MUST use the `sero-plugin` skill
-process: package structure, shared state types, Pi extension, web UI, module
-federation setup, and dev workflow. Do not improvise — follow the skill
-step by step.
+**IPC Data Flow (IMPORTANT)**  
+All cross-process data must update **four layers together**:
+React component → Zustand store → preload (IPC) → main-process handler → Pi SDK
 
-**Plugin registration is fully automatic.** The host (`apps/desktop/`) auto-discovers
-all `plugins/sero-*-plugin/` directories that have a `sero.app` manifest in their
-`package.json`. No manual edits to `vite.config.ts`, `federation-registry.ts`,
-`electron/main.ts`, or `dev.sh` are needed — just create the package, run
-`pnpm install`, and restart the dev server.
+Types live in `src/types/ipc.ts`. Keep renderer and main-process types in sync.
 
-**Built-in plugins in `plugins/` behave like external plugins, but they are not installed/uninstalled and do not appear in the Plugin Manager.**
+**State Management Rules (CRITICAL)**
+- **Never use** `localStorage` or `sessionStorage`. Persistent renderer state goes through `~/.sero-ui/layout.json` via `persistLayout()` (`src/lib/persist-layout.ts`) and `window.sero.layout` IPC. Add new keys to `LayoutState` in `src/types/layout.ts`.
+- All shared state lives in Zustand stores (`src/stores/`). Cross-plugin state uses `@sero-ai/app-runtime` context or `window.sero` bridge.
+- **Avoid `useEffect`**. Prefer Zustand actions, derived state, or `subscribe()`. Use `useEffect` only for external side effects (DOM events, IPC listeners, timers, third-party imperative libs).
 
-**Built remote requirement:** Production remote bundles must use a relative Vite
-`base` (`'./'`) so `sero-ext://` can resolve chunk preloads and assets correctly.
-If the remote Vite config uses `root: 'ui'`, the package must include
-`ui/index.html` or `vite build` will fail.
+**Desktop Notifications**
+Extensions emit: `pi.events.emit('sero:notify', { message, type?, sound?, subtitle? })`
 
-**Tool bridging (AD-020):** App/extension tools are bridged into the single
-`sero-cli` tool — they do NOT appear as standalone tool schemas. Always use
-`pi.registerTool()` in extensions, never `customTools` in
-`createAgentSession()`.
+**Container Integration (AD-018)**
+One macOS container per workspace (`sero-<workspaceId>`). Lazy-started on first prompt. Tools proxied via `container exec`. Code in `electron/container/`.
 
-- Plugin packages with `sero.plugin` bridge **all tools by default**.
-- Use `sero.plugin.bridgeTools` only when you need to disable bridging or
-  bridge a selective subset.
-- Bridged tools/commands execute against the **current session's** loaded
-  extension instance, so do not rely on registration-scoped captured `pi`
-  objects for session-specific behavior inside bridged execution paths.
+**Widevine / Castlabs Electron**
+Uses castlabs fork for Spotify support. Await `components.whenReady()` in `main.ts`. Run `pnpm sign-vmp` (or `bash scripts/sign-vmp.sh`) after install.
 
-See [docs/decisions.md](docs/decisions.md) AD-020.
-
-### IPC Data Flow (IMPORTANT)
-
-All data between the UI and the agent passes through **four layers**. When adding
-or changing any feature that crosses the process boundary, **every layer must be
-updated together** or data will silently drop:
-
-```
-React component → Zustand store → preload (IPC bridge) → main-process handler → Pi SDK
-src/components/    src/stores/      electron/preload.ts  electron/ipc/          session.*()
-```
-
-Each layer has its own types and may need to transform data (e.g. the main
-process converts renderer-friendly `ChatAttachment` objects into Pi SDK
-`ImageContent` objects). If you add a parameter at one layer but forget another,
-the feature appears to work in the UI but silently fails at the agent.
-
-**Key rules:**
-
-- **Types live in `src/types/ipc.ts`** — shared by renderer and main process.
-  The renderer-side window API is typed in `src/types/electron.d.ts`. Keep both
-  in sync.
-- **User messages are optimistic.** The store appends them immediately on send;
-  the `message_start` event handler skips incoming user messages to prevent
-  duplicates.
-- **Renderer vs Electron rebuild.** Vite HMR only covers renderer code
-  (`src/`). Changes to `electron/preload.ts` or `electron/ipc/` require
-  `node scripts/build-electron.mjs` **and** an Electron restart to take effect.
-
-### State Management Rules (CRITICAL)
-
-- **NEVER use `localStorage` or `sessionStorage`** — this is an absolute ban,
-  not a guideline. All renderer state that must persist across reloads is
-  stored in the filesystem-backed layout file (`~/.sero-ui/layout.json`) via
-  the `persistLayout()` helper in `src/lib/persist-layout.ts` and the
-  `window.sero.layout.save/load` IPC bridge. There is no profile-storage
-  module — it was removed.
-  - **`sessionStorage`** is forbidden entirely. Any state that must survive
-    within a session should be tracked in a Zustand store, in a file inside
-    `SERO_HOME` via IPC, or in the profile registry (`profiles.json`).
-  - All shared state lives in Zustand stores (`src/stores/`). Cross-boundary
-    state (e.g. for federated modules in `@sero-ai/app-runtime`) is passed via
-    context providers or the `window.sero` IPC bridge.
-  - If you think you need browser storage, **ask first** — there is almost
-    always a better alternative (Zustand, IPC-backed file state, or the
-    layout file).
-
-### Avoid `useEffect` — Prefer Zustand (CRITICAL)
-
-**Do not reach for React `useEffect` as a first resort.** Most uses of
-`useEffect` in this codebase can (and should) be replaced with Zustand
-store actions, subscriptions, or derived state. `useEffect` causes
-unnecessary render cycles, hides data flow, and makes components harder
-to reason about.
-
-**Preferred alternatives:**
-
-| Instead of…                                  | Use…                                                              |
-|----------------------------------------------|-------------------------------------------------------------------|
-| `useEffect` to fetch data on mount           | Zustand async action called from an event handler or store init   |
-| `useEffect` to sync two pieces of state      | Zustand derived state / selector, or compute inline during render |
-| `useEffect` to react to prop/state changes   | Zustand `subscribe()` or `useStore` selector with equality check  |
-| `useEffect` to run cleanup on unmount        | Zustand store `destroy()` / cleanup action                        |
-| `useEffect` + `setState` (set-on-render)     | Compute the value directly — no effect needed                     |
-
-**When `useEffect` is acceptable:**
-
-- Subscribing to **external, non-React sources** (DOM events, IPC listeners,
-  `IntersectionObserver`, timers) that genuinely require setup/teardown.
-- One-shot initialisation in **leaf components** with no store equivalent
-  (e.g. a `ref`-based scroll-to-bottom).
-- Third-party library integration that requires imperative lifecycle hooks.
-
-**Refactor on encounter:** When you touch a file that contains a `useEffect`
-that could be replaced with a Zustand pattern, **refactor it as part of
-your change.** Do not leave avoidable `useEffect` calls behind in files
-you are already modifying.
-
----
-
-### Desktop Notifications (`sero:notify` EventBus)
-
-Extensions show native desktop notifications via the shared Pi SDK EventBus —
-no `require('electron')` needed.
-
-- **Extension emits:** `pi.events.emit('sero:notify', { message, type?, source?, sound?, subtitle? })`
-- **Host listens:** `electron/sero-extension.ts` → calls `showNotification()` from `electron/notifications.ts`
-- `sound` — `true` (default chime), a macOS sound name (`"Glass"`, `"Hero"`, etc.), or `false` (silent)
-- `type` — `'info'` | `'warning'` | `'error'` (default: `'info'`)
-
-### Container Integration (AD-018)
-
-Every workspace runs inside a native macOS container (Apple Containerization
-framework). See [docs/decisions.md](docs/decisions.md) AD-018 for full details.
-
-**Key points:**
-
-- **One container per workspace** — `sero-<workspaceId>`, shared by all sessions
-- **Lazy start** — containers spin up on first agent prompt, not on workspace open
-- **Host orchestration** — Pi SDK `AgentSession` runs on Electron host; tool
-  execution (bash, read, write, edit, ls, read_terminal) is proxied into the
-  container via `container exec`
-- **Bind mount** — workspace files mounted `<host path>` → `/workspace`
-- **SSH forwarding** — `--ssh` on `container run` for git with private repos
-- **Container code** lives in `electron/container/` — types, lifecycle, files,
-  terminal, image, tools, system-prompt, file-watcher
-- **Ghost containers** — NEVER delete container storage directories directly.
-  NEVER restart the API server in normal operation.
-- **Container CLI** is at `/usr/local/bin/container` (v0.8.0+)
-
-### Widevine DRM / Castlabs Electron
-
-Sero uses the [castlabs Electron fork](https://github.com/castlabs/electron-releases)
-instead of stock Electron. This is a drop-in replacement that adds Widevine CDM
-support (required by the Spotify Web Playback SDK for audio decryption).
-
-- **`components.whenReady()`** must be awaited before `createWindow()` in
-  `electron/main.ts` — this triggers CDM download on first launch.
-- **VMP signing** is required on macOS. Without a production VMP signature,
-  Spotify's Widevine license server returns 500. Run `pnpm sign-vmp` (or
-  `bash scripts/sign-vmp.sh`) from `apps/desktop/`. Re-run after `pnpm install`.
-- **User-Agent** — `session.defaultSession.setUserAgent()` strips "Electron"
-  from the UA; some DRM services reject Electron UAs.
-- **Release packaging** uses the locally installed castlabs Electron dist and
-  stages built-in plugin packages/templates into `dist/electron/builtin/`, so
-  packaged builds do not depend on the monorepo `packages/` directory at runtime.
-
-### node-pty Native Module (CRITICAL)
-
-Interactive terminals use `node-pty` to spawn `container exec -it` sessions.
-**node-pty requires a native binary compiled for the exact Node ABI version.**
-
-The prebuilt binaries shipped with node-pty frequently do NOT match. If
-terminals fail with `posix_spawnp failed`, **you must rebuild from source:**
-
+**node-pty Native Module (CRITICAL)**
+Rebuild if terminals fail:
 ```bash
-cd /path/to/sero/sero   # monorepo root
 npx node-gyp rebuild --directory=node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty
 ```
+See [docs/node-pty-setup.md](docs/node-pty-setup.md).
 
-**Rebuild is needed after:** changing Node version, running `pnpm install`
-(may restore prebuilds), or switching machines.
-
-See [docs/node-pty-setup.md](docs/node-pty-setup.md) for full troubleshooting.
-
-### Banned Patterns (CRITICAL)
-
-These patterns are **absolutely forbidden** without explicit approval from the
-project owner. Do not introduce them under any circumstances.
-
-1. **No `localStorage` or `sessionStorage`.** All persistent renderer state
-   must go through the filesystem-backed layout file via `persistLayout()`
-   from `src/lib/persist-layout.ts` and `window.sero.layout.save/load`. The
-   old `profile-storage.ts` module has been removed. If you need a new
-   persisted key, add it to the `LayoutState` interface in
-   `src/types/layout.ts` — that is the single source of truth used by the
-   renderer, electron main process, and IPC bridge types.
-
-2. **No inline `import('...')` type expressions.** Never write
-   `param: import('./types').Foo` or `type X = import('./module').Bar`.
-   Always use a proper `import type { Foo } from './types'` at the top of the
-   file. The only exception is native addons that **must** use `require()` at
-   runtime — wrap those in a typed helper module.
-
-3. **No unnecessary dynamic `await import('...')`** for source-file modules.
-   Use standard top-level imports. Dynamic imports are only acceptable for
-   truly optional runtime dependencies (e.g. native addons that may not be
-   installed) — not for lazy-loading local source modules.
-
-### General
-- When creating documentation or plans, save them in @docs/ or a subfolder by type
-- When asked to create a PR, use the Github CLI
-- Use Conventional Commit-style messages for all git commits and PR titles
-- When reviewing a PR, always make sure there's good type safety
+**General**
+- Save new documentation/plans in `@docs/` or typed subfolders
+- Use Conventional Commit messages
+- Ensure good type safety in source files when conducting PR reviews
+- Do not delete relevant comments
+- Prefer `useDebouncedCallback` / `createDebouncedFn` from `src/hooks/useDebouncedCallback.ts` over hand-rolled `setTimeout` debounce patterns
+- Preview `.html` files in the in-app editor (sandboxed iframe)
 - Don't use the 'visual explainer' skill when reviewing a PR unless asked
-- Don't delete comments unless they are obvious or no longer relevant - they offer important context unfamiliar users
-- **Prefer `useDebouncedCallback` / `createDebouncedFn`** from `src/hooks/useDebouncedCallback.ts` over hand-rolled `setTimeout` debounce patterns. When you encounter an existing hand-rolled debounce, refactor it to use these helpers.
-- **HTML files can be previewed in-app.** The editor supports rendering
-  `.html` and `.htm` files in a sandboxed iframe preview (same code/preview
-  toggle as markdown). When you generate or reference an HTML file, open it
-  in the Sero editor rather than suggesting the user open it in an external
-  browser. The preview handles self-contained HTML (inline CSS/JS, data:
-  images) — relative asset paths won't resolve.

--- a/apps/desktop/electron/__tests__/features/onboarding/recommendations.test.ts
+++ b/apps/desktop/electron/__tests__/features/onboarding/recommendations.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  AvailableModelGroup,
+  ProviderHealthInfo,
+  ResolvedProviderDefaultsState,
+} from '../../../../src/types/ipc';
+import { buildOnboardingRecommendation } from '../../../features/onboarding/recommendations';
+
+function makeProviderHealth(providerId: string): ProviderHealthInfo {
+  return {
+    providerId,
+    displayName: providerId,
+    status: 'healthy',
+    canReconnect: false,
+    hasUsableModels: true,
+    usableModelIds: [],
+  };
+}
+
+const availableModelGroups: AvailableModelGroup[] = [
+  {
+    provider: 'openai',
+    displayName: 'OpenAI',
+    logo: 'openai.svg',
+    models: [
+      { provider: 'openai', modelId: 'gpt-4.1-mini', name: 'GPT-4.1 Mini', reasoning: false },
+      { provider: 'openai', modelId: 'gpt-5.4', name: 'GPT-5.4', reasoning: true },
+    ],
+  },
+  {
+    provider: 'google',
+    displayName: 'Google',
+    logo: 'google.svg',
+    models: [
+      { provider: 'google', modelId: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', reasoning: false },
+      { provider: 'google', modelId: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', reasoning: true },
+    ],
+  },
+];
+
+const providerDefaults: ResolvedProviderDefaultsState = {
+  builtInDefaults: {},
+  globalDefaults: {
+    openai: { LOW: 'gpt-4.1-mini', MED: 'gpt-5.4', HIGH: 'gpt-5.4' },
+    google: { LOW: 'gemini-2.5-flash', MED: 'gemini-2.5-pro', HIGH: 'gemini-2.5-pro' },
+  },
+  effectiveDefaults: {
+    openai: { LOW: 'gpt-4.1-mini', MED: 'gpt-5.4', HIGH: 'gpt-5.4' },
+    google: { LOW: 'gemini-2.5-flash', MED: 'gemini-2.5-pro', HIGH: 'gemini-2.5-pro' },
+  },
+};
+
+describe('buildOnboardingRecommendation', () => {
+  it('preserves valid tiers and repairs invalid tiers within the preferred provider', () => {
+    const result = buildOnboardingRecommendation({
+      availableModelGroups,
+      currentTiers: {
+        LOW: { provider: 'openai', modelId: 'gpt-4.1-mini' },
+        MED: { provider: 'openai', modelId: 'missing-model' },
+      },
+      providerHealth: [makeProviderHealth('openai'), makeProviderHealth('google')],
+      providerDefaults,
+      legacyDefaultProvider: null,
+    });
+
+    expect(result.invalidTiers).toEqual(['MED']);
+    expect(result.recommendation?.preferredProvider).toBe('openai');
+    expect(result.recommendation?.tiers).toEqual({
+      LOW: { provider: 'openai', modelId: 'gpt-4.1-mini' },
+      MED: { provider: 'openai', modelId: 'gpt-5.4' },
+      HIGH: { provider: 'openai', modelId: 'gpt-5.4' },
+    });
+    expect(result.recommendation?.sourcesByTier).toEqual({
+      LOW: 'preserved',
+      MED: 'provider-defaults',
+      HIGH: 'provider-defaults',
+    });
+  });
+
+  it('chooses a cohesive provider recommendation when no tiers are saved yet', () => {
+    const result = buildOnboardingRecommendation({
+      availableModelGroups,
+      currentTiers: {},
+      providerHealth: [makeProviderHealth('openai'), makeProviderHealth('google')],
+      providerDefaults,
+      legacyDefaultProvider: 'openai',
+    });
+
+    expect(result.invalidTiers).toEqual([]);
+    expect(result.recommendation?.preferredProvider).toBe('openai');
+    expect(result.recommendation?.tiers).toEqual({
+      LOW: { provider: 'openai', modelId: 'gpt-4.1-mini' },
+      MED: { provider: 'openai', modelId: 'gpt-5.4' },
+      HIGH: { provider: 'openai', modelId: 'gpt-5.4' },
+    });
+  });
+
+  it('uses the preserved provider as the recommendation anchor even when another provider has defaults', () => {
+    const result = buildOnboardingRecommendation({
+      availableModelGroups,
+      currentTiers: {
+        HIGH: { provider: 'google', modelId: 'gemini-2.5-pro' },
+      },
+      providerHealth: [makeProviderHealth('openai'), makeProviderHealth('google')],
+      providerDefaults,
+      legacyDefaultProvider: 'openai',
+    });
+
+    expect(result.recommendation?.preferredProvider).toBe('google');
+    expect(result.recommendation?.tiers).toEqual({
+      LOW: { provider: 'google', modelId: 'gemini-2.5-flash' },
+      MED: { provider: 'google', modelId: 'gemini-2.5-pro' },
+      HIGH: { provider: 'google', modelId: 'gemini-2.5-pro' },
+    });
+    expect(result.recommendation?.sourcesByTier?.HIGH).toBe('preserved');
+  });
+});

--- a/apps/desktop/electron/__tests__/features/subagent/resolve.test.ts
+++ b/apps/desktop/electron/__tests__/features/subagent/resolve.test.ts
@@ -12,6 +12,7 @@ describe('resolveConfig', () => {
     );
 
     expect(result.model).toBe('task-model');
+    expect(result.modelSelection).toBe('task-model');
     expect(result.thinking).toBe('low');
     expect(result.timeoutMs).toBe(1000);
   });
@@ -25,8 +26,22 @@ describe('resolveConfig', () => {
     );
 
     expect(result.model).toBe('call-model');
+    expect(result.modelSelection).toBe('call-model');
     expect(result.thinking).toBe('high');
     expect(result.timeoutMs).toBe(2000);
+  });
+
+  it('call override beats structured agent frontmatter', () => {
+    const result = resolveConfig(
+      undefined,
+      { model: 'HIGH' },
+      { model: { prefer: 'MED', fallbacks: ['gpt-5.4'] } },
+      undefined,
+      undefined,
+    );
+
+    expect(result.model).toBe('HIGH');
+    expect(result.modelSelection).toBe('HIGH');
   });
 
   it('agent frontmatter wins over global settings', () => {
@@ -38,8 +53,24 @@ describe('resolveConfig', () => {
     );
 
     expect(result.model).toBe('agent-model');
+    expect(result.modelSelection).toBe('agent-model');
     expect(result.thinking).toBe('medium');
     expect(result.timeoutMs).toBe(3000);
+  });
+
+  it('preserves structured agent frontmatter when it wins', () => {
+    const result = resolveConfig(
+      undefined,
+      undefined,
+      { model: { prefer: 'MED', fallbacks: ['gpt-5.4', 'claude-sonnet-4-6'] } },
+      { model: 'settings-model', thinking: 'off', timeoutMs: 4000, toolStallTimeoutMs: 120_000 },
+    );
+
+    expect(result.model).toBe('MED');
+    expect(result.modelSelection).toEqual({
+      prefer: 'MED',
+      fallbacks: ['gpt-5.4', 'claude-sonnet-4-6'],
+    });
   });
 
   it('global settings win over session defaults', () => {
@@ -52,6 +83,7 @@ describe('resolveConfig', () => {
     );
 
     expect(result.model).toBe('settings-model');
+    expect(result.modelSelection).toBe('settings-model');
     expect(result.thinking).toBe('off');
     expect(result.timeoutMs).toBe(4000);
   });
@@ -66,6 +98,7 @@ describe('resolveConfig', () => {
     );
 
     expect(result.model).toBe('agent-model'); // Skips undefined call override
+    expect(result.modelSelection).toBe('agent-model');
     expect(result.thinking).toBe('xhigh'); // From call override
   });
 
@@ -78,7 +111,8 @@ describe('resolveConfig', () => {
       undefined,
     );
 
-    expect(result.model).toBe('claude-sonnet-4-6');
+    expect(result.model).toBe('MED');
+    expect(result.modelSelection).toBe('MED');
     expect(result.thinking).toBe('high');
     expect(result.timeoutMs).toBe(600_000);
   });
@@ -93,6 +127,7 @@ describe('resolveConfig', () => {
     );
 
     expect(result.model).toBe('session-model'); // Skips null settings model
+    expect(result.modelSelection).toBe('session-model');
     expect(result.timeoutMs).toBe(300_000);
   });
 });

--- a/apps/desktop/electron/features/agent/assistants/adhoc-agent.ts
+++ b/apps/desktop/electron/features/agent/assistants/adhoc-agent.ts
@@ -1,17 +1,19 @@
-import { createAgentSession, SessionManager } from '@mariozechner/pi-coding-agent';
+import { createAgentSession, SettingsManager, SessionManager } from '@mariozechner/pi-coding-agent';
 import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
 import type { Api, Model } from '@mariozechner/pi-ai';
 
 import { SERO_AGENT_DIR } from '../../../platform/env';
 import { ensureInfra } from '../../../shared/infra/shared-infra';
+import { getModelTiers } from '../../../shared/settings/model-tiers';
 
+/** Provider-neutral fast model preferences, ordered by speed/cost. */
 const FAST_MODEL_PREFERENCES: Array<{ provider: string; modelId: string }> = [
-  { provider: 'anthropic', modelId: 'claude-haiku-4-5' },
-  { provider: 'anthropic', modelId: 'claude-3-5-haiku-latest' },
   { provider: 'openai', modelId: 'gpt-4.1-mini' },
   { provider: 'openai', modelId: 'gpt-4o-mini' },
   { provider: 'google', modelId: 'gemini-2.5-flash' },
   { provider: 'google', modelId: 'gemini-2.0-flash' },
+  { provider: 'anthropic', modelId: 'claude-haiku-4-5' },
+  { provider: 'anthropic', modelId: 'claude-3-5-haiku-latest' },
 ];
 
 interface SelectedModel {
@@ -33,7 +35,12 @@ export async function runAdhocAgent(
   thinkingLevel: ThinkingLevel = 'low',
 ): Promise<AdhocAgentResult> {
   const infra = await ensureInfra();
-  const selectedModel = selectFastModel(infra.modelRegistry.getAvailable(), infra.model);
+  const available = infra.modelRegistry.getAvailable();
+  const selectedModel = selectFastModel(
+    available,
+    infra.settingsManager,
+    infra.model,
+  );
 
   const { session } = await createAgentSession({
     cwd: workspacePath,
@@ -74,8 +81,22 @@ export async function runAdhocAgent(
 
 function selectFastModel(
   available: Model<Api>[],
-  fallback: Model<Api>,
+  settingsManager: ReturnType<typeof SettingsManager.create>,
+  fallback: Model<Api> | null,
 ): SelectedModel {
+  // 1. Try user's LOW tier model
+  const globalSettings = settingsManager.getGlobalSettings() as Record<string, unknown>;
+  const tiers = getModelTiers(globalSettings);
+  if (tiers.LOW) {
+    const match = available.find(
+      (m) => m.provider === tiers.LOW!.provider && m.id === tiers.LOW!.modelId,
+    );
+    if (match) {
+      return { model: match, provider: match.provider, modelId: match.id };
+    }
+  }
+
+  // 2. Walk provider-neutral preference list
   for (const pref of FAST_MODEL_PREFERENCES) {
     const model = available.find((m) => m.provider === pref.provider && m.id === pref.modelId);
     if (model) {
@@ -83,6 +104,7 @@ function selectFastModel(
     }
   }
 
+  // 3. First available model
   if (available[0]) {
     return {
       model: available[0],
@@ -91,10 +113,14 @@ function selectFastModel(
     };
   }
 
-  return {
-    model: fallback,
-    provider: fallback.provider,
-    modelId: fallback.id,
-  };
-}
+  // 4. Absolute fallback (shared infra model, may be null)
+  if (fallback) {
+    return {
+      model: fallback,
+      provider: fallback.provider,
+      modelId: fallback.id,
+    };
+  }
 
+  throw new Error('No models available — please authenticate with a model provider.');
+}

--- a/apps/desktop/electron/features/onboarding/index.ts
+++ b/apps/desktop/electron/features/onboarding/index.ts
@@ -1,0 +1,21 @@
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import type { ModelTierSettings } from '../../../src/types/ipc';
+import { SERO_AGENT_DIR } from '../../platform/env';
+import { getOnboardingState } from './preflight';
+import { setModelTiers } from '../../shared/settings/model-tiers';
+
+export { getOnboardingState } from './preflight';
+
+export async function saveOnboardingTierSelections(tiers: ModelTierSettings): Promise<void> {
+  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+  let settings: Record<string, unknown> = {};
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    settings = {};
+  }
+
+  const nextSettings = setModelTiers(settings, tiers);
+  writeFileSync(settingsPath, JSON.stringify(nextSettings, null, 2) + '\n', 'utf8');
+}

--- a/apps/desktop/electron/features/onboarding/preflight.ts
+++ b/apps/desktop/electron/features/onboarding/preflight.ts
@@ -1,0 +1,138 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import type { ModelTier, OnboardingState, OnboardingWarning } from '../../../src/types/ipc';
+import { SERO_AGENT_DIR } from '../../platform/env';
+import { profileManager } from '../profile/manager';
+import { getModelTiers } from '../../shared/settings/model-tiers';
+import { resolveProviderDefaultsState } from '../../shared/settings/provider-model-defaults';
+import { buildOnboardingRecommendation, validateCurrentTiers } from './recommendations';
+import { getProviderHealthSnapshot } from './provider-health';
+import { emptyOnboardingState } from './types';
+
+function readSettings(): Record<string, unknown> {
+  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+  try {
+    return JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function readLegacyDefaultProvider(settings: Record<string, unknown>): string | null {
+  const sero = settings.sero;
+  if (!sero || typeof sero !== 'object' || Array.isArray(sero)) return null;
+  const value = (sero as Record<string, unknown>).defaultProvider;
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function hasSavedAuthJson(): boolean {
+  const authPath = path.join(SERO_AGENT_DIR, 'auth.json');
+  try {
+    if (!existsSync(authPath)) return false;
+    const content = readFileSync(authPath, 'utf8').trim();
+    return content.length > 2 && content !== '{}';
+  } catch {
+    return false;
+  }
+}
+
+function formatTierLabel(tier: ModelTier): string {
+  if (tier === 'LOW') return 'Low';
+  if (tier === 'MED') return 'Medium';
+  return 'High';
+}
+
+function formatProviderNames(providerIds: string[], providerHealth: OnboardingState['providerHealth']): string {
+  const byId = new Map(providerHealth.map((provider) => [provider.providerId, provider.displayName]));
+  return providerIds
+    .map((providerId) => byId.get(providerId) ?? providerId)
+    .sort((a, b) => a.localeCompare(b))
+    .join(', ');
+}
+
+function buildWarnings(args: {
+  hasAnyUsableModels: boolean;
+  invalidTiers: ModelTier[];
+  brokenProviderIds: string[];
+  providerHealth: OnboardingState['providerHealth'];
+}): OnboardingWarning[] {
+  const warnings: OnboardingWarning[] = [];
+  const { hasAnyUsableModels, invalidTiers, brokenProviderIds, providerHealth } = args;
+
+  if (invalidTiers.length > 0) {
+    warnings.push({
+      code: 'invalid_existing_tiers',
+      message: `We repaired unavailable saved model selections for ${invalidTiers.map(formatTierLabel).join(', ')}.`,
+    });
+  }
+
+  if (brokenProviderIds.length > 0 && hasAnyUsableModels) {
+    warnings.push({
+      code: 'broken_imported_providers',
+      message: `Some saved providers need attention: ${formatProviderNames(brokenProviderIds, providerHealth)}.`,
+      providerIds: brokenProviderIds,
+    });
+  }
+
+  if (!hasAnyUsableModels) {
+    warnings.push({
+      code: 'no_usable_models',
+      message: brokenProviderIds.length > 0
+        ? `Reconnect ${formatProviderNames(brokenProviderIds, providerHealth)} or add another provider to continue.`
+        : 'Connect at least one provider to continue.',
+      providerIds: brokenProviderIds.length > 0 ? brokenProviderIds : undefined,
+    });
+  }
+
+  return warnings;
+}
+
+export async function getOnboardingState(): Promise<OnboardingState> {
+  const activeProfile = profileManager.getActive();
+  if (!activeProfile) {
+    return emptyOnboardingState();
+  }
+
+  if (!activeProfile.onboarded) {
+    const settings = readSettings();
+    const currentTiers = getModelTiers(settings);
+    const providerDefaults = resolveProviderDefaultsState(settings);
+    const { availableModelGroups, providerHealth } = await getProviderHealthSnapshot();
+    const hasAnyUsableModels = availableModelGroups.some((group) => group.models.length > 0);
+    const brokenProviderIds = providerHealth
+      .filter((provider) => provider.status === 'broken_expired' || provider.status === 'broken_invalid')
+      .map((provider) => provider.providerId);
+
+    const { recommendation, invalidTiers } = hasAnyUsableModels
+      ? buildOnboardingRecommendation({
+        availableModelGroups,
+        currentTiers,
+        providerHealth,
+        providerDefaults,
+        legacyDefaultProvider: readLegacyDefaultProvider(settings),
+      })
+      : {
+        recommendation: null,
+        invalidTiers: validateCurrentTiers(availableModelGroups, currentTiers).invalidTiers,
+      };
+
+    return {
+      needed: true,
+      phase: hasAnyUsableModels ? 'ready' : 'auth',
+      hasAnyUsableModels,
+      hasImportedCredentials: hasSavedAuthJson(),
+      recommendation,
+      providerHealth,
+      availableModelGroups,
+      warnings: buildWarnings({
+        hasAnyUsableModels,
+        invalidTiers,
+        brokenProviderIds,
+        providerHealth,
+      }),
+      invalidTiers,
+    };
+  }
+
+  return emptyOnboardingState();
+}

--- a/apps/desktop/electron/features/onboarding/preflight.ts
+++ b/apps/desktop/electron/features/onboarding/preflight.ts
@@ -5,18 +5,10 @@ import { SERO_AGENT_DIR } from '../../platform/env';
 import { profileManager } from '../profile/manager';
 import { getModelTiers } from '../../shared/settings/model-tiers';
 import { resolveProviderDefaultsState } from '../../shared/settings/provider-model-defaults';
+import { readSettings } from '../../shared/settings/settings-helpers';
 import { buildOnboardingRecommendation, validateCurrentTiers } from './recommendations';
 import { getProviderHealthSnapshot } from './provider-health';
 import { emptyOnboardingState } from './types';
-
-function readSettings(): Record<string, unknown> {
-  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
-  try {
-    return JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
 
 function readLegacyDefaultProvider(settings: Record<string, unknown>): string | null {
   const sero = settings.sero;

--- a/apps/desktop/electron/features/onboarding/provider-health.ts
+++ b/apps/desktop/electron/features/onboarding/provider-health.ts
@@ -1,0 +1,189 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+import { getEnvApiKey } from '@mariozechner/pi-ai';
+import type { AvailableModelGroup, ProviderHealthInfo, ProviderHealthStatus } from '../../../src/types/ipc';
+import type { LocalModelsConfig } from '../../../src/types/local-models';
+import { SERO_AGENT_DIR } from '../../platform/env';
+import { ensureInfra } from '../../shared/infra/shared-infra';
+import { API_KEY_PROVIDERS, getOAuthProviderCatalog } from '../../shared/auth/provider-catalog';
+import { providerDisplayName, providerLogo } from '../../ipc/platform/auth';
+
+export interface ProviderHealthSnapshot {
+  availableModelGroups: AvailableModelGroup[];
+  providerHealth: ProviderHealthInfo[];
+}
+
+function buildAvailableModelGroups(
+  infra: Awaited<ReturnType<typeof ensureInfra>>,
+): AvailableModelGroup[] {
+  const { modelRegistry } = infra;
+  modelRegistry.authStorage.reload();
+  const available = modelRegistry.getAvailable();
+
+  const grouped = new Map<string, typeof available>();
+  for (const model of available) {
+    const models = grouped.get(model.provider) ?? [];
+    models.push(model);
+    grouped.set(model.provider, models);
+  }
+
+  return [...grouped.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([provider, models]) => ({
+      provider,
+      displayName: providerDisplayName(provider),
+      logo: providerLogo(provider),
+      models: models
+        .map((model) => ({
+          provider: model.provider,
+          modelId: model.id,
+          name: model.name,
+          reasoning: model.reasoning,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name) || a.modelId.localeCompare(b.modelId)),
+    }));
+}
+
+function readConfiguredLocalProviderIds(): string[] {
+  const modelsPath = path.join(SERO_AGENT_DIR, 'models.json');
+  try {
+    if (!existsSync(modelsPath)) return [];
+    const raw = JSON.parse(readFileSync(modelsPath, 'utf8')) as LocalModelsConfig;
+    const providers = raw?.providers && typeof raw.providers === 'object'
+      ? Object.keys(raw.providers)
+      : [];
+    return providers.sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
+function buildMessage(status: ProviderHealthStatus, hasUsableModels: boolean): string {
+  switch (status) {
+    case 'healthy':
+      return hasUsableModels ? 'Ready to use.' : 'No usable models detected yet.';
+    case 'broken_expired':
+      return 'Saved login looks expired or unavailable. Reconnect to use this provider.';
+    case 'broken_invalid':
+      return 'Saved API key may be invalid or no longer works. Reconnect to use this provider.';
+    case 'env':
+      return hasUsableModels
+        ? 'Using environment-backed credentials.'
+        : 'Environment-backed credentials were detected, but no usable models were found.';
+    case 'local':
+      return hasUsableModels
+        ? 'Local or custom models are available.'
+        : 'A local or custom provider is configured, but no usable models were detected.';
+    case 'missing':
+      return 'Not connected yet.';
+    case 'unknown':
+    default:
+      return hasUsableModels ? 'Usable models are available.' : 'Provider health could not be determined.';
+  }
+}
+
+function buildHealthInfo(args: {
+  providerId: string;
+  status: ProviderHealthStatus;
+  usableModelIds: string[];
+}): ProviderHealthInfo {
+  const { providerId, status, usableModelIds } = args;
+  const hasUsableModels = usableModelIds.length > 0;
+
+  return {
+    providerId,
+    displayName: providerDisplayName(providerId),
+    status,
+    message: buildMessage(status, hasUsableModels),
+    canReconnect: status === 'missing' || status === 'broken_expired' || status === 'broken_invalid',
+    hasUsableModels,
+    usableModelIds,
+  };
+}
+
+function sortProviderHealth(providerHealth: ProviderHealthInfo[]): ProviderHealthInfo[] {
+  return [...providerHealth].sort(
+    (a, b) => a.displayName.localeCompare(b.displayName) || a.providerId.localeCompare(b.providerId),
+  );
+}
+
+export async function getProviderHealthSnapshot(): Promise<ProviderHealthSnapshot> {
+  const infra = await ensureInfra();
+  const availableModelGroups = buildAvailableModelGroups(infra);
+  const usableModelIdsByProvider = new Map<string, string[]>();
+  for (const group of availableModelGroups) {
+    usableModelIdsByProvider.set(
+      group.provider,
+      group.models.map((model) => model.modelId),
+    );
+  }
+
+  infra.authStorage.reload();
+  const providerHealth: ProviderHealthInfo[] = [];
+  const knownProviders = new Set<string>();
+
+  for (const provider of getOAuthProviderCatalog()) {
+    knownProviders.add(provider.id);
+    const credential = infra.authStorage.get(provider.id);
+    const usableModelIds = usableModelIdsByProvider.get(provider.id) ?? [];
+    const status: ProviderHealthStatus = usableModelIds.length > 0
+      ? 'healthy'
+      : credential?.type === 'oauth'
+        ? 'broken_expired'
+        : 'missing';
+    providerHealth.push(buildHealthInfo({
+      providerId: provider.id,
+      status,
+      usableModelIds,
+    }));
+  }
+
+  for (const provider of API_KEY_PROVIDERS) {
+    knownProviders.add(provider.id);
+    const credential = infra.authStorage.get(provider.id);
+    const envKey = getEnvApiKey(provider.id);
+    const usableModelIds = usableModelIdsByProvider.get(provider.id) ?? [];
+
+    let status: ProviderHealthStatus;
+    if (usableModelIds.length > 0) {
+      status = envKey && !credential ? 'env' : 'healthy';
+    } else if (envKey && !credential) {
+      status = 'env';
+    } else if (credential?.type === 'api_key') {
+      status = 'broken_invalid';
+    } else {
+      status = 'missing';
+    }
+
+    providerHealth.push(buildHealthInfo({
+      providerId: provider.id,
+      status,
+      usableModelIds,
+    }));
+  }
+
+  const localProviderIds = readConfiguredLocalProviderIds();
+  for (const providerId of localProviderIds) {
+    if (knownProviders.has(providerId)) continue;
+    knownProviders.add(providerId);
+    providerHealth.push(buildHealthInfo({
+      providerId,
+      status: 'local',
+      usableModelIds: usableModelIdsByProvider.get(providerId) ?? [],
+    }));
+  }
+
+  for (const group of availableModelGroups) {
+    if (knownProviders.has(group.provider)) continue;
+    providerHealth.push(buildHealthInfo({
+      providerId: group.provider,
+      status: 'unknown',
+      usableModelIds: group.models.map((model) => model.modelId),
+    }));
+  }
+
+  return {
+    availableModelGroups,
+    providerHealth: sortProviderHealth(providerHealth),
+  };
+}

--- a/apps/desktop/electron/features/onboarding/recommendations.ts
+++ b/apps/desktop/electron/features/onboarding/recommendations.ts
@@ -1,0 +1,308 @@
+import type {
+  AvailableModelGroup,
+  ModelTier,
+  ModelTierEntry,
+  ModelTierSettings,
+  OnboardingRecommendation,
+  OnboardingTierSource,
+  ProviderModelDefaults,
+} from '../../../src/types/ipc';
+import {
+  ONBOARDING_TIERS,
+  buildRecommendation,
+  flattenAvailableModels,
+  hasTierEntry,
+  type AvailableModelRecord,
+  type RecommendationContext,
+  type TierSelectionResult,
+  type ValidatedTierResult,
+} from './types';
+
+const TIER_PRIORITY_IDS: Record<ModelTier, string[]> = {
+  LOW: ['gpt-4.1-mini', 'claude-haiku-4-5', 'gemini-2.5-flash', 'gemini-3-flash'],
+  MED: ['gpt-5.4', 'claude-sonnet-4-6', 'gemini-2.5-pro'],
+  HIGH: ['gpt-5.4', 'claude-sonnet-4-6', 'gemini-2.5-pro'],
+};
+
+function getProviderModels(
+  groups: AvailableModelGroup[],
+  providerId: string,
+): AvailableModelRecord[] {
+  const group = groups.find((candidate) => candidate.provider === providerId);
+  if (!group) return [];
+  return group.models.map((model) => ({
+    provider: model.provider,
+    modelId: model.modelId,
+    name: model.name,
+    reasoning: model.reasoning,
+  }));
+}
+
+function countTierProviders(tiers: ModelTierSettings): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const tier of ONBOARDING_TIERS) {
+    const entry = tiers[tier];
+    if (!entry) continue;
+    counts.set(entry.provider, (counts.get(entry.provider) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function inferPreferredFromValidTiers(tiers: ModelTierSettings): string | null {
+  const counts = countTierProviders(tiers);
+  let preferred: string | null = null;
+  let bestCount = 0;
+  let total = 0;
+
+  for (const count of counts.values()) total += count;
+  for (const [providerId, count] of counts.entries()) {
+    if (count > bestCount || (count === bestCount && preferred !== null && providerId.localeCompare(preferred) < 0)) {
+      preferred = providerId;
+      bestCount = count;
+    }
+  }
+
+  if (!preferred || total === 0) return null;
+  return bestCount >= Math.ceil(total / 2) ? preferred : null;
+}
+
+function modelMatches(entry: ModelTierEntry, model: AvailableModelRecord): boolean {
+  return entry.provider === model.provider && entry.modelId === model.modelId;
+}
+
+function findExactModel(
+  models: AvailableModelRecord[],
+  modelId: string,
+): AvailableModelRecord | null {
+  return models.find((model) => model.modelId === modelId) ?? null;
+}
+
+function scoreModelForTier(model: AvailableModelRecord, tier: ModelTier): number {
+  const haystack = `${model.modelId} ${model.name}`.toLowerCase();
+  let score = 0;
+
+  const priorityIndex = TIER_PRIORITY_IDS[tier].findIndex((candidate) => candidate === model.modelId);
+  if (priorityIndex >= 0) {
+    score += 200 - (priorityIndex * 10);
+  }
+
+  const isFast = /mini|haiku|flash|nano|small|instant|fast/.test(haystack);
+  const isCapable = /pro|sonnet|opus|max|ultra|reason|thinking|gpt-5/.test(haystack);
+
+  if (tier === 'LOW') {
+    if (isFast) score += 45;
+    if (isCapable) score -= 20;
+    score += model.reasoning ? -5 : 10;
+  }
+
+  if (tier === 'MED') {
+    if (isCapable) score += 30;
+    if (isFast) score -= 5;
+    if (model.reasoning) score += 10;
+  }
+
+  if (tier === 'HIGH') {
+    if (isCapable) score += 45;
+    if (isFast) score -= 25;
+    if (model.reasoning) score += 20;
+  }
+
+  return score;
+}
+
+function rankModelsForTier(
+  models: AvailableModelRecord[],
+  tier: ModelTier,
+): AvailableModelRecord[] {
+  return [...models].sort((a, b) => {
+    const scoreDelta = scoreModelForTier(b, tier) - scoreModelForTier(a, tier);
+    if (scoreDelta !== 0) return scoreDelta;
+    return (
+      a.provider.localeCompare(b.provider)
+      || a.name.localeCompare(b.name)
+      || a.modelId.localeCompare(b.modelId)
+    );
+  });
+}
+
+function pickFromDefaults(
+  providerId: string,
+  tier: ModelTier,
+  providerDefaults: ProviderModelDefaults,
+  groups: AvailableModelGroup[],
+): TierSelectionResult | null {
+  const defaults = providerDefaults[providerId];
+  const modelId = defaults?.[tier];
+  if (!modelId) return null;
+
+  const model = findExactModel(getProviderModels(groups, providerId), modelId);
+  if (!model) return null;
+
+  return {
+    entry: {
+      provider: model.provider,
+      modelId: model.modelId,
+    },
+    source: 'provider-defaults',
+  };
+}
+
+function pickBestModel(models: AvailableModelRecord[], tier: ModelTier): TierSelectionResult | null {
+  const best = rankModelsForTier(models, tier)[0];
+  if (!best) return null;
+  return {
+    entry: {
+      provider: best.provider,
+      modelId: best.modelId,
+    },
+    source: 'fallback',
+  };
+}
+
+function scoreProviderCoverage(
+  providerId: string,
+  groups: AvailableModelGroup[],
+  providerDefaults: ProviderModelDefaults,
+): number {
+  const providerModels = getProviderModels(groups, providerId);
+  if (providerModels.length === 0) return Number.NEGATIVE_INFINITY;
+
+  let score = 0;
+  for (const tier of ONBOARDING_TIERS) {
+    if (pickFromDefaults(providerId, tier, providerDefaults, groups)) {
+      score += 5;
+      continue;
+    }
+    if (pickBestModel(providerModels, tier)) {
+      score += 1;
+    }
+  }
+
+  return score;
+}
+
+function pickBestCoverageProvider(
+  groups: AvailableModelGroup[],
+  providerDefaults: ProviderModelDefaults,
+): string | null {
+  let preferred: string | null = null;
+  let bestScore = Number.NEGATIVE_INFINITY;
+
+  for (const group of groups) {
+    const score = scoreProviderCoverage(group.provider, groups, providerDefaults);
+    if (score > bestScore || (score === bestScore && preferred !== null && group.provider.localeCompare(preferred) < 0)) {
+      preferred = group.provider;
+      bestScore = score;
+    }
+  }
+
+  return preferred;
+}
+
+function inferPreferredProvider(
+  context: RecommendationContext,
+  validTiers: ModelTierSettings,
+): string | undefined {
+  const preferredFromValidTiers = inferPreferredFromValidTiers(validTiers);
+  if (preferredFromValidTiers) return preferredFromValidTiers;
+
+  const healthyProviders = new Set(
+    context.providerHealth
+      .filter((provider) => provider.hasUsableModels)
+      .map((provider) => provider.providerId),
+  );
+
+  if (context.legacyDefaultProvider && healthyProviders.has(context.legacyDefaultProvider)) {
+    return context.legacyDefaultProvider;
+  }
+
+  const preferredByCoverage = pickBestCoverageProvider(
+    context.availableModelGroups.filter((group) => healthyProviders.has(group.provider)),
+    context.providerDefaults.effectiveDefaults,
+  );
+  return preferredByCoverage ?? undefined;
+}
+
+export function validateCurrentTiers(
+  groups: AvailableModelGroup[],
+  tiers: ModelTierSettings,
+): ValidatedTierResult {
+  const validTiers: ModelTierSettings = {};
+  const invalidTiers: ModelTier[] = [];
+
+  for (const tier of ONBOARDING_TIERS) {
+    const entry = tiers[tier];
+    if (!entry) continue;
+    if (hasTierEntry(groups, entry)) {
+      validTiers[tier] = entry;
+      continue;
+    }
+    invalidTiers.push(tier);
+  }
+
+  return { validTiers, invalidTiers };
+}
+
+function pickTierSelection(
+  tier: ModelTier,
+  context: RecommendationContext,
+  preferredProvider: string | undefined,
+  preservedTiers: ModelTierSettings,
+): TierSelectionResult | null {
+  const preserved = preservedTiers[tier];
+  if (preserved) {
+    return {
+      entry: preserved,
+      source: 'preserved',
+    };
+  }
+
+  if (preferredProvider) {
+    const fromDefaults = pickFromDefaults(
+      preferredProvider,
+      tier,
+      context.providerDefaults.effectiveDefaults,
+      context.availableModelGroups,
+    );
+    if (fromDefaults) return fromDefaults;
+
+    const preferredModels = getProviderModels(context.availableModelGroups, preferredProvider);
+    const withinProviderFallback = pickBestModel(preferredModels, tier);
+    if (withinProviderFallback) return withinProviderFallback;
+  }
+
+  const anyModelFallback = pickBestModel(
+    flattenAvailableModels(context.availableModelGroups),
+    tier,
+  );
+  return anyModelFallback;
+}
+
+export function buildOnboardingRecommendation(context: RecommendationContext): {
+  recommendation: OnboardingRecommendation | null;
+  invalidTiers: ModelTier[];
+} {
+  const { validTiers, invalidTiers } = validateCurrentTiers(
+    context.availableModelGroups,
+    context.currentTiers,
+  );
+
+  const preferredProvider = inferPreferredProvider(context, validTiers);
+  const tiers: ModelTierSettings = {};
+  const sourcesByTier: Partial<Record<ModelTier, OnboardingTierSource>> = {};
+
+  for (const tier of ONBOARDING_TIERS) {
+    const selection = pickTierSelection(tier, context, preferredProvider, validTiers);
+    if (!selection) continue;
+    tiers[tier] = selection.entry;
+    sourcesByTier[tier] = selection.source;
+  }
+
+  const hasRecommendation = ONBOARDING_TIERS.every((tier) => !!tiers[tier]);
+  return {
+    recommendation: hasRecommendation
+      ? buildRecommendation(tiers, sourcesByTier, preferredProvider)
+      : null,
+    invalidTiers,
+  };
+}

--- a/apps/desktop/electron/features/onboarding/types.ts
+++ b/apps/desktop/electron/features/onboarding/types.ts
@@ -1,0 +1,105 @@
+import type {
+  AvailableModelGroup,
+  ModelTier,
+  ModelTierEntry,
+  ModelTierSettings,
+  OnboardingRecommendation,
+  OnboardingState,
+  OnboardingTierSource,
+  ProviderHealthInfo,
+  ProviderModelDefaults,
+  ResolvedProviderDefaultsState,
+} from '../../../src/types/ipc';
+
+export type {
+  OnboardingRecommendation,
+  OnboardingState,
+  OnboardingTierSource,
+  ProviderHealthInfo,
+  ProviderModelDefaults,
+  ResolvedProviderDefaultsState,
+} from '../../../src/types/ipc';
+
+export const ONBOARDING_TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
+
+export interface AvailableModelRecord {
+  provider: string;
+  modelId: string;
+  name: string;
+  reasoning: boolean;
+}
+
+export interface ValidatedTierResult {
+  validTiers: ModelTierSettings;
+  invalidTiers: ModelTier[];
+}
+
+export interface RecommendationContext {
+  availableModelGroups: AvailableModelGroup[];
+  currentTiers: ModelTierSettings;
+  providerHealth: ProviderHealthInfo[];
+  providerDefaults: ResolvedProviderDefaultsState;
+  legacyDefaultProvider?: string | null;
+}
+
+export interface TierSelectionResult {
+  entry: ModelTierEntry;
+  source: OnboardingTierSource;
+}
+
+export function flattenAvailableModels(groups: AvailableModelGroup[]): AvailableModelRecord[] {
+  return groups.flatMap((group) => group.models.map((model) => ({
+    provider: model.provider,
+    modelId: model.modelId,
+    name: model.name,
+    reasoning: model.reasoning,
+  })));
+}
+
+export function hasTierEntry(
+  groups: AvailableModelGroup[],
+  entry: ModelTierEntry,
+): boolean {
+  return groups.some((group) =>
+    group.provider === entry.provider
+    && group.models.some((model) => model.modelId === entry.modelId),
+  );
+}
+
+export function findModelName(
+  groups: AvailableModelGroup[],
+  entry: ModelTierEntry,
+): string {
+  for (const group of groups) {
+    if (group.provider !== entry.provider) continue;
+    const model = group.models.find((candidate) => candidate.modelId === entry.modelId);
+    if (model) return model.name;
+  }
+  return entry.modelId;
+}
+
+export function buildRecommendation(
+  tiers: ModelTierSettings,
+  sourcesByTier: Partial<Record<ModelTier, OnboardingTierSource>>,
+  preferredProvider?: string,
+): OnboardingRecommendation {
+  return {
+    tiers,
+    sourcesByTier,
+    preferredProvider,
+  };
+}
+
+export function emptyOnboardingState(): OnboardingState {
+  return {
+    needed: false,
+    phase: 'done',
+    hasAnyUsableModels: false,
+    hasImportedCredentials: false,
+    recommendation: null,
+    providerHealth: [],
+    availableModelGroups: [],
+    warnings: [],
+    invalidTiers: [],
+  };
+}

--- a/apps/desktop/electron/features/subagent/core/resolve.ts
+++ b/apps/desktop/electron/features/subagent/core/resolve.ts
@@ -1,12 +1,17 @@
 /**
  * Config resolution — 5-level precedence chain for model, thinking, and timeout.
  *
- * Precedence (highest → lowest):
+ * Precedence (highest -> lowest):
  *   1. Per-task override (tasks[i] / chain[i])
  *   2. Top-level call override
  *   3. Agent frontmatter
  *   4. Global subagent settings (settings.json)
  *   5. Session / app defaults
+ *
+ * The `model` field from agent frontmatter may be a plain string (legacy)
+ * or a structured `{ prefer, fallbacks }` object. When structured, the
+ * `prefer` value is emitted as the model string — tier resolution happens
+ * downstream in the runner where the model registry is available.
  */
 
 import type {
@@ -16,9 +21,12 @@ import type {
   TaskOverride,
 } from './types';
 
-/** Defaults used as the absolute fallback. */
+/**
+ * Provider-neutral defaults used as the absolute fallback.
+ * Uses MED tier alias — resolved to a concrete model at runtime.
+ */
 const HARDCODED_DEFAULTS = {
-  model: 'claude-sonnet-4-6',
+  model: 'MED',
   thinking: 'high',
   timeoutMs: 600_000,
   toolStallTimeoutMs: 120_000,
@@ -30,10 +38,26 @@ export interface SessionDefaults {
 }
 
 /**
+ * Extract the primary model string from an AgentConfig.model value.
+ * Structured fields emit the `prefer` value; plain strings pass through.
+ */
+function extractModelString(
+  model: string | { prefer: string; fallbacks: string[] } | undefined,
+): string | undefined {
+  if (typeof model === 'string') return model || undefined;
+  if (model && typeof model === 'object') return model.prefer || undefined;
+  return undefined;
+}
+
+/**
  * Resolve the concrete model, thinking, and timeoutMs for a subagent run.
  *
  * Each level only overrides if the value is non-null/non-undefined.
  * Falls back to hardcoded defaults as the last resort.
+ *
+ * NOTE: The returned `model` may be a tier alias (e.g. "MED") when it
+ * originates from agent frontmatter or hardcoded defaults. The runner
+ * is responsible for resolving tier aliases to concrete model IDs.
  */
 export function resolveConfig(
   taskOverride?: TaskOverride,
@@ -45,7 +69,7 @@ export function resolveConfig(
   const model = firstDefined(
     taskOverride?.model,
     callOverride?.model,
-    agentConfig?.model,
+    extractModelString(agentConfig?.model),
     settings?.model,
     sessionDefaults?.model,
     HARDCODED_DEFAULTS.model,

--- a/apps/desktop/electron/features/subagent/core/resolve.ts
+++ b/apps/desktop/electron/features/subagent/core/resolve.ts
@@ -9,9 +9,11 @@
  *   5. Session / app defaults
  *
  * The `model` field from agent frontmatter may be a plain string (legacy)
- * or a structured `{ prefer, fallbacks }` object. When structured, the
- * `prefer` value is emitted as the model string — tier resolution happens
- * downstream in the runner where the model registry is available.
+ * or a structured `{ prefer, fallbacks }` object. The merged winner is
+ * returned in `ResolvedConfig.modelSelection`, while `ResolvedConfig.model`
+ * exposes the primary display/reference string (`prefer` for structured
+ * fields). Tier resolution still happens downstream in the runner where the
+ * model registry is available.
  */
 
 import type {
@@ -49,6 +51,16 @@ function extractModelString(
   return undefined;
 }
 
+function firstDefinedModel(
+  ...values: (string | { prefer: string; fallbacks: string[] } | null | undefined)[]
+): string | { prefer: string; fallbacks: string[] } {
+  for (const v of values) {
+    if (typeof v === 'string' && v !== '') return v;
+    if (v && typeof v === 'object') return v;
+  }
+  return HARDCODED_DEFAULTS.model;
+}
+
 /**
  * Resolve the concrete model, thinking, and timeoutMs for a subagent run.
  *
@@ -56,8 +68,8 @@ function extractModelString(
  * Falls back to hardcoded defaults as the last resort.
  *
  * NOTE: The returned `model` may be a tier alias (e.g. "MED") when it
- * originates from agent frontmatter or hardcoded defaults. The runner
- * is responsible for resolving tier aliases to concrete model IDs.
+ * originates from overrides, agent frontmatter, or hardcoded defaults. The
+ * runner is responsible for resolving aliases/fallbacks to a concrete model.
  */
 export function resolveConfig(
   taskOverride?: TaskOverride,
@@ -66,14 +78,15 @@ export function resolveConfig(
   settings?: Pick<SubagentSettings, 'model' | 'thinking' | 'timeoutMs' | 'toolStallTimeoutMs'>,
   sessionDefaults?: SessionDefaults,
 ): ResolvedConfig {
-  const model = firstDefined(
+  const modelSelection = firstDefinedModel(
     taskOverride?.model,
     callOverride?.model,
-    extractModelString(agentConfig?.model),
+    agentConfig?.model,
     settings?.model,
     sessionDefaults?.model,
     HARDCODED_DEFAULTS.model,
   );
+  const model = extractModelString(modelSelection) ?? HARDCODED_DEFAULTS.model;
 
   const thinking = firstDefined(
     taskOverride?.thinking,
@@ -94,7 +107,7 @@ export function resolveConfig(
 
   const toolStallTimeoutMs = settings?.toolStallTimeoutMs ?? HARDCODED_DEFAULTS.toolStallTimeoutMs;
 
-  return { model, thinking, timeoutMs, toolStallTimeoutMs };
+  return { model, modelSelection, thinking, timeoutMs, toolStallTimeoutMs };
 }
 
 /**

--- a/apps/desktop/electron/features/subagent/core/types.ts
+++ b/apps/desktop/electron/features/subagent/core/types.ts
@@ -12,6 +12,7 @@ import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
 import type {
   SubagentMode as _SubagentMode,
   SubagentUsage as _SubagentUsage,
+  SubagentModelConfig as _SubagentModelConfig,
 } from '../../../../src/types/subagent';
 
 // Re-export IPC-shared types as the single source of truth
@@ -26,6 +27,7 @@ export type {
 // Local aliases for use within this file
 type SubagentUsage = _SubagentUsage;
 type SubagentMode = _SubagentMode;
+type SubagentModelConfig = _SubagentModelConfig;
 
 // ── Agent Config (from .md discovery) ────────────────────────
 
@@ -35,7 +37,7 @@ export interface AgentConfig {
   /** What this agent does (from frontmatter `description`). */
   description: string;
   /** Default model — plain string (legacy) or structured { prefer, fallbacks }. */
-  model?: string | { prefer: string; fallbacks: string[] };
+  model?: SubagentModelConfig;
   /** Default thinking level. */
   thinking?: string;
   /** Default timeout in milliseconds. */
@@ -99,8 +101,14 @@ export interface RunResult {
 // ── Resolved Config (merged precedence output) ───────────────
 
 export interface ResolvedConfig {
-  /** Concrete model ID to use. */
+  /** Primary model reference for UI/tracking (model ID or tier alias). */
   model: string;
+  /**
+   * The merged winning model config after precedence resolution.
+   * Preserves structured `{ prefer, fallbacks }` fields so the runner can
+   * resolve the correct concrete model without re-reading agent frontmatter.
+   */
+  modelSelection: SubagentModelConfig;
   /** Concrete thinking level. */
   thinking: string;
   /** Concrete timeout in milliseconds. */

--- a/apps/desktop/electron/features/subagent/core/types.ts
+++ b/apps/desktop/electron/features/subagent/core/types.ts
@@ -34,8 +34,8 @@ export interface AgentConfig {
   name: string;
   /** What this agent does (from frontmatter `description`). */
   description: string;
-  /** Default model for this agent. */
-  model?: string;
+  /** Default model — plain string (legacy) or structured { prefer, fallbacks }. */
+  model?: string | { prefer: string; fallbacks: string[] };
   /** Default thinking level. */
   thinking?: string;
   /** Default timeout in milliseconds. */

--- a/apps/desktop/electron/features/subagent/runtime/discovery.ts
+++ b/apps/desktop/electron/features/subagent/runtime/discovery.ts
@@ -8,6 +8,7 @@
 import { readdir, readFile } from 'fs/promises';
 import path from 'path';
 import type { AgentConfig } from '../core/types';
+import { parseModelField } from '../../../shared/settings/resolve-tier-model';
 
 /**
  * Parse JSON frontmatter from a markdown file.
@@ -87,6 +88,18 @@ function validateFrontmatter(
 }
 
 /**
+ * Parse model field from frontmatter into the AgentConfig union type.
+ * Returns plain string for legacy format, structured object for new format.
+ */
+function parseAgentModelField(
+  raw: unknown,
+): string | { prefer: string; fallbacks: string[] } | undefined {
+  if (typeof raw === 'string' && raw.trim()) return raw;
+  const parsed = parseModelField(raw);
+  return parsed ?? undefined;
+}
+
+/**
  * Convert frontmatter to AgentConfig.
  */
 function toAgentConfig(
@@ -97,7 +110,7 @@ function toAgentConfig(
   return {
     name: fm.name as string,
     description: fm.description as string,
-    model: typeof fm.model === 'string' ? fm.model : undefined,
+    model: parseAgentModelField(fm.model),
     thinking: typeof fm.thinking === 'string' ? fm.thinking : undefined,
     timeoutMs: typeof fm.timeoutMs === 'number' ? fm.timeoutMs : undefined,
     tools: Array.isArray(fm.tools) ? fm.tools.filter((t): t is string => typeof t === 'string') : undefined,
@@ -155,13 +168,14 @@ export async function discoverAgents(
         }
       }
 
-      // Warn about unknown models (non-blocking)
+      // Warn about unknown models (non-blocking) — skip tier aliases
       const model = parsed.frontmatter.model;
       if (typeof model === 'string' && options?.isValidModel && !options.isValidModel(model)) {
         console.warn(
           `[subagent/discovery] ${absPath}: model '${model}' not found in registry`,
         );
       }
+      // Structured model fields are validated at resolution time, not discovery
 
       agents.push(toAgentConfig(parsed.frontmatter, parsed.body, absPath));
     } catch (err) {

--- a/apps/desktop/electron/features/subagent/runtime/runner.ts
+++ b/apps/desktop/electron/features/subagent/runtime/runner.ts
@@ -207,22 +207,10 @@ export async function runSubagent(
       const available = infra.modelRegistry.getAvailable();
       const globalSettings = infra.settingsManager.getGlobalSettings() as Record<string, unknown>;
       const tierSettings = getModelTiers(globalSettings);
-
-      // Check if the resolved model string is a tier alias or has a structured source
-      const agentModelField = agent.model;
-      const parsed = parseModelField(agentModelField);
-      let resolvedModel: { provider: string; modelId: string } | null = null;
-
-      if (parsed) {
-        // Use the full structured field for resolution (tier + fallbacks)
-        resolvedModel = resolveTierModel(parsed, tierSettings, available);
-      }
-
-      if (!resolvedModel) {
-        // Legacy: try the flat resolved.model string directly
-        const match = available.find((m) => m.id === resolved.model);
-        if (match) resolvedModel = { provider: match.provider, modelId: match.id };
-      }
+      const parsed = parseModelField(resolved.modelSelection);
+      const resolvedModel = parsed
+        ? resolveTierModel(parsed, tierSettings, available)
+        : null;
 
       if (resolvedModel) {
         const model = infra.modelRegistry.find(resolvedModel.provider, resolvedModel.modelId);

--- a/apps/desktop/electron/features/subagent/runtime/runner.ts
+++ b/apps/desktop/electron/features/subagent/runtime/runner.ts
@@ -26,6 +26,8 @@ import { createSubagentExtensionFactory } from './loader';
 import { SERO_AGENT_DIR } from '../../../platform/env';
 import { logRawEvent, logTurnContext } from '../../../ipc/editor/debug';
 import { createSkillVisibilityOverride } from '../../apps/extensions/skill-visibility';
+import { parseModelField, resolveTierModel } from '../../../shared/settings/resolve-tier-model';
+import { getModelTiers } from '../../../shared/settings/model-tiers';
 import path from 'path';
 
 const EMPTY_USAGE: SubagentUsage = {
@@ -203,9 +205,27 @@ export async function runSubagent(
     // Try to set the resolved model — needs provider/modelId lookup
     try {
       const available = infra.modelRegistry.getAvailable();
-      const match = available.find((m) => m.id === resolved.model);
-      if (match) {
-        const model = infra.modelRegistry.find(match.provider, match.id);
+      const globalSettings = infra.settingsManager.getGlobalSettings() as Record<string, unknown>;
+      const tierSettings = getModelTiers(globalSettings);
+
+      // Check if the resolved model string is a tier alias or has a structured source
+      const agentModelField = agent.model;
+      const parsed = parseModelField(agentModelField);
+      let resolvedModel: { provider: string; modelId: string } | null = null;
+
+      if (parsed) {
+        // Use the full structured field for resolution (tier + fallbacks)
+        resolvedModel = resolveTierModel(parsed, tierSettings, available);
+      }
+
+      if (!resolvedModel) {
+        // Legacy: try the flat resolved.model string directly
+        const match = available.find((m) => m.id === resolved.model);
+        if (match) resolvedModel = { provider: match.provider, modelId: match.id };
+      }
+
+      if (resolvedModel) {
+        const model = infra.modelRegistry.find(resolvedModel.provider, resolvedModel.modelId);
         if (model) await session.setModel(model);
       }
     } catch {

--- a/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
@@ -148,7 +148,14 @@ export function registerAgentModelContextHandlers(
     async (_event, sessionId: string): Promise<SessionModelState | null> => {
       const entry = getEntry(sessionId);
       if (!entry) return null;
-      const changed = await ensureSessionHasAvailableModel(entry.session);
+      let changed = false;
+      try {
+        changed = await ensureSessionHasAvailableModel(entry.session);
+      } catch (err) {
+        // Model switch failed (e.g. stale OAuth token) — still return
+        // the model state so the user can manually pick a working model.
+        console.warn('[agent-model-context] ensureSessionHasAvailableModel failed:', err);
+      }
       const state = buildModelState(entry);
       if (changed) {
         sendEvent({ type: 'model_change', sessionId, state });

--- a/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
@@ -21,6 +21,7 @@ import {
   persistContextOverrides,
 } from './agent-context-overrides';
 import { getConfiguredModelFallbackChain } from '../../../shared/settings/model-fallback-chain';
+import { getModelTiers } from '../../../shared/settings/model-tiers';
 
 export interface AgentPoolContextEntry {
   session: AgentSession;
@@ -78,6 +79,7 @@ function pickFallbackModel(
 ) {
   session.settingsManager.reload();
 
+  // 1. Try saved default provider/model (existing settings)
   const preferredProvider = session.settingsManager.getDefaultProvider();
   const savedDefaultModel = findAvailableModelByProviderAndId(
     availableModels,
@@ -86,7 +88,17 @@ function pickFallbackModel(
   );
   if (savedDefaultModel) return savedDefaultModel;
 
+  // 2. Try HIGH tier model (main sessions use the most capable model)
   const globalSettings = session.settingsManager.getGlobalSettings() as Record<string, unknown>;
+  const tiers = getModelTiers(globalSettings);
+  if (tiers.HIGH) {
+    const tierMatch = availableModels.find(
+      (m) => m.provider === tiers.HIGH!.provider && m.id === tiers.HIGH!.modelId,
+    );
+    if (tierMatch) return tierMatch;
+  }
+
+  // 3. Walk fallback chain
   const fallbackChain = getConfiguredModelFallbackChain(globalSettings);
   for (const candidate of fallbackChain) {
     const model = findAvailableModelByReference(availableModels, candidate, preferredProvider);

--- a/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
@@ -149,7 +149,7 @@ async function getOrCreateAppSession(
   const { session } = await createAgentSession({
     cwd: wsPath,
     agentDir: SERO_AGENT_DIR,
-    model: infra.model,
+    model: infra.model ?? undefined,
     thinkingLevel: 'high',
     authStorage: infra.authStorage,
     modelRegistry: infra.modelRegistry,

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -8,6 +8,7 @@
 
 import { registerProfileHandlers } from './workspace/profiles';
 import { registerWorkspaceHandlers } from './workspace';
+import { registerOnboardingHandlers } from './onboarding/onboarding';
 import { registerSessionHandlers } from './agent/handlers/sessions';
 import { registerAgentHandlers } from './agent';
 import { registerAppAgentHandlers } from './agent/handlers/app-agent';
@@ -49,6 +50,7 @@ import { registerThemeHandlers } from './platform/ui';
 export function registerAllIpcHandlers(): void {
   registerProfileHandlers();
   registerWorkspaceHandlers();
+  registerOnboardingHandlers();
   registerSessionHandlers();
   registerAgentHandlers();
   registerAppAgentHandlers();

--- a/apps/desktop/electron/ipc/onboarding/onboarding.ts
+++ b/apps/desktop/electron/ipc/onboarding/onboarding.ts
@@ -1,0 +1,49 @@
+import { ipcMain } from 'electron';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { IpcChannels } from '../../../src/types/ipc';
+import type {
+  ModelTierSettings,
+  OnboardingState,
+  ProviderModelDefaults,
+  ResolvedProviderDefaultsState,
+} from '../../../src/types/ipc';
+import { SERO_AGENT_DIR } from '../../platform/env';
+import { getOnboardingState, saveOnboardingTierSelections } from '../../features/onboarding';
+import {
+  resolveProviderDefaultsState,
+  writeGlobalProviderModelDefaults,
+} from '../../shared/settings/provider-model-defaults';
+
+function readSettings(): Record<string, unknown> {
+  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+  try {
+    return JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function registerOnboardingHandlers(): void {
+  ipcMain.handle(
+    IpcChannels.onboarding.getState,
+    async (): Promise<OnboardingState> => getOnboardingState(),
+  );
+
+  ipcMain.handle(
+    IpcChannels.onboarding.saveTierSelections,
+    async (_event, tiers: ModelTierSettings): Promise<void> => saveOnboardingTierSelections(tiers),
+  );
+
+  ipcMain.handle(
+    IpcChannels.providerDefaults.get,
+    async (): Promise<ResolvedProviderDefaultsState> => resolveProviderDefaultsState(readSettings()),
+  );
+
+  ipcMain.handle(
+    IpcChannels.providerDefaults.setGlobalDefaults,
+    async (_event, defaults: ProviderModelDefaults): Promise<void> => {
+      writeGlobalProviderModelDefaults(defaults);
+    },
+  );
+}

--- a/apps/desktop/electron/ipc/onboarding/onboarding.ts
+++ b/apps/desktop/electron/ipc/onboarding/onboarding.ts
@@ -1,6 +1,4 @@
 import { ipcMain } from 'electron';
-import { readFileSync } from 'fs';
-import path from 'path';
 import { IpcChannels } from '../../../src/types/ipc';
 import type {
   ModelTierSettings,
@@ -8,21 +6,12 @@ import type {
   ProviderModelDefaults,
   ResolvedProviderDefaultsState,
 } from '../../../src/types/ipc';
-import { SERO_AGENT_DIR } from '../../platform/env';
 import { getOnboardingState, saveOnboardingTierSelections } from '../../features/onboarding';
 import {
   resolveProviderDefaultsState,
   writeGlobalProviderModelDefaults,
 } from '../../shared/settings/provider-model-defaults';
-
-function readSettings(): Record<string, unknown> {
-  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
-  try {
-    return JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
-  } catch {
-    return {};
-  }
-}
+import { readSettings } from '../../shared/settings/settings-helpers';
 
 export function registerOnboardingHandlers(): void {
   ipcMain.handle(

--- a/apps/desktop/electron/ipc/platform/auth/auth.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth.ts
@@ -141,6 +141,7 @@ export function registerAuthHandlers(): void {
     IpcChannels.auth.getProviders,
     async (): Promise<AuthProvidersResponse> => {
       const infra = await ensureInfra();
+      infra.authStorage.reload();
 
       // OAuth providers
       const oauthProviders = getOAuthProviders();

--- a/apps/desktop/electron/ipc/platform/auth/auth.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth.ts
@@ -31,6 +31,7 @@ import type {
   OAuthEvent,
 } from '../../../../src/types/ipc';
 import { ensureInfra } from '../../../shared/infra/shared-infra';
+import { API_KEY_PROVIDERS } from '../../../shared/auth/provider-catalog';
 import { AUTH_JSON_PATH } from '../../../platform/env';
 
 // ── auth.json permission hardening ───────────────────────────
@@ -65,27 +66,6 @@ function repairAuthJsonPermissionsOnStartup(): void {
     // File doesn't exist yet — nothing to repair
   }
 }
-
-// ── API-key provider definitions ─────────────────────────────
-// Providers that accept a plain API key (not OAuth).
-// Ordered roughly by popularity.
-
-const API_KEY_PROVIDERS: { id: string; name: string }[] = [
-  { id: 'anthropic', name: 'Anthropic' },
-  { id: 'openai', name: 'OpenAI' },
-  { id: 'google', name: 'Google (Gemini)' },
-  { id: 'openrouter', name: 'OpenRouter' },
-  { id: 'xai', name: 'xAI' },
-  { id: 'groq', name: 'Groq' },
-  { id: 'cerebras', name: 'Cerebras' },
-  { id: 'mistral', name: 'Mistral' },
-  { id: 'azure-openai-responses', name: 'Azure OpenAI' },
-  { id: 'huggingface', name: 'Hugging Face' },
-  { id: 'vercel-ai-gateway', name: 'Vercel AI Gateway' },
-  { id: 'zai', name: 'ZAI' },
-  { id: 'opencode', name: 'OpenCode' },
-  { id: 'kimi-coding', name: 'Kimi' },
-];
 
 // ── In-flight login state ────────────────────────────────────
 

--- a/apps/desktop/electron/ipc/subagent/subagent.ts
+++ b/apps/desktop/electron/ipc/subagent/subagent.ts
@@ -125,7 +125,7 @@ export function registerSubagentHandlers(): void {
       return agents.map((a) => ({
         name: a.name,
         description: a.description,
-        model: a.model,
+        model: typeof a.model === 'string' ? a.model : a.model?.prefer,
         thinking: a.thinking,
         timeoutMs: a.timeoutMs,
       }));

--- a/apps/desktop/electron/ipc/subagent/subagent.ts
+++ b/apps/desktop/electron/ipc/subagent/subagent.ts
@@ -190,6 +190,30 @@ export function registerSubagentHandlers(): void {
 
 // ── Agent file parsing/serialization ─────────────────────────
 
+function parseEditableAgentModelField(raw: unknown): SubagentAgentFile['model'] | undefined {
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    return trimmed || undefined;
+  }
+
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const prefer = typeof obj.prefer === 'string' ? obj.prefer.trim() : '';
+  if (!prefer) return undefined;
+
+  const fallbacks = Array.isArray(obj.fallbacks)
+    ? obj.fallbacks
+        .filter((entry): entry is string => typeof entry === 'string')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : [];
+
+  return { prefer, fallbacks };
+}
+
 function parseAgentFile(raw: string, fallbackName: string): SubagentAgentFile {
   const fmMatch = raw.match(/```json\s*\n([\s\S]*?)\n```/);
   let fm: Record<string, unknown> = {};
@@ -203,7 +227,7 @@ function parseAgentFile(raw: string, fallbackName: string): SubagentAgentFile {
   return {
     name: (fm.name as string) || fallbackName,
     description: (fm.description as string) || '',
-    model: fm.model as string | undefined,
+    model: parseEditableAgentModelField(fm.model),
     thinking: fm.thinking as string | undefined,
     timeoutMs: fm.timeoutMs as number | undefined,
     tools: Array.isArray(fm.tools) ? fm.tools : undefined,

--- a/apps/desktop/electron/ipc/workspace/profiles.ts
+++ b/apps/desktop/electron/ipc/workspace/profiles.ts
@@ -10,8 +10,11 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import { IpcChannels } from '../../../src/types/ipc';
 import { profileManager } from '../../features/profile/manager';
+import { SERO_AGENT_DIR } from '../../platform/env';
+import { getModelTiers, setModelTiers } from '../../shared/settings/model-tiers';
 
 import type { ProfileInfo } from '../../features/profile/types';
+import type { ModelTierSettings } from '../../../src/types/ipc';
 
 export function registerProfileHandlers(): void {
   /** List all profiles with active flag. */
@@ -49,6 +52,26 @@ export function registerProfileHandlers(): void {
             const destDir = path.join(entry.path, 'agent');
             mkdirSync(destDir, { recursive: true });
             writeFileSync(path.join(destDir, 'auth.json'), content, 'utf8');
+          }
+
+          // Copy model tier settings
+          const srcSettingsPath = path.join(source.path, 'agent', 'settings.json');
+          if (existsSync(srcSettingsPath)) {
+            try {
+              const srcSettingsObj = JSON.parse(readFileSync(srcSettingsPath, 'utf8'));
+              const srcTiers = getModelTiers(srcSettingsObj);
+              if (Object.keys(srcTiers).length > 0) {
+                const destSettingsPath = path.join(entry.path, 'agent', 'settings.json');
+                let destSettings: Record<string, unknown> = {};
+                try {
+                  destSettings = JSON.parse(readFileSync(destSettingsPath, 'utf8'));
+                } catch { /* fresh settings */ }
+                const updated = setModelTiers(destSettings, srcTiers);
+                writeFileSync(destSettingsPath, JSON.stringify(updated, null, 2) + '\n');
+              }
+            } catch {
+              // Non-critical — tiers can be configured later
+            }
           }
         }
       }
@@ -148,6 +171,33 @@ export function registerProfileHandlers(): void {
           return false;
         }
       });
+    },
+  );
+
+  // ── Model Tier Settings ──────────────────────────────────────
+
+  /** Get current model tier settings. */
+  ipcMain.handle(IpcChannels.modelTiers.get, (): ModelTierSettings => {
+    const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      return getModelTiers(settings);
+    } catch {
+      return {};
+    }
+  });
+
+  /** Set model tier settings. */
+  ipcMain.handle(
+    IpcChannels.modelTiers.set,
+    (_e, tiers: ModelTierSettings): void => {
+      const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+      let settings: Record<string, unknown> = {};
+      try {
+        settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      } catch { /* fresh settings */ }
+      const updated = setModelTiers(settings, tiers);
+      writeFileSync(settingsPath, JSON.stringify(updated, null, 2) + '\n');
     },
   );
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -65,12 +65,11 @@ function bootstrapAgentDir(): void {
   if (!existsSync(settingsPath)) {
     const workspacePackages = getWorkspaceAppPaths();
     const defaults = {
-      defaultProvider: 'anthropic',
-      defaultModel: 'claude-opus-4-6',
       defaultThinkingLevel: 'high',
       packages: workspacePackages,
       sero: {
         modelFallbackChain: getDefaultModelFallbackChain(),
+        modelTiers: {},
       },
     };
     writeFileSync(settingsPath, JSON.stringify(defaults, null, 2) + '\n');

--- a/apps/desktop/electron/preload/api.ts
+++ b/apps/desktop/electron/preload/api.ts
@@ -18,6 +18,7 @@ import { collaborationBridge } from './collaboration';
 import { modelsBridge } from './agent/models';
 import { localModelsBridge } from './agent/local-models';
 import { googleBridge, imagegenBridge } from './integrations/google-imagegen';
+import { onboardingBridge, providerDefaultsBridge } from './onboarding';
 import {
   appStateBridge,
   appsBridge,
@@ -279,6 +280,8 @@ export const seroPreloadApi = {
     set: (tiers: ModelTierSettings): Promise<void> =>
       ipcRenderer.invoke(IpcChannels.modelTiers.set, tiers),
   },
+  onboarding: onboardingBridge,
+  providerDefaults: providerDefaultsBridge,
 
   google: googleBridge,
   imagegen: imagegenBridge,

--- a/apps/desktop/electron/preload/api.ts
+++ b/apps/desktop/electron/preload/api.ts
@@ -63,6 +63,7 @@ import type {
   AppRecordingResult,
   CreateGitHubRepoInput,
   CreateGitHubRepoResult,
+  ModelTierSettings,
 } from '../../src/types/ipc';
 import type {
   VcsCheckpoint,
@@ -271,6 +272,13 @@ export const seroPreloadApi = {
 
   models: modelsBridge,
   localModels: localModelsBridge,
+
+  modelTiers: {
+    get: (): Promise<ModelTierSettings> =>
+      ipcRenderer.invoke(IpcChannels.modelTiers.get),
+    set: (tiers: ModelTierSettings): Promise<void> =>
+      ipcRenderer.invoke(IpcChannels.modelTiers.set, tiers),
+  },
 
   google: googleBridge,
   imagegen: imagegenBridge,

--- a/apps/desktop/electron/preload/onboarding.ts
+++ b/apps/desktop/electron/preload/onboarding.ts
@@ -1,0 +1,22 @@
+import { ipcRenderer } from 'electron';
+import { IpcChannels } from '../../src/types/ipc';
+import type {
+  ModelTierSettings,
+  OnboardingState,
+  ProviderModelDefaults,
+  ResolvedProviderDefaultsState,
+} from '../../src/types/ipc';
+
+export const onboardingBridge = {
+  getState: (): Promise<OnboardingState> =>
+    ipcRenderer.invoke(IpcChannels.onboarding.getState),
+  saveTierSelections: (tiers: ModelTierSettings): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.onboarding.saveTierSelections, tiers),
+};
+
+export const providerDefaultsBridge = {
+  get: (): Promise<ResolvedProviderDefaultsState> =>
+    ipcRenderer.invoke(IpcChannels.providerDefaults.get),
+  setGlobalDefaults: (defaults: ProviderModelDefaults): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.providerDefaults.setGlobalDefaults, defaults),
+};

--- a/apps/desktop/electron/shared/auth/provider-catalog.ts
+++ b/apps/desktop/electron/shared/auth/provider-catalog.ts
@@ -1,0 +1,31 @@
+import { getOAuthProviders } from '@mariozechner/pi-ai/oauth';
+
+export interface NamedProvider {
+  id: string;
+  name: string;
+}
+
+/** Providers that accept a plain API key (not OAuth). */
+export const API_KEY_PROVIDERS: NamedProvider[] = [
+  { id: 'anthropic', name: 'Anthropic' },
+  { id: 'openai', name: 'OpenAI' },
+  { id: 'google', name: 'Google (Gemini)' },
+  { id: 'openrouter', name: 'OpenRouter' },
+  { id: 'xai', name: 'xAI' },
+  { id: 'groq', name: 'Groq' },
+  { id: 'cerebras', name: 'Cerebras' },
+  { id: 'mistral', name: 'Mistral' },
+  { id: 'azure-openai-responses', name: 'Azure OpenAI' },
+  { id: 'huggingface', name: 'Hugging Face' },
+  { id: 'vercel-ai-gateway', name: 'Vercel AI Gateway' },
+  { id: 'zai', name: 'ZAI' },
+  { id: 'opencode', name: 'OpenCode' },
+  { id: 'kimi-coding', name: 'Kimi' },
+];
+
+export function getOAuthProviderCatalog(): NamedProvider[] {
+  return getOAuthProviders().map((provider) => ({
+    id: provider.id,
+    name: provider.name,
+  }));
+}

--- a/apps/desktop/electron/shared/infra/shared-infra.ts
+++ b/apps/desktop/electron/shared/infra/shared-infra.ts
@@ -18,9 +18,11 @@ import {
   AuthStorage,
   ModelRegistry,
 } from '@mariozechner/pi-coding-agent';
-import { getModel, type Model, type Api } from '@mariozechner/pi-ai';
+import { type Model, type Api } from '@mariozechner/pi-ai';
 
 import { SERO_AGENT_DIR, SERO_HOME } from '../../platform/env';
+import { getConfiguredModelFallbackChain } from '../settings/model-fallback-chain';
+import { getModelTiers } from '../settings/model-tiers';
 import type { ContainerConfig } from '../../features/container/core/types';
 import { containerManager } from '../../features/container/core/singleton';
 import { buildWorkspaceContainerConfig } from '../../features/container/core/workspace-container-config';
@@ -119,7 +121,7 @@ export interface SharedInfra {
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
   settingsManager: ReturnType<typeof SettingsManager.create>;
-  model: Model<Api>;
+  model: Model<Api> | null;
 }
 
 /** Apply runtime-only settings that need to update live singletons. */
@@ -137,6 +139,39 @@ export function applyRuntimeSettings(
   });
 }
 
+/**
+ * Pick the first available model using tier settings, then fallback chain.
+ * Returns null if no model is available (no auth configured yet).
+ */
+function pickFirstAvailableModel(
+  registry: ModelRegistry,
+  settingsManager: ReturnType<typeof SettingsManager.create>,
+): Model<Api> | null {
+  const available = registry.getAvailable();
+  if (available.length === 0) return null;
+
+  const globalSettings = settingsManager.getGlobalSettings() as Record<string, unknown>;
+
+  // Try HIGH tier model first (most capable, used for main sessions)
+  const tiers = getModelTiers(globalSettings);
+  if (tiers.HIGH) {
+    const match = available.find(
+      (m) => m.provider === tiers.HIGH!.provider && m.id === tiers.HIGH!.modelId,
+    );
+    if (match) return match;
+  }
+
+  // Try fallback chain
+  const chain = getConfiguredModelFallbackChain(globalSettings);
+  for (const candidate of chain) {
+    const match = available.find((m) => m.id === candidate);
+    if (match) return match;
+  }
+
+  // Last resort: first available model
+  return available[0] ?? null;
+}
+
 /** Lazy-init shared infrastructure. Called once, then cached. */
 export async function ensureInfra(): Promise<SharedInfra> {
   if (!_authStorage) {
@@ -150,15 +185,14 @@ export async function ensureInfra(): Promise<SharedInfra> {
     if (!_settingsManager.getDefaultThinkingLevel()) {
       _settingsManager.setDefaultThinkingLevel('high');
     }
-    _model = getModel('anthropic', 'claude-opus-4-6');
-    if (!_model) throw new Error('Model claude-opus-4-6 not found in registry');
+    _model = pickFirstAvailableModel(_modelRegistry, _settingsManager);
   }
 
   const infra = {
     authStorage: _authStorage,
     modelRegistry: _modelRegistry!,
     settingsManager: _settingsManager!,
-    model: _model!,
+    model: _model,
   };
 
   // Wire subagent manager deps lazily (avoids circular imports)

--- a/apps/desktop/electron/shared/settings/model-fallback-chain.ts
+++ b/apps/desktop/electron/shared/settings/model-fallback-chain.ts
@@ -5,6 +5,8 @@
  * sensible default chain if the setting is missing so users can override it.
  */
 
+import { getSeroSettings } from './settings-helpers';
+
 const DEFAULT_FALLBACK_CHAIN = [
   'gpt-5.4',
   'gpt-4.1-mini',
@@ -30,14 +32,6 @@ function normalizeFallbackChain(value: unknown): string[] {
     result.push(trimmed);
   }
   return result;
-}
-
-function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
-  const raw = settings.sero;
-  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-    return { ...(raw as Record<string, unknown>) };
-  }
-  return {};
 }
 
 export function getDefaultModelFallbackChain(): string[] {

--- a/apps/desktop/electron/shared/settings/model-fallback-chain.ts
+++ b/apps/desktop/electron/shared/settings/model-fallback-chain.ts
@@ -6,13 +6,13 @@
  */
 
 const DEFAULT_FALLBACK_CHAIN = [
+  'gpt-5.4',
+  'gpt-4.1-mini',
   'claude-sonnet-4-6',
   'claude-haiku-4-5',
-  'gpt-5.4',
-  'gpt-5',
-  'gemini-3-flash-preview',
-  'gemini-3-flash',
+  'gemini-2.5-pro',
   'gemini-2.5-flash',
+  'gemini-3-flash',
 ] as const;
 
 function normalizeFallbackChain(value: unknown): string[] {

--- a/apps/desktop/electron/shared/settings/model-tiers.ts
+++ b/apps/desktop/electron/shared/settings/model-tiers.ts
@@ -1,0 +1,61 @@
+/**
+ * Model tier settings — read/write helpers for LOW/MED/HIGH tier
+ * configuration in settings.json.
+ *
+ * Tiers are stored under `sero.modelTiers` in the global settings object.
+ */
+
+import type { ModelTier, ModelTierEntry, ModelTierSettings } from '../../../src/types/ipc';
+
+export const MODEL_TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
+
+function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const raw = settings.sero;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** Read the model tier settings from a settings object. */
+export function getModelTiers(settings: Record<string, unknown>): ModelTierSettings {
+  const sero = getSeroSettings(settings);
+  const raw = sero.modelTiers;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
+  const result: ModelTierSettings = {};
+  for (const tier of MODEL_TIERS) {
+    const entry = (raw as Record<string, unknown>)[tier];
+    if (
+      entry &&
+      typeof entry === 'object' &&
+      !Array.isArray(entry) &&
+      typeof (entry as Record<string, unknown>).provider === 'string' &&
+      typeof (entry as Record<string, unknown>).modelId === 'string'
+    ) {
+      result[tier] = entry as ModelTierEntry;
+    }
+  }
+  return result;
+}
+
+/** Write model tier settings into a settings object (returns new object). */
+export function setModelTiers(
+  settings: Record<string, unknown>,
+  tiers: ModelTierSettings,
+): Record<string, unknown> {
+  const sero = getSeroSettings(settings);
+  return {
+    ...settings,
+    sero: {
+      ...sero,
+      modelTiers: tiers,
+    },
+  };
+}
+
+/** Check if any tier is configured. */
+export function hasModelTiers(settings: Record<string, unknown>): boolean {
+  const tiers = getModelTiers(settings);
+  return Object.keys(tiers).length > 0;
+}

--- a/apps/desktop/electron/shared/settings/model-tiers.ts
+++ b/apps/desktop/electron/shared/settings/model-tiers.ts
@@ -6,16 +6,9 @@
  */
 
 import type { ModelTier, ModelTierEntry, ModelTierSettings } from '../../../src/types/ipc';
+import { getSeroSettings } from './settings-helpers';
 
 export const MODEL_TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
-
-function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
-  const raw = settings.sero;
-  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-    return raw as Record<string, unknown>;
-  }
-  return {};
-}
 
 /** Read the model tier settings from a settings object. */
 export function getModelTiers(settings: Record<string, unknown>): ModelTierSettings {

--- a/apps/desktop/electron/shared/settings/model-tiers.ts
+++ b/apps/desktop/electron/shared/settings/model-tiers.ts
@@ -53,9 +53,3 @@ export function setModelTiers(
     },
   };
 }
-
-/** Check if any tier is configured. */
-export function hasModelTiers(settings: Record<string, unknown>): boolean {
-  const tiers = getModelTiers(settings);
-  return Object.keys(tiers).length > 0;
-}

--- a/apps/desktop/electron/shared/settings/provider-model-defaults.ts
+++ b/apps/desktop/electron/shared/settings/provider-model-defaults.ts
@@ -7,6 +7,7 @@ import type {
   ResolvedProviderDefaultsState,
 } from '../../../src/types/ipc';
 import { SERO_FIXED_ROOT } from '../../platform/env';
+import { getSeroSettings } from './settings-helpers';
 
 const TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
 const GLOBAL_PROVIDER_DEFAULTS_PATH = path.join(SERO_FIXED_ROOT, 'provider-model-defaults.json');
@@ -62,14 +63,6 @@ function normalizeProviderDefaults(value: unknown): ProviderModelDefaults {
     result[normalizedProviderId] = normalizedTierDefaults;
   }
   return result;
-}
-
-function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
-  const raw = settings.sero;
-  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-    return raw as Record<string, unknown>;
-  }
-  return {};
 }
 
 function mergeProviderDefaults(...defaultsList: Array<ProviderModelDefaults | undefined>): ProviderModelDefaults {

--- a/apps/desktop/electron/shared/settings/provider-model-defaults.ts
+++ b/apps/desktop/electron/shared/settings/provider-model-defaults.ts
@@ -1,0 +1,142 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import path from 'path';
+import type {
+  ModelTier,
+  ProviderTierDefaults,
+  ProviderModelDefaults,
+  ResolvedProviderDefaultsState,
+} from '../../../src/types/ipc';
+import { SERO_FIXED_ROOT } from '../../platform/env';
+
+const TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
+const GLOBAL_PROVIDER_DEFAULTS_PATH = path.join(SERO_FIXED_ROOT, 'provider-model-defaults.json');
+
+const BUILTIN_PROVIDER_MODEL_DEFAULTS: ProviderModelDefaults = {
+  openai: {
+    LOW: 'gpt-4.1-mini',
+    MED: 'gpt-5.4',
+    HIGH: 'gpt-5.4',
+  },
+  openrouter: {
+    LOW: 'gpt-4.1-mini',
+    MED: 'gpt-5.4',
+    HIGH: 'gpt-5.4',
+  },
+  google: {
+    LOW: 'gemini-2.5-flash',
+    MED: 'gemini-2.5-pro',
+    HIGH: 'gemini-2.5-pro',
+  },
+  anthropic: {
+    LOW: 'claude-haiku-4-5',
+    MED: 'claude-sonnet-4-6',
+    HIGH: 'claude-sonnet-4-6',
+  },
+};
+
+function normalizeTierDefaults(value: unknown): ProviderTierDefaults {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+  const record = value as Record<string, unknown>;
+  const result: ProviderTierDefaults = {};
+  for (const tier of TIERS) {
+    const modelId = record[tier];
+    if (typeof modelId !== 'string') continue;
+    const trimmed = modelId.trim();
+    if (!trimmed) continue;
+    result[tier] = trimmed;
+  }
+  return result;
+}
+
+function normalizeProviderDefaults(value: unknown): ProviderModelDefaults {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+
+  const record = value as Record<string, unknown>;
+  const result: ProviderModelDefaults = {};
+  for (const [providerId, tierDefaults] of Object.entries(record)) {
+    const normalizedProviderId = providerId.trim();
+    if (!normalizedProviderId) continue;
+    const normalizedTierDefaults = normalizeTierDefaults(tierDefaults);
+    if (Object.keys(normalizedTierDefaults).length === 0) continue;
+    result[normalizedProviderId] = normalizedTierDefaults;
+  }
+  return result;
+}
+
+function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const raw = settings.sero;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+function mergeProviderDefaults(...defaultsList: Array<ProviderModelDefaults | undefined>): ProviderModelDefaults {
+  const result: ProviderModelDefaults = {};
+
+  for (const defaults of defaultsList) {
+    if (!defaults) continue;
+    for (const [providerId, tierDefaults] of Object.entries(defaults)) {
+      const current = result[providerId] ?? {};
+      result[providerId] = {
+        ...current,
+        ...tierDefaults,
+      };
+    }
+  }
+
+  return result;
+}
+
+export function getGlobalProviderDefaultsPath(): string {
+  return GLOBAL_PROVIDER_DEFAULTS_PATH;
+}
+
+export function getBuiltInProviderModelDefaults(): ProviderModelDefaults {
+  return JSON.parse(JSON.stringify(BUILTIN_PROVIDER_MODEL_DEFAULTS)) as ProviderModelDefaults;
+}
+
+export function readGlobalProviderModelDefaults(): ProviderModelDefaults {
+  try {
+    if (!existsSync(GLOBAL_PROVIDER_DEFAULTS_PATH)) return {};
+    const raw = readFileSync(GLOBAL_PROVIDER_DEFAULTS_PATH, 'utf8');
+    return normalizeProviderDefaults(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
+
+export function writeGlobalProviderModelDefaults(defaults: ProviderModelDefaults): void {
+  mkdirSync(path.dirname(GLOBAL_PROVIDER_DEFAULTS_PATH), { recursive: true });
+  const normalized = normalizeProviderDefaults(defaults);
+  writeFileSync(
+    GLOBAL_PROVIDER_DEFAULTS_PATH,
+    JSON.stringify(normalized, null, 2) + '\n',
+    'utf8',
+  );
+}
+
+export function getProfileProviderModelDefaultsOverrides(
+  settings: Record<string, unknown>,
+): ProviderModelDefaults | undefined {
+  const sero = getSeroSettings(settings);
+  const overrides = normalizeProviderDefaults(sero.providerModelDefaultsOverrides);
+  return Object.keys(overrides).length > 0 ? overrides : undefined;
+}
+
+export function resolveProviderDefaultsState(
+  settings: Record<string, unknown>,
+): ResolvedProviderDefaultsState {
+  const builtInDefaults = getBuiltInProviderModelDefaults();
+  const globalDefaults = readGlobalProviderModelDefaults();
+  const profileOverrides = getProfileProviderModelDefaultsOverrides(settings);
+  const effectiveDefaults = mergeProviderDefaults(builtInDefaults, globalDefaults, profileOverrides);
+
+  return {
+    builtInDefaults,
+    globalDefaults,
+    profileOverrides,
+    effectiveDefaults,
+  };
+}

--- a/apps/desktop/electron/shared/settings/resolve-tier-model.ts
+++ b/apps/desktop/electron/shared/settings/resolve-tier-model.ts
@@ -1,0 +1,112 @@
+/**
+ * Tier-aware model resolution.
+ *
+ * Resolves a structured model field (with `prefer` tier alias + `fallbacks`)
+ * to a concrete available model. Used by the subagent resolver and adhoc agent.
+ *
+ * Resolution order:
+ *   1. If `prefer` is a tier alias (LOW/MED/HIGH) → user's chosen model for that tier
+ *   2. If `prefer` is a model ID → try that model directly
+ *   3. Iterate `fallbacks` → use first available
+ *   4. Return null → caller should prompt user to pick
+ */
+
+import type { ModelTier, ModelTierSettings } from '../../../src/types/ipc';
+import { MODEL_TIERS } from './model-tiers';
+
+/** The structured model field from agent frontmatter. */
+export interface StructuredModelField {
+  prefer: string;
+  fallbacks: string[];
+}
+
+/** A model available in the registry (provider + id). */
+export interface AvailableModel {
+  provider: string;
+  id: string;
+}
+
+/** Result of model resolution. */
+export interface ResolvedModel {
+  provider: string;
+  modelId: string;
+}
+
+function isTierAlias(value: string): value is ModelTier {
+  return MODEL_TIERS.includes(value as ModelTier);
+}
+
+function findModelById(
+  available: AvailableModel[],
+  modelId: string,
+): AvailableModel | undefined {
+  const lowerId = modelId.toLowerCase();
+  return available.find((m) => m.id.toLowerCase() === lowerId);
+}
+
+/**
+ * Parse a model field from agent frontmatter.
+ *
+ * Accepts either:
+ * - A plain string (legacy): `"claude-sonnet-4-6"` → { prefer: "claude-sonnet-4-6", fallbacks: [] }
+ * - A structured object: `{ prefer: "MED", fallbacks: ["gpt-5.4", ...] }`
+ */
+export function parseModelField(
+  raw: unknown,
+): StructuredModelField | null {
+  if (typeof raw === 'string' && raw.trim()) {
+    return { prefer: raw.trim(), fallbacks: [] };
+  }
+
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    const prefer = typeof obj.prefer === 'string' ? obj.prefer.trim() : '';
+    if (!prefer) return null;
+
+    const fallbacks: string[] = [];
+    if (Array.isArray(obj.fallbacks)) {
+      for (const f of obj.fallbacks) {
+        if (typeof f === 'string' && f.trim()) fallbacks.push(f.trim());
+      }
+    }
+    return { prefer, fallbacks };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a structured model field to a concrete available model.
+ *
+ * Returns null if no model could be resolved (caller should prompt user).
+ */
+export function resolveTierModel(
+  field: StructuredModelField,
+  tierSettings: ModelTierSettings,
+  available: AvailableModel[],
+): ResolvedModel | null {
+  if (available.length === 0) return null;
+
+  // 1. Resolve `prefer`
+  if (isTierAlias(field.prefer)) {
+    const tierEntry = tierSettings[field.prefer];
+    if (tierEntry) {
+      const match = available.find(
+        (m) => m.provider === tierEntry.provider && m.id === tierEntry.modelId,
+      );
+      if (match) return { provider: match.provider, modelId: match.id };
+    }
+  } else {
+    // Treat as a model ID
+    const match = findModelById(available, field.prefer);
+    if (match) return { provider: match.provider, modelId: match.id };
+  }
+
+  // 2. Walk fallbacks
+  for (const fallback of field.fallbacks) {
+    const match = findModelById(available, fallback);
+    if (match) return { provider: match.provider, modelId: match.id };
+  }
+
+  return null;
+}

--- a/apps/desktop/electron/shared/settings/settings-helpers.ts
+++ b/apps/desktop/electron/shared/settings/settings-helpers.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { SERO_AGENT_DIR } from '../../platform/env';
+
+/** Extract the `sero` namespace from a parsed settings object. */
+export function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const raw = settings.sero;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** Read and parse settings.json from the active agent directory. */
+export function readSettings(): Record<string, unknown> {
+  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+  try {
+    return JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}

--- a/apps/desktop/src/components/layout/AuthLoginDialog.tsx
+++ b/apps/desktop/src/components/layout/AuthLoginDialog.tsx
@@ -47,11 +47,19 @@ interface Props {
   onComplete?: () => void;
   /** Start in logout mode. */
   mode?: 'login' | 'logout';
+  /** Optionally highlight a provider that needs attention. */
+  preferredProviderId?: string | null;
 }
 
 // ── Component ────────────────────────────────────────────────
 
-export function AuthLoginDialog({ open, onOpenChange, onComplete, mode = 'login' }: Props) {
+export function AuthLoginDialog({
+  open,
+  onOpenChange,
+  onComplete,
+  mode = 'login',
+  preferredProviderId = null,
+}: Props) {
   const [oauthProviders, setOauthProviders] = useState<OAuthProviderInfo[]>([]);
   const [apiKeyProviders, setApiKeyProviders] = useState<ApiKeyProviderInfo[]>([]);
   const [phase, setPhase] = useState<DialogPhase>('providers');
@@ -257,6 +265,7 @@ export function AuthLoginDialog({ open, onOpenChange, onComplete, mode = 'login'
               oauthProviders={oauthProviders}
               apiKeyProviders={apiKeyProviders}
               mode={mode}
+              preferredProviderId={preferredProviderId}
               onOAuthLogin={handleOAuthLogin}
               onApiKeyStart={handleApiKeyStart}
               onApiKeyRemove={handleApiKeyRemove}

--- a/apps/desktop/src/components/layout/AuthLoginViews.tsx
+++ b/apps/desktop/src/components/layout/AuthLoginViews.tsx
@@ -24,10 +24,23 @@ import type { OAuthProviderInfo, ApiKeyProviderInfo } from '@/types/ipc';
 
 // ── Provider list ─────────────────────────────────────────────
 
+function sortProvidersByPreference<T extends { id: string; name: string }>(
+  providers: T[],
+  preferredProviderId?: string | null,
+): T[] {
+  return [...providers].sort((a, b) => {
+    const aPreferred = preferredProviderId && a.id === preferredProviderId ? 1 : 0;
+    const bPreferred = preferredProviderId && b.id === preferredProviderId ? 1 : 0;
+    if (aPreferred !== bPreferred) return bPreferred - aPreferred;
+    return a.name.localeCompare(b.name);
+  });
+}
+
 export function ProviderListView({
   oauthProviders,
   apiKeyProviders,
   mode,
+  preferredProviderId,
   onOAuthLogin,
   onApiKeyStart,
   onApiKeyRemove,
@@ -36,6 +49,7 @@ export function ProviderListView({
   oauthProviders: OAuthProviderInfo[];
   apiKeyProviders: ApiKeyProviderInfo[];
   mode: 'login' | 'logout';
+  preferredProviderId?: string | null;
   onOAuthLogin: (id: string) => void;
   onApiKeyStart: (id: string, name: string) => void;
   onApiKeyRemove: (id: string) => void;
@@ -53,7 +67,7 @@ export function ProviderListView({
             OAuth
           </h4>
           <div className="space-y-0.5">
-            {oauthProviders.map((p) => (
+            {sortProvidersByPreference(oauthProviders, preferredProviderId).map((p) => (
               <button
                 key={p.id}
                 onClick={() => {
@@ -69,6 +83,7 @@ export function ProviderListView({
                 <div className="flex items-center gap-2.5">
                   <LogIn className="size-4 text-muted-foreground group-hover:text-foreground transition-colors" />
                   <span>{p.name}</span>
+                  {preferredProviderId === p.id ? <PreferredProviderBadge /> : null}
                 </div>
                 {p.isLoggedIn && <AuthBadge />}
               </button>
@@ -91,7 +106,7 @@ export function ProviderListView({
             API Key
           </h4>
           <div className="space-y-0.5">
-            {apiKeyProviders.map((p) => (
+            {sortProvidersByPreference(apiKeyProviders, preferredProviderId).map((p) => (
               <div
                 key={p.id}
                 className="flex w-full items-center justify-between rounded-md px-3 py-2
@@ -109,6 +124,7 @@ export function ProviderListView({
                 >
                   <Key className="size-4 text-muted-foreground group-hover:text-foreground transition-colors shrink-0" />
                   <span className="truncate">{p.name}</span>
+                  {preferredProviderId === p.id ? <PreferredProviderBadge /> : null}
                 </button>
                 <div className="flex items-center gap-1.5 shrink-0">
                   {p.hasKey && (
@@ -221,6 +237,14 @@ function AnthropicWarningBanner({
 }
 
 // ── Badges ────────────────────────────────────────────────────
+
+function PreferredProviderBadge() {
+  return (
+    <span className="rounded-full border border-[var(--status-warning)]/30 px-1.5 py-0.5 text-[10px] text-[var(--status-warning)]">
+      reconnect
+    </span>
+  );
+}
 
 function AuthBadge() {
   return (

--- a/apps/desktop/src/components/layout/AuthLoginViews.tsx
+++ b/apps/desktop/src/components/layout/AuthLoginViews.tsx
@@ -12,6 +12,7 @@ import {
   EyeOff,
   Key,
   Loader2,
+  TriangleAlert,
   LogIn,
   LogOut,
   Trash2,
@@ -41,6 +42,7 @@ export function ProviderListView({
   onLogout: (id: string) => void;
 }) {
   const isLogin = mode === 'login';
+  const [anthropicWarning, setAnthropicWarning] = useState<string | null>(null);
 
   if (isLogin) {
     return (
@@ -54,7 +56,13 @@ export function ProviderListView({
             {oauthProviders.map((p) => (
               <button
                 key={p.id}
-                onClick={() => onOAuthLogin(p.id)}
+                onClick={() => {
+                  if (p.id === 'anthropic' && !anthropicWarning) {
+                    setAnthropicWarning(p.id);
+                    return;
+                  }
+                  onOAuthLogin(p.id);
+                }}
                 className="flex w-full items-center justify-between rounded-md px-3 py-2
                            text-sm hover:bg-accent transition-colors text-left group"
               >
@@ -66,6 +74,15 @@ export function ProviderListView({
               </button>
             ))}
           </div>
+          {anthropicWarning === 'anthropic' && (
+            <AnthropicWarningBanner
+              onContinue={() => {
+                setAnthropicWarning(null);
+                onOAuthLogin('anthropic');
+              }}
+              onCancel={() => setAnthropicWarning(null)}
+            />
+          )}
         </div>
 
         {/* API Key section */}
@@ -81,7 +98,13 @@ export function ProviderListView({
                            text-sm hover:bg-accent transition-colors group"
               >
                 <button
-                  onClick={() => onApiKeyStart(p.id, p.name)}
+                  onClick={() => {
+                    if (p.id === 'anthropic' && !anthropicWarning) {
+                      setAnthropicWarning('anthropic-apikey');
+                      return;
+                    }
+                    onApiKeyStart(p.id, p.name);
+                  }}
                   className="flex items-center gap-2.5 text-left flex-1 min-w-0"
                 >
                   <Key className="size-4 text-muted-foreground group-hover:text-foreground transition-colors shrink-0" />
@@ -109,6 +132,15 @@ export function ProviderListView({
               </div>
             ))}
           </div>
+          {anthropicWarning === 'anthropic-apikey' && (
+            <AnthropicWarningBanner
+              onContinue={() => {
+                setAnthropicWarning(null);
+                onApiKeyStart('anthropic', 'Anthropic');
+              }}
+              onCancel={() => setAnthropicWarning(null)}
+            />
+          )}
         </div>
       </div>
     );
@@ -148,6 +180,42 @@ export function ProviderListView({
           </span>
         </button>
       ))}
+    </div>
+  );
+}
+
+// ── Anthropic warning banner ──────────────────────────────────
+
+function AnthropicWarningBanner({
+  onContinue,
+  onCancel,
+}: {
+  onContinue: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="mx-1 flex items-start gap-2 rounded-md border border-[var(--status-warning)]/30 bg-[var(--status-warning)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
+      <TriangleAlert className="mt-0.5 size-3.5 shrink-0 text-[var(--status-warning)]" />
+      <div className="space-y-1.5">
+        <p>
+          Anthropic may restrict third-party use of consumer subscriptions.
+          We recommend using an API key with your own billing account.
+        </p>
+        <div className="flex gap-2">
+          <button
+            onClick={onContinue}
+            className="text-xs font-medium text-[var(--text-primary)] hover:underline"
+          >
+            Continue anyway
+          </button>
+          <button
+            onClick={onCancel}
+            className="text-xs text-[var(--text-tertiary)] hover:underline"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/ChatPanel.tsx
@@ -26,7 +26,7 @@ import { useEditorBridge } from '@/stores/editor-bridge';
 import { useUserFeedbackInit } from '@/hooks/useUserFeedbackInit';
 import { createFilePathClickHandler } from './ClickableFilePath';
 import { PendingQuestionCard } from './PendingQuestionCard';
-import { QuestionnaireNotice } from './QuestionnaireNotice';
+import { QuestionnaireNotice, getFeedbackToolGroupDisposition } from './QuestionnaireNotice';
 import { EmptyState } from './ChatPanelHelpers';
 import { CollaborationDetails } from './CollaborationResponse';
 import { CollaborationActivityPanel } from './CollaborationActivityPanel';
@@ -170,17 +170,18 @@ export function ChatPanel() {
                 const isLast = index === groupedItems.length - 1;
                 const isFinalized = !isLast || !isStreaming;
 
-                // Replace a running questionnaire/interview tool call with clickable notice
-                const feedbackToolName = item.tools[0]?.toolName;
-                const isRunningFeedbackForm =
-                  item.tools.length === 1 &&
-                  (feedbackToolName === 'questionnaire' ||
-                    feedbackToolName === 'interview') &&
-                  (item.tools[0].state === 'pending' ||
-                    item.tools[0].state === 'running');
-
-                if (isRunningFeedbackForm) {
-                  return <QuestionnaireNotice key={item.id} tools={item.tools} />;
+                const feedbackDisposition = getFeedbackToolGroupDisposition(item.tools);
+                if (feedbackDisposition === 'hide') {
+                  return null;
+                }
+                if (feedbackDisposition === 'notice') {
+                  return (
+                    <QuestionnaireNotice
+                      key={item.id}
+                      tools={item.tools}
+                      sessionLabel={sessionLabel ?? null}
+                    />
+                  );
                 }
 
                 return (

--- a/apps/desktop/src/components/layout/QuestionnaireNotice.test.tsx
+++ b/apps/desktop/src/components/layout/QuestionnaireNotice.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatToolCallMessage } from '@/types/ipc';
+import { getFeedbackToolGroupDisposition } from './QuestionnaireNotice';
+
+function makeTool(overrides: Partial<ChatToolCallMessage>): ChatToolCallMessage {
+  return {
+    type: 'tool',
+    id: 'tool-1',
+    toolCallId: 'call-1',
+    toolName: 'sero-cli',
+    input: { command: 'sero questionnaire []' },
+    output: null,
+    isError: false,
+    state: 'completed',
+    ...overrides,
+  };
+}
+
+describe('getFeedbackToolGroupDisposition', () => {
+  it('hides preparation-only help commands', () => {
+    const disposition = getFeedbackToolGroupDisposition([
+      makeTool({ input: { command: 'sero help questionnaire' } }),
+    ]);
+
+    expect(disposition).toBe('hide');
+  });
+
+  it('shows a notice for bridged questionnaire commands', () => {
+    const disposition = getFeedbackToolGroupDisposition([
+      makeTool({ input: { command: 'sero questionnaire [{"id":"q1"}]' }, state: 'running' }),
+    ]);
+
+    expect(disposition).toBe('notice');
+  });
+
+  it('shows a notice for direct interview tools', () => {
+    const disposition = getFeedbackToolGroupDisposition([
+      makeTool({ toolName: 'interview', input: { questions: [] } }),
+    ]);
+
+    expect(disposition).toBe('notice');
+  });
+});

--- a/apps/desktop/src/components/layout/QuestionnaireNotice.tsx
+++ b/apps/desktop/src/components/layout/QuestionnaireNotice.tsx
@@ -1,81 +1,228 @@
 /**
- * QuestionnaireNotice — replaces the ToolCallGroup rendering for a running
- * questionnaire or interview tool call. Clickable to switch to the User Feedback app.
- *
- * Rendered inline in the conversation where the tool call would normally appear.
- * Once the tool completes, ChatPanel falls back to the standard ToolCallGroup.
+ * QuestionnaireNotice — friendly inline replacement for questionnaire/interview
+ * related tool calls. Used for both direct tool calls and bridged `sero-cli`
+ * commands such as `sero questionnaire ...` and `sero help questionnaire`.
  */
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { motion } from 'motion/react';
-import { ChevronRight, X } from 'lucide-react';
+import { CheckCircle2, ChevronRight, Loader2, X } from 'lucide-react';
 import { useUserFeedbackStore } from '@/stores/user-feedback-store';
 import type { ChatToolCallMessage } from '@/types/ipc';
 
+type FeedbackKind = 'questionnaire' | 'interview';
+type FeedbackNoticeMode = 'preparing' | 'active' | 'completed';
+
 interface Props {
   tools: ChatToolCallMessage[];
+  sessionLabel?: string | null;
 }
 
-export function QuestionnaireNotice({ tools }: Props) {
-  const toolName = tools[0]?.toolName as 'questionnaire' | 'interview' | undefined;
-  const isInterview = toolName === 'interview';
-  const label = isInterview ? 'interview' : 'questionnaire';
+interface ToolClassification {
+  kind: FeedbackKind;
+  mode: 'preparing' | 'interactive';
+}
 
-  const cancel = useUserFeedbackStore((s) => s.cancel);
-  const openFeedbackApp = useUserFeedbackStore((s) => s.openFeedbackApp);
-  const pending = useUserFeedbackStore(
-    (s) => s.getPending(isInterview ? 'interview' : 'questionnaire'),
-  );
+function getBridgedCommand(tool: ChatToolCallMessage): string | null {
+  const command = tool.input.command;
+  if (tool.toolName !== 'sero-cli' || typeof command !== 'string') return null;
+  const firstLine = command
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return firstLine ?? null;
+}
 
-  // Derive question count from tool input with validation
-  const rawInput = tools[0]?.input;
+function getCommandTokens(command: string): string[] {
+  const tokens = command.split(/\s+/).filter(Boolean);
+  if (tokens[0] === 'sero') tokens.shift();
+  return tokens;
+}
+
+function classifyTool(tool: ChatToolCallMessage): ToolClassification | null {
+  if (tool.toolName === 'questionnaire' || tool.toolName === 'interview') {
+    return { kind: tool.toolName, mode: 'interactive' };
+  }
+
+  const bridgedCommand = getBridgedCommand(tool);
+  if (!bridgedCommand) return null;
+
+  const tokens = getCommandTokens(bridgedCommand);
+  const first = tokens[0];
+  const second = tokens[1];
+
+  if (first === 'questionnaire' || first === 'interview') {
+    return { kind: first, mode: 'interactive' };
+  }
+
+  if (first === 'help' && (second === 'questionnaire' || second === 'interview')) {
+    return { kind: second, mode: 'preparing' };
+  }
+
+  return null;
+}
+
+export function getFeedbackToolGroupDisposition(
+  tools: ChatToolCallMessage[],
+): 'hide' | 'notice' | null {
+  const classification = pickPreferredClassification(tools);
+  if (!classification) return null;
+  return classification.mode === 'preparing' ? 'hide' : 'notice';
+}
+
+function pickPreferredClassification(tools: ChatToolCallMessage[]): ToolClassification | null {
+  let preparing: ToolClassification | null = null;
+
+  for (const tool of tools) {
+    const classification = classifyTool(tool);
+    if (!classification) continue;
+    if (classification.mode === 'interactive') return classification;
+    if (!preparing) preparing = classification;
+  }
+
+  return preparing;
+}
+
+function getQuestionCount(tools: ChatToolCallMessage[]): number {
+  const firstInteractiveTool = tools.find((tool) => {
+    const classification = classifyTool(tool);
+    return classification?.mode === 'interactive';
+  });
+  if (!firstInteractiveTool) return 0;
+
+  const rawInput = firstInteractiveTool.input;
   const questionsArr = rawInput && typeof rawInput === 'object' && 'questions' in rawInput
     ? (rawInput as { questions: unknown }).questions
     : undefined;
-  const count = Array.isArray(questionsArr) ? questionsArr.length : 0;
+  return Array.isArray(questionsArr) ? questionsArr.length : 0;
+}
+
+function getMode(
+  tools: ChatToolCallMessage[],
+  hasPending: boolean,
+  classification: ToolClassification,
+): FeedbackNoticeMode {
+  if (hasPending) return 'active';
+
+  const matchingTools = tools.filter((tool) => {
+    const next = classifyTool(tool);
+    return next?.kind === classification.kind && next.mode === classification.mode;
+  });
+
+  const hasRunningMatchingTool = matchingTools.some(
+    (tool) => tool.state === 'pending' || tool.state === 'running',
+  );
+
+  if (classification.mode === 'preparing') {
+    return hasRunningMatchingTool ? 'preparing' : 'completed';
+  }
+
+  return hasRunningMatchingTool ? 'active' : 'completed';
+}
+
+function getPrimaryLabel(kind: FeedbackKind, isOnboarding: boolean): string {
+  if (isOnboarding && kind === 'questionnaire') return 'Setup questions';
+  return kind === 'interview' ? 'Interview' : 'Questions';
+}
+
+function getSecondaryLabel(mode: FeedbackNoticeMode, kind: FeedbackKind): string {
+  if (mode === 'preparing') return 'Preparing…';
+  if (mode === 'completed') return 'Completed';
+  return kind === 'interview' ? 'Open in User Feedback' : 'Continue in User Feedback';
+}
+
+export function QuestionnaireNotice({ tools, sessionLabel = null }: Props) {
+  const classification = useMemo(() => pickPreferredClassification(tools), [tools]);
+  const isOnboarding = sessionLabel === 'Welcome';
+
+  const pendingQuestionnaire = useUserFeedbackStore((store) => store.getPending('questionnaire'));
+  const pendingInterview = useUserFeedbackStore((store) => store.getPending('interview'));
+  const cancel = useUserFeedbackStore((store) => store.cancel);
+  const openFeedbackApp = useUserFeedbackStore((store) => store.openFeedbackApp);
+
+  const pending = classification?.kind === 'interview' ? pendingInterview : pendingQuestionnaire;
+  const count = pending?.questions.length ?? getQuestionCount(tools);
+
+  if (!classification) return null;
+
+  const mode = getMode(tools, Boolean(pending), classification);
+  const label = getPrimaryLabel(classification.kind, isOnboarding);
+  const secondary = getSecondaryLabel(mode, classification.kind);
+  const clickable = mode === 'active' && Boolean(pending);
 
   const handleClick = useCallback(() => {
+    if (!clickable) return;
     openFeedbackApp();
-  }, [openFeedbackApp]);
+  }, [clickable, openFeedbackApp]);
 
   const handleCancel = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (pending) cancel(pending.id);
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      if (pending) {
+        void cancel(pending.id);
+      }
     },
-    [pending, cancel],
+    [cancel, pending],
   );
 
   return (
     <motion.div
-      role="button"
-      tabIndex={0}
-      aria-label={`Open ${label}${count > 0 ? ` with ${count} question${count !== 1 ? 's' : ''}` : ''} in User Feedback app`}
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      aria-label={clickable ? `${label} — ${secondary}` : label}
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2 }}
       onClick={handleClick}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(); } }}
-      className="cursor-pointer overflow-hidden rounded-lg border border-[var(--status-info-border)] bg-[var(--status-info-faint)] transition-colors hover:bg-[var(--status-info-muted)]"
+      onKeyDown={(event) => {
+        if (!clickable) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          handleClick();
+        }
+      }}
+      className={[
+        'overflow-hidden rounded-lg border px-3 py-2',
+        'transition-colors',
+        clickable
+          ? 'cursor-pointer border-[var(--status-info-border)] bg-[var(--status-info-faint)] hover:bg-[var(--status-info-muted)]'
+          : 'border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50',
+      ].join(' ')}
     >
-      <div className="flex items-center gap-2.5 px-3 py-2">
+      <div className="flex items-center gap-2.5">
         <ChevronRight className="size-3.5 text-[var(--text-muted)]" />
-        <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-[var(--status-info)]" />
-        <span className="flex-1 text-xs font-medium text-[var(--text-secondary)]">
-          {label}{count > 0 ? ` (${count} question${count !== 1 ? 's' : ''})` : ''}
-          {' — switch to '}
-          <strong className="text-[var(--text-primary)]">User Feedback</strong>
-        </span>
-        {pending && (
+        {mode === 'completed' ? (
+          <CheckCircle2 className="size-3.5 shrink-0 text-[var(--status-success)]" />
+        ) : mode === 'preparing' ? (
+          <Loader2 className="size-3.5 shrink-0 animate-spin text-[var(--text-muted)]" />
+        ) : (
+          <span className="size-1.5 shrink-0 animate-pulse rounded-full bg-[var(--status-info)]" />
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate text-xs font-medium text-[var(--text-primary)]">
+              {label}
+            </span>
+            {count > 0 ? (
+              <span className="shrink-0 rounded-full bg-[var(--bg-surface)] px-1.5 py-0.5 text-[10px] text-[var(--text-muted)]">
+                {count}
+              </span>
+            ) : null}
+          </div>
+          <p className="truncate text-[11px] text-[var(--text-secondary)]">{secondary}</p>
+        </div>
+
+        {clickable && pending ? (
           <button
             onClick={handleCancel}
-            aria-label={`Cancel ${label}`}
+            aria-label={`Cancel ${label.toLowerCase()}`}
             className="rounded p-0.5 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-            title={`Cancel ${label}`}
+            title={`Cancel ${label.toLowerCase()}`}
           >
             <X className="size-3.5" />
           </button>
-        )}
+        ) : null}
       </div>
     </motion.div>
   );

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -194,7 +194,7 @@ export function OnboardingWizard() {
               ?? refreshedState.recommendation.tiers.LOW?.provider
               ?? null;
 
-            const failedName = getDisplayProviderName(onboardingState, failedProvider);
+            const failedName = getDisplayProviderName(refreshedState, failedProvider);
             const nextName = getDisplayProviderName(refreshedState, nextProvider);
             const canAutoRetry = !failedProvider || !nextProvider || failedProvider !== nextProvider;
 

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -157,14 +157,14 @@ export function OnboardingWizard() {
       console.error('[onboarding] Memory prompt failed:', msg);
 
       if (isAuthError(msg) && sessionId) {
-        const failedProvider = extractFailedProvider(msg);
-        if (failedProvider) failedProvidersRef.current.add(failedProvider);
+        try {
+          const failedProvider = extractFailedProvider(msg);
+          if (failedProvider) failedProvidersRef.current.add(failedProvider);
 
-        // Try switching to a model from a provider that hasn't failed
-        const switched = await tryFallbackModel(sessionId, failedProvidersRef.current);
-        if (switched) {
-          console.log('[onboarding] Switched to fallback model, retrying prompt...');
-          try {
+          // Try switching to a model from a provider that hasn't failed
+          const switched = await tryFallbackModel(sessionId, failedProvidersRef.current);
+          if (switched) {
+            console.log('[onboarding] Switched to fallback model, retrying prompt...');
             await window.sero.agent.prompt(
               sessionId,
               "Hey! I'm new here — set up my memory so you can get to know me.",
@@ -172,12 +172,9 @@ export function OnboardingWizard() {
             await window.sero.profiles.markOnboardingDone();
             setPhase('done');
             return;
-          } catch (retryErr) {
-            const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-            console.error('[onboarding] Retry also failed:', retryMsg);
-            const retryProvider = extractFailedProvider(retryMsg);
-            if (retryProvider) failedProvidersRef.current.add(retryProvider);
           }
+        } catch (retryErr) {
+          console.error('[onboarding] Fallback retry failed:', retryErr);
         }
 
         // No fallback available or retry also failed — show auth dialog
@@ -207,11 +204,11 @@ export function OnboardingWizard() {
     } catch (err) {
       console.warn('[onboarding] Failed to save model tiers:', err);
     }
-    launchMemorySession();
+    void launchMemorySession();
   }, [launchMemorySession]);
 
   const handleTierSkip = useCallback(() => {
-    launchMemorySession();
+    void launchMemorySession();
   }, [launchMemorySession]);
 
   // Nothing to show

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -1,184 +1,161 @@
 /**
- * OnboardingWizard — new-profile first-run flow.
+ * OnboardingWizard — recommendation-first profile onboarding.
  *
- * Two concerns, handled differently:
- *
- * 1. **Model access** (UI) — if no usable models are currently available,
- *    show the auth dialog. This counts all working model sources surfaced
- *    by the host (saved keys, OAuth, env-backed keys, local models). The
- *    agent can't run without a usable model, so this must be a modal gate.
- *    Cancelling does NOT mark onboarding complete — it shows again on next launch.
- *
- * 2. **Memory setup** (agentic) — once model access is ready, auto-create a
- *    session and let the agent handle it conversationally. The memory
- *    extension's bootstrap instructions inject automatically (triggered
- *    by MEMORY.md not existing). The questionnaire tool is forced to
- *    use exactly the predefined questions via globalThis override.
- *    Completion is detected by the memory extension writing MEMORY.md.
- *
- * The `.onboarding-complete` marker is written once:
- *   - At least one usable model is available
- *   - AND the memory session has been launched (the agent takes it from here)
- *
- * If the user quits before the agent finishes writing MEMORY.md, the
- * bootstrap instructions still inject into the next session — the agent
- * picks up naturally. No wizard needed again.
+ * Electron preflight decides whether onboarding is ready, auth-blocked, or done.
+ * The renderer only manages transient UI states like customize and launching.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-} from '@sero-ai/ui/components/ui/dialog';
-import { Button } from '@sero-ai/ui/components/ui/button';
-import { KeyRound, Loader2, TriangleAlert } from 'lucide-react';
+import { Dialog, DialogContent } from '@sero-ai/ui/components/ui/dialog';
 import { AuthLoginDialog } from '@/components/layout/AuthLoginDialog';
-import { TierPicker } from './TierPicker';
-import type { ModelTierSettings } from '@/types/ipc';
-import { useSessionStore } from '@/stores/sessions';
-import { useAgentStore } from '@/stores/agent';
 import { useAppStore } from '@/stores/app';
+import { useAgentStore } from '@/stores/agent';
+import { useSessionStore } from '@/stores/sessions';
 import { useUserFeedbackStore } from '@/stores/user-feedback-store';
+import type { ModelTierEntry, ModelTierSettings, OnboardingState } from '@/types/ipc';
+import { TierPicker } from './TierPicker';
+import {
+  AuthScreen,
+  ErrorScreen,
+  LaunchingScreen,
+  ReadyScreen,
+} from './onboarding/OnboardingViews';
 
-type Phase = 'checking' | 'auth' | 'tiers' | 'launching' | 'error' | 'done';
+type OnboardingUiPhase =
+  | 'checking'
+  | 'ready'
+  | 'customize'
+  | 'auth'
+  | 'launching'
+  | 'error'
+  | 'done';
 
-function isAuthError(msg: string): boolean {
-  return /authentication failed|unauthorized|401|no api key|credentials/i.test(msg);
+const WELCOME_PROMPT = "Hey! I'm new here — set up my memory so you can get to know me.";
+
+function deriveUiPhase(state: OnboardingState): OnboardingUiPhase {
+  if (!state.needed || state.phase === 'done') return 'done';
+  if (state.phase === 'ready') return 'ready';
+  if (state.phase === 'auth') return 'auth';
+  if (state.phase === 'error') return 'error';
+  return 'done';
 }
 
-/** Extract the failed provider from an auth error message, e.g. 'Authentication failed for "anthropic"' */
-function extractFailedProvider(msg: string): string | null {
-  const match = msg.match(/Authentication failed for "([^"]+)"/i);
+function isAuthError(message: string): boolean {
+  return /authentication failed|unauthorized|401|no api key|credentials/i.test(message);
+}
+
+function extractFailedProvider(message: string): string | null {
+  const match = message.match(/Authentication failed for "([^"]+)"/i);
   return match ? match[1] : null;
 }
 
-/**
- * Switch the session to the user's preferred tier model (HIGH → MED → LOW).
- *
- * The saved tier entry uses the provider/modelId from the model list at
- * onboarding time. If the exact provider/modelId fails (e.g. the provider
- * uses a different ID internally), fall back to finding the modelId under
- * any available provider.
- */
-async function applyTierModel(sessionId: string): Promise<void> {
-  try {
-    const tiers = await window.sero.modelTiers.get();
-    const entry = tiers.HIGH ?? tiers.MED ?? tiers.LOW;
-    if (!entry) return;
-
-    // Try the exact provider/modelId first
-    try {
-      await window.sero.agent.setModel(sessionId, entry.provider, entry.modelId);
-      return;
-    } catch {
-      // Exact match failed — try finding the model under any provider
-    }
-
-    // Search all available models for a matching modelId
-    const state = await window.sero.agent.getModelState(sessionId);
-    if (!state) return;
-
-    for (const group of state.availableModels) {
-      const match = group.models.find((m) => m.modelId === entry.modelId);
-      if (match) {
-        await window.sero.agent.setModel(sessionId, match.provider, match.modelId);
-        return;
-      }
-    }
-
-    console.warn('[onboarding] Tier model not available:', entry);
-  } catch (err) {
-    console.warn('[onboarding] Could not apply tier model:', err);
-  }
+function getDisplayProviderName(state: OnboardingState | null, providerId: string | null): string | null {
+  if (!state || !providerId) return providerId;
+  return state.providerHealth.find((provider) => provider.providerId === providerId)?.displayName ?? providerId;
 }
 
-/**
- * Try to switch the session to a model from a provider that hasn't failed.
- * Returns true if a fallback model was found and set.
- */
-async function tryFallbackModel(sessionId: string, failedProviders: Set<string>): Promise<boolean> {
+async function applyModelEntry(sessionId: string, entry: ModelTierEntry | null): Promise<boolean> {
+  if (!entry) return false;
+
+  try {
+    await window.sero.agent.setModel(sessionId, entry.provider, entry.modelId);
+    return true;
+  } catch {
+    // Fall through to lookup-by-model-id fallback.
+  }
+
   try {
     const state = await window.sero.agent.getModelState(sessionId);
     if (!state) return false;
 
     for (const group of state.availableModels) {
-      if (failedProviders.has(group.provider)) continue;
-      const model = group.models[0];
-      if (model) {
-        await window.sero.agent.setModel(sessionId, model.provider, model.modelId);
-        return true;
-      }
+      const match = group.models.find((model) => model.modelId === entry.modelId);
+      if (!match) continue;
+      await window.sero.agent.setModel(sessionId, match.provider, match.modelId);
+      return true;
     }
   } catch {
-    // Can't switch — fall through
+    // Ignore — onboarding will recover via preflight on the next refresh.
   }
+
   return false;
 }
 
-async function hasUsableModels(): Promise<boolean> {
-  try {
-    const groups = await window.sero.models.list();
-    return groups.some((group) => group.models.length > 0);
-  } catch {
-    return false;
-  }
+async function applyTierModel(sessionId: string, tiers: ModelTierSettings): Promise<boolean> {
+  return applyModelEntry(sessionId, tiers.HIGH ?? tiers.MED ?? tiers.LOW ?? null);
 }
 
 export function OnboardingWizard() {
-  const [phase, setPhase] = useState<Phase>('checking');
+  const [uiPhase, setUiPhase] = useState<OnboardingUiPhase>('checking');
+  const [onboardingState, setOnboardingState] = useState<OnboardingState | null>(null);
   const [showLoginDialog, setShowLoginDialog] = useState(false);
+  const [preferredProviderId, setPreferredProviderId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const failedProvidersRef = useRef<Set<string>>(new Set());
+  const [launchStatusMessage, setLaunchStatusMessage] = useState<string | null>(null);
   const hideLaunchingDialogRef = useRef(false);
-  const hasPendingUserInput = useUserFeedbackStore((s) => s.pending.size > 0);
+  const hasPendingUserInput = useUserFeedbackStore((state) => state.pending.size > 0);
 
-  if (phase === 'launching' && hasPendingUserInput) {
+  if (uiPhase === 'launching' && hasPendingUserInput) {
     hideLaunchingDialogRef.current = true;
   }
 
-  // ── Initial check ───────────────────────────────────────────
+  const syncOnboardingState = useCallback(async (options?: { preserveLaunchMessage?: boolean }) => {
+    if (!options?.preserveLaunchMessage) {
+      setLaunchStatusMessage(null);
+    }
+    setErrorMessage(null);
+    setUiPhase('checking');
+
+    try {
+      const nextState = await window.sero.onboarding.getState();
+      setOnboardingState(nextState);
+      setUiPhase(deriveUiPhase(nextState));
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setErrorMessage(message);
+      setUiPhase('error');
+    }
+  }, []);
+
   useEffect(() => {
-    if (phase !== 'checking') return;
-    let cancelled = false;
+    void syncOnboardingState();
+  }, [syncOnboardingState]);
 
-    (async () => {
-      try {
-        const needed = await window.sero.profiles.needsOnboarding();
-        if (cancelled || !needed) { setPhase('done'); return; }
+  const openAuthDialog = useCallback((providerId: string | null = null) => {
+    setPreferredProviderId(providerId);
+    setShowLoginDialog(true);
+  }, []);
 
-        const hasModels = await hasUsableModels();
-        if (cancelled) return;
+  const handleLoginDialogOpenChange = useCallback((open: boolean) => {
+    setShowLoginDialog(open);
+    if (!open) setPreferredProviderId(null);
+  }, []);
 
-        if (hasModels) {
-          const tiers = await window.sero.modelTiers.get();
-          if (Object.keys(tiers).length > 0) {
-            launchMemorySession();
-          } else {
-            setPhase('tiers');
-          }
-        } else {
-          setPhase('auth');
-        }
-      } catch {
-        setPhase('done');
-      }
-    })();
+  const handleLoginComplete = useCallback(() => {
+    setShowLoginDialog(false);
+    setPreferredProviderId(null);
+    void syncOnboardingState();
+  }, [syncOnboardingState]);
 
-    return () => { cancelled = true; };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase]);
+  const handleSaveCustomizations = useCallback(async (tiers: ModelTierSettings) => {
+    try {
+      await window.sero.onboarding.saveTierSelections(tiers);
+      await syncOnboardingState();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setErrorMessage(message);
+      setUiPhase('error');
+    }
+  }, [syncOnboardingState]);
 
-  // ── Launch the agentic memory session ───────────────────────
-  const launchMemorySession = useCallback(async () => {
+  const launchWelcomeSession = useCallback(async (tiers: ModelTierSettings) => {
     hideLaunchingDialogRef.current = false;
     setErrorMessage(null);
-    setPhase('launching');
+    setLaunchStatusMessage(null);
+    setUiPhase('launching');
 
     let sessionId: string | null = null;
+
     try {
       const session = await useSessionStore.getState().createSession('global');
       sessionId = session.id;
@@ -188,174 +165,167 @@ export function OnboardingWizard() {
       useAgentStore.getState().focusSession(session.id);
       useAppStore.getState().setChatPanelOpen(true);
 
-      // Switch session to the user's tier model (HIGH for main sessions)
-      await applyTierModel(session.id);
-
-      // Await the prompt — if auth fails for one provider, we try another
-      await window.sero.agent.prompt(
-        session.id,
-        "Hey! I'm new here — set up my memory so you can get to know me.",
-      );
-
-      // Prompt completed successfully → mark onboarding done
+      await applyTierModel(session.id, tiers);
+      await window.sero.agent.prompt(session.id, WELCOME_PROMPT);
       await window.sero.profiles.markOnboardingDone();
-      setPhase('done');
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      console.error('[onboarding] Memory prompt failed:', msg);
-
-      if (isAuthError(msg) && sessionId) {
+      setUiPhase('done');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (isAuthError(message) && sessionId) {
         try {
-          const failedProvider = extractFailedProvider(msg);
-          if (failedProvider) failedProvidersRef.current.add(failedProvider);
+          const refreshedState = await window.sero.onboarding.getState();
+          setOnboardingState(refreshedState);
 
-          // Try switching to a model from a provider that hasn't failed
-          const switched = await tryFallbackModel(sessionId, failedProvidersRef.current);
-          if (switched) {
-            console.log('[onboarding] Switched to fallback model, retrying prompt...');
-            await window.sero.agent.prompt(
-              sessionId,
-              "Hey! I'm new here — set up my memory so you can get to know me.",
+          if (refreshedState.phase === 'ready' && refreshedState.recommendation) {
+            const failedProvider = extractFailedProvider(message);
+            const nextProvider = refreshedState.recommendation.preferredProvider
+              ?? refreshedState.recommendation.tiers.HIGH?.provider
+              ?? refreshedState.recommendation.tiers.MED?.provider
+              ?? refreshedState.recommendation.tiers.LOW?.provider
+              ?? null;
+
+            const failedName = getDisplayProviderName(onboardingState, failedProvider);
+            const nextName = getDisplayProviderName(refreshedState, nextProvider);
+            const canAutoRetry = !failedProvider || !nextProvider || failedProvider !== nextProvider;
+
+            setLaunchStatusMessage(
+              failedName && nextName && failedName !== nextName
+                ? `${failedName} stopped working. Switching to ${nextName}.`
+                : 'Refreshing your recommended provider before launch.',
             );
-            await window.sero.profiles.markOnboardingDone();
-            setPhase('done');
-            return;
-          }
-        } catch (retryErr) {
-          console.error('[onboarding] Fallback retry failed:', retryErr);
-        }
 
-        // No fallback available or retry also failed — show auth dialog
-        setPhase('auth');
-        return;
+            if (canAutoRetry) {
+              await window.sero.onboarding.saveTierSelections(refreshedState.recommendation.tiers);
+              const applied = await applyTierModel(sessionId, refreshedState.recommendation.tiers);
+              if (applied) {
+                await window.sero.agent.prompt(sessionId, WELCOME_PROMPT);
+                await window.sero.profiles.markOnboardingDone();
+                setUiPhase('done');
+                return;
+              }
+            }
+          }
+
+          setLaunchStatusMessage(
+            'Your previous provider needs to be reconnected before onboarding can continue.',
+          );
+          setUiPhase(deriveUiPhase(refreshedState));
+          return;
+        } catch (retryError) {
+          const retryMessage = retryError instanceof Error ? retryError.message : String(retryError);
+          setErrorMessage(retryMessage);
+          setUiPhase('error');
+          return;
+        }
       }
 
-      setErrorMessage(msg);
-      setPhase('error');
+      setErrorMessage(message);
+      setUiPhase('error');
     }
-  }, []);
+  }, [onboardingState]);
 
-  // ── Auth completed → move on to tier selection ──────────────
-  const handleLoginComplete = useCallback(() => {
-    setShowLoginDialog(false);
-    setPhase('tiers');
-  }, []);
+  const handleContinue = useCallback(async () => {
+    if (!onboardingState?.recommendation) return;
 
-  // ── Auth skipped → still allow tier selection / later retry ─
-  const handleSkipAuth = useCallback(() => {
-    setPhase('tiers');
-  }, []);
-
-  const handleTierComplete = useCallback(async (tiers: ModelTierSettings) => {
     try {
-      await window.sero.modelTiers.set(tiers);
-    } catch (err) {
-      console.warn('[onboarding] Failed to save model tiers:', err);
+      await window.sero.onboarding.saveTierSelections(onboardingState.recommendation.tiers);
+      await launchWelcomeSession(onboardingState.recommendation.tiers);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setErrorMessage(message);
+      setUiPhase('error');
     }
-    void launchMemorySession();
-  }, [launchMemorySession]);
+  }, [launchWelcomeSession, onboardingState]);
 
-  const handleTierSkip = useCallback(() => {
-    void launchMemorySession();
-  }, [launchMemorySession]);
+  const handleErrorBack = useCallback(() => {
+    if (!onboardingState) {
+      setUiPhase('checking');
+      void syncOnboardingState();
+      return;
+    }
+    setUiPhase(deriveUiPhase(onboardingState));
+  }, [onboardingState, syncOnboardingState]);
 
-  // Nothing to show
-  if (phase === 'checking' || phase === 'done') return null;
+  if (uiPhase === 'checking' || uiPhase === 'done' || !onboardingState) {
+    return (
+      <AuthLoginDialog
+        open={showLoginDialog}
+        onOpenChange={handleLoginDialogOpenChange}
+        onComplete={handleLoginComplete}
+        preferredProviderId={preferredProviderId}
+      />
+    );
+  }
+
+  const readyRecommendation = onboardingState.recommendation;
 
   return (
     <>
       <Dialog
-        open={phase === 'launching' && !hideLaunchingDialogRef.current}
-        onOpenChange={() => {/* prevent close via overlay/escape */}}
+        open={uiPhase === 'launching' && !hideLaunchingDialogRef.current}
+        onOpenChange={() => {}}
       >
-        <DialogContent className="max-w-md" onInteractOutside={(e) => e.preventDefault()}>
-          <DialogHeader>
-            <div className="mb-2 flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-              <Loader2 className="size-5 animate-spin text-[var(--status-success)]" />
-            </div>
-            <DialogTitle>Setting up your memory</DialogTitle>
-            <DialogDescription>
-              Sero is opening a welcome session and starting the memory setup flow.
-              This should only take a moment.
-            </DialogDescription>
-          </DialogHeader>
+        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+          <LaunchingScreen statusMessage={launchStatusMessage} />
         </DialogContent>
       </Dialog>
 
-      <Dialog open={phase === 'tiers'} onOpenChange={() => {/* prevent close */}}>
-        <DialogContent className="max-w-md" onInteractOutside={(e) => e.preventDefault()}>
-          <DialogHeader>
-            <DialogTitle>Choose your default models</DialogTitle>
-            <DialogDescription>
-              Pick which models to use for different task complexities.
-              You can change these anytime in settings.
-            </DialogDescription>
-          </DialogHeader>
-          <TierPicker onComplete={handleTierComplete} onSkip={handleTierSkip} />
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={phase === 'auth'} onOpenChange={() => {/* prevent close via overlay/escape */}}>
-        <DialogContent className="max-w-md" onInteractOutside={(e) => e.preventDefault()}>
-          <DialogHeader>
-            <div className="mb-2 flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-              <KeyRound className="size-5 text-[var(--status-success)]" />
-            </div>
-            <DialogTitle>Welcome to Sero</DialogTitle>
-            <DialogDescription>
-              Sign in to a model provider so the AI agent can work.
-              You can add more providers later in settings.
-            </DialogDescription>
-          </DialogHeader>
-
-          <div className="flex flex-col gap-3 pt-1">
-            <Button onClick={() => setShowLoginDialog(true)} variant="outline" className="w-full">
-              <KeyRound className="mr-2 size-3.5" />
-              Sign in to a provider
-            </Button>
-          </div>
-
-          <DialogFooter>
-            <Button variant="ghost" size="sm" onClick={handleSkipAuth}>
-              Skip for now
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={phase === 'error'} onOpenChange={() => {/* prevent close via overlay/escape */}}>
-        <DialogContent className="max-w-md" onInteractOutside={(e) => e.preventDefault()}>
-          <DialogHeader>
-            <div className="mb-2 flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-              <TriangleAlert className="size-5 text-[var(--status-warning)]" />
-            </div>
-            <DialogTitle>Memory setup couldn't start</DialogTitle>
-            <DialogDescription>
-              Sero hit an error while opening the welcome session for memory setup.
-            </DialogDescription>
-          </DialogHeader>
-
-          {errorMessage ? (
-            <div className="rounded-md border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--text-secondary)]">
-              {errorMessage}
-            </div>
+      <Dialog open={uiPhase === 'ready'} onOpenChange={() => {}}>
+        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+          {readyRecommendation ? (
+            <ReadyScreen
+              recommendation={readyRecommendation}
+              availableModelGroups={onboardingState.availableModelGroups}
+              providerHealth={onboardingState.providerHealth}
+              warnings={onboardingState.warnings.filter((warning) => warning.code !== 'no_usable_models')}
+              launchNotice={launchStatusMessage}
+              onContinue={() => void handleContinue()}
+              onCustomize={() => setUiPhase('customize')}
+              onAddProvider={() => openAuthDialog()}
+              onReconnectProvider={openAuthDialog}
+            />
           ) : null}
+        </DialogContent>
+      </Dialog>
 
-          <DialogFooter>
-            <Button variant="ghost" size="sm" onClick={() => setPhase('done')}>
-              Continue for now
-            </Button>
-            <Button size="sm" onClick={() => void launchMemorySession()}>
-              Retry setup
-            </Button>
-          </DialogFooter>
+      <Dialog open={uiPhase === 'customize'} onOpenChange={() => {}}>
+        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+          <TierPicker
+            groups={onboardingState.availableModelGroups}
+            providerHealth={onboardingState.providerHealth}
+            initialTiers={readyRecommendation?.tiers ?? {}}
+            onSave={(tiers) => void handleSaveCustomizations(tiers)}
+            onBack={() => setUiPhase('ready')}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={uiPhase === 'auth'} onOpenChange={() => {}}>
+        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+          <AuthScreen
+            providerHealth={onboardingState.providerHealth}
+            launchNotice={launchStatusMessage}
+            onAddProvider={() => openAuthDialog()}
+            onReconnectProvider={openAuthDialog}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={uiPhase === 'error'} onOpenChange={() => {}}>
+        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+          <ErrorScreen
+            message={errorMessage}
+            onRetry={() => void syncOnboardingState({ preserveLaunchMessage: true })}
+            onBack={handleErrorBack}
+          />
         </DialogContent>
       </Dialog>
 
       <AuthLoginDialog
         open={showLoginDialog}
-        onOpenChange={setShowLoginDialog}
+        onOpenChange={handleLoginDialogOpenChange}
         onComplete={handleLoginComplete}
+        preferredProviderId={preferredProviderId}
       />
     </>
   );

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -56,6 +56,23 @@ function extractFailedProvider(msg: string): string | null {
 }
 
 /**
+ * Switch the session to the user's preferred tier model (HIGH for main sessions).
+ * Falls back through MED → LOW if HIGH isn't set.
+ */
+async function applyTierModel(sessionId: string): Promise<void> {
+  try {
+    const tiers = await window.sero.modelTiers.get();
+    const entry = tiers.HIGH ?? tiers.MED ?? tiers.LOW;
+    if (entry) {
+      await window.sero.agent.setModel(sessionId, entry.provider, entry.modelId);
+    }
+  } catch (err) {
+    // Non-fatal — session keeps its current model
+    console.warn('[onboarding] Could not apply tier model:', err);
+  }
+}
+
+/**
  * Try to switch the session to a model from a provider that hasn't failed.
  * Returns true if a fallback model was found and set.
  */
@@ -142,6 +159,9 @@ export function OnboardingWizard() {
       await useSessionStore.getState().renameSession(session.id, 'Welcome');
       useAgentStore.getState().focusSession(session.id);
       useAppStore.getState().setChatPanelOpen(true);
+
+      // Switch session to the user's tier model (HIGH for main sessions)
+      await applyTierModel(session.id);
 
       // Await the prompt — if auth fails for one provider, we try another
       await window.sero.agent.prompt(

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -56,18 +56,41 @@ function extractFailedProvider(msg: string): string | null {
 }
 
 /**
- * Switch the session to the user's preferred tier model (HIGH for main sessions).
- * Falls back through MED → LOW if HIGH isn't set.
+ * Switch the session to the user's preferred tier model (HIGH → MED → LOW).
+ *
+ * The saved tier entry uses the provider/modelId from the model list at
+ * onboarding time. If the exact provider/modelId fails (e.g. the provider
+ * uses a different ID internally), fall back to finding the modelId under
+ * any available provider.
  */
 async function applyTierModel(sessionId: string): Promise<void> {
   try {
     const tiers = await window.sero.modelTiers.get();
     const entry = tiers.HIGH ?? tiers.MED ?? tiers.LOW;
-    if (entry) {
+    if (!entry) return;
+
+    // Try the exact provider/modelId first
+    try {
       await window.sero.agent.setModel(sessionId, entry.provider, entry.modelId);
+      return;
+    } catch {
+      // Exact match failed — try finding the model under any provider
     }
+
+    // Search all available models for a matching modelId
+    const state = await window.sero.agent.getModelState(sessionId);
+    if (!state) return;
+
+    for (const group of state.availableModels) {
+      const match = group.models.find((m) => m.modelId === entry.modelId);
+      if (match) {
+        await window.sero.agent.setModel(sessionId, match.provider, match.modelId);
+        return;
+      }
+    }
+
+    console.warn('[onboarding] Tier model not available:', entry);
   } catch (err) {
-    // Non-fatal — session keeps its current model
     console.warn('[onboarding] Could not apply tier model:', err);
   }
 }

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -28,6 +28,7 @@ import {
 type OnboardingUiPhase = 'checking' | 'ready' | 'auth' | 'launching' | 'error' | 'done';
 
 const WELCOME_PROMPT = "Hey! I'm new here — set up my memory so you can get to know me.";
+const WELCOME_GREETING_PROMPT = "The user just finished setting up their profile. Say hello, introduce yourself briefly, and let them know you're ready to help.";
 const EMPTY_PROVIDER_DEFAULTS: ResolvedProviderDefaultsState = {
   builtInDefaults: {},
   globalDefaults: {},
@@ -88,6 +89,49 @@ async function applyModelEntry(sessionId: string, entry: ModelTierEntry | null):
 
 async function applyTierModel(sessionId: string, tiers: ModelTierSettings): Promise<boolean> {
   return applyModelEntry(sessionId, tiers.HIGH ?? tiers.MED ?? tiers.LOW ?? null);
+}
+
+async function createAndRunSession(options: {
+  name?: string;
+  tiers: ModelTierSettings;
+  thinkingLevel?: string;
+  prompt: string;
+  setupUi?: (sessionId: string) => void;
+}): Promise<{ sessionId: string; sessionPath: string }> {
+  const session = await useSessionStore.getState().createSession('global');
+  await window.sero.agent.open(session.id, session.path, 'global');
+
+  if (options.name) {
+    await useSessionStore.getState().renameSession(session.id, options.name);
+  }
+
+  await applyTierModel(session.id, options.tiers);
+
+  if (options.thinkingLevel) {
+    try {
+      await window.sero.agent.setThinkingLevel(session.id, options.thinkingLevel);
+    } catch {
+      // Model may not support thinking levels — proceed with default.
+    }
+  }
+
+  options.setupUi?.(session.id);
+
+  await window.sero.agent.prompt(session.id, options.prompt);
+  return { sessionId: session.id, sessionPath: session.path };
+}
+
+async function teardownSession(sessionId: string, sessionPath: string): Promise<void> {
+  try {
+    await window.sero.agent.close(sessionId);
+  } catch {
+    // Session may already be closed.
+  }
+  try {
+    await useSessionStore.getState().deleteSession(sessionPath);
+  } catch {
+    // Best-effort cleanup.
+  }
 }
 
 export function OnboardingWizard() {
@@ -165,23 +209,47 @@ export function OnboardingWizard() {
     setLaunchStatusMessage(null);
     setUiPhase('launching');
 
-    let sessionId: string | null = null;
+    let tempSessionId: string | null = null;
+    let tempSessionPath: string | null = null;
 
     try {
-      const session = await useSessionStore.getState().createSession('global');
-      sessionId = session.id;
-      useSessionStore.getState().setActiveSession(session.id);
-      await window.sero.agent.open(session.id, session.path, 'global');
-      await useSessionStore.getState().renameSession(session.id, 'Welcome');
-      useAgentStore.getState().focusSession(session.id);
-      useAppStore.getState().setChatPanelOpen(true);
+      // Phase 1: Run memory setup in a dedicated low-thinking session.
+      const temp = await createAndRunSession({
+        tiers,
+        thinkingLevel: 'low',
+        prompt: WELCOME_PROMPT,
+      });
+      tempSessionId = temp.sessionId;
+      tempSessionPath = temp.sessionPath;
 
-      await applyTierModel(session.id, tiers);
-      await window.sero.agent.prompt(session.id, WELCOME_PROMPT);
+      // Phase 2: Tear down the temp session.
+      await teardownSession(tempSessionId, tempSessionPath);
+      tempSessionId = null;
+      tempSessionPath = null;
+
+      // Phase 3: Create the user's clean welcome session.
+      const welcome = await createAndRunSession({
+        name: 'Welcome',
+        tiers,
+        prompt: WELCOME_GREETING_PROMPT,
+        setupUi: (sessionId) => {
+          useSessionStore.getState().setActiveSession(sessionId);
+          useAgentStore.getState().focusSession(sessionId);
+          useAppStore.getState().setChatPanelOpen(true);
+        },
+      });
+
+      useSessionStore.getState().setActiveSession(welcome.sessionId);
       await finishOnboardingLaunch();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (isAuthError(message) && sessionId) {
+
+      // Clean up temp session on failure if it's still around.
+      if (tempSessionId && tempSessionPath) {
+        await teardownSession(tempSessionId, tempSessionPath);
+      }
+
+      if (isAuthError(message)) {
         try {
           const refreshedState = await window.sero.onboarding.getState();
           setOnboardingState(refreshedState);
@@ -206,12 +274,8 @@ export function OnboardingWizard() {
 
             if (canAutoRetry) {
               await window.sero.onboarding.saveTierSelections(refreshedState.recommendation.tiers);
-              const applied = await applyTierModel(sessionId, refreshedState.recommendation.tiers);
-              if (applied) {
-                await window.sero.agent.prompt(sessionId, WELCOME_PROMPT);
-                await finishOnboardingLaunch();
-                return;
-              }
+              await launchWelcomeSession(refreshedState.recommendation.tiers);
+              return;
             }
           }
 
@@ -235,7 +299,7 @@ export function OnboardingWizard() {
       setErrorMessage(message);
       setUiPhase('error');
     }
-  }, [finishOnboardingLaunch, onboardingState]);
+  }, [finishOnboardingLaunch]);
 
   const handleContinue = useCallback(async (tiers: ModelTierSettings) => {
     if (continueInFlightRef.current) return;

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -36,12 +36,14 @@ import {
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { KeyRound, Loader2, TriangleAlert } from 'lucide-react';
 import { AuthLoginDialog } from '@/components/layout/AuthLoginDialog';
+import { TierPicker } from './TierPicker';
+import type { ModelTierSettings } from '@/types/ipc';
 import { useSessionStore } from '@/stores/sessions';
 import { useAgentStore } from '@/stores/agent';
 import { useAppStore } from '@/stores/app';
 import { useUserFeedbackStore } from '@/stores/user-feedback-store';
 
-type Phase = 'checking' | 'auth' | 'launching' | 'error' | 'done';
+type Phase = 'checking' | 'auth' | 'tiers' | 'launching' | 'error' | 'done';
 
 export function OnboardingWizard() {
   const [phase, setPhase] = useState<Phase>('checking');
@@ -72,8 +74,13 @@ export function OnboardingWizard() {
           || providers.apiKey.some((p) => p.hasKey && !p.fromEnv);
 
         if (hasAuth) {
-          // Auth present (copied at creation) → launch memory setup
-          launchMemorySession();
+          // Auth present — check if tiers are configured
+          const tiers = await window.sero.modelTiers.get();
+          if (Object.keys(tiers).length > 0) {
+            launchMemorySession();
+          } else {
+            setPhase('tiers');
+          }
         } else {
           setPhase('auth');
         }
@@ -126,11 +133,24 @@ export function OnboardingWizard() {
   // ── Auth completed → launch memory session ──────────────────
   const handleLoginComplete = useCallback(() => {
     setShowLoginDialog(false);
-    launchMemorySession();
-  }, [launchMemorySession]);
+    setPhase('tiers');
+  }, []);
 
   // ── Auth skipped → launch memory session anyway ─────────────
   const handleSkipAuth = useCallback(() => {
+    setPhase('tiers');
+  }, []);
+
+  const handleTierComplete = useCallback(async (tiers: ModelTierSettings) => {
+    try {
+      await window.sero.modelTiers.set(tiers);
+    } catch (err) {
+      console.warn('[onboarding] Failed to save model tiers:', err);
+    }
+    launchMemorySession();
+  }, [launchMemorySession]);
+
+  const handleTierSkip = useCallback(() => {
     launchMemorySession();
   }, [launchMemorySession]);
 
@@ -154,6 +174,19 @@ export function OnboardingWizard() {
               This should only take a moment.
             </DialogDescription>
           </DialogHeader>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={phase === 'tiers'} onOpenChange={() => {/* prevent close */}}>
+        <DialogContent className="max-w-md" onInteractOutside={(e) => e.preventDefault()}>
+          <DialogHeader>
+            <DialogTitle>Choose your default models</DialogTitle>
+            <DialogDescription>
+              Pick which models to use for different task complexities.
+              You can change these anytime in settings.
+            </DialogDescription>
+          </DialogHeader>
+          <TierPicker onComplete={handleTierComplete} onSkip={handleTierSkip} />
         </DialogContent>
       </Dialog>
 

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -2,7 +2,7 @@
  * OnboardingWizard — recommendation-first profile onboarding.
  *
  * Electron preflight decides whether onboarding is ready, auth-blocked, or done.
- * The renderer only manages transient UI states like customize and launching.
+ * The renderer only manages transient UI states like launching and recovery.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -12,25 +12,27 @@ import { useAppStore } from '@/stores/app';
 import { useAgentStore } from '@/stores/agent';
 import { useSessionStore } from '@/stores/sessions';
 import { useUserFeedbackStore } from '@/stores/user-feedback-store';
-import type { ModelTierEntry, ModelTierSettings, OnboardingState } from '@/types/ipc';
-import { TierPicker } from './TierPicker';
+import type {
+  ModelTierEntry,
+  ModelTierSettings,
+  OnboardingState,
+  ResolvedProviderDefaultsState,
+} from '@/types/ipc';
 import {
   AuthScreen,
   ErrorScreen,
   LaunchingScreen,
-  ReadyScreen,
+  OnboardingSetupScreen,
 } from './onboarding/OnboardingViews';
 
-type OnboardingUiPhase =
-  | 'checking'
-  | 'ready'
-  | 'customize'
-  | 'auth'
-  | 'launching'
-  | 'error'
-  | 'done';
+type OnboardingUiPhase = 'checking' | 'ready' | 'auth' | 'launching' | 'error' | 'done';
 
 const WELCOME_PROMPT = "Hey! I'm new here — set up my memory so you can get to know me.";
+const EMPTY_PROVIDER_DEFAULTS: ResolvedProviderDefaultsState = {
+  builtInDefaults: {},
+  globalDefaults: {},
+  effectiveDefaults: {},
+};
 
 function deriveUiPhase(state: OnboardingState): OnboardingUiPhase {
   if (!state.needed || state.phase === 'done') return 'done';
@@ -49,7 +51,10 @@ function extractFailedProvider(message: string): string | null {
   return match ? match[1] : null;
 }
 
-function getDisplayProviderName(state: OnboardingState | null, providerId: string | null): string | null {
+function getDisplayProviderName(
+  state: Pick<OnboardingState, 'providerHealth'> | null,
+  providerId: string | null,
+): string | null {
   if (!state || !providerId) return providerId;
   return state.providerHealth.find((provider) => provider.providerId === providerId)?.displayName ?? providerId;
 }
@@ -88,11 +93,14 @@ async function applyTierModel(sessionId: string, tiers: ModelTierSettings): Prom
 export function OnboardingWizard() {
   const [uiPhase, setUiPhase] = useState<OnboardingUiPhase>('checking');
   const [onboardingState, setOnboardingState] = useState<OnboardingState | null>(null);
+  const [providerDefaults, setProviderDefaults] = useState<ResolvedProviderDefaultsState>(EMPTY_PROVIDER_DEFAULTS);
   const [showLoginDialog, setShowLoginDialog] = useState(false);
   const [preferredProviderId, setPreferredProviderId] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [launchStatusMessage, setLaunchStatusMessage] = useState<string | null>(null);
+  const [isContinuing, setIsContinuing] = useState(false);
   const hideLaunchingDialogRef = useRef(false);
+  const continueInFlightRef = useRef(false);
   const hasPendingUserInput = useUserFeedbackStore((state) => state.pending.size > 0);
 
   if (uiPhase === 'launching' && hasPendingUserInput) {
@@ -103,12 +111,18 @@ export function OnboardingWizard() {
     if (!options?.preserveLaunchMessage) {
       setLaunchStatusMessage(null);
     }
+    continueInFlightRef.current = false;
+    setIsContinuing(false);
     setErrorMessage(null);
     setUiPhase('checking');
 
     try {
-      const nextState = await window.sero.onboarding.getState();
+      const [nextState, nextProviderDefaults] = await Promise.all([
+        window.sero.onboarding.getState(),
+        window.sero.providerDefaults.get().catch(() => EMPTY_PROVIDER_DEFAULTS),
+      ]);
       setOnboardingState(nextState);
+      setProviderDefaults(nextProviderDefaults);
       setUiPhase(deriveUiPhase(nextState));
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -121,7 +135,7 @@ export function OnboardingWizard() {
     void syncOnboardingState();
   }, [syncOnboardingState]);
 
-  const openAuthDialog = useCallback((providerId: string | null = null) => {
+  const openProviders = useCallback((providerId: string | null = null) => {
     setPreferredProviderId(providerId);
     setShowLoginDialog(true);
   }, []);
@@ -137,16 +151,13 @@ export function OnboardingWizard() {
     void syncOnboardingState();
   }, [syncOnboardingState]);
 
-  const handleSaveCustomizations = useCallback(async (tiers: ModelTierSettings) => {
-    try {
-      await window.sero.onboarding.saveTierSelections(tiers);
-      await syncOnboardingState();
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setErrorMessage(message);
-      setUiPhase('error');
-    }
-  }, [syncOnboardingState]);
+  const finishOnboardingLaunch = useCallback(async () => {
+    useAppStore.getState().setActiveApp('dashboard');
+    await window.sero.profiles.markOnboardingDone();
+    continueInFlightRef.current = false;
+    setIsContinuing(false);
+    setUiPhase('done');
+  }, []);
 
   const launchWelcomeSession = useCallback(async (tiers: ModelTierSettings) => {
     hideLaunchingDialogRef.current = false;
@@ -167,8 +178,7 @@ export function OnboardingWizard() {
 
       await applyTierModel(session.id, tiers);
       await window.sero.agent.prompt(session.id, WELCOME_PROMPT);
-      await window.sero.profiles.markOnboardingDone();
-      setUiPhase('done');
+      await finishOnboardingLaunch();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (isAuthError(message) && sessionId) {
@@ -191,7 +201,7 @@ export function OnboardingWizard() {
             setLaunchStatusMessage(
               failedName && nextName && failedName !== nextName
                 ? `${failedName} stopped working. Switching to ${nextName}.`
-                : 'Refreshing your recommended provider before launch.',
+                : 'Refreshing your provider before launch.',
             );
 
             if (canAutoRetry) {
@@ -199,43 +209,50 @@ export function OnboardingWizard() {
               const applied = await applyTierModel(sessionId, refreshedState.recommendation.tiers);
               if (applied) {
                 await window.sero.agent.prompt(sessionId, WELCOME_PROMPT);
-                await window.sero.profiles.markOnboardingDone();
-                setUiPhase('done');
+                await finishOnboardingLaunch();
                 return;
               }
             }
           }
 
-          setLaunchStatusMessage(
-            'Your previous provider needs to be reconnected before onboarding can continue.',
-          );
+          setLaunchStatusMessage('Reconnect a provider before onboarding can continue.');
+          continueInFlightRef.current = false;
+          setIsContinuing(false);
           setUiPhase(deriveUiPhase(refreshedState));
           return;
         } catch (retryError) {
           const retryMessage = retryError instanceof Error ? retryError.message : String(retryError);
+          continueInFlightRef.current = false;
+          setIsContinuing(false);
           setErrorMessage(retryMessage);
           setUiPhase('error');
           return;
         }
       }
 
+      continueInFlightRef.current = false;
+      setIsContinuing(false);
       setErrorMessage(message);
       setUiPhase('error');
     }
-  }, [onboardingState]);
+  }, [finishOnboardingLaunch, onboardingState]);
 
-  const handleContinue = useCallback(async () => {
-    if (!onboardingState?.recommendation) return;
+  const handleContinue = useCallback(async (tiers: ModelTierSettings) => {
+    if (continueInFlightRef.current) return;
+    continueInFlightRef.current = true;
+    setIsContinuing(true);
 
     try {
-      await window.sero.onboarding.saveTierSelections(onboardingState.recommendation.tiers);
-      await launchWelcomeSession(onboardingState.recommendation.tiers);
+      await window.sero.onboarding.saveTierSelections(tiers);
+      await launchWelcomeSession(tiers);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      continueInFlightRef.current = false;
+      setIsContinuing(false);
       setErrorMessage(message);
       setUiPhase('error');
     }
-  }, [launchWelcomeSession, onboardingState]);
+  }, [launchWelcomeSession]);
 
   const handleErrorBack = useCallback(() => {
     if (!onboardingState) {
@@ -245,6 +262,10 @@ export function OnboardingWizard() {
     }
     setUiPhase(deriveUiPhase(onboardingState));
   }, [onboardingState, syncOnboardingState]);
+
+  const dismissReadyScreen = useCallback(() => {
+    setUiPhase('done');
+  }, []);
 
   if (uiPhase === 'checking' || uiPhase === 'done' || !onboardingState) {
     return (
@@ -261,58 +282,62 @@ export function OnboardingWizard() {
 
   return (
     <>
-      <Dialog
-        open={uiPhase === 'launching' && !hideLaunchingDialogRef.current}
-        onOpenChange={() => {}}
-      >
-        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+      <Dialog open={uiPhase === 'launching' && !hideLaunchingDialogRef.current} onOpenChange={() => {}}>
+        <DialogContent
+          className="max-w-md"
+          showCloseButton={false}
+          onInteractOutside={(event) => event.preventDefault()}
+        >
           <LaunchingScreen statusMessage={launchStatusMessage} />
         </DialogContent>
       </Dialog>
 
-      <Dialog open={uiPhase === 'ready'} onOpenChange={() => {}}>
+      <Dialog
+        open={uiPhase === 'ready'}
+        onOpenChange={(open) => {
+          if (!open) dismissReadyScreen();
+        }}
+      >
         <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
           {readyRecommendation ? (
-            <ReadyScreen
+            <OnboardingSetupScreen
+              key={`${readyRecommendation.preferredProvider ?? 'provider'}:${JSON.stringify(readyRecommendation.tiers)}`}
               recommendation={readyRecommendation}
               availableModelGroups={onboardingState.availableModelGroups}
               providerHealth={onboardingState.providerHealth}
+              providerDefaults={providerDefaults}
               warnings={onboardingState.warnings.filter((warning) => warning.code !== 'no_usable_models')}
               launchNotice={launchStatusMessage}
-              onContinue={() => void handleContinue()}
-              onCustomize={() => setUiPhase('customize')}
-              onAddProvider={() => openAuthDialog()}
-              onReconnectProvider={openAuthDialog}
+              continueDisabled={isContinuing}
+              onContinue={(tiers) => void handleContinue(tiers)}
+              onOpenProviders={() => openProviders()}
+              onReconnectProvider={openProviders}
             />
           ) : null}
         </DialogContent>
       </Dialog>
 
-      <Dialog open={uiPhase === 'customize'} onOpenChange={() => {}}>
-        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
-          <TierPicker
-            groups={onboardingState.availableModelGroups}
-            providerHealth={onboardingState.providerHealth}
-            initialTiers={readyRecommendation?.tiers ?? {}}
-            onSave={(tiers) => void handleSaveCustomizations(tiers)}
-            onBack={() => setUiPhase('ready')}
-          />
-        </DialogContent>
-      </Dialog>
-
       <Dialog open={uiPhase === 'auth'} onOpenChange={() => {}}>
-        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+        <DialogContent
+          className="max-w-md"
+          showCloseButton={false}
+          onInteractOutside={(event) => event.preventDefault()}
+        >
           <AuthScreen
             providerHealth={onboardingState.providerHealth}
             launchNotice={launchStatusMessage}
-            onAddProvider={() => openAuthDialog()}
-            onReconnectProvider={openAuthDialog}
+            onOpenProviders={() => openProviders()}
+            onReconnectProvider={openProviders}
           />
         </DialogContent>
       </Dialog>
 
       <Dialog open={uiPhase === 'error'} onOpenChange={() => {}}>
-        <DialogContent className="max-w-md" onInteractOutside={(event) => event.preventDefault()}>
+        <DialogContent
+          className="max-w-md"
+          showCloseButton={false}
+          onInteractOutside={(event) => event.preventDefault()}
+        >
           <ErrorScreen
             message={errorMessage}
             onRetry={() => void syncOnboardingState({ preserveLaunchMessage: true })}

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -45,10 +45,44 @@ import { useUserFeedbackStore } from '@/stores/user-feedback-store';
 
 type Phase = 'checking' | 'auth' | 'tiers' | 'launching' | 'error' | 'done';
 
+function isAuthError(msg: string): boolean {
+  return /authentication failed|unauthorized|401|no api key|credentials/i.test(msg);
+}
+
+/** Extract the failed provider from an auth error message, e.g. 'Authentication failed for "anthropic"' */
+function extractFailedProvider(msg: string): string | null {
+  const match = msg.match(/Authentication failed for "([^"]+)"/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Try to switch the session to a model from a provider that hasn't failed.
+ * Returns true if a fallback model was found and set.
+ */
+async function tryFallbackModel(sessionId: string, failedProviders: Set<string>): Promise<boolean> {
+  try {
+    const state = await window.sero.agent.getModelState(sessionId);
+    if (!state) return false;
+
+    for (const group of state.availableModels) {
+      if (failedProviders.has(group.provider)) continue;
+      const model = group.models[0];
+      if (model) {
+        await window.sero.agent.setModel(sessionId, model.provider, model.modelId);
+        return true;
+      }
+    }
+  } catch {
+    // Can't switch — fall through
+  }
+  return false;
+}
+
 export function OnboardingWizard() {
   const [phase, setPhase] = useState<Phase>('checking');
   const [showLoginDialog, setShowLoginDialog] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const failedProvidersRef = useRef<Set<string>>(new Set());
   const hideLaunchingDialogRef = useRef(false);
   const hasPendingUserInput = useUserFeedbackStore((s) => s.pending.size > 0);
 
@@ -98,15 +132,18 @@ export function OnboardingWizard() {
     hideLaunchingDialogRef.current = false;
     setErrorMessage(null);
     setPhase('launching');
+
+    let sessionId: string | null = null;
     try {
       const session = await useSessionStore.getState().createSession('global');
+      sessionId = session.id;
       useSessionStore.getState().setActiveSession(session.id);
       await window.sero.agent.open(session.id, session.path, 'global');
       await useSessionStore.getState().renameSession(session.id, 'Welcome');
       useAgentStore.getState().focusSession(session.id);
       useAppStore.getState().setChatPanelOpen(true);
 
-      // Await the prompt — if auth fails, we catch it and show the auth dialog
+      // Await the prompt — if auth fails for one provider, we try another
       await window.sero.agent.prompt(
         session.id,
         "Hey! I'm new here — set up my memory so you can get to know me.",
@@ -119,8 +156,31 @@ export function OnboardingWizard() {
       const msg = err instanceof Error ? err.message : String(err);
       console.error('[onboarding] Memory prompt failed:', msg);
 
-      if (msg.includes('Authentication failed') || msg.includes('authentication') || msg.includes('unauthorized') || msg.includes('401') || msg.includes('No API key') || msg.includes('credentials')) {
-        // Copied credentials were invalid/expired → show auth dialog
+      if (isAuthError(msg) && sessionId) {
+        const failedProvider = extractFailedProvider(msg);
+        if (failedProvider) failedProvidersRef.current.add(failedProvider);
+
+        // Try switching to a model from a provider that hasn't failed
+        const switched = await tryFallbackModel(sessionId, failedProvidersRef.current);
+        if (switched) {
+          console.log('[onboarding] Switched to fallback model, retrying prompt...');
+          try {
+            await window.sero.agent.prompt(
+              sessionId,
+              "Hey! I'm new here — set up my memory so you can get to know me.",
+            );
+            await window.sero.profiles.markOnboardingDone();
+            setPhase('done');
+            return;
+          } catch (retryErr) {
+            const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+            console.error('[onboarding] Retry also failed:', retryMsg);
+            const retryProvider = extractFailedProvider(retryMsg);
+            if (retryProvider) failedProvidersRef.current.add(retryProvider);
+          }
+        }
+
+        // No fallback available or retry also failed — show auth dialog
         setPhase('auth');
         return;
       }

--- a/apps/desktop/src/components/profiles/OnboardingWizard.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.tsx
@@ -3,12 +3,13 @@
  *
  * Two concerns, handled differently:
  *
- * 1. **Auth** (UI) — if no provider credentials exist, show the auth
- *    dialog. The agent can't run without auth, so this must be a modal
- *    gate. Cancelling does NOT mark onboarding complete — it shows again
- *    on next launch.
+ * 1. **Model access** (UI) — if no usable models are currently available,
+ *    show the auth dialog. This counts all working model sources surfaced
+ *    by the host (saved keys, OAuth, env-backed keys, local models). The
+ *    agent can't run without a usable model, so this must be a modal gate.
+ *    Cancelling does NOT mark onboarding complete — it shows again on next launch.
  *
- * 2. **Memory setup** (agentic) — once auth is ready, auto-create a
+ * 2. **Memory setup** (agentic) — once model access is ready, auto-create a
  *    session and let the agent handle it conversationally. The memory
  *    extension's bootstrap instructions inject automatically (triggered
  *    by MEMORY.md not existing). The questionnaire tool is forced to
@@ -16,7 +17,7 @@
  *    Completion is detected by the memory extension writing MEMORY.md.
  *
  * The `.onboarding-complete` marker is written once:
- *   - Auth is configured (or was already present from credential copy)
+ *   - At least one usable model is available
  *   - AND the memory session has been launched (the agent takes it from here)
  *
  * If the user quits before the agent finishes writing MEMORY.md, the
@@ -118,6 +119,15 @@ async function tryFallbackModel(sessionId: string, failedProviders: Set<string>)
   return false;
 }
 
+async function hasUsableModels(): Promise<boolean> {
+  try {
+    const groups = await window.sero.models.list();
+    return groups.some((group) => group.models.length > 0);
+  } catch {
+    return false;
+  }
+}
+
 export function OnboardingWizard() {
   const [phase, setPhase] = useState<Phase>('checking');
   const [showLoginDialog, setShowLoginDialog] = useState(false);
@@ -140,15 +150,10 @@ export function OnboardingWizard() {
         const needed = await window.sero.profiles.needsOnboarding();
         if (cancelled || !needed) { setPhase('done'); return; }
 
-        const providers = await window.sero.auth.getProviders();
+        const hasModels = await hasUsableModels();
         if (cancelled) return;
 
-        // Only count profile-local credentials, not inherited env vars
-        const hasAuth = providers.oauth.some((p) => p.isLoggedIn)
-          || providers.apiKey.some((p) => p.hasKey && !p.fromEnv);
-
-        if (hasAuth) {
-          // Auth present — check if tiers are configured
+        if (hasModels) {
           const tiers = await window.sero.modelTiers.get();
           if (Object.keys(tiers).length > 0) {
             launchMemorySession();
@@ -230,13 +235,13 @@ export function OnboardingWizard() {
     }
   }, []);
 
-  // ── Auth completed → launch memory session ──────────────────
+  // ── Auth completed → move on to tier selection ──────────────
   const handleLoginComplete = useCallback(() => {
     setShowLoginDialog(false);
     setPhase('tiers');
   }, []);
 
-  // ── Auth skipped → launch memory session anyway ─────────────
+  // ── Auth skipped → still allow tier selection / later retry ─
   const handleSkipAuth = useCallback(() => {
     setPhase('tiers');
   }, []);

--- a/apps/desktop/src/components/profiles/ProfileForm.tsx
+++ b/apps/desktop/src/components/profiles/ProfileForm.tsx
@@ -149,7 +149,7 @@ export function ProfileForm({
           />
           <div>
             <span className="text-xs text-[var(--text-secondary)]">
-              Copy credentials from current profile
+              Copy credentials and model preferences from current profile
             </span>
             <p className="text-[10px] text-[var(--text-muted)]">
               Copies API keys and tokens so you can start chatting immediately.

--- a/apps/desktop/src/components/profiles/TierPicker.tsx
+++ b/apps/desktop/src/components/profiles/TierPicker.tsx
@@ -1,0 +1,195 @@
+/**
+ * TierPicker — onboarding step for picking default models per tier.
+ *
+ * Shows three dropdowns (LOW/MED/HIGH) populated with available models.
+ * Includes a "use same for all" toggle and a skip button.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@sero-ai/ui/components/ui/select';
+import { Switch } from '@sero-ai/ui/components/ui/switch';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import type { ModelTierSettings, ModelTierEntry, AvailableModelGroup } from '@/types/ipc';
+
+interface AvailableModel {
+  provider: string;
+  modelId: string;
+  name: string;
+  providerName: string;
+}
+
+interface TierPickerProps {
+  onComplete: (tiers: ModelTierSettings) => void;
+  onSkip: () => void;
+}
+
+const TIER_META = [
+  { key: 'LOW' as const, label: 'Low', desc: 'Fast, cheap tasks — scouts, quick lookups' },
+  { key: 'MED' as const, label: 'Medium', desc: 'Everyday agents — analysis, implementation, review' },
+  { key: 'HIGH' as const, label: 'High', desc: 'Complex reasoning — planning, coordination' },
+] as const;
+
+function modelKey(m: { provider: string; modelId: string }): string {
+  return `${m.provider}/${m.modelId}`;
+}
+
+function parseModelKey(key: string): ModelTierEntry | null {
+  const idx = key.indexOf('/');
+  if (idx === -1) return null;
+  return { provider: key.slice(0, idx), modelId: key.slice(idx + 1) };
+}
+
+function flattenModels(groups: AvailableModelGroup[]): AvailableModel[] {
+  const flat: AvailableModel[] = [];
+  for (const group of groups) {
+    for (const m of group.models) {
+      flat.push({
+        provider: m.provider,
+        modelId: m.modelId,
+        name: m.name,
+        providerName: group.displayName,
+      });
+    }
+  }
+  return flat;
+}
+
+export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
+  const [models, setModels] = useState<AvailableModel[]>([]);
+  const [sameForAll, setSameForAll] = useState(false);
+  const [selections, setSelections] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  // Load available models via session-independent IPC bridge
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const groups = await window.sero.models.list();
+        if (cancelled) return;
+        setModels(flattenModels(groups));
+      } catch {
+        // No models available
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSelect = useCallback((tier: string, value: string) => {
+    setSelections((prev) => {
+      if (sameForAll) {
+        return { LOW: value, MED: value, HIGH: value };
+      }
+      return { ...prev, [tier]: value };
+    });
+  }, [sameForAll]);
+
+  const handleSameToggle = useCallback((checked: boolean) => {
+    setSameForAll(checked);
+    if (checked) {
+      const first = selections.LOW || selections.MED || selections.HIGH || '';
+      setSelections({ LOW: first, MED: first, HIGH: first });
+    }
+  }, [selections]);
+
+  const handleComplete = useCallback(() => {
+    const tiers: ModelTierSettings = {};
+    for (const { key } of TIER_META) {
+      const val = selections[key];
+      if (val) {
+        const parsed = parseModelKey(val);
+        if (parsed) tiers[key] = parsed;
+      }
+    }
+    onComplete(tiers);
+  }, [selections, onComplete]);
+
+  const hasAnySelection = Object.values(selections).some(Boolean);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
+        Loading available models...
+      </div>
+    );
+  }
+
+  if (models.length === 0) {
+    return (
+      <div className="space-y-3 text-center py-4">
+        <p className="text-sm text-muted-foreground">
+          No models available. Sign in to a provider first.
+        </p>
+        <Button variant="ghost" size="sm" onClick={onSkip}>
+          Skip for now
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Switch
+            id="same-for-all"
+            checked={sameForAll}
+            onCheckedChange={handleSameToggle}
+          />
+          <Label htmlFor="same-for-all" className="text-xs text-muted-foreground">
+            Use the same model for all tiers
+          </Label>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {(sameForAll ? [TIER_META[0]] : TIER_META).map(({ key, label, desc }) => (
+          <div key={key} className="space-y-1">
+            <Label className="text-sm font-medium">
+              {sameForAll ? 'All tiers' : label}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {sameForAll ? 'Single model for all task types' : desc}
+            </p>
+            <Select
+              value={selections[key] || ''}
+              onValueChange={(v) => handleSelect(key, v)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Choose a model..." />
+              </SelectTrigger>
+              <SelectContent>
+                {models.map((m) => (
+                  <SelectItem key={modelKey(m)} value={modelKey(m)}>
+                    <span className="text-xs text-muted-foreground mr-1.5">
+                      {m.providerName}
+                    </span>
+                    {m.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between pt-1">
+        <Button variant="ghost" size="sm" onClick={onSkip}>
+          Skip
+        </Button>
+        <Button size="sm" onClick={handleComplete} disabled={!hasAnySelection}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/profiles/TierPicker.tsx
+++ b/apps/desktop/src/components/profiles/TierPicker.tsx
@@ -121,6 +121,7 @@ function ModelPickerPopover({
         sideOffset={4}
         className="w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-xl
           border-[var(--border-subtle)] bg-[var(--bg-surface)] p-0 shadow-2xl shadow-black/40"
+        onWheel={(e) => e.stopPropagation()}
       >
         {/* Search */}
         <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] px-3">
@@ -135,8 +136,8 @@ function ModelPickerPopover({
           />
         </div>
 
-        {/* Model list */}
-        <div className="max-h-[240px] overflow-y-auto py-1">
+        {/* Model list — overscroll-contain fixes trackpad scrolling inside Radix popovers */}
+        <div className="max-h-[240px] overflow-y-auto overscroll-contain py-1">
           {filtered.length === 0 ? (
             <div className="px-3 py-3 text-center text-xs text-[var(--text-muted)]">
               No models matching &ldquo;{filter}&rdquo;

--- a/apps/desktop/src/components/profiles/TierPicker.tsx
+++ b/apps/desktop/src/components/profiles/TierPicker.tsx
@@ -18,6 +18,7 @@ import type {
   ModelTierSettings,
   ProviderHealthInfo,
 } from '@/types/ipc';
+import { modelKey, parseModelKey } from '@/lib/model-keys';
 
 interface TierPickerProps {
   groups: AvailableModelGroup[];
@@ -36,24 +37,11 @@ const TIER_META = [
 type TierKey = (typeof TIER_META)[number]['key'];
 type SelectionState = Record<TierKey, string>;
 
-function mkKey(provider: string, modelId: string): string {
-  return `${provider}/${modelId}`;
-}
-
-function parseModelKey(key: string): ModelTierEntry | null {
-  const separatorIndex = key.indexOf('/');
-  if (separatorIndex <= 0) return null;
-  return {
-    provider: key.slice(0, separatorIndex),
-    modelId: key.slice(separatorIndex + 1),
-  };
-}
-
 function createSelectionState(tiers: ModelTierSettings): SelectionState {
   return {
-    LOW: tiers.LOW ? mkKey(tiers.LOW.provider, tiers.LOW.modelId) : '',
-    MED: tiers.MED ? mkKey(tiers.MED.provider, tiers.MED.modelId) : '',
-    HIGH: tiers.HIGH ? mkKey(tiers.HIGH.provider, tiers.HIGH.modelId) : '',
+    LOW: tiers.LOW ? modelKey(tiers.LOW.provider, tiers.LOW.modelId) : '',
+    MED: tiers.MED ? modelKey(tiers.MED.provider, tiers.MED.modelId) : '',
+    HIGH: tiers.HIGH ? modelKey(tiers.HIGH.provider, tiers.HIGH.modelId) : '',
   };
 }
 
@@ -104,7 +92,7 @@ function ModelPickerPopover({
   const selectedModel = useMemo(() => {
     if (!selectedKey) return null;
     for (const group of groups) {
-      const model = group.models.find((entry) => mkKey(entry.provider, entry.modelId) === selectedKey);
+      const model = group.models.find((entry) => modelKey(entry.provider, entry.modelId) === selectedKey);
       if (model) return { group, model };
     }
     return null;
@@ -119,7 +107,7 @@ function ModelPickerPopover({
   }, []);
 
   const handleSelect = useCallback((model: ModelInfo) => {
-    onSelect(mkKey(model.provider, model.modelId));
+    onSelect(modelKey(model.provider, model.modelId));
     setOpen(false);
   }, [onSelect]);
 
@@ -191,7 +179,7 @@ function ModelPickerPopover({
                   </div>
                   <div className="px-1">
                     {group.models.map((model) => {
-                      const key = mkKey(model.provider, model.modelId);
+                      const key = modelKey(model.provider, model.modelId);
                       const isSelected = key === selectedKey;
                       return (
                         <button

--- a/apps/desktop/src/components/profiles/TierPicker.tsx
+++ b/apps/desktop/src/components/profiles/TierPicker.tsx
@@ -1,29 +1,18 @@
 /**
  * TierPicker — onboarding step for picking default models per tier.
  *
- * Shows three dropdowns (LOW/MED/HIGH) populated with available models.
- * Includes a "use same for all" toggle and a skip button.
+ * Uses popover-based model pickers with search and provider grouping,
+ * matching the look/feel of the main ModelSelector. Includes a "use same
+ * for all" toggle and a skip button.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Check, ChevronDown, Search } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@sero-ai/ui/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui/components/ui/popover';
 import { Switch } from '@sero-ai/ui/components/ui/switch';
 import { Label } from '@sero-ai/ui/components/ui/label';
-import type { ModelTierSettings, ModelTierEntry, AvailableModelGroup } from '@/types/ipc';
-
-interface AvailableModel {
-  provider: string;
-  modelId: string;
-  name: string;
-  providerName: string;
-}
+import type { ModelTierSettings, ModelTierEntry, AvailableModelGroup, ModelInfo } from '@/types/ipc';
 
 interface TierPickerProps {
   onComplete: (tiers: ModelTierSettings) => void;
@@ -31,13 +20,13 @@ interface TierPickerProps {
 }
 
 const TIER_META = [
-  { key: 'LOW' as const, label: 'Low', desc: 'Fast, cheap tasks — scouts, quick lookups' },
-  { key: 'MED' as const, label: 'Medium', desc: 'Everyday agents — analysis, implementation, review' },
-  { key: 'HIGH' as const, label: 'High', desc: 'Complex reasoning — planning, coordination' },
+  { key: 'LOW' as const, label: 'Low', desc: 'Fast, cheap tasks' },
+  { key: 'MED' as const, label: 'Medium', desc: 'Everyday agents' },
+  { key: 'HIGH' as const, label: 'High', desc: 'Complex reasoning' },
 ] as const;
 
-function modelKey(m: { provider: string; modelId: string }): string {
-  return `${m.provider}/${m.modelId}`;
+function mkKey(provider: string, modelId: string): string {
+  return `${provider}/${modelId}`;
 }
 
 function parseModelKey(key: string): ModelTierEntry | null {
@@ -46,35 +35,179 @@ function parseModelKey(key: string): ModelTierEntry | null {
   return { provider: key.slice(0, idx), modelId: key.slice(idx + 1) };
 }
 
-function flattenModels(groups: AvailableModelGroup[]): AvailableModel[] {
-  const flat: AvailableModel[] = [];
+function filterGroups(groups: AvailableModelGroup[], query: string): AvailableModelGroup[] {
+  if (!query) return groups;
+  const q = query.toLowerCase();
+  const filtered: AvailableModelGroup[] = [];
   for (const group of groups) {
-    for (const m of group.models) {
-      flat.push({
-        provider: m.provider,
-        modelId: m.modelId,
-        name: m.name,
-        providerName: group.displayName,
-      });
-    }
+    const matches = group.models.filter(
+      (m) => m.name.toLowerCase().includes(q) || m.modelId.toLowerCase().includes(q),
+    );
+    if (matches.length) filtered.push({ ...group, models: matches });
   }
-  return flat;
+  return filtered;
 }
 
+// ── Popover-based Model Picker ──────────────────────────────
+
+function ModelPickerPopover({
+  groups,
+  selectedKey,
+  onSelect,
+  placeholder,
+}: {
+  groups: AvailableModelGroup[];
+  selectedKey: string;
+  onSelect: (key: string) => void;
+  placeholder: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(() => filterGroups(groups, filter), [groups, filter]);
+
+  const selectedModel = useMemo(() => {
+    if (!selectedKey) return null;
+    for (const g of groups) {
+      const m = g.models.find((model) => mkKey(model.provider, model.modelId) === selectedKey);
+      if (m) return { model: m, group: g };
+    }
+    return null;
+  }, [groups, selectedKey]);
+
+  const handleSelect = useCallback((model: ModelInfo) => {
+    onSelect(mkKey(model.provider, model.modelId));
+    setOpen(false);
+  }, [onSelect]);
+
+  const handleOpenChange = useCallback((next: boolean) => {
+    if (next) {
+      setFilter('');
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+    setOpen(next);
+  }, []);
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          className="flex w-full items-center justify-between rounded-md border border-[var(--border-default)]
+            bg-[var(--bg-base)] px-3 py-2 text-xs transition-colors
+            hover:border-[var(--border-hover)] hover:bg-[var(--bg-elevated)]"
+        >
+          {selectedModel ? (
+            <div className="flex items-center gap-2 min-w-0">
+              <img
+                src={selectedModel.group.logo}
+                alt={selectedModel.group.displayName}
+                className="size-3.5 rounded-sm shrink-0 dark:invert"
+              />
+              <span className="truncate font-medium text-[var(--text-primary)]">
+                {selectedModel.model.name}
+              </span>
+            </div>
+          ) : (
+            <span className="text-[var(--text-muted)]">{placeholder}</span>
+          )}
+          <ChevronDown className="size-3 shrink-0 text-[var(--text-muted)]" />
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        side="bottom"
+        align="start"
+        sideOffset={4}
+        className="w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-xl
+          border-[var(--border-subtle)] bg-[var(--bg-surface)] p-0 shadow-2xl shadow-black/40"
+      >
+        {/* Search */}
+        <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] px-3">
+          <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+          <input
+            ref={inputRef}
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Search models…"
+            className="h-8 w-full bg-transparent text-xs text-[var(--text-primary)]
+              placeholder:text-[var(--text-muted)] outline-none"
+          />
+        </div>
+
+        {/* Model list */}
+        <div className="max-h-[240px] overflow-y-auto py-1">
+          {filtered.length === 0 ? (
+            <div className="px-3 py-3 text-center text-xs text-[var(--text-muted)]">
+              No models matching &ldquo;{filter}&rdquo;
+            </div>
+          ) : (
+            filtered.map((group, i) => (
+              <div key={group.provider}>
+                {i > 0 && <div className="mx-3 border-t border-[var(--border-subtle)]" />}
+                <div className="py-1">
+                  <div className="flex items-center gap-2 px-3 pb-1 pt-2">
+                    <img
+                      src={group.logo}
+                      alt={group.displayName}
+                      className="size-3.5 rounded-sm dark:invert"
+                    />
+                    <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                      {group.displayName}
+                    </span>
+                  </div>
+                  <div className="px-1">
+                    {group.models.map((model) => {
+                      const key = mkKey(model.provider, model.modelId);
+                      const isSelected = key === selectedKey;
+                      return (
+                        <button
+                          key={key}
+                          onClick={() => handleSelect(model)}
+                          className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5
+                            text-left text-xs transition-colors duration-100 ${
+                            isSelected
+                              ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+                              : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]/60 hover:text-[var(--text-primary)]'
+                          }`}
+                        >
+                          <div className="flex size-4 shrink-0 items-center justify-center">
+                            {isSelected ? (
+                              <Check className="size-3.5 text-[var(--status-success)]" />
+                            ) : (
+                              <div className="size-1.5 rounded-full bg-[var(--border-default)]" />
+                            )}
+                          </div>
+                          <span className="truncate font-medium">{model.name}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+// ── Main Component ──────────────────────────────────────────
+
 export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
-  const [models, setModels] = useState<AvailableModel[]>([]);
+  const [groups, setGroups] = useState<AvailableModelGroup[]>([]);
   const [sameForAll, setSameForAll] = useState(false);
   const [selections, setSelections] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(true);
 
-  // Load available models via session-independent IPC bridge
+  // Load available models via session-independent IPC
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
-        const groups = await window.sero.models.list();
-        if (cancelled) return;
-        setModels(flattenModels(groups));
+        const result = await window.sero.models.list();
+        if (!cancelled) setGroups(result);
       } catch {
         // No models available
       } finally {
@@ -86,9 +219,7 @@ export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
 
   const handleSelect = useCallback((tier: string, value: string) => {
     setSelections((prev) => {
-      if (sameForAll) {
-        return { LOW: value, MED: value, HIGH: value };
-      }
+      if (sameForAll) return { LOW: value, MED: value, HIGH: value };
       return { ...prev, [tier]: value };
     });
   }, [sameForAll]);
@@ -96,10 +227,12 @@ export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
   const handleSameToggle = useCallback((checked: boolean) => {
     setSameForAll(checked);
     if (checked) {
-      const first = selections.LOW || selections.MED || selections.HIGH || '';
-      setSelections({ LOW: first, MED: first, HIGH: first });
+      setSelections((prev) => {
+        const first = prev.LOW || prev.MED || prev.HIGH || '';
+        return { LOW: first, MED: first, HIGH: first };
+      });
     }
-  }, [selections]);
+  }, []);
 
   const handleComplete = useCallback(() => {
     const tiers: ModelTierSettings = {};
@@ -114,6 +247,7 @@ export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
   }, [selections, onComplete]);
 
   const hasAnySelection = Object.values(selections).some(Boolean);
+  const totalModels = groups.reduce((n, g) => n + g.models.length, 0);
 
   if (loading) {
     return (
@@ -123,7 +257,7 @@ export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
     );
   }
 
-  if (models.length === 0) {
+  if (totalModels === 0) {
     return (
       <div className="space-y-3 text-center py-4">
         <p className="text-sm text-muted-foreground">
@@ -138,46 +272,34 @@ export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Switch
-            id="same-for-all"
-            checked={sameForAll}
-            onCheckedChange={handleSameToggle}
-          />
-          <Label htmlFor="same-for-all" className="text-xs text-muted-foreground">
-            Use the same model for all tiers
-          </Label>
-        </div>
+      <div className="flex items-center gap-2">
+        <Switch
+          id="same-for-all"
+          checked={sameForAll}
+          onCheckedChange={handleSameToggle}
+        />
+        <Label htmlFor="same-for-all" className="text-xs text-muted-foreground">
+          Use the same model for all tiers
+        </Label>
       </div>
 
       <div className="space-y-3">
         {(sameForAll ? [TIER_META[0]] : TIER_META).map(({ key, label, desc }) => (
-          <div key={key} className="space-y-1">
-            <Label className="text-sm font-medium">
-              {sameForAll ? 'All tiers' : label}
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              {sameForAll ? 'Single model for all task types' : desc}
-            </p>
-            <Select
-              value={selections[key] || ''}
-              onValueChange={(v) => handleSelect(key, v)}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder="Choose a model..." />
-              </SelectTrigger>
-              <SelectContent>
-                {models.map((m) => (
-                  <SelectItem key={modelKey(m)} value={modelKey(m)}>
-                    <span className="text-xs text-muted-foreground mr-1.5">
-                      {m.providerName}
-                    </span>
-                    {m.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <div key={key} className="space-y-1.5">
+            <div>
+              <Label className="text-sm font-medium">
+                {sameForAll ? 'All tiers' : label}
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                {sameForAll ? 'Single model for all task types' : desc}
+              </p>
+            </div>
+            <ModelPickerPopover
+              groups={groups}
+              selectedKey={selections[key] || ''}
+              onSelect={(v) => handleSelect(key, v)}
+              placeholder="Choose a model…"
+            />
           </div>
         ))}
       </div>

--- a/apps/desktop/src/components/profiles/TierPicker.tsx
+++ b/apps/desktop/src/components/profiles/TierPicker.tsx
@@ -1,54 +1,88 @@
 /**
- * TierPicker — onboarding step for picking default models per tier.
+ * TierPicker — advanced onboarding editor for LOW/MED/HIGH model tiers.
  *
- * Uses popover-based model pickers with search and provider grouping,
- * matching the look/feel of the main ModelSelector. Includes a "use same
- * for all" toggle and a skip button.
+ * Prefills the current recommendation, supports a same-model-for-all toggle,
+ * and only surfaces providers that currently have usable models.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Check, ChevronDown, Search } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
+import { Label } from '@sero-ai/ui/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui/components/ui/popover';
 import { Switch } from '@sero-ai/ui/components/ui/switch';
-import { Label } from '@sero-ai/ui/components/ui/label';
-import type { ModelTierSettings, ModelTierEntry, AvailableModelGroup, ModelInfo } from '@/types/ipc';
+import type {
+  AvailableModelGroup,
+  ModelInfo,
+  ModelTierEntry,
+  ModelTierSettings,
+  ProviderHealthInfo,
+} from '@/types/ipc';
 
 interface TierPickerProps {
-  onComplete: (tiers: ModelTierSettings) => void;
-  onSkip: () => void;
+  groups: AvailableModelGroup[];
+  providerHealth: ProviderHealthInfo[];
+  initialTiers: ModelTierSettings;
+  onSave: (tiers: ModelTierSettings) => void;
+  onBack: () => void;
 }
 
 const TIER_META = [
-  { key: 'LOW' as const, label: 'Low', desc: 'Fast, cheap tasks' },
-  { key: 'MED' as const, label: 'Medium', desc: 'Everyday agents' },
-  { key: 'HIGH' as const, label: 'High', desc: 'Complex reasoning' },
+  { key: 'LOW' as const, label: 'Low', desc: 'Fast, inexpensive work' },
+  { key: 'MED' as const, label: 'Medium', desc: 'General-purpose agents' },
+  { key: 'HIGH' as const, label: 'High', desc: 'Deep reasoning and complex work' },
 ] as const;
+
+type TierKey = (typeof TIER_META)[number]['key'];
+type SelectionState = Record<TierKey, string>;
 
 function mkKey(provider: string, modelId: string): string {
   return `${provider}/${modelId}`;
 }
 
 function parseModelKey(key: string): ModelTierEntry | null {
-  const idx = key.indexOf('/');
-  if (idx === -1) return null;
-  return { provider: key.slice(0, idx), modelId: key.slice(idx + 1) };
+  const separatorIndex = key.indexOf('/');
+  if (separatorIndex <= 0) return null;
+  return {
+    provider: key.slice(0, separatorIndex),
+    modelId: key.slice(separatorIndex + 1),
+  };
+}
+
+function createSelectionState(tiers: ModelTierSettings): SelectionState {
+  return {
+    LOW: tiers.LOW ? mkKey(tiers.LOW.provider, tiers.LOW.modelId) : '',
+    MED: tiers.MED ? mkKey(tiers.MED.provider, tiers.MED.modelId) : '',
+    HIGH: tiers.HIGH ? mkKey(tiers.HIGH.provider, tiers.HIGH.modelId) : '',
+  };
+}
+
+function areSelectionsUniform(selections: SelectionState): boolean {
+  const values = [selections.LOW, selections.MED, selections.HIGH].filter(Boolean);
+  return values.length === 3 && new Set(values).size === 1;
 }
 
 function filterGroups(groups: AvailableModelGroup[], query: string): AvailableModelGroup[] {
-  if (!query) return groups;
-  const q = query.toLowerCase();
-  const filtered: AvailableModelGroup[] = [];
-  for (const group of groups) {
-    const matches = group.models.filter(
-      (m) => m.name.toLowerCase().includes(q) || m.modelId.toLowerCase().includes(q),
-    );
-    if (matches.length) filtered.push({ ...group, models: matches });
-  }
-  return filtered;
+  if (!query.trim()) return groups;
+  const lowerQuery = query.trim().toLowerCase();
+
+  return groups
+    .map((group) => ({
+      ...group,
+      models: group.models.filter((model) =>
+        model.name.toLowerCase().includes(lowerQuery)
+        || model.modelId.toLowerCase().includes(lowerQuery),
+      ),
+    }))
+    .filter((group) => group.models.length > 0);
 }
 
-// ── Popover-based Model Picker ──────────────────────────────
+function hiddenBrokenProviders(providerHealth: ProviderHealthInfo[]): string[] {
+  return providerHealth
+    .filter((provider) => !provider.hasUsableModels && (provider.status === 'broken_expired' || provider.status === 'broken_invalid'))
+    .map((provider) => provider.displayName)
+    .sort((a, b) => a.localeCompare(b));
+}
 
 function ModelPickerPopover({
   groups,
@@ -65,29 +99,29 @@ function ModelPickerPopover({
   const [filter, setFilter] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const filtered = useMemo(() => filterGroups(groups, filter), [groups, filter]);
+  const filteredGroups = useMemo(() => filterGroups(groups, filter), [groups, filter]);
 
   const selectedModel = useMemo(() => {
     if (!selectedKey) return null;
-    for (const g of groups) {
-      const m = g.models.find((model) => mkKey(model.provider, model.modelId) === selectedKey);
-      if (m) return { model: m, group: g };
+    for (const group of groups) {
+      const model = group.models.find((entry) => mkKey(entry.provider, entry.modelId) === selectedKey);
+      if (model) return { group, model };
     }
     return null;
   }, [groups, selectedKey]);
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    if (nextOpen) {
+      setFilter('');
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+    setOpen(nextOpen);
+  }, []);
 
   const handleSelect = useCallback((model: ModelInfo) => {
     onSelect(mkKey(model.provider, model.modelId));
     setOpen(false);
   }, [onSelect]);
-
-  const handleOpenChange = useCallback((next: boolean) => {
-    if (next) {
-      setFilter('');
-      requestAnimationFrame(() => inputRef.current?.focus());
-    }
-    setOpen(next);
-  }, []);
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
@@ -98,11 +132,11 @@ function ModelPickerPopover({
             hover:border-[var(--border-hover)] hover:bg-[var(--bg-elevated)]"
         >
           {selectedModel ? (
-            <div className="flex items-center gap-2 min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
               <img
                 src={selectedModel.group.logo}
                 alt={selectedModel.group.displayName}
-                className="size-3.5 rounded-sm shrink-0 dark:invert"
+                className="size-3.5 shrink-0 rounded-sm dark:invert"
               />
               <span className="truncate font-medium text-[var(--text-primary)]">
                 {selectedModel.model.name}
@@ -121,31 +155,29 @@ function ModelPickerPopover({
         sideOffset={4}
         className="w-[var(--radix-popover-trigger-width)] overflow-hidden rounded-xl
           border-[var(--border-subtle)] bg-[var(--bg-surface)] p-0 shadow-2xl shadow-black/40"
-        onWheel={(e) => e.stopPropagation()}
+        onWheel={(event) => event.stopPropagation()}
       >
-        {/* Search */}
         <div className="flex items-center gap-2 border-b border-[var(--border-subtle)] px-3">
           <Search className="size-3.5 shrink-0 text-[var(--text-muted)]" />
           <input
             ref={inputRef}
             value={filter}
-            onChange={(e) => setFilter(e.target.value)}
+            onChange={(event) => setFilter(event.target.value)}
             placeholder="Search models…"
             className="h-8 w-full bg-transparent text-xs text-[var(--text-primary)]
               placeholder:text-[var(--text-muted)] outline-none"
           />
         </div>
 
-        {/* Model list — overscroll-contain fixes trackpad scrolling inside Radix popovers */}
         <div className="max-h-[240px] overflow-y-auto overscroll-contain py-1">
-          {filtered.length === 0 ? (
+          {filteredGroups.length === 0 ? (
             <div className="px-3 py-3 text-center text-xs text-[var(--text-muted)]">
-              No models matching &ldquo;{filter}&rdquo;
+              No models match “{filter}”
             </div>
           ) : (
-            filtered.map((group, i) => (
+            filteredGroups.map((group, groupIndex) => (
               <div key={group.provider}>
-                {i > 0 && <div className="mx-3 border-t border-[var(--border-subtle)]" />}
+                {groupIndex > 0 ? <div className="mx-3 border-t border-[var(--border-subtle)]" /> : null}
                 <div className="py-1">
                   <div className="flex items-center gap-2 px-3 pb-1 pt-2">
                     <img
@@ -165,8 +197,7 @@ function ModelPickerPopover({
                         <button
                           key={key}
                           onClick={() => handleSelect(model)}
-                          className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5
-                            text-left text-xs transition-colors duration-100 ${
+                          className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-xs transition-colors duration-100 ${
                             isSelected
                               ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
                               : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]/60 hover:text-[var(--text-primary)]'
@@ -194,111 +225,96 @@ function ModelPickerPopover({
   );
 }
 
-// ── Main Component ──────────────────────────────────────────
+export function TierPicker({
+  groups,
+  providerHealth,
+  initialTiers,
+  onSave,
+  onBack,
+}: TierPickerProps) {
+  const usableGroups = useMemo(
+    () => groups.filter((group) => group.models.length > 0),
+    [groups],
+  );
+  const brokenProviders = useMemo(
+    () => hiddenBrokenProviders(providerHealth),
+    [providerHealth],
+  );
 
-export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
-  const [groups, setGroups] = useState<AvailableModelGroup[]>([]);
-  const [sameForAll, setSameForAll] = useState(false);
-  const [selections, setSelections] = useState<Record<string, string>>({});
-  const [loading, setLoading] = useState(true);
+  const initialSelections = useMemo(() => createSelectionState(initialTiers), [initialTiers]);
+  const [sameForAll, setSameForAll] = useState(areSelectionsUniform(initialSelections));
+  const [selections, setSelections] = useState<SelectionState>(initialSelections);
 
-  // Load available models via session-independent IPC
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const result = await window.sero.models.list();
-        if (!cancelled) setGroups(result);
-      } catch {
-        // No models available
-      } finally {
-        if (!cancelled) setLoading(false);
+  const handleSelect = useCallback((tier: TierKey, value: string) => {
+    setSelections((current) => {
+      if (sameForAll) {
+        return { LOW: value, MED: value, HIGH: value };
       }
-    })();
-    return () => { cancelled = true; };
-  }, []);
-
-  const handleSelect = useCallback((tier: string, value: string) => {
-    setSelections((prev) => {
-      if (sameForAll) return { LOW: value, MED: value, HIGH: value };
-      return { ...prev, [tier]: value };
+      return { ...current, [tier]: value };
     });
   }, [sameForAll]);
 
   const handleSameToggle = useCallback((checked: boolean) => {
     setSameForAll(checked);
-    if (checked) {
-      setSelections((prev) => {
-        const first = prev.LOW || prev.MED || prev.HIGH || '';
-        return { LOW: first, MED: first, HIGH: first };
-      });
-    }
+    if (!checked) return;
+
+    setSelections((current) => {
+      const sharedValue = current.LOW || current.MED || current.HIGH || '';
+      return { LOW: sharedValue, MED: sharedValue, HIGH: sharedValue };
+    });
   }, []);
 
-  const handleComplete = useCallback(() => {
-    const tiers: ModelTierSettings = {};
+  const allSelectionsFilled = sameForAll
+    ? Boolean(selections.LOW || selections.MED || selections.HIGH)
+    : TIER_META.every(({ key }) => Boolean(selections[key]));
+
+  const handleSave = useCallback(() => {
+    const nextTiers: ModelTierSettings = {};
     for (const { key } of TIER_META) {
-      const val = selections[key];
-      if (val) {
-        const parsed = parseModelKey(val);
-        if (parsed) tiers[key] = parsed;
-      }
+      const rawValue = sameForAll ? (selections.LOW || selections.MED || selections.HIGH) : selections[key];
+      const entry = rawValue ? parseModelKey(rawValue) : null;
+      if (entry) nextTiers[key] = entry;
     }
-    onComplete(tiers);
-  }, [selections, onComplete]);
-
-  const hasAnySelection = Object.values(selections).some(Boolean);
-  const totalModels = groups.reduce((n, g) => n + g.models.length, 0);
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
-        Loading available models...
-      </div>
-    );
-  }
-
-  if (totalModels === 0) {
-    return (
-      <div className="space-y-3 text-center py-4">
-        <p className="text-sm text-muted-foreground">
-          No models available. Sign in to a provider first.
-        </p>
-        <Button variant="ghost" size="sm" onClick={onSkip}>
-          Skip for now
-        </Button>
-      </div>
-    );
-  }
+    onSave(nextTiers);
+  }, [onSave, sameForAll, selections]);
 
   return (
     <div className="space-y-4">
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-[var(--text-primary)]">Customize your model tiers</p>
+        <p className="text-xs text-[var(--text-secondary)]">
+          These defaults stay tied to this profile. You can change them again later.
+        </p>
+      </div>
+
       <div className="flex items-center gap-2">
-        <Switch
-          id="same-for-all"
-          checked={sameForAll}
-          onCheckedChange={handleSameToggle}
-        />
-        <Label htmlFor="same-for-all" className="text-xs text-muted-foreground">
+        <Switch id="same-for-all" checked={sameForAll} onCheckedChange={handleSameToggle} />
+        <Label htmlFor="same-for-all" className="text-xs text-[var(--text-secondary)]">
           Use the same model for all tiers
         </Label>
       </div>
+
+      {brokenProviders.length > 0 ? (
+        <div className="rounded-md border border-[var(--status-warning)]/20 bg-[var(--status-warning)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
+          Hidden for now: {brokenProviders.join(', ')} need to be reconnected before their models can be used.
+        </div>
+      ) : null}
 
       <div className="space-y-3">
         {(sameForAll ? [TIER_META[0]] : TIER_META).map(({ key, label, desc }) => (
           <div key={key} className="space-y-1.5">
             <div>
-              <Label className="text-sm font-medium">
+              <Label className="text-sm font-medium text-[var(--text-primary)]">
                 {sameForAll ? 'All tiers' : label}
               </Label>
-              <p className="text-xs text-muted-foreground">
-                {sameForAll ? 'Single model for all task types' : desc}
+              <p className="text-xs text-[var(--text-secondary)]">
+                {sameForAll ? 'One model for every task complexity.' : desc}
               </p>
             </div>
             <ModelPickerPopover
-              groups={groups}
-              selectedKey={selections[key] || ''}
-              onSelect={(v) => handleSelect(key, v)}
+              groups={usableGroups}
+              selectedKey={selections[key]}
+              onSelect={(value) => handleSelect(key, value)}
               placeholder="Choose a model…"
             />
           </div>
@@ -306,11 +322,11 @@ export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
       </div>
 
       <div className="flex items-center justify-between pt-1">
-        <Button variant="ghost" size="sm" onClick={onSkip}>
-          Skip
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
         </Button>
-        <Button size="sm" onClick={handleComplete} disabled={!hasAnySelection}>
-          Continue
+        <Button size="sm" onClick={handleSave} disabled={!allSelectionsFilled}>
+          Save model tiers
         </Button>
       </div>
     </div>

--- a/apps/desktop/src/components/profiles/onboarding/OnboardingViews.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/OnboardingViews.tsx
@@ -1,0 +1,365 @@
+import { CheckCircle2, KeyRound, Loader2, Sparkles, TriangleAlert } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import type {
+  AvailableModelGroup,
+  OnboardingRecommendation,
+  OnboardingWarning,
+  ProviderHealthInfo,
+} from '@/types/ipc';
+import { findGroup, findModel } from '@/components/layout/model-config';
+
+function statusLabel(provider: ProviderHealthInfo): string {
+  switch (provider.status) {
+    case 'healthy':
+      return 'healthy';
+    case 'env':
+      return 'env';
+    case 'local':
+      return 'local';
+    case 'broken_expired':
+      return 'expired';
+    case 'broken_invalid':
+      return 'invalid';
+    case 'missing':
+      return 'missing';
+    case 'unknown':
+    default:
+      return 'unknown';
+  }
+}
+
+function summarizeProviderHealth(providerHealth: ProviderHealthInfo[]): string {
+  const healthyCount = providerHealth.filter((provider) => provider.hasUsableModels).length;
+  const brokenCount = providerHealth.filter(
+    (provider) => provider.status === 'broken_expired' || provider.status === 'broken_invalid',
+  ).length;
+  const envCount = providerHealth.filter((provider) => provider.status === 'env').length;
+  const localCount = providerHealth.filter((provider) => provider.status === 'local').length;
+
+  const parts = [`${healthyCount} usable provider${healthyCount === 1 ? '' : 's'}`];
+  if (envCount > 0) parts.push(`${envCount} env-backed`);
+  if (localCount > 0) parts.push(`${localCount} local`);
+  if (brokenCount > 0) parts.push(`${brokenCount} needs attention`);
+  return parts.join(' · ');
+}
+
+function sourceLabel(source: OnboardingRecommendation['sourcesByTier'][keyof OnboardingRecommendation['sourcesByTier']]) {
+  switch (source) {
+    case 'preserved':
+      return 'Preserved';
+    case 'provider-defaults':
+      return 'Recommended';
+    case 'imported':
+      return 'Imported';
+    case 'fallback':
+    default:
+      return 'Fallback';
+  }
+}
+
+function TierSummaryCard({
+  tierLabel,
+  provider,
+  modelName,
+  source,
+  logo,
+}: {
+  tierLabel: string;
+  provider: string;
+  modelName: string;
+  source?: OnboardingRecommendation['sourcesByTier'][keyof OnboardingRecommendation['sourcesByTier']];
+  logo?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/50 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+          {tierLabel}
+        </span>
+        {source ? (
+          <span className="rounded-full bg-[var(--bg-surface)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)]">
+            {sourceLabel(source)}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        {logo ? <img src={logo} alt={provider} className="size-4 rounded-sm dark:invert" /> : null}
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-[var(--text-primary)]">{modelName}</p>
+          <p className="truncate text-xs text-[var(--text-secondary)]">{provider}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WarningBanner({
+  warning,
+  providerHealth,
+  onReconnectProvider,
+}: {
+  warning: OnboardingWarning;
+  providerHealth: ProviderHealthInfo[];
+  onReconnectProvider: (providerId: string | null) => void;
+}) {
+  const providers = warning.providerIds
+    ?.map((providerId) => providerHealth.find((provider) => provider.providerId === providerId))
+    .filter((provider): provider is ProviderHealthInfo => Boolean(provider));
+
+  return (
+    <div className="rounded-lg border border-[var(--status-warning)]/25 bg-[var(--status-warning)]/5 px-3 py-2.5 text-xs text-[var(--text-secondary)]">
+      <div className="flex items-start gap-2">
+        <TriangleAlert className="mt-0.5 size-4 shrink-0 text-[var(--status-warning)]" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <p>{warning.message}</p>
+          {providers && providers.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {providers.map((provider) => (
+                <button
+                  key={provider.providerId}
+                  onClick={() => onReconnectProvider(provider.providerId)}
+                  className="rounded-full border border-[var(--border-default)] bg-[var(--bg-surface)] px-2.5 py-1 text-[10px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)]"
+                >
+                  Reconnect {provider.displayName}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ReadyScreen({
+  recommendation,
+  availableModelGroups,
+  providerHealth,
+  warnings,
+  launchNotice,
+  onContinue,
+  onCustomize,
+  onAddProvider,
+  onReconnectProvider,
+}: {
+  recommendation: OnboardingRecommendation;
+  availableModelGroups: AvailableModelGroup[];
+  providerHealth: ProviderHealthInfo[];
+  warnings: OnboardingWarning[];
+  launchNotice?: string | null;
+  onContinue: () => void;
+  onCustomize: () => void;
+  onAddProvider: () => void;
+  onReconnectProvider: (providerId: string | null) => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+          <Sparkles className="size-5 text-[var(--status-success)]" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Sero is ready</h2>
+          <p className="text-sm text-[var(--text-secondary)]">
+            We found a working setup and recommended the best LOW, MED, and HIGH tiers for this profile.
+          </p>
+        </div>
+      </div>
+
+      {launchNotice ? (
+        <div className="rounded-lg border border-[var(--status-success)]/20 bg-[var(--status-success)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
+          {launchNotice}
+        </div>
+      ) : null}
+
+      <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+        {summarizeProviderHealth(providerHealth)}
+      </div>
+
+      <div className="grid gap-3">
+        {(['LOW', 'MED', 'HIGH'] as const).map((tier) => {
+          const entry = recommendation.tiers[tier];
+          if (!entry) return null;
+          const group = findGroup(availableModelGroups, entry.provider, entry.modelId);
+          const model = findModel(availableModelGroups, entry.provider, entry.modelId);
+          return (
+            <TierSummaryCard
+              key={tier}
+              tierLabel={tier}
+              provider={group?.displayName ?? entry.provider}
+              modelName={model?.name ?? entry.modelId}
+              source={recommendation.sourcesByTier[tier]}
+              logo={group?.logo}
+            />
+          );
+        })}
+      </div>
+
+      {warnings.map((warning) => (
+        <WarningBanner
+          key={warning.code}
+          warning={warning}
+          providerHealth={providerHealth}
+          onReconnectProvider={onReconnectProvider}
+        />
+      ))}
+
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" onClick={onCustomize}>
+            Customize models
+          </Button>
+          <Button variant="outline" size="sm" onClick={onAddProvider}>
+            <KeyRound className="mr-2 size-3.5" />
+            Add or reconnect provider
+          </Button>
+        </div>
+        <Button size="sm" onClick={onContinue}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function AuthScreen({
+  providerHealth,
+  launchNotice,
+  onAddProvider,
+  onReconnectProvider,
+}: {
+  providerHealth: ProviderHealthInfo[];
+  launchNotice?: string | null;
+  onAddProvider: () => void;
+  onReconnectProvider: (providerId: string | null) => void;
+}) {
+  const actionableProviders = providerHealth.filter(
+    (provider) => provider.status === 'broken_expired' || provider.status === 'broken_invalid',
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+          <KeyRound className="size-5 text-[var(--status-success)]" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Connect a provider to continue</h2>
+          <p className="text-sm text-[var(--text-secondary)]">
+            Sero needs at least one usable model before it can launch your welcome session.
+          </p>
+        </div>
+      </div>
+
+      {launchNotice ? (
+        <div className="rounded-lg border border-[var(--status-warning)]/20 bg-[var(--status-warning)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
+          {launchNotice}
+        </div>
+      ) : null}
+
+      {actionableProviders.length > 0 ? (
+        <div className="space-y-2 rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/50 p-3">
+          <p className="text-xs font-medium text-[var(--text-primary)]">Providers that need attention</p>
+          <div className="space-y-2">
+            {actionableProviders.map((provider) => (
+              <div key={provider.providerId} className="flex items-start justify-between gap-3 rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-2">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-[var(--text-primary)]">{provider.displayName}</p>
+                  <p className="text-xs text-[var(--text-secondary)]">{provider.message}</p>
+                </div>
+                <Button variant="outline" size="sm" onClick={() => onReconnectProvider(provider.providerId)}>
+                  Reconnect
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+        {providerHealth
+          .filter((provider) => provider.status !== 'missing')
+          .map((provider) => `${provider.displayName}: ${statusLabel(provider)}`)
+          .join(' · ') || 'No providers configured yet.'}
+      </div>
+
+      <div className="flex justify-end">
+        <Button size="sm" onClick={onAddProvider}>
+          <KeyRound className="mr-2 size-3.5" />
+          Add provider
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function LaunchingScreen({ statusMessage }: { statusMessage?: string | null }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+        <Loader2 className="size-5 animate-spin text-[var(--status-success)]" />
+      </div>
+      <div>
+        <h2 className="text-lg font-semibold text-[var(--text-primary)]">Opening your welcome session</h2>
+        <p className="text-sm text-[var(--text-secondary)]">
+          Sero is saving your model setup and starting the memory onboarding flow.
+        </p>
+      </div>
+      {statusMessage ? (
+        <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+          {statusMessage}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ErrorScreen({
+  message,
+  onRetry,
+  onBack,
+}: {
+  message: string | null;
+  onRetry: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+          <TriangleAlert className="size-5 text-[var(--status-warning)]" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Onboarding hit an error</h2>
+          <p className="text-sm text-[var(--text-secondary)]">
+            Something unexpected happened while Sero was preparing your first session.
+          </p>
+        </div>
+      </div>
+
+      {message ? (
+        <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+          {message}
+        </div>
+      ) : null}
+
+      <div className="flex justify-between gap-2">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
+        </Button>
+        <Button size="sm" onClick={onRetry}>
+          Retry
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function DoneNotice() {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-[var(--status-success)]/20 bg-[var(--status-success)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
+      <CheckCircle2 className="size-4 text-[var(--status-success)]" />
+      Onboarding complete.
+    </div>
+  );
+}

--- a/apps/desktop/src/components/profiles/onboarding/OnboardingViews.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/OnboardingViews.tsx
@@ -1,12 +1,8 @@
-import { CheckCircle2, KeyRound, Loader2, Sparkles, TriangleAlert } from 'lucide-react';
+import { KeyRound, Loader2, TriangleAlert } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
-import type {
-  AvailableModelGroup,
-  OnboardingRecommendation,
-  OnboardingWarning,
-  ProviderHealthInfo,
-} from '@/types/ipc';
-import { findGroup, findModel } from '@/components/layout/model-config';
+import type { ProviderHealthInfo } from '@/types/ipc';
+
+export { OnboardingSetupScreen } from './SetupScreen';
 
 function statusLabel(provider: ProviderHealthInfo): string {
   switch (provider.status) {
@@ -28,209 +24,15 @@ function statusLabel(provider: ProviderHealthInfo): string {
   }
 }
 
-function summarizeProviderHealth(providerHealth: ProviderHealthInfo[]): string {
-  const healthyCount = providerHealth.filter((provider) => provider.hasUsableModels).length;
-  const brokenCount = providerHealth.filter(
-    (provider) => provider.status === 'broken_expired' || provider.status === 'broken_invalid',
-  ).length;
-  const envCount = providerHealth.filter((provider) => provider.status === 'env').length;
-  const localCount = providerHealth.filter((provider) => provider.status === 'local').length;
-
-  const parts = [`${healthyCount} usable provider${healthyCount === 1 ? '' : 's'}`];
-  if (envCount > 0) parts.push(`${envCount} env-backed`);
-  if (localCount > 0) parts.push(`${localCount} local`);
-  if (brokenCount > 0) parts.push(`${brokenCount} needs attention`);
-  return parts.join(' · ');
-}
-
-function sourceLabel(source: OnboardingRecommendation['sourcesByTier'][keyof OnboardingRecommendation['sourcesByTier']]) {
-  switch (source) {
-    case 'preserved':
-      return 'Preserved';
-    case 'provider-defaults':
-      return 'Recommended';
-    case 'imported':
-      return 'Imported';
-    case 'fallback':
-    default:
-      return 'Fallback';
-  }
-}
-
-function TierSummaryCard({
-  tierLabel,
-  provider,
-  modelName,
-  source,
-  logo,
-}: {
-  tierLabel: string;
-  provider: string;
-  modelName: string;
-  source?: OnboardingRecommendation['sourcesByTier'][keyof OnboardingRecommendation['sourcesByTier']];
-  logo?: string;
-}) {
-  return (
-    <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/50 p-3">
-      <div className="flex items-center justify-between gap-2">
-        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
-          {tierLabel}
-        </span>
-        {source ? (
-          <span className="rounded-full bg-[var(--bg-surface)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)]">
-            {sourceLabel(source)}
-          </span>
-        ) : null}
-      </div>
-      <div className="mt-2 flex items-center gap-2">
-        {logo ? <img src={logo} alt={provider} className="size-4 rounded-sm dark:invert" /> : null}
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-[var(--text-primary)]">{modelName}</p>
-          <p className="truncate text-xs text-[var(--text-secondary)]">{provider}</p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function WarningBanner({
-  warning,
-  providerHealth,
-  onReconnectProvider,
-}: {
-  warning: OnboardingWarning;
-  providerHealth: ProviderHealthInfo[];
-  onReconnectProvider: (providerId: string | null) => void;
-}) {
-  const providers = warning.providerIds
-    ?.map((providerId) => providerHealth.find((provider) => provider.providerId === providerId))
-    .filter((provider): provider is ProviderHealthInfo => Boolean(provider));
-
-  return (
-    <div className="rounded-lg border border-[var(--status-warning)]/25 bg-[var(--status-warning)]/5 px-3 py-2.5 text-xs text-[var(--text-secondary)]">
-      <div className="flex items-start gap-2">
-        <TriangleAlert className="mt-0.5 size-4 shrink-0 text-[var(--status-warning)]" />
-        <div className="min-w-0 flex-1 space-y-2">
-          <p>{warning.message}</p>
-          {providers && providers.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {providers.map((provider) => (
-                <button
-                  key={provider.providerId}
-                  onClick={() => onReconnectProvider(provider.providerId)}
-                  className="rounded-full border border-[var(--border-default)] bg-[var(--bg-surface)] px-2.5 py-1 text-[10px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)]"
-                >
-                  Reconnect {provider.displayName}
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function ReadyScreen({
-  recommendation,
-  availableModelGroups,
-  providerHealth,
-  warnings,
-  launchNotice,
-  onContinue,
-  onCustomize,
-  onAddProvider,
-  onReconnectProvider,
-}: {
-  recommendation: OnboardingRecommendation;
-  availableModelGroups: AvailableModelGroup[];
-  providerHealth: ProviderHealthInfo[];
-  warnings: OnboardingWarning[];
-  launchNotice?: string | null;
-  onContinue: () => void;
-  onCustomize: () => void;
-  onAddProvider: () => void;
-  onReconnectProvider: (providerId: string | null) => void;
-}) {
-  return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-          <Sparkles className="size-5 text-[var(--status-success)]" />
-        </div>
-        <div>
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Sero is ready</h2>
-          <p className="text-sm text-[var(--text-secondary)]">
-            We found a working setup and recommended the best LOW, MED, and HIGH tiers for this profile.
-          </p>
-        </div>
-      </div>
-
-      {launchNotice ? (
-        <div className="rounded-lg border border-[var(--status-success)]/20 bg-[var(--status-success)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
-          {launchNotice}
-        </div>
-      ) : null}
-
-      <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-2 text-xs text-[var(--text-secondary)]">
-        {summarizeProviderHealth(providerHealth)}
-      </div>
-
-      <div className="grid gap-3">
-        {(['LOW', 'MED', 'HIGH'] as const).map((tier) => {
-          const entry = recommendation.tiers[tier];
-          if (!entry) return null;
-          const group = findGroup(availableModelGroups, entry.provider, entry.modelId);
-          const model = findModel(availableModelGroups, entry.provider, entry.modelId);
-          return (
-            <TierSummaryCard
-              key={tier}
-              tierLabel={tier}
-              provider={group?.displayName ?? entry.provider}
-              modelName={model?.name ?? entry.modelId}
-              source={recommendation.sourcesByTier[tier]}
-              logo={group?.logo}
-            />
-          );
-        })}
-      </div>
-
-      {warnings.map((warning) => (
-        <WarningBanner
-          key={warning.code}
-          warning={warning}
-          providerHealth={providerHealth}
-          onReconnectProvider={onReconnectProvider}
-        />
-      ))}
-
-      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
-        <div className="flex gap-2">
-          <Button variant="ghost" size="sm" onClick={onCustomize}>
-            Customize models
-          </Button>
-          <Button variant="outline" size="sm" onClick={onAddProvider}>
-            <KeyRound className="mr-2 size-3.5" />
-            Add or reconnect provider
-          </Button>
-        </div>
-        <Button size="sm" onClick={onContinue}>
-          Continue
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 export function AuthScreen({
   providerHealth,
   launchNotice,
-  onAddProvider,
+  onOpenProviders,
   onReconnectProvider,
 }: {
   providerHealth: ProviderHealthInfo[];
   launchNotice?: string | null;
-  onAddProvider: () => void;
+  onOpenProviders: () => void;
   onReconnectProvider: (providerId: string | null) => void;
 }) {
   const actionableProviders = providerHealth.filter(
@@ -244,9 +46,9 @@ export function AuthScreen({
           <KeyRound className="size-5 text-[var(--status-success)]" />
         </div>
         <div>
-          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Connect a provider to continue</h2>
+          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Connect a provider</h2>
           <p className="text-sm text-[var(--text-secondary)]">
-            Sero needs at least one usable model before it can launch your welcome session.
+            Sero needs a working model before it can start your welcome session.
           </p>
         </div>
       </div>
@@ -259,7 +61,7 @@ export function AuthScreen({
 
       {actionableProviders.length > 0 ? (
         <div className="space-y-2 rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/50 p-3">
-          <p className="text-xs font-medium text-[var(--text-primary)]">Providers that need attention</p>
+          <p className="text-xs font-medium text-[var(--text-primary)]">Needs attention</p>
           <div className="space-y-2">
             {actionableProviders.map((provider) => (
               <div key={provider.providerId} className="flex items-start justify-between gap-3 rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] px-3 py-2">
@@ -284,9 +86,9 @@ export function AuthScreen({
       </div>
 
       <div className="flex justify-end">
-        <Button size="sm" onClick={onAddProvider}>
+        <Button size="sm" onClick={onOpenProviders}>
           <KeyRound className="mr-2 size-3.5" />
-          Add provider
+          Providers
         </Button>
       </div>
     </div>
@@ -351,15 +153,6 @@ export function ErrorScreen({
           Retry
         </Button>
       </div>
-    </div>
-  );
-}
-
-export function DoneNotice() {
-  return (
-    <div className="flex items-center gap-2 rounded-lg border border-[var(--status-success)]/20 bg-[var(--status-success)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
-      <CheckCircle2 className="size-4 text-[var(--status-success)]" />
-      Onboarding complete.
     </div>
   );
 }

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -1,0 +1,421 @@
+import { useState } from 'react';
+import { KeyRound, Sparkles, TriangleAlert } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@sero-ai/ui/components/ui/select';
+import { Switch } from '@sero-ai/ui/components/ui/switch';
+import type {
+  AvailableModelGroup,
+  ModelTier,
+  ModelTierSettings,
+  OnboardingRecommendation,
+  OnboardingWarning,
+  ProviderHealthInfo,
+  ResolvedProviderDefaultsState,
+} from '@/types/ipc';
+
+const TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
+
+function modelKey(provider: string, modelId: string): string {
+  return `${provider}/${modelId}`;
+}
+
+function parseModelKey(value: string): { provider: string; modelId: string } | null {
+  const separatorIndex = value.indexOf('/');
+  if (separatorIndex <= 0) return null;
+  return {
+    provider: value.slice(0, separatorIndex),
+    modelId: value.slice(separatorIndex + 1),
+  };
+}
+
+function getProviderGroup(
+  groups: AvailableModelGroup[],
+  providerId: string,
+): AvailableModelGroup | undefined {
+  return groups.find((group) => group.provider === providerId);
+}
+
+function scoreModelForTier(
+  model: AvailableModelGroup['models'][number],
+  tier: ModelTier,
+): number {
+  const haystack = `${model.modelId} ${model.name}`.toLowerCase();
+  let score = 0;
+
+  const isFast = /mini|haiku|flash|nano|small|instant|fast/.test(haystack);
+  const isCapable = /pro|sonnet|opus|max|ultra|reason|thinking|gpt-5/.test(haystack);
+
+  if (tier === 'LOW') {
+    if (isFast) score += 40;
+    if (isCapable) score -= 15;
+    if (!model.reasoning) score += 8;
+  }
+
+  if (tier === 'MED') {
+    if (isCapable) score += 20;
+    if (model.reasoning) score += 8;
+  }
+
+  if (tier === 'HIGH') {
+    if (isCapable) score += 35;
+    if (model.reasoning) score += 15;
+    if (isFast) score -= 15;
+  }
+
+  return score;
+}
+
+function getTierModelForProvider(
+  providerId: string,
+  tier: ModelTier,
+  groups: AvailableModelGroup[],
+  providerDefaults: ResolvedProviderDefaultsState,
+): { provider: string; modelId: string } | null {
+  const group = getProviderGroup(groups, providerId);
+  if (!group || group.models.length === 0) return null;
+
+  const preferredModelId = providerDefaults.effectiveDefaults[providerId]?.[tier];
+  if (preferredModelId) {
+    const preferredModel = group.models.find((model) => model.modelId === preferredModelId);
+    if (preferredModel) {
+      return {
+        provider: preferredModel.provider,
+        modelId: preferredModel.modelId,
+      };
+    }
+  }
+
+  const fallbackModel = [...group.models].sort((a, b) => {
+    const scoreDelta = scoreModelForTier(b, tier) - scoreModelForTier(a, tier);
+    if (scoreDelta !== 0) return scoreDelta;
+    return a.name.localeCompare(b.name) || a.modelId.localeCompare(b.modelId);
+  })[0];
+
+  return fallbackModel
+    ? { provider: fallbackModel.provider, modelId: fallbackModel.modelId }
+    : null;
+}
+
+function getSuggestedTiersForProvider(
+  providerId: string,
+  groups: AvailableModelGroup[],
+  providerDefaults: ResolvedProviderDefaultsState,
+): ModelTierSettings {
+  const result: ModelTierSettings = {};
+  for (const tier of TIERS) {
+    const entry = getTierModelForProvider(providerId, tier, groups, providerDefaults);
+    if (entry) result[tier] = entry;
+  }
+  return result;
+}
+
+function getInitialProviderId(
+  recommendation: OnboardingRecommendation,
+  groups: AvailableModelGroup[],
+): string {
+  return recommendation.preferredProvider
+    ?? recommendation.tiers.HIGH?.provider
+    ?? recommendation.tiers.MED?.provider
+    ?? recommendation.tiers.LOW?.provider
+    ?? groups[0]?.provider
+    ?? '';
+}
+
+function getInitialSimpleModelKey(
+  recommendation: OnboardingRecommendation,
+  providerId: string,
+  groups: AvailableModelGroup[],
+  providerDefaults: ResolvedProviderDefaultsState,
+): string {
+  const high = recommendation.tiers.HIGH;
+  if (high && high.provider === providerId) return modelKey(high.provider, high.modelId);
+
+  const med = recommendation.tiers.MED;
+  if (med && med.provider === providerId) return modelKey(med.provider, med.modelId);
+
+  const low = recommendation.tiers.LOW;
+  if (low && low.provider === providerId) return modelKey(low.provider, low.modelId);
+
+  const suggested = getSuggestedTiersForProvider(providerId, groups, providerDefaults);
+  const entry = suggested.MED ?? suggested.HIGH ?? suggested.LOW;
+  return entry ? modelKey(entry.provider, entry.modelId) : '';
+}
+
+function getModelName(
+  groups: AvailableModelGroup[],
+  provider: string,
+  modelId: string,
+): string {
+  const group = getProviderGroup(groups, provider);
+  const model = group?.models.find((candidate) => candidate.modelId === modelId);
+  return model?.name ?? modelId;
+}
+
+function WarningBanner({
+  warning,
+  providerHealth,
+  onReconnectProvider,
+}: {
+  warning: OnboardingWarning;
+  providerHealth: ProviderHealthInfo[];
+  onReconnectProvider: (providerId: string | null) => void;
+}) {
+  const providers = warning.providerIds
+    ?.map((providerId) => providerHealth.find((provider) => provider.providerId === providerId))
+    .filter((provider): provider is ProviderHealthInfo => Boolean(provider));
+
+  return (
+    <div className="rounded-lg border border-[var(--status-warning)]/25 bg-[var(--status-warning)]/5 px-3 py-2.5 text-xs text-[var(--text-secondary)]">
+      <div className="flex items-start gap-2">
+        <TriangleAlert className="mt-0.5 size-4 shrink-0 text-[var(--status-warning)]" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <p>{warning.message}</p>
+          {providers && providers.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {providers.map((provider) => (
+                <button
+                  key={provider.providerId}
+                  onClick={() => onReconnectProvider(provider.providerId)}
+                  className="rounded-full border border-[var(--border-default)] bg-[var(--bg-surface)] px-2.5 py-1 text-[10px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)]"
+                >
+                  Reconnect {provider.displayName}
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TierModelFields({
+  providerId,
+  availableModelGroups,
+  tieredSelections,
+  onTierChange,
+}: {
+  providerId: string;
+  availableModelGroups: AvailableModelGroup[];
+  tieredSelections: ModelTierSettings;
+  onTierChange: (tier: ModelTier, value: string) => void;
+}) {
+  const providerGroup = getProviderGroup(availableModelGroups, providerId);
+  if (!providerGroup) return null;
+
+  return (
+    <div className="grid gap-3">
+      {TIERS.map((tier) => (
+        <div key={tier} className="space-y-1.5">
+          <Label className="text-xs font-medium text-[var(--text-primary)]">
+            {tier === 'LOW' ? 'Low complexity' : tier === 'MED' ? 'Medium complexity' : 'High complexity'}
+          </Label>
+          <Select
+            value={tieredSelections[tier] ? modelKey(tieredSelections[tier]!.provider, tieredSelections[tier]!.modelId) : ''}
+            onValueChange={(value) => onTierChange(tier, value)}
+          >
+            <SelectTrigger className="h-10 text-left">
+              <SelectValue placeholder={`Choose a ${tier.toLowerCase()} model`} />
+            </SelectTrigger>
+            <SelectContent>
+              {providerGroup.models.map((model) => (
+                <SelectItem key={modelKey(model.provider, model.modelId)} value={modelKey(model.provider, model.modelId)}>
+                  {model.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function OnboardingSetupScreen({
+  recommendation,
+  availableModelGroups,
+  providerHealth,
+  providerDefaults,
+  warnings,
+  launchNotice,
+  continueDisabled = false,
+  onContinue,
+  onOpenProviders,
+  onReconnectProvider,
+}: {
+  recommendation: OnboardingRecommendation;
+  availableModelGroups: AvailableModelGroup[];
+  providerHealth: ProviderHealthInfo[];
+  providerDefaults: ResolvedProviderDefaultsState;
+  warnings: OnboardingWarning[];
+  launchNotice?: string | null;
+  continueDisabled?: boolean;
+  onContinue: (tiers: ModelTierSettings) => void;
+  onOpenProviders: () => void;
+  onReconnectProvider: (providerId: string | null) => void;
+}) {
+  const providerGroups = availableModelGroups.filter((group) => group.models.length > 0);
+  const initialProviderId = getInitialProviderId(recommendation, providerGroups);
+  const [selectedProviderId, setSelectedProviderId] = useState(initialProviderId);
+  const [simpleModelKey, setSimpleModelKey] = useState(
+    getInitialSimpleModelKey(recommendation, initialProviderId, providerGroups, providerDefaults),
+  );
+  const [useTieredModels, setUseTieredModels] = useState(false);
+  const [simpleConfigChanged, setSimpleConfigChanged] = useState(false);
+  const [tieredSelections, setTieredSelections] = useState<ModelTierSettings>(recommendation.tiers);
+
+  const selectedProviderGroup = getProviderGroup(providerGroups, selectedProviderId);
+
+  const handleProviderChange = (providerId: string) => {
+    setSelectedProviderId(providerId);
+    setTieredSelections(getSuggestedTiersForProvider(providerId, providerGroups, providerDefaults));
+    setSimpleModelKey(getInitialSimpleModelKey(recommendation, providerId, providerGroups, providerDefaults));
+    setSimpleConfigChanged(true);
+  };
+
+  const handleTierChange = (tier: ModelTier, value: string) => {
+    const parsed = parseModelKey(value);
+    if (!parsed) return;
+    setTieredSelections((current) => ({ ...current, [tier]: parsed }));
+  };
+
+  const canContinue = useTieredModels
+    ? TIERS.every((tier) => Boolean(tieredSelections[tier]))
+    : Boolean(simpleModelKey) || TIERS.some((tier) => Boolean(recommendation.tiers[tier]));
+
+  const handleContinue = () => {
+    if (useTieredModels) {
+      onContinue(tieredSelections);
+      return;
+    }
+
+    if (!simpleConfigChanged) {
+      onContinue(recommendation.tiers);
+      return;
+    }
+
+    const parsed = parseModelKey(simpleModelKey);
+    if (!parsed) return;
+    onContinue({ LOW: parsed, MED: parsed, HIGH: parsed });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+          <Sparkles className="size-5 text-[var(--status-success)]" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-[var(--text-primary)]">Choose your model</h2>
+          <p className="text-sm text-[var(--text-secondary)]">
+            Pick a provider and default model to get started.
+          </p>
+        </div>
+      </div>
+
+      {launchNotice ? (
+        <div className="rounded-lg border border-[var(--status-success)]/20 bg-[var(--status-success)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
+          {launchNotice}
+        </div>
+      ) : null}
+
+      <div className="grid gap-3">
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-[var(--text-primary)]">Provider</Label>
+          <Select value={selectedProviderId} onValueChange={handleProviderChange}>
+            <SelectTrigger className="h-10 text-left">
+              <SelectValue placeholder="Choose a provider" />
+            </SelectTrigger>
+            <SelectContent>
+              {providerGroups.map((group) => (
+                <SelectItem key={group.provider} value={group.provider}>
+                  {group.displayName}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-[var(--text-primary)]">Default model</Label>
+          <Select
+            value={simpleModelKey}
+            onValueChange={(value) => {
+              setSimpleModelKey(value);
+              setSimpleConfigChanged(true);
+            }}
+          >
+            <SelectTrigger className="h-10 text-left">
+              <SelectValue placeholder="Choose a model" />
+            </SelectTrigger>
+            <SelectContent>
+              {(selectedProviderGroup?.models ?? []).map((model) => (
+                <SelectItem key={modelKey(model.provider, model.modelId)} value={modelKey(model.provider, model.modelId)}>
+                  {model.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {!simpleConfigChanged && recommendation.tiers.HIGH ? (
+            <p className="text-[11px] text-[var(--text-muted)]">
+              Current default: {getModelName(
+                providerGroups,
+                recommendation.tiers.HIGH.provider,
+                recommendation.tiers.HIGH.modelId,
+              )}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/40 px-3 py-2.5">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-medium text-[var(--text-primary)]">Use different models by complexity</p>
+            <p className="text-xs text-[var(--text-secondary)]">
+              Optional: pick separate low, medium, and high complexity models.
+            </p>
+          </div>
+          <Switch checked={useTieredModels} onCheckedChange={setUseTieredModels} />
+        </div>
+
+        {useTieredModels ? (
+          <div className="mt-3 border-t border-[var(--border-default)] pt-3">
+            <TierModelFields
+              providerId={selectedProviderId}
+              availableModelGroups={providerGroups}
+              tieredSelections={tieredSelections}
+              onTierChange={handleTierChange}
+            />
+          </div>
+        ) : null}
+      </div>
+
+      {warnings.map((warning) => (
+        <WarningBanner
+          key={warning.code}
+          warning={warning}
+          providerHealth={providerHealth}
+          onReconnectProvider={onReconnectProvider}
+        />
+      ))}
+
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+        <Button variant="outline" size="sm" onClick={onOpenProviders} disabled={continueDisabled}>
+          <KeyRound className="mr-2 size-3.5" />
+          Providers
+        </Button>
+        <Button size="sm" onClick={handleContinue} disabled={!canContinue || continueDisabled}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -19,21 +19,9 @@ import type {
   ProviderHealthInfo,
   ResolvedProviderDefaultsState,
 } from '@/types/ipc';
+import { modelKey, parseModelKey } from '@/lib/model-keys';
 
 const TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
-
-function modelKey(provider: string, modelId: string): string {
-  return `${provider}/${modelId}`;
-}
-
-function parseModelKey(value: string): { provider: string; modelId: string } | null {
-  const separatorIndex = value.indexOf('/');
-  if (separatorIndex <= 0) return null;
-  return {
-    provider: value.slice(0, separatorIndex),
-    modelId: value.slice(separatorIndex + 1),
-  };
-}
 
 function getProviderGroup(
   groups: AvailableModelGroup[],

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -316,17 +316,16 @@ export function OnboardingSetupScreen({
 
       <div className="grid gap-4">
         <div className="space-y-1.5">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
             <Label className="text-xs font-medium text-[var(--text-primary)]">Provider</Label>
             <button
               type="button"
               onClick={() => onOpenProviders()}
               disabled={continueDisabled}
-              className="flex items-center gap-1 text-[10px] font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)] disabled:opacity-50"
+              className="rounded p-0.5 text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)] disabled:opacity-50"
               title="Manage providers"
             >
               <KeyRound className="size-3" />
-              Manage
             </button>
           </div>
           <Select value={selectedProviderId} onValueChange={handleProviderChange}>

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -199,7 +199,7 @@ function TierModelFields({
   if (!providerGroup) return null;
 
   return (
-    <div className="grid gap-3">
+    <div className="grid gap-4">
       {TIERS.map((tier) => (
         <div key={tier} className="space-y-1.5">
           <Label className="text-xs font-medium text-[var(--text-primary)]">
@@ -295,9 +295,9 @@ export function OnboardingSetupScreen({
   };
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+    <div className="space-y-5">
+      <div className="space-y-3">
+        <div className="flex size-11 items-center justify-center rounded-xl bg-[var(--bg-elevated)]">
           <Sparkles className="size-5 text-[var(--status-success)]" />
         </div>
         <div>
@@ -314,7 +314,7 @@ export function OnboardingSetupScreen({
         </div>
       ) : null}
 
-      <div className="grid gap-3">
+      <div className="grid gap-4">
         <div className="space-y-1.5">
           <Label className="text-xs font-medium text-[var(--text-primary)]">Provider</Label>
           <Select value={selectedProviderId} onValueChange={handleProviderChange}>
@@ -363,7 +363,7 @@ export function OnboardingSetupScreen({
         </div>
       </div>
 
-      <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/40 px-3 py-2.5">
+      <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/40 px-4 py-3">
         <div className="flex items-center justify-between gap-3">
           <div>
             <p className="text-sm font-medium text-[var(--text-primary)]">Use different models by complexity</p>
@@ -375,7 +375,7 @@ export function OnboardingSetupScreen({
         </div>
 
         {useTieredModels ? (
-          <div className="mt-3 border-t border-[var(--border-default)] pt-3">
+          <div className="mt-3.5 border-t border-[var(--border-default)] pt-3.5">
             <TierModelFields
               providerId={selectedProviderId}
               availableModelGroups={providerGroups}
@@ -395,7 +395,7 @@ export function OnboardingSetupScreen({
         />
       ))}
 
-      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+      <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-between">
         <Button variant="outline" size="sm" onClick={onOpenProviders} disabled={continueDisabled}>
           <KeyRound className="mr-2 size-3.5" />
           Providers

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -316,22 +316,12 @@ export function OnboardingSetupScreen({
 
       <div className="grid gap-4">
         <div className="space-y-1.5">
-          <div className="flex items-center gap-1.5">
-            <Label className="text-xs font-medium text-[var(--text-primary)]">Provider</Label>
-            <button
-              type="button"
-              onClick={() => onOpenProviders()}
-              disabled={continueDisabled}
-              className="rounded p-0.5 text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)] disabled:opacity-50"
-              title="Manage providers"
-            >
-              <KeyRound className="size-3" />
-            </button>
-          </div>
-          <Select value={selectedProviderId} onValueChange={handleProviderChange}>
-            <SelectTrigger className="h-10 text-left">
-              <SelectValue placeholder="Choose a provider" />
-            </SelectTrigger>
+          <Label className="text-xs font-medium text-[var(--text-primary)]">Provider</Label>
+          <div className="flex items-center gap-2">
+            <Select value={selectedProviderId} onValueChange={handleProviderChange}>
+              <SelectTrigger className="h-10 text-left">
+                <SelectValue placeholder="Choose a provider" />
+              </SelectTrigger>
             <SelectContent>
               {providerGroups.map((group) => (
                 <SelectItem key={group.provider} value={group.provider}>
@@ -340,6 +330,16 @@ export function OnboardingSetupScreen({
               ))}
             </SelectContent>
           </Select>
+          <button
+            type="button"
+            onClick={() => onOpenProviders()}
+            disabled={continueDisabled}
+            className="flex size-10 shrink-0 items-center justify-center rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] text-[var(--text-muted)] transition-colors hover:border-[var(--border-hover)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] disabled:opacity-50"
+            title="Manage providers"
+          >
+            <KeyRound className="size-4" />
+          </button>
+          </div>
         </div>
 
         <div className="space-y-1.5">

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -316,7 +316,19 @@ export function OnboardingSetupScreen({
 
       <div className="grid gap-4">
         <div className="space-y-1.5">
-          <Label className="text-xs font-medium text-[var(--text-primary)]">Provider</Label>
+          <div className="flex items-center justify-between">
+            <Label className="text-xs font-medium text-[var(--text-primary)]">Provider</Label>
+            <button
+              type="button"
+              onClick={() => onOpenProviders()}
+              disabled={continueDisabled}
+              className="flex items-center gap-1 text-[10px] font-medium text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)] disabled:opacity-50"
+              title="Manage providers"
+            >
+              <KeyRound className="size-3" />
+              Manage
+            </button>
+          </div>
           <Select value={selectedProviderId} onValueChange={handleProviderChange}>
             <SelectTrigger className="h-10 text-left">
               <SelectValue placeholder="Choose a provider" />
@@ -395,11 +407,7 @@ export function OnboardingSetupScreen({
         />
       ))}
 
-      <div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-between">
-        <Button variant="outline" size="sm" onClick={onOpenProviders} disabled={continueDisabled}>
-          <KeyRound className="mr-2 size-3.5" />
-          Providers
-        </Button>
+      <div className="flex justify-end pt-1">
         <Button size="sm" onClick={handleContinue} disabled={!canContinue || continueDisabled}>
           Continue
         </Button>

--- a/apps/desktop/src/lib/model-keys.ts
+++ b/apps/desktop/src/lib/model-keys.ts
@@ -1,0 +1,12 @@
+export function modelKey(provider: string, modelId: string): string {
+  return `${provider}/${modelId}`;
+}
+
+export function parseModelKey(value: string): { provider: string; modelId: string } | null {
+  const separatorIndex = value.indexOf('/');
+  if (separatorIndex <= 0) return null;
+  return {
+    provider: value.slice(0, separatorIndex),
+    modelId: value.slice(separatorIndex + 1),
+  };
+}

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -66,6 +66,7 @@ import type {
   CollaborationStateSnapshot,
   CollaborationEvent,
   CollaborationConfig,
+  ModelTierSettings,
   AppControlEntry,
   AppInteractionParams,
   AppInteractionResult,
@@ -366,6 +367,13 @@ interface SeroCollaborationAPI {
   onEvent(callback: (event: CollaborationEvent) => void): () => void;
 }
 
+interface SeroModelTiersAPI {
+  /** Get current model tier settings from settings.json. */
+  get(): Promise<ModelTierSettings>;
+  /** Write model tier settings to settings.json. */
+  set(tiers: ModelTierSettings): Promise<void>;
+}
+
 interface SeroProfilesAPI {
   /** List all profiles with active flag. */
   list(): Promise<ProfileInfo[]>;
@@ -442,6 +450,7 @@ interface SeroAPI {
   skills: SeroSkillsAPI;
   prompts: SeroPromptsAPI;
   github: SeroGitHubAPI;
+  modelTiers: SeroModelTiersAPI;
   plugins: SeroPluginsAPI;
   localModels: SeroLocalModelsAPI;
   pluginConfig: SeroPluginConfigAPI;

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -67,6 +67,7 @@ import type {
   CollaborationEvent,
   CollaborationConfig,
   ModelTierSettings,
+  AvailableModelGroup,
   AppControlEntry,
   AppInteractionParams,
   AppInteractionResult,
@@ -367,6 +368,11 @@ interface SeroCollaborationAPI {
   onEvent(callback: (event: CollaborationEvent) => void): () => void;
 }
 
+interface SeroModelsAPI {
+  /** List all available models (session-independent). */
+  list(): Promise<AvailableModelGroup[]>;
+}
+
 interface SeroModelTiersAPI {
   /** Get current model tier settings from settings.json. */
   get(): Promise<ModelTierSettings>;
@@ -450,6 +456,7 @@ interface SeroAPI {
   skills: SeroSkillsAPI;
   prompts: SeroPromptsAPI;
   github: SeroGitHubAPI;
+  models: SeroModelsAPI;
   modelTiers: SeroModelTiersAPI;
   plugins: SeroPluginsAPI;
   localModels: SeroLocalModelsAPI;

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -74,6 +74,9 @@ import type {
   AppPanelRect,
   AppRecordingStatus,
   AppRecordingResult,
+  OnboardingState,
+  ProviderModelDefaults,
+  ResolvedProviderDefaultsState,
 } from './ipc';
 
 interface SeroWorkspaceAPI {
@@ -380,6 +383,20 @@ interface SeroModelTiersAPI {
   set(tiers: ModelTierSettings): Promise<void>;
 }
 
+interface SeroOnboardingAPI {
+  /** Run onboarding preflight and return the current onboarding state. */
+  getState(): Promise<OnboardingState>;
+  /** Persist validated tier selections for onboarding. */
+  saveTierSelections(tiers: ModelTierSettings): Promise<void>;
+}
+
+interface SeroProviderDefaultsAPI {
+  /** Read built-in, global, and effective provider defaults. */
+  get(): Promise<ResolvedProviderDefaultsState>;
+  /** Persist the global/shared provider defaults registry. */
+  setGlobalDefaults(defaults: ProviderModelDefaults): Promise<void>;
+}
+
 interface SeroProfilesAPI {
   /** List all profiles with active flag. */
   list(): Promise<ProfileInfo[]>;
@@ -458,6 +475,8 @@ interface SeroAPI {
   github: SeroGitHubAPI;
   models: SeroModelsAPI;
   modelTiers: SeroModelTiersAPI;
+  onboarding: SeroOnboardingAPI;
+  providerDefaults: SeroProviderDefaultsAPI;
   plugins: SeroPluginsAPI;
   localModels: SeroLocalModelsAPI;
   pluginConfig: SeroPluginConfigAPI;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -135,6 +135,10 @@ export const IpcChannels = {
     /** List all available models (session-independent). Returns AvailableModelGroup[]. */
     list: 'sero:models:list',
   },
+  modelTiers: {
+    get: 'sero:model-tiers:get',
+    set: 'sero:model-tiers:set',
+  },
   localModels: localModelsIpcChannels,
   imagegen: {
     /** Generate images via Gemini Nano Banana. Returns generation metadata. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -139,6 +139,14 @@ export const IpcChannels = {
     get: 'sero:model-tiers:get',
     set: 'sero:model-tiers:set',
   },
+  onboarding: {
+    getState: 'sero:onboarding:get-state',
+    saveTierSelections: 'sero:onboarding:save-tier-selections',
+  },
+  providerDefaults: {
+    get: 'sero:provider-defaults:get',
+    setGlobalDefaults: 'sero:provider-defaults:set-global-defaults',
+  },
   localModels: localModelsIpcChannels,
   imagegen: {
     /** Generate images via Gemini Nano Banana. Returns generation metadata. */

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -298,6 +298,20 @@ export interface AuthProvidersResponse {
   apiKey: ApiKeyProviderInfo[];
 }
 
+// ── Model Tiers ──────────────────────────────────────────────
+
+/** Model tier levels for user-configured defaults. */
+export type ModelTier = 'LOW' | 'MED' | 'HIGH';
+
+/** A user-configured model for a specific tier. */
+export interface ModelTierEntry {
+  provider: string;
+  modelId: string;
+}
+
+/** Per-profile tier configuration stored in settings.json. */
+export type ModelTierSettings = Partial<Record<ModelTier, ModelTierEntry>>;
+
 /**
  * Events pushed from main → renderer during an OAuth login flow.
  * The renderer dialog reacts to each event to update its UI state.

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -298,19 +298,26 @@ export interface AuthProvidersResponse {
   apiKey: ApiKeyProviderInfo[];
 }
 
-// ── Model Tiers ──────────────────────────────────────────────
+// ── Model Tiers & Onboarding ────────────────────────────────
 
-/** Model tier levels for user-configured defaults. */
-export type ModelTier = 'LOW' | 'MED' | 'HIGH';
+export type {
+  ModelTier,
+  ModelTierEntry,
+  ModelTierSettings,
+  ProviderTierDefaults,
+  ProviderModelDefaults,
+  ResolvedProviderDefaultsState,
+} from './model-tiers';
 
-/** A user-configured model for a specific tier. */
-export interface ModelTierEntry {
-  provider: string;
-  modelId: string;
-}
-
-/** Per-profile tier configuration stored in settings.json. */
-export type ModelTierSettings = Partial<Record<ModelTier, ModelTierEntry>>;
+export type {
+  ProviderHealthStatus,
+  ProviderHealthInfo,
+  OnboardingStatePhase,
+  OnboardingTierSource,
+  OnboardingRecommendation,
+  OnboardingWarning,
+  OnboardingState,
+} from './onboarding';
 
 /**
  * Events pushed from main → renderer during an OAuth login flow.

--- a/apps/desktop/src/types/model-tiers.ts
+++ b/apps/desktop/src/types/model-tiers.ts
@@ -1,0 +1,24 @@
+/** Model tier levels for user-configured defaults. */
+export type ModelTier = 'LOW' | 'MED' | 'HIGH';
+
+/** A user-configured model for a specific tier. */
+export interface ModelTierEntry {
+  provider: string;
+  modelId: string;
+}
+
+/** Per-profile tier configuration stored in settings.json. */
+export type ModelTierSettings = Partial<Record<ModelTier, ModelTierEntry>>;
+
+/** Recommended model IDs per provider and tier. */
+export type ProviderTierDefaults = Partial<Record<ModelTier, string>>;
+
+/** Provider → recommended LOW/MED/HIGH models mapping. */
+export type ProviderModelDefaults = Record<string, ProviderTierDefaults>;
+
+export interface ResolvedProviderDefaultsState {
+  builtInDefaults: ProviderModelDefaults;
+  globalDefaults: ProviderModelDefaults;
+  profileOverrides?: ProviderModelDefaults;
+  effectiveDefaults: ProviderModelDefaults;
+}

--- a/apps/desktop/src/types/onboarding.ts
+++ b/apps/desktop/src/types/onboarding.ts
@@ -1,0 +1,57 @@
+import type { AvailableModelGroup } from './agent';
+import type { ModelTier, ModelTierSettings } from './model-tiers';
+
+export type ProviderHealthStatus =
+  | 'healthy'
+  | 'broken_expired'
+  | 'broken_invalid'
+  | 'env'
+  | 'local'
+  | 'missing'
+  | 'unknown';
+
+export interface ProviderHealthInfo {
+  providerId: string;
+  displayName: string;
+  status: ProviderHealthStatus;
+  message?: string;
+  canReconnect: boolean;
+  hasUsableModels: boolean;
+  usableModelIds: string[];
+}
+
+export type OnboardingStatePhase = 'ready' | 'auth' | 'error' | 'done';
+
+export type OnboardingTierSource =
+  | 'preserved'
+  | 'imported'
+  | 'provider-defaults'
+  | 'fallback';
+
+export interface OnboardingRecommendation {
+  tiers: ModelTierSettings;
+  sourcesByTier: Partial<Record<ModelTier, OnboardingTierSource>>;
+  preferredProvider?: string;
+}
+
+export interface OnboardingWarning {
+  code:
+    | 'broken_imported_providers'
+    | 'invalid_existing_tiers'
+    | 'no_usable_models'
+    | 'provider_recommendation_changed';
+  message: string;
+  providerIds?: string[];
+}
+
+export interface OnboardingState {
+  needed: boolean;
+  phase: OnboardingStatePhase;
+  hasAnyUsableModels: boolean;
+  hasImportedCredentials: boolean;
+  recommendation: OnboardingRecommendation | null;
+  providerHealth: ProviderHealthInfo[];
+  availableModelGroups: AvailableModelGroup[];
+  warnings: OnboardingWarning[];
+  invalidTiers: ModelTier[];
+}

--- a/apps/desktop/src/types/subagent.ts
+++ b/apps/desktop/src/types/subagent.ts
@@ -13,11 +13,20 @@ export interface SubagentAgentSummary {
   timeoutMs?: number;
 }
 
+/** Structured model field supported in subagent frontmatter. */
+export interface StructuredSubagentModelField {
+  prefer: string;
+  fallbacks: string[];
+}
+
+/** Plain string model ID/tier alias, or structured prefer+fallbacks config. */
+export type SubagentModelConfig = string | StructuredSubagentModelField;
+
 /** Full agent data for editing (includes system prompt body). */
 export interface SubagentAgentFile {
   name: string;
   description: string;
-  model?: string;
+  model?: SubagentModelConfig;
   thinking?: string;
   timeoutMs?: number;
   tools?: string[];

--- a/docs/superpowers/plans/2026-04-04-dynamic-model-provider.md
+++ b/docs/superpowers/plans/2026-04-04-dynamic-model-provider.md
@@ -1,0 +1,1799 @@
+# Dynamic Model Provider System — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Claude as the hardcoded default provider and introduce a LOW/MED/HIGH model tier system that lets users choose their preferred models per tier during onboarding, with resilient fallback resolution in agent templates.
+
+**Architecture:** New `modelTiers` field in per-profile `settings.json` stores user-chosen models for LOW/MED/HIGH tiers. Agent templates use a structured `{ prefer, fallbacks }` model field instead of hardcoded model IDs. A new `resolveTierModel()` function resolves tier aliases to concrete models using the user's settings + fallback list. Onboarding gains a tier picker step between auth and memory setup.
+
+**Tech Stack:** TypeScript, Electron IPC, React 19, Zustand, Tailwind 4, shadcn/ui
+
+**Spec:** `docs/superpowers/specs/2026-04-04-dynamic-model-provider-design.md`
+
+---
+
+### Task 1: Add model tier types and settings helpers
+
+**Files:**
+- Create: `apps/desktop/electron/shared/settings/model-tiers.ts`
+- Modify: `apps/desktop/src/types/ipc.ts`
+
+This task defines the shared types and settings read/write helpers for the tier system. Everything else depends on this.
+
+- [ ] **Step 1: Define model tier types in ipc.ts**
+
+Add to `apps/desktop/src/types/ipc.ts` near the other model-related types (around line 279):
+
+```ts
+/** Model tier levels for user-configured defaults. */
+export type ModelTier = 'LOW' | 'MED' | 'HIGH';
+
+/** A user-configured model for a specific tier. */
+export interface ModelTierEntry {
+  provider: string;
+  modelId: string;
+}
+
+/** Per-profile tier configuration stored in settings.json. */
+export type ModelTierSettings = Partial<Record<ModelTier, ModelTierEntry>>;
+```
+
+- [ ] **Step 2: Create model-tiers.ts settings helpers**
+
+Create `apps/desktop/electron/shared/settings/model-tiers.ts`:
+
+```ts
+/**
+ * Model tier settings — read/write helpers for LOW/MED/HIGH tier
+ * configuration in settings.json.
+ *
+ * Tiers are stored under `sero.modelTiers` in the global settings object.
+ */
+
+import type { ModelTier, ModelTierEntry, ModelTierSettings } from '../../../src/types/ipc';
+
+export const MODEL_TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
+
+function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const raw = settings.sero;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** Read the model tier settings from a settings object. */
+export function getModelTiers(settings: Record<string, unknown>): ModelTierSettings {
+  const sero = getSeroSettings(settings);
+  const raw = sero.modelTiers;
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
+  const result: ModelTierSettings = {};
+  for (const tier of MODEL_TIERS) {
+    const entry = (raw as Record<string, unknown>)[tier];
+    if (
+      entry &&
+      typeof entry === 'object' &&
+      !Array.isArray(entry) &&
+      typeof (entry as Record<string, unknown>).provider === 'string' &&
+      typeof (entry as Record<string, unknown>).modelId === 'string'
+    ) {
+      result[tier] = entry as ModelTierEntry;
+    }
+  }
+  return result;
+}
+
+/** Write model tier settings into a settings object (returns new object). */
+export function setModelTiers(
+  settings: Record<string, unknown>,
+  tiers: ModelTierSettings,
+): Record<string, unknown> {
+  const sero = getSeroSettings(settings);
+  return {
+    ...settings,
+    sero: {
+      ...sero,
+      modelTiers: tiers,
+    },
+  };
+}
+
+/** Check if any tier is configured. */
+export function hasModelTiers(settings: Record<string, unknown>): boolean {
+  const tiers = getModelTiers(settings);
+  return Object.keys(tiers).length > 0;
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS with zero errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop/electron/shared/settings/model-tiers.ts apps/desktop/src/types/ipc.ts
+git commit -m "feat: add model tier types and settings helpers (LOW/MED/HIGH)"
+```
+
+---
+
+### Task 2: Create tier-aware model resolver
+
+**Files:**
+- Create: `apps/desktop/electron/shared/settings/resolve-tier-model.ts`
+
+This is the core resolution function that takes a structured model field and resolves it to a concrete available model using tier settings + fallbacks.
+
+- [ ] **Step 1: Create resolve-tier-model.ts**
+
+Create `apps/desktop/electron/shared/settings/resolve-tier-model.ts`:
+
+```ts
+/**
+ * Tier-aware model resolution.
+ *
+ * Resolves a structured model field (with `prefer` tier alias + `fallbacks`)
+ * to a concrete available model. Used by the subagent resolver and adhoc agent.
+ *
+ * Resolution order:
+ *   1. If `prefer` is a tier alias (LOW/MED/HIGH) → user's chosen model for that tier
+ *   2. If `prefer` is a model ID → try that model directly
+ *   3. Iterate `fallbacks` → use first available
+ *   4. Return null → caller should prompt user to pick
+ */
+
+import type { ModelTier, ModelTierSettings } from '../../../src/types/ipc';
+import { MODEL_TIERS } from './model-tiers';
+
+/** The structured model field from agent frontmatter. */
+export interface StructuredModelField {
+  prefer: string;
+  fallbacks: string[];
+}
+
+/** A model available in the registry (provider + id). */
+export interface AvailableModel {
+  provider: string;
+  id: string;
+}
+
+/** Result of model resolution. */
+export interface ResolvedModel {
+  provider: string;
+  modelId: string;
+}
+
+function isTierAlias(value: string): value is ModelTier {
+  return MODEL_TIERS.includes(value as ModelTier);
+}
+
+function findModelById(
+  available: AvailableModel[],
+  modelId: string,
+): AvailableModel | undefined {
+  const lowerId = modelId.toLowerCase();
+  return available.find((m) => m.id.toLowerCase() === lowerId);
+}
+
+/**
+ * Parse a model field from agent frontmatter.
+ *
+ * Accepts either:
+ * - A plain string (legacy): `"claude-sonnet-4-6"` → { prefer: "claude-sonnet-4-6", fallbacks: [] }
+ * - A structured object: `{ prefer: "MED", fallbacks: ["gpt-5.4", ...] }`
+ */
+export function parseModelField(
+  raw: unknown,
+): StructuredModelField | null {
+  if (typeof raw === 'string' && raw.trim()) {
+    return { prefer: raw.trim(), fallbacks: [] };
+  }
+
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const obj = raw as Record<string, unknown>;
+    const prefer = typeof obj.prefer === 'string' ? obj.prefer.trim() : '';
+    if (!prefer) return null;
+
+    const fallbacks: string[] = [];
+    if (Array.isArray(obj.fallbacks)) {
+      for (const f of obj.fallbacks) {
+        if (typeof f === 'string' && f.trim()) fallbacks.push(f.trim());
+      }
+    }
+    return { prefer, fallbacks };
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a structured model field to a concrete available model.
+ *
+ * Returns null if no model could be resolved (caller should prompt user).
+ */
+export function resolveTierModel(
+  field: StructuredModelField,
+  tierSettings: ModelTierSettings,
+  available: AvailableModel[],
+): ResolvedModel | null {
+  if (available.length === 0) return null;
+
+  // 1. Resolve `prefer`
+  if (isTierAlias(field.prefer)) {
+    const tierEntry = tierSettings[field.prefer];
+    if (tierEntry) {
+      const match = available.find(
+        (m) => m.provider === tierEntry.provider && m.id === tierEntry.modelId,
+      );
+      if (match) return { provider: match.provider, modelId: match.id };
+    }
+  } else {
+    // Treat as a model ID
+    const match = findModelById(available, field.prefer);
+    if (match) return { provider: match.provider, modelId: match.id };
+  }
+
+  // 2. Walk fallbacks
+  for (const fallback of field.fallbacks) {
+    const match = findModelById(available, fallback);
+    if (match) return { provider: match.provider, modelId: match.id };
+  }
+
+  return null;
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS with zero errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/electron/shared/settings/resolve-tier-model.ts
+git commit -m "feat: add tier-aware model resolver (parseModelField + resolveTierModel)"
+```
+
+---
+
+### Task 3: Update agent frontmatter parsing for structured model field
+
+**Files:**
+- Modify: `apps/desktop/electron/features/subagent/core/types.ts:32-53`
+- Modify: `apps/desktop/electron/features/subagent/runtime/discovery.ts:92-109`
+
+The `AgentConfig.model` field changes from `string | undefined` to support both legacy strings and structured objects.
+
+- [ ] **Step 1: Update AgentConfig type**
+
+In `apps/desktop/electron/features/subagent/core/types.ts`, change the `model` field on `AgentConfig` (line 38):
+
+Replace:
+```ts
+  /** Default model for this agent. */
+  model?: string;
+```
+
+With:
+```ts
+  /** Default model — plain string (legacy) or structured { prefer, fallbacks }. */
+  model?: string | { prefer: string; fallbacks: string[] };
+```
+
+- [ ] **Step 2: Update toAgentConfig() in discovery.ts**
+
+In `apps/desktop/electron/features/subagent/runtime/discovery.ts`, update `toAgentConfig()` at line 100.
+
+First add the import at the top:
+```ts
+import { parseModelField } from '../../../shared/settings/resolve-tier-model';
+```
+
+Replace:
+```ts
+    model: typeof fm.model === 'string' ? fm.model : undefined,
+```
+
+With:
+```ts
+    model: parseAgentModelField(fm.model),
+```
+
+Add the helper function above `toAgentConfig()`:
+
+```ts
+/**
+ * Parse model field from frontmatter into the AgentConfig union type.
+ * Returns plain string for legacy format, structured object for new format.
+ */
+function parseAgentModelField(
+  raw: unknown,
+): string | { prefer: string; fallbacks: string[] } | undefined {
+  if (typeof raw === 'string' && raw.trim()) return raw;
+  const parsed = parseModelField(raw);
+  return parsed ?? undefined;
+}
+```
+
+- [ ] **Step 3: Update model validation warning in discovery.ts**
+
+In `discovery.ts` around lines 158-164, update the model validation to handle structured fields:
+
+Replace:
+```ts
+      // Warn about unknown models (non-blocking)
+      const model = parsed.frontmatter.model;
+      if (typeof model === 'string' && options?.isValidModel && !options.isValidModel(model)) {
+        console.warn(
+          `[subagent/discovery] ${absPath}: model '${model}' not found in registry`,
+        );
+      }
+```
+
+With:
+```ts
+      // Warn about unknown models (non-blocking) — skip tier aliases
+      const model = parsed.frontmatter.model;
+      if (typeof model === 'string' && options?.isValidModel && !options.isValidModel(model)) {
+        console.warn(
+          `[subagent/discovery] ${absPath}: model '${model}' not found in registry`,
+        );
+      }
+      // Structured model fields are validated at resolution time, not discovery
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: May see type errors in files that consume `AgentConfig.model` as `string`. Fix them in the next task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/electron/features/subagent/core/types.ts apps/desktop/electron/features/subagent/runtime/discovery.ts
+git commit -m "feat: support structured model field in agent frontmatter parsing"
+```
+
+---
+
+### Task 4: Update resolve.ts to handle structured model fields
+
+**Files:**
+- Modify: `apps/desktop/electron/features/subagent/core/resolve.ts`
+
+The resolver must handle `AgentConfig.model` being either a string or a structured object. It still outputs a flat `model: string` in `ResolvedConfig` — the tier resolution happens in the runner (Task 5).
+
+- [ ] **Step 1: Update resolveConfig to handle structured model**
+
+Replace the full contents of `apps/desktop/electron/features/subagent/core/resolve.ts`:
+
+```ts
+/**
+ * Config resolution — 5-level precedence chain for model, thinking, and timeout.
+ *
+ * Precedence (highest → lowest):
+ *   1. Per-task override (tasks[i] / chain[i])
+ *   2. Top-level call override
+ *   3. Agent frontmatter
+ *   4. Global subagent settings (settings.json)
+ *   5. Session / app defaults
+ *
+ * The `model` field from agent frontmatter may be a plain string (legacy)
+ * or a structured `{ prefer, fallbacks }` object. When structured, the
+ * `prefer` value is emitted as the model string — tier resolution happens
+ * downstream in the runner where the model registry is available.
+ */
+
+import type {
+  AgentConfig,
+  SubagentSettings,
+  ResolvedConfig,
+  TaskOverride,
+} from './types';
+
+/**
+ * Provider-neutral defaults used as the absolute fallback.
+ * Uses MED tier alias — resolved to a concrete model at runtime.
+ */
+const HARDCODED_DEFAULTS = {
+  model: 'MED',
+  thinking: 'high',
+  timeoutMs: 600_000,
+  toolStallTimeoutMs: 120_000,
+} as const;
+
+export interface SessionDefaults {
+  model?: string;
+  thinking?: string;
+}
+
+/**
+ * Extract the primary model string from an AgentConfig.model value.
+ * Structured fields emit the `prefer` value; plain strings pass through.
+ */
+function extractModelString(
+  model: string | { prefer: string; fallbacks: string[] } | undefined,
+): string | undefined {
+  if (typeof model === 'string') return model || undefined;
+  if (model && typeof model === 'object') return model.prefer || undefined;
+  return undefined;
+}
+
+/**
+ * Resolve the concrete model, thinking, and timeoutMs for a subagent run.
+ *
+ * Each level only overrides if the value is non-null/non-undefined.
+ * Falls back to hardcoded defaults as the last resort.
+ *
+ * NOTE: The returned `model` may be a tier alias (e.g. "MED") when it
+ * originates from agent frontmatter or hardcoded defaults. The runner
+ * is responsible for resolving tier aliases to concrete model IDs.
+ */
+export function resolveConfig(
+  taskOverride?: TaskOverride,
+  callOverride?: TaskOverride,
+  agentConfig?: Pick<AgentConfig, 'model' | 'thinking' | 'timeoutMs'>,
+  settings?: Pick<SubagentSettings, 'model' | 'thinking' | 'timeoutMs' | 'toolStallTimeoutMs'>,
+  sessionDefaults?: SessionDefaults,
+): ResolvedConfig {
+  const model = firstDefined(
+    taskOverride?.model,
+    callOverride?.model,
+    extractModelString(agentConfig?.model),
+    settings?.model,
+    sessionDefaults?.model,
+    HARDCODED_DEFAULTS.model,
+  );
+
+  const thinking = firstDefined(
+    taskOverride?.thinking,
+    callOverride?.thinking,
+    agentConfig?.thinking,
+    settings?.thinking,
+    sessionDefaults?.thinking,
+    HARDCODED_DEFAULTS.thinking,
+  );
+
+  const timeoutMs = firstDefinedNumber(
+    taskOverride?.timeoutMs,
+    callOverride?.timeoutMs,
+    agentConfig?.timeoutMs,
+    settings?.timeoutMs,
+    HARDCODED_DEFAULTS.timeoutMs,
+  );
+
+  const toolStallTimeoutMs = settings?.toolStallTimeoutMs ?? HARDCODED_DEFAULTS.toolStallTimeoutMs;
+
+  return { model, thinking, timeoutMs, toolStallTimeoutMs };
+}
+
+/**
+ * Return the first non-null, non-undefined string value.
+ */
+function firstDefined(...values: (string | null | undefined)[]): string {
+  for (const v of values) {
+    if (v !== null && v !== undefined && v !== '') return v;
+  }
+  return '';
+}
+
+/**
+ * Return the first non-null, non-undefined number value.
+ */
+function firstDefinedNumber(...values: (number | null | undefined)[]): number {
+  for (const v of values) {
+    if (v !== null && v !== undefined) return v;
+  }
+  return HARDCODED_DEFAULTS.timeoutMs;
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS — the output shape (`ResolvedConfig`) hasn't changed, just the input handling.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/electron/features/subagent/core/resolve.ts
+git commit -m "feat: update resolveConfig to handle structured model fields and tier aliases"
+```
+
+---
+
+### Task 5: Update subagent runner to resolve tier aliases
+
+**Files:**
+- Modify: `apps/desktop/electron/features/subagent/runtime/runner.ts:203-213`
+
+The runner currently does `available.find((m) => m.id === resolved.model)`. It needs to handle tier aliases by using `resolveTierModel()`.
+
+- [ ] **Step 1: Add tier resolution to runner model lookup**
+
+In `apps/desktop/electron/features/subagent/runtime/runner.ts`, at the model resolution block around lines 203-213.
+
+First add imports at the top of the file:
+
+```ts
+import { parseModelField, resolveTierModel } from '../../../shared/settings/resolve-tier-model';
+import { getModelTiers, MODEL_TIERS } from '../../../shared/settings/model-tiers';
+```
+
+Then replace the model resolution block (lines 203-213):
+
+```ts
+      const match = available.find((m) => m.id === resolved.model);
+      if (match) {
+        const model = infra.modelRegistry.find(match.provider, match.id);
+        if (model) await session.setModel(model);
+      }
+```
+
+With:
+
+```ts
+      const globalSettings = infra.settingsManager.getGlobalSettings() as Record<string, unknown>;
+      const tierSettings = getModelTiers(globalSettings);
+
+      // Check if the resolved model string is a tier alias or has a structured source
+      const agentModelField = agent.model;
+      const parsed = parseModelField(agentModelField);
+      let resolvedModel: { provider: string; modelId: string } | null = null;
+
+      if (parsed) {
+        // Use the full structured field for resolution (tier + fallbacks)
+        resolvedModel = resolveTierModel(parsed, tierSettings, available);
+      }
+
+      if (!resolvedModel) {
+        // Legacy: try the flat resolved.model string directly
+        const match = available.find((m) => m.id === resolved.model);
+        if (match) resolvedModel = { provider: match.provider, modelId: match.id };
+      }
+
+      if (resolvedModel) {
+        const model = infra.modelRegistry.find(resolvedModel.provider, resolvedModel.modelId);
+        if (model) await session.setModel(model);
+      }
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/electron/features/subagent/runtime/runner.ts
+git commit -m "feat: resolve tier aliases and structured model fields in subagent runner"
+```
+
+---
+
+### Task 6: Update model fallback chain to be provider-neutral
+
+**Files:**
+- Modify: `apps/desktop/electron/shared/settings/model-fallback-chain.ts:8-16`
+
+Reorder the default fallback chain so it doesn't lead with Claude models.
+
+- [ ] **Step 1: Reorder DEFAULT_FALLBACK_CHAIN**
+
+In `apps/desktop/electron/shared/settings/model-fallback-chain.ts`, replace lines 8-16:
+
+```ts
+const DEFAULT_FALLBACK_CHAIN = [
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+  'gpt-5.4',
+  'gpt-5',
+  'gemini-3-flash-preview',
+  'gemini-3-flash',
+  'gemini-2.5-flash',
+] as const;
+```
+
+With:
+
+```ts
+const DEFAULT_FALLBACK_CHAIN = [
+  'gpt-5.4',
+  'gpt-4.1-mini',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+  'gemini-2.5-pro',
+  'gemini-2.5-flash',
+  'gemini-3-flash',
+] as const;
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/electron/shared/settings/model-fallback-chain.ts
+git commit -m "feat: reorder model fallback chain to be provider-neutral"
+```
+
+---
+
+### Task 7: Remove hardcoded Claude defaults from bootstrap and shared-infra
+
+**Files:**
+- Modify: `apps/desktop/electron/main.ts:61-79`
+- Modify: `apps/desktop/electron/shared/infra/shared-infra.ts:141-155`
+
+The bootstrap seeds empty `modelTiers` instead of a fixed provider/model. The shared-infra lazy-init uses the fallback chain instead of a hardcoded model.
+
+- [ ] **Step 1: Update bootstrapAgentDir() in main.ts**
+
+In `apps/desktop/electron/main.ts`, replace the `defaults` object in `bootstrapAgentDir()` (lines 67-74):
+
+```ts
+    const defaults = {
+      defaultProvider: 'anthropic',
+      defaultModel: 'claude-opus-4-6',
+      defaultThinkingLevel: 'high',
+      packages: workspacePackages,
+      sero: {
+        modelFallbackChain: getDefaultModelFallbackChain(),
+      },
+    };
+```
+
+With:
+
+```ts
+    const defaults = {
+      defaultThinkingLevel: 'high',
+      packages: workspacePackages,
+      sero: {
+        modelFallbackChain: getDefaultModelFallbackChain(),
+        modelTiers: {},
+      },
+    };
+```
+
+- [ ] **Step 2: Update ensureInfra() in shared-infra.ts**
+
+In `apps/desktop/electron/shared/infra/shared-infra.ts`, replace the hardcoded model init (lines 153-154):
+
+```ts
+    _model = getModel('anthropic', 'claude-opus-4-6');
+    if (!_model) throw new Error('Model claude-opus-4-6 not found in registry');
+```
+
+With:
+
+```ts
+    // Pick a model from the fallback chain — no hardcoded provider dependency.
+    // The app must be able to start without any specific provider authenticated.
+    _model = pickFirstAvailableModel(_modelRegistry, _settingsManager!);
+```
+
+Add the helper function above `ensureInfra()`:
+
+```ts
+import { getConfiguredModelFallbackChain } from '../settings/model-fallback-chain';
+import { getModelTiers } from '../settings/model-tiers';
+
+/**
+ * Pick the first available model using tier settings, then fallback chain.
+ * Returns null if no model is available (no auth configured yet).
+ */
+function pickFirstAvailableModel(
+  registry: ModelRegistry,
+  settingsManager: ReturnType<typeof SettingsManager.create>,
+): Model<Api> | null {
+  const available = registry.getAvailable();
+  if (available.length === 0) return null;
+
+  const globalSettings = settingsManager.getGlobalSettings() as Record<string, unknown>;
+
+  // Try HIGH tier model first (most capable, used for main sessions)
+  const tiers = getModelTiers(globalSettings);
+  if (tiers.HIGH) {
+    const match = available.find(
+      (m) => m.provider === tiers.HIGH!.provider && m.id === tiers.HIGH!.modelId,
+    );
+    if (match) return match;
+  }
+
+  // Try fallback chain
+  const chain = getConfiguredModelFallbackChain(globalSettings);
+  for (const candidate of chain) {
+    const match = available.find((m) => m.id === candidate);
+    if (match) return match;
+  }
+
+  // Last resort: first available model
+  return available[0] ?? null;
+}
+```
+
+Also update the null check after the model assignment. Replace:
+
+```ts
+  if (!_authStorage) {
+    _authStorage = AuthStorage.create(`${SERO_AGENT_DIR}/auth.json`);
+    _modelRegistry = new ModelRegistry(_authStorage, `${SERO_AGENT_DIR}/models.json`);
+    _settingsManager = SettingsManager.create(
+      SERO_AGENT_DIR,
+      SERO_AGENT_DIR,
+    );
+    // Default to 'high' thinking if the user hasn't explicitly set a level
+    if (!_settingsManager.getDefaultThinkingLevel()) {
+      _settingsManager.setDefaultThinkingLevel('high');
+    }
+    _model = getModel('anthropic', 'claude-opus-4-6');
+    if (!_model) throw new Error('Model claude-opus-4-6 not found in registry');
+  }
+
+  const infra = {
+    authStorage: _authStorage,
+    modelRegistry: _modelRegistry!,
+    settingsManager: _settingsManager!,
+    model: _model!,
+  };
+```
+
+With:
+
+```ts
+  if (!_authStorage) {
+    _authStorage = AuthStorage.create(`${SERO_AGENT_DIR}/auth.json`);
+    _modelRegistry = new ModelRegistry(_authStorage, `${SERO_AGENT_DIR}/models.json`);
+    _settingsManager = SettingsManager.create(
+      SERO_AGENT_DIR,
+      SERO_AGENT_DIR,
+    );
+    // Default to 'high' thinking if the user hasn't explicitly set a level
+    if (!_settingsManager.getDefaultThinkingLevel()) {
+      _settingsManager.setDefaultThinkingLevel('high');
+    }
+    _model = pickFirstAvailableModel(_modelRegistry, _settingsManager);
+  }
+
+  // Model may be null if no provider is authenticated yet — that's OK.
+  // Sessions resolve their own model at prompt time. The shared model is
+  // only used by adhoc agents as a fallback.
+  const infra = {
+    authStorage: _authStorage,
+    modelRegistry: _modelRegistry!,
+    settingsManager: _settingsManager!,
+    model: _model!,
+  };
+```
+
+- [ ] **Step 3: Update SharedInfra type to allow null model**
+
+In `shared-infra.ts`, update the `SharedInfra` interface (line 122):
+
+```ts
+export interface SharedInfra {
+  authStorage: AuthStorage;
+  modelRegistry: ModelRegistry;
+  settingsManager: ReturnType<typeof SettingsManager.create>;
+  model: Model<Api> | null;
+}
+```
+
+And update the infra object construction:
+
+```ts
+  const infra = {
+    authStorage: _authStorage,
+    modelRegistry: _modelRegistry!,
+    settingsManager: _settingsManager!,
+    model: _model,
+  };
+```
+
+- [ ] **Step 4: Fix downstream null model references**
+
+The `model` field is now nullable. Check callers of `ensureInfra()` that access `.model` — notably `adhoc-agent.ts` at line 36 uses `infra.model` as a fallback. This will be updated in Task 8.
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: Type errors in files consuming `SharedInfra.model` (adhoc-agent.ts, possibly runner.ts). Note them — they'll be fixed in subsequent tasks.
+
+- [ ] **Step 5: Remove unused getModel import if no longer needed**
+
+In `shared-infra.ts` line 21, check if `getModel` is still used elsewhere in the file. If not, remove it from the import:
+
+```ts
+import { type Model, type Api } from '@mariozechner/pi-ai';
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/electron/main.ts apps/desktop/electron/shared/infra/shared-infra.ts
+git commit -m "feat: remove hardcoded Claude defaults from bootstrap and shared-infra"
+```
+
+---
+
+### Task 8: Update adhoc-agent to use tier-aware model selection
+
+**Files:**
+- Modify: `apps/desktop/electron/features/agent/assistants/adhoc-agent.ts`
+
+Replace the Claude-first `FAST_MODEL_PREFERENCES` with tier-aware resolution using the LOW tier.
+
+- [ ] **Step 1: Rewrite adhoc-agent.ts model selection**
+
+Replace the full contents of `apps/desktop/electron/features/agent/assistants/adhoc-agent.ts`:
+
+```ts
+import { createAgentSession, SessionManager } from '@mariozechner/pi-coding-agent';
+import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
+import type { Api, Model } from '@mariozechner/pi-ai';
+
+import { SERO_AGENT_DIR } from '../../../platform/env';
+import { ensureInfra } from '../../../shared/infra/shared-infra';
+import { getModelTiers } from '../../../shared/settings/model-tiers';
+
+/** Provider-neutral fast model preferences, ordered by speed/cost. */
+const FAST_MODEL_PREFERENCES: Array<{ provider: string; modelId: string }> = [
+  { provider: 'openai', modelId: 'gpt-4.1-mini' },
+  { provider: 'openai', modelId: 'gpt-4o-mini' },
+  { provider: 'google', modelId: 'gemini-2.5-flash' },
+  { provider: 'google', modelId: 'gemini-2.0-flash' },
+  { provider: 'anthropic', modelId: 'claude-haiku-4-5' },
+  { provider: 'anthropic', modelId: 'claude-3-5-haiku-latest' },
+];
+
+interface SelectedModel {
+  model: Model<Api>;
+  provider: string;
+  modelId: string;
+}
+
+export interface AdhocAgentResult {
+  text: string;
+  model: string;
+}
+
+const ADHOC_TIMEOUT_MS = 30_000;
+
+export async function runAdhocAgent(
+  workspacePath: string,
+  prompt: string,
+  thinkingLevel: ThinkingLevel = 'low',
+): Promise<AdhocAgentResult> {
+  const infra = await ensureInfra();
+  const available = infra.modelRegistry.getAvailable();
+  const selectedModel = selectFastModel(
+    available,
+    infra.settingsManager,
+    infra.model,
+  );
+
+  const { session } = await createAgentSession({
+    cwd: workspacePath,
+    agentDir: SERO_AGENT_DIR,
+    model: selectedModel.model,
+    thinkingLevel,
+    authStorage: infra.authStorage,
+    modelRegistry: infra.modelRegistry,
+    tools: [],
+    sessionManager: SessionManager.inMemory(workspacePath),
+    settingsManager: infra.settingsManager,
+  });
+
+  let text = '';
+  const unsub = session.subscribe((event) => {
+    if (event.type !== 'message_update') return;
+    const ame = event.assistantMessageEvent;
+    if (ame.type === 'text_delta') text += ame.delta;
+  });
+
+  try {
+    await Promise.race([
+      session.prompt(prompt),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Adhoc agent timed out')), ADHOC_TIMEOUT_MS),
+      ),
+    ]);
+  } finally {
+    unsub();
+    session.dispose();
+  }
+
+  return {
+    text: text.trim(),
+    model: `${selectedModel.provider}/${selectedModel.modelId}`,
+  };
+}
+
+function selectFastModel(
+  available: Model<Api>[],
+  settingsManager: ReturnType<typeof import('@mariozechner/pi-coding-agent').SettingsManager.create>,
+  fallback: Model<Api> | null,
+): SelectedModel {
+  // 1. Try user's LOW tier model
+  const globalSettings = settingsManager.getGlobalSettings() as Record<string, unknown>;
+  const tiers = getModelTiers(globalSettings);
+  if (tiers.LOW) {
+    const match = available.find(
+      (m) => m.provider === tiers.LOW!.provider && m.id === tiers.LOW!.modelId,
+    );
+    if (match) {
+      return { model: match, provider: match.provider, modelId: match.id };
+    }
+  }
+
+  // 2. Walk provider-neutral preference list
+  for (const pref of FAST_MODEL_PREFERENCES) {
+    const model = available.find((m) => m.provider === pref.provider && m.id === pref.modelId);
+    if (model) {
+      return { model, provider: pref.provider, modelId: pref.modelId };
+    }
+  }
+
+  // 3. First available model
+  if (available[0]) {
+    return {
+      model: available[0],
+      provider: available[0].provider,
+      modelId: available[0].id,
+    };
+  }
+
+  // 4. Absolute fallback (shared infra model, may be null)
+  if (fallback) {
+    return {
+      model: fallback,
+      provider: fallback.provider,
+      modelId: fallback.id,
+    };
+  }
+
+  throw new Error('No models available — please authenticate with a model provider.');
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/electron/features/agent/assistants/adhoc-agent.ts
+git commit -m "feat: use LOW tier and provider-neutral ordering in adhoc agent"
+```
+
+---
+
+### Task 9: Update pickFallbackModel to check tier settings
+
+**Files:**
+- Modify: `apps/desktop/electron/ipc/agent/core/agent-model-context.ts:75-97`
+
+The fallback picker for main sessions should check tier settings before walking the chain.
+
+- [ ] **Step 1: Update pickFallbackModel()**
+
+In `apps/desktop/electron/ipc/agent/core/agent-model-context.ts`, add import at the top:
+
+```ts
+import { getModelTiers } from '../../../shared/settings/model-tiers';
+```
+
+Then replace the `pickFallbackModel` function (lines 75-97):
+
+```ts
+function pickFallbackModel(
+  session: AgentSession,
+  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
+) {
+  session.settingsManager.reload();
+
+  // 1. Try saved default provider/model (existing settings)
+  const preferredProvider = session.settingsManager.getDefaultProvider();
+  const savedDefaultModel = findAvailableModelByProviderAndId(
+    availableModels,
+    preferredProvider,
+    session.settingsManager.getDefaultModel(),
+  );
+  if (savedDefaultModel) return savedDefaultModel;
+
+  // 2. Try HIGH tier model (main sessions use the most capable model)
+  const globalSettings = session.settingsManager.getGlobalSettings() as Record<string, unknown>;
+  const tiers = getModelTiers(globalSettings);
+  if (tiers.HIGH) {
+    const tierMatch = availableModels.find(
+      (m) => m.provider === tiers.HIGH!.provider && m.id === tiers.HIGH!.modelId,
+    );
+    if (tierMatch) return tierMatch;
+  }
+
+  // 3. Walk fallback chain
+  const fallbackChain = getConfiguredModelFallbackChain(globalSettings);
+  for (const candidate of fallbackChain) {
+    const model = findAvailableModelByReference(availableModels, candidate, preferredProvider);
+    if (model) return model;
+  }
+
+  return availableModels[0];
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/electron/ipc/agent/core/agent-model-context.ts
+git commit -m "feat: check HIGH tier model in pickFallbackModel before walking chain"
+```
+
+---
+
+### Task 10: Add model tier IPC handlers
+
+**Files:**
+- Modify: `apps/desktop/src/types/ipc-channels.ts`
+- Modify: `apps/desktop/src/types/electron.d.ts`
+- Modify: `apps/desktop/electron/ipc/workspace/profiles.ts`
+
+Add IPC channels for reading/writing model tier settings, and update the profile clone to copy tiers alongside auth.
+
+- [ ] **Step 1: Add IPC channels for model tiers**
+
+In `apps/desktop/src/types/ipc-channels.ts`, add a `modelTiers` section near the `models` channels (around line 137):
+
+```ts
+  modelTiers: {
+    get: 'sero:model-tiers:get',
+    set: 'sero:model-tiers:set',
+  },
+```
+
+- [ ] **Step 2: Add model tier methods to electron.d.ts**
+
+In `apps/desktop/src/types/electron.d.ts`, add to the `SeroAPI` interface a new `modelTiers` section:
+
+```ts
+  modelTiers: {
+    get(): Promise<import('./ipc').ModelTierSettings>;
+    set(tiers: import('./ipc').ModelTierSettings): Promise<void>;
+  };
+```
+
+Note: This is one of the rare cases where inline `import()` is acceptable in `.d.ts` declaration files for the window API type, matching the existing pattern in that file. If the codebase uses a different pattern (top-level import type), follow that instead.
+
+- [ ] **Step 3: Register model tier IPC handlers**
+
+In `apps/desktop/electron/ipc/workspace/profiles.ts`, add handlers. First add imports:
+
+```ts
+import { readFileSync, writeFileSync } from 'fs';
+import { SERO_AGENT_DIR } from '../../platform/env';
+import { getModelTiers, setModelTiers } from '../../shared/settings/model-tiers';
+import type { ModelTierSettings } from '../../../src/types/ipc';
+```
+
+Then add handlers inside `registerProfileHandlers()`:
+
+```ts
+  /** Get current model tier settings. */
+  ipcMain.handle(IpcChannels.modelTiers.get, (): ModelTierSettings => {
+    const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+    try {
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      return getModelTiers(settings);
+    } catch {
+      return {};
+    }
+  });
+
+  /** Set model tier settings. */
+  ipcMain.handle(
+    IpcChannels.modelTiers.set,
+    (_e, tiers: ModelTierSettings): void => {
+      const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+      let settings: Record<string, unknown> = {};
+      try {
+        settings = JSON.parse(readFileSync(settingsPath, 'utf8'));
+      } catch { /* fresh settings */ }
+      const updated = setModelTiers(settings, tiers);
+      writeFileSync(settingsPath, JSON.stringify(updated, null, 2) + '\n');
+    },
+  );
+```
+
+- [ ] **Step 4: Update profile clone to copy model tiers**
+
+In `apps/desktop/electron/ipc/workspace/profiles.ts`, in the `create` handler (around line 43), after the auth.json copy block, add tier cloning:
+
+```ts
+      // Copy modelTiers from source profile's settings.json
+      if (copyAuthFromId) {
+        const source = profileManager.findById(copyAuthFromId);
+        if (source) {
+          // ... existing auth.json copy ...
+
+          // Copy model tier settings
+          const srcSettings = path.join(source.path, 'agent', 'settings.json');
+          if (existsSync(srcSettings)) {
+            try {
+              const srcSettingsObj = JSON.parse(readFileSync(srcSettings, 'utf8'));
+              const srcTiers = getModelTiers(srcSettingsObj);
+              if (Object.keys(srcTiers).length > 0) {
+                const destSettingsPath = path.join(entry.path, 'agent', 'settings.json');
+                let destSettings: Record<string, unknown> = {};
+                try {
+                  destSettings = JSON.parse(readFileSync(destSettingsPath, 'utf8'));
+                } catch { /* fresh settings */ }
+                const updated = setModelTiers(destSettings, srcTiers);
+                writeFileSync(destSettingsPath, JSON.stringify(updated, null, 2) + '\n');
+              }
+            } catch {
+              // Non-critical — tiers can be configured later
+            }
+          }
+        }
+      }
+```
+
+- [ ] **Step 5: Update preload to expose model tier IPC**
+
+Find the preload file (likely `apps/desktop/electron/preload.ts` or similar) and add the `modelTiers` bridge methods to match the `electron.d.ts` declaration. This should follow the existing pattern for other IPC methods:
+
+```ts
+modelTiers: {
+  get: () => ipcRenderer.invoke(IpcChannels.modelTiers.get),
+  set: (tiers: ModelTierSettings) => ipcRenderer.invoke(IpcChannels.modelTiers.set, tiers),
+},
+```
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/types/ipc-channels.ts apps/desktop/src/types/electron.d.ts \
+       apps/desktop/electron/ipc/workspace/profiles.ts apps/desktop/electron/preload.ts
+git commit -m "feat: add model tier IPC handlers and profile clone support"
+```
+
+---
+
+### Task 11: Add Anthropic warning banner to AuthLoginViews
+
+**Files:**
+- Modify: `apps/desktop/src/components/layout/AuthLoginViews.tsx`
+
+Show an inline warning when the user clicks to authenticate with Anthropic.
+
+- [ ] **Step 1: Add warning banner to ProviderListView**
+
+In `apps/desktop/src/components/layout/AuthLoginViews.tsx`, add a state and warning banner inside `ProviderListView`. Add `useState` and `TriangleAlert` to imports (TriangleAlert is from lucide-react).
+
+Inside `ProviderListView`, add state:
+
+```ts
+const [anthropicWarning, setAnthropicWarning] = useState<string | null>(null);
+```
+
+Wrap the `onOAuthLogin` calls for Anthropic. Replace the OAuth button's `onClick`:
+
+```ts
+onClick={() => {
+  if (p.id === 'anthropic' && !anthropicWarning) {
+    setAnthropicWarning(p.id);
+    return;
+  }
+  onOAuthLogin(p.id);
+}}
+```
+
+After the OAuth providers loop (after the `</div>` closing `space-y-0.5`), add:
+
+```tsx
+{anthropicWarning && (
+  <div className="mx-1 flex items-start gap-2 rounded-md border border-[var(--status-warning)]/30 bg-[var(--status-warning)]/5 px-3 py-2 text-xs text-[var(--text-secondary)]">
+    <TriangleAlert className="mt-0.5 size-3.5 shrink-0 text-[var(--status-warning)]" />
+    <div className="space-y-1.5">
+      <p>
+        Anthropic may restrict third-party use of consumer subscriptions.
+        We recommend using an API key with your own billing account.
+      </p>
+      <div className="flex gap-2">
+        <button
+          onClick={() => {
+            setAnthropicWarning(null);
+            onOAuthLogin('anthropic');
+          }}
+          className="text-xs font-medium text-[var(--text-primary)] hover:underline"
+        >
+          Continue anyway
+        </button>
+        <button
+          onClick={() => setAnthropicWarning(null)}
+          className="text-xs text-[var(--text-tertiary)] hover:underline"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+)}
+```
+
+Apply the same pattern for the API key section — when `p.id === 'anthropic'`, show the warning before proceeding to `onApiKeyStart`.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/src/components/layout/AuthLoginViews.tsx
+git commit -m "feat: add Anthropic consumer subscription warning in auth dialog"
+```
+
+---
+
+### Task 12: Create the TierPicker onboarding component
+
+**Files:**
+- Create: `apps/desktop/src/components/profiles/TierPicker.tsx`
+
+A self-contained component for the onboarding step where users pick models for LOW/MED/HIGH tiers.
+
+- [ ] **Step 1: Create TierPicker.tsx**
+
+Create `apps/desktop/src/components/profiles/TierPicker.tsx`:
+
+```tsx
+/**
+ * TierPicker — onboarding step for picking default models per tier.
+ *
+ * Shows three dropdowns (LOW/MED/HIGH) populated with available models.
+ * Includes a "use same for all" toggle and a skip button.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@sero-ai/ui/components/ui/select';
+import { Switch } from '@sero-ai/ui/components/ui/switch';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import type { ModelTierSettings, ModelTierEntry } from '@/types/ipc';
+
+interface AvailableModel {
+  provider: string;
+  modelId: string;
+  name: string;
+  providerName: string;
+}
+
+interface TierPickerProps {
+  onComplete: (tiers: ModelTierSettings) => void;
+  onSkip: () => void;
+}
+
+const TIER_META = [
+  { key: 'LOW' as const, label: 'Low', desc: 'Fast, cheap tasks — scouts, quick lookups' },
+  { key: 'MED' as const, label: 'Medium', desc: 'Everyday agents — analysis, implementation, review' },
+  { key: 'HIGH' as const, label: 'High', desc: 'Complex reasoning — planning, coordination' },
+] as const;
+
+function modelKey(m: { provider: string; modelId: string }): string {
+  return `${m.provider}/${m.modelId}`;
+}
+
+function parseModelKey(key: string): ModelTierEntry | null {
+  const idx = key.indexOf('/');
+  if (idx === -1) return null;
+  return { provider: key.slice(0, idx), modelId: key.slice(idx + 1) };
+}
+
+export function TierPicker({ onComplete, onSkip }: TierPickerProps) {
+  const [models, setModels] = useState<AvailableModel[]>([]);
+  const [sameForAll, setSameForAll] = useState(false);
+  const [selections, setSelections] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+
+  // Load available models
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const state = await window.sero.models.list();
+        if (cancelled) return;
+        const flat: AvailableModel[] = [];
+        for (const group of state) {
+          for (const m of group.models) {
+            flat.push({
+              provider: m.provider,
+              modelId: m.modelId,
+              name: m.name,
+              providerName: group.displayName,
+            });
+          }
+        }
+        setModels(flat);
+      } catch {
+        // No models available
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleSelect = useCallback((tier: string, value: string) => {
+    setSelections((prev) => {
+      if (sameForAll) {
+        return { LOW: value, MED: value, HIGH: value };
+      }
+      return { ...prev, [tier]: value };
+    });
+  }, [sameForAll]);
+
+  const handleSameToggle = useCallback((checked: boolean) => {
+    setSameForAll(checked);
+    if (checked) {
+      // Use first available selection or empty
+      const first = selections.LOW || selections.MED || selections.HIGH || '';
+      setSelections({ LOW: first, MED: first, HIGH: first });
+    }
+  }, [selections]);
+
+  const handleComplete = useCallback(() => {
+    const tiers: ModelTierSettings = {};
+    for (const { key } of TIER_META) {
+      const val = selections[key];
+      if (val) {
+        const parsed = parseModelKey(val);
+        if (parsed) tiers[key] = parsed;
+      }
+    }
+    onComplete(tiers);
+  }, [selections, onComplete]);
+
+  const hasAnySelection = Object.values(selections).some(Boolean);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-8 text-sm text-muted-foreground">
+        Loading available models…
+      </div>
+    );
+  }
+
+  if (models.length === 0) {
+    return (
+      <div className="space-y-3 text-center py-4">
+        <p className="text-sm text-muted-foreground">
+          No models available. Sign in to a provider first.
+        </p>
+        <Button variant="ghost" size="sm" onClick={onSkip}>
+          Skip for now
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Switch
+            id="same-for-all"
+            checked={sameForAll}
+            onCheckedChange={handleSameToggle}
+          />
+          <Label htmlFor="same-for-all" className="text-xs text-muted-foreground">
+            Use the same model for all tiers
+          </Label>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {(sameForAll ? [TIER_META[0]] : TIER_META).map(({ key, label, desc }) => (
+          <div key={key} className="space-y-1">
+            <Label className="text-sm font-medium">
+              {sameForAll ? 'All tiers' : label}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {sameForAll ? 'Single model for all task types' : desc}
+            </p>
+            <Select
+              value={selections[key] || ''}
+              onValueChange={(v) => handleSelect(key, v)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Choose a model…" />
+              </SelectTrigger>
+              <SelectContent>
+                {models.map((m) => (
+                  <SelectItem key={modelKey(m)} value={modelKey(m)}>
+                    <span className="text-xs text-muted-foreground mr-1.5">
+                      {m.providerName}
+                    </span>
+                    {m.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between pt-1">
+        <Button variant="ghost" size="sm" onClick={onSkip}>
+          Skip
+        </Button>
+        <Button size="sm" onClick={handleComplete} disabled={!hasAnySelection}>
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS (or minor issues with the `window.sero.models.list()` return type — adjust to match actual type)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/src/components/profiles/TierPicker.tsx
+git commit -m "feat: create TierPicker onboarding component for model tier selection"
+```
+
+---
+
+### Task 13: Integrate TierPicker into OnboardingWizard
+
+**Files:**
+- Modify: `apps/desktop/src/components/profiles/OnboardingWizard.tsx`
+
+Add a `tiers` phase between auth and memory setup.
+
+- [ ] **Step 1: Update OnboardingWizard phases and flow**
+
+In `apps/desktop/src/components/profiles/OnboardingWizard.tsx`:
+
+Add import:
+```ts
+import { TierPicker } from './TierPicker';
+import type { ModelTierSettings } from '@/types/ipc';
+```
+
+Update the Phase type (line 44):
+```ts
+type Phase = 'checking' | 'auth' | 'tiers' | 'launching' | 'error' | 'done';
+```
+
+Update the initial check (lines 74-78) — after auth is confirmed, go to tiers instead of directly to memory:
+
+Replace:
+```ts
+        if (hasAuth) {
+          // Auth present (copied at creation) → launch memory setup
+          launchMemorySession();
+        } else {
+```
+
+With:
+```ts
+        if (hasAuth) {
+          // Auth present (copied at creation) → check if tiers are configured
+          const tiers = await window.sero.modelTiers.get();
+          if (Object.keys(tiers).length > 0) {
+            // Tiers already configured (copied from source profile)
+            launchMemorySession();
+          } else {
+            setPhase('tiers');
+          }
+        } else {
+```
+
+Update `handleLoginComplete` (line 127-130) to go to tiers:
+
+Replace:
+```ts
+  const handleLoginComplete = useCallback(() => {
+    setShowLoginDialog(false);
+    launchMemorySession();
+  }, [launchMemorySession]);
+```
+
+With:
+```ts
+  const handleLoginComplete = useCallback(() => {
+    setShowLoginDialog(false);
+    setPhase('tiers');
+  }, []);
+```
+
+Update `handleSkipAuth` (line 133-135) to go to tiers:
+
+Replace:
+```ts
+  const handleSkipAuth = useCallback(() => {
+    launchMemorySession();
+  }, [launchMemorySession]);
+```
+
+With:
+```ts
+  const handleSkipAuth = useCallback(() => {
+    setPhase('tiers');
+  }, []);
+```
+
+Add tier completion handlers:
+
+```ts
+  const handleTierComplete = useCallback(async (tiers: ModelTierSettings) => {
+    try {
+      await window.sero.modelTiers.set(tiers);
+    } catch (err) {
+      console.warn('[onboarding] Failed to save model tiers:', err);
+    }
+    launchMemorySession();
+  }, [launchMemorySession]);
+
+  const handleTierSkip = useCallback(() => {
+    launchMemorySession();
+  }, [launchMemorySession]);
+```
+
+Update the null-return gate (line 138):
+
+Replace:
+```ts
+  if (phase === 'checking' || phase === 'done') return null;
+```
+
+With:
+```ts
+  if (phase === 'checking' || phase === 'done') return null;
+```
+
+(Same — no change needed here.)
+
+Add the tiers dialog before the auth dialog in the JSX return:
+
+```tsx
+      <Dialog open={phase === 'tiers'} onOpenChange={() => {/* prevent close */}}>
+        <DialogContent className="max-w-md" onInteractOutside={(e) => e.preventDefault()}>
+          <DialogHeader>
+            <DialogTitle>Choose your default models</DialogTitle>
+            <DialogDescription>
+              Pick which models to use for different task complexities.
+              You can change these anytime in settings.
+            </DialogDescription>
+          </DialogHeader>
+          <TierPicker onComplete={handleTierComplete} onSkip={handleTierSkip} />
+        </DialogContent>
+      </Dialog>
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/src/components/profiles/OnboardingWizard.tsx
+git commit -m "feat: integrate TierPicker into onboarding wizard between auth and memory"
+```
+
+---
+
+### Task 14: Update ProfileForm clone message
+
+**Files:**
+- Modify: `apps/desktop/src/components/profiles/ProfileForm.tsx`
+
+Update the "Copy credentials" checkbox label to mention model preferences.
+
+- [ ] **Step 1: Update checkbox label**
+
+In `apps/desktop/src/components/profiles/ProfileForm.tsx`, find the checkbox label for credential copying (likely around line 151). It should say something like "Copy credentials from current profile".
+
+Replace the label text with:
+
+```
+Copy credentials and model preferences from current profile
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/desktop/src/components/profiles/ProfileForm.tsx
+git commit -m "feat: update profile clone label to mention model preferences"
+```
+
+---
+
+### Task 15: Update all agent templates to use structured model fields
+
+**Files:**
+- Modify: `packages/templates/agents/scout.md`
+- Modify: `packages/templates/agents/analyst.md`
+- Modify: `packages/templates/agents/planner.md`
+- Modify: `packages/templates/agents/implementer.md`
+- Modify: `packages/templates/agents/reviewer.md`
+- Modify: `packages/templates/agents/spec-reviewer.md`
+- Modify: `packages/templates/agents/quality-reviewer.md`
+- Modify: `packages/templates/agents/test-writer.md`
+- Modify: `packages/templates/agents/researcher.md`
+- Modify: `packages/templates/agents/research-analyst.md`
+- Modify: `packages/templates/agents/visionary.md`
+- Modify: `packages/templates/agents/collab-analyst.md`
+- Modify: `packages/templates/agents/coordinator.md`
+
+Replace all hardcoded `"model": "claude-*"` with structured `{ prefer, fallbacks }` fields.
+
+- [ ] **Step 1: Update LOW tier template (scout)**
+
+In `packages/templates/agents/scout.md`, replace:
+```json
+"model": "claude-haiku-4-5",
+```
+With:
+```json
+"model": { "prefer": "LOW", "fallbacks": ["gpt-4.1-mini", "claude-haiku-4-5", "gemini-2.5-flash"] },
+```
+
+- [ ] **Step 2: Update MED tier templates**
+
+For each of these files, replace `"model": "claude-sonnet-4-6"` with the MED tier structured field:
+
+**analyst.md, implementer.md, reviewer.md, researcher.md, test-writer.md, spec-reviewer.md, quality-reviewer.md, research-analyst.md, visionary.md, collab-analyst.md:**
+
+```json
+"model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
+```
+
+- [ ] **Step 3: Update HIGH tier templates**
+
+For **planner.md** and **coordinator.md**, replace `"model": "claude-sonnet-4-6"` with:
+
+```json
+"model": { "prefer": "HIGH", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
+```
+
+- [ ] **Step 4: Verify all templates are updated**
+
+Run: `grep -r '"model": "claude-' packages/templates/agents/`
+Expected: No matches — all templates should use the structured format now.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/templates/agents/
+git commit -m "feat: update all agent templates to use structured model fields with tier aliases"
+```
+
+---
+
+### Deferred: Inline model picker on resolution failure
+
+The spec describes an inline model picker UI that appears in the chat area when no model can be resolved. This is a significant UI feature (new component, agent-pool integration, IPC for user selection mid-prompt). The current implementation gracefully falls back to the first available model in the registry, which handles the common case. The inline picker can be built as a follow-up once the tier system is proven in use.
+
+---
+
+### Task 16: Final typecheck and integration verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS with zero errors across all packages
+
+- [ ] **Step 2: Verify no remaining hardcoded Claude defaults**
+
+Run these checks:
+
+```bash
+# Check for hardcoded claude defaults in bootstrap/infra code (should find none)
+grep -rn "defaultProvider.*anthropic\|defaultModel.*claude\|getModel.*anthropic.*claude" \
+  apps/desktop/electron/main.ts \
+  apps/desktop/electron/shared/infra/shared-infra.ts
+
+# Check agent templates have no plain claude model strings
+grep -rn '"model": "claude-' packages/templates/agents/
+```
+
+Expected: No matches for either command.
+
+- [ ] **Step 3: Verify structured model fields exist in templates**
+
+```bash
+grep -c '"prefer"' packages/templates/agents/*.md
+```
+
+Expected: 13 matches (one per template file).
+
+- [ ] **Step 4: Commit any remaining fixes**
+
+If typecheck revealed issues, fix and commit:
+
+```bash
+git add -A
+git commit -m "fix: resolve remaining type errors from dynamic model provider changes"
+```
+
+---
+
+### Task 17: Add IPC bridge for models.list (if missing)
+
+**Files:**
+- Verify: `apps/desktop/electron/preload.ts` (or wherever the preload bridge is)
+- Verify: `apps/desktop/src/types/electron.d.ts`
+
+The TierPicker component calls `window.sero.models.list()`. Verify this IPC bridge exists and works. If it doesn't exist, add it.
+
+- [ ] **Step 1: Check if models.list bridge exists**
+
+Search for `models.list` or `IpcChannels.models.list` in the preload file. The handler already exists in `electron/ipc/agent/handlers/models.ts` — verify the preload bridge exposes it on `window.sero.models.list`.
+
+- [ ] **Step 2: Add bridge if missing**
+
+If the bridge doesn't exist, add to preload:
+
+```ts
+models: {
+  list: () => ipcRenderer.invoke(IpcChannels.models.list),
+},
+```
+
+And to `electron.d.ts`:
+
+```ts
+models: {
+  list(): Promise<import('./ipc').AvailableModelGroup[]>;
+};
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit if changes were needed**
+
+```bash
+git add apps/desktop/electron/preload.ts apps/desktop/src/types/electron.d.ts
+git commit -m "feat: expose models.list IPC bridge for tier picker"
+```

--- a/docs/superpowers/plans/2026-04-04-onboarding-simplification-plan.md
+++ b/docs/superpowers/plans/2026-04-04-onboarding-simplification-plan.md
@@ -1,0 +1,599 @@
+# Onboarding Simplification + Resilience Plan
+
+## Goal
+
+Make onboarding feel like a fast, polished "ready in one click" flow for the
+common case, while preserving explicit model choice for users who want to tune
+it.
+
+This plan builds on `docs/superpowers/specs/2026-04-04-onboarding-resilience-analysis.md`
+but shifts the emphasis from failure recovery alone to **default-first UX**:
+
+- onboarding should **pre-select sensible models automatically**
+- users should only need to make choices when they want to
+- expired or broken provider auth should be surfaced clearly and recoverably
+- cloned and non-cloned profiles should both follow the same mental model
+
+---
+
+## Review of the Existing Analysis
+
+The analysis doc is directionally correct. Its strongest points are:
+
+1. It correctly identifies that `ModelRegistry.getAvailable()` is not a health
+   check.
+2. It correctly calls out silent fallback behavior as confusing.
+3. It correctly identifies cloned `auth.json` as a major source of stale-token
+   onboarding failures.
+4. It usefully separates onboarding-specific fixes from broader model-selection
+   resilience work.
+
+### What is missing
+
+The current analysis focuses mainly on **how failures should be handled**, but
+not enough on **how to reduce the number of decisions and failure points in the
+first place**.
+
+For a sleek onboarding flow, we should add:
+
+- a **default-first recommendation system**
+- a single **preflight assessment** that determines what the user actually
+  needs to do
+- progressive disclosure so most users never see the full tier editor unless
+  they ask for it
+- a unified path for:
+  - brand-new profiles with no `auth.json`
+  - profiles cloned from another profile
+  - profiles relying on env-backed credentials or local models
+
+---
+
+## Current Workflow Problems
+
+## 1. Too many explicit decisions too early
+
+Today, onboarding often asks the user to:
+
+1. think about providers
+2. sign in
+3. think about LOW / MED / HIGH tiers
+4. manually select models
+5. only then continue to memory bootstrap
+
+That is flexible, but it is not sleek.
+
+## 2. The tier picker starts empty
+
+Even when the system already has enough information to make a strong choice,
+the tier picker makes the user populate everything manually.
+
+This creates unnecessary friction for:
+
+- first-time users
+- users who just want "the recommended option"
+- users who cloned a profile and expect it to work immediately
+
+## 3. Provider state is binary instead of actionable
+
+The UI mostly distinguishes between:
+
+- has credentials
+- does not have credentials
+
+But onboarding really needs richer states:
+
+- healthy
+- broken / expired
+- env-backed
+- local-only
+- not configured
+
+Without these states, the UX becomes misleading.
+
+## 4. Broken cloned auth is discovered too late
+
+Cloned profiles currently inherit `auth.json` and `modelTiers`, but their first
+real validation often happens during `setModel()` or the first prompt.
+
+That means the onboarding flow can look successful up to the point where the
+welcome session fails.
+
+## 5. The "Skip" semantics are muddy
+
+Right now, skip can mean:
+
+- skip auth
+- skip tier selection
+- let the system guess
+
+That makes the flow harder to reason about.
+
+## 6. Clone vs non-clone flows are inconsistent
+
+- Cloned profile: may appear ready, then fail later
+- Fresh profile: must authenticate first, then choose models
+
+These should feel like variations of the same flow, not separate products.
+
+---
+
+## UX Principles for the New Flow
+
+## 1. One-click fast path
+
+If Sero can determine a usable setup, the primary CTA should simply be:
+
+- **Continue**
+
+Not "choose three models first".
+
+## 2. Progressive disclosure
+
+Show recommended defaults first. Hide advanced model customization behind:
+
+- **Customize models**
+
+## 3. Validate once, early
+
+Run a single onboarding preflight to determine:
+
+- what models are actually usable
+- which providers are broken
+- which tier defaults should be preselected
+- whether user action is needed at all
+
+## 4. Explain failures in provider language
+
+Never fail with "model unavailable" when the actual issue is:
+
+- "Anthropic credentials expired"
+- "OpenAI key missing"
+- "Imported credentials could not be validated"
+
+## 5. Preserve control
+
+The fast path should be automatic, but users must still be able to:
+
+- override LOW / MED / HIGH choices
+- add another provider during onboarding
+- re-auth a single broken provider
+- continue with a subset of healthy providers
+
+---
+
+## Proposed Target Flow
+
+## Step 0 — Onboarding Preflight (new, automatic)
+
+Before rendering the onboarding UI, run a single host-side assessment that:
+
+1. inspects available providers and model sources
+2. performs lightweight health checks where possible
+3. validates existing tier selections if present
+4. computes recommended tier defaults
+5. returns a renderer-ready onboarding state
+
+This should become the single source of truth for onboarding.
+
+### Preflight output should include
+
+- `healthyProviders`
+- `brokenProviders`
+- `availableModelGroups`
+- `recommendedTiers`
+- `existingTierValidity`
+- `hasAnyUsableModels`
+- `needsAuth`
+- `hasImportedCredentials`
+- `hasImportedBrokenCredentials`
+
+---
+
+## Step 1 — "You're almost ready" screen
+
+If preflight finds at least one usable model, do **not** drop the user into an
+empty tier picker.
+
+Instead show a compact recommendation screen:
+
+- summary of connected healthy providers
+- summary of broken providers, if any
+- recommended LOW / MED / HIGH selections, already filled in
+- primary button: **Continue**
+- secondary button: **Customize models**
+- tertiary action: **Add / reconnect provider**
+
+### Example
+
+- LOW: OpenAI / GPT-4.1 Mini
+- MED: OpenAI / GPT-5.4
+- HIGH: OpenAI / GPT-5.4
+
+Or, if only Google is healthy:
+
+- LOW: Gemini 2.5 Flash
+- MED: Gemini 2.5 Pro
+- HIGH: Gemini 2.5 Pro
+
+The key change is that onboarding becomes confirmatory by default, not form-like.
+
+---
+
+## Step 2 — Optional advanced customization
+
+If the user clicks **Customize models**, open the current tier editor UI with:
+
+- all three tiers pre-populated
+- "Use same model for all tiers" still available
+- only healthy / usable models shown by default
+- broken providers visible separately as disabled / warning entries, not mixed
+  into the healthy list
+
+This preserves the current flexibility, but makes it opt-in.
+
+---
+
+## Step 3 — Provider auth / reconnect when needed
+
+If preflight finds no usable models, or if the user wants to fix broken
+providers, show a provider auth screen with richer status:
+
+- healthy
+- expired / broken
+- configured from env
+- local models available
+- not configured
+
+### Desired actions
+
+- **Connect provider**
+- **Reconnect [provider]**
+- **Use current healthy providers only**
+- **Continue with env/local models** when available
+
+This means onboarding should stop framing auth as just "logged in or not".
+
+---
+
+## Step 4 — Launch welcome memory session
+
+Only after a usable model setup is confirmed should Sero launch the welcome
+memory session.
+
+At that point:
+
+- selected tiers are already saved
+- the welcome session uses the validated recommendation
+- provider failures become exceptional, not part of the normal path
+
+---
+
+## Provider Default Model Strategy
+
+This is the core simplification lever.
+
+## Proposal
+
+Introduce a provider-defaults registry that defines the recommended models per
+provider and per tier.
+
+Example shape:
+
+```ts
+{
+  openai: {
+    LOW: 'gpt-4.1-mini',
+    MED: 'gpt-5.4',
+    HIGH: 'gpt-5.4',
+  },
+  google: {
+    LOW: 'gemini-2.5-flash',
+    MED: 'gemini-2.5-pro',
+    HIGH: 'gemini-2.5-pro',
+  },
+  anthropic: {
+    LOW: 'claude-haiku-4-5',
+    MED: 'claude-sonnet-4-6',
+    HIGH: 'claude-sonnet-4-6',
+  }
+}
+```
+
+### How recommendations should be chosen
+
+Priority order:
+
+1. Existing saved tier choice, if still healthy
+2. Imported cloned tier choice, if still healthy
+3. Provider-default tier choice from the healthiest / preferred provider
+4. Capability-ranked fallback across all healthy models
+
+### Why this helps
+
+It lets onboarding always start with a real, prefilled answer.
+
+Users can still edit it, but they no longer have to build their setup from
+scratch.
+
+---
+
+## Make Provider Defaults Configurable
+
+The request says provider defaults should be configurable. I agree.
+
+## Recommended scope
+
+### Phase 1
+
+Ship built-in defaults in code, but support optional settings overrides in
+`settings.json`, e.g.:
+
+```json
+{
+  "sero": {
+    "providerModelDefaults": {
+      "openai": {
+        "LOW": "gpt-4.1-mini",
+        "MED": "gpt-5.4",
+        "HIGH": "gpt-5.4"
+      }
+    }
+  }
+}
+```
+
+### Phase 2
+
+Expose a settings UI for editing these provider defaults.
+
+This gives us immediate flexibility without bloating onboarding itself.
+
+---
+
+## Expired Auth Handling Plan
+
+## Desired behavior
+
+Expired auth should be treated as a first-class onboarding state, not an edge
+case discovered during prompt execution.
+
+## Recommended approach
+
+### 1. Add provider health assessment
+
+Introduce a lightweight provider-health pass used by onboarding.
+
+Possible states:
+
+- `healthy`
+- `broken_expired`
+- `broken_invalid`
+- `env`
+- `local`
+- `missing`
+- `unknown`
+
+### 2. Probe in the background, not with a blocking spinner-first UX
+
+The onboarding screen should render quickly, then update provider states as the
+health checks complete.
+
+If a provider cannot be checked quickly, mark it `unknown` initially and avoid
+blocking the entire flow on it.
+
+### 3. Targeted recovery actions
+
+For broken providers, show:
+
+- provider name
+- short explanation
+- **Reconnect** action
+- optional **Ignore for now** action
+
+### 4. Do not silently promote broken providers into recommendations
+
+Broken providers should never be used to prefill tier defaults.
+
+---
+
+## Fresh Profile Without Cloned `auth.json`
+
+This should become the simplest flow.
+
+## Desired experience
+
+1. User creates profile
+2. If env/local models already exist, Sero recommends defaults immediately
+3. Otherwise Sero asks them to connect one provider
+4. After auth succeeds, Sero pre-selects recommended tiers automatically
+5. User clicks Continue
+6. Memory bootstrap starts
+
+That means fresh profiles should not land in an empty tier step either.
+
+---
+
+## Renderer / UX Changes
+
+## Replace the current onboarding state machine with:
+
+- `checking`
+- `ready` (recommended defaults available)
+- `customize`
+- `auth`
+- `launching`
+- `error`
+
+This is simpler than the current "auth then tiers then maybe fail then fallback"
+mental model.
+
+## The new primary onboarding view should show
+
+- headline: ready state
+- recommended models summary
+- provider health summary
+- Continue / Customize / Add provider actions
+
+The current `TierPicker` can remain, but it should become an advanced editor,
+not the first thing every user sees.
+
+---
+
+## Host / Data Model Changes
+
+## 1. Add a dedicated onboarding IPC surface
+
+Instead of spreading onboarding logic across `auth.getProviders()`,
+`models.list()`, `modelTiers.get()`, and `profiles.needsOnboarding()`, add a
+single onboarding-specific API.
+
+Example:
+
+- `window.sero.onboarding.getState()`
+- `window.sero.onboarding.saveSelections()`
+- `window.sero.onboarding.reconnectProvider(providerId)`
+
+This keeps renderer logic thin and centralizes the rules.
+
+## 2. Add provider defaults registry
+
+Suggested location:
+
+- `apps/desktop/electron/shared/settings/provider-model-defaults.ts`
+
+Responsibilities:
+
+- built-in provider defaults
+- settings override merge
+- recommend LOW / MED / HIGH for a healthy provider set
+
+## 3. Add onboarding preflight module
+
+Suggested location:
+
+- `apps/desktop/electron/features/onboarding/`
+
+Responsibilities:
+
+- provider health checks
+- imported tier validation
+- recommendation generation
+- onboarding state assembly
+
+## 4. Extend auth/provider metadata
+
+Current `auth.getProviders()` only exposes basic flags. We likely need richer
+provider state metadata, either by extending auth IPC or by keeping it scoped to
+the new onboarding API.
+
+---
+
+## Profile Clone Strategy
+
+To keep profile creation sleek, I recommend **not** adding extra clone-time
+modals first.
+
+Instead:
+
+1. keep cloning `auth.json` + `modelTiers`
+2. run validation in the first-launch onboarding preflight
+3. show imported broken providers clearly there
+4. let the user reconnect only the providers that failed
+
+This avoids adding friction to profile creation while still making cloned auth
+failures understandable.
+
+### Optional follow-up
+
+Later, we can add clone-time validation if we want early warnings before the
+profile switch, but I would not make that the first implementation.
+
+---
+
+## Proposed Phases
+
+## Phase 1 — Fast-path simplification
+
+Goal: make onboarding feel one-click for healthy setups.
+
+### Deliverables
+
+- provider defaults registry
+- recommended tier generation
+- prefilled onboarding state
+- new "ready" screen with Continue / Customize
+- TierPicker converted to advanced editor
+
+## Phase 2 — Auth resilience
+
+Goal: make broken providers obvious and recoverable.
+
+### Deliverables
+
+- provider health states
+- background health probing
+- broken provider messaging and reconnect actions
+- recommendations exclude broken providers
+
+## Phase 3 — General resilience outside onboarding
+
+Goal: align the rest of the app with onboarding behavior.
+
+### Deliverables
+
+- model selector surfaces auth failures clearly
+- session-start model validation
+- better targeted fallback UX in normal chat flows
+
+---
+
+## Concrete Implementation Checklist
+
+## Backend / Electron
+
+- add provider-default registry + override support
+- add onboarding preflight service
+- define onboarding IPC types
+- compute recommended tiers from:
+  - saved tiers
+  - imported tiers
+  - provider defaults
+  - healthy model set
+- add provider health model and caching policy
+- ensure onboarding can reason about env/local model sources
+
+## Renderer
+
+- replace tier-first flow with ready/customize/auth flow
+- build recommended setup summary UI
+- prefill TierPicker from recommendations
+- show broken providers inline with reconnect actions
+- keep customization accessible but secondary
+
+## Validation / Testing
+
+Test scenarios:
+
+1. fresh profile, no auth
+2. fresh profile, env-backed API key
+3. fresh profile, local models only
+4. cloned profile, healthy auth + healthy tiers
+5. cloned profile, broken auth + healthy fallback provider
+6. cloned profile, all imported providers broken
+7. imported tiers partially invalid
+8. user customizes recommendations before continue
+9. provider expires between preflight and welcome session launch
+
+---
+
+## Recommendation
+
+I recommend we implement this around a single product rule:
+
+> **Onboarding should always begin with Sero's best recommendation, not an empty form.**
+
+That gives us the sleek/simple path by default, while still preserving full
+control behind a single "Customize models" action.
+
+If you want, I can turn this into a tighter implementation spec next, with
+proposed IPC shapes, UI states, and file-by-file tasks.

--- a/docs/superpowers/plans/2026-04-05-onboarding-polish.md
+++ b/docs/superpowers/plans/2026-04-05-onboarding-polish.md
@@ -1,0 +1,557 @@
+# Onboarding Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Polish onboarding UX — dedicated low-thinking session for memory setup, clean welcome session after, UI spacing fixes, and code deduplication.
+
+**Architecture:** OnboardingWizard gets a two-session lifecycle (temp onboarding session with low thinking → delete → fresh welcome session). SetupScreen gets spacing/consistency fixes. Duplicated helpers are extracted to shared modules.
+
+**Tech Stack:** React 19, Electron IPC, Zustand, Tailwind 4
+
+---
+
+### Task 1: Extract shared `modelKey` / `parseModelKey` helpers
+
+**Files:**
+- Create: `apps/desktop/src/lib/model-keys.ts`
+- Modify: `apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx:25-36`
+- Modify: `apps/desktop/src/components/profiles/TierPicker.tsx:39-49`
+
+- [ ] **Step 1: Create the shared module**
+
+Create `apps/desktop/src/lib/model-keys.ts`:
+
+```typescript
+export function modelKey(provider: string, modelId: string): string {
+  return `${provider}/${modelId}`;
+}
+
+export function parseModelKey(value: string): { provider: string; modelId: string } | null {
+  const separatorIndex = value.indexOf('/');
+  if (separatorIndex <= 0) return null;
+  return {
+    provider: value.slice(0, separatorIndex),
+    modelId: value.slice(separatorIndex + 1),
+  };
+}
+```
+
+- [ ] **Step 2: Update SetupScreen.tsx**
+
+Remove the local `modelKey` and `parseModelKey` functions (lines 25-36). Add import at top:
+
+```typescript
+import { modelKey, parseModelKey } from '@/lib/model-keys';
+```
+
+- [ ] **Step 3: Update TierPicker.tsx**
+
+Remove the local `mkKey` and `parseModelKey` functions (lines 39-49). Replace all `mkKey(` calls with `modelKey(`. Add import at top:
+
+```typescript
+import { modelKey, parseModelKey } from '@/lib/model-keys';
+```
+
+The `ModelTierEntry` type import stays since `parseModelKey` returns `{ provider: string; modelId: string }` which is structurally compatible.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: zero errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop/src/lib/model-keys.ts apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx apps/desktop/src/components/profiles/TierPicker.tsx
+git commit -m "refactor: extract shared modelKey/parseModelKey to src/lib/model-keys"
+```
+
+---
+
+### Task 2: Extract shared `getSeroSettings` and `readSettings` helpers
+
+**Files:**
+- Create: `apps/desktop/electron/shared/settings/settings-helpers.ts`
+- Modify: `apps/desktop/electron/shared/settings/model-tiers.ts:12-18`
+- Modify: `apps/desktop/electron/shared/settings/provider-model-defaults.ts:67-73`
+- Modify: `apps/desktop/electron/shared/settings/model-fallback-chain.ts:35-41`
+- Modify: `apps/desktop/electron/features/onboarding/preflight.ts:12-19`
+- Modify: `apps/desktop/electron/ipc/onboarding/onboarding.ts:18-25`
+
+- [ ] **Step 1: Create the shared module**
+
+Create `apps/desktop/electron/shared/settings/settings-helpers.ts`:
+
+```typescript
+import { readFileSync } from 'fs';
+import path from 'path';
+import { SERO_AGENT_DIR } from '../../platform/env';
+
+/** Extract the `sero` namespace from a parsed settings object. */
+export function getSeroSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const raw = settings.sero;
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    return raw as Record<string, unknown>;
+  }
+  return {};
+}
+
+/** Read and parse settings.json from the active agent directory. */
+export function readSettings(): Record<string, unknown> {
+  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+  try {
+    return JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+```
+
+- [ ] **Step 2: Update model-tiers.ts**
+
+Remove the local `getSeroSettings` function (lines 12-18). Add import:
+
+```typescript
+import { getSeroSettings } from './settings-helpers';
+```
+
+- [ ] **Step 3: Update provider-model-defaults.ts**
+
+Remove the local `getSeroSettings` function (lines 67-73). Add import:
+
+```typescript
+import { getSeroSettings } from './settings-helpers';
+```
+
+- [ ] **Step 4: Update model-fallback-chain.ts**
+
+Remove the local `getSeroSettings` function (lines 35-41). Add import:
+
+```typescript
+import { getSeroSettings } from './settings-helpers';
+```
+
+Note: `model-fallback-chain.ts` returns `{ ...(raw as Record<string, unknown>) }` (spread copy). The shared version returns the reference directly — callers in `model-fallback-chain.ts` immediately destructure into new objects via `sero.modelFallbackChain`, so the shallow copy is unnecessary. No behavior change.
+
+- [ ] **Step 5: Update preflight.ts**
+
+Remove the local `readSettings` function (lines 12-19). Add import:
+
+```typescript
+import { readSettings } from '../../shared/settings/settings-helpers';
+```
+
+- [ ] **Step 6: Update onboarding.ts IPC handler**
+
+Remove the local `readSettings` function (lines 18-25). Add import:
+
+```typescript
+import { readSettings } from '../../shared/settings/settings-helpers';
+```
+
+- [ ] **Step 7: Typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: zero errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop/electron/shared/settings/settings-helpers.ts apps/desktop/electron/shared/settings/model-tiers.ts apps/desktop/electron/shared/settings/provider-model-defaults.ts apps/desktop/electron/shared/settings/model-fallback-chain.ts apps/desktop/electron/features/onboarding/preflight.ts apps/desktop/electron/ipc/onboarding/onboarding.ts
+git commit -m "refactor: extract shared getSeroSettings and readSettings helpers"
+```
+
+---
+
+### Task 3: Fix stale closure in OnboardingWizard
+
+**Files:**
+- Modify: `apps/desktop/src/components/profiles/OnboardingWizard.tsx:197`
+
+- [ ] **Step 1: Fix the stale closure**
+
+In `OnboardingWizard.tsx`, inside `launchWelcomeSession`, the auth-error recovery block (around line 197):
+
+Change:
+```typescript
+const failedName = getDisplayProviderName(onboardingState, failedProvider);
+```
+
+To:
+```typescript
+const failedName = getDisplayProviderName(refreshedState, failedProvider);
+```
+
+`refreshedState` has already been fetched at this point and has current `providerHealth` data. `onboardingState` is from the closure and may be stale.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: zero errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/desktop/src/components/profiles/OnboardingWizard.tsx
+git commit -m "fix: use refreshedState for failed provider name in onboarding recovery"
+```
+
+---
+
+### Task 4: UI polish on SetupScreen
+
+**Files:**
+- Modify: `apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx`
+
+- [ ] **Step 1: Increase outer spacing**
+
+Change the root container class on line 310:
+
+From:
+```tsx
+<div className="space-y-4">
+```
+
+To:
+```tsx
+<div className="space-y-5">
+```
+
+- [ ] **Step 2: Add breathing room to header section**
+
+Change the header section (line 311):
+
+From:
+```tsx
+<div className="space-y-2">
+```
+
+To:
+```tsx
+<div className="space-y-3">
+```
+
+- [ ] **Step 3: Increase icon size for visual weight**
+
+Change the icon container (line 312-314):
+
+From:
+```tsx
+<div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+  <Sparkles className="size-5 text-[var(--status-success)]" />
+</div>
+```
+
+To:
+```tsx
+<div className="flex size-11 items-center justify-center rounded-xl bg-[var(--bg-elevated)]">
+  <Sparkles className="size-5 text-[var(--status-success)]" />
+</div>
+```
+
+- [ ] **Step 4: Increase spacing in the provider/model selector grid**
+
+Change the selects grid (line 329):
+
+From:
+```tsx
+<div className="grid gap-3">
+```
+
+To:
+```tsx
+<div className="grid gap-4">
+```
+
+- [ ] **Step 5: Polish the tier toggle card**
+
+Change the tier toggle card container (line 378):
+
+From:
+```tsx
+<div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/40 px-3 py-2.5">
+```
+
+To:
+```tsx
+<div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)]/40 px-4 py-3">
+```
+
+Also increase the inner tier fields separator spacing. Change (line 390):
+
+From:
+```tsx
+<div className="mt-3 border-t border-[var(--border-default)] pt-3">
+```
+
+To:
+```tsx
+<div className="mt-3.5 border-t border-[var(--border-default)] pt-3.5">
+```
+
+- [ ] **Step 6: Increase gap in TierModelFields**
+
+In the `TierModelFields` component, change (line 214):
+
+From:
+```tsx
+<div className="grid gap-3">
+```
+
+To:
+```tsx
+<div className="grid gap-4">
+```
+
+- [ ] **Step 7: Polish the footer buttons**
+
+Change the footer (line 410):
+
+From:
+```tsx
+<div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+```
+
+To:
+```tsx
+<div className="flex flex-col-reverse gap-3 pt-1 sm:flex-row sm:justify-between">
+```
+
+- [ ] **Step 8: Typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: zero errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+git commit -m "fix(onboarding): improve setup screen spacing and visual consistency"
+```
+
+---
+
+### Task 5: Dedicated onboarding session with low thinking
+
+**Files:**
+- Modify: `apps/desktop/src/components/profiles/OnboardingWizard.tsx`
+
+This is the core change. The current `launchWelcomeSession` creates one session and uses it for both memory setup and the user's first session. We split it into two: a temp session (low thinking) for memory setup, then a clean welcome session.
+
+- [ ] **Step 1: Add the welcome prompt constant**
+
+At the top of `OnboardingWizard.tsx`, after the existing `WELCOME_PROMPT` constant, add:
+
+```typescript
+const WELCOME_GREETING_PROMPT = "The user just finished setting up their profile. Say hello, introduce yourself briefly, and let them know you're ready to help.";
+```
+
+- [ ] **Step 2: Extract a helper to create, configure, and run a session**
+
+Add this helper function before the `OnboardingWizard` component (after the existing `applyTierModel` function):
+
+```typescript
+async function createAndRunSession(options: {
+  name?: string;
+  tiers: ModelTierSettings;
+  thinkingLevel?: string;
+  prompt: string;
+  setupUi?: (sessionId: string) => void;
+}): Promise<{ sessionId: string; sessionPath: string }> {
+  const session = await useSessionStore.getState().createSession('global');
+  await window.sero.agent.open(session.id, session.path, 'global');
+
+  if (options.name) {
+    await useSessionStore.getState().renameSession(session.id, options.name);
+  }
+
+  await applyTierModel(session.id, options.tiers);
+
+  if (options.thinkingLevel) {
+    try {
+      await window.sero.agent.setThinkingLevel(session.id, options.thinkingLevel);
+    } catch {
+      // Model may not support thinking levels — proceed with default.
+    }
+  }
+
+  options.setupUi?.(session.id);
+
+  await window.sero.agent.prompt(session.id, options.prompt);
+  return { sessionId: session.id, sessionPath: session.path };
+}
+```
+
+- [ ] **Step 3: Add a helper to tear down a session**
+
+Add this helper after `createAndRunSession`:
+
+```typescript
+async function teardownSession(sessionId: string, sessionPath: string): Promise<void> {
+  try {
+    await window.sero.agent.close(sessionId);
+  } catch {
+    // Session may already be closed.
+  }
+  try {
+    await useSessionStore.getState().deleteSession(sessionPath);
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+```
+
+- [ ] **Step 4: Rewrite `launchWelcomeSession`**
+
+Replace the entire `launchWelcomeSession` callback with:
+
+```typescript
+const launchWelcomeSession = useCallback(async (tiers: ModelTierSettings) => {
+  hideLaunchingDialogRef.current = false;
+  setErrorMessage(null);
+  setLaunchStatusMessage(null);
+  setUiPhase('launching');
+
+  let tempSessionId: string | null = null;
+  let tempSessionPath: string | null = null;
+
+  try {
+    // Phase 1: Run memory setup in a dedicated low-thinking session.
+    const temp = await createAndRunSession({
+      tiers,
+      thinkingLevel: 'low',
+      prompt: WELCOME_PROMPT,
+    });
+    tempSessionId = temp.sessionId;
+    tempSessionPath = temp.sessionPath;
+
+    // Phase 2: Tear down the temp session.
+    await teardownSession(tempSessionId, tempSessionPath);
+    tempSessionId = null;
+    tempSessionPath = null;
+
+    // Phase 3: Create the user's clean welcome session.
+    const welcome = await createAndRunSession({
+      name: 'Welcome',
+      tiers,
+      prompt: WELCOME_GREETING_PROMPT,
+      setupUi: (sessionId) => {
+        useSessionStore.getState().setActiveSession(sessionId);
+        useAgentStore.getState().focusSession(sessionId);
+        useAppStore.getState().setChatPanelOpen(true);
+      },
+    });
+
+    // Keep the welcome session visible.
+    useSessionStore.getState().setActiveSession(welcome.sessionId);
+    await finishOnboardingLaunch();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    // Clean up temp session on failure if it's still around.
+    if (tempSessionId && tempSessionPath) {
+      await teardownSession(tempSessionId, tempSessionPath);
+    }
+
+    if (isAuthError(message)) {
+      try {
+        const refreshedState = await window.sero.onboarding.getState();
+        setOnboardingState(refreshedState);
+
+        if (refreshedState.phase === 'ready' && refreshedState.recommendation) {
+          const failedProvider = extractFailedProvider(message);
+          const nextProvider = refreshedState.recommendation.preferredProvider
+            ?? refreshedState.recommendation.tiers.HIGH?.provider
+            ?? refreshedState.recommendation.tiers.MED?.provider
+            ?? refreshedState.recommendation.tiers.LOW?.provider
+            ?? null;
+
+          const failedName = getDisplayProviderName(refreshedState, failedProvider);
+          const nextName = getDisplayProviderName(refreshedState, nextProvider);
+          const canAutoRetry = !failedProvider || !nextProvider || failedProvider !== nextProvider;
+
+          setLaunchStatusMessage(
+            failedName && nextName && failedName !== nextName
+              ? `${failedName} stopped working. Switching to ${nextName}.`
+              : 'Refreshing your provider before launch.',
+          );
+
+          if (canAutoRetry) {
+            await window.sero.onboarding.saveTierSelections(refreshedState.recommendation.tiers);
+            // Retry the full two-session flow with the new tiers.
+            await launchWelcomeSession(refreshedState.recommendation.tiers);
+            return;
+          }
+        }
+
+        setLaunchStatusMessage('Reconnect a provider before onboarding can continue.');
+        continueInFlightRef.current = false;
+        setIsContinuing(false);
+        setUiPhase(deriveUiPhase(refreshedState));
+        return;
+      } catch (retryError) {
+        const retryMessage = retryError instanceof Error ? retryError.message : String(retryError);
+        continueInFlightRef.current = false;
+        setIsContinuing(false);
+        setErrorMessage(retryMessage);
+        setUiPhase('error');
+        return;
+      }
+    }
+
+    continueInFlightRef.current = false;
+    setIsContinuing(false);
+    setErrorMessage(message);
+    setUiPhase('error');
+  }
+}, [finishOnboardingLaunch]);
+```
+
+Note: the `onboardingState` dependency is removed from the callback since we now use `refreshedState` throughout (fixing the stale closure from Task 3 as well — if Task 3 was already applied, this supersedes it).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: zero errors
+
+- [ ] **Step 6: Manual test**
+
+1. Delete `~/.sero-ui/profiles.json` or create a fresh profile to trigger onboarding.
+2. Pick a provider and model on the setup screen.
+3. Click Continue.
+4. Verify the launching dialog appears.
+5. Verify a temp session is created (may flash briefly in sidebar), runs the memory prompt, then is deleted.
+6. Verify a "Welcome" session appears with an agent greeting.
+7. Verify the Dashboard becomes the active app.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/components/profiles/OnboardingWizard.tsx
+git commit -m "feat(onboarding): use dedicated low-thinking session for memory setup"
+```
+
+---
+
+### Task 6: Final typecheck and cleanup
+
+**Files:**
+- All modified files from Tasks 1-5
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `cd /Users/danielcarter/Documents/Dev/projects/sero/sero && pnpm typecheck`
+Expected: zero errors across all packages
+
+- [ ] **Step 2: Check file sizes**
+
+Run:
+```bash
+wc -l apps/desktop/src/components/profiles/OnboardingWizard.tsx apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx apps/desktop/src/components/profiles/TierPicker.tsx apps/desktop/electron/shared/settings/settings-helpers.ts apps/desktop/src/lib/model-keys.ts
+```
+
+Expected: all files under 500 lines.
+
+- [ ] **Step 3: Verify no unused imports**
+
+Skim each modified file for orphaned imports after the refactoring (e.g., `fs`/`path` imports removed from files that no longer have `readSettings`).

--- a/docs/superpowers/specs/2026-04-04-dynamic-model-provider-design.md
+++ b/docs/superpowers/specs/2026-04-04-dynamic-model-provider-design.md
@@ -1,0 +1,232 @@
+# Dynamic Model Provider System
+
+> Remove Claude as hardcoded default. Make model selection user-driven with a
+> tier system (LOW/MED/HIGH) and resilient fallback resolution.
+
+## Background
+
+Anthropic is restricting third-party use of consumer Claude subscriptions. Sero
+currently hardcodes Claude models as defaults across agent templates, bootstrap
+settings, shared infrastructure, and fallback chains. This must change so that:
+
+- No provider is privileged by default
+- Users explicitly choose their preferred models during onboarding
+- Agent templates work with any provider via tier aliases + fallback lists
+- Anthropic remains an option (with a risk warning)
+
+## Agent Frontmatter Format
+
+### New structured model field
+
+Replace the flat `"model": "claude-sonnet-4-6"` string with a structured object:
+
+```json
+{
+  "model": {
+    "prefer": "MED",
+    "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"]
+  }
+}
+```
+
+**Fields:**
+
+- `prefer` — a tier alias (`LOW`, `MED`, `HIGH`) or a specific model ID.
+  Resolved first.
+- `fallbacks` — ordered list of specific model IDs to try if `prefer` cannot
+  resolve to an available model.
+
+**Backwards compatibility:** If `"model"` is a plain string, treat it as a
+specific model ID (legacy behavior for user-edited templates).
+
+### Resolution order
+
+1. If `prefer` is a tier alias → look up user's chosen model for that tier
+2. If `prefer` is a specific model ID → try that model directly
+3. If resolved model is unavailable → iterate `fallbacks`, use first available
+4. If nothing works → show inline model picker UI
+
+### Tier mapping for existing templates
+
+| Tier | Templates |
+|------|-----------|
+| LOW  | `scout.md` |
+| MED  | `analyst.md`, `implementer.md`, `reviewer.md`, `researcher.md`, `test-writer.md`, `spec-reviewer.md`, `quality-reviewer.md`, `research-analyst.md`, `visionary.md`, `collab-analyst.md` |
+| HIGH | `planner.md`, `coordinator.md` |
+
+### Fallback model lists per tier
+
+Each template includes a multi-provider fallback list appropriate for its tier:
+
+- **LOW fallbacks:** `gpt-4.1-mini`, `claude-haiku-4-5`, `gemini-2.5-flash`
+- **MED fallbacks:** `gpt-5.4`, `claude-sonnet-4-6`, `gemini-2.5-pro`
+- **HIGH fallbacks:** `gpt-5.4`, `claude-sonnet-4-6`, `gemini-2.5-pro`
+
+## Tier Settings Storage
+
+### Per-profile `modelTiers` in settings.json
+
+```json
+{
+  "modelTiers": {
+    "LOW": { "provider": "google", "modelId": "gemini-2.5-flash" },
+    "MED": { "provider": "openai", "modelId": "gpt-5.4" },
+    "HIGH": { "provider": "openai", "modelId": "gpt-5.4" }
+  }
+}
+```
+
+- Stored per-profile inside `settings.json`
+- Cloned alongside `auth.json` when creating a profile from an existing one
+- If `modelTiers` is missing or empty, system auto-assigns from available
+  models using a built-in capability ranking
+- Existing `defaultModel`/`defaultProvider` fields remain functional but
+  become secondary to the tier system. They serve as the fallback when
+  `modelTiers` is absent (migration path).
+
+### Profile cloning
+
+When creating a profile with "copy credentials from existing profile":
+
+- Clone `auth.json` (existing behavior)
+- Clone `modelTiers` from source profile's `settings.json` (new)
+- Update UI copy to say "credentials and model preferences"
+
+## Onboarding Flow
+
+Updated sequence (4 steps):
+
+1. **Create profile** — existing ProfileSetup, clone message updated to mention
+   model preferences
+2. **Sign into provider(s)** — existing AuthLoginDialog, with new Anthropic
+   warning banner
+3. **Pick tier defaults** (NEW) — three model selects (LOW/MED/HIGH), populated
+   from available models only. Features:
+   - "Use same model for all tiers" toggle
+   - Skip button → auto-assigns sensible defaults from available models
+   - Only models from authenticated providers appear
+4. **Memory setup** — existing agent-driven memory bootstrap
+
+### Tier picker UI
+
+- Three labeled sections: LOW ("Fast, cheap tasks"), MED ("Everyday agents"),
+  HIGH ("Complex reasoning")
+- Each has a dropdown/select of available models grouped by provider
+- Toggle at top: "Use the same model for all tiers" — shows single select,
+  populates all three
+- "Skip" button at bottom — auto-assigns using built-in quality ranking
+- "Continue" button — saves selections to `modelTiers` in settings.json
+
+## Anthropic Warning
+
+Inline warning banner in `AuthLoginDialog` when user selects Anthropic as their
+provider, shown before auth proceeds:
+
+> ⚠️ Anthropic may restrict third-party use of consumer subscriptions. We
+> recommend using an API key with your own billing account.
+
+- Appears inline in the provider list / auth form area
+- Dismissible — user clicks through to continue auth
+- Shown once per auth attempt (not persisted)
+- Non-blocking — does not prevent auth from proceeding
+
+## Model Resolver Changes
+
+### `resolve.ts` — HARDCODED_DEFAULTS
+
+Replace:
+```ts
+model: 'claude-sonnet-4-6'
+```
+
+With tier-aware resolution:
+```ts
+model: { prefer: 'MED', fallbacks: ['gpt-5.4', 'claude-sonnet-4-6', 'gemini-2.5-pro'] }
+```
+
+The `resolveConfig()` function must handle the new structured `model` field:
+
+1. Parse `model` — if string, treat as specific model ID (legacy). If object,
+   use `prefer` + `fallbacks`.
+2. Resolve `prefer`:
+   - If tier alias → read `modelTiers[tier]` from settings
+   - If model ID → use directly
+3. Check availability via model registry
+4. If unavailable → iterate `fallbacks`
+5. If all fail → return a sentinel indicating "needs user pick"
+
+### `shared-infra.ts` — ensureInfra()
+
+Remove:
+```ts
+_model = getModel('anthropic', 'claude-opus-4-6');
+```
+
+Replace with tier-aware initialization:
+1. Read `modelTiers.HIGH` from settings
+2. If set and available → use it
+3. If not → walk fallback chain
+4. If nothing available → defer model assignment (don't crash at boot)
+
+The app must be able to start without any authenticated provider. Model
+resolution happens lazily when a session is created, not eagerly at boot.
+
+### `adhoc-agent.ts` — FAST_MODEL_PREFERENCES
+
+Replace Claude-first ordering with tier-aware resolution:
+1. Try user's `LOW` tier model
+2. Fall back to provider-neutral list ordered by cost/speed
+
+### `model-fallback-chain.ts` — default chain
+
+Reorder to be provider-neutral:
+```ts
+[
+  'gpt-5.4',
+  'gpt-4.1-mini',
+  'claude-sonnet-4-6',
+  'claude-haiku-4-5',
+  'gemini-2.5-pro',
+  'gemini-2.5-flash',
+  'gemini-3-flash',
+]
+```
+
+### `agent-model-context.ts` — pickFallbackModel()
+
+Update to check tier settings before walking the fallback chain:
+1. Try user's tier model (based on context — LOW for fast tasks, MED default)
+2. Then existing fallback chain logic
+
+## Inline Model Picker (Resolution Failure)
+
+When no model can be resolved for an agent (tier not set, all fallbacks
+unavailable):
+
+- Show an inline UI prompt in the chat/agent area
+- Message: "No available model for [agent name]. Pick one from your available
+  models:"
+- Dropdown of all available models grouped by provider
+- Selection starts the agent immediately with the chosen model
+- Optionally: "Set as default for [TIER] tier" checkbox
+
+## Hardcoded Default Removal
+
+All hardcoded Claude references must be replaced:
+
+| File | Current | Replacement |
+|------|---------|-------------|
+| `electron/main.ts` bootstrap | `defaultProvider: 'anthropic'`, `defaultModel: 'claude-opus-4-6'` | Remove fixed provider/model; seed empty `modelTiers: {}` so the key exists. Populated during onboarding or auto-assigned on first session. |
+| `electron/shared/infra/shared-infra.ts` | `getModel('anthropic', 'claude-opus-4-6')` | Tier-aware lazy resolution via HIGH tier |
+| `electron/features/subagent/core/resolve.ts` | `HARDCODED_DEFAULTS.model = 'claude-sonnet-4-6'` | Structured model with `prefer: 'MED'` + multi-provider fallbacks |
+| `electron/features/agent/assistants/adhoc-agent.ts` | Claude-first `FAST_MODEL_PREFERENCES` | LOW tier resolution + provider-neutral fallback |
+| `electron/shared/settings/model-fallback-chain.ts` | Claude-first default chain | Provider-neutral ordering |
+| `packages/templates/agents/*.md` (13 files) | `"model": "claude-sonnet-4-6"` or `"claude-haiku-4-5"` | Structured `{ prefer, fallbacks }` per tier mapping above |
+
+## Non-Goals
+
+- Removing Anthropic as a provider — it remains fully functional
+- Changing the model selector UI in the main app (already provider-neutral)
+- Migrating existing user settings automatically (graceful fallback handles
+  this — old `defaultModel` still works)
+- Per-workspace or per-session tier overrides (future enhancement)

--- a/docs/superpowers/specs/2026-04-04-dynamic-model-provider-progress.md
+++ b/docs/superpowers/specs/2026-04-04-dynamic-model-provider-progress.md
@@ -1,0 +1,94 @@
+# Dynamic Model Provider — Progress Status
+
+**Branch:** `feat/dynamic-model-selection`
+**Date:** 2026-04-04
+
+## Completed Tasks (all 17 from the plan)
+
+All implementation tasks from `docs/superpowers/plans/2026-04-04-dynamic-model-provider.md`
+are complete and passing typecheck:
+
+1. Model tier types and settings helpers (`model-tiers.ts`, `ipc.ts`)
+2. Tier-aware model resolver (`resolve-tier-model.ts`)
+3. Agent frontmatter parsing for structured model fields
+4. `resolve.ts` updated for structured model fields + tier aliases
+5. Subagent runner tier resolution
+6. Model fallback chain reordered (provider-neutral)
+7. Hardcoded Claude defaults removed from `main.ts` + `shared-infra.ts`
+8. Adhoc-agent uses LOW tier + provider-neutral ordering
+9. `pickFallbackModel` checks HIGH tier before fallback chain
+10. Model tier IPC handlers + profile clone support
+11. Anthropic warning banner in auth dialog
+12. TierPicker onboarding component (popover-based, searchable)
+13. TierPicker integrated into OnboardingWizard
+14. ProfileForm clone label updated
+15. All 13 agent templates updated to structured model fields
+16. Final typecheck + verification (all passing)
+17. `models.list` IPC bridge verified
+
+## Bug Fixes Applied During Testing
+
+These were discovered during manual testing of the onboarding flow:
+
+- **Trackpad scrolling in TierPicker** — `onWheel` stopPropagation on
+  PopoverContent to prevent Dialog overlay from intercepting scroll events
+- **Auth reload in getProviders** — `authStorage.reload()` added before
+  checking provider credentials (pre-existing bug)
+- **Fallback retry on auth failure** — OnboardingWizard now tries switching
+  to a model from a different provider when one fails, instead of
+  immediately showing the sign-in screen
+- **Error handling in fallback path** — wrapped fallback retry logic in
+  try/catch to prevent unhandled errors leaving wizard stuck
+- **getModelState resilience** — `ensureSessionHasAvailableModel` errors
+  caught so the model list still returns even when model switch fails
+- **Tier model application** — `applyTierModel` added to switch session to
+  user's chosen tier model after opening, with cross-provider fallback
+- **Unused export cleanup** — removed dead `hasModelTiers` function
+
+## Known Issues / Follow-Up Work
+
+### Critical: Onboarding auth resilience
+
+The onboarding flow with cloned credentials is fragile when OAuth tokens are
+expired. See `docs/superpowers/specs/2026-04-04-onboarding-resilience-analysis.md`
+for full analysis and proposed solution.
+
+Key problems:
+- Expired OAuth tokens make models appear available but they can't be used
+- Silent failures when selecting models with broken auth
+- No user feedback about which provider failed
+- Profile clone doesn't validate tokens before copying
+
+### Deferred: Inline model picker on resolution failure
+
+The spec describes an inline model picker UI in the chat area when no model
+can be resolved for a subagent. Currently the system falls back to the first
+available model. The inline picker was deferred as a follow-up.
+
+## Commit History
+
+```
+b416833 fix: robust tier model application with cross-provider fallback
+a4d1bf4 fix: apply user's tier model to onboarding memory session
+85c9e66 fix: catch model switch errors in getModelState handler
+9b7fb10 fix: prevent unhandled errors in onboarding fallback retry path
+6eacc35 fix: retry with fallback provider when onboarding auth fails
+0a17750 fix: reload auth storage before checking providers in getProviders
+ac2622f fix: enable trackpad scrolling in TierPicker model popover
+b9bcae5 fix: replace flat model list with popover picker in TierPicker
+19dd3aa chore: remove unused hasModelTiers export
+bdbf509 feat: integrate TierPicker into onboarding wizard between auth and memory
+da4abc8 feat: create TierPicker onboarding component for model tier selection
+15e0dfa feat: add Anthropic consumer subscription warning in auth dialog
+6cedb78 feat: update all agent templates to use structured model fields with tier aliases
+38d7141 feat: update profile clone label to mention model preferences
+4499e94 feat: add model tier IPC handlers and profile clone support
+9bdc98c feat: check HIGH tier model in pickFallbackModel before walking chain
+bb69070 feat: remove hardcoded Claude defaults and add tier-aware model selection
+86bb030 feat: resolve tier aliases in subagent runner model selection
+8f67541 feat: reorder model fallback chain to be provider-neutral
+356a415 feat: support structured model fields in agent config and resolution
+c857533 feat: add model tier types and tier-aware model resolver
+4e57279 docs: add dynamic model provider implementation plan
+df3a031 docs: add dynamic model provider system design spec
+```

--- a/docs/superpowers/specs/2026-04-04-onboarding-resilience-analysis.md
+++ b/docs/superpowers/specs/2026-04-04-onboarding-resilience-analysis.md
@@ -1,0 +1,106 @@
+# Onboarding Auth Resilience — Problem Analysis
+
+## Problem
+
+When creating a new profile with cloned credentials, the onboarding flow is
+fragile around expired/stale OAuth tokens. The system treats models as
+"available" based on having an auth entry, but doesn't verify the token
+actually works. This leads to:
+
+1. **Silent failures**: `setModel` throws because the provider's token is
+   expired, but errors are caught and swallowed. The user sees "nothing
+   happened" or a wrong model selected.
+
+2. **Misleading model list**: The tier picker and model selector show models
+   from providers with expired tokens. Users select these models, the
+   selection silently fails, and the system falls back to an arbitrary model.
+
+3. **Cascading failures during onboarding**: The memory bootstrap prompt uses
+   whatever model `ensureInfra` picked (not the user's tier choice), fails
+   with an auth error, triggers the fallback retry path, and eventually
+   either shows the auth screen or silently gives up.
+
+4. **No feedback loop**: When a provider's auth is broken, the user is never
+   told which provider failed or offered the chance to re-authenticate just
+   that provider.
+
+## Root Causes
+
+- **`ModelRegistry.getAvailable()`** checks for the presence of an auth
+  entry, not whether the token is valid. An expired OAuth token still makes
+  all models from that provider appear "available."
+
+- **Profile cloning copies auth.json verbatim** — OAuth tokens may already be
+  expired at copy time, or may expire before the user creates their first
+  session.
+
+- **`setModel` errors are swallowed** in the onboarding wizard's
+  `applyTierModel` and in the agent store's `setModel` action. The UI shows
+  no error toast or dialog.
+
+- **No auth validation at session start** — the first API call discovers the
+  broken token, but by then the session is already open with the wrong model.
+
+## Ideal Solution
+
+### 1. Auth validation on profile clone
+
+When cloning credentials to a new profile, validate each provider's token
+before copying. Mark stale tokens and present the user with a choice:
+
+- "These providers have expired credentials: [Anthropic, OpenAI Codex].
+  Would you like to re-authenticate now, or skip them?"
+
+This prevents broken tokens from entering the new profile silently.
+
+### 2. Provider health check in the tier picker
+
+Before showing the tier picker, run a lightweight auth probe per provider
+(e.g. a minimal model list API call). Filter out providers with broken auth
+and show a warning:
+
+- "Some providers couldn't be reached (expired tokens). Models from these
+  providers are hidden. You can re-authenticate in settings."
+
+### 3. Graceful model switch with user feedback
+
+When `setModel` fails during onboarding:
+
+- Show an inline error: "Couldn't use [GPT-5.4 Mini] — [provider] auth may
+  have expired."
+- Offer: "Try a different model" (reopen tier picker) or "Re-authenticate
+  [provider]" (open auth dialog for that specific provider).
+
+Don't silently fall back to an arbitrary model — that's confusing.
+
+### 4. Auth error detection in the model selector
+
+When clicking a model in the ModelSelector fails, show a toast:
+
+- "Couldn't switch to [model name] — [provider] authentication failed.
+  Re-authenticate via Settings > Providers."
+
+Currently the click does nothing with no feedback.
+
+### 5. Stale token detection at session start
+
+Before sending the first prompt in a new session, validate the current
+model's auth. If it fails, immediately try switching to another model AND
+inform the user which provider failed. This is similar to what the Google
+plugin's `stale token detection` does (PR #120).
+
+## Scope
+
+- Items 1-3 are onboarding-specific and should be part of the tier system work
+- Items 4-5 are general resilience improvements that benefit all users, not
+  just onboarding — these could be separate follow-up work
+
+## Files Involved
+
+- `apps/desktop/src/components/profiles/OnboardingWizard.tsx` — onboarding flow
+- `apps/desktop/src/components/profiles/TierPicker.tsx` — model selection
+- `apps/desktop/src/components/layout/ModelSelector.tsx` — main model selector
+- `apps/desktop/electron/ipc/agent/core/agent-model-context.ts` — setModel handler
+- `apps/desktop/electron/ipc/platform/auth/auth.ts` — getProviders handler
+- `apps/desktop/electron/ipc/workspace/profiles.ts` — profile clone handler
+- `apps/desktop/electron/shared/infra/shared-infra.ts` — pickFirstAvailableModel

--- a/docs/superpowers/specs/2026-04-04-onboarding-simplification-implementation-spec.md
+++ b/docs/superpowers/specs/2026-04-04-onboarding-simplification-implementation-spec.md
@@ -1,0 +1,723 @@
+# Onboarding Simplification & Resilience Specification
+
+## Overview
+
+- **Problem**: Sero onboarding is currently too form-like, too eager to expose model/tier complexity, and too fragile around cloned or expired provider auth. Users can reach a broken state after apparently valid onboarding steps, while healthy setups still require too many explicit decisions.
+- **Solution**: Replace the current auth-first / tier-first onboarding flow with a preflight-driven, recommendation-first onboarding system. Sero should compute the best available setup up front, show a one-click confirmation in the common case, preserve valid existing choices, surface broken providers clearly, and allow advanced customization without making it mandatory.
+- **Success Criteria**:
+  - onboarding defaults to a **one-click confirm** path in healthy/common cases
+  - valid saved/imported profile choices are preserved where possible
+  - broken imported providers are surfaced as warnings, not silent failures
+  - onboarding is blocked only until at least one usable model path exists
+  - tier customization remains available, but becomes an advanced path
+  - provider defaults are configurable via app state and editable through the Admin plugin or `sero cli`
+- **Key Stakeholders**:
+  - first-time Sero users
+  - existing users creating new profiles
+  - users cloning profiles with stale auth
+  - maintainers of onboarding/auth/model settings flows
+  - Admin plugin maintainers
+
+---
+
+## Interview-Derived Product Decisions
+
+These decisions are treated as authoritative for this spec:
+
+1. **Common-case UX target**: one-click confirm, with override available.
+2. **Recommendation policy**: preserve valid existing choices first.
+3. **Broken imported providers**: continue with warning if at least one healthy provider remains.
+4. **Validation strategy**: fast best-effort, not strict blocking verification.
+5. **Onboarding customization scope**: tier selections only.
+6. **Provider default configurability**: editable in-app via Admin plugin, persisted in app state; `sero cli` may also edit them.
+7. **Fresh profile behavior**: after first working auth, return to the same recommended confirmation step.
+8. **Cross-provider recommendation**:
+   - prefer the user’s existing/default provider first
+   - otherwise prefer a cohesive single-provider recommendation
+9. **Broken provider visibility**: compact inline warning on the confirm screen.
+10. **Onboarding gate**: do not allow bypass into the app until at least one usable model path exists.
+11. **Global vs profile state**:
+   - provider defaults: app-level/shared source of truth, with optional per-profile overrides
+   - tier selections: per-profile
+12. **Cloned credential validation timing**: first-launch onboarding preflight.
+13. **Rollout**: single cohesive feature rollout, not phased behind a feature flag.
+
+---
+
+## Detailed Requirements
+
+### Functional Requirements
+
+1. Sero must run an **onboarding preflight** before rendering onboarding UI.
+2. The preflight must compute whether the active profile has at least one usable model path.
+3. The preflight must classify provider/model sources into actionable states, including:
+   - healthy
+   - broken/expired
+   - env-backed
+   - local
+   - missing
+   - unknown
+4. The preflight must validate existing per-profile tier selections against current usable models.
+5. If an existing tier selection is still valid, it must be preserved.
+6. If an existing tier selection is invalid, Sero must repair or replace it with a recommendation.
+7. Sero must compute recommended LOW/MED/HIGH tiers from:
+   1. valid existing profile selections
+   2. valid imported selections
+   3. provider defaults
+   4. capability-ranked healthy model fallback
+8. In the common case where a usable setup exists, onboarding must show a **ready/confirm** screen rather than sending users directly to a blank tier editor.
+9. The ready screen must show:
+   - recommended LOW/MED/HIGH models
+   - a short provider health summary
+   - Continue action
+   - Customize models action
+   - Add/reconnect provider action
+10. The ready screen must show broken providers as a compact inline warning when healthy usable models still exist.
+11. The advanced customization path must allow editing LOW/MED/HIGH tier selections only.
+12. The advanced customization path must prefill the currently recommended or preserved tier selections.
+13. The onboarding tier editor must hide or disable broken providers rather than treating them as normal healthy choices.
+14. For a brand-new profile with no auth and no env/local models, onboarding must require the user to connect at least one provider before continuing.
+15. After the first successful auth in a fresh profile, onboarding must return to the same recommended confirm screen rather than launching directly into the memory session.
+16. For cloned profiles, copied `auth.json` and `modelTiers` may still be imported, but their real validity must be checked during preflight.
+17. If cloned providers are broken but healthy alternatives exist, onboarding must continue with warning and allow targeted reconnect actions.
+18. If no usable models exist after preflight, onboarding must move to an auth/reconnect state.
+19. Once a valid setup is confirmed, onboarding must save tier selections to the current profile before launching the welcome session.
+20. Provider default recommendations must be stored in app state and be editable outside onboarding via Admin plugin or `sero cli`.
+21. Provider defaults must support optional per-profile override capability, but the default source of truth must be global/shared.
+22. If the recommended provider fails between preflight and welcome-session launch, Sero should auto-switch to the next healthy recommendation if one exists and inform the user inline; if no suitable fallback exists, return to actionable onboarding UI.
+23. Onboarding must remain a gate until there is at least one usable model path.
+
+### Non-Functional Requirements
+
+1. Preflight must feel fast and not hold the UI hostage on slow/uncertain providers.
+2. Broken provider detection must be best-effort, not excessively blocking.
+3. The common path should minimize clicks and cognitive load.
+4. Renderer components touched by this work must stay under the 500 LOC project rule.
+5. IPC additions must follow the four-layer data-flow convention:
+   - React component
+   - Zustand / renderer state
+   - preload bridge
+   - Electron IPC handler / feature module
+6. Avoid unnecessary `useEffect`; prefer centralized state/actions for onboarding state orchestration where possible.
+7. Recommendations must be deterministic given the same inputs.
+8. Auth/provider failures must be surfaced with user-friendly provider-specific messaging.
+9. Existing settings/profile data must remain backward compatible.
+
+---
+
+## Technical Design
+
+### Architecture
+
+Introduce a dedicated onboarding feature layer in Electron that becomes the single source of truth for onboarding decisions.
+
+#### High-level flow
+
+1. Renderer mounts onboarding shell.
+2. Renderer requests `window.sero.onboarding.getState()`.
+3. Electron onboarding service performs preflight:
+   - reads active profile tiers
+   - reads global provider defaults
+   - inspects providers/model sources
+   - performs fast health assessment
+   - computes validated recommendations
+4. Renderer renders one of the exact onboarding states.
+5. User either:
+   - confirms setup
+   - customizes tiers
+   - reconnects/adds provider
+6. Renderer saves onboarding decisions via onboarding IPC.
+7. Renderer launches welcome session using saved validated tiers.
+
+#### New internal modules
+
+Suggested new files/folders:
+
+- `apps/desktop/electron/features/onboarding/`
+  - `index.ts`
+  - `types.ts`
+  - `preflight.ts`
+  - `provider-health.ts`
+  - `recommendations.ts`
+  - `state.ts` (optional composition helper)
+- `apps/desktop/electron/shared/settings/provider-model-defaults.ts`
+- `apps/desktop/electron/ipc/onboarding/`
+  - `onboarding.ts`
+- `apps/desktop/electron/preload/onboarding.ts`
+
+### Exact Onboarding States
+
+Renderer-visible onboarding state machine:
+
+```ts
+type OnboardingPhase =
+  | 'checking'
+  | 'ready'
+  | 'customize'
+  | 'auth'
+  | 'launching'
+  | 'error'
+  | 'done';
+```
+
+#### State meanings
+
+- `checking`: preflight in progress
+- `ready`: valid recommended setup exists; primary one-click screen
+- `customize`: advanced tier editor
+- `auth`: no usable model path, or user explicitly chose reconnect/add provider
+- `launching`: saving selections + opening welcome session
+- `error`: unexpected onboarding failure that needs retry/recovery
+- `done`: onboarding complete or not needed
+
+### Recommendation Rules
+
+#### Inputs
+
+- active profile’s `modelTiers`
+- active profile’s optional provider-default overrides
+- global provider defaults
+- auth/provider states
+- available model groups
+- existing provider preference, if inferable
+
+#### Provider preference rules
+
+1. If the user already has a clear valid provider preference, prefer that provider.
+2. Otherwise prefer a cohesive single-provider recommendation.
+3. Only mix providers if necessary to fill missing tiers or preserve valid explicit user choices.
+
+#### Tier recommendation rules
+
+For each tier, resolve in this order:
+
+1. valid current profile tier
+2. valid imported tier
+3. valid profile-level provider-default override for preferred provider
+4. valid global provider default for preferred provider
+5. capability-ranked healthy fallback within preferred provider
+6. capability-ranked healthy fallback across all providers
+
+### Provider Default Registry
+
+Add a provider-default settings module.
+
+Suggested types:
+
+```ts
+export type ProviderTierDefaults = Partial<Record<'LOW' | 'MED' | 'HIGH', string>>;
+
+export type ProviderModelDefaults = Record<string, ProviderTierDefaults>;
+
+export interface ResolvedProviderDefaultsState {
+  globalDefaults: ProviderModelDefaults;
+  profileOverrides?: ProviderModelDefaults;
+  effectiveDefaults: ProviderModelDefaults;
+}
+```
+
+#### Storage model
+
+- global/shared defaults in app state
+- optional per-profile overrides in profile settings/state
+- onboarding tier choices remain per-profile in `settings.json` under `sero.modelTiers`
+
+### Provider Health Model
+
+Suggested provider health types:
+
+```ts
+export type ProviderHealthStatus =
+  | 'healthy'
+  | 'broken_expired'
+  | 'broken_invalid'
+  | 'env'
+  | 'local'
+  | 'missing'
+  | 'unknown';
+
+export interface ProviderHealthInfo {
+  providerId: string;
+  displayName: string;
+  status: ProviderHealthStatus;
+  message?: string;
+  canReconnect: boolean;
+  hasUsableModels: boolean;
+  usableModelIds: string[];
+}
+```
+
+#### Health-check strategy
+
+- fast best-effort
+- do not block entire onboarding on slow providers
+- imported or suspicious providers may get a deeper targeted check
+- unknown providers should not be treated as confidently healthy defaults unless model availability is otherwise clear
+
+### Onboarding State Shape
+
+Suggested IPC-returned shape:
+
+```ts
+export interface OnboardingRecommendation {
+  tiers: Partial<Record<'LOW' | 'MED' | 'HIGH', { provider: string; modelId: string }>>;
+  source: 'existing' | 'imported' | 'provider-defaults' | 'fallback';
+  preferredProvider?: string;
+}
+
+export interface OnboardingWarning {
+  code:
+    | 'broken_imported_providers'
+    | 'invalid_existing_tiers'
+    | 'no_usable_models'
+    | 'provider_recommendation_changed';
+  message: string;
+  providerIds?: string[];
+}
+
+export interface OnboardingState {
+  needed: boolean;
+  phase: 'ready' | 'auth' | 'error' | 'done';
+  hasAnyUsableModels: boolean;
+  hasImportedCredentials: boolean;
+  recommendation: OnboardingRecommendation | null;
+  providerHealth: ProviderHealthInfo[];
+  availableModelGroups: AvailableModelGroup[];
+  warnings: OnboardingWarning[];
+  preservedTiers: ModelTierSettings;
+  invalidTiers: Array<'LOW' | 'MED' | 'HIGH'>;
+}
+```
+
+### IPC Design
+
+#### New renderer API
+
+```ts
+interface SeroOnboardingAPI {
+  getState(): Promise<OnboardingState>;
+  saveTierSelections(tiers: ModelTierSettings): Promise<void>;
+  saveProviderDefaults(defaults: ProviderModelDefaults): Promise<void>;
+  reconnectProvider(providerId: string): Promise<void>; // may forward into auth flow helper
+  dismissWarning?(code: string): Promise<void>; // optional, only if needed
+}
+```
+
+#### IPC channels
+
+Suggested additions:
+
+```ts
+onboarding: {
+  getState: 'sero:onboarding:get-state',
+  saveTierSelections: 'sero:onboarding:save-tier-selections',
+  getProviderDefaults: 'sero:onboarding:get-provider-defaults',
+  saveProviderDefaults: 'sero:onboarding:save-provider-defaults',
+  reconnectProvider: 'sero:onboarding:reconnect-provider',
+}
+```
+
+### APIs & Integrations
+
+The onboarding feature will compose existing APIs rather than replacing them:
+
+- `profiles.needsOnboarding()`
+- `auth.getProviders()`
+- `models.list()`
+- `modelTiers.get()` / `modelTiers.set()`
+- auth login flow via `auth.login()` / OAuth event stream
+
+But the renderer should stop orchestrating these directly for onboarding logic. That logic should move into the onboarding feature/IPC.
+
+### Scalability Considerations
+
+This is not traffic-scale sensitive, but operational complexity can grow as providers and local model sources expand.
+
+To keep the design maintainable:
+
+- centralize recommendation logic in a single module
+- centralize provider health logic in a single module
+- separate provider defaults from profile tiers
+- avoid UI components each re-implementing model filtering/health logic
+
+### Security Design
+
+- do not surface sensitive tokens or raw auth data to the renderer
+- only expose provider health/results metadata
+- continue using `auth.json` permission hardening
+- provider health results should be descriptive, not secret-bearing
+
+---
+
+## User Experience
+
+### User Personas
+
+#### 1. First-time user
+Wants to get to a working AI session quickly, does not want to understand provider/model architecture.
+
+#### 2. Existing user creating a new profile
+Expects cloned credentials and preferences to “just work” or fail clearly.
+
+#### 3. Power user
+Wants control over tiers and provider defaults, but does not want onboarding to force unnecessary work every time.
+
+### Primary User Flows
+
+#### Flow A — Healthy existing/cloned setup
+1. User opens new profile.
+2. Preflight runs.
+3. Existing tiers are validated and preserved.
+4. Ready screen shows recommended/preserved setup.
+5. User clicks Continue.
+6. Welcome memory session launches.
+
+#### Flow B — Fresh profile, no auth
+1. User opens new profile.
+2. Preflight finds no usable models.
+3. Auth screen appears.
+4. User connects one provider.
+5. Preflight reruns / onboarding state refreshes.
+6. Ready screen appears with recommended defaults.
+7. User clicks Continue.
+8. Welcome session launches.
+
+#### Flow C — Cloned profile with stale imported auth
+1. User opens cloned profile.
+2. Preflight finds some imported providers broken.
+3. Healthy provider still exists.
+4. Ready screen appears with healthy recommendation.
+5. Compact inline warning shows broken providers and reconnect CTA.
+6. User either continues or reconnects a provider.
+
+#### Flow D — User customizes tiers
+1. From ready screen, user clicks Customize models.
+2. Tier editor opens with prefilled LOW/MED/HIGH.
+3. User changes one or more tiers.
+4. User saves.
+5. Returns to ready/launch flow or launches directly depending on final UX implementation.
+
+### UI States
+
+#### Ready screen
+Must include:
+- headline indicating Sero is ready / almost ready
+- concise recommendation summary for LOW/MED/HIGH
+- compact inline warning for broken providers if applicable
+- primary CTA: Continue
+- secondary CTA: Customize models
+- tertiary CTA: Add/reconnect provider
+
+#### Customize screen
+Must include:
+- prefilled tier choices
+- same-model-for-all toggle retained if useful
+- healthy models shown normally
+- broken provider models hidden or visibly disabled
+- Save / Back controls
+
+#### Auth screen
+Must include:
+- connect provider actions
+- reconnect action for broken providers
+- clear messaging when there are no usable models yet
+
+#### Launching screen
+Must include:
+- simple progress indication
+- no complex choices
+
+#### Error screen
+Must include:
+- readable explanation
+- retry action
+- path back to auth/customize if relevant
+
+### Edge Cases
+
+1. Existing tiers valid but provider defaults changed globally
+   - preserve valid tiers; do not overwrite explicit working profile choices
+2. Imported tiers reference unavailable models but same provider has healthy defaults
+   - replace invalid tiers with recommended alternatives from that provider first
+3. Provider passes preflight but fails at launch
+   - auto-switch to next healthy recommendation if possible and inform user inline
+4. Env-backed models exist with no saved auth
+   - treat as usable path; allow ready screen
+5. Local models exist with no remote provider
+   - treat as usable path if surfaced by model listing
+6. No usable provider but some broken imported creds
+   - auth/reconnect screen with targeted repair actions
+7. User customizes tiers to a provider that later fails
+   - preserve choice if still valid; otherwise explain and repair on next onboarding/preflight
+
+---
+
+## Risks & Mitigations
+
+### Risk Register
+
+| Risk | Category | Impact | Probability | Mitigation | Owner |
+|------|----------|--------|-------------|------------|-------|
+| Provider health checks are too slow and delay onboarding | Technical | Medium | Medium | Use fast best-effort checks, cache results briefly, do not block on uncertain providers | Electron onboarding feature |
+| Recommendation logic becomes scattered across renderer and Electron | Technical | High | Medium | Create a dedicated onboarding service and IPC surface as the source of truth | Desktop maintainers |
+| Broken providers still leak into recommended tiers | Technical | High | Medium | Centralize provider health filtering before recommendation generation | Electron onboarding feature |
+| Users feel forced into hidden automation and don’t trust defaults | UX | Medium | Medium | Always show recommended setup summary before launch; offer Customize models | Product / renderer |
+| Admin/defaults editing scope balloons | Timeline | Medium | Medium | Keep onboarding customization tier-only; provider-default editing lives in Admin plugin/CLI | Product / admin plugin |
+| Cloned auth problems are still discovered during prompt execution | Technical | High | Medium | Run onboarding preflight on first launch and validate imported providers there | Electron onboarding feature |
+| Inconsistent behavior between onboarding and main model selector | Operational | Medium | High | Call out general resilience follow-up explicitly as later phase | Desktop maintainers |
+
+### Accepted Tradeoffs
+
+- Preflight health validation is best-effort, not a strict authoritative full provider audit.
+- Onboarding will optimize for the common-case path rather than exposing all model controls immediately.
+- Provider defaults editing is in app state and edited via Admin plugin/CLI, not the onboarding UI itself.
+
+### Contingency Plans
+
+- If provider health probing proves too flaky, downgrade some checks to `unknown` and only exclude providers from recommendations when failure is more certain.
+- If cross-provider recommendation logic becomes too complex for MVP, constrain the recommendation engine to a preferred-provider-first cohesive strategy and defer mixed-provider optimization.
+
+---
+
+## Implementation Notes
+
+### Key Decisions
+
+1. **Recommendation-first onboarding** replaces empty-form onboarding.
+2. **Tier editor becomes advanced customization**, not the default path.
+3. **Provider defaults are global/shared app state**, with optional per-profile overrides.
+4. **Per-profile tiers remain in profile settings**.
+5. **Validation happens in onboarding preflight**, not primarily at clone time.
+6. **Single cohesive rollout** is preferred over a feature flag rollout.
+
+### Dependencies
+
+- existing auth IPC and OAuth flow
+- existing model listing IPC
+- existing model tier persistence
+- Admin plugin extension point/settings editor
+- optional CLI command surface for provider default editing
+
+### Migration Plan
+
+1. Add provider-default state model with built-in defaults.
+2. Add onboarding preflight feature and IPC.
+3. Refactor onboarding renderer to consume onboarding state instead of composing auth/models/tier calls directly.
+4. Convert tier picker into advanced editor with prefilled selections.
+5. Add Admin plugin editing surface for provider defaults.
+6. Preserve existing `modelTiers` and auth clone behavior while validating them in preflight.
+
+---
+
+## File-by-File Task Breakdown
+
+### New / Major New Modules
+
+#### `apps/desktop/electron/features/onboarding/types.ts`
+Create canonical Electron-side onboarding types:
+- `OnboardingState`
+- `OnboardingRecommendation`
+- `ProviderHealthInfo`
+- warning codes
+- provider-default state types or import shared types from `src/types/ipc`
+
+#### `apps/desktop/electron/features/onboarding/provider-health.ts`
+Implement fast best-effort provider assessment.
+Responsibilities:
+- infer provider health from auth state + available models
+- optionally perform lightweight probe logic
+- classify providers into actionable states
+- normalize provider-specific messages
+
+#### `apps/desktop/electron/features/onboarding/recommendations.ts`
+Implement recommendation engine.
+Responsibilities:
+- preserve valid tiers
+- determine preferred provider
+- apply provider defaults
+- repair invalid tiers
+- produce deterministic recommendation metadata
+
+#### `apps/desktop/electron/features/onboarding/preflight.ts`
+Compose:
+- `profiles.needsOnboarding`
+- provider health
+- available model groups
+- current tiers
+- provider defaults
+- warnings
+- final `OnboardingState`
+
+#### `apps/desktop/electron/ipc/onboarding/onboarding.ts`
+Register onboarding IPC handlers.
+
+#### `apps/desktop/electron/preload/onboarding.ts`
+Expose `window.sero.onboarding.*`.
+
+#### `apps/desktop/electron/shared/settings/provider-model-defaults.ts`
+Add built-in provider defaults + settings merge/override helpers.
+
+### Existing Files to Update
+
+#### `apps/desktop/src/components/profiles/OnboardingWizard.tsx`
+Refactor from local orchestration to onboarding-state-driven rendering.
+Expected changes:
+- replace current `checking/auth/tiers/...` orchestration with `ready/customize/auth/...`
+- call `window.sero.onboarding.getState()`
+- render ready screen first when usable setup exists
+- move TierPicker behind Customize action
+- handle reconnect/add-provider flow
+- retain launching/error behavior
+
+#### `apps/desktop/src/components/profiles/TierPicker.tsx`
+Convert into advanced customization editor.
+Expected changes:
+- accept prefilled selections
+- optionally accept provider health/filter metadata
+- hide/disable broken providers
+- save only tier selections
+- remove assumption that onboarding starts empty
+
+#### `apps/desktop/src/components/layout/AuthLoginDialog.tsx`
+Possible updates:
+- support reconnecting a specific provider from onboarding
+- allow onboarding refresh callback after successful auth
+
+#### `apps/desktop/src/components/layout/AuthLoginViews.tsx`
+Possible updates:
+- surface provider state labels/messages more explicitly if auth screen is enriched for onboarding
+
+#### `apps/desktop/electron/ipc/platform/auth/auth.ts`
+Potential updates:
+- expose richer provider metadata if onboarding service needs it
+- or keep this file stable and let onboarding feature compose auth + model info internally
+
+#### `apps/desktop/electron/ipc/workspace/profiles.ts`
+Keep clone behavior, but ensure onboarding preflight has enough metadata to know auth/model prefs were imported if needed.
+Optional enhancement:
+- return whether credentials/model prefs were cloned during profile creation
+
+#### `apps/desktop/electron/ipc/agent/handlers/models.ts`
+Potential updates:
+- may need richer model-source metadata if onboarding needs to distinguish local/env/remote more explicitly
+
+#### `apps/desktop/src/types/ipc.ts`
+Add onboarding types.
+
+#### `apps/desktop/src/types/electron.d.ts`
+Add `window.sero.onboarding` API typing.
+
+#### `apps/desktop/src/types/ipc-channels.ts`
+Add onboarding channel constants.
+
+#### `apps/desktop/electron/preload/api.ts`
+Wire the onboarding preload bridge into `window.sero`.
+
+### Admin Plugin / CLI Work
+
+#### `plugins/sero-admin-plugin/...`
+Add provider-default editing UI.
+Scope:
+- read global provider defaults
+- edit LOW/MED/HIGH defaults per provider
+- optionally support per-profile overrides later or in a second sub-step
+
+#### CLI (`sero cli`) integration
+Add provider-default read/write commands if not already supported by the settings surface.
+
+---
+
+## Operationalization
+
+### Testing Strategy
+
+#### Unit tests
+- provider-default resolution
+- preferred-provider inference
+- tier repair logic
+- warning generation
+- provider health classification
+
+#### Integration tests
+- onboarding preflight with:
+  - no auth
+  - env-backed auth
+  - cloned valid tiers
+  - cloned stale providers
+  - mixed healthy/broken providers
+
+#### UI tests / renderer tests
+- ready screen rendering
+- customize path with prefilled tiers
+- broken-provider warning rendering
+- auth → ready transition
+- ready → launching transition
+
+### Deployment Plan
+
+Single cohesive rollout.
+
+Recommended implementation order inside the branch:
+1. types + onboarding feature backend
+2. preload + IPC bridge
+3. renderer onboarding refactor
+4. Admin plugin defaults editing
+5. tests + polish
+
+### Monitoring & Observability
+
+At minimum, log or track:
+- onboarding preflight outcome
+- provider health summary counts
+- whether recommendation source was existing/imported/default/fallback
+- number of broken imported providers encountered
+- whether welcome session launched successfully after onboarding
+
+This can initially be debug logging if full analytics are not in scope.
+
+---
+
+## Open Questions
+
+1. What is the exact persisted location/schema for global provider defaults in app state?
+2. Do per-profile provider-default overrides need to ship in the first iteration, or just be supported by the model?
+3. Should provider-health probing have a small cache window to avoid repeated checks during the same onboarding session?
+4. How should onboarding identify a user’s “existing/default provider” when there are multiple historical providers?
+5. Should the ready screen allow launching directly after saving custom tiers, or return to the confirmation summary first?
+
+---
+
+## Out of Scope
+
+1. Full redesign of the main app’s model selector outside onboarding.
+2. Full provider-health UX parity across all non-onboarding model flows.
+3. Rich onboarding editing of provider defaults.
+4. Clone-time blocking validation modal during profile creation.
+5. Feature-flagged dual onboarding systems.
+
+---
+
+## Phasing
+
+### Phase 1: MVP
+
+Deliver:
+- provider-default registry
+- onboarding preflight
+- ready screen with one-click confirm
+- advanced tier customization with prefilled choices
+- compact broken-provider warning
+- onboarding gate until usable model exists
+- preserved valid existing choices
+
+**MVP success criteria**:
+- healthy setup reaches ready screen immediately
+- fresh profile flows through auth → ready → continue
+- broken imported providers no longer fail silently
+
+### Phase 2: Follow-up Enhancements
+
+- stronger provider probing heuristics/caching
+- per-profile provider-default override UX
+- broader app-wide model/auth resilience alignment
+- richer Admin plugin editing and CLI parity

--- a/docs/superpowers/specs/2026-04-04-onboarding-simplification-implementation-spec.md
+++ b/docs/superpowers/specs/2026-04-04-onboarding-simplification-implementation-spec.md
@@ -147,10 +147,28 @@ Suggested new files/folders:
 
 ### Exact Onboarding States
 
-Renderer-visible onboarding state machine:
+Split backend onboarding outcome state from renderer-local UI state.
+
+#### Backend / IPC onboarding outcome
+
+Returned from `window.sero.onboarding.getState()`:
 
 ```ts
-type OnboardingPhase =
+type OnboardingStatePhase =
+  | 'ready'
+  | 'auth'
+  | 'error'
+  | 'done';
+```
+
+This is the authoritative Electron-derived onboarding result.
+
+#### Renderer-local UI state
+
+Managed inside the onboarding shell component:
+
+```ts
+type OnboardingUiPhase =
   | 'checking'
   | 'ready'
   | 'customize'
@@ -160,12 +178,15 @@ type OnboardingPhase =
   | 'done';
 ```
 
+The renderer derives `ready` / `auth` / `error` / `done` from `OnboardingState.phase`,
+and owns transient UI-only phases such as `checking`, `customize`, and `launching`.
+
 #### State meanings
 
-- `checking`: preflight in progress
+- `checking`: renderer is waiting for `getState()` to resolve
 - `ready`: valid recommended setup exists; primary one-click screen
 - `customize`: advanced tier editor
-- `auth`: no usable model path, or user explicitly chose reconnect/add provider
+- `auth`: no usable model path, or user explicitly chose add/reconnect provider
 - `launching`: saving selections + opening welcome session
 - `error`: unexpected onboarding failure that needs retry/recovery
 - `done`: onboarding complete or not needed
@@ -186,6 +207,17 @@ type OnboardingPhase =
 1. If the user already has a clear valid provider preference, prefer that provider.
 2. Otherwise prefer a cohesive single-provider recommendation.
 3. Only mix providers if necessary to fill missing tiers or preserve valid explicit user choices.
+
+#### Preferred-provider heuristic
+
+Determine the user’s "existing/default provider" in this order:
+
+1. If the currently valid saved tiers have a single provider owning the majority of populated tiers, prefer that provider.
+2. Else if a legacy `defaultProvider` exists and is healthy, prefer it.
+3. Else if imported valid tiers all point to the same provider, prefer that provider.
+4. Else there is no existing provider preference.
+
+If there is no existing provider preference, choose a cohesive single-provider setup based on the healthy provider with the best LOW/MED/HIGH coverage from provider defaults plus currently usable models.
 
 #### Tier recommendation rules
 
@@ -256,12 +288,25 @@ export interface ProviderHealthInfo {
 
 ### Onboarding State Shape
 
+Use existing shared types from `apps/desktop/src/types/ipc.ts` for:
+
+- `AvailableModelGroup`
+- `ModelTierSettings`
+
 Suggested IPC-returned shape:
 
 ```ts
+export type OnboardingTierSource =
+  | 'preserved'
+  | 'imported'
+  | 'provider-defaults'
+  | 'fallback';
+
 export interface OnboardingRecommendation {
-  tiers: Partial<Record<'LOW' | 'MED' | 'HIGH', { provider: string; modelId: string }>>;
-  source: 'existing' | 'imported' | 'provider-defaults' | 'fallback';
+  /** Final tiers the renderer displays on the Ready screen. */
+  tiers: ModelTierSettings;
+  /** Where each displayed tier came from. */
+  sourcesByTier: Partial<Record<'LOW' | 'MED' | 'HIGH', OnboardingTierSource>>;
   preferredProvider?: string;
 }
 
@@ -277,17 +322,18 @@ export interface OnboardingWarning {
 
 export interface OnboardingState {
   needed: boolean;
-  phase: 'ready' | 'auth' | 'error' | 'done';
+  phase: OnboardingStatePhase;
   hasAnyUsableModels: boolean;
   hasImportedCredentials: boolean;
   recommendation: OnboardingRecommendation | null;
   providerHealth: ProviderHealthInfo[];
   availableModelGroups: AvailableModelGroup[];
   warnings: OnboardingWarning[];
-  preservedTiers: ModelTierSettings;
   invalidTiers: Array<'LOW' | 'MED' | 'HIGH'>;
 }
 ```
+
+`recommendation.tiers` is the only tier payload the renderer should render on the Ready screen. In `phase: 'ready'`, it is expected to contain usable entries for LOW, MED, and HIGH. Preservation/import/default/fallback details are conveyed through `sourcesByTier`, not a separate `preservedTiers` field.
 
 ### IPC Design
 
@@ -297,8 +343,6 @@ export interface OnboardingState {
 interface SeroOnboardingAPI {
   getState(): Promise<OnboardingState>;
   saveTierSelections(tiers: ModelTierSettings): Promise<void>;
-  saveProviderDefaults(defaults: ProviderModelDefaults): Promise<void>;
-  reconnectProvider(providerId: string): Promise<void>; // may forward into auth flow helper
   dismissWarning?(code: string): Promise<void>; // optional, only if needed
 }
 ```
@@ -311,11 +355,30 @@ Suggested additions:
 onboarding: {
   getState: 'sero:onboarding:get-state',
   saveTierSelections: 'sero:onboarding:save-tier-selections',
-  getProviderDefaults: 'sero:onboarding:get-provider-defaults',
-  saveProviderDefaults: 'sero:onboarding:save-provider-defaults',
-  reconnectProvider: 'sero:onboarding:reconnect-provider',
 }
 ```
+
+Provider-default editing is intentionally **not** part of the onboarding API. It belongs to the Admin plugin / CLI / app-state settings surface.
+
+#### Refresh behavior
+
+`getState()` is both the initial load and the refresh entry point. The onboarding shell must re-call `getState()`:
+
+1. on mount
+2. after successful auth or API-key save in the auth dialog
+3. after saving customized tier selections
+4. after a launch-time provider failure that forces recommendation repair
+
+No separate polling API is required for MVP.
+
+#### Reconnect behavior
+
+Onboarding should not define a separate `reconnectProvider()` IPC method. Instead:
+
+1. the onboarding shell opens the existing `AuthLoginDialog`, optionally targeted at a specific provider
+2. auth happens inside that dialog while the onboarding shell remains mounted
+3. the dialog uses existing `window.sero.auth.*` APIs
+4. on auth success, the onboarding shell re-calls `window.sero.onboarding.getState()` and transitions to the updated state
 
 ### APIs & Integrations
 
@@ -376,8 +439,8 @@ Wants control over tiers and provider defaults, but does not want onboarding to 
 1. User opens new profile.
 2. Preflight finds no usable models.
 3. Auth screen appears.
-4. User connects one provider.
-5. Preflight reruns / onboarding state refreshes.
+4. User connects one provider in the existing auth dialog.
+5. On auth success, the onboarding shell re-calls `getState()`.
 6. Ready screen appears with recommended defaults.
 7. User clicks Continue.
 8. Welcome session launches.
@@ -388,14 +451,17 @@ Wants control over tiers and provider defaults, but does not want onboarding to 
 3. Healthy provider still exists.
 4. Ready screen appears with healthy recommendation.
 5. Compact inline warning shows broken providers and reconnect CTA.
-6. User either continues or reconnects a provider.
+6. If the user chooses reconnect, onboarding opens the existing auth dialog targeted at that provider.
+7. On auth success, the onboarding shell re-calls `getState()` and redraws the recommendation/warnings.
+8. User continues when satisfied.
 
 #### Flow D — User customizes tiers
 1. From ready screen, user clicks Customize models.
 2. Tier editor opens with prefilled LOW/MED/HIGH.
 3. User changes one or more tiers.
-4. User saves.
-5. Returns to ready/launch flow or launches directly depending on final UX implementation.
+4. User saves tier selections.
+5. The onboarding shell persists them, re-calls `getState()`, and returns to the Ready summary screen.
+6. The user explicitly clicks Continue to launch the welcome session.
 
 ### UI States
 
@@ -408,6 +474,8 @@ Must include:
 - secondary CTA: Customize models
 - tertiary CTA: Add/reconnect provider
 
+`Add/reconnect provider` opens the existing `AuthLoginDialog`. If invoked from a broken-provider warning, it should target that provider; otherwise it opens the generic provider list.
+
 #### Customize screen
 Must include:
 - prefilled tier choices
@@ -415,6 +483,7 @@ Must include:
 - healthy models shown normally
 - broken provider models hidden or visibly disabled
 - Save / Back controls
+- Save returns to the Ready summary screen; it does not launch directly
 
 #### Auth screen
 Must include:
@@ -489,6 +558,9 @@ Must include:
 4. **Per-profile tiers remain in profile settings**.
 5. **Validation happens in onboarding preflight**, not primarily at clone time.
 6. **Single cohesive rollout** is preferred over a feature flag rollout.
+7. **Backend onboarding state and renderer UI state are separate**.
+8. **Auth/reconnect reuses the existing auth dialog and APIs**, not a new onboarding-specific reconnect IPC.
+9. **Saving customized tiers always returns to the Ready summary screen**; only Continue launches the welcome session.
 
 ### Dependencies
 
@@ -562,11 +634,12 @@ Add built-in provider defaults + settings merge/override helpers.
 #### `apps/desktop/src/components/profiles/OnboardingWizard.tsx`
 Refactor from local orchestration to onboarding-state-driven rendering.
 Expected changes:
-- replace current `checking/auth/tiers/...` orchestration with `ready/customize/auth/...`
-- call `window.sero.onboarding.getState()`
+- manage renderer-local `OnboardingUiPhase`
+- call `window.sero.onboarding.getState()` on mount and refresh points
 - render ready screen first when usable setup exists
 - move TierPicker behind Customize action
-- handle reconnect/add-provider flow
+- open the existing `AuthLoginDialog` for add/reconnect flows
+- refresh onboarding state after auth success and after tier save
 - retain launching/error behavior
 
 #### `apps/desktop/src/components/profiles/TierPicker.tsx`
@@ -580,8 +653,9 @@ Expected changes:
 
 #### `apps/desktop/src/components/layout/AuthLoginDialog.tsx`
 Possible updates:
-- support reconnecting a specific provider from onboarding
-- allow onboarding refresh callback after successful auth
+- support opening the dialog pre-targeted to a specific provider from onboarding
+- allow onboarding refresh callback after successful auth / API-key save
+- keep the onboarding shell mounted while the dialog is open
 
 #### `apps/desktop/src/components/layout/AuthLoginViews.tsx`
 Possible updates:
@@ -682,8 +756,6 @@ This can initially be debug logging if full analytics are not in scope.
 1. What is the exact persisted location/schema for global provider defaults in app state?
 2. Do per-profile provider-default overrides need to ship in the first iteration, or just be supported by the model?
 3. Should provider-health probing have a small cache window to avoid repeated checks during the same onboarding session?
-4. How should onboarding identify a user’s “existing/default provider” when there are multiple historical providers?
-5. Should the ready screen allow launching directly after saving custom tiers, or return to the confirmation summary first?
 
 ---
 

--- a/docs/superpowers/specs/2026-04-05-onboarding-polish-design.md
+++ b/docs/superpowers/specs/2026-04-05-onboarding-polish-design.md
@@ -1,0 +1,104 @@
+# Onboarding Polish: Session Lifecycle, Low Thinking, UI Cleanup
+
+**Date:** 2026-04-05
+**Branch:** `feat/dynamic-model-selection`
+
+## Problem
+
+The current onboarding flow creates a single session that doubles as both the memory-setup runner and the user's first visible session. This means:
+
+1. The memory setup prompt uses the model's default thinking level, wasting tokens on reasoning that onboarding doesn't need.
+2. The user's first session contains the memory-setup conversation rather than a clean welcome.
+3. The setup screen UI has inconsistent spacing and select sizing compared to other dialogs.
+4. Several helpers are duplicated across files (from PR #121 review).
+
+## Design
+
+### 1. Dedicated Onboarding Session with Low Thinking
+
+**New lifecycle in `OnboardingWizard.launchWelcomeSession`:**
+
+```
+User clicks Continue
+  |
+  v
+Create temp session (unnamed)
+  |
+  v
+Open session -> apply chosen model -> set thinking to 'low'
+  |
+  v
+Prompt: memory setup message
+  |
+  v
+On success: close + delete temp session
+  |
+  v
+Create fresh session named "Welcome"
+  |
+  v
+Open -> apply HIGH tier model (normal thinking)
+  |
+  v
+Prompt: "The user just finished onboarding. Say hello,
+         introduce yourself briefly, and let them know
+         you're ready."
+  |
+  v
+Mark onboarding done, switch to Dashboard
+```
+
+**Key details:**
+
+- Temp session uses `window.sero.agent.setThinkingLevel(sessionId, 'low')` after opening.
+- Temp session cleanup: `window.sero.agent.close(sessionId)` then `window.sero.sessions.delete(sessionPath)`.
+- Fresh session uses the user's HIGH tier model (falling back to MED, then LOW) at the model's default thinking level.
+- The welcome prompt is short and instructs the agent to greet the user and confirm readiness.
+- Error handling: same auth-error detection and fallback-provider retry as today. If the temp session fails, recovery happens before creating the welcome session. If the welcome session prompt fails, the user still lands in a working session — just without the greeting.
+
+**Files changed:**
+
+- `src/components/profiles/OnboardingWizard.tsx` — rewrite `launchWelcomeSession` to two-session flow.
+
+### 2. UI Polish (SetupScreen)
+
+All changes in `src/components/profiles/onboarding/SetupScreen.tsx`:
+
+- Outer container: `space-y-4` -> `space-y-5` for more breathing room.
+- All `SelectTrigger` components: ensure consistent `h-10` height.
+- Tier toggle card: increase padding to `px-4 py-3`.
+- Tier model fields inside the toggle: increase top margin/padding for separation.
+- Consistent label sizing across simple and tiered modes.
+
+No layout restructuring — spacing and consistency only.
+
+### 3. Code Deduplication
+
+**3a. `modelKey` / `parseModelKey` -> `src/lib/model-keys.ts`**
+
+Extract the `modelKey(provider, modelId)` and `parseModelKey(value)` helpers into a shared renderer module. Remove duplicates from:
+- `src/components/profiles/onboarding/SetupScreen.tsx`
+- `src/components/profiles/TierPicker.tsx`
+
+**3b. `getSeroSettings` -> `electron/shared/settings/settings-helpers.ts`**
+
+Extract the `getSeroSettings(settingsPath)` helper. Remove duplicates from:
+- `electron/shared/settings/model-tiers.ts`
+- `electron/shared/settings/provider-model-defaults.ts`
+- `electron/shared/settings/model-fallback-chain.ts`
+
+**3c. `readSettings` -> same `settings-helpers.ts`**
+
+Extract the `readSettings(settingsPath)` helper. Remove duplicates from:
+- `electron/features/onboarding/preflight.ts`
+- `electron/ipc/onboarding/onboarding.ts`
+
+**3d. Stale closure fix in `OnboardingWizard.tsx`**
+
+Line ~197: change `getDisplayProviderName(onboardingState, failedProvider)` to use `refreshedState` instead — the pre-refresh `onboardingState` may have stale `providerHealth` data.
+
+### Out of Scope
+
+- **`scoreModelForTier` divergence** (renderer vs main): Both produce reasonable suggestions. Unifying requires a shared module or IPC round-trip. Low risk — follow-up.
+- **Admin plugin type duplication**: Touches plugin build pipeline. Independent work — follow-up.
+- **TierPicker.tsx consumer audit**: May be unused after SetupScreen rework. Separate cleanup.

--- a/packages/templates/agents/analyst.md
+++ b/packages/templates/agents/analyst.md
@@ -2,7 +2,7 @@
 {
   "name": "analyst",
   "description": "Codebase analysis and planning",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "medium",
   "tools": ["read", "bash", "grep", "find", "ls"]
 }

--- a/packages/templates/agents/collab-analyst.md
+++ b/packages/templates/agents/collab-analyst.md
@@ -2,7 +2,7 @@
 {
   "name": "collab-analyst",
   "description": "Logic, math, and code reasoning for 4-agent collaboration",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "high",
   "tools": ["read", "bash", "grep", "find", "ls", "edit", "write"]
 }

--- a/packages/templates/agents/coordinator.md
+++ b/packages/templates/agents/coordinator.md
@@ -2,7 +2,7 @@
 {
   "name": "coordinator",
   "description": "Lead synthesizer for 4-agent collaboration",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "HIGH", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "high"
 }
 ```

--- a/packages/templates/agents/implementer.md
+++ b/packages/templates/agents/implementer.md
@@ -2,7 +2,7 @@
 {
   "name": "implementer",
   "description": "Subtask implementation specialist",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "high",
   "tools": ["read", "write", "edit", "bash", "grep", "find", "ls"]
 }

--- a/packages/templates/agents/planner.md
+++ b/packages/templates/agents/planner.md
@@ -2,7 +2,7 @@
 {
   "name": "planner",
   "description": "Implementation planning and subtask decomposition",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "HIGH", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "high",
   "tools": ["read", "bash", "grep", "find", "ls"]
 }

--- a/packages/templates/agents/quality-reviewer.md
+++ b/packages/templates/agents/quality-reviewer.md
@@ -2,7 +2,7 @@
 {
   "name": "quality-reviewer",
   "description": "Code quality reviewer — style, patterns, performance, maintainability",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "medium",
   "tools": ["read", "bash", "grep", "find"]
 }

--- a/packages/templates/agents/research-analyst.md
+++ b/packages/templates/agents/research-analyst.md
@@ -2,7 +2,7 @@
 {
   "name": "research-analyst",
   "description": "Synthesizes multi-agent research outputs into unified, insight-driven documents with cross-cutting analysis, confidence assessments, and actionable recommendations",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "high"
 }
 ```

--- a/packages/templates/agents/researcher.md
+++ b/packages/templates/agents/researcher.md
@@ -2,7 +2,7 @@
 {
   "name": "researcher",
   "description": "Fact-checking and evidence gathering for 4-agent collaboration",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "medium",
   "tools": ["read", "bash", "grep", "find", "ls"]
 }

--- a/packages/templates/agents/reviewer.md
+++ b/packages/templates/agents/reviewer.md
@@ -2,7 +2,7 @@
 {
   "name": "reviewer",
   "description": "Code review specialist",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "high",
   "tools": ["read", "bash", "grep", "find"]
 }

--- a/packages/templates/agents/scout.md
+++ b/packages/templates/agents/scout.md
@@ -2,7 +2,7 @@
 {
   "name": "scout",
   "description": "Fast codebase reconnaissance",
-  "model": "claude-haiku-4-5",
+  "model": { "prefer": "LOW", "fallbacks": ["gpt-4.1-mini", "claude-haiku-4-5", "gemini-2.5-flash"] },
   "thinking": "off",
   "tools": ["read", "bash", "grep", "find", "ls"]
 }

--- a/packages/templates/agents/spec-reviewer.md
+++ b/packages/templates/agents/spec-reviewer.md
@@ -2,7 +2,7 @@
 {
   "name": "spec-reviewer",
   "description": "Spec compliance reviewer — compares implementation against subtask spec",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "medium",
   "tools": ["read", "bash", "grep", "find"]
 }

--- a/packages/templates/agents/test-writer.md
+++ b/packages/templates/agents/test-writer.md
@@ -2,7 +2,7 @@
 {
   "name": "test-writer",
   "description": "Unit test generation",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "medium",
   "tools": ["read", "write", "bash", "edit"]
 }

--- a/packages/templates/agents/visionary.md
+++ b/packages/templates/agents/visionary.md
@@ -2,7 +2,7 @@
 {
   "name": "visionary",
   "description": "Creative and divergent thinking for 4-agent collaboration",
-  "model": "claude-sonnet-4-6",
+  "model": { "prefer": "MED", "fallbacks": ["gpt-5.4", "claude-sonnet-4-6", "gemini-2.5-pro"] },
   "thinking": "medium",
   "tools": ["read", "bash", "grep", "find", "ls"]
 }

--- a/plugins/sero-admin-plugin/shared/types.ts
+++ b/plugins/sero-admin-plugin/shared/types.ts
@@ -7,7 +7,7 @@
 
 // ── App state (persisted) ──────────────────────────────────
 
-export type AdminTab = 'config' | 'skills' | 'plugins' | 'logs' | 'sessions';
+export type AdminTab = 'config' | 'modelDefaults' | 'skills' | 'plugins' | 'logs' | 'sessions';
 
 export interface AdminState {
   /** Last active tab. */

--- a/plugins/sero-admin-plugin/ui/AdminApp.tsx
+++ b/plugins/sero-admin-plugin/ui/AdminApp.tsx
@@ -1,8 +1,9 @@
 /**
  * AdminApp — main Sero Admin app component.
  *
- * Five-tab interface:
+ * Six-tab interface:
  *  - Config: browse and edit Sero configuration files
+ *  - Defaults: edit global provider model defaults used by onboarding
  *  - Skills: control which skills stay visible to the model by default
  *  - Plugins: install and remove optional Sero plugins
  *  - Logs: view Sero log files with auto-refresh
@@ -21,6 +22,7 @@ import { DEFAULT_STATE } from '../shared/types';
 import { useProfiles } from './hooks/useSeroFiles';
 import { Header } from './components/Header';
 import { ConfigPanel } from './components/ConfigPanel';
+import { ModelDefaultsPanel } from './components/ModelDefaultsPanel';
 import { SkillsPanel } from './components/SkillsPanel';
 import { PluginsPanel } from './components/PluginsPanel';
 import { LogViewer } from './components/LogViewer';
@@ -94,6 +96,18 @@ export function AdminApp() {
               </span>
             </TabsTrigger>
             <TabsTrigger
+              value="modelDefaults"
+              className={cn(
+                'h-8 rounded-none px-3 text-xs',
+                activeTab === 'modelDefaults' && 'text-indigo-400',
+              )}
+            >
+              <span className="flex items-center gap-1.5">
+                <ModelIcon />
+                Defaults
+              </span>
+            </TabsTrigger>
+            <TabsTrigger
               value="skills"
               className={cn(
                 'h-8 rounded-none px-3 text-xs',
@@ -154,6 +168,10 @@ export function AdminApp() {
           />
         </TabsContent>
 
+        <TabsContent value="modelDefaults" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <ModelDefaultsPanel />
+        </TabsContent>
+
         <TabsContent value="skills" className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <SkillsPanel profilePath={profilePath} />
         </TabsContent>
@@ -186,6 +204,16 @@ function ConfigIcon() {
       <path d="M14 2v4a2 2 0 0 0 2 2h4" />
       <path d="M10 12h4" />
       <path d="M10 16h4" />
+    </svg>
+  );
+}
+
+function ModelIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 3v18" />
+      <path d="M6 8h12" />
+      <path d="M4 16h16" />
     </svg>
   );
 }

--- a/plugins/sero-admin-plugin/ui/components/Header.tsx
+++ b/plugins/sero-admin-plugin/ui/components/Header.tsx
@@ -15,6 +15,7 @@ interface HeaderProps {
 export const Header = memo(function Header({ profileName, activeTab }: HeaderProps) {
   const tabLabel =
     activeTab === 'config' ? 'Configuration' :
+    activeTab === 'modelDefaults' ? 'Model Defaults' :
     activeTab === 'skills' ? 'Skills' :
     activeTab === 'plugins' ? 'Plugins' :
     activeTab === 'logs' ? 'Logs' :

--- a/plugins/sero-admin-plugin/ui/components/ModelDefaultsPanel.tsx
+++ b/plugins/sero-admin-plugin/ui/components/ModelDefaultsPanel.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
+import { getSero, type ProviderDefaultsState, type ProviderModelDefaults } from '../hooks/useSeroFiles';
+
+type TierKey = 'LOW' | 'MED' | 'HIGH';
+type EditableTierDefaults = Record<TierKey, string>;
+
+const TIERS: readonly TierKey[] = ['LOW', 'MED', 'HIGH'] as const;
+
+function toEditableDefaults(defaults: ProviderModelDefaults): Record<string, EditableTierDefaults> {
+  const result: Record<string, EditableTierDefaults> = {};
+  for (const [providerId, tiers] of Object.entries(defaults)) {
+    result[providerId] = {
+      LOW: tiers.LOW ?? '',
+      MED: tiers.MED ?? '',
+      HIGH: tiers.HIGH ?? '',
+    };
+  }
+  return result;
+}
+
+function normalizeDefaults(draft: Record<string, EditableTierDefaults>): ProviderModelDefaults {
+  const result: ProviderModelDefaults = {};
+
+  for (const [providerId, tiers] of Object.entries(draft)) {
+    const normalizedProviderId = providerId.trim();
+    if (!normalizedProviderId) continue;
+
+    const nextTiers: Partial<Record<TierKey, string>> = {};
+    for (const tier of TIERS) {
+      const value = tiers[tier].trim();
+      if (!value) continue;
+      nextTiers[tier] = value;
+    }
+
+    if (Object.keys(nextTiers).length > 0) {
+      result[normalizedProviderId] = nextTiers;
+    }
+  }
+
+  return result;
+}
+
+function effectiveLabel(state: ProviderDefaultsState | null, providerId: string, tier: TierKey): string {
+  return state?.effectiveDefaults[providerId]?.[tier] ?? '—';
+}
+
+export function ModelDefaultsPanel() {
+  const [state, setState] = useState<ProviderDefaultsState | null>(null);
+  const [draft, setDraft] = useState<Record<string, EditableTierDefaults>>({});
+  const [newProviderId, setNewProviderId] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const nextState = await getSero().providerDefaults.get();
+      setState(nextState);
+      setDraft(toEditableDefaults(nextState.globalDefaults));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load provider defaults');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const providerIds = useMemo(() => {
+    const ids = new Set<string>([
+      ...Object.keys(state?.builtInDefaults ?? {}),
+      ...Object.keys(draft),
+      ...Object.keys(state?.effectiveDefaults ?? {}),
+    ]);
+    return [...ids].sort((a, b) => a.localeCompare(b));
+  }, [draft, state]);
+
+  const updateTier = useCallback((providerId: string, tier: TierKey, value: string) => {
+    setDraft((current) => ({
+      ...current,
+      [providerId]: {
+        LOW: current[providerId]?.LOW ?? '',
+        MED: current[providerId]?.MED ?? '',
+        HIGH: current[providerId]?.HIGH ?? '',
+        [tier]: value,
+      },
+    }));
+  }, []);
+
+  const addProvider = useCallback(() => {
+    const providerId = newProviderId.trim();
+    if (!providerId) return;
+    setDraft((current) => ({
+      ...current,
+      [providerId]: current[providerId] ?? { LOW: '', MED: '', HIGH: '' },
+    }));
+    setNewProviderId('');
+  }, [newProviderId]);
+
+  const clearProviderOverride = useCallback((providerId: string) => {
+    setDraft((current) => {
+      const { [providerId]: _removed, ...rest } = current;
+      return rest;
+    });
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    setNotice(null);
+    try {
+      await getSero().providerDefaults.setGlobalDefaults(normalizeDefaults(draft));
+      setNotice('Global provider defaults saved.');
+      await load();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Failed to save provider defaults');
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, load]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="admin-loading text-xs text-muted-foreground">Loading model defaults…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="border-b border-border/30 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h2 className="text-sm font-semibold text-foreground">Provider model defaults</h2>
+            <p className="mt-1 text-xs text-muted-foreground/70">
+              These global defaults feed onboarding recommendations across profiles. Leave a field blank to fall back to built-in defaults.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={() => void load()}>
+              Reload
+            </Button>
+            <Button size="sm" className="h-7 px-2.5 text-xs" onClick={() => void handleSave()} disabled={saving}>
+              {saving ? 'Saving…' : 'Save defaults'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-3 flex gap-2">
+          <Input
+            value={newProviderId}
+            onChange={(event) => setNewProviderId(event.target.value)}
+            placeholder="Add provider id…"
+            className="h-8 text-xs"
+          />
+          <Button variant="outline" size="sm" className="h-8 px-3 text-xs" onClick={addProvider}>
+            Add provider
+          </Button>
+        </div>
+
+        {error ? (
+          <p className="mt-2 text-[11px] text-destructive">{error}</p>
+        ) : null}
+        {notice ? (
+          <p className="mt-2 text-[11px] text-emerald-400">{notice}</p>
+        ) : null}
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-3 p-4">
+          {providerIds.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border/40 px-4 py-8 text-center text-xs text-muted-foreground/60">
+              No provider defaults yet.
+            </div>
+          ) : (
+            providerIds.map((providerId) => {
+              const builtIn = state?.builtInDefaults[providerId];
+              const effective = state?.effectiveDefaults[providerId];
+              const editable = draft[providerId] ?? { LOW: '', MED: '', HIGH: '' };
+
+              return (
+                <div key={providerId} className="rounded-xl border border-border/40 bg-background/60 p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium text-foreground">{providerId}</p>
+                      <p className="mt-1 text-[11px] text-muted-foreground/70">
+                        Effective: {TIERS.map((tier) => `${tier} ${effectiveLabel(state, providerId, tier)}`).join(' · ')}
+                      </p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 text-[11px] text-muted-foreground"
+                      onClick={() => clearProviderOverride(providerId)}
+                    >
+                      Clear override
+                    </Button>
+                  </div>
+
+                  <div className="mt-4 grid gap-3 md:grid-cols-3">
+                    {TIERS.map((tier) => (
+                      <label key={tier} className="space-y-1.5">
+                        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                          {tier}
+                        </span>
+                        <Input
+                          value={editable[tier]}
+                          onChange={(event) => updateTier(providerId, tier, event.target.value)}
+                          placeholder={builtIn?.[tier] ?? effective?.[tier] ?? 'model-id'}
+                          className="h-8 text-xs"
+                        />
+                        <p className="text-[10px] text-muted-foreground/60">
+                          Built-in: {builtIn?.[tier] ?? '—'}
+                        </p>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/plugins/sero-admin-plugin/ui/hooks/useSeroFiles.ts
+++ b/plugins/sero-admin-plugin/ui/hooks/useSeroFiles.ts
@@ -16,6 +16,16 @@ import { formatDate } from '../lib/format';
 
 import type { InstalledPlugin } from '@sero/common';
 
+export type ProviderTierDefaults = Partial<Record<'LOW' | 'MED' | 'HIGH', string>>;
+export type ProviderModelDefaults = Record<string, ProviderTierDefaults>;
+
+export interface ProviderDefaultsState {
+  builtInDefaults: ProviderModelDefaults;
+  globalDefaults: ProviderModelDefaults;
+  profileOverrides?: ProviderModelDefaults;
+  effectiveDefaults: ProviderModelDefaults;
+}
+
 export interface SeroApi {
   appState: {
     read(filePath: string): Promise<unknown>;
@@ -45,6 +55,10 @@ export interface SeroApi {
   skills: {
     listAvailableSkills(): Promise<AvailableSkillInfo[]>;
     setDisabledModelSkills(skillNames: string[]): Promise<void>;
+  };
+  providerDefaults: {
+    get(): Promise<ProviderDefaultsState>;
+    setGlobalDefaults(defaults: ProviderModelDefaults): Promise<void>;
   };
 }
 

--- a/plugins/sero-memory-plugin/extension/index.ts
+++ b/plugins/sero-memory-plugin/extension/index.ts
@@ -44,6 +44,8 @@ import { startBackfillInBackground } from './session-transcripts';
 export default function memoryExtension(pi: ExtensionAPI): void {
   info('extension_loaded', { logPath: getMemoryLogPath() });
 
+  let awaitingBootstrapFollowUp = false;
+
   try {
     const autoConsolidation = syncAutoConsolidationCronJobSync();
     info('auto_consolidation_sync', { ...autoConsolidation });
@@ -66,6 +68,8 @@ export default function memoryExtension(pi: ExtensionAPI): void {
       needsBootstrap: status.needsBootstrap,
       hasExistingUserContent: Boolean(status.existingUserContent),
     });
+
+    awaitingBootstrapFollowUp = status.needsBootstrap;
 
     if (status.needsBootstrap) {
       pi.sendMessage(
@@ -199,9 +203,26 @@ export default function memoryExtension(pi: ExtensionAPI): void {
 
   pi.on('agent_end', async () => {
     const status = await checkBootstrapStatus();
-    info('agent_end', { needsBootstrap: status.needsBootstrap });
+    info('agent_end', {
+      needsBootstrap: status.needsBootstrap,
+      awaitingBootstrapFollowUp,
+    });
+
     if (!status.needsBootstrap) {
       markBootstrapDone();
+
+      if (awaitingBootstrapFollowUp) {
+        awaitingBootstrapFollowUp = false;
+        pi.sendMessage(
+          {
+            customType: '',
+            content: 'Memory is all set — what would you like to work on?',
+            display: true,
+          },
+          { triggerTurn: false },
+        );
+        info('bootstrap_follow_up_sent', {});
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- Add onboarding preflight and recommendation logic for provider/model defaults across the desktop flow
- Simplify the ready screen to provider + model first, with optional LOW/MED/HIGH overrides when needed
- Add global provider default management in the Admin plugin and highlight preferred providers in auth
- Prevent duplicate welcome launches and replace raw onboarding questionnaire tool calls with friendlier chat notices
- Finish onboarding with a proactive follow-up message and switch the user to the Dashboard app
- **Use dedicated low-thinking session for memory setup** — onboarding runs in a temp session with thinking set to 'low', then tears it down and creates a clean "Welcome" session with a greeting
- **Polish setup screen UI** — improved spacing, consistent select sizing, more breathing room; provider management moved to an inline icon button next to the provider select
- **Code deduplication** — extract shared `modelKey`/`parseModelKey`, `getSeroSettings`/`readSettings` helpers; fix stale closure in onboarding recovery path

## Test Plan

- [x] `pnpm typecheck`
- [x] `pnpm test -- --run` (523 tests passing)
- [ ] Create a fresh profile and confirm the ready screen shows provider + model defaults
- [ ] Verify the provider manage button (key icon) next to the provider select opens the auth dialog
- [ ] Enable tiered model selection and verify LOW/MED/HIGH overrides are saved correctly
- [ ] Reconnect a provider during onboarding and verify the flow recovers cleanly
- [ ] Complete onboarding and verify: temp session is created and deleted, clean "Welcome" session appears with agent greeting, Dashboard becomes active
- [ ] Verify thinking level is set to 'low' during memory setup (check agent logs)