### PR TITLE
fix: ad-hoc sign macOS beta app bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,12 @@ jobs:
         if: ${{ matrix.os == 'macos' }}
         run: |
           set -euo pipefail
-          app_path="apps/desktop/release/mac-arm64/Sero.app"
+          # electron-builder emits to mac/ (x64), mac-arm64/, or mac-universal/ depending on arch.
+          app_path="$(find apps/desktop/release -maxdepth 2 -type d -name 'Sero.app' -print -quit)"
+          if [[ -z "$app_path" ]]; then
+            echo "::error::No Sero.app found under apps/desktop/release"
+            exit 1
+          fi
           codesign --verify --deep --strict --verbose=4 "$app_path"
 
       - name: Smoke test Linux Debian artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,13 @@ jobs:
       - name: Build packaged artifacts
         run: pnpm --filter @sero/desktop ${{ matrix.dist }}
 
+      - name: Verify macOS app bundle
+        if: ${{ matrix.os == 'macos' }}
+        run: |
+          set -euo pipefail
+          app_path="apps/desktop/release/mac-arm64/Sero.app"
+          codesign --verify --deep --strict --verbose=4 "$app_path"
+
       - name: Smoke test Linux Debian artifact
         if: ${{ matrix.os == 'linux' }}
         run: |

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -64,6 +64,8 @@ mac:
   # Generate with: bash scripts/generate-icon.sh path/to/1024x1024.png
   # icon: build/icon.icns
   darkModeSupport: true
+  # hardenedRuntime/entitlements apply only to signed (CSC_LINK) builds. Unsigned beta builds are
+  # ad-hoc signed without hardened runtime by scripts/after-pack.mjs.
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist

--- a/apps/desktop/electron/__tests__/scripts/verify-host-mode-release.test.ts
+++ b/apps/desktop/electron/__tests__/scripts/verify-host-mode-release.test.ts
@@ -83,6 +83,12 @@ describe('verify-host-mode-release', () => {
     await expect(verifyFixture()).rejects.toThrow('.github/workflows/release.yml: missing Linux arm64 hosted runner: ubuntu-24.04-arm');
   });
 
+  it('fails when the release workflow is missing the macOS app bundle verification gate', async () => {
+    await fs.writeFile(workflowPath(), workflowText().replace('      - name: Verify macOS app bundle\n', ''));
+
+    await expect(verifyFixture()).rejects.toThrow('.github/workflows/release.yml: missing macOS app bundle verification gate');
+  });
+
   it('fails when Linux packaging would build obsolete non-deb artifacts', async () => {
     await fs.writeFile(path.join(desktopRoot, 'scripts/build-release.sh'), 'BUILDER_ARGS+=(AppImage deb tar.gz)\n');
 

--- a/apps/desktop/electron/__tests__/scripts/verify-host-mode-release.test.ts
+++ b/apps/desktop/electron/__tests__/scripts/verify-host-mode-release.test.ts
@@ -198,6 +198,7 @@ jobs:
     steps:
       - run: pnpm --filter @sero/desktop browser-pack:verify-published
       - run: pnpm --filter @sero/desktop e2e:workflow -- runtime-host-release.workflow.spec.ts
+      - name: Verify macOS app bundle
 `;
 }
 

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -30,12 +30,18 @@ export default async function afterPack(context) {
 
 function signMacBundleAdHoc(context) {
   if (process.env.SERO_MAC_ADHOC_SIGN === '0') return;
+  // Only ad-hoc sign unsigned builds. CSC_IDENTITY_AUTO_DISCOVERY=false means electron-builder
+  // skips its own signing, so this hook is the bundle's only seal. Signed builds (CSC_LINK set)
+  // leave the var unset and get real Developer ID signing + hardened runtime from electron-builder.
   if (process.env.CSC_IDENTITY_AUTO_DISCOVERY !== 'false') return;
 
   const appName = context.packager.appInfo.productFilename;
   const appPath = path.join(context.appOutDir, `${appName}.app`);
   if (!existsSync(appPath)) return;
 
+  // Ad-hoc, non-hardened seal: hardenedRuntime in electron-builder.yml only applies to the signed
+  // path, so an ad-hoc beta is intentionally not hardened. --deep re-seals the rebuilt native
+  // modules; it is a deliberate ad-hoc-only shortcut and must not be reused for notarized builds.
   execFileSync('codesign', [
     '--force',
     '--deep',

--- a/apps/desktop/scripts/after-pack.mjs
+++ b/apps/desktop/scripts/after-pack.mjs
@@ -1,8 +1,13 @@
+import { execFileSync } from 'node:child_process';
 import { chmodSync, existsSync } from 'node:fs';
 import path from 'node:path';
 
 /**
  * electron-builder hook for platform-specific app bundle fixes.
+ *
+ * macOS unsigned beta builds are ad-hoc signed so the downloaded app has a
+ * valid bundle seal. This does not notarize the app or bypass Gatekeeper; it
+ * only prevents malformed-signature "damaged app" failures.
  *
  * Linux packages include Electron's chrome-sandbox helper. Preserve the SUID
  * mode before building .deb packages so Chromium can use it after install.
@@ -10,10 +15,35 @@ import path from 'node:path';
  * also reapplies root:root + 4755 after installation.
  */
 export default async function afterPack(context) {
+  if (context.electronPlatformName === 'darwin') {
+    signMacBundleAdHoc(context);
+    return;
+  }
+
   if (context.electronPlatformName !== 'linux') return;
 
   const sandboxPath = path.join(context.appOutDir, 'chrome-sandbox');
   if (!existsSync(sandboxPath)) return;
 
   chmodSync(sandboxPath, 0o4755);
+}
+
+function signMacBundleAdHoc(context) {
+  if (process.env.SERO_MAC_ADHOC_SIGN === '0') return;
+  if (process.env.CSC_IDENTITY_AUTO_DISCOVERY !== 'false') return;
+
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(context.appOutDir, `${appName}.app`);
+  if (!existsSync(appPath)) return;
+
+  execFileSync('codesign', [
+    '--force',
+    '--deep',
+    '--sign',
+    '-',
+    '--entitlements',
+    path.join(context.packager.projectDir, 'build/entitlements.mac.plist'),
+    '--timestamp=none',
+    appPath,
+  ], { stdio: 'inherit' });
 }

--- a/apps/desktop/scripts/verify-host-mode-release.mjs
+++ b/apps/desktop/scripts/verify-host-mode-release.mjs
@@ -170,6 +170,9 @@ function checkWorkflow(workflowPath, workflowText, failures) {
   if (!workflowText.includes('runtime-host-release.workflow.spec.ts')) {
     failures.push(`${relativePath(workflowPath)}: missing host release smoke workflow spec`);
   }
+  if (!workflowText.includes('Verify macOS app bundle')) {
+    failures.push(`${relativePath(workflowPath)}: missing macOS app bundle verification gate`);
+  }
 }
 
 function checkBuildReleaseScript(buildReleasePath, buildReleaseText, failures) {

--- a/apps/docs-site/docs/guide/getting-started.md
+++ b/apps/docs-site/docs/guide/getting-started.md
@@ -37,6 +37,10 @@ not assume another artifact will work.
 Install Sero using the normal installer flow for your operating system, then open
 the desktop app.
 
+On macOS, Sero beta builds are unsigned but ad-hoc signed. After dragging Sero to
+Applications, open it with **Control-click / right-click → Open** the first time,
+then confirm **Open**. This is the supported no-Apple-account beta flow.
+
 Expected result: the Sero window opens. During beta, macOS Gatekeeper or Windows
 SmartScreen / unknown-publisher prompts may appear depending on the published
 artifact and your system policy.

--- a/apps/docs-site/docs/guide/installation-requirements.md
+++ b/apps/docs-site/docs/guide/installation-requirements.md
@@ -16,6 +16,8 @@ Developers and contributors can still build from source on supported targets. Us
 
 New beta releases may require manual download and installation unless release notes say otherwise. macOS Gatekeeper/notarization warnings and Windows SmartScreen or unknown-publisher warnings may apply during beta.
 
+On macOS, Sero beta DMGs are unsigned but ad-hoc signed. After copying Sero to Applications, use **Control-click / right-click → Open** for the first launch and confirm **Open** if macOS warns that the developer cannot be verified.
+
 ## 2. Check your platform
 
 Sero's public beta currently targets:

--- a/apps/docs-site/docs/reference/troubleshooting.md
+++ b/apps/docs-site/docs/reference/troubleshooting.md
@@ -56,6 +56,21 @@ Useful logs:
 
 If the failure mentions `node-pty`, `better-sqlite3`, `ERR_DLOPEN_FAILED`, or `NODE_MODULE_VERSION`, use the native-module steps below.
 
+### macOS says Sero is damaged or from an unidentified developer
+
+Sero macOS beta builds are unsigned but ad-hoc signed. They are not notarized.
+
+For a first launch from the DMG install:
+
+1. Drag Sero to Applications.
+2. Control-click or right-click **Sero**.
+3. Choose **Open**.
+4. Confirm **Open**.
+
+If macOS still shows a **damaged** warning, the app bundle signature is invalid.
+Delete the installed app, download the latest DMG again, and reinstall. If the
+same release still fails, report the release filename and macOS version.
+
 ## Terminals or memory features fail after install
 
 Interrupted installs and Electron ABI changes can leave native modules in the wrong state.

--- a/docs/plans/desktop-release-distribution.md
+++ b/docs/plans/desktop-release-distribution.md
@@ -44,7 +44,13 @@ Gaps remaining before Sero can ship real, self-updating desktop releases on all 
 - Apple notarization credentials (Apple ID + app-specific password + Team ID).
 - CI secrets configured in the `sero-labs/sero` repository.
 
-**Steps:**
+**Done — ad-hoc signing (no Apple account):**
+
+- [x] Keep unsigned macOS releases installable by ad-hoc-signing the app bundle before the DMG is created (`scripts/after-pack.mjs`, gated on `CSC_IDENTITY_AUTO_DISCOVERY=false`). A release-workflow `codesign --verify` gate guards the seal. Users still need the normal first-launch **right-click → Open** approval because the app is not notarized.
+
+**Remaining — full Developer ID signing + notarization:**
+
+The ad-hoc path auto-disables once real signing is configured: setting `CSC_LINK` leaves `CSC_IDENTITY_AUTO_DISCOVERY` unset, so `after-pack.mjs` bails out and electron-builder does the real signing with hardened runtime. No conflict to unwind.
 
 - [ ] Export Developer ID Application certificate from Keychain as `.p12`. Base64-encode it:
   `base64 -i DeveloperID.p12 | pbcopy`
@@ -54,7 +60,26 @@ Gaps remaining before Sero can ship real, self-updating desktop releases on all 
   - `APPLE_ID` — Apple ID used for notarization
   - `APPLE_APP_SPECIFIC_PASSWORD` — app-specific password for that Apple ID
   - `APPLE_TEAM_ID` — 10-character team ID
-- [x] Keep unsigned macOS releases installable by ad-hoc-signing the app bundle before the DMG is created. Users still need the normal first-launch **right-click → Open** approval because the app is not notarized.
+- [ ] In `release.yml`, pass these secrets as env vars to the macOS build step, and stop forcing the unsigned path (`build-release.sh --sign`) so electron-builder signs with the cert.
+- [ ] Re-enable `afterSign` in `electron-builder.yml` (currently `null`) to point at a notarization script. electron-builder supports `afterSign: build/notarize.js`. A minimal notarize script:
+
+  ```js
+  // build/notarize.js
+  const { notarize } = require('@electron/notarize');
+  exports.default = async (context) => {
+    if (context.electronPlatformName !== 'darwin') return;
+    await notarize({
+      tool: 'notarytool',
+      appBundleId: 'app.sero',
+      appPath: context.appOutDir + '/Sero.app',
+      appleId: process.env.APPLE_ID,
+      appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
+      teamId: process.env.APPLE_TEAM_ID,
+    });
+  };
+  ```
+
+- [ ] Add `@electron/notarize` as a dev dependency in `apps/desktop/`.
 - [ ] Verify entitlements file `build/entitlements.mac.plist` includes `com.apple.security.cs.allow-jit` if needed for JIT (node-pty uses a pseudo-TTY, usually not required).
 - [ ] Test a signed + notarized build before wiring into CI by running `build-release.sh --sign` locally with the cert in Keychain.
 

--- a/docs/plans/desktop-release-distribution.md
+++ b/docs/plans/desktop-release-distribution.md
@@ -36,14 +36,13 @@ Gaps remaining before Sero can ship real, self-updating desktop releases on all 
 
 ## Gap 2 — macOS code signing and notarization
 
-**Current state:** `afterSign: null` in `electron-builder.yml`. `CSC_LINK`/`CSC_KEY_PASSWORD` env vars are documented but no CI secrets are configured. Unsigned `.app` bundles trigger Gatekeeper on macOS 15+ and require users to `xattr -dr com.apple.quarantine` or use "Open Anyway".
+**Current state:** macOS release jobs build an unsigned, ad-hoc-signed app by default so the bundle seal is valid, but Gatekeeper still requires users to approve the app with **right-click → Open** because the app is not notarized.
 
 **What's needed:**
 
 - An Apple Developer ID Application certificate exported as `.p12`.
 - Apple notarization credentials (Apple ID + app-specific password + Team ID).
 - CI secrets configured in the `sero-labs/sero` repository.
-- `afterSign` re-enabled in `electron-builder.yml` for the release workflow.
 
 **Steps:**
 
@@ -55,26 +54,7 @@ Gaps remaining before Sero can ship real, self-updating desktop releases on all 
   - `APPLE_ID` — Apple ID used for notarization
   - `APPLE_APP_SPECIFIC_PASSWORD` — app-specific password for that Apple ID
   - `APPLE_TEAM_ID` — 10-character team ID
-- [ ] In `release.yml`, pass these secrets as env vars to the macOS build step.
-- [ ] Set `afterSign` to the notarization script. electron-builder supports `afterSign: build/notarize.js`. A minimal notarize script:
-
-  ```js
-  // build/notarize.js
-  const { notarize } = require('@electron/notarize');
-  exports.default = async (context) => {
-    if (context.electronPlatformName !== 'darwin') return;
-    await notarize({
-      tool: 'notarytool',
-      appBundleId: 'app.sero',
-      appPath: context.appOutDir + '/Sero.app',
-      appleId: process.env.APPLE_ID,
-      appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
-      teamId: process.env.APPLE_TEAM_ID,
-    });
-  };
-  ```
-
-- [ ] Add `@electron/notarize` as a dev dependency in `apps/desktop/`.
+- [x] Keep unsigned macOS releases installable by ad-hoc-signing the app bundle before the DMG is created. Users still need the normal first-launch **right-click → Open** approval because the app is not notarized.
 - [ ] Verify entitlements file `build/entitlements.mac.plist` includes `com.apple.security.cs.allow-jit` if needed for JIT (node-pty uses a pseudo-TTY, usually not required).
 - [ ] Test a signed + notarized build before wiring into CI by running `build-release.sh --sign` locally with the cert in Keychain.
 


### PR DESCRIPTION
## Summary
- ad-hoc sign unsigned macOS beta app bundles during packaging so the DMG contains a valid bundle seal
- add a release-workflow codesign verification gate for macOS artifacts
- document the no-Apple-account first-launch flow: Control-click/right-click → Open

## Validation
- node --check apps/desktop/scripts/after-pack.mjs
- pnpm --filter @sero/desktop verify:host-mode-release
- pnpm --filter @sero/desktop exec vitest run electron/__tests__/scripts/verify-host-mode-release.test.ts
- pnpm typecheck
