### PR TITLE
docs(skill): slim sero-plugin SKILL.md

### DIFF
--- a/packages/templates/skills/sero-plugin/SKILL.md
+++ b/packages/templates/skills/sero-plugin/SKILL.md
@@ -34,6 +34,7 @@ manifest in `package.json`. No manual registry edits.
 
 | Reference | When to read |
 |-----------|--------------|
+| `example/sero-notes-plugin/` | **Start here.** Canonical, minimal plugin that exercises every surface (extension + CLI bridge, background runtime, UI hooks, static + dynamic widgets, MF config). Copy and rename it as your starting point. See `example/README.md` for the file map. |
 | `references/templates.md` | Creating any file (package.json, extension, runtime, UI, Vite, styles). Also contains the Quick do/don't guide and mini examples. |
 | `references/api-and-widgets.md` | Using app-runtime hooks, background runtimes, dashboard widgets, manifest fields |
 | `references/conversion-guide.md` | Converting an existing Pi extension into a plugin |
@@ -252,6 +253,7 @@ Verify:
 
 | Plugin | Best for |
 |--------|----------|
+| `example/sero-notes-plugin/` (in this skill) | **Canonical minimal plugin.** Every surface (tool + CLI bridge, command, runtime, UI hooks, static + dynamic widgets) in the smallest possible footprint. |
 | `plugins/sero-git-plugin/` | Focused plugin with single tool + substantial UI |
 | `plugins/sero-admin-plugin/` | Multiple panels, settings, dashboard surfaces |
 | `plugins/sero-web-plugin/` | Converting an existing Pi extension |

--- a/packages/templates/skills/sero-plugin/SKILL.md
+++ b/packages/templates/skills/sero-plugin/SKILL.md
@@ -1,682 +1,269 @@
 ---
 name: sero-plugin
 description: |
-  Step-by-step guide for creating new Sero plugins — self-contained packages
-  with a Pi extension (agent tools/commands), an optional React web UI loaded
-  via Module Federation, and an optional background runtime for long-lived
-  workspace orchestration. Use this skill whenever the user asks to
-  create a new Sero app, plugin, extension, or tool with a UI, or when they
-  want to add a new sidebar panel, dashboard widget, or agent-integrated
-  feature to Sero. Also use when converting an existing Pi extension into a
-  Sero plugin. Trigger on phrases like "create a plugin", "new Sero app",
-  "add a tool with UI", "build an extension", "convert this Pi extension",
-  or any request that involves creating something under plugins/sero-*-plugin/.
+  Create Sero plugins — self-contained packages with a Pi extension (agent
+  tools/commands), an optional React UI loaded via Module Federation, and an
+  optional background runtime. Use when the user asks to create a Sero
+  plugin/app/extension, add a sidebar panel, dashboard widget, or
+  agent-integrated feature, or convert a Pi extension into a Sero plugin.
+  Trigger on phrases like "create a plugin", "new Sero app", "add a tool
+  with UI", "build an extension", "convert this Pi extension", or any
+  request that touches `plugins/sero-*-plugin/`.
 ---
 
 # Building Sero Plugins
 
-This skill guides you through creating a complete Sero plugin from scratch.
-A Sero plugin can contain up to three coordinated surfaces:
-- a **standard Pi extension** for tools / commands
-- an optional **React web UI** loaded via Module Federation
-- an optional **background runtime** for long-lived workspace orchestration
+A Sero plugin can expose up to three coordinated surfaces, all backed by a
+single JSON state file:
 
-All three can share state through a JSON file on disk.
+- **Pi extension** (`extension/`) — standard Pi. Pi-CLI-safe, no Sero imports. Registers tools and commands.
+- **Web UI** (`ui/`) — optional React UI loaded via Module Federation. Sero-only.
+- **Background runtime** (`runtime/`) — optional. Sero-only. Long-lived workspace orchestration.
+
+```
+                    state.json (source of truth)
+            ┌──────────────┼──────────────┐
+       Pi extension     Web UI     Background runtime
+       (Pi-CLI safe)   (Sero only)    (Sero only)
+```
+
+Sero auto-discovers `plugins/sero-*-plugin/` directories with a `sero.app`
+manifest in `package.json`. No manual registry edits.
 
 ## When to read reference files
 
-This SKILL.md contains the workflow and key rules. For detailed file templates
-and code snippets, read these reference files as needed:
-
 | Reference | When to read |
 |-----------|--------------|
-| `references/templates.md` | When creating any file (package.json, extension, runtime, UI, Vite, styles) |
-| `references/api-and-widgets.md` | When using app-runtime hooks, background runtimes, dashboard widgets, or checking manifest fields |
-| `references/conversion-guide.md` | Only when converting an existing Pi extension (not for new plugins) |
+| `references/templates.md` | Creating any file (package.json, extension, runtime, UI, Vite, styles). Also contains the Quick do/don't guide and mini examples. |
+| `references/api-and-widgets.md` | Using app-runtime hooks, background runtimes, dashboard widgets, manifest fields |
+| `references/conversion-guide.md` | Converting an existing Pi extension into a plugin |
 
-## Architecture
+## Core rules
 
-```
-                           state.json
-                         (source of truth)
-                 +---------------+---------------+
-                 |               |               |
-           Pi Extension      Web UI (React)   Background Runtime
-           (tools + cmds)   (module federation) (optional)
-           Pi CLI-safe      Sero only          Sero only
-```
-
-Key properties:
-- The extension is 100% standard Pi — works in Pi CLI with zero Sero-only imports
-- The web UI is optional and Sero-only
-- The background runtime is optional and Sero-only; use it for long-lived workspace watching, startup recovery, orchestration, and cleanup semantics
-- Sero reads the `sero` key in `package.json` to discover and mount the UI and background runtime
-- State is workspace-scoped (default) or global-scoped, and persists across sessions
-- Plugin UIs should trigger plugin behavior by calling their own tools through `useAppTools()` / `window.sero.appAgent.invokeTool(...)`
-- Do **not** ask the host to add a custom bridge like `window.sero.myPlugin.doThing()` unless you are intentionally changing the Sero platform itself
-- Changes from the extension, UI, or runtime sync through the same file-backed state
-
-## New external-plugin rules (important)
-
-Recent external-plugin work added three host seams that plugin authors now
-need to understand.
-
-### 1) UI -> plugin tool calls
-
-If your React UI needs to do something that belongs to the plugin extension
-(sign in, refresh data, run a fetch, mutate state, call an API, etc.), the UI
-should call one of the plugin's own tools.
-
-Use:
-- `useAppTools().run('tool_name', params)` inside React components
-- `window.sero.appAgent.invokeTool(...)` only when you cannot use the hook
-
-Do **not** build a plugin-specific host API such as:
-- `window.sero.google.*`
-- `window.sero.myPlugin.*`
-- new plugin-specific preload / IPC channels
-
-If your plugin UI depends on this bridge, add this to `package.json`:
-
-```json
-{
-  "sero": {
-    "plugin": {
-      "requiredHostCapabilities": ["appAgent.invokeTool"]
-    }
-  }
-}
-```
-
-### 2) Plugin-owned CLI commands
-
-If you want a plugin tool to show up as a `sero ...` command, use manifest-driven
-CLI bridging.
-
-Simple rule:
-- normal tool only -> just `pi.registerTool()`
-- tool should also be callable as `sero mytool ...` -> use `bridgeTools`
-- tool needs custom CLI help / summaries / raw arg handling -> add `cli` on the tool definition
-
-If the plugin depends on bridged CLI behavior, add this capability:
-
-```json
-{
-  "sero": {
-    "plugin": {
-      "requiredHostCapabilities": ["tool.cli"]
-    }
-  }
-}
-```
-
-If you need both UI->tool calls and CLI bridging, declare both:
-
-```json
-{
-  "sero": {
-    "plugin": {
-      "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli"]
-    }
-  }
-}
-```
-
-### 3) Plugin-owned background runtimes
-
-If your plugin needs long-lived, workspace-scoped behavior that should continue
-outside the UI lifecycle, add a plugin-owned background runtime.
-
-Good fits:
-- file watching beyond simple UI state sync
-- startup recovery / reconcile passes
-- subagent orchestration
-- worktree / PR / cleanup flows
-- managed dev-server or verification coordination
-
-Do **not** use a background runtime for:
-- simple CRUD mutations that belong in extension tools
-- one-shot UI actions that should just call a tool
-- Pi CLI-safe logic that must remain usable outside Sero
-
-Manifest pattern:
-
-```json
-{
-  "scripts": {
-    "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json && tsc --noEmit -p runtime/tsconfig.json"
-  },
-  "sero": {
-    "app": {
-      "runtime": "./runtime/index.ts"
-    },
-    "plugin": {
-      "requiredHostCapabilities": ["appRuntime.background"]
-    }
-  }
-}
-```
-
-Boundary rules:
-- `extension/` stays Pi-safe and CLI-safe
-- `runtime/` owns Sero-only orchestration
-- `runtime/` should type against `@sero-ai/common` runtime contracts, not desktop-internal imports
-- if logic exists only because of this plugin's runtime behavior, keep it in the plugin instead of pushing it into the Sero host
-
-### Quick do / don't guide
-
-| Situation | Do | Don't |
-|-----------|----|-------|
-| UI button needs to sign in, refresh, sync, or fetch data | Register a normal plugin tool and call it with `useAppTools().run(...)` | Ask the host for a custom API like `window.sero.myPlugin.signIn()` |
-| Plugin tool should also work as `sero mytool ...` | Use `sero.plugin.bridgeTools` | Add special host-side command wiring for that plugin |
-| Plugin CLI needs custom subcommands/help/raw args | Put that logic on the tool's `cli` field | Build a second parallel CLI implementation in the host |
-| Plugin needs host support for direct UI->tool calls | Declare `requiredHostCapabilities: ["appAgent.invokeTool"]` | Assume every host supports it without declaring it |
-| Plugin needs bridged CLI behavior | Declare `requiredHostCapabilities: ["tool.cli"]` | Rely on unstated host behavior |
-| Plugin needs long-lived workspace orchestration, recovery, or watchers | Add `runtime/`, declare `sero.app.runtime`, and require `appRuntime.background` | Hide orchestration inside UI effects or ask the host for plugin-specific runtime glue |
-| Extracting a built-in plugin to external | Move plugin-specific logic into the plugin | Leave plugin-specific preload/IPC/types in the Sero host |
-
-### Mini examples
-
-#### Example 1: UI button triggers plugin auth
-
-Use this when a React button should start a plugin-owned action.
-
-```tsx
-import { useAppTools } from '@sero-ai/app-runtime';
-
-export function MyApp() {
-  const { run } = useAppTools();
-
-  async function handleSignIn() {
-    await run('myapp_auth', { action: 'login' });
-  }
-
-  return <button onClick={handleSignIn}>Sign in</button>;
-}
-```
-
-Manifest requirement:
-
-```json
-{
-  "sero": {
-    "plugin": {
-      "requiredHostCapabilities": ["appAgent.invokeTool"]
-    }
-  }
-}
-```
-
-#### Example 2: Plugin exposes `sero myapp ...`
-
-Use this when a plugin tool should be available as a normal Sero CLI command.
-
-```json
-{
-  "sero": {
-    "plugin": {
-      "bridgeTools": ["myapp"]
-    }
-  }
-}
-```
+### UI → plugin behavior
+If the UI must trigger plugin-owned logic (sign in, refresh, mutate state,
+call an API), register a normal plugin tool and invoke it from React:
 
 ```ts
-pi.registerTool({
-  name: 'myapp',
-  label: 'My App',
-  description: 'Manage My App data',
-  parameters: Params,
-  async execute() {
-    return {
-      content: [{ type: 'text', text: 'Done' }],
-      details: {},
-    };
-  },
-});
+const { run } = useAppTools();
+await run('myapp_auth', { action: 'login' });
 ```
 
-Result: users and the agent can invoke the bridged command as `sero myapp ...`.
+Never add a plugin-specific host bridge (`window.sero.myPlugin.*`, custom
+preload/IPC channels). Declare the host seams you actually use in
+`sero.plugin.requiredHostCapabilities`:
 
-#### Example 3: Plugin replaces a builtin command intentionally
+| Capability | Declare when |
+|------------|--------------|
+| `appAgent.invokeTool` | UI uses `useAppTools()` or `window.sero.appAgent.invokeTool(...)` |
+| `tool.cli` | Plugin uses `bridgeTools`, custom `cli` metadata, or `cli.overrideBuiltin` |
+| `appRuntime.background` | Plugin declares `sero.app.runtime` |
 
-Use this only when the plugin is deliberately taking over an existing command name.
+### Tool bridging (AD-020)
+App tools are bridged into the single `sero-cli` tool — always use `pi.registerTool()`.
 
-```ts
-pi.registerTool({
-  name: 'google',
-  label: 'Google',
-  description: 'Google integration',
-  parameters: Params,
-  async execute() {
-    return {
-      content: [{ type: 'text', text: 'Done' }],
-      details: {},
-    };
-  },
-  cli: {
-    summary: 'Google tools',
-    help: 'sero google <subcommand>',
-    overrideBuiltin: true,
-    async execute(args, ctx) {
-      return {
-        output: `Handled: ${args.join(' ')}`,
-        exitCode: 0,
-      };
-    },
-  },
-});
-```
+- Plugins bridge all tools to `sero <tool> ...` by default
+- `sero.plugin.bridgeTools`: omit/`true` = bridge all, `false` = none, `string[]` = selected tool names
+- Custom CLI help / summary / raw-args parsing goes on the tool's `cli` field
+- `cli.overrideBuiltin: true` only when intentionally replacing a builtin command
+- Never register app tools as `customTools` in `createAgentSession()`
+- Bridged tools run against the current session's extension — don't capture registration-scoped `pi` state in tool logic
 
-Manifest requirement:
+### Background runtime
+Use `runtime/` **only** for long-lived workspace-scoped behavior: startup
+recovery/reconcile, watchers beyond simple UI sync, subagent orchestration,
+worktree/PR/cleanup flows, managed dev-server coordination.
 
-```json
-{
-  "sero": {
-    "plugin": {
-      "bridgeTools": ["google"],
-      "requiredHostCapabilities": ["tool.cli"]
-    }
-  }
-}
-```
+Do **not** use it for simple CRUD, one-shot UI actions, or Pi-CLI-safe logic.
+
+Boundaries:
+- `extension/` stays Pi-safe
+- `runtime/` is Sero-only; type against `@sero-ai/common`, never desktop internals
+- Plugin-specific orchestration stays in the plugin, not the host
+
+### Host ownership
+- Plugin-specific business logic lives in the plugin, not desktop preload/IPC
+- External plugins consume `packages/*` via published package names — do **not** import `../../packages/*` source paths
+- Keep plugin-specific types in `shared/`; only promote neutral cross-plugin contracts to `@sero-ai/common`
+- Never copy desktop host aliases (`@electron`, `@plugins`, `@packages`, `@/`) into plugin TS config
+
+### State
+- **Never use `localStorage`** — all UI state through `useAppState` (file-backed)
+- Keep state JSON-serialisable (no Date/Map/Set/functions)
+- Always use atomic writes (temp file → `fs.rename`)
+- Resolve global paths from `SERO_HOME` / `PI_CODING_AGENT_DIR`; fall back to `~/.pi` only when env vars are unset (Pi CLI mode)
 
 ## Step-by-step workflow
 
-### Step 1: Determine the plugin details
+### 1. Plan
+Decide up front:
+- **Plugin name** (e.g. `myapp`) — directory, app ID, state path
+- **Display name**, **Lucide icon**, **scope** (`workspace` default, or `global`)
+- **State shape** shared across surfaces
+- **Tools** to register
+- **Runtime?** Only for long-lived orchestration
+- **Dev port** — unique 5174+; check existing:
+  ```bash
+  grep -r '"devPort"' plugins/sero-*-plugin/package.json
+  ```
 
-Before writing any code, establish:
-- **Plugin name** (e.g. `myapp`) — used in directory name, app ID, state path
-- **Display name** (e.g. `My App`) — shown in sidebar
-- **Icon** — Lucide icon name (e.g. `box`, `check-square`, `calculator`)
-- **Scope** — `workspace` (default, project-specific data) or `global` (shared across workspaces)
-- **State shape** — what data the extension, UI, and optional runtime will share
-- **Tools** — what agent tools to register
-- **Background runtime?** — only if the plugin needs long-lived workspace orchestration beyond UI/tool lifecycles
-- **Dev port** — unique port for Vite dev server (5174+, check existing plugins first)
-
-Check existing ports:
-```bash
-grep -r '"devPort"' plugins/sero-*-plugin/package.json
-```
-
-### Step 2: Create the directory structure
-
-For plugins with a web UI, use this shape:
+### 2. Create the directory
 
 ```
 plugins/sero-<name>-plugin/
-+-- package.json
-+-- vite.config.ts          # root-level, uses root: 'ui'
-+-- shared/
-|   +-- types.ts
-+-- extension/
-|   +-- index.ts
-|   +-- tsconfig.json
-+-- runtime/                # optional: Sero-only background runtime
-|   +-- index.ts
-|   +-- tsconfig.json
-+-- ui/
-|   +-- <Name>App.tsx
-|   +-- styles.css
-|   +-- tsconfig.json
-|   +-- vite-env.d.ts
-|   +-- index.html
+├── package.json
+├── vite.config.ts            # UI only, at package root
+├── shared/types.ts
+├── extension/
+│   ├── index.ts
+│   └── tsconfig.json
+├── runtime/                  # optional
+│   ├── index.ts
+│   └── tsconfig.json
+└── ui/                       # optional
+    ├── <Name>App.tsx
+    ├── styles.css
+    ├── tsconfig.json
+    ├── vite-env.d.ts
+    └── index.html
 ```
 
-If the plugin is **extension-only** (no sidebar UI / no federated remote),
-keep `package.json`, `shared/`, and `extension/`, and omit `vite.config.ts`,
-`ui/`, and the `sero.app.ui` / `component` / `devPort` fields.
+Extension-only plugins omit `vite.config.ts`, `ui/`, and the
+`sero.app.ui`/`component`/`devPort` fields.
 
-If the plugin does **not** need long-lived background orchestration, omit
-`runtime/`, skip the runtime typecheck, and do not set `sero.app.runtime`.
+### 3. Write `package.json`
 
-Read `references/templates.md` for the exact content of each file.
+Triple-duty: Pi manifest + Sero app manifest + Sero plugin manifest.
+See `references/templates.md` for the full template.
 
-### Step 3: Create package.json
+Critical:
+- `"keywords": ["pi-package"]`
+- Pi SDK packages in `peerDependencies`
+- `@sero-ai/app-runtime` and `@sero-ai/ui` in `devDependencies`
+- `stateFile` is required even for global apps (Pi-CLI fallback)
+- `ui`, `component`, `devPort` only when the plugin ships a UI
+- `runtime` only when the plugin ships a runtime; add `runtime/tsconfig.json` to the `typecheck` script
+- Declare `requiredHostCapabilities` only for seams you use
+- For extension-only plugins, drop the Vite `dev`/`build` scripts
 
-The package.json serves triple duty: Pi manifest + Sero app manifest + Sero
-plugin manifest. Read `references/templates.md` for the full template.
+### 4. Define `shared/types.ts`
 
-Critical rules:
-- `"keywords": ["pi-package"]` for Pi compatibility
-- Pi SDK packages go in `peerDependencies` (runtime provides them)
-- `@sero-ai/app-runtime` is a `devDependency` (shared via MF at runtime)
-- `@sero-ai/ui` is a `devDependency` (bundled at build time)
-- Use `@sero-ai/common` for renderer-safe contracts shared across multiple plugins or desktop packages; keep app-local types in `shared/`
-- Treat the monorepo `packages/*` folders as host-owned shared package sources that external plugins consume via published package names — do NOT import `../../packages/*` source paths from an external plugin, and do NOT move plugin-specific domain models into `packages/*`
-- `stateFile` stays required even for global apps — Sero ignores it there, but Pi CLI uses it as the fallback path
-- `ui`, `component`, and `devPort` are required only when the plugin ships a web UI
-- `runtime` is required only when the plugin ships a background runtime; if present, add `runtime/tsconfig.json` to the package `typecheck` script
-- If the plugin is extension-only, remove the Vite-based `dev` / `build` / UI typecheck scripts and keep an extension-only `typecheck`
-- `devPort` must be unique across all plugins
-- Declare `sero.plugin.requiredHostCapabilities` only for the host features your plugin actually uses:
-  - `appAgent.invokeTool` -> your UI calls plugin tools with `useAppTools()` / `window.sero.appAgent.invokeTool(...)`
-  - `tool.cli` -> your tool is exposed as `sero <command>` via `bridgeTools`, custom `cli`, or builtin override behavior
-  - `appRuntime.background` -> your plugin declares `sero.app.runtime` and depends on the background-runtime host capability bag
-- `sero.plugin.bridgeTools` controls which plugin tools become `sero ...` commands:
-  - omit or `true` -> bridge all plugin tools
-  - `false` -> bridge none of them
-  - `string[]` -> bridge only the listed tool names
+Single source of truth imported by extension, UI, and runtime.
+- JSON-serialisable only
+- Export a `DEFAULT_STATE` constant
+- Auto-incrementing IDs for lists
 
-### Step 4: Define shared state types
+### 5. Mount the plugin into your workspace (dev only)
 
-Create `shared/types.ts` — the single source of truth imported by both
-extension and UI.
-
-Rules:
-- Must be JSON-serialisable (no Date, Map, Set, functions)
-- Provide a `DEFAULT_STATE` constant
-- Keep the shape flat-ish
-- Include auto-incrementing ID fields for lists
-- If a type/helper stops being app-local, move that neutral **platform** contract into `@sero-ai/common` instead of duplicating it
-- If the type/helper is still plugin-specific, keep it in the plugin's own `shared/` layer (or a plugin-owned published package) rather than promoting it into Sero's monorepo `packages/*`
-
-### Step 5: Mount the Plugin in the Workspace
-
-To make the `plugins/sero-*-plugin/` directory visible within the Sero interface, you must mount its path to your workspace. This creates a **multi-root workspace**, allowing you to view and edit the plugin source code directly inside Sero.
-
-1.  **Identify the full path** to your plugin source. 
-    * *Example:* `/Users/danielcarter/Documents/Dev/projects/sero/sero/plugins/sero-sample-plugin/`
-2.  **Run the mount command** using the `sero-cli`:
+Expose the plugin source inside Sero as a multi-root workspace:
 
 ```bash
-sero workspace mount-plugin [full-path-to-plugin]
+sero workspace mount-plugin /absolute/path/to/plugins/sero-<name>-plugin
 ```
 
-> **Note:** Ensure you use the absolute path to the specific plugin directory so the CLI can resolve the location correctly.
+### 6. Build the Pi extension
 
-### Step 6: Build the Pi extension
-
-Create `extension/index.ts`. This is a standard Pi extension.
+`extension/index.ts` is standard Pi. Template in `references/templates.md`.
 
 Key patterns:
 - Use `StringEnum` from `@mariozechner/pi-ai` for action enums (not `Type.Union`)
-- Resolve `statePath` from `ctx.cwd` inside execute handlers; keep registration-scoped session state only as a fallback
-- Always use **atomic writes** (write to temp, then `fs.rename`)
+- Resolve `statePath` from `ctx.cwd` inside `execute` handlers; use `session_start` only as a warm fallback
+- Atomic writes only (temp → rename)
 - Keep tool output concise
-- `session_start` is useful for warmup / fallback state resolution; do not depend on `session_switch` unless the SDK surface you target explicitly guarantees it
+- Do not depend on `session_switch` unless your target SDK guarantees it
 
-Read `references/templates.md` for the full extension template.
+### 7. Optional: background runtime
 
-### Step 7: Build the optional background runtime
+`runtime/index.ts` must export `createAppRuntime(ctx)` and default-export `{ createAppRuntime }`.
 
-Create `runtime/index.ts` only when your plugin needs long-lived,
-workspace-scoped behavior that should continue outside the UI lifecycle.
+Required wiring:
+- `sero.app.runtime: "./runtime/index.ts"` in `package.json`
+- `runtime/tsconfig.json` included in the `typecheck` script
+- `requiredHostCapabilities: ["appRuntime.background"]`
+- If the runtime imports native/non-bundle-safe packages, list them in `sero.app.runtimeExternals`
 
-Good uses:
-- startup recovery / reconcile passes
-- background watchers for runtime-owned files
-- subagent orchestration
-- managed dev-server coordination
-- worktree / PR / cleanup flows
+Context provides: `appId`, `workspaceId`, `workspacePath`, `stateFilePath`,
+and `host.{appState, subagents, workspace, verification, git, devServers}`.
 
-Critical requirements:
-- add `sero.app.runtime: "./runtime/index.ts"` to `package.json`
-- add `runtime/tsconfig.json` and include it in the package `typecheck` script
-- declare `requiredHostCapabilities: ["appRuntime.background"]`
-- if the runtime imports native or otherwise non-bundle-safe packages, declare `sero.app.runtimeExternals: ["<package>"]` so the TS runtime loader leaves them external
-- export `createAppRuntime(ctx)` from `runtime/index.ts` and default-export `{ createAppRuntime }`
-- type against `@sero-ai/common` runtime contracts rather than desktop-host internals
-- keep Pi-safe logic in `extension/`; keep Sero-only orchestration in `runtime/`
+### 8. Optional: build the UI
 
-The runtime receives:
-- `ctx.appId`
-- `ctx.workspaceId`
-- `ctx.workspacePath`
-- `ctx.stateFilePath`
-- `ctx.host.{appState, subagents, workspace, verification, git, devServers}`
+React component in `ui/<Name>App.tsx`. Template in `references/templates.md`.
 
-Read `references/templates.md` and `references/api-and-widgets.md` for the runtime manifest and entry-template details.
-
-### Step 8: Build the web UI
-
-Create the React component in `ui/<Name>App.tsx`.
-
-If the plugin is **extension-only**, skip this step and omit `vite.config.ts`,
-`ui/`, and the `sero.app.ui` / `component` / `devPort` fields.
-
-Critical requirements:
-- **Both named and default exports required** — `export function MyApp()` AND `export default MyApp`
+Required:
+- **Both** exports: `export function MyApp()` AND `export default MyApp`
 - Import components from `@sero-ai/ui/components/ui/*`
-- Import `cn` from `@sero-ai/ui/lib/utils`
-- Import `./styles.css` for Tailwind theme mapping
-- Import the shared stylesheet from **every exposed Module Federation entry** (the main app, widgets, and any other directly exposed components) so installed external plugins ship their own CSS
-- Use Tailwind semantic colors (`bg-background`, `text-foreground`, etc.)
-- If the UI needs to trigger extension behavior, register a normal plugin tool and call it with `useAppTools().run(...)`
-- Do **not** invent a one-off host API for that plugin unless you are intentionally changing Sero core
-- Keep plugin UI aliases/plugin TS config local to the plugin package. Do not copy desktop host aliases like `@electron`, `@plugins`, or `@packages` into plugin UI code unless you intentionally depend on host source.
+- Import `./styles.css` from **every** exposed MF entry (main app, widgets, etc.)
+- Tailwind semantic colors (`bg-background`, `text-foreground`, etc.)
+- Do not alias `@sero-ai/app-runtime`
+- Scope keyboard listeners to the container (`tabIndex={0}`), never `window`
+- Use `ResizeObserver` for dynamic sizing
 
-Also create:
-- `vite.config.ts` at package root (not inside `ui/`)
-- `ui/styles.css` with Tailwind + theme token mapping
-- `ui/tsconfig.json`
-- `ui/vite-env.d.ts` (or equivalent Vite client typing) when side-effect CSS imports are used
-- `ui/index.html` (required for Vite build)
+Also create: `vite.config.ts` (at package root), `ui/styles.css`,
+`ui/tsconfig.json`, `ui/vite-env.d.ts`, `ui/index.html`.
 
-Read `references/templates.md` for all file templates.
-
-### Step 9: Build and verify
+### 9. Verify
 
 ```bash
 pnpm install
-pnpm --filter @sero-ai/plugin-<name> build
+pnpm --filter @sero-ai/plugin-<name> build       # UI only
 pnpm --filter @sero-ai/plugin-<name> typecheck
 ```
 
-All three must pass before the plugin is ready.
+All must pass before the plugin is ready.
 
-Why these steps matter:
-- `pnpm install` links the new workspace package and dependencies
-- `build` validates Module Federation and produces `dist/ui/remoteEntry.js` when the plugin has a UI
-- `typecheck` catches extension, UI, and optional runtime errors before Sero loads the plugin
-
-For **extension-only** plugins, skip the Vite build and use an extension-only
-`typecheck` script instead.
-
-### Step 10: Test
+### 10. Test end-to-end
 
 ```bash
 cd apps/desktop
 SERO_DEV_PLUGINS=<name> bash scripts/dev.sh
 ```
 
-1. Click the app in the sidebar
-2. Add items via UI -> state.json updates -> UI re-renders
-3. Ask agent to use the tool -> writes state.json -> file watcher fires -> UI updates
-4. If the plugin has `runtime/`, verify the runtime starts for an open workspace, reacts to state changes, and cleans up correctly when the workspace closes
+Verify:
+1. Plugin appears in the sidebar
+2. UI mutations → `state.json` → UI re-renders
+3. Agent tool call → `state.json` → file watcher → UI updates
+4. If `runtime/`: starts on workspace open, reacts to state, cleans up on close
 
-## External plugin migration checklist
+## Module Federation
 
-Use this when extracting a built-in Sero app into an external plugin, or when
-updating an older plugin to the current host contract.
-
-If you're unsure about a checkbox, re-read the "Quick do / don't guide" and
-"Mini examples" above before you change host code.
-
-### UI execution
-- [ ] If the UI needs to trigger plugin behavior, it calls plugin-owned tools via `useAppTools().run(...)`
-- [ ] No plugin-specific preload / IPC bridge was added (`window.sero.<plugin>.*`)
-- [ ] If the UI depends on direct tool invocation, `sero.plugin.requiredHostCapabilities` includes `"appAgent.invokeTool"`
-
-### CLI behavior
-- [ ] Decide which tools should become `sero ...` commands
-- [ ] Set `sero.plugin.bridgeTools` intentionally:
-  - [ ] omit / `true` to bridge all tools
-  - [ ] `false` to bridge none
-  - [ ] `string[]` to bridge only selected tools
-- [ ] If a bridged tool needs custom help / summary / raw-args parsing, that logic lives on the tool definition in `cli`
-- [ ] If the plugin depends on bridged CLI behavior, `sero.plugin.requiredHostCapabilities` includes `"tool.cli"`
-- [ ] If the plugin replaces a builtin command, `cli.overrideBuiltin: true` is used intentionally and documented
-
-### Manifest + packaging
-- [ ] `package.json` includes a valid `sero.app` manifest
-- [ ] `package.json` includes a valid `sero.plugin` manifest
-- [ ] `minSeroVersion` is set when the plugin requires a newer Sero host
-- [ ] `requiredHostCapabilities` includes only the seams the plugin actually uses
-- [ ] If the plugin owns a background runtime, `sero.app.runtime` is declared intentionally
-- [ ] Production `vite.config.ts` uses `base: './'`
-- [ ] Runtime npm dependencies are declared in the plugin's own `dependencies`
-- [ ] The plugin does not rely on monorepo-only imports that will disappear after extraction
-
-### State + paths
-- [ ] Shared UI/extension state lives in `shared/` and is JSON-serialisable
-- [ ] Persistent UI state goes through `useAppState`, not `localStorage`
-- [ ] Writes to state files are atomic
-- [ ] App-specific global config/cache paths use `process.env.SERO_HOME`
-- [ ] Pi agent/resource paths use `process.env.PI_CODING_AGENT_DIR`
-- [ ] The plugin does not hardcode `~/.pi` except as a Pi CLI fallback when env vars are missing
-
-### Background runtime
-- [ ] Add `runtime/` only when the plugin truly needs long-lived background behavior
-- [ ] If `runtime/` exists, `requiredHostCapabilities` includes `"appRuntime.background"`
-- [ ] Runtime code types against `@sero-ai/common` runtime contracts rather than desktop-internal imports
-- [ ] Startup recovery, watch/reconcile, and long-lived orchestration semantics live in `runtime/`, not in renderer `useEffect`s
-- [ ] Pi-safe logic remains in `extension/`
-
-### UI bundling / styling
-- [ ] Every exposed MF entry imports the plugin stylesheet (`./styles.css` or `../styles.css`)
-- [ ] `ui/styles.css` includes the Tailwind `@source` paths the plugin depends on
-- [ ] `ui/vite-env.d.ts` (or equivalent `vite/client` typing) exists when side-effect CSS imports are used
-
-### Host ownership boundaries
-- [ ] Plugin-specific business logic lives in the plugin, not in desktop host preload / IPC glue
-- [ ] The plugin does not require new host-only types/channels unless you are intentionally extending the Sero platform itself
-- [ ] If the plugin was converted from an older built-in app, any old bespoke host bridge was removed or replaced with a generic host seam
-
-### Verification
-- [ ] `pnpm install` passes
-- [ ] `pnpm --filter @sero-ai/plugin-<name> build` passes (if the plugin has a UI)
-- [ ] `pnpm --filter @sero-ai/plugin-<name> typecheck` passes
-- [ ] The plugin appears in Sero without manual host wiring
-- [ ] If bridged CLI behavior is used, reinstall/update refreshes help and execution truthfully
-- [ ] If the UI uses `useAppTools()`, those calls work without any plugin-specific host bridge
+- `react` / `react-dom` are shared singletons
+- `@sero-ai/app-runtime` is **not** shared via MF — uses `globalThis` singleton; add to `optimizeDeps.exclude`
+- Production `vite.config.ts` must use `base: './'`
+- MF remote name convention: `sero_<id>` (valid JS identifier)
+- Exposed module: `./<Component>`
+- Every exposed entry must import the plugin stylesheet so external remotes ship their own CSS
 
 ## Development workflow
 
-- Include the plugin ID in `SERO_DEV_PLUGINS` to get UI HMR from the remote Vite dev server
-- UI file changes under `ui/` should reload quickly without restarting Electron
-- Changes to `extension/`, `runtime/`, or `shared/types.ts` require restarting the desktop dev server / Electron main process
+- UI changes (`ui/`) hot-reload via the remote Vite dev server
+- Changes to `extension/`, `runtime/`, or `shared/types.ts` require an Electron restart
 - `devPort` in `package.json` must match `server.port` in `vite.config.ts`
-- Useful logs:
-  - `/tmp/sero-vite.log` — host Vite + remote reload events
-  - `/tmp/sero-remote-<name>.log` — remote Vite dev server
-  - `/tmp/sero-electron.log` — Electron main + forwarded renderer errors
+- Logs: `/tmp/sero-vite.log`, `/tmp/sero-remote-<name>.log`, `/tmp/sero-electron.log`
 
-## Critical rules
+## Conventions
 
-### Tool bridging (AD-020)
-
-App tools are bridged into the single `sero-cli` tool — they do NOT appear as
-standalone tool schemas. Always use `pi.registerTool()` in extensions.
-
-Think about it this way:
-- `pi.registerTool()` defines what the plugin can do
-- `bridgeTools` decides whether that tool is also available as `sero <tool> ...`
-- `tool.cli` lets you customize how that CLI command behaves
-
-Rules:
-- Plugin packages with `sero.plugin` bridge **all tools by default**
-- Use `sero.plugin.bridgeTools` only to disable bridging or select specific tool names
-- If a tool needs custom CLI behavior, put it on `definition.cli` (summary/help/group/raw-args `execute`, optional `overrideBuiltin`)
-- If the plugin depends on manifest-driven CLI bridging or custom `definition.cli` behavior, declare `requiredHostCapabilities: ["tool.cli"]`
-- **Never** register app tools as `customTools` in `createAgentSession()`
-- Bridged tools execute against the **current session's** loaded extension instance
-- Bridged CLI help/execute behavior refreshes from the live session definition on reload/reinstall, so keep the source of truth on the tool definition itself
-- If a bridged tool needs current-session side effects, depend on the execution context passed into the tool instead of capturing a registration-scoped `pi` object inside the tool logic
-
-Common examples:
-- Tool should stay agent-only -> set `bridgeTools: false` or exclude it from the bridged list
-- Tool should be available as `sero mytool ...` with default generated help -> bridge it normally
-- Tool should parse raw subcommands like `sero google auth list` -> add a custom `cli.execute(args, ctx)` handler
-- Tool should replace an existing builtin command -> use `cli.overrideBuiltin: true` intentionally and document that choice
-
-### Auto-discovery
-
-Registration is fully automatic. The host auto-discovers all
-`plugins/sero-*-plugin/` directories with a `sero.app` manifest.
-No manual edits to vite config, federation registry, electron main, or dev.sh.
-
-### File size
-
-No source file over 500 lines. Split into sub-components, utils, types files.
-
-### State management
-
-- **Never use localStorage** — all state through `useAppState` (file-backed)
-- Keep state JSON-serialisable
-- Always use atomic writes (temp file -> rename)
-- If the UI needs to trigger extension-owned behavior, prefer `useAppTools()` over a custom preload/IPC API
-- If you use that UI->tool bridge, declare `requiredHostCapabilities: ["appAgent.invokeTool"]`
-
-### Module Federation
-
-- `react` and `react-dom` are shared singletons via MF
-- `@sero-ai/app-runtime` is NOT shared via MF — uses globalThis singleton
-- Add `@sero-ai/app-runtime` to `optimizeDeps.exclude`
-- Do NOT alias `@sero-ai/app-runtime`
-- Root component MUST have a default export
-- Import the shared stylesheet from every exposed entry so installed external remotes emit their own CSS assets
-
-### Background runtimes
-
-- Use `runtime/` only for long-lived, workspace-scoped Sero behavior
-- `runtime/index.ts` must export `createAppRuntime(ctx)` and default-export `{ createAppRuntime }`
-- Type background runtimes against `@sero-ai/common` (`AppRuntime`, `AppRuntimeContext`, `AppRuntimeModule`)
-- Do not import desktop-only aliases such as `@electron`, `@plugins`, or `@/` into plugin runtime code
-- Keep plugin-specific orchestration semantics in the plugin runtime; the host should only provide generic capabilities
-- If the plugin depends on background-runtime APIs, declare `requiredHostCapabilities: ["appRuntime.background"]`
-
-### Keyboard events
-
-Scope listeners to the app's container element, never `window`.
-Add `tabIndex={0}` and auto-focus the container on mount.
-
-### Responsive sizing
-
-Use `ResizeObserver` for dynamic dimensions, never fixed pixel values.
-
-### Naming conventions
-
-- Built-in plugin dir: `plugins/sero-<name>-plugin/`
-- MF remote name: `sero_<id>` (underscore, valid JS identifier)
-- Exposed module: `./<Component>`
-- State file: `.sero/apps/<id>/state.json`
+- Plugin directory: `plugins/sero-<name>-plugin/`
 - npm package: `@sero-ai/plugin-<name>`
-
-### Profile-aware paths
-
-If the extension needs global config/cache outside workspace state:
-- App-specific: `process.env.SERO_HOME` (e.g. `path.join(SERO_HOME, 'apps', '<id>', 'config.json')`)
-- Pi SDK resources: `process.env.PI_CODING_AGENT_DIR`
-- Pi CLI fallback: `~/.pi` only when env vars are unset
-
-Never hardcode `~/.pi` — it breaks Sero profile isolation.
-
-### Imports
-
-- Always use top-level imports, never inline `import('...')` type expressions
-- No unnecessary dynamic `await import('...')` for source modules
+- State file: `.sero/apps/<id>/state.json` (workspace) or under `SERO_HOME` (global)
+- No source file over 500 LOC — split into sub-components, utils, or types files
+- Always top-level imports; no dynamic `await import(...)` for source modules
 
 ## Reference implementations
 
-When in doubt, study these existing plugins:
-
 | Plugin | Best for |
 |--------|----------|
-| `plugins/sero-git-plugin/` | Clean, focused app with single tool + substantial UI |
-| `plugins/sero-admin-plugin/` | Rich app with multiple panels, settings, and dashboard surfaces |
+| `plugins/sero-git-plugin/` | Focused plugin with single tool + substantial UI |
+| `plugins/sero-admin-plugin/` | Multiple panels, settings, dashboard surfaces |
 | `plugins/sero-web-plugin/` | Converting an existing Pi extension |
 | `plugins/sero-cron-plugin/` | Background jobs, command-oriented plugins |
-| `../plugins/sero-kanban-plugin/` | External plugin with a plugin-owned background runtime, tool-driven UI actions, and dashboard widget styling |
+| `../plugins/sero-kanban-plugin/` | External plugin with background runtime + tool-driven UI + widgets |
 
 ## Related docs
 
 - `docs/plugins/guide.md` — packaging and distributing installable plugins
 - `docs/plugins/technical.md` — plugin system internals, federation, IPC, security
-- `docs/plugins/host-compatibility.md` — when to declare `requiredHostCapabilities`, how CLI bridging/hot-reload works, and downstream migration guidance
-- `docs/architecture.md` — desktop shell layout and host-side state flow
-- `apps/desktop/AGENTS.md` — project-wide rules (500 LOC, storage bans, import rules)
+- `docs/plugins/host-compatibility.md` — `requiredHostCapabilities`, CLI bridging, hot-reload
+- `docs/architecture.md` — desktop shell layout and host state flow
 
 ## Troubleshooting
 
@@ -685,13 +272,13 @@ When in doubt, study these existing plugins:
 | Build fails: "Could not resolve entry module" | Add `ui/index.html` |
 | App not in sidebar | Check `sero.app.id`/`name` in package.json, run `pnpm install` |
 | Agent missing tool | Restart dev server, check `pi.extensions` field |
-| UI changes not showing | Check remote Vite dev server running, extension changes need full restart |
-| Installed external plugin is missing styles | Import the shared stylesheet from every exposed MF entry and ensure `ui/styles.css` includes the needed `@source` paths |
-| `Cannot find module './styles.css'` in plugin UI | Add `ui/vite-env.d.ts` with `/// <reference types="vite/client" />` or otherwise include Vite client CSS typings |
-| Runtime never starts | Add `sero.app.runtime`, declare `requiredHostCapabilities: ["appRuntime.background"]`, and check `/tmp/sero-electron.log` |
-| "No UI module registered" | Set `sero.app.component` and `devPort` in package.json |
-| "No workspace selected" | Pick a workspace first, or make the plugin `scope: "global"` if it should work without one |
+| UI changes not showing | Check remote Vite running; extension changes need full restart |
+| External plugin missing styles | Import `./styles.css` from every exposed MF entry; verify `@source` paths in `ui/styles.css` |
+| `Cannot find module './styles.css'` | Add `ui/vite-env.d.ts` with `/// <reference types="vite/client" />` |
+| Runtime never starts | Declare `sero.app.runtime` + `requiredHostCapabilities: ["appRuntime.background"]`; check `/tmp/sero-electron.log` |
+| "No UI module registered" | Set `sero.app.component` and `devPort` |
+| "No workspace selected" | Pick one, or set `scope: "global"` |
 | State not syncing | Verify same `stateFile` path, use atomic writes |
 | Keyboard stealing input | Scope listeners to container, not `window` |
 | `lazy: Expected dynamic import` | Add `export default MyApp` to component file |
-| MF errors | Check `devPort` matches `server.port` in vite.config.ts |
+| MF errors | `devPort` in package.json must match `server.port` in vite.config.ts |

--- a/packages/templates/skills/sero-plugin/example/README.md
+++ b/packages/templates/skills/sero-plugin/example/README.md
@@ -1,7 +1,17 @@
 # Canonical Sero Plugin Example — `sero-notes-plugin`
 
-Reference implementation for the `sero-plugin` skill. It is intentionally the
-simplest plugin that exercises **every** surface a Sero plugin can ship:
+Reference implementation for the `sero-plugin` skill. It is the smallest
+plugin that exercises **every** surface a Sero plugin can ship.
+
+> **Scope: in-repo built-in plugin.** This example is wired for the Sero
+> monorepo — `workspace:*` devDependencies and `../../../packages/*`
+> tsconfig paths — so it drops into `plugins/sero-<name>-plugin/` and
+> typechecks immediately. For **external** plugins that consume published
+> `@sero-ai/*` packages instead, use
+> [`sero-kanban-plugin`](https://github.com/monobyte/sero-kanban-plugin)
+> as the reference and read `docs/plugins/guide.md` in this repo.
+
+## File map
 
 | Surface | File | What it demonstrates |
 |---------|------|----------------------|
@@ -13,13 +23,13 @@ simplest plugin that exercises **every** surface a Sero plugin can ship:
 | Dashboard widget | `sero-notes-plugin/ui/widgets/NotesWidget.tsx` | Manifest-declared widget, compact layout, `h-full` wrapper contract |
 | Module Federation | `sero-notes-plugin/vite.config.ts` | `root: 'ui'`, `base: './'` for prod, singleton React, MF remote name `sero_notes`, `@sero-ai/app-runtime` excluded from `optimizeDeps` |
 | Styles | `sero-notes-plugin/ui/styles.css` | Tailwind 4 `@source` directives for plugin UI **and** `@sero-ai/ui` components, `@theme inline` mapping of semantic CSS variables |
-| TS configs | `extension/tsconfig.json`, `runtime/tsconfig.json`, `ui/tsconfig.json` | Self-contained compiler options with `paths` for workspace packages |
+| TS configs | `extension/tsconfig.json`, `runtime/tsconfig.json`, `ui/tsconfig.json` | Extension/runtime extend `packages/tsconfig.extension.json`; UI declares workspace `paths` |
 | CSS typings | `ui/vite-env.d.ts` | `vite/client` reference so `import './styles.css'` typechecks |
 | HTML shell | `ui/index.html` | Minimal entry required by `root: 'ui'` |
 
-## How to use this example
+## How to use this example (in-repo built-in plugin)
 
-1. Copy `sero-notes-plugin/` into `plugins/` (or an external plugin repo).
+1. Copy `sero-notes-plugin/` into `plugins/` at the monorepo root.
 2. Rename the directory, the npm package name, `sero.app.id`, the MF remote name
    in `vite.config.ts` (`sero_<id>`), the exported component, and the
    `devPort` (keep it unique — grep existing plugins first).
@@ -36,10 +46,30 @@ simplest plugin that exercises **every** surface a Sero plugin can ship:
      and set `bridgeTools: false`.
 4. Update `shared/types.ts` to model your actual state, then let the extension,
    runtime, and UI all import from there — it is the single source of truth.
+5. `pnpm install && pnpm --filter @sero-ai/plugin-<name> typecheck` — should
+   be green before you run `bash apps/desktop/scripts/dev.sh`.
+
+## How to port this to an external plugin
+
+External plugins live outside the Sero monorepo and consume
+`@sero-ai/app-runtime`, `@sero-ai/common`, `@sero-ai/ui` as published
+packages. Start from the in-repo copy above, then:
+
+1. Replace every `workspace:*` / `workspace:@sero-ai/app-runtime@*` with the
+   published semver range for the `@sero-ai/*` packages you depend on.
+2. Delete the `paths` mapping in `ui/tsconfig.json` — Node's module
+   resolution picks the installed package up from `node_modules/`.
+3. Replace `extends: "../../../packages/tsconfig.extension.json"` in
+   `extension/tsconfig.json` and `runtime/tsconfig.json` with an inline
+   compiler-options block (see `references/templates.md`).
+4. Ship the plugin pre-built if you want install-time consumers to skip
+   Vite (`sero.plugin.preBuilt: true`).
 
 ## What this plugin does
 
 `sero-notes-plugin` manages a list of short notes stored in
 `.sero/apps/notes/state.json`. Notes can be toggled done, removed, and listed
-from the agent (tool + CLI), the React UI, or the dashboard widget. It is
-deliberately trivial so each surface reads in a few minutes.
+from the agent (tool), the CLI (`sero notes <list|add|toggle|remove>`),
+the React UI, or the dashboard widget. The `/list-notes` slash command is a
+distinct name on purpose — it would otherwise shadow the bridged
+`sero notes ...` CLI entry point when tools and commands are both bridged.

--- a/packages/templates/skills/sero-plugin/example/README.md
+++ b/packages/templates/skills/sero-plugin/example/README.md
@@ -1,0 +1,45 @@
+# Canonical Sero Plugin Example — `sero-notes-plugin`
+
+Reference implementation for the `sero-plugin` skill. It is intentionally the
+simplest plugin that exercises **every** surface a Sero plugin can ship:
+
+| Surface | File | What it demonstrates |
+|---------|------|----------------------|
+| Manifest | `sero-notes-plugin/package.json` | Full `pi` + `sero.app` + `sero.plugin` manifest, `bridgeTools`, `requiredHostCapabilities`, static widget, runtime entry |
+| Shared types | `sero-notes-plugin/shared/types.ts` | JSON-serialisable state + `DEFAULT_STATE` |
+| Pi extension | `sero-notes-plugin/extension/index.ts` | `pi.registerTool` with `StringEnum`, atomic state writes, custom TUI render, bridged CLI metadata (`cli`), `pi.registerCommand`, `session_start` warm fallback |
+| Background runtime | `sero-notes-plugin/runtime/index.ts` | `AppRuntime` implementation against `@sero-ai/common` — startup reconcile, `handleStateChange`, `dispose` |
+| Web UI (main) | `sero-notes-plugin/ui/NotesApp.tsx` | `useAppState`, `useAppInfo`, `useAppTools`, `useAgentPrompt`, `useAI`, dynamic widget registration via `useWidgetRegistration` |
+| Dashboard widget | `sero-notes-plugin/ui/widgets/NotesWidget.tsx` | Manifest-declared widget, compact layout, `h-full` wrapper contract |
+| Module Federation | `sero-notes-plugin/vite.config.ts` | `root: 'ui'`, `base: './'` for prod, singleton React, MF remote name `sero_notes`, `@sero-ai/app-runtime` excluded from `optimizeDeps` |
+| Styles | `sero-notes-plugin/ui/styles.css` | Tailwind 4 `@source` directives for plugin UI **and** `@sero-ai/ui` components, `@theme inline` mapping of semantic CSS variables |
+| TS configs | `extension/tsconfig.json`, `runtime/tsconfig.json`, `ui/tsconfig.json` | Self-contained compiler options with `paths` for workspace packages |
+| CSS typings | `ui/vite-env.d.ts` | `vite/client` reference so `import './styles.css'` typechecks |
+| HTML shell | `ui/index.html` | Minimal entry required by `root: 'ui'` |
+
+## How to use this example
+
+1. Copy `sero-notes-plugin/` into `plugins/` (or an external plugin repo).
+2. Rename the directory, the npm package name, `sero.app.id`, the MF remote name
+   in `vite.config.ts` (`sero_<id>`), the exported component, and the
+   `devPort` (keep it unique — grep existing plugins first).
+3. Delete the surfaces you don't need:
+   - No UI? Remove `vite.config.ts`, `ui/`, and the `sero.app.ui` /
+     `component` / `devPort` / `widgets` fields, and collapse
+     `scripts.typecheck` to just `extension/tsconfig.json`.
+   - No background runtime? Remove `runtime/`, `sero.app.runtime`, the
+     `appRuntime.background` capability, and the runtime tsconfig from
+     `scripts.typecheck`.
+   - No UI-invoked tools? Remove `useAppTools` / `useAgentPrompt` / `useAI`
+     usage and drop the `appAgent.invokeTool` capability.
+   - No bridged CLI? Drop the tool's `cli` block, the `tool.cli` capability,
+     and set `bridgeTools: false`.
+4. Update `shared/types.ts` to model your actual state, then let the extension,
+   runtime, and UI all import from there — it is the single source of truth.
+
+## What this plugin does
+
+`sero-notes-plugin` manages a list of short notes stored in
+`.sero/apps/notes/state.json`. Notes can be toggled done, removed, and listed
+from the agent (tool + CLI), the React UI, or the dashboard widget. It is
+deliberately trivial so each surface reads in a few minutes.

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
@@ -1,0 +1,214 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Text } from '@mariozechner/pi-tui';
+import { Type } from '@sinclair/typebox';
+
+import type { Note, NotesState } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+
+const STATE_REL_PATH = path.join('.sero', 'apps', 'notes', 'state.json');
+
+function resolveStatePath(cwd: string): string {
+  return path.join(cwd, STATE_REL_PATH);
+}
+
+async function readState(filePath: string): Promise<NotesState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw) as NotesState;
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+async function writeState(filePath: string, state: NotesState): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  // Atomic write: temp -> rename prevents partial-read corruption.
+  const tmp = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmp, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmp, filePath);
+}
+
+const Params = Type.Object({
+  action: StringEnum(['list', 'add', 'toggle', 'remove'] as const),
+  title: Type.Optional(Type.String({ description: 'Note title (for add)' })),
+  id: Type.Optional(Type.Number({ description: 'Note id (for toggle/remove)' })),
+});
+
+export default function (pi: ExtensionAPI) {
+  let statePath = '';
+
+  pi.on('session_start', async (_event, ctx) => {
+    statePath = resolveStatePath(ctx.cwd);
+  });
+
+  pi.registerTool({
+    name: 'notes',
+    label: 'Notes',
+    description:
+      'Manage notes. Actions: list, add (title), toggle (id), remove (id).',
+    parameters: Params,
+
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const resolved = ctx ? resolveStatePath(ctx.cwd) : statePath;
+      if (!resolved) {
+        return {
+          content: [{ type: 'text', text: 'Error: no workspace cwd' }],
+          details: {},
+        };
+      }
+      statePath = resolved;
+      const state = await readState(statePath);
+
+      switch (params.action) {
+        case 'list': {
+          const text = state.notes.length
+            ? state.notes
+                .map((n) => `${n.done ? '[x]' : '[ ]'} #${n.id} ${n.title}`)
+                .join('\n')
+            : 'No notes yet.';
+          return { content: [{ type: 'text', text }], details: {} };
+        }
+
+        case 'add': {
+          if (!params.title) {
+            return {
+              content: [{ type: 'text', text: 'Error: title is required' }],
+              details: {},
+            };
+          }
+          const note: Note = {
+            id: state.nextId,
+            title: params.title,
+            done: false,
+            createdAt: new Date().toISOString(),
+          };
+          state.notes.push(note);
+          state.nextId++;
+          await writeState(statePath, state);
+          return {
+            content: [{ type: 'text', text: `Added #${note.id}: ${note.title}` }],
+            details: {},
+          };
+        }
+
+        case 'toggle': {
+          if (params.id === undefined) {
+            return {
+              content: [{ type: 'text', text: 'Error: id is required' }],
+              details: {},
+            };
+          }
+          const note = state.notes.find((n) => n.id === params.id);
+          if (!note) {
+            return {
+              content: [{ type: 'text', text: `Error: no note #${params.id}` }],
+              details: {},
+            };
+          }
+          note.done = !note.done;
+          await writeState(statePath, state);
+          return {
+            content: [
+              { type: 'text', text: `Toggled #${note.id} -> ${note.done ? 'done' : 'open'}` },
+            ],
+            details: {},
+          };
+        }
+
+        case 'remove': {
+          if (params.id === undefined) {
+            return {
+              content: [{ type: 'text', text: 'Error: id is required' }],
+              details: {},
+            };
+          }
+          const before = state.notes.length;
+          state.notes = state.notes.filter((n) => n.id !== params.id);
+          if (state.notes.length === before) {
+            return {
+              content: [{ type: 'text', text: `Error: no note #${params.id}` }],
+              details: {},
+            };
+          }
+          await writeState(statePath, state);
+          return {
+            content: [{ type: 'text', text: `Removed #${params.id}` }],
+            details: {},
+          };
+        }
+      }
+    },
+
+    // Pi CLI TUI rendering — ignored by the Sero host.
+    renderCall(args, theme) {
+      let text = theme.fg('toolTitle', theme.bold('notes '));
+      text += theme.fg('muted', args.action);
+      if (args.title) text += ` ${theme.fg('dim', `"${args.title}"`)}`;
+      if (args.id !== undefined) text += ` ${theme.fg('dim', `#${args.id}`)}`;
+      return new Text(text, 0, 0);
+    },
+
+    renderResult(result, _options, theme) {
+      const first = result.content[0];
+      const msg = first?.type === 'text' ? first.text : '';
+      return new Text(
+        msg.startsWith('Error:')
+          ? theme.fg('error', msg)
+          : theme.fg('success', '+ ') + theme.fg('muted', msg),
+        0,
+        0,
+      );
+    },
+
+    // Custom bridged CLI surface — callable as `sero notes <subcommand>`.
+    // Requires `sero.plugin.bridgeTools: ["notes"]` and the `tool.cli` capability.
+    cli: {
+      summary: 'Manage notes from the CLI',
+      help: 'sero notes <list|add|toggle|remove> [title|id]',
+      group: 'Apps',
+      async execute(args, _context) {
+        const [subcommand, ...rest] = args;
+        if (!subcommand) {
+          return { output: 'Usage: sero notes <list|add|toggle|remove>', exitCode: 1 };
+        }
+        const cwd = process.cwd();
+        const filePath = resolveStatePath(cwd);
+        const state = await readState(filePath);
+
+        if (subcommand === 'list') {
+          const out = state.notes.length
+            ? state.notes
+                .map((n) => `${n.done ? '[x]' : '[ ]'} #${n.id} ${n.title}`)
+                .join('\n')
+            : 'No notes yet.';
+          return { output: out, exitCode: 0 };
+        }
+        if (subcommand === 'add') {
+          const title = rest.join(' ').trim();
+          if (!title) return { output: 'Error: title is required', exitCode: 1 };
+          state.notes.push({
+            id: state.nextId,
+            title,
+            done: false,
+            createdAt: new Date().toISOString(),
+          });
+          state.nextId++;
+          await writeState(filePath, state);
+          return { output: `Added #${state.nextId - 1}: ${title}`, exitCode: 0 };
+        }
+        return { output: `Unknown subcommand: ${subcommand}`, exitCode: 1 };
+      },
+    },
+  });
+
+  // User-callable command — types the prompt for the agent.
+  pi.registerCommand('notes', {
+    description: 'Show all notes',
+    handler: async () => {
+      pi.sendUserMessage('List all notes using the notes tool.');
+    },
+  });
+}

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
@@ -204,9 +204,12 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
-  // User-callable command — types the prompt for the agent.
-  pi.registerCommand('notes', {
-    description: 'Show all notes',
+  // User-callable slash command. Keep the command name distinct from the tool
+  // name ('notes'): when tools are bridged, Sero also bridges non-builtin
+  // commands into the CLI, and the command would otherwise shadow
+  // `sero notes ...` and bypass this tool's `cli.execute` handler.
+  pi.registerCommand('list-notes', {
+    description: 'Ask the agent to list all notes',
     handler: async () => {
       pi.sendUserMessage('List all notes using the notes tool.');
     },

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/tsconfig.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/tsconfig.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/tsconfig.json
@@ -1,14 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "types": ["node"],
-    "lib": ["ES2023"]
-  },
+  "extends": "../../../packages/tsconfig.extension.json",
   "include": ["./**/*", "../shared/**/*"]
 }

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@sero-ai/plugin-notes",
+  "version": "0.1.0",
+  "description": "Canonical example Sero plugin — tiny notes list",
+  "keywords": ["pi-package"],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json && tsc --noEmit -p runtime/tsconfig.json"
+  },
+  "pi": {
+    "extensions": ["./extension/index.ts"]
+  },
+  "sero": {
+    "app": {
+      "id": "notes",
+      "name": "Notes",
+      "icon": "sticky-note",
+      "stateFile": ".sero/apps/notes/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "NotesApp",
+      "runtime": "./runtime/index.ts",
+      "devPort": 5199,
+      "widgets": [
+        {
+          "id": "notes-summary",
+          "name": "Notes Summary",
+          "component": "NotesWidget",
+          "description": "Quick overview of open notes",
+          "defaultSize": { "w": 2, "h": 2 },
+          "minSize": { "w": 1, "h": 1 },
+          "maxSize": { "w": 4, "h": 3 }
+        }
+      ]
+    },
+    "plugin": {
+      "category": "productivity",
+      "tags": ["notes", "example", "reference"],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": [
+        "appAgent.invokeTool",
+        "tool.cli",
+        "appRuntime.background"
+      ],
+      "bridgeTools": ["notes"]
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "catalog:"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": "catalog:peer",
+    "@mariozechner/pi-coding-agent": "catalog:peer",
+    "@mariozechner/pi-tui": "catalog:peer",
+    "zod": "catalog:peer"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "catalog:",
+    "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",
+    "@sero-ai/common": "workspace:*",
+    "@sero-ai/ui": "workspace:*",
+    "@tailwindcss/vite": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/runtime/index.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/runtime/index.ts
@@ -1,0 +1,52 @@
+import type {
+  AppRuntime,
+  AppRuntimeContext,
+  AppRuntimeModule,
+} from '@sero-ai/common';
+
+import type { NotesState } from '../shared/types';
+
+// A background runtime is optional. Use it only for long-lived, workspace-scoped
+// orchestration (startup reconcile, subagent workflows, watchers beyond simple
+// UI sync). Simple CRUD belongs in the extension, not here.
+class NotesRuntime implements AppRuntime {
+  constructor(private readonly ctx: AppRuntimeContext) {}
+
+  async start(): Promise<void> {
+    // Startup reconcile — read the current state and run once.
+    const state = await this.ctx.host.appState.read<NotesState>(
+      this.ctx.stateFilePath,
+    );
+    if (state) await this.handleStateChange(state);
+  }
+
+  async handleStateChange(state: unknown): Promise<void> {
+    const current = state as NotesState | null;
+    if (!current) return;
+
+    // Example orchestration: auto-prune notes flagged done for > 30 days.
+    // Kept as a pure read for the reference; a real runtime would mutate state
+    // via this.ctx.host.appState.update(...) or call a subagent via
+    // this.ctx.host.subagents.runStructured(...).
+    const stale = current.notes.filter(
+      (n) =>
+        n.done &&
+        Date.now() - Date.parse(n.createdAt) > 30 * 24 * 60 * 60 * 1000,
+    );
+    if (stale.length > 0) {
+      // In a real plugin, reconcile here. Left as a no-op for the example.
+    }
+  }
+
+  async dispose(): Promise<void> {
+    // Clean up any listeners, timers, or file watchers you opened in start().
+  }
+}
+
+export function createAppRuntime(ctx: AppRuntimeContext): AppRuntime {
+  return new NotesRuntime(ctx);
+}
+
+export default {
+  createAppRuntime,
+} satisfies AppRuntimeModule;

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/runtime/tsconfig.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/runtime/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/runtime/tsconfig.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/runtime/tsconfig.json
@@ -1,14 +1,4 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "types": ["node"],
-    "lib": ["ES2023"]
-  },
+  "extends": "../../../packages/tsconfig.extension.json",
   "include": ["./**/*", "../shared/**/*"]
 }

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/shared/types.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/shared/types.ts
@@ -1,0 +1,19 @@
+// Single source of truth for state shared across extension, runtime, and UI.
+// JSON-serialisable only — no Date, Map, Set, or functions.
+
+export interface Note {
+  id: number;
+  title: string;
+  done: boolean;
+  createdAt: string;
+}
+
+export interface NotesState {
+  notes: Note[];
+  nextId: number;
+}
+
+export const DEFAULT_STATE: NotesState = {
+  notes: [],
+  nextId: 1,
+};

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/NotesApp.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useState } from 'react';
+import {
+  useAI,
+  useAgentPrompt,
+  useAppInfo,
+  useAppState,
+  useAppTools,
+  useWidgetRegistration,
+} from '@sero-ai/app-runtime';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
+
+import type { NotesState } from '../shared/types';
+import { DEFAULT_STATE } from '../shared/types';
+import { NotesWidget } from './widgets/NotesWidget';
+import './styles.css';
+
+export function NotesApp() {
+  // File-backed reactive state — written atomically, reloaded on every change.
+  const [state, updateState] = useAppState<NotesState>(DEFAULT_STATE);
+
+  // Context about the mount — appId and the current workspace path.
+  const { appId, workspacePath } = useAppInfo();
+
+  // Direct invocation of this plugin's own tools.
+  // Requires `requiredHostCapabilities: ["appAgent.invokeTool"]`.
+  const { run } = useAppTools();
+
+  // Send a user message into the active chat session. Silently no-ops with no chat.
+  const prompt = useAgentPrompt();
+
+  // Ad-hoc LLM calls — independent of the chat panel. No chat required.
+  const ai = useAI();
+
+  const [title, setTitle] = useState('');
+  const [suggesting, setSuggesting] = useState(false);
+
+  // Register a widget dynamically. Equivalent to declaring it in the manifest,
+  // but scoped to the lifetime of this component — unregistered on unmount.
+  useWidgetRegistration({
+    widgetId: 'notes-summary-dynamic',
+    name: 'Notes Summary (dynamic)',
+    component: NotesWidget,
+    defaultSize: { w: 2, h: 2 },
+    description: 'Registered at runtime by NotesApp',
+  });
+
+  const addNote = useCallback(() => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+    updateState((prev) => ({
+      ...prev,
+      notes: [
+        ...prev.notes,
+        {
+          id: prev.nextId,
+          title: trimmed,
+          done: false,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+      nextId: prev.nextId + 1,
+    }));
+    setTitle('');
+  }, [title, updateState]);
+
+  const toggleNote = useCallback(
+    (id: number) => {
+      updateState((prev) => ({
+        ...prev,
+        notes: prev.notes.map((n) =>
+          n.id === id ? { ...n, done: !n.done } : n,
+        ),
+      }));
+    },
+    [updateState],
+  );
+
+  const removeNote = useCallback(
+    (id: number) => {
+      updateState((prev) => ({
+        ...prev,
+        notes: prev.notes.filter((n) => n.id !== id),
+      }));
+    },
+    [updateState],
+  );
+
+  // Example: UI button calls the plugin's own tool directly.
+  const removeViaTool = useCallback(
+    async (id: number) => {
+      await run('notes', { action: 'remove', id });
+    },
+    [run],
+  );
+
+  // Example: ask the agent in the chat panel to run our tool.
+  const askAgentToList = () => {
+    prompt('List my notes using the notes tool.');
+  };
+
+  // Example: ad-hoc LLM call — generate a note title and add it.
+  const suggestNote = async () => {
+    setSuggesting(true);
+    try {
+      const response = await ai.prompt(
+        'Suggest a single short todo item in under 6 words. Reply with only the item text.',
+      );
+      const suggested = response.trim().replace(/^["']|["']$/g, '');
+      if (suggested) {
+        updateState((prev) => ({
+          ...prev,
+          notes: [
+            ...prev.notes,
+            {
+              id: prev.nextId,
+              title: suggested,
+              done: false,
+              createdAt: new Date().toISOString(),
+            },
+          ],
+          nextId: prev.nextId + 1,
+        }));
+      }
+    } finally {
+      setSuggesting(false);
+    }
+  };
+
+  const openCount = state.notes.filter((n) => !n.done).length;
+
+  return (
+    <div className="flex h-full flex-col bg-background p-4">
+      <header className="mb-4">
+        <h1 className="text-lg font-semibold text-foreground">Notes</h1>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {openCount} open / {state.notes.length} total · {appId} @ {workspacePath}
+        </p>
+      </header>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          addNote();
+        }}
+        className="mb-3 flex gap-2"
+      >
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Add a note..."
+          className="flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        <Button size="sm" type="submit" disabled={!title.trim()}>
+          Add
+        </Button>
+      </form>
+
+      <div className="mb-3 flex gap-2">
+        <Button size="sm" variant="secondary" onClick={askAgentToList}>
+          Ask agent to list
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={suggestNote}
+          disabled={suggesting}
+        >
+          {suggesting ? 'Thinking…' : 'Suggest with AI'}
+        </Button>
+      </div>
+
+      <Card className="flex-1 gap-0 overflow-hidden py-0 shadow-none">
+        {state.notes.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center py-16">
+            <p className="text-sm text-muted-foreground">No notes yet</p>
+          </div>
+        ) : (
+          <div className="flex-1 overflow-y-auto">
+            {state.notes.map((note) => (
+              <div
+                key={note.id}
+                className="group flex items-center gap-3 border-b px-4 py-2.5 last:border-b-0 hover:bg-secondary"
+              >
+                <input
+                  type="checkbox"
+                  checked={note.done}
+                  onChange={() => toggleNote(note.id)}
+                  className="h-4 w-4"
+                />
+                <span
+                  className={`flex-1 text-sm ${
+                    note.done
+                      ? 'text-muted-foreground line-through'
+                      : 'text-foreground'
+                  }`}
+                >
+                  {note.title}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground opacity-0 hover:text-destructive group-hover:opacity-100"
+                  onClick={() => removeNote(note.id)}
+                >
+                  Remove
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground opacity-0 hover:text-destructive group-hover:opacity-100"
+                  onClick={() => removeViaTool(note.id)}
+                  title="Remove via plugin tool"
+                >
+                  Tool
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+// Both named and default exports are required for Module Federation lazy loading.
+export default NotesApp;

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/index.html
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sero Notes (remote)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/styles.css
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/styles.css
@@ -1,0 +1,37 @@
+@import "tailwindcss";
+
+/* REQUIRED: scan plugin-local UI files so external remotes emit the utility
+   classes they use instead of accidentally depending on host CSS. */
+@source "./**/*.{ts,tsx}";
+
+/* REQUIRED: scan @sero-ai/ui component sources so Tailwind 4 generates CSS for
+   utility classes used inside shared components (Button, Card, etc.). */
+@source "../../ui/src/components";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/tsconfig.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/tsconfig.json
@@ -11,9 +11,10 @@
     "noEmit": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "paths": {
-      "@sero-ai/app-runtime": ["../../app-runtime/src/index.ts"],
-      "@sero-ai/ui": ["../../ui/src/index.ts"],
-      "@sero-ai/ui/*": ["../../ui/src/*"]
+      "@sero-ai/app-runtime": ["../../../packages/app-runtime/src/index.ts"],
+      "@sero-ai/common": ["../../../packages/common/src/index.ts"],
+      "@sero-ai/ui": ["../../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/*": ["../../../packages/ui/src/*"]
     }
   },
   "include": ["./**/*", "../shared/**/*"]

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/tsconfig.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero-ai/app-runtime": ["../../app-runtime/src/index.ts"],
+      "@sero-ai/ui": ["../../ui/src/index.ts"],
+      "@sero-ai/ui/*": ["../../ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/vite-env.d.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/widgets/NotesWidget.tsx
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/ui/widgets/NotesWidget.tsx
@@ -1,0 +1,46 @@
+import { useAppState } from '@sero-ai/app-runtime';
+
+import type { NotesState } from '../../shared/types';
+import { DEFAULT_STATE } from '../../shared/types';
+// Every directly-exposed MF entry must import its own stylesheet so external
+// remotes ship their own CSS assets.
+import '../styles.css';
+
+export function NotesWidget() {
+  const [state] = useAppState<NotesState>(DEFAULT_STATE);
+  const open = state.notes.filter((n) => !n.done);
+
+  return (
+    <div className="flex h-full flex-col gap-2 p-3">
+      <div className="flex items-baseline gap-2">
+        <span className="text-lg font-bold tabular-nums text-foreground">
+          {open.length}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          open / {state.notes.length} total
+        </span>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-auto">
+        {open.slice(0, 5).map((note) => (
+          <div
+            key={note.id}
+            className="truncate rounded-md bg-secondary px-2 py-1 text-xs text-foreground"
+          >
+            {note.title}
+          </div>
+        ))}
+        {open.length > 5 && (
+          <span className="text-[10px] text-muted-foreground">
+            +{open.length - 5} more
+          </span>
+        )}
+        {open.length === 0 && (
+          <span className="text-xs text-muted-foreground">All done.</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default NotesWidget;

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/vite.config.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/vite.config.ts
@@ -1,0 +1,54 @@
+// Vite config lives at the package root (not inside ui/).
+// `root: 'ui'` tells Vite the HTML entry + source live in ui/.
+// `base: './'` in production is required so installed plugin remotes resolve
+// assets via the `sero-ext://` scheme.
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  base: process.env.NODE_ENV === 'production' ? './' : '/',
+  root: 'ui',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      // MF remote name convention: sero_<appId>. Must be a valid JS identifier.
+      name: 'sero_notes',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        // Paths are relative to this config file (package root), not `root`.
+        './NotesApp': './ui/NotesApp.tsx',
+        './NotesWidget': './ui/widgets/NotesWidget.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+        // NOTE: @sero-ai/app-runtime is NOT shared via MF.
+        // The host provides a globalThis singleton; we just excludeDeps below.
+      },
+    }),
+  ],
+  server: {
+    // Must match `sero.app.devPort` in package.json.
+    port: 5199,
+    strictPort: true,
+    origin: 'http://localhost:5199',
+  },
+  optimizeDeps: {
+    exclude: ['@sero-ai/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    // Relative to `root` (ui/) -> writes into <pkg>/dist/ui/.
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
Consolidates duplicated rule blocks (external-plugin rules, critical rules,
migration checklist) into a single Core rules section, drops the mini
examples and quick do/don't table that are already mirrored in
references/templates.md, and tightens the step-by-step workflow. Drops
SKILL.md from 697 to 284 lines (~59%) without losing coverage.

https://claude.ai/code/session_01LaU8CjD2iYW9BdEmx4jQJY