### PR TITLE
fix(editor): respect light UI mode in Monaco and add theme picker

### DIFF
--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -24,6 +24,8 @@ import {
 } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { useAppStore } from '@/stores/app';
+import { useThemeStore } from '@/stores/theme';
+import { resolveMonacoThemeName } from './monaco-themes';
 import type { FileDiffEntry } from '@sero-ai/common';
 import { statusCode, statusColor, basename, langFromPath } from '@/components/apps/explorer/vcs/vcs-utils';
 
@@ -41,7 +43,9 @@ interface Props {
 
 export function DiffTab({ state }: Props) {
   const { workspaceId, fromRev, toRev, initialPath } = state;
-  const theme = useAppStore((s) => s.theme);
+  const effectiveMode = useThemeStore((s) => s.effectiveMode);
+  const editorThemeId = useAppStore((s) => s.editorThemeId);
+  const monacoThemeName = resolveMonacoThemeName(editorThemeId, effectiveMode);
 
   const [files, setFiles] = useState<FileDiffEntry[]>([]);
   const [activePath, setActivePath] = useState<string | null>(initialPath ?? null);
@@ -152,7 +156,7 @@ export function DiffTab({ state }: Props) {
               toRev={toRev}
               path={activePath}
               language={language}
-              theme={theme === 'dark' ? 'vs-dark' : 'vs'}
+              theme={monacoThemeName}
               sideBySide={sideBySide}
             />
           ) : (

--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -25,7 +25,7 @@ import {
 import { cn } from '@sero-ai/ui/lib/utils';
 import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
-import { resolveMonacoThemeName } from './monaco-themes';
+import { registerCustomEditorThemes, resolveMonacoThemeName } from './monaco-themes';
 import type { FileDiffEntry } from '@sero-ai/common';
 import { statusCode, statusColor, basename, langFromPath } from '@/components/apps/explorer/vcs/vcs-utils';
 
@@ -243,6 +243,7 @@ function DiffFileView({
       modified={right}
       language={language}
       theme={theme}
+      beforeMount={registerCustomEditorThemes}
       onMount={handleDiffMount}
       keepCurrentOriginalModel
       keepCurrentModifiedModel

--- a/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
@@ -14,6 +14,8 @@ import { DevServerPreview, isDevServerTab } from './DevServerPreview';
 import { FilePreviewPane } from './FilePreviewPane';
 import { getFilePreviewSpec } from './file-preview-registry';
 import { ViewModeToggle } from './ViewModeToggle';
+import { EditorThemePicker } from './EditorThemePicker';
+import { resolveMonacoThemeName } from './monaco-themes';
 import {
   type EditorPanelProps,
 } from './editor-panel-shared';
@@ -23,6 +25,7 @@ import { useEditorRuntimeSync } from './useEditorRuntimeSync';
 import { useMonacoNavigation } from './useMonacoNavigation';
 import { useLsp } from '@/lsp/use-lsp';
 import { useAppStore } from '@/stores/app';
+import { useThemeStore } from '@/stores/theme';
 
 function EmptyEditorState() {
   return (
@@ -106,7 +109,9 @@ export function EditorPanel({
     setDirtyPaths: documentState.setDirtyPaths,
   });
 
-  const appTheme = useAppStore((state) => state.theme);
+  const effectiveMode = useThemeStore((state) => state.effectiveMode);
+  const editorThemeId = useAppStore((state) => state.editorThemeId);
+  const monacoThemeName = resolveMonacoThemeName(editorThemeId, effectiveMode);
   const previewSpec = activeTab ? getFilePreviewSpec(activeTab) : null;
   const isDevServer = !!activeTab && isDevServerTab(activeTab);
   const supportsCodeView = !!previewSpec?.supportsCodeView;
@@ -133,12 +138,15 @@ export function EditorPanel({
         onCloseAllTabs={documentState.handleCloseAllTabs}
         onReorderTabs={onReorderTabs}
         rightSlot={
-          supportsCodeView ? (
-            <ViewModeToggle
-              viewMode={documentState.viewMode}
-              onModeChange={documentState.handleViewModeChange}
-            />
-          ) : undefined
+          <div className="flex h-full items-center">
+            {supportsCodeView ? (
+              <ViewModeToggle
+                viewMode={documentState.viewMode}
+                onModeChange={documentState.handleViewModeChange}
+              />
+            ) : null}
+            <EditorThemePicker />
+          </div>
         }
       />
       {statusNotice ? (
@@ -166,7 +174,7 @@ export function EditorPanel({
               onChange={documentState.handleChange}
               beforeMount={monacoState.handleBeforeMount}
               onMount={monacoState.handleEditorMount}
-              theme={appTheme === 'dark' ? 'vs-dark' : 'vs'}
+              theme={monacoThemeName}
               options={{
                 fontSize: 13,
                 fontFamily: "'SF Mono', 'Fira Code', 'JetBrains Mono', monospace",

--- a/apps/desktop/src/components/apps/explorer/editor/EditorThemePicker.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorThemePicker.tsx
@@ -1,0 +1,138 @@
+/**
+ * EditorThemePicker — popover dropdown that lets the user pick a Monaco
+ * color scheme. The choice is persisted via the app store.
+ */
+
+import { useMemo, useState } from 'react';
+import { Palette, Check } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui/components/ui/popover';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@sero-ai/ui/components/ui/tooltip';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { useAppStore } from '@/stores/app';
+import {
+  AUTO_EDITOR_THEME_ID,
+  EDITOR_THEMES,
+  getEditorTheme,
+  type EditorThemeEntry,
+} from './monaco-themes';
+
+export function EditorThemePicker() {
+  const editorThemeId = useAppStore((s) => s.editorThemeId);
+  const setEditorThemeId = useAppStore((s) => s.setEditorThemeId);
+  const [open, setOpen] = useState(false);
+
+  const groups = useMemo(() => {
+    const dark: EditorThemeEntry[] = [];
+    const light: EditorThemeEntry[] = [];
+    for (const entry of EDITOR_THEMES) {
+      (entry.kind === 'dark' ? dark : light).push(entry);
+    }
+    return { dark, light };
+  }, []);
+
+  const activeLabel = editorThemeId === AUTO_EDITOR_THEME_ID
+    ? 'Auto'
+    : getEditorTheme(editorThemeId)?.label ?? 'Auto';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Editor color theme"
+              className={cn(
+                'inline-flex size-7 items-center justify-center transition-colors duration-150',
+                open
+                  ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+                  : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)]/80 hover:text-[var(--text-secondary)]',
+              )}
+            >
+              <Palette className="size-3.5" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Editor theme — {activeLabel}</TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        align="end"
+        className="w-56 p-1"
+        sideOffset={4}
+      >
+        <ThemeOption
+          id={AUTO_EDITOR_THEME_ID}
+          label="Auto (follow UI)"
+          active={editorThemeId === AUTO_EDITOR_THEME_ID}
+          onSelect={() => {
+            setEditorThemeId(AUTO_EDITOR_THEME_ID);
+            setOpen(false);
+          }}
+        />
+        <GroupHeader label="Dark" />
+        {groups.dark.map((entry) => (
+          <ThemeOption
+            key={entry.id}
+            id={entry.id}
+            label={entry.label}
+            active={editorThemeId === entry.id}
+            onSelect={() => {
+              setEditorThemeId(entry.id);
+              setOpen(false);
+            }}
+          />
+        ))}
+        <GroupHeader label="Light" />
+        {groups.light.map((entry) => (
+          <ThemeOption
+            key={entry.id}
+            id={entry.id}
+            label={entry.label}
+            active={editorThemeId === entry.id}
+            onSelect={() => {
+              setEditorThemeId(entry.id);
+              setOpen(false);
+            }}
+          />
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function GroupHeader({ label }: { label: string }) {
+  return (
+    <div className="px-2 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+      {label}
+    </div>
+  );
+}
+
+function ThemeOption({
+  id,
+  label,
+  active,
+  onSelect,
+}: {
+  id: string;
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      data-theme-id={id}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 rounded-sm px-2 py-1 text-left text-xs transition-colors',
+        active
+          ? 'bg-[var(--bg-elevated)] text-[var(--text-primary)]'
+          : 'text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]/60 hover:text-[var(--text-primary)]',
+      )}
+    >
+      <span className="truncate">{label}</span>
+      {active ? <Check className="size-3 shrink-0 text-[var(--status-success)]" /> : null}
+    </button>
+  );
+}

--- a/apps/desktop/src/components/apps/explorer/editor/EditorThemePicker.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorThemePicker.tsx
@@ -62,7 +62,7 @@ export function EditorThemePicker() {
       >
         <ThemeOption
           id={AUTO_EDITOR_THEME_ID}
-          label="Auto (follow UI)"
+          label="Auto (system)"
           active={editorThemeId === AUTO_EDITOR_THEME_ID}
           onSelect={() => {
             setEditorThemeId(AUTO_EDITOR_THEME_ID);

--- a/apps/desktop/src/components/apps/explorer/editor/FilePreviewPane.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/FilePreviewPane.tsx
@@ -5,7 +5,7 @@
  * Markdown preview intentionally continues to use Streamdown.
  */
 
-import { useEffect, useRef, useState, type SyntheticEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react';
 import {
   AlertCircle,
   FileText,
@@ -15,10 +15,13 @@ import {
   Video,
 } from 'lucide-react';
 import { Streamdown } from 'streamdown';
-import { code } from '@streamdown/code';
+import { createCodePlugin } from '@streamdown/code';
 import { math } from '@streamdown/math';
 import { mermaid } from '@streamdown/mermaid';
 import { HtmlPreview } from './HtmlPreview';
+import { resolveEditorThemePalette, resolveMarkdownCodeThemes } from './monaco-themes';
+import { useAppStore } from '@/stores/app';
+import { useThemeStore } from '@/stores/theme';
 import type {
   BinaryPreviewKind,
   BinaryPreviewSpec,
@@ -203,17 +206,38 @@ function BinaryFilePreview({ workspaceId, filePath, spec }: BinaryFilePreviewPro
 }
 
 export function FilePreviewPane({ workspaceId, filePath, content, spec }: Props) {
+  const editorThemeId = useAppStore((state) => state.editorThemeId);
+  const effectiveMode = useThemeStore((state) => state.effectiveMode);
+  const markdownPalette = useMemo(
+    () => resolveEditorThemePalette(editorThemeId, effectiveMode),
+    [editorThemeId, effectiveMode],
+  );
+  const markdownPlugins = useMemo(
+    () => ({
+      code: createCodePlugin({ themes: resolveMarkdownCodeThemes(editorThemeId) }),
+      math,
+      mermaid,
+    }),
+    [editorThemeId],
+  );
+
   if (spec.source === 'text') {
     if (spec.kind === 'html') {
       return <HtmlPreview content={content} filePath={filePath} />;
     }
 
     return (
-      <div className="h-full overflow-auto">
+      <div
+        className="h-full overflow-auto"
+        style={{
+          backgroundColor: markdownPalette.background,
+          color: markdownPalette.foreground,
+        }}
+      >
         <div className="mx-auto w-full max-w-[920px] px-6 py-5">
           <Streamdown
             mode="static"
-            plugins={{ code, math, mermaid }}
+            plugins={markdownPlugins}
           >
             {content}
           </Streamdown>

--- a/apps/desktop/src/components/apps/explorer/editor/monaco-themes.ts
+++ b/apps/desktop/src/components/apps/explorer/editor/monaco-themes.ts
@@ -1,0 +1,314 @@
+/**
+ * Monaco editor theme catalog.
+ *
+ * Defines a curated list of editor color schemes available to the user.
+ * Built-in themes ('vs', 'vs-dark', 'hc-light', 'hc-black') are referenced
+ * by id only — Monaco ships them. Custom themes carry an `IStandaloneThemeData`
+ * payload that we register on first mount via `monaco.editor.defineTheme()`.
+ *
+ * The 'auto' entry is a virtual theme that resolves to 'vs' or 'vs-dark'
+ * depending on the app's effective light/dark mode.
+ */
+
+import type * as monacoApi from 'monaco-editor';
+
+export type EditorThemeKind = 'light' | 'dark';
+
+export interface EditorThemeEntry {
+  /** Stable identifier persisted to layout state. */
+  id: string;
+  /** Display label shown in the theme picker. */
+  label: string;
+  /** Whether the theme is light or dark (used to group them). */
+  kind: EditorThemeKind;
+  /** Monaco theme name passed to `<Editor theme={...}>`. */
+  monacoName: string;
+  /** Custom theme definition. Omit for built-in themes (vs, vs-dark, etc.). */
+  data?: monacoApi.editor.IStandaloneThemeData;
+}
+
+export const AUTO_EDITOR_THEME_ID = 'auto';
+export const DEFAULT_EDITOR_THEME_ID = AUTO_EDITOR_THEME_ID;
+
+/** Built-in monaco themes — no `defineTheme` call needed. */
+const BUILTIN_THEMES: EditorThemeEntry[] = [
+  { id: 'vs', label: 'Visual Studio Light', kind: 'light', monacoName: 'vs' },
+  { id: 'vs-dark', label: 'Visual Studio Dark', kind: 'dark', monacoName: 'vs-dark' },
+  { id: 'hc-light', label: 'High Contrast Light', kind: 'light', monacoName: 'hc-light' },
+  { id: 'hc-black', label: 'High Contrast Dark', kind: 'dark', monacoName: 'hc-black' },
+];
+
+/** Custom themes — registered via `defineTheme` on first mount. */
+const CUSTOM_THEMES: EditorThemeEntry[] = [
+  {
+    id: 'one-dark',
+    label: 'One Dark',
+    kind: 'dark',
+    monacoName: 'sero-one-dark',
+    data: {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '5c6370', fontStyle: 'italic' },
+        { token: 'keyword', foreground: 'c678dd' },
+        { token: 'string', foreground: '98c379' },
+        { token: 'number', foreground: 'd19a66' },
+        { token: 'type', foreground: 'e5c07b' },
+        { token: 'function', foreground: '61afef' },
+        { token: 'variable', foreground: 'e06c75' },
+        { token: 'constant', foreground: 'd19a66' },
+      ],
+      colors: {
+        'editor.background': '#282c34',
+        'editor.foreground': '#abb2bf',
+        'editor.lineHighlightBackground': '#2c313c',
+        'editorLineNumber.foreground': '#4b5263',
+        'editorLineNumber.activeForeground': '#abb2bf',
+        'editor.selectionBackground': '#3e4451',
+        'editorCursor.foreground': '#528bff',
+        'editorIndentGuide.background1': '#3b4048',
+      },
+    },
+  },
+  {
+    id: 'github-light',
+    label: 'GitHub Light',
+    kind: 'light',
+    monacoName: 'sero-github-light',
+    data: {
+      base: 'vs',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '6a737d', fontStyle: 'italic' },
+        { token: 'keyword', foreground: 'd73a49' },
+        { token: 'string', foreground: '032f62' },
+        { token: 'number', foreground: '005cc5' },
+        { token: 'type', foreground: '6f42c1' },
+        { token: 'function', foreground: '6f42c1' },
+        { token: 'variable', foreground: '24292e' },
+        { token: 'constant', foreground: '005cc5' },
+      ],
+      colors: {
+        'editor.background': '#ffffff',
+        'editor.foreground': '#24292e',
+        'editor.lineHighlightBackground': '#f6f8fa',
+        'editorLineNumber.foreground': '#959da5',
+        'editorLineNumber.activeForeground': '#24292e',
+        'editor.selectionBackground': '#0366d625',
+        'editorCursor.foreground': '#044289',
+      },
+    },
+  },
+  {
+    id: 'github-dark',
+    label: 'GitHub Dark',
+    kind: 'dark',
+    monacoName: 'sero-github-dark',
+    data: {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '8b949e', fontStyle: 'italic' },
+        { token: 'keyword', foreground: 'ff7b72' },
+        { token: 'string', foreground: 'a5d6ff' },
+        { token: 'number', foreground: '79c0ff' },
+        { token: 'type', foreground: 'ffa657' },
+        { token: 'function', foreground: 'd2a8ff' },
+        { token: 'variable', foreground: 'ffa657' },
+        { token: 'constant', foreground: '79c0ff' },
+      ],
+      colors: {
+        'editor.background': '#0d1117',
+        'editor.foreground': '#c9d1d9',
+        'editor.lineHighlightBackground': '#161b22',
+        'editorLineNumber.foreground': '#484f58',
+        'editorLineNumber.activeForeground': '#c9d1d9',
+        'editor.selectionBackground': '#3392ff44',
+        'editorCursor.foreground': '#58a6ff',
+      },
+    },
+  },
+  {
+    id: 'dracula',
+    label: 'Dracula',
+    kind: 'dark',
+    monacoName: 'sero-dracula',
+    data: {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '6272a4', fontStyle: 'italic' },
+        { token: 'keyword', foreground: 'ff79c6' },
+        { token: 'string', foreground: 'f1fa8c' },
+        { token: 'number', foreground: 'bd93f9' },
+        { token: 'type', foreground: '8be9fd', fontStyle: 'italic' },
+        { token: 'function', foreground: '50fa7b' },
+        { token: 'variable', foreground: 'f8f8f2' },
+        { token: 'constant', foreground: 'bd93f9' },
+      ],
+      colors: {
+        'editor.background': '#282a36',
+        'editor.foreground': '#f8f8f2',
+        'editor.lineHighlightBackground': '#44475a55',
+        'editorLineNumber.foreground': '#6272a4',
+        'editorLineNumber.activeForeground': '#f8f8f2',
+        'editor.selectionBackground': '#44475a',
+        'editorCursor.foreground': '#f8f8f0',
+      },
+    },
+  },
+  {
+    id: 'monokai',
+    label: 'Monokai',
+    kind: 'dark',
+    monacoName: 'sero-monokai',
+    data: {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '75715e', fontStyle: 'italic' },
+        { token: 'keyword', foreground: 'f92672' },
+        { token: 'string', foreground: 'e6db74' },
+        { token: 'number', foreground: 'ae81ff' },
+        { token: 'type', foreground: '66d9ef', fontStyle: 'italic' },
+        { token: 'function', foreground: 'a6e22e' },
+        { token: 'variable', foreground: 'f8f8f2' },
+        { token: 'constant', foreground: 'ae81ff' },
+      ],
+      colors: {
+        'editor.background': '#272822',
+        'editor.foreground': '#f8f8f2',
+        'editor.lineHighlightBackground': '#3e3d32',
+        'editorLineNumber.foreground': '#90908a',
+        'editorLineNumber.activeForeground': '#f8f8f2',
+        'editor.selectionBackground': '#49483e',
+        'editorCursor.foreground': '#f8f8f0',
+      },
+    },
+  },
+  {
+    id: 'solarized-light',
+    label: 'Solarized Light',
+    kind: 'light',
+    monacoName: 'sero-solarized-light',
+    data: {
+      base: 'vs',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '93a1a1', fontStyle: 'italic' },
+        { token: 'keyword', foreground: '859900' },
+        { token: 'string', foreground: '2aa198' },
+        { token: 'number', foreground: 'd33682' },
+        { token: 'type', foreground: 'b58900' },
+        { token: 'function', foreground: '268bd2' },
+        { token: 'variable', foreground: '586e75' },
+        { token: 'constant', foreground: 'cb4b16' },
+      ],
+      colors: {
+        'editor.background': '#fdf6e3',
+        'editor.foreground': '#586e75',
+        'editor.lineHighlightBackground': '#eee8d5',
+        'editorLineNumber.foreground': '#93a1a1',
+        'editorLineNumber.activeForeground': '#586e75',
+        'editor.selectionBackground': '#eee8d5',
+        'editorCursor.foreground': '#586e75',
+      },
+    },
+  },
+  {
+    id: 'solarized-dark',
+    label: 'Solarized Dark',
+    kind: 'dark',
+    monacoName: 'sero-solarized-dark',
+    data: {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '586e75', fontStyle: 'italic' },
+        { token: 'keyword', foreground: '859900' },
+        { token: 'string', foreground: '2aa198' },
+        { token: 'number', foreground: 'd33682' },
+        { token: 'type', foreground: 'b58900' },
+        { token: 'function', foreground: '268bd2' },
+        { token: 'variable', foreground: '93a1a1' },
+        { token: 'constant', foreground: 'cb4b16' },
+      ],
+      colors: {
+        'editor.background': '#002b36',
+        'editor.foreground': '#93a1a1',
+        'editor.lineHighlightBackground': '#073642',
+        'editorLineNumber.foreground': '#586e75',
+        'editorLineNumber.activeForeground': '#93a1a1',
+        'editor.selectionBackground': '#073642',
+        'editorCursor.foreground': '#93a1a1',
+      },
+    },
+  },
+  {
+    id: 'nord',
+    label: 'Nord',
+    kind: 'dark',
+    monacoName: 'sero-nord',
+    data: {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [
+        { token: 'comment', foreground: '616e88', fontStyle: 'italic' },
+        { token: 'keyword', foreground: '81a1c1' },
+        { token: 'string', foreground: 'a3be8c' },
+        { token: 'number', foreground: 'b48ead' },
+        { token: 'type', foreground: '8fbcbb' },
+        { token: 'function', foreground: '88c0d0' },
+        { token: 'variable', foreground: 'd8dee9' },
+        { token: 'constant', foreground: '5e81ac' },
+      ],
+      colors: {
+        'editor.background': '#2e3440',
+        'editor.foreground': '#d8dee9',
+        'editor.lineHighlightBackground': '#3b4252',
+        'editorLineNumber.foreground': '#4c566a',
+        'editorLineNumber.activeForeground': '#d8dee9',
+        'editor.selectionBackground': '#434c5e',
+        'editorCursor.foreground': '#d8dee9',
+      },
+    },
+  },
+];
+
+/** All themes (built-in + custom), in display order. */
+export const EDITOR_THEMES: EditorThemeEntry[] = [...BUILTIN_THEMES, ...CUSTOM_THEMES];
+
+const THEME_BY_ID = new Map(EDITOR_THEMES.map((entry) => [entry.id, entry]));
+
+export function getEditorTheme(id: string): EditorThemeEntry | undefined {
+  return THEME_BY_ID.get(id);
+}
+
+/**
+ * Resolve a theme id to the monaco theme name to apply.
+ *
+ * 'auto' (and any unknown id) maps to 'vs-dark' or 'vs' depending on the
+ * effective UI mode.
+ */
+export function resolveMonacoThemeName(
+  id: string,
+  effectiveMode: 'light' | 'dark',
+): string {
+  if (id === AUTO_EDITOR_THEME_ID) {
+    return effectiveMode === 'dark' ? 'vs-dark' : 'vs';
+  }
+  const entry = THEME_BY_ID.get(id);
+  if (!entry) return effectiveMode === 'dark' ? 'vs-dark' : 'vs';
+  return entry.monacoName;
+}
+
+/**
+ * Register all custom themes with Monaco. Safe to call multiple times —
+ * `defineTheme` is idempotent.
+ */
+export function registerCustomEditorThemes(monaco: typeof monacoApi): void {
+  for (const entry of CUSTOM_THEMES) {
+    if (!entry.data) continue;
+    monaco.editor.defineTheme(entry.monacoName, entry.data);
+  }
+}

--- a/apps/desktop/src/components/apps/explorer/editor/monaco-themes.ts
+++ b/apps/desktop/src/components/apps/explorer/editor/monaco-themes.ts
@@ -11,6 +11,7 @@
  */
 
 import type * as monacoApi from 'monaco-editor';
+import type { ThemeInput } from '@streamdown/code';
 
 export type EditorThemeKind = 'light' | 'dark';
 
@@ -25,6 +26,11 @@ export interface EditorThemeEntry {
   monacoName: string;
   /** Custom theme definition. Omit for built-in themes (vs, vs-dark, etc.). */
   data?: monacoApi.editor.IStandaloneThemeData;
+}
+
+export interface EditorThemePalette {
+  background: string;
+  foreground: string;
 }
 
 export const AUTO_EDITOR_THEME_ID = 'auto';
@@ -300,6 +306,70 @@ export function resolveMonacoThemeName(
   const entry = THEME_BY_ID.get(id);
   if (!entry) return effectiveMode === 'dark' ? 'vs-dark' : 'vs';
   return entry.monacoName;
+}
+
+function getBuiltInPalette(id: string): EditorThemePalette | null {
+  switch (id) {
+    case 'vs':
+      return { background: '#ffffff', foreground: '#000000' };
+    case 'vs-dark':
+      return { background: '#1e1e1e', foreground: '#d4d4d4' };
+    case 'hc-light':
+      return { background: '#ffffff', foreground: '#000000' };
+    case 'hc-black':
+      return { background: '#000000', foreground: '#ffffff' };
+    default:
+      return null;
+  }
+}
+
+export function resolveEditorThemePalette(
+  id: string,
+  effectiveMode: 'light' | 'dark',
+): EditorThemePalette {
+  const resolvedId = id === AUTO_EDITOR_THEME_ID
+    ? effectiveMode === 'dark' ? 'vs-dark' : 'vs'
+    : id;
+  const builtIn = getBuiltInPalette(resolvedId);
+  if (builtIn) return builtIn;
+
+  const colors = THEME_BY_ID.get(resolvedId)?.data?.colors;
+  return {
+    background: colors?.['editor.background'] ?? (effectiveMode === 'dark' ? '#1e1e1e' : '#ffffff'),
+    foreground: colors?.['editor.foreground'] ?? (effectiveMode === 'dark' ? '#d4d4d4' : '#000000'),
+  };
+}
+
+export function resolveMarkdownCodeThemes(id: string): [ThemeInput, ThemeInput] {
+  switch (id) {
+    case 'vs':
+      return ['light-plus', 'light-plus'];
+    case 'vs-dark':
+      return ['dark-plus', 'dark-plus'];
+    case 'hc-light':
+      return ['github-light-high-contrast', 'github-light-high-contrast'];
+    case 'hc-black':
+      return ['github-dark-high-contrast', 'github-dark-high-contrast'];
+    case 'one-dark':
+      return ['one-dark-pro', 'one-dark-pro'];
+    case 'github-light':
+      return ['github-light', 'github-light'];
+    case 'github-dark':
+      return ['github-dark', 'github-dark'];
+    case 'dracula':
+      return ['dracula', 'dracula'];
+    case 'monokai':
+      return ['monokai', 'monokai'];
+    case 'solarized-light':
+      return ['solarized-light', 'solarized-light'];
+    case 'solarized-dark':
+      return ['solarized-dark', 'solarized-dark'];
+    case 'nord':
+      return ['nord', 'nord'];
+    case AUTO_EDITOR_THEME_ID:
+    default:
+      return ['github-light', 'github-dark'];
+  }
 }
 
 /**

--- a/apps/desktop/src/components/apps/explorer/editor/useEditorMonacoState.ts
+++ b/apps/desktop/src/components/apps/explorer/editor/useEditorMonacoState.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from 'react';
 import * as monacoApi from 'monaco-editor';
 import type { editor as MonacoEditor } from 'monaco-editor';
 import { applyGoto, type PendingGoto } from './editor-panel-shared';
+import { registerCustomEditorThemes } from './monaco-themes';
 
 export function useEditorMonacoState() {
   const editorRef = useRef<MonacoEditor.IStandaloneCodeEditor | null>(null);
@@ -60,6 +61,7 @@ export function useEditorMonacoState() {
       noSemanticValidation: true,
       noSyntaxValidation: true,
     });
+    registerCustomEditorThemes(monaco);
   }, []);
 
   const handleEditorMount = useCallback(

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -42,6 +42,7 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
       partial.chatCollaborationSizePct ?? app.chatCollaborationSizePct,
     theme: partial.theme ?? app.theme,
     activeThemeId: partial.activeThemeId ?? useThemeStore.getState().activePresetId,
+    editorThemeId: partial.editorThemeId ?? app.editorThemeId,
     activeWorkspaceId: partial.activeWorkspaceId !== undefined
       ? partial.activeWorkspaceId
       : ws.activeWorkspaceId,

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -71,8 +71,11 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
 
 /** Flush layout state to disk (un-debounced). */
 function flushLayout(partial: Partial<LayoutState>): void {
+  const seroLayout = globalThis.window?.sero?.layout;
+  if (!seroLayout) return;
+
   const state = buildLayoutState(partial);
-  window.sero.layout.save(state).catch((err) => {
+  seroLayout.save(state).catch((err) => {
     console.warn('[persist-layout] Failed to persist layout:', err);
   });
 }

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -38,6 +38,10 @@ export async function loadLayout(): Promise<void> {
       const effective = useThemeStore.getState().effectiveMode;
       update.theme = effective;
 
+      if (typeof state.editorThemeId === 'string' && state.editorThemeId.length > 0) {
+        update.editorThemeId = state.editorThemeId;
+      }
+
       // Hydrate active app
       if (state.activeApp && typeof state.activeApp === 'string') {
         update.activeApp = state.activeApp;

--- a/apps/desktop/src/stores/app/state.ts
+++ b/apps/desktop/src/stores/app/state.ts
@@ -62,6 +62,10 @@ export interface AppState {
   theme: Theme;
   setTheme: (theme: Theme) => void;
   toggleTheme: () => void;
+
+  // Monaco editor theme (separate from UI theme)
+  editorThemeId: string;
+  setEditorThemeId: (id: string) => void;
 }
 
 function preloadAndActivateApp(
@@ -228,5 +232,12 @@ export const useAppStore = create<AppState>((set, get) => ({
     useThemeStore.getState().toggleMode();
     const effective = useThemeStore.getState().effectiveMode;
     set({ theme: effective });
+  },
+
+  // Monaco editor theme — defaults to 'auto' which follows the UI mode.
+  editorThemeId: 'auto',
+  setEditorThemeId: (id) => {
+    set({ editorThemeId: id });
+    persistLayout({ editorThemeId: id });
   },
 }));

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -34,6 +34,8 @@ export interface LayoutState {
   theme?: string;
   /** Active theme preset ID. */
   activeThemeId?: string;
+  /** Selected Monaco editor theme ID (defaults to 'auto' which follows the UI mode). */
+  editorThemeId?: string;
   /** Last active workspace ID. */
   activeWorkspaceId?: string | null;
   /** Last active app tab. */


### PR DESCRIPTION
The Monaco editor was reading useAppStore.theme which only updates when setTheme/toggleTheme are called via the app store. The ModeToggle and StatusBar call useThemeStore.setMode() directly, so app.theme was stale and the editor stayed dark even in light mode.

Switch the editor (and DiffTab) to read effectiveMode from the theme store directly, and add a curated palette of editor themes (One Dark, GitHub Light/Dark, Dracula, Monokai, Solarized, Nord, plus the four built-ins) selectable via a popover in the tab bar. The choice is persisted to layout state and defaults to 'auto' (follow UI mode).

## Summary

- what changed
- why it changed

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm build` (if relevant)
- [ ] `pnpm --filter @sero/desktop test -- --run` (if relevant)
- [ ] `pnpm --filter @sero/desktop test:e2e` (if relevant)
- [ ] docs updated (if relevant)

## Safety checklist

- [ ] no secrets, tokens, credentials, or machine-specific private paths committed
- [ ] no unnecessary `any`, `@ts-ignore`, or `@ts-expect-error`
- [ ] touched source files remain under 500 LOC

## Screenshots / recordings

<!-- Add before/after UI evidence for visible changes. -->

## Risk / rollout notes

- breaking changes:
- security or privacy impact:
- follow-up work:
