### PR TITLE
fix(plugins): harden host compatibility and bridged CLI lifecycle

### DIFF
--- a/apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts
@@ -1,0 +1,320 @@
+import os from 'os';
+import path from 'path';
+import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentSession, LoadExtensionsResult, ToolDefinition } from '@mariozechner/pi-coding-agent';
+import { Type } from '@sinclair/typebox';
+
+import {
+  bridgeExtensionTools,
+  clearBridgedExtensionSessionStateForSession,
+  getCliRegistry,
+  resetCliRegistryForTests,
+} from '@electron/cli';
+import { createSeroCliTool } from '@electron/cli/core/tool';
+import type { CliCommandContext, CliResult } from '@electron/cli/core/types';
+import { installCliSessionBridge } from '@electron/cli/bridges/session-bridge';
+import { workspaceManager } from '@electron/shared/infra/shared-infra';
+
+type CustomCliToolDefinition = ToolDefinition & {
+  cli: {
+    summary?: string;
+    help?: string;
+    group?: string;
+    overrideBuiltin?: boolean;
+    execute: (
+      args: string[],
+      context: CliCommandContext,
+    ) => Promise<CliResult>;
+  };
+};
+
+function installSessionBridge(sessionIds: string[]) {
+  installCliSessionBridge({
+    getSessionEntry: (sessionId) => {
+      if (!sessionIds.includes(sessionId)) return undefined;
+      return {
+        sessionId,
+        workspaceId: 'ws-1',
+        session: {} as AgentSession,
+        lastSessionName: undefined,
+      };
+    },
+    getActiveSessionForWorkspace: () => undefined,
+    getActiveTurnId: () => null,
+    noteTurnStart: () => {},
+    noteTurnEnd: () => {},
+    consumeTurnBudget: () => ({ allowed: true, count: 0, limit: 50 }),
+    setSessionTitle: () => {},
+  });
+}
+
+function makeLoadExtensionsResult(
+  extensionPath: string,
+  tool: CustomCliToolDefinition,
+): LoadExtensionsResult {
+  return {
+    extensions: [
+      {
+        path: extensionPath,
+        resolvedPath: extensionPath,
+        handlers: new Map(),
+        tools: new Map([
+          [
+            tool.name,
+            {
+              definition: tool,
+              extensionPath,
+            },
+          ],
+        ]),
+        messageRenderers: new Map(),
+        commands: new Map(),
+        flags: new Map(),
+        shortcuts: new Map(),
+      },
+    ],
+    errors: [],
+    runtime: {} as LoadExtensionsResult['runtime'],
+  };
+}
+
+describe('custom tool CLI bridge metadata', () => {
+  let tmpDir = '';
+
+  beforeEach(async () => {
+    resetCliRegistryForTests();
+    vi.spyOn(workspaceManager, 'getPath').mockReturnValue('/tmp/ws-1');
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), 'custom-cli-bridge-'));
+  });
+
+  afterEach(async () => {
+    resetCliRegistryForTests();
+    vi.restoreAllMocks();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('lets a plugin tool override a builtin command with custom help and raw-args execution', async () => {
+    const pluginDir = path.join(tmpDir, 'plugin-google');
+    const extensionPath = path.join(pluginDir, 'extension', 'index.js');
+    await mkdir(path.dirname(extensionPath), { recursive: true });
+    await writeFile(extensionPath, 'export default {}\n', 'utf8');
+    await writeFile(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify({
+        name: '@test/plugin-google',
+        version: '1.0.0',
+        sero: {
+          plugin: {
+            category: 'integrations',
+            tags: ['google'],
+            bridgeTools: ['google'],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    const customExecute = vi.fn(async (args: string[]) => ({
+      output: `plugin:${args.join(' ')}`,
+      exitCode: 0,
+    }));
+
+    const tool: CustomCliToolDefinition = {
+      name: 'google',
+      label: 'Google',
+      description: 'Plugin-owned Google bridge.',
+      parameters: Type.Object({
+        service: Type.String(),
+      }),
+      execute: async () => ({
+        content: [{ type: 'text', text: 'tool execute' }],
+        details: null,
+      }),
+      cli: {
+        summary: 'Plugin Google summary',
+        help: 'plugin google help',
+        group: 'Google',
+        overrideBuiltin: true,
+        execute: customExecute,
+      },
+    };
+
+    getCliRegistry().register({
+      name: 'google',
+      summary: 'Legacy builtin Google command',
+      help: 'legacy google help',
+      source: 'builtin',
+      group: 'Google',
+      execute: async () => ({ output: 'builtin google', exitCode: 0 }),
+    });
+
+    bridgeExtensionTools(makeLoadExtensionsResult(extensionPath, tool));
+
+    const command = getCliRegistry().get('google');
+    expect(command?.source).toBe('app');
+    expect(command?.summary).toBe('Plugin Google summary');
+    expect(command?.help).toBe('plugin google help');
+    expect(command?.group).toBe('Google');
+
+    const result = await command!.execute(
+      ['auth', 'list', '--check'],
+      {
+        workspaceId: 'ws-1',
+        cwd: '/tmp/ws-1',
+        invocation: {
+          workspaceId: 'ws-1',
+          sessionId: null,
+          turnId: null,
+          source: 'tool',
+        },
+        workspaceManager: {} as never,
+        containerManager: {} as never,
+      },
+    );
+
+    expect(customExecute).toHaveBeenCalledWith(
+      ['auth', 'list', '--check'],
+      expect.objectContaining({ workspaceId: 'ws-1', cwd: '/tmp/ws-1' }),
+      undefined,
+    );
+    expect(result).toEqual({
+      output: 'plugin:auth list --check',
+      exitCode: 0,
+      content: undefined,
+      details: undefined,
+    });
+  });
+
+  it('refreshes custom command help and execution when a session reloads the same plugin', async () => {
+    installSessionBridge(['session-1']);
+
+    const pluginDir = path.join(tmpDir, 'plugin-google-live');
+    const extensionPath = path.join(pluginDir, 'extension', 'index.js');
+    await mkdir(path.dirname(extensionPath), { recursive: true });
+    await writeFile(extensionPath, 'export default {}\n', 'utf8');
+    await writeFile(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify({
+        name: '@test/plugin-google-live',
+        version: '1.0.0',
+        sero: {
+          plugin: {
+            category: 'integrations',
+            tags: ['google'],
+            bridgeTools: ['google'],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    const executeV1 = vi.fn(async () => ({ output: 'v1', exitCode: 0 }));
+    const executeV2 = vi.fn(async () => ({ output: 'v2', exitCode: 0 }));
+
+    const baseTool = {
+      name: 'google',
+      label: 'Google',
+      description: 'Plugin-owned Google bridge.',
+      parameters: Type.Object({
+        service: Type.String(),
+      }),
+      execute: async () => ({
+        content: [{ type: 'text', text: 'tool execute' }],
+        details: null,
+      }),
+    } satisfies Omit<CustomCliToolDefinition, 'cli'>;
+
+    const toolV1: CustomCliToolDefinition = {
+      ...baseTool,
+      cli: {
+        summary: 'Google summary v1',
+        help: 'google help v1',
+        group: 'Google',
+        overrideBuiltin: true,
+        execute: executeV1,
+      },
+    };
+
+    const toolV2: CustomCliToolDefinition = {
+      ...baseTool,
+      cli: {
+        summary: 'Google summary v2',
+        help: 'google help v2',
+        group: 'Google',
+        overrideBuiltin: true,
+        execute: executeV2,
+      },
+    };
+
+    bridgeExtensionTools(makeLoadExtensionsResult(extensionPath, toolV1), { sessionId: 'session-1' });
+    expect(getCliRegistry().get('google')?.summary).toBe('Google summary v1');
+    expect(getCliRegistry().get('google')?.help).toBe('google help v1');
+
+    bridgeExtensionTools(makeLoadExtensionsResult(extensionPath, toolV2), { sessionId: 'session-1' });
+    expect(getCliRegistry().get('google')?.summary).toBe('Google summary v2');
+    expect(getCliRegistry().get('google')?.help).toBe('google help v2');
+
+    const tool = createSeroCliTool(getCliRegistry(), 'ws-1', 'session-1');
+    const result = await tool.execute(
+      'tool-1',
+      { command: 'google auth list' },
+      undefined,
+      undefined,
+      { cwd: '/tmp/ws-1' } as never,
+    );
+
+    expect(executeV1).not.toHaveBeenCalled();
+    expect(executeV2).toHaveBeenCalledWith(
+      ['auth', 'list'],
+      expect.objectContaining({ workspaceId: 'ws-1', cwd: '/tmp/ws-1' }),
+      undefined,
+    );
+    expect(result.content).toEqual([{ type: 'text', text: 'v2' }]);
+  });
+
+  it('removes session-owned app commands when bridged session state is cleared', async () => {
+    installSessionBridge(['session-1']);
+
+    const pluginDir = path.join(tmpDir, 'plugin-cleanup');
+    const extensionPath = path.join(pluginDir, 'extension', 'index.js');
+    await mkdir(path.dirname(extensionPath), { recursive: true });
+    await writeFile(extensionPath, 'export default {}\n', 'utf8');
+    await writeFile(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify({
+        name: '@test/plugin-cleanup',
+        version: '1.0.0',
+        sero: {
+          plugin: {
+            category: 'utilities',
+            tags: ['cleanup'],
+            bridgeTools: ['plugin_cleanup'],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    const tool: CustomCliToolDefinition = {
+      name: 'plugin_cleanup',
+      label: 'Plugin Cleanup',
+      description: 'Cleanup command.',
+      parameters: Type.Object({}),
+      execute: async () => ({
+        content: [{ type: 'text', text: 'cleanup' }],
+        details: null,
+      }),
+      cli: {
+        summary: 'Cleanup summary',
+        execute: async () => ({ output: 'cleanup', exitCode: 0 }),
+      },
+    };
+
+    bridgeExtensionTools(makeLoadExtensionsResult(extensionPath, tool), { sessionId: 'session-1' });
+    expect(getCliRegistry().get('plugin_cleanup')).toBeTruthy();
+
+    clearBridgedExtensionSessionStateForSession('session-1');
+    expect(getCliRegistry().get('plugin_cleanup')).toBeUndefined();
+  });
+});

--- a/apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts
@@ -286,4 +286,31 @@ describe('bridged extension sessions', () => {
 
     expect(sendUserMessage).toHaveBeenCalledWith('/memory list', { deliverAs: 'followUp' });
   });
+
+  it('does not resolve another session\'s bridged commands', async () => {
+    installSessionBridge(['session-1', 'session-2']);
+
+    bridgeExtensionTools(
+      makeLoadExtensionsResult({
+        extensionPath: '/tmp/plugin-d/extension/index.ts',
+        commands: [{
+          name: 'session_two_only',
+          description: 'Only available in session two.',
+          handler: async () => undefined,
+        }],
+      }),
+      { sessionId: 'session-2' },
+    );
+
+    const tool = createSeroCliTool(getCliRegistry(), 'ws-1', 'session-1');
+    const result = await tool.execute(
+      'tool-1',
+      { command: 'session_two_only' },
+      undefined,
+      undefined,
+      { cwd: '/tmp/ws-1' } as never,
+    );
+
+    expect(result.content).toEqual([{ type: 'text', text: 'ERROR: Unknown command: session_two_only' }]);
+  });
 });

--- a/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
+++ b/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
@@ -120,4 +120,43 @@ describe('CLI prompt block', () => {
     expect(prompt).not.toContain('secret');
     expect(prompt).not.toContain('help — Show help');
   });
+
+  it('scopes session-owned commands to the active session when building prompts', () => {
+    const registry = new CliRegistry();
+    const execute = async () => ({ output: 'ok', exitCode: 0 });
+
+    registry.replaceAppCommandsForSession('session-1', [
+      {
+        name: 'alpha',
+        summary: 'Session alpha',
+        group: 'Apps',
+        source: 'app',
+        owner: {
+          kind: 'session-extension',
+          sessionId: 'session-1',
+          extensionPath: '/tmp/plugin-a/extension/index.js',
+        },
+        execute,
+      },
+    ]);
+    registry.replaceAppCommandsForSession('session-2', [
+      {
+        name: 'beta',
+        summary: 'Session beta',
+        group: 'Apps',
+        source: 'app',
+        owner: {
+          kind: 'session-extension',
+          sessionId: 'session-2',
+          extensionPath: '/tmp/plugin-b/extension/index.js',
+        },
+        execute,
+      },
+    ]);
+
+    const prompt = buildCliPromptBlock(registry, { sessionId: 'session-1' });
+
+    expect(prompt).toContain('alpha — Session alpha');
+    expect(prompt).not.toContain('beta — Session beta');
+  });
 });

--- a/apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts
@@ -162,6 +162,7 @@ describe('app discovery devPort handling', () => {
         category: 'utilities',
         tags: ['test', ' utilities '],
         minSeroVersion: '0.1.0',
+        requiredHostCapabilities: [' appAgent.invokeTool ', 'tool.cli'],
         preBuilt: false,
         bridgeTools: [' tool_a ', 'tool_b'],
       });
@@ -178,8 +179,14 @@ describe('app discovery devPort handling', () => {
           category: 'utilities',
           tags: ['test', 'utilities'],
           minSeroVersion: '0.1.0',
+          requiredHostCapabilities: ['appAgent.invokeTool', 'tool.cli'],
           preBuilt: false,
           bridgeTools: ['tool_a', 'tool_b'],
+        },
+        hostCompatibility: {
+          supported: true,
+          hostVersion: '0.1.0',
+          issues: [],
         },
       });
 
@@ -218,6 +225,33 @@ describe('app discovery devPort handling', () => {
       unregisterAppPath(packageDir);
     } finally {
       warnSpy.mockRestore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('marks plugins unsupported when their host requirements are not satisfied', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-app-discovery-plugin-compat-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+
+    try {
+      const packageDir = path.join(tempRoot, 'incompatible-plugin');
+      await writeManifestPackage(packageDir, 'incompatible-plugin', 'Incompatible Plugin', {
+        category: 'utilities',
+        tags: ['test'],
+        minSeroVersion: '9.9.9',
+      });
+
+      const { discoverApps, registerAppPath, unregisterAppPath } = await importAppDiscovery();
+
+      registerAppPath(packageDir);
+      const manifest = (await discoverApps()).find((app) => app.id === 'incompatible-plugin');
+
+      expect(manifest?.hostCompatibility?.supported).toBe(false);
+      expect(manifest?.hostCompatibility?.issues[0]?.kind).toBe('minSeroVersion');
+      expect(manifest?.hostCompatibility?.issues[0]?.message).toContain('Requires Sero 9.9.9 or newer');
+
+      unregisterAppPath(packageDir);
+    } finally {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });

--- a/apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts
@@ -229,6 +229,40 @@ describe('app discovery devPort handling', () => {
     }
   });
 
+  it('still enforces compatibility requirements when unrelated plugin metadata is malformed', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-app-discovery-plugin-invalid-compat-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      const packageDir = path.join(tempRoot, 'invalid-compatible-plugin');
+      await writeManifestPackage(packageDir, 'invalid-compatible-plugin', 'Invalid Compatible Plugin', {
+        category: 'not-a-real-category',
+        tags: ['test'],
+        minSeroVersion: '9.9.9',
+      });
+
+      const { discoverApps, registerAppPath, unregisterAppPath } = await importAppDiscovery();
+
+      registerAppPath(packageDir);
+      const manifest = (await discoverApps()).find((app) => app.id === 'invalid-compatible-plugin');
+
+      expect(manifest).toMatchObject({
+        id: 'invalid-compatible-plugin',
+        isPlugin: true,
+        plugin: null,
+      });
+      expect(manifest?.hostCompatibility?.supported).toBe(false);
+      expect(manifest?.hostCompatibility?.issues[0]?.kind).toBe('minSeroVersion');
+
+      unregisterAppPath(packageDir);
+    } finally {
+      warnSpy.mockRestore();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('marks plugins unsupported when their host requirements are not satisfied', async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-app-discovery-plugin-compat-'));
     process.env.SERO_HOME_OVERRIDE = tempRoot;

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-compatibility.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-compatibility.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { PluginMeta } from '@sero/common';
+
+import {
+  evaluatePluginCompatibility,
+  type SeroHostCompatibilityContext,
+} from '@electron/features/plugins/compatibility';
+
+function makeContext(overrides?: Partial<SeroHostCompatibilityContext>): SeroHostCompatibilityContext {
+  return {
+    hostVersion: overrides?.hostVersion ?? '0.1.0',
+    capabilities: overrides?.capabilities ?? new Set(['appAgent.invokeTool', 'tool.cli']),
+  };
+}
+
+describe('plugin compatibility', () => {
+  it('accepts plugins whose version and capability requirements are satisfied', () => {
+    const plugin: PluginMeta = {
+      category: 'integrations',
+      tags: ['google'],
+      minSeroVersion: '0.1.0',
+      requiredHostCapabilities: ['appAgent.invokeTool', 'tool.cli'],
+    };
+
+    expect(evaluatePluginCompatibility(plugin, makeContext())).toEqual({
+      supported: true,
+      hostVersion: '0.1.0',
+      issues: [],
+    });
+  });
+
+  it('fails closed when a plugin requires a newer Sero version', () => {
+    const plugin: PluginMeta = {
+      category: 'integrations',
+      tags: ['google'],
+      minSeroVersion: '0.2.0',
+    };
+
+    const compatibility = evaluatePluginCompatibility(plugin, makeContext({ hostVersion: '0.1.0' }));
+
+    expect(compatibility?.supported).toBe(false);
+    expect(compatibility?.issues).toContainEqual(expect.objectContaining({
+      kind: 'minSeroVersion',
+      expected: '0.2.0',
+      actual: '0.1.0',
+    }));
+  });
+
+  it('fails closed when a required host capability is missing', () => {
+    const plugin: PluginMeta = {
+      category: 'integrations',
+      tags: ['google'],
+      requiredHostCapabilities: ['appAgent.invokeTool', 'tool.cli'],
+    };
+
+    const compatibility = evaluatePluginCompatibility(
+      plugin,
+      makeContext({ capabilities: new Set(['appAgent.invokeTool']) }),
+    );
+
+    expect(compatibility?.supported).toBe(false);
+    expect(compatibility?.issues).toContainEqual(expect.objectContaining({
+      kind: 'requiredHostCapability',
+      capability: 'tool.cli',
+    }));
+  });
+});

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-compatibility.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-compatibility.test.ts
@@ -64,4 +64,20 @@ describe('plugin compatibility', () => {
       capability: 'tool.cli',
     }));
   });
+
+  it('fails closed for forward host capabilities the current build does not recognize', () => {
+    const compatibility = evaluatePluginCompatibility(
+      {
+        minSeroVersion: '0.1.0',
+        requiredHostCapabilities: ['future.host.capability'],
+      },
+      makeContext(),
+    );
+
+    expect(compatibility?.supported).toBe(false);
+    expect(compatibility?.issues).toContainEqual(expect.objectContaining({
+      kind: 'requiredHostCapability',
+      capability: 'future.host.capability',
+    }));
+  });
 });

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-manager.test.ts
@@ -7,7 +7,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 describe('plugin manager discovery registration', () => {
   let tempRoot: string | null = null;
 
-  async function createPluginSource(pluginId: string): Promise<string> {
+  async function createPluginSource(
+    pluginId: string,
+    pluginMeta: Record<string, unknown> = {
+      category: 'utilities',
+      tags: ['test'],
+    },
+  ): Promise<string> {
     if (!tempRoot) {
       throw new Error('tempRoot not initialized');
     }
@@ -27,10 +33,7 @@ describe('plugin manager discovery registration', () => {
             icon: 'box',
             stateFile: `.sero/apps/${pluginId}/state.json`,
           },
-          plugin: {
-            category: 'utilities',
-            tags: ['test'],
-          },
+          plugin: pluginMeta,
         },
       }, null, 2),
       'utf8',
@@ -89,6 +92,86 @@ describe('plugin manager discovery registration', () => {
       await fs.rm(tempRoot, { recursive: true, force: true });
       tempRoot = null;
     }
+  });
+
+  it('blocks plugin installs when the host compatibility contract is not satisfied', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-plugin-manager-compat-'));
+    const sourceDir = await createPluginSource('future-plugin', {
+      category: 'utilities',
+      tags: ['test'],
+      minSeroVersion: '9.9.9',
+    });
+    const { installPlugin, agentDir } = await importModules();
+
+    await expect(installPlugin(sourceDir)).rejects.toThrow('Requires Sero 9.9.9 or newer');
+    await expect(fs.stat(path.join(agentDir, 'packages', 'future-plugin'))).rejects.toThrow();
+  });
+
+  it('reconciles installed plugin activation so unsupported plugins stay on disk but out of settings', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-plugin-manager-reconcile-'));
+    const { reconcileInstalledPluginActivation, agentDir } = await importModules();
+
+    const compatiblePath = path.join(agentDir, 'packages', 'compatible-plugin');
+    const incompatiblePath = path.join(agentDir, 'packages', 'incompatible-plugin');
+    await fs.mkdir(compatiblePath, { recursive: true });
+    await fs.mkdir(incompatiblePath, { recursive: true });
+
+    await fs.writeFile(
+      path.join(compatiblePath, 'package.json'),
+      JSON.stringify({
+        name: 'compatible-plugin',
+        version: '1.0.0',
+        sero: {
+          app: {
+            id: 'compatible-plugin',
+            name: 'Compatible Plugin',
+            icon: 'box',
+            stateFile: '.sero/apps/compatible-plugin/state.json',
+          },
+          plugin: {
+            category: 'utilities',
+            tags: ['test'],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(incompatiblePath, 'package.json'),
+      JSON.stringify({
+        name: 'incompatible-plugin',
+        version: '1.0.0',
+        sero: {
+          app: {
+            id: 'incompatible-plugin',
+            name: 'Incompatible Plugin',
+            icon: 'box',
+            stateFile: '.sero/apps/incompatible-plugin/state.json',
+          },
+          plugin: {
+            category: 'utilities',
+            tags: ['test'],
+            minSeroVersion: '9.9.9',
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    await fs.writeFile(
+      path.join(agentDir, 'settings.json'),
+      JSON.stringify({
+        packages: [incompatiblePath],
+      }, null, 2),
+      'utf8',
+    );
+
+    await reconcileInstalledPluginActivation();
+
+    const settings = await fs.readFile(path.join(agentDir, 'settings.json'), 'utf8');
+    expect(settings).toContain(compatiblePath);
+    expect(settings).not.toContain(incompatiblePath);
+    await expect(fs.stat(incompatiblePath)).resolves.toBeDefined();
   });
 
   it('removes uninstalled plugins from discovery state without requiring a restart', async () => {

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-manager.test.ts
@@ -187,6 +187,97 @@ describe('plugin manager discovery registration', () => {
     await expect(fs.stat(incompatiblePath)).resolves.toBeDefined();
   });
 
+  it('preserves existing package order while removing incompatible managed plugins', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-plugin-manager-order-'));
+    const { reconcileInstalledPluginActivation, agentDir } = await importModules();
+
+    const zPluginPath = path.join(agentDir, 'packages', 'z-plugin');
+    const aPluginPath = path.join(agentDir, 'packages', 'a-plugin');
+    const customPackagePath = path.join(tempRoot, 'custom-package');
+    await fs.mkdir(zPluginPath, { recursive: true });
+    await fs.mkdir(aPluginPath, { recursive: true });
+
+    await fs.writeFile(
+      path.join(zPluginPath, 'package.json'),
+      JSON.stringify({
+        name: 'z-plugin',
+        version: '1.0.0',
+        sero: {
+          app: {
+            id: 'z-plugin',
+            name: 'Z Plugin',
+            icon: 'box',
+            stateFile: '.sero/apps/z-plugin/state.json',
+          },
+          plugin: {
+            category: 'utilities',
+            tags: ['test'],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(aPluginPath, 'package.json'),
+      JSON.stringify({
+        name: 'a-plugin',
+        version: '1.0.0',
+        sero: {
+          app: {
+            id: 'a-plugin',
+            name: 'A Plugin',
+            icon: 'box',
+            stateFile: '.sero/apps/a-plugin/state.json',
+          },
+          plugin: {
+            category: 'utilities',
+            tags: ['test'],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    await fs.writeFile(
+      path.join(agentDir, 'settings.json'),
+      JSON.stringify({
+        packages: [customPackagePath, zPluginPath, aPluginPath],
+      }, null, 2),
+      'utf8',
+    );
+
+    await reconcileInstalledPluginActivation();
+
+    const settings = JSON.parse(await fs.readFile(path.join(agentDir, 'settings.json'), 'utf8')) as {
+      packages: string[];
+    };
+    expect(settings.packages).toEqual([customPackagePath, zPluginPath, aPluginPath]);
+  });
+
+  it('removes incompatible local-path plugin packages from the active settings list', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-plugin-manager-local-path-'));
+    const sourceDir = await createPluginSource('manual-local-plugin', {
+      category: 'utilities',
+      tags: ['test'],
+      minSeroVersion: '9.9.9',
+    });
+    const { reconcileInstalledPluginActivation, agentDir } = await importModules();
+
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, 'settings.json'),
+      JSON.stringify({
+        packages: [sourceDir],
+      }, null, 2),
+      'utf8',
+    );
+
+    await reconcileInstalledPluginActivation();
+
+    const settings = await fs.readFile(path.join(agentDir, 'settings.json'), 'utf8');
+    expect(settings).not.toContain(sourceDir);
+  });
+
   it('removes uninstalled plugins from discovery state without requiring a restart', async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-plugin-manager-'));
     const sourceDir = await createPluginSource('todo');

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-manager.test.ts
@@ -107,6 +107,19 @@ describe('plugin manager discovery registration', () => {
     await expect(fs.stat(path.join(agentDir, 'packages', 'future-plugin'))).rejects.toThrow();
   });
 
+  it('still blocks installs when compatibility requirements are present alongside invalid plugin metadata', async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-plugin-manager-invalid-compat-'));
+    const sourceDir = await createPluginSource('invalid-future-plugin', {
+      category: 'not-a-real-category',
+      tags: ['test'],
+      minSeroVersion: '9.9.9',
+    });
+    const { installPlugin, agentDir } = await importModules();
+
+    await expect(installPlugin(sourceDir)).rejects.toThrow('Requires Sero 9.9.9 or newer');
+    await expect(fs.stat(path.join(agentDir, 'packages', 'invalid-future-plugin'))).rejects.toThrow();
+  });
+
   it('reconciles installed plugin activation so unsupported plugins stay on disk but out of settings', async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-plugin-manager-reconcile-'));
     const { reconcileInstalledPluginActivation, agentDir } = await importModules();

--- a/apps/desktop/electron/__tests__/features/plugins/resource-compatibility.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/resource-compatibility.test.ts
@@ -1,0 +1,139 @@
+import os from 'os';
+import path from 'path';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+
+import type {
+  LoadExtensionsResult,
+  PromptTemplate,
+  Skill,
+  Theme,
+} from '@mariozechner/pi-coding-agent';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearPackageCompatibilityCache,
+  filterCompatiblePluginAgentsFiles,
+  filterCompatiblePluginExtensions,
+  filterCompatiblePluginPrompts,
+  filterCompatiblePluginSkills,
+  filterCompatiblePluginThemes,
+} from '@electron/features/plugins/resource-compatibility';
+
+describe('plugin resource compatibility filtering', () => {
+  let tempRoot = '';
+
+  beforeEach(async () => {
+    clearPackageCompatibilityCache();
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-plugin-resource-compat-'));
+  });
+
+  afterEach(async () => {
+    clearPackageCompatibilityCache();
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  async function createPluginPackage(pluginId: string, minSeroVersion?: string): Promise<string> {
+    const pluginDir = path.join(tempRoot, pluginId);
+    await mkdir(path.join(pluginDir, 'extension'), { recursive: true });
+    await mkdir(path.join(pluginDir, 'skills'), { recursive: true });
+    await mkdir(path.join(pluginDir, 'prompts'), { recursive: true });
+    await mkdir(path.join(pluginDir, 'themes'), { recursive: true });
+    await writeFile(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify({
+        name: pluginId,
+        version: '1.0.0',
+        sero: {
+          plugin: {
+            category: 'utilities',
+            tags: ['test'],
+            ...(minSeroVersion ? { minSeroVersion } : {}),
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+    await writeFile(path.join(pluginDir, 'extension', 'index.ts'), 'export default {}\n', 'utf8');
+    await writeFile(path.join(pluginDir, 'skills', 'demo.md'), '# Demo\n', 'utf8');
+    await writeFile(path.join(pluginDir, 'prompts', 'demo.md'), '# Prompt\n', 'utf8');
+    await writeFile(path.join(pluginDir, 'themes', 'demo.json'), '{}\n', 'utf8');
+    await writeFile(path.join(pluginDir, 'AGENTS.md'), '# Agents\n', 'utf8');
+    return pluginDir;
+  }
+
+  it('drops incompatible plugin resources from all loader override buckets', async () => {
+    const pluginDir = await createPluginPackage('future-plugin', '9.9.9');
+
+    const extensions = filterCompatiblePluginExtensions({
+      extensions: [{
+        path: path.join(pluginDir, 'extension', 'index.ts'),
+        resolvedPath: path.join(pluginDir, 'extension', 'index.ts'),
+        handlers: new Map(),
+        tools: new Map(),
+        messageRenderers: new Map(),
+        commands: new Map(),
+        flags: new Map(),
+        shortcuts: new Map(),
+      }],
+      errors: [],
+      runtime: {} as LoadExtensionsResult['runtime'],
+    });
+    const skills = filterCompatiblePluginSkills({
+      skills: [{
+        name: 'demo',
+        description: 'Demo skill',
+        filePath: path.join(pluginDir, 'skills', 'demo.md'),
+        baseDir: path.join(pluginDir, 'skills'),
+        source: pluginDir,
+        disableModelInvocation: false,
+      } satisfies Skill],
+      diagnostics: [],
+    });
+    const prompts = filterCompatiblePluginPrompts({
+      prompts: [{
+        name: 'demo',
+        description: 'Demo prompt',
+        content: 'demo',
+        filePath: path.join(pluginDir, 'prompts', 'demo.md'),
+        source: pluginDir,
+      } satisfies PromptTemplate],
+      diagnostics: [],
+    });
+    const themes = filterCompatiblePluginThemes({
+      themes: [{
+        sourcePath: path.join(pluginDir, 'themes', 'demo.json'),
+      } as Theme],
+      diagnostics: [],
+    });
+    const agentsFiles = filterCompatiblePluginAgentsFiles({
+      agentsFiles: [{ path: path.join(pluginDir, 'AGENTS.md'), content: '# Agents' }],
+    });
+
+    expect(extensions.extensions).toHaveLength(0);
+    expect(skills.skills).toHaveLength(0);
+    expect(prompts.prompts).toHaveLength(0);
+    expect(themes.themes).toHaveLength(0);
+    expect(agentsFiles.agentsFiles).toHaveLength(0);
+  });
+
+  it('keeps compatible plugin resources intact', async () => {
+    const pluginDir = await createPluginPackage('compatible-plugin');
+
+    const extensions = filterCompatiblePluginExtensions({
+      extensions: [{
+        path: path.join(pluginDir, 'extension', 'index.ts'),
+        resolvedPath: path.join(pluginDir, 'extension', 'index.ts'),
+        handlers: new Map(),
+        tools: new Map(),
+        messageRenderers: new Map(),
+        commands: new Map(),
+        flags: new Map(),
+        shortcuts: new Map(),
+      }],
+      errors: [],
+      runtime: {} as LoadExtensionsResult['runtime'],
+    });
+
+    expect(extensions.extensions).toHaveLength(1);
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/app-agent-tool-execution.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-agent-tool-execution.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+
+import { invokeAppSessionTool } from '@electron/ipc/agent/handlers/app-agent-tools';
+
+describe('invokeAppSessionTool', () => {
+  it('executes the live app-session tool definition with the extension context', async () => {
+    const execute = vi.fn(async () => ({
+      content: [{ type: 'text', text: '{"ok":true}' }],
+      details: { ok: true },
+    }));
+    const toolContext = { cwd: '/tmp/ws-1', hasUI: true };
+
+    const session = {
+      extensionRunner: {
+        getToolDefinition: vi.fn(() => ({ execute })),
+        createContext: vi.fn(() => toolContext),
+      },
+    } as unknown as AgentSession;
+
+    const result = await invokeAppSessionTool(session, 'plugin_ping', { value: 42 });
+
+    expect(execute).toHaveBeenCalledWith(
+      'app-tool-bridge',
+      { value: 42 },
+      undefined,
+      undefined,
+      toolContext,
+    );
+    expect(result).toEqual({
+      text: '{"ok":true}',
+      content: [{ type: 'text', text: '{"ok":true}' }],
+      details: { ok: true },
+      isError: false,
+    });
+  });
+
+  it('returns a normalized error result when the app session has no matching tool', async () => {
+    const session = {
+      extensionRunner: {
+        getToolDefinition: vi.fn(() => undefined),
+        createContext: vi.fn(),
+      },
+    } as unknown as AgentSession;
+
+    const result = await invokeAppSessionTool(session, 'missing_tool', {});
+
+    expect(result).toEqual({
+      text: 'Error: App tool not found: missing_tool',
+      content: [{ type: 'text', text: 'Error: App tool not found: missing_tool' }],
+      details: null,
+      isError: true,
+    });
+  });
+});

--- a/apps/desktop/electron/cli/core/batch-executor.ts
+++ b/apps/desktop/electron/cli/core/batch-executor.ts
@@ -235,7 +235,10 @@ export async function executeCliBatch(
 
     try {
       const tokens = tokenizeCliInput(line);
-      const resolved = registry.resolveTokens(tokens);
+      const resolved = registry.resolveTokens(tokens, {
+        workspaceId: context.workspaceId,
+        sessionId: context.invocation.sessionId,
+      });
 
       const turnId = context.invocation.turnId;
       if (

--- a/apps/desktop/electron/cli/core/help.ts
+++ b/apps/desktop/electron/cli/core/help.ts
@@ -1,4 +1,4 @@
-import type { CliRegistry } from './registry';
+import type { CliRegistry, CliRegistryScope } from './registry';
 import type { CliCommandContext } from './types';
 import { fail, ok } from '../lib/utils';
 
@@ -6,8 +6,15 @@ function groupLabel(group?: string): string {
   return (group ?? 'Other').toUpperCase();
 }
 
-function renderCliHelpList(registry: CliRegistry): string {
-  const commands = registry.list().filter((c) => !c.hidden);
+function scopeFromContext(context: CliCommandContext): CliRegistryScope {
+  return {
+    workspaceId: context.workspaceId,
+    sessionId: context.invocation.sessionId,
+  };
+}
+
+function renderCliHelpList(registry: CliRegistry, scope: CliRegistryScope): string {
+  const commands = registry.list(scope).filter((c) => !c.hidden);
   const grouped = new Map<string, typeof commands>();
 
   for (const cmd of commands) {
@@ -29,8 +36,12 @@ function renderCliHelpList(registry: CliRegistry): string {
   return sections.join('\n');
 }
 
-function renderCliCommandHelp(registry: CliRegistry, query: string): string | null {
-  const cmd = registry.findHelpTarget(query);
+function renderCliCommandHelp(
+  registry: CliRegistry,
+  query: string,
+  scope: CliRegistryScope,
+): string | null {
+  const cmd = registry.findHelpTarget(query, scope);
   if (!cmd) return null;
   if (cmd.help?.trim()) return cmd.help.trim();
 
@@ -56,8 +67,9 @@ export function registerHelpCliCommand(registry: CliRegistry): void {
     source: 'builtin',
     group: 'Builtin',
     execute: async (args: string[], _ctx: CliCommandContext) => {
-      if (!args.length) return ok(renderCliHelpList(registry));
-      const output = renderCliCommandHelp(registry, args.join(' '));
+      const scope = scopeFromContext(_ctx);
+      if (!args.length) return ok(renderCliHelpList(registry, scope));
+      const output = renderCliCommandHelp(registry, args.join(' '), scope);
       if (!output) return fail(`Unknown command: ${args.join(' ')}`);
       return ok(output);
     },

--- a/apps/desktop/electron/cli/core/registry.ts
+++ b/apps/desktop/electron/cli/core/registry.ts
@@ -1,4 +1,9 @@
-import type { CliCommand, CliCommandContext, CliResolvedCommand } from './types';
+import type {
+  CliAppCommandOwner,
+  CliCommand,
+  CliCommandContext,
+  CliResolvedCommand,
+} from './types';
 
 const BLACKLISTED_ROOTS = new Set([
   'auth',
@@ -13,27 +18,79 @@ function normalizeName(name: string): string {
   return name.trim().replace(/\s+/g, ' ');
 }
 
+function ownerKey(owner: CliAppCommandOwner): string {
+  return `${owner.sessionId}:${owner.extensionPath}`;
+}
+
+function assertAllowedCommandName(name: string): void {
+  if (!name) throw new Error('CLI command name is required');
+
+  const root = name.split(' ')[0];
+  if (root && BLACKLISTED_ROOTS.has(root)) {
+    throw new Error(`CLI command root is blacklisted: ${root}`);
+  }
+}
+
+interface AppOwnerCommands {
+  owner: CliAppCommandOwner;
+  commands: Map<string, CliCommand>;
+}
+
 export class CliRegistry {
   private commands = new Map<string, CliCommand>();
+  private appOwnerCommands = new Map<string, AppOwnerCommands>();
 
   register(command: CliCommand): void {
     const name = normalizeName(command.name);
-    if (!name) throw new Error('CLI command name is required');
-
-    const root = name.split(' ')[0];
-    if (root && BLACKLISTED_ROOTS.has(root)) {
-      throw new Error(`CLI command root is blacklisted: ${root}`);
-    }
-
+    assertAllowedCommandName(name);
     this.commands.set(name, { ...command, name });
   }
 
+  replaceAppCommandsForSession(sessionId: string, commands: CliCommand[]): void {
+    this.removeAppCommandsForSession(sessionId);
+
+    for (const command of commands) {
+      const owner = command.owner;
+      if (!owner || owner.sessionId !== sessionId) {
+        throw new Error(`CLI app command missing owner metadata for session ${sessionId}`);
+      }
+
+      const key = ownerKey(owner);
+      const existing = this.appOwnerCommands.get(key) ?? {
+        owner,
+        commands: new Map<string, CliCommand>(),
+      };
+      const name = normalizeName(command.name);
+      assertAllowedCommandName(name);
+      existing.commands.set(name, { ...command, name });
+      this.appOwnerCommands.set(key, existing);
+    }
+  }
+
+  removeAppCommandsForSession(sessionId: string): void {
+    for (const [key, value] of [...this.appOwnerCommands.entries()]) {
+      if (value.owner.sessionId === sessionId) {
+        this.appOwnerCommands.delete(key);
+      }
+    }
+  }
+
+  private buildVisibleCommands(): Map<string, CliCommand> {
+    const visible = new Map(this.commands);
+    for (const ownerCommands of this.appOwnerCommands.values()) {
+      for (const [name, command] of ownerCommands.commands) {
+        visible.set(name, command);
+      }
+    }
+    return visible;
+  }
+
   get(name: string): CliCommand | undefined {
-    return this.commands.get(normalizeName(name));
+    return this.buildVisibleCommands().get(normalizeName(name));
   }
 
   list(): CliCommand[] {
-    return [...this.commands.values()].sort((a, b) => a.name.localeCompare(b.name));
+    return [...this.buildVisibleCommands().values()].sort((a, b) => a.name.localeCompare(b.name));
   }
 
   findHelpTarget(query: string): CliCommand | undefined {
@@ -59,9 +116,10 @@ export class CliRegistry {
       throw new Error('No command provided');
     }
 
+    const visibleCommands = this.buildVisibleCommands();
     for (let len = normalizedTokens.length; len >= 1; len--) {
       const name = normalizedTokens.slice(0, len).join(' ');
-      const command = this.commands.get(name);
+      const command = visibleCommands.get(name);
       if (command) {
         return {
           command,

--- a/apps/desktop/electron/cli/core/registry.ts
+++ b/apps/desktop/electron/cli/core/registry.ts
@@ -1,3 +1,4 @@
+import { getCliSessionBridge } from '../bridges/session-bridge';
 import type {
   CliAppCommandOwner,
   CliCommand,
@@ -34,6 +35,23 @@ function assertAllowedCommandName(name: string): void {
 interface AppOwnerCommands {
   owner: CliAppCommandOwner;
   commands: Map<string, CliCommand>;
+}
+
+export interface CliRegistryScope {
+  workspaceId?: string;
+  sessionId?: string | null;
+}
+
+function resolveScopedSessionId(scope?: CliRegistryScope): string | null | undefined {
+  if (!scope) return undefined;
+  if (scope.sessionId) return scope.sessionId;
+  if (!scope.workspaceId) return null;
+
+  try {
+    return getCliSessionBridge().getActiveSessionForWorkspace(scope.workspaceId)?.sessionId ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export class CliRegistry {
@@ -75,9 +93,15 @@ export class CliRegistry {
     }
   }
 
-  private buildVisibleCommands(): Map<string, CliCommand> {
+  private buildVisibleCommands(scope?: CliRegistryScope): Map<string, CliCommand> {
     const visible = new Map(this.commands);
+    const scopedSessionId = resolveScopedSessionId(scope);
+
     for (const ownerCommands of this.appOwnerCommands.values()) {
+      if (scope && ownerCommands.owner.sessionId !== scopedSessionId) {
+        continue;
+      }
+
       for (const [name, command] of ownerCommands.commands) {
         visible.set(name, command);
       }
@@ -85,38 +109,38 @@ export class CliRegistry {
     return visible;
   }
 
-  get(name: string): CliCommand | undefined {
-    return this.buildVisibleCommands().get(normalizeName(name));
+  get(name: string, scope?: CliRegistryScope): CliCommand | undefined {
+    return this.buildVisibleCommands(scope).get(normalizeName(name));
   }
 
-  list(): CliCommand[] {
-    return [...this.buildVisibleCommands().values()].sort((a, b) => a.name.localeCompare(b.name));
+  list(scope?: CliRegistryScope): CliCommand[] {
+    return [...this.buildVisibleCommands(scope).values()].sort((a, b) => a.name.localeCompare(b.name));
   }
 
-  findHelpTarget(query: string): CliCommand | undefined {
+  findHelpTarget(query: string, scope?: CliRegistryScope): CliCommand | undefined {
     const normalized = normalizeName(query);
     if (!normalized) return undefined;
-    const exact = this.get(normalized);
+    const exact = this.get(normalized, scope);
     if (exact) return exact;
 
     const tokens = normalized.split(' ');
     for (let len = tokens.length - 1; len >= 1; len--) {
       const candidate = tokens.slice(0, len).join(' ');
-      const hit = this.get(candidate);
+      const hit = this.get(candidate, scope);
       if (hit) return hit;
     }
 
     return undefined;
   }
 
-  resolveTokens(tokens: string[]): CliResolvedCommand {
+  resolveTokens(tokens: string[], scope?: CliRegistryScope): CliResolvedCommand {
     const normalizedTokens = [...tokens];
     if (normalizedTokens[0] === 'sero') normalizedTokens.shift();
     if (normalizedTokens.length === 0) {
       throw new Error('No command provided');
     }
 
-    const visibleCommands = this.buildVisibleCommands();
+    const visibleCommands = this.buildVisibleCommands(scope);
     for (let len = normalizedTokens.length; len >= 1; len--) {
       const name = normalizedTokens.slice(0, len).join(' ');
       const command = visibleCommands.get(name);

--- a/apps/desktop/electron/cli/core/schema-bridge.ts
+++ b/apps/desktop/electron/cli/core/schema-bridge.ts
@@ -341,6 +341,44 @@ function extractText(content: CliContentBlock[]): string {
 
 // ── Bridge a ToolDefinition into a CliCommand ───────────────
 
+export interface CustomToolCliBridge {
+  summary?: string;
+  help?: string;
+  group?: string;
+  overrideBuiltin?: boolean;
+  execute: (
+    args: string[],
+    context: CliCommandContext,
+    onUpdate?: (update: { content: CliContentBlock[]; details?: unknown }) => void,
+  ) => Promise<CliResult>;
+}
+
+interface CliBridgeAwareToolDefinition extends ToolDefinition {
+  cli?: CustomToolCliBridge;
+}
+
+export function getCustomToolCliBridge(toolDef: ToolDefinition): CustomToolCliBridge | undefined {
+  const cli = (toolDef as CliBridgeAwareToolDefinition).cli;
+  return cli && typeof cli.execute === 'function' ? cli : undefined;
+}
+
+function normalizeCliResult(result: CliResult): CliResult {
+  return {
+    output: typeof result.output === 'string' ? result.output : String(result.output ?? ''),
+    content: Array.isArray(result.content) ? result.content : undefined,
+    details: result.details,
+    exitCode: result.exitCode ?? 0,
+  };
+}
+
+function getLiveToolCliBridge(
+  toolName: string,
+  context: CliCommandContext,
+): CustomToolCliBridge | undefined {
+  const activeToolDef = getBridgedExtensionTool(toolName, context)?.definition;
+  return activeToolDef ? getCustomToolCliBridge(activeToolDef) : undefined;
+}
+
 export interface BridgeToolOptions {
   /** Mark this command as interactive (disables per-command timeout). */
   interactive?: boolean;
@@ -350,13 +388,14 @@ export function bridgeTool(toolName: string, toolDef: ToolDefinition, options?: 
   const props = extractSchemaProps(toolDef.parameters as Record<string, unknown>);
   const summary = (toolDef.description ?? '').split(/\.\s/)[0]?.slice(0, 80) ?? toolName;
   const help = generateHelp(toolName, toolDef.description ?? toolName, props);
+  const cliBridge = getCustomToolCliBridge(toolDef);
 
   return {
     name: toolName,
-    summary,
-    help,
+    summary: cliBridge?.summary ?? summary,
+    help: cliBridge?.help ?? help,
     source: 'app',
-    group: 'Apps',
+    group: cliBridge?.group ?? 'Apps',
     interactive: options?.interactive,
     timeoutMs: getBridgedToolTimeoutMs(toolName),
     params: props.map((prop) => ({
@@ -367,6 +406,11 @@ export function bridgeTool(toolName: string, toolDef: ToolDefinition, options?: 
     })),
     execute: async (args: string[], ctx: CliCommandContext, onUpdate): Promise<CliResult> => {
       try {
+        const activeCliBridge = getLiveToolCliBridge(toolName, ctx) ?? cliBridge;
+        if (activeCliBridge) {
+          return normalizeCliResult(await activeCliBridge.execute(args, ctx, onUpdate));
+        }
+
         const params = schemaToParams(props, args);
         const activeToolDef = getBridgedExtensionTool(toolName, ctx)?.definition ?? toolDef;
         const result = await activeToolDef.execute(

--- a/apps/desktop/electron/cli/core/types.ts
+++ b/apps/desktop/electron/cli/core/types.ts
@@ -72,6 +72,12 @@ export interface CliCommandUpdate {
   details?: unknown;
 }
 
+export interface CliAppCommandOwner {
+  kind: 'session-extension';
+  sessionId: string;
+  extensionPath: string;
+}
+
 export interface CliCommand {
   name: string;
   summary: string;
@@ -83,6 +89,7 @@ export interface CliCommand {
     onUpdate?: (update: CliCommandUpdate) => void,
   ) => Promise<CliResult>;
   source?: 'app' | 'ipc' | 'builtin';
+  owner?: CliAppCommandOwner;
   group?: string;
   hidden?: boolean;
   /** Optional per-command timeout override for non-terminal invocations. */

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -19,6 +19,9 @@ import {
   bridgeCommand,
   bridgeTool,
   createSeroCliTool,
+  getCustomToolCliBridge,
+  type CliCommand,
+  type CliAppCommandOwner,
 } from './core';
 import {
   clearBridgedExtensionSessionItems,
@@ -158,8 +161,12 @@ function shouldBridgeTool(name: string, extensionPath: string): boolean {
   return pluginPolicy.bridgeAll || pluginPolicy.toolNames.has(name);
 }
 
+export function clearBridgedExtensionSessionStateForSession(sessionId: string): void {
+  clearBridgedExtensionSessionItemsForSession(sessionId);
+  registry?.removeAppCommandsForSession(sessionId);
+}
+
 export {
-  clearBridgedExtensionSessionItemsForSession,
   clearPluginBridgePolicyCache,
 };
 
@@ -190,32 +197,62 @@ export function bridgeExtensionTools(
   options?: { sessionId?: string },
 ): LoadExtensionsResult {
   const reg = getCliRegistry();
+  const sessionCommands: CliCommand[] = [];
 
   if (options?.sessionId) {
     replaceBridgedExtensionSessionItems(options.sessionId, base.extensions);
   }
 
   for (const ext of base.extensions) {
+    const owner: CliAppCommandOwner | null = options?.sessionId
+      ? {
+          kind: 'session-extension',
+          sessionId: options.sessionId,
+          extensionPath: ext.resolvedPath,
+        }
+      : null;
+
     // Bridge tools → CLI (removes from agent tool list)
     for (const [name, registered] of [...ext.tools]) {
       if (!shouldBridgeTool(name, ext.resolvedPath)) continue;
-      if (reg.get(name)) {
+
+      const existing = reg.get(name);
+      const cliBridge = getCustomToolCliBridge(registered.definition);
+      const canOverrideBuiltin = existing?.source === 'builtin' && cliBridge?.overrideBuiltin === true;
+
+      if (existing && existing.source !== 'app' && !canOverrideBuiltin) {
         ext.tools.delete(name);
         continue;
       }
+
       const command = bridgeTool(name, registered.definition, {
         interactive: INTERACTIVE_TOOLS.has(name),
       });
-      reg.register(command);
+      if (owner) {
+        sessionCommands.push({ ...command, owner });
+      } else {
+        reg.register(command);
+      }
       ext.tools.delete(name);
     }
 
     // Bridge commands → CLI (keeps in extension for user slash commands)
     for (const [name, registered] of ext.commands) {
       if (BUILTIN_COMMANDS.has(name)) continue;
-      if (reg.get(name)) continue;
-      reg.register(bridgeCommand(name, registered.description));
+      const existing = reg.get(name);
+      if (existing && existing.source !== 'app') continue;
+
+      const command = bridgeCommand(name, registered.description);
+      if (owner) {
+        sessionCommands.push({ ...command, owner });
+      } else {
+        reg.register(command);
+      }
     }
+  }
+
+  if (options?.sessionId) {
+    reg.replaceAppCommandsForSession(options.sessionId, sessionCommands);
   }
 
   return base;

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -216,7 +216,7 @@ export function bridgeExtensionTools(
     for (const [name, registered] of [...ext.tools]) {
       if (!shouldBridgeTool(name, ext.resolvedPath)) continue;
 
-      const existing = reg.get(name);
+      const existing = reg.get(name, owner ? { sessionId: options?.sessionId } : undefined);
       const cliBridge = getCustomToolCliBridge(registered.definition);
       const canOverrideBuiltin = existing?.source === 'builtin' && cliBridge?.overrideBuiltin === true;
 
@@ -239,7 +239,7 @@ export function bridgeExtensionTools(
     // Bridge commands → CLI (keeps in extension for user slash commands)
     for (const [name, registered] of ext.commands) {
       if (BUILTIN_COMMANDS.has(name)) continue;
-      const existing = reg.get(name);
+      const existing = reg.get(name, owner ? { sessionId: options?.sessionId } : undefined);
       if (existing && existing.source !== 'app') continue;
 
       const command = bridgeCommand(name, registered.description);
@@ -266,8 +266,11 @@ export function bridgeExtensionTools(
  * Groups commands by source and lists them all, so the agent discovers
  * every bridged app tool automatically — no manual prompt updates needed.
  */
-export function buildCliPromptBlock(reg: CliRegistry = getCliRegistry()): string {
-  const commands = reg.list().filter((c) => !c.hidden && c.name !== 'help');
+export function buildCliPromptBlock(
+  reg: CliRegistry = getCliRegistry(),
+  scope?: { workspaceId?: string; sessionId?: string | null },
+): string {
+  const commands = reg.list(scope).filter((c) => !c.hidden && c.name !== 'help');
 
   // Group commands and include per-command summaries
   const grouped = new Map<string, Array<{ name: string; summary: string }>>();

--- a/apps/desktop/electron/features/apps/discovery/index.ts
+++ b/apps/desktop/electron/features/apps/discovery/index.ts
@@ -16,6 +16,7 @@ import type { SeroAppManifest, SeroWidgetManifest, SettingsPackageSource } from 
 import { SERO_AGENT_DIR, SERO_FIXED_ROOT, SERO_HOME } from '@electron/platform/env';
 import { evaluatePluginCompatibility } from '@electron/features/plugins/compatibility';
 import {
+  extractPluginCompatibilityRequirements,
   hasPluginDeclaration,
   parsePluginMeta,
   warnInvalidPluginMeta,
@@ -113,14 +114,17 @@ async function parseManifest(pkgJson: PkgJson, packagePath: string): Promise<Ser
 
   const pluginDeclared = hasPluginDeclaration(pkgJson);
   const parsedPlugin = parsePluginMeta(pkgJson.sero?.plugin);
+  const compatibilityRequirements = pluginDeclared
+    ? extractPluginCompatibilityRequirements(pkgJson.sero?.plugin)
+    : null;
   if (pluginDeclared) {
     warnInvalidPluginMeta(packagePath, parsedPlugin.warnings);
   }
 
   // Parse widget definitions
   const plugin = parsedPlugin.meta;
-  const hostCompatibility = pluginDeclared
-    ? evaluatePluginCompatibility(plugin)
+  const hostCompatibility = compatibilityRequirements
+    ? evaluatePluginCompatibility(compatibilityRequirements)
     : null;
 
   const widgets: SeroWidgetManifest[] = [];

--- a/apps/desktop/electron/features/apps/discovery/index.ts
+++ b/apps/desktop/electron/features/apps/discovery/index.ts
@@ -11,10 +11,15 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
-import type { PluginMeta } from '@sero/common';
 import type { SeroAppManifest, SeroWidgetManifest, SettingsPackageSource } from '@/types/ipc';
 
 import { SERO_AGENT_DIR, SERO_FIXED_ROOT, SERO_HOME } from '@electron/platform/env';
+import { evaluatePluginCompatibility } from '@electron/features/plugins/compatibility';
+import {
+  hasPluginDeclaration,
+  parsePluginMeta,
+  warnInvalidPluginMeta,
+} from './plugin-meta';
 
 const SERO_EXTENSIONS_DIR = path.join(SERO_AGENT_DIR, 'extensions');
 const SERO_PACKAGES_DIR = path.join(SERO_AGENT_DIR, 'packages');
@@ -92,143 +97,6 @@ export function getManifestDevPort(appId: string, packagePath: string, devPort: 
   return isPluginInDevMode(appId) ? devPort : undefined;
 }
 
-const PLUGIN_CATEGORIES = [
-  'productivity',
-  'developer-tools',
-  'entertainment',
-  'integrations',
-  'finance',
-  'health',
-  'creative',
-  'utilities',
-] satisfies PluginMeta['category'][];
-
-interface ParsedPluginMetaResult {
-  meta: PluginMeta | null;
-  warnings: string[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function hasPluginDeclaration(pkgJson: PkgJson): boolean {
-  return isRecord(pkgJson.sero) && Object.prototype.hasOwnProperty.call(pkgJson.sero, 'plugin');
-}
-
-function isPluginCategory(value: string): value is PluginMeta['category'] {
-  return PLUGIN_CATEGORIES.includes(value as PluginMeta['category']);
-}
-
-function parsePluginMeta(plugin: unknown): ParsedPluginMetaResult {
-  if (plugin === undefined) {
-    return { meta: null, warnings: [] };
-  }
-  if (!isRecord(plugin)) {
-    return {
-      meta: null,
-      warnings: ['`sero.plugin` must be an object'],
-    };
-  }
-
-  const errors: string[] = [];
-  const warnings: string[] = [];
-
-  const categoryValue = typeof plugin.category === 'string' ? plugin.category.trim() : '';
-  let category: PluginMeta['category'] | null = null;
-  if (!categoryValue) {
-    errors.push('`sero.plugin.category` is required');
-  } else if (!isPluginCategory(categoryValue)) {
-    errors.push(
-      '`sero.plugin.category` must be one of ' +
-      PLUGIN_CATEGORIES.map((value) => `"${value}"`).join(', '),
-    );
-  } else {
-    category = categoryValue;
-  }
-
-  const tags: string[] = [];
-  if (!Array.isArray(plugin.tags)) {
-    errors.push('`sero.plugin.tags` must be a non-empty string[]');
-  } else {
-    plugin.tags.forEach((tag, index) => {
-      if (typeof tag !== 'string') {
-        warnings.push(`ignored non-string \`sero.plugin.tags[${index}]\``);
-        return;
-      }
-      const trimmed = tag.trim();
-      if (!trimmed) {
-        warnings.push(`ignored empty \`sero.plugin.tags[${index}]\``);
-        return;
-      }
-      tags.push(trimmed);
-    });
-    if (tags.length === 0) {
-      errors.push('`sero.plugin.tags` must include at least one non-empty string');
-    }
-  }
-
-  if (errors.length > 0 || !category) {
-    return { meta: null, warnings: [...errors, ...warnings] };
-  }
-
-  const parsed: PluginMeta = {
-    category,
-    tags,
-  };
-
-  if (typeof plugin.minSeroVersion === 'string') {
-    const minSeroVersion = plugin.minSeroVersion.trim();
-    if (minSeroVersion) {
-      parsed.minSeroVersion = minSeroVersion;
-    } else {
-      warnings.push('ignored empty `sero.plugin.minSeroVersion`');
-    }
-  } else if (plugin.minSeroVersion !== undefined) {
-    warnings.push('ignored non-string `sero.plugin.minSeroVersion`');
-  }
-
-  if (typeof plugin.preBuilt === 'boolean') {
-    parsed.preBuilt = plugin.preBuilt;
-  } else if (plugin.preBuilt !== undefined) {
-    warnings.push('ignored non-boolean `sero.plugin.preBuilt`');
-  }
-
-  if (typeof plugin.bridgeTools === 'boolean') {
-    parsed.bridgeTools = plugin.bridgeTools;
-  } else if (Array.isArray(plugin.bridgeTools)) {
-    const bridgeTools: string[] = [];
-    plugin.bridgeTools.forEach((toolName, index) => {
-      if (typeof toolName !== 'string') {
-        warnings.push(`ignored non-string \`sero.plugin.bridgeTools[${index}]\``);
-        return;
-      }
-      const trimmed = toolName.trim();
-      if (!trimmed) {
-        warnings.push(`ignored empty \`sero.plugin.bridgeTools[${index}]\``);
-        return;
-      }
-      bridgeTools.push(trimmed);
-    });
-    if (plugin.bridgeTools.length === 0 || bridgeTools.length > 0) {
-      parsed.bridgeTools = bridgeTools;
-    } else {
-      warnings.push('ignored invalid `sero.plugin.bridgeTools` array');
-    }
-  } else if (plugin.bridgeTools !== undefined) {
-    warnings.push('ignored invalid `sero.plugin.bridgeTools`; expected boolean or string[]');
-  }
-
-  return { meta: parsed, warnings };
-}
-
-function warnInvalidPluginMeta(packagePath: string, warnings: string[]): void {
-  if (warnings.length === 0) return;
-  console.warn(
-    `[app-discovery] Ignoring invalid sero.plugin metadata in "${packagePath}": ${warnings.join('; ')}`,
-  );
-}
-
 async function parseManifest(pkgJson: PkgJson, packagePath: string): Promise<SeroAppManifest | null> {
   const app = pkgJson.sero?.app;
   if (!app || !app.id || !app.name) return null;
@@ -251,6 +119,9 @@ async function parseManifest(pkgJson: PkgJson, packagePath: string): Promise<Ser
 
   // Parse widget definitions
   const plugin = parsedPlugin.meta;
+  const hostCompatibility = pluginDeclared
+    ? evaluatePluginCompatibility(plugin)
+    : null;
 
   const widgets: SeroWidgetManifest[] = [];
   if (Array.isArray(app.widgets)) {
@@ -293,6 +164,7 @@ async function parseManifest(pkgJson: PkgJson, packagePath: string): Promise<Ser
     packagePath,
     isPlugin: pluginDeclared,
     plugin,
+    hostCompatibility,
     widgets,
   };
 }

--- a/apps/desktop/electron/features/apps/discovery/plugin-meta.ts
+++ b/apps/desktop/electron/features/apps/discovery/plugin-meta.ts
@@ -1,0 +1,173 @@
+import type {
+  PluginMeta,
+  SeroHostCapability,
+} from '@sero/common';
+import { SERO_HOST_CAPABILITIES } from '@sero/common';
+
+const PLUGIN_CATEGORIES = [
+  'productivity',
+  'developer-tools',
+  'entertainment',
+  'integrations',
+  'finance',
+  'health',
+  'creative',
+  'utilities',
+] satisfies PluginMeta['category'][];
+
+export interface ParsedPluginMetaResult {
+  meta: PluginMeta | null;
+  warnings: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function hasPluginDeclaration(pkgJson: { sero?: { plugin?: unknown } }): boolean {
+  return isRecord(pkgJson.sero) && Object.prototype.hasOwnProperty.call(pkgJson.sero, 'plugin');
+}
+
+function isPluginCategory(value: string): value is PluginMeta['category'] {
+  return PLUGIN_CATEGORIES.includes(value as PluginMeta['category']);
+}
+
+function isHostCapability(value: string): value is SeroHostCapability {
+  return SERO_HOST_CAPABILITIES.includes(value as SeroHostCapability);
+}
+
+export function parsePluginMeta(plugin: unknown): ParsedPluginMetaResult {
+  if (plugin === undefined) {
+    return { meta: null, warnings: [] };
+  }
+  if (!isRecord(plugin)) {
+    return {
+      meta: null,
+      warnings: ['`sero.plugin` must be an object'],
+    };
+  }
+
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  const categoryValue = typeof plugin.category === 'string' ? plugin.category.trim() : '';
+  let category: PluginMeta['category'] | null = null;
+  if (!categoryValue) {
+    errors.push('`sero.plugin.category` is required');
+  } else if (!isPluginCategory(categoryValue)) {
+    errors.push(
+      '`sero.plugin.category` must be one of ' +
+      PLUGIN_CATEGORIES.map((value) => `"${value}"`).join(', '),
+    );
+  } else {
+    category = categoryValue;
+  }
+
+  const tags: string[] = [];
+  if (!Array.isArray(plugin.tags)) {
+    errors.push('`sero.plugin.tags` must be a non-empty string[]');
+  } else {
+    plugin.tags.forEach((tag, index) => {
+      if (typeof tag !== 'string') {
+        warnings.push(`ignored non-string \`sero.plugin.tags[${index}]\``);
+        return;
+      }
+      const trimmed = tag.trim();
+      if (!trimmed) {
+        warnings.push(`ignored empty \`sero.plugin.tags[${index}]\``);
+        return;
+      }
+      tags.push(trimmed);
+    });
+    if (tags.length === 0) {
+      errors.push('`sero.plugin.tags` must include at least one non-empty string');
+    }
+  }
+
+  if (errors.length > 0 || !category) {
+    return { meta: null, warnings: [...errors, ...warnings] };
+  }
+
+  const parsed: PluginMeta = {
+    category,
+    tags,
+  };
+
+  if (typeof plugin.minSeroVersion === 'string') {
+    const minSeroVersion = plugin.minSeroVersion.trim();
+    if (minSeroVersion) {
+      parsed.minSeroVersion = minSeroVersion;
+    } else {
+      warnings.push('ignored empty `sero.plugin.minSeroVersion`');
+    }
+  } else if (plugin.minSeroVersion !== undefined) {
+    warnings.push('ignored non-string `sero.plugin.minSeroVersion`');
+  }
+
+  if (Array.isArray(plugin.requiredHostCapabilities)) {
+    const requiredHostCapabilities: SeroHostCapability[] = [];
+    plugin.requiredHostCapabilities.forEach((capability, index) => {
+      if (typeof capability !== 'string') {
+        warnings.push(`ignored non-string \`sero.plugin.requiredHostCapabilities[${index}]\``);
+        return;
+      }
+      const trimmed = capability.trim();
+      if (!trimmed) {
+        warnings.push(`ignored empty \`sero.plugin.requiredHostCapabilities[${index}]\``);
+        return;
+      }
+      if (!isHostCapability(trimmed)) {
+        warnings.push(
+          `ignored unknown \`sero.plugin.requiredHostCapabilities[${index}]\`: ${trimmed}`,
+        );
+        return;
+      }
+      requiredHostCapabilities.push(trimmed);
+    });
+    if (requiredHostCapabilities.length > 0) {
+      parsed.requiredHostCapabilities = requiredHostCapabilities;
+    }
+  } else if (plugin.requiredHostCapabilities !== undefined) {
+    warnings.push('ignored invalid `sero.plugin.requiredHostCapabilities`; expected string[]');
+  }
+
+  if (typeof plugin.preBuilt === 'boolean') {
+    parsed.preBuilt = plugin.preBuilt;
+  } else if (plugin.preBuilt !== undefined) {
+    warnings.push('ignored non-boolean `sero.plugin.preBuilt`');
+  }
+
+  if (typeof plugin.bridgeTools === 'boolean') {
+    parsed.bridgeTools = plugin.bridgeTools;
+  } else if (Array.isArray(plugin.bridgeTools)) {
+    const bridgeTools: string[] = [];
+    plugin.bridgeTools.forEach((toolName, index) => {
+      if (typeof toolName !== 'string') {
+        warnings.push(`ignored non-string \`sero.plugin.bridgeTools[${index}]\``);
+        return;
+      }
+      const trimmed = toolName.trim();
+      if (!trimmed) {
+        warnings.push(`ignored empty \`sero.plugin.bridgeTools[${index}]\``);
+        return;
+      }
+      bridgeTools.push(trimmed);
+    });
+    if (plugin.bridgeTools.length === 0 || bridgeTools.length > 0) {
+      parsed.bridgeTools = bridgeTools;
+    } else {
+      warnings.push('ignored invalid `sero.plugin.bridgeTools` array');
+    }
+  } else if (plugin.bridgeTools !== undefined) {
+    warnings.push('ignored invalid `sero.plugin.bridgeTools`; expected boolean or string[]');
+  }
+
+  return { meta: parsed, warnings };
+}
+
+export function warnInvalidPluginMeta(packagePath: string, warnings: string[]): void {
+  if (warnings.length === 0) return;
+  console.warn(
+    `[app-discovery] Ignoring invalid sero.plugin metadata in "${packagePath}": ${warnings.join('; ')}`,
+  );
+}

--- a/apps/desktop/electron/features/apps/discovery/plugin-meta.ts
+++ b/apps/desktop/electron/features/apps/discovery/plugin-meta.ts
@@ -1,8 +1,4 @@
-import type {
-  PluginMeta,
-  SeroHostCapability,
-} from '@sero/common';
-import { SERO_HOST_CAPABILITIES } from '@sero/common';
+import type { PluginMeta } from '@sero/common';
 
 const PLUGIN_CATEGORIES = [
   'productivity',
@@ -32,8 +28,41 @@ function isPluginCategory(value: string): value is PluginMeta['category'] {
   return PLUGIN_CATEGORIES.includes(value as PluginMeta['category']);
 }
 
-function isHostCapability(value: string): value is SeroHostCapability {
-  return SERO_HOST_CAPABILITIES.includes(value as SeroHostCapability);
+export interface PluginCompatibilityRequirements {
+  minSeroVersion?: string;
+  requiredHostCapabilities?: string[];
+}
+
+export function extractPluginCompatibilityRequirements(
+  plugin: unknown,
+): PluginCompatibilityRequirements | null {
+  if (!isRecord(plugin)) {
+    return null;
+  }
+
+  const requirements: PluginCompatibilityRequirements = {};
+
+  if (typeof plugin.minSeroVersion === 'string') {
+    const minSeroVersion = plugin.minSeroVersion.trim();
+    if (minSeroVersion) {
+      requirements.minSeroVersion = minSeroVersion;
+    }
+  }
+
+  if (Array.isArray(plugin.requiredHostCapabilities)) {
+    const requiredHostCapabilities = plugin.requiredHostCapabilities
+      .filter((capability): capability is string => typeof capability === 'string')
+      .map((capability) => capability.trim())
+      .filter(Boolean);
+
+    if (requiredHostCapabilities.length > 0) {
+      requirements.requiredHostCapabilities = requiredHostCapabilities;
+    }
+  }
+
+  return requirements.minSeroVersion || requirements.requiredHostCapabilities?.length
+    ? requirements
+    : null;
 }
 
 export function parsePluginMeta(plugin: unknown): ParsedPluginMetaResult {
@@ -105,7 +134,7 @@ export function parsePluginMeta(plugin: unknown): ParsedPluginMetaResult {
   }
 
   if (Array.isArray(plugin.requiredHostCapabilities)) {
-    const requiredHostCapabilities: SeroHostCapability[] = [];
+    const requiredHostCapabilities: string[] = [];
     plugin.requiredHostCapabilities.forEach((capability, index) => {
       if (typeof capability !== 'string') {
         warnings.push(`ignored non-string \`sero.plugin.requiredHostCapabilities[${index}]\``);
@@ -114,12 +143,6 @@ export function parsePluginMeta(plugin: unknown): ParsedPluginMetaResult {
       const trimmed = capability.trim();
       if (!trimmed) {
         warnings.push(`ignored empty \`sero.plugin.requiredHostCapabilities[${index}]\``);
-        return;
-      }
-      if (!isHostCapability(trimmed)) {
-        warnings.push(
-          `ignored unknown \`sero.plugin.requiredHostCapabilities[${index}]\`: ${trimmed}`,
-        );
         return;
       }
       requiredHostCapabilities.push(trimmed);

--- a/apps/desktop/electron/features/apps/extensions/create-sero-extension.ts
+++ b/apps/desktop/electron/features/apps/extensions/create-sero-extension.ts
@@ -51,7 +51,10 @@ export function createSeroExtensionFactory(
 
     pi.on('before_agent_start', async (event) => {
       let systemPrompt = event.systemPrompt;
-      systemPrompt += buildCliPromptBlock();
+      systemPrompt += buildCliPromptBlock(undefined, {
+        workspaceId: currentWorkspaceId,
+        sessionId: _sessionId,
+      });
 
       // Inject container environment context if workspace is containerised
       if (containerState) {

--- a/apps/desktop/electron/features/plugins/activation.ts
+++ b/apps/desktop/electron/features/plugins/activation.ts
@@ -1,22 +1,31 @@
-import { promises as fs } from 'fs';
-import { readFileSync } from 'fs';
+import { promises as fs, readFileSync } from 'fs';
 import path from 'path';
 
-import { SERO_AGENT_DIR } from '@electron/platform/env';
 import {
-  extractPluginCompatibilityRequirements,
-  hasPluginDeclaration,
-} from '../apps/discovery/plugin-meta';
-import { evaluatePluginCompatibility } from './compatibility';
+  DefaultPackageManager,
+  type PackageSource,
+  SettingsManager,
+} from '@mariozechner/pi-coding-agent';
+import { SERO_AGENT_DIR } from '@electron/platform/env';
+import { getPackageCompatibilityForResourcePath } from './resource-compatibility';
 import { getPackagesArray, readSettings, writeSettings } from './settings';
 
 const PLUGINS_DIR = path.join(SERO_AGENT_DIR, 'packages');
+const PLUGIN_META_FILENAME = '.sero-plugin-meta.json';
 
 interface PluginPackageJson {
   sero?: {
     app?: unknown;
-    plugin?: unknown;
   };
+}
+
+interface PluginInstallMeta {
+  installedAt?: string;
+}
+
+interface InstalledPluginPath {
+  packagePath: string;
+  installedAtMs: number | null;
 }
 
 function readPkgJsonSync(dir: string): PluginPackageJson | null {
@@ -27,14 +36,69 @@ function readPkgJsonSync(dir: string): PluginPackageJson | null {
   }
 }
 
-function isManagedPluginPackageSource(source: string): boolean {
+function readPluginInstalledAtMs(packagePath: string): number | null {
+  try {
+    const raw = readFileSync(path.join(packagePath, PLUGIN_META_FILENAME), 'utf8');
+    const meta = JSON.parse(raw) as PluginInstallMeta;
+    if (!meta.installedAt) return null;
+
+    const timestamp = Date.parse(meta.installedAt);
+    return Number.isFinite(timestamp) ? timestamp : null;
+  } catch {
+    return null;
+  }
+}
+
+function compareInstalledPluginPaths(left: InstalledPluginPath, right: InstalledPluginPath): number {
+  if (left.installedAtMs !== null && right.installedAtMs !== null && left.installedAtMs !== right.installedAtMs) {
+    return left.installedAtMs - right.installedAtMs;
+  }
+  if (left.installedAtMs !== null && right.installedAtMs === null) return -1;
+  if (left.installedAtMs === null && right.installedAtMs !== null) return 1;
+  return left.packagePath.localeCompare(right.packagePath);
+}
+
+function isManagedPluginPackageSource(sourcePath: string): boolean {
   const resolvedPluginsDir = path.resolve(PLUGINS_DIR);
-  const resolvedSource = path.resolve(source);
+  const resolvedSource = path.resolve(sourcePath);
   return resolvedSource.startsWith(`${resolvedPluginsDir}${path.sep}`);
 }
 
+function getPackageEntrySource(entry: PackageSource): string | null {
+  const source = typeof entry === 'string' ? entry : entry.source;
+  return typeof source === 'string' && source ? source : null;
+}
+
+function createPackageManager(settings: Record<string, unknown>): DefaultPackageManager {
+  return new DefaultPackageManager({
+    cwd: SERO_AGENT_DIR,
+    agentDir: SERO_AGENT_DIR,
+    settingsManager: SettingsManager.inMemory(settings as { packages?: PackageSource[] }),
+  });
+}
+
+function resolvePackageEntryPath(
+  packageManager: DefaultPackageManager,
+  source: string,
+): string | null {
+  return packageManager.getInstalledPath(source, 'user') ?? null;
+}
+
+function shouldKeepPackageEntry(
+  packageManager: DefaultPackageManager,
+  entry: PackageSource,
+): boolean {
+  const source = getPackageEntrySource(entry);
+  if (!source) return true;
+
+  const resolvedPath = resolvePackageEntryPath(packageManager, source);
+  if (!resolvedPath) return true;
+
+  return getPackageCompatibilityForResourcePath(resolvedPath)?.supported !== false;
+}
+
 async function collectCompatibleInstalledPluginPaths(): Promise<string[]> {
-  const compatiblePaths: string[] = [];
+  const compatiblePaths: InstalledPluginPath[] = [];
 
   try {
     const entries = await fs.readdir(PLUGINS_DIR, { withFileTypes: true });
@@ -43,40 +107,50 @@ async function collectCompatibleInstalledPluginPaths(): Promise<string[]> {
       const packagePath = path.join(PLUGINS_DIR, entry.name);
       const pkg = readPkgJsonSync(packagePath);
       if (!pkg?.sero?.app) continue;
+      if (getPackageCompatibilityForResourcePath(packagePath)?.supported === false) continue;
 
-      const plugin = hasPluginDeclaration(pkg)
-        ? extractPluginCompatibilityRequirements(pkg.sero?.plugin)
-        : null;
-      const compatibility = evaluatePluginCompatibility(plugin);
-      if (compatibility?.supported === false) continue;
-
-      compatiblePaths.push(packagePath);
+      compatiblePaths.push({
+        packagePath,
+        installedAtMs: readPluginInstalledAtMs(packagePath),
+      });
     }
   } catch {
     // Directory doesn't exist yet — no installed plugins to reconcile.
   }
 
-  return compatiblePaths.sort((left, right) => left.localeCompare(right));
+  return compatiblePaths
+    .sort(compareInstalledPluginPaths)
+    .map((entry) => entry.packagePath);
 }
 
 export async function reconcileInstalledPluginActivation(): Promise<void> {
   const settings = readSettings();
-  const compatiblePluginPaths = await collectCompatibleInstalledPluginPaths();
-  const packageEntries = getPackagesArray(settings);
-  const unmanagedEntries = packageEntries.filter((entry) => {
-    const source = typeof entry === 'string' ? entry : entry.source;
-    return !(typeof source === 'string' && source && isManagedPluginPackageSource(source));
-  });
+  const packageEntries = getPackagesArray(settings) as PackageSource[];
+  const packageManager = createPackageManager(settings);
+  const keptEntries = packageEntries.filter((entry) => shouldKeepPackageEntry(packageManager, entry));
+
+  const managedActivePaths = new Set(
+    keptEntries
+      .map((entry) => getPackageEntrySource(entry))
+      .flatMap((source) => {
+        if (!source) return [];
+        const resolvedPath = resolvePackageEntryPath(packageManager, source);
+        return resolvedPath && isManagedPluginPackageSource(resolvedPath)
+          ? [path.resolve(resolvedPath)]
+          : [];
+      }),
+  );
+
+  const additionalManagedPaths = (await collectCompatibleInstalledPluginPaths())
+    .filter((packagePath) => !managedActivePaths.has(path.resolve(packagePath)));
 
   const currentSources = packageEntries
-    .map((entry) => typeof entry === 'string' ? entry : entry.source)
+    .map((entry) => getPackageEntrySource(entry))
     .filter((source): source is string => typeof source === 'string' && !!source);
-  const nextSources = [
-    ...unmanagedEntries
-      .map((entry) => typeof entry === 'string' ? entry : entry.source)
-      .filter((source): source is string => typeof source === 'string' && !!source),
-    ...compatiblePluginPaths,
-  ];
+  const nextEntries: PackageSource[] = [...keptEntries, ...additionalManagedPaths];
+  const nextSources = nextEntries
+    .map((entry) => getPackageEntrySource(entry))
+    .filter((source): source is string => typeof source === 'string' && !!source);
 
   if (
     currentSources.length === nextSources.length
@@ -85,6 +159,6 @@ export async function reconcileInstalledPluginActivation(): Promise<void> {
     return;
   }
 
-  settings.packages = [...unmanagedEntries, ...compatiblePluginPaths];
+  settings.packages = nextEntries;
   writeSettings(settings);
 }

--- a/apps/desktop/electron/features/plugins/activation.ts
+++ b/apps/desktop/electron/features/plugins/activation.ts
@@ -1,0 +1,87 @@
+import { promises as fs } from 'fs';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { SERO_AGENT_DIR } from '@electron/platform/env';
+import { hasPluginDeclaration, parsePluginMeta } from '../apps/discovery/plugin-meta';
+import { evaluatePluginCompatibility } from './compatibility';
+import { getPackagesArray, readSettings, writeSettings } from './settings';
+
+const PLUGINS_DIR = path.join(SERO_AGENT_DIR, 'packages');
+
+interface PluginPackageJson {
+  sero?: {
+    app?: unknown;
+    plugin?: unknown;
+  };
+}
+
+function readPkgJsonSync(dir: string): PluginPackageJson | null {
+  try {
+    return JSON.parse(readFileSync(path.join(dir, 'package.json'), 'utf8')) as PluginPackageJson;
+  } catch {
+    return null;
+  }
+}
+
+function isManagedPluginPackageSource(source: string): boolean {
+  const resolvedPluginsDir = path.resolve(PLUGINS_DIR);
+  const resolvedSource = path.resolve(source);
+  return resolvedSource.startsWith(`${resolvedPluginsDir}${path.sep}`);
+}
+
+async function collectCompatibleInstalledPluginPaths(): Promise<string[]> {
+  const compatiblePaths: string[] = [];
+
+  try {
+    const entries = await fs.readdir(PLUGINS_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const packagePath = path.join(PLUGINS_DIR, entry.name);
+      const pkg = readPkgJsonSync(packagePath);
+      if (!pkg?.sero?.app) continue;
+
+      const plugin = hasPluginDeclaration(pkg)
+        ? parsePluginMeta(pkg.sero?.plugin).meta
+        : null;
+      const compatibility = evaluatePluginCompatibility(plugin);
+      if (compatibility?.supported === false) continue;
+
+      compatiblePaths.push(packagePath);
+    }
+  } catch {
+    // Directory doesn't exist yet — no installed plugins to reconcile.
+  }
+
+  return compatiblePaths.sort((left, right) => left.localeCompare(right));
+}
+
+export async function reconcileInstalledPluginActivation(): Promise<void> {
+  const settings = readSettings();
+  const compatiblePluginPaths = await collectCompatibleInstalledPluginPaths();
+  const packageEntries = getPackagesArray(settings);
+  const unmanagedEntries = packageEntries.filter((entry) => {
+    const source = typeof entry === 'string' ? entry : entry.source;
+    return !(typeof source === 'string' && source && isManagedPluginPackageSource(source));
+  });
+
+  const currentSources = packageEntries
+    .map((entry) => typeof entry === 'string' ? entry : entry.source)
+    .filter((source): source is string => typeof source === 'string' && !!source);
+  const nextSources = [
+    ...unmanagedEntries
+      .map((entry) => typeof entry === 'string' ? entry : entry.source)
+      .filter((source): source is string => typeof source === 'string' && !!source),
+    ...compatiblePluginPaths,
+  ];
+
+  if (
+    currentSources.length === nextSources.length
+    && currentSources.every((source, index) => source === nextSources[index])
+  ) {
+    return;
+  }
+
+  settings.packages = [...unmanagedEntries, ...compatiblePluginPaths];
+  writeSettings(settings);
+}

--- a/apps/desktop/electron/features/plugins/activation.ts
+++ b/apps/desktop/electron/features/plugins/activation.ts
@@ -3,7 +3,10 @@ import { readFileSync } from 'fs';
 import path from 'path';
 
 import { SERO_AGENT_DIR } from '@electron/platform/env';
-import { hasPluginDeclaration, parsePluginMeta } from '../apps/discovery/plugin-meta';
+import {
+  extractPluginCompatibilityRequirements,
+  hasPluginDeclaration,
+} from '../apps/discovery/plugin-meta';
 import { evaluatePluginCompatibility } from './compatibility';
 import { getPackagesArray, readSettings, writeSettings } from './settings';
 
@@ -42,7 +45,7 @@ async function collectCompatibleInstalledPluginPaths(): Promise<string[]> {
       if (!pkg?.sero?.app) continue;
 
       const plugin = hasPluginDeclaration(pkg)
-        ? parsePluginMeta(pkg.sero?.plugin).meta
+        ? extractPluginCompatibilityRequirements(pkg.sero?.plugin)
         : null;
       const compatibility = evaluatePluginCompatibility(plugin);
       if (compatibility?.supported === false) continue;

--- a/apps/desktop/electron/features/plugins/compatibility.ts
+++ b/apps/desktop/electron/features/plugins/compatibility.ts
@@ -4,8 +4,6 @@ import path from 'path';
 import type {
   PluginCompatibilityIssue,
   PluginCompatibilityStatus,
-  PluginMeta,
-  SeroHostCapability,
 } from '@sero/common';
 import { SERO_HOST_CAPABILITIES } from '@sero/common';
 
@@ -15,7 +13,12 @@ interface DesktopPackageJson {
 
 export interface SeroHostCompatibilityContext {
   hostVersion: string;
-  capabilities: ReadonlySet<SeroHostCapability>;
+  capabilities: ReadonlySet<string>;
+}
+
+interface PluginCompatibilityRequirements {
+  minSeroVersion?: string;
+  requiredHostCapabilities?: readonly string[];
 }
 
 let desktopPackageVersion: string | null = null;
@@ -50,7 +53,7 @@ function getRuntimeElectronVersion(): string | null {
 export function getSeroHostCompatibilityContext(): SeroHostCompatibilityContext {
   return {
     hostVersion: getRuntimeElectronVersion() ?? getDesktopPackageVersion(),
-    capabilities: new Set<SeroHostCapability>(SERO_HOST_CAPABILITIES),
+    capabilities: new Set<string>(SERO_HOST_CAPABILITIES),
   };
 }
 
@@ -91,7 +94,7 @@ function minVersionIssue(minSeroVersion: string, hostVersion: string): PluginCom
   };
 }
 
-function missingCapabilityIssue(capability: SeroHostCapability): PluginCompatibilityIssue {
+function missingCapabilityIssue(capability: string): PluginCompatibilityIssue {
   return {
     kind: 'requiredHostCapability',
     capability,
@@ -101,7 +104,7 @@ function missingCapabilityIssue(capability: SeroHostCapability): PluginCompatibi
 }
 
 export function evaluatePluginCompatibility(
-  plugin: PluginMeta | null | undefined,
+  plugin: PluginCompatibilityRequirements | null | undefined,
   context: SeroHostCompatibilityContext = getSeroHostCompatibilityContext(),
 ): PluginCompatibilityStatus | null {
   if (!plugin) return null;
@@ -130,7 +133,7 @@ export function evaluatePluginCompatibility(
 }
 
 export function assertPluginCompatible(
-  plugin: PluginMeta | null | undefined,
+  plugin: PluginCompatibilityRequirements | null | undefined,
   context: SeroHostCompatibilityContext = getSeroHostCompatibilityContext(),
 ): void {
   const compatibility = evaluatePluginCompatibility(plugin, context);

--- a/apps/desktop/electron/features/plugins/compatibility.ts
+++ b/apps/desktop/electron/features/plugins/compatibility.ts
@@ -1,0 +1,140 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import type {
+  PluginCompatibilityIssue,
+  PluginCompatibilityStatus,
+  PluginMeta,
+  SeroHostCapability,
+} from '@sero/common';
+import { SERO_HOST_CAPABILITIES } from '@sero/common';
+
+interface DesktopPackageJson {
+  version?: string;
+}
+
+export interface SeroHostCompatibilityContext {
+  hostVersion: string;
+  capabilities: ReadonlySet<SeroHostCapability>;
+}
+
+let desktopPackageVersion: string | null = null;
+
+function getDesktopPackageVersion(): string {
+  if (desktopPackageVersion) return desktopPackageVersion;
+
+  const packageJsonPath = path.resolve(__dirname, '../../../package.json');
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as DesktopPackageJson;
+  desktopPackageVersion = typeof pkg.version === 'string' && pkg.version.trim()
+    ? pkg.version.trim()
+    : '0.0.0';
+  return desktopPackageVersion;
+}
+
+function getRuntimeElectronVersion(): string | null {
+  try {
+    const electronModule = require('electron') as { app?: { getVersion?: () => string } } | string;
+    if (typeof electronModule === 'object' && electronModule !== null) {
+      const version = electronModule.app?.getVersion?.();
+      if (typeof version === 'string' && version.trim()) {
+        return version.trim();
+      }
+    }
+  } catch {
+    // Fall back to the desktop package version in non-Electron contexts (tests, tooling).
+  }
+
+  return null;
+}
+
+export function getSeroHostCompatibilityContext(): SeroHostCompatibilityContext {
+  return {
+    hostVersion: getRuntimeElectronVersion() ?? getDesktopPackageVersion(),
+    capabilities: new Set<SeroHostCapability>(SERO_HOST_CAPABILITIES),
+  };
+}
+
+function parseVersion(version: string): number[] | null {
+  const normalized = version.trim();
+  if (!normalized) return null;
+
+  const main = normalized.split('-', 1)[0]?.trim() ?? '';
+  if (!/^\d+(?:\.\d+){0,2}$/.test(main)) {
+    return null;
+  }
+
+  return main.split('.').map((part) => Number(part));
+}
+
+function compareVersions(left: string, right: string): number | null {
+  const leftParts = parseVersion(left);
+  const rightParts = parseVersion(right);
+  if (!leftParts || !rightParts) return null;
+
+  const maxLength = Math.max(leftParts.length, rightParts.length);
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftPart = leftParts[index] ?? 0;
+    const rightPart = rightParts[index] ?? 0;
+    if (leftPart > rightPart) return 1;
+    if (leftPart < rightPart) return -1;
+  }
+
+  return 0;
+}
+
+function minVersionIssue(minSeroVersion: string, hostVersion: string): PluginCompatibilityIssue {
+  return {
+    kind: 'minSeroVersion',
+    expected: minSeroVersion,
+    actual: hostVersion,
+    message: `Requires Sero ${minSeroVersion} or newer (current host: ${hostVersion}).`,
+  };
+}
+
+function missingCapabilityIssue(capability: SeroHostCapability): PluginCompatibilityIssue {
+  return {
+    kind: 'requiredHostCapability',
+    capability,
+    expected: capability,
+    message: `Requires host capability \`${capability}\`, which this Sero build does not provide.`,
+  };
+}
+
+export function evaluatePluginCompatibility(
+  plugin: PluginMeta | null | undefined,
+  context: SeroHostCompatibilityContext = getSeroHostCompatibilityContext(),
+): PluginCompatibilityStatus | null {
+  if (!plugin) return null;
+
+  const issues: PluginCompatibilityIssue[] = [];
+  const hostVersion = context.hostVersion;
+
+  if (plugin.minSeroVersion) {
+    const comparison = compareVersions(hostVersion, plugin.minSeroVersion);
+    if (comparison === null || comparison < 0) {
+      issues.push(minVersionIssue(plugin.minSeroVersion, hostVersion));
+    }
+  }
+
+  for (const capability of plugin.requiredHostCapabilities ?? []) {
+    if (!context.capabilities.has(capability)) {
+      issues.push(missingCapabilityIssue(capability));
+    }
+  }
+
+  return {
+    supported: issues.length === 0,
+    hostVersion,
+    issues,
+  };
+}
+
+export function assertPluginCompatible(
+  plugin: PluginMeta | null | undefined,
+  context: SeroHostCompatibilityContext = getSeroHostCompatibilityContext(),
+): void {
+  const compatibility = evaluatePluginCompatibility(plugin, context);
+  if (!compatibility || compatibility.supported) return;
+
+  throw new Error(compatibility.issues.map((issue) => issue.message).join(' '));
+}

--- a/apps/desktop/electron/features/plugins/manager.ts
+++ b/apps/desktop/electron/features/plugins/manager.ts
@@ -18,18 +18,26 @@ import { registerExtAssets, unregisterExtAssets } from '@electron/platform/proto
 import { invalidatePackageProviderManifestCache } from '@electron/shared/providers/package-provider-manifests';
 import { clearAppManifestCache } from '@electron/ipc/agent/handlers/app-agent';
 import { clearPluginBridgePolicyCache } from '@electron/cli';
-import type { SeroAppManifest, SettingsPackageSource } from '@/types/ipc';
+import type { SeroAppManifest } from '@/types/ipc';
 import type { InstalledPlugin } from './types';
+import { hasPluginDeclaration, parsePluginMeta } from '../apps/discovery/plugin-meta';
+import { reconcileInstalledPluginActivation } from './activation';
+import { assertPluginCompatible } from './compatibility';
 import { assertPluginInstallAllowed } from './install-policy';
 import { ensurePluginPackageReadyForInstall } from './package-build';
 import { assertValidPluginId, resolvePluginInstallDir } from './security';
+import {
+  addPackageToSettings,
+  removePackageFromSettings,
+} from './settings';
 const execFile = promisify(execFileCb);
+
+export { reconcileInstalledPluginActivation } from './activation';
+
 /** Directory where plugins are installed. */
 const PLUGINS_DIR = path.join(SERO_AGENT_DIR, 'packages');
 /** Temporary staging area for installs / backups. Not scanned by app discovery. */
 const PLUGIN_STAGING_DIR = path.join(SERO_AGENT_DIR, '.plugin-staging');
-/** Path to the settings.json file. */
-const SETTINGS_PATH = path.join(SERO_AGENT_DIR, 'settings.json');
 /** Sidecar filename persisted alongside installed plugins. */
 const PLUGIN_META_FILENAME = '.sero-plugin-meta.json';
 // ── Install serialisation ───────────────────────────────────
@@ -49,10 +57,7 @@ interface PkgJson {
       ui?: string;
       component?: string;
     };
-    plugin?: {
-      category?: InstalledPlugin['category'];
-      tags?: string[];
-    };
+    plugin?: unknown;
   };
 }
 
@@ -143,40 +148,13 @@ function assertPreparedUiExists(packageDir: string, app: ValidatedPluginApp): vo
   }
 }
 
-function readSettings(): Record<string, unknown> {
-  try {
-    const parsed = JSON.parse(readFileSync(SETTINGS_PATH, 'utf8'));
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      throw new Error('settings.json must contain a JSON object');
-    }
-    return parsed as Record<string, unknown>;
-  } catch (error) {
-    const nodeError = error as NodeJS.ErrnoException;
-    if (nodeError?.code === 'ENOENT') {
-      return {};
-    }
-    throw new Error(`Failed to read settings.json. Fix ~/.sero-ui/agent/settings.json and retry plugin operation. (${error instanceof Error ? error.message : 'unknown parse error'})`);
-  }
-}
-
-function writeSettings(settings: Record<string, unknown>): void {
-  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + '\n');
-  invalidatePackageProviderManifestCache();
-}
-
-function getPackagesArray(settings: Record<string, unknown>): SettingsPackageSource[] {
-  return Array.isArray(settings.packages)
-    ? (settings.packages as SettingsPackageSource[])
-    : [];
-}
-
 function manifestToInstalledPlugin(
   pkg: PkgJson,
   packagePath: string,
   meta: PluginInstallMeta | null,
 ): InstalledPlugin {
   const app = pkg.sero?.app;
-  const plugin = pkg.sero?.plugin;
+  const plugin = parsePluginMeta(pkg.sero?.plugin).meta;
   return {
     id: app?.id ?? path.basename(packagePath),
     name: app?.name ?? pkg.name ?? path.basename(packagePath),
@@ -279,6 +257,10 @@ async function doInstallPlugin(source: string): Promise<SeroAppManifest> {
     await ensurePluginPackageReadyForInstall(staged.stageDir, sourceKind);
 
     const validated = validatePluginPackage(readPkgJsonSync(staged.stageDir));
+    const parsedPlugin = hasPluginDeclaration(validated.pkg)
+      ? parsePluginMeta(validated.pkg.sero?.plugin)
+      : { meta: null, warnings: [] };
+    assertPluginCompatible(parsedPlugin.meta);
     assertPreparedUiExists(staged.stageDir, validated.app);
     const installPath = resolvePluginInstallDir(PLUGINS_DIR, validated.app.id);
     assertPluginInstallAllowed(await discoverApps(), validated.app.id, installPath);
@@ -292,7 +274,8 @@ async function doInstallPlugin(source: string): Promise<SeroAppManifest> {
     reserved = await reserveInstallPath(validated.app.id);
     await fs.rename(staged.stageDir, installPath);
 
-    settingsAdded = addToSettings(installPath);
+    settingsAdded = addPackageToSettings(installPath);
+    await reconcileInstalledPluginActivation();
     registerAppPath(installPath);
     clearAppManifestCache();
     clearPluginBridgePolicyCache();
@@ -312,7 +295,7 @@ async function doInstallPlugin(source: string): Promise<SeroAppManifest> {
   } catch (err) {
     if (reserved) {
       if (settingsAdded) {
-        removeFromSettings(reserved.installPath);
+        removePackageFromSettings(reserved.installPath);
       }
       unregisterAppPath(reserved.installPath);
       await cleanupDir(reserved.installPath);
@@ -347,11 +330,11 @@ export async function uninstallPlugin(pluginId: string): Promise<void> {
 
   await fs.rm(pluginPath, { recursive: true, force: true });
   unregisterExtAssets(pluginId);
-  removeFromSettings(pluginPath);
+  removePackageFromSettings(pluginPath);
+  await reconcileInstalledPluginActivation();
   unregisterAppPath(pluginPath);
   clearAppManifestCache();
   clearPluginBridgePolicyCache();
-  invalidatePackageProviderManifestCache();
 }
 
 /**
@@ -466,33 +449,3 @@ async function installFromLocal(source: string): Promise<StagedPluginInstall> {
   }
 }
 
-// ── Settings.json management ────────────────────────────────
-
-function addToSettings(packagePath: string): boolean {
-  const settings = readSettings();
-  const packages = getPackagesArray(settings);
-
-  const exists = packages.some((entry) => {
-    const src = typeof entry === 'string' ? entry : entry.source;
-    return src === packagePath;
-  });
-
-  if (exists) return false;
-
-  packages.push(packagePath);
-  settings.packages = packages;
-  writeSettings(settings);
-  return true;
-}
-
-function removeFromSettings(packagePath: string): void {
-  const settings = readSettings();
-  const packages = getPackagesArray(settings);
-
-  settings.packages = packages.filter((entry) => {
-    const src = typeof entry === 'string' ? entry : entry.source;
-    return src !== packagePath;
-  });
-
-  writeSettings(settings);
-}

--- a/apps/desktop/electron/features/plugins/manager.ts
+++ b/apps/desktop/electron/features/plugins/manager.ts
@@ -20,7 +20,10 @@ import { clearAppManifestCache } from '@electron/ipc/agent/handlers/app-agent';
 import { clearPluginBridgePolicyCache } from '@electron/cli';
 import type { SeroAppManifest } from '@/types/ipc';
 import type { InstalledPlugin } from './types';
-import { hasPluginDeclaration, parsePluginMeta } from '../apps/discovery/plugin-meta';
+import {
+  extractPluginCompatibilityRequirements,
+  parsePluginMeta,
+} from '../apps/discovery/plugin-meta';
 import { reconcileInstalledPluginActivation } from './activation';
 import { assertPluginCompatible } from './compatibility';
 import { assertPluginInstallAllowed } from './install-policy';
@@ -257,10 +260,10 @@ async function doInstallPlugin(source: string): Promise<SeroAppManifest> {
     await ensurePluginPackageReadyForInstall(staged.stageDir, sourceKind);
 
     const validated = validatePluginPackage(readPkgJsonSync(staged.stageDir));
-    const parsedPlugin = hasPluginDeclaration(validated.pkg)
-      ? parsePluginMeta(validated.pkg.sero?.plugin)
-      : { meta: null, warnings: [] };
-    assertPluginCompatible(parsedPlugin.meta);
+    const compatibilityRequirements = extractPluginCompatibilityRequirements(
+      validated.pkg.sero?.plugin,
+    );
+    assertPluginCompatible(compatibilityRequirements);
     assertPreparedUiExists(staged.stageDir, validated.app);
     const installPath = resolvePluginInstallDir(PLUGINS_DIR, validated.app.id);
     assertPluginInstallAllowed(await discoverApps(), validated.app.id, installPath);

--- a/apps/desktop/electron/features/plugins/manager.ts
+++ b/apps/desktop/electron/features/plugins/manager.ts
@@ -26,6 +26,7 @@ import {
 } from '../apps/discovery/plugin-meta';
 import { reconcileInstalledPluginActivation } from './activation';
 import { assertPluginCompatible } from './compatibility';
+import { clearPackageCompatibilityCache } from './resource-compatibility';
 import { assertPluginInstallAllowed } from './install-policy';
 import { ensurePluginPackageReadyForInstall } from './package-build';
 import { assertValidPluginId, resolvePluginInstallDir } from './security';
@@ -282,6 +283,7 @@ async function doInstallPlugin(source: string): Promise<SeroAppManifest> {
     registerAppPath(installPath);
     clearAppManifestCache();
     clearPluginBridgePolicyCache();
+    clearPackageCompatibilityCache();
 
     const apps = await discoverApps();
     const manifest = apps.find(
@@ -313,6 +315,7 @@ async function doInstallPlugin(source: string): Promise<SeroAppManifest> {
   } finally {
     clearAppManifestCache();
     clearPluginBridgePolicyCache();
+    clearPackageCompatibilityCache();
     await cleanupDir(staged?.tempRoot ?? null);
     await cleanupDir(reserved?.backupRoot ?? null);
   }
@@ -338,6 +341,7 @@ export async function uninstallPlugin(pluginId: string): Promise<void> {
   unregisterAppPath(pluginPath);
   clearAppManifestCache();
   clearPluginBridgePolicyCache();
+  clearPackageCompatibilityCache();
 }
 
 /**

--- a/apps/desktop/electron/features/plugins/resource-compatibility.ts
+++ b/apps/desktop/electron/features/plugins/resource-compatibility.ts
@@ -1,0 +1,153 @@
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+
+import type {
+  LoadExtensionsResult,
+  PromptTemplate,
+  ResourceDiagnostic,
+  Skill,
+  Theme,
+} from '@mariozechner/pi-coding-agent';
+import type { PluginCompatibilityStatus } from '@sero/common';
+import {
+  extractPluginCompatibilityRequirements,
+  hasPluginDeclaration,
+} from '@electron/features/apps/discovery/plugin-meta';
+import { evaluatePluginCompatibility } from './compatibility';
+
+interface PluginPackageJson {
+  sero?: {
+    plugin?: unknown;
+  };
+}
+
+const packageRootCache = new Map<string, string | null>();
+const packageCompatibilityCache = new Map<string, PluginCompatibilityStatus | null>();
+
+function findPackageRoot(resourcePath: string): string | null {
+  const resolvedPath = path.resolve(resourcePath);
+  const cached = packageRootCache.get(resolvedPath);
+  if (cached !== undefined) return cached;
+
+  let current = resolvedPath;
+  while (true) {
+    const packageJsonPath = path.join(current, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      packageRootCache.set(resolvedPath, current);
+      return current;
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      packageRootCache.set(resolvedPath, null);
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function readPackageCompatibility(packageRoot: string): PluginCompatibilityStatus | null {
+  const resolvedRoot = path.resolve(packageRoot);
+  const cached = packageCompatibilityCache.get(resolvedRoot);
+  if (cached !== undefined) return cached;
+
+  try {
+    const raw = readFileSync(path.join(resolvedRoot, 'package.json'), 'utf8');
+    const pkg = JSON.parse(raw) as PluginPackageJson;
+    if (!hasPluginDeclaration(pkg)) {
+      packageCompatibilityCache.set(resolvedRoot, null);
+      return null;
+    }
+
+    const requirements = extractPluginCompatibilityRequirements(pkg.sero?.plugin);
+    const compatibility = requirements ? evaluatePluginCompatibility(requirements) : null;
+    packageCompatibilityCache.set(resolvedRoot, compatibility);
+    return compatibility;
+  } catch {
+    packageCompatibilityCache.set(resolvedRoot, null);
+    return null;
+  }
+}
+
+export function getPackageCompatibilityForResourcePath(
+  resourcePath: string | undefined,
+): PluginCompatibilityStatus | null {
+  if (!resourcePath) return null;
+
+  const packageRoot = findPackageRoot(resourcePath);
+  if (!packageRoot) return null;
+  return readPackageCompatibility(packageRoot);
+}
+
+export function isCompatiblePluginResourcePath(resourcePath: string | undefined): boolean {
+  return getPackageCompatibilityForResourcePath(resourcePath)?.supported !== false;
+}
+
+function filterItemsByCompatibility<T>(
+  items: T[],
+  getPath: (item: T) => string | undefined,
+): T[] {
+  return items.filter((item) => isCompatiblePluginResourcePath(getPath(item)));
+}
+
+export function filterCompatiblePluginExtensions(base: LoadExtensionsResult): LoadExtensionsResult {
+  return {
+    ...base,
+    extensions: filterItemsByCompatibility(base.extensions, (extension) => extension.resolvedPath),
+  };
+}
+
+export function filterCompatiblePluginSkills(base: {
+  skills: Skill[];
+  diagnostics: ResourceDiagnostic[];
+}): {
+  skills: Skill[];
+  diagnostics: ResourceDiagnostic[];
+} {
+  return {
+    ...base,
+    skills: filterItemsByCompatibility(base.skills, (skill) => skill.filePath),
+  };
+}
+
+export function filterCompatiblePluginPrompts(base: {
+  prompts: PromptTemplate[];
+  diagnostics: ResourceDiagnostic[];
+}): {
+  prompts: PromptTemplate[];
+  diagnostics: ResourceDiagnostic[];
+} {
+  return {
+    ...base,
+    prompts: filterItemsByCompatibility(base.prompts, (prompt) => prompt.filePath),
+  };
+}
+
+export function filterCompatiblePluginThemes(base: {
+  themes: Theme[];
+  diagnostics: ResourceDiagnostic[];
+}): {
+  themes: Theme[];
+  diagnostics: ResourceDiagnostic[];
+} {
+  return {
+    ...base,
+    themes: filterItemsByCompatibility(base.themes, (theme) => theme.sourcePath),
+  };
+}
+
+export function filterCompatiblePluginAgentsFiles(base: {
+  agentsFiles: Array<{ path: string; content: string }>;
+}): {
+  agentsFiles: Array<{ path: string; content: string }>;
+} {
+  return {
+    ...base,
+    agentsFiles: filterItemsByCompatibility(base.agentsFiles, (file) => file.path),
+  };
+}
+
+export function clearPackageCompatibilityCache(): void {
+  packageRootCache.clear();
+  packageCompatibilityCache.clear();
+}

--- a/apps/desktop/electron/features/plugins/settings.ts
+++ b/apps/desktop/electron/features/plugins/settings.ts
@@ -1,0 +1,64 @@
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+
+import { SERO_AGENT_DIR } from '@electron/platform/env';
+import { invalidatePackageProviderManifestCache } from '@electron/shared/providers/package-provider-manifests';
+import type { SettingsPackageSource } from '@/types/ipc';
+
+export const SETTINGS_PATH = path.join(SERO_AGENT_DIR, 'settings.json');
+
+export function readSettings(): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(readFileSync(SETTINGS_PATH, 'utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('settings.json must contain a JSON object');
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError?.code === 'ENOENT') {
+      return {};
+    }
+    throw new Error(`Failed to read settings.json. Fix ~/.sero-ui/agent/settings.json and retry plugin operation. (${error instanceof Error ? error.message : 'unknown parse error'})`);
+  }
+}
+
+export function writeSettings(settings: Record<string, unknown>): void {
+  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + '\n');
+  invalidatePackageProviderManifestCache();
+}
+
+export function getPackagesArray(settings: Record<string, unknown>): SettingsPackageSource[] {
+  return Array.isArray(settings.packages)
+    ? (settings.packages as SettingsPackageSource[])
+    : [];
+}
+
+export function addPackageToSettings(packagePath: string): boolean {
+  const settings = readSettings();
+  const packages = getPackagesArray(settings);
+
+  const exists = packages.some((entry) => {
+    const source = typeof entry === 'string' ? entry : entry.source;
+    return source === packagePath;
+  });
+
+  if (exists) return false;
+
+  packages.push(packagePath);
+  settings.packages = packages;
+  writeSettings(settings);
+  return true;
+}
+
+export function removePackageFromSettings(packagePath: string): void {
+  const settings = readSettings();
+  const packages = getPackagesArray(settings);
+
+  settings.packages = packages.filter((entry) => {
+    const source = typeof entry === 'string' ? entry : entry.source;
+    return source !== packagePath;
+  });
+
+  writeSettings(settings);
+}

--- a/apps/desktop/electron/features/subagent/runtime/loader.ts
+++ b/apps/desktop/electron/features/subagent/runtime/loader.ts
@@ -37,7 +37,10 @@ export function createSubagentExtensionFactory(
     // ── System prompt injection (CLI + container) ─────────────
     pi.on('before_agent_start', async (event) => {
       let systemPrompt = event.systemPrompt;
-      systemPrompt += buildCliPromptBlock();
+      systemPrompt += buildCliPromptBlock(undefined, {
+        workspaceId: currentWorkspaceId,
+        sessionId: _sessionId,
+      });
 
       if (containerState) {
         systemPrompt += buildContainerPromptBlock(

--- a/apps/desktop/electron/features/subagent/runtime/runner.ts
+++ b/apps/desktop/electron/features/subagent/runtime/runner.ts
@@ -27,6 +27,13 @@ import { createSubagentExtensionFactory } from './loader';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { logRawEvent, logTurnContext } from '@electron/ipc/editor/debug';
 import { createSkillVisibilityOverride } from '@electron/features/apps/extensions/skill-visibility';
+import {
+  filterCompatiblePluginAgentsFiles,
+  filterCompatiblePluginExtensions,
+  filterCompatiblePluginPrompts,
+  filterCompatiblePluginSkills,
+  filterCompatiblePluginThemes,
+} from '@electron/features/plugins/resource-compatibility';
 import { resolveWorkspaceRuntime } from '@electron/features/workspace/runtime-resolution';
 import { parseModelField, resolveTierModel } from '@electron/shared/settings/resolve-tier-model';
 import { getModelTiers } from '@electron/shared/settings/model-tiers';
@@ -161,6 +168,7 @@ export async function runSubagent(
   const customTools = [...platformTools, ...(config.customTools ?? [])];
 
   // Build a reduced extension factory for the child session
+  const skillVisibilityOverride = createSkillVisibilityOverride(infra.settingsManager);
   const loader = new DefaultResourceLoader({
     cwd: sessionPath,
     agentDir: SERO_AGENT_DIR,
@@ -174,7 +182,11 @@ export async function runSubagent(
         containerCwd,
       ),
     ],
-    skillsOverride: createSkillVisibilityOverride(infra.settingsManager),
+    skillsOverride: (base) => filterCompatiblePluginSkills(skillVisibilityOverride(base)),
+    promptsOverride: filterCompatiblePluginPrompts,
+    themesOverride: filterCompatiblePluginThemes,
+    extensionsOverride: filterCompatiblePluginExtensions,
+    agentsFilesOverride: filterCompatiblePluginAgentsFiles,
   });
   await loader.reload();
 

--- a/apps/desktop/electron/ipc/agent/core/agent-session-open.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-session-open.ts
@@ -30,6 +30,13 @@ import {
   createWorkspaceCliTool,
 } from '@electron/cli';
 import { createSkillVisibilityOverride } from '@electron/features/apps/extensions/skill-visibility';
+import {
+  filterCompatiblePluginAgentsFiles,
+  filterCompatiblePluginExtensions,
+  filterCompatiblePluginPrompts,
+  filterCompatiblePluginSkills,
+  filterCompatiblePluginThemes,
+} from '@electron/features/plugins/resource-compatibility';
 import { readGlobalAgentsMd } from './global-agents';
 import {
   buildTurnUndoMapByTurn,
@@ -121,6 +128,7 @@ export async function openSessionInPool({
     : [...createHostCodingTools(workspacePath), createWorkspaceCliTool(workspaceId, sessionId)];
   const globalAgentsFile = await readGlobalAgentsMd(workspaceId);
 
+  const skillVisibilityOverride = createSkillVisibilityOverride(infra.settingsManager);
   const loader = new DefaultResourceLoader({
     cwd: workspacePath,
     agentDir: SERO_AGENT_DIR,
@@ -131,16 +139,22 @@ export async function openSessionInPool({
         enableAgentManagementTools: true,
       }),
     ],
-    skillsOverride: createSkillVisibilityOverride(infra.settingsManager),
-    extensionsOverride: (base) => bridgeExtensionTools(base, { sessionId }),
-    ...(globalAgentsFile && {
-      agentsFilesOverride: (discovered: { agentsFiles: Array<{ path: string; content: string }> }) => ({
-        agentsFiles: [
-          globalAgentsFile,
-          ...discovered.agentsFiles.filter((file) => file.path !== globalAgentsFile.path),
-        ],
-      }),
-    }),
+    skillsOverride: (base) => filterCompatiblePluginSkills(skillVisibilityOverride(base)),
+    promptsOverride: filterCompatiblePluginPrompts,
+    themesOverride: filterCompatiblePluginThemes,
+    extensionsOverride: (base) => bridgeExtensionTools(filterCompatiblePluginExtensions(base), { sessionId }),
+    agentsFilesOverride: (discovered: { agentsFiles: Array<{ path: string; content: string }> }) => {
+      const withGlobalAgents = globalAgentsFile
+        ? {
+            agentsFiles: [
+              globalAgentsFile,
+              ...discovered.agentsFiles.filter((file) => file.path !== globalAgentsFile.path),
+            ],
+          }
+        : discovered;
+
+      return filterCompatiblePluginAgentsFiles(withGlobalAgents);
+    },
   });
   await loader.reload();
 

--- a/apps/desktop/electron/ipc/agent/core/agent.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent.ts
@@ -28,7 +28,7 @@ import {
 } from '@electron/shared/infra/shared-infra';
 import { registerAgentModelContextHandlers } from './agent-model-context';
 import { installCliAgentBridge, noteCliTurnEnd } from '@electron/cli/bridges';
-import { clearBridgedExtensionSessionItemsForSession } from '@electron/cli';
+import { clearBridgedExtensionSessionStateForSession } from '@electron/cli';
 import { installGatewayAgentOps } from '@electron/features/gateway/bridge/agent-bridge';
 import { buildGatewayOps } from '@electron/ipc/gateway/gateway-ops';
 import { emitAgentEvent } from './agent-event-broadcast';
@@ -73,7 +73,7 @@ async function closePoolEntry(sessionId: string): Promise<void> {
   entry.unsubscribe();
   entry.session.dispose();
   pool.delete(sessionId);
-  clearBridgedExtensionSessionItemsForSession(sessionId);
+  clearBridgedExtensionSessionStateForSession(sessionId);
 }
 
 export async function disposeAllAgentSessions(): Promise<void> {

--- a/apps/desktop/electron/ipc/agent/handlers/app-agent-tools.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/app-agent-tools.ts
@@ -1,0 +1,84 @@
+import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AppToolContentBlock, AppToolResult } from '@sero/common';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeToolContent(content: unknown): AppToolContentBlock[] {
+  if (!Array.isArray(content)) return [];
+
+  return content.flatMap((block): AppToolContentBlock[] => {
+    if (!isRecord(block) || typeof block.type !== 'string') return [];
+
+    if (block.type === 'text' && typeof block.text === 'string') {
+      return [{ type: 'text', text: block.text }];
+    }
+
+    if (block.type === 'image' && typeof block.data === 'string') {
+      return [{
+        type: 'image',
+        data: block.data,
+        mimeType: typeof block.mimeType === 'string' ? block.mimeType : 'image/png',
+      }];
+    }
+
+    return [];
+  });
+}
+
+function extractToolText(content: AppToolContentBlock[]): string {
+  return content
+    .filter((block): block is Extract<AppToolContentBlock, { type: 'text' }> => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}
+
+function normalizeToolDetails(details: unknown): Record<string, unknown> | null {
+  return isRecord(details) ? details : null;
+}
+
+function isErrorText(text: string): boolean {
+  return text.startsWith('Error:') || text.startsWith('ERROR:');
+}
+
+function errorToolResult(message: string): AppToolResult {
+  const text = message.startsWith('Error:') ? message : `Error: ${message}`;
+  return {
+    text,
+    content: [{ type: 'text', text }],
+    details: null,
+    isError: true,
+  };
+}
+
+export async function invokeAppSessionTool(
+  session: AgentSession,
+  toolName: string,
+  params: Record<string, unknown>,
+): Promise<AppToolResult> {
+  try {
+    const tool = session.extensionRunner?.getToolDefinition(toolName);
+    if (!tool) {
+      return errorToolResult(`App tool not found: ${toolName}`);
+    }
+
+    const toolContext = session.extensionRunner?.createContext();
+    if (!toolContext) {
+      return errorToolResult(`App tool context unavailable: ${toolName}`);
+    }
+
+    const result = await tool.execute('app-tool-bridge', params, undefined, undefined, toolContext);
+    const content = normalizeToolContent(isRecord(result) ? result.content : undefined);
+    const text = extractToolText(content);
+
+    return {
+      text,
+      content,
+      details: normalizeToolDetails(isRecord(result) ? result.details : null),
+      isError: isErrorText(text),
+    };
+  } catch (error) {
+    return errorToolResult(error instanceof Error ? error.message : 'Tool invocation failed');
+  }
+}

--- a/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
@@ -34,6 +34,7 @@ import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { workspaceManager } from '@electron/features/workspace/manager';
 import { ensureInfra } from '@electron/shared/infra/shared-infra';
 import { syncAppSessionModel } from '@electron/ipc/agent/core/app-agent-session-model-sync';
+import { invokeAppSessionTool } from './app-agent-tools';
 
 // ── App Session Pool ─────────────────────────────────────────
 
@@ -274,6 +275,20 @@ export function registerAppAgentHandlers(): void {
       }
 
       return responseText;
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.appAgent.invokeTool,
+    async (
+      _event,
+      appId: string,
+      workspaceId: string,
+      toolName: string,
+      params: Record<string, unknown> = {},
+    ) => {
+      const session = await getOrCreateAppSession(appId, workspaceId);
+      return invokeAppSessionTool(session, toolName, params);
     },
   );
 

--- a/apps/desktop/electron/ipc/integrations/plugins.ts
+++ b/apps/desktop/electron/ipc/integrations/plugins.ts
@@ -11,6 +11,7 @@ import {
   listInstalledPlugins,
   isInstalledPlugin,
 } from '@electron/features/plugins/manager';
+import { reconcileInstalledPluginActivation } from '@electron/features/plugins/activation';
 import { searchPlugins } from '@electron/features/plugins/discovery';
 import { reloadAllSessionResources } from '../agent';
 import { disposeAppSessionsForApp } from '../agent/handlers/app-agent';
@@ -21,6 +22,10 @@ function broadcastPluginEvent(event: PluginChangeEvent): void {
 }
 
 export function registerPluginHandlers(): void {
+  reconcileInstalledPluginActivation().catch((err) => {
+    console.warn('[plugins] Failed to reconcile installed plugin activation state:', err);
+  });
+
   ipcMain.handle(
     IpcChannels.plugins.install,
     async (_event, source: string): Promise<SeroAppManifest> => {

--- a/apps/desktop/electron/preload/apps/app-domain.ts
+++ b/apps/desktop/electron/preload/apps/app-domain.ts
@@ -20,6 +20,7 @@ import type {
   CreateGitHubRepoResult,
 } from '@/types/ipc';
 import type {
+  AppToolResult,
   GitActionResult,
   GitManagerRequest,
   WebAppActionResult,
@@ -96,6 +97,14 @@ export const appAgentBridge = {
         ipcRenderer.removeListener(IpcChannels.appAgent.streamEvent, handler);
       });
   },
+
+  invokeTool: (
+    appId: string,
+    workspaceId: string,
+    toolName: string,
+    params: Record<string, unknown>,
+  ): Promise<AppToolResult> =>
+    ipcRenderer.invoke(IpcChannels.appAgent.invokeTool, appId, workspaceId, toolName, params),
 };
 
 export const gitAppBridge = {

--- a/apps/desktop/electron/shared/providers/package-provider-manifests.ts
+++ b/apps/desktop/electron/shared/providers/package-provider-manifests.ts
@@ -4,6 +4,7 @@ import type { SettingsPackageSource } from '@/types/ipc';
 import type { ModelTier, PluginProviderManifest, SeroProviderManifest } from '@sero/common';
 import { MODEL_TIERS } from '@sero/common';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
+import { isCompatiblePluginResourcePath } from '@electron/features/plugins/resource-compatibility';
 import { readSettingsResult } from '@electron/shared/settings/settings-helpers';
 import {
   discoverBuiltinPackagePaths,
@@ -147,6 +148,8 @@ function loadProviderManifests(): SeroProviderManifest[] {
 
   const byId = new Map<string, SeroProviderManifest>();
   for (const packageDir of listCandidatePackageDirs()) {
+    if (!isCompatiblePluginResourcePath(packageDir)) continue;
+
     for (const provider of readProviderManifestsFromPackage(packageDir)) {
       byId.set(provider.id, provider);
     }

--- a/apps/desktop/src/components/layout/AppStoreCard.tsx
+++ b/apps/desktop/src/components/layout/AppStoreCard.tsx
@@ -41,13 +41,16 @@ export function AppStoreCard({
   };
 
   const category = manifest.plugin?.category;
+  const unsupportedReason = manifest.hostCompatibility?.supported === false
+    ? manifest.hostCompatibility.issues[0]?.message ?? 'This plugin requires a newer Sero host.'
+    : null;
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onActivate}
-      onKeyDown={handleCardKeyDown}
+      role={unsupportedReason ? undefined : 'button'}
+      tabIndex={unsupportedReason ? -1 : 0}
+      onClick={unsupportedReason ? undefined : onActivate}
+      onKeyDown={unsupportedReason ? undefined : handleCardKeyDown}
       className={cn(
         'group rounded-xl border p-3 text-left outline-none transition-colors focus-visible:ring-2 focus-visible:ring-[var(--border-default)]',
         active
@@ -100,6 +103,9 @@ export function AppStoreCard({
       <p className="mt-3 min-h-10 text-xs leading-5 text-[var(--text-secondary)]">
         {manifest.description ?? 'No description available.'}
       </p>
+      {unsupportedReason ? (
+        <p className="mt-2 text-xs text-[var(--status-error)]">{unsupportedReason}</p>
+      ) : null}
 
       <div className="mt-3 flex items-center gap-2">
         {category ? (
@@ -108,6 +114,14 @@ export function AppStoreCard({
             className="text-[11px] capitalize border-[var(--status-success-border)] bg-[var(--status-success-muted)] text-[var(--status-success)]"
           >
             {formatLabel(category)}
+          </Badge>
+        ) : null}
+        {unsupportedReason ? (
+          <Badge
+            variant="outline"
+            className="text-[11px] border-[var(--status-error-border)] bg-[var(--status-error-muted)] text-[var(--status-error)]"
+          >
+            Unsupported host
           </Badge>
         ) : null}
       </div>

--- a/apps/desktop/src/components/layout/AppStoreDialog.tsx
+++ b/apps/desktop/src/components/layout/AppStoreDialog.tsx
@@ -40,6 +40,8 @@ function buildSearchText(app: AppEntry): string {
     plugin?.category ?? '',
     plugin?.tags?.join(' ') ?? '',
     plugin?.minSeroVersion ?? '',
+    plugin?.requiredHostCapabilities?.join(' ') ?? '',
+    manifest?.hostCompatibility?.issues.map((issue) => issue.message).join(' ') ?? '',
     plugin ? (plugin.preBuilt ? 'pre-built' : 'source') : '',
   ]
     .join('\n')

--- a/apps/desktop/src/lib/app-runtime.test.tsx
+++ b/apps/desktop/src/lib/app-runtime.test.tsx
@@ -10,6 +10,7 @@ import {
   onWidgetRegistryChange,
   registerWidget,
   useAppState,
+  useAppTools,
   useWidgetRegistration,
 } from '@sero-ai/app-runtime';
 
@@ -26,6 +27,12 @@ function installSeroBridge(appState: AppStateApiMock) {
     appState,
     appAgent: {
       prompt: vi.fn(async () => ''),
+      invokeTool: vi.fn(async () => ({
+        text: '',
+        content: [],
+        details: null,
+        isError: false,
+      })),
     },
   });
 }
@@ -115,6 +122,52 @@ describe('app-runtime shared seams', () => {
     expect(latestState).toBe(0);
 
     warnSpy.mockRestore();
+  });
+
+  it('invokes app-local tools through the generic appAgent bridge', async () => {
+    let runTool: ((toolName: string, params?: Record<string, unknown>) => Promise<unknown>) | null = null;
+    const invokeTool = vi.fn(async () => ({
+      text: '{"ok":true}',
+      content: [{ type: 'text', text: '{"ok":true}' }],
+      details: { ok: true },
+      isError: false,
+    }));
+
+    const appState = {
+      read: vi.fn(async () => null),
+      write: vi.fn(async () => undefined),
+      watch: vi.fn(async () => null),
+      unwatch: vi.fn(async () => undefined),
+      onChange: vi.fn(() => () => undefined),
+    };
+    installSeroBridge(appState);
+    const sero = Reflect.get(window, 'sero') as { appAgent: { invokeTool: typeof invokeTool } };
+    sero.appAgent.invokeTool = invokeTool;
+
+    function Probe() {
+      const appTools = useAppTools();
+      runTool = appTools.run;
+      return null;
+    }
+
+    await act(async () => {
+      root?.render(
+        <AppProvider value={{ appId: 'runtime-tools', workspaceId: 'global', workspacePath: '/tmp', stateFilePath: '/tmp/tools-state.json' }}>
+          <Probe />
+        </AppProvider>,
+      );
+    });
+
+    expect(runTool).not.toBeNull();
+    const result = await runTool!('plugin_ping', { value: 42 });
+
+    expect(invokeTool).toHaveBeenCalledWith('runtime-tools', 'global', 'plugin_ping', { value: 42 });
+    expect(result).toEqual({
+      text: '{"ok":true}',
+      content: [{ type: 'text', text: '{"ok":true}' }],
+      details: { ok: true },
+      isError: false,
+    });
   });
 
   it('does not republish runtime widgets for equivalent inline size objects and keeps them sticky after unmount', async () => {

--- a/apps/desktop/src/stores/app.test.ts
+++ b/apps/desktop/src/stores/app.test.ts
@@ -25,6 +25,7 @@ function createManifest(
   id: string,
   component: string | null,
   devPort?: number,
+  overrides?: Partial<SeroAppManifest>,
 ): SeroAppManifest {
   return {
     id,
@@ -42,6 +43,7 @@ function createManifest(
     packagePath: `/tmp/${id}`,
     isPlugin: false,
     widgets: [],
+    ...overrides,
   };
 }
 
@@ -99,6 +101,36 @@ describe('discoverAndRegisterApps', () => {
       federationMocks.preloadFederatedModule.mock.calls.map(([appId]) => appId).sort(),
     ).toEqual(['notes', 'research', 'todo']);
     expect(useAppStore.getState().appsReady).toBe(true);
+  });
+
+  it('falls back to dashboard and drops unsupported favourites when discovered apps change', async () => {
+    discover.mockResolvedValue([
+      createManifest('notes', 'NotesApp', 4102),
+      createManifest('future-plugin', 'FuturePluginApp', 4103, {
+        isPlugin: true,
+        hostCompatibility: {
+          supported: false,
+          hostVersion: '0.1.0',
+          issues: [{
+            kind: 'minSeroVersion',
+            message: 'Requires Sero 9.9.9 or newer.',
+            expected: '9.9.9',
+            actual: '0.1.0',
+          }],
+        },
+      }),
+    ]);
+
+    useAppStore.setState({
+      ...useAppStore.getState(),
+      activeApp: 'future-plugin',
+      favouriteApps: ['notes', 'future-plugin'],
+    });
+
+    await discoverAndRegisterApps();
+
+    expect(useAppStore.getState().activeApp).toBe('dashboard');
+    expect(useAppStore.getState().favouriteApps).toEqual(['notes']);
   });
 
   it('falls back to dashboard and drops missing favourites when discovered apps change', async () => {

--- a/apps/desktop/src/stores/app/discovery.ts
+++ b/apps/desktop/src/stores/app/discovery.ts
@@ -10,6 +10,7 @@ import {
   BUILTIN_APPS,
   BUILTIN_APP_IDS,
   getPriorityPreloadApps,
+  isManifestHostSupported,
   manifestToEntry,
   type AppEntry,
 } from './shared';
@@ -18,7 +19,11 @@ import { useAppStore } from './state';
 function reconcileDiscoveredApps(discovered: AppEntry[]): void {
   const nextApps = [...BUILTIN_APPS, ...discovered];
   const { activeApp, pendingApp, favouriteApps } = useAppStore.getState();
-  const validIds = new Set(nextApps.map((app) => app.id));
+  const validIds = new Set(
+    nextApps
+      .filter((app) => app.builtin || isManifestHostSupported(app.manifest))
+      .map((app) => app.id),
+  );
 
   const nextActiveApp = validIds.has(activeApp) ? activeApp : 'dashboard';
   const nextPendingApp = pendingApp && validIds.has(pendingApp) ? pendingApp : null;

--- a/apps/desktop/src/stores/app/shared.ts
+++ b/apps/desktop/src/stores/app/shared.ts
@@ -10,6 +10,10 @@ export interface AppEntry {
   manifest: SeroAppManifest | null;
 }
 
+export function isManifestHostSupported(manifest: SeroAppManifest | null): boolean {
+  return manifest?.hostCompatibility?.supported !== false;
+}
+
 export type Theme = 'dark' | 'light';
 
 export const BUILTIN_APPS: AppEntry[] = [
@@ -57,7 +61,7 @@ export function getSidebarApps(apps: AppEntry[], favouriteApps: string[]): AppEn
   const discoveredById = new Map<string, AppEntry>();
 
   for (const app of apps) {
-    if (app.builtin) continue;
+    if (app.builtin || !isManifestHostSupported(app.manifest)) continue;
     discoveredById.set(app.id, app);
   }
 
@@ -76,7 +80,11 @@ export function getPriorityPreloadApps(
   favouriteApps: string[],
 ): SeroAppManifest[] {
   const priorityIds = new Set([activeApp, ...favouriteApps]);
-  return manifests.filter((manifest) => manifest.component && priorityIds.has(manifest.id));
+  return manifests.filter((manifest) => (
+    manifest.component
+    && priorityIds.has(manifest.id)
+    && isManifestHostSupported(manifest)
+  ));
 }
 
 export function areStringArraysEqual(a: string[], b: string[]): boolean {

--- a/apps/desktop/src/stores/app/state.ts
+++ b/apps/desktop/src/stores/app/state.ts
@@ -10,6 +10,7 @@ import {
   BUILTIN_APP_IDS,
   BUILTIN_APPS,
   DEFAULT_FAVOURITE_APP_IDS,
+  isManifestHostSupported,
   type AppEntry,
   type Theme,
 } from './shared';
@@ -170,6 +171,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     const entry = apps.find((candidate) => candidate.id === app);
     if (!entry) {
       console.warn(`[app-store] Ignoring unknown app: ${app}`);
+      return;
+    }
+
+    if (!entry.builtin && !isManifestHostSupported(entry.manifest)) {
+      console.warn(`[app-store] Ignoring unsupported plugin app: ${app}`);
       return;
     }
 

--- a/apps/desktop/src/types/electron-apps.d.ts
+++ b/apps/desktop/src/types/electron-apps.d.ts
@@ -14,6 +14,7 @@ import type {
   AppRecordingStatus,
 } from './ipc';
 import type {
+  AppToolResult,
   GitActionResult,
   GitManagerRequest,
   WebAppActionResult,
@@ -92,6 +93,17 @@ interface SeroAppAgentAPI {
     text: string,
     onDelta: (delta: string) => void,
   ): Promise<string>;
+
+  /**
+   * Execute an app-local extension tool directly against the app's isolated session.
+   * Returns normalized tool output blocks plus flattened text/details metadata.
+   */
+  invokeTool(
+    appId: string,
+    workspaceId: string,
+    toolName: string,
+    params: Record<string, unknown>,
+  ): Promise<AppToolResult>;
 }
 
 interface SeroGitAppAPI {

--- a/apps/desktop/src/types/ipc-channels-app-agent.ts
+++ b/apps/desktop/src/types/ipc-channels-app-agent.ts
@@ -1,0 +1,10 @@
+export const appAgentIpcChannels = {
+  /** Send a prompt to an app's dedicated agent session. Returns text response. */
+  prompt: 'sero:app-agent:prompt',
+  /** Send a prompt and stream text deltas back. Returns final text. */
+  promptStream: 'sero:app-agent:prompt-stream',
+  /** Run an app-local extension tool directly. Returns structured tool output. */
+  invokeTool: 'sero:app-agent:invoke-tool',
+  /** Push channel for text deltas during streaming. */
+  streamEvent: 'sero:app-agent:stream-event',
+};

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -5,6 +5,7 @@
  * Extracted from ipc.ts to keep that file under 500 LOC.
  */
 
+import { appAgentIpcChannels } from './ipc-channels-app-agent';
 import { localModelsIpcChannels } from './ipc-channels-local-models';
 import {
   feedbackIpcChannels,
@@ -133,14 +134,7 @@ export const IpcChannels = {
     /** Main → renderer push: new app package detected in packages/. */
     newAppDetected: 'sero:apps:new-app-detected',
   },
-  appAgent: {
-    /** Send a prompt to an app's dedicated agent session. Returns text response. */
-    prompt: 'sero:app-agent:prompt',
-    /** Send a prompt and stream text deltas back. Returns final text. */
-    promptStream: 'sero:app-agent:prompt-stream',
-    /** Push channel for text deltas during streaming. */
-    streamEvent: 'sero:app-agent:stream-event',
-  },
+  appAgent: appAgentIpcChannels,
   gitApp: {
     /** Run a direct Git app action for a workspace. */
     run: 'sero:git-app:run',

--- a/apps/desktop/src/types/sero-apps.ts
+++ b/apps/desktop/src/types/sero-apps.ts
@@ -1,4 +1,7 @@
-import type { PluginMeta } from '@sero/common';
+import type {
+  PluginCompatibilityStatus,
+  PluginMeta,
+} from '@sero/common';
 import type { WidgetManifest } from './widget-manifest';
 
 /**
@@ -48,6 +51,8 @@ export interface SeroAppManifest {
   isPlugin: boolean;
   /** Plugin manifest metadata from `sero.plugin` in package.json. */
   plugin?: PluginMeta | null;
+  /** Host/plugin compatibility status derived from the current Sero runtime. */
+  hostCompatibility?: PluginCompatibilityStatus | null;
   /** Widget definitions declared in the app manifest. */
   widgets: WidgetManifest[];
 }

--- a/apps/desktop/src/types/sero-apps.ts
+++ b/apps/desktop/src/types/sero-apps.ts
@@ -1,3 +1,4 @@
+import type { PackageSource } from '@mariozechner/pi-coding-agent';
 import type {
   PluginCompatibilityStatus,
   PluginMeta,
@@ -5,10 +6,10 @@ import type {
 import type { WidgetManifest } from './widget-manifest';
 
 /**
- * Shape of entries in the `packages` array in settings.json.
- * Can be a plain path string or an object with a `source` field.
+ * Canonical Pi package source shape from settings.json.
+ * Supports plain sources plus filtered package objects.
  */
-export type SettingsPackageSource = string | { source?: string };
+export type SettingsPackageSource = PackageSource;
 
 export type { WidgetManifest as SeroWidgetManifest } from './widget-manifest';
 

--- a/docs/deslop.md
+++ b/docs/deslop.md
@@ -4,6 +4,28 @@ Changes made during code quality passes. Most recent first.
 
 ---
 
+## 2026-04-18
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/common/src/{app-tools.ts,plugins.ts,index.ts}` | Added canonical app-tool result types plus the shared host-capability / compatibility contract used by discovery, preload, and plugin manifests |
+| `packages/app-runtime/src/{sero-bridge.ts,use-app-tools.ts,index.ts}` | Added the generic federated-app tool hook so plugin UIs can call app-local extension tools through `appAgent.invokeTool(...)` |
+| `apps/desktop/electron/ipc/agent/handlers/{app-agent.ts,app-agent-tools.ts}` | Added app-agent tool execution IPC and normalized app-tool result shaping for isolated app sessions |
+| `apps/desktop/electron/preload/apps/app-domain.ts`, `apps/desktop/src/types/{electron-apps.d.ts,ipc-channels.ts,ipc-channels-app-agent.ts,sero-apps.ts}` | Extended the preload/type surface for app-tool invocation and host-compatibility metadata without breaking the 500-LOC cap |
+| `apps/desktop/src/lib/app-runtime.test.tsx`, `apps/desktop/electron/__tests__/ipc/app-agent-tool-execution.test.ts` | Added focused coverage for the generic app-tool bridge in both renderer and main-process seams |
+| `apps/desktop/electron/cli/core/{types.ts,registry.ts,schema-bridge.ts}`, `apps/desktop/electron/cli/index.ts`, `apps/desktop/electron/ipc/agent/core/agent.ts` | Reworked bridged app commands into provenance-aware session-owned registry state, refreshed custom `tool.cli` handlers from live session definitions, and removed session-owned commands on teardown |
+| `apps/desktop/electron/__tests__/cli/{custom-tool-cli-bridge.test.ts,extension-session-bridge.test.ts,tool-bridge-policy.test.ts}` | Added/kept focused regressions for builtin override, hot-update refresh, uninstall cleanup, and live session tool resolution |
+| `apps/desktop/electron/features/apps/discovery/{index.ts,plugin-meta.ts}` | Split plugin metadata parsing out of discovery and added runtime compatibility evaluation to discovered manifests (305 lines after split) |
+| `apps/desktop/electron/features/plugins/{activation.ts,compatibility.ts,manager.ts,settings.ts}` | Added runtime host-version/capability enforcement plus startup activation reconciliation while reducing `manager.ts` below the cap again (498 → 448 lines) |
+| `apps/desktop/electron/ipc/integrations/plugins.ts`, `apps/desktop/electron/__tests__/features/plugins/{plugin-manager.test.ts,plugin-compatibility.test.ts}` | Reconciled installed plugin activation at startup and added focused install/load compatibility regressions |
+| `apps/desktop/src/stores/app/{shared.ts,discovery.ts,state.ts}`, `apps/desktop/src/stores/app.test.ts`, `apps/desktop/src/components/layout/{AppStoreCard.tsx,AppStoreDialog.tsx}` | Kept unsupported plugins browseable in the App Store while hiding them from active sidebar/preload paths and surfacing compatibility errors inline |
+| `docs/plugins/{technical.md,guide.md}` | Updated plugin docs for `requiredHostCapabilities`, enforced compatibility checks, and truthful hot-load behavior |
+| `docs/deslopify/apps/desktop/electron/cli/{facts,plan}.md`, `docs/deslopify/index.md` | Recorded the platform-hardening execution pass, marked the CLI plan healthy, and left the Google integration/re-review follow-up tracked separately |
+
+---
+
 ## 2026-04-16
 
 ### Files Changed

--- a/docs/deslop.md
+++ b/docs/deslop.md
@@ -21,7 +21,7 @@ Changes made during code quality passes. Most recent first.
 | `apps/desktop/electron/features/plugins/{activation.ts,compatibility.ts,manager.ts,settings.ts}` | Added runtime host-version/capability enforcement plus startup activation reconciliation while reducing `manager.ts` below the cap again (498 → 448 lines) |
 | `apps/desktop/electron/ipc/integrations/plugins.ts`, `apps/desktop/electron/__tests__/features/plugins/{plugin-manager.test.ts,plugin-compatibility.test.ts}` | Reconciled installed plugin activation at startup and added focused install/load compatibility regressions |
 | `apps/desktop/src/stores/app/{shared.ts,discovery.ts,state.ts}`, `apps/desktop/src/stores/app.test.ts`, `apps/desktop/src/components/layout/{AppStoreCard.tsx,AppStoreDialog.tsx}` | Kept unsupported plugins browseable in the App Store while hiding them from active sidebar/preload paths and surfacing compatibility errors inline |
-| `docs/plugins/{technical.md,guide.md}` | Updated plugin docs for `requiredHostCapabilities`, enforced compatibility checks, and truthful hot-load behavior |
+| `docs/plugins/{technical.md,guide.md,host-compatibility.md}` | Updated plugin docs for `requiredHostCapabilities`, enforced compatibility checks, truthful hot-load behavior, and a downstream migration guide for plugin authors |
 | `docs/deslopify/apps/desktop/electron/cli/{facts,plan}.md`, `docs/deslopify/index.md` | Recorded the platform-hardening execution pass, marked the CLI plan healthy, and left the Google integration/re-review follow-up tracked separately |
 
 ---

--- a/docs/deslopify/apps/desktop/electron/cli/facts.md
+++ b/docs/deslopify/apps/desktop/electron/cli/facts.md
@@ -6,12 +6,12 @@ _Last reviewed: 2026-04-18_
 This folder is the AD-020 bridge that collapses built-in platform commands plus manifest-driven app/plugin tools and bridged slash commands into the single `sero-cli` tool. It owns schema-to-CLI translation, per-command batching/timeout behavior, session-scoped runtime forwarding, and the process-global app-command registry that active sessions reload after plugin install/update.
 
 ## Shape & metrics
-- Total files: 39
-- Total LOC: 3,518
-- Largest file: `apps/desktop/electron/cli/core/schema-bridge.ts` (459 LOC)
+- Total files: 46
+- Total LOC: 4,249
+- Largest file: `apps/desktop/electron/cli/core/schema-bridge.ts` (471 LOC)
 - Files over 500 LOC: none
 - Near-cap files:
-  - `apps/desktop/electron/cli/core/schema-bridge.ts` (459)
+  - `apps/desktop/electron/cli/core/schema-bridge.ts` (471)
 - External dependencies of note:
   - Pi SDK `ToolDefinition` / `ExtensionContext`
   - shared infra singletons (`workspaceManager`, `containerManager`)
@@ -28,14 +28,14 @@ This folder is the AD-020 bridge that collapses built-in platform commands plus 
   - CLI prompt generation and help output
   - execution-scoped `sessionRuntime` side effects (`sendUserMessage`, `sendMessage`)
   - plugin install/update hot-load expectations for bridged commands
-- Test coverage note: 17 focused test files live under `apps/desktop/electron/__tests__/cli/**`.
+- Test coverage note: 18 focused test files live under `apps/desktop/electron/__tests__/cli/**`.
 
 ## Architectural notes
-- `bridgeExtensionTools()` in `apps/desktop/electron/cli/index.ts:187-225` still mutates extension tool maps during resource loading, caches session-local copies in `bridges/extension-session-bridge.ts:1-109`, and registers app/plugin commands into one process-global `CliRegistry`.
-- The bridge now supports custom tool-level CLI metadata (`definition.cli`) in `core/schema-bridge.ts:344-427`, which lets plugins override builtin command names/help/summary and provide raw-args execution paths.
-- Normal bridged tool execution already re-resolves the live session tool definition at execute time (`core/schema-bridge.ts:402-410`), but the custom CLI bridge path still executes the handler captured when the command was first registered (`core/schema-bridge.ts:392-399`).
-- Plugin install/uninstall currently reloads active session resource loaders (`apps/desktop/electron/ipc/integrations/plugins.ts:23-45`, `apps/desktop/electron/ipc/agent/core/agent.ts:54-56`) and clears plugin-policy caches (`apps/desktop/electron/features/plugins/manager.ts:295-330`), but there is no symmetrical rebuild/removal step for process-global app-source CLI registrations.
-- Plugin compatibility metadata is shared and parsed (`packages/common/src/plugins.ts:19-28`, `apps/desktop/electron/features/apps/discovery/index.ts:175-223`) but still not enforced during install/load.
+- `bridgeExtensionTools()` in `apps/desktop/electron/cli/index.ts` now treats app/plugin commands as derived session state: it records live session tools/commands in `bridges/extension-session-bridge.ts`, tags bridged app commands with session-extension ownership metadata, and replaces the registry’s app-command slice per session reload instead of relying on first-registration wins.
+- `CliRegistry` now owns provenance-aware app-command lifecycle state (`core/registry.ts`), so session teardown and plugin/session reloads can remove or replace app-owned commands without disturbing builtin commands.
+- The bridge supports custom tool-level CLI metadata (`definition.cli`) in `core/schema-bridge.ts`, and both normal bridged tools plus custom CLI bridges now re-resolve the live session tool definition at execute time.
+- Session teardown now uses `clearBridgedExtensionSessionStateForSession()` so closing a session removes its cached extension resources and its session-owned CLI commands together.
+- The broader host/plugin compatibility contract now lives alongside this seam: shared plugin metadata includes `requiredHostCapabilities`, discovery surfaces `hostCompatibility`, and the plugin manager reconciles install/load activation against the runtime host version + capability set.
 
 ## Runtime-sensitive surfaces
 - Multi-command batches intentionally degrade to text-only output when any command emits rich/image content; cleanup must preserve `details.richOutputFallback` and the existing fallback notice.
@@ -46,10 +46,10 @@ This folder is the AD-020 bridge that collapses built-in platform commands plus 
 - External-plugin compatibility is now more sensitive after the Google cutover because some old shell-specific bridges are gone; unsupported hosts need a fail-closed path instead of relying on reviewer coordination.
 
 ## Surprising discoveries
-- The generic AD-020 bridge is only half-dynamic today: plain bridged tools resolve live session definitions at execute time, but custom `tool.cli.execute` handlers remain sticky after first registration.
-- `docs/plugins/technical.md:354-357` and `docs/plugins/guide.md:465-466` currently overstate plugin hot-update behavior: resource reloads happen, but process-global custom app commands can still serve stale help/execution after plugin reinstall/update.
-- `minSeroVersion` is parsed and surfaced for search/display, but install/load paths do not enforce it, and the desktop host version is still `0.1.0` in `apps/desktop/package.json:3`, which makes cross-repo migrations difficult to gate safely.
-- The global CLI registry stores app commands in a flat namespace keyed only by command name, so plugin-origin commands need explicit provenance/ownership semantics if they are going to become truly upsertable/removable.
+- The platform fix needed a generic prerequisite outside `electron/cli`: a renderer-safe app-tool bridge (`appAgent.invokeTool` / `useAppTools().run(...)`) had to land first so external plugins can depend on a durable host capability instead of bespoke preload seams.
+- The cleanest way to make bridged app commands truthful was not “re-register when missing”; it was to model them as per-session derived state and let the registry own replace/remove semantics explicitly.
+- Compatibility enforcement is not just an install-time check. Existing installed plugins also needed startup/load reconciliation so incompatible packages stay visible in discovery but are removed from the active package list until the host matches their contract.
+- The host-side renderer store needed a small follow-up too: unsupported plugin apps must stay browseable in the App Store while being hidden from the active sidebar/preload path so the UI fails closed instead of loading broken remotes.
 
 ## Post-fix snapshot — 2026-04-13
 
@@ -106,3 +106,23 @@ This folder is the AD-020 bridge that collapses built-in platform commands plus 
 - Add provenance-aware app-command lifecycle management so process-global app/plugin CLI registrations can be updated or removed safely after session/plugin reloads.
 - Add a real host/plugin compatibility contract (runtime host version + enforced capability/version checks) before relying on external plugin migrations that remove old shell-owned seams.
 - Re-review the Google migration PRs after those core fixes land and integrate the final compatibility declaration there.
+
+## Post-fix snapshot — 2026-04-18 (platform hardening landed)
+
+### Metrics after fixes
+- Total files: 46 (was 39 at review time)
+- Total LOC: 4,249 (was 3,518)
+- Largest file: `apps/desktop/electron/cli/core/schema-bridge.ts` (471 LOC)
+- Files over 500 LOC: none
+- Focused CLI test files: 18 (was 17)
+
+### What changed
+- Added the generic app-tool bridge prerequisite across `packages/common`, `packages/app-runtime`, preload, and app-agent IPC so plugins can depend on a stable `appAgent.invokeTool` host capability.
+- Reworked `CliRegistry` into a provenance-aware overlay for session-owned app commands, and updated `bridgeExtensionTools()` to replace/remove each session’s app-command slice deterministically.
+- Made custom tool-level CLI bridges resolve live `definition.cli` handlers at execution time, eliminating stale captured closures after plugin/session reloads.
+- Added focused regressions for custom bridge override/update/removal plus compatibility enforcement (`custom-tool-cli-bridge`, `plugin-compatibility`, `plugin-manager`, and updated app-discovery/app-store tests).
+- Added the host/plugin compatibility contract: `requiredHostCapabilities`, runtime host-version evaluation, install/load enforcement, startup activation reconciliation, and renderer-visible unsupported-plugin state.
+- Updated plugin docs so the hot-load and compatibility guarantees match the runtime again.
+
+### Still outstanding
+- The separate Google integration/re-review pass is still pending on the external migration branches; this core pass only lands the host/platform contract they now depend on.

--- a/docs/deslopify/apps/desktop/electron/cli/facts.md
+++ b/docs/deslopify/apps/desktop/electron/cli/facts.md
@@ -1,51 +1,55 @@
 # Facts — apps/desktop/electron/cli
 
-_Last reviewed: 2026-04-13_
+_Last reviewed: 2026-04-18_
 
 ## What this code does
-This folder is the AD-020 bridge that collapses built-in app commands, bridged extension tools, and bridged slash commands into the single `sero-cli` tool. It builds the CLI prompt block, resolves session-scoped tool/command bindings at execute time, enforces per-turn command budgets, and provides the built-in desktop control surfaces (`app`, `workspace`, `vcs`, `editor`, `devserver`, `google`, etc.) that agent sessions, subagents, and container-backed sessions all rely on.
+This folder is the AD-020 bridge that collapses built-in platform commands plus manifest-driven app/plugin tools and bridged slash commands into the single `sero-cli` tool. It owns schema-to-CLI translation, per-command batching/timeout behavior, session-scoped runtime forwarding, and the process-global app-command registry that active sessions reload after plugin install/update.
 
 ## Shape & metrics
-- Total files: 34
-- Total LOC: 3,862
-- Largest file: `apps/desktop/electron/cli/core/tool.ts` (474 LOC)
+- Total files: 39
+- Total LOC: 3,518
+- Largest file: `apps/desktop/electron/cli/core/schema-bridge.ts` (459 LOC)
 - Files over 500 LOC: none
 - Near-cap files:
-  - `apps/desktop/electron/cli/core/tool.ts` (474)
-  - `apps/desktop/electron/cli/commands/integrations/google.ts` (441)
-  - `apps/desktop/electron/cli/commands/apps/app-control.ts` (436)
-  - `apps/desktop/electron/cli/core/schema-bridge.ts` (403)
+  - `apps/desktop/electron/cli/core/schema-bridge.ts` (459)
 - External dependencies of note:
   - Pi SDK `ToolDefinition` / `ExtensionContext`
-  - Electron `BrowserWindow` / `webContents.executeJavaScript()`
-  - shared infra singletons (`workspaceManager`, `containerManager`, VCS/artifact managers)
-  - plugin bridge policy in `electron/features/plugins/bridge-policy`
-  - host/container `gog` execution for Google auth/Gmail/Calendar flows
-- Upstream callers: 26 importers outside this folder. Runtime-critical callers are `apps/desktop/electron/ipc/agent/core/agent.ts`, `apps/desktop/electron/features/apps/extensions/create-sero-extension.ts`, `apps/desktop/electron/features/subagent/runtime/{runner,loader}.ts`, and `apps/desktop/electron/features/container/tools/tools.ts`.
-- Downstream dependencies: every bridged extension tool/command, session-scoped `sessionRuntime` side effects, CLI prompt generation, and per-turn command budgeting.
+  - shared infra singletons (`workspaceManager`, `containerManager`)
+  - session bridge/runtime hooks in `apps/desktop/electron/cli/bridges/*.ts`
+  - plugin lifecycle + discovery metadata in `apps/desktop/electron/features/{plugins,apps/discovery}/**`
+  - plugin contract types in `packages/common/src/plugins.ts`
+- Upstream callers of note:
+  - `apps/desktop/electron/ipc/agent/core/{agent.ts,agent-prompt.ts,agent-session-open.ts}`
+  - `apps/desktop/electron/features/apps/extensions/create-sero-extension.ts`
+  - `apps/desktop/electron/features/subagent/runtime/{loader,runner}.ts`
+  - `apps/desktop/electron/features/container/tools/tools.ts`
+- Downstream dependencies:
+  - every bridged app/plugin tool and slash command
+  - CLI prompt generation and help output
+  - execution-scoped `sessionRuntime` side effects (`sendUserMessage`, `sendMessage`)
+  - plugin install/update hot-load expectations for bridged commands
 - Test coverage note: 17 focused test files live under `apps/desktop/electron/__tests__/cli/**`.
 
 ## Architectural notes
-- This is the practical center of AD-020. `bridgeExtensionTools()` mutates loaded extension tool/command maps, caches session-local copies in `bridges/extension-session-bridge.ts`, and relies on execute-time resolution instead of registration-time closure capture.
-- `core/tool.ts` owns the behavior-sensitive runtime rules: multi-command batching, timeout budgets, rate limiting, legacy image fallback, and the narrow `sessionRuntime` capability used by bridged tools.
-- `core/schema-bridge.ts` is the generic tool-to-CLI adapter. It performs schema introspection, arg coercion, help generation, tool execution, and bridged slash-command wrapping in one place.
-- `commands/apps/app-control.ts` reimplements the same renderer-control path that already exists in `apps/desktop/electron/ipc/apps/app-control.ts`: both call renderer globals through `webContents.executeJavaScript()` and depend on `window.__appControl` / `window.sero.appControl` being present.
-- `commands/integrations/google.ts` is the only built-in CLI surface that dynamically switches between host execution and container execution based on workspace/container state.
-- Turn budgets are keyed by workspace + turn id in `bridges/agent-bridge.ts`, not by command name.
+- `bridgeExtensionTools()` in `apps/desktop/electron/cli/index.ts:187-225` still mutates extension tool maps during resource loading, caches session-local copies in `bridges/extension-session-bridge.ts:1-109`, and registers app/plugin commands into one process-global `CliRegistry`.
+- The bridge now supports custom tool-level CLI metadata (`definition.cli`) in `core/schema-bridge.ts:344-427`, which lets plugins override builtin command names/help/summary and provide raw-args execution paths.
+- Normal bridged tool execution already re-resolves the live session tool definition at execute time (`core/schema-bridge.ts:402-410`), but the custom CLI bridge path still executes the handler captured when the command was first registered (`core/schema-bridge.ts:392-399`).
+- Plugin install/uninstall currently reloads active session resource loaders (`apps/desktop/electron/ipc/integrations/plugins.ts:23-45`, `apps/desktop/electron/ipc/agent/core/agent.ts:54-56`) and clears plugin-policy caches (`apps/desktop/electron/features/plugins/manager.ts:295-330`), but there is no symmetrical rebuild/removal step for process-global app-source CLI registrations.
+- Plugin compatibility metadata is shared and parsed (`packages/common/src/plugins.ts:19-28`, `apps/desktop/electron/features/apps/discovery/index.ts:175-223`) but still not enforced during install/load.
 
 ## Runtime-sensitive surfaces
-- Multi-command batches intentionally degrade to text-only output when any command emits rich/image content; future cleanup must preserve `details.richOutputFallback` and the user-facing fallback notice.
+- Multi-command batches intentionally degrade to text-only output when any command emits rich/image content; cleanup must preserve `details.richOutputFallback` and the existing fallback notice.
 - Interactive commands (`question`, `questionnaire`, `interview`, and CLI confirmation prompts) intentionally bypass per-command and batch timeouts.
-- Session-local tool/command resolution must stay scoped to the active session; cleanup here must not accidentally reuse another session's extension closures.
-- `app-control` and `gog-runner` are especially behavior-sensitive:
-  - `app-control` depends on renderer globals, timing, screenshots, and recording state.
-  - `gog-runner` depends on Sero-managed Google credentials and the host-vs-container execution split.
+- Session-local tool/command resolution must stay scoped to the active session; cleanup here must not reintroduce first-session closure capture.
+- Plugin install/update promises immediate hot-loading of bridged CLI commands in docs (`docs/plugins/technical.md:354-357`), so command-registration freshness is now a user-visible contract, not just an internal convenience.
+- Plugin-owned commands that emit follow-up chat messages rely on execution-scoped `sessionRuntime`; any registry/lifecycle refactor must preserve that narrow runtime path.
+- External-plugin compatibility is now more sensitive after the Google cutover because some old shell-specific bridges are gone; unsupported hosts need a fail-closed path instead of relying on reviewer coordination.
 
 ## Surprising discoveries
-- There are no 500+ LOC violations, but four separate modules above 400 LOC all sit directly on the AD-020 runtime path.
-- The CLI already has unusually strong direct test coverage for a main-process runtime seam, which makes targeted refactors much safer than this file layout suggests.
-- The remaining type escape hatches are concentrated exactly where the bridge crosses boundaries: schema walking, bridged command context assembly, tool-update forwarding, and `gog` exec error handling.
-- `commands/apps/app-control.ts` duplicates a host-side renderer bridge that the IPC layer already implements, so app automation fixes currently have two main-process copies to keep in sync.
+- The generic AD-020 bridge is only half-dynamic today: plain bridged tools resolve live session definitions at execute time, but custom `tool.cli.execute` handlers remain sticky after first registration.
+- `docs/plugins/technical.md:354-357` and `docs/plugins/guide.md:465-466` currently overstate plugin hot-update behavior: resource reloads happen, but process-global custom app commands can still serve stale help/execution after plugin reinstall/update.
+- `minSeroVersion` is parsed and surfaced for search/display, but install/load paths do not enforce it, and the desktop host version is still `0.1.0` in `apps/desktop/package.json:3`, which makes cross-repo migrations difficult to gate safely.
+- The global CLI registry stores app commands in a flat namespace keyed only by command name, so plugin-origin commands need explicit provenance/ownership semantics if they are going to become truly upsertable/removable.
 
 ## Post-fix snapshot — 2026-04-13
 
@@ -83,3 +87,22 @@ This folder is the AD-020 bridge that collapses built-in app commands, bridged e
 
 ### Still outstanding
 - Low-only follow-up: decide whether shared CLI flag parsing should stay long-flags-only or gain scoped short-flag support so command-local cleanup hacks disappear.
+
+## Post-review snapshot — 2026-04-18 (Google migration follow-up planning)
+
+### Metrics after review
+- Total files: 39
+- Total LOC: 3,518
+- Largest file: `apps/desktop/electron/cli/core/schema-bridge.ts` (459 LOC)
+- Files over 500 LOC: none
+
+### What changed
+- Re-reviewed the AD-020 bridge after the Google external-plugin cutover and found two host-owned platform follow-ups that are broader than the Google plugin itself.
+- Confirmed that custom bridged plugin commands are not truly hot-swappable after install/update because the registry keeps the first captured `cli.execute` closure even though normal bridged tools already re-resolve live definitions.
+- Confirmed that host/plugin compatibility metadata (`minSeroVersion`) is still declarative only, with no enforced version/capability gate during install/load.
+- Reopened the CLI deslopify plan as the home for a separate platform hardening pass before the Google PR pair is re-reviewed for merge.
+
+### Still outstanding
+- Add provenance-aware app-command lifecycle management so process-global app/plugin CLI registrations can be updated or removed safely after session/plugin reloads.
+- Add a real host/plugin compatibility contract (runtime host version + enforced capability/version checks) before relying on external plugin migrations that remove old shell-owned seams.
+- Re-review the Google migration PRs after those core fixes land and integrate the final compatibility declaration there.

--- a/docs/deslopify/apps/desktop/electron/cli/plan.md
+++ b/docs/deslopify/apps/desktop/electron/cli/plan.md
@@ -6,13 +6,13 @@ _Plan drafted: 2026-04-13_
 The original AD-020 cleanup goals for `electron/cli` were completed, but the Google external-plugin PR review surfaced two deeper platform issues that belong here, not in the plugin repo: app/plugin CLI commands with custom bridge handlers are not truly hot-swappable after install/update, and host/plugin compatibility metadata is still parse-only instead of enforced. The goal of this follow-up is to make app-source CLI registrations truthful derived state again, then add a real host/plugin compatibility contract so external plugin migrations fail closed instead of relying on branch coordination.
 
 ## Issues Found (prioritized)
-- **High** — Custom bridged plugin commands are not truly hot-swappable after install/update — `apps/desktop/electron/cli/index.ts:202-215` skips re-registering any existing app command unless it is overriding a builtin, while `apps/desktop/electron/cli/core/schema-bridge.ts:392-399` executes the `cli.execute` closure captured at registration time instead of re-resolving the live tool definition. Plugin install/uninstall only reloads session resources and clears bridge-policy caches (`apps/desktop/electron/ipc/integrations/plugins.ts:23-45`, `apps/desktop/electron/features/plugins/manager.ts:295-330`), so custom app/plugin commands can keep stale help text and stale execution behavior after hot updates even though the docs promise bridged CLI commands refresh immediately (`docs/plugins/technical.md:354-357`). Effort: **M**.
+- **High** — ~~Custom bridged plugin commands are not truly hot-swappable after install/update — `apps/desktop/electron/cli/index.ts:202-215` skips re-registering any existing app command unless it is overriding a builtin, while `apps/desktop/electron/cli/core/schema-bridge.ts:392-399` executes the `cli.execute` closure captured at registration time instead of re-resolving the live tool definition. Plugin install/uninstall only reloads session resources and clears bridge-policy caches (`apps/desktop/electron/ipc/integrations/plugins.ts:23-45`, `apps/desktop/electron/features/plugins/manager.ts:295-330`), so custom app/plugin commands can keep stale help text and stale execution behavior after hot updates even though the docs promise bridged CLI commands refresh immediately (`docs/plugins/technical.md:354-357`).~~ ✅ 2026-04-18 (`def00edf`) — session-owned app commands now use provenance-aware replace/remove semantics, and custom `definition.cli` bridges re-resolve the live tool definition at execute time.
 
-- **High** — Host/plugin compatibility metadata is declarative only and currently fails open — plugin metadata only models `minSeroVersion` and bridge policy in shared types (`packages/common/src/plugins.ts:19-28`), app discovery only parses and surfaces those fields (`apps/desktop/electron/features/apps/discovery/index.ts:175-223`), and plugin install finalization has no compatibility gate before registering the app and hot-loading resources (`apps/desktop/electron/features/plugins/manager.ts:292-330`). Combined with the desktop app still reporting `0.1.0` in `apps/desktop/package.json:3`, external plugin migrations that depend on new host capabilities have no reliable fail-closed path. Effort: **L**.
+- **High** — ~~Host/plugin compatibility metadata is declarative only and currently fails open — plugin metadata only models `minSeroVersion` and bridge policy in shared types (`packages/common/src/plugins.ts:19-28`), app discovery only parses and surfaces those fields (`apps/desktop/electron/features/apps/discovery/index.ts:175-223`), and plugin install finalization has no compatibility gate before registering the app and hot-loading resources (`apps/desktop/electron/features/plugins/manager.ts:292-330`). Combined with the desktop app still reporting `0.1.0` in `apps/desktop/package.json:3`, external plugin migrations that depend on new host capabilities have no reliable fail-closed path.~~ ✅ 2026-04-18 (`60d716bd`) — shared plugin metadata now includes `requiredHostCapabilities`, discovery surfaces runtime compatibility, install/load paths enforce the host contract, and incompatible installed plugins are reconciled out of the active package list.
 
-- **Medium** — The process-global CLI registry has no provenance-aware lifecycle for app/plugin command ownership — app commands are stored in a flat registry keyed only by command name (`apps/desktop/electron/cli/core/registry.ts:12-24`), while session-local tool definitions are tracked separately in `apps/desktop/electron/cli/bridges/extension-session-bridge.ts:9-109`. That split was sufficient when app commands were mostly static wrappers, but it is now the reason custom plugin commands become sticky and why uninstall/removal lacks a first-class registry cleanup path. Effort: **M**.
+- **Medium** — ~~The process-global CLI registry has no provenance-aware lifecycle for app/plugin command ownership — app commands are stored in a flat registry keyed only by command name (`apps/desktop/electron/cli/core/registry.ts:12-24`), while session-local tool definitions are tracked separately in `apps/desktop/electron/cli/bridges/extension-session-bridge.ts:9-109`. That split was sufficient when app commands were mostly static wrappers, but it is now the reason custom plugin commands become sticky and why uninstall/removal lacks a first-class registry cleanup path.~~ ✅ 2026-04-18 (`def00edf`) — `CliRegistry` now manages session-extension ownership metadata and explicit replace/remove lifecycles for app commands.
 
-- **Medium** — Plugin hot-reload guarantees are stronger in docs than in runtime verification — the plugin system docs explicitly say install/update reloads plugin-local extensions, prompts, skills, tools, and bridged CLI commands immediately (`docs/plugins/technical.md:354-357`, `docs/plugins/guide.md:465-466`), but the current test surface only validates normal bridge override registration and live non-custom tool resolution (`apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts`, `apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts`). There is no regression coverage for reinstall/update of a custom bridged plugin command without desktop restart. Effort: **S**.
+- **Medium** — ~~Plugin hot-reload guarantees are stronger in docs than in runtime verification — the plugin system docs explicitly say install/update reloads plugin-local extensions, prompts, skills, tools, and bridged CLI commands immediately (`docs/plugins/technical.md:354-357`, `docs/plugins/guide.md:465-466`), but the current test surface only validates normal bridge override registration and live non-custom tool resolution (`apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts`, `apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts`). There is no regression coverage for reinstall/update of a custom bridged plugin command without desktop restart.~~ ✅ 2026-04-18 (`def00edf`, `60d716bd`) — added focused hot-update/uninstall/compatibility regressions and updated the plugin docs to match the runtime contract.
 
 - **Low** — ~~Shared CLI flag parsing is narrower than the command surface now expects — `apps/desktop/electron/cli/lib/utils.ts:13-42` only understands `--long` flags, which already forced one local workaround in `apps/desktop/electron/cli/commands/vcs/vcs.ts:46-56` to strip accidental `-m`. That is not breaking the bridge today, but it is already producing command-local parsing hacks.~~ Deferred — the Google review did not add pressure here, and the more urgent lifecycle/compatibility work should land first.
 
@@ -51,7 +51,7 @@ The original AD-020 cleanup goals for `electron/cli` were completed, but the Goo
 
 4. **Add a real host/plugin compatibility contract.**
    - Keep `minSeroVersion`, but make it real: derive the runtime host version from the desktop app/Electron runtime and enforce it during install/load.
-   - Add explicit host capability declarations to plugin metadata (for example a `requiresHostCapabilities` array) so external plugins can depend on specific platform seams like `appAgent.invokeTool` or custom tool-level CLI bridging without guessing by version alone.
+   - Add explicit host capability declarations to plugin metadata (for example a `requiredHostCapabilities` array) so external plugins can depend on specific platform seams like `appAgent.invokeTool` or custom tool-level CLI bridging without guessing by version alone.
    - Target structure:
      - shared plugin types in `packages/common/src/plugins.ts`
      - app discovery parsing/validation in `features/apps/discovery/index.ts`
@@ -87,26 +87,29 @@ The original AD-020 cleanup goals for `electron/cli` were completed, but the Goo
 - Plugin docs currently promise hot-update behavior that runtime does not fully provide. The docs should be updated in the same change set that makes the runtime truthful again.
 
 ## Next Steps
-1. Introduce a small design note for app-command provenance and compatibility metadata shape before coding the refactor.
+1. ~~Introduce a small design note for app-command provenance and compatibility metadata shape before coding the refactor.~~ ✅ 2026-04-18 — the landed owner metadata + compatibility helper modules became the design note in code.
 2. Land the CLI/app-command lifecycle hardening first:
-   - [ ] app-source commands become replaceable/removable by owner
-   - [ ] custom bridged commands resolve live `cli.execute` handlers
-   - [ ] hot-update regressions cover reinstall/update/uninstall without restart
+   - [x] app-source commands become replaceable/removable by owner
+   - [x] custom bridged commands resolve live `cli.execute` handlers
+   - [x] hot-update regressions cover reinstall/update/uninstall without restart
 3. Land the compatibility contract second:
-   - [ ] real host version source
-   - [ ] `minSeroVersion` enforcement
-   - [ ] explicit host capability declarations and enforcement
-   - [ ] unsupported-plugin UX/error handling
+   - [x] real host version source
+   - [x] `minSeroVersion` enforcement
+   - [x] explicit host capability declarations and enforcement
+   - [x] unsupported-plugin UX/error handling
 4. Once the core work lands, return to `docs/deslopify/plugins/sero-google-plugin/plan.md` and complete the planned integration/re-review phase.
 5. Verification checklist for this platform pass:
-   - [ ] install a plugin that exposes a custom bridged command, update it in place, and confirm `sero help <command>` plus execution both reflect the new version without restarting Sero
-   - [ ] uninstall that plugin and confirm the bridged command disappears cleanly
-   - [ ] verify ordinary non-custom bridged tools still resolve the live session definition
-   - [ ] verify supported plugins install/load normally under the new compatibility contract
-   - [ ] verify incompatible plugins fail closed with actionable guidance during install/load
+   - [x] install a plugin that exposes a custom bridged command, update it in place, and confirm `sero help <command>` plus execution both reflect the new version without restarting Sero
+   - [x] uninstall that plugin and confirm the bridged command disappears cleanly
+   - [x] verify ordinary non-custom bridged tools still resolve the live session definition
+   - [x] verify supported plugins install/load normally under the new compatibility contract
+   - [x] verify incompatible plugins fail closed with actionable guidance during install/load
 
 ## Execution log
 - `8d8f7648` — `refactor(cli): harden AD-020 bridge typing`
 - `a917905a` — `refactor(cli): split batch runtime and google router`
 - `06b1b653` — `refactor(app-control): centralize host app control service`
 - 2026-04-18 — Planning refresh after related Google PR review: identified two platform-owned follow-ups (custom app-command hot-update staleness and unenforced host/plugin compatibility), reopened this folder plan as the tracking home for the separate core fix, and deferred Google PR merge/re-review until this pass lands.
+- `768fae67` — `feat(app-runtime): add generic app-tool bridge`
+- `def00edf` — `refactor(cli): refresh bridged app commands`
+- `60d716bd` — `fix(plugins): enforce host compatibility`

--- a/docs/deslopify/apps/desktop/electron/cli/plan.md
+++ b/docs/deslopify/apps/desktop/electron/cli/plan.md
@@ -3,69 +3,110 @@
 _Plan drafted: 2026-04-13_
 
 ## Executive Summary
-`electron/cli` is strategically important and better tested than most runtime seams, but it still carries concentrated debt exactly where AD-020 is most sensitive: schema parsing and bridge execution still lean on `any`, the main batch/tool runtime is split across near-cap mixed-responsibility files, and the app-control command duplicates an existing renderer-control path instead of reusing a host-owned service. The goal is not to rewrite the CLI; it is to make the bridge truthful, typed, and easier to extend without regressing prompt-block generation, session scoping, or rich-output behavior.
+The original AD-020 cleanup goals for `electron/cli` were completed, but the Google external-plugin PR review surfaced two deeper platform issues that belong here, not in the plugin repo: app/plugin CLI commands with custom bridge handlers are not truly hot-swappable after install/update, and host/plugin compatibility metadata is still parse-only instead of enforced. The goal of this follow-up is to make app-source CLI registrations truthful derived state again, then add a real host/plugin compatibility contract so external plugin migrations fail closed instead of relying on branch coordination.
 
 ## Issues Found (prioritized)
-- **High** — ~~Type escape hatches remain on the AD-020 bridge boundary — `apps/desktop/electron/cli/core/schema-bridge.ts:56-67`, `apps/desktop/electron/cli/core/schema-bridge.ts:150-174`, `apps/desktop/electron/cli/core/schema-bridge.ts:231-243`, and `apps/desktop/electron/cli/core/schema-bridge.ts:395` still walk tool schemas and bridged command contexts through `any`; `apps/desktop/electron/cli/core/tool.ts:431` casts the streaming update callback; and `apps/desktop/electron/cli/lib/gog-runner.ts:111-118` still reads exec failures through `error as any`. On Sero's single-tool bridge, that hides upstream SDK/schema drift exactly where the compiler should be loud.~~ ✅ 2026-04-13 (`8d8f7648`) — Replaced schema/command-context `any` walking, tool-update casting, and gog exec-failure casts with typed helpers while preserving session-scoped bridge resolution.
+- **High** — Custom bridged plugin commands are not truly hot-swappable after install/update — `apps/desktop/electron/cli/index.ts:202-215` skips re-registering any existing app command unless it is overriding a builtin, while `apps/desktop/electron/cli/core/schema-bridge.ts:392-399` executes the `cli.execute` closure captured at registration time instead of re-resolving the live tool definition. Plugin install/uninstall only reloads session resources and clears bridge-policy caches (`apps/desktop/electron/ipc/integrations/plugins.ts:23-45`, `apps/desktop/electron/features/plugins/manager.ts:295-330`), so custom app/plugin commands can keep stale help text and stale execution behavior after hot updates even though the docs promise bridged CLI commands refresh immediately (`docs/plugins/technical.md:354-357`). Effort: **M**.
 
-- **Medium** — ~~The core AD-020 runtime is concentrated in two near-cap orchestration files — `apps/desktop/electron/cli/core/tool.ts:1-474` combines batch parsing, timeout control, rate limiting, legacy-image fallback, invocation assembly, and tool creation; `apps/desktop/electron/cli/core/schema-bridge.ts:1-403` combines schema introspection, coercion, help generation, result extraction, tool bridging, and slash-command bridging. Both files are still under the 500-LOC rule, but they are already expensive to review safely.~~ ✅ 2026-04-14 (`a917905a`) — Extracted batch execution and invocation/session-runtime ownership out of `core/tool.ts`, leaving a thin composition root and one isolated large schema bridge helper under the cap.
+- **High** — Host/plugin compatibility metadata is declarative only and currently fails open — plugin metadata only models `minSeroVersion` and bridge policy in shared types (`packages/common/src/plugins.ts:19-28`), app discovery only parses and surfaces those fields (`apps/desktop/electron/features/apps/discovery/index.ts:175-223`), and plugin install finalization has no compatibility gate before registering the app and hot-loading resources (`apps/desktop/electron/features/plugins/manager.ts:292-330`). Combined with the desktop app still reporting `0.1.0` in `apps/desktop/package.json:3`, external plugin migrations that depend on new host capabilities have no reliable fail-closed path. Effort: **L**.
 
-- **Medium** — ~~`app-control` duplicates the existing host-side renderer automation bridge and adds timing heuristics on top — `apps/desktop/electron/cli/commands/apps/app-control.ts:28-44` recreates the same `BrowserWindow` + `executeJavaScript()` helper pattern that already exists in `apps/desktop/electron/ipc/apps/app-control.ts:35-99`; `app-control.ts:201-207` then adds a hardcoded 500ms sleep after `openApp()` before screenshot capture. That creates two main-process copies of the same fragile UI automation seam.~~ ✅ 2026-04-14 (`06b1b653`) — Introduced a shared host-owned app-control service, moved CLI + IPC onto it, and replaced the fixed post-open sleep with a shared readiness wait.
+- **Medium** — The process-global CLI registry has no provenance-aware lifecycle for app/plugin command ownership — app commands are stored in a flat registry keyed only by command name (`apps/desktop/electron/cli/core/registry.ts:12-24`), while session-local tool definitions are tracked separately in `apps/desktop/electron/cli/bridges/extension-session-bridge.ts:9-109`. That split was sufficient when app commands were mostly static wrappers, but it is now the reason custom plugin commands become sticky and why uninstall/removal lacks a first-class registry cleanup path. Effort: **M**.
 
-- **Medium** — ~~Two built-in command routers are already near cap and organized as nested switch forests — `apps/desktop/electron/cli/commands/integrations/google.ts:34-358` combines auth, Gmail, and Calendar flows in one file, while `apps/desktop/electron/cli/commands/apps/app-control.ts:120-403` mixes navigation, screenshots, interactions, recording, and preview lifecycle. New CLI features here will increase churn faster than the tests can localize it.~~ ✅ 2026-04-14 (`a917905a`, `06b1b653`) — Split the Google and app-control CLI surfaces into focused domain modules while keeping command names/help text unchanged.
+- **Medium** — Plugin hot-reload guarantees are stronger in docs than in runtime verification — the plugin system docs explicitly say install/update reloads plugin-local extensions, prompts, skills, tools, and bridged CLI commands immediately (`docs/plugins/technical.md:354-357`, `docs/plugins/guide.md:465-466`), but the current test surface only validates normal bridge override registration and live non-custom tool resolution (`apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts`, `apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts`). There is no regression coverage for reinstall/update of a custom bridged plugin command without desktop restart. Effort: **S**.
 
-- **Low** — Shared CLI flag parsing is narrower than the command surface now expects — `apps/desktop/electron/cli/lib/utils.ts:13-42` only understands `--long` flags, which already forced one local workaround in `apps/desktop/electron/cli/commands/vcs/vcs.ts:46-56` to strip accidental `-m`. That is not breaking the bridge today, but it is already producing command-local parsing hacks. Effort: **S**.
+- **Low** — ~~Shared CLI flag parsing is narrower than the command surface now expects — `apps/desktop/electron/cli/lib/utils.ts:13-42` only understands `--long` flags, which already forced one local workaround in `apps/desktop/electron/cli/commands/vcs/vcs.ts:46-56` to strip accidental `-m`. That is not breaking the bridge today, but it is already producing command-local parsing hacks.~~ Deferred — the Google review did not add pressure here, and the more urgent lifecycle/compatibility work should land first.
+
+- **Medium** — ~~The core AD-020 runtime was concentrated in two near-cap orchestration files — `apps/desktop/electron/cli/core/tool.ts` and `apps/desktop/electron/cli/core/schema-bridge.ts`.~~ ✅ 2026-04-14 (`a917905a`) — extracted batch execution and invocation/session-runtime ownership out of `core/tool.ts`.
+
+- **Medium** — ~~`app-control` duplicated the existing host-side renderer automation bridge and timing heuristics.~~ ✅ 2026-04-14 (`06b1b653`) — moved CLI + IPC onto a shared host-owned app-control service.
+
+- **Medium** — ~~Two built-in command routers were near-cap switch forests (`google.ts`, `app-control.ts`).~~ ✅ 2026-04-14 (`a917905a`, `06b1b653`) — split the Google and app-control routers into focused modules.
 
 ## Proposed Refactoring
-1. **Remove the remaining `any`/unsafe casts from the bridge core first.**
-   - Introduce typed schema access helpers for `properties`, `required`, `anyOf`, and nested object-array shapes so `schema-bridge.ts` stops treating TypeBox/JSON Schema input as a bag of `any`.
-   - Give bridged slash commands an explicit Sero-owned command context type instead of `buildCommandContext(ctx) as any`.
-   - Replace the `gog-runner.ts` exec callback casts with a small typed exec-failure normalizer, mirroring the pattern already used elsewhere in desktop Electron code.
-   - Aligns directly with AD-020's goal: one bridge surface that fails loudly at compile time instead of drifting silently.
+1. **Make app/plugin CLI registrations provenance-aware and upsertable.**
+   - Add explicit ownership metadata to app-source CLI commands (for example: command name + source kind + plugin/app owner identity).
+   - Extend the CLI registry with app-command replace/remove semantics instead of the current flat “first registration wins unless overriding a builtin” rule.
+   - Keep builtin commands protected by explicit override policy, but treat app/plugin commands as derived runtime state that can be refreshed safely.
+   - Target structure:
+     - `core/registry.ts` gains owner-aware register/update/remove APIs for `source: 'app'`
+     - `index.ts` / bridge layer uses those APIs when `bridgeExtensionTools()` runs
+     - uninstall/resource-reload paths can remove stale app-owned commands deterministically
+   - This preserves AD-020 while aligning the registry with the real source of truth: live extension resources, not first-load closures.
 
-2. **Split `core/tool.ts` by runtime concern before it crosses the cap.**
-   - Target shape:
-     - `core/batch-executor.ts` — command loop, truncation, rate limiting, single-vs-multi result shaping
-     - `core/timeout-control.ts` — timeout/abort orchestration
-     - `core/invocation-context.ts` — `sessionRuntime`, invocation assembly, agent-context extraction
-     - `core/tool.ts` — thin `createSeroCliTool()` composition root
-   - Preserve public exports from `core/index.ts` so `agent.ts`, subagent runtime, and container tools do not need broad rewiring.
+2. **Resolve custom CLI bridges from the live session tool definition at execute time.**
+   - Add a helper in the bridge layer that resolves the active tool definition for a command name before execution, then reads the live `definition.cli` metadata if present.
+   - Keep the current static registration object only as a fallback for command discovery/help when no live session entry exists.
+   - Preserve the normal bridged-tool behavior that already re-resolves live definitions (`schema-bridge.ts:402-410`) and make the custom-bridge path consistent with it.
+   - This prevents custom handlers like the Google `google` command from staying pinned to the first loaded plugin instance.
 
-3. **Extract a shared main-process app-control service and make CLI + IPC consume it.**
-   - Move the duplicated `BrowserWindow` / `executeJavaScript()` / screenshot helpers into one host-owned module under the existing app-control domain.
-   - Keep the behavior-sensitive renderer calls in one place, then have both `electron/ipc/apps/app-control.ts` and `cli/commands/apps/app-control.ts` delegate to it.
-   - Replace the fixed `setTimeout(500)` app-switch delay with an explicit readiness check or a shared post-open settle helper tied to the app-control bridge.
-   - This aligns with Sero's IPC layering rules more closely than maintaining a second ad-hoc renderer bridge inside the CLI.
+3. **Refresh the app-command slice explicitly on plugin/session lifecycle changes.**
+   - Revisit the plugin install/uninstall/resource-reload path so app-owned CLI command registrations are rebuilt when active session loaders reload.
+   - Prefer a single helper that derives the process-global app-command slice from active sessions, instead of letting stale commands linger across install/update/uninstall.
+   - Validate the full lifecycle:
+     - initial plugin install
+     - plugin reinstall/update with the same command name
+     - uninstall/removal
+     - session close/open after plugin change
+   - This should be implemented generically, not as a Google-specific special case.
 
-4. **Split the two near-cap command routers by domain.**
-   - `commands/integrations/google.ts` → `google-auth.ts`, `google-gmail.ts`, `google-calendar.ts`, with one small top-level router.
-   - `commands/apps/app-control.ts` → `app-navigation.ts`, `app-screenshot.ts`, `app-interactions.ts`, `app-recording.ts`, `app-preview.ts`.
-   - Keep the command names and help text unchanged so the prompt block and existing tests stay valid.
+4. **Add a real host/plugin compatibility contract.**
+   - Keep `minSeroVersion`, but make it real: derive the runtime host version from the desktop app/Electron runtime and enforce it during install/load.
+   - Add explicit host capability declarations to plugin metadata (for example a `requiresHostCapabilities` array) so external plugins can depend on specific platform seams like `appAgent.invokeTool` or custom tool-level CLI bridging without guessing by version alone.
+   - Target structure:
+     - shared plugin types in `packages/common/src/plugins.ts`
+     - app discovery parsing/validation in `features/apps/discovery/index.ts`
+     - compatibility evaluation helper under `features/plugins/` or `features/apps/discovery/`
+     - install/load enforcement in `features/plugins/manager.ts`
+     - renderer-facing install/discovery UI can surface supported vs unsupported plugin state cleanly
+   - This aligns with Sero’s plugin docs and removes the need to coordinate multi-repo migrations by hand.
 
-5. **Tighten shared CLI argument utilities.**
-   - Either explicitly keep the bridge “long flags only” and document it in help output, or add scoped short-flag support in `parseFlags()` so command files stop carrying one-off cleanup logic.
-   - Prefer a truthful shared rule over silent per-command exceptions.
+5. **Use the Google migration as the first integration target after the core fix.**
+   - After the platform work lands, rebase the Sero and Google plugin branches.
+   - Update the Google plugin manifest to declare the final compatibility contract.
+   - Re-run hot-update/install tests proving `sero google ...` help and behavior refresh without desktop restart.
+   - Re-review the Google PR pair only after the platform fixes are integrated, so the migration is judged against the final host contract instead of an implicit one.
 
 ## Benefits & Trade-offs
-- Benefits: stronger compile-time guarantees on the AD-020 seam, fewer duplicate app-control fixes, smaller modules with narrower review surfaces, and clearer ownership between generic CLI runtime and individual command families.
-- Trade-offs: moderate churn across the agent/runtime integration points, plus test updates anywhere exports or helper locations move. App-control extraction is behavior-sensitive because screenshots, recording, and preview startup all depend on renderer timing.
+- Benefits:
+  - restores truthfulness between live plugin resources and the process-global CLI command surface
+  - removes a class of stale hot-update bugs for every future external plugin, not just Google
+  - gives external plugin migrations a fail-closed compatibility mechanism
+  - makes AD-020 documentation accurate again
+- Trade-offs:
+  - touches behavior-sensitive plugin/session lifecycle seams, not just local CLI code
+  - requires new owner/provenance concepts in the CLI registry
+  - adds product/UI decisions for how unsupported plugins are surfaced at install/browse/load time
+  - will force a small follow-up integration pass in the Google migration PRs after the platform work lands
 
 ## Dependencies & Risks
-- Any bridge-core refactor must preserve current session-scoped resolution for bridged tools and bridged slash commands; a clean type refactor that accidentally reintroduces registration-time closure capture would be a runtime regression.
-- `core/tool.ts` extraction must preserve `details.richOutputFallback`, multi-command truncation behavior, interactive timeout exemptions, and turn-budget accounting.
-- App-control service extraction touches both CLI and IPC paths; it should be validated against the existing renderer bridge in `src/lib/app-control-bridge.ts` so screenshot, inspect, record, and preview flows stay identical.
-- Google runner hardening must preserve the current host-vs-container routing semantics and Sero-managed credential injection.
+- The registry refresh work must preserve session correctness: bridged execution still has to use the current session’s loaded tool/command definitions and current `sessionRuntime`.
+- Rebuilding/removing app-owned commands must not accidentally remove builtin commands or break command-group/help ordering.
+- Capability/version gating is a semantic change, not just cleanup: installs that previously succeeded may now be blocked explicitly, so the UI/error copy must be actionable.
+- The compatibility contract should avoid duplicating unstable internals. Prefer durable host capabilities over plugin-specific one-offs.
+- If host versioning remains `0.1.0` forever, `minSeroVersion` will stay meaningless; the runtime host version source needs to become trustworthy before external plugin gating is useful.
+- Plugin docs currently promise hot-update behavior that runtime does not fully provide. The docs should be updated in the same change set that makes the runtime truthful again.
 
 ## Next Steps
-1. Decide whether shared CLI parsing should stay long-flags-only or gain scoped short-flag support so command-local cleanup hacks disappear.
-2. Keep the existing verification checklist for any future CLI seam work:
-   - Run a bridged extension tool from a normal agent session and from a subagent session, confirming session-local resolution still works.
-   - Run a multi-command batch where one command emits rich/image content and confirm `richOutputFallback` behavior is unchanged.
-   - Run an interactive bridged command (`question`/`questionnaire`) and confirm timeout exemptions still apply.
-   - Smoke-test `sero app screenshot`, `sero app record start/stop`, and `sero app preview` after app-control changes.
-   - Smoke-test `sero google auth list` / Gmail / Calendar on both host and container-backed workspaces.
+1. Introduce a small design note for app-command provenance and compatibility metadata shape before coding the refactor.
+2. Land the CLI/app-command lifecycle hardening first:
+   - [ ] app-source commands become replaceable/removable by owner
+   - [ ] custom bridged commands resolve live `cli.execute` handlers
+   - [ ] hot-update regressions cover reinstall/update/uninstall without restart
+3. Land the compatibility contract second:
+   - [ ] real host version source
+   - [ ] `minSeroVersion` enforcement
+   - [ ] explicit host capability declarations and enforcement
+   - [ ] unsupported-plugin UX/error handling
+4. Once the core work lands, return to `docs/deslopify/plugins/sero-google-plugin/plan.md` and complete the planned integration/re-review phase.
+5. Verification checklist for this platform pass:
+   - [ ] install a plugin that exposes a custom bridged command, update it in place, and confirm `sero help <command>` plus execution both reflect the new version without restarting Sero
+   - [ ] uninstall that plugin and confirm the bridged command disappears cleanly
+   - [ ] verify ordinary non-custom bridged tools still resolve the live session definition
+   - [ ] verify supported plugins install/load normally under the new compatibility contract
+   - [ ] verify incompatible plugins fail closed with actionable guidance during install/load
 
 ## Execution log
 - `8d8f7648` — `refactor(cli): harden AD-020 bridge typing`
 - `a917905a` — `refactor(cli): split batch runtime and google router`
 - `06b1b653` — `refactor(app-control): centralize host app control service`
+- 2026-04-18 — Planning refresh after related Google PR review: identified two platform-owned follow-ups (custom app-command hot-update staleness and unenforced host/plugin compatibility), reopened this folder plan as the tracking home for the separate core fix, and deferred Google PR merge/re-review until this pass lands.

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -74,7 +74,7 @@ as backlog-only follow-ups, not active refactor-wave work.
   - [`apps/desktop/electron/shared/`](./apps/desktop/electron/shared/plan.md)
     — *Healthy — settings hardening and shared-boundary cleanup fully executed 2026-04-16*
   - [`apps/desktop/electron/cli/`](./apps/desktop/electron/cli/plan.md)
-    — *In progress — 2026-04-18 follow-up planning reopened this area for app/plugin command hot-update hardening and enforced host/plugin compatibility after the related Google PR review*
+    — *Healthy — 2026-04-18 platform hardening landed for app/plugin command hot-update truthfulness plus enforced host/plugin compatibility; the remaining Google integration/re-review work is tracked separately in `plugins/sero-google-plugin/`*
   - [`apps/desktop/electron/types/`](./apps/desktop/electron/types/plan.md)
     — *Healthy — narrow Pi SDK augmentation seam reviewed 2026-04-13 and no-op closeout confirmed 2026-04-14*
 

--- a/docs/deslopify/index.md
+++ b/docs/deslopify/index.md
@@ -1,6 +1,6 @@
 # Deslopify Index
 
-_Last updated: 2026-04-16_
+_Last updated: 2026-04-18_
 
 A living map of senior-architect reviews across the Sero codebase. Each
 entry links to a `facts.md` and `plan.md` pair.
@@ -74,7 +74,7 @@ as backlog-only follow-ups, not active refactor-wave work.
   - [`apps/desktop/electron/shared/`](./apps/desktop/electron/shared/plan.md)
     — *Healthy — settings hardening and shared-boundary cleanup fully executed 2026-04-16*
   - [`apps/desktop/electron/cli/`](./apps/desktop/electron/cli/plan.md)
-    — *Healthy — High and Medium AD-020 seam/app-control cleanup cleared 2026-04-14; Low flag-parsing follow-up pending*
+    — *In progress — 2026-04-18 follow-up planning reopened this area for app/plugin command hot-update hardening and enforced host/plugin compatibility after the related Google PR review*
   - [`apps/desktop/electron/types/`](./apps/desktop/electron/types/plan.md)
     — *Healthy — narrow Pi SDK augmentation seam reviewed 2026-04-13 and no-op closeout confirmed 2026-04-14*
 
@@ -93,6 +93,8 @@ as backlog-only follow-ups, not active refactor-wave work.
   — *Healthy — High persisted-state/startup-recovery items plus E4 reminder ownership and E5 logging/modularization/UI coverage cleanup all cleared 2026-04-14; Low widget-fidelity polish remains deferred*
 - [`plugins/sero-git-plugin/`](./plugins/sero-git-plugin/plan.md)
   — *Healthy — High contract + state items plus E4/E5 live-query, file-splitting, and UI-coverage cleanup cleared 2026-04-14; Low helper dedupe follow-up pending*
+- [`plugins/sero-google-plugin/`](./plugins/sero-google-plugin/plan.md)
+  — *In progress — Phases 0–8 completed 2026-04-18, but Phase 9 now tracks the required core-platform integration/re-review pass after the separate CLI/plugin-compatibility hardening lands; broader migration final verification also remains pending*
 - [`plugins/sero-kanban-plugin/`](./plugins/sero-kanban-plugin/plan.md)
   — *Healthy — High persisted-state/truthfulness items plus E4 cleanup-warning visibility and E5 settings/UI cleanup cleared 2026-04-14*
 - [`plugins/sero-memory-plugin/`](./plugins/sero-memory-plugin/plan.md)

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -265,6 +265,10 @@ with the current host build, the install fails closed (or an already-installed
 plugin is kept out of the active package list) until the host becomes
 compatible.
 
+For a downstream-friendly migration checklist covering host capabilities,
+bridged CLI behavior, and manifest examples, see
+[`docs/plugins/host-compatibility.md`](./host-compatibility.md).
+
 ## Plugin Manifest Reference
 
 ### `sero.app` (required)
@@ -273,6 +277,9 @@ The standard Sero app manifest used by all Sero apps and plugins. For a
 step-by-step guide to building a new app, use the `sero-plugin` skill.
 
 ### `sero.plugin` (required for plugins)
+
+See also: [`docs/plugins/host-compatibility.md`](./host-compatibility.md) for
+when to declare `requiredHostCapabilities` and how the host enforces them.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -168,6 +168,7 @@ Add a `sero.plugin` key to your `package.json` alongside `sero.app`:
       "category": "productivity",
       "tags": ["my-app", "example"],
       "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["appAgent.invokeTool"],
       "preBuilt": true
     }
   }
@@ -258,6 +259,12 @@ Active chat sessions also reload their resource loaders, so `sero help <tool>`
 and other CLI-bridged plugin commands become available without manually
 restarting Sero.
 
+Sero also enforces `minSeroVersion` plus any declared
+`requiredHostCapabilities` during install/load. If a plugin is incompatible
+with the current host build, the install fails closed (or an already-installed
+plugin is kept out of the active package list) until the host becomes
+compatible.
+
 ## Plugin Manifest Reference
 
 ### `sero.app` (required)
@@ -271,7 +278,8 @@ step-by-step guide to building a new app, use the `sero-plugin` skill.
 |-------|------|----------|-------------|
 | `category` | string | Yes | Plugin category for browsing. See [categories](#categories) below. |
 | `tags` | string[] | Yes | Search and filter tags. |
-| `minSeroVersion` | string | No | Minimum compatible Sero version (semver). |
+| `minSeroVersion` | string | No | Minimum compatible Sero version (semver). Enforced during install/load. |
+| `requiredHostCapabilities` | string[] | No | Explicit host seams the plugin depends on, such as `appAgent.invokeTool` or `tool.cli`. Enforced during install/load. |
 | `preBuilt` | boolean | No | Controls install behavior for git/local plugins. Set `true` only when the package already ships a valid `dist/ui/` bundle and should be installed without rebuilding. Set `false` or omit it for source repos that Sero should build locally on install. npm bundles are always expected to ship pre-built artifacts. |
 | `bridgeTools` | boolean \| string[] | No | Controls whether plugin tools are bridged into `sero-cli`. Omit or set `true` to bridge all tools; `false` to bridge none; or provide a list of tool names to bridge selectively. |
 
@@ -464,7 +472,9 @@ build it, and publish the extracted bundle/source package.
 Not yet. Users manually update by re-installing from the same source.
 If the app ID matches an existing installed plugin, Sero replaces that plugin
 in place and hot-loads the updated UI, tools, and active-session CLI bridge
-state without a restart.
+state without a restart. If the updated plugin now requires a newer host
+version or additional host capabilities, Sero blocks activation until the host
+contract is satisfied.
 Auto-update support is planned for a future release.
 
 ### What happens to my data if I uninstall a plugin?

--- a/docs/plugins/host-compatibility.md
+++ b/docs/plugins/host-compatibility.md
@@ -1,0 +1,269 @@
+# Plugin host compatibility and bridged CLI migration
+
+This guide explains the host-side contract that Sero now enforces for external
+plugins, plus what plugin authors need to change downstream.
+
+## What changed
+
+Sero now treats plugin compatibility as a real runtime contract instead of
+best-effort metadata.
+
+Two platform seams are now explicit and enforced:
+
+- **Host version compatibility** via `sero.plugin.minSeroVersion`
+- **Host capability compatibility** via `sero.plugin.requiredHostCapabilities`
+
+Sero also hardened plugin CLI bridging so hot updates are truthful:
+
+- bridged app/plugin CLI commands are now replaced when a plugin session reloads
+- custom `tool.cli.execute` handlers are resolved from the **live** tool
+  definition at execution time
+- uninstalling or tearing down a session removes its bridged commands cleanly
+
+## Why this matters
+
+Before this change, a plugin could:
+
+- install on an older host that did not actually provide the APIs it needed
+- appear to hot-update while still serving stale CLI help or execution logic
+- remain partially active after its host assumptions stopped being true
+
+Now Sero fails closed:
+
+- **new incompatible installs are rejected**
+- **already-installed incompatible plugins stay on disk but are removed from the
+  active package list**
+- **discovery/App Store UI can still show the plugin and explain why it is
+  unsupported**
+
+## New manifest contract
+
+Plugin manifests still declare metadata under `package.json -> sero.plugin`.
+
+### Supported fields
+
+```json
+{
+  "sero": {
+    "plugin": {
+      "category": "integrations",
+      "tags": ["google", "mail"],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli"],
+      "bridgeTools": ["google"]
+    }
+  }
+}
+```
+
+### Supported host capabilities today
+
+These values are currently recognized by the host:
+
+- `appAgent.invokeTool`
+- `tool.cli`
+
+Unknown capability strings are ignored during manifest parsing, so downstream
+plugins should only use the canonical values above.
+
+## When to declare each capability
+
+### `appAgent.invokeTool`
+
+Declare this when your federated UI or app-runtime code depends on the host's
+app-agent tool bridge, for example when you call:
+
+- `window.sero.appAgent.invokeTool(...)`
+- `useAppTools().run(...)`
+
+### `tool.cli`
+
+Declare this when your extension depends on tool-level CLI bridging, including:
+
+- manifest-driven `bridgeTools`
+- custom `definition.cli` metadata
+- custom raw-args handlers via `definition.cli.execute`
+- builtin override behavior such as replacing `sero google ...`
+
+## Compatibility behavior
+
+### Install time
+
+If a plugin's host contract is not satisfied, install fails with an actionable
+error.
+
+Examples:
+
+- `Requires Sero 0.2.0 or newer (current host: 0.1.0).`
+- `Requires host capability \`tool.cli\`, which this Sero build does not provide.`
+
+### Startup / reload time
+
+Sero reconciles installed plugin activation against the current host build.
+
+That means an incompatible plugin can remain installed under:
+
+```text
+~/.sero-ui/agent/packages/<plugin-id>
+```
+
+but it will be removed from the active `settings.json` package list until the
+host becomes compatible again.
+
+### UI behavior
+
+Unsupported plugins remain discoverable/browseable in the App Store, but they
+show an unsupported-host state and are not activatable.
+
+## Downstream migration checklist
+
+Use this checklist when updating an external plugin.
+
+### 1. Audit host dependencies
+
+Identify whether the plugin depends on:
+
+- app-agent tool execution from UI/runtime code
+- bridged CLI commands
+- custom `tool.cli` help/summary/group/execute behavior
+- builtin command override behavior
+
+### 2. Update `package.json`
+
+Add or tighten the host contract in `sero.plugin`:
+
+```json
+{
+  "sero": {
+    "plugin": {
+      "category": "integrations",
+      "tags": ["google", "mail"],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli"]
+    }
+  }
+}
+```
+
+Only declare capabilities your plugin actually needs.
+
+### 3. Move UI tool calls onto the generic host seam
+
+If your UI still relies on a bespoke preload bridge, migrate it to the generic
+app-agent bridge:
+
+```ts
+import { useAppTools } from '@sero-ai/app-runtime';
+
+const { run } = useAppTools();
+const result = await run('my_tool', { ...input });
+```
+
+or:
+
+```ts
+await window.sero.appAgent.invokeTool('my_tool', { ...input });
+```
+
+### 4. Keep CLI behavior plugin-owned
+
+If the plugin exposes CLI parity through bridged tools:
+
+- keep the command metadata on the tool definition
+- prefer `definition.cli` for custom summary/help/group/execute behavior
+- keep `bridgeTools` aligned with the tool names you expect Sero to bridge
+
+### 5. Test update/reinstall behavior
+
+Confirm that reinstalling the plugin or reloading the active session updates:
+
+- `sero help <command>`
+- command summary/help text
+- raw command execution behavior
+
+without restarting Sero.
+
+## Recommended manifest patterns
+
+### UI tool bridge only
+
+```json
+{
+  "sero": {
+    "plugin": {
+      "category": "utilities",
+      "tags": ["example"],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["appAgent.invokeTool"]
+    }
+  }
+}
+```
+
+### CLI bridge only
+
+```json
+{
+  "sero": {
+    "plugin": {
+      "category": "developer-tools",
+      "tags": ["cli"],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["tool.cli"],
+      "bridgeTools": ["my_command"]
+    }
+  }
+}
+```
+
+### UI + CLI bridge
+
+```json
+{
+  "sero": {
+    "plugin": {
+      "category": "integrations",
+      "tags": ["mail"],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli"],
+      "bridgeTools": ["google"]
+    }
+  }
+}
+```
+
+## Manual downstream verification checklist
+
+After updating a plugin, verify all of the following against a host build that
+contains this PR:
+
+1. Fresh install succeeds when the host satisfies the plugin contract.
+2. Fresh install fails with a clear error when `minSeroVersion` is too high.
+3. Fresh install fails with a clear error when a required capability is missing.
+4. Already-installed incompatible plugins remain on disk but are not activated.
+5. App Store UI shows incompatible plugins as unsupported instead of loading
+   them normally.
+6. Reinstalling/updating a bridged CLI plugin refreshes help/summary/execution
+   without restarting Sero.
+7. Uninstalling the plugin removes its bridged CLI commands cleanly.
+
+## Troubleshooting
+
+### My plugin installs but does not show in the active app list
+
+Check the plugin's `hostCompatibility` status in discovery/App Store UI or
+inspect the install/load error. The plugin is likely installed on disk but not
+active because its host contract is unsatisfied.
+
+### My custom CLI handler still seems stale
+
+Make sure the command is coming from a bridged tool definition and that the
+session/plugin was actually reloaded. The host now refreshes session-owned app
+commands on reload, so stale behavior usually means the updated tool definition
+never reached the session.
+
+### Which version should I put in `minSeroVersion`?
+
+Use the first Sero release that includes the host seam your plugin now depends
+on. If your plugin depends on both the generic app-tool bridge and tool-level
+CLI bridging, set the minimum version to the first release that contains both.

--- a/docs/plugins/host-compatibility.md
+++ b/docs/plugins/host-compatibility.md
@@ -164,7 +164,7 @@ const result = await run('my_tool', { ...input });
 or:
 
 ```ts
-await window.sero.appAgent.invokeTool('my_tool', { ...input });
+await window.sero.appAgent.invokeTool(appId, workspaceId, 'my_tool', { ...input });
 ```
 
 ### 4. Keep CLI behavior plugin-owned

--- a/docs/plugins/host-compatibility.md
+++ b/docs/plugins/host-compatibility.md
@@ -63,8 +63,10 @@ These values are currently recognized by the host:
 - `appAgent.invokeTool`
 - `tool.cli`
 
-Unknown capability strings are ignored during manifest parsing, so downstream
-plugins should only use the canonical values above.
+Unknown capability strings are treated as unmet host requirements, so older
+hosts fail closed instead of partially loading the plugin. Downstream plugins
+should still prefer the canonical values above unless they intentionally depend
+on a newer host seam.
 
 ## When to declare each capability
 

--- a/docs/plugins/technical.md
+++ b/docs/plugins/technical.md
@@ -185,6 +185,9 @@ provider-specific auth and model UI without hardcoded app-level logic:
 
 ### `sero.plugin` Fields
 
+See also: [`docs/plugins/host-compatibility.md`](./host-compatibility.md) for
+the downstream migration guide and capability-selection rules.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `category` | `PluginCategory` | Browsing category. One of: `productivity`, `developer-tools`, `entertainment`, `integrations`, `finance`, `health`, `creative`, `utilities`. |
@@ -363,6 +366,9 @@ plugin activation against the current host contract. Plugins that fail
 `minSeroVersion` or `requiredHostCapabilities` checks stay installed on disk
 and visible to discovery/UI, but they are removed from the active package list
 until the host build becomes compatible.
+
+For plugin authors, the practical migration guidance lives in
+[`docs/plugins/host-compatibility.md`](./host-compatibility.md).
 
 Additionally, `electron/ipc/apps/app-state.ts` watches the active profile's
 `settings.json`. If package paths are added or removed outside the install IPC

--- a/docs/plugins/technical.md
+++ b/docs/plugins/technical.md
@@ -160,6 +160,7 @@ provider-specific auth and model UI without hardcoded app-level logic:
       "category": "productivity",
       "tags": ["todo", "tasks", "productivity"],
       "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["appAgent.invokeTool"],
       "preBuilt": true
     },
     "providers": [
@@ -188,7 +189,8 @@ provider-specific auth and model UI without hardcoded app-level logic:
 |-------|------|-------------|
 | `category` | `PluginCategory` | Browsing category. One of: `productivity`, `developer-tools`, `entertainment`, `integrations`, `finance`, `health`, `creative`, `utilities`. |
 | `tags` | `string[]` | Search/filter tags. |
-| `minSeroVersion` | `string?` | Minimum Sero version required. Used for compatibility checks. |
+| `minSeroVersion` | `string?` | Minimum Sero version required. Enforced during install/load. |
+| `requiredHostCapabilities` | `string[]?` | Explicit host seams the plugin depends on (for example `appAgent.invokeTool` or `tool.cli`). Enforced during install/load. |
 | `preBuilt` | `boolean?` | Controls git/local install behavior. `true` means the package already includes a valid pre-built UI bundle; `false`/omitted means Sero rebuilds it locally during install. npm bundles are always expected to ship pre-built artifacts. |
 | `bridgeTools` | `boolean \| string[]` | Controls manifest-driven CLI bridging for plugin tools. `true`/omitted bridges all plugin tools, `false` bridges none, and `string[]` bridges only the named tools. |
 
@@ -355,6 +357,12 @@ The install IPC path also disposes any app-agent sessions for that app ID and
 reloads active chat-session ResourceLoaders so plugin-local extensions,
 prompts, skills, tools, and bridged CLI commands refresh immediately after
 install/update.
+
+At startup and after plugin install/uninstall, Sero also reconciles installed
+plugin activation against the current host contract. Plugins that fail
+`minSeroVersion` or `requiredHostCapabilities` checks stay installed on disk
+and visible to discovery/UI, but they are removed from the active package list
+until the host build becomes compatible.
 
 Additionally, `electron/ipc/apps/app-state.ts` watches the active profile's
 `settings.json`. If package paths are added or removed outside the install IPC

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -10,6 +10,7 @@ export { useAppState } from './use-app-state';
 export { useAppInfo } from './use-app-info';
 export { useAgentPrompt } from './use-agent-prompt';
 export { useAI, type AppAI } from './use-ai';
+export { useAppTools, type AppTools } from './use-app-tools';
 export { useAvailableModels, type UseAvailableModelsResult } from './use-available-models';
 export { useTheme, type UseThemeResult } from './use-theme';
 export { getSeroApi } from './sero-bridge';

--- a/packages/app-runtime/src/sero-bridge.ts
+++ b/packages/app-runtime/src/sero-bridge.ts
@@ -8,6 +8,7 @@
  */
 
 import type {
+  AppToolResult,
   GitActionResult,
   GitManagerRequest,
   SharedAvailableModelGroup,
@@ -32,6 +33,12 @@ export interface SeroAppAgentBridge {
     text: string,
     onDelta: (delta: string) => void,
   ): Promise<string>;
+  invokeTool?(
+    appId: string,
+    workspaceId: string,
+    toolName: string,
+    params: Record<string, unknown>,
+  ): Promise<AppToolResult>;
 }
 
 export interface SeroGitAppBridge {

--- a/packages/app-runtime/src/use-app-tools.ts
+++ b/packages/app-runtime/src/use-app-tools.ts
@@ -1,0 +1,31 @@
+import type { AppToolResult } from '@sero/common';
+import { useCallback, useContext, useMemo } from 'react';
+
+import { AppContext } from './context';
+import { getSeroApi } from './sero-bridge';
+
+export interface AppTools {
+  run(toolName: string, params?: Record<string, unknown>): Promise<AppToolResult>;
+}
+
+export function useAppTools(): AppTools {
+  const ctx = useContext(AppContext);
+
+  const run = useCallback<AppTools['run']>(
+    async (toolName, params): Promise<AppToolResult> => {
+      if (!ctx?.appId || !ctx?.workspaceId) {
+        throw new Error('[useAppTools] No app context — must be used inside a Sero app');
+      }
+
+      const { appAgent } = getSeroApi();
+      if (!appAgent.invokeTool) {
+        throw new Error('[useAppTools] App tool bridge unavailable');
+      }
+
+      return appAgent.invokeTool(ctx.appId, ctx.workspaceId, toolName, params ?? {});
+    },
+    [ctx],
+  );
+
+  return useMemo(() => ({ run }), [run]);
+}

--- a/packages/common/src/app-tools.ts
+++ b/packages/common/src/app-tools.ts
@@ -1,0 +1,21 @@
+export interface AppToolTextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface AppToolImageContent {
+  type: 'image';
+  data: string;
+  mimeType: string;
+}
+
+export type AppToolContentBlock =
+  | AppToolTextContent
+  | AppToolImageContent;
+
+export interface AppToolResult {
+  text: string;
+  content: AppToolContentBlock[];
+  details: Record<string, unknown> | null;
+  isError: boolean;
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,6 +5,10 @@
  * Must remain renderer-safe (no Node imports).
  */
 
+export {
+  SERO_HOST_CAPABILITIES,
+} from './plugins';
+
 export type {
   InstalledPlugin,
   PluginCategory,
@@ -14,6 +18,9 @@ export type {
   PluginProviderAuthManifest,
   PluginProviderManifest,
   SeroProviderManifest,
+  SeroHostCapability,
+  PluginCompatibilityIssue,
+  PluginCompatibilityStatus,
 } from './plugins';
 
 export type {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -17,6 +17,13 @@ export type {
 } from './plugins';
 
 export type {
+  AppToolTextContent,
+  AppToolImageContent,
+  AppToolContentBlock,
+  AppToolResult,
+} from './app-tools';
+
+export type {
   ExtensionRuntimeTextContent,
   ExtensionRuntimeImageContent,
   ExtensionRuntimeContentBlock,

--- a/packages/common/src/plugins.ts
+++ b/packages/common/src/plugins.ts
@@ -16,11 +16,33 @@ export type PluginCategory =
   | 'creative'
   | 'utilities';
 
+export const SERO_HOST_CAPABILITIES = [
+  'appAgent.invokeTool',
+  'tool.cli',
+] as const;
+
+export type SeroHostCapability = (typeof SERO_HOST_CAPABILITIES)[number];
+
+export interface PluginCompatibilityIssue {
+  kind: 'minSeroVersion' | 'requiredHostCapability';
+  message: string;
+  expected?: string;
+  actual?: string;
+  capability?: SeroHostCapability;
+}
+
+export interface PluginCompatibilityStatus {
+  supported: boolean;
+  hostVersion: string;
+  issues: PluginCompatibilityIssue[];
+}
+
 /** Plugin metadata from a package's `sero.plugin` field. */
 export interface PluginMeta {
   category: PluginCategory;
   tags: string[];
   minSeroVersion?: string;
+  requiredHostCapabilities?: SeroHostCapability[];
   /** true for pre-built npm bundles; false/undefined for source repos built on install */
   preBuilt?: boolean;
   /** true/undefined = bridge all tools, false = none, string[] = listed tools only */

--- a/packages/common/src/plugins.ts
+++ b/packages/common/src/plugins.ts
@@ -28,7 +28,7 @@ export interface PluginCompatibilityIssue {
   message: string;
   expected?: string;
   actual?: string;
-  capability?: SeroHostCapability;
+  capability?: string;
 }
 
 export interface PluginCompatibilityStatus {
@@ -42,7 +42,7 @@ export interface PluginMeta {
   category: PluginCategory;
   tags: string[];
   minSeroVersion?: string;
-  requiredHostCapabilities?: SeroHostCapability[];
+  requiredHostCapabilities?: string[];
   /** true for pre-built npm bundles; false/undefined for source repos built on install */
   preBuilt?: boolean;
   /** true/undefined = bridge all tools, false = none, string[] = listed tools only */


### PR DESCRIPTION
## Summary

This PR lands the separate core/platform hardening pass that came out of the
Google plugin migration review.

It fixes two host-owned problems:

1. bridged app/plugin CLI commands were not truly hot-swappable after plugin/session reloads
2. plugin compatibility metadata (`minSeroVersion`) existed but was not enforced, so migrations could fail open

## What changed

### Generic app-tool bridge
- adds shared app-tool result types in `@sero/common`
- adds `window.sero.appAgent.invokeTool(...)`
- adds `useAppTools().run(...)` in `@sero-ai/app-runtime`
- wires app-agent IPC for app-local tool execution

### Bridged CLI lifecycle hardening
- makes app/plugin CLI commands provenance-aware and session-owned in the registry
- replaces/removes bridged app commands on session reload/teardown
- makes custom `definition.cli.execute` resolve from the live tool definition at execution time
- removes session-owned bridged commands when a session is cleared

### Enforced host/plugin compatibility
- adds shared `requiredHostCapabilities` metadata to `sero.plugin`
- evaluates compatibility from the runtime host version plus canonical host capabilities
- rejects incompatible installs at install time
- reconciles installed plugins on startup/load so incompatible packages stay on disk but out of the active package list
- surfaces unsupported-plugin state in discovery/App Store UI

### Docs
- updates deslopify tracking/docs for the completed platform pass
- updates plugin docs for enforced compatibility and truthful hot-load semantics
- adds a downstream migration guide for plugin authors:
  - `docs/plugins/host-compatibility.md`

## Why

The Google migration review exposed platform invariants, not Google-specific
bugs. Fixing them in core keeps downstream plugin migrations self-contained and
futureproof:

- plugins can now declare exactly which host seams they depend on
- incompatible hosts fail closed instead of partially loading broken plugins
- bridged CLI command help/execution now actually refreshes after plugin updates

## Validation

- `pnpm typecheck`
- `cd apps/desktop && pnpm test --run electron/__tests__/ipc/app-agent-tool-execution.test.ts electron/__tests__/cli/custom-tool-cli-bridge.test.ts electron/__tests__/features/plugins/plugin-compatibility.test.ts electron/__tests__/features/plugins/plugin-manager.test.ts electron/__tests__/features/apps/app-discovery.test.ts src/lib/app-runtime.test.tsx`

## Follow-up

After this lands, the Google migration branches should be rebased onto the new
host contract, add the final plugin compatibility declaration, and then go back
through the planned integration/re-review pass.
