### PR TITLE
fix(desktop): skip source app watchers in packaged builds

### DIFF
--- a/apps/desktop/electron/__tests__/features/apps/app-discovery-dev-sessions.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-discovery-dev-sessions.test.ts
@@ -210,7 +210,7 @@ describe('app discovery local plugin dev sessions', () => {
         id: 'fallback-dev-plugin',
         packagePath: packageDir,
         component: 'FallbackDevPluginApp',
-        uiEntry: expect.stringContaining('/dist/ui/remoteEntry.js'),
+        uiEntry: expect.stringContaining(path.join('dist', 'ui', 'remoteEntry.js')),
         devPort: undefined,
         remoteEntryOverride: null,
       });

--- a/apps/desktop/electron/ipc/apps/apps.ts
+++ b/apps/desktop/electron/ipc/apps/apps.ts
@@ -53,28 +53,47 @@ export function registerAppsHandlers(): void {
  * @param knownAppIds Set of app IDs discovered at startup
  */
 export function watchForNewApps(knownAppIds: Set<string>): void {
+  if (process.env.NODE_ENV !== 'development') {
+    console.log('[app-watcher] Skipping source app package watchers outside development');
+    return;
+  }
+
   const notified = new Set<string>();
+  let watcherCount = 0;
 
   for (const root of APP_ROOTS) {
     const rootDir = root.dir;
-    if (!rootDir || !existsSync(rootDir)) continue;
+    if (!rootDir || !isWatchableRootDir(rootDir)) continue;
 
     let debounce: ReturnType<typeof setTimeout> | null = null;
 
-    watch(rootDir, { recursive: true }, (_eventType, filename) => {
-      if (!filename || !filename.includes('package.json')) return;
+    try {
+      watch(rootDir, { recursive: true }, (_eventType, filename) => {
+        if (!filename || !filename.includes('package.json')) return;
 
-      const [topLevelDir] = filename.split(path.sep);
-      if (!topLevelDir || !root.matchesDirName(topLevelDir)) return;
+        const [topLevelDir] = filename.split(path.sep);
+        if (!topLevelDir || !root.matchesDirName(topLevelDir)) return;
 
-      if (debounce) clearTimeout(debounce);
-      debounce = setTimeout(() => {
-        void checkForNewApps(rootDir, root.matchesDirName, knownAppIds, notified);
-      }, 2000);
-    });
+        if (debounce) clearTimeout(debounce);
+        debounce = setTimeout(() => {
+          void checkForNewApps(rootDir, root.matchesDirName, knownAppIds, notified);
+        }, 2000);
+      });
+      watcherCount += 1;
+    } catch (err) {
+      console.warn('[app-watcher] Skipping app package watcher:', rootDir, err);
+    }
   }
 
-  console.log('[app-watcher] Watching for new app packages');
+  if (watcherCount > 0) {
+    console.log('[app-watcher] Watching for new app packages');
+  } else {
+    console.log('[app-watcher] No watchable app package roots found');
+  }
+}
+
+function isWatchableRootDir(rootDir: string): boolean {
+  return existsSync(rootDir) && !rootDir.split(/[\\/]/).includes('app.asar');
 }
 
 async function checkForNewApps(

--- a/apps/desktop/scripts/build-release.sh
+++ b/apps/desktop/scripts/build-release.sh
@@ -234,10 +234,11 @@ cd "$MONO_ROOT"
 pnpm typecheck
 cd "$PROJECT_DIR"
 
-# ── Step 3: Build all packages (turbo) ───────────────────────
-echo "▸ Step 3/6: Building all packages..."
+# ── Step 3: Build desktop + bundled app packages ────────────
+echo "▸ Step 3/6: Building bundled app packages..."
 cd "$MONO_ROOT"
-pnpm build
+pnpm --filter "./packages/*" --filter "./plugins/*" --if-present build
+pnpm --filter @sero/desktop build
 cd "$PROJECT_DIR"
 
 # ── Step 4: Build web-remote SPA (if it exists) ─────────────

--- a/plugins/sero-cron-plugin/extension/__tests__/state-io.test.ts
+++ b/plugins/sero-cron-plugin/extension/__tests__/state-io.test.ts
@@ -26,7 +26,7 @@ describe('resolveStatePath', () => {
   it('resolves to SERO_HOME when set', () => {
     process.env.SERO_HOME = '/home/test/.sero-ui';
     const result = resolveStatePath('/any/cwd');
-    expect(result).toBe('/home/test/.sero-ui/apps/cron/state.json');
+    expect(result).toBe(path.join('/home/test/.sero-ui', 'apps', 'cron', 'state.json'));
   });
 
   it('resolves relative to cwd when SERO_HOME not set', () => {

--- a/plugins/sero-cron-plugin/extension/state-io.ts
+++ b/plugins/sero-cron-plugin/extension/state-io.ts
@@ -33,6 +33,8 @@ export function withStateLock<T>(fn: () => Promise<T>): Promise<T> {
 
 // ── Read / Write ───────────────────────────────────────────────
 
+const writeQueues = new Map<string, Promise<void>>();
+
 function isMissingFileError(error: unknown): boolean {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
@@ -67,9 +69,29 @@ export async function readState(filePath: string): Promise<CronState> {
 }
 
 export async function writeState(filePath: string, state: CronState): Promise<void> {
-  const dir = path.dirname(filePath);
-  await fs.mkdir(dir, { recursive: true });
-  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}.${randomUUID()}`;
-  await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+  await enqueueFileWrite(filePath, async () => {
+    const dir = path.dirname(filePath);
+    await fs.mkdir(dir, { recursive: true });
+    const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}.${randomUUID()}`;
+    await fs.writeFile(tmpPath, JSON.stringify(state, null, 2), 'utf8');
+    await replaceFile(tmpPath, filePath);
+  });
+}
+
+async function enqueueFileWrite(filePath: string, write: () => Promise<void>): Promise<void> {
+  const previous = writeQueues.get(filePath) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(write);
+  writeQueues.set(filePath, next);
+  try {
+    await next;
+  } finally {
+    if (writeQueues.get(filePath) === next) writeQueues.delete(filePath);
+  }
+}
+
+async function replaceFile(tmpPath: string, filePath: string): Promise<void> {
+  if (process.platform === 'win32') {
+    await fs.rm(filePath, { force: true });
+  }
   await fs.rename(tmpPath, filePath);
 }

--- a/plugins/sero-cron-plugin/extension/state-io.ts
+++ b/plugins/sero-cron-plugin/extension/state-io.ts
@@ -89,9 +89,23 @@ async function enqueueFileWrite(filePath: string, write: () => Promise<void>): P
   }
 }
 
+// Codes Windows raises when a virus scanner or search indexer briefly holds the
+// destination open. They are transient, so retrying the rename clears them.
+const RENAME_RETRY_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
+
 async function replaceFile(tmpPath: string, filePath: string): Promise<void> {
-  if (process.platform === 'win32') {
-    await fs.rm(filePath, { force: true });
+  // fs.rename replaces the destination atomically on every platform, so retry
+  // transient Windows lock errors rather than deleting the destination first —
+  // a delete-then-rename would briefly expose a missing file to concurrent
+  // readers, who would fall back to empty state.
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await fs.rename(tmpPath, filePath);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (attempt >= 9 || !code || !RENAME_RETRY_CODES.has(code)) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 10 * (attempt + 1)));
+    }
   }
-  await fs.rename(tmpPath, filePath);
 }

--- a/plugins/sero-cron-plugin/package.json
+++ b/plugins/sero-cron-plugin/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "vitest run",
-    "test:watch": "vitest",
+    "test": "pnpm exec vitest run",
+    "test:watch": "pnpm exec vitest",
     "typecheck": "tsc --noEmit -p ui/tsconfig.json"
   },
   "pi": {

--- a/plugins/sero-mcp-plugin/extension/__tests__/paths.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/paths.test.ts
@@ -36,7 +36,7 @@ describe('MCP path helpers', () => {
     process.env.PI_CODING_AGENT_DIR = '/tmp/pi-agent';
 
     expect(getMcpAppDir()).toBe(path.join('/tmp/pi-agent', 'mcp'));
-    expect(getMcpStatePath('/workspace/project')).toBe(path.join('/workspace/project', '.sero', 'apps', 'mcp', 'state.json'));
+    expect(getMcpStatePath('/workspace/project')).toBe(path.join(path.resolve('/workspace/project'), '.sero', 'apps', 'mcp', 'state.json'));
     expect(getMcpConfigPath()).toBe(path.join('/tmp/pi-agent', 'mcp.json'));
     expect(getMcpMetadataCachePath()).toBe(path.join('/tmp/pi-agent', 'mcp-cache.json'));
     expect(getMcpOAuthDir()).toBe(path.join('/tmp/pi-agent', 'mcp-oauth'));

--- a/plugins/sero-memory-plugin/extension/__tests__/agent-dir.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/agent-dir.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { resolveAgentDir, resolveSessionStoreDir } from '../agent-dir';
@@ -19,18 +20,20 @@ describe('profile-scoped agent directory resolution', () => {
     process.env.PI_CODING_AGENT_DIR = '/tmp/sero-profile/agent';
     process.env.SERO_HOME = '/tmp/sero-profile';
 
-    expect(resolveAgentDir()).toBe('/tmp/sero-profile/agent');
-    expect(resolveQmdDbPath()).toBe('/tmp/sero-profile/agent/cache/qmd/index.sqlite');
-    expect(resolveSessionStoreDir()).toBe('/tmp/sero-profile/agent/sessions');
-    expect(getSessionStoreDir()).toBe('/tmp/sero-profile/agent/sessions');
+    const agentDir = '/tmp/sero-profile/agent';
+    expect(resolveAgentDir()).toBe(agentDir);
+    expect(resolveQmdDbPath()).toBe(path.join(agentDir, 'cache', 'qmd', 'index.sqlite'));
+    expect(resolveSessionStoreDir()).toBe(path.join(agentDir, 'sessions'));
+    expect(getSessionStoreDir()).toBe(path.join(agentDir, 'sessions'));
   });
 
   it('falls back to SERO_HOME/agent when the Pi env bridge is absent', () => {
     delete process.env.PI_CODING_AGENT_DIR;
     process.env.SERO_HOME = '/tmp/sero-fallback-home';
 
-    expect(resolveAgentDir()).toBe('/tmp/sero-fallback-home/agent');
-    expect(resolveQmdDbPath()).toBe('/tmp/sero-fallback-home/agent/cache/qmd/index.sqlite');
-    expect(resolveSessionStoreDir()).toBe('/tmp/sero-fallback-home/agent/sessions');
+    const agentDir = path.join('/tmp/sero-fallback-home', 'agent');
+    expect(resolveAgentDir()).toBe(agentDir);
+    expect(resolveQmdDbPath()).toBe(path.join(agentDir, 'cache', 'qmd', 'index.sqlite'));
+    expect(resolveSessionStoreDir()).toBe(path.join(agentDir, 'sessions'));
   });
 });

--- a/plugins/sero-memory-plugin/package.json
+++ b/plugins/sero-memory-plugin/package.json
@@ -6,8 +6,8 @@
     "pi-package"
   ],
   "scripts": {
-    "test": "../../node_modules/.pnpm/node_modules/.bin/vitest run",
-    "test:watch": "../../node_modules/.pnpm/node_modules/.bin/vitest",
+    "test": "pnpm exec vitest run",
+    "test:watch": "pnpm exec vitest",
     "typecheck": "tsc --noEmit -p extension/tsconfig.json"
   },
   "pi": {


### PR DESCRIPTION
## Summary
- skip source app package watchers outside development so packaged Windows builds do not fail before showing the UI
- build bundled packages/plugins before staging desktop release resources
- fix Windows-safe test/runtime issues uncovered while running the full suite

## Validation
- `pnpm typecheck` ?
- `pnpm test` attempted; remaining failures are unrelated Windows-specific Docker/plugin-dev/git test expectations, while targeted fixes passed
- patched installed Windows build locally and confirmed the Sero UI opens

## Notes
The skipped watcher is only for source-tree package discovery. Local plugin development sessions still use their separate watcher on the selected plugin checkout.