### PR TITLE
feat(memory): rotate debug logs by day and expose admin controls

### DIFF
--- a/apps/desktop/electron/__tests__/shared/settings/memory-logging-settings.test.ts
+++ b/apps/desktop/electron/__tests__/shared/settings/memory-logging-settings.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ensureConfiguredMemoryLoggingSettings,
+  getDefaultMemoryLoggingSettings,
+} from '@electron/shared/settings/memory-logging-settings';
+
+describe('memory logging settings', () => {
+  it('returns the default memory logging policy', () => {
+    expect(getDefaultMemoryLoggingSettings()).toEqual({
+      maxBytesPerFile: 2 * 1024 * 1024,
+      maxFilesPerDay: 3,
+      retentionDays: 14,
+      maxPayloadChars: 4_096,
+    });
+  });
+
+  it('seeds missing settings.json memory logging defaults', () => {
+    const result = ensureConfiguredMemoryLoggingSettings({ sero: {} });
+
+    expect(result.changed).toBe(true);
+    expect(result.settings).toEqual({
+      sero: {
+        memory: {
+          logging: getDefaultMemoryLoggingSettings(),
+        },
+      },
+    });
+  });
+
+  it('preserves explicit user overrides while filling missing keys', () => {
+    const result = ensureConfiguredMemoryLoggingSettings({
+      sero: {
+        memory: {
+          logging: {
+            retentionDays: 30,
+          },
+        },
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.settings).toEqual({
+      sero: {
+        memory: {
+          logging: {
+            ...getDefaultMemoryLoggingSettings(),
+            retentionDays: 30,
+          },
+        },
+      },
+    });
+  });
+});

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -41,6 +41,7 @@ import {
   ensureConfiguredModelFallbackChain,
   getDefaultModelFallbackChain,
 } from './shared/settings/model-fallback-chain';
+import { getDefaultMemoryLoggingSettings, ensureConfiguredMemoryLoggingSettings } from './shared/settings/memory-logging-settings';
 
 // Register custom protocol BEFORE app.whenReady()
 registerExtProtocolScheme();
@@ -77,6 +78,9 @@ function bootstrapAgentDir(): void {
       sero: {
         modelFallbackChain: getDefaultModelFallbackChain(),
         modelTiers: {},
+        memory: {
+          logging: getDefaultMemoryLoggingSettings(),
+        },
       },
     };
     writeFileSync(settingsPath, JSON.stringify(defaults, null, 2) + '\n');
@@ -109,6 +113,10 @@ function ensureBuiltinPackages(): void {
   const fallbackSettings = ensureConfiguredModelFallbackChain(settings);
   settings = fallbackSettings.settings;
   if (fallbackSettings.changed) changed = true;
+
+  const memoryLoggingSettings = ensureConfiguredMemoryLoggingSettings(settings);
+  settings = memoryLoggingSettings.settings;
+  if (memoryLoggingSettings.changed) changed = true;
   for (const p of workspacePackages) {
     const hasPackagePath = packages.some((entry) =>
       (typeof entry === 'string' ? entry : entry.source) === p,

--- a/apps/desktop/electron/shared/settings/memory-logging-settings.ts
+++ b/apps/desktop/electron/shared/settings/memory-logging-settings.ts
@@ -1,0 +1,46 @@
+import { getSeroSettings } from './settings-helpers';
+
+const DEFAULT_MEMORY_LOGGING_SETTINGS = {
+  maxBytesPerFile: 2 * 1024 * 1024,
+  maxFilesPerDay: 3,
+  retentionDays: 14,
+  maxPayloadChars: 4_096,
+};
+
+function getObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function getDefaultMemoryLoggingSettings(): Record<string, number> {
+  return { ...DEFAULT_MEMORY_LOGGING_SETTINGS };
+}
+
+export function ensureConfiguredMemoryLoggingSettings(settings: Record<string, unknown>): {
+  settings: Record<string, unknown>;
+  changed: boolean;
+} {
+  const sero = getSeroSettings(settings);
+  const memory = getObject(sero.memory);
+  const logging = getObject(memory.logging);
+
+  const nextLogging = {
+    ...DEFAULT_MEMORY_LOGGING_SETTINGS,
+    ...logging,
+  };
+
+  const nextSettings = {
+    ...settings,
+    sero: {
+      ...sero,
+      memory: {
+        ...memory,
+        logging: nextLogging,
+      },
+    },
+  };
+
+  const changed = JSON.stringify(logging) !== JSON.stringify(nextLogging);
+  return { settings: nextSettings, changed };
+}

--- a/docs/features/memory.md
+++ b/docs/features/memory.md
@@ -213,10 +213,45 @@ QMD provides semantic search via the `@tobilu/qmd` SDK (not CLI).
 
 ## Configuration
 
+### Environment
+
 | Env var | Default | Description |
 |---------|---------|-------------|
 | `SERO_HOME` | `~/.sero-ui` | Base directory for all Sero state |
 | `SERO_MEMORY_NO_SEARCH` | unset | Set to `1` to disable QMD selective injection |
+
+### `settings.json`
+
+Memory debug logs now live in `~/.sero-ui/debug/memory/` as daily files:
+
+- `YYYY-MM-DD.log`
+- `YYYY-MM-DD.log.1`
+- `YYYY-MM-DD.log.2`
+- `YYYY-MM-DD.log.3`
+
+Default policy:
+
+- `maxBytesPerFile`: `2097152` (2 MB)
+- `maxFilesPerDay`: `3`
+- `retentionDays`: `14`
+- `maxPayloadChars`: `4096`
+
+Configure it in `~/.sero-ui/agent/settings.json` under `sero.memory.logging`:
+
+```json
+{
+  "sero": {
+    "memory": {
+      "logging": {
+        "maxBytesPerFile": 2097152,
+        "maxFilesPerDay": 3,
+        "retentionDays": 14,
+        "maxPayloadChars": 4096
+      }
+    }
+  }
+}
+```
 
 ## CLI bridge registration
 

--- a/plugins/sero-admin-plugin/shared/types.ts
+++ b/plugins/sero-admin-plugin/shared/types.ts
@@ -53,7 +53,7 @@ export const CONFIG_FILES: ConfigFile[] = [
     key: 'settings',
     label: 'Settings',
     relativePath: 'agent/settings.json',
-    description: 'Default model, provider, thinking level, packages, and Sero skill visibility',
+    description: 'Default model, provider, thinking level, packages, skill visibility, and memory logging policy',
   },
   {
     key: 'auth',

--- a/plugins/sero-admin-plugin/ui/components/ConfigPanel.tsx
+++ b/plugins/sero-admin-plugin/ui/components/ConfigPanel.tsx
@@ -13,6 +13,7 @@ import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { CONFIG_FILES } from '../../shared/types';
 import type { ConfigFile } from '../../shared/types';
 import { useConfigFile } from '../hooks/useConfigFile';
+import { MemoryLoggingSettingsCard } from './MemoryLoggingSettingsCard';
 
 interface ConfigPanelProps {
   profilePath: string | null;
@@ -325,19 +326,29 @@ function ConfigEditor({
             <p className="text-xs text-muted-foreground/50">File not found</p>
           </div>
         ) : (
-          <textarea
-            value={displayContent ?? ''}
-            onChange={(e) => handleEdit(e.target.value)}
-            readOnly={isReadOnly}
-            spellCheck={false}
-            className={cn(
-              'admin-editor w-full min-h-full resize-none bg-transparent',
-              'px-4 py-3 text-[12px] leading-[1.6] text-foreground/90',
-              isReadOnly && 'opacity-60 cursor-default',
-            )}
-            // fieldSizing: 'content' is Chromium-only (Chrome 123+), fine for Electron
-            style={{ fieldSizing: 'content' } as React.CSSProperties}
-          />
+          <>
+            {configKey === 'settings' && displayContent !== null ? (
+              <MemoryLoggingSettingsCard
+                rawSettings={displayContent}
+                profilePath={profilePath}
+                onChange={handleEdit}
+                disabled={isReadOnly}
+              />
+            ) : null}
+            <textarea
+              value={displayContent ?? ''}
+              onChange={(e) => handleEdit(e.target.value)}
+              readOnly={isReadOnly}
+              spellCheck={false}
+              className={cn(
+                'admin-editor w-full min-h-full resize-none bg-transparent',
+                'px-4 py-3 text-[12px] leading-[1.6] text-foreground/90',
+                isReadOnly && 'opacity-60 cursor-default',
+              )}
+              // fieldSizing: 'content' is Chromium-only (Chrome 123+), fine for Electron
+              style={{ fieldSizing: 'content' } as React.CSSProperties}
+            />
+          </>
         )}
       </ScrollArea>
     </div>

--- a/plugins/sero-admin-plugin/ui/components/MemoryLoggingSettingsCard.tsx
+++ b/plugins/sero-admin-plugin/ui/components/MemoryLoggingSettingsCard.tsx
@@ -1,0 +1,277 @@
+import { useMemo } from 'react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@sero-ai/ui/components/ui/select';
+import { getSero } from '../hooks/host';
+
+const DEFAULTS = {
+  maxBytesPerFile: 2 * 1024 * 1024,
+  maxFilesPerDay: 3,
+  retentionDays: 14,
+  maxPayloadChars: 4_096,
+};
+
+interface MemoryLoggingSettingsCardProps {
+  rawSettings: string;
+  profilePath: string | null;
+  onChange: (next: string) => void;
+  disabled?: boolean;
+}
+
+type LoggingKey = keyof typeof DEFAULTS;
+type MemoryLogPreset = 'minimal' | 'default' | 'verbose-retention';
+
+const PRESETS: Record<MemoryLogPreset, typeof DEFAULTS> = {
+  minimal: {
+    maxBytesPerFile: 512 * 1024,
+    maxFilesPerDay: 2,
+    retentionDays: 7,
+    maxPayloadChars: 1024,
+  },
+  default: DEFAULTS,
+  'verbose-retention': {
+    maxBytesPerFile: 5 * 1024 * 1024,
+    maxFilesPerDay: 5,
+    retentionDays: 30,
+    maxPayloadChars: 12_000,
+  },
+};
+
+function getObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : fallback;
+}
+
+function getDraftValues(rawSettings: string): Record<LoggingKey, number> | null {
+  try {
+    const parsed = JSON.parse(rawSettings) as Record<string, unknown>;
+    const sero = getObject(parsed.sero);
+    const memory = getObject(sero.memory);
+    const logging = getObject(memory.logging);
+    return {
+      maxBytesPerFile: normalizePositiveInteger(logging.maxBytesPerFile, DEFAULTS.maxBytesPerFile),
+      maxFilesPerDay: normalizePositiveInteger(logging.maxFilesPerDay, DEFAULTS.maxFilesPerDay),
+      retentionDays: normalizePositiveInteger(logging.retentionDays, DEFAULTS.retentionDays),
+      maxPayloadChars: normalizePositiveInteger(logging.maxPayloadChars, DEFAULTS.maxPayloadChars),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function updateSettings(rawSettings: string, updates: Partial<Record<LoggingKey, number>>): string | null {
+  try {
+    const parsed = JSON.parse(rawSettings) as Record<string, unknown>;
+    const sero = getObject(parsed.sero);
+    const memory = getObject(sero.memory);
+    const logging = getObject(memory.logging);
+
+    const next = {
+      ...parsed,
+      sero: {
+        ...sero,
+        memory: {
+          ...memory,
+          logging: {
+            ...DEFAULTS,
+            ...logging,
+            ...updates,
+          },
+        },
+      },
+    };
+
+    return `${JSON.stringify(next, null, 2)}\n`;
+  } catch {
+    return null;
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(bytes % (1024 * 1024) === 0 ? 0 : 1)} MB`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(bytes % 1024 === 0 ? 0 : 1)} KB`;
+  return `${bytes} B`;
+}
+
+function NumberField({
+  id,
+  label,
+  hint,
+  value,
+  disabled,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  hint: string;
+  value: number;
+  disabled?: boolean;
+  onChange: (next: number) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className="text-[11px] font-medium text-foreground/80">{label}</Label>
+      <Input
+        id={id}
+        type="number"
+        min={1}
+        step={1}
+        value={String(value)}
+        disabled={disabled}
+        onChange={(event) => {
+          const next = Number.parseInt(event.target.value, 10);
+          if (Number.isFinite(next) && next > 0) onChange(next);
+        }}
+        className="h-8 text-xs"
+      />
+      <p className="text-[11px] text-muted-foreground/65">{hint}</p>
+    </div>
+  );
+}
+
+export function MemoryLoggingSettingsCard({
+  rawSettings,
+  profilePath,
+  onChange,
+  disabled = false,
+}: MemoryLoggingSettingsCardProps) {
+  const values = useMemo(() => getDraftValues(rawSettings), [rawSettings]);
+  const logDirPath = profilePath ? `${profilePath}/debug/memory` : null;
+
+  const applyUpdate = (updates: Partial<Record<LoggingKey, number>>) => {
+    const next = updateSettings(rawSettings, updates);
+    if (next) onChange(next);
+  };
+
+  const applyPreset = (preset: MemoryLogPreset) => {
+    applyUpdate(PRESETS[preset]);
+  };
+
+  const revealLogFolder = async () => {
+    if (!logDirPath) return;
+    await getSero().shell.showItemInFolder(logDirPath);
+  };
+
+  return (
+    <Card className="mx-4 mt-4 border-border/40 bg-background/70">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-sm">Memory log policy</CardTitle>
+            <CardDescription className="mt-1 text-xs">
+              Convenience controls for <code>sero.memory.logging</code> in <code>settings.json</code>.
+            </CardDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            {logDirPath ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 px-2 text-[11px]"
+                onClick={() => void revealLogFolder()}
+              >
+                Open log folder
+              </Button>
+            ) : null}
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-[11px]"
+              disabled={disabled || values === null}
+              onClick={() => applyUpdate(DEFAULTS)}
+            >
+              Reset defaults
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-0">
+        {values === null ? (
+          <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-400">
+            Fix JSON errors in <code>settings.json</code> to use the structured memory logging controls.
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-4 lg:grid-cols-[240px_minmax(0,1fr)]">
+              <div className="space-y-1.5">
+                <Label htmlFor="memory-log-preset" className="text-[11px] font-medium text-foreground/80">
+                  Preset
+                </Label>
+                <Select onValueChange={(value) => applyPreset(value as MemoryLogPreset)}>
+                  <SelectTrigger id="memory-log-preset" className="h-8 w-full text-xs">
+                    <SelectValue placeholder="Apply a preset" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="minimal">Minimal</SelectItem>
+                    <SelectItem value="default">Default</SelectItem>
+                    <SelectItem value="verbose-retention">Verbose retention</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-[11px] text-muted-foreground/65">
+                  Quick presets for low disk usage, balanced defaults, or longer retained history.
+                </p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              <NumberField
+                id="memory-log-max-bytes"
+                label="Max bytes per file"
+                hint={`Current: ${formatBytes(values.maxBytesPerFile)}`}
+                value={values.maxBytesPerFile}
+                disabled={disabled}
+                onChange={(next) => applyUpdate({ maxBytesPerFile: next })}
+              />
+              <NumberField
+                id="memory-log-max-files"
+                label="Rotated files per day"
+                hint="Keeps the active daily log plus numbered backups"
+                value={values.maxFilesPerDay}
+                disabled={disabled}
+                onChange={(next) => applyUpdate({ maxFilesPerDay: next })}
+              />
+              <NumberField
+                id="memory-log-retention"
+                label="Retention days"
+                hint="Older daily log files are pruned automatically"
+                value={values.retentionDays}
+                disabled={disabled}
+                onChange={(next) => applyUpdate({ retentionDays: next })}
+              />
+              <NumberField
+                id="memory-log-payload"
+                label="Max payload chars"
+                hint="Large JSON payloads are truncated before writing"
+                value={values.maxPayloadChars}
+                disabled={disabled}
+                onChange={(next) => applyUpdate({ maxPayloadChars: next })}
+              />
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-border/40 bg-secondary/20 px-3 py-2 text-[11px] text-muted-foreground/75">
+              Logs are written to <code>~/.sero-ui/debug/memory/YYYY-MM-DD.log</code> with per-day rotation.
+              {logDirPath ? (
+                <span> Current profile path: <code>{logDirPath}</code>.</span>
+              ) : null}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/plugins/sero-memory-plugin/extension/__tests__/logger.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/logger.test.ts
@@ -16,6 +16,14 @@ async function createTempSeroHome(): Promise<string> {
   return mkdtemp(path.join(os.tmpdir(), 'sero-memory-logger-'));
 }
 
+function getLocalDayStamp(date: Date): string {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
+}
+
 describe('memory logger', () => {
   let seroHome = '';
 
@@ -35,13 +43,15 @@ describe('memory logger', () => {
     await rm(seroHome, { recursive: true, force: true });
   });
 
-  it('writes daily logs under ~/.sero-ui/debug/memory', async () => {
+  it('writes daily logs under ~/.sero-ui/debug/memory using the local day and offset timestamp', async () => {
     info('daily_log_test', { ok: true });
     await vi.waitFor(async () => {
       const content = await readFile(getMemoryLogPath(), 'utf8');
       expect(getMemoryLogDirPath()).toBe(path.join(seroHome, 'debug', 'memory'));
+      expect(path.basename(getMemoryLogPath())).toBe(`${getLocalDayStamp(new Date())}.log`);
       expect(content).toContain('daily_log_test');
       expect(content).toContain('{"ok":true}');
+      expect(content).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2} \[INFO\] daily_log_test/m);
     });
   });
 

--- a/plugins/sero-memory-plugin/extension/__tests__/logger.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/logger.test.ts
@@ -1,0 +1,145 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getMemoryLogDirPath, getMemoryLogPath, info } from '../logger';
+import { getMemoryLoggingSettingsSync } from '../logger-settings';
+
+const originalEnv = {
+  SERO_HOME: process.env.SERO_HOME,
+  PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+};
+
+async function createTempSeroHome(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), 'sero-memory-logger-'));
+}
+
+describe('memory logger', () => {
+  let seroHome = '';
+
+  beforeEach(async () => {
+    seroHome = await createTempSeroHome();
+    process.env.SERO_HOME = seroHome;
+    process.env.PI_CODING_AGENT_DIR = path.join(seroHome, 'agent');
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.env.SERO_HOME = originalEnv.SERO_HOME;
+    process.env.PI_CODING_AGENT_DIR = originalEnv.PI_CODING_AGENT_DIR;
+    await rm(seroHome, { recursive: true, force: true });
+  });
+
+  it('writes daily logs under ~/.sero-ui/debug/memory', async () => {
+    info('daily_log_test', { ok: true });
+    await vi.waitFor(async () => {
+      const content = await readFile(getMemoryLogPath(), 'utf8');
+      expect(getMemoryLogDirPath()).toBe(path.join(seroHome, 'debug', 'memory'));
+      expect(content).toContain('daily_log_test');
+      expect(content).toContain('{"ok":true}');
+    });
+  });
+
+  it('reads logging settings from agent/settings.json', async () => {
+    const settingsPath = path.join(seroHome, 'agent', 'settings.json');
+    await mkdir(path.dirname(settingsPath), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      sero: {
+        memory: {
+          logging: {
+            maxBytesPerFile: 512,
+            maxFilesPerDay: 5,
+            retentionDays: 30,
+            maxPayloadChars: 256,
+          },
+        },
+      },
+    }, null, 2));
+
+    expect(getMemoryLoggingSettingsSync()).toEqual({
+      maxBytesPerFile: 512,
+      maxFilesPerDay: 5,
+      retentionDays: 30,
+      maxPayloadChars: 256,
+    });
+  });
+
+  it('truncates oversized payloads using the configured maxPayloadChars', async () => {
+    const settingsPath = path.join(seroHome, 'agent', 'settings.json');
+    await mkdir(path.dirname(settingsPath), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      sero: {
+        memory: {
+          logging: {
+            maxPayloadChars: 80,
+          },
+        },
+      },
+    }, null, 2));
+
+    info('truncation_test', { payload: 'x'.repeat(400) });
+    await vi.waitFor(async () => {
+      const content = await readFile(getMemoryLogPath(), 'utf8');
+      expect(content).toContain('truncation_test');
+      expect(content).toContain('[truncated ');
+    });
+  });
+
+  it('rotates daily logs with a bounded backup count', async () => {
+    const settingsPath = path.join(seroHome, 'agent', 'settings.json');
+    await mkdir(path.dirname(settingsPath), { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      sero: {
+        memory: {
+          logging: {
+            maxBytesPerFile: 120,
+            maxFilesPerDay: 2,
+            maxPayloadChars: 200,
+          },
+        },
+      },
+    }, null, 2));
+
+    info('rotate_1', { payload: 'a'.repeat(80) });
+    info('rotate_2', { payload: 'b'.repeat(80) });
+    info('rotate_3', { payload: 'c'.repeat(80) });
+
+    await vi.waitFor(async () => {
+      const names = await readdir(getMemoryLogDirPath());
+      expect(names).toContain(path.basename(getMemoryLogPath()));
+      expect(names).toContain(`${path.basename(getMemoryLogPath())}.1`);
+      expect(names).toContain(`${path.basename(getMemoryLogPath())}.2`);
+    });
+  });
+
+  it('prunes daily logs older than the retention window', async () => {
+    const settingsPath = path.join(seroHome, 'agent', 'settings.json');
+    const logDir = getMemoryLogDirPath();
+    await mkdir(path.dirname(settingsPath), { recursive: true });
+    await mkdir(logDir, { recursive: true });
+    await writeFile(settingsPath, JSON.stringify({
+      sero: {
+        memory: {
+          logging: {
+            retentionDays: 14,
+          },
+        },
+      },
+    }, null, 2));
+    await writeFile(path.join(logDir, '2000-01-01.log'), 'stale\n', 'utf8');
+    await writeFile(path.join(logDir, '2000-01-01.log.1'), 'stale\n', 'utf8');
+
+    info('retention_test', { ok: true });
+    await vi.waitFor(async () => {
+      const names = await readdir(logDir);
+      expect(names).not.toContain('2000-01-01.log');
+      expect(names).not.toContain('2000-01-01.log.1');
+      expect(names).toContain(path.basename(getMemoryLogPath()));
+    });
+  });
+});

--- a/plugins/sero-memory-plugin/extension/index.ts
+++ b/plugins/sero-memory-plugin/extension/index.ts
@@ -29,7 +29,7 @@ import { registerActivityObserver } from './activity-observer';
 import { initQmd, runQmdUpdateNow } from './qmd';
 import { runPhase1Migration } from './migration';
 import { hasPendingStaleLogs, runMemoryConsolidationSafely } from './consolidation';
-import { error, errorDetails, getMemoryLogPath, info } from './logger';
+import { error, errorDetails, getMemoryLogDirPath, getMemoryLogPath, info } from './logger';
 import {
   describeAutoConsolidationCadence,
   getAutoConsolidationCommand,
@@ -285,7 +285,7 @@ export default function memoryExtension(pi: ExtensionAPI): void {
       pi.sendMessage(
         {
           customType: 'memory-debug-log',
-          content: `Memory debug log: \`${getMemoryLogPath()}\``,
+          content: `Memory debug logs: \`${getMemoryLogDirPath()}\` (today: \`${getMemoryLogPath()}\`)`,
           display: true,
         },
         { triggerTurn: false },

--- a/plugins/sero-memory-plugin/extension/local-time.ts
+++ b/plugins/sero-memory-plugin/extension/local-time.ts
@@ -1,0 +1,51 @@
+function pad(value: number, width: number): string {
+  return String(value).padStart(width, '0');
+}
+
+function formatTimezoneOffset(date: Date): string {
+  const offsetMinutes = -date.getTimezoneOffset();
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const absoluteMinutes = Math.abs(offsetMinutes);
+  const hours = Math.floor(absoluteMinutes / 60);
+  const minutes = absoluteMinutes % 60;
+  return `${sign}${pad(hours, 2)}:${pad(minutes, 2)}`;
+}
+
+export function getLocalDayStamp(date: Date): string {
+  return [
+    pad(date.getFullYear(), 4),
+    pad(date.getMonth() + 1, 2),
+    pad(date.getDate(), 2),
+  ].join('-');
+}
+
+export function formatLocalTimestamp(date: Date): string {
+  return `${getLocalDayStamp(date)}T${pad(date.getHours(), 2)}:${pad(date.getMinutes(), 2)}:${pad(date.getSeconds(), 2)}.${pad(date.getMilliseconds(), 3)}${formatTimezoneOffset(date)}`;
+}
+
+export function parseLocalDayStamp(day: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(day);
+  if (!match) return null;
+
+  const [, yearText, monthText, dayText] = match;
+  const year = Number.parseInt(yearText, 10);
+  const month = Number.parseInt(monthText, 10);
+  const date = Number.parseInt(dayText, 10);
+  const parsed = new Date(year, month - 1, date);
+
+  if (
+    parsed.getFullYear() !== year
+    || parsed.getMonth() !== month - 1
+    || parsed.getDate() !== date
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function getLocalDayRetentionCutoff(retentionDays: number, now: Date): Date {
+  const cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  cutoff.setDate(cutoff.getDate() - Math.max(0, retentionDays - 1));
+  return cutoff;
+}

--- a/plugins/sero-memory-plugin/extension/log-writer.ts
+++ b/plugins/sero-memory-plugin/extension/log-writer.ts
@@ -11,11 +11,33 @@ function warnOnce(key: string, message: string, error: unknown): void {
   console.warn(`${message}: ${detail}`);
 }
 
-async function rotateIfNeeded(filePath: string, maxBytes: number): Promise<void> {
+async function rotateFiles(filePath: string, maxFiles: number): Promise<void> {
+  if (maxFiles <= 0) {
+    await fs.rm(filePath, { force: true });
+    return;
+  }
+
+  await fs.rm(`${filePath}.${maxFiles}`, { force: true });
+  for (let index = maxFiles - 1; index >= 1; index -= 1) {
+    const source = `${filePath}.${index}`;
+    const target = `${filePath}.${index + 1}`;
+    try {
+      await fs.rename(source, target);
+    } catch (error) {
+      if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+
+  await fs.rename(filePath, `${filePath}.1`);
+}
+
+async function rotateIfNeeded(filePath: string, maxBytes: number, maxFiles: number): Promise<void> {
   try {
     const { size } = await fs.stat(filePath);
     if (size >= maxBytes) {
-      await fs.rename(filePath, `${filePath}.1`);
+      await rotateFiles(filePath, maxFiles);
     }
   } catch (error) {
     if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') {
@@ -28,15 +50,18 @@ export function appendRotatingLogLine(options: {
   filePath: string;
   line: string;
   maxBytes: number;
+  maxFiles?: number;
   warningKey: string;
   warningMessage: string;
+  beforeAppend?: () => Promise<void>;
 }): void {
   const previous = writeQueues.get(options.filePath) ?? Promise.resolve();
   const next = previous
     .catch(() => undefined)
     .then(async () => {
       await fs.mkdir(path.dirname(options.filePath), { recursive: true });
-      await rotateIfNeeded(options.filePath, options.maxBytes);
+      await options.beforeAppend?.();
+      await rotateIfNeeded(options.filePath, options.maxBytes, options.maxFiles ?? 1);
       await fs.appendFile(options.filePath, options.line, 'utf8');
     })
     .catch((error) => {

--- a/plugins/sero-memory-plugin/extension/log-writer.ts
+++ b/plugins/sero-memory-plugin/extension/log-writer.ts
@@ -67,6 +67,11 @@ export function appendRotatingLogLine(options: {
     .catch((error) => {
       warnOnce(options.warningKey, options.warningMessage, error);
     });
+  const tracked = next.finally(() => {
+    if (writeQueues.get(options.filePath) === tracked) {
+      writeQueues.delete(options.filePath);
+    }
+  });
 
-  writeQueues.set(options.filePath, next);
+  writeQueues.set(options.filePath, tracked);
 }

--- a/plugins/sero-memory-plugin/extension/logger-settings.ts
+++ b/plugins/sero-memory-plugin/extension/logger-settings.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { resolveAgentDir } from './agent-dir';
+
+export interface MemoryLoggingSettings {
+  maxBytesPerFile: number;
+  maxFilesPerDay: number;
+  retentionDays: number;
+  maxPayloadChars: number;
+}
+
+export const DEFAULT_MEMORY_LOGGING_SETTINGS: MemoryLoggingSettings = {
+  maxBytesPerFile: 2 * 1024 * 1024,
+  maxFilesPerDay: 3,
+  retentionDays: 14,
+  maxPayloadChars: 4_096,
+};
+
+const SETTINGS_CACHE_TTL_MS = 5_000;
+let cachedSettings: MemoryLoggingSettings | null = null;
+let lastReadAt = 0;
+let lastSettingsPath = '';
+
+function normalizePositiveInteger(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : fallback;
+}
+
+function getSettingsPath(): string {
+  return path.join(resolveAgentDir(), 'settings.json');
+}
+
+function readSettingsFile(): Record<string, unknown> {
+  const settingsPath = getSettingsPath();
+  try {
+    const raw = readFileSync(settingsPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function getObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+export function getMemoryLoggingSettingsSync(): MemoryLoggingSettings {
+  const now = Date.now();
+  const settingsPath = getSettingsPath();
+  if (cachedSettings && lastSettingsPath === settingsPath && now - lastReadAt < SETTINGS_CACHE_TTL_MS) {
+    return cachedSettings;
+  }
+
+  const settings = readSettingsFile();
+  const sero = getObject(settings.sero);
+  const memory = getObject(sero.memory);
+  const logging = getObject(memory.logging);
+
+  cachedSettings = {
+    maxBytesPerFile: normalizePositiveInteger(
+      logging.maxBytesPerFile,
+      DEFAULT_MEMORY_LOGGING_SETTINGS.maxBytesPerFile,
+    ),
+    maxFilesPerDay: normalizePositiveInteger(
+      logging.maxFilesPerDay,
+      DEFAULT_MEMORY_LOGGING_SETTINGS.maxFilesPerDay,
+    ),
+    retentionDays: normalizePositiveInteger(
+      logging.retentionDays,
+      DEFAULT_MEMORY_LOGGING_SETTINGS.retentionDays,
+    ),
+    maxPayloadChars: normalizePositiveInteger(
+      logging.maxPayloadChars,
+      DEFAULT_MEMORY_LOGGING_SETTINGS.maxPayloadChars,
+    ),
+  };
+  lastReadAt = now;
+  lastSettingsPath = settingsPath;
+  return cachedSettings;
+}

--- a/plugins/sero-memory-plugin/extension/logger.ts
+++ b/plugins/sero-memory-plugin/extension/logger.ts
@@ -1,19 +1,38 @@
+import { readdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+
 import { appendRotatingLogLine } from './log-writer';
+import { getMemoryLoggingSettingsSync } from './logger-settings';
 import { resolveMemoryDebugPath } from './state-paths';
 
 export type MemoryLogLevel = 'INFO' | 'WARN' | 'ERROR';
 
 const TAG = '[memory]';
-const MAX_LOG_SIZE = 1_048_576; // 1 MB
+const DAILY_LOG_FILE_RE = /^\d{4}-\d{2}-\d{2}\.log(?:\.\d+)?$/;
+let lastRetentionSweepKey: string | null = null;
 
-function resolveLogPath(): string {
-  return resolveMemoryDebugPath('memory-plugin.log');
+function getUtcDayStamp(date: Date): string {
+  return date.toISOString().slice(0, 10);
 }
 
-function serializeData(data: Record<string, unknown> | undefined): string {
+function resolveLogPath(date = new Date()): string {
+  return resolveMemoryDebugPath(`${getUtcDayStamp(date)}.log`);
+}
+
+function resolveLogDir(): string {
+  return path.dirname(resolveLogPath());
+}
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const suffix = `…[truncated ${text.length - maxChars} chars]`;
+  return `${text.slice(0, Math.max(0, maxChars - suffix.length))}${suffix}`;
+}
+
+function serializeData(data: Record<string, unknown> | undefined, maxPayloadChars: number): string {
   if (!data) return '';
   try {
-    return ` ${JSON.stringify(data)}`;
+    return ` ${truncateText(JSON.stringify(data), maxPayloadChars)}`;
   } catch {
     return ' {"serialization":"failed"}';
   }
@@ -34,9 +53,36 @@ export function getMemoryLogPath(): string {
   return resolveLogPath();
 }
 
+export function getMemoryLogDirPath(): string {
+  return resolveLogDir();
+}
+
+async function pruneOldDailyLogs(retentionDays: number): Promise<void> {
+  if (retentionDays <= 0) return;
+
+  const sweepDay = getUtcDayStamp(new Date());
+  const logDir = resolveLogDir();
+  const sweepKey = `${logDir}:${sweepDay}`;
+  if (lastRetentionSweepKey === sweepKey) return;
+  lastRetentionSweepKey = sweepKey;
+  const entries = await readdir(logDir, { withFileTypes: true }).catch(() => []);
+  const cutoff = Date.now() - (retentionDays * 24 * 60 * 60 * 1000);
+
+  await Promise.all(entries.map(async (entry) => {
+    if (!entry.isFile() || !DAILY_LOG_FILE_RE.test(entry.name)) return;
+
+    const day = entry.name.slice(0, 10);
+    const parsed = Date.parse(`${day}T00:00:00.000Z`);
+    if (!Number.isFinite(parsed) || parsed >= cutoff) return;
+
+    await rm(path.join(logDir, entry.name), { force: true });
+  }));
+}
+
 export function log(level: MemoryLogLevel, event: string, data?: Record<string, unknown>): void {
   const ts = new Date().toISOString();
-  const line = `${ts} [${level}] ${event}${serializeData(data)}`;
+  const settings = getMemoryLoggingSettingsSync();
+  const line = `${ts} [${level}] ${event}${serializeData(data, settings.maxPayloadChars)}`;
   const consoleLine = `${TAG} ${line}`;
 
   if (level === 'ERROR') {
@@ -50,9 +96,11 @@ export function log(level: MemoryLogLevel, event: string, data?: Record<string, 
   appendRotatingLogLine({
     filePath: resolveLogPath(),
     line: `${line}\n`,
-    maxBytes: MAX_LOG_SIZE,
+    maxBytes: settings.maxBytesPerFile,
+    maxFiles: settings.maxFilesPerDay,
     warningKey: 'memory-plugin-log',
-    warningMessage: '[memory] failed to persist memory-plugin.log',
+    warningMessage: '[memory] failed to persist memory log',
+    beforeAppend: async () => pruneOldDailyLogs(settings.retentionDays),
   });
 }
 

--- a/plugins/sero-memory-plugin/extension/logger.ts
+++ b/plugins/sero-memory-plugin/extension/logger.ts
@@ -2,6 +2,7 @@ import { readdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import { appendRotatingLogLine } from './log-writer';
+import { getLocalDayRetentionCutoff, getLocalDayStamp, formatLocalTimestamp, parseLocalDayStamp } from './local-time';
 import { getMemoryLoggingSettingsSync } from './logger-settings';
 import { resolveMemoryDebugPath } from './state-paths';
 
@@ -11,12 +12,8 @@ const TAG = '[memory]';
 const DAILY_LOG_FILE_RE = /^\d{4}-\d{2}-\d{2}\.log(?:\.\d+)?$/;
 let lastRetentionSweepKey: string | null = null;
 
-function getUtcDayStamp(date: Date): string {
-  return date.toISOString().slice(0, 10);
-}
-
 function resolveLogPath(date = new Date()): string {
-  return resolveMemoryDebugPath(`${getUtcDayStamp(date)}.log`);
+  return resolveMemoryDebugPath(`${getLocalDayStamp(date)}.log`);
 }
 
 function resolveLogDir(): string {
@@ -60,27 +57,29 @@ export function getMemoryLogDirPath(): string {
 async function pruneOldDailyLogs(retentionDays: number): Promise<void> {
   if (retentionDays <= 0) return;
 
-  const sweepDay = getUtcDayStamp(new Date());
+  const now = new Date();
+  const sweepDay = getLocalDayStamp(now);
   const logDir = resolveLogDir();
   const sweepKey = `${logDir}:${sweepDay}`;
   if (lastRetentionSweepKey === sweepKey) return;
   lastRetentionSweepKey = sweepKey;
   const entries = await readdir(logDir, { withFileTypes: true }).catch(() => []);
-  const cutoff = Date.now() - (retentionDays * 24 * 60 * 60 * 1000);
+  const cutoff = getLocalDayRetentionCutoff(retentionDays, now);
 
   await Promise.all(entries.map(async (entry) => {
     if (!entry.isFile() || !DAILY_LOG_FILE_RE.test(entry.name)) return;
 
     const day = entry.name.slice(0, 10);
-    const parsed = Date.parse(`${day}T00:00:00.000Z`);
-    if (!Number.isFinite(parsed) || parsed >= cutoff) return;
+    const parsed = parseLocalDayStamp(day);
+    if (!parsed || parsed >= cutoff) return;
 
     await rm(path.join(logDir, entry.name), { force: true });
   }));
 }
 
 export function log(level: MemoryLogLevel, event: string, data?: Record<string, unknown>): void {
-  const ts = new Date().toISOString();
+  const now = new Date();
+  const ts = formatLocalTimestamp(now);
   const settings = getMemoryLoggingSettingsSync();
   const line = `${ts} [${level}] ${event}${serializeData(data, settings.maxPayloadChars)}`;
   const consoleLine = `${TAG} ${line}`;
@@ -94,7 +93,7 @@ export function log(level: MemoryLogLevel, event: string, data?: Record<string, 
   }
 
   appendRotatingLogLine({
-    filePath: resolveLogPath(),
+    filePath: resolveLogPath(now),
     line: `${line}\n`,
     maxBytes: settings.maxBytesPerFile,
     maxFiles: settings.maxFilesPerDay,

--- a/plugins/sero-memory-plugin/extension/prompt-debug.ts
+++ b/plugins/sero-memory-plugin/extension/prompt-debug.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { appendRotatingLogLine } from './log-writer';
+import { formatLocalTimestamp } from './local-time';
 import { resolveMemoryDebugPath } from './state-paths';
 
 const MAX_LOG_SIZE = 10 * 1024 * 1024; // 10 MB
@@ -120,7 +121,7 @@ export function logMemoryPromptBeforeAgentStart(entry: MemoryPromptDebugEntry): 
 
   writeEntry({
     _type: 'memory_prompt_before_agent_start',
-    timestamp: new Date().toISOString(),
+    timestamp: formatLocalTimestamp(new Date()),
     sessionId: entry.sessionId,
     turn,
     needsBootstrap: entry.needsBootstrap,
@@ -148,7 +149,7 @@ export function logMemoryPromptAgentStart(sessionId: string, effectiveSystemProm
   const pending = pendingTurns.get(sessionId) ?? null;
   writeEntry({
     _type: 'memory_prompt_agent_start',
-    timestamp: new Date().toISOString(),
+    timestamp: formatLocalTimestamp(new Date()),
     sessionId,
     turn: pending?.turn ?? null,
     prompt: pending?.prompt ?? null,

--- a/plugins/sero-memory-plugin/extension/state-paths.ts
+++ b/plugins/sero-memory-plugin/extension/state-paths.ts
@@ -14,7 +14,7 @@ export function resolveMemoryStatePath(fileName: string): string {
 }
 
 export function resolveMemoryDebugPath(fileName: string): string {
-  return path.join(resolveSeroHome(), 'debug', fileName);
+  return path.join(resolveSeroHome(), 'debug', 'memory', fileName);
 }
 
 export function getTranscriptExportDirPath(): string {


### PR DESCRIPTION
## Summary
- rotate memory debug logs into daily files under `~/.sero-ui/debug/memory/` with per-day retention and bounded backups
- seed and read `sero.memory.logging` defaults from `settings.json`, including payload truncation controls
- add Admin settings UI controls for memory log policy, presets, and opening the log folder

## Testing
- pnpm --filter @sero-ai/plugin-memory test -- --run extension/__tests__/logger.test.ts
- pnpm --filter @sero/desktop exec vitest run electron/__tests__/shared/settings/memory-logging-settings.test.ts
- pnpm --filter @sero-ai/plugin-admin typecheck
- pnpm typecheck