### PR TITLE
refactor(desktop): centralize model refresh and collaboration follow-ups

### DIFF
--- a/apps/desktop/electron/__tests__/ipc/agent-session-model-sync.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/agent-session-model-sync.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { Api, Model } from '@mariozechner/pi-ai';
+import { ensureSessionHasAvailableModel } from '@electron/ipc/agent/core/agent-session-model-sync';
+
+function createModel(provider: string, id: string): Model<Api> {
+  return { provider, id } as Model<Api>;
+}
+
+describe('ensureSessionHasAvailableModel', () => {
+  const authReload = vi.fn();
+  const findModel = vi.fn();
+  const getAvailable = vi.fn();
+  const settingsReload = vi.fn();
+  const getDefaultProvider = vi.fn(() => undefined);
+  const getDefaultModel = vi.fn(() => undefined);
+  const getGlobalSettings = vi.fn(() => ({}));
+  const setModel = vi.fn(async () => {});
+  const runtimeSetModel = vi.fn();
+
+  beforeEach(() => {
+    authReload.mockReset();
+    findModel.mockReset();
+    getAvailable.mockReset();
+    settingsReload.mockReset();
+    getDefaultProvider.mockReset().mockReturnValue(undefined);
+    getDefaultModel.mockReset().mockReturnValue(undefined);
+    getGlobalSettings.mockReset().mockReturnValue({});
+    setModel.mockReset();
+    runtimeSetModel.mockReset();
+  });
+
+  it('clears the live session model when availability drops to zero', async () => {
+    const session = {
+      model: createModel('openai', 'gpt-5.4-mini'),
+      agent: { setModel: runtimeSetModel },
+      setModel,
+      modelRegistry: {
+        authStorage: { reload: authReload },
+        find: findModel.mockReturnValue(undefined),
+        getAvailable: getAvailable.mockReturnValue([]),
+      },
+      settingsManager: {
+        reload: settingsReload,
+        getDefaultProvider,
+        getDefaultModel,
+        getGlobalSettings,
+      },
+    } as unknown as AgentSession;
+
+    const changed = await ensureSessionHasAvailableModel(session);
+
+    expect(changed).toBe(true);
+    expect(authReload).toHaveBeenCalledOnce();
+    expect(runtimeSetModel).toHaveBeenCalledWith(undefined);
+    expect(setModel).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the session is already model-less and nothing is available', async () => {
+    const session = {
+      model: undefined,
+      agent: { setModel: runtimeSetModel },
+      setModel,
+      modelRegistry: {
+        authStorage: { reload: authReload },
+        find: findModel.mockReturnValue(undefined),
+        getAvailable: getAvailable.mockReturnValue([]),
+      },
+      settingsManager: {
+        reload: settingsReload,
+        getDefaultProvider,
+        getDefaultModel,
+        getGlobalSettings,
+      },
+    } as unknown as AgentSession;
+
+    const changed = await ensureSessionHasAvailableModel(session);
+
+    expect(changed).toBe(false);
+    expect(runtimeSetModel).not.toHaveBeenCalled();
+    expect(setModel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
@@ -26,17 +26,34 @@ describe('syncAppSessionModel', () => {
     expect(setModel).toHaveBeenCalledWith(targetModel);
   });
 
-  it('does not update reused app sessions when they already match the shared model', async () => {
+  it('does not update reused app sessions when they already hold the shared model instance', async () => {
     const targetModel = createModel('openai', 'gpt-5.4-mini');
     const setModel = vi.fn(async () => {});
     const session = {
-      model: createModel('openai', 'gpt-5.4-mini'),
+      model: targetModel,
       setModel,
     } as unknown as AgentSession;
 
     const changed = await syncAppSessionModel(session, targetModel);
 
     expect(changed).toBe(false);
+    expect(setModel).not.toHaveBeenCalled();
+  });
+
+  it('swaps in refreshed shared model objects even when provider and id stay the same', async () => {
+    const targetModel = createModel('openai', 'gpt-5.4-mini');
+    const setModel = vi.fn(async () => {});
+    const runtimeSetModel = vi.fn();
+    const session = {
+      model: createModel('openai', 'gpt-5.4-mini'),
+      agent: { setModel: runtimeSetModel },
+      setModel,
+    } as unknown as AgentSession;
+
+    const changed = await syncAppSessionModel(session, targetModel);
+
+    expect(changed).toBe(true);
+    expect(runtimeSetModel).toHaveBeenCalledWith(targetModel);
     expect(setModel).not.toHaveBeenCalled();
   });
 
@@ -61,7 +78,7 @@ describe('syncAppSessionModel', () => {
     const matchingSetModel = vi.fn(async () => {});
     const staleSetModel = vi.fn(async () => {});
     const matchingSession = {
-      model: createModel('openai', 'gpt-5.4-mini'),
+      model: targetModel,
       setModel: matchingSetModel,
     } as unknown as AgentSession;
     const staleSession = {

--- a/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { AgentSession } from '@mariozechner/pi-coding-agent';
 import type { Api, Model } from '@mariozechner/pi-ai';
-import { syncAppSessionModel } from '@electron/ipc/agent/handlers/app-agent';
+import {
+  syncAppSessionModel,
+  syncAppSessionPoolModels,
+} from '@electron/ipc/agent/core/app-agent-session-model-sync';
 
 function createModel(provider: string, id: string): Model<Api> {
   return { provider, id } as Model<Api>;
@@ -16,8 +19,9 @@ describe('syncAppSessionModel', () => {
       setModel,
     } as unknown as AgentSession;
 
-    await syncAppSessionModel(session, targetModel);
+    const changed = await syncAppSessionModel(session, targetModel);
 
+    expect(changed).toBe(true);
     expect(setModel).toHaveBeenCalledTimes(1);
     expect(setModel).toHaveBeenCalledWith(targetModel);
   });
@@ -30,8 +34,9 @@ describe('syncAppSessionModel', () => {
       setModel,
     } as unknown as AgentSession;
 
-    await syncAppSessionModel(session, targetModel);
+    const changed = await syncAppSessionModel(session, targetModel);
 
+    expect(changed).toBe(false);
     expect(setModel).not.toHaveBeenCalled();
   });
 
@@ -42,8 +47,32 @@ describe('syncAppSessionModel', () => {
       setModel,
     } as unknown as AgentSession;
 
-    await syncAppSessionModel(session, null);
+    const changed = await syncAppSessionModel(session, null);
 
+    expect(changed).toBe(false);
     expect(setModel).not.toHaveBeenCalled();
+  });
+
+  it('reconciles every reused app session in the pool during a model refresh', async () => {
+    const targetModel = createModel('openai', 'gpt-5.4-mini');
+    const matchingSetModel = vi.fn(async () => {});
+    const staleSetModel = vi.fn(async () => {});
+    const matchingSession = {
+      model: createModel('openai', 'gpt-5.4-mini'),
+      setModel: matchingSetModel,
+    } as unknown as AgentSession;
+    const staleSession = {
+      model: createModel('anthropic', 'claude-sonnet-4-6'),
+      setModel: staleSetModel,
+    } as unknown as AgentSession;
+
+    const updated = await syncAppSessionPoolModels(
+      [matchingSession, staleSession],
+      targetModel,
+    );
+
+    expect(updated).toBe(1);
+    expect(matchingSetModel).not.toHaveBeenCalled();
+    expect(staleSetModel).toHaveBeenCalledWith(targetModel);
   });
 });

--- a/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
@@ -40,16 +40,19 @@ describe('syncAppSessionModel', () => {
     expect(setModel).not.toHaveBeenCalled();
   });
 
-  it('skips model updates when there is no shared model to apply', async () => {
+  it('clears reused app sessions when no shared model remains available', async () => {
     const setModel = vi.fn(async () => {});
+    const runtimeSetModel = vi.fn();
     const session = {
       model: createModel('openai', 'gpt-5.4-mini'),
+      agent: { setModel: runtimeSetModel },
       setModel,
     } as unknown as AgentSession;
 
     const changed = await syncAppSessionModel(session, null);
 
-    expect(changed).toBe(false);
+    expect(changed).toBe(true);
+    expect(runtimeSetModel).toHaveBeenCalledWith(undefined);
     expect(setModel).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/electron/__tests__/ipc/auth-model-refresh.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/auth-model-refresh.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  refreshModelAvailability: vi.fn(),
+}));
+
+vi.mock('@electron/ipc/agent/core/model-availability-refresh', () => ({
+  refreshModelAvailability: mocks.refreshModelAvailability,
+}));
+
+import { refreshModelAvailabilityAfterCredentialChange } from '@electron/ipc/platform/auth/auth-model-refresh';
+
+describe('refreshModelAvailabilityAfterCredentialChange', () => {
+  const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleWarn.mockClear();
+    mocks.refreshModelAvailability.mockReset();
+  });
+
+  it('does not fail the credential flow when model reconciliation hits an unrelated refresh error', async () => {
+    mocks.refreshModelAvailability.mockRejectedValue(new Error('models.json is invalid'));
+
+    await expect(refreshModelAvailabilityAfterCredentialChange()).resolves.toBeUndefined();
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[auth] Credentials changed but model refresh failed:',
+      expect.any(Error),
+    );
+  });
+
+  it('still awaits a successful refresh when reconciliation succeeds', async () => {
+    mocks.refreshModelAvailability.mockResolvedValue({
+      sharedModel: null,
+      updatedChatSessions: 0,
+      updatedAppSessions: 0,
+    });
+
+    await expect(refreshModelAvailabilityAfterCredentialChange()).resolves.toBeUndefined();
+
+    expect(mocks.refreshModelAvailability).toHaveBeenCalledOnce();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/collaboration.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/collaboration.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CollaborationResult } from '@/types/collaboration';
+import { IpcChannels } from '@/types/ipc';
+
+type CollaborationPromptHandler = (
+  event: unknown,
+  sessionId: string,
+  workspaceId: string,
+  query: string,
+  config?: unknown,
+) => Promise<CollaborationResult>;
+
+const mocks = vi.hoisted(() => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  const webContentsSend = vi.fn();
+  const getAllWindows = vi.fn(() => [{ webContents: { send: webContentsSend } }]);
+
+  return {
+    handlers,
+    ipcHandle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler);
+    }),
+    getAllWindows,
+    webContentsSend,
+    runCollaboration: vi.fn(),
+    runDebateCollaboration: vi.fn(),
+    getAgentPoolEntry: vi.fn(),
+    emitAgentEvent: vi.fn(),
+    nextId: vi.fn(() => 'user-1'),
+    applyCollaborationRuntimeEvent: vi.fn(),
+    createCollaborationRuntimeSnapshot: vi.fn(() => ({ status: 'research' })),
+    getCollaborationRuntimeSnapshot: vi.fn(() => null),
+    setCollaborationRuntimeSnapshot: vi.fn(),
+    subagentManager: { isInitialized: true },
+  };
+});
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: mocks.ipcHandle,
+  },
+  BrowserWindow: {
+    getAllWindows: mocks.getAllWindows,
+  },
+}));
+
+vi.mock('@electron/features/collaboration', () => ({
+  runCollaboration: mocks.runCollaboration,
+}));
+
+vi.mock('@electron/features/collaboration/debate', () => ({
+  runDebateCollaboration: mocks.runDebateCollaboration,
+}));
+
+vi.mock('@electron/shared/infra/shared-infra', () => ({
+  subagentManager: mocks.subagentManager,
+}));
+
+vi.mock('../../ipc/agent', () => ({
+  getAgentPoolEntry: mocks.getAgentPoolEntry,
+  emitAgentEvent: mocks.emitAgentEvent,
+}));
+
+vi.mock('../../ipc/agent/core/agent-helpers', () => ({
+  nextId: mocks.nextId,
+}));
+
+vi.mock('../../ipc/collaboration/runtime-state', () => ({
+  applyCollaborationRuntimeEvent: mocks.applyCollaborationRuntimeEvent,
+  createCollaborationRuntimeSnapshot: mocks.createCollaborationRuntimeSnapshot,
+  getCollaborationRuntimeSnapshot: mocks.getCollaborationRuntimeSnapshot,
+  setCollaborationRuntimeSnapshot: mocks.setCollaborationRuntimeSnapshot,
+}));
+
+describe('registerCollaborationHandlers', () => {
+  const result: CollaborationResult = {
+    finalResponse: 'Synthesized answer',
+    specialistOutputs: [],
+    totalDurationMs: 1234,
+    hasErrors: false,
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.handlers.clear();
+    mocks.ipcHandle.mockClear();
+    mocks.getAllWindows.mockClear();
+    mocks.getAllWindows.mockReturnValue([{ webContents: { send: mocks.webContentsSend } }]);
+    mocks.webContentsSend.mockReset();
+    mocks.runCollaboration.mockReset();
+    mocks.runDebateCollaboration.mockReset();
+    mocks.getAgentPoolEntry.mockReset();
+    mocks.emitAgentEvent.mockReset();
+    mocks.nextId.mockReset().mockReturnValue('user-1');
+    mocks.applyCollaborationRuntimeEvent.mockReset();
+    mocks.createCollaborationRuntimeSnapshot.mockReset().mockReturnValue({ status: 'research' });
+    mocks.getCollaborationRuntimeSnapshot.mockReset().mockReturnValue(null);
+    mocks.setCollaborationRuntimeSnapshot.mockReset();
+    mocks.subagentManager.isInitialized = true;
+  });
+
+  it('emits collab_end only after the final injection prompt resolves', async () => {
+    const steps: string[] = [];
+    mocks.webContentsSend.mockImplementation((_channel, event: { type: string }) => {
+      steps.push(event.type);
+    });
+    mocks.runCollaboration.mockResolvedValue(result);
+    const sessionPrompt = vi.fn(async () => {
+      steps.push('prompt');
+    });
+    mocks.getAgentPoolEntry.mockReturnValue({
+      session: {
+        messages: [],
+        prompt: sessionPrompt,
+      },
+      lastCompletedCheckpoint: null,
+    });
+
+    const { registerCollaborationHandlers } = await import('../../ipc/collaboration/collaboration');
+    registerCollaborationHandlers();
+
+    const handler = mocks.handlers.get(
+      IpcChannels.collaboration.prompt,
+    ) as CollaborationPromptHandler;
+
+    await expect(
+      handler({}, 'session-1', 'workspace-1', 'Investigate the regression'),
+    ).resolves.toEqual(result);
+
+    expect(steps).toEqual(['collab_start', 'prompt', 'collab_end']);
+  });
+
+  it('preserves the error path by skipping collab_end when the final injection prompt fails', async () => {
+    const injectionError = new Error('injection failed');
+    mocks.runCollaboration.mockResolvedValue(result);
+    mocks.getAgentPoolEntry.mockReturnValue({
+      session: {
+        messages: [],
+        prompt: vi.fn().mockRejectedValue(injectionError),
+      },
+      lastCompletedCheckpoint: null,
+    });
+
+    const { registerCollaborationHandlers } = await import('../../ipc/collaboration/collaboration');
+    registerCollaborationHandlers();
+
+    const handler = mocks.handlers.get(
+      IpcChannels.collaboration.prompt,
+    ) as CollaborationPromptHandler;
+
+    await expect(
+      handler({}, 'session-1', 'workspace-1', 'Investigate the regression'),
+    ).rejects.toThrow('injection failed');
+
+    const collabEventTypes = mocks.webContentsSend.mock.calls.map(
+      ([, event]) => (event as { type: string }).type,
+    );
+    expect(collabEventTypes).toEqual(['collab_start', 'collab_error']);
+    expect(
+      mocks.applyCollaborationRuntimeEvent.mock.calls.map(
+        ([event]) => (event as { type: string }).type,
+      ),
+    ).toEqual(['collab_start', 'collab_error']);
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/model-availability-refresh.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/model-availability-refresh.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { Api, Model } from '@mariozechner/pi-ai';
+
+const mocks = vi.hoisted(() => ({
+  modelRegistryRefresh: vi.fn(),
+  modelRegistryGetAvailable: vi.fn(),
+  settingsReload: vi.fn(),
+  getGlobalSettings: vi.fn(() => ({})),
+  ensureInfra: vi.fn(),
+  refreshInfraModelSelection: vi.fn(),
+  applyRuntimeSettings: vi.fn(),
+  cleanupUnavailableModelSelections: vi.fn(),
+  getAgentPoolEntries: vi.fn(),
+  emitAgentEvent: vi.fn(),
+  getAppAgentSessions: vi.fn(),
+  ensureSessionHasAvailableModel: vi.fn(),
+  syncAppSessionPoolModels: vi.fn(),
+  buildModelState: vi.fn(),
+}));
+
+vi.mock('@electron/shared/infra/shared-infra', () => ({
+  ensureInfra: mocks.ensureInfra,
+  refreshInfraModelSelection: mocks.refreshInfraModelSelection,
+  applyRuntimeSettings: mocks.applyRuntimeSettings,
+}));
+
+vi.mock('@electron/shared/settings/cleanup-unavailable-model-selections', () => ({
+  cleanupUnavailableModelSelections: mocks.cleanupUnavailableModelSelections,
+}));
+
+vi.mock('@electron/ipc/agent/core/agent', () => ({
+  getAgentPoolEntries: mocks.getAgentPoolEntries,
+  emitAgentEvent: mocks.emitAgentEvent,
+}));
+
+vi.mock('@electron/ipc/agent/handlers/app-agent', () => ({
+  getAppAgentSessions: mocks.getAppAgentSessions,
+}));
+
+vi.mock('@electron/ipc/agent/core/agent-session-model-sync', () => ({
+  ensureSessionHasAvailableModel: mocks.ensureSessionHasAvailableModel,
+}));
+
+vi.mock('@electron/ipc/agent/core/app-agent-session-model-sync', () => ({
+  syncAppSessionPoolModels: mocks.syncAppSessionPoolModels,
+}));
+
+vi.mock('@electron/ipc/agent/core/agent-helpers', () => ({
+  buildModelState: mocks.buildModelState,
+}));
+
+import { refreshModelAvailability } from '@electron/ipc/agent/core/model-availability-refresh';
+
+function createModel(provider: string, id: string): Model<Api> {
+  return { provider, id } as Model<Api>;
+}
+
+describe('refreshModelAvailability', () => {
+  const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleWarn.mockClear();
+    mocks.modelRegistryRefresh.mockReset();
+    mocks.modelRegistryGetAvailable.mockReset();
+    mocks.settingsReload.mockReset();
+    mocks.getGlobalSettings.mockReset().mockReturnValue({});
+    mocks.ensureInfra.mockReset();
+    mocks.refreshInfraModelSelection.mockReset();
+    mocks.applyRuntimeSettings.mockReset();
+    mocks.cleanupUnavailableModelSelections.mockReset();
+    mocks.getAgentPoolEntries.mockReset();
+    mocks.emitAgentEvent.mockReset();
+    mocks.getAppAgentSessions.mockReset();
+    mocks.ensureSessionHasAvailableModel.mockReset();
+    mocks.syncAppSessionPoolModels.mockReset();
+    mocks.buildModelState.mockReset();
+  });
+
+  it('reconciles shared state, live chat sessions, and reused app-agent sessions in one flow', async () => {
+    const sharedModel = createModel('openai', 'gpt-5.4-mini');
+    const availableModels = [
+      createModel('openai', 'gpt-5.4-mini'),
+      createModel('anthropic', 'claude-sonnet-4-6'),
+    ];
+    const chatSessionA = { id: 'chat-a' } as unknown as AgentSession;
+    const chatSessionB = { id: 'chat-b' } as unknown as AgentSession;
+    const appSession = { id: 'app-1' } as unknown as AgentSession;
+
+    mocks.ensureInfra.mockResolvedValue({
+      modelRegistry: {
+        refresh: mocks.modelRegistryRefresh,
+        getError: vi.fn(() => null),
+        getAvailable: mocks.modelRegistryGetAvailable.mockReturnValue(availableModels),
+      },
+      settingsManager: {
+        reload: mocks.settingsReload,
+        getGlobalSettings: mocks.getGlobalSettings,
+      },
+    });
+    mocks.cleanupUnavailableModelSelections.mockReturnValue(true);
+    mocks.refreshInfraModelSelection.mockReturnValue(sharedModel);
+    mocks.getAgentPoolEntries.mockReturnValue([
+      ['chat-a', { session: chatSessionA }],
+      ['chat-b', { session: chatSessionB }],
+    ]);
+    mocks.ensureSessionHasAvailableModel
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    mocks.buildModelState
+      .mockReturnValueOnce({ model: { provider: 'openai', modelId: 'gpt-5.4-mini', name: 'GPT 5.4 Mini', reasoning: true }, thinkingLevel: 'high', availableThinkingLevels: ['high'], supportsXhigh: false, availableModels: [] })
+      .mockReturnValueOnce({ model: { provider: 'anthropic', modelId: 'claude-sonnet-4-6', name: 'Claude Sonnet 4.6', reasoning: true }, thinkingLevel: 'high', availableThinkingLevels: ['high'], supportsXhigh: false, availableModels: [] });
+    mocks.getAppAgentSessions.mockReturnValue([appSession]);
+    mocks.syncAppSessionPoolModels.mockResolvedValue(1);
+
+    const result = await refreshModelAvailability();
+
+    expect(mocks.modelRegistryRefresh).toHaveBeenCalledOnce();
+    expect(mocks.cleanupUnavailableModelSelections).toHaveBeenCalledWith([
+      { provider: 'openai', modelId: 'gpt-5.4-mini' },
+      { provider: 'anthropic', modelId: 'claude-sonnet-4-6' },
+    ]);
+    expect(mocks.settingsReload).toHaveBeenCalledOnce();
+    expect(mocks.applyRuntimeSettings).toHaveBeenCalledOnce();
+    expect(mocks.refreshInfraModelSelection).toHaveBeenCalledOnce();
+    expect(mocks.ensureSessionHasAvailableModel).toHaveBeenCalledTimes(2);
+    expect(mocks.emitAgentEvent).toHaveBeenCalledTimes(2);
+    expect(mocks.syncAppSessionPoolModels).toHaveBeenCalledWith([appSession], sharedModel);
+    expect(result).toEqual({
+      sharedModel,
+      updatedChatSessions: 1,
+      updatedAppSessions: 1,
+    });
+  });
+
+  it('keeps reconciling other sessions when one live chat session fails', async () => {
+    const sharedModel = createModel('openai', 'gpt-5.4-mini');
+    const healthySession = { id: 'chat-b' } as unknown as AgentSession;
+
+    mocks.ensureInfra.mockResolvedValue({
+      modelRegistry: {
+        refresh: mocks.modelRegistryRefresh,
+        getError: vi.fn(() => null),
+        getAvailable: mocks.modelRegistryGetAvailable.mockReturnValue([sharedModel]),
+      },
+      settingsManager: {
+        reload: mocks.settingsReload,
+        getGlobalSettings: mocks.getGlobalSettings,
+      },
+    });
+    mocks.cleanupUnavailableModelSelections.mockReturnValue(false);
+    mocks.refreshInfraModelSelection.mockReturnValue(sharedModel);
+    mocks.getAgentPoolEntries.mockReturnValue([
+      ['broken', { session: {} }],
+      ['healthy', { session: healthySession }],
+    ]);
+    mocks.ensureSessionHasAvailableModel
+      .mockRejectedValueOnce(new Error('stale session'))
+      .mockResolvedValueOnce(false);
+    mocks.buildModelState.mockReturnValue({ model: { provider: 'openai', modelId: 'gpt-5.4-mini', name: 'GPT 5.4 Mini', reasoning: true }, thinkingLevel: 'high', availableThinkingLevels: ['high'], supportsXhigh: false, availableModels: [] });
+    mocks.getAppAgentSessions.mockReturnValue([]);
+    mocks.syncAppSessionPoolModels.mockResolvedValue(0);
+
+    const result = await refreshModelAvailability();
+
+    expect(mocks.settingsReload).not.toHaveBeenCalled();
+    expect(consoleWarn).toHaveBeenCalledTimes(1);
+    expect(mocks.emitAgentEvent).toHaveBeenCalledTimes(1);
+    expect(result.updatedChatSessions).toBe(0);
+    expect(result.updatedAppSessions).toBe(0);
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/preload-api-subscriptions.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/preload-api-subscriptions.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IpcChannels } from '@/types/ipc-channels';
+
+const mocks = vi.hoisted(() => ({
+  ipcRenderer: {
+    invoke: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+vi.mock('electron', () => ({
+  ipcRenderer: mocks.ipcRenderer,
+}));
+
+import { agentBridge } from '@electron/preload/api/core';
+import { filetreeBridge, vcsBridge } from '@electron/preload/api/workbench';
+
+describe('preload event bridge subscriptions', () => {
+  beforeEach(() => {
+    mocks.ipcRenderer.invoke.mockReset();
+    mocks.ipcRenderer.on.mockReset();
+    mocks.ipcRenderer.removeListener.mockReset();
+  });
+
+  it('unsubscribes agent event listeners with the same handler instance', () => {
+    const callback = vi.fn();
+
+    const unsubscribe = agentBridge.onEvent(callback);
+
+    expect(mocks.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannels.agent.event,
+      expect.any(Function),
+    );
+    const handler = mocks.ipcRenderer.on.mock.calls.at(-1)?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    handler?.({}, { type: 'agent_start', sessionId: 'session-1' });
+    expect(callback).toHaveBeenCalledWith({ type: 'agent_start', sessionId: 'session-1' });
+
+    unsubscribe();
+
+    expect(mocks.ipcRenderer.removeListener).toHaveBeenCalledWith(
+      IpcChannels.agent.event,
+      handler,
+    );
+  });
+
+  it('unsubscribes VCS event listeners with the same handler instance', () => {
+    const callback = vi.fn();
+
+    const unsubscribe = vcsBridge.onEvent(callback);
+
+    expect(mocks.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannels.vcs.event,
+      expect.any(Function),
+    );
+    const handler = mocks.ipcRenderer.on.mock.calls.at(-1)?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    handler?.({}, { type: 'status', workspaceId: 'ws-1' });
+    expect(callback).toHaveBeenCalledWith({ type: 'status', workspaceId: 'ws-1' });
+
+    unsubscribe();
+
+    expect(mocks.ipcRenderer.removeListener).toHaveBeenCalledWith(
+      IpcChannels.vcs.event,
+      handler,
+    );
+  });
+
+  it('unsubscribes filetree change listeners with the same handler instance', () => {
+    const callback = vi.fn();
+
+    const unsubscribe = filetreeBridge.onChanged(callback);
+
+    expect(mocks.ipcRenderer.on).toHaveBeenCalledWith(
+      IpcChannels.filetree.changed,
+      expect.any(Function),
+    );
+    const handler = mocks.ipcRenderer.on.mock.calls.at(-1)?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    handler?.({}, { workspaceId: 'ws-1', directories: ['/workspace/src'] });
+    expect(callback).toHaveBeenCalledWith({
+      workspaceId: 'ws-1',
+      directories: ['/workspace/src'],
+    });
+
+    unsubscribe();
+
+    expect(mocks.ipcRenderer.removeListener).toHaveBeenCalledWith(
+      IpcChannels.filetree.changed,
+      handler,
+    );
+  });
+});

--- a/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
@@ -20,9 +20,7 @@ import {
   areContextOverridesEqual,
   persistContextOverrides,
 } from './agent-context-overrides';
-import { getConfiguredModelFallbackChain } from '@electron/shared/settings/model-fallback-chain';
-import { getModelTiers } from '@electron/shared/settings/model-tiers';
-import { cleanupUnavailableModelSelections } from '@electron/shared/settings/cleanup-unavailable-model-selections';
+import { ensureSessionHasAvailableModel } from './agent-session-model-sync';
 
 export interface AgentPoolContextEntry {
   session: AgentSession;
@@ -37,107 +35,6 @@ interface RegisterModelContextHandlersOptions {
   sendEvent: (event: AgentStreamEvent) => void;
 }
 
-function findAvailableModelByProviderAndId(
-  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
-  provider: string | undefined,
-  modelId: string | undefined,
-) {
-  if (!provider || !modelId) return undefined;
-  return availableModels.find((model) => model.provider === provider && model.id === modelId);
-}
-
-function findAvailableModelByReference(
-  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
-  reference: string,
-  preferredProvider?: string,
-) {
-  const trimmed = reference.trim();
-  if (!trimmed) return undefined;
-
-  const slashIndex = trimmed.indexOf('/');
-  if (slashIndex !== -1) {
-    const provider = trimmed.slice(0, slashIndex).trim();
-    const modelId = trimmed.slice(slashIndex + 1).trim();
-    return findAvailableModelByProviderAndId(availableModels, provider, modelId);
-  }
-
-  const lowerId = trimmed.toLowerCase();
-  const matches = availableModels.filter((model) => model.id.toLowerCase() === lowerId);
-  if (matches.length === 0) return undefined;
-  if (matches.length === 1) return matches[0];
-
-  if (preferredProvider) {
-    const preferredMatch = matches.find((model) => model.provider === preferredProvider);
-    if (preferredMatch) return preferredMatch;
-  }
-
-  return matches[0];
-}
-
-function pickFallbackModel(
-  session: AgentSession,
-  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
-) {
-  session.settingsManager.reload();
-
-  // 1. Try saved default provider/model (existing settings)
-  const preferredProvider = session.settingsManager.getDefaultProvider();
-  const savedDefaultModel = findAvailableModelByProviderAndId(
-    availableModels,
-    preferredProvider,
-    session.settingsManager.getDefaultModel(),
-  );
-  if (savedDefaultModel) return savedDefaultModel;
-
-  // 2. Try HIGH tier model (main sessions use the most capable model)
-  const globalSettings = session.settingsManager.getGlobalSettings() as Record<string, unknown>;
-  const tiers = getModelTiers(globalSettings);
-  if (tiers.HIGH) {
-    const tierMatch = availableModels.find(
-      (m) => m.provider === tiers.HIGH!.provider && m.id === tiers.HIGH!.modelId,
-    );
-    if (tierMatch) return tierMatch;
-  }
-
-  // 3. Walk fallback chain
-  const fallbackChain = getConfiguredModelFallbackChain(globalSettings);
-  for (const candidate of fallbackChain) {
-    const model = findAvailableModelByReference(availableModels, candidate, preferredProvider);
-    if (model) return model;
-  }
-
-  return availableModels[0];
-}
-
-async function ensureSessionHasAvailableModel(session: AgentSession): Promise<boolean> {
-  session.modelRegistry.authStorage.reload();
-
-  const currentModel = session.model;
-  const refreshedModel = currentModel
-    ? session.modelRegistry.find(currentModel.provider, currentModel.id)
-    : undefined;
-
-  if (currentModel && refreshedModel && refreshedModel !== currentModel) {
-    session.agent.setModel(refreshedModel);
-  }
-
-  const availableModels = session.modelRegistry.getAvailable();
-  const currentProvider = refreshedModel?.provider ?? currentModel?.provider;
-  const currentModelId = refreshedModel?.id ?? currentModel?.id;
-  const currentStillAvailable = !!findAvailableModelByProviderAndId(
-    availableModels,
-    currentProvider,
-    currentModelId,
-  );
-
-  if (currentStillAvailable) return false;
-
-  const fallbackModel = pickFallbackModel(session, availableModels);
-  if (!fallbackModel) return false;
-
-  await session.setModel(fallbackModel);
-  return true;
-}
 
 export function registerAgentModelContextHandlers(
   options: RegisterModelContextHandlersOptions,

--- a/apps/desktop/electron/ipc/agent/core/agent-session-model-sync.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-session-model-sync.ts
@@ -1,0 +1,107 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+
+import { getConfiguredModelFallbackChain } from '@electron/shared/settings/model-fallback-chain';
+import { getModelTiers } from '@electron/shared/settings/model-tiers';
+
+function findAvailableModelByProviderAndId(
+  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
+  provider: string | undefined,
+  modelId: string | undefined,
+) {
+  if (!provider || !modelId) return undefined;
+  return availableModels.find((model) => model.provider === provider && model.id === modelId);
+}
+
+function findAvailableModelByReference(
+  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
+  reference: string,
+  preferredProvider?: string,
+) {
+  const trimmed = reference.trim();
+  if (!trimmed) return undefined;
+
+  const slashIndex = trimmed.indexOf('/');
+  if (slashIndex !== -1) {
+    const provider = trimmed.slice(0, slashIndex).trim();
+    const modelId = trimmed.slice(slashIndex + 1).trim();
+    return findAvailableModelByProviderAndId(availableModels, provider, modelId);
+  }
+
+  const lowerId = trimmed.toLowerCase();
+  const matches = availableModels.filter((model) => model.id.toLowerCase() === lowerId);
+  if (matches.length === 0) return undefined;
+  if (matches.length === 1) return matches[0];
+
+  if (preferredProvider) {
+    const preferredMatch = matches.find((model) => model.provider === preferredProvider);
+    if (preferredMatch) return preferredMatch;
+  }
+
+  return matches[0];
+}
+
+function pickFallbackModel(
+  session: AgentSession,
+  availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
+) {
+  session.settingsManager.reload();
+
+  const preferredProvider = session.settingsManager.getDefaultProvider();
+  const savedDefaultModel = findAvailableModelByProviderAndId(
+    availableModels,
+    preferredProvider,
+    session.settingsManager.getDefaultModel(),
+  );
+  if (savedDefaultModel) return savedDefaultModel;
+
+  const globalSettings = session.settingsManager.getGlobalSettings() as Record<string, unknown>;
+  const tiers = getModelTiers(globalSettings);
+  if (tiers.HIGH) {
+    const tierMatch = availableModels.find(
+      (model) =>
+        model.provider === tiers.HIGH!.provider &&
+        model.id === tiers.HIGH!.modelId,
+    );
+    if (tierMatch) return tierMatch;
+  }
+
+  const fallbackChain = getConfiguredModelFallbackChain(globalSettings);
+  for (const candidate of fallbackChain) {
+    const model = findAvailableModelByReference(availableModels, candidate, preferredProvider);
+    if (model) return model;
+  }
+
+  return availableModels[0];
+}
+
+export async function ensureSessionHasAvailableModel(
+  session: AgentSession,
+): Promise<boolean> {
+  session.modelRegistry.authStorage.reload();
+
+  const currentModel = session.model;
+  const refreshedModel = currentModel
+    ? session.modelRegistry.find(currentModel.provider, currentModel.id)
+    : undefined;
+
+  if (currentModel && refreshedModel && refreshedModel !== currentModel) {
+    session.agent.setModel(refreshedModel);
+  }
+
+  const availableModels = session.modelRegistry.getAvailable();
+  const currentProvider = refreshedModel?.provider ?? currentModel?.provider;
+  const currentModelId = refreshedModel?.id ?? currentModel?.id;
+  const currentStillAvailable = !!findAvailableModelByProviderAndId(
+    availableModels,
+    currentProvider,
+    currentModelId,
+  );
+
+  if (currentStillAvailable) return false;
+
+  const fallbackModel = pickFallbackModel(session, availableModels);
+  if (!fallbackModel) return false;
+
+  await session.setModel(fallbackModel);
+  return true;
+}

--- a/apps/desktop/electron/ipc/agent/core/agent-session-model-sync.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-session-model-sync.ts
@@ -3,6 +3,12 @@ import type { AgentSession } from '@mariozechner/pi-coding-agent';
 import { getConfiguredModelFallbackChain } from '@electron/shared/settings/model-fallback-chain';
 import { getModelTiers } from '@electron/shared/settings/model-tiers';
 
+type SessionWithMutableRuntimeModel = AgentSession & {
+  agent: {
+    setModel(model: NonNullable<AgentSession['model']> | undefined): void;
+  };
+};
+
 function findAvailableModelByProviderAndId(
   availableModels: ReturnType<AgentSession['modelRegistry']['getAvailable']>,
   provider: string | undefined,
@@ -74,6 +80,17 @@ function pickFallbackModel(
   return availableModels[0];
 }
 
+export function clearUnavailableSessionModel(session: AgentSession): boolean {
+  if (!session.model) return false;
+
+  // The SDK runtime accepts `undefined` here and `AgentSession.prompt()`
+  // already treats that as “No model selected”. We use the widened cast only
+  // to clear stale live-session selections when availability drops to zero.
+  const runtimeMutableSession = session as unknown as SessionWithMutableRuntimeModel;
+  runtimeMutableSession.agent.setModel(undefined);
+  return true;
+}
+
 export async function ensureSessionHasAvailableModel(
   session: AgentSession,
 ): Promise<boolean> {
@@ -100,7 +117,9 @@ export async function ensureSessionHasAvailableModel(
   if (currentStillAvailable) return false;
 
   const fallbackModel = pickFallbackModel(session, availableModels);
-  if (!fallbackModel) return false;
+  if (!fallbackModel) {
+    return clearUnavailableSessionModel(session);
+  }
 
   await session.setModel(fallbackModel);
   return true;

--- a/apps/desktop/electron/ipc/agent/core/agent.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent.ts
@@ -1,5 +1,4 @@
 import { ipcMain, BrowserWindow } from 'electron';
-
 import {
   createAgentSession,
   SessionManager,
@@ -22,7 +21,6 @@ import type {
   SeroSessionInfo,
 } from '@/types/ipc';
 import type { ChatCheckpointRef } from '@/types/checkpoints';
-
 import {
   nextId,
   convertSessionMessages,
@@ -62,7 +60,6 @@ import {
 import { installGatewayAgentOps, forwardEventToGateway } from '@electron/features/gateway/bridge/agent-bridge';
 import { createSkillVisibilityOverride } from '@electron/features/apps/extensions/skill-visibility';
 import { buildGatewayOps } from '@electron/ipc/gateway/gateway-ops';
-
 interface PoolEntry {
   session: AgentSession;
   loader: DefaultResourceLoader;
@@ -76,36 +73,33 @@ interface PoolEntry {
   baseSystemPrompt: string;
   baseTools: ContextToolInfo[];
 }
-
 const pool = new Map<string, PoolEntry>();
-
 function toErrorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : fallback;
 }
-
 /** Get a pool entry by session ID (used by collaboration handler). */
 export function getAgentPoolEntry(sessionId: string): PoolEntry | undefined {
   return pool.get(sessionId);
 }
-
+export function getAgentPoolEntries(): Array<[string, PoolEntry]> {
+  return [...pool.entries()];
+}
 if (process.env.NODE_ENV === 'test') {
   (globalThis as Record<string, unknown>).__seroTestGetAgentPoolEntry = getAgentPoolEntry;
 }
-
 /** Reload all active session ResourceLoaders after edits. */
 export async function reloadAllSessionResources(): Promise<void> {
-  await Promise.all(
-    [...pool.values()].map((entry) => entry.loader.reload()),
-  );
+  await Promise.all([...pool.values()].map((entry) => entry.loader.reload()));
 }
-
-function sendEvent(event: AgentStreamEvent): void {
+export function emitAgentEvent(event: AgentStreamEvent): void {
   for (const win of BrowserWindow.getAllWindows()) {
     win.webContents.send(IpcChannels.agent.event, event);
   }
   forwardEventToGateway(event as unknown as Record<string, unknown>);
 }
-
+function sendEvent(event: AgentStreamEvent): void {
+  emitAgentEvent(event);
+}
 async function closePoolEntry(sessionId: string): Promise<void> {
   const entry = pool.get(sessionId);
   if (!entry) return;

--- a/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
+++ b/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
@@ -2,11 +2,22 @@ import type { AgentSession } from '@mariozechner/pi-coding-agent';
 import type { Api, Model } from '@mariozechner/pi-ai';
 import { clearUnavailableSessionModel } from './agent-session-model-sync';
 
+type SessionWithMutableRuntimeModel = AgentSession & {
+  agent: {
+    setModel(model: NonNullable<AgentSession['model']> | undefined): void;
+  };
+};
+
 export function appSessionMatchesSharedModel(
   session: AgentSession,
   model: Model<Api>,
 ): boolean {
   return session.model?.provider === model.provider && session.model?.id === model.id;
+}
+
+function setRuntimeSessionModel(session: AgentSession, model: Model<Api>): void {
+  const runtimeMutableSession = session as unknown as SessionWithMutableRuntimeModel;
+  runtimeMutableSession.agent.setModel(model);
 }
 
 export async function syncAppSessionModel(
@@ -16,7 +27,18 @@ export async function syncAppSessionModel(
   if (!sharedModel) {
     return clearUnavailableSessionModel(session);
   }
-  if (appSessionMatchesSharedModel(session, sharedModel)) return false;
+
+  const currentModel = session.model;
+  if (currentModel === sharedModel) return false;
+
+  if (appSessionMatchesSharedModel(session, sharedModel)) {
+    // Reused app sessions can keep a stale runtime model object after auth or
+    // local-model registry refreshes. Swap in the refreshed instance without
+    // rewriting settings or appending redundant session history entries.
+    setRuntimeSessionModel(session, sharedModel);
+    return true;
+  }
+
   await session.setModel(sharedModel);
   return true;
 }

--- a/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
+++ b/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
@@ -1,5 +1,6 @@
 import type { AgentSession } from '@mariozechner/pi-coding-agent';
 import type { Api, Model } from '@mariozechner/pi-ai';
+import { clearUnavailableSessionModel } from './agent-session-model-sync';
 
 export function appSessionMatchesSharedModel(
   session: AgentSession,
@@ -12,7 +13,9 @@ export async function syncAppSessionModel(
   session: AgentSession,
   sharedModel: Model<Api> | null,
 ): Promise<boolean> {
-  if (!sharedModel) return false;
+  if (!sharedModel) {
+    return clearUnavailableSessionModel(session);
+  }
   if (appSessionMatchesSharedModel(session, sharedModel)) return false;
   await session.setModel(sharedModel);
   return true;

--- a/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
+++ b/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
@@ -1,0 +1,36 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { Api, Model } from '@mariozechner/pi-ai';
+
+export function appSessionMatchesSharedModel(
+  session: AgentSession,
+  model: Model<Api>,
+): boolean {
+  return session.model?.provider === model.provider && session.model?.id === model.id;
+}
+
+export async function syncAppSessionModel(
+  session: AgentSession,
+  sharedModel: Model<Api> | null,
+): Promise<boolean> {
+  if (!sharedModel) return false;
+  if (appSessionMatchesSharedModel(session, sharedModel)) return false;
+  await session.setModel(sharedModel);
+  return true;
+}
+
+export async function syncAppSessionPoolModels(
+  sessions: Iterable<AgentSession>,
+  sharedModel: Model<Api> | null,
+): Promise<number> {
+  let updated = 0;
+  for (const session of sessions) {
+    try {
+      if (await syncAppSessionModel(session, sharedModel)) {
+        updated += 1;
+      }
+    } catch (error) {
+      console.warn('[app-agent-model-sync] Failed to reconcile app session model:', error);
+    }
+  }
+  return updated;
+}

--- a/apps/desktop/electron/ipc/agent/core/model-availability-refresh.ts
+++ b/apps/desktop/electron/ipc/agent/core/model-availability-refresh.ts
@@ -1,0 +1,86 @@
+import { type Model, type Api } from '@mariozechner/pi-ai';
+
+import {
+  ensureInfra,
+  refreshInfraModelSelection,
+  applyRuntimeSettings,
+} from '@electron/shared/infra/shared-infra';
+import { cleanupUnavailableModelSelections } from '@electron/shared/settings/cleanup-unavailable-model-selections';
+import { buildModelState } from './agent-helpers';
+import { ensureSessionHasAvailableModel } from './agent-session-model-sync';
+import { syncAppSessionPoolModels } from './app-agent-session-model-sync';
+import { emitAgentEvent, getAgentPoolEntries } from './agent';
+import { getAppAgentSessions } from '../handlers/app-agent';
+
+export interface ModelAvailabilityRefreshResult {
+  sharedModel: Model<Api> | null;
+  updatedChatSessions: number;
+  updatedAppSessions: number;
+}
+
+function buildAvailableModelSelections(
+  models: ReturnType<Awaited<ReturnType<typeof ensureInfra>>['modelRegistry']['getAvailable']>,
+) {
+  return models.map((model) => ({
+    provider: model.provider,
+    modelId: model.id,
+  }));
+}
+
+async function reconcileLiveChatSessions(): Promise<number> {
+  const entries = getAgentPoolEntries();
+  let updated = 0;
+
+  for (const [sessionId, entry] of entries) {
+    try {
+      if (await ensureSessionHasAvailableModel(entry.session)) {
+        updated += 1;
+      }
+      emitAgentEvent({
+        type: 'model_change',
+        sessionId,
+        state: buildModelState(entry),
+      });
+    } catch (error) {
+      console.warn(`[model-refresh] Failed to reconcile chat session ${sessionId}:`, error);
+    }
+  }
+
+  return updated;
+}
+
+export async function refreshModelAvailability(): Promise<ModelAvailabilityRefreshResult> {
+  const infra = await ensureInfra();
+
+  infra.modelRegistry.refresh();
+
+  const loadError = infra.modelRegistry.getError();
+  if (loadError) {
+    throw new Error(loadError);
+  }
+
+  const availableModels = infra.modelRegistry.getAvailable();
+  const cleanedSettings = cleanupUnavailableModelSelections(
+    buildAvailableModelSelections(availableModels),
+  );
+
+  if (cleanedSettings) {
+    infra.settingsManager.reload();
+  }
+  applyRuntimeSettings(infra.settingsManager);
+
+  const sharedModel = refreshInfraModelSelection();
+  const [updatedChatSessions, updatedAppSessions] = await Promise.all([
+    reconcileLiveChatSessions(),
+    syncAppSessionPoolModels(getAppAgentSessions(), sharedModel).catch((error) => {
+      console.warn('[model-refresh] Failed to reconcile app-agent sessions:', error);
+      return 0;
+    }),
+  ]);
+
+  return {
+    sharedModel,
+    updatedChatSessions,
+    updatedAppSessions,
+  };
+}

--- a/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
@@ -25,7 +25,6 @@ import {
   SessionManager,
   type AgentSession,
 } from '@mariozechner/pi-coding-agent';
-import type { Api, Model } from '@mariozechner/pi-ai';
 import os from 'os';
 import path from 'path';
 
@@ -34,6 +33,7 @@ import { discoverApps } from '@electron/features/apps/discovery';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { workspaceManager } from '@electron/features/workspace/manager';
 import { ensureInfra } from '@electron/shared/infra/shared-infra';
+import { syncAppSessionModel } from '@electron/ipc/agent/core/app-agent-session-model-sync';
 
 // ── App Session Pool ─────────────────────────────────────────
 
@@ -58,21 +58,6 @@ function poolKey(appId: string, workspaceId: string): string {
   return `${appId}:${workspaceId}`;
 }
 
-function appSessionMatchesSharedModel(
-  session: AgentSession,
-  model: Model<Api>,
-): boolean {
-  return session.model?.provider === model.provider && session.model?.id === model.id;
-}
-
-export async function syncAppSessionModel(
-  session: AgentSession,
-  sharedModel: Model<Api> | null,
-): Promise<void> {
-  if (!sharedModel) return;
-  if (appSessionMatchesSharedModel(session, sharedModel)) return;
-  await session.setModel(sharedModel);
-}
 
 // ── App package resource resolution ─────────────────────────
 
@@ -180,6 +165,10 @@ async function getOrCreateAppSession(
 
   appPool.set(key, { session });
   return session;
+}
+
+export function getAppAgentSessions(): AgentSession[] {
+  return [...appPool.values()].map((entry) => entry.session);
 }
 
 /** Dispose all in-memory app sessions for a specific app id. */

--- a/apps/desktop/electron/ipc/agent/handlers/local-models.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/local-models.ts
@@ -17,6 +17,7 @@ import type {
   LocalRemoteModelInfo,
 } from '@/types/ipc';
 import { ensureInfra } from '@electron/shared/infra/shared-infra';
+import { refreshModelAvailability } from '@electron/ipc/agent/core/model-availability-refresh';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 
 const MODELS_JSON_PATH = path.join(SERO_AGENT_DIR, 'models.json');
@@ -248,15 +249,10 @@ async function readModelsConfig(): Promise<LocalModelsConfig> {
   return JSON.parse(raw) as LocalModelsConfig;
 }
 
-/** Write models.json to disk and refresh the model registry. */
+/** Write models.json to disk. The shared refresh flow validates and reloads it. */
 async function writeModelsConfig(config: LocalModelsConfig): Promise<void> {
   await mkdir(path.dirname(MODELS_JSON_PATH), { recursive: true });
   await writeFile(MODELS_JSON_PATH, JSON.stringify(config, null, 2) + '\n', 'utf8');
-
-  const { modelRegistry } = await ensureInfra();
-  modelRegistry.refresh();
-  const loadError = modelRegistry.getError();
-  if (loadError) throw new Error(loadError);
 }
 
 /** Test connectivity using the selected API and auth settings. */
@@ -325,6 +321,7 @@ export function registerLocalModelsHandlers(): void {
     IpcChannels.localModels.saveConfig,
     async (_event, config: LocalModelsConfig): Promise<void> => {
       await writeModelsConfig(config);
+      await refreshModelAvailability();
     },
   );
 

--- a/apps/desktop/electron/ipc/collaboration/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration/collaboration.ts
@@ -23,7 +23,8 @@ import { DEFAULT_DEBATE_CONFIG } from '@/types/collaboration';
 import { runCollaboration } from '@electron/features/collaboration';
 import { runDebateCollaboration } from '@electron/features/collaboration/debate';
 import { subagentManager } from '@electron/shared/infra/shared-infra';
-import { getAgentPoolEntry } from '../agent';
+import { getAgentPoolEntry, emitAgentEvent } from '../agent';
+import { nextId } from '../agent/core/agent-helpers';
 import { extractOriginalCollaborationQuery } from './collaboration-message';
 import {
   applyCollaborationRuntimeEvent,
@@ -88,6 +89,33 @@ function buildInjectionPrompt(originalQuery: string, synthesis: string): string 
 <collaboration-synthesis>
 ${synthesis}
 </collaboration-synthesis>`;
+}
+
+function emitMainSessionUserMessage(
+  sessionId: string,
+  entry: NonNullable<ReturnType<typeof getAgentPoolEntry>>,
+  query: string,
+): void {
+  const userMessageId = nextId();
+  emitAgentEvent({
+    type: 'message_start',
+    sessionId,
+    message: {
+      type: 'user',
+      id: userMessageId,
+      text: query,
+    },
+  });
+
+  if (entry.lastCompletedCheckpoint) {
+    emitAgentEvent({
+      type: 'user_checkpoint',
+      sessionId,
+      userMessageId,
+      checkpoint: entry.lastCompletedCheckpoint,
+    });
+    entry.lastCompletedCheckpoint = null;
+  }
 }
 
 export function registerCollaborationHandlers(): void {
@@ -179,6 +207,10 @@ export function registerCollaborationHandlers(): void {
               },
             },
           );
+        }
+
+        if (entry) {
+          emitMainSessionUserMessage(sessionId, entry, query);
         }
 
         sendCollabEvent({ type: 'collab_end', sessionId, result });

--- a/apps/desktop/electron/ipc/collaboration/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration/collaboration.ts
@@ -211,15 +211,11 @@ export function registerCollaborationHandlers(): void {
 
         if (entry) {
           emitMainSessionUserMessage(sessionId, entry, query);
-        }
-
-        sendCollabEvent({ type: 'collab_end', sessionId, result });
-
-        if (entry) {
           const injectionPrompt = buildInjectionPrompt(query, result.finalResponse);
           await entry.session.prompt(injectionPrompt);
         }
 
+        sendCollabEvent({ type: 'collab_end', sessionId, result });
         return result;
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/apps/desktop/electron/ipc/collaboration/runtime-state.ts
+++ b/apps/desktop/electron/ipc/collaboration/runtime-state.ts
@@ -151,6 +151,7 @@ export function applyCollaborationRuntimeEvent(event: CollaborationEvent): void 
         ...snapshot,
         status: 'complete',
         result: event.result,
+        pendingUserQuery: null,
         error: null,
       }));
       return;

--- a/apps/desktop/electron/ipc/platform/auth/auth-model-refresh.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth-model-refresh.ts
@@ -1,0 +1,9 @@
+import { refreshModelAvailability } from '@electron/ipc/agent/core/model-availability-refresh';
+
+export async function refreshModelAvailabilityAfterCredentialChange(): Promise<void> {
+  try {
+    await refreshModelAvailability();
+  } catch (error) {
+    console.warn('[auth] Credentials changed but model refresh failed:', error);
+  }
+}

--- a/apps/desktop/electron/ipc/platform/auth/auth.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth.ts
@@ -29,13 +29,10 @@ import type {
   AuthProvidersResponse,
   OAuthEvent,
 } from '@/types/ipc';
-import {
-  ensureInfra,
-  refreshInfraModelSelection,
-} from '@electron/shared/infra/shared-infra';
+import { ensureInfra } from '@electron/shared/infra/shared-infra';
 import { getApiKeyProviderCatalog, getProviderEnvApiKey } from '@electron/shared/auth/provider-catalog';
 import { AUTH_JSON_PATH } from '@electron/platform/env';
-import { cleanupUnavailableModelSelections } from '@electron/shared/settings/cleanup-unavailable-model-selections';
+import { refreshModelAvailability } from '@electron/ipc/agent/core/model-availability-refresh';
 
 // ── auth.json permission hardening ───────────────────────────
 // The Pi SDK writes auth.json with default permissions (0o644).
@@ -111,13 +108,6 @@ function clearPending(): void {
   manualCodeRejecter = null;
   abortController = null;
   loginOriginWebContents = null;
-}
-
-async function refreshModelAvailabilityAfterAuthChange(
-  infra: Awaited<ReturnType<typeof ensureInfra>>,
-): Promise<void> {
-  infra.modelRegistry.refresh();
-  refreshInfraModelSelection();
 }
 
 // ── Registration ─────────────────────────────────────────────
@@ -247,7 +237,7 @@ export function registerAuthHandlers(): void {
         });
 
         // Success — refresh model registry so new credentials are picked up
-        await refreshModelAvailabilityAfterAuthChange(infra);
+        await refreshModelAvailability();
         hardenAuthJsonPermissions();
 
         sendAuthEvent({
@@ -278,7 +268,7 @@ export function registerAuthHandlers(): void {
     async (_event, providerId: string): Promise<void> => {
       const infra = await ensureInfra();
       infra.authStorage.logout(providerId);
-      await refreshModelAvailabilityAfterAuthChange(infra);
+      await refreshModelAvailability();
     },
   );
 
@@ -289,7 +279,7 @@ export function registerAuthHandlers(): void {
       const infra = await ensureInfra();
       infra.authStorage.set(providerId, { type: 'api_key', key });
       hardenAuthJsonPermissions();
-      await refreshModelAvailabilityAfterAuthChange(infra);
+      await refreshModelAvailability();
     },
   );
 
@@ -299,7 +289,7 @@ export function registerAuthHandlers(): void {
     async (_event, providerId: string): Promise<void> => {
       const infra = await ensureInfra();
       infra.authStorage.remove(providerId);
-      await refreshModelAvailabilityAfterAuthChange(infra);
+      await refreshModelAvailability();
     },
   );
 

--- a/apps/desktop/electron/ipc/platform/auth/auth.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth.ts
@@ -32,7 +32,7 @@ import type {
 import { ensureInfra } from '@electron/shared/infra/shared-infra';
 import { getApiKeyProviderCatalog, getProviderEnvApiKey } from '@electron/shared/auth/provider-catalog';
 import { AUTH_JSON_PATH } from '@electron/platform/env';
-import { refreshModelAvailability } from '@electron/ipc/agent/core/model-availability-refresh';
+import { refreshModelAvailabilityAfterCredentialChange } from './auth-model-refresh';
 
 // ── auth.json permission hardening ───────────────────────────
 // The Pi SDK writes auth.json with default permissions (0o644).
@@ -236,8 +236,10 @@ export function registerAuthHandlers(): void {
           signal: abortController.signal,
         });
 
-        // Success — refresh model registry so new credentials are picked up
-        await refreshModelAvailability();
+        // Success — refresh model registry so new credentials are picked up.
+        // If an unrelated models.json error blocks reconciliation, keep the
+        // credential change successful and log the refresh failure separately.
+        await refreshModelAvailabilityAfterCredentialChange();
         hardenAuthJsonPermissions();
 
         sendAuthEvent({
@@ -268,7 +270,7 @@ export function registerAuthHandlers(): void {
     async (_event, providerId: string): Promise<void> => {
       const infra = await ensureInfra();
       infra.authStorage.logout(providerId);
-      await refreshModelAvailability();
+      await refreshModelAvailabilityAfterCredentialChange();
     },
   );
 
@@ -279,7 +281,7 @@ export function registerAuthHandlers(): void {
       const infra = await ensureInfra();
       infra.authStorage.set(providerId, { type: 'api_key', key });
       hardenAuthJsonPermissions();
-      await refreshModelAvailability();
+      await refreshModelAvailabilityAfterCredentialChange();
     },
   );
 
@@ -289,7 +291,7 @@ export function registerAuthHandlers(): void {
     async (_event, providerId: string): Promise<void> => {
       const infra = await ensureInfra();
       infra.authStorage.remove(providerId);
-      await refreshModelAvailability();
+      await refreshModelAvailabilityAfterCredentialChange();
     },
   );
 

--- a/apps/desktop/src/components/apps/explorer/useWorkspaceFileWatch.test.tsx
+++ b/apps/desktop/src/components/apps/explorer/useWorkspaceFileWatch.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { EditorRoot } from '@/types/ipc';
+import {
+  resetWorkspaceFiletreeWatchRefsForTests,
+  retainWorkspaceFiletreeWatch,
+} from '@/hooks/workspace-filetree-subscription';
+import { useWorkspaceFileWatch } from './useWorkspaceFileWatch';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useWorkspaceFileWatch', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  const watch = vi.fn(async () => {});
+  const unwatch = vi.fn(async () => {});
+  const roots: EditorRoot[] = [
+    {
+      id: 'workspace',
+      name: 'Workspace',
+      virtualPath: '/workspace',
+      kind: 'workspace',
+    },
+  ];
+
+  function Harness({ workspaceId }: { workspaceId: string }) {
+    useWorkspaceFileWatch(workspaceId, roots);
+    return null;
+  }
+
+  beforeEach(() => {
+    watch.mockReset();
+    unwatch.mockReset();
+    resetWorkspaceFiletreeWatchRefsForTests();
+
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      writable: true,
+      value: {
+        filetree: {
+          watch,
+          unwatch,
+          onChanged: vi.fn(() => () => {}),
+        },
+      } as unknown as typeof window.sero,
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+    Reflect.deleteProperty(window, 'sero');
+    resetWorkspaceFiletreeWatchRefsForTests();
+  });
+
+  it('refreshes the shared watcher on first mount when another consumer already retained it', async () => {
+    const releaseSharedWatch = retainWorkspaceFiletreeWatch('ws-1');
+    expect(watch).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      root?.render(<Harness workspaceId="ws-1" />);
+    });
+
+    expect(watch).toHaveBeenCalledTimes(2);
+    releaseSharedWatch();
+  });
+
+  it('does not double-refresh the watcher on the first mount when it owns the watch', async () => {
+    await act(async () => {
+      root?.render(<Harness workspaceId="ws-1" />);
+    });
+
+    expect(watch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/components/apps/explorer/useWorkspaceFileWatch.ts
+++ b/apps/desktop/src/components/apps/explorer/useWorkspaceFileWatch.ts
@@ -1,16 +1,23 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { EditorRoot } from '@/types/ipc';
+import {
+  refreshWorkspaceFiletreeWatch,
+  retainWorkspaceFiletreeWatch,
+} from '@/hooks/workspace-filetree-subscription';
 
 export function useWorkspaceFileWatch(workspaceId: string, roots: EditorRoot[]): void {
   const rootsSignature = useMemo(
     () => roots.map((root) => `${root.id}:${root.virtualPath}:${root.kind ?? 'folder'}`).join('|'),
     [roots],
   );
+  const previousRootsSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
-    void window.sero.filetree.watch(workspaceId);
-    return () => {
-      void window.sero.filetree.unwatch(workspaceId);
-    };
+    const release = retainWorkspaceFiletreeWatch(workspaceId);
+    if (previousRootsSignatureRef.current !== null) {
+      refreshWorkspaceFiletreeWatch(workspaceId);
+    }
+    previousRootsSignatureRef.current = rootsSignature;
+    return release;
   }, [workspaceId, rootsSignature]);
 }

--- a/apps/desktop/src/components/apps/explorer/useWorkspaceFileWatch.ts
+++ b/apps/desktop/src/components/apps/explorer/useWorkspaceFileWatch.ts
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from 'react';
 import type { EditorRoot } from '@/types/ipc';
 import {
+  hasWorkspaceFiletreeWatch,
   refreshWorkspaceFiletreeWatch,
   retainWorkspaceFiletreeWatch,
 } from '@/hooks/workspace-filetree-subscription';
@@ -13,8 +14,9 @@ export function useWorkspaceFileWatch(workspaceId: string, roots: EditorRoot[]):
   const previousRootsSignatureRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const hadExistingWatch = hasWorkspaceFiletreeWatch(workspaceId);
     const release = retainWorkspaceFiletreeWatch(workspaceId);
-    if (previousRootsSignatureRef.current !== null) {
+    if (hadExistingWatch || previousRootsSignatureRef.current !== null) {
       refreshWorkspaceFiletreeWatch(workspaceId);
     }
     previousRootsSignatureRef.current = rootsSignature;

--- a/apps/desktop/src/components/layout/CollaborationActivityPanel.tsx
+++ b/apps/desktop/src/components/layout/CollaborationActivityPanel.tsx
@@ -21,6 +21,7 @@ import type { CollaborationRole } from '@/types/collaboration';
 import { useChatFeed } from './collaboration-chat-feed';
 import { useCollaborationSubagentEntries } from './useCollaborationSubagentEntries';
 import {
+  PendingQueryBubble,
   TypingBubble,
   MessageBubble,
   DebateRoundBubble,
@@ -92,6 +93,8 @@ export function CollaborationActivityPanel() {
         <AnimatePresence mode="popLayout">
           {feed.map((item) => {
             switch (item.kind) {
+              case 'query':
+                return <PendingQueryBubble key={item.key} text={item.text} />;
               case 'phase':
                 return <PhaseBanner key={item.key} phase={item.phase} />;
               case 'typing':

--- a/apps/desktop/src/components/layout/CollaborationFeedItems.tsx
+++ b/apps/desktop/src/components/layout/CollaborationFeedItems.tsx
@@ -17,6 +17,28 @@ import {
 import { CollaborationLiveActivity } from './CollaborationLiveActivity';
 import { useFocusedCollaborationStatus } from '@/stores/agent-selectors';
 
+// ── Pending user query bubble ───────────────────────────────────
+
+export function PendingQueryBubble({ text }: { text: string }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8, scale: 0.97 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ type: 'spring', stiffness: 350, damping: 24 }}
+      className="flex justify-end px-2"
+    >
+      <div className="max-w-[92%] rounded-2xl rounded-tr-md border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 shadow-sm">
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+          Your query
+        </div>
+        <p className="whitespace-pre-wrap break-words text-[11px] leading-relaxed text-[var(--text-primary)]">
+          {text}
+        </p>
+      </div>
+    </motion.div>
+  );
+}
+
 // ── Typing indicator (bouncing dots) ────────────────────────────
 
 function TypingDots({ colorClass }: { colorClass: string }) {

--- a/apps/desktop/src/components/layout/collaboration-chat-feed.test.ts
+++ b/apps/desktop/src/components/layout/collaboration-chat-feed.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildChatFeed } from './collaboration-chat-feed';
+
+describe('buildChatFeed', () => {
+  it('renders the pending collaboration query as collaboration UI state while active', () => {
+    const feed = buildChatFeed({
+      status: 'research',
+      strategy: 'standard',
+      specialists: [],
+      debate: null,
+      pendingUserQuery: 'Investigate the regression',
+    });
+
+    expect(feed[0]).toEqual({
+      kind: 'query',
+      key: 'pending-query',
+      text: 'Investigate the regression',
+    });
+  });
+
+  it('stops rendering the pending query after collaboration completes', () => {
+    const feed = buildChatFeed({
+      status: 'complete',
+      strategy: 'standard',
+      specialists: [],
+      debate: null,
+      pendingUserQuery: null,
+    });
+
+    expect(feed.some((item) => item.kind === 'query')).toBe(false);
+  });
+
+  it('keeps the failed query visible in collaboration UI error state', () => {
+    const feed = buildChatFeed({
+      status: 'error',
+      strategy: 'standard',
+      specialists: [],
+      debate: null,
+      pendingUserQuery: 'Why did the run fail?',
+    });
+
+    expect(feed[0]).toEqual({
+      kind: 'query',
+      key: 'pending-query',
+      text: 'Why did the run fail?',
+    });
+  });
+});

--- a/apps/desktop/src/components/layout/collaboration-chat-feed.ts
+++ b/apps/desktop/src/components/layout/collaboration-chat-feed.ts
@@ -14,20 +14,35 @@ import {
   Swords,
 } from 'lucide-react';
 import {
-  useFocusedCollaborationStatus,
+  useFocusedCollaborationPendingUserQuery,
   useFocusedCollaborationSpecialists,
+  useFocusedCollaborationStatus,
   useFocusedCollaborationStrategy,
   useFocusedDebateState,
 } from '@/stores/agent-selectors';
-import type { CollaborationRole, CollaborationStatus } from '@/types/collaboration';
+import type {
+  CollaborationRole,
+  CollaborationStatus,
+  CollaborationStrategy,
+  DebateState,
+} from '@/types/collaboration';
 
 // ── Chat message types ──────────────────────────────────────────
 
 export type ChatItem =
+  | { kind: 'query'; key: string; text: string }
   | { kind: 'phase'; key: string; phase: string }
   | { kind: 'typing'; key: string; role: CollaborationRole }
   | { kind: 'message'; key: string; role: CollaborationRole; text: string; durationMs: number; isError?: boolean }
   | { kind: 'debate-round'; key: string; round: number; challenger: CollaborationRole; defender: CollaborationRole; summary: string; durationMs: number };
+
+export interface ChatFeedInput {
+  status: CollaborationStatus;
+  strategy: CollaborationStrategy;
+  specialists: SpecialistEntry[];
+  debate: DebateState | null;
+  pendingUserQuery: string | null;
+}
 
 // ── Phase banner metadata ───────────────────────────────────────
 
@@ -92,21 +107,61 @@ export function useChatFeed(): ChatItem[] {
   const strategy = useFocusedCollaborationStrategy();
   const specialists = useFocusedCollaborationSpecialists();
   const debate = useFocusedDebateState();
+  const pendingUserQuery = useFocusedCollaborationPendingUserQuery();
 
-  return useMemo(() => {
-    const items: ChatItem[] = [];
+  return useMemo(
+    () =>
+      buildChatFeed({
+        status,
+        strategy,
+        specialists,
+        debate,
+        pendingUserQuery,
+      }),
+    [status, strategy, specialists, debate, pendingUserQuery],
+  );
+}
 
-    if (strategy === 'debate' && debate) {
-      return buildDebateFeed(debate, specialists, items);
-    }
+export function buildChatFeed({
+  status,
+  strategy,
+  specialists,
+  debate,
+  pendingUserQuery,
+}: ChatFeedInput): ChatItem[] {
+  const items: ChatItem[] = [];
 
-    return buildStandardFeed(status, specialists, items);
-  }, [status, strategy, specialists, debate]);
+  if (shouldRenderPendingQuery(status, pendingUserQuery)) {
+    items.push({
+      kind: 'query',
+      key: 'pending-query',
+      text: pendingUserQuery!.trim(),
+    });
+  }
+
+  if (strategy === 'debate' && debate) {
+    return buildDebateFeed(debate, specialists, items);
+  }
+
+  return buildStandardFeed(status, specialists, items);
+}
+
+function shouldRenderPendingQuery(
+  status: CollaborationStatus,
+  pendingUserQuery: string | null,
+): boolean {
+  if (!pendingUserQuery?.trim()) return false;
+  return status !== 'idle' && status !== 'complete';
 }
 
 // ── Standard strategy feed builder ──────────────────────────────
 
-type SpecialistEntry = { role: CollaborationRole; response: string; error?: string; durationMs: number };
+type SpecialistEntry = {
+  role: CollaborationRole;
+  response: string;
+  error?: string;
+  durationMs: number;
+};
 
 function buildStandardFeed(
   status: CollaborationStatus,
@@ -117,7 +172,6 @@ function buildStandardFeed(
 
   const completedRoles = new Set(specialists.map((s) => s.role));
 
-  // Researcher
   const researcher = specialists.find((s) => s.role === 'researcher');
   if (researcher) {
     items.push({ kind: 'message', key: 'msg-researcher', role: 'researcher', text: researcher.response, durationMs: researcher.durationMs, isError: !!researcher.error });
@@ -129,7 +183,6 @@ function buildStandardFeed(
     items.push({ kind: 'phase', key: 'phase-specialists', phase: 'specialists' });
   }
 
-  // Analyst & Visionary
   for (const role of ['analyst', 'visionary'] as CollaborationRole[]) {
     const spec = specialists.find((s) => s.role === role);
     if (spec) {
@@ -143,7 +196,6 @@ function buildStandardFeed(
     items.push({ kind: 'phase', key: 'phase-synthesis', phase: 'synthesis' });
   }
 
-  // Coordinator
   const coordinator = specialists.find((s) => s.role === 'coordinator');
   if (coordinator) {
     items.push({ kind: 'message', key: 'msg-coordinator', role: 'coordinator', text: coordinator.response, durationMs: coordinator.durationMs, isError: !!coordinator.error });
@@ -170,7 +222,7 @@ function buildDebateFeed(
     if (phases[i] === 'decomposition') {
       const decomposition = specialists.find((s) => s.role === 'coordinator');
       const coordinatorStatus =
-        debate.agentStatuses['coordinator'] ?? debate.agentStatuses['collab-coordinator'];
+        debate.agentStatuses.coordinator ?? debate.agentStatuses['collab-coordinator'];
       if (decomposition) {
         items.push({
           kind: 'message',
@@ -211,7 +263,7 @@ function buildDebateFeed(
         });
       }
       if (i === currentIdx && debate.currentRound > debate.rounds.length) {
-        const activeAgents = Object.entries(debate.agentStatuses).filter(([, s]) => s === 'running');
+        const activeAgents = Object.entries(debate.agentStatuses).filter(([, status]) => status === 'running');
         for (const [name] of activeAgents) {
           const role = agentNameToRole(name);
           if (role) items.push({ kind: 'typing', key: `typing-debate-${role}`, role });

--- a/apps/desktop/src/hooks/useSessionAgent.test.tsx
+++ b/apps/desktop/src/hooks/useSessionAgent.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { SeroSessionInfo, WorkspaceInfo } from '@/types/ipc';
+import { useAgentStore } from '@/stores/agent';
+import { useContainerStore } from '@/stores/container';
+import { useSessionStore } from '@/stores/sessions';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { useSessionAgent } from './useSessionAgent';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const initialAgentState = useAgentStore.getState();
+const initialSessionState = useSessionStore.getState();
+const initialWorkspaceState = useWorkspaceStore.getState();
+const initialContainerState = useContainerStore.getState();
+
+function createSession(overrides: Partial<SeroSessionInfo> = {}): SeroSessionInfo {
+  return {
+    id: 'session-1',
+    path: '/tmp/session-1.jsonl',
+    cwd: '/tmp/workspace-1',
+    workspaceId: 'workspace-1',
+    name: 'Session 1',
+    created: '2026-04-12T00:00:00.000Z',
+    modified: '2026-04-12T00:00:00.000Z',
+    messageCount: 1,
+    firstMessage: 'hello',
+    ...overrides,
+  };
+}
+
+function createWorkspace(overrides: Partial<WorkspaceInfo> = {}): WorkspaceInfo {
+  return {
+    id: 'workspace-1',
+    name: 'Workspace 1',
+    path: '/tmp/workspace-1',
+    open: true,
+    container: false,
+    references: [],
+    mounts: [],
+    roots: [],
+    ...overrides,
+  };
+}
+
+function Harness() {
+  useSessionAgent();
+  return null;
+}
+
+describe('useSessionAgent', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  const getState = vi.fn(async () => null);
+  const ensureContainer = vi.fn(async () => null);
+  const openSession = vi.fn(async () => {});
+  const focusSession = vi.fn();
+  const clearFocus = vi.fn();
+  const hydrateCollaborationState = vi.fn();
+  const loadSessions = vi.fn(async () => {});
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getState.mockClear();
+    ensureContainer.mockClear();
+    openSession.mockClear();
+    focusSession.mockClear();
+    clearFocus.mockClear();
+    hydrateCollaborationState.mockClear();
+    loadSessions.mockClear();
+
+    useAgentStore.setState(initialAgentState, true);
+    useSessionStore.setState(initialSessionState, true);
+    useWorkspaceStore.setState(initialWorkspaceState, true);
+    useContainerStore.setState(initialContainerState, true);
+
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      writable: true,
+      value: {
+        collaboration: {
+          getState,
+          onEvent: vi.fn(() => () => {}),
+          prompt: vi.fn(async () => undefined),
+        },
+        container: {
+          ensure: ensureContainer,
+        },
+      } as unknown as typeof window.sero,
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+    Reflect.deleteProperty(window, 'sero');
+    useAgentStore.setState(initialAgentState, true);
+    useSessionStore.setState(initialSessionState, true);
+    useWorkspaceStore.setState(initialWorkspaceState, true);
+    useContainerStore.setState(initialContainerState, true);
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+  });
+
+  it('does not resync collaboration state after idle-triggered session list refreshes', async () => {
+    const initialSession = createSession();
+    const refreshedSession = createSession({
+      modified: '2026-04-12T00:05:00.000Z',
+      name: 'Session 1 (renamed)',
+    });
+
+    loadSessions.mockImplementation(async () => {
+      useSessionStore.setState({ sessions: [refreshedSession] });
+    });
+
+    useWorkspaceStore.setState({
+      workspaces: [createWorkspace()],
+      activeWorkspaceId: 'workspace-1',
+    });
+    useSessionStore.setState({
+      sessions: [initialSession],
+      activeSessionId: initialSession.id,
+      loadSessions,
+    });
+    useAgentStore.setState({
+      agents: {
+        [initialSession.id]: {
+          sessionId: initialSession.id,
+          sessionPath: initialSession.path,
+          workspaceId: initialSession.workspaceId,
+          messages: [],
+          isStreaming: true,
+          error: null,
+          commands: [],
+          modelState: null,
+        },
+      },
+      openSession,
+      focusSession,
+      clearFocus,
+      hydrateCollaborationState,
+    });
+
+    await act(async () => {
+      root?.render(<Harness />);
+    });
+
+    await vi.waitFor(() => {
+      expect(getState).toHaveBeenCalledTimes(1);
+    });
+    expect(focusSession).toHaveBeenCalledTimes(1);
+    expect(openSession).not.toHaveBeenCalled();
+    expect(hydrateCollaborationState).toHaveBeenCalledTimes(1);
+    expect(ensureContainer).not.toHaveBeenCalled();
+
+    await act(async () => {
+      useAgentStore.setState((state) => ({
+        agents: {
+          ...state.agents,
+          [initialSession.id]: {
+            ...state.agents[initialSession.id],
+            isStreaming: false,
+          },
+        },
+      }));
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(220);
+    });
+
+    expect(loadSessions).toHaveBeenCalledTimes(1);
+    expect(getState).toHaveBeenCalledTimes(1);
+    expect(hydrateCollaborationState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/hooks/useWorkspaceFiles.test.tsx
+++ b/apps/desktop/src/hooks/useWorkspaceFiles.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import {
+  resetWorkspaceFilesCacheForTests,
+  useWorkspaceFiles,
+} from './useWorkspaceFiles';
+import { resetWorkspaceFiletreeWatchRefsForTests } from './workspace-filetree-subscription';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useWorkspaceFiles', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+  let onChangedHandler:
+    | ((data: { workspaceId: string; directories: string[] }) => void)
+    | null = null;
+  let latestFiles: string[] = [];
+  let latestIsLoading = false;
+
+  const exec = vi.fn<
+    (workspaceId: string, command: string) => Promise<{ stdout: string }>
+  >();
+  const watch = vi.fn(async () => {});
+  const unwatch = vi.fn(async () => {});
+  const unsubscribe = vi.fn();
+  const onChanged = vi.fn((callback: (data: { workspaceId: string; directories: string[] }) => void) => {
+    onChangedHandler = callback;
+    return unsubscribe;
+  });
+
+  function Harness({ workspaceId }: { workspaceId: string | null }) {
+    const { files, isLoading } = useWorkspaceFiles(workspaceId);
+    latestFiles = files;
+    latestIsLoading = isLoading;
+    return null;
+  }
+
+  async function emitChange(workspaceId: string): Promise<void> {
+    await act(async () => {
+      onChangedHandler?.({ workspaceId, directories: ['/workspace/src'] });
+      await Promise.resolve();
+    });
+  }
+
+  beforeEach(() => {
+    exec.mockReset();
+    watch.mockReset();
+    unwatch.mockReset();
+    unsubscribe.mockReset();
+    onChanged.mockClear();
+    onChangedHandler = null;
+    latestFiles = [];
+    latestIsLoading = false;
+    resetWorkspaceFilesCacheForTests();
+    resetWorkspaceFiletreeWatchRefsForTests();
+
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      writable: true,
+      value: {
+        editor: {
+          exec,
+        },
+        filetree: {
+          watch,
+          unwatch,
+          onChanged,
+        },
+      } as unknown as typeof window.sero,
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+    Reflect.deleteProperty(window, 'sero');
+    resetWorkspaceFilesCacheForTests();
+    resetWorkspaceFiletreeWatchRefsForTests();
+  });
+
+  it('reloads the cached file list immediately after create, rename, and delete events', async () => {
+    exec
+      .mockResolvedValueOnce({ stdout: './src/a.ts\n' })
+      .mockResolvedValueOnce({ stdout: './src/a.ts\n./src/b.ts\n' })
+      .mockResolvedValueOnce({ stdout: './src/a.ts\n./src/c.ts\n' })
+      .mockResolvedValueOnce({ stdout: './src/c.ts\n' });
+
+    await act(async () => {
+      root?.render(<Harness workspaceId="ws-1" />);
+    });
+
+    await vi.waitFor(() => {
+      expect(latestFiles).toEqual(['src/a.ts']);
+    });
+    expect(watch).toHaveBeenCalledWith('ws-1');
+
+    await emitChange('ws-1');
+    await vi.waitFor(() => {
+      expect(latestFiles).toEqual(['src/a.ts', 'src/b.ts']);
+    });
+
+    await emitChange('ws-1');
+    await vi.waitFor(() => {
+      expect(latestFiles).toEqual(['src/a.ts', 'src/c.ts']);
+    });
+
+    await emitChange('ws-1');
+    await vi.waitFor(() => {
+      expect(latestFiles).toEqual(['src/c.ts']);
+    });
+
+    expect(exec).toHaveBeenCalledTimes(4);
+    expect(latestIsLoading).toBe(false);
+  });
+
+  it('ignores filetree events for other workspaces', async () => {
+    exec.mockResolvedValueOnce({ stdout: './src/a.ts\n' });
+
+    await act(async () => {
+      root?.render(<Harness workspaceId="ws-1" />);
+    });
+
+    await vi.waitFor(() => {
+      expect(latestFiles).toEqual(['src/a.ts']);
+    });
+
+    await emitChange('ws-2');
+
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up the filetree subscription and watch on unmount', async () => {
+    exec.mockResolvedValueOnce({ stdout: './src/a.ts\n' });
+
+    await act(async () => {
+      root?.render(<Harness workspaceId="ws-1" />);
+    });
+
+    await vi.waitFor(() => {
+      expect(latestFiles).toEqual(['src/a.ts']);
+    });
+
+    await act(async () => {
+      root?.unmount();
+    });
+    root = null;
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(unwatch).toHaveBeenCalledWith('ws-1');
+  });
+});

--- a/apps/desktop/src/hooks/useWorkspaceFiles.ts
+++ b/apps/desktop/src/hooks/useWorkspaceFiles.ts
@@ -5,7 +5,16 @@
  * Used by the FileReferenceMenu (@-mention) and Tab path completion.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  type MutableRefObject,
+} from 'react';
+import {
+  retainWorkspaceFiletreeWatch,
+} from '@/hooks/workspace-filetree-subscription';
 
 /** Directories excluded from file search results. */
 const EXCLUDED_DIRS = [
@@ -36,6 +45,10 @@ interface WorkspaceFileCacheEntry {
   files: string[];
   ts: number;
   lastAccessedAt: number;
+}
+
+interface LoadWorkspaceFilesOptions {
+  bypassCache?: boolean;
 }
 
 /** Simple in-memory cache keyed by workspaceId. */
@@ -75,59 +88,110 @@ function clearCachedFiles(workspaceId: string): void {
   cache.delete(workspaceId);
 }
 
-export function useWorkspaceFiles(workspaceId: string | null) {
-  const [files, setFiles] = useState<string[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const abortRef = useRef(0);
-
-  const loadFiles = useCallback(async () => {
-    if (!workspaceId) {
-      setFiles([]);
-      setIsLoading(false);
-      return;
-    }
-
+async function loadWorkspaceFiles(
+  workspaceId: string,
+  abortGeneration: number,
+  abortRef: MutableRefObject<number>,
+  setFiles: (files: string[]) => void,
+  setIsLoading: (loading: boolean) => void,
+  options: LoadWorkspaceFilesOptions = {},
+): Promise<void> {
+  if (!options.bypassCache) {
     const cachedFiles = getCachedFiles(workspaceId);
     if (cachedFiles) {
       setFiles(cachedFiles);
       setIsLoading(false);
       return;
     }
+  }
 
-    const gen = ++abortRef.current;
-    setIsLoading(true);
-    try {
-      const pruneArgs = EXCLUDED_DIRS.map((dir) => `-name '${dir}' -prune`).join(' -o ');
-      const command = `find . \\( ${pruneArgs} \\) -o -type f -print | head -${MAX_FILES} | sort`;
-      const { stdout } = await window.sero.editor.exec(workspaceId, command);
+  setIsLoading(true);
+  try {
+    const pruneArgs = EXCLUDED_DIRS.map((dir) => `-name '${dir}' -prune`).join(' -o ');
+    const command = `find . \\( ${pruneArgs} \\) -o -type f -print | head -${MAX_FILES} | sort`;
+    const { stdout } = await window.sero.editor.exec(workspaceId, command);
 
-      if (gen !== abortRef.current) return;
+    if (abortGeneration !== abortRef.current) return;
 
-      const paths = stdout
-        .split('\n')
-        .filter(Boolean)
-        .map((path) => (path.startsWith('./') ? path.slice(2) : path));
+    const paths = stdout
+      .split('\n')
+      .filter(Boolean)
+      .map((path) => (path.startsWith('./') ? path.slice(2) : path));
 
-      setCachedFiles(workspaceId, paths);
-      setFiles(paths);
-    } catch (err) {
-      console.warn('[useWorkspaceFiles] Failed to load files:', err);
-      clearCachedFiles(workspaceId);
-      if (gen === abortRef.current) {
+    setCachedFiles(workspaceId, paths);
+    setFiles(paths);
+  } catch (error) {
+    console.warn('[useWorkspaceFiles] Failed to load files:', error);
+    clearCachedFiles(workspaceId);
+    if (abortGeneration === abortRef.current) {
+      setFiles([]);
+    }
+  }
+
+  if (abortGeneration === abortRef.current) {
+    setIsLoading(false);
+  }
+}
+
+export function useWorkspaceFiles(workspaceId: string | null) {
+  const [files, setFiles] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef(0);
+
+  const loadFiles = useCallback(
+    async (options: LoadWorkspaceFilesOptions = {}) => {
+      if (!workspaceId) {
+        abortRef.current += 1;
         setFiles([]);
+        setIsLoading(false);
+        return;
       }
-    }
 
-    if (gen === abortRef.current) {
-      setIsLoading(false);
-    }
-  }, [workspaceId]);
+      const generation = ++abortRef.current;
+      await loadWorkspaceFiles(
+        workspaceId,
+        generation,
+        abortRef,
+        setFiles,
+        setIsLoading,
+        options,
+      );
+    },
+    [workspaceId],
+  );
 
   useEffect(() => {
     void loadFiles();
   }, [loadFiles]);
 
-  return { files, isLoading, refresh: loadFiles };
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    const releaseWatch = retainWorkspaceFiletreeWatch(workspaceId);
+    const unsubscribe = window.sero.filetree.onChanged((data) => {
+      if (data.workspaceId !== workspaceId) return;
+      clearCachedFiles(workspaceId);
+      void loadFiles({ bypassCache: true });
+    });
+
+    return () => {
+      unsubscribe();
+      releaseWatch();
+    };
+  }, [loadFiles, workspaceId]);
+
+  const refresh = useCallback(async () => {
+    if (workspaceId) {
+      clearCachedFiles(workspaceId);
+    }
+    await loadFiles({ bypassCache: true });
+  }, [loadFiles, workspaceId]);
+
+  return { files, isLoading, refresh };
+}
+
+export function resetWorkspaceFilesCacheForTests(): void {
+  cache.clear();
 }
 
 // ── Fuzzy matching ──────────────────────────────────────────────
@@ -149,7 +213,6 @@ export function fuzzyMatchFiles(
   limit = 20,
 ): FuzzyMatch[] {
   if (!query) {
-    // No query — return first `limit` files
     return files.slice(0, limit).map((path) => ({
       path,
       score: 0,
@@ -182,32 +245,26 @@ function scorePath(
     if (lowerPath[pi] === lowerQuery[qi]) {
       matchIndices.push(pi);
 
-      // Bonus for matching at word boundaries
       if (pi === 0 || '/._-'.includes(lowerPath[pi - 1])) {
         score += 10;
       }
 
-      // Bonus for consecutive matches
       if (matchIndices.length > 1 && matchIndices[matchIndices.length - 2] === pi - 1) {
         score += 5;
       }
 
-      // Base match score
       score += 1;
       qi++;
     }
   }
 
-  // All query chars must match
   if (qi < lowerQuery.length) return null;
 
-  // Bonus for filename match (last segment)
   const filename = path.split('/').pop() ?? path;
   if (filename.toLowerCase().includes(lowerQuery)) {
     score += 20;
   }
 
-  // Penalize longer paths slightly
   score -= path.length * 0.1;
 
   return { path, score, matchIndices };

--- a/apps/desktop/src/hooks/workspace-filetree-subscription.ts
+++ b/apps/desktop/src/hooks/workspace-filetree-subscription.ts
@@ -8,6 +8,10 @@ function releaseWorkspaceWatch(workspaceId: string): void {
   void window.sero.filetree.unwatch(workspaceId);
 }
 
+export function hasWorkspaceFiletreeWatch(workspaceId: string): boolean {
+  return workspaceWatchRefCounts.has(workspaceId);
+}
+
 export function retainWorkspaceFiletreeWatch(workspaceId: string): () => void {
   const nextRefCount = (workspaceWatchRefCounts.get(workspaceId) ?? 0) + 1;
   workspaceWatchRefCounts.set(workspaceId, nextRefCount);

--- a/apps/desktop/src/hooks/workspace-filetree-subscription.ts
+++ b/apps/desktop/src/hooks/workspace-filetree-subscription.ts
@@ -1,0 +1,40 @@
+const workspaceWatchRefCounts = new Map<string, number>();
+
+function ensureWorkspaceWatch(workspaceId: string): void {
+  void window.sero.filetree.watch(workspaceId);
+}
+
+function releaseWorkspaceWatch(workspaceId: string): void {
+  void window.sero.filetree.unwatch(workspaceId);
+}
+
+export function retainWorkspaceFiletreeWatch(workspaceId: string): () => void {
+  const nextRefCount = (workspaceWatchRefCounts.get(workspaceId) ?? 0) + 1;
+  workspaceWatchRefCounts.set(workspaceId, nextRefCount);
+
+  if (nextRefCount === 1) {
+    ensureWorkspaceWatch(workspaceId);
+  }
+
+  return () => {
+    const currentRefCount = workspaceWatchRefCounts.get(workspaceId);
+    if (!currentRefCount) return;
+
+    if (currentRefCount === 1) {
+      workspaceWatchRefCounts.delete(workspaceId);
+      releaseWorkspaceWatch(workspaceId);
+      return;
+    }
+
+    workspaceWatchRefCounts.set(workspaceId, currentRefCount - 1);
+  };
+}
+
+export function refreshWorkspaceFiletreeWatch(workspaceId: string): void {
+  if (!workspaceWatchRefCounts.has(workspaceId)) return;
+  ensureWorkspaceWatch(workspaceId);
+}
+
+export function resetWorkspaceFiletreeWatchRefsForTests(): void {
+  workspaceWatchRefCounts.clear();
+}

--- a/apps/desktop/src/stores/agent-collaboration-runtime.ts
+++ b/apps/desktop/src/stores/agent-collaboration-runtime.ts
@@ -1,0 +1,136 @@
+import type {
+  CollaborationEvent,
+  CollaborationStateSnapshot,
+} from '@/types/collaboration';
+import type { AgentState } from '@/stores/agent-types';
+import {
+  applyCollaborationEvent,
+  hydrateCollaborationSessionForRenderer,
+  setCollaborationErrorForSession,
+  startCollaborationForSession,
+} from '@/stores/agent-collaboration';
+
+type SetFn = (
+  fn: (state: AgentState) => Partial<AgentState> | AgentState,
+) => void;
+
+type GetFn = () => AgentState;
+
+function isCollaborationBusyStatus(
+  status: CollaborationStateSnapshot['status'],
+): boolean {
+  return status !== 'idle' && status !== 'complete' && status !== 'error';
+}
+
+export async function sendCollaborationPromptWithState(
+  set: SetFn,
+  get: GetFn,
+  sessionId: string,
+  text: string,
+): Promise<void> {
+  const agent = get().agents[sessionId];
+  if (!agent) return;
+
+  const collabState = get().collaborations[sessionId];
+  const strategy = collabState?.strategy ?? 'standard';
+  const debateConfig = collabState?.debateConfig;
+
+  set((state) => ({
+    collaborations: startCollaborationForSession(
+      state.collaborations,
+      sessionId,
+      text,
+    ),
+    agents: {
+      ...state.agents,
+      [sessionId]: {
+        ...state.agents[sessionId],
+        error: null,
+        isStreaming: true,
+      },
+    },
+  }));
+
+  try {
+    await window.sero.collaboration.prompt(sessionId, agent.workspaceId, text, {
+      strategy,
+      debate: strategy === 'debate' ? debateConfig : undefined,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Collaboration failed';
+    set((state) => ({
+      collaborations: setCollaborationErrorForSession(state.collaborations, sessionId),
+      agents: {
+        ...state.agents,
+        [sessionId]: {
+          ...state.agents[sessionId],
+          error: message,
+          isStreaming: false,
+        },
+      },
+    }));
+  }
+}
+
+export function hydrateCollaborationStateWithSnapshot(
+  set: SetFn,
+  sessionId: string,
+  snapshot: CollaborationStateSnapshot | null,
+): void {
+  if (!snapshot) return;
+
+  set((state) => {
+    const agent = state.agents[sessionId];
+    if (!agent) return state;
+
+    const collaborationBusy = isCollaborationBusyStatus(snapshot.status);
+    return {
+      collaborations: hydrateCollaborationSessionForRenderer(
+        state.collaborations,
+        sessionId,
+        snapshot,
+      ),
+      agents: {
+        ...state.agents,
+        [sessionId]: {
+          ...agent,
+          error: snapshot.error ?? (collaborationBusy ? null : agent.error),
+          isStreaming: agent.isStreaming || collaborationBusy,
+        },
+      },
+    };
+  });
+}
+
+export function reduceCollaborationEventState(
+  state: AgentState,
+  event: CollaborationEvent,
+): Pick<AgentState, 'agents' | 'collaborations'> {
+  const agent = state.agents[event.sessionId];
+  let agents = state.agents;
+
+  if (agent && event.type === 'collab_start') {
+    agents = {
+      ...state.agents,
+      [event.sessionId]: {
+        ...agent,
+        error: null,
+        isStreaming: true,
+      },
+    };
+  } else if (agent && event.type === 'collab_error') {
+    agents = {
+      ...state.agents,
+      [event.sessionId]: {
+        ...agent,
+        error: event.error,
+        isStreaming: false,
+      },
+    };
+  }
+
+  return {
+    agents,
+    collaborations: applyCollaborationEvent(state.collaborations, event),
+  };
+}

--- a/apps/desktop/src/stores/agent-collaboration.ts
+++ b/apps/desktop/src/stores/agent-collaboration.ts
@@ -137,6 +137,7 @@ export function hydrateCollaborationSessionForRenderer(
 export function startCollaborationForSession(
   collaborations: CollaborationSessionMap,
   sessionId: string,
+  pendingUserQuery: string,
 ): CollaborationSessionMap {
   const current = getSessionState(collaborations, sessionId);
   return {
@@ -148,6 +149,7 @@ export function startCollaborationForSession(
       result: null,
       specialists: [],
       error: null,
+      pendingUserQuery: pendingUserQuery.trim() || pendingUserQuery,
       debate: current.strategy === 'debate'
         ? {
             phase: 'decomposition',
@@ -300,6 +302,7 @@ export function applyCollaborationEvent(
           ...current,
           status: 'complete',
           result: event.result,
+          pendingUserQuery: null,
           error: null,
         },
       };

--- a/apps/desktop/src/stores/agent-selectors.ts
+++ b/apps/desktop/src/stores/agent-selectors.ts
@@ -67,6 +67,14 @@ export function useFocusedCollaborationStrategy() {
   );
 }
 
+export function useFocusedCollaborationPendingUserQuery() {
+  return useAgentStore((s) =>
+    s.focusedSessionId
+      ? (s.collaborations[s.focusedSessionId]?.pendingUserQuery ?? null)
+      : null,
+  );
+}
+
 export function useFocusedDebateState() {
   return useAgentStore((s) =>
     s.focusedSessionId ? (s.collaborations[s.focusedSessionId]?.debate ?? null) : null,

--- a/apps/desktop/src/stores/agent-utils.ts
+++ b/apps/desktop/src/stores/agent-utils.ts
@@ -228,7 +228,26 @@ export function handleAgentStreamEvent(
       break;
 
     case 'message_start':
-      if (event.message.type === 'user') break;
+      if (event.message.type === 'user') {
+        set((state) => {
+          const agent = state.agents[sid];
+          if (!agent) return state;
+          const alreadyPresent = agent.messages.some(
+            (message) => message.type === 'user' && message.id === event.message.id,
+          );
+          if (alreadyPresent) return state;
+          return {
+            agents: {
+              ...state.agents,
+              [sid]: {
+                ...agent,
+                messages: [...agent.messages, event.message],
+              },
+            },
+          };
+        });
+        break;
+      }
       {
         // Attach any pending memory context to the new assistant message
         let message = event.message;

--- a/apps/desktop/src/stores/agent.test.ts
+++ b/apps/desktop/src/stores/agent.test.ts
@@ -44,6 +44,9 @@ describe('useAgentStore', () => {
   const prompt = vi.fn<
     (sessionId: string, text: string, attachments?: unknown, clientMessageId?: string) => Promise<void>
   >();
+  const collaborationPrompt = vi.fn<
+    (sessionId: string, workspaceId: string, text: string, config?: unknown) => Promise<void>
+  >();
   const onCollaborationEvent = vi.fn<
     (callback: (event: CollaborationEvent) => void) => () => void
   >();
@@ -54,11 +57,13 @@ describe('useAgentStore', () => {
     getCommands.mockReset();
     getModelState.mockReset();
     prompt.mockReset();
+    collaborationPrompt.mockReset();
     onCollaborationEvent.mockReset();
     collaborationListener = null;
 
     getCommands.mockResolvedValue([]);
     getModelState.mockResolvedValue(null);
+    collaborationPrompt.mockResolvedValue();
     onCollaborationEvent.mockImplementation((callback) => {
       collaborationListener = callback;
       return () => {
@@ -74,6 +79,7 @@ describe('useAgentStore', () => {
         prompt,
       },
       collaboration: {
+        prompt: collaborationPrompt,
         onEvent: onCollaborationEvent,
       },
     };
@@ -148,7 +154,48 @@ describe('useAgentStore', () => {
     ]);
   });
 
-  it('rehydrates the active collaboration prompt even if an older turn used the same text', () => {
+  it('keeps pending collaboration queries in collaboration state instead of chat history', async () => {
+    useAgentStore.setState((state) => ({
+      ...state,
+      focusedSessionId: 'session-1',
+      agents: {
+        'session-1': {
+          sessionId: 'session-1',
+          sessionPath: '/tmp/session-1.jsonl',
+          workspaceId: 'workspace-1',
+          messages: [
+            { type: 'user', id: 'old-user', text: 'older question' },
+          ],
+          isStreaming: false,
+          error: null,
+          commands: [],
+          modelState: null,
+        },
+      },
+    }));
+
+    await useAgentStore.getState().sendCollaborationPrompt('session-1', 'repeat question');
+
+    const agent = useAgentStore.getState().agents['session-1'];
+    expect(agent?.messages).toEqual([
+      expect.objectContaining({ type: 'user', text: 'older question' }),
+    ]);
+    expect(agent?.isStreaming).toBe(true);
+    expect(useAgentStore.getState().collaborations['session-1']?.pendingUserQuery).toBe(
+      'repeat question',
+    );
+    expect(collaborationPrompt).toHaveBeenCalledWith(
+      'session-1',
+      'workspace-1',
+      'repeat question',
+      {
+        strategy: 'standard',
+        debate: undefined,
+      },
+    );
+  });
+
+  it('rehydrates collaboration snapshots without synthetic placeholder messages', () => {
     useAgentStore.setState((state) => ({
       ...state,
       focusedSessionId: 'session-1',
@@ -178,35 +225,24 @@ describe('useAgentStore', () => {
     useAgentStore.getState().hydrateCollaborationState('session-1', snapshot);
     useAgentStore.getState().hydrateCollaborationState('session-1', snapshot);
 
-    const messages = useAgentStore.getState().agents['session-1']?.messages ?? [];
-    expect(messages).toHaveLength(3);
-    expect(messages.at(-1)).toEqual(
-      expect.objectContaining({ type: 'user', text: 'repeat question' }),
+    const agent = useAgentStore.getState().agents['session-1'];
+    expect(agent?.messages).toHaveLength(2);
+    expect(useAgentStore.getState().collaborations['session-1']?.pendingUserQuery).toBe(
+      'repeat question',
     );
   });
 
-  it('does not append duplicate collaboration placeholders after follow-up assistant messages', () => {
+  it('drops pending collaboration queries once a completed snapshot arrives', () => {
     useAgentStore.setState((state) => ({
       ...state,
+      focusedSessionId: 'session-1',
       agents: {
         'session-1': {
           sessionId: 'session-1',
           sessionPath: '/tmp/session-1.jsonl',
           workspaceId: 'workspace-1',
-          messages: [
-            {
-              type: 'user',
-              id: 'collab-pending-session-1',
-              text: 'repeat question',
-            },
-            {
-              type: 'assistant',
-              id: 'assistant-1',
-              text: 'Synthesized answer',
-              isStreaming: false,
-            },
-          ],
-          isStreaming: false,
+          messages: [],
+          isStreaming: true,
           error: null,
           commands: [],
           modelState: null,
@@ -214,16 +250,12 @@ describe('useAgentStore', () => {
       },
     }));
 
-    const snapshot = createSnapshot({ status: 'complete' });
-    useAgentStore.getState().hydrateCollaborationState('session-1', snapshot);
+    useAgentStore.getState().hydrateCollaborationState(
+      'session-1',
+      createSnapshot({ status: 'complete', pendingUserQuery: null }),
+    );
 
-    const messages = useAgentStore.getState().agents['session-1']?.messages ?? [];
-    expect(
-      messages.filter(
-        (message) =>
-          message.type === 'user' && message.id === 'collab-pending-session-1',
-      ),
-    ).toHaveLength(1);
+    expect(useAgentStore.getState().collaborations['session-1']?.pendingUserQuery).toBeNull();
   });
 
   it('restores collaboration errors from snapshots and live events', () => {

--- a/apps/desktop/src/stores/agent.ts
+++ b/apps/desktop/src/stores/agent.ts
@@ -11,15 +11,16 @@ import type {
   DebateConfig,
 } from '@/types/collaboration';
 import {
-  applyCollaborationEvent,
-  hydrateCollaborationSessionForRenderer,
   removeCollaborationSession,
-  setCollaborationErrorForSession,
   setCollaborationStrategyForSession,
   setDebateConfigForSession,
-  startCollaborationForSession,
   toggleCollaborationModeForSession,
 } from '@/stores/agent-collaboration';
+import {
+  hydrateCollaborationStateWithSnapshot,
+  reduceCollaborationEventState,
+  sendCollaborationPromptWithState,
+} from '@/stores/agent-collaboration-runtime';
 import type { AgentState } from '@/stores/agent-types';
 import {
   appendOptimisticUserMessage,
@@ -309,94 +310,14 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     }),
 
   sendCollaborationPrompt: async (sessionId, text) => {
-    const agent = get().agents[sessionId];
-    if (!agent) return;
-
-    // Read current strategy + config before resetting state
-    const collabState = get().collaborations[sessionId];
-    const strategy = collabState?.strategy ?? 'standard';
-    const debateConfig = collabState?.debateConfig;
-
-    appendOptimisticUserMessage(set, sessionId, text, { isStreaming: true });
-    set((s) => ({
-      collaborations: startCollaborationForSession(s.collaborations, sessionId),
-    }));
-
-    try {
-      await window.sero.collaboration.prompt(sessionId, agent.workspaceId, text, {
-        strategy,
-        debate: strategy === 'debate' ? debateConfig : undefined,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Collaboration failed';
-      set((s) => ({
-        collaborations: setCollaborationErrorForSession(s.collaborations, sessionId),
-        agents: {
-          ...s.agents,
-          [sessionId]: {
-            ...s.agents[sessionId],
-            error: message,
-            isStreaming: false,
-          },
-        },
-      }));
-    }
+    await sendCollaborationPromptWithState(set, get, sessionId, text);
   },
 
   hydrateCollaborationState: (
     sessionId: string,
     snapshot: CollaborationStateSnapshot | null,
   ) => {
-    if (!snapshot) return;
-
-    set((s) => {
-      const agent = s.agents[sessionId];
-      if (!agent) return s;
-
-      const pendingUserQuery = snapshot.pendingUserQuery?.trim() ?? '';
-      const pendingPlaceholderId = `collab-pending-${sessionId}`;
-      const lastMessage = agent.messages[agent.messages.length - 1];
-      const hasPendingUserMessage =
-        lastMessage?.type === 'user' &&
-        lastMessage.text.trim() === pendingUserQuery;
-      const hasPendingPlaceholder = agent.messages.some(
-        (message) => message.type === 'user' && message.id === pendingPlaceholderId,
-      );
-      const shouldAppendPendingUser =
-        pendingUserQuery.length > 0 &&
-        !hasPendingUserMessage &&
-        !hasPendingPlaceholder;
-      const collaborationBusy =
-        snapshot.status !== 'idle' &&
-        snapshot.status !== 'complete' &&
-        snapshot.status !== 'error';
-
-      return {
-        collaborations: hydrateCollaborationSessionForRenderer(
-          s.collaborations,
-          sessionId,
-          snapshot,
-        ),
-        agents: {
-          ...s.agents,
-          [sessionId]: {
-            ...agent,
-            error: snapshot.error ?? (collaborationBusy ? null : agent.error),
-            isStreaming: agent.isStreaming || collaborationBusy,
-            messages: shouldAppendPendingUser
-              ? [
-                  ...agent.messages,
-                  {
-                    type: 'user',
-                    id: pendingPlaceholderId,
-                    text: pendingUserQuery,
-                  },
-                ]
-              : agent.messages,
-          },
-        },
-      };
-    });
+    hydrateCollaborationStateWithSnapshot(set, sessionId, snapshot);
   },
 
   initEventListener: () => {
@@ -433,35 +354,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   initCollaborationListener: () => {
     return window.sero.collaboration.onEvent((event: CollaborationEvent) => {
-      set((s) => {
-        const agent = s.agents[event.sessionId];
-        let agents = s.agents;
-
-        if (agent && event.type === 'collab_start') {
-          agents = {
-            ...s.agents,
-            [event.sessionId]: {
-              ...agent,
-              error: null,
-              isStreaming: true,
-            },
-          };
-        } else if (agent && event.type === 'collab_error') {
-          agents = {
-            ...s.agents,
-            [event.sessionId]: {
-              ...agent,
-              error: event.error,
-              isStreaming: false,
-            },
-          };
-        }
-
-        return {
-          agents,
-          collaborations: applyCollaborationEvent(s.collaborations, event),
-        };
-      });
+      set((state) => reduceCollaborationEventState(state, event));
     });
   },
 }));

--- a/docs/plans/2026-04-12-pr-137-followups.md
+++ b/docs/plans/2026-04-12-pr-137-followups.md
@@ -1,6 +1,6 @@
 ---
 title: PR 137 Follow-ups — Model Refresh, Collaboration State, and Desktop Hardening
-status: todo
+status: done
 date: 2026-04-12
 author: OpenAI
 related:
@@ -43,46 +43,46 @@ Turn the current local fixes into clearer subsystem invariants:
 ## Progress checklist
 
 ### Model refresh and live-session consistency
-- [ ] Task 1 — Centralize model-availability refresh propagation
-  - [ ] Define one explicit flow for “auth/models changed”
-  - [ ] Refresh shared default-model selection and reconcile live chat sessions
-  - [ ] Reconcile live app-agent sessions without waiting for ad hoc reuse paths
-  - [ ] Cover auth change + local-model change regressions with tests
+- [x] Task 1 — Centralize model-availability refresh propagation
+  - [x] Define one explicit flow for “auth/models changed”
+  - [x] Refresh shared default-model selection and reconcile live chat sessions
+  - [x] Reconcile live app-agent sessions without waiting for ad hoc reuse paths
+  - [x] Cover auth change + local-model change regressions with tests
 
 ### Collaboration state cleanup
-- [ ] Task 2 — Stop representing collaboration pending state as synthetic chat messages
-  - [ ] Move pending collaboration query/rendering to collaboration UI state
-  - [ ] Remove placeholder-message append/dedupe rules from the agent store
-  - [ ] Ensure collaboration rehydration remains stable across reload/refocus
+- [x] Task 2 — Stop representing collaboration pending state as synthetic chat messages
+  - [x] Move pending collaboration query/rendering to collaboration UI state
+  - [x] Remove placeholder-message append/dedupe rules from the agent store
+  - [x] Ensure collaboration rehydration remains stable across reload/refocus
 
 ### Store and orchestration simplification
-- [ ] Task 3 — Split desktop agent store responsibilities one more level
-  - [ ] Extract collaboration hydration/send helpers out of `src/stores/agent.ts`
-  - [ ] Reduce cross-cutting coupling between session focus, collaboration, and prompt dispatch
-  - [ ] Leave `agent.ts` meaningfully smaller and easier to scan
+- [x] Task 3 — Split desktop agent store responsibilities one more level
+  - [x] Extract collaboration hydration/send helpers out of `src/stores/agent.ts`
+  - [x] Reduce cross-cutting coupling between session focus, collaboration, and prompt dispatch
+  - [x] Leave `agent.ts` meaningfully smaller and easier to scan
 
 ### Regression coverage at refactor seams
-- [ ] Task 4 — Add seam-level regression coverage for desktop orchestration and bridge refactors
-  - [ ] Add auth/model-refresh coverage for reused app-agent sessions
-  - [ ] Add active-session sync coverage through the real hook chain
-  - [ ] Add a preload bridge/API smoke test for critical subscribe/unsubscribe paths
+- [x] Task 4 — Add seam-level regression coverage for desktop orchestration and bridge refactors
+  - [x] Add auth/model-refresh coverage for reused app-agent sessions
+  - [x] Add active-session sync coverage through the real hook chain
+  - [x] Add a preload bridge/API smoke test for critical subscribe/unsubscribe paths
 
 ### Workspace file cache correctness
-- [ ] Task 5 — Make workspace file-list invalidation event-driven
-  - [ ] Invalidate cached file lists on relevant filetree events
-  - [ ] Keep TTL as a fallback, not the primary correctness mechanism
-  - [ ] Add regression coverage for stale file-list behavior after create/rename/delete
+- [x] Task 5 — Make workspace file-list invalidation event-driven
+  - [x] Invalidate cached file lists on relevant filetree events
+  - [x] Keep TTL as a fallback, not the primary correctness mechanism
+  - [x] Add regression coverage for stale file-list behavior after create/rename/delete
 
 ### Architecture polish
-- [ ] Task 6 — Move app-agent model-sync logic out of the IPC handler module
-  - [ ] Extract the reused-session model-sync helper into a dedicated core/service module
-  - [ ] Keep the IPC handler focused on request wiring rather than policy logic
-  - [ ] Keep coverage at the extracted-module level
+- [x] Task 6 — Move app-agent model-sync logic out of the IPC handler module
+  - [x] Extract the reused-session model-sync helper into a dedicated core/service module
+  - [x] Keep the IPC handler focused on request wiring rather than policy logic
+  - [x] Keep coverage at the extracted-module level
 
 ### Final validation
-- [ ] Run targeted tests for changed desktop agent/store/hook behavior
-- [ ] Run `pnpm typecheck`
-- [ ] Update this checklist as tasks land
+- [x] Run targeted tests for changed desktop agent/store/hook behavior
+- [x] Run `pnpm typecheck`
+- [x] Update this checklist as tasks land
 
 ---
 

--- a/docs/plans/apps-desktop-deslopify-tasklist.md
+++ b/docs/plans/apps-desktop-deslopify-tasklist.md
@@ -117,18 +117,18 @@ Core-first checklist for reviewing and cleaning up `apps/desktop` without losing
   - Debounce session-list refresh after agent idle transitions
   - Add bounded workspace-file cache eviction in `apps/desktop/src/hooks/useWorkspaceFiles.ts`
   - Deduplicate optimistic user-message enqueue + add explicit session-buffer teardown in `apps/desktop/src/stores/agent{,-utils}.ts`
-- [ ] **Wave E3 — Canonical cross-process type cleanup**
+- [x] **Wave E3 — Canonical cross-process type cleanup**
   - `fix-slop` Medium items for `apps/desktop/src/types`
   - `fix-slop` Medium items for `apps/desktop/electron/features/profile`
-- [ ] **Wave E4 — Core IPC/runtime cap-pressure relief**
+- [x] **Wave E4 — Core IPC/runtime cap-pressure relief**
   - `fix-slop` Medium items for `apps/desktop/electron/ipc`
   - `fix-slop` Medium items for `apps/desktop/electron/shared`
   - `fix-slop` Medium items for `apps/desktop/electron/features/workspace`
-- [ ] **Wave E5 — Platform/plugin lifecycle cleanup**
+- [x] **Wave E5 — Platform/plugin lifecycle cleanup**
   - `fix-slop` Medium items for `apps/desktop/electron/platform`
   - `fix-slop` Medium items for `apps/desktop/electron/features/plugins`
   - `fix-slop` Medium items for `apps/desktop/electron/features/apps`
-- [ ] **Wave E6 — Feature-level medium cleanup**
+- [x] **Wave E6 — Feature-level medium cleanup**
   - `fix-slop` Medium items for `apps/desktop/electron/features/editor`
   - `fix-slop` Medium items for `apps/desktop/src/lsp`
   - `fix-slop` Medium items for `apps/desktop/src/components/apps/explorer`


### PR DESCRIPTION
unify auth and local-model availability refresh into one reconciliation flow

move pending collaboration query rendering out of synthetic chat messages and into collaboration UI state, with extracted collaboration runtime helpers to simplify the desktop agent store

make workspace file-list invalidation event-driven via filetree updates while keeping TTL-based caching as a fallback

add regression coverage for reused app-agent model sync, active-session orchestration, preload subscribe/unsubscribe bridges, and stale file-list refresh behavior