### PR TITLE
fix: resolve plugin host tool paths

### DIFF
--- a/apps/desktop/electron/__tests__/features/plugins/dev-sessions/manifest.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/dev-sessions/manifest.test.ts
@@ -84,6 +84,15 @@ describe('plugin dev manifest validation', () => {
     })).rejects.toThrow(/app id drifted from "old-plugin" to "renamed-plugin"/);
   });
 
+  it('rejects yarn local plugin dev sessions with a clear unsupported-manager error', async () => {
+    const sourcePath = await createPluginSource();
+    await writeFile(path.join(sourcePath, 'yarn.lock'), 'lockfile\n');
+
+    await expect(readPluginDevSourceManifest(sourcePath)).rejects.toThrow(
+      /support npm and pnpm only/,
+    );
+  });
+
   it('suppresses UI fields when the resolved session mode has no usable UI', async () => {
     const sourcePath = await createPluginSource();
     const manifest = (await readPluginDevSourceManifest(sourcePath)).manifest;

--- a/apps/desktop/electron/__tests__/features/plugins/host-command-runner.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/host-command-runner.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  renderPluginHostCommand,
+  renderPluginHostShellCommand,
+  runPluginHostCommand,
+} from '@electron/features/plugins/host-command-runner';
+
+describe('plugin host command runner', () => {
+  it('runs managed host tools with prepared PATH', async () => {
+    const tools = {
+      prepareProgram: vi.fn(async (program: string) => (
+        program === 'node' ? '/managed/bin/node' : '/managed/bin/npm'
+      )),
+      prepareEnv: vi.fn(async (env: Record<string, string>) => ({
+        ...env,
+        PATH: `/managed/bin:${env.PATH ?? ''}`,
+      })),
+    };
+    const execute = vi.fn(async () => ({ stdout: '[{"filename":"plugin.tgz"}]', stderr: '' }));
+
+    const result = await runPluginHostCommand('npm', ['pack', '@acme/plugin'], '/tmp/plugin-stage', {
+      env: { PATH: '/usr/bin', npm_config_cache: undefined },
+      execute,
+      tools,
+    });
+
+    expect(result.stdout).toContain('plugin.tgz');
+    expect(tools.prepareProgram).toHaveBeenNthCalledWith(1, 'node', expect.objectContaining({
+      kind: 'plugin-install',
+      command: 'npm pack @acme/plugin',
+    }));
+    expect(tools.prepareProgram).toHaveBeenNthCalledWith(2, 'npm', expect.objectContaining({
+      kind: 'plugin-install',
+      command: 'npm pack @acme/plugin',
+    }));
+    expect(tools.prepareEnv).toHaveBeenCalledWith({ PATH: '/usr/bin' });
+    expect(execute).toHaveBeenCalledWith('/managed/bin/npm', ['pack', '@acme/plugin'], {
+      cwd: '/tmp/plugin-stage',
+      encoding: 'utf8',
+      env: { PATH: '/managed/bin:/usr/bin' },
+    });
+  });
+
+  it('runs Windows command shims through cmd.exe', async () => {
+    const tools = {
+      prepareProgram: vi.fn(async () => 'C:\\Sero\\tools\\npm.cmd'),
+      prepareEnv: vi.fn(async (env: Record<string, string>) => env),
+    };
+    const execute = vi.fn(async () => ({ stdout: '', stderr: '' }));
+
+    await runPluginHostCommand('npm', ['install'], 'C:\\stage', {
+      env: {},
+      execute,
+      platform: 'win32',
+      tools,
+    });
+
+    expect(execute).toHaveBeenCalledWith('cmd.exe', [
+      '/d',
+      '/s',
+      '/c',
+      '""C:\\Sero\\tools\\npm.cmd" "install""',
+    ], {
+      cwd: 'C:\\stage',
+      encoding: 'utf8',
+      env: {},
+    });
+  });
+
+  it('prepares package-manager tools before running plugin dev shell commands', async () => {
+    const tools = {
+      prepareProgram: vi.fn(async (program: string) => `/managed/bin/${program}`),
+      prepareShell: vi.fn(async () => ({ tool: 'bash' as const, source: 'system' as const, path: '/bin/bash' })),
+      prepareEnv: vi.fn(async (env: Record<string, string>) => ({
+        ...env,
+        PATH: `/managed/bin:${env.PATH ?? ''}`,
+      })),
+    };
+
+    await expect(renderPluginHostShellCommand('pnpm dev', '/tmp/plugin', {
+      env: { PATH: '/usr/bin' },
+      tools,
+    })).resolves.toEqual({
+      program: '/bin/bash',
+      args: ['-c', 'pnpm dev'],
+      cwd: '/tmp/plugin',
+      env: { PATH: '/managed/bin:/usr/bin' },
+    });
+
+    expect(tools.prepareProgram).toHaveBeenNthCalledWith(1, 'node', expect.any(Object));
+    expect(tools.prepareProgram).toHaveBeenNthCalledWith(2, 'pnpm', expect.any(Object));
+  });
+
+  it('uses absolute system tar when PATH may not contain system directories', async () => {
+    const rendered = await renderPluginHostCommand('tar', ['-xzf', 'plugin.tgz'], '/tmp/plugin', {
+      env: {},
+      tools: {
+        prepareProgram: vi.fn(async (program: string) => program),
+        prepareEnv: vi.fn(async (env: Record<string, string>) => env),
+      },
+    });
+
+    expect(rendered.program).toMatch(/(?:^|[\\/])tar(?:\.exe)?$/i);
+  });
+});

--- a/apps/desktop/electron/__tests__/features/plugins/plugin-package-build.test.ts
+++ b/apps/desktop/electron/__tests__/features/plugins/plugin-package-build.test.ts
@@ -458,6 +458,27 @@ describe('plugin package build helpers', () => {
     );
   });
 
+  it('rejects yarn source packages with a clear unsupported-manager error', async () => {
+    const dir = await createTempPluginDir(tempDirs);
+    await writePackageJson(dir, {
+      packageManager: 'yarn@4.0.0',
+      scripts: {
+        build: 'vite build',
+      },
+      sero: {
+        app: {
+          id: 'todo',
+          name: 'Todo',
+          ui: './dist/ui/remoteEntry.js',
+        },
+      },
+    });
+
+    await expect(ensurePluginPackageReadyForInstall(dir, 'git')).rejects.toThrow(
+      /support npm and pnpm only/,
+    );
+  });
+
   it('rejects git source packages with workspace specs', async () => {
     const dir = await createTempPluginDir(tempDirs);
     await writePackageJson(dir, {

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/system-candidates.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/system-candidates.test.ts
@@ -3,6 +3,19 @@ import { describe, expect, it } from 'vitest';
 import { systemToolCandidates } from '@electron/features/workspace/runtime/toolchains/system-candidates';
 
 describe('system tool candidates', () => {
+  it('uses absolute POSIX fallback paths when app launch PATH is sparse', () => {
+    expect(systemToolCandidates('git', 'darwin', {})).toEqual(expect.arrayContaining([
+      'git',
+      '/usr/bin/git',
+      '/opt/homebrew/bin/git',
+    ]));
+    expect(systemToolCandidates('bash', 'linux', {})).toEqual(expect.arrayContaining([
+      'bash',
+      '/bin/bash',
+      '/usr/bin/bash',
+    ]));
+  });
+
   it('converts Git Bash/MSYS PATH entries to Windows executable candidates', () => {
     const env = {
       ProgramFiles: 'C:\\Program Files',

--- a/apps/desktop/electron/features/plugins/dev-sessions/dev-server.ts
+++ b/apps/desktop/electron/features/plugins/dev-sessions/dev-server.ts
@@ -12,6 +12,7 @@ import {
 } from '@electron/features/workspace/runtime/native-build/classifier';
 import type { NativeBuildToolsRequiredMetadata } from '@electron/features/workspace/runtime/native-build/types';
 import { stopStalePortListenersForSourcePath } from './process-helpers';
+import { renderPluginHostShellCommand } from '../host-command-runner';
 
 const HEALTH_POLL_INTERVAL_MS = 500;
 const HEALTH_POLL_TIMEOUT_MS = 20_000;
@@ -116,15 +117,16 @@ function getManagedServer(sourcePath: string): ManagedPluginDevServer | undefine
   return entry;
 }
 
-function startManagedServer(
+async function startManagedServer(
   sourcePath: string,
   command: string,
   declaredDevPort: number,
-): ManagedPluginDevServer {
+): Promise<ManagedPluginDevServer> {
   const normalizedSourcePath = normalizeSourcePath(sourcePath);
-  const child = spawn('sh', ['-c', command], {
-    cwd: normalizedSourcePath,
-    env: process.env,
+  const renderedCommand = await renderPluginHostShellCommand(command, normalizedSourcePath);
+  const child = spawn(renderedCommand.program, renderedCommand.args, {
+    cwd: renderedCommand.cwd,
+    env: renderedCommand.env,
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
@@ -391,7 +393,7 @@ export async function ensurePluginDevServer(
 
   if (!entry) {
     try {
-      entry = startManagedServer(sourcePath, options.command, options.declaredDevPort);
+      entry = await startManagedServer(sourcePath, options.command, options.declaredDevPort);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'unknown error';
       return createFallbackResult(
@@ -428,7 +430,7 @@ export async function ensurePluginDevServer(
     const repair = await repairPluginNativeDeps(sourcePath);
     if (repair.ok) {
       try {
-        entry = startManagedServer(sourcePath, options.command, options.declaredDevPort);
+        entry = await startManagedServer(sourcePath, options.command, options.declaredDevPort);
       } catch (error) {
         const message = error instanceof Error ? error.message : 'unknown error';
         return createFallbackResult(

--- a/apps/desktop/electron/features/plugins/dev-sessions/errors.ts
+++ b/apps/desktop/electron/features/plugins/dev-sessions/errors.ts
@@ -4,6 +4,7 @@ export type PluginDevSessionErrorCode =
   | 'source-package-json-invalid'
   | 'source-app-declaration-invalid'
   | 'source-manifest-parse-failed'
+  | 'unsupported-package-manager'
   | 'app-id-drifted'
   | 'app-id-conflict-built-in'
   | 'app-id-conflict-installed-plugin'
@@ -37,6 +38,7 @@ function isPluginDevSessionErrorCode(value: unknown): value is PluginDevSessionE
     case 'source-package-json-invalid':
     case 'source-app-declaration-invalid':
     case 'source-manifest-parse-failed':
+    case 'unsupported-package-manager':
     case 'app-id-drifted':
     case 'app-id-conflict-built-in':
     case 'app-id-conflict-installed-plugin':

--- a/apps/desktop/electron/features/plugins/dev-sessions/manifest.ts
+++ b/apps/desktop/electron/features/plugins/dev-sessions/manifest.ts
@@ -92,9 +92,17 @@ function validatePluginDevAppShape(pkgJson: PluginDevPackageJson, sourcePath: st
 }
 
 function resolveDevCommand(sourcePath: string, pkgJson: PluginDevPackageJson): string | null {
-  return readString(pkgJson.scripts?.dev)
-    ? `${detectPackageManager(sourcePath)} run dev`
-    : null;
+  if (!readString(pkgJson.scripts?.dev)) return null;
+
+  const packageManager = detectPackageManager(sourcePath);
+  if (packageManager === 'yarn') {
+    throw createPluginDevSessionError(
+      'unsupported-package-manager',
+      `Unsupported plugin package manager: yarn. Sero local plugin dev sessions currently support npm and pnpm only: ${sourcePath}`,
+    );
+  }
+
+  return `${packageManager} run dev`;
 }
 
 function hasDeclaredUiSurface(pkgJson: PluginDevPackageJson): boolean {

--- a/apps/desktop/electron/features/plugins/dev-sessions/native-deps-repair.ts
+++ b/apps/desktop/electron/features/plugins/dev-sessions/native-deps-repair.ts
@@ -4,6 +4,7 @@ import {
   createNativeBuildToolsRequiredMetadata,
 } from '@electron/features/workspace/runtime/native-build/classifier';
 import type { NativeBuildToolsRequiredMetadata } from '@electron/features/workspace/runtime/native-build/types';
+import { renderPluginHostCommand } from '../host-command-runner';
 
 const REPAIR_TIMEOUT_MS = 120_000;
 const REPAIR_OUTPUT_LIMIT = 4_000;
@@ -27,6 +28,13 @@ export function isNativeOptionalDependencyFailure(output: string): boolean {
 }
 
 export async function repairPluginNativeDeps(sourcePath: string): Promise<PluginNativeDepsRepairResult> {
+  let renderedCommand: Awaited<ReturnType<typeof renderPluginHostCommand>>;
+  try {
+    renderedCommand = await renderPluginHostCommand('pnpm', ['install', '--force'], sourcePath);
+  } catch (error) {
+    return createRepairResult(false, error instanceof Error ? error.message : String(error));
+  }
+
   return await new Promise((resolve) => {
     let settled = false;
     let output = '';
@@ -42,23 +50,12 @@ export async function repairPluginNativeDeps(sourcePath: string): Promise<Plugin
       settled = true;
       if (timeout) clearTimeout(timeout);
       const trimmedOutput = trimRepairOutput(output);
-      const failure = ok ? null : classifyNativeBuildFailure({
-        command: 'pnpm install --force',
-        exitCode: 1,
-        stdout: '',
-        stderr: trimmedOutput,
-        platform: process.platform,
-      });
-      resolve({
-        ok,
-        output: trimmedOutput,
-        nativeBuildToolsRequired: failure ? createNativeBuildToolsRequiredMetadata(failure) : undefined,
-      });
+      resolve(createRepairResult(ok, trimmedOutput));
     };
 
-    const child = spawn('pnpm', ['install', '--force'], {
-      cwd: sourcePath,
-      env: process.env,
+    const child = spawn(renderedCommand.program, renderedCommand.args, {
+      cwd: renderedCommand.cwd,
+      env: renderedCommand.env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -76,6 +73,22 @@ export async function repairPluginNativeDeps(sourcePath: string): Promise<Plugin
     });
     child.on('exit', (code) => finish(code === 0));
   });
+}
+
+function createRepairResult(ok: boolean, output: string): PluginNativeDepsRepairResult {
+  const trimmedOutput = trimRepairOutput(output);
+  const failure = ok ? null : classifyNativeBuildFailure({
+    command: 'pnpm install --force',
+    exitCode: 1,
+    stdout: '',
+    stderr: trimmedOutput,
+    platform: process.platform,
+  });
+  return {
+    ok,
+    output: trimmedOutput,
+    nativeBuildToolsRequired: failure ? createNativeBuildToolsRequiredMetadata(failure) : undefined,
+  };
 }
 
 function trimRepairOutput(output: string): string {

--- a/apps/desktop/electron/features/plugins/dev-sessions/process-helpers.ts
+++ b/apps/desktop/electron/features/plugins/dev-sessions/process-helpers.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCb } from 'child_process';
+import { existsSync } from 'fs';
 import path from 'path';
 
 const PORT_RELEASE_TIMEOUT_MS = 5_000;
@@ -10,7 +11,7 @@ function normalizeSourcePath(sourcePath: string): string {
 
 function execFileAsync(command: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
-    execFileCb(command, args, { encoding: 'utf8' }, (error, stdout) => {
+    execFileCb(resolveSystemCommand(command), args, { encoding: 'utf8' }, (error, stdout) => {
       if (error) {
         reject(error);
         return;
@@ -18,6 +19,17 @@ function execFileAsync(command: string, args: string[]): Promise<string> {
       resolve(stdout);
     });
   });
+}
+
+function resolveSystemCommand(command: string): string {
+  if (path.isAbsolute(command) || process.platform === 'win32') return command;
+  return systemCommandCandidates(command).find((candidate) => existsSync(candidate)) ?? command;
+}
+
+function systemCommandCandidates(command: string): string[] {
+  if (command === 'lsof') return ['/usr/sbin/lsof', '/usr/bin/lsof'];
+  if (command === 'ps') return ['/bin/ps', '/usr/bin/ps'];
+  return [];
 }
 
 async function readListeningProcessIds(port: number): Promise<number[]> {

--- a/apps/desktop/electron/features/plugins/host-command-runner.ts
+++ b/apps/desktop/electron/features/plugins/host-command-runner.ts
@@ -1,0 +1,189 @@
+import { execFile } from 'child_process';
+import { existsSync } from 'fs';
+import path from 'path';
+
+import { createHostToolResolver, type HostToolResolverLike } from '@electron/features/workspace/runtime/toolchains/host-tool-resolver';
+import { renderWindowsCommandScript } from '@electron/features/workspace/runtime/toolchains/windows-command';
+import type { ToolInstallReason } from '@electron/features/workspace/runtime/toolchains/types';
+
+export interface PluginHostCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface PluginHostCommandExecuteOptions {
+  cwd: string;
+  env: Record<string, string>;
+  encoding: 'utf8';
+}
+
+export type PluginHostCommandExecutor = (
+  program: string,
+  args: string[],
+  options: PluginHostCommandExecuteOptions,
+) => Promise<PluginHostCommandResult>;
+
+export interface PluginHostCommandOptions {
+  env?: NodeJS.ProcessEnv;
+  execute?: PluginHostCommandExecutor;
+  platform?: NodeJS.Platform;
+  tools?: Pick<HostToolResolverLike, 'prepareEnv' | 'prepareProgram'>;
+}
+
+export interface PluginHostShellCommandOptions {
+  env?: NodeJS.ProcessEnv;
+  loginShell?: boolean;
+  platform?: NodeJS.Platform;
+  tools?: Pick<HostToolResolverLike, 'prepareEnv' | 'prepareProgram' | 'prepareShell'>;
+}
+
+export interface RenderedPluginHostCommand {
+  program: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+}
+
+export async function runPluginHostCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  options: PluginHostCommandOptions = {},
+): Promise<PluginHostCommandResult> {
+  const rendered = await renderPluginHostCommand(command, args, cwd, options);
+  const execute = options.execute ?? defaultExecute;
+
+  return execute(rendered.program, rendered.args, {
+    cwd: rendered.cwd,
+    env: rendered.env,
+    encoding: 'utf8',
+  });
+}
+
+export async function renderPluginHostCommand(
+  command: string,
+  args: string[],
+  cwd: string,
+  options: PluginHostCommandOptions = {},
+): Promise<RenderedPluginHostCommand> {
+  const platform = options.platform ?? process.platform;
+  const tools = options.tools ?? createHostToolResolver({ platform });
+  const reason = makeReason([command, ...args].join(' '));
+  if (requiresNodeRuntime(command)) {
+    await tools.prepareProgram('node', reason);
+  }
+  const preparedProgram = resolveSystemFallbackProgram(
+    await tools.prepareProgram(command, reason),
+    command,
+    platform,
+  );
+  const preparedEnv = await tools.prepareEnv(normalizeEnv(options.env ?? process.env));
+  const rendered = platform === 'win32'
+    ? renderWindowsCommandScript(preparedProgram, args)
+    : null;
+
+  return {
+    program: rendered?.program ?? preparedProgram,
+    args: rendered?.args ?? args,
+    cwd,
+    env: preparedEnv,
+  };
+}
+
+export async function renderPluginHostShellCommand(
+  command: string,
+  cwd: string,
+  options: PluginHostShellCommandOptions = {},
+): Promise<RenderedPluginHostCommand> {
+  const platform = options.platform ?? process.platform;
+  const tools = options.tools ?? createHostToolResolver({ platform });
+  const reason = makeReason(command);
+  await prepareShellCommandTools(command, tools, reason);
+  const shell = await tools.prepareShell(reason);
+
+  return {
+    program: shell.path,
+    args: options.loginShell === true ? ['--login', '-c', command] : ['-c', command],
+    cwd,
+    env: await tools.prepareEnv(normalizeEnv(options.env ?? process.env)),
+  };
+}
+
+function defaultExecute(
+  program: string,
+  args: string[],
+  options: PluginHostCommandExecuteOptions,
+): Promise<PluginHostCommandResult> {
+  return new Promise((resolve, reject) => {
+    execFile(program, args, options, (error, stdout, stderr) => {
+      const result = {
+        stdout: String(stdout ?? ''),
+        stderr: String(stderr ?? ''),
+      };
+      if (error) {
+        reject(Object.assign(error, result));
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+function normalizeEnv(env: NodeJS.ProcessEnv): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) result[key] = value;
+  }
+  return result;
+}
+
+function requiresNodeRuntime(command: string): boolean {
+  return command === 'npm' || command === 'pnpm';
+}
+
+async function prepareShellCommandTools(
+  command: string,
+  tools: Pick<HostToolResolverLike, 'prepareProgram'>,
+  reason: ToolInstallReason,
+): Promise<void> {
+  if (usesShellCommand(command, 'node') || usesShellCommand(command, 'npm') || usesShellCommand(command, 'pnpm')) {
+    await tools.prepareProgram('node', reason);
+  }
+  if (usesShellCommand(command, 'npm')) await tools.prepareProgram('npm', reason);
+  if (usesShellCommand(command, 'pnpm')) await tools.prepareProgram('pnpm', reason);
+}
+
+function usesShellCommand(command: string, executable: string): boolean {
+  return new RegExp(`(^|[\\s;&|()])${executable.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}([\\s;&|()]|$)`).test(command);
+}
+
+function makeReason(command: string): ToolInstallReason {
+  return {
+    kind: 'plugin-install',
+    command,
+    detail: 'Sero plugin install',
+  };
+}
+
+function resolveSystemFallbackProgram(
+  preparedProgram: string,
+  requestedCommand: string,
+  platform: NodeJS.Platform,
+): string {
+  if (preparedProgram !== requestedCommand || isAbsoluteProgram(preparedProgram, platform)) {
+    return preparedProgram;
+  }
+  return systemFallbackCandidates(requestedCommand, platform).find((candidate) => existsSync(candidate)) ?? preparedProgram;
+}
+
+function systemFallbackCandidates(command: string, platform: NodeJS.Platform): string[] {
+  if (command !== 'tar') return [];
+  if (platform === 'win32') {
+    return [path.win32.join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'tar.exe')];
+  }
+  return ['/usr/bin/tar', '/bin/tar'];
+}
+
+function isAbsoluteProgram(program: string, platform: NodeJS.Platform): boolean {
+  return platform === 'win32' ? path.win32.isAbsolute(program) : path.isAbsolute(program);
+}

--- a/apps/desktop/electron/features/plugins/manager.ts
+++ b/apps/desktop/electron/features/plugins/manager.ts
@@ -9,8 +9,6 @@
 import { promises as fs } from 'fs';
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
-import { execFile as execFileCb } from 'child_process';
-import { promisify } from 'util';
 
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { discoverApps, registerAppPath, unregisterAppPath } from '../apps/discovery';
@@ -29,13 +27,12 @@ import { assertPluginCompatible } from './compatibility';
 import { clearPackageCompatibilityCache } from './resource-compatibility';
 import { assertPluginInstallAllowed } from './install-policy';
 import { ensurePluginPackageReadyForInstall } from './package-build';
+import { runPluginHostCommand } from './host-command-runner';
 import { assertValidPluginId, resolvePluginInstallDir } from './security';
 import {
   addPackageToSettings,
   removePackageFromSettings,
 } from './settings';
-const execFile = promisify(execFileCb);
-
 export { reconcileInstalledPluginActivation } from './activation';
 
 /** Directory where plugins are installed. */
@@ -189,10 +186,7 @@ async function cleanupDir(dirPath: string | null): Promise<void> {
 }
 
 async function runCommand(command: string, args: string[], cwd: string): Promise<string> {
-  const result = (await execFile(command, args, { cwd, encoding: 'utf8' })) as {
-    stdout: string;
-    stderr: string;
-  };
+  const result = await runPluginHostCommand(command, args, cwd);
   return result.stdout;
 }
 

--- a/apps/desktop/electron/features/plugins/package-build.ts
+++ b/apps/desktop/electron/features/plugins/package-build.ts
@@ -1,14 +1,12 @@
-import { execFile as execFileCb } from 'child_process';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
-import { promisify } from 'util';
 import {
   classifyNativeBuildFailure,
   createNativeBuildToolsRequiredMetadata,
 } from '@electron/features/workspace/runtime/native-build/classifier';
 import { NativeBuildToolsRequiredError } from '@electron/features/workspace/runtime/native-build/types';
+import { runPluginHostCommand } from './host-command-runner';
 
-const execFile = promisify(execFileCb);
 const BUILT_UI_ENTRY = path.join('dist', 'ui', 'remoteEntry.js');
 
 type PluginSourceKind = 'npm' | 'git' | 'local';
@@ -153,11 +151,7 @@ async function defaultRunCommand(
   cwd: string,
   env?: NodeJS.ProcessEnv,
 ): Promise<void> {
-  await execFile(command, args, {
-    cwd,
-    env: env ?? process.env,
-    encoding: 'utf8',
-  });
+  await runPluginHostCommand(command, args, cwd, { env });
 }
 
 function getInstallCommand(pkg: PluginPackageJson): { command: string; args: string[] } {
@@ -166,7 +160,7 @@ function getInstallCommand(pkg: PluginPackageJson): { command: string; args: str
     return { command: 'pnpm', args: ['install', '--no-frozen-lockfile'] };
   }
   if (packageManager === 'yarn') {
-    return { command: 'yarn', args: ['install'] };
+    throw unsupportedPackageManagerError('yarn');
   }
   return { command: 'npm', args: ['install'] };
 }
@@ -184,9 +178,16 @@ function getBuildCommand(pkg: PluginPackageJson): { command: string; args: strin
     return { command: 'pnpm', args: ['run', 'build'] };
   }
   if (packageManager === 'yarn') {
-    return { command: 'yarn', args: ['build'] };
+    throw unsupportedPackageManagerError('yarn');
   }
   return { command: 'npm', args: ['run', 'build'] };
+}
+
+function unsupportedPackageManagerError(packageManager: string): Error {
+  return new Error(
+    `Unsupported plugin package manager: ${packageManager}. ` +
+    'Sero plugin source installs currently support npm and pnpm only.',
+  );
 }
 
 function assertStandaloneSourcePackage(pkg: PluginPackageJson): void {

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/system-candidates.ts
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/system-candidates.ts
@@ -9,8 +9,19 @@ export function systemToolCandidates(
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-  if (platform !== 'win32') return [tool];
+  if (platform !== 'win32') return [...new Set([tool, ...posixSystemToolCandidates(tool, platform)])];
   return [...new Set([...windowsSystemToolCandidates(tool, env), tool])];
+}
+
+function posixSystemToolCandidates(tool: ToolName, platform: NodeJS.Platform): string[] {
+  return posixSearchRoots(platform).map((root) => path.posix.join(root, tool));
+}
+
+function posixSearchRoots(platform: NodeJS.Platform): string[] {
+  const homebrewRoots = platform === 'darwin'
+    ? ['/opt/homebrew/bin', '/usr/local/bin']
+    : ['/usr/local/bin'];
+  return [...homebrewRoots, '/usr/bin', '/bin', '/usr/sbin', '/sbin'];
 }
 
 function windowsSystemToolCandidates(tool: ToolName, env: NodeJS.ProcessEnv): string[] {

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/types.ts
@@ -73,6 +73,7 @@ export type ToolInstallReasonKind =
   | 'doctor'
   | 'settings'
   | 'agent-tool'
+  | 'plugin-install'
   | 'test';
 
 export interface ToolInstallReason {


### PR DESCRIPTION
## Summary
- route plugin install/build commands through the host tool resolver instead of raw child-process PATH lookup
- prepare Node/npm/pnpm for plugin installs, source builds, dev servers, and native dependency repair
- add POSIX absolute system fallbacks and Windows command-shim handling for packaged app environments

## Validation
- pnpm --filter @sero/desktop test -- --run
- pnpm typecheck
- local packaged-app sparse-PATH test confirmed plugin install works
