### PR TITLE
Wave D — Follow-ups — Gateway Scope, Recovery UX, and Coverage

### DIFF
--- a/apps/desktop/electron/__tests__/features/auth/github/auth-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/auth/github/auth-manager.test.ts
@@ -1,0 +1,158 @@
+import { existsSync } from 'fs';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+interface SafeStorageOptions {
+  available: boolean;
+}
+
+function createSafeStorageMock(options: SafeStorageOptions) {
+  return {
+    isEncryptionAvailable: vi.fn(() => options.available),
+    encryptString: vi.fn((value: string) => Buffer.from(`enc:${value}`)),
+    decryptString: vi.fn((value: Buffer) => {
+      const decoded = value.toString();
+      if (!decoded.startsWith('enc:')) {
+        throw new Error('Corrupt encrypted payload');
+      }
+      return decoded.slice(4);
+    }),
+  };
+}
+
+describe('GitHubAuthManager', () => {
+  let tmpDir: string | null = null;
+
+  async function importManager(options: SafeStorageOptions) {
+    if (!tmpDir) {
+      throw new Error('tmpDir not initialized');
+    }
+
+    vi.resetModules();
+
+    const safeStorage = createSafeStorageMock(options);
+    const shell = { openExternal: vi.fn() };
+    const agentDir = path.join(tmpDir, 'agent');
+
+    vi.doMock('electron', () => ({ safeStorage, shell }));
+    vi.doMock('@electron/platform/env', () => ({
+      SERO_HOME: tmpDir,
+      SERO_AGENT_DIR: agentDir,
+    }));
+
+    const mod = await import('@electron/features/auth/github/auth-manager');
+    return {
+      GitHubAuthManager: mod.GitHubAuthManager,
+      safeStorage,
+      shell,
+      tokenFile: path.join(agentDir, 'github-auth.json'),
+      legacyTokenFile: path.join(tmpDir, 'github-auth.json'),
+    };
+  }
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.unmock('electron');
+    vi.unmock('@electron/platform/env');
+
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  it('does not load cached tokens when secure storage is unavailable at startup', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'github-auth-'));
+
+    const encrypted = Buffer.from('enc:token-123').toString('base64');
+    const agentDir = path.join(tmpDir, 'agent');
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, 'github-auth.json'),
+      JSON.stringify({ encrypted, username: 'octocat', scopes: 'repo', createdAt: '2026-01-01T00:00:00.000Z' }),
+      'utf8',
+    );
+
+    const { GitHubAuthManager, tokenFile } = await importManager({ available: false });
+    const manager = new GitHubAuthManager();
+
+    expect(manager.getToken()).toBeNull();
+    expect(manager.getStatus()).toEqual({ authenticated: false });
+    expect(existsSync(tokenFile)).toBe(true);
+  });
+
+  it('clears a corrupt cached token file on startup', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'github-auth-corrupt-'));
+
+    const agentDir = path.join(tmpDir, 'agent');
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(path.join(agentDir, 'github-auth.json'), '{not-valid-json', 'utf8');
+
+    const { GitHubAuthManager, tokenFile } = await importManager({ available: true });
+    const manager = new GitHubAuthManager();
+
+    expect(manager.getToken()).toBeNull();
+    expect(manager.getStatus()).toEqual({ authenticated: false });
+    expect(existsSync(tokenFile)).toBe(false);
+  });
+
+  it('fails login clearly when secure storage cannot persist the token', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'github-auth-login-'));
+
+    const { GitHubAuthManager } = await importManager({ available: false });
+    const manager = new GitHubAuthManager() as unknown as {
+      login: (onProgress: (event: unknown) => void) => Promise<void>;
+      getToken: () => string | null;
+      getStatus: () => { authenticated: boolean; username?: string };
+      requestDeviceCode: () => Promise<{ user_code: string; verification_uri: string; expires_in: number; interval: number; device_code: string }>;
+      pollForToken: () => Promise<string>;
+      fetchUser: () => Promise<{ login: string }>;
+    };
+
+    manager.requestDeviceCode = vi.fn().mockResolvedValue({
+      device_code: 'device-code',
+      user_code: 'CODE-1234',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    });
+    manager.pollForToken = vi.fn().mockResolvedValue('gho_test_token');
+    manager.fetchUser = vi.fn().mockResolvedValue({ login: 'octocat' });
+
+    await expect(manager.login(vi.fn())).rejects.toThrow(
+      'Secure storage is unavailable, so GitHub auth cannot persist your token safely.',
+    );
+    expect(manager.getToken()).toBeNull();
+    expect(manager.getStatus()).toEqual({ authenticated: false });
+  });
+
+  it('removes both current and legacy token files on logout', async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'github-auth-logout-'));
+
+    const { GitHubAuthManager, tokenFile, legacyTokenFile } = await importManager({ available: true });
+    await fs.mkdir(path.dirname(tokenFile), { recursive: true });
+
+    const stored = JSON.stringify({
+      encrypted: Buffer.from('enc:token-123').toString('base64'),
+      username: 'octocat',
+      scopes: 'repo',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    await fs.writeFile(tokenFile, stored, 'utf8');
+    await fs.writeFile(legacyTokenFile, stored, 'utf8');
+
+    const manager = new GitHubAuthManager();
+    expect(manager.getStatus()).toEqual({ authenticated: true, username: 'octocat' });
+
+    manager.logout();
+
+    expect(existsSync(tokenFile)).toBe(false);
+    expect(existsSync(legacyTokenFile)).toBe(false);
+    expect(manager.getStatus()).toEqual({ authenticated: false });
+  });
+});

--- a/apps/desktop/electron/__tests__/features/gateway/access-control.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/access-control.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  authorizeArtifactFromSession,
+  authorizeArtifactsFromSession,
+  authorizeSessionFromWorkspace,
+  hasArtifactAccess,
+  hasSessionAccess,
+  type GatewayAccessScope,
+} from '@electron/features/gateway/server/access-control';
+
+function createScope(workspaceIds: string[] | null): GatewayAccessScope {
+  return {
+    authorizedWorkspaceIds: workspaceIds ? new Set(workspaceIds) : null,
+    authorizedSessions: new Map(),
+    authorizedArtifacts: new Map(),
+  };
+}
+
+describe('gateway access-control provenance', () => {
+  it('requires workspace authorization before a session can be granted', () => {
+    const scopedAccess = createScope(['workspace-a']);
+
+    expect(() => {
+      authorizeSessionFromWorkspace(scopedAccess, 'workspace-b', 'session-b');
+    }).toThrow('Cannot authorize session session-b for unauthorized workspace workspace-b');
+    expect(hasSessionAccess(scopedAccess, 'session-b')).toBe(false);
+
+    authorizeSessionFromWorkspace(scopedAccess, 'workspace-a', 'session-a');
+
+    expect(hasSessionAccess(scopedAccess, 'session-a')).toBe(true);
+    expect(scopedAccess.authorizedSessions.get('session-a')).toBe('workspace-a');
+  });
+
+  it('requires prior session authorization before artifacts can be granted', () => {
+    const accessScope = createScope(null);
+
+    expect(() => {
+      authorizeArtifactFromSession(accessScope, 'session-a', 'artifact-a');
+    }).toThrow('Cannot authorize artifact artifact-a without prior session access for session-a');
+    expect(hasArtifactAccess(accessScope, 'artifact-a')).toBe(false);
+
+    authorizeSessionFromWorkspace(accessScope, 'workspace-a', 'session-a');
+    authorizeArtifactsFromSession(accessScope, 'session-a', ['artifact-a', 'artifact-b']);
+
+    expect(hasArtifactAccess(accessScope, 'artifact-a')).toBe(true);
+    expect(hasArtifactAccess(accessScope, 'artifact-b')).toBe(true);
+    expect(accessScope.authorizedArtifacts.get('artifact-b')).toBe('session-a');
+  });
+});

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
@@ -1,0 +1,391 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { WebSocket, type RawData } from 'ws';
+
+import { GatewayServer, type GatewayAgentOps } from '@electron/features/gateway';
+import type { GatewayPushEvent, GatewayResponse } from '@electron/features/gateway/server/protocol';
+
+interface TestHarness {
+  server: GatewayServer;
+  port: number;
+  tmpDir: string;
+}
+
+interface GatewayMessageBase {
+  type: string;
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+function waitForClose(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    ws.once('close', () => resolve());
+  });
+}
+
+function waitForMessage<T extends GatewayMessageBase>(ws: WebSocket): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      reject(new Error('Timed out waiting for gateway message'));
+    }, 2000);
+
+    const onMessage = (data: RawData) => {
+      clearTimeout(timeout);
+      ws.off('error', onError);
+      resolve(JSON.parse(data.toString()) as T);
+    };
+
+    const onError = (error: Error) => {
+      clearTimeout(timeout);
+      ws.off('message', onMessage);
+      reject(error);
+    };
+
+    ws.once('message', onMessage);
+    ws.once('error', onError);
+  });
+}
+
+async function sendRequest<T extends GatewayMessageBase>(ws: WebSocket, request: Record<string, unknown>): Promise<T> {
+  const responsePromise = waitForMessage<T>(ws);
+  ws.send(JSON.stringify(request));
+  return responsePromise;
+}
+
+async function connectClient(port: number, token: string): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  await waitForOpen(ws);
+
+  const response = await sendRequest<GatewayResponse>(ws, {
+    type: 'connect',
+    token,
+    clientType: 'web',
+    clientId: `test-${Date.now()}`,
+  });
+
+  expect(response).toEqual({ type: 'ok', requestType: 'connect' });
+  return ws;
+}
+
+function createAgentOps(): GatewayAgentOps {
+  const workspaces = [
+    { id: 'workspace-a', name: 'Workspace A', path: '/workspace-a' },
+    { id: 'workspace-b', name: 'Workspace B', path: '/workspace-b' },
+  ];
+  const sessionWorkspaceIds = new Map([
+    ['session-a', 'workspace-a'],
+    ['session-b', 'workspace-b'],
+  ]);
+  const sessionsByWorkspace = new Map([
+    ['workspace-a', [{ id: 'session-a', name: 'Session A', firstMessage: 'hello from A' }]],
+    ['workspace-b', [{ id: 'session-b', name: 'Session B', firstMessage: 'hello from B' }]],
+  ]);
+  const historyBySession = new Map<string, Array<{
+    id: string;
+    type: 'user' | 'assistant' | 'system';
+    text: string;
+    timestamp: number;
+  }>>([
+    ['session-a', [{ id: 'msg-a', type: 'user', text: 'hello a', timestamp: 1 }]],
+    ['session-b', [{ id: 'msg-b', type: 'user', text: 'hello b', timestamp: 2 }]],
+  ]);
+  const artifactsBySession = new Map([
+    ['session-a', [{
+      id: 'artifact-a-1',
+      type: 'image',
+      title: 'Artifact A',
+      timestamp: '2026-04-12T00:00:00.000Z',
+      mimeType: 'image/png',
+    }]],
+    ['session-b', [{
+      id: 'artifact-b-1',
+      type: 'image',
+      title: 'Artifact B',
+      timestamp: '2026-04-12T00:00:00.000Z',
+      mimeType: 'image/png',
+    }]],
+  ]);
+  const artifactContents = new Map([
+    ['artifact-a-1', { base64: 'AAAA', mimeType: 'image/png', title: 'Artifact A' }],
+    ['artifact-b-1', { base64: 'BBBB', mimeType: 'image/png', title: 'Artifact B' }],
+  ]);
+
+  function assertSessionWorkspace(workspaceId: string, sessionId: string): void {
+    const actualWorkspaceId = sessionWorkspaceIds.get(sessionId);
+    if (!actualWorkspaceId) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+    if (actualWorkspaceId !== workspaceId) {
+      throw new Error(`Session ${sessionId} is bound to workspace ${actualWorkspaceId}, not ${workspaceId}`);
+    }
+  }
+
+  return {
+    openSession: async (sessionId, workspaceId) => {
+      const existingWorkspaceId = sessionWorkspaceIds.get(sessionId);
+      if (existingWorkspaceId && existingWorkspaceId !== workspaceId) {
+        throw new Error(`Session ${sessionId} is bound to workspace ${existingWorkspaceId}, not ${workspaceId}`);
+      }
+      sessionWorkspaceIds.set(sessionId, workspaceId);
+      if (!sessionsByWorkspace.has(workspaceId)) {
+        sessionsByWorkspace.set(workspaceId, []);
+      }
+    },
+    prompt: async () => {},
+    steer: async () => {},
+    abort: async () => {},
+    listWorkspaces: async () => workspaces,
+    listSessions: async (workspaceId) => sessionsByWorkspace.get(workspaceId) ?? [],
+    createSession: async (workspaceId, name) => {
+      const sessionId = `created-${workspaceId}`;
+      sessionWorkspaceIds.set(sessionId, workspaceId);
+      const sessions = sessionsByWorkspace.get(workspaceId) ?? [];
+      sessionsByWorkspace.set(workspaceId, [...sessions, { id: sessionId, name: name ?? '', firstMessage: '' }]);
+      historyBySession.set(sessionId, []);
+      return { id: sessionId, name: name ?? '' };
+    },
+    listFiles: async () => [],
+    readFile: async () => ({ content: '', encoding: 'utf8', mimeType: 'text/plain', size: 0 }),
+    listArtifacts: async (sessionId) => artifactsBySession.get(sessionId) ?? [],
+    getArtifact: async (artifactId) => artifactContents.get(artifactId) ?? null,
+    getSessionHistory: async (workspaceId, sessionId) => {
+      assertSessionWorkspace(workspaceId, sessionId);
+      return historyBySession.get(sessionId) ?? [];
+    },
+  };
+}
+
+async function createHarness(): Promise<TestHarness> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'gateway-integration-test-'));
+  const server = new GatewayServer({
+    port: 0,
+    host: '127.0.0.1',
+    tokenPath: path.join(tmpDir, 'gateway-token.txt'),
+    configDir: tmpDir,
+  });
+  server.setAgentOps(createAgentOps());
+  await server.start();
+
+  const port = Number((server as any).httpServer?.address()?.port);
+  if (!port) {
+    throw new Error('Failed to determine gateway test port');
+  }
+
+  return { server, port, tmpDir };
+}
+
+describe('GatewayServer scoped authorization flows', () => {
+  const harnesses: TestHarness[] = [];
+  const sockets: WebSocket[] = [];
+
+  afterEach(async () => {
+    await Promise.all(sockets.splice(0).map(async (ws) => {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close();
+        await waitForClose(ws);
+      }
+    }));
+
+    await Promise.all(harnesses.splice(0).map(async ({ server, tmpDir }) => {
+      await server.stop();
+      await rm(tmpDir, { recursive: true, force: true });
+    }));
+  });
+
+  it('restricts scoped tokens to authorized workspaces across session and artifact flows', async () => {
+    const harness = await createHarness();
+    harnesses.push(harness);
+
+    const scopedToken = harness.server.getAuth().webTokens.create(['workspace-a'], 'Workspace A only').token;
+    const ws = await connectClient(harness.port, scopedToken);
+    sockets.push(ws);
+
+    const workspaces = await sendRequest<GatewayResponse>(ws, { type: 'list_workspaces' });
+    expect(workspaces).toEqual({
+      type: 'ok',
+      requestType: 'list_workspaces',
+      data: [{ id: 'workspace-a', name: 'Workspace A', path: '/workspace-a' }],
+    });
+
+    const sessions = await sendRequest<GatewayResponse>(ws, {
+      type: 'list_sessions',
+      workspaceId: 'workspace-a',
+    });
+    expect(sessions).toEqual({
+      type: 'ok',
+      requestType: 'list_sessions',
+      data: [{ id: 'session-a', name: 'Session A', firstMessage: 'hello from A' }],
+    });
+
+    const steerOk = await sendRequest<GatewayResponse>(ws, {
+      type: 'steer',
+      sessionId: 'session-a',
+      text: 'continue',
+    });
+    expect(steerOk).toEqual({ type: 'ok', requestType: 'steer' });
+
+    const abortOk = await sendRequest<GatewayResponse>(ws, {
+      type: 'abort',
+      sessionId: 'session-a',
+    });
+    expect(abortOk).toEqual({ type: 'ok', requestType: 'abort' });
+
+    const history = await sendRequest<GatewayResponse>(ws, {
+      type: 'get_session_history',
+      workspaceId: 'workspace-a',
+      sessionId: 'session-a',
+    });
+    expect(history).toEqual({
+      type: 'ok',
+      requestType: 'get_session_history',
+      data: [{ id: 'msg-a', type: 'user', text: 'hello a', timestamp: 1 }],
+    });
+
+    const artifactEventPromise = waitForMessage<GatewayPushEvent>(ws);
+    harness.server.broadcastEvent({
+      type: 'artifact_added',
+      sessionId: 'session-a',
+      artifactId: 'artifact-a-1',
+      artifactType: 'image',
+      title: 'Artifact A',
+    });
+    expect(await artifactEventPromise).toEqual({
+      type: 'artifact_added',
+      sessionId: 'session-a',
+      artifactId: 'artifact-a-1',
+      artifactType: 'image',
+      title: 'Artifact A',
+    });
+
+    const artifact = await sendRequest<GatewayResponse>(ws, {
+      type: 'get_artifact',
+      artifactId: 'artifact-a-1',
+    });
+    expect(artifact).toEqual({
+      type: 'ok',
+      requestType: 'get_artifact',
+      data: { base64: 'AAAA', mimeType: 'image/png', title: 'Artifact A' },
+    });
+
+    const foreignWorkspace = await sendRequest<GatewayResponse>(ws, {
+      type: 'list_sessions',
+      workspaceId: 'workspace-b',
+    });
+    expect(foreignWorkspace).toEqual({
+      type: 'error',
+      requestType: 'list_sessions',
+      message: 'Workspace not authorized: workspace-b',
+    });
+
+    const foreignHistory = await sendRequest<GatewayResponse>(ws, {
+      type: 'get_session_history',
+      workspaceId: 'workspace-a',
+      sessionId: 'session-b',
+    });
+    expect(foreignHistory).toEqual({
+      type: 'error',
+      requestType: 'get_session_history',
+      message: 'Session session-b is bound to workspace workspace-b, not workspace-a',
+    });
+
+    const foreignSteer = await sendRequest<GatewayResponse>(ws, {
+      type: 'steer',
+      sessionId: 'session-b',
+      text: 'nope',
+    });
+    expect(foreignSteer).toEqual({
+      type: 'error',
+      requestType: 'steer',
+      message: 'Session not authorized: session-b',
+    });
+  });
+
+  it('allows master tokens to authorize and access sessions across workspaces', async () => {
+    const harness = await createHarness();
+    harnesses.push(harness);
+
+    const ws = await connectClient(harness.port, harness.server.getToken());
+    sockets.push(ws);
+
+    const workspaces = await sendRequest<GatewayResponse>(ws, { type: 'list_workspaces' });
+    expect(workspaces).toEqual({
+      type: 'ok',
+      requestType: 'list_workspaces',
+      data: [
+        { id: 'workspace-a', name: 'Workspace A', path: '/workspace-a' },
+        { id: 'workspace-b', name: 'Workspace B', path: '/workspace-b' },
+      ],
+    });
+
+    const sessions = await sendRequest<GatewayResponse>(ws, {
+      type: 'list_sessions',
+      workspaceId: 'workspace-b',
+    });
+    expect(sessions).toEqual({
+      type: 'ok',
+      requestType: 'list_sessions',
+      data: [{ id: 'session-b', name: 'Session B', firstMessage: 'hello from B' }],
+    });
+
+    const history = await sendRequest<GatewayResponse>(ws, {
+      type: 'get_session_history',
+      workspaceId: 'workspace-b',
+      sessionId: 'session-b',
+    });
+    expect(history).toEqual({
+      type: 'ok',
+      requestType: 'get_session_history',
+      data: [{ id: 'msg-b', type: 'user', text: 'hello b', timestamp: 2 }],
+    });
+
+    const steer = await sendRequest<GatewayResponse>(ws, {
+      type: 'steer',
+      sessionId: 'session-b',
+      text: 'continue',
+    });
+    expect(steer).toEqual({ type: 'ok', requestType: 'steer' });
+
+    const artifactEventPromise = waitForMessage<GatewayPushEvent>(ws);
+    harness.server.broadcastEvent({
+      type: 'artifact_added',
+      sessionId: 'session-b',
+      artifactId: 'artifact-b-1',
+      artifactType: 'image',
+      title: 'Artifact B',
+    });
+    expect(await artifactEventPromise).toEqual({
+      type: 'artifact_added',
+      sessionId: 'session-b',
+      artifactId: 'artifact-b-1',
+      artifactType: 'image',
+      title: 'Artifact B',
+    });
+
+    const artifact = await sendRequest<GatewayResponse>(ws, {
+      type: 'get_artifact',
+      artifactId: 'artifact-b-1',
+    });
+    expect(artifact).toEqual({
+      type: 'ok',
+      requestType: 'get_artifact',
+      data: { base64: 'BBBB', mimeType: 'image/png', title: 'Artifact B' },
+    });
+  });
+});

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
@@ -258,6 +258,18 @@ describe('GatewayServer scoped authorization flows', () => {
       data: [{ id: 'msg-a', type: 'user', text: 'hello a', timestamp: 1 }],
     });
 
+    const liveEventPromise = waitForMessage<GatewayPushEvent>(ws);
+    harness.server.pushEvent('session-a', {
+      type: 'text_delta',
+      sessionId: 'session-a',
+      delta: 'live update',
+    });
+    expect(await liveEventPromise).toEqual({
+      type: 'text_delta',
+      sessionId: 'session-a',
+      delta: 'live update',
+    });
+
     const artifactEventPromise = waitForMessage<GatewayPushEvent>(ws);
     harness.server.broadcastEvent({
       type: 'artifact_added',

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-ops.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-ops.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   workspaceManager: {
@@ -32,7 +32,36 @@ vi.mock('@mariozechner/pi-coding-agent', () => ({
   SessionManager: mocks.sessionManager,
 }));
 
-describe('buildGatewayOps.getSessionHistory', () => {
+describe('buildGatewayOps', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reuses an existing on-disk session when opening by session ID', async () => {
+    const { buildGatewayOps } = await import('@electron/ipc/gateway/gateway-ops');
+
+    mocks.workspaceManager.getPath.mockReturnValue('/workspace-a');
+    mocks.sessionManager.list.mockResolvedValue([
+      { id: 'session-123', cwd: '/workspace-a', path: '/sessions/session-123.jsonl' },
+    ]);
+
+    const openSessionInternal = vi.fn().mockResolvedValue(undefined);
+    const pool = {
+      has: vi.fn(),
+      get: vi.fn().mockReturnValue(undefined),
+    };
+
+    const ops = buildGatewayOps(pool, openSessionInternal);
+    await ops.openSession('session-123', 'workspace-a');
+
+    expect(mocks.sessionManager.create).not.toHaveBeenCalled();
+    expect(openSessionInternal).toHaveBeenCalledWith(
+      'session-123',
+      '/sessions/session-123.jsonl',
+      'workspace-a',
+    );
+  });
+
   it('rejects pooled sessions whose workspace does not match the requested workspace', async () => {
     const { buildGatewayOps } = await import('@electron/ipc/gateway/gateway-ops');
 

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-ops.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-ops.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  workspaceManager: {
+    getPath: vi.fn(),
+  },
+  containerManager: {
+    exec: vi.fn(),
+  },
+  artifactRegistry: {
+    list: vi.fn(),
+    get: vi.fn(),
+  },
+  sessionManager: {
+    list: vi.fn(),
+    open: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock('@electron/features/workspace/manager', () => ({
+  workspaceManager: mocks.workspaceManager,
+}));
+
+vi.mock('@electron/shared/infra/shared-infra', () => ({
+  containerManager: mocks.containerManager,
+  artifactRegistry: mocks.artifactRegistry,
+  SERO_SESSION_DIR: '/tmp/sero-test-sessions',
+}));
+
+vi.mock('@mariozechner/pi-coding-agent', () => ({
+  SessionManager: mocks.sessionManager,
+}));
+
+describe('buildGatewayOps.getSessionHistory', () => {
+  it('rejects pooled sessions whose workspace does not match the requested workspace', async () => {
+    const { buildGatewayOps } = await import('@electron/ipc/gateway/gateway-ops');
+
+    const pool = {
+      has: vi.fn(),
+      get: vi.fn().mockReturnValue({
+        workspaceId: 'workspace-b',
+        session: { messages: [] },
+      }),
+    };
+
+    const ops = buildGatewayOps(pool, vi.fn());
+
+    await expect(
+      ops.getSessionHistory('workspace-a', 'session-123'),
+    ).rejects.toThrow(
+      'Session session-123 is bound to workspace workspace-b, not workspace-a',
+    );
+
+    expect(mocks.workspaceManager.getPath).not.toHaveBeenCalled();
+    expect(mocks.sessionManager.list).not.toHaveBeenCalled();
+    expect(mocks.sessionManager.open).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { WebSocket } from 'ws';
+
+import { GatewayServer } from '@electron/features/gateway';
+
+describe('GatewayServer artifact authorization', () => {
+  let tmpDir: string | null = null;
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  it('authorizes artifact IDs from artifact_added push events for subscribed clients', async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'gateway-server-test-'));
+
+    const server = new GatewayServer({
+      port: 18800,
+      host: '127.0.0.1',
+      tokenPath: path.join(tmpDir, 'gateway-token.txt'),
+      configDir: tmpDir,
+    });
+
+    const authorizedWs = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    } as unknown as WebSocket;
+
+    const unauthorizedWs = {
+      readyState: WebSocket.OPEN,
+      send: vi.fn(),
+      close: vi.fn(),
+    } as unknown as WebSocket;
+
+    const authorizedClient = {
+      ws: authorizedWs,
+      clientType: 'web',
+      clientId: 'authorized',
+      authenticated: true,
+      isMasterAuth: false,
+      authorizedWorkspaceIds: new Set(['workspace-1']),
+      authorizedSessionIds: new Set(['session-1']),
+      authorizedArtifactIds: new Set<string>(),
+      subscribedSessions: new Set(['session-1']),
+      remoteIp: '127.0.0.1',
+      lastActivity: Date.now(),
+    };
+
+    const unauthorizedClient = {
+      ws: unauthorizedWs,
+      clientType: 'web',
+      clientId: 'unauthorized',
+      authenticated: true,
+      isMasterAuth: false,
+      authorizedWorkspaceIds: new Set(['workspace-1']),
+      authorizedSessionIds: new Set<string>(),
+      authorizedArtifactIds: new Set<string>(),
+      subscribedSessions: new Set(['session-1']),
+      remoteIp: '127.0.0.1',
+      lastActivity: Date.now(),
+    };
+
+    (server as any).clients.set(authorizedWs, authorizedClient);
+    (server as any).clients.set(unauthorizedWs, unauthorizedClient);
+
+    server.pushEvent('session-1', {
+      type: 'artifact_added',
+      sessionId: 'session-1',
+      artifactId: 'artifact-1',
+      artifactType: 'image',
+      title: 'Screenshot',
+    });
+
+    expect(authorizedClient.authorizedArtifactIds.has('artifact-1')).toBe(true);
+    expect(authorizedWs.send).toHaveBeenCalledOnce();
+    expect(unauthorizedClient.authorizedArtifactIds.has('artifact-1')).toBe(false);
+    expect(unauthorizedWs.send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
@@ -45,8 +45,8 @@ describe('GatewayServer artifact authorization', () => {
       authenticated: true,
       isMasterAuth: false,
       authorizedWorkspaceIds: new Set(['workspace-1']),
-      authorizedSessionIds: new Set(['session-1']),
-      authorizedArtifactIds: new Set<string>(),
+      authorizedSessions: new Map([['session-1', 'workspace-1']]),
+      authorizedArtifacts: new Map<string, string>(),
       subscribedSessions: new Set(['session-1']),
       remoteIp: '127.0.0.1',
       lastActivity: Date.now(),
@@ -59,8 +59,8 @@ describe('GatewayServer artifact authorization', () => {
       authenticated: true,
       isMasterAuth: false,
       authorizedWorkspaceIds: new Set(['workspace-1']),
-      authorizedSessionIds: new Set<string>(),
-      authorizedArtifactIds: new Set<string>(),
+      authorizedSessions: new Map<string, string>(),
+      authorizedArtifacts: new Map<string, string>(),
       subscribedSessions: new Set(['session-1']),
       remoteIp: '127.0.0.1',
       lastActivity: Date.now(),
@@ -77,9 +77,9 @@ describe('GatewayServer artifact authorization', () => {
       title: 'Screenshot',
     });
 
-    expect(authorizedClient.authorizedArtifactIds.has('artifact-1')).toBe(true);
+    expect(authorizedClient.authorizedArtifacts.has('artifact-1')).toBe(true);
     expect(authorizedWs.send).toHaveBeenCalledOnce();
-    expect(unauthorizedClient.authorizedArtifactIds.has('artifact-1')).toBe(false);
+    expect(unauthorizedClient.authorizedArtifacts.has('artifact-1')).toBe(false);
     expect(unauthorizedWs.send).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/electron/__tests__/features/gateway/protocol.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/protocol.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateRequest } from '@electron/features/gateway/server/protocol';
+
+describe('gateway protocol request validation', () => {
+  it('accepts valid sensitive request payloads', () => {
+    expect(
+      validateRequest({ type: 'connect', token: 'secret-token', clientType: 'web', clientId: 'client-1' }),
+    ).toEqual({ type: 'connect', token: 'secret-token', clientType: 'web', clientId: 'client-1' });
+
+    expect(
+      validateRequest({
+        type: 'prompt',
+        workspaceId: 'workspace-a',
+        sessionId: 'session-a',
+        text: 'hello',
+        images: [{ data: 'Zm9v', mimeType: 'image/png' }],
+        idempotencyKey: 'idem-1',
+      }),
+    ).toEqual({
+      type: 'prompt',
+      workspaceId: 'workspace-a',
+      sessionId: 'session-a',
+      text: 'hello',
+      images: [{ data: 'Zm9v', mimeType: 'image/png' }],
+      idempotencyKey: 'idem-1',
+    });
+
+    expect(
+      validateRequest({
+        type: 'create_web_token',
+        workspaceIds: ['workspace-a', 'workspace-b'],
+        label: 'Shared access',
+        expiryDays: 3,
+      }),
+    ).toEqual({
+      type: 'create_web_token',
+      workspaceIds: ['workspace-a', 'workspace-b'],
+      label: 'Shared access',
+      expiryDays: 3,
+    });
+  });
+
+  it.each([
+    ['connect without token', { type: 'connect', clientType: 'web' }],
+    ['connect with invalid clientType', { type: 'connect', token: 'secret-token', clientType: 'desktop' }],
+    ['prompt without workspaceId', { type: 'prompt', sessionId: 'session-a', text: 'hi' }],
+    ['prompt with malformed images', {
+      type: 'prompt',
+      workspaceId: 'workspace-a',
+      sessionId: 'session-a',
+      text: 'hi',
+      images: [{ data: 1, mimeType: 'image/png' }],
+    }],
+    ['get_session_history without sessionId', { type: 'get_session_history', workspaceId: 'workspace-a' }],
+    ['create_web_token without workspaceIds', { type: 'create_web_token', label: 'Shared access' }],
+    ['create_web_token with empty workspaceIds', { type: 'create_web_token', workspaceIds: [] }],
+    ['create_web_token with invalid workspaceIds', { type: 'create_web_token', workspaceIds: ['workspace-a', 3] }],
+    ['create_web_token with invalid expiryDays', {
+      type: 'create_web_token',
+      workspaceIds: ['workspace-a'],
+      expiryDays: 0,
+    }],
+    ['get_artifact without artifactId', { type: 'get_artifact' }],
+    ['get_artifact with non-string artifactId', { type: 'get_artifact', artifactId: 7 }],
+  ])('rejects %s', (_label, payload) => {
+    expect(validateRequest(payload)).toBeNull();
+  });
+});

--- a/apps/desktop/electron/__tests__/features/profile/recovery-dialog.test.ts
+++ b/apps/desktop/electron/__tests__/features/profile/recovery-dialog.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  showMessageBox: vi.fn(),
+  showItemInFolder: vi.fn(),
+  backupAndResetRegistrySync: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  dialog: {
+    showMessageBox: mocks.showMessageBox,
+  },
+  shell: {
+    showItemInFolder: mocks.showItemInFolder,
+  },
+}));
+
+vi.mock('@electron/features/profile/manager', () => ({
+  backupAndResetRegistrySync: mocks.backupAndResetRegistrySync,
+}));
+
+describe('handleProfileRegistryRecovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.backupAndResetRegistrySync.mockReturnValue({
+      registryPath: '/tmp/.sero-ui/profiles.json',
+      backupPath: '/tmp/.sero-ui/profiles.broken-2026-04-12T10-00-00-000Z.json',
+    });
+  });
+
+  it('resets the registry and requests a relaunch', async () => {
+    mocks.showMessageBox
+      .mockResolvedValueOnce({ response: 0 })
+      .mockResolvedValueOnce({ response: 0 });
+
+    const { handleProfileRegistryRecovery } = await import('@electron/features/profile/recovery');
+    const result = await handleProfileRegistryRecovery({
+      kind: 'malformed_profile_registry',
+      registryPath: '/tmp/.sero-ui/profiles.json',
+      message: 'profiles.json is malformed: Unexpected token',
+    });
+
+    expect(result).toBe('relaunch');
+    expect(mocks.backupAndResetRegistrySync).toHaveBeenCalledOnce();
+    expect(mocks.showItemInFolder).not.toHaveBeenCalled();
+    expect(mocks.showMessageBox).toHaveBeenCalledTimes(2);
+  });
+
+  it('lets the user reveal the folder before quitting', async () => {
+    mocks.showMessageBox
+      .mockResolvedValueOnce({ response: 1 })
+      .mockResolvedValueOnce({ response: 2 });
+
+    const { handleProfileRegistryRecovery } = await import('@electron/features/profile/recovery');
+    const result = await handleProfileRegistryRecovery({
+      kind: 'malformed_profile_registry',
+      registryPath: '/tmp/.sero-ui/profiles.json',
+      message: 'profiles.json is malformed: Unexpected token',
+    });
+
+    expect(result).toBe('quit');
+    expect(mocks.showItemInFolder).toHaveBeenCalledWith('/tmp/.sero-ui/profiles.json');
+    expect(mocks.backupAndResetRegistrySync).not.toHaveBeenCalled();
+    expect(mocks.showMessageBox).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/electron/__tests__/features/profile/recovery.test.ts
+++ b/apps/desktop/electron/__tests__/features/profile/recovery.test.ts
@@ -1,0 +1,64 @@
+import { existsSync } from 'fs';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('profile registry recovery helpers', () => {
+  let tmpHome: string | null = null;
+  const originalHome = process.env.HOME;
+
+  async function importManager() {
+    if (!tmpHome) {
+      throw new Error('tmpHome not initialized');
+    }
+
+    vi.resetModules();
+    process.env.HOME = tmpHome;
+    return import('@electron/features/profile/manager');
+  }
+
+  afterEach(async () => {
+    vi.resetModules();
+    process.env.HOME = originalHome;
+
+    if (tmpHome) {
+      await fs.rm(tmpHome, { recursive: true, force: true });
+      tmpHome = null;
+    }
+  });
+
+  it('reports malformed profiles.json through the startup-safe loader', async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'profile-recovery-'));
+
+    const registryPath = path.join(tmpHome, '.sero-ui', 'profiles.json');
+    await fs.mkdir(path.dirname(registryPath), { recursive: true });
+    await fs.writeFile(registryPath, '{broken-json', 'utf8');
+
+    const { PROFILE_REGISTRY_PATH, readRegistryLoadSync } = await importManager();
+    const result = readRegistryLoadSync();
+
+    expect(PROFILE_REGISTRY_PATH).toBe(registryPath);
+    expect(result.error?.message).toContain('profiles.json is malformed');
+    expect(result.registry).toEqual({ version: 1, activeProfileId: null, profiles: [] });
+  });
+
+  it('backs up the broken registry before resetting it to an empty state', async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'profile-recovery-reset-'));
+
+    const registryPath = path.join(tmpHome, '.sero-ui', 'profiles.json');
+    const brokenContent = '{still-broken-json';
+    await fs.mkdir(path.dirname(registryPath), { recursive: true });
+    await fs.writeFile(registryPath, brokenContent, 'utf8');
+
+    const { backupAndResetRegistrySync, readRegistrySync } = await importManager();
+    const result = backupAndResetRegistrySync();
+
+    expect(result.registryPath).toBe(registryPath);
+    expect(result.backupPath).not.toBeNull();
+    expect(existsSync(result.backupPath!)).toBe(true);
+    await expect(fs.readFile(result.backupPath!, 'utf8')).resolves.toBe(brokenContent);
+    expect(readRegistrySync()).toEqual({ version: 1, activeProfileId: null, profiles: [] });
+  });
+});

--- a/apps/desktop/electron/features/auth/github/auth-manager.ts
+++ b/apps/desktop/electron/features/auth/github/auth-manager.ts
@@ -268,38 +268,36 @@ export class GitHubAuthManager {
   // ── Token Storage ──────────────────────────────────────────
 
   private storeToken(token: string, username: string): void {
-    try {
-      const dir = path.dirname(TOKEN_FILE);
-      if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-
-      const encrypted = canUseSafeStorage()
-        ? safeStorage.encryptString(token).toString('base64')
-        : Buffer.from(token).toString('base64'); // Fallback: base64 only
-
-      const stored: StoredToken = {
-        encrypted,
-        username,
-        scopes: SCOPES,
-        createdAt: new Date().toISOString(),
-      };
-
-      writeFileSync(TOKEN_FILE, JSON.stringify(stored, null, 2), 'utf8');
-    } catch (err) {
-      console.warn('[github-auth] Failed to store token:', err);
+    if (!canUseSafeStorage()) {
+      throw new Error('Secure storage is unavailable, so GitHub auth cannot persist your token safely. Please re-enable OS keychain encryption and try again.');
     }
+
+    const dir = path.dirname(TOKEN_FILE);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+    const stored: StoredToken = {
+      encrypted: safeStorage.encryptString(token).toString('base64'),
+      username,
+      scopes: SCOPES,
+      createdAt: new Date().toISOString(),
+    };
+
+    writeFileSync(TOKEN_FILE, JSON.stringify(stored, null, 2), 'utf8');
   }
 
   private loadCachedToken(): void {
     const tokenFile = getExistingTokenFile();
     if (!tokenFile) return;
 
+    if (!canUseSafeStorage()) {
+      console.warn('[github-auth] Secure storage unavailable; cached GitHub token remains on disk but will not be loaded');
+      return;
+    }
+
     try {
       const raw = readFileSync(tokenFile, 'utf8');
       const stored = JSON.parse(raw) as StoredToken;
-
-      const token = canUseSafeStorage()
-        ? safeStorage.decryptString(Buffer.from(stored.encrypted, 'base64'))
-        : Buffer.from(stored.encrypted, 'base64').toString('utf8');
+      const token = safeStorage.decryptString(Buffer.from(stored.encrypted, 'base64'));
 
       this.cachedToken = token;
       this.cachedUsername = stored.username;

--- a/apps/desktop/electron/features/editor/lsp/lsp-manager.ts
+++ b/apps/desktop/electron/features/editor/lsp/lsp-manager.ts
@@ -5,12 +5,18 @@
 
 import { EventEmitter } from 'events';
 import { LspServerProcess } from './lsp-process';
-import { findConfigByLanguageId, type LspServerConfig } from './types';
+import {
+  findConfigByLanguageId,
+  type JsonRpcNotification,
+  type LspServerConfig,
+} from './types';
 import type { ContainerManager } from '@electron/features/container';
 
 export class LspManager extends EventEmitter {
   /** workspaceId → language → LspServerProcess */
   private servers = new Map<string, Map<string, LspServerProcess>>();
+  /** workspaceId/language → in-flight startup promise */
+  private startupPromises = new Map<string, Promise<{ capabilities: Record<string, unknown>; language: string }>>();
 
   constructor(private containerManager: ContainerManager) {
     super();
@@ -32,43 +38,19 @@ export class LspManager extends EventEmitter {
       return { capabilities: existing.serverCapabilities, language: config.language };
     }
 
-    await this.waitForContainerAndInstall(workspaceId, config);
-
-    const envVars = this.containerManager.getEnvVars?.() ?? {};
-    const server = new LspServerProcess(workspaceId, config, envVars);
-
-    server.on('notification', (notification: any) => {
-      this.emit('notification', { workspaceId, language: config.language, notification });
-    });
-
-    server.on('exit', () => {
-      const wsServers = this.servers.get(workspaceId);
-      if (wsServers) {
-        wsServers.delete(config.language);
-        if (wsServers.size === 0) this.servers.delete(workspaceId);
-      }
-      this.emit('serverStopped', { workspaceId, language: config.language });
-    });
-
-    server.on('error', (err: Error) => {
-      console.error(`[lsp-manager] Error for ${workspaceId}/${config.language}:`, err.message);
-    });
-
-    let wsServers = this.servers.get(workspaceId);
-    if (!wsServers) {
-      wsServers = new Map();
-      this.servers.set(workspaceId, wsServers);
+    const startupKey = this.getStartupKey(workspaceId, config.language);
+    const inFlight = this.startupPromises.get(startupKey);
+    if (inFlight) {
+      return inFlight;
     }
-    wsServers.set(config.language, server);
+
+    const startupPromise = this.createAndStartServer(workspaceId, config);
+    this.startupPromises.set(startupKey, startupPromise);
 
     try {
-      const capabilities = await server.start();
-      console.log(`[lsp-manager] Server ready: ${workspaceId}/${config.language}`);
-      return { capabilities, language: config.language };
-    } catch (err) {
-      wsServers.delete(config.language);
-      if (wsServers.size === 0) this.servers.delete(workspaceId);
-      throw err;
+      return await startupPromise;
+    } finally {
+      this.startupPromises.delete(startupKey);
     }
   }
 
@@ -127,6 +109,55 @@ export class LspManager extends EventEmitter {
     return this.servers.get(workspaceId)?.get(language);
   }
 
+  private getStartupKey(workspaceId: string, language: string): string {
+    return `${workspaceId}:${language}`;
+  }
+
+  private async createAndStartServer(
+    workspaceId: string,
+    config: LspServerConfig,
+  ): Promise<{ capabilities: Record<string, unknown>; language: string }> {
+    await this.waitForContainerAndInstall(workspaceId, config);
+
+    const envVars = this.containerManager.getEnvVars?.() ?? {};
+    const server = new LspServerProcess(workspaceId, config, envVars);
+
+    server.on('notification', (notification: JsonRpcNotification) => {
+      this.emit('notification', { workspaceId, language: config.language, notification });
+    });
+
+    server.on('exit', () => {
+      const wsServers = this.servers.get(workspaceId);
+      if (wsServers) {
+        wsServers.delete(config.language);
+        if (wsServers.size === 0) this.servers.delete(workspaceId);
+      }
+      this.startupPromises.delete(this.getStartupKey(workspaceId, config.language));
+      this.emit('serverStopped', { workspaceId, language: config.language });
+    });
+
+    server.on('error', (err: Error) => {
+      console.error(`[lsp-manager] Error for ${workspaceId}/${config.language}:`, err.message);
+    });
+
+    let wsServers = this.servers.get(workspaceId);
+    if (!wsServers) {
+      wsServers = new Map();
+      this.servers.set(workspaceId, wsServers);
+    }
+    wsServers.set(config.language, server);
+
+    try {
+      const capabilities = await server.start();
+      console.log(`[lsp-manager] Server ready: ${workspaceId}/${config.language}`);
+      return { capabilities, language: config.language };
+    } catch (err) {
+      wsServers.delete(config.language);
+      if (wsServers.size === 0) this.servers.delete(workspaceId);
+      throw err;
+    }
+  }
+
   /**
    * Wait for the container and ensure the LSP binary is installed.
    * Retries up to 5 times for transient container errors.
@@ -147,8 +178,8 @@ export class LspManager extends EventEmitter {
         }
         console.log(`[lsp-manager] Installed ${config.language} server in ${workspaceId}`);
         return;
-      } catch (err: any) {
-        const msg = err?.message ?? '';
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : '';
         const isTransient = msg.includes('not running') || msg.includes('not found');
         if (isTransient && attempt < MAX_RETRIES) {
           console.log(`[lsp-manager] Container not ready for ${workspaceId}, retrying (${attempt}/${MAX_RETRIES})...`);

--- a/apps/desktop/electron/features/editor/lsp/lsp-process.ts
+++ b/apps/desktop/electron/features/editor/lsp/lsp-process.ts
@@ -16,6 +16,48 @@ import { isResponse, isRequest, isNotification, fileUri } from './types';
 const WORKSPACE_DIR = '/workspace';
 const REQUEST_TIMEOUT_MS = 30_000;
 
+interface InitializeResult {
+  capabilities?: Record<string, unknown>;
+}
+
+interface WorkspaceConfigurationParams {
+  items?: unknown[];
+}
+
+interface NodeErrorLike {
+  code?: unknown;
+  message?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getInitializeResult(value: unknown): InitializeResult | null {
+  if (!isRecord(value)) return null;
+  const capabilities = value.capabilities;
+  if (capabilities === undefined) return {};
+  return isRecord(capabilities) ? { capabilities } : null;
+}
+
+function getWorkspaceConfigurationItems(params: unknown): unknown[] {
+  if (!isRecord(params)) return [];
+  const candidate = params.items;
+  return Array.isArray(candidate) ? candidate : [];
+}
+
+function getNodeErrorCode(err: unknown): string | number | undefined {
+  if (!isRecord(err)) return undefined;
+  const code = err.code;
+  return typeof code === 'string' || typeof code === 'number' ? code : undefined;
+}
+
+function getNodeErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (!isRecord(err)) return '';
+  return typeof err.message === 'string' ? err.message : '';
+}
+
 export class LspServerProcess extends EventEmitter {
   private process: ChildProcess | null = null;
   private parser = new JsonRpcParser();
@@ -182,9 +224,14 @@ export class LspServerProcess extends EventEmitter {
       },
       workspaceFolders: [{ uri: rootUri, name: 'workspace' }],
       initializationOptions: this.config.initOptions ?? {},
-    }) as Record<string, unknown>;
+    });
 
-    this.capabilities = (result as any)?.capabilities ?? {};
+    const initializeResult = getInitializeResult(result);
+    if (!initializeResult) {
+      throw new Error('LSP initialize response did not include a valid capabilities object');
+    }
+
+    this.capabilities = initializeResult.capabilities ?? {};
     this._initialized = true;
     this.sendNotification('initialized', {});
     console.log(`[lsp:${this.config.language}] Initialized for ${this.workspaceId}`);
@@ -218,7 +265,7 @@ export class LspServerProcess extends EventEmitter {
     let result: unknown = null;
     switch (req.method) {
       case 'workspace/configuration':
-        result = ((req.params as any)?.items ?? []).map(() => ({}));
+        result = getWorkspaceConfigurationItems(req.params).map(() => ({}));
         break;
       case 'client/registerCapability':
       case 'window/workDoneProgress/create':
@@ -235,9 +282,9 @@ export class LspServerProcess extends EventEmitter {
     if (!this.process?.stdin?.writable) return;
     try {
       this.process.stdin.write(encodeMessage(msg));
-    } catch (err: any) {
-      if (err.code !== 'EPIPE') {
-        console.warn(`[lsp:${this.config.language}] Write error:`, err.message);
+    } catch (err: unknown) {
+      if (getNodeErrorCode(err) !== 'EPIPE') {
+        console.warn(`[lsp:${this.config.language}] Write error:`, getNodeErrorMessage(err));
       }
     }
   }

--- a/apps/desktop/electron/features/gateway/bridge/web-tokens.ts
+++ b/apps/desktop/electron/features/gateway/bridge/web-tokens.ts
@@ -14,11 +14,32 @@ const MAX_TOKENS = 10;
 const DEFAULT_EXPIRY_DAYS = 7;
 const TOKEN_LENGTH = 32;
 
+function normalizeWebToken(value: unknown): WebToken[] {
+  if (typeof value !== 'object' || value === null) {
+    return [];
+  }
+
+  const token = 'token' in value && typeof value.token === 'string' ? value.token : null;
+  const createdAt = 'createdAt' in value && typeof value.createdAt === 'string' ? value.createdAt : null;
+  const expiresAt = 'expiresAt' in value && typeof value.expiresAt === 'string' ? value.expiresAt : null;
+  const label = 'label' in value && typeof value.label === 'string' ? value.label : null;
+  const workspaceIds = 'workspaceIds' in value && Array.isArray(value.workspaceIds)
+    ? value.workspaceIds.filter((workspaceId): workspaceId is string => typeof workspaceId === 'string')
+    : [];
+
+  if (!token || !createdAt || !expiresAt || !label || workspaceIds.length === 0) {
+    return [];
+  }
+
+  return [{ token, createdAt, expiresAt, label, workspaceIds }];
+}
+
 export interface WebToken {
   token: string;
   createdAt: string;
   expiresAt: string;
   label: string;
+  workspaceIds: string[];
 }
 
 export class WebTokenManager {
@@ -32,7 +53,11 @@ export class WebTokenManager {
   }
 
   /** Create a new web token. Returns the token details. */
-  create(label?: string, expiryDays?: number): WebToken {
+  create(workspaceIds: string[], label?: string, expiryDays?: number): WebToken {
+    if (workspaceIds.length === 0) {
+      throw new Error('Web tokens must be scoped to at least one workspace');
+    }
+
     this.pruneExpired();
 
     // Enforce max tokens — remove oldest if at limit
@@ -49,6 +74,7 @@ export class WebTokenManager {
       createdAt: now.toISOString(),
       expiresAt: expires.toISOString(),
       label: label ?? `Web token ${now.toLocaleDateString()}`,
+      workspaceIds: [...new Set(workspaceIds)],
     };
 
     this.tokens.push(webToken);
@@ -67,6 +93,7 @@ export class WebTokenManager {
       createdAt: t.createdAt,
       expiresAt: t.expiresAt,
       label: t.label,
+      workspaceIds: t.workspaceIds,
     }));
   }
 
@@ -82,18 +109,18 @@ export class WebTokenManager {
     return false;
   }
 
-  /** Validate a token. Returns true if the token is valid and not expired. */
-  validate(token: string): boolean {
+  /** Validate a token. Returns the scoped token if valid and not expired. */
+  validate(token: string): WebToken | null {
     const now = Date.now();
     for (const wt of this.tokens) {
       if (new Date(wt.expiresAt).getTime() <= now) continue;
       // Constant-time comparison
       if (token.length !== wt.token.length) continue;
       if (crypto.timingSafeEqual(Buffer.from(token), Buffer.from(wt.token))) {
-        return true;
+        return wt;
       }
     }
-    return false;
+    return null;
   }
 
   /** Remove expired tokens. */
@@ -112,7 +139,10 @@ export class WebTokenManager {
   private load(): void {
     try {
       const data = fs.readFileSync(this.filePath, 'utf-8');
-      this.tokens = JSON.parse(data);
+      const parsed = JSON.parse(data) as unknown;
+      this.tokens = Array.isArray(parsed)
+        ? parsed.flatMap((token) => normalizeWebToken(token))
+        : [];
     } catch {
       this.tokens = [];
     }

--- a/apps/desktop/electron/features/gateway/channels/discord.ts
+++ b/apps/desktop/electron/features/gateway/channels/discord.ts
@@ -241,10 +241,18 @@ export class DiscordAdapter {
 
       case 'abort': {
         const session = this.sessions.get(msg.channel.id);
-        if (session) {
-          await msg.reply('Aborting current task...');
-        } else {
+        if (!session) {
           await msg.reply('No active session in this channel.');
+          break;
+        }
+
+        try {
+          await this.agentOps.abort(session.sessionId);
+          await msg.reply('Aborting current task...');
+        } catch (err) {
+          await msg.reply(
+            `Abort failed: ${err instanceof Error ? err.message : 'Something went wrong'}`,
+          );
         }
         break;
       }

--- a/apps/desktop/electron/features/gateway/index.ts
+++ b/apps/desktop/electron/features/gateway/index.ts
@@ -7,7 +7,7 @@
 import { WebSocketServer, WebSocket } from 'ws';
 import http from 'http';
 
-import { GatewayAuth } from './security/auth';
+import { GatewayAuth, type GatewayAuthResult } from './security/auth';
 import { CostTracker } from './server/cost-tracker';
 import { RateLimiter } from './security/rate-limiter';
 import { sendResponse, routeAgentRequest, disposeIdempotencyStore } from './server/request-handler';
@@ -20,11 +20,9 @@ import {
   type GatewayPushEvent,
 } from './server/protocol';
 import type { GatewayConfig, GatewayAgentOps } from './server/types';
+import type { GatewayAccessScope } from './server/access-control';
 
-// Re-export types so existing importers don't break
 export type { GatewayConfig, GatewayAgentOps, GatewayFileEntry, GatewayFileContent } from './server/types';
-
-// ── Constants ──────────────────────────────────────────────────
 
 /** Maximum WebSocket message payload (1 MB). */
 const MAX_PAYLOAD_BYTES = 1 * 1024 * 1024;
@@ -54,12 +52,9 @@ const STATIC_ALLOWED_ORIGINS = new Set([
   'http://localhost:5176',
 ]);
 
-// ── Types ───────────────────────────────────────────────────
-
-/** Callback that returns the web chat HTML (legacy fallback at /basic). */
 type WebChatHtmlProvider = () => string;
 
-interface ConnectedClient {
+interface ConnectedClient extends GatewayAccessScope {
   ws: WebSocket;
   clientType: string;
   clientId: string;
@@ -74,8 +69,6 @@ interface ConnectedClient {
   lastActivity: number;
 }
 
-// ── Server ──────────────────────────────────────────────────
-
 export class GatewayServer {
   private wss: WebSocketServer | null = null;
   private httpServer: http.Server | null = null;
@@ -86,7 +79,6 @@ export class GatewayServer {
   private webChatHtml: WebChatHtmlProvider | null = null;
   private idleCheckTimer: ReturnType<typeof setInterval> | null = null;
 
-  /** Rate limiter for auth attempts (5 failures / 60s → 5 min block). */
   private authLimiter = new RateLimiter({
     maxAttempts: 5,
     windowMs: 60_000,
@@ -132,14 +124,7 @@ export class GatewayServer {
 
       const pathname = (req.url ?? '/').split('?')[0];
 
-      // ── Server-side routes (must come BEFORE the SPA static fallback,
-      //    which serves index.html for any extensionless path) ──────────
-
-      // QR code pairing is handled in-app via ⌘K → "Connect Device".
-      // The old /qr endpoint (which required the master token in the URL)
-      // has been removed — see ConnectDeviceDialog + gateway IPC handler.
-
-      // Fallback: serve legacy inline HTML at /basic
+      // Server-side routes must come before the SPA static fallback.
       if (pathname === '/basic' && this.webChatHtml) {
         res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
         res.end(this.webChatHtml());
@@ -151,10 +136,6 @@ export class GatewayServer {
         return;
       }
 
-      // ── Static files + SPA fallback (after all server-side routes) ──
-      // This MUST come after /qr, /basic, /health — the SPA fallback
-      // serves index.html for any extensionless path, which would
-      // swallow those routes if checked first.
       if (tryServeStaticFile(pathname, res, __dirname)) return;
 
       res.writeHead(404);
@@ -171,7 +152,6 @@ export class GatewayServer {
       console.error('[gateway] WebSocket server error:', err);
     });
 
-    // Start idle connection checker (every 5 minutes)
     this.idleCheckTimer = setInterval(() => this.checkIdleConnections(), 5 * 60_000);
 
     return new Promise<void>((resolve, reject) => {
@@ -240,20 +220,22 @@ export class GatewayServer {
   pushEvent(sessionId: string, event: GatewayPushEvent): void {
     const payload = JSON.stringify(event);
     for (const [ws, client] of this.clients) {
-      if (!client.authenticated) continue;
-      if (client.subscribedSessions.has(sessionId)) {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(payload);
-        }
+      if (!client.authenticated || !client.subscribedSessions.has(sessionId)) {
+        continue;
+      }
+      if (this.canReceiveSessionEvent(client, sessionId) && ws.readyState === WebSocket.OPEN) {
+        ws.send(payload);
       }
     }
   }
 
-  /** Push an event to ALL authenticated clients (e.g. artifact_added). */
+  /** Push an event to authenticated clients that are authorized for its session. */
   broadcastEvent(event: GatewayPushEvent): void {
     const payload = JSON.stringify(event);
+    const sessionId = 'sessionId' in event ? event.sessionId : null;
     for (const [ws, client] of this.clients) {
       if (!client.authenticated) continue;
+      if (sessionId && !this.canReceiveSessionEvent(client, sessionId)) continue;
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(payload);
       }
@@ -263,6 +245,21 @@ export class GatewayServer {
   /** Get the auth manager (for web token operations from the request handler). */
   getAuth(): GatewayAuth {
     return this.auth;
+  }
+
+  private canReceiveSessionEvent(client: ConnectedClient, sessionId: string): boolean {
+    return client.isMasterAuth || client.authorizedSessionIds.has(sessionId);
+  }
+
+  private applyAuthResult(client: ConnectedClient, result: GatewayAuthResult): void {
+    client.authenticated = true;
+    client.isMasterAuth = result.type === 'master';
+    client.authorizedWorkspaceIds = result.authorizedWorkspaceIds
+      ? new Set(result.authorizedWorkspaceIds)
+      : null;
+    client.authorizedSessionIds.clear();
+    client.authorizedArtifactIds.clear();
+    client.subscribedSessions.clear();
   }
 
   // ── Internal ──────────────────────────────────────────────
@@ -355,6 +352,9 @@ export class GatewayServer {
       clientId: `client-${Date.now()}`,
       authenticated: false,
       isMasterAuth: false,
+      authorizedWorkspaceIds: null,
+      authorizedSessionIds: new Set(),
+      authorizedArtifactIds: new Set(),
       subscribedSessions: new Set(),
       remoteIp,
       lastActivity: Date.now(),
@@ -428,7 +428,8 @@ export class GatewayServer {
         return;
       }
 
-      if (!this.auth.validate(request.token)) {
+      const authResult = this.auth.validate(request.token);
+      if (!authResult) {
         console.warn(
           `[gateway] Auth failed: ${client.remoteIp} (client type: ${request.clientType})`,
         );
@@ -444,8 +445,7 @@ export class GatewayServer {
       // Successful auth — reset rate limiter for this IP
       this.authLimiter.reset(client.remoteIp);
 
-      client.authenticated = true;
-      client.isMasterAuth = this.auth.isMasterToken(request.token);
+      this.applyAuthResult(client, authResult);
       client.clientType = request.clientType;
       if (request.clientId) client.clientId = request.clientId;
       console.log(
@@ -478,6 +478,7 @@ export class GatewayServer {
       ws,
       this.agentOps,
       request,
+      client,
       (sessionId) => client.subscribedSessions.add(sessionId),
       () => this.getStatus(),
       this.costTracker,

--- a/apps/desktop/electron/features/gateway/index.ts
+++ b/apps/desktop/electron/features/gateway/index.ts
@@ -223,7 +223,11 @@ export class GatewayServer {
       if (!client.authenticated || !client.subscribedSessions.has(sessionId)) {
         continue;
       }
-      if (this.canReceiveSessionEvent(client, sessionId) && ws.readyState === WebSocket.OPEN) {
+      if (!this.canReceiveSessionEvent(client, sessionId)) {
+        continue;
+      }
+      this.authorizeEventArtifacts(client, event);
+      if (ws.readyState === WebSocket.OPEN) {
         ws.send(payload);
       }
     }
@@ -236,6 +240,7 @@ export class GatewayServer {
     for (const [ws, client] of this.clients) {
       if (!client.authenticated) continue;
       if (sessionId && !this.canReceiveSessionEvent(client, sessionId)) continue;
+      this.authorizeEventArtifacts(client, event);
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(payload);
       }
@@ -249,6 +254,12 @@ export class GatewayServer {
 
   private canReceiveSessionEvent(client: ConnectedClient, sessionId: string): boolean {
     return client.isMasterAuth || client.authorizedSessionIds.has(sessionId);
+  }
+
+  private authorizeEventArtifacts(client: ConnectedClient, event: GatewayPushEvent): void {
+    if (event.type === 'artifact_added') {
+      client.authorizedArtifactIds.add(event.artifactId);
+    }
   }
 
   private applyAuthResult(client: ConnectedClient, result: GatewayAuthResult): void {

--- a/apps/desktop/electron/features/gateway/index.ts
+++ b/apps/desktop/electron/features/gateway/index.ts
@@ -13,14 +13,9 @@ import { RateLimiter } from './security/rate-limiter';
 import { sendResponse, routeAgentRequest, disposeIdempotencyStore } from './server/request-handler';
 import { tryServeStaticFile } from './server/static-files';
 import { redactSecrets } from '@electron/shared/lib/secret-redact';
-import {
-  validateRequest,
-  type GatewayRequest,
-  type GatewayResponse,
-  type GatewayPushEvent,
-} from './server/protocol';
+import { validateRequest, type GatewayRequest, type GatewayResponse, type GatewayPushEvent } from './server/protocol';
 import type { GatewayConfig, GatewayAgentOps } from './server/types';
-import type { GatewayAccessScope } from './server/access-control';
+import { authorizeArtifactFromSession, hasSessionAccess, type GatewayAccessScope } from './server/access-control';
 
 export type { GatewayConfig, GatewayAgentOps, GatewayFileEntry, GatewayFileContent } from './server/types';
 
@@ -253,12 +248,12 @@ export class GatewayServer {
   }
 
   private canReceiveSessionEvent(client: ConnectedClient, sessionId: string): boolean {
-    return client.isMasterAuth || client.authorizedSessionIds.has(sessionId);
+    return hasSessionAccess(client, sessionId);
   }
 
   private authorizeEventArtifacts(client: ConnectedClient, event: GatewayPushEvent): void {
     if (event.type === 'artifact_added') {
-      client.authorizedArtifactIds.add(event.artifactId);
+      authorizeArtifactFromSession(client, event.sessionId, event.artifactId);
     }
   }
 
@@ -268,8 +263,8 @@ export class GatewayServer {
     client.authorizedWorkspaceIds = result.authorizedWorkspaceIds
       ? new Set(result.authorizedWorkspaceIds)
       : null;
-    client.authorizedSessionIds.clear();
-    client.authorizedArtifactIds.clear();
+    client.authorizedSessions.clear();
+    client.authorizedArtifacts.clear();
     client.subscribedSessions.clear();
   }
 
@@ -364,8 +359,8 @@ export class GatewayServer {
       authenticated: false,
       isMasterAuth: false,
       authorizedWorkspaceIds: null,
-      authorizedSessionIds: new Set(),
-      authorizedArtifactIds: new Set(),
+      authorizedSessions: new Map(),
+      authorizedArtifacts: new Map(),
       subscribedSessions: new Set(),
       remoteIp,
       lastActivity: Date.now(),

--- a/apps/desktop/electron/features/gateway/security/auth.ts
+++ b/apps/desktop/electron/features/gateway/security/auth.ts
@@ -1,14 +1,10 @@
 /**
  * Gateway authentication — token generation and validation.
  *
- * A single bearer token is generated on first run and stored on disk.
- * All gateway clients must present this token to connect.
- *
- * TODO(security): Per-workspace token scoping — the current flat access model
- * lets any authenticated client access all workspaces. For a single-user app
- * with a secret token on localhost this is acceptable, but if multi-user or
- * untrusted client scenarios arise, add workspace-scoped tokens.
- * See docs/security/outstanding-hardening.md #1.
+ * A single master bearer token is generated on first run and stored on disk.
+ * All gateway clients must present either that master token or a scoped web
+ * token created from the desktop app. Web tokens are limited to one or more
+ * explicit workspace IDs.
  */
 
 import crypto from 'crypto';
@@ -17,6 +13,11 @@ import path from 'path';
 import { WebTokenManager } from '../bridge/web-tokens';
 
 const TOKEN_LENGTH = 32;
+
+export interface GatewayAuthResult {
+  type: 'master' | 'web';
+  authorizedWorkspaceIds: string[] | null;
+}
 
 export class GatewayAuth {
   private token: string | null = null;
@@ -55,25 +56,30 @@ export class GatewayAuth {
     return this.token;
   }
 
-  /** Validate a token from a client — accepts master token OR valid web token. */
-  validate(token: string): boolean {
+  /** Validate a token from a client — accepts master token OR valid scoped web token. */
+  validate(token: string): GatewayAuthResult | null {
     // Check master token first (constant-time)
     const expected = this.getToken();
     if (token.length === expected.length) {
       if (crypto.timingSafeEqual(Buffer.from(token), Buffer.from(expected))) {
-        return true;
+        return {
+          type: 'master',
+          authorizedWorkspaceIds: null,
+        };
       }
     }
-    // Fall through to check web tokens
-    return this.webTokens.validate(token);
+
+    const webToken = this.webTokens.validate(token);
+    if (!webToken) {
+      return null;
+    }
+
+    return {
+      type: 'web',
+      authorizedWorkspaceIds: webToken.workspaceIds,
+    };
   }
 
-  /** Check if the given token is the master token (not a web token). */
-  isMasterToken(token: string): boolean {
-    const expected = this.getToken();
-    if (token.length !== expected.length) return false;
-    return crypto.timingSafeEqual(Buffer.from(token), Buffer.from(expected));
-  }
 
   /** Regenerate the token (invalidates all existing connections). */
   regenerate(): string {

--- a/apps/desktop/electron/features/gateway/server/access-control.ts
+++ b/apps/desktop/electron/features/gateway/server/access-control.ts
@@ -1,37 +1,59 @@
 export interface GatewayAccessScope {
   authorizedWorkspaceIds: Set<string> | null;
-  authorizedSessionIds: Set<string>;
-  authorizedArtifactIds: Set<string>;
+  authorizedSessions: Map<string, string>;
+  authorizedArtifacts: Map<string, string>;
 }
 
 export function hasWorkspaceAccess(scope: GatewayAccessScope, workspaceId: string): boolean {
   return scope.authorizedWorkspaceIds === null || scope.authorizedWorkspaceIds.has(workspaceId);
 }
 
-export function authorizeSession(scope: GatewayAccessScope, sessionId: string): void {
-  scope.authorizedSessionIds.add(sessionId);
+export function authorizeSessionFromWorkspace(
+  scope: GatewayAccessScope,
+  workspaceId: string,
+  sessionId: string,
+): void {
+  if (!hasWorkspaceAccess(scope, workspaceId)) {
+    throw new Error(`Cannot authorize session ${sessionId} for unauthorized workspace ${workspaceId}`);
+  }
+  scope.authorizedSessions.set(sessionId, workspaceId);
 }
 
-export function authorizeSessions(scope: GatewayAccessScope, sessionIds: Iterable<string>): void {
+export function authorizeSessionsFromWorkspace(
+  scope: GatewayAccessScope,
+  workspaceId: string,
+  sessionIds: Iterable<string>,
+): void {
   for (const sessionId of sessionIds) {
-    scope.authorizedSessionIds.add(sessionId);
+    authorizeSessionFromWorkspace(scope, workspaceId, sessionId);
   }
 }
 
 export function hasSessionAccess(scope: GatewayAccessScope, sessionId: string): boolean {
-  return scope.authorizedSessionIds.has(sessionId);
+  return scope.authorizedSessions.has(sessionId);
 }
 
-export function authorizeArtifact(scope: GatewayAccessScope, artifactId: string): void {
-  scope.authorizedArtifactIds.add(artifactId);
+export function authorizeArtifactFromSession(
+  scope: GatewayAccessScope,
+  sessionId: string,
+  artifactId: string,
+): void {
+  if (!hasSessionAccess(scope, sessionId)) {
+    throw new Error(`Cannot authorize artifact ${artifactId} without prior session access for ${sessionId}`);
+  }
+  scope.authorizedArtifacts.set(artifactId, sessionId);
 }
 
-export function authorizeArtifacts(scope: GatewayAccessScope, artifactIds: Iterable<string>): void {
+export function authorizeArtifactsFromSession(
+  scope: GatewayAccessScope,
+  sessionId: string,
+  artifactIds: Iterable<string>,
+): void {
   for (const artifactId of artifactIds) {
-    scope.authorizedArtifactIds.add(artifactId);
+    authorizeArtifactFromSession(scope, sessionId, artifactId);
   }
 }
 
 export function hasArtifactAccess(scope: GatewayAccessScope, artifactId: string): boolean {
-  return scope.authorizedArtifactIds.has(artifactId);
+  return scope.authorizedArtifacts.has(artifactId);
 }

--- a/apps/desktop/electron/features/gateway/server/access-control.ts
+++ b/apps/desktop/electron/features/gateway/server/access-control.ts
@@ -1,0 +1,37 @@
+export interface GatewayAccessScope {
+  authorizedWorkspaceIds: Set<string> | null;
+  authorizedSessionIds: Set<string>;
+  authorizedArtifactIds: Set<string>;
+}
+
+export function hasWorkspaceAccess(scope: GatewayAccessScope, workspaceId: string): boolean {
+  return scope.authorizedWorkspaceIds === null || scope.authorizedWorkspaceIds.has(workspaceId);
+}
+
+export function authorizeSession(scope: GatewayAccessScope, sessionId: string): void {
+  scope.authorizedSessionIds.add(sessionId);
+}
+
+export function authorizeSessions(scope: GatewayAccessScope, sessionIds: Iterable<string>): void {
+  for (const sessionId of sessionIds) {
+    scope.authorizedSessionIds.add(sessionId);
+  }
+}
+
+export function hasSessionAccess(scope: GatewayAccessScope, sessionId: string): boolean {
+  return scope.authorizedSessionIds.has(sessionId);
+}
+
+export function authorizeArtifact(scope: GatewayAccessScope, artifactId: string): void {
+  scope.authorizedArtifactIds.add(artifactId);
+}
+
+export function authorizeArtifacts(scope: GatewayAccessScope, artifactIds: Iterable<string>): void {
+  for (const artifactId of artifactIds) {
+    scope.authorizedArtifactIds.add(artifactId);
+  }
+}
+
+export function hasArtifactAccess(scope: GatewayAccessScope, artifactId: string): boolean {
+  return scope.authorizedArtifactIds.has(artifactId);
+}

--- a/apps/desktop/electron/features/gateway/server/extended-handlers.ts
+++ b/apps/desktop/electron/features/gateway/server/extended-handlers.ts
@@ -7,6 +7,16 @@ import { WebSocket } from 'ws';
 import type { GatewayRequest } from './protocol';
 import type { GatewayAgentOps } from '..';
 import type { GatewayAuth } from '../security/auth';
+import {
+  authorizeArtifact,
+  authorizeArtifacts,
+  authorizeSession,
+  authorizeSessions,
+  hasArtifactAccess,
+  hasSessionAccess,
+  hasWorkspaceAccess,
+  type GatewayAccessScope,
+} from './access-control';
 import { sendResponse } from './request-handler';
 
 /**
@@ -29,16 +39,26 @@ export async function routeExtendedRequest(
   ws: WebSocket,
   agentOps: GatewayAgentOps,
   request: GatewayRequest,
+  accessScope: GatewayAccessScope,
   auth: GatewayAuth,
   isMasterAuth: boolean,
 ): Promise<boolean> {
   switch (request.type) {
     case 'create_session': {
+      if (!hasWorkspaceAccess(accessScope, request.workspaceId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'create_session',
+          message: `Workspace not authorized: ${request.workspaceId}`,
+        });
+        return true;
+      }
       try {
         const session = await agentOps.createSession(
           request.workspaceId,
           request.name,
         );
+        authorizeSession(accessScope, session.id);
         sendResponse(ws, {
           type: 'ok',
           requestType: 'create_session',
@@ -55,6 +75,14 @@ export async function routeExtendedRequest(
     }
 
     case 'list_files': {
+      if (!hasWorkspaceAccess(accessScope, request.workspaceId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'list_files',
+          message: `Workspace not authorized: ${request.workspaceId}`,
+        });
+        return true;
+      }
       const listPathErr = validateFilePath(request.path);
       if (listPathErr) {
         sendResponse(ws, { type: 'error', requestType: 'list_files', message: listPathErr });
@@ -78,6 +106,14 @@ export async function routeExtendedRequest(
     }
 
     case 'read_file': {
+      if (!hasWorkspaceAccess(accessScope, request.workspaceId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'read_file',
+          message: `Workspace not authorized: ${request.workspaceId}`,
+        });
+        return true;
+      }
       const readPathErr = validateFilePath(request.path);
       if (readPathErr) {
         sendResponse(ws, { type: 'error', requestType: 'read_file', message: readPathErr });
@@ -101,8 +137,17 @@ export async function routeExtendedRequest(
     }
 
     case 'list_artifacts': {
+      if (!hasSessionAccess(accessScope, request.sessionId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'list_artifacts',
+          message: `Session not authorized: ${request.sessionId}`,
+        });
+        return true;
+      }
       try {
         const artifacts = await agentOps.listArtifacts(request.sessionId);
+        authorizeArtifacts(accessScope, artifacts.map((artifact) => artifact.id));
         sendResponse(ws, {
           type: 'ok',
           requestType: 'list_artifacts',
@@ -119,8 +164,19 @@ export async function routeExtendedRequest(
     }
 
     case 'get_artifact': {
+      if (!hasArtifactAccess(accessScope, request.artifactId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'get_artifact',
+          message: `Artifact not authorized: ${request.artifactId}`,
+        });
+        return true;
+      }
       try {
         const artifact = await agentOps.getArtifact(request.artifactId);
+        if (artifact) {
+          authorizeArtifact(accessScope, request.artifactId);
+        }
         sendResponse(ws, {
           type: 'ok',
           requestType: 'get_artifact',
@@ -137,11 +193,20 @@ export async function routeExtendedRequest(
     }
 
     case 'get_session_history': {
+      if (!hasWorkspaceAccess(accessScope, request.workspaceId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'get_session_history',
+          message: `Workspace not authorized: ${request.workspaceId}`,
+        });
+        return true;
+      }
       try {
         const messages = await agentOps.getSessionHistory(
           request.workspaceId,
           request.sessionId,
         );
+        authorizeSessions(accessScope, [request.sessionId]);
         sendResponse(ws, {
           type: 'ok',
           requestType: 'get_session_history',
@@ -168,7 +233,27 @@ export async function routeExtendedRequest(
         return true;
       }
       try {
-        const webToken = auth.webTokens.create(request.label, request.expiryDays);
+        const workspaceIds = request.workspaceIds;
+        if (!Array.isArray(workspaceIds) || workspaceIds.length === 0) {
+          sendResponse(ws, {
+            type: 'error',
+            requestType: 'create_web_token',
+            message: 'create_web_token requires one or more workspaceIds',
+          });
+          return true;
+        }
+        const unauthorizedWorkspace = workspaceIds.find(
+          (workspaceId) => typeof workspaceId !== 'string' || !hasWorkspaceAccess(accessScope, workspaceId),
+        );
+        if (unauthorizedWorkspace) {
+          sendResponse(ws, {
+            type: 'error',
+            requestType: 'create_web_token',
+            message: `Workspace not authorized: ${String(unauthorizedWorkspace)}`,
+          });
+          return true;
+        }
+        const webToken = auth.webTokens.create(workspaceIds, request.label, request.expiryDays);
         sendResponse(ws, {
           type: 'ok',
           requestType: 'create_web_token',

--- a/apps/desktop/electron/features/gateway/server/extended-handlers.ts
+++ b/apps/desktop/electron/features/gateway/server/extended-handlers.ts
@@ -38,6 +38,7 @@ export async function routeExtendedRequest(
   agentOps: GatewayAgentOps,
   request: GatewayRequest,
   accessScope: GatewayAccessScope,
+  subscribeToSession: (sessionId: string) => void,
   auth: GatewayAuth,
   isMasterAuth: boolean,
 ): Promise<boolean> {
@@ -57,6 +58,7 @@ export async function routeExtendedRequest(
           request.name,
         );
         authorizeSessionFromWorkspace(accessScope, request.workspaceId, session.id);
+        subscribeToSession(session.id);
         sendResponse(ws, {
           type: 'ok',
           requestType: 'create_session',
@@ -206,6 +208,7 @@ export async function routeExtendedRequest(
           request.sessionId,
         );
         authorizeSessionFromWorkspace(accessScope, request.workspaceId, request.sessionId);
+        subscribeToSession(request.sessionId);
         sendResponse(ws, {
           type: 'ok',
           requestType: 'get_session_history',

--- a/apps/desktop/electron/features/gateway/server/extended-handlers.ts
+++ b/apps/desktop/electron/features/gateway/server/extended-handlers.ts
@@ -8,10 +8,8 @@ import type { GatewayRequest } from './protocol';
 import type { GatewayAgentOps } from '..';
 import type { GatewayAuth } from '../security/auth';
 import {
-  authorizeArtifact,
-  authorizeArtifacts,
-  authorizeSession,
-  authorizeSessions,
+  authorizeArtifactsFromSession,
+  authorizeSessionFromWorkspace,
   hasArtifactAccess,
   hasSessionAccess,
   hasWorkspaceAccess,
@@ -58,7 +56,7 @@ export async function routeExtendedRequest(
           request.workspaceId,
           request.name,
         );
-        authorizeSession(accessScope, session.id);
+        authorizeSessionFromWorkspace(accessScope, request.workspaceId, session.id);
         sendResponse(ws, {
           type: 'ok',
           requestType: 'create_session',
@@ -147,7 +145,11 @@ export async function routeExtendedRequest(
       }
       try {
         const artifacts = await agentOps.listArtifacts(request.sessionId);
-        authorizeArtifacts(accessScope, artifacts.map((artifact) => artifact.id));
+        authorizeArtifactsFromSession(
+          accessScope,
+          request.sessionId,
+          artifacts.map((artifact) => artifact.id),
+        );
         sendResponse(ws, {
           type: 'ok',
           requestType: 'list_artifacts',
@@ -174,9 +176,6 @@ export async function routeExtendedRequest(
       }
       try {
         const artifact = await agentOps.getArtifact(request.artifactId);
-        if (artifact) {
-          authorizeArtifact(accessScope, request.artifactId);
-        }
         sendResponse(ws, {
           type: 'ok',
           requestType: 'get_artifact',
@@ -206,7 +205,7 @@ export async function routeExtendedRequest(
           request.workspaceId,
           request.sessionId,
         );
-        authorizeSessions(accessScope, [request.sessionId]);
+        authorizeSessionFromWorkspace(accessScope, request.workspaceId, request.sessionId);
         sendResponse(ws, {
           type: 'ok',
           requestType: 'get_session_history',

--- a/apps/desktop/electron/features/gateway/server/protocol.ts
+++ b/apps/desktop/electron/features/gateway/server/protocol.ts
@@ -82,6 +82,7 @@ export interface GatewayCreateWebTokenRequest {
   type: 'create_web_token';
   label?: string;
   expiryDays?: number;
+  workspaceIds?: string[];
 }
 
 export interface GatewayListWebTokensRequest {

--- a/apps/desktop/electron/features/gateway/server/protocol.ts
+++ b/apps/desktop/electron/features/gateway/server/protocol.ts
@@ -196,7 +196,7 @@ export type GatewayPushEvent =
 
 // ── Validation ──────────────────────────────────────────────
 
-const VALID_REQUEST_TYPES = new Set([
+const VALID_REQUEST_TYPES = new Set<GatewayRequest['type']>([
   'connect',
   'prompt',
   'steer',
@@ -215,9 +215,173 @@ const VALID_REQUEST_TYPES = new Set([
   'get_session_history',
 ]);
 
+const VALID_CLIENT_TYPES = new Set<GatewayConnectRequest['clientType']>(['web', 'discord', 'cli']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readRequiredString(obj: Record<string, unknown>, key: string): string | null {
+  const value = obj[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readOptionalString(obj: Record<string, unknown>, key: string): string | undefined | null {
+  const value = obj[key];
+  if (value === undefined) return undefined;
+  return typeof value === 'string' ? value : null;
+}
+
+function readOptionalFiniteNumber(obj: Record<string, unknown>, key: string): number | undefined | null {
+  const value = obj[key];
+  if (value === undefined) return undefined;
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function readPromptImages(value: unknown): GatewayPromptRequest['images'] | undefined | null {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return null;
+
+  const images: NonNullable<GatewayPromptRequest['images']> = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) return null;
+    const data = readRequiredString(entry, 'data');
+    const mimeType = readRequiredString(entry, 'mimeType');
+    if (!data || !mimeType) return null;
+    images.push({ data, mimeType });
+  }
+  return images;
+}
+
+function readWorkspaceIds(obj: Record<string, unknown>): string[] | null {
+  const value = obj.workspaceIds;
+  if (!Array.isArray(value) || value.length === 0) return null;
+
+  const workspaceIds: string[] = [];
+  for (const workspaceId of value) {
+    if (typeof workspaceId !== 'string' || workspaceId.length === 0) {
+      return null;
+    }
+    workspaceIds.push(workspaceId);
+  }
+  return workspaceIds;
+}
+
 export function validateRequest(data: unknown): GatewayRequest | null {
-  if (typeof data !== 'object' || data === null) return null;
-  const obj = data as Record<string, unknown>;
-  if (typeof obj.type !== 'string' || !VALID_REQUEST_TYPES.has(obj.type)) return null;
-  return obj as unknown as GatewayRequest;
+  if (!isRecord(data)) return null;
+  if (typeof data.type !== 'string' || !VALID_REQUEST_TYPES.has(data.type as GatewayRequest['type'])) {
+    return null;
+  }
+
+  switch (data.type) {
+    case 'connect': {
+      const token = readRequiredString(data, 'token');
+      const clientType = readRequiredString(data, 'clientType');
+      const clientId = readOptionalString(data, 'clientId');
+      if (!token || !clientType || !VALID_CLIENT_TYPES.has(clientType as GatewayConnectRequest['clientType'])) {
+        return null;
+      }
+      if (clientId === null) return null;
+      return { type: 'connect', token, clientType: clientType as GatewayConnectRequest['clientType'], clientId };
+    }
+
+    case 'prompt': {
+      const workspaceId = readRequiredString(data, 'workspaceId');
+      const sessionId = readRequiredString(data, 'sessionId');
+      const text = readOptionalString(data, 'text');
+      const idempotencyKey = readOptionalString(data, 'idempotencyKey');
+      const images = readPromptImages(data.images);
+      if (!workspaceId || !sessionId || text === null || text === undefined || idempotencyKey === null || images === null) {
+        return null;
+      }
+      return { type: 'prompt', workspaceId, sessionId, text, images, idempotencyKey };
+    }
+
+    case 'steer': {
+      const sessionId = readRequiredString(data, 'sessionId');
+      const text = readOptionalString(data, 'text');
+      if (!sessionId || text === null || text === undefined) return null;
+      return { type: 'steer', sessionId, text };
+    }
+
+    case 'abort': {
+      const sessionId = readRequiredString(data, 'sessionId');
+      return sessionId ? { type: 'abort', sessionId } : null;
+    }
+
+    case 'status': {
+      const sessionId = readOptionalString(data, 'sessionId');
+      return sessionId === null ? null : { type: 'status', sessionId };
+    }
+
+    case 'list_workspaces':
+      return { type: 'list_workspaces' };
+
+    case 'list_sessions': {
+      const workspaceId = readRequiredString(data, 'workspaceId');
+      return workspaceId ? { type: 'list_sessions', workspaceId } : null;
+    }
+
+    case 'create_session': {
+      const workspaceId = readRequiredString(data, 'workspaceId');
+      const name = readOptionalString(data, 'name');
+      if (!workspaceId || name === null) return null;
+      return { type: 'create_session', workspaceId, name };
+    }
+
+    case 'list_files': {
+      const workspaceId = readRequiredString(data, 'workspaceId');
+      const requestPath = readRequiredString(data, 'path');
+      return workspaceId && requestPath
+        ? { type: 'list_files', workspaceId, path: requestPath }
+        : null;
+    }
+
+    case 'read_file': {
+      const workspaceId = readRequiredString(data, 'workspaceId');
+      const requestPath = readRequiredString(data, 'path');
+      return workspaceId && requestPath
+        ? { type: 'read_file', workspaceId, path: requestPath }
+        : null;
+    }
+
+    case 'list_artifacts': {
+      const sessionId = readRequiredString(data, 'sessionId');
+      return sessionId ? { type: 'list_artifacts', sessionId } : null;
+    }
+
+    case 'get_artifact': {
+      const artifactId = readRequiredString(data, 'artifactId');
+      return artifactId ? { type: 'get_artifact', artifactId } : null;
+    }
+
+    case 'create_web_token': {
+      const workspaceIds = readWorkspaceIds(data);
+      const label = readOptionalString(data, 'label');
+      const expiryDays = readOptionalFiniteNumber(data, 'expiryDays');
+      if (!workspaceIds || label === null || expiryDays === null) return null;
+      if (expiryDays !== undefined && (!Number.isInteger(expiryDays) || expiryDays <= 0)) {
+        return null;
+      }
+      return { type: 'create_web_token', workspaceIds, label, expiryDays };
+    }
+
+    case 'list_web_tokens':
+      return { type: 'list_web_tokens' };
+
+    case 'revoke_web_token': {
+      const tokenId = readRequiredString(data, 'tokenId');
+      return tokenId ? { type: 'revoke_web_token', tokenId } : null;
+    }
+
+    case 'get_session_history': {
+      const workspaceId = readRequiredString(data, 'workspaceId');
+      const sessionId = readRequiredString(data, 'sessionId');
+      return workspaceId && sessionId
+        ? { type: 'get_session_history', workspaceId, sessionId }
+        : null;
+    }
+  }
+
+  return null;
 }

--- a/apps/desktop/electron/features/gateway/server/request-handler.ts
+++ b/apps/desktop/electron/features/gateway/server/request-handler.ts
@@ -10,6 +10,13 @@ import type { GatewayRequest, GatewayResponse } from './protocol';
 import type { GatewayAgentOps } from '..';
 import type { CostTracker } from './cost-tracker';
 import type { GatewayAuth } from '../security/auth';
+import {
+  authorizeSession,
+  authorizeSessions,
+  hasSessionAccess,
+  hasWorkspaceAccess,
+  type GatewayAccessScope,
+} from './access-control';
 import { routeExtendedRequest } from './extended-handlers';
 
 // ── Idempotency store ───────────────────────────────────────
@@ -69,6 +76,7 @@ export async function routeAgentRequest(
   ws: WebSocket,
   agentOps: GatewayAgentOps,
   request: GatewayRequest,
+  accessScope: GatewayAccessScope,
   subscribeToSession: (sessionId: string) => void,
   getStatus: () => { running: boolean; port: number; host: string; clients: number },
   costTracker: CostTracker,
@@ -77,11 +85,19 @@ export async function routeAgentRequest(
 ): Promise<void> {
   // Try extended handlers first (file ops, artifacts, web tokens, sessions)
   if (auth) {
-    const handled = await routeExtendedRequest(ws, agentOps, request, auth, isMasterAuth ?? false);
+    const handled = await routeExtendedRequest(ws, agentOps, request, accessScope, auth, isMasterAuth ?? false);
     if (handled) return;
   }
   switch (request.type) {
     case 'prompt': {
+      if (!hasWorkspaceAccess(accessScope, request.workspaceId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'prompt',
+          message: `Workspace not authorized: ${request.workspaceId}`,
+        });
+        return;
+      }
       // Idempotency check — prevent duplicate execution from retries
       const idemKey = request.idempotencyKey;
       if (idemKey) {
@@ -116,10 +132,10 @@ export async function routeAgentRequest(
       }
 
       try {
-        // Subscribe client to this session for push events
-        subscribeToSession(request.sessionId);
-        // Ensure session is open
+        // Ensure session is open in an authorized workspace before granting access.
         await agentOps.openSession(request.sessionId, request.workspaceId);
+        subscribeToSession(request.sessionId);
+        authorizeSession(accessScope, request.sessionId);
         // Track session as active for concurrency limiting
         costTracker.markActive(request.sessionId);
         // Send prompt (with optional images)
@@ -143,6 +159,14 @@ export async function routeAgentRequest(
     }
 
     case 'steer': {
+      if (!hasSessionAccess(accessScope, request.sessionId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'steer',
+          message: `Session not authorized: ${request.sessionId}`,
+        });
+        return;
+      }
       try {
         await agentOps.steer(request.sessionId, request.text);
         sendResponse(ws, { type: 'ok', requestType: 'steer' });
@@ -157,6 +181,14 @@ export async function routeAgentRequest(
     }
 
     case 'abort': {
+      if (!hasSessionAccess(accessScope, request.sessionId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'abort',
+          message: `Session not authorized: ${request.sessionId}`,
+        });
+        return;
+      }
       try {
         await agentOps.abort(request.sessionId);
         sendResponse(ws, { type: 'ok', requestType: 'abort' });
@@ -182,10 +214,11 @@ export async function routeAgentRequest(
     case 'list_workspaces': {
       try {
         const workspaces = await agentOps.listWorkspaces();
+        const filtered = workspaces.filter((workspace) => hasWorkspaceAccess(accessScope, workspace.id));
         sendResponse(ws, {
           type: 'ok',
           requestType: 'list_workspaces',
-          data: workspaces,
+          data: filtered,
         });
       } catch (err) {
         sendResponse(ws, {
@@ -198,8 +231,17 @@ export async function routeAgentRequest(
     }
 
     case 'list_sessions': {
+      if (!hasWorkspaceAccess(accessScope, request.workspaceId)) {
+        sendResponse(ws, {
+          type: 'error',
+          requestType: 'list_sessions',
+          message: `Workspace not authorized: ${request.workspaceId}`,
+        });
+        return;
+      }
       try {
         const sessions = await agentOps.listSessions(request.workspaceId);
+        authorizeSessions(accessScope, sessions.map((session) => session.id));
         sendResponse(ws, {
           type: 'ok',
           requestType: 'list_sessions',

--- a/apps/desktop/electron/features/gateway/server/request-handler.ts
+++ b/apps/desktop/electron/features/gateway/server/request-handler.ts
@@ -11,8 +11,8 @@ import type { GatewayAgentOps } from '..';
 import type { CostTracker } from './cost-tracker';
 import type { GatewayAuth } from '../security/auth';
 import {
-  authorizeSession,
-  authorizeSessions,
+  authorizeSessionFromWorkspace,
+  authorizeSessionsFromWorkspace,
   hasSessionAccess,
   hasWorkspaceAccess,
   type GatewayAccessScope,
@@ -135,7 +135,7 @@ export async function routeAgentRequest(
         // Ensure session is open in an authorized workspace before granting access.
         await agentOps.openSession(request.sessionId, request.workspaceId);
         subscribeToSession(request.sessionId);
-        authorizeSession(accessScope, request.sessionId);
+        authorizeSessionFromWorkspace(accessScope, request.workspaceId, request.sessionId);
         // Track session as active for concurrency limiting
         costTracker.markActive(request.sessionId);
         // Send prompt (with optional images)
@@ -241,7 +241,11 @@ export async function routeAgentRequest(
       }
       try {
         const sessions = await agentOps.listSessions(request.workspaceId);
-        authorizeSessions(accessScope, sessions.map((session) => session.id));
+        authorizeSessionsFromWorkspace(
+          accessScope,
+          request.workspaceId,
+          sessions.map((session) => session.id),
+        );
         sendResponse(ws, {
           type: 'ok',
           requestType: 'list_sessions',

--- a/apps/desktop/electron/features/gateway/server/request-handler.ts
+++ b/apps/desktop/electron/features/gateway/server/request-handler.ts
@@ -85,7 +85,15 @@ export async function routeAgentRequest(
 ): Promise<void> {
   // Try extended handlers first (file ops, artifacts, web tokens, sessions)
   if (auth) {
-    const handled = await routeExtendedRequest(ws, agentOps, request, accessScope, auth, isMasterAuth ?? false);
+    const handled = await routeExtendedRequest(
+      ws,
+      agentOps,
+      request,
+      accessScope,
+      subscribeToSession,
+      auth,
+      isMasterAuth ?? false,
+    );
     if (handled) return;
   }
   switch (request.type) {

--- a/apps/desktop/electron/features/profile/manager.ts
+++ b/apps/desktop/electron/features/profile/manager.ts
@@ -13,7 +13,7 @@
  *     module level — those are not yet initialised when this runs.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { copyFileSync, existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -24,6 +24,7 @@ import type { ProfileEntry, ProfileRegistry, ProfileInfo } from './types';
 /** Fixed location for the profile registry — never changes. */
 const SERO_ROOT = path.join(os.homedir(), '.sero-ui');
 const REGISTRY_PATH = path.join(SERO_ROOT, 'profiles.json');
+export const PROFILE_REGISTRY_PATH = REGISTRY_PATH;
 
 /** Default SERO_HOME for the auto-created "Default" profile. */
 const DEFAULT_PROFILE_PATH = SERO_ROOT;
@@ -92,6 +93,23 @@ export function readRegistrySync(): ProfileRegistry {
   return parseRegistry(raw);
 }
 
+export interface ProfileRegistryLoadResult {
+  registry: ProfileRegistry;
+  error: ProfileRegistryError | null;
+}
+
+/** Read registry without throwing for malformed JSON. Used by startup recovery flows. */
+export function readRegistryLoadSync(): ProfileRegistryLoadResult {
+  try {
+    return { registry: readRegistrySync(), error: null };
+  } catch (error) {
+    if (error instanceof ProfileRegistryError) {
+      return { registry: emptyRegistry(), error };
+    }
+    throw error;
+  }
+}
+
 /** Write registry synchronously. */
 function writeRegistrySync(registry: ProfileRegistry): void {
   mkdirSync(SERO_ROOT, { recursive: true });
@@ -106,18 +124,49 @@ async function writeRegistryAsync(registry: ProfileRegistry): Promise<void> {
   await fs.rename(tmpFile, REGISTRY_PATH);
 }
 
+export interface ProfileRegistryResetResult {
+  registryPath: string;
+  backupPath: string | null;
+}
+
+/**
+ * Preserve a malformed profiles.json for inspection, then replace it with a
+ * fresh empty registry so the app can recover on next launch.
+ */
+export function backupAndResetRegistrySync(): ProfileRegistryResetResult {
+  mkdirSync(SERO_ROOT, { recursive: true });
+
+  let backupPath: string | null = null;
+  if (existsSync(REGISTRY_PATH)) {
+    const timestamp = new Date().toISOString().replace(/[.:]/g, '-');
+    backupPath = path.join(SERO_ROOT, `profiles.broken-${timestamp}.json`);
+    copyFileSync(REGISTRY_PATH, backupPath);
+  }
+
+  writeRegistrySync(emptyRegistry());
+  return { registryPath: REGISTRY_PATH, backupPath };
+}
+
 // ── ProfileManager ──────────────────────────────────────────
 
 class ProfileManager {
   private registry: ProfileRegistry;
+  private loadError: ProfileRegistryError | null = null;
 
   constructor() {
-    this.registry = readRegistrySync();
+    const result = readRegistryLoadSync();
+    this.registry = result.registry;
+    this.loadError = result.error;
   }
 
   /** Reload registry from disk (e.g. after external modification). */
   reload(): void {
     this.registry = readRegistrySync();
+    this.loadError = null;
+  }
+
+  getLoadError(): ProfileRegistryError | null {
+    return this.loadError;
   }
 
   // ── Queries ─────────────────────────────────────────────

--- a/apps/desktop/electron/features/profile/manager.ts
+++ b/apps/desktop/electron/features/profile/manager.ts
@@ -34,17 +34,62 @@ function emptyRegistry(): ProfileRegistry {
   return { version: 1, activeProfileId: null, profiles: [] };
 }
 
-/** Read registry synchronously. Returns empty registry if missing/corrupt. */
-export function readRegistrySync(): ProfileRegistry {
-  try {
-    if (!existsSync(REGISTRY_PATH)) return emptyRegistry();
-    const raw = readFileSync(REGISTRY_PATH, 'utf8');
-    const parsed = JSON.parse(raw) as ProfileRegistry;
-    if (!parsed || !Array.isArray(parsed.profiles)) return emptyRegistry();
-    return { ...emptyRegistry(), ...parsed };
-  } catch {
-    return emptyRegistry();
+export class ProfileRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ProfileRegistryError';
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isProfileEntry(value: unknown): value is ProfileEntry {
+  if (!isRecord(value)) return false;
+  return typeof value.id === 'string'
+    && typeof value.name === 'string'
+    && typeof value.path === 'string'
+    && typeof value.createdAt === 'string'
+    && (value.onboarded === undefined || typeof value.onboarded === 'boolean');
+}
+
+function parseRegistry(raw: string): ProfileRegistry {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown JSON parse failure';
+    throw new ProfileRegistryError(`profiles.json is malformed: ${message}`);
+  }
+
+  if (!isRecord(parsed)) {
+    throw new ProfileRegistryError('profiles.json must contain a JSON object');
+  }
+
+  const { activeProfileId, profiles, version } = parsed;
+  if (version !== undefined && version !== 1) {
+    throw new ProfileRegistryError(`profiles.json has unsupported version: ${String(version)}`);
+  }
+  if (activeProfileId !== null && activeProfileId !== undefined && typeof activeProfileId !== 'string') {
+    throw new ProfileRegistryError('profiles.json activeProfileId must be a string or null');
+  }
+  if (!Array.isArray(profiles) || !profiles.every(isProfileEntry)) {
+    throw new ProfileRegistryError('profiles.json profiles must be an array of valid profile entries');
+  }
+
+  return {
+    version: 1,
+    activeProfileId: activeProfileId ?? null,
+    profiles,
+  };
+}
+
+/** Read registry synchronously. Missing registry = empty; malformed registry = explicit failure. */
+export function readRegistrySync(): ProfileRegistry {
+  if (!existsSync(REGISTRY_PATH)) return emptyRegistry();
+  const raw = readFileSync(REGISTRY_PATH, 'utf8');
+  return parseRegistry(raw);
 }
 
 /** Write registry synchronously. */

--- a/apps/desktop/electron/features/profile/recovery.ts
+++ b/apps/desktop/electron/features/profile/recovery.ts
@@ -1,0 +1,75 @@
+import { dialog, shell } from 'electron';
+
+import { backupAndResetRegistrySync } from './manager';
+
+export interface ProfileRegistryStartupIssue {
+  kind: 'malformed_profile_registry';
+  registryPath: string;
+  message: string;
+}
+
+export async function handleProfileRegistryRecovery(
+  issue: ProfileRegistryStartupIssue,
+): Promise<'relaunch' | 'quit'> {
+  while (true) {
+    const choice = await dialog.showMessageBox({
+      type: 'warning',
+      buttons: ['Reset and Restart', 'Open Folder', 'Quit'],
+      defaultId: 0,
+      cancelId: 2,
+      noLink: true,
+      title: 'Recover profile registry',
+      message: 'Sero could not read your profile registry.',
+      detail: [
+        issue.message,
+        '',
+        `Registry: ${issue.registryPath}`,
+        '',
+        'Reset will back up the broken file and replace it with an empty profiles.json so Sero can start again.',
+        'Choose Open Folder if you want to inspect or repair the file manually first.',
+      ].join('\n'),
+    });
+
+    if (choice.response === 0) {
+      try {
+        const result = backupAndResetRegistrySync();
+        await dialog.showMessageBox({
+          type: 'info',
+          buttons: ['Restart Sero'],
+          defaultId: 0,
+          cancelId: 0,
+          noLink: true,
+          title: 'Profile registry reset',
+          message: 'Sero repaired the profile registry and is ready to restart.',
+          detail: result.backupPath
+            ? `Backup saved to ${result.backupPath}`
+            : `A fresh registry was written to ${result.registryPath}`,
+        });
+        return 'relaunch';
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const retry = await dialog.showMessageBox({
+          type: 'error',
+          buttons: ['Try Again', 'Quit'],
+          defaultId: 0,
+          cancelId: 1,
+          noLink: true,
+          title: 'Profile recovery failed',
+          message: 'Sero could not reset the broken profile registry.',
+          detail: message,
+        });
+        if (retry.response === 1) {
+          return 'quit';
+        }
+        continue;
+      }
+    }
+
+    if (choice.response === 1) {
+      await shell.showItemInFolder(issue.registryPath);
+      continue;
+    }
+
+    return 'quit';
+  }
+}

--- a/apps/desktop/electron/features/subagent/core/tracker.ts
+++ b/apps/desktop/electron/features/subagent/core/tracker.ts
@@ -124,6 +124,16 @@ export class SubagentTracker {
     this.endWithStatus(id, 'aborted', 'Aborted by user');
   }
 
+  /** Mark all running entries for a parent session as aborted. */
+  abortByParentSession(parentSessionId: string): void {
+    for (const [id, entry] of this.entries) {
+      if (entry.parentSessionId !== parentSessionId || entry.status !== 'running') {
+        continue;
+      }
+      this.endWithStatus(id, 'aborted', 'Aborted by user');
+    }
+  }
+
   /** Mark a run as timed out. */
   timeout(id: string): void {
     const entry = this.entries.get(id);

--- a/apps/desktop/electron/features/subagent/index.ts
+++ b/apps/desktop/electron/features/subagent/index.ts
@@ -444,6 +444,7 @@ export class SubagentManager {
   // ── Management ─────────────────────────────────────────────
 
   abortAll(parentSessionId: string): void {
+    this.tracker.abortByParentSession(parentSessionId);
     this.pool.abortAll(parentSessionId);
   }
 

--- a/apps/desktop/electron/features/subagent/runtime/runner.ts
+++ b/apps/desktop/electron/features/subagent/runtime/runner.ts
@@ -200,7 +200,7 @@ export async function runSubagent(
       sessionManager: SessionManager.inMemory(sessionPath),
       settingsManager: infra.settingsManager,
       systemPromptSuffix: agent.systemPrompt,
-    } as Parameters<typeof createAgentSession>[0]); // systemPromptSuffix is a Sero extension not in the SDK's public type
+    });
     session = result.session;
 
     let effectiveThinking = resolved.thinking;
@@ -269,8 +269,8 @@ export async function runSubagent(
       // Forward all events to the debug log (same file as main sessions)
       logRawEvent(subagentSessionId, event);
 
-      if (event.type === 'turn_start') {
-        logTurnContext(subagentSessionId, session!);
+      if (event.type === 'turn_start' && session) {
+        logTurnContext(subagentSessionId, session);
       }
 
       // Tool execution events → tool activity feed + stall detection

--- a/apps/desktop/electron/features/vcs/core/git-runner.ts
+++ b/apps/desktop/electron/features/vcs/core/git-runner.ts
@@ -12,6 +12,29 @@ import type { GitResult } from '../support/types';
 
 const execFileAsync = promisify(execFile);
 
+interface ExecFileFailure {
+  code?: unknown;
+  stdout?: unknown;
+  stderr?: unknown;
+  message?: unknown;
+}
+
+function normalizeExecFileFailure(error: unknown): { code: number; stdout: string; stderr: string } {
+  const failure = typeof error === 'object' && error !== null
+    ? (error as ExecFileFailure)
+    : null;
+
+  return {
+    code: typeof failure?.code === 'number' ? failure.code : 1,
+    stdout: typeof failure?.stdout === 'string' ? failure.stdout : '',
+    stderr: typeof failure?.stderr === 'string'
+      ? failure.stderr
+      : typeof failure?.message === 'string'
+        ? failure.message
+        : 'git command failed',
+  };
+}
+
 /**
  * Check if the host likely has SSH keys that can authenticate with GitHub.
  * Cached after first check for the process lifetime.
@@ -34,9 +57,10 @@ async function isHostSshAvailable(): Promise<boolean> {
   try {
     const { stderr } = await execFileAsync('ssh', ['-T', '-o', 'StrictHostKeyChecking=accept-new', '-o', 'ConnectTimeout=5', 'git@github.com'], {
       timeout: 10_000,
-    }).catch((err: any) => {
+    }).catch((error: unknown) => {
       // ssh -T exits with code 1 on success ("You've successfully authenticated")
-      return { stdout: String(err?.stdout ?? ''), stderr: String(err?.stderr ?? '') };
+      const normalized = normalizeExecFileFailure(error);
+      return { stdout: normalized.stdout, stderr: normalized.stderr };
     });
     _sshAvailable = stderr.includes('successfully authenticated');
   } catch {
@@ -128,12 +152,12 @@ export class GitRunner {
         env,
       });
       return { exitCode: 0, stdout, stderr };
-    } catch (err: any) {
-      const code = typeof err?.code === 'number' ? err.code : 1;
+    } catch (error: unknown) {
+      const normalized = normalizeExecFileFailure(error);
       return {
-        exitCode: code,
-        stdout: String(err?.stdout ?? ''),
-        stderr: String(err?.stderr ?? err?.message ?? 'git command failed'),
+        exitCode: normalized.code,
+        stdout: normalized.stdout,
+        stderr: normalized.stderr,
       };
     }
   }

--- a/apps/desktop/electron/ipc/gateway/gateway-ops.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway-ops.ts
@@ -59,6 +59,18 @@ interface SessionPool {
   } | undefined;
 }
 
+async function findSessionInfo(workspaceId: string, sessionId: string): Promise<{
+  id: string;
+  cwd: string;
+  path: string;
+} | null> {
+  const wsPath = workspaceManager.getPath(workspaceId);
+  if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
+
+  const allSessions = await SessionManager.list(os.homedir(), SERO_SESSION_DIR);
+  return allSessions.find((session) => session.id === sessionId && session.cwd === wsPath) ?? null;
+}
+
 /**
  * Build the full GatewayAgentOps implementation.
  *
@@ -78,6 +90,13 @@ export function buildGatewayOps(
         }
         return;
       }
+
+      const existingSession = await findSessionInfo(workspaceId, sessionId);
+      if (existingSession) {
+        await openSessionInternal(sessionId, existingSession.path, workspaceId);
+        return;
+      }
+
       const wsPath = workspaceManager.getPath(workspaceId);
       if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
       const sm = SessionManager.create(wsPath, SERO_SESSION_DIR);
@@ -194,10 +213,7 @@ export function buildGatewayOps(
         return convertToGatewayHistory(chatMsgs);
       }
       // Otherwise, find and read the session file directly
-      const wsPath = workspaceManager.getPath(workspaceId);
-      if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
-      const allSessions = await SessionManager.list(os.homedir(), SERO_SESSION_DIR);
-      const sessionInfo = allSessions.find((s) => s.id === sessionId && s.cwd === wsPath);
+      const sessionInfo = await findSessionInfo(workspaceId, sessionId);
       if (!sessionInfo) throw new Error(`Session not found: ${sessionId}`);
       const sm = SessionManager.open(sessionInfo.path, SERO_SESSION_DIR);
       const branch = sm.getBranch();

--- a/apps/desktop/electron/ipc/gateway/gateway-ops.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway-ops.ts
@@ -71,7 +71,13 @@ export function buildGatewayOps(
 ): GatewayAgentOps {
   return {
     openSession: async (sessionId, workspaceId) => {
-      if (pool.has(sessionId)) return;
+      const existing = pool.get(sessionId);
+      if (existing) {
+        if (existing.workspaceId !== workspaceId) {
+          throw new Error(`Session ${sessionId} is bound to workspace ${existing.workspaceId}, not ${workspaceId}`);
+        }
+        return;
+      }
       const wsPath = workspaceManager.getPath(workspaceId);
       if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
       const sm = SessionManager.create(wsPath, SERO_SESSION_DIR);

--- a/apps/desktop/electron/ipc/gateway/gateway-ops.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway-ops.ts
@@ -182,9 +182,14 @@ export function buildGatewayOps(
       return { base64: a.base64 ?? '', mimeType: a.mimeType, title: a.title };
     },
     getSessionHistory: async (workspaceId, sessionId) => {
-      // If session is already open in the pool, read from live state
+      // If session is already open in the pool, read from live state.
+      // Still enforce the workspace/session binding so a scoped token cannot
+      // claim a foreign session ID under an authorized workspace.
       const existing = pool.get(sessionId);
       if (existing) {
+        if (existing.workspaceId !== workspaceId) {
+          throw new Error(`Session ${sessionId} is bound to workspace ${existing.workspaceId}, not ${workspaceId}`);
+        }
         const chatMsgs = convertSessionMessages(existing.session.messages);
         return convertToGatewayHistory(chatMsgs);
       }

--- a/apps/desktop/electron/ipc/gateway/gateway.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway.ts
@@ -82,9 +82,9 @@ export function registerGatewayHandlers(): void {
 
   ipcMain.handle(
     IpcChannels.gateway.createWebToken,
-    async (_event, label?: string, expiryDays?: number) => {
+    async (_event, workspaceIds: string[], label?: string, expiryDays?: number) => {
       const auth = gatewayServer.getAuth();
-      return auth.webTokens.create(label, expiryDays);
+      return auth.webTokens.create(workspaceIds, label, expiryDays);
     },
   );
 
@@ -103,13 +103,14 @@ export function registerGatewayHandlers(): void {
 
   ipcMain.handle(
     IpcChannels.gateway.getQrLoginData,
-    async (_event, expiryDays?: number): Promise<QrLoginData> => {
+    async (_event, workspaceId: string, expiryDays?: number): Promise<QrLoginData> => {
       await startGateway();
 
       // Clamp expiry to 1–30 days to prevent bogus values from the renderer.
       const days = Math.max(1, Math.min(expiryDays ?? 7, 30));
       const auth = gatewayServer.getAuth();
       const webToken = auth.webTokens.create(
+        [workspaceId],
         `QR login ${new Date().toLocaleDateString()}`,
         days,
       );

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,5 +1,11 @@
 // Load .env BEFORE any SDK imports (they read process.env at module level)
-import { loadSeroEnv, SERO_AGENT_DIR, SERO_HOME, ACTIVE_PROFILE_ID } from './platform/env';
+import {
+  loadSeroEnv,
+  SERO_AGENT_DIR,
+  SERO_HOME,
+  ACTIVE_PROFILE_ID,
+  PROFILE_STARTUP_ISSUE,
+} from './platform/env';
 loadSeroEnv();
 
 import { app, components, BrowserWindow, session, shell } from 'electron';
@@ -26,6 +32,7 @@ import { registerExtProtocolScheme, setupExtProtocol, registerAllExtAssets } fro
 import { discoverApps, registerAppPath } from './features/apps/discovery';
 import { watchForNewApps } from './ipc/apps';
 import { ensureDefaultAgents, ensureDefaultSkills, ensureDefaultThemes, ensureProfileTemplates } from './features/profile/setup';
+import { handleProfileRegistryRecovery } from './features/profile/recovery';
 import { containerManager, fileWatcherManager, lspManager, vcsManager, gatewayServer } from './shared/infra/shared-infra';
 import { startGateway, stopGateway } from './ipc/gateway';
 import { setupContentSecurityPolicy } from './platform/security/csp';
@@ -210,6 +217,15 @@ function createWindow() {
 }
 
 app.whenReady().then(async () => {
+  if (PROFILE_STARTUP_ISSUE) {
+    const recoveryAction = await handleProfileRegistryRecovery(PROFILE_STARTUP_ISSUE);
+    if (recoveryAction === 'relaunch') {
+      app.relaunch();
+    }
+    app.exit(0);
+    return;
+  }
+
   // Bootstrap Sero's agent directory (creates settings.json on first run)
   bootstrapAgentDir();
 

--- a/apps/desktop/electron/platform/env/index.ts
+++ b/apps/desktop/electron/platform/env/index.ts
@@ -17,7 +17,13 @@ import os from 'os';
 import path from 'path';
 
 import { migrateExistingInstall } from '@electron/features/profile/migration';
-import { readRegistrySync } from '@electron/features/profile/manager';
+import {
+  PROFILE_REGISTRY_PATH,
+  readRegistryLoadSync,
+  readRegistrySync,
+} from '@electron/features/profile/manager';
+import type { ProfileRegistry } from '@electron/features/profile/types';
+import type { ProfileRegistryStartupIssue } from '@electron/features/profile/recovery';
 
 // ── Fixed root — always ~/.sero-ui/ ─────────────────────────
 
@@ -40,6 +46,23 @@ export const SERO_FIXED_ROOT = path.join(os.homedir(), '.sero-ui');
  * inherits env vars from the parent process. If we checked SERO_HOME,
  * profile switching would be silently ignored after a relaunch.
  */
+let profileStartupIssue: ProfileRegistryStartupIssue | null = null;
+
+function loadRegistryForStartup(): ProfileRegistry {
+  const result = readRegistryLoadSync();
+  if (result.error) {
+    if (!profileStartupIssue) {
+      profileStartupIssue = {
+        kind: 'malformed_profile_registry',
+        registryPath: PROFILE_REGISTRY_PATH,
+        message: result.error.message,
+      };
+      console.error('[sero:profile] Malformed profiles.json detected:', result.error.message);
+    }
+  }
+  return result.registry;
+}
+
 function resolveProfileHome(): string {
   // Testing override — uses a SEPARATE env var that Sero never sets itself
   if (process.env.SERO_HOME_OVERRIDE) {
@@ -50,7 +73,7 @@ function resolveProfileHome(): string {
   migrateExistingInstall();
 
   // Read profile registry
-  const registry = readRegistrySync();
+  const registry = loadRegistryForStartup();
 
   if (registry.activeProfileId) {
     const active = registry.profiles.find(
@@ -127,11 +150,13 @@ export const AUTH_JSON_PATH = path.join(SERO_AGENT_DIR, 'auth.json');
 // has run any auto-repair. This avoids 3× synchronous file reads at startup.
 const _postResolveRegistry = process.env.SERO_HOME_OVERRIDE
   ? { activeProfileId: null as string | null, profiles: [] as { id: string }[] }
-  : readRegistrySync();
+  : loadRegistryForStartup();
 
 /** The active profile ID (null if no profile yet). */
 export const ACTIVE_PROFILE_ID: string | null = _postResolveRegistry.activeProfileId;
 
+/** Non-null when startup was forced into recovery mode for a broken profiles.json. */
+export const PROFILE_STARTUP_ISSUE = profileStartupIssue;
 
 const ENV_PATH = path.join(SERO_AGENT_DIR, '.env');
 

--- a/apps/desktop/electron/preload/platform/host-services.ts
+++ b/apps/desktop/electron/preload/platform/host-services.ts
@@ -56,8 +56,8 @@ export const safeStorageBridge = {
 };
 
 export const gatewayBridge = {
-  getQrLoginData: (expiryDays?: number): Promise<QrLoginData> =>
-    ipcRenderer.invoke(IpcChannels.gateway.getQrLoginData, expiryDays),
+  getQrLoginData: (workspaceId: string, expiryDays?: number): Promise<QrLoginData> =>
+    ipcRenderer.invoke(IpcChannels.gateway.getQrLoginData, workspaceId, expiryDays),
 };
 
 export const clipboardBridge = {

--- a/apps/desktop/electron/types/pi-coding-agent.d.ts
+++ b/apps/desktop/electron/types/pi-coding-agent.d.ts
@@ -1,0 +1,11 @@
+import '@mariozechner/pi-coding-agent';
+
+declare module '@mariozechner/pi-coding-agent' {
+  interface CreateAgentSessionOptions {
+    /**
+     * Sero-specific prompt suffix appended after the resolved system prompt.
+     * Used by the subagent runtime for markdown-defined agent instructions.
+     */
+    systemPromptSuffix?: string;
+  }
+}

--- a/apps/desktop/src/components/layout/ConnectDeviceDialog.tsx
+++ b/apps/desktop/src/components/layout/ConnectDeviceDialog.tsx
@@ -111,7 +111,8 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
           </DialogTitle>
           <DialogDescription>
             Scan this QR code with your phone to open Sero Remote.
-            Access will be limited to the <span className="font-medium text-foreground">{activeWorkspaceName}</span> workspace.
+            This pairing will share only the <span className="font-medium text-foreground">{activeWorkspaceName}</span> workspace,
+            and the paired browser will only be able to open that workspace’s sessions, files, and artifacts.
           </DialogDescription>
         </DialogHeader>
 
@@ -136,10 +137,22 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
                 />
               </div>
 
+              <div className="w-full rounded-lg border border-border bg-muted/40 px-3 py-2 text-xs">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-muted-foreground">Shared workspace</span>
+                  <span className="font-medium text-foreground">{activeWorkspaceName}</span>
+                </div>
+                <div className="mt-1 flex items-center justify-between gap-3">
+                  <span className="text-muted-foreground">Access expires</span>
+                  <span className="font-medium text-foreground">
+                    {expiresFormatted}
+                  </span>
+                </div>
+              </div>
+
               <p className="text-xs text-muted-foreground">
-                Valid for {data.expiryDays} day{data.expiryDays === 1 ? '' : 's'}
-                {' — expires '}
-                {expiresFormatted}
+                Valid for {data.expiryDays} day{data.expiryDays === 1 ? '' : 's'}.
+                To share a different workspace later, generate a new code from that workspace in Sero desktop.
               </p>
 
               {/* ── Login URL + copy ─────────────────────────── */}
@@ -198,8 +211,8 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
           <p className="text-center text-[11px] leading-relaxed text-muted-foreground/70">
             Or paste the URL in your phone's browser.
             <br />
-            The token auto-saves on the device and won't need re-entry
-            until it expires.
+            The token auto-saves on the device, but it stays limited to {activeWorkspaceName}
+            until it expires or you create a new pairing.
           </p>
         </div>
       </DialogContent>

--- a/apps/desktop/src/components/layout/ConnectDeviceDialog.tsx
+++ b/apps/desktop/src/components/layout/ConnectDeviceDialog.tsx
@@ -25,6 +25,7 @@ import {
 import { Button } from '@sero-ai/ui/components/ui/button';
 import type { QrLoginData } from '@/types/ipc';
 import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
+import { useWorkspaceStore } from '@/stores/workspace';
 
 interface Props {
   open: boolean;
@@ -34,6 +35,10 @@ interface Props {
 type Phase = 'idle' | 'loading' | 'ready' | 'error';
 
 export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId ?? 'global');
+  const activeWorkspaceName = useWorkspaceStore(
+    (s) => s.workspaces.find((workspace) => workspace.id === (s.activeWorkspaceId ?? 'global'))?.name ?? 'Global',
+  );
   const [phase, setPhase] = useState<Phase>('idle');
   const [data, setData] = useState<QrLoginData | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -46,14 +51,14 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
     setCopied(false);
     setCopyFailed(false);
     try {
-      const result = await window.sero.gateway.getQrLoginData(7);
+      const result = await window.sero.gateway.getQrLoginData(activeWorkspaceId, 7);
       setData(result);
       setPhase('ready');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate QR code');
       setPhase('error');
     }
-  }, []);
+  }, [activeWorkspaceId]);
 
   // Generate QR data when the dialog opens. The parent controls `open`
   // via props, so onOpenChange(true) is never called by radix — we need
@@ -106,6 +111,7 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
           </DialogTitle>
           <DialogDescription>
             Scan this QR code with your phone to open Sero Remote.
+            Access will be limited to the <span className="font-medium text-foreground">{activeWorkspaceName}</span> workspace.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/desktop/src/lsp/use-lsp.ts
+++ b/apps/desktop/src/lsp/use-lsp.ts
@@ -7,6 +7,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { useContainerStore } from '@/stores/container';
+import type * as MonacoNamespace from 'monaco-editor';
 import type { editor, languages, IRange } from 'monaco-editor';
 import type { LspCompletionSuggestion } from './lsp-conversions';
 import {
@@ -15,7 +16,7 @@ import {
   LSP_LANGUAGES,
 } from './lsp-conversions';
 
-type Monaco = typeof import('monaco-editor');
+type Monaco = typeof MonacoNamespace;
 
 // Module-level tracking: which language IDs have providers registered.
 // Providers are registered once (Monaco doesn't support un-register), so

--- a/apps/desktop/src/types/electron-services.d.ts
+++ b/apps/desktop/src/types/electron-services.d.ts
@@ -10,10 +10,11 @@ import type {
 export interface SeroGatewayAPI {
   /**
    * Generate a QR code for device pairing.
-   * Creates a time-limited web token and returns the QR data URL + login URL.
+   * Creates a time-limited web token scoped to one workspace and returns the QR data URL + login URL.
+   * @param workspaceId Workspace the remote device is authorized to access.
    * @param expiryDays  Number of days until the token expires (default 7).
    */
-  getQrLoginData(expiryDays?: number): Promise<QrLoginData>;
+  getQrLoginData(workspaceId: string, expiryDays?: number): Promise<QrLoginData>;
 }
 
 export interface SeroLocalModelsAPI {

--- a/apps/web-remote/src/components/AccessBanner.tsx
+++ b/apps/web-remote/src/components/AccessBanner.tsx
@@ -1,0 +1,60 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { AlertCircle, Shield, X } from 'lucide-react';
+
+import {
+  describeGatewayScope,
+  humanizeGatewayRequestError,
+} from '@/lib/gateway-errors';
+import { useConnectionStore } from '@/stores/connection';
+import { useWorkspaceStore } from '@/stores/workspace';
+
+export function AccessBanner() {
+  const requestError = useConnectionStore((s) => s.requestError);
+  const clearRequestError = useConnectionStore((s) => s.clearRequestError);
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId);
+
+  const scope = describeGatewayScope(workspaces, activeWorkspaceId);
+  const error = requestError
+    ? humanizeGatewayRequestError(requestError, workspaces, activeWorkspaceId)
+    : null;
+
+  if (!scope && !error) {
+    return null;
+  }
+
+  return (
+    <div className="border-b border-border bg-card/95 px-3 py-2">
+      <div className="flex flex-col gap-2">
+        {scope && (
+          <div className="flex items-start gap-2 rounded-lg border border-border bg-background/70 px-3 py-2">
+            <Shield className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">{scope.title}</p>
+              <p className="text-xs text-muted-foreground">{scope.detail}</p>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+            <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-foreground">{error.title}</p>
+              <p className="text-xs text-muted-foreground">{error.detail}</p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="shrink-0 text-muted-foreground hover:text-foreground"
+              onClick={clearRequestError}
+              title="Dismiss message"
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web-remote/src/components/Layout.tsx
+++ b/apps/web-remote/src/components/Layout.tsx
@@ -13,6 +13,7 @@ import { FileBrowser } from './FileBrowser';
 import { FilePreview } from './FilePreview';
 import { ArtifactGallery } from './ArtifactGallery';
 import { StatusBar } from './StatusBar';
+import { AccessBanner } from './AccessBanner';
 import { useArtifactStore } from '@/stores/artifacts';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { useIsMobile } from '@sero-ai/ui/hooks/use-mobile';
@@ -90,6 +91,8 @@ export function Layout() {
           </Button>
         </div>
       </header>
+
+      <AccessBanner />
 
       {/* Main content row */}
       <div className="flex flex-1 min-h-0 overflow-hidden">

--- a/apps/web-remote/src/components/StatusBar.tsx
+++ b/apps/web-remote/src/components/StatusBar.tsx
@@ -5,6 +5,7 @@
 
 import { useConnectionStore } from '@/stores/connection';
 import { useWorkspaceStore } from '@/stores/workspace';
+import { describeGatewayScope } from '@/lib/gateway-errors';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { Separator } from '@sero-ai/ui/components/ui/separator';
 import { Circle } from 'lucide-react';
@@ -16,6 +17,7 @@ export function StatusBar() {
   const activeSessionId = useWorkspaceStore((s) => s.activeSessionId);
 
   const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
+  const scope = describeGatewayScope(workspaces, activeWorkspaceId);
 
   const statusColor = {
     disconnected: 'text-destructive',
@@ -45,6 +47,14 @@ export function StatusBar() {
             <Separator orientation="vertical" className="h-3" />
             <span className="text-foreground/60">
               {activeWorkspace.name}
+            </span>
+          </>
+        )}
+        {scope && (
+          <>
+            <Separator orientation="vertical" className="h-3" />
+            <span className="text-foreground/60">
+              Scope: {scope.shortLabel}
             </span>
           </>
         )}

--- a/apps/web-remote/src/lib/gateway-errors.test.ts
+++ b/apps/web-remote/src/lib/gateway-errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  describeGatewayScope,
+  humanizeGatewayRequestError,
+} from '@/lib/gateway-errors';
+
+describe('gateway error helpers', () => {
+  it('describes a single-workspace pairing scope clearly', () => {
+    expect(
+      describeGatewayScope([
+        { id: 'workspace-a', name: 'Workspace A' },
+      ], 'workspace-a'),
+    ).toEqual({
+      title: 'Device access: Workspace A',
+      detail: 'This paired device can only access this workspace.',
+      shortLabel: 'Workspace A',
+    });
+  });
+
+  it('humanizes unauthorized workspace errors with scope guidance', () => {
+    const result = humanizeGatewayRequestError(
+      {
+        requestType: 'list_sessions',
+        message: 'Workspace not authorized: workspace-b',
+      },
+      [{ id: 'workspace-a', name: 'Workspace A' }],
+      'workspace-a',
+    );
+
+    expect(result.title).toBe('That workspace was not shared with this device');
+    expect(result.detail).toContain('pair this device again from Sero desktop');
+    expect(result.detail).toContain('Workspace A');
+  });
+
+  it('falls back to the raw gateway message for unknown errors', () => {
+    expect(
+      humanizeGatewayRequestError(
+        {
+          requestType: 'list_files',
+          message: 'Something unexpected happened',
+        },
+        [],
+        null,
+      ),
+    ).toEqual({
+      title: 'Sero Remote could not complete that action',
+      detail: 'Something unexpected happened',
+    });
+  });
+});

--- a/apps/web-remote/src/lib/gateway-errors.ts
+++ b/apps/web-remote/src/lib/gateway-errors.ts
@@ -1,0 +1,96 @@
+export interface GatewayWorkspaceSummary {
+  id: string;
+  name: string;
+}
+
+export interface GatewayRequestErrorInfo {
+  requestType: string;
+  message: string;
+}
+
+export interface GatewayScopeSummary {
+  title: string;
+  detail: string;
+  shortLabel: string;
+}
+
+export interface GatewayErrorPresentation {
+  title: string;
+  detail: string;
+}
+
+export function describeGatewayScope(
+  workspaces: GatewayWorkspaceSummary[],
+  activeWorkspaceId: string | null,
+): GatewayScopeSummary | null {
+  if (workspaces.length === 0) {
+    return null;
+  }
+
+  if (workspaces.length === 1) {
+    const [workspace] = workspaces;
+    return {
+      title: `Device access: ${workspace.name}`,
+      detail: 'This paired device can only access this workspace.',
+      shortLabel: workspace.name,
+    };
+  }
+
+  const activeWorkspace = activeWorkspaceId
+    ? workspaces.find((workspace) => workspace.id === activeWorkspaceId) ?? null
+    : null;
+
+  return {
+    title: `Device access: ${workspaces.length} workspaces`,
+    detail: activeWorkspace
+      ? `Currently browsing ${activeWorkspace.name}.`
+      : 'Select a workspace to start browsing files and sessions.',
+    shortLabel: `${workspaces.length} workspaces`,
+  };
+}
+
+export function humanizeGatewayRequestError(
+  error: GatewayRequestErrorInfo,
+  workspaces: GatewayWorkspaceSummary[],
+  activeWorkspaceId: string | null,
+): GatewayErrorPresentation {
+  const scope = describeGatewayScope(workspaces, activeWorkspaceId);
+  const scopeHint = scope
+    ? workspaces.length === 1
+      ? ` This device is paired only for ${scope.shortLabel}.`
+      : ` This device is currently limited to ${scope.shortLabel}.`
+    : '';
+
+  if (/workspace not authorized/i.test(error.message)) {
+    return {
+      title: 'That workspace was not shared with this device',
+      detail: `Switch back to a shared workspace or pair this device again from Sero desktop if you need broader access.${scopeHint}`,
+    };
+  }
+
+  if (/session not authorized/i.test(error.message)) {
+    return {
+      title: 'That session is outside this device’s access',
+      detail: `Open a session from a shared workspace instead, or pair this device again from the workspace that owns the session.${scopeHint}`,
+    };
+  }
+
+  if (/artifact not authorized/i.test(error.message)) {
+    return {
+      title: 'That artifact is outside this device’s access',
+      detail: `Artifacts can only be opened from sessions shared with this device. Return to the shared session or create a new pairing.${scopeHint}`,
+    };
+  }
+
+  if (/not authenticated/i.test(error.message)) {
+    return {
+      title: 'Your device is no longer authenticated',
+      detail: 'Reconnect with a valid device token from Sero desktop.',
+    };
+  }
+
+  return {
+    title: 'Sero Remote could not complete that action',
+    detail: error.message,
+  };
+}

--- a/apps/web-remote/src/stores/connection.test.ts
+++ b/apps/web-remote/src/stores/connection.test.ts
@@ -160,6 +160,7 @@ describe('connection store', () => {
     expect(storage.clear).toHaveBeenCalledTimes(1);
     expect(store.getState().token).toBeNull();
     expect(store.getState().authError).toBe('Invalid authentication token');
+    expect(store.getState().requestError).toBeNull();
   });
 
   it('keeps the saved token when connect fails for a transient reason', () => {
@@ -180,6 +181,7 @@ describe('connection store', () => {
     expect(store.getState().disconnectReason).toBe(
       'Too many authentication attempts. Try again later.',
     );
+    expect(store.getState().requestError).toBeNull();
   });
 
   it('does not restore a stored token after the user switches tokens mid-bootstrap', async () => {
@@ -209,6 +211,31 @@ describe('connection store', () => {
     expect(store.getState().isBootstrapping).toBe(false);
   });
 
+  it('captures non-auth request errors and clears them after a successful retry', () => {
+    const client = new FakeGatewayClient();
+    const storage = createStorage();
+    const store = createConnectionStore(client, storage);
+
+    client.emitMessage({
+      type: 'error',
+      requestType: 'get_session_history',
+      message: 'Session not authorized: session-b',
+    });
+
+    expect(store.getState().requestError).toEqual({
+      requestType: 'get_session_history',
+      message: 'Session not authorized: session-b',
+    });
+
+    client.emitMessage({
+      type: 'ok',
+      requestType: 'get_session_history',
+      data: [],
+    });
+
+    expect(store.getState().requestError).toBeNull();
+  });
+
   it('stays in reconnect mode after transport loss and supports immediate retry', () => {
     const client = new FakeGatewayClient();
     const storage = createStorage();
@@ -228,5 +255,6 @@ describe('connection store', () => {
 
     expect(client.retryCalls).toBe(1);
     expect(store.getState().disconnectReason).toBeNull();
+    expect(store.getState().requestError).toBeNull();
   });
 });

--- a/apps/web-remote/src/stores/connection.ts
+++ b/apps/web-remote/src/stores/connection.ts
@@ -11,6 +11,7 @@ import {
   type GatewayMessage,
 } from '@/lib/gateway-client';
 import { isInvalidAuthTokenMessage } from '@/lib/connect-errors';
+import type { GatewayRequestErrorInfo } from '@/lib/gateway-errors';
 import { saveToken, loadToken, clearToken } from '@/lib/token-storage';
 
 interface TokenStorageAdapter {
@@ -49,6 +50,7 @@ interface ConnectionStore {
   token: string | null;
   authError: string | null;
   disconnectReason: string | null;
+  requestError: GatewayRequestErrorInfo | null;
   isBootstrapping: boolean;
   isInitialized: boolean;
 
@@ -60,6 +62,8 @@ interface ConnectionStore {
   retry: () => void;
   /** Disconnect and forget the saved pairing token. */
   disconnect: () => void;
+  /** Dismiss the latest non-auth request error banner. */
+  clearRequestError: () => void;
   /** Called internally when a message arrives. */
   handleMessage: (msg: GatewayMessage) => void;
 }
@@ -130,6 +134,7 @@ export function createConnectionStore(
       token: null,
       authError: null,
       disconnectReason: null,
+      requestError: null,
       isBootstrapping: false,
       isInitialized: false,
 
@@ -140,6 +145,7 @@ export function createConnectionStore(
           token: trimmed,
           authError: null,
           disconnectReason: null,
+          requestError: null,
           isBootstrapping: false,
           isInitialized: true,
         });
@@ -153,6 +159,7 @@ export function createConnectionStore(
           isBootstrapping: true,
           authError: null,
           disconnectReason: null,
+          requestError: null,
         });
 
         const finalize = (token: string | null) => {
@@ -163,6 +170,7 @@ export function createConnectionStore(
             token,
             authError: null,
             disconnectReason: null,
+            requestError: null,
             isBootstrapping: false,
             isInitialized: true,
           });
@@ -186,7 +194,7 @@ export function createConnectionStore(
       },
 
       retry: () => {
-        set({ authError: null, disconnectReason: null });
+        set({ authError: null, disconnectReason: null, requestError: null });
         client.retryNow();
       },
 
@@ -197,33 +205,57 @@ export function createConnectionStore(
           token: null,
           authError: null,
           disconnectReason: null,
+          requestError: null,
           isBootstrapping: false,
           isInitialized: true,
         });
       },
 
+      clearRequestError: () => {
+        set({ requestError: null });
+      },
+
       handleMessage: (msg: GatewayMessage) => {
-        if (msg.type === 'ok' && 'requestType' in msg && msg.requestType === 'connect') {
-          const { token } = get();
-          set({ authError: null, disconnectReason: null });
-          if (token) {
-            void tokenStorage.save(token);
+        if (msg.type === 'ok' && 'requestType' in msg) {
+          if (msg.requestType === 'connect') {
+            const { token } = get();
+            set({ authError: null, disconnectReason: null, requestError: null });
+            if (token) {
+              void tokenStorage.save(token);
+            }
+            return;
+          }
+
+          const currentRequestError = get().requestError;
+          if (currentRequestError?.requestType === msg.requestType) {
+            set({ requestError: null });
           }
           return;
         }
 
-        if (msg.type === 'error' && 'requestType' in msg && msg.requestType === 'connect') {
-          const message = (msg as { message: string }).message;
-          const forgetToken = isInvalidAuthTokenMessage(message);
-          if (forgetToken) {
-            void tokenStorage.clear();
+        if (msg.type === 'error' && 'requestType' in msg) {
+          if (msg.requestType === 'connect') {
+            const message = (msg as { message: string }).message;
+            const forgetToken = isInvalidAuthTokenMessage(message);
+            if (forgetToken) {
+              void tokenStorage.clear();
+            }
+            set({
+              token: forgetToken ? null : get().token,
+              authError: forgetToken ? message : null,
+              disconnectReason: forgetToken ? null : message,
+              requestError: null,
+              isBootstrapping: false,
+              isInitialized: true,
+            });
+            return;
           }
+
           set({
-            token: forgetToken ? null : get().token,
-            authError: forgetToken ? message : null,
-            disconnectReason: forgetToken ? null : message,
-            isBootstrapping: false,
-            isInitialized: true,
+            requestError: {
+              requestType: msg.requestType,
+              message: msg.message,
+            },
           });
         }
       },

--- a/docs/deslop.md
+++ b/docs/deslop.md
@@ -4,6 +4,38 @@ Changes made during code quality passes. Most recent first.
 
 ---
 
+## 2026-04-12
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `apps/desktop/electron/features/editor/lsp/lsp-manager.ts` | Added in-flight startup deduping so repeated `startServer()` calls share one workspace/language boot |
+| `apps/desktop/electron/features/editor/lsp/lsp-process.ts` | Replaced protocol-boundary `any` reads with explicit initialize/configuration/error helpers |
+| `apps/desktop/src/lsp/use-lsp.ts` | Replaced inline Monaco type import with a top-level namespace type import |
+| `apps/desktop/electron/features/profile/manager.ts` | Hardened `profiles.json` parsing — malformed registries now fail closed instead of looking like first run |
+| `apps/desktop/electron/features/auth/github/auth-manager.ts` | Removed base64-only GitHub token persistence fallback; secure storage is now required |
+| `apps/desktop/electron/features/vcs/core/git-runner.ts` | Replaced `any`-typed exec failure handling with a shared typed normalizer |
+| `apps/desktop/electron/features/subagent/core/tracker.ts` | Added parent-session bulk-abort tracker updates |
+| `apps/desktop/electron/features/subagent/index.ts` | `abortAll()` now updates tracker state before aborting pool controllers |
+| `apps/desktop/electron/features/subagent/runtime/runner.ts` | Removed `createAgentSession()` cast and `session!` assertion from the subagent runtime |
+| `apps/desktop/electron/types/pi-coding-agent.d.ts` | New — local Pi SDK module augmentation for typed `systemPromptSuffix` support |
+| `apps/desktop/electron/features/gateway/server/access-control.ts` | New — shared workspace/session/artifact authorization helpers for gateway requests |
+| `apps/desktop/electron/features/gateway/bridge/web-tokens.ts` | Web tokens now carry explicit workspace scopes and validate to token records instead of booleans |
+| `apps/desktop/electron/features/gateway/security/auth.ts` | Gateway auth now returns scoped auth results for master vs web-token clients |
+| `apps/desktop/electron/features/gateway/index.ts` | Enforced scoped client access in connection state and filtered session-scoped push/broadcast events |
+| `apps/desktop/electron/features/gateway/server/request-handler.ts` | Added workspace/session authorization checks for core gateway routes |
+| `apps/desktop/electron/features/gateway/server/extended-handlers.ts` | Added workspace/session/artifact authorization checks for file/history/web-token routes |
+| `apps/desktop/electron/features/gateway/server/protocol.ts` | Extended `create_web_token` request shape with explicit `workspaceIds` |
+| `apps/desktop/electron/ipc/gateway/gateway-ops.ts` | `openSession()` now rejects workspace/session mismatches instead of silently reopening cross-workspace sessions |
+| `apps/desktop/electron/ipc/gateway/gateway.ts` | QR/web-token IPC now creates workspace-scoped tokens |
+| `apps/desktop/electron/preload/platform/host-services.ts` | Updated gateway bridge to require a workspace ID for QR login generation |
+| `apps/desktop/src/types/electron-services.d.ts` | Updated renderer gateway API contract for workspace-scoped QR login generation |
+| `apps/desktop/src/components/layout/ConnectDeviceDialog.tsx` | QR pairing now scopes remote access to the active workspace and surfaces that in the dialog |
+| `apps/desktop/electron/features/gateway/channels/discord.ts` | Fixed `/sero abort` so it actually aborts the active session and reports failures |
+
+---
+
 ## 2026-04-06
 
 ### Files Changed

--- a/docs/deslopify/apps/desktop/electron/features/auth/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/auth/facts.md
@@ -1,0 +1,32 @@
+# Facts — apps/desktop/electron/features/auth
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This feature owns the app-level GitHub and Google auth/runtime integration: GitHub device-flow login plus repo-creation helpers for VCS workflows, and Google OAuth + gog keyring integration for Gmail/Calendar-style plugin commands with profile-aware token migration.
+
+## Shape & metrics
+- Total files: 4
+- Largest file: `apps/desktop/electron/features/auth/google/auth-manager.ts` (418 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥400 LOC): `apps/desktop/electron/features/auth/google/auth-manager.ts` (418)
+- External dependencies of note: Electron `safeStorage`/`shell`, GitHub OAuth endpoints, `gh` CLI, `gog` CLI + file keyring, profile registry, workspace/container-aware `GitRunner`
+- Upstream callers: `apps/desktop/electron/shared/infra/shared-infra.ts`, `apps/desktop/electron/ipc/integrations/github.ts`, `apps/desktop/electron/ipc/integrations/google-api.ts`, `apps/desktop/electron/features/vcs/core/git-runner.ts`, `apps/desktop/electron/cli/lib/gog-runner.ts`, auth tests
+- Downstream dependencies: repo publish/bootstrap flows, host/container git auth injection, Google plugin command execution, per-profile gog client naming and migration
+
+## Architectural notes
+- GitHub auth still carries a legacy root-file shim, but the active write path is profile-scoped under `SERO_AGENT_DIR`.
+- Google auth owns both the live OAuth flow and the migration path out of the previous buggy profile-scoped keyring-password scheme into per-profile client buckets.
+- `gog` binary/PATH discovery is duplicated across this feature, `ipc/integrations/google-api.ts`, and `cli/lib/gog-runner.ts`, so auth runtime assumptions are spread across three layers.
+- GitHub repo creation logic includes its own GitHub URL normalization helpers while renderer publish/origin UI has its own parallel copies.
+
+## Runtime-sensitive surfaces
+- Secret persistence is a high-risk boundary: GitHub tokens, Google refresh tokens, and gog credentials must remain profile-scoped and non-leaky.
+- GitHub device-flow polling/cancellation behavior directly controls user-visible login and failure semantics.
+- `GitHubRepoOps` changes both remote GitHub state and local git remote/bootstrap state; success-path semantics matter as much as error handling.
+- Google’s per-profile client naming and migration logic is coupled to AD-022 profile isolation; path or client-name drift would strand credentials.
+
+## Surprising discoveries
+- `GitHubAuthManager` advertises encrypted token storage but intentionally falls back to base64-only persistence when `safeStorage` is unavailable.
+- `GoogleAuthManager` bundles status caching, buggy-keyring migration, loopback callback-server setup, and gog credential import in one near-cap file.
+- The user-facing “Google OAuth not configured” error still hardcodes the default-root plugin-config path instead of using profile-scoped guidance.

--- a/docs/deslopify/apps/desktop/electron/features/auth/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/auth/facts.md
@@ -30,3 +30,19 @@ This feature owns the app-level GitHub and Google auth/runtime integration: GitH
 - `GitHubAuthManager` advertises encrypted token storage but intentionally falls back to base64-only persistence when `safeStorage` is unavailable.
 - `GoogleAuthManager` bundles status caching, buggy-keyring migration, loopback callback-server setup, and gog credential import in one near-cap file.
 - The user-facing “Google OAuth not configured” error still hardcodes the default-root plugin-config path instead of using profile-scoped guidance.
+
+## Post-fix snapshot — 2026-04-12
+
+### Metrics after fixes
+- Total files: 4 (unchanged)
+- Largest file: `apps/desktop/electron/features/auth/google/auth-manager.ts` (418 LOC)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 0 in this folder
+
+### What changed
+- GitHub token persistence now requires Electron `safeStorage`; when secure storage is unavailable, login fails instead of writing a base64-only token file.
+- Cached GitHub auth is no longer decrypted through a plaintext fallback path.
+
+### Still outstanding
+- GitHub device-flow polling still treats most non-2xx responses as indefinite retry conditions.
+- `GoogleAuthManager` remains the near-cap multi-responsibility hotspot in this feature.

--- a/docs/deslopify/apps/desktop/electron/features/auth/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/auth/plan.md
@@ -1,0 +1,64 @@
+# Refactoring Plan — apps/desktop/electron/features/auth
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/auth` is operationally important and generally effective, but it contains one clear High-risk security compromise plus a few medium-priority maintainability drifts. The High issue is GitHub token persistence falling back to base64-only storage when `safeStorage` is unavailable. After that, the biggest wins are splitting the near-cap Google auth manager into clearer pieces and making auth/runtime helper ownership less duplicated across auth, IPC, CLI, and renderer publish flows.
+
+## Issues Found (prioritized)
+- **High** — GitHub token persistence silently falls back to base64-only storage — `apps/desktop/electron/features/auth/github/auth-manager.ts:270-277` writes the token as `Buffer.from(token).toString('base64')` when `safeStorage` is unavailable, and `apps/desktop/electron/features/auth/github/auth-manager.ts:292-302` reads it back the same way. For a repo-scoped GitHub token in a macOS desktop app, this is effectively plaintext secret storage. Effort: **S**.
+
+- **Medium** — `GoogleAuthManager` is a near-cap multi-responsibility hub — `apps/desktop/electron/features/auth/google/auth-manager.ts:70-408` combines cached status reads, buggy-keyring migration, profile-registry scanning, loopback callback-server setup, token exchange, gog credential import, and client-credential provisioning. This is already hard to review and will get riskier as profile/auth flows evolve. Effort: **M**.
+
+- **Medium** — GitHub device-flow polling hides non-2xx failures until the code expires — `apps/desktop/electron/features/auth/github/auth-manager.ts:209-245`, especially `apps/desktop/electron/features/auth/github/auth-manager.ts:234`, treats every non-OK token response as “keep polling.” Network proxy failures, transient GitHub outages, and rate-limit responses become opaque timeouts instead of actionable auth errors. Effort: **S**.
+
+- **Low** — Auth runtime helpers are duplicated across layers — `apps/desktop/electron/features/auth/google/gog-keyring.ts:29-37` duplicates gog binary discovery that also exists in `apps/desktop/electron/ipc/integrations/google-api.ts:48-57` and `apps/desktop/electron/cli/lib/gog-runner.ts:49-58`, while `apps/desktop/electron/features/auth/github/repo-ops.ts:253-344` carries GitHub URL normalization logic parallel to the renderer publish/origin flows already flagged in `src/components/layout`. Effort: **M**.
+
+- **Low** — Google OAuth setup guidance still hardcodes the default-root config path — `apps/desktop/electron/features/auth/google/auth-manager.ts:248` tells users to edit `~/.sero-ui/agent/plugin-config/sero-google-plugin.json`, which is wrong for non-default profiles under AD-022. Effort: **S**.
+
+## Proposed Refactoring
+1. **Require encrypted GitHub token storage or fail closed.**
+   - On this macOS-targeted app, do not silently persist a repo-scoped token in base64-only form.
+   - Preferred shape: if `safeStorage` is unavailable, abort persistence and surface an explicit auth/storage error so the user can reconnect once secure storage is available.
+   - If the team needs a fallback for non-macOS development, gate it behind an explicit dev-only path with loud warnings rather than the production default.
+
+2. **Split `GoogleAuthManager` by responsibility.**
+   - Target structure could be:
+     - `google/status.ts` — cached status lookup + accessible-email discovery
+     - `google/migration.ts` — buggy-keyring migration helpers
+     - `google/oauth-loopback.ts` — callback server + code exchange
+     - `google/credentials.ts` — gog client credential provisioning/import
+   - Keep `GoogleAuthManager` as a thin coordinator/composition root.
+
+3. **Make GitHub device-flow failure handling explicit.**
+   - Parse non-OK token responses and map known GitHub failure states into user-visible errors instead of endless polling.
+   - Preserve retry behavior for `authorization_pending` / `slow_down`, but treat transport failures, bad responses, and hard denial as explicit terminal states.
+
+4. **Extract shared auth/runtime helpers to canonical modules.**
+   - Centralize gog binary/PATH discovery in one shared helper used by auth, IPC, and CLI surfaces.
+   - Pull GitHub remote URL normalization into a shared VCS/auth helper so `repo-ops` and renderer publish/origin flows stop drifting independently.
+
+5. **Fix profile-scoped user guidance.**
+   - Replace the hardcoded Google plugin-config path with `SERO_AGENT_DIR`-derived guidance or a UI-only instruction that points users to the Google plugin setup form.
+
+## Benefits & Trade-offs
+- Benefits: tighter secret handling, clearer auth ownership boundaries, better error visibility during GitHub login, and less duplicated runtime helper logic.
+- Trade-offs: secure-storage hardening may surface environment issues that were previously hidden, and splitting Google auth will touch several imports/tests at once.
+
+## Dependencies & Risks
+- Secure-storage hardening is a real behavior change: users on environments without `safeStorage` support will get a visible error instead of silent persistence.
+- Extracting shared gog/GitHub helper modules touches IPC/CLI and renderer publish flows, so the migration should happen in one coordinated pass.
+- Splitting `GoogleAuthManager` must preserve the fragile migration behavior for legacy buggy keyring passwords and per-profile client buckets.
+
+## Next Steps
+1. Fix the High issue first: stop base64-only GitHub token persistence in production paths.
+2. Add explicit non-2xx GitHub device-flow error handling.
+3. Split `GoogleAuthManager` into focused modules before it grows further.
+4. Deduplicate gog binary/PATH discovery and GitHub URL-normalization helpers.
+5. Replace hardcoded default-root guidance with profile-scoped instructions.
+6. Verification checklist:
+   - GitHub login/logout still works, including cancel + reconnect.
+   - GitHub token storage fails safely when secure storage is unavailable.
+   - Repo creation still bootstraps origin/push/default-branch behavior correctly.
+   - Google login still imports tokens into the correct per-profile gog client bucket.
+   - Existing buggy-keyring migration path still recovers previously stranded tokens.

--- a/docs/deslopify/apps/desktop/electron/features/auth/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/auth/plan.md
@@ -51,7 +51,7 @@ _Plan drafted: 2026-04-12_
 - Splitting `GoogleAuthManager` must preserve the fragile migration behavior for legacy buggy keyring passwords and per-profile client buckets.
 
 ## Next Steps
-1. Fix the High issue first: stop base64-only GitHub token persistence in production paths.
+1. ~~Fix the High issue first: stop base64-only GitHub token persistence in production paths.~~ ✅ 2026-04-12 (`4350404d`)
 2. Add explicit non-2xx GitHub device-flow error handling.
 3. Split `GoogleAuthManager` into focused modules before it grows further.
 4. Deduplicate gog binary/PATH discovery and GitHub URL-normalization helpers.
@@ -62,3 +62,7 @@ _Plan drafted: 2026-04-12_
    - Repo creation still bootstraps origin/push/default-branch behavior correctly.
    - Google login still imports tokens into the correct per-profile gog client bucket.
    - Existing buggy-keyring migration path still recovers previously stranded tokens.
+
+## Execution log
+- 2026-04-12 — `4350404d` — `fix(desktop): harden wave d high-priority runtime paths`
+  - GitHub auth now fails closed when Electron secure storage is unavailable instead of persisting repo-scoped tokens with base64-only encoding.

--- a/docs/deslopify/apps/desktop/electron/features/collaboration/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/collaboration/facts.md
@@ -1,0 +1,29 @@
+# Facts — apps/desktop/electron/features/collaboration
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This feature implements Sero's multi-agent collaboration strategies on top of the subagent system: a simple researcher → analyst/visionary → coordinator flow and a debate-style strategy with decomposition, cross-checking rounds, and final synthesis. It maps collaboration roles to discovered agent names and returns a summarized collaboration result for IPC consumers.
+
+## Shape & metrics
+- Total files: 3
+- Largest file: `apps/desktop/electron/features/collaboration/debate.ts` (315 LOC)
+- Files over 500 LOC: none
+- External dependencies of note: no direct external packages; depends entirely on `SubagentManager` and shared collaboration types from `@/types/collaboration`
+- Upstream callers: `apps/desktop/electron/ipc/collaboration/collaboration.ts`
+- Downstream dependencies: named subagent definitions (`researcher`, `collab-analyst`, `visionary`, `coordinator`), collaboration/debate renderer flows, subagent runtime availability
+
+## Architectural notes
+- This module is a thin orchestration layer on top of AD-021 subagents; it should stay declarative and reuse subagent execution helpers rather than growing its own runtime conventions.
+- Role-to-agent mapping is hardcoded in `agents.ts`, so the feature depends on the continued presence of those global agent names in the user's agent directory/template set.
+- Collaboration and debate flows currently normalize failures by inserting fallback text into later prompts instead of surfacing a degraded-mode result explicitly.
+
+## Runtime-sensitive surfaces
+- Prompt-size growth matters here: coordinator synthesis prompts embed specialist outputs verbatim, so token/cost/runtime behavior can change sharply as specialist output length grows.
+- Role name drift is external to this folder; renaming a built-in collaboration agent requires migration or compatibility handling rather than a silent change.
+- Failure semantics are subtle: if a specialist fails, the final coordinator may still produce a polished answer based on placeholder text.
+
+## Surprising discoveries
+- The simple collaboration flow and the debate flow both re-implement nearly the same subagent execution/error-timing helper instead of sharing one orchestration primitive.
+- Debate challenge prompts cap “other perspective” context to 500 chars, but final synthesis prompts remain effectively unbounded.
+- Missing or failed specialists currently get turned into strings like `(Researcher failed to produce output)` and `(Agent failed)` that are then fed straight into the coordinator synthesis prompt.

--- a/docs/deslopify/apps/desktop/electron/features/collaboration/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/collaboration/plan.md
@@ -1,0 +1,54 @@
+# Refactoring Plan — apps/desktop/electron/features/collaboration
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/collaboration` is compact and readable, but it hides two meaningful runtime risks behind its small footprint: coordinator synthesis prompts can grow without a guardrail, and specialist failures are currently masked as placeholder text that still gets synthesized into a confident final answer. The follow-up work should stay conservative: add explicit degraded-mode behavior, cap/summarize prompt inputs, and deduplicate the repeated subagent execution scaffolding before this feature grows.
+
+## Issues Found (prioritized)
+- **Medium** — Final synthesis prompts are effectively unbounded — `apps/desktop/electron/features/collaboration/agents.ts:33-53`, `apps/desktop/electron/features/collaboration/index.ts:168-176`, and `apps/desktop/electron/features/collaboration/debate.ts:149-173,298` embed specialist outputs directly into coordinator prompts. Debate challenge context truncates some side-inputs (`debate.ts:127`), but the final synthesis stage still scales with full specialist output length. That is a real token/cost/runtime risk in an AD-021 fan-out feature. Effort: **M**.
+- **Medium** — Specialist failures are converted into placeholder strings and then synthesized as if they were real analysis — `apps/desktop/electron/features/collaboration/index.ts:127,171-172` and `apps/desktop/electron/features/collaboration/debate.ts:239-242,149-173` feed `(Researcher failed to produce output)`, `(Analyst failed to produce output)`, and `(Agent failed)` straight into the final coordinator prompt. That hides degraded runs behind polished output instead of making failure explicit to callers/UI. Effort: **S**.
+- **Low** — Collaboration and debate duplicate the same subagent execution scaffolding — `apps/desktop/electron/features/collaboration/index.ts:40-66` and `apps/desktop/electron/features/collaboration/debate.ts:48-82` both implement nearly identical role → agent-name lookup, `runSingleStructured()` invocation, duration timing, and error normalization. The duplication is small today but unnecessary drift pressure. Effort: **S**.
+- **Low** — Required collaboration agent names are hardcoded with no preflight validation — `apps/desktop/electron/features/collaboration/agents.ts:13-27` binds runtime behavior to specific discovered agent names. If those names drift or the user removes a required agent definition, orchestration only fails mid-run. Effort: **S**.
+
+## Proposed Refactoring
+1. **Add explicit synthesis input budgeting.**
+   - Introduce a small summarization/capping helper for specialist outputs before they are handed to the coordinator.
+   - Keep the strongest signals (key findings, citations, disagreements), but enforce a predictable max size for the final synthesis prompt.
+   - Align with AD-021's motivation: subagents should reduce main-context pollution, not recreate it one synthesis step later.
+
+2. **Make degraded runs explicit instead of silently padded.**
+   - Replace placeholder text injection with structured degraded-mode handling.
+   - Options:
+     - skip synthesis when required specialists fail and return a partial/error result, or
+     - include an explicit `degradedReason`/`missingRoles` field in `CollaborationResult` and let the UI surface it.
+   - Prefer truthful behavior over smooth-but-misleading prose.
+
+3. **Extract a shared collaboration runner helper.**
+   - Move the common “run one named specialist, measure duration, normalize errors, fire callbacks” logic into a local helper module shared by `index.ts` and `debate.ts`.
+   - Keep debate-specific phase handling separate; only dedupe the repeated subagent invocation machinery.
+
+4. **Add required-agent preflight validation.**
+   - Before launching a collaboration run, verify that the required role-mapped agents are present.
+   - Fail early with a clear missing-agent error instead of discovering the problem halfway through a multi-step run.
+   - If agent-name migration is expected, support an alias/compatibility map rather than silently changing the canonical names.
+
+## Benefits & Trade-offs
+- Benefits: lower token burn during synthesis, more truthful failure reporting to the renderer, and less duplicated orchestration code.
+- Trade-offs: any degraded-mode change is a behavior change for callers/UI, and prompt-capping needs careful tuning so quality does not drop unnecessarily.
+
+## Dependencies & Risks
+- Degraded-mode/result-shape changes may require coordinated updates in `apps/desktop/electron/ipc/collaboration/collaboration.ts` and any renderer consumers of collaboration results.
+- Prompt-budgeting changes can alter answer quality; they need real scenario testing, not just type-safe refactoring.
+- Required-agent validation depends on the team's willingness to treat those names as a supported compatibility contract.
+
+## Next Steps
+1. Add explicit synthesis prompt budgeting/capping.
+2. Decide and implement degraded-mode behavior for missing/failed specialists.
+3. Extract the shared single-specialist runner helper used by both collaboration strategies.
+4. Add preflight validation for required collaboration agent names.
+5. Verification checklist:
+   - Run both collaboration modes with healthy specialists and confirm final answer quality stays acceptable.
+   - Force one specialist to fail and confirm the result surfaces degradation explicitly.
+   - Run a long-output scenario and verify final synthesis prompt size stays bounded.
+   - Remove/rename one required collaboration agent and confirm the feature fails early with a clear error.

--- a/docs/deslopify/apps/desktop/electron/features/editor/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/editor/facts.md
@@ -22,3 +22,19 @@ _Last reviewed: 2026-04-12_
 - The manager is small, but `startServer()` is not startup-idempotent: duplicate renderer calls before initialization can create multiple `LspServerProcess` instances for the same workspace/language.
 - The main-process config already carries a language/extension mapping, but the renderer redefines the same routing logic instead of consuming one canonical source.
 - Server installation is still runtime-mutable (`npm install -g ...` inside the container) rather than pinned through an image/toolchain policy, so reproducibility is weaker than the rest of the container story suggests.
+
+## Post-fix snapshot — 2026-04-12
+
+### Metrics after fixes
+- Total files: 4 (unchanged)
+- Largest file: `apps/desktop/electron/features/editor/lsp/lsp-process.ts` (303 LOC)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 0 in this folder
+
+### What changed
+- `LspManager` now deduplicates in-flight startup by workspace/language so rapid renderer remounts cannot orphan duplicate server processes.
+- `lsp-process.ts` now parses initialize/configuration payloads through explicit helpers instead of `as any` reads.
+
+### Still outstanding
+- Canonical language-routing metadata is still duplicated across renderer and main layers.
+- Server-initiated request handling still uses a `switch` instead of a documented adapter table.

--- a/docs/deslopify/apps/desktop/electron/features/editor/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/editor/facts.md
@@ -1,0 +1,24 @@
+# Facts — apps/desktop/electron/features/editor
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`electron/features/editor` is the main-process owner for Sero's language-server runtime. It starts container-backed LSP processes, frames JSON-RPC over stdio, translates process lifecycle events into app-level events, and exposes the server capabilities needed by the renderer-side Monaco integration.
+
+## Shape & metrics
+- Total files: 4
+- Largest file: `apps/desktop/electron/features/editor/lsp/lsp-process.ts` (256 LOC)
+- Files over 500 LOC: None
+- External dependencies of note: Node `child_process`, Node `events`, `@electron/features/container`
+- Upstream callers: `apps/desktop/electron/shared/infra/shared-infra.ts`, `apps/desktop/electron/ipc/editor/lsp.ts`
+- Downstream dependencies: `apps/desktop/src/lsp/use-lsp.ts`, Monaco completion/hover/definition/diagnostic flows
+
+## Architectural notes
+- This directory is an AD-018 consumer: language servers run inside the per-workspace container, not in the renderer and not directly on the host.
+- It is part of the same four-layer contract spine as `src/lsp`, preload, and `electron/ipc/editor/lsp.ts`, so any drift here quickly becomes a renderer-facing regression.
+- The current configuration only supports one server family (`typescript-language-server`), but the structure implies future multi-language growth.
+
+## Surprising discoveries
+- The manager is small, but `startServer()` is not startup-idempotent: duplicate renderer calls before initialization can create multiple `LspServerProcess` instances for the same workspace/language.
+- The main-process config already carries a language/extension mapping, but the renderer redefines the same routing logic instead of consuming one canonical source.
+- Server installation is still runtime-mutable (`npm install -g ...` inside the container) rather than pinned through an image/toolchain policy, so reproducibility is weaker than the rest of the container story suggests.

--- a/docs/deslopify/apps/desktop/electron/features/editor/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/editor/plan.md
@@ -53,8 +53,13 @@ This area is compact, but it carries disproportionate risk because it owns the m
 - Install-policy changes may require container-image rebuild discipline if the team decides to stop doing runtime installs.
 
 ## Next Steps
-1. Add an in-flight startup map to `LspManager` and make `startServer()` idempotent.
-2. Remove the two `as any` casts from `lsp-process.ts` with explicit protocol helpers.
+1. ~~Add an in-flight startup map to `LspManager` and make `startServer()` idempotent.~~ ✅ 2026-04-12 (`4350404d`)
+2. ~~Remove the two `as any` casts from `lsp-process.ts` with explicit protocol helpers.~~ ✅ 2026-04-12 (`4350404d`)
 3. Extract canonical language-routing metadata into a shared renderer-safe contract.
 4. Refactor server-initiated request handling into a documented adapter table.
 5. Decide whether LSP binary versions are pinned at runtime or moved into the container image/toolchain.
+
+## Execution log
+- 2026-04-12 — `4350404d` — `fix(desktop): harden wave d high-priority runtime paths`
+  - Made `LspManager.startServer()` share in-flight startup work per workspace/language.
+  - Replaced the remaining protocol-boundary `any` casts in `lsp-process.ts` with explicit parsing helpers.

--- a/docs/deslopify/apps/desktop/electron/features/editor/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/editor/plan.md
@@ -1,0 +1,60 @@
+# Refactoring Plan — apps/desktop/electron/features/editor
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+This area is compact, but it carries disproportionate risk because it owns the main-process half of the Monaco↔LSP bridge. Two High-priority issues stand out: concurrent `startServer()` calls are not deduplicated, and `lsp-process.ts` still uses `any` casts at the protocol boundary. The goal is to make LSP startup idempotent, keep the protocol layer strictly typed, and establish one canonical language-routing contract before more languages are added.
+
+## Issues Found (prioritized)
+- **High** — `LspManager.startServer()` is not concurrency-safe for the same workspace/language pair — `apps/desktop/electron/features/editor/lsp/lsp-manager.ts:23-69` only short-circuits when an existing server is already `initialized`. If a second caller arrives while the first startup is still in flight, the method creates a second `LspServerProcess`, overwrites the map entry, and leaves the first process/event wiring outside the manager's ownership. In a renderer that can remount editor/LSP surfaces quickly, this is a real lifecycle bug. Effort: **M**.
+
+- **High** — Protocol-boundary `any` casts remain in `lsp-process.ts` — `apps/desktop/electron/features/editor/lsp/lsp-process.ts:187` and `apps/desktop/electron/features/editor/lsp/lsp-process.ts:221` use `as any` to read initialize results and `workspace/configuration` params. That violates the monorepo's no-type-escape rule and weakens one of the most failure-prone renderer↔main boundaries. Effort: **S**.
+
+- **Medium** — Canonical language/config routing is duplicated across main and renderer layers — `apps/desktop/electron/features/editor/lsp/types.ts:25-41` defines the supported language server config and extension mapping, while `apps/desktop/src/lsp/lsp-conversions.ts:222-239` repeats a second renderer-owned map. This is exactly the kind of contract drift that Wave A/B tried to reduce. Effort: **S**.
+
+- **Medium** — Server-initiated request handling is permissive and masks capability drift — `apps/desktop/electron/features/editor/lsp/lsp-process.ts:216-229` answers `workspace/configuration`, `client/registerCapability`, and `window/workDoneProgress/create` with stub values, then returns `null` for everything else after a log line. Unsupported protocol growth will fail unclearly rather than through an explicit adapter contract. Effort: **M**.
+
+- **Low** — Runtime install policy is underspecified and unpinned — `apps/desktop/electron/features/editor/lsp/types.ts:30` installs `typescript-language-server` and `typescript` with a floating `npm install -g` command inside the workspace container. This weakens reproducibility and makes it harder to reason about server-version regressions across workspaces/profiles. Effort: **S**.
+
+## Proposed Refactoring
+1. **Make LSP startup idempotent and share in-flight work.**
+   - Add a second map keyed by `workspaceId + language` for startup promises or explicit server states (`starting | ready | failed`).
+   - Return the in-flight promise when the same server is already starting.
+   - Ensure failure paths clean both the process map and the promise/state map.
+   - This aligns with AD-018's runtime-lifecycle expectations and avoids duplicate container exec processes.
+
+2. **Replace protocol `any` casts with explicit result/request shapes.**
+   - Define small local interfaces for the `initialize` result and the `workspace/configuration` request params.
+   - Use narrow parsing helpers (`isInitializeResult`, `getWorkspaceConfigurationItems`) instead of `as any`.
+   - Keep these types close to the protocol adapter so they do not become another mega-barrel.
+
+3. **Promote one canonical language-routing/config surface.**
+   - Move the language/extension metadata into a shared renderer-safe module (`@sero/common` or a focused `src/types/lsp.ts`-style contract) consumed by both `electron/features/editor` and `src/lsp`.
+   - Keep the main-process-only fields (install/check command) adjacent, but derive renderer-visible language IDs from the same source.
+   - This follows the “import canonical types/contracts instead of re-declaring them” rule from the project guidance.
+
+4. **Turn server-request handling into an explicit adapter table.**
+   - Replace the `switch` in `handleServerRequest()` with a map of supported handlers.
+   - For unsupported methods, either return a structured JSON-RPC error or centralize an explicit “not implemented” path with rate-limited logging.
+   - Document which server-initiated requests are intentionally supported for Sero's current Monaco integration.
+
+5. **Document and tighten install ownership.**
+   - Decide whether LSP binaries are expected to be runtime-installed or container-image-managed.
+   - If runtime install stays, pin versions in `installCommand` and add comments/tests around upgrade expectations.
+   - If toolchain ownership moves into the container image, follow the AGENTS rule about rebuilding `sero-node:latest` after Dockerfile/tool changes.
+
+## Benefits & Trade-offs
+- Benefits: reliable LSP startup, stricter protocol typing, less renderer/main drift when adding languages, and clearer debugging when a server asks for unsupported capabilities.
+- Trade-offs: some additional adapter code and one cross-layer contract move, plus careful regression testing around startup/teardown timing.
+
+## Dependencies & Risks
+- Startup deduping must stay coordinated with `src/lsp/use-lsp.ts`, which may currently assume repeated `start()` calls are cheap.
+- Shared language-config extraction crosses renderer/main boundaries and should be done with a renderer-safe module, not by importing Electron code into the renderer.
+- Install-policy changes may require container-image rebuild discipline if the team decides to stop doing runtime installs.
+
+## Next Steps
+1. Add an in-flight startup map to `LspManager` and make `startServer()` idempotent.
+2. Remove the two `as any` casts from `lsp-process.ts` with explicit protocol helpers.
+3. Extract canonical language-routing metadata into a shared renderer-safe contract.
+4. Refactor server-initiated request handling into a documented adapter table.
+5. Decide whether LSP binary versions are pinned at runtime or moved into the container image/toolchain.

--- a/docs/deslopify/apps/desktop/electron/features/gateway/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/gateway/facts.md
@@ -1,0 +1,36 @@
+# Facts — apps/desktop/electron/features/gateway
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This feature is Sero's remote-access gateway. It owns the WebSocket/HTTP server, gateway auth token handling, request validation/routing, per-session cost tracking, Discord and web chat adapters, Tailscale exposure, QR-code generation, and the bridge that forwards agent-pool events back to remote clients.
+
+## Shape & metrics
+- Total files: 18
+- Largest file: `apps/desktop/electron/features/gateway/index.ts` (488 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥400 LOC):
+  - `apps/desktop/electron/features/gateway/index.ts` (488)
+  - `apps/desktop/electron/features/gateway/channels/discord.ts` (470)
+- Generated assets in scope: `apps/desktop/electron/features/gateway/web-dist/index.html` plus bundled `web-dist/assets/*`
+- External dependencies of note: `ws`, `http`, Electron `net`/`nativeImage`, `qrcode`, dynamic `discord.js`, Tailscale CLI, filesystem-backed auth/config stores
+- Upstream callers: `apps/desktop/electron/shared/infra/shared-infra.ts`, `apps/desktop/electron/ipc/gateway/gateway.ts`, `apps/desktop/electron/ipc/gateway/gateway-ops.ts`, `apps/desktop/electron/ipc/agent/core/agent.ts`, build/packaging scripts
+- Downstream dependencies: remote prompt routing, gateway settings UI, Discord bot access, web remote SPA/basic HTML, Tailscale publishing, agent event streaming
+
+## Architectural notes
+- This feature is an external network boundary, not an internal helper. Type validation, auth scope, and failure semantics are materially more important here than in ordinary in-process modules.
+- The flat gateway token model is still explicitly called out as open security debt in `docs/security/outstanding-hardening.md` and the in-code TODO in `security/auth.ts`.
+- The feature currently ships two remote UI surfaces: an inline minimal web chat (`channels/web.ts`) and a bundled SPA under `web-dist/`, plus a `/basic` fallback route in `index.ts`.
+- Discord integration currently subscribes to gateway events by monkey-patching `GatewayServer` methods rather than using a formal event listener contract.
+
+## Runtime-sensitive surfaces
+- Auth scope and request validation are security-critical: remote clients can list workspaces, open sessions, read files, and fetch history through this boundary.
+- The agent-bridge/cost-tracker path must preserve prompt success-path semantics while preventing duplicate execution and runaway spend.
+- Static asset serving and web remote behavior must work in dev, packaged builds, and Tailscale-exposed paths.
+- Discord image delivery depends on Electron/Chromium networking and `nativeImage` downscaling; transport changes need real-world verification.
+
+## Surprising discoveries
+- The gateway still documents and implements a flat access model where any valid token can reach any workspace.
+- `/sero abort` in the Discord adapter only sends a reply; it never actually calls `agentOps.abort()`.
+- `validateRequest()` only checks the `type` field and then casts the rest of the untrusted payload wholesale.
+- Malformed `gateway-config.json` currently gets overwritten with defaults on the next load, mirroring the same config-clobber pattern already found elsewhere in the monorepo.

--- a/docs/deslopify/apps/desktop/electron/features/gateway/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/gateway/facts.md
@@ -34,3 +34,21 @@ This feature is Sero's remote-access gateway. It owns the WebSocket/HTTP server,
 - `/sero abort` in the Discord adapter only sends a reply; it never actually calls `agentOps.abort()`.
 - `validateRequest()` only checks the `type` field and then casts the rest of the untrusted payload wholesale.
 - Malformed `gateway-config.json` currently gets overwritten with defaults on the next load, mirroring the same config-clobber pattern already found elsewhere in the monorepo.
+
+## Post-fix snapshot — 2026-04-12
+
+### Metrics after fixes
+- Total files: 19 (was 18)
+- Largest file: `apps/desktop/electron/features/gateway/index.ts` (489 LOC)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 3 (all outside the High-priority auth/abort paths)
+
+### What changed
+- Added `server/access-control.ts` and threaded workspace/session/artifact authorization through gateway request handling.
+- Web tokens are now scoped to explicit workspace IDs, and QR pairing in the desktop UI creates workspace-scoped tokens through preload + IPC.
+- `gateway-ops` now validates that an existing session belongs to the requested workspace before reopening it.
+- Discord `/sero abort` now calls `agentOps.abort()` and reports failures honestly.
+
+### Still outstanding
+- Request validation is still type-tag-only and needs real per-request schemas.
+- Discord still subscribes via gateway method monkey-patching, and static-file serving is still synchronous on the hot path.

--- a/docs/deslopify/apps/desktop/electron/features/gateway/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/gateway/plan.md
@@ -60,8 +60,8 @@ _Plan drafted: 2026-04-12_
 - Static-file serving changes must be tested in dev, packaged builds, and Tailscale-exposed flows because the current relative fallback logic is subtle.
 
 ## Next Steps
-1. Fix `/sero abort` first.
-2. Implement workspace-scoped gateway auth and enforce it across all request routes.
+1. ~~Fix `/sero abort` first.~~ ✅ 2026-04-12 (`4350404d`)
+2. ~~Implement workspace-scoped gateway auth and enforce it across all request routes.~~ ✅ 2026-04-12 (`4350404d`)
 3. Replace cast-based request validation with per-request schemas/guards.
 4. Make cost-config loading non-destructive.
 5. Replace Discord monkey-patching with a formal subscription API.
@@ -71,3 +71,8 @@ _Plan drafted: 2026-04-12_
    - Verify `/sero abort` actually stops an in-flight Discord task.
    - Start the web remote in dev, packaged, and Tailscale-served modes and confirm static assets still load.
    - Corrupt `gateway-config.json` intentionally and verify the app surfaces the error without overwriting the file.
+
+## Execution log
+- 2026-04-12 — `4350404d` — `fix(desktop): harden wave d high-priority runtime paths`
+  - Scoped gateway web tokens to explicit workspace IDs, threaded those scopes through connection auth, and enforced them across workspace/session/artifact request routes.
+  - Fixed Discord `/sero abort` so it now calls `agentOps.abort()` and reports failures honestly.

--- a/docs/deslopify/apps/desktop/electron/features/gateway/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/gateway/plan.md
@@ -1,0 +1,73 @@
+# Refactoring Plan — apps/desktop/electron/features/gateway
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/gateway` is doing important work and already has some hardening in place, but it still carries meaningful external-boundary debt. The top priorities are straightforward: the flat workspace access model is still open, and the Discord abort command is currently broken. After that, the biggest wins are to replace the current type-cast request validation with a real schema boundary, stop clobbering malformed gateway config on load, and reduce the brittle coupling between the Discord adapter and the core server.
+
+## Issues Found (prioritized)
+- **High** — Gateway auth is still flat-scoped across all workspaces and sessions — `apps/desktop/electron/features/gateway/security/auth.ts:7-10` still documents the open security debt, while `apps/desktop/electron/features/gateway/server/request-handler.ts:122,182-202` and `apps/desktop/electron/features/gateway/server/extended-handlers.ts:32-87,141-142` trust client-supplied `workspaceId` for prompt/session/file/history routes. For an external network boundary, this is the most important unresolved gateway issue. Effort: **L**.
+- **High** — Discord `/sero abort` is a no-op — `apps/desktop/electron/features/gateway/channels/discord.ts:242-249` replies “Aborting current task...” but never calls `this.agentOps.abort(session.sessionId)`. That is an active behavior bug in a user-facing remote-control path. Effort: **S**.
+- **Medium** — Request validation only checks `type` and then force-casts the payload — `apps/desktop/electron/features/gateway/server/protocol.ts:217-221` returns `obj as unknown as GatewayRequest` after validating just one field. Every other property on this untrusted WebSocket boundary stays unchecked until deeper callsites. Effort: **M**.
+- **Medium** — Malformed gateway cost config is silently overwritten with defaults — `apps/desktop/electron/features/gateway/server/cost-tracker.ts:233-251` catches any read/parse failure and immediately writes `DEFAULT_LIMITS`. That destroys evidence of operator mistakes and can silently widen spend limits back to defaults. Effort: **S**.
+- **Medium** — Discord event subscription relies on monkey-patching `GatewayServer` methods — `apps/desktop/electron/features/gateway/channels/discord.ts:283-301` replaces `broadcastEvent` and `pushEvent` at runtime instead of subscribing through a formal event sink/listener contract. That is brittle cross-module coupling in a feature that already has a dedicated bridge layer. Effort: **M**.
+- **Medium** — Static asset serving does synchronous filesystem checks on every request in the Electron main process — `apps/desktop/electron/features/gateway/server/static-files.ts:29-81` uses `existsSync` and `statSync` repeatedly before streaming. It works today, but this is still event-loop blocking on an externally reachable path. Effort: **S**.
+- **Low** — The gateway feature now carries duplicated remote UI ownership — `apps/desktop/electron/features/gateway/channels/web.ts:1-284` maintains a fully inline web chat UI while `apps/desktop/electron/features/gateway/web-dist/index.html` and `web-dist/assets/*` ship the bundled SPA used by the primary remote flow. Keeping both surfaces in the same feature increases drift and review noise. Effort: **M**.
+
+## Proposed Refactoring
+1. **Land workspace-scoped auth for the gateway.**
+   - Follow the existing security-hardening recommendation: introduce scoped tokens (or equivalent stored scope) and carry the authorized workspace set on the connected client record.
+   - Enforce that scope in both `request-handler.ts` and `extended-handlers.ts` before delegating to `agentOps`.
+   - Filter `list_workspaces` to only authorized scopes instead of exposing the full registry.
+   - This is a real behavior change and needs explicit rollout/verification.
+
+2. **Fix Discord abort immediately.**
+   - In the `/sero abort` command path, call `this.agentOps.abort(session.sessionId)` before replying success.
+   - Handle the “no active session” and “abort failed” paths explicitly so Discord users get truthful feedback.
+
+3. **Replace cast-based request validation with a real schema boundary.**
+   - Add request-shaped validators per message type (Zod or equivalent narrow guards).
+   - Validate required fields like `workspaceId`, `sessionId`, `text`, token metadata, and file paths before routing.
+   - Keep `GatewayRequest` as the typed union, but only after payloads have been proven to match it.
+
+4. **Make gateway config loading non-destructive.**
+   - Return a result-shaped read (`ok/value` vs `ok/error`) from cost-config loading.
+   - On malformed JSON, surface an explicit gateway config error and keep the file untouched instead of overwriting it with defaults.
+   - Align this with the broader monorepo push toward non-destructive config parsing.
+
+5. **Replace Discord monkey-patching with a formal event-listener API.**
+   - Expose a listener/subscription API from `GatewayServer` or reuse the existing bridge layer so adapters can subscribe without rewriting server methods.
+   - Fold the current `pushEvent`/`broadcastEvent` interception into one explicit event fan-out path.
+   - While touching this area, remove the remaining type escapes/non-null assertions in the adapter (`as any`, `this.client!.user!`) where practical.
+
+6. **Move static-file resolution off the synchronous hot path.**
+   - Resolve `webDistDir` once at startup and cache it.
+   - Replace repeated `existsSync`/`statSync` request-time checks with async or precomputed asset handling where practical.
+   - Preserve current dev vs packaged fallback behavior used by the build scripts.
+
+7. **Choose one primary remote-web ownership model.**
+   - Keep `/basic` only as a deliberate fallback with minimal maintenance burden, or retire the inline UI if the SPA is now the real product surface.
+   - Document the chosen ownership so future gateway work does not accidentally duplicate both paths.
+
+## Benefits & Trade-offs
+- Benefits: materially better remote-access safety, a fixed Discord control path, stronger validation on an untrusted boundary, and lower coupling between the Discord adapter and the core server.
+- Trade-offs: workspace-scoped auth is not a cosmetic refactor; it changes how tokens are issued, stored, and validated, and it will touch IPC/UI tooling that displays gateway credentials.
+
+## Dependencies & Risks
+- Workspace-scoped auth must land together with token management/UI changes or remote clients will be stranded between formats.
+- Tightening request validation can reject payloads that older clients currently send; include compatibility notes if external clients exist beyond the repo.
+- Refactoring Discord subscriptions must preserve current gateway event delivery order for streamed text and image attachments.
+- Static-file serving changes must be tested in dev, packaged builds, and Tailscale-exposed flows because the current relative fallback logic is subtle.
+
+## Next Steps
+1. Fix `/sero abort` first.
+2. Implement workspace-scoped gateway auth and enforce it across all request routes.
+3. Replace cast-based request validation with per-request schemas/guards.
+4. Make cost-config loading non-destructive.
+5. Replace Discord monkey-patching with a formal subscription API.
+6. Verification checklist:
+   - Connect via web token and confirm only authorized workspaces/sessions/files are visible.
+   - Prompt, steer, abort, list files, and fetch session history from an authorized workspace.
+   - Verify `/sero abort` actually stops an in-flight Discord task.
+   - Start the web remote in dev, packaged, and Tailscale-served modes and confirm static assets still load.
+   - Corrupt `gateway-config.json` intentionally and verify the app surfaces the error without overwriting the file.

--- a/docs/deslopify/apps/desktop/electron/features/onboarding/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/onboarding/facts.md
@@ -1,0 +1,30 @@
+# Facts — apps/desktop/electron/features/onboarding
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This feature computes main-process onboarding state for the active profile. It inspects auth/config files, queries available models from shared infra, derives provider-health status, preserves or repairs saved tier selections, and returns the recommendation/warning payload that drives the renderer onboarding wizard.
+
+## Shape & metrics
+- Total files: 5
+- Largest file: `apps/desktop/electron/features/onboarding/recommendations.ts` (270 LOC)
+- Files over 500 LOC: none
+- External dependencies of note: shared infra/model registry, shared settings helpers + model-config helpers, provider catalog, `@/types/ipc`, active profile registry, local `models.json`
+- Upstream callers: `apps/desktop/electron/ipc/onboarding/onboarding.ts`, `apps/desktop/electron/ipc/workspace/profiles.ts`, `apps/desktop/electron/__tests__/features/onboarding/recommendations.test.ts`
+- Downstream dependencies: onboarding renderer state, global model-config persistence, provider reconnection UX, active-profile readiness decisions
+
+## Architectural notes
+- `getOnboardingState()` is not a pure read; it currently applies legacy-provider migration and unavailable-model cleanup while answering a status request.
+- `provider-health.ts` crosses layering boundaries by importing provider metadata and model-group shaping helpers from IPC modules instead of a neutral shared/feature module.
+- Recommendation logic is preservation-first: keep valid existing tiers, otherwise infer a preferred provider from healthy coverage or the legacy default provider.
+- The feature treats provider health as a heuristic synthesis of stored credentials plus model availability, not a live remote verification step.
+
+## Runtime-sensitive surfaces
+- `getOnboardingState()` decides whether the renderer shows `ready`, `auth`, or `done`; any logic change here changes first-run behavior immediately.
+- The preflight path can write `settings.json` while the UI is merely refreshing onboarding state, so cleanup ordering and parse-failure behavior matter.
+- Provider-health inference depends on both auth storage and local model config; changing those heuristics can move providers between `healthy`, `env`, `local`, `broken_*`, and `missing` states.
+
+## Surprising discoveries
+- A “getter” path in `preflight.ts` already performs migration/cleanup writes before returning state.
+- `types.ts` still contains dead helper copies (`findModelName`, `buildRecommendation`) even though recommendation construction now lives in `recommendations.ts`.
+- The feature’s provider/model presentation helpers currently live under IPC internals, so onboarding is coupled to transport-layer code for basic display shaping.

--- a/docs/deslopify/apps/desktop/electron/features/onboarding/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/onboarding/plan.md
@@ -1,0 +1,54 @@
+# Refactoring Plan — apps/desktop/electron/features/onboarding
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/onboarding` is compact and mostly understandable, but it currently mixes three concerns that should be cleaner: read-only onboarding-state evaluation, settings-repair side effects, and presentation-shaping helpers borrowed from IPC internals. The code is not in crisis, but it is carrying avoidable boundary drift. The best payoff is to make the onboarding state path explicit and mostly pure, then move shared model/provider presentation helpers out of IPC-owned modules.
+
+## Issues Found (prioritized)
+- **Medium** — `getOnboardingState()` performs settings mutations while answering a status query — `apps/desktop/electron/features/onboarding/preflight.ts:101-116` reads settings, applies legacy-provider migration, writes settings back when changed, and triggers unavailable-model cleanup before returning onboarding state. Because the renderer refreshes onboarding state repeatedly, this makes a “get state” IPC call behaviorally closer to a repair command. Effort: **M**.
+
+- **Medium** — `provider-health.ts` depends on IPC-layer internals for core feature logic — `apps/desktop/electron/features/onboarding/provider-health.ts:12-25` imports `providerDisplayName` from `@electron/ipc/platform/auth` and `buildAvailableModelGroups` from `@electron/ipc/agent/core/model-groups`. That is backwards ownership: a feature module should not reach into transport-layer folders for shared display/model helpers. Effort: **S**.
+
+- **Low** — Onboarding-state reads still do synchronous file probing on the main-process path — `apps/desktop/electron/features/onboarding/preflight.ts:23-41` and `apps/desktop/electron/features/onboarding/provider-health.ts:33-43` synchronously inspect `auth.json`, `MEMORY.md`, and `models.json` on every onboarding-state request. The files are small, so this is not urgent, but it does keep the path more blocking than it needs to be. Effort: **S**.
+
+- **Low** — `types.ts` still carries dead helper copies after the recommendation logic moved — `apps/desktop/electron/features/onboarding/types.ts:64-84` defines unused `findModelName()` and `buildRecommendation()` helpers even though recommendation construction now lives in `apps/desktop/electron/features/onboarding/recommendations.ts:231-239`. Effort: **S**.
+
+## Proposed Refactoring
+1. **Separate onboarding-state evaluation from onboarding-state repair.**
+   - Keep one pure-ish read path that computes current onboarding state from already-loaded settings/provider/model data.
+   - Move migration/cleanup writes into an explicit repair helper (for example `repairOnboardingSettingsState()`), then call it from a clearly named startup or mutation boundary rather than implicitly from every state refresh.
+   - This preserves behavior while making future regressions easier to reason about.
+
+2. **Move model/provider presentation helpers to a neutral shared module.**
+   - Extract provider display metadata and available-model-group shaping into a shared feature/helper location (for example `electron/shared/providers/**` or `electron/features/models/**`).
+   - Let both onboarding and IPC import from that shared module instead of onboarding importing from IPC.
+   - Aligns with the layering guidance already reinforced in earlier deslopify waves.
+
+3. **Trim the synchronous probe surface on the hot path.**
+   - Keep correctness first, but consider caching or batching tiny file reads when `getOnboardingState()` is called multiple times during a single onboarding flow.
+   - If the read path stays synchronous, make that a deliberate documented trade-off instead of an incidental implementation detail.
+
+4. **Delete leftover dead helpers in `types.ts`.**
+   - Keep `types.ts` focused on shared onboarding-only helper types and `emptyOnboardingState()`.
+   - Remove functions that no longer participate in recommendation assembly.
+
+## Benefits & Trade-offs
+- Benefits: cleaner ownership boundaries, fewer surprising side effects on a read path, and a simpler maintenance story for future onboarding-state changes.
+- Trade-offs: moving repair logic out of `getOnboardingState()` means callers need a more explicit sequencing model; the migration path must stay behaviorally identical during the transition.
+
+## Dependencies & Risks
+- If onboarding repair is decoupled from the state getter, the team must decide exactly where repair now happens (startup, model-config mutation, auth mutation, or a dedicated onboarding repair step).
+- Shared helper extraction will touch both onboarding and IPC modules; do it in one change to avoid temporary import churn.
+- Any caching/batching around provider/model health must preserve up-to-date behavior immediately after auth or model-config changes.
+
+## Next Steps
+1. Extract repair/migration writes out of `getOnboardingState()` into an explicitly named helper.
+2. Move provider display + available-model-group helpers out of IPC-owned modules.
+3. Remove dead helper copies from `types.ts`.
+4. Re-check whether synchronous file probes still matter once the state path is cleaner.
+5. Verification checklist:
+   - Existing profiles with legacy default-provider settings still get migrated correctly.
+   - Unavailable saved model tiers are still cleaned up and surfaced as warnings.
+   - Onboarding state still transitions correctly between `auth`, `ready`, and `done` after provider login/logout.
+   - Provider names/model groups render identically after helper extraction.

--- a/docs/deslopify/apps/desktop/electron/features/profile/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/profile/facts.md
@@ -28,3 +28,19 @@ This feature owns the profile registry and bootstrap lifecycle behind AD-022: fi
 - A corrupted `profiles.json` currently looks identical to “no profiles exist yet.”
 - The feature still uses a `KEEP IN SYNC` duplicate `ProfileInfo` contract even after the IPC/type cleanup wave.
 - `writeRegistrySync()` remains defined in `manager.ts` but is unused; async writes handle all live mutations while sync writes are only needed conceptually on bootstrap.
+
+## Post-fix snapshot — 2026-04-12
+
+### Metrics after fixes
+- Total files: 6 (unchanged)
+- Largest file: `apps/desktop/electron/features/profile/setup.ts` (271 LOC)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 0 in this folder
+
+### What changed
+- `readRegistrySync()` now distinguishes a missing registry from malformed content and throws an explicit `ProfileRegistryError` for corrupt `profiles.json` data.
+- Startup/profile consumers now fail closed instead of silently routing corruption into the first-run flow.
+
+### Still outstanding
+- `ProfileInfo` is still duplicated across renderer and main-process contracts.
+- `ProfileManager.create()` still needs path-overlap validation for custom profile roots.

--- a/docs/deslopify/apps/desktop/electron/features/profile/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/profile/facts.md
@@ -1,0 +1,30 @@
+# Facts — apps/desktop/electron/features/profile
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This feature owns the profile registry and bootstrap lifecycle behind AD-022: fixed-location `profiles.json` management, legacy-install migration into the new profile system, copying transferable auth/model data into new profiles, and startup template seeding for agents, skills, themes, and global-workspace profile files.
+
+## Shape & metrics
+- Total files: 6
+- Largest file: `apps/desktop/electron/features/profile/setup.ts` (271 LOC)
+- Files over 500 LOC: none
+- External dependencies of note: fixed `~/.sero-ui/profiles.json` registry, `SERO_HOME` / `SERO_AGENT_DIR`, startup env bootstrap, `fs/promises`, shared model-config helpers
+- Upstream callers: `apps/desktop/electron/platform/env/index.ts`, `apps/desktop/electron/shared/infra/shared-infra.ts`, `apps/desktop/electron/ipc/workspace/profiles.ts`, `apps/desktop/electron/main.ts`, `apps/desktop/electron/features/auth/google/auth-manager.ts`, profile tests
+- Downstream dependencies: all profile-scoped state folders, first-run setup gating, restart-based profile switching, new-profile credential/model-copy flow
+
+## Architectural notes
+- `manager.ts` and `migration.ts` are imported before `SERO_HOME`/`SERO_AGENT_DIR` are established; their module-level comments correctly note that they must stay independent from profile-scoped env helpers.
+- AD-022 is the governing constraint: profile identity is just `SERO_HOME`, registry location is fixed, and switching profiles is restart-based because shared singletons are not reset in-process.
+- `manager.ts` currently treats malformed registry content as an empty registry, which makes registry integrity part of the first-run control path.
+- `types.ts` still duplicates renderer-safe `ProfileInfo` instead of importing a canonical contract.
+
+## Runtime-sensitive surfaces
+- Registry parsing directly determines whether the app behaves like a fresh install or a real profile-scoped environment.
+- `copy-profile-data.ts` runs during profile creation and copies auth/model data into the new profile before the first launch into it.
+- Template seeding in `setup.ts` is startup-only and intentionally “copy missing only”; any refactor must preserve the non-overwrite guarantee.
+
+## Surprising discoveries
+- A corrupted `profiles.json` currently looks identical to “no profiles exist yet.”
+- The feature still uses a `KEEP IN SYNC` duplicate `ProfileInfo` contract even after the IPC/type cleanup wave.
+- `writeRegistrySync()` remains defined in `manager.ts` but is unused; async writes handle all live mutations while sync writes are only needed conceptually on bootstrap.

--- a/docs/deslopify/apps/desktop/electron/features/profile/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/profile/plan.md
@@ -1,0 +1,58 @@
+# Refactoring Plan — apps/desktop/electron/features/profile
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/profile` is foundational AD-022 infrastructure and is mostly well-contained, but it has one serious safety gap and two important contract drifts. The serious gap is registry corruption handling: malformed `profiles.json` currently collapses to “no profiles,” which can send the app down the first-run path and eventually overwrite the registry. The best outcome is a safer registry boundary, one canonical profile contract, and stricter path validation so profile isolation remains trustworthy.
+
+## Issues Found (prioritized)
+- **High** — Corrupt or malformed `profiles.json` is treated as an empty registry — `apps/desktop/electron/features/profile/manager.ts:38-46` returns `emptyRegistry()` for parse/shape failures. In an AD-022 system where registry content decides whether any profile exists, this makes corruption indistinguishable from “fresh install” and creates a path to accidental clobber on the next write. Effort: **S**.
+
+- **Medium** — `ProfileInfo` is still duplicated with a `KEEP IN SYNC` warning instead of a canonical contract — `apps/desktop/electron/features/profile/types.ts:39-50` mirrors `apps/desktop/src/types/ipc.ts:16-25`. This is exactly the kind of renderer↔main type drift Sero wants to avoid. Effort: **S**.
+
+- **Medium** — `ProfileManager.create()` does not validate custom paths strongly enough for profile isolation — `apps/desktop/electron/features/profile/manager.ts:121-149` accepts an arbitrary resolved path, and the only collision logic in `defaultPathForName()` (`apps/desktop/electron/features/profile/manager.ts:198-213`) applies to generated defaults. A user can point multiple profiles at the same directory or create overlapping profile roots, which undermines AD-022’s “profile = independent SERO_HOME” guarantee. Effort: **M**.
+
+- **Low** — Copy/setup helpers still rely on broad best-effort catches and carry small dead surface — `apps/desktop/electron/features/profile/copy-profile-data.ts:93-123` suppresses model-preference-copy failures entirely, and `apps/desktop/electron/features/profile/manager.ts:51-54` keeps an unused `writeRegistrySync()` helper. Effort: **S**.
+
+## Proposed Refactoring
+1. **Harden registry reads into an explicit safe boundary.**
+   - Replace “invalid registry => empty registry” with a result-shaped read that distinguishes:
+     - missing registry
+     - valid registry
+     - malformed/corrupt registry
+   - For malformed registries, fail closed with an actionable error path (or quarantine/backup the bad file) instead of silently behaving like first run.
+   - This is the highest-value fix because it protects the root AD-022 contract.
+
+2. **Collapse profile contracts to one canonical type source.**
+   - Move `ProfileInfo` into the canonical IPC/shared contract location and import it from both renderer and Electron profile code.
+   - Delete the `KEEP IN SYNC` comment and the duplicate interface once consumers compile against the shared source.
+
+3. **Validate profile paths before creating registry entries.**
+   - Reject custom paths that already belong to another registered profile.
+   - Reject paths that nest inside another profile root or that would contain another registered profile root.
+   - Consider rejecting obviously dangerous roots (for example the fixed registry root for non-default profiles unless the default profile case is explicit).
+
+4. **Tighten best-effort copy/setup helpers.**
+   - Keep profile creation resilient, but log or return structured warnings when credential/model copy partially fails.
+   - Remove dead helpers like the unused synchronous writer if they are no longer part of the real bootstrap strategy.
+
+## Benefits & Trade-offs
+- Benefits: safer profile-registry handling, less chance of losing or mis-scoping profiles, stronger renderer↔main type guarantees, and better confidence that each profile really is its own `SERO_HOME`.
+- Trade-offs: path validation can reject configurations that previously slipped through, and malformed-registry handling may require a new recovery UI or startup error path.
+
+## Dependencies & Risks
+- Registry hardening affects `platform/env/index.ts` startup behavior, so the failure mode must be designed carefully before implementation.
+- Canonical type extraction touches both renderer and main-process imports.
+- Path-validation changes are behavior-sensitive: if existing users already have overlapping custom paths, migration/recovery strategy must be explicit.
+
+## Next Steps
+1. Fix the High issue first: distinguish malformed registry content from “no registry yet.”
+2. Extract `ProfileInfo` to one canonical contract shared by renderer + main.
+3. Add path-collision / path-overlap validation to `ProfileManager.create()`.
+4. Tighten copy/setup diagnostics and remove dead helper surface.
+5. Verification checklist:
+   - Fresh install still shows `ProfileSetup` when no registry exists.
+   - Existing valid registries load unchanged.
+   - Malformed `profiles.json` no longer routes silently into the first-run path.
+   - Creating custom-path profiles rejects duplicate or overlapping roots.
+   - Copying credentials/model preferences still works for the happy path and reports partial-copy failure cleanly.

--- a/docs/deslopify/apps/desktop/electron/features/profile/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/profile/plan.md
@@ -46,7 +46,7 @@ _Plan drafted: 2026-04-12_
 - Path-validation changes are behavior-sensitive: if existing users already have overlapping custom paths, migration/recovery strategy must be explicit.
 
 ## Next Steps
-1. Fix the High issue first: distinguish malformed registry content from “no registry yet.”
+1. ~~Fix the High issue first: distinguish malformed registry content from “no registry yet.”~~ ✅ 2026-04-12 (`4350404d`)
 2. Extract `ProfileInfo` to one canonical contract shared by renderer + main.
 3. Add path-collision / path-overlap validation to `ProfileManager.create()`.
 4. Tighten copy/setup diagnostics and remove dead helper surface.
@@ -56,3 +56,7 @@ _Plan drafted: 2026-04-12_
    - Malformed `profiles.json` no longer routes silently into the first-run path.
    - Creating custom-path profiles rejects duplicate or overlapping roots.
    - Copying credentials/model preferences still works for the happy path and reports partial-copy failure cleanly.
+
+## Execution log
+- 2026-04-12 — `4350404d` — `fix(desktop): harden wave d high-priority runtime paths`
+  - Hardened `readRegistrySync()` so malformed `profiles.json` now fails explicitly instead of silently collapsing to an empty registry.

--- a/docs/deslopify/apps/desktop/electron/features/subagent/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/subagent/facts.md
@@ -1,0 +1,31 @@
+# Facts — apps/desktop/electron/features/subagent
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This feature is Sero's AD-021 subagent runtime. It discovers markdown-defined agents from `SERO_AGENT_DIR`, resolves per-run model/thinking/timeout config, enforces concurrency limits, creates transient child `AgentSession`s, tracks live status/tool activity for the renderer, and exposes the `subagent` / `create_agent` tools to parent sessions.
+
+## Shape & metrics
+- Total files: 10
+- Largest file: `apps/desktop/electron/features/subagent/index.ts` (491 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥400 LOC): `apps/desktop/electron/features/subagent/index.ts` (491)
+- External dependencies of note: `@mariozechner/pi-coding-agent`, `@mariozechner/pi-agent-core`, TypeBox, container tools, shared infra/model registry, `SERO_AGENT_DIR`
+- Upstream callers: `apps/desktop/electron/shared/infra/shared-infra.ts`, `apps/desktop/electron/features/apps/extensions/create-sero-extension.ts`, kanban implementation/planning/review executors, IPC subagent handlers, collaboration flows, subagent tests
+- Downstream dependencies: child-session prompt construction, tracker snapshots/events in renderer UI, container/host coding tool selection, agent-definition authoring under `~/.sero-ui/agent/agents/`
+
+## Architectural notes
+- This feature is the main implementation of AD-021, so runtime behavior matters more than aesthetic cleanup: child sessions must stay isolated, non-recursive, and UI-observable.
+- `index.ts` acts as a façade over discovery, pool, tracker, and runner, but it is already carrying duplicated execution logic for single/parallel/chain modes.
+- The runner uses a reduced extension factory plus `skillsOverride`, not the full app extension stack, so comments and settings around blocked tools/extensions need to stay truthful.
+
+## Runtime-sensitive surfaces
+- Child-session creation and teardown must preserve tool visibility, container cwd handling, session disposal, and debug logging behavior.
+- Tracker and pool behavior drive the renderer's snapshot + live-event model; abort paths that miss tracker updates will present stale or misleading status.
+- Discovery and `create_agent` file format handling affect real user-authored agent definitions in `SERO_AGENT_DIR`; migrations need backward compatibility.
+
+## Surprising discoveries
+- `SubagentManager.abortAll()` aborts controllers in the pool but does not update the tracker, even though `abortOne()` does.
+- The reduced extension-factory comments still promise `@ws:` path expansion, but the implementation only injects prompt blocks, provider logging, and notifications.
+- The feature stores `tools`, `extensions`, and `blockedExtensions` policy fields, but the runtime never enforces them in the child-session loader.
+- `runtime/runner.ts` still relies on a casted `createAgentSession()` call to smuggle the Sero-only `systemPromptSuffix` field through the SDK type surface.

--- a/docs/deslopify/apps/desktop/electron/features/subagent/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/subagent/facts.md
@@ -29,3 +29,19 @@ This feature is Sero's AD-021 subagent runtime. It discovers markdown-defined ag
 - The reduced extension-factory comments still promise `@ws:` path expansion, but the implementation only injects prompt blocks, provider logging, and notifications.
 - The feature stores `tools`, `extensions`, and `blockedExtensions` policy fields, but the runtime never enforces them in the child-session loader.
 - `runtime/runner.ts` still relies on a casted `createAgentSession()` call to smuggle the Sero-only `systemPromptSuffix` field through the SDK type surface.
+
+## Post-fix snapshot — 2026-04-12
+
+### Metrics after fixes
+- Total files: 10 (unchanged)
+- Largest file: `apps/desktop/electron/features/subagent/index.ts` (492 LOC)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 0 new High-priority escape hatches in the runner/tracker path
+
+### What changed
+- Bulk aborts now mark matching tracker entries aborted before the concurrency pool cancels controllers.
+- Added a local Pi SDK module augmentation so `systemPromptSuffix` is typed without a cast, and removed the remaining `session!` assertion from runner debug logging.
+
+### Still outstanding
+- `index.ts` is still a near-cap façade and needs the shared single-run executor extraction from the Medium plan.
+- Policy knobs (`tools`, `extensions`, `blockedExtensions`) are still stored without runtime enforcement.

--- a/docs/deslopify/apps/desktop/electron/features/subagent/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/subagent/plan.md
@@ -1,0 +1,60 @@
+# Refactoring Plan — apps/desktop/electron/features/subagent
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/subagent` is strategically important and mostly well-structured, but it still carries two High-priority correctness issues in the AD-021 core: bulk aborts do not propagate to tracker state, and the runner still hides SDK contract drift behind a cast/non-null assertion. After that, the biggest win is slimming the near-cap façade and deleting policy/comment surfaces that no longer match the reduced child-session runtime.
+
+## Issues Found (prioritized)
+- **High** — Bulk aborts do not update tracker state, so UI snapshots/events can stay stale after `abortAll()` — `apps/desktop/electron/features/subagent/index.ts:446-447` only delegates to `this.pool.abortAll(parentSessionId)`, while tracker terminal updates are only wired for single-run aborts (`index.ts:451-455`). `apps/desktop/electron/features/subagent/core/tracker.ts:166-172` even exposes `clear()`/`subagent_clear`, but the bulk-abort path never uses it. In an AD-021 snapshot+events system, that is a real runtime correctness bug. Effort: **M**.
+- **High** — The runner still uses type escapes around the SDK session-creation contract — `apps/desktop/electron/features/subagent/runtime/runner.ts:202-203` casts the `createAgentSession()` config to `Parameters<typeof createAgentSession>[0]` to pass `systemPromptSuffix`, and `runtime/runner.ts:273` uses `session!` when logging turn context. This is a hard-rule violation on a critical session-runtime boundary. Effort: **S**.
+- **Medium** — `SubagentManager` is a near-cap façade with duplicated single-run execution logic — `apps/desktop/electron/features/subagent/index.ts:69-491`, especially `index.ts:113-196` and `index.ts:206-289`, repeats the same resolve/configure/track/run/finalize flow for `runSingle()` and `runSingleStructured()`. That duplication is already making the module expensive to extend safely. Effort: **M**.
+- **Medium** — Subagent policy/config fields are stored but not enforced anywhere in the runtime — `apps/desktop/electron/features/subagent/core/types.ts:46-48,76-87` defines `tools`, `extensions`, and `blockedExtensions`; `apps/desktop/electron/features/subagent/index.ts:83` stores the settings; and `apps/desktop/electron/features/subagent/runtime/runner.ts:164-173` still always builds the same reduced extension stack. This leaves dead policy surface that implies controls the runtime does not actually honor. Effort: **S**.
+- **Low** — Loader comments no longer match behavior — `apps/desktop/electron/features/subagent/runtime/loader.ts:4-10` claims the reduced extension factory provides `@ws:` path expansion, but `loader.ts:34-65` implements prompt injection, provider logging, and notifications only. This is comment rot in a subtle runtime module. Effort: **S**.
+
+## Proposed Refactoring
+1. **Make bulk aborts first-class tracker events.**
+   - Add a `tracker.abortByParentSession(parentSessionId)` or equivalent helper that marks all matching running entries as aborted before/while the pool cascades abort signals.
+   - Emit one clear terminal event path for bulk aborts so renderer state matches the actual child-session lifecycle.
+   - Keep AD-021's snapshot + live-event contract explicit rather than relying on eventual cleanup.
+
+2. **Replace the runner's type escapes with an explicit Sero-owned wrapper.**
+   - Introduce a tiny local wrapper/factory for subagent sessions that models the Sero-only `systemPromptSuffix` extension without a broad cast at the callsite.
+   - Remove the `session!` assertion by guarding `logTurnContext` behind a local `if (session)` or by narrowing earlier in the callback.
+   - This keeps upstream SDK drift visible at compile time instead of being papered over.
+
+3. **Extract one shared single-run execution path from `SubagentManager`.**
+   - Target structure:
+     - `index.ts` stays the façade/public API
+     - `lib/execute-single-run.ts` or similar owns resolve/configure/track/run/finalize mechanics
+     - `runSingle()` and `runSingleStructured()` become thin wrappers over the same executor
+   - Preserve existing public return shapes so callers in kanban/collaboration do not need churn.
+
+4. **Either enforce or delete the unused policy surfaces.**
+   - If `tools`, `extensions`, and `blockedExtensions` are meant to be real v2/v1.5 controls, wire them into discovery + runner filtering.
+   - If AD-021 deliberately excludes that scope for now, remove the dead settings/fields or mark them clearly as unsupported to avoid false affordances.
+   - Prefer smaller truthful contracts over speculative knobs.
+
+5. **Fix the loader commentary to match the real reduced extension factory.**
+   - Remove the stale `@ws:` claim or implement the missing behavior if child sessions truly require it.
+   - Keep the reduced-factory contract explicit: prompt blocks, provider logging, notifications, and no recursion.
+
+## Benefits & Trade-offs
+- Benefits: correct abort-state reporting in the renderer, stricter SDK boundary typing, a smaller/faster-to-review façade, and fewer misleading policy surfaces for future work.
+- Trade-offs: bulk-abort changes touch subtle UI/runtime coordination, and replacing the session-creation cast may require a small amount of shared wrapper code around the Pi SDK.
+
+## Dependencies & Risks
+- Bulk-abort fixes should be validated together with the renderer/IPC consumers of tracker events so the UI does not double-handle terminal entries.
+- Any wrapper around `createAgentSession()` must preserve current child-session semantics: model setting, `systemPromptSuffix`, container tools, debug logging, and disposal behavior.
+- Removing unused policy fields is a behavioral/API change if any external agent definitions or settings UIs already expose them.
+
+## Next Steps
+1. Fix the bulk-abort/tracker desync first.
+2. Remove the `createAgentSession()` cast and `session!` assertion from `runtime/runner.ts`.
+3. Extract shared single-run execution logic so `index.ts` drops well below the LOC cap.
+4. Decide whether policy knobs (`tools`, `extensions`, `blockedExtensions`) are real; enforce or delete them accordingly.
+5. Verification checklist:
+   - Start several subagents, call `abortAll`, and confirm tracker snapshots/events show all affected runs as aborted.
+   - Run single, parallel, and chain modes and verify token counts/tool activity/live output still flow to the UI.
+   - Create an ad-hoc inline subagent and a discovered named agent and confirm both still receive the intended prompt suffix.
+   - Confirm child sessions still exclude recursive subagent tools and external extension loading per AD-021.

--- a/docs/deslopify/apps/desktop/electron/features/subagent/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/subagent/plan.md
@@ -49,8 +49,8 @@ _Plan drafted: 2026-04-12_
 - Removing unused policy fields is a behavioral/API change if any external agent definitions or settings UIs already expose them.
 
 ## Next Steps
-1. Fix the bulk-abort/tracker desync first.
-2. Remove the `createAgentSession()` cast and `session!` assertion from `runtime/runner.ts`.
+1. ~~Fix the bulk-abort/tracker desync first.~~ ✅ 2026-04-12 (`4350404d`)
+2. ~~Remove the `createAgentSession()` cast and `session!` assertion from `runtime/runner.ts`.~~ ✅ 2026-04-12 (`4350404d`)
 3. Extract shared single-run execution logic so `index.ts` drops well below the LOC cap.
 4. Decide whether policy knobs (`tools`, `extensions`, `blockedExtensions`) are real; enforce or delete them accordingly.
 5. Verification checklist:
@@ -58,3 +58,8 @@ _Plan drafted: 2026-04-12_
    - Run single, parallel, and chain modes and verify token counts/tool activity/live output still flow to the UI.
    - Create an ad-hoc inline subagent and a discovered named agent and confirm both still receive the intended prompt suffix.
    - Confirm child sessions still exclude recursive subagent tools and external extension loading per AD-021.
+
+## Execution log
+- 2026-04-12 — `4350404d` — `fix(desktop): harden wave d high-priority runtime paths`
+  - Bulk aborts now mark matching tracker entries aborted before the pool cascade runs.
+  - Added a local Pi SDK module augmentation so subagent session creation no longer needs a cast, and removed the remaining `session!` assertion from debug logging.

--- a/docs/deslopify/apps/desktop/electron/features/vcs/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/vcs/facts.md
@@ -1,0 +1,32 @@
+# Facts — apps/desktop/electron/features/vcs
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This feature is the Electron-side Git/VCS service layer for Sero. It initializes repositories for workspaces, runs git/gh commands on the host or in the workspace container, creates and restores checkpoints, manages branches/remotes/push flows, and builds pull-request previews/context used by higher-level auth, publish, and kanban flows.
+
+## Shape & metrics
+- Total files: 9
+- Largest file: `apps/desktop/electron/features/vcs/core/vcs-ops.ts` (442 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥400 LOC):
+  - `apps/desktop/electron/features/vcs/core/vcs-ops.ts` (442)
+  - `apps/desktop/electron/features/vcs/core/pr-ops.ts` (438)
+- External dependencies of note: Node `child_process`, workspace/container managers, GitHub auth manager, `git`, `gh`
+- Upstream callers: `apps/desktop/electron/shared/infra/shared-infra.ts`, `apps/desktop/electron/features/auth/github/repo-ops.ts`, `apps/desktop/electron/features/kanban/worktree/worktree-manager.ts`, VCS/auth tests
+- Downstream dependencies: workspace checkpointing, publish/origin flows, PR draft context generation, branch naming for kanban worktrees
+
+## Architectural notes
+- This module sits on an AD-018 runtime boundary: every git/gh operation can execute on the host or through the workspace container, so success-path behavior matters more than stylistic cleanup.
+- Shared VCS contracts currently flow from the renderer alias path (`@/types/vcs`) back into Electron via `support/types.ts`, which is the wrong ownership direction for a cross-process contract.
+- `GitRunner` is the only place that decides whether GitHub auth should use SSH-native transport or injected HTTPS auth env vars on the host, so stale heuristics here leak into every push/PR flow.
+
+## Runtime-sensitive surfaces
+- Host/container transport selection and GitHub auth env injection must preserve current push/pull/gh behavior across both runtimes.
+- Checkpoint restore semantics (`checkout`, `clean`, `add`, `commit`) are behavior-sensitive; cleanup should not silently change what files get restored or committed.
+- PR preview/draft flows depend on branch naming, merge-base selection, and `gh` availability heuristics that are consumed by renderer publish UI.
+
+## Surprising discoveries
+- The feature advertises an `fs` checkpoint source but immediately rewrites it to `manual` when creating a checkpoint.
+- The main-process VCS layer still imports its canonical shared types from a renderer path alias instead of a neutral shared package.
+- The host SSH-availability probe is cached for the entire process lifetime, so adding/fixing SSH after app launch will not change git transport behavior until restart.

--- a/docs/deslopify/apps/desktop/electron/features/vcs/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/vcs/facts.md
@@ -30,3 +30,18 @@ This feature is the Electron-side Git/VCS service layer for Sero. It initializes
 - The feature advertises an `fs` checkpoint source but immediately rewrites it to `manual` when creating a checkpoint.
 - The main-process VCS layer still imports its canonical shared types from a renderer path alias instead of a neutral shared package.
 - The host SSH-availability probe is cached for the entire process lifetime, so adding/fixing SSH after app launch will not change git transport behavior until restart.
+
+## Post-fix snapshot — 2026-04-12
+
+### Metrics after fixes
+- Total files: 9 (unchanged)
+- Largest file: `apps/desktop/electron/features/vcs/core/vcs-ops.ts` (442 LOC)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 0 in this folder
+
+### What changed
+- `git-runner.ts` now normalizes exec failures through one typed helper instead of relying on `any` reads in the SSH probe and host command path.
+
+### Still outstanding
+- Shared VCS contracts still point back into renderer-owned types.
+- Checkpoint-source semantics and SSH transport cache invalidation still need a follow-up behavior pass.

--- a/docs/deslopify/apps/desktop/electron/features/vcs/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/vcs/plan.md
@@ -54,7 +54,7 @@ _Plan drafted: 2026-04-12_
 - Transport-cache changes must preserve current host/container auth behavior for both `git` and `gh`, especially for SSH-vs-HTTPS remotes.
 
 ## Next Steps
-1. Remove the two `any` catch sites in `git-runner.ts`.
+1. ~~Remove the two `any` catch sites in `git-runner.ts`.~~ ✅ 2026-04-12 (`4350404d`)
 2. Decide whether `fs` checkpoint source still exists; either preserve it honestly or remove it from the contract.
 3. Move shared VCS contracts to a neutral shared module and update Electron/renderer imports together.
 4. Split `vcs-ops.ts` and `pr-ops.ts` before adding more publish/PR behavior.
@@ -62,3 +62,7 @@ _Plan drafted: 2026-04-12_
    - Push from both SSH and HTTPS GitHub remotes on host and container-backed workspaces.
    - Create/list/restore checkpoints and verify source metadata shown to the renderer stays correct.
    - Build PR preview context, create a PR, and confirm `gh` error handling stays unchanged.
+
+## Execution log
+- 2026-04-12 — `4350404d` — `fix(desktop): harden wave d high-priority runtime paths`
+  - Replaced the remaining `any`-typed git transport error paths in `git-runner.ts` with a shared typed exec-failure normalizer.

--- a/docs/deslopify/apps/desktop/electron/features/vcs/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/vcs/plan.md
@@ -1,0 +1,64 @@
+# Refactoring Plan — apps/desktop/electron/features/vcs
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`electron/features/vcs` is functional and reasonably contained, but it carries a few sharp edges in a behavior-sensitive runtime layer: the host git runner still uses `any` escape hatches, shared VCS contracts point backwards into renderer-owned types, and checkpoint metadata has already drifted from its declared source model. The right outcome is not a rewrite; it is a targeted hardening pass that restores canonical contract ownership, removes the unsafe typing at the transport boundary, and trims the two near-cap orchestration hubs before more publish/PR logic lands.
+
+## Issues Found (prioritized)
+- **High** — `GitRunner` still uses `any` at the git transport/auth boundary — `apps/desktop/electron/features/vcs/core/git-runner.ts:37` and `apps/desktop/electron/features/vcs/core/git-runner.ts:131` use `err: any` in the SSH probe and host command execution path. This violates the monorepo's no-type-escape rule in the one module that decides how git/gh commands execute for every workspace. Effort: **S**.
+- **Medium** — Canonical VCS contracts live in a renderer-owned path instead of a neutral shared module — `apps/desktop/electron/features/vcs/support/types.ts:1-17` re-exports core VCS shapes from `@/types/vcs`, which makes Electron main-process code depend on renderer-local type ownership. For a cross-process contract used by auth, kanban, and renderer UI, this is the wrong direction of dependency. Effort: **M**.
+- **Medium** — Filesystem checkpoints are silently rewritten to manual checkpoints — `apps/desktop/electron/features/vcs/core/vcs-manager.ts:136-155` still defines filesystem checkpoint descriptions, but `createCheckpoint()` remaps `options.source === 'fs'` to `'manual'`. That is a behavioral mismatch, not just a naming nit: downstream UI/analytics cannot trust the stored source. Effort: **S**.
+- **Medium** — Host SSH transport selection is cached for the entire process lifetime — `apps/desktop/electron/features/vcs/core/git-runner.ts:19-43,102` memoizes `_sshAvailable` after the first probe. If the user adds keys, fixes their SSH agent, or changes network state after launch, VCS flows keep using the old transport decision until restart. Effort: **S**.
+- **Medium** — Two orchestration files are already near the 500-LOC cap — `apps/desktop/electron/features/vcs/core/vcs-ops.ts:27-442` and `apps/desktop/electron/features/vcs/core/pr-ops.ts:28-438` both mix state resolution, command building, error formatting, and user-facing message shaping. This is still below the cap, but more publish/review features will push both files into expensive-to-review territory. Effort: **M**.
+- **Low** — Default checkpoint messages are locale-dependent and non-deterministic — `apps/desktop/electron/features/vcs/core/vcs-manager.ts:136-142` uses `new Date().toLocaleString()` inside commit subjects. That makes generated checkpoint text vary by machine locale and weakens tests/automation that assume stable formatting. Effort: **S**.
+
+## Proposed Refactoring
+1. **Remove the `any` escape hatches from `GitRunner`.**
+   - Replace the SSH probe fallback with a small typed error-normalization helper (`normalizeExecFileFailure`).
+   - Use explicit structural reads for `stdout`, `stderr`, `code`, and `message` instead of `err: any`.
+   - Keep current runtime behavior exactly the same while restoring compile-time guarantees.
+
+2. **Move shared VCS contracts to a neutral package/module.**
+   - Target structure: move renderer-safe VCS types out of `@/types/vcs` into `@sero/common` (preferred) or a dedicated shared contract module consumed by both renderer and Electron.
+   - Leave `support/types.ts` as a thin Electron-specific add-on for `GitResult` and other truly main-only helpers.
+   - This aligns with the repo guidance to import canonical shared contracts instead of mirroring or reaching into renderer-local types.
+
+3. **Restore truthful checkpoint-source semantics.**
+   - Decide whether `fs` checkpoints are still a real concept.
+   - If they are, stop rewriting them to `manual` and preserve the declared source through create/list/restore flows.
+   - If they are not, remove `fs` from `CreateCheckpointOptions` and any renderer/UI paths that still expose it.
+   - Treat this as a behavioral change and verify any consumers that bucket checkpoints by source.
+
+4. **Make SSH transport detection refreshable instead of process-global forever.**
+   - Replace `_sshAvailable` with a TTL-based cache or an explicit invalidation hook tied to auth/settings changes.
+   - Preserve the current “prefer native SSH when it works” behavior, but let the decision recover after the environment changes.
+   - Add focused logging for transport selection so future regressions are diagnosable.
+
+5. **Split the near-cap VCS hubs before more publish logic lands.**
+   - `vcs-ops.ts`: extract remotes, bookmarks, and push helpers into focused modules.
+   - `pr-ops.ts`: separate branch-state resolution, diff/preview helpers, and create-PR execution/error formatting.
+   - Keep `VcsOps` and `VcsPullRequestOps` as thin composition façades so shared-infra consumers do not need broad rewiring.
+
+6. **Stabilize generated checkpoint descriptions.**
+   - Replace locale-dependent timestamps with an ISO or Sero-owned formatter suitable for commit subjects.
+   - Preserve the current human-readable intent, but make output deterministic across machines.
+
+## Benefits & Trade-offs
+- Benefits: safer git transport typing, clearer contract ownership, more trustworthy checkpoint metadata, and lower risk of the VCS core turning into another near-cap orchestration bucket.
+- Trade-offs: moving shared VCS types will touch both Electron and renderer imports, and checkpoint-source cleanup is a semantic change that needs UI/analytics verification.
+
+## Dependencies & Risks
+- Shared type extraction should happen in one coordinated pass with renderer VCS consumers so contracts do not temporarily fork.
+- Changing checkpoint-source handling is runtime-sensitive: success-path behavior, stored metadata, and any source-based filtering must all be validated together.
+- Transport-cache changes must preserve current host/container auth behavior for both `git` and `gh`, especially for SSH-vs-HTTPS remotes.
+
+## Next Steps
+1. Remove the two `any` catch sites in `git-runner.ts`.
+2. Decide whether `fs` checkpoint source still exists; either preserve it honestly or remove it from the contract.
+3. Move shared VCS contracts to a neutral shared module and update Electron/renderer imports together.
+4. Split `vcs-ops.ts` and `pr-ops.ts` before adding more publish/PR behavior.
+5. Verification checklist:
+   - Push from both SSH and HTTPS GitHub remotes on host and container-backed workspaces.
+   - Create/list/restore checkpoints and verify source metadata shown to the renderer stays correct.
+   - Build PR preview context, create a PR, and confirm `gh` error handling stays unchanged.

--- a/docs/deslopify/apps/desktop/src/components/apps/explorer/facts.md
+++ b/docs/deslopify/apps/desktop/src/components/apps/explorer/facts.md
@@ -1,0 +1,32 @@
+# Facts — apps/desktop/src/components/apps/explorer
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`src/components/apps/explorer` is the primary desktop work surface. It renders the Explorer app shell (activity bar, sidebar, editor, terminal), hosts the VCS and subagent/orchestration panels, manages multi-root file trees, and bridges Monaco/LSP/file-preview behavior to the renderer stores and the `window.sero` IPC surface.
+
+## Shape & metrics
+- Total files: 38
+- Largest file: `apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx` (480 LOC)
+- Files over 500 LOC: None
+- Near-cap files (≥300 LOC):
+  - `apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx` (480)
+  - `apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx` (473)
+  - `apps/desktop/src/components/apps/explorer/vcs/PullRequestSection.tsx` (362)
+  - `apps/desktop/src/components/apps/explorer/file-tree/FileTree.tsx` (334)
+  - `apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.tsx` (317)
+  - `apps/desktop/src/components/apps/explorer/vcs/BookmarksSection.tsx` (303)
+- External dependencies of note: `@monaco-editor/react`, `monaco-editor`, `@headless-tree/*`, `@dnd-kit/*`, `@xterm/*`, `motion/react`, `streamdown`
+- Upstream callers: `apps/desktop/src/components/apps/ActiveAppPanel.tsx`, `apps/desktop/src/stores/editor-bridge.ts`, shell/session state from `src/stores/{explorer,terminal,vcs,subagent}`
+- Downstream dependencies: `window.sero.{editor,filetree,terminal,vcs,workspace}`, `src/lsp/use-lsp`, `src/lib/copy-to-clipboard`
+
+## Architectural notes
+- This directory is the main renderer consumer of AD-001 and AD-002: Explorer remains a self-contained app, but it now contains several substantial feature islands (editor, terminal, VCS, orchestration) that need clearer internal ownership boundaries.
+- Terminal and editor behavior are direct consumers of AD-018 container-backed execution. Explorer surface code should stay thin over the stores and `window.sero` bridge rather than becoming another orchestration layer.
+- The subagent/orchestration sidebar is the renderer landing zone for AD-021, so its UI state and event subscriptions should stay isolated from the rest of the explorer shell.
+- No source file here breaks the 500 LOC hard cap yet, but `ExplorerWorkspace.tsx` and `editor/EditorPanel.tsx` are both within one medium feature of becoming violations.
+
+## Surprising discoveries
+- The “Explorer” app now owns much more than file navigation: source control, terminal lifecycle, live dev-server previews, diff viewing, markdown/media previews, and subagent monitoring all terminate here.
+- Several seemingly small leaf components re-implement transient async UI patterns (`setTimeout`-cleared notices, inline loading/error state, silent catch blocks) instead of sharing helpers, so the slop is spread horizontally rather than concentrated in one obvious file.
+- `WorkingCopySection.tsx` still renders an “Absorb changes into ancestors” button with no handler, which makes the panel look more complete than it actually is.

--- a/docs/deslopify/apps/desktop/src/components/apps/explorer/plan.md
+++ b/docs/deslopify/apps/desktop/src/components/apps/explorer/plan.md
@@ -1,0 +1,66 @@
+# Refactoring Plan — apps/desktop/src/components/apps/explorer
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/components/apps/explorer` is functional and feature-rich, but it is now carrying the cost of being the first real app surface in the product: orchestration logic is pooling in `ExplorerWorkspace.tsx` and `EditorPanel.tsx`, while the file-tree/VCS/subagent subareas have each grown their own imperative lifecycle patterns. There are no immediate High-priority rule violations in this area, but it is the next place where maintainability will degrade sharply unless ownership is split before the near-cap files tip over.
+
+## Issues Found (prioritized)
+- **Medium** — `ExplorerWorkspace` is a near-cap orchestration hub with too many runtime responsibilities — `apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx:39-454` handles root discovery, persisted editor state restore/save, terminal bootstrap, VCS watcher wiring, editor-bridge subscriptions, diff routing, and panel-resize synchronization in one component. This is beyond the “self-contained app shell” intent of AD-001/AD-002 and makes any explorer change high-churn. Effort: **M**.
+
+- **Medium** — `EditorPanel` is another near-cap multi-owner component instead of a focused editor surface — `apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx:39-444` mixes file loading, unsaved-buffer caching, Monaco view-state persistence, preview-mode switching, custom opener registration, filesystem refresh subscriptions, VCS restore handling, and LSP integration. It is currently the renderer-side choke point for several unrelated behaviors. Effort: **M**.
+
+- **Medium** — `FileTree` relies on effect-heavy imperative synchronization that is hard to reason about and hard to extend safely — `apps/desktop/src/components/apps/explorer/file-tree/FileTree.tsx:83-286` resets local data on workspace/root changes, lazily loads directories, reacts to two event buses, applies drag/drop mutations, and then calls `tree.rebuildTree()` as a final reconciliation pass. This works today, but it makes future multi-root or large-tree behavior risky because data ownership is spread across refs, state, and headless-tree internals. Effort: **M**.
+
+- **Medium** — VCS/orchestration leaf components duplicate transient async UI patterns and still hide at least one failure path — `apps/desktop/src/components/apps/explorer/vcs/BookmarksSection.tsx:83-85`, `apps/desktop/src/components/apps/explorer/vcs/PullRequestSection.tsx:80-101`, `apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.tsx:43-63`, and `apps/desktop/src/components/apps/explorer/orchestration/SubagentOutput.tsx:21-27` each hand-roll timer-cleared notices or optimistic async feedback, while `ChangeDetail.tsx:43-49` swallows file-summary load errors entirely. The area reads as many bespoke mini-flows rather than one coherent UI system. Effort: **S**.
+
+- **Low** — `WorkingCopySection` still ships a dead action in the primary source-control workflow — `apps/desktop/src/components/apps/explorer/vcs/WorkingCopySection.tsx:118-128` renders a Sparkles “Absorb changes into ancestors” button with no handler or disabled state. This is small, but dead controls in a primary surface erode trust quickly. Effort: **S**.
+
+## Proposed Refactoring
+1. **Split `ExplorerWorkspace` into internal controllers plus a thin layout shell.**
+   - Keep the JSX shell responsible for the resizable layout and panel composition only.
+   - Extract focused hooks/modules such as:
+     - `useExplorerRoots(workspaceId)` — root loading/removal + file-watch refresh
+     - `useExplorerEditorState(workspaceId)` — tab restore/persist, diff mode, path remap/delete handling
+     - `useExplorerRuntimeEffects(workspaceId)` — VCS watcher wiring, terminal auto-create, editor-bridge subscription
+   - This keeps the Explorer app aligned with AD-001/AD-002: the app owns its own layout, but the shell should not also be a lifecycle dumping ground.
+
+2. **Decompose `EditorPanel` by concern before it crosses 500 LOC.**
+   - Target structure:
+     - `editor/useEditorDocumentState.ts` — file load/save, dirty tracking, content caches
+     - `editor/useEditorRuntimeSync.ts` — filetree/VCS refresh listeners and reload policy
+     - `editor/useMonacoNavigation.ts` — opener registration + pending goto behavior
+     - `editor/EditorPanel.tsx` — render shell + Monaco/preview switch
+   - Keep the public component API stable so `ExplorerWorkspace` only sees the current props.
+   - Aligns with the four-layer renderer/store/preload/main rule by keeping renderer orchestration legible.
+
+3. **Extract a dedicated file-tree model hook and reduce imperative rebuilds.**
+   - Move directory loading, expansion state, watcher refresh, and drag/drop mutation handling into a `useFileTreeModel` hook.
+   - Keep `FileTree.tsx` focused on headless-tree wiring + rendering.
+   - Replace the blanket `tree.rebuildTree()` reconciliation with narrower updates if the headless-tree API allows it; if not, isolate that requirement inside the model hook with a comment that explains the invariant.
+
+4. **Standardize transient async UI helpers across VCS and orchestration surfaces.**
+   - Introduce a small shared hook/helper for ephemeral notices and copy state (for example `useTransientUiState(durationMs)` or a scoped explorer-only helper).
+   - Replace the repeated `setTimeout(() => clear...)` patterns in bookmarks, PR preview, push notices, and output-copy feedback.
+   - Convert `ChangeDetail.tsx:43-49` from silent failure to an explicit inline error state or warning banner.
+   - This matches the cleanup direction already recorded in `docs/deslop.md` for repeated timer/debounce slop.
+
+5. **Remove or properly wire incomplete controls.**
+   - Either implement the working-copy absorb action through the existing VCS store or hide/disable the button until the workflow exists end-to-end.
+   - Apply the same rule to any other placeholder controls that reached the primary explorer surface.
+
+## Benefits & Trade-offs
+- Benefits: lower review load for explorer changes, clearer app-surface ownership, easier debugging of filetree/editor refresh bugs, and less repeated UI-state boilerplate across VCS/subagent panels.
+- Trade-offs: moderate module churn in a highly visible area, more files to navigate, and some short-term friction while extracting hooks without changing behavior.
+
+## Dependencies & Risks
+- `ExplorerWorkspace` and `EditorPanel` touch many renderer stores (`explorer`, `terminal`, `vcs`, `editor-bridge`), so extraction work must preserve store contracts already stabilized in Wave B.
+- File-tree refactoring must preserve multi-root behavior and drag/drop semantics; this is not a cosmetic split.
+- Any editor decomposition must stay coordinated with `src/lsp` and `electron/features/editor` so renderer/main language-routing drift does not get worse.
+
+## Next Steps
+1. Split `ExplorerWorkspace.tsx` into layout shell + focused controller hooks.
+2. Split `editor/EditorPanel.tsx` into document, Monaco, and runtime-sync modules.
+3. Extract a `useFileTreeModel` hook and contain headless-tree rebuild mechanics there.
+4. Deduplicate transient notice/copy helpers and remove the silent `ChangeDetail` catch.
+5. Remove or implement the dead absorb action before expanding the VCS surface further.

--- a/docs/deslopify/apps/desktop/src/components/layout/facts.md
+++ b/docs/deslopify/apps/desktop/src/components/layout/facts.md
@@ -1,0 +1,59 @@
+# Facts — apps/desktop/src/components/layout
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`src/components/layout` is the shell-facing UI layer for the desktop app. It renders the always-on chrome (`TitleBar`, `MainSidebar`, `StatusBar`, `ChatPanel`) and also hosts a large set of cross-cutting feature surfaces that hang off the shell: workspace/session management, chat/tool rendering, auth/provider dialogs, theme editing, model selection and local-model management, git publish/PR flows, device pairing, and collaboration activity views.
+
+## Shape & metrics
+- Total files: 88
+- Total LOC: 15,908
+- Largest files:
+  - `apps/desktop/src/components/layout/ContextEditor.tsx` (479 LOC)
+  - `apps/desktop/src/components/layout/model-manager/local-models/LocalProviderForm.tsx` (479 LOC)
+- Files over 500 LOC: None
+- Near-cap files (≥400 LOC):
+  - `apps/desktop/src/components/layout/ContextEditor.tsx` (479)
+  - `apps/desktop/src/components/layout/model-manager/local-models/LocalProviderForm.tsx` (479)
+  - `apps/desktop/src/components/layout/AuthLoginViews.tsx` (464)
+  - `apps/desktop/src/components/layout/WorkspaceTree.tsx` (445)
+  - `apps/desktop/src/components/layout/ModelSelector.tsx` (445)
+  - `apps/desktop/src/components/layout/remote-origin-views.tsx` (438)
+  - `apps/desktop/src/components/layout/ToolCallHelpers.tsx` (412)
+  - `apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx` (406)
+  - `apps/desktop/src/components/layout/ThemeEditorSheet.tsx` (400)
+- External dependencies of note: `motion/react`, `lucide-react`, `@sero-ai/ui` ai-elements + Radix wrappers, browser media APIs (`MediaRecorder`, `navigator.mediaDevices`), `zustand`, DOM portals/resizable panels
+- Upstream callers:
+  - `apps/desktop/src/App.tsx`
+  - `apps/desktop/src/components/profiles/OnboardingWizard.tsx`
+  - `apps/desktop/src/hooks/useCheckpointRestore.ts`
+- Downstream dependencies:
+  - Renderer stores: `src/stores/{agent,app,workspace,sessions,theme,feedback,dev-server,vcs,model-preferences,container}`
+  - Hooks: `src/hooks/{useChatPromptInput,useMessageQueue,useCheckpointRestore,useUserFeedbackInit}`
+  - Preload bridge domains: `window.sero.{agent,auth,workspace,plugins,vcs,github,voice,gateway,devServer,appState,localModels,themes,debug,shell,subagent}`
+
+## Architectural notes
+- This directory is no longer just shell chrome. It mixes true shell components (`TitleBar`, `MainSidebar`, `StatusBar`, `ChatPanel`) with several feature islands: auth/provider management, theme editing, model management, git ship/publish/PR flows, device pairing, collaboration visualisation, and workspace remote-origin management.
+- Shell ownership should stay aligned with AD-001 and AD-003: the shell composes global chrome and the global chat panel, but feature-specific workflows should not accumulate as an undifferentiated `layout/` catch-all.
+- Collaboration surfaces in this folder are the shell landing zone for AD-021, while workspace/container affordances (`WorkspaceTree`, mounts, remote origin) are renderer clients of AD-018-backed flows and main-process workspace/VCS state.
+- Memory and thinking UI in chat (`MemoryContextBlock`, `ThinkingBlock`, `ChatMessageItem`) are coupled to the renderer event/stash pipeline described in `docs/features/memory.md`; changes here must stay in sync with the store/hook plans already recorded for `src/stores` and `src/hooks`.
+- Titlebar Git controls consume watched app-state files rather than invoking git directly from the renderer. Watch/unwatch symmetry matters here.
+
+## Runtime-sensitive surfaces
+- Global shell behaviors that must not regress:
+  - `sero:open-session` and `sero:workspace-changed` custom-event handling in `WorkspaceTree`
+  - global chat routing and collaboration tray resize persistence in `ChatPanel`
+  - remote-origin creation/connection and PR creation flows in workspace and titlebar surfaces
+  - auth/provider refresh triggering model-state refresh across open sessions
+  - microphone permission, device enumeration, and transcription lifecycle in `VoiceTranscriptionControl`
+- Production/external assumptions to preserve explicitly:
+  - GitHub auth status and fallback repo URL generation
+  - plugin discovery search/install/uninstall behavior when the registry/network is unavailable
+  - browser support differences for `MediaRecorder`, `requestIdleCallback`, and device labels
+  - font-loading behavior for theme editing (currently tied to Google-font preloading)
+
+## Surprising discoveries
+- `components/layout` contains 88 files and nearly 16k LOC, but only a small subset is actual shell scaffolding.
+- Workspace remote setup (`RemoteOriginManager` + `remote-origin-views`) and titlebar publishing (`titlebar/GitRemotePublishSection`) implement almost the same GitHub/origin workflow separately.
+- Several components still rely on render-phase side effects instead of explicit lifecycle hooks: `ThemeEditorSheet` sets state during render, `useAutoScroll` schedules `requestAnimationFrame` from render, and `FontPicker` preloads fonts during render.
+- The shell directory now houses entire sub-products: model manager/local providers, theme editor, auth dialog, git ship deck, collaboration room, QR device pairing, and plugin discovery.

--- a/docs/deslopify/apps/desktop/src/components/layout/plan.md
+++ b/docs/deslopify/apps/desktop/src/components/layout/plan.md
@@ -1,0 +1,97 @@
+# Refactoring Plan — apps/desktop/src/components/layout
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/components/layout` is functional and feature-rich, but it has drifted from “shell chrome” into a catch-all bucket for nearly every cross-cutting renderer surface in the app. There are no current High-priority hard-rule violations in this folder, but the ownership blur and near-cap file cluster mean shell work will keep getting slower and riskier unless the directory is re-partitioned, duplicated workflows are consolidated, and a few render-time lifecycle hacks are retired.
+
+## Issues Found (prioritized)
+- **Medium** — `components/layout` is no longer a shell-only layer; ownership is smeared across unrelated feature islands — `apps/desktop/src/components/layout/WorkspaceTree.tsx:50-445`, `apps/desktop/src/components/layout/ChatPanel.tsx:46-296`, `apps/desktop/src/components/layout/CommandMenu.tsx:19-118`, `apps/desktop/src/components/layout/AuthLoginDialog.tsx:57-334`, `apps/desktop/src/components/layout/ThemeEditorSheet.tsx:59-399`, and `apps/desktop/src/components/layout/titlebar/GitTitleBarControls.tsx:11-160` together show the pattern. This fights the shell/app split from AD-001 and AD-003: the shell should compose global chrome, not become the default home for auth, git publishing, theme tooling, model management, gateway QR login, and collaboration internals. Effort: **L**.
+
+- **Medium** — A large near-cap cluster is one feature away from repeated 500-LOC violations — `apps/desktop/src/components/layout/ContextEditor.tsx:1-479`, `apps/desktop/src/components/layout/model-manager/local-models/LocalProviderForm.tsx:1-479`, `apps/desktop/src/components/layout/AuthLoginViews.tsx:1-464`, `apps/desktop/src/components/layout/WorkspaceTree.tsx:1-445`, `apps/desktop/src/components/layout/ModelSelector.tsx:1-445`, `apps/desktop/src/components/layout/remote-origin-views.tsx:1-438`, `apps/desktop/src/components/layout/ToolCallHelpers.tsx:1-412`, `apps/desktop/src/components/layout/model-manager/ModelManagerDialog.tsx:1-406`, and `apps/desktop/src/components/layout/ThemeEditorSheet.tsx:1-400` are all already in the danger zone. The folder has no High violation today, but the cap pressure is widespread enough that more feature work here will become expensive by default. Effort: **M**.
+
+- **Medium** — Git remote publish/origin flows are duplicated across workspace and titlebar surfaces and are already diverging in behavior and error semantics — `apps/desktop/src/components/layout/remote-origin-views.tsx:53-289`, `apps/desktop/src/components/layout/RemoteOriginManager.tsx:45-95`, and `apps/desktop/src/components/layout/titlebar/GitRemotePublishSection.tsx:38-317` each implement their own GitHub status checks, default repo-name generation, origin creation, existing-origin connection, fallback URL handling, and failure messaging. This is classic drift-prone duplication in a runtime-sensitive surface. Effort: **M**.
+
+- **Medium** — Slash-command and file-reference autocompletes duplicate the same document-level keyboard/listbox machinery instead of sharing one primitive — `apps/desktop/src/components/layout/SlashCommandMenu.tsx:53-178` and `apps/desktop/src/components/layout/FileReferenceMenu.tsx:85-212` both maintain selected-index state, `scrollIntoView`, capture-phase `keydown` listeners, and nearly identical listbox rendering. This is small-scale duplication, but it sits in a hot UX path and invites inconsistent keyboard behavior over time. Effort: **S**.
+
+- **Medium** — Several layout helpers still perform side effects during render, obscuring lifecycle ownership and making behavior harder to reason about — `apps/desktop/src/components/layout/ThemeEditorSheet.tsx:74-85` sets component state during render, `apps/desktop/src/components/layout/CollaborationFeedItems.tsx:326-338` schedules `requestAnimationFrame` from render, and `apps/desktop/src/components/layout/theme-editor/FontPicker.tsx:20-24` preloads fonts during render. None of these are broken today, but they bypass the normal “external side effects live in effects/callback refs” rule and increase future regression risk. Effort: **S**.
+
+- **Low** — A few shell surfaces still collapse operational failures into empty/no-op states, making runtime issues look like “no data” — `apps/desktop/src/components/layout/WorkspaceTree.tsx:95-97` ignores workspace-open failure, `apps/desktop/src/components/layout/remote-origin-views.tsx:53-61` treats VCS lookup errors as “no origin”, `apps/desktop/src/components/layout/AuthLoginDialog.tsx:80-83` replaces provider-load failure with empty lists, and `apps/desktop/src/components/layout/AppStoreDialog.tsx:83-108` turns plugin-search failure into an empty discover result. Effort: **S**.
+
+## Proposed Refactoring
+1. **Re-partition `components/layout` by ownership while keeping shell entrypoints stable.**
+   - Keep true shell façades at the top level or under a dedicated `shell/` area:
+     - `TitleBar`
+     - `MainSidebar`
+     - `StatusBar`
+     - `ChatPanel`
+     - `NewAppBanner`
+   - Move feature-heavy support code into clearer subtrees, for example:
+     - `layout/chat/**` — prompt/tool/message/collaboration rendering
+     - `layout/workspace/**` — `WorkspaceTree`, `SessionNode`, add-workspace, mounts, remote-origin manager
+     - `layout/auth/**` — auth dialog/views
+     - `layout/theme/**` — theme browser/editor and token controls
+     - `layout/models/**` — `ModelSelector` + `model-manager/**`
+     - `layout/titlebar/git/**` — ship/publish/PR controls
+   - Preserve import stability during the migration with thin re-export files if needed.
+   - Why: restores the AD-001/AD-003 shell boundary without forcing a full UI rewrite.
+
+2. **Split the near-cap hubs before they cross the hard 500-LOC line.**
+   - Target the highest-pressure files first:
+     - `WorkspaceTree.tsx` → `useWorkspaceTreeRuntime`, `WorkspaceNode`, `WorkspaceBulkDeleteDialog`
+     - `ThemeEditorSheet.tsx` → draft-state/preview hook + sectioned presentation shell
+     - `ModelSelector.tsx` → trigger, provider list, thinking picker, search/filter hook
+     - `ContextEditor.tsx` → top-level dialog shell + separate preset/system/tools/skills modules
+     - `model-manager/local-models/LocalProviderForm.tsx` → connection section, compat section, model list section, save footer
+   - Align with the existing Wave A/Wave C pattern: stores/hooks own orchestration, layout files should mostly compose focused helpers.
+
+3. **Extract one shared git-remote workflow used by both workspace and titlebar UI.**
+   - Introduce a shared module/hook (for example `layout/git-remote/useGitRemoteOrigin.ts` or `lib/git-remote.ts`) covering:
+     - GitHub auth status loading
+     - default repo name generation
+     - create-repo + fallback URL resolution
+     - connect/update existing origin
+     - `origin` fetch/parse helpers
+   - Keep the two surfaces visually distinct (`RemoteOriginManager` dialog vs titlebar publish card), but make them thin presenters over the same workflow.
+   - This is especially important because this path changes runtime behavior, not just shape.
+
+4. **Replace the two autocomplete popovers with a shared listbox/navigation primitive.**
+   - Extract generic selection state + capture-phase keyboard handling into something like:
+     - `useAutocompleteListbox(items, open, onSelect, onClose)`
+     - or a shared `AutocompletePopover` component with render props
+   - Then let `SlashCommandMenu` and `FileReferenceMenu` provide only their filtering/grouping and row renderers.
+   - This reduces duplicated hot-path logic and makes keyboard behavior easier to keep consistent.
+
+5. **Move render-time side effects into explicit lifecycle helpers.**
+   - `ThemeEditorSheet`: replace render-phase `setDraft`/`setTab` with an explicit open-transition effect or a small controller hook.
+   - `useAutoScroll`: move `requestAnimationFrame(scrollToBottom)` into an effect keyed by feed length.
+   - `FontPicker`: preload fonts at module init, on panel open, or in an effect rather than during render.
+   - These changes are structural, but they touch subtle UX behavior, so they need targeted verification.
+
+6. **Normalize shell error and transient-feedback behavior.**
+   - Surface explicit load/search/origin failures instead of silently showing empty states.
+   - Consolidate repeated “flash success/error, then clear” state patterns into a small helper where it materially reduces boilerplate.
+   - Make sure shell actions that can fail (open workspace from plugin event, fetch origin, plugin search, auth provider load) leave an observable trace in the UI.
+
+## Benefits & Trade-offs
+- Benefits: clearer shell ownership, smaller and more reviewable files, less duplicated git/autocomplete logic, easier future work on chat/theme/model/git surfaces, and better runtime observability when shell actions fail.
+- Trade-offs: notable file churn, more imports to update, potential merge conflicts with ongoing UI work, and some temporary re-export/shim code while the folder is being re-shaped.
+
+## Dependencies & Risks
+- This folder consumes many store/hook contracts already reviewed in Wave A/B; extraction work should follow those ownership decisions rather than reintroducing renderer-side orchestration.
+- Unifying git remote flows is runtime-sensitive work: it can change success-path behavior, fallback URL generation, and existing-origin update semantics. Verify both “create GitHub repo” and “connect existing origin” flows from both entrypoints.
+- Replacing render-time side effects must preserve subtle UX behavior: live theme preview, collaboration auto-scroll timing, and font availability in the editor.
+- File moves will touch `apps/desktop/src/App.tsx`, profile/onboarding surfaces, and a few hooks importing layout utilities; keep the migration incremental to avoid unnecessary churn.
+
+## Next Steps
+1. Extract a shared git-remote workflow and migrate `RemoteOriginManager` + `GitRemotePublishSection` to it.
+2. Split `WorkspaceTree.tsx`, `ThemeEditorSheet.tsx`, `ModelSelector.tsx`, `ContextEditor.tsx`, and `LocalProviderForm.tsx` before adding more feature work there.
+3. Build a shared autocomplete/listbox primitive and migrate `SlashCommandMenu` + `FileReferenceMenu`.
+4. Remove render-phase side effects from theme/collaboration/font helpers.
+5. Verification checklist:
+   - Open a session via the `sero:open-session` custom event and confirm the chat panel opens/focuses correctly.
+   - Create a workspace, then create/connect a remote origin from both the workspace dialog and the titlebar ship panel.
+   - Draft and create a PR from the titlebar flow after publishing.
+   - Open Theme Editor, preview changes, cancel, reopen, and save a preset.
+   - Exercise slash-command and `@file` menus with keyboard navigation (`↑/↓`, `Enter`, `Tab`, `Esc`).
+   - Test voice transcription device switching and QR URL copy success/failure states.

--- a/docs/deslopify/apps/desktop/src/components/profiles/facts.md
+++ b/docs/deslopify/apps/desktop/src/components/profiles/facts.md
@@ -1,0 +1,32 @@
+# Facts — apps/desktop/src/components/profiles
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+This folder owns the renderer-side profile UX for `apps/desktop`: first-run profile creation, title-bar profile switching, and the recommendation-first onboarding flow that creates a temporary bootstrap session, seeds memory, then opens the user’s first real welcome chat.
+
+## Shape & metrics
+- Total files: 8
+- Largest file: `apps/desktop/src/components/profiles/OnboardingWizard.tsx` (486 LOC)
+- Files over 500 LOC: none
+- Near-cap files (≥400 LOC): `apps/desktop/src/components/profiles/OnboardingWizard.tsx` (486)
+- External dependencies of note: Zustand `profiles` / `app` / `agent` / `sessions` / `user-feedback-store`, `window.sero.{profiles,onboarding,modelConfig,agent,github}`, `AuthLoginDialog`, `useGitHubAuthFlow`
+- Upstream callers: `apps/desktop/src/App.tsx` gates first-run + onboarding here; `apps/desktop/src/components/layout/TitleBar.tsx` mounts `ProfileSwitcher`
+- Downstream dependencies: `apps/desktop/electron/ipc/workspace/profiles.ts`, onboarding IPC, agent session lifecycle, model-config persistence, GitHub device-flow auth
+
+## Architectural notes
+- This folder is not purely presentational. `OnboardingWizard` currently owns temporary-session creation/teardown, model fallback logic, onboarding completion, and shell-side chat/session focus changes.
+- Profile UX sits on the shell critical path: `App.tsx` short-circuits to `ProfileSetup` when no active profile exists, then keeps `OnboardingWizard` mounted as a global overlay once the shell is live.
+- AD-022 matters throughout: profile creation and switching rely on restart semantics, and onboarding completion is persisted through the fixed registry via IPC rather than renderer storage.
+- The optional GitHub step during onboarding reuses the global GitHub device-flow hook instead of a profile-specific auth store.
+
+## Runtime-sensitive surfaces
+- First-run gating: `ProfileSetup` must remain the only screen when there is no active profile.
+- Onboarding launch is multi-stage and order-sensitive: create temp session → run memory bootstrap → verify completion → tear temp session down → create Welcome session → mark profile onboarded.
+- Launch-dialog visibility currently depends on pending user-feedback state, so ref/mount timing changes can alter whether the blocking dialog disappears at the correct moment.
+- Profile switch/create flows intentionally assume an app relaunch on success; any cleanup that changes that contract would be a behavior change.
+
+## Surprising discoveries
+- Memory bootstrap is intentionally performed in a disposable session, not the eventual Welcome conversation.
+- The renderer only offers “copy credentials/model preferences from the current profile,” even though the IPC/store contract is shaped for a more general `copyAuthFromId` flow.
+- Several failure paths currently rely on silent fallback or restart semantics, so observability is scattered across small UI components instead of one controller surface.

--- a/docs/deslopify/apps/desktop/src/components/profiles/plan.md
+++ b/docs/deslopify/apps/desktop/src/components/profiles/plan.md
@@ -1,0 +1,58 @@
+# Refactoring Plan — apps/desktop/src/components/profiles
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/components/profiles` is doing real product work, but too much of that work is concentrated in renderer components instead of a focused onboarding/profile controller layer. The main issue is `OnboardingWizard.tsx`: it is nearly at the 500-LOC cap and currently owns cross-store orchestration, temp-session lifecycle, model fallback, and shell side effects in one component. The right outcome is a thinner UI surface with explicit onboarding/profile controllers, clearer error handling, and fewer render-time lifecycle hacks.
+
+## Issues Found (prioritized)
+- **Medium** — `OnboardingWizard.tsx` is a near-cap renderer orchestration hub instead of a focused UI shell — `apps/desktop/src/components/profiles/OnboardingWizard.tsx:66`, `apps/desktop/src/components/profiles/OnboardingWizard.tsx:97`, `apps/desktop/src/components/profiles/OnboardingWizard.tsx:136`, `apps/desktop/src/components/profiles/OnboardingWizard.tsx:167`, and `apps/desktop/src/components/profiles/OnboardingWizard.tsx:180` together show one component owning failure parsing, model-selection fallback, temp-session creation/teardown, onboarding completion, and dialog rendering. This fights the store/controller ownership direction already established in the Wave A renderer reviews. Effort: **M**.
+
+- **Medium** — Launch-dialog visibility is controlled by a render-phase ref mutation — `apps/desktop/src/components/profiles/OnboardingWizard.tsx:188-193` mutates `hideLaunchingDialogRef.current` during render when pending user input appears, and that ref immediately drives dialog openness at `apps/desktop/src/components/profiles/OnboardingWizard.tsx:415`. This is the same class of render-time side-effect drift already found in `components/layout`, just on a first-run path. Effort: **S**.
+
+- **Medium** — Profile creation/switch flows swallow failures or reduce them to local loading resets — `apps/desktop/src/components/profiles/CreateProfileDialog.tsx:43-46`, `apps/desktop/src/components/profiles/ProfileSwitcher.tsx:42-45`, and `apps/desktop/src/components/profiles/ProfileForm.tsx:39-62` all catch operational failures without surfacing actionable UI state. On a restart-based profile system (AD-022), silent failure is especially confusing because the expected success path is “the app restarts now.” Effort: **S**.
+
+- **Low** — GitHub onboarding ownership is split across too many small renderer surfaces — `apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx:91-172` makes its own GitHub status/cancel decisions while `apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.tsx:5-119` and `apps/desktop/src/hooks/useGitHubAuthFlow.ts:20-92` own overlapping pieces of the same flow. The code works, but it invites drift in optional-step behavior and connected-state messaging. Effort: **S**.
+
+## Proposed Refactoring
+1. **Extract onboarding runtime out of `OnboardingWizard.tsx`.**
+   - Move temp-session lifecycle, model fallback, failure extraction, and onboarding-completion sequencing into a dedicated controller layer such as:
+     - `src/components/profiles/lib/onboarding-session-runtime.ts`
+     - `src/components/profiles/hooks/useOnboardingLaunch.ts`
+   - Keep `OnboardingWizard.tsx` responsible for phase selection and dialog composition only.
+   - Aligns with the store/controller ownership direction from the `src/stores` review and keeps AD-022 profile UX logic explicit.
+
+2. **Replace render-phase dialog-hiding mutations with derived lifecycle state.**
+   - Track “launch dialog should hide because user input is pending” as explicit component state or a small effect keyed on `uiPhase` + `hasPendingUserInput`.
+   - Keep the behavior identical (dialog disappears once the memory bootstrap is waiting on user input), but stop mutating refs during render.
+
+3. **Centralize profile operation error handling.**
+   - Move restart-aware error semantics into one helper/store-facing contract so `CreateProfileDialog`, `ProfileSwitcher`, and `ProfileForm` do not each invent their own catch/reset behavior.
+   - Surface explicit error text in the dialog/popover instead of silently staying on the current profile.
+   - Preserve the success-path assumption that a successful switch/create may never resolve in the current process because the app relaunches.
+
+4. **Collapse GitHub onboarding flow control into one controller primitive.**
+   - Keep `GitHubConnectCard` as the presenter.
+   - Move “check status first / decide whether to show the GitHub step / cancel when leaving the step” into a small `useOnboardingGitHubStep` hook or onboarding-controller helper used only by `SetupScreen`.
+   - That makes the optional GitHub step easy to reason about without duplicating state transitions.
+
+## Benefits & Trade-offs
+- Benefits: clearer ownership, smaller and easier-to-review onboarding code, better error visibility on restart-sensitive profile actions, and fewer lifecycle surprises in a first-run path.
+- Trade-offs: some churn across UI helpers/hooks, plus targeted retesting of onboarding launch behavior because the extracted controller touches real runtime sequencing.
+
+## Dependencies & Risks
+- This work depends on keeping the existing store contracts intact (`profiles`, `app`, `agent`, `sessions`, `user-feedback-store`) rather than inventing a new renderer-side persistence path.
+- Extracting onboarding runtime is behavior-sensitive: temp-session cleanup, welcome-session creation, and onboarding completion ordering must stay identical.
+- Centralizing profile-action errors must preserve the current “success means relaunch” semantics from AD-022.
+
+## Next Steps
+1. Extract onboarding session runtime helpers out of `OnboardingWizard.tsx` and reduce the component to phase/dialog composition.
+2. Remove the render-phase `hideLaunchingDialogRef` mutation and replace it with explicit derived state.
+3. Introduce one restart-aware error helper for profile create/switch flows and surface errors in the UI.
+4. Consolidate GitHub onboarding step control into a single hook/helper.
+5. Verification checklist:
+   - Fresh install with no active profile shows only `ProfileSetup`.
+   - Creating the first profile still triggers activation/relaunch correctly.
+   - Onboarding temp session bootstraps memory, disappears if user feedback is requested, then opens the Welcome session.
+   - GitHub optional step still supports connect, cancel, skip, and already-connected flows.
+   - Failed profile switch/create paths show actionable UI feedback instead of silently doing nothing.

--- a/docs/deslopify/apps/desktop/src/lsp/facts.md
+++ b/docs/deslopify/apps/desktop/src/lsp/facts.md
@@ -22,3 +22,18 @@ _Last reviewed: 2026-04-12_
 - `use-lsp.ts` uses module-level registries (`registeredLanguages`, `uriRegistry`) plus five separate effects, so most of the complexity is hidden outside the hook's public API.
 - The renderer redefines supported language IDs and extension mappings even though the main-process LSP config already owns that information.
 - Diagnostics routing still scans all Monaco models on each notification instead of maintaining a direct URI → model lookup.
+
+## Post-fix snapshot — 2026-04-12
+
+### Metrics after fixes
+- Total files: 2 (unchanged)
+- Largest file: `apps/desktop/src/lsp/use-lsp.ts` (300 LOC)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 0 new High-priority import-rule violations
+
+### What changed
+- `use-lsp.ts` now uses a top-level Monaco namespace type import instead of an inline `typeof import('monaco-editor')` expression.
+
+### Still outstanding
+- `use-lsp.ts` still hides provider registration, document sync, and diagnostics ownership behind one singleton-style hook.
+- Renderer/main language-routing metadata is still duplicated until the shared contract lands.

--- a/docs/deslopify/apps/desktop/src/lsp/facts.md
+++ b/docs/deslopify/apps/desktop/src/lsp/facts.md
@@ -1,0 +1,24 @@
+# Facts — apps/desktop/src/lsp
+
+_Last reviewed: 2026-04-12_
+
+## What this code does
+`src/lsp` is the renderer-side Monaco/LSP bridge. It converts protocol payloads into Monaco-friendly shapes, starts the correct workspace language server through `window.sero.lsp`, opens/closes/syncs documents, and applies diagnostics back onto Monaco models.
+
+## Shape & metrics
+- Total files: 2
+- Largest file: `apps/desktop/src/lsp/use-lsp.ts` (299 LOC)
+- Files over 500 LOC: None
+- External dependencies of note: `monaco-editor`, `src/stores/container`, preload `window.sero.lsp`
+- Upstream callers: `apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx`
+- Downstream dependencies: `electron/ipc/editor/lsp.ts`, `electron/features/editor/lsp/*`, Monaco provider APIs
+
+## Architectural notes
+- This directory is the renderer half of the same contract spine as `electron/features/editor` and the LSP IPC bridge, so duplicated language-routing logic here is high drift risk.
+- It is a direct consumer of AD-018 because the hook only activates when the workspace container is running and all document traffic goes through the container-backed main-process server.
+- `use-lsp.ts` currently owns both provider registration and per-document lifecycle, which makes the hook act more like a singleton service than a normal React hook.
+
+## Surprising discoveries
+- `use-lsp.ts` uses module-level registries (`registeredLanguages`, `uriRegistry`) plus five separate effects, so most of the complexity is hidden outside the hook's public API.
+- The renderer redefines supported language IDs and extension mappings even though the main-process LSP config already owns that information.
+- Diagnostics routing still scans all Monaco models on each notification instead of maintaining a direct URI → model lookup.

--- a/docs/deslopify/apps/desktop/src/lsp/plan.md
+++ b/docs/deslopify/apps/desktop/src/lsp/plan.md
@@ -1,0 +1,60 @@
+# Refactoring Plan — apps/desktop/src/lsp
+
+_Plan drafted: 2026-04-12_
+
+## Executive Summary
+`src/lsp` is small, but it is doing singleton-service work inside a React hook. The only immediate High-priority finding is a renderer import-rule violation (`typeof import('monaco-editor')` inline in `use-lsp.ts`), but the more important medium-term problem is that provider registration, URI routing, diagnostics, and language routing are all coupled together behind module-level mutable state. The goal is to make this bridge more canonical, less stateful, and easier to evolve when the editor feature adds more languages.
+
+## Issues Found (prioritized)
+- **High** — `use-lsp.ts` uses an inline dynamic type import instead of a top-level type import — `apps/desktop/src/lsp/use-lsp.ts:18` declares `type Monaco = typeof import('monaco-editor')`. Project guidance explicitly bans inline `import('...')` type expressions in favor of top-level `import type`, so this should be cleaned up before more LSP types accumulate around it. Effort: **S**.
+
+- **Medium** — `useLsp` hides singleton-style global state and too many responsibilities behind one hook — `apps/desktop/src/lsp/use-lsp.ts:23-27` and `apps/desktop/src/lsp/use-lsp.ts:152-290` combine global provider registration, URI routing, server startup, document open/close, didChange/didSave, diagnostics subscriptions, and server-stop cleanup. This is difficult to test, difficult to reason about across workspaces, and easy to break during editor refactors. Effort: **M**.
+
+- **Medium** — Renderer language routing is duplicated instead of derived from one canonical contract — `apps/desktop/src/lsp/lsp-conversions.ts:222-239` redefines supported Monaco language IDs and extension mappings that already exist in `apps/desktop/electron/features/editor/lsp/types.ts:25-41`, while explorer/editor utilities add more copies in `apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx:39-65` and `apps/desktop/src/components/apps/explorer/vcs/vcs-utils.ts:61-75`. This guarantees drift the next time another language is added. Effort: **S**.
+
+- **Medium** — Diagnostics application is broader and weaker than it needs to be — `apps/desktop/src/lsp/use-lsp.ts:267-277` scans every Monaco model on each `publishDiagnostics` notification and uses `convertDiagnostics(params.diagnostics as never[])` to punch through typing. The runtime work is small today, but it couples diagnostics to global Monaco state and keeps another avoidable cast in a core bridge. Effort: **S**.
+
+- **Low** — LSP protocol shapes are still maintained as inline local interfaces in the conversion layer — `apps/desktop/src/lsp/lsp-conversions.ts:10-45`. That is acceptable at the current size, but if more request/response types are added the file will become a local protocol shadow rather than a focused conversion utility. Effort: **M**.
+
+## Proposed Refactoring
+1. **Fix the import-rule violation first.**
+   - Replace `type Monaco = typeof import('monaco-editor')` with a top-level type import pattern.
+   - Keep runtime Monaco loading unchanged; this is purely a contract cleanup.
+
+2. **Split `useLsp` into service modules plus a thin composition hook.**
+   - Target structure:
+     - `src/lsp/provider-registry.ts` — one-time Monaco provider registration
+     - `src/lsp/document-sync.ts` — didOpen/didChange/didClose/didSave lifecycle
+     - `src/lsp/diagnostics.ts` — diagnostics subscription + marker application
+     - `src/lsp/use-lsp.ts` — compose the above and expose the current public API
+   - This keeps React-specific lifecycle code separate from singleton registry mechanics.
+
+3. **Move language-routing metadata to one shared renderer-safe contract.**
+   - Extract supported language IDs / extension maps into a canonical module shared by `src/lsp`, explorer/editor helpers, and the main-process LSP feature.
+   - Derive `getLspServerLanguage`, `getLspLanguageIdFromPath`, editor language inference, and diff language inference from that same contract.
+   - This aligns with the monorepo rule to import canonical types/contracts instead of duplicating them.
+
+4. **Tighten diagnostics routing and clear stale markers explicitly.**
+   - Maintain a direct URI → Monaco model lookup instead of scanning `monaco.editor.getModels()` on every notification.
+   - Remove the `as never[]` cast by typing the diagnostics payload properly.
+   - Clear markers on document close and server-stop paths so stale diagnostics do not survive beyond the document/session lifecycle.
+
+5. **Keep protocol-shape growth under control.**
+   - If more converters are added, move the inline LSP protocol interfaces into a focused `lsp-protocol.ts` module or adopt a renderer-safe shared package for the small subset Sero actually uses.
+   - Keep `lsp-conversions.ts` about conversion logic, not about being an ad hoc protocol schema dump.
+
+## Benefits & Trade-offs
+- Benefits: cleaner renderer/main contract ownership, easier testing, simpler future language expansion, and less hidden global state inside a hook that looks deceptively local.
+- Trade-offs: more modules in a currently small area and a little extra indirection when tracing Monaco provider registration.
+
+## Dependencies & Risks
+- Canonical routing extraction should happen together with `electron/features/editor` cleanup so renderer/main mappings are not split twice.
+- Provider-registry extraction must preserve Monaco's “register once” behavior; careless refactoring could double-register providers.
+- Diagnostics cleanup must respect Monaco model lifetime so markers are not removed for still-open documents.
+
+## Next Steps
+1. Replace the inline Monaco type import with a top-level type import.
+2. Split `use-lsp.ts` into provider-registry, document-sync, and diagnostics modules.
+3. Extract shared language-routing metadata and remove duplicated maps from explorer/LSP/editor code.
+4. Replace model scanning + `as never[]` with typed diagnostics routing.
+5. Re-review explorer/editor surfaces after the shared routing contract lands.

--- a/docs/deslopify/apps/desktop/src/lsp/plan.md
+++ b/docs/deslopify/apps/desktop/src/lsp/plan.md
@@ -53,8 +53,12 @@ _Plan drafted: 2026-04-12_
 - Diagnostics cleanup must respect Monaco model lifetime so markers are not removed for still-open documents.
 
 ## Next Steps
-1. Replace the inline Monaco type import with a top-level type import.
+1. ~~Replace the inline Monaco type import with a top-level type import.~~ ✅ 2026-04-12 (`4350404d`)
 2. Split `use-lsp.ts` into provider-registry, document-sync, and diagnostics modules.
 3. Extract shared language-routing metadata and remove duplicated maps from explorer/LSP/editor code.
 4. Replace model scanning + `as never[]` with typed diagnostics routing.
 5. Re-review explorer/editor surfaces after the shared routing contract lands.
+
+## Execution log
+- 2026-04-12 — `4350404d` — `fix(desktop): harden wave d high-priority runtime paths`
+  - Replaced the inline `typeof import('monaco-editor')` type expression in `use-lsp.ts` with a top-level Monaco namespace type import.

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -10,6 +10,8 @@ entry links to a `facts.md` and `plan.md` pair.
   — *Wave A reviews complete; Wave B High-only batch plan added 2026-04-12*
   - [`apps/desktop/src/components/apps/explorer/`](./apps/desktop/src/components/apps/explorer/plan.md)
     — *Wave C primary-consumer review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/components/layout/`](./apps/desktop/src/components/layout/plan.md)
+    — *Wave C shell/chrome review complete — plan created 2026-04-12*
   - [`apps/desktop/src/hooks/`](./apps/desktop/src/hooks/plan.md)
     — *Wave A renderer orchestration review complete — plan created 2026-04-12*
   - [`apps/desktop/src/lib/`](./apps/desktop/src/lib/plan.md)

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -30,15 +30,23 @@ entry links to a `facts.md` and `plan.md` pair.
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/auth/`](./apps/desktop/electron/features/auth/plan.md)
     — *Wave C secondary-island review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/collaboration/`](./apps/desktop/electron/features/collaboration/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/container/`](./apps/desktop/electron/features/container/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/editor/`](./apps/desktop/electron/features/editor/plan.md)
     — *Wave C primary-consumer review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/gateway/`](./apps/desktop/electron/features/gateway/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/onboarding/`](./apps/desktop/electron/features/onboarding/plan.md)
     — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/plugins/`](./apps/desktop/electron/features/plugins/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/profile/`](./apps/desktop/electron/features/profile/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/subagent/`](./apps/desktop/electron/features/subagent/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/vcs/`](./apps/desktop/electron/features/vcs/plan.md)
     — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/workspace/`](./apps/desktop/electron/features/workspace/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -7,19 +7,19 @@ entry links to a `facts.md` and `plan.md` pair.
 
 ## apps/
 - [`apps/desktop/`](./apps/desktop/plan.md)
-  — *Wave A reviews complete; Wave B High-only batch plan added 2026-04-12*
+  — *Wave A–D High-priority batches cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/src/components/apps/explorer/`](./apps/desktop/src/components/apps/explorer/plan.md)
-    — *Wave C primary-consumer review complete — plan created 2026-04-12*
+    — *Wave C review complete — no High items; Medium cleanup pending*
   - [`apps/desktop/src/components/layout/`](./apps/desktop/src/components/layout/plan.md)
-    — *Wave C shell/chrome review complete — plan created 2026-04-12*
+    — *Wave C review complete — no High items; Medium cleanup pending*
   - [`apps/desktop/src/components/profiles/`](./apps/desktop/src/components/profiles/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *Wave C review complete — no High items; Medium cleanup pending*
   - [`apps/desktop/src/hooks/`](./apps/desktop/src/hooks/plan.md)
     — *Wave A renderer orchestration review complete — plan created 2026-04-12*
   - [`apps/desktop/src/lib/`](./apps/desktop/src/lib/plan.md)
     — *Wave A renderer orchestration review complete — plan created 2026-04-12*
   - [`apps/desktop/src/lsp/`](./apps/desktop/src/lsp/plan.md)
-    — *Wave C primary-consumer review complete — plan created 2026-04-12*
+    — *In progress — High item cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/src/stores/`](./apps/desktop/src/stores/plan.md)
     — *Wave A renderer orchestration review complete — plan created 2026-04-12*
   - [`apps/desktop/src/types/`](./apps/desktop/src/types/plan.md)
@@ -29,25 +29,25 @@ entry links to a `facts.md` and `plan.md` pair.
   - [`apps/desktop/electron/features/apps/`](./apps/desktop/electron/features/apps/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/auth/`](./apps/desktop/electron/features/auth/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *In progress — High item cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/electron/features/collaboration/`](./apps/desktop/electron/features/collaboration/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *Wave C review complete — no High items; Medium cleanup pending*
   - [`apps/desktop/electron/features/container/`](./apps/desktop/electron/features/container/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/editor/`](./apps/desktop/electron/features/editor/plan.md)
-    — *Wave C primary-consumer review complete — plan created 2026-04-12*
+    — *In progress — High items cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/electron/features/gateway/`](./apps/desktop/electron/features/gateway/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *In progress — High items cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/electron/features/onboarding/`](./apps/desktop/electron/features/onboarding/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *Wave C review complete — no High items; Medium cleanup pending*
   - [`apps/desktop/electron/features/plugins/`](./apps/desktop/electron/features/plugins/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/profile/`](./apps/desktop/electron/features/profile/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *In progress — High item cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/electron/features/subagent/`](./apps/desktop/electron/features/subagent/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *In progress — High items cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/electron/features/vcs/`](./apps/desktop/electron/features/vcs/plan.md)
-    — *Wave C secondary-island review complete — plan created 2026-04-12*
+    — *In progress — High item cleared 2026-04-12; Medium cleanup pending*
   - [`apps/desktop/electron/features/workspace/`](./apps/desktop/electron/features/workspace/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/ipc/`](./apps/desktop/electron/ipc/plan.md)

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -12,6 +12,8 @@ entry links to a `facts.md` and `plan.md` pair.
     — *Wave C primary-consumer review complete — plan created 2026-04-12*
   - [`apps/desktop/src/components/layout/`](./apps/desktop/src/components/layout/plan.md)
     — *Wave C shell/chrome review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/components/profiles/`](./apps/desktop/src/components/profiles/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/src/hooks/`](./apps/desktop/src/hooks/plan.md)
     — *Wave A renderer orchestration review complete — plan created 2026-04-12*
   - [`apps/desktop/src/lib/`](./apps/desktop/src/lib/plan.md)
@@ -26,12 +28,18 @@ entry links to a `facts.md` and `plan.md` pair.
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/apps/`](./apps/desktop/electron/features/apps/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/auth/`](./apps/desktop/electron/features/auth/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/container/`](./apps/desktop/electron/features/container/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/editor/`](./apps/desktop/electron/features/editor/plan.md)
     — *Wave C primary-consumer review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/onboarding/`](./apps/desktop/electron/features/onboarding/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/plugins/`](./apps/desktop/electron/features/plugins/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/profile/`](./apps/desktop/electron/features/profile/plan.md)
+    — *Wave C secondary-island review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/workspace/`](./apps/desktop/electron/features/workspace/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/ipc/`](./apps/desktop/electron/ipc/plan.md)

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -8,31 +8,37 @@ entry links to a `facts.md` and `plan.md` pair.
 ## apps/
 - [`apps/desktop/`](./apps/desktop/plan.md)
   — *Wave A reviews complete; Wave B High-only batch plan added 2026-04-12*
-  - [`apps/desktop/src/types/`](./apps/desktop/src/types/plan.md)
-    — *Wave A contracts review complete — plan created 2026-04-12*
-  - [`apps/desktop/src/stores/`](./apps/desktop/src/stores/plan.md)
-    — *Wave A renderer orchestration review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/components/apps/explorer/`](./apps/desktop/src/components/apps/explorer/plan.md)
+    — *Wave C primary-consumer review complete — plan created 2026-04-12*
   - [`apps/desktop/src/hooks/`](./apps/desktop/src/hooks/plan.md)
     — *Wave A renderer orchestration review complete — plan created 2026-04-12*
   - [`apps/desktop/src/lib/`](./apps/desktop/src/lib/plan.md)
     — *Wave A renderer orchestration review complete — plan created 2026-04-12*
-  - [`apps/desktop/electron/preload/`](./apps/desktop/electron/preload/plan.md)
+  - [`apps/desktop/src/lsp/`](./apps/desktop/src/lsp/plan.md)
+    — *Wave C primary-consumer review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/stores/`](./apps/desktop/src/stores/plan.md)
+    — *Wave A renderer orchestration review complete — plan created 2026-04-12*
+  - [`apps/desktop/src/types/`](./apps/desktop/src/types/plan.md)
     — *Wave A contracts review complete — plan created 2026-04-12*
-  - [`apps/desktop/electron/ipc/`](./apps/desktop/electron/ipc/plan.md)
-    — *Wave A contracts review complete — plan created 2026-04-12*
-  - [`apps/desktop/electron/features/workspace/`](./apps/desktop/electron/features/workspace/plan.md)
-    — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/agent/`](./apps/desktop/electron/features/agent/plan.md)
-    — *Wave A platform-owner review complete — plan created 2026-04-12*
-  - [`apps/desktop/electron/features/container/`](./apps/desktop/electron/features/container/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/apps/`](./apps/desktop/electron/features/apps/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/container/`](./apps/desktop/electron/features/container/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/features/editor/`](./apps/desktop/electron/features/editor/plan.md)
+    — *Wave C primary-consumer review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/features/plugins/`](./apps/desktop/electron/features/plugins/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
-  - [`apps/desktop/electron/shared/`](./apps/desktop/electron/shared/plan.md)
+  - [`apps/desktop/electron/features/workspace/`](./apps/desktop/electron/features/workspace/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/ipc/`](./apps/desktop/electron/ipc/plan.md)
+    — *Wave A contracts review complete — plan created 2026-04-12*
   - [`apps/desktop/electron/platform/`](./apps/desktop/electron/platform/plan.md)
+    — *Wave A platform-owner review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/preload/`](./apps/desktop/electron/preload/plan.md)
+    — *Wave A contracts review complete — plan created 2026-04-12*
+  - [`apps/desktop/electron/shared/`](./apps/desktop/electron/shared/plan.md)
     — *Wave A platform-owner review complete — plan created 2026-04-12*
 
 ## packages/

--- a/docs/plans/2026-04-12-pr-136-followups.md
+++ b/docs/plans/2026-04-12-pr-136-followups.md
@@ -1,0 +1,290 @@
+---
+title: PR 136 Follow-ups — Gateway Scope, Recovery UX, and Coverage
+status: complete
+date: 2026-04-12
+author: OpenAI
+related:
+  - apps/desktop/electron/features/gateway
+  - apps/desktop/electron/features/profile
+  - apps/desktop/electron/features/auth
+  - apps/web-remote/src
+---
+
+# PR 136 Follow-ups — Small Ad-Hoc Tasklist
+
+This is a short implementation-oriented backlog for the next pass after PR 136.
+The PR improved gateway scoping, runtime hardening, and profile/auth safety, but
+there are still a few opportunities to make the new behavior more robust and
+more understandable to users.
+
+## Goal
+
+Tighten the new scoped-access model, improve failure/recovery UX for stricter
+runtime checks, and add enough regression coverage that future refactors do not
+re-open the same classes of bugs.
+
+## Working assumptions
+
+- Keep source files under the 500 LOC cap.
+- Prefer focused regression tests over broad snapshot tests.
+- Do not weaken the new scoped-token security model to “fix” UX issues.
+- Treat desktop main-process auth/scope logic as the source of truth; renderer
+  and web-remote should reflect that model, not duplicate it loosely.
+
+## Progress checklist
+
+### Security boundary and regression coverage
+- [x] Task 1 — Add end-to-end scoped gateway authorization coverage
+  - [x] Add master-vs-scoped-token regression cases
+  - [x] Add at least one full gateway flow test (`connect → list_workspaces → session access → artifact access`)
+  - [x] Cover unauthorized cross-workspace session/history access
+  - [x] Cover immediate retrieval of `artifact_added` artifacts
+- [x] Task 2 — Tighten authorization provenance in gateway internals
+  - [x] Refactor access-granting paths so workspace/session/artifact relationships are explicit
+  - [x] Remove or reduce places where child-resource access can be granted ad hoc
+  - [x] Add provenance-oriented tests for the refactor
+- [x] Task 6 — Tighten gateway protocol parsing at the request boundary
+  - [x] Validate key request fields for sensitive gateway message types
+  - [x] Add malformed-payload tests for rejected request shapes
+
+### Recovery and auth hardening
+- [x] Task 4 — Add secure-storage failure-mode tests for GitHub auth
+  - [x] Cover unavailable secure storage on startup
+  - [x] Cover corrupt encrypted token file cleanup
+  - [x] Cover login persistence failure behavior
+  - [x] Cover logout cleanup of both current and legacy token paths
+- [x] Task 3 — Improve malformed profile registry recovery UX
+  - [x] Catch malformed-registry startup failures at the product boundary
+  - [x] Add a user-visible recovery path with backup/reset guidance
+  - [x] Ensure recovery preserves the broken file for inspection
+
+### UX polish
+- [x] Task 5 — Improve remote/web UX around scoped device access
+  - [x] Clarify workspace scope + expiry in the desktop pairing flow
+  - [x] Show the active scope in the web remote UI
+  - [x] Improve user-facing messaging for unauthorized actions
+
+### Final validation
+- [x] Run targeted tests for gateway/profile/auth changes
+- [x] Run `pnpm typecheck`
+- [x] Update this checklist as tasks land
+
+---
+
+## Task 1 — Add end-to-end scoped gateway authorization coverage
+
+**Priority:** High
+
+### Why
+The main review findings on PR 136 were both authorization-path issues rather
+than type errors. We now have focused unit tests, but we still lack tests that
+exercise realistic request sequences across workspace → session → artifact.
+
+### Scope
+Add tests for the following flows:
+
+- scoped token for workspace A can list only workspace A
+- scoped token for workspace A cannot open/read history for a session from workspace B
+- scoped token cannot steer/abort a session unless that session was authorized via an allowed path
+- `artifact_added` push event results in immediately retrievable artifact content for the authorized client
+- master token can still perform all of the above across workspaces
+
+### Likely files
+- `apps/desktop/electron/__tests__/features/gateway/*`
+- `apps/desktop/electron/features/gateway/server/*`
+- possibly `apps/web-remote/src/lib/gateway-client.test.ts`
+
+### Acceptance criteria
+- Tests fail against the pre-fix behavior and pass with the current behavior.
+- At least one test covers a full “connect → list_workspaces → list_sessions/get_session_history → artifact access” sequence.
+- Tests distinguish master-token and scoped-token behavior.
+
+---
+
+## Task 2 — Tighten authorization provenance in gateway internals
+
+**Priority:** High
+
+### Why
+The gateway currently stores access as three mutable buckets:
+
+- authorized workspaces
+- authorized sessions
+- authorized artifacts
+
+This works, but it is easy to miss a path and accidentally authorize a child
+resource too early or too late. We should make the parent/child relationship
+more explicit.
+
+### Scope
+Refactor toward a clearer rule set:
+
+- session authorization must always be derived from a verified workspace-owned path
+- artifact authorization must always be tied to an already-authorized session
+- handlers should avoid “grant first, validate later” patterns
+
+This does **not** require redesigning the public protocol. It is mainly an
+internal cleanup to reduce future auth drift.
+
+### Likely files
+- `apps/desktop/electron/features/gateway/server/access-control.ts`
+- `apps/desktop/electron/features/gateway/server/request-handler.ts`
+- `apps/desktop/electron/features/gateway/server/extended-handlers.ts`
+- `apps/desktop/electron/features/gateway/index.ts`
+- `apps/desktop/electron/ipc/gateway/gateway-ops.ts`
+
+### Implementation notes
+A good target is to make it obvious, in one read, where each kind of access is
+minted and why. If a new handler is added later, it should be hard to bypass the
+existing invariants by accident.
+
+### Acceptance criteria
+- Access-granting code paths are centralized or at least obviously structured.
+- It is no longer possible to authorize a session or artifact without a prior,
+  valid parent resource relationship.
+- Existing gateway tests still pass; new provenance-oriented tests are added.
+
+---
+
+## Task 3 — Improve malformed profile registry recovery UX
+
+**Priority:** Medium
+
+### Why
+`readRegistrySync()` now fails loudly on malformed `profiles.json`, which is the
+right integrity behavior, but the app still needs a humane recovery path.
+Without one, the stricter behavior may feel like a hard crash or opaque startup
+failure.
+
+### Scope
+Add a user-visible recovery flow for malformed profile registry state.
+
+Possible approach:
+
+- catch `ProfileRegistryError` at the startup boundary
+- render a dedicated recovery screen/dialog instead of failing generically
+- show the path to `~/.sero-ui/profiles.json`
+- offer safe actions like:
+  - create backup of the broken file
+  - reset to empty/default registry
+  - open the containing folder
+
+### Likely files
+- `apps/desktop/electron/features/profile/manager.ts`
+- `apps/desktop/electron/platform/env/index.ts`
+- renderer startup / onboarding / profile-entry surfaces
+- `apps/desktop/src/components/profiles/*`
+
+### Acceptance criteria
+- Malformed registry state produces a deterministic recovery UI.
+- The user can recover without manually editing JSON unless they choose to.
+- Recovery flow preserves forensic information (for example, by backing up the broken file before overwrite).
+
+---
+
+## Task 4 — Add secure-storage failure-mode tests for GitHub auth
+
+**Priority:** Medium
+
+### Why
+The GitHub auth changes are safer now, but they are security-sensitive and still
+under-tested. We should lock down the exact behavior when OS secure storage is
+unavailable or a cached token is corrupt.
+
+### Scope
+Add tests for:
+
+- secure storage unavailable at startup → cached token is not loaded
+- encrypted token file is malformed/corrupt → cache is cleared and file is removed
+- login attempts fail clearly when secure storage cannot persist the token
+- logout removes both current and legacy token-file locations
+
+### Likely files
+- `apps/desktop/electron/features/auth/github/auth-manager.ts`
+- `apps/desktop/electron/__tests__/features/auth/github/*`
+
+### Acceptance criteria
+- Behavior is covered with direct unit tests, not only manual verification.
+- Error handling stays explicit; no silent fallback back to insecure base64-only persistence.
+
+---
+
+## Task 5 — Improve remote/web UX around scoped device access
+
+**Priority:** Medium
+
+### Why
+The security model is better, but the UX should explain it. Device pairing is
+now workspace-scoped, yet the user only gets a small hint in the desktop dialog.
+The remote UI should make the limitation obvious so it feels intentional.
+
+### Scope
+Improve the user-facing copy in both places:
+
+- desktop Connect Device flow should clearly say which workspace is being shared and for how long
+- web remote should show which workspace the token is scoped to once connected
+- unauthorized actions/responses should produce understandable messages, not just protocol-style failures
+
+### Likely files
+- `apps/desktop/src/components/layout/ConnectDeviceDialog.tsx`
+- `apps/web-remote/src/components/*`
+- `apps/web-remote/src/stores/*`
+
+### Acceptance criteria
+- A user can tell, without reading docs, that the paired device is limited to a specific workspace.
+- Error states are understandable and actionable.
+
+---
+
+## Task 6 — Tighten gateway protocol parsing at the request boundary
+
+**Priority:** Medium
+
+### Why
+The PR improved runtime validation in several places, but `validateRequest()` is
+still permissive and mostly checks only the request `type`. The gateway is a
+security boundary, so request-shape validation should be stricter.
+
+### Scope
+Strengthen request validation for key fields on sensitive message types:
+
+- `connect.token`, `clientType`
+- `prompt.workspaceId`, `sessionId`, `text`
+- `get_session_history.workspaceId`, `sessionId`
+- `create_web_token.workspaceIds`
+- `get_artifact.artifactId`
+
+A lightweight hand-written validator is fine if kept readable. No need to bring
+in a heavy schema system unless it clearly reduces duplication.
+
+### Likely files
+- `apps/desktop/electron/features/gateway/server/protocol.ts`
+- callers/tests under `apps/desktop/electron/__tests__/features/gateway/*`
+
+### Acceptance criteria
+- Invalid request shapes are rejected before handler routing.
+- Tests cover malformed payloads for the sensitive request types above.
+- Validation code remains readable and local to the protocol boundary.
+
+---
+
+## Suggested execution order
+
+1. Task 1 — scoped gateway coverage
+2. Task 2 — authorization provenance cleanup
+3. Task 6 — protocol-boundary validation
+4. Task 4 — GitHub secure-storage failure tests
+5. Task 3 — malformed profile recovery UX
+6. Task 5 — remote/device UX polish
+
+This order keeps security-boundary work first, then user-facing recovery/polish.
+
+## Done definition
+
+This follow-up plan is complete when:
+
+- gateway auth/scoping behavior is covered by realistic regression tests
+- internal access propagation is harder to misuse accidentally
+- malformed profile state and secure-storage failures have explicit, testable handling
+- device-scoped access is visible and understandable in the UI
+- `pnpm typecheck` passes and any added tests pass

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -67,9 +67,9 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 ## Wave C — Deslopify Primary Consumers
 
 ### 4. Main app surfaces
-- [ ] `deslopify apps/desktop/src/components/apps/explorer`
-- [ ] `deslopify apps/desktop/electron/features/editor`
-- [ ] `deslopify apps/desktop/src/lsp`
+- [x] `deslopify apps/desktop/src/components/apps/explorer`
+- [x] `deslopify apps/desktop/electron/features/editor`
+- [x] `deslopify apps/desktop/src/lsp`
 
 ### 5. Shell and app chrome
 - [ ] `deslopify apps/desktop/src/components/layout`
@@ -146,3 +146,4 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 - 2026-04-12: Wave A step 3.3 complete for `apps/desktop/src/lib`. Findings + plan documented at `docs/deslopify/apps/desktop/src/lib/{facts.md,plan.md}` (high: federated component load failure can stick as cached null render without retry).
 - 2026-04-12: Wave B synthesis complete. Cross-cutting themes and grouped High-only `fix-slop` batches documented in `docs/deslopify/apps/desktop/plan.md` (B1 IPC contract hardening; B2 settings/discovery safety; B3 runtime lifecycle correctness; B4 security boundary hardening). `apps/desktop/electron/features/workspace`, `apps/desktop/electron/features/agent`, and `apps/desktop/src/hooks` currently have no High items and are deferred to the first Medium wave unless execution uncovers new Highs.
 - 2026-04-12: Wave B High fixes implemented across core contracts/runtime/security. Highlights: `src/types/ipc.ts` reduced below 500 LOC via `src/types/user-feedback.ts`; preload compile-time API conformance guard added; IPC/app-extension `any` escape hatches removed; plugin discovery tag updated to `sero-agent-plugin`; settings parsing made non-destructive/fail-fast in shared + plugin flows; container proxy/scanner lifecycle hardened; production CSP narrowed; destructive store actions now IPC-success gated; federation remote load failure now retryable. Monorepo `pnpm typecheck` passes.
+- 2026-04-12: Wave C step 4 complete for `apps/desktop/src/components/apps/explorer`, `apps/desktop/electron/features/editor`, and `apps/desktop/src/lsp`. Facts + plans added under `docs/deslopify/apps/desktop/**`; index refreshed. Headline findings: explorer runtime ownership is pooling in `ExplorerWorkspace.tsx`/`EditorPanel.tsx`, `LspManager.startServer()` is not concurrency-safe during in-flight startup, and `src/lsp/use-lsp.ts` still uses an inline `import('monaco-editor')` type expression plus duplicated routing metadata.

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -72,7 +72,7 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 - [x] `deslopify apps/desktop/src/lsp`
 
 ### 5. Shell and app chrome
-- [ ] `deslopify apps/desktop/src/components/layout`
+- [x] `deslopify apps/desktop/src/components/layout`
 
 ### 6. Secondary feature islands
 - [ ] `deslopify apps/desktop/src/components/profiles`
@@ -147,3 +147,4 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 - 2026-04-12: Wave B synthesis complete. Cross-cutting themes and grouped High-only `fix-slop` batches documented in `docs/deslopify/apps/desktop/plan.md` (B1 IPC contract hardening; B2 settings/discovery safety; B3 runtime lifecycle correctness; B4 security boundary hardening). `apps/desktop/electron/features/workspace`, `apps/desktop/electron/features/agent`, and `apps/desktop/src/hooks` currently have no High items and are deferred to the first Medium wave unless execution uncovers new Highs.
 - 2026-04-12: Wave B High fixes implemented across core contracts/runtime/security. Highlights: `src/types/ipc.ts` reduced below 500 LOC via `src/types/user-feedback.ts`; preload compile-time API conformance guard added; IPC/app-extension `any` escape hatches removed; plugin discovery tag updated to `sero-agent-plugin`; settings parsing made non-destructive/fail-fast in shared + plugin flows; container proxy/scanner lifecycle hardened; production CSP narrowed; destructive store actions now IPC-success gated; federation remote load failure now retryable. Monorepo `pnpm typecheck` passes.
 - 2026-04-12: Wave C step 4 complete for `apps/desktop/src/components/apps/explorer`, `apps/desktop/electron/features/editor`, and `apps/desktop/src/lsp`. Facts + plans added under `docs/deslopify/apps/desktop/**`; index refreshed. Headline findings: explorer runtime ownership is pooling in `ExplorerWorkspace.tsx`/`EditorPanel.tsx`, `LspManager.startServer()` is not concurrency-safe during in-flight startup, and `src/lsp/use-lsp.ts` still uses an inline `import('monaco-editor')` type expression plus duplicated routing metadata.
+- 2026-04-12: Wave C step 5 complete for `apps/desktop/src/components/layout`. Facts + plan added at `docs/deslopify/apps/desktop/src/components/layout/{facts.md,plan.md}`; index refreshed. Headline findings: `components/layout` has become a shell catch-all with 88 files / 15.9k LOC, remote-origin publishing is duplicated between workspace and titlebar flows, and several theme/collaboration helpers still perform render-phase side effects.

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -75,10 +75,10 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 - [x] `deslopify apps/desktop/src/components/layout`
 
 ### 6. Secondary feature islands
-- [ ] `deslopify apps/desktop/src/components/profiles`
-- [ ] `deslopify apps/desktop/electron/features/onboarding`
-- [ ] `deslopify apps/desktop/electron/features/profile`
-- [ ] `deslopify apps/desktop/electron/features/auth`
+- [x] `deslopify apps/desktop/src/components/profiles`
+- [x] `deslopify apps/desktop/electron/features/onboarding`
+- [x] `deslopify apps/desktop/electron/features/profile`
+- [x] `deslopify apps/desktop/electron/features/auth`
 - [ ] `deslopify apps/desktop/electron/features/vcs`
 - [ ] `deslopify apps/desktop/electron/features/subagent`
 - [ ] `deslopify apps/desktop/electron/features/gateway`
@@ -148,3 +148,4 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 - 2026-04-12: Wave B High fixes implemented across core contracts/runtime/security. Highlights: `src/types/ipc.ts` reduced below 500 LOC via `src/types/user-feedback.ts`; preload compile-time API conformance guard added; IPC/app-extension `any` escape hatches removed; plugin discovery tag updated to `sero-agent-plugin`; settings parsing made non-destructive/fail-fast in shared + plugin flows; container proxy/scanner lifecycle hardened; production CSP narrowed; destructive store actions now IPC-success gated; federation remote load failure now retryable. Monorepo `pnpm typecheck` passes.
 - 2026-04-12: Wave C step 4 complete for `apps/desktop/src/components/apps/explorer`, `apps/desktop/electron/features/editor`, and `apps/desktop/src/lsp`. Facts + plans added under `docs/deslopify/apps/desktop/**`; index refreshed. Headline findings: explorer runtime ownership is pooling in `ExplorerWorkspace.tsx`/`EditorPanel.tsx`, `LspManager.startServer()` is not concurrency-safe during in-flight startup, and `src/lsp/use-lsp.ts` still uses an inline `import('monaco-editor')` type expression plus duplicated routing metadata.
 - 2026-04-12: Wave C step 5 complete for `apps/desktop/src/components/layout`. Facts + plan added at `docs/deslopify/apps/desktop/src/components/layout/{facts.md,plan.md}`; index refreshed. Headline findings: `components/layout` has become a shell catch-all with 88 files / 15.9k LOC, remote-origin publishing is duplicated between workspace and titlebar flows, and several theme/collaboration helpers still perform render-phase side effects.
+- 2026-04-12: Wave C step 6 complete for `apps/desktop/src/components/profiles`, `apps/desktop/electron/features/onboarding`, `apps/desktop/electron/features/profile`, and `apps/desktop/electron/features/auth`. Facts + plans added under `docs/deslopify/apps/desktop/**`; index refreshed. Headline findings: `OnboardingWizard.tsx` has become a near-cap renderer orchestration hub, onboarding preflight still mutates settings on a state-read path and imports IPC internals, malformed `profiles.json` currently degrades to an empty registry, and GitHub auth still falls back to base64-only token persistence when secure storage is unavailable.

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -87,18 +87,18 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 ## Wave D — Fix UI/Feature Findings
 
 ### 7. High-priority fixes first
-- [ ] `fix-slop` High items for `apps/desktop/src/components/apps/explorer`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/editor`
-- [ ] `fix-slop` High items for `apps/desktop/src/lsp`
-- [ ] `fix-slop` High items for `apps/desktop/src/components/layout`
-- [ ] `fix-slop` High items for `apps/desktop/src/components/profiles`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/onboarding`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/profile`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/auth`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/vcs`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/subagent`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/gateway`
-- [ ] `fix-slop` High items for `apps/desktop/electron/features/collaboration`
+- [x] `fix-slop` High items for `apps/desktop/src/components/apps/explorer` _(no High findings in Wave C; deferred to Medium wave)_
+- [x] `fix-slop` High items for `apps/desktop/electron/features/editor`
+- [x] `fix-slop` High items for `apps/desktop/src/lsp`
+- [x] `fix-slop` High items for `apps/desktop/src/components/layout` _(no High findings in Wave C; deferred to Medium wave)_
+- [x] `fix-slop` High items for `apps/desktop/src/components/profiles` _(no High findings in Wave C; deferred to Medium wave)_
+- [x] `fix-slop` High items for `apps/desktop/electron/features/onboarding` _(no High findings in Wave C; deferred to Medium wave)_
+- [x] `fix-slop` High items for `apps/desktop/electron/features/profile`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/auth`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/vcs`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/subagent`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/gateway`
+- [x] `fix-slop` High items for `apps/desktop/electron/features/collaboration` _(no High findings in Wave C; deferred to Medium wave)_
 
 ### 8. Medium-priority cleanup
 - [ ] Schedule Medium batches by dependency order, not folder name
@@ -150,3 +150,4 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 - 2026-04-12: Wave C step 5 complete for `apps/desktop/src/components/layout`. Facts + plan added at `docs/deslopify/apps/desktop/src/components/layout/{facts.md,plan.md}`; index refreshed. Headline findings: `components/layout` has become a shell catch-all with 88 files / 15.9k LOC, remote-origin publishing is duplicated between workspace and titlebar flows, and several theme/collaboration helpers still perform render-phase side effects.
 - 2026-04-12: Wave C step 6 complete for `apps/desktop/src/components/profiles`, `apps/desktop/electron/features/onboarding`, `apps/desktop/electron/features/profile`, and `apps/desktop/electron/features/auth`. Facts + plans added under `docs/deslopify/apps/desktop/**`; index refreshed. Headline findings: `OnboardingWizard.tsx` has become a near-cap renderer orchestration hub, onboarding preflight still mutates settings on a state-read path and imports IPC internals, malformed `profiles.json` currently degrades to an empty registry, and GitHub auth still falls back to base64-only token persistence when secure storage is unavailable.
 - 2026-04-12: Wave C step 6 continued for `apps/desktop/electron/features/vcs`, `apps/desktop/electron/features/subagent`, `apps/desktop/electron/features/gateway`, and `apps/desktop/electron/features/collaboration`. Facts + plans added under `docs/deslopify/apps/desktop/electron/features/**`; index refreshed. Headline findings: VCS still relies on `git-runner.ts` type escapes and renderer-owned shared contracts, subagent bulk aborts do not currently update tracker state, gateway auth remains flat-scoped across all workspaces and Discord `/sero abort` is a no-op, and collaboration synthesis prompts are still effectively unbounded while specialist failures are masked as placeholder text.
+- 2026-04-12: Wave D section 7 completed. High-priority fixes landed for `electron/features/editor`, `src/lsp`, `electron/features/profile`, `electron/features/auth`, `electron/features/vcs`, `electron/features/subagent`, and `electron/features/gateway`; the remaining section-7 folders had no High findings and were explicitly deferred to the Medium wave. Monorepo `pnpm typecheck` passes.

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -79,10 +79,10 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 - [x] `deslopify apps/desktop/electron/features/onboarding`
 - [x] `deslopify apps/desktop/electron/features/profile`
 - [x] `deslopify apps/desktop/electron/features/auth`
-- [ ] `deslopify apps/desktop/electron/features/vcs`
-- [ ] `deslopify apps/desktop/electron/features/subagent`
-- [ ] `deslopify apps/desktop/electron/features/gateway`
-- [ ] `deslopify apps/desktop/electron/features/collaboration`
+- [x] `deslopify apps/desktop/electron/features/vcs`
+- [x] `deslopify apps/desktop/electron/features/subagent`
+- [x] `deslopify apps/desktop/electron/features/gateway`
+- [x] `deslopify apps/desktop/electron/features/collaboration`
 
 ## Wave D — Fix UI/Feature Findings
 
@@ -149,3 +149,4 @@ That keeps us from fixing visible symptoms in the UI before fixing the code that
 - 2026-04-12: Wave C step 4 complete for `apps/desktop/src/components/apps/explorer`, `apps/desktop/electron/features/editor`, and `apps/desktop/src/lsp`. Facts + plans added under `docs/deslopify/apps/desktop/**`; index refreshed. Headline findings: explorer runtime ownership is pooling in `ExplorerWorkspace.tsx`/`EditorPanel.tsx`, `LspManager.startServer()` is not concurrency-safe during in-flight startup, and `src/lsp/use-lsp.ts` still uses an inline `import('monaco-editor')` type expression plus duplicated routing metadata.
 - 2026-04-12: Wave C step 5 complete for `apps/desktop/src/components/layout`. Facts + plan added at `docs/deslopify/apps/desktop/src/components/layout/{facts.md,plan.md}`; index refreshed. Headline findings: `components/layout` has become a shell catch-all with 88 files / 15.9k LOC, remote-origin publishing is duplicated between workspace and titlebar flows, and several theme/collaboration helpers still perform render-phase side effects.
 - 2026-04-12: Wave C step 6 complete for `apps/desktop/src/components/profiles`, `apps/desktop/electron/features/onboarding`, `apps/desktop/electron/features/profile`, and `apps/desktop/electron/features/auth`. Facts + plans added under `docs/deslopify/apps/desktop/**`; index refreshed. Headline findings: `OnboardingWizard.tsx` has become a near-cap renderer orchestration hub, onboarding preflight still mutates settings on a state-read path and imports IPC internals, malformed `profiles.json` currently degrades to an empty registry, and GitHub auth still falls back to base64-only token persistence when secure storage is unavailable.
+- 2026-04-12: Wave C step 6 continued for `apps/desktop/electron/features/vcs`, `apps/desktop/electron/features/subagent`, `apps/desktop/electron/features/gateway`, and `apps/desktop/electron/features/collaboration`. Facts + plans added under `docs/deslopify/apps/desktop/electron/features/**`; index refreshed. Headline findings: VCS still relies on `git-runner.ts` type escapes and renderer-owned shared contracts, subagent bulk aborts do not currently update tracker state, gateway auth remains flat-scoped across all workspaces and Discord `/sero abort` is a no-op, and collaboration synthesis prompts are still effectively unbounded while specialist failures are masked as placeholder text.

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -100,13 +100,17 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
 - [x] `fix-slop` High items for `apps/desktop/electron/features/gateway`
 - [x] `fix-slop` High items for `apps/desktop/electron/features/collaboration` _(no High findings in Wave C; deferred to Medium wave)_
 
-### 8. Medium-priority cleanup
-- [ ] Schedule Medium batches by dependency order, not folder name
-- [ ] Start with core Medium items still affecting multiple consumers
-- [ ] Then do feature-level Medium items
-- [ ] Leave Low items for opportunistic cleanup or dedicated polish passes
+## Wave E — Medium-priority cleanup
+- Identify all the Medium priority items from Wave A, B, C and D and create tasks
+- Schedule Medium batches by dependency order, not folder name
+- Start with core Medium items still affecting multiple consumers
+- Then do feature-level Medium items
+- Leave Low items for opportunistic cleanup or dedicated polish passes
 
-## Wave E — True Periphery Last
+### 8. Medium priority fixes
+- [ ] `fix-slop` Items to be defined here
+
+## Wave F — True Periphery Last
 
 - [ ] Review whether `apps/desktop/src/components/ui` needs deslopify at all
 - [ ] Review styles/theme-only surfaces if still needed

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -1,0 +1,9 @@
+# Plans Index
+
+Ad-hoc planning documents and implementation backlogs.
+
+- [2026-04-12 — PR 136 Follow-ups — Gateway Scope, Recovery UX, and Coverage](./2026-04-12-pr-136-followups.md)
+- [2026-04-10 — Multi-Root Workspaces & Linked Plugin Sources](./2026-04-10-multi-root-workspaces-for-plugin-dev.md)
+- [2026-04-08 — Agent Browser Migration Plan](./2026-04-08-agent-browser-migration-plan.md)
+- [2026-04-06 — Unified Model Selection](./2026-04-06-unified-model-selection.md)
+- [Apps Desktop Deslopify Tasklist](./apps-desktop-deslopify-tasklist.md)


### PR DESCRIPTION
## Summary
- add Wave C deslopify facts/plans for the remaining `apps/desktop` feature surfaces (explorer, layout, profiles, onboarding, auth, profile, vcs, subagent, gateway, collaboration)
- land the Wave D high-priority runtime fixes across desktop LSP, profile, auth, VCS, subagent, and gateway paths
- update the deslop tracking docs, index, and tasklist to reflect the completed High-priority pass

## High-priority fixes included
- dedupe in-flight LSP server startup and remove protocol-boundary `any` casts
- hard-fail on malformed `profiles.json` instead of treating corruption as first run
- require secure storage for persisted GitHub tokens
- remove remaining typed `any` transport handling in `git-runner.ts`
- make subagent bulk abort update tracker state and remove the runner cast/non-null assertion
- scope gateway web/QR tokens to explicit workspaces and fix Discord `/sero abort`

## Testing
- `pnpm typecheck`
