### PR TITLE
feat(desktop): unify GitHub auth flow across Sero

### DIFF
--- a/.pi/plans/2026-04-20-github-auth-unification/plan.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/plan.md
@@ -410,7 +410,7 @@ Cover both the controller/dialog and the contextual integrations.
 - **Acceptance:** supports ISC-2, ISC-3, ISC-6, ISC-12, ISC-A-2.
 - **Status:** completed 2026-04-20.
 
-### GHA-02 — Add the globally mounted GitHub auth dialog host and extracted views
+### [x] GHA-02 — Add the globally mounted GitHub auth dialog host and extracted views
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
 - **Files:**
   - new `apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.tsx`
@@ -448,6 +448,7 @@ Cover both the controller/dialog and the contextual integrations.
   - **Anti-pattern: Local Dialog Clones** — do not render separate GitHub auth dialogs inside Explorer/onboarding/publish.
   - **Anti-pattern: New Global Entry Point** — do not add a command/menu/sidebar button that opens GitHub auth outside contextual launchers.
 - **Acceptance:** supports ISC-2, ISC-3, ISC-6, ISC-9, ISC-11, ISC-A-2.
+- **Status:** completed 2026-04-20.
 
 ### GHA-03 — Create reusable inline launcher/status primitives and migrate Explorer to them
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`

--- a/.pi/plans/2026-04-20-github-auth-unification/plan.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/plan.md
@@ -450,7 +450,7 @@ Cover both the controller/dialog and the contextual integrations.
 - **Acceptance:** supports ISC-2, ISC-3, ISC-6, ISC-9, ISC-11, ISC-A-2.
 - **Status:** completed 2026-04-20.
 
-### GHA-03 — Create reusable inline launcher/status primitives and migrate Explorer to them
+### [x] GHA-03 — Create reusable inline launcher/status primitives and migrate Explorer to them
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
 - **Files:**
   - new `apps/desktop/src/components/layout/auth/github/GitHubAuthSummary.tsx`
@@ -478,6 +478,7 @@ Cover both the controller/dialog and the contextual integrations.
   - **Anti-pattern: Hidden Second Flow** — do not leave the old inline device-flow UI in Explorer while also adding the dialog.
   - **Anti-pattern: Surface-Specific Login Logic** — do not wire the Explorer button straight to `window.sero.github.login()`.
 - **Acceptance:** supports ISC-1, ISC-2, ISC-6, ISC-12, ISC-A-2.
+- **Status:** completed 2026-04-20.
 
 ### GHA-04 — Refactor onboarding to launch the shared dialog and return to a connected step
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`

--- a/.pi/plans/2026-04-20-github-auth-unification/plan.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/plan.md
@@ -547,7 +547,7 @@ Cover both the controller/dialog and the contextual integrations.
 - **Acceptance:** supports ISC-1, ISC-4, ISC-7, ISC-9, ISC-10, ISC-A-1, ISC-A-3.
 - **Status:** completed 2026-04-20.
 
-### GHA-06 — Replace titlebar publish dead ends with a direct connect path and safe auto-resume
+### [x] GHA-06 — Replace titlebar publish dead ends with a direct connect path and safe auto-resume
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
 - **Files:**
   - `apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx`
@@ -576,6 +576,7 @@ Cover both the controller/dialog and the contextual integrations.
   - **Anti-pattern: Shared-State Guessing** — do not trust old `githubStatus` without a fresh `refreshStatus()` before retry/resume.
   - **Anti-pattern: Copy Drift** — do not ship any “connect in the sidebar” or “go to Explorer” instruction here.
 - **Acceptance:** supports ISC-1, ISC-5, ISC-7, ISC-8, ISC-12, ISC-A-1, ISC-A-3.
+- **Status:** completed 2026-04-20.
 
 ### GHA-07 — Add/update tests for controller, dialog, onboarding, remote-origin, and publish flows
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`

--- a/.pi/plans/2026-04-20-github-auth-unification/plan.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/plan.md
@@ -578,7 +578,7 @@ Cover both the controller/dialog and the contextual integrations.
 - **Acceptance:** supports ISC-1, ISC-5, ISC-7, ISC-8, ISC-12, ISC-A-1, ISC-A-3.
 - **Status:** completed 2026-04-20.
 
-### GHA-07 — Add/update tests for controller, dialog, onboarding, remote-origin, and publish flows
+### [x] GHA-07 — Add/update tests for controller, dialog, onboarding, remote-origin, and publish flows
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
 - **Files:**
   - new `apps/desktop/src/stores/github-auth.test.ts` or `apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.test.tsx`
@@ -608,3 +608,4 @@ Cover both the controller/dialog and the contextual integrations.
   - **Anti-pattern: Manual-Only Verification** — do not rely on smoke tests alone for the new controller/dialog behavior.
   - **Anti-pattern: Implementation-Coupled Assertions** — prefer user-visible outcomes and action counts over brittle internal-state snapshots.
 - **Acceptance:** provides thorough regression coverage for ISC-1 through ISC-12 and ISC-A-1 through ISC-A-3.
+- **Status:** completed 2026-04-20.

--- a/.pi/plans/2026-04-20-github-auth-unification/plan.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/plan.md
@@ -1,0 +1,605 @@
+# GitHub Auth Unification Implementation Plan
+
+**Date:** 2026-04-20
+**Status:** Draft
+**Spec:** `.pi/plans/2026-04-20-github-auth-unification/spec.md`
+**Scout:** `.pi/plans/2026-04-20-github-auth-unification/scout-context.md`
+**Directory:** `/Users/danielcarter/Documents/Dev/projects/sero/sero`
+
+## Overview
+
+This work should unify Sero’s renderer-side GitHub authentication UX around **one shared connect path** while preserving contextual entry points.
+
+The Electron/main-process foundation is already unified today:
+
+- `apps/desktop/electron/features/auth/github/auth-manager.ts`
+- `apps/desktop/electron/ipc/integrations/github.ts`
+- `apps/desktop/electron/preload/apps/app-domain.ts`
+- `apps/desktop/src/types/electron-services.d.ts`
+
+What is fragmented is the renderer experience:
+
+- Explorer has an inline device-flow banner.
+- Onboarding has a separate inline device-flow card.
+- Remote-origin creation and titlebar publish hit auth-required dead ends that tell users to go somewhere else.
+- `useGitHubAuthFlow()` currently owns subscription state per mount, which is risky because the underlying GitHub device-flow event stream is global.
+
+The cleanest implementation is a **hybrid architecture**:
+
+1. a **single global GitHub auth dialog** that owns the actual device-flow UI and event subscription,
+2. **lightweight inline launch/status surfaces** in Explorer, onboarding, and blocked git flows,
+3. **local opt-in auto-resume** only for the blocked actions that are simple and safe to retry after success.
+
+That gives Sero one recognizable GitHub auth experience without creating a third disconnected login path or bloating already-large files.
+
+## Investigation Summary
+
+### Current state
+
+- `useGitHubAuthFlow.ts` already encapsulates GitHub status refresh, device-flow progress mapping, copy-code feedback, and login/logout/cancel actions.
+- `GitHubAuthBanner.tsx` and `GitHubConnectCard.tsx` duplicate almost the same code/polling/success/error UI.
+- `CreateGitHubView` in `remote-origin-views.tsx` handles `createGitHubOrigin(...).reason === 'auth'` by showing a dead-end message telling the user to connect in the sidebar.
+- `GitRemotePublishSection.tsx` has a separate dead-end copy path and its own local GitHub status/hint logic.
+- `workflow.ts` already correctly treats `window.sero.github.status()` as the auth source of truth and returns a structured auth failure from `createGitHubOrigin()`.
+- `AuthLoginDialog.tsx` is a strong precedent for a shell-mounted reusable auth dialog with extracted subviews.
+
+### Architectural constraints that matter
+
+- The GitHub device-flow event stream is global, so multiple mounted flow UIs would all receive the same events unless renderer orchestration is centralized.
+- `window.sero.github.status()` must remain the source of truth for connection status.
+- The feature is renderer-heavy; the Electron/device-flow implementation should stay unchanged unless a small gap appears during implementation.
+- File size limits are real: `remote-origin-views.tsx`, `GitRemotePublishSection.tsx`, and `AuthLoginDialog.tsx` are already big enough that auth-related additions should be split into new helpers/subviews.
+
+## Approaches Considered
+
+### 1. Shared inline reusable GitHub auth component only
+
+Build one reusable inline auth surface and render it in Explorer, onboarding, remote-origin, and publish.
+
+**Pros**
+- Smallest conceptual change.
+- Easy to reuse existing `useGitHubAuthFlow()` logic.
+- Minimal shell plumbing.
+
+**Cons**
+- Still leaves the actual device flow mounted in multiple places.
+- Conflicts with the global event-stream gotcha.
+- Makes “one auth path” feel weaker because the login flow is still visually embedded in several contexts.
+- Harder to prevent multiple simultaneous subscribers and inconsistent cancellation behavior.
+
+**Verdict:** better than today, but not strong enough for the spec or the event-stream constraint.
+
+### 2. Shared global GitHub auth dialog only
+
+Move all GitHub auth UX into a shell-level dialog and make every surface open it.
+
+**Pros**
+- Truly one visible login path.
+- Naturally centralizes the event subscription.
+- Cleanest protection against duplicate device-flow UIs.
+
+**Cons**
+- Explorer/onboarding lose their lightweight inline guidance unless replaced with summary-only UI.
+- Blocked git flows still need local context and retry affordances after the dialog closes.
+- Feels slightly too modal-only for onboarding and Explorer, where contextual status is still useful.
+
+**Verdict:** viable, but slightly too rigid for the spec’s “lightweight inline UI may remain” guidance.
+
+### 3. Hybrid: global GitHub auth dialog for the actual flow plus inline launcher/status components (**recommended**)
+
+Use one shared dialog for the real device flow, then keep small contextual surfaces that launch it and show connected / disconnected / retryable states.
+
+**Pros**
+- Satisfies “one shared auth path” without losing contextual guidance.
+- Centralizes the event stream in exactly one place.
+- Lets blocked flows keep local retry UX and safe auto-resume behavior.
+- Keeps Explorer and onboarding lightweight while pointing into the same experience.
+
+**Cons**
+- Requires a small controller/store plus a globally mounted dialog host.
+- Needs careful ownership of dialog outcomes so auto-resume stays local and unsurprising.
+
+**Decision:** use the hybrid approach.
+
+## Recommended Approach
+
+Implement a **renderer-side GitHub auth controller + globally mounted dialog** under `apps/desktop/src/components/layout/auth/github/` and a small store/controller under `apps/desktop/src/stores/`.
+
+All GitHub entry points should call the same launcher API instead of calling `window.sero.github.login()` directly.
+
+### Key Decisions
+
+- **Keep Electron/preload/IPC unchanged** unless a true gap appears. This is primarily a renderer consolidation task.
+- **Create one active GitHub auth controller** in the renderer so there is only one `window.sero.github.onEvent(...)` subscription.
+- **Mount the dialog once in `App.tsx`**, alongside other shell-level surfaces such as `CommandMenu` and `OnboardingWizard`.
+- **Make the shared launcher promise-based** so callers can `await` the result and decide locally whether to auto-resume.
+- **Use `window.sero.github.status()` as the source of truth** on dialog open, on success, on logout, and before any auto-resume decision.
+- **Keep auto-resume local and conservative**:
+  - auto-resume remote-origin creation and titlebar publish only when the user was explicitly blocked while creating a GitHub repo,
+  - do not auto-advance onboarding,
+  - do not trigger repo creation just because someone opened the dialog proactively.
+- **Do not add a new manual “Connect GitHub” entry point** in menus/sidebar/command palette; only contextual launchers should open the dialog.
+- **Remove all copy that says “connect in Explorer” or “connect in the sidebar first.”**
+
+## Architecture
+
+### 1. Renderer GitHub auth controller
+
+Add a small global store/controller, likely at:
+
+- `apps/desktop/src/stores/github-auth.ts`
+
+Recommended responsibilities:
+
+- hold current `authStatus` + `statusReady`,
+- hold current dialog open state + active request metadata,
+- map GitHub device-flow IPC events into renderer flow state,
+- manage copy-code transient state,
+- expose a promise-returning `openGitHubAuthDialog()` action,
+- expose `refreshStatus()`, `startLogin()`, `cancel()`, and `logout()`.
+
+Recommended contract shape:
+
+```ts
+export type GitHubAuthSource = 'explorer' | 'onboarding' | 'remote-origin' | 'publish';
+
+export type GitHubAuthDialogResult =
+  | { outcome: 'success'; status: GitHubAuthStatus }
+  | { outcome: 'cancelled'; status: GitHubAuthStatus }
+  | { outcome: 'error'; status: GitHubAuthStatus; message: string };
+
+export interface GitHubAuthDialogRequest {
+  source: GitHubAuthSource;
+}
+
+export interface GitHubAuthState {
+  openGitHubAuthDialog: (request: GitHubAuthDialogRequest) => Promise<GitHubAuthDialogResult>;
+  refreshStatus: () => Promise<GitHubAuthStatus>;
+  startLogin: () => void;
+  cancel: () => void;
+  logout: () => Promise<void>;
+}
+```
+
+Implementation note: the controller should enforce a **single active dialog request**. If a second surface tries to open the GitHub dialog while it is already open, reuse the current session/result rather than starting another login.
+
+### 2. Global GitHub auth dialog host
+
+Add a shell-mounted dialog, likely split into:
+
+- `apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.tsx`
+- `apps/desktop/src/components/layout/auth/github/GitHubAuthDialogViews.tsx`
+
+Mount it once in `apps/desktop/src/App.tsx`.
+
+The dialog should own the actual device-flow presentation:
+
+- disconnected / ready-to-connect state,
+- device code state,
+- polling state,
+- connected state,
+- generic error state with retry,
+- close/cancel behavior.
+
+It should follow the extracted-view pattern already used by:
+
+- `apps/desktop/src/components/layout/auth/AuthLoginDialog.tsx`
+- `apps/desktop/src/components/layout/auth/AuthLoginViews.tsx`
+
+This dialog is the only place that should render the GitHub device-flow progress UI.
+
+### 3. Inline launcher / status primitives
+
+Create small reusable inline pieces for contextual surfaces, for example:
+
+- `apps/desktop/src/components/layout/auth/github/GitHubAuthSummary.tsx`
+- `apps/desktop/src/components/layout/auth/github/GitHubAuthRequiredNotice.tsx`
+
+These should be **summary/launcher UI only**, not full device-flow UIs.
+
+Recommended responsibilities:
+
+- show connected vs disconnected state,
+- provide a `Connect GitHub` button that opens the shared dialog,
+- optionally show a small retryable note after `cancelled` / `error` outcomes,
+- allow slight copy/layout variation per surface while reusing the same action wiring.
+
+This keeps the product consistent without forcing Explorer, onboarding, remote-origin, and publish into one identical card layout.
+
+### 4. Surface integrations
+
+#### Explorer
+
+`GitHubAuthBanner.tsx` should become a compact summary surface:
+
+- disconnected → concise explanation + `Connect GitHub` button,
+- connected → username + optional disconnect action,
+- no inline code/polling UI.
+
+Explorer should now launch the global dialog and immediately benefit from the same shared flow as every other area.
+
+#### Onboarding
+
+`GitHubConnectCard.tsx` and `useOnboardingGitHubStep.ts` should stop driving the device flow inline.
+
+Recommended behavior:
+
+- onboarding still checks GitHub status before entering the optional GitHub step,
+- the GitHub step shows a lightweight summary/CTA that launches the global dialog,
+- after successful auth, the step shows a clearly connected state and the existing continue action,
+- onboarding does **not** auto-advance after auth success.
+
+This preserves context and keeps the next step obvious without surprising the user.
+
+#### Remote origin create flow
+
+`CreateGitHubView` should replace the current dead-end auth message with a direct auth-required callout.
+
+Recommended behavior:
+
+- when GitHub is required, show a visible `Connect GitHub` action in the current view,
+- preserve form state (`name`, `description`, `visibility`) while the dialog is open,
+- if the user connects successfully **after being blocked by create**, rerun the same create action automatically,
+- if the user cancels, remain in the same view with the same form values and a visible retry path,
+- keep the existing `createGitHubOrigin(...).reason === 'auth'` branch as a fallback safety net.
+
+#### Titlebar publish flow
+
+`GitRemotePublishSection.tsx` should follow the same pattern:
+
+- disconnected GitHub mode should offer a direct `Connect GitHub` action,
+- explicit create/publish attempts blocked by auth should be resumable after successful auth,
+- if the user opened auth proactively from the hint state, do **not** auto-create a repo on success,
+- the “existing remote” mode remains unchanged.
+
+### 5. Safe auto-resume policy
+
+Auto-resume should be intentionally narrow.
+
+**Auto-resume:**
+- remote-origin “Create repository” after auth blocked the exact action,
+- titlebar “Create repo + publish” after auth blocked the exact action.
+
+**Do not auto-resume:**
+- Explorer auth banner,
+- onboarding GitHub step,
+- generic proactive “Connect GitHub” clicks that were not triggered by a blocked repo-creation action.
+
+Recommended launcher-side pattern:
+
+```ts
+const result = await openGitHubAuthDialog({ source: 'publish' });
+if (result.outcome !== 'success') return;
+if (!mountedRef.current) return;
+await retryCreateGitHubRepo();
+```
+
+That keeps resume ownership in the launching component, where the form state and safety context already exist.
+
+### 6. Data flow
+
+```text
+Launcher surface
+  → openGitHubAuthDialog({ source })
+  → global GitHub dialog opens
+  → controller refreshes window.sero.github.status()
+  → user starts login
+  → window.sero.github.onEvent(...) streams code/polling/success/error
+  → controller updates flow state
+  → dialog resolves with success/cancelled/error
+  → launcher refreshes local state and optionally auto-resumes
+```
+
+Rules:
+
+- no launcher should call `window.sero.github.login()` directly,
+- no launcher should infer auth from stale local state alone,
+- launcher-side resume logic should always re-check mounted/open state before mutating local UI.
+
+## Premortem
+
+### Riskiest assumptions
+
+| Assumption | If wrong |
+|---|---|
+| A single renderer controller can own the GitHub event stream cleanly | Multiple surfaces may still subscribe and reintroduce the duplicate-flow bug |
+| A promise-returning dialog launcher is ergonomic in this codebase | Resume wiring may get awkward and spread hidden callback state across components |
+| `refreshStatus()` before resume is enough to avoid stale-auth mistakes | Callers may still rerun create flows after auth has been lost or invalidated |
+| Remote-origin/publish auto-resume is actually “simple and safe” | Users could be surprised by repo creation if we trigger it after a connect-only intent |
+| Existing current touchpoints are limited to the known four surfaces | A forgotten surface may keep old Explorer/sidebar-first copy and break ISC-A-1 |
+
+### Failure modes
+
+- **Built the wrong thing:** workers keep inline device-flow UI in Explorer/onboarding and add a dialog on top, creating a second/third auth path instead of replacing it.
+- **Race conditions:** two surfaces try to launch auth at once, causing duplicate promise resolution or inconsistent UI.
+- **Unsafe resume:** a blocked action auto-runs after auth even though the user only intended to connect, not create a repo.
+- **Status drift:** UI trusts cached state instead of `window.sero.github.status()`, so it shows connected when it is not.
+- **File-size regression:** auth logic is appended directly into `remote-origin-views.tsx` or `GitRemotePublishSection.tsx` until they exceed the monorepo’s 500 LOC limit.
+
+### Accepted mitigations
+
+- One controller, one mounted dialog, one active request at a time.
+- Resume only from the local blocked-action handlers that explicitly await dialog success.
+- Keep `createGitHubOrigin()` auth fallback intact even if surfaces preflight status.
+- Extract new auth subviews/helpers rather than expanding already-large files.
+- Add dedicated tests for cancel, failure, and resume behavior in the blocked flows.
+
+## Dependencies
+
+No new library dependencies are required.
+
+Use existing patterns and modules:
+
+- `apps/desktop/src/components/layout/auth/AuthLoginDialog.tsx`
+- `apps/desktop/src/components/layout/auth/AuthLoginViews.tsx`
+- `apps/desktop/src/stores/context-editor.ts`
+- `apps/desktop/src/hooks/useGitHubAuthFlow.ts`
+- `apps/desktop/src/components/layout/git-remote/workflow.ts`
+- `apps/desktop/src/components/layout/workspace/remote-origin-views.tsx`
+- `apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx`
+- `apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.ts`
+- `apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx`
+
+## Testing Strategy
+
+Cover both the controller/dialog and the contextual integrations.
+
+### Automated
+
+- controller/store test for single active request + shared result resolution,
+- dialog test for idle → code → polling → success/error state rendering,
+- onboarding test confirming shared dialog launch path and no Explorer/sidebar copy,
+- remote-origin test confirming auth-required CTA + cancel retry path + safe resume,
+- publish test confirming auth-required CTA + safe resume only after blocked publish,
+- keep `workflow.test.ts` coverage for auth fallback behavior.
+
+### Manual smoke checks
+
+- Explorer disconnected → Connect GitHub → success → banner shows connected state.
+- Onboarding GitHub step → cancel → remain on onboarding step with retry path.
+- Remote origin create → blocked by auth → connect → automatic create resumes.
+- Titlebar publish → blocked by auth → cancel → remain in publish section with retry path.
+- Any auth failure → obvious retry path, no instruction to go to Explorer/sidebar.
+
+## Risks & Open Questions
+
+- **Result persistence:** the spec requires visible retry paths after cancel/failure, but does not require long-lived per-surface “last attempt” history. V1 should use lightweight local retry messaging only where it adds clarity.
+- **Disconnect UX:** the spec is about connect/recovery, not disconnect. Preserve disconnect where it already exists (Explorer-style connected summary) and avoid broad redesign.
+- **Multiple concurrent launch attempts:** plan assumes a single active dialog request policy is acceptable for v1.
+
+## Implementation Todos
+
+> The structured todo tool is not available in this planner session, so the worker backlog is embedded here as executable markdown todos.
+>
+> **Rule for every todo:** do not add a new manual/global GitHub connect entry point; keep `window.sero.github.status()` as the source of truth; keep all touched source files under 500 LOC.
+
+### [x] GHA-01 — Build the shared renderer GitHub auth controller/store
+- **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
+- **Files:**
+  - new `apps/desktop/src/stores/github-auth.ts`
+  - `apps/desktop/src/hooks/useGitHubAuthFlow.ts`
+- **Reference code:**
+  - store structure and extracted actions: `apps/desktop/src/stores/context-editor.ts`
+  - event/status/copy-code mapping: `apps/desktop/src/hooks/useGitHubAuthFlow.ts`
+- **Expected shape:**
+  ```ts
+  export type GitHubAuthSource = 'explorer' | 'onboarding' | 'remote-origin' | 'publish';
+
+  export type GitHubAuthDialogResult =
+    | { outcome: 'success'; status: GitHubAuthStatus }
+    | { outcome: 'cancelled'; status: GitHubAuthStatus }
+    | { outcome: 'error'; status: GitHubAuthStatus; message: string };
+
+  export const useGitHubAuthStore = create<GitHubAuthStore>((set, get) => ({
+    open: false,
+    authStatus: null,
+    statusReady: false,
+    flow: { step: 'idle' },
+    openGitHubAuthDialog: async (request) => { /* shared deferred result */ },
+    refreshStatus: async () => await window.sero.github.status(),
+  }));
+  ```
+- **Constraints:**
+  - there must be exactly one `window.sero.github.onEvent(...)` subscription path,
+  - `refreshStatus()` must be used on open/success/logout and before auto-resume decisions,
+  - no surface should call `window.sero.github.login()` directly once this controller exists,
+  - if `useGitHubAuthFlow.ts` remains, convert it into a thin adapter over the shared store rather than keeping per-mount state.
+- **Do NOT:**
+  - **Anti-pattern: Per-Surface Device Flow Ownership** — do not keep separate event subscriptions in Explorer/onboarding/publish.
+  - **Anti-pattern: Stale UI Truth** — do not infer auth from cached flow success without rechecking `window.sero.github.status()`.
+- **Acceptance:** supports ISC-2, ISC-3, ISC-6, ISC-12, ISC-A-2.
+- **Status:** completed 2026-04-20.
+
+### GHA-02 — Add the globally mounted GitHub auth dialog host and extracted views
+- **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
+- **Files:**
+  - new `apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.tsx`
+  - new `apps/desktop/src/components/layout/auth/github/GitHubAuthDialogViews.tsx`
+  - `apps/desktop/src/App.tsx`
+- **Reference code:**
+  - dialog shell pattern: `apps/desktop/src/components/layout/auth/AuthLoginDialog.tsx`
+  - extracted view pattern: `apps/desktop/src/components/layout/auth/AuthLoginViews.tsx`
+  - shell-level mounted surfaces: `apps/desktop/src/App.tsx`
+- **Expected shape:**
+  ```tsx
+  export function GitHubAuthDialog() {
+    const { open, flow, authStatus, startLogin, cancel, logout } = useGitHubAuthStore();
+    return (
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          {/* idle / code / polling / success / error views */}
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  // App.tsx
+  <CommandMenu />
+  <GitHubAuthDialog />
+  <NewAppBanner />
+  <OnboardingWizard />
+  ```
+- **Constraints:**
+  - mount the dialog once at the app shell level,
+  - the actual device-flow UI lives only here,
+  - the dialog must clearly cover disconnected, in-progress, connected, and generic failure states,
+  - cancel/close must resolve back to the launching area rather than opening a second in-place flow.
+- **Do NOT:**
+  - **Anti-pattern: Local Dialog Clones** — do not render separate GitHub auth dialogs inside Explorer/onboarding/publish.
+  - **Anti-pattern: New Global Entry Point** — do not add a command/menu/sidebar button that opens GitHub auth outside contextual launchers.
+- **Acceptance:** supports ISC-2, ISC-3, ISC-6, ISC-9, ISC-11, ISC-A-2.
+
+### GHA-03 — Create reusable inline launcher/status primitives and migrate Explorer to them
+- **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
+- **Files:**
+  - new `apps/desktop/src/components/layout/auth/github/GitHubAuthSummary.tsx`
+  - optionally new `apps/desktop/src/components/layout/auth/github/GitHubAuthOutcomeNote.tsx`
+  - `apps/desktop/src/components/apps/explorer/vcs/GitHubAuthBanner.tsx`
+  - `apps/desktop/src/components/apps/explorer/vcs/VcsPanel.tsx` (only if imports change)
+- **Reference code:**
+  - current compact connected/disconnected copy/layout: `apps/desktop/src/components/apps/explorer/vcs/GitHubAuthBanner.tsx`
+  - store-backed global overlay pattern: `apps/desktop/src/components/layout/ImageLightbox.tsx`
+- **Expected shape:**
+  ```tsx
+  <GitHubAuthSummary
+    variant="compact"
+    authStatus={authStatus}
+    onConnect={() => void openGitHubAuthDialog({ source: 'explorer' })}
+    onDisconnect={() => void logout()}
+    disconnectedCopy="Connect GitHub to push, fetch, and create PRs."
+  />
+  ```
+- **Constraints:**
+  - Explorer should become a launcher/status surface only,
+  - keep a connected summary and disconnect affordance if still useful,
+  - remove inline code/polling/success/error device-flow rendering from Explorer.
+- **Do NOT:**
+  - **Anti-pattern: Hidden Second Flow** — do not leave the old inline device-flow UI in Explorer while also adding the dialog.
+  - **Anti-pattern: Surface-Specific Login Logic** — do not wire the Explorer button straight to `window.sero.github.login()`.
+- **Acceptance:** supports ISC-1, ISC-2, ISC-6, ISC-12, ISC-A-2.
+
+### GHA-04 — Refactor onboarding to launch the shared dialog and return to a connected step
+- **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
+- **Files:**
+  - `apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.ts`
+  - `apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx`
+  - `apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.tsx`
+- **Reference code:**
+  - current step gating/status refresh: `apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.ts`
+  - current onboarding GitHub layout: `apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.tsx`
+- **Expected shape:**
+  ```ts
+  const handleConnectGitHub = async () => {
+    const result = await openGitHubAuthDialog({ source: 'onboarding' });
+    if (result.outcome === 'success') {
+      await refreshStatus();
+    }
+  };
+  
+  // keep explicit Continue button; do not auto-advance after auth success
+  ```
+- **Constraints:**
+  - onboarding still checks `refreshStatus()` before deciding whether to show the GitHub step,
+  - the GitHub step must launch the shared dialog instead of rendering the flow inline,
+  - after success, return users to a clearly connected onboarding state with an obvious Continue button,
+  - remove copy that says users can connect later “from Explorer.”
+- **Do NOT:**
+  - **Anti-pattern: Surprise Advance** — do not auto-continue onboarding immediately after successful auth.
+  - **Anti-pattern: Explorer Dependency Copy** — do not retain any copy that tells users to go to Explorer later.
+- **Acceptance:** supports ISC-3, ISC-8, ISC-9, ISC-10, ISC-A-1, ISC-A-2.
+
+### GHA-05 — Replace remote-origin auth dead ends with a direct connect path and safe auto-resume
+- **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
+- **Files:**
+  - `apps/desktop/src/components/layout/workspace/remote-origin-views.tsx`
+  - optionally new `apps/desktop/src/components/layout/workspace/RemoteOriginGitHubAuthNotice.tsx`
+  - `apps/desktop/src/components/layout/git-remote/workflow.ts` (fallback handling only if needed)
+- **Reference code:**
+  - existing blocked create path: `apps/desktop/src/components/layout/workspace/remote-origin-views.tsx`
+  - structured auth failure contract: `apps/desktop/src/components/layout/git-remote/workflow.ts`
+- **Expected shape:**
+  ```ts
+  const handleConnectGitHub = async () => {
+    const result = await openGitHubAuthDialog({ source: 'remote-origin' });
+    if (result.outcome !== 'success') return;
+    if (!mountedRef.current) return;
+    await handleCreate();
+  };
+  
+  if (result.reason === 'auth') {
+    setAuthRequired(true);
+    return;
+  }
+  ```
+- **Constraints:**
+  - preserve repository form values while auth is pending,
+  - when auth blocks the explicit create action, offer `Connect GitHub` in the same view,
+  - after successful auth, resume create only if the component is still mounted and the blocked action was the GitHub create path,
+  - keep `createGitHubOrigin()` auth fallback intact even if the view preflights status,
+  - if `remote-origin-views.tsx` approaches the 500 LOC limit, extract the auth callout into a new file.
+- **Do NOT:**
+  - **Anti-pattern: Sidebar First** — do not leave or reintroduce “connect in the sidebar first” copy.
+  - **Anti-pattern: Lost Form Context** — do not reset name/description/visibility when the dialog opens or closes.
+  - **Anti-pattern: Blind Resume** — do not auto-create a repo after a generic proactive connect click.
+- **Acceptance:** supports ISC-1, ISC-4, ISC-7, ISC-9, ISC-10, ISC-A-1, ISC-A-3.
+
+### GHA-06 — Replace titlebar publish dead ends with a direct connect path and safe auto-resume
+- **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
+- **Files:**
+  - `apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx`
+  - optionally new `apps/desktop/src/components/layout/titlebar/git/GitRemotePublishGitHubPane.tsx`
+  - optionally new `apps/desktop/src/components/layout/titlebar/git/useGitRemotePublishGitHub.ts`
+- **Reference code:**
+  - current publish auth handling: `apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx`
+  - remote-origin resume pattern from GHA-05 should be reused rather than re-invented.
+- **Expected shape:**
+  ```ts
+  const handleConnectForPublish = async () => {
+    const result = await openGitHubAuthDialog({ source: 'publish' });
+    if (result.outcome !== 'success') return;
+    if (!shouldResumeBlockedPublish || !mountedRef.current) return;
+    await handleCreateGitHub();
+  };
+  ```
+- **Constraints:**
+  - GitHub publish mode must offer a direct `Connect GitHub` action when disconnected,
+  - when the user was explicitly blocked during `Create repo + publish`, resume that exact action after successful auth if still mounted,
+  - proactive connect clicks should only refresh the UI, not auto-create a repo,
+  - keep the “existing remote” mode unchanged,
+  - extract helpers if this file nears/exceeds 500 LOC.
+- **Do NOT:**
+  - **Anti-pattern: Dead-End Feedback** — do not leave auth errors as plain text with no direct action.
+  - **Anti-pattern: Shared-State Guessing** — do not trust old `githubStatus` without a fresh `refreshStatus()` before retry/resume.
+  - **Anti-pattern: Copy Drift** — do not ship any “connect in the sidebar” or “go to Explorer” instruction here.
+- **Acceptance:** supports ISC-1, ISC-5, ISC-7, ISC-8, ISC-12, ISC-A-1, ISC-A-3.
+
+### GHA-07 — Add/update tests for controller, dialog, onboarding, remote-origin, and publish flows
+- **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
+- **Files:**
+  - new `apps/desktop/src/stores/github-auth.test.ts` or `apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.test.tsx`
+  - update `apps/desktop/src/hooks/useGitHubAuthFlow.test.tsx`
+  - update `apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx`
+  - new `apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx`
+  - new targeted test for remote-origin auth-required behavior (either new view test or expanded `RemoteOriginManager.test.tsx`)
+  - keep `apps/desktop/src/components/layout/git-remote/workflow.test.ts` aligned if fallback behavior changes
+- **Reference code:**
+  - dialog failure test pattern: `apps/desktop/src/components/layout/auth/AuthLoginDialog.test.tsx`
+  - auth hook timer/status pattern: `apps/desktop/src/hooks/useGitHubAuthFlow.test.tsx`
+  - remote-origin error-surface pattern: `apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx`
+  - workflow contract coverage: `apps/desktop/src/components/layout/git-remote/workflow.test.ts`
+- **Expected shape:**
+  ```ts
+  it('resolves one shared dialog request and resumes publish only after success', async () => {
+    // open dialog from publish surface
+    // cancel => retry path remains visible
+    // success => reruns handleCreateGitHub exactly once
+  });
+  ```
+- **Constraints:**
+  - cover cancel, generic failure, connected success, and safe auto-resume,
+  - include at least one assertion that no UI tells users to go to Explorer/sidebar first,
+  - verify that blocked create/publish flows still offer a visible retry path after cancel.
+- **Do NOT:**
+  - **Anti-pattern: Manual-Only Verification** — do not rely on smoke tests alone for the new controller/dialog behavior.
+  - **Anti-pattern: Implementation-Coupled Assertions** — prefer user-visible outcomes and action counts over brittle internal-state snapshots.
+- **Acceptance:** provides thorough regression coverage for ISC-1 through ISC-12 and ISC-A-1 through ISC-A-3.

--- a/.pi/plans/2026-04-20-github-auth-unification/plan.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/plan.md
@@ -511,7 +511,7 @@ Cover both the controller/dialog and the contextual integrations.
 - **Acceptance:** supports ISC-3, ISC-8, ISC-9, ISC-10, ISC-A-1, ISC-A-2.
 - **Status:** completed 2026-04-20.
 
-### GHA-05 — Replace remote-origin auth dead ends with a direct connect path and safe auto-resume
+### [x] GHA-05 — Replace remote-origin auth dead ends with a direct connect path and safe auto-resume
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
 - **Files:**
   - `apps/desktop/src/components/layout/workspace/remote-origin-views.tsx`
@@ -545,6 +545,7 @@ Cover both the controller/dialog and the contextual integrations.
   - **Anti-pattern: Lost Form Context** — do not reset name/description/visibility when the dialog opens or closes.
   - **Anti-pattern: Blind Resume** — do not auto-create a repo after a generic proactive connect click.
 - **Acceptance:** supports ISC-1, ISC-4, ISC-7, ISC-9, ISC-10, ISC-A-1, ISC-A-3.
+- **Status:** completed 2026-04-20.
 
 ### GHA-06 — Replace titlebar publish dead ends with a direct connect path and safe auto-resume
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`

--- a/.pi/plans/2026-04-20-github-auth-unification/plan.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/plan.md
@@ -480,7 +480,7 @@ Cover both the controller/dialog and the contextual integrations.
 - **Acceptance:** supports ISC-1, ISC-2, ISC-6, ISC-12, ISC-A-2.
 - **Status:** completed 2026-04-20.
 
-### GHA-04 — Refactor onboarding to launch the shared dialog and return to a connected step
+### [x] GHA-04 — Refactor onboarding to launch the shared dialog and return to a connected step
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`
 - **Files:**
   - `apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.ts`
@@ -509,6 +509,7 @@ Cover both the controller/dialog and the contextual integrations.
   - **Anti-pattern: Surprise Advance** — do not auto-continue onboarding immediately after successful auth.
   - **Anti-pattern: Explorer Dependency Copy** — do not retain any copy that tells users to go to Explorer later.
 - **Acceptance:** supports ISC-3, ISC-8, ISC-9, ISC-10, ISC-A-1, ISC-A-2.
+- **Status:** completed 2026-04-20.
 
 ### GHA-05 — Replace remote-origin auth dead ends with a direct connect path and safe auto-resume
 - **Plan artifact:** `.pi/plans/2026-04-20-github-auth-unification/plan.md`

--- a/.pi/plans/2026-04-20-github-auth-unification/scout-context.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/scout-context.md
@@ -1,0 +1,105 @@
+# Context for: Unified GitHub authentication UX in Sero
+
+## Relevant Files
+- `apps/desktop/src/hooks/useGitHubAuthFlow.ts` — shared renderer hook for GitHub device-flow state, copy feedback, login/logout/cancel, and `window.sero.github.*` IPC calls. Used by both Explorer and onboarding.
+- `apps/desktop/src/components/apps/explorer/vcs/GitHubAuthBanner.tsx` — inline GitHub login banner in the VCS panel; currently the main visible auth surface for the Explorer path.
+- `apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx` — remote-origin dialog that now only loads origin state; auth failures are surfaced indirectly inside sub-views.
+- `apps/desktop/src/components/layout/workspace/remote-origin-views.tsx` — origin create/connect views. `CreateGitHubView` is where GitHub-auth failure is shown (`reason === 'auth'`) and it tells users to connect “in the sidebar first.”
+- `apps/desktop/src/components/layout/git-remote/workflow.ts` — shared workspace git workflow helpers. `createGitHubOrigin()` checks auth by calling `window.sero.github.status()` before creating a repo.
+- `apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx` — second GitHub publish/create path. It also checks GitHub status and emits its own “connect in the sidebar” auth copy.
+- `apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.tsx` — onboarding GitHub step UI. It reimplements the same device-flow states/copy/cancel/success/error display as the Explorer banner.
+- `apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.ts` — onboarding flow controller that calls `useGitHubAuthFlow()` and gates the onboarding step.
+- `apps/desktop/src/components/profiles/OnboardingWizard.tsx` and `apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx` — onboarding flow entry points that render `GitHubConnectCard`.
+- `apps/desktop/src/components/layout/auth/AuthLoginDialog.tsx` — existing reusable “global dialog” pattern for auth, but it is for generic providers/API keys via `window.sero.auth.*`, not GitHub.
+- `apps/desktop/electron/features/auth/github/auth-manager.ts` — Electron-side GitHub OAuth device-flow manager; owns token storage, login/open-browser/polling/logout, and GitHub API env injection.
+- `apps/desktop/electron/ipc/integrations/github.ts` — IPC handler layer for GitHub status/login/logout/cancel/createRepo.
+- `apps/desktop/electron/preload/apps/app-domain.ts` — preload bridge exposing `window.sero.github.status/login/logout/cancel/onEvent/createRepo`.
+- `apps/desktop/src/types/electron-services.d.ts` — renderer-side bridge types for GitHub auth events/status.
+- `apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx` and `apps/desktop/src/components/layout/git-remote/workflow.test.ts` — important existing tests covering auth/error behavior and repo creation fallback logic.
+
+## Project Structure
+- GitHub auth is implemented as a **single Electron main-process authority** (`GitHubAuthManager`) with renderer access through `window.sero.github.*`.
+- Renderer UI is currently split across multiple surfaces:
+  - Explorer VCS banner
+  - onboarding card
+  - remote-origin creation error text
+  - titlebar publish section auth hint
+- There is **no dedicated shared GitHub auth dialog/surface** yet; only the hook is shared, and the UI is duplicated.
+- `AuthLoginDialog` shows the project already uses a reusable dialog pattern for auth-like flows; GitHub could follow a similar “shared dialog + entry points” model.
+
+## Conventions
+- Keep source files under 500 LOC. Relevant files are already close enough to care about:
+  - `auth-manager.ts` 373 LOC
+  - `AuthLoginDialog.tsx` 353 LOC
+  - `remote-origin-views.tsx` 392 LOC
+  - `GitRemotePublishSection.tsx` 293 LOC
+- The repo favors small extracted subviews/helpers for dialogs and workflows (`remote-origin-views.tsx`, `AuthLoginViews.tsx`, etc.).
+- `useEffect` is used sparingly, mostly for IPC/event subscriptions or open/close transitions triggered by external state; that pattern already exists in `useGitHubAuthFlow` and the dialog components.
+- Cross-process data flow is expected to stay aligned across renderer ↔ preload ↔ main ↔ Pi SDK; GitHub auth changes should preserve that boundary.
+
+## Current OAuth / Device-Flow Architecture
+- Main process:
+  - `GitHubAuthManager.login()` requests a device code, opens the GitHub verification URL, polls for token, verifies the token against `/user`, then stores the token encrypted with `safeStorage`.
+  - Cached token is loaded from disk on startup and used to build `GH_TOKEN` plus git auth env vars for containers.
+- IPC:
+  - `status`, `login`, `logout`, `cancel`, and `createRepo` are exposed on `IpcChannels.github`.
+  - Login progress is broadcast as `IpcChannels.github.event` and consumed in the renderer.
+- Renderer hook:
+  - `useGitHubAuthFlow()` subscribes to `window.sero.github.onEvent`, fetches status on mount, and exposes `startLogin/logout/cancel/copyCode`.
+- Workspace git flow:
+  - `createGitHubOrigin()` checks auth with `window.sero.github.status()` before invoking repo creation.
+  - `RemoteOriginManager` itself only fetches current remotes; auth is not part of its open-state flow.
+
+## How RemoteOriginManager Surfaces GitHub Auth Failures
+- The actual auth failure path is not in `RemoteOriginManager.tsx`; it comes from `createGitHubOrigin()` in `workflow.ts`.
+- When GitHub is unauthenticated, `createGitHubOrigin()` returns `{ ok: false, reason: 'auth', authStatus }`.
+- `CreateGitHubView` maps that to a plain inline message: “Not authenticated with GitHub. Connect your GitHub account in the sidebar first.”
+- `GitRemotePublishSection` maps the same auth failure to: “GitHub is not connected. Connect it in the sidebar first, then retry.”
+- That means the same underlying failure is currently explained in at least two different places with different copy and no direct action to start login.
+
+## Existing Shared GitHub Auth Surface / Reuse Potential
+- **Shared hook exists:** `useGitHubAuthFlow()` is the only true reusable auth primitive in the renderer right now.
+- **Shared UI does not exist:** both `GitHubAuthBanner` and `GitHubConnectCard` render the same flow states independently.
+- `AuthLoginDialog` is a strong precedent for a centralized auth dialog pattern, but it cannot be reused directly for GitHub because it speaks to a different IPC domain (`window.sero.auth.*`).
+- `RemoteOriginManager` and `GitRemotePublishSection` already rely on `workflow.ts`, so a reusable GitHub auth surface could be co-located there or in a new shared `components/layout/auth/github/` or `components/layout/git-remote/` area.
+
+## Global Dialog / Modal / Action Patterns
+- The app already opens dialogs from many entry points by hoisting `open` state in the parent and rendering the dialog near the relevant shell surface:
+  - `AuthLoginDialog` from Chat/Onboarding
+  - `ThemePanel`, `ModelManagerDialog`, `ConnectDeviceDialog` from the shell/command menu
+  - `RemoteOriginManager` from workspace tree actions
+- This suggests two viable patterns for GitHub auth:
+  1. a globally mounted dialog/sheet controlled by shared state or a shell-level controller
+  2. a shared GitHub auth component rendered inline in multiple places but sourced from one implementation
+- There is no obvious existing app-wide modal registry/store for arbitrary dialogs; current patterns are prop-driven and local.
+
+## Concrete Implementation Options
+### Option A — Extract a reusable GitHub auth surface and use it inline wherever needed
+- Create a shared component around `useGitHubAuthFlow()` that can render compact/expanded states (idle, code, polling, success, error, authenticated).
+- Use it in Explorer, onboarding, remote-origin auth error state, and publish section.
+- Pros: lowest architectural risk; easy to adopt incrementally; keeps context-specific copy possible.
+- Cons: still multiple entry points; the “login from anywhere” experience depends on each caller rendering the shared component.
+
+### Option B — Centralize GitHub auth into a shared dialog/sheet and trigger it from any area
+- Add a shell-level GitHub auth dialog controller, similar in spirit to `AuthLoginDialog`, but for GitHub device flow.
+- Expose a small imperative or store-backed “openGitHubAuth(reason/source)” API so any area can request login.
+- Pros: best for a unified, obvious login path; no disconnected auth UX; can show one consistent flow.
+- Cons: more plumbing; requires new global state/controller and deciding how callers subscribe to completion/error results.
+
+### Option C — Hybrid: shared auth dialog plus inline summary card/banner
+- Use one shared GitHub auth dialog for the actual login flow and keep lightweight inline status pills/banners in Explorer/onboarding/publish surfaces.
+- Error states like `reason === 'auth'` can surface a button that opens the shared dialog instead of showing only text.
+- Pros: good balance of discoverability and compactness; avoids duplicating the flow UI.
+- Cons: still need some duplication of “connected/auth required” status display.
+
+## Key Findings
+- The current “sidebar first” message is the biggest UX smell: GitHub login is already globally available in the Electron host, but the renderer only advertises it in one main banner and in a few disconnected fallback messages.
+- The device-flow implementation is already unified at the main-process level; the missing piece is a **unified renderer entry surface** and consistent “connect GitHub” action wiring.
+- `RemoteOriginManager` itself is not the source of the auth failure; it only delegates to `workflow.ts`, which does the auth check before repo creation.
+- There is no shared GitHub auth dialog/hook combo yet; extracting one is the likely path to a coherent UX.
+
+## Gotchas
+- `window.sero.github.status()` is the source of truth for auth state; callers should not infer auth from prior UI state alone.
+- `GitHubAuthManager` stores tokens using `safeStorage`; auth is tied to OS keychain availability and can fail with a persistence-related error.
+- The login flow uses a global IPC event channel; if multiple GitHub auth surfaces mount concurrently, they will all observe the same progress stream unless the UI architecture scopes the listener carefully.
+- Because the codebase enforces the 500 LOC limit, any centralization should likely split into a small controller/hook plus smaller presentational subviews rather than a single mega-component.

--- a/.pi/plans/2026-04-20-github-auth-unification/spec.md
+++ b/.pi/plans/2026-04-20-github-auth-unification/spec.md
@@ -1,0 +1,88 @@
+# Unified GitHub Authentication UX in Sero
+
+**Date:** 2026-04-20
+**Status:** Draft
+**Directory:** /Users/danielcarter/Documents/Dev/projects/sero/sero
+
+## Intent
+Sero should present one clear, reusable GitHub authentication path instead of treating Explorer as the de facto place to connect GitHub. Any area that depends on GitHub should be able to guide the user directly into the same connect flow so users do not hit dead ends or have to discover Explorer on their own.
+
+## User Story
+As a Sero user trying to perform a GitHub-related action, I want a clear way to connect GitHub from the place where I need it, so that I can recover from auth issues without hunting through the app.
+
+## Behavior
+GitHub authentication should feel like one product experience across Sero, even when it is launched from different parts of the app. When a user reaches a GitHub-dependent action while not connected, the current area should clearly explain that GitHub is required and offer a direct **Connect GitHub** action.
+
+Explorer and onboarding may continue to show lightweight inline GitHub UI, but they should point into the same shared authentication path used everywhere else. The purpose is for users to learn one obvious GitHub connect experience, not separate flows per feature.
+
+When a user completes GitHub authentication successfully, Sero should help them continue from where they were. If the interrupted action can be resumed simply and safely, the app should resume it. If automatic continuation would add complexity or risk surprising behavior, the app should instead return the user to a clearly connected state with an obvious path to proceed.
+
+When a user cancels authentication, they should land back in the area that launched the flow and still see that GitHub is not connected, along with a visible retry path. When authentication fails, the app should show a generic failure state for v1 and make retrying obvious.
+
+### Happy Path
+1. A user starts a GitHub-dependent action from any current GitHub touchpoint in Sero.
+2. If GitHub is not connected, the current area shows that authentication is required and offers a direct **Connect GitHub** action.
+3. The user launches the shared GitHub connect flow.
+4. The shared flow shows the current GitHub auth state consistently, including progress during device login.
+5. The user completes GitHub login successfully.
+6. Sero resumes the interrupted flow when doing so is simple and safe.
+7. If the action is not auto-resumed, Sero returns the user to a clearly connected state where the next step is obvious.
+
+### Edge Cases & Error Handling
+- **User cancels login:** Return the user to the launching area and keep a clear **GitHub not connected** state with a visible **Connect GitHub** retry path.
+- **Generic login failure:** Show a generic GitHub authentication failure state and provide an obvious way to retry.
+- **Auth required outside Explorer:** The user can initiate GitHub connection directly from the current area instead of being told to go to Explorer or the sidebar.
+- **Auto-resume not appropriate:** If continuing automatically would require complex logic or could surprise the user, return them to a connected state and let them proceed manually.
+- **Multiple current touchpoints:** All existing GitHub entry points should feel consistent and clearly part of the same authentication experience.
+
+## Scope
+### In Scope
+- Unifying the GitHub authentication path across current Sero GitHub touchpoints.
+- Providing a direct **Connect GitHub** action wherever a GitHub-dependent action is blocked by missing auth.
+- Reusing one shared GitHub connect experience so Explorer, onboarding, and other GitHub-required areas feel consistent.
+- Ensuring blocked flows do not end in dead ends after auth errors or cancellation.
+- Supporting simple, safe recovery after successful authentication.
+- Replacing copy that instructs users to go connect GitHub somewhere else in the app.
+
+### Out of Scope
+- Creating a new globally discoverable manual GitHub connect entry point outside contextual GitHub flows.
+- Redesigning GitHub features beyond what is needed to unify authentication entry and recovery.
+- Reworking the underlying Electron GitHub device-flow implementation or changing token-storage behavior.
+- Introducing detailed provider-specific failure handling for v1 beyond a generic retryable failure state.
+- Expanding the work into a broader git workflow redesign.
+
+## Effort & Quality
+- **Level:** production
+- **Tests:** thorough
+- **Docs:** inline
+
+## Constraints
+- The unified GitHub auth experience should build on the existing shared GitHub auth foundation rather than creating a third disconnected path.
+- Explorer should no longer be treated as the required place to connect GitHub.
+- Onboarding may remain lightweight and inline, but it should launch the same shared GitHub connect flow as the rest of the app.
+- The product should prioritize convenience and clarity without introducing overly complex auto-resume logic.
+- The v1 failure experience can remain generic as long as the retry path is clear.
+- The experience should preserve user context so GitHub auth failures do not create dead ends.
+
+## Ideal State Criteria
+
+### Core Functionality
+- [ ] ISC-1: Any blocked GitHub action offers a direct **Connect GitHub** action.
+- [ ] ISC-2: Explorer launches the same shared GitHub connect flow as other areas.
+- [ ] ISC-3: Onboarding launches the same shared GitHub connect flow as other areas.
+- [ ] ISC-4: Remote-origin GitHub auth failures include a direct **Connect GitHub** action.
+- [ ] ISC-5: Publish GitHub auth failures include a direct **Connect GitHub** action.
+- [ ] ISC-6: The shared GitHub flow clearly shows in-progress, connected, cancelled, and failed states.
+- [ ] ISC-7: Successful login resumes the interrupted flow when that recovery is simple and safe.
+- [ ] ISC-8: Successful login returns users to a clearly connected state when auto-resume is not appropriate.
+
+### Edge Cases
+- [ ] ISC-9: Cancelling login returns users to the area that launched it.
+- [ ] ISC-10: After cancellation, the launching area still shows a visible retry path.
+- [ ] ISC-11: Generic GitHub login failures show a clear retry path.
+- [ ] ISC-12: Users can connect GitHub from every current GitHub touchpoint, not just Explorer.
+
+### Anti-Criteria
+- [ ] ISC-A-1: No GitHub-required area tells users to go connect “in Explorer” or “in the sidebar first.”
+- [ ] ISC-A-2: No new third disconnected GitHub login experience is introduced.
+- [ ] ISC-A-3: No GitHub auth failure leaves the user at a dead end with only an error.

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -21,6 +21,7 @@ import { NewAppBanner } from '@/components/layout/NewAppBanner';
 import { useSessionAgent } from '@/hooks/useSessionAgent';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { CommandMenu } from '@/components/layout/CommandMenu';
+import { GitHubAuthDialog } from '@/components/layout/auth/github/GitHubAuthDialog';
 import { initAppControlBridge } from '@/lib/app-control-bridge';
 import { hydrateShellState } from '@/lib/app-startup';
 import { ActiveAppPanel } from '@/components/apps/ActiveAppPanel';
@@ -320,6 +321,7 @@ export function App() {
         </div>
 
         <CommandMenu />
+        <GitHubAuthDialog />
         <NewAppBanner />
         <OnboardingWizard />
         <StatusBar />

--- a/apps/desktop/src/components/apps/explorer/vcs/GitHubAuthBanner.test.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/GitHubAuthBanner.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetGitHubAuthStore, useGitHubAuthStore } from '@/stores/github-auth';
+import { GitHubAuthBanner } from './GitHubAuthBanner';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const githubBridge = {
+  status: vi.fn(),
+  onEvent: vi.fn(),
+  login: vi.fn(),
+  logout: vi.fn(),
+  cancel: vi.fn(),
+};
+
+const originalSeroDescriptor = Object.getOwnPropertyDescriptor(window, 'sero');
+
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(label),
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected button with label containing "${label}"`);
+  }
+  return button;
+}
+
+describe('GitHubAuthBanner', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGitHubAuthStore();
+
+    githubBridge.status.mockResolvedValue({ authenticated: false });
+    githubBridge.onEvent.mockReturnValue(vi.fn());
+    githubBridge.login.mockResolvedValue(undefined);
+    githubBridge.logout.mockResolvedValue(undefined);
+    githubBridge.cancel.mockResolvedValue(undefined);
+
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      value: {
+        github: githubBridge,
+      },
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+    resetGitHubAuthStore();
+
+    if (originalSeroDescriptor) {
+      Object.defineProperty(window, 'sero', originalSeroDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'sero');
+    }
+  });
+
+  it('stays summary-only and launches the shared dialog instead of starting login inline', async () => {
+    await act(async () => {
+      root?.render(<GitHubAuthBanner />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Connect GitHub to push, fetch, and create PRs.');
+    });
+
+    await act(async () => {
+      useGitHubAuthStore.setState({
+        flow: {
+          step: 'code',
+          userCode: 'ABCD-1234',
+          verificationUri: 'https://github.com/login/device',
+        },
+      });
+    });
+
+    expect(container.textContent).not.toContain('ABCD-1234');
+    expect(container.textContent).not.toContain('Waiting for authorization');
+
+    await act(async () => {
+      findButton('Connect GitHub').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    expect(githubBridge.login).not.toHaveBeenCalled();
+
+    await act(async () => {
+      useGitHubAuthStore.getState().resolveGitHubAuthDialog({
+        outcome: 'cancelled',
+        status: { authenticated: false },
+      });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('GitHub is still disconnected.');
+      expect(container.textContent).toContain('Try again');
+    });
+  });
+
+  it('shows the connected summary and disconnect affordance', async () => {
+    useGitHubAuthStore.setState({
+      authStatus: { authenticated: true, username: 'octocat' },
+      statusReady: true,
+    });
+
+    await act(async () => {
+      root?.render(<GitHubAuthBanner />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Connected as octocat');
+      expect(container.textContent).toContain('Disconnect');
+    });
+
+    await act(async () => {
+      findButton('Disconnect').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(githubBridge.logout).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain('Connect GitHub to push, fetch, and create PRs.');
+    });
+  });
+});

--- a/apps/desktop/src/components/apps/explorer/vcs/GitHubAuthBanner.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/GitHubAuthBanner.tsx
@@ -1,141 +1,79 @@
-/**
- * GitHubAuthBanner — inline login prompt for the VCS panel.
- *
- * Shows when GitHub is not authenticated. Drives the Device Flow
- * OAuth directly from the Source Control panel — no settings detour.
- */
-
-import { Check, Copy, Github, Loader2, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { cn } from '@sero-ai/ui/lib/utils';
-import { useGitHubAuthFlow } from '@/hooks/useGitHubAuthFlow';
+import type { GitHubAuthDialogResult } from '@/stores/github-auth';
+import { useGitHubAuthStore } from '@/stores/github-auth';
+import { GitHubAuthOutcomeNote } from '@/components/layout/auth/github/GitHubAuthOutcomeNote';
+import { GitHubAuthSummary } from '@/components/layout/auth/github/GitHubAuthSummary';
 
 interface Props {
   className?: string;
 }
 
+type InlineOutcome = Extract<GitHubAuthDialogResult, { outcome: 'cancelled' | 'error' }>;
+
 export function GitHubAuthBanner({ className }: Props) {
   const {
     authStatus,
-    flow,
-    copied,
-    copyFailed,
-    startLogin,
+    statusReady,
+    init,
+    openGitHubAuthDialog,
     logout,
-    cancel,
-    copyCode,
-  } = useGitHubAuthFlow();
+  } = useGitHubAuthStore(
+    useShallow((state) => ({
+      authStatus: state.authStatus,
+      statusReady: state.statusReady,
+      init: state.init,
+      openGitHubAuthDialog: state.openGitHubAuthDialog,
+      logout: state.logout,
+    })),
+  );
+  const [lastOutcome, setLastOutcome] = useState<InlineOutcome | null>(null);
 
-  if (authStatus?.authenticated) {
-    return (
-      <div className={cn('flex items-center justify-between rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/30 px-2 py-1.5', className)}>
-        <span className="flex items-center gap-1.5 text-[10px] text-[var(--status-success)]">
-          <Github className="size-3" />
-          <span>Connected as <strong>{authStatus.username}</strong></span>
-        </span>
-        <button
-          onClick={logout}
-          className="text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--status-error)]"
-        >
-          Disconnect
-        </button>
-      </div>
-    );
-  }
+  useEffect(() => {
+    void init();
+  }, [init]);
+
+  useEffect(() => {
+    if (authStatus?.authenticated) {
+      setLastOutcome(null);
+    }
+  }, [authStatus?.authenticated]);
+
+  const handleConnect = useCallback(async () => {
+    setLastOutcome(null);
+    const result = await openGitHubAuthDialog({ source: 'explorer' });
+    if (result.outcome === 'success') return;
+    setLastOutcome(result);
+  }, [openGitHubAuthDialog]);
+
+  const handleDisconnect = useCallback(() => {
+    setLastOutcome(null);
+    void logout();
+  }, [logout]);
 
   return (
-    <div className={cn('rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/30 px-2 py-2', className)}>
-      {flow.step === 'idle' && (
-        <div className="flex items-center justify-between">
-          <span className="text-[10px] text-[var(--text-muted)]">
-            Connect GitHub to push, fetch, and create PRs.
-          </span>
-          <button
-            onClick={startLogin}
-            className={cn(
-              'flex items-center gap-1 rounded px-2 py-0.5 text-[10px] font-medium',
-              'bg-[var(--bg-muted)] text-[var(--text-secondary)]',
-              'transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]',
-            )}
-          >
-            <Github className="size-3" />
-            Connect GitHub
-          </button>
-        </div>
-      )}
+    <div className={cn('space-y-1.5', className)}>
+      <GitHubAuthSummary
+        variant="compact"
+        authStatus={authStatus}
+        statusReady={statusReady}
+        disconnectedCopy="Connect GitHub to push, fetch, and create PRs."
+        onConnect={() => {
+          void handleConnect();
+        }}
+        onDisconnect={handleDisconnect}
+      />
 
-      {flow.step === 'code' && (
-        <div className="space-y-1.5">
-          <p className="text-[10px] text-[var(--text-muted)]">
-            Enter this code at{' '}
-            <a
-              href={flow.verificationUri}
-              target="_blank"
-              rel="noreferrer"
-              className="text-[var(--status-info)] underline"
-            >
-              github.com/login/device
-            </a>
-          </p>
-          <div className="flex items-center gap-1.5">
-            <code className="rounded border border-[var(--status-info-subtle)] bg-[var(--status-info-muted)] px-2 py-0.5 font-mono text-sm font-bold tracking-widest text-[var(--status-info)]">
-              {flow.userCode}
-            </code>
-            <button
-              onClick={() => void copyCode(flow.userCode)}
-              title="Copy code"
-              className="text-[var(--text-muted)] transition-colors hover:text-[var(--status-info)]"
-            >
-              {copied ? <Check className="size-3 text-[var(--status-success)]" /> : <Copy className="size-3" />}
-            </button>
-            <button
-              onClick={cancel}
-              title="Cancel"
-              className="ml-auto text-[var(--text-muted)] transition-colors hover:text-[var(--status-error)]"
-            >
-              <X className="size-3" />
-            </button>
-          </div>
-          <p className="flex items-center gap-1 text-[10px] text-[var(--text-muted)]/60">
-            <Loader2 className="size-3 animate-spin" />
-            Waiting for authorization…
-          </p>
-          {copyFailed ? (
-            <p className="text-[10px] text-[var(--status-error)]">Copy failed — enter the code manually.</p>
-          ) : null}
-        </div>
-      )}
-
-      {flow.step === 'polling' && (
-        <div className="flex items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
-          <Loader2 className="size-3 animate-spin" />
-          Waiting for authorization…
-          <button
-            onClick={cancel}
-            className="ml-auto text-[var(--text-muted)] transition-colors hover:text-[var(--status-error)]"
-          >
-            <X className="size-3" />
-          </button>
-        </div>
-      )}
-
-      {flow.step === 'success' && (
-        <div className="flex items-center gap-1.5 text-[10px] text-[var(--status-success)]">
-          <Check className="size-3" />
-          Connected as <strong>{flow.username}</strong>
-        </div>
-      )}
-
-      {flow.step === 'error' && (
-        <div className="space-y-1">
-          <p className="text-[10px] text-[var(--status-error)]">{flow.message}</p>
-          <button
-            onClick={startLogin}
-            className="text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)]"
-          >
-            Try again
-          </button>
-        </div>
-      )}
+      {!authStatus?.authenticated && lastOutcome ? (
+        <GitHubAuthOutcomeNote
+          outcome={lastOutcome.outcome}
+          message={lastOutcome.outcome === 'error' ? lastOutcome.message : undefined}
+          onRetry={() => {
+            void handleConnect();
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.test.tsx
+++ b/apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitHubDeviceFlowEvent } from '@/types/electron-services';
+import type { GitHubAuthDialogResult } from '@/stores/github-auth';
+import { resetGitHubAuthStore, useGitHubAuthStore } from '@/stores/github-auth';
+import { GitHubAuthDialog } from './GitHubAuthDialog';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const githubBridge = {
+  status: vi.fn(),
+  onEvent: vi.fn(),
+  login: vi.fn(),
+  logout: vi.fn(),
+  cancel: vi.fn(),
+};
+
+const originalSeroDescriptor = Object.getOwnPropertyDescriptor(window, 'sero');
+
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(label),
+  );
+  if (!button) {
+    throw new Error(`Expected button with label containing "${label}"`);
+  }
+  return button as HTMLButtonElement;
+}
+
+describe('GitHubAuthDialog', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+  let githubEventListener: ((event: GitHubDeviceFlowEvent) => void) | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGitHubAuthStore();
+    githubEventListener = null;
+
+    githubBridge.status.mockResolvedValue({ authenticated: false });
+    githubBridge.login.mockResolvedValue(undefined);
+    githubBridge.logout.mockResolvedValue(undefined);
+    githubBridge.cancel.mockResolvedValue(undefined);
+    githubBridge.onEvent.mockImplementation((callback: (event: GitHubDeviceFlowEvent) => void) => {
+      githubEventListener = callback;
+      return vi.fn(() => {
+        if (githubEventListener === callback) {
+          githubEventListener = null;
+        }
+      });
+    });
+
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      value: {
+        github: githubBridge,
+      },
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+    resetGitHubAuthStore();
+
+    if (originalSeroDescriptor) {
+      Object.defineProperty(window, 'sero', originalSeroDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'sero');
+    }
+  });
+
+  it('resolves cancelled launch requests through the shared dialog store', async () => {
+    await act(async () => {
+      root?.render(<GitHubAuthDialog />);
+    });
+
+    let resultPromise!: Promise<GitHubAuthDialogResult>;
+    await act(async () => {
+      resultPromise = useGitHubAuthStore.getState().openGitHubAuthDialog({ source: 'publish' });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Connect GitHub');
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    let result: GitHubAuthDialogResult | undefined;
+    await act(async () => {
+      findButton('Cancel').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      result = await resultPromise;
+    });
+
+    expect(result).toEqual({
+      outcome: 'cancelled',
+      status: { authenticated: false },
+    });
+
+    expect(useGitHubAuthStore.getState().open).toBe(false);
+    expect(githubBridge.onEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders code, connected, and error states from the shared store', async () => {
+    await act(async () => {
+      useGitHubAuthStore.setState({
+        open: true,
+        activeRequest: { source: 'explorer' },
+        authStatus: { authenticated: false },
+        statusReady: true,
+        flow: {
+          step: 'code',
+          userCode: 'ABCD-1234',
+          verificationUri: 'https://github.com/login/device',
+        },
+      });
+      root?.render(<GitHubAuthDialog />);
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('ABCD-1234');
+      expect(document.body.textContent).toContain('Open GitHub');
+    });
+
+    await act(async () => {
+      useGitHubAuthStore.setState({
+        authStatus: { authenticated: true, username: 'octocat' },
+        flow: { step: 'idle' },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub connected');
+      expect(document.body.textContent).toContain('Connected as octocat');
+    });
+
+    await act(async () => {
+      useGitHubAuthStore.setState({
+        authStatus: { authenticated: false },
+        flow: { step: 'error', message: 'Device flow failed' },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub authentication failed');
+      expect(document.body.textContent).toContain('Device flow failed');
+    });
+
+    await act(async () => {
+      findButton('Try again').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(githubBridge.login).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.tsx
+++ b/apps/desktop/src/components/layout/auth/github/GitHubAuthDialog.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { Github } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@sero-ai/ui/components/ui/dialog';
+import type { GitHubAuthSource } from '@/stores/github-auth';
+import { useGitHubAuthStore } from '@/stores/github-auth';
+import {
+  GitHubAuthCodeView,
+  GitHubAuthConnectedView,
+  GitHubAuthErrorView,
+  GitHubAuthLoadingView,
+  GitHubAuthPollingView,
+  GitHubAuthReadyView,
+} from './GitHubAuthDialogViews';
+
+function describeGitHubAuthDialog(
+  source: GitHubAuthSource | null,
+  state: 'loading' | 'ready' | 'code' | 'polling' | 'connected' | 'error',
+): string {
+  if (state === 'loading') {
+    return 'Checking your current GitHub status.';
+  }
+
+  if (state === 'code' || state === 'polling') {
+    return 'Finish the GitHub device login in your browser to continue.';
+  }
+
+  if (state === 'connected') {
+    return 'GitHub is connected and ready to use.';
+  }
+
+  if (state === 'error') {
+    return 'GitHub login did not complete. Retry here or close the dialog to return.';
+  }
+
+  switch (source) {
+    case 'explorer':
+      return 'Connect GitHub once to use repo workflows directly from Explorer.';
+    case 'onboarding':
+      return 'Connect GitHub during setup, then continue onboarding from the same step.';
+    case 'remote-origin':
+      return 'Connect GitHub to create a remote repository for this workspace.';
+    case 'publish':
+      return 'Connect GitHub to create a repository and publish this workspace.';
+    default:
+      return 'Connect GitHub to use publishing, remote setup, and Explorer workflows.';
+  }
+}
+
+export function GitHubAuthDialog() {
+  const {
+    open,
+    activeRequest,
+    authStatus,
+    statusReady,
+    flow,
+    copied,
+    copyFailed,
+    init,
+    startLogin,
+    dismissGitHubAuthDialog,
+    logout,
+    copyCode,
+  } = useGitHubAuthStore(
+    useShallow((state) => ({
+      open: state.open,
+      activeRequest: state.activeRequest,
+      authStatus: state.authStatus,
+      statusReady: state.statusReady,
+      flow: state.flow,
+      copied: state.copied,
+      copyFailed: state.copyFailed,
+      init: state.init,
+      startLogin: state.startLogin,
+      dismissGitHubAuthDialog: state.dismissGitHubAuthDialog,
+      logout: state.logout,
+      copyCode: state.copyCode,
+    })),
+  );
+
+  useEffect(() => {
+    if (!open || statusReady) return;
+    void init();
+  }, [open, statusReady, init]);
+
+  const handleDismiss = useCallback(() => {
+    void dismissGitHubAuthDialog();
+  }, [dismissGitHubAuthDialog]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        handleDismiss();
+      }
+    },
+    [handleDismiss],
+  );
+
+  const dialogState = useMemo<'loading' | 'ready' | 'code' | 'polling' | 'connected' | 'error'>(() => {
+    if (!statusReady) return 'loading';
+    if (flow.step === 'error') return 'error';
+    if (flow.step === 'code') return 'code';
+    if (flow.step === 'polling') return 'polling';
+    if (flow.step === 'success' || authStatus?.authenticated) return 'connected';
+    return 'ready';
+  }, [authStatus?.authenticated, flow.step, statusReady]);
+
+  const connectedUsername = flow.step === 'success'
+    ? flow.username || authStatus?.username || 'GitHub user'
+    : authStatus?.username || 'GitHub user';
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Github className="size-5" />
+            Connect GitHub
+          </DialogTitle>
+          <DialogDescription>
+            {describeGitHubAuthDialog(activeRequest?.source ?? null, dialogState)}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {dialogState === 'loading' ? (
+            <GitHubAuthLoadingView onClose={handleDismiss} />
+          ) : null}
+
+          {dialogState === 'ready' ? (
+            <GitHubAuthReadyView
+              source={activeRequest?.source ?? null}
+              onConnect={startLogin}
+              onClose={handleDismiss}
+            />
+          ) : null}
+
+          {dialogState === 'code' ? (
+            <GitHubAuthCodeView
+              userCode={flow.step === 'code' ? flow.userCode : ''}
+              verificationUri={flow.step === 'code' ? flow.verificationUri : 'https://github.com/login/device'}
+              copied={copied}
+              copyFailed={copyFailed}
+              onCopyCode={(code) => {
+                void copyCode(code);
+              }}
+              onCancel={handleDismiss}
+            />
+          ) : null}
+
+          {dialogState === 'polling' ? <GitHubAuthPollingView onCancel={handleDismiss} /> : null}
+
+          {dialogState === 'connected' ? (
+            <GitHubAuthConnectedView
+              username={connectedUsername}
+              onClose={handleDismiss}
+              onLogout={() => {
+                void logout();
+              }}
+            />
+          ) : null}
+
+          {dialogState === 'error' ? (
+            <GitHubAuthErrorView
+              message={flow.step === 'error' ? flow.message : 'GitHub login failed.'}
+              onRetry={startLogin}
+              onClose={handleDismiss}
+            />
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/layout/auth/github/GitHubAuthDialogViews.tsx
+++ b/apps/desktop/src/components/layout/auth/github/GitHubAuthDialogViews.tsx
@@ -1,0 +1,254 @@
+import type { ReactNode } from 'react';
+import { AlertCircle, Check, Copy, ExternalLink, Github, Loader2 } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { cn } from '@sero-ai/ui/lib/utils';
+import type { GitHubAuthSource } from '@/stores/github-auth';
+
+function GitHubAuthStateFrame({
+  icon,
+  iconClassName,
+  title,
+  description,
+  children,
+}: {
+  icon: ReactNode;
+  iconClassName: string;
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-3">
+        <div
+          className={cn(
+            'flex size-10 shrink-0 items-center justify-center rounded-lg border',
+            iconClassName,
+          )}
+        >
+          {icon}
+        </div>
+        <div className="min-w-0 space-y-1">
+          <p className="text-sm font-medium text-[var(--text-primary)]">{title}</p>
+          <p className="text-xs leading-relaxed text-[var(--text-secondary)]">{description}</p>
+        </div>
+      </div>
+
+      {children}
+    </div>
+  );
+}
+
+function sourceSummary(source: GitHubAuthSource | null): string {
+  switch (source) {
+    case 'explorer':
+      return 'Explorer so you can continue with repo work.';
+    case 'onboarding':
+      return 'onboarding so you can finish setup.';
+    case 'remote-origin':
+      return 'remote creation so you can finish creating this repository.';
+    case 'publish':
+      return 'publishing so you can finish creating and pushing this repository.';
+    default:
+      return 'the GitHub task that brought you here.';
+  }
+}
+
+export function GitHubAuthLoadingView({ onClose }: { onClose: () => void }) {
+  return (
+    <GitHubAuthStateFrame
+      icon={<Loader2 className="size-4 animate-spin text-[var(--text-primary)]" />}
+      iconClassName="border-[var(--border-subtle)] bg-[var(--bg-elevated)]"
+      title="Checking GitHub connection"
+      description="Sero is refreshing your GitHub status before showing the next step."
+    >
+      <div className="flex justify-end">
+        <Button variant="ghost" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </GitHubAuthStateFrame>
+  );
+}
+
+export function GitHubAuthReadyView({
+  source,
+  onConnect,
+  onClose,
+}: {
+  source: GitHubAuthSource | null;
+  onConnect: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <GitHubAuthStateFrame
+      icon={<Github className="size-4 text-[var(--text-primary)]" />}
+      iconClassName="border-[var(--border-subtle)] bg-[var(--bg-elevated)]"
+      title="Connect GitHub"
+      description="Use one shared GitHub login flow for publishing, remote setup, and Explorer actions."
+    >
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-muted)]/30 px-3 py-2 text-xs leading-relaxed text-[var(--text-secondary)]">
+        We&apos;ll open GitHub in your browser and give you a one-time device code. When you finish, Sero returns you to {sourceSummary(source)}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={onConnect}>
+          <Github className="mr-2 size-4" />
+          Connect GitHub
+        </Button>
+      </div>
+    </GitHubAuthStateFrame>
+  );
+}
+
+export function GitHubAuthCodeView({
+  userCode,
+  verificationUri,
+  copied,
+  copyFailed,
+  onCopyCode,
+  onCancel,
+}: {
+  userCode: string;
+  verificationUri: string;
+  copied: boolean;
+  copyFailed: boolean;
+  onCopyCode: (code: string) => void;
+  onCancel: () => void;
+}) {
+  return (
+    <GitHubAuthStateFrame
+      icon={<Github className="size-4 text-[var(--status-info)]" />}
+      iconClassName="border-[var(--status-info-border)] bg-[var(--status-info-muted)]"
+      title="Authorize in GitHub"
+      description="Enter this one-time code at GitHub, then come back here. Sero will finish the connection automatically."
+    >
+      <div className="space-y-3 rounded-lg border border-[var(--status-info-border)] bg-[var(--status-info-muted)]/70 px-3 py-3">
+        <div className="space-y-2">
+          <p className="text-xs text-[var(--text-secondary)]">Enter this code at github.com/login/device:</p>
+          <div className="flex flex-wrap items-center gap-2">
+            <code className="rounded-md border border-[var(--status-info-border)] bg-[var(--bg-base)] px-3 py-2 font-mono text-lg font-bold tracking-[0.25em] text-[var(--status-info)]">
+              {userCode}
+            </code>
+            <Button variant="outline" size="sm" onClick={() => onCopyCode(userCode)}>
+              {copied ? (
+                <>
+                  <Check className="mr-2 size-3.5" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="mr-2 size-3.5" />
+                  Copy code
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+          <Loader2 className="size-3.5 animate-spin" />
+          Waiting for authorization…
+        </div>
+
+        {copyFailed ? (
+          <p className="text-xs text-[var(--status-error)]">Copy failed — enter the code manually.</p>
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="outline" onClick={() => window.open(verificationUri, '_blank', 'noopener,noreferrer')}>
+          <ExternalLink className="mr-2 size-4" />
+          Open GitHub
+        </Button>
+      </div>
+    </GitHubAuthStateFrame>
+  );
+}
+
+export function GitHubAuthPollingView({ onCancel }: { onCancel: () => void }) {
+  return (
+    <GitHubAuthStateFrame
+      icon={<Loader2 className="size-4 animate-spin text-[var(--status-info)]" />}
+      iconClassName="border-[var(--status-info-border)] bg-[var(--status-info-muted)]"
+      title="Waiting for GitHub"
+      description="Finish the device login in your browser. This dialog updates automatically when GitHub responds."
+    >
+      <div className="rounded-lg border border-[var(--status-info-border)] bg-[var(--status-info-muted)]/70 px-3 py-2 text-xs text-[var(--text-secondary)]">
+        Still waiting for authorization…
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </GitHubAuthStateFrame>
+  );
+}
+
+export function GitHubAuthConnectedView({
+  username,
+  onClose,
+  onLogout,
+}: {
+  username: string;
+  onClose: () => void;
+  onLogout: () => void;
+}) {
+  return (
+    <GitHubAuthStateFrame
+      icon={<Check className="size-4 text-[var(--status-success)]" />}
+      iconClassName="border-[var(--status-success-border)] bg-[var(--status-success-muted)]"
+      title="GitHub connected"
+      description="Your GitHub account is ready to use in Sero."
+    >
+      <div className="rounded-lg border border-[var(--status-success-border)] bg-[var(--status-success-muted)]/70 px-3 py-2 text-xs text-[var(--text-secondary)]">
+        Connected as <span className="font-medium text-[var(--text-primary)]">{username}</span>.
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" onClick={onLogout}>
+          Disconnect GitHub
+        </Button>
+        <Button onClick={onClose}>Done</Button>
+      </div>
+    </GitHubAuthStateFrame>
+  );
+}
+
+export function GitHubAuthErrorView({
+  message,
+  onRetry,
+  onClose,
+}: {
+  message: string;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <GitHubAuthStateFrame
+      icon={<AlertCircle className="size-4 text-[var(--status-error)]" />}
+      iconClassName="border-[var(--status-error-border)] bg-[var(--status-error-muted)]"
+      title="GitHub authentication failed"
+      description="Retry the GitHub device login or close this dialog to return where you started."
+    >
+      <div className="rounded-lg border border-[var(--status-error-border)] bg-[var(--status-error-muted)]/70 px-3 py-2 text-xs leading-relaxed text-[var(--status-error)]">
+        {message}
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={onClose}>
+          Close
+        </Button>
+        <Button onClick={onRetry}>Try again</Button>
+      </div>
+    </GitHubAuthStateFrame>
+  );
+}

--- a/apps/desktop/src/components/layout/auth/github/GitHubAuthOutcomeNote.tsx
+++ b/apps/desktop/src/components/layout/auth/github/GitHubAuthOutcomeNote.tsx
@@ -1,0 +1,46 @@
+import { AlertCircle, RotateCcw } from 'lucide-react';
+import { cn } from '@sero-ai/ui/lib/utils';
+
+export interface GitHubAuthOutcomeNoteProps {
+  outcome: 'cancelled' | 'error';
+  message?: string;
+  onRetry: () => void;
+  className?: string;
+}
+
+export function GitHubAuthOutcomeNote({
+  outcome,
+  message,
+  onRetry,
+  className,
+}: GitHubAuthOutcomeNoteProps) {
+  const isError = outcome === 'error';
+  const description = isError
+    ? message ?? 'GitHub login did not complete. Try again when you’re ready.'
+    : 'GitHub is still disconnected. Try again when you’re ready.';
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-2 rounded border px-2 py-1 text-[10px]',
+        isError
+          ? 'border-[var(--status-error-border)] bg-[var(--status-error-muted)]/70 text-[var(--status-error)]'
+          : 'border-[var(--border-subtle)] bg-[var(--bg-elevated)]/20 text-[var(--text-muted)]',
+        className,
+      )}
+    >
+      <span className="min-w-0 flex-1 leading-relaxed">{description}</span>
+      <button
+        type="button"
+        onClick={onRetry}
+        className={cn(
+          'inline-flex shrink-0 items-center gap-1 text-[10px] font-medium transition-colors',
+          isError ? 'hover:text-[var(--status-error)]/80' : 'hover:text-[var(--text-primary)]',
+        )}
+      >
+        {isError ? <AlertCircle className="size-3" /> : <RotateCcw className="size-3" />}
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/auth/github/GitHubAuthSummary.tsx
+++ b/apps/desktop/src/components/layout/auth/github/GitHubAuthSummary.tsx
@@ -1,0 +1,93 @@
+import { Github, Loader2 } from 'lucide-react';
+import { cn } from '@sero-ai/ui/lib/utils';
+import type { GitHubAuthStatus } from '@/types/electron-services';
+
+export interface GitHubAuthSummaryProps {
+  authStatus: GitHubAuthStatus | null;
+  statusReady?: boolean;
+  disconnectedCopy: string;
+  onConnect: () => void;
+  onDisconnect?: () => void;
+  connectLabel?: string;
+  disconnectLabel?: string;
+  className?: string;
+  variant?: 'compact';
+}
+
+export function GitHubAuthSummary({
+  authStatus,
+  statusReady = true,
+  disconnectedCopy,
+  onConnect,
+  onDisconnect,
+  connectLabel = 'Connect GitHub',
+  disconnectLabel = 'Disconnect',
+  className,
+}: GitHubAuthSummaryProps) {
+  if (!statusReady) {
+    return (
+      <div
+        className={cn(
+          'flex items-center gap-1.5 rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/30 px-2 py-1.5 text-[10px] text-[var(--text-muted)]',
+          className,
+        )}
+      >
+        <Loader2 className="size-3 animate-spin" />
+        <span>Checking GitHub status…</span>
+      </div>
+    );
+  }
+
+  if (authStatus?.authenticated) {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-between gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/30 px-2 py-1.5',
+          className,
+        )}
+      >
+        <span className="flex min-w-0 items-center gap-1.5 text-[10px] text-[var(--status-success)]">
+          <Github className="size-3 shrink-0" />
+          <span className="truncate">
+            Connected as <strong>{authStatus.username ?? 'GitHub user'}</strong>
+          </span>
+        </span>
+
+        {onDisconnect ? (
+          <button
+            type="button"
+            onClick={onDisconnect}
+            className="shrink-0 text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--status-error)]"
+          >
+            {disconnectLabel}
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-2 rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/30 px-2 py-2',
+        className,
+      )}
+    >
+      <span className="min-w-0 flex-1 text-[10px] text-[var(--text-muted)]">{disconnectedCopy}</span>
+      <button
+        type="button"
+        onClick={onConnect}
+        className={cn(
+          'shrink-0 rounded px-2 py-0.5 text-[10px] font-medium',
+          'bg-[var(--bg-muted)] text-[var(--text-secondary)]',
+          'transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]',
+        )}
+      >
+        <span className="flex items-center gap-1">
+          <Github className="size-3" />
+          {connectLabel}
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/git-remote/workflow.test.ts
+++ b/apps/desktop/src/components/layout/git-remote/workflow.test.ts
@@ -45,6 +45,23 @@ describe('git remote workflow', () => {
     expect(defaultRepoName('   ', 'workspace-1')).toBe('workspace-1');
   });
 
+  it('returns a structured auth failure before calling GitHub repo creation when disconnected', async () => {
+    seroBridge.github.status.mockResolvedValue({ authenticated: false });
+
+    const result = await createGitHubOrigin({
+      workspaceId: 'workspace-1',
+      name: 'my-workspace',
+      visibility: 'private',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      authStatus: { authenticated: false },
+      reason: 'auth',
+    });
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+  });
+
   it('falls back to the authenticated GitHub URL when repo creation omits url', async () => {
     seroBridge.github.status.mockResolvedValue({ authenticated: true, username: 'octocat' });
     seroBridge.github.createRepo.mockResolvedValue({ success: true, message: 'created' });

--- a/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx
+++ b/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx
@@ -1,0 +1,276 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitHubAuthStatus, GitHubDeviceFlowEvent } from '@/types/electron-services';
+import { GitHubAuthDialog } from '@/components/layout/auth/github/GitHubAuthDialog';
+import { resetGitHubAuthStore, useGitHubAuthStore } from '@/stores/github-auth';
+import { GitRemotePublishSection } from './GitRemotePublishSection';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const seroBridge = {
+  vcs: {
+    addRemote: vi.fn(),
+    setRemoteUrl: vi.fn(),
+  },
+  github: {
+    status: vi.fn(),
+    createRepo: vi.fn(),
+    onEvent: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+    cancel: vi.fn(),
+  },
+};
+
+const originalSeroDescriptor = Object.getOwnPropertyDescriptor(window, 'sero');
+
+function findButton(label: string, index = 0): HTMLButtonElement {
+  const buttons = Array.from(document.querySelectorAll('button')).filter((candidate) =>
+    candidate.textContent?.includes(label),
+  );
+
+  if (!buttons[index]) {
+    throw new Error(`Expected button ${index} with label containing "${label}"`);
+  }
+
+  return buttons[index] as HTMLButtonElement;
+}
+
+function findInput(id: string): HTMLInputElement {
+  const input = document.getElementById(id);
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`Expected input with id "${id}"`);
+  }
+  return input;
+}
+
+async function clickButton(label: string, index = 0): Promise<void> {
+  await act(async () => {
+    findButton(label, index).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+async function setInputValue(id: string, value: string): Promise<void> {
+  const input = findInput(id);
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  if (!valueSetter) {
+    throw new Error('Expected HTMLInputElement value setter');
+  }
+
+  await act(async () => {
+    valueSetter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+describe('GitRemotePublishSection', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+  let githubStatus: GitHubAuthStatus;
+  let githubEventListener: ((event: GitHubDeviceFlowEvent) => void) | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGitHubAuthStore();
+    githubStatus = { authenticated: false };
+    githubEventListener = null;
+
+    seroBridge.vcs.addRemote.mockResolvedValue(undefined);
+    seroBridge.vcs.setRemoteUrl.mockResolvedValue(undefined);
+    seroBridge.github.status.mockImplementation(async () => githubStatus);
+    seroBridge.github.createRepo.mockResolvedValue({
+      success: true,
+      message: 'created',
+      url: 'https://github.com/octocat/workspace-1',
+    });
+    seroBridge.github.login.mockResolvedValue(undefined);
+    seroBridge.github.logout.mockResolvedValue(undefined);
+    seroBridge.github.cancel.mockResolvedValue(undefined);
+    seroBridge.github.onEvent.mockImplementation((callback: (event: GitHubDeviceFlowEvent) => void) => {
+      githubEventListener = callback;
+      return vi.fn(() => {
+        if (githubEventListener === callback) {
+          githubEventListener = null;
+        }
+      });
+    });
+
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      value: seroBridge,
+    });
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+    resetGitHubAuthStore();
+
+    if (originalSeroDescriptor) {
+      Object.defineProperty(window, 'sero', originalSeroDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'sero');
+    }
+  });
+
+  async function renderSection(onPublished = vi.fn()): Promise<ReturnType<typeof vi.fn>> {
+    await act(async () => {
+      root?.render(
+        <>
+          <GitRemotePublishSection
+            workspaceId="workspace-1"
+            workspaceName="Workspace 1"
+            onPublished={onPublished}
+          />
+          <GitHubAuthDialog />
+        </>,
+      );
+    });
+
+    return onPublished;
+  }
+
+  it('connects proactively without auto-creating a repository', async () => {
+    const onPublished = await renderSection();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Connect GitHub');
+      expect(document.body.textContent).not.toContain('sidebar');
+      expect(document.body.textContent).not.toContain('Explorer');
+    });
+
+    await clickButton('Connect GitHub');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+      expect(document.body.textContent).toContain('publishing so you can finish creating and pushing this repository');
+    });
+
+    await act(async () => {
+      githubStatus = { authenticated: true, username: 'octocat' };
+      useGitHubAuthStore.setState({
+        authStatus: githubStatus,
+        statusReady: true,
+      });
+      useGitHubAuthStore.getState().resolveGitHubAuthDialog({
+        outcome: 'success',
+        status: githubStatus,
+      });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Connected as');
+      expect(document.body.textContent).toContain('octocat');
+    });
+
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+    expect(onPublished).not.toHaveBeenCalled();
+  });
+
+  it('keeps a retry path after auth is cancelled from a blocked publish attempt', async () => {
+    await renderSection();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Create repo + publish');
+    });
+
+    await setInputValue('publish-repo-name', 'alpha-repo');
+    await clickButton('Create repo + publish');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub connection required');
+      expect(document.body.textContent).toContain('Connect GitHub');
+    });
+
+    expect(findInput('publish-repo-name').value).toBe('alpha-repo');
+    expect(document.body.textContent).not.toContain('sidebar');
+    expect(document.body.textContent).not.toContain('Explorer');
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+
+    await clickButton('Connect GitHub');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    await act(async () => {
+      await useGitHubAuthStore.getState().dismissGitHubAuthDialog();
+    });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(false);
+      expect(document.body.textContent).toContain('GitHub is still disconnected');
+      expect(document.body.textContent).toContain('Try again');
+    });
+
+    expect(findInput('publish-repo-name').value).toBe('alpha-repo');
+    expect(document.body.textContent).toContain('GitHub connection required');
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+  });
+
+  it('resumes the blocked create-and-publish action after successful auth', async () => {
+    const onPublished = await renderSection();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Create repo + publish');
+    });
+
+    await setInputValue('publish-repo-name', 'alpha-repo');
+    await clickButton('Public');
+    await clickButton('Create repo + publish');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub connection required');
+    });
+
+    await clickButton('Connect GitHub');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    await act(async () => {
+      githubStatus = { authenticated: true, username: 'octocat' };
+      useGitHubAuthStore.setState({
+        authStatus: githubStatus,
+        statusReady: true,
+      });
+      useGitHubAuthStore.getState().resolveGitHubAuthDialog({
+        outcome: 'success',
+        status: githubStatus,
+      });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(seroBridge.github.createRepo).toHaveBeenCalledTimes(1);
+      expect(seroBridge.github.createRepo).toHaveBeenCalledWith('workspace-1', {
+        name: 'alpha-repo',
+        description: undefined,
+        visibility: 'public',
+        addRemote: true,
+      });
+      expect(document.body.textContent).toContain('Repository published and origin connected.');
+    });
+
+    expect(onPublished).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx
+++ b/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx
@@ -226,6 +226,57 @@ describe('GitRemotePublishSection', () => {
     expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
   });
 
+  it('shows a retryable generic auth failure after a blocked publish attempt', async () => {
+    await renderSection();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Create repo + publish');
+    });
+
+    await setInputValue('publish-repo-name', 'alpha-repo');
+    await clickButton('Create repo + publish');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub connection required');
+    });
+
+    await clickButton('Connect GitHub');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    await act(async () => {
+      useGitHubAuthStore.setState({
+        authStatus: { authenticated: false },
+        statusReady: true,
+        flow: { step: 'error', message: 'Device flow failed' },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub authentication failed');
+      expect(document.body.textContent).toContain('Device flow failed');
+    });
+
+    await clickButton('Close', 1);
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(false);
+      expect(document.body.textContent).toContain('Device flow failed');
+      expect(document.body.textContent).toContain('Try again');
+    });
+
+    expect(findInput('publish-repo-name').value).toBe('alpha-repo');
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+
+    await clickButton('Try again');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+  });
+
   it('resumes the blocked create-and-publish action after successful auth', async () => {
     const onPublished = await renderSection();
 

--- a/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx
+++ b/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx
@@ -1,16 +1,15 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Input } from '@sero-ai/ui/components/ui/input';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { Globe, Github, Link2, Loader2, Lock, Rocket } from 'lucide-react';
-import type { GitHubAuthStatus } from '@/types/electron-services';
-import {
-  connectOrigin,
-  createGitHubOrigin,
-  defaultRepoName,
-  loadGitHubStatus,
-} from '../../git-remote/workflow';
+import { GitHubAuthOutcomeNote } from '@/components/layout/auth/github/GitHubAuthOutcomeNote';
+import { GitHubAuthSummary } from '@/components/layout/auth/github/GitHubAuthSummary';
+import type { GitHubAuthDialogResult } from '@/stores/github-auth';
+import { useGitHubAuthStore } from '@/stores/github-auth';
+import { connectOrigin, createGitHubOrigin, defaultRepoName } from '../../git-remote/workflow';
 
 interface PublishFeedback {
   tone: 'success' | 'error' | 'info';
@@ -24,44 +23,84 @@ interface GitRemotePublishSectionProps {
   onPublished: () => Promise<void> | void;
 }
 
+type PublishGitHubAuthOutcome = Extract<GitHubAuthDialogResult, { outcome: 'cancelled' | 'error' }>;
+
 export function GitRemotePublishSection({
   workspaceId,
   workspaceName,
   onPublished,
 }: GitRemotePublishSectionProps) {
+  const {
+    authStatus,
+    statusReady,
+    init,
+    openGitHubAuthDialog,
+    refreshStatus,
+  } = useGitHubAuthStore(
+    useShallow((state) => ({
+      authStatus: state.authStatus,
+      statusReady: state.statusReady,
+      init: state.init,
+      openGitHubAuthDialog: state.openGitHubAuthDialog,
+      refreshStatus: state.refreshStatus,
+    })),
+  );
   const [mode, setMode] = useState<'github' | 'existing'>('github');
   const [name, setName] = useState(defaultRepoName(workspaceName, workspaceId));
   const [visibility, setVisibility] = useState<'public' | 'private'>('private');
   const [remoteUrl, setRemoteUrl] = useState('');
   const [action, setAction] = useState<'github' | 'existing' | null>(null);
-  const [githubStatus, setGitHubStatus] = useState<GitHubAuthStatus | null>(null);
   const [feedback, setFeedback] = useState<PublishFeedback | null>(null);
+  const [authRequired, setAuthRequired] = useState(false);
+  const [lastAuthOutcome, setLastAuthOutcome] = useState<PublishGitHubAuthOutcome | null>(null);
+  const mountedRef = useRef(false);
+  const authLaunchInFlightRef = useRef(false);
+  const resumeBlockedPublishRef = useRef(false);
 
   useEffect(() => {
-    let active = true;
+    mountedRef.current = true;
+    void init();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [init]);
+
+  useEffect(() => {
     setFeedback(null);
     setName(defaultRepoName(workspaceName, workspaceId));
     setRemoteUrl('');
-
-    void loadGitHubStatus().then((status) => {
-      if (!active) return;
-      setGitHubStatus(status);
-    });
-
-    return () => {
-      active = false;
-    };
+    setAuthRequired(false);
+    setLastAuthOutcome(null);
+    resumeBlockedPublishRef.current = false;
   }, [workspaceId, workspaceName]);
 
-  const githubHint = useMemo(() => {
-    if (!githubStatus) return 'Checking GitHub login…';
-    if (githubStatus.authenticated) {
-      return githubStatus.username
-        ? `Connected as ${githubStatus.username}. Create and wire an origin in one step.`
+  useEffect(() => {
+    if (!authStatus?.authenticated) return;
+    setAuthRequired(false);
+    setLastAuthOutcome(null);
+  }, [authStatus?.authenticated]);
+
+  const githubNoticeDescription = useMemo(() => {
+    if (!statusReady) {
+      return 'Checking your GitHub connection before publishing this workspace.';
+    }
+
+    if (authStatus?.authenticated) {
+      return authStatus.username
+        ? `Connected as ${authStatus.username}. Create and wire an origin in one step.`
         : 'GitHub connected. Create and wire an origin in one step.';
     }
-    return 'Connect GitHub in the sidebar to create a repository from here.';
-  }, [githubStatus]);
+
+    if (authRequired) {
+      return 'Connect GitHub to finish creating and publishing this repository without leaving the title bar.';
+    }
+
+    return 'Connect GitHub now, or start publishing first and Sero will pause here until auth is ready.';
+  }, [authRequired, authStatus?.authenticated, authStatus?.username, statusReady]);
+
+  const githubDisconnectedCopy = authRequired
+    ? 'GitHub needs to be connected before Sero can create and publish this repository.'
+    : 'Connect GitHub to create and publish a repository from here.';
 
   const handleCreateGitHub = async () => {
     const trimmed = name.trim();
@@ -69,6 +108,7 @@ export function GitRemotePublishSection({
 
     setAction('github');
     setFeedback(null);
+    setLastAuthOutcome(null);
     try {
       const result = await createGitHubOrigin({
         workspaceId,
@@ -76,33 +116,86 @@ export function GitRemotePublishSection({
         visibility,
       });
 
+      if (!mountedRef.current) return;
+
       if (!result.ok) {
+        if (result.reason === 'auth') {
+          const status = await refreshStatus();
+          if (!mountedRef.current) return;
+          resumeBlockedPublishRef.current = !status.authenticated;
+          setAuthRequired(!status.authenticated);
+          return;
+        }
+
+        resumeBlockedPublishRef.current = false;
+        setAuthRequired(false);
         setFeedback({
           tone: 'error',
           message:
-            result.reason === 'auth'
-              ? 'GitHub is not connected. Connect it in the sidebar first, then retry.'
-              : result.reason === 'missing-url'
-                ? 'Repository was created, but Sero could not determine its URL. Refresh and reconnect if needed.'
-                : (result.message ?? 'Failed to publish to GitHub'),
+            result.reason === 'missing-url'
+              ? 'Repository was created, but Sero could not determine its URL. Refresh and reconnect if needed.'
+              : (result.message ?? 'Failed to publish to GitHub'),
           url: result.url,
         });
         return;
       }
 
+      resumeBlockedPublishRef.current = false;
+      setAuthRequired(false);
       await onPublished();
+      if (!mountedRef.current) return;
       setFeedback({
         tone: 'success',
         message: 'Repository published and origin connected.',
         url: result.url,
       });
     } catch (error) {
+      if (!mountedRef.current) return;
+      resumeBlockedPublishRef.current = false;
+      setAuthRequired(false);
       setFeedback({
         tone: 'error',
         message: error instanceof Error ? error.message : 'Failed to publish to GitHub',
       });
     } finally {
-      setAction(null);
+      if (mountedRef.current) {
+        setAction(null);
+      }
+    }
+  };
+
+  const handleConnectGitHub = async ({ resumeBlockedPublish }: { resumeBlockedPublish: boolean }) => {
+    if (authLaunchInFlightRef.current) return;
+
+    authLaunchInFlightRef.current = true;
+    resumeBlockedPublishRef.current = resumeBlockedPublish;
+    setFeedback(null);
+    setLastAuthOutcome(null);
+
+    try {
+      const result = await openGitHubAuthDialog({ source: 'publish' });
+      if (!mountedRef.current) return;
+
+      const status = await refreshStatus();
+      if (!mountedRef.current) return;
+
+      if (result.outcome !== 'success' || !status.authenticated) {
+        setAuthRequired(resumeBlockedPublish && !status.authenticated);
+        if (result.outcome !== 'success') {
+          setLastAuthOutcome(result);
+        }
+        return;
+      }
+
+      setAuthRequired(false);
+      if (!resumeBlockedPublishRef.current) {
+        return;
+      }
+
+      resumeBlockedPublishRef.current = false;
+      await handleCreateGitHub();
+    } finally {
+      authLaunchInFlightRef.current = false;
     }
   };
 
@@ -149,13 +242,48 @@ export function GitRemotePublishSection({
 
       {mode === 'github' ? (
         <div className="space-y-3">
-          <div className="rounded-lg border border-[var(--status-info-border)] bg-[var(--status-info-faint)] px-3 py-2 text-[11px] leading-relaxed text-[var(--text-secondary)]">
-            {githubHint}
+          <div
+            className={cn(
+              'space-y-3 rounded-lg border px-3 py-3',
+              authRequired
+                ? 'border-[var(--status-info-border)] bg-[var(--status-info-faint)]'
+                : 'border-[var(--border-subtle)] bg-[var(--bg-base)]',
+            )}
+          >
+            <div className="space-y-1">
+              <p className="text-[11px] font-medium text-[var(--text-primary)]">
+                {authRequired ? 'GitHub connection required' : 'GitHub connection'}
+              </p>
+              <p className="text-[11px] leading-relaxed text-[var(--text-secondary)]">
+                {githubNoticeDescription}
+              </p>
+            </div>
+
+            <GitHubAuthSummary
+              authStatus={authStatus}
+              statusReady={statusReady}
+              disconnectedCopy={githubDisconnectedCopy}
+              onConnect={() => {
+                void handleConnectGitHub({ resumeBlockedPublish: authRequired });
+              }}
+              className="bg-[var(--bg-elevated)]/30"
+            />
+
+            {!authStatus?.authenticated && lastAuthOutcome ? (
+              <GitHubAuthOutcomeNote
+                outcome={lastAuthOutcome.outcome}
+                message={lastAuthOutcome.outcome === 'error' ? lastAuthOutcome.message : undefined}
+                onRetry={() => {
+                  void handleConnectGitHub({ resumeBlockedPublish: authRequired });
+                }}
+              />
+            ) : null}
           </div>
 
           <label className="space-y-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-muted)]">
             <span>Repository name</span>
             <Input
+              id="publish-repo-name"
               value={name}
               onChange={(event) => setName(event.target.value)}
               placeholder="my-project"
@@ -197,6 +325,7 @@ export function GitRemotePublishSection({
           <label className="space-y-1 text-[10px] uppercase tracking-[0.16em] text-[var(--text-muted)]">
             <span>Remote URL</span>
             <Input
+              id="publish-remote-url"
               value={remoteUrl}
               onChange={(event) => setRemoteUrl(event.target.value)}
               placeholder="https://github.com/you/repo.git"
@@ -290,4 +419,3 @@ function VisibilityButton({
     </button>
   );
 }
-

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginGitHubAuthNotice.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginGitHubAuthNotice.tsx
@@ -1,0 +1,58 @@
+import { cn } from '@sero-ai/ui/lib/utils';
+import type { GitHubAuthStatus } from '@/types/electron-services';
+import type { GitHubAuthDialogResult } from '@/stores/github-auth';
+import { GitHubAuthOutcomeNote } from '@/components/layout/auth/github/GitHubAuthOutcomeNote';
+import { GitHubAuthSummary } from '@/components/layout/auth/github/GitHubAuthSummary';
+
+export type RemoteOriginGitHubAuthOutcome = Extract<
+  GitHubAuthDialogResult,
+  { outcome: 'cancelled' | 'error' }
+>;
+
+interface RemoteOriginGitHubAuthNoticeProps {
+  authStatus: GitHubAuthStatus | null;
+  statusReady: boolean;
+  lastOutcome: RemoteOriginGitHubAuthOutcome | null;
+  onConnect: () => void;
+  className?: string;
+}
+
+export function RemoteOriginGitHubAuthNotice({
+  authStatus,
+  statusReady,
+  lastOutcome,
+  onConnect,
+  className,
+}: RemoteOriginGitHubAuthNoticeProps) {
+  return (
+    <div
+      className={cn(
+        'space-y-3 rounded-lg border border-[var(--status-info)]/20 bg-[var(--status-info)]/5 p-3',
+        className,
+      )}
+    >
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-[var(--text-primary)]">GitHub connection required</p>
+        <p className="text-xs leading-relaxed text-[var(--text-secondary)]">
+          Connect GitHub to create this repository without leaving this form.
+        </p>
+      </div>
+
+      <GitHubAuthSummary
+        authStatus={authStatus}
+        statusReady={statusReady}
+        disconnectedCopy="GitHub needs to be connected before Sero can create this repository."
+        onConnect={onConnect}
+        className="bg-[var(--bg-base)]/70"
+      />
+
+      {!authStatus?.authenticated && lastOutcome ? (
+        <GitHubAuthOutcomeNote
+          outcome={lastOutcome.outcome}
+          message={lastOutcome.outcome === 'error' ? lastOutcome.message : undefined}
+          onRetry={onConnect}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
@@ -3,7 +3,10 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitHubAuthStatus, GitHubDeviceFlowEvent } from '@/types/electron-services';
 import type { WorkspaceInfo } from '@/types/ipc';
+import { resetGitHubAuthStore, useGitHubAuthStore } from '@/stores/github-auth';
+import { GitHubAuthDialog } from '../auth/github/GitHubAuthDialog';
 import { RemoteOriginManager } from './RemoteOriginManager';
 
 (
@@ -19,6 +22,10 @@ const seroBridge = {
   github: {
     status: vi.fn(),
     createRepo: vi.fn(),
+    onEvent: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+    cancel: vi.fn(),
   },
 };
 
@@ -34,23 +41,80 @@ const workspace: WorkspaceInfo = {
   roots: [],
 };
 
-function findButton(label: string): HTMLButtonElement {
-  const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
+function findButton(label: string, index = 0): HTMLButtonElement {
+  const buttons = Array.from(document.querySelectorAll('button')).filter((candidate) =>
     candidate.textContent?.includes(label),
   );
-  if (!button) {
-    throw new Error(`Expected button with label containing "${label}"`);
+
+  if (!buttons[index]) {
+    throw new Error(`Expected button ${index} with label containing "${label}"`);
   }
-  return button as HTMLButtonElement;
+
+  return buttons[index] as HTMLButtonElement;
+}
+
+function findInput(id: string): HTMLInputElement {
+  const input = document.getElementById(id);
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`Expected input with id "${id}"`);
+  }
+  return input;
+}
+
+async function clickButton(label: string, index = 0): Promise<void> {
+  await act(async () => {
+    findButton(label, index).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await Promise.resolve();
+  });
+}
+
+async function setInputValue(id: string, value: string): Promise<void> {
+  const input = findInput(id);
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  if (!valueSetter) {
+    throw new Error('Expected HTMLInputElement value setter');
+  }
+
+  await act(async () => {
+    valueSetter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    await Promise.resolve();
+  });
 }
 
 describe('RemoteOriginManager', () => {
   let container: HTMLDivElement;
   let root: Root | null = null;
+  let githubStatus: GitHubAuthStatus;
+  let githubEventListener: ((event: GitHubDeviceFlowEvent) => void) | null = null;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    seroBridge.vcs.remotes.mockRejectedValue(new Error('remote lookup failed'));
+    resetGitHubAuthStore();
+    githubStatus = { authenticated: false };
+    githubEventListener = null;
+
+    seroBridge.vcs.remotes.mockResolvedValue([]);
+    seroBridge.vcs.addRemote.mockResolvedValue(undefined);
+    seroBridge.vcs.setRemoteUrl.mockResolvedValue(undefined);
+    seroBridge.github.status.mockImplementation(async () => githubStatus);
+    seroBridge.github.createRepo.mockResolvedValue({
+      success: true,
+      message: 'created',
+      url: 'https://github.com/octocat/workspace-1',
+    });
+    seroBridge.github.login.mockResolvedValue(undefined);
+    seroBridge.github.logout.mockResolvedValue(undefined);
+    seroBridge.github.cancel.mockResolvedValue(undefined);
+    seroBridge.github.onEvent.mockImplementation((callback: (event: GitHubDeviceFlowEvent) => void) => {
+      githubEventListener = callback;
+      return vi.fn(() => {
+        if (githubEventListener === callback) {
+          githubEventListener = null;
+        }
+      });
+    });
 
     Object.defineProperty(window, 'sero', {
       configurable: true,
@@ -70,6 +134,7 @@ describe('RemoteOriginManager', () => {
     }
     root = null;
     container.remove();
+    resetGitHubAuthStore();
 
     if (originalSeroDescriptor) {
       Object.defineProperty(window, 'sero', originalSeroDescriptor);
@@ -78,7 +143,24 @@ describe('RemoteOriginManager', () => {
     }
   });
 
+  async function renderManager(): Promise<void> {
+    await act(async () => {
+      root?.render(
+        <>
+          <RemoteOriginManager
+            open
+            onOpenChange={vi.fn()}
+            workspace={workspace}
+          />
+          <GitHubAuthDialog />
+        </>,
+      );
+    });
+  }
+
   it('shows origin-load failures instead of treating them as no origin', async () => {
+    seroBridge.vcs.remotes.mockRejectedValue(new Error('remote lookup failed'));
+
     await act(async () => {
       root?.render(
         <RemoteOriginManager
@@ -101,6 +183,110 @@ describe('RemoteOriginManager', () => {
 
     await vi.waitFor(() => {
       expect(seroBridge.vcs.remotes).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('keeps the create form state and retry path after auth is cancelled from the shared dialog', async () => {
+    await renderManager();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Create new on GitHub');
+    });
+
+    await clickButton('Create new on GitHub');
+    await setInputValue('repo-name', 'alpha-repo');
+    await setInputValue('repo-desc', 'Alpha description');
+    await clickButton('Public');
+    await clickButton('Create Repository');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub connection required');
+      expect(document.body.textContent).toContain('Connect GitHub');
+    });
+
+    expect(findInput('repo-name').value).toBe('alpha-repo');
+    expect(findInput('repo-desc').value).toBe('Alpha description');
+    expect(document.body.textContent).not.toContain('sidebar first');
+    expect(document.body.textContent).not.toContain('Explorer');
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+
+    await clickButton('Connect GitHub');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+      expect(document.body.textContent).toContain('remote creation so you can finish creating this repository');
+    });
+
+    await act(async () => {
+      await useGitHubAuthStore.getState().dismissGitHubAuthDialog();
+    });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(false);
+      expect(document.body.textContent).toContain('GitHub is still disconnected');
+      expect(document.body.textContent).toContain('Try again');
+    });
+
+    expect(findInput('repo-name').value).toBe('alpha-repo');
+    expect(findInput('repo-desc').value).toBe('Alpha description');
+    expect(document.body.textContent).toContain('GitHub connection required');
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+  });
+
+  it('resumes the blocked create action after successful auth without losing form values', async () => {
+    seroBridge.github.createRepo.mockResolvedValue({
+      success: true,
+      message: 'created',
+      url: 'https://github.com/octocat/alpha-repo',
+    });
+
+    await renderManager();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Create new on GitHub');
+    });
+
+    await clickButton('Create new on GitHub');
+    await setInputValue('repo-name', 'alpha-repo');
+    await setInputValue('repo-desc', 'Alpha description');
+    await clickButton('Public');
+    await clickButton('Create Repository');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub connection required');
+    });
+
+    await clickButton('Connect GitHub');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    expect(findInput('repo-name').value).toBe('alpha-repo');
+    expect(findInput('repo-desc').value).toBe('Alpha description');
+
+    await act(async () => {
+      githubStatus = { authenticated: true, username: 'octocat' };
+      useGitHubAuthStore.setState({
+        authStatus: githubStatus,
+        statusReady: true,
+      });
+      useGitHubAuthStore.getState().resolveGitHubAuthDialog({
+        outcome: 'success',
+        status: githubStatus,
+      });
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(seroBridge.github.createRepo).toHaveBeenCalledTimes(1);
+      expect(seroBridge.github.createRepo).toHaveBeenCalledWith('workspace-1', {
+        name: 'alpha-repo',
+        description: 'Alpha description',
+        visibility: 'public',
+        addRemote: true,
+      });
+      expect(document.body.textContent).toContain('octocat/alpha-repo');
     });
   });
 });

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
@@ -233,6 +233,60 @@ describe('RemoteOriginManager', () => {
     expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
   });
 
+  it('shows a retryable generic auth failure without losing create form values', async () => {
+    await renderManager();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Create new on GitHub');
+    });
+
+    await clickButton('Create new on GitHub');
+    await setInputValue('repo-name', 'alpha-repo');
+    await setInputValue('repo-desc', 'Alpha description');
+    await clickButton('Create Repository');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub connection required');
+    });
+
+    await clickButton('Connect GitHub');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    await act(async () => {
+      useGitHubAuthStore.setState({
+        authStatus: { authenticated: false },
+        statusReady: true,
+        flow: { step: 'error', message: 'Device flow failed' },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('GitHub authentication failed');
+      expect(document.body.textContent).toContain('Device flow failed');
+    });
+
+    await clickButton('Close', 1);
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(false);
+      expect(document.body.textContent).toContain('Device flow failed');
+      expect(document.body.textContent).toContain('Try again');
+    });
+
+    expect(findInput('repo-name').value).toBe('alpha-repo');
+    expect(findInput('repo-desc').value).toBe('Alpha description');
+    expect(seroBridge.github.createRepo).not.toHaveBeenCalled();
+
+    await clickButton('Try again');
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+  });
+
   it('resumes the blocked create action after successful auth without losing form values', async () => {
     seroBridge.github.createRepo.mockResolvedValue({
       success: true,

--- a/apps/desktop/src/components/layout/workspace/remote-origin-views.tsx
+++ b/apps/desktop/src/components/layout/workspace/remote-origin-views.tsx
@@ -4,7 +4,8 @@
  * Extracted to keep RemoteOriginManager.tsx under 500 LOC.
  */
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Input } from '@sero-ai/ui/components/ui/input';
 import { Label } from '@sero-ai/ui/components/ui/label';
@@ -21,6 +22,7 @@ import {
 } from 'lucide-react';
 import { IconAction } from '@/components/ui/IconAction';
 import type { WorkspaceInfo } from '@/types/ipc';
+import { useGitHubAuthStore } from '@/stores/github-auth';
 import {
   connectOrigin,
   createGitHubOrigin,
@@ -30,6 +32,10 @@ import {
   type GitRemoteOriginInfo,
   type GitRemoteVisibility,
 } from '../git-remote/workflow';
+import {
+  RemoteOriginGitHubAuthNotice,
+  type RemoteOriginGitHubAuthOutcome,
+} from './RemoteOriginGitHubAuthNotice';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -96,49 +102,121 @@ export function CreateGitHubView({
   onBack: () => void;
   onCreated: (url: string) => void;
 }) {
+  const {
+    authStatus,
+    statusReady,
+    openGitHubAuthDialog,
+    refreshStatus,
+  } = useGitHubAuthStore(
+    useShallow((state) => ({
+      authStatus: state.authStatus,
+      statusReady: state.statusReady,
+      openGitHubAuthDialog: state.openGitHubAuthDialog,
+      refreshStatus: state.refreshStatus,
+    })),
+  );
   const [name, setName] = useState(() => defaultRepoName(workspace.name, workspace.id));
   const [description, setDescription] = useState(workspace.description ?? '');
   const [visibility, setVisibility] = useState<Visibility>('private');
   const [isCreating, setIsCreating] = useState(false);
+  const [authRequired, setAuthRequired] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastAuthOutcome, setLastAuthOutcome] = useState<RemoteOriginGitHubAuthOutcome | null>(null);
+  const mountedRef = useRef(false);
+  const authLaunchInFlightRef = useRef(false);
 
-  const handleCreate = async () => {
-    const trimmed = name.trim();
-    if (!trimmed || isCreating) return;
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!authStatus?.authenticated) return;
+    setAuthRequired(false);
+    setLastAuthOutcome(null);
+  }, [authStatus?.authenticated]);
+
+  const handleCreate = useCallback(async () => {
+    const trimmedName = name.trim();
+    if (!trimmedName || isCreating) return;
 
     setIsCreating(true);
     setError(null);
+    setLastAuthOutcome(null);
+
     try {
       const result = await createGitHubOrigin({
         workspaceId: workspace.id,
-        name: trimmed,
+        name: trimmedName,
         description: description.trim() || undefined,
         visibility,
       });
 
+      if (!mountedRef.current) return;
+
       if (result.ok) {
+        setAuthRequired(false);
         onCreated(result.url);
         return;
       }
 
       if (result.reason === 'auth') {
-        setError('Not authenticated with GitHub. Connect your GitHub account in the sidebar first.');
-      } else if (result.reason === 'missing-url') {
+        await refreshStatus();
+        if (!mountedRef.current) return;
+        setAuthRequired(true);
+        return;
+      }
+
+      setAuthRequired(false);
+      if (result.reason === 'missing-url') {
         setError('Repository created, but Sero could not determine its URL. Refresh remotes and reconnect if needed.');
       } else {
         setError(result.message ?? 'Failed to create repository');
       }
     } catch (err) {
+      if (!mountedRef.current) return;
+      setAuthRequired(false);
       setError(err instanceof Error ? err.message : 'Unknown error');
     } finally {
-      setIsCreating(false);
+      if (mountedRef.current) {
+        setIsCreating(false);
+      }
     }
-  };
+  }, [description, isCreating, name, onCreated, refreshStatus, visibility, workspace.id]);
+
+  const handleConnectGitHub = useCallback(async () => {
+    if (authLaunchInFlightRef.current) return;
+
+    authLaunchInFlightRef.current = true;
+    setLastAuthOutcome(null);
+
+    try {
+      const result = await openGitHubAuthDialog({ source: 'remote-origin' });
+      if (!mountedRef.current) return;
+
+      const status = await refreshStatus();
+      if (!mountedRef.current) return;
+
+      if (result.outcome !== 'success' || !status.authenticated) {
+        setAuthRequired(!status.authenticated);
+        if (result.outcome !== 'success') {
+          setLastAuthOutcome(result);
+        }
+        return;
+      }
+
+      await handleCreate();
+    } finally {
+      authLaunchInFlightRef.current = false;
+    }
+  }, [handleCreate, openGitHubAuthDialog, refreshStatus]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !isCreating && name.trim()) {
       e.preventDefault();
-      handleCreate();
+      void handleCreate();
     }
   };
 
@@ -194,11 +272,24 @@ export function CreateGitHubView({
         </div>
       </div>
 
+      {authRequired ? (
+        <RemoteOriginGitHubAuthNotice
+          authStatus={authStatus}
+          statusReady={statusReady}
+          lastOutcome={lastAuthOutcome}
+          onConnect={() => {
+            void handleConnectGitHub();
+          }}
+        />
+      ) : null}
+
       {error && <ErrorBanner message={error} />}
 
       <div className="flex justify-end gap-2 pt-1">
         <Button variant="ghost" onClick={onBack} disabled={isCreating}>Cancel</Button>
-        <Button onClick={handleCreate} disabled={isCreating || !name.trim()}>
+        <Button onClick={() => {
+          void handleCreate();
+        }} disabled={isCreating || !name.trim()}>
           {isCreating ? (
             <><Loader2 className="mr-1.5 size-3.5 animate-spin" />Creating…</>
           ) : (

--- a/apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.test.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.test.tsx
@@ -58,7 +58,38 @@ describe('GitHubConnectCard', () => {
     expect(container.textContent).toContain('continue setup without it');
     expect(container.textContent).toContain('Try again');
     expect(container.textContent).not.toContain('Explorer');
+    expect(container.textContent).not.toContain('sidebar');
     expect(container.textContent).not.toContain('github.com/login/device');
+
+    await act(async () => {
+      findButton('Try again').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows generic auth failures with a retry path that stays inside onboarding', async () => {
+    const onConnect = vi.fn();
+
+    await act(async () => {
+      root?.render(
+        <GitHubConnectCard
+          authStatus={{ authenticated: false }}
+          statusReady
+          lastOutcome={{
+            outcome: 'error',
+            status: { authenticated: false },
+            message: 'GitHub login failed.',
+          }}
+          onConnect={onConnect}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('GitHub login failed.');
+    expect(container.textContent).toContain('Try again');
+    expect(container.textContent).not.toContain('Explorer');
+    expect(container.textContent).not.toContain('sidebar');
 
     await act(async () => {
       findButton('Try again').dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.test.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitHubConnectCard } from './GitHubConnectCard';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function findButton(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(label),
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected button with label containing "${label}"`);
+  }
+  return button;
+}
+
+describe('GitHubConnectCard', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+  });
+
+  it('shows contextual onboarding copy with a retry path and no inline device-flow instructions', async () => {
+    const onConnect = vi.fn();
+
+    await act(async () => {
+      root?.render(
+        <GitHubConnectCard
+          authStatus={{ authenticated: false }}
+          statusReady
+          lastOutcome={{ outcome: 'cancelled', status: { authenticated: false } }}
+          onConnect={onConnect}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Connect GitHub');
+    expect(container.textContent).toContain('continue setup without it');
+    expect(container.textContent).toContain('Try again');
+    expect(container.textContent).not.toContain('Explorer');
+    expect(container.textContent).not.toContain('github.com/login/device');
+
+    await act(async () => {
+      findButton('Try again').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a connected state that points users back to the existing continue action', async () => {
+    await act(async () => {
+      root?.render(
+        <GitHubConnectCard
+          authStatus={{ authenticated: true, username: 'octocat' }}
+          statusReady
+          lastOutcome={null}
+          onConnect={vi.fn()}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('Connected as octocat');
+    expect(container.textContent).toContain("Continue to memory setup when you're ready.");
+    expect(container.textContent).not.toContain('Try again');
+  });
+});

--- a/apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/GitHubConnectCard.tsx
@@ -1,40 +1,51 @@
-import { Check, Copy, Github, Loader2, X } from 'lucide-react';
-import { Button } from '@sero-ai/ui/components/ui/button';
+import { Github } from 'lucide-react';
+import { cn } from '@sero-ai/ui/lib/utils';
 import type { GitHubAuthStatus } from '@/types/electron-services';
-import type { GitHubFlowState } from '@/hooks/useGitHubAuthFlow';
+import { GitHubAuthOutcomeNote } from '@/components/layout/auth/github/GitHubAuthOutcomeNote';
+import { GitHubAuthSummary } from '@/components/layout/auth/github/GitHubAuthSummary';
+import type { GitHubAuthDialogResult } from '@/stores/github-auth';
+
+type GitHubConnectCardOutcome = Extract<GitHubAuthDialogResult, { outcome: 'cancelled' | 'error' }>;
 
 interface GitHubConnectCardProps {
   authStatus: GitHubAuthStatus | null;
   statusReady: boolean;
-  flow: GitHubFlowState;
-  copied: boolean;
-  copyFailed: boolean;
-  showConnectedState?: boolean;
-  onStartLogin: () => void;
-  onCancel: () => void;
-  onCopyCode: (code: string) => void;
+  lastOutcome: GitHubConnectCardOutcome | null;
+  onConnect: () => void;
 }
 
 export function GitHubConnectCard({
   authStatus,
   statusReady,
-  flow,
-  copied,
-  copyFailed,
-  showConnectedState = false,
-  onStartLogin,
-  onCancel,
-  onCopyCode,
+  lastOutcome,
+  onConnect,
 }: GitHubConnectCardProps) {
-  if (!statusReady) return null;
-  if (authStatus?.authenticated && flow.step === 'idle' && !showConnectedState) return null;
+  const connected = Boolean(authStatus?.authenticated);
 
   return (
-    <div className="rounded-lg border border-[var(--status-info)]/20 bg-[var(--status-info)]/5 px-4 py-3">
+    <div
+      className={cn(
+        'rounded-lg border px-4 py-3',
+        connected
+          ? 'border-[var(--status-success)]/20 bg-[var(--status-success)]/5'
+          : 'border-[var(--status-info)]/20 bg-[var(--status-info)]/5',
+      )}
+    >
       <div className="flex items-start gap-3">
-        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-          <Github className="size-4 text-[var(--text-primary)]" />
+        <div
+          className={cn(
+            'flex size-9 shrink-0 items-center justify-center rounded-lg',
+            connected ? 'bg-[var(--status-success-muted)]/70' : 'bg-[var(--bg-elevated)]',
+          )}
+        >
+          <Github
+            className={cn(
+              'size-4',
+              connected ? 'text-[var(--status-success)]' : 'text-[var(--text-primary)]',
+            )}
+          />
         </div>
+
         <div className="min-w-0 flex-1 space-y-3">
           <div className="space-y-1">
             <div className="flex items-center gap-2">
@@ -44,94 +55,32 @@ export function GitHubConnectCard({
               </span>
             </div>
             <p className="text-xs text-[var(--text-secondary)]">
-              Strongly suggested if you work with repos. You can skip this for now and connect later from Explorer.
+              Connect now to enable clone, push, fetch, and pull request workflows in Sero. You
+              can continue setup without it and connect later when a GitHub task needs it.
             </p>
           </div>
 
-          {flow.step === 'idle' && !authStatus?.authenticated ? (
-            <div className="flex flex-wrap items-center gap-2">
-              <Button size="sm" onClick={onStartLogin}>
-                <Github className="mr-2 size-3.5" />
-                Connect GitHub
-              </Button>
-              <span className="text-[11px] text-[var(--text-muted)]">
-                Enables clone, commit, push, fetch, and PR workflows.
-              </span>
-            </div>
+          <GitHubAuthSummary
+            authStatus={authStatus}
+            statusReady={statusReady}
+            disconnectedCopy="Connect GitHub to enable repo workflows in Sero."
+            onConnect={onConnect}
+            className="bg-[var(--bg-base)]/70"
+          />
+
+          {!connected && lastOutcome ? (
+            <GitHubAuthOutcomeNote
+              outcome={lastOutcome.outcome}
+              message={lastOutcome.outcome === 'error' ? lastOutcome.message : undefined}
+              onRetry={onConnect}
+            />
           ) : null}
 
-          {flow.step === 'code' ? (
-            <div className="space-y-2">
-              <p className="text-xs text-[var(--text-secondary)]">
-                Enter this code at{' '}
-                <a
-                  href={flow.verificationUri}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-[var(--status-info)] underline"
-                >
-                  github.com/login/device
-                </a>
-              </p>
-              <div className="flex flex-wrap items-center gap-2">
-                <code className="rounded border border-[var(--status-info)]/20 bg-[var(--bg-base)] px-2.5 py-1 font-mono text-sm font-bold tracking-widest text-[var(--status-info)]">
-                  {flow.userCode}
-                </code>
-                <button
-                  onClick={() => onCopyCode(flow.userCode)}
-                  title="Copy code"
-                  className="text-[var(--text-muted)] transition-colors hover:text-[var(--status-info)]"
-                >
-                  {copied ? <Check className="size-4 text-[var(--status-success)]" /> : <Copy className="size-4" />}
-                </button>
-                <button
-                  onClick={onCancel}
-                  title="Cancel"
-                  className="text-[var(--text-muted)] transition-colors hover:text-[var(--status-error)]"
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-              <p className="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
-                <Loader2 className="size-3.5 animate-spin" />
-                Waiting for authorization. Continue below to skip for now.
-              </p>
-              {copyFailed ? (
-                <p className="text-[11px] text-[var(--status-error)]">
-                  Copy failed — enter the code manually.
-                </p>
-              ) : null}
-            </div>
-          ) : null}
-
-          {flow.step === 'polling' ? (
-            <div className="flex items-center gap-2 text-[11px] text-[var(--text-muted)]">
-              <Loader2 className="size-3.5 animate-spin" />
-              Waiting for authorization…
-              <button
-                onClick={onCancel}
-                className="ml-auto text-[var(--text-muted)] transition-colors hover:text-[var(--status-error)]"
-              >
-                <X className="size-4" />
-              </button>
-            </div>
-          ) : null}
-
-          {flow.step === 'success' || (showConnectedState && authStatus?.authenticated && flow.step === 'idle') ? (
-            <div className="flex items-center gap-2 text-xs text-[var(--status-success)]">
-              <Check className="size-4" />
-              Connected as <strong>{flow.step === 'success' ? flow.username : (authStatus?.username ?? 'GitHub user')}</strong>
-            </div>
-          ) : null}
-
-          {flow.step === 'error' ? (
-            <div className="space-y-2">
-              <p className="text-xs text-[var(--status-error)]">{flow.message}</p>
-              <Button size="sm" variant="outline" onClick={onStartLogin}>
-                Try again
-              </Button>
-            </div>
-          ) : null}
+          <p className="text-[11px] text-[var(--text-muted)]">
+            {connected
+              ? "GitHub is ready. Continue to memory setup when you're ready."
+              : 'Optional for onboarding, but helpful if you work with repositories.'}
+          </p>
         </div>
       </div>
     </div>

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -31,7 +31,7 @@ import { useOnboardingGitHubStep } from './useOnboardingGitHubStep';
 
 const GITHUB_STEP_CONFIG = {
   title: 'Connect GitHub (optional)',
-  description: 'Strongly suggested if you work with repos. You can skip this for now and connect later from Explorer.',
+  description: 'Strongly suggested if you work with repos. Connect now or continue setup and add GitHub later when you need it.',
 } as const;
 
 const TIERS: readonly { key: ModelTier; label: string; description: string }[] = [
@@ -122,7 +122,9 @@ export function OnboardingSetupScreen({
     step,
     checkingGitHub,
     githubAuth,
+    lastOutcome,
     handleTierContinue,
+    handleConnectGitHub,
     handleBack,
     handleContinueFromGitHub,
   } = useOnboardingGitHubStep({
@@ -150,15 +152,10 @@ export function OnboardingSetupScreen({
         <GitHubConnectCard
           authStatus={githubAuth.authStatus}
           statusReady={githubAuth.statusReady}
-          flow={githubAuth.flow}
-          copied={githubAuth.copied}
-          copyFailed={githubAuth.copyFailed}
-          onStartLogin={githubAuth.startLogin}
-          onCancel={githubAuth.cancel}
-          onCopyCode={(code) => {
-            void githubAuth.copyCode(code);
+          lastOutcome={lastOutcome}
+          onConnect={() => {
+            void handleConnectGitHub();
           }}
-          showConnectedState
         />
 
         <div className="flex justify-between gap-2 pt-1">

--- a/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GlobalModelConfigInput, ModelTierSettings } from '@/types/ipc';
+import { resetGitHubAuthStore } from '@/stores/github-auth';
 import { useOnboardingGitHubStep } from './useOnboardingGitHubStep';
 
 (
@@ -83,6 +84,7 @@ describe('useOnboardingGitHubStep', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetGitHubAuthStore();
     installSeroBridge();
     githubBridge.onEvent.mockReturnValue(vi.fn());
 
@@ -99,6 +101,8 @@ describe('useOnboardingGitHubStep', () => {
     }
     root = null;
     container.remove();
+
+    resetGitHubAuthStore();
 
     if (originalSeroDescriptor) {
       Object.defineProperty(window, 'sero', originalSeroDescriptor);

--- a/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx
@@ -277,4 +277,48 @@ describe('useOnboardingGitHubStep', () => {
     expect(container.firstElementChild?.getAttribute('data-authenticated')).toBe('false');
     expect(onContinue).not.toHaveBeenCalled();
   });
+
+  it('keeps users on the GitHub step with a retryable error outcome after the shared dialog fails', async () => {
+    const onContinue = vi.fn();
+
+    await act(async () => {
+      root?.render(<HookProbe onContinue={onContinue} />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.firstElementChild?.getAttribute('data-status-ready')).toBe('true');
+    });
+
+    await act(async () => {
+      findButton('Continue').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(readStep(container)).toBe('github');
+    });
+
+    await act(async () => {
+      findButton('Connect GitHub').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    await act(async () => {
+      useGitHubAuthStore.getState().resolveGitHubAuthDialog({
+        outcome: 'error',
+        status: { authenticated: false },
+        message: 'GitHub login failed.',
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container.firstElementChild?.getAttribute('data-last-outcome')).toBe('error');
+    });
+
+    expect(readStep(container)).toBe('github');
+    expect(container.firstElementChild?.getAttribute('data-authenticated')).toBe('false');
+    expect(onContinue).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx
@@ -4,7 +4,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GlobalModelConfigInput, ModelTierSettings } from '@/types/ipc';
-import { resetGitHubAuthStore } from '@/stores/github-auth';
+import { resetGitHubAuthStore, useGitHubAuthStore } from '@/stores/github-auth';
 import { useOnboardingGitHubStep } from './useOnboardingGitHubStep';
 
 (
@@ -55,7 +55,9 @@ function HookProbe({ onContinue }: { onContinue: (config: GlobalModelConfigInput
     step,
     checkingGitHub,
     githubAuth,
+    lastOutcome,
     handleTierContinue,
+    handleConnectGitHub,
     handleBack,
     handleContinueFromGitHub,
   } = useOnboardingGitHubStep({
@@ -70,8 +72,11 @@ function HookProbe({ onContinue }: { onContinue: (config: GlobalModelConfigInput
       data-step={step}
       data-checking={checkingGitHub ? 'true' : 'false'}
       data-status-ready={githubAuth.statusReady ? 'true' : 'false'}
+      data-authenticated={githubAuth.authStatus?.authenticated ? 'true' : 'false'}
+      data-last-outcome={lastOutcome?.outcome ?? ''}
     >
       <button onClick={() => void handleTierContinue()}>Continue</button>
+      <button onClick={() => void handleConnectGitHub()}>Connect GitHub</button>
       <button onClick={handleBack}>Back</button>
       <button onClick={handleContinueFromGitHub}>Skip GitHub</button>
     </div>
@@ -86,6 +91,7 @@ describe('useOnboardingGitHubStep', () => {
     vi.clearAllMocks();
     resetGitHubAuthStore();
     installSeroBridge();
+    githubBridge.status.mockResolvedValue({ authenticated: false });
     githubBridge.onEvent.mockReturnValue(vi.fn());
 
     container = document.createElement('div');
@@ -137,9 +143,8 @@ describe('useOnboardingGitHubStep', () => {
     expect(githubBridge.cancel).not.toHaveBeenCalled();
   });
 
-  it('shows the GitHub step for unauthenticated users and cancels in-flight device flow when leaving it', async () => {
+  it('shows the GitHub step for unauthenticated users and lets them go back or continue without cancelling a local device flow', async () => {
     const onContinue = vi.fn();
-    githubBridge.status.mockResolvedValue({ authenticated: false });
 
     await act(async () => {
       root?.render(<HookProbe onContinue={onContinue} />);
@@ -162,7 +167,7 @@ describe('useOnboardingGitHubStep', () => {
     });
 
     expect(readStep(container)).toBe('tiers');
-    expect(githubBridge.cancel).toHaveBeenCalledTimes(1);
+    expect(githubBridge.cancel).not.toHaveBeenCalled();
     expect(onContinue).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -177,7 +182,99 @@ describe('useOnboardingGitHubStep', () => {
       findButton('Skip GitHub').dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(githubBridge.cancel).toHaveBeenCalledTimes(2);
+    expect(githubBridge.cancel).not.toHaveBeenCalled();
     expect(onContinue).toHaveBeenCalledWith({ tiers });
+  });
+
+  it('launches the shared GitHub auth dialog and returns to a connected onboarding step without auto-continuing', async () => {
+    const onContinue = vi.fn();
+
+    await act(async () => {
+      root?.render(<HookProbe onContinue={onContinue} />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.firstElementChild?.getAttribute('data-status-ready')).toBe('true');
+    });
+
+    await act(async () => {
+      findButton('Continue').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(readStep(container)).toBe('github');
+    });
+
+    await act(async () => {
+      findButton('Connect GitHub').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    expect(githubBridge.login).not.toHaveBeenCalled();
+
+    githubBridge.status.mockResolvedValueOnce({ authenticated: true, username: 'octocat' });
+
+    await act(async () => {
+      useGitHubAuthStore.getState().resolveGitHubAuthDialog({
+        outcome: 'success',
+        status: { authenticated: true, username: 'octocat' },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container.firstElementChild?.getAttribute('data-authenticated')).toBe('true');
+    });
+
+    expect(readStep(container)).toBe('github');
+    expect(container.firstElementChild?.getAttribute('data-last-outcome')).toBe('');
+    expect(onContinue).not.toHaveBeenCalled();
+  });
+
+  it('keeps users on the GitHub step with a retryable outcome after cancelling the shared dialog', async () => {
+    const onContinue = vi.fn();
+
+    await act(async () => {
+      root?.render(<HookProbe onContinue={onContinue} />);
+    });
+
+    await vi.waitFor(() => {
+      expect(container.firstElementChild?.getAttribute('data-status-ready')).toBe('true');
+    });
+
+    await act(async () => {
+      findButton('Continue').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(readStep(container)).toBe('github');
+    });
+
+    await act(async () => {
+      findButton('Connect GitHub').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    expect(githubBridge.login).not.toHaveBeenCalled();
+
+    await act(async () => {
+      useGitHubAuthStore.getState().resolveGitHubAuthDialog({
+        outcome: 'cancelled',
+        status: { authenticated: false },
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(container.firstElementChild?.getAttribute('data-last-outcome')).toBe('cancelled');
+    });
+
+    expect(readStep(container)).toBe('github');
+    expect(container.firstElementChild?.getAttribute('data-authenticated')).toBe('false');
+    expect(onContinue).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.ts
+++ b/apps/desktop/src/components/profiles/onboarding/useOnboardingGitHubStep.ts
@@ -1,6 +1,8 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { GlobalModelConfigInput, ModelTierSettings } from '@/types/ipc';
 import { useGitHubAuthFlow } from '@/hooks/useGitHubAuthFlow';
+import { useGitHubAuthStore } from '@/stores/github-auth';
+import type { GitHubAuthDialogResult } from '@/stores/github-auth';
 
 interface UseOnboardingGitHubStepOptions {
   tiers: ModelTierSettings;
@@ -9,6 +11,8 @@ interface UseOnboardingGitHubStepOptions {
   onContinue: (config: GlobalModelConfigInput) => void;
 }
 
+type OnboardingGitHubOutcome = Extract<GitHubAuthDialogResult, { outcome: 'cancelled' | 'error' }>;
+
 export function useOnboardingGitHubStep({
   tiers,
   canContinue,
@@ -16,8 +20,16 @@ export function useOnboardingGitHubStep({
   onContinue,
 }: UseOnboardingGitHubStepOptions) {
   const githubAuth = useGitHubAuthFlow();
+  const openGitHubAuthDialog = useGitHubAuthStore((state) => state.openGitHubAuthDialog);
   const [step, setStep] = useState<'tiers' | 'github'>('tiers');
   const [checkingGitHub, setCheckingGitHub] = useState(false);
+  const [lastOutcome, setLastOutcome] = useState<OnboardingGitHubOutcome | null>(null);
+
+  useEffect(() => {
+    if (githubAuth.authStatus?.authenticated) {
+      setLastOutcome(null);
+    }
+  }, [githubAuth.authStatus?.authenticated]);
 
   const handleTierContinue = useCallback(async () => {
     if (!canContinue || continueDisabled || checkingGitHub) return;
@@ -28,29 +40,40 @@ export function useOnboardingGitHubStep({
         onContinue({ tiers });
         return;
       }
+      setLastOutcome(null);
       setStep('github');
     } catch {
+      setLastOutcome(null);
       setStep('github');
     } finally {
       setCheckingGitHub(false);
     }
   }, [canContinue, continueDisabled, checkingGitHub, githubAuth, onContinue, tiers]);
 
+  const handleConnectGitHub = useCallback(async () => {
+    setLastOutcome(null);
+    const result = await openGitHubAuthDialog({ source: 'onboarding' });
+    await githubAuth.refreshStatus();
+    if (result.outcome === 'success') return;
+    setLastOutcome(result);
+  }, [githubAuth, openGitHubAuthDialog]);
+
   const handleBack = useCallback(() => {
-    githubAuth.cancel();
+    setLastOutcome(null);
     setStep('tiers');
-  }, [githubAuth]);
+  }, []);
 
   const handleContinueFromGitHub = useCallback(() => {
-    githubAuth.cancel();
     onContinue({ tiers });
-  }, [githubAuth, onContinue, tiers]);
+  }, [onContinue, tiers]);
 
   return {
     step,
     checkingGitHub,
     githubAuth,
+    lastOutcome,
     handleTierContinue,
+    handleConnectGitHub,
     handleBack,
     handleContinueFromGitHub,
   };

--- a/apps/desktop/src/hooks/useGitHubAuthFlow.test.tsx
+++ b/apps/desktop/src/hooks/useGitHubAuthFlow.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@/lib/copy-to-clipboard', () => ({
   copyTextToClipboard,
 }));
 
+import { resetGitHubAuthStore } from '@/stores/github-auth';
 import { useGitHubAuthFlow } from './useGitHubAuthFlow';
 
 (
@@ -59,6 +60,7 @@ describe('useGitHubAuthFlow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    resetGitHubAuthStore();
     githubBridge.status.mockResolvedValue({ authenticated: false });
     githubBridge.onEvent.mockReturnValue(vi.fn());
 
@@ -82,6 +84,8 @@ describe('useGitHubAuthFlow', () => {
     }
     root = null;
     container.remove();
+
+    resetGitHubAuthStore();
 
     if (originalSeroDescriptor) {
       Object.defineProperty(window, 'sero', originalSeroDescriptor);

--- a/apps/desktop/src/hooks/useGitHubAuthFlow.ts
+++ b/apps/desktop/src/hooks/useGitHubAuthFlow.ts
@@ -1,127 +1,40 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { GitHubAuthStatus, GitHubDeviceFlowEvent } from '@/types/electron-services';
-import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useGitHubAuthStore } from '@/stores/github-auth';
 
-function unauthenticatedStatus(): GitHubAuthStatus {
-  return { authenticated: false };
-}
-
-export type GitHubFlowState =
-  | { step: 'idle' }
-  | { step: 'code'; userCode: string; verificationUri: string }
-  | { step: 'polling' }
-  | { step: 'success'; username: string }
-  | { step: 'error'; message: string };
+export type { GitHubFlowState } from '@/stores/github-auth';
 
 export function useGitHubAuthFlow() {
-  const [authStatus, setAuthStatus] = useState<GitHubAuthStatus | null>(null);
-  const [statusReady, setStatusReady] = useState(false);
-  const [flow, setFlow] = useState<GitHubFlowState>({ step: 'idle' });
-  const [copied, setCopied] = useState(false);
-  const [copyFailed, setCopyFailed] = useState(false);
-  const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const clearCopyResetTimer = useCallback(() => {
-    if (copyResetTimerRef.current) {
-      clearTimeout(copyResetTimerRef.current);
-      copyResetTimerRef.current = null;
-    }
-  }, []);
-
-  const setTransientCopyState = useCallback(
-    (state: 'copied' | 'failed') => {
-      clearCopyResetTimer();
-      setCopied(state === 'copied');
-      setCopyFailed(state === 'failed');
-      copyResetTimerRef.current = setTimeout(() => {
-        setCopied(false);
-        setCopyFailed(false);
-        copyResetTimerRef.current = null;
-      }, state === 'copied' ? 2000 : 3000);
-    },
-    [clearCopyResetTimer],
+  const githubAuth = useGitHubAuthStore(
+    useShallow((state) => ({
+      authStatus: state.authStatus,
+      statusReady: state.statusReady,
+      flow: state.flow,
+      copied: state.copied,
+      copyFailed: state.copyFailed,
+      init: state.init,
+      startLogin: state.startLogin,
+      logout: state.logout,
+      cancel: state.cancel,
+      copyCode: state.copyCode,
+      refreshStatus: state.refreshStatus,
+    })),
   );
 
-  const refreshStatus = useCallback(async (): Promise<GitHubAuthStatus> => {
-    try {
-      const status = await window.sero.github.status();
-      setAuthStatus(status);
-      setStatusReady(true);
-      return status;
-    } catch {
-      const status = unauthenticatedStatus();
-      setAuthStatus(status);
-      setStatusReady(true);
-      return status;
-    }
-  }, []);
-
   useEffect(() => {
-    void refreshStatus();
-  }, [refreshStatus]);
-
-  useEffect(() => {
-    const unsubscribe = window.sero.github.onEvent((event) => {
-      const nextEvent = event as GitHubDeviceFlowEvent;
-      switch (nextEvent.type) {
-        case 'code':
-          setFlow({
-            step: 'code',
-            userCode: nextEvent.userCode ?? '',
-            verificationUri: nextEvent.verificationUri ?? '',
-          });
-          break;
-        case 'polling':
-          setFlow((current) => (current.step === 'code' ? current : { step: 'polling' }));
-          break;
-        case 'success':
-          setFlow({ step: 'success', username: nextEvent.username ?? '' });
-          setAuthStatus({ authenticated: true, username: nextEvent.username });
-          setStatusReady(true);
-          break;
-        case 'error':
-          setFlow({ step: 'error', message: nextEvent.message ?? 'Login failed' });
-          break;
-      }
-    });
-
-    return unsubscribe;
-  }, []);
-
-  useEffect(() => clearCopyResetTimer, [clearCopyResetTimer]);
-
-  const startLogin = useCallback(() => {
-    setFlow({ step: 'idle' });
-    void window.sero.github.login();
-  }, []);
-
-  const logout = useCallback(() => {
-    void window.sero.github.logout().then(() => {
-      setAuthStatus(unauthenticatedStatus());
-      setFlow({ step: 'idle' });
-    });
-  }, []);
-
-  const cancel = useCallback(() => {
-    void window.sero.github.cancel();
-    setFlow({ step: 'idle' });
-  }, []);
-
-  const copyCode = useCallback(async (code: string) => {
-    const ok = await copyTextToClipboard(code);
-    setTransientCopyState(ok ? 'copied' : 'failed');
-  }, [setTransientCopyState]);
+    void githubAuth.init();
+  }, [githubAuth.init]);
 
   return {
-    authStatus,
-    statusReady,
-    flow,
-    copied,
-    copyFailed,
-    startLogin,
-    logout,
-    cancel,
-    copyCode,
-    refreshStatus,
+    authStatus: githubAuth.authStatus,
+    statusReady: githubAuth.statusReady,
+    flow: githubAuth.flow,
+    copied: githubAuth.copied,
+    copyFailed: githubAuth.copyFailed,
+    startLogin: githubAuth.startLogin,
+    logout: githubAuth.logout,
+    cancel: githubAuth.cancel,
+    copyCode: githubAuth.copyCode,
+    refreshStatus: githubAuth.refreshStatus,
   };
 }

--- a/apps/desktop/src/stores/github-auth.test.ts
+++ b/apps/desktop/src/stores/github-auth.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GitHubDeviceFlowEvent } from '@/types/electron-services';
+import { resetGitHubAuthStore, useGitHubAuthStore } from './github-auth';
+
+const githubBridge = {
+  status: vi.fn(),
+  onEvent: vi.fn(),
+  login: vi.fn(),
+  logout: vi.fn(),
+  cancel: vi.fn(),
+};
+
+const originalSeroDescriptor = Object.getOwnPropertyDescriptor(window, 'sero');
+
+function installSeroBridge() {
+  Object.defineProperty(window, 'sero', {
+    configurable: true,
+    value: {
+      github: githubBridge,
+    },
+  });
+}
+
+describe('useGitHubAuthStore', () => {
+  let githubEventListener: ((event: GitHubDeviceFlowEvent) => void) | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetGitHubAuthStore();
+    githubEventListener = null;
+
+    githubBridge.status.mockResolvedValue({ authenticated: false });
+    githubBridge.login.mockResolvedValue(undefined);
+    githubBridge.logout.mockResolvedValue(undefined);
+    githubBridge.cancel.mockResolvedValue(undefined);
+    githubBridge.onEvent.mockImplementation((callback: (event: GitHubDeviceFlowEvent) => void) => {
+      githubEventListener = callback;
+      return vi.fn(() => {
+        if (githubEventListener === callback) {
+          githubEventListener = null;
+        }
+      });
+    });
+
+    installSeroBridge();
+  });
+
+  afterEach(() => {
+    resetGitHubAuthStore();
+
+    if (originalSeroDescriptor) {
+      Object.defineProperty(window, 'sero', originalSeroDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'sero');
+    }
+  });
+
+  it('initializes one shared GitHub event subscription path', async () => {
+    await useGitHubAuthStore.getState().init();
+    await useGitHubAuthStore.getState().init();
+
+    expect(githubBridge.onEvent).toHaveBeenCalledTimes(1);
+    expect(githubBridge.status).toHaveBeenCalledTimes(1);
+    expect(useGitHubAuthStore.getState().statusReady).toBe(true);
+  });
+
+  it('reuses one active dialog request and resolves with refreshed auth status on success', async () => {
+    githubBridge.status
+      .mockResolvedValueOnce({ authenticated: false })
+      .mockResolvedValueOnce({ authenticated: false })
+      .mockResolvedValueOnce({ authenticated: true, username: 'octocat' });
+
+    const firstPromise = useGitHubAuthStore.getState().openGitHubAuthDialog({ source: 'explorer' });
+    const secondPromise = useGitHubAuthStore.getState().openGitHubAuthDialog({ source: 'publish' });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+      expect(useGitHubAuthStore.getState().activeRequest).toEqual({ source: 'explorer' });
+    });
+
+    expect(githubBridge.status).toHaveBeenCalledTimes(2);
+    expect(githubEventListener).not.toBeNull();
+
+    githubEventListener?.({ type: 'success', username: 'octocat' });
+
+    await expect(Promise.all([firstPromise, secondPromise])).resolves.toEqual([
+      {
+        outcome: 'success',
+        status: { authenticated: true, username: 'octocat' },
+      },
+      {
+        outcome: 'success',
+        status: { authenticated: true, username: 'octocat' },
+      },
+    ]);
+
+    expect(useGitHubAuthStore.getState().open).toBe(false);
+    expect(useGitHubAuthStore.getState().activeRequest).toBeNull();
+    expect(useGitHubAuthStore.getState().authStatus).toEqual({ authenticated: true, username: 'octocat' });
+  });
+
+  it('refreshes GitHub status after logout instead of trusting cached success state', async () => {
+    useGitHubAuthStore.setState({
+      authStatus: { authenticated: true, username: 'octocat' },
+      statusReady: true,
+      flow: { step: 'success', username: 'octocat' },
+    });
+    githubBridge.status.mockResolvedValue({ authenticated: false });
+
+    await useGitHubAuthStore.getState().logout();
+
+    expect(githubBridge.logout).toHaveBeenCalledTimes(1);
+    expect(githubBridge.status).toHaveBeenCalledTimes(1);
+    expect(useGitHubAuthStore.getState().authStatus).toEqual({ authenticated: false });
+    expect(useGitHubAuthStore.getState().flow).toEqual({ step: 'idle' });
+  });
+});

--- a/apps/desktop/src/stores/github-auth.test.ts
+++ b/apps/desktop/src/stores/github-auth.test.ts
@@ -120,8 +120,32 @@ describe('useGitHubAuthStore', () => {
       message: 'Device flow failed',
     });
 
-    expect(githubBridge.cancel).not.toHaveBeenCalled();
+    expect(githubBridge.cancel).toHaveBeenCalledTimes(1);
     expect(useGitHubAuthStore.getState().open).toBe(false);
+  });
+
+  it('cancels an in-flight login even if the user closes the dialog before the device code arrives', async () => {
+    const resultPromise = useGitHubAuthStore.getState().openGitHubAuthDialog({ source: 'explorer' });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    useGitHubAuthStore.getState().startLogin();
+
+    expect(useGitHubAuthStore.getState().flow).toEqual({ step: 'idle' });
+
+    await useGitHubAuthStore.getState().dismissGitHubAuthDialog();
+
+    await expect(resultPromise).resolves.toEqual({
+      outcome: 'cancelled',
+      status: { authenticated: false },
+    });
+
+    expect(githubBridge.login).toHaveBeenCalledTimes(1);
+    expect(githubBridge.cancel).toHaveBeenCalledTimes(1);
+    expect(useGitHubAuthStore.getState().open).toBe(false);
+    expect(useGitHubAuthStore.getState().flow).toEqual({ step: 'idle' });
   });
 
   it('refreshes GitHub status after logout instead of trusting cached success state', async () => {

--- a/apps/desktop/src/stores/github-auth.test.ts
+++ b/apps/desktop/src/stores/github-auth.test.ts
@@ -101,6 +101,29 @@ describe('useGitHubAuthStore', () => {
     expect(useGitHubAuthStore.getState().authStatus).toEqual({ authenticated: true, username: 'octocat' });
   });
 
+  it('resolves generic failures back to the launching surface when the shared dialog closes', async () => {
+    const resultPromise = useGitHubAuthStore.getState().openGitHubAuthDialog({ source: 'remote-origin' });
+
+    await vi.waitFor(() => {
+      expect(useGitHubAuthStore.getState().open).toBe(true);
+    });
+
+    useGitHubAuthStore.setState({
+      flow: { step: 'error', message: 'Device flow failed' },
+    });
+
+    await useGitHubAuthStore.getState().dismissGitHubAuthDialog();
+
+    await expect(resultPromise).resolves.toEqual({
+      outcome: 'error',
+      status: { authenticated: false },
+      message: 'Device flow failed',
+    });
+
+    expect(githubBridge.cancel).not.toHaveBeenCalled();
+    expect(useGitHubAuthStore.getState().open).toBe(false);
+  });
+
   it('refreshes GitHub status after logout instead of trusting cached success state', async () => {
     useGitHubAuthStore.setState({
       authStatus: { authenticated: true, username: 'octocat' },

--- a/apps/desktop/src/stores/github-auth.ts
+++ b/apps/desktop/src/stores/github-auth.ts
@@ -248,12 +248,10 @@ export const useGitHubAuthStore = create<GitHubAuthStore>((set, get) => ({
     const flow = get().flow;
     const errorMessage = flow.step === 'error' ? flow.message : null;
 
-    if (isFlowInProgress(flow)) {
-      try {
-        await window.sero.github.cancel();
-      } catch {
-        // Best effort — auth status refresh below remains authoritative.
-      }
+    try {
+      await window.sero.github.cancel();
+    } catch {
+      // Best effort — auth status refresh below remains authoritative.
     }
 
     resetCopyFeedback();

--- a/apps/desktop/src/stores/github-auth.ts
+++ b/apps/desktop/src/stores/github-auth.ts
@@ -1,0 +1,339 @@
+import { create } from 'zustand';
+import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
+import type { GitHubAuthStatus, GitHubDeviceFlowEvent } from '@/types/electron-services';
+
+function unauthenticatedStatus(): GitHubAuthStatus {
+  return { authenticated: false };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+function isFlowInProgress(flow: GitHubFlowState): boolean {
+  return flow.step === 'code' || flow.step === 'polling';
+}
+
+function normalizeFlowForStatus(
+  flow: GitHubFlowState,
+  status: GitHubAuthStatus,
+): GitHubFlowState {
+  if (status.authenticated) {
+    if (flow.step === 'success') {
+      return {
+        step: 'success',
+        username: flow.username || status.username || '',
+      };
+    }
+    return { step: 'idle' };
+  }
+
+  if (flow.step === 'success') {
+    return { step: 'idle' };
+  }
+
+  return flow;
+}
+
+function createInitialGitHubAuthStoreState(): GitHubAuthStoreData {
+  return {
+    open: false,
+    activeRequest: null,
+    authStatus: null,
+    statusReady: false,
+    flow: { step: 'idle' },
+    copied: false,
+    copyFailed: false,
+    eventsInitialized: false,
+  };
+}
+
+export type GitHubFlowState =
+  | { step: 'idle' }
+  | { step: 'code'; userCode: string; verificationUri: string }
+  | { step: 'polling' }
+  | { step: 'success'; username: string }
+  | { step: 'error'; message: string };
+
+export type GitHubAuthSource = 'explorer' | 'onboarding' | 'remote-origin' | 'publish';
+
+export type GitHubAuthDialogResult =
+  | { outcome: 'success'; status: GitHubAuthStatus }
+  | { outcome: 'cancelled'; status: GitHubAuthStatus }
+  | { outcome: 'error'; status: GitHubAuthStatus; message: string };
+
+export interface GitHubAuthDialogRequest {
+  source: GitHubAuthSource;
+}
+
+interface GitHubAuthStoreData {
+  open: boolean;
+  activeRequest: GitHubAuthDialogRequest | null;
+  authStatus: GitHubAuthStatus | null;
+  statusReady: boolean;
+  flow: GitHubFlowState;
+  copied: boolean;
+  copyFailed: boolean;
+  eventsInitialized: boolean;
+}
+
+interface GitHubAuthStoreActions {
+  init: () => Promise<void>;
+  openGitHubAuthDialog: (request: GitHubAuthDialogRequest) => Promise<GitHubAuthDialogResult>;
+  dismissGitHubAuthDialog: () => Promise<void>;
+  resolveGitHubAuthDialog: (result: GitHubAuthDialogResult) => void;
+  refreshStatus: () => Promise<GitHubAuthStatus>;
+  startLogin: () => void;
+  logout: () => Promise<void>;
+  cancel: () => Promise<void>;
+  copyCode: (code: string) => Promise<void>;
+}
+
+export type GitHubAuthStore = GitHubAuthStoreData & GitHubAuthStoreActions;
+
+let githubEventUnsubscribe: (() => void) | null = null;
+let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+let activeDialogDeferred: ReturnType<typeof createDeferred<GitHubAuthDialogResult>> | null = null;
+let dialogLaunchPromise: Promise<GitHubAuthDialogResult> | null = null;
+
+function clearCopyResetTimer(): void {
+  if (copyResetTimer) {
+    clearTimeout(copyResetTimer);
+    copyResetTimer = null;
+  }
+}
+
+function resetCopyFeedback(): void {
+  clearCopyResetTimer();
+  useGitHubAuthStore.setState({ copied: false, copyFailed: false });
+}
+
+function setTransientCopyState(state: 'copied' | 'failed'): void {
+  resetCopyFeedback();
+  useGitHubAuthStore.setState({
+    copied: state === 'copied',
+    copyFailed: state === 'failed',
+  });
+
+  copyResetTimer = setTimeout(() => {
+    useGitHubAuthStore.setState({ copied: false, copyFailed: false });
+    copyResetTimer = null;
+  }, state === 'copied' ? 2000 : 3000);
+}
+
+function resolveActiveGitHubAuthDialog(result: GitHubAuthDialogResult): void {
+  const deferred = activeDialogDeferred;
+  activeDialogDeferred = null;
+  useGitHubAuthStore.setState({ open: false, activeRequest: null });
+  deferred?.resolve(result);
+}
+
+async function handleGitHubDeviceFlowEvent(event: GitHubDeviceFlowEvent): Promise<void> {
+  switch (event.type) {
+    case 'code':
+      resetCopyFeedback();
+      useGitHubAuthStore.setState({
+        flow: {
+          step: 'code',
+          userCode: event.userCode ?? '',
+          verificationUri: event.verificationUri ?? '',
+        },
+      });
+      return;
+
+    case 'polling':
+      useGitHubAuthStore.setState((state) => ({
+        flow: state.flow.step === 'code' ? state.flow : { step: 'polling' },
+      }));
+      return;
+
+    case 'success': {
+      resetCopyFeedback();
+      const fallbackUsername = event.username ?? useGitHubAuthStore.getState().authStatus?.username ?? '';
+      useGitHubAuthStore.setState({
+        flow: {
+          step: 'success',
+          username: fallbackUsername,
+        },
+      });
+
+      const status = await useGitHubAuthStore.getState().refreshStatus();
+      if (status.authenticated) {
+        useGitHubAuthStore.setState({
+          flow: {
+            step: 'success',
+            username: status.username ?? fallbackUsername,
+          },
+        });
+        resolveActiveGitHubAuthDialog({ outcome: 'success', status });
+        return;
+      }
+
+      useGitHubAuthStore.setState({
+        flow: {
+          step: 'error',
+          message: 'GitHub auth completed, but the refreshed status was unavailable.',
+        },
+      });
+      return;
+    }
+
+    case 'error':
+      resetCopyFeedback();
+      useGitHubAuthStore.setState({
+        flow: {
+          step: 'error',
+          message: event.message ?? 'Login failed',
+        },
+      });
+      return;
+  }
+}
+
+export const useGitHubAuthStore = create<GitHubAuthStore>((set, get) => ({
+  ...createInitialGitHubAuthStoreState(),
+
+  init: async () => {
+    if (!get().eventsInitialized) {
+      githubEventUnsubscribe = window.sero.github.onEvent((event) => {
+        void handleGitHubDeviceFlowEvent(event);
+      });
+      set({ eventsInitialized: true });
+    }
+
+    if (!get().statusReady) {
+      await get().refreshStatus();
+    }
+  },
+
+  openGitHubAuthDialog: (request) => {
+    if (dialogLaunchPromise) {
+      return dialogLaunchPromise;
+    }
+
+    dialogLaunchPromise = (async () => {
+      await get().init();
+
+      const status = await get().refreshStatus();
+      if (status.authenticated) {
+        return { outcome: 'success', status } satisfies GitHubAuthDialogResult;
+      }
+
+      resetCopyFeedback();
+      activeDialogDeferred = createDeferred<GitHubAuthDialogResult>();
+      set((state) => ({
+        open: true,
+        activeRequest: state.activeRequest ?? request,
+        flow: isFlowInProgress(state.flow) ? state.flow : { step: 'idle' },
+      }));
+
+      return activeDialogDeferred.promise;
+    })().finally(() => {
+      dialogLaunchPromise = null;
+    });
+
+    return dialogLaunchPromise;
+  },
+
+  dismissGitHubAuthDialog: async () => {
+    if (!activeDialogDeferred) {
+      set({ open: false, activeRequest: null });
+      return;
+    }
+
+    const flow = get().flow;
+    const errorMessage = flow.step === 'error' ? flow.message : null;
+
+    if (isFlowInProgress(flow)) {
+      try {
+        await window.sero.github.cancel();
+      } catch {
+        // Best effort — auth status refresh below remains authoritative.
+      }
+    }
+
+    resetCopyFeedback();
+    set({ flow: { step: 'idle' } });
+
+    const status = await get().refreshStatus();
+    if (status.authenticated) {
+      resolveActiveGitHubAuthDialog({ outcome: 'success', status });
+      return;
+    }
+
+    if (errorMessage) {
+      resolveActiveGitHubAuthDialog({ outcome: 'error', status, message: errorMessage });
+      return;
+    }
+
+    resolveActiveGitHubAuthDialog({ outcome: 'cancelled', status });
+  },
+
+  resolveGitHubAuthDialog: (result) => {
+    resolveActiveGitHubAuthDialog(result);
+  },
+
+  refreshStatus: async () => {
+    try {
+      const status = await window.sero.github.status();
+      set((state) => ({
+        authStatus: status,
+        statusReady: true,
+        flow: normalizeFlowForStatus(state.flow, status),
+      }));
+      return status;
+    } catch {
+      const status = unauthenticatedStatus();
+      set((state) => ({
+        authStatus: status,
+        statusReady: true,
+        flow: normalizeFlowForStatus(state.flow, status),
+      }));
+      return status;
+    }
+  },
+
+  startLogin: () => {
+    void get().init();
+    resetCopyFeedback();
+    set({ flow: { step: 'idle' } });
+    void window.sero.github.login();
+  },
+
+  logout: async () => {
+    try {
+      await window.sero.github.logout();
+    } finally {
+      resetCopyFeedback();
+      set({ flow: { step: 'idle' } });
+      await get().refreshStatus();
+    }
+  },
+
+  cancel: async () => {
+    try {
+      await window.sero.github.cancel();
+    } finally {
+      resetCopyFeedback();
+      set({ flow: { step: 'idle' } });
+    }
+  },
+
+  copyCode: async (code) => {
+    const ok = await copyTextToClipboard(code);
+    setTransientCopyState(ok ? 'copied' : 'failed');
+  },
+}));
+
+export function resetGitHubAuthStore(): void {
+  githubEventUnsubscribe?.();
+  githubEventUnsubscribe = null;
+  clearCopyResetTimer();
+  activeDialogDeferred = null;
+  dialogLaunchPromise = null;
+  useGitHubAuthStore.setState(createInitialGitHubAuthStoreState());
+}


### PR DESCRIPTION
## Summary
- centralize renderer GitHub auth state behind a shared store and one global GitHub auth dialog
- replace duplicated Explorer/onboarding login UIs with shared launcher/status surfaces that point into the same auth flow
- add direct GitHub connect + safe retry/resume behavior for remote-origin creation and titlebar publish flows
- expand regression coverage for success, cancel, error, retry, and auth-required fallback behavior

## Testing
- `pnpm typecheck`
- `cd apps/desktop && pnpm vitest run src/stores/github-auth.test.ts src/hooks/useGitHubAuthFlow.test.tsx src/components/layout/auth/github/GitHubAuthDialog.test.tsx src/components/apps/explorer/vcs/GitHubAuthBanner.test.tsx src/components/profiles/onboarding/useOnboardingGitHubStep.test.tsx src/components/profiles/onboarding/GitHubConnectCard.test.tsx src/components/layout/workspace/RemoteOriginManager.test.tsx src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx src/components/layout/git-remote/workflow.test.ts`
