### PR TITLE
feat(chat): add copy-to-clipboard button on user and assistant messages

### DIFF
--- a/apps/desktop/src/components/layout/ChatMessageItem.test.tsx
+++ b/apps/desktop/src/components/layout/ChatMessageItem.test.tsx
@@ -7,6 +7,8 @@ import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
 vi.mock('lucide-react', () => ({
   Bot: () => <svg data-icon="bot" />,
+  Check: () => <svg data-icon="check" />,
+  Copy: () => <svg data-icon="copy" />,
   Loader2: () => <svg data-icon="loader" />,
   RotateCcw: () => <svg data-icon="undo" />,
   User: () => <svg data-icon="user" />,
@@ -110,7 +112,8 @@ describe('ChatMessageItem turn-undo affordance', () => {
       );
     });
 
-    expect(container.querySelector('button')).toBeNull();
+    expect(container.querySelector('button[aria-label="Undo this turn"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Copy message to clipboard"]')).not.toBeNull();
   });
 });
 

--- a/apps/desktop/src/components/layout/ChatMessageItem.tsx
+++ b/apps/desktop/src/components/layout/ChatMessageItem.tsx
@@ -1,5 +1,7 @@
-import { memo, useMemo } from 'react';
-import { Bot, RotateCcw, User } from 'lucide-react';
+import { memo, useCallback, useMemo } from 'react';
+import { Bot, Check, Copy, RotateCcw, User } from 'lucide-react';
+import { useTransientFlag } from '@/components/apps/explorer/useTransientUiState';
+import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
 
 import {
   Message,
@@ -15,6 +17,30 @@ import { MemoryContextBlock } from './MemoryContextBlock';
 import { ResponseFeedback } from './ResponseFeedback';
 import { ThinkingIndicator } from './ChatPanelHelpers';
 import type { ChatMessage, ChatTurnUndoRef } from '@/types/ipc';
+
+function UserCopyButton({ text }: { text: string }) {
+  const [copied, showCopied] = useTransientFlag(2000);
+  const handleCopy = useCallback(async () => {
+    if (!(await copyTextToClipboard(text))) return;
+    showCopied();
+  }, [text, showCopied]);
+
+  return (
+    <div className="ml-auto flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100">
+      <button
+        onClick={handleCopy}
+        className="rounded-md p-1 transition-colors duration-100 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
+        title="Copy to clipboard"
+      >
+        {copied ? (
+          <Check className="size-3 text-[var(--status-success)]" />
+        ) : (
+          <Copy className="size-3" />
+        )}
+      </button>
+    </div>
+  );
+}
 
 function ChatAvatar({ kind }: { kind: 'user' | 'assistant' }) {
   const Icon = kind === 'user' ? User : Bot;
@@ -62,33 +88,36 @@ export const ChatMessageItem = memo(function ChatMessageItem({
       const canRestore = !!turnUndo && !!onRestoreTurnUndo;
 
       return (
-        <Message from="user">
+        <Message from="user" className="group/msg">
           <div className="ml-auto flex w-fit max-w-full items-start gap-2">
-            <div className="relative min-w-0">
-              <MessageContent
-                className={cn(
-                  'group-[.is-user]:bg-[var(--bg-elevated)]',
-                  canRestore && 'pr-8',
-                )}
-              >
-                <MessageResponse>{message.text}</MessageResponse>
-                {message.attachments?.length ? (
-                  <MessageAttachments attachments={message.attachments} />
-                ) : null}
-              </MessageContent>
+            <div className="flex min-w-0 flex-col">
+              <div className="relative min-w-0">
+                <MessageContent
+                  className={cn(
+                    'group-[.is-user]:bg-[var(--bg-elevated)]',
+                    canRestore && 'pr-8',
+                  )}
+                >
+                  <MessageResponse>{message.text}</MessageResponse>
+                  {message.attachments?.length ? (
+                    <MessageAttachments attachments={message.attachments} />
+                  ) : null}
+                </MessageContent>
 
-              {canRestore && turnUndo && onRestoreTurnUndo ? (
-                <MessageActions className="absolute top-1/2 right-0 -translate-y-1/2 translate-x-1/2">
-                  <MessageAction
-                    tooltip="Undo this turn"
-                    label="Undo this turn"
-                    className="h-7 w-7 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-muted)] shadow-sm hover:text-[var(--text-primary)]"
-                    onClick={() => onRestoreTurnUndo(turnUndo)}
-                  >
-                    <RotateCcw className="size-3.5" />
-                  </MessageAction>
-                </MessageActions>
-              ) : null}
+                {canRestore && turnUndo && onRestoreTurnUndo ? (
+                  <MessageActions className="absolute top-1/2 right-0 -translate-y-1/2 translate-x-1/2">
+                    <MessageAction
+                      tooltip="Undo this turn"
+                      label="Undo this turn"
+                      className="h-7 w-7 rounded-full border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-muted)] shadow-sm hover:text-[var(--text-primary)]"
+                      onClick={() => onRestoreTurnUndo(turnUndo)}
+                    >
+                      <RotateCcw className="size-3.5" />
+                    </MessageAction>
+                  </MessageActions>
+                ) : null}
+              </div>
+              {message.text ? <UserCopyButton text={message.text} /> : null}
             </div>
             <ChatAvatar kind="user" />
           </div>
@@ -142,6 +171,7 @@ export const ChatMessageItem = memo(function ChatMessageItem({
                 sessionId={sessionId}
                 promptExcerpt={promptExcerpt}
                 responseExcerpt={responseExcerpt}
+                responseText={message.text}
               />
             ) : null}
           </div>

--- a/apps/desktop/src/components/layout/ChatMessageItem.tsx
+++ b/apps/desktop/src/components/layout/ChatMessageItem.tsx
@@ -26,8 +26,15 @@ function UserCopyButton({ text }: { text: string }) {
   }, [text, showCopied]);
 
   return (
-    <div className="ml-auto flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100">
+    <div
+      className={cn(
+        'ml-auto flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 focus-within:opacity-100',
+        copied && 'opacity-100',
+      )}
+    >
       <button
+        type="button"
+        aria-label="Copy message to clipboard"
         onClick={handleCopy}
         className="rounded-md p-1 transition-colors duration-100 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
         title="Copy to clipboard"

--- a/apps/desktop/src/components/layout/ResponseFeedback.tsx
+++ b/apps/desktop/src/components/layout/ResponseFeedback.tsx
@@ -6,9 +6,11 @@
  */
 
 import { useCallback } from 'react';
-import { ThumbsUp, ThumbsDown } from 'lucide-react';
+import { ThumbsUp, ThumbsDown, Copy, Check } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { useFeedbackStore } from '@/stores/feedback';
+import { useTransientFlag } from '@/components/apps/explorer/useTransientUiState';
+import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
 
 interface ResponseFeedbackProps {
   messageId: string;
@@ -17,6 +19,8 @@ interface ResponseFeedbackProps {
   promptExcerpt?: string;
   /** Excerpt of the assistant's response text. */
   responseExcerpt?: string;
+  /** Full response text for copy-to-clipboard. */
+  responseText?: string;
 }
 
 export function ResponseFeedback({
@@ -24,10 +28,19 @@ export function ResponseFeedback({
   sessionId,
   promptExcerpt,
   responseExcerpt,
+  responseText,
 }: ResponseFeedbackProps) {
   const rating = useFeedbackStore((s) => s.ratings[messageId]);
   const rate = useFeedbackStore((s) => s.rate);
   const unrate = useFeedbackStore((s) => s.unrate);
+  const [copied, showCopied] = useTransientFlag(2000);
+
+  const handleCopy = useCallback(async () => {
+    const text = responseText ?? responseExcerpt;
+    if (!text) return;
+    if (!(await copyTextToClipboard(text))) return;
+    showCopied();
+  }, [responseText, responseExcerpt, showCopied]);
 
   const handleRate = useCallback(
     (value: 'good' | 'bad') => {
@@ -74,6 +87,17 @@ export function ResponseFeedback({
         title="Bad response"
       >
         <ThumbsDown className="size-3" />
+      </button>
+      <button
+        onClick={handleCopy}
+        className="rounded-md p-1 transition-colors duration-100 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
+        title="Copy to clipboard"
+      >
+        {copied ? (
+          <Check className="size-3 text-[var(--status-success)]" />
+        ) : (
+          <Copy className="size-3" />
+        )}
       </button>
     </div>
   );

--- a/apps/desktop/src/components/layout/ResponseFeedback.tsx
+++ b/apps/desktop/src/components/layout/ResponseFeedback.tsx
@@ -61,8 +61,14 @@ export function ResponseFeedback({
   );
 
   return (
-    <div className="flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 has-[button[data-active=true]]:opacity-100">
+    <div
+      className={cn(
+        'flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/msg:opacity-100 focus-within:opacity-100 has-[button[data-active=true]]:opacity-100',
+        copied && 'opacity-100',
+      )}
+    >
       <button
+        type="button"
         data-active={rating === 'good'}
         onClick={() => handleRate('good')}
         className={cn(
@@ -76,6 +82,7 @@ export function ResponseFeedback({
         <ThumbsUp className="size-3" />
       </button>
       <button
+        type="button"
         data-active={rating === 'bad'}
         onClick={() => handleRate('bad')}
         className={cn(
@@ -89,6 +96,8 @@ export function ResponseFeedback({
         <ThumbsDown className="size-3" />
       </button>
       <button
+        type="button"
+        aria-label="Copy response to clipboard"
         onClick={handleCopy}
         className="rounded-md p-1 transition-colors duration-100 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
         title="Copy to clipboard"


### PR DESCRIPTION
Adds a Copy icon button alongside the existing thumbs up/down feedback
buttons on assistant messages, and below user message bubbles. Clicking
copies the full message text; the icon switches to a Check for 2 s as
confirmation. Both buttons appear on hover via group-hover/msg.

https://claude.ai/code/session_01UNKXieaooUCJ9AaChawC5Z