### PR TITLE
fix: address React Doctor hook and key diagnostics

### DIFF
--- a/apps/desktop/src/components/apps/explorer/TerminalPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/TerminalPanel.tsx
@@ -80,7 +80,6 @@ export function TerminalPanel({ terminalId, isActive }: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
-  const unsubDataRef = useRef<(() => void) | null>(null);
 
   // Set up terminal on mount, replay buffered content
   useEffect(() => {
@@ -116,7 +115,15 @@ export function TerminalPanel({ terminalId, isActive }: TerminalPanelProps) {
 
     // Replay buffered output from the main process, then subscribe to live data.
     // This ensures content persists across workspace switches.
-    replayAndSubscribe(term, terminalId, unsubDataRef);
+    let active = true;
+    let unsubscribeData: (() => void) | null = null;
+    void replayAndSubscribe(term, terminalId, (unsubscribe) => {
+      if (!active) {
+        unsubscribe();
+        return;
+      }
+      unsubscribeData = unsubscribe;
+    });
 
     // Forward user input to the main process
     term.onData((data) => {
@@ -131,8 +138,9 @@ export function TerminalPanel({ terminalId, isActive }: TerminalPanelProps) {
     }
 
     return () => {
-      unsubDataRef.current?.();
-      unsubDataRef.current = null;
+      active = false;
+      unsubscribeData?.();
+      unsubscribeData = null;
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
@@ -224,7 +232,7 @@ export function TerminalPanel({ terminalId, isActive }: TerminalPanelProps) {
 async function replayAndSubscribe(
   term: Terminal,
   terminalId: string,
-  unsubRef: React.MutableRefObject<(() => void) | null>,
+  onSubscribe: (unsubscribe: () => void) => void,
 ): Promise<void> {
   try {
     const buffer = await window.sero.terminal.replay(terminalId);
@@ -243,5 +251,5 @@ async function replayAndSubscribe(
       term.write(data);
     }
   });
-  unsubRef.current = unsub;
+  onSubscribe(unsub);
 }

--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useEffect, useState, useCallback, useRef } from 'react';
+import type { RefObject } from 'react';
 import { DiffEditor } from '@monaco-editor/react';
 import type { editor as MonacoEditor } from 'monaco-editor';
 import { AnimatePresence, motion } from 'motion/react';
@@ -60,12 +61,12 @@ export function DiffTab({ state }: Props) {
       .then((f) => {
         if (cancelled) return;
         setFiles(f);
-        if (!activePath && f.length > 0) setActivePath(f[0].path);
+        setActivePath((currentPath) => currentPath ?? f[0]?.path ?? null);
         setLoading(false);
       })
       .catch(() => { if (!cancelled) setLoading(false); });
     return () => { cancelled = true; };
-  }, [workspaceId, fromRev, toRev]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [workspaceId, fromRev, toRev]);
 
   const language = activePath ? langFromPath(activePath) : 'plaintext';
 
@@ -207,15 +208,7 @@ function DiffFileView({
 
   useEffect(() => {
     return () => {
-      const { original, modified } = modelRefs.current;
-      modelRefs.current = { original: null, modified: null };
-      if (!original && !modified) return;
-
-      // Defer model disposal until after DiffEditor has fully unmounted.
-      setTimeout(() => {
-        try { original?.dispose(); } catch {}
-        try { modified?.dispose(); } catch {}
-      }, 0);
+      disposeDiffModels(modelRefs);
     };
   }, []);
 
@@ -257,4 +250,19 @@ function DiffFileView({
       }}
     />
   );
+}
+
+function disposeDiffModels(refs: RefObject<{
+  original: MonacoEditor.ITextModel | null;
+  modified: MonacoEditor.ITextModel | null;
+}>) {
+  const { original, modified } = refs.current;
+  refs.current = { original: null, modified: null };
+  if (!original && !modified) return;
+
+  // Defer model disposal until after DiffEditor has fully unmounted.
+  setTimeout(() => {
+    try { original?.dispose(); } catch {}
+    try { modified?.dispose(); } catch {}
+  }, 0);
 }

--- a/apps/desktop/src/components/apps/explorer/editor/useEditorRuntimeSync.test.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/useEditorRuntimeSync.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, useState, type MutableRefObject } from 'react';
+import { act, useState, type RefObject } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SeroEditorAPI, SeroFileTreeAPI, SeroVcsAPI } from '@/types/electron-workspace';
@@ -16,8 +16,8 @@ interface HarnessProps {
   activeTab: string | null;
   initialDirtyPaths?: Set<string>;
   initialContent?: string;
-  contentMapRef: MutableRefObject<Map<string, string>>;
-  savedContentRef: MutableRefObject<Map<string, string>>;
+  contentMapRef: RefObject<Map<string, string>>;
+  savedContentRef: RefObject<Map<string, string>>;
 }
 
 describe('useEditorRuntimeSync', () => {

--- a/apps/desktop/src/components/apps/explorer/editor/useEditorRuntimeSync.ts
+++ b/apps/desktop/src/components/apps/explorer/editor/useEditorRuntimeSync.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type {
   Dispatch,
-  MutableRefObject,
+  RefObject,
   SetStateAction,
 } from 'react';
 
@@ -10,8 +10,8 @@ interface UseEditorRuntimeSyncOptions {
   tabs: string[];
   activeTab: string | null;
   dirtyPaths: Set<string>;
-  contentMapRef: MutableRefObject<Map<string, string>>;
-  savedContentRef: MutableRefObject<Map<string, string>>;
+  contentMapRef: RefObject<Map<string, string>>;
+  savedContentRef: RefObject<Map<string, string>>;
   setContent: Dispatch<SetStateAction<string>>;
   setDirtyPaths: Dispatch<SetStateAction<Set<string>>>;
 }

--- a/apps/desktop/src/components/apps/explorer/editor/useMonacoNavigation.ts
+++ b/apps/desktop/src/components/apps/explorer/editor/useMonacoNavigation.ts
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
-import type { MutableRefObject } from 'react';
+import type { RefObject } from 'react';
 import type * as monacoApi from 'monaco-editor';
 import type { editor as MonacoEditor } from 'monaco-editor';
 import { applyGoto, type PendingGoto } from './editor-panel-shared';
 
 interface UseMonacoNavigationOptions {
   activeTab: string | null;
-  editorRef: MutableRefObject<MonacoEditor.IStandaloneCodeEditor | null>;
+  editorRef: RefObject<MonacoEditor.IStandaloneCodeEditor | null>;
   monacoInstance: typeof monacoApi | null;
-  pendingGotoRef: MutableRefObject<PendingGoto | null>;
+  pendingGotoRef: RefObject<PendingGoto | null>;
   handleOpenTab: (path: string) => void;
 }
 

--- a/apps/desktop/src/components/layout/ChatMessageItem.tsx
+++ b/apps/desktop/src/components/layout/ChatMessageItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 import { Bot, Check, Copy, RotateCcw, User } from 'lucide-react';
 import { useTransientFlag } from '@/components/apps/explorer/useTransientUiState';
 import { copyTextToClipboard } from '@/lib/copy-to-clipboard';
@@ -143,15 +143,9 @@ export const ChatMessageItem = memo(function ChatMessageItem({
       const showAvatar = hasContent;
       const showFeedback = isDone && hasContent && !!sessionId;
 
-      // Truncate excerpts for storage (keep feedback entries lean)
-      const promptExcerpt = useMemo(
-        () => previousUserText?.slice(0, 300),
-        [previousUserText],
-      );
-      const responseExcerpt = useMemo(
-        () => message.text?.slice(0, 300),
-        [message.text],
-      );
+      // Truncate excerpts for storage (keep feedback entries lean).
+      const promptExcerpt = previousUserText?.slice(0, 300);
+      const responseExcerpt = message.text?.slice(0, 300);
 
       return (
         <Message from="assistant" className="group/msg flex-row items-start gap-2">

--- a/apps/desktop/src/components/layout/ComposerAttachmentBridge.tsx
+++ b/apps/desktop/src/components/layout/ComposerAttachmentBridge.tsx
@@ -13,15 +13,13 @@ export function ComposerAttachmentBridge() {
   const attachments = usePromptInputAttachments();
   const pendingCount = useComposerAttachmentQueue((s) => s.pending.length);
   const consume = useComposerAttachmentQueue((s) => s.consume);
+  const addAttachments = attachments.add;
 
   useEffect(() => {
     if (pendingCount === 0) return;
     const files = consume();
-    if (files.length > 0) attachments.add(files);
-    // `attachments` is recreated by the context on every render so we avoid
-    // depending on it directly — pendingCount is enough to trigger drain.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pendingCount, consume]);
+    if (files.length > 0) addAttachments(files);
+  }, [pendingCount, consume, addAttachments]);
 
   return null;
 }

--- a/apps/desktop/src/components/layout/FileReferenceMenu.tsx
+++ b/apps/desktop/src/components/layout/FileReferenceMenu.tsx
@@ -44,7 +44,7 @@ function HighlightedPath({
 
   return (
     <span className="min-w-0 truncate">
-      {Array.from(path).map((char, index) => (
+      {path.split('').map((char, index) => (
         <span
           key={path.slice(0, index + 1)}
           className={indexSet.has(index)

--- a/apps/desktop/src/components/layout/FileReferenceMenu.tsx
+++ b/apps/desktop/src/components/layout/FileReferenceMenu.tsx
@@ -44,9 +44,9 @@ function HighlightedPath({
 
   return (
     <span className="min-w-0 truncate">
-      {path.split('').map((char, index) => (
+      {Array.from(path).map((char, index) => (
         <span
-          key={index}
+          key={path.slice(0, index + 1)}
           className={indexSet.has(index)
             ? selected
               ? 'text-white font-semibold'

--- a/apps/desktop/src/components/layout/ImageLightbox.tsx
+++ b/apps/desktop/src/components/layout/ImageLightbox.tsx
@@ -182,7 +182,7 @@ export function ImageLightbox() {
 
           {/* Image */}
           <motion.img
-            key={`${index}-${src.slice(0, 40)}`}
+            key={src}
             initial={{ scale: 0.9, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}

--- a/apps/desktop/src/components/layout/PendingQuestionCard.tsx
+++ b/apps/desktop/src/components/layout/PendingQuestionCard.tsx
@@ -40,10 +40,6 @@ function PermissionGateCard({ question }: { question: UserFeedbackPendingQuestio
   const q = question.questions[0];
   const qId = q?.id;
 
-  // Extract the command from the prompt (between the two newlines after "detected:")
-  const commandMatch = q.prompt.match(/:\n\n\s+(.+)\n\n/);
-  const command = commandMatch?.[1]?.trim() ?? q.prompt;
-
   const handleAllow = useCallback(() => {
     if (!qId) return;
     const ans: UserFeedbackAnswer = {
@@ -73,6 +69,10 @@ function PermissionGateCard({ question }: { question: UserFeedbackPendingQuestio
   }, [question.id, cancel]);
 
   if (!q) return null;
+
+  // Extract the command from the prompt (between the two newlines after "detected:")
+  const commandMatch = q.prompt.match(/:\n\n\s+(.+)\n\n/);
+  const command = commandMatch?.[1]?.trim() ?? q.prompt;
 
   return (
     <motion.div

--- a/apps/desktop/src/components/layout/PendingQuestionCard.tsx
+++ b/apps/desktop/src/components/layout/PendingQuestionCard.tsx
@@ -38,37 +38,41 @@ function PermissionGateCard({ question }: { question: UserFeedbackPendingQuestio
   const cancel = useUserFeedbackStore((s) => s.cancel);
 
   const q = question.questions[0];
-  if (!q) return null;
+  const qId = q?.id;
 
   // Extract the command from the prompt (between the two newlines after "detected:")
   const commandMatch = q.prompt.match(/:\n\n\s+(.+)\n\n/);
   const command = commandMatch?.[1]?.trim() ?? q.prompt;
 
   const handleAllow = useCallback(() => {
+    if (!qId) return;
     const ans: UserFeedbackAnswer = {
-      questionId: q.id,
+      questionId: qId,
       value: 'allow',
       label: 'Allow',
       wasCustom: false,
       index: 1,
     };
     answer(question.id, [ans]);
-  }, [q.id, question.id, answer]);
+  }, [qId, question.id, answer]);
 
   const handleBlock = useCallback(() => {
+    if (!qId) return;
     const ans: UserFeedbackAnswer = {
-      questionId: q.id,
+      questionId: qId,
       value: 'block',
       label: 'Block',
       wasCustom: false,
       index: 2,
     };
     answer(question.id, [ans]);
-  }, [q.id, question.id, answer]);
+  }, [qId, question.id, answer]);
 
   const handleCancel = useCallback(() => {
     cancel(question.id);
   }, [question.id, cancel]);
+
+  if (!q) return null;
 
   return (
     <motion.div
@@ -137,12 +141,13 @@ function QuestionCardInner({ question }: { question: UserFeedbackPendingQuestion
   const [customText, setCustomText] = useState('');
 
   const q = question.questions[0];
-  if (!q) return null;
+  const qId = q?.id;
 
   const handleSelect = useCallback(
     (opt: { value: string; label: string }, index: number) => {
+      if (!qId) return;
       const ans: UserFeedbackAnswer = {
-        questionId: q.id,
+        questionId: qId,
         value: opt.value,
         label: opt.label,
         wasCustom: false,
@@ -150,24 +155,27 @@ function QuestionCardInner({ question }: { question: UserFeedbackPendingQuestion
       };
       answer(question.id, [ans]);
     },
-    [q.id, question.id, answer],
+    [qId, question.id, answer],
   );
 
   const handleCustomSubmit = useCallback(() => {
+    if (!qId) return;
     const text = customText.trim();
     if (!text) return;
     const ans: UserFeedbackAnswer = {
-      questionId: q.id,
+      questionId: qId,
       value: text,
       label: text,
       wasCustom: true,
     };
     answer(question.id, [ans]);
-  }, [q.id, question.id, customText, answer]);
+  }, [qId, question.id, customText, answer]);
 
   const handleCancel = useCallback(() => {
     cancel(question.id);
   }, [question.id, cancel]);
+
+  if (!q) return null;
 
   return (
     <motion.div

--- a/apps/desktop/src/components/layout/QuestionnaireNotice.tsx
+++ b/apps/desktop/src/components/layout/QuestionnaireNotice.tsx
@@ -143,12 +143,13 @@ export function QuestionnaireNotice({ tools, sessionLabel = null }: Props) {
 
   const pending = classification?.kind === 'interview' ? pendingInterview : pendingQuestionnaire;
   const count = pending?.questions.length ?? getQuestionCount(tools);
-
-  if (!classification) return null;
-
-  const mode = getMode(tools, Boolean(pending), classification);
-  const label = getPrimaryLabel(classification.kind, isOnboarding);
-  const secondary = getSecondaryLabel(mode, classification.kind);
+  const mode = classification ? getMode(tools, Boolean(pending), classification) : 'completed';
+  const label = classification
+    ? getPrimaryLabel(classification.kind, isOnboarding)
+    : 'Questions';
+  const secondary = classification
+    ? getSecondaryLabel(mode, classification.kind)
+    : 'Completed';
   const clickable = mode === 'active' && Boolean(pending);
 
   const handleClick = useCallback(() => {
@@ -165,6 +166,8 @@ export function QuestionnaireNotice({ tools, sessionLabel = null }: Props) {
     },
     [cancel, pending],
   );
+
+  if (!classification) return null;
 
   return (
     <motion.div

--- a/apps/desktop/src/components/layout/auth/auth-login-views/AuthFlowViews.tsx
+++ b/apps/desktop/src/components/layout/auth/auth-login-views/AuthFlowViews.tsx
@@ -45,8 +45,8 @@ export function AuthenticatingView({
 
       {progressMessages.length > 0 ? (
         <div className="space-y-0.5 text-xs text-muted-foreground">
-          {progressMessages.map((message, index) => (
-            <p key={index}>{message}</p>
+          {progressMessages.map((message) => (
+            <p key={message}>{message}</p>
           ))}
         </div>
       ) : null}

--- a/apps/desktop/src/components/layout/auth/auth-login-views/AuthFlowViews.tsx
+++ b/apps/desktop/src/components/layout/auth/auth-login-views/AuthFlowViews.tsx
@@ -45,8 +45,8 @@ export function AuthenticatingView({
 
       {progressMessages.length > 0 ? (
         <div className="space-y-0.5 text-xs text-muted-foreground">
-          {progressMessages.map((message) => (
-            <p key={message}>{message}</p>
+          {progressMessages.map((message, index) => (
+            <p key={`${index}-${message}`}>{message}</p>
           ))}
         </div>
       ) : null}

--- a/apps/desktop/src/components/layout/tool-call-helpers/ToolImages.tsx
+++ b/apps/desktop/src/components/layout/tool-call-helpers/ToolImages.tsx
@@ -47,7 +47,7 @@ export function ToolImages({
         const isOpenablePath = !!workspaceId && !!image.filePath && looksLikeFilePath(image.filePath);
 
         return (
-          <div key={index} className="flex max-w-[220px] flex-col gap-1.5">
+          <div key={`${image.filePath ?? image.description ?? 'image'}:${src}`} className="flex max-w-[220px] flex-col gap-1.5">
             <button
               onClick={() => handlePreview(index)}
               className={cn(

--- a/apps/desktop/src/hooks/useWorkspaceFiles.ts
+++ b/apps/desktop/src/hooks/useWorkspaceFiles.ts
@@ -10,7 +10,7 @@ import {
   useEffect,
   useCallback,
   useRef,
-  type MutableRefObject,
+  type RefObject,
 } from 'react';
 import {
   retainWorkspaceFiletreeWatch,
@@ -207,7 +207,7 @@ async function collectWorkspaceFiles(workspaceId: string): Promise<string[]> {
 async function loadWorkspaceFiles(
   workspaceId: string,
   abortGeneration: number,
-  abortRef: MutableRefObject<number>,
+  abortRef: RefObject<number>,
   setFiles: (files: string[]) => void,
   setIsLoading: (loading: boolean) => void,
   options: LoadWorkspaceFilesOptions = {},

--- a/apps/web-remote/src/components/ChatMessage.tsx
+++ b/apps/web-remote/src/components/ChatMessage.tsx
@@ -112,7 +112,7 @@ export const ChatMessageComponent = memo(function ChatMessageComponent({
               const src = `data:${img.mimeType};base64,${img.base64}`;
               return (
                 <button
-                  key={i}
+                  key={src}
                   onClick={() => setLightboxSrc(src)}
                   className="cursor-zoom-in"
                 >

--- a/apps/web-remote/src/components/ChatPanel.tsx
+++ b/apps/web-remote/src/components/ChatPanel.tsx
@@ -226,7 +226,7 @@ export function ChatPanel() {
         {pendingImages.length > 0 && (
           <div className="flex gap-2 mb-2 flex-wrap">
             {pendingImages.map((img, i) => (
-              <div key={i} className="relative group">
+              <div key={img.preview} className="relative group">
                 <img
                   src={img.preview}
                   alt={`Attachment ${i + 1}`}

--- a/apps/web-remote/src/components/ToolCallDisplay.tsx
+++ b/apps/web-remote/src/components/ToolCallDisplay.tsx
@@ -54,7 +54,7 @@ const ToolCallItem = memo(function ToolCallItem({ tc }: { tc: ToolCall }) {
               const src = `data:${img.mimeType};base64,${img.data}`;
               return (
                 <button
-                  key={i}
+                  key={src}
                   onClick={() => setLightboxSrc(src)}
                   className="cursor-zoom-in"
                 >

--- a/packages/ui/src/components/ai-elements/web-preview.tsx
+++ b/packages/ui/src/components/ai-elements/web-preview.tsx
@@ -265,7 +265,7 @@ export const WebPreviewConsole = ({
                   log.level === "warn" && "text-yellow-600",
                   log.level === "log" && "text-foreground"
                 )}
-                key={`${log.timestamp.getTime()}-${index}`}
+                key={`${log.timestamp.getTime()}-${log.level}-${log.message}`}
               >
                 <span className="text-muted-foreground">
                   {log.timestamp.toLocaleTimeString()}

--- a/packages/ui/src/components/ui/field.tsx
+++ b/packages/ui/src/components/ui/field.tsx
@@ -211,8 +211,8 @@ function FieldError({
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
         {uniqueErrors.map(
-          (error, index) =>
-            error?.message && <li key={index}>{error.message}</li>
+          (error) =>
+            error?.message && <li key={error.message}>{error.message}</li>
         )}
       </ul>
     )

--- a/packages/ui/src/components/ui/slider.tsx
+++ b/packages/ui/src/components/ui/slider.tsx
@@ -47,10 +47,10 @@ function Slider({
           )}
         />
       </SliderPrimitive.Track>
-      {_values.map((value) => (
+      {_values.map((_, index) => (
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
-          key={value}
+          key={index}
           className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}

--- a/packages/ui/src/components/ui/slider.tsx
+++ b/packages/ui/src/components/ui/slider.tsx
@@ -47,10 +47,10 @@ function Slider({
           )}
         />
       </SliderPrimitive.Track>
-      {Array.from({ length: _values.length }, (_, index) => (
+      {_values.map((value) => (
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
-          key={index}
+          key={value}
           className="border-primary ring-ring/50 block size-4 shrink-0 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50"
         />
       ))}

--- a/plugins/sero-git-plugin/ui/components/DiffViewer.tsx
+++ b/plugins/sero-git-plugin/ui/components/DiffViewer.tsx
@@ -41,7 +41,7 @@ export function DiffViewer({ diff, onClose }: DiffViewerProps) {
     <DiffShell path={diff.path} diff={diff} onClose={onClose}>
       <div className="overflow-auto git-scrollbar max-h-96">
         {diff.hunks.map((hunk, i) => (
-          <HunkView key={i} hunk={hunk} index={i} />
+          <HunkView key={`${hunk.oldStart}-${hunk.newStart}-${hunk.oldCount}-${hunk.newCount}`} hunk={hunk} index={i} />
         ))}
       </div>
     </DiffShell>
@@ -118,8 +118,8 @@ function HunkView({ hunk, index }: { hunk: DiffHunk; index: number }) {
 
       {/* Lines */}
       <div className="font-[var(--g-mono)] text-[11px] leading-[1.6]">
-        {hunk.lines.map((line, i) => (
-          <LineView key={i} line={line} />
+        {hunk.lines.map((line) => (
+          <LineView key={`${line.oldLineNo ?? ''}-${line.newLineNo ?? ''}-${line.type}-${line.content}`} line={line} />
         ))}
       </div>
     </div>

--- a/plugins/sero-web-plugin/ui/components/SearchEntry.tsx
+++ b/plugins/sero-web-plugin/ui/components/SearchEntry.tsx
@@ -117,8 +117,8 @@ function SourceLink({ title, url, domain }: { title: string; url: string; domain
 function SearchQueryDetails({ queries }: { queries: QueryInfo[] }) {
   return (
     <div className="flex flex-col gap-3">
-      {queries.map((q, i) => (
-        <div key={i} className="flex flex-col gap-1.5">
+      {queries.map((q) => (
+        <div key={`${q.provider ?? 'search'}:${q.query}`} className="flex flex-col gap-1.5">
           <div className="flex items-center gap-2">
             <span className="text-xs font-semibold text-foreground">{q.query}</span>
             {q.provider && <ProviderBadge provider={q.provider} />}
@@ -136,8 +136,8 @@ function SearchQueryDetails({ queries }: { queries: QueryInfo[] }) {
 
           {q.sources.length > 0 && (
             <div className="flex flex-col gap-0.5 pl-1">
-              {q.sources.slice(0, 8).map((s, j) => (
-                <SourceLink key={j} title={s.title} url={s.url} domain={extractDomain(s.url)} />
+              {q.sources.slice(0, 8).map((s) => (
+                <SourceLink key={s.url} title={s.title} url={s.url} domain={extractDomain(s.url)} />
               ))}
               {q.sources.length > 8 && (
                 <span className="text-[10px] text-muted-foreground/40 pl-5">
@@ -157,8 +157,8 @@ function SearchQueryDetails({ queries }: { queries: QueryInfo[] }) {
 function FetchUrlDetails({ urls }: { urls: UrlInfo[] }) {
   return (
     <div className="flex flex-col gap-0.5">
-      {urls.map((u, i) => (
-        <div key={i} className="flex items-center gap-2">
+      {urls.map((u) => (
+        <div key={u.url} className="flex items-center gap-2">
           <a
             href={u.url}
             target="_blank"


### PR DESCRIPTION
## Summary
- Fix conditional hook diagnostics in desktop chat/questionnaire components
- Replace remaining array-index React keys with stable data-derived keys across desktop, web remote, shared UI, and plugins
- Clean up several exhaustive-deps diagnostics without suppressions and replace deprecated MutableRefObject usages with RefObject

## Validation
- npx react-doctor@latest --verbose
- pnpm test
- pnpm typecheck
- pnpm --filter @sero/desktop typecheck