### PR TITLE
feat(desktop): make gateway QR pairing profile-wide

### DIFF
--- a/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
@@ -329,6 +329,51 @@ describe('GatewayServer scoped authorization flows', () => {
     });
   });
 
+  it('allows unrestricted owner web tokens across workspaces without granting master-only token management', async () => {
+    const harness = await createHarness();
+    harnesses.push(harness);
+
+    const ownerToken = harness.server.getAuth().webTokens.create(null, 'Owner device').token;
+    const ws = await connectClient(harness.port, ownerToken);
+    sockets.push(ws);
+
+    const workspaces = await sendRequest<GatewayResponse>(ws, { type: 'list_workspaces' });
+    expect(workspaces).toEqual({
+      type: 'ok',
+      requestType: 'list_workspaces',
+      data: [
+        { id: 'workspace-a', name: 'Workspace A', path: '/workspace-a' },
+        { id: 'workspace-b', name: 'Workspace B', path: '/workspace-b' },
+      ],
+    });
+
+    const sessions = await sendRequest<GatewayResponse>(ws, {
+      type: 'list_sessions',
+      workspaceId: 'workspace-b',
+    });
+    expect(sessions).toEqual({
+      type: 'ok',
+      requestType: 'list_sessions',
+      data: [{ id: 'session-b', name: 'Session B', firstMessage: 'hello from B' }],
+    });
+
+    expect(await sendRequest<GatewayResponse>(ws, { type: 'list_web_tokens' })).toEqual({
+      type: 'error',
+      requestType: 'list_web_tokens',
+      message: 'Only master token can list web tokens',
+    });
+    expect(await sendRequest<GatewayResponse>(ws, { type: 'create_web_token', workspaceIds: null })).toEqual({
+      type: 'error',
+      requestType: 'create_web_token',
+      message: 'Only master token can create web tokens',
+    });
+    expect(await sendRequest<GatewayResponse>(ws, { type: 'revoke_web_token', tokenId: 'deadbeef' })).toEqual({
+      type: 'error',
+      requestType: 'revoke_web_token',
+      message: 'Only master token can revoke web tokens',
+    });
+  });
+
   it('allows master tokens to authorize and access sessions across workspaces', async () => {
     const harness = await createHarness();
     harnesses.push(harness);

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-owner-token.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-owner-token.test.ts
@@ -1,0 +1,381 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { WebSocket, type RawData } from 'ws';
+
+import { GatewayServer, type GatewayAgentOps } from '@electron/features/gateway';
+import type { GatewayPushEvent, GatewayResponse } from '@electron/features/gateway/server/protocol';
+
+interface TestHarness {
+  server: GatewayServer;
+  port: number;
+  tmpDir: string;
+  state: {
+    addWorkspace: (workspaceId: string, name: string, fileContent: string) => void;
+    getPromptCalls: () => Array<{ sessionId: string; text: string }>;
+    getCreatedSessionId: (workspaceId: string) => string | null;
+  };
+}
+
+interface GatewayMessageBase {
+  type: string;
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+function waitForClose(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    ws.once('close', () => resolve());
+  });
+}
+
+function waitForMessage<T extends GatewayMessageBase>(ws: WebSocket): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      reject(new Error('Timed out waiting for gateway message'));
+    }, 2000);
+
+    const onMessage = (data: RawData) => {
+      clearTimeout(timeout);
+      ws.off('error', onError);
+      resolve(JSON.parse(data.toString()) as T);
+    };
+
+    const onError = (error: Error) => {
+      clearTimeout(timeout);
+      ws.off('message', onMessage);
+      reject(error);
+    };
+
+    ws.once('message', onMessage);
+    ws.once('error', onError);
+  });
+}
+
+async function sendRequest<T extends GatewayMessageBase>(ws: WebSocket, request: Record<string, unknown>): Promise<T> {
+  const responsePromise = waitForMessage<T>(ws);
+  ws.send(JSON.stringify(request));
+  return responsePromise;
+}
+
+async function connectClient(port: number, token: string): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  await waitForOpen(ws);
+
+  const response = await sendRequest<GatewayResponse>(ws, {
+    type: 'connect',
+    token,
+    clientType: 'web',
+    clientId: `owner-${Date.now()}`,
+  });
+
+  expect(response).toEqual({ type: 'ok', requestType: 'connect' });
+  return ws;
+}
+
+function createAgentOps(): TestHarness['state'] & { ops: GatewayAgentOps } {
+  const workspaces = [
+    { id: 'workspace-a', name: 'Workspace A', path: '/workspace-a' },
+    { id: 'workspace-b', name: 'Workspace B', path: '/workspace-b' },
+  ];
+  const sessionsByWorkspace = new Map<string, Array<{ id: string; name: string; firstMessage: string }>>([
+    ['workspace-a', []],
+    ['workspace-b', []],
+  ]);
+  const historyBySession = new Map<string, Array<{ id: string; type: 'user'; text: string; timestamp: number }>>();
+  const filesByWorkspace = new Map<string, { content: string; size: number }>([
+    ['workspace-a', { content: '# A\n', size: 4 }],
+    ['workspace-b', { content: '# B\n', size: 4 }],
+  ]);
+  const artifactsBySession = new Map<string, { base64: string; mimeType: string; title: string }>();
+  const promptCalls: Array<{ sessionId: string; text: string }> = [];
+  const createdSessionIds = new Map<string, string>();
+
+  const addWorkspace = (workspaceId: string, name: string, fileContent: string) => {
+    workspaces.push({ id: workspaceId, name, path: `/${workspaceId}` });
+    sessionsByWorkspace.set(workspaceId, []);
+    filesByWorkspace.set(workspaceId, { content: fileContent, size: Buffer.byteLength(fileContent, 'utf8') });
+  };
+
+  const ops: GatewayAgentOps = {
+    openSession: async (sessionId, workspaceId) => {
+      if (!sessionsByWorkspace.has(workspaceId)) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      if (!historyBySession.has(sessionId)) {
+        historyBySession.set(sessionId, []);
+      }
+    },
+    prompt: async (sessionId, text) => {
+      promptCalls.push({ sessionId, text });
+      const history = historyBySession.get(sessionId);
+      if (!history) {
+        throw new Error(`Session not found: ${sessionId}`);
+      }
+      history.push({
+        id: `msg-${history.length + 1}`,
+        type: 'user',
+        text,
+        timestamp: history.length + 1,
+      });
+      artifactsBySession.set(sessionId, {
+        base64: 'Q09OVEVOVA==',
+        mimeType: 'image/png',
+        title: `Artifact for ${sessionId}`,
+      });
+    },
+    steer: async () => {},
+    abort: async () => {},
+    listWorkspaces: async () => workspaces,
+    listSessions: async (workspaceId) => sessionsByWorkspace.get(workspaceId) ?? [],
+    createSession: async (workspaceId, name) => {
+      if (!sessionsByWorkspace.has(workspaceId)) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      const sessionId = `session-${workspaceId}-${(sessionsByWorkspace.get(workspaceId)?.length ?? 0) + 1}`;
+      sessionsByWorkspace.get(workspaceId)?.push({ id: sessionId, name: name ?? '', firstMessage: '' });
+      historyBySession.set(sessionId, []);
+      createdSessionIds.set(workspaceId, sessionId);
+      return { id: sessionId, name: name ?? '' };
+    },
+    listFiles: async (workspaceId) => {
+      if (!filesByWorkspace.has(workspaceId)) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      return [{ name: 'README.md', type: 'file', path: '/README.md', size: filesByWorkspace.get(workspaceId)?.size ?? 0 }];
+    },
+    readFile: async (workspaceId) => {
+      const file = filesByWorkspace.get(workspaceId);
+      if (!file) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      return {
+        content: file.content,
+        encoding: 'utf8',
+        mimeType: 'text/markdown',
+        size: file.size,
+      };
+    },
+    listArtifacts: async (sessionId) => {
+      const artifact = artifactsBySession.get(sessionId);
+      if (!artifact) return [];
+      return [{
+        id: `artifact-${sessionId}`,
+        type: 'image',
+        title: artifact.title,
+        timestamp: '2026-04-17T00:00:00.000Z',
+        mimeType: artifact.mimeType,
+      }];
+    },
+    getArtifact: async (artifactId) => {
+      const sessionId = artifactId.replace(/^artifact-/, '');
+      return artifactsBySession.get(sessionId) ?? null;
+    },
+    getSessionHistory: async (_workspaceId, sessionId) => historyBySession.get(sessionId) ?? [],
+  };
+
+  return {
+    ops,
+    addWorkspace,
+    getPromptCalls: () => [...promptCalls],
+    getCreatedSessionId: (workspaceId: string) => createdSessionIds.get(workspaceId) ?? null,
+  };
+}
+
+async function createHarness(): Promise<TestHarness> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'gateway-owner-token-test-'));
+  const state = createAgentOps();
+  const server = new GatewayServer({
+    port: 0,
+    host: '127.0.0.1',
+    tokenPath: path.join(tmpDir, 'gateway-token.txt'),
+    configDir: tmpDir,
+  });
+  server.setAgentOps(state.ops);
+  await server.start();
+
+  const port = Number((server as unknown as { httpServer?: { address(): { port?: number } | null } }).httpServer?.address()?.port);
+  if (!port) {
+    throw new Error('Failed to determine gateway test port');
+  }
+
+  return { server, port, tmpDir, state };
+}
+
+describe('GatewayServer owner web token flows', () => {
+  const harnesses: TestHarness[] = [];
+  const sockets: WebSocket[] = [];
+
+  afterEach(async () => {
+    await Promise.all(sockets.splice(0).map(async (ws) => {
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
+        ws.close();
+        await waitForClose(ws);
+      }
+    }));
+
+    await Promise.all(harnesses.splice(0).map(async ({ server, tmpDir }) => {
+      await server.stop();
+      await rm(tmpDir, { recursive: true, force: true });
+    }));
+  });
+
+  it('keeps unrestricted owner tokens authorized for current and future workspaces across gateway operations', async () => {
+    const harness = await createHarness();
+    harnesses.push(harness);
+
+    const ownerToken = harness.server.getAuth().webTokens.create(null, 'Owner device').token;
+    const ws = await connectClient(harness.port, ownerToken);
+    sockets.push(ws);
+
+    expect(await sendRequest<GatewayResponse>(ws, { type: 'list_workspaces' })).toEqual({
+      type: 'ok',
+      requestType: 'list_workspaces',
+      data: [
+        { id: 'workspace-a', name: 'Workspace A', path: '/workspace-a' },
+        { id: 'workspace-b', name: 'Workspace B', path: '/workspace-b' },
+      ],
+    });
+
+    harness.state.addWorkspace('workspace-c', 'Workspace C', '# C\n');
+
+    expect(await sendRequest<GatewayResponse>(ws, { type: 'list_workspaces' })).toEqual({
+      type: 'ok',
+      requestType: 'list_workspaces',
+      data: [
+        { id: 'workspace-a', name: 'Workspace A', path: '/workspace-a' },
+        { id: 'workspace-b', name: 'Workspace B', path: '/workspace-b' },
+        { id: 'workspace-c', name: 'Workspace C', path: '/workspace-c' },
+      ],
+    });
+
+    expect(await sendRequest<GatewayResponse>(ws, {
+      type: 'create_session',
+      workspaceId: 'workspace-c',
+      name: 'Remote session',
+    })).toEqual({
+      type: 'ok',
+      requestType: 'create_session',
+      data: { id: 'session-workspace-c-1', name: 'Remote session' },
+    });
+
+    expect(await sendRequest<GatewayResponse>(ws, {
+      type: 'list_sessions',
+      workspaceId: 'workspace-c',
+    })).toEqual({
+      type: 'ok',
+      requestType: 'list_sessions',
+      data: [{ id: 'session-workspace-c-1', name: 'Remote session', firstMessage: '' }],
+    });
+
+    expect(await sendRequest<GatewayResponse>(ws, {
+      type: 'prompt',
+      workspaceId: 'workspace-c',
+      sessionId: 'session-workspace-c-1',
+      text: 'hello future workspace',
+    })).toEqual({
+      type: 'ok',
+      requestType: 'prompt',
+    });
+    expect(harness.state.getPromptCalls()).toEqual([
+      { sessionId: 'session-workspace-c-1', text: 'hello future workspace' },
+    ]);
+
+    expect(await sendRequest<GatewayResponse>(ws, {
+      type: 'list_files',
+      workspaceId: 'workspace-c',
+      path: '/',
+    })).toEqual({
+      type: 'ok',
+      requestType: 'list_files',
+      data: {
+        path: '/',
+        entries: [{ name: 'README.md', type: 'file', path: '/README.md', size: 4 }],
+      },
+    });
+
+    expect(await sendRequest<GatewayResponse>(ws, {
+      type: 'read_file',
+      workspaceId: 'workspace-c',
+      path: '/README.md',
+    })).toEqual({
+      type: 'ok',
+      requestType: 'read_file',
+      data: {
+        content: '# C\n',
+        encoding: 'utf8',
+        mimeType: 'text/markdown',
+        size: 4,
+      },
+    });
+
+    expect(await sendRequest<GatewayResponse>(ws, {
+      type: 'get_session_history',
+      workspaceId: 'workspace-c',
+      sessionId: 'session-workspace-c-1',
+    })).toEqual({
+      type: 'ok',
+      requestType: 'get_session_history',
+      data: [{ id: 'msg-1', type: 'user', text: 'hello future workspace', timestamp: 1 }],
+    });
+
+    const textDeltaPromise = waitForMessage<GatewayPushEvent>(ws);
+    harness.server.pushEvent('session-workspace-c-1', {
+      type: 'text_delta',
+      sessionId: 'session-workspace-c-1',
+      delta: 'streamed owner token update',
+    });
+    expect(await textDeltaPromise).toEqual({
+      type: 'text_delta',
+      sessionId: 'session-workspace-c-1',
+      delta: 'streamed owner token update',
+    });
+
+    const artifactEventPromise = waitForMessage<GatewayPushEvent>(ws);
+    harness.server.broadcastEvent({
+      type: 'artifact_added',
+      sessionId: 'session-workspace-c-1',
+      artifactId: 'artifact-session-workspace-c-1',
+      artifactType: 'image',
+      title: 'Artifact for session-workspace-c-1',
+    });
+    expect(await artifactEventPromise).toEqual({
+      type: 'artifact_added',
+      sessionId: 'session-workspace-c-1',
+      artifactId: 'artifact-session-workspace-c-1',
+      artifactType: 'image',
+      title: 'Artifact for session-workspace-c-1',
+    });
+
+    expect(await sendRequest<GatewayResponse>(ws, {
+      type: 'get_artifact',
+      artifactId: 'artifact-session-workspace-c-1',
+    })).toEqual({
+      type: 'ok',
+      requestType: 'get_artifact',
+      data: {
+        base64: 'Q09OVEVOVA==',
+        mimeType: 'image/png',
+        title: 'Artifact for session-workspace-c-1',
+      },
+    });
+
+    expect(harness.state.getCreatedSessionId('workspace-c')).toBe('session-workspace-c-1');
+  });
+});

--- a/apps/desktop/electron/__tests__/features/gateway/protocol.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/protocol.test.ts
@@ -39,6 +39,19 @@ describe('gateway protocol request validation', () => {
       label: 'Shared access',
       expiryDays: 3,
     });
+
+    expect(
+      validateRequest({
+        type: 'create_web_token',
+        workspaceIds: null,
+        label: 'Owner device',
+      }),
+    ).toEqual({
+      type: 'create_web_token',
+      workspaceIds: null,
+      label: 'Owner device',
+      expiryDays: undefined,
+    });
   });
 
   it.each([
@@ -56,6 +69,7 @@ describe('gateway protocol request validation', () => {
     ['create_web_token without workspaceIds', { type: 'create_web_token', label: 'Shared access' }],
     ['create_web_token with empty workspaceIds', { type: 'create_web_token', workspaceIds: [] }],
     ['create_web_token with invalid workspaceIds', { type: 'create_web_token', workspaceIds: ['workspace-a', 3] }],
+    ['create_web_token with invalid null-like workspaceIds', { type: 'create_web_token', workspaceIds: 'all' }],
     ['create_web_token with invalid expiryDays', {
       type: 'create_web_token',
       workspaceIds: ['workspace-a'],

--- a/apps/desktop/electron/__tests__/features/gateway/web-tokens.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/web-tokens.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { WebTokenManager } from '@electron/features/gateway/bridge/web-tokens';
+
+describe('WebTokenManager', () => {
+  let tmpDir: string | null = null;
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+      tmpDir = null;
+    }
+  });
+
+  it('creates unrestricted owner tokens with null workspace scope', async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'web-token-test-'));
+
+    const manager = new WebTokenManager(tmpDir);
+    const token = manager.create(null, 'Owner device', 7);
+
+    expect(token.workspaceIds).toBeNull();
+    expect(manager.validate(token.token)?.workspaceIds).toBeNull();
+    expect(manager.list()).toEqual([
+      expect.objectContaining({
+        label: 'Owner device',
+        workspaceIds: null,
+      }),
+    ]);
+
+    const stored = JSON.parse(await readFile(path.join(tmpDir, 'gateway-web-tokens.json'), 'utf8')) as unknown[];
+    expect(stored).toEqual([
+      expect.objectContaining({
+        label: 'Owner device',
+        workspaceIds: null,
+      }),
+    ]);
+  });
+
+  it('loads both legacy unrestricted tokens and scoped tokens from disk', async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'web-token-test-'));
+
+    await writeFile(
+      path.join(tmpDir, 'gateway-web-tokens.json'),
+      JSON.stringify([
+        {
+          token: 'a'.repeat(64),
+          createdAt: '2026-04-17T00:00:00.000Z',
+          expiresAt: '2099-04-17T00:00:00.000Z',
+          label: 'Legacy owner token',
+        },
+        {
+          token: 'b'.repeat(64),
+          createdAt: '2026-04-17T00:00:00.000Z',
+          expiresAt: '2099-04-17T00:00:00.000Z',
+          label: 'Scoped token',
+          workspaceIds: ['workspace-a'],
+        },
+      ], null, 2),
+      'utf8',
+    );
+
+    const manager = new WebTokenManager(tmpDir);
+
+    expect(manager.validate('a'.repeat(64))?.workspaceIds).toBeNull();
+    expect(manager.validate('b'.repeat(64))?.workspaceIds).toEqual(['workspace-a']);
+    expect(manager.list()).toEqual([
+      expect.objectContaining({
+        label: 'Legacy owner token',
+        workspaceIds: null,
+      }),
+      expect.objectContaining({
+        label: 'Scoped token',
+        workspaceIds: ['workspace-a'],
+      }),
+    ]);
+  });
+});

--- a/apps/desktop/electron/features/gateway/bridge/web-tokens.ts
+++ b/apps/desktop/electron/features/gateway/bridge/web-tokens.ts
@@ -14,6 +14,24 @@ const MAX_TOKENS = 10;
 const DEFAULT_EXPIRY_DAYS = 7;
 const TOKEN_LENGTH = 32;
 
+function normalizeWorkspaceScope(value: unknown): { ok: true; workspaceIds: string[] | null } | { ok: false } {
+  if (value === undefined || value === null) {
+    return { ok: true, workspaceIds: null };
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    return { ok: false };
+  }
+
+  const workspaceIds = value.filter(
+    (workspaceId): workspaceId is string => typeof workspaceId === 'string' && workspaceId.length > 0,
+  );
+  if (workspaceIds.length !== value.length) {
+    return { ok: false };
+  }
+
+  return { ok: true, workspaceIds: [...new Set(workspaceIds)] };
+}
+
 function normalizeWebToken(value: unknown): WebToken[] {
   if (typeof value !== 'object' || value === null) {
     return [];
@@ -23,15 +41,13 @@ function normalizeWebToken(value: unknown): WebToken[] {
   const createdAt = 'createdAt' in value && typeof value.createdAt === 'string' ? value.createdAt : null;
   const expiresAt = 'expiresAt' in value && typeof value.expiresAt === 'string' ? value.expiresAt : null;
   const label = 'label' in value && typeof value.label === 'string' ? value.label : null;
-  const workspaceIds = 'workspaceIds' in value && Array.isArray(value.workspaceIds)
-    ? value.workspaceIds.filter((workspaceId): workspaceId is string => typeof workspaceId === 'string')
-    : [];
+  const workspaceScope = normalizeWorkspaceScope('workspaceIds' in value ? value.workspaceIds : undefined);
 
-  if (!token || !createdAt || !expiresAt || !label || workspaceIds.length === 0) {
+  if (!token || !createdAt || !expiresAt || !label || !workspaceScope.ok) {
     return [];
   }
 
-  return [{ token, createdAt, expiresAt, label, workspaceIds }];
+  return [{ token, createdAt, expiresAt, label, workspaceIds: workspaceScope.workspaceIds }];
 }
 
 export interface WebToken {
@@ -39,7 +55,8 @@ export interface WebToken {
   createdAt: string;
   expiresAt: string;
   label: string;
-  workspaceIds: string[];
+  /** Null means unrestricted owner access across current and future workspaces. */
+  workspaceIds: string[] | null;
 }
 
 export class WebTokenManager {
@@ -53,8 +70,8 @@ export class WebTokenManager {
   }
 
   /** Create a new web token. Returns the token details. */
-  create(workspaceIds: string[], label?: string, expiryDays?: number): WebToken {
-    if (workspaceIds.length === 0) {
+  create(workspaceIds: string[] | null, label?: string, expiryDays?: number): WebToken {
+    if (workspaceIds !== null && workspaceIds.length === 0) {
       throw new Error('Web tokens must be scoped to at least one workspace');
     }
 
@@ -74,7 +91,7 @@ export class WebTokenManager {
       createdAt: now.toISOString(),
       expiresAt: expires.toISOString(),
       label: label ?? `Web token ${now.toLocaleDateString()}`,
-      workspaceIds: [...new Set(workspaceIds)],
+      workspaceIds: workspaceIds ? [...new Set(workspaceIds)] : null,
     };
 
     this.tokens.push(webToken);

--- a/apps/desktop/electron/features/gateway/security/auth.ts
+++ b/apps/desktop/electron/features/gateway/security/auth.ts
@@ -3,8 +3,8 @@
  *
  * A single master bearer token is generated on first run and stored on disk.
  * All gateway clients must present either that master token or a scoped web
- * token created from the desktop app. Web tokens are limited to one or more
- * explicit workspace IDs.
+ * token created from the desktop app. Web tokens can either be limited to one
+ * or more explicit workspace IDs or grant owner-wide access across the profile.
  */
 
 import crypto from 'crypto';

--- a/apps/desktop/electron/features/gateway/server/extended-handlers.ts
+++ b/apps/desktop/electron/features/gateway/server/extended-handlers.ts
@@ -236,24 +236,18 @@ export async function routeExtendedRequest(
       }
       try {
         const workspaceIds = request.workspaceIds;
-        if (!Array.isArray(workspaceIds) || workspaceIds.length === 0) {
-          sendResponse(ws, {
-            type: 'error',
-            requestType: 'create_web_token',
-            message: 'create_web_token requires one or more workspaceIds',
-          });
-          return true;
-        }
-        const unauthorizedWorkspace = workspaceIds.find(
-          (workspaceId) => typeof workspaceId !== 'string' || !hasWorkspaceAccess(accessScope, workspaceId),
-        );
-        if (unauthorizedWorkspace) {
-          sendResponse(ws, {
-            type: 'error',
-            requestType: 'create_web_token',
-            message: `Workspace not authorized: ${String(unauthorizedWorkspace)}`,
-          });
-          return true;
+        if (workspaceIds !== null) {
+          const unauthorizedWorkspace = workspaceIds.find(
+            (workspaceId) => typeof workspaceId !== 'string' || !hasWorkspaceAccess(accessScope, workspaceId),
+          );
+          if (unauthorizedWorkspace) {
+            sendResponse(ws, {
+              type: 'error',
+              requestType: 'create_web_token',
+              message: `Workspace not authorized: ${String(unauthorizedWorkspace)}`,
+            });
+            return true;
+          }
         }
         const webToken = auth.webTokens.create(workspaceIds, request.label, request.expiryDays);
         sendResponse(ws, {

--- a/apps/desktop/electron/features/gateway/server/protocol.ts
+++ b/apps/desktop/electron/features/gateway/server/protocol.ts
@@ -82,7 +82,8 @@ export interface GatewayCreateWebTokenRequest {
   type: 'create_web_token';
   label?: string;
   expiryDays?: number;
-  workspaceIds?: string[];
+  /** Null means unrestricted owner access; string[] means explicitly scoped access. */
+  workspaceIds: string[] | null;
 }
 
 export interface GatewayListWebTokensRequest {
@@ -253,18 +254,25 @@ function readPromptImages(value: unknown): GatewayPromptRequest['images'] | unde
   return images;
 }
 
-function readWorkspaceIds(obj: Record<string, unknown>): string[] | null {
+function readWorkspaceIds(
+  obj: Record<string, unknown>,
+): { ok: true; workspaceIds: string[] | null } | { ok: false } {
   const value = obj.workspaceIds;
-  if (!Array.isArray(value) || value.length === 0) return null;
+  if (value === null) {
+    return { ok: true, workspaceIds: null };
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    return { ok: false };
+  }
 
   const workspaceIds: string[] = [];
   for (const workspaceId of value) {
     if (typeof workspaceId !== 'string' || workspaceId.length === 0) {
-      return null;
+      return { ok: false };
     }
     workspaceIds.push(workspaceId);
   }
-  return workspaceIds;
+  return { ok: true, workspaceIds };
 }
 
 export function validateRequest(data: unknown): GatewayRequest | null {
@@ -356,14 +364,14 @@ export function validateRequest(data: unknown): GatewayRequest | null {
     }
 
     case 'create_web_token': {
-      const workspaceIds = readWorkspaceIds(data);
+      const workspaceScope = readWorkspaceIds(data);
       const label = readOptionalString(data, 'label');
       const expiryDays = readOptionalFiniteNumber(data, 'expiryDays');
-      if (!workspaceIds || label === null || expiryDays === null) return null;
+      if (!workspaceScope.ok || label === null || expiryDays === null) return null;
       if (expiryDays !== undefined && (!Number.isInteger(expiryDays) || expiryDays <= 0)) {
         return null;
       }
-      return { type: 'create_web_token', workspaceIds, label, expiryDays };
+      return { type: 'create_web_token', workspaceIds: workspaceScope.workspaceIds, label, expiryDays };
     }
 
     case 'list_web_tokens':

--- a/apps/desktop/electron/ipc/gateway/gateway.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway.ts
@@ -103,14 +103,14 @@ export function registerGatewayHandlers(): void {
 
   ipcMain.handle(
     IpcChannels.gateway.getQrLoginData,
-    async (_event, workspaceId: string, expiryDays?: number): Promise<QrLoginData> => {
+    async (_event, expiryDays?: number): Promise<QrLoginData> => {
       await startGateway();
 
       // Clamp expiry to 1–30 days to prevent bogus values from the renderer.
       const days = Math.max(1, Math.min(expiryDays ?? 7, 30));
       const auth = gatewayServer.getAuth();
       const webToken = auth.webTokens.create(
-        [workspaceId],
+        null,
         `QR login ${new Date().toLocaleDateString()}`,
         days,
       );

--- a/apps/desktop/electron/ipc/gateway/gateway.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway.ts
@@ -82,7 +82,7 @@ export function registerGatewayHandlers(): void {
 
   ipcMain.handle(
     IpcChannels.gateway.createWebToken,
-    async (_event, workspaceIds: string[], label?: string, expiryDays?: number) => {
+    async (_event, workspaceIds: string[] | null, label?: string, expiryDays?: number) => {
       const auth = gatewayServer.getAuth();
       return auth.webTokens.create(workspaceIds, label, expiryDays);
     },

--- a/apps/desktop/electron/preload/platform/host-services.ts
+++ b/apps/desktop/electron/preload/platform/host-services.ts
@@ -57,8 +57,8 @@ export const safeStorageBridge = {
 };
 
 export const gatewayBridge = {
-  getQrLoginData: (workspaceId: string, expiryDays?: number): Promise<QrLoginData> =>
-    ipcRenderer.invoke(IpcChannels.gateway.getQrLoginData, workspaceId, expiryDays),
+  getQrLoginData: (expiryDays?: number): Promise<QrLoginData> =>
+    ipcRenderer.invoke(IpcChannels.gateway.getQrLoginData, expiryDays),
 };
 
 export const clipboardBridge = {

--- a/apps/desktop/src/components/layout/device/ConnectDeviceDialog.tsx
+++ b/apps/desktop/src/components/layout/device/ConnectDeviceDialog.tsx
@@ -4,9 +4,9 @@
  *
  * Flow:
  *   1. User opens this dialog (e.g. via ⌘K → "Connect Device")
- *   2. The dialog calls the main process to create a time-limited web token
+ *   2. The dialog calls the main process to create a time-limited owner web token
  *   3. A QR code + login URL are shown
- *   4. User scans the QR on their device → web-remote auto-connects
+ *   4. User scans the QR on their device → web-remote auto-connects with access to the whole profile
  *
  * The manual token entry in the web-remote AuthScreen remains available
  * for same-machine development where camera scanning isn't possible.
@@ -25,7 +25,6 @@ import {
 import { Button } from '@sero-ai/ui/components/ui/button';
 import type { QrLoginData } from '@/types/ipc';
 import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
-import { useWorkspaceStore } from '@/stores/workspace';
 
 interface Props {
   open: boolean;
@@ -35,10 +34,6 @@ interface Props {
 type Phase = 'idle' | 'loading' | 'ready' | 'error';
 
 export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
-  const activeWorkspaceId = useWorkspaceStore((s) => s.activeWorkspaceId ?? 'global');
-  const activeWorkspaceName = useWorkspaceStore(
-    (s) => s.workspaces.find((workspace) => workspace.id === (s.activeWorkspaceId ?? 'global'))?.name ?? 'Global',
-  );
   const [phase, setPhase] = useState<Phase>('idle');
   const [data, setData] = useState<QrLoginData | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -51,14 +46,14 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
     setCopied(false);
     setCopyFailed(false);
     try {
-      const result = await window.sero.gateway.getQrLoginData(activeWorkspaceId, 7);
+      const result = await window.sero.gateway.getQrLoginData(7);
       setData(result);
       setPhase('ready');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate QR code');
       setPhase('error');
     }
-  }, [activeWorkspaceId]);
+  }, []);
 
   // Generate QR data when the dialog opens. The parent controls `open`
   // via props, so onOpenChange(true) is never called by radix — we need
@@ -111,8 +106,7 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
           </DialogTitle>
           <DialogDescription>
             Scan this QR code with your phone to open Sero Remote.
-            This pairing will share only the <span className="font-medium text-foreground">{activeWorkspaceName}</span> workspace,
-            and the paired browser will only be able to open that workspace’s sessions, files, and artifacts.
+            This pairing signs the device into this Sero profile, with access to all current workspaces and any new workspaces you create later.
           </DialogDescription>
         </DialogHeader>
 
@@ -139,8 +133,8 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
 
               <div className="w-full rounded-lg border border-border bg-muted/40 px-3 py-2 text-xs">
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-muted-foreground">Shared workspace</span>
-                  <span className="font-medium text-foreground">{activeWorkspaceName}</span>
+                  <span className="text-muted-foreground">Profile access</span>
+                  <span className="font-medium text-foreground">All workspaces</span>
                 </div>
                 <div className="mt-1 flex items-center justify-between gap-3">
                   <span className="text-muted-foreground">Access expires</span>
@@ -152,7 +146,7 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
 
               <p className="text-xs text-muted-foreground">
                 Valid for {data.expiryDays} day{data.expiryDays === 1 ? '' : 's'}.
-                To share a different workspace later, generate a new code from that workspace in Sero desktop.
+                Once paired, this device can switch between any workspace in the profile, including ones created after pairing.
               </p>
 
               {/* ── Login URL + copy ─────────────────────────── */}
@@ -211,8 +205,7 @@ export function ConnectDeviceDialog({ open, onOpenChange }: Props) {
           <p className="text-center text-[11px] leading-relaxed text-muted-foreground/70">
             Or paste the URL in your phone's browser.
             <br />
-            The token auto-saves on the device, but it stays limited to {activeWorkspaceName}
-            until it expires or you create a new pairing.
+            The token auto-saves on the device and keeps profile-wide workspace access until it expires or you create a new pairing.
           </p>
         </div>
       </DialogContent>

--- a/apps/desktop/src/types/electron-services.d.ts
+++ b/apps/desktop/src/types/electron-services.d.ts
@@ -10,11 +10,10 @@ import type {
 export interface SeroGatewayAPI {
   /**
    * Generate a QR code for device pairing.
-   * Creates a time-limited web token scoped to one workspace and returns the QR data URL + login URL.
-   * @param workspaceId Workspace the remote device is authorized to access.
-   * @param expiryDays  Number of days until the token expires (default 7).
+   * Creates a time-limited owner web token with access to the whole profile and returns the QR data URL + login URL.
+   * @param expiryDays Number of days until the token expires (default 7).
    */
-  getQrLoginData(workspaceId: string, expiryDays?: number): Promise<QrLoginData>;
+  getQrLoginData(expiryDays?: number): Promise<QrLoginData>;
 }
 
 export interface SeroLocalModelsAPI {

--- a/apps/desktop/src/types/gateway.ts
+++ b/apps/desktop/src/types/gateway.ts
@@ -1,4 +1,4 @@
-/** Data returned when generating a QR code for device pairing. */
+/** Data returned when generating a QR code for profile-wide device pairing. */
 export interface QrLoginData {
   /** Data URL (SVG, base64) for rendering the QR code in an <img> tag. */
   qrDataUrl: string;

--- a/apps/web-remote/src/lib/gateway-client.test.ts
+++ b/apps/web-remote/src/lib/gateway-client.test.ts
@@ -145,4 +145,33 @@ describe('GatewayClient', () => {
 
     expect(MockWebSocket.instances).toHaveLength(1);
   });
+
+  it('sends explicit workspace scope when creating web tokens', () => {
+    const client = new GatewayClient('ws://gateway.test');
+    client.connect('master-token');
+
+    const socket = MockWebSocket.instances[0];
+    expect(socket).toBeDefined();
+
+    socket!.emitOpen();
+    socket!.sent = [];
+
+    client.createWebToken(null, 'Owner device', 7);
+    client.createWebToken(['workspace-a'], 'Workspace A only', 3);
+
+    expect(socket!.sent.map((payload) => JSON.parse(payload))).toEqual([
+      {
+        type: 'create_web_token',
+        workspaceIds: null,
+        label: 'Owner device',
+        expiryDays: 7,
+      },
+      {
+        type: 'create_web_token',
+        workspaceIds: ['workspace-a'],
+        label: 'Workspace A only',
+        expiryDays: 3,
+      },
+    ]);
+  });
 });

--- a/apps/web-remote/src/lib/gateway-client.ts
+++ b/apps/web-remote/src/lib/gateway-client.ts
@@ -245,8 +245,8 @@ export class GatewayClient {
   }
 
   /** Create a web token (requires master token auth). */
-  createWebToken(label?: string, expiryDays?: number): void {
-    this.send({ type: 'create_web_token', label, expiryDays });
+  createWebToken(workspaceIds: string[] | null = null, label?: string, expiryDays?: number): void {
+    this.send({ type: 'create_web_token', workspaceIds, label, expiryDays });
   }
 
   /** List web tokens. */

--- a/docs/deslop.md
+++ b/docs/deslop.md
@@ -482,17 +482,18 @@ Changes made during code quality passes. Most recent first.
 | `apps/desktop/electron/features/subagent/runtime/runner.ts` | Removed `createAgentSession()` cast and `session!` assertion from the subagent runtime |
 | `apps/desktop/electron/types/pi-coding-agent.d.ts` | New — local Pi SDK module augmentation for typed `systemPromptSuffix` support |
 | `apps/desktop/electron/features/gateway/server/access-control.ts` | New — shared workspace/session/artifact authorization helpers for gateway requests |
-| `apps/desktop/electron/features/gateway/bridge/web-tokens.ts` | Web tokens now carry explicit workspace scopes and validate to token records instead of booleans |
-| `apps/desktop/electron/features/gateway/security/auth.ts` | Gateway auth now returns scoped auth results for master vs web-token clients |
+| `apps/desktop/electron/features/gateway/bridge/web-tokens.ts` | Web tokens now support both explicit workspace scopes and unrestricted owner-wide scope (`workspaceIds: null`) while validating to token records instead of booleans |
+| `apps/desktop/electron/features/gateway/security/auth.ts` | Gateway auth now returns master-vs-web auth results with optional unrestricted workspace access for owner web tokens |
 | `apps/desktop/electron/features/gateway/index.ts` | Enforced scoped client access in connection state and filtered session-scoped push/broadcast events |
 | `apps/desktop/electron/features/gateway/server/request-handler.ts` | Added workspace/session authorization checks for core gateway routes |
 | `apps/desktop/electron/features/gateway/server/extended-handlers.ts` | Added workspace/session/artifact authorization checks for file/history/web-token routes |
 | `apps/desktop/electron/features/gateway/server/protocol.ts` | Extended `create_web_token` request shape with explicit `workspaceIds` |
 | `apps/desktop/electron/ipc/gateway/gateway-ops.ts` | `openSession()` now rejects workspace/session mismatches instead of silently reopening cross-workspace sessions |
-| `apps/desktop/electron/ipc/gateway/gateway.ts` | QR/web-token IPC now creates workspace-scoped tokens |
-| `apps/desktop/electron/preload/platform/host-services.ts` | Updated gateway bridge to require a workspace ID for QR login generation |
-| `apps/desktop/src/types/electron-services.d.ts` | Updated renderer gateway API contract for workspace-scoped QR login generation |
-| `apps/desktop/src/components/layout/ConnectDeviceDialog.tsx` | QR pairing now scopes remote access to the active workspace and surfaces that in the dialog |
+| `apps/desktop/electron/ipc/gateway/gateway.ts` | QR/web-token IPC now supports unrestricted owner tokens and `Connect Device` mints profile-wide QR pairings |
+| `apps/desktop/electron/preload/platform/host-services.ts` | Updated gateway bridge for owner-wide QR login generation (no workspace ID parameter) |
+| `apps/desktop/src/types/electron-services.d.ts` | Updated renderer gateway API contract for profile-wide QR login generation |
+| `apps/desktop/src/components/layout/ConnectDeviceDialog.tsx` | QR pairing now grants profile-wide remote access across current and future workspaces and explains that in the dialog |
+| `apps/desktop/electron/__tests__/features/gateway/gateway-owner-token.test.ts` | New — focused owner-token regression coverage for all-workspaces access, future-workspace visibility, and master-only route separation |
 | `apps/desktop/electron/features/gateway/channels/discord.ts` | Fixed `/sero abort` so it actually aborts the active session and reports failures |
 | `apps/desktop/electron/preload/api.ts` | Split aggregate preload bridge into a thin composer (485 → 88 lines) |
 | `apps/desktop/electron/preload/api/core.ts` | New — extracted shell/profile/workspace/session/agent/context-preset preload bridges |

--- a/docs/deslopify/apps/desktop/electron/features/gateway/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/gateway/facts.md
@@ -1,6 +1,6 @@
 # Facts — apps/desktop/electron/features/gateway
 
-_Last reviewed: 2026-04-16_
+_Last reviewed: 2026-04-17_
 
 ## What this code does
 This feature is Sero's remote-access gateway. It owns the WebSocket/HTTP server, gateway auth token handling, request validation/routing, per-session cost tracking, Discord and web chat adapters, Tailscale exposure, QR-code generation, and the bridge that forwards agent-pool events back to remote clients.
@@ -19,7 +19,7 @@ This feature is Sero's remote-access gateway. It owns the WebSocket/HTTP server,
 
 ## Architectural notes
 - This feature is an external network boundary, not an internal helper. Type validation, auth scope, and failure semantics are materially more important here than in ordinary in-process modules.
-- The flat gateway token model is still explicitly called out as open security debt in `docs/security/outstanding-hardening.md` and the in-code TODO in `security/auth.ts`.
+- The flat master-token model is still explicitly called out as open security debt in `docs/security/outstanding-hardening.md` and the in-code TODO in `security/auth.ts`, even though web tokens now support both explicit workspace scopes and unrestricted owner-wide profile access.
 - The bundled SPA under `web-dist/` is now the primary remote UI owner. The inline web chat is retained only as an explicit `/basic` diagnostics fallback surface.
 - Discord integration now subscribes through a formal gateway event-listener seam in `bridge/agent-bridge.ts` rather than rewriting `GatewayServer` methods at runtime.
 
@@ -30,7 +30,7 @@ This feature is Sero's remote-access gateway. It owns the WebSocket/HTTP server,
 - Discord image delivery depends on Electron/Chromium networking and `nativeImage` downscaling; transport changes need real-world verification.
 
 ## Surprising discoveries
-- The gateway originally used a flat access model where any valid token reached any workspace; this was replaced with scoped workspace tokens in `4350404d`, while the master-token hardening TODO remains open.
+- The gateway originally used a flat access model where any valid token reached any workspace; `4350404d` replaced that with scope-aware web tokens, and `980b61ea` later corrected the default QR/device-pairing product flow from workspace-scoped sharing to owner-wide profile access. The master-token hardening TODO remains open.
 - `/sero abort` in the Discord adapter only sent a reply and never called `agentOps.abort()` before the 2026-04-12 hardening pass (resolved).
 - `validateRequest()` previously checked only the `type` field before force-casting payloads; this was closed in `19242c02` (tracker synced 2026-04-16).
 - Malformed `gateway-config.json` previously got overwritten with defaults on load; this was fixed in `fc8558ed` (2026-04-16).
@@ -45,7 +45,7 @@ This feature is Sero's remote-access gateway. It owns the WebSocket/HTTP server,
 
 ### What changed
 - Added `server/access-control.ts` and threaded workspace/session/artifact authorization through gateway request handling.
-- Web tokens are now scoped to explicit workspace IDs, and QR pairing in the desktop UI creates workspace-scoped tokens through preload + IPC.
+- Web tokens are now scoped to explicit workspace IDs, and QR pairing in the desktop UI initially created workspace-scoped tokens through preload + IPC (later corrected to owner-wide profile pairing in the 2026-04-17 follow-up pass).
 - `gateway-ops` now validates that an existing session belongs to the requested workspace before reopening it.
 - Discord `/sero abort` now calls `agentOps.abort()` and reports failures honestly.
 
@@ -83,6 +83,23 @@ This feature is Sero's remote-access gateway. It owns the WebSocket/HTTP server,
 - Removed the Discord adapter's remaining easy type escapes/non-null assertions in message routing (`sendTyping` guard + mention handling).
 - Reworked static-file serving so `web-dist` resolution and file-manifest discovery are primed once at startup, with request-time lookups served from cached metadata instead of repeated `existsSync`/`statSync` checks.
 - Added focused regression coverage for the new event-listener bridge and static-file cache/fallback behavior.
+
+### Still outstanding
+- None in the tracked gateway folder plan; remaining gateway hardening debt is the separate master-token security follow-up in `docs/security/outstanding-hardening.md`.
+
+## Post-fix snapshot — 2026-04-17 (owner-wide QR pairing correction)
+
+### Metrics after fixes
+- Total files: 19 (unchanged)
+- Largest file: `apps/desktop/electron/features/gateway/index.ts` (497 LOC, unchanged)
+- Files over 500 LOC: none (unchanged)
+- Type escape hatches remaining: 1 (`chromiumFetch` response compatibility cast in `channels/discord.ts`, unchanged)
+
+### What changed
+- Extended web-token storage/protocol handling so web tokens can be either explicitly scoped (`workspaceIds: string[]`) or unrestricted owner tokens (`workspaceIds: null`), while preserving compatibility with older tokens that omitted the field entirely.
+- Added focused owner-token regression coverage that locks in all-workspaces access, future-workspace visibility after issuance, and the rule that owner web tokens still cannot perform master-only token management.
+- Corrected the desktop QR/device-pairing product flow: `Connect Device` now creates an expiring, revocable owner web token for the whole profile instead of forcing one workspace per QR code.
+- Updated the desktop pairing copy and API contract so the flow now clearly describes profile-wide remote access across current and future workspaces.
 
 ### Still outstanding
 - None in the tracked gateway folder plan; remaining gateway hardening debt is the separate master-token security follow-up in `docs/security/outstanding-hardening.md`.

--- a/docs/deslopify/apps/desktop/electron/features/gateway/plan.md
+++ b/docs/deslopify/apps/desktop/electron/features/gateway/plan.md
@@ -53,11 +53,22 @@ _Plan drafted: 2026-04-12_
 - Benefits: materially better remote-access safety, a fixed Discord control path, stronger validation on an untrusted boundary, and lower coupling between the Discord adapter and the core server.
 - Trade-offs: workspace-scoped auth is not a cosmetic refactor; it changes how tokens are issued, stored, and validated, and it will touch IPC/UI tooling that displays gateway credentials.
 
+## Product-direction correction — 2026-04-17
+- The original hardening pass treated desktop QR/device pairing like a delegated sharing flow and therefore made QR tokens workspace-scoped.
+- That turned out to be the wrong product fit for Sero's default gateway model: in a profile there is typically one owner who needs reliable remote access to all current and future workspaces.
+- The follow-up correction kept the stronger security model but split the semantics more cleanly:
+  - **master token** — unrestricted + token-management authority
+  - **owner web token** — unrestricted workspace access, but still not allowed to manage tokens
+  - **scoped web token** — still available for explicit limited-access/share scenarios
+- As a result, the gateway keeps scope-aware auth, but `Connect Device` now issues owner-wide profile tokens instead of one-workspace QR pairings.
+
 ## Dependencies & Risks
 - Workspace-scoped auth must land together with token management/UI changes or remote clients will be stranded between formats.
 - Tightening request validation can reject payloads that older clients currently send; include compatibility notes if external clients exist beyond the repo.
 - Refactoring Discord subscriptions must preserve current gateway event delivery order for streamed text and image attachments.
 - Static-file serving changes must be tested in dev, packaged builds, and Tailscale-exposed flows because the current relative fallback logic is subtle.
+- Owner-wide QR tokens must remain distinct from master tokens so device pairing does not accidentally acquire token-management authority.
+- Optional limited-share UX is still a separate product surface; the follow-up pass intentionally fixed owner remote access first rather than exposing a new sharing UI.
 
 ## Next Steps
 1. ~~Fix `/sero abort` first.~~ ✅ 2026-04-12 (`4350404d`)
@@ -67,7 +78,8 @@ _Plan drafted: 2026-04-12_
 5. ~~Replace Discord monkey-patching with a formal subscription API.~~ ✅ 2026-04-16 (`32320672`)
 6. ~~Move static-file resolution off the synchronous hot path.~~ ✅ 2026-04-16 (`32320672`)
 7. ~~Choose one primary remote-web ownership model.~~ ✅ 2026-04-16 (`766fd45e`)
-8. Verification checklist:
+8. ~~Correct QR/device pairing from workspace-scoped sharing to owner-wide profile access while preserving scoped-token support for non-QR flows.~~ ✅ 2026-04-17 (`12df5e7c`, `02a0d3c4`, `980b61ea`)
+9. Verification checklist:
    - Connect via web token and confirm only authorized workspaces/sessions/files are visible.
    - Prompt, steer, abort, list files, and fetch session history from an authorized workspace.
    - Verify `/sero abort` actually stops an in-flight Discord task.
@@ -92,3 +104,13 @@ _Plan drafted: 2026-04-12_
   - Chose `web-dist/` SPA as the primary web remote UI owner by making the standalone web-chat port redirect root traffic to the gateway SPA.
   - Retained `/basic` as an explicit diagnostics fallback surface for no-build recovery scenarios.
   - Added focused coverage for redirect + fallback behavior in `web-chat-server.test.ts`.
+- 2026-04-17 — `12df5e7c` — `refactor(gateway): add owner-wide web token scope model`
+  - Extended web-token storage/protocol semantics so web tokens can represent either explicit workspace scopes or unrestricted owner-wide access via `workspaceIds: null`.
+  - Preserved compatibility with existing scoped tokens and legacy tokens that omitted `workspaceIds`.
+  - Kept master-only token-management routes (`create/list/revoke_web_token`) reserved for the master token.
+- 2026-04-17 — `02a0d3c4` — `test(gateway): cover owner-wide authorization flows`
+  - Added focused owner-token coverage for all-workspaces access, future-workspace visibility after token issuance, and session/file/history/artifact access across the unrestricted web-token path.
+  - Locked in the rule that owner web tokens still cannot use master-only token-management operations.
+- 2026-04-17 — `980b61ea` — `feat(desktop): make QR pairing profile-wide`
+  - Corrected `Connect Device` / QR login generation to mint owner-wide profile tokens instead of single-workspace QR tokens.
+  - Updated preload + renderer API contracts and the desktop pairing copy to describe whole-profile remote access across current and future workspaces.

--- a/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
+++ b/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
@@ -101,10 +101,10 @@ without collapsing owner web tokens into master auth.
 - [x] Ensure future workspaces automatically appear to already-paired owner devices
 
 ### QR / IPC / desktop UX
-- [ ] Change QR login generation to mint owner-wide web tokens instead of single-workspace tokens
-- [ ] Update renderer/preload/API contract if `workspaceId` is no longer needed for QR generation
-- [ ] Update `ConnectDeviceDialog` copy so it clearly says the paired device can access the whole profile / all workspaces
-- [ ] Remove now-misleading single-workspace wording from the pairing flow
+- [x] Change QR login generation to mint owner-wide web tokens instead of single-workspace tokens
+- [x] Update renderer/preload/API contract if `workspaceId` is no longer needed for QR generation
+- [x] Update `ConnectDeviceDialog` copy so it clearly says the paired device can access the whole profile / all workspaces
+- [x] Remove now-misleading single-workspace wording from the pairing flow
 
 ### Regression coverage
 - [x] Add focused tests for unrestricted owner web tokens

--- a/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
+++ b/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
@@ -78,17 +78,17 @@ without collapsing owner web tokens into master auth.
 ## Progress checklist
 
 ### Design and scope model
-- [ ] Confirm the wire/storage representation for unrestricted web-token scope
-  - [ ] Decide between `workspaceIds: null`, omitted field, or explicit `scope: 'all'`
-  - [ ] Preserve backward compatibility for existing scoped tokens if practical
-- [ ] Keep master-only operations master-only
-  - [ ] `create_web_token`
-  - [ ] `list_web_tokens`
-  - [ ] `revoke_web_token`
+- [x] Confirm the wire/storage representation for unrestricted web-token scope
+  - [x] Decide on `workspaceIds: null` for unrestricted owner-wide web tokens
+  - [x] Preserve backward compatibility for existing scoped tokens and legacy no-`workspaceIds` tokens where practical
+- [x] Keep master-only operations master-only
+  - [x] `create_web_token`
+  - [x] `list_web_tokens`
+  - [x] `revoke_web_token`
 
 ### Gateway auth and authorization
-- [ ] Update web-token storage/normalization to support unrestricted owner tokens
-- [ ] Update gateway auth validation to return unrestricted workspace access for owner web tokens
+- [x] Update web-token storage/normalization to support unrestricted owner tokens
+- [x] Update gateway auth validation to return unrestricted workspace access for owner web tokens
 - [ ] Verify request authorization still works correctly for:
   - [ ] `list_workspaces`
   - [ ] `list_sessions`
@@ -108,11 +108,11 @@ without collapsing owner web tokens into master auth.
 
 ### Regression coverage
 - [ ] Add focused tests for unrestricted owner web tokens
-  - [ ] owner web token can list all workspaces
+  - [x] owner web token can list all workspaces
   - [ ] owner web token can access a workspace created after token issuance
-  - [ ] owner web token is still blocked from master-only token management routes
-  - [ ] existing scoped-token behavior still works if retained
-- [ ] Update any affected gateway protocol / auth / IPC tests
+  - [x] owner web token is still blocked from master-only token management routes
+  - [x] existing scoped-token behavior still works if retained
+- [x] Update any affected gateway protocol / auth / IPC tests
 
 ### Documentation sync
 - [ ] Update `docs/deslopify/apps/desktop/electron/features/gateway/facts.md`

--- a/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
+++ b/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
@@ -89,16 +89,16 @@ without collapsing owner web tokens into master auth.
 ### Gateway auth and authorization
 - [x] Update web-token storage/normalization to support unrestricted owner tokens
 - [x] Update gateway auth validation to return unrestricted workspace access for owner web tokens
-- [ ] Verify request authorization still works correctly for:
-  - [ ] `list_workspaces`
-  - [ ] `list_sessions`
-  - [ ] `create_session`
-  - [ ] `prompt`
-  - [ ] `list_files`
-  - [ ] `read_file`
-  - [ ] `get_session_history`
-  - [ ] session/artifact event fan-out
-- [ ] Ensure future workspaces automatically appear to already-paired owner devices
+- [x] Verify request authorization still works correctly for:
+  - [x] `list_workspaces`
+  - [x] `list_sessions`
+  - [x] `create_session`
+  - [x] `prompt`
+  - [x] `list_files`
+  - [x] `read_file`
+  - [x] `get_session_history`
+  - [x] session/artifact event fan-out
+- [x] Ensure future workspaces automatically appear to already-paired owner devices
 
 ### QR / IPC / desktop UX
 - [ ] Change QR login generation to mint owner-wide web tokens instead of single-workspace tokens
@@ -107,9 +107,9 @@ without collapsing owner web tokens into master auth.
 - [ ] Remove now-misleading single-workspace wording from the pairing flow
 
 ### Regression coverage
-- [ ] Add focused tests for unrestricted owner web tokens
+- [x] Add focused tests for unrestricted owner web tokens
   - [x] owner web token can list all workspaces
-  - [ ] owner web token can access a workspace created after token issuance
+  - [x] owner web token can access a workspace created after token issuance
   - [x] owner web token is still blocked from master-only token management routes
   - [x] existing scoped-token behavior still works if retained
 - [x] Update any affected gateway protocol / auth / IPC tests
@@ -124,9 +124,9 @@ without collapsing owner web tokens into master auth.
 - [ ] Add a brief execution summary to `docs/deslop.md` if this lands as a tracked cleanup/refinement
 
 ### Validation
-- [ ] Run targeted gateway tests
+- [x] Run targeted gateway tests
 - [ ] Run any targeted renderer/web-remote tests touched by the API change
-- [ ] Run `pnpm typecheck`
+- [x] Run `pnpm typecheck`
 
 ## Likely files
 

--- a/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
+++ b/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
@@ -1,0 +1,170 @@
+---
+title: Gateway Owner-Wide QR Access Plan
+date: 2026-04-17
+status: proposed
+author: OpenAI
+related:
+  - apps/desktop/electron/features/gateway
+  - apps/desktop/electron/ipc/gateway
+  - apps/desktop/src/components/layout/device
+  - docs/deslopify/apps/desktop/electron/features/gateway/facts.md
+  - docs/deslopify/apps/desktop/electron/features/gateway/plan.md
+---
+
+# Gateway Owner-Wide QR Access Plan
+
+## Goal
+
+Change the device-pairing / QR-login flow from **single-workspace web tokens** to **profile-wide owner access** so a paired remote device can access:
+
+- all current workspaces
+- future workspaces created after pairing
+
+without requiring the user to generate a new QR code from the host machine.
+
+## Product decision
+
+Sero gateway pairing is an **owner remote-access** flow, not a delegated workspace-sharing flow.
+
+That means:
+
+- **Connect Device** should grant profile-wide remote access for that profile
+- the paired token should still be a **web token**, not a master token
+- the token should remain **expiring** and **revocable**
+- token-management/admin behavior should remain distinct from master-token behavior
+- optional limited workspace-sharing can be added later as a separate flow, not by overloading the default pairing UX
+
+## Current problem
+
+Today, `ConnectDeviceDialog` calls `getQrLoginData(workspaceId, expiryDays)`, and the main process creates a web token scoped to `[workspaceId]`.
+
+That means a paired device:
+
+- can access only the workspace that was active when the QR code was generated
+- cannot access newly created workspaces
+- needs a new token/QR code to switch to another workspace
+
+This is stronger than necessary for the owner-access use case and harms the gateway's core remote-work usability.
+
+## Desired end state
+
+The QR/device-pairing flow should mint a web token with **all-workspace access**.
+
+Recommended semantic model:
+
+- **Master token**
+  - unrestricted workspace access
+  - can manage/revoke/create tokens
+- **Owner web token**
+  - unrestricted workspace access
+  - can use remote workspace/session/file/artifact operations
+  - cannot perform master-only token management actions
+- **Future scoped share token**
+  - optional later feature for restricted workspace sharing
+
+Implementation-wise, the cleanest shape is to allow web tokens to carry either:
+
+- an explicit `workspaceIds: string[]`, or
+- an unrestricted scope marker (for example `workspaceIds: null`)
+
+so the connection auth path can distinguish:
+
+- unrestricted web token
+- scoped web token
+- master token
+
+without collapsing owner web tokens into master auth.
+
+## Progress checklist
+
+### Design and scope model
+- [ ] Confirm the wire/storage representation for unrestricted web-token scope
+  - [ ] Decide between `workspaceIds: null`, omitted field, or explicit `scope: 'all'`
+  - [ ] Preserve backward compatibility for existing scoped tokens if practical
+- [ ] Keep master-only operations master-only
+  - [ ] `create_web_token`
+  - [ ] `list_web_tokens`
+  - [ ] `revoke_web_token`
+
+### Gateway auth and authorization
+- [ ] Update web-token storage/normalization to support unrestricted owner tokens
+- [ ] Update gateway auth validation to return unrestricted workspace access for owner web tokens
+- [ ] Verify request authorization still works correctly for:
+  - [ ] `list_workspaces`
+  - [ ] `list_sessions`
+  - [ ] `create_session`
+  - [ ] `prompt`
+  - [ ] `list_files`
+  - [ ] `read_file`
+  - [ ] `get_session_history`
+  - [ ] session/artifact event fan-out
+- [ ] Ensure future workspaces automatically appear to already-paired owner devices
+
+### QR / IPC / desktop UX
+- [ ] Change QR login generation to mint owner-wide web tokens instead of single-workspace tokens
+- [ ] Update renderer/preload/API contract if `workspaceId` is no longer needed for QR generation
+- [ ] Update `ConnectDeviceDialog` copy so it clearly says the paired device can access the whole profile / all workspaces
+- [ ] Remove now-misleading single-workspace wording from the pairing flow
+
+### Regression coverage
+- [ ] Add focused tests for unrestricted owner web tokens
+  - [ ] owner web token can list all workspaces
+  - [ ] owner web token can access a workspace created after token issuance
+  - [ ] owner web token is still blocked from master-only token management routes
+  - [ ] existing scoped-token behavior still works if retained
+- [ ] Update any affected gateway protocol / auth / IPC tests
+
+### Documentation sync
+- [ ] Update `docs/deslopify/apps/desktop/electron/features/gateway/facts.md`
+  - [ ] replace the “QR pairing creates workspace-scoped tokens” statements with the new owner-wide behavior
+  - [ ] note whether scoped tokens still exist for non-QR use cases
+- [ ] Update `docs/deslopify/apps/desktop/electron/features/gateway/plan.md`
+  - [ ] record the product-direction correction from workspace-scoped QR pairing to owner-wide pairing
+  - [ ] note any remaining follow-up work for optional limited-share tokens
+- [ ] Add a brief execution summary to `docs/deslop.md` if this lands as a tracked cleanup/refinement
+
+### Validation
+- [ ] Run targeted gateway tests
+- [ ] Run any targeted renderer/web-remote tests touched by the API change
+- [ ] Run `pnpm typecheck`
+
+## Likely files
+
+### Gateway auth / server
+- `apps/desktop/electron/features/gateway/bridge/web-tokens.ts`
+- `apps/desktop/electron/features/gateway/security/auth.ts`
+- `apps/desktop/electron/features/gateway/server/access-control.ts`
+- `apps/desktop/electron/features/gateway/server/request-handler.ts`
+- `apps/desktop/electron/features/gateway/server/extended-handlers.ts`
+- `apps/desktop/electron/features/gateway/index.ts`
+
+### IPC / preload / renderer
+- `apps/desktop/electron/ipc/gateway/gateway.ts`
+- `apps/desktop/electron/preload/platform/host-services.ts`
+- `apps/desktop/src/types/electron-services.d.ts`
+- `apps/desktop/src/types/gateway.ts`
+- `apps/desktop/src/components/layout/device/ConnectDeviceDialog.tsx`
+
+### Tests
+- `apps/desktop/electron/__tests__/features/gateway/*`
+- possibly any renderer tests affected by the pairing contract
+
+### Docs
+- `docs/deslopify/apps/desktop/electron/features/gateway/facts.md`
+- `docs/deslopify/apps/desktop/electron/features/gateway/plan.md`
+- `docs/deslop.md`
+
+## Risks / watch-outs
+
+- Do **not** accidentally make owner web tokens equivalent to master tokens.
+- Avoid baking single-workspace assumptions into the web remote UI after this change.
+- If token storage format changes, preserve compatibility with already-issued tokens where reasonable.
+- Make sure unrestricted web tokens naturally include future workspaces rather than snapshotting the workspace list at issuance time.
+
+## Acceptance criteria
+
+- Pairing a device from `Connect Device` grants access to all current and future workspaces in the profile.
+- The paired device does not need a new QR code just because a different workspace is opened or created later.
+- The token remains revocable/expiring and is still not allowed to perform master-only token-management operations.
+- Existing authorization provenance for sessions/artifacts remains intact.
+- `facts.md` and `plan.md` under `docs/deslopify/.../gateway/` are updated to reflect the new behavior.

--- a/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
+++ b/docs/plans/2026-04-17-gateway-owner-wide-qr-access.md
@@ -115,13 +115,13 @@ without collapsing owner web tokens into master auth.
 - [x] Update any affected gateway protocol / auth / IPC tests
 
 ### Documentation sync
-- [ ] Update `docs/deslopify/apps/desktop/electron/features/gateway/facts.md`
-  - [ ] replace the “QR pairing creates workspace-scoped tokens” statements with the new owner-wide behavior
-  - [ ] note whether scoped tokens still exist for non-QR use cases
-- [ ] Update `docs/deslopify/apps/desktop/electron/features/gateway/plan.md`
-  - [ ] record the product-direction correction from workspace-scoped QR pairing to owner-wide pairing
-  - [ ] note any remaining follow-up work for optional limited-share tokens
-- [ ] Add a brief execution summary to `docs/deslop.md` if this lands as a tracked cleanup/refinement
+- [x] Update `docs/deslopify/apps/desktop/electron/features/gateway/facts.md`
+  - [x] replace the “QR pairing creates workspace-scoped tokens” statements with the new owner-wide behavior
+  - [x] note whether scoped tokens still exist for non-QR use cases
+- [x] Update `docs/deslopify/apps/desktop/electron/features/gateway/plan.md`
+  - [x] record the product-direction correction from workspace-scoped QR pairing to owner-wide pairing
+  - [x] note any remaining follow-up work for optional limited-share tokens
+- [x] Add a brief execution summary to `docs/deslop.md` if this lands as a tracked cleanup/refinement
 
 ### Validation
 - [x] Run targeted gateway tests

--- a/docs/plans/index.md
+++ b/docs/plans/index.md
@@ -2,6 +2,7 @@
 
 Ad-hoc planning documents and implementation backlogs.
 
+- [2026-04-17 — Gateway Owner-Wide QR Access Plan](./2026-04-17-gateway-owner-wide-qr-access.md)
 - [2026-04-13 — Apps Desktop Wave F — Periphery Review and Closeout](./2026-04-13-apps-desktop-wave-f-periphery-closeout.md)
 - [2026-04-12 — PR 137 Follow-ups — Model Refresh, Collaboration State, and Desktop Hardening](./2026-04-12-pr-137-followups.md)
 - [2026-04-12 — PR 136 Follow-ups — Gateway Scope, Recovery UX, and Coverage](./2026-04-12-pr-136-followups.md)


### PR DESCRIPTION
## Summary
- change gateway web tokens to support unrestricted owner-wide scope via `workspaceIds: null`
- keep master-only token management separate from owner web tokens
- make `Connect Device` / QR pairing profile-wide so paired devices can access current and future workspaces
- add focused regression coverage for owner-token auth flows and sync the gateway docs/plans

## Why
The previous QR/device-pairing behavior treated the flow like delegated workspace sharing. In practice, Sero's gateway is primarily an owner remote-access surface, so requiring a new QR code per workspace was the wrong product fit and broke the remote-workflow story.

## Changes
- support both scoped web tokens (`workspaceIds: string[]`) and unrestricted owner tokens (`workspaceIds: null`)
- preserve compatibility with legacy tokens that omitted `workspaceIds`
- keep `create_web_token`, `list_web_tokens`, and `revoke_web_token` master-only
- update QR login IPC/preload/renderer APIs to mint profile-wide owner tokens
- update `ConnectDeviceDialog` copy to explain profile-wide access across current and future workspaces
- add owner-token integration coverage for workspaces, sessions, files, history, prompt flow, and event fan-out
- refresh `docs/deslopify/.../gateway/{facts,plan}.md`, `docs/deslop.md`, and the tracking plan

## Validation
- `pnpm --filter @sero/desktop exec vitest run electron/__tests__/features/gateway/protocol.test.ts electron/__tests__/features/gateway/gateway-integration.test.ts electron/__tests__/features/gateway/gateway-owner-token.test.ts electron/__tests__/features/gateway/web-tokens.test.ts`
- `pnpm typecheck`
