### PR TITLE
fix: stabilize Promptfoo eval runner and agent harness

### DIFF
--- a/docs/testing/eval-guide.md
+++ b/docs/testing/eval-guide.md
@@ -54,11 +54,23 @@ These assemble an approximation of the full Sero session prompt by calling the p
 
 **When to run:** Before releases, after SDK upgrades, or when changing agent behavior. Requires `ANTHROPIC_API_KEY` and costs real API tokens.
 
+**Runtime shape of the harness:**
+- Each scenario runs in its own isolated temp workspace under `/tmp/sero-eval-*`
+- The temp workspace is initialised as a clean Git repo so VCS/workspace prompts behave predictably
+- The provider exposes real coding tools (`read`, `bash`, `write`, `edit`) plus a small eval-only `sero-cli` shim for deterministic Sero platform checks
+- Raw extension tools are intentionally hidden during agent evals so CLI scenarios assert against `sero-cli`, not direct tool calls like `todo` or `git_manager`
+
+**Auth behavior:**
+- `pnpm eval` honors `ANTHROPIC_API_KEY` from the shell or from `--env-path .env`
+- The provider applies env credentials as runtime overrides before falling back to `~/.sero-ui/agent/auth.json`
+- This prevents stale OAuth entries in `auth.json` from breaking evals that should use an API key
+
 ## File Layout
 
 ```
 eval/
 ├── seroProvider.ts              # Agent provider (real LLM calls)
+├── evalCli.ts                   # Eval-only sero-cli shim + temp workspace seeding
 ├── snapshotProvider.ts          # Snapshot provider (no LLM calls)
 ├── setup.ts                     # Temp directory helpers
 ├── patch-drizzle.cjs            # Workaround for drizzle-orm async tx bug
@@ -108,7 +120,7 @@ The drizzle-orm patch must be re-applied after installing dependencies:
 node eval/patch-drizzle.cjs
 ```
 
-Both `pnpm eval` and `./eval/run.sh` do this automatically, but if you run `npx promptfoo eval` directly you'll need to apply it first.
+Both `pnpm eval` and `./eval/run.sh` do this automatically. If you need to invoke promptfoo manually, use `node scripts/run-promptfoo.mjs ...` instead of `npx promptfoo ...`; the wrapper runs promptfoo under Electron's Node ABI so `better-sqlite3` stays compatible.
 
 ## Writing New Scenarios
 
@@ -227,6 +239,12 @@ Promptfoo runs each scenario against every listed provider and displays results 
 ## Troubleshooting
 
 **`FOREIGN KEY constraint failed` from promptfoo** — The drizzle-orm patch needs re-applying. Run `node eval/patch-drizzle.cjs` or use `pnpm eval` which applies it automatically.
+
+**`NODE_MODULE_VERSION` / `better-sqlite3` mismatch** — Use `pnpm eval`, `pnpm eval:snapshot`, `pnpm eval:view`, or `node scripts/run-promptfoo.mjs ...`. Those commands run promptfoo under Electron's Node runtime so it matches the `better-sqlite3` binary rebuilt in `postinstall`.
+
+**Anthropic auth still fails even with `ANTHROPIC_API_KEY` set** — A stale `anthropic` OAuth entry in `~/.sero-ui/agent/auth.json` can shadow env-based auth. The eval provider now applies env vars as runtime API-key overrides, but if you still need to debug, inspect `~/.sero-ui/agent/auth.json` and check whether the `anthropic` entry is an expired OAuth token.
+
+**`Cannot find module '@sinclair/typebox'` when running evals** — Run `pnpm install` from the monorepo root. The eval harness uses TypeBox for its local `sero-cli` tool schema, and the dependency is declared at the workspace root.
 
 **`Cannot find module` errors in snapshot provider** — Dynamic imports require `.ts` extensions. If adding a new import, use the full path: `path.join(SERO_ROOT, 'apps/desktop/electron/.../file.ts')`.
 

--- a/docs/testing/promptfoo-eval-plan.md
+++ b/docs/testing/promptfoo-eval-plan.md
@@ -1,7 +1,9 @@
 # Promptfoo Eval Integration Plan
 
-**Status:** Proposed
+**Status:** Implemented (historical design notes)
 **Date:** 2026-04-06
+
+> This document is the original implementation plan. For the current workflow and runtime behavior, use [`docs/testing/eval-guide.md`](./eval-guide.md). The shipped eval harness now runs Promptfoo through `node scripts/run-promptfoo.mjs ...`, applies runtime API-key overrides, and uses `eval/evalCli.ts` for the eval-only `sero-cli` shim.
 
 ## Goal
 

--- a/eval/evalCli.ts
+++ b/eval/evalCli.ts
@@ -1,0 +1,335 @@
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { Type } from '@sinclair/typebox';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+
+const execFileAsync = promisify(execFile);
+
+const EVAL_CLI_PROMPT_BLOCK = `
+
+## Sero CLI
+
+Use \`sero-cli\` for Sero platform actions instead of doing them manually.
+
+Supported commands:
+- \`todo add <text>\`
+- \`todo list\`
+- \`notes add <title> --body <text>\`
+- \`current_time\`
+- \`workspace info\`
+- \`vcs status\`
+
+Aliases also supported:
+- \`note add ...\`
+- \`current-time\`
+- \`git status\` (maps to \`vcs status\`)
+
+You can batch multiple commands in ONE \`sero-cli\` call by putting one command per line.
+Prefer a single batched \`sero-cli\` call when the user asks for multiple Sero actions.
+
+## Eval response rules
+- If you create or edit a file, include the final file contents inline in a fenced code block after doing the tool work.
+- If you use \`sero-cli\`, explicitly say that you used \`sero-cli\` and summarise what it returned.
+- Be concise, but include enough concrete detail for an evaluator to verify the result.
+`;
+
+interface EvalCliTodo {
+  id: number;
+  text: string;
+  completed: boolean;
+}
+
+interface EvalCliNote {
+  id: number;
+  title: string;
+  body: string;
+}
+
+interface EvalCliState {
+  todos: EvalCliTodo[];
+  notes: EvalCliNote[];
+  nextTodoId: number;
+  nextNoteId: number;
+}
+
+interface EvalCliResult {
+  output: string;
+  exitCode: number;
+}
+
+export function createEvalPromptExtensionFactory() {
+  return (pi: ExtensionAPI) => {
+    pi.on('before_agent_start', async (event) => {
+      if (event.systemPrompt.includes('## Sero CLI')) {
+        return { systemPrompt: event.systemPrompt };
+      }
+      return {
+        systemPrompt: `${event.systemPrompt}${EVAL_CLI_PROMPT_BLOCK}`,
+      };
+    });
+  };
+}
+
+export function stripExtensionTools(base: any): any {
+  for (const extension of base.extensions ?? []) {
+    if (extension.tools instanceof Map) {
+      extension.tools.clear();
+    }
+    if (extension.commands instanceof Map) {
+      extension.commands.clear();
+    }
+  }
+  return base;
+}
+
+export async function seedEvalWorkspace(tmpDir: string): Promise<void> {
+  await writeFile(
+    `${tmpDir}/.sero-workspace.json`,
+    `${JSON.stringify(
+      {
+        id: `eval-${randomUUID().slice(0, 8)}`,
+        name: 'Eval Workspace',
+        container: false,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf8',
+  );
+
+  await execFileAsync('git', ['init', '-q'], { cwd: tmpDir });
+  await execFileAsync('git', ['config', 'user.email', 'eval@sero.local'], { cwd: tmpDir });
+  await execFileAsync('git', ['config', 'user.name', 'Sero Eval'], { cwd: tmpDir });
+  await execFileAsync('git', ['add', '.sero-workspace.json'], { cwd: tmpDir });
+  await execFileAsync('git', ['commit', '-qm', 'chore: initialise eval workspace'], {
+    cwd: tmpDir,
+  });
+}
+
+function tokenizeCliInput(input: string): string[] {
+  const matches = input.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\S+/g) ?? [];
+  return matches.map((token) => {
+    if (
+      (token.startsWith('"') && token.endsWith('"'))
+      || (token.startsWith("'") && token.endsWith("'"))
+    ) {
+      return token.slice(1, -1);
+    }
+    return token;
+  });
+}
+
+function pullFlag(tokens: string[], ...names: string[]): string | undefined {
+  for (const name of names) {
+    const index = tokens.indexOf(name);
+    if (index === -1) continue;
+    const value = tokens[index + 1];
+    tokens.splice(index, value ? 2 : 1);
+    return value;
+  }
+  return undefined;
+}
+
+function formatTodoList(todos: EvalCliTodo[]): string {
+  if (todos.length === 0) return 'No todos.';
+  return todos
+    .map((todo) => `#${todo.id} [${todo.completed ? 'x' : ' '}] ${todo.text}`)
+    .join('\n');
+}
+
+function buildHelpText(command?: string): string {
+  switch (command) {
+    case 'todo':
+      return 'todo — Usage: todo add <text> | todo list';
+    case 'notes':
+    case 'note':
+      return 'notes — Usage: notes add <title> --body <text>';
+    case 'workspace':
+      return 'workspace — Usage: workspace info';
+    case 'current_time':
+    case 'current-time':
+      return 'current_time — Usage: current_time';
+    case 'vcs':
+    case 'git':
+      return 'vcs — Usage: vcs status';
+    default:
+      return [
+        'Available commands:',
+        '  todo add <text>',
+        '  todo list',
+        '  notes add <title> --body <text>',
+        '  current_time',
+        '  workspace info',
+        '  vcs status',
+      ].join('\n');
+  }
+}
+
+async function runVcsStatus(tmpDir: string): Promise<EvalCliResult> {
+  try {
+    const { stdout } = await execFileAsync('git', ['status', '--porcelain'], {
+      cwd: tmpDir,
+    });
+    const status = stdout.trim();
+    if (!status) {
+      return {
+        exitCode: 0,
+        output: 'Working copy clean. No uncommitted changes.',
+      };
+    }
+    return {
+      exitCode: 0,
+      output: `Uncommitted changes:\n${status}`,
+    };
+  } catch (error: any) {
+    const message = String(error?.stderr ?? error?.message ?? 'Failed to get git status').trim();
+    return {
+      exitCode: 1,
+      output: `ERROR: ${message}`,
+    };
+  }
+}
+
+async function runEvalCliLine(
+  line: string,
+  state: EvalCliState,
+  tmpDir: string,
+): Promise<EvalCliResult> {
+  const tokens = tokenizeCliInput(line);
+  if (tokens[0] === 'sero') tokens.shift();
+  if (tokens.length === 0) {
+    return { exitCode: 1, output: 'ERROR: No command provided' };
+  }
+
+  const [root, action = ''] = tokens;
+
+  if (root === 'help') {
+    return { exitCode: 0, output: buildHelpText(tokens[1]) };
+  }
+  if (root === 'current_time' || root === 'current-time') {
+    const now = new Date();
+    return {
+      exitCode: 0,
+      output: `Current time: ${now.toLocaleString()} (${now.toISOString()})`,
+    };
+  }
+  if (root === 'workspace') {
+    if (!action || action === 'info') {
+      return {
+        exitCode: 0,
+        output: [
+          'Workspace: Eval Workspace',
+          `Path: ${tmpDir}`,
+          'Runtime: host filesystem',
+          'Containerized: no',
+        ].join('\n'),
+      };
+    }
+    return { exitCode: 1, output: 'ERROR: Usage: workspace info' };
+  }
+  if (root === 'todo') {
+    if (action === 'add') {
+      const text = tokens.slice(2).join(' ').trim();
+      if (!text) return { exitCode: 1, output: 'ERROR: Usage: todo add <text>' };
+      const todo: EvalCliTodo = {
+        id: state.nextTodoId++,
+        text,
+        completed: false,
+      };
+      state.todos.push(todo);
+      return {
+        exitCode: 0,
+        output: `Added todo #${todo.id}: ${todo.text}`,
+      };
+    }
+    if (action === 'list') {
+      return {
+        exitCode: 0,
+        output: formatTodoList(state.todos),
+      };
+    }
+    return { exitCode: 1, output: 'ERROR: Usage: todo add <text> | todo list' };
+  }
+  if (root === 'notes' || root === 'note') {
+    if (action !== 'add') {
+      return { exitCode: 1, output: 'ERROR: Usage: notes add <title> --body <text>' };
+    }
+    const args = tokens.slice(2);
+    const body = pullFlag(args, '--body', '-b') ?? args.slice(1).join(' ').trim();
+    const title = pullFlag(args, '--title') ?? args[0]?.trim();
+    if (!title || !body) {
+      return { exitCode: 1, output: 'ERROR: Usage: notes add <title> --body <text>' };
+    }
+    const note: EvalCliNote = {
+      id: state.nextNoteId++,
+      title,
+      body,
+    };
+    state.notes.push(note);
+    return {
+      exitCode: 0,
+      output: `Added note #${note.id}: ${note.title}\n${note.body}`,
+    };
+  }
+  if (root === 'vcs' || root === 'git') {
+    if (!action || action === 'status') {
+      return runVcsStatus(tmpDir);
+    }
+    return { exitCode: 1, output: 'ERROR: Usage: vcs status' };
+  }
+
+  return {
+    exitCode: 1,
+    output: `ERROR: Unknown command: ${tokens.join(' ')}`,
+  };
+}
+
+export function createEvalSeroCliTool(tmpDir: string) {
+  const state: EvalCliState = {
+    todos: [],
+    notes: [],
+    nextTodoId: 1,
+    nextNoteId: 1,
+  };
+
+  return {
+    name: 'sero-cli',
+    label: 'Sero CLI',
+    description:
+      'Execute Sero platform commands. Supports multi-line input to chain commands (one per line).',
+    parameters: Type.Object({
+      command: Type.String({ description: 'CLI command text to execute' }),
+      timeout: Type.Optional(Type.Number({ description: 'Optional timeout in seconds' })),
+    }),
+    execute: async (_toolCallId: string, params: { command: string }) => {
+      const lines = params.command
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      if (lines.length === 0) {
+        return {
+          content: [{ type: 'text', text: 'ERROR: No command provided' }],
+          details: { exitCode: 1 },
+        };
+      }
+
+      const sections: string[] = [];
+      let finalExitCode = 0;
+
+      for (const line of lines) {
+        const result = await runEvalCliLine(line, state, tmpDir);
+        finalExitCode = result.exitCode;
+        sections.push(lines.length === 1 ? result.output : `$ ${line}\n${result.output}`);
+        if (result.exitCode !== 0) break;
+      }
+
+      return {
+        content: [{ type: 'text', text: sections.join('\n\n') }],
+        details: { exitCode: finalExitCode },
+      };
+    },
+  };
+}

--- a/eval/run.sh
+++ b/eval/run.sh
@@ -16,7 +16,7 @@ node eval/patch-drizzle.cjs
 
 if [[ "${1:-}" == "snapshot" ]]; then
   shift
-  exec npx promptfoo eval --config eval/promptfoo-snapshot.yaml --no-cache "$@"
+  exec node scripts/run-promptfoo.mjs eval --config eval/promptfoo-snapshot.yaml --no-cache "$@"
 else
-  exec npx promptfoo eval "$@"
+  exec node scripts/run-promptfoo.mjs eval "$@"
 fi

--- a/eval/seroProvider.ts
+++ b/eval/seroProvider.ts
@@ -1,11 +1,12 @@
 /**
  * Custom Promptfoo provider that wraps pi-coding-agent's SDK.
  *
- * Creates a headless agent session (no Electron, no containers) and sends
- * the eval prompt through the same code path Sero's desktop app uses.
+ * Creates a headless agent session for evals, with:
+ * - standard coding tools (read/bash/edit/write)
+ * - a minimal eval-only `sero-cli` tool for Sero platform actions
+ * - runtime API-key overrides so env vars beat stale OAuth state
  *
- * Uses dynamic import() because the SDK is ESM-only and promptfoo's tsx
- * loader resolves via CJS by default.
+ * Uses dynamic import() for the SDK because it is ESM-only.
  *
  * SDK event shapes (from agent-subscription.ts):
  *   message_update       → { assistantMessageEvent: { type: 'text_delta', delta } }
@@ -13,8 +14,14 @@
  *   tool_execution_end   → { toolCallId, result, isError }
  */
 import type { ApiProvider, ProviderResponse } from 'promptfoo';
-import { setupTempDir, teardownTempDir } from './setup';
 import { captureSessionSnapshot } from './helpers/sessionSnapshot';
+import {
+  createEvalPromptExtensionFactory,
+  createEvalSeroCliTool,
+  seedEvalWorkspace,
+  stripExtensionTools,
+} from './evalCli';
+import { setupTempDir, teardownTempDir } from './setup';
 
 const DEFAULT_AGENT_DIR =
   process.env.SERO_AGENT_DIR ?? `${process.env.HOME}/.sero-ui/agent`;
@@ -33,6 +40,74 @@ interface ToolCall {
   args: unknown;
 }
 
+const RUNTIME_API_KEY_ENV_VARS: Record<string, string[]> = {
+  anthropic: ['ANTHROPIC_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'],
+  openai: ['OPENAI_API_KEY'],
+  google: ['GEMINI_API_KEY'],
+  openrouter: ['OPENROUTER_API_KEY'],
+  xai: ['XAI_API_KEY'],
+  groq: ['GROQ_API_KEY'],
+  cerebras: ['CEREBRAS_API_KEY'],
+  mistral: ['MISTRAL_API_KEY'],
+  'azure-openai-responses': ['AZURE_OPENAI_API_KEY'],
+  huggingface: ['HF_TOKEN'],
+  'vercel-ai-gateway': ['AI_GATEWAY_API_KEY'],
+  zai: ['ZAI_API_KEY'],
+  opencode: ['OPENCODE_API_KEY'],
+  'opencode-go': ['OPENCODE_API_KEY'],
+  'kimi-coding': ['KIMI_API_KEY'],
+  minimax: ['MINIMAX_API_KEY'],
+  'minimax-cn': ['MINIMAX_CN_API_KEY'],
+};
+
+function getRuntimeEnvApiKey(providerId: string): string | undefined {
+  const envVars = RUNTIME_API_KEY_ENV_VARS[providerId] ?? [];
+  for (const envVar of envVars) {
+    const value = process.env[envVar]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function applyRuntimeApiKeyOverrides(authStorage: any): string[] {
+  const applied: string[] = [];
+  for (const providerId of Object.keys(RUNTIME_API_KEY_ENV_VARS)) {
+    const apiKey = getRuntimeEnvApiKey(providerId);
+    if (!apiKey) continue;
+    authStorage.setRuntimeApiKey(providerId, apiKey);
+    applied.push(providerId);
+  }
+  return applied;
+}
+
+function buildAuthDiagnostics(
+  authStorage: any,
+  providerId: string | undefined,
+  runtimeOverrideProviders: string[],
+): string | undefined {
+  if (!providerId) return undefined;
+
+  const cred = authStorage.get(providerId);
+  const errors = authStorage
+    .drainErrors()
+    .map((error: unknown) => (error instanceof Error ? error.message : String(error)));
+
+  const parts = [
+    `provider=${providerId}`,
+    `runtimeOverride=${runtimeOverrideProviders.includes(providerId)}`,
+    `authJsonType=${cred?.type ?? 'none'}`,
+  ];
+
+  if (cred?.type === 'oauth' && typeof cred.expires === 'number') {
+    parts.push(`oauthExpires=${new Date(cred.expires).toISOString()}`);
+  }
+  if (errors.length > 0) {
+    parts.push(`authErrors=${errors.join(' | ')}`);
+  }
+
+  return parts.join(', ');
+}
+
 // Lazy-loaded SDK modules (ESM-only)
 let _sdk: {
   createAgentSession: any;
@@ -41,6 +116,7 @@ let _sdk: {
   AuthStorage: any;
   ModelRegistry: any;
   SettingsManager: any;
+  createCodingTools: any;
 } | null = null;
 
 async function loadSdk() {
@@ -53,6 +129,7 @@ async function loadSdk() {
     AuthStorage: mod.AuthStorage,
     ModelRegistry: mod.ModelRegistry,
     SettingsManager: mod.SettingsManager,
+    createCodingTools: mod.createCodingTools,
   };
   return _sdk;
 }
@@ -76,45 +153,51 @@ export default class SeroProvider implements ApiProvider {
     const tmpDir = await setupTempDir();
     const start = Date.now();
 
+    let authStorage: any = null;
+    let runtimeOverrideProviders: string[] = [];
+    let activeModel: { provider?: string; id?: string } | undefined;
+
     try {
+      await seedEvalWorkspace(tmpDir);
+
       const sdk = await loadSdk();
 
-      // Initialise SDK infra — mirrors shared-infra.ts but headless
-      const authStorage = sdk.AuthStorage.create(`${agentDir}/auth.json`);
+      authStorage = sdk.AuthStorage.create(`${agentDir}/auth.json`);
+      runtimeOverrideProviders = applyRuntimeApiKeyOverrides(authStorage);
+
       const modelRegistry = new sdk.ModelRegistry(
         authStorage,
         `${agentDir}/models.json`,
       );
       const settingsManager = sdk.SettingsManager.create(agentDir, agentDir);
-
       const loader = new sdk.DefaultResourceLoader({
         cwd: tmpDir,
         agentDir,
         settingsManager,
+        extensionFactories: [createEvalPromptExtensionFactory()],
+        extensionsOverride: stripExtensionTools,
       });
       await loader.reload();
 
-      const { session } = await sdk.createAgentSession({
+      const created = await sdk.createAgentSession({
         cwd: tmpDir,
         agentDir,
         authStorage,
         modelRegistry,
-        tools: [],
-        customTools: [],
+        tools: sdk.createCodingTools(tmpDir),
+        customTools: [createEvalSeroCliTool(tmpDir)],
         resourceLoader: loader,
         sessionManager: sdk.SessionManager.inMemory(),
         settingsManager,
       });
+      const session = created.session;
 
-      // Apply model override if configured
       if (this.config.model) {
         await session.setModel(this.config.model);
       }
+      activeModel = session.model;
 
-      // Capture initial session state for prompt-caching assertions
       const snapshot = captureSessionSnapshot(session);
-
-      // Collect events during the agent run
       const toolCalls: ToolCall[] = [];
       let fullText = '';
 
@@ -160,11 +243,21 @@ export default class SeroProvider implements ApiProvider {
           toolCalls,
           toolCallCount: toolCalls.length,
           snapshot,
+          runtimeOverrideProviders,
+          model: activeModel,
         },
       };
     } catch (err: any) {
+      const authDiagnostics = authStorage
+        ? buildAuthDiagnostics(
+            authStorage,
+            activeModel?.provider,
+            runtimeOverrideProviders,
+          )
+        : undefined;
+      const details = authDiagnostics ? ` [${authDiagnostics}]` : '';
       return {
-        error: `Agent error: ${err.message}`,
+        error: `Agent error: ${err.message}${details}`,
       };
     } finally {
       await teardownTempDir(tmpDir);

--- a/eval/snapshotProvider.ts
+++ b/eval/snapshotProvider.ts
@@ -11,29 +11,12 @@
  *
  * No LLM calls, no API key needed. Runs in ~2 seconds.
  */
-import path from 'node:path';
 import type { ApiProvider, ProviderResponse } from 'promptfoo';
 import { setupTempDir, teardownTempDir } from './setup';
 import { captureSessionSnapshot } from './helpers/sessionSnapshot';
 
 const DEFAULT_AGENT_DIR =
   process.env.SERO_AGENT_DIR ?? `${process.env.HOME}/.sero-ui/agent`;
-
-/** Monorepo root — one level up from eval/ */
-const SERO_ROOT = path.resolve(__dirname, '..');
-
-/**
- * Unwrap CJS/ESM interop: tsx wraps TS modules under .default when
- * loaded via dynamic import(). This normalizes to the real exports.
- */
-function unwrapDefault(mod: any): any {
-  // If the module only has a 'default' key and default is an object,
-  // the real named exports live inside it.
-  if (mod?.default && typeof mod.default === 'object') {
-    return mod.default;
-  }
-  return mod;
-}
 
 interface SnapshotProviderConfig {
   agentDir?: string;
@@ -45,12 +28,179 @@ interface SnapshotProviderConfig {
   workspaceId?: string;
 }
 
+interface PromptCommand {
+  name: string;
+  summary: string;
+  group?: string;
+  hidden?: boolean;
+}
+
+/**
+ * These helpers intentionally inline the pure prompt builders from the
+ * Electron codebase. Promptfoo loads this provider through tsx, but when we
+ * run promptfoo under Electron's Node runtime the absolute `.ts` dynamic
+ * imports used here are not loader-aware and fail with "Unknown file
+ * extension '.ts'". Keeping tiny pure copies here preserves snapshot fidelity
+ * while making the eval runner runtime-agnostic.
+ */
+const BLACKLISTED_ROOTS = new Set([
+  'auth',
+  'safeStorage',
+  'net',
+  'layout',
+  'agent',
+  'github',
+]);
+
+function normalizeCommandName(name: string): string {
+  return name.trim().replace(/\s+/g, ' ');
+}
+
+class SnapshotCliRegistry {
+  private commands = new Map<string, PromptCommand>();
+
+  register(command: PromptCommand): void {
+    const name = normalizeCommandName(command.name);
+    if (!name) {
+      throw new Error('CLI command name is required');
+    }
+
+    const root = name.split(' ')[0];
+    if (root && BLACKLISTED_ROOTS.has(root)) {
+      throw new Error(`CLI command root is blacklisted: ${root}`);
+    }
+
+    this.commands.set(name, { ...command, name });
+  }
+
+  list(): PromptCommand[] {
+    return [...this.commands.values()].sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+  }
+}
+
+function buildContainerPromptBlock(
+  workspaceId: string,
+  containerIp?: string,
+  opts?: { currentWorkingDir?: string },
+): string {
+  const currentWorkingDir = opts?.currentWorkingDir ?? '/workspace';
+  const cwdNote =
+    currentWorkingDir === '/workspace'
+      ? 'Your current working directory is also /workspace.'
+      : `Your current working directory for this session is ${currentWorkingDir}.`;
+
+  return `
+
+## Container Environment
+
+You are operating inside a sandboxed Linux container for workspace "${workspaceId}".
+Workspace root: /workspace.
+${cwdNote}
+Prefer relative paths and keep work in the current working directory unless the task explicitly needs another location.
+If this session is in a git worktree subdirectory, do NOT reset yourself with \`cd /workspace\` before making changes.
+
+**Container details**
+- Base image: node:22-slim (Debian-based)
+- Full root access inside the container
+- Network access for installing packages
+- Available tools: git, curl, wget, node, npm, python3, ss, netstat, dig, ps, less, jq
+${containerIp ? `- Container IP: ${containerIp} (accessible from the host)` : ''}
+
+**Version control (git)**
+- Mutating git commands in bash are BLOCKED.
+- Use the \`sero-cli\` tool for VCS actions such as \`vcs status\`, \`vcs checkpoint\`, \`vcs push\`, \`vcs remote\`, \`vcs log\`, and \`vcs fetch\`.
+- Read-only git commands in bash are fine: \`git status\`, \`git log\`, \`git diff\`, \`git show\`, \`git fetch\`, \`git remote -v\`, \`git branch\`, \`git blame\`.
+
+**Cross-workspace access**
+- Other open workspaces (including the global workspace) are mounted at their original host paths.
+- You CAN read and write cross-workspace **project files** via absolute host paths.
+- **Memory files** — always use \`sero memory\`/\`memory_search\`/\`scratchpad\` commands (see Memory System section), never direct file access.
+- For the CURRENT workspace, stay in the current working directory or under \`/workspace\`, not its host absolute path.
+- Use absolute host paths only when you intentionally need a DIFFERENT workspace.
+- Use \`sero-cli\` with \`workspace list\` to discover workspace paths.
+
+**Dev servers and networking**
+- Dev servers MUST bind to \`0.0.0.0\`, not localhost/127.0.0.1.
+  - Vite: \`npx vite --host 0.0.0.0 --port 3000\`
+  - Next.js: \`next dev -H 0.0.0.0 -p 3000\`
+  - Express/Node: \`.listen(3000, '0.0.0.0')\`
+- Access servers via the container IP (${containerIp ?? '<container-ip>'}), NOT localhost.
+- After bash commands, the tool output shows detected server URLs — always tell the user the exact URL shown there.
+- Any port is fine; container servers do not conflict with host ports.
+- Before saying a dev server is running, check whether it is actually running.
+
+**Background / long-running processes**
+Each bash tool call runs in an isolated \`sh -c\` shell.
+- Use \`setsid\` for processes that must outlive the command, e.g. \`setsid sh -c 'cd ${currentWorkingDir}/myapp && npx vite --host 0.0.0.0 --port 3000 > /tmp/vite.log 2>&1 &'\`.
+- Always redirect stdout/stderr to a log file.
+- Verify startup with \`ss -tlnp | grep <port>\`; if it failed, inspect the log.
+- NEVER use bare \`command &\` without \`setsid\`.
+- NEVER use \`kill -9 -1\`.
+- Stop servers with \`pkill -f ...\` or \`kill <PID>\`.
+
+**Dev server registration**
+- After a server is listening, you MUST use the \`sero-cli\` tool with \`devserver register\` so the host can track it.
+- This is what makes the server appear in the Dev Servers UI for stop/restart controls.
+
+**Terminal awareness**
+- The user may have interactive terminal sessions running in this container.
+- After starting a server, use the \`sero-cli\` tool with \`terminal read\` to inspect terminal output and proactively fix errors.
+
+**Web search, fetching, and downloads**
+- For normal web tasks, prefer the Sero web tools exposed through \`sero-cli\`.
+- Use \`web_search\` for web search and current information lookup.
+- Use \`fetch_content\` for article/page retrieval, content extraction, and file downloads.
+- Use \`get_search_content\` to retrieve full stored content from earlier search/fetch results.
+- Use \`web_bookmark\` for bookmark and web-history management.
+- If you are unsure about syntax, run \`sero help web_search\`, \`sero help fetch_content\`, etc.
+
+**Browser automation (Computer Use)**
+- \`browser\` controls a headless Chromium browser inside the container via Playwright.
+- Use it for known pages/apps only: UI testing, interaction flows, visual bug reproduction, screenshots, and recordings.
+- Do NOT use \`browser\` for generic web search, routine page/content retrieval, downloads, or bookmark management.
+- Typical flow: start the app → \`browser launch\` / \`navigate\` → interact → \`screenshot\` → verify → \`close\`.
+- Use the container IP for URLs, not localhost.
+- Use \`get_text\`, \`evaluate\`, and \`wait\` for assertions and dynamic pages.
+- Always take screenshots after key interactions as evidence.
+
+**Autonomous verification**
+- For UI work: build/start the app, verify with \`browser\`, capture screenshots, and save artifacts with \`sero-cli artifacts save\`.
+- For test work: run tests, fix failures, rerun until passing, then capture final evidence.
+- Prefer demos over diffs: prove the result works.`;
+}
+
+function buildSubagentPromptBlock(): string {
+  return `
+
+## Subagents
+
+Use the \`subagent\` tool to delegate substantial independent work to specialist agents.
+Each subagent gets a fresh context window and full workspace access.
+
+Use subagents when:
+- work can be split into independent parallel pieces
+- you want specialist analysis, review, or testing
+- a subtask would benefit from a clean context window
+
+Do NOT use subagents for:
+- quick file reads or simple lookups
+- tasks that require back-and-forth with the user
+- work that would take fewer than ~5 tool calls
+
+Prefer named agents for recurring roles and inline \`systemPrompt\` for one-off tasks.
+Subagents cannot spawn further subagents or call \`create_agent\`.
+When running tasks in parallel, give each one independent file scope to avoid races.
+`;
+}
+
 /**
  * Build the CLI system prompt dynamically from registered commands.
  * This is a copy of the pure logic from cli/index.ts, avoiding the
  * Electron-dependent imports that live in the same file.
  */
-function buildCliPromptBlock(registry: { list(): Array<{ name: string; summary: string; group?: string; hidden?: boolean }> }): string {
+function buildCliPromptBlock(registry: { list(): PromptCommand[] }): string {
   const commands = registry.list().filter((c) => !c.hidden && c.name !== 'help');
 
   const grouped = new Map<string, Array<{ name: string; summary: string }>>();
@@ -134,95 +284,58 @@ export default class SnapshotProvider implements ApiProvider {
       const baseSnapshot = captureSessionSnapshot(session);
 
       // ── 2. Assemble Sero prompt blocks ─────────────────────────
-      // Import pure prompt-building functions using absolute paths
-      // resolved from the monorepo root.
       let cliBlock = '';
       let containerBlock = '';
-      let subagentBlock = '';
+      const subagentBlock = buildSubagentPromptBlock();
 
-      try {
-        const containerPromptPath = path.join(
-          SERO_ROOT, 'apps/desktop/electron/features/container/tools/system-prompt.ts'
+      if (this.config.containerMode) {
+        containerBlock = buildContainerPromptBlock(
+          this.config.workspaceId ?? 'eval-workspace',
+          this.config.containerIp ?? '172.17.0.2',
         );
-        const { buildContainerPromptBlock } = unwrapDefault(await import(containerPromptPath));
-        if (this.config.containerMode) {
-          containerBlock = buildContainerPromptBlock(
-            this.config.workspaceId ?? 'eval-workspace',
-            this.config.containerIp ?? '172.17.0.2',
-          );
-        }
-      } catch (e) {
-        containerBlock = `<!-- container prompt import failed: ${(e as Error).message} -->`;
       }
 
-      try {
-        const subagentPromptPath = path.join(
-          SERO_ROOT, 'apps/desktop/electron/features/subagent/extensions/prompt.ts'
-        );
-        const { buildSubagentPromptBlock } = unwrapDefault(await import(subagentPromptPath));
-        subagentBlock = buildSubagentPromptBlock();
-      } catch (e) {
-        subagentBlock = `<!-- subagent prompt import failed: ${(e as Error).message} -->`;
+      const registry = new SnapshotCliRegistry();
+
+      // Register the same core commands that registerCoreCommands() does.
+      const coreCommands: PromptCommand[] = [
+        { name: 'workspace', summary: 'Manage workspaces', group: 'Builtin' },
+        { name: 'session', summary: 'Session commands', group: 'Builtin' },
+        { name: 'vcs', summary: 'Git/VCS operations', group: 'Builtin' },
+        { name: 'capture', summary: 'Capture app screenshot', group: 'Apps' },
+        { name: 'dev-server', summary: 'Dev server control', group: 'Builtin' },
+        { name: 'terminal', summary: 'Terminal management', group: 'Builtin' },
+        { name: 'editor', summary: 'Code editor operations', group: 'Builtin' },
+        { name: 'artifacts', summary: 'Manage artifacts', group: 'Builtin' },
+        { name: 'google', summary: 'Google services', group: 'Builtin' },
+      ];
+
+      // Bridged extension tools (these come from plugins in a real session).
+      const bridgedTools: PromptCommand[] = [
+        { name: 'todo', summary: 'Manage todos', group: 'Apps' },
+        { name: 'notes', summary: 'Manage notes', group: 'Apps' },
+        { name: 'memory', summary: 'Long-term memory', group: 'Apps' },
+        { name: 'memory_search', summary: 'Search memory', group: 'Apps' },
+        { name: 'kanban', summary: 'Kanban board', group: 'Apps' },
+        { name: 'cron', summary: 'Scheduled tasks', group: 'Apps' },
+        { name: 'reminder', summary: 'Set reminders', group: 'Apps' },
+        { name: 'current_time', summary: 'Current time', group: 'Apps' },
+        { name: 'spotify', summary: 'Spotify control', group: 'Apps' },
+        { name: 'generate_image', summary: 'Generate images', group: 'Apps' },
+        { name: 'question', summary: 'Ask user a question', group: 'Apps' },
+        { name: 'scratchpad', summary: 'Working notes', group: 'Apps' },
+        { name: 'calc', summary: 'Calculator', group: 'Apps' },
+        { name: 'gmail', summary: 'Gmail integration', group: 'Apps' },
+        { name: 'gcal', summary: 'Google Calendar', group: 'Apps' },
+        { name: 'git_manager', summary: 'Git management', group: 'Apps' },
+        { name: 'humanize', summary: 'Humanize text', group: 'Apps' },
+      ];
+
+      for (const command of [...coreCommands, ...bridgedTools]) {
+        registry.register(command);
       }
 
-      try {
-        // Import CliRegistry from core/registry (pure — no Electron deps).
-        // buildCliPromptBlock is inlined above because cli/index.ts imports
-        // Electron-dependent command registrations.
-        const registryPath = path.join(
-          SERO_ROOT, 'apps/desktop/electron/cli/core/registry.ts'
-        );
-        const { CliRegistry } = unwrapDefault(await import(registryPath));
-        const registry = new CliRegistry();
-        const noop = async () => ({ output: '', exitCode: 0 });
-
-        // Register the same core commands that registerCoreCommands() does
-        const coreCommands = [
-          { name: 'workspace', summary: 'Manage workspaces', group: 'Builtin' },
-          { name: 'session', summary: 'Session commands', group: 'Builtin' },
-          { name: 'vcs', summary: 'Git/VCS operations', group: 'Builtin' },
-          { name: 'capture', summary: 'Capture app screenshot', group: 'Apps' },
-          { name: 'dev-server', summary: 'Dev server control', group: 'Builtin' },
-          { name: 'terminal', summary: 'Terminal management', group: 'Builtin' },
-          { name: 'editor', summary: 'Code editor operations', group: 'Builtin' },
-          { name: 'artifacts', summary: 'Manage artifacts', group: 'Builtin' },
-          { name: 'google', summary: 'Google services', group: 'Builtin' },
-        ];
-        // Bridged extension tools (these come from plugins in a real session)
-        const bridgedTools = [
-          { name: 'todo', summary: 'Manage todos', group: 'Apps' },
-          { name: 'notes', summary: 'Manage notes', group: 'Apps' },
-          { name: 'memory', summary: 'Long-term memory', group: 'Apps' },
-          { name: 'memory_search', summary: 'Search memory', group: 'Apps' },
-          { name: 'kanban', summary: 'Kanban board', group: 'Apps' },
-          { name: 'cron', summary: 'Scheduled tasks', group: 'Apps' },
-          { name: 'reminder', summary: 'Set reminders', group: 'Apps' },
-          { name: 'current_time', summary: 'Current time', group: 'Apps' },
-          { name: 'spotify', summary: 'Spotify control', group: 'Apps' },
-          { name: 'generate_image', summary: 'Generate images', group: 'Apps' },
-          { name: 'question', summary: 'Ask user a question', group: 'Apps' },
-          { name: 'scratchpad', summary: 'Working notes', group: 'Apps' },
-          { name: 'calc', summary: 'Calculator', group: 'Apps' },
-          { name: 'gmail', summary: 'Gmail integration', group: 'Apps' },
-          { name: 'gcal', summary: 'Google Calendar', group: 'Apps' },
-          { name: 'git_manager', summary: 'Git management', group: 'Apps' },
-          { name: 'humanize', summary: 'Humanize text', group: 'Apps' },
-        ];
-
-        for (const cmd of [...coreCommands, ...bridgedTools]) {
-          registry.register({
-            name: cmd.name,
-            summary: cmd.summary,
-            group: cmd.group,
-            source: cmd.group === 'Apps' ? 'app' : 'builtin',
-            execute: noop,
-          });
-        }
-
-        cliBlock = buildCliPromptBlock(registry);
-      } catch (e) {
-        cliBlock = `<!-- CLI prompt import failed: ${(e as Error).message} -->`;
-      }
+      cliBlock = buildCliPromptBlock(registry);
 
       // ── 3. Assemble the full Sero prompt ───────────────────────
       // This mirrors create-sero-extension.ts before_agent_start handler:

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
     "rebuild-electron": "bash apps/desktop/scripts/rebuild-electron.sh",
     "clean": "rm -rf node_modules apps/*/.__mf__temp packages/*/.__mf__temp plugins/*/.__mf__temp apps/*/node_modules packages/*/node_modules plugins/*/node_modules apps/*/.next apps/*/.turbo packages/*/.turbo plugins/*/.turbo apps/*/dist packages/*/dist plugins/*/dist apps/*/out packages/*/out plugins/*/out .turbo",
     "prepare": "husky",
-    "eval": "node eval/patch-drizzle.cjs && promptfoo eval",
-    "eval:snapshot": "node eval/patch-drizzle.cjs && promptfoo eval --config eval/promptfoo-snapshot.yaml --no-cache",
-    "eval:view": "promptfoo view"
+    "eval": "node eval/patch-drizzle.cjs && node scripts/run-promptfoo.mjs eval",
+    "eval:snapshot": "node eval/patch-drizzle.cjs && node scripts/run-promptfoo.mjs eval --config eval/promptfoo-snapshot.yaml --no-cache",
+    "eval:view": "node scripts/run-promptfoo.mjs view"
   },
   "devDependencies": {
     "@mariozechner/pi-coding-agent": "catalog:",
+    "@sinclair/typebox": "catalog:",
     "husky": "^9.1.7",
     "promptfoo": "0.103.5",
     "turbo": "^2.8.17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@mariozechner/pi-coding-agent':
         specifier: 'catalog:'
         version: 0.61.1(ws@8.19.0)(zod@3.25.76)
+      '@sinclair/typebox':
+        specifier: 'catalog:'
+        version: 0.34.48
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/promptfooconfig.yaml
+++ b/promptfooconfig.yaml
@@ -30,4 +30,4 @@ tests:
 defaultTest:
   options:
     provider:
-      id: anthropic:messages:claude-sonnet-4-5-20250929
+      id: anthropic:messages:claude-sonnet-4-6

--- a/scripts/promptfoo-electron-runner.cjs
+++ b/scripts/promptfoo-electron-runner.cjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { createRequire } = require('module');
+
+const promptfooEntry = require.resolve('promptfoo');
+const promptfooRoot = path.resolve(promptfooEntry, '../../..');
+const promptfooRequire = createRequire(path.join(promptfooRoot, 'package.json'));
+
+const { Command } = promptfooRequire('commander');
+const { version } = promptfooRequire('./package.json');
+const { checkNodeVersion } = promptfooRequire('./dist/src/checkNodeVersion.js');
+const { authCommand } = promptfooRequire('./dist/src/commands/auth.js');
+const { cacheCommand } = promptfooRequire('./dist/src/commands/cache.js');
+const { configCommand } = promptfooRequire('./dist/src/commands/config.js');
+const { debugCommand } = promptfooRequire('./dist/src/commands/debug.js');
+const { deleteCommand } = promptfooRequire('./dist/src/commands/delete.js');
+const { evalCommand } = promptfooRequire('./dist/src/commands/eval.js');
+const { exportCommand } = promptfooRequire('./dist/src/commands/export.js');
+const { feedbackCommand } = promptfooRequire('./dist/src/commands/feedback.js');
+const { generateDatasetCommand } = promptfooRequire('./dist/src/commands/generate/dataset.js');
+const { importCommand } = promptfooRequire('./dist/src/commands/import.js');
+const { initCommand } = promptfooRequire('./dist/src/commands/init.js');
+const { listCommand } = promptfooRequire('./dist/src/commands/list.js');
+const { shareCommand } = promptfooRequire('./dist/src/commands/share.js');
+const { showCommand } = promptfooRequire('./dist/src/commands/show.js');
+const { viewCommand } = promptfooRequire('./dist/src/commands/view.js');
+const logger = promptfooRequire('./dist/src/logger.js').default;
+const { runDbMigrations } = promptfooRequire('./dist/src/migrate.js');
+const { redteamGenerateCommand } = promptfooRequire('./dist/src/redteam/commands/generate.js');
+const { initCommand: redteamInitCommand } = promptfooRequire('./dist/src/redteam/commands/init.js');
+const { pluginsCommand } = promptfooRequire('./dist/src/redteam/commands/plugins.js');
+const { redteamReportCommand } = promptfooRequire('./dist/src/redteam/commands/report.js');
+const { redteamRunCommand } = promptfooRequire('./dist/src/redteam/commands/run.js');
+const { redteamSetupCommand } = promptfooRequire('./dist/src/redteam/commands/setup.js');
+const { checkForUpdates } = promptfooRequire('./dist/src/updates.js');
+const { loadDefaultConfig } = promptfooRequire('./dist/src/util/config/default.js');
+
+async function main() {
+  await checkForUpdates();
+  await runDbMigrations();
+
+  const { defaultConfig, defaultConfigPath } = await loadDefaultConfig();
+  const program = new Command('promptfoo');
+
+  program
+    .version(version)
+    .showHelpAfterError()
+    .showSuggestionAfterError()
+    .on('option:*', function () {
+      logger.error('Invalid option(s)');
+      program.help();
+      process.exitCode = 1;
+    });
+
+  evalCommand(program, defaultConfig, defaultConfigPath);
+  initCommand(program);
+  viewCommand(program);
+
+  const redteamBaseCommand = program.command('redteam').description('Red team LLM applications');
+  shareCommand(program);
+  authCommand(program);
+  cacheCommand(program);
+  configCommand(program);
+  debugCommand(program, defaultConfig, defaultConfigPath);
+  deleteCommand(program);
+  exportCommand(program);
+  feedbackCommand(program);
+  const generateCommand = program.command('generate').description('Generate synthetic data');
+  importCommand(program);
+  listCommand(program);
+  showCommand(program);
+  generateDatasetCommand(generateCommand, defaultConfig, defaultConfigPath);
+  redteamGenerateCommand(generateCommand, 'redteam', defaultConfig, defaultConfigPath);
+
+  const {
+    defaultConfig: redteamConfig,
+    defaultConfigPath: redteamConfigPath,
+  } = await loadDefaultConfig(undefined, 'redteam');
+
+  redteamInitCommand(redteamBaseCommand);
+  evalCommand(redteamBaseCommand, redteamConfig ?? defaultConfig, redteamConfigPath ?? defaultConfigPath);
+  redteamGenerateCommand(redteamBaseCommand, 'generate', defaultConfig, defaultConfigPath);
+  redteamRunCommand(redteamBaseCommand);
+  redteamReportCommand(redteamBaseCommand);
+  redteamSetupCommand(redteamBaseCommand);
+  pluginsCommand(redteamBaseCommand);
+
+  program.parse(process.argv, { from: 'node' });
+}
+
+checkNodeVersion();
+main();

--- a/scripts/run-promptfoo.mjs
+++ b/scripts/run-promptfoo.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process';
+import { existsSync, readdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const PNPM_STORE = resolve(ROOT, 'node_modules/.pnpm');
+const RUNNER = resolve(ROOT, 'scripts/promptfoo-electron-runner.cjs');
+
+function findElectronBinary() {
+  if (!existsSync(PNPM_STORE)) return null;
+
+  const entries = readdirSync(PNPM_STORE).filter(entry => entry.startsWith('electron@'));
+  for (const entry of entries) {
+    const binary = resolve(
+      PNPM_STORE,
+      entry,
+      'node_modules/electron/dist/Electron.app/Contents/MacOS/Electron',
+    );
+    if (existsSync(binary)) {
+      return binary;
+    }
+  }
+
+  return null;
+}
+
+const electronBinary = findElectronBinary();
+if (!electronBinary) {
+  console.error('[promptfoo] Electron binary not found. Run pnpm install first.');
+  process.exit(1);
+}
+
+const result = spawnSync(electronBinary, [RUNNER, ...process.argv.slice(2)], {
+  cwd: ROOT,
+  env: {
+    ...process.env,
+    ELECTRON_RUN_AS_NODE: '1',
+  },
+  stdio: 'inherit',
+});
+
+if (result.error) {
+  console.error(`[promptfoo] Failed to launch Electron runner: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- run Promptfoo through Electron's Node runtime so evals use the same ABI as the rebuilt `better-sqlite3` binary
- make eval auth honor runtime API-key overrides before falling back to stale OAuth state in `~/.sero-ui/agent/auth.json`
- align agent evals with expected Sero behavior using isolated temp Git workspaces, real coding tools, and an eval-only `sero-cli` shim
- update eval docs and troubleshooting notes for the new workflow

## Testing
- `pnpm typecheck`
- `pnpm eval --env-path .env`
- `pnpm eval:snapshot`
