### PR TITLE
Optimize desktop package size and migrate Pi SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,9 @@ Public links:
 - Website: <https://sero-ai.dev/>
 - Docs: <https://docs.sero-ai.dev/>
 
-Sero is built on [Pi](https://github.com/badlogic/pi), the open-source coding
-agent platform. The current pinned Pi SDK baseline is **0.61.1**
-(`@mariozechner/pi-*` packages in `pnpm-workspace.yaml`). This will be updated
-during beta: later Pi releases may include breaking Extension API changes that Sero
-needs to adopt before plugin contracts can settle.
+Sero is built on [Pi](https://github.com/earendil-works/pi-mono), the
+open-source coding agent platform. The current pinned Pi SDK baseline is
+**0.78.0** (`@earendil-works/pi-*` packages in `pnpm-workspace.yaml`).
 
 ## What Sero is not
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -47,6 +47,7 @@ asarUnpack:
   # Native modules must be unpacked (they contain .node binaries)
   - node_modules/node-pty/**/*
   - node_modules/better-sqlite3/**/*
+  - dist/electron/builtin/plugins/sero-web-plugin/node_modules/better-sqlite3/**/*
 
 # ── macOS ─────────────────────────────────────────────────────
 mac:

--- a/apps/desktop/electron/__tests__/agent/agent-session-events.test.ts
+++ b/apps/desktop/electron/__tests__/agent/agent-session-events.test.ts
@@ -4,7 +4,7 @@ import {
   emitSessionShutdown,
   emitSessionBeforeSwitch,
 } from '@electron/ipc/agent/core/agent-session-events';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 
 function createMockSession(opts?: {
   hasRunner?: boolean;

--- a/apps/desktop/electron/__tests__/cli/agent-context-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/agent-context-bridge.test.ts
@@ -3,7 +3,7 @@ import { Type } from 'typebox';
 
 import { bridgeTool } from '@electron/cli/core/schema-bridge';
 import type { CliCommandContext, CliInvocation } from '@electron/cli/core/types';
-import { defineTool, type ExtensionContext, type ToolDefinition } from '@mariozechner/pi-coding-agent';
+import { defineTool, type ExtensionContext, type ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { ContainerManager } from '@electron/features/container';
 import type { WorkspaceManager } from '@electron/features/workspace/manager';
 

--- a/apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/custom-tool-cli-bridge.test.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createSyntheticSourceInfo, defineTool, type AgentSession, type LoadExtensionsResult, type ToolDefinition } from '@mariozechner/pi-coding-agent';
+import { createSyntheticSourceInfo, defineTool, type AgentSession, type LoadExtensionsResult, type ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
 import {

--- a/apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/extension-session-bridge.test.ts
@@ -6,7 +6,7 @@ import {
   type LoadExtensionsResult,
   type RegisteredCommand,
   type ToolDefinition,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
 import {

--- a/apps/desktop/electron/__tests__/cli/extract-agent-context.test.ts
+++ b/apps/desktop/electron/__tests__/cli/extract-agent-context.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { extractAgentContext } from '@electron/cli/core/tool';
-import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent';
 
 function createMockExtensionContext(
   overrides?: Partial<ExtensionContext>,

--- a/apps/desktop/electron/__tests__/cli/session-runtime-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/cli/session-runtime-bridge.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AgentSession, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { AgentSession, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
 import { CliRegistry } from '@electron/cli/core/registry';

--- a/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
+++ b/apps/desktop/electron/__tests__/cli/tool-bridge-policy.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Type, type TSchema } from 'typebox';
-import type { LoadExtensionsResult, ToolDefinition, RegisteredCommand } from '@mariozechner/pi-coding-agent';
+import type { LoadExtensionsResult, ToolDefinition, RegisteredCommand } from '@earendil-works/pi-coding-agent';
 import { bridgeExtensionTools, getCliRegistry, resetCliRegistryForTests } from '@electron/cli';
 
 // ── Helpers ─────────────────────────────────────────────────

--- a/apps/desktop/electron/__tests__/features/apps/git-checkpoints.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/git-checkpoints.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({

--- a/apps/desktop/electron/__tests__/features/apps/runtime/custom-tools.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/runtime/custom-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Type } from 'typebox';
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { validateRuntimeCustomTools } from '@electron/features/apps/runtime/capabilities/custom-tools';
 
 describe('validateRuntimeCustomTools', () => {

--- a/apps/desktop/electron/__tests__/features/apps/skill-visibility.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/skill-visibility.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createSyntheticSourceInfo, type Skill } from '@mariozechner/pi-coding-agent';
+import { createSyntheticSourceInfo, type Skill } from '@earendil-works/pi-coding-agent';
 import { getDisabledModelSkills, withDisabledModelSkills } from '@sero-ai/common';
 import { createSkillVisibilityOverride } from '@electron/features/apps/extensions/skill-visibility';
 

--- a/apps/desktop/electron/__tests__/features/container/tools-browser.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/tools-browser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 
 const createAgentBrowserMock = vi.fn();
 

--- a/apps/desktop/electron/__tests__/features/container/tools-host-memory-guard.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/tools-host-memory-guard.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 
 import { createHostCodingTools } from '@electron/features/container/tools/tools-host';
 import {

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-ops.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-ops.test.ts
@@ -28,8 +28,8 @@ vi.mock('@electron/shared/infra/shared-infra', () => ({
   SERO_SESSION_DIR: '/tmp/sero-test-sessions',
 }));
 
-vi.mock('@mariozechner/pi-coding-agent', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@mariozechner/pi-coding-agent')>();
+vi.mock('@earendil-works/pi-coding-agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@earendil-works/pi-coding-agent')>();
   return {
     ...actual,
     SessionManager: mocks.sessionManager,

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-cli-bridge.test.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 import { mkdtemp, mkdir, rm, writeFile } from 'fs/promises';
 import { describe, expect, it, beforeEach, afterEach } from 'vitest';
-import { createSyntheticSourceInfo, defineTool, type LoadExtensionsResult } from '@mariozechner/pi-coding-agent';
+import { createSyntheticSourceInfo, defineTool, type LoadExtensionsResult } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
 import {

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-package-build.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-package-build.test.ts
@@ -134,8 +134,43 @@ describe('plugin package build helpers', () => {
     };
 
     expect(builtPkg.sero?.app?.runtime).toBe('./runtime/index.js');
-    expect(builtPkg.files).toContain('runtime');
+    expect(builtPkg.files).toContain('runtime/index.js');
     await expect(stat(path.join(dir, 'dist', 'plugin', 'runtime', 'index.js'))).resolves.toBeDefined();
+  });
+
+  it('whitelists compiled extension and runtime entries outside conventional folders', async () => {
+    const dir = await createTempPluginDir(tempDirs);
+    await mkdir(path.join(dir, 'agent'), { recursive: true });
+    await mkdir(path.join(dir, 'background'), { recursive: true });
+    await writeFile(path.join(dir, 'agent', 'main.ts'), 'export default { tools: [] };\n', 'utf8');
+    await writeFile(
+      path.join(dir, 'background', 'worker.ts'),
+      'export function createAppRuntime() { return { start() {}, handleStateChange() {}, dispose() {} }; }\n',
+      'utf8',
+    );
+    await writePackageJson(dir, {
+      name: '@acme/custom-layout-plugin',
+      pi: { extensions: ['./agent/main.ts'] },
+      sero: {
+        app: {
+          id: 'custom-layout-plugin',
+          name: 'Custom Layout Plugin',
+          runtime: './background/worker.ts',
+        },
+      },
+    });
+
+    await execFile(process.execPath, [buildPluginScript, dir], { cwd: repoRoot });
+
+    const builtPkg = JSON.parse(await readFile(path.join(dir, 'dist', 'plugin', 'package.json'), 'utf8')) as {
+      files?: string[];
+      pi?: { extensions?: string[] };
+      sero?: { app?: { runtime?: string } };
+    };
+
+    expect(builtPkg.pi?.extensions).toEqual(['./agent/main.js']);
+    expect(builtPkg.sero?.app?.runtime).toBe('./background/worker.js');
+    expect(builtPkg.files).toEqual(expect.arrayContaining(['agent/main.js', 'background/worker.js']));
   });
 
   it('exports runtime source trees with npm-installable tsconfig rewrites', async () => {

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-package-build.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-package-build.test.ts
@@ -122,7 +122,7 @@ describe('plugin package build helpers', () => {
         },
       },
       peerDependencies: {
-        '@mariozechner/pi-coding-agent': '^0.0.0',
+        '@earendil-works/pi-coding-agent': '^0.0.0',
       },
     });
 

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-runtime-package-build.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-runtime-package-build.test.ts
@@ -80,6 +80,62 @@ describe('plugin runtime packaging and source preparation', () => {
     expect(builtRuntime).not.toContain('NEEDS_EXTERNALIZATION');
   });
 
+  it('builds extension-only packages and keeps declared extensionExternals external', async () => {
+    const dir = await createTempPluginDir();
+    await mkdir(path.join(dir, 'extension'), { recursive: true });
+    await mkdir(path.join(dir, 'node_modules', 'tiny-lib'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'node_modules', 'tiny-lib', 'package.json'),
+      JSON.stringify({ name: 'tiny-lib', version: '1.0.0', type: 'module', exports: './index.js' }, null, 2),
+      'utf8',
+    );
+    await writeFile(
+      path.join(dir, 'node_modules', 'tiny-lib', 'index.js'),
+      'export const tinyValue = "BUNDLED_VALUE";\n',
+      'utf8',
+    );
+    await writeFile(
+      path.join(dir, 'extension', 'index.ts'),
+      'import { externalValue } from "@acme/nativeish"; import { tinyValue } from "tiny-lib"; export default { externalValue, tinyValue };\n',
+      'utf8',
+    );
+    await writePackageJson(dir, {
+      name: '@acme/extension-only-plugin',
+      version: '1.0.0',
+      dependencies: {
+        '@acme/nativeish': '^1.0.0',
+        'tiny-lib': '^1.0.0',
+      },
+      pi: {
+        extensions: ['./extension/index.ts'],
+      },
+      sero: {
+        plugin: {
+          category: 'utilities',
+          tags: ['extension'],
+          bundleExtensions: true,
+          extensionExternals: ['@acme/nativeish'],
+        },
+      },
+      peerDependencies: {
+        '@mariozechner/pi-coding-agent': '^0.0.0',
+      },
+    });
+
+    await execFile(process.execPath, [buildPluginScript, dir], { cwd: repoRoot });
+
+    const builtPkg = JSON.parse(await readFile(path.join(dir, 'dist', 'plugin', 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+      pi?: { extensions?: string[] };
+    };
+    const builtExtension = await readFile(path.join(dir, 'dist', 'plugin', 'extension', 'index.js'), 'utf8');
+
+    expect(builtPkg.pi?.extensions).toEqual(['./extension/index.js']);
+    expect(builtPkg.dependencies).toEqual({ '@acme/nativeish': '^1.0.0' });
+    expect(builtExtension).toContain('@acme/nativeish');
+    expect(builtExtension).toContain('BUNDLED_VALUE');
+  });
+
   it.each([
     {
       label: 'runtime-only',

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-runtime-package-build.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-runtime-package-build.test.ts
@@ -2,6 +2,7 @@ import { execFile as execFileCb } from 'child_process';
 import os from 'os';
 import path from 'path';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { pathToFileURL } from 'url';
 import { promisify } from 'util';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -134,6 +135,40 @@ describe('plugin runtime packaging and source preparation', () => {
     expect(builtPkg.dependencies).toEqual({ '@acme/nativeish': '^1.0.0' });
     expect(builtExtension).toContain('@acme/nativeish');
     expect(builtExtension).toContain('BUNDLED_VALUE');
+  });
+
+  it('supports bundled CommonJS dependencies that require Node builtins', async () => {
+    const dir = await createTempPluginDir();
+    await mkdir(path.join(dir, 'extension'), { recursive: true });
+    await mkdir(path.join(dir, 'node_modules', 'spawnish'), { recursive: true });
+    await writeFile(
+      path.join(dir, 'node_modules', 'spawnish', 'package.json'),
+      JSON.stringify({ name: 'spawnish', version: '1.0.0', main: './index.js' }, null, 2),
+      'utf8',
+    );
+    await writeFile(
+      path.join(dir, 'node_modules', 'spawnish', 'index.js'),
+      'const childProcess = require("child_process"); module.exports = { hasExecFile: typeof childProcess.execFile === "function" };\n',
+      'utf8',
+    );
+    await writeFile(
+      path.join(dir, 'extension', 'index.ts'),
+      'import spawnish from "spawnish"; export default { value: spawnish.hasExecFile };\n',
+      'utf8',
+    );
+    await writePackageJson(dir, {
+      name: '@acme/cjs-plugin',
+      version: '1.0.0',
+      dependencies: { spawnish: '^1.0.0' },
+      pi: { extensions: ['./extension/index.ts'] },
+      sero: { plugin: { category: 'utilities', tags: ['extension'], bundleExtensions: true } },
+    });
+
+    await execFile(process.execPath, [buildPluginScript, dir], { cwd: repoRoot });
+
+    const builtExtensionUrl = pathToFileURL(path.join(dir, 'dist', 'plugin', 'extension', 'index.js')).href;
+    const builtExtension = await import(builtExtensionUrl) as { default?: { value?: unknown } };
+    expect(builtExtension.default?.value).toBe(true);
   });
 
   it.each([

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-runtime-package-build.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-runtime-package-build.test.ts
@@ -70,7 +70,7 @@ describe('plugin runtime packaging and source preparation', () => {
         },
       },
       peerDependencies: {
-        '@mariozechner/pi-coding-agent': '^0.0.0',
+        '@earendil-works/pi-coding-agent': '^0.0.0',
       },
     });
 
@@ -119,7 +119,7 @@ describe('plugin runtime packaging and source preparation', () => {
         },
       },
       peerDependencies: {
-        '@mariozechner/pi-coding-agent': '^0.0.0',
+        '@earendil-works/pi-coding-agent': '^0.0.0',
       },
     });
 

--- a/apps/desktop/electron/__tests__/features/plugins/resource-compatibility.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/resource-compatibility.test.ts
@@ -8,7 +8,7 @@ import {
   type PromptTemplate,
   type Skill,
   type Theme,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {

--- a/apps/desktop/electron/__tests__/ipc/agent-sdk-private-adapter.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/agent-sdk-private-adapter.test.ts
@@ -1,5 +1,5 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import { createAgentSession, SessionManager } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import { createAgentSession, SessionManager } from '@earendil-works/pi-coding-agent';
 import { mkdtemp, rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -62,7 +62,7 @@ describe('agent SDK private adapter', () => {
 
     expect(session.agent.state.systemPrompt).toBe('Updated prompt');
     expect(consoleWarn).toHaveBeenCalledWith(
-      expect.stringContaining('pi-coding-agent@0.72.1'),
+      expect.stringContaining('pi-coding-agent@0.78.0'),
     );
   });
 
@@ -87,11 +87,11 @@ describe('agent SDK private adapter', () => {
     rewriteSessionManagerFile(toAgentSession(session));
 
     expect(consoleWarn).toHaveBeenCalledWith(
-      expect.stringContaining('pi-coding-agent@0.72.1'),
+      expect.stringContaining('pi-coding-agent@0.78.0'),
     );
   });
 
-  it('matches private prompt/rewrite shapes on the Pi 0.72.1 AgentSession runtime', async () => {
+  it('matches private prompt/rewrite shapes on the Pi 0.78.0 AgentSession runtime', async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'sero-pi-adapter-'));
     try {
       const { session } = await createAgentSession({

--- a/apps/desktop/electron/__tests__/ipc/agent-session-model-sync.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/agent-session-model-sync.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import type { Api, Model } from '@mariozechner/pi-ai';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import type { Api, Model } from '@earendil-works/pi-ai';
 import { ensureSessionHasAvailableModel } from '@electron/ipc/agent/core/agent-session-model-sync';
 
 function createModel(provider: string, id: string): Model<Api> {

--- a/apps/desktop/electron/__tests__/ipc/app-agent-tool-execution.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-agent-tool-execution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 
 import { invokeAppSessionTool } from '@electron/ipc/agent/handlers/app-agent-tools';
 

--- a/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/app-agent.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import type { Api, Model } from '@mariozechner/pi-ai';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import type { Api, Model } from '@earendil-works/pi-ai';
 import {
   syncAppSessionModel,
   syncAppSessionPoolModels,

--- a/apps/desktop/electron/__tests__/ipc/model-availability-refresh.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/model-availability-refresh.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import type { Api, Model } from '@mariozechner/pi-ai';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import type { Api, Model } from '@earendil-works/pi-ai';
 
 const mocks = vi.hoisted(() => ({
   modelRegistryRefresh: vi.fn(),

--- a/apps/desktop/electron/__tests__/ipc/session-metadata.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/session-metadata.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { listSessionMetadata } from '@electron/ipc/agent/core/session-metadata';
+
+const tempDirs: string[] = [];
+
+async function createTempSessionDir(): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'sero-session-metadata-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function writeJsonl(filePath: string, entries: object[]): Promise<void> {
+  await writeFile(filePath, entries.map((entry) => JSON.stringify(entry)).join('\n') + '\n', 'utf8');
+}
+
+describe('session metadata listing', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('lists sessions from every cwd in the session directory', async () => {
+    const sessionDir = await createTempSessionDir();
+    await writeJsonl(path.join(sessionDir, 'one.jsonl'), [
+      {
+        type: 'session',
+        version: 3,
+        id: 'session-one',
+        timestamp: '2026-05-30T10:00:00.000Z',
+        cwd: '/workspace/one',
+      },
+      { type: 'session_info', id: 'info-one', parentId: null, timestamp: '2026-05-30T10:00:01.000Z', name: 'One' },
+      {
+        type: 'message',
+        id: 'message-one',
+        parentId: 'info-one',
+        timestamp: '2026-05-30T10:00:02.000Z',
+        message: { role: 'user', content: [{ type: 'text', text: 'first prompt' }] },
+      },
+    ]);
+    await writeJsonl(path.join(sessionDir, 'two.jsonl'), [
+      {
+        type: 'session',
+        version: 3,
+        id: 'session-two',
+        timestamp: '2026-05-30T11:00:00.000Z',
+        cwd: '/workspace/two',
+      },
+    ]);
+
+    const sessions = await listSessionMetadata(sessionDir);
+
+    expect(sessions.map((session) => session.id).sort()).toEqual(['session-one', 'session-two']);
+    expect(sessions.find((session) => session.id === 'session-one')).toMatchObject({
+      cwd: '/workspace/one',
+      name: 'One',
+      firstMessage: 'first prompt',
+      messageCount: 1,
+    });
+    expect(sessions.find((session) => session.id === 'session-two')).toMatchObject({
+      cwd: '/workspace/two',
+      firstMessage: '',
+      messageCount: 0,
+    });
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/session-metadata.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/session-metadata.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdtemp, rm, utimes, writeFile } from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -64,5 +64,51 @@ describe('session metadata listing', () => {
       firstMessage: '',
       messageCount: 0,
     });
+  });
+
+  it('sorts sessions by modified time newest first', async () => {
+    const sessionDir = await createTempSessionDir();
+    const oldPath = path.join(sessionDir, 'old.jsonl');
+    const newPath = path.join(sessionDir, 'new.jsonl');
+    await writeJsonl(oldPath, [{ type: 'session', id: 'old', timestamp: '2026-05-30T10:00:00.000Z', cwd: '/old' }]);
+    await writeJsonl(newPath, [{ type: 'session', id: 'new', timestamp: '2026-05-30T11:00:00.000Z', cwd: '/new' }]);
+    await utimes(oldPath, new Date('2026-05-30T10:00:00.000Z'), new Date('2026-05-30T10:00:00.000Z'));
+    await utimes(newPath, new Date('2026-05-30T12:00:00.000Z'), new Date('2026-05-30T12:00:00.000Z'));
+
+    const sessions = await listSessionMetadata(sessionDir);
+
+    expect(sessions.map((session) => session.id)).toEqual(['new', 'old']);
+  });
+
+  it('counts all message entries, including messages outside the active branch', async () => {
+    const sessionDir = await createTempSessionDir();
+    await writeJsonl(path.join(sessionDir, 'branched.jsonl'), [
+      { type: 'session', version: 3, id: 'branched', timestamp: '2026-05-30T10:00:00.000Z', cwd: '/workspace' },
+      {
+        type: 'message',
+        id: 'root-message',
+        parentId: null,
+        timestamp: '2026-05-30T10:00:01.000Z',
+        message: { role: 'user', content: 'start' },
+      },
+      {
+        type: 'message',
+        id: 'abandoned-branch',
+        parentId: 'root-message',
+        timestamp: '2026-05-30T10:00:02.000Z',
+        message: { role: 'assistant', content: 'old branch' },
+      },
+      {
+        type: 'message',
+        id: 'active-branch',
+        parentId: 'root-message',
+        timestamp: '2026-05-30T10:00:03.000Z',
+        message: { role: 'assistant', content: 'new branch' },
+      },
+    ]);
+
+    const sessions = await listSessionMetadata(sessionDir);
+
+    expect(sessions[0]?.messageCount).toBe(3);
   });
 });

--- a/apps/desktop/electron/__tests__/shared/provider-catalog.test.ts
+++ b/apps/desktop/electron/__tests__/shared/provider-catalog.test.ts
@@ -13,7 +13,7 @@ import {
 const removedProviderIds = ['google-gemini-cli', 'google-antigravity'];
 
 describe('provider catalog', () => {
-  it('lists Pi 0.72 API-key providers exposed by Sero auth', () => {
+  it('lists Pi API-key providers exposed by Sero auth', () => {
     const ids = getApiKeyProviderCatalog().map((provider) => provider.id);
 
     expect(ids).toEqual(expect.arrayContaining([
@@ -21,6 +21,9 @@ describe('provider catalog', () => {
       'moonshotai',
       'moonshotai-cn',
       'xiaomi',
+      'xiaomi-token-plan-cn',
+      'xiaomi-token-plan-ams',
+      'xiaomi-token-plan-sgp',
     ]));
     expect(ids).not.toContain('cloudflare-workers-ai');
     expect(ids).not.toContain('cloudflare-ai-gateway');

--- a/apps/desktop/electron/cli/bridges/agent-bridge.ts
+++ b/apps/desktop/electron/cli/bridges/agent-bridge.ts
@@ -1,4 +1,4 @@
-import type { AgentSession, DefaultResourceLoader } from '@mariozechner/pi-coding-agent';
+import type { AgentSession, DefaultResourceLoader } from '@earendil-works/pi-coding-agent';
 import type { AgentStreamEvent } from '@/types/ipc';
 import { installCliSessionBridge } from './session-bridge';
 

--- a/apps/desktop/electron/cli/bridges/extension-session-bridge.ts
+++ b/apps/desktop/electron/cli/bridges/extension-session-bridge.ts
@@ -3,7 +3,7 @@ import {
   type Extension,
   type RegisteredCommand,
   type RegisteredTool,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 
 import type { CliCommandContext } from '../core/types';
 import { getCliSessionBridge } from './session-bridge';

--- a/apps/desktop/electron/cli/bridges/session-bridge.ts
+++ b/apps/desktop/electron/cli/bridges/session-bridge.ts
@@ -1,4 +1,4 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 
 export interface CliSessionEntry {
   sessionId: string;

--- a/apps/desktop/electron/cli/core/batch-executor.ts
+++ b/apps/desktop/electron/cli/core/batch-executor.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type {
   CliCommandContext,
   CliCommandUpdate,

--- a/apps/desktop/electron/cli/core/bridge-context.ts
+++ b/apps/desktop/electron/cli/core/bridge-context.ts
@@ -4,7 +4,7 @@ import {
   SessionManager,
   type ExtensionCommandContext,
   type ExtensionContext,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 
 import { createSeroUIContext } from '@electron/features/apps/extensions/ui-context';
 import type { CliCommandContext, CliSessionRuntime } from './types';

--- a/apps/desktop/electron/cli/core/invocation-context.ts
+++ b/apps/desktop/electron/cli/core/invocation-context.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import type {
   BridgedAgentContext,
   CliCommandContext,

--- a/apps/desktop/electron/cli/core/schema-bridge.ts
+++ b/apps/desktop/electron/cli/core/schema-bridge.ts
@@ -12,7 +12,7 @@
  * and re-register them as CLI commands (removing them from agent context).
  */
 
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { CliCommand, CliCommandContext, CliContentBlock, CliResult } from './types';
 import { buildCommandContext, buildToolContext } from './bridge-context';
 import { getBridgedExtensionCommand, getBridgedExtensionTool } from '../bridges/extension-session-bridge';

--- a/apps/desktop/electron/cli/core/tool.ts
+++ b/apps/desktop/electron/cli/core/tool.ts
@@ -1,4 +1,4 @@
-import { defineTool, type ToolDefinition } from '@mariozechner/pi-coding-agent';
+import { defineTool, type ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import { containerManager, workspaceManager } from '@electron/shared/infra/shared-infra';
 import type { CliCommandContext } from './types';

--- a/apps/desktop/electron/cli/core/types.ts
+++ b/apps/desktop/electron/cli/core/types.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent';
 import type {
   ExtensionRuntimeMessage,
   ExtensionSessionRuntime,

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -1,4 +1,4 @@
-import type { LoadExtensionsResult } from '@mariozechner/pi-coding-agent';
+import type { LoadExtensionsResult } from '@earendil-works/pi-coding-agent';
 import {
   registerAppControlCliCommands,
   registerAppStateCliCommands,

--- a/apps/desktop/electron/features/agent/assistants/adhoc-agent.ts
+++ b/apps/desktop/electron/features/agent/assistants/adhoc-agent.ts
@@ -1,6 +1,6 @@
-import { createAgentSession, SettingsManager, SessionManager } from '@mariozechner/pi-coding-agent';
-import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
-import type { Api, Model } from '@mariozechner/pi-ai';
+import { createAgentSession, SettingsManager, SessionManager } from '@earendil-works/pi-coding-agent';
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
+import type { Api, Model } from '@earendil-works/pi-ai';
 
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { ensureInfra } from '@electron/shared/infra/shared-infra';

--- a/apps/desktop/electron/features/agent/assistants/voice-transcription-host.ts
+++ b/apps/desktop/electron/features/agent/assistants/voice-transcription-host.ts
@@ -6,7 +6,7 @@
  * by web-remote) can share the same behaviour.
  */
 
-import { getEnvApiKey } from '@mariozechner/pi-ai';
+import { getEnvApiKey } from '@earendil-works/pi-ai';
 
 import type {
   VoiceTranscriptionResult,

--- a/apps/desktop/electron/features/apps/discovery/plugin-meta.ts
+++ b/apps/desktop/electron/features/apps/discovery/plugin-meta.ts
@@ -160,6 +160,33 @@ export function parsePluginMeta(plugin: unknown): ParsedPluginMetaResult {
     warnings.push('ignored non-boolean `sero.plugin.preBuilt`');
   }
 
+  if (typeof plugin.bundleExtensions === 'boolean') {
+    parsed.bundleExtensions = plugin.bundleExtensions;
+  } else if (plugin.bundleExtensions !== undefined) {
+    warnings.push('ignored non-boolean `sero.plugin.bundleExtensions`');
+  }
+
+  if (Array.isArray(plugin.extensionExternals)) {
+    const extensionExternals: string[] = [];
+    plugin.extensionExternals.forEach((external, index) => {
+      if (typeof external !== 'string') {
+        warnings.push(`ignored non-string \`sero.plugin.extensionExternals[${index}]\``);
+        return;
+      }
+      const trimmed = external.trim();
+      if (!trimmed) {
+        warnings.push(`ignored empty \`sero.plugin.extensionExternals[${index}]\``);
+        return;
+      }
+      extensionExternals.push(trimmed);
+    });
+    if (extensionExternals.length > 0) {
+      parsed.extensionExternals = extensionExternals;
+    }
+  } else if (plugin.extensionExternals !== undefined) {
+    warnings.push('ignored invalid `sero.plugin.extensionExternals`; expected string[]');
+  }
+
   if (typeof plugin.bridgeTools === 'boolean') {
     parsed.bridgeTools = plugin.bridgeTools;
   } else if (Array.isArray(plugin.bridgeTools)) {

--- a/apps/desktop/electron/features/apps/extensions/commands.ts
+++ b/apps/desktop/electron/features/apps/extensions/commands.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 export function registerSeroBuiltinCommands(
   pi: ExtensionAPI,

--- a/apps/desktop/electron/features/apps/extensions/create-sero-extension.ts
+++ b/apps/desktop/electron/features/apps/extensions/create-sero-extension.ts
@@ -14,7 +14,7 @@
  */
 
 import path from 'path';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import type { WorkspaceManager } from '@electron/features/workspace/manager';
 import type { ContainerState } from '@electron/features/container';
 import { buildContainerPromptBlock } from '@electron/features/container/tools/system-prompt';

--- a/apps/desktop/electron/features/apps/extensions/git-checkpoint-commands.ts
+++ b/apps/desktop/electron/features/apps/extensions/git-checkpoint-commands.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 import { vcsManager } from '@electron/shared/infra/shared-infra';
 import type { GitCheckpointSessionEntries } from './git-checkpoint-session-entries';

--- a/apps/desktop/electron/features/apps/extensions/git-checkpoint-session-entries.ts
+++ b/apps/desktop/electron/features/apps/extensions/git-checkpoint-session-entries.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 export const WORKSPACE_LINK_ENTRY = 'git-workspace-link';
 export const CHECKPOINT_ENTRY = 'git-checkpoint';

--- a/apps/desktop/electron/features/apps/extensions/git-checkpoints.ts
+++ b/apps/desktop/electron/features/apps/extensions/git-checkpoints.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 import { createGitCheckpointSessionEntries } from './git-checkpoint-session-entries';
 import { registerManualGitCheckpointCommands } from './git-checkpoint-commands';

--- a/apps/desktop/electron/features/apps/extensions/git-turn-undo-capture.ts
+++ b/apps/desktop/electron/features/apps/extensions/git-turn-undo-capture.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 
 import { vcsManager } from '@electron/shared/infra/shared-infra';
 import { gitWorkspaceStateManager } from '@electron/features/apps/git-app/manager';

--- a/apps/desktop/electron/features/apps/extensions/skill-visibility.ts
+++ b/apps/desktop/electron/features/apps/extensions/skill-visibility.ts
@@ -1,4 +1,4 @@
-import type { Skill } from '@mariozechner/pi-coding-agent';
+import type { Skill } from '@earendil-works/pi-coding-agent';
 import { getDisabledModelSkills } from '@sero-ai/common';
 
 interface SkillLoadResult {

--- a/apps/desktop/electron/features/apps/extensions/ui-context.ts
+++ b/apps/desktop/electron/features/apps/extensions/ui-context.ts
@@ -9,7 +9,7 @@
  * Compatible with the Pi SDK's ExtensionUIContext interface.
  */
 
-import { Theme, type ExtensionUIContext, type ThemeColor } from '@mariozechner/pi-coding-agent';
+import { Theme, type ExtensionUIContext, type ThemeColor } from '@earendil-works/pi-coding-agent';
 import { showNotification } from '@electron/platform/desktop/notifications';
 
 const SERO_UI_THEME_COLORS: Record<ThemeColor, string> = {

--- a/apps/desktop/electron/features/apps/runtime/capabilities/custom-tools.ts
+++ b/apps/desktop/electron/features/apps/runtime/capabilities/custom-tools.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 
 function isToolDefinition(value: unknown): value is ToolDefinition {
   if (typeof value !== 'object' || value === null) {

--- a/apps/desktop/electron/features/apps/runtime/loader.ts
+++ b/apps/desktop/electron/features/apps/runtime/loader.ts
@@ -1,15 +1,27 @@
 import { createHash } from 'crypto';
 import { existsSync } from 'fs';
 import { mkdir, readFile, stat, writeFile } from 'fs/promises';
+import { createRequire } from 'module';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import { build } from 'esbuild';
+import type { BuildResult, build as esbuildBuild } from 'esbuild';
 import type { AppRuntimeModule, LoadAppRuntimeModuleOptions } from './types';
 
 const SUPPORTED_RUNTIME_EXTENSIONS = new Set(['.js', '.mjs', '.cjs', '.ts', '.mts', '.cts', '.tsx']);
 const TRANSPILED_RUNTIME_EXTENSIONS = new Set(['.ts', '.mts', '.cts', '.tsx']);
 const DEFAULT_RUNTIME_EXTERNALS = ['better-sqlite3', 'electron', 'keytar', 'node-pty'] as const;
 const RUNTIME_CACHE_VERSION = 2;
+const runtimeRequire = createRequire(__filename);
+
+const ESBUILD_PLATFORM_PACKAGES: Record<string, { packageName: string; binaryPath: string }> = {
+  'darwin arm64': { packageName: '@esbuild/darwin-arm64', binaryPath: 'bin/esbuild' },
+  'darwin x64': { packageName: '@esbuild/darwin-x64', binaryPath: 'bin/esbuild' },
+  'linux arm64': { packageName: '@esbuild/linux-arm64', binaryPath: 'bin/esbuild' },
+  'linux x64': { packageName: '@esbuild/linux-x64', binaryPath: 'bin/esbuild' },
+  'win32 arm64': { packageName: '@esbuild/win32-arm64', binaryPath: 'esbuild.exe' },
+  'win32 ia32': { packageName: '@esbuild/win32-ia32', binaryPath: 'esbuild.exe' },
+  'win32 x64': { packageName: '@esbuild/win32-x64', binaryPath: 'esbuild.exe' },
+};
 
 interface RuntimeInputSnapshot {
   path: string;
@@ -45,6 +57,37 @@ function normalizeRuntimeExternals(externals: string[] | undefined): string[] {
 
 function buildEsbuildExternalList(externals: string[]): string[] {
   return externals.flatMap((external) => [external, `${external}/*`]);
+}
+
+function resolveAsarUnpackedPath(filePath: string): string | null {
+  const asarSegment = `${path.sep}app.asar${path.sep}`;
+  if (!filePath.includes(asarSegment)) return null;
+  return filePath.replace(asarSegment, `${path.sep}app.asar.unpacked${path.sep}`);
+}
+
+function configurePackagedEsbuildBinary(): void {
+  if (process.env.ESBUILD_BINARY_PATH) return;
+
+  const platformPackage = ESBUILD_PLATFORM_PACKAGES[`${process.platform} ${process.arch}`];
+  if (!platformPackage) return;
+
+  let binaryPath: string;
+  try {
+    binaryPath = runtimeRequire.resolve(`${platformPackage.packageName}/${platformPackage.binaryPath}`);
+  } catch {
+    return;
+  }
+
+  const unpackedPath = resolveAsarUnpackedPath(binaryPath);
+  if (unpackedPath && existsSync(unpackedPath)) {
+    process.env.ESBUILD_BINARY_PATH = unpackedPath;
+  }
+}
+
+function loadEsbuildBuild(): typeof esbuildBuild {
+  configurePackagedEsbuildBinary();
+  const esbuild = runtimeRequire('esbuild') as { build: typeof esbuildBuild };
+  return esbuild.build;
 }
 
 function normalizeRuntimeModule(candidate: unknown, runtimeEntryPath: string): AppRuntimeModule {
@@ -168,9 +211,9 @@ async function buildTranspiledRuntime(runtimeEntryPath: string, externals: strin
 
   const outfile = path.join(cacheDir, `${outputPrefix}.mjs`);
 
-  let result: Awaited<ReturnType<typeof build>>;
+  let result: BuildResult;
   try {
-    result = await build({
+    result = await loadEsbuildBuild()({
       entryPoints: [runtimeEntryPath],
       outfile,
       absWorkingDir: packageDir,

--- a/apps/desktop/electron/features/container/tools/tools-browser-agent-helpers.ts
+++ b/apps/desktop/electron/features/container/tools/tools-browser-agent-helpers.ts
@@ -1,4 +1,4 @@
-import type { AgentToolResult } from '@mariozechner/pi-agent-core';
+import type { AgentToolResult } from '@earendil-works/pi-agent-core';
 import { prepareToolImage } from '@electron/shared/media/image-resize';
 
 interface BrowserTextResponse {

--- a/apps/desktop/electron/features/container/tools/tools-browser-agent.ts
+++ b/apps/desktop/electron/features/container/tools/tools-browser-agent.ts
@@ -1,6 +1,6 @@
 import type { Static } from 'typebox';
-import type { ToolDefinition, ExtensionContext } from '@mariozechner/pi-coding-agent';
-import type { AgentToolResult, AgentToolUpdateCallback } from '@mariozechner/pi-agent-core';
+import type { ToolDefinition, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import type { AgentToolResult, AgentToolUpdateCallback } from '@earendil-works/pi-agent-core';
 import type { RuntimeBackend } from '@electron/features/workspace/runtime/types';
 import type { BrowserRuntimeAdapter } from '@electron/features/workspace/runtime/browser-pack/types';
 import {

--- a/apps/desktop/electron/features/container/tools/tools-browser.ts
+++ b/apps/desktop/electron/features/container/tools/tools-browser.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { RuntimeBackend } from '@electron/features/workspace/runtime/types';
 import { createAgentBrowser } from './tools-browser-agent';
 

--- a/apps/desktop/electron/features/container/tools/tools-coding.ts
+++ b/apps/desktop/electron/features/container/tools/tools-coding.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Static } from 'typebox';
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { RuntimeBackend, RuntimeFileReadResult } from '@electron/features/workspace/runtime/types';
 import {
   DEFAULT_MAX_LINES,

--- a/apps/desktop/electron/features/container/tools/tools-host.ts
+++ b/apps/desktop/electron/features/container/tools/tools-host.ts
@@ -3,7 +3,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import type { Static } from 'typebox';
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 
 import {
   DEFAULT_MAX_LINES,

--- a/apps/desktop/electron/features/container/tools/tools.ts
+++ b/apps/desktop/electron/features/container/tools/tools.ts
@@ -6,7 +6,7 @@
  * which routes to host-side Sero commands.
  */
 
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import type { RuntimeBackend } from '@electron/features/workspace/runtime/types';
 import { createBash, createRead, createWrite, createEdit } from './tools-coding';
 import { createBrowser } from './tools-browser';

--- a/apps/desktop/electron/features/onboarding/model-groups.ts
+++ b/apps/desktop/electron/features/onboarding/model-groups.ts
@@ -1,4 +1,4 @@
-import { getSupportedThinkingLevels, type Api, type Model } from '@mariozechner/pi-ai';
+import { getSupportedThinkingLevels, type Api, type Model } from '@earendil-works/pi-ai';
 import { THINKING_LEVELS, type ThinkingLevel } from '@sero-ai/common';
 import type { AvailableModelGroup } from '@/types/ipc';
 import { providerDisplayName, providerLogo } from './provider-metadata';

--- a/apps/desktop/electron/features/plugins/activation.ts
+++ b/apps/desktop/electron/features/plugins/activation.ts
@@ -5,7 +5,7 @@ import {
   DefaultPackageManager,
   type PackageSource,
   SettingsManager,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import {
   discoverBuiltinPackagePaths,

--- a/apps/desktop/electron/features/plugins/dev-sessions/activation.ts
+++ b/apps/desktop/electron/features/plugins/dev-sessions/activation.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type { PackageSource } from '@mariozechner/pi-coding-agent';
+import type { PackageSource } from '@earendil-works/pi-coding-agent';
 import type { SeroAppManifest } from '@/types/ipc';
 import { registerExtAssets, unregisterExtAssets } from '@electron/platform/protocols/ext-protocol';
 import { getPackagesArray, readSettings, writeSettings } from '../settings';

--- a/apps/desktop/electron/features/plugins/resource-compatibility.ts
+++ b/apps/desktop/electron/features/plugins/resource-compatibility.ts
@@ -7,7 +7,7 @@ import type {
   ResourceDiagnostic,
   Skill,
   Theme,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import type { PluginCompatibilityStatus } from '@sero-ai/common';
 import {
   extractPluginCompatibilityRequirements,

--- a/apps/desktop/electron/features/subagent/core/single-run.ts
+++ b/apps/desktop/electron/features/subagent/core/single-run.ts
@@ -1,4 +1,4 @@
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 import { randomUUID } from 'crypto';
 import { resolveConfig } from './resolve';
 import type { ConcurrencyPool } from './pool';

--- a/apps/desktop/electron/features/subagent/core/types.ts
+++ b/apps/desktop/electron/features/subagent/core/types.ts
@@ -6,7 +6,7 @@
  * here. Main-process-only types (AgentConfig, RunnerConfig, etc.) are defined below.
  */
 
-import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
+import type { ToolDefinition } from '@earendil-works/pi-coding-agent';
 
 // Import IPC-shared types for local use
 import type {

--- a/apps/desktop/electron/features/subagent/extensions/tool.ts
+++ b/apps/desktop/electron/features/subagent/extensions/tool.ts
@@ -11,8 +11,8 @@
 import { writeFile, readdir, mkdir } from 'fs/promises';
 import path from 'path';
 import { Type } from 'typebox';
-import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
-import type { AgentToolResult, AgentToolUpdateCallback } from '@mariozechner/pi-agent-core';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import type { AgentToolResult, AgentToolUpdateCallback } from '@earendil-works/pi-agent-core';
 import type { SubagentManager } from '..';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 

--- a/apps/desktop/electron/features/subagent/runtime/loader.ts
+++ b/apps/desktop/electron/features/subagent/runtime/loader.ts
@@ -12,7 +12,7 @@
  *   - /reload, /compact, /name etc. (not relevant for child sessions)
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import type { WorkspaceManager } from '@electron/features/workspace/manager';
 import type { ContainerState } from '@electron/features/container/core/types';
 import { buildContainerPromptBlock } from '@electron/features/container/tools/system-prompt';

--- a/apps/desktop/electron/features/subagent/runtime/runner.ts
+++ b/apps/desktop/electron/features/subagent/runtime/runner.ts
@@ -10,9 +10,9 @@ import {
   createAgentSession,
   SessionManager,
   DefaultResourceLoader,
-} from '@mariozechner/pi-coding-agent';
-import type { CreateAgentSessionOptions } from '@mariozechner/pi-coding-agent';
-import type { ThinkingLevel, AgentMessage } from '@mariozechner/pi-agent-core';
+} from '@earendil-works/pi-coding-agent';
+import type { CreateAgentSessionOptions } from '@earendil-works/pi-coding-agent';
+import type { ThinkingLevel, AgentMessage } from '@earendil-works/pi-agent-core';
 import { getModelTierThinkingLevel, isModelTier } from '@sero-ai/common';
 
 import type { RunnerConfig, RunResult, SubagentUsage, SubagentToolActivity } from '../core/types';

--- a/apps/desktop/electron/ipc/agent/core/agent-checkpoint.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-checkpoint.ts
@@ -3,7 +3,7 @@
  */
 
 import { ipcMain } from 'electron';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 
 import { IpcChannels } from '@/types/ipc-channels';
 import type { AgentStreamEvent, ChatMessage, ChatTurnUndoRef } from '@/types/ipc';

--- a/apps/desktop/electron/ipc/agent/core/agent-context-overrides.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-context-overrides.ts
@@ -1,4 +1,4 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 import type { ContextOverrides, ContextToolInfo } from '@/types/ipc';
 import {
   rewriteSessionManagerFile,

--- a/apps/desktop/electron/ipc/agent/core/agent-helpers.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-helpers.ts
@@ -5,8 +5,8 @@
  * `agent-messages.ts` and `sdk-private-adapter.ts`.
  */
 
-import type { AgentSession, DefaultResourceLoader } from '@mariozechner/pi-coding-agent';
-import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
+import type { AgentSession, DefaultResourceLoader } from '@earendil-works/pi-coding-agent';
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
 import { promises as fs } from 'fs';
 import type {
   SeroSlashCommandInfo,

--- a/apps/desktop/electron/ipc/agent/core/agent-messages.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-messages.ts
@@ -1,5 +1,5 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import type { ImageContent } from '@mariozechner/pi-ai';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import type { ImageContent } from '@earendil-works/pi-ai';
 import type {
   ChatAttachment,
   ChatAssistantMessage,

--- a/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-model-context.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import type { AgentSession, DefaultResourceLoader } from '@mariozechner/pi-coding-agent';
+import type { AgentSession, DefaultResourceLoader } from '@earendil-works/pi-coding-agent';
 
 import { IpcChannels } from '@/types/ipc-channels';
 import type {

--- a/apps/desktop/electron/ipc/agent/core/agent-prompt.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-prompt.ts
@@ -1,4 +1,4 @@
-import type { AgentSession, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { AgentSession, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import type {
   AssistantMessage,
   ImageContent,
@@ -7,7 +7,7 @@ import type {
   ToolResultMessage,
   Usage,
   UserMessage,
-} from '@mariozechner/pi-ai';
+} from '@earendil-works/pi-ai';
 import type { ChatAttachment, ChatMessage, ChatToolCallMessage, AgentStreamEvent, ToolResultImage } from '@/types/ipc';
 import { getCliRegistry } from '@electron/cli';
 import type { CliContentBlock } from '@electron/cli/core';

--- a/apps/desktop/electron/ipc/agent/core/agent-session-events.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-session-events.ts
@@ -9,7 +9,7 @@ import type {
   AgentSession,
   SessionBeforeSwitchEvent,
   SessionShutdownEvent,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 
 /**
  * Emit `session_shutdown` via the session's extension runner.

--- a/apps/desktop/electron/ipc/agent/core/agent-session-model-sync.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-session-model-sync.ts
@@ -1,4 +1,4 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 
 import { getConfiguredModelFallbackChain } from '@electron/shared/settings/model-fallback-chain';
 import { getModelTiers } from '@electron/shared/settings/model-tiers';

--- a/apps/desktop/electron/ipc/agent/core/agent-session-open.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-session-open.ts
@@ -3,7 +3,7 @@ import {
   DefaultResourceLoader,
   SessionManager,
   type AgentSession,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import type {
   AgentStreamEvent,
   ChatMessage,

--- a/apps/desktop/electron/ipc/agent/core/agent-subscription.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent-subscription.ts
@@ -5,7 +5,7 @@
  * Extracted from agent.ts to keep it under 500 LOC.
  */
 
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 import type {
   ChatAssistantMessage,
   ChatToolCallMessage,

--- a/apps/desktop/electron/ipc/agent/core/agent.ts
+++ b/apps/desktop/electron/ipc/agent/core/agent.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron';
-import { SessionManager } from '@mariozechner/pi-coding-agent';
+import { SessionManager } from '@earendil-works/pi-coding-agent';
 import { IpcChannels } from '@/types/ipc-channels';
 import type {
   AgentStreamEvent,

--- a/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
+++ b/apps/desktop/electron/ipc/agent/core/app-agent-session-model-sync.ts
@@ -1,5 +1,5 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import type { Api, Model } from '@mariozechner/pi-ai';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import type { Api, Model } from '@earendil-works/pi-ai';
 import { clearUnavailableSessionModel } from './agent-session-model-sync';
 import { setRuntimeSessionModel } from './agent-helpers';
 

--- a/apps/desktop/electron/ipc/agent/core/model-availability-refresh.ts
+++ b/apps/desktop/electron/ipc/agent/core/model-availability-refresh.ts
@@ -1,4 +1,4 @@
-import { type Model, type Api } from '@mariozechner/pi-ai';
+import { type Model, type Api } from '@earendil-works/pi-ai';
 
 import {
   ensureInfra,

--- a/apps/desktop/electron/ipc/agent/core/model-groups.ts
+++ b/apps/desktop/electron/ipc/agent/core/model-groups.ts
@@ -1,4 +1,4 @@
-import { getSupportedThinkingLevels, type Api, type Model } from '@mariozechner/pi-ai';
+import { getSupportedThinkingLevels, type Api, type Model } from '@earendil-works/pi-ai';
 import { THINKING_LEVELS, type ThinkingLevel } from '@sero-ai/common';
 import type { AvailableModelGroup } from '@/types/ipc';
 import { providerDisplayName, providerLogo } from '@electron/ipc/platform/auth';

--- a/apps/desktop/electron/ipc/agent/core/sdk-private-adapter.ts
+++ b/apps/desktop/electron/ipc/agent/core/sdk-private-adapter.ts
@@ -1,7 +1,7 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import type { Api, Model } from '@mariozechner/pi-ai';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import type { Api, Model } from '@earendil-works/pi-ai';
 
-const VALIDATED_PI_CODING_AGENT_VERSION = '0.72.1';
+const VALIDATED_PI_CODING_AGENT_VERSION = '0.78.0';
 
 interface SessionPrivatePromptAccessor {
   _baseSystemPrompt?: string;

--- a/apps/desktop/electron/ipc/agent/core/session-metadata.ts
+++ b/apps/desktop/electron/ipc/agent/core/session-metadata.ts
@@ -50,14 +50,14 @@ async function sessionFileNames(sessionDir: string): Promise<string[]> {
 
 async function readSessionMetadata(sessionDir: string, fileName: string): Promise<SessionMetadata | null> {
   const filePath = path.join(sessionDir, fileName);
+  const fileStat = await stat(filePath);
   const manager = SessionManager.open(filePath, sessionDir);
   const header = manager.getHeader() as SessionHeader | undefined;
   if (!header) return null;
 
-  const branch = manager.getBranch() as SessionEntry[];
-  const messages = branch.filter((entry) => entry.type === 'message' && entry.message);
+  const entries = manager.getEntries() as SessionEntry[];
+  const messages = entries.filter((entry) => entry.type === 'message' && entry.message);
   const firstUserMessage = messages.find((entry) => entry.message?.role === 'user');
-  const fileStat = await stat(filePath);
 
   return {
     path: filePath,
@@ -77,7 +77,8 @@ export async function listSessionMetadata(sessionDir: string): Promise<SessionMe
   return metadata
     .filter((result): result is PromiseFulfilledResult<SessionMetadata | null> => result.status === 'fulfilled')
     .map((result) => result.value)
-    .filter((session): session is SessionMetadata => session !== null);
+    .filter((session): session is SessionMetadata => session !== null)
+    .sort((a, b) => b.modified.getTime() - a.modified.getTime());
 }
 
 export async function findSessionMetadata(

--- a/apps/desktop/electron/ipc/agent/core/session-metadata.ts
+++ b/apps/desktop/electron/ipc/agent/core/session-metadata.ts
@@ -1,6 +1,7 @@
+import { createReadStream } from 'fs';
 import { readdir, stat } from 'fs/promises';
 import path from 'path';
-import { SessionManager } from '@earendil-works/pi-coding-agent';
+import { createInterface } from 'readline';
 
 export interface SessionMetadata {
   path: string;
@@ -19,12 +20,16 @@ interface SessionHeader {
   timestamp: string;
 }
 
-interface SessionEntry {
-  type: string;
-  message?: {
-    role?: string;
-    content?: unknown;
-  };
+interface CachedSessionMetadata {
+  mtimeMs: number;
+  size: number;
+  metadata: SessionMetadata | null;
+}
+
+const metadataCache = new Map<string, CachedSessionMetadata>();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
 }
 
 function textFromContent(content: unknown): string {
@@ -48,32 +53,65 @@ async function sessionFileNames(sessionDir: string): Promise<string[]> {
     .map((entry) => entry.name);
 }
 
-async function readSessionMetadata(sessionDir: string, fileName: string): Promise<SessionMetadata | null> {
-  const filePath = path.join(sessionDir, fileName);
-  const fileStat = await stat(filePath);
-  const manager = SessionManager.open(filePath, sessionDir);
-  const header = manager.getHeader() as SessionHeader | undefined;
+function sessionHeaderFromEntry(entry: Record<string, unknown>): SessionHeader | null {
+  if (entry.type !== 'session') return null;
+  const { id, cwd, timestamp } = entry;
+  if (typeof id !== 'string' || typeof cwd !== 'string' || typeof timestamp !== 'string') return null;
+  return { id, cwd, timestamp };
+}
+
+async function scanSessionFile(filePath: string, modified: Date): Promise<SessionMetadata | null> {
+  const lines = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity });
+  let header: SessionHeader | null = null;
+  let name: string | undefined;
+  let messageCount = 0;
+  let firstMessage = '';
+
+  for await (const line of lines) {
+    if (!line.trim()) continue;
+    const entry = JSON.parse(line) as unknown;
+    if (!isRecord(entry)) continue;
+
+    header ??= sessionHeaderFromEntry(entry);
+    if (entry.type === 'session_info' && typeof entry.name === 'string') name = entry.name;
+    if (entry.type !== 'message' || !isRecord(entry.message)) continue;
+
+    messageCount += 1;
+    if (!firstMessage && entry.message.role === 'user') {
+      firstMessage = textFromContent(entry.message.content);
+    }
+  }
+
   if (!header) return null;
-
-  const entries = manager.getEntries() as SessionEntry[];
-  const messages = entries.filter((entry) => entry.type === 'message' && entry.message);
-  const firstUserMessage = messages.find((entry) => entry.message?.role === 'user');
-
   return {
     path: filePath,
     id: header.id,
     cwd: header.cwd,
-    name: manager.getSessionName(),
+    name,
     created: new Date(header.timestamp),
-    modified: fileStat.mtime,
-    messageCount: messages.length,
-    firstMessage: textFromContent(firstUserMessage?.message?.content),
+    modified,
+    messageCount,
+    firstMessage,
   };
+}
+
+async function readSessionMetadata(sessionDir: string, fileName: string): Promise<SessionMetadata | null> {
+  const filePath = path.join(sessionDir, fileName);
+  const fileStat = await stat(filePath);
+  const cached = metadataCache.get(filePath);
+  if (cached && cached.mtimeMs === fileStat.mtimeMs && cached.size === fileStat.size) return cached.metadata;
+
+  const metadata = await scanSessionFile(filePath, fileStat.mtime);
+  metadataCache.set(filePath, { mtimeMs: fileStat.mtimeMs, size: fileStat.size, metadata });
+  return metadata;
 }
 
 export async function listSessionMetadata(sessionDir: string): Promise<SessionMetadata[]> {
   const files = await sessionFileNames(sessionDir);
   const metadata = await Promise.allSettled(files.map((file) => readSessionMetadata(sessionDir, file)));
+  for (const result of metadata) {
+    if (result.status === 'rejected') console.warn('[sessions] Failed to read session metadata:', result.reason);
+  }
   return metadata
     .filter((result): result is PromiseFulfilledResult<SessionMetadata | null> => result.status === 'fulfilled')
     .map((result) => result.value)

--- a/apps/desktop/electron/ipc/agent/core/session-metadata.ts
+++ b/apps/desktop/electron/ipc/agent/core/session-metadata.ts
@@ -1,0 +1,90 @@
+import { readdir, stat } from 'fs/promises';
+import path from 'path';
+import { SessionManager } from '@earendil-works/pi-coding-agent';
+
+export interface SessionMetadata {
+  path: string;
+  id: string;
+  cwd: string;
+  name?: string;
+  created: Date;
+  modified: Date;
+  messageCount: number;
+  firstMessage: string;
+}
+
+interface SessionHeader {
+  id: string;
+  cwd: string;
+  timestamp: string;
+}
+
+interface SessionEntry {
+  type: string;
+  message?: {
+    role?: string;
+    content?: unknown;
+  };
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+
+  return content
+    .map((part) => {
+      if (!part || typeof part !== 'object') return '';
+      const text = (part as { text?: unknown }).text;
+      return typeof text === 'string' ? text : '';
+    })
+    .filter(Boolean)
+    .join('\n');
+}
+
+async function sessionFileNames(sessionDir: string): Promise<string[]> {
+  const entries = await readdir(sessionDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.jsonl'))
+    .map((entry) => entry.name);
+}
+
+async function readSessionMetadata(sessionDir: string, fileName: string): Promise<SessionMetadata | null> {
+  const filePath = path.join(sessionDir, fileName);
+  const manager = SessionManager.open(filePath, sessionDir);
+  const header = manager.getHeader() as SessionHeader | undefined;
+  if (!header) return null;
+
+  const branch = manager.getBranch() as SessionEntry[];
+  const messages = branch.filter((entry) => entry.type === 'message' && entry.message);
+  const firstUserMessage = messages.find((entry) => entry.message?.role === 'user');
+  const fileStat = await stat(filePath);
+
+  return {
+    path: filePath,
+    id: header.id,
+    cwd: header.cwd,
+    name: manager.getSessionName(),
+    created: new Date(header.timestamp),
+    modified: fileStat.mtime,
+    messageCount: messages.length,
+    firstMessage: textFromContent(firstUserMessage?.message?.content),
+  };
+}
+
+export async function listSessionMetadata(sessionDir: string): Promise<SessionMetadata[]> {
+  const files = await sessionFileNames(sessionDir);
+  const metadata = await Promise.allSettled(files.map((file) => readSessionMetadata(sessionDir, file)));
+  return metadata
+    .filter((result): result is PromiseFulfilledResult<SessionMetadata | null> => result.status === 'fulfilled')
+    .map((result) => result.value)
+    .filter((session): session is SessionMetadata => session !== null);
+}
+
+export async function findSessionMetadata(
+  sessionDir: string,
+  sessionId: string,
+  cwd?: string,
+): Promise<SessionMetadata | null> {
+  const sessions = await listSessionMetadata(sessionDir);
+  return sessions.find((session) => session.id === sessionId && (!cwd || session.cwd === cwd)) ?? null;
+}

--- a/apps/desktop/electron/ipc/agent/handlers/app-agent-tools.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/app-agent-tools.ts
@@ -1,4 +1,4 @@
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 import type { AppToolContentBlock, AppToolResult } from '@sero-ai/common';
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/app-agent.ts
@@ -24,7 +24,7 @@ import {
   DefaultResourceLoader,
   SessionManager,
   type AgentSession,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import os from 'os';
 import path from 'path';
 

--- a/apps/desktop/electron/ipc/agent/handlers/prompts.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/prompts.ts
@@ -14,7 +14,7 @@
 import { ipcMain } from 'electron';
 import { readFile, writeFile, mkdir, readdir, rm, rename, stat } from 'fs/promises';
 import path from 'path';
-import { parseFrontmatter } from '@mariozechner/pi-coding-agent';
+import { parseFrontmatter } from '@earendil-works/pi-coding-agent';
 import { IpcChannels } from '@/types/ipc-channels';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { reloadAllSessionResources } from '..';

--- a/apps/desktop/electron/ipc/agent/handlers/sessions.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/sessions.ts
@@ -9,7 +9,7 @@
  */
 
 import { ipcMain } from 'electron';
-import { SessionManager } from '@mariozechner/pi-coding-agent';
+import { SessionManager } from '@earendil-works/pi-coding-agent';
 import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
@@ -19,6 +19,7 @@ import type { SeroSessionInfo } from '@/types/ipc';
 import { workspaceManager } from '@electron/features/workspace/manager';
 import { SERO_SESSION_DIR } from '@electron/shared/infra/shared-infra';
 import { extractOriginalCollaborationQuery } from '@electron/ipc/collaboration/collaboration-message';
+import { listSessionMetadata, type SessionMetadata } from '@electron/ipc/agent/core/session-metadata';
 
 /**
  * Legacy cwd used before workspaces existed.
@@ -82,17 +83,8 @@ export async function resolveSessionWorkspaceId(
   return detachedWorkspaceId(cwd);
 }
 
-/** Convert Pi SDK SessionInfo to our serialisable IPC shape. */
-async function toSeroSessionInfo(info: {
-  path: string;
-  id: string;
-  cwd: string;
-  name?: string;
-  created: Date;
-  modified: Date;
-  messageCount: number;
-  firstMessage: string;
-}): Promise<SeroSessionInfo> {
+/** Convert Pi SDK session metadata to our serialisable IPC shape. */
+async function toSeroSessionInfo(info: SessionMetadata): Promise<SeroSessionInfo> {
   return {
     path: info.path,
     id: info.id,
@@ -110,15 +102,14 @@ export function registerSessionHandlers(): void {
   // ── List all sessions ──────────────────────────────────────
   //    Optional workspaceId filter.
   //
-  //    SessionManager.list(cwd, sessionDir) with an explicit sessionDir
-  //    lists all .jsonl files in that directory regardless of cwd.
-  //    We use LEGACY_CWD as a dummy — the sessionDir override is what matters.
+  //    Pi SDK 0.78 filters SessionManager.list(cwd, sessionDir) by cwd when
+  //    sessionDir is explicit, so read the session directory directly here.
   ipcMain.handle(
     IpcChannels.sessions.list,
     async (_event, workspaceId?: string): Promise<SeroSessionInfo[]> => {
       await ensureSessionDir();
       try {
-        const allSessions = await SessionManager.list(LEGACY_CWD, SERO_SESSION_DIR);
+        const allSessions = await listSessionMetadata(SERO_SESSION_DIR);
         const mapped = await Promise.all(allSessions.map(toSeroSessionInfo));
 
         // Filter by workspace if requested

--- a/apps/desktop/electron/ipc/agent/handlers/skills.ts
+++ b/apps/desktop/electron/ipc/agent/handlers/skills.ts
@@ -17,7 +17,7 @@ import {
   parseFrontmatter,
   type SkillFrontmatter,
   type SourceInfo,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 import { IpcChannels } from '@/types/ipc-channels';
 import { SERO_AGENT_DIR, SERO_HOME } from '@electron/platform/env';
 import { appStateManager } from '@electron/features/apps/state/manager';

--- a/apps/desktop/electron/ipc/collaboration/collaboration.ts
+++ b/apps/desktop/electron/ipc/collaboration/collaboration.ts
@@ -12,7 +12,7 @@
  */
 
 import { ipcMain } from 'electron';
-import type { AgentMessage } from '@mariozechner/pi-agent-core';
+import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import { IpcChannels } from '@/types/ipc-channels';
 import type {
   CollaborationEvent,

--- a/apps/desktop/electron/ipc/editor/debug.ts
+++ b/apps/desktop/electron/ipc/editor/debug.ts
@@ -17,7 +17,7 @@
 import { ipcMain, shell } from 'electron';
 import { promises as fs, createWriteStream, type WriteStream } from 'fs';
 import path from 'path';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 import { SERO_HOME } from '@electron/platform/env';
 import { IpcChannels } from '@/types/ipc-channels';
 import { tryParseImageJson } from '../agent/core/tool-result-images';

--- a/apps/desktop/electron/ipc/gateway/gateway-ops.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway-ops.ts
@@ -10,9 +10,8 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import os from 'os';
-import { SessionManager } from '@mariozechner/pi-coding-agent';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
+import { SessionManager } from '@earendil-works/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
 import { workspaceManager } from '@electron/features/workspace/manager';
 import {
   artifactRegistry,
@@ -67,8 +66,8 @@ async function findSessionInfo(workspaceId: string, sessionId: string): Promise<
   const wsPath = workspaceManager.getPath(workspaceId);
   if (!wsPath) throw new Error(`Workspace not found: ${workspaceId}`);
 
-  const allSessions = await SessionManager.list(os.homedir(), SERO_SESSION_DIR);
-  return allSessions.find((session) => session.id === sessionId && session.cwd === wsPath) ?? null;
+  const workspaceSessions = await SessionManager.list(wsPath, SERO_SESSION_DIR);
+  return workspaceSessions.find((session) => session.id === sessionId) ?? null;
 }
 
 /**
@@ -131,8 +130,9 @@ export function buildGatewayOps(
     },
     listSessions: async (workspaceId) => {
       const wsPath = workspaceManager.getPath(workspaceId);
-      const all = await SessionManager.list(os.homedir(), SERO_SESSION_DIR);
-      return all.filter((s) => s.cwd === wsPath).map((s) => ({
+      if (!wsPath) return [];
+      const workspaceSessions = await SessionManager.list(wsPath, SERO_SESSION_DIR);
+      return workspaceSessions.map((s) => ({
         id: s.id, name: s.name || '', firstMessage: s.firstMessage || '',
       }));
     },

--- a/apps/desktop/electron/ipc/platform/auth/auth.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth.ts
@@ -19,8 +19,8 @@
 
 import fs from 'fs';
 import { ipcMain, BrowserWindow, shell, type WebContents } from 'electron';
-import { getOAuthProviders } from '@mariozechner/pi-ai/oauth';
-import type { OAuthProviderId } from '@mariozechner/pi-ai';
+import { getOAuthProviders } from '@earendil-works/pi-ai/oauth';
+import type { OAuthProviderId } from '@earendil-works/pi-ai';
 
 import { IpcChannels } from '@/types/ipc-channels';
 import type {
@@ -207,6 +207,18 @@ export function registerAuthHandlers(): void {
             }
           },
 
+          onDeviceCode: (info) => {
+            shell.openExternal(info.verificationUri).catch(() => {
+              // Silently ignore — URL is shown in dialog anyway
+            });
+
+            sendAuthEvent({
+              type: 'auth',
+              url: info.verificationUri,
+              instructions: `Enter code: ${info.userCode}`,
+            });
+          },
+
           onPrompt: async (prompt) => {
             sendAuthEvent({
               type: 'prompt',
@@ -232,6 +244,8 @@ export function registerAuthHandlers(): void {
               manualCodeRejecter = reject;
             });
           },
+
+          onSelect: async (prompt) => prompt.options[0]?.id,
 
           signal: abortController.signal,
         });

--- a/apps/desktop/electron/ipc/platform/auth/auth.ts
+++ b/apps/desktop/electron/ipc/platform/auth/auth.ts
@@ -74,6 +74,8 @@ let promptResolver: ((value: string) => void) | null = null;
 let promptRejecter: ((err: Error) => void) | null = null;
 let manualCodeResolver: ((value: string) => void) | null = null;
 let manualCodeRejecter: ((err: Error) => void) | null = null;
+let selectResolver: ((value: string | undefined) => void) | null = null;
+let selectRejecter: ((err: Error) => void) | null = null;
 
 /**
  * The webContents that initiated the current login flow.
@@ -106,6 +108,8 @@ function clearPending(): void {
   promptRejecter = null;
   manualCodeResolver = null;
   manualCodeRejecter = null;
+  selectResolver = null;
+  selectRejecter = null;
   abortController = null;
   loginOriginWebContents = null;
 }
@@ -245,7 +249,18 @@ export function registerAuthHandlers(): void {
             });
           },
 
-          onSelect: async (prompt) => prompt.options[0]?.id,
+          onSelect: async (prompt) => {
+            sendAuthEvent({
+              type: 'select',
+              message: prompt.message,
+              options: prompt.options,
+            });
+
+            return new Promise<string | undefined>((resolve, reject) => {
+              selectResolver = resolve;
+              selectRejecter = reject;
+            });
+          },
 
           signal: abortController.signal,
         });
@@ -339,6 +354,21 @@ export function registerAuthHandlers(): void {
     },
   );
 
+  // ── Respond to pending selection ───────────────────────────
+  ipcMain.handle(
+    IpcChannels.auth.respondSelect,
+    async (_event, value: string): Promise<boolean> => {
+      if (selectResolver) {
+        selectResolver(value);
+        selectResolver = null;
+        selectRejecter = null;
+        return true;
+      }
+      console.warn('[auth] respondSelect called but no selection is pending — ignoring');
+      return false;
+    },
+  );
+
   // ── Cancel in-progress login ───────────────────────────────
   ipcMain.handle(
     IpcChannels.auth.cancel,
@@ -352,6 +382,9 @@ export function registerAuthHandlers(): void {
       }
       if (manualCodeRejecter) {
         manualCodeRejecter(new Error('Login cancelled'));
+      }
+      if (selectRejecter) {
+        selectRejecter(new Error('Login cancelled'));
       }
       clearPending();
     },

--- a/apps/desktop/electron/platform/protocols/builtin-package-detection.js
+++ b/apps/desktop/electron/platform/protocols/builtin-package-detection.js
@@ -1,8 +1,8 @@
-import fs from 'fs';
-import path from 'path';
+const fs = require('fs');
+const path = require('path');
 
 /** Check if a directory is a Sero extension/app package. */
-export function isBuiltinPackageDir(pkgPath) {
+function isBuiltinPackageDir(pkgPath) {
   const pkgJsonPath = path.join(pkgPath, 'package.json');
   if (!fs.existsSync(pkgJsonPath)) return false;
 
@@ -18,3 +18,5 @@ export function isBuiltinPackageDir(pkgPath) {
     return false;
   }
 }
+
+module.exports = { isBuiltinPackageDir };

--- a/apps/desktop/electron/preload/apps/app-domain.ts
+++ b/apps/desktop/electron/preload/apps/app-domain.ts
@@ -162,6 +162,8 @@ export const authBridge = {
     ipcRenderer.invoke(IpcChannels.auth.removeApiKey, providerId),
   respondPrompt: (value: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.auth.respondPrompt, value),
+  respondSelect: (value: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.auth.respondSelect, value),
   respondManualCode: (value: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.auth.respondManualCode, value),
   cancel: (): Promise<void> =>

--- a/apps/desktop/electron/shared/auth/provider-catalog.ts
+++ b/apps/desktop/electron/shared/auth/provider-catalog.ts
@@ -1,5 +1,5 @@
-import { getEnvApiKey } from '@mariozechner/pi-ai';
-import { getOAuthProviders } from '@mariozechner/pi-ai/oauth';
+import { getEnvApiKey } from '@earendil-works/pi-ai';
+import { getOAuthProviders } from '@earendil-works/pi-ai/oauth';
 import { getPackageApiKeyProviders, getPackageProviderEnvVar } from '../providers/package-provider-manifests';
 
 export interface NamedProvider {
@@ -7,7 +7,7 @@ export interface NamedProvider {
   name: string;
 }
 
-// Mirrors Pi 0.72.1 API-key auth.json keys from docs/providers.md and
+// Mirrors Pi API-key auth.json keys from docs/providers.md and
 // env-api-keys.ts. Sero still stores credentials in ~/.sero-ui/agent/auth.json.
 const BUILTIN_API_KEY_PROVIDERS: NamedProvider[] = [
   { id: 'anthropic', name: 'Anthropic' }, // ANTHROPIC_OAUTH_TOKEN or ANTHROPIC_API_KEY
@@ -34,8 +34,10 @@ const BUILTIN_API_KEY_PROVIDERS: NamedProvider[] = [
   { id: 'moonshotai-cn', name: 'Moonshot AI (China)' }, // MOONSHOT_API_KEY
   { id: 'fireworks', name: 'Fireworks' }, // FIREWORKS_API_KEY
   { id: 'xiaomi', name: 'Xiaomi MiMo' }, // XIAOMI_API_KEY
+  { id: 'xiaomi-token-plan-cn', name: 'Xiaomi MiMo Token Plan CN' }, // XIAOMI_TOKEN_PLAN_CN_API_KEY
+  { id: 'xiaomi-token-plan-ams', name: 'Xiaomi MiMo Token Plan AMS' }, // XIAOMI_TOKEN_PLAN_AMS_API_KEY
+  { id: 'xiaomi-token-plan-sgp', name: 'Xiaomi MiMo Token Plan SGP' }, // XIAOMI_TOKEN_PLAN_SGP_API_KEY
   // google-gemini-cli and google-antigravity were removed from Pi built-ins in 0.71.
-  // xiaomi-token-plan-* are documented upstream but not exported by pi-ai 0.72.1.
 ];
 
 export function getApiKeyProviderCatalog(): NamedProvider[] {

--- a/apps/desktop/electron/shared/infra/runtime-settings.ts
+++ b/apps/desktop/electron/shared/infra/runtime-settings.ts
@@ -1,5 +1,5 @@
-import type { Api, Model } from '@mariozechner/pi-ai';
-import { type ModelRegistry, type SettingsManager } from '@mariozechner/pi-coding-agent';
+import type { Api, Model } from '@earendil-works/pi-ai';
+import { type ModelRegistry, type SettingsManager } from '@earendil-works/pi-coding-agent';
 import { getConfiguredModelFallbackChain } from '../settings/model-fallback-chain';
 import { getModelTiers } from '../settings/model-tiers';
 import { subagentManager } from './singletons';

--- a/apps/desktop/electron/shared/infra/shared-infra.ts
+++ b/apps/desktop/electron/shared/infra/shared-infra.ts
@@ -17,8 +17,8 @@ import {
   AuthStorage,
   ModelRegistry,
   SettingsManager,
-} from '@mariozechner/pi-coding-agent';
-import { type Api, type Model } from '@mariozechner/pi-ai';
+} from '@earendil-works/pi-coding-agent';
+import { type Api, type Model } from '@earendil-works/pi-ai';
 
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { migrateLegacyProfileRootConfigsSync } from '@electron/features/profile/agent-config-migration';

--- a/apps/desktop/electron/shared/settings/model-config.ts
+++ b/apps/desktop/electron/shared/settings/model-config.ts
@@ -7,7 +7,7 @@ import {
   type SharedAvailableModelGroup,
   type SharedModelInfo,
 } from '@sero-ai/common';
-import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
 import type {
   GlobalModelConfigInput,
   GlobalModelConfigState,

--- a/apps/desktop/electron/types/pi-coding-agent.d.ts
+++ b/apps/desktop/electron/types/pi-coding-agent.d.ts
@@ -1,8 +1,8 @@
-import '@mariozechner/pi-coding-agent';
+import '@earendil-works/pi-coding-agent';
 import type { TSchema } from 'typebox';
 import type { CustomToolCliBridge } from '../cli/core/schema-bridge';
 
-declare module '@mariozechner/pi-coding-agent' {
+declare module '@earendil-works/pi-coding-agent' {
   interface CreateAgentSessionOptions {
     /**
      * Sero-specific prompt suffix appended after the resolved system prompt.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -48,9 +48,9 @@
   },
   "dependencies": {
     "@google/genai": "^1.45.0",
-    "@mariozechner/pi-agent-core": "catalog:",
-    "@mariozechner/pi-ai": "catalog:",
-    "@mariozechner/pi-coding-agent": "catalog:",
+    "@earendil-works/pi-agent-core": "catalog:",
+    "@earendil-works/pi-ai": "catalog:",
+    "@earendil-works/pi-coding-agent": "catalog:",
     "@sero-ai/common": "workspace:*",
     "ansi-styles": "4.3.0",
     "chalk": "4.1.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -47,7 +47,7 @@
     "dist:win": "bash scripts/build-release.sh --target win"
   },
   "dependencies": {
-    "@google/genai": "^1.45.0",
+    "@google/genai": "^1.52.0",
     "@earendil-works/pi-agent-core": "catalog:",
     "@earendil-works/pi-ai": "catalog:",
     "@earendil-works/pi-coding-agent": "catalog:",

--- a/apps/desktop/scripts/build-electron.mjs
+++ b/apps/desktop/scripts/build-electron.mjs
@@ -7,8 +7,10 @@ import { isBuiltinPackageDir } from '../electron/platform/protocols/builtin-pack
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(projectRoot, '../..');
 const monorepoPackagesDir = path.resolve(projectRoot, '../../packages');
 const monorepoPluginsDir = path.resolve(projectRoot, '../../plugins');
+const buildPluginScript = path.join(repoRoot, 'scripts/build-plugin.mjs');
 const desktopProvidedPluginDeps = new Set(['@sero-ai/common', 'typebox']);
 
 const shared = {
@@ -49,8 +51,23 @@ function runCommand(command, args, cwd) {
   }
 }
 
-function stagePluginRuntimeDependencies(srcDir, destDir) {
+function readPackageJson(srcDir) {
   const packageJsonPath = path.join(srcDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) return null;
+  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+}
+
+function shouldBundlePackageExtensions(pkg) {
+  return pkg?.sero?.plugin?.bundleExtensions === true;
+}
+
+function buildPluginPackage(srcDir) {
+  runCommand(process.execPath, [buildPluginScript, srcDir], repoRoot);
+  return path.join(srcDir, 'dist/plugin');
+}
+
+function stagePluginRuntimeDependencies(srcDir, destDir, manifestDir = srcDir) {
+  const packageJsonPath = path.join(manifestDir, 'package.json');
   if (!fs.existsSync(packageJsonPath)) return;
 
   const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
@@ -78,6 +95,26 @@ function stagePluginRuntimeDependencies(srcDir, destDir) {
   }
 }
 
+function stagePackageResources(srcDir, destDir) {
+  const pkg = readPackageJson(srcDir);
+  if (shouldBundlePackageExtensions(pkg)) {
+    const builtDir = buildPluginPackage(srcDir);
+    fs.cpSync(builtDir, destDir, { recursive: true });
+    stagePluginRuntimeDependencies(srcDir, destDir, destDir);
+    return;
+  }
+
+  copyIfExists(path.join(srcDir, 'package.json'), path.join(destDir, 'package.json'));
+  copyIfExists(path.join(srcDir, 'README.md'), path.join(destDir, 'README.md'));
+  copyIfExists(path.join(srcDir, 'dist'), path.join(destDir, 'dist'));
+  copyIfExists(path.join(srcDir, 'extension'), path.join(destDir, 'extension'));
+  copyIfExists(path.join(srcDir, 'shared'), path.join(destDir, 'shared'));
+  copyIfExists(path.join(srcDir, 'skills'), path.join(destDir, 'skills'));
+  copyIfExists(path.join(srcDir, 'prompts'), path.join(destDir, 'prompts'));
+  copyIfExists(path.join(srcDir, 'themes'), path.join(destDir, 'themes'));
+  stagePluginRuntimeDependencies(srcDir, destDir);
+}
+
 function stageBuiltinResources() {
   const builtinRoot = path.join(projectRoot, 'dist/electron/builtin');
   const builtinPackagesDest = path.join(builtinRoot, 'packages');
@@ -102,15 +139,7 @@ function stageBuiltinResources() {
     const destDir = path.join(builtinPackagesDest, entry);
     fs.mkdirSync(destDir, { recursive: true });
 
-    copyIfExists(path.join(srcDir, 'package.json'), path.join(destDir, 'package.json'));
-    copyIfExists(path.join(srcDir, 'README.md'), path.join(destDir, 'README.md'));
-    copyIfExists(path.join(srcDir, 'dist'), path.join(destDir, 'dist'));
-    copyIfExists(path.join(srcDir, 'extension'), path.join(destDir, 'extension'));
-    copyIfExists(path.join(srcDir, 'shared'), path.join(destDir, 'shared'));
-    copyIfExists(path.join(srcDir, 'skills'), path.join(destDir, 'skills'));
-    copyIfExists(path.join(srcDir, 'prompts'), path.join(destDir, 'prompts'));
-    copyIfExists(path.join(srcDir, 'themes'), path.join(destDir, 'themes'));
-    stagePluginRuntimeDependencies(srcDir, destDir);
+    stagePackageResources(srcDir, destDir);
   }
 
   for (const entry of pluginEntries) {
@@ -121,15 +150,7 @@ function stageBuiltinResources() {
     const destDir = path.join(builtinPluginsDest, entry);
     fs.mkdirSync(destDir, { recursive: true });
 
-    copyIfExists(path.join(srcDir, 'package.json'), path.join(destDir, 'package.json'));
-    copyIfExists(path.join(srcDir, 'README.md'), path.join(destDir, 'README.md'));
-    copyIfExists(path.join(srcDir, 'dist'), path.join(destDir, 'dist'));
-    copyIfExists(path.join(srcDir, 'extension'), path.join(destDir, 'extension'));
-    copyIfExists(path.join(srcDir, 'shared'), path.join(destDir, 'shared'));
-    copyIfExists(path.join(srcDir, 'skills'), path.join(destDir, 'skills'));
-    copyIfExists(path.join(srcDir, 'prompts'), path.join(destDir, 'prompts'));
-    copyIfExists(path.join(srcDir, 'themes'), path.join(destDir, 'themes'));
-    stagePluginRuntimeDependencies(srcDir, destDir);
+    stagePackageResources(srcDir, destDir);
   }
 
   const templatesSrc = path.join(monorepoPackagesDir, 'templates');

--- a/apps/desktop/scripts/build-electron.mjs
+++ b/apps/desktop/scripts/build-electron.mjs
@@ -3,7 +3,7 @@ import { build } from 'esbuild';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { isBuiltinPackageDir } from '../electron/platform/protocols/builtin-package-detection.js';
+import builtinPackageDetection from '../electron/platform/protocols/builtin-package-detection.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
@@ -12,6 +12,7 @@ const monorepoPackagesDir = path.resolve(projectRoot, '../../packages');
 const monorepoPluginsDir = path.resolve(projectRoot, '../../plugins');
 const buildPluginScript = path.join(repoRoot, 'scripts/build-plugin.mjs');
 const desktopProvidedPluginDeps = new Set(['@sero-ai/common', 'typebox']);
+const { isBuiltinPackageDir } = builtinPackageDetection;
 
 const shared = {
   platform: 'node',
@@ -62,7 +63,7 @@ function shouldBundlePackageExtensions(pkg) {
 }
 
 function buildPluginPackage(srcDir) {
-  runCommand(process.execPath, [buildPluginScript, srcDir], repoRoot);
+  runCommand(process.execPath, [buildPluginScript, srcDir, '--quiet'], repoRoot);
   return path.join(srcDir, 'dist/plugin');
 }
 

--- a/apps/desktop/scripts/build-electron.mjs
+++ b/apps/desktop/scripts/build-electron.mjs
@@ -13,14 +13,15 @@ const monorepoPluginsDir = path.resolve(projectRoot, '../../plugins');
 const buildPluginScript = path.join(repoRoot, 'scripts/build-plugin.mjs');
 const desktopProvidedPluginDeps = new Set(['@sero-ai/common', 'typebox']);
 const { isBuiltinPackageDir } = builtinPackageDetection;
+const electronOutDir = path.join(projectRoot, 'dist/electron');
 
 const shared = {
   platform: 'node',
-  target: 'node20',
+  target: 'node22',
   format: 'esm',
   bundle: true,
   sourcemap: true,
-  external: ['electron', 'node-pty', 'esbuild', '@mariozechner/*', 'typebox', '@google/genai', 'ws', 'discord.js'],
+  external: ['electron', 'node-pty', 'esbuild', '@earendil-works/*', 'typebox', '@google/genai', 'ws', 'discord.js'],
   outdir: 'dist/electron',
   logLevel: 'info',
   // Keep import.meta.url working for ESM dependencies (pi SDK)
@@ -35,6 +36,8 @@ const __dirname = __dirnameFn(__filename);
 `.trim(),
   },
 };
+
+fs.rmSync(electronOutDir, { recursive: true, force: true });
 
 function copyIfExists(src, dest) {
   if (!fs.existsSync(src)) return;

--- a/apps/desktop/scripts/build-electron.mjs
+++ b/apps/desktop/scripts/build-electron.mjs
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(__dirname, '..');
 const monorepoPackagesDir = path.resolve(projectRoot, '../../packages');
 const monorepoPluginsDir = path.resolve(projectRoot, '../../plugins');
+const desktopProvidedPluginDeps = new Set(['@sero-ai/common', 'typebox']);
 
 const shared = {
   platform: 'node',
@@ -53,7 +54,8 @@ function stagePluginRuntimeDependencies(srcDir, destDir) {
   if (!fs.existsSync(packageJsonPath)) return;
 
   const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-  const runtimeDeps = Object.keys(pkg.dependencies ?? {});
+  const runtimeDeps = Object.keys(pkg.dependencies ?? {})
+    .filter((dep) => !desktopProvidedPluginDeps.has(dep));
   if (runtimeDeps.length === 0) return;
 
   const pluginNodeModules = path.join(srcDir, 'node_modules');

--- a/apps/desktop/scripts/build-electron.mjs
+++ b/apps/desktop/scripts/build-electron.mjs
@@ -95,6 +95,21 @@ function stagePluginRuntimeDependencies(srcDir, destDir, manifestDir = srcDir) {
   }
 }
 
+function stagePackageUiResources(pkg, srcDir, destDir) {
+  const uiEntry = typeof pkg?.sero?.app?.ui === 'string'
+    ? pkg.sero.app.ui.trim().replace(/^\.\//, '')
+    : '';
+  if (!uiEntry) return;
+
+  const uiDir = path.dirname(uiEntry);
+  if (uiDir === '.') {
+    copyIfExists(path.join(srcDir, uiEntry), path.join(destDir, uiEntry));
+    return;
+  }
+
+  copyIfExists(path.join(srcDir, uiDir), path.join(destDir, uiDir));
+}
+
 function stagePackageResources(srcDir, destDir) {
   const pkg = readPackageJson(srcDir);
   if (shouldBundlePackageExtensions(pkg)) {
@@ -106,7 +121,7 @@ function stagePackageResources(srcDir, destDir) {
 
   copyIfExists(path.join(srcDir, 'package.json'), path.join(destDir, 'package.json'));
   copyIfExists(path.join(srcDir, 'README.md'), path.join(destDir, 'README.md'));
-  copyIfExists(path.join(srcDir, 'dist'), path.join(destDir, 'dist'));
+  stagePackageUiResources(pkg, srcDir, destDir);
   copyIfExists(path.join(srcDir, 'extension'), path.join(destDir, 'extension'));
   copyIfExists(path.join(srcDir, 'shared'), path.join(destDir, 'shared'));
   copyIfExists(path.join(srcDir, 'skills'), path.join(destDir, 'skills'));

--- a/apps/desktop/scripts/build-release.sh
+++ b/apps/desktop/scripts/build-release.sh
@@ -310,6 +310,8 @@ else
   exit 1
 fi
 
+node scripts/prune-release-artifacts.mjs "$DEPLOY_DIR"
+
 # ── Step 6: Package with electron-builder ────────────────────
 echo "▸ Step 6/6: Packaging with electron-builder..."
 # --publish never: the GitHub `publish` stanza makes electron-builder embed

--- a/apps/desktop/scripts/build-release.sh
+++ b/apps/desktop/scripts/build-release.sh
@@ -273,7 +273,7 @@ node scripts/prepare-packaging.mjs
 # ── Step 5: Create a self-contained deploy bundle ───────────
 # pnpm's isolated node_modules layout makes electron-builder's dependency
 # collector silently drop transitive deps of externalized packages (e.g. the
-# pi SDK's @mariozechner/pi-ai → partial-json/openai/@anthropic-ai/sdk), which
+# pi SDK's @earendil-works/pi-ai → partial-json/openai/@anthropic-ai/sdk), which
 # crashes the packaged app at startup. `pnpm deploy` with a hoisted linker emits
 # a flat, fully-resolved *production* node_modules that electron-builder packages
 # reliably — so we no longer hand-maintain a node_modules allowlist.

--- a/apps/desktop/scripts/prune-release-artifacts.mjs
+++ b/apps/desktop/scripts/prune-release-artifacts.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+
+const deployDir = process.argv[2];
+
+if (!deployDir) {
+  console.error('Usage: node scripts/prune-release-artifacts.mjs <deploy-dir>');
+  process.exit(1);
+}
+
+const webPluginNodeModules = path.join(
+  deployDir,
+  'dist/electron/builtin/plugins/sero-web-plugin/node_modules',
+);
+
+const prunedPaths = [
+  // better-sqlite3 needs lib/ and build/Release at runtime. The SQLite source
+  // tree is only needed before electron-rebuild runs.
+  'better-sqlite3/deps',
+  'better-sqlite3/src',
+  'better-sqlite3/binding.gyp',
+  // Type declarations and repository metadata are not used by packaged Sero.
+  'linkedom/types',
+  'linkedom/.github',
+  'unpdf/dist/types',
+  'unpdf/dist/index.d.cts',
+  'unpdf/dist/index.d.mts',
+  'unpdf/dist/index.d.ts',
+  'unpdf/dist/pdfjs.d.mts',
+  'unpdf/dist/pdfjs.d.ts',
+];
+
+for (const relativePath of prunedPaths) {
+  const target = path.join(webPluginNodeModules, relativePath);
+  if (fs.existsSync(target)) {
+    fs.rmSync(target, { recursive: true, force: true });
+  }
+}
+
+console.log('  Pruned release-only web plugin build artifacts');

--- a/apps/desktop/scripts/prune-release-artifacts.mjs
+++ b/apps/desktop/scripts/prune-release-artifacts.mjs
@@ -14,8 +14,9 @@ const webPluginNodeModules = path.join(
   deployDir,
   'dist/electron/builtin/plugins/sero-web-plugin/node_modules',
 );
+const appNodeModules = path.join(deployDir, 'node_modules');
 
-const prunedPaths = [
+const webPluginPrunedPaths = [
   // better-sqlite3 needs lib/ and build/Release at runtime. The SQLite source
   // tree is only needed before electron-rebuild runs.
   'better-sqlite3/deps',
@@ -32,11 +33,22 @@ const prunedPaths = [
   'unpdf/dist/pdfjs.d.ts',
 ];
 
-for (const relativePath of prunedPaths) {
-  const target = path.join(webPluginNodeModules, relativePath);
-  if (fs.existsSync(target)) {
-    fs.rmSync(target, { recursive: true, force: true });
+const appPrunedPaths = [
+  // The esbuild JS API resolves the platform package binary under @esbuild/*.
+  // The top-level bin copy is a duplicate in packaged Sero.
+  'esbuild/bin/esbuild',
+];
+
+function prunePaths(rootDir, relativePaths) {
+  for (const relativePath of relativePaths) {
+    const target = path.join(rootDir, relativePath);
+    if (fs.existsSync(target)) {
+      fs.rmSync(target, { recursive: true, force: true });
+    }
   }
 }
 
-console.log('  Pruned release-only web plugin build artifacts');
+prunePaths(webPluginNodeModules, webPluginPrunedPaths);
+prunePaths(appNodeModules, appPrunedPaths);
+
+console.log('  Pruned release-only package artifacts');

--- a/apps/desktop/src/components/layout/auth/AuthLoginDialog.tsx
+++ b/apps/desktop/src/components/layout/auth/AuthLoginDialog.tsx
@@ -27,6 +27,7 @@ import {
   AuthenticatingView,
   PromptView,
   ResultView,
+  SelectView,
   WaitingView,
 } from './auth-login-views/AuthFlowViews';
 import { ProviderListView } from './auth-login-views/ProviderListView';
@@ -36,6 +37,7 @@ import { ProviderListView } from './auth-login-views/ProviderListView';
 type DialogPhase =
   | 'providers'       // Provider list (initial)
   | 'authenticating'  // Browser opened, waiting for OAuth
+  | 'select'          // Waiting for user selection (OAuth)
   | 'prompt'          // Waiting for user text input (OAuth)
   | 'manual_input'    // Waiting for redirect URL paste (OAuth)
   | 'waiting'         // Polling (e.g. GitHub Copilot)
@@ -70,6 +72,7 @@ export function AuthLoginDialog({
   const [selectedProviderName, setSelectedProviderName] = useState('');
   const [authUrl, setAuthUrl] = useState<string | null>(null);
   const [promptMessage, setPromptMessage] = useState('');
+  const [selectOptions, setSelectOptions] = useState<Array<{ id: string; label: string }>>([]);
   const [promptPlaceholder, setPromptPlaceholder] = useState('');
   const [inputValue, setInputValue] = useState('');
   const [statusMessage, setStatusMessage] = useState('');
@@ -137,6 +140,11 @@ export function AuthLoginDialog({
           setInputValue('');
           setPhase('prompt');
           break;
+        case 'select':
+          setPromptMessage(event.message);
+          setSelectOptions(event.options);
+          setPhase('select');
+          break;
         case 'manual_input':
           setPromptMessage(event.prompt);
           setInputValue('');
@@ -177,7 +185,7 @@ export function AuthLoginDialog({
   // ── Cancel on close ─────────────────────────────────────────
   const handleOpenChange = useCallback(
     (next: boolean) => {
-      if (!next && (phase === 'authenticating' || phase === 'prompt' || phase === 'manual_input' || phase === 'waiting')) {
+      if (!next && ['authenticating', 'prompt', 'select', 'manual_input', 'waiting'].includes(phase)) {
         window.sero.auth.cancel();
       }
       onOpenChange(next);
@@ -219,6 +227,12 @@ export function AuthLoginDialog({
     setInputValue('');
     setPhase('authenticating');
   }, [inputValue]);
+
+  const handleSelectOption = useCallback((value: string) => {
+    window.sero.auth.respondSelect(value);
+    setSelectOptions([]);
+    setPhase('authenticating');
+  }, []);
 
   const handleOAuthCancel = useCallback(() => {
     window.sero.auth.cancel();
@@ -314,6 +328,15 @@ export function AuthLoginDialog({
 
           {phase === 'waiting' && (
             <WaitingView message={statusMessage} onCancel={handleOAuthCancel} />
+          )}
+
+          {phase === 'select' && (
+            <SelectView
+              message={promptMessage}
+              options={selectOptions}
+              onSelect={handleSelectOption}
+              onCancel={handleOAuthCancel}
+            />
           )}
 
           {(phase === 'prompt' || phase === 'manual_input') && (

--- a/apps/desktop/src/components/layout/auth/auth-login-views/AuthFlowViews.tsx
+++ b/apps/desktop/src/components/layout/auth/auth-login-views/AuthFlowViews.tsx
@@ -115,6 +115,40 @@ export function PromptView({
   );
 }
 
+export function SelectView({
+  message,
+  options,
+  onSelect,
+  onCancel,
+}: {
+  message: string;
+  options: Array<{ id: string; label: string }>;
+  onSelect: (value: string) => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm">{message}</p>
+      <div className="space-y-2">
+        {options.map((option) => (
+          <Button
+            key={option.id}
+            variant="outline"
+            size="sm"
+            onClick={() => onSelect(option.id)}
+            className="w-full justify-start"
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+      <Button variant="ghost" size="sm" onClick={onCancel} className="w-full">
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
 export function ApiKeyEntryView({
   providerName,
   value,

--- a/apps/desktop/src/types/agent.ts
+++ b/apps/desktop/src/types/agent.ts
@@ -5,7 +5,7 @@
  * Re-exported from ipc.ts so existing imports continue to work.
  */
 
-import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
 import type { ChatComposerPrefill, ChatTurnUndoRef } from './turn-undo';
 
 // ── Chat Messages ──────────────────────────────────────────────

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -169,6 +169,8 @@ interface SeroAuthAPI {
   removeApiKey(providerId: string): Promise<void>;
   /** Respond to a pending prompt during login. */
   respondPrompt(value: string): Promise<void>;
+  /** Respond to a pending selection during login. */
+  respondSelect(value: string): Promise<void>;
   /** Respond to a pending manual code input during login. */
   respondManualCode(value: string): Promise<void>;
   /** Cancel in-progress login. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -150,6 +150,8 @@ export const IpcChannels = {
     removeApiKey: 'sero:auth:remove-api-key',
     /** Respond to a pending prompt during login. */
     respondPrompt: 'sero:auth:respond-prompt',
+    /** Respond to a pending selection during login. */
+    respondSelect: 'sero:auth:respond-select',
     /** Respond to a pending manual code input during login. */
     respondManualCode: 'sero:auth:respond-manual-code',
     /** Cancel in-progress login. */

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -370,21 +370,16 @@ export type {
   OnboardingState,
 } from './onboarding';
 
-/**
- * Events pushed from main → renderer during an OAuth login flow.
- * The renderer dialog reacts to each event to update its UI state.
- */
 export type OAuthEvent =
   | { type: 'auth'; url: string; instructions?: string }
   | { type: 'prompt'; message: string; placeholder?: string }
+  | { type: 'select'; message: string; options: Array<{ id: string; label: string }> }
   | { type: 'manual_input'; prompt: string }
   | { type: 'waiting'; message: string }
   | { type: 'progress'; message: string }
   | { type: 'success'; provider: string; message: string }
   | { type: 'error'; provider: string; message: string }
   | { type: 'cancelled' };
-
-// ── Response + User Feedback ───────────────────────────────────
 
 export type {
   ResponseFeedbackEntry,
@@ -395,8 +390,6 @@ export type {
   UserFeedbackAnswer,
   UserFeedbackResponse,
 } from './user-feedback';
-
-// ── Net Proxy ──────────────────────────────────────────────────
 
 /** Request payload for sero:net:fetch (main-process HTTP proxy). */
 export interface ProxyFetchRequest {

--- a/apps/desktop/src/types/local-models.ts
+++ b/apps/desktop/src/types/local-models.ts
@@ -5,7 +5,7 @@
  * Shared by Electron main process and renderer.
  */
 
-import type { OpenAICompletionsCompat, ThinkingLevelMap } from '@mariozechner/pi-ai';
+import type { OpenAICompletionsCompat, ThinkingLevelMap } from '@earendil-works/pi-ai';
 
 /** Supported API types for local model providers. */
 export type LocalModelApi =

--- a/apps/desktop/src/types/model-tiers.ts
+++ b/apps/desktop/src/types/model-tiers.ts
@@ -1,4 +1,4 @@
-import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
 import type { ModelValidationWarning } from '@sero-ai/common';
 
 /** Model tier levels for user-configured defaults. */

--- a/apps/desktop/src/types/sero-apps.ts
+++ b/apps/desktop/src/types/sero-apps.ts
@@ -1,4 +1,4 @@
-import type { PackageSource } from '@mariozechner/pi-coding-agent';
+import type { PackageSource } from '@earendil-works/pi-coding-agent';
 import type {
   PluginCompatibilityStatus,
   PluginMeta,

--- a/apps/desktop/src/types/skills.ts
+++ b/apps/desktop/src/types/skills.ts
@@ -2,7 +2,7 @@
  * Skill IPC types — shared by Electron main process and renderer.
  *
  * Based on the Pi SDK's `Skill` and `SkillFrontmatter` types from
- * `@mariozechner/pi-coding-agent/core/skills`.
+ * `@earendil-works/pi-coding-agent/core/skills`.
  */
 
 /** Skill source — matches the SDK's source identifiers. */

--- a/apps/desktop/tsconfig.electron.json
+++ b/apps/desktop/tsconfig.electron.json
@@ -21,8 +21,8 @@
       "@plugins/*": ["../../plugins/*"],
       "@packages/*": ["../../packages/*"],
       "@sero-ai/common": ["../../packages/common/src/index.ts"],
-      // Pi 0.72.1 exports this subpath, but moduleResolution:node still needs this mapping.
-      "@mariozechner/pi-ai/oauth": ["./node_modules/@mariozechner/pi-ai/dist/oauth"]
+      // Pi exports this subpath, but moduleResolution:node still needs this mapping.
+      "@earendil-works/pi-ai/oauth": ["./node_modules/@earendil-works/pi-ai/dist/oauth"]
     }
   },
   "include": ["electron/**/*", "src/types/ipc.ts", "src/types/ipc-channels.ts"],

--- a/apps/web-remote/src/components/Layout.tsx
+++ b/apps/web-remote/src/components/Layout.tsx
@@ -20,7 +20,7 @@ import { useArtifactStore } from '@/stores/artifacts';
 import { useDevServerStore } from '@/stores/dev-servers';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { Button } from '@sero-ai/ui/components/ui/button';
-import { cn } from '@sero-ai/ui';
+import { cn } from '@sero-ai/ui/lib/utils';
 import { useIsMobile } from '@sero-ai/ui/hooks/use-mobile';
 import {
   Sheet,

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -57,7 +57,7 @@ Will integrate with Pi agent session via Vercel AI SDK `useChat` hook.
 | Main     | esbuild | `electron/main.ts`   | `dist/electron/main.mjs`  | ESM    |
 | Preload  | esbuild | `electron/preload.ts`| `dist/electron/preload.js`| CJS    |
 
-Preload must be CJS. `electron`, `node-pty`, `@mariozechner/*` are external.
+Preload must be CJS. `electron`, `node-pty`, `@earendil-works/*` are external.
 `scripts/dev.sh` starts Vite first, waits for :5173, then launches Electron.
 
 ## AD-008: Preload API (`window.sero`)

--- a/docs/deslopify/apps/desktop/electron/features/agent/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/agent/facts.md
@@ -14,7 +14,7 @@ PR draft prompt/parsing helpers (`pr-draft.ts`), and OpenAI voice transcription
 - Largest file: `apps/desktop/electron/features/agent/assistants/voice-transcription.ts` (219 LOC)
 - Files over 500 LOC: none
 - External dependencies of note:
-  - Pi SDK session creation (`@mariozechner/pi-coding-agent`)
+  - Pi SDK session creation (`@earendil-works/pi-coding-agent`)
   - provider SDK clients (`@google/genai`, OpenAI HTTP API)
   - shared infra model/auth access
 - Upstream callers:

--- a/docs/deslopify/apps/desktop/electron/features/apps/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/apps/facts.md
@@ -11,7 +11,7 @@ This folder owns app/runtime glue in Electron main for Sero apps: app manifest d
 - Largest file: `apps/desktop/electron/features/apps/discovery/index.ts` (312 LOC)
 - Files over 500 LOC: none
 - External dependencies of note:
-  - Pi SDK extension APIs (`@mariozechner/pi-coding-agent`)
+  - Pi SDK extension APIs (`@earendil-works/pi-coding-agent`)
   - Electron `BrowserWindow` fanout in app-state change broadcaster
   - Workspace/container/subagent managers from Electron feature layer
   - Plugin-package internals from `@plugins/sero-admin-plugin` and `@plugins/sero-git-plugin`

--- a/docs/deslopify/apps/desktop/electron/features/subagent/facts.md
+++ b/docs/deslopify/apps/desktop/electron/features/subagent/facts.md
@@ -10,7 +10,7 @@ This feature is Sero's AD-021 subagent runtime. It discovers markdown-defined ag
 - Largest file: `apps/desktop/electron/features/subagent/index.ts` (491 LOC)
 - Files over 500 LOC: none
 - Near-cap files (≥400 LOC): `apps/desktop/electron/features/subagent/index.ts` (491)
-- External dependencies of note: `@mariozechner/pi-coding-agent`, `@mariozechner/pi-agent-core`, TypeBox, container tools, shared infra/model registry, `SERO_AGENT_DIR`
+- External dependencies of note: `@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`, TypeBox, container tools, shared infra/model registry, `SERO_AGENT_DIR`
 - Upstream callers: `apps/desktop/electron/shared/infra/shared-infra.ts`, `apps/desktop/electron/features/apps/extensions/create-sero-extension.ts`, kanban implementation/planning/review executors, IPC subagent handlers, collaboration flows, subagent tests
 - Downstream dependencies: child-session prompt construction, tracker snapshots/events in renderer UI, container/host coding tool selection, agent-definition authoring under `~/.sero-ui/agent/agents/`
 

--- a/docs/deslopify/apps/desktop/electron/ipc/facts.md
+++ b/docs/deslopify/apps/desktop/electron/ipc/facts.md
@@ -17,7 +17,7 @@ VCS, collaboration, and platform UI services.
   - `apps/desktop/electron/ipc/agent/core/agent.ts` (498)
   - `apps/desktop/electron/ipc/agent/core/agent-helpers.ts` (453)
 - External dependencies of note:
-  - Pi SDK session/runtime (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-agent-core`)
+  - Pi SDK session/runtime (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-agent-core`)
   - shared infra singletons (`@electron/shared/infra/shared-infra`)
   - workspace/container systems (AD-018 paths)
   - gateway/subagent bridges (AD-021)

--- a/docs/deslopify/apps/desktop/electron/types/facts.md
+++ b/docs/deslopify/apps/desktop/electron/types/facts.md
@@ -16,7 +16,7 @@ subagent runtime uses to append markdown-defined agent instructions.
 - Upstream callers / consumers of note:
   - `apps/desktop/electron/features/subagent/runtime/runner.ts:191-202`
 - External dependencies of note:
-  - `@mariozechner/pi-coding-agent` module augmentation only
+  - `@earendil-works/pi-coding-agent` module augmentation only
 
 ## Architectural notes
 - This folder is not a general-purpose desktop types bucket; it is currently a

--- a/docs/deslopify/apps/desktop/electron/types/plan.md
+++ b/docs/deslopify/apps/desktop/electron/types/plan.md
@@ -22,7 +22,7 @@ upstream package exposes the option natively.
    - Keep future additions package-specific and minimal.
 
 2. **Check upstream before touching it during future SDK upgrades.**
-   - If `@mariozechner/pi-coding-agent` gains native `systemPromptSuffix`
+   - If `@earendil-works/pi-coding-agent` gains native `systemPromptSuffix`
      support, delete the local augmentation instead of keeping duplicate typing.
    - If the upstream option shape changes, update this augmentation and the
      subagent runner in the same pass.
@@ -42,7 +42,7 @@ upstream package exposes the option natively.
 
 ## Next Steps
 1. ~~Mark this target as reviewed and move on to the heavier Wave A seams.~~ ✅ 2026-04-14 (`c7452f4d`)
-2. Revisit it only when upgrading `@mariozechner/pi-coding-agent` or changing
+2. Revisit it only when upgrading `@earendil-works/pi-coding-agent` or changing
    the subagent session-construction path.
 
 Verification checklist for future changes:

--- a/docs/deslopify/apps/desktop/src/types/facts.md
+++ b/docs/deslopify/apps/desktop/src/types/facts.md
@@ -22,7 +22,7 @@ consumed by both renderer stores/components and Electron preload/main modules.
   - `IpcChannels` imported from `@/types/ipc` (not `@/types/ipc-channels`) in 59 files
 - Downstream dependencies of note:
   - `@sero-ai/common` (plugin/model validation contracts)
-  - `@mariozechner/pi-agent-core` and `@mariozechner/pi-ai` (model/thinking + local model compat)
+  - `@earendil-works/pi-agent-core` and `@earendil-works/pi-ai` (model/thinking + local model compat)
   - `@electron/features/container/core/types` re-exported as canonical `ContainerInfo`
   - `react-grid-layout` and `react` for dashboard/widget typing
 

--- a/docs/deslopify/packages/common/src/facts.md
+++ b/docs/deslopify/packages/common/src/facts.md
@@ -17,7 +17,7 @@ used by onboarding, model configuration UIs, and agent model availability flows.
 - Near-cap files (≥390 LOC):
   - `packages/common/src/model-selection.ts` (396)
 - External dependencies of note:
-  - `@mariozechner/pi-agent-core` — `ThinkingLevel` type only
+  - `@earendil-works/pi-agent-core` — `ThinkingLevel` type only
 - Upstream callers / consumers of note:
   - `apps/desktop/src/components/layout/model-config.ts`
   - `apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx`

--- a/docs/deslopify/plugins/sero-git-plugin/facts.md
+++ b/docs/deslopify/plugins/sero-git-plugin/facts.md
@@ -17,7 +17,7 @@ _Last reviewed: 2026-04-13_
   - `plugins/sero-git-plugin/extension/git-service.ts` (457 LOC)
   - `plugins/sero-git-plugin/ui/components/BranchPanel.tsx` (421 LOC)
 - External dependencies of note:
-  - Pi extension/runtime APIs (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-tui`, `@mariozechner/pi-ai`)
+  - Pi extension/runtime APIs (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `@earendil-works/pi-ai`)
   - Git CLI via `execFileSync` / `execFile`
   - `@sero-ai/app-runtime` for file-backed plugin state and the `window.sero` bridge
   - Module Federation + Vite for the remote UI (`vite.config.ts` uses production `base: './'` correctly)

--- a/docs/deslopify/plugins/sero-google-plugin/facts.md
+++ b/docs/deslopify/plugins/sero-google-plugin/facts.md
@@ -13,7 +13,7 @@ _Last reviewed: 2026-04-18_
 - Near-cap files (≥400 LOC): none
 - Test surface: none — no plugin-local `*test*` files are present today
 - External dependencies of note:
-  - Pi extension/runtime APIs (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-ai`, `@mariozechner/pi-tui`)
+  - Pi extension/runtime APIs (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui`)
   - `@sero-ai/app-runtime` file-backed state bridge (`packages/app-runtime/src/use-app-state.ts:19-99`)
   - gogcli / `gog` on the host machine
   - Google OAuth endpoints + localhost loopback callback server

--- a/docs/deslopify/plugins/sero-kanban-plugin/facts.md
+++ b/docs/deslopify/plugins/sero-kanban-plugin/facts.md
@@ -15,7 +15,7 @@ _Last reviewed: 2026-04-13_
   - `plugins/sero-kanban-plugin/ui/components/DescriptionEditor.tsx` (405)
   - `plugins/sero-kanban-plugin/ui/components/ActivityPanel.tsx` (393)
 - External dependencies of note:
-  - Pi extension/runtime APIs (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-tui`)
+  - Pi extension/runtime APIs (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`)
   - `@sinclair/typebox` for the bridged `kanban` tool schema
   - `@sero-ai/app-runtime` for file-backed plugin state, AI hooks, and agent prompting
   - `motion/react` for the federated UI and widget

--- a/docs/deslopify/plugins/sero-memory-plugin/facts.md
+++ b/docs/deslopify/plugins/sero-memory-plugin/facts.md
@@ -17,7 +17,7 @@ _Last reviewed: 2026-04-13_
   - `plugins/sero-memory-plugin/extension/consolidation.ts` (335)
   - `plugins/sero-memory-plugin/extension/migration.ts` (334)
 - External dependencies of note:
-  - Pi SDK extension/session APIs (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-ai`, `@mariozechner/pi-tui`)
+  - Pi SDK extension/session APIs (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui`)
   - `@tobilu/qmd` for ranked search/indexing
   - `date-fns` for date formatting
   - Global Sero workspace files under `SERO_HOME/workspaces/global`

--- a/docs/deslopify/plugins/sero-signal-desk-plugin/facts.md
+++ b/docs/deslopify/plugins/sero-signal-desk-plugin/facts.md
@@ -16,7 +16,7 @@ _Last reviewed: 2026-05-03_
   - `ui/styles.css` (1,345 LOC)
   - `ui/SignalDeskApp.tsx` (729 LOC)
 - External dependencies of note:
-  - Pi extension APIs (`@mariozechner/pi-coding-agent`, `@mariozechner/pi-ai`, `@mariozechner/pi-tui`)
+  - Pi extension APIs (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui`)
   - `@sero-ai/common` runtime contracts
   - `@sero-ai/app-runtime` declared for UI/runtime integration, though the current UI bypasses the hooks
   - `fast-xml-parser` for RSS/Atom parsing

--- a/docs/deslopify/plugins/sero-user-feedback-plugin/facts.md
+++ b/docs/deslopify/plugins/sero-user-feedback-plugin/facts.md
@@ -10,7 +10,7 @@ _Last reviewed: 2026-04-13_
 - Largest file: `plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.tsx` (469 LOC)
 - Files over 500 LOC: none
 - Near-cap / hotspot files: `ui/QuestionnaireForm.tsx` (469), `extension/tui-questionnaire.ts` (416), `extension/index.ts` (339)
-- External dependencies of note: Pi SDK + `@mariozechner/pi-tui`, `@sinclair/typebox`, React, `@sero-ai/app-runtime`, `@sero-ai/ui`, `lucide-react`
+- External dependencies of note: Pi SDK + `@earendil-works/pi-tui`, `@sinclair/typebox`, React, `@sero-ai/app-runtime`, `@sero-ai/ui`, `lucide-react`
 - Upstream callers: Pi session resource loading loads `extension/index.ts`; Sero app/plugin discovery loads `UserFeedbackApp` via the manifest remote; desktop tests import the plugin UI/types directly
 - Downstream dependencies: `window.sero.userFeedback` + `window.sero.profiles` preload bridges, `apps/desktop/electron/ipc/platform/ui/user-feedback-questions.ts`, `apps/desktop/electron/shared/lib/user-feedback-bus.ts`, `apps/desktop/src/types/user-feedback.ts`, renderer user-feedback store/notice flows
 

--- a/docs/features/environment-doctor.md
+++ b/docs/features/environment-doctor.md
@@ -91,7 +91,7 @@ The engine module **must not** import:
 
 - anything under `electron/features/` other than its own subtree
 - anything under `electron/ipc/`
-- `electron`, `node-pty`, `better-sqlite3`, `@mariozechner/pi-*` SDKs,
+- `electron`, `node-pty`, `better-sqlite3`, `@earendil-works/pi-*` SDKs,
   `@google/genai`, `@anthropic-ai/sdk`, etc.
 
 The engine **may** import:

--- a/docs/features/sero-apps.md
+++ b/docs/features/sero-apps.md
@@ -190,7 +190,7 @@ A simplified pattern:
 ```ts
 import path from 'path';
 import { promises as fs } from 'fs';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from '@sinclair/typebox';
 
 export default function (pi: ExtensionAPI) {

--- a/docs/optimise-deps.md
+++ b/docs/optimise-deps.md
@@ -1,0 +1,106 @@
+Sero Desktop — Release Packaging Continuation
+
+I'm picking up after a session that fixed a broken v0.2.0-beta.0 macOS DMG (it installed but did nothing on launch). The fix shipped as v0.2.1-beta.0 (now Latest). I want you to dig deeper on further bundle-size reduction — but first, here's what's already been done and verified so you don't re-litigate it.
+
+Repo
+
+  - /Users/danielcarter/Documents/Dev/projects/sero/sero — pnpm monorepo (pinned pnpm@10.33.4), Electron desktop app in apps/desktop.
+  - Renderer: vite + module-federation, fully bundled. Main: esbuild bundled with a small external set declared in apps/desktop/scripts/build-electron.mjs: external: ['electron', 'node-pty', 'esbuild', '@mariozechner/*', 'typebox', '@google/genai', 'ws', 'discord.js']
+  - Release entry: apps/desktop/scripts/build-release.sh, config: apps/desktop/electron-builder.yml, CI: .github/workflows/release.yml.
+
+  Root cause that was fixed (don't re-investigate)
+
+  b9ef7e095 bumped the pi SDK catalog ^0.72.1 → ^0.73.1. pi-ai's deps are byte-identical between those versions, but the lockfile rewrite/peer-hash change moved pi-ai's transitive runtime closure (partial-json, openai, @anthropic-ai/sdk, @aws-sdk/client-bedrock-runtime, @mistralai/mistralai, proxy-agent, zod-to-json-schema) into a nested .pnpm location that the old electron-builder files allowlist silently stopped collecting. Result: ERR_MODULE_NOT_FOUND at startup, window never shows. The recurring chalk/ansi-styles/cli-highlight allowlist entries in old configs were the same bug being whack-a-moled.
+
+  Fix that shipped (treat as load-bearing — don't undo)
+
+  1. Package from pnpm deploy bundle (build-release.sh): hoisted pnpm deploy --prod into .package-deploy/ with
+  NPM_CONFIG_INJECT_WORKSPACE_PACKAGES=true, rebuild natives there, run electron-builder --projectDir <bundle> with a pinned electronVersion (since electron is
+  a stripped devDep). HUSKY=0 keeps the deploy from re-running git-hook setup. Do not use --legacy: pnpm v10's legacy deploy path ignores the workspace
+  lockfile and can package newer semver-compatible runtime deps than the tested frozen install.
+  2. Removed the node_modules/* allowlist from electron-builder.yml and the workspace/cli-highlight materialization hacks from prepare-packaging.mjs. The flat
+  deploy resolves per-consumer versions correctly (pi-ai gets its declared nested chalk@5.6.2; cli-highlight gets nested chalk@4.1.2). Never reintroduce that
+  allowlist — it short-circuits transitive collection in pnpm's isolated layout.
+  3. Reclassified renderer/build-only packages as devDependencies in apps/desktop/package.json, leaving only the esbuild externals + a few small runtime modules
+  as dependencies. Adding a renderer/build package back to dependencies regresses the size (monaco-editor 98M + mermaid 76M + lucide-react 44M +
+  @module-federation→@rspack/tsx).
+
+  Memory: ~/.claude/projects/-Users-danielcarter-Documents-Dev-projects-sero-sero/memory/release-packaging-pnpm-deploy.md has the rule.
+
+  Verified current state (v0.2.1-beta.0, signed/notarized, installs + launches on macOS arm64)
+
+  ┌────────────────────────┬───────────────────────────┬────────────────────────┐
+  │                        │ Old broken (0.2.0-beta.0) │ Current (0.2.1-beta.0) │
+  ├────────────────────────┼───────────────────────────┼────────────────────────┤
+  │ app.asar               │ 264 M                     │ 152 M                  │
+  ├────────────────────────┼───────────────────────────┼────────────────────────┤
+  │ app.asar.unpacked      │ 91 M                      │ 54 M                   │
+  ├────────────────────────┼───────────────────────────┼────────────────────────┤
+  │ mac DMG                │ 202 M (crashed)           │ 157 M (launches)       │
+  ├────────────────────────┼───────────────────────────┼────────────────────────┤
+  │ Pi SDK runtime closure │ ❌ missing                │ ✅ complete            │
+  └────────────────────────┴───────────────────────────┴────────────────────────┘
+
+  Lean deploy bundle node_modules is 311 M (down from 790 M pre-reclassification).
+
+  Top remaining size in the lean deploy node_modules — investigate these
+
+   62M  node-pty               # native; ships prebuilds for win32-x64, win32-arm64, darwin-x64, darwin-arm64
+   28M  koffi                  # native FFI; transitive — find who pulls it
+   25M  @mariozechner          # pi SDK; .ts sources retained ("loaded via jiti at runtime" per electron-builder.yml comment)
+   22M  @mistralai/mistralai   } the pi-ai provider SDKs — all four
+   13M  openai                 } are listed unconditionally as
+  6.6M  @aws-sdk/*             } pi-ai dependencies and pi-ai is
+  6.4M  @anthropic-ai/sdk      } external, so esbuild can't tree-shake them
+   10M  esbuild + @esbuild/darwin-arm64   # runtime external (plugin transpilation)
+  8.7M  web-streams-polyfill   # large; check transitive origin
+  6.4M  discord-api-types      # transitive of discord.js
+  6.3M  zod                    # check for duplicates / peer dedup
+  5.8M  typebox                # runtime external
+  5.8M  @modelcontextprotocol/sdk
+
+  Concrete things to investigate (ordered by likely payoff)
+
+  1. Strip cross-platform prebuilds. node-pty (and possibly koffi) carry prebuilds for all four OS/arch combos. On a macOS-arm64 build, ~75% of node-pty's 62 M is
+   dead weight (win32 + darwin-x64). Investigate electron-builder's mac/linux/win prebuild handling, or add an afterPack step that deletes non-target prebuilds/* under app.asar.unpacked/node_modules/node-pty/. Same for any other native module that ships fat prebuilds.
+  2. koffi 28 M — who depends on it, and is it actually used at runtime? Run pnpm why koffi from apps/desktop. If it's a transitive of a single feature, see if that feature can be deferred or its dependency relaxed. If it's used, multi-platform binaries are the trim target (same approach as node-pty).
+  3. Provider SDK reduction. pi-ai 0.73.1 declares all four provider SDKs (@aws-sdk/client-bedrock-runtime, @mistralai/mistralai, openai, @anthropic-ai/sdk) as hard dependencies (~48 M combined). Two angles:
+    - Check if pi-ai upstream supports optional/peer provider deps; if so, omit unused ones.
+    - If pi-ai must keep them, see whether @aws-sdk/client-bedrock-runtime can be replaced with the lighter aws4/raw HTTPS path (the AWS SDK has huge @smithy/*
+  transitives).
+  4. @mariozechner 25 M includes .ts sources. electron-builder.yml keeps .ts because Pi extensions are loaded via jiti at runtime under dist/electron/builtin/.
+  Verify whether the external @mariozechner/* packages in node_modules also need their .ts retained, or if only the dist/electron/builtin/** staged copies do — if
+   the latter, the node_modules .ts files can be excluded.
+  5. asar.unpacked is 54 M — audit what's in it. Currently only node-pty is unpacked. Confirm nothing else got unpacked accidentally and that node-pty's unpack is
+   darwin-arm64-only.
+  6. Per-plugin better-sqlite3 situation. It's a per-plugin runtime external staged under
+  dist/electron/builtin/plugins/sero-web-plugin/node_modules/better-sqlite3 (via stagePluginRuntimeDependencies in build-electron.mjs). Its .node lives inside the
+   asar — asarUnpack doesn't currently cover that path. This is pre-existing (the broken release had the same issue), and out of scope for the size fix, but worth
+   a follow-up to confirm sqlite-using plugins actually work in the packaged app.
+  7. web-streams-polyfill and discord-api-types — large transitives. If they're only needed by a non-essential code path, see if the path itself can be removed or
+   lazy-loaded.
+
+  Useful local commands
+
+  # Reproduce the deploy bundle locally to size-audit (don't commit anything from this)
+  HUSKY=0 NPM_CONFIG_NODE_LINKER=hoisted NPM_CONFIG_INJECT_WORKSPACE_PACKAGES=true \
+    pnpm --filter @sero/desktop deploy --prod /tmp/audit-deploy
+  du -sh /tmp/audit-deploy/node_modules/* | sort -rh | head -30
+
+  # Full release build (mac, unsigned, --dir for fast iteration)
+  pnpm --filter @sero/desktop pack:mac
+
+  # Why is package X in the prod tree?
+  pnpm --filter @sero/desktop why <package>
+
+  Caveats / env quirks (don't get bitten)
+
+  - Volta shadows the pinned pnpm. Interactive shells get pnpm 10.33.4 via corepack; background processes have picked up volta's 10.14.0, which previously
+  corrupted package.json (overwrote it with ansi-styles' contents) and rewrote pnpm-lock.yaml. Verify pnpm --version is 10.33.4 before any install/release
+  operation. Memory: ~/.claude/projects/.../memory/local-pnpm-volta-shadow.md.
+  - The v0.2.1-beta.0 tag sits on the original fix-branch lineage (53edbc065), not on main's squash-merge commit (72184f04c). Functionally identical content; the
+  user accepted this. Don't try to "fix" the history.
+  - Don't run pnpm install non-frozen unless you know why — frozen-lockfile is what keeps the build deterministic.
+
+  Start by reproducing the lean deploy locally, then dig into items 1–3 above (prebuild stripping is the most mechanical win; provider SDK reduction is the most
+  upstream and likely the highest payoff if pi-ai can be persuaded to make providers optional).

--- a/docs/optimise-deps.md
+++ b/docs/optimise-deps.md
@@ -5,7 +5,7 @@ I'm picking up after a session that fixed a broken v0.2.0-beta.0 macOS DMG (it i
 Repo
 
   - /Users/danielcarter/Documents/Dev/projects/sero/sero — pnpm monorepo (pinned pnpm@10.33.4), Electron desktop app in apps/desktop.
-  - Renderer: vite + module-federation, fully bundled. Main: esbuild bundled with a small external set declared in apps/desktop/scripts/build-electron.mjs: external: ['electron', 'node-pty', 'esbuild', '@mariozechner/*', 'typebox', '@google/genai', 'ws', 'discord.js']
+  - Renderer: vite + module-federation, fully bundled. Main: esbuild bundled with a small external set declared in apps/desktop/scripts/build-electron.mjs: external: ['electron', 'node-pty', 'esbuild', '@earendil-works/*', 'typebox', '@google/genai', 'ws', 'discord.js']
   - Release entry: apps/desktop/scripts/build-release.sh, config: apps/desktop/electron-builder.yml, CI: .github/workflows/release.yml.
 
   Root cause that was fixed (don't re-investigate)
@@ -46,8 +46,7 @@ Repo
   Top remaining size in the lean deploy node_modules — investigate these
 
    62M  node-pty               # native; ships prebuilds for win32-x64, win32-arm64, darwin-x64, darwin-arm64
-   28M  koffi                  # native FFI; transitive — find who pulls it
-   25M  @mariozechner          # pi SDK; .ts sources retained ("loaded via jiti at runtime" per electron-builder.yml comment)
+   25M  @earendil-works        # pi SDK; .ts sources retained ("loaded via jiti at runtime" per electron-builder.yml comment)
    22M  @mistralai/mistralai   } the pi-ai provider SDKs — all four
    13M  openai                 } are listed unconditionally as
   6.6M  @aws-sdk/*             } pi-ai dependencies and pi-ai is
@@ -61,17 +60,16 @@ Repo
 
   Concrete things to investigate (ordered by likely payoff)
 
-  1. Strip cross-platform prebuilds. node-pty (and possibly koffi) carry prebuilds for all four OS/arch combos. On a macOS-arm64 build, ~75% of node-pty's 62 M is
+  1. Strip cross-platform prebuilds. node-pty carries prebuilds for all four OS/arch combos. On a macOS-arm64 build, ~75% of node-pty's 62 M is
    dead weight (win32 + darwin-x64). Investigate electron-builder's mac/linux/win prebuild handling, or add an afterPack step that deletes non-target prebuilds/* under app.asar.unpacked/node_modules/node-pty/. Same for any other native module that ships fat prebuilds.
-  2. koffi 28 M — who depends on it, and is it actually used at runtime? Run pnpm why koffi from apps/desktop. If it's a transitive of a single feature, see if that feature can be deferred or its dependency relaxed. If it's used, multi-platform binaries are the trim target (same approach as node-pty).
-  3. Provider SDK reduction. pi-ai 0.73.1 declares all four provider SDKs (@aws-sdk/client-bedrock-runtime, @mistralai/mistralai, openai, @anthropic-ai/sdk) as hard dependencies (~48 M combined). Two angles:
+  2. Provider SDK reduction. pi-ai 0.73.1 declares all four provider SDKs (@aws-sdk/client-bedrock-runtime, @mistralai/mistralai, openai, @anthropic-ai/sdk) as hard dependencies (~48 M combined). Two angles:
     - Check if pi-ai upstream supports optional/peer provider deps; if so, omit unused ones.
     - If pi-ai must keep them, see whether @aws-sdk/client-bedrock-runtime can be replaced with the lighter aws4/raw HTTPS path (the AWS SDK has huge @smithy/*
   transitives).
-  4. @mariozechner 25 M includes .ts sources. electron-builder.yml keeps .ts because Pi extensions are loaded via jiti at runtime under dist/electron/builtin/.
-  Verify whether the external @mariozechner/* packages in node_modules also need their .ts retained, or if only the dist/electron/builtin/** staged copies do — if
+  3. @earendil-works 25 M includes .ts sources. electron-builder.yml keeps .ts because Pi extensions are loaded via jiti at runtime under dist/electron/builtin/.
+  Verify whether the external @earendil-works/* packages in node_modules also need their .ts retained, or if only the dist/electron/builtin/** staged copies do — if
    the latter, the node_modules .ts files can be excluded.
-  5. asar.unpacked is 54 M — audit what's in it. Currently only node-pty is unpacked. Confirm nothing else got unpacked accidentally and that node-pty's unpack is
+  4. asar.unpacked is 54 M — audit what's in it. Currently only node-pty is unpacked. Confirm nothing else got unpacked accidentally and that node-pty's unpack is
    darwin-arm64-only.
   6. Per-plugin better-sqlite3 situation. It's a per-plugin runtime external staged under
   dist/electron/builtin/plugins/sero-web-plugin/node_modules/better-sqlite3 (via stagePluginRuntimeDependencies in build-electron.mjs). Its .node lives inside the

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -420,6 +420,10 @@ This builds a ready-to-install plugin bundle at `dist/plugin/` containing:
 - `prompts/` / `skills/` — copied runtime resources
 - `package.json` — cleaned manifest with compiled `pi.extensions` paths
 
+Extension dependencies are bundled by default. Add native, large, or
+runtime-loaded packages to `sero.plugin.extensionExternals` so the bundle keeps
+them in `node_modules` instead.
+
 Verify the output contains:
 
 ```

--- a/docs/plugins/technical.md
+++ b/docs/plugins/technical.md
@@ -195,6 +195,8 @@ the downstream migration guide and capability-selection rules.
 | `minSeroVersion` | `string?` | Minimum Sero version required. Enforced during install/load. |
 | `requiredHostCapabilities` | `string[]?` | Explicit host seams the plugin depends on (for example `appAgent.invokeTool` or `tool.cli`). Enforced during install/load. |
 | `preBuilt` | `boolean?` | Controls git/local install behavior. `true` means the package already includes a valid pre-built UI bundle; `false`/omitted means Sero rebuilds it locally during install. npm bundles are always expected to ship pre-built artifacts. |
+| `bundleExtensions` | `boolean?` | Build-time hint for Sero's release packaging. When `true`, built-in packaging uses `scripts/build-plugin.mjs` and ships bundled JS `pi.extensions` instead of raw extension source. Local development sessions still use source directly. |
+| `extensionExternals` | `string[]?` | Packages to keep external when bundling Pi extension entrypoints. Use this for native, large, or runtime-loaded dependencies that must remain in `node_modules`. |
 | `bridgeTools` | `boolean \| string[]` | Controls manifest-driven CLI bridging for plugin tools. `true`/omitted bridges all plugin tools, `false` bridges none, and `string[]` bridges only the named tools. |
 
 ### `sero.providers` Fields

--- a/docs/reference/pi-0.72-migration.md
+++ b/docs/reference/pi-0.72-migration.md
@@ -1,14 +1,14 @@
 # Pi SDK 0.72 Migration Notes
 
-Sero upgraded its Pi SDK integration from 0.61.1 to 0.72.1. This note only covers Sero-facing migration details; use the Pi changelog for the full upstream release history.
+Sero upgraded its Pi SDK integration from 0.61.1 to the 0.72 line. This historical note only covers Sero-facing migration details from that upgrade; use the Pi changelog for the full upstream release history.
 
 ## Provider credentials
 
 Sero continues to store Pi credentials under `~/.sero-ui/agent/auth.json` and does not use `~/.pi/agent`.
 
-The auth UI mirrors the Pi 0.72.1 API-key provider set used by Sero, including DeepSeek, Cloudflare Workers AI, Cloudflare AI Gateway, Moonshot, Fireworks, MiniMax, OpenCode Go, and Xiaomi MiMo API billing. Removed Pi providers `google-gemini-cli` and `google-antigravity` are not shown as built-ins.
+At the time of the 0.72 migration, the auth UI mirrored the API-key provider set used by Sero, including DeepSeek, Cloudflare Workers AI, Cloudflare AI Gateway, Moonshot, Fireworks, MiniMax, OpenCode Go, and Xiaomi MiMo API billing. Removed Pi providers `google-gemini-cli` and `google-antigravity` are not shown as built-ins.
 
-Pi documents Xiaomi Token Plan provider IDs (`xiaomi-token-plan-*`), but the installed `@mariozechner/pi-ai@0.72.1` package does not export them. Sero therefore exposes the Xiaomi API-billing provider (`xiaomi`) only. Users with Token Plan credentials should keep those credentials outside Sero until the provider IDs are exported by Pi and added to Sero's auth catalog.
+Pi documented Xiaomi Token Plan provider IDs (`xiaomi-token-plan-*`), but the Sero version from this migration did not expose them. Current provider availability is defined by `apps/desktop/electron/shared/auth/provider-catalog.ts`.
 
 ## Plugin author notes
 
@@ -20,4 +20,4 @@ import { Type } from 'typebox';
 
 Do not use `@sinclair/typebox` for new Pi tool schemas. Custom provider models should place thinking mappings on model objects via `thinkingLevelMap`; do not put `reasoningEffortMap` in provider `compat`.
 
-For extension lifecycle hooks, use Pi 0.72 events such as `session_start`, `session_before_switch`, `session_shutdown`, and `session_tree`. The old `session_switch` / `session_fork` hooks are not part of the 0.72.1 typed API.
+For extension lifecycle hooks, use events such as `session_start`, `session_before_switch`, `session_shutdown`, and `session_tree`. The old `session_switch` / `session_fork` hooks are not part of the typed API from this migration line.

--- a/docs/sero.md
+++ b/docs/sero.md
@@ -34,7 +34,7 @@ The container is the body. The Electron UI is the face. Pi is the mind.
 - **Current maintainer-validated baseline:** macOS 26 Tahoe+ on Apple Silicon
 - **Electron 33** (TypeScript + React)
 - **Container-backed runtimes** are strongly recommended for the full Sero feature set: Apple Container on supported Apple Silicon Macs, Docker on macOS/Linux/Windows
-- **Pi SDK** (`@mariozechner/pi-coding-agent`) as the AI agent core
+- **Pi SDK** (`@earendil-works/pi-coding-agent`) as the AI agent core
 - **Supported fallback:** Host is the default runtime on supported packaged targets when available. Sero can continue in reduced host mode when containers are unavailable or intentionally disabled; Docker/Podman and Apple Container remain explicit runtime choices where supported.
 
 For the canonical public beta support contract, prefer

--- a/eval/evalCli.ts
+++ b/eval/evalCli.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { Type } from '@sinclair/typebox';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 const execFileAsync = promisify(execFile);
 

--- a/eval/seroProvider.ts
+++ b/eval/seroProvider.ts
@@ -121,7 +121,7 @@ let _sdk: {
 
 async function loadSdk() {
   if (_sdk) return _sdk;
-  const mod = await import('@mariozechner/pi-coding-agent');
+  const mod = await import('@earendil-works/pi-coding-agent');
   _sdk = {
     createAgentSession: mod.createAgentSession,
     SessionManager: mod.SessionManager,

--- a/eval/snapshotProvider.ts
+++ b/eval/snapshotProvider.ts
@@ -252,7 +252,7 @@ export default class SnapshotProvider implements ApiProvider {
 
     try {
       // ── 1. Get the SDK base prompt ─────────────────────────────
-      const sdk = await import('@mariozechner/pi-coding-agent');
+      const sdk = await import('@earendil-works/pi-coding-agent');
 
       const authStorage = sdk.AuthStorage.create(`${agentDir}/auth.json`);
       const modelRegistry = new sdk.ModelRegistry(

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "release:stable:dry": "release-it --dry-run --ci --no-preRelease"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "catalog:",
+    "@earendil-works/pi-coding-agent": "catalog:",
     "@release-it/conventional-changelog": "^11.0.0",
     "@sinclair/typebox": "catalog:",
     "husky": "^9.1.7",

--- a/packages/app-runtime/package.json
+++ b/packages/app-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/app-runtime",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Hooks for Sero federated app modules — useAppState, useAppInfo, useAgentPrompt, useAppTools",
   "type": "module",
   "main": "./src/index.ts",
@@ -20,8 +20,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@sero-ai/common": ">=0.1.0",
-    "react": "catalog:peer"
+    "@sero-ai/common": ">=0.3.1",
+    "react": "^19.2.4"
   },
   "devDependencies": {
     "@sero-ai/common": "workspace:*",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@mariozechner/pi-agent-core": "catalog:"
+    "@earendil-works/pi-agent-core": "0.78.0"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/common",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Shared types and utilities for Sero packages",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/common/src/model-selection/types.ts
+++ b/packages/common/src/model-selection/types.ts
@@ -4,7 +4,7 @@
  * Keep this file renderer-safe and framework-agnostic.
  */
 
-import type { ThinkingLevel } from '@mariozechner/pi-agent-core';
+import type { ThinkingLevel } from '@earendil-works/pi-agent-core';
 
 export type { ThinkingLevel };
 

--- a/packages/common/src/plugins.ts
+++ b/packages/common/src/plugins.ts
@@ -46,6 +46,10 @@ export interface PluginMeta {
   requiredHostCapabilities?: string[];
   /** true for pre-built npm bundles; false/undefined for source repos built on install */
   preBuilt?: boolean;
+  /** build-time hint for release packaging to ship bundled JS extension entries */
+  bundleExtensions?: boolean;
+  /** packages to keep external when bundling Pi extension entries */
+  extensionExternals?: string[];
   /** true/undefined = bridge all tools, false = none, string[] = listed tools only */
   bridgeTools?: boolean | string[];
 }

--- a/packages/templates/skills/sero-plugin/SKILL.md
+++ b/packages/templates/skills/sero-plugin/SKILL.md
@@ -180,7 +180,7 @@ sero workspace mount-plugin /absolute/path/to/plugins/sero-<name>-plugin
 `extension/index.ts` is standard Pi. Template in `references/templates.md`.
 
 Key patterns:
-- Use `StringEnum` from `@mariozechner/pi-ai` for action enums (not `Type.Union`)
+- Use `StringEnum` from `@earendil-works/pi-ai` for action enums (not `Type.Union`)
 - Resolve `statePath` from `ctx.cwd` inside `execute` handlers; use `session_start` only as a warm fallback
 - Atomic writes only (temp → rename)
 - Keep tool output concise

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/extension/index.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { StringEnum } from '@mariozechner/pi-ai';
-import type { ExtensionAPI, ToolDefinition } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import type { Note, NotesState } from '../shared/types';

--- a/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
+++ b/packages/templates/skills/sero-plugin/example/sero-notes-plugin/package.json
@@ -49,9 +49,9 @@
     "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer",
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
     "zod": "catalog:peer"
   },
   "devDependencies": {

--- a/packages/templates/skills/sero-plugin/references/templates.md
+++ b/packages/templates/skills/sero-plugin/references/templates.md
@@ -72,9 +72,9 @@ If the plugin ships **prompt templates** or **skills**, add `prompts/` and/or
     "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer",
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
     "zod": "catalog:peer"
   },
   "devDependencies": {
@@ -327,9 +327,9 @@ export const DEFAULT_STATE: MyAppState = {
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { StringEnum } from '@mariozechner/pi-ai';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import type { MyAppState, MyItem } from '../shared/types';

--- a/plugins/sero-admin-plugin/extension/index.ts
+++ b/plugins/sero-admin-plugin/extension/index.ts
@@ -6,7 +6,7 @@
  * or bridged into `sero-cli`.
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 export default function adminExtension(pi: ExtensionAPI) {
   pi.registerCommand('admin', {

--- a/plugins/sero-admin-plugin/package.json
+++ b/plugins/sero-admin-plugin/package.json
@@ -46,9 +46,9 @@
     "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer",
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
     "zod": "catalog:peer"
   },
   "devDependencies": {

--- a/plugins/sero-alibaba-plugin/extension/index.ts
+++ b/plugins/sero-alibaba-plugin/extension/index.ts
@@ -15,7 +15,7 @@
  *   MiniMax: MiniMax-M2.5
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 const THINKING_LEVEL_MAP = {
   minimal: 'false',

--- a/plugins/sero-alibaba-plugin/package.json
+++ b/plugins/sero-alibaba-plugin/package.json
@@ -32,7 +32,7 @@
     ]
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "catalog:peer"
+    "@earendil-works/pi-coding-agent": "catalog:peer"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/plugins/sero-cron-plugin/extension/__tests__/session-runner.test.ts
+++ b/plugins/sero-cron-plugin/extension/__tests__/session-runner.test.ts
@@ -57,7 +57,7 @@ function createMockSession(opts?: {
   return instance;
 }
 
-vi.mock('@mariozechner/pi-coding-agent', () => ({
+vi.mock('@earendil-works/pi-coding-agent', () => ({
   createAgentSession: vi.fn(async () => {
     const session = createMockSession();
     return { session, extensionsResult: { extensions: [], errors: [], runtime: {} } };
@@ -73,7 +73,7 @@ vi.mock('../logger', () => ({
   error: vi.fn(),
 }));
 
-import { createAgentSession } from '@mariozechner/pi-coding-agent';
+import { createAgentSession } from '@earendil-works/pi-coding-agent';
 import {
   runTransientSession,
   setMaxConcurrent,
@@ -166,7 +166,7 @@ describe('runTransientSession', () => {
   });
 
   it('uses SessionManager.inMemory() — no files persisted', async () => {
-    const { SessionManager } = await import('@mariozechner/pi-coding-agent');
+    const { SessionManager } = await import('@earendil-works/pi-coding-agent');
     await runTransientSession('job-1', 'test');
 
     expect(SessionManager.inMemory).toHaveBeenCalled();

--- a/plugins/sero-cron-plugin/extension/index.ts
+++ b/plugins/sero-cron-plugin/extension/index.ts
@@ -12,7 +12,7 @@
  * scheduler exists per process. This prevents double job execution.
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 import { createCronRuntime } from './runtime';
 import {

--- a/plugins/sero-cron-plugin/extension/logger.ts
+++ b/plugins/sero-cron-plugin/extension/logger.ts
@@ -10,7 +10,7 @@
 
 import { appendFile, mkdir, rename, stat } from 'node:fs/promises';
 import path from 'node:path';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 export type LogLevel = 'INFO' | 'WARN' | 'ERROR';
 

--- a/plugins/sero-cron-plugin/extension/runtime.ts
+++ b/plugins/sero-cron-plugin/extension/runtime.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 import type {
   CronRunResult,

--- a/plugins/sero-cron-plugin/extension/session-runner.ts
+++ b/plugins/sero-cron-plugin/extension/session-runner.ts
@@ -14,9 +14,9 @@
 import {
   createAgentSession,
   SessionManager,
-} from '@mariozechner/pi-coding-agent';
-import type { AgentSession } from '@mariozechner/pi-coding-agent';
-import type { Model } from '@mariozechner/pi-ai';
+} from '@earendil-works/pi-coding-agent';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+import type { Model } from '@earendil-works/pi-ai';
 import { info, error as logError } from './logger';
 
 // ── Types ───────────────────────────────────────────────────────

--- a/plugins/sero-cron-plugin/extension/tools.ts
+++ b/plugins/sero-cron-plugin/extension/tools.ts
@@ -1,6 +1,6 @@
-import { StringEnum } from '@mariozechner/pi-ai';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import type { ActionParams } from './actions';

--- a/plugins/sero-cron-plugin/package.json
+++ b/plugins/sero-cron-plugin/package.json
@@ -63,9 +63,9 @@
     "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer",
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
     "zod": "catalog:peer"
   },
   "devDependencies": {

--- a/plugins/sero-git-plugin/extension/index.ts
+++ b/plugins/sero-git-plugin/extension/index.ts
@@ -8,9 +8,9 @@
  * Commands (user): /git
  */
 
-import { StringEnum } from '@mariozechner/pi-ai';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import type { GitManagerRequest } from '../shared/types';

--- a/plugins/sero-git-plugin/package.json
+++ b/plugins/sero-git-plugin/package.json
@@ -42,9 +42,9 @@
     "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer"
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer"
   },
   "devDependencies": {
     "@module-federation/vite": "catalog:",

--- a/plugins/sero-mcp-plugin/extension/__tests__/index.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import mcpExtension from '../index';
 
 describe('mcp extension registration', () => {

--- a/plugins/sero-mcp-plugin/extension/__tests__/manager-tool.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/manager-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { registerMcpManagerTool } from '../tools/manager-tool';
 import { createToolResult } from '../tools/types';
 import type { McpRuntime } from '../runtime/mcp-runtime';

--- a/plugins/sero-mcp-plugin/extension/__tests__/proxy-tool.test.ts
+++ b/plugins/sero-mcp-plugin/extension/__tests__/proxy-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { registerMcpProxyTool } from '../tools/proxy-tool';
 import { createToolResult } from '../tools/types';
 import type { McpRuntime } from '../runtime/mcp-runtime';

--- a/plugins/sero-mcp-plugin/extension/index.ts
+++ b/plugins/sero-mcp-plugin/extension/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { buildMcpPromptBlock } from './prompt';
 import { getMcpRuntime } from './runtime/mcp-runtime';
 import { registerMcpManagerTool } from './tools/manager-tool';

--- a/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
+++ b/plugins/sero-mcp-plugin/extension/runtime/mcp-runtime.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import type { McpServerEditorInput } from '../../shared/types';
 import { validateServerEditorInput } from '../../shared/types';
 import { ensureOAuthDir, hasOAuthTokens } from '../auth/storage';

--- a/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/manager-tool.ts
@@ -1,5 +1,5 @@
-import { StringEnum } from '@mariozechner/pi-ai';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 import type { McpServerEditorInput } from '../../shared/types';
 import type { McpRuntime } from '../runtime/mcp-runtime';

--- a/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
+++ b/plugins/sero-mcp-plugin/extension/tools/proxy-tool.ts
@@ -1,5 +1,5 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { StringEnum } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { StringEnum } from '@earendil-works/pi-ai';
 import { Type } from 'typebox';
 import type { McpRuntime } from '../runtime/mcp-runtime';
 import type { CliContext, CliResult, ProxyAction } from './types';

--- a/plugins/sero-mcp-plugin/package.json
+++ b/plugins/sero-mcp-plugin/package.json
@@ -46,6 +46,7 @@
       "bridgeTools": [
         "mcp"
       ],
+      "bundleExtensions": true,
       "preBuilt": false
     }
   },

--- a/plugins/sero-mcp-plugin/package.json
+++ b/plugins/sero-mcp-plugin/package.json
@@ -57,9 +57,9 @@
     "zod": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer"
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer"
   },
   "devDependencies": {
     "@module-federation/vite": "catalog:",

--- a/plugins/sero-memory-plugin/extension/__tests__/context-injector.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/context-injector.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 const mocks = vi.hoisted(() => ({
   checkBootstrapStatus: vi.fn(),

--- a/plugins/sero-memory-plugin/extension/activity-observer.ts
+++ b/plugins/sero-memory-plugin/extension/activity-observer.ts
@@ -11,7 +11,7 @@
  * notable commands. Only logs turns with real successful work.
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import {
   resolveMemoryRoot,
   ensureDirectories,

--- a/plugins/sero-memory-plugin/extension/consolidation.ts
+++ b/plugins/sero-memory-plugin/extension/consolidation.ts
@@ -1,8 +1,8 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
-import { complete, type Message } from '@mariozechner/pi-ai';
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { complete, type Message } from '@earendil-works/pi-ai';
 
 import { format } from 'date-fns';
 import {

--- a/plugins/sero-memory-plugin/extension/context-injector.ts
+++ b/plugins/sero-memory-plugin/extension/context-injector.ts
@@ -16,7 +16,7 @@
  * is byte-identical across turns in frozen mode so cache hits are preserved.
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 import {
   checkBootstrapStatus,

--- a/plugins/sero-memory-plugin/extension/index.ts
+++ b/plugins/sero-memory-plugin/extension/index.ts
@@ -13,7 +13,7 @@
  * Hooks: before_agent_start (context injection), session lifecycle
  */
 
-import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 
 import { checkBootstrapStatus } from './bootstrap';
 import { registerContextInjection, markBootstrapDone } from './context-injector';

--- a/plugins/sero-memory-plugin/extension/memory-tool-admin.ts
+++ b/plugins/sero-memory-plugin/extension/memory-tool-admin.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent';
 
 import {
   describeAutoConsolidationCadence,

--- a/plugins/sero-memory-plugin/extension/memory-tool.ts
+++ b/plugins/sero-memory-plugin/extension/memory-tool.ts
@@ -5,9 +5,9 @@
  * by the schema bridge (AD-020).
  */
 
-import { StringEnum } from '@mariozechner/pi-ai';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type, type Static } from 'typebox';
 
 import {

--- a/plugins/sero-memory-plugin/extension/migration.ts
+++ b/plugins/sero-memory-plugin/extension/migration.ts
@@ -1,5 +1,5 @@
-import type { ExtensionContext } from '@mariozechner/pi-coding-agent';
-import { complete, type Message } from '@mariozechner/pi-ai';
+import type { ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { complete, type Message } from '@earendil-works/pi-ai';
 
 import { promises as fs } from 'node:fs';
 

--- a/plugins/sero-memory-plugin/extension/search-tool.ts
+++ b/plugins/sero-memory-plugin/extension/search-tool.ts
@@ -10,9 +10,9 @@
  * Falls back to install instructions when QMD is unavailable.
  */
 
-import { StringEnum } from '@mariozechner/pi-ai';
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import {

--- a/plugins/sero-memory-plugin/extension/session-lifecycle.ts
+++ b/plugins/sero-memory-plugin/extension/session-lifecycle.ts
@@ -10,9 +10,9 @@
  *   daily log. Uses reasoning_effort: low for cost control.
  */
 
-import type { ExtensionAPI, SessionMessageEntry } from '@mariozechner/pi-coding-agent';
-import { complete, type Message } from '@mariozechner/pi-ai';
-import { convertToLlm, serializeConversation } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI, SessionMessageEntry } from '@earendil-works/pi-coding-agent';
+import { complete, type Message } from '@earendil-works/pi-ai';
+import { convertToLlm, serializeConversation } from '@earendil-works/pi-coding-agent';
 
 import {
   resolveMemoryRoot,

--- a/plugins/sero-memory-plugin/extension/session-transcripts.ts
+++ b/plugins/sero-memory-plugin/extension/session-transcripts.ts
@@ -5,7 +5,7 @@ import { format } from 'date-fns';
 import {
   SessionManager,
   type SessionMessageEntry,
-} from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-coding-agent';
 
 import {
   getSessionTranscriptPath,

--- a/plugins/sero-memory-plugin/package.json
+++ b/plugins/sero-memory-plugin/package.json
@@ -21,9 +21,9 @@
     "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer",
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
     "zod": "catalog:peer"
   },
   "devDependencies": {

--- a/plugins/sero-memory-plugin/package.json
+++ b/plugins/sero-memory-plugin/package.json
@@ -41,6 +41,10 @@
         "logs"
       ],
       "minSeroVersion": "0.1.0",
+      "bundleExtensions": true,
+      "extensionExternals": [
+        "@tobilu/qmd"
+      ],
       "preBuilt": false
     }
   }

--- a/plugins/sero-user-feedback-plugin/extension/__tests__/permission-gate.test.ts
+++ b/plugins/sero-user-feedback-plugin/extension/__tests__/permission-gate.test.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({

--- a/plugins/sero-user-feedback-plugin/extension/index.ts
+++ b/plugins/sero-user-feedback-plugin/extension/index.ts
@@ -11,8 +11,8 @@
  * listeners), otherwise falls back to TUI rendering in Pi CLI.
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import type { QuestionItem, QuestionAnswer } from '../shared/types';

--- a/plugins/sero-user-feedback-plugin/extension/interview-tool.ts
+++ b/plugins/sero-user-feedback-plugin/extension/interview-tool.ts
@@ -9,8 +9,8 @@
  * prompt template to drive the full interview→spec workflow.
  */
 
-import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
-import { Text } from '@mariozechner/pi-tui';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 
 import type { QuestionItem, QuestionAnswer } from '../shared/types';

--- a/plugins/sero-user-feedback-plugin/extension/permission-gate.ts
+++ b/plugins/sero-user-feedback-plugin/extension/permission-gate.ts
@@ -16,7 +16,7 @@
  * do not hang forever waiting for an answer.
  */
 
-import type { ExtensionAPI, ExtensionContext } from '@mariozechner/pi-coding-agent';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import path from 'path';
 import { nextQuestionId, askQuestion, hasSeroIPCBridge } from './ipc-bridge';
 import { showPermissionWarningTUI } from './tui-permission-warning';

--- a/plugins/sero-user-feedback-plugin/extension/tui-interview.ts
+++ b/plugins/sero-user-feedback-plugin/extension/tui-interview.ts
@@ -14,8 +14,8 @@ import {
   Key,
   matchesKey,
   truncateToWidth
-} from '@mariozechner/pi-tui';
-import type { ExtensionUIContext, Theme } from '@mariozechner/pi-coding-agent';
+} from '@earendil-works/pi-tui';
+import type { ExtensionUIContext, Theme } from '@earendil-works/pi-coding-agent';
 import type { QuestionItem, QuestionAnswer } from '../shared/types';
 
 interface InterviewResult {

--- a/plugins/sero-user-feedback-plugin/extension/tui-permission-warning.ts
+++ b/plugins/sero-user-feedback-plugin/extension/tui-permission-warning.ts
@@ -5,8 +5,8 @@
  * Allow/Block options. Uses warning/error colors to make it stand out.
  */
 
-import { Key, matchesKey, truncateToWidth } from '@mariozechner/pi-tui';
-import type { ExtensionUIContext } from '@mariozechner/pi-coding-agent';
+import { Key, matchesKey, truncateToWidth } from '@earendil-works/pi-tui';
+import type { ExtensionUIContext } from '@earendil-works/pi-coding-agent';
 
 /**
  * Show a TUI warning prompt for a dangerous command.

--- a/plugins/sero-user-feedback-plugin/extension/tui-question.ts
+++ b/plugins/sero-user-feedback-plugin/extension/tui-question.ts
@@ -5,8 +5,8 @@
  * "Type something…" inline editor. Only used when ctx.hasUI === true.
  */
 
-import { Editor, type EditorTheme, Key, matchesKey, truncateToWidth } from '@mariozechner/pi-tui';
-import type { ExtensionUIContext } from '@mariozechner/pi-coding-agent';
+import { Editor, type EditorTheme, Key, matchesKey, truncateToWidth } from '@earendil-works/pi-tui';
+import type { ExtensionUIContext } from '@earendil-works/pi-coding-agent';
 import type { QuestionItem, QuestionAnswer } from '../shared/types';
 
 interface DisplayOption {

--- a/plugins/sero-user-feedback-plugin/extension/tui-questionnaire-render.ts
+++ b/plugins/sero-user-feedback-plugin/extension/tui-questionnaire-render.ts
@@ -1,5 +1,5 @@
-import { truncateToWidth } from '@mariozechner/pi-tui';
-import type { Theme } from '@mariozechner/pi-coding-agent';
+import { truncateToWidth } from '@earendil-works/pi-tui';
+import type { Theme } from '@earendil-works/pi-coding-agent';
 
 import type { AnswerMap } from '../shared/questionnaire-flow';
 import type { QuestionAnswer, QuestionItem, QuestionOption } from '../shared/types';

--- a/plugins/sero-user-feedback-plugin/extension/tui-questionnaire.ts
+++ b/plugins/sero-user-feedback-plugin/extension/tui-questionnaire.ts
@@ -5,8 +5,8 @@
  * Only used when ctx.hasUI === true.
  */
 
-import { Editor, type EditorTheme, Key, matchesKey } from '@mariozechner/pi-tui';
-import type { ExtensionUIContext } from '@mariozechner/pi-coding-agent';
+import { Editor, type EditorTheme, Key, matchesKey } from '@earendil-works/pi-tui';
+import type { ExtensionUIContext } from '@earendil-works/pi-coding-agent';
 
 import {
   canSubmitQuestionnaire,

--- a/plugins/sero-user-feedback-plugin/package.json
+++ b/plugins/sero-user-feedback-plugin/package.json
@@ -43,8 +43,8 @@
     "typebox": "catalog:"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
     "zod": "catalog:peer"
   },
   "devDependencies": {

--- a/plugins/sero-web-plugin/extension/commands.ts
+++ b/plugins/sero-web-plugin/extension/commands.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 function sendToolRoutedPrompt(pi: ExtensionAPI, lines: string[]): void {
 	pi.sendUserMessage(lines.filter(Boolean).join("\n"));

--- a/plugins/sero-web-plugin/extension/index.ts
+++ b/plugins/sero-web-plugin/extension/index.ts
@@ -3,7 +3,7 @@
 // session lifecycle handlers, and Sero state file sync.
 // Curator (TUI-only) is omitted; the Sero UI provides result browsing.
 
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { fetchAllContent, type ExtractedContent } from "./extract.js";
 import { clearCloneCache } from "./github-extract.js";
 import { clearResults, generateId, storeResult, restoreFromSession, type QueryResultData, type StoredSearchData } from "./storage.js";

--- a/plugins/sero-web-plugin/extension/storage.ts
+++ b/plugins/sero-web-plugin/extension/storage.ts
@@ -1,4 +1,4 @@
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { ExtractedContent } from "./extract.js";
 import type { SearchResult } from "./perplexity.js";
 

--- a/plugins/sero-web-plugin/extension/summary-review.ts
+++ b/plugins/sero-web-plugin/extension/summary-review.ts
@@ -1,5 +1,5 @@
-import { complete, getModel, type Message, type Model } from "@mariozechner/pi-ai";
-import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { complete, getModel, type Message, type Model } from "@earendil-works/pi-ai";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { QueryResultData } from "./storage.js";
 
 const PREFERRED_SUMMARY_MODELS = [

--- a/plugins/sero-web-plugin/extension/tools-bookmark.ts
+++ b/plugins/sero-web-plugin/extension/tools-bookmark.ts
@@ -1,9 +1,9 @@
 // tools-bookmark.ts — bookmark + clear_history tool registrations.
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { addBookmark, removeBookmark, listBookmarks, clearHistory } from "./state-sync.js";
 
 export function registerBookmarkTool(

--- a/plugins/sero-web-plugin/extension/tools-code-search.ts
+++ b/plugins/sero-web-plugin/extension/tools-code-search.ts
@@ -1,7 +1,7 @@
 // tools-code-search.ts — code_search tool registration.
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { executeCodeSearch } from "./code-search.js";
 

--- a/plugins/sero-web-plugin/extension/tools-fetch.ts
+++ b/plugins/sero-web-plugin/extension/tools-fetch.ts
@@ -1,8 +1,8 @@
 // tools-fetch.ts — fetch_content + get_search_content tool registrations.
 
 import path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { fetchAllContent, type ExtractedContent } from "./extract.js";
 import { generateId, getResult, storeResult, type StoredSearchData, type QueryResultData } from "./storage.js";

--- a/plugins/sero-web-plugin/extension/tools-search.ts
+++ b/plugins/sero-web-plugin/extension/tools-search.ts
@@ -1,9 +1,9 @@
 // tools-search.ts — web_search tool registration.
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { Text } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { StringEnum } from "@mariozechner/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
 import { search } from "./gemini-search.js";
 import type { ExtractedContent } from "./extract.js";
 import type { QueryResultData, StoredSearchData } from "./storage.js";

--- a/plugins/sero-web-plugin/package.json
+++ b/plugins/sero-web-plugin/package.json
@@ -70,9 +70,9 @@
     "unpdf": "^1.4.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "catalog:peer",
-    "@mariozechner/pi-coding-agent": "catalog:peer",
-    "@mariozechner/pi-tui": "catalog:peer",
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
     "zod": "catalog:peer"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,7 +391,7 @@ importers:
   packages/app-runtime:
     dependencies:
       react:
-        specifier: catalog:peer
+        specifier: ^19.2.4
         version: 19.2.5
     devDependencies:
       '@sero-ai/common':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,15 @@ settings:
 
 catalogs:
   default:
-    '@mariozechner/pi-agent-core':
-      specifier: ^0.73.1
-      version: 0.73.1
-    '@mariozechner/pi-ai':
-      specifier: ^0.73.1
-      version: 0.73.1
-    '@mariozechner/pi-coding-agent':
-      specifier: ^0.73.1
-      version: 0.73.1
+    '@earendil-works/pi-agent-core':
+      specifier: 0.78.0
+      version: 0.78.0
+    '@earendil-works/pi-ai':
+      specifier: 0.78.0
+      version: 0.78.0
+    '@earendil-works/pi-coding-agent':
+      specifier: 0.78.0
+      version: 0.78.0
     '@module-federation/vite':
       specifier: 1.11.0
       version: 1.11.0
@@ -70,15 +70,15 @@ catalogs:
       specifier: ^4.3.6
       version: 4.3.6
   peer:
-    '@mariozechner/pi-ai':
-      specifier: '>=0.72.1'
-      version: 0.73.1
-    '@mariozechner/pi-coding-agent':
-      specifier: '>=0.72.1'
-      version: 0.73.1
-    '@mariozechner/pi-tui':
-      specifier: '>=0.72.1'
-      version: 0.73.1
+    '@earendil-works/pi-ai':
+      specifier: '>=0.78.0'
+      version: 0.78.0
+    '@earendil-works/pi-coding-agent':
+      specifier: '>=0.78.0'
+      version: 0.78.0
+    '@earendil-works/pi-tui':
+      specifier: '>=0.78.0'
+      version: 0.78.0
     react:
       specifier: ^19.2.4
       version: 19.2.5
@@ -93,9 +93,9 @@ importers:
 
   .:
     devDependencies:
-      '@mariozechner/pi-coding-agent':
+      '@earendil-works/pi-coding-agent':
         specifier: 'catalog:'
-        version: 0.73.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.78.0(ws@8.20.0)(zod@4.4.3)
       '@release-it/conventional-changelog':
         specifier: ^11.0.0
         version: 11.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@20.0.1(@types/node@25.9.1)(magicast@0.5.3))
@@ -120,18 +120,18 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@earendil-works/pi-agent-core':
+        specifier: 'catalog:'
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai':
+        specifier: 'catalog:'
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: 'catalog:'
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
       '@google/genai':
         specifier: ^1.45.0
         version: 1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)
-      '@mariozechner/pi-agent-core':
-        specifier: 'catalog:'
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-ai':
-        specifier: 'catalog:'
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-coding-agent':
-        specifier: 'catalog:'
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
       '@sero-ai/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -406,9 +406,9 @@ importers:
 
   packages/common:
     dependencies:
-      '@mariozechner/pi-agent-core':
-        specifier: 'catalog:'
-        version: 0.73.1(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-agent-core':
+        specifier: 0.78.0
+        version: 0.78.0(ws@8.20.0)(zod@4.4.3)
     devDependencies:
       typescript:
         specifier: ^5.9.3
@@ -567,15 +567,15 @@ importers:
 
   plugins/sero-admin-plugin:
     dependencies:
-      '@mariozechner/pi-ai':
+      '@earendil-works/pi-ai':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-coding-agent':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-tui':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
         specifier: catalog:peer
-        version: 0.73.1
+        version: 0.78.0
       typebox:
         specifier: 'catalog:'
         version: 1.1.37
@@ -634,9 +634,9 @@ importers:
 
   plugins/sero-alibaba-plugin:
     dependencies:
-      '@mariozechner/pi-coding-agent':
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(ws@8.20.0)(zod@4.4.3)
+        version: 0.78.0(ws@8.20.0)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -647,15 +647,15 @@ importers:
 
   plugins/sero-cron-plugin:
     dependencies:
-      '@mariozechner/pi-ai':
+      '@earendil-works/pi-ai':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-coding-agent':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-tui':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
         specifier: catalog:peer
-        version: 0.73.1
+        version: 0.78.0
       typebox:
         specifier: 'catalog:'
         version: 1.1.37
@@ -714,15 +714,15 @@ importers:
 
   plugins/sero-git-plugin:
     dependencies:
-      '@mariozechner/pi-ai':
+      '@earendil-works/pi-ai':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-coding-agent':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-tui':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
         specifier: catalog:peer
-        version: 0.73.1
+        version: 0.78.0
       typebox:
         specifier: 'catalog:'
         version: 1.1.37
@@ -778,15 +778,15 @@ importers:
 
   plugins/sero-mcp-plugin:
     dependencies:
-      '@mariozechner/pi-ai':
+      '@earendil-works/pi-ai':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@mariozechner/pi-coding-agent':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@mariozechner/pi-tui':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-tui':
         specifier: catalog:peer
-        version: 0.73.1
+        version: 0.78.0
       '@modelcontextprotocol/ext-apps':
         specifier: 1.2.2
         version: 1.2.2(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.3.6)
@@ -854,15 +854,15 @@ importers:
 
   plugins/sero-memory-plugin:
     dependencies:
-      '@mariozechner/pi-ai':
+      '@earendil-works/pi-ai':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-coding-agent':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-tui':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
         specifier: catalog:peer
-        version: 0.73.1
+        version: 0.78.0
       '@tobilu/qmd':
         specifier: ^2.5.2
         version: 2.5.2(@cfworker/json-schema@4.1.1)(typescript@5.9.3)
@@ -891,12 +891,12 @@ importers:
 
   plugins/sero-user-feedback-plugin:
     dependencies:
-      '@mariozechner/pi-coding-agent':
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(ws@8.20.0)(zod@4.4.3)
-      '@mariozechner/pi-tui':
+        version: 0.78.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
         specifier: catalog:peer
-        version: 0.73.1
+        version: 0.78.0
       '@sero-ai/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -955,15 +955,15 @@ importers:
 
   plugins/sero-web-plugin:
     dependencies:
-      '@mariozechner/pi-ai':
+      '@earendil-works/pi-ai':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-coding-agent':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
         specifier: catalog:peer
-        version: 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-tui':
+        version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
         specifier: catalog:peer
-        version: 0.73.1
+        version: 0.78.0
       '@mozilla/readability':
         specifier: ^0.5.0
         version: 0.5.0
@@ -1242,6 +1242,10 @@ packages:
     resolution: {integrity: sha512-buKSmh/GJNvP9r9Ghx9nl6QPju3zRvLgX3WNKJztDWxoEe1WJAkL0Kh37P3JMQ2SWxx+JrSKQvuwF/4jY60mkQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-bedrock-runtime@3.1054.0':
     resolution: {integrity: sha512-APBAWir5vHzUWZ11bHfG3fXJ9t359bcwehwLTScpiYwmUydw7DqH76RAbtiYSstrV76hJ1v3pHM8pGk//E/0uw==}
     engines: {node: '>=20.0.0'}
@@ -1380,6 +1384,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1041.0':
     resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1054.0':
@@ -1900,6 +1908,24 @@ packages:
   '@dotenvx/dotenvx@1.55.1':
     resolution: {integrity: sha512-WEuKyoe9CA7dfcFBnNbL0ndbCNcptaEYBygfFo9X1qEG+HD7xku4CYIplw6sbAHJavesZWbVBHeRSpvri0eKqw==}
     hasBin: true
+
+  '@earendil-works/pi-agent-core@0.78.0':
+    resolution: {integrity: sha512-xhWd59Qzd8yO88gYQw2S4dEQstJJEiUtxRP01//YzVJ61jCtUASMfcyAmYhgGYR4Onp7GmwEAbBBGOiV6Iwk9g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.78.0':
+    resolution: {integrity: sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-coding-agent@0.78.0':
+    resolution: {integrity: sha512-gXt6pD3BoSG0yLwfLqb6844vz6qAO87PvNrv+YSDYKP3QliTjcwIld9v4ihmDcmBjO13QwKswubq/lYCvn4bkg==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.78.0':
+    resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
+    engines: {node: '>=22.19.0'}
 
   '@ecies/ciphers@0.2.5':
     resolution: {integrity: sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==}
@@ -2641,6 +2667,15 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@googleapis/sheets@13.0.2':
     resolution: {integrity: sha512-b1tBlMcfvNEziM4DZCikLOc9iqSlgCK1e5bMKtNQIADRXr1CQmbkHV3ZBVvTsFsjLErgihqO58Itn/kzCnSZ0A==}
     engines: {node: '>=12.0.0'}
@@ -3203,95 +3238,73 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
     engines: {node: '>= 10'}
     os: [darwin]
 
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@mariozechner/clipboard@0.3.6':
-    resolution: {integrity: sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==}
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
     engines: {node: '>= 10'}
-
-  '@mariozechner/pi-agent-core@0.73.1':
-    resolution: {integrity: sha512-Y/KVOhuKSgRQgYBlwmRtO2gPkUcoavOSqGF9bpQIINvNZvc19k6Z1H3bFDTce3Vp5ApMmTsfLH3+tNvOg75fAQ==}
-    engines: {node: '>=20.0.0'}
-    deprecated: please use @earendil-works/pi-agent-core instead going forward
-
-  '@mariozechner/pi-ai@0.73.1':
-    resolution: {integrity: sha512-Jh4lXawZYuC83HzSIYuVum9NBqJD49i4JOt3H96cGW/924cwJMOyUs1Mv/e4QPzTXnzrqMoGviNQnvGgSu1LSg==}
-    engines: {node: '>=20.0.0'}
-    deprecated: please use @earendil-works/pi-ai instead going forward
-    hasBin: true
-
-  '@mariozechner/pi-coding-agent@0.73.1':
-    resolution: {integrity: sha512-gXQh3SaZmWTfVMc4Ao5+LGbVeKvzyO7tolok0nLsZgq9nGjZx/EEU3NM8C+qUnB4Nvs2rswG5qOVgLzQkq0fHQ==}
-    engines: {node: '>=20.6.0'}
-    deprecated: please use @earendil-works/pi-coding-agent instead going forward
-    hasBin: true
-
-  '@mariozechner/pi-tui@0.73.1':
-    resolution: {integrity: sha512-ybVsRnUbzQRtbocltJ2OXb2QogrO67N2BlUyKjZz9BHcZYiDJtNkcKQockxDjsVvDc0uBCLDX6iZJoBElBd8fw==}
-    engines: {node: '>=20.0.0'}
-    deprecated: please use @earendil-works/pi-tui instead going forward
 
   '@mdx-js/loader@2.3.0':
     resolution: {integrity: sha512-IqsscXh7Q3Rzb+f5DXYk0HU71PK+WuFsEhf+mSV3fOhpLcEpgsHvTQ2h0T6TlZ5gHOaBeFjkXwB52by7ypMyNg==}
@@ -3309,8 +3322,8 @@ packages:
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
-  '@mistralai/mistralai@2.2.5':
-    resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
+  '@mistralai/mistralai@2.2.1':
+    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
@@ -5418,10 +5431,6 @@ packages:
     resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.17':
-    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.24.4':
     resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
     engines: {node: '>=18.0.0'}
@@ -5484,6 +5493,10 @@ packages:
 
   '@smithy/node-http-handler@4.6.1':
     resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.7.4':
@@ -5872,9 +5885,6 @@ packages:
   '@tokenlens/models@1.3.0':
     resolution: {integrity: sha512-9mx7ZGeewW4ndXAiD7AT1bbCk4OpJeortbjHHyNkgap+pMPPn1chY6R5zqe1ggXIUzZ2l8VOAKfPqOvpcrisJw==}
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
 
@@ -6084,9 +6094,6 @@ packages:
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
-
-  '@types/mime-types@2.1.4':
-    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -6654,10 +6661,6 @@ packages:
     resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
     engines: {node: '>=10.0.0'}
     deprecated: Security vulnerability fixed in 5.2.1, please upgrade
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
 
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
@@ -7441,10 +7444,6 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
   data-uri-to-buffer@7.0.0:
     resolution: {integrity: sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==}
     engines: {node: '>= 14'}
@@ -7562,10 +7561,6 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
-
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
 
   degenerator@6.0.0:
     resolution: {integrity: sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==}
@@ -8278,10 +8273,6 @@ packages:
     resolution: {integrity: sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==}
     engines: {node: '>=20'}
 
-  file-type@21.3.4:
-    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
-    engines: {node: '>=20'}
-
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -8500,10 +8491,6 @@ packages:
 
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
-
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
 
   get-uri@7.0.0:
     resolution: {integrity: sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==}
@@ -9302,9 +9289,6 @@ packages:
   koa@3.0.3:
     resolution: {integrity: sha512-MeuwbCoN1daWS32/Ni5qkzmrOtQO2qrnfdxDHjrm6s4b59yG4nexAJ0pTEFyzjLp0pBVO80CZp0vW8Ze30Ebow==}
     engines: {node: '>= 18'}
-
-  koffi@2.16.2:
-    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
 
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
@@ -10314,10 +10298,6 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
-
   new-github-release-url@2.0.0:
     resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -10672,10 +10652,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
   pac-proxy-agent@8.0.0:
     resolution: {integrity: sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==}
     engines: {node: '>= 14'}
@@ -10683,10 +10659,6 @@ packages:
   pac-proxy-agent@9.0.1:
     resolution: {integrity: sha512-3ZOSpLboOlpW4yp8Cuv21KlTULRqyJ5Uuad3wXpSKFrxdNgcHEyoa22GRaZ2UlgCVuR6z+5BiavtYVvbajL/Yw==}
     engines: {node: '>= 20'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
 
   pac-resolver@8.0.0:
     resolution: {integrity: sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==}
@@ -11085,10 +11057,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-agent@6.5.0:
-    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
-    engines: {node: '>= 14'}
 
   proxy-agent@7.0.0:
     resolution: {integrity: sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==}
@@ -12002,10 +11970,6 @@ packages:
     resolution: {integrity: sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==}
     engines: {node: '>= 20'}
 
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
   socks-proxy-agent@9.0.0:
     resolution: {integrity: sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==}
     engines: {node: '>= 14'}
@@ -12727,6 +12691,10 @@ packages:
     resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
     engines: {node: '>=20.18.1'}
 
+  undici@8.3.0:
+    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+    engines: {node: '>=22.19.0'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -12960,10 +12928,6 @@ packages:
 
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
-    hasBin: true
-
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uvu@0.5.6:
@@ -13858,7 +13822,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
@@ -13883,7 +13847,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -13891,7 +13855,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -13900,7 +13864,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -13918,6 +13882,23 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/credential-provider-node': 3.972.45
+      '@aws-sdk/eventstream-handler-node': 3.972.17
+      '@aws-sdk/middleware-eventstream': 3.972.13
+      '@aws-sdk/middleware-websocket': 3.972.22
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-bedrock-runtime@3.1054.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -13934,6 +13915,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/client-s3@3.1054.0':
     dependencies:
@@ -13984,15 +13966,15 @@ snapshots:
 
   '@aws-sdk/core@3.974.8':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/xml-builder': 3.972.22
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/signature-v4': 5.3.14
       '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-retry': 4.3.8
@@ -14150,9 +14132,9 @@ snapshots:
 
   '@aws-sdk/middleware-host-header@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -14165,31 +14147,31 @@ snapshots:
 
   '@aws-sdk/middleware-logger@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@aws-sdk/middleware-recursion-detection@3.972.11':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@aws/lambda-invoke-store': 0.2.4
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@aws-sdk/middleware-sdk-s3@3.972.37':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-arn-parser': 3.972.3
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/node-config-provider': 4.3.14
       '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
+      '@smithy/signature-v4': 5.4.4
       '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-stream': 4.5.25
@@ -14216,12 +14198,12 @@ snapshots:
 
   '@aws-sdk/middleware-user-agent@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-endpoints': 3.996.8
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-retry': 4.3.8
       tslib: 2.8.1
     optional: true
@@ -14260,12 +14242,12 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/region-config-resolver': 3.972.13
       '@aws-sdk/signature-v4-multi-region': 3.996.25
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
       '@aws-sdk/util-user-agent-node': 3.973.24
       '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/hash-node': 4.2.14
       '@smithy/invalid-dependency': 4.2.14
@@ -14275,10 +14257,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
+      '@smithy/node-http-handler': 4.7.4
       '@smithy/protocol-http': 5.3.14
       '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -14296,20 +14278,20 @@ snapshots:
 
   '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/config-resolver': 4.4.17
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@aws-sdk/signature-v4-multi-region@3.996.25':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.37
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/protocol-http': 5.3.14
-      '@smithy/signature-v4': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -14324,14 +14306,23 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.8
       '@aws-sdk/nested-clients': 3.997.6
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
     optional: true
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.14
+      '@aws-sdk/nested-clients': 3.997.12
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1054.0':
     dependencies:
@@ -14344,8 +14335,9 @@ snapshots:
 
   '@aws-sdk/types@3.973.8':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/types@3.973.9':
     dependencies:
@@ -14359,8 +14351,8 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.996.8':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
       '@smithy/url-parser': 4.2.14
       '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
@@ -14372,8 +14364,8 @@ snapshots:
 
   '@aws-sdk/util-user-agent-browser@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.8
-      '@smithy/types': 4.14.1
+      '@aws-sdk/types': 3.973.9
+      '@smithy/types': 4.14.2
       bowser: 2.14.1
       tslib: 2.8.1
     optional: true
@@ -14381,9 +14373,9 @@ snapshots:
   '@aws-sdk/util-user-agent-node@3.973.24':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
     optional: true
@@ -14391,7 +14383,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.22':
     dependencies:
       '@nodable/entities': 2.1.0
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       fast-xml-parser: 5.7.2
       tslib: 2.8.1
     optional: true
@@ -14543,7 +14535,7 @@ snapshots:
 
   '@azure/core-xml@1.5.1':
     dependencies:
-      fast-xml-parser: 5.7.2
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
     optional: true
 
@@ -14857,8 +14849,7 @@ snapshots:
 
   '@babel/runtime@7.28.6': {}
 
-  '@babel/runtime@7.29.7':
-    optional: true
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -14912,7 +14903,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@borewit/text-codec@0.2.2': {}
+  '@borewit/text-codec@0.2.2':
+    optional: true
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -15103,6 +15095,263 @@ snapshots:
       object-treeify: 1.1.33
       picomatch: 4.0.4
       which: 4.0.0
+
+  '@earendil-works/pi-agent-core@0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-agent-core@0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-agent-core@0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-agent-core@0.78.0(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.78.0(ws@8.20.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
+      '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      openai: 6.26.0(ws@8.21.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)
+      '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.78.0(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@mistralai/mistralai': 2.2.1
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-tui': 0.78.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.78.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.78.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.78.0(ws@8.20.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.78.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.78.0(ws@8.20.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.78.0
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      typebox: 1.1.38
+      undici: 8.3.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-tui@0.78.0':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 15.0.12
 
   '@ecies/ciphers@0.2.5(@noble/ciphers@1.3.0)':
     dependencies:
@@ -15589,19 +15838,6 @@ snapshots:
 
   '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
-  '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
-    dependencies:
-      google-auth-library: 10.6.1(supports-color@7.2.0)
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)':
     dependencies:
       google-auth-library: 10.6.1(supports-color@7.2.0)
@@ -15615,9 +15851,35 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
     dependencies:
-      google-auth-library: 10.6.1(supports-color@7.2.0)
+      google-auth-library: 10.6.2(supports-color@7.2.0)
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)':
+    dependencies:
+      google-auth-library: 10.6.2(supports-color@7.2.0)
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))':
+    dependencies:
+      google-auth-library: 10.6.2(supports-color@7.2.0)
       p-retry: 4.6.2
       protobufjs: 7.5.4
       ws: 8.21.0
@@ -16194,323 +16456,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
     optional: true
 
-  '@mariozechner/clipboard@0.3.6':
+  '@mariozechner/clipboard@0.3.9':
     optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.6
-      '@mariozechner/clipboard-darwin-universal': 0.3.6
-      '@mariozechner/clipboard-darwin-x64': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.6
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.6
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.6
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.6
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
     optional: true
-
-  '@mariozechner/pi-agent-core@0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      typebox: 1.1.37
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-agent-core@0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
-      typebox: 1.1.37
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-agent-core@0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      typebox: 1.1.37
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-agent-core@0.73.1(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.73.1(ws@8.20.0)(zod@4.4.3)
-      typebox: 1.1.37
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1054.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))
-      '@mistralai/mistralai': 2.2.5
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.21.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0(supports-color@7.2.0)
-      typebox: 1.1.37
-      undici: 7.26.0
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1054.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)
-      '@mistralai/mistralai': 2.2.5
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0(supports-color@7.2.0)
-      typebox: 1.1.37
-      undici: 7.26.0
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1054.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
-      '@mistralai/mistralai': 2.2.5
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0(supports-color@7.2.0)
-      typebox: 1.1.37
-      undici: 7.26.0
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.73.1(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1054.0
-      '@google/genai': 1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
-      '@mistralai/mistralai': 2.2.5
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0(supports-color@7.2.0)
-      typebox: 1.1.37
-      undici: 7.26.0
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-agent-core': 0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.73.1(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
-      '@mariozechner/pi-tui': 0.73.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1(supports-color@7.2.0)
-      file-type: 21.3.4(supports-color@7.2.0)
-      glob: 13.0.6
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.38
-      undici: 7.26.0
-      uuid: 14.0.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@mariozechner/pi-agent-core': 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-ai': 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-tui': 0.73.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1(supports-color@7.2.0)
-      file-type: 21.3.4(supports-color@7.2.0)
-      glob: 13.0.6
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.38
-      undici: 7.26.0
-      uuid: 14.0.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
-    dependencies:
-      '@mariozechner/pi-agent-core': 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-ai': 0.73.1(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@mariozechner/pi-tui': 0.73.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1(supports-color@7.2.0)
-      file-type: 21.3.4(supports-color@7.2.0)
-      glob: 13.0.6
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.38
-      undici: 7.26.0
-      uuid: 14.0.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-coding-agent@0.73.1(ws@8.20.0)(zod@4.4.3)':
-    dependencies:
-      '@mariozechner/pi-agent-core': 0.73.1(ws@8.20.0)(zod@4.4.3)
-      '@mariozechner/pi-ai': 0.73.1(ws@8.20.0)(zod@4.4.3)
-      '@mariozechner/pi-tui': 0.73.1
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cli-highlight: 2.1.11
-      diff: 8.0.4
-      extract-zip: 2.0.1(supports-color@7.2.0)
-      file-type: 21.3.4(supports-color@7.2.0)
-      glob: 13.0.6
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      marked: 15.0.12
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      strip-ansi: 7.2.0
-      typebox: 1.1.38
-      undici: 7.26.0
-      uuid: 14.0.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-tui@0.73.1':
-    dependencies:
-      '@types/mime-types': 2.1.4
-      chalk: 5.6.2
-      get-east-asian-width: 1.6.0
-      marked: 15.0.12
-      mime-types: 3.0.2
-    optionalDependencies:
-      koffi: 2.16.2
 
   '@mdx-js/loader@2.3.0(webpack@5.106.2)':
     dependencies:
@@ -16552,7 +16540,7 @@ snapshots:
     dependencies:
       '@chevrotain/types': 11.1.2
 
-  '@mistralai/mistralai@2.2.5':
+  '@mistralai/mistralai@2.2.1':
     dependencies:
       ws: 8.21.0
       zod: 4.4.3
@@ -18874,24 +18862,10 @@ snapshots:
   '@smithy/config-resolver@4.4.17':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-endpoints': 3.4.2
       '@smithy/util-middleware': 4.2.14
-      tslib: 2.8.1
-    optional: true
-
-  '@smithy/core@3.23.17':
-    dependencies:
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.25
-      '@smithy/util-utf8': 4.2.2
-      '@smithy/uuid': 1.1.2
       tslib: 2.8.1
     optional: true
 
@@ -18905,7 +18879,7 @@ snapshots:
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
     optional: true
@@ -18920,7 +18894,7 @@ snapshots:
     dependencies:
       '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
     optional: true
@@ -18933,7 +18907,7 @@ snapshots:
 
   '@smithy/hash-node@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
@@ -18941,7 +18915,7 @@ snapshots:
 
   '@smithy/invalid-dependency@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -18957,17 +18931,17 @@ snapshots:
   '@smithy/middleware-content-length@4.2.14':
     dependencies:
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/middleware-endpoint@4.4.32':
     dependencies:
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/middleware-serde': 4.2.20
       '@smithy/node-config-provider': 4.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/url-parser': 4.2.14
       '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
@@ -18975,12 +18949,12 @@ snapshots:
 
   '@smithy/middleware-retry@4.5.7':
     dependencies:
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/node-config-provider': 4.3.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/service-error-classification': 4.3.1
       '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-retry': 4.3.8
       '@smithy/uuid': 1.1.2
@@ -18989,15 +18963,15 @@ snapshots:
 
   '@smithy/middleware-serde@4.2.20':
     dependencies:
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/middleware-stack@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -19005,7 +18979,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -19017,6 +18991,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.7.4':
     dependencies:
       '@smithy/core': 3.24.4
@@ -19025,37 +19005,37 @@ snapshots:
 
   '@smithy/property-provider@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/protocol-http@5.3.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/querystring-builder@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/querystring-parser@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/service-error-classification@4.3.1':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
     optional: true
 
   '@smithy/shared-ini-file-loader@4.4.9':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -19063,7 +19043,7 @@ snapshots:
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-uri-escape': 4.2.2
@@ -19079,11 +19059,11 @@ snapshots:
 
   '@smithy/smithy-client@4.12.13':
     dependencies:
-      '@smithy/core': 3.23.17
+      '@smithy/core': 3.24.4
       '@smithy/middleware-endpoint': 4.4.32
       '@smithy/middleware-stack': 4.2.14
       '@smithy/protocol-http': 5.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
     optional: true
@@ -19091,6 +19071,7 @@ snapshots:
   '@smithy/types@4.14.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@smithy/types@4.14.2':
     dependencies:
@@ -19099,7 +19080,7 @@ snapshots:
   '@smithy/url-parser@4.2.14':
     dependencies:
       '@smithy/querystring-parser': 4.2.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -19140,7 +19121,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.14
       '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -19151,14 +19132,14 @@ snapshots:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
       '@smithy/smithy-client': 4.12.13
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/util-endpoints@3.4.2':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
@@ -19169,22 +19150,22 @@ snapshots:
 
   '@smithy/util-middleware@4.2.14':
     dependencies:
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/util-retry@4.3.8':
     dependencies:
       '@smithy/service-error-classification': 4.3.1
-      '@smithy/types': 4.14.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     optional: true
 
   '@smithy/util-stream@4.5.25':
     dependencies:
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/types': 4.14.1
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -19430,14 +19411,16 @@ snapshots:
       - supports-color
       - tree-sitter
 
-  '@tokenizer/inflate@0.4.1(supports-color@7.2.0)':
+  '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
-  '@tokenizer/token@0.3.0': {}
+  '@tokenizer/token@0.3.0':
+    optional: true
 
   '@tokenlens/core@1.3.0': {}
 
@@ -19454,12 +19437,10 @@ snapshots:
     dependencies:
       '@tokenlens/core': 1.3.0
 
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
   '@ts-morph/common@0.27.0':
     dependencies:
       fast-glob: 3.3.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       path-browserify: 1.0.1
 
   '@turbo/darwin-64@2.9.14':
@@ -19704,8 +19685,6 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.13': {}
-
-  '@types/mime-types@2.1.4': {}
 
   '@types/ms@2.1.0': {}
 
@@ -20472,8 +20451,6 @@ snapshots:
   baseline-browser-mapping@2.10.7: {}
 
   basic-ftp@5.2.0: {}
-
-  basic-ftp@5.3.1: {}
 
   before-after-hook@4.0.0: {}
 
@@ -21323,8 +21300,6 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-uri-to-buffer@6.0.2: {}
-
   data-uri-to-buffer@7.0.0: {}
 
   data-uri-to-buffer@8.0.0: {}
@@ -21409,12 +21384,6 @@ snapshots:
     optional: true
 
   defu@6.1.7: {}
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
 
   degenerator@6.0.0(quickjs-wasi@0.0.1):
     dependencies:
@@ -21528,7 +21497,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
   dom-serializer@1.4.1:
@@ -22231,22 +22200,13 @@ snapshots:
 
   file-type@21.3.2:
     dependencies:
-      '@tokenizer/inflate': 0.4.1(supports-color@7.2.0)
+      '@tokenizer/inflate': 0.4.1
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
     transitivePeerDependencies:
       - supports-color
     optional: true
-
-  file-type@21.3.4(supports-color@7.2.0):
-    dependencies:
-      '@tokenizer/inflate': 0.4.1(supports-color@7.2.0)
-      strtok3: 10.3.5
-      token-types: 6.1.2
-      uint8array-extras: 1.5.0
-    transitivePeerDependencies:
-      - supports-color
 
   file-uri-to-path@1.0.0: {}
 
@@ -22419,7 +22379,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  gaxios@7.1.4:
+  gaxios@7.1.4(supports-color@7.2.0):
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
@@ -22477,14 +22437,6 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  get-uri@6.0.5(supports-color@7.2.0):
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
 
   get-uri@7.0.0:
     dependencies:
@@ -22554,7 +22506,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -22608,11 +22560,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@10.6.2:
+  google-auth-library@10.6.2(supports-color@7.2.0):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.4
+      gaxios: 7.1.4(supports-color@7.2.0)
       gcp-metadata: 8.1.2(supports-color@7.2.0)
       google-logging-utils: 1.1.3
       jws: 4.0.1
@@ -22625,7 +22577,7 @@ snapshots:
     dependencies:
       extend: 3.0.2
       gaxios: 7.1.3(supports-color@7.2.0)
-      google-auth-library: 10.6.2
+      google-auth-library: 10.6.2(supports-color@7.2.0)
       qs: 6.15.0
       url-template: 2.0.8
     transitivePeerDependencies:
@@ -23113,7 +23065,8 @@ snapshots:
 
   ip-address@10.1.0: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.2.0:
+    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -23380,7 +23333,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
@@ -23497,9 +23450,6 @@ snapshots:
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
-
-  koffi@2.16.2:
-    optional: true
 
   kuler@2.0.0: {}
 
@@ -24981,8 +24931,6 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  netmask@2.1.1: {}
-
   new-github-release-url@2.0.0:
     dependencies:
       type-fest: 2.19.0
@@ -25406,19 +25354,6 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0(supports-color@7.2.0):
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      get-uri: 6.0.5(supports-color@7.2.0)
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
   pac-proxy-agent@8.0.0:
     dependencies:
       agent-base: 8.0.0
@@ -25444,11 +25379,6 @@ snapshots:
       socks-proxy-agent: 10.0.0
     transitivePeerDependencies:
       - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
 
   pac-resolver@8.0.0(quickjs-wasi@0.0.1):
     dependencies:
@@ -25923,7 +25853,7 @@ snapshots:
       '@swc/core-linux-x64-gnu': 1.15.40
       '@swc/core-linux-x64-musl': 1.15.40
       '@swc/core-win32-x64-msvc': 1.15.40
-      google-auth-library: 10.6.2
+      google-auth-library: 10.6.2(supports-color@7.2.0)
       hono: 4.12.8
       ibm-cloud-sdk-core: 5.4.20
       langfuse: 3.38.20
@@ -26034,19 +25964,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-agent@6.5.0(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0(supports-color@7.2.0)
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5(supports-color@7.2.0)
-    transitivePeerDependencies:
-      - supports-color
 
   proxy-agent@7.0.0:
     dependencies:
@@ -26371,7 +26288,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -27353,14 +27270,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socks-proxy-agent@8.0.5(supports-color@7.2.0):
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
   socks-proxy-agent@9.0.0:
     dependencies:
       agent-base: 8.0.0
@@ -27378,6 +27287,7 @@ snapshots:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
+    optional: true
 
   sonner@2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -27596,6 +27506,7 @@ snapshots:
   strtok3@10.3.5:
     dependencies:
       '@tokenizer/token': 0.3.0
+    optional: true
 
   style-to-js@1.1.21:
     dependencies:
@@ -27811,6 +27722,7 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+    optional: true
 
   tokenlens@1.3.1:
     dependencies:
@@ -27983,7 +27895,8 @@ snapshots:
 
   uhyphen@0.2.0: {}
 
-  uint8array-extras@1.5.0: {}
+  uint8array-extras@1.5.0:
+    optional: true
 
   ultrahtml@1.6.0: {}
 
@@ -28012,6 +27925,8 @@ snapshots:
   undici@7.24.8: {}
 
   undici@7.26.0: {}
+
+  undici@8.3.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -28226,8 +28141,6 @@ snapshots:
 
   uuid@13.0.2:
     optional: true
-
-  uuid@14.0.0: {}
 
   uvu@0.5.6:
     dependencies:
@@ -28901,10 +28814,6 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ catalogs:
       specifier: 4.1.18
       version: 4.1.18
     typebox:
-      specifier: ^1.1.37
-      version: 1.1.37
+      specifier: ^1.1.38
+      version: 1.1.38
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -130,8 +130,8 @@ importers:
         specifier: 'catalog:'
         version: 0.78.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
       '@google/genai':
-        specifier: ^1.45.0
-        version: 1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)
+        specifier: ^1.52.0
+        version: 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)
       '@sero-ai/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -170,7 +170,7 @@ importers:
         version: 7.2.0
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -578,7 +578,7 @@ importers:
         version: 0.78.0
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
       zod:
         specifier: catalog:peer
         version: 4.4.3
@@ -658,7 +658,7 @@ importers:
         version: 0.78.0
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
       zod:
         specifier: catalog:peer
         version: 4.4.3
@@ -725,7 +725,7 @@ importers:
         version: 0.78.0
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
     devDependencies:
       '@module-federation/vite':
         specifier: 'catalog:'
@@ -795,7 +795,7 @@ importers:
         version: 1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -871,7 +871,7 @@ importers:
         version: 4.1.0
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
       zod:
         specifier: catalog:peer
         version: 4.4.3
@@ -902,7 +902,7 @@ importers:
         version: link:../../packages/common
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
       zod:
         specifier: catalog:peer
         version: 4.4.3
@@ -981,7 +981,7 @@ importers:
         version: 7.2.4
       typebox:
         specifier: 'catalog:'
-        version: 1.1.37
+        version: 1.1.38
       unpdf:
         specifier: ^1.4.0
         version: 1.4.0(@napi-rs/canvas@0.1.80)
@@ -2657,15 +2657,6 @@ packages:
 
   '@fontsource-variable/jetbrains-mono@5.2.8':
     resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
-
-  '@google/genai@1.45.0':
-    resolution: {integrity: sha512-+sNRWhKiRibVgc4OKi7aBJJ0A7RcoVD8tGG+eFkqxAWRjASDW+ktS9lLwTDnAxZICzCVoeAdu8dYLJVTX60N9w==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
 
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
@@ -8564,10 +8555,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  google-auth-library@10.6.1:
-    resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
-    engines: {node: '>=18'}
-
   google-auth-library@10.6.2:
     resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
@@ -12605,9 +12592,6 @@ packages:
     resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
     engines: {node: '>= 18'}
 
-  typebox@1.1.37:
-    resolution: {integrity: sha512-jb7jp6KvOvvy5sd+11AfJ0/e0F0AS9RcOXd55oGi2ZnRHIGmFvrTaNF+ZidRmGBmmNTkM5KKl0Z37KzxJ+owEQ==}
-
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
@@ -15837,19 +15821,6 @@ snapshots:
   '@floating-ui/utils@0.2.11': {}
 
   '@fontsource-variable/jetbrains-mono@5.2.8': {}
-
-  '@google/genai@1.45.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)':
-    dependencies:
-      google-auth-library: 10.6.1(supports-color@7.2.0)
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@4.3.6))':
     dependencies:
@@ -22549,17 +22520,6 @@ snapshots:
       gopd: 1.2.0
     optional: true
 
-  google-auth-library@10.6.1(supports-color@7.2.0):
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.3(supports-color@7.2.0)
-      gcp-metadata: 8.1.2(supports-color@7.2.0)
-      google-logging-utils: 1.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   google-auth-library@10.6.2(supports-color@7.2.0):
     dependencies:
       base64-js: 1.5.1
@@ -25951,7 +25911,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.12.2
+      '@types/node': 25.9.1
       long: 5.3.2
 
   protobufjs@8.4.2:
@@ -27869,8 +27829,6 @@ snapshots:
       content-type: 2.0.0
       media-typer: 1.1.0
       mime-types: 3.0.2
-
-  typebox@1.1.37: {}
 
   typebox@1.1.38: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,12 +35,12 @@ catalog:
   "@types/node": "^22.19.11"
 
   # Pi SDK
-  "@mariozechner/pi-agent-core": "^0.73.1"
-  "@mariozechner/pi-ai": "^0.73.1"
-  "@mariozechner/pi-coding-agent": "^0.73.1"
-  "@mariozechner/pi-tui": "^0.73.1"
+  "@earendil-works/pi-agent-core": "0.78.0"
+  "@earendil-works/pi-ai": "0.78.0"
+  "@earendil-works/pi-coding-agent": "0.78.0"
+  "@earendil-works/pi-tui": "0.78.0"
 
-  # Zod (peer of @mariozechner/pi-* transitives: openai, @anthropic-ai/sdk, zod-to-json-schema)
+  # Zod (peer of @earendil-works/pi-* transitives: openai, @anthropic-ai/sdk, zod-to-json-schema)
   zod: "^4.3.6"
 
   # Shared libraries
@@ -55,10 +55,10 @@ catalog:
 # Use "catalog:peer" in peerDependencies.
 catalogs:
   peer:
-    "@mariozechner/pi-agent-core": ">=0.72.1"
-    "@mariozechner/pi-ai": ">=0.72.1"
-    "@mariozechner/pi-coding-agent": ">=0.72.1"
-    "@mariozechner/pi-tui": ">=0.72.1"
+    "@earendil-works/pi-agent-core": ">=0.78.0"
+    "@earendil-works/pi-ai": ">=0.78.0"
+    "@earendil-works/pi-coding-agent": ">=0.78.0"
+    "@earendil-works/pi-tui": ">=0.78.0"
     # Mirror the strict catalog above. See the comment there for why these
     # MUST stay aligned.
     react: "^19.2.4"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
 
   # Shared libraries
   "@sinclair/typebox": "^0.34.49"
-  typebox: "^1.1.37"
+  typebox: "^1.1.38"
   lucide-react: "^0.563.0"
   motion: "^12.34.0"
   streamdown: "^2.5.0"

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -14,9 +14,10 @@ const require = createRequire(import.meta.url);
 const esbuild = require(path.join(repoRoot, 'apps/desktop/node_modules/esbuild'));
 const workspaceYamlPath = path.join(repoRoot, 'pnpm-workspace.yaml');
 
-const packageArg = process.argv[2];
+const quiet = process.argv.includes('--quiet');
+const packageArg = process.argv.slice(2).find((arg) => !arg.startsWith('-'));
 if (!packageArg) {
-  console.error('Usage: node scripts/build-plugin.mjs <package-dir>');
+  console.error('Usage: node scripts/build-plugin.mjs <package-dir> [--quiet]');
   process.exit(1);
 }
 
@@ -33,6 +34,10 @@ function run(command, args, options = {}) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+}
+
+function log(message = '') {
+  if (!quiet) console.log(message);
 }
 
 function toPosix(relativePath) {
@@ -195,8 +200,8 @@ async function listFilesRecursive(dirPath) {
 async function buildUiIfPresent(pkg) {
   if (!pkg.sero?.app?.ui) return;
 
-  console.log('  → Building UI remote...');
-  run('pnpm', ['exec', 'vite', 'build'], {
+  log('  → Building UI remote...');
+  run('pnpm', ['exec', 'vite', 'build', ...(quiet ? ['--logLevel', 'error'] : [])], {
     cwd: packageDir,
     env: {
       ...process.env,
@@ -243,7 +248,7 @@ async function bundleExtensions(pkg, outputDir) {
     const outputRelativePath = toJsRelativePath(entry.replace(/^\.\//, ''));
     const outputPath = path.join(outputDir, outputRelativePath);
 
-    console.log(`  → Bundling extension ${entry}...`);
+    log(`  → Bundling extension ${entry}...`);
     await bundleNodeEntry(sourcePath, outputPath, [...extensionExternals]);
     compiledEntries.push(`./${toPosix(outputRelativePath)}`);
   }
@@ -265,7 +270,7 @@ async function bundleRuntimeIfPresent(pkg, outputDir) {
   const outputRelativePath = toJsRelativePath(runtimeEntry.replace(/^\.\//, ''));
   const outputPath = path.join(outputDir, outputRelativePath);
 
-  console.log(`  → Bundling runtime ${runtimeEntry}...`);
+  log(`  → Bundling runtime ${runtimeEntry}...`);
   await bundleNodeEntry(sourcePath, outputPath, [...runtimeExternals]);
   return `./${toPosix(outputRelativePath)}`;
 }
@@ -426,7 +431,7 @@ async function main() {
   await fs.rm(outputDir, { recursive: true, force: true });
   await fs.mkdir(outputDir, { recursive: true });
 
-  console.log(`📦 Building plugin: ${packageLabel} (${packageDir})`);
+  log(`📦 Building plugin: ${packageLabel} (${packageDir})`);
   await buildUiIfPresent(pkg);
   const compiledExtensions = await bundleExtensions(pkg, outputDir);
   const compiledRuntimeEntry = await bundleRuntimeIfPresent(pkg, outputDir);
@@ -440,14 +445,14 @@ async function main() {
     'utf8',
   );
 
-  console.log(`✅ Plugin ${packageLabel} built successfully`);
-  console.log(`   Output: ${path.relative(process.cwd(), outputDir)}`);
-  console.log('');
-  console.log('To test locally:');
-  console.log(`   await window.sero.plugins.install('${outputDir}')`);
-  console.log('');
-  console.log('To inspect the publishable tarball:');
-  console.log(`   (cd '${outputDir}' && npm pack)`);
+  log(`✅ Plugin ${packageLabel} built successfully`);
+  log(`   Output: ${path.relative(process.cwd(), outputDir)}`);
+  log();
+  log('To test locally:');
+  log(`   await window.sero.plugins.install('${outputDir}')`);
+  log();
+  log('To inspect the publishable tarball:');
+  log(`   (cd '${outputDir}' && npm pack)`);
 }
 
 main().catch((error) => {

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -354,6 +354,25 @@ function getPublishedDependencies(pkg, keepNames) {
     : pkg.dependencies;
 }
 
+function compiledFileEntry(entry) {
+  return entry.replace(/^\.\//, '');
+}
+
+function buildPublishedFiles(compiledExtensions, compiledRuntimeEntry) {
+  const entries = new Set([
+    'package.json',
+    'README.md',
+    'LICENSE',
+    'dist/ui',
+    'shared',
+    'prompts',
+    'skills',
+  ]);
+  for (const entry of compiledExtensions) entries.add(compiledFileEntry(entry));
+  if (compiledRuntimeEntry) entries.add(compiledFileEntry(compiledRuntimeEntry));
+  return [...entries];
+}
+
 function buildPublishedManifest(pkg, compiledExtensions, compiledRuntimeEntry, catalogs) {
   const publishedDependencyNames = getPublishedDependencyNames(pkg);
   const publishedAppManifest = pkg.sero?.app
@@ -400,17 +419,7 @@ function buildPublishedManifest(pkg, compiledExtensions, compiledRuntimeEntry, c
             : {}),
         }
       : undefined,
-    files: [
-      'package.json',
-      'README.md',
-      'LICENSE',
-      'dist/ui',
-      'extension',
-      ...(compiledRuntimeEntry ? ['runtime'] : []),
-      'shared',
-      'prompts',
-      'skills',
-    ],
+    files: buildPublishedFiles(compiledExtensions, compiledRuntimeEntry),
   };
 
   return Object.fromEntries(

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -217,6 +217,16 @@ async function bundleNodeEntry(sourcePath, outputPath, externals) {
     external: externals,
     sourcemap: false,
     legalComments: 'none',
+    banner: {
+      js: `
+import { createRequire as __createRequire } from 'module';
+import { fileURLToPath as __fileURLToPath } from 'url';
+import { dirname as __dirnameFn } from 'path';
+const require = __createRequire(import.meta.url);
+const __filename = __fileURLToPath(import.meta.url);
+const __dirname = __dirnameFn(__filename);
+`.trim(),
+    },
   });
 }
 

--- a/scripts/build-plugin.mjs
+++ b/scripts/build-plugin.mjs
@@ -66,6 +66,31 @@ function getRuntimeExternals(pkg) {
   return expandExternalSpecifiers(runtimeExternals);
 }
 
+function getExtensionExternals(pkg) {
+  const extensionExternals = Array.isArray(pkg.sero?.plugin?.extensionExternals)
+    ? pkg.sero.plugin.extensionExternals
+    : [];
+  return expandExternalSpecifiers(extensionExternals);
+}
+
+function packageNameFromSpecifier(specifier) {
+  if (typeof specifier !== 'string' || !specifier.trim()) return null;
+  const normalized = specifier.trim().replace(/\/\*$/, '');
+  if (normalized.startsWith('@')) {
+    const [scope, name] = normalized.split('/');
+    return scope && name ? `${scope}/${name}` : null;
+  }
+  return normalized.split('/')[0] ?? null;
+}
+
+function dependencyNamesFromExternals(specifiers) {
+  return new Set(
+    specifiers
+      .map(packageNameFromSpecifier)
+      .filter((name) => typeof name === 'string' && name.length > 0),
+  );
+}
+
 async function loadWorkspaceCatalogs() {
   const raw = await fs.readFile(workspaceYamlPath, 'utf8');
   const defaultCatalog = {};
@@ -197,7 +222,10 @@ async function bundleNodeEntry(sourcePath, outputPath, externals) {
 
 async function bundleExtensions(pkg, outputDir) {
   const extensionEntries = Array.isArray(pkg.pi?.extensions) ? pkg.pi.extensions : [];
-  const peerExternals = getPeerExternals(pkg);
+  const extensionExternals = new Set([
+    ...getPeerExternals(pkg),
+    ...getExtensionExternals(pkg),
+  ]);
   const compiledEntries = [];
 
   for (const entry of extensionEntries) {
@@ -206,7 +234,7 @@ async function bundleExtensions(pkg, outputDir) {
     const outputPath = path.join(outputDir, outputRelativePath);
 
     console.log(`  → Bundling extension ${entry}...`);
-    await bundleNodeEntry(sourcePath, outputPath, peerExternals);
+    await bundleNodeEntry(sourcePath, outputPath, [...extensionExternals]);
     compiledEntries.push(`./${toPosix(outputRelativePath)}`);
   }
 
@@ -288,7 +316,31 @@ async function copyPackageResources(pkg, outputDir) {
   await copyIfExists(path.join(packageDir, 'LICENSE'), path.join(outputDir, 'LICENSE'));
 }
 
+function filterDependencyMap(dependencies, keepNames) {
+  if (!dependencies) return undefined;
+
+  const filtered = Object.fromEntries(
+    Object.entries(dependencies).filter(([name]) => keepNames.has(name)),
+  );
+
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
+function getPublishedDependencyNames(pkg) {
+  return new Set([
+    ...dependencyNamesFromExternals(getExtensionExternals(pkg)),
+    ...dependencyNamesFromExternals(getRuntimeExternals(pkg)),
+  ]);
+}
+
+function getPublishedDependencies(pkg, keepNames) {
+  return pkg.sero?.plugin?.bundleExtensions === true
+    ? filterDependencyMap(pkg.dependencies, keepNames)
+    : pkg.dependencies;
+}
+
 function buildPublishedManifest(pkg, compiledExtensions, compiledRuntimeEntry, catalogs) {
+  const publishedDependencyNames = getPublishedDependencyNames(pkg);
   const publishedAppManifest = pkg.sero?.app
     ? (() => {
         const {
@@ -308,7 +360,10 @@ function buildPublishedManifest(pkg, compiledExtensions, compiledRuntimeEntry, c
     scripts: undefined,
     devDependencies: undefined,
     private: undefined,
-    dependencies: resolveDependencyMap(pkg.dependencies, catalogs),
+    dependencies: resolveDependencyMap(
+      getPublishedDependencies(pkg, publishedDependencyNames),
+      catalogs,
+    ),
     peerDependencies: resolveDependencyMap(pkg.peerDependencies, catalogs),
     pi: pkg.pi
       ? {
@@ -350,9 +405,10 @@ function buildPublishedManifest(pkg, compiledExtensions, compiledRuntimeEntry, c
 
 async function main() {
   const pkg = await readPackageJson();
-  const appId = pkg.sero?.app?.id;
-  if (!appId) {
-    throw new Error(`No sero.app.id found in ${packageJsonPath}`);
+  const packageLabel = pkg.sero?.app?.id ?? pkg.name ?? path.basename(packageDir);
+  const hasExtensionEntries = Array.isArray(pkg.pi?.extensions) && pkg.pi.extensions.length > 0;
+  if (!pkg.sero?.app?.id && !hasExtensionEntries) {
+    throw new Error(`No sero.app.id or pi.extensions found in ${packageJsonPath}`);
   }
 
   const catalogs = await loadWorkspaceCatalogs();
@@ -360,7 +416,7 @@ async function main() {
   await fs.rm(outputDir, { recursive: true, force: true });
   await fs.mkdir(outputDir, { recursive: true });
 
-  console.log(`📦 Building plugin: ${appId} (${packageDir})`);
+  console.log(`📦 Building plugin: ${packageLabel} (${packageDir})`);
   await buildUiIfPresent(pkg);
   const compiledExtensions = await bundleExtensions(pkg, outputDir);
   const compiledRuntimeEntry = await bundleRuntimeIfPresent(pkg, outputDir);
@@ -374,7 +430,7 @@ async function main() {
     'utf8',
   );
 
-  console.log(`✅ Plugin ${appId} built successfully`);
+  console.log(`✅ Plugin ${packageLabel} built successfully`);
   console.log(`   Output: ${path.relative(process.cwd(), outputDir)}`);
   console.log('');
   console.log('To test locally:');


### PR DESCRIPTION
## Summary
- Reduce packaged desktop/web-remote bundle size and prune stale/redundant release artifacts.
- Migrate Sero from deprecated `@mariozechner/pi-*` packages to `@earendil-works/pi-*` at Pi SDK `0.78.0`.
- Fix the Pi SDK `0.78.0` session-listing regression by reading all-session metadata directly and keeping gateway listings workspace-scoped.
- Bump `@sero-ai/common` and `@sero-ai/app-runtime` for the Pi SDK migration.
- Align packaged dependency versions for `@google/genai` and `typebox` to avoid duplicate deployed versions.

## Validation
- `pnpm --filter @sero/desktop typecheck`
- `pnpm --filter @sero/desktop build`
- `pnpm --filter @sero/desktop run pack`
- `pnpm --filter @sero/desktop test` (`301` files, `1555` tests passed)

## Notes
- Final local packaged `app.asar` is about `89M` by `ls -lh`.
- `app.asar.unpacked` remains about `17M`.
