### PR TITLE
feat: add built-in MCP plugin

### DIFF
--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
@@ -12,7 +12,7 @@ Current checkpoint: `420f251c`
 ## Remaining coverage work
 
 - [x] MCP-10 — finish the remaining automated coverage *(runtime + CSP coverage already landed; remaining bridge/path coverage still open)* ([plan](./plan.md))
-- [ ] MCP-11 — add the planned UI test coverage ([plan](./plan.md))
+- [x] MCP-11 — add the planned UI test coverage ([plan](./plan.md))
 
 ## Final wrap-up
 

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
@@ -1,0 +1,19 @@
+# MCP plugin completion checklist
+
+Reference plan: [`plan.md`](./plan.md)
+
+Current checkpoint: `420f251c`
+
+## Remaining product work
+
+- [ ] MCP-07 — finish the first-run wizard ([plan](./plan.md))
+- [ ] MCP-09 — finish full viewer / AppBridge UI hosting *(current viewer/auth pane is a partial step)* ([plan](./plan.md))
+
+## Remaining coverage work
+
+- [ ] MCP-10 — finish the remaining automated coverage *(runtime + CSP coverage already landed; remaining bridge/path coverage still open)* ([plan](./plan.md))
+- [ ] MCP-11 — add the planned UI test coverage ([plan](./plan.md))
+
+## Final wrap-up
+
+- [ ] MCP-12 — final README + validation refresh after the remaining work lands ([plan](./plan.md))

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
@@ -6,7 +6,7 @@ Current checkpoint: `420f251c`
 
 ## Remaining product work
 
-- [ ] MCP-07 — finish the first-run wizard ([plan](./plan.md))
+- [x] MCP-07 — finish the first-run wizard ([plan](./plan.md))
 - [ ] MCP-09 — finish full viewer / AppBridge UI hosting *(current viewer/auth pane is a partial step)* ([plan](./plan.md))
 
 ## Remaining coverage work

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
@@ -7,7 +7,7 @@ Current checkpoint: `420f251c`
 ## Remaining product work
 
 - [x] MCP-07 — finish the first-run wizard ([plan](./plan.md))
-- [ ] MCP-09 — finish full viewer / AppBridge UI hosting *(current viewer/auth pane is a partial step)* ([plan](./plan.md))
+- [x] MCP-09 — finish full viewer / AppBridge UI hosting *(current viewer/auth pane is a partial step)* ([plan](./plan.md))
 
 ## Remaining coverage work
 

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
@@ -2,7 +2,7 @@
 
 Reference plan: [`plan.md`](./plan.md)
 
-Current checkpoint: `420f251c`
+Current checkpoint: `MCP-12 complete`
 
 ## Remaining product work
 
@@ -16,4 +16,4 @@ Current checkpoint: `420f251c`
 
 ## Final wrap-up
 
-- [ ] MCP-12 — final README + validation refresh after the remaining work lands ([plan](./plan.md))
+- [x] MCP-12 — final README + validation refresh after the remaining work lands ([plan](./plan.md))

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/checklist.md
@@ -11,7 +11,7 @@ Current checkpoint: `420f251c`
 
 ## Remaining coverage work
 
-- [ ] MCP-10 — finish the remaining automated coverage *(runtime + CSP coverage already landed; remaining bridge/path coverage still open)* ([plan](./plan.md))
+- [x] MCP-10 — finish the remaining automated coverage *(runtime + CSP coverage already landed; remaining bridge/path coverage still open)* ([plan](./plan.md))
 - [ ] MCP-11 — add the planned UI test coverage ([plan](./plan.md))
 
 ## Final wrap-up

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/connect-slice-scout.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/connect-slice-scout.md
@@ -1,0 +1,80 @@
+# MCP connect/reconnect slice scout
+
+## 1) Minimal modules/functions to port next
+- `server-manager.ts`
+  - `connect()` / `createConnection()` with real transport creation, dedupe, and `needs-auth` handling.
+  - `close()` / `closeAll()` for lifecycle teardown.
+  - `fetchAllTools()` / `fetchAllResources()` for post-connect discovery.
+  - `isIdle()` and in-flight tracking if the lifecycle manager keeps using idle shutdown.
+- `lifecycle.ts`
+  - `startHealthChecks()` + reconnect loop for keep-alive servers.
+  - reconnect callback hook so metadata can refresh after a successful reconnect.
+- `init.ts`
+  - startup bootstrap that connects eager/keep-alive servers, builds metadata from live connections, and seeds cache.
+  - `lazyConnect()` path so first use can connect and then write metadata/cache.
+  - reconnect callback wiring to refresh metadata and status.
+- `tool-metadata.ts`
+  - `buildToolMetadata()` for converting live tools/resources into exposed tool metadata.
+  - `totalToolCount()` for status bar/snapshot summaries.
+- `metadata-cache.ts`
+  - cache read/write/validate helpers plus serialize/reconstruct helpers.
+  - server hash computation so cache invalidation matches config changes.
+- `mcp-auth-flow.ts`
+  - only the preconditions: `supportsOAuth(definition)` and the auth status result shape used by connect() when a server needs auth.
+
+## 2) Recommended destination files under `plugins/sero-mcp-plugin/extension/`
+- `runtime/mcp-runtime.ts`
+  - expose connect/reconnect manager actions and route them through the singleton.
+- `runtime/runtime-utils.ts`
+  - add small formatting helpers for reconnect/connect results if needed.
+- `tools/types.ts`
+  - extend `ManagerAction` with connect/reconnect or refresh-style actions.
+- `tools/manager-tool.ts`
+  - add tool parameters for server name / reconnect target and dispatch to runtime.
+- `cache/metadata-cache.ts`
+  - keep as the persistence layer for tool/resource counts and cache entries.
+- `state/snapshot.ts`
+  - keep snapshot counts aligned with cached metadata after connect/reconnect.
+
+## 3) Smallest viable manager action/API additions
+- Add a single explicit action for `connect_server` or `reconnect_server` instead of a broader lifecycle API.
+- Input should be minimal: `serverName` only, with runtime looking up the config from current state.
+- Return a `ToolResult` that includes:
+  - `connectionStatus`
+  - `toolCount`
+  - `resourceCount`
+  - `authStatus`
+  - `snapshotWritten` / `metadataCache` if the reconnect changed persisted state
+- Keep `refresh` separate from connect/reconnect if it already means “rewrite snapshot from current files”; don’t overload it.
+
+## 4) Metadata/tool-count/resource-count refresh path
+- On successful connect/reconnect:
+  1. connect the server through the manager
+  2. fetch tools/resources from the live client
+  3. rebuild tool metadata via `buildToolMetadata()`
+  4. update in-memory metadata map
+  5. persist the cache entry with serialized tools/resources and counts
+  6. refresh the snapshot/state so UI summaries pick up new counts
+- On reconnect callback from lifecycle:
+  - re-run the same metadata rebuild + cache write path for that server only.
+- If resources are unsupported or empty, preserve existing cached resources only when the config hash still matches and the server returned none.
+
+## 5) Auth precondition handling for OAuth/bearer servers
+- `supportsOAuth(definition)` gates the OAuth path.
+- For OAuth servers:
+  - if `connect()` hits `UnauthorizedError`, return `needs-auth` instead of throwing.
+  - do not attempt SSE fallback after an auth failure on HTTP servers.
+  - reconnect should short-circuit to auth-required state until tokens exist.
+- For bearer servers:
+  - add the Authorization header before transport creation.
+  - treat missing bearer token / env token as not connectable or auth-not-ready.
+- Keep the auth decision at transport creation time so the manager API can stay simple.
+
+## 6) Biggest gotchas
+- Concurrent connect dedupe matters: reconnect checks can overlap with lazy connect or user-triggered actions.
+- Cache writes are merged by file, so a reconnect slice should only update the one server entry it owns.
+- Tool/resource counts are derived from live discovery, not config alone; reconnect must rebuild metadata from the live client.
+- OAuth failures are semantically different from transport failures; don’t collapse them into a generic connect error.
+- `keep-alive` health checks may reconnect servers that are already being connected elsewhere.
+- Snapshot counts in the plugin UI come from the metadata cache, so refreshing in-memory metadata alone is not enough.
+- Be careful not to expand scope into CRUD or config editing; the next slice is just real connect/reconnect plus metadata refresh.

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md
@@ -1,0 +1,1322 @@
+# Built-in MCP Plugin Implementation Plan
+
+**Date:** 2026-04-20
+**Status:** Draft
+**Spec:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/spec.md`
+**Scout:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/scout-context.md`
+**Directory:** `/Users/danielcarter/Documents/Dev/projects/sero/sero`
+
+## Overview
+
+This work should add a new built-in **MCP** plugin to the Sero monorepo by
+adapting `pi-mcp-adapter` into a **Sero-native, UI-first control center**.
+
+The implementation should preserve the adapter’s strongest backend value:
+
+- lazy/eager/keep-alive MCP lifecycle management,
+- metadata caching,
+- stdio + HTTP/SSE transport support,
+- OAuth/token handling,
+- MCP UI/resource hosting,
+- one small proxy tool instead of exploding the agent tool surface.
+
+But it should deliberately **not** ship as a thin wrapper around the adapter’s
+current TUI/popup workflows.
+
+The recommended build is:
+
+- **new built-in plugin package:** `plugins/sero-mcp-plugin/`
+- **shape:** `extension + ui`
+- **scope:** `global`
+- **app id:** `mcp`
+- **package name:** `@sero-ai/plugin-mcp`
+- **icon:** `plug`
+- **devPort:** `5196`
+- **agent/CLI surface:** exactly **one bridged tool** named `mcp`
+- **UI control surface:** separate **UI-only management tool** (not bridged)
+- **background runtime:** **no `runtime/` in v1**
+
+## Scope Guards / Non-Goals
+
+These are explicit implementation guardrails for workers:
+
+- **No direct per-server or per-tool exposure** in v1.
+- **No import/migration from `~/.pi/agent`** config, cache, or tokens.
+- **No port of the TUI `/mcp` panel** as a product surface.
+- **No command-first primary workflow** — CLI remains secondary/basic.
+- **No rich UI session-history explorer** in v1.
+- **No separate plugin runtime** unless the chosen singleton extension model proves insufficient.
+- **No new plugin-specific preload bridge** if app-state + `useAppTools()` + existing host seams are enough.
+
+## Investigation Summary
+
+### What already fits well in Sero
+
+- Built-in plugins already follow the right package structure:
+  - `plugins/sero-admin-plugin/`
+  - `plugins/sero-git-plugin/`
+  - `plugins/sero-web-plugin/`
+- `@sero-ai/app-runtime` gives the MCP UI the two key seams it needs:
+  - `useAppState()` for file-backed reactive app state
+  - `useAppTools()` for UI -> extension tool actions
+- Plugin CLI bridging is already manifest-driven (AD-020), so the MCP plugin can expose only one CLI-facing tool via `bridgeTools: ['mcp']`.
+- Global apps already exist (`admin`, `cron`), and global state resolves through `SERO_HOME/apps/<id>/state.json`.
+- There is a strong precedent for **module-level singleton extension logic** in `plugins/sero-cron-plugin/extension/index.ts` + `runtime.ts`, which is exactly what this MCP port needs.
+
+### Important constraints discovered during investigation
+
+1. **App sessions do not give tools a real TUI surface.**
+   `createSeroUIContext()` provides `notify()`, but `custom()`, `select()`, and
+   other TUI affordances are effectively no-ops. So the MCP plugin UI cannot
+   depend on `ctx.ui.custom()` or the adapter’s TUI `/mcp` panel.
+
+2. **Opening the plugin UI does not automatically start an app session.**
+   `useAppState()` reads files directly; the plugin’s app session only exists
+   after the UI calls `useAppTools()` / `useAI()`. So the MCP UI needs an
+   explicit bootstrap action on mount.
+
+3. **Production CSP currently blocks the adapter’s localhost UI-host model.**
+   `apps/desktop/electron/platform/security/csp.ts` only allows general
+   `http:` / `https:` frames in development. In production, `frame-src` and
+   `connect-src` are too tight for a localhost-backed MCP viewer. Host changes
+   are required.
+
+4. **`webviewTag` is not enabled today.**
+   If auth must remain fully in-plugin for OAuth providers that disallow iframe
+   embedding, the host needs a dedicated embedded browser rail. The lowest-scope
+   path is a whitelisted webview-based surface.
+
+5. **The adapter’s biggest files must be split during conversion.**
+   Hotspots:
+   - `proxy-modes.ts` — 810 LOC
+   - `mcp-panel.ts` — 740 LOC
+   - `ui-server.ts` — 623 LOC
+   - `host-html-template.ts` — 427 LOC
+   - `types.ts` — 426 LOC
+   - `npx-resolver.ts` — 419 LOC
+   - `mcp-auth-flow.ts` — 400 LOC
+   - `direct-tools.ts` — 400 LOC
+
+6. **The adapter’s per-session state model is not the right fit for Sero.**
+   If ported naively, the plugin UI, chat sessions, and CLI calls would all see
+   different connection state. The cron plugin’s module-level singleton pattern
+   is the right adaptation.
+
+### Key repo references
+
+- Manifest + plugin structure:
+  - `docs/plugins/guide.md`
+  - `docs/plugins/technical.md`
+  - `docs/plugins/host-compatibility.md`
+- Architectural constraints:
+  - `docs/architecture.md`
+  - `docs/decisions.md` (especially AD-020)
+- Plugin references:
+  - `plugins/sero-admin-plugin/package.json`
+  - `plugins/sero-admin-plugin/ui/AdminApp.tsx`
+  - `plugins/sero-git-plugin/extension/index.ts`
+  - `plugins/sero-git-plugin/shared/types.ts`
+  - `plugins/sero-git-plugin/vite.config.ts`
+  - `plugins/sero-web-plugin/extension/index.ts`
+  - `plugins/sero-web-plugin/extension/state-sync.ts`
+  - `plugins/sero-cron-plugin/extension/index.ts`
+  - `plugins/sero-cron-plugin/extension/runtime.ts`
+- Host/browser references:
+  - `apps/desktop/electron/platform/security/csp.ts`
+  - `apps/desktop/electron/main.ts`
+  - `apps/desktop/src/components/apps/explorer/editor/DevServerPreview.tsx`
+  - `packages/ui/src/components/ai-elements/web-preview.tsx`
+
+## Approaches Considered
+
+### 1. Thin plugin wrapper around the adapter’s current extension and commands
+
+Copy the adapter, change paths, keep `/mcp`, `/mcp-auth`, popup UI-hosting, and
+ship a light dashboard around it.
+
+**Pros**
+- Lowest apparent code churn.
+- Fastest path to partial parity.
+- Reuses most adapter code directly.
+
+**Cons**
+- Violates the spec’s “native first-party app” requirement.
+- Keeps command/TUI/popup workflows central.
+- Leaves per-session state drift unresolved.
+- Still depends on Pi-style UI affordances Sero app sessions do not provide.
+- Does not solve production CSP / embedded auth/resource viewing cleanly.
+
+**Decision:** reject.
+
+### 2. Sero-native plugin with a module-level singleton extension runtime and a redesigned UI (**recommended**)
+
+Port the adapter’s backend primitives into a plugin-local singleton runtime,
+then build a dedicated Sero UI for setup, management, auth, diagnostics, and
+resource viewing.
+
+**Pros**
+- Matches the spec closely.
+- Avoids a separate `runtime/` package while still sharing live state across
+  UI, agent, and CLI entry points.
+- Keeps the agent surface intentionally small.
+- Lets the UI use Sero-native forms, dashboards, and recovery patterns.
+- Reuses the adapter where it is strongest, but only where it fits.
+
+**Cons**
+- Requires host support for embedded browser/auth viewing.
+- Requires deliberate state snapshot design instead of straight code copying.
+- Needs more careful refactoring to stay under 500 LOC per file.
+
+**Decision:** use this.
+
+### 3. Elevate MCP into a desktop-host subsystem outside the plugin
+
+Move lifecycle, auth, viewer hosting, and storage into `apps/desktop/electron/`
+first, then let the plugin UI sit on top of host APIs.
+
+**Pros**
+- Strongest centralization.
+- Could eventually support non-plugin MCP use cases.
+
+**Cons**
+- Too invasive for the current scope.
+- Breaks the plugin ownership model.
+- Encourages new host-specific IPC/preload seams the repo is trying to avoid.
+- Harder to extract or evolve later.
+
+**Decision:** defer. Keep MCP product logic plugin-owned unless a generic host
+seam is truly required.
+
+## Recommended Approach
+
+## Key Decisions
+
+- **Plugin ID / package:** `mcp` / `@sero-ai/plugin-mcp`
+- **Manifest:** built-in plugin with `scope: 'global'`, `bridgeTools: ['mcp']`,
+  and `requiredHostCapabilities: ['appAgent.invokeTool', 'tool.cli']`
+- **No plugin `runtime/` in v1** — use a **module-level singleton extension runtime** instead.
+- **Two extension tools only:**
+  - `mcp` — bridged, user/agent-facing proxy tool
+  - `mcp_manager` — UI-only management tool, intentionally not bridged
+- **No direct-tool registration or direct-tool toggles** in v1.
+- **No `/mcp-auth`-style primary auth flow.** Auth is launched from the plugin UI.
+- **Canonical config lives under `SERO_HOME/apps/mcp/`**, not under legacy `~/.pi` paths.
+- **OAuth tokens live under `PI_CODING_AGENT_DIR/mcp-oauth/`** so profile isolation stays aligned with Pi agent resources.
+- **Sensitive auth URLs / viewer tokens stay ephemeral in UI local state**, not persisted in `state.json`.
+- **Embedded MCP resources use a localhost viewer iframe; external OAuth uses an in-plugin embedded browser surface** rather than the system browser.
+- **Agent proxy search is MCP-only.** Do not include plugin-internal Pi tools in search results.
+
+## Architecture
+
+### 1. Package + manifest shape
+
+Create a new built-in plugin package:
+
+```text
+plugins/sero-mcp-plugin/
+├── package.json
+├── vite.config.ts
+├── README.md
+├── shared/
+│   └── types.ts
+├── extension/
+│   ├── index.ts
+│   ├── runtime/
+│   │   └── mcp-runtime.ts
+│   ├── config/
+│   ├── auth/
+│   ├── state/
+│   ├── manager/
+│   ├── viewer/
+│   └── tools/
+└── ui/
+    ├── McpApp.tsx
+    ├── index.html
+    ├── styles.css
+    ├── hooks/
+    └── components/
+```
+
+Recommended manifest shape:
+
+```json
+{
+  "name": "@sero-ai/plugin-mcp",
+  "pi": { "extensions": ["./extension/index.ts"] },
+  "sero": {
+    "app": {
+      "id": "mcp",
+      "name": "MCP",
+      "icon": "plug",
+      "scope": "global",
+      "stateFile": ".sero/apps/mcp/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "McpApp",
+      "devPort": 5196
+    },
+    "plugin": {
+      "category": "developer-tools",
+      "tags": ["mcp", "servers", "oauth", "resources"],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli"],
+      "bridgeTools": ["mcp"],
+      "preBuilt": false
+    }
+  }
+}
+```
+
+### 2. Storage contract
+
+Use three distinct storage layers.
+
+#### A. Global app state snapshot
+
+For the UI’s reactive read model:
+
+```text
+$SERO_HOME/apps/mcp/state.json
+```
+
+This is the file watched by `useAppState()` and should contain:
+
+- first-run / wizard state
+- normalized server list + friendly status
+- derived auth status
+- resource/UI capability summaries
+- lightweight diagnostics summaries
+- last refresh timestamps
+
+It should **not** contain:
+
+- OAuth access tokens / refresh tokens
+- pending auth URLs
+- temporary viewer session URLs or tokens
+- large raw tool schemas if they are only needed on demand
+
+#### B. Canonical editable config
+
+For forms + raw JSON editing:
+
+```text
+$SERO_HOME/apps/mcp/config.json
+```
+
+Recommended root shape:
+
+```ts
+export interface McpConfigDocument {
+  settings?: {
+    idleTimeout?: number;
+    toolPrefix?: 'server' | 'short' | 'none';
+  };
+  mcpServers: Record<string, McpServerConfig>;
+}
+
+export interface McpServerConfig {
+  enabled?: boolean;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  auth?: 'oauth' | 'bearer' | false;
+  bearerToken?: string;
+  bearerTokenEnv?: string;
+  oauth?: {
+    grantType?: 'authorization_code' | 'client_credentials';
+    clientId?: string;
+    clientSecret?: string;
+    scope?: string;
+  } | false;
+  lifecycle?: 'lazy' | 'eager' | 'keep-alive';
+  idleTimeout?: number;
+  exposeResources?: boolean;
+  excludeTools?: string[];
+  debug?: boolean;
+}
+```
+
+Notes:
+- keep the adapter-friendly `mcpServers` shape so the backend port is simple,
+  but add `enabled?: boolean` for first-class enable/disable.
+- do **not** carry `imports`, `directTools`, or `disableProxyTool` into the
+  UI product model for v1.
+- raw config editing should preserve unknown fields instead of destructively
+  rewriting them away.
+
+#### C. Cache + auth storage
+
+- metadata cache:
+  ```text
+  $SERO_HOME/apps/mcp/metadata-cache.json
+  ```
+- OAuth/token storage:
+  ```text
+  $PI_CODING_AGENT_DIR/mcp-oauth/<server>/tokens.json
+  ```
+
+Fallback rules for Pi CLI mode:
+- use `process.env.SERO_HOME` / `process.env.PI_CODING_AGENT_DIR` when present,
+- otherwise fall back to the adapter’s Pi-compatible defaults.
+
+### 3. Module-level singleton extension runtime
+
+Use the cron plugin’s pattern instead of the adapter’s per-session state.
+
+Recommended shape:
+
+```ts
+const runtime = createOrGetMcpRuntime();
+
+export default function mcpExtension(pi: ExtensionAPI) {
+  runtime.attachPi(pi);
+
+  pi.on('session_start', async (_event, ctx) => {
+    await runtime.handleSessionStart({ cwd: ctx.cwd, ui: ctx.hasUI ? ctx.ui : undefined });
+  });
+
+  pi.on('session_shutdown', async () => {
+    await runtime.handleSessionShutdown();
+  });
+
+  registerMcpProxyTool(pi, runtime);
+  registerMcpManagerTool(pi, runtime);
+}
+```
+
+`McpRuntime` should own:
+
+- config document load/save/reconcile
+- singleton `McpServerManager`
+- singleton lifecycle / health checks / idle shutdown
+- metadata cache read/write
+- auth storage + OAuth orchestration
+- derived state snapshot writing
+- resource/UI launch controller
+- refcounted session attach/detach so health checks only run once per process
+
+This gives all of the following one shared truth source:
+
+- the MCP plugin UI app session,
+- normal chat sessions using `sero-cli mcp ...`,
+- the agent-facing `mcp` proxy tool.
+
+### 4. Shared state / snapshot contract
+
+The plugin UI should consume a normalized, UI-friendly state shape from
+`shared/types.ts`.
+
+Recommended direction:
+
+```ts
+export type McpConnectionStatus =
+  | 'disabled'
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'needs-auth'
+  | 'error';
+
+export type McpAuthStatus =
+  | 'not-required'
+  | 'not-authenticated'
+  | 'authenticating'
+  | 'authenticated'
+  | 'expired'
+  | 'error';
+
+export interface McpServerSnapshot {
+  serverName: string;
+  enabled: boolean;
+  transport: 'stdio' | 'http';
+  lifecycle: 'lazy' | 'eager' | 'keep-alive';
+  connectionStatus: McpConnectionStatus;
+  authStatus: McpAuthStatus;
+  toolCount: number;
+  resourceCount: number;
+  uiToolCount: number;
+  lastError?: string;
+  lastConnectedAt?: string;
+  lastFailedAt?: string;
+  resources: Array<{ uri: string; name: string; description?: string }>;
+  uiTools: Array<{ name: string; description?: string; inputSchema?: unknown }>;
+}
+
+export interface McpAppState {
+  initialized: boolean;
+  firstRun: boolean;
+  configPath: string;
+  rawConfigUpdatedAt: string | null;
+  servers: McpServerSnapshot[];
+  settings: {
+    idleTimeout: number;
+    toolPrefix: 'server' | 'short' | 'none';
+  };
+  lastRefreshedAt: string | null;
+  summary: {
+    totalServers: number;
+    enabledServers: number;
+    connectedServers: number;
+    needsAuthServers: number;
+    errorServers: number;
+  };
+}
+```
+
+Important rule:
+- **on-demand technical details** should come from `mcp_manager` actions such as
+  `diagnostics`, not by bloating the main state file with everything.
+
+### 5. Tool and CLI surface
+
+#### A. `mcp` — the only bridged tool
+
+Keep the one small proxy tool as the agent-facing surface.
+
+Responsibilities:
+- status
+- list/search MCP tools/resources
+- describe MCP tools
+- call MCP tools through the proxy
+- connect / reconnect when explicitly requested
+
+Prune the adapter’s agent surface:
+- no direct-tool registration
+- no `/mcp-auth` dependency in normal messages
+- no auto-auth path
+- no search over all Pi tools (MCP-only search)
+
+#### B. `mcp_manager` — UI-only management tool
+
+Use `useAppTools()` from the plugin UI to call a second tool with an action enum.
+
+Recommended actions:
+
+```ts
+'bootstrap'
+| 'refresh'
+| 'upsert_server'
+| 'remove_server'
+| 'enable_server'
+| 'disable_server'
+| 'connect_server'
+| 'reconnect_server'
+| 'start_auth'
+| 'cancel_auth'
+| 'clear_auth'
+| 'save_raw_config'
+| 'get_raw_config'
+| 'get_diagnostics'
+| 'open_resource'
+| 'open_tool_ui'
+| 'close_viewer'
+```
+
+This tool is **not bridged** and should not appear in MCP search results.
+
+#### C. Custom CLI on `mcp`
+
+Implement basic Sero CLI management through `tool.cli.execute` on the `mcp` tool.
+
+Recommended CLI commands:
+
+```text
+sero mcp status
+sero mcp list
+sero mcp connect <server>
+sero mcp reconnect [server]
+sero mcp enable <server>
+sero mcp disable <server>
+```
+
+Auth stays UI-first. CLI should report when a server requires UI-based auth:
+
+> `Server "github" requires in-app authentication. Open the MCP app in Sero and authenticate there.`
+
+### 6. Embedded viewer + auth rail
+
+This is the main cross-package integration point.
+
+#### MCP UI/resources
+
+Use the adapter’s local viewer-host pattern, but make it **UI-driven** instead of
+agent-pop-up-driven:
+
+- derive `resources` from `listResources`
+- derive `uiTools` from tool metadata `_meta.ui.resourceUri`
+- when the user clicks **Open** or **Launch UI** in the plugin UI, call
+  `mcp_manager.open_resource` / `mcp_manager.open_tool_ui`
+- the management tool returns an **ephemeral** `{ viewerUrl, sessionId }`
+- the plugin UI renders that URL in a sandboxed iframe / web preview pane
+
+This keeps the core flow in-plugin and avoids persisting sensitive session URLs.
+
+#### OAuth auth surface
+
+Because many providers disallow iframe embedding, auth should use a **dedicated
+embedded browser surface** inside the plugin, not a normal iframe.
+
+**Concrete plan assumption:** enable Electron `webviewTag` and use a tightly
+whitelisted plugin-local auth browser component.
+
+Why this is the recommended path:
+- lower scope than a new host-managed BrowserView subsystem,
+- keeps auth inside the plugin UI,
+- avoids the spec’s forbidden external browser requirement.
+
+Required host changes:
+- enable `webviewTag: true` in `apps/desktop/electron/main.ts`
+- add a production CSP allowlist for **loopback viewer URLs** (`127.0.0.1` / `localhost`) without reopening arbitrary `http:` / `https:` frames globally
+- if the auth surface itself needs top-level external navigation, enforce a
+  plugin-owned URL allowlist and explicit event handling in the webview component
+
+Important design rule:
+- **viewer iframe for local loopback UI sessions**
+- **embedded browser surface for external OAuth**
+- **no `shell.openExternal()` as the primary happy path**
+
+### 7. UI composition
+
+The Sero UI should be a hybrid **overview + drill-down** workbench.
+
+Recommended layout:
+
+```text
+┌────────────────────────────────────────────────────────────┐
+│ Header: MCP · summary badges · Add server · Raw config    │
+├───────────────┬──────────────────────────┬─────────────────┤
+│ Server rail   │ Main detail workbench    │ Viewer / auth   │
+│ - all servers │ - overview cards         │ pane            │
+│ - status      │ - selected server        │ - resource UI   │
+│ - add/edit    │ - config/auth/actions    │ - auth browser  │
+│               │ - resources / UIs        │ - fallback help │
+│               │ - diagnostics            │                 │
+└───────────────┴──────────────────────────┴─────────────────┘
+```
+
+Recommended sub-surfaces:
+
+- **First-run wizard** when there are no servers:
+  - explain MCP briefly
+  - choose `stdio` or `HTTP/SSE`
+  - provide examples/help text
+  - jump to a blank server form
+- **Overview dashboard** when servers exist:
+  - totals, auth-needed, connected, errors
+  - setup guidance for the next most useful action
+- **Server detail** for one selected server:
+  - Overview
+  - Settings
+  - Resources / UIs
+  - Diagnostics
+- **Raw config editor** as an advanced side sheet/dialog
+- **Ask Sero to help** button on error surfaces using `useAgentPrompt()`
+
+UI state rules:
+- use `useAppState()` only for the shared app snapshot
+- keep selected tabs, current draft modals, and current viewer/auth URL in
+  local React state
+- do not use `localStorage`
+
+### 8. Data flow
+
+#### Bootstrap
+
+```text
+Open MCP app
+  -> UI mount calls mcp_manager({ action: 'bootstrap' })
+  -> singleton runtime initializes config/cache/auth/lifecycle
+  -> runtime writes state snapshot to state.json
+  -> useAppState() re-renders UI
+```
+
+#### Add / edit / enable / disable server
+
+```text
+UI form -> mcp_manager upsert/enable/disable
+  -> config.json write
+  -> runtime reconcile target server
+  -> metadata/cache/status refresh
+  -> state snapshot write
+  -> UI re-renders from useAppState()
+```
+
+#### Connect / reconnect / auth
+
+```text
+UI click Connect
+  -> mcp_manager connect/reconnect
+  -> singleton server manager connects
+  -> if needs auth, state authStatus becomes needs-auth
+  -> UI click Authenticate
+  -> mcp_manager start_auth returns { authUrl, authSessionId }
+  -> UI opens embedded auth browser
+  -> callback server completes auth
+  -> runtime updates auth storage + state snapshot
+  -> UI closes auth pane and shows authenticated state
+```
+
+#### Open resource / launch tool UI
+
+```text
+UI click Open resource / Launch UI
+  -> mcp_manager open_resource / open_tool_ui
+  -> runtime reads resource or executes tool
+  -> runtime starts localhost UI host
+  -> tool returns ephemeral { viewerUrl, sessionId }
+  -> UI renders viewerUrl in right pane
+```
+
+#### Agent / CLI usage
+
+```text
+Agent or CLI -> mcp proxy tool / custom CLI
+  -> singleton runtime resolves metadata + lazy connection
+  -> MCP call executes through shared manager
+  -> result returns without creating popup UI side effects
+```
+
+## Parallelizable Workstreams
+
+The user explicitly asked for maximum safe parallelism. This feature supports
+parallel work, but only after a small contract/scaffolding slice lands first.
+
+### Workstream map
+
+| Workstream | Scope | Primary todos | Can run in parallel with | Hard blockers |
+|---|---|---|---|---|
+| **WS-A** | Contract + scaffolding | MCP-01, MCP-02 | none | foundation for all other slices |
+| **WS-B** | Extension runtime core | MCP-03, MCP-04, MCP-05 | WS-C, WS-D (after MCP-01/02) | needs shared types + storage contract |
+| **WS-C** | Desktop host viewer/auth rail | MCP-06 | WS-B, WS-D (after MCP-01) | needs manifest/app-id decision; integration waits on runtime URLs |
+| **WS-D** | UI product surface | MCP-07, MCP-08, MCP-09 | WS-B, WS-C (after MCP-01/02) | MCP-08 depends on management-tool contract; MCP-09 depends on host rail |
+| **WS-E** | Validation + docs | MCP-10, MCP-11, MCP-12 | partial parallel after feature slices land | final pass waits on WS-B/C/D |
+
+### Hard sequencing edges
+
+1. **MCP-01 and MCP-02 must land first.**
+   Shared manifest/tool/state/path decisions are the contract for every other slice.
+
+2. **MCP-04 is the main integration choke point.**
+   UI work and host viewer work both depend on the snapshot + management-action contract.
+
+3. **MCP-06 must land before MCP-09 can be considered done.**
+   The viewer/auth UI cannot be finalized until production CSP and embedded browser support exist.
+
+4. **MCP-10 / MCP-11 / MCP-12 finish last.**
+   They can start as slices land, but the repo-wide acceptance pass belongs at the end.
+
+### Validation checkpoints between workstreams
+
+- **Checkpoint A:** plugin is discoverable and mounts a placeholder UI.
+- **Checkpoint B:** opening the MCP app triggers bootstrap and writes a real state snapshot.
+- **Checkpoint C:** add a stdio server, connect it, and see resource metadata in UI.
+- **Checkpoint D:** `sero mcp status` and `sero mcp reconnect <server>` work.
+- **Checkpoint E:** open an embedded MCP resource inside the plugin.
+- **Checkpoint F:** complete an OAuth flow without leaving Sero.
+- **Checkpoint G:** `pnpm typecheck` passes and all touched files remain under 500 LOC.
+
+## Sequencing
+
+### Phase 1 — Foundation contract
+
+- create plugin package
+- land manifest, dependencies, Vite config, shared types
+- define storage paths and config/state split
+
+### Phase 2 — Extension singleton runtime
+
+- port config loading, metadata cache, auth storage, lifecycle, and server manager
+- introduce the snapshot writer and UI-only management service
+- prune direct-tool and TUI-first behavior
+
+### Phase 3 — Bridged proxy + CLI
+
+- land `mcp` proxy tool
+- add custom CLI for status/control actions
+- ensure only `mcp` is bridged
+
+### Phase 4 — Host viewer/auth rail
+
+- add production CSP loopback allowances
+- enable embedded auth browser support
+- add plugin-local viewer/auth components
+
+### Phase 5 — UI product surface
+
+- wizard + dashboard
+- server CRUD/detail screens
+- raw config and diagnostics
+- viewer/auth pane integration
+
+### Phase 6 — Tests, docs, final validation
+
+- extension/host tests
+- UI/integration tests
+- plugin README
+- root `pnpm typecheck`
+
+## File-Size / Refactor Notes
+
+The port must be organized to keep files below the monorepo’s 500 LOC rule.
+
+### Adapter files that must be split during conversion
+
+| Original file | Problem | Recommended split |
+|---|---|---|
+| `proxy-modes.ts` | too large + mixed responsibilities | `tools/proxy-status.ts`, `tools/proxy-search.ts`, `tools/proxy-call.ts`, `tools/proxy-format.ts` |
+| `mcp-panel.ts` | TUI-only and oversized | do not port as-is; redesign into UI components |
+| `ui-server.ts` | too large | `viewer/http-server.ts`, `viewer/sse.ts`, `viewer/session-events.ts`, `viewer/request-handlers.ts` |
+| `host-html-template.ts` | too large | `viewer/host-template.ts`, `viewer/csp.ts`, `viewer/html-shell.ts` |
+| `types.ts` | too broad | split into `shared/types.ts`, `extension/config/types.ts`, `extension/viewer/types.ts`, `extension/auth/types.ts` |
+| `mcp-auth-flow.ts` | too broad | `auth/flow.ts`, `auth/browser.ts`, `auth/callback.ts` |
+| `direct-tools.ts` | out of scope | do not port direct-tool registration logic in v1 |
+| `npx-resolver.ts` | large utility | keep isolated under `extension/manager/npx-resolver.ts` |
+
+### UI split guidance
+
+Do not let `ui/McpApp.tsx` become the admin panel equivalent of a god file.
+Split immediately into:
+
+- shell/layout
+- wizard
+- server rail
+- server detail
+- diagnostics
+- resource viewer/auth pane
+
+## Risks & Premortem
+
+### Riskiest assumptions
+
+| Assumption | If wrong |
+|---|---|
+| A module-level singleton extension runtime is shared across app sessions and normal chat sessions reliably enough | Status/connection state would drift again, and we would need a deeper host-owned runtime or explicit cross-session bus |
+| A whitelisted embedded browser surface is sufficient for OAuth providers that block iframe embedding | We would need a more invasive host-managed BrowserView/Browsing pane implementation |
+| Production CSP can be widened narrowly enough for loopback viewer URLs without reopening general external framing | Embedded MCP UI/resources would fail in packaged builds |
+| The adapter’s backend logic can be reused after pruning TUI/direct-tool behavior without hidden coupling | Porting effort grows because more modules need redesign than expected |
+| MCP tool UI launch flows can be represented cleanly from server detail views | We might need a second-stage launch dialog or stricter v1 support limits for parameter-heavy UI tools |
+
+### Realistic failure modes
+
+- **Built the wrong thing** — workers port `/mcp` and `/mcp-auth` as primary UX instead of the Sero UI.
+- **State drift across sessions** — app UI and agent CLI do not agree on connection/auth status.
+- **Packaged-build breakage** — localhost viewer works in dev but fails in production because CSP/webview allowances were incomplete.
+- **Auth regression** — some OAuth providers still force the system browser, violating the in-plugin requirement.
+- **File-size regression** — adapter code is copied into a few oversized files and immediately breaks repo standards.
+- **Leaked sensitive data** — auth URLs, viewer tokens, or token JSON accidentally get written into `state.json`.
+
+### Accepted mitigations
+
+- Use the cron-style singleton extension pattern from the start.
+- Treat viewer/auth host work as a first-class slice, not an afterthought.
+- Keep ephemeral auth/viewer URLs in local UI state or tool-returned details only.
+- Make the `mcp_manager` action contract explicit before UI work fans out.
+- Prune direct-tools, imports, and TUI panel code early so workers do not port dead scope.
+
+## Dependencies
+
+### Plugin dependencies to add
+
+Based on `pi-mcp-adapter/package.json`, the plugin will likely need:
+
+- `@modelcontextprotocol/sdk`
+- `@modelcontextprotocol/ext-apps`
+- `@sinclair/typebox`
+- `open` (fallback only; not primary UX)
+- `zod` peer compatibility if required by the SDK/AppBridge path
+
+### Existing platform dependencies / references
+
+- `@sero-ai/app-runtime`
+- `@sero-ai/common`
+- `@sero-ai/ui`
+- Electron main-process host seams already in the repo
+
+## Testing Strategy
+
+### Automated
+
+#### Extension / runtime
+
+- config path + storage tests
+- singleton runtime + refcount behavior
+- metadata cache read/write tests
+- enable/disable/connect/reconnect lifecycle tests
+- auth storage + auth-state transition tests
+- proxy search/describe/call tests (MCP-only search)
+- CLI bridge tests for `sero mcp ...`
+
+#### Host / security
+
+- production CSP allowlist test for loopback viewer URLs
+- main-window preference test for embedded auth browser support
+- if a reusable auth-browser component is extracted, add navigation/allowlist tests
+
+#### UI
+
+- bootstrap-on-mount test
+- first-run wizard flow
+- forms-first add/edit flow
+- raw config save/validation error flow
+- friendly error card + technical details + Ask Sero action
+- resource viewer launch flow
+- auth pane lifecycle flow
+
+### Manual smoke checks
+
+1. Open MCP app on a clean profile -> wizard appears.
+2. Add a stdio server -> connect -> status/resource counts populate.
+3. Add an HTTP/SSE server requiring OAuth -> authenticate entirely in-plugin.
+4. Open an MCP resource/UI inside the plugin.
+5. Force a broken server URL -> friendly recovery copy + details + Ask Sero button.
+6. Run `sero mcp status` and `sero mcp reconnect <server>`.
+7. Ask the agent to use the `mcp` tool after setup.
+8. Run root `pnpm typecheck`.
+
+## Implementation Todos
+
+> The structured todo tool / write-todos skill is not available in this planner session, so the worker backlog is embedded here as executable markdown todos.
+>
+> **Global rule for every todo:** keep the agent-facing surface to exactly one bridged tool (`mcp`), keep auth/viewer URLs out of persisted state, and keep every touched source file under 500 LOC.
+
+### MCP-01 — Scaffold the built-in plugin package and shared manifest contract
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-A
+- **Depends on:** none
+- **Files:**
+  - new `plugins/sero-mcp-plugin/package.json`
+  - new `plugins/sero-mcp-plugin/vite.config.ts`
+  - new `plugins/sero-mcp-plugin/ui/index.html`
+  - new `plugins/sero-mcp-plugin/ui/styles.css`
+  - new `plugins/sero-mcp-plugin/ui/tsconfig.json`
+  - new `plugins/sero-mcp-plugin/extension/tsconfig.json`
+  - new `plugins/sero-mcp-plugin/shared/types.ts`
+- **Reference code:**
+  - manifest/package pattern: `plugins/sero-git-plugin/package.json`
+  - global-scope manifest example: `plugins/sero-admin-plugin/package.json`
+  - Vite MF config: `plugins/sero-git-plugin/vite.config.ts`
+  - conversion constraints: `packages/templates/skills/sero-plugin/references/conversion-guide.md`
+- **Expected shape:**
+  ```json
+  {
+    "name": "@sero-ai/plugin-mcp",
+    "pi": { "extensions": ["./extension/index.ts"] },
+    "sero": {
+      "app": {
+        "id": "mcp",
+        "name": "MCP",
+        "icon": "plug",
+        "scope": "global",
+        "stateFile": ".sero/apps/mcp/state.json",
+        "ui": "./dist/ui/remoteEntry.js",
+        "component": "McpApp",
+        "devPort": 5196
+      },
+      "plugin": {
+        "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli"],
+        "bridgeTools": ["mcp"]
+      }
+    }
+  }
+  ```
+- **Constraints:**
+  - use `@sero-ai/plugin-mcp`, `mcp`, `plug`, and `5196`
+  - plugin is `scope: 'global'`
+  - expose exactly one bridged tool via `bridgeTools: ['mcp']`
+  - do **not** add `runtime/` or `requiredHostCapabilities: ['appRuntime.background']`
+- **Do NOT:**
+  - **Anti-pattern: Thin Wrapper Manifest** — do not keep adapter naming such as `pi-mcp-adapter` in the Sero package surface.
+  - **Anti-pattern: Bridge Everything** — do not omit `bridgeTools` and accidentally expose internal management tools.
+- **Acceptance:** establishes ISC-1, ISC-13, ISC-14, ISC-28 and the foundation for all later slices.
+
+### MCP-02 — Build path, config, cache, and auth-storage helpers with Sero-aware locations
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-A
+- **Depends on:** MCP-01
+- **Files:**
+  - new `plugins/sero-mcp-plugin/extension/state/paths.ts`
+  - new `plugins/sero-mcp-plugin/extension/state/state-io.ts`
+  - new `plugins/sero-mcp-plugin/extension/config/io.ts`
+  - new `plugins/sero-mcp-plugin/extension/config/types.ts`
+  - new `plugins/sero-mcp-plugin/extension/auth/storage.ts`
+  - new `plugins/sero-mcp-plugin/extension/cache/metadata-cache.ts`
+- **Reference code:**
+  - global state path pattern: `plugins/sero-cron-plugin/extension/state-io.ts`
+  - agent-dir resolution: `plugins/sero-memory-plugin/extension/agent-dir.ts`
+  - app-specific config paths: `plugins/sero-web-plugin/extension/paths.ts`
+  - adapter storage references: `/Users/danielcarter/Documents/Dev/ai/pi-mcp-adapter/config.ts`, `mcp-auth.ts`, `metadata-cache.ts`
+- **Expected shape:**
+  ```ts
+  export function getMcpStatePath(cwd?: string): string;
+  export function getMcpConfigPath(): string;
+  export function getMcpMetadataCachePath(): string;
+  export function getMcpOAuthDir(): string;
+  ```
+- **Constraints:**
+  - canonical config/state/cache live under `$SERO_HOME/apps/mcp/`
+  - OAuth tokens live under `$PI_CODING_AGENT_DIR/mcp-oauth/`
+  - keep Pi CLI fallback behavior only when env vars are absent
+  - use atomic writes for config, cache, and state
+  - preserve unknown raw-config keys when round-tripping advanced edits
+- **Do NOT:**
+  - **Anti-pattern: Legacy Path Lock-In** — do not hardcode `~/.pi/agent/...` as the primary path.
+  - **Anti-pattern: One Big State File** — do not merge config, auth secrets, and derived UI state into a single persisted blob.
+- **Acceptance:** covers ISC-13, ISC-17, ISC-22, ISC-28, ISC-A-2.
+
+### MCP-03 — Port the adapter core into a module-level singleton MCP runtime
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-B
+- **Depends on:** MCP-01, MCP-02
+- **Files:**
+  - new `plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts`
+  - new `plugins/sero-mcp-plugin/extension/runtime/session-hooks.ts`
+  - new `plugins/sero-mcp-plugin/extension/manager/server-manager.ts`
+  - new `plugins/sero-mcp-plugin/extension/manager/lifecycle.ts`
+  - new `plugins/sero-mcp-plugin/extension/manager/tool-metadata.ts`
+  - new `plugins/sero-mcp-plugin/extension/manager/npx-resolver.ts`
+  - `plugins/sero-mcp-plugin/extension/index.ts`
+- **Reference code:**
+  - singleton extension pattern: `plugins/sero-cron-plugin/extension/index.ts`
+  - runtime/refcount structure: `plugins/sero-cron-plugin/extension/runtime.ts`
+  - adapter lifecycle core: `/Users/danielcarter/Documents/Dev/ai/pi-mcp-adapter/init.ts`, `lifecycle.ts`, `server-manager.ts`
+- **Expected shape:**
+  ```ts
+  const runtime = createOrGetMcpRuntime();
+
+  export default function mcpExtension(pi: ExtensionAPI) {
+    runtime.attachPi(pi);
+    pi.on('session_start', async (_event, ctx) => runtime.handleSessionStart(ctx));
+    pi.on('session_shutdown', async () => runtime.handleSessionShutdown());
+  }
+  ```
+- **Constraints:**
+  - one process-wide MCP runtime shared across app sessions and chat sessions
+  - no `runtime/` plugin package — this stays inside the extension layer
+  - port stdio + HTTP/SSE lifecycle behavior, but prune direct-tools and TUI-only concerns
+  - split the ported logic immediately; do not recreate `proxy-modes.ts` / `ui-server.ts`-style mega files
+- **Do NOT:**
+  - **Anti-pattern: Per-Session MCP State** — do not instantiate a fresh server manager per session the way the raw adapter does today.
+  - **Anti-pattern: Dead-Scope Porting** — do not copy `mcp-panel.ts` or direct-tool registration logic into v1.
+- **Acceptance:** establishes ISC-11, ISC-12, ISC-18, ISC-19, ISC-27 while preserving the no-runtime decision.
+
+### MCP-04 — Add snapshot writing and the shared management service contract
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-B
+- **Depends on:** MCP-02, MCP-03
+- **Files:**
+  - new `plugins/sero-mcp-plugin/extension/state/snapshot.ts`
+  - new `plugins/sero-mcp-plugin/extension/service/management.ts`
+  - update `plugins/sero-mcp-plugin/shared/types.ts`
+  - update `plugins/sero-mcp-plugin/extension/state/state-io.ts`
+- **Reference code:**
+  - UI-facing snapshot sync: `plugins/sero-web-plugin/extension/state-sync.ts`
+  - file-backed shared state contract: `plugins/sero-git-plugin/shared/types.ts`
+- **Expected shape:**
+  ```ts
+  export interface McpAppState {
+    initialized: boolean;
+    firstRun: boolean;
+    servers: McpServerSnapshot[];
+    summary: { totalServers: number; connectedServers: number; needsAuthServers: number; errorServers: number };
+    lastRefreshedAt: string | null;
+  }
+
+  export interface McpManagerActionResult {
+    snapshotWritten: boolean;
+    viewerUrl?: string;
+    authUrl?: string;
+  }
+  ```
+- **Constraints:**
+  - persisted state must stay UI-friendly and secret-free
+  - auth URLs, viewer URLs, and session tokens are **ephemeral return values**, not persisted state
+  - add a `bootstrap` management action so the UI can initialize the app session on mount
+  - expose diagnostics on demand via the management service instead of stuffing everything into `state.json`
+- **Do NOT:**
+  - **Anti-pattern: Persisted Secret Drift** — do not write OAuth URLs, tokens, or local viewer session tokens into `state.json`.
+  - **Anti-pattern: UI Reads Config Directly** — do not make the UI parse `config.json` itself instead of consuming the normalized snapshot.
+- **Acceptance:** establishes ISC-2, ISC-3, ISC-18, ISC-19, ISC-21, ISC-22, ISC-23, ISC-27.
+
+### MCP-05 — Implement the `mcp` proxy tool, the `mcp_manager` UI tool, and custom CLI bridging
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-B
+- **Depends on:** MCP-03, MCP-04
+- **Files:**
+  - new `plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts`
+  - new `plugins/sero-mcp-plugin/extension/tools/manager-tool.ts`
+  - new `plugins/sero-mcp-plugin/extension/tools/cli.ts`
+  - update `plugins/sero-mcp-plugin/extension/index.ts`
+  - update `plugins/sero-mcp-plugin/package.json`
+- **Reference code:**
+  - tool registration pattern: `plugins/sero-git-plugin/extension/index.ts`
+  - action-enum tool pattern: `plugins/sero-cron-plugin/extension/tools.ts`
+  - custom CLI bridge behavior: `apps/desktop/electron/cli/core/schema-bridge.ts`
+  - live CLI refresh tests: `apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts`
+  - adapter proxy behavior reference: `/Users/danielcarter/Documents/Dev/ai/pi-mcp-adapter/index.ts`, `proxy-modes.ts`
+- **Expected shape:**
+  ```ts
+  pi.registerTool({
+    name: 'mcp',
+    parameters: McpProxyParams,
+    cli: {
+      summary: 'Manage MCP servers and use the MCP proxy',
+      help: 'sero mcp status | list | connect <server> | reconnect [server] | enable <server> | disable <server>',
+      async execute(args, ctx) {
+        return runMcpCli(runtime, args, ctx);
+      },
+    },
+  });
+
+  pi.registerTool({
+    name: 'mcp_manager',
+    parameters: McpManagerParams,
+    async execute(_id, params) {
+      return runtime.executeManagerAction(params);
+    },
+  });
+  ```
+- **Constraints:**
+  - `mcp` is the only bridged tool
+  - `mcp_manager` is for UI actions only and must not be bridged
+  - basic CLI actions = `status`, `list`, `connect`, `reconnect`, `enable`, `disable`
+  - auth remains UI-first; CLI should return guidance, not launch external auth flows
+  - proxy search results should only include MCP tools/resources, not `mcp_manager` or unrelated Pi tools
+- **Do NOT:**
+  - **Anti-pattern: Agent Surface Creep** — do not surface `mcp_manager`, direct MCP tools, or internal admin actions to the agent.
+  - **Anti-pattern: Search All Pi Tools** — do not keep the adapter’s mixed Pi-tool search behavior; it leaks internal tools and violates the single-surface intent.
+- **Acceptance:** covers ISC-14, ISC-15, ISC-16, ISC-A-1, ISC-A-4.
+
+### MCP-06 — Add the desktop host support required for in-plugin viewer and auth surfaces
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-C
+- **Depends on:** MCP-01
+- **Files:**
+  - `apps/desktop/electron/main.ts`
+  - `apps/desktop/electron/platform/security/csp.ts`
+  - new `plugins/sero-mcp-plugin/ui/components/viewer/McpAuthBrowser.tsx`
+  - new `plugins/sero-mcp-plugin/ui/webview.d.ts` (or equivalent JSX intrinsic typing)
+- **Reference code:**
+  - production CSP policy: `apps/desktop/electron/platform/security/csp.ts`
+  - loopback iframe preview pattern: `apps/desktop/src/components/apps/explorer/editor/DevServerPreview.tsx`
+  - shared iframe UI patterns: `packages/ui/src/components/ai-elements/web-preview.tsx`
+- **Expected shape:**
+  ```ts
+  // main.ts
+  webPreferences: {
+    preload: ...,
+    contextIsolation: true,
+    nodeIntegration: false,
+    plugins: true,
+    webviewTag: true,
+  }
+  ```
+
+  ```tsx
+  export function McpAuthBrowser({ src }: { src: string }) {
+    return <webview src={src} className="size-full" partition="persist:sero-mcp-auth" />;
+  }
+  ```
+- **Constraints:**
+  - production CSP must allow **loopback** frame/connect sources needed by the viewer without reopening arbitrary `http:` / `https:` production frames
+  - embedded auth must stay in-plugin; do not require a popup or the system browser on the happy path
+  - if `webviewTag` is enabled, the auth component must enforce a strict URL allowlist and must not enable Node integration
+- **Do NOT:**
+  - **Anti-pattern: Broad Production CSP** — do not add blanket `http:` / `https:` frame allowances in production.
+  - **Anti-pattern: External Browser Primary Path** — do not make `shell.openExternal()` or `open()` the normal auth flow.
+- **Acceptance:** unlocks ISC-17, ISC-20, ISC-24, ISC-26, ISC-A-3.
+
+### MCP-07 — Build the MCP app shell, bootstrap hook, and first-run overview/wizard
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-D
+- **Depends on:** MCP-01, MCP-04
+- **Files:**
+  - new `plugins/sero-mcp-plugin/ui/McpApp.tsx`
+  - new `plugins/sero-mcp-plugin/ui/hooks/useMcpBootstrap.ts`
+  - new `plugins/sero-mcp-plugin/ui/components/layout/McpShell.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/overview/McpOverview.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/wizard/McpSetupWizard.tsx`
+- **Reference code:**
+  - rich multi-panel app shell: `plugins/sero-admin-plugin/ui/AdminApp.tsx`
+  - lightweight state-driven UI: `plugins/sero-web-plugin/ui/WebApp.tsx`
+  - `useAppTools()` behavior: `packages/app-runtime/src/use-app-tools.ts`
+- **Expected shape:**
+  ```tsx
+  export function McpApp() {
+    useMcpBootstrap();
+    const [state] = useAppState<McpAppState>(DEFAULT_MCP_STATE);
+    return <McpShell state={state} />;
+  }
+  ```
+- **Constraints:**
+  - on mount, bootstrap the app session via `useAppTools().run('mcp_manager', { action: 'bootstrap' })`
+  - show a first-run wizard when there are no configured servers
+  - healthy-state overview should be friendly and non-technical by default
+  - keep selection/tab state local to React; no localStorage
+- **Do NOT:**
+  - **Anti-pattern: Passive UI Bootstrap** — do not assume opening the plugin automatically initializes the app session.
+  - **Anti-pattern: TUI UI Port** — do not rebuild the adapter’s overlay panel inside React.
+- **Acceptance:** covers ISC-2, ISC-3, ISC-4, ISC-13, ISC-21.
+
+### MCP-08 — Implement server list/detail UX, forms-first CRUD, raw config editing, and Ask-Sero recovery
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-D
+- **Depends on:** MCP-04, MCP-07
+- **Files:**
+  - new `plugins/sero-mcp-plugin/ui/components/servers/McpServerRail.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/servers/McpServerDetail.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/servers/McpServerForm.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/servers/McpServerStatusCard.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/config/McpRawConfigEditor.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/diagnostics/McpDiagnosticsPanel.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/shared/AskSeroButton.tsx`
+- **Reference code:**
+  - dense admin/config panels: `plugins/sero-admin-plugin/ui/components/ConfigPanel.tsx`
+  - status-heavy card sections: `plugins/sero-admin-plugin/ui/components/plugins/PluginDevSessionCard.tsx`
+  - agent prompt hook: `packages/app-runtime/src/use-agent-prompt.ts`
+- **Expected shape:**
+  ```tsx
+  const promptAgent = useAgentPrompt();
+
+  <AskSeroButton
+    onClick={() => promptAgent(buildMcpHelpPrompt(serverSnapshot, diagnostics))}
+  />
+  ```
+- **Constraints:**
+  - support add, edit, enable, disable, connect, reconnect, remove
+  - forms-first UX for normal setup; raw JSON editor for advanced users
+  - failure states must show friendly copy first, with copyable diagnostics on demand
+  - include explicit **Ask Sero to help** actions on auth/server/render failures
+- **Do NOT:**
+  - **Anti-pattern: Raw-JSON-Only Management** — do not make raw config the primary setup path.
+  - **Anti-pattern: Technical-First Healthy UI** — do not front-load diagnostics when everything is working.
+- **Acceptance:** covers ISC-5, ISC-6, ISC-7, ISC-8, ISC-9, ISC-10, ISC-18, ISC-22, ISC-23, ISC-24, ISC-25.
+
+### MCP-09 — Integrate embedded resource/UI viewing and the in-plugin auth pane
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-D
+- **Depends on:** MCP-04, MCP-06, MCP-07
+- **Files:**
+  - new `plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.tsx`
+  - new `plugins/sero-mcp-plugin/ui/hooks/useMcpViewer.ts`
+  - new `plugins/sero-mcp-plugin/extension/viewer/ui-server.ts`
+  - new `plugins/sero-mcp-plugin/extension/viewer/ui-session.ts`
+  - new `plugins/sero-mcp-plugin/extension/viewer/ui-resource-handler.ts`
+  - new `plugins/sero-mcp-plugin/extension/auth/flow.ts`
+  - new `plugins/sero-mcp-plugin/extension/auth/callback-server.ts`
+- **Reference code:**
+  - loopback viewer rendering: `apps/desktop/src/components/apps/explorer/editor/DevServerPreview.tsx`
+  - shared iframe shell: `packages/ui/src/components/ai-elements/web-preview.tsx`
+  - adapter viewer/auth backend: `/Users/danielcarter/Documents/Dev/ai/pi-mcp-adapter/ui-session.ts`, `ui-server.ts`, `ui-resource-handler.ts`, `mcp-auth-flow.ts`, `mcp-callback-server.ts`
+- **Expected shape:**
+  ```ts
+  const result = await run('mcp_manager', {
+    action: 'open_resource',
+    serverName,
+    resourceUri,
+  });
+
+  setViewer({ url: result.details?.viewerUrl as string, mode: 'resource' });
+  ```
+- **Constraints:**
+  - MCP resources and UI-capable tools must open inside the plugin UI
+  - use iframe/web preview for localhost viewer URLs only
+  - use the embedded auth browser for external OAuth URLs
+  - if a resource cannot render, keep the user in-plugin with recovery guidance and Ask-Sero action
+  - do not persist viewer/auth URLs into app state
+- **Do NOT:**
+  - **Anti-pattern: Popup Viewer Regression** — do not keep the adapter’s browser/Glimpse popup model as the primary flow.
+  - **Anti-pattern: Persisted Viewer Secrets** — do not write session URLs/tokens to `state.json`.
+- **Acceptance:** covers ISC-17, ISC-19, ISC-20, ISC-24, ISC-26, ISC-A-3.
+
+### MCP-10 — Add extension/runtime/host automated tests for lifecycle, paths, CLI, and CSP
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-E
+- **Depends on:** MCP-03, MCP-04, MCP-05, MCP-06
+- **Files:**
+  - new `plugins/sero-mcp-plugin/extension/__tests__/*.test.ts`
+  - update `apps/desktop/electron/__tests__/platform/csp.test.ts`
+  - optionally update `apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts` if manifest parsing changes are needed
+- **Reference code:**
+  - adapter test inventory: `/Users/danielcarter/Documents/Dev/ai/pi-mcp-adapter/__tests__/*`
+  - CSP tests: `apps/desktop/electron/__tests__/platform/csp.test.ts`
+  - plugin manifest/compatibility tests: `apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts`
+  - CLI custom bridge tests: `apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts`
+- **Expected coverage:**
+  - singleton runtime dedupes session attach
+  - config/cache/auth paths resolve to Sero-aware locations
+  - enable/disable/connect/reconnect update runtime + snapshot correctly
+  - `mcp_manager` is not exposed via bridgeTools
+  - `mcp` CLI subcommands execute and refresh from live tool definitions
+  - production CSP allows loopback viewer URLs without broad `http:`/`https:` reopening
+- **Do NOT:**
+  - **Anti-pattern: Happy-Path-Only Backend Tests** — do not stop at “connect works”.
+  - **Anti-pattern: Untested CSP Change** — do not ship production frame/connect policy changes without targeted tests.
+- **Acceptance:** covers ISC-11 through ISC-20, ISC-24, ISC-26, ISC-A-1, ISC-A-3.
+
+### MCP-11 — Add UI tests for wizard, server detail, diagnostics, Ask-Sero, and viewer/auth flows
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-E
+- **Depends on:** MCP-07, MCP-08, MCP-09
+- **Files:**
+  - new `plugins/sero-mcp-plugin/ui/*.test.tsx`
+  - new `plugins/sero-mcp-plugin/ui/components/**/*.test.tsx`
+  - optionally new local UI hook tests under `plugins/sero-mcp-plugin/ui/hooks/*.test.ts`
+- **Reference code:**
+  - app-runtime bridge test: `apps/desktop/src/lib/app-runtime.test.tsx`
+  - federated UI test patterns: `plugins/sero-git-plugin/ui/GitApp.test.tsx`
+  - questionnaire UI tests: `plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.test.tsx`
+- **Expected coverage:**
+  - bootstrap action runs on mount
+  - first-run wizard appears only when expected
+  - forms-first add/edit/remove flows call `mcp_manager` correctly
+  - diagnostics remain hidden until requested
+  - Ask-Sero buttons compose useful prompts
+  - viewer/auth panes render and recover from failure states in-plugin
+- **Do NOT:**
+  - **Anti-pattern: Snapshot-Only UI Coverage** — assert visible recovery copy, button presence, and action calls rather than only snapshots.
+  - **Anti-pattern: LocalStorage UI State** — do not add tests for forbidden persistence paths because the feature should not use them.
+- **Acceptance:** covers ISC-2 through ISC-10, ISC-17 through ISC-26.
+
+### MCP-12 — Write the plugin README and run the final monorepo validation pass
+- **Plan artifact:** `.pi/plans/2026-04-20-mcp-adaptor-plugin/plan.md`
+- **Workstream:** WS-E
+- **Depends on:** MCP-05, MCP-08, MCP-09, MCP-10, MCP-11
+- **Files:**
+  - new `plugins/sero-mcp-plugin/README.md`
+  - optional small doc touchpoints only if needed for cross-linking
+- **Reference code:**
+  - README structure and user guide style: `plugins/sero-cron-plugin/README.md`
+  - plugin packaging docs: `docs/plugins/guide.md`
+- **Expected shape:**
+  ```md
+  # @sero-ai/plugin-mcp
+  - setup wizard
+  - stdio and HTTP/SSE server setup
+  - in-plugin auth flow
+  - embedded resources/UIs
+  - `sero mcp status|list|connect|reconnect|enable|disable`
+  - troubleshooting and storage paths
+  ```
+- **Constraints:**
+  - cover setup, auth, CLI control, troubleshooting, and storage behavior
+  - explicitly document that v1 has one proxy tool and no direct-tool exposure
+  - end with repo-root `pnpm typecheck`
+- **Do NOT:**
+  - **Anti-pattern: Adapter README Copy-Paste** — do not document `/mcp-auth`, imports, direct tool toggles, or popup-first UI as if they shipped in v1.
+  - **Anti-pattern: Partial Validation** — do not skip the final root `pnpm typecheck` and touched-file line-count checks.
+- **Acceptance:** covers ISC-28 and closes the release checklist.
+
+## Final Notes for Workers
+
+- Use the adapter as a **backend parts bin**, not as the final product shape.
+- Keep the singleton runtime decision intact unless it is conclusively proven insufficient.
+- Do not invent a new host IPC surface if `useAppTools()` + shared state + minimal host viewer/auth support are enough.
+- Protect the single-tool agent surface aggressively:
+  - no direct-tool registration
+  - no proxy search over plugin-internal tools
+  - no accidental `bridgeTools` omissions
+- Treat production viewer/auth support as a first-class requirement, not a late polish task.
+- Run `pnpm typecheck` from the monorepo root before calling the feature done.

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/scout-context.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/scout-context.md
@@ -1,0 +1,76 @@
+# Context for: integrate pi-mcp-adapter as a built-in Sero plugin
+
+## Recommended plugin shape
+- **Shape:** `extension + ui`, **no separate runtime** for v1.
+- **Why:** the adapter already owns MCP server lifecycle, OAuth, metadata cache, tool bridging, and the interactive `/mcp` panel. Sero only needs a polished plugin UI to inspect/manage config, direct-tool bridging, server status, auth, and UI-session history.
+- **Avoid adding `runtime/` initially:** there is no evidence the adapter needs a long-lived background process beyond the extension process itself. A runtime would add lifecycle complexity without solving a clear gap.
+- **Likely app id / package name:**
+  - `app.id`: `mcp`
+  - display name: `MCP`
+  - package name: `@sero-ai/plugin-mcp` or `@sero-ai/plugin-mcp-adapter`
+- **Icon:** `plug` or `puzzle`/`workflow`-style icon; `plug` best matches a connector/bridge product.
+- **State file:** `.sero/apps/mcp/state.json`
+- **Likely devPort:** `5196` (next free slot after current built-ins: 5188 cron, 5193 admin, 5194 git, 5195 web; avoid reusing those)
+
+## Relevant Sero references
+- `docs/plugins/guide.md` — plugin packaging, manifest fields, install/build expectations, UI + extension structure.
+- `docs/plugins/technical.md` — built-in vs installed plugin behavior, manifest-driven tool bridging, app discovery, and package format.
+- `docs/plugins/host-compatibility.md` — declare `requiredHostCapabilities` when the UI calls tools directly or the plugin depends on bridged CLI behavior.
+- `docs/architecture.md` — shell/app layout and state conventions.
+- `docs/decisions.md` — especially tool-bridge decisions (AD-020) and app/plugin loading patterns.
+- Reference built-ins:
+  - `plugins/sero-admin-plugin/extension/index.ts` — UI-only plugin pattern.
+  - `plugins/sero-git-plugin/extension/index.ts` + `shared/types.ts` — app state, workspace-bound extension/tool pattern, and shared state contract.
+  - `plugins/sero-web-plugin/extension/index.ts` — richer tool orchestration, session hooks, background-ish fetch behavior, and state sync.
+  - `plugins/sero-cron-plugin/extension/index.ts` — global singleton runtime pattern and persistent scheduler.
+
+## Relevant pi-mcp-adapter references
+- `README.md` — defines the product: single proxy tool + direct tools + interactive `/mcp` panel + UI integration for MCP resources.
+- `package.json` — current extension surface and file inventory.
+- `index.ts` — main extension entry; registers tools/commands, handles session lifecycle, bootstraps auth and state.
+- `commands.ts` — `/mcp`, `/mcp-auth`, status, reconnect, and TUI panel entry points.
+- `state.ts` — extension state shape: server manager, lifecycle manager, tool metadata cache, consent manager, UI server handle, completed UI sessions, message bridge.
+- `ui-server.ts` — the heavy piece: HTTP/SSE host for MCP UI resources, message replay, stream summaries, consent gating.
+- `mcp-auth.ts`, `mcp-auth-flow.ts`, `mcp-callback-server.ts`, `mcp-oauth-provider.ts` — OAuth/token handling and callback server logic.
+- `config.ts`, `metadata-cache.ts`, `server-manager.ts`, `direct-tools.ts`, `proxy-modes.ts`, `tool-registrar.ts`, `resource-tools.ts`, `ui-resource-handler.ts` — MCP config parsing, lazy/eager connection management, metadata cache, proxy/direct tool registration, resource bridging.
+- `mcp-panel.ts` — TUI overlay for config and direct-tool selection.
+- `glimpse-ui.ts` and `host-html-template.ts` — browser/native UI rendering and host HTML shell.
+- Data storage location: `~/.pi/agent/mcp-oauth/<server>/tokens.json` for OAuth creds; config defaults to `~/.pi/agent/mcp.json`; metadata cache and UI/session state are also stored under the Pi agent directory (adapter uses `~/.pi/agent/...`, which Sero should likely redirect to `~/.sero-ui/agent/...` if this becomes Sero-owned).
+
+## Migration hotspots
+- **File-size hotspots in adapter (must split during conversion):**
+  - `proxy-modes.ts` — 810 LOC
+  - `mcp-panel.ts` — 740 LOC
+  - `ui-server.ts` — 623 LOC
+  - `index.ts` — 305 LOC
+  - `mcp-auth-flow.ts` — 400 LOC
+  - `direct-tools.ts` — 400 LOC
+  - `types.ts` — 426 LOC
+  - `host-html-template.ts` — 427 LOC
+  - `npx-resolver.ts` — 419 LOC
+- **Sero-side UI patterns worth copying:**
+  - `sero-admin-plugin` for a dense, multi-panel admin surface with lots of settings/detail panes.
+  - `sero-git-plugin` for strongly typed shared state and deterministic UI state/file sync.
+  - `sero-web-plugin` for richer command/tool orchestration and session-aware state syncing.
+- **Likely copy vs redesign split:**
+  - Copy/adapt: config parser, auth storage, lazy/eager server manager logic, tool metadata caching, UI-session tracking, CLI parsing/helpers.
+  - Redesign for Sero: any UI that currently assumes Pi’s `/mcp` TUI overlay or `~/.pi/agent` storage, and any host-specific browser/native window handling.
+
+## Open questions for spec
+1. **Scope of the UI:** do we want the full MCP manager (server list, auth, direct-tool toggles, activity/history, UI-session inspector), or a narrower “server settings + status” dashboard?
+2. **CLI bridging policy:** should plugin tools be bridged into `sero-cli` by default, or should this plugin opt out / selectively bridge? The adapter already exposes a single `mcp` proxy tool plus optional direct tools.
+3. **Tool surface exposure:** do users want the large proxy tool only, direct per-server tools, or both? This affects `bridgeTools` and `requiredHostCapabilities: ["tool.cli"]`.
+4. **OAuth UX:** should auth be handled entirely in the plugin UI, or should the extension keep a `/mcp-auth` command for agent-only workflows?
+5. **Storage contract:** should Sero keep the adapter’s `mcp.json` path under `~/.sero-ui/agent/` or move to app state under `.sero/apps/mcp/state.json` with a separate config file?
+6. **UI resource handling:** do we want to preserve MCP UI resources as native/browser popups, or embed them inside the Sero plugin UI shell?
+7. **Protocol support scope:** stdio-only, HTTP-only, or both?
+8. **Import workflow:** should Sero import an existing `~/.pi/agent/mcp.json`, or create a fresh Sero-specific config schema?
+
+## Suggested implementation slices
+1. **Manifest + scaffolding:** create built-in plugin package, manifest, and app shell; choose initial `app.id`, icon, port, and state file.
+2. **Core extension port:** move config loading, state handling, tool registration, and lifecycle wiring into Sero conventions.
+3. **UI manager panel:** build a polished admin-style web UI for server status, auth, direct-tool management, config editing/import, and session history.
+4. **OAuth + server lifecycle:** port auth flow and lazy/eager/keep-alive connection logic, but swap storage paths to Sero’s agent directory conventions.
+5. **UI-resource viewing:** decide whether to render MCP UIs in-app, in a popup, or in a dedicated embedded viewer panel.
+6. **Tool bridging policy:** define `bridgeTools` defaults and any `requiredHostCapabilities` in the manifest.
+7. **Data migration/import:** add import of existing Pi MCP config + token cache, plus migration from `~/.pi/agent` to `~/.sero-ui/agent` if desired.

--- a/.pi/plans/2026-04-20-mcp-adaptor-plugin/spec.md
+++ b/.pi/plans/2026-04-20-mcp-adaptor-plugin/spec.md
@@ -1,0 +1,173 @@
+# Built-in MCP Plugin for Sero
+
+**Date:** 2026-04-20
+**Status:** Draft
+**Directory:** /Users/danielcarter/Documents/Dev/projects/sero/sero
+
+## Intent
+Build a new first-party **MCP** plugin inside the Sero monorepo by converting the existing `pi-mcp-adapter` product into a **Sero-native, UI-first management experience**. The result should let a single Sero user configure MCP servers, complete authentication, inspect current status, use MCP capability through Sero, and open MCP-provided UIs/resources without feeling like they are using a bolted-on adapter.
+
+The key outcome is not just feature parity with the existing adapter. The key outcome is a **polished personal MCP control center** that feels as sophisticated and integrated as Sero's stronger built-in plugins, especially `sero-admin-plugin` and `sero-git-plugin`.
+
+## User Story
+As a Sero user who wants to connect MCP servers to my local Sero environment, I want a built-in MCP control center where I can add and manage servers, authenticate them, check their status, and open MCP-provided UIs/resources, so that MCP feels like a natural part of Sero instead of an external tool or command-only workflow.
+
+## Behavior
+The plugin appears as a built-in first-party Sero app named around **MCP**. Its main experience is a **hybrid** of:
+- an approachable overview/dashboard layer for current setup and status
+- deeper admin-style drill-down views for individual servers
+
+The product is optimized for a **single-user local Sero install**. It assumes the user broadly understands what MCP servers are, but it should still help new users get started through a **lightweight setup wizard** and clear examples/help text. The UX should be user-friendly and not needlessly technical, while still making deeper diagnostic information available whenever something goes wrong.
+
+The plugin is the primary place to:
+- add, edit, enable, disable, reconnect, and remove MCP servers
+- complete authentication flows
+- inspect auth and connection status
+- view and open that server's MCP-provided UIs/resources
+- recover from server, auth, or resource failures without leaving the plugin
+
+The plugin is also the primary visual surface for MCP management, but Sero CLI should still be able to perform **basic management** actions and use the MCP capability exposed through Sero.
+
+### Happy Path
+1. The user opens the built-in MCP plugin in Sero.
+2. On first use, the plugin offers a lightweight setup wizard.
+3. The user creates a new MCP server entry using a forms-first setup flow.
+4. The plugin provides examples/help text while the user fills in server details.
+5. The user saves the server and connects it.
+6. If authentication is required, the user completes it entirely from the plugin UI.
+7. The server detail view shows current auth state, connection state, and available MCP-provided UIs/resources.
+8. The user opens an MCP-provided UI/resource directly inside the plugin.
+9. Sero can use the plugin's single MCP proxy tool for agent workflows.
+10. If needed, the user can also use Sero CLI for basic MCP management actions such as listing status or reconnecting a server.
+
+### Edge Cases & Error Handling
+- **Authentication failure:** The user stays inside the plugin, sees a friendly explanation, gets clear next steps, and can retry or re-authenticate from the same surface.
+- **Offline or unreachable server:** The plugin shows current status clearly, explains the problem in plain language first, and offers actionable recovery steps such as reconnecting.
+- **Embedded MCP resource cannot render cleanly:** The plugin keeps the user in context and shows recovery guidance inside the plugin rather than requiring an external browser/window for the core flow.
+- **User needs technical detail:** Technical diagnostics are available on demand, are easy to copy/paste, and support an explicit **Ask Sero to help** recovery path.
+- **Healthy system state:** The UI does not overwhelm the user with technical details when everything is working.
+
+## Scope
+### In Scope
+- A new built-in first-party MCP plugin in the Sero monorepo
+- A polished Sero-native UI comparable in sophistication to `sero-admin-plugin` or `sero-git-plugin`
+- A hybrid experience with overview/dashboard entry points and deeper per-server drill-down views
+- First-run lightweight setup wizard
+- Forms-first creation and editing of MCP server entries
+- Advanced raw-config inspection/editing for users who want it
+- Full server management from the plugin UI:
+  - add
+  - edit
+  - enable/disable
+  - connect/reconnect
+  - remove
+- Support for both `stdio` and `HTTP/SSE` MCP server transports
+- Global MCP configuration for the user's Sero install
+- Authentication handled entirely in the plugin UI
+- Server detail views that show auth state and connection state
+- Embedded viewing/opening of MCP-provided UIs/resources inside the plugin
+- A single agent-facing MCP proxy tool exposed through Sero
+- Basic Sero CLI control for MCP management, including status visibility and basic server control actions
+- Friendly default error UX with technical details available on demand
+- Explicit **Ask Sero to help** actions in failure states
+- README-level documentation covering setup, auth, CLI control, and troubleshooting
+
+### Out of Scope
+- Importing existing config, token, or state from `~/.pi/agent` or prior Pi MCP setups
+- Direct per-server or per-tool exposure in v1
+- Making command-driven workflows the primary way to manage MCP
+- Rich session-history browsing as a first-class product surface in v1
+- Requiring external browser windows or popups for core MCP UI/resource flows
+- Multi-user, team-admin, or enterprise management workflows
+- Workspace-specific MCP configuration in v1
+- A curated marketplace/catalog of known MCP servers in v1
+
+## Priorities
+### Priority 1 — Core Product Shape
+- The plugin must feel like a native first-party Sero app, not a thin wrapper around the existing adapter.
+- The plugin must make MCP server setup, management, authentication, and current status understandable and comfortable for a single user.
+- MCP-provided UIs/resources must be usable from inside the plugin.
+
+### Priority 2 — Reliable Daily Usability
+- The primary UI must support all important server-management actions without forcing the user to drop into commands.
+- Error states must be easy to understand and recover from.
+- Sero CLI must cover basic management needs for users who prefer command access.
+
+### Priority 3 — Advanced User Confidence
+- Advanced users must be able to inspect raw config when needed.
+- Technical details must be easy to reveal and copy/paste.
+- The product should make it easy to ask Sero for help when something fails.
+
+## Effort & Quality
+- **Level:** production
+- **Tests:** thorough
+- **Docs:** README
+
+## Constraints
+- The plugin is a **built-in** Sero plugin in the monorepo, not an external add-on.
+- The product should preserve the existing adapter's core value while becoming **Sero-native** in UX and workflow.
+- The UI should be friendly by default and avoid unnecessary technical complexity.
+- Users are expected to have a basic understanding of MCP server concepts, but onboarding should reduce friction through a lightweight wizard and examples/help.
+- Technical diagnostics must exist, but they should not dominate the healthy-state experience.
+- MCP configuration is **global** to the Sero install.
+- MCP UI/resource discovery in v1 happens from **server detail views**, not a separate central resource browser.
+- Basic management must remain accessible from **Sero CLI** in addition to the plugin UI.
+- The agent-facing tool surface must stay intentionally simple in v1.
+- The source behavior being adapted comes from `/Users/danielcarter/Documents/Dev/ai/pi-mcp-adapter`.
+
+## Non-Goals
+- Recreating Pi-specific command/TUI workflows as the main product experience
+- Exposing the full direct-tool surface of the original adapter in v1
+- Solving migration from prior Pi MCP installs in the first release
+- Building a deep observability console or session-history explorer before the core management experience is solid
+- Expanding this feature into a broader multi-user or policy-management system
+
+## Decisions Deferred to Planner
+These are implementation decisions, not open product-scope questions:
+- Exact package name, app id, icon, and manifest naming
+- Exact CLI command names and syntax for basic MCP management actions
+- Exact visual layout of the hybrid dashboard/drill-down experience
+- Exact storage-file layout inside Sero, as long as it stays global to the Sero install and honors the product scope above
+- Exact embedded viewer mechanics for MCP-provided UIs/resources, as long as core flows remain in-plugin
+- Exact internal split of adapted code from `pi-mcp-adapter`
+
+## Ideal State Criteria
+
+### Core Functionality
+- [ ] ISC-1: A built-in **MCP** plugin appears as a first-party Sero app.
+- [ ] ISC-2: The main experience blends overview panels with deeper server drill-downs.
+- [ ] ISC-3: First run offers a lightweight wizard for initial MCP setup.
+- [ ] ISC-4: New server setup starts blank and includes examples/help text.
+- [ ] ISC-5: Users can add MCP servers from the plugin UI.
+- [ ] ISC-6: Users can edit server settings from forms-first screens.
+- [ ] ISC-7: Advanced users can inspect and edit raw config.
+- [ ] ISC-8: Users can enable or disable a configured server.
+- [ ] ISC-9: Users can connect or reconnect a configured server.
+- [ ] ISC-10: Users can remove a configured server from the plugin UI.
+- [ ] ISC-11: The plugin supports `stdio`-based MCP servers.
+- [ ] ISC-12: The plugin supports `HTTP/SSE`-based MCP servers.
+- [ ] ISC-13: MCP configuration is global to the user's Sero install.
+- [ ] ISC-14: Agent-facing integration exposes exactly one MCP proxy tool.
+- [ ] ISC-15: Sero CLI can list configured MCP servers and current status.
+- [ ] ISC-16: Sero CLI can trigger basic server control actions.
+- [ ] ISC-17: Authentication flows are completed from the plugin UI.
+- [ ] ISC-18: Each server detail view shows auth state and connection state.
+- [ ] ISC-19: Each server detail view exposes that server's MCP UIs/resources.
+- [ ] ISC-20: Users can open MCP-provided UIs/resources inside the plugin.
+
+### Edge Cases
+- [ ] ISC-21: Healthy-state screens default to friendly, non-technical language.
+- [ ] ISC-22: Failure states expose copyable technical details on demand.
+- [ ] ISC-23: Failure states include an explicit **Ask Sero to help** action.
+- [ ] ISC-24: Auth failures keep users in-plugin and show recovery guidance.
+- [ ] ISC-25: Offline servers show actionable recovery steps in the plugin.
+- [ ] ISC-26: Unrenderable MCP resources stay in-plugin and show recovery guidance.
+- [ ] ISC-27: Current server status is visible without detailed session-history views.
+- [ ] ISC-28: A README covers setup, auth, CLI control, and troubleshooting.
+
+### Anti-Criteria
+- [ ] ISC-A-1: No direct per-server or per-tool exposure ships in v1.
+- [ ] ISC-A-2: No Pi config, token, or state import ships in v1.
+- [ ] ISC-A-3: No external browser or popup is required for core MCP UI flows.
+- [ ] ISC-A-4: No command-first workflow is required for core management tasks.
+- [ ] ISC-A-5: No rich session-history explorer is required in v1.

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
@@ -179,4 +179,34 @@ describe('plugin CLI bridging', () => {
     expect(getCliRegistry().get('plugin_selective_keep')).toBeTruthy();
     expect(getCliRegistry().get('plugin_selective_skip')).toBeFalsy();
   });
+
+  it('keeps mcp_manager private when the MCP plugin bridges only mcp', async () => {
+    const pluginDir = path.join(tmpDir, 'plugin-mcp');
+    const extensionPath = path.join(pluginDir, 'extension', 'index.js');
+    await mkdir(path.dirname(extensionPath), { recursive: true });
+    await writeFile(extensionPath, 'export default {}\n', 'utf8');
+    await writeFile(
+      path.join(pluginDir, 'package.json'),
+      JSON.stringify({
+        name: '@sero-ai/plugin-mcp',
+        version: '1.0.0',
+        sero: {
+          plugin: {
+            category: 'developer-tools',
+            tags: ['mcp'],
+            bridgeTools: ['mcp'],
+          },
+        },
+      }, null, 2),
+      'utf8',
+    );
+
+    const base = createLoadExtensionsResult(extensionPath, ['mcp', 'mcp_manager']);
+    bridgeExtensionTools(base);
+
+    expect(base.extensions[0]?.tools.has('mcp')).toBe(false);
+    expect(base.extensions[0]?.tools.has('mcp_manager')).toBe(true);
+    expect(getCliRegistry().get('mcp')).toBeTruthy();
+    expect(getCliRegistry().get('mcp_manager')).toBeFalsy();
+  });
 });

--- a/apps/desktop/electron/__tests__/platform/csp.test.ts
+++ b/apps/desktop/electron/__tests__/platform/csp.test.ts
@@ -13,12 +13,17 @@ vi.mock('electron', () => ({
 import { buildContentSecurityPolicy } from '@electron/platform/security/csp';
 
 describe('content security policy', () => {
-  it('keeps production script and frame sources tight', () => {
+  it('keeps production script sources tight while allowing only loopback viewer URLs', () => {
     const csp = buildContentSecurityPolicy({ isDevelopment: false });
 
     expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval' blob: https://sdk.scdn.co https://cdn.jsdelivr.net sero-ext:");
     expect(csp).not.toContain("script-src 'self' 'unsafe-inline'");
-    expect(csp).toContain("frame-src 'self' blob: sero-ext:");
+    expect(csp).toContain("frame-src 'self' blob: http://localhost:* http://127.0.0.1:* http://[::1]:* sero-ext:");
+    expect(csp).toContain("child-src 'self' blob: http://localhost:* http://127.0.0.1:* http://[::1]:* sero-ext:");
+    expect(csp).toContain("connect-src 'self' blob:");
+    expect(csp).toContain('http://localhost:*');
+    expect(csp).toContain('http://127.0.0.1:*');
+    expect(csp).toContain('http://[::1]:*');
     expect(csp).not.toContain('frame-src http:');
     expect(csp).not.toContain('frame-src https:');
     expect(csp).not.toContain('child-src http:');

--- a/apps/desktop/electron/__tests__/platform/window-security.test.ts
+++ b/apps/desktop/electron/__tests__/platform/window-security.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
+
+import {
+  hardenMainWindowWebviewPreferences,
+  isAllowedMainWindowWebview,
+  MCP_AUTH_WEBVIEW_PARTITION,
+} from '@electron/platform/security/window-security';
+
+describe('window security webview policy', () => {
+  it('allows only the MCP auth partition and trusted auth origins', () => {
+    expect(isAllowedMainWindowWebview('https://github.com/login/device', MCP_AUTH_WEBVIEW_PARTITION)).toBe(true);
+    expect(isAllowedMainWindowWebview('http://127.0.0.1:3845/callback', MCP_AUTH_WEBVIEW_PARTITION)).toBe(true);
+    expect(isAllowedMainWindowWebview('https://evil.example.com', MCP_AUTH_WEBVIEW_PARTITION)).toBe(false);
+    expect(isAllowedMainWindowWebview('https://github.com/login/device', 'persist:other')).toBe(false);
+  });
+
+  it('strips dangerous webview preferences and forces sandboxed defaults', () => {
+    const webPreferences = {
+      preload: '/tmp/attack.js',
+      preloadURL: '/tmp/attack.js',
+      nodeIntegration: true,
+      nodeIntegrationInSubFrames: true,
+      contextIsolation: false,
+      allowRunningInsecureContent: true,
+      webSecurity: false,
+      sandbox: false,
+      javascript: false,
+      partition: 'persist:other',
+    } as unknown as Parameters<typeof hardenMainWindowWebviewPreferences>[0];
+
+    hardenMainWindowWebviewPreferences(webPreferences);
+
+    expect((webPreferences as Record<string, unknown>).preload).toBeUndefined();
+    expect((webPreferences as Record<string, unknown>).preloadURL).toBeUndefined();
+    expect((webPreferences as Record<string, unknown>).nodeIntegration).toBe(false);
+    expect((webPreferences as Record<string, unknown>).nodeIntegrationInSubFrames).toBe(false);
+    expect((webPreferences as Record<string, unknown>).contextIsolation).toBe(true);
+    expect((webPreferences as Record<string, unknown>).allowRunningInsecureContent).toBe(false);
+    expect((webPreferences as Record<string, unknown>).webSecurity).toBe(true);
+    expect((webPreferences as Record<string, unknown>).sandbox).toBe(true);
+    expect((webPreferences as Record<string, unknown>).javascript).toBe(true);
+    expect((webPreferences as Record<string, unknown>).partition).toBe(MCP_AUTH_WEBVIEW_PARTITION);
+  });
+});

--- a/apps/desktop/electron/__tests__/platform/window-security.test.ts
+++ b/apps/desktop/electron/__tests__/platform/window-security.test.ts
@@ -13,10 +13,11 @@ import {
 } from '@electron/platform/security/window-security';
 
 describe('window security webview policy', () => {
-  it('allows only the MCP auth partition and trusted auth origins', () => {
+  it('allows only the MCP auth partition plus https and loopback auth sources', () => {
     expect(isAllowedMainWindowWebview('https://github.com/login/device', MCP_AUTH_WEBVIEW_PARTITION)).toBe(true);
+    expect(isAllowedMainWindowWebview('https://oauth.example.com/authorize', MCP_AUTH_WEBVIEW_PARTITION)).toBe(true);
     expect(isAllowedMainWindowWebview('http://127.0.0.1:3845/callback', MCP_AUTH_WEBVIEW_PARTITION)).toBe(true);
-    expect(isAllowedMainWindowWebview('https://evil.example.com', MCP_AUTH_WEBVIEW_PARTITION)).toBe(false);
+    expect(isAllowedMainWindowWebview('http://evil.example.com', MCP_AUTH_WEBVIEW_PARTITION)).toBe(false);
     expect(isAllowedMainWindowWebview('https://github.com/login/device', 'persist:other')).toBe(false);
   });
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -8,7 +8,7 @@ import {
 } from './platform/env';
 loadSeroEnv();
 
-import { app, components, BrowserWindow, session, shell } from 'electron';
+import { app, components, BrowserWindow, session } from 'electron';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import path from 'path';
 import type { SettingsPackageSource } from '../src/types/ipc';
@@ -44,6 +44,7 @@ import {
 } from './shared/infra/shared-infra';
 import { startGateway, stopGateway } from './ipc/gateway';
 import { setupContentSecurityPolicy } from './platform/security/csp';
+import { setupMainWindowSecurity } from './platform/security/window-security';
 import { discoverBuiltinPackagePaths, discoverBuiltinPluginPaths } from './platform/protocols/builtin-resources';
 import {
   ensureConfiguredModelFallbackChain,
@@ -157,6 +158,7 @@ function createWindow() {
       contextIsolation: true,
       nodeIntegration: false,
       plugins: true,
+      webviewTag: true,
     },
   });
 
@@ -175,52 +177,9 @@ function createWindow() {
     }
   });
 
-  // ── Security: navigation restrictions ──────────────────────────
-  // Block navigation to untrusted origins. Only allow the dev server
-  // (in development) and the production renderer HTML (file: protocol).
-  // All other navigation attempts (e.g., from XSS or malicious content)
-  // are blocked.
-  const isDev = process.env.NODE_ENV === 'development';
-  mainWindow.webContents.on('will-navigate', (event, navigationUrl) => {
-    try {
-      const parsed = new URL(navigationUrl);
-      // Production: only file: protocol (local renderer HTML) is allowed
-      if (parsed.protocol === 'file:') return;
-      // Development: allow the Vite dev server origin
-      if (isDev && parsed.origin === 'http://localhost:5173') return;
-      console.warn(`[security] Blocked navigation to untrusted origin: ${navigationUrl}`);
-      event.preventDefault();
-    } catch {
-      event.preventDefault();
-    }
+  setupMainWindowSecurity(mainWindow, {
+    isDevelopment: process.env.NODE_ENV === 'development',
   });
-
-  // Open external links (target="_blank", href to external domains) in the
-  // system browser instead of a new Electron window. This ensures the user's
-  // existing browser session (GitHub login, etc.) is used.
-  // Also blocks file:// and other dangerous protocols from opening new windows.
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    if (url.startsWith('http://') || url.startsWith('https://')) {
-      void shell.openExternal(url);
-    }
-    // Always deny new windows — external links open in system browser
-    return { action: 'deny' };
-  });
-
-  // ── Security: deny unnecessary permissions ──────────────────
-  // Block permission requests for capabilities Sero doesn't need.
-  // Allow media (Spotify) and clipboard-sanitized-write for in-app copy actions.
-  const allowedPermissions = new Set(['media', 'clipboard-sanitized-write']);
-  mainWindow.webContents.session.setPermissionRequestHandler(
-    (_webContents, permission, callback) => {
-      if (allowedPermissions.has(permission)) {
-        callback(true);
-      } else {
-        console.warn(`[security] Denied permission request: ${permission}`);
-        callback(false);
-      }
-    },
-  );
 
   // Give the file watcher manager access to the window for push events
   fileWatcherManager.setWindow(mainWindow);

--- a/apps/desktop/electron/platform/security/csp.ts
+++ b/apps/desktop/electron/platform/security/csp.ts
@@ -9,7 +9,8 @@
  * Sources that must be allowed:
  * - Dev: localhost (Vite dev server + module federation remotes), ws: (HMR),
  *   and sero-ext: for selectively skipped apps loaded from built bundles
- * - Prod: sero-ext: (custom protocol for federated extension assets)
+ * - Prod: sero-ext: (custom protocol for federated extension assets) plus
+ *   tightly scoped loopback HTTP sources for embedded MCP viewers/auth rails
  * - Both: https://sdk.scdn.co (Spotify Web Playback SDK script),
  *   https://*.scdn.co + https://*.spotify.com (Spotify API/CDN),
  *   blob: (Vite/MF dynamic imports), data: (inline images),
@@ -23,6 +24,12 @@ interface BuildContentSecurityPolicyOptions {
 }
 
 /** Build the CSP directive string for the current environment. */
+const LOOPBACK_HTTP_SRC = [
+  'http://localhost:*',
+  'http://127.0.0.1:*',
+  'http://[::1]:*',
+];
+
 export function buildContentSecurityPolicy(
   options: BuildContentSecurityPolicyOptions = {},
 ): string {
@@ -30,6 +37,7 @@ export function buildContentSecurityPolicy(
   const extensionSrc = ['sero-ext:'];
   const devHttpSrc = isDevelopment ? ['http://localhost:*'] : [];
   const devConnectSrc = isDevelopment ? ['http://localhost:*', 'ws://localhost:*'] : [];
+  const prodLoopbackSrc = isDevelopment ? [] : LOOPBACK_HTTP_SRC;
 
   // -- script-src --
   // Dev keeps 'unsafe-inline' for Vite's injected dev runtime.
@@ -60,6 +68,7 @@ export function buildContentSecurityPolicy(
     'https://*.scdn.co',       // Spotify CDN
     'https://api.spotify.com',
     ...devConnectSrc,          // Vite HMR + dev servers
+    ...prodLoopbackSrc,        // In-plugin loopback viewers/auth rails in production
     ...extensionSrc,           // Federated extension manifests/assets
   ];
 
@@ -105,7 +114,7 @@ export function buildContentSecurityPolicy(
   const frameSrc = [
     "'self'",
     'blob:',
-    ...(isDevelopment ? ['http:', 'https:'] : []),
+    ...(isDevelopment ? ['http:', 'https:'] : prodLoopbackSrc),
     ...extensionSrc,
   ];
 

--- a/apps/desktop/electron/platform/security/window-security.ts
+++ b/apps/desktop/electron/platform/security/window-security.ts
@@ -1,10 +1,19 @@
-import { BrowserWindow, shell } from 'electron';
+import { shell, type BrowserWindow, type WebPreferences } from 'electron';
 
 interface SetupMainWindowSecurityOptions {
   isDevelopment: boolean;
 }
 
 const ALLOWED_PERMISSIONS = new Set(['media', 'clipboard-sanitized-write']);
+const ALLOWED_AUTH_WEBVIEW_ORIGINS = new Set([
+  'https://github.com',
+  'https://login.microsoftonline.com',
+  'https://login.live.com',
+  'https://accounts.google.com',
+  'https://auth.openai.com',
+]);
+
+export const MCP_AUTH_WEBVIEW_PARTITION = 'persist:sero-mcp-auth';
 
 export function setupMainWindowSecurity(
   mainWindow: BrowserWindow,
@@ -24,6 +33,20 @@ export function setupMainWindowSecurity(
     }
   });
 
+  mainWindow.webContents.on('will-attach-webview', (event, webPreferences, params) => {
+    hardenMainWindowWebviewPreferences(webPreferences);
+
+    const src = typeof params.src === 'string' ? params.src : '';
+    const partition = typeof params.partition === 'string' ? params.partition : '';
+    if (!isAllowedMainWindowWebview(src, partition)) {
+      console.warn(`[security] Blocked webview attachment for ${src || '<missing src>'}`);
+      event.preventDefault();
+      return;
+    }
+
+    webPreferences.partition = MCP_AUTH_WEBVIEW_PARTITION;
+  });
+
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     if (url.startsWith('http://') || url.startsWith('https://')) {
       void shell.openExternal(url);
@@ -41,4 +64,46 @@ export function setupMainWindowSecurity(
       callback(false);
     },
   );
+}
+
+export function hardenMainWindowWebviewPreferences(webPreferences: WebPreferences): void {
+  const mutablePreferences = webPreferences as WebPreferences & {
+    preload?: string;
+    preloadURL?: string;
+  };
+
+  delete mutablePreferences.preload;
+  delete mutablePreferences.preloadURL;
+  mutablePreferences.nodeIntegration = false;
+  mutablePreferences.nodeIntegrationInSubFrames = false;
+  mutablePreferences.contextIsolation = true;
+  mutablePreferences.allowRunningInsecureContent = false;
+  mutablePreferences.webSecurity = true;
+  mutablePreferences.sandbox = true;
+  mutablePreferences.javascript = true;
+  mutablePreferences.partition = MCP_AUTH_WEBVIEW_PARTITION;
+}
+
+export function isAllowedMainWindowWebview(src: string, partition: string): boolean {
+  if (partition !== MCP_AUTH_WEBVIEW_PARTITION) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(src);
+    if (isLoopbackCallbackUrl(parsed)) {
+      return true;
+    }
+    return parsed.protocol === 'https:' && ALLOWED_AUTH_WEBVIEW_ORIGINS.has(parsed.origin);
+  } catch {
+    return false;
+  }
+}
+
+function isLoopbackCallbackUrl(url: URL): boolean {
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    return false;
+  }
+
+  return url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]' || url.hostname === '::1';
 }

--- a/apps/desktop/electron/platform/security/window-security.ts
+++ b/apps/desktop/electron/platform/security/window-security.ts
@@ -1,0 +1,44 @@
+import { BrowserWindow, shell } from 'electron';
+
+interface SetupMainWindowSecurityOptions {
+  isDevelopment: boolean;
+}
+
+const ALLOWED_PERMISSIONS = new Set(['media', 'clipboard-sanitized-write']);
+
+export function setupMainWindowSecurity(
+  mainWindow: BrowserWindow,
+  options: SetupMainWindowSecurityOptions,
+): void {
+  const { isDevelopment } = options;
+
+  mainWindow.webContents.on('will-navigate', (event, navigationUrl) => {
+    try {
+      const parsed = new URL(navigationUrl);
+      if (parsed.protocol === 'file:') return;
+      if (isDevelopment && parsed.origin === 'http://localhost:5173') return;
+      console.warn(`[security] Blocked navigation to untrusted origin: ${navigationUrl}`);
+      event.preventDefault();
+    } catch {
+      event.preventDefault();
+    }
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('http://') || url.startsWith('https://')) {
+      void shell.openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+
+  mainWindow.webContents.session.setPermissionRequestHandler(
+    (_webContents, permission, callback) => {
+      if (ALLOWED_PERMISSIONS.has(permission)) {
+        callback(true);
+        return;
+      }
+      console.warn(`[security] Denied permission request: ${permission}`);
+      callback(false);
+    },
+  );
+}

--- a/apps/desktop/electron/platform/security/window-security.ts
+++ b/apps/desktop/electron/platform/security/window-security.ts
@@ -30,6 +30,9 @@ export function setupMainWindowSecurity(
     hardenMainWindowWebviewPreferences(webPreferences);
 
     const src = typeof params.src === 'string' ? params.src : '';
+    // The renderer must opt into the dedicated MCP auth partition explicitly.
+    // Once accepted, we still force the hardened partition here so the final
+    // webview prefs cannot be swapped by renderer-controlled attributes.
     const partition = typeof params.partition === 'string' ? params.partition : '';
     if (!isAllowedMainWindowWebview(src, partition)) {
       console.warn(`[security] Blocked webview attachment for ${src || '<missing src>'}`);

--- a/apps/desktop/electron/platform/security/window-security.ts
+++ b/apps/desktop/electron/platform/security/window-security.ts
@@ -5,13 +5,6 @@ interface SetupMainWindowSecurityOptions {
 }
 
 const ALLOWED_PERMISSIONS = new Set(['media', 'clipboard-sanitized-write']);
-const ALLOWED_AUTH_WEBVIEW_ORIGINS = new Set([
-  'https://github.com',
-  'https://login.microsoftonline.com',
-  'https://login.live.com',
-  'https://accounts.google.com',
-  'https://auth.openai.com',
-]);
 
 export const MCP_AUTH_WEBVIEW_PARTITION = 'persist:sero-mcp-auth';
 
@@ -94,7 +87,7 @@ export function isAllowedMainWindowWebview(src: string, partition: string): bool
     if (isLoopbackCallbackUrl(parsed)) {
       return true;
     }
-    return parsed.protocol === 'https:' && ALLOWED_AUTH_WEBVIEW_ORIGINS.has(parsed.origin);
+    return parsed.protocol === 'https:';
   } catch {
     return false;
   }

--- a/plugins/sero-mcp-plugin/README.md
+++ b/plugins/sero-mcp-plugin/README.md
@@ -25,6 +25,7 @@ The MCP app currently supports:
 - embedded OAuth browser flows
 - resource preview
 - basic UI-tool launching by opening the advertised UI resource
+- basic MCP tool runner in the server detail view
 - auth clearing / re-auth / cancel-auth controls
 
 ### Bridged tool

--- a/plugins/sero-mcp-plugin/README.md
+++ b/plugins/sero-mcp-plugin/README.md
@@ -50,6 +50,7 @@ sero mcp list
 sero mcp search <query>
 sero mcp tools <server>
 sero mcp resources <server>
+sero mcp read <server> <resourceUri>
 sero mcp describe <server> <tool>
 sero mcp call <server> <tool> [jsonArgs]
 sero mcp connect <server>
@@ -63,6 +64,7 @@ Examples:
 ```bash
 sero mcp search github
 sero mcp tools github
+sero mcp read github file://README.md
 sero mcp describe github search_docs
 sero mcp call github search_docs '{"query":"oauth"}'
 ```

--- a/plugins/sero-mcp-plugin/README.md
+++ b/plugins/sero-mcp-plugin/README.md
@@ -9,6 +9,7 @@ This plugin adapts the `pi-mcp-adapter` backend ideas into a **Sero-native, UI-f
 - inspect connection/auth/metadata state
 - preview embedded MCP resources inside the plugin
 - launch basic UI-capable MCP tool resources in the dedicated viewer pane
+- search cached MCP tools/resources across servers from a top-level workbench
 - use a single bridged `mcp` proxy tool from Sero chat or the CLI
 
 ## Current v1 surface
@@ -24,6 +25,7 @@ The MCP app currently supports:
 - diagnostics
 - embedded OAuth browser flows
 - dedicated viewer/auth pane for resources, tool UIs, and OAuth flows
+- top-level MCP search workbench
 - resource preview
 - basic UI-tool launching by opening the advertised UI resource
 - basic MCP tool runner in the server detail view

--- a/plugins/sero-mcp-plugin/README.md
+++ b/plugins/sero-mcp-plugin/README.md
@@ -1,0 +1,142 @@
+# `@sero-ai/plugin-mcp`
+
+Built-in first-party MCP control center for Sero.
+
+This plugin adapts the `pi-mcp-adapter` backend ideas into a **Sero-native, UI-first** workflow:
+
+- configure MCP servers from inside Sero
+- authenticate OAuth-backed servers in-app
+- inspect connection/auth/metadata state
+- preview embedded MCP resources inside the plugin
+- launch basic UI-capable MCP tool resources in the embedded viewer
+- use a single bridged `mcp` proxy tool from Sero chat or the CLI
+
+## Current v1 surface
+
+### UI
+
+The MCP app currently supports:
+
+- server CRUD
+- enable / disable
+- connect / reconnect
+- raw config editing
+- diagnostics
+- embedded OAuth browser flows
+- resource preview
+- basic UI-tool launching by opening the advertised UI resource
+- auth clearing / re-auth / cancel-auth controls
+
+### Bridged tool
+
+Exactly one bridged tool is exposed:
+
+- `mcp`
+
+The plugin also uses one UI-only management tool internally:
+
+- `mcp_manager`
+
+`mcp_manager` is **not** part of the agent-facing MCP proxy surface.
+
+## CLI
+
+The built-in CLI bridge currently supports:
+
+```bash
+sero mcp status
+sero mcp list
+sero mcp search <query>
+sero mcp tools <server>
+sero mcp resources <server>
+sero mcp describe <server> <tool>
+sero mcp call <server> <tool> [jsonArgs]
+sero mcp connect <server>
+sero mcp reconnect <server>
+sero mcp enable <server>
+sero mcp disable <server>
+```
+
+Examples:
+
+```bash
+sero mcp search github
+sero mcp tools github
+sero mcp describe github search_docs
+sero mcp call github search_docs '{"query":"oauth"}'
+```
+
+## OAuth behavior
+
+OAuth-backed HTTP MCP servers authenticate entirely inside Sero.
+
+Current behavior:
+
+- start auth from the MCP app
+- complete the provider redirect inside the embedded auth browser
+- persist OAuth client info / tokens under the Sero agent profile
+- if a live MCP call or resource read becomes unauthorized, the plugin:
+  - closes the stale connection
+  - marks the server as `needs-auth`
+  - guides the user back to the MCP app auth flow
+
+## Storage locations
+
+### App config / state / cache
+
+Stored under the Sero app home for the global `mcp` app.
+
+### OAuth credentials
+
+Stored under:
+
+```text
+$PI_CODING_AGENT_DIR/mcp-oauth/
+```
+
+This keeps auth material aligned with the active Sero agent profile.
+
+## Notes on UI-capable MCP tools
+
+Current v1 behavior is intentionally modest:
+
+- the plugin discovers tools that advertise `_meta.ui.resourceUri`
+- the server detail view can launch that advertised UI resource in the embedded viewer
+- the bridged `mcp` tool can describe and call those tools, but it does **not** yet host a full AppBridge-backed interactive MCP app session
+
+That fuller MCP UI hosting slice is still in progress.
+
+## Troubleshooting
+
+### A server says it needs auth
+
+Open the MCP app in Sero and authenticate the server there.
+
+### A previously working OAuth server stopped working
+
+Use one of:
+
+- **Re-authenticate**
+- **Clear saved auth**
+- reconnect the server after auth completes
+
+The runtime now automatically drops expired live auth back to `needs-auth` when a call or resource read is rejected.
+
+### Tools/resources do not appear
+
+Connect or reconnect the server so metadata can be refreshed and cached.
+
+### A resource or tool UI does not render
+
+Use the embedded **Ask Sero to help** recovery actions from the MCP app.
+
+## Validation
+
+Common local validation commands:
+
+```bash
+pnpm --filter @sero-ai/plugin-mcp typecheck
+pnpm --filter @sero-ai/plugin-mcp test
+pnpm --filter @sero-ai/plugin-mcp build
+pnpm typecheck
+```

--- a/plugins/sero-mcp-plugin/README.md
+++ b/plugins/sero-mcp-plugin/README.md
@@ -8,7 +8,7 @@ This plugin adapts the `pi-mcp-adapter` backend ideas into a **Sero-native, UI-f
 - authenticate OAuth-backed servers in-app
 - inspect connection/auth/metadata state
 - preview embedded MCP resources inside the plugin
-- launch basic UI-capable MCP tool resources in the embedded viewer
+- launch basic UI-capable MCP tool resources in the dedicated viewer pane
 - use a single bridged `mcp` proxy tool from Sero chat or the CLI
 
 ## Current v1 surface
@@ -23,6 +23,7 @@ The MCP app currently supports:
 - raw config editing
 - diagnostics
 - embedded OAuth browser flows
+- dedicated viewer/auth pane for resources, tool UIs, and OAuth flows
 - resource preview
 - basic UI-tool launching by opening the advertised UI resource
 - basic MCP tool runner in the server detail view
@@ -76,7 +77,7 @@ OAuth-backed HTTP MCP servers authenticate entirely inside Sero.
 Current behavior:
 
 - start auth from the MCP app
-- complete the provider redirect inside the embedded auth browser
+- complete the provider redirect inside the dedicated embedded auth browser pane
 - persist OAuth client info / tokens under the Sero agent profile
 - if a live MCP call or resource read becomes unauthorized, the plugin:
   - closes the stale connection
@@ -104,7 +105,7 @@ This keeps auth material aligned with the active Sero agent profile.
 Current v1 behavior is intentionally modest:
 
 - the plugin discovers tools that advertise `_meta.ui.resourceUri`
-- the server detail view can launch that advertised UI resource in the embedded viewer
+- the server detail view can launch that advertised UI resource in the dedicated viewer pane
 - the bridged `mcp` tool can describe and call those tools, but it does **not** yet host a full AppBridge-backed interactive MCP app session
 
 That fuller MCP UI hosting slice is still in progress.

--- a/plugins/sero-mcp-plugin/README.md
+++ b/plugins/sero-mcp-plugin/README.md
@@ -2,46 +2,148 @@
 
 Built-in first-party MCP control center for Sero.
 
-This plugin adapts the `pi-mcp-adapter` backend ideas into a **Sero-native, UI-first** workflow:
+This plugin adapts the `pi-mcp-adapter` backend ideas into a **Sero-native, UI-first** workflow for configuring, authenticating, inspecting, and using MCP servers from inside the desktop app.
 
-- configure MCP servers from inside Sero
-- authenticate OAuth-backed servers in-app
-- inspect connection/auth/metadata state
-- preview embedded MCP resources inside the plugin
-- launch interactive UI-capable MCP tool resources in the dedicated viewer pane
-- search cached MCP tools/resources across servers from a top-level workbench
-- use a single bridged `mcp` proxy tool from Sero chat or the CLI
+## What v1 ships
 
-## Current v1 surface
+- first-run setup wizard
+- stdio and HTTP/SSE server setup
+- server CRUD, enable/disable, connect/reconnect
+- lazy/eager/keep-alive lifecycle handling through the singleton extension runtime
+- metadata caching plus cache-backed snapshot state
+- top-level MCP-only search workbench across cached tools/resources
+- embedded OAuth auth flow inside Sero
+- inline previews for normal MCP resources
+- interactive loopback viewer sessions for `ui://` resources and UI-capable tools
+- server detail tool runner for calling discovered tools
+- exactly one bridged agent/CLI tool: `mcp`
+- one UI-only management tool: `mcp_manager`
 
-### UI
+## Product shape
 
-The MCP app currently supports:
+This plugin keeps the agent-facing MCP surface intentionally small.
 
-- server CRUD
-- enable / disable
-- connect / reconnect
-- raw config editing
-- diagnostics
-- embedded OAuth browser flows
-- dedicated viewer/auth pane for resources, tool UIs, and OAuth flows
-- top-level MCP search workbench
-- resource preview
-- interactive MCP UI hosting for advertised `ui://` resources and UI-capable tools
-- basic MCP tool runner in the server detail view
-- auth clearing / re-auth / cancel-auth controls
-
-### Bridged tool
+### Bridged tool surface
 
 Exactly one bridged tool is exposed:
 
 - `mcp`
 
-The plugin also uses one UI-only management tool internally:
+### UI-only management surface
+
+The app uses one internal management tool:
 
 - `mcp_manager`
 
-`mcp_manager` is **not** part of the agent-facing MCP proxy surface.
+`mcp_manager` is **not** bridged to the agent or CLI. It exists so the MCP app can handle config, auth, diagnostics, and viewer actions without exploding the tool surface.
+
+### Explicit v1 guardrails
+
+- no direct per-server tool registration
+- no direct per-tool exposure
+- no popup-first auth or viewer workflow
+- no TUI `/mcp` panel port
+
+## Quick start in Sero
+
+1. Open the **MCP** app from the Sero sidebar.
+2. On first launch, use the setup wizard to create your first server.
+3. Choose either a **stdio** server or an **HTTP/SSE** server.
+4. Save the server, then use **Connect** or **Reconnect**.
+5. If the server requires OAuth, start auth from the MCP app and complete it in the embedded auth/viewer pane.
+6. Inspect tools/resources from the server detail view, run tools from the tool runner, or use the search workbench to jump across cached MCP inventory.
+
+The app also includes diagnostics and **Ask Sero to help** recovery actions when a server, auth flow, or resource viewer fails.
+
+## Server setup
+
+### Stdio servers
+
+Use stdio mode for local MCP servers launched by a command such as `npx`, `uvx`, `python`, `docker`, or a local executable.
+
+Typical fields:
+
+- command
+- args
+- optional env
+- optional cwd
+- lifecycle mode
+
+Example raw config:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "enabled": true,
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "lifecycle": "lazy"
+    }
+  }
+}
+```
+
+### HTTP / SSE servers
+
+Use HTTP mode for remote MCP servers that expose an HTTP/SSE endpoint.
+
+Typical fields:
+
+- url
+- optional headers
+- auth mode
+- lifecycle mode
+
+Example raw config:
+
+```json
+{
+  "mcpServers": {
+    "remote-demo": {
+      "enabled": true,
+      "transport": "http",
+      "url": "https://example.com/mcp",
+      "auth": "oauth",
+      "lifecycle": "keep-alive"
+    }
+  }
+}
+```
+
+### Raw config editing
+
+The MCP app also exposes a raw config editor for advanced edits. Validation errors are surfaced in-app before a broken config is accepted.
+
+## UI behavior
+
+### Resources
+
+- standard resources open as inline previews when possible
+- text, JSON, HTML, and image content render directly in the MCP viewer pane
+- binary/unsupported content falls back to summarized preview states
+
+### Interactive MCP UIs
+
+When a resource URI starts with `ui://`, or when a discovered tool advertises `_meta.ui.resourceUri`, the plugin launches an **interactive loopback viewer session** inside the dedicated viewer pane.
+
+That viewer host:
+
+- runs entirely inside Sero
+- uses ephemeral localhost session URLs
+- speaks AppBridge-style JSON-RPC to the embedded MCP UI
+- keeps viewer session identifiers and URLs out of persisted app state
+
+### Tool runner
+
+The server detail view includes a basic MCP tool runner that can:
+
+- list cached tools
+- inspect tool descriptions and schemas
+- submit structured JSON arguments
+- render results
+- open advertised MCP tool UIs when available
 
 ## CLI
 
@@ -67,6 +169,7 @@ Examples:
 ```bash
 sero mcp search github
 sero mcp tools github
+sero mcp resources github
 sero mcp read github file://README.md
 sero mcp describe github search_docs
 sero mcp call github search_docs '{"query":"oauth"}'
@@ -78,40 +181,50 @@ OAuth-backed HTTP MCP servers authenticate entirely inside Sero.
 
 Current behavior:
 
-- start auth from the MCP app
-- complete the provider redirect inside the dedicated embedded auth browser pane
-- persist OAuth client info / tokens under the Sero agent profile
-- if a live MCP call or resource read becomes unauthorized, the plugin:
+- auth is started from the MCP app
+- provider sign-in opens in the dedicated auth/viewer pane
+- loopback callback URLs are intercepted in-app and completed without leaving Sero
+- tokens, client info, and flow state are stored under the active Sero agent profile
+- if a live tool call or resource read becomes unauthorized, the runtime:
   - closes the stale connection
   - marks the server as `needs-auth`
-  - guides the user back to the MCP app auth flow
+  - guides the user back to the in-app auth flow
 
-## Storage locations
+## Storage
 
-### App config / state / cache
+### App config, state, and metadata cache
 
-Stored under the Sero app home for the global `mcp` app.
+When `SERO_HOME` is available, MCP files live under:
+
+```text
+$SERO_HOME/apps/mcp/
+  config.json
+  state.json
+  metadata-cache.json
+```
 
 ### OAuth credentials
 
-Stored under:
+OAuth material lives under the active agent profile:
 
 ```text
 $PI_CODING_AGENT_DIR/mcp-oauth/
 ```
 
-This keeps auth material aligned with the active Sero agent profile.
+Per-server auth data is split into files such as:
 
-## Notes on UI-capable MCP tools
+- `tokens.json`
+- `client.json`
+- `flow.json`
 
-Current v1 behavior is now more capable:
+### Persistence rules
 
-- the plugin discovers tools that advertise `_meta.ui.resourceUri`
-- the server detail view can launch those advertised UI resources inside a loopback viewer session in the dedicated pane
-- `ui://` resources also open through that same in-plugin interactive host
-- the bridged `mcp` tool still remains the only agent-facing surface; interactive UI hosting stays entirely behind the UI-only `mcp_manager` tool
+The following stay **ephemeral** and are not persisted in app state:
 
-The current host focuses on in-plugin AppBridge-style tool/resource access and ephemeral session URLs. It is intentionally not a browser-popup workflow.
+- viewer session IDs
+- viewer URLs
+- auth callback URLs
+- transient auth/viewer pane state
 
 ## Troubleshooting
 
@@ -127,23 +240,28 @@ Use one of:
 - **Clear saved auth**
 - reconnect the server after auth completes
 
-The runtime now automatically drops expired live auth back to `needs-auth` when a call or resource read is rejected.
+The runtime automatically drops expired live auth back to `needs-auth` when a call or resource read is rejected.
 
-### Tools/resources do not appear
+### Tools or resources do not appear
 
 Connect or reconnect the server so metadata can be refreshed and cached.
 
-### A resource or tool UI does not render
+### A resource preview or tool UI does not render
 
-Use the embedded **Ask Sero to help** recovery actions from the MCP app. Interactive MCP UIs now run through an ephemeral localhost viewer session, so clearing the pane and reopening the UI is also a useful first recovery step.
+Use the embedded **Ask Sero to help** recovery actions from the MCP app. For interactive MCP UIs, closing the viewer pane session and reopening the resource/tool UI is also a useful first recovery step.
+
+### I only want one MCP tool exposed to chat/CLI
+
+That is the intended v1 design. The plugin exposes only `mcp` through the bridge. Config/auth/viewer actions stay behind `mcp_manager` inside the app.
 
 ## Validation
 
-Common local validation commands:
+Recommended local validation commands:
 
 ```bash
 pnpm --filter @sero-ai/plugin-mcp typecheck
 pnpm --filter @sero-ai/plugin-mcp test
 pnpm --filter @sero-ai/plugin-mcp build
+pnpm --filter @sero/desktop exec vitest run electron/__tests__/features/plugins/plugin-cli-bridge.test.ts electron/__tests__/platform/window-security.test.ts electron/__tests__/platform/csp.test.ts
 pnpm typecheck
 ```

--- a/plugins/sero-mcp-plugin/README.md
+++ b/plugins/sero-mcp-plugin/README.md
@@ -8,7 +8,7 @@ This plugin adapts the `pi-mcp-adapter` backend ideas into a **Sero-native, UI-f
 - authenticate OAuth-backed servers in-app
 - inspect connection/auth/metadata state
 - preview embedded MCP resources inside the plugin
-- launch basic UI-capable MCP tool resources in the dedicated viewer pane
+- launch interactive UI-capable MCP tool resources in the dedicated viewer pane
 - search cached MCP tools/resources across servers from a top-level workbench
 - use a single bridged `mcp` proxy tool from Sero chat or the CLI
 
@@ -27,7 +27,7 @@ The MCP app currently supports:
 - dedicated viewer/auth pane for resources, tool UIs, and OAuth flows
 - top-level MCP search workbench
 - resource preview
-- basic UI-tool launching by opening the advertised UI resource
+- interactive MCP UI hosting for advertised `ui://` resources and UI-capable tools
 - basic MCP tool runner in the server detail view
 - auth clearing / re-auth / cancel-auth controls
 
@@ -104,13 +104,14 @@ This keeps auth material aligned with the active Sero agent profile.
 
 ## Notes on UI-capable MCP tools
 
-Current v1 behavior is intentionally modest:
+Current v1 behavior is now more capable:
 
 - the plugin discovers tools that advertise `_meta.ui.resourceUri`
-- the server detail view can launch that advertised UI resource in the dedicated viewer pane
-- the bridged `mcp` tool can describe and call those tools, but it does **not** yet host a full AppBridge-backed interactive MCP app session
+- the server detail view can launch those advertised UI resources inside a loopback viewer session in the dedicated pane
+- `ui://` resources also open through that same in-plugin interactive host
+- the bridged `mcp` tool still remains the only agent-facing surface; interactive UI hosting stays entirely behind the UI-only `mcp_manager` tool
 
-That fuller MCP UI hosting slice is still in progress.
+The current host focuses on in-plugin AppBridge-style tool/resource access and ephemeral session URLs. It is intentionally not a browser-popup workflow.
 
 ## Troubleshooting
 
@@ -134,7 +135,7 @@ Connect or reconnect the server so metadata can be refreshed and cached.
 
 ### A resource or tool UI does not render
 
-Use the embedded **Ask Sero to help** recovery actions from the MCP app.
+Use the embedded **Ask Sero to help** recovery actions from the MCP app. Interactive MCP UIs now run through an ephemeral localhost viewer session, so clearing the pane and reopening the UI is also a useful first recovery step.
 
 ## Validation
 

--- a/plugins/sero-mcp-plugin/extension/__tests__/oauth-coordinator.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/oauth-coordinator.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { parseOAuthCallbackUrl } from '../auth/oauth-coordinator';
+
+describe('parseOAuthCallbackUrl', () => {
+  it('extracts the authorization code and validates state', () => {
+    expect(
+      parseOAuthCallbackUrl('http://127.0.0.1:19876/mcp/oauth/callback?code=abc123&state=expected', 'expected'),
+    ).toEqual({ code: 'abc123' });
+  });
+
+  it('throws when the callback contains an OAuth error', () => {
+    expect(() => {
+      parseOAuthCallbackUrl('http://127.0.0.1:19876/mcp/oauth/callback?error=access_denied');
+    }).toThrow(/access_denied/);
+  });
+
+  it('throws when the state does not match', () => {
+    expect(() => {
+      parseOAuthCallbackUrl('http://127.0.0.1:19876/mcp/oauth/callback?code=abc123&state=wrong', 'expected');
+    }).toThrow(/did not match/);
+  });
+});

--- a/plugins/sero-mcp-plugin/extension/__tests__/paths.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/paths.test.ts
@@ -1,0 +1,60 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getMcpAppDir,
+  getMcpConfigPath,
+  getMcpMetadataCachePath,
+  getMcpOAuthDir,
+  getMcpStatePath,
+} from '../state/paths';
+
+const ORIGINAL_ENV = {
+  SERO_HOME: process.env.SERO_HOME,
+  PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+};
+
+afterEach(() => {
+  restoreEnv('SERO_HOME', ORIGINAL_ENV.SERO_HOME);
+  restoreEnv('PI_CODING_AGENT_DIR', ORIGINAL_ENV.PI_CODING_AGENT_DIR);
+});
+
+describe('MCP path helpers', () => {
+  it('prefers SERO_HOME for app config, cache, and state while keeping OAuth under the Pi agent dir', () => {
+    process.env.SERO_HOME = '/tmp/sero-home';
+    process.env.PI_CODING_AGENT_DIR = '/tmp/sero-agent';
+
+    expect(getMcpAppDir()).toBe(path.join('/tmp/sero-home', 'apps', 'mcp'));
+    expect(getMcpStatePath('/workspace/project')).toBe(path.join('/tmp/sero-home', 'apps', 'mcp', 'state.json'));
+    expect(getMcpConfigPath()).toBe(path.join('/tmp/sero-home', 'apps', 'mcp', 'config.json'));
+    expect(getMcpMetadataCachePath()).toBe(path.join('/tmp/sero-home', 'apps', 'mcp', 'metadata-cache.json'));
+    expect(getMcpOAuthDir()).toBe(path.join('/tmp/sero-agent', 'mcp-oauth'));
+  });
+
+  it('falls back to cwd-relative state and Pi agent files when SERO_HOME is absent', () => {
+    delete process.env.SERO_HOME;
+    process.env.PI_CODING_AGENT_DIR = '/tmp/pi-agent';
+
+    expect(getMcpAppDir()).toBe(path.join('/tmp/pi-agent', 'mcp'));
+    expect(getMcpStatePath('/workspace/project')).toBe(path.join('/workspace/project', '.sero', 'apps', 'mcp', 'state.json'));
+    expect(getMcpConfigPath()).toBe(path.join('/tmp/pi-agent', 'mcp.json'));
+    expect(getMcpMetadataCachePath()).toBe(path.join('/tmp/pi-agent', 'mcp-cache.json'));
+    expect(getMcpOAuthDir()).toBe(path.join('/tmp/pi-agent', 'mcp-oauth'));
+  });
+
+  it('expands home-relative env vars before building paths', () => {
+    process.env.SERO_HOME = '~/.sero-ui';
+    process.env.PI_CODING_AGENT_DIR = '~/.sero-ui/agent';
+
+    expect(getMcpAppDir()).toBe(path.join(os.homedir(), '.sero-ui', 'apps', 'mcp'));
+    expect(getMcpOAuthDir()).toBe(path.join(os.homedir(), '.sero-ui', 'agent', 'mcp-oauth'));
+  });
+});
+
+function restoreEnv(name: 'SERO_HOME' | 'PI_CODING_AGENT_DIR', value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/plugins/sero-mcp-plugin/extension/__tests__/proxy-tool.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/proxy-tool.test.ts
@@ -54,6 +54,19 @@ describe('registerMcpProxyTool CLI bridge', () => {
     expect(result).toEqual({ output: 'connected', exitCode: 0 });
   });
 
+  it('routes direct tool connect actions through the manager runtime action', async () => {
+    const { tool, runtime } = registerTool();
+    runtime.executeManagerAction.mockResolvedValue(createToolResult('connected'));
+
+    const result = await tool.execute('call-1', { action: 'connect', serverName: 'github' }, null, () => undefined, { cwd: '/tmp/ws' });
+
+    expect(runtime.executeManagerAction).toHaveBeenCalledWith('connect_server', {
+      cwd: '/tmp/ws',
+      serverName: 'github',
+    });
+    expect(result.content[0]?.text).toBe('connected');
+  });
+
   it('returns a usage error without touching the runtime when required args are missing', async () => {
     const { tool, runtime } = registerTool();
 
@@ -87,6 +100,13 @@ function registerTool() {
       cli: {
         execute: (args: string[], ctx: { cwd: string }) => Promise<{ output: string; exitCode: number }>;
       };
+      execute: (
+        toolCallId: string,
+        params: Record<string, unknown>,
+        signal: AbortSignal | null,
+        onUpdate: () => void,
+        ctx?: { cwd?: string },
+      ) => Promise<{ content: Array<{ type: 'text'; text: string }>; details: Record<string, unknown> }>;
     },
     runtime: {
       executeProxyAction,

--- a/plugins/sero-mcp-plugin/extension/__tests__/proxy-tool.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/proxy-tool.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { registerMcpProxyTool } from '../tools/proxy-tool';
+import { createToolResult } from '../tools/types';
+import type { McpRuntime } from '../runtime/mcp-runtime';
+
+describe('registerMcpProxyTool CLI bridge', () => {
+  it('defaults to proxy status when no subcommand is provided', async () => {
+    const { tool, runtime } = registerTool();
+    runtime.executeProxyAction.mockResolvedValue(createToolResult('status ok'));
+
+    const result = await tool.cli.execute([], { cwd: '/tmp/ws' });
+
+    expect(runtime.executeProxyAction).toHaveBeenCalledWith('status', {
+      cwd: '/tmp/ws',
+      query: undefined,
+      serverName: undefined,
+      toolName: undefined,
+      resourceUri: undefined,
+      toolArguments: undefined,
+      argumentsJson: undefined,
+    });
+    expect(result).toEqual({ output: 'status ok', exitCode: 0 });
+  });
+
+  it('routes resource reads through the proxy runtime action', async () => {
+    const { tool, runtime } = registerTool();
+    runtime.executeProxyAction.mockResolvedValue(createToolResult('resource ok'));
+
+    const result = await tool.cli.execute(['read', 'github', 'file://README.md'], { cwd: '/tmp/ws' });
+
+    expect(runtime.executeProxyAction).toHaveBeenCalledWith('read_resource', {
+      cwd: '/tmp/ws',
+      query: undefined,
+      serverName: 'github',
+      toolName: undefined,
+      resourceUri: 'file://README.md',
+      toolArguments: undefined,
+      argumentsJson: undefined,
+    });
+    expect(result).toEqual({ output: 'resource ok', exitCode: 0 });
+  });
+
+  it('routes connect through the manager runtime action', async () => {
+    const { tool, runtime } = registerTool();
+    runtime.executeManagerAction.mockResolvedValue(createToolResult('connected'));
+
+    const result = await tool.cli.execute(['connect', 'github'], { cwd: '/tmp/ws' });
+
+    expect(runtime.executeManagerAction).toHaveBeenCalledWith('connect_server', {
+      cwd: '/tmp/ws',
+      serverName: 'github',
+    });
+    expect(result).toEqual({ output: 'connected', exitCode: 0 });
+  });
+
+  it('returns a usage error without touching the runtime when required args are missing', async () => {
+    const { tool, runtime } = registerTool();
+
+    const result = await tool.cli.execute(['read', 'github'], { cwd: '/tmp/ws' });
+
+    expect(runtime.executeProxyAction).not.toHaveBeenCalled();
+    expect(runtime.executeManagerAction).not.toHaveBeenCalled();
+    expect(result).toEqual({ output: 'Usage: sero mcp read <server> <resourceUri>', exitCode: 1 });
+  });
+});
+
+function registerTool() {
+  const registerTool = vi.fn();
+  const pi = { registerTool } as unknown as ExtensionAPI;
+  const executeProxyAction = vi.fn();
+  const executeManagerAction = vi.fn();
+  const runtime = {
+    executeProxyAction,
+    executeManagerAction,
+  } as unknown as McpRuntime;
+
+  registerMcpProxyTool(pi, runtime);
+
+  const tool = registerTool.mock.calls[0]?.[0];
+  if (!tool?.cli) {
+    throw new Error('Failed to register MCP proxy tool CLI definition.');
+  }
+
+  return {
+    tool: tool as {
+      cli: {
+        execute: (args: string[], ctx: { cwd: string }) => Promise<{ output: string; exitCode: number }>;
+      };
+    },
+    runtime: {
+      executeProxyAction,
+      executeManagerAction,
+    },
+  };
+}

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-actions.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-actions.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { McpConfigDocument } from '../config/types';
+import type { McpServerManager } from '../manager/server-manager';
+import { connectServerAction } from '../runtime/runtime-actions';
+import type { SyncedRuntimeState } from '../runtime/runtime-types';
+
+const { readMetadataCacheMock, reconcileConnectionMock } = vi.hoisted(() => ({
+  readMetadataCacheMock: vi.fn(),
+  reconcileConnectionMock: vi.fn(),
+}));
+
+vi.mock('../cache/metadata-cache', () => ({
+  readMetadataCache: readMetadataCacheMock,
+}));
+
+vi.mock('../runtime/runtime-connect', async () => {
+  const actual = await vi.importActual<typeof import('../runtime/runtime-connect')>('../runtime/runtime-connect');
+  return {
+    ...actual,
+    reconcileConnection: reconcileConnectionMock,
+  };
+});
+
+function createSyncedState(
+  config: McpConfigDocument,
+  connectionStatus: 'idle' | 'connected',
+): SyncedRuntimeState {
+  return {
+    configPath: '/tmp/mcp.json',
+    statePath: '/tmp/mcp-state.json',
+    config,
+    metadataCache: { version: 1, servers: {} },
+    rawConfigUpdatedAt: null,
+    snapshot: {
+      initialized: true,
+      firstRun: false,
+      configPath: '/tmp/mcp.json',
+      rawConfigUpdatedAt: null,
+      servers: [
+        {
+          serverName: 'github',
+          enabled: true,
+          transport: 'http',
+          lifecycle: 'lazy',
+          authMode: 'none',
+          connectionStatus,
+          authStatus: 'not-required',
+          toolCount: connectionStatus === 'connected' ? 2 : 0,
+          resourceCount: 0,
+          uiToolCount: 0,
+          url: 'https://example.com/mcp',
+          exposeResources: true,
+          debug: false,
+          lastConnectedAt: connectionStatus === 'connected' ? '2026-04-21T00:00:00.000Z' : null,
+          lastFailedAt: null,
+          resources: [],
+          uiTools: [],
+        },
+      ],
+      settings: {
+        idleTimeout: 10,
+        toolPrefix: 'server',
+      },
+      lastRefreshedAt: null,
+      summary: {
+        totalServers: 1,
+        enabledServers: 1,
+        connectedServers: connectionStatus === 'connected' ? 1 : 0,
+        needsAuthServers: 0,
+        errorServers: 0,
+      },
+    },
+  };
+}
+
+describe('connectServerAction', () => {
+  it('returns an explicit no-op message when the server is already connected', async () => {
+    readMetadataCacheMock.mockReset();
+    reconcileConnectionMock.mockReset();
+
+    const config: McpConfigDocument = {
+      mcpServers: {
+        github: {
+          transport: 'http',
+          url: 'https://example.com/mcp',
+          enabled: true,
+        },
+      },
+    };
+
+    readMetadataCacheMock.mockResolvedValue({ version: 1, servers: {} });
+    reconcileConnectionMock.mockResolvedValue({
+      nextCache: { version: 1, servers: {} },
+      runtimeStatus: {
+        connectionStatus: 'connected',
+        authStatus: 'not-required',
+        lastConnectedAt: '2026-04-21T00:00:00.000Z',
+        lastFailedAt: null,
+      },
+    });
+
+    const syncSnapshot = vi
+      .fn<(...args: unknown[]) => Promise<SyncedRuntimeState>>()
+      .mockResolvedValueOnce(createSyncedState(config, 'idle'))
+      .mockResolvedValueOnce(createSyncedState(config, 'connected'));
+    const connect = vi.fn(async () => {
+      throw new Error('connect should not be called when an active connection already exists');
+    });
+    const manager = {
+      getConnection: vi.fn(() => ({
+        name: 'github',
+        client: null,
+        transport: null,
+        tools: [{ name: 'search_docs', inputSchema: { type: 'object' } }],
+        resources: [],
+        status: 'connected' as const,
+        lastConnectedAt: '2026-04-21T00:00:00.000Z',
+        lastFailedAt: null,
+      })),
+      connect,
+      reconnect: vi.fn(),
+    } as unknown as McpServerManager;
+    const setRuntimeStatus = vi.fn();
+
+    const result = await connectServerAction({
+      cwd: '/tmp',
+      serverName: 'github',
+      reconnect: false,
+      manager,
+      setRuntimeStatus,
+      syncSnapshot,
+    });
+
+    expect(connect).not.toHaveBeenCalled();
+    expect(result.content[0]?.text).toBe('MCP server "github" is already connected.');
+    expect(result.details.alreadyConnected).toBe(true);
+    expect(setRuntimeStatus).toHaveBeenCalledWith('github', expect.objectContaining({
+      connectionStatus: 'connected',
+      authStatus: 'not-required',
+    }));
+  });
+});

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-auth.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createEmptyMetadataCache } from '../cache/metadata-cache';
+import type { McpConfigDocument } from '../config/types';
+import type { McpServerManager } from '../manager/server-manager';
+import type { McpOAuthCoordinator } from '../auth/oauth-coordinator';
+import { clearServerAuthAction } from '../runtime/runtime-auth';
+import type { SyncedRuntimeState } from '../runtime/runtime-types';
+
+const { clearOAuthCredentialsMock } = vi.hoisted(() => ({
+  clearOAuthCredentialsMock: vi.fn(),
+}));
+
+vi.mock('../auth/storage', () => ({
+  clearOAuthCredentials: clearOAuthCredentialsMock,
+}));
+
+function createSyncedState(config: McpConfigDocument, authStatus: 'authenticated' | 'not-authenticated'): SyncedRuntimeState {
+  return {
+    configPath: '/tmp/mcp.json',
+    statePath: '/tmp/mcp-state.json',
+    config,
+    metadataCache: createEmptyMetadataCache(),
+    rawConfigUpdatedAt: null,
+    snapshot: {
+      initialized: true,
+      firstRun: false,
+      configPath: '/tmp/mcp.json',
+      rawConfigUpdatedAt: null,
+      servers: [
+        {
+          serverName: 'github',
+          enabled: true,
+          transport: 'http',
+          lifecycle: 'lazy',
+          authMode: 'oauth',
+          connectionStatus: authStatus === 'authenticated' ? 'connected' : 'needs-auth',
+          authStatus,
+          toolCount: 0,
+          resourceCount: 0,
+          uiToolCount: 0,
+          url: 'https://example.com/mcp',
+          exposeResources: true,
+          debug: false,
+          lastConnectedAt: null,
+          lastFailedAt: null,
+          resources: [],
+          uiTools: [],
+        },
+      ],
+      settings: {
+        idleTimeout: 10,
+        toolPrefix: 'server',
+      },
+      lastRefreshedAt: null,
+      summary: {
+        totalServers: 1,
+        enabledServers: 1,
+        connectedServers: authStatus === 'authenticated' ? 1 : 0,
+        needsAuthServers: authStatus === 'authenticated' ? 0 : 1,
+        errorServers: 0,
+      },
+    },
+  };
+}
+
+describe('clearServerAuthAction', () => {
+  it('clears saved OAuth credentials and resets the server auth state', async () => {
+    clearOAuthCredentialsMock.mockReset();
+    const config: McpConfigDocument = {
+      mcpServers: {
+        github: {
+          url: 'https://example.com/mcp',
+          transport: 'http',
+          auth: 'oauth',
+        },
+      },
+    };
+    const syncSnapshot = vi
+      .fn<() => Promise<SyncedRuntimeState>>()
+      .mockResolvedValueOnce(createSyncedState(config, 'authenticated'))
+      .mockResolvedValueOnce(createSyncedState(config, 'not-authenticated'));
+    const cancelAuth = vi.fn(async () => {});
+    const close = vi.fn(async () => {});
+    const setRuntimeStatus = vi.fn();
+
+    const result = await clearServerAuthAction({
+      cwd: '/tmp',
+      serverName: 'github',
+      authCoordinator: { cancelAuth } as unknown as McpOAuthCoordinator,
+      manager: { close } as unknown as McpServerManager,
+      setRuntimeStatus,
+      syncSnapshot,
+    });
+
+    expect(cancelAuth).toHaveBeenCalledWith('github');
+    expect(close).toHaveBeenCalledWith('github');
+    expect(clearOAuthCredentialsMock).toHaveBeenCalledWith('github');
+    expect(setRuntimeStatus).toHaveBeenCalledWith('github', { authStatus: 'not-authenticated' });
+    expect(result.details.authStatus).toBe('not-authenticated');
+  });
+});

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-lifecycle.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-lifecycle.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { McpConfigDocument, McpServerConfig } from '../config/types';
+import {
+  getAutoConnectServerEntries,
+  getChangedServerNames,
+  getKeepAliveServerEntries,
+  shouldAttemptAutoConnect,
+} from '../runtime/runtime-lifecycle';
+
+function createConfig(servers: Record<string, McpServerConfig>): McpConfigDocument {
+  return { mcpServers: servers };
+}
+
+describe('runtime-lifecycle helpers', () => {
+  it('returns only enabled eager and keep-alive servers for auto-connect', () => {
+    const config = createConfig({
+      lazy: { command: 'node', lifecycle: 'lazy' },
+      eager: { command: 'node', lifecycle: 'eager' },
+      keepAlive: { command: 'node', lifecycle: 'keep-alive' },
+      disabled: { command: 'node', lifecycle: 'keep-alive', enabled: false },
+    });
+
+    expect(getAutoConnectServerEntries(config).map(([name]) => name)).toEqual(['eager', 'keepAlive']);
+    expect(getKeepAliveServerEntries(config).map(([name]) => name)).toEqual(['keepAlive']);
+  });
+
+  it('skips auto-connect for connected or auth-blocked servers', async () => {
+    const connected = await shouldAttemptAutoConnect({
+      serverName: 'github',
+      serverConfig: { command: 'node', lifecycle: 'keep-alive' },
+      connection: {
+        name: 'github',
+        client: null,
+        transport: null,
+        tools: [],
+        resources: [],
+        status: 'connected',
+      },
+      hasOAuthTokens: async () => false,
+    });
+    const oauthWithoutTokens = await shouldAttemptAutoConnect({
+      serverName: 'oauth-server',
+      serverConfig: { url: 'https://example.com/mcp', auth: 'oauth', lifecycle: 'keep-alive' },
+      hasOAuthTokens: async () => false,
+    });
+
+    expect(connected).toBe(false);
+    expect(oauthWithoutTokens).toBe(false);
+  });
+
+  it('reports removed and transport-changing servers as changed', () => {
+    const previousConfig = createConfig({
+      github: { command: 'node', args: ['old'] },
+      memory: { command: 'npx' },
+    });
+    const nextConfig = createConfig({
+      github: { url: 'https://example.com/mcp', transport: 'http' },
+      newServer: { command: 'bunx' },
+    });
+
+    expect(getChangedServerNames(previousConfig, nextConfig).sort()).toEqual(['github', 'memory']);
+  });
+});

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
@@ -144,6 +144,41 @@ describe('executeProxyAction', () => {
     ]);
   });
 
+  it('reads a live MCP resource through the bridged proxy', async () => {
+    const serverConfig: McpServerConfig = { command: 'node', args: ['server.js'] };
+    const synced = createSyncedState(serverConfig);
+    const manager = {
+      getConnection: () => ({
+        name: 'github',
+        client: null,
+        transport: null,
+        tools: [],
+        resources: [],
+        status: 'connected' as const,
+      }),
+      readResource: vi.fn(async () => ({
+        contents: [{
+          uri: 'file://README.md',
+          mimeType: 'text/plain',
+          text: 'hello from MCP',
+        }],
+      })),
+    } as unknown as McpServerManager;
+
+    const result = await executeProxyAction({
+      action: 'read_resource',
+      serverName: 'github',
+      resourceUri: 'file://README.md',
+      manager,
+      setRuntimeStatus: () => {},
+      syncSnapshot: async () => synced,
+    });
+
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('MCP resource from github: file://README.md');
+    expect(text).toContain('hello from MCP');
+  });
+
   it('describes a cached tool including its input schema', async () => {
     const serverConfig: McpServerConfig = { command: 'node', args: ['server.js'] };
     const synced = createSyncedState(serverConfig);

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
@@ -60,13 +60,17 @@ function createSyncedState(serverConfig: McpServerConfig): SyncedRuntimeState {
           lifecycle: serverConfig.lifecycle ?? 'lazy',
           authMode: serverConfig.auth === 'oauth' ? 'oauth' : serverConfig.auth === 'bearer' ? 'bearer' : 'none',
           connectionStatus: serverConfig.auth === 'oauth' ? 'needs-auth' : 'idle',
-          authStatus: serverConfig.auth === 'oauth' ? 'not-authenticated' : 'not-required',
+          authStatus: serverConfig.auth === 'oauth'
+            ? 'not-authenticated'
+            : serverConfig.auth === 'bearer'
+              ? 'authenticated'
+              : 'not-required',
           toolCount: 2,
           resourceCount: 1,
           uiToolCount: 1,
           command: serverConfig.command,
           url: serverConfig.url,
-          exposeResources: true,
+          exposeResources: serverConfig.exposeResources ?? true,
           debug: false,
           lastConnectedAt: null,
           lastFailedAt: null,
@@ -142,6 +146,25 @@ describe('executeProxyAction', () => {
         description: 'Embedded GitHub dashboard',
       },
     ]);
+  });
+
+  it('hides resource inventory when resource exposure is disabled', async () => {
+    const serverConfig: McpServerConfig = {
+      command: 'node',
+      args: ['server.js'],
+      exposeResources: false,
+    };
+    const synced = createSyncedState(serverConfig);
+    const result = await executeProxyAction({
+      action: 'list_resources',
+      serverName: 'github',
+      manager: { getConnection: () => undefined } as unknown as McpServerManager,
+      setRuntimeStatus: () => {},
+      syncSnapshot: async () => synced,
+    });
+
+    expect(result.content[0]?.text).toContain('Resource exposure is disabled');
+    expect(result.details.resources).toEqual([]);
   });
 
   it('reads a live MCP resource through the bridged proxy', async () => {

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
@@ -121,6 +121,29 @@ describe('executeProxyAction', () => {
     expect(result.details.matches).toHaveLength(2);
   });
 
+  it('lists cached server resources', async () => {
+    const serverConfig: McpServerConfig = { command: 'node', args: ['server.js'] };
+    const synced = createSyncedState(serverConfig);
+    const result = await executeProxyAction({
+      action: 'list_resources',
+      serverName: 'github',
+      manager: { getConnection: () => undefined } as unknown as McpServerManager,
+      setRuntimeStatus: () => {},
+      syncSnapshot: async () => synced,
+    });
+
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('github resources (1):');
+    expect(text).toContain('ui://github/dashboard');
+    expect(result.details.resources).toEqual([
+      {
+        uri: 'ui://github/dashboard',
+        name: 'Dashboard',
+        description: 'Embedded GitHub dashboard',
+      },
+    ]);
+  });
+
   it('describes a cached tool including its input schema', async () => {
     const serverConfig: McpServerConfig = { command: 'node', args: ['server.js'] };
     const synced = createSyncedState(serverConfig);

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import { computeServerHash } from '../cache/metadata-cache';
+import type { McpServerConfig } from '../config/types';
+import type { McpServerManager } from '../manager/server-manager';
+import { executeProxyAction } from '../runtime/runtime-proxy';
+import type { SyncedRuntimeState } from '../runtime/runtime-types';
+
+function createSyncedState(serverConfig: McpServerConfig): SyncedRuntimeState {
+  return {
+    configPath: '/tmp/mcp.json',
+    statePath: '/tmp/mcp-state.json',
+    config: {
+      mcpServers: {
+        github: serverConfig,
+      },
+    },
+    metadataCache: {
+      version: 1,
+      servers: {
+        github: {
+          cachedAt: Date.now(),
+          configHash: computeServerHash(serverConfig),
+          toolCount: 2,
+          resourceCount: 1,
+          tools: [
+            {
+              name: 'search_docs',
+              description: 'Search repository documentation',
+              inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+            },
+            {
+              name: 'open_dashboard',
+              description: 'Open the dashboard UI',
+              inputSchema: { type: 'object' },
+              uiResourceUri: 'ui://github/dashboard',
+            },
+          ],
+          resources: [
+            {
+              uri: 'ui://github/dashboard',
+              name: 'Dashboard',
+              description: 'Embedded GitHub dashboard',
+            },
+          ],
+        },
+      },
+    },
+    rawConfigUpdatedAt: null,
+    snapshot: {
+      initialized: true,
+      firstRun: false,
+      configPath: '/tmp/mcp.json',
+      rawConfigUpdatedAt: null,
+      servers: [
+        {
+          serverName: 'github',
+          enabled: true,
+          transport: serverConfig.transport ?? 'stdio',
+          lifecycle: serverConfig.lifecycle ?? 'lazy',
+          authMode: serverConfig.auth === 'oauth' ? 'oauth' : serverConfig.auth === 'bearer' ? 'bearer' : 'none',
+          connectionStatus: serverConfig.auth === 'oauth' ? 'needs-auth' : 'idle',
+          authStatus: serverConfig.auth === 'oauth' ? 'not-authenticated' : 'not-required',
+          toolCount: 2,
+          resourceCount: 1,
+          uiToolCount: 1,
+          command: serverConfig.command,
+          url: serverConfig.url,
+          exposeResources: true,
+          debug: false,
+          lastConnectedAt: null,
+          lastFailedAt: null,
+          resources: [
+            {
+              uri: 'ui://github/dashboard',
+              name: 'Dashboard',
+              description: 'Embedded GitHub dashboard',
+            },
+          ],
+          uiTools: [
+            {
+              name: 'open_dashboard',
+              description: 'Open the dashboard UI',
+              inputSchema: { type: 'object' },
+              resourceUri: 'ui://github/dashboard',
+            },
+          ],
+        },
+      ],
+      settings: {
+        idleTimeout: 10,
+        toolPrefix: 'server',
+      },
+      lastRefreshedAt: null,
+      summary: {
+        totalServers: 1,
+        enabledServers: 1,
+        connectedServers: 0,
+        needsAuthServers: serverConfig.auth === 'oauth' ? 1 : 0,
+        errorServers: 0,
+      },
+    },
+  };
+}
+
+describe('executeProxyAction', () => {
+  it('searches cached MCP tools and resources only', async () => {
+    const serverConfig: McpServerConfig = { command: 'node', args: ['server.js'] };
+    const synced = createSyncedState(serverConfig);
+    const result = await executeProxyAction({
+      action: 'search',
+      query: 'dashboard',
+      manager: { getConnection: () => undefined } as unknown as McpServerManager,
+      setRuntimeStatus: () => {},
+      syncSnapshot: async () => synced,
+    });
+
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('[tool] github.open_dashboard');
+    expect(text).toContain('[resource] github ui://github/dashboard');
+    expect(result.details.matches).toHaveLength(2);
+  });
+
+  it('describes a cached tool including its input schema', async () => {
+    const serverConfig: McpServerConfig = { command: 'node', args: ['server.js'] };
+    const synced = createSyncedState(serverConfig);
+    const result = await executeProxyAction({
+      action: 'describe_tool',
+      serverName: 'github',
+      toolName: 'search_docs',
+      manager: { getConnection: () => undefined } as unknown as McpServerManager,
+      setRuntimeStatus: () => {},
+      syncSnapshot: async () => synced,
+    });
+
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('Tool: github.search_docs');
+    expect(text).toContain('Search repository documentation');
+    expect(text).toContain('"query"');
+  });
+
+  it('calls a live MCP tool and includes structured content in the response', async () => {
+    const serverConfig: McpServerConfig = { command: 'node', args: ['server.js'] };
+    const synced = createSyncedState(serverConfig);
+    const callTool = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'Found 2 matching docs.' }],
+      structuredContent: { count: 2 },
+      isError: false,
+    }));
+    const manager = {
+      getConnection: () => ({
+        name: 'github',
+        client: null,
+        transport: null,
+        tools: [
+          {
+            name: 'search_docs',
+            description: 'Search repository documentation',
+            inputSchema: { type: 'object' },
+          },
+        ],
+        resources: [],
+        status: 'connected' as const,
+      }),
+      callTool,
+    } as unknown as McpServerManager;
+
+    const result = await executeProxyAction({
+      action: 'call_tool',
+      serverName: 'github',
+      toolName: 'search_docs',
+      argumentsJson: '{"query":"auth"}',
+      manager,
+      setRuntimeStatus: () => {},
+      syncSnapshot: async () => synced,
+    });
+
+    const text = result.content[0]?.text ?? '';
+    expect(callTool).toHaveBeenCalledWith('github', 'search_docs', { query: 'auth' });
+    expect(text).toContain('MCP tool result from github.search_docs');
+    expect(text).toContain('Found 2 matching docs.');
+    expect(text).toContain('Structured content:');
+    expect(result.details.structuredContent).toEqual({ count: 2 });
+  });
+
+  it('returns in-app auth guidance when a tool call hits an OAuth-gated server', async () => {
+    const serverConfig: McpServerConfig = {
+      url: 'https://example.com/mcp',
+      transport: 'http',
+      auth: 'oauth',
+    };
+    const synced = createSyncedState(serverConfig);
+    const result = await executeProxyAction({
+      action: 'call_tool',
+      serverName: 'github',
+      toolName: 'search_docs',
+      manager: {
+        getConnection: () => ({
+          name: 'github',
+          client: null,
+          transport: null,
+          tools: [],
+          resources: [],
+          status: 'needs-auth' as const,
+          lastFailedAt: null,
+        }),
+      } as unknown as McpServerManager,
+      setRuntimeStatus: () => {},
+      syncSnapshot: async () => synced,
+    });
+
+    expect(result.content[0]?.text).toContain('requires in-app authentication');
+    expect(result.details.authRequired).toBe(true);
+  });
+});

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
@@ -192,7 +192,7 @@ describe('executeProxyAction', () => {
       action: 'call_tool',
       serverName: 'github',
       toolName: 'search_docs',
-      argumentsJson: '{"query":"auth"}',
+      toolArguments: { query: 'auth' },
       manager,
       setRuntimeStatus: () => {},
       syncSnapshot: async () => synced,

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-proxy.test.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import { describe, expect, it, vi } from 'vitest';
 import { computeServerHash } from '../cache/metadata-cache';
 import type { McpServerConfig } from '../config/types';
@@ -208,6 +209,47 @@ describe('executeProxyAction', () => {
       syncSnapshot: async () => synced,
     });
 
+    expect(result.content[0]?.text).toContain('requires in-app authentication');
+    expect(result.details.authRequired).toBe(true);
+  });
+
+  it('downgrades a connected OAuth server back to auth-required when a live tool call is unauthorized', async () => {
+    const serverConfig: McpServerConfig = {
+      url: 'https://example.com/mcp',
+      transport: 'http',
+      auth: 'oauth',
+    };
+    const synced = createSyncedState(serverConfig);
+    const close = vi.fn(async () => {});
+    const setRuntimeStatus = vi.fn();
+    const result = await executeProxyAction({
+      action: 'call_tool',
+      serverName: 'github',
+      toolName: 'search_docs',
+      manager: {
+        getConnection: () => ({
+          name: 'github',
+          client: null,
+          transport: null,
+          tools: [{ name: 'search_docs', inputSchema: { type: 'object' } }],
+          resources: [],
+          status: 'connected' as const,
+        }),
+        callTool: vi.fn(async () => {
+          throw new UnauthorizedError('Expired token');
+        }),
+        close,
+      } as unknown as McpServerManager,
+      setRuntimeStatus,
+      syncSnapshot: async () => synced,
+    });
+
+    expect(close).toHaveBeenCalledWith('github');
+    expect(setRuntimeStatus).toHaveBeenCalledWith('github', expect.objectContaining({
+      connectionStatus: 'needs-auth',
+      authStatus: 'not-authenticated',
+      lastError: 'Expired token',
+    }));
     expect(result.content[0]?.text).toContain('requires in-app authentication');
     expect(result.details.authRequired).toBe(true);
   });

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
@@ -1,9 +1,60 @@
-import { describe, expect, it } from 'vitest';
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
+import { describe, expect, it, vi } from 'vitest';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
-import { normalizeResourcePreview } from '../runtime/runtime-resource';
+import { createEmptyMetadataCache } from '../cache/metadata-cache';
+import type { McpConfigDocument } from '../config/types';
+import type { McpServerManager } from '../manager/server-manager';
+import { normalizeResourcePreview, readServerResourceAction } from '../runtime/runtime-resource';
+import type { SyncedRuntimeState } from '../runtime/runtime-types';
 
 function createResult(contents: Array<Record<string, unknown>>): ReadResourceResult {
   return { contents } as unknown as ReadResourceResult;
+}
+
+function createSyncedState(config: McpConfigDocument): SyncedRuntimeState {
+  return {
+    configPath: '/tmp/mcp.json',
+    statePath: '/tmp/mcp-state.json',
+    config,
+    metadataCache: createEmptyMetadataCache(),
+    rawConfigUpdatedAt: null,
+    snapshot: {
+      initialized: true,
+      firstRun: false,
+      configPath: '/tmp/mcp.json',
+      rawConfigUpdatedAt: null,
+      servers: [
+        {
+          serverName: 'demo',
+          enabled: true,
+          transport: 'http',
+          lifecycle: 'lazy',
+          authMode: config.mcpServers.demo?.auth === 'oauth' ? 'oauth' : 'none',
+          connectionStatus: 'connected',
+          authStatus: config.mcpServers.demo?.auth === 'oauth' ? 'authenticated' : 'not-required',
+          toolCount: 0,
+          resourceCount: 0,
+          uiToolCount: 0,
+          url: config.mcpServers.demo?.url,
+          exposeResources: true,
+          debug: false,
+          lastConnectedAt: null,
+          lastFailedAt: null,
+          resources: [],
+          uiTools: [],
+        },
+      ],
+      settings: { idleTimeout: 10, toolPrefix: 'server' },
+      lastRefreshedAt: null,
+      summary: {
+        totalServers: 1,
+        enabledServers: 1,
+        connectedServers: 1,
+        needsAuthServers: 0,
+        errorServers: 0,
+      },
+    },
+  };
 }
 
 describe('normalizeResourcePreview', () => {
@@ -57,5 +108,53 @@ describe('normalizeResourcePreview', () => {
 
     expect(preview.previewKind).toBe('binary');
     expect(preview.text).toBeUndefined();
+  });
+});
+
+describe('readServerResourceAction', () => {
+  it('marks OAuth servers as needing auth again when a live resource read is unauthorized', async () => {
+    const config: McpConfigDocument = {
+      mcpServers: {
+        demo: {
+          url: 'https://example.com/mcp',
+          transport: 'http',
+          auth: 'oauth',
+        },
+      },
+    };
+    const synced = createSyncedState(config);
+    const close = vi.fn(async () => {});
+    const setRuntimeStatus = vi.fn();
+
+    const result = await readServerResourceAction({
+      cwd: '/tmp',
+      serverName: 'demo',
+      resourceUri: 'ui://demo/app',
+      manager: {
+        getConnection: () => ({
+          name: 'demo',
+          client: null,
+          transport: null,
+          tools: [],
+          resources: [],
+          status: 'connected' as const,
+        }),
+        readResource: vi.fn(async () => {
+          throw new UnauthorizedError('Expired token');
+        }),
+        close,
+      } as unknown as McpServerManager,
+      setRuntimeStatus,
+      syncSnapshot: async () => synced,
+    });
+
+    expect(close).toHaveBeenCalledWith('demo');
+    expect(setRuntimeStatus).toHaveBeenCalledWith('demo', expect.objectContaining({
+      connectionStatus: 'needs-auth',
+      authStatus: 'not-authenticated',
+      lastError: 'Expired token',
+    }));
+    expect(result.content[0]?.text).toContain('requires in-app authentication');
+    expect(result.details.authRequired).toBe(true);
   });
 });

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
@@ -7,11 +7,11 @@ function createResult(contents: Array<Record<string, unknown>>): ReadResourceRes
 }
 
 describe('normalizeResourcePreview', () => {
-  it('renders HTML resource previews from text content', () => {
+  it('renders HTML resource previews from MCP UI resources', () => {
     const preview = normalizeResourcePreview('demo', 'ui://demo/app', createResult([
       {
         uri: 'ui://demo/app',
-        mimeType: 'text/html',
+        mimeType: 'text/html;profile=mcp-app',
         text: '<html><body>Hello</body></html>',
       },
     ]));

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
@@ -112,6 +112,39 @@ describe('normalizeResourcePreview', () => {
 });
 
 describe('readServerResourceAction', () => {
+  it('blocks resource reads when resource exposure is disabled', async () => {
+    const config: McpConfigDocument = {
+      mcpServers: {
+        demo: {
+          command: 'node',
+          args: ['server.js'],
+          exposeResources: false,
+        },
+      },
+    };
+    const synced = createSyncedState(config);
+    const readResource = vi.fn();
+
+    const result = await readServerResourceAction({
+      cwd: '/tmp',
+      serverName: 'demo',
+      resourceUri: 'file://README.md',
+      manager: {
+        getConnection: vi.fn(() => undefined),
+        connect: vi.fn(async () => {
+          throw new Error('connect should not be called');
+        }),
+        readResource,
+      } as unknown as McpServerManager,
+      setRuntimeStatus: vi.fn(),
+      syncSnapshot: async () => synced,
+    });
+
+    expect(readResource).not.toHaveBeenCalled();
+    expect(result.content[0]?.text).toContain('Resource exposure is disabled');
+    expect(result.details.resourceExposureEnabled).toBe(false);
+  });
+
   it('marks OAuth servers as needing auth again when a live resource read is unauthorized', async () => {
     const config: McpConfigDocument = {
       mcpServers: {

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-resource.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { normalizeResourcePreview } from '../runtime/runtime-resource';
+
+function createResult(contents: Array<Record<string, unknown>>): ReadResourceResult {
+  return { contents } as unknown as ReadResourceResult;
+}
+
+describe('normalizeResourcePreview', () => {
+  it('renders HTML resource previews from text content', () => {
+    const preview = normalizeResourcePreview('demo', 'ui://demo/app', createResult([
+      {
+        uri: 'ui://demo/app',
+        mimeType: 'text/html',
+        text: '<html><body>Hello</body></html>',
+      },
+    ]));
+
+    expect(preview.previewKind).toBe('html');
+    expect(preview.html).toContain('Hello');
+  });
+
+  it('pretty-prints JSON resource previews', () => {
+    const preview = normalizeResourcePreview('demo', 'file://config.json', createResult([
+      {
+        uri: 'file://config.json',
+        mimeType: 'application/json',
+        text: '{"ok":true}',
+      },
+    ]));
+
+    expect(preview.previewKind).toBe('json');
+    expect(preview.text).toContain('"ok": true');
+  });
+
+  it('returns data URLs for image blobs', () => {
+    const preview = normalizeResourcePreview('demo', 'file://diagram.png', createResult([
+      {
+        uri: 'file://diagram.png',
+        mimeType: 'image/png',
+        blob: Buffer.from('png-data').toString('base64'),
+      },
+    ]));
+
+    expect(preview.previewKind).toBe('image');
+    expect(preview.dataUrl).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it('falls back to binary preview when no text payload exists', () => {
+    const preview = normalizeResourcePreview('demo', 'file://archive.bin', createResult([
+      {
+        uri: 'file://archive.bin',
+        mimeType: 'application/octet-stream',
+        blob: Buffer.from('binary').toString('base64'),
+      },
+    ]));
+
+    expect(preview.previewKind).toBe('binary');
+    expect(preview.text).toBeUndefined();
+  });
+});

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-viewer.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-viewer.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SyncedRuntimeState } from '../runtime/runtime-types';
+import { createToolResult } from '../tools/types';
+import { closeViewerAction, openToolUiAction, openViewerResourceAction } from '../runtime/runtime-viewer';
+
+const readServerResourceActionMock = vi.fn();
+
+vi.mock('../runtime/runtime-resource', () => ({
+  readServerResourceAction: (options: unknown) => readServerResourceActionMock(options),
+}));
+
+describe('runtime-viewer', () => {
+  beforeEach(() => {
+    readServerResourceActionMock.mockReset();
+  });
+
+  it('opens a loopback viewer session for ui resources', async () => {
+    const manager = createManager({
+      status: 'connected',
+      tools: [],
+      resources: [{ uri: 'ui://demo/dashboard', name: 'Dashboard', _meta: {} }],
+    });
+    const uiResourceHandler = {
+      readUiResource: vi.fn(async () => ({
+        uri: 'ui://demo/dashboard',
+        html: '<html><body>demo</body></html>',
+        mimeType: 'text/html;profile=mcp-app',
+        meta: {},
+      })),
+    };
+    const uiSessions = {
+      open: vi.fn(async () => ({
+        sessionId: 'session-1',
+        viewerUrl: 'http://127.0.0.1:43123/?session=session-1',
+        serverName: 'demo',
+        resourceUri: 'ui://demo/dashboard',
+        close: vi.fn(),
+      })),
+    };
+
+    const result = await openViewerResourceAction({
+      cwd: '/tmp/workspace',
+      serverName: 'demo',
+      resourceUri: 'ui://demo/dashboard',
+      manager: manager as never,
+      uiResourceHandler: uiResourceHandler as never,
+      uiSessions: uiSessions as never,
+      setRuntimeStatus: vi.fn(),
+      syncSnapshot: vi.fn(async () => createSyncedState()),
+    });
+
+    expect(uiResourceHandler.readUiResource).toHaveBeenCalledWith('demo', 'ui://demo/dashboard');
+    expect(uiSessions.open).toHaveBeenCalled();
+    expect(result.details.viewerUrl).toBe('http://127.0.0.1:43123/?session=session-1');
+    expect(result.details.sessionId).toBe('session-1');
+  });
+
+  it('falls back to inline preview handling for non-ui resources', async () => {
+    readServerResourceActionMock.mockResolvedValue(createToolResult('Loaded resource.', {
+      resourcePreview: {
+        serverName: 'demo',
+        requestedUri: 'file://README.md',
+        resolvedUri: 'file://README.md',
+        previewKind: 'text',
+        text: 'hello',
+        truncated: false,
+      },
+    }));
+
+    const result = await openViewerResourceAction({
+      cwd: '/tmp/workspace',
+      serverName: 'demo',
+      resourceUri: 'file://README.md',
+      manager: createManager({ status: 'connected', tools: [], resources: [] }) as never,
+      uiResourceHandler: { readUiResource: vi.fn() } as never,
+      uiSessions: { open: vi.fn(), getActiveSession: vi.fn(), closeActive: vi.fn(async () => undefined) } as never,
+      setRuntimeStatus: vi.fn(),
+      syncSnapshot: vi.fn(async () => createSyncedState()),
+    });
+
+    expect(readServerResourceActionMock).toHaveBeenCalled();
+    expect(result.details.resourcePreview).toBeTruthy();
+  });
+
+  it('opens tool UIs using metadata-derived ui resource URIs', async () => {
+    const manager = createManager({
+      status: 'connected',
+      tools: [
+        {
+          name: 'dashboard',
+          description: 'Open the dashboard',
+          inputSchema: { type: 'object', properties: {} },
+          _meta: { ui: { resourceUri: 'ui://demo/dashboard' } },
+        },
+      ],
+      resources: [],
+    });
+    const uiResourceHandler = {
+      readUiResource: vi.fn(async () => ({
+        uri: 'ui://demo/dashboard',
+        html: '<html><body>tool ui</body></html>',
+        mimeType: 'text/html;profile=mcp-app',
+        meta: {},
+      })),
+    };
+    const uiSessions = {
+      open: vi.fn(async () => ({
+        sessionId: 'session-2',
+        viewerUrl: 'http://127.0.0.1:43123/?session=session-2',
+        serverName: 'demo',
+        resourceUri: 'ui://demo/dashboard',
+        close: vi.fn(),
+      })),
+    };
+
+    const result = await openToolUiAction({
+      cwd: '/tmp/workspace',
+      serverName: 'demo',
+      toolName: 'dashboard',
+      manager: manager as never,
+      uiResourceHandler: uiResourceHandler as never,
+      uiSessions: uiSessions as never,
+      setRuntimeStatus: vi.fn(),
+      syncSnapshot: vi.fn(async () => createSyncedState()),
+    });
+
+    expect(uiResourceHandler.readUiResource).toHaveBeenCalledWith('demo', 'ui://demo/dashboard');
+    expect(result.details.toolName).toBe('dashboard');
+    expect(result.details.viewerUrl).toBe('http://127.0.0.1:43123/?session=session-2');
+  });
+
+  it('closes the active viewer session', async () => {
+    const closeActive = vi.fn(async () => undefined);
+
+    const result = await closeViewerAction({
+      uiSessions: {
+        getActiveSession: () => ({
+          sessionId: 'session-3',
+          viewerUrl: 'http://127.0.0.1:43123/?session=session-3',
+          serverName: 'demo',
+          resourceUri: 'ui://demo/dashboard',
+          close: vi.fn(),
+        }),
+        closeActive,
+      } as never,
+    });
+
+    expect(closeActive).toHaveBeenCalledWith('closed-from-ui');
+    expect(result.details.sessionClosed).toBe(true);
+  });
+});
+
+function createManager({
+  status,
+  tools,
+  resources,
+}: {
+  status: 'connected' | 'needs-auth' | 'error';
+  tools: Array<Record<string, unknown>>;
+  resources: Array<Record<string, unknown>>;
+}) {
+  return {
+    getConnection: vi.fn(() => ({
+      name: 'demo',
+      client: null,
+      transport: null,
+      status,
+      tools,
+      resources,
+      lastConnectedAt: null,
+      lastFailedAt: null,
+    })),
+    connect: vi.fn(async () => ({
+      name: 'demo',
+      client: null,
+      transport: null,
+      status,
+      tools,
+      resources,
+      lastConnectedAt: null,
+      lastFailedAt: null,
+    })),
+    close: vi.fn(async () => undefined),
+    callTool: vi.fn(async () => ({ isError: false, content: [{ type: 'text', text: 'ok' }] })),
+    readResource: vi.fn(async () => ({ contents: [] })),
+  };
+}
+
+function createSyncedState(): SyncedRuntimeState {
+  return {
+    configPath: '/tmp/sero/apps/mcp/config.json',
+    statePath: '/tmp/sero/apps/mcp/state.json',
+    rawConfigUpdatedAt: '2026-04-20T00:00:00.000Z',
+    metadataCache: { version: 1, servers: {} },
+    config: {
+      mcpServers: {
+        demo: {
+          enabled: true,
+          transport: 'stdio',
+          lifecycle: 'lazy',
+          auth: false,
+          command: 'npx',
+          args: ['demo'],
+        },
+      },
+    },
+    snapshot: {
+      initialized: true,
+      firstRun: false,
+      configPath: '/tmp/sero/apps/mcp/config.json',
+      rawConfigUpdatedAt: '2026-04-20T00:00:00.000Z',
+      servers: [],
+      settings: { idleTimeout: 10, toolPrefix: 'server' },
+      lastRefreshedAt: '2026-04-20T00:00:00.000Z',
+      summary: {
+        totalServers: 1,
+        enabledServers: 1,
+        connectedServers: 1,
+        needsAuthServers: 0,
+        errorServers: 0,
+      },
+    },
+  } as unknown as SyncedRuntimeState;
+}

--- a/plugins/sero-mcp-plugin/extension/__tests__/runtime-viewer.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/runtime-viewer.test.ts
@@ -7,6 +7,8 @@ const readServerResourceActionMock = vi.fn();
 
 vi.mock('../runtime/runtime-resource', () => ({
   readServerResourceAction: (options: unknown) => readServerResourceActionMock(options),
+  buildResourcesDisabledMessage: (serverName: string) =>
+    `Resource exposure is disabled for "${serverName}". Enable \"Expose resources\" in the MCP app to list or read resources.`,
 }));
 
 describe('runtime-viewer', () => {
@@ -80,6 +82,22 @@ describe('runtime-viewer', () => {
 
     expect(readServerResourceActionMock).toHaveBeenCalled();
     expect(result.details.resourcePreview).toBeTruthy();
+  });
+
+  it('blocks direct ui-resource opens when resource exposure is disabled', async () => {
+    const result = await openViewerResourceAction({
+      cwd: '/tmp/workspace',
+      serverName: 'demo',
+      resourceUri: 'ui://demo/dashboard',
+      manager: createManager({ status: 'connected', tools: [], resources: [] }) as never,
+      uiResourceHandler: { readUiResource: vi.fn() } as never,
+      uiSessions: { open: vi.fn(), getActiveSession: vi.fn(), closeActive: vi.fn(async () => undefined) } as never,
+      setRuntimeStatus: vi.fn(),
+      syncSnapshot: vi.fn(async () => createSyncedState({ exposeResources: false })),
+    });
+
+    expect(result.content[0]?.text).toContain('Resource exposure is disabled');
+    expect(result.details.resourceExposureEnabled).toBe(false);
   });
 
   it('opens tool UIs using metadata-derived ui resource URIs', async () => {
@@ -186,7 +204,7 @@ function createManager({
   };
 }
 
-function createSyncedState(): SyncedRuntimeState {
+function createSyncedState(overrides: { exposeResources?: boolean } = {}): SyncedRuntimeState {
   return {
     configPath: '/tmp/sero/apps/mcp/config.json',
     statePath: '/tmp/sero/apps/mcp/state.json',
@@ -201,6 +219,7 @@ function createSyncedState(): SyncedRuntimeState {
           auth: false,
           command: 'npx',
           args: ['demo'],
+          exposeResources: overrides.exposeResources,
         },
       },
     },

--- a/plugins/sero-mcp-plugin/extension/__tests__/state-snapshot.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/state-snapshot.test.ts
@@ -56,4 +56,74 @@ describe('buildSnapshot', () => {
       },
     ]);
   });
+
+  it('hides resource inventory when resource exposure is disabled', async () => {
+    const serverConfig: McpServerConfig = {
+      command: 'node',
+      args: ['server.js'],
+      exposeResources: false,
+    };
+    const config = createConfig(serverConfig);
+
+    const snapshot = await buildSnapshot({
+      configPath: '/tmp/mcp.json',
+      rawConfigUpdatedAt: null,
+      config,
+      metadataCache: {
+        version: 1,
+        servers: {
+          demo: {
+            cachedAt: Date.now(),
+            configHash: computeServerHash(serverConfig),
+            toolCount: 0,
+            resourceCount: 1,
+            tools: [],
+            resources: [
+              {
+                uri: 'file://README.md',
+                name: 'README',
+                description: 'Repository readme',
+              },
+            ],
+          },
+        },
+      },
+      hasOAuthTokens: async () => false,
+    });
+
+    expect(snapshot.servers[0]?.resourceCount).toBe(0);
+    expect(snapshot.servers[0]?.resources).toEqual([]);
+  });
+
+  it('marks bearer auth as needing auth when its env var is missing', async () => {
+    const previousToken = process.env.MCP_TEST_TOKEN;
+    delete process.env.MCP_TEST_TOKEN;
+
+    try {
+      const serverConfig: McpServerConfig = {
+        url: 'https://example.com/mcp',
+        transport: 'http',
+        auth: 'bearer',
+        bearerTokenEnv: 'MCP_TEST_TOKEN',
+      };
+      const config = createConfig(serverConfig);
+
+      const snapshot = await buildSnapshot({
+        configPath: '/tmp/mcp.json',
+        rawConfigUpdatedAt: null,
+        config,
+        metadataCache: { version: 1, servers: {} },
+        hasOAuthTokens: async () => false,
+      });
+
+      expect(snapshot.servers[0]?.authStatus).toBe('not-authenticated');
+      expect(snapshot.servers[0]?.connectionStatus).toBe('needs-auth');
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.MCP_TEST_TOKEN;
+      } else {
+        process.env.MCP_TEST_TOKEN = previousToken;
+      }
+    }
+  });
 });

--- a/plugins/sero-mcp-plugin/extension/__tests__/state-snapshot.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/state-snapshot.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { computeServerHash } from '../cache/metadata-cache';
+import type { McpConfigDocument, McpServerConfig } from '../config/types';
+import { buildSnapshot } from '../state/snapshot';
+
+function createConfig(serverConfig: McpServerConfig): McpConfigDocument {
+  return {
+    mcpServers: {
+      demo: serverConfig,
+    },
+  };
+}
+
+describe('buildSnapshot', () => {
+  it('preserves UI tool resource URIs so the UI can launch them', async () => {
+    const serverConfig: McpServerConfig = {
+      command: 'node',
+      args: ['server.js'],
+    };
+    const config = createConfig(serverConfig);
+
+    const snapshot = await buildSnapshot({
+      configPath: '/tmp/mcp.json',
+      rawConfigUpdatedAt: null,
+      config,
+      metadataCache: {
+        version: 1,
+        servers: {
+          demo: {
+            cachedAt: Date.now(),
+            configHash: computeServerHash(serverConfig),
+            toolCount: 1,
+            resourceCount: 0,
+            tools: [
+              {
+                name: 'open_dashboard',
+                description: 'Open the dashboard UI',
+                inputSchema: { type: 'object' },
+                uiResourceUri: 'ui://demo/dashboard',
+              },
+            ],
+            resources: [],
+          },
+        },
+      },
+      hasOAuthTokens: async () => false,
+    });
+
+    expect(snapshot.servers[0]?.uiToolCount).toBe(1);
+    expect(snapshot.servers[0]?.uiTools).toEqual([
+      {
+        name: 'open_dashboard',
+        description: 'Open the dashboard UI',
+        inputSchema: { type: 'object' },
+        resourceUri: 'ui://demo/dashboard',
+      },
+    ]);
+  });
+});

--- a/plugins/sero-mcp-plugin/extension/__tests__/ui-server.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/ui-server.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { UiServerHandle } from '../viewer/ui-server';
+import { startUiServer } from '../viewer/ui-server';
+
+const activeHandles: UiServerHandle[] = [];
+
+afterEach(() => {
+  while (activeHandles.length > 0) {
+    activeHandles.pop()?.close('test-cleanup');
+  }
+});
+
+describe('ui-server', () => {
+  it('serves the viewer shell with a CSP header and sandboxed bridge-only iframe', async () => {
+    const handle = await openViewerServer();
+
+    const response = await fetch(handle.viewerUrl);
+    const html = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-security-policy')).toContain("default-src 'none'");
+    expect(response.headers.get('content-security-policy')).toContain("frame-src 'self'");
+    expect(html).toContain("sandbox', 'allow-scripts allow-forms allow-popups allow-downloads'");
+    expect(html).not.toContain("sandbox', 'allow-scripts allow-same-origin");
+  });
+
+  it('rejects host-page requests without the viewer session token', async () => {
+    const handle = await openViewerServer();
+    const url = new URL(handle.viewerUrl);
+    url.search = '';
+
+    const response = await fetch(url);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ ok: false, error: 'Invalid viewer session token' });
+  });
+
+  it('rejects proxy requests without the viewer session token in the body', async () => {
+    const handle = await openViewerServer();
+    const url = new URL('/proxy/tools/list', handle.viewerUrl);
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ params: {} }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ ok: false, error: 'Invalid viewer session token' });
+  });
+});
+
+async function openViewerServer(): Promise<UiServerHandle> {
+  const handle = await startUiServer({
+    serverName: 'demo',
+    resourceUri: 'ui://demo/dashboard',
+    title: 'Demo dashboard',
+    resource: {
+      uri: 'ui://demo/dashboard',
+      html: '<html><body>demo</body></html>',
+      mimeType: 'text/html;profile=mcp-app',
+      meta: {},
+    },
+    manager: createManager() as never,
+  });
+
+  activeHandles.push(handle);
+  return handle;
+}
+
+function createManager() {
+  return {
+    getConnection: vi.fn(() => ({ tools: [], resources: [] })),
+    callTool: vi.fn(async () => ({ isError: false, content: [{ type: 'text', text: 'ok' }] })),
+    readResource: vi.fn(async () => ({ contents: [] })),
+  };
+}

--- a/plugins/sero-mcp-plugin/extension/auth/oauth-coordinator.ts
+++ b/plugins/sero-mcp-plugin/extension/auth/oauth-coordinator.ts
@@ -1,0 +1,129 @@
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { McpServerConfig } from '../config/types';
+import { clearOAuthFlowState, readOAuthFlowState } from './storage';
+import { McpOAuthProvider } from './oauth-provider';
+
+interface PendingAuthSession {
+  serverName: string;
+  serverUrl: string;
+  authUrl: string;
+  expectedState?: string;
+  transport: StreamableHTTPClientTransport;
+}
+
+export interface StartOAuthResult {
+  status: 'pending' | 'authenticated';
+  authUrl?: string;
+}
+
+export class McpOAuthCoordinator {
+  private readonly pendingSessions = new Map<string, PendingAuthSession>();
+
+  async startAuth(serverName: string, definition: McpServerConfig): Promise<StartOAuthResult> {
+    const serverUrl = definition.url?.trim();
+    if (!serverUrl) {
+      throw new Error(`Server "${serverName}" does not have an HTTP URL for OAuth authentication.`);
+    }
+
+    await this.cancelAuth(serverName);
+    await clearOAuthFlowState(serverName);
+
+    let capturedAuthUrl = '';
+    const authProvider = new McpOAuthProvider(
+      serverName,
+      serverUrl,
+      definition.oauth || {},
+      { onRedirect: async (url) => { capturedAuthUrl = url.toString(); } },
+    );
+
+    const transport = new StreamableHTTPClientTransport(new URL(serverUrl), { authProvider });
+    const client = new Client({ name: `sero-mcp-auth-${serverName}`, version: '0.1.0' });
+    let keepTransportOpen = false;
+
+    try {
+      await client.connect(transport);
+      return { status: 'authenticated' };
+    } catch (error) {
+      if (error instanceof UnauthorizedError && capturedAuthUrl) {
+        const flowState = await readOAuthFlowState(serverName);
+        this.pendingSessions.set(serverName, {
+          serverName,
+          serverUrl,
+          authUrl: capturedAuthUrl,
+          expectedState: flowState?.oauthState,
+          transport,
+        });
+        keepTransportOpen = true;
+        return {
+          status: 'pending',
+          authUrl: capturedAuthUrl,
+        };
+      }
+      throw error;
+    } finally {
+      await client.close().catch(() => {});
+      if (!keepTransportOpen) {
+        await transport.close().catch(() => {});
+      }
+    }
+  }
+
+  async completeAuth(serverName: string, callbackUrl: string): Promise<void> {
+    const session = this.pendingSessions.get(serverName);
+    if (!session) {
+      throw new Error(`No pending OAuth flow exists for server "${serverName}".`);
+    }
+
+    const parsed = parseOAuthCallbackUrl(callbackUrl, session.expectedState);
+    try {
+      await session.transport.finishAuth(parsed.code);
+    } finally {
+      this.pendingSessions.delete(serverName);
+      await clearOAuthFlowState(serverName);
+      await session.transport.close().catch(() => {});
+    }
+  }
+
+  async cancelAuth(serverName: string): Promise<void> {
+    const session = this.pendingSessions.get(serverName);
+    this.pendingSessions.delete(serverName);
+    await clearOAuthFlowState(serverName);
+    if (session) {
+      await session.transport.close().catch(() => {});
+    }
+  }
+
+  async cancelAll(): Promise<void> {
+    await Promise.all([...this.pendingSessions.keys()].map((serverName) => this.cancelAuth(serverName)));
+  }
+}
+
+export function parseOAuthCallbackUrl(callbackUrl: string, expectedState?: string): { code: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(callbackUrl);
+  } catch {
+    throw new Error('The OAuth callback URL was invalid.');
+  }
+
+  const error = parsed.searchParams.get('error');
+  if (error) {
+    throw new Error(`OAuth authorization failed: ${error}`);
+  }
+
+  const code = parsed.searchParams.get('code');
+  if (!code) {
+    throw new Error('The OAuth callback did not include an authorization code.');
+  }
+
+  if (expectedState) {
+    const returnedState = parsed.searchParams.get('state');
+    if (returnedState !== expectedState) {
+      throw new Error('The OAuth callback state did not match the pending authorization request.');
+    }
+  }
+
+  return { code };
+}

--- a/plugins/sero-mcp-plugin/extension/auth/oauth-provider.ts
+++ b/plugins/sero-mcp-plugin/extension/auth/oauth-provider.ts
@@ -1,0 +1,196 @@
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+  OAuthClientInformation,
+  OAuthClientInformationFull,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import type { McpOAuthConfig } from '../config/types';
+import {
+  clearOAuthClientInfo,
+  clearOAuthCredentials,
+  clearOAuthFlowState,
+  clearOAuthTokens,
+  readOAuthClientInfo,
+  readOAuthFlowState,
+  readOAuthTokens,
+  writeOAuthClientInfo,
+  writeOAuthFlowState,
+  writeOAuthTokens,
+} from './storage';
+
+const DEFAULT_OAUTH_CALLBACK_PORT = 19876;
+const OAUTH_CALLBACK_PATH = '/mcp/oauth/callback';
+
+export interface McpOAuthCallbacks {
+  onRedirect: (url: URL) => void | Promise<void>;
+}
+
+export function getOAuthCallbackUrl(): string {
+  return `http://127.0.0.1:${DEFAULT_OAUTH_CALLBACK_PORT}${OAUTH_CALLBACK_PATH}`;
+}
+
+export class McpOAuthProvider implements OAuthClientProvider {
+  constructor(
+    private readonly serverName: string,
+    private readonly serverUrl: string,
+    private readonly config: McpOAuthConfig,
+    private readonly callbacks: McpOAuthCallbacks,
+  ) {}
+
+  private get usesClientCredentials(): boolean {
+    return this.config.grantType === 'client_credentials';
+  }
+
+  get redirectUrl(): string | undefined {
+    return this.usesClientCredentials ? undefined : getOAuthCallbackUrl();
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    if (this.usesClientCredentials) {
+      return {
+        client_name: 'Sero MCP',
+        redirect_uris: [],
+        grant_types: ['client_credentials'],
+        token_endpoint_auth_method: this.config.clientSecret ? 'client_secret_post' : 'none',
+      };
+    }
+
+    return {
+      redirect_uris: [getOAuthCallbackUrl()],
+      client_name: 'Sero MCP',
+      client_uri: 'https://github.com/mariozechner/sero',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: this.config.clientSecret ? 'client_secret_post' : 'none',
+    };
+  }
+
+  async clientInformation(): Promise<OAuthClientInformation | undefined> {
+    if (this.config.clientId) {
+      return {
+        client_id: this.config.clientId,
+        client_secret: this.config.clientSecret,
+      };
+    }
+
+    const clientInfo = await readOAuthClientInfo(this.serverName, this.serverUrl);
+    if (!clientInfo) {
+      return undefined;
+    }
+    if (clientInfo.clientSecretExpiresAt && clientInfo.clientSecretExpiresAt < Date.now() / 1000) {
+      return undefined;
+    }
+
+    return {
+      client_id: clientInfo.clientId,
+      client_secret: clientInfo.clientSecret,
+    };
+  }
+
+  async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
+    await writeOAuthClientInfo(this.serverName, {
+      clientId: info.client_id,
+      clientSecret: info.client_secret,
+      clientIdIssuedAt: info.client_id_issued_at,
+      clientSecretExpiresAt: info.client_secret_expires_at,
+      serverUrl: this.serverUrl,
+    });
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const tokens = await readOAuthTokens(this.serverName, this.serverUrl);
+    if (!tokens) {
+      return undefined;
+    }
+
+    return {
+      access_token: tokens.accessToken,
+      token_type: 'Bearer',
+      refresh_token: tokens.refreshToken,
+      expires_in: tokens.expiresAt
+        ? Math.max(0, Math.floor(tokens.expiresAt - Date.now() / 1000))
+        : undefined,
+      scope: tokens.scope,
+    };
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await writeOAuthTokens(this.serverName, {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: tokens.expires_in ? Date.now() / 1000 + tokens.expires_in : undefined,
+      scope: tokens.scope,
+      serverUrl: this.serverUrl,
+    });
+  }
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    if (this.usesClientCredentials) {
+      throw new Error('redirectToAuthorization is not used for client_credentials flow');
+    }
+    await this.callbacks.onRedirect(authorizationUrl);
+  }
+
+  async saveCodeVerifier(codeVerifier: string): Promise<void> {
+    await writeOAuthFlowState(this.serverName, {
+      codeVerifier,
+      serverUrl: this.serverUrl,
+    });
+  }
+
+  async codeVerifier(): Promise<string> {
+    if (this.usesClientCredentials) {
+      throw new Error('codeVerifier is not used for client_credentials flow');
+    }
+    const flowState = await readOAuthFlowState(this.serverName);
+    if (!flowState?.codeVerifier) {
+      throw new Error(`No code verifier saved for MCP server: ${this.serverName}`);
+    }
+    return flowState.codeVerifier;
+  }
+
+  async saveState(state: string): Promise<void> {
+    await writeOAuthFlowState(this.serverName, {
+      oauthState: state,
+      serverUrl: this.serverUrl,
+    });
+  }
+
+  async state(): Promise<string> {
+    if (this.usesClientCredentials) {
+      throw new Error('state is not used for client_credentials flow');
+    }
+    const flowState = await readOAuthFlowState(this.serverName);
+    if (!flowState?.oauthState) {
+      throw new Error(`No OAuth state saved for MCP server: ${this.serverName}`);
+    }
+    return flowState.oauthState;
+  }
+
+  async invalidateCredentials(type: 'all' | 'client' | 'tokens'): Promise<void> {
+    if (type === 'all') {
+      await clearOAuthCredentials(this.serverName);
+      return;
+    }
+    if (type === 'client') {
+      await clearOAuthClientInfo(this.serverName);
+      return;
+    }
+    await clearOAuthTokens(this.serverName);
+    await clearOAuthFlowState(this.serverName);
+  }
+
+  prepareTokenRequest(scope?: string): URLSearchParams | undefined {
+    if (!this.usesClientCredentials) {
+      return undefined;
+    }
+
+    const params = new URLSearchParams({ grant_type: 'client_credentials' });
+    const requestedScope = scope ?? this.config.scope;
+    if (requestedScope) {
+      params.set('scope', requestedScope);
+    }
+    return params;
+  }
+}

--- a/plugins/sero-mcp-plugin/extension/auth/storage.ts
+++ b/plugins/sero-mcp-plugin/extension/auth/storage.ts
@@ -1,11 +1,41 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { getMcpOAuthDir, getMcpOAuthTokenPath } from '../state/paths';
+import {
+  getMcpOAuthClientPath,
+  getMcpOAuthDir,
+  getMcpOAuthFlowPath,
+  getMcpOAuthServerDir,
+  getMcpOAuthTokenPath,
+} from '../state/paths';
 
-export type McpStoredTokens = Record<string, unknown>;
+export interface McpStoredTokens {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  scope?: string;
+  serverUrl?: string;
+}
+
+export interface McpStoredClientInfo {
+  clientId: string;
+  clientSecret?: string;
+  clientIdIssuedAt?: number;
+  clientSecretExpiresAt?: number;
+  serverUrl?: string;
+}
+
+export interface McpStoredOAuthFlowState {
+  oauthState?: string;
+  codeVerifier?: string;
+  serverUrl?: string;
+}
 
 function isMissingFileError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
@@ -15,30 +45,100 @@ async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
   await fs.rename(tmpPath, filePath);
 }
 
-export async function readOAuthTokens(serverName: string): Promise<McpStoredTokens | null> {
+async function readJsonFile(filePath: string): Promise<Record<string, unknown> | null> {
   try {
-    const raw = await fs.readFile(getMcpOAuthTokenPath(serverName), 'utf8');
+    const raw = await fs.readFile(filePath, 'utf8');
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed as McpStoredTokens;
+    return isRecord(parsed) ? parsed : null;
   } catch (error) {
     if (isMissingFileError(error)) return null;
     throw error;
   }
 }
 
+export async function readOAuthTokens(serverName: string, serverUrl?: string): Promise<McpStoredTokens | null> {
+  const parsed = await readJsonFile(getMcpOAuthTokenPath(serverName));
+  if (!parsed || typeof parsed.accessToken !== 'string') {
+    return null;
+  }
+  if (serverUrl && typeof parsed.serverUrl === 'string' && parsed.serverUrl !== serverUrl) {
+    return null;
+  }
+  return {
+    accessToken: parsed.accessToken,
+    refreshToken: typeof parsed.refreshToken === 'string' ? parsed.refreshToken : undefined,
+    expiresAt: typeof parsed.expiresAt === 'number' ? parsed.expiresAt : undefined,
+    scope: typeof parsed.scope === 'string' ? parsed.scope : undefined,
+    serverUrl: typeof parsed.serverUrl === 'string' ? parsed.serverUrl : undefined,
+  };
+}
+
 export async function writeOAuthTokens(serverName: string, tokens: McpStoredTokens): Promise<void> {
   await writeJsonFile(getMcpOAuthTokenPath(serverName), tokens);
 }
 
-export async function hasOAuthTokens(serverName: string): Promise<boolean> {
-  return (await readOAuthTokens(serverName)) !== null;
+export async function hasOAuthTokens(serverName: string, serverUrl?: string): Promise<boolean> {
+  return (await readOAuthTokens(serverName, serverUrl)) !== null;
 }
 
 export async function clearOAuthTokens(serverName: string): Promise<void> {
-  await fs.rm(path.dirname(getMcpOAuthTokenPath(serverName)), { recursive: true, force: true });
+  await fs.rm(getMcpOAuthTokenPath(serverName), { force: true });
+}
+
+export async function readOAuthClientInfo(
+  serverName: string,
+  serverUrl?: string,
+): Promise<McpStoredClientInfo | null> {
+  const parsed = await readJsonFile(getMcpOAuthClientPath(serverName));
+  if (!parsed || typeof parsed.clientId !== 'string') {
+    return null;
+  }
+  if (serverUrl && typeof parsed.serverUrl === 'string' && parsed.serverUrl !== serverUrl) {
+    return null;
+  }
+  return {
+    clientId: parsed.clientId,
+    clientSecret: typeof parsed.clientSecret === 'string' ? parsed.clientSecret : undefined,
+    clientIdIssuedAt: typeof parsed.clientIdIssuedAt === 'number' ? parsed.clientIdIssuedAt : undefined,
+    clientSecretExpiresAt: typeof parsed.clientSecretExpiresAt === 'number' ? parsed.clientSecretExpiresAt : undefined,
+    serverUrl: typeof parsed.serverUrl === 'string' ? parsed.serverUrl : undefined,
+  };
+}
+
+export async function writeOAuthClientInfo(serverName: string, clientInfo: McpStoredClientInfo): Promise<void> {
+  await writeJsonFile(getMcpOAuthClientPath(serverName), clientInfo);
+}
+
+export async function clearOAuthClientInfo(serverName: string): Promise<void> {
+  await fs.rm(getMcpOAuthClientPath(serverName), { force: true });
+}
+
+export async function readOAuthFlowState(serverName: string): Promise<McpStoredOAuthFlowState | null> {
+  const parsed = await readJsonFile(getMcpOAuthFlowPath(serverName));
+  if (!parsed) {
+    return null;
+  }
+  return {
+    oauthState: typeof parsed.oauthState === 'string' ? parsed.oauthState : undefined,
+    codeVerifier: typeof parsed.codeVerifier === 'string' ? parsed.codeVerifier : undefined,
+    serverUrl: typeof parsed.serverUrl === 'string' ? parsed.serverUrl : undefined,
+  };
+}
+
+export async function writeOAuthFlowState(serverName: string, flowState: McpStoredOAuthFlowState): Promise<void> {
+  const existing = await readOAuthFlowState(serverName);
+  await writeJsonFile(getMcpOAuthFlowPath(serverName), {
+    ...(existing ?? {}),
+    ...flowState,
+  });
+}
+
+export async function clearOAuthFlowState(serverName: string): Promise<void> {
+  await fs.rm(getMcpOAuthFlowPath(serverName), { force: true });
+}
+
+export async function clearOAuthCredentials(serverName: string): Promise<void> {
+  await fs.rm(getMcpOAuthServerDir(serverName), { recursive: true, force: true });
 }
 
 export async function ensureOAuthDir(): Promise<string> {

--- a/plugins/sero-mcp-plugin/extension/auth/storage.ts
+++ b/plugins/sero-mcp-plugin/extension/auth/storage.ts
@@ -1,0 +1,44 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { getMcpOAuthDir, getMcpOAuthTokenPath } from '../state/paths';
+
+export type McpStoredTokens = Record<string, unknown>;
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(value, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+export async function readOAuthTokens(serverName: string): Promise<McpStoredTokens | null> {
+  try {
+    const raw = await fs.readFile(getMcpOAuthTokenPath(serverName), 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as McpStoredTokens;
+  } catch (error) {
+    if (isMissingFileError(error)) return null;
+    throw error;
+  }
+}
+
+export async function writeOAuthTokens(serverName: string, tokens: McpStoredTokens): Promise<void> {
+  await writeJsonFile(getMcpOAuthTokenPath(serverName), tokens);
+}
+
+export async function clearOAuthTokens(serverName: string): Promise<void> {
+  await fs.rm(path.dirname(getMcpOAuthTokenPath(serverName)), { recursive: true, force: true });
+}
+
+export async function ensureOAuthDir(): Promise<string> {
+  const dir = getMcpOAuthDir();
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}

--- a/plugins/sero-mcp-plugin/extension/auth/storage.ts
+++ b/plugins/sero-mcp-plugin/extension/auth/storage.ts
@@ -33,6 +33,10 @@ export async function writeOAuthTokens(serverName: string, tokens: McpStoredToke
   await writeJsonFile(getMcpOAuthTokenPath(serverName), tokens);
 }
 
+export async function hasOAuthTokens(serverName: string): Promise<boolean> {
+  return (await readOAuthTokens(serverName)) !== null;
+}
+
 export async function clearOAuthTokens(serverName: string): Promise<void> {
   await fs.rm(path.dirname(getMcpOAuthTokenPath(serverName)), { recursive: true, force: true });
 }

--- a/plugins/sero-mcp-plugin/extension/cache/metadata-cache.ts
+++ b/plugins/sero-mcp-plugin/extension/cache/metadata-cache.ts
@@ -1,0 +1,59 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { getMcpMetadataCachePath } from '../state/paths';
+
+export interface McpMetadataCacheEntry {
+  cachedAt: number;
+  toolCount?: number;
+  resourceCount?: number;
+}
+
+export interface McpMetadataCacheDocument {
+  version: 1;
+  servers: Record<string, McpMetadataCacheEntry>;
+}
+
+export const DEFAULT_METADATA_CACHE: McpMetadataCacheDocument = {
+  version: 1,
+  servers: {},
+};
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function normalizeCache(raw: unknown): McpMetadataCacheDocument {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...DEFAULT_METADATA_CACHE };
+  }
+
+  const parsed = raw as Partial<McpMetadataCacheDocument>;
+  return {
+    version: 1,
+    servers: parsed.servers && typeof parsed.servers === 'object' && !Array.isArray(parsed.servers)
+      ? parsed.servers
+      : {},
+  };
+}
+
+export async function readMetadataCache(filePath = getMcpMetadataCachePath()): Promise<McpMetadataCacheDocument> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return normalizeCache(JSON.parse(raw));
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return { ...DEFAULT_METADATA_CACHE };
+    }
+    throw error;
+  }
+}
+
+export async function writeMetadataCache(
+  cache: McpMetadataCacheDocument,
+  filePath = getMcpMetadataCachePath(),
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(cache, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}

--- a/plugins/sero-mcp-plugin/extension/cache/metadata-cache.ts
+++ b/plugins/sero-mcp-plugin/extension/cache/metadata-cache.ts
@@ -1,11 +1,29 @@
+import { createHash } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import type { McpServerConfig } from '../config/types';
 import { getMcpMetadataCachePath } from '../state/paths';
+
+export interface CachedMcpTool {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  uiResourceUri?: string;
+}
+
+export interface CachedMcpResource {
+  uri: string;
+  name: string;
+  description?: string;
+}
 
 export interface McpMetadataCacheEntry {
   cachedAt: number;
-  toolCount?: number;
-  resourceCount?: number;
+  configHash: string;
+  toolCount: number;
+  resourceCount: number;
+  tools: CachedMcpTool[];
+  resources: CachedMcpResource[];
 }
 
 export interface McpMetadataCacheDocument {
@@ -22,17 +40,49 @@ function isMissingFileError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeCacheEntry(raw: unknown): McpMetadataCacheEntry | null {
+  if (!isRecord(raw)) return null;
+  return {
+    cachedAt: typeof raw.cachedAt === 'number' ? raw.cachedAt : Date.now(),
+    configHash: typeof raw.configHash === 'string' ? raw.configHash : '',
+    toolCount: typeof raw.toolCount === 'number' ? raw.toolCount : 0,
+    resourceCount: typeof raw.resourceCount === 'number' ? raw.resourceCount : 0,
+    tools: Array.isArray(raw.tools) ? raw.tools.filter(isRecord).map((tool) => ({
+      name: typeof tool.name === 'string' ? tool.name : '',
+      description: typeof tool.description === 'string' ? tool.description : undefined,
+      inputSchema: tool.inputSchema,
+      uiResourceUri: typeof tool.uiResourceUri === 'string' ? tool.uiResourceUri : undefined,
+    })).filter((tool) => tool.name.length > 0) : [],
+    resources: Array.isArray(raw.resources) ? raw.resources.filter(isRecord).map((resource) => ({
+      uri: typeof resource.uri === 'string' ? resource.uri : '',
+      name: typeof resource.name === 'string' ? resource.name : 'Resource',
+      description: typeof resource.description === 'string' ? resource.description : undefined,
+    })).filter((resource) => resource.uri.length > 0) : [],
+  };
+}
+
 function normalizeCache(raw: unknown): McpMetadataCacheDocument {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+  if (!isRecord(raw)) {
     return { ...DEFAULT_METADATA_CACHE };
   }
 
-  const parsed = raw as Partial<McpMetadataCacheDocument>;
+  const servers: Record<string, McpMetadataCacheEntry> = {};
+  if (isRecord(raw.servers)) {
+    for (const [serverName, entry] of Object.entries(raw.servers)) {
+      const normalized = normalizeCacheEntry(entry);
+      if (normalized) {
+        servers[serverName] = normalized;
+      }
+    }
+  }
+
   return {
     version: 1,
-    servers: parsed.servers && typeof parsed.servers === 'object' && !Array.isArray(parsed.servers)
-      ? parsed.servers
-      : {},
+    servers,
   };
 }
 
@@ -56,4 +106,73 @@ export async function writeMetadataCache(
   const tmpPath = `${filePath}.tmp.${Date.now()}`;
   await fs.writeFile(tmpPath, JSON.stringify(cache, null, 2), 'utf8');
   await fs.rename(tmpPath, filePath);
+}
+
+export function computeServerHash(definition: McpServerConfig): string {
+  const identity: Record<string, unknown> = {
+    transport: definition.transport,
+    command: definition.command,
+    args: definition.args,
+    env: definition.env,
+    cwd: definition.cwd,
+    url: definition.url,
+    headers: definition.headers,
+    auth: definition.auth,
+    bearerToken: definition.bearerToken,
+    bearerTokenEnv: definition.bearerTokenEnv,
+    oauth: definition.oauth,
+    exposeResources: definition.exposeResources,
+    excludeTools: definition.excludeTools,
+  };
+  return createHash('sha256').update(stableStringify(identity)).digest('hex');
+}
+
+export function isMetadataCacheEntryValid(
+  entry: McpMetadataCacheEntry | undefined,
+  definition: McpServerConfig,
+): boolean {
+  return !!entry && entry.configHash === computeServerHash(definition);
+}
+
+export function setMetadataCacheEntry(
+  cache: McpMetadataCacheDocument,
+  serverName: string,
+  entry: McpMetadataCacheEntry,
+): McpMetadataCacheDocument {
+  return {
+    ...cache,
+    servers: {
+      ...cache.servers,
+      [serverName]: entry,
+    },
+  };
+}
+
+export function removeMetadataCacheEntry(
+  cache: McpMetadataCacheDocument,
+  serverName: string,
+): McpMetadataCacheDocument {
+  const nextServers = { ...cache.servers };
+  delete nextServers[serverName];
+  return {
+    ...cache,
+    servers: nextServers,
+  };
+}
+
+export function createEmptyMetadataCache(): McpMetadataCacheDocument {
+  return { ...DEFAULT_METADATA_CACHE, servers: {} };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || value === undefined || typeof value !== 'object') {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? 'undefined' : serialized;
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(',')}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`).join(',')}}`;
 }

--- a/plugins/sero-mcp-plugin/extension/config/io.ts
+++ b/plugins/sero-mcp-plugin/extension/config/io.ts
@@ -54,6 +54,7 @@ function normalizeServerConfig(value: unknown): McpServerConfig | null {
   if (!isRecord(value)) return null;
   const next: McpServerConfig = { ...value };
   if (typeof value.enabled === 'boolean') next.enabled = value.enabled;
+  if (value.transport === 'stdio' || value.transport === 'http') next.transport = value.transport;
   if (typeof value.command === 'string') next.command = value.command;
   if (typeof value.cwd === 'string') next.cwd = value.cwd;
   if (typeof value.url === 'string') next.url = value.url;

--- a/plugins/sero-mcp-plugin/extension/config/io.ts
+++ b/plugins/sero-mcp-plugin/extension/config/io.ts
@@ -1,0 +1,148 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { getMcpConfigPath } from '../state/paths';
+import type { McpConfigDocument, McpConfigSettings, McpOAuthConfig, McpServerConfig } from './types';
+import { createDefaultMcpConfig } from './types';
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function normalizeStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined;
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  );
+}
+
+function normalizeOAuthConfig(value: unknown): McpOAuthConfig | false | undefined {
+  if (value === false) return false;
+  if (!isRecord(value)) return undefined;
+  const next: McpOAuthConfig = { ...value };
+  if (value.grantType === 'authorization_code' || value.grantType === 'client_credentials') {
+    next.grantType = value.grantType;
+  }
+  if (typeof value.clientId === 'string') next.clientId = value.clientId;
+  if (typeof value.clientSecret === 'string') next.clientSecret = value.clientSecret;
+  if (typeof value.scope === 'string') next.scope = value.scope;
+  return next;
+}
+
+function normalizeSettings(value: unknown): McpConfigSettings {
+  const defaults = createDefaultMcpConfig().settings ?? {};
+  if (!isRecord(value)) return { ...defaults };
+  return {
+    ...value,
+    idleTimeout: typeof value.idleTimeout === 'number' ? value.idleTimeout : defaults.idleTimeout,
+    toolPrefix:
+      value.toolPrefix === 'server' || value.toolPrefix === 'short' || value.toolPrefix === 'none'
+        ? value.toolPrefix
+        : defaults.toolPrefix,
+  };
+}
+
+function normalizeServerConfig(value: unknown): McpServerConfig | null {
+  if (!isRecord(value)) return null;
+  const next: McpServerConfig = { ...value };
+  if (typeof value.enabled === 'boolean') next.enabled = value.enabled;
+  if (typeof value.command === 'string') next.command = value.command;
+  if (typeof value.cwd === 'string') next.cwd = value.cwd;
+  if (typeof value.url === 'string') next.url = value.url;
+  if (typeof value.bearerToken === 'string') next.bearerToken = value.bearerToken;
+  if (typeof value.bearerTokenEnv === 'string') next.bearerTokenEnv = value.bearerTokenEnv;
+  if (value.auth === 'oauth' || value.auth === 'bearer' || value.auth === false) next.auth = value.auth;
+  if (value.lifecycle === 'lazy' || value.lifecycle === 'eager' || value.lifecycle === 'keep-alive') {
+    next.lifecycle = value.lifecycle;
+  }
+  if (typeof value.idleTimeout === 'number') next.idleTimeout = value.idleTimeout;
+  if (typeof value.exposeResources === 'boolean') next.exposeResources = value.exposeResources;
+  if (typeof value.debug === 'boolean') next.debug = value.debug;
+  const args = normalizeStringArray(value.args);
+  if (args) next.args = args;
+  const excludeTools = normalizeStringArray(value.excludeTools);
+  if (excludeTools) next.excludeTools = excludeTools;
+  const env = normalizeStringRecord(value.env);
+  if (env) next.env = env;
+  const headers = normalizeStringRecord(value.headers);
+  if (headers) next.headers = headers;
+  const oauth = normalizeOAuthConfig(value.oauth);
+  if (oauth !== undefined) next.oauth = oauth;
+  return next;
+}
+
+export function normalizeConfigDocument(raw: unknown): McpConfigDocument {
+  const defaults = createDefaultMcpConfig();
+  if (!isRecord(raw)) return defaults;
+
+  const servers: Record<string, McpServerConfig> = {};
+  if (isRecord(raw.mcpServers)) {
+    for (const [serverName, serverConfig] of Object.entries(raw.mcpServers)) {
+      const normalized = normalizeServerConfig(serverConfig);
+      if (normalized) {
+        servers[serverName] = normalized;
+      }
+    }
+  }
+
+  return {
+    ...raw,
+    settings: normalizeSettings(raw.settings),
+    mcpServers: servers,
+  };
+}
+
+export async function readConfig(filePath = getMcpConfigPath()): Promise<McpConfigDocument> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return normalizeConfigDocument(JSON.parse(raw));
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return createDefaultMcpConfig();
+    }
+    throw error;
+  }
+}
+
+export async function writeConfig(config: McpConfigDocument, filePath = getMcpConfigPath()): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(config, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+export async function ensureConfigFile(filePath = getMcpConfigPath()): Promise<McpConfigDocument> {
+  const config = await readConfig(filePath);
+  await writeConfig(config, filePath);
+  return config;
+}
+
+export async function readRawConfig(filePath = getMcpConfigPath()): Promise<string> {
+  try {
+    return await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      const config = createDefaultMcpConfig();
+      return `${JSON.stringify(config, null, 2)}\n`;
+    }
+    throw error;
+  }
+}
+
+export async function getConfigUpdatedAt(filePath = getMcpConfigPath()): Promise<string | null> {
+  try {
+    const stat = await fs.stat(filePath);
+    return stat.mtime.toISOString();
+  } catch (error) {
+    if (isMissingFileError(error)) return null;
+    throw error;
+  }
+}

--- a/plugins/sero-mcp-plugin/extension/config/types.ts
+++ b/plugins/sero-mcp-plugin/extension/config/types.ts
@@ -44,3 +44,25 @@ export function createDefaultMcpConfig(): McpConfigDocument {
     mcpServers: {},
   };
 }
+
+export function isResourceExposureEnabled(serverConfig: McpServerConfig): boolean {
+  return serverConfig.exposeResources !== false;
+}
+
+export function resolveBearerTokenValue(serverConfig: McpServerConfig): string | undefined {
+  if (typeof serverConfig.bearerToken === 'string' && serverConfig.bearerToken.length > 0) {
+    return serverConfig.bearerToken;
+  }
+
+  const envName = serverConfig.bearerTokenEnv?.trim();
+  if (!envName) {
+    return undefined;
+  }
+
+  const envValue = process.env[envName];
+  return typeof envValue === 'string' && envValue.length > 0 ? envValue : undefined;
+}
+
+export function hasBearerTokenValue(serverConfig: McpServerConfig): boolean {
+  return !!resolveBearerTokenValue(serverConfig);
+}

--- a/plugins/sero-mcp-plugin/extension/config/types.ts
+++ b/plugins/sero-mcp-plugin/extension/config/types.ts
@@ -10,6 +10,7 @@ export interface McpOAuthConfig extends Record<string, unknown> {
 
 export interface McpServerConfig extends Record<string, unknown> {
   enabled?: boolean;
+  transport?: 'stdio' | 'http';
   command?: string;
   args?: string[];
   env?: Record<string, string>;

--- a/plugins/sero-mcp-plugin/extension/config/types.ts
+++ b/plugins/sero-mcp-plugin/extension/config/types.ts
@@ -1,0 +1,45 @@
+import type { McpLifecycle, McpToolPrefix } from '../../shared/types';
+import { DEFAULT_MCP_SETTINGS } from '../../shared/types';
+
+export interface McpOAuthConfig extends Record<string, unknown> {
+  grantType?: 'authorization_code' | 'client_credentials';
+  clientId?: string;
+  clientSecret?: string;
+  scope?: string;
+}
+
+export interface McpServerConfig extends Record<string, unknown> {
+  enabled?: boolean;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  auth?: 'oauth' | 'bearer' | false;
+  bearerToken?: string;
+  bearerTokenEnv?: string;
+  oauth?: McpOAuthConfig | false;
+  lifecycle?: McpLifecycle;
+  idleTimeout?: number;
+  exposeResources?: boolean;
+  excludeTools?: string[];
+  debug?: boolean;
+}
+
+export interface McpConfigSettings extends Record<string, unknown> {
+  idleTimeout?: number;
+  toolPrefix?: McpToolPrefix;
+}
+
+export interface McpConfigDocument extends Record<string, unknown> {
+  settings?: McpConfigSettings;
+  mcpServers: Record<string, McpServerConfig>;
+}
+
+export function createDefaultMcpConfig(): McpConfigDocument {
+  return {
+    settings: { ...DEFAULT_MCP_SETTINGS },
+    mcpServers: {},
+  };
+}

--- a/plugins/sero-mcp-plugin/extension/index.ts
+++ b/plugins/sero-mcp-plugin/extension/index.ts
@@ -1,0 +1,183 @@
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Type } from '@sinclair/typebox';
+import { ensureOAuthDir } from './auth/storage';
+import { readMetadataCache, writeMetadataCache } from './cache/metadata-cache';
+import { ensureConfigFile, getConfigUpdatedAt, readRawConfig } from './config/io';
+import { createSnapshotFromConfig, writeState } from './state/state-io';
+import { getMcpConfigPath, getMcpStatePath } from './state/paths';
+
+const ManagerParams = Type.Object({
+  action: StringEnum(['bootstrap', 'refresh', 'get_raw_config'] as const),
+});
+
+const ProxyParams = Type.Object({
+  action: Type.Optional(StringEnum(['status', 'list'] as const)),
+});
+
+type ManagerAction = 'bootstrap' | 'refresh' | 'get_raw_config';
+type ProxyAction = 'status' | 'list';
+type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  details: Record<string, unknown>;
+};
+type CliResult = {
+  output: string;
+  exitCode: number;
+};
+type CliContext = {
+  cwd: string;
+};
+type ToolWithCli = Parameters<ExtensionAPI['registerTool']>[0] & {
+  cli: {
+    summary: string;
+    help: string;
+    execute: (args: string[], ctx: CliContext) => Promise<CliResult>;
+  };
+};
+
+export default function mcpExtension(pi: ExtensionAPI) {
+  pi.on('session_start', async (_event, ctx) => {
+    await syncSnapshot(ctx.cwd).catch((error) => {
+      console.error('[mcp] Failed to bootstrap snapshot on session start', error);
+    });
+  });
+
+  pi.on('session_switch', async (_event, ctx) => {
+    await syncSnapshot(ctx.cwd).catch((error) => {
+      console.error('[mcp] Failed to refresh snapshot on session switch', error);
+    });
+  });
+
+  pi.registerTool({
+    name: 'mcp_manager',
+    label: 'MCP Manager',
+    description:
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, get_raw_config.',
+    parameters: ManagerParams,
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const action = (params.action ?? 'bootstrap') as ManagerAction;
+      return runManagerAction(action, ctx?.cwd);
+    },
+  });
+
+  const mcpTool: ToolWithCli = {
+    name: 'mcp',
+    label: 'MCP',
+    description:
+      'Initial MCP control surface for Sero. Actions: status or list configured MCP servers while the full proxy experience is being built.',
+    parameters: ProxyParams,
+    cli: {
+      summary: 'Inspect configured MCP servers',
+      help: 'sero mcp status | list',
+      async execute(args: string[], ctx: CliContext) {
+        const action = parseCliAction(args);
+        const result = await runProxyAction(action, ctx.cwd);
+        return {
+          output: result.content[0]?.text ?? '',
+          exitCode: result.content[0]?.text?.startsWith('Error:') ? 1 : 0,
+        };
+      },
+    },
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const proxyParams = params as { action?: ProxyAction };
+      return runProxyAction(proxyParams.action ?? 'status', ctx?.cwd);
+    },
+  };
+
+  pi.registerTool(mcpTool);
+}
+
+function parseCliAction(args: string[]): ProxyAction {
+  const subcommand = args[0]?.trim();
+  if (subcommand === 'list') return 'list';
+  return 'status';
+}
+
+async function runManagerAction(action: ManagerAction, cwd?: string): Promise<ToolResult> {
+  const synced = await syncSnapshot(cwd);
+
+  if (action === 'get_raw_config') {
+    const rawConfig = await readRawConfig(synced.configPath);
+    return toToolResult(rawConfig.trim() || '{}', {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      rawConfig,
+    });
+  }
+
+  const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
+  return toToolResult(`${prefix} MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`, {
+    snapshotWritten: true,
+    configPath: synced.configPath,
+    statePath: synced.statePath,
+    serverCount: synced.snapshot.summary.totalServers,
+  });
+}
+
+async function runProxyAction(action: ProxyAction, cwd?: string): Promise<ToolResult> {
+  const synced = await syncSnapshot(cwd);
+  if (action === 'list') {
+    return toToolResult(formatServerList(synced.snapshot.servers), {
+      mode: 'list',
+      serverCount: synced.snapshot.summary.totalServers,
+    });
+  }
+
+  return toToolResult(formatStatusSummary(synced.snapshot), {
+    mode: 'status',
+    serverCount: synced.snapshot.summary.totalServers,
+  });
+}
+
+async function syncSnapshot(cwd?: string) {
+  const configPath = getMcpConfigPath();
+  const statePath = getMcpStatePath(cwd);
+  const config = await ensureConfigFile(configPath);
+  const rawConfigUpdatedAt = await getConfigUpdatedAt(configPath);
+  const metadataCache = await readMetadataCache();
+  await Promise.all([
+    ensureOAuthDir(),
+    writeMetadataCache(metadataCache),
+  ]);
+  const snapshot = createSnapshotFromConfig(configPath, config, rawConfigUpdatedAt);
+  await writeState(snapshot, statePath);
+  return { configPath, statePath, snapshot };
+}
+
+function formatStatusSummary(snapshot: Awaited<ReturnType<typeof syncSnapshot>>['snapshot']): string {
+  const lines = [
+    `MCP status: ${snapshot.summary.totalServers} server(s) configured`,
+    `Enabled: ${snapshot.summary.enabledServers}`,
+    `Connected: ${snapshot.summary.connectedServers}`,
+    `Needs auth: ${snapshot.summary.needsAuthServers}`,
+    `Errors: ${snapshot.summary.errorServers}`,
+  ];
+
+  if (snapshot.servers.length === 0) {
+    lines.push('', 'Open the MCP app in Sero to add your first MCP server.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatServerList(servers: Array<{ serverName: string; enabled: boolean; connectionStatus: string; authStatus: string }>): string {
+  if (servers.length === 0) {
+    return 'No MCP servers are configured yet. Open the MCP app in Sero to add one.';
+  }
+
+  return servers
+    .map((server) => {
+      const enabledLabel = server.enabled ? 'enabled' : 'disabled';
+      return `- ${server.serverName} (${enabledLabel}, ${server.connectionStatus}, ${server.authStatus})`;
+    })
+    .join('\n');
+}
+
+function toToolResult(text: string, details: Record<string, unknown> = {}): ToolResult {
+  return {
+    content: [{ type: 'text', text }],
+    details,
+  };
+}

--- a/plugins/sero-mcp-plugin/extension/index.ts
+++ b/plugins/sero-mcp-plugin/extension/index.ts
@@ -1,214 +1,31 @@
-import { StringEnum } from '@mariozechner/pi-ai';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Type } from '@sinclair/typebox';
-import { ensureOAuthDir } from './auth/storage';
-import { readMetadataCache, writeMetadataCache } from './cache/metadata-cache';
-import { ensureConfigFile, getConfigUpdatedAt, normalizeConfigDocument, readRawConfig, writeConfig } from './config/io';
-import { createSnapshotFromConfig, writeState } from './state/state-io';
-import { getMcpConfigPath, getMcpStatePath } from './state/paths';
+import { getMcpRuntime } from './runtime/mcp-runtime';
+import { registerMcpManagerTool } from './tools/manager-tool';
+import { registerMcpProxyTool } from './tools/proxy-tool';
 
-const ManagerParams = Type.Object({
-  action: StringEnum(['bootstrap', 'refresh', 'get_raw_config', 'save_raw_config'] as const),
-  rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
-});
-
-const ProxyParams = Type.Object({
-  action: Type.Optional(StringEnum(['status', 'list'] as const)),
-});
-
-type ManagerAction = 'bootstrap' | 'refresh' | 'get_raw_config' | 'save_raw_config';
-type ProxyAction = 'status' | 'list';
-type ToolResult = {
-  content: Array<{ type: 'text'; text: string }>;
-  details: Record<string, unknown>;
-};
-type CliResult = {
-  output: string;
-  exitCode: number;
-};
-type CliContext = {
-  cwd: string;
-};
-type ToolWithCli = Parameters<ExtensionAPI['registerTool']>[0] & {
-  cli: {
-    summary: string;
-    help: string;
-    execute: (args: string[], ctx: CliContext) => Promise<CliResult>;
-  };
-};
+const runtime = getMcpRuntime();
 
 export default function mcpExtension(pi: ExtensionAPI) {
+  runtime.attachPi(pi);
+
   pi.on('session_start', async (_event, ctx) => {
-    await syncSnapshot(ctx.cwd).catch((error) => {
-      console.error('[mcp] Failed to bootstrap snapshot on session start', error);
+    await runtime.handleSessionStart({ cwd: ctx.cwd }).catch((error) => {
+      console.error('[mcp] Failed to bootstrap runtime on session start', error);
     });
   });
 
   pi.on('session_switch', async (_event, ctx) => {
-    await syncSnapshot(ctx.cwd).catch((error) => {
-      console.error('[mcp] Failed to refresh snapshot on session switch', error);
+    await runtime.handleSessionSwitch({ cwd: ctx.cwd }).catch((error) => {
+      console.error('[mcp] Failed to refresh runtime on session switch', error);
     });
   });
 
-  pi.registerTool({
-    name: 'mcp_manager',
-    label: 'MCP Manager',
-    description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, get_raw_config, save_raw_config.',
-    parameters: ManagerParams,
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const managerParams = params as { action?: ManagerAction; rawConfig?: string };
-      const action = managerParams.action ?? 'bootstrap';
-      return runManagerAction(action, ctx?.cwd, managerParams.rawConfig);
-    },
+  pi.on('session_shutdown', async () => {
+    await runtime.handleSessionShutdown().catch((error) => {
+      console.error('[mcp] Failed to shut down runtime cleanly', error);
+    });
   });
 
-  const mcpTool: ToolWithCli = {
-    name: 'mcp',
-    label: 'MCP',
-    description:
-      'Initial MCP control surface for Sero. Actions: status or list configured MCP servers while the full proxy experience is being built.',
-    parameters: ProxyParams,
-    cli: {
-      summary: 'Inspect configured MCP servers',
-      help: 'sero mcp status | list',
-      async execute(args: string[], ctx: CliContext) {
-        const action = parseCliAction(args);
-        const result = await runProxyAction(action, ctx.cwd);
-        return {
-          output: result.content[0]?.text ?? '',
-          exitCode: result.content[0]?.text?.startsWith('Error:') ? 1 : 0,
-        };
-      },
-    },
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const proxyParams = params as { action?: ProxyAction };
-      return runProxyAction(proxyParams.action ?? 'status', ctx?.cwd);
-    },
-  };
-
-  pi.registerTool(mcpTool);
-}
-
-function parseCliAction(args: string[]): ProxyAction {
-  const subcommand = args[0]?.trim();
-  if (subcommand === 'list') return 'list';
-  return 'status';
-}
-
-async function runManagerAction(action: ManagerAction, cwd?: string, rawConfigInput?: string): Promise<ToolResult> {
-  if (action === 'save_raw_config') {
-    return saveRawConfig(cwd, rawConfigInput);
-  }
-
-  const synced = await syncSnapshot(cwd);
-
-  if (action === 'get_raw_config') {
-    const rawConfig = await readRawConfig(synced.configPath);
-    return toToolResult(rawConfig.trim() || '{}', {
-      snapshotWritten: true,
-      configPath: synced.configPath,
-      statePath: synced.statePath,
-      rawConfig,
-    });
-  }
-
-  const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
-  return toToolResult(`${prefix} MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`, {
-    snapshotWritten: true,
-    configPath: synced.configPath,
-    statePath: synced.statePath,
-    serverCount: synced.snapshot.summary.totalServers,
-  });
-}
-
-async function runProxyAction(action: ProxyAction, cwd?: string): Promise<ToolResult> {
-  const synced = await syncSnapshot(cwd);
-  if (action === 'list') {
-    return toToolResult(formatServerList(synced.snapshot.servers), {
-      mode: 'list',
-      serverCount: synced.snapshot.summary.totalServers,
-    });
-  }
-
-  return toToolResult(formatStatusSummary(synced.snapshot), {
-    mode: 'status',
-    serverCount: synced.snapshot.summary.totalServers,
-  });
-}
-
-async function syncSnapshot(cwd?: string) {
-  const configPath = getMcpConfigPath();
-  const statePath = getMcpStatePath(cwd);
-  const config = await ensureConfigFile(configPath);
-  const rawConfigUpdatedAt = await getConfigUpdatedAt(configPath);
-  const metadataCache = await readMetadataCache();
-  await Promise.all([
-    ensureOAuthDir(),
-    writeMetadataCache(metadataCache),
-  ]);
-  const snapshot = createSnapshotFromConfig(configPath, config, rawConfigUpdatedAt);
-  await writeState(snapshot, statePath);
-  return { configPath, statePath, snapshot };
-}
-
-async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
-  if (!rawConfigInput?.trim()) {
-    return toToolResult('Error: Raw config cannot be empty.', { snapshotWritten: false });
-  }
-
-  try {
-    const parsed = JSON.parse(rawConfigInput);
-    const normalized = normalizeConfigDocument(parsed);
-    const configPath = getMcpConfigPath();
-    await writeConfig(normalized, configPath);
-    const synced = await syncSnapshot(cwd);
-    return toToolResult(`Saved MCP config with ${synced.snapshot.summary.totalServers} configured server(s).`, {
-      snapshotWritten: true,
-      configPath: synced.configPath,
-      statePath: synced.statePath,
-      rawConfig: `${JSON.stringify(normalized, null, 2)}\n`,
-    });
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return toToolResult(`Error: Failed to save raw MCP config. ${message}`, {
-      snapshotWritten: false,
-    });
-  }
-}
-
-function formatStatusSummary(snapshot: Awaited<ReturnType<typeof syncSnapshot>>['snapshot']): string {
-  const lines = [
-    `MCP status: ${snapshot.summary.totalServers} server(s) configured`,
-    `Enabled: ${snapshot.summary.enabledServers}`,
-    `Connected: ${snapshot.summary.connectedServers}`,
-    `Needs auth: ${snapshot.summary.needsAuthServers}`,
-    `Errors: ${snapshot.summary.errorServers}`,
-  ];
-
-  if (snapshot.servers.length === 0) {
-    lines.push('', 'Open the MCP app in Sero to add your first MCP server.');
-  }
-
-  return lines.join('\n');
-}
-
-function formatServerList(servers: Array<{ serverName: string; enabled: boolean; connectionStatus: string; authStatus: string }>): string {
-  if (servers.length === 0) {
-    return 'No MCP servers are configured yet. Open the MCP app in Sero to add one.';
-  }
-
-  return servers
-    .map((server) => {
-      const enabledLabel = server.enabled ? 'enabled' : 'disabled';
-      return `- ${server.serverName} (${enabledLabel}, ${server.connectionStatus}, ${server.authStatus})`;
-    })
-    .join('\n');
-}
-
-function toToolResult(text: string, details: Record<string, unknown> = {}): ToolResult {
-  return {
-    content: [{ type: 'text', text }],
-    details,
-  };
+  registerMcpManagerTool(pi, runtime);
+  registerMcpProxyTool(pi, runtime);
 }

--- a/plugins/sero-mcp-plugin/extension/index.ts
+++ b/plugins/sero-mcp-plugin/extension/index.ts
@@ -3,19 +3,20 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
 import { ensureOAuthDir } from './auth/storage';
 import { readMetadataCache, writeMetadataCache } from './cache/metadata-cache';
-import { ensureConfigFile, getConfigUpdatedAt, readRawConfig } from './config/io';
+import { ensureConfigFile, getConfigUpdatedAt, normalizeConfigDocument, readRawConfig, writeConfig } from './config/io';
 import { createSnapshotFromConfig, writeState } from './state/state-io';
 import { getMcpConfigPath, getMcpStatePath } from './state/paths';
 
 const ManagerParams = Type.Object({
-  action: StringEnum(['bootstrap', 'refresh', 'get_raw_config'] as const),
+  action: StringEnum(['bootstrap', 'refresh', 'get_raw_config', 'save_raw_config'] as const),
+  rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
 });
 
 const ProxyParams = Type.Object({
   action: Type.Optional(StringEnum(['status', 'list'] as const)),
 });
 
-type ManagerAction = 'bootstrap' | 'refresh' | 'get_raw_config';
+type ManagerAction = 'bootstrap' | 'refresh' | 'get_raw_config' | 'save_raw_config';
 type ProxyAction = 'status' | 'list';
 type ToolResult = {
   content: Array<{ type: 'text'; text: string }>;
@@ -53,11 +54,12 @@ export default function mcpExtension(pi: ExtensionAPI) {
     name: 'mcp_manager',
     label: 'MCP Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, get_raw_config.',
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, get_raw_config, save_raw_config.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const action = (params.action ?? 'bootstrap') as ManagerAction;
-      return runManagerAction(action, ctx?.cwd);
+      const managerParams = params as { action?: ManagerAction; rawConfig?: string };
+      const action = managerParams.action ?? 'bootstrap';
+      return runManagerAction(action, ctx?.cwd, managerParams.rawConfig);
     },
   });
 
@@ -94,7 +96,11 @@ function parseCliAction(args: string[]): ProxyAction {
   return 'status';
 }
 
-async function runManagerAction(action: ManagerAction, cwd?: string): Promise<ToolResult> {
+async function runManagerAction(action: ManagerAction, cwd?: string, rawConfigInput?: string): Promise<ToolResult> {
+  if (action === 'save_raw_config') {
+    return saveRawConfig(cwd, rawConfigInput);
+  }
+
   const synced = await syncSnapshot(cwd);
 
   if (action === 'get_raw_config') {
@@ -144,6 +150,31 @@ async function syncSnapshot(cwd?: string) {
   const snapshot = createSnapshotFromConfig(configPath, config, rawConfigUpdatedAt);
   await writeState(snapshot, statePath);
   return { configPath, statePath, snapshot };
+}
+
+async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
+  if (!rawConfigInput?.trim()) {
+    return toToolResult('Error: Raw config cannot be empty.', { snapshotWritten: false });
+  }
+
+  try {
+    const parsed = JSON.parse(rawConfigInput);
+    const normalized = normalizeConfigDocument(parsed);
+    const configPath = getMcpConfigPath();
+    await writeConfig(normalized, configPath);
+    const synced = await syncSnapshot(cwd);
+    return toToolResult(`Saved MCP config with ${synced.snapshot.summary.totalServers} configured server(s).`, {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      rawConfig: `${JSON.stringify(normalized, null, 2)}\n`,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return toToolResult(`Error: Failed to save raw MCP config. ${message}`, {
+      snapshotWritten: false,
+    });
+  }
 }
 
 function formatStatusSummary(snapshot: Awaited<ReturnType<typeof syncSnapshot>>['snapshot']): string {

--- a/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
+++ b/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
@@ -3,7 +3,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { CallToolResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { McpOAuthProvider } from '../auth/oauth-provider';
 import type { McpServerConfig } from '../config/types';
 import type { ManagedConnection, ManagedResource, ManagedTool, ManagedTransport } from './types';
@@ -58,6 +58,18 @@ export class McpServerManager {
       throw new Error(`Server "${name}" is not connected.`);
     }
     return connection.client.readResource({ uri });
+  }
+
+  async callTool(name: string, toolName: string, toolArguments?: Record<string, unknown>): Promise<CallToolResult> {
+    const connection = this.connections.get(name);
+    if (!connection || connection.status !== 'connected' || !connection.client) {
+      throw new Error(`Server "${name}" is not connected.`);
+    }
+    const result = await connection.client.callTool({
+      name: toolName,
+      arguments: toolArguments,
+    });
+    return result as CallToolResult;
   }
 
   async close(name: string): Promise<void> {

--- a/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
+++ b/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
@@ -3,6 +3,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpServerConfig } from '../config/types';
 import type { ManagedConnection, ManagedResource, ManagedTool, ManagedTransport } from './types';
 
@@ -48,6 +49,14 @@ export class McpServerManager {
 
   getConnection(name: string): ManagedConnection | undefined {
     return this.connections.get(name);
+  }
+
+  async readResource(name: string, uri: string): Promise<ReadResourceResult> {
+    const connection = this.connections.get(name);
+    if (!connection || connection.status !== 'connected' || !connection.client) {
+      throw new Error(`Server "${name}" is not connected.`);
+    }
+    return connection.client.readResource({ uri });
   }
 
   async close(name: string): Promise<void> {

--- a/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
+++ b/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
@@ -1,0 +1,271 @@
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { McpServerConfig } from '../config/types';
+import type { ManagedConnection, ManagedResource, ManagedTool, ManagedTransport } from './types';
+
+interface McpServerManagerOptions {
+  hasOAuthTokens?: (serverName: string) => Promise<boolean>;
+}
+
+export class McpServerManager {
+  private readonly connections = new Map<string, ManagedConnection>();
+  private readonly connectPromises = new Map<string, Promise<ManagedConnection>>();
+  private readonly hasOAuthTokens: (serverName: string) => Promise<boolean>;
+
+  constructor(options: McpServerManagerOptions = {}) {
+    this.hasOAuthTokens = options.hasOAuthTokens ?? (async () => false);
+  }
+
+  async connect(name: string, definition: McpServerConfig): Promise<ManagedConnection> {
+    if (this.connectPromises.has(name)) {
+      return this.connectPromises.get(name)!;
+    }
+
+    const existing = this.connections.get(name);
+    if (existing?.status === 'connected') {
+      return existing;
+    }
+
+    const promise = this.createConnection(name, definition);
+    this.connectPromises.set(name, promise);
+
+    try {
+      const connection = await promise;
+      this.connections.set(name, connection);
+      return connection;
+    } finally {
+      this.connectPromises.delete(name);
+    }
+  }
+
+  async reconnect(name: string, definition: McpServerConfig): Promise<ManagedConnection> {
+    await this.close(name);
+    return this.connect(name, definition);
+  }
+
+  getConnection(name: string): ManagedConnection | undefined {
+    return this.connections.get(name);
+  }
+
+  async close(name: string): Promise<void> {
+    const connection = this.connections.get(name);
+    this.connections.delete(name);
+    if (!connection) return;
+    await Promise.allSettled([
+      connection.client?.close() ?? Promise.resolve(),
+      connection.transport?.close() ?? Promise.resolve(),
+    ]);
+  }
+
+  async closeAll(): Promise<void> {
+    await Promise.all([...this.connections.keys()].map((name) => this.close(name)));
+  }
+
+  private async createConnection(name: string, definition: McpServerConfig): Promise<ManagedConnection> {
+    if (definition.auth === 'oauth' && !(await this.hasOAuthTokens(name))) {
+      return this.createDisconnectedConnection(name, 'needs-auth', 'OAuth authentication is required before connecting.');
+    }
+
+    const bearerToken = resolveBearerToken(definition);
+    if (definition.auth === 'bearer' && !bearerToken) {
+      return this.createDisconnectedConnection(name, 'needs-auth', 'Bearer authentication is configured but no token is available.');
+    }
+
+    if (definition.command) {
+      return this.connectStdio(name, definition);
+    }
+
+    if (definition.url) {
+      return this.connectHttp(name, definition, bearerToken);
+    }
+
+    return this.createDisconnectedConnection(name, 'error', 'Server has no command or URL.');
+  }
+
+  private async connectStdio(name: string, definition: McpServerConfig): Promise<ManagedConnection> {
+    const client = new Client({ name: `sero-mcp-${name}`, version: '0.1.0' });
+    const transport = new StdioClientTransport({
+      command: definition.command!,
+      args: definition.args ?? [],
+      env: resolveEnv(definition.env),
+      cwd: definition.cwd,
+      stderr: definition.debug ? 'inherit' : 'ignore',
+    });
+
+    try {
+      await client.connect(transport);
+      const tools = await this.fetchAllTools(client);
+      const resources = await this.fetchAllResources(client);
+      return this.createConnectedConnection(name, client, transport, tools, resources);
+    } catch (error) {
+      await this.safeClose(client, transport);
+      return this.createErrorConnection(name, error);
+    }
+  }
+
+  private async connectHttp(
+    name: string,
+    definition: McpServerConfig,
+    bearerToken?: string,
+  ): Promise<ManagedConnection> {
+    const url = new URL(definition.url!);
+    const requestInit = buildRequestInit(definition, bearerToken);
+
+    const streamableClient = new Client({ name: `sero-mcp-${name}`, version: '0.1.0' });
+    const streamableTransport = new StreamableHTTPClientTransport(url, { requestInit });
+    try {
+      await streamableClient.connect(streamableTransport);
+      const tools = await this.fetchAllTools(streamableClient);
+      const resources = await this.fetchAllResources(streamableClient);
+      return this.createConnectedConnection(name, streamableClient, streamableTransport, tools, resources);
+    } catch (error) {
+      await this.safeClose(streamableClient, streamableTransport);
+      if (error instanceof UnauthorizedError || definition.auth === 'oauth') {
+        return this.createDisconnectedConnection(name, 'needs-auth', 'Authentication is required before connecting.');
+      }
+    }
+
+    const sseClient = new Client({ name: `sero-mcp-${name}`, version: '0.1.0' });
+    const sseTransport = new SSEClientTransport(url, { requestInit });
+    try {
+      await sseClient.connect(sseTransport);
+      const tools = await this.fetchAllTools(sseClient);
+      const resources = await this.fetchAllResources(sseClient);
+      return this.createConnectedConnection(name, sseClient, sseTransport, tools, resources);
+    } catch (error) {
+      await this.safeClose(sseClient, sseTransport);
+      return this.createErrorConnection(name, error);
+    }
+  }
+
+  private async fetchAllTools(client: Client): Promise<ManagedTool[]> {
+    const tools: ManagedTool[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const result = await client.listTools(cursor ? { cursor } : undefined);
+      tools.push(...normalizeTools(result.tools));
+      cursor = result.nextCursor;
+    } while (cursor);
+
+    return tools;
+  }
+
+  private async fetchAllResources(client: Client): Promise<ManagedResource[]> {
+    const resources: ManagedResource[] = [];
+    let cursor: string | undefined;
+
+    try {
+      do {
+        const result = await client.listResources(cursor ? { cursor } : undefined);
+        resources.push(...normalizeResources(result.resources));
+        cursor = result.nextCursor;
+      } while (cursor);
+    } catch {
+      return [];
+    }
+
+    return resources;
+  }
+
+  private createConnectedConnection(
+    name: string,
+    client: Client,
+    transport: ManagedTransport,
+    tools: ManagedTool[],
+    resources: ManagedResource[],
+  ): ManagedConnection {
+    return {
+      name,
+      client,
+      transport,
+      tools,
+      resources,
+      status: 'connected',
+      lastConnectedAt: new Date().toISOString(),
+      lastFailedAt: null,
+    };
+  }
+
+  private createDisconnectedConnection(
+    name: string,
+    status: 'needs-auth' | 'error',
+    lastError: string,
+  ): ManagedConnection {
+    return {
+      name,
+      client: null,
+      transport: null,
+      tools: [],
+      resources: [],
+      status,
+      lastError,
+      lastConnectedAt: null,
+      lastFailedAt: new Date().toISOString(),
+    };
+  }
+
+  private createErrorConnection(name: string, error: unknown): ManagedConnection {
+    const message = error instanceof Error ? error.message : String(error);
+    return this.createDisconnectedConnection(name, 'error', message);
+  }
+
+  private async safeClose(client: Client, transport: ManagedTransport): Promise<void> {
+    await Promise.allSettled([client.close(), transport.close()]);
+  }
+}
+
+function resolveEnv(env: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!env) return undefined;
+  return Object.fromEntries(
+    Object.entries(env).map(([key, value]) => [key, expandEnvReferences(value)]),
+  );
+}
+
+function expandEnvReferences(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_match, key: string) => process.env[key] ?? '');
+}
+
+function resolveBearerToken(definition: McpServerConfig): string | undefined {
+  if (definition.bearerToken) return definition.bearerToken;
+  if (definition.bearerTokenEnv) return process.env[definition.bearerTokenEnv];
+  return undefined;
+}
+
+function buildRequestInit(definition: McpServerConfig, bearerToken?: string): { headers?: Record<string, string> } | undefined {
+  const headers: Record<string, string> = { ...(definition.headers ?? {}) };
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`;
+  }
+  return Object.keys(headers).length > 0 ? { headers } : undefined;
+}
+
+function normalizeTools(rawTools: unknown): ManagedTool[] {
+  if (!Array.isArray(rawTools)) return [];
+  return rawTools
+    .filter((tool): tool is Record<string, unknown> => !!tool && typeof tool === 'object' && !Array.isArray(tool))
+    .map((tool) => ({
+      name: typeof tool.name === 'string' ? tool.name : '',
+      description: typeof tool.description === 'string' ? tool.description : undefined,
+      inputSchema: tool.inputSchema,
+      _meta: tool._meta && typeof tool._meta === 'object' ? tool._meta as Record<string, unknown> : undefined,
+    }))
+    .filter((tool) => tool.name.length > 0);
+}
+
+function normalizeResources(rawResources: unknown): ManagedResource[] {
+  if (!Array.isArray(rawResources)) return [];
+  return rawResources
+    .filter((resource): resource is Record<string, unknown> => !!resource && typeof resource === 'object' && !Array.isArray(resource))
+    .map((resource) => ({
+      uri: typeof resource.uri === 'string' ? resource.uri : '',
+      name: typeof resource.name === 'string' ? resource.name : '',
+      description: typeof resource.description === 'string' ? resource.description : undefined,
+      mimeType: typeof resource.mimeType === 'string' ? resource.mimeType : undefined,
+      _meta: resource._meta && typeof resource._meta === 'object' ? resource._meta as Record<string, unknown> : undefined,
+    }))
+    .filter((resource) => resource.uri.length > 0 && resource.name.length > 0);
+}

--- a/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
+++ b/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
@@ -4,17 +4,18 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { McpOAuthProvider } from '../auth/oauth-provider';
 import type { McpServerConfig } from '../config/types';
 import type { ManagedConnection, ManagedResource, ManagedTool, ManagedTransport } from './types';
 
 interface McpServerManagerOptions {
-  hasOAuthTokens?: (serverName: string) => Promise<boolean>;
+  hasOAuthTokens?: (serverName: string, serverUrl?: string) => Promise<boolean>;
 }
 
 export class McpServerManager {
   private readonly connections = new Map<string, ManagedConnection>();
   private readonly connectPromises = new Map<string, Promise<ManagedConnection>>();
-  private readonly hasOAuthTokens: (serverName: string) => Promise<boolean>;
+  private readonly hasOAuthTokens: (serverName: string, serverUrl?: string) => Promise<boolean>;
 
   constructor(options: McpServerManagerOptions = {}) {
     this.hasOAuthTokens = options.hasOAuthTokens ?? (async () => false);
@@ -74,7 +75,7 @@ export class McpServerManager {
   }
 
   private async createConnection(name: string, definition: McpServerConfig): Promise<ManagedConnection> {
-    if (definition.auth === 'oauth' && !(await this.hasOAuthTokens(name))) {
+    if (definition.auth === 'oauth' && !(await this.hasOAuthTokens(name, definition.url))) {
       return this.createDisconnectedConnection(name, 'needs-auth', 'OAuth authentication is required before connecting.');
     }
 
@@ -122,9 +123,14 @@ export class McpServerManager {
   ): Promise<ManagedConnection> {
     const url = new URL(definition.url!);
     const requestInit = buildRequestInit(definition, bearerToken);
+    const authProvider = definition.auth === 'oauth'
+      ? new McpOAuthProvider(name, definition.url!, definition.oauth || {}, {
+          onRedirect: async () => {},
+        })
+      : undefined;
 
     const streamableClient = new Client({ name: `sero-mcp-${name}`, version: '0.1.0' });
-    const streamableTransport = new StreamableHTTPClientTransport(url, { requestInit });
+    const streamableTransport = new StreamableHTTPClientTransport(url, { requestInit, authProvider });
     try {
       await streamableClient.connect(streamableTransport);
       const tools = await this.fetchAllTools(streamableClient);
@@ -132,7 +138,7 @@ export class McpServerManager {
       return this.createConnectedConnection(name, streamableClient, streamableTransport, tools, resources);
     } catch (error) {
       await this.safeClose(streamableClient, streamableTransport);
-      if (error instanceof UnauthorizedError || definition.auth === 'oauth') {
+      if (error instanceof UnauthorizedError) {
         return this.createDisconnectedConnection(name, 'needs-auth', 'Authentication is required before connecting.');
       }
     }

--- a/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
+++ b/plugins/sero-mcp-plugin/extension/manager/server-manager.ts
@@ -5,7 +5,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import type { CallToolResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { McpOAuthProvider } from '../auth/oauth-provider';
-import type { McpServerConfig } from '../config/types';
+import { resolveBearerTokenValue, type McpServerConfig } from '../config/types';
 import type { ManagedConnection, ManagedResource, ManagedTool, ManagedTransport } from './types';
 
 interface McpServerManagerOptions {
@@ -91,7 +91,7 @@ export class McpServerManager {
       return this.createDisconnectedConnection(name, 'needs-auth', 'OAuth authentication is required before connecting.');
     }
 
-    const bearerToken = resolveBearerToken(definition);
+    const bearerToken = resolveBearerTokenValue(definition);
     if (definition.auth === 'bearer' && !bearerToken) {
       return this.createDisconnectedConnection(name, 'needs-auth', 'Bearer authentication is configured but no token is available.');
     }
@@ -254,12 +254,6 @@ function resolveEnv(env: Record<string, string> | undefined): Record<string, str
 
 function expandEnvReferences(value: string): string {
   return value.replace(/\$\{([^}]+)\}/g, (_match, key: string) => process.env[key] ?? '');
-}
-
-function resolveBearerToken(definition: McpServerConfig): string | undefined {
-  if (definition.bearerToken) return definition.bearerToken;
-  if (definition.bearerTokenEnv) return process.env[definition.bearerTokenEnv];
-  return undefined;
 }
 
 function buildRequestInit(definition: McpServerConfig, bearerToken?: string): { headers?: Record<string, string> } | undefined {

--- a/plugins/sero-mcp-plugin/extension/manager/tool-metadata.ts
+++ b/plugins/sero-mcp-plugin/extension/manager/tool-metadata.ts
@@ -1,0 +1,49 @@
+import { getToolUiResourceUri } from '@modelcontextprotocol/ext-apps/app-bridge';
+import type { CachedMcpResource, CachedMcpTool, McpMetadataCacheEntry } from '../cache/metadata-cache';
+import type { ManagedResource, ManagedTool } from './types';
+
+export function serializeTools(tools: ManagedTool[]): CachedMcpTool[] {
+  return tools
+    .filter((tool) => !!tool?.name)
+    .map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+      uiResourceUri: extractToolUiResourceUri(tool),
+    }));
+}
+
+export function serializeResources(resources: ManagedResource[]): CachedMcpResource[] {
+  return resources
+    .filter((resource) => !!resource?.uri && !!resource?.name)
+    .map((resource) => ({
+      uri: resource.uri,
+      name: resource.name,
+      description: resource.description,
+    }));
+}
+
+export function buildMetadataCacheEntry(options: {
+  configHash: string;
+  tools: ManagedTool[];
+  resources: ManagedResource[];
+}): McpMetadataCacheEntry {
+  const serializedTools = serializeTools(options.tools);
+  const serializedResources = serializeResources(options.resources);
+  return {
+    cachedAt: Date.now(),
+    configHash: options.configHash,
+    toolCount: serializedTools.length,
+    resourceCount: serializedResources.length,
+    tools: serializedTools,
+    resources: serializedResources,
+  };
+}
+
+function extractToolUiResourceUri(tool: ManagedTool): string | undefined {
+  try {
+    return getToolUiResourceUri({ _meta: tool._meta });
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/sero-mcp-plugin/extension/manager/types.ts
+++ b/plugins/sero-mcp-plugin/extension/manager/types.ts
@@ -1,0 +1,36 @@
+import type { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+
+export type ManagedTransport =
+  | StdioClientTransport
+  | StreamableHTTPClientTransport
+  | SSEClientTransport;
+
+export interface ManagedTool {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  _meta?: Record<string, unknown>;
+}
+
+export interface ManagedResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+  _meta?: Record<string, unknown>;
+}
+
+export interface ManagedConnection {
+  name: string;
+  client: Client | null;
+  transport: ManagedTransport | null;
+  tools: ManagedTool[];
+  resources: ManagedResource[];
+  status: 'connected' | 'needs-auth' | 'error' | 'closed';
+  lastError?: string;
+  lastConnectedAt?: string | null;
+  lastFailedAt?: string | null;
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -4,7 +4,7 @@ import { validateServerEditorInput } from '../../shared/types';
 import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';
 import { McpOAuthCoordinator } from '../auth/oauth-coordinator';
 import { readMetadataCache, removeMetadataCacheEntry, writeMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
-import { ensureConfigFile, getConfigUpdatedAt, readRawConfig, writeConfig } from '../config/io';
+import { ensureConfigFile, getConfigUpdatedAt, writeConfig } from '../config/io';
 import type { McpConfigDocument, McpServerConfig } from '../config/types';
 import { McpServerManager } from '../manager/server-manager';
 import { buildSnapshot, type RuntimeServerStatus } from '../state/snapshot';
@@ -27,12 +27,12 @@ import {
 } from './runtime-lifecycle';
 import { writeState } from '../state/state-io';
 import { createToolResult, type ManagerAction, type ProxyAction, type ToolResult } from '../tools/types';
-import { buildServerConfig, formatDiagnostics, mutationErrorResult } from './runtime-utils';
-import type { SyncedRuntimeState } from './runtime-types';
+import { buildServerConfig, mutationErrorResult } from './runtime-utils';
+import { executeManagerActionRoute } from './runtime-manager-router';
+import type { ManagerActionOptions, SyncedRuntimeState, SyncSnapshotOptions } from './runtime-types';
 import { McpUiSessionManager } from '../viewer/ui-session';
 import { UiResourceHandler } from '../viewer/ui-resource-handler';
-interface ManagerActionOptions { cwd?: string; rawConfig?: string; serverName?: string; resourceUri?: string; toolName?: string; toolArguments?: Record<string, unknown>; callbackUrl?: string; serverInput?: McpServerEditorInput; }
-interface SyncSnapshotOptions { config?: McpConfigDocument; rawConfigUpdatedAt?: string | null; metadataCache?: McpMetadataCacheDocument; }
+
 export interface McpRuntime {
   attachPi(pi: ExtensionAPI): void;
   handleSessionStart(ctx: { cwd: string }): Promise<void>;
@@ -108,90 +108,32 @@ function createMcpRuntime(): McpRuntime {
     });
   }
   function executeManagerAction(action: ManagerAction, options: ManagerActionOptions = {}): Promise<ToolResult> {
-    return runExclusive(async () => {
-      switch (action) {
-        case 'save_raw_config':
-          return saveRawConfig(options.cwd, options.rawConfig);
-        case 'upsert_server':
-          return upsertServer(options.cwd, options.serverInput);
-        case 'remove_server':
-          return removeServer(options.cwd, options.serverName);
-        case 'enable_server':
-          return toggleServer(options.cwd, options.serverName, true);
-        case 'disable_server':
-          return toggleServer(options.cwd, options.serverName, false);
-        case 'connect_server':
-          return connectServer(options.cwd, options.serverName, false);
-        case 'reconnect_server':
-          return connectServer(options.cwd, options.serverName, true);
-        case 'start_auth':
-          return startServerAuth(options.cwd, options.serverName);
-        case 'complete_auth':
-          return completeServerAuth(options.cwd, options.serverName, options.callbackUrl);
-        case 'cancel_auth':
-          return cancelServerAuth(options.cwd, options.serverName);
-        case 'clear_auth':
-          return clearServerAuth(options.cwd, options.serverName);
-        case 'read_resource':
-          return readServerResource(options.cwd, options.serverName, options.resourceUri);
-        case 'open_resource':
-          return openViewerResource(options);
-        case 'open_tool_ui':
-          return openToolUi(options);
-        case 'close_viewer':
-          return closeViewer();
-        default:
-          break;
-      }
-      const synced = await syncSnapshot(options.cwd);
-      if (action === 'bootstrap' || action === 'refresh') {
-        keepAliveScheduler.start();
-        const nextState = await reconcileManagedServers(options.cwd, synced.config, 'startup') ?? synced;
-        const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
-        return createToolResult(
-          `${prefix} MCP app state for ${nextState.snapshot.summary.totalServers} configured server(s).`,
-          {
-            snapshotWritten: true,
-            configPath: nextState.configPath,
-            statePath: nextState.statePath,
-            serverCount: nextState.snapshot.summary.totalServers,
-          },
-        );
-      }
-      if (action === 'get_raw_config') {
-        const rawConfig = await readRawConfig(synced.configPath);
-        return createToolResult(rawConfig.trim() || '{}', {
-          snapshotWritten: true,
-          configPath: synced.configPath,
-          statePath: synced.statePath,
-          rawConfig,
-        });
-      }
-      if (action === 'get_diagnostics') {
-        return createToolResult(formatDiagnostics({
-          configPath: synced.configPath,
-          statePath: synced.statePath,
-          rawConfigUpdatedAt: synced.rawConfigUpdatedAt,
-          snapshot: synced.snapshot,
-          sessionRefCount,
-          hasAttachedPi: !!attachedPi,
-        }), {
-          snapshotWritten: true,
-          configPath: synced.configPath,
-          statePath: synced.statePath,
-          metadataCache: synced.metadataCache,
-        });
-      }
-      return createToolResult(
-        `Initialized MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`,
-        {
-          snapshotWritten: true,
-          configPath: synced.configPath,
-          statePath: synced.statePath,
-          serverCount: synced.snapshot.summary.totalServers,
-        },
-      );
-    });
+    return runExclusive(async () => executeManagerActionRoute({
+      action,
+      options,
+      handlers: {
+        save_raw_config: () => saveRawConfig(options.cwd, options.rawConfig),
+        upsert_server: () => upsertServer(options.cwd, options.serverInput),
+        remove_server: () => removeServer(options.cwd, options.serverName),
+        enable_server: () => toggleServer(options.cwd, options.serverName, true),
+        disable_server: () => toggleServer(options.cwd, options.serverName, false),
+        connect_server: () => connectServer(options.cwd, options.serverName, false),
+        reconnect_server: () => connectServer(options.cwd, options.serverName, true),
+        start_auth: () => startServerAuth(options.cwd, options.serverName),
+        complete_auth: () => completeServerAuth(options.cwd, options.serverName, options.callbackUrl),
+        cancel_auth: () => cancelServerAuth(options.cwd, options.serverName),
+        clear_auth: () => clearServerAuth(options.cwd, options.serverName),
+        read_resource: () => readServerResource(options.cwd, options.serverName, options.resourceUri),
+        open_resource: () => openViewerResource(options),
+        open_tool_ui: () => openToolUi(options),
+        close_viewer: () => closeViewer(),
+      },
+      syncSnapshot,
+      reconcileManagedServers,
+      startKeepAliveScheduler: () => keepAliveScheduler.start(),
+      sessionRefCount,
+      hasAttachedPi: !!attachedPi,
+    }));
   }
   function executeProxyAction(action: ProxyAction, options: { cwd?: string; query?: string; serverName?: string; toolName?: string; resourceUri?: string; toolArguments?: Record<string, unknown>; argumentsJson?: string; } = {}): Promise<ToolResult> {
     return runExclusive(async () => executeProxyActionInternal({

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -103,7 +103,17 @@ function createMcpRuntime(): McpRuntime {
         await uiSessions.closeActive('runtime-shutdown');
         await manager.closeAll();
         runtimeStatuses.clear();
-        lastState = null;
+
+        if (lastState || lastKnownCwd) {
+          try {
+            await syncSnapshot(lastKnownCwd || process.cwd());
+          } catch (error) {
+            console.error('[mcp] Failed to persist idle snapshot on session shutdown', error);
+            lastState = null;
+          }
+        } else {
+          lastState = null;
+        }
       }
     });
   }

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import type { McpServerEditorInput } from '../../shared/types';
 import { validateServerEditorInput } from '../../shared/types';
 import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';
+import { McpOAuthCoordinator } from '../auth/oauth-coordinator';
 import { readMetadataCache, removeMetadataCacheEntry, writeMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
 import { ensureConfigFile, getConfigUpdatedAt, readRawConfig, writeConfig } from '../config/io';
 import type { McpConfigDocument, McpServerConfig } from '../config/types';
@@ -9,6 +10,11 @@ import { McpServerManager } from '../manager/server-manager';
 import { buildSnapshot, type RuntimeServerStatus } from '../state/snapshot';
 import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
 import { connectServerAction, saveRawConfigAction } from './runtime-actions';
+import {
+  cancelServerAuthAction,
+  completeServerAuthAction,
+  startServerAuthAction,
+} from './runtime-auth';
 import { readServerResourceAction } from './runtime-resource';
 import { reconcileConnection } from './runtime-connect';
 import { createKeepAliveScheduler } from './runtime-keep-alive';
@@ -20,21 +26,19 @@ import { writeState } from '../state/state-io';
 import { createToolResult, type ManagerAction, type ProxyAction, type ToolResult } from '../tools/types';
 import { buildServerConfig, formatDiagnostics, formatServerList, formatStatusSummary, mutationErrorResult } from './runtime-utils';
 import type { SyncedRuntimeState } from './runtime-types';
-
 interface ManagerActionOptions {
   cwd?: string;
   rawConfig?: string;
   serverName?: string;
   resourceUri?: string;
+  callbackUrl?: string;
   serverInput?: McpServerEditorInput;
 }
-
 interface SyncSnapshotOptions {
   config?: McpConfigDocument;
   rawConfigUpdatedAt?: string | null;
   metadataCache?: McpMetadataCacheDocument;
 }
-
 export interface McpRuntime {
   attachPi(pi: ExtensionAPI): void;
   handleSessionStart(ctx: { cwd: string }): Promise<void>;
@@ -43,22 +47,19 @@ export interface McpRuntime {
   executeManagerAction(action: ManagerAction, options?: ManagerActionOptions): Promise<ToolResult>;
   executeProxyAction(action: ProxyAction, options?: { cwd?: string }): Promise<ToolResult>;
 }
-
 let runtimeSingleton: McpRuntime | null = null;
-
 export function getMcpRuntime(): McpRuntime {
   runtimeSingleton ??= createMcpRuntime();
   return runtimeSingleton;
 }
-
 function createMcpRuntime(): McpRuntime {
   let attachedPi: ExtensionAPI | null = null;
   let lastKnownCwd = '';
   let sessionRefCount = 0;
   let lastState: SyncedRuntimeState | null = null;
   let operationQueue: Promise<void> = Promise.resolve();
-
   const manager = new McpServerManager({ hasOAuthTokens });
+  const authCoordinator = new McpOAuthCoordinator();
   const runtimeStatuses = new Map<string, RuntimeServerStatus>();
   const keepAliveScheduler = createKeepAliveScheduler({
     intervalMs: KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS,
@@ -70,9 +71,7 @@ function createMcpRuntime(): McpRuntime {
       });
     },
   });
-
   function attachPi(pi: ExtensionAPI): void { attachedPi = pi; }
-
   function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
     const previous = operationQueue;
     let release!: () => void;
@@ -80,15 +79,12 @@ function createMcpRuntime(): McpRuntime {
       release = resolve;
     });
     operationQueue = previous.then(() => current);
-
     return previous.then(operation).finally(() => {
       release();
     });
   }
-
   function handleSessionStart(ctx: { cwd: string }): Promise<void> { return handleSessionActivation(ctx, true); }
   function handleSessionSwitch(ctx: { cwd: string }): Promise<void> { return handleSessionActivation(ctx, false); }
-
   function handleSessionActivation(ctx: { cwd: string }, incrementRefCount: boolean): Promise<void> {
     return runExclusive(async () => {
       if (incrementRefCount) {
@@ -99,19 +95,18 @@ function createMcpRuntime(): McpRuntime {
       await reconcileManagedServers(ctx.cwd, synced.config, 'startup');
     });
   }
-
   function handleSessionShutdown(): Promise<void> {
     return runExclusive(async () => {
       sessionRefCount = Math.max(0, sessionRefCount - 1);
       if (sessionRefCount === 0) {
         keepAliveScheduler.stop();
+        await authCoordinator.cancelAll();
         await manager.closeAll();
         runtimeStatuses.clear();
         lastState = null;
       }
     });
   }
-
   function executeManagerAction(
     action: ManagerAction,
     options: ManagerActionOptions = {},
@@ -132,14 +127,18 @@ function createMcpRuntime(): McpRuntime {
           return connectServer(options.cwd, options.serverName, false);
         case 'reconnect_server':
           return connectServer(options.cwd, options.serverName, true);
+        case 'start_auth':
+          return startServerAuth(options.cwd, options.serverName);
+        case 'complete_auth':
+          return completeServerAuth(options.cwd, options.serverName, options.callbackUrl);
+        case 'cancel_auth':
+          return cancelServerAuth(options.cwd, options.serverName);
         case 'read_resource':
           return readServerResource(options.cwd, options.serverName, options.resourceUri);
         default:
           break;
       }
-
       const synced = await syncSnapshot(options.cwd);
-
       if (action === 'bootstrap' || action === 'refresh') {
         keepAliveScheduler.start();
         const nextState = await reconcileManagedServers(options.cwd, synced.config, 'startup') ?? synced;
@@ -154,7 +153,6 @@ function createMcpRuntime(): McpRuntime {
           },
         );
       }
-
       if (action === 'get_raw_config') {
         const rawConfig = await readRawConfig(synced.configPath);
         return createToolResult(rawConfig.trim() || '{}', {
@@ -164,7 +162,6 @@ function createMcpRuntime(): McpRuntime {
           rawConfig,
         });
       }
-
       if (action === 'get_diagnostics') {
         return createToolResult(formatDiagnostics({
           configPath: synced.configPath,
@@ -180,7 +177,6 @@ function createMcpRuntime(): McpRuntime {
           metadataCache: synced.metadataCache,
         });
       }
-
       return createToolResult(
         `Initialized MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`,
         {
@@ -192,7 +188,6 @@ function createMcpRuntime(): McpRuntime {
       );
     });
   }
-
   function executeProxyAction(
     action: ProxyAction,
     options: { cwd?: string } = {},
@@ -205,28 +200,23 @@ function createMcpRuntime(): McpRuntime {
           serverCount: synced.snapshot.summary.totalServers,
         });
       }
-
       return createToolResult(formatStatusSummary(synced.snapshot), {
         mode: 'status',
         serverCount: synced.snapshot.summary.totalServers,
       });
     });
   }
-
   async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
     return saveRawConfigAction({ cwd, rawConfigInput, writeConfigAndSyncSnapshot });
   }
-
   async function upsertServer(cwd: string | undefined, serverInput?: McpServerEditorInput): Promise<ToolResult> {
     if (!serverInput) {
       return createToolResult('Error: Server input is required.', { snapshotWritten: false });
     }
-
     const validationError = validateServerEditorInput(serverInput);
     if (validationError) {
       return createToolResult(`Error: ${validationError}`, { snapshotWritten: false });
     }
-
     try {
       const synced = await mutateConfig(cwd, (config) => {
         const nextServers = { ...config.mcpServers };
@@ -236,21 +226,17 @@ function createMcpRuntime(): McpRuntime {
           originalName && originalName !== nextName && nextServers[nextName],
         );
         const hasCreateCollision = Boolean(!originalName && nextServers[nextName]);
-
         if (hasRenameCollision || hasCreateCollision) {
           throw new Error(`A server named "${nextName}" already exists.`);
         }
-
         const existing = originalName ? nextServers[originalName] : undefined;
         if (originalName && originalName !== nextName) {
           delete nextServers[originalName];
           runtimeStatuses.delete(originalName);
         }
-
         nextServers[nextName] = buildServerConfig(serverInput, existing);
         config.mcpServers = nextServers;
       });
-
       return createToolResult(`Saved MCP server "${serverInput.serverName.trim()}".`, {
         snapshotWritten: true,
         configPath: synced.configPath,
@@ -261,13 +247,11 @@ function createMcpRuntime(): McpRuntime {
       return mutationErrorResult(error);
     }
   }
-
   async function removeServer(cwd: string | undefined, serverName?: string): Promise<ToolResult> {
     const normalizedServerName = serverName?.trim();
     if (!normalizedServerName) {
       return createToolResult('Error: Server name is required.', { snapshotWritten: false });
     }
-
     try {
       await manager.close(normalizedServerName);
       runtimeStatuses.delete(normalizedServerName);
@@ -279,7 +263,6 @@ function createMcpRuntime(): McpRuntime {
         delete nextServers[normalizedServerName];
         config.mcpServers = nextServers;
       }, normalizedServerName);
-
       return createToolResult(`Removed MCP server "${normalizedServerName}".`, {
         snapshotWritten: true,
         configPath: synced.configPath,
@@ -290,19 +273,16 @@ function createMcpRuntime(): McpRuntime {
       return mutationErrorResult(error);
     }
   }
-
   async function toggleServer(cwd: string | undefined, serverName: string | undefined, enabled: boolean): Promise<ToolResult> {
     const normalizedServerName = serverName?.trim();
     if (!normalizedServerName) {
       return createToolResult('Error: Server name is required.', { snapshotWritten: false });
     }
-
     try {
       if (!enabled) {
         await manager.close(normalizedServerName);
         runtimeStatuses.delete(normalizedServerName);
       }
-
       const synced = await mutateConfig(cwd, (config) => {
         const current = config.mcpServers[normalizedServerName];
         if (!current) {
@@ -316,7 +296,6 @@ function createMcpRuntime(): McpRuntime {
           },
         };
       });
-
       return createToolResult(`${enabled ? 'Enabled' : 'Disabled'} MCP server "${normalizedServerName}".`, {
         snapshotWritten: true,
         configPath: synced.configPath,
@@ -327,7 +306,6 @@ function createMcpRuntime(): McpRuntime {
       return mutationErrorResult(error);
     }
   }
-
   async function connectServer(
     cwd: string | undefined,
     serverName: string | undefined,
@@ -342,7 +320,40 @@ function createMcpRuntime(): McpRuntime {
       syncSnapshot,
     });
   }
-
+  async function startServerAuth(cwd: string | undefined, serverName: string | undefined): Promise<ToolResult> {
+    return startServerAuthAction({
+      cwd,
+      serverName,
+      authCoordinator,
+      manager,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    });
+  }
+  async function completeServerAuth(
+    cwd: string | undefined,
+    serverName: string | undefined,
+    callbackUrl: string | undefined,
+  ): Promise<ToolResult> {
+    return completeServerAuthAction({
+      cwd,
+      serverName,
+      callbackUrl,
+      authCoordinator,
+      manager,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    });
+  }
+  async function cancelServerAuth(cwd: string | undefined, serverName: string | undefined): Promise<ToolResult> {
+    return cancelServerAuthAction({
+      cwd,
+      serverName,
+      authCoordinator,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    });
+  }
   async function readServerResource(
     cwd: string | undefined,
     serverName: string | undefined,
@@ -357,7 +368,6 @@ function createMcpRuntime(): McpRuntime {
       syncSnapshot,
     });
   }
-
   async function reconcileManagedServers(
     cwd: string | undefined,
     config: McpConfigDocument,
@@ -369,10 +379,8 @@ function createMcpRuntime(): McpRuntime {
     if (entries.length === 0) {
       return null;
     }
-
     let nextCache: McpMetadataCacheDocument | null = null;
     let changed = false;
-
     for (const [serverName, serverConfig] of entries) {
       const shouldConnect = await shouldAttemptAutoConnect({
         serverName,
@@ -383,7 +391,6 @@ function createMcpRuntime(): McpRuntime {
       if (!shouldConnect) {
         continue;
       }
-
       const connection = await manager.connect(serverName, serverConfig);
       const { nextCache: updatedCache, runtimeStatus } = await reconcileConnection({
         serverName,
@@ -395,14 +402,11 @@ function createMcpRuntime(): McpRuntime {
       nextCache = updatedCache;
       changed = true;
     }
-
     if (!changed) {
       return null;
     }
-
     return syncSnapshot(cwd, { config, metadataCache: nextCache ?? await readMetadataCache() });
   }
-
   async function mutateConfig(
     cwd: string | undefined,
     mutate: (config: McpConfigDocument) => void,
@@ -415,16 +419,13 @@ function createMcpRuntime(): McpRuntime {
       mcpServers: { ...config.mcpServers },
     };
     mutate(nextConfig);
-
     let metadataCache = await readMetadataCache();
     if (removeServerName) {
       metadataCache = removeMetadataCacheEntry(metadataCache, removeServerName);
       await writeMetadataCache(metadataCache);
     }
-
     return writeConfigAndSyncSnapshot(cwd, nextConfig, metadataCache);
   }
-
   async function writeConfigAndSyncSnapshot(
     cwd: string | undefined,
     config: McpConfigDocument,
@@ -433,19 +434,16 @@ function createMcpRuntime(): McpRuntime {
     const configPath = getMcpConfigPath();
     const previousConfig = await ensureConfigFile(configPath);
     let metadataCache = metadataCacheOverride ?? await readMetadataCache();
-
     for (const serverName of getChangedServerNames(previousConfig, config)) {
       await manager.close(serverName);
       runtimeStatuses.delete(serverName);
       metadataCache = removeMetadataCacheEntry(metadataCache, serverName);
     }
-
     await writeConfig(config, configPath);
     const rawConfigUpdatedAt = await getConfigUpdatedAt(configPath);
     const synced = await syncSnapshot(cwd, { config, rawConfigUpdatedAt, metadataCache });
     return await reconcileManagedServers(cwd, config, 'startup') ?? synced;
   }
-
   async function syncSnapshot(
     cwd?: string,
     options: SyncSnapshotOptions = {},
@@ -453,17 +451,13 @@ function createMcpRuntime(): McpRuntime {
     if (cwd) {
       lastKnownCwd = cwd;
     }
-
     const resolvedCwd = lastKnownCwd || cwd || process.cwd();
     const configPath = getMcpConfigPath();
     const statePath = getMcpStatePath(resolvedCwd);
-
     await ensureOAuthDir();
-
     const config = options.config ?? await ensureConfigFile(configPath);
     const rawConfigUpdatedAt = options.rawConfigUpdatedAt ?? await getConfigUpdatedAt(configPath);
     const metadataCache = options.metadataCache ?? await readMetadataCache();
-
     const snapshot = await buildSnapshot({
       configPath,
       rawConfigUpdatedAt,
@@ -472,13 +466,11 @@ function createMcpRuntime(): McpRuntime {
       hasOAuthTokens,
       runtimeStatuses,
     });
-
     await writeMetadataCache(metadataCache);
     await writeState(snapshot, statePath);
     lastState = { configPath, statePath, config, metadataCache, rawConfigUpdatedAt, snapshot };
     return lastState;
   }
-
   return {
     attachPi,
     handleSessionStart,
@@ -488,4 +480,3 @@ function createMcpRuntime(): McpRuntime {
     executeProxyAction,
   };
 }
-

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -18,6 +18,7 @@ import {
 } from './runtime-auth';
 import { readServerResourceAction } from './runtime-resource';
 import { executeProxyAction as executeProxyActionInternal } from './runtime-proxy';
+import { closeViewerAction, openToolUiAction, openViewerResourceAction } from './runtime-viewer';
 import { reconcileConnection } from './runtime-connect';
 import { createKeepAliveScheduler } from './runtime-keep-alive';
 import {
@@ -28,19 +29,10 @@ import { writeState } from '../state/state-io';
 import { createToolResult, type ManagerAction, type ProxyAction, type ToolResult } from '../tools/types';
 import { buildServerConfig, formatDiagnostics, mutationErrorResult } from './runtime-utils';
 import type { SyncedRuntimeState } from './runtime-types';
-interface ManagerActionOptions {
-  cwd?: string;
-  rawConfig?: string;
-  serverName?: string;
-  resourceUri?: string;
-  callbackUrl?: string;
-  serverInput?: McpServerEditorInput;
-}
-interface SyncSnapshotOptions {
-  config?: McpConfigDocument;
-  rawConfigUpdatedAt?: string | null;
-  metadataCache?: McpMetadataCacheDocument;
-}
+import { McpUiSessionManager } from '../viewer/ui-session';
+import { UiResourceHandler } from '../viewer/ui-resource-handler';
+interface ManagerActionOptions { cwd?: string; rawConfig?: string; serverName?: string; resourceUri?: string; toolName?: string; toolArguments?: Record<string, unknown>; callbackUrl?: string; serverInput?: McpServerEditorInput; }
+interface SyncSnapshotOptions { config?: McpConfigDocument; rawConfigUpdatedAt?: string | null; metadataCache?: McpMetadataCacheDocument; }
 export interface McpRuntime {
   attachPi(pi: ExtensionAPI): void;
   handleSessionStart(ctx: { cwd: string }): Promise<void>;
@@ -66,6 +58,8 @@ function createMcpRuntime(): McpRuntime {
   const manager = new McpServerManager({ hasOAuthTokens });
   const authCoordinator = new McpOAuthCoordinator();
   const runtimeStatuses = new Map<string, RuntimeServerStatus>();
+  const uiResourceHandler = new UiResourceHandler(manager);
+  const uiSessions = new McpUiSessionManager();
   const keepAliveScheduler = createKeepAliveScheduler({
     intervalMs: KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS,
     isEnabled: () => sessionRefCount > 0,
@@ -106,16 +100,14 @@ function createMcpRuntime(): McpRuntime {
       if (sessionRefCount === 0) {
         keepAliveScheduler.stop();
         await authCoordinator.cancelAll();
+        await uiSessions.closeActive('runtime-shutdown');
         await manager.closeAll();
         runtimeStatuses.clear();
         lastState = null;
       }
     });
   }
-  function executeManagerAction(
-    action: ManagerAction,
-    options: ManagerActionOptions = {},
-  ): Promise<ToolResult> {
+  function executeManagerAction(action: ManagerAction, options: ManagerActionOptions = {}): Promise<ToolResult> {
     return runExclusive(async () => {
       switch (action) {
         case 'save_raw_config':
@@ -142,6 +134,12 @@ function createMcpRuntime(): McpRuntime {
           return clearServerAuth(options.cwd, options.serverName);
         case 'read_resource':
           return readServerResource(options.cwd, options.serverName, options.resourceUri);
+        case 'open_resource':
+          return openViewerResource(options);
+        case 'open_tool_ui':
+          return openToolUi(options);
+        case 'close_viewer':
+          return closeViewer();
         default:
           break;
       }
@@ -195,10 +193,7 @@ function createMcpRuntime(): McpRuntime {
       );
     });
   }
-  function executeProxyAction(action: ProxyAction, options: {
-    cwd?: string; query?: string; serverName?: string; toolName?: string; resourceUri?: string;
-    toolArguments?: Record<string, unknown>; argumentsJson?: string;
-  } = {}): Promise<ToolResult> {
+  function executeProxyAction(action: ProxyAction, options: { cwd?: string; query?: string; serverName?: string; toolName?: string; resourceUri?: string; toolArguments?: Record<string, unknown>; argumentsJson?: string; } = {}): Promise<ToolResult> {
     return runExclusive(async () => executeProxyActionInternal({
       action,
       cwd: options.cwd,
@@ -313,11 +308,7 @@ function createMcpRuntime(): McpRuntime {
       return mutationErrorResult(error);
     }
   }
-  async function connectServer(
-    cwd: string | undefined,
-    serverName: string | undefined,
-    reconnect: boolean,
-  ): Promise<ToolResult> {
+  async function connectServer(cwd: string | undefined, serverName: string | undefined, reconnect: boolean): Promise<ToolResult> {
     return connectServerAction({
       cwd,
       serverName,
@@ -337,11 +328,7 @@ function createMcpRuntime(): McpRuntime {
       syncSnapshot,
     });
   }
-  async function completeServerAuth(
-    cwd: string | undefined,
-    serverName: string | undefined,
-    callbackUrl: string | undefined,
-  ): Promise<ToolResult> {
+  async function completeServerAuth(cwd: string | undefined, serverName: string | undefined, callbackUrl: string | undefined): Promise<ToolResult> {
     return completeServerAuthAction({
       cwd,
       serverName,
@@ -371,11 +358,7 @@ function createMcpRuntime(): McpRuntime {
       syncSnapshot,
     });
   }
-  async function readServerResource(
-    cwd: string | undefined,
-    serverName: string | undefined,
-    resourceUri: string | undefined,
-  ): Promise<ToolResult> {
+  async function readServerResource(cwd: string | undefined, serverName: string | undefined, resourceUri: string | undefined): Promise<ToolResult> {
     return readServerResourceAction({
       cwd,
       serverName,
@@ -385,11 +368,36 @@ function createMcpRuntime(): McpRuntime {
       syncSnapshot,
     });
   }
-  async function reconcileManagedServers(
-    cwd: string | undefined,
-    config: McpConfigDocument,
-    mode: 'startup' | 'keep-alive',
-  ): Promise<SyncedRuntimeState | null> {
+  async function openViewerResource(options: ManagerActionOptions): Promise<ToolResult> {
+    return openViewerResourceAction({
+      cwd: options.cwd,
+      serverName: options.serverName,
+      resourceUri: options.resourceUri,
+      manager,
+      uiResourceHandler,
+      uiSessions,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    });
+  }
+  async function openToolUi(options: ManagerActionOptions): Promise<ToolResult> {
+    return openToolUiAction({
+      cwd: options.cwd,
+      serverName: options.serverName,
+      resourceUri: options.resourceUri,
+      toolName: options.toolName,
+      toolArguments: options.toolArguments,
+      manager,
+      uiResourceHandler,
+      uiSessions,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    });
+  }
+  async function closeViewer(): Promise<ToolResult> {
+    return closeViewerAction({ uiSessions });
+  }
+  async function reconcileManagedServers(cwd: string | undefined, config: McpConfigDocument, mode: 'startup' | 'keep-alive'): Promise<SyncedRuntimeState | null> {
     const entries = mode === 'keep-alive'
       ? getKeepAliveServerEntries(config)
       : getAutoConnectServerEntries(config);
@@ -424,11 +432,7 @@ function createMcpRuntime(): McpRuntime {
     }
     return syncSnapshot(cwd, { config, metadataCache: nextCache ?? await readMetadataCache() });
   }
-  async function mutateConfig(
-    cwd: string | undefined,
-    mutate: (config: McpConfigDocument) => void,
-    removeServerName?: string,
-  ): Promise<SyncedRuntimeState> {
+  async function mutateConfig(cwd: string | undefined, mutate: (config: McpConfigDocument) => void, removeServerName?: string): Promise<SyncedRuntimeState> {
     const configPath = getMcpConfigPath();
     const config = await ensureConfigFile(configPath);
     const nextConfig: McpConfigDocument = {
@@ -443,15 +447,12 @@ function createMcpRuntime(): McpRuntime {
     }
     return writeConfigAndSyncSnapshot(cwd, nextConfig, metadataCache);
   }
-  async function writeConfigAndSyncSnapshot(
-    cwd: string | undefined,
-    config: McpConfigDocument,
-    metadataCacheOverride?: McpMetadataCacheDocument,
-  ): Promise<SyncedRuntimeState> {
+  async function writeConfigAndSyncSnapshot(cwd: string | undefined, config: McpConfigDocument, metadataCacheOverride?: McpMetadataCacheDocument): Promise<SyncedRuntimeState> {
     const configPath = getMcpConfigPath();
     const previousConfig = await ensureConfigFile(configPath);
     let metadataCache = metadataCacheOverride ?? await readMetadataCache();
     for (const serverName of getChangedServerNames(previousConfig, config)) {
+      await uiSessions.closeIfServerMatches(serverName);
       await manager.close(serverName);
       runtimeStatuses.delete(serverName);
       metadataCache = removeMetadataCacheEntry(metadataCache, serverName);
@@ -461,10 +462,7 @@ function createMcpRuntime(): McpRuntime {
     const synced = await syncSnapshot(cwd, { config, rawConfigUpdatedAt, metadataCache });
     return await reconcileManagedServers(cwd, config, 'startup') ?? synced;
   }
-  async function syncSnapshot(
-    cwd?: string,
-    options: SyncSnapshotOptions = {},
-  ): Promise<SyncedRuntimeState> {
+  async function syncSnapshot(cwd?: string, options: SyncSnapshotOptions = {}): Promise<SyncedRuntimeState> {
     if (cwd) {
       lastKnownCwd = cwd;
     }

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -12,6 +12,7 @@ import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
 import { connectServerAction, saveRawConfigAction } from './runtime-actions';
 import {
   cancelServerAuthAction,
+  clearServerAuthAction,
   completeServerAuthAction,
   startServerAuthAction,
 } from './runtime-auth';
@@ -133,6 +134,8 @@ function createMcpRuntime(): McpRuntime {
           return completeServerAuth(options.cwd, options.serverName, options.callbackUrl);
         case 'cancel_auth':
           return cancelServerAuth(options.cwd, options.serverName);
+        case 'clear_auth':
+          return clearServerAuth(options.cwd, options.serverName);
         case 'read_resource':
           return readServerResource(options.cwd, options.serverName, options.resourceUri);
         default:
@@ -350,6 +353,16 @@ function createMcpRuntime(): McpRuntime {
       cwd,
       serverName,
       authCoordinator,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    });
+  }
+  async function clearServerAuth(cwd: string | undefined, serverName: string | undefined): Promise<ToolResult> {
+    return clearServerAuthAction({
+      cwd,
+      serverName,
+      authCoordinator,
+      manager,
       setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
       syncSnapshot,
     });

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -1,0 +1,232 @@
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';
+import { readMetadataCache, writeMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
+import { ensureConfigFile, getConfigUpdatedAt, normalizeConfigDocument, readRawConfig, writeConfig } from '../config/io';
+import type { McpConfigDocument } from '../config/types';
+import { buildSnapshot } from '../state/snapshot';
+import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
+import { writeState } from '../state/state-io';
+import { createToolResult, type ManagerAction, type ProxyAction, type ToolResult } from '../tools/types';
+
+export interface McpRuntime {
+  attachPi(pi: ExtensionAPI): void;
+  handleSessionStart(ctx: { cwd: string }): Promise<void>;
+  handleSessionSwitch(ctx: { cwd: string }): Promise<void>;
+  handleSessionShutdown(): Promise<void>;
+  executeManagerAction(action: ManagerAction, options?: { cwd?: string; rawConfig?: string }): Promise<ToolResult>;
+  executeProxyAction(action: ProxyAction, options?: { cwd?: string }): Promise<ToolResult>;
+}
+
+interface SyncedRuntimeState {
+  configPath: string;
+  statePath: string;
+  config: McpConfigDocument;
+  metadataCache: McpMetadataCacheDocument;
+  rawConfigUpdatedAt: string | null;
+  snapshot: Awaited<ReturnType<typeof buildSnapshot>>;
+}
+
+let runtimeSingleton: McpRuntime | null = null;
+
+export function getMcpRuntime(): McpRuntime {
+  runtimeSingleton ??= createMcpRuntime();
+  return runtimeSingleton;
+}
+
+function createMcpRuntime(): McpRuntime {
+  let attachedPi: ExtensionAPI | null = null;
+  let lastKnownCwd = '';
+  let sessionRefCount = 0;
+  let lastState: SyncedRuntimeState | null = null;
+
+  function attachPi(pi: ExtensionAPI): void {
+    attachedPi = pi;
+  }
+
+  async function handleSessionStart(ctx: { cwd: string }): Promise<void> {
+    sessionRefCount += 1;
+    await syncSnapshot(ctx.cwd);
+  }
+
+  async function handleSessionSwitch(ctx: { cwd: string }): Promise<void> {
+    await syncSnapshot(ctx.cwd);
+  }
+
+  async function handleSessionShutdown(): Promise<void> {
+    sessionRefCount = Math.max(0, sessionRefCount - 1);
+    if (sessionRefCount === 0) {
+      lastState = null;
+    }
+  }
+
+  async function executeManagerAction(
+    action: ManagerAction,
+    options: { cwd?: string; rawConfig?: string } = {},
+  ): Promise<ToolResult> {
+    if (action === 'save_raw_config') {
+      return saveRawConfig(options.cwd, options.rawConfig);
+    }
+
+    const synced = await syncSnapshot(options.cwd);
+
+    if (action === 'get_raw_config') {
+      const rawConfig = await readRawConfig(synced.configPath);
+      return createToolResult(rawConfig.trim() || '{}', {
+        snapshotWritten: true,
+        configPath: synced.configPath,
+        statePath: synced.statePath,
+        rawConfig,
+      });
+    }
+
+    if (action === 'get_diagnostics') {
+      return createToolResult(formatDiagnostics(synced, sessionRefCount, !!attachedPi), {
+        snapshotWritten: true,
+        configPath: synced.configPath,
+        statePath: synced.statePath,
+        metadataCache: synced.metadataCache,
+      });
+    }
+
+    const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
+    return createToolResult(`${prefix} MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`, {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      serverCount: synced.snapshot.summary.totalServers,
+    });
+  }
+
+  async function executeProxyAction(
+    action: ProxyAction,
+    options: { cwd?: string } = {},
+  ): Promise<ToolResult> {
+    const synced = await syncSnapshot(options.cwd);
+    if (action === 'list') {
+      return createToolResult(formatServerList(synced.snapshot.servers), {
+        mode: 'list',
+        serverCount: synced.snapshot.summary.totalServers,
+      });
+    }
+
+    return createToolResult(formatStatusSummary(synced.snapshot), {
+      mode: 'status',
+      serverCount: synced.snapshot.summary.totalServers,
+    });
+  }
+
+  async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
+    if (!rawConfigInput?.trim()) {
+      return createToolResult('Error: Raw config cannot be empty.', { snapshotWritten: false });
+    }
+
+    try {
+      const parsed = JSON.parse(rawConfigInput);
+      const normalized = normalizeConfigDocument(parsed);
+      const configPath = getMcpConfigPath();
+      await writeConfig(normalized, configPath);
+      const synced = await syncSnapshot(cwd);
+      return createToolResult(`Saved MCP config with ${synced.snapshot.summary.totalServers} configured server(s).`, {
+        snapshotWritten: true,
+        configPath: synced.configPath,
+        statePath: synced.statePath,
+        rawConfig: `${JSON.stringify(normalized, null, 2)}\n`,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return createToolResult(`Error: Failed to save raw MCP config. ${message}`, {
+        snapshotWritten: false,
+      });
+    }
+  }
+
+  async function syncSnapshot(cwd?: string): Promise<SyncedRuntimeState> {
+    if (cwd) {
+      lastKnownCwd = cwd;
+    }
+
+    const resolvedCwd = lastKnownCwd || cwd || process.cwd();
+    const configPath = getMcpConfigPath();
+    const statePath = getMcpStatePath(resolvedCwd);
+    const [config, rawConfigUpdatedAt, metadataCache] = await Promise.all([
+      ensureConfigFile(configPath),
+      getConfigUpdatedAt(configPath),
+      readMetadataCache(),
+      ensureOAuthDir(),
+    ]);
+
+    await writeMetadataCache(metadataCache);
+
+    const snapshot = await buildSnapshot({
+      configPath,
+      rawConfigUpdatedAt,
+      config,
+      metadataCache,
+      hasOAuthTokens,
+    });
+
+    await writeState(snapshot, statePath);
+    lastState = { configPath, statePath, config, metadataCache, rawConfigUpdatedAt, snapshot };
+    return lastState;
+  }
+
+  return {
+    attachPi,
+    handleSessionStart,
+    handleSessionSwitch,
+    handleSessionShutdown,
+    executeManagerAction,
+    executeProxyAction,
+  };
+}
+
+function formatStatusSummary(snapshot: SyncedRuntimeState['snapshot']): string {
+  const lines = [
+    `MCP status: ${snapshot.summary.totalServers} server(s) configured`,
+    `Enabled: ${snapshot.summary.enabledServers}`,
+    `Connected: ${snapshot.summary.connectedServers}`,
+    `Needs auth: ${snapshot.summary.needsAuthServers}`,
+    `Errors: ${snapshot.summary.errorServers}`,
+  ];
+
+  if (snapshot.servers.length === 0) {
+    lines.push('', 'Open the MCP app in Sero to add your first MCP server.');
+  }
+
+  return lines.join('\n');
+}
+
+function formatServerList(snapshotServers: SyncedRuntimeState['snapshot']['servers']): string {
+  if (snapshotServers.length === 0) {
+    return 'No MCP servers are configured yet. Open the MCP app in Sero to add one.';
+  }
+
+  return snapshotServers
+    .map((server) => {
+      const enabledLabel = server.enabled ? 'enabled' : 'disabled';
+      return `- ${server.serverName} (${enabledLabel}, ${server.connectionStatus}, ${server.authStatus})`;
+    })
+    .join('\n');
+}
+
+function formatDiagnostics(state: SyncedRuntimeState, sessionRefCount: number, hasAttachedPi: boolean): string {
+  const lines = [
+    `Config: ${state.configPath}`,
+    `State: ${state.statePath}`,
+    `Raw config updated: ${state.rawConfigUpdatedAt ?? 'never'}`,
+    `Servers: ${state.snapshot.summary.totalServers}`,
+  ];
+
+  for (const server of state.snapshot.servers) {
+    lines.push(
+      `- ${server.serverName}: ${server.transport}, ${server.lifecycle}, ${server.connectionStatus}, ${server.authStatus}, tools=${server.toolCount}, resources=${server.resourceCount}`,
+    );
+  }
+
+  lines.push(`Runtime sessions: ${sessionRefCount}`);
+  if (hasAttachedPi) {
+    lines.push('Runtime: attached to active Pi extension instance');
+  }
+
+  return lines.join('\n');
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -1,8 +1,9 @@
+import type { McpServerEditorInput } from '../../shared/types';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';
 import { readMetadataCache, writeMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
 import { ensureConfigFile, getConfigUpdatedAt, normalizeConfigDocument, readRawConfig, writeConfig } from '../config/io';
-import type { McpConfigDocument } from '../config/types';
+import type { McpConfigDocument, McpServerConfig } from '../config/types';
 import { buildSnapshot } from '../state/snapshot';
 import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
 import { writeState } from '../state/state-io';
@@ -13,7 +14,10 @@ export interface McpRuntime {
   handleSessionStart(ctx: { cwd: string }): Promise<void>;
   handleSessionSwitch(ctx: { cwd: string }): Promise<void>;
   handleSessionShutdown(): Promise<void>;
-  executeManagerAction(action: ManagerAction, options?: { cwd?: string; rawConfig?: string }): Promise<ToolResult>;
+  executeManagerAction(
+    action: ManagerAction,
+    options?: { cwd?: string; rawConfig?: string; serverName?: string; serverInput?: McpServerEditorInput },
+  ): Promise<ToolResult>;
   executeProxyAction(action: ProxyAction, options?: { cwd?: string }): Promise<ToolResult>;
 }
 
@@ -61,10 +65,21 @@ function createMcpRuntime(): McpRuntime {
 
   async function executeManagerAction(
     action: ManagerAction,
-    options: { cwd?: string; rawConfig?: string } = {},
+    options: { cwd?: string; rawConfig?: string; serverName?: string; serverInput?: McpServerEditorInput } = {},
   ): Promise<ToolResult> {
-    if (action === 'save_raw_config') {
-      return saveRawConfig(options.cwd, options.rawConfig);
+    switch (action) {
+      case 'save_raw_config':
+        return saveRawConfig(options.cwd, options.rawConfig);
+      case 'upsert_server':
+        return upsertServer(options.cwd, options.serverInput);
+      case 'remove_server':
+        return removeServer(options.cwd, options.serverName);
+      case 'enable_server':
+        return toggleServer(options.cwd, options.serverName, true);
+      case 'disable_server':
+        return toggleServer(options.cwd, options.serverName, false);
+      default:
+        break;
     }
 
     const synced = await syncSnapshot(options.cwd);
@@ -97,10 +112,7 @@ function createMcpRuntime(): McpRuntime {
     });
   }
 
-  async function executeProxyAction(
-    action: ProxyAction,
-    options: { cwd?: string } = {},
-  ): Promise<ToolResult> {
+  async function executeProxyAction(action: ProxyAction, options: { cwd?: string } = {}): Promise<ToolResult> {
     const synced = await syncSnapshot(options.cwd);
     if (action === 'list') {
       return createToolResult(formatServerList(synced.snapshot.servers), {
@@ -138,6 +150,96 @@ function createMcpRuntime(): McpRuntime {
         snapshotWritten: false,
       });
     }
+  }
+
+  async function upsertServer(cwd: string | undefined, serverInput?: McpServerEditorInput): Promise<ToolResult> {
+    if (!serverInput?.serverName.trim()) {
+      return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+    }
+
+    const synced = await mutateConfig(cwd, (config) => {
+      const nextServers = { ...config.mcpServers };
+      const originalName = serverInput.originalServerName?.trim();
+      const nextName = serverInput.serverName.trim();
+      const existing = originalName ? nextServers[originalName] : nextServers[nextName];
+
+      if (originalName && originalName !== nextName) {
+        delete nextServers[originalName];
+      }
+
+      nextServers[nextName] = buildServerConfig(serverInput, existing);
+      config.mcpServers = nextServers;
+    });
+
+    return createToolResult(`Saved MCP server "${serverInput.serverName.trim()}".`, {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      serverCount: synced.snapshot.summary.totalServers,
+    });
+  }
+
+  async function removeServer(cwd: string | undefined, serverName?: string): Promise<ToolResult> {
+    const normalizedServerName = serverName?.trim();
+    if (!normalizedServerName) {
+      return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+    }
+
+    const synced = await mutateConfig(cwd, (config) => {
+      const nextServers = { ...config.mcpServers };
+      delete nextServers[normalizedServerName];
+      config.mcpServers = nextServers;
+    });
+
+    return createToolResult(`Removed MCP server "${normalizedServerName}".`, {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      serverCount: synced.snapshot.summary.totalServers,
+    });
+  }
+
+  async function toggleServer(cwd: string | undefined, serverName: string | undefined, enabled: boolean): Promise<ToolResult> {
+    const normalizedServerName = serverName?.trim();
+    if (!normalizedServerName) {
+      return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+    }
+
+    const synced = await mutateConfig(cwd, (config) => {
+      const current = config.mcpServers[normalizedServerName];
+      if (!current) {
+        throw new Error(`Server "${normalizedServerName}" does not exist.`);
+      }
+      config.mcpServers = {
+        ...config.mcpServers,
+        [normalizedServerName]: {
+          ...current,
+          enabled,
+        },
+      };
+    });
+
+    return createToolResult(`${enabled ? 'Enabled' : 'Disabled'} MCP server "${normalizedServerName}".`, {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      serverCount: synced.snapshot.summary.totalServers,
+    });
+  }
+
+  async function mutateConfig(
+    cwd: string | undefined,
+    mutate: (config: McpConfigDocument) => void,
+  ): Promise<SyncedRuntimeState> {
+    const configPath = getMcpConfigPath();
+    const config = await ensureConfigFile(configPath);
+    const nextConfig: McpConfigDocument = {
+      ...config,
+      mcpServers: { ...config.mcpServers },
+    };
+    mutate(nextConfig);
+    await writeConfig(nextConfig, configPath);
+    return syncSnapshot(cwd);
   }
 
   async function syncSnapshot(cwd?: string): Promise<SyncedRuntimeState> {
@@ -178,6 +280,68 @@ function createMcpRuntime(): McpRuntime {
     executeManagerAction,
     executeProxyAction,
   };
+}
+
+function buildServerConfig(input: McpServerEditorInput, existing?: McpServerConfig): McpServerConfig {
+  const next: McpServerConfig = { ...(existing ?? {}) };
+  next.enabled = input.enabled;
+  next.lifecycle = input.lifecycle;
+  next.exposeResources = input.exposeResources;
+  next.debug = input.debug;
+
+  const cwd = input.cwd.trim();
+  if (cwd) next.cwd = cwd;
+  else delete next.cwd;
+
+  if (input.transport === 'stdio') {
+    const command = input.command.trim();
+    if (command) next.command = command;
+    else delete next.command;
+
+    const args = parseArgsText(input.argsText);
+    if (args.length > 0) next.args = args;
+    else delete next.args;
+
+    delete next.url;
+  } else {
+    const url = input.url.trim();
+    if (url) next.url = url;
+    else delete next.url;
+
+    delete next.command;
+    delete next.args;
+  }
+
+  switch (input.authMode) {
+    case 'oauth':
+      next.auth = 'oauth';
+      delete next.bearerToken;
+      delete next.bearerTokenEnv;
+      break;
+    case 'bearer': {
+      next.auth = 'bearer';
+      delete next.oauth;
+      const bearerTokenEnv = input.bearerTokenEnv.trim();
+      if (bearerTokenEnv) next.bearerTokenEnv = bearerTokenEnv;
+      else delete next.bearerTokenEnv;
+      break;
+    }
+    default:
+      next.auth = false;
+      delete next.bearerToken;
+      delete next.bearerTokenEnv;
+      delete next.oauth;
+      break;
+  }
+
+  return next;
+}
+
+function parseArgsText(argsText: string): string[] {
+  return argsText
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }
 
 function formatStatusSummary(snapshot: SyncedRuntimeState['snapshot']): string {

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -11,7 +11,6 @@ import {
 import {
   ensureConfigFile,
   getConfigUpdatedAt,
-  normalizeConfigDocument,
   readRawConfig,
   writeConfig,
 } from '../config/io';
@@ -19,7 +18,16 @@ import type { McpConfigDocument, McpServerConfig } from '../config/types';
 import { McpServerManager } from '../manager/server-manager';
 import { buildSnapshot, type RuntimeServerStatus } from '../state/snapshot';
 import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
-import { formatConnectMessage, reconcileConnection } from './runtime-connect';
+import { connectServerAction, saveRawConfigAction } from './runtime-actions';
+import { reconcileConnection } from './runtime-connect';
+import { createKeepAliveScheduler } from './runtime-keep-alive';
+import {
+  getAutoConnectServerEntries,
+  getChangedServerNames,
+  getKeepAliveServerEntries,
+  KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS,
+  shouldAttemptAutoConnect,
+} from './runtime-lifecycle';
 import { writeState } from '../state/state-io';
 import {
   createToolResult,
@@ -34,6 +42,7 @@ import {
   formatStatusSummary,
   mutationErrorResult,
 } from './runtime-utils';
+import type { SyncedRuntimeState } from './runtime-types';
 
 interface ManagerActionOptions {
   cwd?: string;
@@ -57,15 +66,6 @@ export interface McpRuntime {
   executeProxyAction(action: ProxyAction, options?: { cwd?: string }): Promise<ToolResult>;
 }
 
-interface SyncedRuntimeState {
-  configPath: string;
-  statePath: string;
-  config: McpConfigDocument;
-  metadataCache: McpMetadataCacheDocument;
-  rawConfigUpdatedAt: string | null;
-  snapshot: Awaited<ReturnType<typeof buildSnapshot>>;
-}
-
 let runtimeSingleton: McpRuntime | null = null;
 
 export function getMcpRuntime(): McpRuntime {
@@ -82,10 +82,18 @@ function createMcpRuntime(): McpRuntime {
 
   const manager = new McpServerManager({ hasOAuthTokens });
   const runtimeStatuses = new Map<string, RuntimeServerStatus>();
+  const keepAliveScheduler = createKeepAliveScheduler({
+    intervalMs: KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS,
+    isEnabled: () => sessionRefCount > 0,
+    onTick: async () => {
+      await runExclusive(async () => {
+        const config = lastState?.config ?? await ensureConfigFile(getMcpConfigPath());
+        await reconcileManagedServers(lastKnownCwd, config, 'keep-alive');
+      });
+    },
+  });
 
-  function attachPi(pi: ExtensionAPI): void {
-    attachedPi = pi;
-  }
+  function attachPi(pi: ExtensionAPI): void { attachedPi = pi; }
 
   function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
     const previous = operationQueue;
@@ -100,16 +108,17 @@ function createMcpRuntime(): McpRuntime {
     });
   }
 
-  function handleSessionStart(ctx: { cwd: string }): Promise<void> {
-    return runExclusive(async () => {
-      sessionRefCount += 1;
-      await syncSnapshot(ctx.cwd);
-    });
-  }
+  function handleSessionStart(ctx: { cwd: string }): Promise<void> { return handleSessionActivation(ctx, true); }
+  function handleSessionSwitch(ctx: { cwd: string }): Promise<void> { return handleSessionActivation(ctx, false); }
 
-  function handleSessionSwitch(ctx: { cwd: string }): Promise<void> {
+  function handleSessionActivation(ctx: { cwd: string }, incrementRefCount: boolean): Promise<void> {
     return runExclusive(async () => {
-      await syncSnapshot(ctx.cwd);
+      if (incrementRefCount) {
+        sessionRefCount += 1;
+      }
+      const synced = await syncSnapshot(ctx.cwd);
+      keepAliveScheduler.start();
+      await reconcileManagedServers(ctx.cwd, synced.config, 'startup');
     });
   }
 
@@ -117,6 +126,7 @@ function createMcpRuntime(): McpRuntime {
     return runExclusive(async () => {
       sessionRefCount = Math.max(0, sessionRefCount - 1);
       if (sessionRefCount === 0) {
+        keepAliveScheduler.stop();
         await manager.closeAll();
         runtimeStatuses.clear();
         lastState = null;
@@ -150,6 +160,21 @@ function createMcpRuntime(): McpRuntime {
 
       const synced = await syncSnapshot(options.cwd);
 
+      if (action === 'bootstrap' || action === 'refresh') {
+        keepAliveScheduler.start();
+        const nextState = await reconcileManagedServers(options.cwd, synced.config, 'startup') ?? synced;
+        const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
+        return createToolResult(
+          `${prefix} MCP app state for ${nextState.snapshot.summary.totalServers} configured server(s).`,
+          {
+            snapshotWritten: true,
+            configPath: nextState.configPath,
+            statePath: nextState.statePath,
+            serverCount: nextState.snapshot.summary.totalServers,
+          },
+        );
+      }
+
       if (action === 'get_raw_config') {
         const rawConfig = await readRawConfig(synced.configPath);
         return createToolResult(rawConfig.trim() || '{}', {
@@ -176,9 +201,8 @@ function createMcpRuntime(): McpRuntime {
         });
       }
 
-      const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
       return createToolResult(
-        `${prefix} MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`,
+        `Initialized MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`,
         {
           snapshotWritten: true,
           configPath: synced.configPath,
@@ -210,28 +234,7 @@ function createMcpRuntime(): McpRuntime {
   }
 
   async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
-    if (!rawConfigInput?.trim()) {
-      return createToolResult('Error: Raw config cannot be empty.', { snapshotWritten: false });
-    }
-
-    try {
-      const normalized = normalizeConfigDocument(JSON.parse(rawConfigInput));
-      const synced = await writeConfigAndSyncSnapshot(cwd, normalized);
-      return createToolResult(
-        `Saved MCP config with ${synced.snapshot.summary.totalServers} configured server(s).`,
-        {
-          snapshotWritten: true,
-          configPath: synced.configPath,
-          statePath: synced.statePath,
-          rawConfig: `${JSON.stringify(normalized, null, 2)}\n`,
-        },
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      return createToolResult(`Error: Failed to save raw MCP config. ${message}`, {
-        snapshotWritten: false,
-      });
-    }
+    return saveRawConfigAction({ cwd, rawConfigInput, writeConfigAndSyncSnapshot });
   }
 
   async function upsertServer(cwd: string | undefined, serverInput?: McpServerEditorInput): Promise<ToolResult> {
@@ -350,44 +353,59 @@ function createMcpRuntime(): McpRuntime {
     serverName: string | undefined,
     reconnect: boolean,
   ): Promise<ToolResult> {
-    const normalizedServerName = serverName?.trim();
-    if (!normalizedServerName) {
-      return createToolResult('Error: Server name is required.', { snapshotWritten: false });
-    }
-
-    const synced = await syncSnapshot(cwd);
-    const serverConfig = synced.config.mcpServers[normalizedServerName];
-    if (!serverConfig) {
-      return createToolResult(`Error: Server "${normalizedServerName}" does not exist.`, { snapshotWritten: false });
-    }
-    if (serverConfig.enabled === false) {
-      return createToolResult(`Error: Server "${normalizedServerName}" is disabled. Enable it before connecting.`, { snapshotWritten: false });
-    }
-
-    const connection = reconnect
-      ? await manager.reconnect(normalizedServerName, serverConfig)
-      : await manager.connect(normalizedServerName, serverConfig);
-
-    const metadataCache = await readMetadataCache();
-    const { nextCache, runtimeStatus } = await reconcileConnection({
-      serverName: normalizedServerName,
-      serverConfig,
-      metadataCache,
-      connection,
+    return connectServerAction({
+      cwd,
+      serverName,
+      reconnect,
+      manager,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
     });
-    runtimeStatuses.set(normalizedServerName, runtimeStatus);
+  }
 
-    const nextState = await syncSnapshot(cwd, { config: synced.config, metadataCache: nextCache });
-    return createToolResult(formatConnectMessage(normalizedServerName, connection.status), {
-      snapshotWritten: true,
-      configPath: nextState.configPath,
-      statePath: nextState.statePath,
-      connectionStatus: runtimeStatus.connectionStatus,
-      authStatus: runtimeStatus.authStatus,
-      toolCount: nextState.snapshot.servers.find((server) => server.serverName === normalizedServerName)?.toolCount ?? 0,
-      resourceCount: nextState.snapshot.servers.find((server) => server.serverName === normalizedServerName)?.resourceCount ?? 0,
-      lastError: runtimeStatus.lastError ?? null,
-    });
+  async function reconcileManagedServers(
+    cwd: string | undefined,
+    config: McpConfigDocument,
+    mode: 'startup' | 'keep-alive',
+  ): Promise<SyncedRuntimeState | null> {
+    const entries = mode === 'keep-alive'
+      ? getKeepAliveServerEntries(config)
+      : getAutoConnectServerEntries(config);
+    if (entries.length === 0) {
+      return null;
+    }
+
+    let nextCache: McpMetadataCacheDocument | null = null;
+    let changed = false;
+
+    for (const [serverName, serverConfig] of entries) {
+      const shouldConnect = await shouldAttemptAutoConnect({
+        serverName,
+        serverConfig,
+        connection: manager.getConnection(serverName),
+        hasOAuthTokens,
+      });
+      if (!shouldConnect) {
+        continue;
+      }
+
+      const connection = await manager.connect(serverName, serverConfig);
+      const { nextCache: updatedCache, runtimeStatus } = await reconcileConnection({
+        serverName,
+        serverConfig,
+        metadataCache: nextCache ?? await readMetadataCache(),
+        connection,
+      });
+      runtimeStatuses.set(serverName, runtimeStatus);
+      nextCache = updatedCache;
+      changed = true;
+    }
+
+    if (!changed) {
+      return null;
+    }
+
+    return syncSnapshot(cwd, { config, metadataCache: nextCache ?? await readMetadataCache() });
   }
 
   async function mutateConfig(
@@ -418,13 +436,19 @@ function createMcpRuntime(): McpRuntime {
     metadataCacheOverride?: McpMetadataCacheDocument,
   ): Promise<SyncedRuntimeState> {
     const configPath = getMcpConfigPath();
+    const previousConfig = await ensureConfigFile(configPath);
+    let metadataCache = metadataCacheOverride ?? await readMetadataCache();
+
+    for (const serverName of getChangedServerNames(previousConfig, config)) {
+      await manager.close(serverName);
+      runtimeStatuses.delete(serverName);
+      metadataCache = removeMetadataCacheEntry(metadataCache, serverName);
+    }
+
     await writeConfig(config, configPath);
     const rawConfigUpdatedAt = await getConfigUpdatedAt(configPath);
-    return syncSnapshot(cwd, {
-      config,
-      rawConfigUpdatedAt,
-      metadataCache: metadataCacheOverride,
-    });
+    const synced = await syncSnapshot(cwd, { config, rawConfigUpdatedAt, metadataCache });
+    return await reconcileManagedServers(cwd, config, 'startup') ?? synced;
   }
 
   async function syncSnapshot(

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -1,23 +1,56 @@
-import type { McpServerEditorInput } from '../../shared/types';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { McpServerEditorInput } from '../../shared/types';
+import { validateServerEditorInput } from '../../shared/types';
 import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';
-import { readMetadataCache, writeMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
-import { ensureConfigFile, getConfigUpdatedAt, normalizeConfigDocument, readRawConfig, writeConfig } from '../config/io';
+import {
+  readMetadataCache,
+  writeMetadataCache,
+  type McpMetadataCacheDocument,
+} from '../cache/metadata-cache';
+import {
+  ensureConfigFile,
+  getConfigUpdatedAt,
+  normalizeConfigDocument,
+  readRawConfig,
+  writeConfig,
+} from '../config/io';
 import type { McpConfigDocument, McpServerConfig } from '../config/types';
 import { buildSnapshot } from '../state/snapshot';
 import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
 import { writeState } from '../state/state-io';
-import { createToolResult, type ManagerAction, type ProxyAction, type ToolResult } from '../tools/types';
+import {
+  createToolResult,
+  type ManagerAction,
+  type ProxyAction,
+  type ToolResult,
+} from '../tools/types';
+import {
+  buildServerConfig,
+  formatDiagnostics,
+  formatServerList,
+  formatStatusSummary,
+  mutationErrorResult,
+} from './runtime-utils';
+
+interface ManagerActionOptions {
+  cwd?: string;
+  rawConfig?: string;
+  serverName?: string;
+  serverInput?: McpServerEditorInput;
+}
+
+interface SyncSnapshotOptions {
+  config?: McpConfigDocument;
+  rawConfigUpdatedAt?: string | null;
+  metadataCache?: McpMetadataCacheDocument;
+}
 
 export interface McpRuntime {
   attachPi(pi: ExtensionAPI): void;
   handleSessionStart(ctx: { cwd: string }): Promise<void>;
   handleSessionSwitch(ctx: { cwd: string }): Promise<void>;
   handleSessionShutdown(): Promise<void>;
-  executeManagerAction(
-    action: ManagerAction,
-    options?: { cwd?: string; rawConfig?: string; serverName?: string; serverInput?: McpServerEditorInput },
-  ): Promise<ToolResult>;
+  executeManagerAction(action: ManagerAction, options?: ManagerActionOptions): Promise<ToolResult>;
   executeProxyAction(action: ProxyAction, options?: { cwd?: string }): Promise<ToolResult>;
 }
 
@@ -42,108 +75,148 @@ function createMcpRuntime(): McpRuntime {
   let lastKnownCwd = '';
   let sessionRefCount = 0;
   let lastState: SyncedRuntimeState | null = null;
+  let operationQueue: Promise<void> = Promise.resolve();
 
   function attachPi(pi: ExtensionAPI): void {
     attachedPi = pi;
   }
 
-  async function handleSessionStart(ctx: { cwd: string }): Promise<void> {
-    sessionRefCount += 1;
-    await syncSnapshot(ctx.cwd);
-  }
+  function runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = operationQueue;
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    operationQueue = previous.then(() => current);
 
-  async function handleSessionSwitch(ctx: { cwd: string }): Promise<void> {
-    await syncSnapshot(ctx.cwd);
-  }
-
-  async function handleSessionShutdown(): Promise<void> {
-    sessionRefCount = Math.max(0, sessionRefCount - 1);
-    if (sessionRefCount === 0) {
-      lastState = null;
-    }
-  }
-
-  async function executeManagerAction(
-    action: ManagerAction,
-    options: { cwd?: string; rawConfig?: string; serverName?: string; serverInput?: McpServerEditorInput } = {},
-  ): Promise<ToolResult> {
-    switch (action) {
-      case 'save_raw_config':
-        return saveRawConfig(options.cwd, options.rawConfig);
-      case 'upsert_server':
-        return upsertServer(options.cwd, options.serverInput);
-      case 'remove_server':
-        return removeServer(options.cwd, options.serverName);
-      case 'enable_server':
-        return toggleServer(options.cwd, options.serverName, true);
-      case 'disable_server':
-        return toggleServer(options.cwd, options.serverName, false);
-      default:
-        break;
-    }
-
-    const synced = await syncSnapshot(options.cwd);
-
-    if (action === 'get_raw_config') {
-      const rawConfig = await readRawConfig(synced.configPath);
-      return createToolResult(rawConfig.trim() || '{}', {
-        snapshotWritten: true,
-        configPath: synced.configPath,
-        statePath: synced.statePath,
-        rawConfig,
-      });
-    }
-
-    if (action === 'get_diagnostics') {
-      return createToolResult(formatDiagnostics(synced, sessionRefCount, !!attachedPi), {
-        snapshotWritten: true,
-        configPath: synced.configPath,
-        statePath: synced.statePath,
-        metadataCache: synced.metadataCache,
-      });
-    }
-
-    const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
-    return createToolResult(`${prefix} MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`, {
-      snapshotWritten: true,
-      configPath: synced.configPath,
-      statePath: synced.statePath,
-      serverCount: synced.snapshot.summary.totalServers,
+    return previous.then(operation).finally(() => {
+      release();
     });
   }
 
-  async function executeProxyAction(action: ProxyAction, options: { cwd?: string } = {}): Promise<ToolResult> {
-    const synced = await syncSnapshot(options.cwd);
-    if (action === 'list') {
-      return createToolResult(formatServerList(synced.snapshot.servers), {
-        mode: 'list',
+  function handleSessionStart(ctx: { cwd: string }): Promise<void> {
+    return runExclusive(async () => {
+      sessionRefCount += 1;
+      await syncSnapshot(ctx.cwd);
+    });
+  }
+
+  function handleSessionSwitch(ctx: { cwd: string }): Promise<void> {
+    return runExclusive(async () => {
+      await syncSnapshot(ctx.cwd);
+    });
+  }
+
+  function handleSessionShutdown(): Promise<void> {
+    return runExclusive(async () => {
+      sessionRefCount = Math.max(0, sessionRefCount - 1);
+      if (sessionRefCount === 0) {
+        lastState = null;
+      }
+    });
+  }
+
+  function executeManagerAction(
+    action: ManagerAction,
+    options: ManagerActionOptions = {},
+  ): Promise<ToolResult> {
+    return runExclusive(async () => {
+      switch (action) {
+        case 'save_raw_config':
+          return saveRawConfig(options.cwd, options.rawConfig);
+        case 'upsert_server':
+          return upsertServer(options.cwd, options.serverInput);
+        case 'remove_server':
+          return removeServer(options.cwd, options.serverName);
+        case 'enable_server':
+          return toggleServer(options.cwd, options.serverName, true);
+        case 'disable_server':
+          return toggleServer(options.cwd, options.serverName, false);
+        default:
+          break;
+      }
+
+      const synced = await syncSnapshot(options.cwd);
+
+      if (action === 'get_raw_config') {
+        const rawConfig = await readRawConfig(synced.configPath);
+        return createToolResult(rawConfig.trim() || '{}', {
+          snapshotWritten: true,
+          configPath: synced.configPath,
+          statePath: synced.statePath,
+          rawConfig,
+        });
+      }
+
+      if (action === 'get_diagnostics') {
+        return createToolResult(formatDiagnostics({
+          configPath: synced.configPath,
+          statePath: synced.statePath,
+          rawConfigUpdatedAt: synced.rawConfigUpdatedAt,
+          snapshot: synced.snapshot,
+          sessionRefCount,
+          hasAttachedPi: !!attachedPi,
+        }), {
+          snapshotWritten: true,
+          configPath: synced.configPath,
+          statePath: synced.statePath,
+          metadataCache: synced.metadataCache,
+        });
+      }
+
+      const prefix = action === 'refresh' ? 'Refreshed' : 'Initialized';
+      return createToolResult(
+        `${prefix} MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`,
+        {
+          snapshotWritten: true,
+          configPath: synced.configPath,
+          statePath: synced.statePath,
+          serverCount: synced.snapshot.summary.totalServers,
+        },
+      );
+    });
+  }
+
+  function executeProxyAction(
+    action: ProxyAction,
+    options: { cwd?: string } = {},
+  ): Promise<ToolResult> {
+    return runExclusive(async () => {
+      const synced = await syncSnapshot(options.cwd);
+      if (action === 'list') {
+        return createToolResult(formatServerList(synced.snapshot.servers), {
+          mode: 'list',
+          serverCount: synced.snapshot.summary.totalServers,
+        });
+      }
+
+      return createToolResult(formatStatusSummary(synced.snapshot), {
+        mode: 'status',
         serverCount: synced.snapshot.summary.totalServers,
       });
-    }
-
-    return createToolResult(formatStatusSummary(synced.snapshot), {
-      mode: 'status',
-      serverCount: synced.snapshot.summary.totalServers,
     });
   }
 
-  async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
+  async function saveRawConfig(
+    cwd: string | undefined,
+    rawConfigInput?: string,
+  ): Promise<ToolResult> {
     if (!rawConfigInput?.trim()) {
       return createToolResult('Error: Raw config cannot be empty.', { snapshotWritten: false });
     }
 
     try {
-      const parsed = JSON.parse(rawConfigInput);
-      const normalized = normalizeConfigDocument(parsed);
-      const configPath = getMcpConfigPath();
-      await writeConfig(normalized, configPath);
-      const synced = await syncSnapshot(cwd);
-      return createToolResult(`Saved MCP config with ${synced.snapshot.summary.totalServers} configured server(s).`, {
-        snapshotWritten: true,
-        configPath: synced.configPath,
-        statePath: synced.statePath,
-        rawConfig: `${JSON.stringify(normalized, null, 2)}\n`,
-      });
+      const normalized = normalizeConfigDocument(JSON.parse(rawConfigInput));
+      const synced = await writeConfigAndSyncSnapshot(cwd, normalized);
+      return createToolResult(
+        `Saved MCP config with ${synced.snapshot.summary.totalServers} configured server(s).`,
+        {
+          snapshotWritten: true,
+          configPath: synced.configPath,
+          statePath: synced.statePath,
+          rawConfig: `${JSON.stringify(normalized, null, 2)}\n`,
+        },
+      );
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       return createToolResult(`Error: Failed to save raw MCP config. ${message}`, {
@@ -152,79 +225,124 @@ function createMcpRuntime(): McpRuntime {
     }
   }
 
-  async function upsertServer(cwd: string | undefined, serverInput?: McpServerEditorInput): Promise<ToolResult> {
-    if (!serverInput?.serverName.trim()) {
-      return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+  async function upsertServer(
+    cwd: string | undefined,
+    serverInput?: McpServerEditorInput,
+  ): Promise<ToolResult> {
+    if (!serverInput) {
+      return createToolResult('Error: Server input is required.', { snapshotWritten: false });
     }
 
-    const synced = await mutateConfig(cwd, (config) => {
-      const nextServers = { ...config.mcpServers };
-      const originalName = serverInput.originalServerName?.trim();
-      const nextName = serverInput.serverName.trim();
-      const existing = originalName ? nextServers[originalName] : nextServers[nextName];
+    const validationError = validateServerEditorInput(serverInput);
+    if (validationError) {
+      return createToolResult(`Error: ${validationError}`, { snapshotWritten: false });
+    }
 
-      if (originalName && originalName !== nextName) {
-        delete nextServers[originalName];
-      }
+    try {
+      const synced = await mutateConfig(cwd, (config) => {
+        const nextServers = { ...config.mcpServers };
+        const originalName = serverInput.originalServerName?.trim();
+        const nextName = serverInput.serverName.trim();
+        const hasRenameCollision = Boolean(
+          originalName &&
+          originalName !== nextName &&
+          nextServers[nextName],
+        );
+        const hasCreateCollision = Boolean(!originalName && nextServers[nextName]);
 
-      nextServers[nextName] = buildServerConfig(serverInput, existing);
-      config.mcpServers = nextServers;
-    });
+        if (hasRenameCollision || hasCreateCollision) {
+          throw new Error(`A server named "${nextName}" already exists.`);
+        }
 
-    return createToolResult(`Saved MCP server "${serverInput.serverName.trim()}".`, {
-      snapshotWritten: true,
-      configPath: synced.configPath,
-      statePath: synced.statePath,
-      serverCount: synced.snapshot.summary.totalServers,
-    });
+        const existing = originalName ? nextServers[originalName] : undefined;
+        if (originalName && originalName !== nextName) {
+          delete nextServers[originalName];
+        }
+
+        nextServers[nextName] = buildServerConfig(serverInput, existing);
+        config.mcpServers = nextServers;
+      });
+
+      return createToolResult(`Saved MCP server "${serverInput.serverName.trim()}".`, {
+        snapshotWritten: true,
+        configPath: synced.configPath,
+        statePath: synced.statePath,
+        serverCount: synced.snapshot.summary.totalServers,
+      });
+    } catch (error) {
+      return mutationErrorResult(error);
+    }
   }
 
-  async function removeServer(cwd: string | undefined, serverName?: string): Promise<ToolResult> {
+  async function removeServer(
+    cwd: string | undefined,
+    serverName?: string,
+  ): Promise<ToolResult> {
     const normalizedServerName = serverName?.trim();
     if (!normalizedServerName) {
       return createToolResult('Error: Server name is required.', { snapshotWritten: false });
     }
 
-    const synced = await mutateConfig(cwd, (config) => {
-      const nextServers = { ...config.mcpServers };
-      delete nextServers[normalizedServerName];
-      config.mcpServers = nextServers;
-    });
+    try {
+      const synced = await mutateConfig(cwd, (config) => {
+        if (!config.mcpServers[normalizedServerName]) {
+          throw new Error(`Server "${normalizedServerName}" does not exist.`);
+        }
 
-    return createToolResult(`Removed MCP server "${normalizedServerName}".`, {
-      snapshotWritten: true,
-      configPath: synced.configPath,
-      statePath: synced.statePath,
-      serverCount: synced.snapshot.summary.totalServers,
-    });
+        const nextServers = { ...config.mcpServers };
+        delete nextServers[normalizedServerName];
+        config.mcpServers = nextServers;
+      });
+
+      return createToolResult(`Removed MCP server "${normalizedServerName}".`, {
+        snapshotWritten: true,
+        configPath: synced.configPath,
+        statePath: synced.statePath,
+        serverCount: synced.snapshot.summary.totalServers,
+      });
+    } catch (error) {
+      return mutationErrorResult(error);
+    }
   }
 
-  async function toggleServer(cwd: string | undefined, serverName: string | undefined, enabled: boolean): Promise<ToolResult> {
+  async function toggleServer(
+    cwd: string | undefined,
+    serverName: string | undefined,
+    enabled: boolean,
+  ): Promise<ToolResult> {
     const normalizedServerName = serverName?.trim();
     if (!normalizedServerName) {
       return createToolResult('Error: Server name is required.', { snapshotWritten: false });
     }
 
-    const synced = await mutateConfig(cwd, (config) => {
-      const current = config.mcpServers[normalizedServerName];
-      if (!current) {
-        throw new Error(`Server "${normalizedServerName}" does not exist.`);
-      }
-      config.mcpServers = {
-        ...config.mcpServers,
-        [normalizedServerName]: {
-          ...current,
-          enabled,
+    try {
+      const synced = await mutateConfig(cwd, (config) => {
+        const current = config.mcpServers[normalizedServerName];
+        if (!current) {
+          throw new Error(`Server "${normalizedServerName}" does not exist.`);
+        }
+
+        config.mcpServers = {
+          ...config.mcpServers,
+          [normalizedServerName]: {
+            ...current,
+            enabled,
+          },
+        };
+      });
+
+      return createToolResult(
+        `${enabled ? 'Enabled' : 'Disabled'} MCP server "${normalizedServerName}".`,
+        {
+          snapshotWritten: true,
+          configPath: synced.configPath,
+          statePath: synced.statePath,
+          serverCount: synced.snapshot.summary.totalServers,
         },
-      };
-    });
-
-    return createToolResult(`${enabled ? 'Enabled' : 'Disabled'} MCP server "${normalizedServerName}".`, {
-      snapshotWritten: true,
-      configPath: synced.configPath,
-      statePath: synced.statePath,
-      serverCount: synced.snapshot.summary.totalServers,
-    });
+      );
+    } catch (error) {
+      return mutationErrorResult(error);
+    }
   }
 
   async function mutateConfig(
@@ -238,11 +356,23 @@ function createMcpRuntime(): McpRuntime {
       mcpServers: { ...config.mcpServers },
     };
     mutate(nextConfig);
-    await writeConfig(nextConfig, configPath);
-    return syncSnapshot(cwd);
+    return writeConfigAndSyncSnapshot(cwd, nextConfig);
   }
 
-  async function syncSnapshot(cwd?: string): Promise<SyncedRuntimeState> {
+  async function writeConfigAndSyncSnapshot(
+    cwd: string | undefined,
+    config: McpConfigDocument,
+  ): Promise<SyncedRuntimeState> {
+    const configPath = getMcpConfigPath();
+    await writeConfig(config, configPath);
+    const rawConfigUpdatedAt = await getConfigUpdatedAt(configPath);
+    return syncSnapshot(cwd, { config, rawConfigUpdatedAt });
+  }
+
+  async function syncSnapshot(
+    cwd?: string,
+    options: SyncSnapshotOptions = {},
+  ): Promise<SyncedRuntimeState> {
     if (cwd) {
       lastKnownCwd = cwd;
     }
@@ -250,12 +380,12 @@ function createMcpRuntime(): McpRuntime {
     const resolvedCwd = lastKnownCwd || cwd || process.cwd();
     const configPath = getMcpConfigPath();
     const statePath = getMcpStatePath(resolvedCwd);
-    const [config, rawConfigUpdatedAt, metadataCache] = await Promise.all([
-      ensureConfigFile(configPath),
-      getConfigUpdatedAt(configPath),
-      readMetadataCache(),
-      ensureOAuthDir(),
-    ]);
+
+    await ensureOAuthDir();
+
+    const config = options.config ?? await ensureConfigFile(configPath);
+    const rawConfigUpdatedAt = options.rawConfigUpdatedAt ?? await getConfigUpdatedAt(configPath);
+    const metadataCache = options.metadataCache ?? await readMetadataCache();
 
     await writeMetadataCache(metadataCache);
 
@@ -282,115 +412,3 @@ function createMcpRuntime(): McpRuntime {
   };
 }
 
-function buildServerConfig(input: McpServerEditorInput, existing?: McpServerConfig): McpServerConfig {
-  const next: McpServerConfig = { ...(existing ?? {}) };
-  next.enabled = input.enabled;
-  next.lifecycle = input.lifecycle;
-  next.exposeResources = input.exposeResources;
-  next.debug = input.debug;
-
-  const cwd = input.cwd.trim();
-  if (cwd) next.cwd = cwd;
-  else delete next.cwd;
-
-  if (input.transport === 'stdio') {
-    const command = input.command.trim();
-    if (command) next.command = command;
-    else delete next.command;
-
-    const args = parseArgsText(input.argsText);
-    if (args.length > 0) next.args = args;
-    else delete next.args;
-
-    delete next.url;
-  } else {
-    const url = input.url.trim();
-    if (url) next.url = url;
-    else delete next.url;
-
-    delete next.command;
-    delete next.args;
-  }
-
-  switch (input.authMode) {
-    case 'oauth':
-      next.auth = 'oauth';
-      delete next.bearerToken;
-      delete next.bearerTokenEnv;
-      break;
-    case 'bearer': {
-      next.auth = 'bearer';
-      delete next.oauth;
-      const bearerTokenEnv = input.bearerTokenEnv.trim();
-      if (bearerTokenEnv) next.bearerTokenEnv = bearerTokenEnv;
-      else delete next.bearerTokenEnv;
-      break;
-    }
-    default:
-      next.auth = false;
-      delete next.bearerToken;
-      delete next.bearerTokenEnv;
-      delete next.oauth;
-      break;
-  }
-
-  return next;
-}
-
-function parseArgsText(argsText: string): string[] {
-  return argsText
-    .split('\n')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
-}
-
-function formatStatusSummary(snapshot: SyncedRuntimeState['snapshot']): string {
-  const lines = [
-    `MCP status: ${snapshot.summary.totalServers} server(s) configured`,
-    `Enabled: ${snapshot.summary.enabledServers}`,
-    `Connected: ${snapshot.summary.connectedServers}`,
-    `Needs auth: ${snapshot.summary.needsAuthServers}`,
-    `Errors: ${snapshot.summary.errorServers}`,
-  ];
-
-  if (snapshot.servers.length === 0) {
-    lines.push('', 'Open the MCP app in Sero to add your first MCP server.');
-  }
-
-  return lines.join('\n');
-}
-
-function formatServerList(snapshotServers: SyncedRuntimeState['snapshot']['servers']): string {
-  if (snapshotServers.length === 0) {
-    return 'No MCP servers are configured yet. Open the MCP app in Sero to add one.';
-  }
-
-  return snapshotServers
-    .map((server) => {
-      const enabledLabel = server.enabled ? 'enabled' : 'disabled';
-      return `- ${server.serverName} (${enabledLabel}, ${server.connectionStatus}, ${server.authStatus})`;
-    })
-    .join('\n');
-}
-
-function formatDiagnostics(state: SyncedRuntimeState, sessionRefCount: number, hasAttachedPi: boolean): string {
-  const lines = [
-    `Config: ${state.configPath}`,
-    `State: ${state.statePath}`,
-    `Raw config updated: ${state.rawConfigUpdatedAt ?? 'never'}`,
-    `Servers: ${state.snapshot.summary.totalServers}`,
-  ];
-
-  for (const server of state.snapshot.servers) {
-    lines.push(
-      `- ${server.serverName}: ${server.transport}, ${server.lifecycle}, ${server.connectionStatus}, ${server.authStatus}, tools=${server.toolCount}, resources=${server.resourceCount}`,
-    );
-  }
-
-  lines.push(`Runtime sessions: ${sessionRefCount}`);
-  if (hasAttachedPi) {
-    lines.push('Runtime: attached to active Pi extension instance');
-  }
-
-  return lines.join('\n');
-}

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -17,6 +17,7 @@ import {
   startServerAuthAction,
 } from './runtime-auth';
 import { readServerResourceAction } from './runtime-resource';
+import { executeProxyAction as executeProxyActionInternal } from './runtime-proxy';
 import { reconcileConnection } from './runtime-connect';
 import { createKeepAliveScheduler } from './runtime-keep-alive';
 import {
@@ -25,7 +26,7 @@ import {
 } from './runtime-lifecycle';
 import { writeState } from '../state/state-io';
 import { createToolResult, type ManagerAction, type ProxyAction, type ToolResult } from '../tools/types';
-import { buildServerConfig, formatDiagnostics, formatServerList, formatStatusSummary, mutationErrorResult } from './runtime-utils';
+import { buildServerConfig, formatDiagnostics, mutationErrorResult } from './runtime-utils';
 import type { SyncedRuntimeState } from './runtime-types';
 interface ManagerActionOptions {
   cwd?: string;
@@ -46,7 +47,10 @@ export interface McpRuntime {
   handleSessionSwitch(ctx: { cwd: string }): Promise<void>;
   handleSessionShutdown(): Promise<void>;
   executeManagerAction(action: ManagerAction, options?: ManagerActionOptions): Promise<ToolResult>;
-  executeProxyAction(action: ProxyAction, options?: { cwd?: string }): Promise<ToolResult>;
+  executeProxyAction(
+    action: ProxyAction,
+    options?: { cwd?: string; query?: string; serverName?: string; toolName?: string; argumentsJson?: string },
+  ): Promise<ToolResult>;
 }
 let runtimeSingleton: McpRuntime | null = null;
 export function getMcpRuntime(): McpRuntime {
@@ -193,21 +197,19 @@ function createMcpRuntime(): McpRuntime {
   }
   function executeProxyAction(
     action: ProxyAction,
-    options: { cwd?: string } = {},
+    options: { cwd?: string; query?: string; serverName?: string; toolName?: string; argumentsJson?: string } = {},
   ): Promise<ToolResult> {
-    return runExclusive(async () => {
-      const synced = await syncSnapshot(options.cwd);
-      if (action === 'list') {
-        return createToolResult(formatServerList(synced.snapshot.servers), {
-          mode: 'list',
-          serverCount: synced.snapshot.summary.totalServers,
-        });
-      }
-      return createToolResult(formatStatusSummary(synced.snapshot), {
-        mode: 'status',
-        serverCount: synced.snapshot.summary.totalServers,
-      });
-    });
+    return runExclusive(async () => executeProxyActionInternal({
+      action,
+      cwd: options.cwd,
+      query: options.query,
+      serverName: options.serverName,
+      toolName: options.toolName,
+      argumentsJson: options.argumentsJson,
+      manager,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    }));
   }
   async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
     return saveRawConfigAction({ cwd, rawConfigInput, writeConfigAndSyncSnapshot });

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -4,6 +4,7 @@ import { validateServerEditorInput } from '../../shared/types';
 import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';
 import {
   readMetadataCache,
+  removeMetadataCacheEntry,
   writeMetadataCache,
   type McpMetadataCacheDocument,
 } from '../cache/metadata-cache';
@@ -15,8 +16,10 @@ import {
   writeConfig,
 } from '../config/io';
 import type { McpConfigDocument, McpServerConfig } from '../config/types';
-import { buildSnapshot } from '../state/snapshot';
+import { McpServerManager } from '../manager/server-manager';
+import { buildSnapshot, type RuntimeServerStatus } from '../state/snapshot';
 import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
+import { formatConnectMessage, reconcileConnection } from './runtime-connect';
 import { writeState } from '../state/state-io';
 import {
   createToolResult,
@@ -77,6 +80,9 @@ function createMcpRuntime(): McpRuntime {
   let lastState: SyncedRuntimeState | null = null;
   let operationQueue: Promise<void> = Promise.resolve();
 
+  const manager = new McpServerManager({ hasOAuthTokens });
+  const runtimeStatuses = new Map<string, RuntimeServerStatus>();
+
   function attachPi(pi: ExtensionAPI): void {
     attachedPi = pi;
   }
@@ -111,6 +117,8 @@ function createMcpRuntime(): McpRuntime {
     return runExclusive(async () => {
       sessionRefCount = Math.max(0, sessionRefCount - 1);
       if (sessionRefCount === 0) {
+        await manager.closeAll();
+        runtimeStatuses.clear();
         lastState = null;
       }
     });
@@ -132,6 +140,10 @@ function createMcpRuntime(): McpRuntime {
           return toggleServer(options.cwd, options.serverName, true);
         case 'disable_server':
           return toggleServer(options.cwd, options.serverName, false);
+        case 'connect_server':
+          return connectServer(options.cwd, options.serverName, false);
+        case 'reconnect_server':
+          return connectServer(options.cwd, options.serverName, true);
         default:
           break;
       }
@@ -197,10 +209,7 @@ function createMcpRuntime(): McpRuntime {
     });
   }
 
-  async function saveRawConfig(
-    cwd: string | undefined,
-    rawConfigInput?: string,
-  ): Promise<ToolResult> {
+  async function saveRawConfig(cwd: string | undefined, rawConfigInput?: string): Promise<ToolResult> {
     if (!rawConfigInput?.trim()) {
       return createToolResult('Error: Raw config cannot be empty.', { snapshotWritten: false });
     }
@@ -225,10 +234,7 @@ function createMcpRuntime(): McpRuntime {
     }
   }
 
-  async function upsertServer(
-    cwd: string | undefined,
-    serverInput?: McpServerEditorInput,
-  ): Promise<ToolResult> {
+  async function upsertServer(cwd: string | undefined, serverInput?: McpServerEditorInput): Promise<ToolResult> {
     if (!serverInput) {
       return createToolResult('Error: Server input is required.', { snapshotWritten: false });
     }
@@ -244,9 +250,7 @@ function createMcpRuntime(): McpRuntime {
         const originalName = serverInput.originalServerName?.trim();
         const nextName = serverInput.serverName.trim();
         const hasRenameCollision = Boolean(
-          originalName &&
-          originalName !== nextName &&
-          nextServers[nextName],
+          originalName && originalName !== nextName && nextServers[nextName],
         );
         const hasCreateCollision = Boolean(!originalName && nextServers[nextName]);
 
@@ -257,6 +261,7 @@ function createMcpRuntime(): McpRuntime {
         const existing = originalName ? nextServers[originalName] : undefined;
         if (originalName && originalName !== nextName) {
           delete nextServers[originalName];
+          runtimeStatuses.delete(originalName);
         }
 
         nextServers[nextName] = buildServerConfig(serverInput, existing);
@@ -274,25 +279,23 @@ function createMcpRuntime(): McpRuntime {
     }
   }
 
-  async function removeServer(
-    cwd: string | undefined,
-    serverName?: string,
-  ): Promise<ToolResult> {
+  async function removeServer(cwd: string | undefined, serverName?: string): Promise<ToolResult> {
     const normalizedServerName = serverName?.trim();
     if (!normalizedServerName) {
       return createToolResult('Error: Server name is required.', { snapshotWritten: false });
     }
 
     try {
+      await manager.close(normalizedServerName);
+      runtimeStatuses.delete(normalizedServerName);
       const synced = await mutateConfig(cwd, (config) => {
         if (!config.mcpServers[normalizedServerName]) {
           throw new Error(`Server "${normalizedServerName}" does not exist.`);
         }
-
         const nextServers = { ...config.mcpServers };
         delete nextServers[normalizedServerName];
         config.mcpServers = nextServers;
-      });
+      }, normalizedServerName);
 
       return createToolResult(`Removed MCP server "${normalizedServerName}".`, {
         snapshotWritten: true,
@@ -305,23 +308,23 @@ function createMcpRuntime(): McpRuntime {
     }
   }
 
-  async function toggleServer(
-    cwd: string | undefined,
-    serverName: string | undefined,
-    enabled: boolean,
-  ): Promise<ToolResult> {
+  async function toggleServer(cwd: string | undefined, serverName: string | undefined, enabled: boolean): Promise<ToolResult> {
     const normalizedServerName = serverName?.trim();
     if (!normalizedServerName) {
       return createToolResult('Error: Server name is required.', { snapshotWritten: false });
     }
 
     try {
+      if (!enabled) {
+        await manager.close(normalizedServerName);
+        runtimeStatuses.delete(normalizedServerName);
+      }
+
       const synced = await mutateConfig(cwd, (config) => {
         const current = config.mcpServers[normalizedServerName];
         if (!current) {
           throw new Error(`Server "${normalizedServerName}" does not exist.`);
         }
-
         config.mcpServers = {
           ...config.mcpServers,
           [normalizedServerName]: {
@@ -331,23 +334,66 @@ function createMcpRuntime(): McpRuntime {
         };
       });
 
-      return createToolResult(
-        `${enabled ? 'Enabled' : 'Disabled'} MCP server "${normalizedServerName}".`,
-        {
-          snapshotWritten: true,
-          configPath: synced.configPath,
-          statePath: synced.statePath,
-          serverCount: synced.snapshot.summary.totalServers,
-        },
-      );
+      return createToolResult(`${enabled ? 'Enabled' : 'Disabled'} MCP server "${normalizedServerName}".`, {
+        snapshotWritten: true,
+        configPath: synced.configPath,
+        statePath: synced.statePath,
+        serverCount: synced.snapshot.summary.totalServers,
+      });
     } catch (error) {
       return mutationErrorResult(error);
     }
   }
 
+  async function connectServer(
+    cwd: string | undefined,
+    serverName: string | undefined,
+    reconnect: boolean,
+  ): Promise<ToolResult> {
+    const normalizedServerName = serverName?.trim();
+    if (!normalizedServerName) {
+      return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+    }
+
+    const synced = await syncSnapshot(cwd);
+    const serverConfig = synced.config.mcpServers[normalizedServerName];
+    if (!serverConfig) {
+      return createToolResult(`Error: Server "${normalizedServerName}" does not exist.`, { snapshotWritten: false });
+    }
+    if (serverConfig.enabled === false) {
+      return createToolResult(`Error: Server "${normalizedServerName}" is disabled. Enable it before connecting.`, { snapshotWritten: false });
+    }
+
+    const connection = reconnect
+      ? await manager.reconnect(normalizedServerName, serverConfig)
+      : await manager.connect(normalizedServerName, serverConfig);
+
+    const metadataCache = await readMetadataCache();
+    const { nextCache, runtimeStatus } = await reconcileConnection({
+      serverName: normalizedServerName,
+      serverConfig,
+      metadataCache,
+      connection,
+    });
+    runtimeStatuses.set(normalizedServerName, runtimeStatus);
+
+    const nextState = await syncSnapshot(cwd, { config: synced.config, metadataCache: nextCache });
+    return createToolResult(formatConnectMessage(normalizedServerName, connection.status), {
+      snapshotWritten: true,
+      configPath: nextState.configPath,
+      statePath: nextState.statePath,
+      connectionStatus: runtimeStatus.connectionStatus,
+      authStatus: runtimeStatus.authStatus,
+      toolCount: nextState.snapshot.servers.find((server) => server.serverName === normalizedServerName)?.toolCount ?? 0,
+      resourceCount: nextState.snapshot.servers.find((server) => server.serverName === normalizedServerName)?.resourceCount ?? 0,
+      lastError: runtimeStatus.lastError ?? null,
+    });
+  }
+
   async function mutateConfig(
     cwd: string | undefined,
     mutate: (config: McpConfigDocument) => void,
+    removeServerName?: string,
   ): Promise<SyncedRuntimeState> {
     const configPath = getMcpConfigPath();
     const config = await ensureConfigFile(configPath);
@@ -356,17 +402,29 @@ function createMcpRuntime(): McpRuntime {
       mcpServers: { ...config.mcpServers },
     };
     mutate(nextConfig);
-    return writeConfigAndSyncSnapshot(cwd, nextConfig);
+
+    let metadataCache = await readMetadataCache();
+    if (removeServerName) {
+      metadataCache = removeMetadataCacheEntry(metadataCache, removeServerName);
+      await writeMetadataCache(metadataCache);
+    }
+
+    return writeConfigAndSyncSnapshot(cwd, nextConfig, metadataCache);
   }
 
   async function writeConfigAndSyncSnapshot(
     cwd: string | undefined,
     config: McpConfigDocument,
+    metadataCacheOverride?: McpMetadataCacheDocument,
   ): Promise<SyncedRuntimeState> {
     const configPath = getMcpConfigPath();
     await writeConfig(config, configPath);
     const rawConfigUpdatedAt = await getConfigUpdatedAt(configPath);
-    return syncSnapshot(cwd, { config, rawConfigUpdatedAt });
+    return syncSnapshot(cwd, {
+      config,
+      rawConfigUpdatedAt,
+      metadataCache: metadataCacheOverride,
+    });
   }
 
   async function syncSnapshot(
@@ -387,16 +445,16 @@ function createMcpRuntime(): McpRuntime {
     const rawConfigUpdatedAt = options.rawConfigUpdatedAt ?? await getConfigUpdatedAt(configPath);
     const metadataCache = options.metadataCache ?? await readMetadataCache();
 
-    await writeMetadataCache(metadataCache);
-
     const snapshot = await buildSnapshot({
       configPath,
       rawConfigUpdatedAt,
       config,
       metadataCache,
       hasOAuthTokens,
+      runtimeStatuses,
     });
 
+    await writeMetadataCache(metadataCache);
     await writeState(snapshot, statePath);
     lastState = { configPath, statePath, config, metadataCache, rawConfigUpdatedAt, snapshot };
     return lastState;

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -48,7 +48,7 @@ export interface McpRuntime {
   handleSessionShutdown(): Promise<void>;
   executeManagerAction(action: ManagerAction, options?: ManagerActionOptions): Promise<ToolResult>;
   executeProxyAction(action: ProxyAction, options?: {
-    cwd?: string; query?: string; serverName?: string; toolName?: string;
+    cwd?: string; query?: string; serverName?: string; toolName?: string; resourceUri?: string;
     toolArguments?: Record<string, unknown>; argumentsJson?: string;
   }): Promise<ToolResult>;
 }
@@ -196,7 +196,7 @@ function createMcpRuntime(): McpRuntime {
     });
   }
   function executeProxyAction(action: ProxyAction, options: {
-    cwd?: string; query?: string; serverName?: string; toolName?: string;
+    cwd?: string; query?: string; serverName?: string; toolName?: string; resourceUri?: string;
     toolArguments?: Record<string, unknown>; argumentsJson?: string;
   } = {}): Promise<ToolResult> {
     return runExclusive(async () => executeProxyActionInternal({
@@ -205,6 +205,7 @@ function createMcpRuntime(): McpRuntime {
       query: options.query,
       serverName: options.serverName,
       toolName: options.toolName,
+      resourceUri: options.resourceUri,
       toolArguments: options.toolArguments,
       argumentsJson: options.argumentsJson,
       manager,

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -47,10 +47,10 @@ export interface McpRuntime {
   handleSessionSwitch(ctx: { cwd: string }): Promise<void>;
   handleSessionShutdown(): Promise<void>;
   executeManagerAction(action: ManagerAction, options?: ManagerActionOptions): Promise<ToolResult>;
-  executeProxyAction(
-    action: ProxyAction,
-    options?: { cwd?: string; query?: string; serverName?: string; toolName?: string; argumentsJson?: string },
-  ): Promise<ToolResult>;
+  executeProxyAction(action: ProxyAction, options?: {
+    cwd?: string; query?: string; serverName?: string; toolName?: string;
+    toolArguments?: Record<string, unknown>; argumentsJson?: string;
+  }): Promise<ToolResult>;
 }
 let runtimeSingleton: McpRuntime | null = null;
 export function getMcpRuntime(): McpRuntime {
@@ -195,16 +195,17 @@ function createMcpRuntime(): McpRuntime {
       );
     });
   }
-  function executeProxyAction(
-    action: ProxyAction,
-    options: { cwd?: string; query?: string; serverName?: string; toolName?: string; argumentsJson?: string } = {},
-  ): Promise<ToolResult> {
+  function executeProxyAction(action: ProxyAction, options: {
+    cwd?: string; query?: string; serverName?: string; toolName?: string;
+    toolArguments?: Record<string, unknown>; argumentsJson?: string;
+  } = {}): Promise<ToolResult> {
     return runExclusive(async () => executeProxyActionInternal({
       action,
       cwd: options.cwd,
       query: options.query,
       serverName: options.serverName,
       toolName: options.toolName,
+      toolArguments: options.toolArguments,
       argumentsJson: options.argumentsJson,
       manager,
       setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -2,52 +2,30 @@ import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import type { McpServerEditorInput } from '../../shared/types';
 import { validateServerEditorInput } from '../../shared/types';
 import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';
-import {
-  readMetadataCache,
-  removeMetadataCacheEntry,
-  writeMetadataCache,
-  type McpMetadataCacheDocument,
-} from '../cache/metadata-cache';
-import {
-  ensureConfigFile,
-  getConfigUpdatedAt,
-  readRawConfig,
-  writeConfig,
-} from '../config/io';
+import { readMetadataCache, removeMetadataCacheEntry, writeMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
+import { ensureConfigFile, getConfigUpdatedAt, readRawConfig, writeConfig } from '../config/io';
 import type { McpConfigDocument, McpServerConfig } from '../config/types';
 import { McpServerManager } from '../manager/server-manager';
 import { buildSnapshot, type RuntimeServerStatus } from '../state/snapshot';
 import { getMcpConfigPath, getMcpStatePath } from '../state/paths';
 import { connectServerAction, saveRawConfigAction } from './runtime-actions';
+import { readServerResourceAction } from './runtime-resource';
 import { reconcileConnection } from './runtime-connect';
 import { createKeepAliveScheduler } from './runtime-keep-alive';
 import {
-  getAutoConnectServerEntries,
-  getChangedServerNames,
-  getKeepAliveServerEntries,
-  KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS,
-  shouldAttemptAutoConnect,
+  getAutoConnectServerEntries, getChangedServerNames, getKeepAliveServerEntries,
+  KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS, shouldAttemptAutoConnect,
 } from './runtime-lifecycle';
 import { writeState } from '../state/state-io';
-import {
-  createToolResult,
-  type ManagerAction,
-  type ProxyAction,
-  type ToolResult,
-} from '../tools/types';
-import {
-  buildServerConfig,
-  formatDiagnostics,
-  formatServerList,
-  formatStatusSummary,
-  mutationErrorResult,
-} from './runtime-utils';
+import { createToolResult, type ManagerAction, type ProxyAction, type ToolResult } from '../tools/types';
+import { buildServerConfig, formatDiagnostics, formatServerList, formatStatusSummary, mutationErrorResult } from './runtime-utils';
 import type { SyncedRuntimeState } from './runtime-types';
 
 interface ManagerActionOptions {
   cwd?: string;
   rawConfig?: string;
   serverName?: string;
+  resourceUri?: string;
   serverInput?: McpServerEditorInput;
 }
 
@@ -154,6 +132,8 @@ function createMcpRuntime(): McpRuntime {
           return connectServer(options.cwd, options.serverName, false);
         case 'reconnect_server':
           return connectServer(options.cwd, options.serverName, true);
+        case 'read_resource':
+          return readServerResource(options.cwd, options.serverName, options.resourceUri);
         default:
           break;
       }
@@ -357,6 +337,21 @@ function createMcpRuntime(): McpRuntime {
       cwd,
       serverName,
       reconnect,
+      manager,
+      setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
+      syncSnapshot,
+    });
+  }
+
+  async function readServerResource(
+    cwd: string | undefined,
+    serverName: string | undefined,
+    resourceUri: string | undefined,
+  ): Promise<ToolResult> {
+    return readServerResourceAction({
+      cwd,
+      serverName,
+      resourceUri,
       manager,
       setRuntimeStatus: (name, status) => runtimeStatuses.set(name, status),
       syncSnapshot,

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-actions.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-actions.ts
@@ -1,0 +1,101 @@
+import { readMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
+import { normalizeConfigDocument } from '../config/io';
+import type { McpConfigDocument } from '../config/types';
+import { McpServerManager } from '../manager/server-manager';
+import type { RuntimeServerStatus } from '../state/snapshot';
+import { createToolResult, type ToolResult } from '../tools/types';
+import { formatConnectMessage, reconcileConnection } from './runtime-connect';
+import type { SyncedRuntimeState } from './runtime-types';
+
+export async function saveRawConfigAction(options: {
+  cwd?: string;
+  rawConfigInput?: string;
+  writeConfigAndSyncSnapshot: (
+    cwd: string | undefined,
+    config: McpConfigDocument,
+    metadataCacheOverride?: McpMetadataCacheDocument,
+  ) => Promise<SyncedRuntimeState>;
+}): Promise<ToolResult> {
+  if (!options.rawConfigInput?.trim()) {
+    return createToolResult('Error: Raw config cannot be empty.', { snapshotWritten: false });
+  }
+
+  try {
+    const normalized = normalizeConfigDocument(JSON.parse(options.rawConfigInput));
+    const synced = await options.writeConfigAndSyncSnapshot(options.cwd, normalized);
+    return createToolResult(
+      `Saved MCP config with ${synced.snapshot.summary.totalServers} configured server(s).`,
+      {
+        snapshotWritten: true,
+        configPath: synced.configPath,
+        statePath: synced.statePath,
+        rawConfig: `${JSON.stringify(normalized, null, 2)}\n`,
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return createToolResult(`Error: Failed to save raw MCP config. ${message}`, {
+      snapshotWritten: false,
+    });
+  }
+}
+
+export async function connectServerAction(options: {
+  cwd?: string;
+  serverName?: string;
+  reconnect: boolean;
+  manager: McpServerManager;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: McpMetadataCacheDocument;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}): Promise<ToolResult> {
+  const normalizedServerName = options.serverName?.trim();
+  if (!normalizedServerName) {
+    return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+  }
+
+  const synced = await options.syncSnapshot(options.cwd);
+  const serverConfig = synced.config.mcpServers[normalizedServerName];
+  if (!serverConfig) {
+    return createToolResult(`Error: Server "${normalizedServerName}" does not exist.`, { snapshotWritten: false });
+  }
+  if (serverConfig.enabled === false) {
+    return createToolResult(`Error: Server "${normalizedServerName}" is disabled. Enable it before connecting.`, { snapshotWritten: false });
+  }
+
+  const connection = options.reconnect
+    ? await options.manager.reconnect(normalizedServerName, serverConfig)
+    : await options.manager.connect(normalizedServerName, serverConfig);
+
+  const metadataCache = await readMetadataCache();
+  const { nextCache, runtimeStatus } = await reconcileConnection({
+    serverName: normalizedServerName,
+    serverConfig,
+    metadataCache,
+    connection,
+  });
+  options.setRuntimeStatus(normalizedServerName, runtimeStatus);
+
+  const nextState = await options.syncSnapshot(options.cwd, {
+    config: synced.config,
+    metadataCache: nextCache,
+  });
+  const nextServer = nextState.snapshot.servers.find((server) => server.serverName === normalizedServerName);
+
+  return createToolResult(formatConnectMessage(normalizedServerName, connection.status), {
+    snapshotWritten: true,
+    configPath: nextState.configPath,
+    statePath: nextState.statePath,
+    connectionStatus: runtimeStatus.connectionStatus,
+    authStatus: runtimeStatus.authStatus,
+    toolCount: nextServer?.toolCount ?? 0,
+    resourceCount: nextServer?.resourceCount ?? 0,
+    lastError: runtimeStatus.lastError ?? null,
+  });
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-actions.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-actions.ts
@@ -69,9 +69,16 @@ export async function connectServerAction(options: {
     return createToolResult(`Error: Server "${normalizedServerName}" is disabled. Enable it before connecting.`, { snapshotWritten: false });
   }
 
-  const connection = options.reconnect
-    ? await options.manager.reconnect(normalizedServerName, serverConfig)
-    : await options.manager.connect(normalizedServerName, serverConfig);
+  const existingConnection = options.manager.getConnection(normalizedServerName);
+  const alreadyConnected = !options.reconnect && existingConnection?.status === 'connected';
+  let connection: Awaited<ReturnType<McpServerManager['connect']>>;
+  if (options.reconnect) {
+    connection = await options.manager.reconnect(normalizedServerName, serverConfig);
+  } else if (alreadyConnected && existingConnection) {
+    connection = existingConnection;
+  } else {
+    connection = await options.manager.connect(normalizedServerName, serverConfig);
+  }
 
   const metadataCache = await readMetadataCache();
   const { nextCache, runtimeStatus } = await reconcileConnection({
@@ -88,7 +95,10 @@ export async function connectServerAction(options: {
   });
   const nextServer = nextState.snapshot.servers.find((server) => server.serverName === normalizedServerName);
 
-  return createToolResult(formatConnectMessage(normalizedServerName, connection.status), {
+  return createToolResult(formatConnectMessage(normalizedServerName, connection.status, {
+    reconnect: options.reconnect,
+    alreadyConnected,
+  }), {
     snapshotWritten: true,
     configPath: nextState.configPath,
     statePath: nextState.statePath,
@@ -97,5 +107,6 @@ export async function connectServerAction(options: {
     toolCount: nextServer?.toolCount ?? 0,
     resourceCount: nextServer?.resourceCount ?? 0,
     lastError: runtimeStatus.lastError ?? null,
+    alreadyConnected,
   });
 }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-auth.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-auth.ts
@@ -1,0 +1,174 @@
+import { McpOAuthCoordinator } from '../auth/oauth-coordinator';
+import { readMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
+import type { McpConfigDocument } from '../config/types';
+import { McpServerManager } from '../manager/server-manager';
+import type { RuntimeServerStatus } from '../state/snapshot';
+import { createToolResult, type ToolResult } from '../tools/types';
+import { reconcileConnection } from './runtime-connect';
+import type { SyncedRuntimeState } from './runtime-types';
+
+export async function startServerAuthAction(options: {
+  cwd?: string;
+  serverName?: string;
+  authCoordinator: McpOAuthCoordinator;
+  manager: McpServerManager;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: McpMetadataCacheDocument;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+  }
+
+  const synced = await options.syncSnapshot(options.cwd);
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { snapshotWritten: false });
+  }
+  if (serverConfig.enabled === false) {
+    return createToolResult(`Error: Server "${serverName}" is disabled. Enable it before authenticating.`, { snapshotWritten: false });
+  }
+  if (serverConfig.auth !== 'oauth') {
+    return createToolResult(`Error: Server "${serverName}" is not configured for OAuth authentication.`, { snapshotWritten: false });
+  }
+
+  const result = await options.authCoordinator.startAuth(serverName, serverConfig);
+  if (result.status === 'pending' && result.authUrl) {
+    options.setRuntimeStatus(serverName, {
+      connectionStatus: 'needs-auth',
+      authStatus: 'authenticating',
+    });
+    await options.syncSnapshot(options.cwd, { config: synced.config });
+    return createToolResult(`Authentication started for MCP server "${serverName}".`, {
+      snapshotWritten: true,
+      serverName,
+      authUrl: result.authUrl,
+      authStatus: 'authenticating',
+      authFlowPending: true,
+    });
+  }
+
+  const nextState = await reconnectAuthenticatedServer(options, synced, serverName);
+  const nextServer = nextState.snapshot.servers.find((server) => server.serverName === serverName);
+  return createToolResult(`Authenticated MCP server "${serverName}".`, {
+    snapshotWritten: true,
+    serverName,
+    authStatus: nextServer?.authStatus ?? 'authenticated',
+    connectionStatus: nextServer?.connectionStatus ?? 'connected',
+  });
+}
+
+export async function completeServerAuthAction(options: {
+  cwd?: string;
+  serverName?: string;
+  callbackUrl?: string;
+  authCoordinator: McpOAuthCoordinator;
+  manager: McpServerManager;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: McpMetadataCacheDocument;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  const callbackUrl = options.callbackUrl?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+  }
+  if (!callbackUrl) {
+    return createToolResult('Error: OAuth callback URL is required.', { snapshotWritten: false });
+  }
+
+  const synced = await options.syncSnapshot(options.cwd);
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { snapshotWritten: false });
+  }
+
+  await options.authCoordinator.completeAuth(serverName, callbackUrl);
+  const nextState = await reconnectAuthenticatedServer(options, synced, serverName);
+  const nextServer = nextState.snapshot.servers.find((server) => server.serverName === serverName);
+  return createToolResult(`Completed authentication for MCP server "${serverName}".`, {
+    snapshotWritten: true,
+    serverName,
+    authStatus: nextServer?.authStatus ?? 'authenticated',
+    connectionStatus: nextServer?.connectionStatus ?? 'connected',
+    toolCount: nextServer?.toolCount ?? 0,
+    resourceCount: nextServer?.resourceCount ?? 0,
+  });
+}
+
+export async function cancelServerAuthAction(options: {
+  cwd?: string;
+  serverName?: string;
+  authCoordinator: McpOAuthCoordinator;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: McpMetadataCacheDocument;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+  }
+
+  await options.authCoordinator.cancelAuth(serverName);
+  options.setRuntimeStatus(serverName, {
+    connectionStatus: 'needs-auth',
+    authStatus: 'not-authenticated',
+  });
+  const synced = await options.syncSnapshot(options.cwd);
+  return createToolResult(`Cancelled authentication for MCP server "${serverName}".`, {
+    snapshotWritten: true,
+    serverName,
+    authStatus: synced.snapshot.servers.find((server) => server.serverName === serverName)?.authStatus ?? 'not-authenticated',
+  });
+}
+
+async function reconnectAuthenticatedServer(
+  options: {
+    cwd?: string;
+    serverName?: string;
+    authCoordinator?: McpOAuthCoordinator;
+    manager: McpServerManager;
+    setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+    syncSnapshot: (
+      cwd?: string,
+      options?: {
+        config?: McpConfigDocument;
+        metadataCache?: McpMetadataCacheDocument;
+        rawConfigUpdatedAt?: string | null;
+      },
+    ) => Promise<SyncedRuntimeState>;
+  },
+  synced: SyncedRuntimeState,
+  serverName: string,
+): Promise<SyncedRuntimeState> {
+  const serverConfig = synced.config.mcpServers[serverName];
+  const connection = await options.manager.reconnect(serverName, serverConfig);
+  const metadataCache = await readMetadataCache();
+  const { nextCache, runtimeStatus } = await reconcileConnection({
+    serverName,
+    serverConfig,
+    metadataCache,
+    connection,
+  });
+  options.setRuntimeStatus(serverName, runtimeStatus);
+  return options.syncSnapshot(options.cwd, { config: synced.config, metadataCache: nextCache });
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-auth.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-auth.ts
@@ -1,3 +1,4 @@
+import { clearOAuthCredentials } from '../auth/storage';
 import { McpOAuthCoordinator } from '../auth/oauth-coordinator';
 import { readMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
 import type { McpConfigDocument } from '../config/types';
@@ -138,6 +139,47 @@ export async function cancelServerAuthAction(options: {
     snapshotWritten: true,
     serverName,
     authStatus: synced.snapshot.servers.find((server) => server.serverName === serverName)?.authStatus ?? 'not-authenticated',
+  });
+}
+
+export async function clearServerAuthAction(options: {
+  cwd?: string;
+  serverName?: string;
+  authCoordinator: McpOAuthCoordinator;
+  manager: McpServerManager;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: McpMetadataCacheDocument;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+  }
+
+  const synced = await options.syncSnapshot(options.cwd);
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { snapshotWritten: false });
+  }
+  if (serverConfig.auth !== 'oauth') {
+    return createToolResult(`Error: Server "${serverName}" is not configured for OAuth authentication.`, { snapshotWritten: false });
+  }
+
+  await options.authCoordinator.cancelAuth(serverName);
+  await options.manager.close(serverName);
+  await clearOAuthCredentials(serverName);
+  options.setRuntimeStatus(serverName, { authStatus: 'not-authenticated' });
+  const nextState = await options.syncSnapshot(options.cwd, { config: synced.config });
+  return createToolResult(`Cleared saved authentication for MCP server "${serverName}".`, {
+    snapshotWritten: true,
+    serverName,
+    authStatus: nextState.snapshot.servers.find((server) => server.serverName === serverName)?.authStatus ?? 'not-authenticated',
   });
 }
 

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-connect.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-connect.ts
@@ -1,0 +1,90 @@
+import {
+  computeServerHash,
+  setMetadataCacheEntry,
+  writeMetadataCache,
+  type McpMetadataCacheDocument,
+} from '../cache/metadata-cache';
+import type { McpServerConfig } from '../config/types';
+import { buildMetadataCacheEntry } from '../manager/tool-metadata';
+import type { ManagedConnection } from '../manager/types';
+import type { RuntimeServerStatus } from '../state/snapshot';
+
+export async function reconcileConnection(options: {
+  serverName: string;
+  serverConfig: McpServerConfig;
+  metadataCache: McpMetadataCacheDocument;
+  connection: ManagedConnection;
+}): Promise<{ nextCache: McpMetadataCacheDocument; runtimeStatus: RuntimeServerStatus }> {
+  const { serverName, serverConfig, metadataCache, connection } = options;
+
+  if (connection.status === 'connected') {
+    const nextCache = setMetadataCacheEntry(
+      metadataCache,
+      serverName,
+      buildMetadataCacheEntry({
+        configHash: computeServerHash(serverConfig),
+        tools: connection.tools,
+        resources: connection.resources,
+      }),
+    );
+    await writeMetadataCache(nextCache);
+    return {
+      nextCache,
+      runtimeStatus: {
+        connectionStatus: 'connected',
+        authStatus: resolveConnectedAuthStatus(serverConfig),
+        lastConnectedAt: connection.lastConnectedAt ?? new Date().toISOString(),
+        lastFailedAt: null,
+      },
+    };
+  }
+
+  if (connection.status === 'needs-auth') {
+    await writeMetadataCache(metadataCache);
+    return {
+      nextCache: metadataCache,
+      runtimeStatus: {
+        connectionStatus: 'needs-auth',
+        authStatus: 'not-authenticated',
+        lastError: connection.lastError,
+        lastConnectedAt: null,
+        lastFailedAt: connection.lastFailedAt ?? new Date().toISOString(),
+      },
+    };
+  }
+
+  await writeMetadataCache(metadataCache);
+  return {
+    nextCache: metadataCache,
+    runtimeStatus: {
+      connectionStatus: 'error',
+      authStatus: serverConfig.auth ? 'error' : 'not-required',
+      lastError: connection.lastError,
+      lastConnectedAt: null,
+      lastFailedAt: connection.lastFailedAt ?? new Date().toISOString(),
+    },
+  };
+}
+
+export function formatConnectMessage(
+  serverName: string,
+  status: ManagedConnection['status'],
+): string {
+  switch (status) {
+    case 'connected':
+      return `Connected MCP server "${serverName}".`;
+    case 'needs-auth':
+      return `Server "${serverName}" needs authentication before it can connect.`;
+    case 'error':
+      return `Server "${serverName}" failed to connect.`;
+    default:
+      return `Server "${serverName}" is closed.`;
+  }
+}
+
+function resolveConnectedAuthStatus(serverConfig: McpServerConfig) {
+  if (serverConfig.auth === 'oauth' || serverConfig.auth === 'bearer') {
+    return 'authenticated' as const;
+  }
+  return 'not-required' as const;
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-connect.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-connect.ts
@@ -69,14 +69,25 @@ export async function reconcileConnection(options: {
 export function formatConnectMessage(
   serverName: string,
   status: ManagedConnection['status'],
+  options: {
+    reconnect?: boolean;
+    alreadyConnected?: boolean;
+  } = {},
 ): string {
   switch (status) {
     case 'connected':
-      return `Connected MCP server "${serverName}".`;
+      if (options.alreadyConnected) {
+        return `MCP server "${serverName}" is already connected.`;
+      }
+      return options.reconnect
+        ? `Reconnected MCP server "${serverName}".`
+        : `Connected MCP server "${serverName}".`;
     case 'needs-auth':
       return `Server "${serverName}" needs authentication before it can connect.`;
     case 'error':
-      return `Server "${serverName}" failed to connect.`;
+      return options.reconnect
+        ? `Server "${serverName}" failed to reconnect.`
+        : `Server "${serverName}" failed to connect.`;
     default:
       return `Server "${serverName}" is closed.`;
   }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-keep-alive.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-keep-alive.ts
@@ -1,0 +1,35 @@
+export interface KeepAliveScheduler {
+  start(): void;
+  stop(): void;
+}
+
+export function createKeepAliveScheduler(options: {
+  intervalMs: number;
+  isEnabled: () => boolean;
+  onTick: () => Promise<void>;
+}): KeepAliveScheduler {
+  let timer: NodeJS.Timeout | null = null;
+  let running = false;
+
+  return {
+    start() {
+      if (timer) return;
+      timer = setInterval(() => {
+        if (running || !options.isEnabled()) {
+          return;
+        }
+        running = true;
+        void options.onTick().finally(() => {
+          running = false;
+        });
+      }, options.intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      if (!timer) return;
+      clearInterval(timer);
+      timer = null;
+      running = false;
+    },
+  };
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-lifecycle.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-lifecycle.ts
@@ -1,5 +1,5 @@
 import { computeServerHash } from '../cache/metadata-cache';
-import type { McpConfigDocument, McpServerConfig } from '../config/types';
+import { hasBearerTokenValue, type McpConfigDocument, type McpServerConfig } from '../config/types';
 import type { ManagedConnection } from '../manager/types';
 
 export const KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS = 30_000;
@@ -39,7 +39,7 @@ export async function shouldAttemptAutoConnect(options: {
   }
 
   if (serverConfig.auth === 'bearer') {
-    return Boolean(serverConfig.bearerToken || (serverConfig.bearerTokenEnv && process.env[serverConfig.bearerTokenEnv]));
+    return hasBearerTokenValue(serverConfig);
   }
 
   return true;

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-lifecycle.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-lifecycle.ts
@@ -4,7 +4,7 @@ import type { ManagedConnection } from '../manager/types';
 
 export const KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS = 30_000;
 
-type OAuthTokenChecker = (serverName: string) => Promise<boolean>;
+type OAuthTokenChecker = (serverName: string, serverUrl?: string) => Promise<boolean>;
 
 export function getAutoConnectServerEntries(config: McpConfigDocument): Array<[string, McpServerConfig]> {
   return Object.entries(config.mcpServers).filter(([, serverConfig]) => {
@@ -35,7 +35,7 @@ export async function shouldAttemptAutoConnect(options: {
   }
 
   if (serverConfig.auth === 'oauth') {
-    return hasOAuthTokens(serverName);
+    return hasOAuthTokens(serverName, serverConfig.url);
   }
 
   if (serverConfig.auth === 'bearer') {

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-lifecycle.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-lifecycle.ts
@@ -1,0 +1,66 @@
+import { computeServerHash } from '../cache/metadata-cache';
+import type { McpConfigDocument, McpServerConfig } from '../config/types';
+import type { ManagedConnection } from '../manager/types';
+
+export const KEEP_ALIVE_HEALTHCHECK_INTERVAL_MS = 30_000;
+
+type OAuthTokenChecker = (serverName: string) => Promise<boolean>;
+
+export function getAutoConnectServerEntries(config: McpConfigDocument): Array<[string, McpServerConfig]> {
+  return Object.entries(config.mcpServers).filter(([, serverConfig]) => {
+    return serverConfig.enabled !== false && serverConfig.lifecycle !== 'lazy';
+  });
+}
+
+export function getKeepAliveServerEntries(config: McpConfigDocument): Array<[string, McpServerConfig]> {
+  return Object.entries(config.mcpServers).filter(([, serverConfig]) => {
+    return serverConfig.enabled !== false && serverConfig.lifecycle === 'keep-alive';
+  });
+}
+
+export async function shouldAttemptAutoConnect(options: {
+  serverName: string;
+  serverConfig: McpServerConfig;
+  connection?: ManagedConnection;
+  hasOAuthTokens: OAuthTokenChecker;
+}): Promise<boolean> {
+  const { serverName, serverConfig, connection, hasOAuthTokens } = options;
+
+  if (serverConfig.enabled === false || serverConfig.lifecycle === 'lazy') {
+    return false;
+  }
+
+  if (connection?.status === 'connected') {
+    return false;
+  }
+
+  if (serverConfig.auth === 'oauth') {
+    return hasOAuthTokens(serverName);
+  }
+
+  if (serverConfig.auth === 'bearer') {
+    return Boolean(serverConfig.bearerToken || (serverConfig.bearerTokenEnv && process.env[serverConfig.bearerTokenEnv]));
+  }
+
+  return true;
+}
+
+export function getChangedServerNames(
+  previousConfig: McpConfigDocument,
+  nextConfig: McpConfigDocument,
+): string[] {
+  const changed = new Set<string>();
+
+  for (const [serverName, previousServer] of Object.entries(previousConfig.mcpServers)) {
+    const nextServer = nextConfig.mcpServers[serverName];
+    if (!nextServer) {
+      changed.add(serverName);
+      continue;
+    }
+    if (computeServerHash(previousServer) !== computeServerHash(nextServer)) {
+      changed.add(serverName);
+    }
+  }
+
+  return [...changed];
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-manager-router.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-manager-router.ts
@@ -1,0 +1,80 @@
+import { readRawConfig } from '../config/io';
+import type { McpConfigDocument } from '../config/types';
+import { createToolResult, type ManagerAction, type ToolResult } from '../tools/types';
+import type { ManagerActionOptions, SyncedRuntimeState, SyncSnapshotOptions } from './runtime-types';
+import { formatDiagnostics } from './runtime-utils';
+
+export interface ManagerActionRouterInput {
+  action: ManagerAction;
+  options: ManagerActionOptions;
+  handlers: Partial<Record<ManagerAction, () => Promise<ToolResult>>>;
+  syncSnapshot: (cwd?: string, options?: SyncSnapshotOptions) => Promise<SyncedRuntimeState>;
+  reconcileManagedServers: (
+    cwd: string | undefined,
+    config: McpConfigDocument,
+    mode: 'startup' | 'keep-alive',
+  ) => Promise<SyncedRuntimeState | null>;
+  startKeepAliveScheduler: () => void;
+  sessionRefCount: number;
+  hasAttachedPi: boolean;
+}
+
+export async function executeManagerActionRoute(input: ManagerActionRouterInput): Promise<ToolResult> {
+  const directHandler = input.handlers[input.action];
+  if (directHandler) {
+    return directHandler();
+  }
+
+  const synced = await input.syncSnapshot(input.options.cwd);
+
+  if (input.action === 'bootstrap' || input.action === 'refresh') {
+    input.startKeepAliveScheduler();
+    const nextState = await input.reconcileManagedServers(input.options.cwd, synced.config, 'startup') ?? synced;
+    const prefix = input.action === 'refresh' ? 'Refreshed' : 'Initialized';
+    return createToolResult(
+      `${prefix} MCP app state for ${nextState.snapshot.summary.totalServers} configured server(s).`,
+      {
+        snapshotWritten: true,
+        configPath: nextState.configPath,
+        statePath: nextState.statePath,
+        serverCount: nextState.snapshot.summary.totalServers,
+      },
+    );
+  }
+
+  if (input.action === 'get_raw_config') {
+    const rawConfig = await readRawConfig(synced.configPath);
+    return createToolResult(rawConfig.trim() || '{}', {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      rawConfig,
+    });
+  }
+
+  if (input.action === 'get_diagnostics') {
+    return createToolResult(formatDiagnostics({
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      rawConfigUpdatedAt: synced.rawConfigUpdatedAt,
+      snapshot: synced.snapshot,
+      sessionRefCount: input.sessionRefCount,
+      hasAttachedPi: input.hasAttachedPi,
+    }), {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      metadataCache: synced.metadataCache,
+    });
+  }
+
+  return createToolResult(
+    `Initialized MCP app state for ${synced.snapshot.summary.totalServers} configured server(s).`,
+    {
+      snapshotWritten: true,
+      configPath: synced.configPath,
+      statePath: synced.statePath,
+      serverCount: synced.snapshot.summary.totalServers,
+    },
+  );
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
@@ -12,6 +12,7 @@ import { McpServerManager } from '../manager/server-manager';
 import type { ManagedConnection, ManagedTool } from '../manager/types';
 import type { RuntimeServerStatus } from '../state/snapshot';
 import { createToolResult, type ProxyAction, type ToolResult } from '../tools/types';
+import { readProxyResourceAction } from './runtime-resource';
 import { reconcileConnection } from './runtime-connect';
 import { formatServerList, formatStatusSummary } from './runtime-utils';
 import type { SyncedRuntimeState } from './runtime-types';
@@ -20,6 +21,7 @@ interface ProxyToolOptions {
   query?: string;
   serverName?: string;
   toolName?: string;
+  resourceUri?: string;
   toolArguments?: Record<string, unknown>;
   argumentsJson?: string;
   manager: McpServerManager;
@@ -67,6 +69,8 @@ export async function executeProxyAction(options: ProxyToolOptions & { action: P
       return describeServerTool(options, synced);
     case 'call_tool':
       return callServerTool(options, synced);
+    case 'read_resource':
+      return readProxyResourceAction(options);
     default:
       return createToolResult('Error: Unsupported MCP proxy action.', { mode: 'unknown_action' });
   }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
@@ -1,0 +1,450 @@
+import { getToolUiResourceUri } from '@modelcontextprotocol/ext-apps/app-bridge';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import {
+  isMetadataCacheEntryValid,
+  readMetadataCache,
+  type McpMetadataCacheDocument,
+} from '../cache/metadata-cache';
+import type { McpConfigDocument } from '../config/types';
+import { serializeResources, serializeTools } from '../manager/tool-metadata';
+import { McpServerManager } from '../manager/server-manager';
+import type { ManagedConnection, ManagedTool } from '../manager/types';
+import type { RuntimeServerStatus } from '../state/snapshot';
+import { createToolResult, type ProxyAction, type ToolResult } from '../tools/types';
+import { reconcileConnection } from './runtime-connect';
+import { formatServerList, formatStatusSummary } from './runtime-utils';
+import type { SyncedRuntimeState } from './runtime-types';
+
+interface ProxyToolOptions {
+  cwd?: string;
+  query?: string;
+  serverName?: string;
+  toolName?: string;
+  argumentsJson?: string;
+  manager: McpServerManager;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: McpMetadataCacheDocument;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}
+
+interface ToolInventoryEntry {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+  uiResourceUri?: string;
+}
+
+interface ResourceInventoryEntry {
+  uri: string;
+  name: string;
+  description?: string;
+}
+
+export async function executeProxyAction(options: ProxyToolOptions & { action: ProxyAction }): Promise<ToolResult> {
+  const synced = await options.syncSnapshot(options.cwd);
+
+  switch (options.action) {
+    case 'status':
+      return createToolResult(formatStatusSummary(synced.snapshot), {
+        mode: 'status',
+        serverCount: synced.snapshot.summary.totalServers,
+      });
+    case 'list':
+      return createToolResult(formatServerList(synced.snapshot.servers), {
+        mode: 'list',
+        serverCount: synced.snapshot.summary.totalServers,
+      });
+    case 'search':
+      return searchProxyInventory(options, synced);
+    case 'list_tools':
+      return listServerTools(options, synced);
+    case 'describe_tool':
+      return describeServerTool(options, synced);
+    case 'call_tool':
+      return callServerTool(options, synced);
+    default:
+      return createToolResult('Error: Unsupported MCP proxy action.', { mode: 'unknown_action' });
+  }
+}
+
+async function searchProxyInventory(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
+  const query = options.query?.trim();
+  if (!query) {
+    return createToolResult('Error: Search query is required.', { mode: 'search' });
+  }
+
+  const pattern = new RegExp(query.split(/\s+/).filter(Boolean).map(escapeRegex).join('|'), 'i');
+  const matches: Array<Record<string, unknown>> = [];
+  const servers = options.serverName?.trim() ? [options.serverName.trim()] : Object.keys(synced.config.mcpServers);
+
+  for (const serverName of servers) {
+    const toolInventory = getToolInventory(serverName, synced, options.manager);
+    const resourceInventory = getResourceInventory(serverName, synced, options.manager);
+
+    for (const tool of toolInventory) {
+      if (pattern.test(tool.name) || pattern.test(tool.description ?? '')) {
+        matches.push({
+          kind: 'tool',
+          serverName,
+          name: tool.name,
+          description: tool.description ?? null,
+          uiResourceUri: tool.uiResourceUri ?? null,
+        });
+      }
+    }
+
+    for (const resource of resourceInventory) {
+      if (pattern.test(resource.name) || pattern.test(resource.description ?? '') || pattern.test(resource.uri)) {
+        matches.push({
+          kind: 'resource',
+          serverName,
+          name: resource.name,
+          uri: resource.uri,
+          description: resource.description ?? null,
+        });
+      }
+    }
+  }
+
+  if (matches.length === 0) {
+    return createToolResult(
+      `No MCP tools or resources matched "${query}". Connect or refresh servers in the MCP app if metadata has not been loaded yet.`,
+      { mode: 'search', query, matches: [] },
+    );
+  }
+
+  const lines = [`Found ${matches.length} MCP match(es) for "${query}":`, ''];
+  for (const match of matches) {
+    if (match.kind === 'tool') {
+      lines.push(`- [tool] ${match.serverName as string}.${match.name as string}`);
+      if (typeof match.description === 'string' && match.description) {
+        lines.push(`  ${match.description}`);
+      }
+      if (typeof match.uiResourceUri === 'string' && match.uiResourceUri) {
+        lines.push(`  UI resource: ${match.uiResourceUri}`);
+      }
+      continue;
+    }
+
+    lines.push(`- [resource] ${match.serverName as string} ${match.uri as string}`);
+    if (typeof match.description === 'string' && match.description) {
+      lines.push(`  ${match.description}`);
+    }
+  }
+
+  return createToolResult(lines.join('\n'), { mode: 'search', query, matches });
+}
+
+async function listServerTools(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { mode: 'list_tools' });
+  }
+
+  if (!synced.config.mcpServers[serverName]) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { mode: 'list_tools', serverName });
+  }
+
+  const tools = getToolInventory(serverName, synced, options.manager);
+  if (tools.length === 0) {
+    return createToolResult(getMissingMetadataMessage(serverName, synced), {
+      mode: 'list_tools',
+      serverName,
+      tools: [],
+    });
+  }
+
+  const lines = [`${serverName} tools (${tools.length}):`, ''];
+  for (const tool of tools) {
+    lines.push(`- ${tool.name}${tool.uiResourceUri ? ' [UI]' : ''}`);
+    if (tool.description) {
+      lines.push(`  ${tool.description}`);
+    }
+  }
+
+  return createToolResult(lines.join('\n'), {
+    mode: 'list_tools',
+    serverName,
+    tools: tools.map((tool) => ({
+      name: tool.name,
+      description: tool.description ?? null,
+      uiResourceUri: tool.uiResourceUri ?? null,
+    })),
+  });
+}
+
+async function describeServerTool(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  const toolName = options.toolName?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { mode: 'describe_tool' });
+  }
+  if (!toolName) {
+    return createToolResult('Error: Tool name is required.', { mode: 'describe_tool', serverName });
+  }
+  if (!synced.config.mcpServers[serverName]) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { mode: 'describe_tool', serverName });
+  }
+
+  const tool = getToolInventory(serverName, synced, options.manager).find((entry) => entry.name === toolName);
+  if (!tool) {
+    return createToolResult(
+      `Error: Tool "${toolName}" was not found on "${serverName}". Use action="list_tools" to inspect the available tool names.`,
+      { mode: 'describe_tool', serverName, toolName },
+    );
+  }
+
+  const lines = [`Tool: ${serverName}.${tool.name}`];
+  if (tool.description) {
+    lines.push('', tool.description);
+  }
+  if (tool.uiResourceUri) {
+    lines.push('', `UI resource: ${tool.uiResourceUri}`);
+  }
+  lines.push('', 'Input schema:', formatUnknown(tool.inputSchema ?? '(no schema reported)'));
+
+  return createToolResult(lines.join('\n'), {
+    mode: 'describe_tool',
+    serverName,
+    toolName,
+    inputSchema: tool.inputSchema ?? null,
+    uiResourceUri: tool.uiResourceUri ?? null,
+  });
+}
+
+async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  const toolName = options.toolName?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { mode: 'call_tool' });
+  }
+  if (!toolName) {
+    return createToolResult('Error: Tool name is required.', { mode: 'call_tool', serverName });
+  }
+
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { mode: 'call_tool', serverName, toolName });
+  }
+  if (serverConfig.enabled === false) {
+    return createToolResult(`Error: Server "${serverName}" is disabled. Enable it before calling tools.`, {
+      mode: 'call_tool',
+      serverName,
+      toolName,
+    });
+  }
+
+  const toolArguments = parseToolArguments(options.argumentsJson);
+  if (toolArguments instanceof Error) {
+    return createToolResult(`Error: ${toolArguments.message}`, { mode: 'call_tool', serverName, toolName });
+  }
+
+  const connection = await ensureConnectedServer(options, synced, serverName);
+  if (connection.status === 'needs-auth') {
+    return createToolResult(buildAuthRequiredMessage(serverName), {
+      mode: 'call_tool',
+      serverName,
+      toolName,
+      authRequired: true,
+    });
+  }
+  if (connection.status !== 'connected') {
+    return createToolResult(
+      `Error: Server "${serverName}" failed to connect before calling "${toolName}".${connection.lastError ? ` ${connection.lastError}` : ''}`,
+      { mode: 'call_tool', serverName, toolName },
+    );
+  }
+
+  const liveTool = connection.tools.find((tool) => tool.name === toolName);
+  if (!liveTool) {
+    const availableTools = connection.tools.map((tool) => tool.name).sort();
+    return createToolResult(
+      `Error: Tool "${toolName}" was not found on "${serverName}". Available tools: ${availableTools.join(', ') || '(none)'}.`,
+      { mode: 'call_tool', serverName, toolName, availableTools },
+    );
+  }
+
+  try {
+    const result = await options.manager.callTool(serverName, toolName, toolArguments);
+    const text = formatCallToolResult(serverName, liveTool, result);
+    return createToolResult(text, {
+      mode: 'call_tool',
+      serverName,
+      toolName,
+      isError: Boolean(result.isError),
+      structuredContent: result.structuredContent ?? null,
+      uiResourceUri: getToolUiResourceUri({ _meta: liveTool._meta }) ?? null,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return createToolResult(`Error: Failed to call MCP tool "${toolName}" on "${serverName}". ${message}`, {
+      mode: 'call_tool',
+      serverName,
+      toolName,
+    });
+  }
+}
+
+async function ensureConnectedServer(
+  options: ProxyToolOptions,
+  synced: SyncedRuntimeState,
+  serverName: string,
+): Promise<ManagedConnection> {
+  const existing = options.manager.getConnection(serverName);
+  if (existing?.status === 'connected' || existing?.status === 'needs-auth') {
+    return existing;
+  }
+
+  const serverConfig = synced.config.mcpServers[serverName];
+  const connection = existing
+    ? await options.manager.reconnect(serverName, serverConfig)
+    : await options.manager.connect(serverName, serverConfig);
+  const metadataCache = await readMetadataCache();
+  const { nextCache, runtimeStatus } = await reconcileConnection({
+    serverName,
+    serverConfig,
+    metadataCache,
+    connection,
+  });
+  options.setRuntimeStatus(serverName, runtimeStatus);
+  await options.syncSnapshot(options.cwd, { config: synced.config, metadataCache: nextCache });
+  return connection;
+}
+
+function getToolInventory(serverName: string, synced: SyncedRuntimeState, manager: McpServerManager): ToolInventoryEntry[] {
+  const connection = manager.getConnection(serverName);
+  if (connection?.status === 'connected') {
+    return serializeTools(connection.tools);
+  }
+
+  const serverConfig = synced.config.mcpServers[serverName];
+  const cachedEntry = serverConfig ? synced.metadataCache.servers[serverName] : undefined;
+  if (serverConfig && cachedEntry && isMetadataCacheEntryValid(cachedEntry, serverConfig)) {
+    return cachedEntry.tools;
+  }
+
+  return [];
+}
+
+function getResourceInventory(serverName: string, synced: SyncedRuntimeState, manager: McpServerManager): ResourceInventoryEntry[] {
+  const connection = manager.getConnection(serverName);
+  if (connection?.status === 'connected') {
+    return serializeResources(connection.resources);
+  }
+
+  const serverConfig = synced.config.mcpServers[serverName];
+  const cachedEntry = serverConfig ? synced.metadataCache.servers[serverName] : undefined;
+  if (serverConfig && cachedEntry && isMetadataCacheEntryValid(cachedEntry, serverConfig)) {
+    return cachedEntry.resources;
+  }
+
+  return [];
+}
+
+function getMissingMetadataMessage(serverName: string, synced: SyncedRuntimeState): string {
+  const server = synced.snapshot.servers.find((entry) => entry.serverName === serverName);
+  if (server?.connectionStatus === 'needs-auth' || server?.authStatus === 'not-authenticated') {
+    return buildAuthRequiredMessage(serverName);
+  }
+  return `No MCP metadata is cached for "${serverName}" yet. Connect or refresh this server in the MCP app first.`;
+}
+
+function buildAuthRequiredMessage(serverName: string): string {
+  return `Server "${serverName}" requires in-app authentication. Open the MCP app in Sero and authenticate there.`;
+}
+
+function parseToolArguments(argumentsJson: string | undefined): Record<string, unknown> | undefined | Error {
+  const trimmed = argumentsJson?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return new Error('Tool arguments must be a JSON object.');
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return new Error('Tool arguments must be valid JSON.');
+  }
+}
+
+function formatCallToolResult(serverName: string, tool: ManagedTool, result: CallToolResult): string {
+  const lines = extractResultContentLines(result);
+  const text = lines.join('\n').trim();
+  const uiResourceUri = getToolUiResourceUri({ _meta: tool._meta });
+  const structured = formatStructuredContent(result.structuredContent);
+  const sections = [text || (result.isError ? 'Tool execution failed.' : '(empty result)')];
+
+  if (structured) {
+    sections.push(`Structured content:\n${structured}`);
+  }
+  if (uiResourceUri) {
+    sections.push(`This tool also advertises a UI resource: ${uiResourceUri}. Open it from the MCP app for the embedded UI experience.`);
+  }
+  if (result.isError && tool.inputSchema) {
+    sections.push(`Expected input schema:\n${formatUnknown(tool.inputSchema)}`);
+  }
+
+  const body = sections.join('\n\n');
+  return result.isError
+    ? `Error: MCP tool ${serverName}.${tool.name} failed.\n\n${body}`
+    : `MCP tool result from ${serverName}.${tool.name}:\n\n${body}`;
+}
+
+function extractResultContentLines(result: CallToolResult): string[] {
+  const contents = Array.isArray(result.content) ? result.content : [];
+  return contents.map((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return '[unknown MCP content]';
+    }
+
+    const block = entry as Record<string, unknown>;
+    if (block.type === 'text' && typeof block.text === 'string') {
+      return block.text;
+    }
+    if (block.type === 'image') {
+      return `[image content${typeof block.mimeType === 'string' ? `: ${block.mimeType}` : ''}]`;
+    }
+    if (block.type === 'audio') {
+      return `[audio content${typeof block.mimeType === 'string' ? `: ${block.mimeType}` : ''}]`;
+    }
+    if (block.type === 'resource' || block.type === 'resource_link') {
+      const resource = block.resource && typeof block.resource === 'object'
+        ? block.resource as Record<string, unknown>
+        : null;
+      const uri = typeof resource?.uri === 'string' ? resource.uri : '(unknown resource)';
+      return `[resource: ${uri}]`;
+    }
+    return `[${typeof block.type === 'string' ? block.type : 'unknown'} content]`;
+  });
+}
+
+function formatStructuredContent(value: unknown): string {
+  if (value === undefined) {
+    return '';
+  }
+  return formatUnknown(value);
+}
+
+function formatUnknown(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
@@ -80,6 +80,9 @@ async function searchProxyInventory(options: ProxyToolOptions, synced: SyncedRun
   if (!query) {
     return createToolResult('Error: Search query is required.', { mode: 'search' });
   }
+  // Search stays intentionally broad: whitespace-separated query tokens are
+  // treated as OR terms so short discovery prompts like "read file" or
+  // "github issue" still surface likely matches from cached MCP inventory.
   const pattern = new RegExp(query.split(/\s+/).filter(Boolean).map(escapeRegex).join('|'), 'i');
   const matches: Array<Record<string, unknown>> = [];
   const servers = options.serverName?.trim() ? [options.serverName.trim()] : Object.keys(synced.config.mcpServers);

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
@@ -1,4 +1,5 @@
 import { getToolUiResourceUri } from '@modelcontextprotocol/ext-apps/app-bridge';
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import {
   isMetadataCacheEntryValid,
@@ -282,6 +283,26 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
       uiResourceUri: getToolUiResourceUri({ _meta: liveTool._meta }) ?? null,
     });
   } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      const message = error.message || 'Authentication is required.';
+      await options.manager.close(serverName);
+      options.setRuntimeStatus(serverName, {
+        connectionStatus: 'needs-auth',
+        authStatus: 'not-authenticated',
+        lastError: message,
+        lastConnectedAt: null,
+        lastFailedAt: new Date().toISOString(),
+      });
+      await options.syncSnapshot(options.cwd, { config: synced.config });
+      return createToolResult(buildAuthRequiredMessage(serverName), {
+        mode: 'call_tool',
+        serverName,
+        toolName,
+        authRequired: true,
+        snapshotWritten: true,
+      });
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     return createToolResult(`Error: Failed to call MCP tool "${toolName}" on "${serverName}". ${message}`, {
       mode: 'call_tool',

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
@@ -15,7 +15,6 @@ import { createToolResult, type ProxyAction, type ToolResult } from '../tools/ty
 import { reconcileConnection } from './runtime-connect';
 import { formatServerList, formatStatusSummary } from './runtime-utils';
 import type { SyncedRuntimeState } from './runtime-types';
-
 interface ProxyToolOptions {
   cwd?: string;
   query?: string;
@@ -33,23 +32,19 @@ interface ProxyToolOptions {
     },
   ) => Promise<SyncedRuntimeState>;
 }
-
 interface ToolInventoryEntry {
   name: string;
   description?: string;
   inputSchema?: unknown;
   uiResourceUri?: string;
 }
-
 interface ResourceInventoryEntry {
   uri: string;
   name: string;
   description?: string;
 }
-
 export async function executeProxyAction(options: ProxyToolOptions & { action: ProxyAction }): Promise<ToolResult> {
   const synced = await options.syncSnapshot(options.cwd);
-
   switch (options.action) {
     case 'status':
       return createToolResult(formatStatusSummary(synced.snapshot), {
@@ -65,6 +60,8 @@ export async function executeProxyAction(options: ProxyToolOptions & { action: P
       return searchProxyInventory(options, synced);
     case 'list_tools':
       return listServerTools(options, synced);
+    case 'list_resources':
+      return listServerResources(options, synced);
     case 'describe_tool':
       return describeServerTool(options, synced);
     case 'call_tool':
@@ -73,21 +70,17 @@ export async function executeProxyAction(options: ProxyToolOptions & { action: P
       return createToolResult('Error: Unsupported MCP proxy action.', { mode: 'unknown_action' });
   }
 }
-
 async function searchProxyInventory(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
   const query = options.query?.trim();
   if (!query) {
     return createToolResult('Error: Search query is required.', { mode: 'search' });
   }
-
   const pattern = new RegExp(query.split(/\s+/).filter(Boolean).map(escapeRegex).join('|'), 'i');
   const matches: Array<Record<string, unknown>> = [];
   const servers = options.serverName?.trim() ? [options.serverName.trim()] : Object.keys(synced.config.mcpServers);
-
   for (const serverName of servers) {
     const toolInventory = getToolInventory(serverName, synced, options.manager);
     const resourceInventory = getResourceInventory(serverName, synced, options.manager);
-
     for (const tool of toolInventory) {
       if (pattern.test(tool.name) || pattern.test(tool.description ?? '')) {
         matches.push({
@@ -99,7 +92,6 @@ async function searchProxyInventory(options: ProxyToolOptions, synced: SyncedRun
         });
       }
     }
-
     for (const resource of resourceInventory) {
       if (pattern.test(resource.name) || pattern.test(resource.description ?? '') || pattern.test(resource.uri)) {
         matches.push({
@@ -112,14 +104,12 @@ async function searchProxyInventory(options: ProxyToolOptions, synced: SyncedRun
       }
     }
   }
-
   if (matches.length === 0) {
     return createToolResult(
       `No MCP tools or resources matched "${query}". Connect or refresh servers in the MCP app if metadata has not been loaded yet.`,
       { mode: 'search', query, matches: [] },
     );
   }
-
   const lines = [`Found ${matches.length} MCP match(es) for "${query}":`, ''];
   for (const match of matches) {
     if (match.kind === 'tool') {
@@ -132,26 +122,21 @@ async function searchProxyInventory(options: ProxyToolOptions, synced: SyncedRun
       }
       continue;
     }
-
     lines.push(`- [resource] ${match.serverName as string} ${match.uri as string}`);
     if (typeof match.description === 'string' && match.description) {
       lines.push(`  ${match.description}`);
     }
   }
-
   return createToolResult(lines.join('\n'), { mode: 'search', query, matches });
 }
-
 async function listServerTools(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
   const serverName = options.serverName?.trim();
   if (!serverName) {
     return createToolResult('Error: Server name is required.', { mode: 'list_tools' });
   }
-
   if (!synced.config.mcpServers[serverName]) {
     return createToolResult(`Error: Server "${serverName}" does not exist.`, { mode: 'list_tools', serverName });
   }
-
   const tools = getToolInventory(serverName, synced, options.manager);
   if (tools.length === 0) {
     return createToolResult(getMissingMetadataMessage(serverName, synced), {
@@ -160,7 +145,6 @@ async function listServerTools(options: ProxyToolOptions, synced: SyncedRuntimeS
       tools: [],
     });
   }
-
   const lines = [`${serverName} tools (${tools.length}):`, ''];
   for (const tool of tools) {
     lines.push(`- ${tool.name}${tool.uiResourceUri ? ' [UI]' : ''}`);
@@ -168,7 +152,6 @@ async function listServerTools(options: ProxyToolOptions, synced: SyncedRuntimeS
       lines.push(`  ${tool.description}`);
     }
   }
-
   return createToolResult(lines.join('\n'), {
     mode: 'list_tools',
     serverName,
@@ -179,7 +162,40 @@ async function listServerTools(options: ProxyToolOptions, synced: SyncedRuntimeS
     })),
   });
 }
-
+async function listServerResources(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { mode: 'list_resources' });
+  }
+  if (!synced.config.mcpServers[serverName]) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { mode: 'list_resources', serverName });
+  }
+  const resources = getResourceInventory(serverName, synced, options.manager);
+  if (resources.length === 0) {
+    return createToolResult(getMissingMetadataMessage(serverName, synced), {
+      mode: 'list_resources',
+      serverName,
+      resources: [],
+    });
+  }
+  const lines = [`${serverName} resources (${resources.length}):`, ''];
+  for (const resource of resources) {
+    lines.push(`- ${resource.name}`);
+    lines.push(`  ${resource.uri}`);
+    if (resource.description) {
+      lines.push(`  ${resource.description}`);
+    }
+  }
+  return createToolResult(lines.join('\n'), {
+    mode: 'list_resources',
+    serverName,
+    resources: resources.map((resource) => ({
+      uri: resource.uri,
+      name: resource.name,
+      description: resource.description ?? null,
+    })),
+  });
+}
 async function describeServerTool(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
   const serverName = options.serverName?.trim();
   const toolName = options.toolName?.trim();
@@ -192,7 +208,6 @@ async function describeServerTool(options: ProxyToolOptions, synced: SyncedRunti
   if (!synced.config.mcpServers[serverName]) {
     return createToolResult(`Error: Server "${serverName}" does not exist.`, { mode: 'describe_tool', serverName });
   }
-
   const tool = getToolInventory(serverName, synced, options.manager).find((entry) => entry.name === toolName);
   if (!tool) {
     return createToolResult(
@@ -200,7 +215,6 @@ async function describeServerTool(options: ProxyToolOptions, synced: SyncedRunti
       { mode: 'describe_tool', serverName, toolName },
     );
   }
-
   const lines = [`Tool: ${serverName}.${tool.name}`];
   if (tool.description) {
     lines.push('', tool.description);
@@ -209,7 +223,6 @@ async function describeServerTool(options: ProxyToolOptions, synced: SyncedRunti
     lines.push('', `UI resource: ${tool.uiResourceUri}`);
   }
   lines.push('', 'Input schema:', formatUnknown(tool.inputSchema ?? '(no schema reported)'));
-
   return createToolResult(lines.join('\n'), {
     mode: 'describe_tool',
     serverName,
@@ -218,7 +231,6 @@ async function describeServerTool(options: ProxyToolOptions, synced: SyncedRunti
     uiResourceUri: tool.uiResourceUri ?? null,
   });
 }
-
 async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeState): Promise<ToolResult> {
   const serverName = options.serverName?.trim();
   const toolName = options.toolName?.trim();
@@ -228,7 +240,6 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
   if (!toolName) {
     return createToolResult('Error: Tool name is required.', { mode: 'call_tool', serverName });
   }
-
   const serverConfig = synced.config.mcpServers[serverName];
   if (!serverConfig) {
     return createToolResult(`Error: Server "${serverName}" does not exist.`, { mode: 'call_tool', serverName, toolName });
@@ -240,12 +251,10 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
       toolName,
     });
   }
-
   const toolArguments = parseToolArguments(options.argumentsJson);
   if (toolArguments instanceof Error) {
     return createToolResult(`Error: ${toolArguments.message}`, { mode: 'call_tool', serverName, toolName });
   }
-
   const connection = await ensureConnectedServer(options, synced, serverName);
   if (connection.status === 'needs-auth') {
     return createToolResult(buildAuthRequiredMessage(serverName), {
@@ -261,7 +270,6 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
       { mode: 'call_tool', serverName, toolName },
     );
   }
-
   const liveTool = connection.tools.find((tool) => tool.name === toolName);
   if (!liveTool) {
     const availableTools = connection.tools.map((tool) => tool.name).sort();
@@ -270,7 +278,6 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
       { mode: 'call_tool', serverName, toolName, availableTools },
     );
   }
-
   try {
     const result = await options.manager.callTool(serverName, toolName, toolArguments);
     const text = formatCallToolResult(serverName, liveTool, result);
@@ -302,7 +309,6 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
         snapshotWritten: true,
       });
     }
-
     const message = error instanceof Error ? error.message : String(error);
     return createToolResult(`Error: Failed to call MCP tool "${toolName}" on "${serverName}". ${message}`, {
       mode: 'call_tool',
@@ -311,7 +317,6 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
     });
   }
 }
-
 async function ensureConnectedServer(
   options: ProxyToolOptions,
   synced: SyncedRuntimeState,
@@ -321,7 +326,6 @@ async function ensureConnectedServer(
   if (existing?.status === 'connected' || existing?.status === 'needs-auth') {
     return existing;
   }
-
   const serverConfig = synced.config.mcpServers[serverName];
   const connection = existing
     ? await options.manager.reconnect(serverName, serverConfig)
@@ -337,37 +341,30 @@ async function ensureConnectedServer(
   await options.syncSnapshot(options.cwd, { config: synced.config, metadataCache: nextCache });
   return connection;
 }
-
 function getToolInventory(serverName: string, synced: SyncedRuntimeState, manager: McpServerManager): ToolInventoryEntry[] {
   const connection = manager.getConnection(serverName);
   if (connection?.status === 'connected') {
     return serializeTools(connection.tools);
   }
-
   const serverConfig = synced.config.mcpServers[serverName];
   const cachedEntry = serverConfig ? synced.metadataCache.servers[serverName] : undefined;
   if (serverConfig && cachedEntry && isMetadataCacheEntryValid(cachedEntry, serverConfig)) {
     return cachedEntry.tools;
   }
-
   return [];
 }
-
 function getResourceInventory(serverName: string, synced: SyncedRuntimeState, manager: McpServerManager): ResourceInventoryEntry[] {
   const connection = manager.getConnection(serverName);
   if (connection?.status === 'connected') {
     return serializeResources(connection.resources);
   }
-
   const serverConfig = synced.config.mcpServers[serverName];
   const cachedEntry = serverConfig ? synced.metadataCache.servers[serverName] : undefined;
   if (serverConfig && cachedEntry && isMetadataCacheEntryValid(cachedEntry, serverConfig)) {
     return cachedEntry.resources;
   }
-
   return [];
 }
-
 function getMissingMetadataMessage(serverName: string, synced: SyncedRuntimeState): string {
   const server = synced.snapshot.servers.find((entry) => entry.serverName === serverName);
   if (server?.connectionStatus === 'needs-auth' || server?.authStatus === 'not-authenticated') {
@@ -375,17 +372,14 @@ function getMissingMetadataMessage(serverName: string, synced: SyncedRuntimeStat
   }
   return `No MCP metadata is cached for "${serverName}" yet. Connect or refresh this server in the MCP app first.`;
 }
-
 function buildAuthRequiredMessage(serverName: string): string {
   return `Server "${serverName}" requires in-app authentication. Open the MCP app in Sero and authenticate there.`;
 }
-
 function parseToolArguments(argumentsJson: string | undefined): Record<string, unknown> | undefined | Error {
   const trimmed = argumentsJson?.trim();
   if (!trimmed) {
     return undefined;
   }
-
   try {
     const parsed = JSON.parse(trimmed) as unknown;
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -396,14 +390,12 @@ function parseToolArguments(argumentsJson: string | undefined): Record<string, u
     return new Error('Tool arguments must be valid JSON.');
   }
 }
-
 function formatCallToolResult(serverName: string, tool: ManagedTool, result: CallToolResult): string {
   const lines = extractResultContentLines(result);
   const text = lines.join('\n').trim();
   const uiResourceUri = getToolUiResourceUri({ _meta: tool._meta });
   const structured = formatStructuredContent(result.structuredContent);
   const sections = [text || (result.isError ? 'Tool execution failed.' : '(empty result)')];
-
   if (structured) {
     sections.push(`Structured content:\n${structured}`);
   }
@@ -413,20 +405,17 @@ function formatCallToolResult(serverName: string, tool: ManagedTool, result: Cal
   if (result.isError && tool.inputSchema) {
     sections.push(`Expected input schema:\n${formatUnknown(tool.inputSchema)}`);
   }
-
   const body = sections.join('\n\n');
   return result.isError
     ? `Error: MCP tool ${serverName}.${tool.name} failed.\n\n${body}`
     : `MCP tool result from ${serverName}.${tool.name}:\n\n${body}`;
 }
-
 function extractResultContentLines(result: CallToolResult): string[] {
   const contents = Array.isArray(result.content) ? result.content : [];
   return contents.map((entry) => {
     if (!entry || typeof entry !== 'object') {
       return '[unknown MCP content]';
     }
-
     const block = entry as Record<string, unknown>;
     if (block.type === 'text' && typeof block.text === 'string') {
       return block.text;
@@ -447,14 +436,12 @@ function extractResultContentLines(result: CallToolResult): string[] {
     return `[${typeof block.type === 'string' ? block.type : 'unknown'} content]`;
   });
 }
-
 function formatStructuredContent(value: unknown): string {
   if (value === undefined) {
     return '';
   }
   return formatUnknown(value);
 }
-
 function formatUnknown(value: unknown): string {
   if (typeof value === 'string') {
     return value;
@@ -465,7 +452,6 @@ function formatUnknown(value: unknown): string {
     return String(value);
   }
 }
-
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
@@ -6,13 +6,16 @@ import {
   readMetadataCache,
   type McpMetadataCacheDocument,
 } from '../cache/metadata-cache';
-import type { McpConfigDocument } from '../config/types';
+import {
+  isResourceExposureEnabled,
+  type McpConfigDocument,
+} from '../config/types';
 import { serializeResources, serializeTools } from '../manager/tool-metadata';
 import { McpServerManager } from '../manager/server-manager';
 import type { ManagedConnection, ManagedTool } from '../manager/types';
 import type { RuntimeServerStatus } from '../state/snapshot';
 import { createToolResult, type ProxyAction, type ToolResult } from '../tools/types';
-import { readProxyResourceAction } from './runtime-resource';
+import { buildResourcesDisabledMessage, readProxyResourceAction } from './runtime-resource';
 import { reconcileConnection } from './runtime-connect';
 import { formatServerList, formatStatusSummary } from './runtime-utils';
 import type { SyncedRuntimeState } from './runtime-types';
@@ -362,13 +365,18 @@ function getToolInventory(serverName: string, synced: SyncedRuntimeState, manage
   return [];
 }
 function getResourceInventory(serverName: string, synced: SyncedRuntimeState, manager: McpServerManager): ResourceInventoryEntry[] {
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig || !isResourceExposureEnabled(serverConfig)) {
+    return [];
+  }
+
   const connection = manager.getConnection(serverName);
   if (connection?.status === 'connected') {
     return serializeResources(connection.resources);
   }
-  const serverConfig = synced.config.mcpServers[serverName];
-  const cachedEntry = serverConfig ? synced.metadataCache.servers[serverName] : undefined;
-  if (serverConfig && cachedEntry && isMetadataCacheEntryValid(cachedEntry, serverConfig)) {
+
+  const cachedEntry = synced.metadataCache.servers[serverName];
+  if (cachedEntry && isMetadataCacheEntryValid(cachedEntry, serverConfig)) {
     return cachedEntry.resources;
   }
   return [];
@@ -377,6 +385,9 @@ function getMissingMetadataMessage(serverName: string, synced: SyncedRuntimeStat
   const server = synced.snapshot.servers.find((entry) => entry.serverName === serverName);
   if (server?.connectionStatus === 'needs-auth' || server?.authStatus === 'not-authenticated') {
     return buildAuthRequiredMessage(serverName);
+  }
+  if (server?.exposeResources === false) {
+    return buildResourcesDisabledMessage(serverName);
   }
   return `No MCP metadata is cached for "${serverName}" yet. Connect or refresh this server in the MCP app first.`;
 }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-proxy.ts
@@ -20,6 +20,7 @@ interface ProxyToolOptions {
   query?: string;
   serverName?: string;
   toolName?: string;
+  toolArguments?: Record<string, unknown>;
   argumentsJson?: string;
   manager: McpServerManager;
   setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
@@ -251,7 +252,7 @@ async function callServerTool(options: ProxyToolOptions, synced: SyncedRuntimeSt
       toolName,
     });
   }
-  const toolArguments = parseToolArguments(options.argumentsJson);
+  const toolArguments = parseToolArguments(options.toolArguments, options.argumentsJson);
   if (toolArguments instanceof Error) {
     return createToolResult(`Error: ${toolArguments.message}`, { mode: 'call_tool', serverName, toolName });
   }
@@ -375,7 +376,13 @@ function getMissingMetadataMessage(serverName: string, synced: SyncedRuntimeStat
 function buildAuthRequiredMessage(serverName: string): string {
   return `Server "${serverName}" requires in-app authentication. Open the MCP app in Sero and authenticate there.`;
 }
-function parseToolArguments(argumentsJson: string | undefined): Record<string, unknown> | undefined | Error {
+function parseToolArguments(
+  toolArguments: Record<string, unknown> | undefined,
+  argumentsJson: string | undefined,
+): Record<string, unknown> | undefined | Error {
+  if (toolArguments) {
+    return toolArguments;
+  }
   const trimmed = argumentsJson?.trim();
   if (!trimmed) {
     return undefined;

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
@@ -1,0 +1,210 @@
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { McpResourcePreview } from '../../shared/types';
+import { readMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
+import type { McpConfigDocument } from '../config/types';
+import { McpServerManager } from '../manager/server-manager';
+import type { RuntimeServerStatus } from '../state/snapshot';
+import { createToolResult, type ToolResult } from '../tools/types';
+import { reconcileConnection } from './runtime-connect';
+import type { SyncedRuntimeState } from './runtime-types';
+
+const MAX_PREVIEW_TEXT_LENGTH = 200_000;
+
+interface ResourceContentRecord {
+  uri?: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+}
+
+export async function readServerResourceAction(options: {
+  cwd?: string;
+  serverName?: string;
+  resourceUri?: string;
+  manager: McpServerManager;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: McpMetadataCacheDocument;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}): Promise<ToolResult> {
+  const serverName = options.serverName?.trim();
+  const resourceUri = options.resourceUri?.trim();
+  if (!serverName) {
+    return createToolResult('Error: Server name is required.', { snapshotWritten: false });
+  }
+  if (!resourceUri) {
+    return createToolResult('Error: Resource URI is required.', { snapshotWritten: false });
+  }
+
+  const synced = await options.syncSnapshot(options.cwd);
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig) {
+    return createToolResult(`Error: Server "${serverName}" does not exist.`, { snapshotWritten: false });
+  }
+  if (serverConfig.enabled === false) {
+    return createToolResult(`Error: Server "${serverName}" is disabled. Enable it before reading resources.`, {
+      snapshotWritten: false,
+    });
+  }
+
+  let snapshotWritten = false;
+  const connection = options.manager.getConnection(serverName);
+  if (!connection || connection.status !== 'connected') {
+    const nextConnection = await options.manager.connect(serverName, serverConfig);
+    const metadataCache = await readMetadataCache();
+    const { nextCache, runtimeStatus } = await reconcileConnection({
+      serverName,
+      serverConfig,
+      metadataCache,
+      connection: nextConnection,
+    });
+    options.setRuntimeStatus(serverName, runtimeStatus);
+    await options.syncSnapshot(options.cwd, { config: synced.config, metadataCache: nextCache });
+    snapshotWritten = true;
+
+    if (nextConnection.status !== 'connected') {
+      return createToolResult(
+        nextConnection.status === 'needs-auth'
+          ? `Error: Server "${serverName}" needs authentication before resources can be opened.`
+          : `Error: Server "${serverName}" failed to connect before reading resources.`,
+        {
+          snapshotWritten,
+          connectionStatus: runtimeStatus.connectionStatus,
+          authStatus: runtimeStatus.authStatus,
+          lastError: runtimeStatus.lastError ?? null,
+        },
+      );
+    }
+  }
+
+  try {
+    const result = await options.manager.readResource(serverName, resourceUri);
+    const preview = normalizeResourcePreview(serverName, resourceUri, result);
+    return createToolResult(`Loaded resource "${preview.resolvedUri}" from "${serverName}".`, {
+      snapshotWritten,
+      serverName,
+      resourceUri,
+      resourcePreview: preview,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return createToolResult(`Error: Failed to read resource "${resourceUri}" from "${serverName}". ${message}`, {
+      snapshotWritten,
+      serverName,
+      resourceUri,
+    });
+  }
+}
+
+export function normalizeResourcePreview(
+  serverName: string,
+  requestedUri: string,
+  result: ReadResourceResult,
+): McpResourcePreview {
+  const content = selectPreferredContent(result, requestedUri);
+  const mimeType = normalizeMimeType(content.mimeType);
+
+  if (mimeType?.startsWith('image/') && typeof content.blob === 'string') {
+    return {
+      serverName,
+      requestedUri,
+      resolvedUri: content.uri ?? requestedUri,
+      mimeType,
+      previewKind: 'image',
+      dataUrl: `data:${mimeType};base64,${content.blob}`,
+      truncated: false,
+    };
+  }
+
+  const decodedText = decodeTextContent(content);
+  const truncated = decodedText.length > MAX_PREVIEW_TEXT_LENGTH;
+  const previewText = decodedText.slice(0, MAX_PREVIEW_TEXT_LENGTH);
+
+  if (mimeType?.startsWith('text/html')) {
+    return {
+      serverName,
+      requestedUri,
+      resolvedUri: content.uri ?? requestedUri,
+      mimeType,
+      previewKind: 'html',
+      html: previewText,
+      truncated,
+    };
+  }
+
+  if (mimeType?.includes('json')) {
+    return {
+      serverName,
+      requestedUri,
+      resolvedUri: content.uri ?? requestedUri,
+      mimeType,
+      previewKind: 'json',
+      text: formatJsonPreview(previewText),
+      truncated,
+    };
+  }
+
+  if (decodedText.length > 0) {
+    return {
+      serverName,
+      requestedUri,
+      resolvedUri: content.uri ?? requestedUri,
+      mimeType,
+      previewKind: 'text',
+      text: previewText,
+      truncated,
+    };
+  }
+
+  return {
+    serverName,
+    requestedUri,
+    resolvedUri: content.uri ?? requestedUri,
+    mimeType,
+    previewKind: 'binary',
+    truncated: false,
+  };
+}
+
+function selectPreferredContent(result: ReadResourceResult, requestedUri: string): ResourceContentRecord {
+  const contents = (result.contents ?? []) as ResourceContentRecord[];
+  if (contents.length === 0) {
+    throw new Error(`No contents were returned for resource "${requestedUri}".`);
+  }
+
+  return contents.find((content) => content.uri === requestedUri) ?? contents[0];
+}
+
+function normalizeMimeType(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function decodeTextContent(content: ResourceContentRecord): string {
+  if (typeof content.text === 'string') {
+    return content.text;
+  }
+  if (typeof content.blob === 'string' && isTextLikeMimeType(content.mimeType)) {
+    return Buffer.from(content.blob, 'base64').toString('utf8');
+  }
+  return '';
+}
+
+function isTextLikeMimeType(mimeType: string | undefined): boolean {
+  if (!mimeType) return true;
+  const normalized = mimeType.toLowerCase();
+  return normalized.startsWith('text/') || normalized.includes('json') || normalized.includes('xml') || normalized.includes('javascript');
+}
+
+function formatJsonPreview(value: string): string {
+  try {
+    return JSON.stringify(JSON.parse(value), null, 2);
+  } catch {
+    return value;
+  }
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
@@ -2,7 +2,10 @@ import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpResourcePreview } from '../../shared/types';
 import { readMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
-import type { McpConfigDocument } from '../config/types';
+import {
+  isResourceExposureEnabled,
+  type McpConfigDocument,
+} from '../config/types';
 import { McpServerManager } from '../manager/server-manager';
 import type { RuntimeServerStatus } from '../state/snapshot';
 import { createToolResult, type ToolResult } from '../tools/types';
@@ -176,6 +179,10 @@ function buildAuthRequiredMessage(serverName: string): string {
   return `Server "${serverName}" requires in-app authentication. Open the MCP app in Sero and authenticate there.`;
 }
 
+export function buildResourcesDisabledMessage(serverName: string): string {
+  return `Resource exposure is disabled for "${serverName}". Enable \"Expose resources\" in the MCP app to list or read resources.`;
+}
+
 async function loadResourcePreview(options: ResourceActionOptions): Promise<
   | { preview: McpResourcePreview; snapshotWritten: boolean }
   | { errorResult: ToolResult }
@@ -198,6 +205,16 @@ async function loadResourcePreview(options: ResourceActionOptions): Promise<
     return {
       errorResult: createToolResult(`Error: Server "${serverName}" is disabled. Enable it before reading resources.`, {
         snapshotWritten: false,
+      }),
+    };
+  }
+  if (!isResourceExposureEnabled(serverConfig)) {
+    return {
+      errorResult: createToolResult(buildResourcesDisabledMessage(serverName), {
+        snapshotWritten: false,
+        serverName,
+        resourceUri,
+        resourceExposureEnabled: false,
       }),
     };
   }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpResourcePreview } from '../../shared/types';
 import { readMetadataCache, type McpMetadataCacheDocument } from '../cache/metadata-cache';
@@ -92,6 +93,25 @@ export async function readServerResourceAction(options: {
       resourcePreview: preview,
     });
   } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      const message = error.message || 'Authentication is required.';
+      await options.manager.close(serverName);
+      options.setRuntimeStatus(serverName, {
+        connectionStatus: 'needs-auth',
+        authStatus: 'not-authenticated',
+        lastError: message,
+        lastConnectedAt: null,
+        lastFailedAt: new Date().toISOString(),
+      });
+      await options.syncSnapshot(options.cwd, { config: synced.config });
+      return createToolResult(buildAuthRequiredMessage(serverName), {
+        snapshotWritten: true,
+        serverName,
+        resourceUri,
+        authRequired: true,
+      });
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     return createToolResult(`Error: Failed to read resource "${resourceUri}" from "${serverName}". ${message}`, {
       snapshotWritten,
@@ -207,4 +227,8 @@ function formatJsonPreview(value: string): string {
   } catch {
     return value;
   }
+}
+
+function buildAuthRequiredMessage(serverName: string): string {
+  return `Server "${serverName}" requires in-app authentication. Open the MCP app in Sero and authenticate there.`;
 }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-resource.ts
@@ -18,7 +18,7 @@ interface ResourceContentRecord {
   blob?: string;
 }
 
-export async function readServerResourceAction(options: {
+interface ResourceActionOptions {
   cwd?: string;
   serverName?: string;
   resourceUri?: string;
@@ -32,93 +32,36 @@ export async function readServerResourceAction(options: {
       rawConfigUpdatedAt?: string | null;
     },
   ) => Promise<SyncedRuntimeState>;
-}): Promise<ToolResult> {
-  const serverName = options.serverName?.trim();
-  const resourceUri = options.resourceUri?.trim();
-  if (!serverName) {
-    return createToolResult('Error: Server name is required.', { snapshotWritten: false });
-  }
-  if (!resourceUri) {
-    return createToolResult('Error: Resource URI is required.', { snapshotWritten: false });
+}
+
+export async function readServerResourceAction(options: ResourceActionOptions): Promise<ToolResult> {
+  const resourceResult = await loadResourcePreview(options);
+  if ('errorResult' in resourceResult) {
+    return resourceResult.errorResult;
   }
 
-  const synced = await options.syncSnapshot(options.cwd);
-  const serverConfig = synced.config.mcpServers[serverName];
-  if (!serverConfig) {
-    return createToolResult(`Error: Server "${serverName}" does not exist.`, { snapshotWritten: false });
-  }
-  if (serverConfig.enabled === false) {
-    return createToolResult(`Error: Server "${serverName}" is disabled. Enable it before reading resources.`, {
-      snapshotWritten: false,
-    });
-  }
+  const { preview, snapshotWritten } = resourceResult;
+  return createToolResult(`Loaded resource "${preview.resolvedUri}" from "${preview.serverName}".`, {
+    snapshotWritten,
+    serverName: preview.serverName,
+    resourceUri: preview.resolvedUri,
+    resourcePreview: preview,
+  });
+}
 
-  let snapshotWritten = false;
-  const connection = options.manager.getConnection(serverName);
-  if (!connection || connection.status !== 'connected') {
-    const nextConnection = await options.manager.connect(serverName, serverConfig);
-    const metadataCache = await readMetadataCache();
-    const { nextCache, runtimeStatus } = await reconcileConnection({
-      serverName,
-      serverConfig,
-      metadataCache,
-      connection: nextConnection,
-    });
-    options.setRuntimeStatus(serverName, runtimeStatus);
-    await options.syncSnapshot(options.cwd, { config: synced.config, metadataCache: nextCache });
-    snapshotWritten = true;
-
-    if (nextConnection.status !== 'connected') {
-      return createToolResult(
-        nextConnection.status === 'needs-auth'
-          ? `Error: Server "${serverName}" needs authentication before resources can be opened.`
-          : `Error: Server "${serverName}" failed to connect before reading resources.`,
-        {
-          snapshotWritten,
-          connectionStatus: runtimeStatus.connectionStatus,
-          authStatus: runtimeStatus.authStatus,
-          lastError: runtimeStatus.lastError ?? null,
-        },
-      );
-    }
+export async function readProxyResourceAction(options: ResourceActionOptions): Promise<ToolResult> {
+  const resourceResult = await loadResourcePreview(options);
+  if ('errorResult' in resourceResult) {
+    return resourceResult.errorResult;
   }
 
-  try {
-    const result = await options.manager.readResource(serverName, resourceUri);
-    const preview = normalizeResourcePreview(serverName, resourceUri, result);
-    return createToolResult(`Loaded resource "${preview.resolvedUri}" from "${serverName}".`, {
-      snapshotWritten,
-      serverName,
-      resourceUri,
-      resourcePreview: preview,
-    });
-  } catch (error) {
-    if (error instanceof UnauthorizedError) {
-      const message = error.message || 'Authentication is required.';
-      await options.manager.close(serverName);
-      options.setRuntimeStatus(serverName, {
-        connectionStatus: 'needs-auth',
-        authStatus: 'not-authenticated',
-        lastError: message,
-        lastConnectedAt: null,
-        lastFailedAt: new Date().toISOString(),
-      });
-      await options.syncSnapshot(options.cwd, { config: synced.config });
-      return createToolResult(buildAuthRequiredMessage(serverName), {
-        snapshotWritten: true,
-        serverName,
-        resourceUri,
-        authRequired: true,
-      });
-    }
-
-    const message = error instanceof Error ? error.message : String(error);
-    return createToolResult(`Error: Failed to read resource "${resourceUri}" from "${serverName}". ${message}`, {
-      snapshotWritten,
-      serverName,
-      resourceUri,
-    });
-  }
+  const { preview, snapshotWritten } = resourceResult;
+  return createToolResult(formatProxyResourcePreview(preview), {
+    snapshotWritten,
+    serverName: preview.serverName,
+    resourceUri: preview.resolvedUri,
+    resourcePreview: preview,
+  });
 }
 
 export function normalizeResourcePreview(
@@ -231,4 +174,117 @@ function formatJsonPreview(value: string): string {
 
 function buildAuthRequiredMessage(serverName: string): string {
   return `Server "${serverName}" requires in-app authentication. Open the MCP app in Sero and authenticate there.`;
+}
+
+async function loadResourcePreview(options: ResourceActionOptions): Promise<
+  | { preview: McpResourcePreview; snapshotWritten: boolean }
+  | { errorResult: ToolResult }
+> {
+  const serverName = options.serverName?.trim();
+  const resourceUri = options.resourceUri?.trim();
+  if (!serverName) {
+    return { errorResult: createToolResult('Error: Server name is required.', { snapshotWritten: false }) };
+  }
+  if (!resourceUri) {
+    return { errorResult: createToolResult('Error: Resource URI is required.', { snapshotWritten: false }) };
+  }
+
+  const synced = await options.syncSnapshot(options.cwd);
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig) {
+    return { errorResult: createToolResult(`Error: Server "${serverName}" does not exist.`, { snapshotWritten: false }) };
+  }
+  if (serverConfig.enabled === false) {
+    return {
+      errorResult: createToolResult(`Error: Server "${serverName}" is disabled. Enable it before reading resources.`, {
+        snapshotWritten: false,
+      }),
+    };
+  }
+
+  let snapshotWritten = false;
+  const connection = options.manager.getConnection(serverName);
+  if (!connection || connection.status !== 'connected') {
+    const nextConnection = await options.manager.connect(serverName, serverConfig);
+    const metadataCache = await readMetadataCache();
+    const { nextCache, runtimeStatus } = await reconcileConnection({
+      serverName,
+      serverConfig,
+      metadataCache,
+      connection: nextConnection,
+    });
+    options.setRuntimeStatus(serverName, runtimeStatus);
+    await options.syncSnapshot(options.cwd, { config: synced.config, metadataCache: nextCache });
+    snapshotWritten = true;
+
+    if (nextConnection.status !== 'connected') {
+      return {
+        errorResult: createToolResult(
+          nextConnection.status === 'needs-auth'
+            ? buildAuthRequiredMessage(serverName)
+            : `Error: Server "${serverName}" failed to connect before reading resources.`,
+          {
+            snapshotWritten,
+            connectionStatus: runtimeStatus.connectionStatus,
+            authStatus: runtimeStatus.authStatus,
+            lastError: runtimeStatus.lastError ?? null,
+            authRequired: nextConnection.status === 'needs-auth',
+          },
+        ),
+      };
+    }
+  }
+
+  try {
+    const result = await options.manager.readResource(serverName, resourceUri);
+    return {
+      preview: normalizeResourcePreview(serverName, resourceUri, result),
+      snapshotWritten,
+    };
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      const message = error.message || 'Authentication is required.';
+      await options.manager.close(serverName);
+      options.setRuntimeStatus(serverName, {
+        connectionStatus: 'needs-auth',
+        authStatus: 'not-authenticated',
+        lastError: message,
+        lastConnectedAt: null,
+        lastFailedAt: new Date().toISOString(),
+      });
+      await options.syncSnapshot(options.cwd, { config: synced.config });
+      return {
+        errorResult: createToolResult(buildAuthRequiredMessage(serverName), {
+          snapshotWritten: true,
+          serverName,
+          resourceUri,
+          authRequired: true,
+        }),
+      };
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      errorResult: createToolResult(`Error: Failed to read resource "${resourceUri}" from "${serverName}". ${message}`, {
+        snapshotWritten,
+        serverName,
+        resourceUri,
+      }),
+    };
+  }
+}
+
+function formatProxyResourcePreview(preview: McpResourcePreview): string {
+  const header = `MCP resource from ${preview.serverName}: ${preview.resolvedUri}`;
+  const metadata = `Kind: ${preview.previewKind}${preview.mimeType ? ` · ${preview.mimeType}` : ''}`;
+  if (preview.previewKind === 'image') {
+    return `${header}\n${metadata}\n\nThis resource is an image. Open it in the MCP app for the embedded visual preview.`;
+  }
+  if (preview.previewKind === 'binary') {
+    return `${header}\n${metadata}\n\nThis resource returned binary content that cannot be rendered inline by the bridged MCP proxy.`;
+  }
+
+  const body = preview.previewKind === 'html' ? preview.html ?? '' : preview.text ?? '(empty resource)';
+  const truncatedNote = preview.truncated ? '\n\nPreview truncated for proxy output.' : '';
+  return `${header}\n${metadata}\n\n${body}${truncatedNote}`;
 }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-types.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-types.ts
@@ -1,0 +1,12 @@
+import type { McpMetadataCacheDocument } from '../cache/metadata-cache';
+import type { McpConfigDocument } from '../config/types';
+import type { buildSnapshot } from '../state/snapshot';
+
+export interface SyncedRuntimeState {
+  configPath: string;
+  statePath: string;
+  config: McpConfigDocument;
+  metadataCache: McpMetadataCacheDocument;
+  rawConfigUpdatedAt: string | null;
+  snapshot: Awaited<ReturnType<typeof buildSnapshot>>;
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-types.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-types.ts
@@ -1,6 +1,24 @@
 import type { McpMetadataCacheDocument } from '../cache/metadata-cache';
 import type { McpConfigDocument } from '../config/types';
 import type { buildSnapshot } from '../state/snapshot';
+import type { McpServerEditorInput } from '../../shared/types';
+
+export interface ManagerActionOptions {
+  cwd?: string;
+  rawConfig?: string;
+  serverName?: string;
+  resourceUri?: string;
+  toolName?: string;
+  toolArguments?: Record<string, unknown>;
+  callbackUrl?: string;
+  serverInput?: McpServerEditorInput;
+}
+
+export interface SyncSnapshotOptions {
+  config?: McpConfigDocument;
+  rawConfigUpdatedAt?: string | null;
+  metadataCache?: McpMetadataCacheDocument;
+}
 
 export interface SyncedRuntimeState {
   configPath: string;

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-utils.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-utils.ts
@@ -1,0 +1,125 @@
+import type { McpAppState, McpServerEditorInput } from '../../shared/types';
+import type { McpServerConfig } from '../config/types';
+import { createToolResult, type ToolResult } from '../tools/types';
+
+export function buildServerConfig(
+  input: McpServerEditorInput,
+  existing?: McpServerConfig,
+): McpServerConfig {
+  const next: McpServerConfig = { ...(existing ?? {}) };
+  next.enabled = input.enabled;
+  next.transport = input.transport;
+  next.lifecycle = input.lifecycle;
+  next.exposeResources = input.exposeResources;
+  next.debug = input.debug;
+
+  const cwd = input.cwd.trim();
+  if (cwd) next.cwd = cwd;
+  else delete next.cwd;
+
+  if (input.transport === 'stdio') {
+    next.command = input.command.trim();
+    const args = parseArgsText(input.argsText);
+    if (args.length > 0) next.args = args;
+    else delete next.args;
+    delete next.url;
+  } else {
+    next.url = input.url.trim();
+    delete next.command;
+    delete next.args;
+  }
+
+  switch (input.authMode) {
+    case 'oauth':
+      next.auth = 'oauth';
+      delete next.bearerToken;
+      delete next.bearerTokenEnv;
+      break;
+    case 'bearer': {
+      next.auth = 'bearer';
+      delete next.oauth;
+      const bearerTokenEnv = input.bearerTokenEnv.trim();
+      if (bearerTokenEnv) next.bearerTokenEnv = bearerTokenEnv;
+      else delete next.bearerTokenEnv;
+      break;
+    }
+    default:
+      next.auth = false;
+      delete next.bearerToken;
+      delete next.bearerTokenEnv;
+      delete next.oauth;
+      break;
+  }
+
+  return next;
+}
+
+export function formatStatusSummary(snapshot: McpAppState): string {
+  const lines = [
+    `MCP status: ${snapshot.summary.totalServers} server(s) configured`,
+    `Enabled: ${snapshot.summary.enabledServers}`,
+    `Connected: ${snapshot.summary.connectedServers}`,
+    `Needs auth: ${snapshot.summary.needsAuthServers}`,
+    `Errors: ${snapshot.summary.errorServers}`,
+  ];
+
+  if (snapshot.servers.length === 0) {
+    lines.push('', 'Open the MCP app in Sero to add your first MCP server.');
+  }
+
+  return lines.join('\n');
+}
+
+export function formatServerList(snapshotServers: McpAppState['servers']): string {
+  if (snapshotServers.length === 0) {
+    return 'No MCP servers are configured yet. Open the MCP app in Sero to add one.';
+  }
+
+  return snapshotServers
+    .map((server) => {
+      const enabledLabel = server.enabled ? 'enabled' : 'disabled';
+      return `- ${server.serverName} (${enabledLabel}, ${server.connectionStatus}, ${server.authStatus})`;
+    })
+    .join('\n');
+}
+
+export function formatDiagnostics(options: {
+  configPath: string;
+  statePath: string;
+  rawConfigUpdatedAt: string | null;
+  snapshot: McpAppState;
+  sessionRefCount: number;
+  hasAttachedPi: boolean;
+}): string {
+  const lines = [
+    `Config: ${options.configPath}`,
+    `State: ${options.statePath}`,
+    `Raw config updated: ${options.rawConfigUpdatedAt ?? 'never'}`,
+    `Servers: ${options.snapshot.summary.totalServers}`,
+  ];
+
+  for (const server of options.snapshot.servers) {
+    lines.push(
+      `- ${server.serverName}: ${server.transport}, ${server.lifecycle}, ${server.connectionStatus}, ${server.authStatus}, tools=${server.toolCount}, resources=${server.resourceCount}`,
+    );
+  }
+
+  lines.push(`Runtime sessions: ${options.sessionRefCount}`);
+  if (options.hasAttachedPi) {
+    lines.push('Runtime: attached to active Pi extension instance');
+  }
+
+  return lines.join('\n');
+}
+
+export function mutationErrorResult(error: unknown): ToolResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return createToolResult(`Error: ${message}`, { snapshotWritten: false });
+}
+
+function parseArgsText(argsText: string): string[] {
+  return argsText
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-viewer.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-viewer.ts
@@ -1,5 +1,8 @@
 import { readMetadataCache } from '../cache/metadata-cache';
-import type { McpConfigDocument } from '../config/types';
+import {
+  isResourceExposureEnabled,
+  type McpConfigDocument,
+} from '../config/types';
 import type { ManagedConnection, ManagedTool } from '../manager/types';
 import type { McpServerManager } from '../manager/server-manager';
 import type { RuntimeServerStatus } from '../state/snapshot';
@@ -7,7 +10,7 @@ import { createToolResult, type ToolResult } from '../tools/types';
 import type { McpUiSessionManager } from '../viewer/ui-session';
 import type { UiResourceHandler } from '../viewer/ui-resource-handler';
 import { reconcileConnection } from './runtime-connect';
-import { readServerResourceAction } from './runtime-resource';
+import { buildResourcesDisabledMessage, readServerResourceAction } from './runtime-resource';
 import type { SyncedRuntimeState } from './runtime-types';
 
 interface ViewerActionOptions {
@@ -40,7 +43,7 @@ export async function openViewerResourceAction(options: ViewerActionOptions): Pr
     return readServerResourceAction(options);
   }
 
-  const ensured = await ensureConnectedServer(options);
+  const ensured = await ensureConnectedServer(options, { requireExposedResources: true });
   if ('errorResult' in ensured) {
     return ensured.errorResult;
   }
@@ -145,6 +148,7 @@ interface EnsuredConnectedServer {
 
 async function ensureConnectedServer(
   options: ViewerActionOptions,
+  policy: { requireExposedResources?: boolean } = {},
 ): Promise<EnsuredConnectedServer | { errorResult: ToolResult }> {
   const serverName = options.serverName?.trim();
   if (!serverName) {
@@ -160,6 +164,16 @@ async function ensureConnectedServer(
     return {
       errorResult: createToolResult(`Error: Server "${serverName}" is disabled. Enable it before opening MCP UIs.`, {
         snapshotWritten: false,
+      }),
+    };
+  }
+  if (policy.requireExposedResources && !isResourceExposureEnabled(serverConfig)) {
+    return {
+      errorResult: createToolResult(buildResourcesDisabledMessage(serverName), {
+        snapshotWritten: false,
+        serverName,
+        resourceUri: options.resourceUri ?? null,
+        resourceExposureEnabled: false,
       }),
     };
   }

--- a/plugins/sero-mcp-plugin/extension/runtime/runtime-viewer.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/runtime-viewer.ts
@@ -1,0 +1,246 @@
+import { readMetadataCache } from '../cache/metadata-cache';
+import type { McpConfigDocument } from '../config/types';
+import type { ManagedConnection, ManagedTool } from '../manager/types';
+import type { McpServerManager } from '../manager/server-manager';
+import type { RuntimeServerStatus } from '../state/snapshot';
+import { createToolResult, type ToolResult } from '../tools/types';
+import type { McpUiSessionManager } from '../viewer/ui-session';
+import type { UiResourceHandler } from '../viewer/ui-resource-handler';
+import { reconcileConnection } from './runtime-connect';
+import { readServerResourceAction } from './runtime-resource';
+import type { SyncedRuntimeState } from './runtime-types';
+
+interface ViewerActionOptions {
+  cwd?: string;
+  serverName?: string;
+  resourceUri?: string;
+  toolName?: string;
+  toolArguments?: Record<string, unknown>;
+  manager: McpServerManager;
+  uiResourceHandler: UiResourceHandler;
+  uiSessions: McpUiSessionManager;
+  setRuntimeStatus: (serverName: string, status: RuntimeServerStatus) => void;
+  syncSnapshot: (
+    cwd?: string,
+    options?: {
+      config?: McpConfigDocument;
+      metadataCache?: Awaited<ReturnType<typeof readMetadataCache>>;
+      rawConfigUpdatedAt?: string | null;
+    },
+  ) => Promise<SyncedRuntimeState>;
+}
+
+export async function openViewerResourceAction(options: ViewerActionOptions): Promise<ToolResult> {
+  const resourceUri = options.resourceUri?.trim();
+  if (!resourceUri) {
+    return createToolResult('Error: Resource URI is required.', { snapshotWritten: false });
+  }
+
+  if (!resourceUri.startsWith('ui://')) {
+    return readServerResourceAction(options);
+  }
+
+  const ensured = await ensureConnectedServer(options);
+  if ('errorResult' in ensured) {
+    return ensured.errorResult;
+  }
+
+  try {
+    const resource = await options.uiResourceHandler.readUiResource(ensured.serverName, resourceUri);
+    const session = await options.uiSessions.open({
+      serverName: ensured.serverName,
+      resourceUri,
+      title: resourceUri,
+      resource,
+      manager: options.manager,
+      onUnauthorized: async (_serverName, message) => {
+        await handleUnauthorized(ensured, options, message);
+      },
+    });
+
+    return createToolResult(`Opened MCP UI resource "${resourceUri}" from "${ensured.serverName}".`, {
+      snapshotWritten: ensured.snapshotWritten,
+      serverName: ensured.serverName,
+      resourceUri,
+      sessionId: session.sessionId,
+      viewerUrl: session.viewerUrl,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return createToolResult(`Error: Failed to open MCP UI resource "${resourceUri}". ${message}`, {
+      snapshotWritten: ensured.snapshotWritten,
+      serverName: ensured.serverName,
+      resourceUri,
+    });
+  }
+}
+
+export async function openToolUiAction(options: ViewerActionOptions): Promise<ToolResult> {
+  const ensured = await ensureConnectedServer(options);
+  if ('errorResult' in ensured) {
+    return ensured.errorResult;
+  }
+
+  const toolName = options.toolName?.trim() || '';
+  const connection = options.manager.getConnection(ensured.serverName);
+  const tool = findTool(connection, toolName);
+  const resourceUri = resolveToolUiResourceUri(tool, options.resourceUri);
+  if (!resourceUri) {
+    return createToolResult('Error: A UI resource URI is required for this MCP tool.', { snapshotWritten: ensured.snapshotWritten });
+  }
+
+  try {
+    const resource = await options.uiResourceHandler.readUiResource(ensured.serverName, resourceUri);
+    const session = await options.uiSessions.open({
+      serverName: ensured.serverName,
+      resourceUri,
+      title: toolName || resourceUri,
+      resource,
+      toolInfo: tool ? { name: tool.name, description: tool.description, inputSchema: tool.inputSchema } : undefined,
+      toolArgs: options.toolArguments,
+      manager: options.manager,
+      onUnauthorized: async (_serverName, message) => {
+        await handleUnauthorized(ensured, options, message);
+      },
+    });
+
+    return createToolResult(`Opened MCP tool UI for "${toolName || resourceUri}" from "${ensured.serverName}".`, {
+      snapshotWritten: ensured.snapshotWritten,
+      serverName: ensured.serverName,
+      resourceUri,
+      toolName: toolName || null,
+      sessionId: session.sessionId,
+      viewerUrl: session.viewerUrl,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return createToolResult(`Error: Failed to open MCP tool UI "${toolName || resourceUri}". ${message}`, {
+      snapshotWritten: ensured.snapshotWritten,
+      serverName: ensured.serverName,
+      resourceUri,
+      toolName: toolName || null,
+    });
+  }
+}
+
+export async function closeViewerAction(options: Pick<ViewerActionOptions, 'uiSessions'>): Promise<ToolResult> {
+  const session = options.uiSessions.getActiveSession();
+  if (!session) {
+    return createToolResult('No MCP viewer session is currently active.', { sessionClosed: false });
+  }
+
+  await options.uiSessions.closeActive('closed-from-ui');
+  return createToolResult(`Closed MCP viewer session for "${session.resourceUri}".`, {
+    sessionClosed: true,
+    sessionId: session.sessionId,
+    resourceUri: session.resourceUri,
+  });
+}
+
+interface EnsuredConnectedServer {
+  config: McpConfigDocument;
+  serverName: string;
+  snapshotWritten: boolean;
+}
+
+async function ensureConnectedServer(
+  options: ViewerActionOptions,
+): Promise<EnsuredConnectedServer | { errorResult: ToolResult }> {
+  const serverName = options.serverName?.trim();
+  if (!serverName) {
+    return { errorResult: createToolResult('Error: Server name is required.', { snapshotWritten: false }) };
+  }
+
+  const synced = await options.syncSnapshot(options.cwd);
+  const serverConfig = synced.config.mcpServers[serverName];
+  if (!serverConfig) {
+    return { errorResult: createToolResult(`Error: Server "${serverName}" does not exist.`, { snapshotWritten: false }) };
+  }
+  if (serverConfig.enabled === false) {
+    return {
+      errorResult: createToolResult(`Error: Server "${serverName}" is disabled. Enable it before opening MCP UIs.`, {
+        snapshotWritten: false,
+      }),
+    };
+  }
+
+  const existingConnection = options.manager.getConnection(serverName);
+  if (existingConnection?.status === 'connected') {
+    return { config: synced.config, serverName, snapshotWritten: false };
+  }
+
+  const nextConnection = await options.manager.connect(serverName, serverConfig);
+  const metadataCache = await readMetadataCache();
+  const { nextCache, runtimeStatus } = await reconcileConnection({
+    serverName,
+    serverConfig,
+    metadataCache,
+    connection: nextConnection,
+  });
+  options.setRuntimeStatus(serverName, runtimeStatus);
+  await options.syncSnapshot(options.cwd, {
+    config: synced.config,
+    metadataCache: nextCache,
+    rawConfigUpdatedAt: synced.rawConfigUpdatedAt,
+  });
+
+  if (nextConnection.status !== 'connected') {
+    return {
+      errorResult: createToolResult(
+        nextConnection.status === 'needs-auth'
+          ? `Server "${serverName}" requires in-app authentication. Open the MCP app in Sero and authenticate there.`
+          : `Error: Server "${serverName}" failed to connect before opening an MCP UI.`,
+        {
+          snapshotWritten: true,
+          connectionStatus: runtimeStatus.connectionStatus,
+          authStatus: runtimeStatus.authStatus,
+          lastError: runtimeStatus.lastError ?? null,
+          authRequired: nextConnection.status === 'needs-auth',
+          metadataCache: nextCache,
+        },
+      ),
+    };
+  }
+
+  return { config: synced.config, serverName, snapshotWritten: true };
+}
+
+async function handleUnauthorized(
+  ensured: EnsuredConnectedServer,
+  options: ViewerActionOptions,
+  message: string,
+): Promise<void> {
+  await options.manager.close(ensured.serverName);
+  options.setRuntimeStatus(ensured.serverName, {
+    connectionStatus: 'needs-auth',
+    authStatus: 'not-authenticated',
+    lastError: message,
+    lastConnectedAt: null,
+    lastFailedAt: new Date().toISOString(),
+  });
+  await options.syncSnapshot(options.cwd, { config: ensured.config });
+}
+
+function findTool(connection: ManagedConnection | undefined, toolName: string): ManagedTool | undefined {
+  if (!toolName) {
+    return undefined;
+  }
+  return connection?.tools.find((tool) => tool.name === toolName);
+}
+
+function resolveToolUiResourceUri(tool: ManagedTool | undefined, resourceUri: string | undefined): string {
+  const direct = resourceUri?.trim();
+  if (direct) {
+    return direct;
+  }
+  if (!tool?._meta || typeof tool._meta !== 'object') {
+    return '';
+  }
+  const ui = tool._meta.ui;
+  if (!ui || typeof ui !== 'object' || Array.isArray(ui)) {
+    return '';
+  }
+  return typeof (ui as Record<string, unknown>).resourceUri === 'string'
+    ? (ui as Record<string, unknown>).resourceUri as string
+    : '';
+}

--- a/plugins/sero-mcp-plugin/extension/state/paths.ts
+++ b/plugins/sero-mcp-plugin/extension/state/paths.ts
@@ -1,0 +1,57 @@
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_PI_AGENT_DIR = path.join(homedir(), '.pi', 'agent');
+const STATE_RELATIVE_PATH = path.join('.sero', 'apps', 'mcp', 'state.json');
+
+function expandHome(value: string): string {
+  if (value === '~') return homedir();
+  if (value.startsWith('~/')) return path.join(homedir(), value.slice(2));
+  return value;
+}
+
+function getEnvPath(name: 'SERO_HOME' | 'PI_CODING_AGENT_DIR'): string | null {
+  const value = process.env[name]?.trim();
+  return value ? expandHome(value) : null;
+}
+
+export function getSeroHomeDir(): string | null {
+  return getEnvPath('SERO_HOME');
+}
+
+export function getPiAgentDir(): string {
+  return getEnvPath('PI_CODING_AGENT_DIR') ?? DEFAULT_PI_AGENT_DIR;
+}
+
+export function getMcpAppDir(): string {
+  const seroHome = getSeroHomeDir();
+  if (seroHome) return path.join(seroHome, 'apps', 'mcp');
+  return path.join(getPiAgentDir(), 'mcp');
+}
+
+export function getMcpStatePath(cwd?: string): string {
+  const seroHome = getSeroHomeDir();
+  if (seroHome) return path.join(seroHome, 'apps', 'mcp', 'state.json');
+  if (cwd?.trim()) return path.join(path.resolve(cwd), STATE_RELATIVE_PATH);
+  return path.join(getPiAgentDir(), 'mcp-state.json');
+}
+
+export function getMcpConfigPath(): string {
+  const seroHome = getSeroHomeDir();
+  if (seroHome) return path.join(seroHome, 'apps', 'mcp', 'config.json');
+  return path.join(getPiAgentDir(), 'mcp.json');
+}
+
+export function getMcpMetadataCachePath(): string {
+  const seroHome = getSeroHomeDir();
+  if (seroHome) return path.join(seroHome, 'apps', 'mcp', 'metadata-cache.json');
+  return path.join(getPiAgentDir(), 'mcp-cache.json');
+}
+
+export function getMcpOAuthDir(): string {
+  return path.join(getPiAgentDir(), 'mcp-oauth');
+}
+
+export function getMcpOAuthTokenPath(serverName: string): string {
+  return path.join(getMcpOAuthDir(), encodeURIComponent(serverName), 'tokens.json');
+}

--- a/plugins/sero-mcp-plugin/extension/state/paths.ts
+++ b/plugins/sero-mcp-plugin/extension/state/paths.ts
@@ -52,6 +52,18 @@ export function getMcpOAuthDir(): string {
   return path.join(getPiAgentDir(), 'mcp-oauth');
 }
 
+export function getMcpOAuthServerDir(serverName: string): string {
+  return path.join(getMcpOAuthDir(), encodeURIComponent(serverName));
+}
+
 export function getMcpOAuthTokenPath(serverName: string): string {
-  return path.join(getMcpOAuthDir(), encodeURIComponent(serverName), 'tokens.json');
+  return path.join(getMcpOAuthServerDir(serverName), 'tokens.json');
+}
+
+export function getMcpOAuthClientPath(serverName: string): string {
+  return path.join(getMcpOAuthServerDir(serverName), 'client.json');
+}
+
+export function getMcpOAuthFlowPath(serverName: string): string {
+  return path.join(getMcpOAuthServerDir(serverName), 'flow.json');
 }

--- a/plugins/sero-mcp-plugin/extension/state/snapshot.ts
+++ b/plugins/sero-mcp-plugin/extension/state/snapshot.ts
@@ -56,7 +56,7 @@ async function createServerSnapshot(
   return {
     serverName,
     enabled,
-    transport: typeof serverConfig.url === 'string' && serverConfig.url.length > 0 ? 'http' : 'stdio',
+    transport: resolveTransport(serverConfig),
     lifecycle: serverConfig.lifecycle ?? 'lazy',
     authMode: resolveAuthMode(serverConfig),
     connectionStatus: resolveConnectionStatus(enabled, authStatus),
@@ -93,6 +93,13 @@ async function resolveAuthStatus(
   }
 
   return 'not-required';
+}
+
+function resolveTransport(serverConfig: McpServerConfig): 'stdio' | 'http' {
+  if (serverConfig.transport === 'stdio' || serverConfig.transport === 'http') {
+    return serverConfig.transport;
+  }
+  return typeof serverConfig.url === 'string' && serverConfig.url.length > 0 ? 'http' : 'stdio';
 }
 
 function resolveAuthMode(serverConfig: McpServerConfig): 'none' | 'oauth' | 'bearer' {

--- a/plugins/sero-mcp-plugin/extension/state/snapshot.ts
+++ b/plugins/sero-mcp-plugin/extension/state/snapshot.ts
@@ -1,0 +1,94 @@
+import type { McpAppState, McpAuthStatus, McpConnectionStatus, McpServerSnapshot } from '../../shared/types';
+import type { McpMetadataCacheDocument } from '../cache/metadata-cache';
+import type { McpConfigDocument, McpServerConfig } from '../config/types';
+
+interface BuildSnapshotOptions {
+  configPath: string;
+  rawConfigUpdatedAt: string | null;
+  config: McpConfigDocument;
+  metadataCache: McpMetadataCacheDocument;
+  hasOAuthTokens: (serverName: string) => Promise<boolean>;
+}
+
+export async function buildSnapshot(options: BuildSnapshotOptions): Promise<McpAppState> {
+  const servers = await Promise.all(
+    Object.entries(options.config.mcpServers).map(([serverName, serverConfig]) => {
+      return createServerSnapshot(serverName, serverConfig, options.metadataCache, options.hasOAuthTokens);
+    }),
+  );
+
+  const enabledServers = servers.filter((server) => server.enabled).length;
+  const connectedServers = servers.filter((server) => server.connectionStatus === 'connected').length;
+  const needsAuthServers = servers.filter((server) => server.authStatus === 'not-authenticated').length;
+  const errorServers = servers.filter((server) => server.connectionStatus === 'error' || server.authStatus === 'error').length;
+
+  return {
+    initialized: true,
+    firstRun: servers.length === 0,
+    configPath: options.configPath,
+    rawConfigUpdatedAt: options.rawConfigUpdatedAt,
+    servers,
+    settings: {
+      idleTimeout: options.config.settings?.idleTimeout ?? 10,
+      toolPrefix: options.config.settings?.toolPrefix ?? 'server',
+    },
+    lastRefreshedAt: new Date().toISOString(),
+    summary: {
+      totalServers: servers.length,
+      enabledServers,
+      connectedServers,
+      needsAuthServers,
+      errorServers,
+    },
+  };
+}
+
+async function createServerSnapshot(
+  serverName: string,
+  serverConfig: McpServerConfig,
+  metadataCache: McpMetadataCacheDocument,
+  hasOAuthTokens: (serverName: string) => Promise<boolean>,
+): Promise<McpServerSnapshot> {
+  const enabled = serverConfig.enabled !== false;
+  const authStatus = await resolveAuthStatus(serverName, serverConfig, hasOAuthTokens);
+  const metadata = metadataCache.servers[serverName];
+
+  return {
+    serverName,
+    enabled,
+    transport: typeof serverConfig.url === 'string' && serverConfig.url.length > 0 ? 'http' : 'stdio',
+    lifecycle: serverConfig.lifecycle ?? 'lazy',
+    connectionStatus: resolveConnectionStatus(enabled, authStatus),
+    authStatus,
+    toolCount: metadata?.toolCount ?? 0,
+    resourceCount: metadata?.resourceCount ?? 0,
+    uiToolCount: 0,
+    lastError: undefined,
+    lastConnectedAt: null,
+    lastFailedAt: null,
+    resources: [],
+    uiTools: [],
+  };
+}
+
+async function resolveAuthStatus(
+  serverName: string,
+  serverConfig: McpServerConfig,
+  hasOAuthTokens: (serverName: string) => Promise<boolean>,
+): Promise<McpAuthStatus> {
+  if (serverConfig.auth === 'oauth') {
+    return (await hasOAuthTokens(serverName)) ? 'authenticated' : 'not-authenticated';
+  }
+
+  if (serverConfig.auth === 'bearer') {
+    return serverConfig.bearerToken || serverConfig.bearerTokenEnv ? 'authenticated' : 'not-authenticated';
+  }
+
+  return 'not-required';
+}
+
+function resolveConnectionStatus(enabled: boolean, authStatus: McpAuthStatus): McpConnectionStatus {
+  if (!enabled) return 'disabled';
+  if (authStatus === 'not-authenticated') return 'needs-auth';
+  return 'idle';
+}

--- a/plugins/sero-mcp-plugin/extension/state/snapshot.ts
+++ b/plugins/sero-mcp-plugin/extension/state/snapshot.ts
@@ -58,11 +58,19 @@ async function createServerSnapshot(
     enabled,
     transport: typeof serverConfig.url === 'string' && serverConfig.url.length > 0 ? 'http' : 'stdio',
     lifecycle: serverConfig.lifecycle ?? 'lazy',
+    authMode: resolveAuthMode(serverConfig),
     connectionStatus: resolveConnectionStatus(enabled, authStatus),
     authStatus,
     toolCount: metadata?.toolCount ?? 0,
     resourceCount: metadata?.resourceCount ?? 0,
     uiToolCount: 0,
+    command: typeof serverConfig.command === 'string' ? serverConfig.command : undefined,
+    argsText: Array.isArray(serverConfig.args) ? serverConfig.args.join('\n') : undefined,
+    cwd: typeof serverConfig.cwd === 'string' ? serverConfig.cwd : undefined,
+    url: typeof serverConfig.url === 'string' ? serverConfig.url : undefined,
+    bearerTokenEnv: typeof serverConfig.bearerTokenEnv === 'string' ? serverConfig.bearerTokenEnv : undefined,
+    exposeResources: typeof serverConfig.exposeResources === 'boolean' ? serverConfig.exposeResources : true,
+    debug: typeof serverConfig.debug === 'boolean' ? serverConfig.debug : false,
     lastError: undefined,
     lastConnectedAt: null,
     lastFailedAt: null,
@@ -85,6 +93,12 @@ async function resolveAuthStatus(
   }
 
   return 'not-required';
+}
+
+function resolveAuthMode(serverConfig: McpServerConfig): 'none' | 'oauth' | 'bearer' {
+  if (serverConfig.auth === 'oauth') return 'oauth';
+  if (serverConfig.auth === 'bearer') return 'bearer';
+  return 'none';
 }
 
 function resolveConnectionStatus(enabled: boolean, authStatus: McpAuthStatus): McpConnectionStatus {

--- a/plugins/sero-mcp-plugin/extension/state/snapshot.ts
+++ b/plugins/sero-mcp-plugin/extension/state/snapshot.ts
@@ -1,6 +1,27 @@
-import type { McpAppState, McpAuthStatus, McpConnectionStatus, McpServerSnapshot } from '../../shared/types';
-import type { McpMetadataCacheDocument } from '../cache/metadata-cache';
+import type {
+  McpAppState,
+  McpAuthMode,
+  McpAuthStatus,
+  McpConnectionStatus,
+  McpResourceSummary,
+  McpServerSnapshot,
+  McpUiToolSummary,
+} from '../../shared/types';
+import {
+  isMetadataCacheEntryValid,
+  type CachedMcpResource,
+  type CachedMcpTool,
+  type McpMetadataCacheDocument,
+} from '../cache/metadata-cache';
 import type { McpConfigDocument, McpServerConfig } from '../config/types';
+
+export interface RuntimeServerStatus {
+  connectionStatus?: McpConnectionStatus;
+  authStatus?: McpAuthStatus;
+  lastError?: string;
+  lastConnectedAt?: string | null;
+  lastFailedAt?: string | null;
+}
 
 interface BuildSnapshotOptions {
   configPath: string;
@@ -8,12 +29,13 @@ interface BuildSnapshotOptions {
   config: McpConfigDocument;
   metadataCache: McpMetadataCacheDocument;
   hasOAuthTokens: (serverName: string) => Promise<boolean>;
+  runtimeStatuses?: Map<string, RuntimeServerStatus>;
 }
 
 export async function buildSnapshot(options: BuildSnapshotOptions): Promise<McpAppState> {
   const servers = await Promise.all(
     Object.entries(options.config.mcpServers).map(([serverName, serverConfig]) => {
-      return createServerSnapshot(serverName, serverConfig, options.metadataCache, options.hasOAuthTokens);
+      return createServerSnapshot(serverName, serverConfig, options);
     }),
   );
 
@@ -46,12 +68,15 @@ export async function buildSnapshot(options: BuildSnapshotOptions): Promise<McpA
 async function createServerSnapshot(
   serverName: string,
   serverConfig: McpServerConfig,
-  metadataCache: McpMetadataCacheDocument,
-  hasOAuthTokens: (serverName: string) => Promise<boolean>,
+  options: BuildSnapshotOptions,
 ): Promise<McpServerSnapshot> {
   const enabled = serverConfig.enabled !== false;
-  const authStatus = await resolveAuthStatus(serverName, serverConfig, hasOAuthTokens);
-  const metadata = metadataCache.servers[serverName];
+  const runtimeStatus = options.runtimeStatuses?.get(serverName);
+  const derivedAuthStatus = await resolveAuthStatus(serverName, serverConfig, options.hasOAuthTokens);
+  const authStatus = runtimeStatus?.authStatus ?? derivedAuthStatus;
+  const metadata = getValidMetadata(serverName, serverConfig, options.metadataCache);
+  const uiTools = buildUiToolSummaries(metadata?.tools ?? []);
+  const resources = buildResourceSummaries(metadata?.resources ?? []);
 
   return {
     serverName,
@@ -59,11 +84,13 @@ async function createServerSnapshot(
     transport: resolveTransport(serverConfig),
     lifecycle: serverConfig.lifecycle ?? 'lazy',
     authMode: resolveAuthMode(serverConfig),
-    connectionStatus: resolveConnectionStatus(enabled, authStatus),
+    connectionStatus: enabled
+      ? runtimeStatus?.connectionStatus ?? resolveConnectionStatus(authStatus)
+      : 'disabled',
     authStatus,
     toolCount: metadata?.toolCount ?? 0,
     resourceCount: metadata?.resourceCount ?? 0,
-    uiToolCount: 0,
+    uiToolCount: uiTools.length,
     command: typeof serverConfig.command === 'string' ? serverConfig.command : undefined,
     argsText: Array.isArray(serverConfig.args) ? serverConfig.args.join('\n') : undefined,
     cwd: typeof serverConfig.cwd === 'string' ? serverConfig.cwd : undefined,
@@ -71,12 +98,21 @@ async function createServerSnapshot(
     bearerTokenEnv: typeof serverConfig.bearerTokenEnv === 'string' ? serverConfig.bearerTokenEnv : undefined,
     exposeResources: typeof serverConfig.exposeResources === 'boolean' ? serverConfig.exposeResources : true,
     debug: typeof serverConfig.debug === 'boolean' ? serverConfig.debug : false,
-    lastError: undefined,
-    lastConnectedAt: null,
-    lastFailedAt: null,
-    resources: [],
-    uiTools: [],
+    lastError: runtimeStatus?.lastError,
+    lastConnectedAt: runtimeStatus?.lastConnectedAt ?? null,
+    lastFailedAt: runtimeStatus?.lastFailedAt ?? null,
+    resources,
+    uiTools,
   };
+}
+
+function getValidMetadata(
+  serverName: string,
+  serverConfig: McpServerConfig,
+  metadataCache: McpMetadataCacheDocument,
+) {
+  const entry = metadataCache.servers[serverName];
+  return isMetadataCacheEntryValid(entry, serverConfig) ? entry : undefined;
 }
 
 async function resolveAuthStatus(
@@ -102,14 +138,31 @@ function resolveTransport(serverConfig: McpServerConfig): 'stdio' | 'http' {
   return typeof serverConfig.url === 'string' && serverConfig.url.length > 0 ? 'http' : 'stdio';
 }
 
-function resolveAuthMode(serverConfig: McpServerConfig): 'none' | 'oauth' | 'bearer' {
+function resolveAuthMode(serverConfig: McpServerConfig): McpAuthMode {
   if (serverConfig.auth === 'oauth') return 'oauth';
   if (serverConfig.auth === 'bearer') return 'bearer';
   return 'none';
 }
 
-function resolveConnectionStatus(enabled: boolean, authStatus: McpAuthStatus): McpConnectionStatus {
-  if (!enabled) return 'disabled';
+function resolveConnectionStatus(authStatus: McpAuthStatus): McpConnectionStatus {
   if (authStatus === 'not-authenticated') return 'needs-auth';
   return 'idle';
+}
+
+function buildUiToolSummaries(tools: CachedMcpTool[]): McpUiToolSummary[] {
+  return tools
+    .filter((tool) => !!tool.uiResourceUri)
+    .map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    }));
+}
+
+function buildResourceSummaries(resources: CachedMcpResource[]): McpResourceSummary[] {
+  return resources.map((resource) => ({
+    uri: resource.uri,
+    name: resource.name,
+    description: resource.description,
+  }));
 }

--- a/plugins/sero-mcp-plugin/extension/state/snapshot.ts
+++ b/plugins/sero-mcp-plugin/extension/state/snapshot.ts
@@ -151,11 +151,12 @@ function resolveConnectionStatus(authStatus: McpAuthStatus): McpConnectionStatus
 
 function buildUiToolSummaries(tools: CachedMcpTool[]): McpUiToolSummary[] {
   return tools
-    .filter((tool) => !!tool.uiResourceUri)
+    .filter((tool): tool is CachedMcpTool & { uiResourceUri: string } => !!tool.uiResourceUri)
     .map((tool) => ({
       name: tool.name,
       description: tool.description,
       inputSchema: tool.inputSchema,
+      resourceUri: tool.uiResourceUri,
     }));
 }
 

--- a/plugins/sero-mcp-plugin/extension/state/snapshot.ts
+++ b/plugins/sero-mcp-plugin/extension/state/snapshot.ts
@@ -28,7 +28,7 @@ interface BuildSnapshotOptions {
   rawConfigUpdatedAt: string | null;
   config: McpConfigDocument;
   metadataCache: McpMetadataCacheDocument;
-  hasOAuthTokens: (serverName: string) => Promise<boolean>;
+  hasOAuthTokens: (serverName: string, serverUrl?: string) => Promise<boolean>;
   runtimeStatuses?: Map<string, RuntimeServerStatus>;
 }
 
@@ -118,10 +118,10 @@ function getValidMetadata(
 async function resolveAuthStatus(
   serverName: string,
   serverConfig: McpServerConfig,
-  hasOAuthTokens: (serverName: string) => Promise<boolean>,
+  hasOAuthTokens: (serverName: string, serverUrl?: string) => Promise<boolean>,
 ): Promise<McpAuthStatus> {
   if (serverConfig.auth === 'oauth') {
-    return (await hasOAuthTokens(serverName)) ? 'authenticated' : 'not-authenticated';
+    return (await hasOAuthTokens(serverName, serverConfig.url)) ? 'authenticated' : 'not-authenticated';
   }
 
   if (serverConfig.auth === 'bearer') {

--- a/plugins/sero-mcp-plugin/extension/state/snapshot.ts
+++ b/plugins/sero-mcp-plugin/extension/state/snapshot.ts
@@ -13,7 +13,12 @@ import {
   type CachedMcpTool,
   type McpMetadataCacheDocument,
 } from '../cache/metadata-cache';
-import type { McpConfigDocument, McpServerConfig } from '../config/types';
+import {
+  hasBearerTokenValue,
+  isResourceExposureEnabled,
+  type McpConfigDocument,
+  type McpServerConfig,
+} from '../config/types';
 
 export interface RuntimeServerStatus {
   connectionStatus?: McpConnectionStatus;
@@ -76,7 +81,7 @@ async function createServerSnapshot(
   const authStatus = runtimeStatus?.authStatus ?? derivedAuthStatus;
   const metadata = getValidMetadata(serverName, serverConfig, options.metadataCache);
   const uiTools = buildUiToolSummaries(metadata?.tools ?? []);
-  const resources = buildResourceSummaries(metadata?.resources ?? []);
+  const resources = buildResourceSummaries(metadata?.resources ?? [], serverConfig);
 
   return {
     serverName,
@@ -89,7 +94,7 @@ async function createServerSnapshot(
       : 'disabled',
     authStatus,
     toolCount: metadata?.toolCount ?? 0,
-    resourceCount: metadata?.resourceCount ?? 0,
+    resourceCount: resources.length,
     uiToolCount: uiTools.length,
     command: typeof serverConfig.command === 'string' ? serverConfig.command : undefined,
     argsText: Array.isArray(serverConfig.args) ? serverConfig.args.join('\n') : undefined,
@@ -125,7 +130,7 @@ async function resolveAuthStatus(
   }
 
   if (serverConfig.auth === 'bearer') {
-    return serverConfig.bearerToken || serverConfig.bearerTokenEnv ? 'authenticated' : 'not-authenticated';
+    return hasBearerTokenValue(serverConfig) ? 'authenticated' : 'not-authenticated';
   }
 
   return 'not-required';
@@ -160,7 +165,14 @@ function buildUiToolSummaries(tools: CachedMcpTool[]): McpUiToolSummary[] {
     }));
 }
 
-function buildResourceSummaries(resources: CachedMcpResource[]): McpResourceSummary[] {
+function buildResourceSummaries(
+  resources: CachedMcpResource[],
+  serverConfig: McpServerConfig,
+): McpResourceSummary[] {
+  if (!isResourceExposureEnabled(serverConfig)) {
+    return [];
+  }
+
   return resources.map((resource) => ({
     uri: resource.uri,
     name: resource.name,

--- a/plugins/sero-mcp-plugin/extension/state/state-io.ts
+++ b/plugins/sero-mcp-plugin/extension/state/state-io.ts
@@ -1,0 +1,214 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { McpAppState, McpAuthStatus, McpConnectionStatus, McpServerSnapshot } from '../../shared/types';
+import { createDefaultMcpState, EMPTY_MCP_SUMMARY } from '../../shared/types';
+import type { McpConfigDocument, McpServerConfig } from '../config/types';
+import { getMcpStatePath } from './paths';
+
+const stateWriteQueues = new Map<string, Promise<void>>();
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeServerSnapshot(value: unknown): McpServerSnapshot | null {
+  if (!isRecord(value) || typeof value.serverName !== 'string') return null;
+  return {
+    serverName: value.serverName,
+    enabled: typeof value.enabled === 'boolean' ? value.enabled : true,
+    transport: value.transport === 'http' ? 'http' : 'stdio',
+    lifecycle:
+      value.lifecycle === 'eager' || value.lifecycle === 'keep-alive' ? value.lifecycle : 'lazy',
+    connectionStatus: normalizeConnectionStatus(value.connectionStatus),
+    authStatus: normalizeAuthStatus(value.authStatus),
+    toolCount: typeof value.toolCount === 'number' ? value.toolCount : 0,
+    resourceCount: typeof value.resourceCount === 'number' ? value.resourceCount : 0,
+    uiToolCount: typeof value.uiToolCount === 'number' ? value.uiToolCount : 0,
+    lastError: typeof value.lastError === 'string' ? value.lastError : undefined,
+    lastConnectedAt: typeof value.lastConnectedAt === 'string' ? value.lastConnectedAt : null,
+    lastFailedAt: typeof value.lastFailedAt === 'string' ? value.lastFailedAt : null,
+    resources: Array.isArray(value.resources) ? value.resources.filter(isRecord).map((resource) => ({
+      uri: typeof resource.uri === 'string' ? resource.uri : '',
+      name: typeof resource.name === 'string' ? resource.name : 'Resource',
+      description: typeof resource.description === 'string' ? resource.description : undefined,
+    })).filter((resource) => resource.uri.length > 0) : [],
+    uiTools: Array.isArray(value.uiTools) ? value.uiTools.filter(isRecord).map((tool) => ({
+      name: typeof tool.name === 'string' ? tool.name : '',
+      description: typeof tool.description === 'string' ? tool.description : undefined,
+      inputSchema: tool.inputSchema,
+    })).filter((tool) => tool.name.length > 0) : [],
+  };
+}
+
+function normalizeConnectionStatus(value: unknown): McpConnectionStatus {
+  switch (value) {
+    case 'disabled':
+    case 'idle':
+    case 'connecting':
+    case 'connected':
+    case 'needs-auth':
+    case 'error':
+      return value;
+    default:
+      return 'idle';
+  }
+}
+
+function normalizeAuthStatus(value: unknown): McpAuthStatus {
+  switch (value) {
+    case 'not-required':
+    case 'not-authenticated':
+    case 'authenticating':
+    case 'authenticated':
+    case 'expired':
+    case 'error':
+      return value;
+    default:
+      return 'not-required';
+  }
+}
+
+export function normalizeState(raw: unknown): McpAppState {
+  const defaults = createDefaultMcpState();
+  if (!isRecord(raw)) return defaults;
+
+  const servers = Array.isArray(raw.servers)
+    ? raw.servers.map(normalizeServerSnapshot).filter((server): server is McpServerSnapshot => !!server)
+    : [];
+
+  return {
+    initialized: typeof raw.initialized === 'boolean' ? raw.initialized : defaults.initialized,
+    firstRun: typeof raw.firstRun === 'boolean' ? raw.firstRun : servers.length === 0,
+    configPath: typeof raw.configPath === 'string' ? raw.configPath : defaults.configPath,
+    rawConfigUpdatedAt: typeof raw.rawConfigUpdatedAt === 'string' ? raw.rawConfigUpdatedAt : defaults.rawConfigUpdatedAt,
+    servers,
+    settings: {
+      idleTimeout:
+        isRecord(raw.settings) && typeof raw.settings.idleTimeout === 'number'
+          ? raw.settings.idleTimeout
+          : defaults.settings.idleTimeout,
+      toolPrefix:
+        isRecord(raw.settings) && (raw.settings.toolPrefix === 'server' || raw.settings.toolPrefix === 'short' || raw.settings.toolPrefix === 'none')
+          ? raw.settings.toolPrefix
+          : defaults.settings.toolPrefix,
+    },
+    lastRefreshedAt: typeof raw.lastRefreshedAt === 'string' ? raw.lastRefreshedAt : defaults.lastRefreshedAt,
+    summary: isRecord(raw.summary)
+      ? {
+          totalServers: typeof raw.summary.totalServers === 'number' ? raw.summary.totalServers : 0,
+          enabledServers: typeof raw.summary.enabledServers === 'number' ? raw.summary.enabledServers : 0,
+          connectedServers: typeof raw.summary.connectedServers === 'number' ? raw.summary.connectedServers : 0,
+          needsAuthServers: typeof raw.summary.needsAuthServers === 'number' ? raw.summary.needsAuthServers : 0,
+          errorServers: typeof raw.summary.errorServers === 'number' ? raw.summary.errorServers : 0,
+        }
+      : { ...EMPTY_MCP_SUMMARY },
+  };
+}
+
+export async function readState(filePath = getMcpStatePath()): Promise<McpAppState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return normalizeState(JSON.parse(raw));
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return createDefaultMcpState();
+    }
+    throw error;
+  }
+}
+
+export async function writeState(state: McpAppState, filePath = getMcpStatePath()): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp.${Date.now()}`;
+  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await fs.rename(tmpPath, filePath);
+}
+
+export async function updateState<T>(
+  updater: (state: McpAppState) => Promise<T> | T,
+  filePath = getMcpStatePath(),
+): Promise<T> {
+  const previous = stateWriteQueues.get(filePath) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  stateWriteQueues.set(filePath, previous.then(() => current));
+
+  await previous;
+  try {
+    const state = await readState(filePath);
+    return await updater(state);
+  } finally {
+    release();
+    if (stateWriteQueues.get(filePath) === current) {
+      stateWriteQueues.delete(filePath);
+    }
+  }
+}
+
+export function createSnapshotFromConfig(
+  configPath: string,
+  config: McpConfigDocument,
+  rawConfigUpdatedAt: string | null,
+): McpAppState {
+  const servers = Object.entries(config.mcpServers).map(([serverName, serverConfig]) => {
+    return createServerSnapshot(serverName, serverConfig);
+  });
+
+  const enabledServers = servers.filter((server) => server.enabled).length;
+  const connectedServers = servers.filter((server) => server.connectionStatus === 'connected').length;
+  const needsAuthServers = servers.filter((server) => server.authStatus === 'not-authenticated').length;
+  const errorServers = servers.filter((server) => server.connectionStatus === 'error' || server.authStatus === 'error').length;
+
+  return {
+    initialized: true,
+    firstRun: servers.length === 0,
+    configPath,
+    rawConfigUpdatedAt,
+    servers,
+    settings: {
+      idleTimeout: config.settings?.idleTimeout ?? 10,
+      toolPrefix: config.settings?.toolPrefix ?? 'server',
+    },
+    lastRefreshedAt: new Date().toISOString(),
+    summary: {
+      totalServers: servers.length,
+      enabledServers,
+      connectedServers,
+      needsAuthServers,
+      errorServers,
+    },
+  };
+}
+
+function createServerSnapshot(serverName: string, serverConfig: McpServerConfig): McpServerSnapshot {
+  const enabled = serverConfig.enabled !== false;
+  return {
+    serverName,
+    enabled,
+    transport: typeof serverConfig.url === 'string' && serverConfig.url.length > 0 ? 'http' : 'stdio',
+    lifecycle: serverConfig.lifecycle ?? 'lazy',
+    connectionStatus: enabled ? 'idle' : 'disabled',
+    authStatus: resolveAuthStatus(serverConfig),
+    toolCount: 0,
+    resourceCount: 0,
+    uiToolCount: 0,
+    lastError: undefined,
+    lastConnectedAt: null,
+    lastFailedAt: null,
+    resources: [],
+    uiTools: [],
+  };
+}
+
+function resolveAuthStatus(serverConfig: McpServerConfig): McpAuthStatus {
+  if (serverConfig.auth === 'oauth' || serverConfig.auth === 'bearer') {
+    return 'not-authenticated';
+  }
+  return 'not-required';
+}

--- a/plugins/sero-mcp-plugin/extension/state/state-io.ts
+++ b/plugins/sero-mcp-plugin/extension/state/state-io.ts
@@ -2,7 +2,6 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { McpAppState, McpAuthStatus, McpConnectionStatus, McpServerSnapshot } from '../../shared/types';
 import { createDefaultMcpState, EMPTY_MCP_SUMMARY } from '../../shared/types';
-import type { McpConfigDocument, McpServerConfig } from '../config/types';
 import { getMcpStatePath } from './paths';
 
 const stateWriteQueues = new Map<string, Promise<void>>();
@@ -151,64 +150,3 @@ export async function updateState<T>(
   }
 }
 
-export function createSnapshotFromConfig(
-  configPath: string,
-  config: McpConfigDocument,
-  rawConfigUpdatedAt: string | null,
-): McpAppState {
-  const servers = Object.entries(config.mcpServers).map(([serverName, serverConfig]) => {
-    return createServerSnapshot(serverName, serverConfig);
-  });
-
-  const enabledServers = servers.filter((server) => server.enabled).length;
-  const connectedServers = servers.filter((server) => server.connectionStatus === 'connected').length;
-  const needsAuthServers = servers.filter((server) => server.authStatus === 'not-authenticated').length;
-  const errorServers = servers.filter((server) => server.connectionStatus === 'error' || server.authStatus === 'error').length;
-
-  return {
-    initialized: true,
-    firstRun: servers.length === 0,
-    configPath,
-    rawConfigUpdatedAt,
-    servers,
-    settings: {
-      idleTimeout: config.settings?.idleTimeout ?? 10,
-      toolPrefix: config.settings?.toolPrefix ?? 'server',
-    },
-    lastRefreshedAt: new Date().toISOString(),
-    summary: {
-      totalServers: servers.length,
-      enabledServers,
-      connectedServers,
-      needsAuthServers,
-      errorServers,
-    },
-  };
-}
-
-function createServerSnapshot(serverName: string, serverConfig: McpServerConfig): McpServerSnapshot {
-  const enabled = serverConfig.enabled !== false;
-  return {
-    serverName,
-    enabled,
-    transport: typeof serverConfig.url === 'string' && serverConfig.url.length > 0 ? 'http' : 'stdio',
-    lifecycle: serverConfig.lifecycle ?? 'lazy',
-    connectionStatus: enabled ? 'idle' : 'disabled',
-    authStatus: resolveAuthStatus(serverConfig),
-    toolCount: 0,
-    resourceCount: 0,
-    uiToolCount: 0,
-    lastError: undefined,
-    lastConnectedAt: null,
-    lastFailedAt: null,
-    resources: [],
-    uiTools: [],
-  };
-}
-
-function resolveAuthStatus(serverConfig: McpServerConfig): McpAuthStatus {
-  if (serverConfig.auth === 'oauth' || serverConfig.auth === 'bearer') {
-    return 'not-authenticated';
-  }
-  return 'not-required';
-}

--- a/plugins/sero-mcp-plugin/extension/state/state-io.ts
+++ b/plugins/sero-mcp-plugin/extension/state/state-io.ts
@@ -47,7 +47,8 @@ function normalizeServerSnapshot(value: unknown): McpServerSnapshot | null {
       name: typeof tool.name === 'string' ? tool.name : '',
       description: typeof tool.description === 'string' ? tool.description : undefined,
       inputSchema: tool.inputSchema,
-    })).filter((tool) => tool.name.length > 0) : [],
+      resourceUri: typeof tool.resourceUri === 'string' ? tool.resourceUri : '',
+    })).filter((tool) => tool.name.length > 0 && tool.resourceUri.length > 0) : [],
   };
 }
 

--- a/plugins/sero-mcp-plugin/extension/state/state-io.ts
+++ b/plugins/sero-mcp-plugin/extension/state/state-io.ts
@@ -22,11 +22,19 @@ function normalizeServerSnapshot(value: unknown): McpServerSnapshot | null {
     transport: value.transport === 'http' ? 'http' : 'stdio',
     lifecycle:
       value.lifecycle === 'eager' || value.lifecycle === 'keep-alive' ? value.lifecycle : 'lazy',
+    authMode: normalizeAuthMode(value.authMode),
     connectionStatus: normalizeConnectionStatus(value.connectionStatus),
     authStatus: normalizeAuthStatus(value.authStatus),
     toolCount: typeof value.toolCount === 'number' ? value.toolCount : 0,
     resourceCount: typeof value.resourceCount === 'number' ? value.resourceCount : 0,
     uiToolCount: typeof value.uiToolCount === 'number' ? value.uiToolCount : 0,
+    command: typeof value.command === 'string' ? value.command : undefined,
+    argsText: typeof value.argsText === 'string' ? value.argsText : undefined,
+    cwd: typeof value.cwd === 'string' ? value.cwd : undefined,
+    url: typeof value.url === 'string' ? value.url : undefined,
+    bearerTokenEnv: typeof value.bearerTokenEnv === 'string' ? value.bearerTokenEnv : undefined,
+    exposeResources: typeof value.exposeResources === 'boolean' ? value.exposeResources : true,
+    debug: typeof value.debug === 'boolean' ? value.debug : false,
     lastError: typeof value.lastError === 'string' ? value.lastError : undefined,
     lastConnectedAt: typeof value.lastConnectedAt === 'string' ? value.lastConnectedAt : null,
     lastFailedAt: typeof value.lastFailedAt === 'string' ? value.lastFailedAt : null,
@@ -41,6 +49,16 @@ function normalizeServerSnapshot(value: unknown): McpServerSnapshot | null {
       inputSchema: tool.inputSchema,
     })).filter((tool) => tool.name.length > 0) : [],
   };
+}
+
+function normalizeAuthMode(value: unknown): 'none' | 'oauth' | 'bearer' {
+  switch (value) {
+    case 'oauth':
+    case 'bearer':
+      return value;
+    default:
+      return 'none';
+  }
 }
 
 function normalizeConnectionStatus(value: unknown): McpConnectionStatus {

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -18,9 +18,11 @@ const ManagerParams = Type.Object({
     'disable_server',
     'connect_server',
     'reconnect_server',
+    'read_resource',
   ] as const),
   rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
-  serverName: Type.Optional(Type.String({ description: 'Server name for remove/enable/disable actions.' })),
+  serverName: Type.Optional(Type.String({ description: 'Server name for server or resource actions.' })),
+  resourceUri: Type.Optional(Type.String({ description: 'Resource URI for read_resource.' })),
   originalServerName: Type.Optional(Type.String({ description: 'Existing server name when renaming a server.' })),
   enabled: Type.Optional(Type.Boolean()),
   transport: Type.Optional(StringEnum(['stdio', 'http'] as const)),
@@ -40,19 +42,21 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
     name: 'mcp_manager',
     label: 'MCP Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, and connect/reconnect operations.',
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, and resource preview operations.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const managerParams = params as Partial<McpServerEditorInput> & {
         action?: ManagerAction;
         rawConfig?: string;
         serverName?: string;
+        resourceUri?: string;
       };
       const action = managerParams.action ?? 'bootstrap';
       return runtime.executeManagerAction(action, {
         cwd: ctx?.cwd,
         rawConfig: managerParams.rawConfig,
         serverName: managerParams.serverName,
+        resourceUri: managerParams.resourceUri,
         serverInput: action === 'upsert_server' ? toServerEditorInput(managerParams) : undefined,
       });
     },

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -16,6 +16,8 @@ const ManagerParams = Type.Object({
     'remove_server',
     'enable_server',
     'disable_server',
+    'connect_server',
+    'reconnect_server',
   ] as const),
   rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
   serverName: Type.Optional(Type.String({ description: 'Server name for remove/enable/disable actions.' })),
@@ -38,7 +40,7 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
     name: 'mcp_manager',
     label: 'MCP Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, and server CRUD/toggle operations.',
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, and connect/reconnect operations.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const managerParams = params as Partial<McpServerEditorInput> & {

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -18,11 +18,15 @@ const ManagerParams = Type.Object({
     'disable_server',
     'connect_server',
     'reconnect_server',
+    'start_auth',
+    'complete_auth',
+    'cancel_auth',
     'read_resource',
   ] as const),
   rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
   serverName: Type.Optional(Type.String({ description: 'Server name for server or resource actions.' })),
   resourceUri: Type.Optional(Type.String({ description: 'Resource URI for read_resource.' })),
+  callbackUrl: Type.Optional(Type.String({ description: 'OAuth callback URL for complete_auth.' })),
   originalServerName: Type.Optional(Type.String({ description: 'Existing server name when renaming a server.' })),
   enabled: Type.Optional(Type.Boolean()),
   transport: Type.Optional(StringEnum(['stdio', 'http'] as const)),
@@ -42,7 +46,7 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
     name: 'mcp_manager',
     label: 'MCP Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, and resource preview operations.',
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, OAuth auth flow, and resource preview operations.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const managerParams = params as Partial<McpServerEditorInput> & {
@@ -50,6 +54,7 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
         rawConfig?: string;
         serverName?: string;
         resourceUri?: string;
+        callbackUrl?: string;
       };
       const action = managerParams.action ?? 'bootstrap';
       return runtime.executeManagerAction(action, {
@@ -57,6 +62,7 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
         rawConfig: managerParams.rawConfig,
         serverName: managerParams.serverName,
         resourceUri: managerParams.resourceUri,
+        callbackUrl: managerParams.callbackUrl,
         serverInput: action === 'upsert_server' ? toServerEditorInput(managerParams) : undefined,
       });
     },

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -23,10 +23,15 @@ const ManagerParams = Type.Object({
     'cancel_auth',
     'clear_auth',
     'read_resource',
+    'open_resource',
+    'open_tool_ui',
+    'close_viewer',
   ] as const),
   rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
   serverName: Type.Optional(Type.String({ description: 'Server name for server or resource actions.' })),
-  resourceUri: Type.Optional(Type.String({ description: 'Resource URI for read_resource.' })),
+  resourceUri: Type.Optional(Type.String({ description: 'Resource URI for read_resource, open_resource, or open_tool_ui.' })),
+  toolName: Type.Optional(Type.String({ description: 'Tool name for open_tool_ui.' })),
+  toolArguments: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: 'Structured tool arguments for open_tool_ui.' })),
   callbackUrl: Type.Optional(Type.String({ description: 'OAuth callback URL for complete_auth.' })),
   originalServerName: Type.Optional(Type.String({ description: 'Existing server name when renaming a server.' })),
   enabled: Type.Optional(Type.Boolean()),
@@ -47,7 +52,7 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
     name: 'mcp_manager',
     label: 'MCP Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, OAuth auth flow and cleanup, and resource preview operations.',
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, OAuth auth flow and cleanup, resource preview operations, and interactive viewer session hosting.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const managerParams = params as Partial<McpServerEditorInput> & {
@@ -55,6 +60,8 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
         rawConfig?: string;
         serverName?: string;
         resourceUri?: string;
+        toolName?: string;
+        toolArguments?: Record<string, unknown>;
         callbackUrl?: string;
       };
       const action = managerParams.action ?? 'bootstrap';
@@ -63,6 +70,8 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
         rawConfig: managerParams.rawConfig,
         serverName: managerParams.serverName,
         resourceUri: managerParams.resourceUri,
+        toolName: managerParams.toolName,
+        toolArguments: managerParams.toolArguments,
         callbackUrl: managerParams.callbackUrl,
         serverInput: action === 'upsert_server' ? toServerEditorInput(managerParams) : undefined,
       });

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -50,9 +50,9 @@ const ManagerParams = Type.Object({
 export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): void {
   pi.registerTool({
     name: 'mcp_manager',
-    label: 'MCP Manager',
+    label: 'MCP Internal Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, OAuth auth flow and cleanup, resource preview operations, and interactive viewer session hosting.',
+      'Internal MCP management surface for the MCP app UI. Prefer the `mcp` tool for normal agent work: status, discovery, resource reads, and tool calls. `mcp` auto-connects servers for live reads/calls, so this tool should usually be reserved for UI config/auth/viewer workflows and explicit server lifecycle changes.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const managerParams = params as Partial<McpServerEditorInput> & {

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -1,0 +1,28 @@
+import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Type } from '@sinclair/typebox';
+import type { McpRuntime } from '../runtime/mcp-runtime';
+import type { ManagerAction } from './types';
+
+const ManagerParams = Type.Object({
+  action: StringEnum(['bootstrap', 'refresh', 'get_raw_config', 'save_raw_config', 'get_diagnostics'] as const),
+  rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
+});
+
+export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): void {
+  pi.registerTool({
+    name: 'mcp_manager',
+    label: 'MCP Manager',
+    description:
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, get_raw_config, save_raw_config, get_diagnostics.',
+    parameters: ManagerParams,
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const managerParams = params as { action?: ManagerAction; rawConfig?: string };
+      const action = managerParams.action ?? 'bootstrap';
+      return runtime.executeManagerAction(action, {
+        cwd: ctx?.cwd,
+        rawConfig: managerParams.rawConfig,
+      });
+    },
+  });
+}

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -1,12 +1,36 @@
 import { StringEnum } from '@mariozechner/pi-ai';
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
+import type { McpServerEditorInput } from '../../shared/types';
 import type { McpRuntime } from '../runtime/mcp-runtime';
 import type { ManagerAction } from './types';
 
 const ManagerParams = Type.Object({
-  action: StringEnum(['bootstrap', 'refresh', 'get_raw_config', 'save_raw_config', 'get_diagnostics'] as const),
+  action: StringEnum([
+    'bootstrap',
+    'refresh',
+    'get_raw_config',
+    'save_raw_config',
+    'get_diagnostics',
+    'upsert_server',
+    'remove_server',
+    'enable_server',
+    'disable_server',
+  ] as const),
   rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
+  serverName: Type.Optional(Type.String({ description: 'Server name for remove/enable/disable actions.' })),
+  originalServerName: Type.Optional(Type.String({ description: 'Existing server name when renaming a server.' })),
+  enabled: Type.Optional(Type.Boolean()),
+  transport: Type.Optional(StringEnum(['stdio', 'http'] as const)),
+  lifecycle: Type.Optional(StringEnum(['lazy', 'eager', 'keep-alive'] as const)),
+  authMode: Type.Optional(StringEnum(['none', 'oauth', 'bearer'] as const)),
+  command: Type.Optional(Type.String()),
+  argsText: Type.Optional(Type.String()),
+  cwd: Type.Optional(Type.String()),
+  url: Type.Optional(Type.String()),
+  bearerTokenEnv: Type.Optional(Type.String()),
+  exposeResources: Type.Optional(Type.Boolean()),
+  debug: Type.Optional(Type.Boolean()),
 });
 
 export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): void {
@@ -14,15 +38,39 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
     name: 'mcp_manager',
     label: 'MCP Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, get_raw_config, save_raw_config, get_diagnostics.',
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, and server CRUD/toggle operations.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const managerParams = params as { action?: ManagerAction; rawConfig?: string };
+      const managerParams = params as Partial<McpServerEditorInput> & {
+        action?: ManagerAction;
+        rawConfig?: string;
+        serverName?: string;
+      };
       const action = managerParams.action ?? 'bootstrap';
       return runtime.executeManagerAction(action, {
         cwd: ctx?.cwd,
         rawConfig: managerParams.rawConfig,
+        serverName: managerParams.serverName,
+        serverInput: action === 'upsert_server' ? toServerEditorInput(managerParams) : undefined,
       });
     },
   });
+}
+
+function toServerEditorInput(value: Partial<McpServerEditorInput>): McpServerEditorInput {
+  return {
+    originalServerName: value.originalServerName,
+    serverName: value.serverName ?? '',
+    enabled: value.enabled ?? true,
+    transport: value.transport ?? 'stdio',
+    lifecycle: value.lifecycle ?? 'lazy',
+    authMode: value.authMode ?? 'none',
+    command: value.command ?? '',
+    argsText: value.argsText ?? '',
+    cwd: value.cwd ?? '',
+    url: value.url ?? '',
+    bearerTokenEnv: value.bearerTokenEnv ?? '',
+    exposeResources: value.exposeResources ?? true,
+    debug: value.debug ?? false,
+  };
 }

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -21,6 +21,7 @@ const ManagerParams = Type.Object({
     'start_auth',
     'complete_auth',
     'cancel_auth',
+    'clear_auth',
     'read_resource',
   ] as const),
   rawConfig: Type.Optional(Type.String({ description: 'Raw MCP config JSON for save_raw_config.' })),
@@ -46,7 +47,7 @@ export function registerMcpManagerTool(pi: ExtensionAPI, runtime: McpRuntime): v
     name: 'mcp_manager',
     label: 'MCP Manager',
     description:
-      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, OAuth auth flow, and resource preview operations.',
+      'Internal management surface for the MCP app UI. Actions: bootstrap, refresh, raw config, diagnostics, server CRUD/toggle, connect/reconnect, OAuth auth flow and cleanup, and resource preview operations.',
     parameters: ManagerParams,
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const managerParams = params as Partial<McpServerEditorInput> & {

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -5,10 +5,11 @@ import type { McpRuntime } from '../runtime/mcp-runtime';
 import type { CliContext, CliResult, ProxyAction } from './types';
 
 const ProxyParams = Type.Object({
-  action: Type.Optional(StringEnum(['status', 'list', 'search', 'list_tools', 'list_resources', 'describe_tool', 'call_tool'] as const)),
+  action: Type.Optional(StringEnum(['status', 'list', 'search', 'list_tools', 'list_resources', 'describe_tool', 'call_tool', 'read_resource'] as const)),
   query: Type.Optional(Type.String({ description: 'Search query for MCP tools and resources.' })),
   serverName: Type.Optional(Type.String({ description: 'Server name for MCP tool inventory or calls.' })),
   toolName: Type.Optional(Type.String({ description: 'Exact MCP tool name for describe_tool or call_tool.' })),
+  resourceUri: Type.Optional(Type.String({ description: 'Resource URI for read_resource.' })),
   toolArguments: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: 'Structured MCP tool arguments for call_tool.' })),
   argumentsJson: Type.Optional(Type.String({ description: 'JSON object string for MCP tool arguments when action is call_tool.' })),
 });
@@ -30,7 +31,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
     parameters: ProxyParams,
     cli: {
       summary: 'Inspect, search, and call MCP servers through one proxy surface',
-      help: 'sero mcp status | list | search <query> | tools <server> | resources <server> | describe <server> <tool> | call <server> <tool> [jsonArgs] | connect <server> | reconnect <server> | enable <server> | disable <server>',
+      help: 'sero mcp status | list | search <query> | tools <server> | resources <server> | read <server> <resourceUri> | describe <server> <tool> | call <server> <tool> [jsonArgs] | connect <server> | reconnect <server> | enable <server> | disable <server>',
       async execute(args: string[], ctx: CliContext) {
         const action = parseCliCommand(args);
         if (action.kind === 'usage-error') {
@@ -42,6 +43,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
               query: action.query,
               serverName: action.serverName,
               toolName: action.toolName,
+              resourceUri: action.resourceUri,
               toolArguments: action.toolArguments,
               argumentsJson: action.argumentsJson,
             })
@@ -59,6 +61,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
         query?: string;
         serverName?: string;
         toolName?: string;
+        resourceUri?: string;
         toolArguments?: Record<string, unknown>;
         argumentsJson?: string;
       };
@@ -67,6 +70,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
         query: proxyParams.query,
         serverName: proxyParams.serverName,
         toolName: proxyParams.toolName,
+        resourceUri: proxyParams.resourceUri,
         toolArguments: proxyParams.toolArguments,
         argumentsJson: proxyParams.argumentsJson,
       });
@@ -83,6 +87,7 @@ type CliCommand =
       query?: string;
       serverName?: string;
       toolName?: string;
+      resourceUri?: string;
       toolArguments?: Record<string, unknown>;
       argumentsJson?: string;
     }
@@ -111,6 +116,12 @@ function parseCliCommand(args: string[]): CliCommand {
     return serverName
       ? { kind: 'proxy', action: 'list_resources', serverName }
       : { kind: 'usage-error', message: 'Usage: sero mcp resources <server>' };
+  }
+  if (subcommand === 'read') {
+    const resourceUri = args.slice(2).join(' ').trim();
+    return serverName && resourceUri
+      ? { kind: 'proxy', action: 'read_resource', serverName, resourceUri }
+      : { kind: 'usage-error', message: 'Usage: sero mcp read <server> <resourceUri>' };
   }
   if (subcommand === 'describe') {
     const toolName = args[2]?.trim();

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -9,6 +9,7 @@ const ProxyParams = Type.Object({
   query: Type.Optional(Type.String({ description: 'Search query for MCP tools and resources.' })),
   serverName: Type.Optional(Type.String({ description: 'Server name for MCP tool inventory or calls.' })),
   toolName: Type.Optional(Type.String({ description: 'Exact MCP tool name for describe_tool or call_tool.' })),
+  toolArguments: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: 'Structured MCP tool arguments for call_tool.' })),
   argumentsJson: Type.Optional(Type.String({ description: 'JSON object string for MCP tool arguments when action is call_tool.' })),
 });
 
@@ -41,6 +42,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
               query: action.query,
               serverName: action.serverName,
               toolName: action.toolName,
+              toolArguments: action.toolArguments,
               argumentsJson: action.argumentsJson,
             })
           : await runtime.executeManagerAction(action.action, { cwd: ctx.cwd, serverName: action.serverName });
@@ -57,6 +59,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
         query?: string;
         serverName?: string;
         toolName?: string;
+        toolArguments?: Record<string, unknown>;
         argumentsJson?: string;
       };
       return runtime.executeProxyAction(proxyParams.action ?? 'status', {
@@ -64,6 +67,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
         query: proxyParams.query,
         serverName: proxyParams.serverName,
         toolName: proxyParams.toolName,
+        toolArguments: proxyParams.toolArguments,
         argumentsJson: proxyParams.argumentsJson,
       });
     },
@@ -79,6 +83,7 @@ type CliCommand =
       query?: string;
       serverName?: string;
       toolName?: string;
+      toolArguments?: Record<string, unknown>;
       argumentsJson?: string;
     }
   | { kind: 'manager'; action: 'connect_server' | 'reconnect_server' | 'enable_server' | 'disable_server'; serverName: string }

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -5,7 +5,7 @@ import type { McpRuntime } from '../runtime/mcp-runtime';
 import type { CliContext, CliResult, ProxyAction } from './types';
 
 const ProxyParams = Type.Object({
-  action: Type.Optional(StringEnum(['status', 'list', 'search', 'list_tools', 'describe_tool', 'call_tool'] as const)),
+  action: Type.Optional(StringEnum(['status', 'list', 'search', 'list_tools', 'list_resources', 'describe_tool', 'call_tool'] as const)),
   query: Type.Optional(Type.String({ description: 'Search query for MCP tools and resources.' })),
   serverName: Type.Optional(Type.String({ description: 'Server name for MCP tool inventory or calls.' })),
   toolName: Type.Optional(Type.String({ description: 'Exact MCP tool name for describe_tool or call_tool.' })),
@@ -29,7 +29,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
     parameters: ProxyParams,
     cli: {
       summary: 'Inspect, search, and call MCP servers through one proxy surface',
-      help: 'sero mcp status | list | search <query> | tools <server> | describe <server> <tool> | call <server> <tool> [jsonArgs] | connect <server> | reconnect <server> | enable <server> | disable <server>',
+      help: 'sero mcp status | list | search <query> | tools <server> | resources <server> | describe <server> <tool> | call <server> <tool> [jsonArgs] | connect <server> | reconnect <server> | enable <server> | disable <server>',
       async execute(args: string[], ctx: CliContext) {
         const action = parseCliCommand(args);
         if (action.kind === 'usage-error') {
@@ -101,6 +101,11 @@ function parseCliCommand(args: string[]): CliCommand {
     return serverName
       ? { kind: 'proxy', action: 'list_tools', serverName }
       : { kind: 'usage-error', message: 'Usage: sero mcp tools <server>' };
+  }
+  if (subcommand === 'resources') {
+    return serverName
+      ? { kind: 'proxy', action: 'list_resources', serverName }
+      : { kind: 'usage-error', message: 'Usage: sero mcp resources <server>' };
   }
   if (subcommand === 'describe') {
     const toolName = args[2]?.trim();

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -5,7 +5,11 @@ import type { McpRuntime } from '../runtime/mcp-runtime';
 import type { CliContext, CliResult, ProxyAction } from './types';
 
 const ProxyParams = Type.Object({
-  action: Type.Optional(StringEnum(['status', 'list'] as const)),
+  action: Type.Optional(StringEnum(['status', 'list', 'search', 'list_tools', 'describe_tool', 'call_tool'] as const)),
+  query: Type.Optional(Type.String({ description: 'Search query for MCP tools and resources.' })),
+  serverName: Type.Optional(Type.String({ description: 'Server name for MCP tool inventory or calls.' })),
+  toolName: Type.Optional(Type.String({ description: 'Exact MCP tool name for describe_tool or call_tool.' })),
+  argumentsJson: Type.Optional(Type.String({ description: 'JSON object string for MCP tool arguments when action is call_tool.' })),
 });
 
 type ToolWithCli = Parameters<ExtensionAPI['registerTool']>[0] & {
@@ -21,29 +25,47 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
     name: 'mcp',
     label: 'MCP',
     description:
-      'Initial MCP control surface for Sero. The bridged tool reports status/list today, and the CLI also supports basic connect/reconnect/enable/disable actions.',
+      'MCP proxy for Sero. Use it to inspect MCP server status, search cached MCP tools/resources, describe server tools, and call MCP tools through one bridged surface.',
     parameters: ProxyParams,
     cli: {
-      summary: 'Inspect and control configured MCP servers',
-      help: 'sero mcp status | list | connect <server> | reconnect <server> | enable <server> | disable <server>',
+      summary: 'Inspect, search, and call MCP servers through one proxy surface',
+      help: 'sero mcp status | list | search <query> | tools <server> | describe <server> <tool> | call <server> <tool> [jsonArgs] | connect <server> | reconnect <server> | enable <server> | disable <server>',
       async execute(args: string[], ctx: CliContext) {
         const action = parseCliCommand(args);
         if (action.kind === 'usage-error') {
           return { output: action.message, exitCode: 1 };
         }
         const result = action.kind === 'proxy'
-          ? await runtime.executeProxyAction(action.action, { cwd: ctx.cwd })
+          ? await runtime.executeProxyAction(action.action, {
+              cwd: ctx.cwd,
+              query: action.query,
+              serverName: action.serverName,
+              toolName: action.toolName,
+              argumentsJson: action.argumentsJson,
+            })
           : await runtime.executeManagerAction(action.action, { cwd: ctx.cwd, serverName: action.serverName });
         const text = result.content[0]?.text ?? '';
         return {
           output: text,
-          exitCode: text.startsWith('Error:') ? 1 : 0,
+          exitCode: text.startsWith('Error:') || result.details.isError === true ? 1 : 0,
         };
       },
     },
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const proxyParams = params as { action?: ProxyAction };
-      return runtime.executeProxyAction(proxyParams.action ?? 'status', { cwd: ctx?.cwd });
+      const proxyParams = params as {
+        action?: ProxyAction;
+        query?: string;
+        serverName?: string;
+        toolName?: string;
+        argumentsJson?: string;
+      };
+      return runtime.executeProxyAction(proxyParams.action ?? 'status', {
+        cwd: ctx?.cwd,
+        query: proxyParams.query,
+        serverName: proxyParams.serverName,
+        toolName: proxyParams.toolName,
+        argumentsJson: proxyParams.argumentsJson,
+      });
     },
   };
 
@@ -51,7 +73,14 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
 }
 
 type CliCommand =
-  | { kind: 'proxy'; action: ProxyAction }
+  | {
+      kind: 'proxy';
+      action: ProxyAction;
+      query?: string;
+      serverName?: string;
+      toolName?: string;
+      argumentsJson?: string;
+    }
   | { kind: 'manager'; action: 'connect_server' | 'reconnect_server' | 'enable_server' | 'disable_server'; serverName: string }
   | { kind: 'usage-error'; message: string };
 
@@ -61,6 +90,30 @@ function parseCliCommand(args: string[]): CliCommand {
 
   if (subcommand === 'list') {
     return { kind: 'proxy', action: 'list' };
+  }
+  if (subcommand === 'search') {
+    const query = args.slice(1).join(' ').trim();
+    return query
+      ? { kind: 'proxy', action: 'search', query }
+      : { kind: 'usage-error', message: 'Usage: sero mcp search <query>' };
+  }
+  if (subcommand === 'tools') {
+    return serverName
+      ? { kind: 'proxy', action: 'list_tools', serverName }
+      : { kind: 'usage-error', message: 'Usage: sero mcp tools <server>' };
+  }
+  if (subcommand === 'describe') {
+    const toolName = args[2]?.trim();
+    return serverName && toolName
+      ? { kind: 'proxy', action: 'describe_tool', serverName, toolName }
+      : { kind: 'usage-error', message: 'Usage: sero mcp describe <server> <tool>' };
+  }
+  if (subcommand === 'call') {
+    const toolName = args[2]?.trim();
+    const argumentsJson = args.slice(3).join(' ').trim();
+    return serverName && toolName
+      ? { kind: 'proxy', action: 'call_tool', serverName, toolName, argumentsJson: argumentsJson || undefined }
+      : { kind: 'usage-error', message: 'Usage: sero mcp call <server> <tool> [jsonArgs]' };
   }
   if (subcommand === 'connect') {
     return serverName

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -4,10 +4,25 @@ import { Type } from '@sinclair/typebox';
 import type { McpRuntime } from '../runtime/mcp-runtime';
 import type { CliContext, CliResult, ProxyAction } from './types';
 
+const MCP_TOOL_ACTIONS = [
+  'status',
+  'list',
+  'search',
+  'list_tools',
+  'list_resources',
+  'describe_tool',
+  'call_tool',
+  'read_resource',
+  'connect',
+  'reconnect',
+] as const;
+
+type McpToolAction = ProxyAction | 'connect' | 'reconnect';
+
 const ProxyParams = Type.Object({
-  action: Type.Optional(StringEnum(['status', 'list', 'search', 'list_tools', 'list_resources', 'describe_tool', 'call_tool', 'read_resource'] as const)),
+  action: Type.Optional(StringEnum(MCP_TOOL_ACTIONS)),
   query: Type.Optional(Type.String({ description: 'Search query for MCP tools and resources.' })),
-  serverName: Type.Optional(Type.String({ description: 'Server name for MCP tool inventory or calls.' })),
+  serverName: Type.Optional(Type.String({ description: 'Server name for MCP inventory, resource/tool calls, or connect/reconnect actions.' })),
   toolName: Type.Optional(Type.String({ description: 'Exact MCP tool name for describe_tool or call_tool.' })),
   resourceUri: Type.Optional(Type.String({ description: 'Resource URI for read_resource.' })),
   toolArguments: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: 'Structured MCP tool arguments for call_tool.' })),
@@ -27,11 +42,11 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
     name: 'mcp',
     label: 'MCP',
     description:
-      'MCP proxy for Sero. Use it to inspect MCP server status, search cached MCP tools/resources, describe server tools, and call MCP tools through one bridged surface.',
+      'Preferred MCP surface for agents in Sero. Use it for status, discovery, resource reads, and tool calls. Live reads and tool calls auto-connect enabled servers when needed, so explicit connect actions are usually only needed when the user asks for lifecycle control.',
     parameters: ProxyParams,
     cli: {
-      summary: 'Inspect, search, and call MCP servers through one proxy surface',
-      help: 'sero mcp status | list | search <query> | tools <server> | resources <server> | read <server> <resourceUri> | describe <server> <tool> | call <server> <tool> [jsonArgs] | connect <server> | reconnect <server> | enable <server> | disable <server>',
+      summary: 'Inspect, search, connect, and call MCP servers through the preferred agent surface',
+      help: 'Preferred MCP surface: start with status/list/search/tools/resources/describe/call/read. Live read/call actions auto-connect enabled servers when needed. CLI: sero mcp status | list | search <query> | tools <server> | resources <server> | read <server> <resourceUri> | describe <server> <tool> | call <server> <tool> [jsonArgs] | connect <server> | reconnect <server> | enable <server> | disable <server>',
       async execute(args: string[], ctx: CliContext) {
         const action = parseCliCommand(args);
         if (action.kind === 'usage-error') {
@@ -57,7 +72,7 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
     },
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const proxyParams = params as {
-        action?: ProxyAction;
+        action?: McpToolAction;
         query?: string;
         serverName?: string;
         toolName?: string;
@@ -65,7 +80,14 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
         toolArguments?: Record<string, unknown>;
         argumentsJson?: string;
       };
-      return runtime.executeProxyAction(proxyParams.action ?? 'status', {
+      const action = proxyParams.action ?? 'status';
+      if (action === 'connect' || action === 'reconnect') {
+        return runtime.executeManagerAction(action === 'connect' ? 'connect_server' : 'reconnect_server', {
+          cwd: ctx?.cwd,
+          serverName: proxyParams.serverName,
+        });
+      }
+      return runtime.executeProxyAction(action, {
         cwd: ctx?.cwd,
         query: proxyParams.query,
         serverName: proxyParams.serverName,

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -21,14 +21,19 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
     name: 'mcp',
     label: 'MCP',
     description:
-      'Initial MCP control surface for Sero. Actions: status or list configured MCP servers while the full proxy experience is being built.',
+      'Initial MCP control surface for Sero. The bridged tool reports status/list today, and the CLI also supports basic connect/reconnect/enable/disable actions.',
     parameters: ProxyParams,
     cli: {
-      summary: 'Inspect configured MCP servers',
-      help: 'sero mcp status | list',
+      summary: 'Inspect and control configured MCP servers',
+      help: 'sero mcp status | list | connect <server> | reconnect <server> | enable <server> | disable <server>',
       async execute(args: string[], ctx: CliContext) {
-        const action = parseCliAction(args);
-        const result = await runtime.executeProxyAction(action, { cwd: ctx.cwd });
+        const action = parseCliCommand(args);
+        if (action.kind === 'usage-error') {
+          return { output: action.message, exitCode: 1 };
+        }
+        const result = action.kind === 'proxy'
+          ? await runtime.executeProxyAction(action.action, { cwd: ctx.cwd })
+          : await runtime.executeManagerAction(action.action, { cwd: ctx.cwd, serverName: action.serverName });
         const text = result.content[0]?.text ?? '';
         return {
           output: text,
@@ -45,8 +50,37 @@ export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): voi
   pi.registerTool(mcpTool);
 }
 
-function parseCliAction(args: string[]): ProxyAction {
+type CliCommand =
+  | { kind: 'proxy'; action: ProxyAction }
+  | { kind: 'manager'; action: 'connect_server' | 'reconnect_server' | 'enable_server' | 'disable_server'; serverName: string }
+  | { kind: 'usage-error'; message: string };
+
+function parseCliCommand(args: string[]): CliCommand {
   const subcommand = args[0]?.trim();
-  if (subcommand === 'list') return 'list';
-  return 'status';
+  const serverName = args[1]?.trim();
+
+  if (subcommand === 'list') {
+    return { kind: 'proxy', action: 'list' };
+  }
+  if (subcommand === 'connect') {
+    return serverName
+      ? { kind: 'manager', action: 'connect_server', serverName }
+      : { kind: 'usage-error', message: 'Usage: sero mcp connect <server>' };
+  }
+  if (subcommand === 'reconnect') {
+    return serverName
+      ? { kind: 'manager', action: 'reconnect_server', serverName }
+      : { kind: 'usage-error', message: 'Usage: sero mcp reconnect <server>' };
+  }
+  if (subcommand === 'enable') {
+    return serverName
+      ? { kind: 'manager', action: 'enable_server', serverName }
+      : { kind: 'usage-error', message: 'Usage: sero mcp enable <server>' };
+  }
+  if (subcommand === 'disable') {
+    return serverName
+      ? { kind: 'manager', action: 'disable_server', serverName }
+      : { kind: 'usage-error', message: 'Usage: sero mcp disable <server>' };
+  }
+  return { kind: 'proxy', action: 'status' };
 }

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -1,0 +1,52 @@
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { StringEnum } from '@mariozechner/pi-ai';
+import { Type } from '@sinclair/typebox';
+import type { McpRuntime } from '../runtime/mcp-runtime';
+import type { CliContext, CliResult, ProxyAction } from './types';
+
+const ProxyParams = Type.Object({
+  action: Type.Optional(StringEnum(['status', 'list'] as const)),
+});
+
+type ToolWithCli = Parameters<ExtensionAPI['registerTool']>[0] & {
+  cli: {
+    summary: string;
+    help: string;
+    execute: (args: string[], ctx: CliContext) => Promise<CliResult>;
+  };
+};
+
+export function registerMcpProxyTool(pi: ExtensionAPI, runtime: McpRuntime): void {
+  const mcpTool: ToolWithCli = {
+    name: 'mcp',
+    label: 'MCP',
+    description:
+      'Initial MCP control surface for Sero. Actions: status or list configured MCP servers while the full proxy experience is being built.',
+    parameters: ProxyParams,
+    cli: {
+      summary: 'Inspect configured MCP servers',
+      help: 'sero mcp status | list',
+      async execute(args: string[], ctx: CliContext) {
+        const action = parseCliAction(args);
+        const result = await runtime.executeProxyAction(action, { cwd: ctx.cwd });
+        const text = result.content[0]?.text ?? '';
+        return {
+          output: text,
+          exitCode: text.startsWith('Error:') ? 1 : 0,
+        };
+      },
+    },
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      const proxyParams = params as { action?: ProxyAction };
+      return runtime.executeProxyAction(proxyParams.action ?? 'status', { cwd: ctx?.cwd });
+    },
+  };
+
+  pi.registerTool(mcpTool);
+}
+
+function parseCliAction(args: string[]): ProxyAction {
+  const subcommand = args[0]?.trim();
+  if (subcommand === 'list') return 'list';
+  return 'status';
+}

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -15,7 +15,7 @@ export type ManagerAction =
   | 'cancel_auth'
   | 'clear_auth'
   | 'read_resource';
-export type ProxyAction = 'status' | 'list' | 'search' | 'list_tools' | 'list_resources' | 'describe_tool' | 'call_tool';
+export type ProxyAction = 'status' | 'list' | 'search' | 'list_tools' | 'list_resources' | 'describe_tool' | 'call_tool' | 'read_resource';
 
 export type ToolResult = {
   content: Array<{ type: 'text'; text: string }>;

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -10,6 +10,9 @@ export type ManagerAction =
   | 'disable_server'
   | 'connect_server'
   | 'reconnect_server'
+  | 'start_auth'
+  | 'complete_auth'
+  | 'cancel_auth'
   | 'read_resource';
 export type ProxyAction = 'status' | 'list';
 

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -14,7 +14,10 @@ export type ManagerAction =
   | 'complete_auth'
   | 'cancel_auth'
   | 'clear_auth'
-  | 'read_resource';
+  | 'read_resource'
+  | 'open_resource'
+  | 'open_tool_ui'
+  | 'close_viewer';
 export type ProxyAction = 'status' | 'list' | 'search' | 'list_tools' | 'list_resources' | 'describe_tool' | 'call_tool' | 'read_resource';
 
 export type ToolResult = {

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -15,7 +15,7 @@ export type ManagerAction =
   | 'cancel_auth'
   | 'clear_auth'
   | 'read_resource';
-export type ProxyAction = 'status' | 'list';
+export type ProxyAction = 'status' | 'list' | 'search' | 'list_tools' | 'describe_tool' | 'call_tool';
 
 export type ToolResult = {
   content: Array<{ type: 'text'; text: string }>;

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -15,7 +15,7 @@ export type ManagerAction =
   | 'cancel_auth'
   | 'clear_auth'
   | 'read_resource';
-export type ProxyAction = 'status' | 'list' | 'search' | 'list_tools' | 'describe_tool' | 'call_tool';
+export type ProxyAction = 'status' | 'list' | 'search' | 'list_tools' | 'list_resources' | 'describe_tool' | 'call_tool';
 
 export type ToolResult = {
   content: Array<{ type: 'text'; text: string }>;

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -13,6 +13,7 @@ export type ManagerAction =
   | 'start_auth'
   | 'complete_auth'
   | 'cancel_auth'
+  | 'clear_auth'
   | 'read_resource';
 export type ProxyAction = 'status' | 'list';
 

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -7,7 +7,9 @@ export type ManagerAction =
   | 'upsert_server'
   | 'remove_server'
   | 'enable_server'
-  | 'disable_server';
+  | 'disable_server'
+  | 'connect_server'
+  | 'reconnect_server';
 export type ProxyAction = 'status' | 'list';
 
 export type ToolResult = {

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -1,4 +1,13 @@
-export type ManagerAction = 'bootstrap' | 'refresh' | 'get_raw_config' | 'save_raw_config' | 'get_diagnostics';
+export type ManagerAction =
+  | 'bootstrap'
+  | 'refresh'
+  | 'get_raw_config'
+  | 'save_raw_config'
+  | 'get_diagnostics'
+  | 'upsert_server'
+  | 'remove_server'
+  | 'enable_server'
+  | 'disable_server';
 export type ProxyAction = 'status' | 'list';
 
 export type ToolResult = {

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -1,0 +1,23 @@
+export type ManagerAction = 'bootstrap' | 'refresh' | 'get_raw_config' | 'save_raw_config' | 'get_diagnostics';
+export type ProxyAction = 'status' | 'list';
+
+export type ToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  details: Record<string, unknown>;
+};
+
+export type CliResult = {
+  output: string;
+  exitCode: number;
+};
+
+export type CliContext = {
+  cwd: string;
+};
+
+export function createToolResult(text: string, details: Record<string, unknown> = {}): ToolResult {
+  return {
+    content: [{ type: 'text', text }],
+    details,
+  };
+}

--- a/plugins/sero-mcp-plugin/extension/tools/types.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/types.ts
@@ -9,7 +9,8 @@ export type ManagerAction =
   | 'enable_server'
   | 'disable_server'
   | 'connect_server'
-  | 'reconnect_server';
+  | 'reconnect_server'
+  | 'read_resource';
 export type ProxyAction = 'status' | 'list';
 
 export type ToolResult = {

--- a/plugins/sero-mcp-plugin/extension/tsconfig.json
+++ b/plugins/sero-mcp-plugin/extension/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../packages/tsconfig.extension.json",
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/plugins/sero-mcp-plugin/extension/viewer/host-template.ts
+++ b/plugins/sero-mcp-plugin/extension/viewer/host-template.ts
@@ -1,4 +1,9 @@
+import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/ext-apps/app-bridge';
 import type { UiResourceContent, UiToolInfo } from './types';
+
+// Keep this aligned with the desktop host version until the shell exposes a
+// runtime version constant to plugin extensions.
+const SERO_HOST_VERSION = '0.1.0';
 
 export function buildHostHtmlTemplate(input: {
   sessionId: string;
@@ -63,7 +68,7 @@ export function buildHostHtmlTemplate(input: {
     const ALLOW_ATTRIBUTE = ${safeInlineJson(input.allowAttribute)};
     const iframe = document.getElementById('mcp-ui');
     const statusBadge = document.getElementById('status-badge');
-    const hostInfo = { name: 'Sero', version: '0.1.0' };
+    const hostInfo = { name: 'Sero', version: ${safeInlineJson(SERO_HOST_VERSION)} };
     const hostCapabilities = {
       openLinks: {},
       downloadFile: {},
@@ -111,7 +116,7 @@ export function buildHostHtmlTemplate(input: {
 
       try {
         if (method === 'ui/initialize' && isRequest) {
-          sendResult(id, { protocolVersion: '2026-01-26', hostInfo, hostCapabilities, hostContext: HOST_CONTEXT });
+          sendResult(id, { protocolVersion: ${safeInlineJson(LATEST_PROTOCOL_VERSION)}, hostInfo, hostCapabilities, hostContext: HOST_CONTEXT });
           return;
         }
         if (method === 'ping' && isRequest) {
@@ -225,11 +230,29 @@ export function buildHostHtmlTemplate(input: {
     if (ALLOW_ATTRIBUTE) {
       iframe.setAttribute('allow', ALLOW_ATTRIBUTE);
     }
-    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms allow-popups allow-downloads');
+    // Deliberately omit allow-same-origin so embedded MCP UIs cannot reach back
+    // into the host frame directly; they must go through the AppBridge-style
+    // postMessage contract exposed by this viewer shell.
+    iframe.setAttribute('sandbox', 'allow-scripts allow-forms allow-popups allow-downloads');
     iframe.src = '/ui-app?session=' + encodeURIComponent(SESSION_ID);
   </script>
 </body>
 </html>`;
+}
+
+export function buildViewerHostCspContent(): string {
+  return [
+    "default-src 'none'",
+    "script-src 'unsafe-inline'",
+    "style-src 'unsafe-inline'",
+    "img-src 'self' data:",
+    "connect-src 'self'",
+    "frame-src 'self'",
+    "font-src 'none'",
+    "object-src 'none'",
+    "base-uri 'none'",
+    "form-action 'none'",
+  ].join('; ');
 }
 
 export function buildCspMetaContent(csp: UiResourceContent['meta']['csp']): string | undefined {

--- a/plugins/sero-mcp-plugin/extension/viewer/host-template.ts
+++ b/plugins/sero-mcp-plugin/extension/viewer/host-template.ts
@@ -1,0 +1,318 @@
+import type { UiResourceContent, UiToolInfo } from './types';
+
+export function buildHostHtmlTemplate(input: {
+  sessionId: string;
+  serverName: string;
+  resourceUri: string;
+  title: string;
+  allowAttribute: string;
+  toolArgs: Record<string, unknown>;
+  toolInfo?: UiToolInfo;
+}): string {
+  const hostContext = buildHostContext(input.toolInfo);
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(input.title)}</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f1115;
+      --surface: #181c22;
+      --text: #ecf0f5;
+      --muted: #98a2b3;
+      --border: rgba(255,255,255,0.12);
+      --danger: #f87171;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; background: var(--bg); color: var(--text); font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { display: flex; flex-direction: column; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 14px; border-bottom: 1px solid var(--border); background: var(--surface); }
+    .title { min-width: 0; }
+    .label { display: block; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
+    .name { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 14px; font-weight: 600; }
+    .badges { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+    .badge { border: 1px solid var(--border); border-radius: 999px; padding: 2px 8px; font-size: 11px; color: var(--muted); }
+    .badge.error { border-color: color-mix(in srgb, var(--danger) 35%, var(--border) 65%); color: var(--danger); }
+    main { flex: 1; min-height: 0; padding: 10px; }
+    iframe { width: 100%; height: 100%; min-height: 520px; border: 1px solid var(--border); border-radius: 10px; background: white; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="title">
+      <span class="label">MCP interactive UI</span>
+      <span class="name">${escapeHtml(input.title)}</span>
+    </div>
+    <div class="badges">
+      <span class="badge">${escapeHtml(input.serverName)}</span>
+      <span class="badge">${escapeHtml(input.resourceUri)}</span>
+      <span class="badge" id="status-badge">connecting</span>
+    </div>
+  </header>
+  <main>
+    <iframe id="mcp-ui" referrerpolicy="no-referrer"></iframe>
+  </main>
+  <script>
+    const SESSION_ID = ${safeInlineJson(input.sessionId)};
+    const TOOL_ARGS = ${safeInlineJson(input.toolArgs)};
+    const HOST_CONTEXT = ${safeInlineJson(hostContext)};
+    const ALLOW_ATTRIBUTE = ${safeInlineJson(input.allowAttribute)};
+    const iframe = document.getElementById('mcp-ui');
+    const statusBadge = document.getElementById('status-badge');
+    const hostInfo = { name: 'Sero', version: '0.1.0' };
+    const hostCapabilities = {
+      openLinks: {},
+      downloadFile: {},
+      serverTools: { listChanged: false },
+      serverResources: { listChanged: false },
+      updateModelContext: {},
+      message: {},
+    };
+
+    const setStatus = (label, isError = false) => {
+      statusBadge.textContent = label;
+      statusBadge.classList.toggle('error', isError);
+    };
+
+    const post = async (path, params) => {
+      const response = await fetch(path, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: SESSION_ID, params }),
+      });
+      const body = await response.json().catch(() => ({ ok: false, error: 'Invalid JSON response' }));
+      if (!response.ok || !body.ok) {
+        throw new Error(body.error || ('HTTP ' + response.status));
+      }
+      return body.result ?? {};
+    };
+
+    const sendResult = (id, result) => {
+      iframe.contentWindow?.postMessage({ jsonrpc: '2.0', id, result }, '*');
+    };
+
+    const sendError = (id, message, code = -32000) => {
+      iframe.contentWindow?.postMessage({ jsonrpc: '2.0', id, error: { code, message } }, '*');
+    };
+
+    const sendNotification = (method, params) => {
+      iframe.contentWindow?.postMessage({ jsonrpc: '2.0', method, params }, '*');
+    };
+
+    const handleJsonRpc = async (message) => {
+      const method = typeof message.method === 'string' ? message.method : '';
+      const params = message.params;
+      const id = Object.prototype.hasOwnProperty.call(message, 'id') ? message.id : undefined;
+      const isRequest = id !== undefined;
+
+      try {
+        if (method === 'ui/initialize' && isRequest) {
+          sendResult(id, { protocolVersion: '2026-01-26', hostInfo, hostCapabilities, hostContext: HOST_CONTEXT });
+          return;
+        }
+        if (method === 'ping' && isRequest) {
+          sendResult(id, {});
+          return;
+        }
+        if (method === 'ui/notifications/initialized') {
+          setStatus('connected');
+          sendNotification('ui/notifications/tool-input', { arguments: TOOL_ARGS });
+          return;
+        }
+        if (method === 'ui/notifications/size-changed') {
+          if (params && typeof params === 'object') {
+            const height = typeof params.height === 'number' ? Math.max(params.height, 320) : null;
+            if (height) {
+              iframe.style.height = height + 'px';
+            }
+          }
+          return;
+        }
+        if (!isRequest) {
+          return;
+        }
+
+        if (method === 'tools/call') {
+          sendResult(id, await post('/proxy/tools/call', params));
+          return;
+        }
+        if (method === 'tools/list') {
+          sendResult(id, await post('/proxy/tools/list', params));
+          return;
+        }
+        if (method === 'resources/list') {
+          sendResult(id, await post('/proxy/resources/list', params));
+          return;
+        }
+        if (method === 'resources/templates/list') {
+          sendResult(id, await post('/proxy/resources/templates/list', params));
+          return;
+        }
+        if (method === 'resources/read') {
+          sendResult(id, await post('/proxy/resources/read', params));
+          return;
+        }
+        if (method === 'prompts/list') {
+          sendResult(id, await post('/proxy/prompts/list', params));
+          return;
+        }
+        if (method === 'ui/message') {
+          await post('/proxy/ui/message', params);
+          sendResult(id, {});
+          return;
+        }
+        if (method === 'ui/update-model-context') {
+          await post('/proxy/ui/context', params);
+          sendResult(id, {});
+          return;
+        }
+        if (method === 'ui/open-link') {
+          if (params && typeof params.url === 'string') {
+            window.open(params.url, '_blank', 'noopener,noreferrer');
+          }
+          sendResult(id, { isError: false });
+          return;
+        }
+        if (method === 'ui/download-file') {
+          sendResult(id, { isError: true });
+          return;
+        }
+        if (method === 'ui/request-display-mode') {
+          sendResult(id, { mode: 'inline' });
+          return;
+        }
+        if (method === 'ui/resource-teardown') {
+          sendResult(id, {});
+          return;
+        }
+
+        sendError(id, 'Method not found', -32601);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        setStatus('error', true);
+        sendError(id, message);
+      }
+    };
+
+    window.addEventListener('message', (event) => {
+      if (event.source !== iframe.contentWindow) {
+        return;
+      }
+      const payload = event.data;
+      if (!payload || typeof payload !== 'object') {
+        return;
+      }
+      if (payload.jsonrpc === '2.0' && typeof payload.method === 'string') {
+        void handleJsonRpc(payload);
+        return;
+      }
+      const messageType = typeof payload.type === 'string' ? payload.type : '';
+      if (!messageType || messageType.startsWith('ui-lifecycle-') || messageType.startsWith('ui-message-')) {
+        return;
+      }
+      const forwarded = messageType === 'notify' || messageType === 'prompt' || messageType === 'intent' || messageType === 'message'
+        ? { ...payload }
+        : { type: 'intent', intent: messageType, params: payload.payload && typeof payload.payload === 'object' ? payload.payload : {} };
+      void post('/proxy/ui/message', forwarded).catch(() => {
+        setStatus('error', true);
+      });
+    });
+
+    if (ALLOW_ATTRIBUTE) {
+      iframe.setAttribute('allow', ALLOW_ATTRIBUTE);
+    }
+    iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms allow-popups allow-downloads');
+    iframe.src = '/ui-app?session=' + encodeURIComponent(SESSION_ID);
+  </script>
+</body>
+</html>`;
+}
+
+export function buildCspMetaContent(csp: UiResourceContent['meta']['csp']): string | undefined {
+  if (!csp) {
+    return undefined;
+  }
+
+  const directives = ["default-src 'none'"];
+  pushDirective(directives, 'script-src', csp.scriptDomains);
+  pushDirective(directives, 'style-src', csp.styleDomains);
+  pushDirective(directives, 'font-src', csp.fontDomains);
+  pushDirective(directives, 'img-src', csp.imgDomains);
+  pushDirective(directives, 'media-src', csp.mediaDomains);
+  pushDirective(directives, 'connect-src', csp.connectDomains);
+  pushDirective(directives, 'frame-src', csp.frameDomains);
+  pushDirective(directives, 'worker-src', csp.workerDomains);
+  pushDirective(directives, 'base-uri', csp.baseUriDomains);
+  return directives.join('; ');
+}
+
+export function applyCspMeta(html: string, cspContent: string | undefined): string {
+  if (!cspContent || /http-equiv=["']Content-Security-Policy["']/i.test(html)) {
+    return html;
+  }
+  const metaTag = `<meta http-equiv="Content-Security-Policy" content="${escapeHtmlAttribute(cspContent)}">`;
+  if (/<head[^>]*>/i.test(html)) {
+    return html.replace(/<head[^>]*>/i, (match) => `${match}\n${metaTag}`);
+  }
+  return `${metaTag}\n${html}`;
+}
+
+function buildHostContext(toolInfo: UiToolInfo | undefined): Record<string, unknown> {
+  if (!toolInfo) {
+    return { platform: 'desktop', displayMode: 'inline', availableDisplayModes: ['inline'] };
+  }
+
+  return {
+    platform: 'desktop',
+    displayMode: 'inline',
+    availableDisplayModes: ['inline'],
+    toolInfo: {
+      tool: {
+        name: toolInfo.name,
+        description: toolInfo.description,
+        inputSchema: isRecord(toolInfo.inputSchema) ? toolInfo.inputSchema : { type: 'object', properties: {} },
+      },
+    },
+  };
+}
+
+function pushDirective(target: string[], name: string, values: string[] | undefined): void {
+  if (!values || values.length === 0) {
+    return;
+  }
+  target.push(`${name} ${values.join(' ')}`);
+}
+
+function safeInlineJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/plugins/sero-mcp-plugin/extension/viewer/types.ts
+++ b/plugins/sero-mcp-plugin/extension/viewer/types.ts
@@ -1,0 +1,38 @@
+export interface UiResourceCsp {
+  scriptDomains?: string[];
+  styleDomains?: string[];
+  fontDomains?: string[];
+  imgDomains?: string[];
+  mediaDomains?: string[];
+  connectDomains?: string[];
+  frameDomains?: string[];
+  workerDomains?: string[];
+  baseUriDomains?: string[];
+}
+
+export interface UiResourcePermissions {
+  camera?: Record<string, never>;
+  microphone?: Record<string, never>;
+  geolocation?: Record<string, never>;
+  clipboardWrite?: Record<string, never>;
+}
+
+export interface UiResourceMeta {
+  csp?: UiResourceCsp;
+  permissions?: UiResourcePermissions;
+  domain?: string;
+  prefersBorder?: boolean;
+}
+
+export interface UiResourceContent {
+  uri: string;
+  html: string;
+  mimeType: string;
+  meta: UiResourceMeta;
+}
+
+export interface UiToolInfo {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}

--- a/plugins/sero-mcp-plugin/extension/viewer/ui-resource-handler.ts
+++ b/plugins/sero-mcp-plugin/extension/viewer/ui-resource-handler.ts
@@ -1,0 +1,108 @@
+import { RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/app-bridge';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { McpServerManager } from '../manager/server-manager';
+import type { UiResourceContent, UiResourceMeta } from './types';
+
+interface ResourceContentRecord {
+  uri?: string;
+  mimeType?: string;
+  text?: string;
+  blob?: string;
+  _meta?: Record<string, unknown>;
+}
+
+export class UiResourceHandler {
+  constructor(private readonly manager: McpServerManager) {}
+
+  async readUiResource(serverName: string, resourceUri: string): Promise<UiResourceContent> {
+    if (!resourceUri.startsWith('ui://')) {
+      throw new Error(`Resource "${resourceUri}" is not an MCP UI resource.`);
+    }
+
+    const result = await this.manager.readResource(serverName, resourceUri);
+    const content = selectContent(result, resourceUri);
+    const mimeType = content.mimeType?.trim() || RESOURCE_MIME_TYPE;
+    if (!isHtmlMimeType(mimeType)) {
+      throw new Error(`Resource "${resourceUri}" is not HTML and cannot be hosted as an MCP UI.`);
+    }
+
+    const html = toHtml(content);
+    if (!html.trim()) {
+      throw new Error(`Resource "${resourceUri}" did not return any HTML.`);
+    }
+
+    return {
+      uri: content.uri ?? resourceUri,
+      html,
+      mimeType,
+      meta: mergeUiMeta(content._meta, this.getListResourceMeta(serverName, resourceUri)),
+    };
+  }
+
+  private getListResourceMeta(serverName: string, resourceUri: string): Record<string, unknown> | undefined {
+    const connection = this.manager.getConnection(serverName);
+    const resource = connection?.resources.find((entry) => entry.uri === resourceUri);
+    return resource?._meta && typeof resource._meta === 'object' ? resource._meta : undefined;
+  }
+}
+
+function selectContent(result: ReadResourceResult, preferredUri: string): ResourceContentRecord {
+  const contents = (result.contents ?? []) as ResourceContentRecord[];
+  if (contents.length === 0) {
+    throw new Error(`No contents were returned for resource "${preferredUri}".`);
+  }
+
+  return contents.find((content) => content.uri === preferredUri) ?? contents[0];
+}
+
+function isHtmlMimeType(mimeType: string): boolean {
+  const normalized = mimeType.toLowerCase();
+  return normalized.startsWith('text/html') || normalized === RESOURCE_MIME_TYPE.toLowerCase();
+}
+
+function toHtml(content: ResourceContentRecord): string {
+  if (typeof content.text === 'string') {
+    return content.text;
+  }
+  if (typeof content.blob === 'string') {
+    return Buffer.from(content.blob, 'base64').toString('utf8');
+  }
+  throw new Error(`UI resource ${content.uri ?? '(unknown)'} did not include text or blob content.`);
+}
+
+function mergeUiMeta(
+  contentMeta: Record<string, unknown> | undefined,
+  listMeta: Record<string, unknown> | undefined,
+): UiResourceMeta {
+  const nextContentMeta = extractUiMeta(contentMeta);
+  const nextListMeta = extractUiMeta(listMeta);
+  return {
+    csp: nextContentMeta.csp ?? nextListMeta.csp,
+    permissions: nextContentMeta.permissions ?? nextListMeta.permissions,
+    domain: nextContentMeta.domain ?? nextListMeta.domain,
+    prefersBorder: nextContentMeta.prefersBorder ?? nextListMeta.prefersBorder,
+  };
+}
+
+function extractUiMeta(meta: Record<string, unknown> | undefined): UiResourceMeta {
+  if (!meta || typeof meta !== 'object') {
+    return {};
+  }
+
+  const ui = meta.ui;
+  if (!ui || typeof ui !== 'object' || Array.isArray(ui)) {
+    return {};
+  }
+
+  const nextUi = ui as Record<string, unknown>;
+  return {
+    csp: nextUi.csp && typeof nextUi.csp === 'object' && !Array.isArray(nextUi.csp)
+      ? nextUi.csp as UiResourceMeta['csp']
+      : undefined,
+    permissions: nextUi.permissions && typeof nextUi.permissions === 'object' && !Array.isArray(nextUi.permissions)
+      ? nextUi.permissions as UiResourceMeta['permissions']
+      : undefined,
+    domain: typeof nextUi.domain === 'string' ? nextUi.domain : undefined,
+    prefersBorder: typeof nextUi.prefersBorder === 'boolean' ? nextUi.prefersBorder : undefined,
+  };
+}

--- a/plugins/sero-mcp-plugin/extension/viewer/ui-server.ts
+++ b/plugins/sero-mcp-plugin/extension/viewer/ui-server.ts
@@ -1,0 +1,317 @@
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { buildAllowAttribute } from '@modelcontextprotocol/ext-apps/app-bridge';
+import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { CallToolResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { McpServerManager } from '../manager/server-manager';
+import { applyCspMeta, buildCspMetaContent, buildHostHtmlTemplate } from './host-template';
+import type { UiResourceContent, UiToolInfo } from './types';
+
+const MAX_BODY_SIZE = 2 * 1024 * 1024;
+
+interface JsonRpcRequest {
+  jsonrpc?: string;
+  id?: string | number | null;
+  method?: string;
+  params?: unknown;
+}
+
+interface PostBody {
+  token?: string;
+  params?: unknown;
+}
+
+export interface UiServerOptions {
+  serverName: string;
+  resourceUri: string;
+  title: string;
+  resource: UiResourceContent;
+  toolInfo?: UiToolInfo;
+  toolArgs?: Record<string, unknown>;
+  manager: McpServerManager;
+  onUnauthorized?: (serverName: string, message: string) => Promise<void>;
+  onUiMessage?: (params: Record<string, unknown>) => Promise<void> | void;
+  onClose?: (reason: string) => void;
+}
+
+export interface UiServerHandle {
+  sessionId: string;
+  viewerUrl: string;
+  serverName: string;
+  resourceUri: string;
+  close: (reason?: string) => void;
+}
+
+export async function startUiServer(options: UiServerOptions): Promise<UiServerHandle> {
+  const sessionId = randomUUID();
+  let closed = false;
+  let closeReason = 'closed';
+
+  const server = http.createServer(async (request, response) => {
+    try {
+      const method = request.method || 'GET';
+      const url = new URL(request.url || '/', `http://${request.headers.host || '127.0.0.1'}`);
+
+      if (method === 'GET' && url.pathname === '/') {
+        if (!validateSessionQuery(url, sessionId, response)) return;
+        sendHtml(response, buildHostHtmlTemplate({
+          sessionId,
+          serverName: options.serverName,
+          resourceUri: options.resourceUri,
+          title: options.title,
+          allowAttribute: buildAllowAttribute(options.resource.meta.permissions),
+          toolArgs: options.toolArgs ?? {},
+          toolInfo: options.toolInfo,
+        }));
+        return;
+      }
+
+      if (method === 'GET' && url.pathname === '/ui-app') {
+        if (!validateSessionQuery(url, sessionId, response)) return;
+        sendHtml(response, applyCspMeta(options.resource.html, buildCspMetaContent(options.resource.meta.csp)));
+        return;
+      }
+
+      if (method !== 'POST') {
+        sendJson(response, 404, { ok: false, error: 'Not found' });
+        return;
+      }
+
+      const body = await readBody(request);
+      if (!validateSessionBody(body, sessionId, response)) {
+        return;
+      }
+
+      if (url.pathname === '/proxy/tools/call') {
+        sendJson(response, 200, {
+          ok: true,
+          result: await callViewerTool(options, body.params),
+        });
+        return;
+      }
+
+      if (url.pathname === '/proxy/tools/list') {
+        sendJson(response, 200, {
+          ok: true,
+          result: { tools: options.manager.getConnection(options.serverName)?.tools ?? [] },
+        });
+        return;
+      }
+
+      if (url.pathname === '/proxy/resources/list') {
+        sendJson(response, 200, {
+          ok: true,
+          result: { resources: options.manager.getConnection(options.serverName)?.resources ?? [] },
+        });
+        return;
+      }
+
+      if (url.pathname === '/proxy/resources/read') {
+        sendJson(response, 200, {
+          ok: true,
+          result: await readViewerResource(options, body.params),
+        });
+        return;
+      }
+
+      if (url.pathname === '/proxy/resources/templates/list') {
+        sendJson(response, 200, {
+          ok: true,
+          result: { resourceTemplates: [] },
+        });
+        return;
+      }
+
+      if (url.pathname === '/proxy/prompts/list') {
+        sendJson(response, 200, {
+          ok: true,
+          result: { prompts: [] },
+        });
+        return;
+      }
+
+      if (url.pathname === '/proxy/ui/message' || url.pathname === '/proxy/ui/context') {
+        await options.onUiMessage?.(toRecord(body.params));
+        sendJson(response, 200, { ok: true, result: {} });
+        return;
+      }
+
+      sendJson(response, 404, { ok: false, error: 'Not found' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      sendJson(response, 500, { ok: false, error: message });
+    }
+  });
+
+  const port = await listen(server);
+  const viewerUrl = `http://127.0.0.1:${port}/?session=${encodeURIComponent(sessionId)}`;
+
+  const close = (reason = 'closed') => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    closeReason = reason;
+    server.close();
+  };
+
+  server.on('close', () => {
+    options.onClose?.(closeReason);
+  });
+
+  return {
+    sessionId,
+    viewerUrl,
+    serverName: options.serverName,
+    resourceUri: options.resourceUri,
+    close,
+  };
+}
+
+async function callViewerTool(options: UiServerOptions, params: unknown): Promise<CallToolResult> {
+  const toolCall = toRecord(params);
+  const toolName = typeof toolCall.name === 'string' ? toolCall.name.trim() : '';
+  const toolArguments = isRecord(toolCall.arguments) ? toolCall.arguments : undefined;
+  if (!toolName) {
+    return createToolErrorResult('Tool name is required.');
+  }
+
+  try {
+    return await options.manager.callTool(options.serverName, toolName, toolArguments);
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      const message = error.message || 'Authentication is required.';
+      await options.onUnauthorized?.(options.serverName, message);
+      return createToolErrorResult('This MCP UI session lost authentication. Re-authenticate the server in Sero and reopen the UI.');
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    return createToolErrorResult(message);
+  }
+}
+
+async function readViewerResource(options: UiServerOptions, params: unknown): Promise<ReadResourceResult> {
+  const readRequest = toRecord(params);
+  const resourceUri = typeof readRequest.uri === 'string' ? readRequest.uri.trim() : '';
+  if (!resourceUri) {
+    throw new Error('Resource URI is required.');
+  }
+
+  try {
+    return await options.manager.readResource(options.serverName, resourceUri);
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      const message = error.message || 'Authentication is required.';
+      await options.onUnauthorized?.(options.serverName, message);
+      throw new Error('This MCP UI session lost authentication. Re-authenticate the server in Sero and reopen the UI.');
+    }
+    throw error;
+  }
+}
+
+function validateSessionQuery(url: URL, sessionId: string, response: ServerResponse): boolean {
+  if (url.searchParams.get('session') === sessionId) {
+    return true;
+  }
+  sendJson(response, 403, { ok: false, error: 'Invalid viewer session token' });
+  return false;
+}
+
+function validateSessionBody(body: unknown, sessionId: string, response: ServerResponse): body is PostBody {
+  if (isRecord(body) && body.token === sessionId) {
+    return true;
+  }
+  sendJson(response, 403, { ok: false, error: 'Invalid viewer session token' });
+  return false;
+}
+
+async function readBody(request: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+    if (size > MAX_BODY_SIZE) {
+      throw new Error('Request body too large.');
+    }
+    chunks.push(buffer);
+  }
+
+  const bodyText = Buffer.concat(chunks).toString('utf8');
+  if (!bodyText.trim()) {
+    return {};
+  }
+  return JSON.parse(bodyText);
+}
+
+function sendHtml(response: ServerResponse, html: string): void {
+  response.writeHead(200, {
+    'Content-Type': 'text/html; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  response.end(html);
+}
+
+function sendJson(response: ServerResponse, statusCode: number, body: Record<string, unknown>): void {
+  response.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  response.end(JSON.stringify(body));
+}
+
+function createToolErrorResult(message: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: message }],
+  };
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to determine MCP viewer port.'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function safeInlineJson(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/plugins/sero-mcp-plugin/extension/viewer/ui-server.ts
+++ b/plugins/sero-mcp-plugin/extension/viewer/ui-server.ts
@@ -4,7 +4,7 @@ import { buildAllowAttribute } from '@modelcontextprotocol/ext-apps/app-bridge';
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { CallToolResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import type { McpServerManager } from '../manager/server-manager';
-import { applyCspMeta, buildCspMetaContent, buildHostHtmlTemplate } from './host-template';
+import { applyCspMeta, buildCspMetaContent, buildHostHtmlTemplate, buildViewerHostCspContent } from './host-template';
 import type { UiResourceContent, UiToolInfo } from './types';
 
 const MAX_BODY_SIZE = 2 * 1024 * 1024;
@@ -54,21 +54,26 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
       if (method === 'GET' && url.pathname === '/') {
         if (!validateSessionQuery(url, sessionId, response)) return;
-        sendHtml(response, buildHostHtmlTemplate({
-          sessionId,
-          serverName: options.serverName,
-          resourceUri: options.resourceUri,
-          title: options.title,
-          allowAttribute: buildAllowAttribute(options.resource.meta.permissions),
-          toolArgs: options.toolArgs ?? {},
-          toolInfo: options.toolInfo,
-        }));
+        sendHtml(
+          response,
+          buildHostHtmlTemplate({
+            sessionId,
+            serverName: options.serverName,
+            resourceUri: options.resourceUri,
+            title: options.title,
+            allowAttribute: buildAllowAttribute(options.resource.meta.permissions),
+            toolArgs: options.toolArgs ?? {},
+            toolInfo: options.toolInfo,
+          }),
+          buildViewerHostCspContent(),
+        );
         return;
       }
 
       if (method === 'GET' && url.pathname === '/ui-app') {
         if (!validateSessionQuery(url, sessionId, response)) return;
-        sendHtml(response, applyCspMeta(options.resource.html, buildCspMetaContent(options.resource.meta.csp)));
+        const csp = buildCspMetaContent(options.resource.meta.csp);
+        sendHtml(response, applyCspMeta(options.resource.html, csp), csp);
         return;
       }
 
@@ -245,10 +250,11 @@ async function readBody(request: IncomingMessage): Promise<unknown> {
   return JSON.parse(bodyText);
 }
 
-function sendHtml(response: ServerResponse, html: string): void {
+function sendHtml(response: ServerResponse, html: string, csp?: string): void {
   response.writeHead(200, {
     'Content-Type': 'text/html; charset=utf-8',
     'Cache-Control': 'no-store',
+    ...(csp ? { 'Content-Security-Policy': csp } : {}),
   });
   response.end(html);
 }
@@ -290,28 +296,3 @@ function listen(server: http.Server): Promise<number> {
   });
 }
 
-function safeInlineJson(value: unknown): string {
-  return JSON.stringify(value)
-    .replace(/</g, '\\u003c')
-    .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026')
-    .replace(/\u2028/g, '\\u2028')
-    .replace(/\u2029/g, '\\u2029');
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function escapeHtmlAttribute(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}

--- a/plugins/sero-mcp-plugin/extension/viewer/ui-session.ts
+++ b/plugins/sero-mcp-plugin/extension/viewer/ui-session.ts
@@ -1,0 +1,38 @@
+import { startUiServer, type UiServerHandle, type UiServerOptions } from './ui-server';
+
+export class McpUiSessionManager {
+  private activeSession: UiServerHandle | null = null;
+
+  async open(options: UiServerOptions): Promise<UiServerHandle> {
+    await this.closeActive('replaced');
+
+    const handle = await startUiServer({
+      ...options,
+      onClose: (reason) => {
+        if (this.activeSession?.sessionId === handle.sessionId) {
+          this.activeSession = null;
+        }
+        options.onClose?.(reason);
+      },
+    });
+
+    this.activeSession = handle;
+    return handle;
+  }
+
+  getActiveSession(): UiServerHandle | null {
+    return this.activeSession;
+  }
+
+  async closeActive(reason = 'closed'): Promise<void> {
+    const current = this.activeSession;
+    this.activeSession = null;
+    current?.close(reason);
+  }
+
+  async closeIfServerMatches(serverName: string): Promise<void> {
+    if (this.activeSession?.serverName === serverName) {
+      await this.closeActive('server-config-changed');
+    }
+  }
+}

--- a/plugins/sero-mcp-plugin/package.json
+++ b/plugins/sero-mcp-plugin/package.json
@@ -67,6 +67,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "jsdom": "^26.1.0",
     "lucide-react": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/plugins/sero-mcp-plugin/package.json
+++ b/plugins/sero-mcp-plugin/package.json
@@ -46,7 +46,10 @@
     }
   },
   "dependencies": {
-    "@sinclair/typebox": "catalog:"
+    "@modelcontextprotocol/ext-apps": "1.2.2",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@sinclair/typebox": "catalog:",
+    "zod": "catalog:"
   },
   "peerDependencies": {
     "@mariozechner/pi-ai": "catalog:peer",

--- a/plugins/sero-mcp-plugin/package.json
+++ b/plugins/sero-mcp-plugin/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json"
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json",
+    "test": "pnpm exec vitest run --root ."
   },
   "pi": {
     "extensions": [
@@ -71,6 +72,7 @@
     "react-dom": "catalog:",
     "tailwindcss": "catalog:",
     "typescript": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/plugins/sero-mcp-plugin/package.json
+++ b/plugins/sero-mcp-plugin/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@sero-ai/plugin-mcp",
+  "version": "0.1.0",
+  "description": "Built-in MCP control center for Sero",
+  "keywords": [
+    "pi-package"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json"
+  },
+  "pi": {
+    "extensions": [
+      "./extension/index.ts"
+    ]
+  },
+  "sero": {
+    "app": {
+      "id": "mcp",
+      "name": "MCP",
+      "icon": "plug",
+      "scope": "global",
+      "stateFile": ".sero/apps/mcp/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "McpApp",
+      "devPort": 5196
+    },
+    "plugin": {
+      "category": "developer-tools",
+      "tags": [
+        "mcp",
+        "servers",
+        "oauth",
+        "resources"
+      ],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": [
+        "appAgent.invokeTool",
+        "tool.cli"
+      ],
+      "bridgeTools": [
+        "mcp"
+      ],
+      "preBuilt": false
+    }
+  },
+  "dependencies": {
+    "@sinclair/typebox": "catalog:"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-ai": "catalog:peer",
+    "@mariozechner/pi-coding-agent": "catalog:peer",
+    "@mariozechner/pi-tui": "catalog:peer"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "catalog:",
+    "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",
+    "@sero-ai/common": "workspace:*",
+    "@sero-ai/ui": "workspace:*",
+    "@tailwindcss/vite": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "lucide-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/plugins/sero-mcp-plugin/shared/types.ts
+++ b/plugins/sero-mcp-plugin/shared/types.ts
@@ -3,6 +3,7 @@ export type McpTransport = 'stdio' | 'http';
 export type McpLifecycle = 'lazy' | 'eager' | 'keep-alive';
 export type McpConnectionStatus = 'disabled' | 'idle' | 'connecting' | 'connected' | 'needs-auth' | 'error';
 export type McpAuthStatus = 'not-required' | 'not-authenticated' | 'authenticating' | 'authenticated' | 'expired' | 'error';
+export type McpAuthMode = 'none' | 'oauth' | 'bearer';
 
 export interface McpResourceSummary {
   uri: string;
@@ -21,11 +22,19 @@ export interface McpServerSnapshot {
   enabled: boolean;
   transport: McpTransport;
   lifecycle: McpLifecycle;
+  authMode: McpAuthMode;
   connectionStatus: McpConnectionStatus;
   authStatus: McpAuthStatus;
   toolCount: number;
   resourceCount: number;
   uiToolCount: number;
+  command?: string;
+  argsText?: string;
+  cwd?: string;
+  url?: string;
+  bearerTokenEnv?: string;
+  exposeResources?: boolean;
+  debug?: boolean;
   lastError?: string;
   lastConnectedAt?: string | null;
   lastFailedAt?: string | null;
@@ -57,6 +66,22 @@ export interface McpAppState {
   summary: McpSummary;
 }
 
+export interface McpServerEditorInput {
+  originalServerName?: string;
+  serverName: string;
+  enabled: boolean;
+  transport: McpTransport;
+  lifecycle: McpLifecycle;
+  authMode: McpAuthMode;
+  command: string;
+  argsText: string;
+  cwd: string;
+  url: string;
+  bearerTokenEnv: string;
+  exposeResources: boolean;
+  debug: boolean;
+}
+
 export const DEFAULT_MCP_SETTINGS: McpSettingsSnapshot = {
   idleTimeout: 10,
   toolPrefix: 'server',
@@ -80,6 +105,43 @@ export function createDefaultMcpState(): McpAppState {
     settings: { ...DEFAULT_MCP_SETTINGS },
     lastRefreshedAt: null,
     summary: { ...EMPTY_MCP_SUMMARY },
+  };
+}
+
+export function createEmptyServerEditorInput(): McpServerEditorInput {
+  return {
+    originalServerName: undefined,
+    serverName: '',
+    enabled: true,
+    transport: 'stdio',
+    lifecycle: 'lazy',
+    authMode: 'none',
+    command: '',
+    argsText: '',
+    cwd: '',
+    url: '',
+    bearerTokenEnv: '',
+    exposeResources: true,
+    debug: false,
+  };
+}
+
+export function createServerEditorInputFromSnapshot(server: McpServerSnapshot): McpServerEditorInput {
+  return {
+    ...createEmptyServerEditorInput(),
+    originalServerName: server.serverName,
+    serverName: server.serverName,
+    enabled: server.enabled,
+    transport: server.transport,
+    lifecycle: server.lifecycle,
+    authMode: server.authMode,
+    command: server.command ?? '',
+    argsText: server.argsText ?? '',
+    cwd: server.cwd ?? '',
+    url: server.url ?? '',
+    bearerTokenEnv: server.bearerTokenEnv ?? '',
+    exposeResources: server.exposeResources ?? true,
+    debug: server.debug ?? false,
   };
 }
 

--- a/plugins/sero-mcp-plugin/shared/types.ts
+++ b/plugins/sero-mcp-plugin/shared/types.ts
@@ -1,0 +1,86 @@
+export type McpToolPrefix = 'server' | 'short' | 'none';
+export type McpTransport = 'stdio' | 'http';
+export type McpLifecycle = 'lazy' | 'eager' | 'keep-alive';
+export type McpConnectionStatus = 'disabled' | 'idle' | 'connecting' | 'connected' | 'needs-auth' | 'error';
+export type McpAuthStatus = 'not-required' | 'not-authenticated' | 'authenticating' | 'authenticated' | 'expired' | 'error';
+
+export interface McpResourceSummary {
+  uri: string;
+  name: string;
+  description?: string;
+}
+
+export interface McpUiToolSummary {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+export interface McpServerSnapshot {
+  serverName: string;
+  enabled: boolean;
+  transport: McpTransport;
+  lifecycle: McpLifecycle;
+  connectionStatus: McpConnectionStatus;
+  authStatus: McpAuthStatus;
+  toolCount: number;
+  resourceCount: number;
+  uiToolCount: number;
+  lastError?: string;
+  lastConnectedAt?: string | null;
+  lastFailedAt?: string | null;
+  resources: McpResourceSummary[];
+  uiTools: McpUiToolSummary[];
+}
+
+export interface McpSummary {
+  totalServers: number;
+  enabledServers: number;
+  connectedServers: number;
+  needsAuthServers: number;
+  errorServers: number;
+}
+
+export interface McpSettingsSnapshot {
+  idleTimeout: number;
+  toolPrefix: McpToolPrefix;
+}
+
+export interface McpAppState {
+  initialized: boolean;
+  firstRun: boolean;
+  configPath: string | null;
+  rawConfigUpdatedAt: string | null;
+  servers: McpServerSnapshot[];
+  settings: McpSettingsSnapshot;
+  lastRefreshedAt: string | null;
+  summary: McpSummary;
+}
+
+export const DEFAULT_MCP_SETTINGS: McpSettingsSnapshot = {
+  idleTimeout: 10,
+  toolPrefix: 'server',
+};
+
+export const EMPTY_MCP_SUMMARY: McpSummary = {
+  totalServers: 0,
+  enabledServers: 0,
+  connectedServers: 0,
+  needsAuthServers: 0,
+  errorServers: 0,
+};
+
+export function createDefaultMcpState(): McpAppState {
+  return {
+    initialized: false,
+    firstRun: true,
+    configPath: null,
+    rawConfigUpdatedAt: null,
+    servers: [],
+    settings: { ...DEFAULT_MCP_SETTINGS },
+    lastRefreshedAt: null,
+    summary: { ...EMPTY_MCP_SUMMARY },
+  };
+}
+
+export const DEFAULT_MCP_STATE = createDefaultMcpState();

--- a/plugins/sero-mcp-plugin/shared/types.ts
+++ b/plugins/sero-mcp-plugin/shared/types.ts
@@ -15,6 +15,7 @@ export interface McpUiToolSummary {
   name: string;
   description?: string;
   inputSchema?: unknown;
+  resourceUri: string;
 }
 
 export type McpResourcePreviewKind = 'text' | 'json' | 'html' | 'image' | 'binary';

--- a/plugins/sero-mcp-plugin/shared/types.ts
+++ b/plugins/sero-mcp-plugin/shared/types.ts
@@ -82,6 +82,39 @@ export interface McpServerEditorInput {
   debug: boolean;
 }
 
+export function validateServerEditorInput(input: McpServerEditorInput): string | null {
+  const serverName = input.serverName.trim();
+  if (!serverName) {
+    return 'Server name is required.';
+  }
+
+  if (input.transport === 'stdio') {
+    if (!input.command.trim()) {
+      return 'A stdio server needs a command.';
+    }
+  } else {
+    const rawUrl = input.url.trim();
+    if (!rawUrl) {
+      return 'An HTTP/SSE server needs a URL.';
+    }
+
+    try {
+      const parsed = new URL(rawUrl);
+      if (!['http:', 'https:'].includes(parsed.protocol)) {
+        return 'HTTP/SSE server URLs must use http or https.';
+      }
+    } catch {
+      return 'Enter a valid HTTP/SSE server URL.';
+    }
+  }
+
+  if (input.authMode === 'bearer' && !input.bearerTokenEnv.trim()) {
+    return 'Bearer auth requires an environment variable name.';
+  }
+
+  return null;
+}
+
 export const DEFAULT_MCP_SETTINGS: McpSettingsSnapshot = {
   idleTimeout: 10,
   toolPrefix: 'server',

--- a/plugins/sero-mcp-plugin/shared/types.ts
+++ b/plugins/sero-mcp-plugin/shared/types.ts
@@ -17,6 +17,20 @@ export interface McpUiToolSummary {
   inputSchema?: unknown;
 }
 
+export type McpResourcePreviewKind = 'text' | 'json' | 'html' | 'image' | 'binary';
+
+export interface McpResourcePreview {
+  serverName: string;
+  requestedUri: string;
+  resolvedUri: string;
+  mimeType?: string;
+  previewKind: McpResourcePreviewKind;
+  text?: string;
+  html?: string;
+  dataUrl?: string;
+  truncated: boolean;
+}
+
 export interface McpServerSnapshot {
   serverName: string;
   enabled: boolean;

--- a/plugins/sero-mcp-plugin/ui/McpApp.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.test.tsx
@@ -54,6 +54,7 @@ describe('McpApp', () => {
     await act(async () => {
       root?.unmount();
     });
+    vi.useRealTimers();
     container.remove();
     root = null;
     useAppStateMock.mockReset();
@@ -74,6 +75,27 @@ describe('McpApp', () => {
     expect(runMock).toHaveBeenCalledWith('mcp_manager', { action: 'bootstrap' });
     expect(container.textContent).toContain('setup-wizard');
     expect(container.textContent).not.toContain('search-workbench');
+  });
+
+  it('falls back to a periodic background refresh while mounted', async () => {
+    vi.useFakeTimers();
+    useAppStateMock.mockReturnValue([createState({ firstRun: false, servers: [] }), vi.fn()]);
+
+    await act(async () => {
+      root?.render(<McpApp />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runMock).toHaveBeenNthCalledWith(1, 'mcp_manager', { action: 'bootstrap' });
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runMock).toHaveBeenNthCalledWith(2, 'mcp_manager', { action: 'refresh' });
   });
 
   it('hides the wizard and shows the search workbench once servers exist', async () => {

--- a/plugins/sero-mcp-plugin/ui/McpApp.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpAppState } from '../shared/types';
+import { createDefaultMcpState } from '../shared/types';
+import { McpApp } from './McpApp';
+
+const useAppStateMock = vi.fn();
+const useAppToolsMock = vi.fn();
+const runMock = vi.fn();
+
+vi.mock('@sero-ai/app-runtime', () => ({
+  useAppState: (initialState: McpAppState) => useAppStateMock(initialState),
+  useAppTools: () => useAppToolsMock(),
+}));
+
+vi.mock('./components/config/McpRawConfigPanel', () => ({
+  McpRawConfigPanel: () => <div>raw-config-panel</div>,
+}));
+
+vi.mock('./components/diagnostics/McpDiagnosticsPanel', () => ({
+  McpDiagnosticsPanel: () => <div>diagnostics-panel</div>,
+}));
+
+vi.mock('./components/search/McpSearchWorkbenchPanel', () => ({
+  McpSearchWorkbenchPanel: () => <div>search-workbench</div>,
+}));
+
+vi.mock('./components/servers/McpServerCrudPanel', () => ({
+  McpServerCrudPanel: () => <div>server-crud-panel</div>,
+}));
+
+vi.mock('./components/wizard/McpSetupWizard', () => ({
+  McpSetupWizard: () => <div>setup-wizard</div>,
+}));
+
+describe('McpApp', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    runMock.mockReset();
+    runMock.mockResolvedValue({ text: '', content: [], details: null, isError: false });
+    useAppToolsMock.mockReturnValue({ run: runMock });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container.remove();
+    root = null;
+    useAppStateMock.mockReset();
+    useAppToolsMock.mockReset();
+    runMock.mockReset();
+    Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
+  });
+
+  it('bootstraps on mount and shows the first-run wizard when no servers are configured', async () => {
+    useAppStateMock.mockReturnValue([createState({ firstRun: true, servers: [] }), vi.fn()]);
+
+    await act(async () => {
+      root?.render(<McpApp />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runMock).toHaveBeenCalledWith('mcp_manager', { action: 'bootstrap' });
+    expect(container.textContent).toContain('setup-wizard');
+    expect(container.textContent).not.toContain('search-workbench');
+  });
+
+  it('hides the wizard and shows the search workbench once servers exist', async () => {
+    useAppStateMock.mockReturnValue([
+      createState({
+        firstRun: false,
+        servers: [
+          {
+            serverName: 'github',
+            enabled: true,
+            transport: 'http',
+            lifecycle: 'eager',
+            authMode: 'oauth',
+            connectionStatus: 'connected',
+            authStatus: 'authenticated',
+            toolCount: 3,
+            resourceCount: 2,
+            uiToolCount: 1,
+            resources: [],
+            uiTools: [],
+          },
+        ],
+      }),
+      vi.fn(),
+    ]);
+
+    await act(async () => {
+      root?.render(<McpApp />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain('setup-wizard');
+    expect(container.textContent).toContain('search-workbench');
+  });
+});
+
+function createState(partial: Partial<McpAppState>): McpAppState {
+  return {
+    ...createDefaultMcpState(),
+    initialized: true,
+    configPath: '/tmp/sero/apps/mcp/config.json',
+    ...partial,
+  };
+}

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ComponentType } from 'react';
+import { useMemo, useState, type ComponentType } from 'react';
 import { useAppState } from '@sero-ai/app-runtime';
 import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
@@ -10,6 +10,7 @@ import type { McpAppState } from '../shared/types';
 import { createDefaultMcpState } from '../shared/types';
 import { McpRawConfigPanel } from './components/config/McpRawConfigPanel';
 import { McpDiagnosticsPanel } from './components/diagnostics/McpDiagnosticsPanel';
+import { McpSearchWorkbenchPanel } from './components/search/McpSearchWorkbenchPanel';
 import { McpServerCrudPanel } from './components/servers/McpServerCrudPanel';
 import { useMcpBootstrap } from './hooks/useMcpBootstrap';
 import { useMcpDiagnostics } from './hooks/useMcpDiagnostics';
@@ -22,6 +23,14 @@ export function McpApp() {
   const bootstrap = useMcpBootstrap();
   const diagnostics = useMcpDiagnostics();
   const rawConfig = useMcpRawConfig();
+  const [selectedServerName, setSelectedServerName] = useState<string | null>(null);
+
+  const resolvedSelectedServerName = useMemo(() => {
+    if (selectedServerName && state.servers.some((server) => server.serverName === selectedServerName)) {
+      return selectedServerName;
+    }
+    return state.servers[0]?.serverName ?? null;
+  }, [selectedServerName, state.servers]);
 
   const summaryCards = useMemo(() => {
     return [
@@ -45,7 +54,7 @@ export function McpApp() {
             <p className="max-w-3xl text-sm text-muted-foreground">
               Sero-native MCP management now supports snapshot bootstrap, connect/reconnect, eager and keep-alive
               lifecycle startup, cache-backed metadata, a dedicated viewer/auth pane for resources and OAuth,
-              and basic in-app UI-tool launching.
+              a cross-server search workbench, and basic in-app UI-tool launching.
             </p>
           </div>
 
@@ -97,7 +106,18 @@ export function McpApp() {
 
         <McpDiagnosticsPanel state={diagnostics} />
         <McpRawConfigPanel state={rawConfig} />
-        <McpServerCrudPanel servers={state.servers} />
+        {state.servers.length > 0 && (
+          <McpSearchWorkbenchPanel
+            servers={state.servers}
+            selectedServerName={resolvedSelectedServerName}
+            onSelectServer={setSelectedServerName}
+          />
+        )}
+        <McpServerCrudPanel
+          servers={state.servers}
+          selectedServerName={resolvedSelectedServerName}
+          onSelectServerName={setSelectedServerName}
+        />
 
         <section className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
           {state.firstRun ? (
@@ -105,8 +125,8 @@ export function McpApp() {
               <CardHeader>
                 <CardTitle>Start with a first MCP server</CardTitle>
                 <CardDescription>
-                  The plugin has created its config and state files. Next slices will add the full setup wizard,
-                  forms-first server creation, and in-plugin auth/resource flows.
+                  The plugin has created its config and state files. Use the Add server flow above to create the
+                  first MCP server, then use the viewer/auth pane once resources or OAuth flows are available.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3 text-sm text-muted-foreground">
@@ -118,7 +138,7 @@ export function McpApp() {
                   <strong>{state.settings.toolPrefix}</strong>.
                 </p>
                 <p>
-                  For now, you can refresh this view after editing the config file manually while the CRUD UI is under construction.
+                  You can still inspect and edit the raw config directly if you want to seed a more advanced setup before using the forms-first management flow.
                 </p>
               </CardContent>
             </Card>
@@ -162,6 +182,7 @@ export function McpApp() {
               <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths resolve through Sero-aware helpers with Pi fallback behavior." />
               <FeatureRow icon={PlugZap} title="Lifecycle bootstrap" body="Enabled eager and keep-alive servers now auto-connect on bootstrap and keep-alive servers retry in the background." />
               <FeatureRow icon={Wrench} title="Viewer pane" body="Discovered resources and UI-capable tools now open in a dedicated MCP viewer pane instead of pushing you out to a popup or external browser." />
+              <FeatureRow icon={AlertCircle} title="Search workbench" body="Search cached MCP tools and resources across servers, then jump directly into the matching server detail view." />
               <FeatureRow icon={ShieldCheck} title="Embedded OAuth auth" body="OAuth servers now launch a hardened auth browser in the same viewer pane and complete loopback callbacks without leaving the app." />
             </CardContent>
           </Card>

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -40,11 +40,12 @@ export function McpApp() {
             <div className="flex items-center gap-2">
               <PlugZap className="h-4 w-4 text-primary" />
               <h1 className="text-base font-semibold">MCP</h1>
-              <Badge variant="secondary">foundation</Badge>
+              <Badge variant="secondary">connected</Badge>
             </div>
             <p className="max-w-3xl text-sm text-muted-foreground">
-              Sero-native MCP management is now scaffolded. The plugin can bootstrap its state, maintain Sero-aware
-              config paths, and surface configured servers while deeper lifecycle, auth, and viewer features are built.
+              Sero-native MCP management now supports snapshot bootstrap, connect/reconnect, eager and keep-alive
+              lifecycle startup, and cache-backed tool/resource metadata while deeper auth and embedded viewer flows are
+              still being built.
             </p>
           </div>
 
@@ -158,8 +159,8 @@ export function McpApp() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-muted-foreground">
               <FeatureRow icon={Wrench} title="Plugin scaffold" body="Built-in plugin manifest, remote UI wiring, and extension entry point are in place." />
-              <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths now resolve through Sero-aware helpers with Pi fallback behavior." />
-              <FeatureRow icon={PlugZap} title="Bootstrap + status" body="The MCP app can bootstrap its config snapshot, and the bridged mcp tool can report basic status/list output." />
+              <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths resolve through Sero-aware helpers with Pi fallback behavior." />
+              <FeatureRow icon={PlugZap} title="Lifecycle bootstrap" body="Enabled eager and keep-alive servers now auto-connect on bootstrap and keep-alive servers retry in the background." />
             </CardContent>
           </Card>
         </section>

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -8,13 +8,16 @@ import { cn } from '@sero-ai/ui/lib/utils';
 import { AlertCircle, PlugZap, RefreshCw, Server, ShieldCheck, Wrench } from 'lucide-react';
 import type { McpAppState } from '../shared/types';
 import { createDefaultMcpState } from '../shared/types';
+import { McpRawConfigPanel } from './components/config/McpRawConfigPanel';
 import { useMcpBootstrap } from './hooks/useMcpBootstrap';
+import { useMcpRawConfig } from './hooks/useMcpRawConfig';
 import './styles.css';
 
 export function McpApp() {
   const initialState = useMemo(() => createDefaultMcpState(), []);
   const [state] = useAppState<McpAppState>(initialState);
   const bootstrap = useMcpBootstrap();
+  const rawConfig = useMcpRawConfig();
 
   const summaryCards = useMemo(() => {
     return [
@@ -41,10 +44,16 @@ export function McpApp() {
             </p>
           </div>
 
-          <Button type="button" variant="outline" size="sm" onClick={() => void bootstrap.refresh()} disabled={bootstrap.loading}>
-            <RefreshCw className={cn('mr-2 h-4 w-4', bootstrap.loading && 'animate-spin')} />
-            Refresh
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={() => void rawConfig.open()} disabled={rawConfig.loading || rawConfig.saving}>
+              <Wrench className="mr-2 h-4 w-4" />
+              Raw config
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => void bootstrap.refresh()} disabled={bootstrap.loading}>
+              <RefreshCw className={cn('mr-2 h-4 w-4', bootstrap.loading && 'animate-spin')} />
+              Refresh
+            </Button>
+          </div>
         </div>
       </header>
 
@@ -76,6 +85,8 @@ export function McpApp() {
             );
           })}
         </section>
+
+        <McpRawConfigPanel state={rawConfig} />
 
         <section className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
           {state.firstRun ? (

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -1,9 +1,9 @@
-import { useMemo, useState, type ComponentType } from 'react';
+import { useMemo, useState } from 'react';
 import { useAppState } from '@sero-ai/app-runtime';
 import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { Button } from '@sero-ai/ui/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { Card, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { AlertCircle, PlugZap, RefreshCw, Server, ShieldCheck, Wrench } from 'lucide-react';
 import type { McpAppState } from '../shared/types';
@@ -30,7 +30,7 @@ export function McpApp() {
     if (selectedServerName && state.servers.some((server) => server.serverName === selectedServerName)) {
       return selectedServerName;
     }
-    return state.servers[0]?.serverName ?? null;
+    return null;
   }, [selectedServerName, state.servers]);
 
   const summaryCards = useMemo(() => {
@@ -45,26 +45,35 @@ export function McpApp() {
   return (
     <div className="flex h-full w-full flex-col bg-background text-foreground">
       <header className="border-b border-border px-5 py-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0 space-y-2">
             <div className="flex items-center gap-2">
               <PlugZap className="h-4 w-4 text-primary" />
               <h1 className="text-base font-semibold">MCP</h1>
               <Badge variant="secondary">connected</Badge>
             </div>
-            <p className="max-w-3xl text-sm text-muted-foreground">
-              Sero-native MCP management now supports snapshot bootstrap, connect/reconnect, eager and keep-alive
-              lifecycle startup, cache-backed metadata, a dedicated viewer/auth pane for resources and OAuth,
-              a cross-server search workbench, and basic in-app UI-tool launching.
-            </p>
           </div>
 
-          <div className="flex items-center gap-2">
-            <Button type="button" variant="outline" size="sm" onClick={() => void diagnostics.open()} disabled={diagnostics.loading}>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant={diagnostics.isOpen ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => (diagnostics.isOpen ? diagnostics.close() : void diagnostics.open())}
+              disabled={diagnostics.loading}
+              aria-pressed={diagnostics.isOpen}
+            >
               <AlertCircle className="mr-2 h-4 w-4" />
               Diagnostics
             </Button>
-            <Button type="button" variant="outline" size="sm" onClick={() => void rawConfig.open()} disabled={rawConfig.loading || rawConfig.saving}>
+            <Button
+              type="button"
+              variant={rawConfig.isOpen ? 'default' : 'outline'}
+              size="sm"
+              onClick={() => (rawConfig.isOpen ? rawConfig.close() : void rawConfig.open())}
+              disabled={rawConfig.loading || rawConfig.saving}
+              aria-pressed={rawConfig.isOpen}
+            >
               <Wrench className="mr-2 h-4 w-4" />
               Raw config
             </Button>
@@ -88,11 +97,11 @@ export function McpApp() {
           </Alert>
         )}
 
-        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
           {summaryCards.map((card) => {
             const Icon = card.icon;
             return (
-              <Card key={card.label} className="animate-mcp-fade-in gap-3 py-4">
+              <Card key={card.label} className="animate-mcp-fade-in gap-3 border-border/75 py-4">
                 <CardHeader className="px-4">
                   <CardDescription className="flex items-center gap-2 text-xs uppercase tracking-wide">
                     <Icon className="h-3.5 w-3.5" />
@@ -120,108 +129,16 @@ export function McpApp() {
           onSelectServerName={setSelectedServerName}
         />
 
-        <section className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
-          {state.firstRun ? (
-            <McpSetupWizard
-              configPath={state.configPath}
-              settings={state.settings}
-              onCreated={setSelectedServerName}
-            />
-          ) : (
-            <Card className="animate-mcp-fade-in py-4">
-              <CardHeader>
-                <CardTitle>Configured servers</CardTitle>
-                <CardDescription>
-                  Snapshot-backed server inventory from the new MCP plugin state file.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {state.servers.map((server) => (
-                  <div key={server.serverName} className="rounded-lg border border-border bg-card/60 p-4">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div>
-                        <div className="font-medium">{server.serverName}</div>
-                        <div className="mt-1 text-xs text-muted-foreground">
-                          {server.transport.toUpperCase()} · {server.lifecycle} lifecycle
-                        </div>
-                      </div>
-                      <div className="flex flex-wrap items-center gap-2 text-xs">
-                        <Badge variant={server.enabled ? 'default' : 'outline'}>{server.enabled ? 'Enabled' : 'Disabled'}</Badge>
-                        <StatusBadge label={server.connectionStatus} />
-                        <StatusBadge label={server.authStatus} />
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          )}
-
-          <Card className="animate-mcp-fade-in py-4">
-            <CardHeader>
-              <CardTitle>Current foundation slice</CardTitle>
-              <CardDescription>What is implemented so far.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm text-muted-foreground">
-              <FeatureRow icon={Wrench} title="Plugin scaffold" body="Built-in plugin manifest, remote UI wiring, and extension entry point are in place." />
-              <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths resolve through Sero-aware helpers with Pi fallback behavior." />
-              <FeatureRow icon={PlugZap} title="Lifecycle bootstrap" body="Enabled eager and keep-alive servers now auto-connect on bootstrap and keep-alive servers retry in the background." />
-              <FeatureRow icon={Wrench} title="Viewer pane" body="Discovered resources and UI-capable tools now open in a dedicated MCP viewer pane instead of pushing you out to a popup or external browser." />
-              <FeatureRow icon={AlertCircle} title="Search workbench" body="Search cached MCP tools and resources across servers, then jump directly into the matching server detail view." />
-              <FeatureRow icon={ShieldCheck} title="Embedded OAuth auth" body="OAuth servers now launch a hardened auth browser in the same viewer pane and complete loopback callbacks without leaving the app." />
-            </CardContent>
-          </Card>
-        </section>
+        {state.firstRun && (
+          <McpSetupWizard
+            configPath={state.configPath}
+            settings={state.settings}
+            onCreated={setSelectedServerName}
+          />
+        )}
       </div>
     </div>
   );
-}
-
-function FeatureRow({
-  icon: Icon,
-  title,
-  body,
-}: {
-  icon: ComponentType<{ className?: string }>;
-  title: string;
-  body: string;
-}) {
-  return (
-    <div className="flex gap-3 rounded-lg border border-border/70 bg-muted/20 p-3">
-      <div className="mt-0.5 rounded-md bg-primary/10 p-2 text-primary">
-        <Icon className="h-4 w-4" />
-      </div>
-      <div>
-        <div className="text-sm font-medium text-foreground">{title}</div>
-        <p className="mt-1 text-sm text-muted-foreground">{body}</p>
-      </div>
-    </div>
-  );
-}
-
-function StatusBadge({ label }: { label: string }) {
-  return (
-    <span className={cn('rounded-full border px-2 py-0.5 font-medium', getStatusTone(label))}>
-      {label}
-    </span>
-  );
-}
-
-function getStatusTone(label: string): string {
-  switch (label) {
-    case 'connected':
-    case 'authenticated':
-      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
-    case 'not-authenticated':
-    case 'needs-auth':
-      return 'border-amber-500/30 bg-amber-500/10 text-amber-300';
-    case 'error':
-      return 'border-destructive/30 bg-destructive/10 text-destructive';
-    case 'disabled':
-      return 'border-border bg-muted text-muted-foreground';
-    default:
-      return 'border-primary/20 bg-primary/5 text-primary';
-  }
 }
 
 export default McpApp;

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -10,6 +10,7 @@ import type { McpAppState } from '../shared/types';
 import { createDefaultMcpState } from '../shared/types';
 import { McpRawConfigPanel } from './components/config/McpRawConfigPanel';
 import { McpDiagnosticsPanel } from './components/diagnostics/McpDiagnosticsPanel';
+import { McpServerCrudPanel } from './components/servers/McpServerCrudPanel';
 import { useMcpBootstrap } from './hooks/useMcpBootstrap';
 import { useMcpDiagnostics } from './hooks/useMcpDiagnostics';
 import { useMcpRawConfig } from './hooks/useMcpRawConfig';
@@ -95,6 +96,7 @@ export function McpApp() {
 
         <McpDiagnosticsPanel state={diagnostics} />
         <McpRawConfigPanel state={rawConfig} />
+        <McpServerCrudPanel servers={state.servers} />
 
         <section className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
           {state.firstRun ? (

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -44,8 +44,8 @@ export function McpApp() {
             </div>
             <p className="max-w-3xl text-sm text-muted-foreground">
               Sero-native MCP management now supports snapshot bootstrap, connect/reconnect, eager and keep-alive
-              lifecycle startup, cache-backed metadata, embedded resource previews, basic in-app UI-tool launching,
-              and in-app OAuth browser flows.
+              lifecycle startup, cache-backed metadata, a dedicated viewer/auth pane for resources and OAuth,
+              and basic in-app UI-tool launching.
             </p>
           </div>
 
@@ -161,8 +161,8 @@ export function McpApp() {
               <FeatureRow icon={Wrench} title="Plugin scaffold" body="Built-in plugin manifest, remote UI wiring, and extension entry point are in place." />
               <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths resolve through Sero-aware helpers with Pi fallback behavior." />
               <FeatureRow icon={PlugZap} title="Lifecycle bootstrap" body="Enabled eager and keep-alive servers now auto-connect on bootstrap and keep-alive servers retry in the background." />
-              <FeatureRow icon={Wrench} title="Embedded viewers" body="Discovered resources and UI-capable tools can now open directly in the MCP app's embedded viewer pane." />
-              <FeatureRow icon={ShieldCheck} title="Embedded OAuth auth" body="OAuth servers can now launch an embedded auth browser inside Sero and complete loopback callbacks without leaving the app." />
+              <FeatureRow icon={Wrench} title="Viewer pane" body="Discovered resources and UI-capable tools now open in a dedicated MCP viewer pane instead of pushing you out to a popup or external browser." />
+              <FeatureRow icon={ShieldCheck} title="Embedded OAuth auth" body="OAuth servers now launch a hardened auth browser in the same viewer pane and complete loopback callbacks without leaving the app." />
             </CardContent>
           </Card>
         </section>

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -12,6 +12,7 @@ import { McpRawConfigPanel } from './components/config/McpRawConfigPanel';
 import { McpDiagnosticsPanel } from './components/diagnostics/McpDiagnosticsPanel';
 import { McpSearchWorkbenchPanel } from './components/search/McpSearchWorkbenchPanel';
 import { McpServerCrudPanel } from './components/servers/McpServerCrudPanel';
+import { McpSetupWizard } from './components/wizard/McpSetupWizard';
 import { useMcpBootstrap } from './hooks/useMcpBootstrap';
 import { useMcpDiagnostics } from './hooks/useMcpDiagnostics';
 import { useMcpRawConfig } from './hooks/useMcpRawConfig';
@@ -121,27 +122,11 @@ export function McpApp() {
 
         <section className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
           {state.firstRun ? (
-            <Card className="animate-mcp-fade-in py-4">
-              <CardHeader>
-                <CardTitle>Start with a first MCP server</CardTitle>
-                <CardDescription>
-                  The plugin has created its config and state files. Use the Add server flow above to create the
-                  first MCP server, then use the viewer/auth pane once resources or OAuth flows are available.
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm text-muted-foreground">
-                <p>
-                  Config path: <span className="font-mono text-foreground">{state.configPath ?? 'pending bootstrap'}</span>
-                </p>
-                <p>
-                  Current defaults: idle timeout <strong>{state.settings.idleTimeout}m</strong>, tool prefix{' '}
-                  <strong>{state.settings.toolPrefix}</strong>.
-                </p>
-                <p>
-                  You can still inspect and edit the raw config directly if you want to seed a more advanced setup before using the forms-first management flow.
-                </p>
-              </CardContent>
-            </Card>
+            <McpSetupWizard
+              configPath={state.configPath}
+              settings={state.settings}
+              onCreated={setSelectedServerName}
+            />
           ) : (
             <Card className="animate-mcp-fade-in py-4">
               <CardHeader>

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -9,7 +9,9 @@ import { AlertCircle, PlugZap, RefreshCw, Server, ShieldCheck, Wrench } from 'lu
 import type { McpAppState } from '../shared/types';
 import { createDefaultMcpState } from '../shared/types';
 import { McpRawConfigPanel } from './components/config/McpRawConfigPanel';
+import { McpDiagnosticsPanel } from './components/diagnostics/McpDiagnosticsPanel';
 import { useMcpBootstrap } from './hooks/useMcpBootstrap';
+import { useMcpDiagnostics } from './hooks/useMcpDiagnostics';
 import { useMcpRawConfig } from './hooks/useMcpRawConfig';
 import './styles.css';
 
@@ -17,6 +19,7 @@ export function McpApp() {
   const initialState = useMemo(() => createDefaultMcpState(), []);
   const [state] = useAppState<McpAppState>(initialState);
   const bootstrap = useMcpBootstrap();
+  const diagnostics = useMcpDiagnostics();
   const rawConfig = useMcpRawConfig();
 
   const summaryCards = useMemo(() => {
@@ -45,6 +48,10 @@ export function McpApp() {
           </div>
 
           <div className="flex items-center gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={() => void diagnostics.open()} disabled={diagnostics.loading}>
+              <AlertCircle className="mr-2 h-4 w-4" />
+              Diagnostics
+            </Button>
             <Button type="button" variant="outline" size="sm" onClick={() => void rawConfig.open()} disabled={rawConfig.loading || rawConfig.saving}>
               <Wrench className="mr-2 h-4 w-4" />
               Raw config
@@ -86,6 +93,7 @@ export function McpApp() {
           })}
         </section>
 
+        <McpDiagnosticsPanel state={diagnostics} />
         <McpRawConfigPanel state={rawConfig} />
 
         <section className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -1,0 +1,197 @@
+import { useMemo, type ComponentType } from 'react';
+import { useAppState } from '@sero-ai/app-runtime';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, PlugZap, RefreshCw, Server, ShieldCheck, Wrench } from 'lucide-react';
+import type { McpAppState } from '../shared/types';
+import { createDefaultMcpState } from '../shared/types';
+import { useMcpBootstrap } from './hooks/useMcpBootstrap';
+import './styles.css';
+
+export function McpApp() {
+  const initialState = useMemo(() => createDefaultMcpState(), []);
+  const [state] = useAppState<McpAppState>(initialState);
+  const bootstrap = useMcpBootstrap();
+
+  const summaryCards = useMemo(() => {
+    return [
+      { label: 'Servers', value: state.summary.totalServers, icon: Server },
+      { label: 'Connected', value: state.summary.connectedServers, icon: PlugZap },
+      { label: 'Needs auth', value: state.summary.needsAuthServers, icon: ShieldCheck },
+      { label: 'Errors', value: state.summary.errorServers, icon: AlertCircle },
+    ];
+  }, [state.summary.connectedServers, state.summary.errorServers, state.summary.needsAuthServers, state.summary.totalServers]);
+
+  return (
+    <div className="flex h-full w-full flex-col bg-background text-foreground">
+      <header className="border-b border-border px-5 py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <PlugZap className="h-4 w-4 text-primary" />
+              <h1 className="text-base font-semibold">MCP</h1>
+              <Badge variant="secondary">foundation</Badge>
+            </div>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              Sero-native MCP management is now scaffolded. The plugin can bootstrap its state, maintain Sero-aware
+              config paths, and surface configured servers while deeper lifecycle, auth, and viewer features are built.
+            </p>
+          </div>
+
+          <Button type="button" variant="outline" size="sm" onClick={() => void bootstrap.refresh()} disabled={bootstrap.loading}>
+            <RefreshCw className={cn('mr-2 h-4 w-4', bootstrap.loading && 'animate-spin')} />
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      <div className="flex-1 space-y-4 overflow-auto p-5">
+        {bootstrap.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Bootstrap failed</AlertTitle>
+            <AlertDescription>
+              <p>{bootstrap.error}</p>
+              <p>The plugin could not initialize its MCP config snapshot yet. You can retry after fixing the path or permissions issue.</p>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {summaryCards.map((card) => {
+            const Icon = card.icon;
+            return (
+              <Card key={card.label} className="animate-mcp-fade-in gap-3 py-4">
+                <CardHeader className="px-4">
+                  <CardDescription className="flex items-center gap-2 text-xs uppercase tracking-wide">
+                    <Icon className="h-3.5 w-3.5" />
+                    {card.label}
+                  </CardDescription>
+                  <CardTitle className="text-3xl">{card.value}</CardTitle>
+                </CardHeader>
+              </Card>
+            );
+          })}
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
+          {state.firstRun ? (
+            <Card className="animate-mcp-fade-in py-4">
+              <CardHeader>
+                <CardTitle>Start with a first MCP server</CardTitle>
+                <CardDescription>
+                  The plugin has created its config and state files. Next slices will add the full setup wizard,
+                  forms-first server creation, and in-plugin auth/resource flows.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
+                <p>
+                  Config path: <span className="font-mono text-foreground">{state.configPath ?? 'pending bootstrap'}</span>
+                </p>
+                <p>
+                  Current defaults: idle timeout <strong>{state.settings.idleTimeout}m</strong>, tool prefix{' '}
+                  <strong>{state.settings.toolPrefix}</strong>.
+                </p>
+                <p>
+                  For now, you can refresh this view after editing the config file manually while the CRUD UI is under construction.
+                </p>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card className="animate-mcp-fade-in py-4">
+              <CardHeader>
+                <CardTitle>Configured servers</CardTitle>
+                <CardDescription>
+                  Snapshot-backed server inventory from the new MCP plugin state file.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {state.servers.map((server) => (
+                  <div key={server.serverName} className="rounded-lg border border-border bg-card/60 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <div className="font-medium">{server.serverName}</div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {server.transport.toUpperCase()} · {server.lifecycle} lifecycle
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-2 text-xs">
+                        <Badge variant={server.enabled ? 'default' : 'outline'}>{server.enabled ? 'Enabled' : 'Disabled'}</Badge>
+                        <StatusBadge label={server.connectionStatus} />
+                        <StatusBadge label={server.authStatus} />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+          <Card className="animate-mcp-fade-in py-4">
+            <CardHeader>
+              <CardTitle>Current foundation slice</CardTitle>
+              <CardDescription>What is implemented so far.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <FeatureRow icon={Wrench} title="Plugin scaffold" body="Built-in plugin manifest, remote UI wiring, and extension entry point are in place." />
+              <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths now resolve through Sero-aware helpers with Pi fallback behavior." />
+              <FeatureRow icon={PlugZap} title="Bootstrap + status" body="The MCP app can bootstrap its config snapshot, and the bridged mcp tool can report basic status/list output." />
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function FeatureRow({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: ComponentType<{ className?: string }>;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="flex gap-3 rounded-lg border border-border/70 bg-muted/20 p-3">
+      <div className="mt-0.5 rounded-md bg-primary/10 p-2 text-primary">
+        <Icon className="h-4 w-4" />
+      </div>
+      <div>
+        <div className="text-sm font-medium text-foreground">{title}</div>
+        <p className="mt-1 text-sm text-muted-foreground">{body}</p>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ label }: { label: string }) {
+  return (
+    <span className={cn('rounded-full border px-2 py-0.5 font-medium', getStatusTone(label))}>
+      {label}
+    </span>
+  );
+}
+
+function getStatusTone(label: string): string {
+  switch (label) {
+    case 'connected':
+    case 'authenticated':
+      return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300';
+    case 'not-authenticated':
+    case 'needs-auth':
+      return 'border-amber-500/30 bg-amber-500/10 text-amber-300';
+    case 'error':
+      return 'border-destructive/30 bg-destructive/10 text-destructive';
+    case 'disabled':
+      return 'border-border bg-muted text-muted-foreground';
+    default:
+      return 'border-primary/20 bg-primary/5 text-primary';
+  }
+}
+
+export default McpApp;

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -44,7 +44,8 @@ export function McpApp() {
             </div>
             <p className="max-w-3xl text-sm text-muted-foreground">
               Sero-native MCP management now supports snapshot bootstrap, connect/reconnect, eager and keep-alive
-              lifecycle startup, cache-backed metadata, embedded resource previews, and in-app OAuth browser flows.
+              lifecycle startup, cache-backed metadata, embedded resource previews, basic in-app UI-tool launching,
+              and in-app OAuth browser flows.
             </p>
           </div>
 
@@ -160,6 +161,7 @@ export function McpApp() {
               <FeatureRow icon={Wrench} title="Plugin scaffold" body="Built-in plugin manifest, remote UI wiring, and extension entry point are in place." />
               <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths resolve through Sero-aware helpers with Pi fallback behavior." />
               <FeatureRow icon={PlugZap} title="Lifecycle bootstrap" body="Enabled eager and keep-alive servers now auto-connect on bootstrap and keep-alive servers retry in the background." />
+              <FeatureRow icon={Wrench} title="Embedded viewers" body="Discovered resources and UI-capable tools can now open directly in the MCP app's embedded viewer pane." />
               <FeatureRow icon={ShieldCheck} title="Embedded OAuth auth" body="OAuth servers can now launch an embedded auth browser inside Sero and complete loopback callbacks without leaving the app." />
             </CardContent>
           </Card>

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -44,8 +44,7 @@ export function McpApp() {
             </div>
             <p className="max-w-3xl text-sm text-muted-foreground">
               Sero-native MCP management now supports snapshot bootstrap, connect/reconnect, eager and keep-alive
-              lifecycle startup, and cache-backed tool/resource metadata while deeper auth and embedded viewer flows are
-              still being built.
+              lifecycle startup, cache-backed metadata, embedded resource previews, and in-app OAuth browser flows.
             </p>
           </div>
 
@@ -161,6 +160,7 @@ export function McpApp() {
               <FeatureRow icon={Wrench} title="Plugin scaffold" body="Built-in plugin manifest, remote UI wiring, and extension entry point are in place." />
               <FeatureRow icon={Server} title="Sero-aware storage" body="State, config, metadata cache, and OAuth token paths resolve through Sero-aware helpers with Pi fallback behavior." />
               <FeatureRow icon={PlugZap} title="Lifecycle bootstrap" body="Enabled eager and keep-alive servers now auto-connect on bootstrap and keep-alive servers retry in the background." />
+              <FeatureRow icon={ShieldCheck} title="Embedded OAuth auth" body="OAuth servers can now launch an embedded auth browser inside Sero and complete loopback callbacks without leaving the app." />
             </CardContent>
           </Card>
         </section>

--- a/plugins/sero-mcp-plugin/ui/components/config/McpRawConfigPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/config/McpRawConfigPanel.tsx
@@ -1,0 +1,57 @@
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
+import { AlertCircle, FileJson, Save, X } from 'lucide-react';
+import type { McpRawConfigState } from '../../hooks/useMcpRawConfig';
+
+export function McpRawConfigPanel({ state }: { state: McpRawConfigState }) {
+  if (!state.isOpen) return null;
+
+  return (
+    <Card className="animate-mcp-fade-in py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <FileJson className="h-4 w-4 text-primary" />
+              Raw MCP config
+            </CardTitle>
+            <CardDescription>
+              Advanced editor for MCP config JSON. Unknown keys are preserved, and saving refreshes the shared MCP snapshot.
+            </CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={state.close}>
+              <X className="mr-2 h-4 w-4" />
+              Close
+            </Button>
+            <Button type="button" size="sm" onClick={() => void state.save()} disabled={state.loading || state.saving}>
+              <Save className="mr-2 h-4 w-4" />
+              {state.saving ? 'Saving…' : 'Save config'}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {state.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Config error</AlertTitle>
+            <AlertDescription>{state.error}</AlertDescription>
+          </Alert>
+        )}
+
+        <Textarea
+          value={state.rawConfig}
+          onChange={(event) => state.setRawConfig(event.target.value)}
+          spellCheck={false}
+          className="min-h-[24rem] font-mono text-xs"
+          placeholder={state.loading ? 'Loading MCP config…' : '{\n  "settings": {},\n  "mcpServers": {}\n}'}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default McpRawConfigPanel;

--- a/plugins/sero-mcp-plugin/ui/components/config/McpRawConfigPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/config/McpRawConfigPanel.tsx
@@ -9,7 +9,7 @@ export function McpRawConfigPanel({ state }: { state: McpRawConfigState }) {
   if (!state.isOpen) return null;
 
   return (
-    <Card className="animate-mcp-fade-in py-4">
+    <Card className="animate-mcp-fade-in border-border/75 py-4">
       <CardHeader>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>

--- a/plugins/sero-mcp-plugin/ui/components/diagnostics/McpDiagnosticsPanel.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/diagnostics/McpDiagnosticsPanel.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { McpDiagnosticsPanel } from './McpDiagnosticsPanel';
+
+const promptAgentMock = vi.fn();
+
+vi.mock('@sero-ai/app-runtime', () => ({
+  useAgentPrompt: () => promptAgentMock,
+}));
+
+describe('McpDiagnosticsPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    promptAgentMock.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container.remove();
+    root = null;
+    promptAgentMock.mockReset();
+    Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
+  });
+
+  it('stays hidden until diagnostics are opened', async () => {
+    await act(async () => {
+      root?.render(
+        <McpDiagnosticsPanel
+          state={{
+            loading: false,
+            error: null,
+            isOpen: false,
+            diagnostics: '',
+            open: vi.fn(async () => undefined),
+            close: vi.fn(),
+            refresh: vi.fn(async () => undefined),
+          }}
+        />,
+      );
+    });
+
+    expect(container.textContent).toBe('');
+  });
+
+  it('sends the current diagnostics to Ask Sero', async () => {
+    await act(async () => {
+      root?.render(
+        <McpDiagnosticsPanel
+          state={{
+            loading: false,
+            error: null,
+            isOpen: true,
+            diagnostics: 'server github failed to authenticate',
+            open: vi.fn(async () => undefined),
+            close: vi.fn(),
+            refresh: vi.fn(async () => undefined),
+          }}
+        />,
+      );
+    });
+
+    await act(async () => {
+      clickButton(container, 'Ask Sero to help');
+    });
+
+    expect(promptAgentMock).toHaveBeenCalledWith(expect.stringContaining('server github failed to authenticate'));
+  });
+});
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes(label));
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`);
+  }
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}

--- a/plugins/sero-mcp-plugin/ui/components/diagnostics/McpDiagnosticsPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/diagnostics/McpDiagnosticsPanel.tsx
@@ -13,7 +13,7 @@ export function McpDiagnosticsPanel({ state }: { state: McpDiagnosticsState }) {
   if (!state.isOpen) return null;
 
   return (
-    <Card className="animate-mcp-fade-in py-4">
+    <Card className="animate-mcp-fade-in border-border/75 py-4">
       <CardHeader>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>

--- a/plugins/sero-mcp-plugin/ui/components/diagnostics/McpDiagnosticsPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/diagnostics/McpDiagnosticsPanel.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { useAgentPrompt } from '@sero-ai/app-runtime';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { AlertCircle, LifeBuoy, RefreshCw, Stethoscope, X } from 'lucide-react';
+import type { McpDiagnosticsState } from '../../hooks/useMcpDiagnostics';
+
+export function McpDiagnosticsPanel({ state }: { state: McpDiagnosticsState }) {
+  const promptAgent = useAgentPrompt();
+  const helpPrompt = useMemo(() => buildMcpHelpPrompt(state.diagnostics), [state.diagnostics]);
+
+  if (!state.isOpen) return null;
+
+  return (
+    <Card className="animate-mcp-fade-in py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Stethoscope className="h-4 w-4 text-primary" />
+              Diagnostics
+            </CardTitle>
+            <CardDescription>
+              Friendly UI by default, technical detail on demand. Use this when a server is misconfigured or auth/viewer behavior looks wrong.
+            </CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={state.close}>
+              <X className="mr-2 h-4 w-4" />
+              Close
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => void state.refresh()} disabled={state.loading}>
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Refresh
+            </Button>
+            <Button type="button" size="sm" onClick={() => promptAgent(helpPrompt)} disabled={!state.diagnostics}>
+              <LifeBuoy className="mr-2 h-4 w-4" />
+              Ask Sero to help
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {state.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Diagnostics load error</AlertTitle>
+            <AlertDescription>{state.error}</AlertDescription>
+          </Alert>
+        )}
+
+        <pre className="overflow-x-auto rounded-lg border border-border bg-muted/20 p-4 text-xs leading-6 text-muted-foreground">
+          {state.loading ? 'Loading diagnostics…' : state.diagnostics || 'No diagnostics available yet.'}
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}
+
+function buildMcpHelpPrompt(diagnostics: string): string {
+  return [
+    'Help me troubleshoot the MCP plugin in Sero.',
+    'Focus on the current MCP diagnostics below and suggest the most likely issue plus next steps.',
+    '',
+    diagnostics || 'No diagnostics were available.',
+  ].join('\n');
+}
+
+export default McpDiagnosticsPanel;

--- a/plugins/sero-mcp-plugin/ui/components/search/McpSearchWorkbenchPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/search/McpSearchWorkbenchPanel.tsx
@@ -1,0 +1,185 @@
+import { useAgentPrompt } from '@sero-ai/app-runtime';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { NativeSelect, NativeSelectOption } from '@sero-ai/ui/components/ui/native-select';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, LifeBuoy, Search, Server } from 'lucide-react';
+import type { McpServerSnapshot } from '../../../shared/types';
+import { useMcpSearchWorkbench } from '../../hooks/useMcpSearchWorkbench';
+
+export function McpSearchWorkbenchPanel({
+  servers,
+  selectedServerName,
+  onSelectServer,
+}: {
+  servers: McpServerSnapshot[];
+  selectedServerName: string | null;
+  onSelectServer: (serverName: string) => void;
+}) {
+  const promptAgent = useAgentPrompt();
+  const search = useMcpSearchWorkbench();
+
+  return (
+    <Card className="animate-mcp-fade-in py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Search className="h-4 w-4 text-primary" />
+              Search workbench
+            </CardTitle>
+            <CardDescription>
+              Cross-server MCP-only discovery for cached tools and resources. Search here, then jump straight into the matching server detail view for execution, preview, or auth recovery.
+            </CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" size="sm" onClick={search.clear} disabled={search.loading}>
+              Clear
+            </Button>
+            <Button type="button" size="sm" onClick={() => void search.search()} disabled={search.loading}>
+              <Search className="mr-2 h-4 w-4" />
+              {search.loading ? 'Searching…' : 'Search MCP'}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {search.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>MCP search failed</AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>{search.error}</p>
+              <Button type="button" size="sm" onClick={() => promptAgent(buildSearchHelpPrompt(search.query, search.error ?? 'Unknown MCP search error.', search.serverFilter))}>
+                <LifeBuoy className="mr-2 h-4 w-4" />
+                Ask Sero to help
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <form
+          className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_220px_auto]"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void search.search();
+          }}
+        >
+          <div className="space-y-2">
+            <Label htmlFor="mcp-search-query">Search query</Label>
+            <Input
+              id="mcp-search-query"
+              value={search.query}
+              onChange={(event) => search.setQuery(event.target.value)}
+              placeholder="github oauth docs"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="mcp-search-server-filter">Server scope</Label>
+            <NativeSelect
+              id="mcp-search-server-filter"
+              value={search.serverFilter}
+              onChange={(event) => search.setServerFilter(event.target.value)}
+              className="w-full"
+            >
+              <NativeSelectOption value="all">All servers</NativeSelectOption>
+              {servers.map((server) => (
+                <NativeSelectOption key={server.serverName} value={server.serverName}>
+                  {server.serverName}
+                </NativeSelectOption>
+              ))}
+            </NativeSelect>
+          </div>
+          <div className="flex items-end">
+            <Button type="submit" className="w-full lg:w-auto" disabled={search.loading}>
+              <Search className="mr-2 h-4 w-4" />
+              {search.loading ? 'Searching…' : 'Run search'}
+            </Button>
+          </div>
+        </form>
+
+        {!search.lastQuery ? (
+          <EmptyState body="Search the cached MCP inventory to find tools or resources across servers, then jump into the right server detail view." />
+        ) : search.results.length === 0 ? (
+          <EmptyState body={search.summaryText ?? `No MCP tools or resources matched "${search.lastQuery}".`} />
+        ) : (
+          <div className="space-y-3">
+            {search.summaryText && <p className="text-sm text-muted-foreground">{search.summaryText}</p>}
+            {search.results.map((match) => {
+              const isSelectedServer = selectedServerName === match.serverName;
+              return (
+                <div key={`${match.kind}:${match.serverName}:${match.uri ?? match.name}`} className="rounded-lg border border-border bg-card/60 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2 text-xs">
+                        <ToneBadge label={match.kind} tone={match.kind === 'tool' ? 'default' : 'muted'} />
+                        <ToneBadge label={match.serverName} tone="muted" />
+                        {match.uiResourceUri && <ToneBadge label="ui capable" tone="warning" />}
+                      </div>
+                      <div>
+                        <div className="font-medium text-foreground">{match.name}</div>
+                        {match.kind === 'resource' && match.uri && <div className="break-all text-xs text-muted-foreground">{match.uri}</div>}
+                        {match.kind === 'tool' && match.uiResourceUri && <div className="break-all text-xs text-muted-foreground">UI resource: {match.uiResourceUri}</div>}
+                      </div>
+                      {match.description && <p className="text-sm text-muted-foreground">{match.description}</p>}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant={isSelectedServer ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => onSelectServer(match.serverName)}
+                      >
+                        <Server className="mr-2 h-4 w-4" />
+                        {isSelectedServer ? 'Viewing server' : 'Open server'}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function EmptyState({ body }: { body: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-background/40 p-4 text-sm text-muted-foreground">
+      {body}
+    </div>
+  );
+}
+
+function ToneBadge({ label, tone }: { label: string; tone: 'default' | 'warning' | 'muted' }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        tone === 'default' && 'border-primary/20 bg-primary/5 text-primary',
+        tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+        tone === 'muted' && 'border-border bg-background text-muted-foreground',
+      )}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function buildSearchHelpPrompt(query: string, error: string, serverFilter: string): string {
+  return [
+    'Help me troubleshoot MCP search in Sero.',
+    `Query: ${query || '(empty)'}`,
+    `Server filter: ${serverFilter}`,
+    '',
+    error,
+  ].join('\n');
+}
+
+export default McpSearchWorkbenchPanel;

--- a/plugins/sero-mcp-plugin/ui/components/search/McpSearchWorkbenchPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/search/McpSearchWorkbenchPanel.tsx
@@ -24,7 +24,7 @@ export function McpSearchWorkbenchPanel({
   const search = useMcpSearchWorkbench();
 
   return (
-    <Card className="animate-mcp-fade-in py-4">
+    <Card className="animate-mcp-fade-in border-border/75 py-4">
       <CardHeader>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerAuthPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerAuthPanel.tsx
@@ -60,6 +60,10 @@ export function McpServerAuthPanel({ server }: { server: McpServerSnapshot }) {
               Cancel auth
             </Button>
           )}
+          <Button type="button" variant="outline" size="sm" disabled={authFlow.loading} onClick={() => void authFlow.clearAuth(server.serverName)}>
+            <X className="mr-2 h-4 w-4" />
+            Clear saved auth
+          </Button>
           <Button type="button" variant="outline" size="sm" disabled={!authFlow.error} onClick={() => promptAgent(helpPrompt)}>
             <LifeBuoy className="mr-2 h-4 w-4" />
             Ask Sero to help

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerAuthPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerAuthPanel.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react';
 import { useAgentPrompt } from '@sero-ai/app-runtime';
 import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
@@ -7,23 +6,21 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero
 import { cn } from '@sero-ai/ui/lib/utils';
 import { AlertCircle, LifeBuoy, LoaderCircle, ShieldCheck, X } from 'lucide-react';
 import type { McpServerSnapshot } from '../../../shared/types';
-import { useMcpAuthFlow } from '../../hooks/useMcpAuthFlow';
-import { McpAuthBrowser } from '../viewer/McpAuthBrowser';
+import type { McpViewerState } from '../../hooks/useMcpViewer';
 
-export function McpServerAuthPanel({ server }: { server: McpServerSnapshot }) {
+export function McpServerAuthPanel({
+  server,
+  viewer,
+}: {
+  server: McpServerSnapshot;
+  viewer: McpViewerState;
+}) {
   const promptAgent = useAgentPrompt();
-  const authFlow = useMcpAuthFlow();
   const isOAuth = server.authMode === 'oauth';
-  const activeSession = authFlow.session?.serverName === server.serverName ? authFlow.session : null;
-  const allowedOrigins = useMemo(() => {
-    if (!activeSession?.authUrl) return [];
-    try {
-      return [new URL(activeSession.authUrl).origin];
-    } catch {
-      return [];
-    }
-  }, [activeSession?.authUrl]);
-  const helpPrompt = buildAuthHelpPrompt(server, authFlow.error, activeSession?.authUrl ?? null);
+  const activeSession = viewer.authSession?.serverName === server.serverName ? viewer.authSession : null;
+  const authPaneActive = viewer.pane?.kind === 'auth' && viewer.pane.serverName === server.serverName;
+  const authError = viewer.pane?.serverName === server.serverName || activeSession ? viewer.authError : null;
+  const helpPrompt = buildAuthHelpPrompt(server, authError, activeSession?.authUrl ?? null, authPaneActive);
 
   if (!isOAuth) {
     return null;
@@ -39,7 +36,7 @@ export function McpServerAuthPanel({ server }: { server: McpServerSnapshot }) {
               OAuth authentication
             </CardTitle>
             <CardDescription>
-              Authenticate this MCP server entirely inside Sero. The browser rail is hardened and only allows the active auth origin plus the loopback callback.
+              Authenticate this MCP server entirely inside Sero. The active sign-in flow opens in the dedicated viewer pane instead of a popup or external browser.
             </CardDescription>
           </div>
           <div className="flex flex-wrap gap-2 text-xs">
@@ -50,52 +47,51 @@ export function McpServerAuthPanel({ server }: { server: McpServerSnapshot }) {
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex flex-wrap gap-2">
-          <Button type="button" size="sm" disabled={authFlow.loading} onClick={() => void authFlow.startAuth(server.serverName)}>
-            {authFlow.loading ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
+          <Button type="button" size="sm" disabled={viewer.authLoading} onClick={() => void viewer.startAuth(server.serverName)}>
+            {viewer.authLoading ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
             {server.authStatus === 'authenticated' ? 'Re-authenticate' : 'Authenticate'}
           </Button>
+          {activeSession && !authPaneActive && (
+            <Button type="button" variant="outline" size="sm" disabled={viewer.authLoading} onClick={viewer.focusAuthSession}>
+              <ShieldCheck className="mr-2 h-4 w-4" />
+              Show auth browser
+            </Button>
+          )}
           {activeSession && (
-            <Button type="button" variant="outline" size="sm" disabled={authFlow.loading} onClick={() => void authFlow.cancelAuth(server.serverName)}>
+            <Button type="button" variant="outline" size="sm" disabled={viewer.authLoading} onClick={() => void viewer.cancelAuth(server.serverName)}>
               <X className="mr-2 h-4 w-4" />
               Cancel auth
             </Button>
           )}
-          <Button type="button" variant="outline" size="sm" disabled={authFlow.loading} onClick={() => void authFlow.clearAuth(server.serverName)}>
+          <Button type="button" variant="outline" size="sm" disabled={viewer.authLoading} onClick={() => void viewer.clearAuth(server.serverName)}>
             <X className="mr-2 h-4 w-4" />
             Clear saved auth
           </Button>
-          <Button type="button" variant="outline" size="sm" disabled={!authFlow.error} onClick={() => promptAgent(helpPrompt)}>
+          <Button type="button" variant="outline" size="sm" disabled={!authError} onClick={() => promptAgent(helpPrompt)}>
             <LifeBuoy className="mr-2 h-4 w-4" />
             Ask Sero to help
           </Button>
         </div>
 
-        {authFlow.error && (
+        {authError && (
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
             <AlertTitle>OAuth flow error</AlertTitle>
-            <AlertDescription>{authFlow.error}</AlertDescription>
+            <AlertDescription>{authError}</AlertDescription>
           </Alert>
         )}
 
-        <div className={cn(activeSession ? 'block' : 'hidden')}>
-          <McpAuthBrowser
-            src={activeSession?.authUrl ?? null}
-            allowedOrigins={allowedOrigins}
-            className="h-[460px]"
-            onBlockedNavigation={(url) => authFlow.setError(`Blocked auth navigation to ${url}`)}
-            onLoadError={(message) => authFlow.setError(message)}
-            onCallbackUrl={(callbackUrl) => {
-              void authFlow.completeAuth(server.serverName, callbackUrl);
-            }}
-          />
-        </div>
-
-        {!activeSession && !authFlow.error && server.authStatus !== 'authenticated' && (
-          <div className="rounded-lg border border-dashed border-border bg-background/40 p-4 text-sm text-muted-foreground">
-            Start authentication to open the provider sign-in flow in an embedded browser. When the provider redirects back to the loopback callback, Sero will complete the exchange automatically.
+        {activeSession ? (
+          <div className="rounded-lg border border-border bg-background/60 p-4 text-sm text-muted-foreground">
+            {authPaneActive
+              ? 'The provider sign-in flow is open in the viewer pane. Complete it there and Sero will finish the loopback callback automatically.'
+              : 'An authentication session is active for this server. Open the auth browser in the viewer pane to continue the sign-in flow.'}
           </div>
-        )}
+        ) : !authError && server.authStatus !== 'authenticated' ? (
+          <div className="rounded-lg border border-dashed border-border bg-background/40 p-4 text-sm text-muted-foreground">
+            Start authentication to open the provider sign-in flow in the viewer pane. When the provider redirects back to the loopback callback, Sero will complete the exchange automatically.
+          </div>
+        ) : null}
       </CardContent>
     </Card>
   );
@@ -117,12 +113,18 @@ function StatusBadge({ label, tone }: { label: string; tone: 'default' | 'succes
   );
 }
 
-function buildAuthHelpPrompt(server: McpServerSnapshot, error: string | null, authUrl: string | null): string {
+function buildAuthHelpPrompt(
+  server: McpServerSnapshot,
+  error: string | null,
+  authUrl: string | null,
+  authPaneActive: boolean,
+): string {
   return [
     `Help me troubleshoot OAuth authentication for MCP server "${server.serverName}" in Sero.`,
     `Connection status: ${server.connectionStatus}`,
     `Auth status: ${server.authStatus}`,
     authUrl ? `Current auth URL origin: ${safeOrigin(authUrl)}` : 'No auth browser is currently open.',
+    authPaneActive ? 'The auth browser is already open in the viewer pane.' : 'The auth browser is not currently focused in the viewer pane.',
     '',
     error ?? 'Explain the most likely next checks and recovery steps.',
   ].join('\n');

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerAuthPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerAuthPanel.tsx
@@ -1,0 +1,135 @@
+import { useMemo } from 'react';
+import { useAgentPrompt } from '@sero-ai/app-runtime';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, LifeBuoy, LoaderCircle, ShieldCheck, X } from 'lucide-react';
+import type { McpServerSnapshot } from '../../../shared/types';
+import { useMcpAuthFlow } from '../../hooks/useMcpAuthFlow';
+import { McpAuthBrowser } from '../viewer/McpAuthBrowser';
+
+export function McpServerAuthPanel({ server }: { server: McpServerSnapshot }) {
+  const promptAgent = useAgentPrompt();
+  const authFlow = useMcpAuthFlow();
+  const isOAuth = server.authMode === 'oauth';
+  const activeSession = authFlow.session?.serverName === server.serverName ? authFlow.session : null;
+  const allowedOrigins = useMemo(() => {
+    if (!activeSession?.authUrl) return [];
+    try {
+      return [new URL(activeSession.authUrl).origin];
+    } catch {
+      return [];
+    }
+  }, [activeSession?.authUrl]);
+  const helpPrompt = buildAuthHelpPrompt(server, authFlow.error, activeSession?.authUrl ?? null);
+
+  if (!isOAuth) {
+    return null;
+  }
+
+  return (
+    <Card className="border-border/70 bg-muted/15 py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <ShieldCheck className="h-4 w-4 text-primary" />
+              OAuth authentication
+            </CardTitle>
+            <CardDescription>
+              Authenticate this MCP server entirely inside Sero. The browser rail is hardened and only allows the active auth origin plus the loopback callback.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <StatusBadge label={server.authStatus} tone={server.authStatus === 'authenticated' ? 'success' : server.authStatus === 'authenticating' ? 'default' : 'warning'} />
+            <StatusBadge label={server.connectionStatus} tone={server.connectionStatus === 'connected' ? 'success' : server.connectionStatus === 'needs-auth' ? 'warning' : 'muted'} />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" size="sm" disabled={authFlow.loading} onClick={() => void authFlow.startAuth(server.serverName)}>
+            {authFlow.loading ? <LoaderCircle className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
+            {server.authStatus === 'authenticated' ? 'Re-authenticate' : 'Authenticate'}
+          </Button>
+          {activeSession && (
+            <Button type="button" variant="outline" size="sm" disabled={authFlow.loading} onClick={() => void authFlow.cancelAuth(server.serverName)}>
+              <X className="mr-2 h-4 w-4" />
+              Cancel auth
+            </Button>
+          )}
+          <Button type="button" variant="outline" size="sm" disabled={!authFlow.error} onClick={() => promptAgent(helpPrompt)}>
+            <LifeBuoy className="mr-2 h-4 w-4" />
+            Ask Sero to help
+          </Button>
+        </div>
+
+        {authFlow.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>OAuth flow error</AlertTitle>
+            <AlertDescription>{authFlow.error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className={cn(activeSession ? 'block' : 'hidden')}>
+          <McpAuthBrowser
+            src={activeSession?.authUrl ?? null}
+            allowedOrigins={allowedOrigins}
+            className="h-[460px]"
+            onBlockedNavigation={(url) => authFlow.setError(`Blocked auth navigation to ${url}`)}
+            onLoadError={(message) => authFlow.setError(message)}
+            onCallbackUrl={(callbackUrl) => {
+              void authFlow.completeAuth(server.serverName, callbackUrl);
+            }}
+          />
+        </div>
+
+        {!activeSession && !authFlow.error && server.authStatus !== 'authenticated' && (
+          <div className="rounded-lg border border-dashed border-border bg-background/40 p-4 text-sm text-muted-foreground">
+            Start authentication to open the provider sign-in flow in an embedded browser. When the provider redirects back to the loopback callback, Sero will complete the exchange automatically.
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatusBadge({ label, tone }: { label: string; tone: 'default' | 'success' | 'warning' | 'muted' }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        tone === 'default' && 'border-primary/20 bg-primary/5 text-primary',
+        tone === 'success' && 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+        tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+        tone === 'muted' && 'border-border bg-background text-muted-foreground',
+      )}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function buildAuthHelpPrompt(server: McpServerSnapshot, error: string | null, authUrl: string | null): string {
+  return [
+    `Help me troubleshoot OAuth authentication for MCP server "${server.serverName}" in Sero.`,
+    `Connection status: ${server.connectionStatus}`,
+    `Auth status: ${server.authStatus}`,
+    authUrl ? `Current auth URL origin: ${safeOrigin(authUrl)}` : 'No auth browser is currently open.',
+    '',
+    error ?? 'Explain the most likely next checks and recovery steps.',
+  ].join('\n');
+}
+
+function safeOrigin(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return value;
+  }
+}
+
+export default McpServerAuthPanel;

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
@@ -159,6 +159,7 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
           ) : (
             sortedServers.map((server) => {
               const toggleAction = `${server.enabled ? 'disable' : 'enable'}:${server.serverName}`;
+              const connectAction = `${server.connectionStatus === 'connected' ? 'reconnect' : 'connect'}:${server.serverName}`;
               const removeAction = `remove:${server.serverName}`;
               return (
                 <div key={server.serverName} className="rounded-lg border border-border bg-card/60 p-4">
@@ -178,6 +179,16 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
                       <Button type="button" variant="outline" size="sm" onClick={() => setDraft(createServerEditorInputFromSnapshot(server))}>
                         <Pencil className="mr-2 h-4 w-4" />
                         Edit
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={!server.enabled || mutations.pendingAction === connectAction}
+                        onClick={() => void mutations.connectServer(server.serverName, server.connectionStatus === 'connected')}
+                      >
+                        <Server className="mr-2 h-4 w-4" />
+                        {server.connectionStatus === 'connected' ? 'Reconnect' : 'Connect'}
                       </Button>
                       <Button type="button" variant="outline" size="sm" disabled={mutations.pendingAction === toggleAction} onClick={() => void mutations.toggleServer(server.serverName, !server.enabled)}>
                         <Power className="mr-2 h-4 w-4" />

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
@@ -9,7 +9,11 @@ import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { AlertCircle, Pencil, Plus, Power, Save, Server, Trash2, X } from 'lucide-react';
 import type { McpServerEditorInput, McpServerSnapshot } from '../../../shared/types';
-import { createEmptyServerEditorInput, createServerEditorInputFromSnapshot } from '../../../shared/types';
+import {
+  createEmptyServerEditorInput,
+  createServerEditorInputFromSnapshot,
+  validateServerEditorInput,
+} from '../../../shared/types';
 import { useMcpServerMutations } from '../../hooks/useMcpServerMutations';
 
 export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }) {
@@ -17,7 +21,7 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
   const [draft, setDraft] = useState<McpServerEditorInput | null>(null);
 
   const sortedServers = useMemo(() => [...servers].sort((a, b) => a.serverName.localeCompare(b.serverName)), [servers]);
-
+  const validationError = useMemo(() => (draft ? validateServerEditorInput(draft) : null), [draft]);
   const title = draft?.originalServerName ? `Edit ${draft.originalServerName}` : 'Add MCP server';
 
   return (
@@ -40,11 +44,11 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        {mutations.error && (
+        {(mutations.error || validationError) && (
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Server update failed</AlertTitle>
-            <AlertDescription>{mutations.error}</AlertDescription>
+            <AlertTitle>Server update blocked</AlertTitle>
+            <AlertDescription>{validationError ?? mutations.error}</AlertDescription>
           </Alert>
         )}
 
@@ -65,7 +69,7 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
                 <Button
                   type="button"
                   size="sm"
-                  disabled={mutations.pendingAction === 'save'}
+                  disabled={mutations.pendingAction === 'save' || !!validationError}
                   onClick={async () => {
                     const ok = await mutations.upsertServer(draft);
                     if (ok) {

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
@@ -7,7 +7,7 @@ import { Input } from '@sero-ai/ui/components/ui/input';
 import { NativeSelect, NativeSelectOption } from '@sero-ai/ui/components/ui/native-select';
 import { Textarea } from '@sero-ai/ui/components/ui/textarea';
 import { cn } from '@sero-ai/ui/lib/utils';
-import { AlertCircle, Pencil, Plus, Power, Save, Server, Trash2, X } from 'lucide-react';
+import { AlertCircle, ChevronDown, ChevronUp, Pencil, Plus, Power, Save, Server, Trash2, X } from 'lucide-react';
 import type { McpServerEditorInput, McpServerSnapshot } from '../../../shared/types';
 import {
   createEmptyServerEditorInput,
@@ -24,7 +24,7 @@ export function McpServerCrudPanel({
 }: {
   servers: McpServerSnapshot[];
   selectedServerName?: string | null;
-  onSelectServerName?: (serverName: string) => void;
+  onSelectServerName?: (serverName: string | null) => void;
 }) {
   const mutations = useMcpServerMutations();
   const [draft, setDraft] = useState<McpServerEditorInput | null>(null);
@@ -33,15 +33,11 @@ export function McpServerCrudPanel({
   const sortedServers = useMemo(() => [...servers].sort((a, b) => a.serverName.localeCompare(b.serverName)), [servers]);
   const selectedServerName = controlledSelectedServerName ?? uncontrolledSelectedServerName;
   const setSelectedServerName = onSelectServerName ?? setUncontrolledSelectedServerName;
-  const selectedServer = useMemo(
-    () => sortedServers.find((server) => server.serverName === selectedServerName) ?? sortedServers[0] ?? null,
-    [selectedServerName, sortedServers],
-  );
   const validationError = useMemo(() => (draft ? validateServerEditorInput(draft) : null), [draft]);
   const title = draft?.originalServerName ? `Edit ${draft.originalServerName}` : 'Add MCP server';
 
   return (
-    <Card className="animate-mcp-fade-in py-4">
+    <Card className="animate-mcp-fade-in border-border/75 py-4">
       <CardHeader>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
@@ -69,7 +65,7 @@ export function McpServerCrudPanel({
         )}
 
         {draft && (
-          <div className="rounded-xl border border-border bg-muted/20 p-4">
+          <div className="rounded-xl border border-border bg-primary/5 p-4">
             <div className="mb-4 flex items-center justify-between gap-3">
               <div>
                 <div className="font-medium text-foreground">{title}</div>
@@ -177,8 +173,9 @@ export function McpServerCrudPanel({
               const toggleAction = `${server.enabled ? 'disable' : 'enable'}:${server.serverName}`;
               const connectAction = `${server.connectionStatus === 'connected' ? 'reconnect' : 'connect'}:${server.serverName}`;
               const removeAction = `remove:${server.serverName}`;
+              const isExpanded = selectedServerName === server.serverName;
               return (
-                <div key={server.serverName} className={cn('rounded-lg border border-border bg-card/60 p-4', selectedServer?.serverName === server.serverName && 'border-primary/40 bg-primary/5')}>
+                <div key={server.serverName} className={cn('rounded-lg border border-border bg-primary/5 p-4', isExpanded && 'border-primary/40')}>
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-2">
                       <div>
@@ -208,12 +205,13 @@ export function McpServerCrudPanel({
                     <div className="flex flex-wrap gap-2">
                       <Button
                         type="button"
-                        variant={selectedServer?.serverName === server.serverName ? 'default' : 'outline'}
+                        variant={isExpanded ? 'default' : 'outline'}
                         size="sm"
-                        onClick={() => setSelectedServerName(server.serverName)}
+                        onClick={() => setSelectedServerName(isExpanded ? null : server.serverName)}
+                        aria-expanded={isExpanded}
                       >
-                        <Server className="mr-2 h-4 w-4" />
-                        Details
+                        {isExpanded ? <ChevronUp className="mr-2 h-4 w-4" /> : <ChevronDown className="mr-2 h-4 w-4" />}
+                        {isExpanded ? 'Hide details' : 'Show details'}
                       </Button>
                       <Button type="button" variant="outline" size="sm" onClick={() => setDraft(createServerEditorInputFromSnapshot(server))}>
                         <Pencil className="mr-2 h-4 w-4" />
@@ -239,13 +237,16 @@ export function McpServerCrudPanel({
                       </Button>
                     </div>
                   </div>
+                  {isExpanded && (
+                    <div className="mt-4 border-t border-border/75 pt-4">
+                      <McpServerDetailPanel server={server} />
+                    </div>
+                  )}
                 </div>
               );
             })
           )}
         </div>
-
-        <McpServerDetailPanel server={selectedServer} />
       </CardContent>
     </Card>
   );

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
@@ -15,12 +15,18 @@ import {
   validateServerEditorInput,
 } from '../../../shared/types';
 import { useMcpServerMutations } from '../../hooks/useMcpServerMutations';
+import { McpServerDetailPanel } from './McpServerDetailPanel';
 
 export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }) {
   const mutations = useMcpServerMutations();
   const [draft, setDraft] = useState<McpServerEditorInput | null>(null);
+  const [selectedServerName, setSelectedServerName] = useState<string | null>(null);
 
   const sortedServers = useMemo(() => [...servers].sort((a, b) => a.serverName.localeCompare(b.serverName)), [servers]);
+  const selectedServer = useMemo(
+    () => sortedServers.find((server) => server.serverName === selectedServerName) ?? sortedServers[0] ?? null,
+    [selectedServerName, sortedServers],
+  );
   const validationError = useMemo(() => (draft ? validateServerEditorInput(draft) : null), [draft]);
   const title = draft?.originalServerName ? `Edit ${draft.originalServerName}` : 'Add MCP server';
 
@@ -162,7 +168,7 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
               const connectAction = `${server.connectionStatus === 'connected' ? 'reconnect' : 'connect'}:${server.serverName}`;
               const removeAction = `remove:${server.serverName}`;
               return (
-                <div key={server.serverName} className="rounded-lg border border-border bg-card/60 p-4">
+                <div key={server.serverName} className={cn('rounded-lg border border-border bg-card/60 p-4', selectedServer?.serverName === server.serverName && 'border-primary/40 bg-primary/5')}>
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-2">
                       <div>
@@ -190,6 +196,15 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
                       )}
                     </div>
                     <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        variant={selectedServer?.serverName === server.serverName ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => setSelectedServerName(server.serverName)}
+                      >
+                        <Server className="mr-2 h-4 w-4" />
+                        Details
+                      </Button>
                       <Button type="button" variant="outline" size="sm" onClick={() => setDraft(createServerEditorInputFromSnapshot(server))}>
                         <Pencil className="mr-2 h-4 w-4" />
                         Edit
@@ -219,6 +234,8 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
             })
           )}
         </div>
+
+        <McpServerDetailPanel server={selectedServer} />
       </CardContent>
     </Card>
   );

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
@@ -1,0 +1,229 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { NativeSelect, NativeSelectOption } from '@sero-ai/ui/components/ui/native-select';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, Pencil, Plus, Power, Save, Server, Trash2, X } from 'lucide-react';
+import type { McpServerEditorInput, McpServerSnapshot } from '../../../shared/types';
+import { createEmptyServerEditorInput, createServerEditorInputFromSnapshot } from '../../../shared/types';
+import { useMcpServerMutations } from '../../hooks/useMcpServerMutations';
+
+export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }) {
+  const mutations = useMcpServerMutations();
+  const [draft, setDraft] = useState<McpServerEditorInput | null>(null);
+
+  const sortedServers = useMemo(() => [...servers].sort((a, b) => a.serverName.localeCompare(b.serverName)), [servers]);
+
+  const title = draft?.originalServerName ? `Edit ${draft.originalServerName}` : 'Add MCP server';
+
+  return (
+    <Card className="animate-mcp-fade-in py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Server className="h-4 w-4 text-primary" />
+              Servers
+            </CardTitle>
+            <CardDescription>
+              Forms-first MCP server management. Configure stdio or HTTP/SSE servers here without dropping into raw JSON.
+            </CardDescription>
+          </div>
+          <Button type="button" size="sm" onClick={() => setDraft(createEmptyServerEditorInput())}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add server
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {mutations.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Server update failed</AlertTitle>
+            <AlertDescription>{mutations.error}</AlertDescription>
+          </Alert>
+        )}
+
+        {draft && (
+          <div className="rounded-xl border border-border bg-muted/20 p-4">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <div>
+                <div className="font-medium text-foreground">{title}</div>
+                <p className="text-sm text-muted-foreground">
+                  Use command + args for stdio servers, or a URL for HTTP/SSE servers. Auth can stay off, OAuth, or bearer-token based.
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" size="sm" onClick={() => setDraft(null)}>
+                  <X className="mr-2 h-4 w-4" />
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  disabled={mutations.pendingAction === 'save'}
+                  onClick={async () => {
+                    const ok = await mutations.upsertServer(draft);
+                    if (ok) {
+                      setDraft(null);
+                    }
+                  }}
+                >
+                  <Save className="mr-2 h-4 w-4" />
+                  Save server
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              <Field label="Server name">
+                <Input value={draft.serverName} onChange={(event) => setDraft({ ...draft, serverName: event.target.value })} placeholder="github" />
+              </Field>
+              <Field label="Transport">
+                <NativeSelect value={draft.transport} onChange={(event) => setDraft({ ...draft, transport: event.target.value as McpServerEditorInput['transport'] })} className="w-full">
+                  <NativeSelectOption value="stdio">stdio</NativeSelectOption>
+                  <NativeSelectOption value="http">http / sse</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <Field label="Lifecycle">
+                <NativeSelect value={draft.lifecycle} onChange={(event) => setDraft({ ...draft, lifecycle: event.target.value as McpServerEditorInput['lifecycle'] })} className="w-full">
+                  <NativeSelectOption value="lazy">lazy</NativeSelectOption>
+                  <NativeSelectOption value="eager">eager</NativeSelectOption>
+                  <NativeSelectOption value="keep-alive">keep-alive</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <Field label="Auth">
+                <NativeSelect value={draft.authMode} onChange={(event) => setDraft({ ...draft, authMode: event.target.value as McpServerEditorInput['authMode'] })} className="w-full">
+                  <NativeSelectOption value="none">none</NativeSelectOption>
+                  <NativeSelectOption value="oauth">oauth</NativeSelectOption>
+                  <NativeSelectOption value="bearer">bearer</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              {draft.transport === 'stdio' ? (
+                <>
+                  <Field label="Command">
+                    <Input value={draft.command} onChange={(event) => setDraft({ ...draft, command: event.target.value })} placeholder="npx" />
+                  </Field>
+                  <Field label="Working directory">
+                    <Input value={draft.cwd} onChange={(event) => setDraft({ ...draft, cwd: event.target.value })} placeholder="/path/to/project" />
+                  </Field>
+                </>
+              ) : (
+                <>
+                  <Field label="Server URL" className="md:col-span-2">
+                    <Input value={draft.url} onChange={(event) => setDraft({ ...draft, url: event.target.value })} placeholder="https://example.com/mcp" />
+                  </Field>
+                  <Field label="Working directory (optional)">
+                    <Input value={draft.cwd} onChange={(event) => setDraft({ ...draft, cwd: event.target.value })} placeholder="/path/to/project" />
+                  </Field>
+                </>
+              )}
+              {draft.authMode === 'bearer' && (
+                <Field label="Bearer token env var">
+                  <Input value={draft.bearerTokenEnv} onChange={(event) => setDraft({ ...draft, bearerTokenEnv: event.target.value })} placeholder="GITHUB_TOKEN" />
+                </Field>
+              )}
+              {draft.transport === 'stdio' && (
+                <Field label="Args (one per line)" className="md:col-span-2 xl:col-span-3">
+                  <Textarea
+                    value={draft.argsText}
+                    onChange={(event) => setDraft({ ...draft, argsText: event.target.value })}
+                    className="min-h-28 font-mono text-xs"
+                    placeholder="-y\n@modelcontextprotocol/server-github"
+                  />
+                </Field>
+              )}
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-4 text-sm text-muted-foreground">
+              <Toggle label="Enabled" checked={draft.enabled} onChange={(checked) => setDraft({ ...draft, enabled: checked })} />
+              <Toggle label="Expose resources" checked={draft.exposeResources} onChange={(checked) => setDraft({ ...draft, exposeResources: checked })} />
+              <Toggle label="Debug stderr" checked={draft.debug} onChange={(checked) => setDraft({ ...draft, debug: checked })} />
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {sortedServers.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border bg-muted/20 p-6 text-sm text-muted-foreground">
+              No MCP servers yet. Add one above to start building the plugin’s global MCP config.
+            </div>
+          ) : (
+            sortedServers.map((server) => {
+              const toggleAction = `${server.enabled ? 'disable' : 'enable'}:${server.serverName}`;
+              const removeAction = `remove:${server.serverName}`;
+              return (
+                <div key={server.serverName} className="rounded-lg border border-border bg-card/60 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-1">
+                      <div className="font-medium text-foreground">{server.serverName}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {server.transport.toUpperCase()} · {server.lifecycle} lifecycle · auth {server.authMode}
+                      </div>
+                      <div className="flex flex-wrap gap-2 pt-1">
+                        <StatusPill label={server.enabled ? 'enabled' : 'disabled'} tone={server.enabled ? 'default' : 'muted'} />
+                        <StatusPill label={server.connectionStatus} tone={server.connectionStatus === 'needs-auth' ? 'warning' : 'muted'} />
+                        <StatusPill label={server.authStatus} tone={server.authStatus === 'authenticated' ? 'success' : server.authStatus === 'not-authenticated' ? 'warning' : 'muted'} />
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button type="button" variant="outline" size="sm" onClick={() => setDraft(createServerEditorInputFromSnapshot(server))}>
+                        <Pencil className="mr-2 h-4 w-4" />
+                        Edit
+                      </Button>
+                      <Button type="button" variant="outline" size="sm" disabled={mutations.pendingAction === toggleAction} onClick={() => void mutations.toggleServer(server.serverName, !server.enabled)}>
+                        <Power className="mr-2 h-4 w-4" />
+                        {server.enabled ? 'Disable' : 'Enable'}
+                      </Button>
+                      <Button type="button" variant="outline" size="sm" disabled={mutations.pendingAction === removeAction} onClick={() => void mutations.removeServer(server.serverName)}>
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Field({ label, className, children }: { label: string; className?: string; children: ReactNode }) {
+  return (
+    <label className={cn('space-y-2 text-sm text-muted-foreground', className)}>
+      <span className="block font-medium text-foreground">{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function Toggle({ label, checked, onChange }: { label: string; checked: boolean; onChange: (checked: boolean) => void }) {
+  return (
+    <label className="flex items-center gap-2">
+      <input type="checkbox" checked={checked} onChange={(event) => onChange(event.target.checked)} />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+function StatusPill({ label, tone }: { label: string; tone: 'default' | 'success' | 'warning' | 'muted' }) {
+  const className = cn(
+    tone === 'success' && 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+    tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+    tone === 'muted' && 'border-border bg-muted text-muted-foreground',
+  );
+  return (
+    <Badge variant="outline" className={className}>
+      {label}
+    </Badge>
+  );
+}
+
+export default McpServerCrudPanel;

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
@@ -164,16 +164,30 @@ export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }
               return (
                 <div key={server.serverName} className="rounded-lg border border-border bg-card/60 p-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="space-y-1">
-                      <div className="font-medium text-foreground">{server.serverName}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {server.transport.toUpperCase()} · {server.lifecycle} lifecycle · auth {server.authMode}
+                    <div className="space-y-2">
+                      <div>
+                        <div className="font-medium text-foreground">{server.serverName}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {server.transport.toUpperCase()} · {server.lifecycle} lifecycle · auth {server.authMode}
+                        </div>
                       </div>
-                      <div className="flex flex-wrap gap-2 pt-1">
+                      <div className="flex flex-wrap gap-2">
                         <StatusPill label={server.enabled ? 'enabled' : 'disabled'} tone={server.enabled ? 'default' : 'muted'} />
-                        <StatusPill label={server.connectionStatus} tone={server.connectionStatus === 'needs-auth' ? 'warning' : 'muted'} />
+                        <StatusPill label={server.connectionStatus} tone={server.connectionStatus === 'connected' ? 'success' : server.connectionStatus === 'needs-auth' ? 'warning' : 'muted'} />
                         <StatusPill label={server.authStatus} tone={server.authStatus === 'authenticated' ? 'success' : server.authStatus === 'not-authenticated' ? 'warning' : 'muted'} />
                       </div>
+                      <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                        <span>Tools: <strong className="text-foreground">{server.toolCount}</strong></span>
+                        <span>Resources: <strong className="text-foreground">{server.resourceCount}</strong></span>
+                        <span>UI tools: <strong className="text-foreground">{server.uiToolCount}</strong></span>
+                        {server.lastConnectedAt && <span>Last connected: <strong className="text-foreground">{formatCompactTimestamp(server.lastConnectedAt)}</strong></span>}
+                        {server.lastFailedAt && <span>Last failure: <strong className="text-foreground">{formatCompactTimestamp(server.lastFailedAt)}</strong></span>}
+                      </div>
+                      {server.lastError && (
+                        <div className="max-w-3xl text-xs text-destructive/90">
+                          Last error: {server.lastError}
+                        </div>
+                      )}
                     </div>
                     <div className="flex flex-wrap gap-2">
                       <Button type="button" variant="outline" size="sm" onClick={() => setDraft(createServerEditorInputFromSnapshot(server))}>
@@ -239,6 +253,19 @@ function StatusPill({ label, tone }: { label: string; tone: 'default' | 'success
       {label}
     </Badge>
   );
+}
+
+function formatCompactTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
 }
 
 export default McpServerCrudPanel;

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerCrudPanel.tsx
@@ -17,12 +17,22 @@ import {
 import { useMcpServerMutations } from '../../hooks/useMcpServerMutations';
 import { McpServerDetailPanel } from './McpServerDetailPanel';
 
-export function McpServerCrudPanel({ servers }: { servers: McpServerSnapshot[] }) {
+export function McpServerCrudPanel({
+  servers,
+  selectedServerName: controlledSelectedServerName,
+  onSelectServerName,
+}: {
+  servers: McpServerSnapshot[];
+  selectedServerName?: string | null;
+  onSelectServerName?: (serverName: string) => void;
+}) {
   const mutations = useMcpServerMutations();
   const [draft, setDraft] = useState<McpServerEditorInput | null>(null);
-  const [selectedServerName, setSelectedServerName] = useState<string | null>(null);
+  const [uncontrolledSelectedServerName, setUncontrolledSelectedServerName] = useState<string | null>(null);
 
   const sortedServers = useMemo(() => [...servers].sort((a, b) => a.serverName.localeCompare(b.serverName)), [servers]);
+  const selectedServerName = controlledSelectedServerName ?? uncontrolledSelectedServerName;
+  const setSelectedServerName = onSelectServerName ?? setUncontrolledSelectedServerName;
   const selectedServer = useMemo(
     () => sortedServers.find((server) => server.serverName === selectedServerName) ?? sortedServers[0] ?? null,
     [selectedServerName, sortedServers],

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
@@ -9,6 +9,7 @@ import { AlertCircle, LifeBuoy, MonitorSmartphone, RefreshCw, ScrollText, X } fr
 import type { McpResourcePreview, McpServerSnapshot } from '../../../shared/types';
 import { useMcpResourceReader } from '../../hooks/useMcpResourceReader';
 import { McpServerAuthPanel } from './McpServerAuthPanel';
+import { McpServerToolRunnerPanel } from './McpServerToolRunnerPanel';
 
 export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | null }) {
   const promptAgent = useAgentPrompt();
@@ -69,6 +70,13 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
         <div className="grid gap-4 xl:grid-cols-[0.95fr_1.25fr]">
           <section className="space-y-4">
             <McpServerAuthPanel server={server} />
+
+            <McpServerToolRunnerPanel
+              server={server}
+              onOpenResource={(resourceUri) => {
+                void resourceReader.loadResource(server.serverName, resourceUri);
+              }}
+            />
 
             <Card className="border-border/70 bg-muted/15 py-4">
               <CardHeader>

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
@@ -1,74 +1,42 @@
 import { useMemo } from 'react';
 import { useAgentPrompt } from '@sero-ai/app-runtime';
 import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
-import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
 import { cn } from '@sero-ai/ui/lib/utils';
-import { AlertCircle, LifeBuoy, MonitorSmartphone, RefreshCw, ScrollText } from 'lucide-react';
+import { AlertCircle, LifeBuoy, MonitorSmartphone, RefreshCw } from 'lucide-react';
 import type { McpServerSnapshot } from '../../../shared/types';
 import { useMcpViewer } from '../../hooks/useMcpViewer';
 import { McpServerAuthPanel } from './McpServerAuthPanel';
 import { McpServerToolRunnerPanel } from './McpServerToolRunnerPanel';
 import { McpViewerPane } from '../viewer/McpViewerPane';
 
-export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | null }) {
+export function McpServerDetailPanel({ server }: { server: McpServerSnapshot }) {
   const promptAgent = useAgentPrompt();
   const viewer = useMcpViewer();
-  const sortedResources = useMemo(() => [...(server?.resources ?? [])].sort((a, b) => a.name.localeCompare(b.name)), [server?.resources]);
-  const sortedUiTools = useMemo(() => [...(server?.uiTools ?? [])].sort((a, b) => a.name.localeCompare(b.name)), [server?.uiTools]);
-
-  if (!server) {
-    return (
-      <Card className="animate-mcp-fade-in py-4">
-        <CardHeader>
-          <CardTitle>Server details</CardTitle>
-          <CardDescription>Select a configured server to inspect its resources, UI-capable tools, and live preview details.</CardDescription>
-        </CardHeader>
-      </Card>
-    );
-  }
+  const sortedResources = useMemo(() => [...server.resources].sort((a, b) => a.name.localeCompare(b.name)), [server.resources]);
+  const sortedUiTools = useMemo(() => [...server.uiTools].sort((a, b) => a.name.localeCompare(b.name)), [server.uiTools]);
 
   const helpPrompt = buildServerHelpPrompt(server, viewer.resourceError, viewer.preview?.serverName === server.serverName ? viewer.preview : null);
 
   return (
-    <Card className="animate-mcp-fade-in py-4">
-      <CardHeader>
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <CardTitle className="flex items-center gap-2">
-              <ScrollText className="h-4 w-4 text-primary" />
-              {server.serverName} details
-            </CardTitle>
-            <CardDescription>
-              Inspect discovered MCP resources and UI-capable tools. Resources, tool UIs, and auth flows now open in the dedicated viewer pane so you can troubleshoot without leaving context.
-            </CardDescription>
-          </div>
-          <div className="flex flex-wrap gap-2 text-xs">
-            <ToneBadge label={server.connectionStatus} tone={server.connectionStatus === 'connected' ? 'success' : server.connectionStatus === 'needs-auth' ? 'warning' : 'muted'} />
-            <ToneBadge label={server.authStatus} tone={server.authStatus === 'authenticated' ? 'success' : server.authStatus === 'not-authenticated' ? 'warning' : 'muted'} />
-            <ToneBadge label={`${server.toolCount} tools`} tone="muted" />
-            <ToneBadge label={`${server.resourceCount} resources`} tone="muted" />
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {viewer.resourceError && viewer.pane?.serverName === server.serverName && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Resource or UI preview failed</AlertTitle>
-            <AlertDescription className="space-y-3">
-              <p>{viewer.resourceError}</p>
-              <Button type="button" size="sm" onClick={() => promptAgent(helpPrompt)}>
-                <LifeBuoy className="mr-2 h-4 w-4" />
-                Ask Sero to help
-              </Button>
-            </AlertDescription>
-          </Alert>
-        )}
+    <div className="space-y-4">
+      {viewer.resourceError && viewer.pane?.serverName === server.serverName && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>Resource or UI preview failed</AlertTitle>
+          <AlertDescription className="space-y-3">
+            <p>{viewer.resourceError}</p>
+            <Button type="button" size="sm" onClick={() => promptAgent(helpPrompt)}>
+              <LifeBuoy className="mr-2 h-4 w-4" />
+              Ask Sero to help
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
 
-        <div className="grid gap-4 xl:grid-cols-[0.95fr_1.25fr]">
-          <section className="space-y-4">
+      <div className="grid gap-4 2xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.25fr)]">
+        <section className="min-w-0 space-y-4">
             <McpServerAuthPanel server={server} viewer={viewer} />
 
             <McpServerToolRunnerPanel
@@ -78,7 +46,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
               }}
             />
 
-            <Card className="border-border/70 bg-muted/15 py-4">
+            <Card className="border-border/70 bg-card py-4">
               <CardHeader>
                 <CardTitle className="text-base">Resources</CardTitle>
                 <CardDescription>
@@ -120,7 +88,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
               </CardContent>
             </Card>
 
-            <Card className="border-border/70 bg-muted/15 py-4">
+            <Card className="border-border/70 bg-card py-4">
               <CardHeader>
                 <CardTitle className="flex items-center gap-2 text-base">
                   <MonitorSmartphone className="h-4 w-4 text-primary" />
@@ -168,10 +136,11 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
             </Card>
           </section>
 
+        <div className="min-w-0">
           <McpViewerPane viewer={viewer} />
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 
@@ -181,21 +150,6 @@ function EmptyState({ title, body }: { title: string; body: string }) {
       <div className="font-medium text-foreground">{title}</div>
       <p className="mt-1 text-sm text-muted-foreground">{body}</p>
     </div>
-  );
-}
-
-function ToneBadge({ label, tone }: { label: string; tone: 'success' | 'warning' | 'muted' }) {
-  return (
-    <Badge
-      variant="outline"
-      className={cn(
-        tone === 'success' && 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
-        tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
-        tone === 'muted' && 'border-border bg-background text-muted-foreground',
-      )}
-    >
-      {label}
-    </Badge>
   );
 }
 

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
@@ -1,0 +1,266 @@
+import { useMemo } from 'react';
+import { useAgentPrompt } from '@sero-ai/app-runtime';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, LifeBuoy, MonitorSmartphone, RefreshCw, ScrollText, X } from 'lucide-react';
+import type { McpResourcePreview, McpServerSnapshot } from '../../../shared/types';
+import { useMcpResourceReader } from '../../hooks/useMcpResourceReader';
+
+export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | null }) {
+  const promptAgent = useAgentPrompt();
+  const resourceReader = useMcpResourceReader();
+  const preview = resourceReader.preview?.serverName === server?.serverName ? resourceReader.preview : null;
+  const sortedResources = useMemo(() => [...(server?.resources ?? [])].sort((a, b) => a.name.localeCompare(b.name)), [server?.resources]);
+  const sortedUiTools = useMemo(() => [...(server?.uiTools ?? [])].sort((a, b) => a.name.localeCompare(b.name)), [server?.uiTools]);
+
+  if (!server) {
+    return (
+      <Card className="animate-mcp-fade-in py-4">
+        <CardHeader>
+          <CardTitle>Server details</CardTitle>
+          <CardDescription>Select a configured server to inspect its resources, UI-capable tools, and live preview details.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const helpPrompt = buildServerHelpPrompt(server, resourceReader.error, preview);
+
+  return (
+    <Card className="animate-mcp-fade-in py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <ScrollText className="h-4 w-4 text-primary" />
+              {server.serverName} details
+            </CardTitle>
+            <CardDescription>
+              Inspect discovered MCP resources and UI-capable tools. Resource previews stay inside Sero so you can troubleshoot without leaving context.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <ToneBadge label={server.connectionStatus} tone={server.connectionStatus === 'connected' ? 'success' : server.connectionStatus === 'needs-auth' ? 'warning' : 'muted'} />
+            <ToneBadge label={server.authStatus} tone={server.authStatus === 'authenticated' ? 'success' : server.authStatus === 'not-authenticated' ? 'warning' : 'muted'} />
+            <ToneBadge label={`${server.toolCount} tools`} tone="muted" />
+            <ToneBadge label={`${server.resourceCount} resources`} tone="muted" />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {resourceReader.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Resource preview failed</AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>{resourceReader.error}</p>
+              <Button type="button" size="sm" onClick={() => promptAgent(helpPrompt)}>
+                <LifeBuoy className="mr-2 h-4 w-4" />
+                Ask Sero to help
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="grid gap-4 xl:grid-cols-[0.95fr_1.25fr]">
+          <section className="space-y-4">
+            <Card className="border-border/70 bg-muted/15 py-4">
+              <CardHeader>
+                <CardTitle className="text-base">Resources</CardTitle>
+                <CardDescription>
+                  Cached from the last successful metadata refresh. Click a resource to lazy-connect the server if needed and preview its current content.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {sortedResources.length === 0 ? (
+                  <EmptyState title="No resources discovered" body="Connect the server and refresh metadata if you expect resources here." />
+                ) : (
+                  sortedResources.map((resource) => {
+                    const isActive = resourceReader.activeResourceUri === resource.uri;
+                    return (
+                      <div key={resource.uri} className={cn('rounded-lg border border-border bg-background/60 p-3', isActive && 'border-primary/40 bg-primary/5')}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 space-y-1">
+                            <div className="font-medium text-foreground">{resource.name}</div>
+                            <div className="break-all text-xs text-muted-foreground">{resource.uri}</div>
+                            {resource.description && <p className="text-xs text-muted-foreground">{resource.description}</p>}
+                          </div>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={isActive ? 'default' : 'outline'}
+                            onClick={() => void resourceReader.loadResource(server.serverName, resource.uri)}
+                            disabled={resourceReader.loading && isActive}
+                          >
+                            <RefreshCw className={cn('mr-2 h-4 w-4', resourceReader.loading && isActive && 'animate-spin')} />
+                            {isActive ? 'Reload' : 'Preview'}
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/70 bg-muted/15 py-4">
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <MonitorSmartphone className="h-4 w-4 text-primary" />
+                  UI-capable tools
+                </CardTitle>
+                <CardDescription>
+                  Tools that advertised MCP UI metadata. Full interactive UI launching is the next slice; for now this view exposes what the server reported.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {sortedUiTools.length === 0 ? (
+                  <EmptyState title="No UI-capable tools discovered" body="If this server exposes interactive MCP UIs, reconnect it and refresh metadata to repopulate the cache." />
+                ) : (
+                  sortedUiTools.map((tool) => (
+                    <div key={tool.name} className="rounded-lg border border-border bg-background/60 p-3">
+                      <div className="font-medium text-foreground">{tool.name}</div>
+                      {tool.description && <p className="mt-1 text-sm text-muted-foreground">{tool.description}</p>}
+                      <pre className="mt-3 overflow-x-auto rounded-md border border-border/70 bg-muted/20 p-3 text-xs leading-6 text-muted-foreground">
+                        {formatSchemaSummary(tool.inputSchema)}
+                      </pre>
+                    </div>
+                  ))
+                )}
+              </CardContent>
+            </Card>
+          </section>
+
+          <Card className="border-border/70 bg-muted/15 py-4">
+            <CardHeader>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <CardTitle className="text-base">Embedded resource preview</CardTitle>
+                  <CardDescription>
+                    Current preview renders directly in the MCP app. HTML resources are sandboxed in an iframe; text and JSON resources stay copyable.
+                  </CardDescription>
+                </div>
+                {preview && (
+                  <Button type="button" variant="outline" size="sm" onClick={resourceReader.clearPreview}>
+                    <X className="mr-2 h-4 w-4" />
+                    Clear preview
+                  </Button>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              <ResourcePreview preview={preview} loading={resourceReader.loading} />
+            </CardContent>
+          </Card>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ResourcePreview({ preview, loading }: { preview: McpResourcePreview | null; loading: boolean }) {
+  if (loading && !preview) {
+    return <PreviewPlaceholder body="Loading resource preview…" />;
+  }
+  if (!preview) {
+    return <PreviewPlaceholder body="Select a discovered resource to preview it here." />;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+        <ToneBadge label={preview.previewKind} tone="muted" />
+        <ToneBadge label={preview.mimeType ?? 'unknown mime'} tone="muted" />
+        <span className="rounded-full border border-border bg-background px-2 py-0.5">{preview.resolvedUri}</span>
+        {preview.truncated && <ToneBadge label="preview truncated" tone="warning" />}
+      </div>
+
+      {preview.previewKind === 'html' ? (
+        <iframe
+          title={preview.resolvedUri}
+          srcDoc={preview.html ?? ''}
+          sandbox="allow-scripts allow-forms"
+          className="h-[520px] w-full rounded-lg border border-border bg-white"
+        />
+      ) : preview.previewKind === 'image' ? (
+        <div className="overflow-hidden rounded-lg border border-border bg-background p-3">
+          {preview.dataUrl ? (
+            <img src={preview.dataUrl} alt={preview.resolvedUri} className="max-h-[520px] w-full object-contain" />
+          ) : (
+            <PreviewPlaceholder body="This image resource did not return a renderable payload." />
+          )}
+        </div>
+      ) : preview.previewKind === 'binary' ? (
+        <PreviewPlaceholder body="This resource returned binary content that cannot be previewed inline yet." />
+      ) : (
+        <pre className="max-h-[520px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+          {preview.text || '(empty resource)'}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function PreviewPlaceholder({ body }: { body: string }) {
+  return (
+    <div className="flex min-h-[280px] items-center justify-center rounded-lg border border-dashed border-border bg-background/60 p-6 text-center text-sm text-muted-foreground">
+      <div className="max-w-md">{body}</div>
+    </div>
+  );
+}
+
+function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-background/40 p-4">
+      <div className="font-medium text-foreground">{title}</div>
+      <p className="mt-1 text-sm text-muted-foreground">{body}</p>
+    </div>
+  );
+}
+
+function ToneBadge({ label, tone }: { label: string; tone: 'success' | 'warning' | 'muted' }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        tone === 'success' && 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+        tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+        tone === 'muted' && 'border-border bg-background text-muted-foreground',
+      )}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function formatSchemaSummary(schema: unknown): string {
+  if (!schema) {
+    return '(no schema reported)';
+  }
+  try {
+    return JSON.stringify(schema, null, 2);
+  } catch {
+    return String(schema);
+  }
+}
+
+function buildServerHelpPrompt(
+  server: McpServerSnapshot,
+  error: string | null,
+  preview: McpResourcePreview | null,
+): string {
+  return [
+    `Help me troubleshoot MCP resource viewing for server "${server.serverName}" in Sero.`,
+    `Connection status: ${server.connectionStatus}`,
+    `Auth status: ${server.authStatus}`,
+    `Resources discovered: ${server.resourceCount}`,
+    preview ? `Current resource URI: ${preview.resolvedUri}` : 'No resource preview is open.',
+    '',
+    error ?? 'No explicit reader error was present; explain likely next checks and recovery steps.',
+  ].join('\n');
+}
+
+export default McpServerDetailPanel;

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
@@ -8,6 +8,7 @@ import { cn } from '@sero-ai/ui/lib/utils';
 import { AlertCircle, LifeBuoy, MonitorSmartphone, RefreshCw, ScrollText, X } from 'lucide-react';
 import type { McpResourcePreview, McpServerSnapshot } from '../../../shared/types';
 import { useMcpResourceReader } from '../../hooks/useMcpResourceReader';
+import { McpServerAuthPanel } from './McpServerAuthPanel';
 
 export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | null }) {
   const promptAgent = useAgentPrompt();
@@ -67,6 +68,8 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
 
         <div className="grid gap-4 xl:grid-cols-[0.95fr_1.25fr]">
           <section className="space-y-4">
+            <McpServerAuthPanel server={server} />
+
             <Card className="border-border/70 bg-muted/15 py-4">
               <CardHeader>
                 <CardTitle className="text-base">Resources</CardTitle>

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
@@ -40,7 +40,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
               {server.serverName} details
             </CardTitle>
             <CardDescription>
-              Inspect discovered MCP resources and UI-capable tools. Resource previews stay inside Sero so you can troubleshoot without leaving context.
+              Inspect discovered MCP resources and UI-capable tools. Resources and advertised tool UIs open in the embedded viewer so you can troubleshoot without leaving context.
             </CardDescription>
           </div>
           <div className="flex flex-wrap gap-2 text-xs">
@@ -116,22 +116,40 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                   UI-capable tools
                 </CardTitle>
                 <CardDescription>
-                  Tools that advertised MCP UI metadata. Full interactive UI launching is the next slice; for now this view exposes what the server reported.
+                  Tools that advertised MCP UI metadata. Launching a tool reads its advertised UI resource and opens it in the embedded viewer.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
                 {sortedUiTools.length === 0 ? (
                   <EmptyState title="No UI-capable tools discovered" body="If this server exposes interactive MCP UIs, reconnect it and refresh metadata to repopulate the cache." />
                 ) : (
-                  sortedUiTools.map((tool) => (
-                    <div key={tool.name} className="rounded-lg border border-border bg-background/60 p-3">
-                      <div className="font-medium text-foreground">{tool.name}</div>
-                      {tool.description && <p className="mt-1 text-sm text-muted-foreground">{tool.description}</p>}
-                      <pre className="mt-3 overflow-x-auto rounded-md border border-border/70 bg-muted/20 p-3 text-xs leading-6 text-muted-foreground">
-                        {formatSchemaSummary(tool.inputSchema)}
-                      </pre>
-                    </div>
-                  ))
+                  sortedUiTools.map((tool) => {
+                    const isActive = resourceReader.activeResourceUri === tool.resourceUri;
+                    return (
+                      <div key={tool.name} className={cn('rounded-lg border border-border bg-background/60 p-3', isActive && 'border-primary/40 bg-primary/5')}>
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 space-y-1">
+                            <div className="font-medium text-foreground">{tool.name}</div>
+                            <div className="break-all text-xs text-muted-foreground">{tool.resourceUri}</div>
+                            {tool.description && <p className="text-sm text-muted-foreground">{tool.description}</p>}
+                          </div>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={isActive ? 'default' : 'outline'}
+                            onClick={() => void resourceReader.loadResource(server.serverName, tool.resourceUri)}
+                            disabled={resourceReader.loading && isActive}
+                          >
+                            <MonitorSmartphone className="mr-2 h-4 w-4" />
+                            {isActive ? 'Reload UI' : 'Launch UI'}
+                          </Button>
+                        </div>
+                        <pre className="mt-3 overflow-x-auto rounded-md border border-border/70 bg-muted/20 p-3 text-xs leading-6 text-muted-foreground">
+                          {formatSchemaSummary(tool.inputSchema)}
+                        </pre>
+                      </div>
+                    );
+                  })
                 )}
               </CardContent>
             </Card>
@@ -141,9 +159,9 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
             <CardHeader>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                  <CardTitle className="text-base">Embedded resource preview</CardTitle>
+                  <CardTitle className="text-base">Embedded viewer</CardTitle>
                   <CardDescription>
-                    Current preview renders directly in the MCP app. HTML resources are sandboxed in an iframe; text and JSON resources stay copyable.
+                    Resource previews and launched tool UIs render directly in the MCP app. HTML content is sandboxed in an iframe; text and JSON content stay copyable.
                   </CardDescription>
                 </div>
                 {preview && (

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
@@ -5,16 +5,16 @@ import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
 import { cn } from '@sero-ai/ui/lib/utils';
-import { AlertCircle, LifeBuoy, MonitorSmartphone, RefreshCw, ScrollText, X } from 'lucide-react';
-import type { McpResourcePreview, McpServerSnapshot } from '../../../shared/types';
-import { useMcpResourceReader } from '../../hooks/useMcpResourceReader';
+import { AlertCircle, LifeBuoy, MonitorSmartphone, RefreshCw, ScrollText } from 'lucide-react';
+import type { McpServerSnapshot } from '../../../shared/types';
+import { useMcpViewer } from '../../hooks/useMcpViewer';
 import { McpServerAuthPanel } from './McpServerAuthPanel';
 import { McpServerToolRunnerPanel } from './McpServerToolRunnerPanel';
+import { McpViewerPane } from '../viewer/McpViewerPane';
 
 export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | null }) {
   const promptAgent = useAgentPrompt();
-  const resourceReader = useMcpResourceReader();
-  const preview = resourceReader.preview?.serverName === server?.serverName ? resourceReader.preview : null;
+  const viewer = useMcpViewer();
   const sortedResources = useMemo(() => [...(server?.resources ?? [])].sort((a, b) => a.name.localeCompare(b.name)), [server?.resources]);
   const sortedUiTools = useMemo(() => [...(server?.uiTools ?? [])].sort((a, b) => a.name.localeCompare(b.name)), [server?.uiTools]);
 
@@ -29,7 +29,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
     );
   }
 
-  const helpPrompt = buildServerHelpPrompt(server, resourceReader.error, preview);
+  const helpPrompt = buildServerHelpPrompt(server, viewer.resourceError, viewer.preview?.serverName === server.serverName ? viewer.preview : null);
 
   return (
     <Card className="animate-mcp-fade-in py-4">
@@ -41,7 +41,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
               {server.serverName} details
             </CardTitle>
             <CardDescription>
-              Inspect discovered MCP resources and UI-capable tools. Resources and advertised tool UIs open in the embedded viewer so you can troubleshoot without leaving context.
+              Inspect discovered MCP resources and UI-capable tools. Resources, tool UIs, and auth flows now open in the dedicated viewer pane so you can troubleshoot without leaving context.
             </CardDescription>
           </div>
           <div className="flex flex-wrap gap-2 text-xs">
@@ -53,12 +53,12 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        {resourceReader.error && (
+        {viewer.resourceError && viewer.pane?.serverName === server.serverName && (
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Resource preview failed</AlertTitle>
+            <AlertTitle>Resource or UI preview failed</AlertTitle>
             <AlertDescription className="space-y-3">
-              <p>{resourceReader.error}</p>
+              <p>{viewer.resourceError}</p>
               <Button type="button" size="sm" onClick={() => promptAgent(helpPrompt)}>
                 <LifeBuoy className="mr-2 h-4 w-4" />
                 Ask Sero to help
@@ -69,12 +69,12 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
 
         <div className="grid gap-4 xl:grid-cols-[0.95fr_1.25fr]">
           <section className="space-y-4">
-            <McpServerAuthPanel server={server} />
+            <McpServerAuthPanel server={server} viewer={viewer} />
 
             <McpServerToolRunnerPanel
               server={server}
-              onOpenResource={(resourceUri) => {
-                void resourceReader.loadResource(server.serverName, resourceUri);
+              onOpenResource={(resourceUri, options) => {
+                void viewer.openResource(server.serverName, resourceUri, options);
               }}
             />
 
@@ -82,7 +82,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
               <CardHeader>
                 <CardTitle className="text-base">Resources</CardTitle>
                 <CardDescription>
-                  Cached from the last successful metadata refresh. Click a resource to lazy-connect the server if needed and preview its current content.
+                  Cached from the last successful metadata refresh. Click a resource to lazy-connect the server if needed and preview its current content in the viewer pane.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
@@ -90,7 +90,9 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                   <EmptyState title="No resources discovered" body="Connect the server and refresh metadata if you expect resources here." />
                 ) : (
                   sortedResources.map((resource) => {
-                    const isActive = resourceReader.activeResourceUri === resource.uri;
+                    const isActive = viewer.pane?.kind === 'resource'
+                      && viewer.pane.serverName === server.serverName
+                      && viewer.activeResourceUri === resource.uri;
                     return (
                       <div key={resource.uri} className={cn('rounded-lg border border-border bg-background/60 p-3', isActive && 'border-primary/40 bg-primary/5')}>
                         <div className="flex items-start justify-between gap-3">
@@ -103,10 +105,10 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                             type="button"
                             size="sm"
                             variant={isActive ? 'default' : 'outline'}
-                            onClick={() => void resourceReader.loadResource(server.serverName, resource.uri)}
-                            disabled={resourceReader.loading && isActive}
+                            onClick={() => void viewer.openResource(server.serverName, resource.uri, { kind: 'resource', title: resource.name })}
+                            disabled={viewer.resourceLoading && isActive}
                           >
-                            <RefreshCw className={cn('mr-2 h-4 w-4', resourceReader.loading && isActive && 'animate-spin')} />
+                            <RefreshCw className={cn('mr-2 h-4 w-4', viewer.resourceLoading && isActive && 'animate-spin')} />
                             {isActive ? 'Reload' : 'Preview'}
                           </Button>
                         </div>
@@ -124,7 +126,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                   UI-capable tools
                 </CardTitle>
                 <CardDescription>
-                  Tools that advertised MCP UI metadata. Launching a tool reads its advertised UI resource and opens it in the embedded viewer.
+                  Tools that advertised MCP UI metadata. Launching a tool reads its advertised UI resource and opens it in the viewer pane.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
@@ -132,7 +134,9 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                   <EmptyState title="No UI-capable tools discovered" body="If this server exposes interactive MCP UIs, reconnect it and refresh metadata to repopulate the cache." />
                 ) : (
                   sortedUiTools.map((tool) => {
-                    const isActive = resourceReader.activeResourceUri === tool.resourceUri;
+                    const isActive = viewer.pane?.kind === 'tool-ui'
+                      && viewer.pane.serverName === server.serverName
+                      && viewer.activeResourceUri === tool.resourceUri;
                     return (
                       <div key={tool.name} className={cn('rounded-lg border border-border bg-background/60 p-3', isActive && 'border-primary/40 bg-primary/5')}>
                         <div className="flex items-start justify-between gap-3">
@@ -145,8 +149,8 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                             type="button"
                             size="sm"
                             variant={isActive ? 'default' : 'outline'}
-                            onClick={() => void resourceReader.loadResource(server.serverName, tool.resourceUri)}
-                            disabled={resourceReader.loading && isActive}
+                            onClick={() => void viewer.openResource(server.serverName, tool.resourceUri, { kind: 'tool-ui', title: tool.name })}
+                            disabled={viewer.resourceLoading && isActive}
                           >
                             <MonitorSmartphone className="mr-2 h-4 w-4" />
                             {isActive ? 'Reload UI' : 'Launch UI'}
@@ -163,81 +167,10 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
             </Card>
           </section>
 
-          <Card className="border-border/70 bg-muted/15 py-4">
-            <CardHeader>
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div>
-                  <CardTitle className="text-base">Embedded viewer</CardTitle>
-                  <CardDescription>
-                    Resource previews and launched tool UIs render directly in the MCP app. HTML content is sandboxed in an iframe; text and JSON content stay copyable.
-                  </CardDescription>
-                </div>
-                {preview && (
-                  <Button type="button" variant="outline" size="sm" onClick={resourceReader.clearPreview}>
-                    <X className="mr-2 h-4 w-4" />
-                    Clear preview
-                  </Button>
-                )}
-              </div>
-            </CardHeader>
-            <CardContent>
-              <ResourcePreview preview={preview} loading={resourceReader.loading} />
-            </CardContent>
-          </Card>
+          <McpViewerPane viewer={viewer} />
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-function ResourcePreview({ preview, loading }: { preview: McpResourcePreview | null; loading: boolean }) {
-  if (loading && !preview) {
-    return <PreviewPlaceholder body="Loading resource preview…" />;
-  }
-  if (!preview) {
-    return <PreviewPlaceholder body="Select a discovered resource to preview it here." />;
-  }
-
-  return (
-    <div className="space-y-3">
-      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-        <ToneBadge label={preview.previewKind} tone="muted" />
-        <ToneBadge label={preview.mimeType ?? 'unknown mime'} tone="muted" />
-        <span className="rounded-full border border-border bg-background px-2 py-0.5">{preview.resolvedUri}</span>
-        {preview.truncated && <ToneBadge label="preview truncated" tone="warning" />}
-      </div>
-
-      {preview.previewKind === 'html' ? (
-        <iframe
-          title={preview.resolvedUri}
-          srcDoc={preview.html ?? ''}
-          sandbox="allow-scripts allow-forms"
-          className="h-[520px] w-full rounded-lg border border-border bg-white"
-        />
-      ) : preview.previewKind === 'image' ? (
-        <div className="overflow-hidden rounded-lg border border-border bg-background p-3">
-          {preview.dataUrl ? (
-            <img src={preview.dataUrl} alt={preview.resolvedUri} className="max-h-[520px] w-full object-contain" />
-          ) : (
-            <PreviewPlaceholder body="This image resource did not return a renderable payload." />
-          )}
-        </div>
-      ) : preview.previewKind === 'binary' ? (
-        <PreviewPlaceholder body="This resource returned binary content that cannot be previewed inline yet." />
-      ) : (
-        <pre className="max-h-[520px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
-          {preview.text || '(empty resource)'}
-        </pre>
-      )}
-    </div>
-  );
-}
-
-function PreviewPlaceholder({ body }: { body: string }) {
-  return (
-    <div className="flex min-h-[280px] items-center justify-center rounded-lg border border-dashed border-border bg-background/60 p-6 text-center text-sm text-muted-foreground">
-      <div className="max-w-md">{body}</div>
-    </div>
   );
 }
 
@@ -279,16 +212,16 @@ function formatSchemaSummary(schema: unknown): string {
 function buildServerHelpPrompt(
   server: McpServerSnapshot,
   error: string | null,
-  preview: McpResourcePreview | null,
+  preview: { resolvedUri: string } | null,
 ): string {
   return [
-    `Help me troubleshoot MCP resource viewing for server "${server.serverName}" in Sero.`,
+    `Help me troubleshoot MCP resource or UI viewing for server "${server.serverName}" in Sero.`,
     `Connection status: ${server.connectionStatus}`,
     `Auth status: ${server.authStatus}`,
     `Resources discovered: ${server.resourceCount}`,
     preview ? `Current resource URI: ${preview.resolvedUri}` : 'No resource preview is open.',
     '',
-    error ?? 'No explicit reader error was present; explain likely next checks and recovery steps.',
+    error ?? 'No explicit viewer error was present; explain likely next checks and recovery steps.',
   ].join('\n');
 }
 

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerDetailPanel.tsx
@@ -82,7 +82,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
               <CardHeader>
                 <CardTitle className="text-base">Resources</CardTitle>
                 <CardDescription>
-                  Cached from the last successful metadata refresh. Click a resource to lazy-connect the server if needed and preview its current content in the viewer pane.
+                  Cached from the last successful metadata refresh. Standard resources open as inline previews, while `ui://` resources launch an interactive loopback viewer session in the pane.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
@@ -90,6 +90,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                   <EmptyState title="No resources discovered" body="Connect the server and refresh metadata if you expect resources here." />
                 ) : (
                   sortedResources.map((resource) => {
+                    const isUiResource = resource.uri.startsWith('ui://');
                     const isActive = viewer.pane?.kind === 'resource'
                       && viewer.pane.serverName === server.serverName
                       && viewer.activeResourceUri === resource.uri;
@@ -109,7 +110,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                             disabled={viewer.resourceLoading && isActive}
                           >
                             <RefreshCw className={cn('mr-2 h-4 w-4', viewer.resourceLoading && isActive && 'animate-spin')} />
-                            {isActive ? 'Reload' : 'Preview'}
+                            {isActive ? (isUiResource ? 'Reload UI' : 'Reload') : (isUiResource ? 'Open UI' : 'Preview')}
                           </Button>
                         </div>
                       </div>
@@ -126,7 +127,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                   UI-capable tools
                 </CardTitle>
                 <CardDescription>
-                  Tools that advertised MCP UI metadata. Launching a tool reads its advertised UI resource and opens it in the viewer pane.
+                  Tools that advertised MCP UI metadata. Launching a tool now hosts its advertised UI resource in a loopback AppBridge-style viewer session inside Sero.
                 </CardDescription>
               </CardHeader>
               <CardContent className="space-y-3">
@@ -149,7 +150,7 @@ export function McpServerDetailPanel({ server }: { server: McpServerSnapshot | n
                             type="button"
                             size="sm"
                             variant={isActive ? 'default' : 'outline'}
-                            onClick={() => void viewer.openResource(server.serverName, tool.resourceUri, { kind: 'tool-ui', title: tool.name })}
+                            onClick={() => void viewer.openResource(server.serverName, tool.resourceUri, { kind: 'tool-ui', title: tool.name, toolName: tool.name })}
                             disabled={viewer.resourceLoading && isActive}
                           >
                             <MonitorSmartphone className="mr-2 h-4 w-4" />

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
@@ -23,7 +23,7 @@ export function McpServerToolRunnerPanel({
   const helpPrompt = buildToolHelpPrompt(server, toolRunner.error, selectedTool?.name ?? null);
 
   return (
-    <Card className="border-border/70 bg-muted/15 py-4">
+    <Card className="border-border/70 bg-card py-4">
       <CardHeader>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
@@ -80,74 +80,70 @@ export function McpServerToolRunnerPanel({
               {selectedTool?.description && <p className="text-sm text-muted-foreground">{selectedTool.description}</p>}
             </div>
 
-            <div className="grid gap-4 xl:grid-cols-[1fr_0.95fr]">
-              <div className="space-y-2">
-                <div className="flex items-center justify-between gap-3">
-                  <Label htmlFor={`mcp-tool-input-${server.serverName}`}>Tool input JSON</Label>
-                  <div className="flex gap-2">
-                    {(selectedTool?.uiResourceUri || toolRunner.result?.uiResourceUri) && (
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        onClick={() => onOpenResource(selectedTool?.uiResourceUri ?? toolRunner.result?.uiResourceUri ?? '', {
-                          kind: 'tool-ui',
-                          title: selectedTool?.name ?? toolRunner.selectedToolName ?? 'Tool UI',
-                          toolName: selectedTool?.name ?? toolRunner.selectedToolName,
-                        })}
-                      >
-                        Open in viewer
-                      </Button>
-                    )}
-                    <Button type="button" size="sm" onClick={() => void toolRunner.runTool()} disabled={toolRunner.running || toolRunner.loadingDetails}>
-                      <Play className="mr-2 h-4 w-4" />
-                      {toolRunner.running ? 'Running…' : 'Run tool'}
-                    </Button>
-                  </div>
-                </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="min-w-0 space-y-2">
+                <Label htmlFor={`mcp-tool-input-${server.serverName}`}>Tool input JSON</Label>
                 <Textarea
                   id={`mcp-tool-input-${server.serverName}`}
                   value={toolRunner.inputText}
                   onChange={(event) => toolRunner.setInputText(event.target.value)}
                   spellCheck={false}
-                  className="min-h-[220px] font-mono text-xs leading-6"
+                  className="min-h-[260px] w-full font-mono text-xs leading-6"
                   placeholder="{}"
                 />
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" size="sm" onClick={() => void toolRunner.runTool()} disabled={toolRunner.running || toolRunner.loadingDetails}>
+                    <Play className="mr-2 h-4 w-4" />
+                    {toolRunner.running ? 'Running…' : 'Run tool'}
+                  </Button>
+                  {(selectedTool?.uiResourceUri || toolRunner.result?.uiResourceUri) && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => onOpenResource(selectedTool?.uiResourceUri ?? toolRunner.result?.uiResourceUri ?? '', {
+                        kind: 'tool-ui',
+                        title: selectedTool?.name ?? toolRunner.selectedToolName ?? 'Tool UI',
+                        toolName: selectedTool?.name ?? toolRunner.selectedToolName,
+                      })}
+                    >
+                      Open in viewer
+                    </Button>
+                  )}
+                </div>
               </div>
 
-              <div className="space-y-4">
-                <div className="space-y-2">
-                  <Label>Input schema</Label>
-                  <pre className="max-h-[220px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
-                    {formatUnknown(toolRunner.inputSchema ?? '(no schema reported)')}
-                  </pre>
-                </div>
-
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between gap-3">
-                    <Label>Last result</Label>
-                    {toolRunner.result && (
-                      <Button type="button" variant="outline" size="sm" onClick={toolRunner.clearResult}>
-                        <X className="mr-2 h-4 w-4" />
-                        Clear result
-                      </Button>
-                    )}
-                  </div>
-                  <pre className="max-h-[220px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
-                    {toolRunner.result ? toolRunner.result.text : 'Run a tool to inspect its latest bridged result here.'}
-                  </pre>
-                </div>
-
-                {toolRunner.result?.structuredContent !== undefined && (
-                  <div className="space-y-2">
-                    <Label>Structured content</Label>
-                    <pre className="max-h-[220px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
-                      {formatUnknown(toolRunner.result.structuredContent)}
-                    </pre>
-                  </div>
-                )}
+              <div className="min-w-0 space-y-2">
+                <Label>Input schema</Label>
+                <pre className="max-h-[260px] w-full overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+                  {formatUnknown(toolRunner.inputSchema ?? '(no schema reported)')}
+                </pre>
               </div>
             </div>
+
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <Label>Last result</Label>
+                {toolRunner.result && (
+                  <Button type="button" variant="outline" size="sm" onClick={toolRunner.clearResult}>
+                    <X className="mr-2 h-4 w-4" />
+                    Clear result
+                  </Button>
+                )}
+              </div>
+              <pre className="max-h-[260px] w-full overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+                {toolRunner.result ? toolRunner.result.text : 'Run a tool to inspect its latest bridged result here.'}
+              </pre>
+            </div>
+
+            {toolRunner.result?.structuredContent !== undefined && (
+              <div className="space-y-2">
+                <Label>Structured content</Label>
+                <pre className="max-h-[260px] w-full overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+                  {formatUnknown(toolRunner.result.structuredContent)}
+                </pre>
+              </div>
+            )}
           </>
         )}
       </CardContent>

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
@@ -1,0 +1,162 @@
+import { useAgentPrompt } from '@sero-ai/app-runtime';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { NativeSelect, NativeSelectOption } from '@sero-ai/ui/components/ui/native-select';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, LifeBuoy, Play, RefreshCw, Wrench, X } from 'lucide-react';
+import type { McpServerSnapshot } from '../../../shared/types';
+import { useMcpToolRunner } from '../../hooks/useMcpToolRunner';
+
+export function McpServerToolRunnerPanel({
+  server,
+  onOpenResource,
+}: {
+  server: McpServerSnapshot;
+  onOpenResource: (resourceUri: string) => void;
+}) {
+  const promptAgent = useAgentPrompt();
+  const toolRunner = useMcpToolRunner(server.serverName);
+  const selectedTool = toolRunner.selectedTool;
+  const helpPrompt = buildToolHelpPrompt(server, toolRunner.error, selectedTool?.name ?? null);
+
+  return (
+    <Card className="border-border/70 bg-muted/15 py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Wrench className="h-4 w-4 text-primary" />
+              Tool runner
+            </CardTitle>
+            <CardDescription>
+              Use the single bridged MCP proxy to inspect cached tools, review a selected schema, and execute a tool with structured JSON input.
+            </CardDescription>
+          </div>
+          <Button type="button" variant="outline" size="sm" onClick={() => void toolRunner.refresh()} disabled={toolRunner.loadingInventory || toolRunner.loadingDetails || toolRunner.running}>
+            <RefreshCw className={cn('mr-2 h-4 w-4', (toolRunner.loadingInventory || toolRunner.loadingDetails) && 'animate-spin')} />
+            Refresh tools
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {toolRunner.error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Tool execution problem</AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>{toolRunner.error}</p>
+              <Button type="button" size="sm" onClick={() => promptAgent(helpPrompt)}>
+                <LifeBuoy className="mr-2 h-4 w-4" />
+                Ask Sero to help
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {toolRunner.tools.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-background/40 p-4 text-sm text-muted-foreground">
+            No cached tools are available for this server yet. Connect or reconnect the server to refresh MCP tool metadata.
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2">
+              <Label htmlFor={`mcp-tool-select-${server.serverName}`}>MCP tool</Label>
+              <NativeSelect
+                id={`mcp-tool-select-${server.serverName}`}
+                value={toolRunner.selectedToolName}
+                onChange={(event) => void toolRunner.selectTool(event.target.value)}
+                disabled={toolRunner.loadingInventory || toolRunner.loadingDetails || toolRunner.running}
+                className="w-full"
+              >
+                {toolRunner.tools.map((tool) => (
+                  <NativeSelectOption key={tool.name} value={tool.name}>
+                    {tool.name}{tool.uiResourceUri ? ' · UI' : ''}
+                  </NativeSelectOption>
+                ))}
+              </NativeSelect>
+              {selectedTool?.description && <p className="text-sm text-muted-foreground">{selectedTool.description}</p>}
+            </div>
+
+            <div className="grid gap-4 xl:grid-cols-[1fr_0.95fr]">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <Label htmlFor={`mcp-tool-input-${server.serverName}`}>Tool input JSON</Label>
+                  <div className="flex gap-2">
+                    {toolRunner.result?.uiResourceUri && (
+                      <Button type="button" size="sm" variant="outline" onClick={() => onOpenResource(toolRunner.result!.uiResourceUri!)}>
+                        Open advertised UI
+                      </Button>
+                    )}
+                    <Button type="button" size="sm" onClick={() => void toolRunner.runTool()} disabled={toolRunner.running || toolRunner.loadingDetails}>
+                      <Play className="mr-2 h-4 w-4" />
+                      {toolRunner.running ? 'Running…' : 'Run tool'}
+                    </Button>
+                  </div>
+                </div>
+                <Textarea
+                  id={`mcp-tool-input-${server.serverName}`}
+                  value={toolRunner.inputText}
+                  onChange={(event) => toolRunner.setInputText(event.target.value)}
+                  spellCheck={false}
+                  className="min-h-[220px] font-mono text-xs leading-6"
+                  placeholder="{}"
+                />
+              </div>
+
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label>Input schema</Label>
+                  <pre className="max-h-[220px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+                    {formatUnknown(toolRunner.inputSchema ?? '(no schema reported)')}
+                  </pre>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <Label>Last result</Label>
+                    {toolRunner.result && (
+                      <Button type="button" variant="outline" size="sm" onClick={toolRunner.clearResult}>
+                        <X className="mr-2 h-4 w-4" />
+                        Clear result
+                      </Button>
+                    )}
+                  </div>
+                  <pre className="max-h-[260px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+                    {toolRunner.result ? toolRunner.result.text : 'Run a tool to inspect its latest bridged result here.'}
+                  </pre>
+                </div>
+              </div>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatUnknown(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function buildToolHelpPrompt(server: McpServerSnapshot, error: string | null, toolName: string | null): string {
+  return [
+    `Help me troubleshoot MCP tool execution for server "${server.serverName}" in Sero.`,
+    `Connection status: ${server.connectionStatus}`,
+    `Auth status: ${server.authStatus}`,
+    toolName ? `Selected tool: ${toolName}` : 'No tool is currently selected.',
+    '',
+    error ?? 'Explain the most likely next checks and recovery steps.',
+  ].join('\n');
+}
+
+export default McpServerToolRunnerPanel;

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
@@ -15,7 +15,7 @@ export function McpServerToolRunnerPanel({
   onOpenResource,
 }: {
   server: McpServerSnapshot;
-  onOpenResource: (resourceUri: string, options?: { kind?: 'resource' | 'tool-ui'; title?: string }) => void;
+  onOpenResource: (resourceUri: string, options?: { kind?: 'resource' | 'tool-ui'; title?: string; toolName?: string }) => void;
 }) {
   const promptAgent = useAgentPrompt();
   const toolRunner = useMcpToolRunner(server.serverName);
@@ -93,6 +93,7 @@ export function McpServerToolRunnerPanel({
                         onClick={() => onOpenResource(selectedTool?.uiResourceUri ?? toolRunner.result?.uiResourceUri ?? '', {
                           kind: 'tool-ui',
                           title: selectedTool?.name ?? toolRunner.selectedToolName ?? 'Tool UI',
+                          toolName: selectedTool?.name ?? toolRunner.selectedToolName,
                         })}
                       >
                         Open in viewer

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
@@ -85,8 +85,13 @@ export function McpServerToolRunnerPanel({
                 <div className="flex items-center justify-between gap-3">
                   <Label htmlFor={`mcp-tool-input-${server.serverName}`}>Tool input JSON</Label>
                   <div className="flex gap-2">
-                    {toolRunner.result?.uiResourceUri && (
-                      <Button type="button" size="sm" variant="outline" onClick={() => onOpenResource(toolRunner.result!.uiResourceUri!)}>
+                    {(selectedTool?.uiResourceUri || toolRunner.result?.uiResourceUri) && (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onOpenResource(selectedTool?.uiResourceUri ?? toolRunner.result?.uiResourceUri ?? '')}
+                      >
                         Open advertised UI
                       </Button>
                     )}
@@ -124,10 +129,19 @@ export function McpServerToolRunnerPanel({
                       </Button>
                     )}
                   </div>
-                  <pre className="max-h-[260px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+                  <pre className="max-h-[220px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
                     {toolRunner.result ? toolRunner.result.text : 'Run a tool to inspect its latest bridged result here.'}
                   </pre>
                 </div>
+
+                {toolRunner.result?.structuredContent !== undefined && (
+                  <div className="space-y-2">
+                    <Label>Structured content</Label>
+                    <pre className="max-h-[220px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+                      {formatUnknown(toolRunner.result.structuredContent)}
+                    </pre>
+                  </div>
+                )}
               </div>
             </div>
           </>

--- a/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/servers/McpServerToolRunnerPanel.tsx
@@ -15,7 +15,7 @@ export function McpServerToolRunnerPanel({
   onOpenResource,
 }: {
   server: McpServerSnapshot;
-  onOpenResource: (resourceUri: string) => void;
+  onOpenResource: (resourceUri: string, options?: { kind?: 'resource' | 'tool-ui'; title?: string }) => void;
 }) {
   const promptAgent = useAgentPrompt();
   const toolRunner = useMcpToolRunner(server.serverName);
@@ -90,9 +90,12 @@ export function McpServerToolRunnerPanel({
                         type="button"
                         size="sm"
                         variant="outline"
-                        onClick={() => onOpenResource(selectedTool?.uiResourceUri ?? toolRunner.result?.uiResourceUri ?? '')}
+                        onClick={() => onOpenResource(selectedTool?.uiResourceUri ?? toolRunner.result?.uiResourceUri ?? '', {
+                          kind: 'tool-ui',
+                          title: selectedTool?.name ?? toolRunner.selectedToolName ?? 'Tool UI',
+                        })}
                       >
-                        Open advertised UI
+                        Open in viewer
                       </Button>
                     )}
                     <Button type="button" size="sm" onClick={() => void toolRunner.runTool()} disabled={toolRunner.running || toolRunner.loadingDetails}>

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpAuthBrowser.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpAuthBrowser.tsx
@@ -169,10 +169,20 @@ function normalizeOrigin(origin: string): string | null {
 }
 
 function isAllowedUrl(url: URL, allowedOrigins: string[]): boolean {
+  if (isLoopbackUrl(url)) {
+    return true;
+  }
   if (!['https:', 'http:'].includes(url.protocol)) {
     return false;
   }
   return allowedOrigins.includes(url.origin);
+}
+
+function isLoopbackUrl(url: URL): boolean {
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    return false;
+  }
+  return url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]' || url.hostname === '::1';
 }
 
 export default McpAuthBrowser;

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpAuthBrowser.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpAuthBrowser.tsx
@@ -17,6 +17,7 @@ export interface McpAuthBrowserProps {
   partition?: string;
   allowedOrigins?: string[];
   onBlockedNavigation?: (url: string) => void;
+  onCallbackUrl?: (url: string) => void;
   onLoadStateChange?: (loading: boolean) => void;
   onLoadError?: (message: string) => void;
 }
@@ -27,6 +28,7 @@ export function McpAuthBrowser({
   partition = 'persist:sero-mcp-auth',
   allowedOrigins = DEFAULT_ALLOWED_ORIGINS,
   onBlockedNavigation,
+  onCallbackUrl,
   onLoadStateChange,
   onLoadError,
 }: McpAuthBrowserProps) {
@@ -55,6 +57,14 @@ export function McpAuthBrowser({
     const handleWillNavigate = (event: WebviewNavigationEvent) => {
       try {
         const parsed = new URL(event.url);
+        if (isLoopbackUrl(parsed)) {
+          event.preventDefault();
+          setLoading(false);
+          setError(null);
+          onLoadStateChange?.(false);
+          onCallbackUrl?.(event.url);
+          return;
+        }
         if (isAllowedUrl(parsed, normalizedAllowedOrigins)) return;
       } catch {
         // Invalid navigation attempts are blocked below.
@@ -95,7 +105,7 @@ export function McpAuthBrowser({
       webview.removeEventListener('did-stop-loading', handleDidStopLoading);
       webview.removeEventListener('did-fail-load', handleDidFailLoad);
     };
-  }, [initialUrl, normalizedAllowedOrigins, onBlockedNavigation, onLoadError, onLoadStateChange]);
+  }, [initialUrl, normalizedAllowedOrigins, onBlockedNavigation, onCallbackUrl, onLoadError, onLoadStateChange]);
 
   if (!src) {
     return <AuthBrowserPlaceholder message="Authentication session not started yet." className={className} />;

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpAuthBrowser.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpAuthBrowser.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, LoaderCircle } from 'lucide-react';
+
+const DEFAULT_ALLOWED_ORIGINS = [
+  'https://github.com',
+  'https://login.microsoftonline.com',
+  'https://login.live.com',
+  'https://accounts.google.com',
+  'https://auth.openai.com',
+];
+
+export interface McpAuthBrowserProps {
+  src: string | null;
+  className?: string;
+  partition?: string;
+  allowedOrigins?: string[];
+  onBlockedNavigation?: (url: string) => void;
+  onLoadStateChange?: (loading: boolean) => void;
+  onLoadError?: (message: string) => void;
+}
+
+export function McpAuthBrowser({
+  src,
+  className,
+  partition = 'persist:sero-mcp-auth',
+  allowedOrigins = DEFAULT_ALLOWED_ORIGINS,
+  onBlockedNavigation,
+  onLoadStateChange,
+  onLoadError,
+}: McpAuthBrowserProps) {
+  const webviewRef = useRef<HTMLWebViewElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const normalizedAllowedOrigins = useMemo(() => {
+    return allowedOrigins.map((origin) => normalizeOrigin(origin)).filter((origin): origin is string => !!origin);
+  }, [allowedOrigins]);
+
+  const initialUrl = useMemo(() => {
+    if (!src) return null;
+    try {
+      const parsed = new URL(src);
+      return isAllowedUrl(parsed, normalizedAllowedOrigins) ? parsed.toString() : null;
+    } catch {
+      return null;
+    }
+  }, [normalizedAllowedOrigins, src]);
+
+  useEffect(() => {
+    const webview = webviewRef.current;
+    if (!webview || !initialUrl) return;
+
+    const handleWillNavigate = (event: WebviewNavigationEvent) => {
+      try {
+        const parsed = new URL(event.url);
+        if (isAllowedUrl(parsed, normalizedAllowedOrigins)) return;
+      } catch {
+        // Invalid navigation attempts are blocked below.
+      }
+
+      event.preventDefault();
+      setError(`Blocked navigation to ${event.url}`);
+      onBlockedNavigation?.(event.url);
+    };
+
+    const handleDidStartLoading = () => {
+      setLoading(true);
+      setError(null);
+      onLoadStateChange?.(true);
+    };
+
+    const handleDidStopLoading = () => {
+      setLoading(false);
+      onLoadStateChange?.(false);
+    };
+
+    const handleDidFailLoad = (event: WebviewLoadErrorEvent) => {
+      const message = event.errorDescription || 'Auth page failed to load.';
+      setError(message);
+      setLoading(false);
+      onLoadStateChange?.(false);
+      onLoadError?.(message);
+    };
+
+    webview.addEventListener('will-navigate', handleWillNavigate);
+    webview.addEventListener('did-start-loading', handleDidStartLoading);
+    webview.addEventListener('did-stop-loading', handleDidStopLoading);
+    webview.addEventListener('did-fail-load', handleDidFailLoad);
+
+    return () => {
+      webview.removeEventListener('will-navigate', handleWillNavigate);
+      webview.removeEventListener('did-start-loading', handleDidStartLoading);
+      webview.removeEventListener('did-stop-loading', handleDidStopLoading);
+      webview.removeEventListener('did-fail-load', handleDidFailLoad);
+    };
+  }, [initialUrl, normalizedAllowedOrigins, onBlockedNavigation, onLoadError, onLoadStateChange]);
+
+  if (!src) {
+    return <AuthBrowserPlaceholder message="Authentication session not started yet." className={className} />;
+  }
+
+  if (!initialUrl) {
+    return (
+      <AuthBrowserPlaceholder
+        className={className}
+        message="The requested authentication URL is invalid or outside the MCP auth allowlist."
+      />
+    );
+  }
+
+  return (
+    <div className={cn('relative h-full min-h-0 w-full overflow-hidden rounded-xl border border-border bg-card', className)}>
+      {loading && (
+        <div className="absolute inset-x-0 top-0 z-10 flex items-center gap-2 border-b border-border bg-background/95 px-3 py-2 text-xs text-muted-foreground backdrop-blur">
+          <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+          Loading authentication page…
+        </div>
+      )}
+
+      {error && (
+        <div className="absolute inset-x-3 top-3 z-10">
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Authentication browser warning</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      <webview
+        ref={(node) => {
+          webviewRef.current = node;
+        }}
+        src={initialUrl}
+        partition={partition}
+        allowpopups={false}
+        webpreferences="contextIsolation=yes,nodeIntegration=no,javascript=yes"
+        className="h-full w-full bg-background"
+      />
+    </div>
+  );
+}
+
+function AuthBrowserPlaceholder({
+  message,
+  className,
+}: {
+  message: string;
+  className?: string;
+}) {
+  return (
+    <div className={cn('flex h-full w-full items-center justify-center rounded-xl border border-dashed border-border bg-muted/20 p-6 text-center', className)}>
+      <div className="max-w-md space-y-2">
+        <div className="text-sm font-medium text-foreground">Embedded auth browser</div>
+        <p className="text-sm text-muted-foreground">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function normalizeOrigin(origin: string): string | null {
+  try {
+    return new URL(origin).origin;
+  } catch {
+    return null;
+  }
+}
+
+function isAllowedUrl(url: URL, allowedOrigins: string[]): boolean {
+  if (!['https:', 'http:'].includes(url.protocol)) {
+    return false;
+  }
+  return allowedOrigins.includes(url.origin);
+}
+
+export default McpAuthBrowser;

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { McpResourceViewer } from './McpResourceViewer';
+
+describe('McpResourceViewer', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container.remove();
+    root = null;
+    Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
+  });
+
+  it('grants the loopback viewer shell same-origin access while keeping it sandboxed', async () => {
+    await act(async () => {
+      root?.render(
+        <McpResourceViewer
+          preview={null}
+          loading={false}
+          kind="resource"
+          session={{
+            sessionId: 'session-1',
+            viewerUrl: 'http://127.0.0.1:43123/?session=session-1',
+            resourceUri: 'ui://demo/dashboard',
+            kind: 'resource',
+          }}
+        />,
+      );
+    });
+
+    const iframe = container.querySelector('iframe');
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('sandbox')).toBe(
+      'allow-same-origin allow-scripts allow-forms allow-popups allow-downloads',
+    );
+  });
+});

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
@@ -31,7 +31,10 @@ export function McpResourceViewer({
         <iframe
           title={session.resourceUri}
           src={session.viewerUrl}
-          sandbox="allow-scripts allow-forms allow-popups allow-downloads"
+          // The localhost viewer shell needs same-origin access so its bridge
+          // host can fetch its own /proxy/* endpoints. The nested MCP UI frame
+          // inside that shell remains sandboxed without allow-same-origin.
+          sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-downloads"
           referrerPolicy="no-referrer"
           className="h-[560px] w-full rounded-lg border border-border bg-background"
         />

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
@@ -1,0 +1,100 @@
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { cn } from '@sero-ai/ui/lib/utils';
+import type { McpResourcePreview } from '../../../shared/types';
+import type { McpViewerKind } from '../../hooks/useMcpViewer';
+
+export function McpResourceViewer({
+  preview,
+  loading,
+  kind,
+}: {
+  preview: McpResourcePreview | null;
+  loading: boolean;
+  kind: Exclude<McpViewerKind, 'auth'>;
+}) {
+  if (loading && !preview) {
+    return <ViewerPlaceholder body="Loading MCP content…" />;
+  }
+
+  if (!preview) {
+    return (
+      <ViewerPlaceholder
+        body={
+          kind === 'tool-ui'
+            ? 'Launch a UI-capable tool or open an advertised MCP UI resource to render it here.'
+            : 'Select a discovered resource to preview it here.'
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+        <ToneBadge label={kind === 'tool-ui' ? 'tool ui' : preview.previewKind} tone="muted" />
+        {kind === 'tool-ui' && <ToneBadge label={preview.previewKind} tone="muted" />}
+        <ToneBadge label={preview.mimeType ?? 'unknown mime'} tone="muted" />
+        <span className="rounded-full border border-border bg-background px-2 py-0.5">{preview.resolvedUri}</span>
+        {preview.truncated && <ToneBadge label="preview truncated" tone="warning" />}
+      </div>
+
+      {kind === 'tool-ui' && (
+        <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-xs leading-6 text-muted-foreground">
+          This UI is currently rendered from the tool&apos;s advertised MCP resource. Full AppBridge-backed interactive hosting is a larger follow-on slice.
+        </div>
+      )}
+
+      {preview.previewKind === 'html' ? (
+        <iframe
+          title={preview.resolvedUri}
+          srcDoc={preview.html ?? ''}
+          sandbox="allow-scripts allow-forms"
+          className="h-[520px] w-full rounded-lg border border-border bg-white"
+        />
+      ) : preview.previewKind === 'image' ? (
+        <div className="overflow-hidden rounded-lg border border-border bg-background p-3">
+          {preview.dataUrl ? (
+            <img src={preview.dataUrl} alt={preview.resolvedUri} className="max-h-[520px] w-full object-contain" />
+          ) : (
+            <ViewerPlaceholder body="This image resource did not return a renderable payload." compact />
+          )}
+        </div>
+      ) : preview.previewKind === 'binary' ? (
+        <ViewerPlaceholder body="This resource returned binary content that cannot be previewed inline yet." compact />
+      ) : (
+        <pre className="max-h-[520px] overflow-auto rounded-lg border border-border bg-background p-4 text-xs leading-6 text-muted-foreground">
+          {preview.text || '(empty resource)'}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function ViewerPlaceholder({ body, compact = false }: { body: string; compact?: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-center rounded-lg border border-dashed border-border bg-background/60 p-6 text-center text-sm text-muted-foreground',
+        compact ? 'min-h-[180px]' : 'min-h-[280px]',
+      )}
+    >
+      <div className="max-w-md">{body}</div>
+    </div>
+  );
+}
+
+function ToneBadge({ label, tone }: { label: string; tone: 'warning' | 'muted' }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+        tone === 'muted' && 'border-border bg-background text-muted-foreground',
+      )}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+export default McpResourceViewer;

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
@@ -31,7 +31,7 @@ export function McpResourceViewer({
         <iframe
           title={session.resourceUri}
           src={session.viewerUrl}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
+          sandbox="allow-scripts allow-forms allow-popups allow-downloads"
           referrerPolicy="no-referrer"
           className="h-[560px] w-full rounded-lg border border-border bg-background"
         />

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpResourceViewer.tsx
@@ -1,19 +1,42 @@
 import { Badge } from '@sero-ai/ui/components/ui/badge';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { McpResourcePreview } from '../../../shared/types';
-import type { McpViewerKind } from '../../hooks/useMcpViewer';
+import type { McpViewerKind, McpViewerSession } from '../../hooks/useMcpViewer';
 
 export function McpResourceViewer({
   preview,
+  session,
   loading,
   kind,
 }: {
   preview: McpResourcePreview | null;
+  session: McpViewerSession | null;
   loading: boolean;
   kind: Exclude<McpViewerKind, 'auth'>;
 }) {
-  if (loading && !preview) {
+  if (loading && !preview && !session) {
     return <ViewerPlaceholder body="Loading MCP content…" />;
+  }
+
+  if (session) {
+    return (
+      <div className="space-y-3">
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <ToneBadge label={kind === 'tool-ui' ? 'interactive tool ui' : 'interactive ui resource'} tone="success" />
+          <ToneBadge label={session.resourceUri} tone="muted" />
+        </div>
+        <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-xs leading-6 text-muted-foreground">
+          This MCP UI is running inside a loopback viewer session so AppBridge-style tool and resource calls stay in-plugin and ephemeral.
+        </div>
+        <iframe
+          title={session.resourceUri}
+          src={session.viewerUrl}
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-downloads"
+          referrerPolicy="no-referrer"
+          className="h-[560px] w-full rounded-lg border border-border bg-background"
+        />
+      </div>
+    );
   }
 
   if (!preview) {
@@ -21,7 +44,7 @@ export function McpResourceViewer({
       <ViewerPlaceholder
         body={
           kind === 'tool-ui'
-            ? 'Launch a UI-capable tool or open an advertised MCP UI resource to render it here.'
+            ? 'Launch a UI-capable tool to host its interactive MCP UI here.'
             : 'Select a discovered resource to preview it here.'
         }
       />
@@ -31,18 +54,12 @@ export function McpResourceViewer({
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-        <ToneBadge label={kind === 'tool-ui' ? 'tool ui' : preview.previewKind} tone="muted" />
+        <ToneBadge label={kind === 'tool-ui' ? 'tool ui preview' : preview.previewKind} tone="muted" />
         {kind === 'tool-ui' && <ToneBadge label={preview.previewKind} tone="muted" />}
         <ToneBadge label={preview.mimeType ?? 'unknown mime'} tone="muted" />
         <span className="rounded-full border border-border bg-background px-2 py-0.5">{preview.resolvedUri}</span>
         {preview.truncated && <ToneBadge label="preview truncated" tone="warning" />}
       </div>
-
-      {kind === 'tool-ui' && (
-        <div className="rounded-lg border border-border/70 bg-muted/20 p-3 text-xs leading-6 text-muted-foreground">
-          This UI is currently rendered from the tool&apos;s advertised MCP resource. Full AppBridge-backed interactive hosting is a larger follow-on slice.
-        </div>
-      )}
 
       {preview.previewKind === 'html' ? (
         <iframe
@@ -83,11 +100,12 @@ function ViewerPlaceholder({ body, compact = false }: { body: string; compact?: 
   );
 }
 
-function ToneBadge({ label, tone }: { label: string; tone: 'warning' | 'muted' }) {
+function ToneBadge({ label, tone }: { label: string; tone: 'success' | 'warning' | 'muted' }) {
   return (
     <Badge
       variant="outline"
       className={cn(
+        tone === 'success' && 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
         tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
         tone === 'muted' && 'border-border bg-background text-muted-foreground',
       )}

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpResourcePreview } from '../../../shared/types';
+import type { McpViewerState } from '../../hooks/useMcpViewer';
+import { McpViewerPane } from './McpViewerPane';
+
+const promptAgentMock = vi.fn();
+
+vi.mock('@sero-ai/app-runtime', () => ({
+  useAgentPrompt: () => promptAgentMock,
+}));
+
+vi.mock('./McpAuthBrowser', () => ({
+  McpAuthBrowser: ({ src }: { src: string }) => <div>auth-browser:{src}</div>,
+}));
+
+vi.mock('./McpResourceViewer', () => ({
+  McpResourceViewer: ({ kind }: { kind: string }) => <div>resource-viewer:{kind}</div>,
+}));
+
+describe('McpViewerPane', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    promptAgentMock.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container.remove();
+    root = null;
+    promptAgentMock.mockReset();
+    Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
+  });
+
+  it('renders the auth browser in the dedicated auth pane and lets the user clear it', async () => {
+    const clearPane = vi.fn();
+
+    await act(async () => {
+      root?.render(<McpViewerPane viewer={createViewerState({
+        pane: { kind: 'auth', serverName: 'github', title: 'Authenticate github' },
+        authSession: { serverName: 'github', authUrl: 'https://github.com/login/oauth/authorize' },
+        clearPane,
+      })} />);
+    });
+
+    expect(container.textContent).toContain('auth-browser:https://github.com/login/oauth/authorize');
+
+    await act(async () => {
+      clickButton(container, 'Clear pane');
+    });
+
+    expect(clearPane).toHaveBeenCalled();
+  });
+
+  it('uses Ask Sero recovery copy for viewer failures', async () => {
+    const preview: McpResourcePreview = {
+      serverName: 'github',
+      requestedUri: 'file://README.md',
+      resolvedUri: 'file://README.md',
+      previewKind: 'text',
+      text: 'hello',
+      truncated: false,
+    };
+
+    await act(async () => {
+      root?.render(<McpViewerPane viewer={createViewerState({
+        pane: { kind: 'resource', serverName: 'github', title: 'README' },
+        preview,
+        activeResourceUri: 'file://README.md',
+        resourceError: 'Preview failed',
+      })} />);
+    });
+
+    await act(async () => {
+      clickButton(container, 'Ask Sero to help');
+    });
+
+    expect(promptAgentMock).toHaveBeenCalledWith(expect.stringContaining('Server: github'));
+    expect(promptAgentMock).toHaveBeenCalledWith(expect.stringContaining('file://README.md'));
+  });
+});
+
+function createViewerState(overrides: Partial<McpViewerState>): McpViewerState {
+  return {
+    pane: null,
+    preview: null,
+    activeResourceUri: null,
+    resourceLoading: false,
+    resourceError: null,
+    authSession: null,
+    authLoading: false,
+    authError: null,
+    setAuthError: vi.fn(),
+    openResource: vi.fn(async () => undefined),
+    startAuth: vi.fn(async () => true),
+    completeAuth: vi.fn(async () => true),
+    cancelAuth: vi.fn(async () => true),
+    clearAuth: vi.fn(async () => true),
+    focusAuthSession: vi.fn(),
+    clearPane: vi.fn(),
+    ...overrides,
+  };
+}
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes(label));
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`);
+  }
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.test.tsx
@@ -94,6 +94,7 @@ describe('McpViewerPane', () => {
 function createViewerState(overrides: Partial<McpViewerState>): McpViewerState {
   return {
     pane: null,
+    session: null,
     preview: null,
     activeResourceUri: null,
     resourceLoading: false,

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.tsx
@@ -1,0 +1,174 @@
+import { useMemo } from 'react';
+import { useAgentPrompt } from '@sero-ai/app-runtime';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, LifeBuoy, MonitorSmartphone, ShieldCheck, X } from 'lucide-react';
+import type { McpViewerKind, McpViewerState } from '../../hooks/useMcpViewer';
+import { McpAuthBrowser } from './McpAuthBrowser';
+import { McpResourceViewer } from './McpResourceViewer';
+
+export function McpViewerPane({ viewer }: { viewer: McpViewerState }) {
+  const promptAgent = useAgentPrompt();
+  const authSession = viewer.authSession;
+  const authOrigin = useMemo(() => {
+    if (!authSession?.authUrl) {
+      return null;
+    }
+    try {
+      return new URL(authSession.authUrl).origin;
+    } catch {
+      return null;
+    }
+  }, [authSession?.authUrl]);
+  const allowedOrigins = authOrigin ? [authOrigin] : [];
+  const activeKind = viewer.pane?.kind ?? null;
+  const error = activeKind === 'auth' ? viewer.authError : viewer.resourceError;
+  const helpPrompt = buildViewerHelpPrompt({
+    kind: activeKind,
+    serverName: viewer.pane?.serverName ?? authSession?.serverName ?? viewer.preview?.serverName ?? null,
+    error,
+    resourceUri: viewer.preview?.resolvedUri ?? viewer.activeResourceUri,
+    authOrigin,
+  });
+
+  return (
+    <Card className="border-border/70 bg-muted/15 py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-base">
+              {activeKind === 'auth' ? <ShieldCheck className="h-4 w-4 text-primary" /> : <MonitorSmartphone className="h-4 w-4 text-primary" />}
+              {getPaneTitle(viewer)}
+            </CardTitle>
+            <CardDescription>{getPaneDescription(activeKind)}</CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            {viewer.pane && <ToneBadge label={viewer.pane.kind} tone="muted" />}
+            {viewer.pane?.serverName && <ToneBadge label={viewer.pane.serverName} tone="muted" />}
+            {authSession && activeKind !== 'auth' && <ToneBadge label={`auth active for ${authSession.serverName}`} tone="warning" />}
+            {viewer.pane && (
+              <Button type="button" variant="outline" size="sm" onClick={viewer.clearPane}>
+                <X className="mr-2 h-4 w-4" />
+                Clear pane
+              </Button>
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>{activeKind === 'auth' ? 'Auth browser problem' : 'Viewer problem'}</AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>{error}</p>
+              <Button type="button" size="sm" onClick={() => promptAgent(helpPrompt)}>
+                <LifeBuoy className="mr-2 h-4 w-4" />
+                Ask Sero to help
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {activeKind === 'auth' ? (
+          authSession ? (
+            <div className="space-y-3">
+              <McpAuthBrowser
+                src={authSession.authUrl}
+                allowedOrigins={allowedOrigins}
+                className="h-[520px]"
+                onBlockedNavigation={(url) => viewer.setAuthError(`Blocked auth navigation to ${url}`)}
+                onLoadError={viewer.setAuthError}
+                onCallbackUrl={(callbackUrl) => {
+                  void viewer.completeAuth(authSession.serverName, callbackUrl);
+                }}
+              />
+              <p className="text-xs leading-6 text-muted-foreground">
+                Only the active provider origin and the loopback callback are allowed in this embedded browser session.
+              </p>
+            </div>
+          ) : (
+            <PanePlaceholder message={viewer.authLoading ? 'Starting authentication session…' : 'Start authentication from an OAuth-backed server to open the sign-in flow here.'} />
+          )
+        ) : activeKind === 'resource' || activeKind === 'tool-ui' ? (
+          <McpResourceViewer preview={viewer.preview} loading={viewer.resourceLoading} kind={activeKind} />
+        ) : (
+          <PanePlaceholder message="Resources, advertised tool UIs, and OAuth sign-in flows open here so you can stay inside Sero while managing MCP servers." />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PanePlaceholder({ message }: { message: string }) {
+  return (
+    <div className="flex min-h-[320px] items-center justify-center rounded-lg border border-dashed border-border bg-background/60 p-6 text-center text-sm text-muted-foreground">
+      <div className="max-w-md">{message}</div>
+    </div>
+  );
+}
+
+function ToneBadge({ label, tone }: { label: string; tone: 'warning' | 'muted' }) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        tone === 'warning' && 'border-amber-500/30 bg-amber-500/10 text-amber-300',
+        tone === 'muted' && 'border-border bg-background text-muted-foreground',
+      )}
+    >
+      {label}
+    </Badge>
+  );
+}
+
+function getPaneTitle(viewer: McpViewerState): string {
+  if (!viewer.pane) {
+    return 'Viewer & auth pane';
+  }
+  if (viewer.pane.kind === 'auth') {
+    return viewer.pane.title ?? `Authenticate ${viewer.pane.serverName}`;
+  }
+  return viewer.pane.title ?? (viewer.pane.kind === 'tool-ui' ? 'Tool UI' : 'Resource preview');
+}
+
+function getPaneDescription(kind: McpViewerKind | null): string {
+  switch (kind) {
+    case 'auth':
+      return 'OAuth providers open in a hardened embedded browser so sign-in can complete without leaving Sero.';
+    case 'tool-ui':
+      return 'Advertised MCP tool UIs render here from their backing resources so you can inspect tool surfaces in context.';
+    case 'resource':
+      return 'Discovered MCP resources render here with inline previews for HTML, text, JSON, and images.';
+    default:
+      return 'Use the selected server detail view to open resources, launch advertised UIs, or complete OAuth authentication here.';
+  }
+}
+
+function buildViewerHelpPrompt({
+  kind,
+  serverName,
+  error,
+  resourceUri,
+  authOrigin,
+}: {
+  kind: McpViewerKind | null;
+  serverName: string | null;
+  error: string | null;
+  resourceUri: string | null;
+  authOrigin: string | null;
+}): string {
+  return [
+    `Help me troubleshoot the MCP ${kind ?? 'viewer'} pane in Sero.`,
+    serverName ? `Server: ${serverName}` : 'Server: unknown',
+    resourceUri ? `Resource/UI URI: ${resourceUri}` : 'No resource or UI is currently loaded.',
+    authOrigin ? `Auth origin: ${authOrigin}` : 'No auth browser origin is active.',
+    '',
+    error ?? 'Explain the most likely next checks and recovery steps.',
+  ].join('\n');
+}
+
+export default McpViewerPane;

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.tsx
@@ -35,7 +35,7 @@ export function McpViewerPane({ viewer }: { viewer: McpViewerState }) {
   });
 
   return (
-    <Card className="border-border/70 bg-muted/15 py-4">
+    <Card className="border-border/70 bg-card py-4">
       <CardHeader>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>

--- a/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/viewer/McpViewerPane.tsx
@@ -30,7 +30,7 @@ export function McpViewerPane({ viewer }: { viewer: McpViewerState }) {
     kind: activeKind,
     serverName: viewer.pane?.serverName ?? authSession?.serverName ?? viewer.preview?.serverName ?? null,
     error,
-    resourceUri: viewer.preview?.resolvedUri ?? viewer.activeResourceUri,
+    resourceUri: viewer.preview?.resolvedUri ?? viewer.session?.resourceUri ?? viewer.activeResourceUri,
     authOrigin,
   });
 
@@ -50,7 +50,7 @@ export function McpViewerPane({ viewer }: { viewer: McpViewerState }) {
             {viewer.pane?.serverName && <ToneBadge label={viewer.pane.serverName} tone="muted" />}
             {authSession && activeKind !== 'auth' && <ToneBadge label={`auth active for ${authSession.serverName}`} tone="warning" />}
             {viewer.pane && (
-              <Button type="button" variant="outline" size="sm" onClick={viewer.clearPane}>
+              <Button type="button" variant="outline" size="sm" onClick={() => viewer.clearPane()}>
                 <X className="mr-2 h-4 w-4" />
                 Clear pane
               </Button>
@@ -94,7 +94,7 @@ export function McpViewerPane({ viewer }: { viewer: McpViewerState }) {
             <PanePlaceholder message={viewer.authLoading ? 'Starting authentication session…' : 'Start authentication from an OAuth-backed server to open the sign-in flow here.'} />
           )
         ) : activeKind === 'resource' || activeKind === 'tool-ui' ? (
-          <McpResourceViewer preview={viewer.preview} loading={viewer.resourceLoading} kind={activeKind} />
+          <McpResourceViewer preview={viewer.preview} session={viewer.session} loading={viewer.resourceLoading} kind={activeKind} />
         ) : (
           <PanePlaceholder message="Resources, advertised tool UIs, and OAuth sign-in flows open here so you can stay inside Sero while managing MCP servers." />
         )}
@@ -140,9 +140,9 @@ function getPaneDescription(kind: McpViewerKind | null): string {
     case 'auth':
       return 'OAuth providers open in a hardened embedded browser so sign-in can complete without leaving Sero.';
     case 'tool-ui':
-      return 'Advertised MCP tool UIs render here from their backing resources so you can inspect tool surfaces in context.';
+      return 'Advertised MCP tool UIs render here through loopback AppBridge-style sessions so they can call tools and resources without leaving Sero.';
     case 'resource':
-      return 'Discovered MCP resources render here with inline previews for HTML, text, JSON, and images.';
+      return 'Discovered MCP resources render here with inline previews for text/image content and interactive hosting for MCP UI resources.';
     default:
       return 'Use the selected server detail view to open resources, launch advertised UIs, or complete OAuth authentication here.';
   }

--- a/plugins/sero-mcp-plugin/ui/components/wizard/McpSetupWizard.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/wizard/McpSetupWizard.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppToolResult } from '@sero-ai/common';
+import { McpSetupWizard } from './McpSetupWizard';
+
+const useAppToolsMock = vi.fn();
+const runMock = vi.fn<(
+  toolName: string,
+  params?: Record<string, unknown>,
+) => Promise<AppToolResult>>();
+
+vi.mock('@sero-ai/app-runtime', () => ({
+  useAppTools: () => useAppToolsMock(),
+}));
+
+describe('McpSetupWizard', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    Reflect.set(globalThis, 'IS_REACT_ACT_ENVIRONMENT', true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    runMock.mockReset();
+    runMock.mockResolvedValue({ text: 'saved', content: [{ type: 'text', text: 'saved' }], details: null, isError: false });
+    useAppToolsMock.mockReturnValue({ run: runMock });
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root?.unmount();
+    });
+    container.remove();
+    root = null;
+    runMock.mockReset();
+    useAppToolsMock.mockReset();
+    Reflect.deleteProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT');
+  });
+
+  it('saves the guided draft through mcp_manager and reports the created server name', async () => {
+    const onCreated = vi.fn();
+
+    await act(async () => {
+      root?.render(
+        <McpSetupWizard
+          configPath="/tmp/sero/apps/mcp/config.json"
+          settings={{ idleTimeout: 10, toolPrefix: 'server' }}
+          onCreated={onCreated}
+        />,
+      );
+    });
+
+    await act(async () => {
+      clickButton(container, 'Filesystem example');
+    });
+
+    await act(async () => {
+      clickButton(container, 'Save first server');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runMock).toHaveBeenCalledWith('mcp_manager', expect.objectContaining({
+      action: 'upsert_server',
+      serverName: 'filesystem',
+      command: 'npx',
+      transport: 'stdio',
+    }));
+    expect(onCreated).toHaveBeenCalledWith('filesystem');
+  });
+});
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes(label));
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Button not found: ${label}`);
+  }
+  button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+

--- a/plugins/sero-mcp-plugin/ui/components/wizard/McpSetupWizard.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/wizard/McpSetupWizard.tsx
@@ -129,7 +129,7 @@ export function McpSetupWizard({ configPath, settings, onCreated }: McpSetupWiza
   };
 
   return (
-    <Card className="animate-mcp-fade-in py-4">
+    <Card className="animate-mcp-fade-in border-border/75 py-4">
       <CardHeader>
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>

--- a/plugins/sero-mcp-plugin/ui/components/wizard/McpSetupWizard.tsx
+++ b/plugins/sero-mcp-plugin/ui/components/wizard/McpSetupWizard.tsx
@@ -1,0 +1,379 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@sero-ai/ui/components/ui/card';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import { NativeSelect, NativeSelectOption } from '@sero-ai/ui/components/ui/native-select';
+import { Textarea } from '@sero-ai/ui/components/ui/textarea';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { AlertCircle, ArrowRight, Globe, HardDriveDownload, Save, Sparkles, Terminal } from 'lucide-react';
+import type { McpServerEditorInput, McpSettingsSnapshot, McpTransport } from '../../../shared/types';
+import { createEmptyServerEditorInput, validateServerEditorInput } from '../../../shared/types';
+import { useMcpServerMutations } from '../../hooks/useMcpServerMutations';
+
+interface McpSetupWizardProps {
+  configPath: string | null;
+  settings: McpSettingsSnapshot;
+  onCreated?: (serverName: string) => void;
+}
+
+interface McpWizardPreset {
+  id: string;
+  transport: McpTransport;
+  label: string;
+  summary: string;
+  badge?: string;
+  draft: McpServerEditorInput;
+}
+
+const WIZARD_PRESETS: McpWizardPreset[] = [
+  {
+    id: 'stdio-blank',
+    transport: 'stdio',
+    label: 'Blank stdio server',
+    summary: 'Start from scratch with a local command and arguments.',
+    draft: createPresetDraft({ transport: 'stdio' }),
+  },
+  {
+    id: 'stdio-filesystem',
+    transport: 'stdio',
+    label: 'Filesystem example',
+    summary: 'A practical local server for browsing files in a project folder.',
+    badge: 'example',
+    draft: createPresetDraft({
+      transport: 'stdio',
+      serverName: 'filesystem',
+      command: 'npx',
+      argsText: '-y\n@modelcontextprotocol/server-filesystem\n.',
+      cwd: '.',
+      lifecycle: 'keep-alive',
+    }),
+  },
+  {
+    id: 'stdio-github',
+    transport: 'stdio',
+    label: 'GitHub example',
+    summary: 'A common remote API adapter that uses a bearer token env var.',
+    badge: 'example',
+    draft: createPresetDraft({
+      transport: 'stdio',
+      serverName: 'github',
+      command: 'npx',
+      argsText: '-y\n@modelcontextprotocol/server-github',
+      authMode: 'bearer',
+      bearerTokenEnv: 'GITHUB_TOKEN',
+      lifecycle: 'eager',
+    }),
+  },
+  {
+    id: 'http-blank',
+    transport: 'http',
+    label: 'Blank HTTP/SSE server',
+    summary: 'Start from scratch with a hosted MCP endpoint.',
+    draft: createPresetDraft({ transport: 'http', authMode: 'none' }),
+  },
+  {
+    id: 'http-oauth',
+    transport: 'http',
+    label: 'Hosted OAuth example',
+    summary: 'A good default when the server authenticates in-browser.',
+    badge: 'recommended',
+    draft: createPresetDraft({
+      transport: 'http',
+      serverName: 'remote-oauth',
+      url: 'https://example.com/mcp',
+      authMode: 'oauth',
+      lifecycle: 'eager',
+    }),
+  },
+  {
+    id: 'http-bearer',
+    transport: 'http',
+    label: 'Hosted bearer-token example',
+    summary: 'A good fit for internal or vendor MCP endpoints that use env-based auth.',
+    badge: 'example',
+    draft: createPresetDraft({
+      transport: 'http',
+      serverName: 'internal-api',
+      url: 'https://example.com/mcp',
+      authMode: 'bearer',
+      bearerTokenEnv: 'API_TOKEN',
+      lifecycle: 'eager',
+    }),
+  },
+];
+
+export function McpSetupWizard({ configPath, settings, onCreated }: McpSetupWizardProps) {
+  const mutations = useMcpServerMutations();
+  const [transport, setTransport] = useState<McpTransport>('stdio');
+  const [selectedPresetId, setSelectedPresetId] = useState('stdio-blank');
+  const [draft, setDraft] = useState<McpServerEditorInput>(() => getPresetDraft('stdio-blank'));
+  const validationError = useMemo(() => validateServerEditorInput(draft), [draft]);
+  const transportPresets = useMemo(
+    () => WIZARD_PRESETS.filter((preset) => preset.transport === transport),
+    [transport],
+  );
+
+  const applyPreset = (presetId: string) => {
+    setSelectedPresetId(presetId);
+    setDraft(getPresetDraft(presetId));
+  };
+
+  const handleTransportChange = (nextTransport: McpTransport) => {
+    setTransport(nextTransport);
+    const nextPresetId = nextTransport === 'stdio' ? 'stdio-blank' : 'http-blank';
+    setSelectedPresetId(nextPresetId);
+    setDraft(getPresetDraft(nextPresetId));
+  };
+
+  return (
+    <Card className="animate-mcp-fade-in py-4">
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-primary" />
+              First-run setup wizard
+            </CardTitle>
+            <CardDescription>
+              Pick a transport, start from a blank config or a friendly example, then save your first MCP server without dropping into raw JSON.
+            </CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <StepBadge label="1. Choose transport" />
+            <StepBadge label="2. Pick a starting point" />
+            <StepBadge label="3. Save your first server" />
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {(mutations.error || validationError) && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Wizard blocked</AlertTitle>
+            <AlertDescription>{validationError ?? mutations.error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="grid gap-4 xl:grid-cols-[1.05fr_1.35fr]">
+          <section className="space-y-4">
+            <div className="space-y-3 rounded-xl border border-border bg-muted/20 p-4">
+              <div className="space-y-1">
+                <div className="text-sm font-medium text-foreground">Choose your server type</div>
+                <p className="text-sm text-muted-foreground">
+                  Use <strong>stdio</strong> for a local command you launch from this machine, or <strong>HTTP/SSE</strong> for a hosted MCP endpoint.
+                </p>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2">
+                <TransportButton
+                  active={transport === 'stdio'}
+                  icon={Terminal}
+                  title="stdio"
+                  body="Launch a local command like npx, uvx, or a checked-in project script."
+                  onClick={() => handleTransportChange('stdio')}
+                />
+                <TransportButton
+                  active={transport === 'http'}
+                  icon={Globe}
+                  title="HTTP / SSE"
+                  body="Connect to a hosted MCP service over http or https, with OAuth or bearer auth if needed."
+                  onClick={() => handleTransportChange('http')}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3 rounded-xl border border-border bg-muted/20 p-4">
+              <div className="space-y-1">
+                <div className="text-sm font-medium text-foreground">Choose a starting point</div>
+                <p className="text-sm text-muted-foreground">
+                  Blank presets keep things simple. Example presets are safe starting templates you can edit before saving.
+                </p>
+              </div>
+              <div className="space-y-2">
+                {transportPresets.map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    className={cn(
+                      'w-full rounded-lg border p-3 text-left transition-colors',
+                      selectedPresetId === preset.id ? 'border-primary/40 bg-primary/5' : 'border-border bg-background hover:bg-muted/40',
+                    )}
+                    onClick={() => applyPreset(preset.id)}
+                  >
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium text-foreground">{preset.label}</span>
+                      {preset.badge && <Badge variant="secondary">{preset.badge}</Badge>}
+                    </div>
+                    <p className="mt-1 text-sm text-muted-foreground">{preset.summary}</p>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+              <div className="font-medium text-foreground">What happens next?</div>
+              <ul className="mt-2 space-y-2 leading-6">
+                <li>• Your config lives at <span className="font-mono text-foreground">{configPath ?? 'pending bootstrap'}</span>.</li>
+                <li>• New servers start with an idle timeout of <strong>{settings.idleTimeout} minutes</strong>.</li>
+                <li>• You can fine-tune lifecycle, auth, raw config, and diagnostics after this first save.</li>
+              </ul>
+            </div>
+          </section>
+
+          <section className="space-y-4 rounded-xl border border-border bg-background/70 p-4">
+            <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <HardDriveDownload className="h-4 w-4 text-primary" />
+              Guided server draft
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Field label="Server name">
+                <Input value={draft.serverName} onChange={(event) => setDraft({ ...draft, serverName: event.target.value })} placeholder={transport === 'stdio' ? 'filesystem' : 'remote-oauth'} />
+              </Field>
+              <Field label="Lifecycle">
+                <NativeSelect value={draft.lifecycle} onChange={(event) => setDraft({ ...draft, lifecycle: event.target.value as McpServerEditorInput['lifecycle'] })} className="w-full">
+                  <NativeSelectOption value="lazy">lazy</NativeSelectOption>
+                  <NativeSelectOption value="eager">eager</NativeSelectOption>
+                  <NativeSelectOption value="keep-alive">keep-alive</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              <Field label="Auth mode">
+                <NativeSelect value={draft.authMode} onChange={(event) => setDraft({ ...draft, authMode: event.target.value as McpServerEditorInput['authMode'] })} className="w-full">
+                  <NativeSelectOption value="none">none</NativeSelectOption>
+                  <NativeSelectOption value="oauth">oauth</NativeSelectOption>
+                  <NativeSelectOption value="bearer">bearer</NativeSelectOption>
+                </NativeSelect>
+              </Field>
+              {draft.authMode === 'bearer' && (
+                <Field label="Bearer token env var">
+                  <Input value={draft.bearerTokenEnv} onChange={(event) => setDraft({ ...draft, bearerTokenEnv: event.target.value })} placeholder="GITHUB_TOKEN" />
+                </Field>
+              )}
+            </div>
+
+            {transport === 'stdio' ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                <Field label="Command">
+                  <Input value={draft.command} onChange={(event) => setDraft({ ...draft, command: event.target.value })} placeholder="npx" />
+                </Field>
+                <Field label="Working directory (optional)">
+                  <Input value={draft.cwd} onChange={(event) => setDraft({ ...draft, cwd: event.target.value })} placeholder="/path/to/project" />
+                </Field>
+                <Field label="Args (one per line)" className="md:col-span-2">
+                  <Textarea
+                    value={draft.argsText}
+                    onChange={(event) => setDraft({ ...draft, argsText: event.target.value })}
+                    className="min-h-32 font-mono text-xs leading-6"
+                    placeholder="-y\n@modelcontextprotocol/server-filesystem\n."
+                  />
+                </Field>
+              </div>
+            ) : (
+              <div className="grid gap-4 md:grid-cols-2">
+                <Field label="Server URL" className="md:col-span-2">
+                  <Input value={draft.url} onChange={(event) => setDraft({ ...draft, url: event.target.value })} placeholder="https://example.com/mcp" />
+                </Field>
+                <Field label="Working directory (optional)">
+                  <Input value={draft.cwd} onChange={(event) => setDraft({ ...draft, cwd: event.target.value })} placeholder="/path/to/project" />
+                </Field>
+                <div className="rounded-lg border border-border bg-muted/20 p-3 text-sm text-muted-foreground md:col-span-2">
+                  Hosted servers often work best with <strong>OAuth</strong> or <strong>bearer</strong> auth and an <strong>eager</strong> lifecycle so metadata is available soon after startup.
+                </div>
+              </div>
+            )}
+
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-dashed border-border bg-muted/10 p-4">
+              <p className="max-w-2xl text-sm text-muted-foreground">
+                Save this starter server now, then use the full server panel below for advanced edits, reconnects, raw config inspection, diagnostics, and Ask-Sero recovery.
+              </p>
+              <Button
+                type="button"
+                onClick={async () => {
+                  const ok = await mutations.upsertServer(draft);
+                  if (ok) {
+                    onCreated?.(draft.serverName.trim());
+                  }
+                }}
+                disabled={mutations.pendingAction === 'save' || !!validationError}
+              >
+                <Save className="mr-2 h-4 w-4" />
+                Save first server
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            </div>
+          </section>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TransportButton({
+  active,
+  icon: Icon,
+  title,
+  body,
+  onClick,
+}: {
+  active: boolean;
+  icon: typeof Terminal;
+  title: string;
+  body: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'rounded-lg border p-4 text-left transition-colors',
+        active ? 'border-primary/40 bg-primary/5' : 'border-border bg-background hover:bg-muted/40',
+      )}
+      onClick={onClick}
+    >
+      <div className="flex items-center gap-2 font-medium text-foreground">
+        <Icon className="h-4 w-4 text-primary" />
+        {title}
+      </div>
+      <p className="mt-2 text-sm text-muted-foreground">{body}</p>
+    </button>
+  );
+}
+
+function StepBadge({ label }: { label: string }) {
+  return (
+    <Badge variant="outline" className="border-primary/20 bg-primary/5 text-primary">
+      {label}
+    </Badge>
+  );
+}
+
+function Field({ label, className, children }: { label: string; className?: string; children: ReactNode }) {
+  return (
+    <label className={cn('space-y-2 text-sm text-muted-foreground', className)}>
+      <Label className="text-foreground">{label}</Label>
+      {children}
+    </label>
+  );
+}
+
+function getPresetDraft(presetId: string): McpServerEditorInput {
+  return { ...findPreset(presetId).draft };
+}
+
+function findPreset(presetId: string): McpWizardPreset {
+  return WIZARD_PRESETS.find((preset) => preset.id === presetId) ?? WIZARD_PRESETS[0]!;
+}
+
+function createPresetDraft(input: Partial<McpServerEditorInput> & { transport: McpTransport }): McpServerEditorInput {
+  const base = createEmptyServerEditorInput();
+  return {
+    ...base,
+    authMode: input.transport === 'http' ? 'oauth' : 'none',
+    lifecycle: input.transport === 'http' ? 'eager' : 'lazy',
+    ...input,
+  };
+}
+
+export default McpSetupWizard;

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpAuthFlow.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpAuthFlow.ts
@@ -1,0 +1,93 @@
+import { useCallback, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+
+export interface McpAuthSession {
+  serverName: string;
+  authUrl: string;
+}
+
+export interface McpAuthFlowState {
+  loading: boolean;
+  error: string | null;
+  session: McpAuthSession | null;
+  setError: (message: string | null) => void;
+  startAuth: (serverName: string) => Promise<boolean>;
+  completeAuth: (serverName: string, callbackUrl: string) => Promise<boolean>;
+  cancelAuth: (serverName: string) => Promise<boolean>;
+}
+
+export function useMcpAuthFlow(): McpAuthFlowState {
+  const { run } = useAppTools();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [session, setSession] = useState<McpAuthSession | null>(null);
+
+  const startAuth = useCallback(async (serverName: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', { action: 'start_auth', serverName });
+      const authUrl = typeof result.details?.authUrl === 'string' ? result.details.authUrl : null;
+      setSession(authUrl ? { serverName, authUrl } : null);
+      if (result.isError) {
+        setError(result.text);
+        return false;
+      }
+      return true;
+    } catch (cause) {
+      setSession(null);
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
+  const completeAuth = useCallback(async (serverName: string, callbackUrl: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', { action: 'complete_auth', serverName, callbackUrl });
+      if (result.isError) {
+        setError(result.text);
+        return false;
+      }
+      setSession((current) => current?.serverName === serverName ? null : current);
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
+  const cancelAuth = useCallback(async (serverName: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', { action: 'cancel_auth', serverName });
+      if (result.isError) {
+        setError(result.text);
+        return false;
+      }
+      setSession((current) => current?.serverName === serverName ? null : current);
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
+  return {
+    loading,
+    error,
+    session,
+    setError,
+    startAuth,
+    completeAuth,
+    cancelAuth,
+  };
+}

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpAuthFlow.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpAuthFlow.ts
@@ -14,6 +14,7 @@ export interface McpAuthFlowState {
   startAuth: (serverName: string) => Promise<boolean>;
   completeAuth: (serverName: string, callbackUrl: string) => Promise<boolean>;
   cancelAuth: (serverName: string) => Promise<boolean>;
+  clearAuth: (serverName: string) => Promise<boolean>;
 }
 
 export function useMcpAuthFlow(): McpAuthFlowState {
@@ -81,6 +82,25 @@ export function useMcpAuthFlow(): McpAuthFlowState {
     }
   }, [run]);
 
+  const clearAuth = useCallback(async (serverName: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', { action: 'clear_auth', serverName });
+      if (result.isError) {
+        setError(result.text);
+        return false;
+      }
+      setSession((current) => current?.serverName === serverName ? null : current);
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
   return {
     loading,
     error,
@@ -89,5 +109,6 @@ export function useMcpAuthFlow(): McpAuthFlowState {
     startAuth,
     completeAuth,
     cancelAuth,
+    clearAuth,
   };
 }

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpBootstrap.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpBootstrap.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+
+interface BootstrapState {
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useMcpBootstrap(): BootstrapState {
+  const { run } = useAppTools();
+  const didBootstrapRef = useRef(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await run('mcp_manager', { action: 'bootstrap' });
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
+  useEffect(() => {
+    if (didBootstrapRef.current) return;
+    didBootstrapRef.current = true;
+    void refresh();
+  }, [refresh]);
+
+  return { loading, error, refresh };
+}

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpBootstrap.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpBootstrap.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAppTools } from '@sero-ai/app-runtime';
 
+const MCP_AUTO_REFRESH_INTERVAL_MS = 30_000;
+
 interface BootstrapState {
   loading: boolean;
   error: string | null;
@@ -10,27 +12,84 @@ interface BootstrapState {
 export function useMcpBootstrap(): BootstrapState {
   const { run } = useAppTools();
   const didBootstrapRef = useRef(false);
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
-    setError(null);
+  const runRefresh = useCallback(async (options: { action?: 'bootstrap' | 'refresh'; silent?: boolean } = {}) => {
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current;
+    }
+
+    const refreshPromise = (async () => {
+      const isSilent = options.silent === true;
+      if (!isSilent) {
+        setLoading(true);
+        setError(null);
+      }
+
+      try {
+        await run('mcp_manager', { action: options.action ?? 'refresh' });
+      } catch (cause) {
+        if (!isSilent) {
+          const message = cause instanceof Error ? cause.message : String(cause);
+          setError(message);
+        }
+      } finally {
+        if (!isSilent) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    refreshPromiseRef.current = refreshPromise;
     try {
-      await run('mcp_manager', { action: 'bootstrap' });
-    } catch (cause) {
-      const message = cause instanceof Error ? cause.message : String(cause);
-      setError(message);
+      await refreshPromise;
     } finally {
-      setLoading(false);
+      if (refreshPromiseRef.current === refreshPromise) {
+        refreshPromiseRef.current = null;
+      }
     }
   }, [run]);
+
+  const refresh = useCallback(() => {
+    return runRefresh();
+  }, [runRefresh]);
 
   useEffect(() => {
     if (didBootstrapRef.current) return;
     didBootstrapRef.current = true;
-    void refresh();
-  }, [refresh]);
+    void runRefresh({ action: 'bootstrap' });
+  }, [runRefresh]);
+
+  useEffect(() => {
+    const refreshIfVisible = () => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+      void runRefresh({ silent: true });
+    };
+
+    const interval = window.setInterval(() => {
+      if (document.visibilityState !== 'visible') {
+        return;
+      }
+      void runRefresh({ silent: true });
+    }, MCP_AUTO_REFRESH_INTERVAL_MS);
+
+    window.addEventListener('focus', refreshIfVisible);
+    window.addEventListener('online', refreshIfVisible);
+    window.addEventListener('pageshow', refreshIfVisible);
+    document.addEventListener('visibilitychange', refreshIfVisible);
+
+    return () => {
+      window.clearInterval(interval);
+      window.removeEventListener('focus', refreshIfVisible);
+      window.removeEventListener('online', refreshIfVisible);
+      window.removeEventListener('pageshow', refreshIfVisible);
+      document.removeEventListener('visibilitychange', refreshIfVisible);
+    };
+  }, [runRefresh]);
 
   return { loading, error, refresh };
 }

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpDiagnostics.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpDiagnostics.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+
+export interface McpDiagnosticsState {
+  loading: boolean;
+  error: string | null;
+  isOpen: boolean;
+  diagnostics: string;
+  open: () => Promise<void>;
+  close: () => void;
+  refresh: () => Promise<void>;
+}
+
+export function useMcpDiagnostics(): McpDiagnosticsState {
+  const { run } = useAppTools();
+  const [isOpen, setIsOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [diagnostics, setDiagnostics] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', { action: 'get_diagnostics' });
+      setDiagnostics(result.text);
+      if (result.isError) {
+        setError(result.text);
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
+  const open = useCallback(async () => {
+    setIsOpen(true);
+    await load();
+  }, [load]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return {
+    loading,
+    error,
+    isOpen,
+    diagnostics,
+    open,
+    close,
+    refresh: load,
+  };
+}

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpRawConfig.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpRawConfig.ts
@@ -1,0 +1,78 @@
+import { useCallback, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+
+export interface McpRawConfigState {
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+  isOpen: boolean;
+  rawConfig: string;
+  open: () => Promise<void>;
+  close: () => void;
+  setRawConfig: (value: string) => void;
+  save: () => Promise<boolean>;
+}
+
+export function useMcpRawConfig(): McpRawConfigState {
+  const { run } = useAppTools();
+  const [isOpen, setIsOpen] = useState(false);
+  const [rawConfig, setRawConfig] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const open = useCallback(async () => {
+    setIsOpen(true);
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', { action: 'get_raw_config' });
+      const raw = typeof result.details?.rawConfig === 'string' ? result.details.rawConfig : result.text;
+      setRawConfig(raw);
+      if (result.isError) {
+        setError(result.text);
+      }
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setError(null);
+  }, []);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', { action: 'save_raw_config', rawConfig });
+      if (result.isError) {
+        setError(result.text);
+        return false;
+      }
+      const savedRaw = typeof result.details?.rawConfig === 'string' ? result.details.rawConfig : rawConfig;
+      setRawConfig(savedRaw);
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, [rawConfig, run]);
+
+  return {
+    loading,
+    saving,
+    error,
+    isOpen,
+    rawConfig,
+    open,
+    close,
+    setRawConfig,
+    save,
+  };
+}

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpResourceReader.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpResourceReader.ts
@@ -1,0 +1,75 @@
+import { useCallback, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+import type { McpResourcePreview } from '../../shared/types';
+
+export interface McpResourceReaderState {
+  loading: boolean;
+  error: string | null;
+  activeResourceUri: string | null;
+  preview: McpResourcePreview | null;
+  loadResource: (serverName: string, resourceUri: string) => Promise<void>;
+  clearPreview: () => void;
+}
+
+export function useMcpResourceReader(): McpResourceReaderState {
+  const { run } = useAppTools();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeResourceUri, setActiveResourceUri] = useState<string | null>(null);
+  const [preview, setPreview] = useState<McpResourcePreview | null>(null);
+
+  const loadResource = useCallback(async (serverName: string, resourceUri: string) => {
+    setLoading(true);
+    setError(null);
+    setActiveResourceUri(resourceUri);
+
+    try {
+      const result = await run('mcp_manager', {
+        action: 'read_resource',
+        serverName,
+        resourceUri,
+      });
+      const nextPreview = isMcpResourcePreview(result.details?.resourcePreview)
+        ? result.details.resourcePreview
+        : null;
+      setPreview(nextPreview);
+      if (result.isError) {
+        setError(result.text);
+      } else if (!nextPreview) {
+        setError('The MCP resource loaded, but no preview payload was returned.');
+      }
+    } catch (cause) {
+      setPreview(null);
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, [run]);
+
+  const clearPreview = useCallback(() => {
+    setActiveResourceUri(null);
+    setPreview(null);
+    setError(null);
+  }, []);
+
+  return {
+    loading,
+    error,
+    activeResourceUri,
+    preview,
+    loadResource,
+    clearPreview,
+  };
+}
+
+function isMcpResourcePreview(value: unknown): value is McpResourcePreview {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const preview = value as Record<string, unknown>;
+  return typeof preview.serverName === 'string'
+    && typeof preview.requestedUri === 'string'
+    && typeof preview.resolvedUri === 'string'
+    && typeof preview.previewKind === 'string'
+    && typeof preview.truncated === 'boolean';
+}

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpSearchWorkbench.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpSearchWorkbench.ts
@@ -1,0 +1,141 @@
+import { useAppTools } from '@sero-ai/app-runtime';
+import { useCallback, useRef, useState } from 'react';
+
+export interface McpSearchMatch {
+  kind: 'tool' | 'resource';
+  serverName: string;
+  name: string;
+  description?: string;
+  uri?: string;
+  uiResourceUri?: string;
+}
+
+export interface McpSearchWorkbenchState {
+  query: string;
+  serverFilter: string;
+  lastQuery: string | null;
+  loading: boolean;
+  error: string | null;
+  results: McpSearchMatch[];
+  summaryText: string | null;
+  setQuery: (value: string) => void;
+  setServerFilter: (value: string) => void;
+  search: () => Promise<boolean>;
+  clear: () => void;
+}
+
+export function useMcpSearchWorkbench(): McpSearchWorkbenchState {
+  const { run } = useAppTools();
+  const requestIdRef = useRef(0);
+  const [query, setQuery] = useState('');
+  const [serverFilter, setServerFilter] = useState('all');
+  const [lastQuery, setLastQuery] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [results, setResults] = useState<McpSearchMatch[]>([]);
+  const [summaryText, setSummaryText] = useState<string | null>(null);
+
+  const search = useCallback(async () => {
+    const normalizedQuery = query.trim();
+    if (!normalizedQuery) {
+      setError('Enter a search query first.');
+      setResults([]);
+      setSummaryText(null);
+      return false;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+    setLastQuery(normalizedQuery);
+
+    try {
+      const result = await run('mcp', {
+        action: 'search',
+        query: normalizedQuery,
+        serverName: serverFilter === 'all' ? undefined : serverFilter,
+      });
+      if (requestId !== requestIdRef.current) {
+        return false;
+      }
+      const matches = parseMatches(result.details?.matches);
+      setResults(matches);
+      setSummaryText(result.text);
+      if (result.isError) {
+        setError(result.text);
+        return false;
+      }
+      return true;
+    } catch (cause) {
+      if (requestId !== requestIdRef.current) {
+        return false;
+      }
+      const message = cause instanceof Error ? cause.message : String(cause);
+      setResults([]);
+      setSummaryText(null);
+      setError(message);
+      return false;
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [query, run, serverFilter]);
+
+  const clear = useCallback(() => {
+    requestIdRef.current += 1;
+    setQuery('');
+    setLastQuery(null);
+    setError(null);
+    setResults([]);
+    setSummaryText(null);
+    setServerFilter('all');
+    setLoading(false);
+  }, []);
+
+  return {
+    query,
+    serverFilter,
+    lastQuery,
+    loading,
+    error,
+    results,
+    summaryText,
+    setQuery,
+    setServerFilter,
+    search,
+    clear,
+  };
+}
+
+function parseMatches(value: unknown): McpSearchMatch[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.reduce<McpSearchMatch[]>((matches, entry) => {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      return matches;
+    }
+
+    const record = entry as Record<string, unknown>;
+    const kind = record.kind === 'resource' ? 'resource' : record.kind === 'tool' ? 'tool' : null;
+    const serverName = typeof record.serverName === 'string' ? record.serverName : '';
+    const name = typeof record.name === 'string' ? record.name : '';
+    if (!kind || !serverName || !name) {
+      return matches;
+    }
+
+    matches.push({
+      kind,
+      serverName,
+      name,
+      description: typeof record.description === 'string' ? record.description : undefined,
+      uri: typeof record.uri === 'string' ? record.uri : undefined,
+      uiResourceUri: typeof record.uiResourceUri === 'string' ? record.uiResourceUri : undefined,
+    });
+    return matches;
+  }, []);
+}
+
+export default useMcpSearchWorkbench;

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpServerMutations.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpServerMutations.ts
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+import type { McpServerEditorInput } from '../../shared/types';
+
+interface McpServerMutations {
+  pendingAction: string | null;
+  error: string | null;
+  clearError: () => void;
+  upsertServer: (input: McpServerEditorInput) => Promise<boolean>;
+  removeServer: (serverName: string) => Promise<boolean>;
+  toggleServer: (serverName: string, enabled: boolean) => Promise<boolean>;
+}
+
+export function useMcpServerMutations(): McpServerMutations {
+  const { run } = useAppTools();
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const execute = useCallback(async (label: string, params: Record<string, unknown>) => {
+    setPendingAction(label);
+    setError(null);
+    try {
+      const result = await run('mcp_manager', params);
+      if (result.isError) {
+        setError(result.text);
+        return false;
+      }
+      return true;
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setPendingAction(null);
+    }
+  }, [run]);
+
+  const upsertServer = useCallback((input: McpServerEditorInput) => {
+    return execute('save', { action: 'upsert_server', ...input });
+  }, [execute]);
+
+  const removeServer = useCallback((serverName: string) => {
+    return execute(`remove:${serverName}`, { action: 'remove_server', serverName });
+  }, [execute]);
+
+  const toggleServer = useCallback((serverName: string, enabled: boolean) => {
+    return execute(`${enabled ? 'enable' : 'disable'}:${serverName}`, {
+      action: enabled ? 'enable_server' : 'disable_server',
+      serverName,
+    });
+  }, [execute]);
+
+  return {
+    pendingAction,
+    error,
+    clearError: () => setError(null),
+    upsertServer,
+    removeServer,
+    toggleServer,
+  };
+}

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpServerMutations.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpServerMutations.ts
@@ -9,6 +9,7 @@ interface McpServerMutations {
   upsertServer: (input: McpServerEditorInput) => Promise<boolean>;
   removeServer: (serverName: string) => Promise<boolean>;
   toggleServer: (serverName: string, enabled: boolean) => Promise<boolean>;
+  connectServer: (serverName: string, reconnect?: boolean) => Promise<boolean>;
 }
 
 export function useMcpServerMutations(): McpServerMutations {
@@ -49,6 +50,13 @@ export function useMcpServerMutations(): McpServerMutations {
     });
   }, [execute]);
 
+  const connectServer = useCallback((serverName: string, reconnect = false) => {
+    return execute(`${reconnect ? 'reconnect' : 'connect'}:${serverName}`, {
+      action: reconnect ? 'reconnect_server' : 'connect_server',
+      serverName,
+    });
+  }, [execute]);
+
   return {
     pendingAction,
     error,
@@ -56,5 +64,6 @@ export function useMcpServerMutations(): McpServerMutations {
     upsertServer,
     removeServer,
     toggleServer,
+    connectServer,
   };
 }

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpToolRunner.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpToolRunner.ts
@@ -100,6 +100,7 @@ export function useMcpToolRunner(serverName: string | null | undefined): McpTool
     setLoadingInventory(true);
     setError(null);
 
+    let preferredTool: string | null = null;
     try {
       const toolResult = await run('mcp', {
         action: 'list_tools',
@@ -126,8 +127,7 @@ export function useMcpToolRunner(serverName: string | null | undefined): McpTool
         return;
       }
 
-      const preferredTool = nextTools.find((tool) => tool.name === selectedToolNameRef.current)?.name ?? nextTools[0]?.name ?? '';
-      await selectTool(preferredTool);
+      preferredTool = nextTools.find((tool) => tool.name === selectedToolNameRef.current)?.name ?? nextTools[0]?.name ?? null;
     } catch (cause) {
       if (requestId !== requestIdRef.current) {
         return;
@@ -140,6 +140,10 @@ export function useMcpToolRunner(serverName: string | null | undefined): McpTool
       if (requestId === requestIdRef.current) {
         setLoadingInventory(false);
       }
+    }
+
+    if (preferredTool) {
+      await selectTool(preferredTool);
     }
   }, [run, selectTool, serverName]);
 

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpToolRunner.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpToolRunner.ts
@@ -1,0 +1,251 @@
+import { useAppTools } from '@sero-ai/app-runtime';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface McpToolInventoryItem {
+  name: string;
+  description?: string;
+  uiResourceUri?: string;
+}
+
+export interface McpToolRunnerResult {
+  text: string;
+  structuredContent?: unknown;
+  uiResourceUri?: string;
+  isError: boolean;
+}
+
+export interface McpToolRunnerState {
+  tools: McpToolInventoryItem[];
+  selectedToolName: string;
+  selectedTool: McpToolInventoryItem | null;
+  inputSchema: unknown;
+  inputText: string;
+  loadingInventory: boolean;
+  loadingDetails: boolean;
+  running: boolean;
+  error: string | null;
+  result: McpToolRunnerResult | null;
+  setInputText: (value: string) => void;
+  selectTool: (toolName: string) => Promise<void>;
+  refresh: () => Promise<void>;
+  runTool: () => Promise<boolean>;
+  clearResult: () => void;
+}
+
+export function useMcpToolRunner(serverName: string | null | undefined): McpToolRunnerState {
+  const { run } = useAppTools();
+  const requestIdRef = useRef(0);
+  const selectedToolNameRef = useRef('');
+  const [tools, setTools] = useState<McpToolInventoryItem[]>([]);
+  const [selectedToolName, setSelectedToolName] = useState('');
+  const [inputSchema, setInputSchema] = useState<unknown>(null);
+  const [inputText, setInputText] = useState('{}');
+  const [loadingInventory, setLoadingInventory] = useState(false);
+  const [loadingDetails, setLoadingDetails] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<McpToolRunnerResult | null>(null);
+
+  const selectTool = useCallback(async (toolName: string) => {
+    const normalizedServerName = serverName?.trim();
+    const normalizedToolName = toolName.trim();
+    if (!normalizedServerName || !normalizedToolName) {
+      setSelectedToolName('');
+      setInputSchema(null);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setLoadingDetails(true);
+    setError(null);
+    setSelectedToolName(normalizedToolName);
+
+    try {
+      const toolResult = await run('mcp', {
+        action: 'describe_tool',
+        serverName: normalizedServerName,
+        toolName: normalizedToolName,
+      });
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setInputSchema(toolResult.details?.inputSchema ?? null);
+      if (toolResult.isError) {
+        setError(toolResult.text);
+      }
+    } catch (cause) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setInputSchema(null);
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoadingDetails(false);
+      }
+    }
+  }, [run, serverName]);
+
+  const refresh = useCallback(async () => {
+    const normalizedServerName = serverName?.trim();
+    if (!normalizedServerName) {
+      setTools([]);
+      setSelectedToolName('');
+      setInputSchema(null);
+      setError(null);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setLoadingInventory(true);
+    setError(null);
+
+    try {
+      const toolResult = await run('mcp', {
+        action: 'list_tools',
+        serverName: normalizedServerName,
+      });
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
+      const nextTools = parseToolInventory(toolResult.details?.tools);
+      setTools(nextTools);
+      setResult(null);
+
+      if (toolResult.isError) {
+        setSelectedToolName('');
+        setInputSchema(null);
+        setError(toolResult.text);
+        return;
+      }
+
+      if (nextTools.length === 0) {
+        setSelectedToolName('');
+        setInputSchema(null);
+        return;
+      }
+
+      const preferredTool = nextTools.find((tool) => tool.name === selectedToolNameRef.current)?.name ?? nextTools[0]?.name ?? '';
+      await selectTool(preferredTool);
+    } catch (cause) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setTools([]);
+      setSelectedToolName('');
+      setInputSchema(null);
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoadingInventory(false);
+      }
+    }
+  }, [run, selectTool, serverName]);
+
+  const runTool = useCallback(async () => {
+    const normalizedServerName = serverName?.trim();
+    const normalizedToolName = selectedToolName.trim();
+    if (!normalizedServerName || !normalizedToolName) {
+      setError('Select an MCP tool before running it.');
+      return false;
+    }
+
+    const toolArguments = parseInputText(inputText);
+    if (toolArguments instanceof Error) {
+      setError(toolArguments.message);
+      return false;
+    }
+
+    setRunning(true);
+    setError(null);
+    try {
+      const toolResult = await run('mcp', {
+        action: 'call_tool',
+        serverName: normalizedServerName,
+        toolName: normalizedToolName,
+        toolArguments,
+      });
+      setResult({
+        text: toolResult.text,
+        structuredContent: toolResult.details?.structuredContent,
+        uiResourceUri: typeof toolResult.details?.uiResourceUri === 'string' ? toolResult.details.uiResourceUri : undefined,
+        isError: toolResult.isError,
+      });
+      if (toolResult.isError) {
+        setError(toolResult.text);
+        return false;
+      }
+      return true;
+    } catch (cause) {
+      setResult(null);
+      setError(cause instanceof Error ? cause.message : String(cause));
+      return false;
+    } finally {
+      setRunning(false);
+    }
+  }, [inputText, run, selectedToolName, serverName]);
+
+  const clearResult = useCallback(() => {
+    setResult(null);
+    setError(null);
+  }, []);
+
+  useEffect(() => {
+    selectedToolNameRef.current = selectedToolName;
+  }, [selectedToolName]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    tools,
+    selectedToolName,
+    selectedTool: tools.find((tool) => tool.name === selectedToolName) ?? null,
+    inputSchema,
+    inputText,
+    loadingInventory,
+    loadingDetails,
+    running,
+    error,
+    result,
+    setInputText,
+    selectTool,
+    refresh,
+    runTool,
+    clearResult,
+  };
+}
+
+function parseToolInventory(value: unknown): McpToolInventoryItem[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter((entry): entry is Record<string, unknown> => !!entry && typeof entry === 'object' && !Array.isArray(entry))
+    .map((entry) => ({
+      name: typeof entry.name === 'string' ? entry.name : '',
+      description: typeof entry.description === 'string' ? entry.description : undefined,
+      uiResourceUri: typeof entry.uiResourceUri === 'string' ? entry.uiResourceUri : undefined,
+    }))
+    .filter((entry) => entry.name.length > 0);
+}
+
+function parseInputText(value: string): Record<string, unknown> | undefined | Error {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '{}') {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return new Error('Tool input must be a JSON object.');
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return new Error('Tool input must be valid JSON.');
+  }
+}

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpViewer.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpViewer.ts
@@ -1,0 +1,141 @@
+import { useCallback, useState } from 'react';
+import type { McpResourcePreview } from '../../shared/types';
+import { useMcpAuthFlow, type McpAuthSession } from './useMcpAuthFlow';
+import { useMcpResourceReader } from './useMcpResourceReader';
+
+export type McpViewerKind = 'resource' | 'tool-ui' | 'auth';
+
+export interface McpViewerPaneState {
+  kind: McpViewerKind;
+  serverName: string;
+  title: string | null;
+}
+
+export interface McpViewerOpenResourceOptions {
+  kind?: 'resource' | 'tool-ui';
+  title?: string;
+}
+
+export interface McpViewerState {
+  pane: McpViewerPaneState | null;
+  preview: McpResourcePreview | null;
+  activeResourceUri: string | null;
+  resourceLoading: boolean;
+  resourceError: string | null;
+  authSession: McpAuthSession | null;
+  authLoading: boolean;
+  authError: string | null;
+  setAuthError: (message: string | null) => void;
+  openResource: (serverName: string, resourceUri: string, options?: McpViewerOpenResourceOptions) => Promise<void>;
+  startAuth: (serverName: string) => Promise<boolean>;
+  completeAuth: (serverName: string, callbackUrl: string) => Promise<boolean>;
+  cancelAuth: (serverName: string) => Promise<boolean>;
+  clearAuth: (serverName: string) => Promise<boolean>;
+  focusAuthSession: () => void;
+  clearPane: () => void;
+}
+
+export function useMcpViewer(): McpViewerState {
+  const {
+    loading: authLoading,
+    error: authError,
+    session: authSession,
+    setError: setAuthError,
+    startAuth: startAuthFlow,
+    completeAuth: completeAuthFlow,
+    cancelAuth: cancelAuthFlow,
+    clearAuth: clearAuthFlow,
+  } = useMcpAuthFlow();
+  const {
+    loading: resourceLoading,
+    error: resourceError,
+    activeResourceUri,
+    preview,
+    loadResource,
+    clearPreview,
+  } = useMcpResourceReader();
+  const [pane, setPane] = useState<McpViewerPaneState | null>(null);
+
+  const openResource = useCallback(async (
+    serverName: string,
+    resourceUri: string,
+    options: McpViewerOpenResourceOptions = {},
+  ) => {
+    setPane({
+      kind: options.kind ?? 'resource',
+      serverName,
+      title: options.title ?? resourceUri,
+    });
+    setAuthError(null);
+    await loadResource(serverName, resourceUri);
+  }, [loadResource, setAuthError]);
+
+  const startAuth = useCallback(async (serverName: string) => {
+    setPane({ kind: 'auth', serverName, title: `Authenticate ${serverName}` });
+    clearPreview();
+    return startAuthFlow(serverName);
+  }, [clearPreview, startAuthFlow]);
+
+  const completeAuth = useCallback(async (serverName: string, callbackUrl: string) => {
+    const ok = await completeAuthFlow(serverName, callbackUrl);
+    if (ok) {
+      setPane((current) => current?.kind === 'auth' && current.serverName === serverName ? null : current);
+    }
+    return ok;
+  }, [completeAuthFlow]);
+
+  const cancelAuth = useCallback(async (serverName: string) => {
+    const ok = await cancelAuthFlow(serverName);
+    if (ok) {
+      setPane((current) => current?.kind === 'auth' && current.serverName === serverName ? null : current);
+    }
+    return ok;
+  }, [cancelAuthFlow]);
+
+  const clearAuth = useCallback(async (serverName: string) => {
+    const ok = await clearAuthFlow(serverName);
+    if (ok) {
+      setPane((current) => current?.kind === 'auth' && current.serverName === serverName ? null : current);
+    }
+    return ok;
+  }, [clearAuthFlow]);
+
+  const focusAuthSession = useCallback(() => {
+    if (!authSession) {
+      return;
+    }
+    setPane({
+      kind: 'auth',
+      serverName: authSession.serverName,
+      title: `Authenticate ${authSession.serverName}`,
+    });
+    clearPreview();
+  }, [authSession, clearPreview]);
+
+  const clearPane = useCallback(() => {
+    setPane(null);
+    clearPreview();
+    setAuthError(null);
+  }, [clearPreview, setAuthError]);
+
+  return {
+    pane,
+    preview,
+    activeResourceUri,
+    resourceLoading,
+    resourceError,
+    authSession,
+    authLoading,
+    authError,
+    setAuthError,
+    openResource,
+    startAuth,
+    completeAuth,
+    cancelAuth,
+    clearAuth,
+    focusAuthSession,
+    clearPane,
+  };
+}
+
+export default useMcpViewer;

--- a/plugins/sero-mcp-plugin/ui/hooks/useMcpViewer.ts
+++ b/plugins/sero-mcp-plugin/ui/hooks/useMcpViewer.ts
@@ -1,7 +1,7 @@
-import { useCallback, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+import { useCallback, useRef, useState } from 'react';
 import type { McpResourcePreview } from '../../shared/types';
 import { useMcpAuthFlow, type McpAuthSession } from './useMcpAuthFlow';
-import { useMcpResourceReader } from './useMcpResourceReader';
 
 export type McpViewerKind = 'resource' | 'tool-ui' | 'auth';
 
@@ -11,13 +11,23 @@ export interface McpViewerPaneState {
   title: string | null;
 }
 
+export interface McpViewerSession {
+  sessionId: string;
+  viewerUrl: string;
+  resourceUri: string;
+  kind: Exclude<McpViewerKind, 'auth'>;
+}
+
 export interface McpViewerOpenResourceOptions {
   kind?: 'resource' | 'tool-ui';
   title?: string;
+  toolName?: string;
+  toolArguments?: Record<string, unknown>;
 }
 
 export interface McpViewerState {
   pane: McpViewerPaneState | null;
+  session: McpViewerSession | null;
   preview: McpResourcePreview | null;
   activeResourceUri: string | null;
   resourceLoading: boolean;
@@ -36,6 +46,8 @@ export interface McpViewerState {
 }
 
 export function useMcpViewer(): McpViewerState {
+  const { run } = useAppTools();
+  const requestIdRef = useRef(0);
   const {
     loading: authLoading,
     error: authError,
@@ -46,35 +58,97 @@ export function useMcpViewer(): McpViewerState {
     cancelAuth: cancelAuthFlow,
     clearAuth: clearAuthFlow,
   } = useMcpAuthFlow();
-  const {
-    loading: resourceLoading,
-    error: resourceError,
-    activeResourceUri,
-    preview,
-    loadResource,
-    clearPreview,
-  } = useMcpResourceReader();
   const [pane, setPane] = useState<McpViewerPaneState | null>(null);
+  const [session, setSession] = useState<McpViewerSession | null>(null);
+  const [preview, setPreview] = useState<McpResourcePreview | null>(null);
+  const [activeResourceUri, setActiveResourceUri] = useState<string | null>(null);
+  const [resourceLoading, setResourceLoading] = useState(false);
+  const [resourceError, setResourceError] = useState<string | null>(null);
+
+  const closeViewerSession = useCallback(async () => {
+    await run('mcp_manager', { action: 'close_viewer' });
+  }, [run]);
 
   const openResource = useCallback(async (
     serverName: string,
     resourceUri: string,
     options: McpViewerOpenResourceOptions = {},
   ) => {
+    const requestId = ++requestIdRef.current;
+    const nextKind = options.kind ?? 'resource';
+    const action = nextKind === 'tool-ui' ? 'open_tool_ui' : 'open_resource';
+
     setPane({
-      kind: options.kind ?? 'resource',
+      kind: nextKind,
       serverName,
       title: options.title ?? resourceUri,
     });
+    setSession(null);
+    setPreview(null);
+    setActiveResourceUri(resourceUri);
+    setResourceLoading(true);
+    setResourceError(null);
     setAuthError(null);
-    await loadResource(serverName, resourceUri);
-  }, [loadResource, setAuthError]);
+    void closeViewerSession().catch(() => undefined);
+
+    try {
+      const result = await run('mcp_manager', {
+        action,
+        serverName,
+        resourceUri,
+        toolName: options.toolName,
+        toolArguments: options.toolArguments,
+      });
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
+      const viewerUrl = typeof result.details?.viewerUrl === 'string' ? result.details.viewerUrl : null;
+      const sessionId = typeof result.details?.sessionId === 'string' ? result.details.sessionId : null;
+      const nextPreview = isMcpResourcePreview(result.details?.resourcePreview) ? result.details.resourcePreview : null;
+
+      if (viewerUrl && sessionId) {
+        setSession({
+          sessionId,
+          viewerUrl,
+          resourceUri,
+          kind: nextKind,
+        });
+        setPreview(null);
+      } else {
+        setSession(null);
+        setPreview(nextPreview);
+      }
+
+      if (result.isError) {
+        setResourceError(result.text);
+      } else if (!viewerUrl && !nextPreview) {
+        setResourceError('The MCP viewer opened, but no preview or interactive session payload was returned.');
+      }
+    } catch (cause) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setSession(null);
+      setPreview(null);
+      setResourceError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setResourceLoading(false);
+      }
+    }
+  }, [closeViewerSession, run, setAuthError]);
 
   const startAuth = useCallback(async (serverName: string) => {
+    requestIdRef.current += 1;
+    setSession(null);
+    setPreview(null);
+    setActiveResourceUri(null);
+    setResourceError(null);
+    void closeViewerSession().catch(() => undefined);
     setPane({ kind: 'auth', serverName, title: `Authenticate ${serverName}` });
-    clearPreview();
     return startAuthFlow(serverName);
-  }, [clearPreview, startAuthFlow]);
+  }, [closeViewerSession, startAuthFlow]);
 
   const completeAuth = useCallback(async (serverName: string, callbackUrl: string) => {
     const ok = await completeAuthFlow(serverName, callbackUrl);
@@ -104,22 +178,33 @@ export function useMcpViewer(): McpViewerState {
     if (!authSession) {
       return;
     }
+    requestIdRef.current += 1;
+    setSession(null);
+    setPreview(null);
+    setActiveResourceUri(null);
+    setResourceError(null);
+    void closeViewerSession().catch(() => undefined);
     setPane({
       kind: 'auth',
       serverName: authSession.serverName,
       title: `Authenticate ${authSession.serverName}`,
     });
-    clearPreview();
-  }, [authSession, clearPreview]);
+  }, [authSession, closeViewerSession]);
 
   const clearPane = useCallback(() => {
+    requestIdRef.current += 1;
     setPane(null);
-    clearPreview();
+    setSession(null);
+    setPreview(null);
+    setActiveResourceUri(null);
+    setResourceError(null);
     setAuthError(null);
-  }, [clearPreview, setAuthError]);
+    void closeViewerSession().catch(() => undefined);
+  }, [closeViewerSession, setAuthError]);
 
   return {
     pane,
+    session,
     preview,
     activeResourceUri,
     resourceLoading,
@@ -136,6 +221,19 @@ export function useMcpViewer(): McpViewerState {
     focusAuthSession,
     clearPane,
   };
+}
+
+function isMcpResourcePreview(value: unknown): value is McpResourcePreview {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+
+  const preview = value as Record<string, unknown>;
+  return typeof preview.serverName === 'string'
+    && typeof preview.requestedUri === 'string'
+    && typeof preview.resolvedUri === 'string'
+    && typeof preview.previewKind === 'string'
+    && typeof preview.truncated === 'boolean';
 }
 
 export default useMcpViewer;

--- a/plugins/sero-mcp-plugin/ui/index.html
+++ b/plugins/sero-mcp-plugin/ui/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Sero MCP (remote)</title></head>
+<body><div id="root"></div></body>
+</html>

--- a/plugins/sero-mcp-plugin/ui/styles.css
+++ b/plugins/sero-mcp-plugin/ui/styles.css
@@ -1,0 +1,41 @@
+@import "tailwindcss";
+
+@source "../../../packages/ui/src/components";
+@source "./hooks";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+}
+
+@keyframes mcp-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@utility animate-mcp-fade-in {
+  animation: mcp-fade-in 0.2s ease-out both;
+}

--- a/plugins/sero-mcp-plugin/ui/tsconfig.json
+++ b/plugins/sero-mcp-plugin/ui/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "paths": {
+      "@sero-ai/app-runtime": ["../../../packages/app-runtime/src/index.ts"],
+      "@sero-ai/common": ["../../../packages/common/src/index.ts"],
+      "@sero-ai/ui": ["../../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/*": ["../../../packages/ui/src/*"]
+    }
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/plugins/sero-mcp-plugin/ui/webview.d.ts
+++ b/plugins/sero-mcp-plugin/ui/webview.d.ts
@@ -1,0 +1,42 @@
+import type * as React from 'react';
+
+declare global {
+  interface WebviewNavigationEvent extends Event {
+    url: string;
+    preventDefault(): void;
+  }
+
+  interface WebviewLoadErrorEvent extends Event {
+    errorDescription: string;
+    validatedURL?: string;
+  }
+
+  interface HTMLWebViewElement extends HTMLElement {
+    src: string;
+    partition: string;
+    stop(): void;
+    reload(): void;
+    loadURL(url: string): void;
+    addEventListener(type: 'will-navigate', listener: (event: WebviewNavigationEvent) => void): void;
+    addEventListener(type: 'did-start-loading', listener: () => void): void;
+    addEventListener(type: 'did-stop-loading', listener: () => void): void;
+    addEventListener(type: 'did-fail-load', listener: (event: WebviewLoadErrorEvent) => void): void;
+    removeEventListener(type: 'will-navigate', listener: (event: WebviewNavigationEvent) => void): void;
+    removeEventListener(type: 'did-start-loading', listener: () => void): void;
+    removeEventListener(type: 'did-stop-loading', listener: () => void): void;
+    removeEventListener(type: 'did-fail-load', listener: (event: WebviewLoadErrorEvent) => void): void;
+  }
+
+  namespace JSX {
+    interface IntrinsicElements {
+      webview: React.DetailedHTMLProps<React.HTMLAttributes<HTMLWebViewElement>, HTMLWebViewElement> & {
+        src?: string;
+        partition?: string;
+        allowpopups?: 'true' | 'false';
+        webpreferences?: string;
+      };
+    }
+  }
+}
+
+export {};

--- a/plugins/sero-mcp-plugin/vite.config.ts
+++ b/plugins/sero-mcp-plugin/vite.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  root: 'ui',
+  base: process.env.NODE_ENV === 'production' ? './' : '/',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_mcp',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './McpApp': './ui/McpApp.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+      },
+    }),
+  ],
+  server: {
+    port: 5196,
+    strictPort: true,
+    origin: 'http://localhost:5196',
+  },
+  optimizeDeps: {
+    exclude: ['@sero-ai/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: '../dist/ui',
+    emptyOutDir: true,
+  },
+});

--- a/plugins/sero-mcp-plugin/vitest.config.ts
+++ b/plugins/sero-mcp-plugin/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['extension/__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/plugins/sero-mcp-plugin/vitest.config.ts
+++ b/plugins/sero-mcp-plugin/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    include: ['extension/__tests__/**/*.test.ts'],
+    include: ['extension/__tests__/**/*.test.ts', 'ui/**/*.test.ts', 'ui/**/*.test.tsx'],
     environment: 'node',
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,6 +715,67 @@ importers:
         specifier: 'catalog:'
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
+  plugins/sero-mcp-plugin:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: catalog:peer
+        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: catalog:peer
+        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: catalog:peer
+        version: 0.61.1
+      '@sinclair/typebox':
+        specifier: 'catalog:'
+        version: 0.34.48
+    devDependencies:
+      '@module-federation/vite':
+        specifier: 'catalog:'
+        version: 1.11.0(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@sero-ai/app-runtime':
+        specifier: workspace:@sero-ai/app-runtime@*
+        version: link:../../packages/app-runtime
+      '@sero-ai/common':
+        specifier: workspace:*
+        version: link:../../packages/common
+      '@sero-ai/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.1.18(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.11
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.563.0(react@19.2.4)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.1.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+
   plugins/sero-memory-plugin:
     dependencies:
       '@mariozechner/pi-ai':
@@ -1016,10 +1077,6 @@ packages:
     resolution: {integrity: sha512-0k9d0oO6nw3Y6jtgs1cmMPNuwAVPQahIoshKK3NDfhVQR1wNC90/gSpdfa9GKswe8XRq/ZZlq7ny0qM1rd/Hkg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.973.20':
-    resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/core@3.973.26':
     resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
     engines: {node: '>=20.0.0'}
@@ -1048,10 +1105,6 @@ packages:
     resolution: {integrity: sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.20':
-    resolution: {integrity: sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-sso@3.972.28':
     resolution: {integrity: sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==}
     engines: {node: '>=20.0.0'}
@@ -1076,16 +1129,8 @@ packages:
     resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
-    resolution: {integrity: sha512-BnnvYs2ZEpdlmZ2PNlV2ZyQ8j8AEkMTjN79y/YA475ER1ByFYrkVR85qmhni8oeTaJcDqbx364wDpitDAA/wCA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/middleware-recursion-detection@3.972.9':
     resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-user-agent@3.972.21':
-    resolution: {integrity: sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-user-agent@3.972.28':
@@ -1096,20 +1141,12 @@ packages:
     resolution: {integrity: sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==}
     engines: {node: '>= 14.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.10':
-    resolution: {integrity: sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/nested-clients@3.996.18':
     resolution: {integrity: sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.10':
     resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/region-config-resolver@3.972.8':
-    resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1009.0':
@@ -1147,19 +1184,6 @@ packages:
     peerDependenciesMeta:
       aws-crt:
         optional: true
-
-  '@aws-sdk/util-user-agent-node@3.973.7':
-    resolution: {integrity: sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      aws-crt: '>=1.0.0'
-    peerDependenciesMeta:
-      aws-crt:
-        optional: true
-
-  '@aws-sdk/xml-builder@3.972.11':
-    resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
-    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.16':
     resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
@@ -3716,20 +3740,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@smithy/abort-controller@4.2.12':
-    resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/config-resolver@4.4.11':
-    resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/config-resolver@4.4.13':
     resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/core@3.23.11':
-    resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.23.13':
@@ -3788,24 +3800,12 @@ packages:
     resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.25':
-    resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-endpoint@4.4.28':
     resolution: {integrity: sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.4.42':
-    resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/middleware-retry@4.4.46':
     resolution: {integrity: sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/middleware-serde@4.2.14':
-    resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-serde@4.2.16':
@@ -3818,10 +3818,6 @@ packages:
 
   '@smithy/node-config-provider@4.3.12':
     resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/node-http-handler@4.4.16':
-    resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.5.1':
@@ -3862,10 +3858,6 @@ packages:
 
   '@smithy/signature-v4@5.3.12':
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/smithy-client@4.12.5':
-    resolution: {integrity: sha512-UqwYawyqSr/aog8mnLnfbPurS0gi4G7IYDcD28cUIBhsvWs1+rQcL2IwkUQ+QZ7dibaoRzhNF99fAQ9AUcO00w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.8':
@@ -3912,16 +3904,8 @@ packages:
     resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-defaults-mode-browser@4.3.44':
     resolution: {integrity: sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-defaults-mode-node@4.2.44':
-    resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-defaults-mode-node@4.2.48':
@@ -3948,16 +3932,8 @@ packages:
     resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.2.12':
-    resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-retry@4.2.13':
     resolution: {integrity: sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/util-stream@4.5.19':
-    resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.21':
@@ -6167,18 +6143,11 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
-  fast-xml-builder@1.1.3:
-    resolution: {integrity: sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==}
-
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
   fast-xml-parser@4.5.6:
     resolution: {integrity: sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==}
-    hasBin: true
-
-  fast-xml-parser@5.4.1:
-    resolution: {integrity: sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==}
     hasBin: true
 
   fast-xml-parser@5.5.8:
@@ -8299,10 +8268,6 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
-    engines: {node: '>=14.0.0'}
 
   path-expression-matcher@1.2.1:
     resolution: {integrity: sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==}
@@ -10449,23 +10414,23 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/credential-provider-node': 3.972.21
       '@aws-sdk/eventstream-handler-node': 3.972.11
       '@aws-sdk/middleware-eventstream': 3.972.8
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.28
       '@aws-sdk/middleware-websocket': 3.972.13
-      '@aws-sdk/region-config-resolver': 3.972.8
+      '@aws-sdk/region-config-resolver': 3.972.10
       '@aws-sdk/token-providers': 3.1009.0
       '@aws-sdk/types': 3.973.6
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
+      '@aws-sdk/util-user-agent-node': 3.973.14
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.13
       '@smithy/eventstream-serde-browser': 4.2.12
       '@smithy/eventstream-serde-config-resolver': 4.3.12
       '@smithy/eventstream-serde-node': 4.2.12
@@ -10473,45 +10438,29 @@ snapshots:
       '@smithy/hash-node': 4.2.12
       '@smithy/invalid-dependency': 4.2.12
       '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-retry': 4.4.46
+      '@smithy/middleware-serde': 4.2.16
       '@smithy/middleware-stack': 4.2.12
       '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
+      '@smithy/node-http-handler': 4.5.1
       '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
+      '@smithy/util-defaults-mode-browser': 4.3.44
+      '@smithy/util-defaults-mode-node': 4.2.48
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-retry': 4.2.13
+      '@smithy/util-stream': 4.5.21
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-
-  '@aws-sdk/core@3.973.20':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/xml-builder': 3.972.11
-      '@smithy/core': 3.23.11
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
 
   '@aws-sdk/core@3.973.26':
     dependencies:
@@ -10531,7 +10480,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-env@3.972.18':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
@@ -10539,27 +10488,27 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.20':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/types': 3.973.6
       '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
+      '@smithy/node-http-handler': 4.5.1
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
+      '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-stream': 4.5.21
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.20':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/credential-provider-env': 3.972.18
       '@aws-sdk/credential-provider-http': 3.972.20
       '@aws-sdk/credential-provider-login': 3.972.20
       '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
+      '@aws-sdk/credential-provider-sso': 3.972.28
       '@aws-sdk/credential-provider-web-identity': 3.972.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/nested-clients': 3.996.18
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
       '@smithy/property-provider': 4.2.12
@@ -10571,8 +10520,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.20':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.18
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
@@ -10588,7 +10537,7 @@ snapshots:
       '@aws-sdk/credential-provider-http': 3.972.20
       '@aws-sdk/credential-provider-ini': 3.972.20
       '@aws-sdk/credential-provider-process': 3.972.18
-      '@aws-sdk/credential-provider-sso': 3.972.20
+      '@aws-sdk/credential-provider-sso': 3.972.28
       '@aws-sdk/credential-provider-web-identity': 3.972.20
       '@aws-sdk/types': 3.973.6
       '@smithy/credential-provider-imds': 4.2.12
@@ -10601,25 +10550,12 @@ snapshots:
 
   '@aws-sdk/credential-provider-process@3.972.18':
     dependencies:
-      '@aws-sdk/core': 3.973.20
+      '@aws-sdk/core': 3.973.26
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
       tslib: 2.8.1
-
-  '@aws-sdk/credential-provider-sso@3.972.20':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
-      '@aws-sdk/token-providers': 3.1009.0
-      '@aws-sdk/types': 3.973.6
-      '@smithy/property-provider': 4.2.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-sso@3.972.28':
     dependencies:
@@ -10636,8 +10572,8 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.972.20':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.18
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -10673,31 +10609,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-recursion-detection@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-recursion-detection@3.972.9':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@aws/lambda-invoke-store': 0.2.4
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-user-agent@3.972.21':
-    dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.28':
@@ -10725,49 +10642,6 @@ snapshots:
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
-
-  '@aws-sdk/nested-clients@3.996.10':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-utf8': 4.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/nested-clients@3.996.18':
     dependencies:
@@ -10820,18 +10694,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/region-config-resolver@3.972.8':
-    dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@aws-sdk/token-providers@3.1009.0':
     dependencies:
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/nested-clients': 3.996.10
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.18
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
@@ -10890,21 +10756,6 @@ snapshots:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/util-user-agent-node@3.973.7':
-    dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/types': 3.973.6
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      tslib: 2.8.1
-
-  '@aws-sdk/xml-builder@3.972.11':
-    dependencies:
-      '@smithy/types': 4.13.1
-      fast-xml-parser: 5.4.1
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.16':
@@ -12128,6 +11979,18 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
+  '@mariozechner/pi-agent-core@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@mariozechner/pi-agent-core@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
@@ -12155,6 +12018,30 @@ snapshots:
   '@mariozechner/pi-agent-core@0.61.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1009.0
+      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
+      '@mistralai/mistralai': 1.14.1
+      '@sinclair/typebox': 0.34.48
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.18.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.24.2
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12203,6 +12090,38 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.24.2
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-coding-agent@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.61.1
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.3
+      extract-zip: 2.0.1
+      file-type: 21.3.2
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.4
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      undici: 7.24.2
+      yaml: 2.8.2
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.2
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12424,7 +12343,7 @@ snapshots:
       '@module-federation/third-party-dts-extractor': 0.21.6
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
-      axios: 1.13.6
+      axios: 1.14.0(debug@4.4.3)
       chalk: 3.0.0
       fs-extra: 9.1.0
       isomorphic-ws: 5.0.0(ws@8.18.0)
@@ -13899,20 +13818,6 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@smithy/abort-controller@4.2.12':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/config-resolver@4.4.11':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
   '@smithy/config-resolver@4.4.13':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -13920,19 +13825,6 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-endpoints': 3.3.3
       '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
-  '@smithy/core@3.23.11':
-    dependencies:
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-stream': 4.5.19
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/core@3.23.13':
@@ -14024,17 +13916,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.25':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
-      '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
   '@smithy/middleware-endpoint@4.4.28':
     dependencies:
       '@smithy/core': 3.23.13
@@ -14044,18 +13925,6 @@ snapshots:
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-middleware': 4.2.12
-      tslib: 2.8.1
-
-  '@smithy/middleware-retry@4.4.42':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.46':
@@ -14068,13 +13937,6 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-retry': 4.2.13
       '@smithy/uuid': 1.1.2
-      tslib: 2.8.1
-
-  '@smithy/middleware-serde@4.2.14':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.16':
@@ -14093,14 +13955,6 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.4.16':
-    dependencies:
-      '@smithy/abort-controller': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -14168,16 +14022,6 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/smithy-client@4.12.5':
-    dependencies:
-      '@smithy/core': 3.23.11
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
-      '@smithy/util-stream': 4.5.19
-      tslib: 2.8.1
-
   '@smithy/smithy-client@4.12.8':
     dependencies:
       '@smithy/core': 3.23.13
@@ -14235,27 +14079,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.41':
-    dependencies:
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-defaults-mode-browser@4.3.44':
     dependencies:
       '@smithy/property-provider': 4.2.12
       '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-defaults-mode-node@4.2.44':
-    dependencies:
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/credential-provider-imds': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/property-provider': 4.2.12
-      '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
@@ -14293,27 +14120,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-retry@4.2.12':
-    dependencies:
-      '@smithy/service-error-classification': 4.2.12
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
   '@smithy/util-retry@4.2.13':
     dependencies:
       '@smithy/service-error-classification': 4.2.12
       '@smithy/types': 4.13.1
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.19':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/types': 4.13.1
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.21':
@@ -16771,10 +16581,6 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
-  fast-xml-builder@1.1.3:
-    dependencies:
-      path-expression-matcher: 1.1.3
-
   fast-xml-builder@1.1.4:
     dependencies:
       path-expression-matcher: 1.2.1
@@ -16782,11 +16588,6 @@ snapshots:
   fast-xml-parser@4.5.6:
     dependencies:
       strnum: 1.1.2
-
-  fast-xml-parser@5.4.1:
-    dependencies:
-      fast-xml-builder: 1.1.3
-      strnum: 2.2.0
 
   fast-xml-parser@5.5.8:
     dependencies:
@@ -19197,6 +18998,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  openai@6.26.0(ws@8.18.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.18.0
+      zod: 4.3.6
+
   openai@6.26.0(ws@8.19.0)(zod@3.25.76):
     optionalDependencies:
       ws: 8.19.0
@@ -19373,8 +19179,6 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
-
-  path-expression-matcher@1.1.3: {}
 
   path-expression-matcher@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ catalogs:
     vitest:
       specifier: ^4.0.18
       version: 4.0.18
+    zod:
+      specifier: ^4.3.6
+      version: 4.3.6
   peer:
     '@mariozechner/pi-ai':
       specifier: '>=0.61.1'
@@ -726,9 +729,18 @@ importers:
       '@mariozechner/pi-tui':
         specifier: catalog:peer
         version: 0.61.1
+      '@modelcontextprotocol/ext-apps':
+        specifier: 1.2.2
+        version: 1.2.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.27.1
+        version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@sinclair/typebox':
         specifier: 'catalog:'
         version: 0.34.48
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@module-federation/vite':
         specifier: 'catalog:'
@@ -2268,6 +2280,20 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@modelcontextprotocol/ext-apps@1.2.2':
+    resolution: {integrity: sha512-qMnhIKb8tyPesl+kZU76Xz9Bi9putCO+LcgvBJ00fDdIniiLZsnQbAeTKoq+sTiYH1rba2Fvj8NPAFxij+gyxw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.24.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -12183,6 +12209,14 @@ snapshots:
       - utf-8-validate
 
   '@mixmark-io/domino@2.2.0': {}
+
+  '@modelcontextprotocol/ext-apps@1.2.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+      zod: 4.3.6
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,6 +787,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.31.1)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
   plugins/sero-memory-plugin:
     dependencies:
@@ -12031,7 +12034,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.61.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.61.1(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12080,6 +12083,30 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.24.2
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.61.1(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1009.0
+      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
+      '@mistralai/mistralai': 1.14.1
+      '@sinclair/typebox': 0.34.48
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.24.2
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12157,7 +12184,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.61.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.61.1(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.61.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -17298,7 +17325,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0)
+      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -19993,7 +20020,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.14.0):
+  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
     dependencies:
       axios: 1.14.0(debug@4.4.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -769,6 +769,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 4.7.0(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       lucide-react:
         specifier: 'catalog:'
         version: 0.563.0(react@19.2.4)
@@ -12034,7 +12037,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.61.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.61.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12083,30 +12086,6 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.24.2
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.61.1(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1009.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
-      '@mistralai/mistralai': 1.14.1
-      '@sinclair/typebox': 0.34.48
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      undici: 7.24.2
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12184,7 +12163,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.61.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.61.1(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.61.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -17325,7 +17304,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.14.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -20020,7 +19999,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.14.0):
     dependencies:
       axios: 1.14.0(debug@4.4.3)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,10 +719,10 @@ importers:
     dependencies:
       '@mariozechner/pi-ai':
         specifier: catalog:peer
-        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
+        version: 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: catalog:peer
         version: 0.61.1
@@ -11979,18 +11979,6 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
   '@mariozechner/pi-agent-core@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
@@ -12018,30 +12006,6 @@ snapshots:
   '@mariozechner/pi-agent-core@0.61.1(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1009.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
-      '@mistralai/mistralai': 1.14.1
-      '@sinclair/typebox': 0.34.48
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.18.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      undici: 7.24.2
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12090,38 +12054,6 @@ snapshots:
       proxy-agent: 6.5.0
       undici: 7.24.2
       zod-to-json-schema: 3.25.1(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.61.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.18.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.61.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.3
-      extract-zip: 2.0.1
-      file-type: 21.3.2
-      glob: 13.0.6
-      hosted-git-info: 9.0.2
-      ignore: 7.0.5
-      marked: 15.0.12
-      minimatch: 10.2.4
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      undici: 7.24.2
-      yaml: 2.8.2
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.2
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -18997,11 +18929,6 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
-
-  openai@6.26.0(ws@8.18.0)(zod@4.3.6):
-    optionalDependencies:
-      ws: 8.18.0
-      zod: 4.3.6
 
   openai@6.26.0(ws@8.19.0)(zod@3.25.76):
     optionalDependencies:


### PR DESCRIPTION
## Summary

Adds a built-in first-party MCP control center at `plugins/sero-mcp-plugin/`.

This adapts the `pi-mcp-adapter` backend ideas into a **Sero-native, UI-first** MCP experience with:

- exactly one bridged agent/CLI tool: `mcp`
- one UI-only management tool: `mcp_manager`
- a module-level singleton runtime shared across UI/chat/CLI entry points
- embedded OAuth auth inside Sero
- cache-backed MCP discovery, lifecycle management, diagnostics, and resource/tool inspection
- dedicated viewer/auth pane with interactive MCP UI hosting

## Delivered

- scaffolded the new built-in plugin package and manifest
- added config/state/cache/auth storage under Sero-owned paths
- implemented server CRUD, enable/disable, connect/reconnect, and raw config editing
- implemented eager/lazy/keep-alive lifecycle handling plus reconnect/refresh behavior
- added metadata caching and cache-backed state snapshots
- added diagnostics and Ask-Sero recovery flows
- added embedded OAuth auth, re-auth, cancel-auth, and clear-auth controls
- added routed `mcp` proxy actions for status/list/search/tools/resources/describe/call/read
- added top-level MCP-only search workbench and server detail tool runner
- added inline resource previews for non-UI resources
- added interactive loopback viewer hosting for `ui://` resources and UI-capable tools
- added automated coverage for runtime, bridge boundaries, security/CSP, and UI behavior
- added final plugin README and completed the MCP plan/checklist

## Suitable alternatives / implementation decisions

These are intentional plan-aligned choices rather than missing work:

- **Interactive viewer hosting:** instead of porting the adapter’s popup/browser-first host model, this PR ships a Sero-native ephemeral localhost viewer host that keeps session URLs/tokens out of persisted state while still supporting AppBridge-style JSON-RPC for embedded MCP UIs.
- **Runtime shape:** uses a **module-level singleton extension runtime** instead of a separate plugin runtime process so UI/chat/CLI all share live MCP state in v1.
- **Agent surface discipline:** preserves the one-bridged-tool model (`mcp`) and keeps management/viewer/auth actions behind `mcp_manager`.

## Explicit non-goals for v1

Not shipped by design:

- direct per-server or per-tool bridge exposure
- import/migration from legacy `~/.pi` MCP config/cache/tokens
- TUI `/mcp` panel parity
- popup-first auth/viewer workflow
- separate plugin runtime process

## Validation

Ran successfully:

```bash
pnpm --filter @sero-ai/plugin-mcp typecheck
pnpm --filter @sero-ai/plugin-mcp test
pnpm --filter @sero-ai/plugin-mcp build
pnpm --filter @sero/desktop exec vitest run electron/__tests__/features/plugins/plugin-cli-bridge.test.ts electron/__tests__/platform/window-security.test.ts electron/__tests__/platform/csp.test.ts
pnpm typecheck
```

## Plan status

Completed plan/checklist items:

- MCP-07
- MCP-09
- MCP-10
- MCP-11
- MCP-12
