### PR TITLE
refactor: replace UI emoji icons with Lucide

### DIFF
--- a/.pi/plans/2026-04-20-emoji-to-lucide-icons/plan.md
+++ b/.pi/plans/2026-04-20-emoji-to-lucide-icons/plan.md
@@ -1,0 +1,549 @@
+# Emoji to Lucide Icons Implementation Plan
+
+**Date:** 2026-04-20  
+**Status:** Draft  
+**Spec:** `.pi/plans/2026-04-20-emoji-to-lucide-icons/spec.md`  
+**Scout:** `.pi/plans/2026-04-20-emoji-to-lucide-icons/scout-context.md`  
+**Directory:** `/Users/danielcarter/Documents/Dev/projects/sero/sero`
+
+## Overview
+
+This initiative should remove repo-authored emoji iconography from in-scope Sero UI surfaces and normalize recurring icon semantics around Lucide.
+
+The repo is already mostly Lucide-first. The work is therefore not a redesign and not a new abstraction project; it is a **targeted normalization pass** across the remaining hotspots in:
+
+- `apps/desktop/src/components/**`
+- `packages/ui/src/components/**`
+- `plugins/sero-*-plugin/ui/**`
+
+The safest implementation shape is:
+
+1. define one canonical icon vocabulary for the recurring concepts in the spec,
+2. migrate by **folder/file clusters** so multiple workers can run concurrently,
+3. avoid a monorepo-wide icon registry unless duplication is both repeated and load-bearing,
+4. finish with a repo-wide in-scope search sweep plus monorepo `pnpm typecheck`.
+
+## Investigation Summary
+
+Relevant codebase facts:
+
+- `lucide-react` is already the dominant icon system in desktop, shared UI, and plugin surfaces.
+- `packages/ui/src/components/ui/button.tsx` already handles icon/text spacing and SVG sizing well, so most button migrations are straightforward icon swaps.
+- The clearest low-risk first cluster is the admin editor trio:
+  - `plugins/sero-admin-plugin/ui/components/SkillEditor.tsx`
+  - `plugins/sero-admin-plugin/ui/components/PromptEditor.tsx`
+  - `plugins/sero-admin-plugin/ui/components/AgentEditor.tsx`
+- Strong in-repo references already exist for the desired semantics:
+  - `apps/desktop/src/components/layout/context-editor/PresetBar.tsx` → `Save`, `Trash2`, `RotateCcw`
+  - `apps/desktop/src/components/layout/shell/StatusBar.tsx` → `Palette`, `Sun`, `Moon`, `Monitor`
+  - `packages/ui/src/components/model-selection/available-model-picker.tsx` → `Sparkles`, `Check`, `X`
+  - `plugins/sero-admin-plugin/ui/components/plugins/PluginDevSessionCard.tsx` → `RefreshCw`, `Trash2`, `Loader2`
+- The duplicated tool icon map is isolated to two desktop files:
+  - `apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx`
+  - `apps/desktop/src/components/layout/CollaborationLiveActivity.tsx`
+- `packages/ui/src/components/ai-elements/voice-selector.tsx` is already **525 LOC**, so any change there must also bring it back under the repo’s 500 LOC limit.
+
+## Recommended Approach
+
+Use a **folder-scoped migration plan with a canonical decision table**, not a new shared registry.
+
+### Why this approach
+
+- It minimizes git conflicts by assigning workers to mostly disjoint files/folders.
+- It keeps the work semantic: workers normalize concepts, not just literal glyphs.
+- It avoids adding a speculative abstraction layer for icons that are mostly consumed once per file.
+- It still allows one small local helper when duplication is extremely tight, but only inside a single worker-owned cluster.
+
+### Key Decisions
+
+- **No monorepo-wide icon registry.** The scope is too small and too UI-local to justify a new shared system.
+- **Do not chase every non-ASCII glyph in the repo.** Focus on repo-authored UI emoji and emoji-adjacent icon markers that function as actions/statuses in the touched surfaces.
+- **Leave non-icon punctuation alone** unless it is part of the same semantic cleanup:
+  - keep keyboard shortcut glyphs like `⌘`
+  - keep comments/docs/examples
+  - keep user/external content
+  - do not sweep generic disclosure glyphs everywhere just because they are non-ASCII
+- **Tool/action maps are in scope.** The duplicated desktop tool maps should become Lucide-based.
+- **Theme/appearance controls must align to existing desktop semantics**:
+  - browse themes → `Palette`
+  - edit theme → `Pencil`
+  - light/dark/system → `Sun` / `Moon` / `Monitor`
+- **Voice accent flags in shared UI get one generic Lucide treatment**: use `Languages` as the planner-approved replacement because Lucide does not provide a country-flag family. Accent-specific meaning should come from adjacent text or `children`, not the icon.
+- **If a touched file crosses or already exceeds 500 LOC, split it immediately.** `voice-selector.tsx` is the only known must-split case up front.
+
+## Non-Goals / Scope Guards
+
+- Do not modify docs, scripts, tests, fixtures, logs, prompts, or config text.
+- Do not rewrite emoji inside user-authored or external content.
+- Do not redesign layouts beyond icon alignment/spacing fixes needed for legibility.
+- Do not build a generalized “icon DSL”, registry package, or cross-repo helper library.
+- Do not change data flow/store/IPC contracts for any surface in this pass.
+
+## Canonical Icon Decision Table
+
+| Concept | Canonical Lucide icon | Decision notes |
+| --- | --- | --- |
+| delete / remove / uninstall | `Trash2` | Matches existing dominant repo usage. |
+| save / persist | `Save` | Use in text buttons where semantics are save/persist. |
+| add / create / new | `Plus` | Use `PlusCircle` only for intentionally prominent create affordances; default to `Plus` in dense UI. |
+| edit / rename / custom answer | `Pencil` | Use for edit affordances and “Type something” style custom-entry affordances. |
+| close / dismiss / clear | `X` | Use for dismiss/clear/close, not error status. |
+| search / find / grep / glob | `Search` | One canonical search-family choice for UI labels and tool maps. |
+| refresh / reload / rescan | `RefreshCw` | Use for refresh and auto-refresh; do not use `RotateCcw` unless meaning is reset/retry/undo. |
+| reset / undo / restore | `RotateCcw` | Keep distinct from refresh. |
+| loading / in progress | `Loader2` | Keep existing spinner pattern. |
+| warning / caution / sensitive data | `TriangleAlert` | Planner choice for warning-family standard. Keep `AlertCircle` only for softer advisory states already intentionally distinct. |
+| success / completed status | `CheckCircle2` | Use for status chips/badges and prominent complete states. |
+| selected / confirmed inline state | `Check` | Use in pickers, checklines, compact confirmation labels, and inline “Done” actions. |
+| error / failed status | `XCircle` | Use for actual status/failure, not close buttons. |
+| theme / browse appearance | `Palette` | Theme browsing / theme library semantics. |
+| edit current theme | `Pencil` | Same edit-family semantic as other edit actions. |
+| theme mode: light / dark / system | `Sun` / `Moon` / `Monitor` | Mirrors existing `StatusBar.tsx`. |
+| one-time / time / scheduled at | `Clock3` | Planner choice for clock-family standard in cron/reminder UI. |
+| recurring / repeat | `RefreshCw` | Reuse repo’s existing refresh/repeat family rather than introducing `Repeat` drift. |
+| notification / reminder | `Bell` | Reminder count, active reminder badge, notification settings entrypoint. |
+| notifications muted / sound off | `BellOff` | Use when the meaning is bell/notification disabled. |
+| desktop notification destination | `Monitor` | Use when the meaning is explicitly “desktop notification”. |
+| start / run / enable | `Play` | For start/run/enable controls. |
+| pause / disable / snooze-like hold | `Pause` | For pause/disable/snooze states when semantics are temporary stop/hold. |
+| reasoning / premium capability marker | `Sparkles` | Matches existing available-model picker convention. |
+| settings / use default / configure | `Settings2` | Use when the current glyph is a gear/config meaning, not system theme mode. |
+| tool map: read | `FileText` | Compact file-reading semantic. |
+| tool map: bash / shell | `Terminal` | Use for shell execution. |
+| tool map: write / edit | `Pencil` | One canonical edit/write family. |
+| tool map: ls / folder browse | `FolderOpen` | Folder listing/browse semantic. |
+| tool map: unknown tool | `Wrench` | Generic tool fallback. |
+| voice accent / locale marker | `Languages` | Planner decision for shared UI because there is no Lucide flag family; rely on text for the specific locale. |
+
+## Architecture / Implementation Notes
+
+### 1. Migrate in place with direct Lucide imports
+
+For most files, the right implementation is simply:
+
+- import the needed icon(s) from `lucide-react`
+- replace the emoji-leading label with `<Icon className="..." />` + existing text
+- keep current button variants, text, colors, and handlers
+
+This repo already has good references for the exact markup shape.
+
+### 2. Avoid shared abstraction unless duplication is unavoidable inside one cluster
+
+Two places look tempting for helpers:
+
+- desktop tool icon maps
+- theme/appearance icon selections
+
+The recommendation is still **not** to create a reusable cross-repo registry.
+
+- For the theme surfaces, the duplication is tiny; keep it file-local.
+- For the desktop tool maps, either:
+  - keep both files in one worker cluster and duplicate the small Lucide map intentionally, or
+  - extract one tiny helper only inside that cluster if the worker judges it cleaner.
+
+Do **not** introduce a new package/shared registry just for this initiative.
+
+### 3. Preserve density and accessibility
+
+- Buttons should continue to rely on `@sero-ai/ui` `Button` spacing behavior.
+- Dense rows should generally use `size-3` or `size-3.5` icons.
+- Empty-state icons can use `size-5` or similar scale.
+- If the icon becomes icon-only, add `title` / `aria-label` where needed.
+- Preserve existing visible text labels whenever possible; this is a consistency pass, not a copy rewrite.
+
+### 4. Treat voice-selector as a special case
+
+`packages/ui/src/components/ai-elements/voice-selector.tsx` is already over the max file size. Any work there must:
+
+1. split the accent rendering into a new file/module first,
+2. preserve exports/public API shape,
+3. replace flag emoji with the canonical `Languages` treatment.
+
+## Concurrent Todo Groups
+
+### Summary table
+
+| ID | Scope | Primary files | Can run in parallel with |
+| --- | --- | --- | --- |
+| TG-01 | Admin editor actions | `SkillEditor.tsx`, `PromptEditor.tsx`, `AgentEditor.tsx` | TG-02–TG-09 |
+| TG-02 | Admin supporting controls | `ConfigPanel.tsx`, `ResourceSection.tsx`, `SessionList.tsx`, `SessionDetail.tsx`, `LogViewer.tsx` | TG-01, TG-03–TG-09 |
+| TG-03 | Desktop shell/theme controls | `CommandMenu.tsx`, `ModeToggle.tsx` | TG-01–TG-02, TG-04–TG-09 |
+| TG-04 | Desktop orchestration tool maps | `SubagentCard.tsx`, `CollaborationLiveActivity.tsx` | TG-01–TG-03, TG-05–TG-09 |
+| TG-05 | Desktop explorer/workspace icon cleanup | `EditorPanel.tsx`, `ChangeLogRow.tsx`, `WorkspaceNode.tsx`, `PendingQuestionCard.tsx` | TG-01–TG-04, TG-06–TG-09 |
+| TG-06 | Cron reminders/scheduler core | `ReminderForm.tsx`, `ReminderCard.tsx`, `ReminderList.tsx`, `SchedulerBar.tsx`, `NotificationSettings.tsx` | TG-01–TG-05, TG-07–TG-09 |
+| TG-07 | Cron jobs/header/model picker | `CronAppHeader.tsx`, `JobsTab.tsx`, `JobCard.tsx`, `JobForm.tsx`, `ModelPicker.tsx` | TG-01–TG-06, TG-08–TG-09 |
+| TG-08 | User-feedback questionnaires | `QuestionnaireForm.tsx`, `InterviewForm.tsx`, `QuestionnaireQuestionStep.tsx` | TG-01–TG-07, TG-09 |
+| TG-09 | Shared UI voice selector | `voice-selector.tsx` + extracted accent module | TG-01–TG-08 |
+| TG-10 | Final sweep / validation / reconciliation | in-scope folders only | after TG-01–TG-09 |
+
+### TG-01 — Admin editor action normalization
+
+**Files**
+- `plugins/sero-admin-plugin/ui/components/SkillEditor.tsx`
+- `plugins/sero-admin-plugin/ui/components/PromptEditor.tsx`
+- `plugins/sero-admin-plugin/ui/components/AgentEditor.tsx`
+
+**Changes**
+- Replace `🗑 Delete` with `Trash2 + Delete`.
+- Replace `💾 Save` with `Save + Save` when not saving.
+- Preserve the plain `Saving…` loading copy while disabled.
+
+**Constraints**
+- Do not create a shared admin icon helper.
+- Keep current button variants/classes and destructive coloring.
+- Preserve existing save/delete enablement logic.
+
+**Reference patterns**
+- `apps/desktop/src/components/layout/context-editor/PresetBar.tsx`
+- `plugins/sero-admin-plugin/ui/components/plugins/PluginDevSessionCard.tsx`
+
+**Acceptance targets**
+- ISC-3, ISC-4, ISC-5, ISC-13
+
+### TG-02 — Admin supporting controls
+
+**Files**
+- `plugins/sero-admin-plugin/ui/components/ConfigPanel.tsx`
+- `plugins/sero-admin-plugin/ui/components/ResourceSection.tsx`
+- `plugins/sero-admin-plugin/ui/components/SessionList.tsx`
+- `plugins/sero-admin-plugin/ui/components/SessionDetail.tsx`
+- `plugins/sero-admin-plugin/ui/components/LogViewer.tsx`
+
+**Changes**
+- `⚠ Contains sensitive data` → `TriangleAlert + text`.
+- `↻` refresh affordances → `RefreshCw`.
+- `+ New …` actions in `ResourceSection` → `Plus + label`.
+- `✕` close button in `SessionDetail` → `X`.
+- Auto-refresh bullet indicators in `LogViewer` → refresh-family Lucide treatment, preferably `RefreshCw` with existing text.
+
+**Constraints**
+- Do not alter CRUD/session loading behavior.
+- Keep dense toolbar sizing (`h-5`, `h-6`, `size="sm"`, etc.).
+- Avoid broad admin folder sweeps outside the listed files.
+
+**Reference patterns**
+- `plugins/sero-admin-plugin/ui/components/plugins/PluginDevSessionCard.tsx` for `RefreshCw`
+- `packages/ui/src/components/model-selection/available-model-picker.tsx` for compact `X`
+
+**Acceptance targets**
+- ISC-3, ISC-7, ISC-10, ISC-11, ISC-13
+
+### TG-03 — Desktop shell/theme controls
+
+**Files**
+- `apps/desktop/src/components/layout/shell/CommandMenu.tsx`
+- `apps/desktop/src/components/layout/theme/theme-panel/ModeToggle.tsx`
+
+**Changes**
+- `🎨 Browse Themes` → `Palette + Browse Themes`.
+- `✏️ Edit Current Theme` → `Pencil + Edit Current Theme`.
+- `◑ Toggle Light / Dark / System` → one Lucide appearance icon; planner preference is `Monitor` for the command item.
+- Mode toggle options:
+  - Light → `Sun`
+  - Dark → `Moon`
+  - System → `Monitor`
+
+**Constraints**
+- Match the visual semantics already used in `StatusBar.tsx`.
+- Keep existing keyboard/open behavior unchanged.
+- Do not add a shared theme icon registry.
+
+**Reference patterns**
+- `apps/desktop/src/components/layout/shell/StatusBar.tsx`
+
+**Acceptance targets**
+- ISC-1, ISC-8, ISC-13
+
+### TG-04 — Desktop orchestration tool maps
+
+**Files**
+- `apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx`
+- `apps/desktop/src/components/layout/CollaborationLiveActivity.tsx`
+
+**Changes**
+- Replace emoji tool maps with the canonical Lucide mapping:
+  - read → `FileText`
+  - bash → `Terminal`
+  - write/edit → `Pencil`
+  - ls → `FolderOpen`
+  - find/grep/glob → `Search`
+  - unknown → `Wrench`
+
+**Constraints**
+- Keep both files in the same worker cluster to prevent drift.
+- Do not change subagent store/IPC types or activity feed behavior.
+- Preserve compact row density.
+- If a helper is introduced, keep it local to this cluster only.
+
+**Reference patterns**
+- `apps/desktop/src/components/layout/collaboration-visuals.tsx` for a `LucideIcon` mapping style
+
+**Acceptance targets**
+- ISC-1, ISC-9, ISC-13
+
+### TG-05 — Desktop explorer/workspace dense status and empty states
+
+**Files**
+- `apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx`
+- `apps/desktop/src/components/apps/explorer/vcs/ChangeLogRow.tsx`
+- `apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx`
+- `apps/desktop/src/components/layout/PendingQuestionCard.tsx`
+
+**Changes**
+- `📝 No file open` empty state → a document/code Lucide icon; planner preference is `FileCode2` because the surface is editor-specific.
+- `✕` clear-selection affordance in `WorkspaceNode` → `X`.
+- `✎ Type something…` in `PendingQuestionCard` → `Pencil`.
+- `ChangeLogRow` status glyphs should move to Lucide where semantics are status-like:
+  - immutable → success icon (`CheckCircle2`)
+  - conflict → failure icon (`XCircle`)
+  - empty/default neutral → circle-family Lucide icon
+- Keep the VCS working-copy `@` marker unchanged; it is domain notation, not emoji UI chrome.
+
+**Constraints**
+- Preserve row density in `ChangeLogRow`.
+- Do not redesign VCS semantics or workspace selection logic.
+- Limit edits to the listed files.
+
+**Reference patterns**
+- `apps/desktop/src/components/layout/CollaborationFeedItems.tsx` for compact status icons
+- `packages/ui/src/components/model-selection/available-model-picker.tsx` for compact `X`
+- `apps/desktop/src/components/layout/workspace/SessionNode.tsx` for `Pencil`
+
+**Acceptance targets**
+- ISC-1, ISC-10, ISC-11, ISC-13, ISC-14
+
+### TG-06 — Cron reminders and scheduler core
+
+**Files**
+- `plugins/sero-cron-plugin/ui/components/ReminderForm.tsx`
+- `plugins/sero-cron-plugin/ui/components/ReminderCard.tsx`
+- `plugins/sero-cron-plugin/ui/components/ReminderList.tsx`
+- `plugins/sero-cron-plugin/ui/components/SchedulerBar.tsx`
+- `plugins/sero-cron-plugin/ui/components/NotificationSettings.tsx`
+
+**Changes**
+- Reminder type labels:
+  - one-time → `Clock3`
+  - recurring → `RefreshCw`
+- Reminder/time/status labels:
+  - active → `Bell`
+  - done status → `CheckCircle2`
+  - inline done action → `Check`
+  - paused/snoozed/held states → `Pause`
+  - legacy email badge → `Mail`
+  - desktop notification destination → `Monitor`
+- Scheduler bar:
+  - reminder count → `Bell`
+  - start/stop → `Play` / `Pause`
+- Notification settings popover button:
+  - sound enabled → `Bell`
+  - sound disabled → `BellOff`
+
+**Constraints**
+- Preserve all reminder/job logic and labels.
+- Keep `Badge`/`Button` density intact.
+- Do not invent a separate cron-specific icon set that diverges from the canonical table.
+
+**Reference patterns**
+- `apps/desktop/src/components/layout/shell/StatusBar.tsx` for `Monitor`
+- `packages/ui/src/components/model-selection/available-model-picker.tsx` for `Check` and `X`
+
+**Acceptance targets**
+- ISC-3, ISC-7, ISC-11, ISC-12, ISC-13
+
+### TG-07 — Cron jobs, header, and model picker
+
+**Files**
+- `plugins/sero-cron-plugin/ui/components/CronAppHeader.tsx`
+- `plugins/sero-cron-plugin/ui/components/JobsTab.tsx`
+- `plugins/sero-cron-plugin/ui/components/JobCard.tsx`
+- `plugins/sero-cron-plugin/ui/components/JobForm.tsx`
+- `plugins/sero-cron-plugin/ui/components/ModelPicker.tsx`
+
+**Changes**
+- Empty/title/create surfaces:
+  - scheduler title / jobs empty state → `Clock3`
+  - `+ Reminder` / `+ Job` / `+ New Job` → `Plus`
+- Job actions:
+  - enable/run → `Play`
+  - disable → `Pause`
+- Cron validation success line → `Check`
+- Model picker normalization:
+  - reasoning marker `✦` → `Sparkles`
+  - clear `✕` → `X`
+  - default-model gear `⚙` → `Settings2`
+  - selection checkmarks `✓` → `Check`
+- Explicitly leave `RunHistory.tsx` disclosure chevrons for a later pass; they are not part of the emoji cleanup target.
+
+**Constraints**
+- Match `available-model-picker.tsx` closely for picker icon shape/spacing.
+- Do not change search/filter/model resolution logic.
+- Keep this group isolated from TG-06 by file boundary.
+
+**Reference patterns**
+- `packages/ui/src/components/model-selection/available-model-picker.tsx`
+
+**Acceptance targets**
+- ISC-3, ISC-10, ISC-11, ISC-12, ISC-13
+
+### TG-08 — User-feedback questionnaire surfaces
+
+**Files**
+- `plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.tsx`
+- `plugins/sero-user-feedback-plugin/ui/InterviewForm.tsx`
+- `plugins/sero-user-feedback-plugin/ui/questionnaire/QuestionnaireQuestionStep.tsx`
+
+**Changes**
+- Step-complete `✓` markers → `Check`.
+- `✎ Type something…` → `Pencil`.
+- Preserve the numbered fallback when a step/option is not yet selected.
+
+**Constraints**
+- Do not change questionnaire data structures or answer flattening behavior.
+- Keep current button/card layout intact.
+- Use compact icon sizing so list rhythm does not change.
+
+**Reference patterns**
+- `packages/ui/src/components/model-selection/available-model-picker.tsx` for `Check`
+- `apps/desktop/src/components/layout/workspace/SessionNode.tsx` for `Pencil`
+
+**Acceptance targets**
+- ISC-3, ISC-10, ISC-11, ISC-13
+
+### TG-09 — Shared UI voice selector accent cleanup
+
+**Files**
+- `packages/ui/src/components/ai-elements/voice-selector.tsx`
+- new extracted module(s), e.g. `packages/ui/src/components/ai-elements/voice-selector-accent.tsx`
+
+**Changes**
+- First split accent rendering out of the 525 LOC file to bring all touched files under 500 LOC.
+- Replace flag emoji mapping with a Lucide-based implementation.
+- Planner decision: the default accent icon becomes `Languages` for all accents.
+- Preserve `children ?? icon` behavior so callers can still override presentation if needed.
+
+**Constraints**
+- Preserve the public export surface.
+- Do not add a custom SVG/flag asset pack.
+- Do not try to emulate flags with ad hoc CSS shapes.
+- Keep the generic accent icon decision intentional and documented in code comments if helpful.
+
+**Reference patterns**
+- `packages/ui/src/components/ai-elements/voice-selector.tsx` existing `VoiceSelectorGender` icon pattern
+- `apps/desktop/src/components/layout/collaboration-visuals.tsx` for a typed `LucideIcon` mapping style
+
+**Acceptance targets**
+- ISC-2, ISC-12, ISC-13, ISC-A-3
+
+### TG-10 — Final validation and reconciliation sweep
+
+**Files**
+- In-scope UI folders only; no out-of-scope cleanup.
+
+**Changes**
+- Run targeted searches for remaining emoji/icon-glyph hotspots.
+- Fix any leftovers using the canonical table rather than ad hoc choices.
+- Run root `pnpm typecheck`.
+- Check touched file line counts, especially any extracted/shared UI files.
+
+**Constraints**
+- Do not expand into docs/tests/scripts.
+- Do not “fix” unrelated copy/layout issues discovered during the sweep.
+- Resolve conflicts in favor of the canonical table in this plan.
+
+**Acceptance targets**
+- ISC-1, ISC-2, ISC-3, ISC-9, ISC-10, ISC-A-1, ISC-A-2, ISC-A-3
+
+## Sequencing
+
+Recommended execution order:
+
+1. **Start in parallel:** TG-01 through TG-09.
+2. **Finish last:** TG-10 after the cluster PRs/branches are merged or rebased together.
+
+There are intentionally **no global-blocker prerequisites** before the surface migrations begin.
+
+The only notable sequencing caveat is TG-09:
+
+- the worker must split `voice-selector.tsx` before or while replacing its flag emoji,
+- because the file is already above the repo’s file-size limit.
+
+## Validation Strategy
+
+### Targeted searches
+
+Run these searches during TG-10 and optionally within each cluster before handoff:
+
+```bash
+rg -n '(🗑|💾|⚠|🕐|🔄|✅|🎨|✏️|◑|⏰|🔔|💤|📧|▶|⏸|🖥|✦|✕|✓|☀|☾|⚙|📖|📂|📁|🔍|🔎|🔧|📝|↻|✎|◆|✖)' \
+  apps/desktop/src/components \
+  packages/ui/src/components \
+  plugins/sero-*-plugin/ui
+
+rg -n '🇺🇸|🇬🇧|🇦🇺|🇨🇦|🇮🇪|🏴|🇮🇳|🇿🇦|🇳🇿|🇪🇸|🇫🇷|🇩🇪|🇮🇹|🇵🇹|🇧🇷|🇲🇽|🇦🇷|🇯🇵|🇨🇳|🇰🇷|🇷🇺|🇸🇦|🇳🇱|🇸🇪|🇳🇴|🇩🇰|🇫🇮|🇵🇱|🇹🇷|🇬🇷' \
+  packages/ui/src/components/ai-elements/voice-selector.tsx
+```
+
+Interpretation notes:
+
+- ignore comments/examples/docs if a search pattern catches them accidentally,
+- ignore keyboard shortcut glyphs and domain notation intentionally excluded above,
+- only repo-authored UI chrome in the in-scope folders counts.
+
+### Type safety
+
+From repo root:
+
+```bash
+pnpm typecheck
+```
+
+### File-size check
+
+For any touched file near the limit:
+
+```bash
+wc -l <file>
+```
+
+### Manual smoke review
+
+Manually review at least one representative surface from each cluster:
+
+- admin editors
+- admin config/session/log tools
+- command palette + theme mode toggle
+- subagent card + collaboration live activity
+- explorer empty state + VCS change log
+- cron reminders/jobs/model picker
+- user-feedback questionnaire
+- any consumer/story/example available for shared `voice-selector`
+
+## Risks & Accepted Premortem
+
+| Risk / assumption | If wrong | Mitigation / decision |
+| --- | --- | --- |
+| The remaining scope is mostly isolated to the inventoried files | A final sweep could still find uncatalogued emoji in in-scope UI | TG-10 targeted search + reconciliation pass |
+| Replacing emoji with Lucide will fit dense layouts without redesign | Dense rows/buttons could misalign or wrap | Use existing `Button` spacing and existing `size-3` / `size-3.5` patterns; keep changes local |
+| Voice selector can tolerate a generic accent icon | If a consumer relied on flag distinction alone, semantics get weaker | Preserve `children` override; rely on adjacent text; document the planner decision |
+| Workers might drift on ambiguous icon families | Different surfaces could choose different icons for the same concept | Canonical table is the source of truth; TG-10 reconciles drift |
+| Broad unicode searches may tempt workers into scope creep | Time gets lost cleaning comments, tests, or non-UI glyphs | Explicit scope guards and file lists per todo group |
+
+Accepted risks for this plan:
+
+- We are intentionally **not** standardizing every punctuation/disclosure glyph in the repo.
+- We are intentionally choosing a **generic** accent icon in shared UI instead of inventing pseudo-flag replacements.
+- We are intentionally avoiding a cross-repo icon registry even though a couple of local maps remain duplicated; concurrency and simplicity matter more here.
+
+## Dependencies
+
+- No new libraries.
+- Use existing `lucide-react` already present in the monorepo.
+
+## Worker Notes
+
+- Prefer direct Lucide imports in each touched file.
+- Keep imports top-level; no inline dynamic icon imports.
+- Preserve existing comments unless they become misleading.
+- Check file size before marking the work complete.
+- Avoid touching the same files across multiple worker branches; the todo groups above are the assignment boundary.

--- a/.pi/plans/2026-04-20-emoji-to-lucide-icons/scout-context.md
+++ b/.pi/plans/2026-04-20-emoji-to-lucide-icons/scout-context.md
@@ -1,0 +1,106 @@
+# Context for: repo-wide emoji-to-Lucide icon consistency initiative
+
+## Relevant Files
+- `plugins/sero-admin-plugin/ui/components/SkillEditor.tsx` — current user-facing `🗑 Delete` / `💾 Save` labels; explicitly called out by user.
+- `plugins/sero-admin-plugin/ui/components/PromptEditor.tsx` — same delete/save emoji pattern as SkillEditor.
+- `plugins/sero-admin-plugin/ui/components/AgentEditor.tsx` — same delete/save emoji pattern; likely part of the same worker cluster.
+- `plugins/sero-admin-plugin/ui/components/plugins/PluginDevSessionCard.tsx` — already uses Lucide `RefreshCw`, `Trash2`, `Loader2`, helpful as a style reference for destructive / loading actions.
+- `plugins/sero-admin-plugin/ui/components/plugins/InstalledPluginsSection.tsx` — Lucide `Trash2` / `FolderOpen` / `PackagePlus` pattern reference.
+- `plugins/sero-web-plugin/ui/components/*` — Lucide-heavy surface; useful reference for consistent icon sizing and status coloring.
+- `apps/desktop/src/components/layout/**` and `apps/desktop/src/components/apps/**` — main desktop UI surfaces with the highest volume of icons and several remaining emoji literals.
+- `packages/ui/src/components/ui/button.tsx` — button primitive enforces icon/text spacing (`gap-2`, svg sizing rules, `has-[>svg]` padding); important for migration behavior.
+- `apps/desktop/src/components/ui/IconAction.tsx` — reusable icon-only action wrapper that can inform destructive action styling.
+- `apps/desktop/src/lib/app-icons.ts` — centralized app icon registry; not action icons, but demonstrates the repo’s preference for centralized mapping.
+- `apps/desktop/src/components/layout/collaboration-chat-feed.ts` / `apps/desktop/src/components/layout/collaboration-visuals.tsx` — centralized Lucide mappings for collaboration phases/roles.
+- `apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx` — representative mixed pattern: Lucide status icons but emoji-based tool icons, which may be out of scope unless the initiative expands beyond button/actions.
+
+## Project Structure
+- The repo is a monorepo with the most relevant React/UI surfaces in:
+  - `apps/desktop/src/components/**` — desktop shell and app panels.
+  - `packages/ui/src/components/**` — shared UI primitives and ai-elements.
+  - `plugins/sero-*-plugin/ui/**` — plugin-specific web UIs.
+- Built-in plugins are where the emoji cleanup is most visible. `sero-admin-plugin` has the clearest low-risk scope because the same header action pattern repeats across several editor forms.
+- `packages/ui` already leans heavily on Lucide icons, especially in shared controls like `button`, `command`, `dialog`, `select`, `combobox`, etc.
+
+## Conventions
+- Lucide is the dominant icon system in UI code. Imports are usually from `lucide-react` with direct component usage (`<Trash2 className="size-3" />`).
+- Standard sizing conventions are consistent:
+  - `size-3` / `size-3.5` for dense buttons and list items.
+  - `size-4` for typical command/dialog icons.
+  - `size-5` and larger for empty states and prominent banners.
+- Status colors are encoded with semantic CSS tokens rather than hardcoded hex values, e.g. `text-[var(--status-success)]`, `text-destructive`, `text-[var(--banner-primary)]`.
+- Buttons generally rely on the shared `Button` primitive from `@sero-ai/ui/components/ui/button`, which already handles SVG spacing and sizing. That means most migrations should be simple icon swaps, not layout rewrites.
+- Some areas already use centralized icon maps instead of inline icon selection (`app-icons`, collaboration role visuals, phase banners), which suggests a good precedent for any future action-icon registry.
+
+## Current Emoji-Based UI Usage Inventory
+Representative UI-facing emoji literals found in source (not docs/tests/build output):
+- `plugins/sero-admin-plugin/ui/components/SkillEditor.tsx` — `🗑 Delete`, `💾 Save`
+- `plugins/sero-admin-plugin/ui/components/PromptEditor.tsx` — `🗑 Delete`, `💾 Save`
+- `plugins/sero-admin-plugin/ui/components/AgentEditor.tsx` — `🗑 Delete`, `💾 Save`
+- `plugins/sero-admin-plugin/ui/components/ConfigPanel.tsx` — `⚠ Contains sensitive data` (status/warning badge; likely migrate if treated as UI iconography)
+- `plugins/sero-cron-plugin/ui/components/ReminderForm.tsx` — `🕐 One-time`, `🔄 Recurring`
+- `plugins/sero-cron-plugin/ui/components/ReminderCard.tsx` — `✅ Done`, `🔄 Recurring`
+- `apps/desktop/src/components/layout/shell/CommandMenu.tsx` — `🎨 Browse Themes`, `✏️ Edit Current Theme`, `◑ Toggle Light / Dark / System`
+- `apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx` — tool icons map includes `📖`, `📂`, `✏️`, `📁`, `🔍`, `🔎`, `🔧`
+- `apps/desktop/src/components/layout/CollaborationLiveActivity.tsx` — tool icons map uses `✏️`, `📁`, `🔍`
+- `apps/desktop/electron/platform/desktop/notifications.ts` — emoji mapping for notification types (`ℹ️`, `⚠️`, `❌`) in a non-React layer; likely out of scope unless the initiative explicitly includes notification UI.
+- Several shell scripts / Python utilities and logs include emoji status markers (`✅`, `❌`, `⚠️`, `🔍`) but are operational output rather than UI surfaces; likely out of scope.
+
+## Existing Lucide Usage Patterns
+- Destructive actions are already frequently represented with `Trash2` across desktop and plugin UIs:
+  - `SessionBadge`, `WorkspaceNode`, `DiscoverPluginCard`, `ProviderListView`, `InstalledPluginsSection`, `PluginDevSessionCard`, `SearchHistory`, `DownloadsList`, etc.
+- Save actions already use `Save` in some places, e.g. `apps/desktop/src/components/layout/context-editor/PresetBar.tsx`; in other places the text-only `Save` label remains.
+- Add/create actions commonly use `Plus`, `PlusCircle`, `PackagePlus`, `FolderPlus`, `MessageSquarePlus`, `Grid2x2Plus`.
+- Search actions commonly use `Search` / `SearchIcon`.
+- Refresh/retry actions commonly use `RefreshCw` or `RotateCcw` depending on semantics.
+- External navigation uses `ExternalLink` consistently in desktop/plugin UI and shared ai-elements.
+- Success/error/warning states frequently use `Check`, `CheckCircle2`, `X`, `XCircle`, `AlertCircle`, `AlertTriangle`, and `Loader2`.
+
+## Key Findings
+- The most obvious low-risk win is `sero-admin-plugin` editor headers: three sibling files share the same `🗑 Delete` and `💾 Save` pattern, so they can be migrated together with minimal conflict.
+- The repo already has a de facto semantic icon vocabulary; the work is mostly normalization and replacing emoji literals with existing Lucide components rather than inventing new patterns.
+- Inconsistent semantics already exist for similar actions:
+  - delete is usually `Trash2`, but some areas may use `Trash` or text-only labels.
+  - edit sometimes uses `Pencil`, sometimes `Edit`, and some areas still use `✏️`.
+  - refresh sometimes uses `RefreshCw` and sometimes `RotateCcw` depending on whether the action is "reload" or "undo/retry".
+- A centralized action-icon map does not appear to exist yet. The closest precedents are app icon registries and collaboration role/phase icon tables.
+- Several emoji usages are non-button/status shorthand inside tool feeds or notifications. Those should probably be excluded from a first pass unless the scope is broadened, because they are more about compact log-like telemetry than direct UI controls.
+
+## Gotchas
+- Button spacing and icon sizing can drift if icons are inserted ad hoc without using the shared `Button` primitive; the primitive already applies `gap-2` / SVG sizing rules, but dense custom buttons may still need manual `gap-1.5` or explicit `size-*` classes.
+- Lucide icon choice consistency matters as much as replacing emoji. Example: if delete becomes `Trash2` in one place, it should likely be `Trash2` everywhere unless a stronger semantic distinction is intended.
+- Some current UI text uses emoji as part of compact list labels (`One-time`, `Recurring`, theme menu options). Migrating these may require layout tweaks for line height, truncation, and alignment.
+- Accessibility: emoji-only or emoji-leading affordances often lack strong semantics. Swapping to icons should preserve or improve accessible names via button text or `aria-label` if the icon becomes standalone.
+- Import churn: many files currently import a single icon inline. A broad sweep may create noisy diffs unless grouped by folder and aligned to existing import style.
+- There are multiple file clusters under `apps/desktop/src/components/layout/**`; avoid cross-cutting edits in the same files when possible so workers can split by subdirectory without conflicts.
+- `apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx` and similar telemetry-style feeds use emoji in tool-type maps. Those are likely better handled separately from core action icon standardization to avoid scope creep.
+
+## Proposed First-Pass Action/Icon Consistency Table
+Based on existing repo patterns:
+
+| Action / Meaning | Preferred Lucide icon | Notes |
+| --- | --- | --- |
+| Delete / remove / uninstall | `Trash2` | Already the most common destructive icon in the repo. |
+| Save / persist | `Save` | Already used in `PresetBar`; better than a floppy emoji. |
+| Add / create / new | `Plus` or `PlusCircle` | `Plus` for compact buttons, `PlusCircle` for more prominent create actions. |
+| Edit / rename | `Pencil` or `PencilLine` | Prefer one icon family consistently; `Pencil` is already common. |
+| Search / find | `Search` | Standard across command bars and search fields. |
+| Refresh / reload | `RefreshCw` | Use `RotateCcw` only when the action is semantically undo/restore/retry. |
+| Warning / caution | `AlertTriangle` for strong warnings, `AlertCircle` for softer info/warning states | Match existing token colors. |
+| Success / done / complete | `CheckCircle2` for status badges, `Check` for inline actions | Repo uses both; distinguish status vs action. |
+| Error / failure / close | `XCircle` for status, `X` for dismiss/close | Consistent with dialog and status surfaces. |
+| Open folder / browse local files | `FolderOpen` | Already common in file/workspace/plugin UIs. |
+| External link / open in browser | `ExternalLink` | Strong existing precedent. |
+| Save as / duplicate | `Save` + text, or `Copy` / `Files` depending on behavior | Needs semantic clarity per use case. |
+| Loading / in progress | `Loader2` | Already the repo standard; keep spinning class usage consistent. |
+| Settings / configure | `Settings2` | Common in model/context editors. |
+| Theme / appearance | `Palette` or `Sparkles` depending on meaning | Current theme menu emoji is a likely candidate for `Palette` if it means theme browsing, and `Sun/Moon/Monitor` for mode toggles. |
+| One-time / scheduled time | `Clock` / `Clock3` / `CalendarClock`-style alternative if available | For cron/reminder UI, use a time-based icon instead of `🕐`. |
+| Recurring / repeat | `RefreshCw` or `Repeat` | Semantically better than `🔄` in user-facing labels. |
+
+## Suggested Concurrent Work Clusters
+1. **Admin plugin editors**: `SkillEditor.tsx`, `PromptEditor.tsx`, `AgentEditor.tsx`, and possibly `ModelPanel.tsx` / `ConfigPanel.tsx` for warning/save affordances.
+2. **Desktop shell & command palette**: `shell/CommandMenu.tsx`, `theme/*`, `AppStoreDialog.tsx`, `MainSidebar.tsx`, `StatusBar.tsx`, `SessionBadge.tsx`, `ChatPromptArea.tsx`, `ErrorSurface.tsx`.
+3. **Workspace/explorer actions**: `workspace/*`, `apps/explorer/*`, especially delete/add/refresh/open-folder actions.
+4. **Plugin UIs**: `sero-web-plugin/ui/*`, `sero-cron-plugin/ui/*`, `sero-git-plugin/ui/*`, each mostly self-contained and low-conflict.
+5. **Shared UI cleanup**: `packages/ui/src/components/ui/*` and `packages/ui/src/components/ai-elements/*` if the initiative expands to shared primitives or icon-only components.

--- a/.pi/plans/2026-04-20-emoji-to-lucide-icons/spec.md
+++ b/.pi/plans/2026-04-20-emoji-to-lucide-icons/spec.md
@@ -1,0 +1,127 @@
+# Sero Monorepo Icon Consistency Initiative
+
+**Date:** 2026-04-20
+**Status:** Draft
+**Directory:** /Users/danielcarter/Documents/Dev/projects/sero/sero
+
+## Intent
+Standardize Sero’s user-facing UI iconography by removing repo-authored emoji from in-scope UI surfaces and replacing it with Lucide icons. The goal is a visually consistent product where recurring actions and concepts use the same icon everywhere practical, while preserving displayed user-provided or external content exactly as authored.
+
+## User Story
+As a Sero user, I want the app and built-in plugin UIs to use one consistent icon language, so that actions, statuses, and controls feel coherent and predictable instead of mixing emoji and Lucide icons.
+
+## Behavior
+Any repo-authored visual marker in in-scope UI should use Lucide rather than emoji. This applies to action buttons, menu items, labels, badges, tool/icon maps, status markers, theme and appearance controls, and similar UI chrome. When the same user-facing concept appears in multiple places, it should use the same Lucide icon wherever the semantics are the same. If an emoji currently acts only as decoration, it should still be replaced by the closest Lucide equivalent rather than silently dropped.
+
+Rendered content that originates from users, external systems, logs, stored data, or other non-UI content sources is not normalized by this initiative. The cleanup targets repo-authored UI labels and visuals only.
+
+### Happy Path
+1. A user opens the desktop app or a built-in plugin UI.
+2. Buttons, menus, cards, badges, and controls show Lucide icons instead of emoji.
+3. Common actions such as save, delete, search, and refresh use the same icon family wherever the meaning is the same.
+4. Theme and appearance controls use Lucide theme icons rather than emoji glyphs.
+5. Tool/action maps and similar visual dictionaries also use Lucide icons.
+6. Any user-provided or external content that contains emoji is displayed unchanged.
+
+### Edge Cases & Error Handling
+- **No exact emoji equivalent exists:** Use the closest Lucide icon rather than leaving emoji in place.
+- **Decorative emoji with light semantic value:** Replace with the closest Lucide icon instead of removing the visual marker.
+- **Same concept appears in multiple contexts:** Use one canonical Lucide icon when semantics match.
+- **Context genuinely changes the meaning:** A different Lucide icon is allowed only when the semantic distinction is material to the user.
+- **Existing Lucide drift already exists in an in-scope surface:** Normalize it during this initiative even if that specific UI did not previously use emoji.
+- **UI renders external or user-authored content:** Do not rewrite emoji that are part of that content.
+
+## Scope
+### In Scope
+- Repo-authored, user-facing UI iconography under:
+  - `apps/desktop/src/components/**`
+  - `packages/ui/src/components/**`
+  - `plugins/sero-*-plugin/ui/**`
+- All visual UI iconography in those surfaces, including:
+  - action controls
+  - menu items and command surfaces
+  - status chips, badges, and labels
+  - theme and appearance controls
+  - tool/action icon maps
+  - decorative UI markers in headers, cards, forms, and similar chrome
+- Normalization of recurring Lucide icon drift across all in-scope UI surfaces.
+- The explicitly identified admin editor patterns such as:
+  - `plugins/sero-admin-plugin/ui/components/SkillEditor.tsx`
+  - `plugins/sero-admin-plugin/ui/components/PromptEditor.tsx`
+  - `plugins/sero-admin-plugin/ui/components/AgentEditor.tsx`
+- Surface coverage that is clear enough for the planner to split by independent UI areas, including at minimum:
+  - desktop shell, command, and theme/appearance UI
+  - desktop workspace/explorer/orchestration UI
+  - shared UI package components
+  - admin plugin UI
+  - cron plugin UI
+  - other built-in plugin UIs under `plugins/sero-*-plugin/ui/**`
+
+### Out of Scope
+- Non-UI repo text such as docs, prompts, markdown, scripts, logs, tests, fixtures, config files, or developer-only console text.
+- Vendor, generated, or third-party code.
+- Copy rewrites unrelated to emoji/icon replacement.
+- Redesigning interaction flows or layout beyond what is necessary to preserve clarity after icon replacement.
+- Rewriting or sanitizing emoji that come from rendered user content, external systems, logs, or stored data.
+
+## Canonical Consistency Expectations
+At minimum, the initiative should preserve or enforce the repo’s dominant Lucide conventions for recurring user-facing concepts where semantics match:
+
+- delete / remove / uninstall → `Trash2`
+- save / persist → `Save`
+- search / find → `Search`
+- refresh / reload → `RefreshCw`
+- external navigation → `ExternalLink`
+- loading / in-progress → `Loader2`
+- success / done status → a check-family Lucide icon used consistently
+- error / failure status → an x-family Lucide icon used consistently
+- warning / caution status → an alert-family Lucide icon used consistently
+- theme / appearance controls → Lucide theme icons rather than emoji
+- clock / schedule / one-time timing concepts → clock-family Lucide iconography
+- recurring / repeat concepts → repeat or refresh-family Lucide iconography used consistently
+
+For recurring concepts beyond the list above, the initiative should still converge on one canonical Lucide choice per concept wherever the semantics are the same.
+
+## Effort & Quality
+- **Level:** production
+- **Tests:** none
+- **Docs:** none
+
+## Constraints
+- Lucide is the required visual system for replacing in-scope emoji iconography.
+- The initiative must preserve accessibility and legibility for dense controls, menus, and button labels.
+- The initiative must avoid scope creep into non-UI repo text.
+- The initiative must preserve displayed content fidelity when emoji belong to user-provided or external content.
+- The initiative must remain focused on consistency and semantics, not on unrelated visual redesign.
+
+## Success Metrics
+- Zero repo-authored emoji iconography remains in the defined in-scope UI surfaces.
+- Recurring user-facing concepts use consistent Lucide icons across in-scope surfaces when semantics match.
+- Existing Lucide inconsistency in in-scope UI is reduced to deliberate, semantically justified differences only.
+- Known hotspot patterns such as admin editor save/delete actions, cron reminder states, theme controls, and tool/icon maps conform to the consistency rules.
+- Manual product review can move through representative in-scope surfaces without encountering mixed emoji/Lucide iconography in repo-authored UI chrome.
+
+## Ideal State Criteria
+
+### Core Functionality
+- [ ] ISC-1: Desktop app UI contains no repo-authored emoji iconography.
+- [ ] ISC-2: Shared UI package components contain no repo-authored emoji iconography.
+- [ ] ISC-3: Built-in plugin UIs contain no repo-authored emoji iconography.
+- [ ] ISC-4: Delete and remove actions use `Trash2` when semantics match.
+- [ ] ISC-5: Save and persist actions use `Save` when semantics match.
+- [ ] ISC-6: Search and find actions use `Search` when semantics match.
+- [ ] ISC-7: Refresh and reload actions use `RefreshCw` when semantics match.
+- [ ] ISC-8: Theme and appearance controls use Lucide theme icons.
+- [ ] ISC-9: Tool and action icon maps use Lucide icons.
+- [ ] ISC-10: Existing Lucide drift is normalized across all in-scope UI.
+
+### Edge Cases
+- [ ] ISC-11: Decorative emoji markers are replaced with Lucide equivalents.
+- [ ] ISC-12: Closest Lucide matches are used when exact equivalents do not exist.
+- [ ] ISC-13: Recurring UI concepts use one canonical Lucide choice.
+- [ ] ISC-14: Context-specific icon variants appear only when semantics materially differ.
+
+### Anti-Criteria
+- [ ] ISC-A-1: User-provided or external content emoji are not rewritten.
+- [ ] ISC-A-2: Non-UI repo text is not required to change.
+- [ ] ISC-A-3: No new repo-authored UI emoji are introduced.

--- a/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useMemo, useRef, type KeyboardEvent } from 'react';
+import { FileCode2 } from 'lucide-react';
 import Editor from '@monaco-editor/react';
 import { EditorTabBar, type EditorTab } from './EditorTabBar';
 import { DevServerPreview, isDevServerTab } from './DevServerPreview';
@@ -26,7 +27,7 @@ import { useAppStore } from '@/stores/app';
 function EmptyEditorState() {
   return (
     <div className="flex h-full flex-col items-center justify-center gap-2 text-[var(--text-muted)]">
-      <p className="text-4xl opacity-40">📝</p>
+      <FileCode2 className="size-10 opacity-40" />
       <p className="text-sm font-medium text-[var(--text-secondary)]">No file open</p>
       <p className="max-w-[260px] text-center text-xs leading-relaxed">
         Select a file from the explorer or let your agent create one

--- a/apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx
+++ b/apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx
@@ -6,7 +6,22 @@
  */
 
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { ChevronRight, Loader2, CheckCircle2, XCircle, AlertCircle, Clock, Square } from 'lucide-react';
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronRight,
+  Clock,
+  FileText,
+  FolderOpen,
+  Loader2,
+  Pencil,
+  Search,
+  Square,
+  Terminal,
+  Wrench,
+  XCircle,
+  type LucideIcon,
+} from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { SubagentEntry, SubagentToolActivity } from '@/types/ipc';
 import { useSubagentStore } from '@/stores/subagent';
@@ -51,13 +66,19 @@ function formatCost(cost: number): string {
 
 // ── Tool activity icon ──────────────────────────────────────
 
-const TOOL_ICONS: Record<string, string> = {
-  read: '📖', bash: '📂', write: '✏️', edit: '✏️',
-  ls: '📁', find: '🔍', grep: '🔎',
+const TOOL_ICONS: Record<string, LucideIcon> = {
+  read: FileText,
+  bash: Terminal,
+  write: Pencil,
+  edit: Pencil,
+  ls: FolderOpen,
+  find: Search,
+  grep: Search,
 };
 
-function toolIcon(name: string): string {
-  return TOOL_ICONS[name] ?? '🔧';
+function ToolIcon({ name }: { name: string }) {
+  const Icon = TOOL_ICONS[name] ?? Wrench;
+  return <Icon className="size-3" />;
 }
 
 // ── Tool Activity Feed ──────────────────────────────────────
@@ -88,7 +109,7 @@ function ToolActivityFeed({ activity }: { activity: SubagentToolActivity[] }) {
           ) : (
             <span className="size-1.5 shrink-0 rounded-full bg-[var(--status-success)]" />
           )}
-          <span className="shrink-0 text-[10px]">{toolIcon(item.toolName)}</span>
+          <span className="shrink-0 text-[10px]"><ToolIcon name={item.toolName} /></span>
           <span className="shrink-0 text-[10px] font-medium text-[var(--text-muted)]">
             {item.toolName}
           </span>

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeLogRow.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeLogRow.tsx
@@ -6,6 +6,7 @@
  */
 
 import { memo } from 'react';
+import { CheckCircle2, Circle, XCircle } from 'lucide-react';
 import { motion } from 'motion/react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { ChangeEntry } from '@sero-ai/common';
@@ -24,15 +25,15 @@ function ChangeGlyph({ entry }: { entry: ChangeEntry }) {
     return <span className="text-[11px] font-bold text-[var(--status-info)]">@</span>;
   }
   if (entry.immutable) {
-    return <span className="text-[11px] text-[var(--status-success)]">◆</span>;
+    return <CheckCircle2 className="size-3 text-[var(--status-success)]" />;
   }
   if (entry.conflict) {
-    return <span className="text-[11px] text-[var(--status-error)]">✖</span>;
+    return <XCircle className="size-3 text-[var(--status-error)]" />;
   }
   if (entry.empty) {
-    return <span className="text-[11px] text-[var(--text-muted)]/30">○</span>;
+    return <Circle className="size-3 text-[var(--text-muted)]/30" />;
   }
-  return <span className="text-[11px] text-[var(--text-muted)]/60">○</span>;
+  return <Circle className="size-3 text-[var(--text-muted)]/60" />;
 }
 
 export const ChangeLogRow = memo(function ChangeLogRow({ entry, index, isExpanded, onToggle }: Props) {

--- a/apps/desktop/src/components/layout/CollaborationLiveActivity.tsx
+++ b/apps/desktop/src/components/layout/CollaborationLiveActivity.tsx
@@ -1,19 +1,29 @@
+import {
+  FileText,
+  FolderOpen,
+  Pencil,
+  Search,
+  Terminal,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { SubagentEntry } from '@/types/ipc';
 
-const TOOL_ICONS: Record<string, string> = {
-  read: '📖',
-  bash: '📂',
-  write: '✏️',
-  edit: '✏️',
-  ls: '📁',
-  find: '🔍',
-  grep: '🔎',
-  glob: '🔍',
+const TOOL_ICONS: Record<string, LucideIcon> = {
+  read: FileText,
+  bash: Terminal,
+  write: Pencil,
+  edit: Pencil,
+  ls: FolderOpen,
+  find: Search,
+  grep: Search,
+  glob: Search,
 };
 
-function toolIcon(name: string): string {
-  return TOOL_ICONS[name] ?? '🔧';
+function ToolIcon({ name }: { name: string }) {
+  const Icon = TOOL_ICONS[name] ?? Wrench;
+  return <Icon className="size-3" />;
 }
 
 interface CollaborationLiveActivityProps {
@@ -72,7 +82,7 @@ export function CollaborationLiveActivity({
                     : 'bg-[var(--status-success)]',
                 )}
               />
-              <span className="text-[10px]">{toolIcon(currentToolActivity.toolName)}</span>
+              <ToolIcon name={currentToolActivity.toolName} />
               <span className="shrink-0 text-[10px] font-medium text-[var(--text-secondary)]/80">
                 {currentToolActivity.toolName}
               </span>

--- a/apps/desktop/src/components/layout/PendingQuestionCard.tsx
+++ b/apps/desktop/src/components/layout/PendingQuestionCard.tsx
@@ -10,7 +10,7 @@
 
 import { useState, useCallback } from 'react';
 import { motion } from 'motion/react';
-import { ChevronRight, X, Send, ShieldAlert } from 'lucide-react';
+import { ChevronRight, Pencil, X, Send, ShieldAlert } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { IconAction } from '@/components/ui/IconAction';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -228,7 +228,7 @@ function QuestionCardInner({ question }: { question: UserFeedbackPendingQuestion
             onClick={() => setCustomMode(true)}
             className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left hover:bg-[var(--bg-elevated)]/80"
           >
-            <span className="mt-px text-[11px] text-[var(--text-muted)]">✎</span>
+            <Pencil className="size-3 text-[var(--text-muted)]" />
             <span className="text-[13px] text-[var(--text-muted)]">Type something…</span>
           </button>
         )}

--- a/apps/desktop/src/components/layout/shell/CommandMenu.tsx
+++ b/apps/desktop/src/components/layout/shell/CommandMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Smartphone } from 'lucide-react';
+import { Monitor, Palette, Pencil, Smartphone } from 'lucide-react';
 import {
   CommandDialog,
   CommandEmpty,
@@ -105,15 +105,15 @@ export function CommandMenu() {
           </CommandGroup>
           <CommandGroup heading="Theme">
             <CommandItem value="Browse Themes" onSelect={handleOpenThemePanel}>
-              <span className="size-4 shrink-0 flex items-center justify-center">🎨</span>
+              <Palette className="size-4 shrink-0" />
               <span>Browse Themes</span>
             </CommandItem>
             <CommandItem value="Edit Current Theme" onSelect={handleEditCurrent}>
-              <span className="size-4 shrink-0 flex items-center justify-center">✏️</span>
+              <Pencil className="size-4 shrink-0" />
               <span>Edit Current Theme</span>
             </CommandItem>
             <CommandItem value="Toggle Theme Mode" onSelect={handleToggleMode}>
-              <span className="size-4 shrink-0 flex items-center justify-center">◑</span>
+              <Monitor className="size-4 shrink-0" />
               <span>Toggle Light / Dark / System</span>
             </CommandItem>
           </CommandGroup>

--- a/apps/desktop/src/components/layout/theme/theme-panel/ModeToggle.tsx
+++ b/apps/desktop/src/components/layout/theme/theme-panel/ModeToggle.tsx
@@ -2,6 +2,7 @@
  * ModeToggle — three-way toggle for Light / Dark / System theme mode.
  */
 
+import { Monitor, Moon, Sun, type LucideIcon } from 'lucide-react';
 import type { ThemeMode } from '@/types/theme';
 
 interface ModeToggleProps {
@@ -9,33 +10,36 @@ interface ModeToggleProps {
   onModeChange: (mode: ThemeMode) => void;
 }
 
-const MODES: Array<{ value: ThemeMode; label: string; icon: string }> = [
-  { value: 'light', label: 'Light', icon: '☀' },
-  { value: 'dark', label: 'Dark', icon: '☾' },
-  { value: 'system', label: 'System', icon: '⚙' },
+const MODES: Array<{ value: ThemeMode; label: string; icon: LucideIcon }> = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
 ];
 
 export function ModeToggle({ mode, onModeChange }: ModeToggleProps) {
   return (
     <div className="flex items-center gap-1 rounded-lg bg-[var(--bg-surface)] p-1">
-      {MODES.map((m) => (
-        <button
-          key={m.value}
-          type="button"
-          onClick={() => onModeChange(m.value)}
-          className={`
-            flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium
-            transition-colors
-            ${mode === m.value
-              ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-sm'
-              : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
-            }
-          `}
-        >
-          <span>{m.icon}</span>
-          <span>{m.label}</span>
-        </button>
-      ))}
+      {MODES.map((m) => {
+        const Icon = m.icon;
+        return (
+          <button
+            key={m.value}
+            type="button"
+            onClick={() => onModeChange(m.value)}
+            className={`
+              flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium
+              transition-colors
+              ${mode === m.value
+                ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)] shadow-sm'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+              }
+            `}
+          >
+            <Icon className="size-3.5" />
+            <span>{m.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
+++ b/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
@@ -9,6 +9,7 @@ import {
   Monitor,
   Plus,
   Trash2,
+  X,
 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -196,7 +197,7 @@ export function WorkspaceNode({ workspace, sessions }: WorkspaceNodeProps) {
                 className="rounded p-0.5 text-xs text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-base)] hover:text-[var(--text-primary)]"
                 title="Clear selection (Esc)"
               >
-                ✕
+                <X className="size-3" />
               </span>
             </span>
           ) : (

--- a/packages/ui/src/components/ai-elements/voice-selector-accent.tsx
+++ b/packages/ui/src/components/ai-elements/voice-selector-accent.tsx
@@ -1,0 +1,50 @@
+import type { ComponentProps } from 'react';
+import { Languages } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+export type VoiceSelectorAccentValue =
+  | 'american'
+  | 'british'
+  | 'australian'
+  | 'canadian'
+  | 'irish'
+  | 'scottish'
+  | 'indian'
+  | 'south-african'
+  | 'new-zealand'
+  | 'spanish'
+  | 'french'
+  | 'german'
+  | 'italian'
+  | 'portuguese'
+  | 'brazilian'
+  | 'mexican'
+  | 'argentinian'
+  | 'japanese'
+  | 'chinese'
+  | 'korean'
+  | 'russian'
+  | 'arabic'
+  | 'dutch'
+  | 'swedish'
+  | 'norwegian'
+  | 'danish'
+  | 'finnish'
+  | 'polish'
+  | 'turkish'
+  | 'greek'
+  | string;
+
+export type VoiceSelectorAccentProps = ComponentProps<'span'> & {
+  value?: VoiceSelectorAccentValue;
+};
+
+export const VoiceSelectorAccent = ({
+  className,
+  children,
+  ...props
+}: VoiceSelectorAccentProps) => (
+  <span className={cn('text-muted-foreground text-xs', className)} {...props}>
+    {children ?? <Languages className="size-4" />}
+  </span>
+);

--- a/packages/ui/src/components/ai-elements/voice-selector.tsx
+++ b/packages/ui/src/components/ai-elements/voice-selector.tsx
@@ -3,6 +3,10 @@
 import type { ComponentProps, ReactNode } from "react";
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import {
+  VoiceSelectorAccent,
+  type VoiceSelectorAccentProps,
+} from "./voice-selector-accent";
 import { Button } from "../ui/button";
 import {
   Command,
@@ -238,181 +242,8 @@ export const VoiceSelectorGender = ({
   );
 };
 
-export type VoiceSelectorAccentProps = ComponentProps<"span"> & {
-  value?:
-    | "american"
-    | "british"
-    | "australian"
-    | "canadian"
-    | "irish"
-    | "scottish"
-    | "indian"
-    | "south-african"
-    | "new-zealand"
-    | "spanish"
-    | "french"
-    | "german"
-    | "italian"
-    | "portuguese"
-    | "brazilian"
-    | "mexican"
-    | "argentinian"
-    | "japanese"
-    | "chinese"
-    | "korean"
-    | "russian"
-    | "arabic"
-    | "dutch"
-    | "swedish"
-    | "norwegian"
-    | "danish"
-    | "finnish"
-    | "polish"
-    | "turkish"
-    | "greek"
-    | string;
-};
-
-export const VoiceSelectorAccent = ({
-  className,
-  value,
-  children,
-  ...props
-}: VoiceSelectorAccentProps) => {
-  let emoji: string | null = null;
-
-  switch (value) {
-    case "american": {
-      emoji = "🇺🇸";
-      break;
-    }
-    case "british": {
-      emoji = "🇬🇧";
-      break;
-    }
-    case "australian": {
-      emoji = "🇦🇺";
-      break;
-    }
-    case "canadian": {
-      emoji = "🇨🇦";
-      break;
-    }
-    case "irish": {
-      emoji = "🇮🇪";
-      break;
-    }
-    case "scottish": {
-      emoji = "🏴󠁧󠁢󠁳󠁣󠁴󠁿";
-      break;
-    }
-    case "indian": {
-      emoji = "🇮🇳";
-      break;
-    }
-    case "south-african": {
-      emoji = "🇿🇦";
-      break;
-    }
-    case "new-zealand": {
-      emoji = "🇳🇿";
-      break;
-    }
-    case "spanish": {
-      emoji = "🇪🇸";
-      break;
-    }
-    case "french": {
-      emoji = "🇫🇷";
-      break;
-    }
-    case "german": {
-      emoji = "🇩🇪";
-      break;
-    }
-    case "italian": {
-      emoji = "🇮🇹";
-      break;
-    }
-    case "portuguese": {
-      emoji = "🇵🇹";
-      break;
-    }
-    case "brazilian": {
-      emoji = "🇧🇷";
-      break;
-    }
-    case "mexican": {
-      emoji = "🇲🇽";
-      break;
-    }
-    case "argentinian": {
-      emoji = "🇦🇷";
-      break;
-    }
-    case "japanese": {
-      emoji = "🇯🇵";
-      break;
-    }
-    case "chinese": {
-      emoji = "🇨🇳";
-      break;
-    }
-    case "korean": {
-      emoji = "🇰🇷";
-      break;
-    }
-    case "russian": {
-      emoji = "🇷🇺";
-      break;
-    }
-    case "arabic": {
-      emoji = "🇸🇦";
-      break;
-    }
-    case "dutch": {
-      emoji = "🇳🇱";
-      break;
-    }
-    case "swedish": {
-      emoji = "🇸🇪";
-      break;
-    }
-    case "norwegian": {
-      emoji = "🇳🇴";
-      break;
-    }
-    case "danish": {
-      emoji = "🇩🇰";
-      break;
-    }
-    case "finnish": {
-      emoji = "🇫🇮";
-      break;
-    }
-    case "polish": {
-      emoji = "🇵🇱";
-      break;
-    }
-    case "turkish": {
-      emoji = "🇹🇷";
-      break;
-    }
-    case "greek": {
-      emoji = "🇬🇷";
-      break;
-    }
-    default: {
-      emoji = null;
-    }
-  }
-
-  return (
-    <span className={cn("text-muted-foreground text-xs", className)} {...props}>
-      {children ?? emoji}
-    </span>
-  );
-};
+export { VoiceSelectorAccent };
+export type { VoiceSelectorAccentProps };
 
 export type VoiceSelectorAgeProps = ComponentProps<"span">;
 

--- a/plugins/sero-admin-plugin/ui/components/AgentEditor.tsx
+++ b/plugins/sero-admin-plugin/ui/components/AgentEditor.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Save, Trash2 } from 'lucide-react';
 import {
   THINKING_LABELS,
   findModelByReference,
@@ -167,11 +168,17 @@ export function AgentEditor({ data, isNew, saving, onSave, onDelete, onChange }:
             className="text-destructive hover:text-destructive"
             onClick={() => onDelete(data.name)}
           >
-            🗑 Delete
+            <Trash2 className="size-3.5" />
+            Delete
           </Button>
         )}
         <Button type="submit" size="sm" disabled={!canSave || saving}>
-          {saving ? 'Saving…' : '💾 Save'}
+          {saving ? 'Saving…' : (
+            <>
+              <Save className="size-3.5" />
+              Save
+            </>
+          )}
         </Button>
       </div>
 

--- a/plugins/sero-admin-plugin/ui/components/ConfigPanel.tsx
+++ b/plugins/sero-admin-plugin/ui/components/ConfigPanel.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useEffect, useCallback, memo } from 'react';
+import { TriangleAlert } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
@@ -267,7 +268,10 @@ function ConfigEditor({
             {configFile?.label ?? configKey}
           </span>
           {isSensitive && (
-            <span className="text-[10px] text-amber-400/70">⚠ Contains sensitive data</span>
+            <span className="inline-flex items-center gap-1 text-[10px] text-amber-400/70">
+              <TriangleAlert className="size-3" />
+              Contains sensitive data
+            </span>
           )}
         </div>
         <div className="flex items-center gap-1.5">

--- a/plugins/sero-admin-plugin/ui/components/LogViewer.tsx
+++ b/plugins/sero-admin-plugin/ui/components/LogViewer.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef, memo } from 'react';
+import { RefreshCw } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
@@ -235,7 +236,8 @@ function LogContent({ log }: { log: LogEntry }) {
             )}
             onClick={() => setAutoRefresh(!autoRefresh)}
           >
-            {autoRefresh ? '● Auto' : '○ Auto'}
+            <RefreshCw className={cn('size-3', autoRefresh && 'animate-spin')} />
+            Auto
           </Button>
           <Button
             variant="ghost"
@@ -302,7 +304,10 @@ function LogContent({ log }: { log: LogEntry }) {
         <p className="text-[10px] text-muted-foreground/40">
           {totalLines} lines
           {autoRefresh && (
-            <span className="ml-2 text-primary/50">● Refreshing every 3s</span>
+            <span className="ml-2 inline-flex items-center gap-1 text-primary/50">
+              <RefreshCw className="size-3 animate-spin" />
+              Refreshing every 3s
+            </span>
           )}
         </p>
       </div>

--- a/plugins/sero-admin-plugin/ui/components/PromptEditor.tsx
+++ b/plugins/sero-admin-plugin/ui/components/PromptEditor.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useCallback } from 'react';
+import { Save, Trash2 } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { PromptTemplateFileData } from './types';
@@ -52,11 +53,17 @@ export function PromptEditor({ data, isNew, saving, onSave, onDelete, onChange }
             className="text-destructive hover:text-destructive"
             onClick={() => onDelete(data.filePath!)}
           >
-            🗑 Delete
+            <Trash2 className="size-3.5" />
+            Delete
           </Button>
         )}
         <Button type="submit" size="sm" disabled={!canSave || saving}>
-          {saving ? 'Saving…' : '💾 Save'}
+          {saving ? 'Saving…' : (
+            <>
+              <Save className="size-3.5" />
+              Save
+            </>
+          )}
         </Button>
       </div>
 

--- a/plugins/sero-admin-plugin/ui/components/ResourceSection.tsx
+++ b/plugins/sero-admin-plugin/ui/components/ResourceSection.tsx
@@ -3,6 +3,7 @@
  * Used by Agents, Skills, and Prompts sections.
  */
 
+import { Plus, RefreshCw } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 
 interface ResourceSectionProps {
@@ -34,10 +35,10 @@ export function ResourceSection({
             {count} {label.toLowerCase()}{count !== 1 ? 's' : ''}
           </span>
           <Button variant="ghost" size="icon-sm" onClick={onRefresh} title="Refresh">
-            <span className="text-xs">↻</span>
+            <RefreshCw className="size-3" />
           </Button>
           <Button variant="ghost" size="icon-sm" onClick={onNew} title={`New ${label}`}>
-            <span className="text-xs">+</span>
+            <Plus className="size-3" />
           </Button>
         </div>
 
@@ -79,7 +80,8 @@ function EmptyState({ label, onNew }: { label: string; onNew: () => void }) {
         Select a {label.toLowerCase()} to edit, or create a new one
       </p>
       <Button variant="secondary" size="sm" onClick={onNew}>
-        + New {label}
+        <Plus className="size-3.5" />
+        New {label}
       </Button>
     </div>
   );

--- a/plugins/sero-admin-plugin/ui/components/SessionDetail.tsx
+++ b/plugins/sero-admin-plugin/ui/components/SessionDetail.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useEffect, useMemo, useState, memo } from 'react';
+import { X } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
@@ -247,7 +248,7 @@ const MessageDetailOverlay = memo(function MessageDetailOverlay({
             className="h-6 px-2 text-xs text-muted-foreground"
             onClick={onClose}
           >
-            ✕
+            <X className="size-3.5" />
           </Button>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto">

--- a/plugins/sero-admin-plugin/ui/components/SessionList.tsx
+++ b/plugins/sero-admin-plugin/ui/components/SessionList.tsx
@@ -6,6 +6,7 @@
  */
 
 import { memo } from 'react';
+import { RefreshCw } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
@@ -38,7 +39,7 @@ export const SessionList = memo(function SessionList({
           className="h-5 px-1.5 text-[10px] text-muted-foreground/40 hover:text-foreground"
           onClick={onReload}
         >
-          ↻
+          <RefreshCw className="size-3" />
         </Button>
       </div>
 

--- a/plugins/sero-admin-plugin/ui/components/SkillEditor.tsx
+++ b/plugins/sero-admin-plugin/ui/components/SkillEditor.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useCallback } from 'react';
+import { Save, Trash2 } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Switch } from '@sero-ai/ui/components/ui/switch';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -61,11 +62,17 @@ export function SkillEditor({
             className="text-destructive hover:text-destructive"
             onClick={() => onDelete(data.filePath!)}
           >
-            🗑 Delete
+            <Trash2 className="size-3.5" />
+            Delete
           </Button>
         )}
         <Button type="submit" size="sm" disabled={!canSave || saving}>
-          {saving ? 'Saving…' : '💾 Save'}
+          {saving ? 'Saving…' : (
+            <>
+              <Save className="size-3.5" />
+              Save
+            </>
+          )}
         </Button>
       </div>
 

--- a/plugins/sero-cron-plugin/package.json
+++ b/plugins/sero-cron-plugin/package.json
@@ -81,6 +81,7 @@
     "@vitejs/plugin-react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "lucide-react": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:"

--- a/plugins/sero-cron-plugin/ui/components/CronAppHeader.tsx
+++ b/plugins/sero-cron-plugin/ui/components/CronAppHeader.tsx
@@ -1,3 +1,4 @@
+import { Clock3, Plus } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 
 type CronAppTab = 'jobs' | 'reminders' | 'history';
@@ -20,7 +21,7 @@ export function CronAppHeader({
   return (
     <div className="mb-3 flex items-center justify-between">
       <div>
-        <h1 className="text-lg font-semibold text-foreground">⏰ Scheduler</h1>
+        <h1 className="inline-flex items-center gap-2 text-lg font-semibold text-foreground"><Clock3 className="size-5" />Scheduler</h1>
         <p className="mt-0.5 text-xs text-muted-foreground">
           Cron jobs, reminders, and notifications
         </p>
@@ -28,12 +29,14 @@ export function CronAppHeader({
       <div className="flex gap-2">
         {activeTab === 'reminders' && (
           <Button size="sm" onClick={onAddReminder}>
-            + Reminder
+            <Plus className="size-3.5" />
+            Reminder
           </Button>
         )}
         {activeTab === 'jobs' && (
           <Button size="sm" onClick={onAddJob}>
-            + Job
+            <Plus className="size-3.5" />
+            Job
           </Button>
         )}
         {activeTab === 'history' && historyCount > 0 && (

--- a/plugins/sero-cron-plugin/ui/components/JobCard.tsx
+++ b/plugins/sero-cron-plugin/ui/components/JobCard.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState } from 'react';
+import { Pause, Play } from 'lucide-react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -126,7 +127,17 @@ export function JobCard({
             className="h-7 text-xs"
             onClick={() => onToggleEnabled(job.name)}
           >
-            {job.disabled ? '▶ Enable' : '⏸ Disable'}
+            {job.disabled ? (
+              <>
+                <Play className="size-3.5" />
+                Enable
+              </>
+            ) : (
+              <>
+                <Pause className="size-3.5" />
+                Disable
+              </>
+            )}
           </Button>
           <Button
             variant="ghost"
@@ -138,7 +149,8 @@ export function JobCard({
               schedulerActive ? 'Run now' : 'Start scheduler first'
             }
           >
-            ▶ Run
+            <Play className="size-3.5" />
+            Run
           </Button>
           <div className="flex-1" />
           <Button

--- a/plugins/sero-cron-plugin/ui/components/JobForm.tsx
+++ b/plugins/sero-cron-plugin/ui/components/JobForm.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
+import { Check } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import {
   Dialog,
@@ -171,8 +172,9 @@ export function JobForm({ open, onClose, onSave, editingJob }: JobFormProps) {
                 {scheduleError}
               </p>
             ) : schedule.trim() ? (
-              <p className="mt-1 text-[11px] text-emerald-500">
-                ✓ {cronToHuman(schedule.trim())}
+              <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-emerald-500">
+                <Check className="size-3" />
+                {cronToHuman(schedule.trim())}
               </p>
             ) : (
               <p className="mt-1 text-[11px] text-muted-foreground">

--- a/plugins/sero-cron-plugin/ui/components/JobsTab.tsx
+++ b/plugins/sero-cron-plugin/ui/components/JobsTab.tsx
@@ -1,3 +1,4 @@
+import { Clock3, Plus } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 
 import type { CronJob } from '../../shared/types';
@@ -25,13 +26,14 @@ export function JobsTab({
   if (jobs.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center animate-cron-fade-in">
-        <div className="mb-4 text-4xl">⏰</div>
+        <Clock3 className="mb-4 size-10 text-muted-foreground" />
         <h2 className="text-base font-medium text-foreground">No cron jobs yet</h2>
         <p className="mt-1.5 max-w-[240px] text-xs leading-relaxed text-muted-foreground">
           Create a job to schedule recurring agent prompts.
         </p>
         <Button size="sm" className="mt-4" onClick={onAdd}>
-          + New Job
+          <Plus className="size-3.5" />
+          New Job
         </Button>
       </div>
     );

--- a/plugins/sero-cron-plugin/ui/components/ModelPicker.tsx
+++ b/plugins/sero-cron-plugin/ui/components/ModelPicker.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { Check, Settings2, Sparkles, X } from 'lucide-react';
 import {
   useAvailableModels,
   type AppModelInfo,
@@ -141,7 +142,7 @@ export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
               {resolved.model.name}
             </span>
             {resolved.model.reasoning && (
-              <span className="text-[10px] text-amber-500">✦</span>
+              <Sparkles className="size-3 text-amber-500" />
             )}
           </>
         ) : value ? (
@@ -162,7 +163,7 @@ export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
             className="ml-1 rounded p-0.5 text-muted-foreground hover:text-foreground"
             title="Reset to default"
           >
-            ✕
+            <X className="size-3" />
           </button>
         ) : (
           <svg className="size-3 text-muted-foreground" viewBox="0 0 12 12" fill="none">
@@ -227,9 +228,9 @@ export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
                   : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground',
               )}
             >
-              <span className="size-4 text-center text-[10px]">⚙</span>
+              <Settings2 className="size-4" />
               <span className="font-medium">Use default model</span>
-              {!value && <span className="ml-auto text-emerald-500 text-[11px]">✓</span>}
+              {!value && <Check className="ml-auto size-3.5 text-emerald-500" />}
             </button>
           </div>
         </div>
@@ -282,14 +283,14 @@ function ProviderGroup({
             >
               <span className="size-3.5 text-center text-[11px]">
                 {isSelected ? (
-                  <span className="text-emerald-500">✓</span>
+                  <Check className="size-3 text-emerald-500" />
                 ) : (
                   <span className="inline-block size-1.5 rounded-full bg-border" />
                 )}
               </span>
               <span className="flex-1 truncate font-medium">{model.name}</span>
               {model.reasoning && (
-                <span className="text-[10px] text-amber-500/60">✦</span>
+                <Sparkles className="size-3 text-amber-500/60" />
               )}
             </button>
           );

--- a/plugins/sero-cron-plugin/ui/components/NotificationSettings.tsx
+++ b/plugins/sero-cron-plugin/ui/components/NotificationSettings.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState } from 'react';
+import { Bell, BellOff } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Switch } from '@sero-ai/ui/components/ui/switch';
 import {
@@ -40,7 +41,7 @@ export function NotificationSettings({
           className="h-7 w-7 p-0 text-muted-foreground hover:text-foreground"
           title="Notification settings"
         >
-          {effective.soundEnabled ? '🔔' : '🔕'}
+          {effective.soundEnabled ? <Bell className="size-3.5" /> : <BellOff className="size-3.5" />}
         </Button>
       </PopoverTrigger>
 

--- a/plugins/sero-cron-plugin/ui/components/ReminderCard.tsx
+++ b/plugins/sero-cron-plugin/ui/components/ReminderCard.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState } from 'react';
+import { Bell, Check, CheckCircle2, Clock3, Mail, Pause, Play, RefreshCw } from 'lucide-react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -72,8 +73,9 @@ export function ReminderCard({
               </Badge>
             )}
             {reminder.channel === 'email' && (
-              <Badge variant="outline" className="border-amber-500/30 text-[10px] text-amber-500">
-                📧 legacy email
+              <Badge variant="outline" className="inline-flex items-center gap-1 border-amber-500/30 text-[10px] text-amber-500">
+                <Mail className="size-3" />
+                legacy email
               </Badge>
             )}
           </div>
@@ -89,11 +91,15 @@ export function ReminderCard({
               </>
             )}
             {reminder.type === 'once' && reminder.fireAt && (
-              <span>🕐 {formatDateTime(reminder.fireAt)}</span>
+              <span className="inline-flex items-center gap-1">
+                <Clock3 className="size-3" />
+                {formatDateTime(reminder.fireAt)}
+              </span>
             )}
             {isSnoozed && reminder.snoozedUntil && (
-              <span className="text-amber-500">
-                💤 Until {formatDateTime(reminder.snoozedUntil)}
+              <span className="inline-flex items-center gap-1 text-amber-500">
+                <Pause className="size-3" />
+                Until {formatDateTime(reminder.snoozedUntil)}
               </span>
             )}
           </div>
@@ -124,7 +130,17 @@ export function ReminderCard({
                   variant="ghost" size="sm" className="h-7 text-xs"
                   onClick={() => onToggleEnabled(reminder.id)}
                 >
-                  {isDisabled ? '▶ Enable' : '⏸ Disable'}
+                  {isDisabled ? (
+                    <>
+                      <Play className="size-3.5" />
+                      Enable
+                    </>
+                  ) : (
+                    <>
+                      <Pause className="size-3.5" />
+                      Disable
+                    </>
+                  )}
                 </Button>
                 {!isDisabled && (
                   <div className="relative">
@@ -133,7 +149,8 @@ export function ReminderCard({
                       className="h-7 text-xs text-amber-500 hover:text-amber-600"
                       onClick={() => setShowSnoozeMenu(!showSnoozeMenu)}
                     >
-                      💤 Snooze
+                      <Pause className="size-3.5" />
+                      Snooze
                     </Button>
                     {showSnoozeMenu && (
                       <SnoozeDropdown
@@ -148,7 +165,8 @@ export function ReminderCard({
                   className="h-7 text-xs text-emerald-500 hover:text-emerald-600"
                   onClick={() => onComplete(reminder.id)}
                 >
-                  ✓ Done
+                  <Check className="size-3.5" />
+                  Done
                 </Button>
               </>
             )}
@@ -194,26 +212,30 @@ function StatusBadge({ status }: { status: Reminder['status'] }) {
   switch (status) {
     case 'active':
       return (
-        <Badge variant="outline" className="border-emerald-500/30 text-[10px] text-emerald-500">
-          🔔 Active
+        <Badge variant="outline" className="inline-flex items-center gap-1 border-emerald-500/30 text-[10px] text-emerald-500">
+          <Bell className="size-3" />
+          Active
         </Badge>
       );
     case 'snoozed':
       return (
-        <Badge variant="outline" className="border-amber-500/30 text-[10px] text-amber-500">
-          💤 Snoozed
+        <Badge variant="outline" className="inline-flex items-center gap-1 border-amber-500/30 text-[10px] text-amber-500">
+          <Pause className="size-3" />
+          Snoozed
         </Badge>
       );
     case 'completed':
       return (
-        <Badge variant="secondary" className="text-[10px]">
-          ✅ Done
+        <Badge variant="secondary" className="inline-flex items-center gap-1 text-[10px]">
+          <CheckCircle2 className="size-3" />
+          Done
         </Badge>
       );
     case 'disabled':
       return (
-        <Badge variant="secondary" className="text-[10px]">
-          ⏸ Paused
+        <Badge variant="secondary" className="inline-flex items-center gap-1 text-[10px]">
+          <Pause className="size-3" />
+          Paused
         </Badge>
       );
     default:
@@ -224,8 +246,9 @@ function StatusBadge({ status }: { status: Reminder['status'] }) {
 function TypeBadge({ type }: { type: Reminder['type'] }) {
   if (type === 'recurring') {
     return (
-      <Badge variant="outline" className="border-primary/30 text-[10px] text-primary">
-        🔄 Recurring
+      <Badge variant="outline" className="inline-flex items-center gap-1 border-primary/30 text-[10px] text-primary">
+        <RefreshCw className="size-3" />
+        Recurring
       </Badge>
     );
   }

--- a/plugins/sero-cron-plugin/ui/components/ReminderForm.tsx
+++ b/plugins/sero-cron-plugin/ui/components/ReminderForm.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
+import { Check, Clock3, Monitor, RefreshCw } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import {
   Dialog,
@@ -185,7 +186,17 @@ export function ReminderForm({
                       : 'border-border text-muted-foreground hover:bg-secondary',
                   )}
                 >
-                  {t === 'once' ? '🕐 One-time' : '🔄 Recurring'}
+                  {t === 'once' ? (
+                    <span className="inline-flex items-center gap-1.5">
+                      <Clock3 className="size-3.5" />
+                      One-time
+                    </span>
+                  ) : (
+                    <span className="inline-flex items-center gap-1.5">
+                      <RefreshCw className="size-3.5" />
+                      Recurring
+                    </span>
+                  )}
                 </button>
               ))}
             </div>
@@ -222,8 +233,9 @@ export function ReminderForm({
               {scheduleError ? (
                 <p className="mt-1 text-[11px] text-destructive">{scheduleError}</p>
               ) : schedule.trim() ? (
-                <p className="mt-1 text-[11px] text-emerald-500">
-                  ✓ {cronToHuman(schedule.trim())}
+                <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-emerald-500">
+                  <Check className="size-3" />
+                  {cronToHuman(schedule.trim())}
                 </p>
               ) : (
                 <p className="mt-1 text-[11px] text-muted-foreground">
@@ -273,7 +285,10 @@ export function ReminderForm({
               Notification Channel
             </label>
             <div className="rounded-md border border-border bg-secondary/30 px-3 py-2 text-xs text-foreground">
-              <div className="font-medium">🖥 Desktop notification</div>
+              <div className="inline-flex items-center gap-1.5 font-medium">
+                <Monitor className="size-3.5" />
+                Desktop notification
+              </div>
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Email delivery is not supported yet. Saving this reminder will use the desktop notification path.
               </p>

--- a/plugins/sero-cron-plugin/ui/components/ReminderList.tsx
+++ b/plugins/sero-cron-plugin/ui/components/ReminderList.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useMemo } from 'react';
+import { Bell, Plus } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -163,7 +164,7 @@ function getNextFireTime(r: Reminder): number {
 function EmptyState({ onAdd }: { onAdd: () => void }) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center animate-cron-fade-in">
-      <div className="mb-4 text-4xl">🔔</div>
+      <Bell className="mb-4 size-10 text-muted-foreground" />
       <h2 className="text-base font-medium text-foreground">
         No reminders yet
       </h2>
@@ -172,7 +173,8 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
         something like "Remind me in 1 hour to phone mum".
       </p>
       <Button size="sm" className="mt-4" onClick={onAdd}>
-        + New Reminder
+        <Plus className="size-3.5" />
+        New Reminder
       </Button>
     </div>
   );

--- a/plugins/sero-cron-plugin/ui/components/SchedulerBar.tsx
+++ b/plugins/sero-cron-plugin/ui/components/SchedulerBar.tsx
@@ -3,6 +3,7 @@
  * and start/stop button.
  */
 
+import { Bell, Pause, Play } from 'lucide-react';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Switch } from '@sero-ai/ui/components/ui/switch';
@@ -76,9 +77,10 @@ export function SchedulerBar({
         {(reminderCount ?? 0) > 0 && (
           <Badge
             variant="outline"
-            className="border-amber-500/30 text-xs text-amber-500"
+            className="inline-flex items-center gap-1 border-amber-500/30 text-xs text-amber-500"
           >
-            🔔 {reminderCount} reminder{reminderCount === 1 ? '' : 's'}
+            <Bell className="size-3" />
+            {reminderCount} reminder{reminderCount === 1 ? '' : 's'}
           </Badge>
         )}
       </div>
@@ -114,7 +116,17 @@ export function SchedulerBar({
             'bg-emerald-600 text-white hover:bg-emerald-700',
         )}
       >
-        {active ? '⏸ Stop' : '▶ Start'}
+        {active ? (
+          <>
+            <Pause className="size-3.5" />
+            Stop
+          </>
+        ) : (
+          <>
+            <Play className="size-3.5" />
+            Start
+          </>
+        )}
       </Button>
     </div>
   );

--- a/plugins/sero-user-feedback-plugin/ui/InterviewForm.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/InterviewForm.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect } from 'react';
+import { Check } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type {
@@ -127,7 +128,7 @@ function QuestionRow({
             : 'bg-[var(--bg-elevated)] text-[var(--text-muted)]',
         )}
       >
-        {hasValue ? '✓' : index + 1}
+        {hasValue ? <Check className="size-3" /> : index + 1}
       </span>
 
       {/* Question + input */}

--- a/plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Check } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Card } from '@sero-ai/ui/components/ui/card';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -148,7 +149,7 @@ export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
                     : 'bg-secondary text-muted-foreground',
               )}
             >
-              {hasQuestionAnswer(answers, item.id) ? '✓' : index + 1} {item.label}
+              {hasQuestionAnswer(answers, item.id) ? <Check className="size-3" /> : index + 1} {item.label}
             </button>
           ))}
           <button

--- a/plugins/sero-user-feedback-plugin/ui/questionnaire/QuestionnaireQuestionStep.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/questionnaire/QuestionnaireQuestionStep.tsx
@@ -1,3 +1,4 @@
+import { Check, Pencil } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 
@@ -70,7 +71,7 @@ export function QuestionnaireQuestionStep({
                     : 'border-[var(--border)] text-muted-foreground',
                 )}
               >
-                {question.multiSelect ? (isSelected ? '✓' : '') : index + 1}
+                {question.multiSelect ? (isSelected ? <Check className="size-3" /> : null) : index + 1}
               </span>
               <div className="min-w-0 flex-1">
                 <span className="text-sm text-foreground">{option.label}</span>
@@ -113,7 +114,7 @@ export function QuestionnaireQuestionStep({
             className="flex w-full items-center gap-3 rounded-md border border-transparent px-3 py-2.5 text-left hover:border-border hover:bg-secondary"
           >
             <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-[var(--border)] text-[10px] text-muted-foreground">
-              ✎
+              <Pencil className="size-3" />
             </span>
             <span className="text-sm text-muted-foreground">Type something…</span>
           </button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,10 +508,10 @@ importers:
     dependencies:
       '@mariozechner/pi-ai':
         specifier: catalog:peer
-        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: catalog:peer
         version: 0.61.1
@@ -629,6 +629,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.563.0(react@19.2.4)
       react:
         specifier: 'catalog:'
         version: 19.2.4
@@ -12125,18 +12128,6 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
   '@mariozechner/pi-agent-core@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
@@ -12164,30 +12155,6 @@ snapshots:
   '@mariozechner/pi-agent-core@0.61.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1009.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
-      '@mistralai/mistralai': 1.14.1
-      '@sinclair/typebox': 0.34.48
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.18.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      undici: 7.24.2
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12236,38 +12203,6 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.24.2
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.61.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.3
-      extract-zip: 2.0.1
-      file-type: 21.3.2
-      glob: 13.0.6
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      marked: 15.0.12
-      minimatch: 10.2.4
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      undici: 7.24.2
-      yaml: 2.8.2
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.2
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -19261,11 +19196,6 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
-
-  openai@6.26.0(ws@8.18.0)(zod@4.3.6):
-    optionalDependencies:
-      ws: 8.18.0
-      zod: 4.3.6
 
   openai@6.26.0(ws@8.19.0)(zod@3.25.76):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- replace repo-authored user-facing UI emoji icons with Lucide across desktop, admin, cron, user-feedback, and shared UI surfaces
- normalize common icon semantics for actions and states like save, delete, refresh, theme controls, scheduler actions, and tool activity maps
- split `voice-selector` accent handling into a dedicated module, swap flag emoji for `Languages`, and keep touched files within the repo LOC limits

## Validation
- `pnpm typecheck`
- targeted in-scope emoji sweep across `apps/desktop/src/components`, `packages/ui/src/components`, and `plugins/sero-*-plugin/ui`

## Notes
- includes planning artifacts under `.pi/plans/2026-04-20-emoji-to-lucide-icons/` in a separate docs commit
- adds `lucide-react` to `plugins/sero-cron-plugin/package.json` so the new UI imports resolve correctly