### PR TITLE
feat(container): default to public sero-node image

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -3,8 +3,6 @@ name: Container Image
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*.*.*'
     paths:
       - 'apps/desktop/images/Dockerfile.sero-node'
       - '.github/workflows/container-image.yml'
@@ -38,8 +36,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository_owner }}/sero-node
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
+            type=raw,value=latest
             type=sha,prefix=sha-
 
       - name: Build and push image

--- a/apps/desktop/electron/__tests__/features/container/lifecycle.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/lifecycle.test.ts
@@ -41,7 +41,7 @@ describe('createFreshContainer', () => {
     const execFn = vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 }));
     const inspectState: ContainerState = {
       id: 'sero-ws-1',
-      image: 'sero-node:latest',
+      image: 'ghcr.io/sero-labs/sero-node:latest',
       state: 'running',
       ipAddress: '192.168.64.2',
       cpus: 2,

--- a/apps/desktop/electron/features/container/core/image.ts
+++ b/apps/desktop/electron/features/container/core/image.ts
@@ -1,5 +1,6 @@
 /**
- * Container image management — check if sero-node image exists, build if not.
+ * Container image management — check if the public sero-node image exists,
+ * pull it when missing, and fall back to a local Dockerfile build in dev.
  */
 
 import { execFile } from 'child_process';
@@ -11,6 +12,16 @@ import { CONTAINER_BIN, DEFAULT_IMAGE } from './types';
 
 const execFileAsync = promisify(execFile);
 
+function imageNameParts(imageName: string): { name: string; tag: string } {
+  const lastSlash = imageName.lastIndexOf('/');
+  const tagSeparator = imageName.indexOf(':', lastSlash + 1);
+  if (tagSeparator === -1) return { name: imageName, tag: 'latest' };
+  return {
+    name: imageName.slice(0, tagSeparator),
+    tag: imageName.slice(tagSeparator + 1),
+  };
+}
+
 /**
  * Check if the sero-node image is available locally.
  */
@@ -19,11 +30,29 @@ async function imageExists(imageName = DEFAULT_IMAGE): Promise<boolean> {
     const { stdout } = await execFileAsync(CONTAINER_BIN, ['image', 'list'], {
       timeout: 10_000,
     });
-    // Image name is "sero-node" and tag is "latest" — check for "sero-node" in the list
-    const name = imageName.split(':')[0];
-    return stdout.includes(name);
+    const expected = imageNameParts(imageName);
+    return stdout
+      .split('\n')
+      .slice(1)
+      .some((line) => {
+        const [name, tag] = line.trim().split(/\s+/);
+        return name === expected.name && tag === expected.tag;
+      });
   } catch {
     return false;
+  }
+}
+
+async function pullImage(imageName = DEFAULT_IMAGE): Promise<void> {
+  console.log(`[container] Pulling image ${imageName}...`);
+  try {
+    await execFileAsync(CONTAINER_BIN, ['image', 'pull', imageName], {
+      timeout: 300_000,
+    });
+    console.log(`[container] Image ${imageName} pulled successfully`);
+  } catch (err: unknown) {
+    const e = err as Record<string, unknown>;
+    throw new Error(`Failed to pull image ${imageName}: ${e.stderr || (err instanceof Error ? err.message : String(err))}`);
   }
 }
 
@@ -64,15 +93,23 @@ async function buildImage(
 }
 
 /**
- * Ensure the sero-node image is available. Builds it if missing.
+ * Ensure the sero-node image is available. Pulls the public image first and
+ * falls back to a local Dockerfile build for offline development checkouts.
  *
  * @param imagesDir - Directory containing Dockerfile.sero-node
  */
 export async function ensureImage(imagesDir: string): Promise<void> {
   const exists = await imageExists();
   if (exists) {
-    console.log('[container] sero-node:latest image already available');
+    console.log(`[container] ${DEFAULT_IMAGE} image already available`);
     return;
+  }
+
+  try {
+    await pullImage();
+    return;
+  } catch (err) {
+    console.warn(`[container] Public image pull failed; falling back to local build: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   const dockerfilePath = path.join(imagesDir, 'Dockerfile.sero-node');

--- a/apps/desktop/electron/features/container/core/types.ts
+++ b/apps/desktop/electron/features/container/core/types.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import os from 'os';
 
 export const CONTAINER_BIN = '/usr/local/bin/container';
-export const DEFAULT_IMAGE = 'sero-node:latest';
+export const DEFAULT_IMAGE = 'ghcr.io/sero-labs/sero-node:latest';
 export const DEFAULT_CPUS = 2;
 export const DEFAULT_MEMORY_MB = 1024;
 export const WORKSPACE_MOUNT = '/workspace';

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "test:e2e:headed": "npm run build && npx playwright test --project=local --headed",
     "container:nat": "sudo ./scripts/setup-container-nat.sh",
     "container:nat:teardown": "sudo ./scripts/setup-container-nat.sh --teardown",
-    "container:build-image": "cd images && container build -t sero-node:latest -f Dockerfile.sero-node .",
+    "container:build-image": "cd images && container build -t ghcr.io/sero-labs/sero-node:latest -f Dockerfile.sero-node .",
     "sign-vmp": "bash scripts/sign-vmp.sh",
     "release": "bash scripts/build-release.sh",
     "release:signed": "bash scripts/build-release.sh --sign",

--- a/docs/guides/macos-containers.md
+++ b/docs/guides/macos-containers.md
@@ -48,13 +48,13 @@ Verify it reports `running` before retrying container-backed workflows in Sero.
 
 ## Verify Sero's image
 
-Sero expects the workspace image:
+Sero defaults to the public workspace image:
 
 ```text
-sero-node:latest
+ghcr.io/sero-labs/sero-node:latest
 ```
 
-For local development, build it with:
+Sero pulls this image automatically when it is missing locally. For local development, build the same tag with:
 
 ```bash
 cd apps/desktop
@@ -64,9 +64,9 @@ pnpm container:build-image
 Public releases publish the same Dockerfile to GitHub Container Registry as:
 
 ```text
-ghcr.io/<owner>/sero-node:latest
-ghcr.io/<owner>/sero-node:<version>
-ghcr.io/<owner>/sero-node:sha-<git-sha>
+ghcr.io/sero-labs/sero-node:latest
+ghcr.io/sero-labs/sero-node:<version>
+ghcr.io/sero-labs/sero-node:sha-<git-sha>
 ```
 
 If you changed `apps/desktop/images/Dockerfile.sero-node` or container-installed tools, rebuild the image and recreate affected workspace containers.
@@ -97,7 +97,7 @@ Fix:
 
 Fix:
 - recreate the affected workspace container after fixing the runtime
-- if you changed the base image, rebuild `sero-node:latest` first
+- if you changed the base image, rebuild `ghcr.io/sero-labs/sero-node:latest` first
 
 ## What still works in host mode
 


### PR DESCRIPTION
## Summary
- default Sero containers to ghcr.io/sero-labs/sero-node:latest
- pull the public image when it is missing locally
- retain local Dockerfile build fallback for development/offline cases
- update local build script, test expectation, and container docs

## Validation
- pnpm --filter @sero/desktop typecheck
- verified ghcr.io/sero-labs/sero-node appears in container image list