### PR TITLE
refactor(desktop): Deslopify Core Contracts and Ownership

### DIFF
--- a/apps/desktop/electron/features/apps/extensions/git-checkpoints.ts
+++ b/apps/desktop/electron/features/apps/extensions/git-checkpoints.ts
@@ -13,17 +13,26 @@ type MixedEditCheckpointPolicy = 'merge-working-copy' | 'require-manual-first';
 // create a single turn checkpoint that includes the full resulting workspace state.
 const MIXED_EDIT_CHECKPOINT_POLICY: MixedEditCheckpointPolicy = 'merge-working-copy';
 
+type TextContentBlock = { type: 'text'; text: string };
+
+function isTextContentBlock(block: unknown): block is TextContentBlock {
+  if (!block || typeof block !== 'object') return false;
+  const candidate = block as { type?: unknown; text?: unknown };
+  return candidate.type === 'text' && typeof candidate.text === 'string';
+}
+
 function extractTextContent(content: unknown): string {
   if (!Array.isArray(content)) return '';
   return content
-    .filter((block: any) => block?.type === 'text' && typeof block?.text === 'string')
-    .map((block: any) => block.text)
+    .filter(isTextContentBlock)
+    .map((block) => block.text)
     .join('\n')
     .trim();
 }
 
 function summarizeAssistantMessage(message: unknown): string {
-  const text = extractTextContent((message as any)?.content);
+  const candidate = message as { content?: unknown };
+  const text = extractTextContent(candidate.content);
   if (!text) return 'checkpoint: turn';
   const first = text.split(/\r?\n/).find((line) => line.trim().length > 0) ?? 'checkpoint: turn';
   return `checkpoint: ${first.trim().slice(0, 220)}`;

--- a/apps/desktop/electron/features/apps/extensions/ui-context.ts
+++ b/apps/desktop/electron/features/apps/extensions/ui-context.ts
@@ -48,7 +48,7 @@ export function createSeroUIContext(): ExtensionUIContext {
 
     // ── Custom components (no-op) ────────────────────────
 
-    custom: async () => undefined as never,
+    custom: async <T>(..._args: Parameters<ExtensionUIContext['custom']>) => undefined as unknown as T,
 
     // ── Editor (no-op) ───────────────────────────────────
 
@@ -60,8 +60,8 @@ export function createSeroUIContext(): ExtensionUIContext {
 
     // ── Theme (stubs) ────────────────────────────────────
 
-    get theme(): any {
-      return {};
+    get theme(): ExtensionUIContext['theme'] {
+      return {} as ExtensionUIContext['theme'];
     },
     getAllThemes: () => [],
     getTheme: () => undefined,

--- a/apps/desktop/electron/features/apps/state/manager.ts
+++ b/apps/desktop/electron/features/apps/state/manager.ts
@@ -21,11 +21,15 @@ import { IpcChannels } from '@/types/ipc';
 // ── Types ────────────────────────────────────────────────────
 
 interface WatcherEntry {
-  watcher: FSWatcher;
+  watcher: FSWatcher | null;
   /** Number of renderer subscriptions for this file. */
   refCount: number;
   /** Debounce timer for change events. */
   debounceTimer: ReturnType<typeof setTimeout> | null;
+  /** True while async watch bootstrap is in progress. */
+  initializing: boolean;
+  /** True when all refs were released before bootstrap completed. */
+  cancelled: boolean;
 }
 
 // ── AppStateManager ──────────────────────────────────────────
@@ -129,12 +133,27 @@ class AppStateManager {
     const existing = this.watchers.get(filePath);
     if (existing) {
       existing.refCount++;
+      existing.cancelled = false;
       return;
     }
+
+    this.watchers.set(filePath, {
+      watcher: null,
+      refCount: 1,
+      debounceTimer: null,
+      initializing: true,
+      cancelled: false,
+    });
 
     // Ensure directory exists before watching
     const dir = path.dirname(filePath);
     fs.mkdir(dir, { recursive: true }).then(async () => {
+      const entry = this.watchers.get(filePath);
+      if (!entry || entry.cancelled || entry.refCount <= 0) {
+        this.watchers.delete(filePath);
+        return;
+      }
+
       // Touch file if missing so fs.watch has something to watch.
       // MUST await — startWatcher needs the file to exist on disk.
       try {
@@ -145,10 +164,17 @@ class AppStateManager {
 
       try {
         this.startWatcher(filePath);
-        const entry = this.watchers.get(filePath)!;
-        entry.refCount = 1;
       } catch (err) {
         console.error(`[AppStateManager] Failed to watch ${filePath}:`, err);
+      } finally {
+        const current = this.watchers.get(filePath);
+        if (!current) return;
+        current.initializing = false;
+        if (current.cancelled || current.refCount <= 0) {
+          current.watcher?.close();
+          if (current.debounceTimer) clearTimeout(current.debounceTimer);
+          this.watchers.delete(filePath);
+        }
       }
     });
   }
@@ -162,9 +188,12 @@ class AppStateManager {
 
     entry.refCount--;
     if (entry.refCount <= 0) {
-      entry.watcher.close();
+      entry.cancelled = true;
+      entry.watcher?.close();
       if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
-      this.watchers.delete(filePath);
+      if (!entry.initializing) {
+        this.watchers.delete(filePath);
+      }
     }
   }
 
@@ -194,7 +223,13 @@ class AppStateManager {
 
     const refCount = existing?.refCount ?? 0;
     const debounceTimer = existing?.debounceTimer ?? null;
-    this.watchers.set(filePath, { watcher, refCount, debounceTimer });
+    this.watchers.set(filePath, {
+      watcher,
+      refCount,
+      debounceTimer,
+      initializing: false,
+      cancelled: existing?.cancelled ?? false,
+    });
   }
 
   /**
@@ -257,7 +292,7 @@ class AppStateManager {
 
   dispose(): void {
     for (const [, entry] of this.watchers) {
-      entry.watcher.close();
+      entry.watcher?.close();
       if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
     }
     this.watchers.clear();

--- a/apps/desktop/electron/features/auth/github/auth-manager.ts
+++ b/apps/desktop/electron/features/auth/github/auth-manager.ts
@@ -290,10 +290,10 @@ export class GitHubAuthManager {
   }
 
   private loadCachedToken(): void {
-    try {
-      const tokenFile = getExistingTokenFile();
-      if (!tokenFile) return;
+    const tokenFile = getExistingTokenFile();
+    if (!tokenFile) return;
 
+    try {
       const raw = readFileSync(tokenFile, 'utf8');
       const stored = JSON.parse(raw) as StoredToken;
 
@@ -304,9 +304,14 @@ export class GitHubAuthManager {
       this.cachedToken = token;
       this.cachedUsername = stored.username;
     } catch (err) {
-      console.warn('[github-auth] Failed to load cached token:', err);
+      console.warn('[github-auth] Failed to load cached token, clearing cached auth file:', err);
       this.cachedToken = null;
       this.cachedUsername = null;
+      try {
+        unlinkSync(tokenFile);
+      } catch (unlinkErr) {
+        console.warn('[github-auth] Failed to remove invalid cached token file:', unlinkErr);
+      }
     }
   }
 }

--- a/apps/desktop/electron/features/container/index.ts
+++ b/apps/desktop/electron/features/container/index.ts
@@ -266,10 +266,14 @@ export class ContainerManager {
   }
 
   async stop(workspaceId: string): Promise<void> {
+    this.portScanner.stopScanning(workspaceId);
+    this.containerIps.delete(workspaceId);
     return stopContainer(workspaceId, this.containers);
   }
 
   async remove(workspaceId: string): Promise<void> {
+    this.portScanner.stopScanning(workspaceId);
+    this.containerIps.delete(workspaceId);
     return removeContainer(workspaceId, this.containers);
   }
 

--- a/apps/desktop/electron/features/container/network/http-proxy.ts
+++ b/apps/desktop/electron/features/container/network/http-proxy.ts
@@ -14,6 +14,26 @@ import * as http from 'http';
 import * as net from 'net';
 
 const DEFAULT_PORT = 19800;
+const GATEWAY_IP = '192.168.64.1';
+const FALLBACK_BIND_ADDRESS = '0.0.0.0';
+
+function normalizeClientAddress(address: string | undefined): string {
+  if (!address) return '';
+  return address.startsWith('::ffff:') ? address.slice(7) : address;
+}
+
+function isAllowedProxyClient(address: string | undefined): boolean {
+  const normalized = normalizeClientAddress(address);
+  if (!normalized) return false;
+  if (normalized === '127.0.0.1' || normalized === '::1') return true;
+  return /^192\.168\.64\.\d{1,3}$/.test(normalized);
+}
+
+function getSocketRemoteAddress(socket: NodeJS.ReadWriteStream): string | undefined {
+  return 'remoteAddress' in socket && typeof socket.remoteAddress === 'string'
+    ? socket.remoteAddress
+    : undefined;
+}
 
 function isBlockedProxyTarget(host: string): boolean {
   const normalized = host.trim().toLowerCase();
@@ -51,9 +71,9 @@ export class ContainerHttpProxy {
   private server: http.Server | null = null;
   private port: number;
   /** The gateway IP containers use to reach the host. */
-  private gatewayIp = '192.168.64.1';
-  /** Bind only to the container gateway interface to avoid LAN-wide exposure. */
-  private bindAddress = '192.168.64.1';
+  private gatewayIp = GATEWAY_IP;
+  /** Prefer the gateway IP, but fall back to 0.0.0.0 if macOS does not expose it as a bindable interface. */
+  private bindAddress = GATEWAY_IP;
 
   constructor(port = DEFAULT_PORT) {
     this.port = port;
@@ -70,8 +90,22 @@ export class ContainerHttpProxy {
         res.end('Use CONNECT for HTTPS');
       });
 
+      const listen = () => {
+        server.listen(this.port, this.bindAddress, () => {
+          console.log(`[http-proxy] Container proxy running on ${this.bindAddress}:${this.port}`);
+          this.server = server;
+          resolve(this.getProxyUrl());
+        });
+      };
+
       // Handle CONNECT method (HTTPS tunneling)
       server.on('connect', (req, clientSocket, head) => {
+        if (!isAllowedProxyClient(getSocketRemoteAddress(clientSocket))) {
+          clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+          clientSocket.destroy();
+          return;
+        }
+
         const [host, portStr] = (req.url ?? '').split(':');
         if (!host || isBlockedProxyTarget(host)) {
           clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
@@ -97,6 +131,12 @@ export class ContainerHttpProxy {
 
       // Also handle plain HTTP GET/POST (for npm registry HTTP fallback)
       server.on('request', (req, res) => {
+        if (!isAllowedProxyClient(req.socket.remoteAddress)) {
+          res.writeHead(403);
+          res.end('Forbidden client');
+          return;
+        }
+
         if (!req.url || !req.url.startsWith('http://')) {
           res.writeHead(400);
           res.end('Bad request');
@@ -141,17 +181,23 @@ export class ContainerHttpProxy {
         if (err.code === 'EADDRINUSE') {
           console.log(`[http-proxy] Port ${this.port} in use on ${this.bindAddress}, trying ${this.port + 1}`);
           this.port += 1;
-          server.listen(this.port, this.bindAddress);
-        } else {
-          reject(err);
+          listen();
+          return;
         }
+
+        if (err.code === 'EADDRNOTAVAIL' && this.bindAddress !== FALLBACK_BIND_ADDRESS) {
+          console.warn(
+            `[http-proxy] ${this.bindAddress} is not bindable on this host, falling back to ${FALLBACK_BIND_ADDRESS}`,
+          );
+          this.bindAddress = FALLBACK_BIND_ADDRESS;
+          listen();
+          return;
+        }
+
+        reject(err);
       });
 
-      server.listen(this.port, this.bindAddress, () => {
-        console.log(`[http-proxy] Container proxy running on ${this.bindAddress}:${this.port}`);
-        this.server = server;
-        resolve(this.getProxyUrl());
-      });
+      listen();
     });
   }
 

--- a/apps/desktop/electron/features/container/network/http-proxy.ts
+++ b/apps/desktop/electron/features/container/network/http-proxy.ts
@@ -1,7 +1,7 @@
 /**
  * Minimal HTTP CONNECT proxy for container internet access.
  *
- * Runs on the host, bound to 0.0.0.0 so containers can reach it via
+ * Runs on the host, bound to the container gateway interface so containers can reach it via
  * the gateway IP (e.g. 192.168.64.1). Containers set HTTP_PROXY/HTTPS_PROXY
  * to use this proxy for all outbound traffic.
  *
@@ -14,6 +14,25 @@ import * as http from 'http';
 import * as net from 'net';
 
 const DEFAULT_PORT = 19800;
+
+function isBlockedProxyTarget(host: string): boolean {
+  const normalized = host.trim().toLowerCase();
+  if (!normalized) return true;
+  if (normalized === 'localhost' || normalized.endsWith('.local') || normalized.endsWith('.localhost')) {
+    return true;
+  }
+
+  const ipVersion = net.isIP(normalized);
+  if (!ipVersion) return false;
+
+  if (normalized.startsWith('127.') || normalized === '::1') return true;
+  if (normalized.startsWith('10.') || normalized.startsWith('192.168.') || normalized.startsWith('169.254.')) {
+    return true;
+  }
+  if (/^172\.(1[6-9]|2\d|3[0-1])\./.test(normalized)) return true;
+
+  return false;
+}
 
 export function handleProxyRequestError(
   res: Pick<http.ServerResponse, 'headersSent' | 'writableEnded' | 'destroyed' | 'writeHead' | 'end' | 'destroy'>,
@@ -33,6 +52,8 @@ export class ContainerHttpProxy {
   private port: number;
   /** The gateway IP containers use to reach the host. */
   private gatewayIp = '192.168.64.1';
+  /** Bind only to the container gateway interface to avoid LAN-wide exposure. */
+  private bindAddress = '192.168.64.1';
 
   constructor(port = DEFAULT_PORT) {
     this.port = port;
@@ -52,8 +73,13 @@ export class ContainerHttpProxy {
       // Handle CONNECT method (HTTPS tunneling)
       server.on('connect', (req, clientSocket, head) => {
         const [host, portStr] = (req.url ?? '').split(':');
-        const port = parseInt(portStr, 10) || 443;
+        if (!host || isBlockedProxyTarget(host)) {
+          clientSocket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+          clientSocket.destroy();
+          return;
+        }
 
+        const port = parseInt(portStr, 10) || 443;
         const remoteSocket = net.connect(port, host, () => {
           clientSocket.write(
             'HTTP/1.1 200 Connection Established\r\n\r\n',
@@ -78,6 +104,12 @@ export class ContainerHttpProxy {
         }
 
         const url = new URL(req.url);
+        if (isBlockedProxyTarget(url.hostname)) {
+          res.writeHead(403);
+          res.end('Forbidden target');
+          return;
+        }
+
         const options: http.RequestOptions = {
           hostname: url.hostname,
           port: url.port || 80,
@@ -107,16 +139,16 @@ export class ContainerHttpProxy {
 
       server.on('error', (err: NodeJS.ErrnoException) => {
         if (err.code === 'EADDRINUSE') {
-          console.log(`[http-proxy] Port ${this.port} in use, trying ${this.port + 1}`);
+          console.log(`[http-proxy] Port ${this.port} in use on ${this.bindAddress}, trying ${this.port + 1}`);
           this.port += 1;
-          server.listen(this.port, '0.0.0.0');
+          server.listen(this.port, this.bindAddress);
         } else {
           reject(err);
         }
       });
 
-      server.listen(this.port, '0.0.0.0', () => {
-        console.log(`[http-proxy] Container proxy running on 0.0.0.0:${this.port}`);
+      server.listen(this.port, this.bindAddress, () => {
+        console.log(`[http-proxy] Container proxy running on ${this.bindAddress}:${this.port}`);
         this.server = server;
         resolve(this.getProxyUrl());
       });

--- a/apps/desktop/electron/features/container/network/port-forward.ts
+++ b/apps/desktop/electron/features/container/network/port-forward.ts
@@ -65,8 +65,18 @@ function parseListeningPorts(ssOutput: string): ListeningPort[] {
 
 const BRIDGE_OFFSET = 20000;
 
-function bridgeScript(targetPort: number, bridgePort: number): string {
-  return `node -e "require('net').createServer(c=>{const r=require('net').connect(${targetPort},'127.0.0.1');c.pipe(r);r.pipe(c);c.on('error',()=>r.destroy());r.on('error',()=>c.destroy())}).listen(${bridgePort},'0.0.0.0')" &`;
+function bridgeMarker(wsId: string, targetPort: number): string {
+  return `sero-port-bridge-${wsId}-${targetPort}`;
+}
+
+function bridgeScript(wsId: string, targetPort: number, bridgePort: number): string {
+  const marker = bridgeMarker(wsId, targetPort);
+  return `node -e "process.title='${marker}';require('net').createServer(c=>{const r=require('net').connect(${targetPort},'127.0.0.1');c.pipe(r);r.pipe(c);c.on('error',()=>r.destroy());r.on('error',()=>c.destroy())}).listen(${bridgePort},'0.0.0.0')" &`;
+}
+
+function stopBridgeCommand(wsId: string, targetPort: number): string {
+  const marker = bridgeMarker(wsId, targetPort);
+  return `pkill -f '${marker}' >/dev/null 2>&1 || true`;
 }
 
 // ── PortScanner ─────────────────────────────────────────────
@@ -99,6 +109,12 @@ export class PortScanner {
     const state = this.workspaces.get(wsId);
     if (!state) return;
     clearInterval(state.timer);
+    for (const port of state.bridges) {
+      void state.execFn(stopBridgeCommand(wsId, port));
+    }
+    state.bridges.clear();
+    state.detected = [];
+    state.lastPorts.clear();
     this.workspaces.delete(wsId);
   }
 
@@ -129,7 +145,11 @@ export class PortScanner {
 
     try {
       const result = await state.execFn('ss -tlnp 2>/dev/null');
-      if (result.exitCode !== 0) return;
+      if (result.exitCode !== 0) {
+        state.detected = [];
+        state.lastPorts.clear();
+        return;
+      }
 
       const ports = parseListeningPorts(result.stdout);
       const currentSet = new Set<number>();
@@ -152,13 +172,16 @@ export class PortScanner {
       // Clean up bridges for ports that stopped listening
       for (const old of state.lastPorts) {
         if (!currentSet.has(old) && state.bridges.has(old)) {
-          state.bridges.delete(old);
+          await this.stopBridge(state, wsId, old);
         }
       }
 
       state.lastPorts = currentSet;
       state.detected = detected;
-    } catch { /* container may have stopped */ }
+    } catch {
+      state.detected = [];
+      state.lastPorts.clear();
+    }
   }
 
   private async ensureBridge(
@@ -169,11 +192,22 @@ export class PortScanner {
     if (state.bridges.has(port)) return;
     const bridgePort = port + BRIDGE_OFFSET;
     try {
-      await state.execFn(`${bridgeScript(port, bridgePort)} sleep 0.5`);
+      await state.execFn(stopBridgeCommand(wsId, port));
+      await state.execFn(`${bridgeScript(wsId, port, bridgePort)} sleep 0.5`);
       state.bridges.add(port);
       console.log(`[ports] Bridge: 0.0.0.0:${bridgePort} → 127.0.0.1:${port} (${wsId})`);
     } catch {
       console.warn(`[ports] Failed to bridge port ${port} in ${wsId}`);
     }
+  }
+
+  private async stopBridge(state: WorkspaceScanState, wsId: string, port: number): Promise<void> {
+    if (!state.bridges.has(port)) return;
+    try {
+      await state.execFn(stopBridgeCommand(wsId, port));
+    } catch {
+      // best effort
+    }
+    state.bridges.delete(port);
   }
 }

--- a/apps/desktop/electron/features/plugins/discovery.ts
+++ b/apps/desktop/electron/features/plugins/discovery.ts
@@ -1,16 +1,16 @@
 /**
  * Plugin Discovery — search for public Sero plugins on GitHub and npm.
  *
- * GitHub repos are discovered via the "sero-agent-plugin" topic.
- * npm packages are discovered via the "sero-agent-plugin" keyword.
- * Results are merged by matching GitHub repos referenced in npm metadata.
+ * During the tag migration, we search both the legacy "sero-ai-plugin"
+ * metadata and the newer "sero-agent-plugin" metadata, then dedupe the
+ * combined results.
  */
 
 import type { DiscoveredPlugin } from '@sero/common';
 import { listInstalledPlugins } from './manager';
 
-const GITHUB_TOPIC = 'sero-agent-plugin';
-const NPM_KEYWORD = 'sero-agent-plugin';
+const GITHUB_TOPICS = ['sero-agent-plugin', 'sero-ai-plugin'] as const;
+const NPM_KEYWORDS = ['sero-agent-plugin', 'sero-ai-plugin'] as const;
 
 // ── GitHub types ───────────────────────────────────────────
 
@@ -44,10 +44,24 @@ interface NpmSearchResponse {
 
 // ── Search functions ───────────────────────────────────────
 
-async function searchGitHub(query: string): Promise<GitHubRepo[]> {
+function dedupeByKey<T>(items: T[], getKey: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+
+  for (const item of items) {
+    const key = getKey(item).trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+
+  return result;
+}
+
+async function searchGitHubByTopic(topic: string, query: string): Promise<GitHubRepo[]> {
   const q = query
-    ? `topic:${GITHUB_TOPIC} ${query} in:name,description`
-    : `topic:${GITHUB_TOPIC}`;
+    ? `topic:${topic} ${query} in:name,description`
+    : `topic:${topic}`;
   const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(q)}&sort=stars&order=desc&per_page=30`;
 
   const res = await fetch(url, {
@@ -58,7 +72,7 @@ async function searchGitHub(query: string): Promise<GitHubRepo[]> {
   });
 
   if (!res.ok) {
-    console.warn(`[plugin-discovery] GitHub search failed: ${res.status} ${res.statusText}`);
+    console.warn(`[plugin-discovery] GitHub search failed for topic ${topic}: ${res.status} ${res.statusText}`);
     return [];
   }
 
@@ -66,10 +80,15 @@ async function searchGitHub(query: string): Promise<GitHubRepo[]> {
   return data.items ?? [];
 }
 
-async function searchNpm(query: string): Promise<NpmPackage[]> {
+async function searchGitHub(query: string): Promise<GitHubRepo[]> {
+  const results = await Promise.all(GITHUB_TOPICS.map((topic) => searchGitHubByTopic(topic, query)));
+  return dedupeByKey(results.flat(), (repo) => repo.full_name);
+}
+
+async function searchNpmByKeyword(keyword: string, query: string): Promise<NpmPackage[]> {
   const text = query
-    ? `keywords:${NPM_KEYWORD} ${query}`
-    : `keywords:${NPM_KEYWORD}`;
+    ? `keywords:${keyword} ${query}`
+    : `keywords:${keyword}`;
   const url = `https://registry.npmjs.org/-/v1/search?text=${encodeURIComponent(text)}&size=30`;
 
   const res = await fetch(url, {
@@ -77,12 +96,17 @@ async function searchNpm(query: string): Promise<NpmPackage[]> {
   });
 
   if (!res.ok) {
-    console.warn(`[plugin-discovery] npm search failed: ${res.status} ${res.statusText}`);
+    console.warn(`[plugin-discovery] npm search failed for keyword ${keyword}: ${res.status} ${res.statusText}`);
     return [];
   }
 
   const data = (await res.json()) as NpmSearchResponse;
   return data.objects?.map((o) => o.package) ?? [];
+}
+
+async function searchNpm(query: string): Promise<NpmPackage[]> {
+  const results = await Promise.all(NPM_KEYWORDS.map((keyword) => searchNpmByKeyword(keyword, query)));
+  return dedupeByKey(results.flat(), (pkg) => pkg.name);
 }
 
 // ── Merge & deduplicate ────────────────────────────────────

--- a/apps/desktop/electron/features/plugins/discovery.ts
+++ b/apps/desktop/electron/features/plugins/discovery.ts
@@ -1,16 +1,16 @@
 /**
  * Plugin Discovery — search for public Sero plugins on GitHub and npm.
  *
- * GitHub repos are discovered via the "sero-ai-plugin" topic.
- * npm packages are discovered via the "sero-ai-plugin" keyword.
+ * GitHub repos are discovered via the "sero-agent-plugin" topic.
+ * npm packages are discovered via the "sero-agent-plugin" keyword.
  * Results are merged by matching GitHub repos referenced in npm metadata.
  */
 
 import type { DiscoveredPlugin } from '@sero/common';
 import { listInstalledPlugins } from './manager';
 
-const GITHUB_TOPIC = 'sero-ai-plugin';
-const NPM_KEYWORD = 'sero-ai-plugin';
+const GITHUB_TOPIC = 'sero-agent-plugin';
+const NPM_KEYWORD = 'sero-agent-plugin';
 
 // ── GitHub types ───────────────────────────────────────────
 

--- a/apps/desktop/electron/features/plugins/manager.ts
+++ b/apps/desktop/electron/features/plugins/manager.ts
@@ -146,7 +146,6 @@ function validatePluginPackage(pkg: PkgJson | null): ValidatedPluginPackage {
 
 function assertPreparedUiExists(packageDir: string, app: ValidatedPluginApp): void {
   if (!app.ui) return;
-
   const distUi = path.join(packageDir, 'dist', 'ui', 'remoteEntry.js');
   if (!existsSync(distUi)) {
     throw new Error('Invalid plugin: declares UI but dist/ui/remoteEntry.js is missing.');
@@ -155,9 +154,17 @@ function assertPreparedUiExists(packageDir: string, app: ValidatedPluginApp): vo
 
 function readSettings(): Record<string, unknown> {
   try {
-    return JSON.parse(readFileSync(SETTINGS_PATH, 'utf8')) as Record<string, unknown>;
-  } catch {
-    return {};
+    const parsed = JSON.parse(readFileSync(SETTINGS_PATH, 'utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('settings.json must contain a JSON object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError?.code === 'ENOENT') {
+      return {};
+    }
+    throw new Error(`Failed to read settings.json. Fix ~/.sero-ui/agent/settings.json and retry plugin operation. (${error instanceof Error ? error.message : 'unknown parse error'})`);
   }
 }
 
@@ -264,7 +271,6 @@ async function doInstallPlugin(source: string): Promise<SeroAppManifest> {
   let staged: StagedPluginInstall | null = null;
   let reserved: ReservedInstallPath | null = null;
   let settingsAdded = false;
-
   try {
     let sourceKind: 'npm' | 'git' | 'local' = 'local';
 

--- a/apps/desktop/electron/ipc/agent/core/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-helpers.ts
@@ -285,7 +285,7 @@ export function convertSessionMessages(
         });
       }
     } else if (msg.role === 'custom') {
-      const prefixed = formatCustomMessage(msg as any);
+      const prefixed = formatCustomMessage(msg);
       if (!prefixed) continue;
       result.push({ type: 'assistant', id: nextId(), text: prefixed, isStreaming: false });
     }
@@ -417,27 +417,35 @@ export function buildCommandList(entry: PoolEntryRef, hidden?: Set<string>): Ser
 
 // ── Context override helpers ────────────────────────────────
 
+type SessionPrivatePromptAccessor = { _baseSystemPrompt?: string };
+
+function asSessionWithPrivatePrompt(session: AgentSession): SessionPrivatePromptAccessor {
+  return session as unknown as SessionPrivatePromptAccessor;
+}
+
 /** Safely read _baseSystemPrompt from AgentSession (private SDK field). */
 export function getBaseSystemPrompt(session: AgentSession): string | undefined {
-  if (!('_baseSystemPrompt' in (session as any))) {
+  const privateSession = asSessionWithPrivatePrompt(session);
+  if (typeof privateSession._baseSystemPrompt !== 'string') {
     console.warn(
       '[context-editor] _baseSystemPrompt not found on AgentSession — ' +
         'SDK version mismatch? Tested against pi-coding-agent@0.52.12.',
     );
     return undefined;
   }
-  return (session as any)._baseSystemPrompt;
+  return privateSession._baseSystemPrompt;
 }
 
 /** Safely write _baseSystemPrompt + update the agent's current prompt. */
 export function setBaseSystemPrompt(session: AgentSession, prompt: string): void {
-  if (!('_baseSystemPrompt' in (session as any))) {
+  const privateSession = asSessionWithPrivatePrompt(session);
+  if (typeof privateSession._baseSystemPrompt !== 'string') {
     console.warn(
       '[context-editor] _baseSystemPrompt not found on AgentSession — ' +
         'SDK version mismatch? Tested against pi-coding-agent@0.52.12.',
     );
   }
-  (session as any)._baseSystemPrompt = prompt;
+  privateSession._baseSystemPrompt = prompt;
   session.agent.setSystemPrompt(prompt);
 }
 

--- a/apps/desktop/electron/ipc/agent/core/agent.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent.ts
@@ -79,6 +79,10 @@ interface PoolEntry {
 
 const pool = new Map<string, PoolEntry>();
 
+function toErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
 /** Get a pool entry by session ID (used by collaboration handler). */
 export function getAgentPoolEntry(sessionId: string): PoolEntry | undefined {
   return pool.get(sessionId);
@@ -153,9 +157,10 @@ async function openSessionInternal(
       containerState = await containerManager.ensure(containerConfig);
       sendEvent({ type: 'container_ready', sessionId, workspaceId, ipAddress: containerState.ipAddress });
     }
-  } catch (containerErr: any) {
-    console.error(`[agent] Container failed for ${workspaceId}:`, containerErr?.message);
-    sendEvent({ type: 'container_error', sessionId, workspaceId, error: containerErr?.message ?? 'Container failed to start' });
+  } catch (containerErr: unknown) {
+    const message = toErrorMessage(containerErr, 'Container failed to start');
+    console.error(`[agent] Container failed for ${workspaceId}:`, message);
+    sendEvent({ type: 'container_error', sessionId, workspaceId, error: message });
   }
 
   const useContainer = !!containerState;
@@ -390,8 +395,8 @@ export function registerAgentHandlers(): void {
       try {
         const result = await entry.session.compact(customInstructions);
         return { success: true, tokensBefore: result.tokensBefore };
-      } catch (err: any) {
-        return { success: false, error: err?.message || 'Compaction failed' };
+      } catch (err: unknown) {
+        return { success: false, error: toErrorMessage(err, 'Compaction failed') };
       }
     },
   );

--- a/apps/desktop/electron/ipc/agent/handlers/imagegen.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/imagegen.ts
@@ -24,8 +24,18 @@ import {
 const STATE_REL = path.join('.sero', 'apps', 'imagegen', 'state.json');
 const IMAGES_REL = path.join('.sero', 'apps', 'imagegen', 'images');
 
+interface PersistedImageGeneration {
+  id: number;
+  prompt: string;
+  negativePrompt?: string;
+  model: ImageGenParams['model'];
+  aspectRatio: ImageGenParams['aspectRatio'];
+  images: ImageGenResult['images'];
+  createdAt: string;
+}
+
 interface ImageGenState {
-  generations: any[];
+  generations: PersistedImageGeneration[];
   nextId: number;
 }
 
@@ -58,7 +68,7 @@ export function registerImagegenHandlers(): void {
       _event,
       workspaceId: string,
       params: ImageGenParams,
-    ): Promise<{ generation: any; error?: string }> => {
+    ): Promise<{ generation: PersistedImageGeneration | null; error?: string }> => {
       const wsPath = workspaceManager.getPath(workspaceId);
       if (!wsPath) throw new Error('No workspace path');
 
@@ -104,14 +114,14 @@ export function registerImagegenHandlers(): void {
       const statePath = path.join(wsPath, STATE_REL);
       const state = await readState(statePath);
 
-      const idx = state.generations.findIndex((g: any) => g.id === generationId);
+      const idx = state.generations.findIndex((g) => g.id === generationId);
       if (idx === -1) return { ok: false, error: 'Image not found' };
 
       const gen = state.generations[idx];
 
       if (singleImageId) {
         // Remove a single image from the generation
-        const imgIdx = gen.images.findIndex((img: any) => img.id === singleImageId);
+        const imgIdx = gen.images.findIndex((img) => img.id === singleImageId);
         if (imgIdx === -1) return { ok: false, error: 'Image not found' };
 
         const [removed] = gen.images.splice(imgIdx, 1);

--- a/apps/desktop/electron/ipc/editor/lsp.ts
+++ b/apps/desktop/electron/ipc/editor/lsp.ts
@@ -48,7 +48,7 @@ export function registerLspHandlers(): void {
   );
 
   // Forward LSP notifications (diagnostics etc.) to the renderer
-  lspManager.on('notification', (data: { workspaceId: string; language: string; notification: any }) => {
+  lspManager.on('notification', (data: { workspaceId: string; language: string; notification: unknown }) => {
     for (const win of BrowserWindow.getAllWindows()) {
       try {
         if (!win.isDestroyed()) {

--- a/apps/desktop/electron/ipc/gateway/gateway.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway.ts
@@ -104,6 +104,8 @@ export function registerGatewayHandlers(): void {
   ipcMain.handle(
     IpcChannels.gateway.getQrLoginData,
     async (_event, expiryDays?: number): Promise<QrLoginData> => {
+      await startGateway();
+
       // Clamp expiry to 1–30 days to prevent bogus values from the renderer.
       const days = Math.max(1, Math.min(expiryDays ?? 7, 30));
       const auth = gatewayServer.getAuth();
@@ -113,11 +115,14 @@ export function registerGatewayHandlers(): void {
       );
 
       // Determine the best base URL for the login link.
-      // Prefer the Tailscale URL (reachable from other devices on the tailnet),
-      // fall back to localhost (same-machine development).
+      // Only use the tailnet URL after we have explicitly exposed the gateway
+      // via `tailscale serve`; otherwise the hostname can return 502s.
       const status = gatewayServer.getStatus();
       const tsStatus = await tailscale.getStatus();
-      const baseUrl = tsStatus.gatewayUrl ?? `http://127.0.0.1:${status.port}`;
+      const tailnetUrl = tsStatus.running
+        ? await tailscale.serve(status.port)
+        : null;
+      const baseUrl = tailnetUrl ?? `http://127.0.0.1:${status.port}`;
 
       const loginUrl = new URL('/', baseUrl);
       loginUrl.searchParams.set('token', webToken.token);

--- a/apps/desktop/electron/ipc/integrations/google-api.ts
+++ b/apps/desktop/electron/ipc/integrations/google-api.ts
@@ -30,6 +30,10 @@ export interface GogExecResult {
   exitCode: number;
 }
 
+type ExecFileError = NodeJS.ErrnoException & {
+  status?: number | null;
+};
+
 // ── Binary resolution ────────────────────────────────────────
 
 const GOG_SEARCH_PATHS = [
@@ -70,7 +74,7 @@ function runGog(args: string[], email?: string): Promise<GogExecResult> {
       maxBuffer: 10 * 1024 * 1024,
       env: { ...process.env, PATH: buildEnhancedPath(), GOG_KEYRING_PASSWORD: deriveKeyringPassword() },
     }, (error, stdout, stderr) => {
-      const childError = error as NodeJS.ErrnoException | null;
+      const childError = error as ExecFileError | null;
       if (childError?.code === 'ENOENT') {
         resolve({ stdout: '', stderr: 'gog binary not found', exitCode: 127 });
         return;
@@ -78,7 +82,7 @@ function runGog(args: string[], email?: string): Promise<GogExecResult> {
       resolve({
         stdout: stdout ?? '',
         stderr: stderr ?? '',
-        exitCode: typeof childError?.code === 'number' ? childError.code : 1,
+        exitCode: childError ? (typeof childError.status === 'number' ? childError.status : 1) : 0,
       });
     });
     child.on('error', (err) => {

--- a/apps/desktop/electron/ipc/integrations/google-api.ts
+++ b/apps/desktop/electron/ipc/integrations/google-api.ts
@@ -70,13 +70,15 @@ function runGog(args: string[], email?: string): Promise<GogExecResult> {
       maxBuffer: 10 * 1024 * 1024,
       env: { ...process.env, PATH: buildEnhancedPath(), GOG_KEYRING_PASSWORD: deriveKeyringPassword() },
     }, (error, stdout, stderr) => {
-      if (error && (error as any).code === 'ENOENT') {
+      const childError = error as NodeJS.ErrnoException | null;
+      if (childError?.code === 'ENOENT') {
         resolve({ stdout: '', stderr: 'gog binary not found', exitCode: 127 });
         return;
       }
       resolve({
-        stdout: stdout ?? '', stderr: stderr ?? '',
-        exitCode: error ? ((error as any).status ?? 1) : 0,
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        exitCode: typeof childError?.code === 'number' ? childError.code : 1,
       });
     });
     child.on('error', (err) => {

--- a/apps/desktop/electron/platform/security/csp.ts
+++ b/apps/desktop/electron/platform/security/csp.ts
@@ -34,7 +34,7 @@ function buildCSP(): string {
   // — it only allows WebAssembly compilation, not arbitrary JS eval().
   const scriptSrc = [
     "'self'",
-    "'unsafe-inline'",
+    ...(isDev ? ["'unsafe-inline'"] : []),
     "'wasm-unsafe-eval'",
     'blob:',
     'https://sdk.scdn.co',          // Spotify Web Playback SDK
@@ -96,7 +96,12 @@ function buildCSP(): string {
   // Dev server previews load arbitrary http(s) URLs inside a sandboxed iframe
   // in the editor, so the renderer must explicitly allow framed http(s)
   // content in addition to blob:-backed HTML previews.
-  const frameSrc = ["'self'", 'blob:', 'http:', 'https:'];
+  const frameSrc = [
+    "'self'",
+    'blob:',
+    ...extensionSrc,
+    ...(isDev ? ['http:', 'https:'] : []),
+  ];
 
   return [
     `default-src 'self'`,

--- a/apps/desktop/electron/platform/security/csp.ts
+++ b/apps/desktop/electron/platform/security/csp.ts
@@ -27,8 +27,9 @@ function buildCSP(): string {
   const devConnectSrc = isDev ? ['http://localhost:*', 'ws://localhost:*'] : [];
 
   // -- script-src --
-  // Dev needs 'unsafe-inline' for Vite's injected HMR client script and
-  // the inline <script> in index.html (theme flash prevention).
+  // Dev keeps 'unsafe-inline' for Vite's injected dev runtime.
+  // The theme bootstrap now ships as a same-origin external script so
+  // production no longer needs inline script allowances.
   // 'wasm-unsafe-eval' is required for Shiki's Oniguruma WASM engine
   // (syntax highlighting in the editor). This is narrower than 'unsafe-eval'
   // — it only allows WebAssembly compilation, not arbitrary JS eval().
@@ -99,8 +100,9 @@ function buildCSP(): string {
   const frameSrc = [
     "'self'",
     'blob:',
+    'http:',
+    'https:',
     ...extensionSrc,
-    ...(isDev ? ['http:', 'https:'] : []),
   ];
 
   return [

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,4 +1,7 @@
 import { contextBridge } from 'electron';
+import type { SeroAPI } from '@/types/electron';
 import { seroPreloadApi } from './preload/api';
 
-contextBridge.exposeInMainWorld('sero', seroPreloadApi);
+const seroApiContract = seroPreloadApi satisfies SeroAPI;
+
+contextBridge.exposeInMainWorld('sero', seroApiContract);

--- a/apps/desktop/electron/preload/apps/app-domain.ts
+++ b/apps/desktop/electron/preload/apps/app-domain.ts
@@ -19,6 +19,7 @@ import type {
   CreateGitHubRepoInput,
   CreateGitHubRepoResult,
 } from '@/types/ipc';
+import type { GitHubDeviceFlowEvent } from '@/types/electron-services';
 
 export const appStateBridge = {
   read: (filePath: string): Promise<unknown> =>
@@ -196,8 +197,8 @@ export const githubBridge = {
     ipcRenderer.invoke(IpcChannels.github.logout),
   cancel: (): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.github.cancel),
-  onEvent: (callback: (event: unknown) => void): (() => void) => {
-    const handler = (_e: Electron.IpcRendererEvent, data: unknown) => callback(data);
+  onEvent: (callback: (event: GitHubDeviceFlowEvent) => void): (() => void) => {
+    const handler = (_e: Electron.IpcRendererEvent, data: GitHubDeviceFlowEvent) => callback(data);
     ipcRenderer.on(IpcChannels.github.event, handler);
     return () => ipcRenderer.removeListener(IpcChannels.github.event, handler);
   },

--- a/apps/desktop/electron/shared/settings/settings-helpers.ts
+++ b/apps/desktop/electron/shared/settings/settings-helpers.ts
@@ -11,14 +11,41 @@ export function getSeroSettings(settings: Record<string, unknown>): Record<strin
   return {};
 }
 
+export type SettingsReadResult =
+  | { ok: true; settings: Record<string, unknown> }
+  | { ok: false; error: Error };
+
 /** Read and parse settings.json from the active agent directory. */
-export function readSettings(): Record<string, unknown> {
+export function readSettingsResult(): SettingsReadResult {
   const settingsPath = path.join(SERO_AGENT_DIR, 'settings.json');
   try {
-    return JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
-  } catch {
-    return {};
+    const raw = readFileSync(settingsPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { ok: false, error: new Error('settings.json must contain a JSON object') };
+    }
+    return { ok: true, settings: parsed as Record<string, unknown> };
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError?.code === 'ENOENT') {
+      return { ok: true, settings: {} };
+    }
+    return {
+      ok: false,
+      error: error instanceof Error
+        ? error
+        : new Error('Failed to read settings.json'),
+    };
   }
+}
+
+/** Read settings.json, throwing if the file is malformed/unreadable. */
+export function readSettings(): Record<string, unknown> {
+  const result = readSettingsResult();
+  if (!result.ok) {
+    throw result.error;
+  }
+  return result.settings;
 }
 
 /** Persist the active profile's settings.json. */

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -4,15 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sero</title>
-    <script>
-      // Apply saved theme before first paint to prevent flash
-      (function() {
-        var theme = localStorage.getItem('sero:theme');
-        if (theme === 'light') {
-          document.documentElement.classList.remove('dark');
-        }
-      })();
-    </script>
+    <script src="/theme-bootstrap.js"></script>
     <style>
       body {
         background: #0a0a0b;

--- a/apps/desktop/public/theme-bootstrap.js
+++ b/apps/desktop/public/theme-bootstrap.js
@@ -1,0 +1,7 @@
+// Apply saved theme before first paint to prevent flash.
+(function () {
+  var theme = localStorage.getItem('sero:theme');
+  if (theme === 'light') {
+    document.documentElement.classList.remove('dark');
+  }
+})();

--- a/apps/desktop/src/components/apps/explorer/editor/DevServerPreview.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DevServerPreview.tsx
@@ -12,8 +12,8 @@
  * `allow-forms` / `allow-popups` for full app functionality.
  */
 
-import { useCallback, useRef, useState } from 'react';
-import { Globe, RefreshCw, ExternalLink } from 'lucide-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Globe, RefreshCw, ExternalLink, AlertTriangle } from 'lucide-react';
 
 /** Prefix used to identify dev server preview tabs in the editor. */
 const DEV_SERVER_PREFIX = 'devserver://';
@@ -30,6 +30,28 @@ function getDevServerUrl(tabPath: string): string {
 
 interface Props {
   tabPath: string;
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  if (hostname.startsWith('10.') || hostname.startsWith('192.168.') || hostname.startsWith('169.254.')) {
+    return true;
+  }
+  return /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname);
+}
+
+function canEmbedDevServerUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+
+    const hostname = url.hostname.toLowerCase();
+    if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1') return true;
+    if (hostname.endsWith('.local')) return true;
+    if (/^192\.168\.64\.\d{1,3}$/.test(hostname)) return true;
+    return isPrivateIpv4(hostname);
+  } catch {
+    return false;
+  }
 }
 
 export function DevServerPreview({ tabPath }: Props) {
@@ -66,14 +88,16 @@ export function DevServerPreview({ tabPath }: Props) {
     window.open(currentUrl, '_blank');
   }, [currentUrl]);
 
-  const displayHost = (() => {
+  const displayHost = useMemo(() => {
     try {
       const u = new URL(currentUrl);
       return `${u.hostname}:${u.port || (u.protocol === 'https:' ? '443' : '80')}`;
     } catch {
       return currentUrl;
     }
-  })();
+  }, [currentUrl]);
+
+  const canEmbed = useMemo(() => canEmbedDevServerUrl(currentUrl), [currentUrl]);
 
   return (
     <div className="flex h-full flex-col bg-[var(--bg-base)]">
@@ -108,16 +132,36 @@ export function DevServerPreview({ tabPath }: Props) {
         </span>
       </div>
 
-      {/* Sandboxed iframe — allow-scripts + allow-same-origin for HMR,
-          allow-forms + allow-popups for app functionality. */}
-      <iframe
-        ref={iframeRef}
-        src={currentUrl}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
-        referrerPolicy="no-referrer"
-        title={`Dev Server: ${displayHost}`}
-        className="flex-1 w-full border-0"
-      />
+      {canEmbed ? (
+        /* Sandboxed iframe — allow-scripts + allow-same-origin for HMR,
+            allow-forms + allow-popups for app functionality. */
+        <iframe
+          ref={iframeRef}
+          src={currentUrl}
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
+          referrerPolicy="no-referrer"
+          title={`Dev Server: ${displayHost}`}
+          className="flex-1 w-full border-0"
+        />
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-6">
+          <div className="max-w-lg rounded-xl border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-center">
+            <AlertTriangle className="mx-auto mb-3 size-6 text-amber-500" />
+            <h3 className="mb-2 text-sm font-medium text-[var(--text-primary)]">Open this URL in your browser</h3>
+            <p className="mb-4 text-sm text-[var(--text-muted)]">
+              The preview pane only embeds local dev servers such as localhost, .local hosts, and private/container IPs.
+              External URLs like Tailscale links can trigger frame-navigation security errors inside Electron.
+            </p>
+            <button
+              onClick={handleOpenExternal}
+              className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] bg-[var(--bg-base)] px-3 py-2 text-sm text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
+            >
+              <ExternalLink className="size-4" />
+              Open {displayHost}
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/lib/federation-registry.ts
+++ b/apps/desktop/src/lib/federation-registry.ts
@@ -297,6 +297,8 @@ export function getFederatedComponent(
     const loaded = await loadRemoteModule(appId, component, devPort);
     if (!loaded) {
       console.error(`[federation] Failed to load remote: ${toRemoteName(appId)}/${component}`);
+      cache.delete(cacheKey);
+      resolvedModules.delete(cacheKey);
       return { default: () => null };
     }
 

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -135,8 +135,14 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   closeSession: async (sessionId) => {
     try {
       await window.sero.agent.close(sessionId);
-    } catch {
-      // Ignore close errors
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to close session';
+      set((s) => {
+        const current = s.agents[sessionId];
+        if (!current) return {};
+        return { agents: { ...s.agents, [sessionId]: { ...current, error: message, isStreaming: false } } };
+      });
+      return;
     }
     set((s) => {
       const { [sessionId]: _, ...rest } = s.agents;

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -33,7 +33,7 @@ interface WorkspaceState {
   /** Load all workspaces from main process. */
   loadWorkspaces: () => Promise<void>;
   /** Close a workspace — removes it from the registry entirely. */
-  closeWorkspace: (id: string) => void;
+  closeWorkspace: (id: string) => Promise<void>;
   /** Toggle expanded/collapsed state of a workspace tree node. */
   toggleCollapsed: (id: string) => void;
   /** Collapse all workspace tree nodes. */
@@ -81,14 +81,22 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
     }
   },
 
-  closeWorkspace: (id) => {
+  closeWorkspace: async (id) => {
     if (id === 'global') return; // Can't close global
+
+    try {
+      await window.sero.workspace.close(id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to close workspace';
+      console.error('[workspace] closeWorkspace failed:', err);
+      set({ error: message });
+      return;
+    }
+
     set((s) => ({
       workspaces: s.workspaces.filter((w) => w.id !== id),
       activeWorkspaceId: s.activeWorkspaceId === id ? 'global' : s.activeWorkspaceId,
     }));
-    // Remove from registry on disk
-    window.sero.workspace.close(id).catch(console.error);
   },
 
   toggleCollapsed: (id) => {

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -55,6 +55,7 @@ import type {
   SubagentEvent,
   SubagentAgentSummary,
   SubagentEntry,
+  SubagentAgentFile,
   InstalledPlugin,
   PluginChangeEvent,
   DiscoveredPlugin,
@@ -439,7 +440,7 @@ interface SeroPluginsAPI {
   onChanged(callback: (event: PluginChangeEvent) => void): () => void;
 }
 
-interface SeroAPI {
+export interface SeroAPI {
   platform: string;
   shell: SeroShellAPI;
   profiles: SeroProfilesAPI;

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -382,76 +382,17 @@ export type OAuthEvent =
   | { type: 'error'; provider: string; message: string }
   | { type: 'cancelled' };
 
-// ── Response Feedback ──────────────────────────────────────────
+// ── Response + User Feedback ───────────────────────────────────
 
-/** A single user feedback entry for an agent response. */
-export interface ResponseFeedbackEntry {
-  /** The assistant message ID this feedback is for. */
-  messageId: string;
-  /** Session ID where the response occurred. */
-  sessionId: string;
-  /** 'good' or 'bad' rating. */
-  rating: 'good' | 'bad';
-  /** ISO timestamp when feedback was submitted. */
-  timestamp: string;
-  /** First ~300 chars of the user prompt that preceded this response. */
-  promptExcerpt?: string;
-  /** First ~300 chars of the assistant response. */
-  responseExcerpt?: string;
-  /** Optional free-text note from the user. */
-  note?: string;
-}
-
-/** Full feedback state persisted to disk. */
-export interface ResponseFeedbackState {
-  entries: ResponseFeedbackEntry[];
-}
-
-// ── User Feedback (question / questionnaire tools) ─────────────
-//
-// Source of truth: packages/pi-user-feedback/shared/types.ts
-// These are mirrored here to keep the renderer/Electron IPC surface stable and
-// decoupled from the plugin package boundary. When modifying, update BOTH files.
-
-export interface UserFeedbackQuestionOption {
-  value: string;
-  label: string;
-  description?: string;
-  exclusive?: boolean;
-}
-
-export interface UserFeedbackQuestionItem {
-  id: string;
-  label: string;
-  prompt: string;
-  options: UserFeedbackQuestionOption[];
-  allowOther: boolean;
-  multiSelect?: boolean;
-}
-
-/** Sent from main → renderer when a question/questionnaire/interview/permission tool starts. */
-export interface UserFeedbackPendingQuestion {
-  id: string;
-  type: 'question' | 'questionnaire' | 'interview' | 'permission';
-  toolCallId: string;
-  questions: UserFeedbackQuestionItem[];
-  timestamp: string;
-}
-
-export interface UserFeedbackAnswer {
-  questionId: string;
-  value: string;
-  label: string;
-  wasCustom: boolean;
-  index?: number;
-}
-
-/** Sent from renderer → main when the user answers or cancels. */
-export interface UserFeedbackResponse {
-  id: string;
-  answers: UserFeedbackAnswer[];
-  cancelled: boolean;
-}
+export type {
+  ResponseFeedbackEntry,
+  ResponseFeedbackState,
+  UserFeedbackQuestionOption,
+  UserFeedbackQuestionItem,
+  UserFeedbackPendingQuestion,
+  UserFeedbackAnswer,
+  UserFeedbackResponse,
+} from './user-feedback';
 
 // ── Net Proxy ──────────────────────────────────────────────────
 

--- a/apps/desktop/src/types/user-feedback.ts
+++ b/apps/desktop/src/types/user-feedback.ts
@@ -1,0 +1,65 @@
+// Source of truth for user feedback contracts used across renderer + Electron IPC.
+// This module is intentionally separate from ipc.ts to keep contract files below size caps.
+
+/** A single user feedback entry for an agent response. */
+export interface ResponseFeedbackEntry {
+  /** The assistant message ID this feedback is for. */
+  messageId: string;
+  /** Session ID where the response occurred. */
+  sessionId: string;
+  /** 'good' or 'bad' rating. */
+  rating: 'good' | 'bad';
+  /** ISO timestamp when feedback was submitted. */
+  timestamp: string;
+  /** First ~300 chars of the user prompt that preceded this response. */
+  promptExcerpt?: string;
+  /** First ~300 chars of the assistant response. */
+  responseExcerpt?: string;
+  /** Optional free-text note from the user. */
+  note?: string;
+}
+
+/** Full feedback state persisted to disk. */
+export interface ResponseFeedbackState {
+  entries: ResponseFeedbackEntry[];
+}
+
+export interface UserFeedbackQuestionOption {
+  value: string;
+  label: string;
+  description?: string;
+  exclusive?: boolean;
+}
+
+export interface UserFeedbackQuestionItem {
+  id: string;
+  label: string;
+  prompt: string;
+  options: UserFeedbackQuestionOption[];
+  allowOther: boolean;
+  multiSelect?: boolean;
+}
+
+/** Sent from main → renderer when a question/questionnaire/interview/permission tool starts. */
+export interface UserFeedbackPendingQuestion {
+  id: string;
+  type: 'question' | 'questionnaire' | 'interview' | 'permission';
+  toolCallId: string;
+  questions: UserFeedbackQuestionItem[];
+  timestamp: string;
+}
+
+export interface UserFeedbackAnswer {
+  questionId: string;
+  value: string;
+  label: string;
+  wasCustom: boolean;
+  index?: number;
+}
+
+/** Sent from renderer → main when the user answers or cancels. */
+export interface UserFeedbackResponse {
+  id: string;
+  answers: UserFeedbackAnswer[];
+  cancelled: boolean;
+}

--- a/docs/deslopify/apps/desktop/electron/features/agent/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/agent/facts.md
@@ -1,0 +1,35 @@
+# Facts — apps/desktop/electron/features/agent
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This module provides small assistant utilities used by IPC handlers: ad-hoc
+LLM drafting (`adhoc-agent.ts`), Gemini image generation (`image-agent.ts`),
+PR draft prompt/parsing helpers (`pr-draft.ts`), and OpenAI voice transcription
+(`voice-transcription.ts`).
+
+## Shape & metrics
+- Total files: 4
+- Total LOC: 613
+- Largest file: `apps/desktop/electron/features/agent/assistants/voice-transcription.ts` (219 LOC)
+- Files over 500 LOC: none
+- External dependencies of note:
+  - Pi SDK session creation (`@mariozechner/pi-coding-agent`)
+  - provider SDK clients (`@google/genai`, OpenAI HTTP API)
+  - shared infra model/auth access
+- Upstream callers:
+  - `runAdhocAgent` and PR draft helpers consumed by `electron/ipc/integrations/vcs.ts`
+  - `generateImages` consumed by `electron/ipc/agent/handlers/imagegen.ts`
+  - transcription helpers consumed by `electron/ipc/agent/handlers/voice.ts`
+- Downstream dependencies:
+  - model tier/settings helpers and auth infrastructure in `electron/shared/**`
+
+## Architectural notes
+- This folder is intentionally assistant-focused and avoids pulling IPC concerns in directly.
+- It sits below the IPC surface as a domain helper layer; most files are cohesive and under cap.
+
+## Surprising discoveries
+- `image-agent.ts` still uses loose `any` typing in multimodal content assembly
+  (`image-agent.ts:163-164`) and global exposure (`image-agent.ts:188`).
+- `exposeImageAgent()` writes `globalThis.__seroImageGen` (`image-agent.ts:186-188`), but
+  there is no in-repo read site for that symbol, suggesting dead bridge scaffolding.

--- a/docs/deslopify/apps/desktop/electron/features/agent/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/agent/plan.md
@@ -1,0 +1,49 @@
+# Refactoring Plan — apps/desktop/electron/features/agent
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+This area is comparatively healthy: low file count, clear responsibilities, and no size-cap
+violations. Cleanup is mostly type-hygiene and dead-bridge reduction in `image-agent.ts`.
+No major architecture rewrite is needed.
+
+## Issues Found (prioritized)
+- **Medium** — `any` leaks remain in image agent content and global exposure paths —
+  `apps/desktop/electron/features/agent/assistants/image-agent.ts:163-164,188` uses
+  `Record<string, any>` and `globalThis as any`, weakening compile-time guarantees.
+  Effort: **S**.
+
+- **Low** — Potential dead global bridge hook for image generation —
+  `apps/desktop/electron/features/agent/assistants/image-agent.ts:186-188` exports
+  `generateImages` on `globalThis.__seroImageGen`, but there is no internal consumer.
+  Effort: **S**.
+
+- **Low** — Comment suggests mirrored shared types that no longer exist —
+  `apps/desktop/electron/features/agent/assistants/image-agent.ts:19` references
+  “shared/types.ts” mirroring, but no corresponding shared source is present.
+  Effort: **S**.
+
+## Proposed Refactoring
+1. **Tighten image-agent typing.**
+   - Replace `Record<string, any>` content-part shapes with explicit interfaces.
+   - Remove `globalThis as any` via a typed global augmentation if exposure is required.
+
+2. **Verify and either remove or formalize `__seroImageGen` bridge.**
+   - If unused, delete `exposeImageAgent()` and the handler call site.
+   - If required for extension interop, document the contract and add a typed accessor.
+
+3. **Update stale comments and align docs to actual ownership.**
+   - Remove “mirrored from shared/types.ts” wording or move types to a real shared module.
+
+## Benefits & Trade-offs
+- Benefits: cleaner typing, less dead scaffolding, and easier maintenance in a small critical helper layer.
+- Trade-offs: minor churn only; no broad migration expected.
+
+## Dependencies & Risks
+- If `__seroImageGen` is consumed externally (outside repo), removing it requires compatibility validation.
+- Type tightening may require small updates in `ipc/agent/handlers/imagegen.ts` signatures.
+
+## Next Steps
+1. Replace `any` usages in `image-agent.ts` with explicit types.
+2. Confirm whether `__seroImageGen` is still needed; remove or document/augment typing.
+3. Continue Wave A: `deslopify apps/desktop/electron/features/container`.

--- a/docs/deslopify/apps/desktop/electron/features/apps/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/apps/facts.md
@@ -1,0 +1,36 @@
+# Facts — apps/desktop/electron/features/apps
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This folder owns app/runtime glue in Electron main for Sero apps: app manifest discovery, shared JSON state file IO/watchers, session extension wiring (`createSeroExtensionFactory`), skill visibility overrides, and Git app state synchronization helpers used by IPC and agent runtime flows.
+
+## Shape & metrics
+- Total files: 8
+- Total LOC: 1,690
+- Largest file: `apps/desktop/electron/features/apps/discovery/index.ts` (312 LOC)
+- Files over 500 LOC: none
+- External dependencies of note:
+  - Pi SDK extension APIs (`@mariozechner/pi-coding-agent`)
+  - Electron `BrowserWindow` fanout in app-state change broadcaster
+  - Workspace/container/subagent managers from Electron feature layer
+  - Plugin-package internals from `@plugins/sero-admin-plugin` and `@plugins/sero-git-plugin`
+  - Node filesystem watchers (`fs.watch`, recursive workspace watch)
+- Upstream callers:
+  - 17 runtime files import this feature area (IPC agent/apps handlers, CLI bridge, kanban orchestration, subagent runtime)
+  - Plus focused tests in `electron/__tests__/features/apps/**`
+- Downstream dependencies:
+  - `electron/ipc/apps/{apps,app-state,git-app}.ts`
+  - `electron/ipc/agent/core/{agent,agent-prompt}.ts`
+  - Kanban orchestration modules that depend on `appStateManager`
+
+## Architectural notes
+- This is a boundary-heavy module: it couples app discovery, extension runtime behavior, and cross-window state broadcasting in one area.
+- `appStateManager` is effectively infrastructure, not app-specific utility; many non-app modules depend on it for state reactivity.
+- Two files currently import plugin internals directly (`sero-admin-plugin` + `sero-git-plugin`), creating host↔plugin coupling that conflicts with clean app/plugin separation (AD-001 intent).
+- `createSeroExtensionFactory` is the integration point for AD-020/AD-021-adjacent behavior (CLI prompt injection + subagent tool registration).
+
+## Surprising discoveries
+- `AppStateManager.watch()` initializes watchers asynchronously without reserving an entry first, so rapid watch/unwatch or concurrent watch calls can miscount refs and leave orphan watchers (`state/manager.ts:128-153`).
+- Type escape hatches are concentrated in small helper files (`extensions/git-checkpoints.ts:19-20,26`, `extensions/ui-context.ts:51,63`) rather than in large orchestration files.
+- `isPlugin` in discovery is derived from parsed/validated plugin metadata (`Boolean(plugin)`) rather than direct `sero.plugin` key presence, which can hide malformed plugin manifests from plugin-specific UI flows (`discovery/index.ts:140-182`).

--- a/docs/deslopify/apps/desktop/electron/features/apps/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/apps/plan.md
@@ -1,0 +1,62 @@
+# Refactoring Plan — apps/desktop/electron/features/apps
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/apps` is functionally important and mostly within size limits, but it carries concentrated boundary debt: watcher lifecycle races in shared state infrastructure, multiple `any` escape hatches in extension helpers, and direct host imports from plugin internals. The plan focuses on hardening reliability and contracts first, then reducing coupling so this layer can evolve without breaking app/plugin boundaries.
+
+## Issues Found (prioritized)
+- **High** — Watcher bootstrap race can miscount refs and leak state watchers — `apps/desktop/electron/features/apps/state/manager.ts:128-153` starts async setup before a map entry exists, while `unwatch` assumes a registered entry (`state/manager.ts:159-168`). Concurrent watch/unwatch calls can leave orphan watchers or incorrect ref counts in a module used by IPC/kanban/git state flows. Effort: **M**.
+
+- **High** — Type-safety escape hatches in extension paths — `apps/desktop/electron/features/apps/extensions/git-checkpoints.ts:19-20,26` uses `any` for message content parsing, and `apps/desktop/electron/features/apps/extensions/ui-context.ts:51,63` uses `undefined as never` plus `theme: any`. These bypass strict contracts on agent-extension boundaries. Effort: **S**.
+
+- **Medium** — Host code is coupled to plugin-internal modules — `apps/desktop/electron/features/apps/extensions/skill-visibility.ts:2` imports admin-plugin shared helper, and `apps/desktop/electron/features/apps/git-app/manager.ts:4-6` imports git-plugin extension internals. This makes core host behavior depend on plugin package structure and fights AD-001 ownership boundaries. Effort: **M**.
+
+- **Medium** — Discovery contract drift around plugin metadata classification — `apps/desktop/electron/features/apps/discovery/index.ts:97-123` casts category strings instead of validating the union, and `discovery/index.ts:181` sets `isPlugin` from parsed meta truthiness rather than explicit `sero.plugin` presence. Malformed manifests can silently degrade plugin behavior/visibility. Effort: **S**.
+
+- **Medium** — `createSeroExtensionFactory` is an integration hotspot with mixed responsibilities — `apps/desktop/electron/features/apps/extensions/create-sero-extension.ts:52-241` combines prompt wiring, provider logging, notifications, workspace commands, git checkpoint features, and subagent tool registration. This is still under the LOC cap but already hard to reason about and extend safely. Effort: **M**.
+
+- **Low** — File-change listener API has no unsubscribe path — `apps/desktop/electron/features/apps/state/manager.ts:45-47` only appends listeners, so repeated handler registration in tests/dev reload scenarios can accumulate callbacks. Effort: **S**.
+
+## Proposed Refactoring
+1. **Make app-state watch registration deterministic and race-safe.**
+   - Insert a placeholder watch entry before async filesystem prep starts.
+   - Track init state (`initializing`, `cancelled`) so `unwatch` can cancel pending setup.
+   - Ensure concurrent `watch(filePath)` calls coalesce into one setup path with correct ref counting.
+   - Aligns with reliability expectations for shared infra used by IPC + orchestration layers.
+
+2. **Remove `any`/unsafe casts from extension helper surfaces.**
+   - Introduce narrow type guards for assistant message content blocks in `git-checkpoints.ts`.
+   - Replace `theme: any` and `undefined as never` in `ui-context.ts` with explicit typed stubs matching `ExtensionUIContext`.
+   - Keep fallback/no-op behavior unchanged while restoring compile-time checks.
+
+3. **Decouple host features from plugin package internals.**
+   - Move shared skill-visibility helpers to a neutral shared module (`packages/common` or `electron/shared/**`) and import from there in both host + admin plugin.
+   - Define a host-owned git app service boundary so `git-app/manager.ts` consumes a stable API rather than plugin extension file paths.
+   - Aligns with AD-001 boundary intent and plugin technical docs that treat plugins as independently evolvable.
+
+4. **Harden app-discovery manifest parsing.**
+   - Validate `plugin.category` against canonical `PluginCategory` values instead of force-casting.
+   - Distinguish “plugin declared” from “plugin metadata valid”: preserve `isPlugin` based on manifest key presence, while surfacing invalid metadata diagnostics.
+   - Add focused tests for malformed `sero.plugin` manifests.
+
+5. **Split extension factory wiring into focused registrars.**
+   - Extract modules such as `registerPromptHooks`, `registerWorkspaceCommands`, `registerNotificationBridge`, and `registerAgentManagementTools`.
+   - Keep `createSeroExtensionFactory` as a thin composition root.
+   - Reduces change risk as AD-020/AD-021 behaviors continue to evolve.
+
+## Benefits & Trade-offs
+- Benefits: safer watcher lifecycle behavior, better type guarantees in agent-extension paths, lower host/plugin coupling, and clearer ownership in extension wiring.
+- Trade-offs: moderate churn across host + plugin shared contracts, plus some test updates for discovery and watcher behavior.
+
+## Dependencies & Risks
+- Host/plugin decoupling requires coordinated updates in `plugins/sero-admin-plugin` and `plugins/sero-git-plugin` to avoid temporary import breakage.
+- Watcher lifecycle changes touch kanban/git/settings reload paths; regression testing should cover rapid watch/unwatch and atomic write rename events.
+- Discovery classification tweaks may change plugin-manager visibility for malformed packages; include migration notes in release PR if behavior changes.
+
+## Next Steps
+1. Fix High items first: watcher bootstrap/refcount race and all `any` escape hatches.
+2. Extract plugin-shared helpers to neutral contracts and update imports in host/plugin packages.
+3. Tighten discovery plugin metadata validation and add malformed-manifest tests.
+4. Split `createSeroExtensionFactory` into registrar modules before adding new extension hooks.
+5. Continue Wave A: `deslopify apps/desktop/electron/features/plugins`.

--- a/docs/deslopify/apps/desktop/electron/features/container/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/container/facts.md
@@ -1,0 +1,48 @@
+# Facts — apps/desktop/electron/features/container
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This module is Sero’s container runtime layer (AD-018): it manages container lifecycle,
+container-executed coding tools (`bash/read/write/edit/browser`), terminal/PTy integration,
+port scanning/bridging, HTTP proxying for outbound network access, and registries for dev
+servers and artifacts.
+
+## Shape & metrics
+- Total files: 26
+- Total LOC: 4,751
+- Largest file: `apps/desktop/electron/features/container/tools/tools-browser-agent.ts` (483 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥440 LOC):
+  - `apps/desktop/electron/features/container/tools/tools-browser-agent.ts` (483)
+  - `apps/desktop/electron/features/container/tools/tools-host.ts` (460)
+  - `apps/desktop/electron/features/container/core/lifecycle.ts` (454)
+  - `apps/desktop/electron/features/container/tools/tools-coding.ts` (444)
+- External dependencies of note:
+  - Apple container CLI (`/usr/local/bin/container`)
+  - `node-pty` terminal bridge
+  - Pi SDK tool/session interfaces
+  - shared media helpers and CLI bridge (`sero-cli`)
+- Upstream callers:
+  - container feature imported from ~24 desktop files
+  - `createContainerTools` consumed by agent/subagent runtime
+  - singleton used through `shared/infra/shared-infra.ts`
+- Downstream dependencies:
+  - `electron/ipc/container/**`, `electron/ipc/editor/**`, `electron/ipc/agent/**`
+  - renderer dev-server/terminal/container state UIs via IPC
+
+## Architectural notes
+- This module is the execution boundary for AD-018 and is tightly coupled to agent/tool reliability.
+- Memory file protection is intentionally implemented at tool layer (`memory-file-guard.ts`) to
+  enforce memory-tool usage over direct filesystem writes.
+- Host fallback tools (`tools-host.ts`) intentionally mirror container tool behavior, but currently
+  duplicate most of `tools-coding.ts` logic.
+
+## Surprising discoveries
+- `ContainerHttpProxy` binds to `0.0.0.0` and acts as a generic CONNECT/HTTP proxy without auth
+  (`network/http-proxy.ts:4`, `network/http-proxy.ts:52`, `network/http-proxy.ts:118`).
+- Port scanner lifecycle is incomplete: scanner/bridge cleanup is not tied to container
+  `stop/remove`, and stale detected ports can persist (`index.ts:161`, `index.ts:268-273`,
+  `network/port-forward.ts:98`, `network/port-forward.ts:155`).
+- `readOnlyMounts` are documented as read-only but mounted with plain `--volume` (read-write)
+  (`core/types.ts:60`, `core/lifecycle.ts:240-242`).

--- a/docs/deslopify/apps/desktop/electron/features/container/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/container/plan.md
@@ -1,0 +1,91 @@
+# Refactoring Plan — apps/desktop/electron/features/container
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+Container runtime coverage is comprehensive, but this layer now carries meaningful reliability and
+security debt for a critical AD-018 boundary. The most urgent issues are an unauthenticated host
+proxy surface, incomplete port-scanner/bridge lifecycle cleanup, and mount-permission semantics
+that do not match declared intent. The plan prioritizes securing network exposure and stabilizing
+runtime cleanup before broader maintainability refactors.
+
+## Issues Found (prioritized)
+- **High** — Container HTTP proxy is an unauthenticated open proxy bound on all host interfaces —
+  `apps/desktop/electron/features/container/network/http-proxy.ts:4`,
+  `apps/desktop/electron/features/container/network/http-proxy.ts:52`, and
+  `apps/desktop/electron/features/container/network/http-proxy.ts:118` expose CONNECT + HTTP forwarding on
+  `0.0.0.0` with no auth/allowlist. This is a real security surface beyond container-only traffic.
+  Effort: **M**.
+
+- **High** — Port scanning/bridge lifecycle leaks can leave stale port state and orphan bridge processes —
+  scanning starts in `apps/desktop/electron/features/container/index.ts:161`, but container
+  `stop/remove` (`index.ts:268-273`) do not stop scanning. `PortScanner.stopScanning` only clears timers
+  (`network/port-forward.ts:98`) and bridge "cleanup" only drops in-memory flags (`network/port-forward.ts:155`)
+  without killing bridge processes created at `network/port-forward.ts:172`. This risks stale UI state,
+  background churn, and lingering bridge listeners. Effort: **M**.
+
+- **Medium** — `readOnlyMounts` contract is not enforced in lifecycle implementation —
+  type contract says read-only (`core/types.ts:60`), but lifecycle mounts with plain
+  `--volume ${hostDir}:${hostDir}` (`core/lifecycle.ts:240-242`) same as writable mounts.
+  This violates module intent and weakens mount-boundary guarantees. Effort: **S**.
+
+- **Medium** — Host and container coding tools duplicate large logic blocks, increasing drift risk —
+  parallel implementations in `tools/tools-coding.ts:97-442` and `tools/tools-host.ts:174-460`
+  duplicate truncation, fuzzy edit, memory-guard checks, and read/write/edit formatting.
+  Fixes in one path can silently diverge from the other. Effort: **L**.
+
+- **Medium** — Multiple core files are near the 500 LOC cap —
+  `tools/tools-browser-agent.ts:1-483`, `tools/tools-host.ts:1-460`,
+  `core/lifecycle.ts:1-454`, `tools/tools-coding.ts:1-444`. This area is one feature wave away
+  from hard cap violations. Effort: **M**.
+
+- **Low** — Browser metrics map is write-only dead state —
+  `tools/tools-browser-agent.ts:15` is updated (`:302`, `:306`) but never read/exported,
+  adding noise without operational value. Effort: **S**.
+
+## Proposed Refactoring
+1. **Harden proxy exposure first.**
+   - Restrict proxy bind scope (container-reachable interface only), add destination safeguards,
+     and optionally require an internal token/header for use.
+   - Add startup logging that clearly reports effective bind address and risk mode.
+
+2. **Fix scanner/bridge lifecycle coupling.**
+   - On container `stop/remove`, call scanner stop + bridge teardown for that workspace.
+   - Extend `PortScanner` to track bridge PIDs and kill them when ports disappear or scans stop.
+   - Clear detected-port cache on repeated scan failure so UI reflects actual state.
+
+3. **Align mount semantics with declared contract.**
+   - Either enforce read-only mounts in lifecycle command construction, or rename the type/field
+     to reflect actual behavior and update all callsites/docs.
+   - Keep AD-018 trust boundaries explicit in type-level naming and implementation.
+
+4. **Extract shared coding-tool core for host/container parity.**
+   - Create a transport-agnostic tool core (read/write/edit/bash behavior) and inject execution/path
+     adapters for host vs container.
+   - Preserve current response shape so upstream agent behavior does not regress.
+
+5. **Pre-emptively split near-cap files.**
+   - `tools-browser-agent.ts`: split install/bootstrap, action handlers, and response formatting.
+   - `core/lifecycle.ts`: split system management, ghost recovery, create/inspect operations.
+   - Keep module APIs narrow and test-friendly.
+
+6. **Prune dead metrics or wire them to observability.**
+   - Remove `metricsByWorkspace` if unused, or publish it through debug/status endpoints.
+
+## Benefits & Trade-offs
+- Benefits: materially safer network posture, fewer stale-container runtime bugs, better tool parity,
+  and lower risk of cap violations in the highest-change subsystem.
+- Trade-offs: lifecycle and scanner changes are sensitive and need careful regression testing for
+  container startup, dev-server detection, and terminal workflows.
+
+## Dependencies & Risks
+- Proxy hardening may affect environments relying on current broad bind behavior.
+- Scanner/bridge teardown changes can break dev-server detection if bridge tracking is wrong.
+- Tool-core extraction touches both host fallback and container paths; requires broad test coverage.
+
+## Next Steps
+1. Patch High security + lifecycle issues (`http-proxy`, scanner/bridge teardown, cache clearing).
+2. Resolve `readOnlyMounts` semantic mismatch.
+3. Plan and execute tool-core de-duplication between `tools-coding` and `tools-host`.
+4. Split near-cap container files before next feature additions.
+5. Continue Wave A: `deslopify apps/desktop/electron/features/apps`.

--- a/docs/deslopify/apps/desktop/electron/features/plugins/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/plugins/facts.md
@@ -1,0 +1,36 @@
+# Facts — apps/desktop/electron/features/plugins
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This folder owns plugin lifecycle and discovery in Electron main: install/uninstall/list/is-plugin operations, staged package preparation/build rules, plugin install-path security checks, GitHub/npm marketplace discovery, and manifest-driven CLI bridge policy lookup for plugin tools (AD-020).
+
+## Shape & metrics
+- Total files: 7
+- Total LOC: 1,141
+- Largest file: `apps/desktop/electron/features/plugins/manager.ts` (494 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥450 LOC):
+  - `apps/desktop/electron/features/plugins/manager.ts` (494)
+- External dependencies of note:
+  - Shelling out to system tooling (`npm`, `git`, `tar`) via `child_process.execFile`
+  - GitHub Search API + npm registry search API (`fetch` in Electron main)
+  - App discovery + ext protocol registration (`features/apps/discovery`, `platform/protocols/ext-protocol`)
+  - CLI bridge policy cache integration (`@electron/cli`)
+- Upstream callers:
+  - Runtime: `electron/ipc/integrations/plugins.ts` (manager + discovery), `electron/cli/index.ts` (bridge policy)
+  - Tests: plugin discovery/security/install-policy/package-build/CLI-bridge suites
+- Downstream dependencies:
+  - `features/apps/discovery` cache/manifest lifecycle
+  - `platform/protocols/ext-protocol` remote asset registration
+  - `features/plugins/package-build` source-build/install sanitization path
+
+## Architectural notes
+- `manager.ts` currently combines package staging, rollback, settings mutation, discovery registration, and install locking in one near-cap file.
+- Plugin bridge behavior is intentionally manifest-driven (`bridge-policy.ts`) to align with AD-020 and avoid core allowlist churn.
+- Plugin install state mutates the shared `settings.json` package list, so error handling here affects broader app/provider/model configuration surfaces.
+
+## Surprising discoveries
+- Discovery still queries `sero-ai-plugin` topic/keyword (`discovery.ts:12-13`), while plugin docs now instruct `sero-agent-plugin`; this can hide otherwise valid community plugins from search.
+- Settings parsing failures in plugin manager silently downgrade to `{}` (`manager.ts:156-161`), and subsequent add/remove writes can overwrite the full settings file shape (`manager.ts:467-492`).
+- Installed plugin paths are manually registered on install (`manager.ts:298`) but never unregistered on uninstall (`manager.ts:340-350`), leaving stale in-memory discovery entries until process restart.

--- a/docs/deslopify/apps/desktop/electron/features/plugins/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/plugins/plan.md
@@ -1,0 +1,64 @@
+# Refactoring Plan — apps/desktop/electron/features/plugins
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+This module is functionally solid and mostly typed, but it now carries high-impact drift in plugin discovery metadata, fragile settings-file mutation behavior, and a near-cap manager orchestrator that mixes too many responsibilities. The plan prioritizes correctness of marketplace discovery and settings safety first, then splits/clarifies lifecycle orchestration to keep plugin operations maintainable.
+
+## Issues Found (prioritized)
+- **High** — Plugin discovery topic/keyword drift breaks discoverability contract — `apps/desktop/electron/features/plugins/discovery.ts:12-13` hardcodes `sero-ai-plugin`, but current plugin author docs and discovery guidance use `sero-agent-plugin` (`docs/plugins/guide.md`). This can cause valid community plugins to never appear in search results. Effort: **S**.
+
+- **High** — Settings parse fallback can cause destructive rewrites — `apps/desktop/electron/features/plugins/manager.ts:156-165` returns `{}` on any read/parse failure, then `addToSettings`/`removeFromSettings` writes that object back (`manager.ts:467-492`). A malformed/partially-written settings file can be collapsed into a minimal object during plugin operations, losing unrelated settings. Effort: **M**.
+
+- **Medium** — Plugin manager is one change away from violating file-size policy and mixes concerns — `apps/desktop/electron/features/plugins/manager.ts:1-494` includes install serialization, staging/backups, package source strategies, settings mutation, discovery registration, and metadata shaping in one file. This is high review load and fragile for future changes. Effort: **M**.
+
+- **Medium** — Local source builds are non-deterministic when `node_modules` is present — `apps/desktop/electron/features/plugins/package-build.ts:160-163` skips install if `node_modules` exists, so copied local plugins can build against stale/symlinked workspace dependencies instead of clean install state. Effort: **S**.
+
+- **Medium** — Installed-path registration has no uninstall teardown path — install calls `registerAppPath` (`apps/desktop/electron/features/plugins/manager.ts:298`), but uninstall never unregisters (`manager.ts:340-350`), and discovery keeps an in-memory path list (`apps/desktop/electron/features/apps/discovery/index.ts:267-276`). This leaves stale entries until restart. Effort: **S**.
+
+- **Low** — Bridge policy parse/read failures are fully silent — `apps/desktop/electron/features/plugins/bridge-policy.ts:72-73` collapses errors to `null` with no diagnostics, making plugin tool-bridging failures hard to debug under AD-020. Effort: **S**.
+
+## Proposed Refactoring
+1. **Fix discovery taxonomy drift immediately.**
+   - Update topic/keyword constants in `discovery.ts` to the canonical value used in docs (`sero-agent-plugin`).
+   - Add a small test asserting generated GitHub/npm search queries include the canonical tag.
+   - Aligns behavior with plugin docs and avoids silent marketplace regressions.
+
+2. **Make settings mutation fail-safe.**
+   - Replace raw `readSettings`/`writeSettings` logic in plugin manager with shared settings helpers plus explicit malformed-file handling.
+   - On parse failure, abort install/uninstall with actionable error (and optional backup suggestion) instead of writing `{}`.
+   - Keep writes narrow: mutate only `packages` while preserving all other settings keys.
+
+3. **Split `manager.ts` into focused lifecycle modules.**
+   - Extract to modules like `sources.ts` (npm/git/local staging), `settings-packages.ts` (settings list mutation), and `install-transaction.ts` (reserve/rollback/finalize).
+   - Keep `manager.ts` as thin orchestration API (`installPlugin`, `uninstallPlugin`, `listInstalledPlugins`, `isInstalledPlugin`).
+   - This keeps the area under the 500-LOC policy and reduces coupling.
+
+4. **Enforce deterministic build preparation for source installs.**
+   - In `package-build.ts`, do not treat pre-existing `node_modules` as authoritative for git/local staged packages.
+   - Either always reinstall (preferred for correctness) or gate skip-behavior behind explicit validated metadata.
+   - Preserve current `preBuilt` semantics from plugin docs.
+
+5. **Add uninstall symmetry for discovery path registration.**
+   - Introduce `unregisterAppPath()` in app discovery and call it on plugin uninstall/error rollback paths.
+   - Ensure install/uninstall idempotency and remove stale path accumulation.
+
+6. **Improve plugin bridge-policy diagnostics.**
+   - Log one scoped warning when package.json parsing fails for an extension path (include extension/package path, avoid noisy repeats via cache).
+   - Keep fail-closed behavior (`null`) but make diagnosis straightforward.
+
+## Benefits & Trade-offs
+- Benefits: correct plugin marketplace results, safer settings persistence, smaller/focused lifecycle modules, and easier debugging of bridge-policy failures.
+- Trade-offs: moderate churn across plugin + app-discovery boundaries, plus additional tests and migration of utility helpers.
+
+## Dependencies & Risks
+- Introducing `unregisterAppPath` touches `features/apps/discovery` consumers and should be regression-tested against built-in dev path registration flows.
+- Settings hardening changes behavior for malformed `settings.json`; callers may now receive explicit errors where previous behavior silently continued.
+- Build-prep changes can increase install time for local source plugins if always reinstalling dependencies.
+
+## Next Steps
+1. Patch High items first (`discovery.ts` taxonomy constants; settings parse/write safety in manager).
+2. Add coverage for plugin manager transactional flows (install rollback + uninstall settings/path symmetry).
+3. Split `manager.ts` into transaction/source/settings helpers before adding new plugin lifecycle features.
+4. Tighten source-build determinism in `package-build.ts` and document expected behavior in plugin technical docs.
+5. Continue Wave A: `deslopify apps/desktop/electron/shared`.

--- a/docs/deslopify/apps/desktop/electron/features/workspace/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/workspace/facts.md
@@ -1,0 +1,42 @@
+# Facts — apps/desktop/electron/features/workspace
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This module owns workspace lifecycle and metadata: registry/config I/O,
+workspace creation/attachment, container toggle and mount metadata,
+multi-root support, message-based workspace inference, and host-side file
+watching for workspace roots.
+
+## Shape & metrics
+- Total files: 8
+- Total LOC: 1,150
+- Largest file: `apps/desktop/electron/features/workspace/manager.ts` (461 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥450 LOC):
+  - `apps/desktop/electron/features/workspace/manager.ts` (461)
+- External dependencies of note:
+  - `@electron/platform/env` (`SERO_HOME`, `SERO_AGENT_DIR`)
+  - shared infra container/workspace managers from IPC callers
+  - Node filesystem (`fs`, `path`) and host watchers (`fs.watch`)
+- Upstream callers:
+  - Imported from 27 files across Electron features, IPC, CLI, and tests
+    (container config, VCS, subagent runtime, gateway ops, etc.)
+- Downstream dependencies:
+  - `electron/ipc/workspace/**`, `electron/ipc/editor/path-resolution.ts`,
+    and container config/build paths that consume workspace roots/mounts.
+
+## Architectural notes
+- This module is a foundational owner for AD-010 workspace semantics and AD-018
+  container mount composition.
+- Multi-root behavior is intentionally delegated (`roots.ts`) and mount/reference
+  behavior is delegated (`mounts.ts`) to keep `manager.ts` under the 500 LOC cap.
+- Workspace container recreation is centralized in `container-sync.ts` and reused
+  by IPC/CLI surfaces to avoid inconsistent mount-apply behavior.
+
+## Surprising discoveries
+- `manager.ts` is already at 461 LOC and still contains duplicated cleanup logic
+  for editor-state deletion in both `remove()` and `close()` (`manager.ts:313`, `manager.ts:339`).
+- Error swallowing exists in critical lifecycle paths (`manager.ts:313`, `manager.ts:339`)
+  via `.catch(() => {})`, which can hide disk-permission failures.
+- `watcher.ts` still uses `catch (err: any)` (`watcher.ts:126`) despite strict typing expectations.

--- a/docs/deslopify/apps/desktop/electron/features/workspace/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/workspace/plan.md
@@ -1,0 +1,67 @@
+# Refactoring Plan — apps/desktop/electron/features/workspace
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+Workspace ownership is mostly clean and intentionally modularized, but the core manager
+is nearing the size cap and contains a few reliability drifts (silent error swallowing,
+minor duplication, and lingering `any` in watcher error handling). The goal is to keep this
+foundational AD-010/AD-018 module stable by trimming lifecycle duplication and tightening
+error/type handling before the next feature wave lands.
+
+## Issues Found (prioritized)
+- **Medium** — `WorkspaceManager` is near cap and accumulating mixed responsibilities —
+  `apps/desktop/electron/features/workspace/manager.ts:1-461` combines registry I/O,
+  default workspace setup, CRUD, state toggles, mount/reference/root delegations,
+  and inference plumbing. It is one medium feature away from crossing 500 LOC.
+  Effort: **M**.
+
+- **Medium** — Lifecycle cleanup errors are silently swallowed in workspace remove/close paths —
+  `apps/desktop/electron/features/workspace/manager.ts:313` and
+  `apps/desktop/electron/features/workspace/manager.ts:339` suppress editor-state
+  deletion failures with `.catch(() => {})`, hiding disk/permission regressions.
+  Effort: **S**.
+
+- **Low** — Duplicate editor-state cleanup logic appears in both `remove()` and `close()` —
+  `apps/desktop/electron/features/workspace/manager.ts:310-313` and
+  `apps/desktop/electron/features/workspace/manager.ts:336-339` repeat the same deletion block.
+  Effort: **S**.
+
+- **Low** — File watcher error path still uses `any` typing —
+  `apps/desktop/electron/features/workspace/watcher.ts:126` uses `catch (err: any)`.
+  Effort: **S**.
+
+## Proposed Refactoring
+1. **Pre-emptively split `manager.ts` before cap breach.**
+   - Extract registry/default-workspace lifecycle into a dedicated service module
+     (e.g. `workspace-registry.ts`) and keep `manager.ts` focused on orchestration.
+
+2. **Centralize editor-state cleanup in one helper.**
+   - Add a private `cleanupEditorState(id)` helper in `manager.ts` (or shared util)
+     and call it from both `remove()` and `close()`.
+   - Keep behavior identical but remove duplicate branches.
+
+3. **Stop swallowing cleanup failures silently.**
+   - Replace `.catch(() => {})` with explicit ENOENT-only tolerance and warning logs
+     for other failure modes.
+
+4. **Tighten watcher error typing.**
+   - Switch `catch (err: any)` to `unknown` with a safe error-message helper.
+
+## Benefits & Trade-offs
+- Benefits: keeps core workspace ownership maintainable, reduces hidden failure modes,
+  and prevents file-size debt from spiking later in Wave A/B changes.
+- Trade-offs: small structural churn in a widely imported module; requires careful
+  touch discipline because many features depend on workspace manager behavior.
+
+## Dependencies & Risks
+- Changes here can affect container mount rebuild behavior (AD-018) and workspace
+  resolution in agent/gateway/subagent flows.
+- Refactors should avoid altering external method signatures consumed by 27 callers
+  unless migration updates are staged together.
+
+## Next Steps
+1. Extract `manager.ts` lifecycle submodule(s) to keep the file comfortably below 500 LOC.
+2. Refactor remove/close cleanup into one shared helper with explicit error handling.
+3. Replace watcher `any` catch with typed error normalization.
+4. Continue Wave A: `deslopify apps/desktop/electron/features/agent`.

--- a/docs/deslopify/apps/desktop/electron/ipc/facts.md
+++ b/docs/deslopify/apps/desktop/electron/ipc/facts.md
@@ -1,0 +1,47 @@
+# Facts — apps/desktop/electron/ipc
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This folder is the Electron main-process IPC surface for desktop. It registers
+all channel handlers for agent/session orchestration, workspace/profile lifecycle,
+container/terminal/editor operations, auth/integrations, subagents, plugins,
+VCS, collaboration, and platform UI services.
+
+## Shape & metrics
+- Total files: 69
+- Total LOC: 8,602
+- Largest file: `apps/desktop/electron/ipc/agent/core/agent.ts` (498 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥450 LOC):
+  - `apps/desktop/electron/ipc/agent/core/agent.ts` (498)
+  - `apps/desktop/electron/ipc/agent/core/agent-helpers.ts` (453)
+- External dependencies of note:
+  - Pi SDK session/runtime (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-agent-core`)
+  - shared infra singletons (`@electron/shared/infra/shared-infra`)
+  - workspace/container systems (AD-018 paths)
+  - gateway/subagent bridges (AD-021)
+- Upstream callers:
+  - Registered once via `registerAllIpcHandlers()` (`electron/ipc/index.ts`) from
+    `electron/main.ts:244`
+- Downstream dependencies:
+  - `electron/preload/**` bridge methods and `window.sero` APIs
+  - renderer stores/components using corresponding preload contracts
+
+## Architectural notes
+- This folder is the main-process leg of the 4-layer IPC rule; contract drift here
+  directly breaks renderer-preload-main alignment.
+- AD-018, AD-020, and AD-021 are all represented in this layer (container exec,
+  tool bridge/session routing, subagent lifecycle).
+- Handler registration is broad and modular, but type coupling still routes through
+  `@/types/ipc` in most modules instead of narrower channel/type entrypoints.
+
+## Surprising discoveries
+- `@/types/ipc` is imported in 48/69 IPC files, while only one file imports
+  `@/types/ipc-channels` directly (`apps/desktop/electron/ipc/apps/git-app.ts:3`).
+- `any`/`as any` usage remains in core IPC boundaries (agent, imagegen, LSP, google):
+  e.g. `agent/core/agent-helpers.ts:288,422-440`, `agent/core/agent.ts:156,393`,
+  `agent/handlers/imagegen.ts:28,61,107,114`, `editor/lsp.ts:51`,
+  `integrations/google-api.ts:73,79`.
+- Main-process broadcast loops (`BrowserWindow.getAllWindows()`) are duplicated
+  across many files (16 occurrences), creating repeated event-fanout boilerplate.

--- a/docs/deslopify/apps/desktop/electron/ipc/plan.md
+++ b/docs/deslopify/apps/desktop/electron/ipc/plan.md
@@ -1,0 +1,93 @@
+# Refactoring Plan — apps/desktop/electron/ipc
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/ipc` is broad but mostly well-partitioned by domain. The biggest debt is
+contract hygiene: repeated `any`/`as any` in core handler paths, high coupling to the
+`@/types/ipc` mega-barrel, and two near-cap core agent files that are one feature
+away from violating the 500 LOC rule. The plan focuses on tightening type safety and
+decoupling channel imports before this layer becomes brittle.
+
+## Issues Found (prioritized)
+- **High** — Type-safety escape hatches (`any` / `as any`) remain in critical IPC paths —
+  `apps/desktop/electron/ipc/agent/core/agent-helpers.ts:288,422-440`,
+  `apps/desktop/electron/ipc/agent/core/agent.ts:156,393`,
+  `apps/desktop/electron/ipc/agent/handlers/imagegen.ts:28,61,107,114`,
+  `apps/desktop/electron/ipc/editor/lsp.ts:51`, and
+  `apps/desktop/electron/ipc/integrations/google-api.ts:73,79` bypass strict contracts at
+  core renderer↔main boundaries. Effort: **M**.
+
+- **Medium** — Core agent IPC files are near cap and overloaded —
+  `apps/desktop/electron/ipc/agent/core/agent.ts:1-498` and
+  `apps/desktop/electron/ipc/agent/core/agent-helpers.ts:1-453` are close to hard-limit
+  breach and combine many responsibilities (pool lifecycle, context overrides, message
+  conversion, command shaping, private SDK access). Effort: **M**.
+
+- **Medium** — IPC modules are tightly coupled to `@/types/ipc` instead of narrow channels/types —
+  48 files import `IpcChannels` from `@/types/ipc` (examples:
+  `agent/core/agent.ts:11`, `workspace/workspace.ts:9`, `platform/system/net.ts:15`) while
+  the dedicated channel module is largely unused. This amplifies blast radius of type-barrel edits.
+  Effort: **M**.
+
+- **Medium** — Main-process sync filesystem calls appear in handler paths that can run on demand —
+  `agent/handlers/prompts.ts:16,61,68`, `agent/handlers/sessions.ts:13,125`,
+  `gateway/gateway-ops.ts:13,79,119`, and `apps/apps.ts:10,84,94` use sync fs APIs, increasing
+  risk of UI hitching under heavy activity. Effort: **M**.
+
+- **Medium** — Private SDK internals are mutated directly for context overrides —
+  `agent/core/agent-helpers.ts:420-440` (`_baseSystemPrompt`) and
+  `agent/core/agent-context-overrides.ts:111` (`_rewriteFile`) depend on non-public SDK fields,
+  creating upgrade fragility. Effort: **M**.
+
+- **Low** — Event fanout boilerplate is duplicated across many modules —
+  repeated `BrowserWindow.getAllWindows()` loops (e.g. `agent/core/agent.ts:99`,
+  `integrations/plugins.ts:19`, `container/terminal.ts:18`, `subagent/subagent.ts:33`) add
+  mechanical noise and inconsistent error handling. Effort: **S**.
+
+## Proposed Refactoring
+1. **Remove `any`/unsafe casts from high-risk IPC boundaries first.**
+   - Replace loose imagegen and google/LSP payloads with explicit interfaces.
+   - Introduce narrow type guards where SDK unions are broad.
+   - Keep unavoidable SDK-private escapes isolated behind a single helper with strong comments/tests.
+
+2. **Split near-cap core agent files by responsibility.**
+   - `agent.ts`: isolate session lifecycle, prompt/steer handlers, and utility handlers into
+     dedicated modules under `agent/core/handlers/`.
+   - `agent-helpers.ts`: move context-editor private SDK helpers and message conversion helpers
+     into separate files.
+
+3. **Decouple channel constants from the mega-barrel.**
+   - Migrate `IpcChannels` imports to `@/types/ipc-channels` across IPC handlers.
+   - Keep payload imports from focused type modules (`@/types/agent`, `@/types/vcs`, etc.) as available.
+
+4. **Replace sync fs APIs in handler hot paths with async equivalents.**
+   - Prompts/apps discovery and session-header writes should avoid sync operations inside IPC handlers.
+   - Preserve atomic-write semantics where required.
+
+5. **Stabilize private SDK-field access.**
+   - Encapsulate `_baseSystemPrompt` / `_rewriteFile` interactions in a single adapter with explicit
+     version guard + fallback behavior.
+   - This keeps AD-020/AD-021 session behavior intact while reducing upgrade risk.
+
+6. **Introduce a shared IPC event broadcaster helper.**
+   - Centralize `BrowserWindow` fanout logic (optional logger + destroyed-window guards), then reuse
+     across gateway/subagent/plugins/terminal/debug/collaboration handlers.
+
+## Benefits & Trade-offs
+- Benefits: better type reliability at the highest-risk boundary, lower regression risk on SDK upgrades,
+  easier review of IPC changes, and fewer accidental cap breaches.
+- Trade-offs: medium refactor churn across many files and potential temporary merge friction while
+  import paths and shared helpers are being normalized.
+
+## Dependencies & Risks
+- Depends on Wave A `src/types` + `preload` cleanup to avoid conflicting import strategy changes.
+- Tightening types may surface latent mismatches in renderer/preload callers that were previously hidden.
+- Refactoring private SDK access requires careful regression checks around context editor + session persistence.
+
+## Next Steps
+1. Fix High: remove/contain `any` escape hatches in core IPC handlers.
+2. Split `agent/core/agent.ts` and `agent/core/agent-helpers.ts` before they exceed 500 LOC.
+3. Migrate IPC handler channel imports to `@/types/ipc-channels`.
+4. Convert sync fs handler operations to async where practical.
+5. Start Wave A step 4: `deslopify apps/desktop/electron/features/workspace`.

--- a/docs/deslopify/apps/desktop/electron/platform/facts.md
+++ b/docs/deslopify/apps/desktop/electron/platform/facts.md
@@ -1,0 +1,34 @@
+# Facts — apps/desktop/electron/platform
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This folder is the Electron host platform boundary: profile-aware environment bootstrap (`SERO_HOME`/`PI_CODING_AGENT_DIR`), custom protocol handlers for extension assets, builtin package/plugin discovery for dev+packaged runtime, renderer CSP enforcement, git-command safety classification, and desktop notification dispatch.
+
+## Shape & metrics
+- Total files: 6
+- Total LOC: 795
+- Largest file: `apps/desktop/electron/platform/env/index.ts` (186 LOC)
+- Files over 500 LOC: none
+- External dependencies of note:
+  - Electron platform APIs (`protocol`, `net.fetch`, `session.webRequest`, `Notification`)
+  - Sync filesystem path/manifest reads (`readFileSync`, `readdirSync`, `realpathSync`)
+  - Profile migration/registry layer (`features/profile/{migration,manager}`)
+- Upstream callers:
+  - 39 runtime files import `@electron/platform/**` (40 including tests)
+  - Main bootstrap entrypoint consumes env/protocol/CSP directly (`apps/desktop/electron/main.ts:2-3,25,31-32,39,220,266`)
+- Downstream dependencies:
+  - App/plugin discovery + install lifecycle (`features/apps/discovery`, `features/plugins/manager`)
+  - Shared settings/provider layers via `SERO_AGENT_DIR`
+  - IPC auth/theme/debug surfaces that depend on environment and security policies
+
+## Architectural notes
+- `env/index.ts` is a startup-critical root (runs before SDK imports) and effectively defines AD-022 profile scoping at process boot.
+- `ext-protocol.ts` is the serving boundary for federated plugin assets and therefore a key security gate for path traversal/symlink checks.
+- `csp.ts` applies one global CSP policy across all renderer responses via `session.defaultSession.webRequest.onHeadersReceived`.
+
+## Surprising discoveries
+- `script-src` includes `'unsafe-inline'` unconditionally (`platform/security/csp.ts:37`), despite comments describing the need as dev-driven, and `frame-src`/`child-src` allow broad `http:`/`https:` in all environments (`csp.ts:99-111`).
+- Extension asset registry has add-only APIs (`platform/protocols/ext-protocol.ts:24-32`) with no removal counterpart, while plugin install flow registers manifests (`features/plugins/manager.ts:311`), creating stale-memory risk after uninstall/reload.
+- Builtin package detection logic is duplicated in runtime and build pipeline (`platform/protocols/builtin-resources.ts:31-44` and `apps/desktop/scripts/build-electron.mjs:35-48`) with a manual “keep in sync” comment.
+- Environment resolution performs migration/registry work synchronously during module initialization (`platform/env/index.ts:43-53,118-130`), which is acceptable today but concentrates startup coupling in one import side effect.

--- a/docs/deslopify/apps/desktop/electron/platform/plan.md
+++ b/docs/deslopify/apps/desktop/electron/platform/plan.md
@@ -1,0 +1,50 @@
+# Refactoring Plan — apps/desktop/electron/platform
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/platform` is compact and generally well-factored, but it carries one material security debt (overly permissive CSP in production) plus two lifecycle/maintenance drifts around extension-asset registration and duplicated package-detection logic. The plan tightens runtime security first, then reduces drift in platform discovery/protocol contracts.
+
+## Issues Found (prioritized)
+- **High** — CSP is broader than necessary in production — `apps/desktop/electron/platform/security/csp.ts:37` includes `'unsafe-inline'` for scripts unconditionally, and `frame-src`/`child-src` allow global `http:` + `https:` (`csp.ts:99-111`) across environments. This weakens renderer containment and increases XSS blast radius if an injection path appears. Effort: **M**.
+
+- **Medium** — Extension protocol registry is add-only with no uninstall symmetry — manifests are inserted via `registerExtAssets`/`registerAllExtAssets` (`apps/desktop/electron/platform/protocols/ext-protocol.ts:24-32`) and consumed in protocol handling (`ext-protocol.ts:89`), but there is no remove API while plugin install currently registers on install (`apps/desktop/electron/features/plugins/manager.ts:311`). This can leave stale entries until restart. Effort: **S**.
+
+- **Medium** — Builtin package detection rules are duplicated between runtime and build scripts — `apps/desktop/electron/platform/protocols/builtin-resources.ts:31-44` and `apps/desktop/scripts/build-electron.mjs:35-48` contain mirrored `isBuiltinPackageDir` logic with manual sync comments. Drift here causes packaged-vs-dev discovery mismatch. Effort: **S**.
+
+- **Low** — Environment bootstrap uses synchronous migration/registry IO during module init — `apps/desktop/electron/platform/env/index.ts:43-53,118-130` runs profile resolution and registry reads at import time. It works today, but raises startup coupling and test harness complexity. Effort: **M**.
+
+## Proposed Refactoring
+1. **Tighten CSP by environment and feature need.**
+   - Gate `script-src 'unsafe-inline'` behind explicit dev mode or nonce/hash-protected production bootstrap scripts.
+   - Restrict `frame-src`/`child-src` to the minimum required for sandboxed preview flows (e.g., explicit preview origins or route-aware policy decisions).
+   - Add tests/snapshots for dev vs prod CSP strings so future policy broadening is intentional.
+
+2. **Add protocol registry lifecycle symmetry.**
+   - Introduce `unregisterExtAssets(appId)` (and optional bulk remove) in `ext-protocol.ts`.
+   - Call it from plugin uninstall and rollback paths to keep registry state aligned with current install set.
+   - Aligns with plugin lifecycle boundaries and avoids stale protocol mappings.
+
+3. **Unify builtin package detection in a single shared helper.**
+   - Move `isBuiltinPackageDir` to one canonical module consumed by both runtime discovery and `build-electron.mjs`.
+   - Keep behavior identical while eliminating manual copy-sync comments.
+
+4. **Make env resolution side effects more explicit.**
+   - Keep existing semantics (must execute before SDK imports), but isolate migration/registry repair in a named bootstrap function and reduce module-top execution.
+   - Preserve `loadSeroEnv()` ordering guarantees while making startup state easier to test.
+
+## Benefits & Trade-offs
+- Benefits: stronger production security posture, fewer stale plugin protocol mappings, and less packaged/dev drift in builtin discovery.
+- Trade-offs: CSP tightening can surface hidden dependencies (inline scripts/preview scenarios), requiring coordination with renderer/bootstrap code.
+
+## Dependencies & Risks
+- CSP changes may require updating `apps/desktop/index.html` bootstrap behavior and any preview iframe assumptions.
+- Registry lifecycle fixes depend on plugin manager uninstall/rollback flow updates being landed together.
+- Shared detection helper extraction touches build tooling and runtime paths, so both dev and packaged builds must be validated.
+
+## Next Steps
+1. Patch CSP policy first (prod-focused tightening + regression tests).
+2. Add `unregisterExtAssets` and wire uninstall/rollback paths.
+3. Extract canonical builtin package detection helper and remove duplicate implementations.
+4. Refactor env bootstrap into explicit staged init while preserving pre-SDK ordering.
+5. Continue Wave A into renderer orchestration deslopify targets (`src/stores`, `src/hooks`, `src/lib`).

--- a/docs/deslopify/apps/desktop/electron/preload/facts.md
+++ b/docs/deslopify/apps/desktop/electron/preload/facts.md
@@ -1,0 +1,44 @@
+# Facts — apps/desktop/electron/preload
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This folder implements the renderer-safe bridge (`window.sero`) by wrapping
+`ipcRenderer.invoke/send/on` calls into typed domain APIs (agent, workspace,
+auth, collaboration, editor/LSP, plugins, gateway, etc.). `preload.ts` exposes
+`seroPreloadApi` into the isolated renderer via `contextBridge`.
+
+## Shape & metrics
+- Total files: 14
+- Total LOC: 1,119
+- Largest file: `apps/desktop/electron/preload/api.ts` (483 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥450 LOC):
+  - `apps/desktop/electron/preload/api.ts` (483)
+- External dependencies of note:
+  - Electron preload primitives: `ipcRenderer`, `contextBridge`
+  - Shared contracts from `@/types/ipc`, `@/types/vcs`, `@/types/theme`
+- Upstream callers:
+  - `apps/desktop/electron/preload.ts` exposes `seroPreloadApi` directly
+  - Renderer code consumes this via global `window.sero` declarations in `src/types/electron*.d.ts`
+- Downstream dependencies:
+  - `apps/desktop/electron/ipc/**` handler signatures through `IpcChannels`
+  - `apps/desktop/src/types/ipc.ts` and related type modules
+
+## Architectural notes
+- This folder is the preload leg of the 4-layer IPC rule (React → store → preload → main).
+  Any type drift here breaks the core contract boundary.
+- AD-008 (preload bridge boundary) and AD-018/AD-021 surfaces (container/subagent)
+  are materially represented here through channel wrappers.
+- `api.ts` acts as the aggregate object that wires all domain bridges; current size is one
+  feature away from breaching the 500 LOC cap.
+
+## Surprising discoveries
+- `contextBridge.exposeInMainWorld('sero', seroPreloadApi)` currently has no compile-time
+  conformance check against the declared `SeroAPI` contract (`electron/preload.ts:4`), so
+  implementation/declaration drift can slip through.
+- All 14 preload modules import `IpcChannels` from `@/types/ipc` instead of the dedicated
+  `@/types/ipc-channels` module, pulling in the monolithic type barrel everywhere.
+- Public preload bridges still expose loose `any`/`unknown` contracts at key boundaries:
+  `integrations/google-imagegen.ts:16-17,26`, `editor/debug-lsp.ts:45-51`,
+  and `apps/app-domain.ts:95`.

--- a/docs/deslopify/apps/desktop/electron/preload/plan.md
+++ b/docs/deslopify/apps/desktop/electron/preload/plan.md
@@ -1,0 +1,81 @@
+# Refactoring Plan — apps/desktop/electron/preload
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+Preload bridge coverage is broad and mostly consistent, but contract safety is weaker than it
+should be for such a critical boundary: no direct compile-time guard between implementation and
+`window.sero` declarations, near-cap aggregation in `api.ts`, and lingering `any`/`unknown`
+signatures at IPC edges. The target outcome is a stricter, slimmer preload layer with explicit
+contract enforcement and reduced coupling to the `@/types/ipc` mega-barrel.
+
+## Issues Found (prioritized)
+- **High** — No compile-time conformance check for exposed preload API contract —
+  `apps/desktop/electron/preload.ts:4` exposes `seroPreloadApi` directly from
+  `apps/desktop/electron/preload/api.ts:89-483` without a `SeroAPI`-level conformance guard.
+  This allows declaration/implementation drift to bypass type safety at the process boundary.
+  Effort: **S**.
+
+- **Medium** — `api.ts` is near cap and still aggregates too many domains in one object —
+  `apps/desktop/electron/preload/api.ts:89-483` bundles profiles, workspaces, agent, VCS,
+  terminal, editor, and integration wiring. One additional domain likely crosses 500 LOC.
+  Effort: **M**.
+
+- **Medium** — Preload modules are coupled to `@/types/ipc` for channel constants, not the dedicated
+  channels module — all 14 files in this folder import `IpcChannels` from `@/types/ipc`
+  (example: `apps/desktop/electron/preload/api.ts:2`). This increases blast radius for
+  `ipc.ts` edits and reinforces mega-barrel coupling. Effort: **S**.
+
+- **Medium** — Weak public typings (`any`/`unknown`) leak across preload IPC boundaries —
+  `apps/desktop/electron/preload/integrations/google-imagegen.ts:16-17,26`,
+  `apps/desktop/electron/preload/editor/debug-lsp.ts:45-51`, and
+  `apps/desktop/electron/preload/apps/app-domain.ts:95` expose untyped payloads/results despite
+  existing domain contracts in type declarations. Effort: **M**.
+
+- **Low** — Layout bridge uses ad-hoc shape instead of canonical layout contracts —
+  `apps/desktop/electron/preload/platform/host-services.ts:21-24` narrows layout save/load to
+  a partial inline object, while declared API expects `LayoutState` / `LoadedLayoutState`
+  (`apps/desktop/src/types/electron.d.ts:264-268`). Effort: **S**.
+
+## Proposed Refactoring
+1. **Enforce preload API contract conformance at compile time.**
+   - Introduce a typed contract source for preload (exportable interface/type), then apply
+     `satisfies` or explicit annotation to `seroPreloadApi` before `exposeInMainWorld`.
+   - Keep this check in build/typecheck so drift is caught immediately.
+   - Aligns with AD-008 and the 4-layer IPC integrity rule.
+
+2. **Split `api.ts` into domain composition modules before cap breach.**
+   - Target shape: `preload/api/{workspace.ts,agent.ts,vcs.ts,terminal.ts,editor.ts,services.ts}`
+     plus a thin `api.ts` composer.
+   - Keep implementation files focused on one IPC namespace each.
+
+3. **Decouple channel constants from `@/types/ipc` in preload.**
+   - Import `IpcChannels` from `@/types/ipc-channels` everywhere in preload.
+   - Reserve `@/types/ipc` imports for payload contracts only.
+
+4. **Replace `any`/`unknown` bridge signatures with canonical types.**
+   - Type Google auth events and imagegen params/results explicitly.
+   - Type LSP notification payloads as `unknown` + narrow helper (or a concrete notification union).
+   - Replace `gitAppBridge.run` unknown params/result with dedicated action/result interfaces.
+
+5. **Align host-service bridges with canonical type contracts.**
+   - Use `LayoutState` / `LoadedLayoutState` in `layoutBridge` signatures.
+   - Remove inline shape duplication across preload + declaration layers.
+
+## Benefits & Trade-offs
+- Benefits: stronger contract guarantees at the preload boundary, lower drift risk between
+  declarations and implementation, and better maintainability as IPC surface area grows.
+- Trade-offs: moderate refactor churn across preload modules and imports; temporary migration
+  overhead while moving `IpcChannels` consumers.
+
+## Dependencies & Risks
+- Depends on `src/types` contract cleanup (especially `ipc.ts` split) to avoid duplicated churn.
+- Contract tightening can surface latent IPC mismatches in `electron/ipc/**`, requiring coordinated fixes.
+- API conformance enforcement may fail fast on existing weakly typed methods; budget time for type repair.
+
+## Next Steps
+1. Add compile-time conformance check between `seroPreloadApi` and declared Sero API contract.
+2. Fix `any`/`unknown` signatures in `google-imagegen`, `debug-lsp`, and `app-domain` bridges.
+3. Migrate preload imports to `@/types/ipc-channels` for `IpcChannels`.
+4. Split `preload/api.ts` before adding new IPC namespaces.
+5. Proceed to `deslopify apps/desktop/electron/ipc` (Wave A step 3).

--- a/docs/deslopify/apps/desktop/electron/shared/facts.md
+++ b/docs/deslopify/apps/desktop/electron/shared/facts.md
@@ -1,0 +1,35 @@
+# Facts — apps/desktop/electron/shared
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This folder is the Electron main-process shared foundation layer: singleton infra bootstrap (`ensureInfra` + cross-feature managers), auth/provider catalog helpers, model/settings read-write utilities, media capture/encoding helpers, and small runtime utilities (native PTY loader, secret redaction, user-feedback event bus).
+
+## Shape & metrics
+- Total files: 15
+- Total LOC: 1,611
+- Largest file: `apps/desktop/electron/shared/infra/shared-infra.ts` (258 LOC)
+- Files over 500 LOC: none
+- External dependencies of note:
+  - Pi SDK core infra (`AuthStorage`, `ModelRegistry`, `SettingsManager`, session/model types)
+  - Electron media/runtime APIs (`BrowserWindow`, `screen`, `nativeImage`)
+  - Host process primitives (`child_process` ffmpeg execution, sync filesystem reads/writes)
+  - Cross-feature singletons (`container`, `workspace`, `subagent`, `gateway`, `vcs`, `lsp`)
+- Upstream callers:
+  - 53 runtime files import `@electron/shared/**` (63 including tests)
+  - Heavy consumers include IPC auth/agent/workspace handlers, CLI command modules, and container tool paths
+- Downstream dependencies:
+  - `@electron/platform/env` for profile-scoped paths (`SERO_AGENT_DIR`)
+  - `@electron/features/{container,workspace,subagent,gateway,vcs,profile}` from `shared-infra`
+  - `@/types/ipc` model-tier contracts from settings/provider helpers
+
+## Architectural notes
+- `shared-infra.ts` is a central composition root for AD-018/AD-021-adjacent services; many runtime paths assume its singleton lifecycle and side effects are stable.
+- Settings helpers are profile-scoped via `SERO_AGENT_DIR` (AD-022 profile isolation behavior).
+- Provider metadata is assembled from built-ins + package/plugin manifests, bridging platform discovery (`builtin-resources`) into auth/provider UI surfaces.
+
+## Surprising discoveries
+- `readSettings()` silently returns `{}` on parse/read errors (`shared/settings/settings-helpers.ts:15-20`), and multiple call sites write the returned object back (`ipc/workspace/profiles.ts:168-169`, `features/onboarding/preflight.ts:101-116`), creating a settings-clobber risk on malformed JSON.
+- Shared default model caching is one-shot (`shared/infra/shared-infra.ts:119,196`), while auth flows only refresh `modelRegistry` (`ipc/platform/auth/auth.ts:116`), leaving `infra.model` consumers (notably `ipc/agent/handlers/app-agent.ts:152`) at risk of stale defaults.
+- User-feedback bus singleton key/initialization is duplicated in two modules (`shared/lib/user-feedback-bus.ts:13` and `plugins/sero-user-feedback-plugin/shared/emitter.ts:11`), with manual “must match” comments instead of a shared source.
+- `getPackageProviderManifests()` is currently dead private code (`shared/providers/package-provider-manifests.ts:185`).

--- a/docs/deslopify/apps/desktop/electron/shared/plan.md
+++ b/docs/deslopify/apps/desktop/electron/shared/plan.md
@@ -1,0 +1,57 @@
+# Refactoring Plan — apps/desktop/electron/shared
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/shared` is foundational and mostly under control (no file-size or obvious type-escape violations), but it has two correctness risks that should be scheduled early: settings parse failures can cascade into destructive rewrites, and the cached default model in shared infra can drift after auth changes. The plan focuses on hardening those contracts first, then reducing coupling/drift in shared helper surfaces.
+
+## Issues Found (prioritized)
+- **High** — Silent settings parse fallback can clobber `settings.json` on subsequent writes — `apps/desktop/electron/shared/settings/settings-helpers.ts:15-20` returns `{}` on any parse/read failure, and callers later persist derived state (`apps/desktop/electron/ipc/workspace/profiles.ts:168-169`, `apps/desktop/electron/features/onboarding/preflight.ts:101-116`). A malformed settings file can be unintentionally overwritten with a partial object. Effort: **S**.
+
+- **Medium** — Shared default model cache can become stale after auth changes — `_model` is initialized once (`apps/desktop/electron/shared/infra/shared-infra.ts:119,196`), but auth mutations only call `modelRegistry.refresh()` (`apps/desktop/electron/ipc/platform/auth/auth.ts:116`). Consumers that rely on `infra.model` (`apps/desktop/electron/ipc/agent/handlers/app-agent.ts:152`) may use outdated defaults. Effort: **S**.
+
+- **Medium** — `shared-infra.ts` is a cross-domain singleton hub with import-time side effects — it mixes profile migration side effects (`apps/desktop/electron/shared/infra/shared-infra.ts:42`) and many service singletons (`shared-infra.ts:50-112`) across gateway, VCS, workspace, subagent, and LSP concerns. This increases review/load-bearing blast radius for unrelated changes. Effort: **M**.
+
+- **Low** — Provider manifest scanning does repeated sync filesystem traversal with tiny TTL and includes dead helper surface — sync scans/parses run in `apps/desktop/electron/shared/providers/package-provider-manifests.ts:113-179` with `CACHE_TTL_MS = 250` (`:11`), and `getPackageProviderManifests()` is unused (`:185`). Effort: **S**.
+
+- **Low** — User-feedback bus singleton key is duplicated across host/plugin modules — `apps/desktop/electron/shared/lib/user-feedback-bus.ts:13` and `plugins/sero-user-feedback-plugin/shared/emitter.ts:11` must stay manually aligned. Effort: **S**.
+
+## Proposed Refactoring
+1. **Harden shared settings read/write as an explicit boundary contract.**
+   - Replace “return `{}` on failure” with a result-shaped API (`{ ok: true; value } | { ok: false; error }`) in `settings-helpers`.
+   - Update mutating callers (`profiles` model-config set path, onboarding preflight) to abort on parse failure and return actionable UI errors instead of rewriting corrupted settings.
+   - Aligns with current settings safety goals already identified in plugin manager deslop plans.
+
+2. **Introduce a shared model refresh hook in infra.**
+   - Add a small `refreshInfraModelSelection()` in `shared-infra` that re-runs `pickFirstAvailableModel` after auth/settings changes.
+   - Invoke it from auth mutation paths after `modelRegistry.refresh()`.
+   - Keep `ensureInfra()` lazy behavior unchanged while removing stale-model drift.
+
+3. **Modularize `shared-infra` by registrar responsibility.**
+   - Extract focused registrars (e.g., `registerGatewayInfra`, `registerVcsInfra`, `registerAgentOrchestrationInfra`) and keep `shared-infra.ts` as the composition root.
+   - Preserve existing exported singleton API to avoid breaking IPC/CLI modules.
+   - This keeps AD-018/AD-021 infra wiring explicit without further central-file sprawl.
+
+4. **Refine provider manifest caching + dead code cleanup.**
+   - Remove the unused private `getPackageProviderManifests` function.
+   - Move from short-interval TTL polling to invalidation triggers tied to known mutation points (plugin install/uninstall, settings writes), while keeping one fallback TTL for safety.
+
+5. **Deduplicate user-feedback bus contract.**
+   - Extract the emitter key + singleton factory into one shared module consumed by both Electron and plugin bridge code.
+   - Remove mirrored-copy comments once both sides import one source.
+
+## Benefits & Trade-offs
+- Benefits: safer settings persistence, fewer stale model-selection bugs, lower coupling in a foundational module, and clearer shared contract ownership.
+- Trade-offs: moderate cross-module touch points (IPC auth + onboarding + profiles) and some temporary churn in singleton wiring imports.
+
+## Dependencies & Risks
+- Settings-contract changes require coordinated updates in all write paths; partial migration can introduce inconsistent error behavior.
+- Infra modularization must preserve singleton initialization ordering (gateway/subagent/container dependencies) to avoid startup regressions.
+- Cache invalidation strategy for provider manifests needs clear mutation hooks from plugin manager and settings writes.
+
+## Next Steps
+1. Land High fix first: make settings parse failures non-destructive.
+2. Add infra model-refresh path and wire auth mutation handlers to it.
+3. Split `shared-infra.ts` into registrars while preserving exported singleton API.
+4. Remove dead manifest helper and switch to mutation-driven cache invalidation.
+5. Queue follow-up deslopify/fix work in `apps/desktop/electron/platform` and then renderer orchestration (`src/stores`, `src/hooks`, `src/lib`).

--- a/docs/deslopify/apps/desktop/facts.md
+++ b/docs/deslopify/apps/desktop/facts.md
@@ -1,0 +1,53 @@
+# Facts — apps/desktop
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`apps/desktop` is the Electron host + React renderer for Sero. It owns shell UI,
+agent session orchestration, IPC contracts, preload bridges, container-backed tool
+execution, and plugin/runtime integration points.
+
+## Shape & metrics
+- Total files scanned (`src` + `electron`, TS/JS): 621
+- Largest file: `apps/desktop/src/types/ipc.ts` (544 LOC)
+- Files over 500 LOC: `apps/desktop/src/types/ipc.ts` (544)
+- Near-cap files (≥470 LOC):
+  - `apps/desktop/electron/ipc/agent/core/agent.ts` (498)
+  - `apps/desktop/electron/features/plugins/manager.ts` (494)
+  - `apps/desktop/src/types/electron.d.ts` (492)
+  - `apps/desktop/electron/features/subagent/index.ts` (491)
+  - `apps/desktop/electron/features/kanban/core/orchestrator.ts` (491)
+  - `apps/desktop/src/stores/agent.ts` (489)
+  - `apps/desktop/electron/features/gateway/index.ts` (488)
+  - `apps/desktop/src/components/profiles/OnboardingWizard.tsx` (486)
+  - `apps/desktop/src/types/ipc-channels.ts` (483)
+  - `apps/desktop/electron/preload/api.ts` (483)
+  - `apps/desktop/electron/features/container/tools/tools-browser-agent.ts` (483)
+  - `apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx` (480)
+- Highest-LOC areas (directory totals):
+  - `apps/desktop/src/components/layout` (~15,908 LOC)
+  - `apps/desktop/src/components/apps` (~7,105 LOC)
+  - `apps/desktop/electron/features/kanban` (~6,702 LOC)
+  - `apps/desktop/electron/features/container` (~4,751 LOC)
+  - `apps/desktop/electron/ipc/agent` (~3,708 LOC)
+- Contract/boundary hotspots (Phase A scope):
+  - `apps/desktop/src/types` — 27 files / 3,323 LOC (largest: `src/types/ipc.ts` 544)
+  - `apps/desktop/electron/preload` — 14 files / 1,119 LOC (largest: `preload/api.ts` 483)
+  - `apps/desktop/electron/ipc` — 69 files / 8,602 LOC (largest: `ipc/agent/core/agent.ts` 498)
+  - `apps/desktop/src/stores` — 29 files / 5,377 LOC (largest: `stores/agent.ts` 489)
+
+## Architectural notes
+- AD-018, AD-020, and AD-021 make `electron/ipc`, `electron/features/container`,
+  and agent/subagent paths high-risk for contract drift.
+- The four-layer IPC rule from project conventions (React → store → preload → main)
+  puts `src/types/ipc.ts`, `src/types/ipc-channels.ts`, `electron/preload/api.ts`,
+  and `electron/ipc/**` at the center of most regression risk.
+- Baseline grep found no active renderer `localStorage`/`sessionStorage` writes in
+  app code (excluding comments/tests), which aligns with current layout persistence
+  guidance.
+
+## Surprising discoveries
+- Only one strict 500+ LOC violation exists right now (`src/types/ipc.ts`), but there
+  is a dense cluster of near-cap files in core contract and orchestration modules.
+- `electron/ipc` already spans 69 source files and 8.6k LOC, so Wave A sequencing is
+  still the correct first move before app-surface cleanups.

--- a/docs/deslopify/apps/desktop/plan.md
+++ b/docs/deslopify/apps/desktop/plan.md
@@ -1,0 +1,75 @@
+# Refactoring Plan — apps/desktop
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+Phase 0 baseline confirms one hard-rule file-size violation and a large near-cap
+cluster in IPC/contracts/orchestration code. The right scheduling move is still
+core-first: stabilize type and boundary ownership (types, preload, IPC, platform
+owners, stores/hooks/lib) before touching shell/app-surface modules. This plan
+locks that sequence and defines the first deslopify wave scope.
+
+## Issues Found (prioritized)
+- **High** — 500 LOC cap violation in core IPC contract file —
+  `apps/desktop/src/types/ipc.ts:1-544` exceeds the hard 500 LOC rule and is the
+  highest-risk shared contract file for renderer↔main drift. Effort: **M**.
+
+- **Medium** — Contract modules are concentrated near the 500 LOC ceiling —
+  `apps/desktop/electron/ipc/agent/core/agent.ts:1-498`,
+  `apps/desktop/electron/preload/api.ts:1-483`,
+  `apps/desktop/src/types/ipc-channels.ts:1-483`, and
+  `apps/desktop/src/stores/agent.ts:1-489` are all one feature away from hard
+  violation, increasing refactor cost and review load. Effort: **M**.
+
+- **Medium** — Ownership boundaries span many files before app surfaces are touched —
+  `apps/desktop/electron/ipc/**` (69 files), `apps/desktop/src/types/**` (27 files),
+  and `apps/desktop/src/stores/**` (29 files) indicate contract-first sequencing is
+  mandatory to avoid symptom-level UI fixes. Effort: **S** (planning alignment).
+
+- **Low** — No immediate storage-policy violation detected in production paths —
+  baseline scan found no active `localStorage`/`sessionStorage` usage in
+  `apps/desktop/src` or `apps/desktop/electron` app code, so no emergency policy
+  cleanup is needed before Wave A starts. Effort: **S**.
+
+## Proposed Refactoring
+1. **Execute Wave A deslopify reviews in strict order (no source edits yet).**
+   - Start with `src/types`, then `electron/preload`, then `electron/ipc`.
+   - Continue through platform owners (`electron/features/{workspace,agent,container,apps,plugins}`, `electron/shared`, `electron/platform`).
+   - Finish core renderer orchestration (`src/stores`, `src/hooks`, `src/lib`).
+   - Why: aligns with the 4-layer IPC contract rule and AD-018/AD-020/AD-021.
+
+2. **Split `src/types/ipc.ts` during the matching fix-slop wave.**
+   - Target shape: `src/types/ipc/{agent.ts, workspace.ts, profiles.ts, tools.ts, index.ts}`
+     with `index.ts` as the public barrel.
+   - Keep canonical imports from shared/Pi SDK types; avoid parallel type redeclarations.
+
+3. **Pre-emptively partition near-cap contract files before they cross 500 LOC.**
+   - `preload/api.ts`: split by domain bridge modules (agent/workspace/layout/debug/etc.).
+   - `ipc/agent/core/agent.ts`: separate orchestration, event routing, and session helpers.
+   - `stores/agent.ts`: extract command/event reducers vs. persistence/selectors.
+
+4. **Track cross-cutting drift patterns in each Wave A plan.**
+   - Require each folder plan to call out: IPC type drift risk, boundary leakage,
+     and duplicated helper opportunities.
+   - Consolidate before Wave B batching.
+
+## Benefits & Trade-offs
+- Benefits: reduces contract-regression risk, prevents 500+ LOC creep, and keeps
+  fix-slop batches focused on foundational modules with high downstream impact.
+- Trade-offs: front-loads planning/review effort before visible UI cleanup; requires
+  disciplined sequencing so contributors do not jump to shell/components early.
+
+## Dependencies & Risks
+- Depends on completing all Wave A deslopify docs first; fixing in parallel would
+  create churn as boundary assumptions change.
+- Type moves may require coordinated updates across preload and main IPC handlers to
+  preserve signature parity.
+- If container tooling paths are changed later (`images/Dockerfile.sero-node`), follow
+  the required image rebuild/recreate protocol from project guidance.
+
+## Next Steps
+1. Run `deslopify apps/desktop/src/types`.
+2. Run `deslopify apps/desktop/electron/preload`.
+3. Run `deslopify apps/desktop/electron/ipc`.
+4. Continue remaining Wave A targets in listed order.
+5. After all Wave A plans exist, schedule Wave B `fix-slop` High-only batches.

--- a/docs/deslopify/apps/desktop/plan.md
+++ b/docs/deslopify/apps/desktop/plan.md
@@ -1,6 +1,6 @@
 # Refactoring Plan — apps/desktop
 
-_Plan drafted: 2026-04-12_
+_Plan drafted: 2026-04-12 • Wave B synthesis added: 2026-04-12_
 
 ## Executive Summary
 Phase 0 baseline confirms one hard-rule file-size violation and a large near-cap
@@ -53,6 +53,64 @@ locks that sequence and defines the first deslopify wave scope.
      and duplicated helper opportunities.
    - Consolidate before Wave B batching.
 
+## Wave B synthesis — 2026-04-12
+
+### Cross-cutting themes across all Wave A plans
+1. **Contract drift is concentrated on the IPC spine, not in isolated folders.**
+   - `src/types`, `electron/preload`, and `electron/ipc` all found variants of the
+     same core problem: canonical contracts exist, but conformance is weak and
+     `any`/compat barrels are masking drift.
+   - The High type-escape findings in `electron/features/apps` belong to this same
+     family because they sit on extension/agent boundaries.
+   - Result: the first `fix-slop` batch should harden the contract spine end to
+     end instead of treating each folder as unrelated cleanup.
+
+2. **Lifecycle and failure semantics are inconsistent across runtime owners.**
+   - `src/stores` found optimistic destructive actions that can desync renderer and
+     main state.
+   - `electron/features/apps` found watcher bootstrap/refcount races.
+   - `electron/features/container` found stale port/orphan bridge lifecycle leaks.
+   - `src/lib` found sticky transient failures in federated component loading.
+   - Result: these should be grouped as one runtime-integrity batch focused on
+     explicit recovery behavior, teardown symmetry, and retryability.
+
+3. **Malformed settings/config handling currently fails open in more than one layer.**
+   - `electron/shared` and `electron/features/plugins` independently found
+     destructive `settings.json` parse-fallback flows.
+   - `electron/features/plugins` also found plugin discovery taxonomy drift, which
+     is the discoverability-contract sibling of the same host-boundary problem.
+   - Result: settings safety and plugin discovery should move together so the host
+     has one clear non-destructive config contract before more plugin/platform work.
+
+4. **Security hardening should be a dedicated wave, not incidental cleanup.**
+   - `electron/features/container` identified an unauthenticated open proxy on all
+     host interfaces.
+   - `electron/platform` identified a broader-than-needed production CSP.
+   - Result: these are the only Wave A High findings that directly widen attack
+     surface, so they deserve a focused hardening batch with explicit validation.
+
+5. **Not every Wave A folder actually has High work for Wave B.**
+   - `electron/features/workspace`, `electron/features/agent`, and `src/hooks` are
+     Medium/Low only in their current plans.
+   - Result: do not force artificial Wave B work there just to preserve folder
+     order. They should roll into the first Medium wave after the core High
+     batches land, unless new Highs appear during execution.
+
+### Recommended High-only `fix-slop` batches
+| Batch | Targets | High items covered | Batch intent |
+| --- | --- | --- | --- |
+| **B1 — IPC contract hardening** | `src/types`, `electron/preload`, `electron/ipc`, `electron/features/apps` (type-safety subset) | Split `src/types/ipc.ts`, fix `electron.d.ts` declaration gap, add preload contract conformance guard, remove unsafe `any`/`as any` escapes from IPC and extension helper boundaries | Lock down the React → store → preload → main contract spine before downstream refactors. |
+| **B2 — Settings & discovery safety** | `electron/shared`, `electron/features/plugins` | Make `settings.json` parse/write flows non-destructive and fix plugin discovery taxonomy drift | Establish one safe host config/discovery contract before more plugin/platform work. |
+| **B3 — Runtime lifecycle correctness** | `src/stores`, `electron/features/apps` (watcher subset), `electron/features/container` (lifecycle subset), `src/lib` | Make destructive actions IPC-result aware, fix watcher bootstrap/refcount race, fix scanner/bridge teardown leaks, and make federated remote failures retryable | Eliminate stale state, orphan processes/watchers, and sticky blank UI after transient failures. |
+| **B4 — Security boundary hardening** | `electron/features/container` (proxy subset), `electron/platform` | Restrict container proxy exposure and tighten production CSP | Keep attack-surface reductions reviewable as one dedicated hardening pass. |
+
+### Wave B targets with no current High items
+- Defer to the first Medium wave: `electron/features/workspace`,
+  `electron/features/agent`, `src/hooks`.
+- Keep Medium file-splitting work (`preload/api.ts`, `ipc/agent/core/agent.ts`,
+  `stores/agent.ts`, `plugins/manager.ts`, `shared-infra.ts`) attached to the
+  batch that already touches that area, rather than running standalone surgery.
+
 ## Benefits & Trade-offs
 - Benefits: reduces contract-regression risk, prevents 500+ LOC creep, and keeps
   fix-slop batches focused on foundational modules with high downstream impact.
@@ -68,8 +126,8 @@ locks that sequence and defines the first deslopify wave scope.
   the required image rebuild/recreate protocol from project guidance.
 
 ## Next Steps
-1. Run `deslopify apps/desktop/src/types`.
-2. Run `deslopify apps/desktop/electron/preload`.
-3. Run `deslopify apps/desktop/electron/ipc`.
-4. Continue remaining Wave A targets in listed order.
-5. After all Wave A plans exist, schedule Wave B `fix-slop` High-only batches.
+1. Execute **Batch B1 — IPC contract hardening** (`src/types` → `electron/preload` → `electron/ipc` → `electron/features/apps` type-safety subset).
+2. Execute **Batch B2 — Settings & discovery safety** (`electron/shared` + `electron/features/plugins`).
+3. Execute **Batch B3 — Runtime lifecycle correctness** (`src/stores` + `electron/features/apps` watcher work + `electron/features/container` lifecycle work + `src/lib`).
+4. Execute **Batch B4 — Security boundary hardening** (`electron/features/container` proxy work + `electron/platform` CSP work).
+5. Start the first Medium wave only after those High-only batches land and `workspace`/`agent`/`hooks` are re-evaluated against the updated core boundaries.

--- a/docs/deslopify/apps/desktop/src/hooks/facts.md
+++ b/docs/deslopify/apps/desktop/src/hooks/facts.md
@@ -1,0 +1,31 @@
+# Facts — apps/desktop/src/hooks
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`src/hooks` contains renderer orchestration hooks that glue shell UI to store and IPC behavior: prompt-input command/file completion, session↔agent lifecycle sync, checkpoint restore flow, keyboard shortcuts, GitHub auth device flow, user-feedback listener bootstrapping, debouncing utilities, and workspace file indexing.
+
+## Shape & metrics
+- Total files: 9
+- Total LOC: 939
+- Largest file: `apps/desktop/src/hooks/useChatPromptInput.ts` (202 LOC)
+- Files over 500 LOC: none
+- External dependencies of note:
+  - React hooks (`useEffect`, `useCallback`, `useMemo`, refs)
+  - Store entry points in `@/stores/*`
+  - Renderer IPC bridge (`window.sero.*`) for agent/container/github/editor/user-feedback interactions
+- Upstream callers:
+  - Hook modules are imported by ~12 files, mostly `components/layout/ChatPanel.tsx`, explorer UI, and shell startup layers.
+- Downstream dependencies:
+  - `useSessionAgent` depends on `agent`, `sessions`, `workspace`, and `container` stores simultaneously.
+  - `useWorkspaceFiles` depends on `window.sero.editor.exec` shell command execution and is consumed by prompt-input completion.
+
+## Architectural notes
+- This folder is thin by LOC, but high-impact in orchestration: hooks decide when state mutations and IPC calls happen.
+- Most `useEffect` usage here is legitimate external side-effect wiring (IPC listeners, DOM listeners, async startup fetches).
+- `useDebouncedCallback.ts` is already the canonical debounce helper and is referenced by stores/lib code, consistent with repository conventions.
+
+## Surprising discoveries
+- `useSessionAgent.ts` is effectively a mini-orchestrator with three separate effects and intentionally suppressed exhaustive-deps checks.
+- `useWorkspaceFiles.ts` uses a module-global cache map keyed by workspace ID with TTL but no explicit size bound/eviction policy.
+- Chat prompt handling duplicates built-in command handling in both menu-select and free-text submit paths (`/login`, `/logout`).

--- a/docs/deslopify/apps/desktop/src/hooks/plan.md
+++ b/docs/deslopify/apps/desktop/src/hooks/plan.md
@@ -1,0 +1,56 @@
+# Refactoring Plan — apps/desktop/src/hooks
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/hooks` is generally healthy and compact, but a few orchestration hooks are carrying too much coordination logic and hidden lifecycle risk. The priority is to make `useSessionAgent` and `useWorkspaceFiles` more predictable under load (fewer implicit retries/churn, clearer dependency ownership) while preserving current UX behavior.
+
+## Issues Found (prioritized)
+- **Medium** — `useSessionAgent` combines multiple orchestration responsibilities with suppressed dependency checks — `apps/desktop/src/hooks/useSessionAgent.ts:39-74` and `apps/desktop/src/hooks/useSessionAgent.ts:87-116` handle session open/focus, collaboration hydration, and container ensure with `eslint-disable` comments for exhaustive deps (`useSessionAgent.ts:74`, `useSessionAgent.ts:116`). This increases stale-closure risk and makes lifecycle regressions hard to test. Effort: **M**.
+
+- **Medium** — Session refresh trigger can spam IPC on bursty agent completions — `apps/desktop/src/hooks/useSessionAgent.ts:119-138` calls `loadSessions()` whenever any tracked agent transitions streaming→idle, with no debounce/coalescing. Multi-agent/subagent bursts can trigger repeated `sessions.list` calls. Effort: **S**.
+
+- **Medium** — Workspace file cache is global and unbounded by workspace count — `apps/desktop/src/hooks/useWorkspaceFiles.ts:34-35` stores arrays of up to 5,000 paths per workspace (`useWorkspaceFiles.ts:23`), and entries only expire by TTL checks during future reads. There is no max-size eviction, so long sessions across many workspaces can retain stale arrays in memory. Effort: **S**.
+
+- **Low** — Built-in command behavior (`/login`, `/logout`) is duplicated across two paths — `apps/desktop/src/hooks/useChatPromptInput.ts:63-76` and `apps/desktop/src/hooks/useChatPromptInput.ts:136-147`. Minor drift risk if command handling changes. Effort: **S**.
+
+- **Low** — Copy-status timer logic is duplicated in GitHub auth flow — `apps/desktop/src/hooks/useGitHubAuthFlow.ts:94-108` repeats timer-reset boilerplate for success/failure states. Effort: **S**.
+
+## Proposed Refactoring
+1. **Decompose `useSessionAgent` into focused orchestration hooks.**
+   - Split into:
+     - `useActiveSessionSync` (open/focus + collaboration hydrate)
+     - `useContainerEnsureOnSessionFocus` (AD-018 container startup)
+     - `useSessionListRefreshOnAgentIdle` (refresh policy)
+   - Keep `useSessionAgent` as a thin composition wrapper.
+
+2. **Coalesce session-list refreshes with the shared debounce utility.**
+   - Replace direct `loadSessions()` trigger in idle-detection effect with `useDebouncedCallback(loadSessions, 150-300)`.
+   - Preserve “eventual refresh after turn completion” behavior while reducing IPC chatter.
+
+3. **Add bounded eviction for workspace file cache.**
+   - Keep TTL behavior, but introduce max cache entries (e.g. 8–12 workspaces) using simple LRU metadata.
+   - Optional: clear cache entry on explicit `refresh()` failure to avoid stale false confidence.
+
+4. **Deduplicate built-in command handling in prompt hook.**
+   - Extract helper `handleBuiltinCommand(text)` returning boolean/side-effect.
+   - Use from both slash-menu selection and raw submit path.
+
+5. **Extract timer-reset helper in GitHub auth flow.**
+   - Introduce small local helper (`setTransientCopyState`) to collapse repeated timeout cleanup and state toggles.
+
+## Benefits & Trade-offs
+- Benefits: clearer hook ownership, fewer hidden lifecycle pitfalls, less IPC churn under heavy streaming activity, and lower maintenance overhead for command/auth UX behavior.
+- Trade-offs: additional hook modules and slightly more indirection when tracing ChatPanel/session orchestration behavior.
+
+## Dependencies & Risks
+- `useSessionAgent` split touches startup and ChatPanel wiring; behavior parity tests are needed to avoid focus/container regressions.
+- Debounce timings for session refresh should be tuned to avoid making session rename/firstMessage updates feel delayed.
+- Cache eviction policy must not break path completion immediately after switching workspaces.
+
+## Next Steps
+1. Extract `useSessionAgent` into three focused hooks with unchanged public behavior.
+2. Debounce session-list refresh after stream completion.
+3. Add capped LRU eviction to `useWorkspaceFiles` cache.
+4. Deduplicate built-in command/timer helper code paths.
+5. Re-check `ChatPanel` and explorer prompt UX after these hook changes.

--- a/docs/deslopify/apps/desktop/src/lib/facts.md
+++ b/docs/deslopify/apps/desktop/src/lib/facts.md
@@ -1,0 +1,32 @@
+# Facts — apps/desktop/src/lib
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`src/lib` contains renderer utility and integration modules for shell startup, layout persistence, module federation remote loading, app-control bridge/DOM interaction helpers, theme engine + font loading, app icon lookup, and lightweight helpers (copy-to-clipboard, app navigation).
+
+## Shape & metrics
+- Total files: 15
+- Total LOC: 1,788
+- Largest file: `apps/desktop/src/lib/app-control/dom-interactions.ts` (385 LOC)
+- Files over 500 LOC: none
+- External dependencies of note:
+  - `@module-federation/enhanced/runtime` for remote registration/loading
+  - React `lazy()` for federated component wrappers
+  - DOM/browser APIs for app-control automation and theme/font application
+  - Cross-store access (`useAppStore`, `useWorkspaceStore`, `useThemeStore`, etc.) from persistence/bridge utilities
+- Upstream callers:
+  - `@/lib/*` modules are imported by ~26 files in renderer codepaths (stores, shell components, theme editor, app surfaces).
+- Downstream dependencies:
+  - `persist-layout.ts` is a central persistence chokepoint for multiple stores.
+  - `federation-registry.ts` is the sole runtime remote loader path for discovered plugin apps.
+
+## Architectural notes
+- This folder sits on boundary-heavy renderer infrastructure: module federation, DOM interaction simulation, and shell persistence.
+- `federation-registry.ts` controls dynamic remote lifecycle and transient fallback behavior, so cache semantics here directly impact app availability.
+- `app-control/dom-interactions.ts` is intentionally renderer-only imperative code and should remain isolated from store/domain logic.
+
+## Surprising discoveries
+- `getFederatedComponent()` caches lazy wrappers before load completion; when loading fails, the cached wrapper resolves to a permanent null component unless external invalidation happens.
+- `app-control/dom-interactions.ts` has grown into a dense multi-mode interaction engine (click/type/scroll/select/hover/get-text/inspect) but remains in one file at 385 LOC.
+- `theme-engine.ts` ends with an unexported `presetToMeta()` helper that is currently dead code.

--- a/docs/deslopify/apps/desktop/src/lib/plan.md
+++ b/docs/deslopify/apps/desktop/src/lib/plan.md
@@ -1,0 +1,53 @@
+# Refactoring Plan — apps/desktop/src/lib
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/lib` is mostly disciplined, but it contains one high-impact reliability bug in federated remote loading and a growing concentration of imperative DOM automation logic. The key outcome is to make app remote loading retry-safe and split dense interaction/runtime modules before they become fragile infrastructure bottlenecks.
+
+## Issues Found (prioritized)
+- **High** — Federated component load failures can become sticky null renders with no automatic retry — `apps/desktop/src/lib/federation-registry.ts:297-309` returns `{ default: () => null }` on failed remote load while keeping the `LazyComp` cached (`cache.set(cacheKey, LazyComp)`). Subsequent renders reuse the same failed wrapper, so transient outages can leave an app blank until manual invalidation/restart. Effort: **S**.
+
+- **Medium** — DOM interaction engine is a near-cap multi-responsibility module — `apps/desktop/src/lib/app-control/dom-interactions.ts:1-385` combines selector/point targeting, synthetic pointer+mouse dispatch, inspect payload building, and action routing in one file. This increases regression risk for app-control tooling changes. Effort: **M**.
+
+- **Medium** — Font preloader eagerly injects all Google font links with no prioritization — `apps/desktop/src/lib/google-fonts.ts:84-92` appends stylesheet links for every mapped family on preload. This front-loads network overhead even if most fonts are never used. Effort: **S**.
+
+- **Low** — Dead code in theme engine (`presetToMeta`) adds noise — `apps/desktop/src/lib/theme-engine.ts:289-297` defines an unexported helper with no callers. Effort: **S**.
+
+## Proposed Refactoring
+1. **Make federation load failures retryable.**
+   - On `loadRemoteModule` failure in `getFederatedComponent`, delete `cacheKey` from `cache`/`resolvedModules` before returning fallback.
+   - Optionally return a lightweight error component with retry affordance instead of permanent null.
+   - Keep existing `refreshTransientRemote()` behavior for explicit invalidation, but don’t require it for transient recovery.
+
+2. **Split `dom-interactions.ts` by concern.**
+   - Target structure:
+     - `app-control/dom/geometry.ts` (rect math + panel lookup)
+     - `app-control/dom/targeting.ts` (selector/point resolution)
+     - `app-control/dom/actions.ts` (click/type/scroll/select/hover/get-text)
+     - `app-control/dom/inspect.ts` (inspection payload building)
+     - thin `dom-interactions.ts` router.
+   - Preserve exported API: `executeAppInteraction`, `getAppPanelRect`.
+
+3. **Introduce lazy font-preload strategy.**
+   - Change `preloadAllGoogleFonts()` to preload only curated “popular” fonts up front, then load others on demand via `loadGoogleFont`.
+   - Keep `loadedFonts` dedupe behavior.
+
+4. **Remove or wire dead theme helper.**
+   - Delete `presetToMeta()` if unused, or export+use it in theme store serialization paths.
+
+## Benefits & Trade-offs
+- Benefits: remote apps recover from transient failures without restart, app-control internals become easier to reason about/test, and theme editor startup network load drops.
+- Trade-offs: splitting DOM utilities introduces additional files and requires careful regression testing for interaction semantics.
+
+## Dependencies & Risks
+- Federation retry changes affect plugin/app loading behavior; verify both dev (`localhost`) and packaged (`sero-ext://`) scenarios.
+- App-control module split may require test updates (`dom-interactions.test.ts`) if internals move.
+- Font preload tuning should be validated against UX expectations in the theme editor (avoid flashing unavailable fonts).
+
+## Next Steps
+1. Land High fix in `federation-registry.ts` (drop failed lazy cache entries and retry on next access).
+2. Add regression tests for transient remote failure → later recovery without restart.
+3. Split `dom-interactions.ts` into focused modules while preserving API.
+4. Optimize `preloadAllGoogleFonts()` strategy.
+5. Remove dead `presetToMeta` helper or connect it to an actual call site.

--- a/docs/deslopify/apps/desktop/src/stores/facts.md
+++ b/docs/deslopify/apps/desktop/src/stores/facts.md
@@ -1,0 +1,35 @@
+# Facts — apps/desktop/src/stores
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`src/stores` is the renderer orchestration layer for Sero’s desktop shell. It owns shell layout state, app discovery state, workspace/session selection, active agent message streams, container/VCS/subagent runtime state, and several cross-app UI bridges (dashboard widgets, feedback, editor open requests, context overrides, model preferences).
+
+## Shape & metrics
+- Total files: 29
+- Total LOC: 5,377
+- Largest file: `apps/desktop/src/stores/agent.ts` (489 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥400 LOC):
+  - `apps/desktop/src/stores/agent.ts` (489)
+  - `apps/desktop/src/stores/app.ts` (460)
+- External dependencies of note:
+  - `zustand` + `zustand/react/shallow`
+  - IPC contracts from `@/types/ipc` (agent/workspace/session/app/plugin/theme/container)
+  - `react-grid-layout` layout types via dashboard store
+- Upstream callers:
+  - Store modules are imported from ~83 files across `apps/desktop/src` + `apps/desktop/electron`.
+  - Most heavily consumed modules are `agent.ts`, `app.ts`, `workspace.ts`, `sessions.ts`.
+- Downstream dependencies:
+  - `window.sero.*` preload APIs are the hard boundary for almost every action in this folder.
+  - `persistLayout()` is used by shell/model/dashboard/session/workspace flows, making this folder central to layout persistence correctness.
+
+## Architectural notes
+- This folder is the renderer side of the React → Zustand → preload → IPC → main pipeline. If store updates and IPC outcomes diverge, shell state can drift from persisted/main-process truth.
+- `agent.ts` and `app.ts` currently act as orchestration hubs (session lifecycle + streaming events; app discovery + plugin-change handling + layout hydration), which increases blast radius for changes.
+- Container lifecycle orchestration in `useSessionAgent` relies on store methods from both `agent` and `container`, matching AD-018’s “container available per workspace session” behavior.
+
+## Surprising discoveries
+- Destructive actions are optimistic in multiple places (`agent.closeSession`, `workspace.closeWorkspace`) and can remove renderer state even if IPC fails.
+- `agent-utils.ts` keeps module-level `pendingMemoryContext` state that is only cleared on `message_start`; session-close/error paths do not explicitly prune leftover entries.
+- A lot of quality work already happened here: no `any`/`@ts-ignore` escapes in production store code, and no source files currently violate the 500 LOC cap.

--- a/docs/deslopify/apps/desktop/src/stores/plan.md
+++ b/docs/deslopify/apps/desktop/src/stores/plan.md
@@ -1,0 +1,63 @@
+# Refactoring Plan — apps/desktop/src/stores
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/stores` is functionally solid and type-safe, but two orchestration hubs (`agent.ts`, `app.ts`) are near the 500-LOC ceiling and a few renderer↔main lifecycle edges can desync on IPC failure. The goal is to keep stores as reliable contract owners by hardening destructive action error handling, extracting repeated agent logic, and splitting near-cap orchestration code before it becomes another hard-rule file-size violation.
+
+## Issues Found (prioritized)
+- **High** — Optimistic destructive actions can leave renderer/main state out of sync on IPC failure — `apps/desktop/src/stores/agent.ts:135-151` removes the local agent entry even when `window.sero.agent.close()` throws, and `apps/desktop/src/stores/workspace.ts:84-92` removes a workspace locally before `window.sero.workspace.close()` succeeds (failure is only logged). This risks ghost sessions/workspaces that reappear after reload and violates the four-layer consistency expectation. Effort: **S**.
+
+- **Medium** — Core orchestration stores are one feature away from the 500-LOC cap — `apps/desktop/src/stores/agent.ts:1-489` and `apps/desktop/src/stores/app.ts:1-460` each mix multiple responsibilities (state, IPC orchestration, hydration/startup utilities, listener wiring), increasing review risk and future refactor cost. Effort: **M**.
+
+- **Medium** — `agent.ts` duplicates optimistic user-message creation and ID generation in three flows — `apps/desktop/src/stores/agent.ts:155-176`, `apps/desktop/src/stores/agent.ts:198-218`, and `apps/desktop/src/stores/agent.ts:338-356`. This duplication already drifted (prompt/steer/collab paths are subtly different) and makes future message-shape changes error-prone. Effort: **S**.
+
+- **Medium** — Module-level pending memory context has no explicit cleanup on session teardown — `apps/desktop/src/stores/agent-utils.ts:108-169` adds per-session entries on `memory_context` and clears only on the next assistant `message_start`. Session close/error paths do not prune stale session keys, so long-lived apps can accumulate dead map entries. Effort: **S**.
+
+- **Low** — Selector helpers return fresh arrays/objects each call, creating avoidable render churn in hot UI paths — e.g. `apps/desktop/src/stores/agent-selectors.ts:25-29` (`useStreamingSessionIds`) and `apps/desktop/src/stores/sessions.ts:230-253` (`useSessionsByWorkspace`). Effort: **S**.
+
+## Proposed Refactoring
+1. **Make destructive actions IPC-result aware before mutating local state.**
+   - Update `closeSession`/`closeWorkspace` paths to either:
+     - commit local removal only after successful IPC, or
+     - keep optimistic updates but roll back on failure.
+   - Add explicit error state updates so the UI can surface failures.
+   - Aligns with Sero’s React→store→preload→main consistency rule.
+
+2. **Split `agent.ts` into orchestration slices under `src/stores/agent/`.**
+   - Keep `agent.ts` as a thin public surface; move prompt lifecycle, model actions, and collaboration hydration into focused modules.
+   - Extract shared helper for optimistic user-message enqueue:
+     - before: repeated `userMessageId` + message append in 3 methods
+     - after: `appendOptimisticUserMessage(sessionId, text, attachments?)`.
+
+3. **Split `app.ts` by ownership boundaries.**
+   - Target shape:
+     - `stores/app/state.ts` (store definition)
+     - `stores/app/layout-hydration.ts` (`loadLayout`)
+     - `stores/app/discovery.ts` (`discoverAndRegisterApps`, plugin-change reconciliation)
+     - `stores/app/listeners.ts` (`listenForNewApps`)
+   - Keep existing exports from `stores/app.ts` as compatibility re-exports.
+
+4. **Add explicit teardown hooks for agent utility module-level maps.**
+   - Introduce `clearAgentSessionBuffers(sessionId)` in `agent-utils.ts` and call it from session close/failure paths.
+   - Also clear buffers on `agent_end` for unknown sessions to avoid stale entries.
+
+5. **Stabilize high-traffic selectors.**
+   - Memoize or derive streaming IDs within store state updates (or use `useShallow` selectors returning stable references).
+   - Move expensive grouping/filtering (`useSessionsByWorkspace`) to memoized component-level selectors when query/session inputs change.
+
+## Benefits & Trade-offs
+- Benefits: stronger renderer/main consistency, fewer ghost-state bugs, easier-to-review store modules, and lower risk of crossing the 500-LOC cap during feature work.
+- Trade-offs: moderate import churn from store-file splits and slightly more indirection when tracing control flow.
+
+## Dependencies & Risks
+- Store split work touches many consumers in `components/layout/**`, `hooks/**`, and app-control bridge code.
+- Error-handling behavior changes can expose latent UI assumptions (some flows currently assume close/remove always succeeds).
+- Any exported API reshaping should preserve public signatures to keep Wave B fixes incremental.
+
+## Next Steps
+1. Land High fix: make `closeSession` and `closeWorkspace` consistent on IPC failure.
+2. Extract optimistic user-message helper and de-duplicate prompt/steer/collab paths.
+3. Add session-buffer teardown for `pendingMemoryContext` in `agent-utils`.
+4. Split `agent.ts` and `app.ts` into submodules before either file crosses 500 LOC.
+5. After fixes, re-run deslopify on `components/layout` (Wave C) with updated store ownership boundaries.

--- a/docs/deslopify/apps/desktop/src/types/facts.md
+++ b/docs/deslopify/apps/desktop/src/types/facts.md
@@ -1,0 +1,46 @@
+# Facts — apps/desktop/src/types
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`src/types` is the renderer-facing contract layer for desktop: it defines IPC payloads,
+channel constants, `window.sero` preload API declarations, and shared domain shapes
+(models, onboarding, collaboration, VCS, plugins, dashboard, etc.). This folder is
+consumed by both renderer stores/components and Electron preload/main modules.
+
+## Shape & metrics
+- Total files: 27
+- Total LOC: 3,323
+- Largest file: `apps/desktop/src/types/ipc.ts` (544 LOC)
+- Files over 500 LOC:
+  - `apps/desktop/src/types/ipc.ts` (544)
+- Near-cap files (≥450 LOC):
+  - `apps/desktop/src/types/electron.d.ts` (492)
+  - `apps/desktop/src/types/ipc-channels.ts` (483)
+- Upstream callers:
+  - `@/types/ipc` imported by ~170 files under `apps/desktop/{src,electron}`
+  - `IpcChannels` imported from `@/types/ipc` (not `@/types/ipc-channels`) in 59 files
+- Downstream dependencies of note:
+  - `@sero/common` (plugin/model validation contracts)
+  - `@mariozechner/pi-agent-core` and `@mariozechner/pi-ai` (model/thinking + local model compat)
+  - `@electron/features/container/core/types` re-exported as canonical `ContainerInfo`
+  - `react-grid-layout` and `react` for dashboard/widget typing
+
+## Architectural notes
+- This folder is a key part of the 4-layer IPC path (types → preload bridge → main handlers).
+  Any drift here cascades into preload and IPC breakage quickly.
+- AD-022 (profiles) is currently represented by duplicated `ProfileInfo` contracts in both
+  renderer and electron feature code (`src/types/ipc.ts` and `electron/features/profile/types.ts`).
+- AD-021 (subagent) types are routed through `ipc.ts` and `electron.d.ts`; declaration hygiene
+  matters because `window.sero` is the renderer’s hard API contract.
+- `ipc.ts` currently mixes domain interfaces, cross-file re-exports, and channel re-exports,
+  making it a "god barrel" that couples unrelated modules.
+
+## Surprising discoveries
+- `apps/desktop/src/types/electron.d.ts` references `SubagentAgentFile` but does not import it
+  (`electron.d.ts:55-56`, `electron.d.ts:343`, `electron.d.ts:345`); this can be masked by
+  `skipLibCheck` and silently weaken preload API typing.
+- `apps/desktop/src/types/plugins.ts` imports `SeroAppManifest` from `./ipc`, while `ipc.ts`
+  re-exports plugin types from `./plugins` (`plugins.ts:1`, `ipc.ts:320`), creating a type-only cycle.
+- Widget manifest shape is duplicated (`dashboard.ts:15` and `sero-apps.ts:10`) instead of sharing
+  a single canonical interface.

--- a/docs/deslopify/apps/desktop/src/types/plan.md
+++ b/docs/deslopify/apps/desktop/src/types/plan.md
@@ -1,0 +1,104 @@
+# Refactoring Plan — apps/desktop/src/types
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/types` is functionally solid but structurally over-coupled: one hard 500-LOC violation,
+a near-cap declaration cluster, and a central `ipc.ts` barrel that now owns too many unrelated
+contracts. The goal is to restore strict contract ownership by splitting `ipc.ts`, removing
+cycles/duplicates, and tightening declaration hygiene so preload + IPC changes remain safe and
+reviewable.
+
+## Issues Found (prioritized)
+- **High** — `ipc.ts` violates the hard 500 LOC cap and mixes too many ownership domains —
+  `apps/desktop/src/types/ipc.ts:1-544` remains above the file-size limit while containing
+  profiles, workspace/session contracts, auth, user-feedback, gateway, app-control exports,
+  and channel re-exports. This is the highest-risk contract surface in Wave A. Effort: **M**.
+
+- **High** — Preload declaration contract has an unimported subagent type masked by declaration skipping —
+  `apps/desktop/src/types/electron.d.ts:55-56` imports subagent types but omits `SubagentAgentFile`,
+  yet `SubagentAgentFile` is used at `electron.d.ts:343` and `electron.d.ts:345`. With
+  `apps/desktop/tsconfig.json` using `skipLibCheck`, this can silently degrade API type safety.
+  Effort: **S**.
+
+- **Medium** — Manual duplicated cross-process contracts create drift risk in profile and user-feedback APIs —
+  `apps/desktop/src/types/ipc.ts:13-27` duplicates `ProfileInfo` from
+  `apps/desktop/electron/features/profile/types.ts:39-49`; user-feedback shapes are mirrored in
+  `apps/desktop/src/types/ipc.ts:410-455` and
+  `plugins/sero-user-feedback-plugin/shared/types.ts:10-72`. This fights the canonical-type rule
+  and increases AD-022/extension drift risk. Effort: **M**.
+
+- **Medium** — Type-layer cycle between `ipc.ts` and `plugins.ts` increases coupling and review complexity —
+  `apps/desktop/src/types/plugins.ts:1` imports `SeroAppManifest` from `./ipc`, while
+  `apps/desktop/src/types/ipc.ts:320` re-exports plugin types from `./plugins`. Effort: **S**.
+
+- **Medium** — `IpcChannels` consumption is routed through the monolithic `ipc.ts` barrel instead of the
+  dedicated channels module — `apps/desktop/src/types/ipc.ts:544` re-exports channels, and 59 files
+  import `IpcChannels` from `@/types/ipc` rather than `@/types/ipc-channels` (example:
+  `apps/desktop/electron/preload/api.ts:2`). This widens dependency fanout and slows safe contract edits.
+  Effort: **M**.
+
+- **Medium** — Widget manifest contract is duplicated across files —
+  `apps/desktop/src/types/dashboard.ts:15-32` (`WidgetManifest`) and
+  `apps/desktop/src/types/sero-apps.ts:10-25` (`SeroWidgetManifest`) define the same shape.
+  Effort: **S**.
+
+- **Low** — `any` leak in LSP preload API declaration weakens strict typing —
+  `apps/desktop/src/types/electron-workspace.d.ts:79` uses `notification: any`.
+  Effort: **S**.
+
+- **Low** — Comment/default mismatch in collaboration debate config —
+  `apps/desktop/src/types/collaboration.ts:50` documents `maxRounds` default as 3, while
+  `DEFAULT_DEBATE_CONFIG.maxRounds` is 1 at `collaboration.ts:60`. Effort: **S**.
+
+## Proposed Refactoring
+1. **Split `ipc.ts` into domain modules and keep `ipc.ts` as a thin compatibility barrel.**
+   - Move concrete interfaces into `src/types/ipc/` (e.g. `profiles.ts`, `workspace.ts`,
+     `sessions.ts`, `auth.ts`, `feedback.ts`, `network.ts`, `github.ts`, `app-control.ts` alias exports).
+   - Keep root `ipc.ts` as re-export-only (target <150 LOC) for migration stability.
+   - Aligns with the Wave A objective and the 4-layer IPC contract discipline.
+
+2. **Fix declaration hygiene in `electron.d.ts` and tighten declaration checking.**
+   - Import `SubagentAgentFile` explicitly and verify all referenced symbols are imported.
+   - Audit for other hidden declaration gaps while touching the file.
+   - Optionally add a focused declaration-check script (without full `skipLibCheck`) for `src/types/*.d.ts`.
+
+3. **Canonicalize duplicated cross-process contracts.**
+   - Promote shared profile/user-feedback transport types to a neutral shared contract module
+     (prefer `@sero/common` for renderer-safe types) and import from both renderer and Electron/plugin sides.
+   - Remove “KEEP IN SYNC” manual duplication comments once canonical source is in place.
+   - Aligns with AD-022 reliability goals and avoids extension drift.
+
+4. **Break the type-only cycle and isolate manifests.**
+   - Change `plugins.ts` to import `SeroAppManifest` from `./sero-apps` directly.
+   - Keep plugin event and plugin metadata types in a one-way dependency chain.
+
+5. **Decouple channel constants from the `ipc.ts` mega-barrel.**
+   - Update imports to use `@/types/ipc-channels` for `IpcChannels`.
+   - Keep `@/types/ipc` for payload/type contracts only.
+   - Further split `ipc-channels.ts` by domain before it crosses 500 LOC.
+
+6. **Remove remaining low-grade type/documentation drift.**
+   - Replace `notification: any` with a stricter type (`unknown` or a dedicated LSP notification shape).
+   - Correct debate config comments to match actual defaults.
+   - Unify widget manifest interface (single source, with alias export if needed).
+
+## Benefits & Trade-offs
+- Benefits: clearer ownership boundaries, lower IPC drift risk, easier preload/main signature reviews,
+  reduced accidental coupling, and stronger declaration safety.
+- Trade-offs: broad import-path churn (many files touch), temporary dual-export compatibility layers,
+  and higher short-term review volume while modules are re-homed.
+
+## Dependencies & Risks
+- Requires coordinated updates with `electron/preload/**` and `electron/ipc/**` imports because this
+  folder is central to both layers.
+- Any type relocation must preserve public import stability (`@/types/ipc`) during migration to avoid
+  breaking 170+ callers in one shot.
+- If shared types move to `@sero/common`, keep them renderer-safe (no Electron/Node runtime imports).
+
+## Next Steps
+1. Execute High item: split `ipc.ts` below 500 LOC with domain modules + compatibility barrel.
+2. Fix `electron.d.ts` subagent type import gap and run typecheck.
+3. Land cycle break (`plugins.ts` → `sero-apps.ts`) and widget-manifest unification.
+4. Start converting `IpcChannels` imports to `@/types/ipc-channels` in preload/ipc modules.
+5. Queue follow-up deslopify for `apps/desktop/electron/preload` next (Wave A step 2).

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -7,7 +7,7 @@ entry links to a `facts.md` and `plan.md` pair.
 
 ## apps/
 - [`apps/desktop/`](./apps/desktop/plan.md)
-  — *Phase 0 baseline map complete — plan created 2026-04-12*
+  — *Wave A reviews complete; Wave B High-only batch plan added 2026-04-12*
   - [`apps/desktop/src/types/`](./apps/desktop/src/types/plan.md)
     — *Wave A contracts review complete — plan created 2026-04-12*
   - [`apps/desktop/src/stores/`](./apps/desktop/src/stores/plan.md)

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -1,0 +1,42 @@
+# Deslopify Index
+
+_Last updated: 2026-04-12_
+
+A living map of senior-architect reviews across the Sero codebase. Each
+entry links to a `facts.md` and `plan.md` pair.
+
+## apps/
+- [`apps/desktop/`](./apps/desktop/plan.md)
+  — *Phase 0 baseline map complete — plan created 2026-04-12*
+  - [`apps/desktop/src/types/`](./apps/desktop/src/types/plan.md)
+    — *Wave A contracts review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/stores/`](./apps/desktop/src/stores/plan.md)
+    — *Wave A renderer orchestration review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/hooks/`](./apps/desktop/src/hooks/plan.md)
+    — *Wave A renderer orchestration review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/lib/`](./apps/desktop/src/lib/plan.md)
+    — *Wave A renderer orchestration review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/preload/`](./apps/desktop/electron/preload/plan.md)
+    — *Wave A contracts review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/ipc/`](./apps/desktop/electron/ipc/plan.md)
+    — *Wave A contracts review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/workspace/`](./apps/desktop/electron/features/workspace/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/agent/`](./apps/desktop/electron/features/agent/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/container/`](./apps/desktop/electron/features/container/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/apps/`](./apps/desktop/electron/features/apps/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/plugins/`](./apps/desktop/electron/features/plugins/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/shared/`](./apps/desktop/electron/shared/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/platform/`](./apps/desktop/electron/platform/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+
+## packages/
+- _No reviews yet._
+
+## plugins/
+- _No reviews yet._

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -42,8 +42,13 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 
 ## Wave B — Fix Core High-Priority Findings
 
-- [ ] Review all Wave A plans together for cross-cutting themes
-- [ ] Group fixes into coherent `fix-slop` batches
+- [x] Review all Wave A plans together for cross-cutting themes
+- [x] Group fixes into coherent `fix-slop` batches
+  - See `docs/deslopify/apps/desktop/plan.md` (`Wave B synthesis — 2026-04-12`) for the grouped High-only batch order:
+    1. IPC contract hardening
+    2. Settings & discovery safety
+    3. Runtime lifecycle correctness
+    4. Security boundary hardening
 - [ ] `fix-slop` High items for `apps/desktop/src/types`
 - [ ] `fix-slop` High items for `apps/desktop/electron/preload`
 - [ ] `fix-slop` High items for `apps/desktop/electron/ipc`
@@ -139,3 +144,4 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 - 2026-04-12: Wave A step 3.1 complete for `apps/desktop/src/stores`. Findings + plan documented at `docs/deslopify/apps/desktop/src/stores/{facts.md,plan.md}` (high: optimistic destructive actions can desync renderer/main state when close IPC fails; medium: near-cap `agent.ts`/`app.ts` orchestration hubs).
 - 2026-04-12: Wave A step 3.2 complete for `apps/desktop/src/hooks`. Findings + plan documented at `docs/deslopify/apps/desktop/src/hooks/{facts.md,plan.md}` (top findings: overloaded `useSessionAgent` orchestration + unbounded workspace file cache map).
 - 2026-04-12: Wave A step 3.3 complete for `apps/desktop/src/lib`. Findings + plan documented at `docs/deslopify/apps/desktop/src/lib/{facts.md,plan.md}` (high: federated component load failure can stick as cached null render without retry).
+- 2026-04-12: Wave B synthesis complete. Cross-cutting themes and grouped High-only `fix-slop` batches documented in `docs/deslopify/apps/desktop/plan.md` (B1 IPC contract hardening; B2 settings/discovery safety; B3 runtime lifecycle correctness; B4 security boundary hardening). `apps/desktop/electron/features/workspace`, `apps/desktop/electron/features/agent`, and `apps/desktop/src/hooks` currently have no High items and are deferred to the first Medium wave unless execution uncovers new Highs.

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -10,34 +10,35 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 - Finish a full **deslopify wave** before starting the matching **fix-slop wave**.
 - Default `fix-slop` scope: **High only** unless explicitly expanded.
 - Re-analyze downstream UI areas after core High items are fixed.
+- Ignore files in `@sero-ai/ui` -  these are Shadcn components
 
 ## Phase 0 — Baseline Map
 
-- [ ] Capture current hotspot inventory for `apps/desktop/src` and `apps/desktop/electron`
-- [ ] Note files over the 500 LOC cap
-- [ ] Note likely contract/boundary hotspots (`types`, `preload`, `ipc`, stores)
-- [ ] Confirm the first wave order before starting
+- [x] Capture current hotspot inventory for `apps/desktop/src` and `apps/desktop/electron`
+- [x] Note files over the 500 LOC cap
+- [x] Note likely contract/boundary hotspots (`types`, `preload`, `ipc`, stores)
+- [x] Confirm the first wave order before starting
 
 ## Wave A — Deslopify Core Contracts and Ownership
 
 ### 1. Contracts and boundaries
-- [ ] `deslopify apps/desktop/src/types`
-- [ ] `deslopify apps/desktop/electron/preload`
-- [ ] `deslopify apps/desktop/electron/ipc`
+- [x] `deslopify apps/desktop/src/types`
+- [x] `deslopify apps/desktop/electron/preload`
+- [x] `deslopify apps/desktop/electron/ipc`
 
 ### 2. Core platform/domain owners
-- [ ] `deslopify apps/desktop/electron/features/workspace`
-- [ ] `deslopify apps/desktop/electron/features/agent`
-- [ ] `deslopify apps/desktop/electron/features/container`
-- [ ] `deslopify apps/desktop/electron/features/apps`
-- [ ] `deslopify apps/desktop/electron/features/plugins`
-- [ ] `deslopify apps/desktop/electron/shared`
-- [ ] `deslopify apps/desktop/electron/platform`
+- [x] `deslopify apps/desktop/electron/features/workspace`
+- [x] `deslopify apps/desktop/electron/features/agent`
+- [x] `deslopify apps/desktop/electron/features/container`
+- [x] `deslopify apps/desktop/electron/features/apps`
+- [x] `deslopify apps/desktop/electron/features/plugins`
+- [x] `deslopify apps/desktop/electron/shared`
+- [x] `deslopify apps/desktop/electron/platform`
 
 ### 3. Renderer orchestration
-- [ ] `deslopify apps/desktop/src/stores`
-- [ ] `deslopify apps/desktop/src/hooks`
-- [ ] `deslopify apps/desktop/src/lib`
+- [x] `deslopify apps/desktop/src/stores`
+- [x] `deslopify apps/desktop/src/hooks`
+- [x] `deslopify apps/desktop/src/lib`
 
 ## Wave B — Fix Core High-Priority Findings
 
@@ -124,3 +125,17 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 ## Progress Notes
 
 - 2026-04-12: Initial tasklist created from the agreed core-first deslopify/fix-slop strategy.
+- 2026-04-12: Phase 0 baseline map completed via deslopify. Hotspot inventory + wave-order confirmation documented at `docs/deslopify/apps/desktop/{facts.md,plan.md}`; `docs/deslopify/index.md` initialized.
+- 2026-04-12: Wave A step 1 complete for `apps/desktop/src/types`. Findings + plan documented at `docs/deslopify/apps/desktop/src/types/{facts.md,plan.md}` (highs: `ipc.ts` 544 LOC cap violation and `electron.d.ts` missing `SubagentAgentFile` import).
+- 2026-04-12: Wave A step 2 complete for `apps/desktop/electron/preload`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/preload/{facts.md,plan.md}` (high: missing compile-time conformance guard between exposed `seroPreloadApi` and declared Sero API contract).
+- 2026-04-12: Wave A step 3 complete for `apps/desktop/electron/ipc`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/ipc/{facts.md,plan.md}` (high: `any`/`as any` type escape hatches in core IPC handlers).
+- 2026-04-12: Wave A step 4.1 complete for `apps/desktop/electron/features/workspace`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/features/workspace/{facts.md,plan.md}` (top findings: near-cap manager + silent cleanup error swallowing).
+- 2026-04-12: Wave A step 4.2 complete for `apps/desktop/electron/features/agent`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/features/agent/{facts.md,plan.md}` (module is mostly healthy; main cleanup is `image-agent.ts` typing/dead global bridge).
+- 2026-04-12: Wave A step 4.3 complete for `apps/desktop/electron/features/container`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/features/container/{facts.md,plan.md}` (highs: unauthenticated 0.0.0.0 proxy exposure + scanner/bridge lifecycle leaks).
+- 2026-04-12: Wave A step 4.4 complete for `apps/desktop/electron/features/apps`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/features/apps/{facts.md,plan.md}` (highs: app-state watcher bootstrap/refcount race + `any` escape hatches in extension helpers).
+- 2026-04-12: Wave A step 4.5 complete for `apps/desktop/electron/features/plugins`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/features/plugins/{facts.md,plan.md}` (highs: plugin discovery topic drift against current docs + settings.json parse/write safety risk in plugin manager).
+- 2026-04-12: Wave A step 4.6 complete for `apps/desktop/electron/shared`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/shared/{facts.md,plan.md}` (high: `settings-helpers` parse-fallback + write paths can clobber malformed `settings.json`; medium: stale cached default model in shared infra after auth refresh).
+- 2026-04-12: Wave A step 4.7 complete for `apps/desktop/electron/platform`. Findings + plan documented at `docs/deslopify/apps/desktop/electron/platform/{facts.md,plan.md}` (high: production CSP currently allows broad inline script/frame sources; medium: extension protocol registry missing uninstall symmetry + duplicated builtin-package detection logic).
+- 2026-04-12: Wave A step 3.1 complete for `apps/desktop/src/stores`. Findings + plan documented at `docs/deslopify/apps/desktop/src/stores/{facts.md,plan.md}` (high: optimistic destructive actions can desync renderer/main state when close IPC fails; medium: near-cap `agent.ts`/`app.ts` orchestration hubs).
+- 2026-04-12: Wave A step 3.2 complete for `apps/desktop/src/hooks`. Findings + plan documented at `docs/deslopify/apps/desktop/src/hooks/{facts.md,plan.md}` (top findings: overloaded `useSessionAgent` orchestration + unbounded workspace file cache map).
+- 2026-04-12: Wave A step 3.3 complete for `apps/desktop/src/lib`. Findings + plan documented at `docs/deslopify/apps/desktop/src/lib/{facts.md,plan.md}` (high: federated component load failure can stick as cached null render without retry).

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -49,20 +49,20 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
     2. Settings & discovery safety
     3. Runtime lifecycle correctness
     4. Security boundary hardening
-- [ ] `fix-slop` High items for `apps/desktop/src/types`
-- [ ] `fix-slop` High items for `apps/desktop/electron/preload`
-- [ ] `fix-slop` High items for `apps/desktop/electron/ipc`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/workspace`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/agent`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/container`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/apps`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/plugins`
-- [ ] `fix-slop` High items for `apps/desktop/electron/shared`
-- [ ] `fix-slop` High items for `apps/desktop/electron/platform`
-- [ ] `fix-slop` High items for `apps/desktop/src/stores`
-- [ ] `fix-slop` High items for `apps/desktop/src/hooks`
-- [ ] `fix-slop` High items for `apps/desktop/src/lib`
-- [ ] Run `pnpm typecheck` after each batch and keep notes linked from the relevant plan
+- [x] `fix-slop` High items for `apps/desktop/src/types`
+- [x] `fix-slop` High items for `apps/desktop/electron/preload`
+- [x] `fix-slop` High items for `apps/desktop/electron/ipc`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/workspace` _(no High findings in Wave A; deferred to Medium wave)_
+- [x] `fix-slop` High items for `apps/desktop/electron/features/agent` _(no High findings in Wave A; deferred to Medium wave)_
+- [x] `fix-slop` High items for `apps/desktop/electron/features/container`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/apps`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/plugins`
+- [x] `fix-slop` High items for `apps/desktop/electron/shared`
+- [x] `fix-slop` High items for `apps/desktop/electron/platform`
+- [x] `fix-slop` High items for `apps/desktop/src/stores`
+- [x] `fix-slop` High items for `apps/desktop/src/hooks` _(no High findings in Wave A; deferred to Medium wave)_
+- [x] `fix-slop` High items for `apps/desktop/src/lib`
+- [x] Run `pnpm typecheck` after each batch and keep notes linked from the relevant plan
 
 ## Wave C — Deslopify Primary Consumers
 
@@ -145,3 +145,4 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 - 2026-04-12: Wave A step 3.2 complete for `apps/desktop/src/hooks`. Findings + plan documented at `docs/deslopify/apps/desktop/src/hooks/{facts.md,plan.md}` (top findings: overloaded `useSessionAgent` orchestration + unbounded workspace file cache map).
 - 2026-04-12: Wave A step 3.3 complete for `apps/desktop/src/lib`. Findings + plan documented at `docs/deslopify/apps/desktop/src/lib/{facts.md,plan.md}` (high: federated component load failure can stick as cached null render without retry).
 - 2026-04-12: Wave B synthesis complete. Cross-cutting themes and grouped High-only `fix-slop` batches documented in `docs/deslopify/apps/desktop/plan.md` (B1 IPC contract hardening; B2 settings/discovery safety; B3 runtime lifecycle correctness; B4 security boundary hardening). `apps/desktop/electron/features/workspace`, `apps/desktop/electron/features/agent`, and `apps/desktop/src/hooks` currently have no High items and are deferred to the first Medium wave unless execution uncovers new Highs.
+- 2026-04-12: Wave B High fixes implemented across core contracts/runtime/security. Highlights: `src/types/ipc.ts` reduced below 500 LOC via `src/types/user-feedback.ts`; preload compile-time API conformance guard added; IPC/app-extension `any` escape hatches removed; plugin discovery tag updated to `sero-agent-plugin`; settings parsing made non-destructive/fail-fast in shared + plugin flows; container proxy/scanner lifecycle hardened; production CSP narrowed; destructive store actions now IPC-success gated; federation remote load failure now retryable. Monorepo `pnpm typecheck` passes.


### PR DESCRIPTION
## Summary
- complete Wave B high-priority deslopify fixes across desktop core contracts, preload/ipc boundaries, runtime lifecycle, and security hardening
- split `apps/desktop/src/types/ipc.ts` below the 500 LOC cap by extracting user-feedback contracts to `apps/desktop/src/types/user-feedback.ts`
- add compile-time preload contract enforcement (`satisfies SeroAPI`) and tighten multiple IPC/app-extension `any` escape hatches
- harden plugin discovery/settings safety (`sero-agent-plugin` taxonomy + non-destructive settings parse behavior)
- improve runtime correctness for app-state watcher lifecycle, container scanner/bridge teardown, store close flows, and federation remote retry behavior
- tighten production CSP and reduce container proxy exposure risk
- mark Wave B tasklist items complete in `docs/plans/apps-desktop-deslopify-tasklist.md`

## Validation
- `cd apps/desktop && pnpm typecheck`
- `pnpm typecheck`

## Notes
- `apps/desktop/electron/features/workspace`, `apps/desktop/electron/features/agent`, and `apps/desktop/src/hooks` had no Wave A High findings and remain deferred to the first Medium wave per plan.
