### PR TITLE
fix: harden git plugin UX and add regression coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ See [docs/node-pty-setup.md](docs/node-pty-setup.md).
 - Save new documentation/plans in `@docs/` or typed subfolders
 - Use Conventional Commit messages
 - Ensure good type safety in source files when conducting PR reviews
+- Don't push to remote git branch automatically unless asked specifically or asked to create a PR
 - Do not delete relevant comments
 - Prefer `useDebouncedCallback` / `createDebouncedFn` from `src/hooks/useDebouncedCallback.ts` over hand-rolled `setTimeout` debounce patterns
 - Preview `.html` files in the in-app editor (sandboxed iframe)

--- a/apps/desktop/electron/features/apps/git-app/manager.ts
+++ b/apps/desktop/electron/features/apps/git-app/manager.ts
@@ -169,6 +169,7 @@ class GitWorkspaceStateManager {
     entry.ignoreEventsUntil = Date.now() + 1_000;
     entry.refreshInFlight = refreshGitState(entry.workspacePath, entry.stateFilePath, {
       syncMode: entry.syncMode,
+      scope: 'auto',
     })
       .then(() => {
         // no-op; the state file watcher notifies renderers
@@ -181,6 +182,7 @@ class GitWorkspaceStateManager {
           currentBranch: '',
           headHash: '',
           branches: [],
+          remoteBranches: [],
           remotes: [],
           commits: [],
           stashes: [],

--- a/apps/desktop/src/components/layout/AppStoreDialog.tsx
+++ b/apps/desktop/src/components/layout/AppStoreDialog.tsx
@@ -197,13 +197,13 @@ export function AppStoreDialog({
           <TabsContent value="installed" className="mt-0 flex min-h-0 flex-1 flex-col">
             <div className="border-b border-[var(--border-default)] px-4 py-3">
               <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
                 <Input
                   autoFocus
                   value={searchQuery}
                   onChange={(event) => setSearchQuery(event.target.value)}
                   placeholder="Search installed apps…"
-                  className="pl-9"
+                  className="pl-10"
                 />
               </div>
             </div>
@@ -238,12 +238,12 @@ export function AppStoreDialog({
           <TabsContent value="discover" className="mt-0 flex min-h-0 flex-1 flex-col">
             <div className="border-b border-[var(--border-default)] px-4 py-3">
               <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-[var(--text-muted)]" />
                 <Input
                   value={discoverQuery}
                   onChange={(event) => handleDiscoverQueryChange(event.target.value)}
                   placeholder="Search public plugins…"
-                  className="pl-9"
+                  className="pl-10"
                 />
               </div>
             </div>

--- a/plugins/sero-git-plugin/extension/__tests__/git-diff.test.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-diff.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCommitDiff, getFileDiff } from '../git-commands';
+import { runGit } from '../git-exec';
+import {
+  cleanupPaths,
+  commitAll,
+  createGitRepo,
+  writeRepoFile,
+} from './git-test-helpers';
+
+describe('diff parsing', () => {
+  it('includes oldPath metadata for staged renames', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'hello\n');
+      commitAll(repoPath, 'initial');
+
+      runGit(['mv', 'a.txt', 'b.txt'], repoPath);
+      const diff = getFileDiff(repoPath, 'b.txt', true);
+
+      expect(diff).not.toBeNull();
+      expect(diff?.status).toBe('renamed');
+      expect(diff?.oldPath).toBe('a.txt');
+      expect(diff?.path).toBe('b.txt');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('includes oldPath metadata for committed renames', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'hello\n');
+      commitAll(repoPath, 'initial');
+
+      runGit(['mv', 'a.txt', 'b.txt'], repoPath);
+      commitAll(repoPath, 'rename file');
+      const renameCommitHash = runGit(['rev-parse', 'HEAD'], repoPath);
+
+      const diffs = getCommitDiff(repoPath, renameCommitHash);
+
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0]?.status).toBe('renamed');
+      expect(diffs[0]?.oldPath).toBe('a.txt');
+      expect(diffs[0]?.path).toBe('b.txt');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+});

--- a/plugins/sero-git-plugin/extension/__tests__/git-refresh.test.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-refresh.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { runGit } from '../git-exec';
 import { refreshGitState } from '../git-service';
 import {
   cleanupPaths,
@@ -29,6 +30,24 @@ describe('refreshGitState', () => {
       expect(refreshedState.branches).toEqual(initialState.branches);
       expect(refreshedState.remoteBranches).toEqual(initialState.remoteBranches);
       expect(refreshedState.fileChanges.some((file) => file.path === 'notes.txt')).toBe(true);
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('falls back to a full refresh when refs change without a HEAD update', async () => {
+    const repoPath = await createGitRepo();
+    const statePath = statePathFor(repoPath);
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      await refreshGitState(repoPath, statePath, { scope: 'full' });
+
+      runGit(['branch', 'feature'], repoPath);
+      const refreshedState = await refreshGitState(repoPath, statePath, { scope: 'auto' });
+
+      expect(refreshedState.branches.some((branch) => branch.name === 'feature')).toBe(true);
     } finally {
       await cleanupPaths([repoPath]);
     }

--- a/plugins/sero-git-plugin/extension/__tests__/git-refresh.test.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-refresh.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { refreshGitState } from '../git-service';
+import {
+  cleanupPaths,
+  commitAll,
+  createGitRepo,
+  statePathFor,
+  writeRepoFile,
+} from './git-test-helpers';
+
+describe('refreshGitState', () => {
+  it('uses quick refresh mode when HEAD and branch are unchanged', async () => {
+    const repoPath = await createGitRepo();
+    const statePath = statePathFor(repoPath);
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+
+      const initialState = await refreshGitState(repoPath, statePath, { scope: 'full' });
+      await writeRepoFile(repoPath, 'notes.txt', 'dirty\n');
+
+      const refreshedState = await refreshGitState(repoPath, statePath, { scope: 'auto' });
+
+      expect(refreshedState.headHash).toBe(initialState.headHash);
+      expect(refreshedState.currentBranch).toBe(initialState.currentBranch);
+      expect(refreshedState.commits).toEqual(initialState.commits);
+      expect(refreshedState.branches).toEqual(initialState.branches);
+      expect(refreshedState.remoteBranches).toEqual(initialState.remoteBranches);
+      expect(refreshedState.fileChanges.some((file) => file.path === 'notes.txt')).toBe(true);
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+});

--- a/plugins/sero-git-plugin/extension/__tests__/git-refs.test.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-refs.test.ts
@@ -13,7 +13,7 @@ import {
 } from './git-test-helpers';
 
 describe('git refs helpers', () => {
-  it('marks branches checked out in linked worktrees and keeps the current branch first', async () => {
+  it('marks branches checked out in linked worktrees and sorts by branch activity rather than current selection', async () => {
     const repoPath = await createGitRepo();
     const worktreePath = path.join(repoPath, 'feature-worktree');
 
@@ -23,11 +23,15 @@ describe('git refs helpers', () => {
       runGit(['branch', 'feature'], repoPath);
       runGit(['worktree', 'add', worktreePath, 'feature'], repoPath);
 
+      runGit(['switch', 'feature'], worktreePath);
+      await writeRepoFile(worktreePath, 'feature.txt', 'feature\n');
+      commitAll(worktreePath, 'feature work');
+
       const branches = getBranches(repoPath);
 
-      expect(branches[0]?.current).toBe(true);
-      expect(branches[0]?.name).toBe(runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath));
+      expect(branches[0]?.name).toBe('feature');
       expect(branches.find((branch) => branch.name === 'feature')?.checkedOutIn).toContain('feature-worktree');
+      expect(branches.find((branch) => branch.name === runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath))?.current).toBe(true);
     } finally {
       await cleanupPaths([repoPath]);
     }

--- a/plugins/sero-git-plugin/extension/__tests__/git-refs.test.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-refs.test.ts
@@ -1,0 +1,64 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { runGit } from '../git-exec';
+import { getBranches, getRemoteBranches } from '../git-refs';
+import {
+  cleanupPaths,
+  commitAll,
+  createBareRemote,
+  createGitRepo,
+  writeRepoFile,
+} from './git-test-helpers';
+
+describe('git refs helpers', () => {
+  it('marks branches checked out in linked worktrees and keeps the current branch first', async () => {
+    const repoPath = await createGitRepo();
+    const worktreePath = path.join(repoPath, 'feature-worktree');
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      runGit(['branch', 'feature'], repoPath);
+      runGit(['worktree', 'add', worktreePath, 'feature'], repoPath);
+
+      const branches = getBranches(repoPath);
+
+      expect(branches[0]?.current).toBe(true);
+      expect(branches[0]?.name).toBe(runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath));
+      expect(branches.find((branch) => branch.name === 'feature')?.checkedOutIn).toContain('feature-worktree');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('lists fetched remote branches and excludes remote HEAD aliases', async () => {
+    const repoPath = await createGitRepo();
+    const remotePath = await createBareRemote();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      const defaultBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
+
+      runGit(['remote', 'add', 'origin', remotePath], repoPath);
+      runGit(['push', '-u', 'origin', defaultBranch], repoPath);
+
+      runGit(['switch', '-c', 'feature'], repoPath);
+      await writeRepoFile(repoPath, 'feature.txt', 'feature\n');
+      commitAll(repoPath, 'feature');
+      runGit(['push', '-u', 'origin', 'feature'], repoPath);
+      runGit(['switch', defaultBranch], repoPath);
+      runGit(['fetch', '--all', '--prune'], repoPath);
+
+      const remoteBranches = getRemoteBranches(repoPath).map((branch) => branch.name);
+
+      expect(remoteBranches).toContain(`origin/${defaultBranch}`);
+      expect(remoteBranches).toContain('origin/feature');
+      expect(remoteBranches.some((branch) => branch.endsWith('/HEAD'))).toBe(false);
+    } finally {
+      await cleanupPaths([repoPath, remotePath]);
+    }
+  });
+});

--- a/plugins/sero-git-plugin/extension/__tests__/git-service.test.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-service.test.ts
@@ -7,6 +7,7 @@ import { runGit } from '../git-exec';
 import {
   cleanupPaths,
   commitAll,
+  createBareRemote,
   createGitRepo,
   statePathFor,
   writeRepoFile,
@@ -48,6 +49,139 @@ describe('runGitAction', () => {
       expect(result.ok).toBe(false);
       expect(result.message).toContain('already checked out in');
       expect(result.message).toContain(worktreePath);
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('removes linked worktrees and supports force removal for dirty ones', async () => {
+    const repoPath = await createGitRepo();
+    const worktreePath = path.join(repoPath, 'feature-worktree');
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      runGit(['branch', 'feature'], repoPath);
+      runGit(['worktree', 'add', worktreePath, 'feature'], repoPath);
+      await writeRepoFile(worktreePath, 'dirty.txt', 'dirty\n');
+
+      const blockedResult = await runGitAction(
+        { action: 'remove_worktree', worktreePath },
+        repoPath,
+        statePathFor(repoPath),
+      );
+      expect(blockedResult.ok).toBe(false);
+      expect(blockedResult.message).toContain('Use force remove to remove it anyway');
+
+      const forcedResult = await runGitAction(
+        { action: 'remove_worktree', worktreePath, force: true },
+        repoPath,
+        statePathFor(repoPath),
+      );
+      expect(forcedResult.ok).toBe(true);
+      expect(runGit(['worktree', 'list', '--porcelain'], repoPath)).not.toContain(worktreePath);
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('blocks removing the main worktree', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+
+      const result = await runGitAction(
+        { action: 'remove_worktree', worktreePath: repoPath },
+        repoPath,
+        statePathFor(repoPath),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('Cannot remove the main worktree');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('blocks deleting the default branch', async () => {
+    const repoPath = await createGitRepo();
+    const remotePath = await createBareRemote();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      const defaultBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
+
+      runGit(['remote', 'add', 'origin', remotePath], repoPath);
+      runGit(['push', '-u', 'origin', defaultBranch], repoPath);
+      runGit(['remote', 'set-head', 'origin', '--auto'], repoPath);
+
+      runGit(['switch', '-c', 'feature'], repoPath);
+
+      const result = await runGitAction(
+        { action: 'delete_branch', branch: defaultBranch },
+        repoPath,
+        statePathFor(repoPath),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('Cannot delete the default branch');
+    } finally {
+      await cleanupPaths([repoPath, remotePath]);
+    }
+  });
+
+  it('blocks deleting the current branch', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      const currentBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
+
+      const result = await runGitAction(
+        { action: 'delete_branch', branch: currentBranch },
+        repoPath,
+        statePathFor(repoPath),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('Cannot delete the current branch');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('supports force-deleting unmerged branches', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      const defaultBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
+
+      runGit(['switch', '-c', 'feature'], repoPath);
+      await writeRepoFile(repoPath, 'feature.txt', 'feature\n');
+      commitAll(repoPath, 'feature work');
+      runGit(['switch', defaultBranch], repoPath);
+
+      const blockedResult = await runGitAction(
+        { action: 'delete_branch', branch: 'feature' },
+        repoPath,
+        statePathFor(repoPath),
+      );
+      expect(blockedResult.ok).toBe(false);
+      expect(blockedResult.message).toContain('Use force delete to remove it anyway');
+
+      const forcedResult = await runGitAction(
+        { action: 'delete_branch', branch: 'feature', force: true },
+        repoPath,
+        statePathFor(repoPath),
+      );
+      expect(forcedResult.ok).toBe(true);
+      expect(runGit(['branch', '--list', 'feature'], repoPath)).toBe('');
     } finally {
       await cleanupPaths([repoPath]);
     }

--- a/plugins/sero-git-plugin/extension/__tests__/git-service.test.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-service.test.ts
@@ -1,0 +1,119 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { runGitAction } from '../git-service';
+import { runGit } from '../git-exec';
+import {
+  cleanupPaths,
+  commitAll,
+  createGitRepo,
+  statePathFor,
+  writeRepoFile,
+} from './git-test-helpers';
+
+describe('runGitAction', () => {
+  it('unstages all files even before the first commit exists', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'hello\n');
+      runGit(['add', 'a.txt'], repoPath);
+
+      const result = await runGitAction({ action: 'unstage', all: true }, repoPath, statePathFor(repoPath));
+
+      expect(result.ok).toBe(true);
+      expect(runGit(['status', '--short'], repoPath)).toContain('?? a.txt');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('blocks switching to branches checked out in another worktree', async () => {
+    const repoPath = await createGitRepo();
+    const worktreePath = path.join(repoPath, 'feature-worktree');
+
+    try {
+      await writeRepoFile(repoPath, 'a.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      runGit(['branch', 'feature'], repoPath);
+      runGit(['worktree', 'add', worktreePath, 'feature'], repoPath);
+
+      const result = await runGitAction(
+        { action: 'checkout', branch: 'feature' },
+        repoPath,
+        statePathFor(repoPath),
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('already checked out in');
+      expect(result.message).toContain(worktreePath);
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('applies a stash without dropping it', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'notes.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+
+      await writeRepoFile(repoPath, 'notes.txt', 'base\nupdated\n');
+      const stashResult = await runGitAction({ action: 'stash' }, repoPath, statePathFor(repoPath));
+      expect(stashResult.ok).toBe(true);
+      expect(runGit(['stash', 'list'], repoPath)).toContain('stash@{0}');
+
+      const applyResult = await runGitAction(
+        { action: 'stash_apply', stashIndex: 0 },
+        repoPath,
+        statePathFor(repoPath),
+      );
+
+      expect(applyResult.ok).toBe(true);
+      expect(runGit(['stash', 'list'], repoPath)).toContain('stash@{0}');
+      expect(runGit(['status', '--short'], repoPath)).toContain('M notes.txt');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+
+  it('can auto-stash before cherry-picking onto a dirty working tree', async () => {
+    const repoPath = await createGitRepo();
+
+    try {
+      await writeRepoFile(repoPath, 'app.txt', 'base\n');
+      commitAll(repoPath, 'initial');
+      const defaultBranch = runGit(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath);
+
+      runGit(['switch', '-c', 'feature'], repoPath);
+      await writeRepoFile(repoPath, 'app.txt', 'base\nfeature\n');
+      commitAll(repoPath, 'feature change');
+      const cherryPickHash = runGit(['rev-parse', 'HEAD'], repoPath);
+
+      runGit(['switch', defaultBranch], repoPath);
+      await writeRepoFile(repoPath, 'dirty.txt', 'dirty\n');
+
+      const blockedResult = await runGitAction(
+        { action: 'cherry_pick', hash: cherryPickHash },
+        repoPath,
+        statePathFor(repoPath),
+      );
+      expect(blockedResult.ok).toBe(false);
+      expect(blockedResult.message).toContain('Working tree has uncommitted changes');
+
+      const result = await runGitAction(
+        { action: 'cherry_pick', hash: cherryPickHash, all: true },
+        repoPath,
+        statePathFor(repoPath),
+      );
+
+      expect(result.ok).toBe(true);
+      expect(runGit(['log', '--format=%s', '-1'], repoPath)).toBe('feature change');
+      expect(runGit(['stash', 'list'], repoPath)).toContain('Auto-stash before cherry-pick');
+    } finally {
+      await cleanupPaths([repoPath]);
+    }
+  });
+});

--- a/plugins/sero-git-plugin/extension/__tests__/git-test-helpers.ts
+++ b/plugins/sero-git-plugin/extension/__tests__/git-test-helpers.ts
@@ -1,0 +1,39 @@
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { runGit } from '../git-exec';
+import { resolveStatePath } from '../state-io';
+
+export async function createGitRepo(prefix = 'sero-git-plugin-'): Promise<string> {
+  const repoPath = await mkdtemp(path.join(os.tmpdir(), prefix));
+  runGit(['init'], repoPath);
+  runGit(['config', 'user.name', 'Sero Test'], repoPath);
+  runGit(['config', 'user.email', 'test@example.com'], repoPath);
+  return repoPath;
+}
+
+export async function createBareRemote(prefix = 'sero-git-remote-'): Promise<string> {
+  const remotePath = await mkdtemp(path.join(os.tmpdir(), prefix));
+  runGit(['init', '--bare'], remotePath);
+  return remotePath;
+}
+
+export async function writeRepoFile(repoPath: string, relativePath: string, content: string): Promise<void> {
+  const absolutePath = path.join(repoPath, relativePath);
+  await mkdir(path.dirname(absolutePath), { recursive: true });
+  await writeFile(absolutePath, content, 'utf8');
+}
+
+export function commitAll(repoPath: string, message: string): void {
+  runGit(['add', '-A'], repoPath);
+  runGit(['commit', '-m', message], repoPath);
+}
+
+export function statePathFor(repoPath: string): string {
+  return resolveStatePath(repoPath);
+}
+
+export async function cleanupPaths(paths: string[]): Promise<void> {
+  await Promise.all(paths.map((targetPath) => rm(targetPath, { recursive: true, force: true })));
+}

--- a/plugins/sero-git-plugin/extension/git-commands.ts
+++ b/plugins/sero-git-plugin/extension/git-commands.ts
@@ -9,7 +9,6 @@ import { readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import type {
-  BranchInfo,
   CommitNode,
   DiffHunk,
   DiffLine,
@@ -108,32 +107,6 @@ function parseRefs(raw: string): RefLabel[] {
     });
 }
 
-// ── Branches ────────────────────────────────────────────────
-
-export function getBranches(cwd: string): BranchInfo[] {
-  const raw = git([
-    'for-each-ref',
-    '--format=%(refname:short)%00%(HEAD)%00%(upstream:short)%00%(upstream:track,nobracket)%00%(objectname:short)%00%(creatordate:iso-strict)',
-    'refs/heads/',
-  ], cwd);
-  if (!raw) return [];
-
-  return raw.split('\n').filter(nonEmpty).map((line) => {
-    const [name, head, upstream, track, hash, date] = line.split('\x00');
-    const ahead = parseInt(track?.match(/ahead (\d+)/)?.[1] ?? '0', 10);
-    const behind = parseInt(track?.match(/behind (\d+)/)?.[1] ?? '0', 10);
-    return {
-      name: name ?? '',
-      current: head === '*',
-      remote: upstream || undefined,
-      ahead,
-      behind,
-      lastCommitHash: hash,
-      lastCommitDate: date,
-    };
-  });
-}
-
 // ── Remotes ─────────────────────────────────────────────────
 
 export function getRemotes(cwd: string): RemoteInfo[] {
@@ -216,20 +189,37 @@ export function getStashes(cwd: string): StashEntry[] {
 // ── Diff ────────────────────────────────────────────────────
 
 export function getFileDiff(cwd: string, filePath: string, staged: boolean): FileDiff | null {
-  const args = staged ? ['diff', '--cached', '--', filePath] : ['diff', '--', filePath];
+  const args = staged ? ['diff', '--cached', '-M', '--', filePath] : ['diff', '-M', '--', filePath];
   const raw = git(args, cwd);
+  const statusEntry = getFileChanges(cwd).find((change) => change.path === filePath && change.staged === staged);
   const diff = parseDiffOutput(raw, filePath, staged);
-  if (diff) return diff;
+  if (diff) {
+    if (statusEntry?.oldPath && !diff.oldPath) diff.oldPath = statusEntry.oldPath;
+    if (statusEntry?.status === 'renamed') diff.status = 'renamed';
+    if (statusEntry?.status === 'copied') diff.status = 'copied';
+    return diff;
+  }
 
   if (!staged && isUntrackedWorktreePath(cwd, filePath)) {
     return createUntrackedFileDiff(cwd, filePath, staged);
   }
 
-  return null;
+  return statusEntry?.status === 'renamed' || statusEntry?.status === 'copied'
+    ? {
+      path: statusEntry.path,
+      oldPath: statusEntry.oldPath,
+      status: statusEntry.status,
+      hunks: [],
+      binary: false,
+      additions: 0,
+      deletions: 0,
+      staged,
+    }
+    : null;
 }
 
 export function getCommitDiff(cwd: string, hash: string): FileDiff[] {
-  const raw = git(['diff-tree', '--root', '-p', '--no-commit-id', hash], cwd);
+  const raw = git(['diff-tree', '--root', '-M', '-p', '--no-commit-id', hash], cwd);
   if (!raw) return [];
   return splitDiffByFile(raw);
 }
@@ -237,6 +227,7 @@ export function getCommitDiff(cwd: string, hash: string): FileDiff[] {
 function parseDiffOutput(raw: string, filePath: string, staged: boolean): FileDiff | null {
   if (!raw) return null;
 
+  const resolvedPaths = extractDiffPaths(raw, filePath);
   const hunks = parseHunks(raw);
   const additions = hunks.reduce((sum, hunk) => {
     return sum + hunk.lines.filter((line) => line.type === 'add').length;
@@ -246,7 +237,8 @@ function parseDiffOutput(raw: string, filePath: string, staged: boolean): FileDi
   }, 0);
 
   return {
-    path: filePath,
+    path: resolvedPaths.path,
+    oldPath: resolvedPaths.oldPath,
     status: inferDiffStatus(raw),
     hunks,
     binary: raw.includes('Binary files') || raw.includes('GIT binary patch'),
@@ -261,8 +253,7 @@ function splitDiffByFile(raw: string): FileDiff[] {
   const chunks = raw.split(/^diff --git /m).filter(nonEmpty);
 
   for (const chunk of chunks) {
-    const nameMatch = chunk.match(/^a\/(.+?) b\/(.+)/);
-    const filePath = nameMatch?.[2] ?? nameMatch?.[1] ?? 'unknown';
+    const resolvedPaths = extractDiffPaths(chunk, 'unknown');
     const hunks = parseHunks(chunk);
     const additions = hunks.reduce((sum, hunk) => {
       return sum + hunk.lines.filter((line) => line.type === 'add').length;
@@ -272,7 +263,8 @@ function splitDiffByFile(raw: string): FileDiff[] {
     }, 0);
 
     fileDiffs.push({
-      path: filePath,
+      path: resolvedPaths.path,
+      oldPath: resolvedPaths.oldPath,
       status: inferDiffStatus(chunk),
       hunks,
       binary: chunk.includes('Binary files') || chunk.includes('GIT binary patch'),
@@ -289,6 +281,35 @@ function inferDiffStatus(raw: string): FileChangeStatus {
   if (raw.includes('rename from')) return 'renamed';
   if (raw.includes('copy from')) return 'copied';
   return 'modified';
+}
+
+function extractDiffPaths(raw: string, fallbackPath: string): { path: string; oldPath?: string } {
+  const renameFrom = raw.match(/^rename from (.+)$/m)?.[1];
+  const renameTo = raw.match(/^rename to (.+)$/m)?.[1];
+  if (renameFrom && renameTo) {
+    return { path: renameTo, oldPath: renameFrom };
+  }
+
+  const copyFrom = raw.match(/^copy from (.+)$/m)?.[1];
+  const copyTo = raw.match(/^copy to (.+)$/m)?.[1];
+  if (copyFrom && copyTo) {
+    return { path: copyTo, oldPath: copyFrom };
+  }
+
+  const diffHeader = raw.match(/^a\/(.+?) b\/(.+)$/m);
+  if (diffHeader?.[2]) {
+    return {
+      path: diffHeader[2],
+      oldPath: diffHeader[1] !== diffHeader[2] ? diffHeader[1] : undefined,
+    };
+  }
+
+  const newPath = raw.match(/^\+\+\+ b\/(.+)$/m)?.[1];
+  const oldPath = raw.match(/^--- a\/(.+)$/m)?.[1];
+  return {
+    path: newPath ?? fallbackPath,
+    oldPath: oldPath && oldPath !== newPath ? oldPath : undefined,
+  };
 }
 
 function isUntrackedWorktreePath(cwd: string, filePath: string): boolean {

--- a/plugins/sero-git-plugin/extension/git-default-branch.ts
+++ b/plugins/sero-git-plugin/extension/git-default-branch.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from 'node:child_process';
+
+function git(args: string[], cwd: string): string {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function refExists(cwd: string, ref: string): boolean {
+  return git(['rev-parse', '--verify', ref], cwd).length > 0;
+}
+
+export function getDefaultBranch(cwd: string): string | undefined {
+  const remoteNames = ['origin', ...git(['remote'], cwd).split('\n').map((line) => line.trim()).filter(Boolean)];
+
+  for (const remoteName of new Set(remoteNames)) {
+    const symbolicRef = git(['symbolic-ref', `refs/remotes/${remoteName}/HEAD`], cwd).trim();
+    const detectedBranch = symbolicRef.split('/').pop();
+    if (detectedBranch) return detectedBranch;
+
+    const remoteInfo = git(['remote', 'show', '-n', remoteName], cwd);
+    const remoteHeadBranch = remoteInfo.match(/HEAD branch:\s+(.+)/)?.[1]?.trim();
+    if (remoteHeadBranch && remoteHeadBranch !== '(unknown)') return remoteHeadBranch;
+  }
+
+  for (const branch of ['main', 'master']) {
+    if (refExists(cwd, `refs/remotes/origin/${branch}`) || refExists(cwd, `refs/heads/${branch}`)) {
+      return branch;
+    }
+  }
+
+  return undefined;
+}

--- a/plugins/sero-git-plugin/extension/git-exec.ts
+++ b/plugins/sero-git-plugin/extension/git-exec.ts
@@ -1,10 +1,41 @@
-import { execFileSync } from 'node:child_process';
+import { execFile, execFileSync } from 'node:child_process';
+import { promisify } from 'node:util';
 
 interface RunGitOptions {
   timeout?: number;
   maxBuffer?: number;
   allowFailure?: boolean;
   trim?: boolean;
+}
+
+interface ExecErrorLike {
+  stderr?: string | Buffer;
+  stdout?: string | Buffer;
+  message?: string;
+}
+
+const execFileAsync = promisify(execFile);
+
+function normalizeOutput(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (Buffer.isBuffer(value)) return value.toString('utf8').trim();
+  return '';
+}
+
+function formatGitError(error: unknown, args: string[]): string {
+  const execError = error as ExecErrorLike | undefined;
+  const stderr = normalizeOutput(execError?.stderr);
+  if (stderr) return stderr.split(/\r?\n/).find((line) => line.trim().length > 0) ?? stderr;
+
+  const stdout = normalizeOutput(execError?.stdout);
+  if (stdout) return stdout.split(/\r?\n/).find((line) => line.trim().length > 0) ?? stdout;
+
+  if (error instanceof Error && error.message) return error.message;
+  return `git ${args.join(' ')} failed`;
+}
+
+function normalizeResult(output: string, trim: boolean): string {
+  return trim ? output.trim() : output;
 }
 
 export function runGit(
@@ -25,9 +56,38 @@ export function runGit(
       maxBuffer,
     });
 
-    return trim ? output.trim() : output;
+    return normalizeResult(output, trim);
   } catch (error) {
     if (allowFailure) return '';
-    throw error;
+    throw new Error(formatGitError(error, args), {
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+}
+
+export async function runGitAsync(
+  args: string[],
+  cwd: string,
+  {
+    timeout = 15_000,
+    maxBuffer = 10 * 1024 * 1024,
+    allowFailure = false,
+    trim = true,
+  }: RunGitOptions = {},
+): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      timeout,
+      maxBuffer,
+    });
+
+    return normalizeResult(stdout, trim);
+  } catch (error) {
+    if (allowFailure) return '';
+    throw new Error(formatGitError(error, args), {
+      cause: error instanceof Error ? error : undefined,
+    });
   }
 }

--- a/plugins/sero-git-plugin/extension/git-refresh.ts
+++ b/plugins/sero-git-plugin/extension/git-refresh.ts
@@ -1,0 +1,98 @@
+import type {
+  BranchInfo,
+  GitAppState,
+  GitSyncMode,
+  RemoteInfo,
+} from '../shared/types';
+import {
+  getCurrentBranch,
+  getFileChanges,
+  getHeadHash,
+  getRemotes,
+  getRepoName,
+  getStashes,
+} from './git-commands';
+import { getDefaultBranch } from './git-default-branch';
+import { getBranches, getRemoteBranches } from './git-refs';
+
+interface GitRefSnapshot {
+  currentBranch: string;
+  headHash: string;
+  defaultBranch?: string;
+  branches: BranchInfo[];
+  remoteBranches: BranchInfo[];
+  remotes: RemoteInfo[];
+}
+
+function serializeBranch(branch: BranchInfo): string {
+  return [
+    branch.name,
+    branch.current ? '1' : '0',
+    branch.remote ?? '',
+    String(branch.ahead),
+    String(branch.behind),
+    branch.lastCommitHash ?? '',
+    branch.lastCommitDate ?? '',
+    branch.checkedOutIn ?? '',
+  ].join('\u0000');
+}
+
+function serializeRemote(remote: RemoteInfo): string {
+  return [remote.name, remote.fetchUrl, remote.pushUrl].join('\u0000');
+}
+
+function createRefSignature(snapshot: Pick<GitRefSnapshot, 'defaultBranch' | 'branches' | 'remoteBranches' | 'remotes'>): string {
+  const remotes = [...snapshot.remotes].sort((a, b) => a.name.localeCompare(b.name));
+  return [
+    snapshot.defaultBranch ?? '',
+    snapshot.branches.map(serializeBranch).join('\n'),
+    snapshot.remoteBranches.map(serializeBranch).join('\n'),
+    remotes.map(serializeRemote).join('\n'),
+  ].join('\n---\n');
+}
+
+export function createGitRefSnapshot(cwd: string): GitRefSnapshot {
+  return {
+    currentBranch: getCurrentBranch(cwd),
+    headHash: getHeadHash(cwd),
+    defaultBranch: getDefaultBranch(cwd),
+    branches: getBranches(cwd),
+    remoteBranches: getRemoteBranches(cwd),
+    remotes: getRemotes(cwd),
+  };
+}
+
+export function canUseQuickRefresh(previousState: GitAppState, snapshot: GitRefSnapshot): boolean {
+  if (!previousState.repoPath) return false;
+  if (!previousState.commits.length) return false;
+  if (!previousState.branches.length && !previousState.remoteBranches.length) return false;
+  if (previousState.currentBranch !== snapshot.currentBranch) return false;
+  if (previousState.headHash !== snapshot.headHash) return false;
+
+  return createRefSignature(previousState) === createRefSignature(snapshot);
+}
+
+export function createQuickRefreshState(
+  cwd: string,
+  syncMode: GitSyncMode,
+  previousState: GitAppState,
+  snapshot: GitRefSnapshot,
+): GitAppState {
+  return {
+    ...previousState,
+    repoPath: cwd,
+    repoName: getRepoName(cwd),
+    currentBranch: snapshot.currentBranch,
+    headHash: snapshot.headHash,
+    defaultBranch: snapshot.defaultBranch,
+    branches: snapshot.branches,
+    remoteBranches: snapshot.remoteBranches,
+    remotes: snapshot.remotes,
+    fileChanges: getFileChanges(cwd),
+    stashes: getStashes(cwd),
+    lastRefresh: new Date().toISOString(),
+    loading: false,
+    syncMode,
+    error: undefined,
+  };
+}

--- a/plugins/sero-git-plugin/extension/git-refs.ts
+++ b/plugins/sero-git-plugin/extension/git-refs.ts
@@ -47,7 +47,6 @@ function parseTracking(track?: string): { ahead: number; behind: number } {
 
 function sortBranches(branches: BranchInfo[]): BranchInfo[] {
   return [...branches].sort((a, b) => {
-    if (a.current !== b.current) return a.current ? -1 : 1;
     const aTime = a.lastCommitDate ? Date.parse(a.lastCommitDate) : 0;
     const bTime = b.lastCommitDate ? Date.parse(b.lastCommitDate) : 0;
     if (aTime !== bTime) return bTime - aTime;

--- a/plugins/sero-git-plugin/extension/git-refs.ts
+++ b/plugins/sero-git-plugin/extension/git-refs.ts
@@ -1,0 +1,108 @@
+import path from 'node:path';
+
+import type { BranchInfo } from '../shared/types';
+import { runGit } from './git-exec';
+
+function git(args: string[], cwd: string): string {
+  return runGit(args, cwd, { allowFailure: true });
+}
+
+function nonEmpty(line: string): boolean {
+  return line.trim().length > 0;
+}
+
+function getWorktreeRoot(cwd: string): string {
+  return git(['rev-parse', '--show-toplevel'], cwd) || cwd;
+}
+
+function getBranchWorktreeMap(cwd: string): Map<string, string> {
+  const raw = git(['worktree', 'list', '--porcelain'], cwd);
+  if (!raw) return new Map();
+
+  const worktreeRoot = path.resolve(getWorktreeRoot(cwd));
+  const result = new Map<string, string>();
+  const blocks = raw.split(/\n(?=worktree )/g).filter(nonEmpty);
+
+  for (const block of blocks) {
+    const lines = block.split('\n').filter(nonEmpty);
+    const worktreePath = lines.find((line) => line.startsWith('worktree '))?.slice('worktree '.length);
+    const branchRef = lines.find((line) => line.startsWith('branch '))?.slice('branch '.length);
+    if (!worktreePath || !branchRef?.startsWith('refs/heads/')) continue;
+
+    const branchName = branchRef.slice('refs/heads/'.length);
+    const resolvedWorktree = path.resolve(worktreePath);
+    if (resolvedWorktree === worktreeRoot) continue;
+    result.set(branchName, worktreePath);
+  }
+
+  return result;
+}
+
+function parseTracking(track?: string): { ahead: number; behind: number } {
+  return {
+    ahead: parseInt(track?.match(/ahead (\d+)/)?.[1] ?? '0', 10),
+    behind: parseInt(track?.match(/behind (\d+)/)?.[1] ?? '0', 10),
+  };
+}
+
+function sortBranches(branches: BranchInfo[]): BranchInfo[] {
+  return [...branches].sort((a, b) => {
+    if (a.current !== b.current) return a.current ? -1 : 1;
+    const aTime = a.lastCommitDate ? Date.parse(a.lastCommitDate) : 0;
+    const bTime = b.lastCommitDate ? Date.parse(b.lastCommitDate) : 0;
+    if (aTime !== bTime) return bTime - aTime;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function getBranches(cwd: string): BranchInfo[] {
+  const raw = git([
+    'for-each-ref',
+    '--format=%(refname:short)%00%(HEAD)%00%(upstream:short)%00%(upstream:track,nobracket)%00%(objectname:short)%00%(creatordate:iso-strict)',
+    'refs/heads/',
+  ], cwd);
+  if (!raw) return [];
+
+  const worktreeByBranch = getBranchWorktreeMap(cwd);
+  const branches = raw.split('\n').filter(nonEmpty).map((line) => {
+    const [name, head, upstream, track, hash, date] = line.split('\x00');
+    const branchName = name ?? '';
+    const tracking = parseTracking(track);
+
+    return {
+      name: branchName,
+      current: head === '*',
+      remote: upstream || undefined,
+      ahead: tracking.ahead,
+      behind: tracking.behind,
+      lastCommitHash: hash,
+      lastCommitDate: date,
+      checkedOutIn: worktreeByBranch.get(branchName),
+    } satisfies BranchInfo;
+  });
+
+  return sortBranches(branches);
+}
+
+export function getRemoteBranches(cwd: string): BranchInfo[] {
+  const raw = git([
+    'for-each-ref',
+    '--format=%(refname:short)%00%(objectname:short)%00%(creatordate:iso-strict)',
+    'refs/remotes/',
+  ], cwd);
+  if (!raw) return [];
+
+  const remoteBranches = raw.split('\n').filter(nonEmpty).map((line) => {
+    const [name, hash, date] = line.split('\x00');
+    return {
+      name: name ?? '',
+      current: false,
+      ahead: 0,
+      behind: 0,
+      lastCommitHash: hash,
+      lastCommitDate: date,
+    } satisfies BranchInfo;
+  }).filter((branch) => branch.name !== 'origin/HEAD' && !branch.name.endsWith('/HEAD'));
+
+  return sortBranches(remoteBranches);
+}

--- a/plugins/sero-git-plugin/extension/git-service.ts
+++ b/plugins/sero-git-plugin/extension/git-service.ts
@@ -22,6 +22,7 @@ import {
 } from './git-commands';
 import { getBranches, getRemoteBranches } from './git-refs';
 import { getDefaultBranch } from './git-default-branch';
+import { canUseQuickRefresh, createGitRefSnapshot, createQuickRefreshState } from './git-refresh';
 import { runGit, runGitAsync } from './git-exec';
 import { readState, writeState } from './state-io';
 
@@ -104,36 +105,6 @@ async function unstageChanges(cwd: string, exec: (args: string[]) => Promise<str
   await exec(['rm', '-r', '--cached', '--', '.']);
 }
 
-function canUseQuickRefresh(previousState: GitAppState, currentBranch: string, headHash: string): boolean {
-  if (!previousState.repoPath) return false;
-  if (!previousState.commits.length) return false;
-  if (!previousState.branches.length && !previousState.remoteBranches.length) return false;
-  return previousState.currentBranch === currentBranch && previousState.headHash === headHash;
-}
-
-function createQuickRefreshState(
-  cwd: string,
-  syncMode: GitSyncMode,
-  previousState: GitAppState,
-  currentBranch: string,
-  headHash: string,
-): GitAppState {
-  return {
-    ...previousState,
-    repoPath: cwd,
-    repoName: getRepoName(cwd),
-    currentBranch,
-    headHash,
-    defaultBranch: previousState.defaultBranch,
-    fileChanges: getFileChanges(cwd),
-    stashes: getStashes(cwd),
-    lastRefresh: new Date().toISOString(),
-    loading: false,
-    syncMode,
-    error: undefined,
-  };
-}
-
 function createFullRefreshState(cwd: string, syncMode: GitSyncMode): GitAppState {
   return {
     repoPath: cwd,
@@ -185,11 +156,10 @@ export async function refreshGitState(
 
   if (scope === 'auto') {
     const previousState = await readState(statePath);
-    const currentBranch = getCurrentBranch(cwd);
-    const headHash = getHeadHash(cwd);
+    const snapshot = createGitRefSnapshot(cwd);
 
-    if (canUseQuickRefresh(previousState, currentBranch, headHash)) {
-      const state = createQuickRefreshState(cwd, syncMode, previousState, currentBranch, headHash);
+    if (canUseQuickRefresh(previousState, snapshot)) {
+      const state = createQuickRefreshState(cwd, syncMode, previousState, snapshot);
       await writeState(statePath, state);
       return state;
     }

--- a/plugins/sero-git-plugin/extension/git-service.ts
+++ b/plugins/sero-git-plugin/extension/git-service.ts
@@ -6,9 +6,8 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import type { GitAppState, GitManagerRequest, GitSyncMode } from '../shared/types';
-import { DEFAULT_GIT_STATE } from '../shared/types';
+import { createDefaultGitState } from '../shared/types';
 import {
-  getBranches,
   getCommitCount,
   getCommitDiff,
   getCommits,
@@ -21,7 +20,8 @@ import {
   getStashes,
   isGitRepo,
 } from './git-commands';
-import { runGit } from './git-exec';
+import { getBranches, getRemoteBranches } from './git-refs';
+import { runGit, runGitAsync } from './git-exec';
 import { readState, writeState } from './state-io';
 
 // Match the Git app state directory anywhere in the repo so nested workspaces
@@ -33,8 +33,11 @@ export type GitActionResult = {
   message: string;
 };
 
+type GitRefreshScope = 'auto' | 'full';
+
 interface GitRefreshOptions {
   syncMode?: GitSyncMode;
+  scope?: GitRefreshScope;
 }
 
 async function ensureGitStateIgnored(cwd: string): Promise<void> {
@@ -64,9 +67,9 @@ async function ensureGitStateIgnored(cwd: string): Promise<void> {
   await fs.writeFile(excludePath, next, 'utf8');
 }
 
-function pushWithUpstreamFallback(cwd: string, exec: (args: string[]) => string): string {
+async function pushWithUpstreamFallback(cwd: string, exec: (args: string[]) => Promise<string>): Promise<string> {
   try {
-    return exec(['push']);
+    return await exec(['push']);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     const upstreamMissing = /upstream branch|has no upstream branch|set the remote as upstream/i.test(message);
@@ -81,16 +84,91 @@ function pushWithUpstreamFallback(cwd: string, exec: (args: string[]) => string)
   }
 }
 
+function hasHeadCommit(cwd: string): boolean {
+  return runGit(['rev-parse', '--verify', 'HEAD'], cwd, { allowFailure: true }).length > 0;
+}
+
+async function unstageChanges(cwd: string, exec: (args: string[]) => Promise<string>, file?: string): Promise<void> {
+  if (hasHeadCommit(cwd)) {
+    if (file) await exec(['reset', 'HEAD', '--', file]);
+    else await exec(['reset', 'HEAD']);
+    return;
+  }
+
+  if (file) {
+    await exec(['rm', '--cached', '--', file]);
+    return;
+  }
+
+  await exec(['rm', '-r', '--cached', '--', '.']);
+}
+
+function canUseQuickRefresh(previousState: GitAppState, currentBranch: string, headHash: string): boolean {
+  if (!previousState.repoPath) return false;
+  if (!previousState.commits.length) return false;
+  if (!previousState.branches.length && !previousState.remoteBranches.length) return false;
+  return previousState.currentBranch === currentBranch && previousState.headHash === headHash;
+}
+
+function createQuickRefreshState(
+  cwd: string,
+  syncMode: GitSyncMode,
+  previousState: GitAppState,
+  currentBranch: string,
+  headHash: string,
+): GitAppState {
+  return {
+    ...previousState,
+    repoPath: cwd,
+    repoName: getRepoName(cwd),
+    currentBranch,
+    headHash,
+    fileChanges: getFileChanges(cwd),
+    stashes: getStashes(cwd),
+    lastRefresh: new Date().toISOString(),
+    loading: false,
+    syncMode,
+    error: undefined,
+  };
+}
+
+function createFullRefreshState(cwd: string, syncMode: GitSyncMode): GitAppState {
+  return {
+    repoPath: cwd,
+    repoName: getRepoName(cwd),
+    currentBranch: getCurrentBranch(cwd),
+    headHash: getHeadHash(cwd),
+    branches: getBranches(cwd),
+    remoteBranches: getRemoteBranches(cwd),
+    remotes: getRemotes(cwd),
+    commits: getCommits(cwd, 150),
+    stashes: getStashes(cwd),
+    fileChanges: getFileChanges(cwd),
+    commitCount: getCommitCount(cwd),
+    lastRefresh: new Date().toISOString(),
+    loading: false,
+    syncMode,
+  };
+}
+
+function formatActionError(action: GitManagerRequest['action'], message: string): string {
+  if ((action === 'cherry_pick' || action === 'merge') && /after resolving the conflicts|conflict/i.test(message)) {
+    return `${message} Resolve the conflicts in your workspace, stage the files, and continue from the command line if needed.`;
+  }
+  return message;
+}
+
 export async function refreshGitState(
   cwd: string,
   statePath: string,
   options: GitRefreshOptions = {},
 ): Promise<GitAppState> {
   const syncMode = options.syncMode ?? 'manual';
+  const scope = options.scope ?? 'full';
 
   if (!isGitRepo(cwd)) {
     const state: GitAppState = {
-      ...DEFAULT_GIT_STATE,
+      ...createDefaultGitState(),
       repoPath: cwd,
       error: 'Not a git repository',
       lastRefresh: new Date().toISOString(),
@@ -102,22 +180,19 @@ export async function refreshGitState(
 
   await ensureGitStateIgnored(cwd);
 
-  const state: GitAppState = {
-    repoPath: cwd,
-    repoName: getRepoName(cwd),
-    currentBranch: getCurrentBranch(cwd),
-    headHash: getHeadHash(cwd),
-    branches: getBranches(cwd),
-    remotes: getRemotes(cwd),
-    commits: getCommits(cwd, 150),
-    stashes: getStashes(cwd),
-    fileChanges: getFileChanges(cwd),
-    commitCount: getCommitCount(cwd),
-    lastRefresh: new Date().toISOString(),
-    loading: false,
-    syncMode,
-  };
+  if (scope === 'auto') {
+    const previousState = await readState(statePath);
+    const currentBranch = getCurrentBranch(cwd);
+    const headHash = getHeadHash(cwd);
 
+    if (canUseQuickRefresh(previousState, currentBranch, headHash)) {
+      const state = createQuickRefreshState(cwd, syncMode, previousState, currentBranch, headHash);
+      await writeState(statePath, state);
+      return state;
+    }
+  }
+
+  const state = createFullRefreshState(cwd, syncMode);
   await writeState(statePath, state);
   return state;
 }
@@ -130,13 +205,13 @@ export async function runGitAction(
 ): Promise<GitActionResult> {
   const ok = (message: string): GitActionResult => ({ ok: true, message });
   const err = (message: string): GitActionResult => ({ ok: false, message });
-  const exec = (args: string[]) => runGit(args, cwd, { timeout: 30_000 });
-  const refresh = () => refreshGitState(cwd, statePath, options);
+  const exec = (args: string[]) => runGitAsync(args, cwd, { timeout: 30_000 });
+  const refresh = (scope: GitRefreshScope = 'full') => refreshGitState(cwd, statePath, { ...options, scope });
 
   try {
     switch (params.action) {
       case 'refresh': {
-        const state = await refresh();
+        const state = await refresh('full');
         const staged = state.fileChanges.filter((file) => file.staged).length;
         const unstaged = state.fileChanges.filter((file) => !file.staged).length;
         return ok(
@@ -147,7 +222,7 @@ export async function runGitAction(
       }
 
       case 'status': {
-        const state = await refresh();
+        const state = await refresh('auto');
         const staged = state.fileChanges.filter((file) => file.staged);
         const unstaged = state.fileChanges.filter((file) => !file.staged);
         let message = `On branch ${state.currentBranch}\n`;
@@ -174,16 +249,18 @@ export async function runGitAction(
 
       case 'branches': {
         const state = await readState(statePath);
-        return ok(
-          state.branches
-            .map((branch) => {
-              return `${branch.current ? '* ' : '  '}${branch.name}` +
-                `${branch.remote ? ` -> ${branch.remote}` : ''}` +
-                `${branch.ahead ? ` +${branch.ahead}` : ''}` +
-                `${branch.behind ? ` -${branch.behind}` : ''}`;
-            })
-            .join('\n') || 'No branches.',
-        );
+        const localBranchLines = state.branches.map((branch) => {
+          return `${branch.current ? '* ' : '  '}${branch.name}` +
+            `${branch.remote ? ` -> ${branch.remote}` : ''}` +
+            `${branch.ahead ? ` +${branch.ahead}` : ''}` +
+            `${branch.behind ? ` -${branch.behind}` : ''}` +
+            `${branch.checkedOutIn ? ` [worktree: ${branch.checkedOutIn}]` : ''}`;
+        });
+        const remoteBranchLines = state.remoteBranches.map((branch) => `  ${branch.name}`);
+        const sections = [];
+        if (localBranchLines.length) sections.push(`Local:\n${localBranchLines.join('\n')}`);
+        if (remoteBranchLines.length) sections.push(`\nRemote:\n${remoteBranchLines.join('\n')}`);
+        return ok(sections.join('\n') || 'No branches.');
       }
 
       case 'diff': {
@@ -200,69 +277,80 @@ export async function runGitAction(
       }
 
       case 'stage': {
-        if (params.all) exec(['add', '-A']);
-        else if (params.file) exec(['add', '--', params.file]);
+        if (params.all) await exec(['add', '-A']);
+        else if (params.file) await exec(['add', '--', params.file]);
         else return err('file or all=true required');
-        await refresh();
+        await refresh('auto');
         return ok(params.all ? 'Staged all changes.' : `Staged ${params.file}`);
       }
 
       case 'unstage': {
-        if (params.all) exec(['reset', 'HEAD']);
-        else if (params.file) exec(['reset', 'HEAD', '--', params.file]);
+        if (params.all) await unstageChanges(cwd, exec);
+        else if (params.file) await unstageChanges(cwd, exec, params.file);
         else return err('file or all=true required');
-        await refresh();
+        await refresh('auto');
         return ok(params.all ? 'Unstaged all.' : `Unstaged ${params.file}`);
       }
 
       case 'commit': {
         if (!params.message) return err('message is required for commit');
-        if (params.all) exec(['add', '-A']);
-        exec(['commit', '-m', params.message]);
-        await refresh();
+        if (params.all) await exec(['add', '-A']);
+        await exec(['commit', '-m', params.message]);
+        await refresh('full');
         return ok(`Committed: ${params.message}`);
       }
 
       case 'checkout': {
         if (!params.branch) return err('branch is required');
-        exec(['checkout', params.branch]);
-        await refresh();
+        const branch = getBranches(cwd).find((entry) => entry.name === params.branch);
+        if (branch?.checkedOutIn) {
+          return err(`Branch ${params.branch} is already checked out in ${branch.checkedOutIn}`);
+        }
+        await exec(['switch', params.branch]);
+        await refresh('full');
         return ok(`Switched to ${params.branch}`);
       }
 
       case 'create_branch': {
         if (!params.branch) return err('branch name is required');
-        exec(['checkout', '-b', params.branch]);
-        await refresh();
+        await exec(['switch', '-c', params.branch]);
+        await refresh('full');
         return ok(`Created and switched to ${params.branch}`);
       }
 
       case 'delete_branch': {
         if (!params.branch) return err('branch name is required');
-        exec(['branch', '-d', params.branch]);
-        await refresh();
+        await exec(['branch', '-d', params.branch]);
+        await refresh('full');
         return ok(`Deleted branch ${params.branch}`);
       }
 
       case 'merge': {
         if (!params.branch) return err('branch is required');
-        const result = exec(['merge', params.branch]);
-        await refresh();
+        const result = await exec(['merge', params.branch]);
+        await refresh('full');
         return ok(`Merged ${params.branch}: ${result.split('\n')[0]}`);
       }
 
       case 'cherry_pick': {
         if (!params.hash) return err('hash is required');
-        exec(['cherry-pick', params.hash]);
-        await refresh();
+        const fileChanges = getFileChanges(cwd);
+        if (fileChanges.length > 0) {
+          if (!params.all) {
+            return err('Working tree has uncommitted changes. Stash or commit them before cherry-picking.');
+          }
+          await exec(['stash', 'push', '-u', '-m', `Auto-stash before cherry-pick ${params.hash}`]);
+        }
+        await exec(['cherry-pick', params.hash]);
+        await refresh('full');
         return ok(`Cherry-picked ${params.hash}`);
       }
 
       case 'stash': {
         const args = ['stash', 'push'];
         if (params.message) args.push('-m', params.message);
-        exec(args);
-        await refresh();
+        await exec(args);
+        await refresh('auto');
         return ok('Changes stashed.');
       }
 
@@ -278,26 +366,43 @@ export async function runGitAction(
           ? `stash@{${params.stashIndex}}`
           : undefined;
         const args = target ? ['stash', 'pop', target] : ['stash', 'pop'];
-        exec(args);
-        await refresh();
+        await exec(args);
+        await refresh('auto');
         return ok(target ? `Popped ${target}.` : 'Stash popped.');
       }
 
+      case 'stash_apply': {
+        if (
+          params.stashIndex !== undefined &&
+          (!Number.isInteger(params.stashIndex) || params.stashIndex < 0)
+        ) {
+          return err('stashIndex must be a non-negative integer');
+        }
+
+        const target = params.stashIndex !== undefined
+          ? `stash@{${params.stashIndex}}`
+          : undefined;
+        const args = target ? ['stash', 'apply', target] : ['stash', 'apply'];
+        await exec(args);
+        await refresh('auto');
+        return ok(target ? `Applied ${target}.` : 'Stash applied.');
+      }
+
       case 'fetch': {
-        exec(['fetch', '--all', '--prune']);
-        await refresh();
+        await exec(['fetch', '--all', '--prune']);
+        await refresh('full');
         return ok('Fetched all remotes.');
       }
 
       case 'pull': {
-        const result = exec(['pull']);
-        await refresh();
+        const result = await exec(['pull']);
+        await refresh('full');
         return ok(`Pulled: ${result.split('\n')[0]}`);
       }
 
       case 'push': {
-        const result = pushWithUpstreamFallback(cwd, exec);
-        await refresh();
+        const result = await pushWithUpstreamFallback(cwd, exec);
+        await refresh('full');
         return ok(`Pushed: ${result || 'up to date'}`);
       }
 
@@ -318,6 +423,6 @@ export async function runGitAction(
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return err(message.split('\n')[0] ?? message);
+    return err(formatActionError(params.action, message));
   }
 }

--- a/plugins/sero-git-plugin/extension/git-service.ts
+++ b/plugins/sero-git-plugin/extension/git-service.ts
@@ -21,6 +21,7 @@ import {
   isGitRepo,
 } from './git-commands';
 import { getBranches, getRemoteBranches } from './git-refs';
+import { getDefaultBranch } from './git-default-branch';
 import { runGit, runGitAsync } from './git-exec';
 import { readState, writeState } from './state-io';
 
@@ -123,6 +124,7 @@ function createQuickRefreshState(
     repoName: getRepoName(cwd),
     currentBranch,
     headHash,
+    defaultBranch: previousState.defaultBranch,
     fileChanges: getFileChanges(cwd),
     stashes: getStashes(cwd),
     lastRefresh: new Date().toISOString(),
@@ -138,6 +140,7 @@ function createFullRefreshState(cwd: string, syncMode: GitSyncMode): GitAppState
     repoName: getRepoName(cwd),
     currentBranch: getCurrentBranch(cwd),
     headHash: getHeadHash(cwd),
+    defaultBranch: getDefaultBranch(cwd),
     branches: getBranches(cwd),
     remoteBranches: getRemoteBranches(cwd),
     remotes: getRemotes(cwd),
@@ -320,9 +323,65 @@ export async function runGitAction(
 
       case 'delete_branch': {
         if (!params.branch) return err('branch name is required');
-        await exec(['branch', '-d', params.branch]);
+
+        const branchName = params.branch;
+        const currentBranch = getCurrentBranch(cwd);
+        if (branchName === currentBranch) {
+          return err(`Cannot delete the current branch ${branchName}. Switch to another branch first.`);
+        }
+
+        const defaultBranch = getDefaultBranch(cwd);
+        if (defaultBranch && branchName === defaultBranch) {
+          return err(`Cannot delete the default branch ${branchName}.`);
+        }
+
+        const branch = getBranches(cwd).find((entry) => entry.name === branchName);
+        if (branch?.checkedOutIn) {
+          return err(`Branch ${branchName} is already checked out in ${branch.checkedOutIn}`);
+        }
+
+        try {
+          await exec(['branch', params.force ? '-D' : '-d', branchName]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!params.force && /not fully merged/i.test(message)) {
+            return err(`${message} Use force delete to remove it anyway.`);
+          }
+          throw error;
+        }
+
         await refresh('full');
-        return ok(`Deleted branch ${params.branch}`);
+        return ok(`${params.force ? 'Force deleted' : 'Deleted'} branch ${branchName}`);
+      }
+
+      case 'remove_worktree': {
+        if (!params.worktreePath) return err('worktreePath is required');
+
+        const worktreePath = params.worktreePath;
+        const repoRoot = runGit(['rev-parse', '--show-toplevel'], cwd, { allowFailure: true }) || cwd;
+        const resolvedWorktreePath = await fs.realpath(worktreePath).catch(() => path.resolve(worktreePath));
+        const resolvedRepoRoot = await fs.realpath(repoRoot).catch(() => path.resolve(repoRoot));
+        if (resolvedWorktreePath === resolvedRepoRoot) {
+          return err('Cannot remove the main worktree.');
+        }
+
+        try {
+          await exec([
+            'worktree',
+            'remove',
+            ...(params.force ? ['--force', '--force'] : []),
+            worktreePath,
+          ]);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!params.force && /(dirty|modified|untracked|locked)/i.test(message)) {
+            return err(`${message} Use force remove to remove it anyway.`);
+          }
+          throw error;
+        }
+
+        await refresh('full');
+        return ok(`${params.force ? 'Force removed' : 'Removed'} worktree ${worktreePath}`);
       }
 
       case 'merge': {

--- a/plugins/sero-git-plugin/extension/index.ts
+++ b/plugins/sero-git-plugin/extension/index.ts
@@ -29,6 +29,7 @@ const ACTIONS = [
   'checkout',
   'stash',
   'stash_pop',
+  'stash_apply',
   'fetch',
   'pull',
   'push',
@@ -47,7 +48,7 @@ const GitManagerParams = Type.Object({
   hash: Type.Optional(Type.String({ description: 'Commit hash' })),
   staged: Type.Optional(Type.Boolean({ description: 'View staged diff (default: false)' })),
   all: Type.Optional(Type.Boolean({ description: 'Stage all / push all' })),
-  stashIndex: Type.Optional(Type.Number({ description: 'Specific stash index to pop (e.g. 0 for stash@{0})' })),
+  stashIndex: Type.Optional(Type.Number({ description: 'Specific stash index to apply/pop (e.g. 0 for stash@{0})' })),
 });
 
 type ToolResult = {
@@ -77,7 +78,7 @@ export default function (pi: ExtensionAPI) {
     name: 'git_manager',
     label: 'Git',
     description:
-      'Manage the workspace Git repository. Actions: refresh (reload all state), status (working tree summary), log (recent commits), branches (list branches), diff (file diff — requires file, optional staged), stage (requires file or all=true), unstage (requires file or all=true), commit (requires message, optional all to auto-stage), checkout (requires branch), create_branch (requires branch), delete_branch (requires branch), merge (requires branch), cherry_pick (requires hash), stash (optional message), stash_pop (optional stashIndex to pop a specific stash), fetch, pull, push, show_commit (requires hash for detailed commit diff).',
+      'Manage the workspace Git repository. Actions: refresh (reload all state), status (working tree summary), log (recent commits), branches (list branches), diff (file diff — requires file, optional staged), stage (requires file or all=true), unstage (requires file or all=true), commit (requires message, optional all to auto-stage), checkout (requires branch), create_branch (requires branch), delete_branch (requires branch), merge (requires branch), cherry_pick (requires hash, optional all=true to auto-stash a dirty working tree first), stash (optional message), stash_pop (optional stashIndex to pop a specific stash), stash_apply (optional stashIndex to apply without dropping the stash), fetch, pull, push, show_commit (requires hash for detailed commit diff).',
     parameters: GitManagerParams,
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {

--- a/plugins/sero-git-plugin/extension/index.ts
+++ b/plugins/sero-git-plugin/extension/index.ts
@@ -35,6 +35,7 @@ const ACTIONS = [
   'push',
   'create_branch',
   'delete_branch',
+  'remove_worktree',
   'merge',
   'cherry_pick',
   'show_commit',
@@ -46,8 +47,10 @@ const GitManagerParams = Type.Object({
   message: Type.Optional(Type.String({ description: 'Commit or stash message' })),
   branch: Type.Optional(Type.String({ description: 'Branch name' })),
   hash: Type.Optional(Type.String({ description: 'Commit hash' })),
+  worktreePath: Type.Optional(Type.String({ description: 'Linked worktree path' })),
   staged: Type.Optional(Type.Boolean({ description: 'View staged diff (default: false)' })),
   all: Type.Optional(Type.Boolean({ description: 'Stage all / push all' })),
+  force: Type.Optional(Type.Boolean({ description: 'Force the action when supported (for example, branch deletion)' })),
   stashIndex: Type.Optional(Type.Number({ description: 'Specific stash index to apply/pop (e.g. 0 for stash@{0})' })),
 });
 
@@ -78,7 +81,7 @@ export default function (pi: ExtensionAPI) {
     name: 'git_manager',
     label: 'Git',
     description:
-      'Manage the workspace Git repository. Actions: refresh (reload all state), status (working tree summary), log (recent commits), branches (list branches), diff (file diff — requires file, optional staged), stage (requires file or all=true), unstage (requires file or all=true), commit (requires message, optional all to auto-stage), checkout (requires branch), create_branch (requires branch), delete_branch (requires branch), merge (requires branch), cherry_pick (requires hash, optional all=true to auto-stash a dirty working tree first), stash (optional message), stash_pop (optional stashIndex to pop a specific stash), stash_apply (optional stashIndex to apply without dropping the stash), fetch, pull, push, show_commit (requires hash for detailed commit diff).',
+      'Manage the workspace Git repository. Actions: refresh (reload all state), status (working tree summary), log (recent commits), branches (list branches), diff (file diff — requires file, optional staged), stage (requires file or all=true), unstage (requires file or all=true), commit (requires message, optional all to auto-stage), checkout (requires branch), create_branch (requires branch), delete_branch (requires branch, optional force=true for -D), remove_worktree (requires worktreePath, optional force=true), merge (requires branch), cherry_pick (requires hash, optional all=true to auto-stash a dirty working tree first), stash (optional message), stash_pop (optional stashIndex to pop a specific stash), stash_apply (optional stashIndex to apply without dropping the stash), fetch, pull, push, show_commit (requires hash for detailed commit diff).',
     parameters: GitManagerParams,
 
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -100,6 +103,8 @@ export default function (pi: ExtensionAPI) {
       if (args.file) text += ` ${theme.fg('dim', args.file)}`;
       if (args.branch) text += ` ${theme.fg('accent', args.branch)}`;
       if (args.hash) text += ` ${theme.fg('accent', args.hash)}`;
+      if (args.worktreePath) text += ` ${theme.fg('dim', args.worktreePath)}`;
+      if (args.force) text += ` ${theme.fg('error', '--force')}`;
       if (typeof args.stashIndex === 'number') text += ` ${theme.fg('accent', `stash@{${args.stashIndex}}`)}`;
       return new Text(text, 0, 0);
     },

--- a/plugins/sero-git-plugin/extension/state-io.ts
+++ b/plugins/sero-git-plugin/extension/state-io.ts
@@ -6,7 +6,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import type { GitAppState } from '../shared/types';
-import { createDefaultGitState } from '../shared/types';
+import { createDefaultGitState, normalizeGitState } from '../shared/types';
 
 const STATE_REL_PATH = path.join('.sero', 'apps', 'git', 'state.json');
 
@@ -17,7 +17,7 @@ export function resolveStatePath(cwd: string): string {
 export async function readState(filePath: string): Promise<GitAppState> {
   try {
     const raw = await fs.readFile(filePath, 'utf8');
-    return JSON.parse(raw) as GitAppState;
+    return normalizeGitState(JSON.parse(raw) as Partial<GitAppState>);
   } catch {
     return createDefaultGitState();
   }

--- a/plugins/sero-git-plugin/extension/state-io.ts
+++ b/plugins/sero-git-plugin/extension/state-io.ts
@@ -6,7 +6,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import type { GitAppState } from '../shared/types';
-import { DEFAULT_GIT_STATE } from '../shared/types';
+import { createDefaultGitState } from '../shared/types';
 
 const STATE_REL_PATH = path.join('.sero', 'apps', 'git', 'state.json');
 
@@ -19,7 +19,7 @@ export async function readState(filePath: string): Promise<GitAppState> {
     const raw = await fs.readFile(filePath, 'utf8');
     return JSON.parse(raw) as GitAppState;
   } catch {
-    return { ...DEFAULT_GIT_STATE };
+    return createDefaultGitState();
   }
 }
 

--- a/plugins/sero-git-plugin/package.json
+++ b/plugins/sero-git-plugin/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "pnpm exec vitest run",
+    "test:watch": "pnpm exec vitest",
     "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json"
   },
   "pi": {
@@ -57,6 +59,7 @@
     "react-dom": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/plugins/sero-git-plugin/package.json
+++ b/plugins/sero-git-plugin/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@module-federation/vite": "catalog:",
     "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",
+    "@sero-ai/ui": "workspace:*",
     "@tailwindcss/vite": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",

--- a/plugins/sero-git-plugin/shared/__tests__/state-normalization.test.ts
+++ b/plugins/sero-git-plugin/shared/__tests__/state-normalization.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeGitState } from '../types';
+
+describe('normalizeGitState', () => {
+  it('fills in arrays missing from legacy persisted state', () => {
+    const state = normalizeGitState({
+      repoPath: '/tmp/repo',
+      repoName: 'repo',
+      currentBranch: 'main',
+      headHash: 'abc123',
+      branches: [],
+      remotes: [],
+      commits: [],
+      stashes: [],
+      fileChanges: [],
+      commitCount: 0,
+      lastRefresh: '2026-04-06T12:00:00.000Z',
+      loading: false,
+      syncMode: 'watch',
+    });
+
+    expect(state.remoteBranches).toEqual([]);
+    expect(state.branches).toEqual([]);
+    expect(state.remotes).toEqual([]);
+    expect(state.fileChanges).toEqual([]);
+    expect(state.currentBranch).toBe('main');
+  });
+
+  it('falls back cleanly when persisted values are malformed', () => {
+    const state = normalizeGitState({
+      branches: undefined,
+      remoteBranches: undefined,
+      remotes: undefined,
+      commits: undefined,
+      stashes: undefined,
+      fileChanges: undefined,
+      commitDiffs: undefined,
+      syncMode: 'bogus' as never,
+      loading: undefined,
+    });
+
+    expect(state.branches).toEqual([]);
+    expect(state.remoteBranches).toEqual([]);
+    expect(state.remotes).toEqual([]);
+    expect(state.commits).toEqual([]);
+    expect(state.stashes).toEqual([]);
+    expect(state.fileChanges).toEqual([]);
+    expect(state.syncMode).toBe('manual');
+    expect(state.loading).toBe(false);
+  });
+});

--- a/plugins/sero-git-plugin/shared/types.ts
+++ b/plugins/sero-git-plugin/shared/types.ts
@@ -176,6 +176,33 @@ export function createDefaultGitState(): GitAppState {
   };
 }
 
+export function normalizeGitState(state: Partial<GitAppState> | null | undefined): GitAppState {
+  const defaults = createDefaultGitState();
+  if (!state) return defaults;
+
+  return {
+    ...defaults,
+    ...state,
+    repoPath: typeof state.repoPath === 'string' ? state.repoPath : defaults.repoPath,
+    repoName: typeof state.repoName === 'string' ? state.repoName : defaults.repoName,
+    currentBranch: typeof state.currentBranch === 'string' ? state.currentBranch : defaults.currentBranch,
+    headHash: typeof state.headHash === 'string' ? state.headHash : defaults.headHash,
+    branches: Array.isArray(state.branches) ? state.branches : defaults.branches,
+    remoteBranches: Array.isArray(state.remoteBranches) ? state.remoteBranches : defaults.remoteBranches,
+    remotes: Array.isArray(state.remotes) ? state.remotes : defaults.remotes,
+    commits: Array.isArray(state.commits) ? state.commits : defaults.commits,
+    stashes: Array.isArray(state.stashes) ? state.stashes : defaults.stashes,
+    fileChanges: Array.isArray(state.fileChanges) ? state.fileChanges : defaults.fileChanges,
+    commitDiffs: Array.isArray(state.commitDiffs) ? state.commitDiffs : undefined,
+    lastRefresh: typeof state.lastRefresh === 'string' ? state.lastRefresh : defaults.lastRefresh,
+    loading: typeof state.loading === 'boolean' ? state.loading : defaults.loading,
+    syncMode: state.syncMode === 'watch' || state.syncMode === 'poll' || state.syncMode === 'manual'
+      ? state.syncMode
+      : defaults.syncMode,
+    error: typeof state.error === 'string' ? state.error : undefined,
+  };
+}
+
 export const DEFAULT_GIT_STATE: GitAppState = createDefaultGitState();
 
 /** Vibrant branch colors for the commit graph — GitKraken-inspired */

--- a/plugins/sero-git-plugin/shared/types.ts
+++ b/plugins/sero-git-plugin/shared/types.ts
@@ -111,6 +111,7 @@ export type GitManagerAction =
   | 'push'
   | 'create_branch'
   | 'delete_branch'
+  | 'remove_worktree'
   | 'merge'
   | 'cherry_pick'
   | 'show_commit';
@@ -121,8 +122,10 @@ export interface GitManagerRequest {
   message?: string;
   branch?: string;
   hash?: string;
+  worktreePath?: string;
   staged?: boolean;
   all?: boolean;
+  force?: boolean;
   stashIndex?: number;
 }
 
@@ -135,6 +138,7 @@ export interface GitAppState {
   repoName: string;
   currentBranch: string;
   headHash: string;
+  defaultBranch?: string;
 
   branches: BranchInfo[];
   remoteBranches: BranchInfo[];
@@ -163,6 +167,7 @@ export function createDefaultGitState(): GitAppState {
     repoName: '',
     currentBranch: '',
     headHash: '',
+    defaultBranch: undefined,
     branches: [],
     remoteBranches: [],
     remotes: [],
@@ -187,6 +192,7 @@ export function normalizeGitState(state: Partial<GitAppState> | null | undefined
     repoName: typeof state.repoName === 'string' ? state.repoName : defaults.repoName,
     currentBranch: typeof state.currentBranch === 'string' ? state.currentBranch : defaults.currentBranch,
     headHash: typeof state.headHash === 'string' ? state.headHash : defaults.headHash,
+    defaultBranch: typeof state.defaultBranch === 'string' ? state.defaultBranch : undefined,
     branches: Array.isArray(state.branches) ? state.branches : defaults.branches,
     remoteBranches: Array.isArray(state.remoteBranches) ? state.remoteBranches : defaults.remoteBranches,
     remotes: Array.isArray(state.remotes) ? state.remotes : defaults.remotes,

--- a/plugins/sero-git-plugin/shared/types.ts
+++ b/plugins/sero-git-plugin/shared/types.ts
@@ -33,6 +33,8 @@ export interface BranchInfo {
   behind: number;
   lastCommitHash?: string;
   lastCommitDate?: string;
+  /** Absolute worktree path when the branch is checked out elsewhere. */
+  checkedOutIn?: string;
 }
 
 export interface RemoteInfo {
@@ -103,6 +105,7 @@ export type GitManagerAction =
   | 'checkout'
   | 'stash'
   | 'stash_pop'
+  | 'stash_apply'
   | 'fetch'
   | 'pull'
   | 'push'
@@ -134,6 +137,7 @@ export interface GitAppState {
   headHash: string;
 
   branches: BranchInfo[];
+  remoteBranches: BranchInfo[];
   remotes: RemoteInfo[];
   commits: CommitNode[];
   stashes: StashEntry[];
@@ -153,21 +157,26 @@ export interface GitAppState {
   error?: string;
 }
 
-export const DEFAULT_GIT_STATE: GitAppState = {
-  repoPath: '',
-  repoName: '',
-  currentBranch: '',
-  headHash: '',
-  branches: [],
-  remotes: [],
-  commits: [],
-  stashes: [],
-  fileChanges: [],
-  commitCount: 0,
-  lastRefresh: new Date().toISOString(),
-  loading: false,
-  syncMode: 'manual',
-};
+export function createDefaultGitState(): GitAppState {
+  return {
+    repoPath: '',
+    repoName: '',
+    currentBranch: '',
+    headHash: '',
+    branches: [],
+    remoteBranches: [],
+    remotes: [],
+    commits: [],
+    stashes: [],
+    fileChanges: [],
+    commitCount: 0,
+    lastRefresh: new Date().toISOString(),
+    loading: false,
+    syncMode: 'manual',
+  };
+}
+
+export const DEFAULT_GIT_STATE: GitAppState = createDefaultGitState();
 
 /** Vibrant branch colors for the commit graph — GitKraken-inspired */
 export const BRANCH_COLORS = [

--- a/plugins/sero-git-plugin/ui/GitApp.tsx
+++ b/plugins/sero-git-plugin/ui/GitApp.tsx
@@ -204,6 +204,7 @@ export function GitApp() {
             </div>
 
             <CommitDetail
+              key={selectedCommit?.hash ?? 'none'}
               commit={selectedCommit}
               diffs={commitDiffs}
               hasWorkingTreeChanges={state.fileChanges.length > 0}
@@ -358,6 +359,7 @@ function getActionFailureTitle(action: GitManagerRequest['action']): string {
       return 'Could not fetch remotes';
     case 'stash':
     case 'stash_pop':
+    case 'stash_apply':
       return 'Could not update stashes';
     case 'cherry_pick':
       return 'Could not cherry-pick commit';

--- a/plugins/sero-git-plugin/ui/GitApp.tsx
+++ b/plugins/sero-git-plugin/ui/GitApp.tsx
@@ -10,7 +10,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { getSeroApi, useAppInfo, useAppState } from '@sero-ai/app-runtime';
 
 import type { CommitNode, FileDiff, GitAppState, GitManagerRequest } from '../shared/types';
-import { createDefaultGitState } from '../shared/types';
+import { createDefaultGitState, normalizeGitState } from '../shared/types';
 import { BranchPanel } from './components/BranchPanel';
 import { CommitDetail } from './components/CommitDetail';
 import { CommitGraph } from './components/CommitGraph';
@@ -38,7 +38,8 @@ interface GitActionResult {
 
 export function GitApp() {
   const initialState = useMemo(() => createDefaultGitState(), []);
-  const [state] = useAppState<GitAppState>(initialState);
+  const [rawState] = useAppState<GitAppState>(initialState);
+  const state = useMemo(() => normalizeGitState(rawState), [rawState]);
   const { workspaceId, workspacePath } = useAppInfo();
 
   const [selectedCommit, setSelectedCommit] = useState<CommitNode | null>(null);

--- a/plugins/sero-git-plugin/ui/GitApp.tsx
+++ b/plugins/sero-git-plugin/ui/GitApp.tsx
@@ -6,11 +6,11 @@
  * from @sero-ai/app-runtime for file-backed reactive state.
  */
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { getSeroApi, useAppInfo, useAppState } from '@sero-ai/app-runtime';
 
 import type { CommitNode, FileDiff, GitAppState, GitManagerRequest } from '../shared/types';
-import { DEFAULT_GIT_STATE } from '../shared/types';
+import { createDefaultGitState } from '../shared/types';
 import { BranchPanel } from './components/BranchPanel';
 import { CommitDetail } from './components/CommitDetail';
 import { CommitGraph } from './components/CommitGraph';
@@ -25,30 +25,74 @@ interface PendingDiffRequest {
   refreshSnapshot: string;
 }
 
+interface GitActionNoticeState {
+  id: number;
+  title: string;
+  message: string;
+}
+
+interface GitActionResult {
+  ok: boolean;
+  message: string;
+}
+
 export function GitApp() {
-  const [state] = useAppState<GitAppState>(DEFAULT_GIT_STATE);
+  const initialState = useMemo(() => createDefaultGitState(), []);
+  const [state] = useAppState<GitAppState>(initialState);
   const { workspaceId, workspacePath } = useAppInfo();
 
   const [selectedCommit, setSelectedCommit] = useState<CommitNode | null>(null);
   const [activeDiff, setActiveDiff] = useState<FileDiff | null>(null);
   const [pendingDiffRequest, setPendingDiffRequest] = useState<PendingDiffRequest | null>(null);
   const [showDiffPanel, setShowDiffPanel] = useState(false);
+  const [notice, setNotice] = useState<GitActionNoticeState | null>(null);
+  const noticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const dismissNotice = useCallback(() => {
+    if (noticeTimerRef.current) {
+      clearTimeout(noticeTimerRef.current);
+      noticeTimerRef.current = null;
+    }
+    setNotice(null);
+  }, []);
+
+  const showNotice = useCallback((title: string, message: string) => {
+    if (noticeTimerRef.current) {
+      clearTimeout(noticeTimerRef.current);
+    }
+
+    const nextNotice: GitActionNoticeState = {
+      id: Date.now(),
+      title,
+      message,
+    };
+    setNotice(nextNotice);
+    noticeTimerRef.current = setTimeout(() => {
+      setNotice((current) => current?.id === nextNotice.id ? null : current);
+      noticeTimerRef.current = null;
+    }, 5000);
+  }, []);
 
   const runAction = useCallback((params: GitManagerRequest) => {
     const gitApp = getSeroApi().gitApp;
     if (!gitApp) {
       console.warn('[git-app] gitApp bridge unavailable');
+      showNotice('Git bridge unavailable', 'Reload Sero or reopen this workspace to restore Git actions.');
       return;
     }
 
     void gitApp.run(workspaceId, params).then((result) => {
-      if (!result.ok) {
-        console.error('[git-app] Action failed:', result.message);
+      const actionResult = result as GitActionResult;
+      if (!actionResult.ok) {
+        console.error('[git-app] Action failed:', actionResult.message);
+        showNotice(getActionFailureTitle(params.action), actionResult.message);
       }
     }).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
       console.error('[git-app] Action failed:', error);
+      showNotice(getActionFailureTitle(params.action), message);
     });
-  }, [workspaceId]);
+  }, [showNotice, workspaceId]);
 
   const handleSelectCommit = useCallback((commit: CommitNode) => {
     setSelectedCommit(commit);
@@ -116,6 +160,12 @@ export function GitApp() {
       <div className="git-root relative flex h-full w-full flex-col overflow-hidden">
         <Header state={state} onAction={runAction} />
 
+        {notice && (
+          <div className="pointer-events-none absolute right-4 top-14 z-30 flex w-[min(30rem,calc(100%-2rem))] justify-end">
+            <GitActionNotice notice={notice} onClose={dismissNotice} />
+          </div>
+        )}
+
         {showWorkspaceLoading ? (
           <WorkspaceLoadingState workspacePath={workspacePath} />
         ) : isNotRepo ? (
@@ -125,6 +175,7 @@ export function GitApp() {
             <div className="flex flex-1 overflow-hidden">
               <BranchPanel
                 branches={state.branches}
+                remoteBranches={state.remoteBranches}
                 remotes={state.remotes}
                 stashes={state.stashes}
                 currentBranch={state.currentBranch}
@@ -153,6 +204,7 @@ export function GitApp() {
             <CommitDetail
               commit={selectedCommit}
               diffs={commitDiffs}
+              hasWorkingTreeChanges={state.fileChanges.length > 0}
               onSelectFile={handleSelectDiffFile}
               onClose={handleCloseCommitDetail}
               onAction={runAction}
@@ -201,6 +253,43 @@ function DiffPlaceholder({
   );
 }
 
+function GitActionNotice({
+  notice,
+  onClose,
+}: {
+  notice: GitActionNoticeState;
+  onClose: () => void;
+}) {
+  return (
+    <div className="pointer-events-auto w-full rounded-lg border border-[var(--g-red)]/30 bg-[var(--g-surface)] shadow-2xl shadow-black/30 backdrop-blur-sm">
+      <div className="flex items-start gap-3 px-3 py-2.5">
+        <div className="mt-0.5 shrink-0 rounded-full bg-[var(--g-red)]/12 p-1 text-[var(--g-red)]">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            <path d="M6 3.2v3.2" />
+            <path d="M6 8.8h.01" />
+            <circle cx="6" cy="6" r="4.5" />
+          </svg>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-semibold text-[var(--g-text)]">{notice.title}</div>
+          <div className="mt-0.5 text-[11px] leading-relaxed text-[var(--g-muted)]">
+            {notice.message}
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          className="shrink-0 p-1 text-[var(--g-dim)] transition-colors hover:text-[var(--g-text)]"
+          aria-label="Dismiss git action notice"
+        >
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+            <path d="M2 2l8 8M10 2l-8 8" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function WorkspaceLoadingState({ workspacePath }: { workspacePath: string }) {
   return (
     <div className="flex flex-1 items-center justify-center">
@@ -241,6 +330,42 @@ function EmptyRepoState({ workspacePath }: { workspacePath: string }) {
       </div>
     </div>
   );
+}
+
+function getActionFailureTitle(action: GitManagerRequest['action']): string {
+  switch (action) {
+    case 'checkout':
+      return 'Could not switch branch';
+    case 'create_branch':
+      return 'Could not create branch';
+    case 'delete_branch':
+      return 'Could not delete branch';
+    case 'stage':
+      return 'Could not stage changes';
+    case 'unstage':
+      return 'Could not unstage changes';
+    case 'commit':
+      return 'Could not create commit';
+    case 'push':
+      return 'Could not push changes';
+    case 'pull':
+      return 'Could not pull changes';
+    case 'fetch':
+      return 'Could not fetch remotes';
+    case 'stash':
+    case 'stash_pop':
+      return 'Could not update stashes';
+    case 'cherry_pick':
+      return 'Could not cherry-pick commit';
+    case 'merge':
+      return 'Could not merge branch';
+    case 'diff':
+      return 'Could not load diff';
+    case 'show_commit':
+      return 'Could not load commit details';
+    default:
+      return 'Git action failed';
+  }
 }
 
 export default GitApp;

--- a/plugins/sero-git-plugin/ui/GitApp.tsx
+++ b/plugins/sero-git-plugin/ui/GitApp.tsx
@@ -180,6 +180,7 @@ export function GitApp() {
                 remotes={state.remotes}
                 stashes={state.stashes}
                 currentBranch={state.currentBranch}
+                defaultBranch={state.defaultBranch}
                 onAction={runAction}
               />
 
@@ -341,6 +342,8 @@ function getActionFailureTitle(action: GitManagerRequest['action']): string {
       return 'Could not create branch';
     case 'delete_branch':
       return 'Could not delete branch';
+    case 'remove_worktree':
+      return 'Could not remove worktree';
     case 'stage':
       return 'Could not stage changes';
     case 'unstage':

--- a/plugins/sero-git-plugin/ui/components/BranchContextMenu.tsx
+++ b/plugins/sero-git-plugin/ui/components/BranchContextMenu.tsx
@@ -1,0 +1,89 @@
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@sero-ai/ui/components/ui/context-menu';
+import type { BranchInfo } from '../../shared/types';
+
+interface BranchContextMenuProps {
+  branch: BranchInfo;
+  onCheckout?: () => void;
+  onDelete?: () => void;
+  onForceDelete?: () => void;
+  onRemoveWorktree?: () => void;
+  onForceRemoveWorktree?: () => void;
+  children: React.ReactNode;
+}
+
+export function BranchContextMenu({
+  branch,
+  onCheckout,
+  onDelete,
+  onForceDelete,
+  onRemoveWorktree,
+  onForceRemoveWorktree,
+  children,
+}: BranchContextMenuProps) {
+  const hasBranchActions = Boolean(onCheckout || onDelete || onForceDelete);
+  const hasWorktreeActions = Boolean(onRemoveWorktree || onForceRemoveWorktree);
+
+  if (!hasBranchActions && !hasWorktreeActions) return <>{children}</>;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div className="w-full">{children}</div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-56">
+        <div className="px-3 py-1.5 text-[10px] uppercase tracking-wider text-[var(--g-dim)] git-mono">
+          {branch.name}
+        </div>
+        {branch.checkedOutIn && (
+          <div className="px-3 pb-1.5 text-[10px] text-[var(--g-dim)] git-mono">
+            {branch.checkedOutIn}
+          </div>
+        )}
+
+        {onCheckout && (
+          <ContextMenuItem onSelect={onCheckout}>
+            Switch to branch
+          </ContextMenuItem>
+        )}
+
+        {(onDelete || onForceDelete) && (
+          <>
+            {onCheckout && <ContextMenuSeparator />}
+            {onDelete && (
+              <ContextMenuItem onSelect={onDelete}>
+                Delete branch
+              </ContextMenuItem>
+            )}
+            {onForceDelete && (
+              <ContextMenuItem variant="destructive" onSelect={onForceDelete}>
+                Force delete branch
+              </ContextMenuItem>
+            )}
+          </>
+        )}
+
+        {(onRemoveWorktree || onForceRemoveWorktree) && (
+          <>
+            {hasBranchActions && <ContextMenuSeparator />}
+            {onRemoveWorktree && (
+              <ContextMenuItem onSelect={onRemoveWorktree}>
+                Remove worktree
+              </ContextMenuItem>
+            )}
+            {onForceRemoveWorktree && (
+              <ContextMenuItem variant="destructive" onSelect={onForceRemoveWorktree}>
+                Force remove worktree
+              </ContextMenuItem>
+            )}
+          </>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}

--- a/plugins/sero-git-plugin/ui/components/BranchPanel.tsx
+++ b/plugins/sero-git-plugin/ui/components/BranchPanel.tsx
@@ -2,106 +2,222 @@
  * Left sidebar — branches, remotes, stashes.
  */
 
-import { useState } from 'react';
-import type { BranchInfo, GitManagerRequest, RemoteInfo, StashEntry } from '../../shared/types';
+import { useMemo, useState } from 'react';
+import type { BranchInfo, GitManagerRequest, StashEntry } from '../../shared/types';
+import type { RemoteInfo } from '../../shared/types';
+import {
+  formatBranchLabel,
+  groupRemoteBranches,
+  sortBranchesForDisplay,
+} from '../lib/branch-groups';
 
 interface BranchPanelProps {
   branches: BranchInfo[];
+  remoteBranches: BranchInfo[];
   remotes: RemoteInfo[];
   stashes: StashEntry[];
   currentBranch: string;
   onAction: (action: GitManagerRequest) => void;
 }
 
-export function BranchPanel({ branches, remotes, stashes, currentBranch, onAction }: BranchPanelProps) {
+export function BranchPanel({
+  branches,
+  remoteBranches,
+  remotes,
+  stashes,
+  currentBranch,
+  onAction,
+}: BranchPanelProps) {
   const [localOpen, setLocalOpen] = useState(true);
   const [remoteOpen, setRemoteOpen] = useState(true);
   const [stashOpen, setStashOpen] = useState(true);
+  const [creatingBranch, setCreatingBranch] = useState(false);
+  const [newBranchName, setNewBranchName] = useState('');
+  const [confirmPopIndex, setConfirmPopIndex] = useState<number | null>(null);
 
-  const localBranches = branches.filter((b) => !b.remote?.startsWith('origin/') || b.name === b.remote?.replace('origin/', ''));
+  const localBranches = useMemo(() => sortBranchesForDisplay(branches), [branches]);
+  const remoteGroups = useMemo(() => groupRemoteBranches(remoteBranches, remotes), [remoteBranches, remotes]);
+  const trimmedBranchName = newBranchName.trim();
+  const branchNameExists = useMemo(
+    () => localBranches.some((branch) => branch.name === trimmedBranchName),
+    [localBranches, trimmedBranchName],
+  );
+
+  const resetBranchForm = () => {
+    setCreatingBranch(false);
+    setNewBranchName('');
+  };
+
+  const submitBranch = () => {
+    if (!trimmedBranchName || branchNameExists) return;
+    onAction({ action: 'create_branch', branch: trimmedBranchName });
+    resetBranchForm();
+  };
+
+  const handleStashApply = (stashIndex: number) => {
+    setConfirmPopIndex((current) => current === stashIndex ? null : current);
+    onAction({ action: 'stash_apply', stashIndex });
+  };
+
+  const handleStashPop = (stashIndex: number) => {
+    if (confirmPopIndex !== stashIndex) {
+      setConfirmPopIndex(stashIndex);
+      return;
+    }
+
+    setConfirmPopIndex(null);
+    onAction({ action: 'stash_pop', stashIndex });
+  };
 
   return (
-    <div className="w-52 shrink-0 border-r border-[var(--g-border)] overflow-y-auto git-scrollbar bg-[var(--g-surface)]">
-      {/* Local Branches */}
-      <Section title="LOCAL" count={localBranches.length} open={localOpen} onToggle={() => setLocalOpen(!localOpen)}>
-        {localBranches.map((b) => (
-          <BranchRow
-            key={b.name}
-            branch={b}
-            isCurrent={b.name === currentBranch}
-            onCheckout={() => onAction({ action: 'checkout', branch: b.name })}
-          />
-        ))}
-        <button
-          onClick={() => {
-            const name = prompt('New branch name:');
-            if (name?.trim()) onAction({ action: 'create_branch', branch: name.trim() });
-          }}
-          className="w-full flex items-center gap-2 px-3 py-1.5 text-[11px] text-[var(--g-dim)]
-            hover:text-[var(--g-accent)] hover:bg-[var(--g-hover)] transition-colors cursor-pointer"
-        >
-          <PlusIcon />
-          <span>New branch</span>
-        </button>
-      </Section>
+    <div
+      className="w-64 min-w-[13rem] max-w-[24rem] shrink-0 resize-x overflow-auto border-r border-[var(--g-border)] bg-[var(--g-surface)] git-scrollbar"
+      style={{ minHeight: 0 }}
+    >
+      <div className="min-h-full">
+        <Section title="LOCAL" count={localBranches.length} open={localOpen} onToggle={() => setLocalOpen(!localOpen)}>
+          {localBranches.map((branch) => (
+            <BranchRow
+              key={branch.name}
+              branch={branch}
+              label={branch.name}
+              isCurrent={branch.name === currentBranch}
+              onCheckout={() => onAction({ action: 'checkout', branch: branch.name })}
+            />
+          ))}
 
-      {/* Remotes */}
-      <Section title="REMOTE" count={remotes.length} open={remoteOpen} onToggle={() => setRemoteOpen(!remoteOpen)}>
-        {remotes.map((r) => (
-          <div key={r.name} className="flex items-center gap-2 px-3 py-1.5">
-            <CloudIcon />
-            <span className="text-xs text-[var(--g-muted)] truncate">{r.name}</span>
-            <span className="text-[10px] text-[var(--g-dim)] truncate ml-auto">{extractHostname(r.fetchUrl)}</span>
-          </div>
-        ))}
-      </Section>
+          {creatingBranch ? (
+            <div className="space-y-2 border-t border-[var(--g-border)] px-3 py-2">
+              <input
+                type="text"
+                autoFocus
+                value={newBranchName}
+                onChange={(event) => setNewBranchName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    submitBranch();
+                  }
+                  if (event.key === 'Escape') {
+                    event.preventDefault();
+                    resetBranchForm();
+                  }
+                }}
+                placeholder="feature/my-branch"
+                className="w-full rounded-md border border-[var(--g-border)] bg-[var(--g-elevated)] px-2.5 py-1.5
+                  text-[11px] text-[var(--g-text)] outline-none transition-colors git-mono
+                  placeholder-[var(--g-dim)] focus:border-[var(--g-accent)]"
+              />
+              {branchNameExists && (
+                <p className="text-[10px] text-[var(--g-red)]">
+                  A branch with that name already exists.
+                </p>
+              )}
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={submitBranch}
+                  disabled={!trimmedBranchName || branchNameExists}
+                  className="rounded-md bg-[var(--g-accent)] px-2 py-1 text-[10px] font-medium text-white
+                    transition-opacity hover:opacity-90 disabled:cursor-default disabled:opacity-30"
+                >
+                  Create
+                </button>
+                <button
+                  onClick={resetBranchForm}
+                  className="rounded-md border border-[var(--g-border)] px-2 py-1 text-[10px] text-[var(--g-muted)]
+                    transition-colors hover:border-[var(--g-border-bright)] hover:text-[var(--g-text)]"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              onClick={() => setCreatingBranch(true)}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] text-[var(--g-dim)]
+                transition-colors hover:bg-[var(--g-hover)] hover:text-[var(--g-accent)]"
+            >
+              <PlusIcon />
+              <span>New branch</span>
+            </button>
+          )}
+        </Section>
 
-      {/* Stashes */}
-      <Section title="STASHES" count={stashes.length} open={stashOpen} onToggle={() => setStashOpen(!stashOpen)}>
-        {stashes.map((s) => (
-          <div
-            key={s.hash || s.index}
-            className="flex items-center gap-2 px-3 py-1.5 group hover:bg-[var(--g-hover)] cursor-pointer"
-            onClick={() => onAction({ action: 'stash_pop', stashIndex: s.index })}
-            title={`Click to pop stash@{${s.index}}`}
+        <Section title="REMOTE" count={remoteBranches.length} open={remoteOpen} onToggle={() => setRemoteOpen(!remoteOpen)}>
+          {remoteGroups.map((group) => (
+            <div key={group.name} className="border-t border-[var(--g-border)] first:border-t-0">
+              <div className="flex items-center gap-2 px-3 py-1.5">
+                <CloudIcon />
+                <span className="truncate text-[11px] text-[var(--g-muted)]">{group.name}</span>
+                {group.host && (
+                  <span className="ml-auto truncate text-[10px] text-[var(--g-dim)]">{group.host}</span>
+                )}
+              </div>
+              <div className="pb-1">
+                {group.branches.map((branch) => (
+                  <BranchRow
+                    key={branch.name}
+                    branch={branch}
+                    label={formatBranchLabel(branch.name)}
+                    isCurrent={false}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+          {remoteGroups.length === 0 && (
+            <div className="px-3 py-2 text-[11px] text-[var(--g-dim)]">No remote branches</div>
+          )}
+        </Section>
+
+        <Section title="STASHES" count={stashes.length} open={stashOpen} onToggle={() => setStashOpen(!stashOpen)}>
+          {stashes.map((stash) => (
+            <StashRow
+              key={stash.hash || stash.index}
+              stash={stash}
+              confirmPop={confirmPopIndex === stash.index}
+              onApply={() => handleStashApply(stash.index)}
+              onPop={() => handleStashPop(stash.index)}
+            />
+          ))}
+          <button
+            onClick={() => onAction({ action: 'stash' })}
+            className="flex w-full items-center gap-2 px-3 py-1.5 text-[11px] text-[var(--g-dim)]
+              transition-colors hover:bg-[var(--g-hover)] hover:text-[var(--g-accent)]"
           >
-            <StashIcon />
-            <span className="text-xs text-[var(--g-muted)] truncate flex-1">{s.message}</span>
-            <span className="text-[10px] text-[var(--g-dim)] opacity-0 group-hover:opacity-100">pop</span>
-          </div>
-        ))}
-        <button
-          onClick={() => onAction({ action: 'stash' })}
-          className="w-full flex items-center gap-2 px-3 py-1.5 text-[11px] text-[var(--g-dim)]
-            hover:text-[var(--g-accent)] hover:bg-[var(--g-hover)] transition-colors cursor-pointer"
-        >
-          <PlusIcon />
-          <span>Stash changes</span>
-        </button>
-      </Section>
+            <PlusIcon />
+            <span>Stash changes</span>
+          </button>
+        </Section>
+      </div>
     </div>
   );
 }
 
-// ── Section collapsible ─────────────────────────────────────
-
 function Section({
-  title, count, open, onToggle, children,
+  title,
+  count,
+  open,
+  onToggle,
+  children,
 }: {
-  title: string; count: number; open: boolean; onToggle: () => void; children: React.ReactNode;
+  title: string;
+  count: number;
+  open: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
 }) {
   return (
     <div className="border-b border-[var(--g-border)]">
       <button
         onClick={onToggle}
-        className="w-full flex items-center justify-between px-3 py-2 text-[10px] font-semibold
-          tracking-wider text-[var(--g-dim)] hover:text-[var(--g-muted)] transition-colors cursor-pointer"
+        className="flex w-full items-center justify-between px-3 py-2 text-[10px] font-semibold tracking-wider text-[var(--g-dim)] transition-colors hover:text-[var(--g-muted)]"
       >
         <div className="flex items-center gap-1.5">
           <ChevronIcon open={open} />
           {title}
         </div>
-        <span className="text-[9px] px-1.5 py-0.5 rounded bg-[var(--g-elevated)] text-[var(--g-dim)]">
+        <span className="rounded bg-[var(--g-elevated)] px-1.5 py-0.5 text-[9px] text-[var(--g-dim)]">
           {count}
         </span>
       </button>
@@ -110,41 +226,111 @@ function Section({
   );
 }
 
-// ── Branch row ──────────────────────────────────────────────
-
 function BranchRow({
-  branch, isCurrent, onCheckout,
+  branch,
+  label,
+  isCurrent,
+  onCheckout,
 }: {
-  branch: BranchInfo; isCurrent: boolean; onCheckout: () => void;
+  branch: BranchInfo;
+  label: string;
+  isCurrent: boolean;
+  onCheckout?: () => void;
 }) {
+  const checkedOutElsewhere = Boolean(branch.checkedOutIn);
+  const rowTitle = checkedOutElsewhere
+    ? `Checked out in ${branch.checkedOutIn}`
+    : isCurrent
+      ? 'Current branch'
+      : onCheckout
+        ? `Switch to ${branch.name}`
+        : branch.name;
+
   return (
     <div
-      onClick={isCurrent ? undefined : onCheckout}
+      onClick={!isCurrent && !checkedOutElsewhere ? onCheckout : undefined}
+      title={rowTitle}
       className={`flex items-center gap-2 px-3 py-1.5 text-xs transition-colors
         ${isCurrent
-          ? 'text-[var(--g-accent)] bg-[var(--g-glow)]'
-          : 'text-[var(--g-muted)] hover:bg-[var(--g-hover)] hover:text-[var(--g-text)] cursor-pointer'
+          ? 'bg-[var(--g-glow)] text-[var(--g-accent)]'
+          : checkedOutElsewhere
+            ? 'cursor-default text-[var(--g-dim)] opacity-70'
+            : onCheckout
+              ? 'cursor-pointer text-[var(--g-muted)] hover:bg-[var(--g-hover)] hover:text-[var(--g-text)]'
+              : 'text-[var(--g-muted)]'
         }`}
     >
       <BranchIcon active={isCurrent} />
-      <span className="truncate flex-1 git-mono text-[11px]">{branch.name}</span>
-      {(branch.ahead > 0 || branch.behind > 0) && (
-        <div className="flex items-center gap-1 text-[9px]">
-          {branch.ahead > 0 && <span className="text-[var(--g-green)]">+{branch.ahead}</span>}
-          {branch.behind > 0 && <span className="text-[var(--g-red)]">-{branch.behind}</span>}
-        </div>
-      )}
+      <span className="min-w-0 flex-1 truncate git-mono text-[11px]">{label}</span>
+      <div className="flex shrink-0 items-center gap-1">
+        {checkedOutElsewhere && (
+          <span className="rounded bg-[var(--g-elevated)] px-1 py-0.5 text-[8px] uppercase tracking-wider text-[var(--g-dim)]">
+            WT
+          </span>
+        )}
+        {(branch.ahead > 0 || branch.behind > 0) && (
+          <div className="flex items-center gap-1 text-[9px]">
+            {branch.ahead > 0 && <span className="text-[var(--g-green)]">+{branch.ahead}</span>}
+            {branch.behind > 0 && <span className="text-[var(--g-red)]">-{branch.behind}</span>}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
 
-// ── Icons ───────────────────────────────────────────────────
+function StashRow({
+  stash,
+  confirmPop,
+  onApply,
+  onPop,
+}: {
+  stash: StashEntry;
+  confirmPop: boolean;
+  onApply: () => void;
+  onPop: () => void;
+}) {
+  return (
+    <div className="group border-t border-[var(--g-border)] first:border-t-0 px-3 py-1.5">
+      <div className="flex items-center gap-2">
+        <StashIcon />
+        <span className="min-w-0 flex-1 truncate text-xs text-[var(--g-muted)]">{stash.message}</span>
+        <div className="flex items-center gap-1 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
+          <button
+            onClick={onApply}
+            className="rounded border border-[var(--g-border)] px-1.5 py-0.5 text-[9px] text-[var(--g-muted)] transition-colors hover:border-[var(--g-border-bright)] hover:text-[var(--g-text)]"
+          >
+            Apply
+          </button>
+          <button
+            onClick={onPop}
+            className={`rounded border px-1.5 py-0.5 text-[9px] transition-colors ${confirmPop
+              ? 'border-[var(--g-red)] text-[var(--g-red)] hover:bg-[var(--g-red)]/10'
+              : 'border-[var(--g-border)] text-[var(--g-muted)] hover:border-[var(--g-border-bright)] hover:text-[var(--g-text)]'
+            }`}
+          >
+            {confirmPop ? 'Confirm pop' : 'Pop'}
+          </button>
+        </div>
+      </div>
+      <div className="mt-1 flex items-center justify-between text-[10px] text-[var(--g-dim)]">
+        <span className="git-mono">{`stash@{${stash.index}}`}</span>
+        {stash.date && <span>{formatRelativeDate(stash.date)}</span>}
+      </div>
+    </div>
+  );
+}
 
 function ChevronIcon({ open }: { open: boolean }) {
   return (
     <svg
-      width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor"
-      strokeWidth="1.5" strokeLinecap="round"
+      width="10"
+      height="10"
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
       style={{ transform: open ? 'rotate(90deg)' : 'rotate(0)', transition: 'transform 150ms' }}
     >
       <path d="M3 2l4 3-4 3" />
@@ -189,13 +375,15 @@ function PlusIcon() {
   );
 }
 
-function extractHostname(url: string): string {
-  try {
-    if (url.startsWith('git@')) {
-      return url.split(':')[0]?.replace('git@', '') ?? url;
-    }
-    return new URL(url).hostname;
-  } catch {
-    return url;
-  }
+function formatRelativeDate(value: string): string {
+  const date = new Date(value);
+  const diffMs = Date.now() - date.getTime();
+  if (Number.isNaN(diffMs)) return '';
+
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${Math.max(minutes, 1)}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }

--- a/plugins/sero-git-plugin/ui/components/BranchPanel.tsx
+++ b/plugins/sero-git-plugin/ui/components/BranchPanel.tsx
@@ -5,6 +5,8 @@
 import { useMemo, useState } from 'react';
 import type { BranchInfo, GitManagerRequest, StashEntry } from '../../shared/types';
 import type { RemoteInfo } from '../../shared/types';
+import { BranchContextMenu } from './BranchContextMenu';
+import { canDeleteBranch } from '../lib/branch-actions';
 import {
   formatBranchLabel,
   groupRemoteBranches,
@@ -17,6 +19,7 @@ interface BranchPanelProps {
   remotes: RemoteInfo[];
   stashes: StashEntry[];
   currentBranch: string;
+  defaultBranch?: string;
   onAction: (action: GitManagerRequest) => void;
 }
 
@@ -26,6 +29,7 @@ export function BranchPanel({
   remotes,
   stashes,
   currentBranch,
+  defaultBranch,
   onAction,
 }: BranchPanelProps) {
   const [localOpen, setLocalOpen] = useState(true);
@@ -76,15 +80,43 @@ export function BranchPanel({
     >
       <div className="min-h-full">
         <Section title="LOCAL" count={localBranches.length} open={localOpen} onToggle={() => setLocalOpen(!localOpen)}>
-          {localBranches.map((branch) => (
-            <BranchRow
-              key={branch.name}
-              branch={branch}
-              label={branch.name}
-              isCurrent={branch.name === currentBranch}
-              onCheckout={() => onAction({ action: 'checkout', branch: branch.name })}
-            />
-          ))}
+          {localBranches.map((branch) => {
+            const onCheckout = branch.name === currentBranch
+              ? undefined
+              : () => onAction({ action: 'checkout', branch: branch.name });
+            const allowDelete = canDeleteBranch(branch, currentBranch, defaultBranch);
+            const onDelete = allowDelete
+              ? () => onAction({ action: 'delete_branch', branch: branch.name })
+              : undefined;
+            const onForceDelete = allowDelete
+              ? () => onAction({ action: 'delete_branch', branch: branch.name, force: true })
+              : undefined;
+            const onRemoveWorktree = branch.checkedOutIn
+              ? () => onAction({ action: 'remove_worktree', worktreePath: branch.checkedOutIn })
+              : undefined;
+            const onForceRemoveWorktree = branch.checkedOutIn
+              ? () => onAction({ action: 'remove_worktree', worktreePath: branch.checkedOutIn, force: true })
+              : undefined;
+
+            return (
+              <BranchContextMenu
+                key={branch.name}
+                branch={branch}
+                onCheckout={onCheckout}
+                onDelete={onDelete}
+                onForceDelete={onForceDelete}
+                onRemoveWorktree={onRemoveWorktree}
+                onForceRemoveWorktree={onForceRemoveWorktree}
+              >
+                <BranchRow
+                  branch={branch}
+                  label={branch.name}
+                  isCurrent={branch.name === currentBranch}
+                  onCheckout={onCheckout}
+                />
+              </BranchContextMenu>
+            );
+          })}
 
           {creatingBranch ? (
             <div className="space-y-2 border-t border-[var(--g-border)] px-3 py-2">

--- a/plugins/sero-git-plugin/ui/components/CommitDetail.tsx
+++ b/plugins/sero-git-plugin/ui/components/CommitDetail.tsx
@@ -4,36 +4,59 @@
  * Displays commit metadata, stats, and changed files.
  */
 
+import { useState } from 'react';
 import type { CommitNode, FileDiff, GitManagerRequest } from '../../shared/types';
 
 interface CommitDetailProps {
   commit: CommitNode | null;
   diffs: FileDiff[];
+  hasWorkingTreeChanges: boolean;
   onSelectFile: (diff: FileDiff) => void;
   onClose: () => void;
   onAction: (action: GitManagerRequest) => void;
 }
 
-export function CommitDetail({ commit, diffs, onSelectFile, onClose, onAction }: CommitDetailProps) {
+export function CommitDetail({
+  commit,
+  diffs,
+  hasWorkingTreeChanges,
+  onSelectFile,
+  onClose,
+  onAction,
+}: CommitDetailProps) {
+  const [confirmCherryPick, setConfirmCherryPick] = useState(false);
+
   if (!commit) return null;
 
-  const totalAdd = diffs.reduce((s, d) => s + d.additions, 0);
-  const totalDel = diffs.reduce((s, d) => s + d.deletions, 0);
+  const totalAdd = diffs.reduce((sum, diff) => sum + diff.additions, 0);
+  const totalDel = diffs.reduce((sum, diff) => sum + diff.deletions, 0);
   const date = new Date(commit.authorDate);
+
+  const handleCherryPick = () => {
+    if (hasWorkingTreeChanges) {
+      setConfirmCherryPick(true);
+      return;
+    }
+    onAction({ action: 'cherry_pick', hash: commit.hash });
+  };
+
+  const handleAutoStashCherryPick = () => {
+    onAction({ action: 'cherry_pick', hash: commit.hash, all: true });
+    setConfirmCherryPick(false);
+  };
 
   return (
     <div className="border-t border-[var(--g-border)] bg-[var(--g-surface)]">
-      {/* Commit header */}
-      <div className="flex items-start justify-between px-4 py-3 border-b border-[var(--g-border)]">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1.5">
-            <span className="git-mono text-xs text-[var(--g-accent)] bg-[var(--g-glow)] px-1.5 py-0.5 rounded border border-[var(--g-border)]">
+      <div className="flex items-start justify-between border-b border-[var(--g-border)] px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="mb-1.5 flex items-center gap-2">
+            <span className="rounded border border-[var(--g-border)] bg-[var(--g-glow)] px-1.5 py-0.5 text-xs text-[var(--g-accent)] git-mono">
               {commit.shortHash}
             </span>
             {commit.refs.map((ref) => (
               <span
                 key={ref.name}
-                className="text-[9px] font-medium px-1.5 py-0.5 rounded git-mono"
+                className="rounded px-1.5 py-0.5 text-[9px] font-medium git-mono"
                 style={{
                   background: ref.type === 'tag' ? 'rgba(251,191,36,0.12)' : 'rgba(129,140,248,0.12)',
                   color: ref.type === 'tag' ? '#fbbf24' : '#818cf8',
@@ -44,23 +67,48 @@ export function CommitDetail({ commit, diffs, onSelectFile, onClose, onAction }:
               </span>
             ))}
           </div>
-          <p className="text-sm text-[var(--g-text)] font-medium leading-snug">{commit.subject}</p>
-          <div className="flex items-center gap-3 mt-2 text-[11px] text-[var(--g-muted)]">
+          <p className="text-sm font-medium leading-snug text-[var(--g-text)]">{commit.subject}</p>
+          <div className="mt-2 flex items-center gap-3 text-[11px] text-[var(--g-muted)]">
             <span className="font-medium text-[var(--g-text)]">{commit.authorName}</span>
             <span>{date.toLocaleDateString()} {date.toLocaleTimeString()}</span>
           </div>
+          {confirmCherryPick && (
+            <div className="mt-3 rounded-md border border-[var(--g-yellow)]/25 bg-[var(--g-bg)] px-3 py-2">
+              <div className="text-[11px] font-medium text-[var(--g-text)]">
+                Your working tree has uncommitted changes.
+              </div>
+              <div className="mt-1 text-[10px] leading-relaxed text-[var(--g-muted)]">
+                Auto-stash your current changes before cherry-picking this commit. If the cherry-pick conflicts,
+                the error toast will include next-step guidance.
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <button
+                  onClick={handleAutoStashCherryPick}
+                  className="rounded border border-[var(--g-border)] px-2 py-1 text-[10px] text-[var(--g-text)] transition-colors hover:border-[var(--g-border-bright)] hover:bg-[var(--g-elevated)]"
+                >
+                  Auto-stash + cherry-pick
+                </button>
+                <button
+                  onClick={() => setConfirmCherryPick(false)}
+                  className="rounded px-2 py-1 text-[10px] text-[var(--g-dim)] transition-colors hover:text-[var(--g-text)]"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
         </div>
-        <div className="flex items-center gap-2 shrink-0 ml-4">
+        <div className="ml-4 flex shrink-0 items-center gap-2">
           <button
-            onClick={() => onAction({ action: 'cherry_pick', hash: commit.hash })}
-            className="px-2 py-1 text-[10px] text-[var(--g-muted)] border border-[var(--g-border)]
-              rounded hover:bg-[var(--g-elevated)] hover:text-[var(--g-text)] transition-colors cursor-pointer"
+            onClick={handleCherryPick}
+            className="rounded border border-[var(--g-border)] px-2 py-1 text-[10px] text-[var(--g-muted)]
+              transition-colors hover:bg-[var(--g-elevated)] hover:text-[var(--g-text)]"
           >
-            Cherry-pick
+            {hasWorkingTreeChanges ? 'Cherry-pick…' : 'Cherry-pick'}
           </button>
           <button
             onClick={onClose}
-            className="p-1 text-[var(--g-dim)] hover:text-[var(--g-text)] transition-colors cursor-pointer"
+            className="cursor-pointer p-1 text-[var(--g-dim)] transition-colors hover:text-[var(--g-text)]"
           >
             <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
               <path d="M3 3l8 8M11 3l-8 8" />
@@ -69,10 +117,8 @@ export function CommitDetail({ commit, diffs, onSelectFile, onClose, onAction }:
         </div>
       </div>
 
-      {/* File list */}
       <div className="max-h-48 overflow-y-auto git-scrollbar">
-        {/* Summary bar */}
-        <div className="flex items-center gap-3 px-4 py-2 border-b border-[var(--g-border)] bg-[var(--g-bg)]">
+        <div className="flex items-center gap-3 border-b border-[var(--g-border)] bg-[var(--g-bg)] px-4 py-2">
           <span className="text-[11px] text-[var(--g-muted)]">
             {diffs.length} file{diffs.length !== 1 ? 's' : ''} changed
           </span>
@@ -82,14 +128,12 @@ export function CommitDetail({ commit, diffs, onSelectFile, onClose, onAction }:
         </div>
 
         {diffs.map((diff) => (
-          <FileRow key={diff.path} diff={diff} onClick={() => onSelectFile(diff)} />
+          <FileRow key={`${diff.oldPath ?? diff.path}:${diff.path}`} diff={diff} onClick={() => onSelectFile(diff)} />
         ))}
       </div>
     </div>
   );
 }
-
-// ── File row ────────────────────────────────────────────────
 
 function FileRow({ diff, onClick }: { diff: FileDiff; onClick: () => void }) {
   const statusColor = {
@@ -102,32 +146,35 @@ function FileRow({ diff, onClick }: { diff: FileDiff; onClick: () => void }) {
   }[diff.status];
 
   const statusLabel = diff.status[0].toUpperCase();
-  const dir = diff.path.includes('/') ? diff.path.substring(0, diff.path.lastIndexOf('/') + 1) : '';
-  const file = diff.path.includes('/') ? diff.path.substring(diff.path.lastIndexOf('/') + 1) : diff.path;
+  const primaryLabel = diff.path.includes('/')
+    ? diff.path.substring(diff.path.lastIndexOf('/') + 1)
+    : diff.path;
+  const secondaryLabel = diff.oldPath && diff.oldPath !== diff.path
+    ? `${diff.oldPath} → ${diff.path}`
+    : diff.path;
 
   return (
     <div
       onClick={onClick}
-      className="flex items-center gap-2 px-4 py-1.5 hover:bg-[var(--g-hover)] cursor-pointer
-        border-b border-[var(--g-border)] last:border-b-0"
+      className="flex cursor-pointer items-center gap-2 border-b border-[var(--g-border)] px-4 py-1.5 hover:bg-[var(--g-hover)] last:border-b-0"
     >
       <span
-        className="w-4 h-4 rounded flex items-center justify-center text-[9px] font-bold shrink-0"
+        className="flex h-4 w-4 shrink-0 items-center justify-center rounded text-[9px] font-bold"
         style={{ background: `${statusColor}18`, color: statusColor }}
       >
         {statusLabel}
       </span>
-      <span className="text-[11px] text-[var(--g-dim)] git-mono truncate">{dir}</span>
-      <span className="text-[11px] text-[var(--g-text)] git-mono truncate">{file}</span>
-      <div className="ml-auto flex items-center gap-1.5 shrink-0">
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[11px] text-[var(--g-text)] git-mono">{primaryLabel}</div>
+        <div className="truncate text-[10px] text-[var(--g-dim)] git-mono">{secondaryLabel}</div>
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-1.5">
         {diff.additions > 0 && <span className="text-[10px] text-[var(--g-green)]">+{diff.additions}</span>}
         {diff.deletions > 0 && <span className="text-[10px] text-[var(--g-red)]">-{diff.deletions}</span>}
       </div>
     </div>
   );
 }
-
-// ── Stat bar ────────────────────────────────────────────────
 
 function StatBar({ additions, deletions }: { additions: number; deletions: number }) {
   const total = additions + deletions;
@@ -137,12 +184,12 @@ function StatBar({ additions, deletions }: { additions: number; deletions: numbe
   const addBlocks = Math.round((addPct / 100) * blocks);
 
   return (
-    <div className="flex gap-0.5 ml-auto">
-      {Array.from({ length: blocks }, (_, i) => (
+    <div className="ml-auto flex gap-0.5">
+      {Array.from({ length: blocks }, (_, index) => (
         <div
-          key={i}
-          className="w-1.5 h-1.5 rounded-sm"
-          style={{ background: i < addBlocks ? 'var(--g-green)' : 'var(--g-red)', opacity: 0.6 }}
+          key={index}
+          className="h-1.5 w-1.5 rounded-sm"
+          style={{ background: index < addBlocks ? 'var(--g-green)' : 'var(--g-red)', opacity: 0.6 }}
         />
       ))}
     </div>

--- a/plugins/sero-git-plugin/ui/components/CommitGraph.tsx
+++ b/plugins/sero-git-plugin/ui/components/CommitGraph.tsx
@@ -60,7 +60,7 @@ export function CommitGraph({ commits, selectedHash, onSelectCommit }: CommitGra
               {/* SVG graph column */}
               <div className="shrink-0" style={{ width: graphWidth, height: ROW_HEIGHT, position: 'relative' }}>
                 <svg width={graphWidth} height={ROW_HEIGHT} className="absolute inset-0">
-                  {renderEdgesForRow(layout.edges, node.row, node.row, graphWidth)}
+                  {renderEdgesForRow(layout.edges, node.row)}
                   <CommitDot
                     cx={GRAPH_PAD_LEFT + node.lane * LANE_WIDTH}
                     cy={ROW_HEIGHT / 2}
@@ -110,65 +110,72 @@ export function CommitGraph({ commits, selectedHash, onSelectCommit }: CommitGra
 
 // ── Edge rendering for a specific row ───────────────────────
 
-function renderEdgesForRow(edges: GraphEdge[], row: number, _currentRow: number, _width: number) {
-  const relevantEdges = edges.filter((e) => {
-    // Edge passes through this row (between fromRow and toRow)
-    return e.fromRow <= row && e.toRow >= row;
-  });
+function renderEdgesForRow(edges: GraphEdge[], row: number) {
+  const relevantEdges = edges.filter((edge) => edge.fromRow <= row && edge.toRow >= row);
 
   return relevantEdges.map((edge, i) => {
     const fromX = GRAPH_PAD_LEFT + edge.fromLane * LANE_WIDTH;
     const toX = GRAPH_PAD_LEFT + edge.toLane * LANE_WIDTH;
 
-    // Calculate Y positions relative to this row
-    const relFromY = (edge.fromRow - row) * ROW_HEIGHT + ROW_HEIGHT / 2;
-    const relToY = (edge.toRow - row) * ROW_HEIGHT + ROW_HEIGHT / 2;
-
-    // Only render the portion visible in this row
-    const y1 = Math.max(relFromY, 0);
-    const y2 = Math.min(relToY, ROW_HEIGHT);
-
     if (fromX === toX) {
-      // Straight vertical line
+      const relFromY = (edge.fromRow - row) * ROW_HEIGHT + ROW_HEIGHT / 2;
+      const relToY = (edge.toRow - row) * ROW_HEIGHT + ROW_HEIGHT / 2;
       return (
         <line
           key={`e-${i}`}
-          x1={fromX} y1={y1} x2={toX} y2={y2}
-          stroke={edge.color} strokeWidth={2} strokeOpacity={0.7}
+          x1={fromX}
+          y1={Math.max(relFromY, 0)}
+          x2={toX}
+          y2={Math.min(relToY, ROW_HEIGHT)}
+          stroke={edge.color}
+          strokeWidth={2}
+          strokeOpacity={0.7}
+          strokeLinecap="round"
         />
       );
     }
 
-    // Diagonal/curved connection for merge/branch
     if (edge.fromRow === row) {
-      // Start of edge (commit row) — draw curve down to next row
       return (
         <path
           key={`e-${i}`}
-          d={`M ${fromX} ${ROW_HEIGHT / 2} C ${fromX} ${ROW_HEIGHT}, ${toX} ${ROW_HEIGHT / 2}, ${toX} ${ROW_HEIGHT}`}
-          fill="none" stroke={edge.color} strokeWidth={2} strokeOpacity={0.6}
+          d={`M ${fromX} ${ROW_HEIGHT / 2} C ${fromX} ${ROW_HEIGHT * 0.9}, ${toX} ${ROW_HEIGHT * 0.15}, ${toX} ${ROW_HEIGHT}`}
+          fill="none"
+          stroke={edge.color}
+          strokeWidth={2}
+          strokeOpacity={0.65}
+          strokeLinecap="round"
         />
       );
     }
 
     if (edge.toRow === row) {
-      // End of edge (parent row) — curve into parent
       return (
-        <path
+        <line
           key={`e-${i}`}
-          d={`M ${fromX} 0 C ${fromX} ${ROW_HEIGHT / 2}, ${toX} 0, ${toX} ${ROW_HEIGHT / 2}`}
-          fill="none" stroke={edge.color} strokeWidth={2} strokeOpacity={0.6}
+          x1={toX}
+          y1={0}
+          x2={toX}
+          y2={ROW_HEIGHT / 2}
+          stroke={edge.color}
+          strokeWidth={2}
+          strokeOpacity={0.55}
+          strokeLinecap="round"
         />
       );
     }
 
-    // Middle rows — straight vertical in the target lane
-    const x = row - edge.fromRow < edge.toRow - row ? fromX : toX;
     return (
       <line
         key={`e-${i}`}
-        x1={x} y1={0} x2={x} y2={ROW_HEIGHT}
-        stroke={edge.color} strokeWidth={2} strokeOpacity={0.5}
+        x1={toX}
+        y1={0}
+        x2={toX}
+        y2={ROW_HEIGHT}
+        stroke={edge.color}
+        strokeWidth={2}
+        strokeOpacity={0.5}
+        strokeLinecap="round"
       />
     );
   });

--- a/plugins/sero-git-plugin/ui/components/DiffViewer.tsx
+++ b/plugins/sero-git-plugin/ui/components/DiffViewer.tsx
@@ -29,7 +29,9 @@ export function DiffViewer({ diff, onClose }: DiffViewerProps) {
     return (
       <DiffShell path={diff.path} diff={diff} onClose={onClose}>
         <div className="flex items-center justify-center py-12 text-[var(--g-dim)] text-xs">
-          No changes
+          {diff.oldPath && diff.oldPath !== diff.path
+            ? `Renamed without content changes: ${diff.oldPath} → ${diff.path}`
+            : 'No changes'}
         </div>
       </DiffShell>
     );
@@ -66,13 +68,20 @@ function DiffShell({
     <div className="border border-[var(--g-border)] rounded-lg bg-[var(--g-bg)] overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-[var(--g-border)] bg-[var(--g-surface)]">
-        <div className="flex items-center gap-2">
+        <div className="min-w-0 flex items-center gap-2">
           <span
             className="w-2 h-2 rounded-full shrink-0"
             style={{ background: statusColor }}
           />
-          <span className="text-xs text-[var(--g-text)] git-mono">{path}</span>
-          <div className="flex items-center gap-1.5 ml-2">
+          <div className="min-w-0">
+            <div className="truncate text-xs text-[var(--g-text)] git-mono">{path}</div>
+            {diff.oldPath && diff.oldPath !== path && (
+              <div className="truncate text-[10px] text-[var(--g-dim)] git-mono">
+                {diff.oldPath} → {path}
+              </div>
+            )}
+          </div>
+          <div className="ml-2 flex items-center gap-1.5">
             {diff.additions > 0 && (
               <span className="text-[10px] text-[var(--g-green)] font-medium">+{diff.additions}</span>
             )}

--- a/plugins/sero-git-plugin/ui/components/Header.tsx
+++ b/plugins/sero-git-plugin/ui/components/Header.tsx
@@ -77,6 +77,7 @@ export function Header({ state, onAction }: HeaderProps) {
 
         <div className="w-px h-4 bg-[var(--g-border)]" />
 
+        <ActionBtn label="Refresh" icon="refresh" onClick={() => onAction({ action: 'refresh' })} />
         <ActionBtn label="Fetch" icon="fetch" onClick={() => onAction({ action: 'fetch' })} />
         <ActionBtn label="Pull" icon="pull" onClick={() => onAction({ action: 'pull' })} />
         <ActionBtn label="Push" icon="push" onClick={() => onAction({ action: 'push' })} />

--- a/plugins/sero-git-plugin/ui/components/StagingArea.tsx
+++ b/plugins/sero-git-plugin/ui/components/StagingArea.tsx
@@ -46,23 +46,18 @@ export function StagingArea({ fileChanges, onAction, onSelectFile }: StagingArea
   }
 
   return (
-    <div className="border-t border-[var(--g-border)] bg-[var(--g-surface)] flex flex-col max-h-72">
-      <div className="flex flex-1 overflow-hidden">
-        {/* Unstaged changes */}
-        <div className="flex-1 border-r border-[var(--g-border)] overflow-y-auto git-scrollbar">
-          <div className="flex items-center justify-between px-3 py-1.5 border-b border-[var(--g-border)] bg-[var(--g-bg)]">
-            <span className="text-[10px] font-semibold tracking-wider text-[var(--g-dim)]">
-              UNSTAGED ({unstaged.length})
-            </span>
-            {unstaged.length > 0 && (
-              <button
-                onClick={handleStageAll}
-                className="text-[10px] text-[var(--g-accent)] hover:text-[var(--g-accent-hover)] transition-colors cursor-pointer"
-              >
-                Stage all
-              </button>
-            )}
-          </div>
+    <div className="border-t border-[var(--g-border)] bg-[var(--g-surface)] flex max-h-72 flex-col">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <ChangeColumn
+          title="UNSTAGED"
+          count={unstaged.length}
+          className="border-r border-[var(--g-border)]"
+          action={unstaged.length > 0 ? {
+            label: 'Stage all',
+            onClick: handleStageAll,
+            tone: 'accent',
+          } : undefined}
+        >
           {unstaged.map((f) => (
             <ChangeRow
               key={`${f.path}:unstaged:${f.status}`}
@@ -72,23 +67,17 @@ export function StagingArea({ fileChanges, onAction, onSelectFile }: StagingArea
               actionLabel="+"
             />
           ))}
-        </div>
+        </ChangeColumn>
 
-        {/* Staged changes */}
-        <div className="flex-1 overflow-y-auto git-scrollbar">
-          <div className="flex items-center justify-between px-3 py-1.5 border-b border-[var(--g-border)] bg-[var(--g-bg)]">
-            <span className="text-[10px] font-semibold tracking-wider text-[var(--g-dim)]">
-              STAGED ({staged.length})
-            </span>
-            {staged.length > 0 && (
-              <button
-                onClick={handleUnstageAll}
-                className="text-[10px] text-[var(--g-muted)] hover:text-[var(--g-text)] transition-colors cursor-pointer"
-              >
-                Unstage all
-              </button>
-            )}
-          </div>
+        <ChangeColumn
+          title="STAGED"
+          count={staged.length}
+          action={staged.length > 0 ? {
+            label: 'Unstage all',
+            onClick: handleUnstageAll,
+            tone: 'muted',
+          } : undefined}
+        >
           {staged.map((f) => (
             <ChangeRow
               key={`${f.path}:staged:${f.status}`}
@@ -98,7 +87,7 @@ export function StagingArea({ fileChanges, onAction, onSelectFile }: StagingArea
               actionLabel="-"
             />
           ))}
-        </div>
+        </ChangeColumn>
       </div>
 
       {/* Commit input */}
@@ -123,6 +112,45 @@ export function StagingArea({ fileChanges, onAction, onSelectFile }: StagingArea
         >
           Commit
         </button>
+      </div>
+    </div>
+  );
+}
+
+interface ChangeColumnProps {
+  title: string;
+  count: number;
+  className?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+    tone: 'accent' | 'muted';
+  };
+  children: React.ReactNode;
+}
+
+function ChangeColumn({ title, count, className = '', action, children }: ChangeColumnProps) {
+  const actionClassName = action?.tone === 'accent'
+    ? 'text-[var(--g-accent)] hover:text-[var(--g-accent-hover)]'
+    : 'text-[var(--g-muted)] hover:text-[var(--g-text)]';
+
+  return (
+    <div className={`flex min-h-0 flex-1 flex-col overflow-hidden ${className}`.trim()}>
+      <div className="shrink-0 flex items-center justify-between px-3 py-1.5 border-b border-[var(--g-border)] bg-[var(--g-bg)]">
+        <span className="text-[10px] font-semibold tracking-wider text-[var(--g-dim)]">
+          {title} ({count})
+        </span>
+        {action && (
+          <button
+            onClick={action.onClick}
+            className={`text-[10px] transition-colors cursor-pointer ${actionClassName}`}
+          >
+            {action.label}
+          </button>
+        )}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto git-scrollbar">
+        {children}
       </div>
     </div>
   );

--- a/plugins/sero-git-plugin/ui/lib/branch-actions.test.ts
+++ b/plugins/sero-git-plugin/ui/lib/branch-actions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BranchInfo } from '../../shared/types';
+import { canDeleteBranch, isDefaultBranch } from './branch-actions';
+
+function makeBranch(overrides: Partial<BranchInfo> = {}): BranchInfo {
+  return {
+    name: 'feature/test',
+    current: false,
+    ahead: 0,
+    behind: 0,
+    ...overrides,
+  };
+}
+
+describe('branch action helpers', () => {
+  it('allows deleting non-current branches not checked out elsewhere', () => {
+    expect(canDeleteBranch(makeBranch(), 'main')).toBe(true);
+  });
+
+  it('detects the default branch', () => {
+    expect(isDefaultBranch(makeBranch({ name: 'main' }), 'main')).toBe(true);
+    expect(isDefaultBranch(makeBranch({ name: 'feature/test' }), 'main')).toBe(false);
+  });
+
+  it('blocks deleting the current branch', () => {
+    expect(canDeleteBranch(makeBranch({ name: 'main' }), 'main')).toBe(false);
+    expect(canDeleteBranch(makeBranch({ current: true }), 'feature/test')).toBe(false);
+  });
+
+  it('blocks deleting branches checked out in another worktree', () => {
+    expect(canDeleteBranch(makeBranch({ checkedOutIn: '/tmp/worktree' }), 'main')).toBe(false);
+  });
+
+  it('blocks deleting the default branch', () => {
+    expect(canDeleteBranch(makeBranch({ name: 'main' }), 'feature/test', 'main')).toBe(false);
+  });
+});

--- a/plugins/sero-git-plugin/ui/lib/branch-actions.ts
+++ b/plugins/sero-git-plugin/ui/lib/branch-actions.ts
@@ -1,0 +1,17 @@
+import type { BranchInfo } from '../../shared/types';
+
+export function isDefaultBranch(branch: BranchInfo, defaultBranch?: string): boolean {
+  return Boolean(defaultBranch) && branch.name === defaultBranch;
+}
+
+export function canDeleteBranch(
+  branch: BranchInfo,
+  currentBranch: string,
+  defaultBranch?: string,
+): boolean {
+  if (branch.name === currentBranch) return false;
+  if (branch.current) return false;
+  if (isDefaultBranch(branch, defaultBranch)) return false;
+  if (branch.checkedOutIn) return false;
+  return true;
+}

--- a/plugins/sero-git-plugin/ui/lib/branch-groups.test.ts
+++ b/plugins/sero-git-plugin/ui/lib/branch-groups.test.ts
@@ -8,7 +8,7 @@ import {
 } from './branch-groups';
 
 describe('branch group helpers', () => {
-  it('sorts the current branch first, then newest branches', () => {
+  it('sorts branches by most recent commit date without prioritizing the current branch', () => {
     const branches: BranchInfo[] = [
       {
         name: 'older',
@@ -34,8 +34,8 @@ describe('branch group helpers', () => {
     ];
 
     expect(sortBranchesForDisplay(branches).map((branch) => branch.name)).toEqual([
-      'current',
       'newer',
+      'current',
       'older',
     ]);
   });

--- a/plugins/sero-git-plugin/ui/lib/branch-groups.test.ts
+++ b/plugins/sero-git-plugin/ui/lib/branch-groups.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BranchInfo, RemoteInfo } from '../../shared/types';
+import {
+  formatBranchLabel,
+  groupRemoteBranches,
+  sortBranchesForDisplay,
+} from './branch-groups';
+
+describe('branch group helpers', () => {
+  it('sorts the current branch first, then newest branches', () => {
+    const branches: BranchInfo[] = [
+      {
+        name: 'older',
+        current: false,
+        ahead: 0,
+        behind: 0,
+        lastCommitDate: '2026-04-01T10:00:00.000Z',
+      },
+      {
+        name: 'current',
+        current: true,
+        ahead: 0,
+        behind: 0,
+        lastCommitDate: '2026-04-02T10:00:00.000Z',
+      },
+      {
+        name: 'newer',
+        current: false,
+        ahead: 0,
+        behind: 0,
+        lastCommitDate: '2026-04-03T10:00:00.000Z',
+      },
+    ];
+
+    expect(sortBranchesForDisplay(branches).map((branch) => branch.name)).toEqual([
+      'current',
+      'newer',
+      'older',
+    ]);
+  });
+
+  it('groups remote branches by remote name and preserves host labels', () => {
+    const remoteBranches: BranchInfo[] = [
+      { name: 'origin/main', current: false, ahead: 0, behind: 0, lastCommitDate: '2026-04-03T10:00:00.000Z' },
+      { name: 'origin/feature', current: false, ahead: 0, behind: 0, lastCommitDate: '2026-04-04T10:00:00.000Z' },
+      { name: 'upstream/release', current: false, ahead: 0, behind: 0, lastCommitDate: '2026-04-02T10:00:00.000Z' },
+    ];
+    const remotes: RemoteInfo[] = [
+      { name: 'origin', fetchUrl: 'git@github.com:sero-ai/sero.git', pushUrl: 'git@github.com:sero-ai/sero.git' },
+      { name: 'upstream', fetchUrl: 'https://github.com/sero-ai/upstream.git', pushUrl: 'https://github.com/sero-ai/upstream.git' },
+    ];
+
+    const groups = groupRemoteBranches(remoteBranches, remotes);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ name: 'origin', host: 'github.com' });
+    expect(groups[0]?.branches.map((branch) => branch.name)).toEqual(['origin/feature', 'origin/main']);
+    expect(groups[1]).toMatchObject({ name: 'upstream', host: 'github.com' });
+  });
+
+  it('formats remote branch labels without the remote prefix', () => {
+    expect(formatBranchLabel('origin/feature/test')).toBe('feature/test');
+    expect(formatBranchLabel('main')).toBe('main');
+  });
+});

--- a/plugins/sero-git-plugin/ui/lib/branch-groups.ts
+++ b/plugins/sero-git-plugin/ui/lib/branch-groups.ts
@@ -12,7 +12,6 @@ function getBranchTimestamp(branch: BranchInfo): number {
 
 export function sortBranchesForDisplay(branches: BranchInfo[]): BranchInfo[] {
   return [...branches].sort((a, b) => {
-    if (a.current !== b.current) return a.current ? -1 : 1;
     const aTime = getBranchTimestamp(a);
     const bTime = getBranchTimestamp(b);
     if (aTime !== bTime) return bTime - aTime;

--- a/plugins/sero-git-plugin/ui/lib/branch-groups.ts
+++ b/plugins/sero-git-plugin/ui/lib/branch-groups.ts
@@ -1,0 +1,60 @@
+import type { BranchInfo, RemoteInfo } from '../../shared/types';
+
+export interface RemoteBranchGroup {
+  name: string;
+  host: string;
+  branches: BranchInfo[];
+}
+
+function getBranchTimestamp(branch: BranchInfo): number {
+  return branch.lastCommitDate ? Date.parse(branch.lastCommitDate) : 0;
+}
+
+export function sortBranchesForDisplay(branches: BranchInfo[]): BranchInfo[] {
+  return [...branches].sort((a, b) => {
+    if (a.current !== b.current) return a.current ? -1 : 1;
+    const aTime = getBranchTimestamp(a);
+    const bTime = getBranchTimestamp(b);
+    if (aTime !== bTime) return bTime - aTime;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+export function formatBranchLabel(name: string): string {
+  const slashIndex = name.indexOf('/');
+  return slashIndex >= 0 ? name.slice(slashIndex + 1) : name;
+}
+
+export function groupRemoteBranches(
+  remoteBranches: BranchInfo[],
+  remotes: RemoteInfo[],
+): RemoteBranchGroup[] {
+  const hostByRemote = new Map(remotes.map((remote) => [remote.name, extractHostname(remote.fetchUrl)]));
+  const groups = new Map<string, BranchInfo[]>();
+
+  for (const branch of sortBranchesForDisplay(remoteBranches)) {
+    const remoteName = branch.name.split('/')[0] ?? 'remote';
+    const existing = groups.get(remoteName) ?? [];
+    existing.push(branch);
+    groups.set(remoteName, existing);
+  }
+
+  return Array.from(groups.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, branches]) => ({
+      name,
+      host: hostByRemote.get(name) ?? '',
+      branches,
+    }));
+}
+
+function extractHostname(url: string): string {
+  try {
+    if (url.startsWith('git@')) {
+      return url.split(':')[0]?.replace('git@', '') ?? url;
+    }
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}

--- a/plugins/sero-git-plugin/ui/lib/graph-layout.test.ts
+++ b/plugins/sero-git-plugin/ui/lib/graph-layout.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CommitNode } from '../../shared/types';
+import { computeGraphLayout } from './graph-layout';
+
+describe('computeGraphLayout', () => {
+  it('collapses merged first-parent lanes once the parent already owns another lane', () => {
+    const commits: CommitNode[] = [
+      makeCommit('M', ['A', 'B']),
+      makeCommit('A', ['C']),
+      makeCommit('B', ['C']),
+      makeCommit('C', ['D']),
+      makeCommit('D', []),
+    ];
+
+    const layout = computeGraphLayout(commits);
+    const lanesByHash = new Map(layout.nodes.map((node) => [node.commit.hash, node.lane]));
+    const mergeEdge = layout.edges.find((edge) => edge.fromRow === 2 && edge.toRow === 3);
+
+    expect(layout.maxLane).toBe(1);
+    expect(lanesByHash.get('M')).toBe(0);
+    expect(lanesByHash.get('A')).toBe(0);
+    expect(lanesByHash.get('B')).toBe(1);
+    expect(lanesByHash.get('C')).toBe(0);
+    expect(mergeEdge).toMatchObject({ fromLane: 1, toLane: 0 });
+  });
+});
+
+function makeCommit(hash: string, parents: string[]): CommitNode {
+  return {
+    hash,
+    shortHash: hash,
+    parents,
+    authorName: 'Test User',
+    authorEmail: 'test@example.com',
+    authorDate: '2026-04-01T12:00:00.000Z',
+    subject: hash,
+    refs: [],
+  };
+}

--- a/plugins/sero-git-plugin/ui/lib/graph-layout.ts
+++ b/plugins/sero-git-plugin/ui/lib/graph-layout.ts
@@ -87,28 +87,33 @@ export function computeGraphLayout(commits: CommitNode[]): GraphLayout {
 
     nodes.push({ commit, row, lane, color });
 
+    const visibleParents = commit.parents.filter((parentHash) => hashToRow.has(parentHash));
+
     // Process parents
-    for (let pi = 0; pi < commit.parents.length; pi++) {
-      const parentHash = commit.parents[pi];
+    for (let pi = 0; pi < visibleParents.length; pi++) {
+      const parentHash = visibleParents[pi]!;
       const parentRow = hashToRow.get(parentHash);
-      if (parentRow === undefined) continue; // parent not in visible range
+      if (parentRow === undefined) continue;
 
       if (pi === 0) {
-        // First parent: inherit this commit's lane
+        // First parent keeps the current lane unless that parent already
+        // owns another lane, in which case this lane can collapse.
         if (!hashToLane.has(parentHash)) {
           hashToLane.set(parentHash, lane);
           hashToColor.set(parentHash, color);
-          lanes[lane] = parentHash;
         }
+
+        const parentLane = hashToLane.get(parentHash) ?? lane;
+        lanes[lane] = parentLane === lane ? parentHash : null;
         edges.push({
           fromRow: row,
           fromLane: lane,
           toRow: parentRow,
-          toLane: hashToLane.get(parentHash) ?? lane,
+          toLane: parentLane,
           color,
         });
       } else {
-        // Merge parent: may need a new lane
+        // Merge parent: may need a new lane.
         if (!hashToLane.has(parentHash)) {
           const mergeLane = findFreeLane();
           hashToLane.set(parentHash, mergeLane);
@@ -116,6 +121,7 @@ export function computeGraphLayout(commits: CommitNode[]): GraphLayout {
           lanes[mergeLane] = parentHash;
         }
         const parentLane = hashToLane.get(parentHash)!;
+        lanes[parentLane] = parentHash;
         edges.push({
           fromRow: row,
           fromLane: lane,
@@ -126,8 +132,8 @@ export function computeGraphLayout(commits: CommitNode[]): GraphLayout {
       }
     }
 
-    // Free lane if no parent will use it
-    if (commit.parents.length === 0) {
+    // Free lane if no visible parent will continue in-range.
+    if (visibleParents.length === 0) {
       lanes[lane] = null;
     }
   }

--- a/plugins/sero-git-plugin/ui/styles.ts
+++ b/plugins/sero-git-plugin/ui/styles.ts
@@ -6,9 +6,6 @@
  */
 
 export const GIT_STYLES = `
-  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300;1,9..40,400&display=swap');
-  @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap');
-
   .git-root {
     --g-bg: #0c0e14;
     --g-surface: #14161e;
@@ -26,9 +23,9 @@ export const GIT_STYLES = `
     --g-border: rgba(255, 255, 255, 0.06);
     --g-border-bright: rgba(255, 255, 255, 0.10);
     --g-glow: rgba(129, 140, 248, 0.08);
-    --g-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+    --g-mono: ui-monospace, 'SF Mono', 'Fira Code', monospace;
 
-    font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
+    font-family: Inter, 'SF Pro Display', system-ui, -apple-system, sans-serif;
     background: var(--g-bg);
     color: var(--g-text);
   }
@@ -44,7 +41,7 @@ export const GIT_STYLES = `
   }
 
   .git-root h1, .git-root h2, .git-root h3, .git-root h4 {
-    font-family: 'DM Sans', system-ui, -apple-system, sans-serif;
+    font-family: Inter, 'SF Pro Display', system-ui, -apple-system, sans-serif;
   }
 
   .git-scrollbar::-webkit-scrollbar { width: 5px; height: 5px; }

--- a/plugins/sero-git-plugin/ui/tsconfig.json
+++ b/plugins/sero-git-plugin/ui/tsconfig.json
@@ -10,7 +10,9 @@
     "noEmit": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "paths": {
-      "@sero-ai/app-runtime": ["../../../packages/app-runtime/src/index.ts"]
+      "@sero-ai/app-runtime": ["../../../packages/app-runtime/src/index.ts"],
+      "@sero-ai/ui": ["../../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/*": ["../../../packages/ui/src/*"]
     }
   },
   "include": ["./**/*", "../shared/**/*"]

--- a/plugins/sero-git-plugin/vitest.config.ts
+++ b/plugins/sero-git-plugin/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [
+      'extension/__tests__/**/*.test.ts',
+      'shared/__tests__/**/*.test.ts',
+      'ui/lib/**/*.test.ts',
+    ],
+    environment: 'node',
+  },
+});

--- a/plugins/sero-memory-plugin/extension/activity-observer.ts
+++ b/plugins/sero-memory-plugin/extension/activity-observer.ts
@@ -19,6 +19,7 @@ import {
   todayStr,
   readFile,
 } from './memory-manager';
+import { nowTimestamp } from './memory-format';
 import { scheduleQmdUpdate } from './qmd';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
@@ -42,13 +43,6 @@ const AUTO_LOG_COOLDOWN_MS = 60_000; // 1 minute
 
 function freshTurn(): TurnSummary {
   return { editedPaths: new Set(), notableCommands: [] };
-}
-
-function nowStamp(): string {
-  return new Date()
-    .toISOString()
-    .replace('T', ' ')
-    .replace(/\.\d+Z$/, '');
 }
 
 // ── Classification ─────────────────────────────────────────────
@@ -165,7 +159,7 @@ async function appendToDailyLog(entry: string): Promise<void> {
   await fs.mkdir(dir, { recursive: true });
 
   const existing = await readFile(filePath);
-  const timestamp = nowStamp();
+  const timestamp = nowTimestamp();
 
   // Append under a "## Activity" heading if it doesn't exist yet
   const heading = '## Activity (auto)';
@@ -207,7 +201,7 @@ async function logToolFailure(
   result: unknown,
 ): Promise<void> {
   const entry = [
-    `[${nowStamp()}] ${pending?.toolName ?? toolName}`,
+    `[${nowTimestamp()}] ${pending?.toolName ?? toolName}`,
     `cwd: ${pending?.cwd ?? cwd}`,
     `input: ${pending?.inputSummary ?? '(input unavailable)'}`,
     'result:',

--- a/plugins/sero-memory-plugin/extension/consolidation.ts
+++ b/plugins/sero-memory-plugin/extension/consolidation.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
 import { complete, type Message } from '@mariozechner/pi-ai';
 
+import { format } from 'date-fns';
 import {
   appendFile,
   ensureDirectories,
@@ -312,7 +313,7 @@ export async function hasPendingStaleLogs(staleDays = 7): Promise<boolean> {
   const root = resolveMemoryRoot();
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - staleDays);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const cutoffStr = format(cutoff, 'yyyy-MM-dd');
 
   const logs = await listPendingDailyLogs(root);
   return logs.some((log) => log.date <= cutoffStr);

--- a/plugins/sero-memory-plugin/extension/memory-format.ts
+++ b/plugins/sero-memory-plugin/extension/memory-format.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto';
+import { format } from 'date-fns';
 
 export const MEMORY_V2_MARKER = '<!-- v2 format: structured memory entries with ids -->';
 export const FILE_UPDATED_PREFIX = '<!-- last updated: ';
@@ -39,11 +40,15 @@ export interface LegacyMemoryEntrySeed {
 }
 
 export function nowTimestamp(): string {
-  return new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+  return format(new Date(), 'yyyy-MM-dd HH:mm:ss');
 }
 
 export function formatShortTimestamp(date: Date): string {
-  return date.toISOString().replace('T', ' ').slice(0, 16);
+  return format(date, 'yyyy-MM-dd HH:mm');
+}
+
+export function localDateStr(date: Date): string {
+  return format(date, 'yyyy-MM-dd');
 }
 
 export function generateEntryId(): string {

--- a/plugins/sero-memory-plugin/extension/memory-manager.ts
+++ b/plugins/sero-memory-plugin/extension/memory-manager.ts
@@ -16,7 +16,8 @@ import path from 'node:path';
 import os from 'node:os';
 
 import type { MemorySearchResult, MemoryFileList } from '../shared/types';
-import { stripEntryIdComments, stripManagedFileMetadata } from './memory-format';
+import { format } from 'date-fns';
+import { nowTimestamp, stripEntryIdComments, stripManagedFileMetadata } from './memory-format';
 
 // ── Constants ──────────────────────────────────────────────────
 
@@ -76,7 +77,7 @@ export function getScratchpadPath(root: string): string {
 }
 
 export function todayStr(): string {
-  return new Date().toISOString().slice(0, 10);
+  return format(new Date(), 'yyyy-MM-dd');
 }
 
 // ── Directory setup ────────────────────────────────────────────
@@ -114,10 +115,7 @@ export async function appendFile(filePath: string, content: string): Promise<voi
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   const existing = await readFile(filePath);
   const separator = existing?.trim() ? '\n\n' : '';
-  const timestamp = new Date()
-    .toISOString()
-    .replace('T', ' ')
-    .replace(/\.\d+Z$/, '');
+  const timestamp = nowTimestamp();
   const stamped = `<!-- ${timestamp} -->\n${content}`;
   await fs.writeFile(filePath, (existing ?? '') + separator + stamped, 'utf-8');
 }

--- a/plugins/sero-memory-plugin/extension/scratchpad.ts
+++ b/plugins/sero-memory-plugin/extension/scratchpad.ts
@@ -21,6 +21,7 @@ import {
   getScratchpadPath as resolveScratchpadPath,
   getTargetUsage,
 } from './memory-manager';
+import { nowTimestamp } from './memory-format';
 import { scheduleQmdUpdate } from './qmd';
 import type { ScratchpadItem } from '../shared/types';
 
@@ -89,10 +90,6 @@ function withinScratchpadCapacity(content: string): string | null {
   const usage = getTargetUsage('scratchpad', content);
   if (usage.chars <= usage.max) return null;
   return `Error: SCRATCHPAD.md would exceed capacity (${usage.chars}/${usage.max} chars). Clear done items or shorten open items before adding more.`;
-}
-
-function nowTimestamp(): string {
-  return new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
 }
 
 // ── Tool parameters ────────────────────────────────────────────

--- a/plugins/sero-memory-plugin/extension/session-lifecycle.ts
+++ b/plugins/sero-memory-plugin/extension/session-lifecycle.ts
@@ -20,6 +20,7 @@ import {
   getDailyPath,
   todayStr,
 } from './memory-manager';
+import { nowTimestamp } from './memory-format';
 import { getOpenScratchpadItems } from './scratchpad';
 import { runQmdUpdateNow, clearUpdateTimer } from './qmd';
 import { error, errorDetails, info } from './logger';
@@ -38,10 +39,6 @@ const SUMMARY_SYSTEM_PROMPT = [
 ].join('\n');
 
 // ── Helpers ────────────────────────────────────────────────────
-
-function nowTimestamp(): string {
-  return new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
-}
 
 async function appendToDaily(content: string): Promise<void> {
   const root = resolveMemoryRoot();

--- a/plugins/sero-memory-plugin/extension/session-transcripts.ts
+++ b/plugins/sero-memory-plugin/extension/session-transcripts.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
+import { format } from 'date-fns';
 
 import {
   SessionManager,
@@ -38,6 +39,8 @@ export function getSessionStoreDir(): string {
 function resolveTranscriptDate(sessionManager: SessionTranscriptManager): string {
   const timestamp = sessionManager.getHeader()?.timestamp;
   if (typeof timestamp === 'string' && /^\d{4}-\d{2}-\d{2}/.test(timestamp)) {
+    const d = new Date(timestamp);
+    if (!Number.isNaN(d.getTime())) return format(d, 'yyyy-MM-dd');
     return timestamp.slice(0, 10);
   }
   return todayStr();
@@ -46,7 +49,7 @@ function resolveTranscriptDate(sessionManager: SessionTranscriptManager): string
 function formatClockTime(timestamp: number): string {
   const date = new Date(timestamp);
   if (Number.isNaN(date.getTime())) return 'unknown';
-  return date.toISOString().slice(11, 16);
+  return format(date, 'HH:mm');
 }
 
 function truncateTranscriptSection(text: string): string {

--- a/plugins/sero-memory-plugin/package.json
+++ b/plugins/sero-memory-plugin/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "@sinclair/typebox": "catalog:",
-    "@tobilu/qmd": "^2.0.1"
+    "@tobilu/qmd": "^2.0.1",
+    "date-fns": "^4.1.0"
   },
   "peerDependencies": {
     "@mariozechner/pi-ai": "catalog:peer",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -747,6 +747,9 @@ importers:
       '@sero-ai/app-runtime':
         specifier: workspace:@sero-ai/app-runtime@*
         version: link:../../packages/app-runtime
+      '@sero-ai/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
@@ -865,6 +868,9 @@ importers:
       '@tobilu/qmd':
         specifier: ^2.0.1
         version: 2.0.1(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       zod:
         specifier: catalog:peer
         version: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -780,6 +780,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
   plugins/sero-kanban-plugin:
     dependencies:


### PR DESCRIPTION
## Summary\n- fix the Git plugin staging, branching, stash, diff, refresh, and error handling UX\n- add safer branch/stash/cherry-pick flows, remote branch visibility, rename metadata, and in-app failure toasts\n- add plugin Vitest coverage for git service, refs, diffs, refresh logic, branch grouping, and graph layout\n- include the pending AGENTS.md guidance update and App Store search input spacing tweak\n\n## Testing\n- pnpm --filter @sero-ai/plugin-git test\n- pnpm --filter @sero-ai/plugin-git build\n- pnpm typecheck