### PR TITLE
fix(desktop): publish host core tools from releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,9 @@ jobs:
       - name: Verify published browser packs
         run: pnpm --filter @sero/desktop browser-pack:verify-published
 
+      - name: Verify published core toolchains
+        run: pnpm --filter @sero/desktop toolchain:verify-published
+
       - name: Run host release smoke
         run: |
           if [[ "${{ matrix.os }}" == "linux" ]] && command -v xvfb-run >/dev/null 2>&1; then

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
@@ -39,15 +39,15 @@ describe('toolchain manifest helpers', () => {
     const loaded = loadBundledToolchainManifest();
     const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'] as const;
     const targets = [
-      { platform: 'darwin', arch: 'arm64' },
-      { platform: 'linux', arch: 'arm64' },
-      { platform: 'linux', arch: 'x64' },
-      { platform: 'win32', arch: 'x64' },
+      { platform: 'darwin', arch: 'arm64', tools: ['node', 'npm', 'pnpm'] },
+      { platform: 'linux', arch: 'arm64', tools: coreTools },
+      { platform: 'linux', arch: 'x64', tools: coreTools },
+      { platform: 'win32', arch: 'x64', tools: coreTools },
     ] as const;
 
-    expect(Object.keys(loaded.artifacts).length).toBe(coreTools.length * targets.length);
+    expect(Object.keys(loaded.artifacts).length).toBe(targets.reduce((count, target) => count + target.tools.length, 0));
     for (const target of targets) {
-      for (const tool of coreTools) {
+      for (const tool of target.tools) {
         expect(findArtifactForPlatform(loaded, tool, target.platform, target.arch)).toMatchObject({
           tool,
           platform: target.platform,

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import generatedArtifacts from '@electron/features/workspace/runtime/toolchains/generated-artifacts.json';
 import {
   createTestToolchainManifest,
   findArtifactForPlatform,
@@ -39,7 +40,6 @@ describe('toolchain manifest helpers', () => {
     const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'] as const;
     const targets = [
       { platform: 'darwin', arch: 'arm64' },
-      { platform: 'darwin', arch: 'x64' },
       { platform: 'linux', arch: 'arm64' },
       { platform: 'linux', arch: 'x64' },
       { platform: 'win32', arch: 'x64' },
@@ -62,7 +62,7 @@ describe('toolchain manifest helpers', () => {
     const loaded = loadBundledToolchainManifest();
     for (const artifact of Object.values(loaded.artifacts)) {
       expect(artifact.url).toMatch(/^https:\/\//);
-      expect(artifact.url).toMatch(/^https:\/\/github\.com\/sero-labs\/sero\/releases\/download\/toolchains-2026-05-16\//);
+      expect(artifact.url).toMatch(new RegExp(`^https://github\\.com/sero-labs/sero/releases/download/${generatedArtifacts.releaseTag}/`));
       expect(artifact.url).not.toContain('downloads.sero.ai');
       expect(artifact.url).toMatch(/\.tar\.gz$/);
       expect(artifact.sha256).toMatch(/^[a-f0-9]{64}$/);

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
@@ -62,6 +62,8 @@ describe('toolchain manifest helpers', () => {
     const loaded = loadBundledToolchainManifest();
     for (const artifact of Object.values(loaded.artifacts)) {
       expect(artifact.url).toMatch(/^https:\/\//);
+      expect(artifact.url).toMatch(/^https:\/\/github\.com\/sero-labs\/sero\/releases\/download\/toolchains-2026-05-16\//);
+      expect(artifact.url).not.toContain('downloads.sero.ai');
       expect(artifact.url).toMatch(/\.tar\.gz$/);
       expect(artifact.sha256).toMatch(/^[a-f0-9]{64}$/);
       expect(new Set(artifact.sha256).size).toBeGreaterThan(6);

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts
@@ -69,6 +69,9 @@ describe('toolchain manifest helpers', () => {
       expect(new Set(artifact.sha256).size).toBeGreaterThan(6);
       expect(artifact.unpackTo).not.toContain('..');
       expect(Object.keys(artifact.binPaths)).toContain(artifact.tool);
+      for (const binPath of Object.values(artifact.binPaths)) {
+        expect(binPath.startsWith(`${artifact.unpackTo}/`)).toBe(true);
+      }
       expect(artifact.minVersion).toBeTruthy();
     }
   });

--- a/apps/desktop/electron/__tests__/scripts/toolchains/merge-toolchain-metadata.test.ts
+++ b/apps/desktop/electron/__tests__/scripts/toolchains/merge-toolchain-metadata.test.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mergeToolchainMetadata } from '../../../../scripts/toolchains/merge-toolchain-metadata.mjs';
+
+let tempRoot: string;
+
+beforeEach(async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-toolchain-merge-'));
+});
+
+afterEach(async () => {
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+describe('merge-toolchain-metadata', () => {
+  it('merges release sidecars into committed toolchain metadata', async () => {
+    const metadataPath = path.join(tempRoot, 'generated-artifacts.json');
+    const sidecarDir = path.join(tempRoot, 'sidecars');
+    const out = path.join(tempRoot, 'out.json');
+    await fs.mkdir(sidecarDir, { recursive: true });
+    await writeJson(metadataPath, { version: 'old', releaseTag: 'old-tag', artifacts: baseArtifacts() });
+    await writeJson(path.join(sidecarDir, 'node-linux-x64.json'), {
+      key: 'node-linux-x64',
+      tool: 'node',
+      platform: 'linux',
+      arch: 'x64',
+      slug: 'node-linux-x64',
+      url: 'https://github.com/sero-labs/sero/releases/download/toolchains-test/node-linux-x64.tar.gz',
+      sha256: 'a'.repeat(64),
+    });
+
+    await mergeToolchainMetadata({
+      sidecarDir,
+      metadataPath,
+      out,
+      releaseTag: 'toolchains-test',
+      version: 'test-version',
+    });
+
+    const merged = JSON.parse(await fs.readFile(out, 'utf8'));
+    expect(merged.version).toBe('test-version');
+    expect(merged.releaseTag).toBe('toolchains-test');
+    expect(merged.artifacts['node-linux-x64']).toMatchObject({ status: 'built', available: true, sha256: 'a'.repeat(64) });
+    expect(merged.artifacts['npm-linux-x64']).toMatchObject({ status: 'pending', available: false });
+  });
+});
+
+function baseArtifacts() {
+  return {
+    'node-linux-x64': artifact('node'),
+    'npm-linux-x64': artifact('npm'),
+  };
+}
+
+function artifact(tool: string) {
+  return {
+    tool,
+    platform: 'linux',
+    arch: 'x64',
+    slug: `${tool}-linux-x64`,
+    status: 'pending',
+    available: false,
+    unpackTo: `${tool}-linux-x64`,
+    binPaths: { [tool]: `bin/${tool}` },
+    minVersion: '1.0.0',
+    installPolicy: 'core',
+  };
+}
+
+async function writeJson(filePath: string, value: unknown) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}

--- a/apps/desktop/electron/__tests__/scripts/toolchains/verify-toolchain-publication.test.ts
+++ b/apps/desktop/electron/__tests__/scripts/toolchains/verify-toolchain-publication.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { verifyToolchainPublication } from '../../../../scripts/toolchains/verify-toolchain-publication.mjs';
+
+const targets = [
+  { platform: 'darwin', arch: 'arm64', releaseSupported: true },
+  { platform: 'darwin', arch: 'x64', releaseSupported: false },
+  { platform: 'linux', arch: 'x64', releaseSupported: true },
+  { platform: 'linux', arch: 'arm64', releaseSupported: true },
+  { platform: 'win32', arch: 'x64', releaseSupported: true },
+];
+const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'];
+const releaseTag = 'toolchains-2026-05-16';
+
+function shaFor(key: string): string {
+  return createHash('sha256').update(Buffer.from(key)).digest('hex');
+}
+
+describe('verify-toolchain-publication', () => {
+  it('fails when a release-supported core artifact is pending', async () => {
+    const metadata = createMetadata();
+    metadata.artifacts['node-linux-x64'] = pendingArtifact('node', 'linux', 'x64', 'node-linux-x64');
+
+    await expect(verify(metadata)).rejects.toThrow('node-linux-x64 is required for release but is not built/available');
+  });
+
+  it('fails when a core artifact does not use the toolchain GitHub Release URL', async () => {
+    const metadata = createMetadata();
+    metadata.artifacts['node-linux-x64'].url = 'https://downloads.sero.ai/toolchains/2026-05-16/node-linux-x64.tar.gz';
+
+    await expect(verify(metadata)).rejects.toThrow('node-linux-x64 must use the toolchains-2026-05-16 GitHub Release asset URL');
+  });
+
+  it('passes when release-supported core artifacts are published and hash verified', async () => {
+    await expect(verify(createMetadata())).resolves.toMatchObject({
+      verifiedKeys: expect.arrayContaining(['node-macos-arm64', 'bash-windows-x64']),
+    });
+  });
+});
+
+function verify(metadata: ReturnType<typeof createMetadata>) {
+  return verifyToolchainPublication({
+    targets,
+    metadata,
+    downloadArtifact: async (_url: string, key: string) => Buffer.from(key),
+  });
+}
+
+function createMetadata() {
+  const artifacts: Record<string, ReturnType<typeof builtArtifact> | ReturnType<typeof pendingArtifact>> = {};
+  for (const target of targets) {
+    for (const tool of coreTools) {
+      const slug = `${tool}-${toolchainSlugFor(target.platform, target.arch)}`;
+      artifacts[slug] = target.releaseSupported
+        ? builtArtifact(tool, target.platform, target.arch, slug)
+        : pendingArtifact(tool, target.platform, target.arch, slug);
+    }
+  }
+  return { version: '2026.05.16', releaseTag, artifacts };
+}
+
+function builtArtifact(tool: string, platform: string, arch: string, slug: string) {
+  return {
+    tool,
+    platform,
+    arch,
+    slug,
+    status: 'built' as const,
+    available: true,
+    url: `https://github.com/sero-labs/sero/releases/download/${releaseTag}/${slug}.tar.gz`,
+    sha256: shaFor(slug),
+  };
+}
+
+function pendingArtifact(tool: string, platform: string, arch: string, slug: string) {
+  return {
+    tool,
+    platform,
+    arch,
+    slug,
+    status: 'pending' as const,
+    available: false,
+    url: undefined as string | undefined,
+    sha256: undefined as string | undefined,
+  };
+}
+
+function toolchainSlugFor(platform: string, arch: string): string {
+  if (platform === 'darwin') return arch === 'arm64' ? 'macos-arm64' : 'macos-x64';
+  if (platform === 'linux') return arch === 'arm64' ? 'linux-arm64' : 'linux-x64';
+  if (platform === 'win32') return arch === 'arm64' ? 'windows-arm64' : 'windows-x64';
+  throw new Error(`Unsupported target: ${platform}/${arch}`);
+}

--- a/apps/desktop/electron/__tests__/scripts/verify-host-mode-release.test.ts
+++ b/apps/desktop/electron/__tests__/scripts/verify-host-mode-release.test.ts
@@ -57,6 +57,23 @@ describe('verify-host-mode-release', () => {
     await expect(verifyFixture()).rejects.toThrow('Missing built/available browser-pack artifact in committed metadata: browser-linux-x64');
   });
 
+  it('fails when a required core toolchain artifact is not built and available', async () => {
+    const metadata = createBuiltToolchainMetadata();
+    metadata.artifacts['node-linux-x64'] = createPendingToolchainArtifact('node', 'linux', 'x64', 'node-linux-x64');
+    await writeJson(toolchainMetadataPath(), metadata);
+
+    await expect(verifyFixture()).rejects.toThrow('Missing built/available core toolchain artifact in committed metadata: node-linux-x64');
+  });
+
+  it('fails when runtime artifact metadata references downloads.sero.ai', async () => {
+    const metadata = createBuiltToolchainMetadata();
+    metadata.artifacts['node-linux-x64'].url = 'https://downloads.sero.ai/toolchains/2026-05-16/node-linux-x64.tar.gz';
+    await writeJson(toolchainMetadataPath(), metadata);
+
+    await expect(verifyFixture()).rejects.toThrow('node-linux-x64 must use a GitHub Release core toolchain URL in committed metadata');
+    await expect(verifyFixture()).rejects.toThrow('runtime artifacts must not use downloads.sero.ai');
+  });
+
   it('fails when a required package script is missing', async () => {
     await writeJson(path.join(desktopRoot, 'package.json'), {
       scripts: {
@@ -65,6 +82,7 @@ describe('verify-host-mode-release', () => {
         'dist:linux:arm64': 'bash scripts/build-release.sh --target linux --arch arm64',
         'dist:win': 'bash scripts/build-release.sh --target win',
         'browser-pack:verify-published': 'node scripts/browser-pack/verify-browser-pack-publication.mjs',
+        'toolchain:verify-published': 'node scripts/toolchains/verify-toolchain-publication.mjs',
       },
     });
 
@@ -126,10 +144,12 @@ function verifyFixture() {
 async function writeFixture() {
   await fs.mkdir(path.dirname(matrixPath()), { recursive: true });
   await fs.mkdir(path.dirname(metadataPath()), { recursive: true });
+  await fs.mkdir(path.dirname(toolchainMetadataPath()), { recursive: true });
   await fs.mkdir(path.dirname(workflowPath()), { recursive: true });
   await fs.mkdir(path.join(repoRoot, 'docs/features'), { recursive: true });
   await writeJson(matrixPath(), matrix);
   await writeJson(metadataPath(), createBuiltMetadata());
+  await writeJson(toolchainMetadataPath(), createBuiltToolchainMetadata());
   await writeJson(path.join(desktopRoot, 'package.json'), {
     scripts: {
       'dist:mac': 'bash scripts/build-release.sh --target mac',
@@ -138,6 +158,7 @@ async function writeFixture() {
       'dist:linux:arm64': 'bash scripts/build-release.sh --target linux --arch arm64',
       'dist:win': 'bash scripts/build-release.sh --target win',
       'browser-pack:verify-published': 'node scripts/browser-pack/verify-browser-pack-publication.mjs',
+      'toolchain:verify-published': 'node scripts/toolchains/verify-toolchain-publication.mjs',
     },
   });
   await fs.writeFile(workflowPath(), workflowText());
@@ -155,6 +176,39 @@ function createBuiltMetadata() {
       : createPendingArtifact(target.platform, target.arch, slug);
   }
   return { artifacts };
+}
+
+function createBuiltToolchainMetadata() {
+  const artifacts: Record<string, FixtureArtifact & { tool: string; installPolicy: string }> = {};
+  for (const target of matrix) {
+    for (const tool of ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash']) {
+      const slug = `${tool}-${toolchainSlugFor(target.platform, target.arch)}`;
+      artifacts[slug] = target.releaseSupported
+        ? createBuiltToolchainArtifact(tool, target.platform, target.arch, slug)
+        : createPendingToolchainArtifact(tool, target.platform, target.arch, slug);
+    }
+  }
+  return { version: '2026.05.16', releaseTag: 'toolchains-2026-05-16', artifacts };
+}
+
+function createBuiltToolchainArtifact(tool: string, platform: string, arch: string, slug: string) {
+  return {
+    ...createBuiltArtifact(platform, arch, slug),
+    tool,
+    url: `https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/${slug}.tar.gz`,
+    unpackTo: slug,
+    binPaths: { [tool]: `bin/${tool}` },
+    minVersion: '1.0.0',
+    installPolicy: 'core',
+  };
+}
+
+function createPendingToolchainArtifact(tool: string, platform: string, arch: string, slug: string) {
+  return {
+    ...createPendingArtifact(platform, arch, slug),
+    tool,
+    installPolicy: 'core',
+  };
 }
 
 function createBuiltArtifact(platform: string, arch: string, slug: string): FixtureArtifact {
@@ -203,6 +257,7 @@ jobs:
             dist: dist:win
     steps:
       - run: pnpm --filter @sero/desktop browser-pack:verify-published
+      - run: pnpm --filter @sero/desktop toolchain:verify-published
       - run: pnpm --filter @sero/desktop e2e:workflow -- runtime-host-release.workflow.spec.ts
       - name: Verify macOS app bundle
 `;
@@ -222,6 +277,13 @@ function slugFor(platform: string, arch: string): string {
   throw new Error(`Unsupported fixture target: ${platform}/${arch}`);
 }
 
+function toolchainSlugFor(platform: string, arch: string): string {
+  if (platform === 'darwin') return arch === 'arm64' ? 'macos-arm64' : 'macos-x64';
+  if (platform === 'linux') return arch === 'arm64' ? 'linux-arm64' : 'linux-x64';
+  if (platform === 'win32') return arch === 'arm64' ? 'windows-arm64' : 'windows-x64';
+  throw new Error(`Unsupported fixture target: ${platform}/${arch}`);
+}
+
 async function writeJson(filePath: string, value: unknown) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
@@ -233,6 +295,10 @@ function matrixPath() {
 
 function metadataPath() {
   return path.join(desktopRoot, 'electron/features/workspace/runtime/browser-pack/generated-artifacts.json');
+}
+
+function toolchainMetadataPath() {
+  return path.join(desktopRoot, 'electron/features/workspace/runtime/toolchains/generated-artifacts.json');
 }
 
 function workflowPath() {

--- a/apps/desktop/electron/features/workspace/runtime/install-actions.ts
+++ b/apps/desktop/electron/features/workspace/runtime/install-actions.ts
@@ -87,7 +87,10 @@ export function setRuntimeInstallManagersForTest(input: {
 
 async function ensureCoreToolsInternal(reason: string): Promise<ToolchainStatusIPC> {
   try {
-    await getToolchainManager().ensureCore({ kind: 'settings', detail: reason });
+    const installReason = reason === 'onboarding'
+      ? { kind: 'onboarding' as const }
+      : { kind: 'settings' as const, detail: reason };
+    await getToolchainManager().ensureCore(installReason);
     return buildToolchainStatus(false);
   } catch {
     return buildToolchainStatus(false);

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/bundled-manifest-data.ts
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/bundled-manifest-data.ts
@@ -1,100 +1,135 @@
-import type { ArtifactSpec, ManagedToolArch, ManagedToolPlatform, ToolName, ToolchainManifest } from './types';
+import generatedArtifacts from './generated-artifacts.json';
+import type {
+  ArtifactSpec,
+  ManagedToolArch,
+  ManagedToolPlatform,
+  ToolInstallPolicy,
+  ToolName,
+  ToolchainManifest,
+} from './types';
 
-const MANIFEST_VERSION = '2026.05.16';
-const RELEASE_DATE = '2026-05-16';
-const CORE_TOOLS = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'] as const satisfies readonly ToolName[];
-const SUPPORTED_TARGETS = [
-  { platform: 'darwin', arch: 'arm64', slug: 'macos-arm64' },
-  { platform: 'darwin', arch: 'x64', slug: 'macos-x64' },
-  { platform: 'linux', arch: 'arm64', slug: 'linux-arm64' },
-  { platform: 'linux', arch: 'x64', slug: 'linux-x64' },
-  { platform: 'win32', arch: 'x64', slug: 'windows-x64' },
-] as const satisfies readonly SupportedTarget[];
+const LOCAL_URL_BASE_ENV = 'SERO_TOOLCHAIN_BASE_URL';
 
-interface SupportedTarget {
-  platform: ManagedToolPlatform;
-  arch: ManagedToolArch;
+interface ToolchainGeneratedArtifactJson {
+  tool: string;
+  platform: string;
+  arch: string;
   slug: string;
+  status?: string;
+  available?: boolean;
+  url?: string;
+  sha256?: string;
+  unpackTo: string;
+  binPaths: Record<string, string>;
+  minVersion?: string;
+  installPolicy: string;
 }
 
-const MIN_VERSIONS: Record<(typeof CORE_TOOLS)[number], string> = {
-  node: '22.0.0',
-  npm: '10.0.0',
-  pnpm: '9.0.0',
-  git: '2.30.0',
-  ssh: '8.0.0',
-  bash: '3.2.0',
-};
+interface ToolchainGeneratedArtifact extends ToolchainGeneratedArtifactJson {
+  tool: ToolName;
+  platform: ManagedToolPlatform;
+  arch: ManagedToolArch;
+  installPolicy: ToolInstallPolicy;
+}
 
-const PINNED_SHA256: Record<string, string> = {
-  'bash-linux-arm64': '478cc6a68ef5198fbff527647753a07f1f2039e331d86a1246ac07e97de723b0',
-  'bash-linux-x64': 'a686b40502d3f7d123aab13f339234cb506a13ab02e347e9172634dc3000531d',
-  'bash-macos-arm64': '95388d315d2c9a8809549e80948d71184a5f743995b8b58c0cc7c330fc4567ec',
-  'bash-macos-x64': 'de8bc4346d99db1b2548f777ec5a5c5a1e993067d4349f874870c08f1d9c05f5',
-  'bash-windows-x64': '78b6d9d3a92767d1d5fde162055dce02e6d8a7df496dbcb85b408b8e3373b7f4',
-  'git-linux-arm64': '35cbf8f69e242dcf7614488d447cf028e24bd6251e3828b77642a74264417d49',
-  'git-linux-x64': '8bb7986e3ff23ec3c8dafdbed621ac6fe4a20d935cd37a6c133b7e023aa50fff',
-  'git-macos-arm64': '5119bd9811458665b6dcc8f2d5f0131c3c7f960287689b8031fbd4ddc83be2f2',
-  'git-macos-x64': '03d7b8c9d2c8117ff80c416a2e7f7d483b1e8c82f5546fad8cd3f1ccc39efb28',
-  'git-windows-x64': '4bf11bfc98b157d51e6f7494223bdb7af9bcd9f79a03cf58d499a715d09a8e35',
-  'node-linux-arm64': '0e958a7c61eb52752c64696a6b35da38be512276e47182926c096e96ae25e0bf',
-  'node-linux-x64': '4c175beb78eb3ce63721df399d16c88c5c1d5f157449e43bb54e782177a66a3d',
-  'node-macos-arm64': '22ab6bc9a8f566a3c4a7f0d71dc7a4e1b5985a545a7145739ccb31929d66ab4b',
-  'node-macos-x64': 'd8f63452c248b969ea5ac2933fcb80569e341522db0ada7aedff4cd3c71743f0',
-  'node-windows-x64': '2fa2a169efdc97ba3db9f671d71f66bdb529e801c5933c1554b4009358a0fc92',
-  'npm-linux-arm64': '1a3e6d24fe00e1186859b2e45d743ff224e3eb683cb0e6ff87fcb8051042664b',
-  'npm-linux-x64': '345d7b46412a51388cfa21873e5c1f36cc58d41ea01bb69f9a271469c9281298',
-  'npm-macos-arm64': 'd75ef7ea84d99ff337352c1d5ce9fc41286f55982fd36dc052216235f3d10376',
-  'npm-macos-x64': '7ae2f82b686d2ec7d1ec8c31dca892d7b45dc411959b8317d00d433d90f1d9d0',
-  'npm-windows-x64': 'ad98a3e0d2b88fb5d6eecf0800bb260e5e1cb196c357f0e28562c3e7e6428389',
-  'pnpm-linux-arm64': 'f7dce46fd8918d8a40e3bb6e67d6dd34d6f52fd618df34f3ef227ad4edc7e33c',
-  'pnpm-linux-x64': '5f040cc7fd0cbb9d91c7c7cdd84cf74dd906bc2a7ea673f8fad143bd310f4952',
-  'pnpm-macos-arm64': '2600317cdafac1a32d4f864357642c13549d146e6e9d8a0da1bf085d8a313371',
-  'pnpm-macos-x64': 'b493964d2ee47807bf4b20fd7727338e7d997a73ce6188d92c220104e6cb40f1',
-  'pnpm-windows-x64': 'c997f3e281a1213eac2e5ea00ee6cb273708f727ced85b42f40730dc40366555',
-  'ssh-linux-arm64': '7f49957e4d2f479a54c382517152504875997905ebccdfb9f767e729ce64626e',
-  'ssh-linux-x64': 'a2f43c0f2d8b53b7bb48c95404b6fac03410397d4b285e3fdd4c762a061840db',
-  'ssh-macos-arm64': '8b545388e64477c7b0a20d13d47a7b31d418bd595f20a43d16056f724c89a05b',
-  'ssh-macos-x64': '35db7f3258806050edc596d29eb33ef0fd3652d9f95f1d14160d01d2e90b719e',
-  'ssh-windows-x64': '3d4b84e5853f43960d5df63ef14ca440414777586ad097375fb882f392c582e5',
-};
+interface ToolchainGeneratedMetadataJson {
+  version: string;
+  releaseTag: string;
+  artifacts: Record<string, ToolchainGeneratedArtifactJson>;
+}
 
-export const bundledToolchainManifest: ToolchainManifest = {
-  version: MANIFEST_VERSION,
-  artifacts: Object.fromEntries(
-    SUPPORTED_TARGETS.flatMap((target) => CORE_TOOLS.map((tool) => [artifactKey(tool, target), coreArtifact(tool, target)])),
-  ),
-};
+interface ToolchainGeneratedMetadata extends ToolchainGeneratedMetadataJson {
+  artifacts: Record<string, ToolchainGeneratedArtifact>;
+}
 
-function coreArtifact(tool: (typeof CORE_TOOLS)[number], target: SupportedTarget): ArtifactSpec {
-  const key = artifactKey(tool, target);
+const GENERATED_METADATA = normalizeGeneratedMetadata(generatedArtifacts);
+
+export const bundledToolchainManifest: ToolchainManifest = createToolchainManifest(GENERATED_METADATA, undefined);
+
+export function getBundledToolchainManifest(): ToolchainManifest {
+  return createToolchainManifest(GENERATED_METADATA, process.env[LOCAL_URL_BASE_ENV]);
+}
+
+export function createToolchainManifest(
+  metadata: ToolchainGeneratedMetadata,
+  urlBaseOverride = process.env[LOCAL_URL_BASE_ENV],
+): ToolchainManifest {
+  const artifacts: Record<string, ArtifactSpec> = {};
+  for (const [key, artifact] of Object.entries(metadata.artifacts)) {
+    if (isBuiltArtifact(artifact)) artifacts[key] = toManifestArtifact(artifact, urlBaseOverride);
+  }
   return {
-    tool,
-    platform: target.platform,
-    arch: target.arch,
-    url: `https://downloads.sero.ai/toolchains/${RELEASE_DATE}/${key}.tar.gz`,
-    sha256: pinnedSha256(key),
-    unpackTo: key,
-    binPaths: { [tool]: binPath(tool, target.platform) },
-    minVersion: MIN_VERSIONS[tool],
-    installPolicy: 'core',
+    version: metadata.version,
+    artifacts,
   };
 }
 
-function artifactKey(tool: ToolName, target: SupportedTarget): string {
-  return `${tool}-${target.slug}`;
+function normalizeGeneratedMetadata(metadata: ToolchainGeneratedMetadataJson): ToolchainGeneratedMetadata {
+  return {
+    ...metadata,
+    artifacts: Object.fromEntries(
+      Object.entries(metadata.artifacts).map(([key, artifact]) => [key, normalizeGeneratedArtifact(key, artifact)]),
+    ),
+  };
 }
 
-function binPath(tool: ToolName, platform: ManagedToolPlatform): string {
-  if (platform !== 'win32') return 'bin/' + tool;
-  if (tool === 'node') return 'bin/node.exe';
-  if (tool === 'npm' || tool === 'pnpm') return 'bin/' + tool + '.cmd';
-  if (tool === 'git') return 'mingw64/bin/git.exe';
-  return 'usr/bin/' + tool + '.exe';
+function normalizeGeneratedArtifact(key: string, artifact: ToolchainGeneratedArtifactJson): ToolchainGeneratedArtifact {
+  if (!isToolName(artifact.tool)) throw new Error(`Invalid toolchain tool for ${key}: ${artifact.tool}`);
+  if (!isToolchainPlatform(artifact.platform)) throw new Error(`Invalid toolchain platform for ${key}: ${artifact.platform}`);
+  if (!isToolchainArch(artifact.arch)) throw new Error(`Invalid toolchain arch for ${key}: ${artifact.arch}`);
+  if (!isToolInstallPolicy(artifact.installPolicy)) throw new Error(`Invalid toolchain install policy for ${key}: ${artifact.installPolicy}`);
+  return {
+    ...artifact,
+    tool: artifact.tool,
+    platform: artifact.platform,
+    arch: artifact.arch,
+    installPolicy: artifact.installPolicy,
+  };
 }
 
-function pinnedSha256(key: string): string {
-  const value = PINNED_SHA256[key];
-  if (!value) throw new Error(`Missing toolchain digest for ${key}`);
-  return value;
+function toManifestArtifact(
+  artifact: ToolchainGeneratedArtifact & { url: string; sha256: string; status: 'built'; available: true },
+  urlBaseOverride: string | undefined,
+): ArtifactSpec {
+  return {
+    tool: artifact.tool,
+    platform: artifact.platform,
+    arch: artifact.arch,
+    url: withUrlBaseOverride(artifact.url, artifact.slug, urlBaseOverride),
+    sha256: artifact.sha256,
+    unpackTo: artifact.unpackTo,
+    binPaths: artifact.binPaths,
+    minVersion: artifact.minVersion,
+    installPolicy: artifact.installPolicy,
+  };
+}
+
+function isBuiltArtifact(
+  artifact: ToolchainGeneratedArtifact,
+): artifact is ToolchainGeneratedArtifact & { url: string; sha256: string; status: 'built'; available: true } {
+  return artifact.status === 'built'
+    && artifact.available === true
+    && typeof artifact.url === 'string'
+    && /^[a-f0-9]{64}$/.test(artifact.sha256 ?? '');
+}
+
+function withUrlBaseOverride(defaultUrl: string, slug: string, urlBaseOverride: string | undefined): string {
+  const baseUrl = urlBaseOverride?.replace(/\/+$/, '');
+  return baseUrl ? `${baseUrl}/${slug}.tar.gz` : defaultUrl;
+}
+
+function isToolName(tool: string): tool is ToolName {
+  return ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash', 'rg', 'fd', 'jq', 'gh', 'curl', 'zip', 'unzip'].includes(tool);
+}
+
+function isToolchainPlatform(platform: string): platform is ManagedToolPlatform {
+  return platform === 'darwin' || platform === 'linux' || platform === 'win32';
+}
+
+function isToolchainArch(arch: string): arch is ManagedToolArch {
+  return arch === 'x64' || arch === 'arm64';
+}
+
+function isToolInstallPolicy(policy: string): policy is ToolInstallPolicy {
+  return policy === 'core' || policy === 'on-demand' || policy === 'large-explicit';
 }

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/bundled-manifest-data.ts
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/bundled-manifest-data.ts
@@ -44,8 +44,6 @@ interface ToolchainGeneratedMetadata extends ToolchainGeneratedMetadataJson {
 
 const GENERATED_METADATA = normalizeGeneratedMetadata(generatedArtifacts);
 
-export const bundledToolchainManifest: ToolchainManifest = createToolchainManifest(GENERATED_METADATA, undefined);
-
 export function getBundledToolchainManifest(): ToolchainManifest {
   return createToolchainManifest(GENERATED_METADATA, process.env[LOCAL_URL_BASE_ENV]);
 }

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
@@ -1,7 +1,6 @@
 {
   "version": "2026.05.16",
   "releaseTag": "toolchains-2026-05-16",
-  "generatedAt": "2026-05-16T00:00:00.000Z",
   "artifacts": {
     "node-macos-arm64": {
       "tool": "node",
@@ -104,10 +103,8 @@
       "platform": "darwin",
       "arch": "x64",
       "slug": "node-macos-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-macos-x64.tar.gz",
-      "sha256": "d8f63452c248b969ea5ac2933fcb80569e341522db0ada7aedff4cd3c71743f0",
+      "status": "pending",
+      "available": false,
       "unpackTo": "node-macos-x64",
       "binPaths": {
         "node": "bin/node"
@@ -120,10 +117,8 @@
       "platform": "darwin",
       "arch": "x64",
       "slug": "npm-macos-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-macos-x64.tar.gz",
-      "sha256": "7ae2f82b686d2ec7d1ec8c31dca892d7b45dc411959b8317d00d433d90f1d9d0",
+      "status": "pending",
+      "available": false,
       "unpackTo": "npm-macos-x64",
       "binPaths": {
         "npm": "bin/npm"
@@ -136,10 +131,8 @@
       "platform": "darwin",
       "arch": "x64",
       "slug": "pnpm-macos-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-macos-x64.tar.gz",
-      "sha256": "b493964d2ee47807bf4b20fd7727338e7d997a73ce6188d92c220104e6cb40f1",
+      "status": "pending",
+      "available": false,
       "unpackTo": "pnpm-macos-x64",
       "binPaths": {
         "pnpm": "bin/pnpm"
@@ -152,10 +145,8 @@
       "platform": "darwin",
       "arch": "x64",
       "slug": "git-macos-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-macos-x64.tar.gz",
-      "sha256": "03d7b8c9d2c8117ff80c416a2e7f7d483b1e8c82f5546fad8cd3f1ccc39efb28",
+      "status": "pending",
+      "available": false,
       "unpackTo": "git-macos-x64",
       "binPaths": {
         "git": "bin/git"
@@ -168,10 +159,8 @@
       "platform": "darwin",
       "arch": "x64",
       "slug": "ssh-macos-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-macos-x64.tar.gz",
-      "sha256": "35db7f3258806050edc596d29eb33ef0fd3652d9f95f1d14160d01d2e90b719e",
+      "status": "pending",
+      "available": false,
       "unpackTo": "ssh-macos-x64",
       "binPaths": {
         "ssh": "bin/ssh"
@@ -184,10 +173,8 @@
       "platform": "darwin",
       "arch": "x64",
       "slug": "bash-macos-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-macos-x64.tar.gz",
-      "sha256": "de8bc4346d99db1b2548f777ec5a5c5a1e993067d4349f874870c08f1d9c05f5",
+      "status": "pending",
+      "available": false,
       "unpackTo": "bash-macos-x64",
       "binPaths": {
         "bash": "bin/bash"

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
@@ -1,474 +1,474 @@
 {
-  "version": "2026.05.16",
-  "releaseTag": "toolchains-2026-05-16",
+  "version": "2026.05.31",
+  "releaseTag": "toolchains-2026-05-31",
   "artifacts": {
     "node-macos-arm64": {
       "tool": "node",
       "platform": "darwin",
       "arch": "arm64",
       "slug": "node-macos-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-macos-arm64.tar.gz",
-      "sha256": "22ab6bc9a8f566a3c4a7f0d71dc7a4e1b5985a545a7145739ccb31929d66ab4b",
       "unpackTo": "node-macos-arm64",
       "binPaths": {
-        "node": "bin/node"
+        "node": "node-macos-arm64/bin/node"
       },
       "minVersion": "22.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/node-macos-arm64.tar.gz",
+      "sha256": "d59d206bb2b20f98e420f17131d8bc7546450c93ea0bb15254ff4be98b1f304e"
     },
     "npm-macos-arm64": {
       "tool": "npm",
       "platform": "darwin",
       "arch": "arm64",
       "slug": "npm-macos-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-macos-arm64.tar.gz",
-      "sha256": "d75ef7ea84d99ff337352c1d5ce9fc41286f55982fd36dc052216235f3d10376",
       "unpackTo": "npm-macos-arm64",
       "binPaths": {
-        "npm": "bin/npm"
+        "npm": "npm-macos-arm64/bin/npm"
       },
       "minVersion": "10.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/npm-macos-arm64.tar.gz",
+      "sha256": "85b6876bbcfe1b5e5d6317cea2ac6693ffb52797896f79772abae2b9ac57f15f"
     },
     "pnpm-macos-arm64": {
       "tool": "pnpm",
       "platform": "darwin",
       "arch": "arm64",
       "slug": "pnpm-macos-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-macos-arm64.tar.gz",
-      "sha256": "2600317cdafac1a32d4f864357642c13549d146e6e9d8a0da1bf085d8a313371",
       "unpackTo": "pnpm-macos-arm64",
       "binPaths": {
-        "pnpm": "bin/pnpm"
+        "pnpm": "pnpm-macos-arm64/bin/pnpm"
       },
       "minVersion": "9.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/pnpm-macos-arm64.tar.gz",
+      "sha256": "c0142ea5f23fe85e7c364ea5f27b56b86ce8c0b27bec07242e559f84e6f06994"
     },
     "git-macos-arm64": {
       "tool": "git",
       "platform": "darwin",
       "arch": "arm64",
       "slug": "git-macos-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-macos-arm64.tar.gz",
-      "sha256": "5119bd9811458665b6dcc8f2d5f0131c3c7f960287689b8031fbd4ddc83be2f2",
       "unpackTo": "git-macos-arm64",
       "binPaths": {
-        "git": "bin/git"
+        "git": "git-macos-arm64/bin/git"
       },
       "minVersion": "2.30.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/git-macos-arm64.tar.gz",
+      "sha256": "f6295044caecc1ab9cee33fbe05349a241aa0475560f6a86380c67336a035dc0"
     },
     "ssh-macos-arm64": {
       "tool": "ssh",
       "platform": "darwin",
       "arch": "arm64",
       "slug": "ssh-macos-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-macos-arm64.tar.gz",
-      "sha256": "8b545388e64477c7b0a20d13d47a7b31d418bd595f20a43d16056f724c89a05b",
       "unpackTo": "ssh-macos-arm64",
       "binPaths": {
-        "ssh": "bin/ssh"
+        "ssh": "ssh-macos-arm64/bin/ssh"
       },
       "minVersion": "8.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/ssh-macos-arm64.tar.gz",
+      "sha256": "692e12db100657fce105015305083be1f3daea8098be9e08757982ae50a45477"
     },
     "bash-macos-arm64": {
       "tool": "bash",
       "platform": "darwin",
       "arch": "arm64",
       "slug": "bash-macos-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-macos-arm64.tar.gz",
-      "sha256": "95388d315d2c9a8809549e80948d71184a5f743995b8b58c0cc7c330fc4567ec",
       "unpackTo": "bash-macos-arm64",
       "binPaths": {
-        "bash": "bin/bash"
+        "bash": "bash-macos-arm64/bin/bash"
       },
       "minVersion": "3.2.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/bash-macos-arm64.tar.gz",
+      "sha256": "96337e8a22a34a4fa77d9d0319da2fa1b3cda74bd862b3fbba1afffc166669cf"
     },
     "node-macos-x64": {
       "tool": "node",
       "platform": "darwin",
       "arch": "x64",
       "slug": "node-macos-x64",
-      "status": "pending",
-      "available": false,
       "unpackTo": "node-macos-x64",
       "binPaths": {
-        "node": "bin/node"
+        "node": "node-macos-x64/bin/node"
       },
       "minVersion": "22.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "pending",
+      "available": false
     },
     "npm-macos-x64": {
       "tool": "npm",
       "platform": "darwin",
       "arch": "x64",
       "slug": "npm-macos-x64",
-      "status": "pending",
-      "available": false,
       "unpackTo": "npm-macos-x64",
       "binPaths": {
-        "npm": "bin/npm"
+        "npm": "npm-macos-x64/bin/npm"
       },
       "minVersion": "10.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "pending",
+      "available": false
     },
     "pnpm-macos-x64": {
       "tool": "pnpm",
       "platform": "darwin",
       "arch": "x64",
       "slug": "pnpm-macos-x64",
-      "status": "pending",
-      "available": false,
       "unpackTo": "pnpm-macos-x64",
       "binPaths": {
-        "pnpm": "bin/pnpm"
+        "pnpm": "pnpm-macos-x64/bin/pnpm"
       },
       "minVersion": "9.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "pending",
+      "available": false
     },
     "git-macos-x64": {
       "tool": "git",
       "platform": "darwin",
       "arch": "x64",
       "slug": "git-macos-x64",
-      "status": "pending",
-      "available": false,
       "unpackTo": "git-macos-x64",
       "binPaths": {
-        "git": "bin/git"
+        "git": "git-macos-x64/bin/git"
       },
       "minVersion": "2.30.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "pending",
+      "available": false
     },
     "ssh-macos-x64": {
       "tool": "ssh",
       "platform": "darwin",
       "arch": "x64",
       "slug": "ssh-macos-x64",
-      "status": "pending",
-      "available": false,
       "unpackTo": "ssh-macos-x64",
       "binPaths": {
-        "ssh": "bin/ssh"
+        "ssh": "ssh-macos-x64/bin/ssh"
       },
       "minVersion": "8.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "pending",
+      "available": false
     },
     "bash-macos-x64": {
       "tool": "bash",
       "platform": "darwin",
       "arch": "x64",
       "slug": "bash-macos-x64",
-      "status": "pending",
-      "available": false,
       "unpackTo": "bash-macos-x64",
       "binPaths": {
-        "bash": "bin/bash"
+        "bash": "bash-macos-x64/bin/bash"
       },
       "minVersion": "3.2.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "pending",
+      "available": false
     },
     "node-linux-arm64": {
       "tool": "node",
       "platform": "linux",
       "arch": "arm64",
       "slug": "node-linux-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-linux-arm64.tar.gz",
-      "sha256": "0e958a7c61eb52752c64696a6b35da38be512276e47182926c096e96ae25e0bf",
       "unpackTo": "node-linux-arm64",
       "binPaths": {
-        "node": "bin/node"
+        "node": "node-linux-arm64/bin/node"
       },
       "minVersion": "22.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/node-linux-arm64.tar.gz",
+      "sha256": "9467bd562198e7d99167ef18512c286a031a9d162deaa82ad49b279e5f5f131b"
     },
     "npm-linux-arm64": {
       "tool": "npm",
       "platform": "linux",
       "arch": "arm64",
       "slug": "npm-linux-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-linux-arm64.tar.gz",
-      "sha256": "1a3e6d24fe00e1186859b2e45d743ff224e3eb683cb0e6ff87fcb8051042664b",
       "unpackTo": "npm-linux-arm64",
       "binPaths": {
-        "npm": "bin/npm"
+        "npm": "npm-linux-arm64/bin/npm"
       },
       "minVersion": "10.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/npm-linux-arm64.tar.gz",
+      "sha256": "733e82278aa217b8fefbd188da48b4fcbf664fa66b8c135c4c2fec063a191f24"
     },
     "pnpm-linux-arm64": {
       "tool": "pnpm",
       "platform": "linux",
       "arch": "arm64",
       "slug": "pnpm-linux-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-linux-arm64.tar.gz",
-      "sha256": "f7dce46fd8918d8a40e3bb6e67d6dd34d6f52fd618df34f3ef227ad4edc7e33c",
       "unpackTo": "pnpm-linux-arm64",
       "binPaths": {
-        "pnpm": "bin/pnpm"
+        "pnpm": "pnpm-linux-arm64/bin/pnpm"
       },
       "minVersion": "9.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/pnpm-linux-arm64.tar.gz",
+      "sha256": "b725f11162a4ccfd39fa0170857a67b45e75547ba81e75ff5a3de32bb5246471"
     },
     "git-linux-arm64": {
       "tool": "git",
       "platform": "linux",
       "arch": "arm64",
       "slug": "git-linux-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-linux-arm64.tar.gz",
-      "sha256": "35cbf8f69e242dcf7614488d447cf028e24bd6251e3828b77642a74264417d49",
       "unpackTo": "git-linux-arm64",
       "binPaths": {
-        "git": "bin/git"
+        "git": "git-linux-arm64/bin/git"
       },
       "minVersion": "2.30.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/git-linux-arm64.tar.gz",
+      "sha256": "cc718bc6c0198482c1da6238599e93a952afbac717d6843c17f34eb3ac5a56a5"
     },
     "ssh-linux-arm64": {
       "tool": "ssh",
       "platform": "linux",
       "arch": "arm64",
       "slug": "ssh-linux-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-linux-arm64.tar.gz",
-      "sha256": "7f49957e4d2f479a54c382517152504875997905ebccdfb9f767e729ce64626e",
       "unpackTo": "ssh-linux-arm64",
       "binPaths": {
-        "ssh": "bin/ssh"
+        "ssh": "ssh-linux-arm64/bin/ssh"
       },
       "minVersion": "8.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/ssh-linux-arm64.tar.gz",
+      "sha256": "48b6ec33f3bc07af9b5c700b408fc3fd5ddf2493d93ce574844da90408f92f39"
     },
     "bash-linux-arm64": {
       "tool": "bash",
       "platform": "linux",
       "arch": "arm64",
       "slug": "bash-linux-arm64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-linux-arm64.tar.gz",
-      "sha256": "478cc6a68ef5198fbff527647753a07f1f2039e331d86a1246ac07e97de723b0",
       "unpackTo": "bash-linux-arm64",
       "binPaths": {
-        "bash": "bin/bash"
+        "bash": "bash-linux-arm64/bin/bash"
       },
       "minVersion": "3.2.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/bash-linux-arm64.tar.gz",
+      "sha256": "3a405d9cc943f7b7a34b640346d92b3272625b35cba137907fc2ab7c98794c81"
     },
     "node-linux-x64": {
       "tool": "node",
       "platform": "linux",
       "arch": "x64",
       "slug": "node-linux-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-linux-x64.tar.gz",
-      "sha256": "4c175beb78eb3ce63721df399d16c88c5c1d5f157449e43bb54e782177a66a3d",
       "unpackTo": "node-linux-x64",
       "binPaths": {
-        "node": "bin/node"
+        "node": "node-linux-x64/bin/node"
       },
       "minVersion": "22.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/node-linux-x64.tar.gz",
+      "sha256": "828c25c73e2e8e6927820f4b788044de8ee5b3888c1fb0e464331e01d1508279"
     },
     "npm-linux-x64": {
       "tool": "npm",
       "platform": "linux",
       "arch": "x64",
       "slug": "npm-linux-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-linux-x64.tar.gz",
-      "sha256": "345d7b46412a51388cfa21873e5c1f36cc58d41ea01bb69f9a271469c9281298",
       "unpackTo": "npm-linux-x64",
       "binPaths": {
-        "npm": "bin/npm"
+        "npm": "npm-linux-x64/bin/npm"
       },
       "minVersion": "10.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/npm-linux-x64.tar.gz",
+      "sha256": "9adc70978f8a5f7d1af90331a9cb4d18c7d309e482b1816c9dae089037e85354"
     },
     "pnpm-linux-x64": {
       "tool": "pnpm",
       "platform": "linux",
       "arch": "x64",
       "slug": "pnpm-linux-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-linux-x64.tar.gz",
-      "sha256": "5f040cc7fd0cbb9d91c7c7cdd84cf74dd906bc2a7ea673f8fad143bd310f4952",
       "unpackTo": "pnpm-linux-x64",
       "binPaths": {
-        "pnpm": "bin/pnpm"
+        "pnpm": "pnpm-linux-x64/bin/pnpm"
       },
       "minVersion": "9.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/pnpm-linux-x64.tar.gz",
+      "sha256": "dd997b3450cfc191bfbdc6896e39647bfb088c82ca00b2767bc40a1957cfa824"
     },
     "git-linux-x64": {
       "tool": "git",
       "platform": "linux",
       "arch": "x64",
       "slug": "git-linux-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-linux-x64.tar.gz",
-      "sha256": "8bb7986e3ff23ec3c8dafdbed621ac6fe4a20d935cd37a6c133b7e023aa50fff",
       "unpackTo": "git-linux-x64",
       "binPaths": {
-        "git": "bin/git"
+        "git": "git-linux-x64/bin/git"
       },
       "minVersion": "2.30.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/git-linux-x64.tar.gz",
+      "sha256": "c3c6c73529498e0026c21ae707b88af2f55f345be35d8d15fcfc1dd99b69c193"
     },
     "ssh-linux-x64": {
       "tool": "ssh",
       "platform": "linux",
       "arch": "x64",
       "slug": "ssh-linux-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-linux-x64.tar.gz",
-      "sha256": "a2f43c0f2d8b53b7bb48c95404b6fac03410397d4b285e3fdd4c762a061840db",
       "unpackTo": "ssh-linux-x64",
       "binPaths": {
-        "ssh": "bin/ssh"
+        "ssh": "ssh-linux-x64/bin/ssh"
       },
       "minVersion": "8.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/ssh-linux-x64.tar.gz",
+      "sha256": "b93a8d3f523e7c44463ed0d78019a78865e4d24a162f2a3468fa899628646a8a"
     },
     "bash-linux-x64": {
       "tool": "bash",
       "platform": "linux",
       "arch": "x64",
       "slug": "bash-linux-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-linux-x64.tar.gz",
-      "sha256": "a686b40502d3f7d123aab13f339234cb506a13ab02e347e9172634dc3000531d",
       "unpackTo": "bash-linux-x64",
       "binPaths": {
-        "bash": "bin/bash"
+        "bash": "bash-linux-x64/bin/bash"
       },
       "minVersion": "3.2.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/bash-linux-x64.tar.gz",
+      "sha256": "e6077aae2b55b6a4302a5750bd39c8ab9e814ae1480db4b6e8c63b0c8cebd2ec"
     },
     "node-windows-x64": {
       "tool": "node",
       "platform": "win32",
       "arch": "x64",
       "slug": "node-windows-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-windows-x64.tar.gz",
-      "sha256": "2fa2a169efdc97ba3db9f671d71f66bdb529e801c5933c1554b4009358a0fc92",
       "unpackTo": "node-windows-x64",
       "binPaths": {
-        "node": "bin/node.exe"
+        "node": "node-windows-x64/bin/node.exe"
       },
       "minVersion": "22.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/node-windows-x64.tar.gz",
+      "sha256": "7c58730bb447ac73d534eeabe102ce42279f92266cdd4ba98c5f8d57793415df"
     },
     "npm-windows-x64": {
       "tool": "npm",
       "platform": "win32",
       "arch": "x64",
       "slug": "npm-windows-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-windows-x64.tar.gz",
-      "sha256": "ad98a3e0d2b88fb5d6eecf0800bb260e5e1cb196c357f0e28562c3e7e6428389",
       "unpackTo": "npm-windows-x64",
       "binPaths": {
-        "npm": "bin/npm.cmd"
+        "npm": "npm-windows-x64/bin/npm.cmd"
       },
       "minVersion": "10.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/npm-windows-x64.tar.gz",
+      "sha256": "2e375ed6b595ffa6592fdced13fbf6f3be31d37b9ca8d454797d670999d0d2f6"
     },
     "pnpm-windows-x64": {
       "tool": "pnpm",
       "platform": "win32",
       "arch": "x64",
       "slug": "pnpm-windows-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-windows-x64.tar.gz",
-      "sha256": "c997f3e281a1213eac2e5ea00ee6cb273708f727ced85b42f40730dc40366555",
       "unpackTo": "pnpm-windows-x64",
       "binPaths": {
-        "pnpm": "bin/pnpm.cmd"
+        "pnpm": "pnpm-windows-x64/bin/pnpm.exe"
       },
       "minVersion": "9.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/pnpm-windows-x64.tar.gz",
+      "sha256": "dcddeb3c519ae5f16dd40d42f837790f0224237d3ae41b36e74ecae6470d89e1"
     },
     "git-windows-x64": {
       "tool": "git",
       "platform": "win32",
       "arch": "x64",
       "slug": "git-windows-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-windows-x64.tar.gz",
-      "sha256": "4bf11bfc98b157d51e6f7494223bdb7af9bcd9f79a03cf58d499a715d09a8e35",
       "unpackTo": "git-windows-x64",
       "binPaths": {
-        "git": "mingw64/bin/git.exe"
+        "git": "git-windows-x64/cmd/git.exe"
       },
       "minVersion": "2.30.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/git-windows-x64.tar.gz",
+      "sha256": "32d745c48e78e918ec7769160c72fe51f006d1635297b94648eac8e0e541fc70"
     },
     "ssh-windows-x64": {
       "tool": "ssh",
       "platform": "win32",
       "arch": "x64",
       "slug": "ssh-windows-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-windows-x64.tar.gz",
-      "sha256": "3d4b84e5853f43960d5df63ef14ca440414777586ad097375fb882f392c582e5",
       "unpackTo": "ssh-windows-x64",
       "binPaths": {
-        "ssh": "usr/bin/ssh.exe"
+        "ssh": "ssh-windows-x64/usr/bin/ssh.exe"
       },
       "minVersion": "8.0.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/ssh-windows-x64.tar.gz",
+      "sha256": "a037abb06a523768f7c4e0097892b7864d2aae920303fc108bd5dd5b08ae0aa8"
     },
     "bash-windows-x64": {
       "tool": "bash",
       "platform": "win32",
       "arch": "x64",
       "slug": "bash-windows-x64",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-windows-x64.tar.gz",
-      "sha256": "78b6d9d3a92767d1d5fde162055dce02e6d8a7df496dbcb85b408b8e3373b7f4",
       "unpackTo": "bash-windows-x64",
       "binPaths": {
-        "bash": "usr/bin/bash.exe"
+        "bash": "bash-windows-x64/bin/bash.exe"
       },
       "minVersion": "3.2.0",
-      "installPolicy": "core"
+      "installPolicy": "core",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/bash-windows-x64.tar.gz",
+      "sha256": "3adbb6f9346f5e348bd7e9341d94d4bc1a41402aa06823cde2062e05099e5e55"
     }
   }
 }

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
@@ -1,0 +1,487 @@
+{
+  "version": "2026.05.16",
+  "releaseTag": "toolchains-2026-05-16",
+  "generatedAt": "2026-05-16T00:00:00.000Z",
+  "artifacts": {
+    "node-macos-arm64": {
+      "tool": "node",
+      "platform": "darwin",
+      "arch": "arm64",
+      "slug": "node-macos-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-macos-arm64.tar.gz",
+      "sha256": "22ab6bc9a8f566a3c4a7f0d71dc7a4e1b5985a545a7145739ccb31929d66ab4b",
+      "unpackTo": "node-macos-arm64",
+      "binPaths": {
+        "node": "bin/node"
+      },
+      "minVersion": "22.0.0",
+      "installPolicy": "core"
+    },
+    "npm-macos-arm64": {
+      "tool": "npm",
+      "platform": "darwin",
+      "arch": "arm64",
+      "slug": "npm-macos-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-macos-arm64.tar.gz",
+      "sha256": "d75ef7ea84d99ff337352c1d5ce9fc41286f55982fd36dc052216235f3d10376",
+      "unpackTo": "npm-macos-arm64",
+      "binPaths": {
+        "npm": "bin/npm"
+      },
+      "minVersion": "10.0.0",
+      "installPolicy": "core"
+    },
+    "pnpm-macos-arm64": {
+      "tool": "pnpm",
+      "platform": "darwin",
+      "arch": "arm64",
+      "slug": "pnpm-macos-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-macos-arm64.tar.gz",
+      "sha256": "2600317cdafac1a32d4f864357642c13549d146e6e9d8a0da1bf085d8a313371",
+      "unpackTo": "pnpm-macos-arm64",
+      "binPaths": {
+        "pnpm": "bin/pnpm"
+      },
+      "minVersion": "9.0.0",
+      "installPolicy": "core"
+    },
+    "git-macos-arm64": {
+      "tool": "git",
+      "platform": "darwin",
+      "arch": "arm64",
+      "slug": "git-macos-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-macos-arm64.tar.gz",
+      "sha256": "5119bd9811458665b6dcc8f2d5f0131c3c7f960287689b8031fbd4ddc83be2f2",
+      "unpackTo": "git-macos-arm64",
+      "binPaths": {
+        "git": "bin/git"
+      },
+      "minVersion": "2.30.0",
+      "installPolicy": "core"
+    },
+    "ssh-macos-arm64": {
+      "tool": "ssh",
+      "platform": "darwin",
+      "arch": "arm64",
+      "slug": "ssh-macos-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-macos-arm64.tar.gz",
+      "sha256": "8b545388e64477c7b0a20d13d47a7b31d418bd595f20a43d16056f724c89a05b",
+      "unpackTo": "ssh-macos-arm64",
+      "binPaths": {
+        "ssh": "bin/ssh"
+      },
+      "minVersion": "8.0.0",
+      "installPolicy": "core"
+    },
+    "bash-macos-arm64": {
+      "tool": "bash",
+      "platform": "darwin",
+      "arch": "arm64",
+      "slug": "bash-macos-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-macos-arm64.tar.gz",
+      "sha256": "95388d315d2c9a8809549e80948d71184a5f743995b8b58c0cc7c330fc4567ec",
+      "unpackTo": "bash-macos-arm64",
+      "binPaths": {
+        "bash": "bin/bash"
+      },
+      "minVersion": "3.2.0",
+      "installPolicy": "core"
+    },
+    "node-macos-x64": {
+      "tool": "node",
+      "platform": "darwin",
+      "arch": "x64",
+      "slug": "node-macos-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-macos-x64.tar.gz",
+      "sha256": "d8f63452c248b969ea5ac2933fcb80569e341522db0ada7aedff4cd3c71743f0",
+      "unpackTo": "node-macos-x64",
+      "binPaths": {
+        "node": "bin/node"
+      },
+      "minVersion": "22.0.0",
+      "installPolicy": "core"
+    },
+    "npm-macos-x64": {
+      "tool": "npm",
+      "platform": "darwin",
+      "arch": "x64",
+      "slug": "npm-macos-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-macos-x64.tar.gz",
+      "sha256": "7ae2f82b686d2ec7d1ec8c31dca892d7b45dc411959b8317d00d433d90f1d9d0",
+      "unpackTo": "npm-macos-x64",
+      "binPaths": {
+        "npm": "bin/npm"
+      },
+      "minVersion": "10.0.0",
+      "installPolicy": "core"
+    },
+    "pnpm-macos-x64": {
+      "tool": "pnpm",
+      "platform": "darwin",
+      "arch": "x64",
+      "slug": "pnpm-macos-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-macos-x64.tar.gz",
+      "sha256": "b493964d2ee47807bf4b20fd7727338e7d997a73ce6188d92c220104e6cb40f1",
+      "unpackTo": "pnpm-macos-x64",
+      "binPaths": {
+        "pnpm": "bin/pnpm"
+      },
+      "minVersion": "9.0.0",
+      "installPolicy": "core"
+    },
+    "git-macos-x64": {
+      "tool": "git",
+      "platform": "darwin",
+      "arch": "x64",
+      "slug": "git-macos-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-macos-x64.tar.gz",
+      "sha256": "03d7b8c9d2c8117ff80c416a2e7f7d483b1e8c82f5546fad8cd3f1ccc39efb28",
+      "unpackTo": "git-macos-x64",
+      "binPaths": {
+        "git": "bin/git"
+      },
+      "minVersion": "2.30.0",
+      "installPolicy": "core"
+    },
+    "ssh-macos-x64": {
+      "tool": "ssh",
+      "platform": "darwin",
+      "arch": "x64",
+      "slug": "ssh-macos-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-macos-x64.tar.gz",
+      "sha256": "35db7f3258806050edc596d29eb33ef0fd3652d9f95f1d14160d01d2e90b719e",
+      "unpackTo": "ssh-macos-x64",
+      "binPaths": {
+        "ssh": "bin/ssh"
+      },
+      "minVersion": "8.0.0",
+      "installPolicy": "core"
+    },
+    "bash-macos-x64": {
+      "tool": "bash",
+      "platform": "darwin",
+      "arch": "x64",
+      "slug": "bash-macos-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-macos-x64.tar.gz",
+      "sha256": "de8bc4346d99db1b2548f777ec5a5c5a1e993067d4349f874870c08f1d9c05f5",
+      "unpackTo": "bash-macos-x64",
+      "binPaths": {
+        "bash": "bin/bash"
+      },
+      "minVersion": "3.2.0",
+      "installPolicy": "core"
+    },
+    "node-linux-arm64": {
+      "tool": "node",
+      "platform": "linux",
+      "arch": "arm64",
+      "slug": "node-linux-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-linux-arm64.tar.gz",
+      "sha256": "0e958a7c61eb52752c64696a6b35da38be512276e47182926c096e96ae25e0bf",
+      "unpackTo": "node-linux-arm64",
+      "binPaths": {
+        "node": "bin/node"
+      },
+      "minVersion": "22.0.0",
+      "installPolicy": "core"
+    },
+    "npm-linux-arm64": {
+      "tool": "npm",
+      "platform": "linux",
+      "arch": "arm64",
+      "slug": "npm-linux-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-linux-arm64.tar.gz",
+      "sha256": "1a3e6d24fe00e1186859b2e45d743ff224e3eb683cb0e6ff87fcb8051042664b",
+      "unpackTo": "npm-linux-arm64",
+      "binPaths": {
+        "npm": "bin/npm"
+      },
+      "minVersion": "10.0.0",
+      "installPolicy": "core"
+    },
+    "pnpm-linux-arm64": {
+      "tool": "pnpm",
+      "platform": "linux",
+      "arch": "arm64",
+      "slug": "pnpm-linux-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-linux-arm64.tar.gz",
+      "sha256": "f7dce46fd8918d8a40e3bb6e67d6dd34d6f52fd618df34f3ef227ad4edc7e33c",
+      "unpackTo": "pnpm-linux-arm64",
+      "binPaths": {
+        "pnpm": "bin/pnpm"
+      },
+      "minVersion": "9.0.0",
+      "installPolicy": "core"
+    },
+    "git-linux-arm64": {
+      "tool": "git",
+      "platform": "linux",
+      "arch": "arm64",
+      "slug": "git-linux-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-linux-arm64.tar.gz",
+      "sha256": "35cbf8f69e242dcf7614488d447cf028e24bd6251e3828b77642a74264417d49",
+      "unpackTo": "git-linux-arm64",
+      "binPaths": {
+        "git": "bin/git"
+      },
+      "minVersion": "2.30.0",
+      "installPolicy": "core"
+    },
+    "ssh-linux-arm64": {
+      "tool": "ssh",
+      "platform": "linux",
+      "arch": "arm64",
+      "slug": "ssh-linux-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-linux-arm64.tar.gz",
+      "sha256": "7f49957e4d2f479a54c382517152504875997905ebccdfb9f767e729ce64626e",
+      "unpackTo": "ssh-linux-arm64",
+      "binPaths": {
+        "ssh": "bin/ssh"
+      },
+      "minVersion": "8.0.0",
+      "installPolicy": "core"
+    },
+    "bash-linux-arm64": {
+      "tool": "bash",
+      "platform": "linux",
+      "arch": "arm64",
+      "slug": "bash-linux-arm64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-linux-arm64.tar.gz",
+      "sha256": "478cc6a68ef5198fbff527647753a07f1f2039e331d86a1246ac07e97de723b0",
+      "unpackTo": "bash-linux-arm64",
+      "binPaths": {
+        "bash": "bin/bash"
+      },
+      "minVersion": "3.2.0",
+      "installPolicy": "core"
+    },
+    "node-linux-x64": {
+      "tool": "node",
+      "platform": "linux",
+      "arch": "x64",
+      "slug": "node-linux-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-linux-x64.tar.gz",
+      "sha256": "4c175beb78eb3ce63721df399d16c88c5c1d5f157449e43bb54e782177a66a3d",
+      "unpackTo": "node-linux-x64",
+      "binPaths": {
+        "node": "bin/node"
+      },
+      "minVersion": "22.0.0",
+      "installPolicy": "core"
+    },
+    "npm-linux-x64": {
+      "tool": "npm",
+      "platform": "linux",
+      "arch": "x64",
+      "slug": "npm-linux-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-linux-x64.tar.gz",
+      "sha256": "345d7b46412a51388cfa21873e5c1f36cc58d41ea01bb69f9a271469c9281298",
+      "unpackTo": "npm-linux-x64",
+      "binPaths": {
+        "npm": "bin/npm"
+      },
+      "minVersion": "10.0.0",
+      "installPolicy": "core"
+    },
+    "pnpm-linux-x64": {
+      "tool": "pnpm",
+      "platform": "linux",
+      "arch": "x64",
+      "slug": "pnpm-linux-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-linux-x64.tar.gz",
+      "sha256": "5f040cc7fd0cbb9d91c7c7cdd84cf74dd906bc2a7ea673f8fad143bd310f4952",
+      "unpackTo": "pnpm-linux-x64",
+      "binPaths": {
+        "pnpm": "bin/pnpm"
+      },
+      "minVersion": "9.0.0",
+      "installPolicy": "core"
+    },
+    "git-linux-x64": {
+      "tool": "git",
+      "platform": "linux",
+      "arch": "x64",
+      "slug": "git-linux-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-linux-x64.tar.gz",
+      "sha256": "8bb7986e3ff23ec3c8dafdbed621ac6fe4a20d935cd37a6c133b7e023aa50fff",
+      "unpackTo": "git-linux-x64",
+      "binPaths": {
+        "git": "bin/git"
+      },
+      "minVersion": "2.30.0",
+      "installPolicy": "core"
+    },
+    "ssh-linux-x64": {
+      "tool": "ssh",
+      "platform": "linux",
+      "arch": "x64",
+      "slug": "ssh-linux-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-linux-x64.tar.gz",
+      "sha256": "a2f43c0f2d8b53b7bb48c95404b6fac03410397d4b285e3fdd4c762a061840db",
+      "unpackTo": "ssh-linux-x64",
+      "binPaths": {
+        "ssh": "bin/ssh"
+      },
+      "minVersion": "8.0.0",
+      "installPolicy": "core"
+    },
+    "bash-linux-x64": {
+      "tool": "bash",
+      "platform": "linux",
+      "arch": "x64",
+      "slug": "bash-linux-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-linux-x64.tar.gz",
+      "sha256": "a686b40502d3f7d123aab13f339234cb506a13ab02e347e9172634dc3000531d",
+      "unpackTo": "bash-linux-x64",
+      "binPaths": {
+        "bash": "bin/bash"
+      },
+      "minVersion": "3.2.0",
+      "installPolicy": "core"
+    },
+    "node-windows-x64": {
+      "tool": "node",
+      "platform": "win32",
+      "arch": "x64",
+      "slug": "node-windows-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-windows-x64.tar.gz",
+      "sha256": "2fa2a169efdc97ba3db9f671d71f66bdb529e801c5933c1554b4009358a0fc92",
+      "unpackTo": "node-windows-x64",
+      "binPaths": {
+        "node": "bin/node.exe"
+      },
+      "minVersion": "22.0.0",
+      "installPolicy": "core"
+    },
+    "npm-windows-x64": {
+      "tool": "npm",
+      "platform": "win32",
+      "arch": "x64",
+      "slug": "npm-windows-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/npm-windows-x64.tar.gz",
+      "sha256": "ad98a3e0d2b88fb5d6eecf0800bb260e5e1cb196c357f0e28562c3e7e6428389",
+      "unpackTo": "npm-windows-x64",
+      "binPaths": {
+        "npm": "bin/npm.cmd"
+      },
+      "minVersion": "10.0.0",
+      "installPolicy": "core"
+    },
+    "pnpm-windows-x64": {
+      "tool": "pnpm",
+      "platform": "win32",
+      "arch": "x64",
+      "slug": "pnpm-windows-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/pnpm-windows-x64.tar.gz",
+      "sha256": "c997f3e281a1213eac2e5ea00ee6cb273708f727ced85b42f40730dc40366555",
+      "unpackTo": "pnpm-windows-x64",
+      "binPaths": {
+        "pnpm": "bin/pnpm.cmd"
+      },
+      "minVersion": "9.0.0",
+      "installPolicy": "core"
+    },
+    "git-windows-x64": {
+      "tool": "git",
+      "platform": "win32",
+      "arch": "x64",
+      "slug": "git-windows-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/git-windows-x64.tar.gz",
+      "sha256": "4bf11bfc98b157d51e6f7494223bdb7af9bcd9f79a03cf58d499a715d09a8e35",
+      "unpackTo": "git-windows-x64",
+      "binPaths": {
+        "git": "mingw64/bin/git.exe"
+      },
+      "minVersion": "2.30.0",
+      "installPolicy": "core"
+    },
+    "ssh-windows-x64": {
+      "tool": "ssh",
+      "platform": "win32",
+      "arch": "x64",
+      "slug": "ssh-windows-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/ssh-windows-x64.tar.gz",
+      "sha256": "3d4b84e5853f43960d5df63ef14ca440414777586ad097375fb882f392c582e5",
+      "unpackTo": "ssh-windows-x64",
+      "binPaths": {
+        "ssh": "usr/bin/ssh.exe"
+      },
+      "minVersion": "8.0.0",
+      "installPolicy": "core"
+    },
+    "bash-windows-x64": {
+      "tool": "bash",
+      "platform": "win32",
+      "arch": "x64",
+      "slug": "bash-windows-x64",
+      "status": "built",
+      "available": true,
+      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/bash-windows-x64.tar.gz",
+      "sha256": "78b6d9d3a92767d1d5fde162055dce02e6d8a7df496dbcb85b408b8e3373b7f4",
+      "unpackTo": "bash-windows-x64",
+      "binPaths": {
+        "bash": "usr/bin/bash.exe"
+      },
+      "minVersion": "3.2.0",
+      "installPolicy": "core"
+    }
+  }
+}

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
@@ -61,10 +61,8 @@
       },
       "minVersion": "2.30.0",
       "installPolicy": "core",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/git-macos-arm64.tar.gz",
-      "sha256": "f6295044caecc1ab9cee33fbe05349a241aa0475560f6a86380c67336a035dc0"
+      "status": "pending",
+      "available": false
     },
     "ssh-macos-arm64": {
       "tool": "ssh",
@@ -77,10 +75,8 @@
       },
       "minVersion": "8.0.0",
       "installPolicy": "core",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/ssh-macos-arm64.tar.gz",
-      "sha256": "692e12db100657fce105015305083be1f3daea8098be9e08757982ae50a45477"
+      "status": "pending",
+      "available": false
     },
     "bash-macos-arm64": {
       "tool": "bash",
@@ -93,10 +89,8 @@
       },
       "minVersion": "3.2.0",
       "installPolicy": "core",
-      "status": "built",
-      "available": true,
-      "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/bash-macos-arm64.tar.gz",
-      "sha256": "96337e8a22a34a4fa77d9d0319da2fa1b3cda74bd862b3fbba1afffc166669cf"
+      "status": "pending",
+      "available": false
     },
     "node-macos-x64": {
       "tool": "node",

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/manifest.ts
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/manifest.ts
@@ -1,5 +1,5 @@
 import { assertValidToolchainVersion } from './storage';
-import { bundledToolchainManifest } from './bundled-manifest-data';
+import { getBundledToolchainManifest } from './bundled-manifest-data';
 import type {
   ArtifactSpec,
   ManagedToolArch,
@@ -30,7 +30,7 @@ const POLICIES = new Set<ToolInstallPolicy>(['core', 'on-demand', 'large-explici
 const SHA_256_PATTERN = /^[a-f0-9]{64}$/i;
 
 export function loadBundledToolchainManifest(): ToolchainManifest {
-  return validateToolchainManifest(bundledToolchainManifest);
+  return validateToolchainManifest(getBundledToolchainManifest());
 }
 
 export function createTestToolchainManifest(

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/types.ts
@@ -69,6 +69,7 @@ export type ToolInstallReasonKind =
   | 'workspace-shell'
   | 'workspace-terminal'
   | 'workspace-dev-server'
+  | 'onboarding'
   | 'doctor'
   | 'settings'
   | 'agent-tool'

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -44,7 +44,8 @@
     "dist:linux": "bash scripts/build-release.sh --target linux",
     "dist:linux:x64": "bash scripts/build-release.sh --target linux --arch x64",
     "dist:linux:arm64": "bash scripts/build-release.sh --target linux --arch arm64",
-    "dist:win": "bash scripts/build-release.sh --target win"
+    "dist:win": "bash scripts/build-release.sh --target win",
+    "toolchain:verify-published": "node scripts/toolchains/verify-toolchain-publication.mjs"
   },
   "dependencies": {
     "@google/genai": "^1.52.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -45,7 +45,8 @@
     "dist:linux:x64": "bash scripts/build-release.sh --target linux --arch x64",
     "dist:linux:arm64": "bash scripts/build-release.sh --target linux --arch arm64",
     "dist:win": "bash scripts/build-release.sh --target win",
-    "toolchain:verify-published": "node scripts/toolchains/verify-toolchain-publication.mjs"
+    "toolchain:verify-published": "node scripts/toolchains/verify-toolchain-publication.mjs",
+    "toolchain:merge-metadata": "node scripts/toolchains/merge-toolchain-metadata.mjs"
   },
   "dependencies": {
     "@google/genai": "^1.52.0",

--- a/apps/desktop/scripts/toolchains/merge-toolchain-metadata.mjs
+++ b/apps/desktop/scripts/toolchains/merge-toolchain-metadata.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const desktopRoot = path.resolve(scriptDir, '../..');
+const defaultMetadataPath = path.join(
+  desktopRoot,
+  'electron/features/workspace/runtime/toolchains/generated-artifacts.json',
+);
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`toolchain metadata merge failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+  await mergeToolchainMetadata({
+    sidecarDir: options.sidecarDir,
+    out: options.out ?? defaultMetadataPath,
+    metadataPath: options.metadata ?? defaultMetadataPath,
+    releaseTag: options.releaseTag,
+    version: options.version,
+  });
+}
+
+export async function mergeToolchainMetadata({ sidecarDir, out = defaultMetadataPath, metadataPath = defaultMetadataPath, releaseTag, version }) {
+  if (!sidecarDir) throw new Error('Missing --sidecar-dir');
+  if (!releaseTag) throw new Error('Missing --release-tag');
+  if (!version) throw new Error('Missing --version');
+
+  const base = await readJson(metadataPath);
+  const sidecars = await readSidecars(sidecarDir);
+  const artifacts = Object.fromEntries(
+    Object.entries(base.artifacts ?? {}).map(([key, artifact]) => [
+      key,
+      mergeArtifact(key, artifact, sidecars.get(key), releaseTag),
+    ]),
+  );
+
+  await fs.mkdir(path.dirname(out), { recursive: true });
+  await fs.writeFile(out, `${JSON.stringify({ version, releaseTag, artifacts }, null, 2)}\n`);
+}
+
+async function readSidecars(sidecarDir) {
+  const entries = await fs.readdir(sidecarDir, { withFileTypes: true }).catch((error) => {
+    if (error && error.code === 'ENOENT') return [];
+    throw error;
+  });
+  const sidecars = new Map();
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const filePath = path.join(sidecarDir, entry.name);
+    const sidecar = await readJson(filePath);
+    validateSidecar(sidecar, filePath);
+    if (sidecars.has(sidecar.key)) throw new Error(`Duplicate sidecar for ${sidecar.key}`);
+    sidecars.set(sidecar.key, sidecar);
+  }
+  return sidecars;
+}
+
+function mergeArtifact(key, artifact, sidecar, releaseTag) {
+  const base = {
+    tool: artifact.tool,
+    platform: artifact.platform,
+    arch: artifact.arch,
+    slug: artifact.slug,
+    unpackTo: artifact.unpackTo,
+    binPaths: artifact.binPaths,
+    minVersion: artifact.minVersion,
+    installPolicy: artifact.installPolicy,
+  };
+  if (!sidecar) return { ...base, status: 'pending', available: false };
+  validateSidecarMatchesArtifact(sidecar, key, artifact, releaseTag);
+  return {
+    ...base,
+    status: 'built',
+    available: true,
+    url: sidecar.url,
+    sha256: sidecar.sha256,
+  };
+}
+
+function validateSidecar(sidecar, filePath) {
+  if (!sidecar || typeof sidecar !== 'object' || Array.isArray(sidecar)) {
+    throw new Error(`${filePath} must contain a sidecar object`);
+  }
+  for (const field of ['key', 'tool', 'platform', 'arch', 'slug', 'url', 'sha256']) {
+    if (typeof sidecar[field] !== 'string' || sidecar[field].length === 0) {
+      throw new Error(`${filePath} has invalid ${field}`);
+    }
+  }
+  if (!/^[a-f0-9]{64}$/.test(sidecar.sha256)) throw new Error(`${sidecar.key} has invalid sha256`);
+}
+
+function validateSidecarMatchesArtifact(sidecar, key, artifact, releaseTag) {
+  for (const field of ['tool', 'platform', 'arch', 'slug']) {
+    if (sidecar[field] !== artifact[field]) throw new Error(`${key} ${field} does not match existing toolchain metadata`);
+  }
+  if (sidecar.key !== key) throw new Error(`${sidecar.key} key does not match existing toolchain metadata`);
+  const expectedUrl = `https://github.com/sero-labs/sero/releases/download/${releaseTag}/${artifact.slug}.tar.gz`;
+  if (sidecar.url !== expectedUrl) throw new Error(`${key} URL must be ${expectedUrl}`);
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') continue;
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) throw new Error(`Unexpected argument: ${arg}`);
+    const [rawKey, inlineValue] = arg.slice(2).split('=', 2);
+    const key = rawKey.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    if (!['sidecarDir', 'out', 'metadata', 'releaseTag', 'version'].includes(key)) throw new Error(`Unknown option: ${arg}`);
+    const value = inlineValue ?? args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`Missing value for ${arg}`);
+    options[key] = value;
+    if (inlineValue === undefined) index += 1;
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log('Usage: node scripts/toolchains/merge-toolchain-metadata.mjs --sidecar-dir <path> --release-tag <tag> --version <version> [--metadata <path>] [--out <path>]');
+}

--- a/apps/desktop/scripts/toolchains/merge-toolchain-metadata.mjs.d.ts
+++ b/apps/desktop/scripts/toolchains/merge-toolchain-metadata.mjs.d.ts
@@ -1,0 +1,7 @@
+export function mergeToolchainMetadata(input: {
+  sidecarDir: string;
+  out?: string;
+  metadataPath?: string;
+  releaseTag: string;
+  version: string;
+}): Promise<void>;

--- a/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
+++ b/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
@@ -63,17 +63,11 @@ export async function verifyToolchainPublication({ targets, metadata, downloadAr
 
       try {
         const bytes = await downloadArtifact(artifact.url, key);
-        const actualSize = byteLength(bytes);
         const actualSha = createHash('sha256').update(bytes).digest('hex');
-        if (Number.isInteger(artifact.sizeBytes) && actualSize !== artifact.sizeBytes) {
-          failures.push(`${key} downloaded size ${actualSize} does not match metadata size ${artifact.sizeBytes}`);
-        }
         if (actualSha !== artifact.sha256) {
           failures.push(`${key} sha256 mismatch: expected ${artifact.sha256}, got ${actualSha}`);
         }
-        if (actualSha === artifact.sha256 && (!Number.isInteger(artifact.sizeBytes) || actualSize === artifact.sizeBytes)) {
-          verifiedKeys.push(key);
-        }
+        if (actualSha === artifact.sha256) verifiedKeys.push(key);
       } catch (error) {
         failures.push(`${key} download failed from ${artifact.url}: ${errorMessage(error)}`);
       }
@@ -95,9 +89,6 @@ function validateArtifactMetadata({ key, artifact, productionUrlPrefix, releaseT
   if (typeof artifact.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(artifact.sha256)) {
     failures.push(`${key} has invalid sha256`);
   }
-  if (artifact.sizeBytes !== undefined && (!Number.isInteger(artifact.sizeBytes) || artifact.sizeBytes <= 0)) {
-    failures.push(`${key} has invalid sizeBytes`);
-  }
   return failures;
 }
 
@@ -107,13 +98,6 @@ async function fetchArtifactBytes(url) {
   const body = new Uint8Array(await response.arrayBuffer());
   if (body.byteLength === 0) throw new Error('downloaded artifact is empty');
   return body;
-}
-
-function byteLength(bytes) {
-  if (bytes instanceof Uint8Array) return bytes.byteLength;
-  if (Buffer.isBuffer(bytes)) return bytes.byteLength;
-  if (typeof bytes === 'string') return Buffer.byteLength(bytes);
-  throw new Error('download helper returned unsupported bytes');
 }
 
 function artifactKey(metadata, target, tool) {

--- a/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
+++ b/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
@@ -15,6 +15,7 @@ const hostReleaseMatrixPath = path.join(
   'electron/features/workspace/runtime/host-support-matrix.json',
 );
 const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'];
+const macosSystemCoreTools = new Set(['git', 'ssh', 'bash']);
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main().catch((error) => {
@@ -47,7 +48,7 @@ export async function verifyToolchainPublication({ targets, metadata, downloadAr
   const productionUrlPrefix = `https://github.com/sero-labs/sero/releases/download/${releaseTag}/`;
 
   for (const target of targets) {
-    for (const tool of coreTools) {
+    for (const tool of requiredCoreToolsForTarget(target)) {
       const key = artifactKey(metadata, target, tool);
       const artifact = key ? metadata?.artifacts?.[key] : undefined;
       if (!target.releaseSupported) {
@@ -76,6 +77,11 @@ export async function verifyToolchainPublication({ targets, metadata, downloadAr
 
   if (failures.length > 0) throw new Error(failures.join('\n'));
   return { verifiedKeys, warnings };
+}
+
+function requiredCoreToolsForTarget(target) {
+  if (target.platform === 'darwin') return coreTools.filter((tool) => !macosSystemCoreTools.has(tool));
+  return coreTools;
 }
 
 function validateArtifactMetadata({ key, artifact, productionUrlPrefix, releaseTag }) {

--- a/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
+++ b/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const desktopRoot = path.resolve(scriptDir, '../..');
+const defaultMetadataPath = path.join(
+  desktopRoot,
+  'electron/features/workspace/runtime/toolchains/generated-artifacts.json',
+);
+const hostReleaseMatrixPath = path.join(
+  desktopRoot,
+  'electron/features/workspace/runtime/host-support-matrix.json',
+);
+const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'];
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`toolchain publication verification failed: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const [targets, metadata] = await Promise.all([
+    readJson(hostReleaseMatrixPath),
+    readJson(options.metadata ?? defaultMetadataPath),
+  ]);
+  const result = await verifyToolchainPublication({ targets, metadata });
+  for (const warning of result.warnings) console.warn(`warning: ${warning}`);
+  console.log(`Verified ${result.verifiedKeys.length} published core toolchain artifact(s).`);
+}
+
+export async function verifyToolchainPublication({ targets, metadata, downloadArtifact = fetchArtifactBytes }) {
+  const failures = [];
+  const warnings = [];
+  const verifiedKeys = [];
+  const releaseTag = releaseTagFor(metadata);
+  const productionUrlPrefix = `https://github.com/sero-labs/sero/releases/download/${releaseTag}/`;
+
+  for (const target of targets) {
+    for (const tool of coreTools) {
+      const key = artifactKey(metadata, target, tool);
+      const artifact = key ? metadata?.artifacts?.[key] : undefined;
+      if (!target.releaseSupported) {
+        if (artifact?.status === 'pending') warnings.push(`${tool}-${target.platform}-${target.arch} is unsupported/future and remains pending`);
+        continue;
+      }
+
+      const artifactFailures = validateArtifactMetadata({ key: key ?? `${tool}-${target.platform}-${target.arch}`, artifact, productionUrlPrefix, releaseTag });
+      if (artifactFailures.length > 0) {
+        failures.push(...artifactFailures);
+        continue;
+      }
+
+      try {
+        const bytes = await downloadArtifact(artifact.url, key);
+        const actualSize = byteLength(bytes);
+        const actualSha = createHash('sha256').update(bytes).digest('hex');
+        if (Number.isInteger(artifact.sizeBytes) && actualSize !== artifact.sizeBytes) {
+          failures.push(`${key} downloaded size ${actualSize} does not match metadata size ${artifact.sizeBytes}`);
+        }
+        if (actualSha !== artifact.sha256) {
+          failures.push(`${key} sha256 mismatch: expected ${artifact.sha256}, got ${actualSha}`);
+        }
+        if (actualSha === artifact.sha256 && (!Number.isInteger(artifact.sizeBytes) || actualSize === artifact.sizeBytes)) {
+          verifiedKeys.push(key);
+        }
+      } catch (error) {
+        failures.push(`${key} download failed from ${artifact.url}: ${errorMessage(error)}`);
+      }
+    }
+  }
+
+  if (failures.length > 0) throw new Error(failures.join('\n'));
+  return { verifiedKeys, warnings };
+}
+
+function validateArtifactMetadata({ key, artifact, productionUrlPrefix, releaseTag }) {
+  const failures = [];
+  if (!artifact || artifact.status !== 'built' || artifact.available !== true) {
+    return [`${key} is required for release but is not built/available`];
+  }
+  if (typeof artifact.url !== 'string' || !artifact.url.startsWith(productionUrlPrefix)) {
+    failures.push(`${key} must use the ${releaseTag} GitHub Release asset URL`);
+  }
+  if (typeof artifact.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(artifact.sha256)) {
+    failures.push(`${key} has invalid sha256`);
+  }
+  if (artifact.sizeBytes !== undefined && (!Number.isInteger(artifact.sizeBytes) || artifact.sizeBytes <= 0)) {
+    failures.push(`${key} has invalid sizeBytes`);
+  }
+  return failures;
+}
+
+async function fetchArtifactBytes(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`HTTP ${response.status} ${response.statusText}`.trim());
+  const body = new Uint8Array(await response.arrayBuffer());
+  if (body.byteLength === 0) throw new Error('downloaded artifact is empty');
+  return body;
+}
+
+function byteLength(bytes) {
+  if (bytes instanceof Uint8Array) return bytes.byteLength;
+  if (Buffer.isBuffer(bytes)) return bytes.byteLength;
+  if (typeof bytes === 'string') return Buffer.byteLength(bytes);
+  throw new Error('download helper returned unsupported bytes');
+}
+
+function artifactKey(metadata, target, tool) {
+  return Object.entries(metadata?.artifacts ?? {}).find(([, artifact]) => (
+    artifact.tool === tool && artifact.platform === target.platform && artifact.arch === target.arch
+  ))?.[0];
+}
+
+function releaseTagFor(metadata) {
+  const tag = metadata?.releaseTag;
+  if (typeof tag !== 'string' || tag.length === 0) throw new Error('toolchain metadata is missing releaseTag');
+  return tag;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+}
+
+function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') continue;
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+    if (!arg.startsWith('--')) throw new Error(`Unexpected argument: ${arg}`);
+    const [rawKey, inlineValue] = arg.slice(2).split('=', 2);
+    const key = rawKey.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+    if (key !== 'metadata') throw new Error(`Unknown option: ${arg}`);
+    const value = inlineValue ?? args[index + 1];
+    if (!value || value.startsWith('--')) throw new Error(`Missing value for ${arg}`);
+    options[key] = value;
+    if (inlineValue === undefined) index += 1;
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log('Usage: node scripts/toolchains/verify-toolchain-publication.mjs [--metadata <path>]');
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs.d.ts
+++ b/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs.d.ts
@@ -1,0 +1,5 @@
+export function verifyToolchainPublication(input: {
+  targets: Array<{ platform: string; arch: string; releaseSupported: boolean }>;
+  metadata: unknown;
+  downloadArtifact?: (url: string, key: string) => Promise<Uint8Array | Buffer | string>;
+}): Promise<{ verifiedKeys: string[]; warnings: string[] }>;

--- a/apps/desktop/scripts/verify-host-mode-release.mjs
+++ b/apps/desktop/scripts/verify-host-mode-release.mjs
@@ -139,12 +139,11 @@ function checkBrowserPackMetadata(targets, metadata, failures) {
 }
 
 function checkToolchainMetadata(targets, metadata, failures) {
-  const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'];
   const requiredArtifactKeys = [];
   const productionUrlPrefix = `https://github.com/sero-labs/sero/releases/download/${metadata?.releaseTag ?? ''}/`;
   for (const target of targets) {
     if (!target.releaseSupported) continue;
-    for (const tool of coreTools) {
+    for (const tool of requiredCoreToolsForTarget(target)) {
       const entry = Object.entries(metadata?.artifacts ?? {}).find(([, artifact]) => (
         artifact.tool === tool && artifact.platform === target.platform && artifact.arch === target.arch
       ));
@@ -167,6 +166,13 @@ function checkToolchainMetadata(targets, metadata, failures) {
     }
   }
   return requiredArtifactKeys;
+}
+
+
+function requiredCoreToolsForTarget(target) {
+  const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'];
+  if (target.platform === 'darwin') return coreTools.filter((tool) => !['git', 'ssh', 'bash'].includes(tool));
+  return coreTools;
 }
 
 function checkPackageScripts(packageJson, failures) {

--- a/apps/desktop/scripts/verify-host-mode-release.mjs
+++ b/apps/desktop/scripts/verify-host-mode-release.mjs
@@ -17,6 +17,7 @@ const requiredPackageScripts = [
   'dist:linux:arm64',
   'dist:win',
   'browser-pack:verify-published',
+  'toolchain:verify-published',
 ];
 
 const workflowRequirements = [
@@ -69,9 +70,9 @@ async function main() {
   });
 
   for (const warning of result.warnings) console.warn(`warning: ${warning}`);
-  console.log(`Host-mode release repository checks passed for ${result.requiredArtifactKeys.length} browser-pack target(s).`);
+  console.log(`Host-mode release repository checks passed for ${result.requiredArtifactKeys.length} browser-pack and ${result.requiredToolchainArtifactKeys.length} core toolchain artifact(s).`);
   if (!options.verifyPublished) {
-    console.log('Network publication verification was not run. Run `pnpm --filter @sero/desktop browser-pack:verify-published` before release.');
+    console.log('Network publication verification was not run. Run `pnpm --filter @sero/desktop browser-pack:verify-published` and `pnpm --filter @sero/desktop toolchain:verify-published` before release.');
   }
 }
 
@@ -80,32 +81,37 @@ export async function verifyHostModeRelease({ repoRoot = defaultRepoRoot, deskto
   const warnings = [];
   const matrixPath = path.join(desktopRoot, 'electron/features/workspace/runtime/host-support-matrix.json');
   const metadataPath = path.join(desktopRoot, 'electron/features/workspace/runtime/browser-pack/generated-artifacts.json');
+  const toolchainMetadataPath = path.join(desktopRoot, 'electron/features/workspace/runtime/toolchains/generated-artifacts.json');
   const packageJsonPath = path.join(desktopRoot, 'package.json');
   const workflowPath = path.join(repoRoot, '.github/workflows/release.yml');
   const buildReleasePath = path.join(desktopRoot, 'scripts/build-release.sh');
 
-  const [targets, metadata, packageJson, workflowText, buildReleaseText] = await Promise.all([
+  const [targets, metadata, toolchainMetadata, packageJson, workflowText, buildReleaseText] = await Promise.all([
     readJson(matrixPath),
     readJson(metadataPath),
+    readJson(toolchainMetadataPath),
     readJson(packageJsonPath),
     readOptionalText(workflowPath),
     readOptionalText(buildReleasePath),
   ]);
 
   const requiredArtifactKeys = checkBrowserPackMetadata(targets, metadata, failures);
+  const requiredToolchainArtifactKeys = checkToolchainMetadata(targets, toolchainMetadata, failures);
   checkPackageScripts(packageJson, failures);
   checkWorkflow(workflowPath, workflowText, failures);
   checkBuildReleaseScript(buildReleasePath, buildReleaseText, failures);
   await checkDocs(repoRoot, failures);
+  await checkForbiddenRuntimeDownloads(desktopRoot, failures);
 
   if (verifyPublished) {
     await runBrowserPackPublicationVerifier(desktopRoot, failures);
+    await runToolchainPublicationVerifier(desktopRoot, failures);
   } else {
-    warnings.push('Skipped network browser-pack publication verification; run browser-pack:verify-published separately.');
+    warnings.push('Skipped network artifact publication verification; run browser-pack:verify-published and toolchain:verify-published separately.');
   }
 
   if (failures.length > 0) throw new Error(failures.join('\n'));
-  return { requiredArtifactKeys, warnings };
+  return { requiredArtifactKeys, requiredToolchainArtifactKeys, warnings };
 }
 
 function checkBrowserPackMetadata(targets, metadata, failures) {
@@ -127,6 +133,37 @@ function checkBrowserPackMetadata(targets, metadata, failures) {
     }
     if (typeof artifact.url !== 'string' || !artifact.url.startsWith('https://github.com/sero-labs/sero/releases/download/')) {
       failures.push(`${key} must use a GitHub Release browser-pack URL in committed metadata`);
+    }
+  }
+  return requiredArtifactKeys;
+}
+
+function checkToolchainMetadata(targets, metadata, failures) {
+  const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'];
+  const requiredArtifactKeys = [];
+  const productionUrlPrefix = `https://github.com/sero-labs/sero/releases/download/${metadata?.releaseTag ?? ''}/`;
+  for (const target of targets) {
+    if (!target.releaseSupported) continue;
+    for (const tool of coreTools) {
+      const entry = Object.entries(metadata?.artifacts ?? {}).find(([, artifact]) => (
+        artifact.tool === tool && artifact.platform === target.platform && artifact.arch === target.arch
+      ));
+      const key = entry?.[0] ?? `${tool}-${target.platform}-${target.arch}`;
+      const artifact = entry?.[1];
+      requiredArtifactKeys.push(key);
+      if (!artifact || artifact.status !== 'built' || artifact.available !== true) {
+        failures.push(`Missing built/available core toolchain artifact in committed metadata: ${key}`);
+        continue;
+      }
+      if (typeof artifact.sha256 !== 'string' || !/^[a-f0-9]{64}$/.test(artifact.sha256)) {
+        failures.push(`${key} has invalid sha256 in committed metadata`);
+      }
+      if (typeof artifact.url !== 'string' || !artifact.url.startsWith(productionUrlPrefix)) {
+        failures.push(`${key} must use a GitHub Release core toolchain URL in committed metadata`);
+      }
+      if (artifact.url?.includes('downloads.sero.ai')) {
+        failures.push(`${key} must not use downloads.sero.ai`);
+      }
     }
   }
   return requiredArtifactKeys;
@@ -167,12 +204,38 @@ function checkWorkflow(workflowPath, workflowText, failures) {
   if (!workflowText.includes('browser-pack:verify-published')) {
     failures.push(`${relativePath(workflowPath)}: missing browser-pack:verify-published release gate`);
   }
+  if (!workflowText.includes('toolchain:verify-published')) {
+    failures.push(`${relativePath(workflowPath)}: missing toolchain:verify-published release gate`);
+  }
   if (!workflowText.includes('runtime-host-release.workflow.spec.ts')) {
     failures.push(`${relativePath(workflowPath)}: missing host release smoke workflow spec`);
   }
   if (!workflowText.includes('Verify macOS app bundle')) {
     failures.push(`${relativePath(workflowPath)}: missing macOS app bundle verification gate`);
   }
+}
+
+async function checkForbiddenRuntimeDownloads(desktopRoot, failures) {
+  const runtimeRoot = path.join(desktopRoot, 'electron/features/workspace/runtime');
+  const files = await listFiles(runtimeRoot);
+  await Promise.all(files.map(async (filePath) => {
+    const text = await fs.readFile(filePath, 'utf8');
+    if (text.includes('downloads.sero.ai')) failures.push(`${relativePath(filePath)}: runtime artifacts must not use downloads.sero.ai`);
+  }));
+}
+
+async function listFiles(root) {
+  const entries = await fs.readdir(root, { withFileTypes: true }).catch((error) => {
+    if (error && error.code === 'ENOENT') return [];
+    throw error;
+  });
+  const files = [];
+  for (const entry of entries) {
+    const filePath = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...await listFiles(filePath));
+    if (entry.isFile() && /\.(json|ts|tsx|js|mjs)$/.test(entry.name)) files.push(filePath);
+  }
+  return files;
 }
 
 function checkBuildReleaseScript(buildReleasePath, buildReleaseText, failures) {
@@ -211,6 +274,18 @@ async function runBrowserPackPublicationVerifier(desktopRoot, failures) {
     });
   } catch (error) {
     failures.push(`browser-pack publication verifier failed: ${errorOutput(error)}`);
+  }
+}
+
+async function runToolchainPublicationVerifier(desktopRoot, failures) {
+  try {
+    await execFileAsync('pnpm', ['--filter', '@sero/desktop', 'toolchain:verify-published'], {
+      cwd: path.resolve(desktopRoot, '../..'),
+      encoding: 'utf8',
+      maxBuffer: 1024 * 1024 * 20,
+    });
+  } catch (error) {
+    failures.push(`core toolchain publication verifier failed: ${errorOutput(error)}`);
   }
 }
 

--- a/apps/desktop/scripts/verify-host-mode-release.mjs.d.ts
+++ b/apps/desktop/scripts/verify-host-mode-release.mjs.d.ts
@@ -1,5 +1,6 @@
 export interface VerifyHostModeReleaseResult {
   readonly requiredArtifactKeys: readonly string[];
+  readonly requiredToolchainArtifactKeys: readonly string[];
   readonly warnings: readonly string[];
 }
 

--- a/apps/desktop/src/components/profiles/OnboardingWizard.test.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.test.tsx
@@ -97,6 +97,15 @@ describe('OnboardingWizard', () => {
           writeText: vi.fn().mockResolvedValue(true),
         },
         workspace: {
+          getToolchainStatus: vi.fn().mockResolvedValue({
+            state: 'ready',
+            tools: [
+              { tool: 'node', state: 'ready', source: 'system' },
+              { tool: 'npm', state: 'ready', source: 'system' },
+            ],
+          }),
+          ensureCoreTools: vi.fn().mockResolvedValue({ state: 'ready', tools: [] }),
+          onToolchainProgress: vi.fn(() => () => {}),
           getBrowserPackStatus: vi.fn().mockResolvedValue({ state: 'installable', manifestVersion: 'test' }),
           ensureBrowserPack: vi.fn().mockResolvedValue({ state: 'installable', manifestVersion: 'test' }),
           onBrowserPackProgress: vi.fn(() => () => {}),
@@ -215,12 +224,40 @@ describe('OnboardingWizard', () => {
       continueButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    expect(document.body.textContent).toContain('Install dependencies (optional)');
-    expect(document.body.textContent).toContain('strongly recommended for screenshots');
+    expect(document.body.textContent).toContain('Install host dependencies');
+    expect(document.body.textContent).toContain('Sero checks core development tools during setup');
+    expect(document.body.textContent).toContain('Core development tools');
     expect(document.body.textContent).toContain('Browser automation');
     expect(document.body.textContent).toContain('Large download for browser screenshots');
     expect(document.body.textContent).toContain('Install browser support');
     expect(document.body.textContent).not.toContain('Skip for now');
+  });
+
+  it('starts core tool installation from the onboarding dependency step when host tools are missing', async () => {
+    const ensureCoreTools = vi.fn().mockResolvedValue({ state: 'ready', tools: [] });
+    window.sero.workspace.getToolchainStatus = vi.fn().mockResolvedValue({
+      state: 'missing',
+      tools: [{ tool: 'node', state: 'missing' }],
+      error: { code: 'TOOL_REQUIRED', message: 'node is missing', retryable: true, installable: true },
+    });
+    window.sero.workspace.ensureCoreTools = ensureCoreTools;
+    mockUseOnboardingLaunch.mockReturnValue(createLaunchState());
+
+    await act(async () => {
+      root?.render(<OnboardingWizard />);
+    });
+
+    const continueButton = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Continue'),
+    );
+    await act(async () => {
+      continueButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(ensureCoreTools).toHaveBeenCalledWith('onboarding');
   });
 
   it('omits the container warning when containers are available', async () => {

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -28,6 +28,7 @@ import type {
   ProviderHealthInfo,
 } from '@/types/ipc';
 import { BrowserPackOffer } from '@/components/runtime/BrowserPackOffer';
+import { CoreToolsOffer } from '@/components/runtime/CoreToolsOffer';
 import { ContainerRuntimeNotice } from './ContainerRuntimeNotice';
 import { GitHubConnectCard } from './GitHubConnectCard';
 import { useOnboardingGitHubStep } from './useOnboardingGitHubStep';
@@ -148,14 +149,15 @@ export function OnboardingSetupScreen({
             <Download className="size-5 text-[var(--status-success)]" />
           </div>
           <div>
-            <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">Install dependencies (optional)</DialogTitle>
+            <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">Install host dependencies</DialogTitle>
             <DialogDescription className="text-sm text-[var(--text-secondary)]">
-              If you are not using containers, installing browser support is strongly recommended for screenshots, recordings, and web tasks.
+              Sero checks core development tools during setup. Browser support is optional unless you need screenshots, recordings, or web tasks.
             </DialogDescription>
           </div>
         </div>
 
         <ContainerRuntimeNotice runtime={containerRuntime} />
+        <CoreToolsOffer reason="onboarding" autoInstall />
         <BrowserPackOffer reason="onboarding" />
 
         <div className="flex justify-between gap-2 pt-1">

--- a/apps/desktop/src/components/runtime/CoreToolsOffer.tsx
+++ b/apps/desktop/src/components/runtime/CoreToolsOffer.tsx
@@ -75,6 +75,7 @@ export function CoreToolsOffer({ reason, className, autoInstall = false }: CoreT
     && status !== null
     && status.state !== 'ready'
     && status.state !== 'installing'
+    && status.error?.installable !== false
     && (status.state !== 'failed' || canRetry);
 
   const install = async () => {

--- a/apps/desktop/src/components/runtime/CoreToolsOffer.tsx
+++ b/apps/desktop/src/components/runtime/CoreToolsOffer.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { AlertCircle, CheckCircle2, Download, Loader2 } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import type { ToolchainStatusIPC } from '@sero-ai/common';
+import { cn } from '@sero-ai/ui/lib/utils';
+
+interface CoreToolsOfferProps {
+  reason: string;
+  className?: string;
+  autoInstall?: boolean;
+}
+
+function coreToolsMessage(status: ToolchainStatusIPC | null): string {
+  if (!status) return 'Required for host terminals, Git, language servers, package installs, and dev servers.';
+  if (status.state === 'ready') return 'Installed or provided by your system and ready for host workspaces.';
+  if (status.state === 'installing') return 'Installing. You can continue setup while Sero verifies the toolchain.';
+  if (status.state === 'failed') return status.error?.message ?? 'Install failed. Retry or use a container runtime.';
+  const missingTool = status.tools.find((tool) => tool.state !== 'ready')?.tool;
+  return missingTool
+    ? `${missingTool} is missing or incompatible. Sero can install its managed core tools.`
+    : 'Sero can install its managed core tools for host workspaces.';
+}
+
+function updateStatusFromProgress(
+  current: ToolchainStatusIPC | null,
+  progress: NonNullable<ToolchainStatusIPC['progress']>,
+): ToolchainStatusIPC | null {
+  if (!current) return null;
+  if (progress.phase === 'ready') return { ...current, state: 'ready', progress };
+  if (progress.phase === 'failed') return { ...current, state: 'failed', error: progress.error, progress };
+  return { ...current, state: 'installing', progress };
+}
+
+export function CoreToolsOffer({ reason, className, autoInstall = false }: CoreToolsOfferProps) {
+  const [status, setStatus] = useState<ToolchainStatusIPC | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      const nextStatus = await window.sero.workspace.getToolchainStatus?.();
+      if (cancelled || !nextStatus) return;
+      setStatus(nextStatus);
+      if (autoInstall && nextStatus.state === 'missing') {
+        await installFromStatus(nextStatus);
+      }
+    };
+
+    const installFromStatus = async (currentStatus: ToolchainStatusIPC) => {
+      if (cancelled || currentStatus.error?.installable === false) return;
+      setBusy(true);
+      try {
+        const installedStatus = await window.sero.workspace.ensureCoreTools?.(reason);
+        if (!cancelled && installedStatus) setStatus(installedStatus);
+      } finally {
+        if (!cancelled) setBusy(false);
+      }
+    };
+
+    void load().catch(() => undefined);
+    const unsubscribe = window.sero.workspace.onToolchainProgress?.((event) => {
+      setStatus((current) => updateStatusFromProgress(current, event));
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [autoInstall, reason]);
+
+  const canRetry = status?.state === 'failed'
+    && status.error?.retryable === true
+    && status.error.installable === true;
+  const canInstall = Boolean(window.sero.workspace?.ensureCoreTools)
+    && status !== null
+    && status.state !== 'ready'
+    && status.state !== 'installing'
+    && (status.state !== 'failed' || canRetry);
+
+  const install = async () => {
+    if (!canInstall || busy) return;
+    const ensureCoreTools = window.sero.workspace.ensureCoreTools;
+    if (!ensureCoreTools) return;
+    setBusy(true);
+    try {
+      const nextStatus = await ensureCoreTools(reason);
+      setStatus(nextStatus);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const ready = status?.state === 'ready';
+  const installing = busy || status?.state === 'installing';
+  const failed = status?.state === 'failed';
+
+  return (
+    <div className={cn(
+      'rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-elevated)]/60 p-3 text-sm text-[var(--text-secondary)]',
+      className,
+    )}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-base)]">
+          {ready ? <CheckCircle2 className="size-4 text-[var(--status-success)]" /> : failed ? <AlertCircle className="size-4 text-[var(--status-warning)]" /> : <Download className="size-4 text-[var(--accent-primary)]" />}
+        </div>
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="space-y-1">
+            <p className="font-medium text-[var(--text-primary)]">Core development tools</p>
+            <p className={cn(failed ? 'text-[var(--status-error)]' : 'text-[var(--text-muted)]')}>
+              {coreToolsMessage(status)}
+            </p>
+          </div>
+          {!ready && (canInstall || installing) ? (
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" size="sm" className="h-7 text-xs" disabled={!canInstall || installing} onClick={() => void install()}>
+                {installing ? <Loader2 className="mr-1.5 size-3 animate-spin" /> : null}
+                {failed ? 'Retry install' : installing ? 'Installing…' : 'Install core tools'}
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs-site/docs/reference/environment-doctor.md
+++ b/apps/docs-site/docs/reference/environment-doctor.md
@@ -131,7 +131,7 @@ Host checks cover Node, pnpm, Git/SSH, shell readiness, and Sero-managed host to
 ~/.sero-ui/toolchains/<manifest-version>/
 ```
 
-The tools are considered usable only after their readiness marker is present.
+The tools are considered usable only after their readiness marker is present. If compatible system tools are missing, Sero installs managed core tools from GitHub Release assets during onboarding, Runtime settings, or first use.
 
 Host is the default on supported macOS arm64, Linux x64/arm64, and Windows x64 systems. For the canonical matrix, see [Support Scope](/reference/support-scope).
 

--- a/apps/docs-site/docs/reference/troubleshooting.md
+++ b/apps/docs-site/docs/reference/troubleshooting.md
@@ -130,7 +130,7 @@ Common Doctor results and next actions:
 
 | Doctor result | What to do |
 | --- | --- |
-| Host core tools missing | Confirm Node, pnpm, Git/SSH, and your shell are available on `PATH`. |
+| Host core tools missing | Use onboarding or Runtime settings to install Sero-managed core tools, or confirm Node, pnpm, Git/SSH, and your shell are available on `PATH`. |
 | Managed tools still installing | Wait for the install to finish, then rerun Doctor. |
 | Browser pack missing but installable | Use the in-app install action if offered, then rerun Doctor. |
 | Browser pack failed | Check disk space and network access, then rerun Doctor. Include the report if it still fails. |

--- a/docs/features/host-toolchain.md
+++ b/docs/features/host-toolchain.md
@@ -50,7 +50,7 @@ Windows host mode is native Windows execution with a verified Git Bash/MSYS-comp
 Core managed tools use committed metadata in `apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json`. Update it from release receipt JSON with `pnpm --filter @sero/desktop toolchain:merge-metadata -- --sidecar-dir <dir> --release-tag <tag> --version <version>`. Release-supported targets must point to GitHub Release assets such as:
 
 ```txt
-https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-linux-x64.tar.gz
+https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/node-linux-x64.tar.gz
 ```
 
 Do not use `downloads.sero.ai`; that host is not part of Sero's distribution path. Release gates run `pnpm --filter @sero/desktop toolchain:verify-published` and fail if required core artifacts are missing, unpublished, or hash-mismatched. `SERO_TOOLCHAIN_BASE_URL` is only a local diagnostic override for serving byte-identical mirrors of the committed artifacts; rebuilt artifacts with different bytes must update the committed SHA-256 metadata first. Unsupported host targets, such as macOS x64, stay `pending` so Sero does not offer unpublished installs.

--- a/docs/features/host-toolchain.md
+++ b/docs/features/host-toolchain.md
@@ -21,7 +21,7 @@ Managed host tools are stored under the fixed Sero root, not the active profile 
 
 Implementation uses `SERO_FIXED_ROOT` from `apps/desktop/electron/platform/env/index.ts`, which resolves to `~/.sero-ui`. Do not store shared toolchains under `SERO_HOME`, `~/.sero`, `~/.pi/agent`, or `~/.sero-ui/agent`.
 
-Installers download into staging paths, verify pinned SHA-256 checksums, and atomically activate final directories. Core tools share a version-level `.installed` marker that is removed before any core install and written only after every required core tool resolves successfully; absence of `.installed` means the managed toolchain version is incomplete and must not be used for PATH resolution. Non-core artifacts write the marker only after their own activation/verification completes. Concurrent installs for the same manifest/artifact attach to the same in-flight operation.
+Installers download from published GitHub Release assets into staging paths, verify pinned SHA-256 checksums, and atomically activate final directories. Core tools share a version-level `.installed` marker that is removed before any core install and written only after every required core tool resolves successfully; absence of `.installed` means the managed toolchain version is incomplete and must not be used for PATH resolution. Non-core artifacts write the marker only after their own activation/verification completes. Concurrent installs for the same manifest/artifact attach to the same in-flight operation.
 
 ## Resolution order
 
@@ -38,12 +38,22 @@ Verification runs version or smoke commands; PATH presence alone is not trusted.
 
 | Tier | Tools | Install behavior |
 | --- | --- | --- |
-| Core | `node`, `npm`, `pnpm`, `git`, `ssh`, `bash`/compatible shell | Auto-install on first Sero-owned use when missing/incompatible. |
+| Core | `node`, `npm`, `pnpm`, `git`, `ssh`, `bash`/compatible shell | Checked during onboarding and auto-install on first Sero-owned use when missing/incompatible. |
 | Small convenience | `rg`, `fd`, `jq`, `gh`, `curl`, `zip`, `unzip` | Install on demand for Sero features or declared dependencies. |
 | Large optional | Browser automation pack | Explicit/onboarding/settings install or first browser-tool use. |
 | Not managed | Xcode CLT, Linux build-essential/gcc/make, MSVC/Windows SDK | User-installed or use a container fallback. |
 
 Windows host mode is native Windows execution with a verified Git Bash/MSYS-compatible shell; it is not WSL by default.
+
+## Core toolchain publication
+
+Core managed tools use committed metadata in `apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json`. Release-supported targets must point to GitHub Release assets such as:
+
+```txt
+https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-linux-x64.tar.gz
+```
+
+Do not use `downloads.sero.ai`; that host is not part of Sero's distribution path. Release gates run `pnpm --filter @sero/desktop toolchain:verify-published` and fail if required core artifacts are missing, unpublished, or hash-mismatched. `SERO_TOOLCHAIN_BASE_URL` is only a local diagnostic override for serving rebuilt artifacts during development.
 
 ## Browser automation pack
 

--- a/docs/features/host-toolchain.md
+++ b/docs/features/host-toolchain.md
@@ -47,13 +47,13 @@ Windows host mode is native Windows execution with a verified Git Bash/MSYS-comp
 
 ## Core toolchain publication
 
-Core managed tools use committed metadata in `apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json`. Release-supported targets must point to GitHub Release assets such as:
+Core managed tools use committed metadata in `apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json`. Update it from release receipt JSON with `pnpm --filter @sero/desktop toolchain:merge-metadata -- --sidecar-dir <dir> --release-tag <tag> --version <version>`. Release-supported targets must point to GitHub Release assets such as:
 
 ```txt
 https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-16/node-linux-x64.tar.gz
 ```
 
-Do not use `downloads.sero.ai`; that host is not part of Sero's distribution path. Release gates run `pnpm --filter @sero/desktop toolchain:verify-published` and fail if required core artifacts are missing, unpublished, or hash-mismatched. `SERO_TOOLCHAIN_BASE_URL` is only a local diagnostic override for serving rebuilt artifacts during development.
+Do not use `downloads.sero.ai`; that host is not part of Sero's distribution path. Release gates run `pnpm --filter @sero/desktop toolchain:verify-published` and fail if required core artifacts are missing, unpublished, or hash-mismatched. `SERO_TOOLCHAIN_BASE_URL` is only a local diagnostic override for serving byte-identical mirrors of the committed artifacts; rebuilt artifacts with different bytes must update the committed SHA-256 metadata first. Unsupported host targets, such as macOS x64, stay `pending` so Sero does not offer unpublished installs.
 
 ## Browser automation pack
 

--- a/docs/features/host-toolchain.md
+++ b/docs/features/host-toolchain.md
@@ -55,6 +55,8 @@ https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/node-l
 
 Do not use `downloads.sero.ai`; that host is not part of Sero's distribution path. Release gates run `pnpm --filter @sero/desktop toolchain:verify-published` and fail if required core artifacts are missing, unpublished, or hash-mismatched. `SERO_TOOLCHAIN_BASE_URL` is only a local diagnostic override for serving byte-identical mirrors of the committed artifacts; rebuilt artifacts with different bytes must update the committed SHA-256 metadata first. Unsupported host targets, such as macOS x64, stay `pending` so Sero does not offer unpublished installs.
 
+macOS arm64 publishes managed Node/npm/pnpm artifacts. Git, SSH, and Bash are verified from macOS system locations until real portable macOS artifacts are available; do not publish wrapper-only archives for those tools.
+
 ## Browser automation pack
 
 Host browser automation is install-state-aware:

--- a/docs/features/runtime-provider-architecture.md
+++ b/docs/features/runtime-provider-architecture.md
@@ -71,7 +71,7 @@ Callers must use runtime diagnostics instead of branching on provider-specific i
 - availability: is it available for this workspace right now?
 - install state: are core tools, browser pack, and native build tools ready/missing/installing/failed?
 
-Host browser automation is available only when the browser pack is installed and Doctor launch checks pass. Release-supported platforms require published GitHub Release browser-pack artifacts verified by `pnpm --filter @sero/desktop browser-pack:verify-published`; pending entries in `generated-artifacts.json` block the release claim. Local artifact overrides are developer diagnostics only. Native compiler stacks are informational and non-managed.
+Host browser automation is available only when the browser pack is installed and Doctor launch checks pass. Release-supported platforms require published GitHub Release browser-pack artifacts verified by `pnpm --filter @sero/desktop browser-pack:verify-published`; pending entries in `generated-artifacts.json` block the release claim. Core managed tools use the same GitHub Release asset model and are verified by `pnpm --filter @sero/desktop toolchain:verify-published`. Local artifact overrides are developer diagnostics only. Native compiler stacks are informational and non-managed.
 
 ## Managed host tooling
 

--- a/docs/reference/runtime-smoke.md
+++ b/docs/reference/runtime-smoke.md
@@ -60,7 +60,9 @@ Run on release-supported macOS Apple Silicon, Linux, and Windows x64 with backen
 2. Confirm managed artifacts, if installed, are under `SERO_FIXED_ROOT` and not under profile-local `SERO_HOME`, `~/.sero`, or `~/.pi/agent`.
 3. Confirm `.installed` is present for ready managed artifacts.
 4. In Runtime settings, trigger core tool install/retry when status permits and verify progress/failure details are visible.
-5. Confirm Sero does not run `corepack enable`, mutate shell profiles, or require global `npm install -g` for managed tools.
+5. Confirm onboarding shows core development tools before browser automation and starts managed core install when host tools are missing.
+6. Confirm core managed artifacts use GitHub Release URLs and `pnpm --filter @sero/desktop toolchain:verify-published` passes before release.
+7. Confirm Sero does not run `corepack enable`, mutate shell profiles, or require global `npm install -g` for managed tools.
 
 ## Host browser pack checks
 


### PR DESCRIPTION
## Summary
- move managed host core tool metadata to GitHub Release asset URLs instead of downloads.sero.ai
- add core toolchain publication verification and host release gates
- add onboarding core development tools install/check before optional browser automation
- update runtime docs and docs-site troubleshooting

## Validation
- pnpm --filter @sero/desktop exec vitest run electron/__tests__/features/workspace/runtime/toolchains/manifest.test.ts electron/__tests__/scripts/toolchains/verify-toolchain-publication.test.ts electron/__tests__/scripts/verify-host-mode-release.test.ts
- pnpm --filter @sero/desktop exec vitest run src/components/profiles/OnboardingWizard.test.tsx
- pnpm --filter @sero/desktop verify:host-mode-release
- pnpm typecheck
