### PR TITLE
feat(desktop): add in-app web browser with tabs to Explorer

### DIFF
--- a/apps/desktop/electron/cli/commands/browser/browser.ts
+++ b/apps/desktop/electron/cli/commands/browser/browser.ts
@@ -102,12 +102,8 @@ async function handleBrowser(
     case 'open': {
       const url = positionals[0];
       if (!url) return fail('Usage: sero browser open <url>');
-      try {
-        new URL(url);
-      } catch {
-        return fail(`Not a valid URL: ${url}`);
-      }
       const tabId = browserViewManager.openTabForHost(url, ctx.workspaceId);
+      if (!tabId) return fail(`Unsupported browser URL: ${url}. Use http(s) URLs only.`);
       return ok(`Opened tab ${tabId} in workspace "${ctx.workspaceId}" → ${url}`);
     }
 
@@ -143,7 +139,10 @@ async function handleBrowser(
         );
       }
       try {
-        new URL(url);
+        const parsed = new URL(url);
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          return fail(`Unsupported browser URL: ${url}. Use http(s) URLs only.`);
+        }
       } catch {
         return fail(`Not a valid URL: ${url}`);
       }

--- a/apps/desktop/electron/cli/commands/browser/browser.ts
+++ b/apps/desktop/electron/cli/commands/browser/browser.ts
@@ -1,0 +1,182 @@
+/**
+ * `sero browser` — lets the agent drive the in-app web browser directly,
+ * without going through a plugin extension.
+ *
+ * Registered straight onto the CliRegistry (the same surface that
+ * `pi.registerTool` ultimately funnels into for plugins). This is the
+ * intended path for built-in host features: plugins get the `registerTool`
+ * convenience; the host owns the registry.
+ *
+ * Subcommands:
+ *   list [--all]                List loaded tabs (default: current workspace)
+ *   open <url>                  Open a new tab in the current workspace
+ *   close <tab-id>              Close a tab
+ *   navigate <tab-id> <url>     Point an existing tab at a new URL
+ *   get-text [--tab <id>]       Extract title + plain text from the tab
+ *   screenshot [--tab <id>]     Return a PNG of the tab as an image block
+ *
+ * Tab ids for `get-text` / `screenshot` default to the active tab of the
+ * invoking workspace. If no tab is active and no --tab is supplied, the
+ * command fails — the agent can list first and pick.
+ */
+
+import { browserViewManager } from '@electron/features/browser/view-manager';
+import type { CliRegistry } from '@electron/cli/core/registry';
+import type { CliCommandContext, CliResult } from '@electron/cli/core/types';
+import { fail, ok, parseFlags } from '@electron/cli/lib/utils';
+
+function resolveTabId(
+  explicit: string | undefined,
+  ctx: CliCommandContext,
+): { tabId: string } | { error: string } {
+  if (explicit) {
+    if (!browserViewManager.hasTab(explicit)) {
+      return { error: `Unknown or unloaded tab: ${explicit}` };
+    }
+    return { tabId: explicit };
+  }
+  const active = browserViewManager.resolveActiveTabForWorkspace(ctx.workspaceId);
+  if (!active) {
+    return {
+      error:
+        `No active tab in workspace "${ctx.workspaceId}". ` +
+        `Run 'sero browser list' to see loaded tabs or 'sero browser open <url>' first.`,
+    };
+  }
+  return { tabId: active };
+}
+
+function formatTabRow(info: {
+  id: string;
+  workspaceId: string;
+  url: string;
+  title: string;
+  isActive: boolean;
+}): string {
+  const marker = info.isActive ? '● ' : '  ';
+  const title = info.title || '(untitled)';
+  return `${marker}${info.id}  [${info.workspaceId}]  ${title}\n    ${info.url}`;
+}
+
+async function handleBrowser(
+  args: string[],
+  ctx: CliCommandContext,
+): Promise<CliResult> {
+  const [action, ...rest] = args;
+  const { positionals, flags } = parseFlags(rest);
+
+  switch (action) {
+    case undefined:
+    case 'list': {
+      const wantsAll = flags.get('all') === true;
+      const list = browserViewManager.listLoadedTabs(
+        wantsAll ? undefined : ctx.workspaceId,
+      );
+      if (list.length === 0) {
+        return ok(
+          wantsAll
+            ? 'No tabs are currently loaded in any workspace.'
+            : `No tabs are currently loaded in workspace "${ctx.workspaceId}". ` +
+                `Use 'sero browser open <url>' to open one.`,
+        );
+      }
+      const body = list.map(formatTabRow).join('\n');
+      return ok(body);
+    }
+
+    case 'open': {
+      const url = positionals[0];
+      if (!url) return fail('Usage: sero browser open <url>');
+      try {
+        new URL(url);
+      } catch {
+        return fail(`Not a valid URL: ${url}`);
+      }
+      const tabId = browserViewManager.openTabForHost(url, ctx.workspaceId);
+      return ok(`Opened tab ${tabId} in workspace "${ctx.workspaceId}" → ${url}`);
+    }
+
+    case 'close': {
+      const tabId = positionals[0];
+      if (!tabId) return fail('Usage: sero browser close <tab-id>');
+      const closed = browserViewManager.closeTabForHost(tabId);
+      if (!closed) return fail(`Unknown or already-closed tab: ${tabId}`);
+      return ok(`Closed tab ${tabId}`);
+    }
+
+    case 'navigate': {
+      const tabId = positionals[0];
+      const url = positionals[1];
+      if (!tabId || !url) return fail('Usage: sero browser navigate <tab-id> <url>');
+      if (!browserViewManager.hasTab(tabId)) {
+        return fail(`Unknown or unloaded tab: ${tabId}`);
+      }
+      try {
+        new URL(url);
+      } catch {
+        return fail(`Not a valid URL: ${url}`);
+      }
+      browserViewManager.navigate(tabId, url);
+      return ok(`Navigating tab ${tabId} → ${url}`);
+    }
+
+    case 'get-text': {
+      const resolved = resolveTabId(
+        typeof flags.get('tab') === 'string' ? (flags.get('tab') as string) : undefined,
+        ctx,
+      );
+      if ('error' in resolved) return fail(resolved.error);
+      const page = await browserViewManager.extractPage(resolved.tabId);
+      if (!page) return fail(`Failed to extract text from tab ${resolved.tabId}`);
+      const header = page.title
+        ? `# ${page.title}\n\n_${page.url}_\n\n`
+        : `_${page.url}_\n\n`;
+      return ok(`${header}${page.text}`);
+    }
+
+    case 'screenshot': {
+      const resolved = resolveTabId(
+        typeof flags.get('tab') === 'string' ? (flags.get('tab') as string) : undefined,
+        ctx,
+      );
+      if ('error' in resolved) return fail(resolved.error);
+      const base64 = await browserViewManager.capturePage(resolved.tabId);
+      if (!base64) return fail(`Failed to capture tab ${resolved.tabId}`);
+      return {
+        output: `Captured tab ${resolved.tabId}`,
+        exitCode: 0,
+        content: [{ type: 'image', data: base64, mimeType: 'image/png' }],
+      };
+    }
+
+    default:
+      return fail(`Unknown browser action: ${action}`);
+  }
+}
+
+export function registerBrowserCliCommands(registry: CliRegistry): void {
+  registry.register({
+    name: 'browser',
+    summary: 'Drive the in-app web browser (list, open, close, navigate, get-text, screenshot)',
+    help:
+      'browser — Drive the in-app web browser\n\n' +
+      'Usage: sero browser <action> [args]\n\n' +
+      'Actions:\n' +
+      '  list [--all]                 List loaded tabs in the current workspace (default)\n' +
+      '                               or across all workspaces (--all)\n' +
+      '  open <url>                   Open a new tab in the current workspace\n' +
+      '  close <tab-id>               Close a tab\n' +
+      '  navigate <tab-id> <url>      Point an existing tab at a new URL\n' +
+      '  get-text [--tab <id>]        Extract the page as title + plain text. Defaults\n' +
+      '                               to the active tab of the current workspace.\n' +
+      '  screenshot [--tab <id>]      Return a PNG of the tab as an image block. Defaults\n' +
+      '                               to the active tab of the current workspace.\n\n' +
+      'Tabs in a workspace share a persistent session partition (cookies/logins\n' +
+      'isolated per workspace). Tabs only appear in `list` once their view has\n' +
+      'been loaded — persisted tabs are loaded lazily when the user opens the\n' +
+      'Browser panel.',
+    source: 'ipc',
+    group: 'Builtin',
+    execute: handleBrowser,
+  });
+}

--- a/apps/desktop/electron/cli/commands/browser/browser.ts
+++ b/apps/desktop/electron/cli/commands/browser/browser.ts
@@ -25,13 +25,28 @@ import type { CliRegistry } from '@electron/cli/core/registry';
 import type { CliCommandContext, CliResult } from '@electron/cli/core/types';
 import { fail, ok, parseFlags } from '@electron/cli/lib/utils';
 
+/**
+ * Resolve an agent-supplied tab reference to a concrete id, enforcing
+ * workspace ownership. An explicit `--tab <id>` is accepted only if the
+ * tab actually belongs to the invoking workspace — otherwise an agent
+ * that learned a tab id through `list --all` could reach across workspace
+ * boundaries.
+ */
 function resolveTabId(
   explicit: string | undefined,
   ctx: CliCommandContext,
 ): { tabId: string } | { error: string } {
   if (explicit) {
-    if (!browserViewManager.hasTab(explicit)) {
+    const owner = browserViewManager.workspaceForTab(explicit);
+    if (!owner) {
       return { error: `Unknown or unloaded tab: ${explicit}` };
+    }
+    if (owner !== ctx.workspaceId) {
+      return {
+        error:
+          `Tab ${explicit} belongs to workspace "${owner}", not the current ` +
+          `workspace "${ctx.workspaceId}". Switch workspaces to access it.`,
+      };
     }
     return { tabId: explicit };
   }
@@ -99,8 +114,19 @@ async function handleBrowser(
     case 'close': {
       const tabId = positionals[0];
       if (!tabId) return fail('Usage: sero browser close <tab-id>');
-      const closed = browserViewManager.closeTabForHost(tabId);
-      if (!closed) return fail(`Unknown or already-closed tab: ${tabId}`);
+      // closeTabForHost now enforces workspace ownership itself; check first
+      // so we can return a precise error instead of a silent no-op.
+      const owner = browserViewManager.workspaceForTab(tabId);
+      if (!owner) return fail(`Unknown or already-closed tab: ${tabId}`);
+      if (owner !== ctx.workspaceId) {
+        return fail(
+          `Tab ${tabId} belongs to workspace "${owner}", not "${ctx.workspaceId}". ` +
+            `Refusing to close.`,
+        );
+      }
+      if (!browserViewManager.closeTabForHost(tabId, ctx.workspaceId)) {
+        return fail(`Failed to close tab ${tabId}`);
+      }
       return ok(`Closed tab ${tabId}`);
     }
 
@@ -108,15 +134,20 @@ async function handleBrowser(
       const tabId = positionals[0];
       const url = positionals[1];
       if (!tabId || !url) return fail('Usage: sero browser navigate <tab-id> <url>');
-      if (!browserViewManager.hasTab(tabId)) {
-        return fail(`Unknown or unloaded tab: ${tabId}`);
+      const owner = browserViewManager.workspaceForTab(tabId);
+      if (!owner) return fail(`Unknown or unloaded tab: ${tabId}`);
+      if (owner !== ctx.workspaceId) {
+        return fail(
+          `Tab ${tabId} belongs to workspace "${owner}", not "${ctx.workspaceId}". ` +
+            `Refusing to navigate.`,
+        );
       }
       try {
         new URL(url);
       } catch {
         return fail(`Not a valid URL: ${url}`);
       }
-      browserViewManager.navigate(tabId, url);
+      browserViewManager.navigate(tabId, url, ctx.workspaceId);
       return ok(`Navigating tab ${tabId} → ${url}`);
     }
 
@@ -126,7 +157,7 @@ async function handleBrowser(
         ctx,
       );
       if ('error' in resolved) return fail(resolved.error);
-      const page = await browserViewManager.extractPage(resolved.tabId);
+      const page = await browserViewManager.extractPage(resolved.tabId, ctx.workspaceId);
       if (!page) return fail(`Failed to extract text from tab ${resolved.tabId}`);
       const header = page.title
         ? `# ${page.title}\n\n_${page.url}_\n\n`
@@ -140,7 +171,7 @@ async function handleBrowser(
         ctx,
       );
       if ('error' in resolved) return fail(resolved.error);
-      const base64 = await browserViewManager.capturePage(resolved.tabId);
+      const base64 = await browserViewManager.capturePage(resolved.tabId, ctx.workspaceId);
       if (!base64) return fail(`Failed to capture tab ${resolved.tabId}`);
       return {
         output: `Captured tab ${resolved.tabId}`,

--- a/apps/desktop/electron/cli/commands/browser/index.ts
+++ b/apps/desktop/electron/cli/commands/browser/index.ts
@@ -1,0 +1,1 @@
+export { registerBrowserCliCommands } from './browser';

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -9,6 +9,7 @@ import {
   registerTerminalCliCommands,
 } from './commands/container';
 import { registerEditorCliCommands } from './commands/editor';
+import { registerBrowserCliCommands } from './commands/browser';
 import { registerSessionCliCommands } from './commands/agent';
 import { registerVcsCliCommands } from './commands/vcs';
 import { registerWorkspaceCliCommands } from './commands/workspace';
@@ -48,6 +49,7 @@ function registerCoreCommands(target: CliRegistry): void {
   registerEditorCliCommands(target);
   registerAppStateCliCommands(target);
   registerTerminalCliCommands(target);
+  registerBrowserCliCommands(target);
   registerHelpCliCommand(target);
 }
 

--- a/apps/desktop/electron/features/browser/context-menu.ts
+++ b/apps/desktop/electron/features/browser/context-menu.ts
@@ -1,0 +1,121 @@
+/**
+ * Builds the native context menu shown inside a browser tab's WebContents.
+ *
+ * The WebContentsView has no built-in chrome so we own the menu entirely.
+ * Items are gated on the Electron ContextMenuParams — `selectionText`,
+ * `linkURL`, `srcURL`/`mediaType`, `isEditable` — so we only show actions
+ * that make sense for what the user actually right-clicked on.
+ */
+
+import { Menu, clipboard } from 'electron';
+import type {
+  BrowserWindow,
+  ContextMenuParams,
+  MenuItemConstructorOptions,
+  WebContentsView,
+} from 'electron';
+import type { BrowserEvent } from '@/types/browser';
+
+interface ShowContextMenuOptions {
+  tabId: string;
+  workspaceId: string;
+  view: WebContentsView;
+  params: ContextMenuParams;
+  window: BrowserWindow | null;
+  emit: (event: BrowserEvent) => void;
+}
+
+export function showBrowserContextMenu(opts: ShowContextMenuOptions): void {
+  const { tabId, workspaceId, view, params, window, emit } = opts;
+  const wc = view.webContents;
+  const items: MenuItemConstructorOptions[] = [];
+
+  if (params.selectionText && params.selectionText.trim()) {
+    items.push({
+      label: 'Add to Sero Chat',
+      click: () => {
+        emit({
+          tabId,
+          workspaceId,
+          kind: 'selection-to-chat',
+          selection: params.selectionText,
+          pageUrl: wc.getURL(),
+          pageTitle: wc.getTitle(),
+        });
+      },
+    });
+    items.push({
+      label: 'Save to Memory',
+      click: () => {
+        emit({
+          tabId,
+          workspaceId,
+          kind: 'selection-to-memory',
+          selection: params.selectionText,
+          pageUrl: wc.getURL(),
+          pageTitle: wc.getTitle(),
+        });
+      },
+    });
+    items.push({ type: 'separator' });
+    items.push({ label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy });
+  }
+
+  if (params.linkURL) {
+    if (items.length) items.push({ type: 'separator' });
+    items.push({
+      label: 'Open Link in New Tab',
+      click: () => {
+        emit({ tabId, workspaceId, kind: 'new-tab-request', url: params.linkURL });
+      },
+    });
+    items.push({
+      label: 'Copy Link Address',
+      click: () => clipboard.writeText(params.linkURL),
+    });
+  }
+
+  if (params.srcURL && params.mediaType === 'image') {
+    if (items.length) items.push({ type: 'separator' });
+    items.push({
+      label: 'Open Image in New Tab',
+      click: () => {
+        emit({ tabId, workspaceId, kind: 'new-tab-request', url: params.srcURL });
+      },
+    });
+    items.push({
+      label: 'Copy Image Address',
+      click: () => clipboard.writeText(params.srcURL),
+    });
+  }
+
+  if (params.isEditable) {
+    if (items.length) items.push({ type: 'separator' });
+    items.push({ label: 'Cut', role: 'cut', enabled: params.editFlags.canCut });
+    items.push({ label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy });
+    items.push({ label: 'Paste', role: 'paste', enabled: params.editFlags.canPaste });
+    items.push({ label: 'Select All', role: 'selectAll', enabled: params.editFlags.canSelectAll });
+  }
+
+  if (items.length) items.push({ type: 'separator' });
+  items.push({
+    label: 'Back',
+    enabled: wc.navigationHistory.canGoBack(),
+    click: () => wc.navigationHistory.goBack(),
+  });
+  items.push({
+    label: 'Forward',
+    enabled: wc.navigationHistory.canGoForward(),
+    click: () => wc.navigationHistory.goForward(),
+  });
+  items.push({ label: 'Reload', click: () => wc.reload() });
+
+  items.push({ type: 'separator' });
+  items.push({
+    label: 'Inspect Element',
+    click: () => wc.inspectElement(params.x, params.y),
+  });
+
+  const menu = Menu.buildFromTemplate(items);
+  menu.popup({ window: window ?? undefined });
+}

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -16,10 +16,11 @@
  *   - the main window is closed (each view's wc is destroyed with the parent)
  */
 
-import { BrowserWindow, Menu, WebContentsView, clipboard, shell, session } from 'electron';
-import type { ContextMenuParams, MenuItemConstructorOptions, WebContents } from 'electron';
+import { BrowserWindow, WebContentsView, shell, session } from 'electron';
+import type { WebContents } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
 import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
+import { showBrowserContextMenu } from './context-menu';
 
 const BROWSER_PARTITION_PREFIX = 'persist:sero-browser';
 
@@ -36,9 +37,22 @@ function partitionFor(workspaceId: string): string {
 /** Position used to "hide" a view without destroying it. */
 const HIDDEN_BOUNDS = { x: 0, y: 0, width: 0, height: 0 } as const;
 
+/** Public snapshot of a loaded tab, returned by listLoadedTabs. */
+export interface LoadedTabInfo {
+  id: string;
+  workspaceId: string;
+  url: string;
+  title: string;
+  isActive: boolean;
+}
+
 class BrowserViewManager {
   private window: BrowserWindow | null = null;
   private readonly views = new Map<string, WebContentsView>();
+  /** Tracks the workspace each view belongs to (mirror of wireViewEvents closure). */
+  private readonly viewWorkspaces = new Map<string, string>();
+  /** Most-recently-activated tab per workspace, updated by setActive. */
+  private readonly lastActivePerWorkspace = new Map<string, string>();
   private activeTabId: string | null = null;
   private currentBounds: BrowserViewBounds = { ...HIDDEN_BOUNDS };
 
@@ -47,6 +61,8 @@ class BrowserViewManager {
     window.on('closed', () => {
       // Views are destroyed with the window; just drop our refs.
       this.views.clear();
+      this.viewWorkspaces.clear();
+      this.lastActivePerWorkspace.clear();
       this.window = null;
       this.activeTabId = null;
     });
@@ -95,6 +111,7 @@ class BrowserViewManager {
     }
 
     this.views.set(tabId, view);
+    this.viewWorkspaces.set(tabId, workspaceId);
 
     // Park off-screen until explicitly shown. addChildView places it on top,
     // but zero-size bounds keep it invisible.
@@ -109,7 +126,12 @@ class BrowserViewManager {
   closeTab(tabId: string): void {
     const view = this.views.get(tabId);
     if (!view) return;
+    const workspaceId = this.viewWorkspaces.get(tabId);
     this.views.delete(tabId);
+    this.viewWorkspaces.delete(tabId);
+    if (workspaceId && this.lastActivePerWorkspace.get(workspaceId) === tabId) {
+      this.lastActivePerWorkspace.delete(workspaceId);
+    }
     if (this.activeTabId === tabId) {
       this.activeTabId = null;
     }
@@ -125,6 +147,10 @@ class BrowserViewManager {
   /** Show the given tab's view at the current panel bounds, hide all others. */
   setActive(tabId: string | null): void {
     this.activeTabId = tabId;
+    if (tabId) {
+      const workspaceId = this.viewWorkspaces.get(tabId);
+      if (workspaceId) this.lastActivePerWorkspace.set(workspaceId, tabId);
+    }
     for (const [id, view] of this.views) {
       if (id === tabId) {
         view.setBounds(this.currentBounds);
@@ -222,6 +248,63 @@ class BrowserViewManager {
   }
 
   /**
+   * Open a new tab from the host (CLI bridge, agent tools). Assigns a
+   * fresh id, creates the view, and emits `host-tab-opened` so the
+   * renderer store mirrors it in its tab list. Returns the new tab id.
+   */
+  openTabForHost(url: string, workspaceId: string): string {
+    const tabId = `tab_host_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+    this.openTab(tabId, url, workspaceId);
+    this.emit({ tabId, workspaceId, kind: 'host-tab-opened', url });
+    return tabId;
+  }
+
+  /**
+   * Close a tab from the host. Emits `host-tab-closed` so the renderer
+   * store removes its entry. Returns false if the tab is unknown.
+   */
+  closeTabForHost(tabId: string): boolean {
+    const workspaceId = this.viewWorkspaces.get(tabId);
+    if (!workspaceId) return false;
+    this.closeTab(tabId);
+    this.emit({ tabId, workspaceId, kind: 'host-tab-closed' });
+    return true;
+  }
+
+  /** Snapshot of currently-loaded tabs, optionally filtered by workspace. */
+  listLoadedTabs(workspaceId?: string): LoadedTabInfo[] {
+    const out: LoadedTabInfo[] = [];
+    for (const [id, view] of this.views) {
+      const ws = this.viewWorkspaces.get(id) ?? 'global';
+      if (workspaceId && ws !== workspaceId) continue;
+      const wc = view.webContents;
+      out.push({
+        id,
+        workspaceId: ws,
+        url: wc.getURL(),
+        title: wc.getTitle(),
+        isActive: this.lastActivePerWorkspace.get(ws) === id,
+      });
+    }
+    return out;
+  }
+
+  /** Most-recently-activated tab id for a workspace, or null. */
+  resolveActiveTabForWorkspace(workspaceId: string): string | null {
+    return this.lastActivePerWorkspace.get(workspaceId) ?? null;
+  }
+
+  /** Whether a given tab id exists as a loaded WebContentsView. */
+  hasTab(tabId: string): boolean {
+    return this.views.has(tabId);
+  }
+
+  /** Workspace a tab belongs to, or null if unknown. */
+  workspaceForTab(tabId: string): string | null {
+    return this.viewWorkspaces.get(tabId) ?? null;
+  }
+
+  /**
    * Capture the tab as a PNG. Returns a base64 string (no data URI prefix).
    * The optional rect is in CSS pixels relative to the view's top-left.
    */
@@ -307,107 +390,15 @@ class BrowserViewManager {
 
     // The WebContentsView has no built-in chrome — we own the context menu.
     wc.on('context-menu', (_e, params) => {
-      this.showContextMenu(tabId, view, params, workspaceId);
+      showBrowserContextMenu({
+        tabId,
+        workspaceId,
+        view,
+        params,
+        window: this.window,
+        emit: (event) => this.emit(event),
+      });
     });
-  }
-
-  private showContextMenu(
-    tabId: string,
-    view: WebContentsView,
-    params: ContextMenuParams,
-    workspaceId: string,
-  ): void {
-    const wc = view.webContents;
-    const items: MenuItemConstructorOptions[] = [];
-
-    if (params.selectionText && params.selectionText.trim()) {
-      items.push({
-        label: 'Add to Sero Chat',
-        click: () => {
-          this.emit({
-            tabId,
-            workspaceId,
-            kind: 'selection-to-chat',
-            selection: params.selectionText,
-            pageUrl: wc.getURL(),
-            pageTitle: wc.getTitle(),
-          });
-        },
-      });
-      items.push({
-        label: 'Save to Memory',
-        click: () => {
-          this.emit({
-            tabId,
-            workspaceId,
-            kind: 'selection-to-memory',
-            selection: params.selectionText,
-            pageUrl: wc.getURL(),
-            pageTitle: wc.getTitle(),
-          });
-        },
-      });
-      items.push({ type: 'separator' });
-      items.push({ label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy });
-    }
-
-    if (params.linkURL) {
-      if (items.length) items.push({ type: 'separator' });
-      items.push({
-        label: 'Open Link in New Tab',
-        click: () => {
-          this.emit({ tabId, workspaceId, kind: 'new-tab-request', url: params.linkURL });
-        },
-      });
-      items.push({
-        label: 'Copy Link Address',
-        click: () => clipboard.writeText(params.linkURL),
-      });
-    }
-
-    if (params.srcURL && params.mediaType === 'image') {
-      if (items.length) items.push({ type: 'separator' });
-      items.push({
-        label: 'Open Image in New Tab',
-        click: () => {
-          this.emit({ tabId, workspaceId, kind: 'new-tab-request', url: params.srcURL });
-        },
-      });
-      items.push({
-        label: 'Copy Image Address',
-        click: () => clipboard.writeText(params.srcURL),
-      });
-    }
-
-    if (params.isEditable) {
-      if (items.length) items.push({ type: 'separator' });
-      items.push({ label: 'Cut', role: 'cut', enabled: params.editFlags.canCut });
-      items.push({ label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy });
-      items.push({ label: 'Paste', role: 'paste', enabled: params.editFlags.canPaste });
-      items.push({ label: 'Select All', role: 'selectAll', enabled: params.editFlags.canSelectAll });
-    }
-
-    if (items.length) items.push({ type: 'separator' });
-    items.push({
-      label: 'Back',
-      enabled: wc.navigationHistory.canGoBack(),
-      click: () => wc.navigationHistory.goBack(),
-    });
-    items.push({
-      label: 'Forward',
-      enabled: wc.navigationHistory.canGoForward(),
-      click: () => wc.navigationHistory.goForward(),
-    });
-    items.push({ label: 'Reload', click: () => wc.reload() });
-
-    items.push({ type: 'separator' });
-    items.push({
-      label: 'Inspect Element',
-      click: () => wc.inspectElement(params.x, params.y),
-    });
-
-    const menu = Menu.buildFromTemplate(items);
-    menu.popup({ window: this.window ?? undefined });
   }
 
   private emit(event: BrowserEvent): void {

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -123,13 +123,13 @@ class BrowserViewManager {
     });
   }
 
-  closeTab(tabId: string): void {
+  closeTab(tabId: string, workspaceId: string): void {
+    if (!this.ownsTab(tabId, workspaceId, 'closeTab')) return;
     const view = this.views.get(tabId);
     if (!view) return;
-    const workspaceId = this.viewWorkspaces.get(tabId);
     this.views.delete(tabId);
     this.viewWorkspaces.delete(tabId);
-    if (workspaceId && this.lastActivePerWorkspace.get(workspaceId) === tabId) {
+    if (this.lastActivePerWorkspace.get(workspaceId) === tabId) {
       this.lastActivePerWorkspace.delete(workspaceId);
     }
     if (this.activeTabId === tabId) {
@@ -144,12 +144,17 @@ class BrowserViewManager {
     wc.destroy?.();
   }
 
-  /** Show the given tab's view at the current panel bounds, hide all others. */
-  setActive(tabId: string | null): void {
+  /**
+   * Show the given tab's view at the current panel bounds, hide all others.
+   * Pass `tabId = null` (and the caller's workspace) to deactivate.
+   */
+  setActive(tabId: string | null, workspaceId: string): void {
+    if (tabId && !this.ownsTab(tabId, workspaceId, 'setActive')) return;
     this.activeTabId = tabId;
     if (tabId) {
-      const workspaceId = this.viewWorkspaces.get(tabId);
-      if (workspaceId) this.lastActivePerWorkspace.set(workspaceId, tabId);
+      this.lastActivePerWorkspace.set(workspaceId, tabId);
+    } else {
+      this.lastActivePerWorkspace.delete(workspaceId);
     }
     for (const [id, view] of this.views) {
       if (id === tabId) {
@@ -176,7 +181,8 @@ class BrowserViewManager {
     }
   }
 
-  navigate(tabId: string, url: string): void {
+  navigate(tabId: string, url: string, workspaceId: string): void {
+    if (!this.ownsTab(tabId, workspaceId, 'navigate')) return;
     const view = this.views.get(tabId);
     if (!view) return;
     void view.webContents.loadURL(url).catch(() => {
@@ -184,21 +190,25 @@ class BrowserViewManager {
     });
   }
 
-  goBack(tabId: string): void {
+  goBack(tabId: string, workspaceId: string): void {
+    if (!this.ownsTab(tabId, workspaceId, 'goBack')) return;
     const wc = this.views.get(tabId)?.webContents;
     if (wc?.navigationHistory?.canGoBack()) wc.navigationHistory.goBack();
   }
 
-  goForward(tabId: string): void {
+  goForward(tabId: string, workspaceId: string): void {
+    if (!this.ownsTab(tabId, workspaceId, 'goForward')) return;
     const wc = this.views.get(tabId)?.webContents;
     if (wc?.navigationHistory?.canGoForward()) wc.navigationHistory.goForward();
   }
 
-  reload(tabId: string): void {
+  reload(tabId: string, workspaceId: string): void {
+    if (!this.ownsTab(tabId, workspaceId, 'reload')) return;
     this.views.get(tabId)?.webContents.reload();
   }
 
-  stop(tabId: string): void {
+  stop(tabId: string, workspaceId: string): void {
+    if (!this.ownsTab(tabId, workspaceId, 'stop')) return;
     this.views.get(tabId)?.webContents.stop();
   }
 
@@ -211,7 +221,9 @@ class BrowserViewManager {
    */
   async extractPage(
     tabId: string,
+    workspaceId: string,
   ): Promise<{ title: string; url: string; text: string } | null> {
+    if (!this.ownsTab(tabId, workspaceId, 'extractPage')) return null;
     const wc = this.views.get(tabId)?.webContents;
     if (!wc) return null;
     const script = `(() => {
@@ -260,13 +272,14 @@ class BrowserViewManager {
   }
 
   /**
-   * Close a tab from the host. Emits `host-tab-closed` so the renderer
-   * store removes its entry. Returns false if the tab is unknown.
+   * Close a tab from the host. Validates that the tab belongs to the
+   * caller's workspace, then emits `host-tab-closed` so the renderer
+   * store removes its entry. Returns false if the tab is unknown or
+   * belongs to a different workspace.
    */
-  closeTabForHost(tabId: string): boolean {
-    const workspaceId = this.viewWorkspaces.get(tabId);
-    if (!workspaceId) return false;
-    this.closeTab(tabId);
+  closeTabForHost(tabId: string, workspaceId: string): boolean {
+    if (!this.ownsTab(tabId, workspaceId, 'closeTabForHost')) return false;
+    this.closeTab(tabId, workspaceId);
     this.emit({ tabId, workspaceId, kind: 'host-tab-closed' });
     return true;
   }
@@ -305,13 +318,38 @@ class BrowserViewManager {
   }
 
   /**
+   * Authorization gate for every tab-scoped operation. Returns true iff
+   * `tabId` exists and belongs to `workspaceId`. Mismatches are logged —
+   * they indicate either a renderer bug or a tampered IPC call and should
+   * never happen in normal use.
+   */
+  private ownsTab(tabId: string, workspaceId: string, op: string): boolean {
+    const owner = this.viewWorkspaces.get(tabId);
+    if (!owner) {
+      // Unknown tab — operation silently dropped. Not logged because this
+      // fires normally during race conditions (e.g. close + late reload).
+      return false;
+    }
+    if (owner !== workspaceId) {
+      console.warn(
+        `[browser] ${op}: tab ${tabId} belongs to workspace "${owner}" but ` +
+          `caller claimed "${workspaceId}" — rejecting.`,
+      );
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Capture the tab as a PNG. Returns a base64 string (no data URI prefix).
    * The optional rect is in CSS pixels relative to the view's top-left.
    */
   async capturePage(
     tabId: string,
+    workspaceId: string,
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<string | null> {
+    if (!this.ownsTab(tabId, workspaceId, 'capturePage')) return null;
     const wc = this.views.get(tabId)?.webContents;
     if (!wc) return null;
     try {

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -16,8 +16,8 @@
  *   - the main window is closed (each view's wc is destroyed with the parent)
  */
 
-import { BrowserWindow, WebContentsView, shell, session } from 'electron';
-import type { WebContents } from 'electron';
+import { BrowserWindow, Menu, WebContentsView, clipboard, shell, session } from 'electron';
+import type { ContextMenuParams, MenuItemConstructorOptions, WebContents } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
 import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
 
@@ -226,6 +226,95 @@ class BrowserViewManager {
       if (!isMainFrame) return;
       this.emit({ tabId, kind: 'did-fail-load', errorDescription });
     });
+
+    // The WebContentsView has no built-in chrome — we own the context menu.
+    wc.on('context-menu', (_e, params) => {
+      this.showContextMenu(tabId, view, params);
+    });
+  }
+
+  private showContextMenu(
+    tabId: string,
+    view: WebContentsView,
+    params: ContextMenuParams,
+  ): void {
+    const wc = view.webContents;
+    const items: MenuItemConstructorOptions[] = [];
+
+    if (params.selectionText && params.selectionText.trim()) {
+      items.push({
+        label: 'Add to Sero Chat',
+        click: () => {
+          this.emit({
+            tabId,
+            kind: 'selection-to-chat',
+            selection: params.selectionText,
+            pageUrl: wc.getURL(),
+            pageTitle: wc.getTitle(),
+          });
+        },
+      });
+      items.push({ type: 'separator' });
+      items.push({ label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy });
+    }
+
+    if (params.linkURL) {
+      if (items.length) items.push({ type: 'separator' });
+      items.push({
+        label: 'Open Link in New Tab',
+        click: () => {
+          this.emit({ tabId, kind: 'new-tab-request', url: params.linkURL });
+        },
+      });
+      items.push({
+        label: 'Copy Link Address',
+        click: () => clipboard.writeText(params.linkURL),
+      });
+    }
+
+    if (params.srcURL && params.mediaType === 'image') {
+      if (items.length) items.push({ type: 'separator' });
+      items.push({
+        label: 'Open Image in New Tab',
+        click: () => {
+          this.emit({ tabId, kind: 'new-tab-request', url: params.srcURL });
+        },
+      });
+      items.push({
+        label: 'Copy Image Address',
+        click: () => clipboard.writeText(params.srcURL),
+      });
+    }
+
+    if (params.isEditable) {
+      if (items.length) items.push({ type: 'separator' });
+      items.push({ label: 'Cut', role: 'cut', enabled: params.editFlags.canCut });
+      items.push({ label: 'Copy', role: 'copy', enabled: params.editFlags.canCopy });
+      items.push({ label: 'Paste', role: 'paste', enabled: params.editFlags.canPaste });
+      items.push({ label: 'Select All', role: 'selectAll', enabled: params.editFlags.canSelectAll });
+    }
+
+    if (items.length) items.push({ type: 'separator' });
+    items.push({
+      label: 'Back',
+      enabled: wc.navigationHistory.canGoBack(),
+      click: () => wc.navigationHistory.goBack(),
+    });
+    items.push({
+      label: 'Forward',
+      enabled: wc.navigationHistory.canGoForward(),
+      click: () => wc.navigationHistory.goForward(),
+    });
+    items.push({ label: 'Reload', click: () => wc.reload() });
+
+    items.push({ type: 'separator' });
+    items.push({
+      label: 'Inspect Element',
+      click: () => wc.inspectElement(params.x, params.y),
+    });
+
+    const menu = Menu.buildFromTemplate(items);
+    menu.popup({ window: this.window ?? undefined });
   }
 
   private emit(event: BrowserEvent): void {

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -1,43 +1,31 @@
-/**
- * Main-process manager for the in-app web browser.
- *
- * One WebContentsView is created per tab and stacked as a child of the
- * main window's contentView. Only the active tab's view is placed at the
- * panel rect — all others are parked off-screen (width/height = 0) so they
- * keep running (audio, timers) but don't render.
- *
- * Why WebContentsView over <webview>:
- *   - no CSP `frame-src` headaches (it's a native sibling, not an iframe)
- *   - main-process controls navigation lifecycle + security
- *   - renderer can't spoof webPreferences via attributes
- *
- * Views are torn down when:
- *   - `closeTab` is invoked
- *   - the main window is closed (each view's wc is destroyed with the parent)
- */
-
 import { BrowserWindow, WebContentsView, shell, session } from 'electron';
 import type { WebContents } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
 import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
+import { BROWSER_HOME_URL } from '@/types/browser';
 import { showBrowserContextMenu } from './context-menu';
 
 const BROWSER_PARTITION_PREFIX = 'persist:sero-browser';
+const ALLOWED_BROWSER_PROTOCOLS = new Set(['http:', 'https:']);
 
-/**
- * Compute the persistent session partition for a workspace. Workspace ids
- * are kebab-case slugs already, so they're safe to embed in a partition
- * string directly — but we still strip anything unexpected defensively.
- */
+function normalizeBrowserUrl(raw: string): string | null {
+  if (raw === 'about:blank') return raw;
+  try {
+    const parsed = new URL(raw);
+    if (!ALLOWED_BROWSER_PROTOCOLS.has(parsed.protocol)) return null;
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
 function partitionFor(workspaceId: string): string {
   const safe = workspaceId.replace(/[^a-zA-Z0-9._-]/g, '_') || 'global';
   return `${BROWSER_PARTITION_PREFIX}:${safe}`;
 }
 
-/** Position used to "hide" a view without destroying it. */
 const HIDDEN_BOUNDS = { x: 0, y: 0, width: 0, height: 0 } as const;
 
-/** Public snapshot of a loaded tab, returned by listLoadedTabs. */
 export interface LoadedTabInfo {
   id: string;
   workspaceId: string;
@@ -49,17 +37,17 @@ export interface LoadedTabInfo {
 class BrowserViewManager {
   private window: BrowserWindow | null = null;
   private readonly views = new Map<string, WebContentsView>();
-  /** Tracks the workspace each view belongs to (mirror of wireViewEvents closure). */
   private readonly viewWorkspaces = new Map<string, string>();
-  /** Most-recently-activated tab per workspace, updated by setActive. */
   private readonly lastActivePerWorkspace = new Map<string, string>();
   private activeTabId: string | null = null;
   private currentBounds: BrowserViewBounds = { ...HIDDEN_BOUNDS };
 
   setWindow(window: BrowserWindow): void {
     this.window = window;
+    window.webContents.on('did-start-loading', () => {
+      this.hideAll();
+    });
     window.on('closed', () => {
-      // Views are destroyed with the window; just drop our refs.
       this.views.clear();
       this.viewWorkspaces.clear();
       this.lastActivePerWorkspace.clear();
@@ -68,17 +56,17 @@ class BrowserViewManager {
     });
   }
 
-  /**
-   * Create a view for a tab id and load the URL. If the tab already exists,
-   * navigate the existing view (idempotent for startup rehydration).
-   */
   openTab(tabId: string, url: string, workspaceId: string): void {
     if (!this.window) return;
+    const safeUrl = normalizeBrowserUrl(url);
+    if (!safeUrl) {
+      console.warn(`[browser] Refusing to load unsupported URL: ${url}`);
+      return;
+    }
     const existing = this.views.get(tabId);
     if (existing) {
-      if (existing.webContents.getURL() !== url) {
-        void existing.webContents.loadURL(url).catch(() => {
-          // Navigation errors surface via did-fail-load; ignore the promise rejection.
+      if (existing.webContents.getURL() !== safeUrl) {
+        void existing.webContents.loadURL(safeUrl).catch(() => {
         });
       }
       return;
@@ -118,7 +106,7 @@ class BrowserViewManager {
     view.setBounds({ ...HIDDEN_BOUNDS });
     this.window.contentView.addChildView(view);
 
-    void view.webContents.loadURL(url).catch(() => {
+    void view.webContents.loadURL(safeUrl).catch(() => {
       // see above
     });
   }
@@ -153,6 +141,7 @@ class BrowserViewManager {
     this.activeTabId = tabId;
     if (tabId) {
       this.lastActivePerWorkspace.set(workspaceId, tabId);
+      this.emit({ tabId, workspaceId, kind: 'host-tab-activated' });
     } else {
       this.lastActivePerWorkspace.delete(workspaceId);
     }
@@ -183,9 +172,14 @@ class BrowserViewManager {
 
   navigate(tabId: string, url: string, workspaceId: string): void {
     if (!this.ownsTab(tabId, workspaceId, 'navigate')) return;
+    const safeUrl = normalizeBrowserUrl(url);
+    if (!safeUrl) {
+      console.warn(`[browser] Refusing to navigate to unsupported URL: ${url}`);
+      return;
+    }
     const view = this.views.get(tabId);
     if (!view) return;
-    void view.webContents.loadURL(url).catch(() => {
+    void view.webContents.loadURL(safeUrl).catch(() => {
       // surfaced via did-fail-load
     });
   }
@@ -264,10 +258,13 @@ class BrowserViewManager {
    * fresh id, creates the view, and emits `host-tab-opened` so the
    * renderer store mirrors it in its tab list. Returns the new tab id.
    */
-  openTabForHost(url: string, workspaceId: string): string {
+  openTabForHost(url: string, workspaceId: string): string | null {
+    const safeUrl = normalizeBrowserUrl(url);
+    if (!safeUrl) return null;
     const tabId = `tab_host_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
-    this.openTab(tabId, url, workspaceId);
-    this.emit({ tabId, workspaceId, kind: 'host-tab-opened', url });
+    this.openTab(tabId, safeUrl, workspaceId);
+    this.setActive(tabId, workspaceId);
+    this.emit({ tabId, workspaceId, kind: 'host-tab-opened', url: safeUrl });
     return tabId;
   }
 
@@ -305,6 +302,15 @@ class BrowserViewManager {
   /** Most-recently-activated tab id for a workspace, or null. */
   resolveActiveTabForWorkspace(workspaceId: string): string | null {
     return this.lastActivePerWorkspace.get(workspaceId) ?? null;
+  }
+
+  private activateByOffset(workspaceId: string, delta: number): void {
+    const tabs = this.listLoadedTabs(workspaceId);
+    if (tabs.length === 0) return;
+    const activeId = this.resolveActiveTabForWorkspace(workspaceId);
+    const index = tabs.findIndex((tab) => tab.id === activeId);
+    const next = index < 0 ? 0 : ((index + delta) % tabs.length + tabs.length) % tabs.length;
+    this.setActive(tabs[next].id, workspaceId);
   }
 
   /** Whether a given tab id exists as a loaded WebContentsView. */
@@ -364,14 +370,64 @@ class BrowserViewManager {
   private wireViewEvents(tabId: string, view: WebContentsView, workspaceId: string): void {
     const wc = view.webContents;
 
+    wc.on('before-input-event', (event, input) => {
+      if (input.type !== 'keyDown' || (!input.meta && !input.control) || input.alt) return;
+      const key = input.key.toLowerCase();
+      const loaded = this.listLoadedTabs(workspaceId);
+      const activeId = this.resolveActiveTabForWorkspace(workspaceId) ?? tabId;
+      const activeView = this.views.get(activeId);
+
+      if (input.shift && (key === '[' || key === ']')) {
+        event.preventDefault();
+        this.activateByOffset(workspaceId, key === '[' ? -1 : 1);
+        return;
+      }
+      if (input.shift) return;
+
+      if (/^[1-9]$/.test(key)) {
+        event.preventDefault();
+        const index = key === '9' ? loaded.length - 1 : Number(key) - 1;
+        const target = loaded[index];
+        if (target) this.setActive(target.id, workspaceId);
+        return;
+      }
+
+      switch (key) {
+        case 't':
+          event.preventDefault();
+          this.openTabForHost(BROWSER_HOME_URL, workspaceId);
+          return;
+        case 'w':
+          event.preventDefault();
+          this.closeTabForHost(activeId, workspaceId);
+          return;
+        case 'r':
+          event.preventDefault();
+          activeView?.webContents.reload();
+          return;
+        case '[':
+          if (activeView?.webContents.navigationHistory.canGoBack()) {
+            event.preventDefault();
+            activeView.webContents.navigationHistory.goBack();
+          }
+          return;
+        case ']':
+          if (activeView?.webContents.navigationHistory.canGoForward()) {
+            event.preventDefault();
+            activeView.webContents.navigationHistory.goForward();
+          }
+          return;
+      }
+    });
+
     // Security: open new windows (target=_blank, window.open) as new tabs
     // within Sero rather than spawning OS browser windows. New tab stays
     // on the same workspace as the opener.
     wc.setWindowOpenHandler(({ url }) => {
-      if (/^https?:\/\//i.test(url) || /^about:blank$/i.test(url)) {
-        this.emit({ tabId, workspaceId, kind: 'new-tab-request', url });
-      } else {
-        // Hand off exotic schemes (mailto:, tel:, …) to the OS.
+      const safeUrl = normalizeBrowserUrl(url);
+      if (safeUrl) {
+        this.emit({ tabId, workspaceId, kind: 'new-tab-request', url: safeUrl });
+      } else if (/^(mailto|tel):/i.test(url)) {
         void shell.openExternal(url).catch(() => undefined);
       }
       return { action: 'deny' };
@@ -379,12 +435,7 @@ class BrowserViewManager {
 
     // Block file:// and other local-filesystem navigations inside the view.
     wc.on('will-navigate', (event, navigationUrl) => {
-      try {
-        const parsed = new URL(navigationUrl);
-        if (parsed.protocol === 'file:') {
-          event.preventDefault();
-        }
-      } catch {
+      if (!normalizeBrowserUrl(navigationUrl)) {
         event.preventDefault();
       }
     });

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -1,0 +1,238 @@
+/**
+ * Main-process manager for the in-app web browser.
+ *
+ * One WebContentsView is created per tab and stacked as a child of the
+ * main window's contentView. Only the active tab's view is placed at the
+ * panel rect — all others are parked off-screen (width/height = 0) so they
+ * keep running (audio, timers) but don't render.
+ *
+ * Why WebContentsView over <webview>:
+ *   - no CSP `frame-src` headaches (it's a native sibling, not an iframe)
+ *   - main-process controls navigation lifecycle + security
+ *   - renderer can't spoof webPreferences via attributes
+ *
+ * Views are torn down when:
+ *   - `closeTab` is invoked
+ *   - the main window is closed (each view's wc is destroyed with the parent)
+ */
+
+import { BrowserWindow, WebContentsView, shell, session } from 'electron';
+import type { WebContents } from 'electron';
+import { IpcChannels } from '@/types/ipc-channels';
+import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
+
+const BROWSER_PARTITION = 'persist:sero-browser';
+
+/** Position used to "hide" a view without destroying it. */
+const HIDDEN_BOUNDS = { x: 0, y: 0, width: 0, height: 0 } as const;
+
+class BrowserViewManager {
+  private window: BrowserWindow | null = null;
+  private readonly views = new Map<string, WebContentsView>();
+  private activeTabId: string | null = null;
+  private currentBounds: BrowserViewBounds = { ...HIDDEN_BOUNDS };
+
+  setWindow(window: BrowserWindow): void {
+    this.window = window;
+    window.on('closed', () => {
+      // Views are destroyed with the window; just drop our refs.
+      this.views.clear();
+      this.window = null;
+      this.activeTabId = null;
+    });
+  }
+
+  /**
+   * Create a view for a tab id and load the URL. If the tab already exists,
+   * navigate the existing view (idempotent for startup rehydration).
+   */
+  openTab(tabId: string, url: string): void {
+    if (!this.window) return;
+    const existing = this.views.get(tabId);
+    if (existing) {
+      if (existing.webContents.getURL() !== url) {
+        void existing.webContents.loadURL(url).catch(() => {
+          // Navigation errors surface via did-fail-load; ignore the promise rejection.
+        });
+      }
+      return;
+    }
+
+    const view = new WebContentsView({
+      webPreferences: {
+        partition: BROWSER_PARTITION,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        webSecurity: true,
+      },
+    });
+
+    this.wireViewEvents(tabId, view);
+
+    // Use a clean Chrome UA (strip "Electron/<version>") so sites don't
+    // treat us as an embedded browser and block Widevine / logins.
+    try {
+      const cleanUA = session
+        .fromPartition(BROWSER_PARTITION)
+        .getUserAgent()
+        .replace(/\sElectron\/[\S]+/, '')
+        .replace(/\s+sero\/[\S]+/i, '');
+      view.webContents.setUserAgent(cleanUA);
+    } catch {
+      // getUserAgent can throw before any page has loaded on some platforms.
+    }
+
+    this.views.set(tabId, view);
+
+    // Park off-screen until explicitly shown. addChildView places it on top,
+    // but zero-size bounds keep it invisible.
+    view.setBounds({ ...HIDDEN_BOUNDS });
+    this.window.contentView.addChildView(view);
+
+    void view.webContents.loadURL(url).catch(() => {
+      // see above
+    });
+  }
+
+  closeTab(tabId: string): void {
+    const view = this.views.get(tabId);
+    if (!view) return;
+    this.views.delete(tabId);
+    if (this.activeTabId === tabId) {
+      this.activeTabId = null;
+    }
+    if (this.window && !this.window.isDestroyed()) {
+      this.window.contentView.removeChildView(view);
+    }
+    // Electron's type defs don't expose WebContents.destroy(), but the method
+    // exists at runtime and is the only way to free the underlying process.
+    const wc = view.webContents as WebContents & { destroy?: () => void };
+    wc.destroy?.();
+  }
+
+  /** Show the given tab's view at the current panel bounds, hide all others. */
+  setActive(tabId: string | null): void {
+    this.activeTabId = tabId;
+    for (const [id, view] of this.views) {
+      if (id === tabId) {
+        view.setBounds(this.currentBounds);
+      } else {
+        view.setBounds({ ...HIDDEN_BOUNDS });
+      }
+    }
+  }
+
+  /** Update the rect where the active view should be rendered. */
+  setBounds(bounds: BrowserViewBounds): void {
+    this.currentBounds = bounds;
+    if (!this.activeTabId) return;
+    const view = this.views.get(this.activeTabId);
+    if (view) view.setBounds(bounds);
+  }
+
+  /** Park every view off-screen (panel hidden / switched away). */
+  hideAll(): void {
+    this.currentBounds = { ...HIDDEN_BOUNDS };
+    for (const view of this.views.values()) {
+      view.setBounds({ ...HIDDEN_BOUNDS });
+    }
+  }
+
+  navigate(tabId: string, url: string): void {
+    const view = this.views.get(tabId);
+    if (!view) return;
+    void view.webContents.loadURL(url).catch(() => {
+      // surfaced via did-fail-load
+    });
+  }
+
+  goBack(tabId: string): void {
+    const wc = this.views.get(tabId)?.webContents;
+    if (wc?.navigationHistory?.canGoBack()) wc.navigationHistory.goBack();
+  }
+
+  goForward(tabId: string): void {
+    const wc = this.views.get(tabId)?.webContents;
+    if (wc?.navigationHistory?.canGoForward()) wc.navigationHistory.goForward();
+  }
+
+  reload(tabId: string): void {
+    this.views.get(tabId)?.webContents.reload();
+  }
+
+  stop(tabId: string): void {
+    this.views.get(tabId)?.webContents.stop();
+  }
+
+  private wireViewEvents(tabId: string, view: WebContentsView): void {
+    const wc = view.webContents;
+
+    // Security: open new windows (target=_blank, window.open) as new tabs
+    // within Sero rather than spawning OS browser windows.
+    wc.setWindowOpenHandler(({ url }) => {
+      if (/^https?:\/\//i.test(url) || /^about:blank$/i.test(url)) {
+        this.emit({ tabId, kind: 'new-tab-request', url });
+      } else {
+        // Hand off exotic schemes (mailto:, tel:, …) to the OS.
+        void shell.openExternal(url).catch(() => undefined);
+      }
+      return { action: 'deny' };
+    });
+
+    // Block file:// and other local-filesystem navigations inside the view.
+    wc.on('will-navigate', (event, navigationUrl) => {
+      try {
+        const parsed = new URL(navigationUrl);
+        if (parsed.protocol === 'file:') {
+          event.preventDefault();
+        }
+      } catch {
+        event.preventDefault();
+      }
+    });
+
+    wc.on('did-start-loading', () => {
+      this.emit({ tabId, kind: 'did-start-loading' });
+    });
+    wc.on('did-stop-loading', () => {
+      this.emit({ tabId, kind: 'did-stop-loading' });
+    });
+    wc.on('did-navigate', (_e, url) => {
+      this.emit({
+        tabId,
+        kind: 'did-navigate',
+        url,
+        canGoBack: wc.navigationHistory.canGoBack(),
+        canGoForward: wc.navigationHistory.canGoForward(),
+      });
+    });
+    wc.on('did-navigate-in-page', (_e, url) => {
+      this.emit({
+        tabId,
+        kind: 'did-navigate',
+        url,
+        canGoBack: wc.navigationHistory.canGoBack(),
+        canGoForward: wc.navigationHistory.canGoForward(),
+      });
+    });
+    wc.on('page-title-updated', (_e, title) => {
+      this.emit({ tabId, kind: 'title-updated', title });
+    });
+    wc.on('page-favicon-updated', (_e, favicons) => {
+      this.emit({ tabId, kind: 'favicon-updated', favicon: favicons[0] });
+    });
+    wc.on('did-fail-load', (_e, _code, errorDescription, _url, isMainFrame) => {
+      if (!isMainFrame) return;
+      this.emit({ tabId, kind: 'did-fail-load', errorDescription });
+    });
+  }
+
+  private emit(event: BrowserEvent): void {
+    const win = this.window;
+    if (!win || win.isDestroyed()) return;
+    win.webContents.send(IpcChannels.browser.event, event);
+  }
+}
+
+export const browserViewManager = new BrowserViewManager();

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -21,7 +21,17 @@ import type { ContextMenuParams, MenuItemConstructorOptions, WebContents } from 
 import { IpcChannels } from '@/types/ipc-channels';
 import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
 
-const BROWSER_PARTITION = 'persist:sero-browser';
+const BROWSER_PARTITION_PREFIX = 'persist:sero-browser';
+
+/**
+ * Compute the persistent session partition for a workspace. Workspace ids
+ * are kebab-case slugs already, so they're safe to embed in a partition
+ * string directly — but we still strip anything unexpected defensively.
+ */
+function partitionFor(workspaceId: string): string {
+  const safe = workspaceId.replace(/[^a-zA-Z0-9._-]/g, '_') || 'global';
+  return `${BROWSER_PARTITION_PREFIX}:${safe}`;
+}
 
 /** Position used to "hide" a view without destroying it. */
 const HIDDEN_BOUNDS = { x: 0, y: 0, width: 0, height: 0 } as const;
@@ -46,7 +56,7 @@ class BrowserViewManager {
    * Create a view for a tab id and load the URL. If the tab already exists,
    * navigate the existing view (idempotent for startup rehydration).
    */
-  openTab(tabId: string, url: string): void {
+  openTab(tabId: string, url: string, workspaceId: string): void {
     if (!this.window) return;
     const existing = this.views.get(tabId);
     if (existing) {
@@ -58,9 +68,10 @@ class BrowserViewManager {
       return;
     }
 
+    const partition = partitionFor(workspaceId);
     const view = new WebContentsView({
       webPreferences: {
-        partition: BROWSER_PARTITION,
+        partition,
         contextIsolation: true,
         nodeIntegration: false,
         sandbox: true,
@@ -68,13 +79,13 @@ class BrowserViewManager {
       },
     });
 
-    this.wireViewEvents(tabId, view);
+    this.wireViewEvents(tabId, view, workspaceId);
 
     // Use a clean Chrome UA (strip "Electron/<version>") so sites don't
     // treat us as an embedded browser and block Widevine / logins.
     try {
       const cleanUA = session
-        .fromPartition(BROWSER_PARTITION)
+        .fromPartition(partition)
         .getUserAgent()
         .replace(/\sElectron\/[\S]+/, '')
         .replace(/\s+sero\/[\S]+/i, '');
@@ -165,14 +176,15 @@ class BrowserViewManager {
     this.views.get(tabId)?.webContents.stop();
   }
 
-  private wireViewEvents(tabId: string, view: WebContentsView): void {
+  private wireViewEvents(tabId: string, view: WebContentsView, workspaceId: string): void {
     const wc = view.webContents;
 
     // Security: open new windows (target=_blank, window.open) as new tabs
-    // within Sero rather than spawning OS browser windows.
+    // within Sero rather than spawning OS browser windows. New tab stays
+    // on the same workspace as the opener.
     wc.setWindowOpenHandler(({ url }) => {
       if (/^https?:\/\//i.test(url) || /^about:blank$/i.test(url)) {
-        this.emit({ tabId, kind: 'new-tab-request', url });
+        this.emit({ tabId, workspaceId, kind: 'new-tab-request', url });
       } else {
         // Hand off exotic schemes (mailto:, tel:, …) to the OS.
         void shell.openExternal(url).catch(() => undefined);
@@ -193,14 +205,15 @@ class BrowserViewManager {
     });
 
     wc.on('did-start-loading', () => {
-      this.emit({ tabId, kind: 'did-start-loading' });
+      this.emit({ tabId, workspaceId, kind: 'did-start-loading' });
     });
     wc.on('did-stop-loading', () => {
-      this.emit({ tabId, kind: 'did-stop-loading' });
+      this.emit({ tabId, workspaceId, kind: 'did-stop-loading' });
     });
     wc.on('did-navigate', (_e, url) => {
       this.emit({
         tabId,
+        workspaceId,
         kind: 'did-navigate',
         url,
         canGoBack: wc.navigationHistory.canGoBack(),
@@ -210,6 +223,7 @@ class BrowserViewManager {
     wc.on('did-navigate-in-page', (_e, url) => {
       this.emit({
         tabId,
+        workspaceId,
         kind: 'did-navigate',
         url,
         canGoBack: wc.navigationHistory.canGoBack(),
@@ -217,19 +231,19 @@ class BrowserViewManager {
       });
     });
     wc.on('page-title-updated', (_e, title) => {
-      this.emit({ tabId, kind: 'title-updated', title });
+      this.emit({ tabId, workspaceId, kind: 'title-updated', title });
     });
     wc.on('page-favicon-updated', (_e, favicons) => {
-      this.emit({ tabId, kind: 'favicon-updated', favicon: favicons[0] });
+      this.emit({ tabId, workspaceId, kind: 'favicon-updated', favicon: favicons[0] });
     });
     wc.on('did-fail-load', (_e, _code, errorDescription, _url, isMainFrame) => {
       if (!isMainFrame) return;
-      this.emit({ tabId, kind: 'did-fail-load', errorDescription });
+      this.emit({ tabId, workspaceId, kind: 'did-fail-load', errorDescription });
     });
 
     // The WebContentsView has no built-in chrome — we own the context menu.
     wc.on('context-menu', (_e, params) => {
-      this.showContextMenu(tabId, view, params);
+      this.showContextMenu(tabId, view, params, workspaceId);
     });
   }
 
@@ -237,6 +251,7 @@ class BrowserViewManager {
     tabId: string,
     view: WebContentsView,
     params: ContextMenuParams,
+    workspaceId: string,
   ): void {
     const wc = view.webContents;
     const items: MenuItemConstructorOptions[] = [];
@@ -247,7 +262,21 @@ class BrowserViewManager {
         click: () => {
           this.emit({
             tabId,
+            workspaceId,
             kind: 'selection-to-chat',
+            selection: params.selectionText,
+            pageUrl: wc.getURL(),
+            pageTitle: wc.getTitle(),
+          });
+        },
+      });
+      items.push({
+        label: 'Save to Memory',
+        click: () => {
+          this.emit({
+            tabId,
+            workspaceId,
+            kind: 'selection-to-memory',
             selection: params.selectionText,
             pageUrl: wc.getURL(),
             pageTitle: wc.getTitle(),
@@ -263,7 +292,7 @@ class BrowserViewManager {
       items.push({
         label: 'Open Link in New Tab',
         click: () => {
-          this.emit({ tabId, kind: 'new-tab-request', url: params.linkURL });
+          this.emit({ tabId, workspaceId, kind: 'new-tab-request', url: params.linkURL });
         },
       });
       items.push({
@@ -277,7 +306,7 @@ class BrowserViewManager {
       items.push({
         label: 'Open Image in New Tab',
         click: () => {
-          this.emit({ tabId, kind: 'new-tab-request', url: params.srcURL });
+          this.emit({ tabId, workspaceId, kind: 'new-tab-request', url: params.srcURL });
         },
       });
       items.push({

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -176,6 +176,70 @@ class BrowserViewManager {
     this.views.get(tabId)?.webContents.stop();
   }
 
+  /**
+   * Run a cleanup script in the tab and return the page's title + plain
+   * text. We do the extraction inside the page so we have a real DOM; the
+   * main process has none without jsdom. Readability-quality markdown is
+   * a deliberate non-goal for v1 — this gets ~90% of the value with a
+   * fraction of the code.
+   */
+  async extractPage(
+    tabId: string,
+  ): Promise<{ title: string; url: string; text: string } | null> {
+    const wc = this.views.get(tabId)?.webContents;
+    if (!wc) return null;
+    const script = `(() => {
+      try {
+        const title = document.title || '';
+        const url = location.href;
+        const body = document.body ? document.body.cloneNode(true) : null;
+        if (!body) return { title, url, text: '' };
+        const drop = ['script','style','noscript','nav','header','footer','aside','iframe','svg','canvas','form'];
+        for (const sel of drop) {
+          for (const el of body.querySelectorAll(sel)) el.remove();
+        }
+        // innerText is better than textContent — respects visibility and block breaks.
+        const raw = body.innerText || '';
+        const text = raw
+          .split('\\n')
+          .map((l) => l.trim())
+          .filter((l, i, a) => !(l === '' && a[i - 1] === ''))
+          .join('\\n')
+          .trim();
+        return { title, url, text };
+      } catch (err) {
+        return { title: document.title || '', url: location.href, text: '' };
+      }
+    })()`;
+    try {
+      const result = await wc.executeJavaScript(script, true);
+      if (!result || typeof result !== 'object') return null;
+      return result as { title: string; url: string; text: string };
+    } catch (err) {
+      console.warn('[browser] extractPage failed:', err);
+      return null;
+    }
+  }
+
+  /**
+   * Capture the tab as a PNG. Returns a base64 string (no data URI prefix).
+   * The optional rect is in CSS pixels relative to the view's top-left.
+   */
+  async capturePage(
+    tabId: string,
+    rect?: { x: number; y: number; width: number; height: number },
+  ): Promise<string | null> {
+    const wc = this.views.get(tabId)?.webContents;
+    if (!wc) return null;
+    try {
+      const image = rect ? await wc.capturePage(rect) : await wc.capturePage();
+      return image.toPNG().toString('base64');
+    } catch (err) {
+      console.warn('[browser] capturePage failed:', err);
+      return null;
+    }
+  }
+
   private wireViewEvents(tabId: string, view: WebContentsView, workspaceId: string): void {
     const wc = view.webContents;
 

--- a/apps/desktop/electron/ipc/apps/browser.ts
+++ b/apps/desktop/electron/ipc/apps/browser.ts
@@ -1,6 +1,9 @@
 /**
- * IPC handlers for the in-app browser. Thin passthrough to
- * `browserViewManager` in the main process.
+ * IPC handlers for the in-app browser. Every tab-scoped call carries the
+ * renderer's claimed workspaceId and is validated against the tab's
+ * actual workspace in the view manager — we don't trust the tab id
+ * alone, because a compromised renderer could otherwise target tabs in
+ * other workspaces.
  */
 
 import { ipcMain } from 'electron';
@@ -16,14 +19,17 @@ export function registerBrowserHandlers(): void {
     },
   );
 
-  ipcMain.handle(IpcChannels.browser.closeTab, (_e, tabId: string) => {
-    browserViewManager.closeTab(tabId);
-  });
+  ipcMain.handle(
+    IpcChannels.browser.closeTab,
+    (_e, tabId: string, workspaceId: string) => {
+      browserViewManager.closeTab(tabId, workspaceId);
+    },
+  );
 
   ipcMain.handle(
     IpcChannels.browser.setActive,
-    (_e, tabId: string | null) => {
-      browserViewManager.setActive(tabId);
+    (_e, tabId: string | null, workspaceId: string) => {
+      browserViewManager.setActive(tabId, workspaceId);
     },
   );
 
@@ -40,35 +46,55 @@ export function registerBrowserHandlers(): void {
 
   ipcMain.handle(
     IpcChannels.browser.navigate,
-    (_e, tabId: string, url: string) => {
-      browserViewManager.navigate(tabId, url);
+    (_e, tabId: string, url: string, workspaceId: string) => {
+      browserViewManager.navigate(tabId, url, workspaceId);
     },
   );
 
-  ipcMain.handle(IpcChannels.browser.goBack, (_e, tabId: string) => {
-    browserViewManager.goBack(tabId);
-  });
+  ipcMain.handle(
+    IpcChannels.browser.goBack,
+    (_e, tabId: string, workspaceId: string) => {
+      browserViewManager.goBack(tabId, workspaceId);
+    },
+  );
 
-  ipcMain.handle(IpcChannels.browser.goForward, (_e, tabId: string) => {
-    browserViewManager.goForward(tabId);
-  });
+  ipcMain.handle(
+    IpcChannels.browser.goForward,
+    (_e, tabId: string, workspaceId: string) => {
+      browserViewManager.goForward(tabId, workspaceId);
+    },
+  );
 
-  ipcMain.handle(IpcChannels.browser.reload, (_e, tabId: string) => {
-    browserViewManager.reload(tabId);
-  });
+  ipcMain.handle(
+    IpcChannels.browser.reload,
+    (_e, tabId: string, workspaceId: string) => {
+      browserViewManager.reload(tabId, workspaceId);
+    },
+  );
 
-  ipcMain.handle(IpcChannels.browser.stop, (_e, tabId: string) => {
-    browserViewManager.stop(tabId);
-  });
+  ipcMain.handle(
+    IpcChannels.browser.stop,
+    (_e, tabId: string, workspaceId: string) => {
+      browserViewManager.stop(tabId, workspaceId);
+    },
+  );
 
-  ipcMain.handle(IpcChannels.browser.extractPage, (_e, tabId: string) => {
-    return browserViewManager.extractPage(tabId);
-  });
+  ipcMain.handle(
+    IpcChannels.browser.extractPage,
+    (_e, tabId: string, workspaceId: string) => {
+      return browserViewManager.extractPage(tabId, workspaceId);
+    },
+  );
 
   ipcMain.handle(
     IpcChannels.browser.capturePage,
-    (_e, tabId: string, rect?: { x: number; y: number; width: number; height: number }) => {
-      return browserViewManager.capturePage(tabId, rect);
+    (
+      _e,
+      tabId: string,
+      workspaceId: string,
+      rect?: { x: number; y: number; width: number; height: number },
+    ) => {
+      return browserViewManager.capturePage(tabId, workspaceId, rect);
     },
   );
 }

--- a/apps/desktop/electron/ipc/apps/browser.ts
+++ b/apps/desktop/electron/ipc/apps/browser.ts
@@ -1,0 +1,63 @@
+/**
+ * IPC handlers for the in-app browser. Thin passthrough to
+ * `browserViewManager` in the main process.
+ */
+
+import { ipcMain } from 'electron';
+import { IpcChannels } from '@/types/ipc-channels';
+import type { BrowserViewBounds } from '@/types/browser';
+import { browserViewManager } from '@electron/features/browser/view-manager';
+
+export function registerBrowserHandlers(): void {
+  ipcMain.handle(
+    IpcChannels.browser.openTab,
+    (_e, tabId: string, url: string) => {
+      browserViewManager.openTab(tabId, url);
+    },
+  );
+
+  ipcMain.handle(IpcChannels.browser.closeTab, (_e, tabId: string) => {
+    browserViewManager.closeTab(tabId);
+  });
+
+  ipcMain.handle(
+    IpcChannels.browser.setActive,
+    (_e, tabId: string | null) => {
+      browserViewManager.setActive(tabId);
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.browser.setBounds,
+    (_e, bounds: BrowserViewBounds) => {
+      browserViewManager.setBounds(bounds);
+    },
+  );
+
+  ipcMain.handle(IpcChannels.browser.hideAll, () => {
+    browserViewManager.hideAll();
+  });
+
+  ipcMain.handle(
+    IpcChannels.browser.navigate,
+    (_e, tabId: string, url: string) => {
+      browserViewManager.navigate(tabId, url);
+    },
+  );
+
+  ipcMain.handle(IpcChannels.browser.goBack, (_e, tabId: string) => {
+    browserViewManager.goBack(tabId);
+  });
+
+  ipcMain.handle(IpcChannels.browser.goForward, (_e, tabId: string) => {
+    browserViewManager.goForward(tabId);
+  });
+
+  ipcMain.handle(IpcChannels.browser.reload, (_e, tabId: string) => {
+    browserViewManager.reload(tabId);
+  });
+
+  ipcMain.handle(IpcChannels.browser.stop, (_e, tabId: string) => {
+    browserViewManager.stop(tabId);
+  });
+}

--- a/apps/desktop/electron/ipc/apps/browser.ts
+++ b/apps/desktop/electron/ipc/apps/browser.ts
@@ -11,8 +11,8 @@ import { browserViewManager } from '@electron/features/browser/view-manager';
 export function registerBrowserHandlers(): void {
   ipcMain.handle(
     IpcChannels.browser.openTab,
-    (_e, tabId: string, url: string) => {
-      browserViewManager.openTab(tabId, url);
+    (_e, tabId: string, url: string, workspaceId: string) => {
+      browserViewManager.openTab(tabId, url, workspaceId);
     },
   );
 

--- a/apps/desktop/electron/ipc/apps/browser.ts
+++ b/apps/desktop/electron/ipc/apps/browser.ts
@@ -6,10 +6,57 @@
  * other workspaces.
  */
 
-import { ipcMain } from 'electron';
+import { BrowserWindow, Menu, ipcMain, type MenuItemConstructorOptions } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
-import type { BrowserViewBounds } from '@/types/browser';
+import type {
+  BrowserBookmarkContextAction,
+  BrowserTabContextAction,
+  BrowserViewBounds,
+} from '@/types/browser';
 import { browserViewManager } from '@electron/features/browser/view-manager';
+
+function popupActionMenu<T extends string>(
+  window: BrowserWindow | null,
+  items: MenuItemConstructorOptions[],
+): Promise<T | null> {
+  if (!window) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let selected: T | null = null;
+    const withPick = items.map((item) => {
+      if (!('id' in item) || !item.id) return item;
+      return {
+        ...item,
+        click: () => {
+          selected = item.id as T;
+          resolve(selected);
+        },
+      };
+    });
+    const menu = Menu.buildFromTemplate(withPick);
+    menu.popup({ window, callback: () => { if (!selected) resolve(null); } });
+  });
+}
+
+function showTabContextMenu(window: BrowserWindow | null): Promise<BrowserTabContextAction | null> {
+  return popupActionMenu<BrowserTabContextAction>(window, [
+    { id: 'bookmark', label: 'Bookmark Tab' },
+    { id: 'copy-url', label: 'Copy URL' },
+    { type: 'separator' },
+    { id: 'close', label: 'Close' },
+    { id: 'close-others', label: 'Close Others' },
+    { id: 'close-all', label: 'Close All' },
+  ]);
+}
+
+function showBookmarkContextMenu(window: BrowserWindow | null): Promise<BrowserBookmarkContextAction | null> {
+  return popupActionMenu<BrowserBookmarkContextAction>(window, [
+    { id: 'open', label: 'Open' },
+    { id: 'open-new-tab', label: 'Open in New Tab' },
+    { type: 'separator' },
+    { id: 'edit', label: 'Edit…' },
+    { id: 'delete', label: 'Delete' },
+  ]);
+}
 
 export function registerBrowserHandlers(): void {
   ipcMain.handle(
@@ -97,4 +144,16 @@ export function registerBrowserHandlers(): void {
       return browserViewManager.capturePage(tabId, workspaceId, rect);
     },
   );
+
+  ipcMain.handle(
+    IpcChannels.browser.showTabContextMenu,
+    (event, tabId: string, workspaceId: string) => {
+      if (browserViewManager.workspaceForTab(tabId) !== workspaceId) return null;
+      return showTabContextMenu(BrowserWindow.fromWebContents(event.sender));
+    },
+  );
+
+  ipcMain.handle(IpcChannels.browser.showBookmarkContextMenu, (event) => {
+    return showBookmarkContextMenu(BrowserWindow.fromWebContents(event.sender));
+  });
 }

--- a/apps/desktop/electron/ipc/apps/browser.ts
+++ b/apps/desktop/electron/ipc/apps/browser.ts
@@ -60,4 +60,15 @@ export function registerBrowserHandlers(): void {
   ipcMain.handle(IpcChannels.browser.stop, (_e, tabId: string) => {
     browserViewManager.stop(tabId);
   });
+
+  ipcMain.handle(IpcChannels.browser.extractPage, (_e, tabId: string) => {
+    return browserViewManager.extractPage(tabId);
+  });
+
+  ipcMain.handle(
+    IpcChannels.browser.capturePage,
+    (_e, tabId: string, rect?: { x: number; y: number; width: number; height: number }) => {
+      return browserViewManager.capturePage(tabId, rect);
+    },
+  );
 }

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -14,6 +14,7 @@ import { registerAgentHandlers } from './agent';
 import { registerAppAgentHandlers } from './agent/handlers/app-agent';
 import { registerGitAppHandlers } from './apps/git-app';
 import { registerWebAppHandlers } from './apps/web-app';
+import { registerBrowserHandlers } from './apps/browser';
 import { registerVoiceHandlers } from './agent/handlers/voice';
 import { registerShellHandlers } from './platform/system';
 import { registerAppStateHandlers } from './apps/app-state';
@@ -56,6 +57,7 @@ export function registerAllIpcHandlers(): void {
   registerAppAgentHandlers();
   registerGitAppHandlers();
   registerWebAppHandlers();
+  registerBrowserHandlers();
   registerVoiceHandlers();
   registerShellHandlers();
   registerAppStateHandlers();

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -44,6 +44,7 @@ function isLayoutState(value: unknown): value is LoadedLayoutState {
   if (!isOptionalArray(c.favouriteModels)) return false;
   if (!isOptionalArray(c.hiddenModels)) return false;
   if (!isOptionalArray(c.hiddenProviders)) return false;
+  if (!isOptionalArray(c.browserTabs)) return false;
   // Optional numeric panel sizes
   if (!isOptionalNumber(c.mainSidebarSizePct)) return false;
   if (!isOptionalNumber(c.chatPanelSizePct)) return false;
@@ -55,7 +56,21 @@ function isLayoutState(value: unknown): value is LoadedLayoutState {
   // Nullable strings
   if (c.activeWorkspaceId !== undefined && c.activeWorkspaceId !== null && typeof c.activeWorkspaceId !== 'string') return false;
   if (c.activeSessionId !== undefined && c.activeSessionId !== null && typeof c.activeSessionId !== 'string') return false;
+  if (c.activeBrowserTabId !== undefined && c.activeBrowserTabId !== null && typeof c.activeBrowserTabId !== 'string') return false;
   return true;
+}
+
+function sanitizeBrowserTabs(value: unknown): import('@/types/layout').PersistedBrowserTab[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: import('@/types/layout').PersistedBrowserTab[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.id !== 'string' || typeof e.url !== 'string') continue;
+    const title = typeof e.title === 'string' ? e.title : undefined;
+    out.push({ id: e.id, url: e.url, ...(title !== undefined ? { title } : {}) });
+  }
+  return out;
 }
 
 /** Parse layout JSON. Returns the state if valid, null otherwise. */
@@ -69,6 +84,7 @@ function parseLayoutState(raw: string): LoadedLayoutState | null {
       favouriteModels: sanitizeStringArray(parsed.favouriteModels),
       hiddenModels: sanitizeStringArray(parsed.hiddenModels),
       hiddenProviders: sanitizeStringArray(parsed.hiddenProviders),
+      browserTabs: sanitizeBrowserTabs(parsed.browserTabs),
     };
   } catch {
     return null;

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -45,6 +45,7 @@ function isLayoutState(value: unknown): value is LoadedLayoutState {
   if (!isOptionalArray(c.hiddenModels)) return false;
   if (!isOptionalArray(c.hiddenProviders)) return false;
   if (!isOptionalArray(c.browserTabs)) return false;
+  if (!isOptionalArray(c.browserBookmarks)) return false;
   // Optional numeric panel sizes
   if (!isOptionalNumber(c.mainSidebarSizePct)) return false;
   if (!isOptionalNumber(c.chatPanelSizePct)) return false;
@@ -73,6 +74,19 @@ function sanitizeBrowserTabs(value: unknown): import('@/types/layout').Persisted
   return out;
 }
 
+function sanitizeBookmarks(value: unknown): import('@/types/layout').PersistedBrowserBookmark[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: import('@/types/layout').PersistedBrowserBookmark[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.id !== 'string' || typeof e.url !== 'string' || typeof e.title !== 'string') continue;
+    const favicon = typeof e.favicon === 'string' ? e.favicon : undefined;
+    out.push({ id: e.id, title: e.title, url: e.url, ...(favicon !== undefined ? { favicon } : {}) });
+  }
+  return out;
+}
+
 /** Parse layout JSON. Returns the state if valid, null otherwise. */
 function parseLayoutState(raw: string): LoadedLayoutState | null {
   try {
@@ -85,6 +99,7 @@ function parseLayoutState(raw: string): LoadedLayoutState | null {
       hiddenModels: sanitizeStringArray(parsed.hiddenModels),
       hiddenProviders: sanitizeStringArray(parsed.hiddenProviders),
       browserTabs: sanitizeBrowserTabs(parsed.browserTabs),
+      browserBookmarks: sanitizeBookmarks(parsed.browserBookmarks),
     };
   } catch {
     return null;

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -58,6 +58,7 @@ function isLayoutState(value: unknown): value is LoadedLayoutState {
   if (c.activeWorkspaceId !== undefined && c.activeWorkspaceId !== null && typeof c.activeWorkspaceId !== 'string') return false;
   if (c.activeSessionId !== undefined && c.activeSessionId !== null && typeof c.activeSessionId !== 'string') return false;
   if (c.activeBrowserTabId !== undefined && c.activeBrowserTabId !== null && typeof c.activeBrowserTabId !== 'string') return false;
+  if (c.activeBrowserTabIds !== undefined && (typeof c.activeBrowserTabIds !== 'object' || c.activeBrowserTabIds === null || Array.isArray(c.activeBrowserTabIds))) return false;
   return true;
 }
 
@@ -69,7 +70,23 @@ function sanitizeBrowserTabs(value: unknown): import('@/types/layout').Persisted
     const e = entry as Record<string, unknown>;
     if (typeof e.id !== 'string' || typeof e.url !== 'string') continue;
     const title = typeof e.title === 'string' ? e.title : undefined;
-    out.push({ id: e.id, url: e.url, ...(title !== undefined ? { title } : {}) });
+    const workspaceId = typeof e.workspaceId === 'string' ? e.workspaceId : undefined;
+    out.push({
+      id: e.id,
+      url: e.url,
+      ...(title !== undefined ? { title } : {}),
+      ...(workspaceId !== undefined ? { workspaceId } : {}),
+    });
+  }
+  return out;
+}
+
+function sanitizeActiveBrowserTabIds(value: unknown): Record<string, string | null> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const out: Record<string, string | null> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof k !== 'string') continue;
+    if (v === null || typeof v === 'string') out[k] = v;
   }
   return out;
 }
@@ -99,6 +116,7 @@ function parseLayoutState(raw: string): LoadedLayoutState | null {
       hiddenModels: sanitizeStringArray(parsed.hiddenModels),
       hiddenProviders: sanitizeStringArray(parsed.hiddenProviders),
       browserTabs: sanitizeBrowserTabs(parsed.browserTabs),
+      activeBrowserTabIds: sanitizeActiveBrowserTabIds(parsed.activeBrowserTabIds),
       browserBookmarks: sanitizeBookmarks(parsed.browserBookmarks),
     };
   } catch {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -350,6 +350,7 @@ app.on('activate', () => {
 });
 
 function hideAllWindowsForShutdown(): void {
+  browserViewManager.hideAll();
   for (const window of BrowserWindow.getAllWindows()) {
     if (window.isDestroyed()) continue;
     window.hide();
@@ -422,6 +423,15 @@ async function performGracefulShutdown(): Promise<void> {
   console.log(`[sero] Graceful shutdown complete (${Date.now() - startedAt}ms)`);
 }
 
+function requestGracefulAppQuit(): void {
+  if (isGracefullyShuttingDown) return;
+  if (app.isReady()) {
+    app.quit();
+  } else {
+    app.exit(0);
+  }
+}
+
 // ── Graceful shutdown ──────────────────────────────────────────
 app.on('before-quit', (e) => {
   if (isGracefullyShuttingDown) return;
@@ -438,6 +448,9 @@ app.on('before-quit', (e) => {
       app.exit(0);
     });
 });
+
+process.once('SIGTERM', requestGracefulAppQuit);
+process.once('SIGINT', requestGracefulAppQuit);
 
 // ── Orphan cleanup ─────────────────────────────────────────────
 /**

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -45,6 +45,7 @@ import {
 import { startGateway, stopGateway } from './ipc/gateway';
 import { setupContentSecurityPolicy } from './platform/security/csp';
 import { setupMainWindowSecurity } from './platform/security/window-security';
+import { browserViewManager } from './features/browser/view-manager';
 import { discoverBuiltinPackagePaths, discoverBuiltinPluginPaths } from './platform/protocols/builtin-resources';
 import {
   ensureConfiguredModelFallbackChain,
@@ -183,6 +184,10 @@ function createWindow() {
 
   // Give the file watcher manager access to the window for push events
   fileWatcherManager.setWindow(mainWindow);
+
+  // Attach the in-app browser's view manager so new WebContentsViews land
+  // on top of the renderer at the bounds the BrowserPanel reports.
+  browserViewManager.setWindow(mainWindow);
 
   mainWindow.once('ready-to-show', () => {
     mainWindow?.show();

--- a/apps/desktop/electron/platform/security/csp.ts
+++ b/apps/desktop/electron/platform/security/csp.ts
@@ -86,13 +86,13 @@ export function buildContentSecurityPolicy(
   ];
 
   // -- img-src --
+  // Browser tabs mirror remote favicons into React chrome, so images need
+  // broad HTTPS access even though script/connect stay tightly scoped.
   const imgSrc = [
     "'self'",
     'data:',
     'blob:',
-    'https://*.scdn.co',       // Spotify album art
-    'https://*.spotifycdn.com',
-    'https://models.dev',      // AI model provider logos
+    'https:',
     ...devHttpSrc,
     ...extensionSrc,
   ];

--- a/apps/desktop/electron/preload/api.ts
+++ b/apps/desktop/electron/preload/api.ts
@@ -31,6 +31,7 @@ import {
   devServerBridge,
   githubBridge,
 } from './apps/app-domain';
+import { browserBridge } from './apps/browser';
 import { pluginsBridge } from './integrations/plugins';
 import {
   agentBridge,
@@ -55,6 +56,7 @@ export const seroPreloadApi = {
   appAgent: appAgentBridge,
   gitApp: gitAppBridge,
   webApp: webAppBridge,
+  browser: browserBridge,
   appControl: appControlBridge,
   models: modelsBridge,
   localModels: localModelsBridge,

--- a/apps/desktop/electron/preload/apps/browser.ts
+++ b/apps/desktop/electron/preload/apps/browser.ts
@@ -3,34 +3,44 @@ import { ipcRenderer, type IpcRendererEvent } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
 import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
 
+/**
+ * Every tab-scoped bridge method takes a `workspaceId` alongside the tab
+ * id. Main validates that the tab actually belongs to that workspace
+ * before acting — don't trust the renderer to stay honest about which
+ * workspace it's currently scoped to.
+ */
 export const browserBridge = {
   openTab: (tabId: string, url: string, workspaceId: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.browser.openTab, tabId, url, workspaceId),
-  closeTab: (tabId: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.closeTab, tabId),
-  setActive: (tabId: string | null): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.setActive, tabId),
+  closeTab: (tabId: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.closeTab, tabId, workspaceId),
+  setActive: (tabId: string | null, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.setActive, tabId, workspaceId),
   setBounds: (bounds: BrowserViewBounds): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.browser.setBounds, bounds),
   hideAll: (): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.browser.hideAll),
-  navigate: (tabId: string, url: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.navigate, tabId, url),
-  goBack: (tabId: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.goBack, tabId),
-  goForward: (tabId: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.goForward, tabId),
-  reload: (tabId: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.reload, tabId),
-  stop: (tabId: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.stop, tabId),
-  extractPage: (tabId: string): Promise<{ title: string; url: string; text: string } | null> =>
-    ipcRenderer.invoke(IpcChannels.browser.extractPage, tabId),
+  navigate: (tabId: string, url: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.navigate, tabId, url, workspaceId),
+  goBack: (tabId: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.goBack, tabId, workspaceId),
+  goForward: (tabId: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.goForward, tabId, workspaceId),
+  reload: (tabId: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.reload, tabId, workspaceId),
+  stop: (tabId: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.stop, tabId, workspaceId),
+  extractPage: (
+    tabId: string,
+    workspaceId: string,
+  ): Promise<{ title: string; url: string; text: string } | null> =>
+    ipcRenderer.invoke(IpcChannels.browser.extractPage, tabId, workspaceId),
   capturePage: (
     tabId: string,
+    workspaceId: string,
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<string | null> =>
-    ipcRenderer.invoke(IpcChannels.browser.capturePage, tabId, rect),
+    ipcRenderer.invoke(IpcChannels.browser.capturePage, tabId, workspaceId, rect),
   onEvent: (callback: (event: BrowserEvent) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, event: BrowserEvent) => callback(event);
     ipcRenderer.on(IpcChannels.browser.event, listener);

--- a/apps/desktop/electron/preload/apps/browser.ts
+++ b/apps/desktop/electron/preload/apps/browser.ts
@@ -4,8 +4,8 @@ import { IpcChannels } from '@/types/ipc-channels';
 import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
 
 export const browserBridge = {
-  openTab: (tabId: string, url: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.browser.openTab, tabId, url),
+  openTab: (tabId: string, url: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.openTab, tabId, url, workspaceId),
   closeTab: (tabId: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.browser.closeTab, tabId),
   setActive: (tabId: string | null): Promise<void> =>

--- a/apps/desktop/electron/preload/apps/browser.ts
+++ b/apps/desktop/electron/preload/apps/browser.ts
@@ -1,7 +1,12 @@
 import { ipcRenderer, type IpcRendererEvent } from 'electron';
 
 import { IpcChannels } from '@/types/ipc-channels';
-import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
+import type {
+  BrowserBookmarkContextAction,
+  BrowserEvent,
+  BrowserTabContextAction,
+  BrowserViewBounds,
+} from '@/types/browser';
 
 /**
  * Every tab-scoped bridge method takes a `workspaceId` alongside the tab
@@ -41,6 +46,10 @@ export const browserBridge = {
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<string | null> =>
     ipcRenderer.invoke(IpcChannels.browser.capturePage, tabId, workspaceId, rect),
+  showTabContextMenu: (tabId: string, workspaceId: string): Promise<BrowserTabContextAction | null> =>
+    ipcRenderer.invoke(IpcChannels.browser.showTabContextMenu, tabId, workspaceId),
+  showBookmarkContextMenu: (): Promise<BrowserBookmarkContextAction | null> =>
+    ipcRenderer.invoke(IpcChannels.browser.showBookmarkContextMenu),
   onEvent: (callback: (event: BrowserEvent) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, event: BrowserEvent) => callback(event);
     ipcRenderer.on(IpcChannels.browser.event, listener);

--- a/apps/desktop/electron/preload/apps/browser.ts
+++ b/apps/desktop/electron/preload/apps/browser.ts
@@ -1,0 +1,32 @@
+import { ipcRenderer, type IpcRendererEvent } from 'electron';
+
+import { IpcChannels } from '@/types/ipc-channels';
+import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
+
+export const browserBridge = {
+  openTab: (tabId: string, url: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.openTab, tabId, url),
+  closeTab: (tabId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.closeTab, tabId),
+  setActive: (tabId: string | null): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.setActive, tabId),
+  setBounds: (bounds: BrowserViewBounds): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.setBounds, bounds),
+  hideAll: (): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.hideAll),
+  navigate: (tabId: string, url: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.navigate, tabId, url),
+  goBack: (tabId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.goBack, tabId),
+  goForward: (tabId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.goForward, tabId),
+  reload: (tabId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.reload, tabId),
+  stop: (tabId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.stop, tabId),
+  onEvent: (callback: (event: BrowserEvent) => void): (() => void) => {
+    const listener = (_e: IpcRendererEvent, event: BrowserEvent) => callback(event);
+    ipcRenderer.on(IpcChannels.browser.event, listener);
+    return () => ipcRenderer.off(IpcChannels.browser.event, listener);
+  },
+};

--- a/apps/desktop/electron/preload/apps/browser.ts
+++ b/apps/desktop/electron/preload/apps/browser.ts
@@ -24,6 +24,13 @@ export const browserBridge = {
     ipcRenderer.invoke(IpcChannels.browser.reload, tabId),
   stop: (tabId: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.browser.stop, tabId),
+  extractPage: (tabId: string): Promise<{ title: string; url: string; text: string } | null> =>
+    ipcRenderer.invoke(IpcChannels.browser.extractPage, tabId),
+  capturePage: (
+    tabId: string,
+    rect?: { x: number; y: number; width: number; height: number },
+  ): Promise<string | null> =>
+    ipcRenderer.invoke(IpcChannels.browser.capturePage, tabId, rect),
   onEvent: (callback: (event: BrowserEvent) => void): (() => void) => {
     const listener = (_e: IpcRendererEvent, event: BrowserEvent) => callback(event);
     ipcRenderer.on(IpcChannels.browser.event, listener);

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -4,9 +4,10 @@
   "description": "Zero context switch, zero sprawl - an agent-first workspace for macOS",
   "main": "dist/electron/main.mjs",
   "scripts": {
-    "dev": "concurrently \"npm run dev:renderer\" \"npm run dev:electron\"",
+    "dev": "bash scripts/dev.sh",
     "dev:renderer": "vite",
     "dev:electron": "npm run build:electron && NODE_ENV=development electron .",
+    "dev:raw": "concurrently --kill-others \"npm run dev:renderer\" \"npm run dev:electron\"",
     "build:electron": "node scripts/build-electron.mjs",
     "build": "npm run build:electron && vite build",
     "start": "electron .",

--- a/apps/desktop/src/components/apps/explorer/ActivityBar.tsx
+++ b/apps/desktop/src/components/apps/explorer/ActivityBar.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react';
-import { Files, GitBranch, Terminal, Network } from 'lucide-react';
+import { Files, GitBranch, Terminal, Network, Globe } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@sero-ai/ui/components/ui/tooltip';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { useSubagentStore } from '@/stores/subagent';
 
 // ── Types ──────────────────────────────────────────────────────
-export type ExplorerPanel = 'explorer' | 'git' | 'orchestration' | 'terminal';
+export type ExplorerPanel = 'explorer' | 'git' | 'orchestration' | 'browser' | 'terminal';
 
 interface ActivityItem {
   id: ExplorerPanel;
@@ -20,6 +20,7 @@ const items: ActivityItem[] = [
   { id: 'explorer', label: 'Explorer', icon: <Files className="size-[18px]" /> },
   { id: 'git', label: 'Source Control', icon: <GitBranch className="size-[18px]" /> },
   { id: 'orchestration', label: 'Orchestration', icon: <Network className="size-[18px]" /> },
+  { id: 'browser', label: 'Browser', icon: <Globe className="size-[18px]" /> },
   { id: 'terminal', label: 'Terminal', icon: <Terminal className="size-[18px]" />, bottom: true },
 ];
 

--- a/apps/desktop/src/components/apps/explorer/ExplorerSidebar.tsx
+++ b/apps/desktop/src/components/apps/explorer/ExplorerSidebar.tsx
@@ -8,6 +8,7 @@ const panelTitles: Record<ExplorerPanel, string> = {
   explorer: 'Explorer',
   git: 'Source Control',
   orchestration: 'Orchestration',
+  browser: 'Browser',
   terminal: 'Terminal',
 };
 

--- a/apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx
+++ b/apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx
@@ -11,6 +11,7 @@ import { TerminalTabs } from './TerminalTabs';
 import { TerminalPanel } from './TerminalPanel';
 import { EditorPanel } from './editor/EditorPanel';
 import { DiffTab } from './editor/DiffTab';
+import { BrowserPanel } from './browser/BrowserPanel';
 import { usePanelOpenSync } from './usePanelOpenSync';
 import { useExplorerRoots } from './useExplorerRoots';
 import { useExplorerEditorState } from './useExplorerEditorState';
@@ -209,7 +210,9 @@ export function ExplorerWorkspace() {
               {/* ── Editor fills all remaining space ─────────────── */}
               <ResizablePanel id="explorer-editor" minSize={200} className="min-w-0">
                 <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--bg-base)]">
-                  {diffState ? (
+                  {activePanel === 'browser' ? (
+                    <BrowserPanel />
+                  ) : diffState ? (
                     <>
                       {/* Diff mode: show a minimal tab bar with close action */}
                       <div className="flex h-8 shrink-0 items-center border-b border-[var(--border-subtle)] bg-[var(--bg-base)] px-2">

--- a/apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx
+++ b/apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx
@@ -211,7 +211,7 @@ export function ExplorerWorkspace() {
               <ResizablePanel id="explorer-editor" minSize={200} className="min-w-0">
                 <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--bg-base)]">
                   {activePanel === 'browser' ? (
-                    <BrowserPanel />
+                    <BrowserPanel workspaceId={workspaceId} />
                   ) : diffState ? (
                     <>
                       {/* Diff mode: show a minimal tab bar with close action */}

--- a/apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx
+++ b/apps/desktop/src/components/apps/explorer/ExplorerWorkspace.tsx
@@ -42,6 +42,7 @@ export function ExplorerWorkspace() {
   const workspaceId = activeWorkspace?.id ?? 'global';
   const { sidebarOpen, activePanel, terminalOpen, explorerSidebarSizePct, terminalSizePct } =
     useWorkspaceExplorer(workspaceId);
+  const showSidebar = sidebarOpen && activePanel !== 'browser';
   const setExplorer = useExplorerStore((state) => state.set);
   const termTabs = useWorkspaceTerminals(workspaceId);
   const activeTerminalId = useActiveTerminalId(workspaceId);
@@ -88,7 +89,10 @@ export function ExplorerWorkspace() {
         return;
       }
 
-      setExplorer(workspaceId, { activePanel: panel, sidebarOpen: true });
+      setExplorer(workspaceId, {
+        activePanel: panel,
+        sidebarOpen: panel !== 'browser',
+      });
     },
     [workspaceId, activePanel, sidebarOpen, terminalOpen, termTabs.length, setExplorer],
   );
@@ -105,7 +109,7 @@ export function ExplorerWorkspace() {
   usePanelOpenSync(
     sidebarPanelRef,
     isSidebarProgrammaticRef,
-    sidebarOpen,
+    showSidebar,
     explorerSidebarLastExpandedPctRef.current || undefined,
   );
 
@@ -157,7 +161,7 @@ export function ExplorerWorkspace() {
       <div className="flex min-h-0 flex-1">
         <ActivityBar
           activePanel={activePanel}
-          sidebarOpen={sidebarOpen}
+          sidebarOpen={showSidebar}
           terminalOpen={terminalOpen}
           onPanelClick={handlePanelClick}
           workspaceId={workspaceId}
@@ -184,7 +188,7 @@ export function ExplorerWorkspace() {
                 onResize={handleSidebarResize}
                 style={{ overflow: 'hidden' }}
               >
-                {sidebarOpen && (
+                {showSidebar && (
                   <ExplorerSidebar
                     activePanel={activePanel}
                     workspaceId={workspaceId}
@@ -203,8 +207,8 @@ export function ExplorerWorkspace() {
               </ResizablePanel>
 
               <ResizableHandle
-                disabled={!sidebarOpen}
-                className={!sidebarOpen ? 'pointer-events-none opacity-0' : undefined}
+                disabled={!showSidebar}
+                className={!showSidebar ? 'pointer-events-none opacity-0' : undefined}
               />
 
               {/* ── Editor fills all remaining space ─────────────── */}

--- a/apps/desktop/src/components/apps/explorer/browser/BookmarksBar.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BookmarksBar.tsx
@@ -1,0 +1,138 @@
+/**
+ * BookmarksBar — horizontal strip of user bookmarks below the toolbar.
+ *
+ * Click → navigate active tab. Middle-click or ⌘-click → open in new tab.
+ * Right-click → rename / delete via context menu.
+ */
+
+import { useState } from 'react';
+import { Globe, Star } from 'lucide-react';
+import { cn } from '@sero-ai/ui/lib/utils';
+import {
+  ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem,
+} from '@sero-ai/ui/components/ui/context-menu';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
+} from '@sero-ai/ui/components/ui/dialog';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { useBrowserStore } from '@/stores/browser';
+import type { BrowserBookmark } from '@/types/browser';
+
+interface BookmarksBarProps {
+  /** Called when a bookmark should replace the active tab's URL. */
+  onNavigate: (url: string) => void;
+}
+
+export function BookmarksBar({ onNavigate }: BookmarksBarProps) {
+  const bookmarks = useBrowserStore((s) => s.bookmarks);
+  const createTab = useBrowserStore((s) => s.createTab);
+  const removeBookmark = useBrowserStore((s) => s.removeBookmark);
+  const updateBookmark = useBrowserStore((s) => s.updateBookmark);
+
+  const [editing, setEditing] = useState<BrowserBookmark | null>(null);
+
+  if (bookmarks.length === 0) {
+    return (
+      <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-[var(--border-subtle)] bg-[var(--bg-base)] px-2 text-[11px] text-[var(--text-muted)]">
+        <Star className="size-3" />
+        <span>No bookmarks yet — press ⌘D on any page to save it here.</span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex h-7 shrink-0 items-center gap-0.5 overflow-x-auto border-b border-[var(--border-subtle)] bg-[var(--bg-base)] px-1 scrollbar-none">
+        {bookmarks.map((bm) => (
+          <ContextMenu key={bm.id}>
+            <ContextMenuTrigger asChild>
+              <button
+                onClick={(e) => {
+                  if (e.metaKey || e.ctrlKey) createTab(bm.url);
+                  else onNavigate(bm.url);
+                }}
+                onMouseDown={(e) => {
+                  if (e.button === 1) {
+                    e.preventDefault();
+                    createTab(bm.url);
+                  }
+                }}
+                className={cn(
+                  'flex h-5 shrink-0 items-center gap-1.5 rounded px-1.5 text-[11px]',
+                  'text-[var(--text-muted)] transition-colors',
+                  'hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+                )}
+                title={`${bm.title}\n${bm.url}`}
+              >
+                {bm.favicon ? (
+                  <img src={bm.favicon} alt="" className="size-3 shrink-0 rounded-sm" />
+                ) : (
+                  <Globe className="size-3 shrink-0 opacity-60" />
+                )}
+                <span className="max-w-[140px] truncate">{bm.title}</span>
+              </button>
+            </ContextMenuTrigger>
+            <ContextMenuContent className="w-48">
+              <ContextMenuItem onSelect={() => onNavigate(bm.url)}>Open</ContextMenuItem>
+              <ContextMenuItem onSelect={() => createTab(bm.url)}>Open in New Tab</ContextMenuItem>
+              <ContextMenuItem onSelect={() => setEditing(bm)}>Edit…</ContextMenuItem>
+              <ContextMenuItem onSelect={() => removeBookmark(bm.id)}>Delete</ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
+        ))}
+      </div>
+
+      {editing && (
+        <EditBookmarkDialog
+          bookmark={editing}
+          onClose={() => setEditing(null)}
+          onSave={(patch) => {
+            updateBookmark(editing.id, patch);
+            setEditing(null);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+interface EditBookmarkDialogProps {
+  bookmark: BrowserBookmark;
+  onClose: () => void;
+  onSave: (patch: { title: string; url: string }) => void;
+}
+
+function EditBookmarkDialog({ bookmark, onClose, onSave }: EditBookmarkDialogProps) {
+  const [title, setTitle] = useState(bookmark.title);
+  const [url, setUrl] = useState(bookmark.url);
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Edit bookmark</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 py-2">
+          <label className="flex flex-col gap-1 text-xs text-[var(--text-muted)]">
+            Name
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} autoFocus />
+          </label>
+          <label className="flex flex-col gap-1 text-xs text-[var(--text-muted)]">
+            URL
+            <Input value={url} onChange={(e) => setUrl(e.target.value)} />
+          </label>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={onClose}>Cancel</Button>
+          <Button
+            size="sm"
+            onClick={() => onSave({ title: title.trim() || bookmark.title, url: url.trim() || bookmark.url })}
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/apps/explorer/browser/BookmarksBar.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BookmarksBar.tsx
@@ -5,12 +5,9 @@
  * Right-click → rename / delete via context menu.
  */
 
-import { useState } from 'react';
+import { useState, type MouseEvent } from 'react';
 import { Globe, Star } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
-import {
-  ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem,
-} from '@sero-ai/ui/components/ui/context-menu';
 import {
   Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
 } from '@sero-ai/ui/components/ui/dialog';
@@ -34,11 +31,31 @@ export function BookmarksBar({ workspaceId, onNavigate }: BookmarksBarProps) {
 
   const [editing, setEditing] = useState<BrowserBookmark | null>(null);
 
+  const handleBookmarkContextMenu = async (event: MouseEvent, bm: BrowserBookmark) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const action = await window.sero.browser.showBookmarkContextMenu();
+    switch (action) {
+      case 'open':
+        onNavigate(bm.url);
+        break;
+      case 'open-new-tab':
+        createTab(workspaceId, bm.url);
+        break;
+      case 'edit':
+        setEditing(bm);
+        break;
+      case 'delete':
+        removeBookmark(bm.id);
+        break;
+    }
+  };
+
   if (bookmarks.length === 0) {
     return (
       <div className="flex h-7 shrink-0 items-center gap-1.5 border-b border-[var(--border-subtle)] bg-[var(--bg-base)] px-2 text-[11px] text-[var(--text-muted)]">
         <Star className="size-3" />
-        <span>No bookmarks yet — press ⌘D on any page to save it here.</span>
+        <span>No bookmarks yet — press ⌘B on any page to save it here.</span>
       </div>
     );
   }
@@ -47,41 +64,33 @@ export function BookmarksBar({ workspaceId, onNavigate }: BookmarksBarProps) {
     <>
       <div className="flex h-7 shrink-0 items-center gap-0.5 overflow-x-auto border-b border-[var(--border-subtle)] bg-[var(--bg-base)] px-1 scrollbar-none">
         {bookmarks.map((bm) => (
-          <ContextMenu key={bm.id}>
-            <ContextMenuTrigger asChild>
-              <button
-                onClick={(e) => {
-                  if (e.metaKey || e.ctrlKey) createTab(workspaceId, bm.url);
-                  else onNavigate(bm.url);
-                }}
-                onMouseDown={(e) => {
-                  if (e.button === 1) {
-                    e.preventDefault();
-                    createTab(workspaceId, bm.url);
-                  }
-                }}
-                className={cn(
-                  'flex h-5 shrink-0 items-center gap-1.5 rounded px-1.5 text-[11px]',
-                  'text-[var(--text-muted)] transition-colors',
-                  'hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
-                )}
-                title={`${bm.title}\n${bm.url}`}
-              >
-                {bm.favicon ? (
-                  <img src={bm.favicon} alt="" className="size-3 shrink-0 rounded-sm" />
-                ) : (
-                  <Globe className="size-3 shrink-0 opacity-60" />
-                )}
-                <span className="max-w-[140px] truncate">{bm.title}</span>
-              </button>
-            </ContextMenuTrigger>
-            <ContextMenuContent className="w-48">
-              <ContextMenuItem onSelect={() => onNavigate(bm.url)}>Open</ContextMenuItem>
-              <ContextMenuItem onSelect={() => createTab(workspaceId, bm.url)}>Open in New Tab</ContextMenuItem>
-              <ContextMenuItem onSelect={() => setEditing(bm)}>Edit…</ContextMenuItem>
-              <ContextMenuItem onSelect={() => removeBookmark(bm.id)}>Delete</ContextMenuItem>
-            </ContextMenuContent>
-          </ContextMenu>
+          <button
+            key={bm.id}
+            onClick={(e) => {
+              if (e.metaKey || e.ctrlKey) createTab(workspaceId, bm.url);
+              else onNavigate(bm.url);
+            }}
+            onMouseDown={(e) => {
+              if (e.button === 1) {
+                e.preventDefault();
+                createTab(workspaceId, bm.url);
+              }
+            }}
+            onContextMenu={(e) => { void handleBookmarkContextMenu(e, bm); }}
+            className={cn(
+              'flex h-5 shrink-0 items-center gap-1.5 rounded px-1.5 text-[11px]',
+              'text-[var(--text-muted)] transition-colors',
+              'hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+            )}
+            title={`${bm.title}\n${bm.url}`}
+          >
+            {bm.favicon ? (
+              <img src={bm.favicon} alt="" className="size-3 shrink-0 rounded-sm" />
+            ) : (
+              <Globe className="size-3 shrink-0 opacity-60" />
+            )}
+            <span className="max-w-[140px] truncate">{bm.title}</span>
+          </button>
         ))}
       </div>
 

--- a/apps/desktop/src/components/apps/explorer/browser/BookmarksBar.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BookmarksBar.tsx
@@ -20,11 +20,13 @@ import { useBrowserStore } from '@/stores/browser';
 import type { BrowserBookmark } from '@/types/browser';
 
 interface BookmarksBarProps {
+  /** Workspace a new-tab bookmark should land in. */
+  workspaceId: string;
   /** Called when a bookmark should replace the active tab's URL. */
   onNavigate: (url: string) => void;
 }
 
-export function BookmarksBar({ onNavigate }: BookmarksBarProps) {
+export function BookmarksBar({ workspaceId, onNavigate }: BookmarksBarProps) {
   const bookmarks = useBrowserStore((s) => s.bookmarks);
   const createTab = useBrowserStore((s) => s.createTab);
   const removeBookmark = useBrowserStore((s) => s.removeBookmark);
@@ -49,13 +51,13 @@ export function BookmarksBar({ onNavigate }: BookmarksBarProps) {
             <ContextMenuTrigger asChild>
               <button
                 onClick={(e) => {
-                  if (e.metaKey || e.ctrlKey) createTab(bm.url);
+                  if (e.metaKey || e.ctrlKey) createTab(workspaceId, bm.url);
                   else onNavigate(bm.url);
                 }}
                 onMouseDown={(e) => {
                   if (e.button === 1) {
                     e.preventDefault();
-                    createTab(bm.url);
+                    createTab(workspaceId, bm.url);
                   }
                 }}
                 className={cn(
@@ -75,7 +77,7 @@ export function BookmarksBar({ onNavigate }: BookmarksBarProps) {
             </ContextMenuTrigger>
             <ContextMenuContent className="w-48">
               <ContextMenuItem onSelect={() => onNavigate(bm.url)}>Open</ContextMenuItem>
-              <ContextMenuItem onSelect={() => createTab(bm.url)}>Open in New Tab</ContextMenuItem>
+              <ContextMenuItem onSelect={() => createTab(workspaceId, bm.url)}>Open in New Tab</ContextMenuItem>
               <ContextMenuItem onSelect={() => setEditing(bm)}>Edit…</ContextMenuItem>
               <ContextMenuItem onSelect={() => removeBookmark(bm.id)}>Delete</ContextMenuItem>
             </ContextMenuContent>

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
@@ -77,6 +77,12 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
     return off;
   }, [applyEvent]);
 
+  // Keep native WebContentsView activation aligned with renderer state,
+  // including tabs created by the host/CLI while this panel is mounted.
+  useEffect(() => {
+    void window.sero.browser.setActive(activeTabId, workspaceId);
+  }, [activeTabId, workspaceId]);
+
   // Track the placeholder element's screen rect and push it to main so the
   // active view stays glued to the visible area. Runs on mount, tab change,
   // and whenever the element resizes (window / sidebar / chat panel toggle).

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
@@ -118,7 +118,7 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
     const el = viewportRef.current;
     if (!el) return;
     const r = el.getBoundingClientRect();
-    const pngBase64 = await window.sero.browser.capturePage(activeTab.id);
+    const pngBase64 = await window.sero.browser.capturePage(activeTab.id, activeTab.workspaceId);
     if (!pngBase64) {
       console.warn('[browser] capturePage returned nothing.');
       return;

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
@@ -1,0 +1,120 @@
+/**
+ * BrowserPanel — host for the in-app web browser.
+ *
+ * The WebContents themselves live in the main process as WebContentsView
+ * children of the window. This component only:
+ *   1. Renders chrome (tab strip + toolbar).
+ *   2. Reserves a rectangle via a placeholder `<div>` and reports its bounds
+ *      to the main process so the active view is positioned over it.
+ *   3. Subscribes to main → renderer events to keep the store in sync.
+ *   4. Calls `hideAll` on unmount so views don't bleed onto other panels.
+ */
+
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { Globe } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { BrowserTabs } from './BrowserTabs';
+import { BrowserToolbar } from './BrowserToolbar';
+import { useBrowserStore } from '@/stores/browser';
+
+export function BrowserPanel() {
+  const tabs = useBrowserStore((s) => s.tabs);
+  const activeTabId = useBrowserStore((s) => s.activeTabId);
+  const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
+  const ensureViewsOpen = useBrowserStore((s) => s.ensureViewsOpen);
+  const applyEvent = useBrowserStore((s) => s.applyEvent);
+  const createTab = useBrowserStore((s) => s.createTab);
+  const navigate = useBrowserStore((s) => s.navigate);
+  const goBack = useBrowserStore((s) => s.goBack);
+  const goForward = useBrowserStore((s) => s.goForward);
+  const reload = useBrowserStore((s) => s.reload);
+  const stop = useBrowserStore((s) => s.stop);
+
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+
+  // Ensure all persisted tabs have WebContentsViews in main on mount.
+  useEffect(() => {
+    ensureViewsOpen();
+    return () => {
+      // When the panel unmounts (user switches to another ActivityBar panel
+      // or the whole Explorer is destroyed), park every view off-screen so
+      // they don't sit on top of the editor / other panels.
+      void window.sero.browser.hideAll();
+    };
+  }, [ensureViewsOpen]);
+
+  // Subscribe once to main-process events.
+  useEffect(() => {
+    const off = window.sero.browser.onEvent((event) => {
+      applyEvent(event);
+    });
+    return off;
+  }, [applyEvent]);
+
+  // Track the placeholder element's screen rect and push it to main so the
+  // active view stays glued to the visible area. Runs on mount, tab change,
+  // and whenever the element resizes (window / sidebar / chat panel toggle).
+  useLayoutEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+
+    const sync = () => {
+      const rect = el.getBoundingClientRect();
+      const width = Math.max(0, Math.round(rect.width));
+      const height = Math.max(0, Math.round(rect.height));
+      if (width === 0 || height === 0) return;
+      void window.sero.browser.setBounds({
+        x: Math.round(rect.left),
+        y: Math.round(rect.top),
+        width,
+        height,
+      });
+    };
+
+    sync();
+    const observer = new ResizeObserver(sync);
+    observer.observe(el);
+    window.addEventListener('resize', sync);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', sync);
+    };
+  }, [activeTabId]);
+
+  // Empty state — no tabs yet.
+  if (tabs.length === 0 || !activeTab) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-[var(--bg-base)]">
+        <Globe className="size-10 text-[var(--text-muted)] opacity-40" />
+        <div className="text-sm text-[var(--text-muted)]">No browser tabs open</div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => createTab()}
+        >
+          New tab
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col bg-[var(--bg-base)]">
+      <BrowserTabs />
+      <BrowserToolbar
+        tab={activeTab}
+        onNavigate={(url) => navigate(activeTab.id, url)}
+        onBack={() => goBack(activeTab.id)}
+        onForward={() => goForward(activeTab.id)}
+        onReload={() => reload(activeTab.id)}
+        onStop={() => stop(activeTab.id)}
+      />
+      {/*
+        Native WebContentsView renders on top of this div at the bounds we
+        report. The div itself stays blank — it only exists to reserve space
+        and give the ResizeObserver something to track.
+      */}
+      <div ref={viewportRef} className="min-h-0 flex-1" />
+    </div>
+  );
+}

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
@@ -13,18 +13,21 @@
  * between projects.
  */
 
-import { useEffect, useLayoutEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Globe } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { BookmarksBar } from './BookmarksBar';
 import { BrowserTabs } from './BrowserTabs';
 import { BrowserToolbar } from './BrowserToolbar';
+import { ScreenshotOverlay } from './ScreenshotOverlay';
 import {
   useActiveBrowserTabId,
   useBrowserStore,
   useWorkspaceBrowserTabs,
 } from '@/stores/browser';
 import { useBrowserShortcuts } from '@/hooks/useBrowserShortcuts';
+import { useAppStore } from '@/stores/app';
+import { useComposerAttachmentQueue } from '@/stores/composer-attachments';
 
 interface BrowserPanelProps {
   workspaceId: string;
@@ -42,8 +45,17 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
   const goForward = useBrowserStore((s) => s.goForward);
   const reload = useBrowserStore((s) => s.reload);
   const stop = useBrowserStore((s) => s.stop);
+  const sharePageWithChat = useBrowserStore((s) => s.sharePageWithChat);
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
+
+  // Capture mode: we fetch a full-page PNG, hide the native view, and let
+  // the user draw a rect over a renderer-side image. On confirm, the
+  // cropped PNG is pushed into the composer attachment queue.
+  const [capture, setCapture] = useState<{
+    pngBase64: string;
+    viewRect: { x: number; y: number; width: number; height: number };
+  } | null>(null);
 
   useBrowserShortcuts(workspaceId);
 
@@ -68,11 +80,17 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
   // Track the placeholder element's screen rect and push it to main so the
   // active view stays glued to the visible area. Runs on mount, tab change,
   // and whenever the element resizes (window / sidebar / chat panel toggle).
+  // While in capture mode the view is intentionally parked off-screen so
+  // the overlay can receive mouse events on top of the PNG.
   useLayoutEffect(() => {
     const el = viewportRef.current;
     if (!el) return;
 
     const sync = () => {
+      if (capture) {
+        void window.sero.browser.hideAll();
+        return;
+      }
       const rect = el.getBoundingClientRect();
       const width = Math.max(0, Math.round(rect.width));
       const height = Math.max(0, Math.round(rect.height));
@@ -93,7 +111,40 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
       observer.disconnect();
       window.removeEventListener('resize', sync);
     };
-  }, [activeTabId]);
+  }, [activeTabId, capture]);
+
+  const startCapture = useCallback(async () => {
+    if (!activeTab) return;
+    const el = viewportRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const pngBase64 = await window.sero.browser.capturePage(activeTab.id);
+    if (!pngBase64) {
+      console.warn('[browser] capturePage returned nothing.');
+      return;
+    }
+    setCapture({
+      pngBase64,
+      viewRect: {
+        x: Math.round(r.left),
+        y: Math.round(r.top),
+        width: Math.round(r.width),
+        height: Math.round(r.height),
+      },
+    });
+  }, [activeTab]);
+
+  const handleCaptureConfirm = useCallback(
+    (blob: Blob) => {
+      const file = new File([blob], `tab-${Date.now()}.png`, { type: 'image/png' });
+      useComposerAttachmentQueue.getState().push(file);
+      if (!useAppStore.getState().chatPanelOpen) {
+        useAppStore.getState().setChatPanelOpen(true);
+      }
+      setCapture(null);
+    },
+    [],
+  );
 
   // Empty state — no tabs yet in this workspace.
   if (tabs.length === 0 || !activeTab) {
@@ -122,6 +173,8 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
         onForward={() => goForward(activeTab.id)}
         onReload={() => reload(activeTab.id)}
         onStop={() => stop(activeTab.id)}
+        onSharePage={() => { void sharePageWithChat(activeTab.id); }}
+        onCaptureArea={() => { void startCapture(); }}
       />
       <BookmarksBar onNavigate={(url) => navigate(activeTab.id, url)} workspaceId={workspaceId} />
       {/*
@@ -130,6 +183,14 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
         and give the ResizeObserver something to track.
       */}
       <div ref={viewportRef} className="min-h-0 flex-1" />
+      {capture && (
+        <ScreenshotOverlay
+          pngBase64={capture.pngBase64}
+          viewRect={capture.viewRect}
+          onCapture={handleCaptureConfirm}
+          onCancel={() => setCapture(null)}
+        />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
@@ -8,6 +8,9 @@
  *      to the main process so the active view is positioned over it.
  *   3. Subscribes to main → renderer events to keep the store in sync.
  *   4. Calls `hideAll` on unmount so views don't bleed onto other panels.
+ *
+ * Tabs are scoped to the active workspace so cookies/logins don't leak
+ * between projects.
  */
 
 import { useEffect, useLayoutEffect, useRef } from 'react';
@@ -16,12 +19,20 @@ import { Button } from '@sero-ai/ui/components/ui/button';
 import { BookmarksBar } from './BookmarksBar';
 import { BrowserTabs } from './BrowserTabs';
 import { BrowserToolbar } from './BrowserToolbar';
-import { useBrowserStore } from '@/stores/browser';
+import {
+  useActiveBrowserTabId,
+  useBrowserStore,
+  useWorkspaceBrowserTabs,
+} from '@/stores/browser';
 import { useBrowserShortcuts } from '@/hooks/useBrowserShortcuts';
 
-export function BrowserPanel() {
-  const tabs = useBrowserStore((s) => s.tabs);
-  const activeTabId = useBrowserStore((s) => s.activeTabId);
+interface BrowserPanelProps {
+  workspaceId: string;
+}
+
+export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
+  const tabs = useWorkspaceBrowserTabs(workspaceId);
+  const activeTabId = useActiveBrowserTabId(workspaceId);
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? null;
   const ensureViewsOpen = useBrowserStore((s) => s.ensureViewsOpen);
   const applyEvent = useBrowserStore((s) => s.applyEvent);
@@ -34,18 +45,17 @@ export function BrowserPanel() {
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
 
-  useBrowserShortcuts();
+  useBrowserShortcuts(workspaceId);
 
-  // Ensure all persisted tabs have WebContentsViews in main on mount.
+  // Ensure all persisted tabs have WebContentsViews in main when the panel
+  // mounts or the active workspace changes, and snap the active view to
+  // the workspace's last active tab.
   useEffect(() => {
-    ensureViewsOpen();
+    ensureViewsOpen(workspaceId);
     return () => {
-      // When the panel unmounts (user switches to another ActivityBar panel
-      // or the whole Explorer is destroyed), park every view off-screen so
-      // they don't sit on top of the editor / other panels.
       void window.sero.browser.hideAll();
     };
-  }, [ensureViewsOpen]);
+  }, [workspaceId, ensureViewsOpen]);
 
   // Subscribe once to main-process events.
   useEffect(() => {
@@ -85,16 +95,16 @@ export function BrowserPanel() {
     };
   }, [activeTabId]);
 
-  // Empty state — no tabs yet.
+  // Empty state — no tabs yet in this workspace.
   if (tabs.length === 0 || !activeTab) {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-3 bg-[var(--bg-base)]">
         <Globe className="size-10 text-[var(--text-muted)] opacity-40" />
-        <div className="text-sm text-[var(--text-muted)]">No browser tabs open</div>
+        <div className="text-sm text-[var(--text-muted)]">No browser tabs open in this workspace</div>
         <Button
           variant="outline"
           size="sm"
-          onClick={() => createTab()}
+          onClick={() => createTab(workspaceId)}
         >
           New tab
         </Button>
@@ -104,7 +114,7 @@ export function BrowserPanel() {
 
   return (
     <div className="flex h-full w-full flex-col bg-[var(--bg-base)]">
-      <BrowserTabs />
+      <BrowserTabs workspaceId={workspaceId} />
       <BrowserToolbar
         tab={activeTab}
         onNavigate={(url) => navigate(activeTab.id, url)}
@@ -113,7 +123,7 @@ export function BrowserPanel() {
         onReload={() => reload(activeTab.id)}
         onStop={() => stop(activeTab.id)}
       />
-      <BookmarksBar onNavigate={(url) => navigate(activeTab.id, url)} />
+      <BookmarksBar onNavigate={(url) => navigate(activeTab.id, url)} workspaceId={workspaceId} />
       {/*
         Native WebContentsView renders on top of this div at the bounds we
         report. The div itself stays blank — it only exists to reserve space

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
@@ -13,9 +13,11 @@
 import { useEffect, useLayoutEffect, useRef } from 'react';
 import { Globe } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
+import { BookmarksBar } from './BookmarksBar';
 import { BrowserTabs } from './BrowserTabs';
 import { BrowserToolbar } from './BrowserToolbar';
 import { useBrowserStore } from '@/stores/browser';
+import { useBrowserShortcuts } from '@/hooks/useBrowserShortcuts';
 
 export function BrowserPanel() {
   const tabs = useBrowserStore((s) => s.tabs);
@@ -31,6 +33,8 @@ export function BrowserPanel() {
   const stop = useBrowserStore((s) => s.stop);
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
+
+  useBrowserShortcuts();
 
   // Ensure all persisted tabs have WebContentsViews in main on mount.
   useEffect(() => {
@@ -109,6 +113,7 @@ export function BrowserPanel() {
         onReload={() => reload(activeTab.id)}
         onStop={() => stop(activeTab.id)}
       />
+      <BookmarksBar onNavigate={(url) => navigate(activeTab.id, url)} />
       {/*
         Native WebContentsView renders on top of this div at the bounds we
         report. The div itself stays blank — it only exists to reserve space

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
@@ -19,7 +19,11 @@ import {
   ContextMenu, ContextMenuTrigger, ContextMenuContent,
   ContextMenuItem, ContextMenuSeparator,
 } from '@sero-ai/ui/components/ui/context-menu';
-import { useBrowserStore } from '@/stores/browser';
+import {
+  useActiveBrowserTabId,
+  useBrowserStore,
+  useWorkspaceBrowserTabs,
+} from '@/stores/browser';
 import type { BrowserTab } from '@/types/browser';
 
 /* ── Single sortable tab ──────────────────────────────────── */
@@ -109,9 +113,13 @@ function SortableBrowserTab({
 
 /* ── Tab bar ──────────────────────────────────────────────── */
 
-export function BrowserTabs() {
-  const tabs = useBrowserStore((s) => s.tabs);
-  const activeTabId = useBrowserStore((s) => s.activeTabId);
+interface BrowserTabsProps {
+  workspaceId: string;
+}
+
+export function BrowserTabs({ workspaceId }: BrowserTabsProps) {
+  const tabs = useWorkspaceBrowserTabs(workspaceId);
+  const activeTabId = useActiveBrowserTabId(workspaceId);
   const setActive = useBrowserStore((s) => s.setActive);
   const closeTab = useBrowserStore((s) => s.closeTab);
   const closeOtherTabs = useBrowserStore((s) => s.closeOtherTabs);
@@ -160,8 +168,8 @@ export function BrowserTabs() {
     const oldIdx = ids.indexOf(active.id as string);
     const newIdx = ids.indexOf(over.id as string);
     if (oldIdx < 0 || newIdx < 0) return;
-    reorderTabs(arrayMove(ids, oldIdx, newIdx));
-  }, [tabs, reorderTabs]);
+    reorderTabs(workspaceId, arrayMove(ids, oldIdx, newIdx));
+  }, [tabs, reorderTabs, workspaceId]);
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent, id: string) => {
@@ -199,7 +207,7 @@ export function BrowserTabs() {
                   onSelect={() => setActive(tab.id)}
                   onClose={() => closeTab(tab.id)}
                   onCloseOthers={() => closeOtherTabs(tab.id)}
-                  onCloseAll={closeAllTabs}
+                  onCloseAll={() => closeAllTabs(workspaceId)}
                   onBookmark={() =>
                     addBookmark({ title: tab.title || tab.url, url: tab.url, favicon: tab.favicon })
                   }
@@ -217,7 +225,7 @@ export function BrowserTabs() {
         </SortableContext>
       </DndContext>
       <button
-        onClick={() => createTab()}
+        onClick={() => createTab(workspaceId)}
         className={cn(
           'flex h-full shrink-0 items-center border-l border-[var(--border-subtle)] px-2.5',
           'text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
@@ -1,0 +1,60 @@
+import { Plus, X, Globe } from 'lucide-react';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { useBrowserStore } from '@/stores/browser';
+
+export function BrowserTabs() {
+  const tabs = useBrowserStore((s) => s.tabs);
+  const activeTabId = useBrowserStore((s) => s.activeTabId);
+  const setActive = useBrowserStore((s) => s.setActive);
+  const closeTab = useBrowserStore((s) => s.closeTab);
+  const createTab = useBrowserStore((s) => s.createTab);
+
+  return (
+    <div className="flex h-8 shrink-0 items-center gap-0.5 overflow-x-auto border-b border-[var(--border-default)] bg-[var(--bg-surface)] px-1">
+      {tabs.map((tab) => (
+        <button
+          key={tab.id}
+          onClick={() => setActive(tab.id)}
+          className={cn(
+            'group flex h-6 max-w-[200px] items-center gap-1.5 rounded px-2 text-xs transition-colors',
+            activeTabId === tab.id
+              ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+              : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+          )}
+          title={tab.title}
+        >
+          {tab.favicon ? (
+            <img src={tab.favicon} alt="" className="size-3.5 shrink-0 rounded-sm" />
+          ) : (
+            <Globe className="size-3 shrink-0 opacity-60" />
+          )}
+          <span className="truncate">{tab.isLoading ? 'Loading…' : tab.title}</span>
+          <span
+            role="button"
+            tabIndex={-1}
+            onClick={(e) => {
+              e.stopPropagation();
+              closeTab(tab.id);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.stopPropagation();
+                closeTab(tab.id);
+              }
+            }}
+            className="rounded p-0.5 opacity-0 transition-opacity hover:bg-[var(--bg-base)] group-hover:opacity-100"
+          >
+            <X className="size-2.5" />
+          </span>
+        </button>
+      ))}
+      <button
+        onClick={() => createTab()}
+        className="flex h-6 items-center rounded px-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+        title="New tab (⌘N)"
+      >
+        <Plus className="size-3" />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
@@ -16,10 +16,6 @@ import { CSS } from '@dnd-kit/utilities';
 import { Globe, Plus } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import {
-  ContextMenu, ContextMenuTrigger, ContextMenuContent,
-  ContextMenuItem, ContextMenuSeparator,
-} from '@sero-ai/ui/components/ui/context-menu';
-import {
   useActiveBrowserTabId,
   useBrowserStore,
   useWorkspaceBrowserTabs,
@@ -38,11 +34,12 @@ interface SortableBrowserTabProps {
   onBookmark: () => void;
   onCopyUrl: () => void;
   onMouseDown: (e: React.MouseEvent) => void;
+  onContextMenu: (e: React.MouseEvent) => void;
 }
 
 function SortableBrowserTab({
   tab, isActive, onSelect, onClose, onCloseOthers, onCloseAll,
-  onBookmark, onCopyUrl, onMouseDown,
+  onBookmark, onCopyUrl, onMouseDown, onContextMenu,
 }: SortableBrowserTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id });
   const style: React.CSSProperties = {
@@ -54,60 +51,49 @@ function SortableBrowserTab({
   const label = tab.isLoading && !tab.title ? 'Loading…' : (tab.title || tab.url);
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <div
-          ref={setNodeRef} style={style}
-          className={cn(
-            'group flex items-center gap-1.5 px-2.5 h-full cursor-pointer shrink-0 select-none',
-            'border-r border-[var(--border-subtle)] text-xs whitespace-nowrap transition-colors',
-            'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
-            isActive && 'bg-[var(--bg-elevated)] text-[var(--text-primary)] relative',
-          )}
-          data-tab-id={tab.id}
-          {...attributes} {...listeners}
-          onClick={onSelect}
-          onMouseDown={onMouseDown}
-          title={tab.title ? `${tab.title}\n${tab.url}` : tab.url}
-        >
-          {tab.favicon ? (
-            <img src={tab.favicon} alt="" className="size-3.5 shrink-0 rounded-sm" />
-          ) : (
-            <Globe className="size-3.5 shrink-0 text-[var(--text-muted)] opacity-60" />
-          )}
-          <span className={cn('font-normal max-w-[180px] truncate', isActive && 'font-medium')}>
-            {label}
-          </span>
-          {tab.isLoading && (
-            <span
-              aria-hidden
-              className="size-2 shrink-0 rounded-full border border-[var(--text-muted)] border-t-transparent animate-spin"
-            />
-          )}
-          <button
-            className={cn(
-              'flex items-center justify-center size-4 border-none bg-transparent',
-              'text-[var(--text-muted)] text-sm leading-none cursor-pointer rounded-sm',
-              'ml-0.5 opacity-0 transition-opacity shrink-0',
-              'group-hover:opacity-60 hover:!opacity-100 hover:bg-[var(--bg-muted)] hover:text-[var(--text-primary)]',
-              isActive && 'opacity-60',
-            )}
-            onClick={(e) => { e.stopPropagation(); onClose(); }}
-            onMouseDown={(e) => e.stopPropagation()}
-            title="Close"
-          >×</button>
-          {isActive && <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--accent-primary)]" />}
-        </div>
-      </ContextMenuTrigger>
-      <ContextMenuContent className="w-52">
-        <ContextMenuItem onSelect={onBookmark}>Bookmark Tab</ContextMenuItem>
-        <ContextMenuItem onSelect={onCopyUrl}>Copy URL</ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem onSelect={onClose}>Close</ContextMenuItem>
-        <ContextMenuItem onSelect={onCloseOthers}>Close Others</ContextMenuItem>
-        <ContextMenuItem onSelect={onCloseAll}>Close All</ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
+    <div
+      ref={setNodeRef} style={style}
+      className={cn(
+        'group flex items-center gap-1.5 px-2.5 h-full cursor-pointer shrink-0 select-none',
+        'border-r border-[var(--border-subtle)] text-xs whitespace-nowrap transition-colors',
+        'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+        isActive && 'bg-[var(--bg-elevated)] text-[var(--text-primary)] relative',
+      )}
+      data-tab-id={tab.id}
+      {...attributes} {...listeners}
+      onClick={onSelect}
+      onMouseDown={onMouseDown}
+      onContextMenu={onContextMenu}
+      title={tab.title ? `${tab.title}\n${tab.url}` : tab.url}
+    >
+      {tab.favicon ? (
+        <img src={tab.favicon} alt="" className="size-3.5 shrink-0 rounded-sm" />
+      ) : (
+        <Globe className="size-3.5 shrink-0 text-[var(--text-muted)] opacity-60" />
+      )}
+      <span className={cn('font-normal max-w-[180px] truncate', isActive && 'font-medium')}>
+        {label}
+      </span>
+      {tab.isLoading && (
+        <span
+          aria-hidden
+          className="size-2 shrink-0 rounded-full border border-[var(--text-muted)] border-t-transparent animate-spin"
+        />
+      )}
+      <button
+        className={cn(
+          'flex items-center justify-center size-4 border-none bg-transparent',
+          'text-[var(--text-muted)] text-sm leading-none cursor-pointer rounded-sm',
+          'ml-0.5 opacity-0 transition-opacity shrink-0',
+          'group-hover:opacity-60 hover:!opacity-100 hover:bg-[var(--bg-muted)] hover:text-[var(--text-primary)]',
+          isActive && 'opacity-60',
+        )}
+        onClick={(e) => { e.stopPropagation(); onClose(); }}
+        onMouseDown={(e) => e.stopPropagation()}
+        title="Close"
+      >×</button>
+      {isActive && <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--accent-primary)]" />}
+    </div>
   );
 }
 
@@ -171,6 +157,32 @@ export function BrowserTabs({ workspaceId }: BrowserTabsProps) {
     reorderTabs(workspaceId, arrayMove(ids, oldIdx, newIdx));
   }, [tabs, reorderTabs, workspaceId]);
 
+  const handleTabContextMenu = useCallback(
+    async (event: React.MouseEvent, tab: BrowserTab) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const action = await window.sero.browser.showTabContextMenu(tab.id, workspaceId);
+      switch (action) {
+        case 'bookmark':
+          addBookmark({ title: tab.title || tab.url, url: tab.url, favicon: tab.favicon });
+          break;
+        case 'copy-url':
+          await window.sero.clipboard.writeText(tab.url);
+          break;
+        case 'close':
+          closeTab(tab.id);
+          break;
+        case 'close-others':
+          closeOtherTabs(tab.id);
+          break;
+        case 'close-all':
+          closeAllTabs(workspaceId);
+          break;
+      }
+    },
+    [addBookmark, closeAllTabs, closeOtherTabs, closeTab, workspaceId],
+  );
+
   const handleMouseDown = useCallback(
     (e: React.MouseEvent, id: string) => {
       // Middle-click closes the tab (universal browser convention).
@@ -215,6 +227,7 @@ export function BrowserTabs({ workspaceId }: BrowserTabsProps) {
                     void window.sero.clipboard.writeText(tab.url);
                   }}
                   onMouseDown={(e) => handleMouseDown(e, tab.id)}
+                  onContextMenu={(e) => { void handleTabContextMenu(e, tab); }}
                 />
               ))}
             </div>

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserTabs.tsx
@@ -1,59 +1,230 @@
-import { Plus, X, Globe } from 'lucide-react';
+/**
+ * BrowserTabs — draggable, scrollable tab strip for the in-app browser.
+ * Mirrors the EditorTabBar style (dnd-kit reorder, context menu, overflow
+ * fades) so Browser and Editor feel like the same tabbed surface.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  DndContext, closestCenter, PointerSensor, useSensor, useSensors,
+  type DragEndEvent, type Modifier,
+} from '@dnd-kit/core';
+import {
+  SortableContext, horizontalListSortingStrategy, useSortable, arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { Globe, Plus } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
+import {
+  ContextMenu, ContextMenuTrigger, ContextMenuContent,
+  ContextMenuItem, ContextMenuSeparator,
+} from '@sero-ai/ui/components/ui/context-menu';
 import { useBrowserStore } from '@/stores/browser';
+import type { BrowserTab } from '@/types/browser';
+
+/* ── Single sortable tab ──────────────────────────────────── */
+
+interface SortableBrowserTabProps {
+  tab: BrowserTab;
+  isActive: boolean;
+  onSelect: () => void;
+  onClose: () => void;
+  onCloseOthers: () => void;
+  onCloseAll: () => void;
+  onBookmark: () => void;
+  onCopyUrl: () => void;
+  onMouseDown: (e: React.MouseEvent) => void;
+}
+
+function SortableBrowserTab({
+  tab, isActive, onSelect, onClose, onCloseOthers, onCloseAll,
+  onBookmark, onCopyUrl, onMouseDown,
+}: SortableBrowserTabProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: tab.id });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 10 : undefined,
+  };
+  const label = tab.isLoading && !tab.title ? 'Loading…' : (tab.title || tab.url);
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div
+          ref={setNodeRef} style={style}
+          className={cn(
+            'group flex items-center gap-1.5 px-2.5 h-full cursor-pointer shrink-0 select-none',
+            'border-r border-[var(--border-subtle)] text-xs whitespace-nowrap transition-colors',
+            'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+            isActive && 'bg-[var(--bg-elevated)] text-[var(--text-primary)] relative',
+          )}
+          data-tab-id={tab.id}
+          {...attributes} {...listeners}
+          onClick={onSelect}
+          onMouseDown={onMouseDown}
+          title={tab.title ? `${tab.title}\n${tab.url}` : tab.url}
+        >
+          {tab.favicon ? (
+            <img src={tab.favicon} alt="" className="size-3.5 shrink-0 rounded-sm" />
+          ) : (
+            <Globe className="size-3.5 shrink-0 text-[var(--text-muted)] opacity-60" />
+          )}
+          <span className={cn('font-normal max-w-[180px] truncate', isActive && 'font-medium')}>
+            {label}
+          </span>
+          {tab.isLoading && (
+            <span
+              aria-hidden
+              className="size-2 shrink-0 rounded-full border border-[var(--text-muted)] border-t-transparent animate-spin"
+            />
+          )}
+          <button
+            className={cn(
+              'flex items-center justify-center size-4 border-none bg-transparent',
+              'text-[var(--text-muted)] text-sm leading-none cursor-pointer rounded-sm',
+              'ml-0.5 opacity-0 transition-opacity shrink-0',
+              'group-hover:opacity-60 hover:!opacity-100 hover:bg-[var(--bg-muted)] hover:text-[var(--text-primary)]',
+              isActive && 'opacity-60',
+            )}
+            onClick={(e) => { e.stopPropagation(); onClose(); }}
+            onMouseDown={(e) => e.stopPropagation()}
+            title="Close"
+          >×</button>
+          {isActive && <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--accent-primary)]" />}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-52">
+        <ContextMenuItem onSelect={onBookmark}>Bookmark Tab</ContextMenuItem>
+        <ContextMenuItem onSelect={onCopyUrl}>Copy URL</ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={onClose}>Close</ContextMenuItem>
+        <ContextMenuItem onSelect={onCloseOthers}>Close Others</ContextMenuItem>
+        <ContextMenuItem onSelect={onCloseAll}>Close All</ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+}
+
+/* ── Tab bar ──────────────────────────────────────────────── */
 
 export function BrowserTabs() {
   const tabs = useBrowserStore((s) => s.tabs);
   const activeTabId = useBrowserStore((s) => s.activeTabId);
   const setActive = useBrowserStore((s) => s.setActive);
   const closeTab = useBrowserStore((s) => s.closeTab);
+  const closeOtherTabs = useBrowserStore((s) => s.closeOtherTabs);
+  const closeAllTabs = useBrowserStore((s) => s.closeAllTabs);
   const createTab = useBrowserStore((s) => s.createTab);
+  const reorderTabs = useBrowserStore((s) => s.reorderTabs);
+  const addBookmark = useBrowserStore((s) => s.addBookmark);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [overflowLeft, setOverflowLeft] = useState(false);
+  const [overflowRight, setOverflowRight] = useState(false);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const restrictToHorizontal: Modifier = useCallback(({ transform }) => ({ ...transform, y: 0 }), []);
+
+  // Auto-scroll the active tab into view when it changes.
+  useEffect(() => {
+    if (!activeTabId || !scrollRef.current) return;
+    const el = scrollRef.current.querySelector(
+      `[data-tab-id="${globalThis.CSS.escape(activeTabId)}"]`,
+    ) as HTMLElement | null;
+    el?.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+  }, [activeTabId]);
+
+  const updateOverflow = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setOverflowLeft(el.scrollLeft > 1);
+    setOverflowRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateOverflow();
+    el.addEventListener('scroll', updateOverflow, { passive: true });
+    const ro = new ResizeObserver(updateOverflow);
+    ro.observe(el);
+    return () => { el.removeEventListener('scroll', updateOverflow); ro.disconnect(); };
+  }, [updateOverflow, tabs.length]);
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const ids = tabs.map((t) => t.id);
+    const oldIdx = ids.indexOf(active.id as string);
+    const newIdx = ids.indexOf(over.id as string);
+    if (oldIdx < 0 || newIdx < 0) return;
+    reorderTabs(arrayMove(ids, oldIdx, newIdx));
+  }, [tabs, reorderTabs]);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent, id: string) => {
+      // Middle-click closes the tab (universal browser convention).
+      if (e.button === 1) {
+        e.preventDefault();
+        closeTab(id);
+      }
+    },
+    [closeTab],
+  );
 
   return (
-    <div className="flex h-8 shrink-0 items-center gap-0.5 overflow-x-auto border-b border-[var(--border-default)] bg-[var(--bg-surface)] px-1">
-      {tabs.map((tab) => (
-        <button
-          key={tab.id}
-          onClick={() => setActive(tab.id)}
-          className={cn(
-            'group flex h-6 max-w-[200px] items-center gap-1.5 rounded px-2 text-xs transition-colors',
-            activeTabId === tab.id
-              ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
-              : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
-          )}
-          title={tab.title}
-        >
-          {tab.favicon ? (
-            <img src={tab.favicon} alt="" className="size-3.5 shrink-0 rounded-sm" />
-          ) : (
-            <Globe className="size-3 shrink-0 opacity-60" />
-          )}
-          <span className="truncate">{tab.isLoading ? 'Loading…' : tab.title}</span>
-          <span
-            role="button"
-            tabIndex={-1}
-            onClick={(e) => {
-              e.stopPropagation();
-              closeTab(tab.id);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.stopPropagation();
-                closeTab(tab.id);
-              }
-            }}
-            className="rounded p-0.5 opacity-0 transition-opacity hover:bg-[var(--bg-base)] group-hover:opacity-100"
-          >
-            <X className="size-2.5" />
-          </span>
-        </button>
-      ))}
+    <div className="flex items-stretch h-8 bg-[var(--bg-base)] border-b border-[var(--border-subtle)] shrink-0 overflow-hidden relative">
+      {overflowLeft && (
+        <div className="absolute top-0 bottom-px left-0 w-7 pointer-events-none z-10 bg-gradient-to-r from-[var(--bg-base)] to-transparent" />
+      )}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToHorizontal]}
+      >
+        <SortableContext items={tabs.map((t) => t.id)} strategy={horizontalListSortingStrategy}>
+          <div className="relative min-w-0 flex-1">
+            <div
+              ref={scrollRef}
+              className="flex h-full w-full items-stretch overflow-x-auto overflow-y-hidden scrollbar-none"
+            >
+              {tabs.map((tab) => (
+                <SortableBrowserTab
+                  key={tab.id}
+                  tab={tab}
+                  isActive={tab.id === activeTabId}
+                  onSelect={() => setActive(tab.id)}
+                  onClose={() => closeTab(tab.id)}
+                  onCloseOthers={() => closeOtherTabs(tab.id)}
+                  onCloseAll={closeAllTabs}
+                  onBookmark={() =>
+                    addBookmark({ title: tab.title || tab.url, url: tab.url, favicon: tab.favicon })
+                  }
+                  onCopyUrl={() => {
+                    void window.sero.clipboard.writeText(tab.url);
+                  }}
+                  onMouseDown={(e) => handleMouseDown(e, tab.id)}
+                />
+              ))}
+            </div>
+            {overflowRight && (
+              <div className="absolute top-0 bottom-px right-0 w-7 pointer-events-none z-10 bg-gradient-to-l from-[var(--bg-base)] to-transparent" />
+            )}
+          </div>
+        </SortableContext>
+      </DndContext>
       <button
         onClick={() => createTab()}
-        className="flex h-6 items-center rounded px-1.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
-        title="New tab (⌘N)"
+        className={cn(
+          'flex h-full shrink-0 items-center border-l border-[var(--border-subtle)] px-2.5',
+          'text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
+        )}
+        title="New tab (⌘T)"
       >
-        <Plus className="size-3" />
+        <Plus className="size-3.5" />
       </button>
     </div>
   );

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserToolbar.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserToolbar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type FormEvent, type KeyboardEvent } from 'react';
-import { ArrowLeft, ArrowRight, RotateCw, X } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Camera, MessageSquareQuote, RotateCw, X } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { BrowserTab } from '@/types/browser';
@@ -11,10 +11,12 @@ interface BrowserToolbarProps {
   onForward: () => void;
   onReload: () => void;
   onStop: () => void;
+  onSharePage: () => void;
+  onCaptureArea: () => void;
 }
 
 export function BrowserToolbar({
-  tab, onNavigate, onBack, onForward, onReload, onStop,
+  tab, onNavigate, onBack, onForward, onReload, onStop, onSharePage, onCaptureArea,
 }: BrowserToolbarProps) {
   // Mirror the tab URL into the input but let the user edit freely. When the
   // tab navigates elsewhere (e.g. clicking a link), the field refreshes to
@@ -98,6 +100,26 @@ export function BrowserToolbar({
           'focus:border-[var(--border-default)] focus:outline-none',
         )}
       />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onSharePage}
+        title="Share page with chat"
+        className="text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+      >
+        <MessageSquareQuote className="size-[14px]" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onCaptureArea}
+        title="Screenshot area to chat"
+        className="text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+      >
+        <Camera className="size-[14px]" />
+      </Button>
     </form>
   );
 }

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserToolbar.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserToolbar.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, type FormEvent, type KeyboardEvent } from 'react';
+import { ArrowLeft, ArrowRight, RotateCw, X } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { cn } from '@sero-ai/ui/lib/utils';
+import type { BrowserTab } from '@/types/browser';
+
+interface BrowserToolbarProps {
+  tab: BrowserTab;
+  onNavigate: (urlOrQuery: string) => void;
+  onBack: () => void;
+  onForward: () => void;
+  onReload: () => void;
+  onStop: () => void;
+}
+
+export function BrowserToolbar({
+  tab, onNavigate, onBack, onForward, onReload, onStop,
+}: BrowserToolbarProps) {
+  // Mirror the tab URL into the input but let the user edit freely. When the
+  // tab navigates elsewhere (e.g. clicking a link), the field refreshes to
+  // match unless the user has focused it.
+  const [draft, setDraft] = useState(tab.url);
+  const [focused, setFocused] = useState(false);
+
+  useEffect(() => {
+    if (!focused) setDraft(tab.url);
+  }, [tab.url, focused]);
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const value = draft.trim();
+    if (!value) return;
+    onNavigate(value);
+    (document.activeElement as HTMLElement | null)?.blur();
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      setDraft(tab.url);
+      (event.target as HTMLInputElement).blur();
+    }
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      className="flex h-9 shrink-0 items-center gap-1 border-b border-[var(--border-default)] bg-[var(--bg-surface)] px-2"
+    >
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        disabled={!tab.canGoBack}
+        onClick={onBack}
+        title="Back"
+        className="text-[var(--text-muted)] hover:text-[var(--text-secondary)] disabled:opacity-40"
+      >
+        <ArrowLeft className="size-[14px]" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        disabled={!tab.canGoForward}
+        onClick={onForward}
+        title="Forward"
+        className="text-[var(--text-muted)] hover:text-[var(--text-secondary)] disabled:opacity-40"
+      >
+        <ArrowRight className="size-[14px]" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={tab.isLoading ? onStop : onReload}
+        title={tab.isLoading ? 'Stop' : 'Reload'}
+        className="text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+      >
+        {tab.isLoading ? <X className="size-[14px]" /> : <RotateCw className="size-[14px]" />}
+      </Button>
+      <input
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onFocus={(e) => {
+          setFocused(true);
+          e.target.select();
+        }}
+        onBlur={() => setFocused(false)}
+        onKeyDown={onKeyDown}
+        placeholder="Search DuckDuckGo or type a URL"
+        spellCheck={false}
+        autoComplete="off"
+        className={cn(
+          'mx-1 h-6 flex-1 rounded bg-[var(--bg-base)] px-2 text-xs',
+          'border border-[var(--border-subtle)] text-[var(--text-primary)]',
+          'placeholder:text-[var(--text-muted)]',
+          'focus:border-[var(--border-default)] focus:outline-none',
+        )}
+      />
+    </form>
+  );
+}

--- a/apps/desktop/src/components/apps/explorer/browser/ScreenshotOverlay.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/ScreenshotOverlay.tsx
@@ -1,0 +1,189 @@
+/**
+ * ScreenshotOverlay — modal region picker shown over the browser viewport.
+ *
+ * Behaviour:
+ *   - Renders the full-page PNG as the backdrop.
+ *   - User drags a rect; on release the rect is cropped out of the PNG
+ *     and returned as a Blob via `onCapture`.
+ *   - Esc cancels.
+ *
+ * The overlay is positioned to cover the same area the WebContentsView
+ * normally occupies — the parent is responsible for hiding the view
+ * while the overlay is up and for restoring it on close.
+ */
+
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react';
+import { Check, X } from 'lucide-react';
+import { cn } from '@sero-ai/ui/lib/utils';
+
+interface ScreenshotOverlayProps {
+  /** Base64 PNG (no data URI prefix) of the full page at current viewport. */
+  pngBase64: string;
+  /** The rect the browser view occupies in viewport coordinates (for layout). */
+  viewRect: { x: number; y: number; width: number; height: number };
+  onCapture: (blob: Blob) => void;
+  onCancel: () => void;
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export function ScreenshotOverlay({
+  pngBase64, viewRect, onCapture, onCancel,
+}: ScreenshotOverlayProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const imgRef = useRef<HTMLImageElement | null>(null);
+  const [rect, setRect] = useState<Rect | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onCancel]);
+
+  const localCoords = (e: MouseEvent) => {
+    const el = containerRef.current;
+    if (!el) return { x: 0, y: 0 };
+    const b = el.getBoundingClientRect();
+    return {
+      x: Math.max(0, Math.min(b.width, e.clientX - b.left)),
+      y: Math.max(0, Math.min(b.height, e.clientY - b.top)),
+    };
+  };
+
+  const handleMouseDown = (e: MouseEvent) => {
+    if (e.button !== 0) return;
+    const pt = localCoords(e);
+    startRef.current = pt;
+    setRect({ x: pt.x, y: pt.y, w: 0, h: 0 });
+    setDragging(true);
+  };
+
+  const handleMouseMove = (e: MouseEvent) => {
+    if (!dragging || !startRef.current) return;
+    const pt = localCoords(e);
+    const s = startRef.current;
+    setRect({
+      x: Math.min(s.x, pt.x),
+      y: Math.min(s.y, pt.y),
+      w: Math.abs(pt.x - s.x),
+      h: Math.abs(pt.y - s.y),
+    });
+  };
+
+  const handleMouseUp = () => {
+    setDragging(false);
+  };
+
+  const confirm = useCallback(async () => {
+    if (!rect || rect.w < 4 || rect.h < 4) return;
+    const img = imgRef.current;
+    const container = containerRef.current;
+    if (!img || !container) return;
+
+    // Image is rendered at container size (CSS) but has native pixel
+    // dimensions from the capture. Scale the selection back into native
+    // pixels so we crop accurately.
+    const scaleX = img.naturalWidth / container.clientWidth;
+    const scaleY = img.naturalHeight / container.clientHeight;
+
+    const sx = Math.round(rect.x * scaleX);
+    const sy = Math.round(rect.y * scaleY);
+    const sw = Math.max(1, Math.round(rect.w * scaleX));
+    const sh = Math.max(1, Math.round(rect.h * scaleY));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = sw;
+    canvas.height = sh;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, sw, sh);
+
+    const blob: Blob | null = await new Promise((resolve) => {
+      canvas.toBlob((b) => resolve(b), 'image/png');
+    });
+    if (blob) onCapture(blob);
+  }, [rect, onCapture]);
+
+  return (
+    <div
+      className="fixed z-50 select-none"
+      style={{
+        left: viewRect.x,
+        top: viewRect.y,
+        width: viewRect.width,
+        height: viewRect.height,
+      }}
+    >
+      <div
+        ref={containerRef}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        className="relative h-full w-full cursor-crosshair overflow-hidden bg-black/50"
+      >
+        <img
+          ref={imgRef}
+          src={`data:image/png;base64,${pngBase64}`}
+          alt=""
+          className="pointer-events-none absolute inset-0 h-full w-full object-fill opacity-90"
+          draggable={false}
+        />
+        {/* Dim everything outside the selected rect */}
+        <div
+          className="pointer-events-none absolute inset-0 bg-black/50"
+          style={rect ? {
+            clipPath: `polygon(
+              0 0, 100% 0, 100% 100%, 0 100%, 0 0,
+              ${rect.x}px ${rect.y}px,
+              ${rect.x}px ${rect.y + rect.h}px,
+              ${rect.x + rect.w}px ${rect.y + rect.h}px,
+              ${rect.x + rect.w}px ${rect.y}px,
+              ${rect.x}px ${rect.y}px
+            )`,
+          } : undefined}
+        />
+        {rect && rect.w > 0 && rect.h > 0 && (
+          <div
+            className="pointer-events-none absolute border-2 border-[var(--accent-primary)]"
+            style={{ left: rect.x, top: rect.y, width: rect.w, height: rect.h }}
+          />
+        )}
+      </div>
+
+      <div className="pointer-events-none absolute left-1/2 top-3 -translate-x-1/2">
+        <div className="pointer-events-auto flex items-center gap-2 rounded-full bg-[var(--bg-elevated)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] shadow-lg ring-1 ring-[var(--border-default)]">
+          <span>Drag to select an area · Esc to cancel</span>
+          <button
+            onClick={confirm}
+            disabled={!rect || rect.w < 4 || rect.h < 4}
+            className={cn(
+              'flex items-center gap-1 rounded-full px-2 py-0.5',
+              'bg-[var(--accent-primary)] text-white',
+              'disabled:cursor-not-allowed disabled:opacity-40',
+            )}
+          >
+            <Check className="size-3" />
+            Attach
+          </button>
+          <button
+            onClick={onCancel}
+            className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[var(--text-muted)] hover:bg-[var(--bg-base)]"
+          >
+            <X className="size-3" />
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/ChatAttachments.tsx
+++ b/apps/desktop/src/components/layout/ChatAttachments.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { Trash2 } from 'lucide-react';
 import {
   Attachments,
   Attachment,
@@ -18,26 +19,46 @@ import { useLightbox, type LightboxImage } from './ImageLightbox';
  * Renders queued attachments inside the PromptInput header.
  * Uses the `inline` variant — compact badges with hover-reveal remove buttons.
  * Must be rendered inside a <PromptInput> context.
+ *
+ * Shows a compact count + "Clear all" affordance above the badges when more
+ * than one item is queued so the user can reset without clicking each ×.
  */
 export function PromptAttachmentsBar() {
   const attachments = usePromptInputAttachments();
 
-  if (attachments.files.length === 0) return null;
+  const count = attachments.files.length;
+  if (count === 0) return null;
 
   return (
-    <Attachments variant="inline" className="px-1 pb-1">
-      {attachments.files.map((file) => (
-        <Attachment
-          key={file.id}
-          data={file}
-          onRemove={() => attachments.remove(file.id)}
-        >
-          <AttachmentPreview />
-          <AttachmentInfo />
-          <AttachmentRemove />
-        </Attachment>
-      ))}
-    </Attachments>
+    <div className="flex flex-col gap-1 px-1 pb-1">
+      {count > 1 && (
+        <div className="flex items-center justify-between px-1 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+          <span>{count} attachments</span>
+          <button
+            type="button"
+            onClick={() => attachments.clear()}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+            title="Remove all attachments"
+          >
+            <Trash2 className="size-3" />
+            Clear all
+          </button>
+        </div>
+      )}
+      <Attachments variant="inline">
+        {attachments.files.map((file) => (
+          <Attachment
+            key={file.id}
+            data={file}
+            onRemove={() => attachments.remove(file.id)}
+          >
+            <AttachmentPreview />
+            <AttachmentInfo />
+            <AttachmentRemove />
+          </Attachment>
+        ))}
+      </Attachments>
+    </div>
   );
 }
 

--- a/apps/desktop/src/components/layout/ChatPromptArea.tsx
+++ b/apps/desktop/src/components/layout/ChatPromptArea.tsx
@@ -36,6 +36,7 @@ import { AuthLoginDialog } from './AuthLoginDialog';
 import { ContextEditor } from './ContextEditor';
 import { VoiceTranscriptionControl } from './VoiceTranscriptionControl';
 import { ContextEditorMenuItem, ThinkingBlocksToggle, MemoryBlocksToggle, CollaborationToggle } from './ChatPanelHelpers';
+import { WorkspaceSnapshotMenuItem } from './WorkspaceSnapshotMenuItem';
 import { useMessageQueue } from '@/hooks/useMessageQueue';
 import { useChatPromptInput } from '@/hooks/useChatPromptInput';
 import type { ChatComposerPrefill } from '@/types/ipc';
@@ -182,6 +183,7 @@ export const ChatPromptArea = memo(function ChatPromptArea({
                 />
                 <PromptInputActionMenuContent>
                   <PromptInputActionAddAttachments />
+                  <WorkspaceSnapshotMenuItem disabled={isStreaming || !hasSession} />
                   <ContextEditorMenuItem sessionId={sessionId} disabled={isStreaming} />
                 </PromptInputActionMenuContent>
               </PromptInputActionMenu>

--- a/apps/desktop/src/components/layout/ChatPromptArea.tsx
+++ b/apps/desktop/src/components/layout/ChatPromptArea.tsx
@@ -30,6 +30,7 @@ import {
 import { SlashCommandMenu } from './SlashCommandMenu';
 import { FileReferenceMenu } from './FileReferenceMenu';
 import { PromptAttachmentsBar } from './ChatAttachments';
+import { ComposerAttachmentBridge } from './ComposerAttachmentBridge';
 import { ModelSelector } from './ModelSelector';
 import { AuthLoginDialog } from './AuthLoginDialog';
 import { ContextEditor } from './ContextEditor';
@@ -128,6 +129,8 @@ export const ChatPromptArea = memo(function ChatPromptArea({
           multiple
           globalDrop={hasSession}
         >
+          {/* Pulls files pushed to useComposerAttachmentQueue (screenshots, etc.). */}
+          <ComposerAttachmentBridge />
           <PromptInputHeader>
             <PromptAttachmentsBar />
             {messageQueue.hasQueued && (

--- a/apps/desktop/src/components/layout/ComposerAttachmentBridge.tsx
+++ b/apps/desktop/src/components/layout/ComposerAttachmentBridge.tsx
@@ -1,0 +1,27 @@
+/**
+ * Bridges the app-wide `useComposerAttachmentQueue` into the local
+ * `<PromptInput>` attachments context. Mount as a child of `<PromptInput>`.
+ * Each time new files land in the queue, they're forwarded into the
+ * composer's attachment state and the queue is drained.
+ */
+
+import { useEffect } from 'react';
+import { usePromptInputAttachments } from '@sero-ai/ui/components/ai-elements/prompt-input-context';
+import { useComposerAttachmentQueue } from '@/stores/composer-attachments';
+
+export function ComposerAttachmentBridge() {
+  const attachments = usePromptInputAttachments();
+  const pendingCount = useComposerAttachmentQueue((s) => s.pending.length);
+  const consume = useComposerAttachmentQueue((s) => s.consume);
+
+  useEffect(() => {
+    if (pendingCount === 0) return;
+    const files = consume();
+    if (files.length > 0) attachments.add(files);
+    // `attachments` is recreated by the context on every render so we avoid
+    // depending on it directly — pendingCount is enough to trigger drain.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingCount, consume]);
+
+  return null;
+}

--- a/apps/desktop/src/components/layout/WorkspaceSnapshotMenuItem.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceSnapshotMenuItem.tsx
@@ -1,0 +1,107 @@
+/**
+ * "Insert workspace snapshot" — menu item that packages the current
+ * workspace's state into a concise markdown block and prefills the chat
+ * composer with it. Useful as the opening message of a new turn: "here's
+ * where I am, help me from here".
+ *
+ * What goes in the snapshot:
+ *   - Workspace name + root path
+ *   - Currently open editor tabs
+ *   - Currently open browser tabs (scoped to workspace)
+ *
+ * What's intentionally NOT in the snapshot:
+ *   - Git diff / status — can be arbitrarily huge and the agent can run
+ *     `git status` itself if needed.
+ *   - Terminal history — not tracked in a reliable per-workspace store yet.
+ */
+
+import { FolderTree } from 'lucide-react';
+import { PromptInputActionMenuItem } from '@sero-ai/ui/components/ai-elements/prompt-input-elements';
+import { useAgentStore } from '@/stores/agent';
+import { useAppStore } from '@/stores/app';
+import { useBrowserStore } from '@/stores/browser';
+import { useSessionStore } from '@/stores/sessions';
+import { useWorkspaceStore } from '@/stores/workspace';
+
+function pad<T>(section: string, lines: T[] | undefined, formatter: (entry: T) => string): string {
+  if (!lines || lines.length === 0) return `### ${section}\n_(none)_\n`;
+  const body = lines.map((entry) => `- ${formatter(entry)}`).join('\n');
+  return `### ${section}\n${body}\n`;
+}
+
+async function buildSnapshot(workspaceId: string): Promise<string> {
+  const workspace = useWorkspaceStore
+    .getState()
+    .workspaces.find((w) => w.id === workspaceId);
+
+  const browserTabs = useBrowserStore
+    .getState()
+    .tabs.filter((t) => t.workspaceId === workspaceId);
+
+  let openEditorTabs: string[] = [];
+  let activeEditorTab: string | null = null;
+  try {
+    const state = await window.sero.editor.loadState(workspaceId);
+    if (state) {
+      openEditorTabs = state.openTabs ?? [];
+      activeEditorTab = state.activeTab ?? null;
+    }
+  } catch {
+    // Editor state is best-effort.
+  }
+
+  const header = `## Workspace snapshot — ${workspace?.name ?? workspaceId}`;
+  const primaryRoot = workspace?.roots?.[0]?.path;
+  const rootLine = primaryRoot ? `\n_Root:_ \`${primaryRoot}\`\n` : '\n';
+
+  const editorSection = pad(
+    'Open editor tabs',
+    openEditorTabs.map((path) => ({ path, active: path === activeEditorTab })),
+    (t) => (t.active ? `**${t.path}** _(active)_` : t.path),
+  );
+
+  const browserSection = pad(
+    'Open browser tabs',
+    browserTabs,
+    (t) => `[${t.title || t.url}](${t.url})`,
+  );
+
+  return [header, rootLine, editorSection, '', browserSection, '\n'].join('\n');
+}
+
+export function WorkspaceSnapshotMenuItem({ disabled }: { disabled?: boolean }) {
+  const insert = async () => {
+    const workspaceId =
+      useWorkspaceStore.getState().activeWorkspaceId ?? 'global';
+    const sessionId =
+      useAgentStore.getState().focusedSessionId ??
+      useSessionStore.getState().activeSessionId;
+    if (!sessionId) {
+      console.warn('[workspace-snapshot] No chat session to insert into.');
+      return;
+    }
+
+    const snapshot = await buildSnapshot(workspaceId);
+    useAgentStore.getState().setComposerPrefill(sessionId, {
+      requestId: `snap_${Date.now().toString(36)}`,
+      text: snapshot,
+      source: 'system',
+    });
+    if (!useAppStore.getState().chatPanelOpen) {
+      useAppStore.getState().setChatPanelOpen(true);
+    }
+  };
+
+  return (
+    <PromptInputActionMenuItem
+      onSelect={(e) => {
+        e.preventDefault();
+        void insert();
+      }}
+      disabled={disabled}
+    >
+      <FolderTree className="size-4" />
+      Insert workspace snapshot
+    </PromptInputActionMenuItem>
+  );
+}

--- a/apps/desktop/src/hooks/useBrowserShortcuts.ts
+++ b/apps/desktop/src/hooks/useBrowserShortcuts.ts
@@ -1,0 +1,104 @@
+/**
+ * Browser-scoped keyboard shortcuts. Only active while the BrowserPanel is
+ * mounted — avoids hijacking keys (⌘W, ⌘R, ⌘T) when the user is in the
+ * editor or another app.
+ *
+ * ⌘T          New tab
+ * ⌘W          Close active tab
+ * ⌘Shift+T    Reopen last closed tab
+ * ⌘R          Reload active tab
+ * ⌘D          Bookmark active tab
+ * ⌘[ / ⌘]     Back / forward
+ * ⌘1..⌘9      Jump to tab N (⌘9 jumps to the last tab, mirroring Chrome)
+ * ⌘Shift+[/]  Cycle active tab left / right
+ */
+
+import { useEffect } from 'react';
+import { useBrowserStore } from '@/stores/browser';
+
+export function useBrowserShortcuts() {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (!e.metaKey && !e.ctrlKey) return;
+      if (e.altKey) return;
+
+      const store = useBrowserStore.getState();
+      const activeId = store.activeTabId;
+      const key = e.key.toLowerCase();
+
+      // ⌘Shift+… combinations first so plain ⌘+… doesn't swallow them.
+      if (e.shiftKey) {
+        switch (key) {
+          case 't':
+            e.preventDefault();
+            store.reopenClosedTab();
+            return;
+          case '[':
+            e.preventDefault();
+            store.cycleActive(-1);
+            return;
+          case ']':
+            e.preventDefault();
+            store.cycleActive(1);
+            return;
+        }
+        return;
+      }
+
+      switch (key) {
+        case 't':
+          e.preventDefault();
+          store.createTab();
+          return;
+        case 'w':
+          if (activeId) {
+            e.preventDefault();
+            store.closeTab(activeId);
+          }
+          return;
+        case 'r':
+          if (activeId) {
+            e.preventDefault();
+            store.reload(activeId);
+          }
+          return;
+        case 'd':
+          if (activeId) {
+            const tab = store.tabs.find((t) => t.id === activeId);
+            if (tab) {
+              e.preventDefault();
+              store.addBookmark({
+                title: tab.title || tab.url,
+                url: tab.url,
+                favicon: tab.favicon,
+              });
+            }
+          }
+          return;
+        case '[':
+          if (activeId) {
+            e.preventDefault();
+            store.goBack(activeId);
+          }
+          return;
+        case ']':
+          if (activeId) {
+            e.preventDefault();
+            store.goForward(activeId);
+          }
+          return;
+      }
+
+      // ⌘1 … ⌘8 → jump to that tab; ⌘9 → last tab (Chrome convention).
+      if (/^[1-9]$/.test(e.key)) {
+        e.preventDefault();
+        const digit = parseInt(e.key, 10);
+        if (digit === 9) store.setActiveByIndex(store.tabs.length - 1);
+        else store.setActiveByIndex(digit - 1);
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+}

--- a/apps/desktop/src/hooks/useBrowserShortcuts.ts
+++ b/apps/desktop/src/hooks/useBrowserShortcuts.ts
@@ -7,7 +7,7 @@
  * ⌘W          Close active tab
  * ⌘Shift+T    Reopen last closed tab
  * ⌘R          Reload active tab
- * ⌘D          Bookmark active tab
+ * ⌘B          Bookmark active tab
  * ⌘[ / ⌘]     Back / forward
  * ⌘1..⌘9      Jump to tab N (⌘9 jumps to the last tab, mirroring Chrome)
  * ⌘Shift+[/]  Cycle active tab left / right
@@ -62,7 +62,7 @@ export function useBrowserShortcuts(workspaceId: string) {
             store.reload(activeId);
           }
           return;
-        case 'd':
+        case 'b':
           if (activeId) {
             const tab = store.tabs.find((t) => t.id === activeId);
             if (tab) {

--- a/apps/desktop/src/hooks/useBrowserShortcuts.ts
+++ b/apps/desktop/src/hooks/useBrowserShortcuts.ts
@@ -16,14 +16,14 @@
 import { useEffect } from 'react';
 import { useBrowserStore } from '@/stores/browser';
 
-export function useBrowserShortcuts() {
+export function useBrowserShortcuts(workspaceId: string) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (!e.metaKey && !e.ctrlKey) return;
       if (e.altKey) return;
 
       const store = useBrowserStore.getState();
-      const activeId = store.activeTabId;
+      const activeId = store.activeTabIds[workspaceId] ?? null;
       const key = e.key.toLowerCase();
 
       // ⌘Shift+… combinations first so plain ⌘+… doesn't swallow them.
@@ -31,15 +31,15 @@ export function useBrowserShortcuts() {
         switch (key) {
           case 't':
             e.preventDefault();
-            store.reopenClosedTab();
+            store.reopenClosedTab(workspaceId);
             return;
           case '[':
             e.preventDefault();
-            store.cycleActive(-1);
+            store.cycleActive(workspaceId, -1);
             return;
           case ']':
             e.preventDefault();
-            store.cycleActive(1);
+            store.cycleActive(workspaceId, 1);
             return;
         }
         return;
@@ -48,7 +48,7 @@ export function useBrowserShortcuts() {
       switch (key) {
         case 't':
           e.preventDefault();
-          store.createTab();
+          store.createTab(workspaceId);
           return;
         case 'w':
           if (activeId) {
@@ -93,12 +93,13 @@ export function useBrowserShortcuts() {
       if (/^[1-9]$/.test(e.key)) {
         e.preventDefault();
         const digit = parseInt(e.key, 10);
-        if (digit === 9) store.setActiveByIndex(store.tabs.length - 1);
-        else store.setActiveByIndex(digit - 1);
+        const wsTabs = store.tabs.filter((t) => t.workspaceId === workspaceId);
+        if (digit === 9) store.setActiveByIndex(workspaceId, wsTabs.length - 1);
+        else store.setActiveByIndex(workspaceId, digit - 1);
       }
     };
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, []);
+  }, [workspaceId]);
 }

--- a/apps/desktop/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/desktop/src/hooks/useKeyboardShortcuts.ts
@@ -40,7 +40,7 @@ export function useKeyboardShortcuts() {
             useWorkspaceStore.getState().activeWorkspaceId ?? 'global';
           useExplorerStore
             .getState()
-            .set(workspaceId, { activePanel: 'browser', sidebarOpen: true });
+            .set(workspaceId, { activePanel: 'browser', sidebarOpen: false });
           useBrowserStore.getState().createTab(workspaceId);
           break;
         }

--- a/apps/desktop/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/desktop/src/hooks/useKeyboardShortcuts.ts
@@ -41,7 +41,7 @@ export function useKeyboardShortcuts() {
           useExplorerStore
             .getState()
             .set(workspaceId, { activePanel: 'browser', sidebarOpen: true });
-          useBrowserStore.getState().createTab();
+          useBrowserStore.getState().createTab(workspaceId);
           break;
         }
       }

--- a/apps/desktop/src/hooks/useKeyboardShortcuts.ts
+++ b/apps/desktop/src/hooks/useKeyboardShortcuts.ts
@@ -1,11 +1,15 @@
 import { useEffect } from 'react';
 import { useAppStore } from '@/stores/app';
+import { useBrowserStore } from '@/stores/browser';
+import { useExplorerStore } from '@/stores/explorer';
+import { useWorkspaceStore } from '@/stores/workspace';
 
 /**
  * Global keyboard shortcuts.
  *
  * ⌘B — Toggle main sidebar
  * ⌘L — Toggle chat panel
+ * ⌘N — New browser tab (opens the Browser panel if not already active)
  */
 export function useKeyboardShortcuts() {
   const toggleMainSidebar = useAppStore((s) => s.toggleMainSidebar);
@@ -27,6 +31,19 @@ export function useKeyboardShortcuts() {
           e.preventDefault();
           toggleChatPanel();
           break;
+        case 'n': {
+          // Only handle ⌘N when the Explorer workspace is the active app,
+          // so it doesn't hijack shortcuts inside other apps.
+          if (useAppStore.getState().activeApp !== 'explorer') return;
+          e.preventDefault();
+          const workspaceId =
+            useWorkspaceStore.getState().activeWorkspaceId ?? 'global';
+          useExplorerStore
+            .getState()
+            .set(workspaceId, { activePanel: 'browser', sidebarOpen: true });
+          useBrowserStore.getState().createTab();
+          break;
+        }
       }
     };
 

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -22,6 +22,7 @@ import { useWorkspaceStore } from '@/stores/workspace';
 import { useSessionStore } from '@/stores/sessions';
 import { useModelPreferences } from '@/stores/model-preferences';
 import { useDashboardStore } from '@/stores/dashboard';
+import { useBrowserStore } from '@/stores/browser';
 
 // Re-export the canonical type so callers don't need a second import.
 export type { LayoutState };
@@ -55,6 +56,15 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
       widgets: useDashboardStore.getState().widgets,
       layouts: useDashboardStore.getState().layouts,
     },
+    browserTabs: partial.browserTabs ?? useBrowserStore.getState().tabs.map((t) => ({
+      id: t.id,
+      url: t.url,
+      title: t.title,
+    })),
+    activeBrowserTabId:
+      partial.activeBrowserTabId !== undefined
+        ? partial.activeBrowserTabId
+        : useBrowserStore.getState().activeTabId,
   };
 }
 

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -58,13 +58,12 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
     },
     browserTabs: partial.browserTabs ?? useBrowserStore.getState().tabs.map((t) => ({
       id: t.id,
+      workspaceId: t.workspaceId,
       url: t.url,
       title: t.title,
     })),
-    activeBrowserTabId:
-      partial.activeBrowserTabId !== undefined
-        ? partial.activeBrowserTabId
-        : useBrowserStore.getState().activeTabId,
+    activeBrowserTabIds:
+      partial.activeBrowserTabIds ?? useBrowserStore.getState().activeTabIds,
     browserBookmarks: partial.browserBookmarks ?? useBrowserStore.getState().bookmarks,
   };
 }

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -65,6 +65,7 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
       partial.activeBrowserTabId !== undefined
         ? partial.activeBrowserTabId
         : useBrowserStore.getState().activeTabId,
+    browserBookmarks: partial.browserBookmarks ?? useBrowserStore.getState().bookmarks,
   };
 }
 

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -69,7 +69,8 @@ export async function loadLayout(): Promise<void> {
       // user opens the browser panel, not eagerly here).
       useBrowserStore.getState().hydrate({
         tabs: state.browserTabs,
-        activeId: state.activeBrowserTabId ?? null,
+        activeIds: state.activeBrowserTabIds,
+        legacyActiveId: state.activeBrowserTabId ?? null,
         bookmarks: state.browserBookmarks,
       });
 

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -3,6 +3,7 @@ import { useModelPreferences } from '@/stores/model-preferences';
 import { useSessionStore } from '@/stores/sessions';
 import { hydrateThemeStore, useThemeStore } from '@/stores/theme';
 import { useWorkspaceStore } from '@/stores/workspace';
+import { useBrowserStore } from '@/stores/browser';
 import { normaliseFavouriteApps } from './shared';
 import type { AppState } from './state';
 import { useAppStore } from './state';
@@ -63,6 +64,10 @@ export async function loadLayout(): Promise<void> {
         hiddenModels: state.hiddenModels,
         hiddenProviders: state.hiddenProviders,
       });
+
+      // Hydrate browser tabs (WebContentsViews are created lazily when the
+      // user opens the browser panel, not eagerly here).
+      useBrowserStore.getState().hydrate(state.browserTabs, state.activeBrowserTabId ?? null);
 
       return;
     }

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -67,7 +67,11 @@ export async function loadLayout(): Promise<void> {
 
       // Hydrate browser tabs (WebContentsViews are created lazily when the
       // user opens the browser panel, not eagerly here).
-      useBrowserStore.getState().hydrate(state.browserTabs, state.activeBrowserTabId ?? null);
+      useBrowserStore.getState().hydrate({
+        tabs: state.browserTabs,
+        activeId: state.activeBrowserTabId ?? null,
+        bookmarks: state.browserBookmarks,
+      });
 
       return;
     }

--- a/apps/desktop/src/stores/browser-helpers.ts
+++ b/apps/desktop/src/stores/browser-helpers.ts
@@ -1,0 +1,66 @@
+/**
+ * Helpers used by the browser store. Pulled out to keep
+ * `stores/browser.ts` under the 500-LOC rule.
+ */
+
+import { useAgentStore } from '@/stores/agent';
+import { useAppStore } from '@/stores/app';
+import { useSessionStore } from '@/stores/sessions';
+
+/**
+ * Format a page selection as a markdown blockquote with an attribution
+ * line. Two trailing newlines leave the cursor on a fresh line so the user
+ * can start typing their question immediately.
+ */
+export function formatSelectionForChat(
+  selection: string,
+  pageUrl: string,
+  pageTitle: string,
+): string {
+  const trimmed = selection.replace(/\s+$/, '');
+  const quoted = trimmed.split('\n').map((line) => `> ${line}`).join('\n');
+  const title = pageTitle.trim();
+  const attribution = title ? `— ${title} — ${pageUrl}` : `— ${pageUrl}`;
+  return `${quoted}\n\n${attribution}\n\n`;
+}
+
+/**
+ * "Please save this to memory" template that nudges the agent to call
+ * the memory tool.
+ */
+export function formatSelectionForMemory(
+  selection: string,
+  pageUrl: string,
+  pageTitle: string,
+): string {
+  const trimmed = selection.replace(/\s+$/, '');
+  const quoted = trimmed.split('\n').map((line) => `> ${line}`).join('\n');
+  const title = pageTitle.trim();
+  const attribution = title ? `— ${title} — ${pageUrl}` : `— ${pageUrl}`;
+  return `Please save this to memory:\n\n${quoted}\n\n${attribution}\n\n`;
+}
+
+function resolveActiveSessionId(): string | null {
+  return (
+    useAgentStore.getState().focusedSessionId ??
+    useSessionStore.getState().activeSessionId ??
+    null
+  );
+}
+
+/** Drop formatted text into the focused (or active) chat session's composer. */
+export function prefillChatComposer(text: string): void {
+  const sessionId = resolveActiveSessionId();
+  if (!sessionId) {
+    console.warn('[browser] No chat session available — selection ignored.');
+    return;
+  }
+  useAgentStore.getState().setComposerPrefill(sessionId, {
+    requestId: `sel_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`,
+    text,
+    source: 'system',
+  });
+  if (!useAppStore.getState().chatPanelOpen) {
+    useAppStore.getState().setChatPanelOpen(true);
+  }
+}

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -1,14 +1,15 @@
 /**
  * Browser tab store — drives the in-app browser panel.
  *
- * Holds the renderer-side view of each tab (URL, title, favicon, loading,
- * history) while the actual WebContents lives in the main process. Events
- * pushed from `window.sero.browser.onEvent` keep the runtime metadata in
- * sync; every structural change (create/close/reorder/active/bookmark) is
- * persisted into `layout.json` via `persistLayout`.
+ * Tabs belong to a workspace (cookies/sessions are isolated via per-workspace
+ * partitions in the main-process view manager). The renderer keeps the flat
+ * `tabs` list but filters by workspace at the UI edge. `activeTabIds` is a
+ * per-workspace map so switching workspaces snaps back to each one's last
+ * active tab.
  */
 
 import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
 import { persistLayout } from '@/lib/persist-layout';
 import { useAgentStore } from '@/stores/agent';
 import { useAppStore } from '@/stores/app';
@@ -22,11 +23,21 @@ import {
 } from '@/types/browser';
 import type { PersistedBrowserBookmark, PersistedBrowserTab } from '@/types/layout';
 
+/** Snapshot of a tab the user just closed, kept in-memory for ⌘Shift+T. */
+interface ClosedTab {
+  workspaceId: string;
+  url: string;
+  title: string;
+  favicon?: string;
+  closedAt: number;
+}
+
+const MAX_RECENTLY_CLOSED = 10;
+
 /**
  * Format a page selection as a markdown blockquote with an attribution
- * line, ready to be inserted into the chat composer. Two trailing newlines
- * leave the cursor on a fresh line so the user can start typing their
- * question immediately.
+ * line. Two trailing newlines leave the cursor on a fresh line so the user
+ * can start typing their question immediately.
  */
 function formatSelectionForChat(
   selection: string,
@@ -40,79 +51,82 @@ function formatSelectionForChat(
   return `${quoted}\n\n${attribution}\n\n`;
 }
 
-/** Drop a page selection into the focused (or active) chat session's composer. */
-function dropSelectionInChat(
+/** "Please save this to memory" template that nudges the agent to call the memory tool. */
+function formatSelectionForMemory(
   selection: string,
   pageUrl: string,
   pageTitle: string,
-): void {
-  const sessionId =
+): string {
+  const trimmed = selection.replace(/\s+$/, '');
+  const quoted = trimmed.split('\n').map((line) => `> ${line}`).join('\n');
+  const title = pageTitle.trim();
+  const attribution = title ? `— ${title} — ${pageUrl}` : `— ${pageUrl}`;
+  return `Please save this to memory:\n\n${quoted}\n\n${attribution}\n\n`;
+}
+
+function resolveActiveSessionId(): string | null {
+  return (
     useAgentStore.getState().focusedSessionId ??
-    useSessionStore.getState().activeSessionId;
+    useSessionStore.getState().activeSessionId ??
+    null
+  );
+}
+
+/** Drop formatted text into the focused (or active) chat session's composer. */
+function prefillChatComposer(text: string): void {
+  const sessionId = resolveActiveSessionId();
   if (!sessionId) {
     console.warn('[browser] No chat session available — selection ignored.');
     return;
   }
   useAgentStore.getState().setComposerPrefill(sessionId, {
     requestId: generateId('sel'),
-    text: formatSelectionForChat(selection, pageUrl, pageTitle),
+    text,
     source: 'system',
   });
-  // Make sure the panel is visible so the user can see the prefill.
   if (!useAppStore.getState().chatPanelOpen) {
     useAppStore.getState().setChatPanelOpen(true);
   }
 }
 
-/** Snapshot of a tab the user just closed, kept in-memory for ⌘Shift+T. */
-interface ClosedTab {
-  url: string;
-  title: string;
-  favicon?: string;
-  closedAt: number;
-}
-
-const MAX_RECENTLY_CLOSED = 10;
-
 interface BrowserState {
   tabs: BrowserTab[];
-  activeTabId: string | null;
+  /** Active tab id per workspace. */
+  activeTabIds: Record<string, string | null>;
   bookmarks: BrowserBookmark[];
   /** Most-recently-closed first. In-memory only (not persisted). */
   recentlyClosed: ClosedTab[];
 
-  /** Create a new tab. Returns the new id. */
-  createTab: (urlOrQuery?: string) => string;
+  /** Create a new tab under the given workspace. Returns the new id. */
+  createTab: (workspaceId: string, urlOrQuery?: string) => string;
   closeTab: (id: string) => void;
   closeOtherTabs: (id: string) => void;
-  closeAllTabs: () => void;
-  reopenClosedTab: () => void;
+  closeAllTabs: (workspaceId: string) => void;
+  reopenClosedTab: (workspaceId: string) => void;
   setActive: (id: string) => void;
-  reorderTabs: (ids: string[]) => void;
-  /** Switch to tab by zero-based index (⌘1..⌘9). Ignores out-of-range. */
-  setActiveByIndex: (index: number) => void;
-  /** Move active tab selection by delta (⌘Shift+[ / ⌘Shift+]). Wraps. */
-  cycleActive: (delta: number) => void;
+  reorderTabs: (workspaceId: string, ids: string[]) => void;
+  /** Switch to tab at zero-based index within the workspace (⌘1..⌘9). */
+  setActiveByIndex: (workspaceId: string, index: number) => void;
+  /** Cycle active tab left/right within the workspace (wraps). */
+  cycleActive: (workspaceId: string, delta: number) => void;
   navigate: (id: string, urlOrQuery: string) => void;
   goBack: (id: string) => void;
   goForward: (id: string) => void;
   reload: (id: string) => void;
   stop: (id: string) => void;
 
-  /** Bookmarks. */
   addBookmark: (input: { title: string; url: string; favicon?: string }) => void;
   removeBookmark: (id: string) => void;
   updateBookmark: (id: string, patch: Partial<Omit<BrowserBookmark, 'id'>>) => void;
 
-  /** Hydrate from persisted layout state (called once on startup). */
   hydrate: (input: {
     tabs: PersistedBrowserTab[] | undefined;
-    activeId: string | null | undefined;
+    activeIds: Record<string, string | null> | undefined;
+    legacyActiveId: string | null | undefined;
     bookmarks: PersistedBrowserBookmark[] | undefined;
   }) => void;
-  /** Ensure the main process has a WebContentsView for every tab. Idempotent. */
-  ensureViewsOpen: () => void;
-  /** Apply an event pushed from the main-process view manager. */
+  /** Ensure the main process has a WebContentsView for every tab in a workspace. */
+  ensureViewsOpen: (workspaceId: string) => void;
   applyEvent: (event: BrowserEvent) => void;
 }
 
@@ -121,12 +135,13 @@ function generateId(prefix: string): string {
 }
 
 function toPersistedTabs(tabs: BrowserTab[]): PersistedBrowserTab[] {
-  return tabs.map((t) => ({ id: t.id, url: t.url, title: t.title }));
+  return tabs.map((t) => ({ id: t.id, workspaceId: t.workspaceId, url: t.url, title: t.title }));
 }
 
-function newTab(url: string): BrowserTab {
+function newTab(workspaceId: string, url: string): BrowserTab {
   return {
     id: generateId('tab'),
+    workspaceId,
     url,
     title: url,
     isLoading: false,
@@ -137,101 +152,150 @@ function newTab(url: string): BrowserTab {
 
 export const useBrowserStore = create<BrowserState>((set, get) => ({
   tabs: [],
-  activeTabId: null,
+  activeTabIds: {},
   bookmarks: [],
   recentlyClosed: [],
 
-  createTab: (urlOrQuery) => {
+  createTab: (workspaceId, urlOrQuery) => {
     const url = urlOrQuery ? resolveAddressBarInput(urlOrQuery) : BROWSER_HOME_URL;
-    const tab = newTab(url);
-    set((s) => ({ tabs: [...s.tabs, tab], activeTabId: tab.id }));
-    void window.sero.browser.openTab(tab.id, url);
+    const tab = newTab(workspaceId, url);
+    set((s) => ({
+      tabs: [...s.tabs, tab],
+      activeTabIds: { ...s.activeTabIds, [workspaceId]: tab.id },
+    }));
+    void window.sero.browser.openTab(tab.id, url, workspaceId);
     void window.sero.browser.setActive(tab.id);
     persistLayout({
       browserTabs: toPersistedTabs(get().tabs),
-      activeBrowserTabId: tab.id,
+      activeBrowserTabIds: get().activeTabIds,
     });
     return tab.id;
   },
 
   closeTab: (id) => {
-    const { tabs, activeTabId, recentlyClosed } = get();
+    const { tabs, activeTabIds, recentlyClosed } = get();
     const idx = tabs.findIndex((t) => t.id === id);
     if (idx === -1) return;
     const closing = tabs[idx];
+    const ws = closing.workspaceId;
+
     const nextTabs = tabs.filter((t) => t.id !== id);
-    let nextActive = activeTabId;
-    if (activeTabId === id) {
-      // Prefer the neighbour to the right, fall back to the left.
-      const neighbour = nextTabs[idx] ?? nextTabs[idx - 1] ?? null;
+    // Neighbour preference is scoped to the same workspace.
+    const wsTabs = tabs.filter((t) => t.workspaceId === ws);
+    const wsIdx = wsTabs.findIndex((t) => t.id === id);
+    const nextWsTabs = wsTabs.filter((t) => t.id !== id);
+
+    let nextActive: string | null = activeTabIds[ws] ?? null;
+    if (nextActive === id) {
+      const neighbour = nextWsTabs[wsIdx] ?? nextWsTabs[wsIdx - 1] ?? null;
       nextActive = neighbour ? neighbour.id : null;
     }
+
     const nextClosed = [
-      { url: closing.url, title: closing.title, favicon: closing.favicon, closedAt: Date.now() },
+      {
+        workspaceId: ws,
+        url: closing.url,
+        title: closing.title,
+        favicon: closing.favicon,
+        closedAt: Date.now(),
+      },
       ...recentlyClosed,
     ].slice(0, MAX_RECENTLY_CLOSED);
-    set({ tabs: nextTabs, activeTabId: nextActive, recentlyClosed: nextClosed });
+
+    set({
+      tabs: nextTabs,
+      activeTabIds: { ...activeTabIds, [ws]: nextActive },
+      recentlyClosed: nextClosed,
+    });
     void window.sero.browser.closeTab(id);
     void window.sero.browser.setActive(nextActive);
     persistLayout({
       browserTabs: toPersistedTabs(nextTabs),
-      activeBrowserTabId: nextActive,
+      activeBrowserTabIds: get().activeTabIds,
     });
   },
 
   closeOtherTabs: (id) => {
-    const { tabs } = get();
-    for (const t of tabs) {
-      if (t.id !== id) get().closeTab(t.id);
+    const target = get().tabs.find((t) => t.id === id);
+    if (!target) return;
+    const ws = target.workspaceId;
+    for (const t of get().tabs) {
+      if (t.workspaceId === ws && t.id !== id) get().closeTab(t.id);
     }
   },
 
-  closeAllTabs: () => {
-    const { tabs } = get();
-    for (const t of tabs) get().closeTab(t.id);
+  closeAllTabs: (workspaceId) => {
+    for (const t of get().tabs) {
+      if (t.workspaceId === workspaceId) get().closeTab(t.id);
+    }
   },
 
-  reopenClosedTab: () => {
-    const [last, ...rest] = get().recentlyClosed;
-    if (!last) return;
-    set({ recentlyClosed: rest });
-    get().createTab(last.url);
+  reopenClosedTab: (workspaceId) => {
+    const index = get().recentlyClosed.findIndex((t) => t.workspaceId === workspaceId);
+    if (index === -1) return;
+    const entry = get().recentlyClosed[index];
+    set((s) => ({
+      recentlyClosed: [...s.recentlyClosed.slice(0, index), ...s.recentlyClosed.slice(index + 1)],
+    }));
+    get().createTab(workspaceId, entry.url);
   },
 
   setActive: (id) => {
-    if (get().activeTabId === id) return;
-    set({ activeTabId: id });
+    const tab = get().tabs.find((t) => t.id === id);
+    if (!tab) return;
+    if (get().activeTabIds[tab.workspaceId] === id) return;
+    set((s) => ({
+      activeTabIds: { ...s.activeTabIds, [tab.workspaceId]: id },
+    }));
     void window.sero.browser.setActive(id);
-    persistLayout({ activeBrowserTabId: id });
+    persistLayout({ activeBrowserTabIds: get().activeTabIds });
   },
 
-  reorderTabs: (ids) => {
+  reorderTabs: (workspaceId, ids) => {
     const { tabs } = get();
     const byId = new Map(tabs.map((t) => [t.id, t]));
-    const reordered = ids
-      .map((id) => byId.get(id))
-      .filter((t): t is BrowserTab => Boolean(t));
-    // Append any tabs the caller forgot (defensive — keeps us from silently dropping tabs).
+
+    // Split current tabs into "belongs to workspace" (reordered) and "other" (kept in place).
+    const wsTabsInNewOrder: BrowserTab[] = [];
+    for (const id of ids) {
+      const t = byId.get(id);
+      if (t && t.workspaceId === workspaceId) wsTabsInNewOrder.push(t);
+    }
+    // Append any workspace tabs that got dropped (defensive).
     for (const t of tabs) {
-      if (!ids.includes(t.id)) reordered.push(t);
+      if (t.workspaceId === workspaceId && !ids.includes(t.id)) wsTabsInNewOrder.push(t);
+    }
+
+    // Rebuild the flat list, slotting reordered workspace tabs into the
+    // positions of their siblings (so other workspaces' tabs keep their
+    // relative order).
+    const reordered: BrowserTab[] = [];
+    let wsCursor = 0;
+    for (const t of tabs) {
+      if (t.workspaceId === workspaceId) {
+        reordered.push(wsTabsInNewOrder[wsCursor++] ?? t);
+      } else {
+        reordered.push(t);
+      }
     }
     set({ tabs: reordered });
     persistLayout({ browserTabs: toPersistedTabs(reordered) });
   },
 
-  setActiveByIndex: (index) => {
-    const tab = get().tabs[index];
+  setActiveByIndex: (workspaceId, index) => {
+    const wsTabs = get().tabs.filter((t) => t.workspaceId === workspaceId);
+    const tab = wsTabs[index];
     if (tab) get().setActive(tab.id);
   },
 
-  cycleActive: (delta) => {
-    const { tabs, activeTabId } = get();
-    if (tabs.length === 0) return;
-    const idx = tabs.findIndex((t) => t.id === activeTabId);
-    // Modulo that handles negatives (JS % keeps sign of dividend).
-    const len = tabs.length;
+  cycleActive: (workspaceId, delta) => {
+    const wsTabs = get().tabs.filter((t) => t.workspaceId === workspaceId);
+    if (wsTabs.length === 0) return;
+    const activeId = get().activeTabIds[workspaceId] ?? null;
+    const idx = wsTabs.findIndex((t) => t.id === activeId);
+    const len = wsTabs.length;
     const next = idx < 0 ? 0 : ((idx + delta) % len + len) % len;
-    get().setActive(tabs[next].id);
+    get().setActive(wsTabs[next].id);
   },
 
   navigate: (id, urlOrQuery) => {
@@ -243,22 +307,13 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     persistLayout({ browserTabs: toPersistedTabs(get().tabs) });
   },
 
-  goBack: (id) => {
-    void window.sero.browser.goBack(id);
-  },
-  goForward: (id) => {
-    void window.sero.browser.goForward(id);
-  },
-  reload: (id) => {
-    void window.sero.browser.reload(id);
-  },
-  stop: (id) => {
-    void window.sero.browser.stop(id);
-  },
+  goBack: (id) => { void window.sero.browser.goBack(id); },
+  goForward: (id) => { void window.sero.browser.goForward(id); },
+  reload: (id) => { void window.sero.browser.reload(id); },
+  stop: (id) => { void window.sero.browser.stop(id); },
 
   addBookmark: (input) => {
     const { bookmarks } = get();
-    // Dedupe on URL — updating the existing entry if the title has changed.
     const existing = bookmarks.find((b) => b.url === input.url);
     const next = existing
       ? bookmarks.map((b) =>
@@ -291,33 +346,59 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     persistLayout({ browserBookmarks: next });
   },
 
-  hydrate: ({ tabs, activeId, bookmarks }) => {
+  hydrate: ({ tabs, activeIds, legacyActiveId, bookmarks }) => {
     const hydratedTabs: BrowserTab[] = (tabs ?? []).map((t) => ({
       id: t.id,
+      workspaceId: t.workspaceId ?? 'global',
       url: t.url,
       title: t.title ?? t.url,
       isLoading: false,
       canGoBack: false,
       canGoForward: false,
     }));
-    const active = activeId && hydratedTabs.some((t) => t.id === activeId)
-      ? activeId
-      : hydratedTabs[0]?.id ?? null;
+
+    const resolvedActiveIds: Record<string, string | null> = {};
+    if (activeIds) {
+      for (const [ws, id] of Object.entries(activeIds)) {
+        if (!id) continue;
+        if (hydratedTabs.some((t) => t.id === id && t.workspaceId === ws)) {
+          resolvedActiveIds[ws] = id;
+        }
+      }
+    }
+    // Backward compat: promote legacy single active id into its workspace bucket.
+    if (legacyActiveId) {
+      const tab = hydratedTabs.find((t) => t.id === legacyActiveId);
+      if (tab && !resolvedActiveIds[tab.workspaceId]) {
+        resolvedActiveIds[tab.workspaceId] = tab.id;
+      }
+    }
+
+    // Backfill: every workspace with tabs should have an active tab.
+    const workspaces = new Set(hydratedTabs.map((t) => t.workspaceId));
+    for (const ws of workspaces) {
+      if (!resolvedActiveIds[ws]) {
+        const first = hydratedTabs.find((t) => t.workspaceId === ws);
+        if (first) resolvedActiveIds[ws] = first.id;
+      }
+    }
+
     set({
       tabs: hydratedTabs,
-      activeTabId: active,
+      activeTabIds: resolvedActiveIds,
       bookmarks: bookmarks ?? [],
     });
   },
 
-  ensureViewsOpen: () => {
-    const { tabs, activeTabId } = get();
+  ensureViewsOpen: (workspaceId) => {
+    const { tabs, activeTabIds } = get();
     for (const tab of tabs) {
+      if (tab.workspaceId !== workspaceId) continue;
       // openTab is idempotent — the manager navigates the existing view if
       // the tab already has one.
-      void window.sero.browser.openTab(tab.id, tab.url);
+      void window.sero.browser.openTab(tab.id, tab.url, tab.workspaceId);
     }
-    void window.sero.browser.setActive(activeTabId);
+    void window.sero.browser.setActive(activeTabIds[workspaceId] ?? null);
   },
 
   applyEvent: (event) => {
@@ -349,22 +430,35 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
       return { tabs };
     });
 
-    // new-tab-request originates from window.open in the WebContents; open
-    // a fresh tab with the requested URL.
     if (event.kind === 'new-tab-request') {
-      get().createTab(event.url);
+      get().createTab(event.workspaceId, event.url);
       return;
     }
 
     if (event.kind === 'selection-to-chat') {
-      dropSelectionInChat(event.selection, event.pageUrl, event.pageTitle);
+      prefillChatComposer(formatSelectionForChat(event.selection, event.pageUrl, event.pageTitle));
       return;
     }
 
-    // Persist navigation and title changes so a restart restores the
-    // current page, not whatever URL was first opened in the tab.
+    if (event.kind === 'selection-to-memory') {
+      prefillChatComposer(formatSelectionForMemory(event.selection, event.pageUrl, event.pageTitle));
+      return;
+    }
+
     if (event.kind === 'did-navigate' || event.kind === 'title-updated') {
       persistLayout({ browserTabs: toPersistedTabs(get().tabs) });
     }
   },
 }));
+
+/* ── Selectors ──────────────────────────────────────────────── */
+
+export function useWorkspaceBrowserTabs(workspaceId: string): BrowserTab[] {
+  return useBrowserStore(
+    useShallow((s) => s.tabs.filter((t) => t.workspaceId === workspaceId)),
+  );
+}
+
+export function useActiveBrowserTabId(workspaceId: string): string | null {
+  return useBrowserStore((s) => s.activeTabIds[workspaceId] ?? null);
+}

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -113,7 +113,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
       activeTabIds: { ...s.activeTabIds, [workspaceId]: tab.id },
     }));
     void window.sero.browser.openTab(tab.id, url, workspaceId);
-    void window.sero.browser.setActive(tab.id);
+    void window.sero.browser.setActive(tab.id, workspaceId);
     persistLayout({
       browserTabs: toPersistedTabs(get().tabs),
       activeBrowserTabIds: get().activeTabIds,
@@ -156,8 +156,8 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
       activeTabIds: { ...activeTabIds, [ws]: nextActive },
       recentlyClosed: nextClosed,
     });
-    void window.sero.browser.closeTab(id);
-    void window.sero.browser.setActive(nextActive);
+    void window.sero.browser.closeTab(id, ws);
+    void window.sero.browser.setActive(nextActive, ws);
     persistLayout({
       browserTabs: toPersistedTabs(nextTabs),
       activeBrowserTabIds: get().activeTabIds,
@@ -196,7 +196,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     set((s) => ({
       activeTabIds: { ...s.activeTabIds, [tab.workspaceId]: id },
     }));
-    void window.sero.browser.setActive(id);
+    void window.sero.browser.setActive(id, tab.workspaceId);
     persistLayout({ activeBrowserTabIds: get().activeTabIds });
   },
 
@@ -248,21 +248,37 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
   },
 
   navigate: (id, urlOrQuery) => {
+    const tab = get().tabs.find((t) => t.id === id);
+    if (!tab) return;
     const url = resolveAddressBarInput(urlOrQuery);
     set((s) => ({
       tabs: s.tabs.map((t) => (t.id === id ? { ...t, url, isLoading: true } : t)),
     }));
-    void window.sero.browser.navigate(id, url);
+    void window.sero.browser.navigate(id, url, tab.workspaceId);
     persistLayout({ browserTabs: toPersistedTabs(get().tabs) });
   },
 
-  goBack: (id) => { void window.sero.browser.goBack(id); },
-  goForward: (id) => { void window.sero.browser.goForward(id); },
-  reload: (id) => { void window.sero.browser.reload(id); },
-  stop: (id) => { void window.sero.browser.stop(id); },
+  goBack: (id) => {
+    const ws = get().tabs.find((t) => t.id === id)?.workspaceId;
+    if (ws) void window.sero.browser.goBack(id, ws);
+  },
+  goForward: (id) => {
+    const ws = get().tabs.find((t) => t.id === id)?.workspaceId;
+    if (ws) void window.sero.browser.goForward(id, ws);
+  },
+  reload: (id) => {
+    const ws = get().tabs.find((t) => t.id === id)?.workspaceId;
+    if (ws) void window.sero.browser.reload(id, ws);
+  },
+  stop: (id) => {
+    const ws = get().tabs.find((t) => t.id === id)?.workspaceId;
+    if (ws) void window.sero.browser.stop(id, ws);
+  },
 
   sharePageWithChat: async (id) => {
-    const result = await window.sero.browser.extractPage(id);
+    const tab = get().tabs.find((t) => t.id === id);
+    if (!tab) return;
+    const result = await window.sero.browser.extractPage(id, tab.workspaceId);
     if (!result) {
       console.warn('[browser] Page extraction returned nothing.');
       return;
@@ -364,7 +380,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
       // the tab already has one.
       void window.sero.browser.openTab(tab.id, tab.url, tab.workspaceId);
     }
-    void window.sero.browser.setActive(activeTabIds[workspaceId] ?? null);
+    void window.sero.browser.setActive(activeTabIds[workspaceId] ?? null, workspaceId);
   },
 
   applyEvent: (event) => {

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -4,8 +4,8 @@
  * Holds the renderer-side view of each tab (URL, title, favicon, loading,
  * history) while the actual WebContents lives in the main process. Events
  * pushed from `window.sero.browser.onEvent` keep the runtime metadata in
- * sync; every structural change (create/close/reorder/active) is persisted
- * into `layout.json` via `persistLayout`.
+ * sync; every structural change (create/close/reorder/active/bookmark) is
+ * persisted into `layout.json` via `persistLayout`.
  */
 
 import { create } from 'zustand';
@@ -13,44 +13,75 @@ import { persistLayout } from '@/lib/persist-layout';
 import {
   BROWSER_HOME_URL,
   resolveAddressBarInput,
+  type BrowserBookmark,
   type BrowserEvent,
   type BrowserTab,
 } from '@/types/browser';
-import type { PersistedBrowserTab } from '@/types/layout';
+import type { PersistedBrowserBookmark, PersistedBrowserTab } from '@/types/layout';
+
+/** Snapshot of a tab the user just closed, kept in-memory for ⌘Shift+T. */
+interface ClosedTab {
+  url: string;
+  title: string;
+  favicon?: string;
+  closedAt: number;
+}
+
+const MAX_RECENTLY_CLOSED = 10;
 
 interface BrowserState {
   tabs: BrowserTab[];
   activeTabId: string | null;
+  bookmarks: BrowserBookmark[];
+  /** Most-recently-closed first. In-memory only (not persisted). */
+  recentlyClosed: ClosedTab[];
 
   /** Create a new tab. Returns the new id. */
   createTab: (urlOrQuery?: string) => string;
   closeTab: (id: string) => void;
+  closeOtherTabs: (id: string) => void;
+  closeAllTabs: () => void;
+  reopenClosedTab: () => void;
   setActive: (id: string) => void;
+  reorderTabs: (ids: string[]) => void;
+  /** Switch to tab by zero-based index (⌘1..⌘9). Ignores out-of-range. */
+  setActiveByIndex: (index: number) => void;
+  /** Move active tab selection by delta (⌘Shift+[ / ⌘Shift+]). Wraps. */
+  cycleActive: (delta: number) => void;
   navigate: (id: string, urlOrQuery: string) => void;
   goBack: (id: string) => void;
   goForward: (id: string) => void;
   reload: (id: string) => void;
   stop: (id: string) => void;
 
+  /** Bookmarks. */
+  addBookmark: (input: { title: string; url: string; favicon?: string }) => void;
+  removeBookmark: (id: string) => void;
+  updateBookmark: (id: string, patch: Partial<Omit<BrowserBookmark, 'id'>>) => void;
+
   /** Hydrate from persisted layout state (called once on startup). */
-  hydrate: (tabs: PersistedBrowserTab[] | undefined, activeId: string | null | undefined) => void;
+  hydrate: (input: {
+    tabs: PersistedBrowserTab[] | undefined;
+    activeId: string | null | undefined;
+    bookmarks: PersistedBrowserBookmark[] | undefined;
+  }) => void;
   /** Ensure the main process has a WebContentsView for every tab. Idempotent. */
   ensureViewsOpen: () => void;
   /** Apply an event pushed from the main-process view manager. */
   applyEvent: (event: BrowserEvent) => void;
 }
 
-function generateTabId(): string {
-  return `tab_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+function generateId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function toPersisted(tabs: BrowserTab[]): PersistedBrowserTab[] {
+function toPersistedTabs(tabs: BrowserTab[]): PersistedBrowserTab[] {
   return tabs.map((t) => ({ id: t.id, url: t.url, title: t.title }));
 }
 
 function newTab(url: string): BrowserTab {
   return {
-    id: generateTabId(),
+    id: generateId('tab'),
     url,
     title: url,
     isLoading: false,
@@ -62,6 +93,8 @@ function newTab(url: string): BrowserTab {
 export const useBrowserStore = create<BrowserState>((set, get) => ({
   tabs: [],
   activeTabId: null,
+  bookmarks: [],
+  recentlyClosed: [],
 
   createTab: (urlOrQuery) => {
     const url = urlOrQuery ? resolveAddressBarInput(urlOrQuery) : BROWSER_HOME_URL;
@@ -70,16 +103,17 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     void window.sero.browser.openTab(tab.id, url);
     void window.sero.browser.setActive(tab.id);
     persistLayout({
-      browserTabs: toPersisted(get().tabs),
+      browserTabs: toPersistedTabs(get().tabs),
       activeBrowserTabId: tab.id,
     });
     return tab.id;
   },
 
   closeTab: (id) => {
-    const { tabs, activeTabId } = get();
+    const { tabs, activeTabId, recentlyClosed } = get();
     const idx = tabs.findIndex((t) => t.id === id);
     if (idx === -1) return;
+    const closing = tabs[idx];
     const nextTabs = tabs.filter((t) => t.id !== id);
     let nextActive = activeTabId;
     if (activeTabId === id) {
@@ -87,13 +121,36 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
       const neighbour = nextTabs[idx] ?? nextTabs[idx - 1] ?? null;
       nextActive = neighbour ? neighbour.id : null;
     }
-    set({ tabs: nextTabs, activeTabId: nextActive });
+    const nextClosed = [
+      { url: closing.url, title: closing.title, favicon: closing.favicon, closedAt: Date.now() },
+      ...recentlyClosed,
+    ].slice(0, MAX_RECENTLY_CLOSED);
+    set({ tabs: nextTabs, activeTabId: nextActive, recentlyClosed: nextClosed });
     void window.sero.browser.closeTab(id);
     void window.sero.browser.setActive(nextActive);
     persistLayout({
-      browserTabs: toPersisted(nextTabs),
+      browserTabs: toPersistedTabs(nextTabs),
       activeBrowserTabId: nextActive,
     });
+  },
+
+  closeOtherTabs: (id) => {
+    const { tabs } = get();
+    for (const t of tabs) {
+      if (t.id !== id) get().closeTab(t.id);
+    }
+  },
+
+  closeAllTabs: () => {
+    const { tabs } = get();
+    for (const t of tabs) get().closeTab(t.id);
+  },
+
+  reopenClosedTab: () => {
+    const [last, ...rest] = get().recentlyClosed;
+    if (!last) return;
+    set({ recentlyClosed: rest });
+    get().createTab(last.url);
   },
 
   setActive: (id) => {
@@ -103,13 +160,42 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     persistLayout({ activeBrowserTabId: id });
   },
 
+  reorderTabs: (ids) => {
+    const { tabs } = get();
+    const byId = new Map(tabs.map((t) => [t.id, t]));
+    const reordered = ids
+      .map((id) => byId.get(id))
+      .filter((t): t is BrowserTab => Boolean(t));
+    // Append any tabs the caller forgot (defensive — keeps us from silently dropping tabs).
+    for (const t of tabs) {
+      if (!ids.includes(t.id)) reordered.push(t);
+    }
+    set({ tabs: reordered });
+    persistLayout({ browserTabs: toPersistedTabs(reordered) });
+  },
+
+  setActiveByIndex: (index) => {
+    const tab = get().tabs[index];
+    if (tab) get().setActive(tab.id);
+  },
+
+  cycleActive: (delta) => {
+    const { tabs, activeTabId } = get();
+    if (tabs.length === 0) return;
+    const idx = tabs.findIndex((t) => t.id === activeTabId);
+    // Modulo that handles negatives (JS % keeps sign of dividend).
+    const len = tabs.length;
+    const next = idx < 0 ? 0 : ((idx + delta) % len + len) % len;
+    get().setActive(tabs[next].id);
+  },
+
   navigate: (id, urlOrQuery) => {
     const url = resolveAddressBarInput(urlOrQuery);
     set((s) => ({
       tabs: s.tabs.map((t) => (t.id === id ? { ...t, url, isLoading: true } : t)),
     }));
     void window.sero.browser.navigate(id, url);
-    persistLayout({ browserTabs: toPersisted(get().tabs) });
+    persistLayout({ browserTabs: toPersistedTabs(get().tabs) });
   },
 
   goBack: (id) => {
@@ -125,12 +211,43 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     void window.sero.browser.stop(id);
   },
 
-  hydrate: (tabs, activeId) => {
-    if (!tabs || tabs.length === 0) {
-      set({ tabs: [], activeTabId: null });
-      return;
-    }
-    const hydrated: BrowserTab[] = tabs.map((t) => ({
+  addBookmark: (input) => {
+    const { bookmarks } = get();
+    // Dedupe on URL — updating the existing entry if the title has changed.
+    const existing = bookmarks.find((b) => b.url === input.url);
+    const next = existing
+      ? bookmarks.map((b) =>
+          b.id === existing.id
+            ? { ...b, title: input.title || b.title, favicon: input.favicon ?? b.favicon }
+            : b,
+        )
+      : [
+          ...bookmarks,
+          {
+            id: generateId('bm'),
+            title: input.title || input.url,
+            url: input.url,
+            ...(input.favicon !== undefined ? { favicon: input.favicon } : {}),
+          },
+        ];
+    set({ bookmarks: next });
+    persistLayout({ browserBookmarks: next });
+  },
+
+  removeBookmark: (id) => {
+    const next = get().bookmarks.filter((b) => b.id !== id);
+    set({ bookmarks: next });
+    persistLayout({ browserBookmarks: next });
+  },
+
+  updateBookmark: (id, patch) => {
+    const next = get().bookmarks.map((b) => (b.id === id ? { ...b, ...patch } : b));
+    set({ bookmarks: next });
+    persistLayout({ browserBookmarks: next });
+  },
+
+  hydrate: ({ tabs, activeId, bookmarks }) => {
+    const hydratedTabs: BrowserTab[] = (tabs ?? []).map((t) => ({
       id: t.id,
       url: t.url,
       title: t.title ?? t.url,
@@ -138,10 +255,14 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
       canGoBack: false,
       canGoForward: false,
     }));
-    const active = activeId && hydrated.some((t) => t.id === activeId)
+    const active = activeId && hydratedTabs.some((t) => t.id === activeId)
       ? activeId
-      : hydrated[0]?.id ?? null;
-    set({ tabs: hydrated, activeTabId: active });
+      : hydratedTabs[0]?.id ?? null;
+    set({
+      tabs: hydratedTabs,
+      activeTabId: active,
+      bookmarks: bookmarks ?? [],
+    });
   },
 
   ensureViewsOpen: () => {
@@ -193,7 +314,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     // Persist navigation and title changes so a restart restores the
     // current page, not whatever URL was first opened in the tab.
     if (event.kind === 'did-navigate' || event.kind === 'title-updated') {
-      persistLayout({ browserTabs: toPersisted(get().tabs) });
+      persistLayout({ browserTabs: toPersistedTabs(get().tabs) });
     }
   },
 }));

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -1,0 +1,199 @@
+/**
+ * Browser tab store — drives the in-app browser panel.
+ *
+ * Holds the renderer-side view of each tab (URL, title, favicon, loading,
+ * history) while the actual WebContents lives in the main process. Events
+ * pushed from `window.sero.browser.onEvent` keep the runtime metadata in
+ * sync; every structural change (create/close/reorder/active) is persisted
+ * into `layout.json` via `persistLayout`.
+ */
+
+import { create } from 'zustand';
+import { persistLayout } from '@/lib/persist-layout';
+import {
+  BROWSER_HOME_URL,
+  resolveAddressBarInput,
+  type BrowserEvent,
+  type BrowserTab,
+} from '@/types/browser';
+import type { PersistedBrowserTab } from '@/types/layout';
+
+interface BrowserState {
+  tabs: BrowserTab[];
+  activeTabId: string | null;
+
+  /** Create a new tab. Returns the new id. */
+  createTab: (urlOrQuery?: string) => string;
+  closeTab: (id: string) => void;
+  setActive: (id: string) => void;
+  navigate: (id: string, urlOrQuery: string) => void;
+  goBack: (id: string) => void;
+  goForward: (id: string) => void;
+  reload: (id: string) => void;
+  stop: (id: string) => void;
+
+  /** Hydrate from persisted layout state (called once on startup). */
+  hydrate: (tabs: PersistedBrowserTab[] | undefined, activeId: string | null | undefined) => void;
+  /** Ensure the main process has a WebContentsView for every tab. Idempotent. */
+  ensureViewsOpen: () => void;
+  /** Apply an event pushed from the main-process view manager. */
+  applyEvent: (event: BrowserEvent) => void;
+}
+
+function generateTabId(): string {
+  return `tab_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function toPersisted(tabs: BrowserTab[]): PersistedBrowserTab[] {
+  return tabs.map((t) => ({ id: t.id, url: t.url, title: t.title }));
+}
+
+function newTab(url: string): BrowserTab {
+  return {
+    id: generateTabId(),
+    url,
+    title: url,
+    isLoading: false,
+    canGoBack: false,
+    canGoForward: false,
+  };
+}
+
+export const useBrowserStore = create<BrowserState>((set, get) => ({
+  tabs: [],
+  activeTabId: null,
+
+  createTab: (urlOrQuery) => {
+    const url = urlOrQuery ? resolveAddressBarInput(urlOrQuery) : BROWSER_HOME_URL;
+    const tab = newTab(url);
+    set((s) => ({ tabs: [...s.tabs, tab], activeTabId: tab.id }));
+    void window.sero.browser.openTab(tab.id, url);
+    void window.sero.browser.setActive(tab.id);
+    persistLayout({
+      browserTabs: toPersisted(get().tabs),
+      activeBrowserTabId: tab.id,
+    });
+    return tab.id;
+  },
+
+  closeTab: (id) => {
+    const { tabs, activeTabId } = get();
+    const idx = tabs.findIndex((t) => t.id === id);
+    if (idx === -1) return;
+    const nextTabs = tabs.filter((t) => t.id !== id);
+    let nextActive = activeTabId;
+    if (activeTabId === id) {
+      // Prefer the neighbour to the right, fall back to the left.
+      const neighbour = nextTabs[idx] ?? nextTabs[idx - 1] ?? null;
+      nextActive = neighbour ? neighbour.id : null;
+    }
+    set({ tabs: nextTabs, activeTabId: nextActive });
+    void window.sero.browser.closeTab(id);
+    void window.sero.browser.setActive(nextActive);
+    persistLayout({
+      browserTabs: toPersisted(nextTabs),
+      activeBrowserTabId: nextActive,
+    });
+  },
+
+  setActive: (id) => {
+    if (get().activeTabId === id) return;
+    set({ activeTabId: id });
+    void window.sero.browser.setActive(id);
+    persistLayout({ activeBrowserTabId: id });
+  },
+
+  navigate: (id, urlOrQuery) => {
+    const url = resolveAddressBarInput(urlOrQuery);
+    set((s) => ({
+      tabs: s.tabs.map((t) => (t.id === id ? { ...t, url, isLoading: true } : t)),
+    }));
+    void window.sero.browser.navigate(id, url);
+    persistLayout({ browserTabs: toPersisted(get().tabs) });
+  },
+
+  goBack: (id) => {
+    void window.sero.browser.goBack(id);
+  },
+  goForward: (id) => {
+    void window.sero.browser.goForward(id);
+  },
+  reload: (id) => {
+    void window.sero.browser.reload(id);
+  },
+  stop: (id) => {
+    void window.sero.browser.stop(id);
+  },
+
+  hydrate: (tabs, activeId) => {
+    if (!tabs || tabs.length === 0) {
+      set({ tabs: [], activeTabId: null });
+      return;
+    }
+    const hydrated: BrowserTab[] = tabs.map((t) => ({
+      id: t.id,
+      url: t.url,
+      title: t.title ?? t.url,
+      isLoading: false,
+      canGoBack: false,
+      canGoForward: false,
+    }));
+    const active = activeId && hydrated.some((t) => t.id === activeId)
+      ? activeId
+      : hydrated[0]?.id ?? null;
+    set({ tabs: hydrated, activeTabId: active });
+  },
+
+  ensureViewsOpen: () => {
+    const { tabs, activeTabId } = get();
+    for (const tab of tabs) {
+      // openTab is idempotent — the manager navigates the existing view if
+      // the tab already has one.
+      void window.sero.browser.openTab(tab.id, tab.url);
+    }
+    void window.sero.browser.setActive(activeTabId);
+  },
+
+  applyEvent: (event) => {
+    set((s) => {
+      const tabs = s.tabs.map((t) => {
+        if (t.id !== event.tabId) return t;
+        switch (event.kind) {
+          case 'did-navigate':
+            return {
+              ...t,
+              url: event.url,
+              canGoBack: event.canGoBack,
+              canGoForward: event.canGoForward,
+            };
+          case 'did-start-loading':
+            return { ...t, isLoading: true };
+          case 'did-stop-loading':
+            return { ...t, isLoading: false };
+          case 'title-updated':
+            return { ...t, title: event.title || t.title };
+          case 'favicon-updated':
+            return { ...t, favicon: event.favicon };
+          case 'did-fail-load':
+            return { ...t, isLoading: false };
+          default:
+            return t;
+        }
+      });
+      return { tabs };
+    });
+
+    // new-tab-request originates from window.open in the WebContents; open
+    // a fresh tab with the requested URL.
+    if (event.kind === 'new-tab-request') {
+      get().createTab(event.url);
+      return;
+    }
+
+    // Persist navigation and title changes so a restart restores the
+    // current page, not whatever URL was first opened in the tab.
+    if (event.kind === 'did-navigate' || event.kind === 'title-updated') {
+      persistLayout({ browserTabs: toPersisted(get().tabs) });
+    }
+  },
+}));

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -114,6 +114,8 @@ interface BrowserState {
   goForward: (id: string) => void;
   reload: (id: string) => void;
   stop: (id: string) => void;
+  /** Extract the tab's page (title + plain text) and prefill the chat composer. */
+  sharePageWithChat: (id: string) => Promise<void>;
 
   addBookmark: (input: { title: string; url: string; favicon?: string }) => void;
   removeBookmark: (id: string) => void;
@@ -311,6 +313,23 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
   goForward: (id) => { void window.sero.browser.goForward(id); },
   reload: (id) => { void window.sero.browser.reload(id); },
   stop: (id) => { void window.sero.browser.stop(id); },
+
+  sharePageWithChat: async (id) => {
+    const result = await window.sero.browser.extractPage(id);
+    if (!result) {
+      console.warn('[browser] Page extraction returned nothing.');
+      return;
+    }
+    const { title, url, text } = result;
+    const heading = title.trim() ? `# ${title.trim()}\n\n` : '';
+    // Trim very long page captures — the composer prefill path overwrites
+    // the draft, and agent token budgets are finite. 12k chars ~= 3k tokens
+    // and is enough to carry most articles' salient content.
+    const MAX = 12000;
+    const body = text.length > MAX ? `${text.slice(0, MAX)}\n\n[…truncated…]` : text;
+    const attribution = `— ${url}`;
+    prefillChatComposer(`${heading}${body}\n\n${attribution}\n\n`);
+  },
 
   addBookmark: (input) => {
     const { bookmarks } = get();

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -11,9 +11,11 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { persistLayout } from '@/lib/persist-layout';
-import { useAgentStore } from '@/stores/agent';
-import { useAppStore } from '@/stores/app';
-import { useSessionStore } from '@/stores/sessions';
+import {
+  formatSelectionForChat,
+  formatSelectionForMemory,
+  prefillChatComposer,
+} from './browser-helpers';
 import {
   BROWSER_HOME_URL,
   resolveAddressBarInput,
@@ -33,61 +35,6 @@ interface ClosedTab {
 }
 
 const MAX_RECENTLY_CLOSED = 10;
-
-/**
- * Format a page selection as a markdown blockquote with an attribution
- * line. Two trailing newlines leave the cursor on a fresh line so the user
- * can start typing their question immediately.
- */
-function formatSelectionForChat(
-  selection: string,
-  pageUrl: string,
-  pageTitle: string,
-): string {
-  const trimmed = selection.replace(/\s+$/, '');
-  const quoted = trimmed.split('\n').map((line) => `> ${line}`).join('\n');
-  const title = pageTitle.trim();
-  const attribution = title ? `— ${title} — ${pageUrl}` : `— ${pageUrl}`;
-  return `${quoted}\n\n${attribution}\n\n`;
-}
-
-/** "Please save this to memory" template that nudges the agent to call the memory tool. */
-function formatSelectionForMemory(
-  selection: string,
-  pageUrl: string,
-  pageTitle: string,
-): string {
-  const trimmed = selection.replace(/\s+$/, '');
-  const quoted = trimmed.split('\n').map((line) => `> ${line}`).join('\n');
-  const title = pageTitle.trim();
-  const attribution = title ? `— ${title} — ${pageUrl}` : `— ${pageUrl}`;
-  return `Please save this to memory:\n\n${quoted}\n\n${attribution}\n\n`;
-}
-
-function resolveActiveSessionId(): string | null {
-  return (
-    useAgentStore.getState().focusedSessionId ??
-    useSessionStore.getState().activeSessionId ??
-    null
-  );
-}
-
-/** Drop formatted text into the focused (or active) chat session's composer. */
-function prefillChatComposer(text: string): void {
-  const sessionId = resolveActiveSessionId();
-  if (!sessionId) {
-    console.warn('[browser] No chat session available — selection ignored.');
-    return;
-  }
-  useAgentStore.getState().setComposerPrefill(sessionId, {
-    requestId: generateId('sel'),
-    text,
-    source: 'system',
-  });
-  if (!useAppStore.getState().chatPanelOpen) {
-    useAppStore.getState().setChatPanelOpen(true);
-  }
-}
 
 interface BrowserState {
   tabs: BrowserTab[];
@@ -461,6 +408,47 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
 
     if (event.kind === 'selection-to-memory') {
       prefillChatComposer(formatSelectionForMemory(event.selection, event.pageUrl, event.pageTitle));
+      return;
+    }
+
+    if (event.kind === 'host-tab-opened') {
+      // Mirror the host-created tab into the renderer store so it shows up
+      // in the tab strip. The view already exists in main; don't re-open it.
+      if (get().tabs.some((t) => t.id === event.tabId)) return;
+      const tab: BrowserTab = {
+        id: event.tabId,
+        workspaceId: event.workspaceId,
+        url: event.url,
+        title: event.url,
+        isLoading: true,
+        canGoBack: false,
+        canGoForward: false,
+      };
+      set((s) => ({
+        tabs: [...s.tabs, tab],
+        activeTabIds: { ...s.activeTabIds, [event.workspaceId]: event.tabId },
+      }));
+      persistLayout({
+        browserTabs: toPersistedTabs(get().tabs),
+        activeBrowserTabIds: get().activeTabIds,
+      });
+      return;
+    }
+
+    if (event.kind === 'host-tab-closed') {
+      if (!get().tabs.some((t) => t.id === event.tabId)) return;
+      const nextTabs = get().tabs.filter((t) => t.id !== event.tabId);
+      const ws = event.workspaceId;
+      const activeIds = { ...get().activeTabIds };
+      if (activeIds[ws] === event.tabId) {
+        const replacement = nextTabs.find((t) => t.workspaceId === ws) ?? null;
+        activeIds[ws] = replacement ? replacement.id : null;
+      }
+      set({ tabs: nextTabs, activeTabIds: activeIds });
+      persistLayout({
+        browserTabs: toPersistedTabs(nextTabs),
+        activeBrowserTabIds: activeIds,
+      });
       return;
     }
 

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -10,6 +10,9 @@
 
 import { create } from 'zustand';
 import { persistLayout } from '@/lib/persist-layout';
+import { useAgentStore } from '@/stores/agent';
+import { useAppStore } from '@/stores/app';
+import { useSessionStore } from '@/stores/sessions';
 import {
   BROWSER_HOME_URL,
   resolveAddressBarInput,
@@ -18,6 +21,48 @@ import {
   type BrowserTab,
 } from '@/types/browser';
 import type { PersistedBrowserBookmark, PersistedBrowserTab } from '@/types/layout';
+
+/**
+ * Format a page selection as a markdown blockquote with an attribution
+ * line, ready to be inserted into the chat composer. Two trailing newlines
+ * leave the cursor on a fresh line so the user can start typing their
+ * question immediately.
+ */
+function formatSelectionForChat(
+  selection: string,
+  pageUrl: string,
+  pageTitle: string,
+): string {
+  const trimmed = selection.replace(/\s+$/, '');
+  const quoted = trimmed.split('\n').map((line) => `> ${line}`).join('\n');
+  const title = pageTitle.trim();
+  const attribution = title ? `— ${title} — ${pageUrl}` : `— ${pageUrl}`;
+  return `${quoted}\n\n${attribution}\n\n`;
+}
+
+/** Drop a page selection into the focused (or active) chat session's composer. */
+function dropSelectionInChat(
+  selection: string,
+  pageUrl: string,
+  pageTitle: string,
+): void {
+  const sessionId =
+    useAgentStore.getState().focusedSessionId ??
+    useSessionStore.getState().activeSessionId;
+  if (!sessionId) {
+    console.warn('[browser] No chat session available — selection ignored.');
+    return;
+  }
+  useAgentStore.getState().setComposerPrefill(sessionId, {
+    requestId: generateId('sel'),
+    text: formatSelectionForChat(selection, pageUrl, pageTitle),
+    source: 'system',
+  });
+  // Make sure the panel is visible so the user can see the prefill.
+  if (!useAppStore.getState().chatPanelOpen) {
+    useAppStore.getState().setChatPanelOpen(true);
+  }
+}
 
 /** Snapshot of a tab the user just closed, kept in-memory for ⌘Shift+T. */
 interface ClosedTab {
@@ -308,6 +353,11 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     // a fresh tab with the requested URL.
     if (event.kind === 'new-tab-request') {
       get().createTab(event.url);
+      return;
+    }
+
+    if (event.kind === 'selection-to-chat') {
+      dropSelectionInChat(event.selection, event.pageUrl, event.pageTitle);
       return;
     }
 

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -451,6 +451,15 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
       return;
     }
 
+    if (event.kind === 'host-tab-activated') {
+      if (!get().tabs.some((t) => t.id === event.tabId && t.workspaceId === event.workspaceId)) return;
+      set((s) => ({
+        activeTabIds: { ...s.activeTabIds, [event.workspaceId]: event.tabId },
+      }));
+      persistLayout({ activeBrowserTabIds: get().activeTabIds });
+      return;
+    }
+
     if (event.kind === 'host-tab-closed') {
       if (!get().tabs.some((t) => t.id === event.tabId)) return;
       const nextTabs = get().tabs.filter((t) => t.id !== event.tabId);

--- a/apps/desktop/src/stores/composer-attachments.ts
+++ b/apps/desktop/src/stores/composer-attachments.ts
@@ -1,0 +1,37 @@
+/**
+ * Composer attachment queue — cross-component bridge for pushing files
+ * (screenshots, downloaded captures, drag-saved assets) into the chat
+ * composer from anywhere in the app.
+ *
+ * The composer's `<PromptInput>` owns its own attachment state internally.
+ * This store is a thin FIFO that a small bridge component inside
+ * `<PromptInput>` drains by calling `attachments.add(files)`; the files
+ * then flow through the normal submit path (becoming ChatAttachment[] on
+ * send).
+ */
+
+import { create } from 'zustand';
+
+interface ComposerAttachmentQueueState {
+  pending: File[];
+  /** Push a File into the queue. The composer bridge will pick it up. */
+  push: (file: File) => void;
+  /** Push multiple files at once. */
+  pushMany: (files: File[]) => void;
+  /** Pull all pending files and clear the queue. Called by the bridge. */
+  consume: () => File[];
+}
+
+export const useComposerAttachmentQueue = create<ComposerAttachmentQueueState>(
+  (set, get) => ({
+    pending: [],
+    push: (file) => set((s) => ({ pending: [...s.pending, file] })),
+    pushMany: (files) => set((s) => ({ pending: [...s.pending, ...files] })),
+    consume: () => {
+      const { pending } = get();
+      if (pending.length === 0) return [];
+      set({ pending: [] });
+      return pending;
+    },
+  }),
+);

--- a/apps/desktop/src/types/browser.ts
+++ b/apps/desktop/src/types/browser.ts
@@ -54,7 +54,11 @@ export type BrowserEvent =
   /** User picked "Add to Sero Chat" from the page's context menu. */
   | { tabId: string; workspaceId: string; kind: 'selection-to-chat'; selection: string; pageUrl: string; pageTitle: string }
   /** User picked "Save to Memory" from the page's context menu. */
-  | { tabId: string; workspaceId: string; kind: 'selection-to-memory'; selection: string; pageUrl: string; pageTitle: string };
+  | { tabId: string; workspaceId: string; kind: 'selection-to-memory'; selection: string; pageUrl: string; pageTitle: string }
+  /** A new tab was opened by the host (CLI bridge, agent). Renderer store should mirror it. */
+  | { tabId: string; workspaceId: string; kind: 'host-tab-opened'; url: string }
+  /** A tab was closed by the host. Renderer store should remove it. */
+  | { tabId: string; workspaceId: string; kind: 'host-tab-closed' };
 
 /** Default home page for a new empty tab. */
 export const BROWSER_HOME_URL = 'https://duckduckgo.com/';

--- a/apps/desktop/src/types/browser.ts
+++ b/apps/desktop/src/types/browser.ts
@@ -5,6 +5,8 @@
 
 export interface BrowserTab {
   id: string;
+  /** Workspace this tab belongs to. Cookies/sessions are isolated per workspace. */
+  workspaceId: string;
   url: string;
   /** Page title (defaults to URL until the page loads). */
   title: string;
@@ -35,21 +37,24 @@ export interface BrowserViewBounds {
  * Events emitted by the main-process view manager to the renderer so the
  * store can keep tab metadata in sync with what the WebContentsView reports.
  */
+/**
+ * Events pushed from the main-process view manager. Every event carries the
+ * owning `workspaceId` so the renderer can route it correctly even when the
+ * user has switched workspaces between emission and delivery.
+ */
 export type BrowserEvent =
-  | { tabId: string; kind: 'did-navigate'; url: string; canGoBack: boolean; canGoForward: boolean }
-  | { tabId: string; kind: 'did-start-loading' }
-  | { tabId: string; kind: 'did-stop-loading' }
-  | { tabId: string; kind: 'title-updated'; title: string }
-  | { tabId: string; kind: 'favicon-updated'; favicon: string | undefined }
-  | { tabId: string; kind: 'did-fail-load'; errorDescription: string }
+  | { tabId: string; workspaceId: string; kind: 'did-navigate'; url: string; canGoBack: boolean; canGoForward: boolean }
+  | { tabId: string; workspaceId: string; kind: 'did-start-loading' }
+  | { tabId: string; workspaceId: string; kind: 'did-stop-loading' }
+  | { tabId: string; workspaceId: string; kind: 'title-updated'; title: string }
+  | { tabId: string; workspaceId: string; kind: 'favicon-updated'; favicon: string | undefined }
+  | { tabId: string; workspaceId: string; kind: 'did-fail-load'; errorDescription: string }
   /** Renderer should open a new tab (triggered by window.open / target=_blank). */
-  | { tabId: string; kind: 'new-tab-request'; url: string }
-  /**
-   * User picked "Add to Sero Chat" from the page's context menu — the
-   * selection (and the page metadata) should be quoted into the chat
-   * composer of the focused session.
-   */
-  | { tabId: string; kind: 'selection-to-chat'; selection: string; pageUrl: string; pageTitle: string };
+  | { tabId: string; workspaceId: string; kind: 'new-tab-request'; url: string }
+  /** User picked "Add to Sero Chat" from the page's context menu. */
+  | { tabId: string; workspaceId: string; kind: 'selection-to-chat'; selection: string; pageUrl: string; pageTitle: string }
+  /** User picked "Save to Memory" from the page's context menu. */
+  | { tabId: string; workspaceId: string; kind: 'selection-to-memory'; selection: string; pageUrl: string; pageTitle: string };
 
 /** Default home page for a new empty tab. */
 export const BROWSER_HOME_URL = 'https://duckduckgo.com/';

--- a/apps/desktop/src/types/browser.ts
+++ b/apps/desktop/src/types/browser.ts
@@ -33,6 +33,19 @@ export interface BrowserViewBounds {
   height: number;
 }
 
+export type BrowserTabContextAction =
+  | 'bookmark'
+  | 'copy-url'
+  | 'close'
+  | 'close-others'
+  | 'close-all';
+
+export type BrowserBookmarkContextAction =
+  | 'open'
+  | 'open-new-tab'
+  | 'edit'
+  | 'delete';
+
 /**
  * Events emitted by the main-process view manager to the renderer so the
  * store can keep tab metadata in sync with what the WebContentsView reports.
@@ -58,7 +71,9 @@ export type BrowserEvent =
   /** A new tab was opened by the host (CLI bridge, agent). Renderer store should mirror it. */
   | { tabId: string; workspaceId: string; kind: 'host-tab-opened'; url: string }
   /** A tab was closed by the host. Renderer store should remove it. */
-  | { tabId: string; workspaceId: string; kind: 'host-tab-closed' };
+  | { tabId: string; workspaceId: string; kind: 'host-tab-closed' }
+  /** A tab was activated by the host/native WebContents shortcut. */
+  | { tabId: string; workspaceId: string; kind: 'host-tab-activated' };
 
 /** Default home page for a new empty tab. */
 export const BROWSER_HOME_URL = 'https://duckduckgo.com/';
@@ -74,7 +89,9 @@ export const BROWSER_HOME_URL = 'https://duckduckgo.com/';
 export function resolveAddressBarInput(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return BROWSER_HOME_URL;
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  // Unsupported schemes (file:, data:, chrome:, …) are treated as searches;
+  // the main process enforces the same http(s)-only policy before loadURL.
   // Looks like a bare host (has a dot, no spaces, no path-like characters)
   if (/^[^\s]+\.[^\s]+$/.test(trimmed) && !/\s/.test(trimmed)) {
     return `https://${trimmed}`;

--- a/apps/desktop/src/types/browser.ts
+++ b/apps/desktop/src/types/browser.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared browser types — used by the main process, preload bridge and
+ * renderer store. Kept renderer-safe (no Electron imports).
+ */
+
+export interface BrowserTab {
+  id: string;
+  url: string;
+  /** Page title (defaults to URL until the page loads). */
+  title: string;
+  /** Data-URI favicon if the page provides one. */
+  favicon?: string;
+  /** True while the tab's page is loading. */
+  isLoading: boolean;
+  /** Back/forward button availability, mirrored from WebContents. */
+  canGoBack: boolean;
+  canGoForward: boolean;
+}
+
+export interface BrowserViewBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Events emitted by the main-process view manager to the renderer so the
+ * store can keep tab metadata in sync with what the WebContentsView reports.
+ */
+export type BrowserEvent =
+  | { tabId: string; kind: 'did-navigate'; url: string; canGoBack: boolean; canGoForward: boolean }
+  | { tabId: string; kind: 'did-start-loading' }
+  | { tabId: string; kind: 'did-stop-loading' }
+  | { tabId: string; kind: 'title-updated'; title: string }
+  | { tabId: string; kind: 'favicon-updated'; favicon: string | undefined }
+  | { tabId: string; kind: 'did-fail-load'; errorDescription: string }
+  /** Renderer should open a new tab (triggered by window.open / target=_blank). */
+  | { tabId: string; kind: 'new-tab-request'; url: string };
+
+/** Default home page for a new empty tab. */
+export const BROWSER_HOME_URL = 'https://duckduckgo.com/';
+
+/**
+ * Turn a user-typed string into a URL.
+ *
+ * - Obvious URLs (contain `://` or a dot + no spaces) → used as-is.
+ * - Anything else → DuckDuckGo search query. DuckDuckGo was chosen over
+ *   Google because it serves a clean results page to headless/embedded
+ *   browsers without CAPTCHA walls, which matters for agent-driven flows.
+ */
+export function resolveAddressBarInput(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return BROWSER_HOME_URL;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed;
+  // Looks like a bare host (has a dot, no spaces, no path-like characters)
+  if (/^[^\s]+\.[^\s]+$/.test(trimmed) && !/\s/.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+  return `https://duckduckgo.com/?q=${encodeURIComponent(trimmed)}`;
+}

--- a/apps/desktop/src/types/browser.ts
+++ b/apps/desktop/src/types/browser.ts
@@ -43,7 +43,13 @@ export type BrowserEvent =
   | { tabId: string; kind: 'favicon-updated'; favicon: string | undefined }
   | { tabId: string; kind: 'did-fail-load'; errorDescription: string }
   /** Renderer should open a new tab (triggered by window.open / target=_blank). */
-  | { tabId: string; kind: 'new-tab-request'; url: string };
+  | { tabId: string; kind: 'new-tab-request'; url: string }
+  /**
+   * User picked "Add to Sero Chat" from the page's context menu — the
+   * selection (and the page metadata) should be quoted into the chat
+   * composer of the focused session.
+   */
+  | { tabId: string; kind: 'selection-to-chat'; selection: string; pageUrl: string; pageTitle: string };
 
 /** Default home page for a new empty tab. */
 export const BROWSER_HOME_URL = 'https://duckduckgo.com/';

--- a/apps/desktop/src/types/browser.ts
+++ b/apps/desktop/src/types/browser.ts
@@ -17,6 +17,13 @@ export interface BrowserTab {
   canGoForward: boolean;
 }
 
+export interface BrowserBookmark {
+  id: string;
+  title: string;
+  url: string;
+  favicon?: string;
+}
+
 export interface BrowserViewBounds {
   x: number;
   y: number;

--- a/apps/desktop/src/types/electron-browser.d.ts
+++ b/apps/desktop/src/types/electron-browser.d.ts
@@ -1,0 +1,31 @@
+import type {
+  BrowserBookmarkContextAction,
+  BrowserEvent,
+  BrowserTabContextAction,
+  BrowserViewBounds,
+} from './browser';
+
+export interface SeroBrowserAPI {
+  openTab(tabId: string, url: string, workspaceId: string): Promise<void>;
+  closeTab(tabId: string, workspaceId: string): Promise<void>;
+  setActive(tabId: string | null, workspaceId: string): Promise<void>;
+  setBounds(bounds: BrowserViewBounds): Promise<void>;
+  hideAll(): Promise<void>;
+  navigate(tabId: string, url: string, workspaceId: string): Promise<void>;
+  goBack(tabId: string, workspaceId: string): Promise<void>;
+  goForward(tabId: string, workspaceId: string): Promise<void>;
+  reload(tabId: string, workspaceId: string): Promise<void>;
+  stop(tabId: string, workspaceId: string): Promise<void>;
+  extractPage(
+    tabId: string,
+    workspaceId: string,
+  ): Promise<{ title: string; url: string; text: string } | null>;
+  capturePage(
+    tabId: string,
+    workspaceId: string,
+    rect?: { x: number; y: number; width: number; height: number },
+  ): Promise<string | null>;
+  showTabContextMenu(tabId: string, workspaceId: string): Promise<BrowserTabContextAction | null>;
+  showBookmarkContextMenu(): Promise<BrowserBookmarkContextAction | null>;
+  onEvent(callback: (event: BrowserEvent) => void): () => void;
+}

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -1,8 +1,6 @@
 /**
  * Types for the `window.sero` API exposed by the preload script.
  *
- * Workspace tool interfaces (editor, filetree, LSP, debug, VCS) are in
- * electron-workspace.d.ts to keep each file under 500 LOC.
  */
 import type {
   SeroEditorAPI,
@@ -12,7 +10,7 @@ import type {
   SeroVcsAPI,
 } from './electron-workspace';
 import type { LayoutState, LoadedLayoutState } from './layout';
-import type { BrowserEvent, BrowserViewBounds } from './browser';
+import type { SeroBrowserAPI } from './electron-browser';
 import type {
   SeroGatewayAPI,
   SeroGitHubAPI,
@@ -444,29 +442,6 @@ interface SeroPluginsAPI {
   stopDevSession(sessionId: string): Promise<void>;
   /** Subscribe to plugin install/dev-session lifecycle events. */
   onChanged(callback: (event: PluginChangeEvent) => void): () => void;
-}
-
-export interface SeroBrowserAPI {
-  openTab(tabId: string, url: string, workspaceId: string): Promise<void>;
-  closeTab(tabId: string, workspaceId: string): Promise<void>;
-  setActive(tabId: string | null, workspaceId: string): Promise<void>;
-  setBounds(bounds: BrowserViewBounds): Promise<void>;
-  hideAll(): Promise<void>;
-  navigate(tabId: string, url: string, workspaceId: string): Promise<void>;
-  goBack(tabId: string, workspaceId: string): Promise<void>;
-  goForward(tabId: string, workspaceId: string): Promise<void>;
-  reload(tabId: string, workspaceId: string): Promise<void>;
-  stop(tabId: string, workspaceId: string): Promise<void>;
-  extractPage(
-    tabId: string,
-    workspaceId: string,
-  ): Promise<{ title: string; url: string; text: string } | null>;
-  capturePage(
-    tabId: string,
-    workspaceId: string,
-    rect?: { x: number; y: number; width: number; height: number },
-  ): Promise<string | null>;
-  onEvent(callback: (event: BrowserEvent) => void): () => void;
 }
 
 export interface SeroAPI {

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -448,18 +448,22 @@ interface SeroPluginsAPI {
 
 export interface SeroBrowserAPI {
   openTab(tabId: string, url: string, workspaceId: string): Promise<void>;
-  closeTab(tabId: string): Promise<void>;
-  setActive(tabId: string | null): Promise<void>;
+  closeTab(tabId: string, workspaceId: string): Promise<void>;
+  setActive(tabId: string | null, workspaceId: string): Promise<void>;
   setBounds(bounds: BrowserViewBounds): Promise<void>;
   hideAll(): Promise<void>;
-  navigate(tabId: string, url: string): Promise<void>;
-  goBack(tabId: string): Promise<void>;
-  goForward(tabId: string): Promise<void>;
-  reload(tabId: string): Promise<void>;
-  stop(tabId: string): Promise<void>;
-  extractPage(tabId: string): Promise<{ title: string; url: string; text: string } | null>;
+  navigate(tabId: string, url: string, workspaceId: string): Promise<void>;
+  goBack(tabId: string, workspaceId: string): Promise<void>;
+  goForward(tabId: string, workspaceId: string): Promise<void>;
+  reload(tabId: string, workspaceId: string): Promise<void>;
+  stop(tabId: string, workspaceId: string): Promise<void>;
+  extractPage(
+    tabId: string,
+    workspaceId: string,
+  ): Promise<{ title: string; url: string; text: string } | null>;
   capturePage(
     tabId: string,
+    workspaceId: string,
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<string | null>;
   onEvent(callback: (event: BrowserEvent) => void): () => void;

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -12,6 +12,7 @@ import type {
   SeroVcsAPI,
 } from './electron-workspace';
 import type { LayoutState, LoadedLayoutState } from './layout';
+import type { BrowserEvent, BrowserViewBounds } from './browser';
 import type {
   SeroGatewayAPI,
   SeroGitHubAPI,
@@ -445,6 +446,20 @@ interface SeroPluginsAPI {
   onChanged(callback: (event: PluginChangeEvent) => void): () => void;
 }
 
+export interface SeroBrowserAPI {
+  openTab(tabId: string, url: string): Promise<void>;
+  closeTab(tabId: string): Promise<void>;
+  setActive(tabId: string | null): Promise<void>;
+  setBounds(bounds: BrowserViewBounds): Promise<void>;
+  hideAll(): Promise<void>;
+  navigate(tabId: string, url: string): Promise<void>;
+  goBack(tabId: string): Promise<void>;
+  goForward(tabId: string): Promise<void>;
+  reload(tabId: string): Promise<void>;
+  stop(tabId: string): Promise<void>;
+  onEvent(callback: (event: BrowserEvent) => void): () => void;
+}
+
 export interface SeroAPI {
   platform: string;
   shell: SeroShellAPI;
@@ -460,6 +475,7 @@ export interface SeroAPI {
   appAgent: SeroAppAgentAPI;
   gitApp: SeroGitAppAPI;
   webApp: SeroWebAppAPI;
+  browser: SeroBrowserAPI;
   voice: SeroVoiceAPI;
   auth: SeroAuthAPI;
   container: SeroContainerAPI;

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -457,6 +457,11 @@ export interface SeroBrowserAPI {
   goForward(tabId: string): Promise<void>;
   reload(tabId: string): Promise<void>;
   stop(tabId: string): Promise<void>;
+  extractPage(tabId: string): Promise<{ title: string; url: string; text: string } | null>;
+  capturePage(
+    tabId: string,
+    rect?: { x: number; y: number; width: number; height: number },
+  ): Promise<string | null>;
   onEvent(callback: (event: BrowserEvent) => void): () => void;
 }
 

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -447,7 +447,7 @@ interface SeroPluginsAPI {
 }
 
 export interface SeroBrowserAPI {
-  openTab(tabId: string, url: string): Promise<void>;
+  openTab(tabId: string, url: string, workspaceId: string): Promise<void>;
   closeTab(tabId: string): Promise<void>;
   setActive(tabId: string | null): Promise<void>;
   setBounds(bounds: BrowserViewBounds): Promise<void>;

--- a/apps/desktop/src/types/ipc-channels-browser.ts
+++ b/apps/desktop/src/types/ipc-channels-browser.ts
@@ -1,0 +1,30 @@
+/** IPC channel constants for the in-app browser. */
+export const browserIpcChannels = {
+  /** Create a WebContentsView for a tab id and load a URL. */
+  openTab: 'sero:browser:open-tab',
+  /** Destroy the WebContentsView for a tab id. */
+  closeTab: 'sero:browser:close-tab',
+  /** Show a tab's view on top; hide all others. */
+  setActive: 'sero:browser:set-active',
+  /** Position the active view within the main window, or hide all. */
+  setBounds: 'sero:browser:set-bounds',
+  /** Hide all browser views (panel no longer visible). */
+  hideAll: 'sero:browser:hide-all',
+  /** Navigate the given tab to a URL. */
+  navigate: 'sero:browser:navigate',
+  /** History controls. */
+  goBack: 'sero:browser:go-back',
+  goForward: 'sero:browser:go-forward',
+  reload: 'sero:browser:reload',
+  stop: 'sero:browser:stop',
+  /** Extract the active page's title + plain text for "Share with chat". */
+  extractPage: 'sero:browser:extract-page',
+  /** Capture the tab as a PNG (optionally cropped). Returns base64 PNG. */
+  capturePage: 'sero:browser:capture-page',
+  /** Native tab-strip context menu. Returns selected action or null. */
+  showTabContextMenu: 'sero:browser:show-tab-context-menu',
+  /** Native bookmarks-bar context menu. Returns selected action or null. */
+  showBookmarkContextMenu: 'sero:browser:show-bookmark-context-menu',
+  /** Main → renderer push: navigation / load / title / favicon events. */
+  event: 'sero:browser:event',
+} as const;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -6,6 +6,7 @@
  */
 
 import { appAgentIpcChannels } from './ipc-channels-app-agent';
+import { browserIpcChannels } from './ipc-channels-browser';
 import { localModelsIpcChannels } from './ipc-channels-local-models';
 import {
   feedbackIpcChannels,
@@ -233,31 +234,7 @@ export const IpcChannels = {
     /** Load UI layout state. */
     load: 'sero:layout:load',
   },
-  browser: {
-    /** Create a WebContentsView for a tab id and load a URL. */
-    openTab: 'sero:browser:open-tab',
-    /** Destroy the WebContentsView for a tab id. */
-    closeTab: 'sero:browser:close-tab',
-    /** Show a tab's view on top; hide all others. */
-    setActive: 'sero:browser:set-active',
-    /** Position the active view within the main window, or hide all. */
-    setBounds: 'sero:browser:set-bounds',
-    /** Hide all browser views (panel no longer visible). */
-    hideAll: 'sero:browser:hide-all',
-    /** Navigate the given tab to a URL. */
-    navigate: 'sero:browser:navigate',
-    /** History controls. */
-    goBack: 'sero:browser:go-back',
-    goForward: 'sero:browser:go-forward',
-    reload: 'sero:browser:reload',
-    stop: 'sero:browser:stop',
-    /** Extract the active page's title + plain text for "Share with chat". */
-    extractPage: 'sero:browser:extract-page',
-    /** Capture the tab as a PNG (optionally cropped). Returns base64 PNG. */
-    capturePage: 'sero:browser:capture-page',
-    /** Main → renderer push: navigation / load / title / favicon events. */
-    event: 'sero:browser:event',
-  },
+  browser: browserIpcChannels,
   themes: {
     /** List all available theme presets (built-in + custom). */
     list: 'sero:themes:list',

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -233,6 +233,27 @@ export const IpcChannels = {
     /** Load UI layout state. */
     load: 'sero:layout:load',
   },
+  browser: {
+    /** Create a WebContentsView for a tab id and load a URL. */
+    openTab: 'sero:browser:open-tab',
+    /** Destroy the WebContentsView for a tab id. */
+    closeTab: 'sero:browser:close-tab',
+    /** Show a tab's view on top; hide all others. */
+    setActive: 'sero:browser:set-active',
+    /** Position the active view within the main window, or hide all. */
+    setBounds: 'sero:browser:set-bounds',
+    /** Hide all browser views (panel no longer visible). */
+    hideAll: 'sero:browser:hide-all',
+    /** Navigate the given tab to a URL. */
+    navigate: 'sero:browser:navigate',
+    /** History controls. */
+    goBack: 'sero:browser:go-back',
+    goForward: 'sero:browser:go-forward',
+    reload: 'sero:browser:reload',
+    stop: 'sero:browser:stop',
+    /** Main → renderer push: navigation / load / title / favicon events. */
+    event: 'sero:browser:event',
+  },
   themes: {
     /** List all available theme presets (built-in + custom). */
     list: 'sero:themes:list',

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -251,6 +251,10 @@ export const IpcChannels = {
     goForward: 'sero:browser:go-forward',
     reload: 'sero:browser:reload',
     stop: 'sero:browser:stop',
+    /** Extract the active page's title + plain text for "Share with chat". */
+    extractPage: 'sero:browser:extract-page',
+    /** Capture the tab as a PNG (optionally cropped). Returns base64 PNG. */
+    capturePage: 'sero:browser:capture-page',
     /** Main → renderer push: navigation / load / title / favicon events. */
     event: 'sero:browser:event',
   },

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -7,7 +7,7 @@
  */
 
 import type { DashboardLayoutState } from './dashboard';
-import type { BrowserTab } from './browser';
+import type { BrowserBookmark, BrowserTab } from './browser';
 
 /** Subset of a BrowserTab that is safe to persist across restarts. */
 export interface PersistedBrowserTab {
@@ -15,6 +15,9 @@ export interface PersistedBrowserTab {
   url: string;
   title?: string;
 }
+
+/** Bookmarks persist whole (favicons are optional and small). */
+export type PersistedBrowserBookmark = BrowserBookmark;
 
 /** Full layout state persisted to ~/.sero-ui/layout.json. */
 export interface LayoutState {
@@ -47,11 +50,13 @@ export interface LayoutState {
   browserTabs?: PersistedBrowserTab[];
   /** Active browser tab id. */
   activeBrowserTabId?: string | null;
+  /** User-saved bookmarks. */
+  browserBookmarks?: PersistedBrowserBookmark[];
 }
 
 // Re-export so callers can import the canonical runtime tab shape
 // alongside the persisted shape.
-export type { BrowserTab };
+export type { BrowserBookmark, BrowserTab };
 
 /**
  * Shape returned by layout.load() — same fields but favouriteApps

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -12,6 +12,8 @@ import type { BrowserBookmark, BrowserTab } from './browser';
 /** Subset of a BrowserTab that is safe to persist across restarts. */
 export interface PersistedBrowserTab {
   id: string;
+  /** Workspace the tab belongs to. Omitted = pre-multi-workspace tabs; hydration defaults to 'global'. */
+  workspaceId?: string;
   url: string;
   title?: string;
 }
@@ -48,7 +50,9 @@ export interface LayoutState {
   dashboardLayout?: DashboardLayoutState;
   /** Open browser tabs (restored on app start). */
   browserTabs?: PersistedBrowserTab[];
-  /** Active browser tab id. */
+  /** Active browser tab id per workspace. */
+  activeBrowserTabIds?: Record<string, string | null>;
+  /** Legacy: single active browser tab id (pre-per-workspace). */
   activeBrowserTabId?: string | null;
   /** User-saved bookmarks. */
   browserBookmarks?: PersistedBrowserBookmark[];

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -7,6 +7,14 @@
  */
 
 import type { DashboardLayoutState } from './dashboard';
+import type { BrowserTab } from './browser';
+
+/** Subset of a BrowserTab that is safe to persist across restarts. */
+export interface PersistedBrowserTab {
+  id: string;
+  url: string;
+  title?: string;
+}
 
 /** Full layout state persisted to ~/.sero-ui/layout.json. */
 export interface LayoutState {
@@ -35,7 +43,15 @@ export interface LayoutState {
   hiddenProviders?: string[];
   /** Dashboard widget grid layout. */
   dashboardLayout?: DashboardLayoutState;
+  /** Open browser tabs (restored on app start). */
+  browserTabs?: PersistedBrowserTab[];
+  /** Active browser tab id. */
+  activeBrowserTabId?: string | null;
 }
+
+// Re-export so callers can import the canonical runtime tab shape
+// alongside the persisted shape.
+export type { BrowserTab };
 
 /**
  * Shape returned by layout.load() — same fields but favouriteApps


### PR DESCRIPTION
Adds a real web browser panel alongside the editor in the Explorer
workspace. Each tab is backed by a main-process WebContentsView that is
stacked as a child of the main window and positioned over a placeholder
div the BrowserPanel reports bounds for. Plugins can't host webviews, so
this lives in the shell.

- ActivityBar: new Browser icon (between Orchestration and Terminal).
- ⌘N while the Explorer app is active opens a new browser tab.
- Address bar accepts URLs or queries (DuckDuckGo is the default engine
  because it serves clean HTML to embedded/agent browsers without
  CAPTCHA walls).
- Tabs survive app restart via ~/.sero-ui/layout.json; WebContentsViews
  are created lazily when the Browser panel is first opened.
- target=_blank / window.open opens a new in-app tab (not an external
  browser) and file:// navigations are blocked. UA is stripped of the
  "Electron/<ver>" token to match existing session policy.