### PR TITLE
fix(desktop): release safe toolchain archives

### DIFF
--- a/apps/desktop/electron/__tests__/scripts/toolchains/verify-toolchain-publication.test.ts
+++ b/apps/desktop/electron/__tests__/scripts/toolchains/verify-toolchain-publication.test.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { gzipSync } from 'node:zlib';
 
 import { describe, expect, it } from 'vitest';
 
@@ -15,7 +16,7 @@ const coreTools = ['node', 'npm', 'pnpm', 'git', 'ssh', 'bash'];
 const releaseTag = 'toolchains-2026-05-16';
 
 function shaFor(key: string): string {
-  return createHash('sha256').update(Buffer.from(key)).digest('hex');
+  return createHash('sha256').update(artifactBytes(key)).digest('hex');
 }
 
 describe('verify-toolchain-publication', () => {
@@ -38,14 +39,49 @@ describe('verify-toolchain-publication', () => {
       verifiedKeys: expect.arrayContaining(['node-macos-arm64', 'bash-windows-x64']),
     });
   });
+
+  it('fails when a published archive contains an unsafe absolute symlink', async () => {
+    const metadata = createMetadata();
+    metadata.artifacts['npm-linux-x64'].sha256 = createHash('sha256').update(unsafeSymlinkTarGz()).digest('hex');
+
+    await expect(verifyToolchainPublication({
+      targets,
+      metadata,
+      downloadArtifact: async (_url: string, key: string) => (
+        key === 'npm-linux-x64' ? unsafeSymlinkTarGz() : artifactBytes(key)
+      ),
+    })).rejects.toThrow('npm-linux-x64 archive is unsafe: unsafe symlink target /tmp/build/npm-cli.js');
+  });
 });
 
 function verify(metadata: ReturnType<typeof createMetadata>) {
   return verifyToolchainPublication({
     targets,
     metadata,
-    downloadArtifact: async (_url: string, key: string) => Buffer.from(key),
+    downloadArtifact: async (_url: string, key: string) => artifactBytes(key),
   });
+}
+
+function artifactBytes(_key: string): Buffer {
+  return gzipSync(Buffer.alloc(1024));
+}
+
+function unsafeSymlinkTarGz(): Buffer {
+  const header = Buffer.alloc(512);
+  header.write('bin/npm');
+  header.write('0000777\0', 100);
+  header.write('0000000\0', 108);
+  header.write('0000000\0', 116);
+  header.write('00000000000\0', 124);
+  header.write('00000000000\0', 136);
+  header.fill(' ', 148, 156);
+  header.write('2', 156);
+  header.write('/tmp/build/npm-cli.js', 157);
+  header.write('ustar\0', 257);
+  header.write('00', 263);
+  const checksum = [...header].reduce((sum, byte) => sum + byte, 0).toString(8).padStart(6, '0');
+  header.write(`${checksum}\0 `, 148);
+  return gzipSync(Buffer.concat([header, Buffer.alloc(1024)]));
 }
 
 function createMetadata() {

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/generated-artifacts.json
@@ -32,7 +32,7 @@
       "status": "built",
       "available": true,
       "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/npm-macos-arm64.tar.gz",
-      "sha256": "85b6876bbcfe1b5e5d6317cea2ac6693ffb52797896f79772abae2b9ac57f15f"
+      "sha256": "faf9e68ebe796f741ab8fcae7c813b38b3aaa3cf774ed3be7310689f557d15c4"
     },
     "pnpm-macos-arm64": {
       "tool": "pnpm",
@@ -206,7 +206,7 @@
       "status": "built",
       "available": true,
       "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/npm-linux-arm64.tar.gz",
-      "sha256": "733e82278aa217b8fefbd188da48b4fcbf664fa66b8c135c4c2fec063a191f24"
+      "sha256": "49f1d068123325033a344a5e453c6333681fbdf84dcba0f0ff3871da2957953d"
     },
     "pnpm-linux-arm64": {
       "tool": "pnpm",
@@ -238,7 +238,7 @@
       "status": "built",
       "available": true,
       "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/git-linux-arm64.tar.gz",
-      "sha256": "cc718bc6c0198482c1da6238599e93a952afbac717d6843c17f34eb3ac5a56a5"
+      "sha256": "dd693e1bfbe140e98fd6c4afe9d3d6da3e6a946e095322c24d69e50bd9b22d09"
     },
     "ssh-linux-arm64": {
       "tool": "ssh",
@@ -302,7 +302,7 @@
       "status": "built",
       "available": true,
       "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/npm-linux-x64.tar.gz",
-      "sha256": "9adc70978f8a5f7d1af90331a9cb4d18c7d309e482b1816c9dae089037e85354"
+      "sha256": "7e5bd5f5cd20b9b14ec398cf83ea8ef8e8e3a69637a278f74c47ea2adf9b901c"
     },
     "pnpm-linux-x64": {
       "tool": "pnpm",
@@ -334,7 +334,7 @@
       "status": "built",
       "available": true,
       "url": "https://github.com/sero-labs/sero/releases/download/toolchains-2026-05-31/git-linux-x64.tar.gz",
-      "sha256": "c3c6c73529498e0026c21ae707b88af2f55f345be35d8d15fcfc1dd99b69c193"
+      "sha256": "33ce50b94914c05dab13c9f492cb28297b5b3c7dcd5ae2de4dcbd3c2453153a5"
     },
     "ssh-linux-x64": {
       "tool": "ssh",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero/desktop",
-  "version": "0.2.6-beta.0",
+  "version": "0.2.7-beta.0",
   "description": "Zero context switch, zero sprawl - an agent-first workspace",
   "homepage": "https://sero.ai",
   "author": {

--- a/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
+++ b/apps/desktop/scripts/toolchains/verify-toolchain-publication.mjs
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { gunzipSync } from 'node:zlib';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const desktopRoot = path.resolve(scriptDir, '../..');
@@ -68,6 +69,11 @@ export async function verifyToolchainPublication({ targets, metadata, downloadAr
         if (actualSha !== artifact.sha256) {
           failures.push(`${key} sha256 mismatch: expected ${artifact.sha256}, got ${actualSha}`);
         }
+        try {
+          assertSafeTarGz(bytes, key);
+        } catch (error) {
+          failures.push(`${key} archive is unsafe: ${errorMessage(error)}`);
+        }
         if (actualSha === artifact.sha256) verifiedKeys.push(key);
       } catch (error) {
         failures.push(`${key} download failed from ${artifact.url}: ${errorMessage(error)}`);
@@ -96,6 +102,75 @@ function validateArtifactMetadata({ key, artifact, productionUrlPrefix, releaseT
     failures.push(`${key} has invalid sha256`);
   }
   return failures;
+}
+
+function assertSafeTarGz(bytes, key) {
+  const tar = gunzipSync(bytes);
+  let offset = 0;
+  let sawEnd = false;
+  let nextLongLink = null;
+  let nextPaxLink = null;
+  while (offset + 512 <= tar.length) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      sawEnd = true;
+      break;
+    }
+    const type = readTarString(header, 156, 1) || '0';
+    const size = readTarOctal(header, 124, 12);
+    const linkName = nextPaxLink ?? nextLongLink ?? readTarString(header, 157, 100);
+    nextPaxLink = null;
+    nextLongLink = null;
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+    if (dataEnd > tar.length) throw new Error('entry exceeds archive length');
+    if (type === '1') throw new Error('hardlinks are not supported by the runtime unpacker');
+    if (type === '2') validateTarLinkName(linkName);
+    if (type === 'K') nextLongLink = readTarPayloadString(tar.subarray(dataStart, dataEnd));
+    if (type === 'x') nextPaxLink = parsePaxLinkpath(tar.subarray(dataStart, dataEnd));
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+  if (!sawEnd) throw new Error(`${key} is missing tar end-of-archive marker`);
+}
+
+function validateTarLinkName(linkName) {
+  if (!linkName || linkName.includes('\0') || linkName.includes('\\')) throw new Error(`unsafe symlink target ${linkName}`);
+  if (/^[A-Za-z]:/.test(linkName) || path.posix.isAbsolute(linkName)) throw new Error(`unsafe symlink target ${linkName}`);
+  const normalized = path.posix.normalize(linkName);
+  if (normalized === '..' || normalized.startsWith('../') || normalized.includes('/../')) {
+    throw new Error(`unsafe symlink target ${linkName}`);
+  }
+}
+
+function parsePaxLinkpath(data) {
+  let offset = 0;
+  while (offset < data.length) {
+    const space = data.indexOf(32, offset);
+    if (space === -1) return null;
+    const length = Number.parseInt(data.subarray(offset, space).toString('utf8'), 10);
+    if (!Number.isFinite(length) || length <= 0) return null;
+    const record = data.subarray(space + 1, offset + length).toString('utf8').replace(/\n$/, '');
+    const equals = record.indexOf('=');
+    if (record.slice(0, equals) === 'linkpath') return record.slice(equals + 1);
+    offset += length;
+  }
+  return null;
+}
+
+function readTarPayloadString(data) {
+  const end = data.indexOf(0);
+  return data.subarray(0, end === -1 ? data.length : end).toString('utf8').trim();
+}
+
+function readTarString(buffer, offset, length) {
+  const slice = buffer.subarray(offset, offset + length);
+  const end = slice.indexOf(0);
+  return slice.subarray(0, end === -1 ? slice.length : end).toString('utf8').trim();
+}
+
+function readTarOctal(buffer, offset, length) {
+  const value = readTarString(buffer, offset, length).replace(/\0/g, '').trim();
+  return value ? Number.parseInt(value, 8) : 0;
 }
 
 async function fetchArtifactBytes(url) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sero-monorepo",
-  "version": "0.2.6-beta.0",
+  "version": "0.2.7-beta.0",
   "private": true,
   "packageManager": "pnpm@10.33.4",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump desktop release version to 0.2.7-beta.0
- update checksums for rebuilt toolchain archives without unsafe absolute symlinks
- make publication verification fail on unsafe tar symlinks/hardlinks

## Validation
- pnpm --filter @sero/desktop exec vitest run electron/__tests__/scripts/toolchains/verify-toolchain-publication.test.ts
- pnpm --filter @sero/desktop toolchain:verify-published
- pnpm --filter @sero/desktop exec node scripts/verify-host-mode-release.mjs --verify-published
- pnpm typecheck
