### PR TITLE
feat: add Alibaba Cloud (DashScope) as a custom LLM provider

### DIFF
--- a/apps/desktop/electron/features/onboarding/provider-health.ts
+++ b/apps/desktop/electron/features/onboarding/provider-health.ts
@@ -1,11 +1,14 @@
 import { existsSync, readFileSync } from 'fs';
 import path from 'path';
-import { getEnvApiKey } from '@mariozechner/pi-ai';
 import type { AvailableModelGroup, ProviderHealthInfo, ProviderHealthStatus } from '../../../src/types/ipc';
 import type { LocalModelsConfig } from '../../../src/types/local-models';
 import { SERO_AGENT_DIR } from '../../platform/env';
 import { ensureInfra } from '../../shared/infra/shared-infra';
-import { API_KEY_PROVIDERS, getOAuthProviderCatalog } from '../../shared/auth/provider-catalog';
+import {
+  getApiKeyProviderCatalog,
+  getOAuthProviderCatalog,
+  getProviderEnvApiKey,
+} from '../../shared/auth/provider-catalog';
 import { providerDisplayName, providerLogo } from '../../ipc/platform/auth';
 
 export interface ProviderHealthSnapshot {
@@ -138,10 +141,10 @@ export async function getProviderHealthSnapshot(): Promise<ProviderHealthSnapsho
     }));
   }
 
-  for (const provider of API_KEY_PROVIDERS) {
+  for (const provider of getApiKeyProviderCatalog()) {
     knownProviders.add(provider.id);
     const credential = infra.authStorage.get(provider.id);
-    const envKey = getEnvApiKey(provider.id);
+    const envKey = getProviderEnvApiKey(provider.id);
     const usableModelIds = usableModelIdsByProvider.get(provider.id) ?? [];
 
     let status: ProviderHealthStatus;

--- a/apps/desktop/electron/ipc/platform/auth/auth.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth.ts
@@ -19,7 +19,6 @@
 
 import fs from 'fs';
 import { ipcMain, BrowserWindow, shell, type WebContents } from 'electron';
-import { getEnvApiKey } from '@mariozechner/pi-ai';
 import { getOAuthProviders } from '@mariozechner/pi-ai/oauth';
 import type { OAuthProviderId } from '@mariozechner/pi-ai';
 
@@ -31,7 +30,7 @@ import type {
   OAuthEvent,
 } from '../../../../src/types/ipc';
 import { ensureInfra } from '../../../shared/infra/shared-infra';
-import { API_KEY_PROVIDERS } from '../../../shared/auth/provider-catalog';
+import { getApiKeyProviderCatalog, getProviderEnvApiKey } from '../../../shared/auth/provider-catalog';
 import { AUTH_JSON_PATH } from '../../../platform/env';
 
 // ── auth.json permission hardening ───────────────────────────
@@ -135,9 +134,9 @@ export function registerAuthHandlers(): void {
       });
 
       // API key providers
-      const apiKey: ApiKeyProviderInfo[] = API_KEY_PROVIDERS.map((p) => {
+      const apiKey: ApiKeyProviderInfo[] = getApiKeyProviderCatalog().map((p) => {
         const cred = infra.authStorage.get(p.id);
-        const envKey = getEnvApiKey(p.id);
+        const envKey = getProviderEnvApiKey(p.id);
         return {
           id: p.id,
           name: p.name,

--- a/apps/desktop/electron/ipc/platform/auth/provider-metadata.ts
+++ b/apps/desktop/electron/ipc/platform/auth/provider-metadata.ts
@@ -5,6 +5,8 @@
  * Extracted from agent-helpers.ts to keep it under 500 LOC.
  */
 
+import { getPackageProviderManifest } from '../../../shared/providers/package-provider-manifests';
+
 const PROVIDER_NAMES: Record<string, string> = {
   anthropic: 'Anthropic',
   openai: 'OpenAI',
@@ -28,7 +30,6 @@ const PROVIDER_NAMES: Record<string, string> = {
   'kimi-coding': 'Kimi',
   minimax: 'MiniMax',
   'minimax-cn': 'MiniMax CN',
-  'alibaba-cloud': 'Alibaba Cloud',
 };
 
 const PROVIDER_LOGO_MAP: Record<string, string> = {
@@ -41,14 +42,25 @@ const PROVIDER_LOGO_MAP: Record<string, string> = {
   'github-copilot': 'github-copilot',
   'vercel-ai-gateway': 'vercel',
   'kimi-coding': 'openai',
-  'alibaba-cloud': 'alibaba-cloud',
 };
 
+function titleizeProviderId(provider: string): string {
+  return provider.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 export function providerLogo(provider: string): string {
+  const manifestLogo = getPackageProviderManifest(provider)?.logo;
+  if (manifestLogo) {
+    if (/^https?:\/\//.test(manifestLogo)) return manifestLogo;
+    return `https://models.dev/logos/${manifestLogo}.svg`;
+  }
+
   const slug = PROVIDER_LOGO_MAP[provider] ?? provider;
   return `https://models.dev/logos/${slug}.svg`;
 }
 
 export function providerDisplayName(provider: string): string {
-  return PROVIDER_NAMES[provider] ?? provider.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  const manifestName = getPackageProviderManifest(provider)?.name;
+  if (manifestName) return manifestName;
+  return PROVIDER_NAMES[provider] ?? titleizeProviderId(provider);
 }

--- a/apps/desktop/electron/ipc/platform/auth/provider-metadata.ts
+++ b/apps/desktop/electron/ipc/platform/auth/provider-metadata.ts
@@ -28,6 +28,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   'kimi-coding': 'Kimi',
   minimax: 'MiniMax',
   'minimax-cn': 'MiniMax CN',
+  'alibaba-cloud': 'Alibaba Cloud',
 };
 
 const PROVIDER_LOGO_MAP: Record<string, string> = {
@@ -40,6 +41,7 @@ const PROVIDER_LOGO_MAP: Record<string, string> = {
   'github-copilot': 'github-copilot',
   'vercel-ai-gateway': 'vercel',
   'kimi-coding': 'openai',
+  'alibaba-cloud': 'alibaba-cloud',
 };
 
 export function providerLogo(provider: string): string {

--- a/apps/desktop/electron/shared/auth/provider-catalog.ts
+++ b/apps/desktop/electron/shared/auth/provider-catalog.ts
@@ -21,6 +21,7 @@ export const API_KEY_PROVIDERS: NamedProvider[] = [
   { id: 'zai', name: 'ZAI' },
   { id: 'opencode', name: 'OpenCode' },
   { id: 'kimi-coding', name: 'Kimi' },
+  { id: 'alibaba-cloud', name: 'Alibaba Cloud' },
 ];
 
 export function getOAuthProviderCatalog(): NamedProvider[] {

--- a/apps/desktop/electron/shared/auth/provider-catalog.ts
+++ b/apps/desktop/electron/shared/auth/provider-catalog.ts
@@ -1,12 +1,13 @@
+import { getEnvApiKey } from '@mariozechner/pi-ai';
 import { getOAuthProviders } from '@mariozechner/pi-ai/oauth';
+import { getPackageApiKeyProviders, getPackageProviderEnvVar } from '../providers/package-provider-manifests';
 
 export interface NamedProvider {
   id: string;
   name: string;
 }
 
-/** Providers that accept a plain API key (not OAuth). */
-export const API_KEY_PROVIDERS: NamedProvider[] = [
+const BUILTIN_API_KEY_PROVIDERS: NamedProvider[] = [
   { id: 'anthropic', name: 'Anthropic' },
   { id: 'openai', name: 'OpenAI' },
   { id: 'google', name: 'Google (Gemini)' },
@@ -21,8 +22,26 @@ export const API_KEY_PROVIDERS: NamedProvider[] = [
   { id: 'zai', name: 'ZAI' },
   { id: 'opencode', name: 'OpenCode' },
   { id: 'kimi-coding', name: 'Kimi' },
-  { id: 'alibaba-cloud', name: 'Alibaba Cloud' },
 ];
+
+export function getApiKeyProviderCatalog(): NamedProvider[] {
+  const byId = new Map<string, NamedProvider>();
+  for (const provider of BUILTIN_API_KEY_PROVIDERS) {
+    byId.set(provider.id, provider);
+  }
+  for (const provider of getPackageApiKeyProviders()) {
+    byId.set(provider.id, provider);
+  }
+  return [...byId.values()];
+}
+
+export function getProviderEnvApiKey(providerId: string): string | undefined {
+  const defaultEnvKey = getEnvApiKey(providerId);
+  if (defaultEnvKey) return defaultEnvKey;
+
+  const envVar = getPackageProviderEnvVar(providerId);
+  return envVar ? process.env[envVar] : undefined;
+}
 
 export function getOAuthProviderCatalog(): NamedProvider[] {
   return getOAuthProviders().map((provider) => ({

--- a/apps/desktop/electron/shared/providers/package-provider-manifests.ts
+++ b/apps/desktop/electron/shared/providers/package-provider-manifests.ts
@@ -1,0 +1,215 @@
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import type { ModelTier, ProviderModelDefaults, SettingsPackageSource } from '../../../src/types/ipc';
+import { SERO_AGENT_DIR } from '../../platform/env';
+import {
+  discoverBuiltinPackagePaths,
+  discoverBuiltinPluginPaths,
+} from '../../platform/protocols/builtin-resources';
+
+const MODEL_TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
+const CACHE_TTL_MS = 250;
+
+interface PackageProviderAuthManifest {
+  type?: string;
+  envVar?: string;
+}
+
+interface PackageProviderManifest {
+  id?: string;
+  name?: string;
+  logo?: string;
+  auth?: PackageProviderAuthManifest;
+  defaults?: Partial<Record<ModelTier, string>>;
+}
+
+interface PackageJson {
+  sero?: {
+    providers?: PackageProviderManifest[];
+  };
+}
+
+export interface SeroProviderManifest {
+  id: string;
+  name?: string;
+  logo?: string;
+  auth?: {
+    type: 'apiKey';
+    envVar?: string;
+  };
+  defaults?: Partial<Record<ModelTier, string>>;
+}
+
+let cachedAt = 0;
+let cachedProviders: SeroProviderManifest[] = [];
+
+function titleizeProviderId(providerId: string): string {
+  return providerId.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function normalizeTierDefaults(value: unknown): Partial<Record<ModelTier, string>> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+
+  const record = value as Record<string, unknown>;
+  const result: Partial<Record<ModelTier, string>> = {};
+  for (const tier of MODEL_TIERS) {
+    const modelId = record[tier];
+    if (typeof modelId !== 'string') continue;
+    const trimmed = modelId.trim();
+    if (!trimmed) continue;
+    result[tier] = trimmed;
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function normalizeProviderManifest(value: PackageProviderManifest): SeroProviderManifest | null {
+  const id = typeof value.id === 'string' ? value.id.trim() : '';
+  if (!id) return null;
+
+  const name = typeof value.name === 'string' && value.name.trim()
+    ? value.name.trim()
+    : undefined;
+  const logo = typeof value.logo === 'string' && value.logo.trim()
+    ? value.logo.trim()
+    : undefined;
+
+  let auth: SeroProviderManifest['auth'];
+  if (value.auth && typeof value.auth === 'object' && !Array.isArray(value.auth)) {
+    const type = typeof value.auth.type === 'string' ? value.auth.type.trim() : '';
+    const envVar = typeof value.auth.envVar === 'string' && value.auth.envVar.trim()
+      ? value.auth.envVar.trim()
+      : undefined;
+    if (type === 'apiKey') {
+      auth = { type: 'apiKey', envVar };
+    }
+  }
+
+  return {
+    id,
+    name,
+    logo,
+    auth,
+    defaults: normalizeTierDefaults(value.defaults),
+  };
+}
+
+function readProviderManifestsFromPackage(packageDir: string): SeroProviderManifest[] {
+  const pkgJsonPath = path.join(packageDir, 'package.json');
+  if (!existsSync(pkgJsonPath)) return [];
+
+  try {
+    const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8')) as PackageJson;
+    if (!Array.isArray(pkg.sero?.providers)) return [];
+
+    return pkg.sero.providers
+      .map(normalizeProviderManifest)
+      .filter((provider): provider is SeroProviderManifest => provider !== null);
+  } catch {
+    return [];
+  }
+}
+
+function readSettingsPackagePaths(): string[] {
+  const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
+  if (!existsSync(settingsPath)) return [];
+
+  try {
+    const raw = JSON.parse(readFileSync(settingsPath, 'utf8')) as {
+      packages?: SettingsPackageSource[];
+      extensions?: string[];
+    };
+
+    const paths = new Set<string>();
+
+    for (const pkgSource of raw.packages ?? []) {
+      const source = typeof pkgSource === 'string' ? pkgSource : pkgSource.source;
+      if (typeof source !== 'string' || !source) continue;
+      if (source.startsWith('npm:') || source.startsWith('git:')) continue;
+      paths.add(path.resolve(source));
+    }
+
+    for (const ext of raw.extensions ?? []) {
+      if (typeof ext !== 'string' || !ext) continue;
+      if (ext.startsWith('npm:') || ext.startsWith('git:')) continue;
+      paths.add(path.resolve(ext));
+    }
+
+    return [...paths];
+  } catch {
+    return [];
+  }
+}
+
+function scanPackageDir(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+
+  try {
+    return readdirSync(dir)
+      .map((entry) => path.join(dir, entry))
+      .filter((entryPath) => existsSync(path.join(entryPath, 'package.json')))
+      .sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
+}
+
+function listCandidatePackageDirs(): string[] {
+  const dirs = new Set<string>();
+
+  for (const pkgPath of discoverBuiltinPackagePaths()) dirs.add(pkgPath);
+  for (const pluginPath of discoverBuiltinPluginPaths()) dirs.add(pluginPath);
+  for (const settingsPath of readSettingsPackagePaths()) dirs.add(settingsPath);
+  for (const installedPath of scanPackageDir(path.join(SERO_AGENT_DIR, 'packages'))) dirs.add(installedPath);
+  for (const extPath of scanPackageDir(path.join(SERO_AGENT_DIR, 'extensions'))) dirs.add(extPath);
+
+  return [...dirs];
+}
+
+function loadProviderManifests(): SeroProviderManifest[] {
+  const now = Date.now();
+  if (now - cachedAt < CACHE_TTL_MS) return cachedProviders;
+
+  const byId = new Map<string, SeroProviderManifest>();
+  for (const packageDir of listCandidatePackageDirs()) {
+    for (const provider of readProviderManifestsFromPackage(packageDir)) {
+      byId.set(provider.id, provider);
+    }
+  }
+
+  cachedProviders = [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
+  cachedAt = now;
+  return cachedProviders;
+}
+
+export function getPackageProviderManifests(): SeroProviderManifest[] {
+  return loadProviderManifests();
+}
+
+export function getPackageProviderManifest(providerId: string): SeroProviderManifest | undefined {
+  return loadProviderManifests().find((provider) => provider.id === providerId);
+}
+
+export function getPackageApiKeyProviders(): Array<{ id: string; name: string }> {
+  return loadProviderManifests()
+    .filter((provider) => provider.auth?.type === 'apiKey')
+    .map((provider) => ({
+      id: provider.id,
+      name: provider.name ?? titleizeProviderId(provider.id),
+    }));
+}
+
+export function getPackageProviderEnvVar(providerId: string): string | undefined {
+  return getPackageProviderManifest(providerId)?.auth?.envVar;
+}
+
+export function getPackageProviderDefaults(): ProviderModelDefaults {
+  const result: ProviderModelDefaults = {};
+
+  for (const provider of loadProviderManifests()) {
+    if (!provider.defaults || Object.keys(provider.defaults).length === 0) continue;
+    result[provider.id] = { ...provider.defaults };
+  }
+
+  return result;
+}

--- a/apps/desktop/electron/shared/settings/provider-model-defaults.ts
+++ b/apps/desktop/electron/shared/settings/provider-model-defaults.ts
@@ -33,6 +33,11 @@ const BUILTIN_PROVIDER_MODEL_DEFAULTS: ProviderModelDefaults = {
     MED: 'claude-sonnet-4-6',
     HIGH: 'claude-sonnet-4-6',
   },
+  'alibaba-cloud': {
+    LOW: 'qwen-coder-turbo-latest',
+    MED: 'qwen-coder-plus-latest',
+    HIGH: 'qwen-max-latest',
+  },
 };
 
 function normalizeTierDefaults(value: unknown): ProviderTierDefaults {

--- a/apps/desktop/electron/shared/settings/provider-model-defaults.ts
+++ b/apps/desktop/electron/shared/settings/provider-model-defaults.ts
@@ -34,9 +34,9 @@ const BUILTIN_PROVIDER_MODEL_DEFAULTS: ProviderModelDefaults = {
     HIGH: 'claude-sonnet-4-6',
   },
   'alibaba-cloud': {
-    LOW: 'qwen-coder-turbo-latest',
-    MED: 'qwen-coder-plus-latest',
-    HIGH: 'qwen-max-latest',
+    LOW: 'qwen3-coder-plus',
+    MED: 'qwen3-coder-plus',
+    HIGH: 'qwen3.5-plus',
   },
 };
 

--- a/apps/desktop/electron/shared/settings/provider-model-defaults.ts
+++ b/apps/desktop/electron/shared/settings/provider-model-defaults.ts
@@ -7,12 +7,13 @@ import type {
   ResolvedProviderDefaultsState,
 } from '../../../src/types/ipc';
 import { SERO_FIXED_ROOT } from '../../platform/env';
+import { getPackageProviderDefaults } from '../providers/package-provider-manifests';
 import { getSeroSettings } from './settings-helpers';
 
 const TIERS: readonly ModelTier[] = ['LOW', 'MED', 'HIGH'] as const;
 const GLOBAL_PROVIDER_DEFAULTS_PATH = path.join(SERO_FIXED_ROOT, 'provider-model-defaults.json');
 
-const BUILTIN_PROVIDER_MODEL_DEFAULTS: ProviderModelDefaults = {
+const STATIC_PROVIDER_MODEL_DEFAULTS: ProviderModelDefaults = {
   openai: {
     LOW: 'gpt-4.1-mini',
     MED: 'gpt-5.4',
@@ -32,11 +33,6 @@ const BUILTIN_PROVIDER_MODEL_DEFAULTS: ProviderModelDefaults = {
     LOW: 'claude-haiku-4-5',
     MED: 'claude-sonnet-4-6',
     HIGH: 'claude-sonnet-4-6',
-  },
-  'alibaba-cloud': {
-    LOW: 'qwen3-coder-plus',
-    MED: 'qwen3-coder-plus',
-    HIGH: 'qwen3.5-plus',
   },
 };
 
@@ -65,7 +61,10 @@ function normalizeProviderDefaults(value: unknown): ProviderModelDefaults {
     if (!normalizedProviderId) continue;
     const normalizedTierDefaults = normalizeTierDefaults(tierDefaults);
     if (Object.keys(normalizedTierDefaults).length === 0) continue;
-    result[normalizedProviderId] = normalizedTierDefaults;
+    result[normalizedProviderId] = {
+      ...(result[normalizedProviderId] ?? {}),
+      ...normalizedTierDefaults,
+    };
   }
   return result;
 }
@@ -92,7 +91,8 @@ export function getGlobalProviderDefaultsPath(): string {
 }
 
 export function getBuiltInProviderModelDefaults(): ProviderModelDefaults {
-  return JSON.parse(JSON.stringify(BUILTIN_PROVIDER_MODEL_DEFAULTS)) as ProviderModelDefaults;
+  const defaults = mergeProviderDefaults(STATIC_PROVIDER_MODEL_DEFAULTS, getPackageProviderDefaults());
+  return JSON.parse(JSON.stringify(defaults)) as ProviderModelDefaults;
 }
 
 export function readGlobalProviderModelDefaults(): ProviderModelDefaults {

--- a/docs/features/sero-apps.md
+++ b/docs/features/sero-apps.md
@@ -1,270 +1,383 @@
-# Sero Apps — Pi Extensions with Web UI
+# Sero Apps — Runtime Architecture
 
-## Core Concept
+This document explains what a **Sero app** is at runtime: how a Pi extension,
+a federated React UI, and a shared state file fit together inside Sero.
 
-A Sero app is a **standard Pi extension** that reads/writes a JSON state file.
-Sero can optionally mount a **web UI** (loaded via Vite module federation) that
-reads/writes the **same JSON file**. The file IS the shared state.
+For packaging, distribution, installation, and plugin manifest details, see:
 
+- `docs/plugins/guide.md`
+- `docs/plugins/technical.md`
+
+## Core Idea
+
+A Sero app is a **standard Pi extension** with optional extra metadata under
+`sero.app` in `package.json`.
+
+- **Pi** loads the extension from `pi.extensions`
+- **Sero** reads the same package and, if `sero.app` exists, can also mount a
+  federated React UI for it
+- **Persistent app state** lives in a JSON file on disk and is shared by both
+  the extension and the UI
+
+For durable app data, the state file is the source of truth.
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                         state.json                          │
+│                durable shared app state on disk             │
+│                                                             │
+│       ┌──────────── read / write ────────────┐              │
+│       │                                      │              │
+│  Pi extension                          React UI             │
+│  (tools, commands, hooks)              (module federation)  │
+│  works in Pi + Sero                    works in Sero        │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
 ```
-┌─────────────────────────────────────────────────────────┐
-│                    state.json                            │
-│                   (source of truth)                      │
-│                                                         │
-│          ┌──── reads/writes ────┐                       │
-│          │                      │                       │
-│    Pi Extension             Web UI (React)               │
-│    (tools, commands)        (module federation)           │
-│    works in Pi CLI          works in Sero only            │
-│    + Sero                                                │
-└─────────────────────────────────────────────────────────┘
-```
 
-- Extension is 100% standard Pi. Distributable as a Pi package.
-- The `sero` key in `package.json` is metadata Pi CLI ignores.
-- Sero reads it to discover and mount the UI.
+## Built-in Apps vs Optional Plugins
 
-## Package Structure
+Sero apps can be shipped in two ways:
 
-```
-pi-todo/
-├── package.json              # Pi package manifest + sero app manifest
-├── shared/
-│   └── types.ts              # State shape (imported by both extension & UI)
+| Kind | Location | Ships with desktop app | Removable |
+|---|---|---:|---:|
+| Built-in app | monorepo (`packages/`, `plugins/`) | Yes | No |
+| Optional plugin | `~/.sero-ui/agent/packages/<id>/` | No | Yes |
+
+The runtime model is the same in both cases:
+
+- the extension is still a Pi extension
+- the UI is still loaded via Module Federation
+- the state file is still shared
+
+The difference is mainly **distribution and lifecycle**, which the plugin docs
+cover in detail.
+
+## Package Shape
+
+A typical source package looks like this:
+
+```text
+my-app/
+├── package.json
 ├── extension/
-│   └── index.ts              # Standard Pi extension (tools, commands, events)
+│   └── index.ts
+├── shared/
+│   └── types.ts
 ├── ui/
-│   ├── TodoApp.tsx           # React component
-│   ├── vite.config.ts        # Module federation (exposes TodoApp)
-│   └── dist/
-│       └── assets/           # Built output (shipped with package)
-└── README.md
+│   └── MyApp.tsx
+├── vite.config.ts
+└── dist/
+    └── ui/
+        └── remoteEntry.js   # after build
 ```
+
+### Minimal manifest
 
 ```json
 {
-  "name": "@sero/todo",
+  "name": "@sero/plugin-my-app",
   "keywords": ["pi-package"],
   "pi": {
     "extensions": ["./extension/index.ts"]
   },
   "sero": {
     "app": {
-      "id": "todo",
-      "name": "Todo",
-      "icon": "check-square",
-      "stateFile": ".sero/apps/todo/state.json",
-      "ui": "./ui/dist/remoteEntry.js",
-      "component": "TodoApp"
+      "id": "my-app",
+      "name": "My App",
+      "icon": "star",
+      "stateFile": ".sero/apps/my-app/state.json",
+      "scope": "workspace",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "MyApp",
+      "devPort": 5180
     }
   }
 }
 ```
 
-Pi CLI sees `pi.extensions` → loads the extension, ignores `sero`.
-Sero sees both → loads the extension AND mounts the UI.
+What each runtime cares about:
 
-## Shared State File
+- **Pi CLI / Pi runtime** cares about `pi.extensions`
+- **Sero** cares about `sero.app`
+- **Plugin packaging/distribution** additionally uses `sero.plugin`
+- **Optional provider plugins** may also declare `sero.providers`; see the
+  plugin docs for that host metadata
 
-State lives relative to the workspace root:
+## Persistent State Model
 
-```
-workspace-root/
+### Workspace-scoped apps
+
+Most apps are workspace-scoped. Their state lives under the workspace root:
+
+```text
+<workspace>/
 └── .sero/
     └── apps/
-        └── todo/
+        └── <app-id>/
             └── state.json
 ```
 
-### Why File-Based, Not Session Entries
+Example:
 
-- The todo list is a **workspace resource**, not a conversation artifact.
-  It persists across sessions.
-- Session entries are for conversation-scoped state. An "app" is
-  workspace-scoped — your todos exist whether or not you're chatting.
-- The agent reads/modifies the file like it reads/modifies any source file.
+```text
+<workspace>/.sero/apps/todo/state.json
+```
 
-### Concurrency
+### Global apps
 
-- Writes are atomic: write to temp file, then `fs.rename()`.
-- Writes from the UI are serialised through a queue in the main process.
-- `fs.watch()` on macOS uses FSEvents — reliable for our use case.
+Apps can also declare `scope: "global"`.
 
-## Extension Pattern (Standard Pi)
+For those, Sero stores state under:
 
-The extension uses plain `fs` to read/write the state file. It resolves the
-path from `ctx.cwd` on session events. Tools are callable by the LLM. Commands
-are callable by the user. TUI rendering is optional.
+```text
+~/.sero-ui/apps/<app-id>/state.json
+```
 
-```typescript
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
+Notes:
+
+- `stateFile` still remains part of the manifest even for global apps
+- Sero resolves the actual global path at runtime
+- keeping `stateFile` in the manifest preserves a consistent app contract and
+  remains useful as a fallback path convention outside the renderer
+
+### Why file-backed state?
+
+Because app state is a **workspace/global resource**, not a chat artifact.
+
+That gives you:
+
+- persistence across sessions
+- a format the extension can manipulate directly
+- a format the UI can watch reactively
+- a simple, inspectable source of truth on disk
+
+## Main Runtime Pieces
+
+| Piece | Role |
+|---|---|
+| `sero.app` manifest | Declares app identity, scope, UI entry, component export |
+| Pi extension | Tools, commands, hooks, background logic |
+| Module Federation remote | Optional web UI mounted by Sero |
+| `AppStateManager` | Main-process file read/write/watch service |
+| `@sero-ai/app-runtime` | Shared hooks used by federated UIs |
+| App discovery | Finds packages with `sero.app` and registers them |
+
+## Extension Side
+
+The extension should stay as close to a normal Pi extension as possible.
+
+Typical responsibilities:
+
+- register tools and commands
+- read and write the app's state file
+- react to session or app events
+- remain usable outside the Sero renderer when that makes sense
+
+A simplified pattern:
+
+```ts
+import path from 'path';
+import { promises as fs } from 'fs';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Type } from '@sinclair/typebox';
 
 export default function (pi: ExtensionAPI) {
-  let statePath: string;
+  let statePath = '';
 
-  async function readState() { /* fs.readFile(statePath) */ }
-  async function writeState(state) { /* atomic write to statePath */ }
+  async function readState() {
+    try {
+      const raw = await fs.readFile(statePath, 'utf8');
+      return JSON.parse(raw);
+    } catch {
+      return { items: [] };
+    }
+  }
 
-  pi.on("session_start", async (_event, ctx) => {
-    statePath = path.join(ctx.cwd, ".sero", "apps", "todo", "state.json");
+  async function writeState(next: unknown) {
+    await fs.mkdir(path.dirname(statePath), { recursive: true });
+    const tmp = `${statePath}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(next, null, 2), 'utf8');
+    await fs.rename(tmp, statePath);
+  }
+
+  pi.on('session_start', async (_event, ctx) => {
+    statePath = path.join(ctx.cwd, '.sero', 'apps', 'todo', 'state.json');
   });
 
   pi.registerTool({
-    name: "todo",
-    description: "Manage workspace todos: list, add, toggle, clear",
-    parameters: Type.Object({ action: ..., text: ..., id: ... }),
+    name: 'todo',
+    description: 'Manage todos',
+    parameters: Type.Object({
+      action: Type.String(),
+      text: Type.Optional(Type.String()),
+    }),
     async execute(_id, params) {
       const state = await readState();
-      // mutate based on action
+      // mutate state based on params.action
       await writeState(state);
-      return { content: [...], details: {} };
+      return { content: [{ type: 'text', text: 'Done.' }] };
     },
   });
-
-  pi.registerCommand("todos", { handler: async (_args, ctx) => { ... } });
 }
 ```
 
-This extension works in Pi CLI with zero Sero dependencies.
+Key point: the extension owns behavior; Sero-specific UI metadata lives beside
+it in the manifest.
 
-## Web UI Pattern (Sero Only)
+## UI Side
 
-The UI is a React component loaded via module federation. It uses `useAppState`
-from Sero's app runtime — a hook that reads/watches/writes the same JSON file.
+The React UI runs only inside Sero. It is mounted as a Module Federation remote
+and receives app context from the host shell.
+
+### Core hooks from `@sero-ai/app-runtime`
+
+Common hooks include:
+
+- `useAppState<T>()` — reactive file-backed app state
+- `useAppInfo()` — current app/workspace context
+- `useAgentPrompt()` — send a prompt through the host-injected prompt bridge
+- `useAI()` — talk to the app's dedicated app-agent session
+- `useAvailableModels()` — inspect model availability from the UI
+- `useTheme()` — react to host theme information
+
+A typical component:
 
 ```tsx
-import { useAppState } from "@sero-ai/app-runtime";
-import type { TodoState } from "../shared/types";
+import { useAppInfo, useAppState, useAI } from '@sero-ai/app-runtime';
+import type { TodoState } from '../shared/types';
+
+const DEFAULT_STATE: TodoState = { todos: [] };
 
 export function TodoApp() {
-  const [state, updateState] = useAppState<TodoState>(DEFAULT);
+  const [state, updateState] = useAppState<TodoState>(DEFAULT_STATE);
+  const { workspacePath, appId } = useAppInfo();
+  const ai = useAI();
 
   const toggleTodo = (id: number) => {
-    updateState(prev => ({
+    updateState((prev) => ({
       ...prev,
-      todos: prev.todos.map(t => t.id === id ? { ...t, done: !t.done } : t),
+      todos: prev.todos.map((todo) => (
+        todo.id === id ? { ...todo, done: !todo.done } : todo
+      )),
     }));
   };
 
-  return ( /* full React component — shadcn, Tailwind, animations */ );
+  const askAI = async () => {
+    const response = await ai.prompt('Summarize my todo list.');
+    console.log(appId, workspacePath, response);
+  };
+
+  return null;
 }
 ```
 
-## Module Federation
+### How `useAppState()` works
 
-Sero (host) shares React, ReactDOM, Tailwind, and `@sero-ai/app-runtime`.
-App UIs (remotes) consume these — no bundled React per app.
+`useAppState()` is file-backed and reactive:
 
-```typescript
-// Sero vite.config.ts (host)
-federation({ name: "sero", shared: ["react", "react-dom"] })
+1. the UI asks the main process for the current JSON value
+2. the main process begins watching the file
+3. updates from any writer are pushed back over IPC
+4. UI writes go through IPC back to the main process
+5. writes are persisted atomically and the watch pipeline fans the update out
 
-// App ui/vite.config.ts (remote)
-federation({
-  name: "sero-todo",
-  filename: "remoteEntry.js",
-  exposes: { "./TodoApp": "./TodoApp.tsx" },
-  shared: ["react", "react-dom"],
-})
+This means the UI sees changes whether they came from:
+
+- the UI itself
+- the extension
+- another part of the app writing the same file
+
+## App State Infrastructure
+
+The main-process `AppStateManager` handles shared state mechanics:
+
+- JSON reads
+- atomic writes via temp file + rename
+- `fs.watch()` subscriptions
+- per-file write serialization to avoid races
+- push notifications back to renderer consumers
+
+That manager lives in:
+
+```text
+apps/desktop/electron/features/apps/state/manager.ts
 ```
 
-## Sero App Runtime (`@sero-ai/app-runtime`)
+The IPC bridge for renderer consumers lives in:
 
-Hooks provided by Sero to federated app modules:
-
-```typescript
-// Core: file-backed reactive state
-useAppState<T>(defaultState: T): [T, (updater: (prev: T) => T) => void]
-
-// Context: which workspace, session, etc.
-useAppInfo(): { workspaceId: string, workspacePath: string, appId: string }
-
-// Optional: send a message to the agent from the app UI
-useAgentPrompt(): (text: string) => void
+```text
+apps/desktop/electron/ipc/apps/app-state.ts
 ```
 
-### useAppState Under the Hood
+## Module Federation and Mounting
 
-1. Initial read — IPC call to read the JSON file
-2. File watching — main process watches with `fs.watch()`, pushes via IPC
-3. Writes — `updateState` writes via IPC → atomic file write → watcher fires
-4. Concurrency — writes serialised through a queue in main process
+The UI side is loaded dynamically through Module Federation.
 
-## Sero Infrastructure
+At a high level:
 
-| Piece | What |
-|-------|------|
-| **AppStateManager** | Generic file watcher + read/write + IPC for state files |
-| **App discovery** | Scan Pi packages for `sero.app` manifest, register in app store |
-| **App mount point** | Dynamic import of federation remote, mount in main area |
-| **`@sero-ai/app-runtime`** | `useAppState`, `useAppInfo`, `useAgentPrompt` hooks |
-| **App registry store** | Zustand store for discovered apps + active app |
+1. Sero discovers a package with `sero.app`
+2. the host resolves its `ui` entry and exported `component`
+3. the remote is loaded via the `sero-ext://` protocol
+4. the host wraps it in `AppProvider`
+5. hooks such as `useAppState()` and `useAppInfo()` become available
 
-## Architecture Flow
+For app authors, the main requirement is that the manifest and build output
+match what the host expects:
 
-```
-┌─ Electron Main ──────────────────────────────────────────┐
-│                                                          │
-│  DefaultResourceLoader discovers extension                │
-│    → pi.registerTool("todo", ...) ← agent calls this     │
-│                                                          │
-│  AppStateManager (generic):                              │
-│    watches state files for all mounted apps               │
-│    handles read/write IPC from renderer                   │
-│    serialises writes (atomic rename)                      │
-│                                                          │
-│  App discovery (sero manifest in package.json):           │
-│    registers app in app registry                          │
-│    resolves UI entry path                                 │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
+- `sero.app.ui` points at the built remote entry
+- `sero.app.component` names the exported React component
+- production builds should emit `dist/ui/remoteEntry.js`
+- production `base` should be relative (`'./'`) so chunk URLs resolve under
+  `sero-ext://`
 
-┌─ Renderer ───────────────────────────────────────────────┐
-│                                                          │
-│  App Switcher (MainSidebar):                             │
-│    [Explorer] [Todo] [...]  ← discovered from manifests    │
-│                                                          │
-│  When user selects Todo:                                 │
-│    Module federation loads remoteEntry.js                 │
-│    Mounts TodoApp in main area                            │
-│    useAppState reads/watches via AppStateManager IPC      │
-│                                                          │
-│  ChatPanel (unchanged):                                  │
-│    Agent tool calls visible. User also sees items         │
-│    appear in TodoApp simultaneously.                     │
-│                                                          │
-└──────────────────────────────────────────────────────────┘
-```
+## Discovery Model
 
-## The Full Loop
+Sero discovers apps by scanning package manifests for `sero.app`.
 
-1. User installs: `pi install npm:@sero/todo`
-2. **Pi CLI:** extension loads, agent has `todo` tool, `/todos` works. No UI.
-3. **Sero:** extension loads the same way. ALSO reads `sero.app` manifest →
-   registers Todo in app switcher.
-4. User clicks Todo → module federation loads TodoApp → renders from state.json
-5. User adds via UI → `useAppState` writes state.json → UI re-renders
-6. Agent calls `todo add` → writes state.json → file watcher → UI re-renders
-7. Both paths write the same file. Both see each other's changes instantly.
+That includes:
 
-## Build Order
+- built-in monorepo packages/apps
+- built-in monorepo plugins
+- installed optional plugins in `~/.sero-ui/agent/packages/`
+- explicitly configured package paths from settings
 
-1. AppStateManager (main process — generic file watcher + read/write IPC)
-2. `useAppState` hook (renderer — reads/watches/writes via IPC)
-3. Todo extension (standard Pi extension, file-based state)
-4. Todo UI (React component using `useAppState`)
-5. App discovery + mount (scan manifests, module federation loader)
+So for normal app/plugin work, registration is manifest-driven — not something
+that should require hand-editing random Electron files.
 
-## Tutorial
+## End-to-End Flow
 
-For a step-by-step guide to building a new app use the `sero-plugin` skill
+A typical flow looks like this:
 
-## Open Decisions
+1. A package is available to Sero (built-in or installed as a plugin)
+2. Pi loads its extension from `pi.extensions`
+3. Sero discovers `sero.app` and adds the app to the runtime registry
+4. The user opens the app
+5. Sero loads the UI remote and mounts the exported component
+6. The UI reads and watches the state file via `useAppState()`
+7. The extension and the UI both read/write the same durable JSON state
+8. Changes from either side propagate back to the other
 
-- **State file location** — `.sero/apps/<id>/state.json` relative to workspace
-  cwd. Configurable per-app in manifest.
-- **Multiple state files** — Some apps may want a directory. `stateFile`
-  could support patterns. `useAppState` could accept a path.
-- **State file location for non-workspace apps** — Global apps could use
-  `~/.sero-ui/apps/<id>/state.json`.
+## Relationship to Plugin Docs
+
+Use this document when you want to understand:
+
+- what a Sero app is conceptually
+- how extension + UI + state fit together
+- how `useAppState()` and the app runtime work
+- how discovery and mounting work at runtime
+
+Use the plugin docs when you want to know:
+
+- how to package or publish an app as a plugin
+- what `sero.plugin` does
+- what `sero.providers` does for provider plugins
+- how installation, updates, and uninstall work
+
+## Tutorial / Next Step
+
+For a step-by-step implementation walkthrough, use the `sero-plugin` skill and
+then refer to:
+
+- `docs/plugins/guide.md` for author-facing packaging guidance
+- `docs/plugins/technical.md` for host/plugin-system internals

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -3,7 +3,7 @@
 How to create, distribute, install, and manage Sero plugins.
 
 For internal architecture details, see
-[plugins-technical.md](plugins-technical.md).
+[technical.md](technical.md).
 
 ## Contents
 
@@ -106,9 +106,9 @@ deleted — you can clean those up manually if desired.
 
 ## Creating a Plugin
 
-Any existing Sero app can become a plugin. Follow the
-[Building Sero Apps] For a step-by-step guide to building a new app use the `sero-plugin` skill, then add
-the plugin metadata described below.
+Any existing Sero app can become a plugin. For a step-by-step guide to building
+a new app, use the `sero-plugin` skill, then add the plugin metadata described
+below.
 
 ### 1. Start with a standard Sero app
 
@@ -168,6 +168,47 @@ Add a `sero.plugin` key to your `package.json` alongside `sero.app`:
 }
 ```
 
+If your plugin registers one or more custom model providers via
+`pi.registerProvider(...)`, also add a `sero.providers` section so the Electron
+host can discover provider metadata directly from the plugin package instead of
+hardcoding it:
+
+```json
+{
+  "sero": {
+    "providers": [
+      {
+        "id": "alibaba-coding-plan",
+        "name": "Alibaba Coding Plan",
+        "logo": "alibaba-cloud",
+        "auth": {
+          "type": "apiKey",
+          "envVar": "ALIBABA_CODING_PLAN_KEY"
+        },
+        "defaults": {
+          "LOW": "qwen3-coder-plus",
+          "MED": "qwen3-coder-plus",
+          "HIGH": "qwen3.5-plus"
+        }
+      }
+    ]
+  }
+}
+```
+
+This metadata is used for:
+
+- the auth dialog API-key provider list
+- provider display names and logos in model pickers
+- environment-variable lookup for plugin-defined providers
+- onboarding / tier default suggestions for plugin-defined models
+
+When you do this, keep the extension's provider ID and env var in sync with the
+manifest entry. For example, if your manifest declares
+`id: "alibaba-coding-plan"` and `envVar: "ALIBABA_CODING_PLAN_KEY"`, your
+extension should also register `alibaba-coding-plan` and resolve the same env
+var when calling `pi.registerProvider(...)`.
+
 ### 3. Build and test locally
 
 For **npm distribution**, build a ready-to-install plugin bundle:
@@ -215,8 +256,8 @@ restarting Sero.
 
 ### `sero.app` (required)
 
-The standard Sero app manifest. See the
-For a step-by-step guide to building a new app use the `sero-plugin` skill
+The standard Sero app manifest used by all Sero apps and plugins. For a
+step-by-step guide to building a new app, use the `sero-plugin` skill.
 
 ### `sero.plugin` (required for plugins)
 
@@ -227,6 +268,32 @@ For a step-by-step guide to building a new app use the `sero-plugin` skill
 | `minSeroVersion` | string | No | Minimum compatible Sero version (semver). |
 | `preBuilt` | boolean | No | Controls install behavior for git/local plugins. Set `true` only when the package already ships a valid `dist/ui/` bundle and should be installed without rebuilding. Set `false` or omit it for source repos that Sero should build locally on install. npm bundles are always expected to ship pre-built artifacts. |
 | `bridgeTools` | boolean \| string[] | No | Controls whether plugin tools are bridged into `sero-cli`. Omit or set `true` to bridge all tools; `false` to bridge none; or provide a list of tool names to bridge selectively. |
+
+### `sero.providers` (optional)
+
+Declare this when a plugin registers one or more custom model providers with
+`pi.registerProvider(...)` and wants the Electron host to surface matching
+provider metadata automatically.
+
+Each entry supports:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Provider ID. Must match the ID passed to `pi.registerProvider(...)`. |
+| `name` | string | No | Display name shown in auth UI and model selectors. Defaults to a title-cased version of `id`. |
+| `logo` | string | No | Logo slug or absolute URL used by the host UI. Slugs resolve to `https://models.dev/logos/<slug>.svg`. |
+| `auth.type` | `"apiKey"` | No | Declares that the provider authenticates via API key. |
+| `auth.envVar` | string | No | Environment variable name the host should check for this provider. |
+| `defaults` | object | No | Optional default LOW/MED/HIGH model IDs for onboarding and tier suggestions. |
+
+Notes:
+
+- `sero.providers` is metadata for the Electron host. It does **not** register
+  models by itself — your extension still needs to call `pi.registerProvider(...)`.
+- Keep `id`, auth env var, and default model IDs aligned with the provider your
+  extension actually registers.
+- Use plugin-owned env var names such as `ALIBABA_CODING_PLAN_KEY` rather than
+  reusing ambiguous upstream product names where possible.
 
 ### Categories
 
@@ -411,7 +478,10 @@ commands will still work through the agent.
 
 A Pi package works in the Pi CLI. A Sero plugin adds a `sero.app` manifest
 (for sidebar + UI) and a `sero.plugin` manifest (for distribution metadata).
-Every Sero plugin is also a valid Pi package — it works in both environments.
+Plugins that register custom model providers can also add `sero.providers` so
+Sero's Electron host can surface provider auth and model metadata without core
+changes. Every Sero plugin is also a valid Pi package — it works in both
+environments.
 
 ### Can third-party plugins be installed?
 

--- a/docs/plugins/technical.md
+++ b/docs/plugins/technical.md
@@ -2,7 +2,7 @@
 
 Internal documentation for Sero developers working on the plugin system.
 For user-facing plugin authoring instructions, see
-[plugins-guide.md](plugins-guide.md).
+[guide.md](guide.md).
 
 ## Contents
 
@@ -43,7 +43,8 @@ The architecture leverages existing infrastructure:
 - **All extensions are independent** — zero cross-package dependencies
 
 The plugin system adds: a manager for lifecycle operations, IPC bridging,
-dynamic MF registration, and manifest-driven tool bridging.
+dynamic MF registration, manifest-driven tool bridging, and optional
+plugin-defined provider metadata via `sero.providers`.
 
 ## Architecture
 
@@ -73,6 +74,7 @@ dynamic MF registration, and manifest-driven tool bridging.
 │  ext-protocol.ts   → sero-ext://<id>/...    │
 │  federation-registry.ts → MF remote load    │
 │  cli/index.ts      → tool bridging          │
+│  package-provider-manifests.ts → host UI    │
 └─────────────────────────────────────────────┘
 ```
 
@@ -135,12 +137,12 @@ must be declared in the plugin's own `dependencies` and staged alongside the
 plugin instead of relying on workspace hoisting or desktop-app-level
 dependencies.
 
-plugin declares a UI.
-
 ## Plugin Manifest
 
 Plugins declare metadata via `sero.plugin` in `package.json`, alongside the
-standard `sero.app` manifest:
+standard `sero.app` manifest. Plugins that register custom model providers can
+also declare optional `sero.providers` metadata so the Electron host can render
+provider-specific auth and model UI without hardcoded app-level logic:
 
 ```json
 {
@@ -159,7 +161,23 @@ standard `sero.app` manifest:
       "tags": ["todo", "tasks", "productivity"],
       "minSeroVersion": "0.1.0",
       "preBuilt": true
-    }
+    },
+    "providers": [
+      {
+        "id": "alibaba-coding-plan",
+        "name": "Alibaba Coding Plan",
+        "logo": "alibaba-cloud",
+        "auth": {
+          "type": "apiKey",
+          "envVar": "ALIBABA_CODING_PLAN_KEY"
+        },
+        "defaults": {
+          "LOW": "qwen3-coder-plus",
+          "MED": "qwen3-coder-plus",
+          "HIGH": "qwen3.5-plus"
+        }
+      }
+    ]
   }
 }
 ```
@@ -173,6 +191,30 @@ standard `sero.app` manifest:
 | `minSeroVersion` | `string?` | Minimum Sero version required. Used for compatibility checks. |
 | `preBuilt` | `boolean?` | Controls git/local install behavior. `true` means the package already includes a valid pre-built UI bundle; `false`/omitted means Sero rebuilds it locally during install. npm bundles are always expected to ship pre-built artifacts. |
 | `bridgeTools` | `boolean \| string[]` | Controls manifest-driven CLI bridging for plugin tools. `true`/omitted bridges all plugin tools, `false` bridges none, and `string[]` bridges only the named tools. |
+
+### `sero.providers` Fields
+
+Use this optional manifest when a plugin extension registers custom providers via
+`pi.registerProvider(...)` and wants the desktop host to discover matching
+provider metadata from the plugin package itself.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `string` | Provider ID. Must match the ID passed to `pi.registerProvider(...)`. |
+| `name` | `string?` | Display name for auth UI and model selectors. Defaults to a title-cased provider ID. |
+| `logo` | `string?` | Logo slug or absolute URL. Slugs resolve through `models.dev`. |
+| `auth.type` | `"apiKey"` | Declares API-key auth for this provider. |
+| `auth.envVar` | `string?` | Environment variable the host should check for auth. |
+| `defaults` | `{ LOW?, MED?, HIGH? }` | Optional per-tier default model IDs used by onboarding and model tier suggestions. |
+
+Notes:
+
+- `sero.providers` is host metadata only. The plugin extension still owns the
+  runtime provider registration.
+- Keep `id`, auth env var, and default model IDs aligned with the provider the
+  extension actually registers.
+- Prefer plugin-owned env var names such as `ALIBABA_CODING_PLAN_KEY` over
+  ambiguous upstream product names when exposing provider auth to users.
 
 ### Types
 
@@ -254,6 +296,23 @@ lives at `<workspace>/.sero/apps/<id>/state.json`; global state lives at
 
 Plugins are just regular app packages in location 3. No special discovery
 logic was needed — the existing infrastructure handles it.
+
+### Provider manifest discovery
+
+The desktop host also scans plugin `package.json` files for `sero.providers`.
+That metadata is consumed by shared host helpers so optional provider plugins
+can fully describe themselves without adding provider-specific conditionals to
+Electron code.
+
+Current host uses of `sero.providers` include:
+
+- API-key provider list in the auth dialog
+- provider display names and logos in model UIs
+- environment-variable lookup for plugin-defined providers
+- provider tier defaults used by onboarding / suggestions
+
+This keeps optional provider plugins self-contained: uninstalling the plugin
+removes both the extension and the host-visible provider metadata.
 
 ### `isPlugin` Flag
 
@@ -398,8 +457,15 @@ apps/desktop/
 │   │   └── security.ts         # Safe plugin ids and install paths
 │   ├── ipc/
 │   │   └── plugins.ts          # IPC handlers
-│   └── preload/
-│       └── plugins.ts          # Preload bridge
+│   ├── preload/
+│   │   └── plugins.ts          # Preload bridge
+│   └── shared/
+│       ├── auth/
+│       │   └── provider-catalog.ts         # Built-in + plugin API-key providers
+│       ├── providers/
+│       │   └── package-provider-manifests.ts # Reads sero.providers metadata
+│       └── settings/
+│           └── provider-model-defaults.ts  # Static + plugin-defined tier defaults
 ├── src/
 │   ├── types/
 │   │   ├── ipc.ts              # Re-exports plugin types

--- a/plugins/sero-alibaba-plugin/extension/index.ts
+++ b/plugins/sero-alibaba-plugin/extension/index.ts
@@ -5,11 +5,14 @@
  * Set DASHSCOPE_API_KEY in the environment, or add via Sero auth settings.
  *
  * Provider ID: alibaba-cloud
- * Models: Qwen3 (current generation) + Qwen2.5 (legacy, broad API access)
  *
- * Coding Plan models: qwen3.5-plus, qwen3-max-2026-01-23,
- *                     qwen3-coder-next, qwen3-coder-plus
- * Full API key:       all models below
+ * Coding Plan models (all brands via single DashScope API key):
+ *   Qwen:    qwen3.5-plus, qwen3-max-2026-01-23, qwen3-coder-next, qwen3-coder-plus
+ *   Zhipu:   glm-5, glm-4.7
+ *   Kimi:    kimi-k2.5
+ *   MiniMax: MiniMax-M2.5
+ *
+ * Full API key also unlocks legacy Qwen2.5 models listed at the bottom.
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
@@ -20,9 +23,8 @@ export default function (pi: ExtensionAPI) {
     apiKey: 'DASHSCOPE_API_KEY',
     api: 'openai-completions',
     models: [
-      // ── Qwen3 Coder (Coding Plan + API key) ───────────────────────────
+      // ── Qwen3 Coder ───────────────────────────────────────────────────
       {
-        // Next-gen flagship coder — not yet GA, may require allowlist
         id: 'qwen3-coder-next',
         name: 'Qwen3 Coder Next',
         reasoning: false,
@@ -50,7 +52,7 @@ export default function (pi: ExtensionAPI) {
           maxTokensField: 'max_tokens',
         },
       },
-      // ── Qwen3.5 (Coding Plan + API key) ───────────────────────────────
+      // ── Qwen3.5 ───────────────────────────────────────────────────────
       {
         // Vision + Deep Thinking, 1M context
         id: 'qwen3.5-plus',
@@ -74,9 +76,8 @@ export default function (pi: ExtensionAPI) {
           thinkingFormat: 'qwen',
         },
       },
-      // ── Qwen3 General (Coding Plan + API key) ─────────────────────────
+      // ── Qwen3 General ─────────────────────────────────────────────────
       {
-        // Deep Thinking, 262K context
         id: 'qwen3-max-2026-01-23',
         name: 'Qwen3 Max',
         reasoning: true,
@@ -99,7 +100,6 @@ export default function (pi: ExtensionAPI) {
         },
       },
       {
-        // Balanced: thinking optional, 128K context
         id: 'qwen3-plus',
         name: 'Qwen3 Plus',
         reasoning: true,
@@ -122,7 +122,6 @@ export default function (pi: ExtensionAPI) {
         },
       },
       {
-        // Fast + cheap, 1M context
         id: 'qwen3-turbo',
         name: 'Qwen3 Turbo',
         reasoning: false,
@@ -134,6 +133,97 @@ export default function (pi: ExtensionAPI) {
           supportsDeveloperRole: false,
           supportsReasoningEffort: false,
           maxTokensField: 'max_tokens',
+        },
+      },
+      // ── Zhipu GLM (via DashScope Coding Plan) ─────────────────────────
+      {
+        id: 'glm-5',
+        name: 'GLM-5',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 2.0, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
+        },
+      },
+      {
+        id: 'glm-4.7',
+        name: 'GLM-4.7',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 1.0, output: 3.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
+        },
+      },
+      // ── Kimi (via DashScope Coding Plan) ──────────────────────────────
+      {
+        id: 'kimi-k2.5',
+        name: 'Kimi K2.5',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 2.0, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
+        },
+      },
+      // ── MiniMax (via DashScope Coding Plan) ───────────────────────────
+      {
+        id: 'MiniMax-M2.5',
+        name: 'MiniMax M2.5',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 2.0, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
         },
       },
       // ── Qwen2.5 legacy (full API key only) ────────────────────────────

--- a/plugins/sero-alibaba-plugin/extension/index.ts
+++ b/plugins/sero-alibaba-plugin/extension/index.ts
@@ -1,0 +1,115 @@
+/**
+ * Alibaba Cloud Extension — registers the Alibaba Cloud (DashScope) provider.
+ *
+ * Uses the OpenAI-compatible DashScope API (international endpoint).
+ * Set DASHSCOPE_API_KEY in the environment, or add via Sero auth settings.
+ *
+ * Provider ID: alibaba-cloud
+ * Models: Qwen coding + general models
+ */
+
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+export default function (pi: ExtensionAPI) {
+  pi.registerProvider('alibaba-cloud', {
+    baseUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+    apiKey: 'DASHSCOPE_API_KEY',
+    api: 'openai-completions',
+    models: [
+      // ── Qwen Coder (coding-optimised) ──────────────────────────────────
+      {
+        id: 'qwen-coder-plus-latest',
+        name: 'Qwen Coder Plus',
+        reasoning: false,
+        input: ['text', 'image'],
+        cost: { input: 3.5, output: 7.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+      {
+        id: 'qwen-coder-turbo-latest',
+        name: 'Qwen Coder Turbo',
+        reasoning: false,
+        input: ['text', 'image'],
+        cost: { input: 0.5, output: 2.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+      // ── Qwen General (with reasoning) ─────────────────────────────────
+      {
+        id: 'qwen-max-latest',
+        name: 'Qwen Max',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 4.0, output: 12.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32768,
+        maxTokens: 8192,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
+        },
+      },
+      {
+        id: 'qwen-plus-latest',
+        name: 'Qwen Plus',
+        reasoning: false,
+        input: ['text', 'image'],
+        cost: { input: 0.8, output: 2.4, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 8192,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+      {
+        id: 'qwen-turbo-latest',
+        name: 'Qwen Turbo',
+        reasoning: false,
+        input: ['text'],
+        cost: { input: 0.05, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 8192,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+      {
+        id: 'qwen-long',
+        name: 'Qwen Long',
+        reasoning: false,
+        input: ['text'],
+        cost: { input: 0.05, output: 0.14, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 6000,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+    ],
+  });
+}

--- a/plugins/sero-alibaba-plugin/extension/index.ts
+++ b/plugins/sero-alibaba-plugin/extension/index.ts
@@ -1,29 +1,76 @@
 /**
- * Alibaba Cloud Extension — registers the Alibaba Cloud (DashScope) provider.
+ * Alibaba Coding Plan Extension — registers Coding Plan models.
  *
- * Uses the OpenAI-compatible DashScope API (international endpoint).
- * Set DASHSCOPE_API_KEY in the environment, or add via Sero auth settings.
+ * Uses Alibaba Coding Plan's OpenAI-compatible endpoint.
+ * Authenticate by either:
+ *   1. Saving an API key in Sero auth settings for provider `alibaba-coding-plan`, or
+ *   2. Setting ALIBABA_CODING_PLAN_KEY in the environment.
  *
- * Provider ID: alibaba-cloud
+ * Provider ID: alibaba-coding-plan
  *
- * Coding Plan models (all brands via single DashScope API key):
+ * Coding Plan models:
  *   Qwen:    qwen3.5-plus, qwen3-max-2026-01-23, qwen3-coder-next, qwen3-coder-plus
  *   Zhipu:   glm-5, glm-4.7
  *   Kimi:    kimi-k2.5
  *   MiniMax: MiniMax-M2.5
- *
- * Full API key also unlocks legacy Qwen2.5 models listed at the bottom.
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 
+const REASONING_EFFORT_MAP = {
+  minimal: 'false',
+  low: 'false',
+  medium: 'true',
+  high: 'true',
+  xhigh: 'true',
+} as const;
+
+function textCompat() {
+  return {
+    supportsDeveloperRole: false,
+    supportsReasoningEffort: false,
+    maxTokensField: 'max_tokens' as const,
+  };
+}
+
+function reasoningCompat() {
+  return {
+    supportsDeveloperRole: false,
+    supportsReasoningEffort: true,
+    reasoningEffortMap: REASONING_EFFORT_MAP,
+    maxTokensField: 'max_tokens' as const,
+    thinkingFormat: 'qwen' as const,
+  };
+}
+
 export default function (pi: ExtensionAPI) {
-  pi.registerProvider('alibaba-cloud', {
-    baseUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
-    apiKey: 'DASHSCOPE_API_KEY',
+  pi.registerProvider('alibaba-coding-plan', {
+    baseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
+    // Shell-resolved env lookup keeps the provider hidden until the user has
+    // either saved a key in auth.json or actually exported ALIBABA_CODING_PLAN_KEY.
+    apiKey: '!printenv ALIBABA_CODING_PLAN_KEY',
     api: 'openai-completions',
     models: [
-      // ── Qwen3 Coder ───────────────────────────────────────────────────
+      {
+        id: 'qwen3.5-plus',
+        name: 'Qwen3.5 Plus',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 1.5, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 65536,
+        compat: reasoningCompat(),
+      },
+      {
+        id: 'qwen3-max-2026-01-23',
+        name: 'Qwen3 Max',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 1.2, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262144,
+        maxTokens: 16384,
+        compat: reasoningCompat(),
+      },
       {
         id: 'qwen3-coder-next',
         name: 'Qwen3 Coder Next',
@@ -32,11 +79,7 @@ export default function (pi: ExtensionAPI) {
         cost: { input: 3.5, output: 7.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 262144,
         maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
+        compat: textCompat(),
       },
       {
         id: 'qwen3-coder-plus',
@@ -46,96 +89,8 @@ export default function (pi: ExtensionAPI) {
         cost: { input: 3.5, output: 7.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 262144,
         maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
+        compat: textCompat(),
       },
-      // ── Qwen3.5 ───────────────────────────────────────────────────────
-      {
-        // Vision + Deep Thinking, 1M context
-        id: 'qwen3.5-plus',
-        name: 'Qwen3.5 Plus',
-        reasoning: true,
-        input: ['text', 'image'],
-        cost: { input: 1.5, output: 6.0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 65536,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
-      },
-      // ── Qwen3 General ─────────────────────────────────────────────────
-      {
-        id: 'qwen3-max-2026-01-23',
-        name: 'Qwen3 Max',
-        reasoning: true,
-        input: ['text'],
-        cost: { input: 1.2, output: 6.0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 262144,
-        maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
-      },
-      {
-        id: 'qwen3-plus',
-        name: 'Qwen3 Plus',
-        reasoning: true,
-        input: ['text'],
-        cost: { input: 0.4, output: 1.2, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 131072,
-        maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
-      },
-      {
-        id: 'qwen3-turbo',
-        name: 'Qwen3 Turbo',
-        reasoning: false,
-        input: ['text'],
-        cost: { input: 0.05, output: 0.2, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
-      },
-      // ── Zhipu GLM (via DashScope Coding Plan) ─────────────────────────
       {
         id: 'glm-5',
         name: 'GLM-5',
@@ -144,19 +99,7 @@ export default function (pi: ExtensionAPI) {
         cost: { input: 2.0, output: 6.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 131072,
         maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
+        compat: reasoningCompat(),
       },
       {
         id: 'glm-4.7',
@@ -166,21 +109,8 @@ export default function (pi: ExtensionAPI) {
         cost: { input: 1.0, output: 3.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 131072,
         maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
+        compat: reasoningCompat(),
       },
-      // ── Kimi (via DashScope Coding Plan) ──────────────────────────────
       {
         id: 'kimi-k2.5',
         name: 'Kimi K2.5',
@@ -189,21 +119,8 @@ export default function (pi: ExtensionAPI) {
         cost: { input: 2.0, output: 6.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 1000000,
         maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
+        compat: reasoningCompat(),
       },
-      // ── MiniMax (via DashScope Coding Plan) ───────────────────────────
       {
         id: 'MiniMax-M2.5',
         name: 'MiniMax M2.5',
@@ -212,98 +129,7 @@ export default function (pi: ExtensionAPI) {
         cost: { input: 2.0, output: 6.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 1000000,
         maxTokens: 16384,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
-      },
-      // ── Qwen2.5 legacy (full API key only) ────────────────────────────
-      {
-        id: 'qwen-coder-plus-latest',
-        name: 'Qwen2.5 Coder Plus',
-        reasoning: false,
-        input: ['text'],
-        cost: { input: 3.5, output: 7.0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 131072,
-        maxTokens: 8192,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
-      },
-      {
-        id: 'qwen-coder-turbo-latest',
-        name: 'Qwen2.5 Coder Turbo',
-        reasoning: false,
-        input: ['text'],
-        cost: { input: 0.5, output: 2.0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 131072,
-        maxTokens: 8192,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
-      },
-      {
-        id: 'qwen-max-latest',
-        name: 'Qwen2.5 Max',
-        reasoning: true,
-        input: ['text', 'image'],
-        cost: { input: 4.0, output: 12.0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 32768,
-        maxTokens: 8192,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: true,
-          reasoningEffortMap: {
-            minimal: 'false',
-            low: 'false',
-            medium: 'true',
-            high: 'true',
-            xhigh: 'true',
-          },
-          maxTokensField: 'max_tokens',
-          thinkingFormat: 'qwen',
-        },
-      },
-      {
-        id: 'qwen-plus-latest',
-        name: 'Qwen2.5 Plus',
-        reasoning: false,
-        input: ['text', 'image'],
-        cost: { input: 0.8, output: 2.4, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 131072,
-        maxTokens: 8192,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
-      },
-      {
-        id: 'qwen-long',
-        name: 'Qwen2.5 Long',
-        reasoning: false,
-        input: ['text'],
-        cost: { input: 0.05, output: 0.14, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 6000,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
+        compat: reasoningCompat(),
       },
     ],
   });

--- a/plugins/sero-alibaba-plugin/extension/index.ts
+++ b/plugins/sero-alibaba-plugin/extension/index.ts
@@ -5,7 +5,11 @@
  * Set DASHSCOPE_API_KEY in the environment, or add via Sero auth settings.
  *
  * Provider ID: alibaba-cloud
- * Models: Qwen coding + general models
+ * Models: Qwen3 (current generation) + Qwen2.5 (legacy, broad API access)
+ *
+ * Coding Plan models: qwen3.5-plus, qwen3-max-2026-01-23,
+ *                     qwen3-coder-next, qwen3-coder-plus
+ * Full API key:       all models below
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
@@ -16,12 +20,128 @@ export default function (pi: ExtensionAPI) {
     apiKey: 'DASHSCOPE_API_KEY',
     api: 'openai-completions',
     models: [
-      // ── Qwen Coder (coding-optimised) ──────────────────────────────────
+      // ── Qwen3 Coder (Coding Plan + API key) ───────────────────────────
+      {
+        // Next-gen flagship coder — not yet GA, may require allowlist
+        id: 'qwen3-coder-next',
+        name: 'Qwen3 Coder Next',
+        reasoning: false,
+        input: ['text'],
+        cost: { input: 3.5, output: 7.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262144,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+      {
+        id: 'qwen3-coder-plus',
+        name: 'Qwen3 Coder Plus',
+        reasoning: false,
+        input: ['text'],
+        cost: { input: 3.5, output: 7.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262144,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+      // ── Qwen3.5 (Coding Plan + API key) ───────────────────────────────
+      {
+        // Vision + Deep Thinking, 1M context
+        id: 'qwen3.5-plus',
+        name: 'Qwen3.5 Plus',
+        reasoning: true,
+        input: ['text', 'image'],
+        cost: { input: 1.5, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 65536,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
+        },
+      },
+      // ── Qwen3 General (Coding Plan + API key) ─────────────────────────
+      {
+        // Deep Thinking, 262K context
+        id: 'qwen3-max-2026-01-23',
+        name: 'Qwen3 Max',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 1.2, output: 6.0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 262144,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
+        },
+      },
+      {
+        // Balanced: thinking optional, 128K context
+        id: 'qwen3-plus',
+        name: 'Qwen3 Plus',
+        reasoning: true,
+        input: ['text'],
+        cost: { input: 0.4, output: 1.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 131072,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: true,
+          reasoningEffortMap: {
+            minimal: 'false',
+            low: 'false',
+            medium: 'true',
+            high: 'true',
+            xhigh: 'true',
+          },
+          maxTokensField: 'max_tokens',
+          thinkingFormat: 'qwen',
+        },
+      },
+      {
+        // Fast + cheap, 1M context
+        id: 'qwen3-turbo',
+        name: 'Qwen3 Turbo',
+        reasoning: false,
+        input: ['text'],
+        cost: { input: 0.05, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 16384,
+        compat: {
+          supportsDeveloperRole: false,
+          supportsReasoningEffort: false,
+          maxTokensField: 'max_tokens',
+        },
+      },
+      // ── Qwen2.5 legacy (full API key only) ────────────────────────────
       {
         id: 'qwen-coder-plus-latest',
-        name: 'Qwen Coder Plus',
+        name: 'Qwen2.5 Coder Plus',
         reasoning: false,
-        input: ['text', 'image'],
+        input: ['text'],
         cost: { input: 3.5, output: 7.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 131072,
         maxTokens: 8192,
@@ -33,9 +153,9 @@ export default function (pi: ExtensionAPI) {
       },
       {
         id: 'qwen-coder-turbo-latest',
-        name: 'Qwen Coder Turbo',
+        name: 'Qwen2.5 Coder Turbo',
         reasoning: false,
-        input: ['text', 'image'],
+        input: ['text'],
         cost: { input: 0.5, output: 2.0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 131072,
         maxTokens: 8192,
@@ -45,10 +165,9 @@ export default function (pi: ExtensionAPI) {
           maxTokensField: 'max_tokens',
         },
       },
-      // ── Qwen General (with reasoning) ─────────────────────────────────
       {
         id: 'qwen-max-latest',
-        name: 'Qwen Max',
+        name: 'Qwen2.5 Max',
         reasoning: true,
         input: ['text', 'image'],
         cost: { input: 4.0, output: 12.0, cacheRead: 0, cacheWrite: 0 },
@@ -70,7 +189,7 @@ export default function (pi: ExtensionAPI) {
       },
       {
         id: 'qwen-plus-latest',
-        name: 'Qwen Plus',
+        name: 'Qwen2.5 Plus',
         reasoning: false,
         input: ['text', 'image'],
         cost: { input: 0.8, output: 2.4, cacheRead: 0, cacheWrite: 0 },
@@ -83,22 +202,8 @@ export default function (pi: ExtensionAPI) {
         },
       },
       {
-        id: 'qwen-turbo-latest',
-        name: 'Qwen Turbo',
-        reasoning: false,
-        input: ['text'],
-        cost: { input: 0.05, output: 0.2, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 1000000,
-        maxTokens: 8192,
-        compat: {
-          supportsDeveloperRole: false,
-          supportsReasoningEffort: false,
-          maxTokensField: 'max_tokens',
-        },
-      },
-      {
         id: 'qwen-long',
-        name: 'Qwen Long',
+        name: 'Qwen2.5 Long',
         reasoning: false,
         input: ['text'],
         cost: { input: 0.05, output: 0.14, cacheRead: 0, cacheWrite: 0 },

--- a/plugins/sero-alibaba-plugin/extension/tsconfig.json
+++ b/plugins/sero-alibaba-plugin/extension/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../packages/tsconfig.extension.json",
+  "include": ["./**/*"]
+}

--- a/plugins/sero-alibaba-plugin/package.json
+++ b/plugins/sero-alibaba-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sero-ai/plugin-alibaba",
   "version": "0.1.0",
-  "description": "Alibaba Cloud (DashScope) LLM provider for Sero — Qwen models via OpenAI-compatible API",
+  "description": "Alibaba Coding Plan provider for Sero — Qwen, GLM, Kimi, and MiniMax via OpenAI-compatible API",
   "keywords": [
     "pi-package"
   ],
@@ -11,6 +11,24 @@
   "pi": {
     "extensions": [
       "./extension/index.ts"
+    ]
+  },
+  "sero": {
+    "providers": [
+      {
+        "id": "alibaba-coding-plan",
+        "name": "Alibaba Coding Plan",
+        "logo": "alibaba-cloud",
+        "auth": {
+          "type": "apiKey",
+          "envVar": "ALIBABA_CODING_PLAN_KEY"
+        },
+        "defaults": {
+          "LOW": "qwen3-coder-plus",
+          "MED": "qwen3-coder-plus",
+          "HIGH": "qwen3.5-plus"
+        }
+      }
     ]
   },
   "peerDependencies": {

--- a/plugins/sero-alibaba-plugin/package.json
+++ b/plugins/sero-alibaba-plugin/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@sero-ai/plugin-alibaba",
+  "version": "0.1.0",
+  "description": "Alibaba Cloud (DashScope) LLM provider for Sero — Qwen models via OpenAI-compatible API",
+  "keywords": [
+    "pi-package"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit -p extension/tsconfig.json"
+  },
+  "pi": {
+    "extensions": [
+      "./extension/index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "catalog:peer"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,19 @@ importers:
         specifier: 'catalog:'
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
+  plugins/sero-alibaba-plugin:
+    dependencies:
+      '@mariozechner/pi-coding-agent':
+        specifier: catalog:peer
+        version: 0.61.1
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.11
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+
   plugins/sero-context-plugin:
     dependencies:
       '@mariozechner/pi-ai':
@@ -12448,6 +12461,38 @@ snapshots:
       - ws
       - zod
 
+  '@mariozechner/pi-coding-agent@0.61.1(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.61.1(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.61.1(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.61.1
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.3
+      extract-zip: 2.0.1
+      file-type: 21.3.2
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.4
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      undici: 7.24.2
+      yaml: 2.8.2
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.2
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-tui@0.61.1':
     dependencies:
       '@types/mime-types': 2.1.4
@@ -15014,7 +15059,7 @@ snapshots:
 
   '@types/qrcode@1.5.6':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 22.19.15
 
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
@@ -15080,7 +15125,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.11
+      '@types/node': 22.19.15
 
   '@types/yauzl@2.10.3':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,7 +595,7 @@ importers:
     dependencies:
       '@mariozechner/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.61.1
+        version: 0.61.1(ws@8.19.0)(zod@3.25.76)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -12434,38 +12434,6 @@ snapshots:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.61.1(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.61.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.3
-      extract-zip: 2.0.1
-      file-type: 21.3.2
-      glob: 13.0.6
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      marked: 15.0.12
-      minimatch: 10.2.4
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      undici: 7.24.2
-      yaml: 2.8.2
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.2
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.61.1(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.61.1(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.61.1(zod@4.3.6)
       '@mariozechner/pi-tui': 0.61.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2


### PR DESCRIPTION
Registers the alibaba-cloud provider via a new Pi extension plugin,
integrating it with the existing Sero auth, model selection, and
provider metadata infrastructure.

New plugin: plugins/sero-alibaba-plugin/
- extension/index.ts: calls pi.registerProvider('alibaba-cloud') with
  Qwen coder + general models using the OpenAI-compatible DashScope
  international endpoint (DASHSCOPE_API_KEY)
- Models: qwen-coder-plus-latest, qwen-coder-turbo-latest,
  qwen-max-latest (reasoning), qwen-plus-latest, qwen-turbo-latest,
  qwen-long

Sero integration:
- provider-catalog.ts: adds alibaba-cloud to API_KEY_PROVIDERS so it
  appears in Auth settings alongside openai, anthropic, kimi-coding, etc.
- provider-metadata.ts: display name "Alibaba Cloud" + logo mapping
- provider-model-defaults.ts: tier defaults — LOW: qwen-coder-turbo,
  MED: qwen-coder-plus, HIGH: qwen-max

https://claude.ai/code/session_01SAMGohKcsjo2tcJQ8dUYb3