### PR TITLE
Fix React 19 deprecated context APIs

### DIFF
--- a/apps/desktop/src/components/apps/dashboard/DashboardWidget.tsx
+++ b/apps/desktop/src/components/apps/dashboard/DashboardWidget.tsx
@@ -6,7 +6,7 @@
  * component via WidgetMount.
  */
 
-import { forwardRef } from 'react';
+import type { CSSProperties, ReactNode, Ref } from 'react';
 import { X, Maximize2, GripVertical } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import type { DashboardWidgetInstance, AvailableWidget } from '@/types/dashboard';
@@ -20,75 +20,73 @@ interface DashboardWidgetProps {
   widget: DashboardWidgetInstance;
   manifest: SeroAppManifest | null;
   widgetMeta: AvailableWidget | null;
-  style?: React.CSSProperties;
+  style?: CSSProperties;
   className?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
+  ref?: Ref<HTMLDivElement>;
 }
 
 /**
- * forwardRef is required by react-grid-layout, it passes a ref to
- * each grid child for measuring and positioning.
+ * react-grid-layout passes a ref to each grid child for measuring and positioning.
  */
-export const DashboardWidget = forwardRef<HTMLDivElement, DashboardWidgetProps>(
-  function DashboardWidget({ widget, manifest, widgetMeta, style, className, children, ...rest }, ref) {
-    const removeWidget = useDashboardStore((s) => s.removeWidget);
-    const AppIcon = getAppIcon(widgetMeta?.appIcon ?? null);
-    const widgetName = widgetMeta?.manifest.name ?? widget.widgetId;
-    const appName = widgetMeta?.appName ?? widget.appId;
-    const canOpenApp = manifest !== null;
+export function DashboardWidget({ widget, manifest, widgetMeta, style, className, children, ref, ...rest }: DashboardWidgetProps) {
+  const removeWidget = useDashboardStore((s) => s.removeWidget);
+  const AppIcon = getAppIcon(widgetMeta?.appIcon ?? null);
+  const widgetName = widgetMeta?.manifest.name ?? widget.widgetId;
+  const appName = widgetMeta?.appName ?? widget.appId;
+  const canOpenApp = manifest !== null;
 
-    return (
-      <div
-        ref={ref}
-        style={style}
-        className={`${className ?? ''} flex flex-col overflow-hidden rounded-lg border border-[var(--border-default)] bg-[var(--bg-surface)]`}
-        {...rest}
-      >
-        {/* ── Header ── */}
-        <div className="widget-drag-handle flex cursor-grab items-center gap-1.5 border-b border-[var(--border-default)] px-3 py-1.5 active:cursor-grabbing">
-          <GripVertical className="size-3 shrink-0 text-[var(--text-muted)]" />
-          <AppIcon className="size-3.5 shrink-0 text-[var(--text-muted)]" />
-          <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--text-secondary)]">
-            {widgetName}
-          </span>
-          {canOpenApp && (
-            <Button
-              type="button"
-              size="icon-xs"
-              variant="ghost"
-              aria-label={`Open ${appName}`}
-              title={`Open ${appName}`}
-              onClick={() => openApp(widget.appId)}
-            >
-              <Maximize2 className="size-3" />
-            </Button>
-          )}
+  return (
+    <div
+      ref={ref}
+      style={style}
+      className={`${className ?? ''} flex flex-col overflow-hidden rounded-lg border border-[var(--border-default)] bg-[var(--bg-surface)]`}
+      {...rest}
+    >
+      {/* ── Header ── */}
+      <div className="widget-drag-handle flex cursor-grab items-center gap-1.5 border-b border-[var(--border-default)] px-3 py-1.5 active:cursor-grabbing">
+        <GripVertical className="size-3 shrink-0 text-[var(--text-muted)]" />
+        <AppIcon className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-[var(--text-secondary)]">
+          {widgetName}
+        </span>
+        {canOpenApp && (
           <Button
             type="button"
             size="icon-xs"
             variant="ghost"
-            aria-label="Remove widget"
-            title="Remove widget"
-            onClick={() => removeWidget(widget.instanceId)}
+            aria-label={`Open ${appName}`}
+            title={`Open ${appName}`}
+            onClick={() => openApp(widget.appId)}
           >
-            <X className="size-3" />
+            <Maximize2 className="size-3" />
           </Button>
-        </div>
-
-        {/* ── Content ── */}
-        <div className="min-h-0 flex-1 overflow-auto">
-          {manifest ? (
-            <WidgetMount widget={widget} manifest={manifest} widgetMeta={widgetMeta} />
-          ) : (
-            <div className="flex h-full items-center justify-center text-xs text-[var(--text-muted)]">
-              App not found: {widget.appId}
-            </div>
-          )}
-        </div>
-
-        {/* react-grid-layout resize handle (injected as children) */}
-        {children}
+        )}
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          aria-label="Remove widget"
+          title="Remove widget"
+          onClick={() => removeWidget(widget.instanceId)}
+        >
+          <X className="size-3" />
+        </Button>
       </div>
-    );
-  },
-);
+
+      {/* ── Content ── */}
+      <div className="min-h-0 flex-1 overflow-auto">
+        {manifest ? (
+          <WidgetMount widget={widget} manifest={manifest} widgetMeta={widgetMeta} />
+        ) : (
+          <div className="flex h-full items-center justify-center text-xs text-[var(--text-muted)]">
+            App not found: {widget.appId}
+          </div>
+        )}
+      </div>
+
+      {/* react-grid-layout resize handle (injected as children) */}
+      {children}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ui/IconAction.tsx
+++ b/apps/desktop/src/components/ui/IconAction.tsx
@@ -1,5 +1,4 @@
 import {
-  forwardRef,
   type AnchorHTMLAttributes,
   type ButtonHTMLAttributes,
   type HTMLAttributes,
@@ -26,53 +25,51 @@ type AnchorProps = BaseProps & {
   as: 'a';
 } & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'className' | 'children'>;
 
-type IconActionProps = ButtonProps | SpanProps | AnchorProps;
+type IconActionProps = (ButtonProps | SpanProps | AnchorProps) & {
+  ref?: Ref<HTMLButtonElement | HTMLSpanElement | HTMLAnchorElement>;
+};
 
-export const IconAction = forwardRef<HTMLButtonElement | HTMLSpanElement, IconActionProps>(
-  ({ as = 'button', tone = 'default', className, children, ...props }, ref) => {
-    const classes = cn(
-      'rounded p-0.5 transition-colors',
-      tone === 'destructive'
-        ? 'text-[var(--status-error)] hover:bg-[var(--status-error)]/15'
-        : 'text-[var(--text-muted)] hover:bg-[var(--bg-base)] hover:text-[var(--text-primary)]',
-      className,
-    );
+export function IconAction({ as = 'button', tone = 'default', className, children, ref, ...props }: IconActionProps) {
+  const classes = cn(
+    'rounded p-0.5 transition-colors',
+    tone === 'destructive'
+      ? 'text-[var(--status-error)] hover:bg-[var(--status-error)]/15'
+      : 'text-[var(--text-muted)] hover:bg-[var(--bg-base)] hover:text-[var(--text-primary)]',
+    className,
+  );
 
-    if (as === 'span') {
-      return (
-        <span
-          ref={ref as Ref<HTMLSpanElement>}
-          className={classes}
-          {...(props as Omit<SpanProps, keyof BaseProps | 'as'>)}
-        >
-          {children}
-        </span>
-      );
-    }
-
-    if (as === 'a') {
-      return (
-        <a
-          ref={ref as Ref<HTMLAnchorElement>}
-          className={classes}
-          {...(props as Omit<AnchorProps, keyof BaseProps | 'as'>)}
-        >
-          {children}
-        </a>
-      );
-    }
-
+  if (as === 'span') {
     return (
-      <button
-        ref={ref as Ref<HTMLButtonElement>}
-        type="button"
+      <span
+        ref={ref as Ref<HTMLSpanElement>}
         className={classes}
-        {...(props as Omit<ButtonProps, keyof BaseProps | 'as'>)}
+        {...(props as Omit<SpanProps, keyof BaseProps | 'as'>)}
       >
         {children}
-      </button>
+      </span>
     );
-  },
-);
+  }
 
-IconAction.displayName = 'IconAction';
+  if (as === 'a') {
+    return (
+      <a
+        ref={ref as Ref<HTMLAnchorElement>}
+        className={classes}
+        {...(props as Omit<AnchorProps, keyof BaseProps | 'as'>)}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      ref={ref as Ref<HTMLButtonElement>}
+      type="button"
+      className={classes}
+      {...(props as Omit<ButtonProps, keyof BaseProps | 'as'>)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/app-runtime/src/use-agent-prompt.ts
+++ b/packages/app-runtime/src/use-agent-prompt.ts
@@ -7,7 +7,7 @@
  * session IDs or storage details.
  */
 
-import { useContext, useCallback } from 'react';
+import { use, useCallback } from 'react';
 import { AppContext } from './context';
 
 /**
@@ -18,7 +18,7 @@ import { AppContext } from './context';
  *   prompt("Add a todo: buy milk");
  */
 export function useAgentPrompt(): (text: string) => void {
-  const ctx = useContext(AppContext);
+  const ctx = use(AppContext);
 
   return useCallback(
     (text: string) => {

--- a/packages/app-runtime/src/use-ai.ts
+++ b/packages/app-runtime/src/use-ai.ts
@@ -11,7 +11,7 @@
  *   const response = await ai.prompt("Generate an inspirational quote.");
  */
 
-import { useContext, useCallback, useMemo } from 'react';
+import { use, useCallback, useMemo } from 'react';
 import { AppContext } from './context';
 import { getSeroApi } from './sero-bridge';
 
@@ -23,7 +23,7 @@ export interface AppAI {
 }
 
 export function useAI(): AppAI {
-  const ctx = useContext(AppContext);
+  const ctx = use(AppContext);
 
   const prompt = useCallback(
     async (text: string): Promise<string> => {

--- a/packages/app-runtime/src/use-app-info.ts
+++ b/packages/app-runtime/src/use-app-info.ts
@@ -2,7 +2,7 @@
  * useAppInfo — read-only context about the current app and workspace.
  */
 
-import { useContext } from 'react';
+import { use } from 'react';
 import { AppContext } from './context';
 
 export interface AppInfo {
@@ -12,7 +12,7 @@ export interface AppInfo {
 }
 
 export function useAppInfo(): AppInfo {
-  const ctx = useContext(AppContext);
+  const ctx = use(AppContext);
   if (!ctx) {
     throw new Error('useAppInfo must be used inside an <AppProvider>');
   }

--- a/packages/app-runtime/src/use-app-state.ts
+++ b/packages/app-runtime/src/use-app-state.ts
@@ -6,7 +6,7 @@
  * 3. Writes via IPC (atomic file write → watcher fires → all consumers update)
  */
 
-import { useState, useEffect, useCallback, useContext, useRef } from 'react';
+import { useState, useEffect, useCallback, use, useRef } from 'react';
 import { AppContext } from './context';
 import { getSeroApi, type SeroWindowAppStateBridge } from './sero-bridge';
 
@@ -44,7 +44,7 @@ function applyDefaultState<T>(defaultState: T, current: unknown): T {
 }
 
 export function useAppState<T>(defaultState: T): [T, (updater: (prev: T) => T) => void] {
-  const ctx = useContext(AppContext);
+  const ctx = use(AppContext);
   if (!ctx) {
     throw new Error('useAppState must be used inside an <AppProvider>');
   }

--- a/packages/app-runtime/src/use-app-tools.ts
+++ b/packages/app-runtime/src/use-app-tools.ts
@@ -1,5 +1,5 @@
 import type { AppToolResult } from '@sero-ai/common';
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, use, useMemo } from 'react';
 
 import { AppContext } from './context';
 import { getSeroApi } from './sero-bridge';
@@ -9,7 +9,7 @@ export interface AppTools {
 }
 
 export function useAppTools(): AppTools {
-  const ctx = useContext(AppContext);
+  const ctx = use(AppContext);
 
   const run = useCallback<AppTools['run']>(
     async (toolName, params): Promise<AppToolResult> => {

--- a/packages/app-runtime/src/use-theme.ts
+++ b/packages/app-runtime/src/use-theme.ts
@@ -6,7 +6,7 @@
  * canvas rendering, charts, or conditional logic).
  */
 
-import { useContext } from 'react';
+import { use } from 'react';
 import { AppContext } from './context';
 
 export interface UseThemeResult {
@@ -17,7 +17,7 @@ export interface UseThemeResult {
 }
 
 export function useTheme(): UseThemeResult {
-  const ctx = useContext(AppContext);
+  const ctx = use(AppContext);
   return {
     mode: ctx?.themeMode ?? 'dark',
     presetId: ctx?.themePresetId ?? 'default',

--- a/packages/app-runtime/src/use-widget-registration.ts
+++ b/packages/app-runtime/src/use-widget-registration.ts
@@ -21,7 +21,7 @@
  * ```
  */
 
-import { useContext, useEffect } from 'react';
+import { use, useEffect } from 'react';
 import type { ComponentType } from 'react';
 import { AppContext } from './context';
 import { registerWidget } from './widget-registry';
@@ -50,7 +50,7 @@ interface WidgetRegistrationOptions {
  * dashboard widget can keep rendering after the full app view unmounts.
  */
 export function useWidgetRegistration(options: WidgetRegistrationOptions): void {
-  const ctx = useContext(AppContext);
+  const ctx = use(AppContext);
   const appId = ctx?.appId;
   const { component, defaultSize, description, maxSize, minSize, name, widgetId } = options;
   const { h: defaultHeight, w: defaultWidth } = defaultSize;

--- a/packages/ui/src/components/ai-elements/attachments.tsx
+++ b/packages/ui/src/components/ai-elements/attachments.tsx
@@ -19,7 +19,7 @@ import {
   VideoIcon,
   XIcon,
 } from "lucide-react";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import { createContext, useCallback, use, useMemo } from "react";
 
 // ============================================================================
 // Types
@@ -133,10 +133,10 @@ const AttachmentContext = createContext<AttachmentContextValue | null>(null);
 // ============================================================================
 
 export const useAttachmentsContext = () =>
-  useContext(AttachmentsContext) ?? { variant: "grid" as const };
+  use(AttachmentsContext) ?? { variant: "grid" as const };
 
 export const useAttachmentContext = () => {
-  const ctx = useContext(AttachmentContext);
+  const ctx = use(AttachmentContext);
   if (!ctx) {
     throw new Error("Attachment components must be used within <Attachment>");
   }

--- a/packages/ui/src/components/ai-elements/chain-of-thought.tsx
+++ b/packages/ui/src/components/ai-elements/chain-of-thought.tsx
@@ -12,7 +12,7 @@ import {
 } from "../ui/collapsible";
 import { cn } from "../../lib/utils";
 import { BrainIcon, ChevronDownIcon, DotIcon } from "lucide-react";
-import { createContext, memo, useContext, useMemo } from "react";
+import { createContext, memo, use, useMemo } from "react";
 
 interface ChainOfThoughtContextValue {
   isOpen: boolean;
@@ -24,7 +24,7 @@ const ChainOfThoughtContext = createContext<ChainOfThoughtContextValue | null>(
 );
 
 const useChainOfThought = () => {
-  const context = useContext(ChainOfThoughtContext);
+  const context = use(ChainOfThoughtContext);
   if (!context) {
     throw new Error(
       "ChainOfThought components must be used within ChainOfThought"

--- a/packages/ui/src/components/ai-elements/confirmation.tsx
+++ b/packages/ui/src/components/ai-elements/confirmation.tsx
@@ -6,7 +6,7 @@ import type { ComponentProps, ReactNode } from "react";
 import { Alert, AlertDescription } from "../ui/alert";
 import { Button } from "../ui/button";
 import { cn } from "../../lib/utils";
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 
 type ToolUIPartApproval =
   | {
@@ -46,7 +46,7 @@ const ConfirmationContext = createContext<ConfirmationContextValue | null>(
 );
 
 const useConfirmation = () => {
-  const context = useContext(ConfirmationContext);
+  const context = use(ConfirmationContext);
 
   if (!context) {
     throw new Error("Confirmation components must be used within Confirmation");

--- a/packages/ui/src/components/ai-elements/context.tsx
+++ b/packages/ui/src/components/ai-elements/context.tsx
@@ -11,7 +11,7 @@ import {
 } from "../ui/hover-card";
 import { Progress } from "../ui/progress";
 import { cn } from "../../lib/utils";
-import { createContext, useContext, useMemo } from "react";
+import { createContext, use, useMemo } from "react";
 import { getUsage } from "tokenlens";
 
 const PERCENT_MAX = 100;
@@ -32,7 +32,7 @@ interface ContextSchema {
 const ContextContext = createContext<ContextSchema | null>(null);
 
 const useContextValue = () => {
-  const context = useContext(ContextContext);
+  const context = use(ContextContext);
 
   if (!context) {
     throw new Error("Context components must be used within Context");

--- a/packages/ui/src/components/ai-elements/environment-variables.tsx
+++ b/packages/ui/src/components/ai-elements/environment-variables.tsx
@@ -10,7 +10,7 @@ import { CheckIcon, CopyIcon, EyeIcon, EyeOffIcon } from "lucide-react";
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -111,7 +111,7 @@ export const EnvironmentVariablesToggle = ({
   className,
   ...props
 }: EnvironmentVariablesToggleProps) => {
-  const { showValues, setShowValues } = useContext(EnvironmentVariablesContext);
+  const { showValues, setShowValues } = use(EnvironmentVariablesContext);
 
   return (
     <div className={cn("flex items-center gap-2", className)}>
@@ -206,7 +206,7 @@ export const EnvironmentVariableName = ({
   children,
   ...props
 }: EnvironmentVariableNameProps) => {
-  const { name } = useContext(EnvironmentVariableContext);
+  const { name } = use(EnvironmentVariableContext);
 
   return (
     <span className={cn("font-mono text-sm", className)} {...props}>
@@ -222,8 +222,8 @@ export const EnvironmentVariableValue = ({
   children,
   ...props
 }: EnvironmentVariableValueProps) => {
-  const { value } = useContext(EnvironmentVariableContext);
-  const { showValues } = useContext(EnvironmentVariablesContext);
+  const { value } = use(EnvironmentVariableContext);
+  const { showValues } = use(EnvironmentVariablesContext);
 
   const displayValue = showValues
     ? value
@@ -263,7 +263,7 @@ export const EnvironmentVariableCopyButton = ({
 }: EnvironmentVariableCopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
-  const { name, value } = useContext(EnvironmentVariableContext);
+  const { name, value } = use(EnvironmentVariableContext);
 
   const getTextToCopy = useCallback((): string => {
     const formatMap = {

--- a/packages/ui/src/components/ai-elements/file-tree.tsx
+++ b/packages/ui/src/components/ai-elements/file-tree.tsx
@@ -17,7 +17,7 @@ import {
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useMemo,
   useState,
 } from "react";
@@ -120,7 +120,7 @@ export const FileTreeFolder = ({
   ...props
 }: FileTreeFolderProps) => {
   const { expandedPaths, togglePath, selectedPath, onSelect } =
-    useContext(FileTreeContext);
+    use(FileTreeContext);
   const isExpanded = expandedPaths.has(path);
   const isSelected = selectedPath === path;
 
@@ -204,7 +204,7 @@ export const FileTreeFile = ({
   children,
   ...props
 }: FileTreeFileProps) => {
-  const { selectedPath, onSelect } = useContext(FileTreeContext);
+  const { selectedPath, onSelect } = use(FileTreeContext);
   const isSelected = selectedPath === path;
 
   const handleClick = useCallback(() => {

--- a/packages/ui/src/components/ai-elements/inline-citation.tsx
+++ b/packages/ui/src/components/ai-elements/inline-citation.tsx
@@ -19,7 +19,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useState,
 } from "react";
@@ -93,7 +93,7 @@ export const InlineCitationCardBody = ({
 const CarouselApiContext = createContext<CarouselApi | undefined>(undefined);
 
 const useCarouselApi = () => {
-  const context = useContext(CarouselApiContext);
+  const context = use(CarouselApiContext);
   return context;
 };
 

--- a/packages/ui/src/components/ai-elements/jsx-preview.tsx
+++ b/packages/ui/src/components/ai-elements/jsx-preview.tsx
@@ -9,7 +9,7 @@ import {
   createContext,
   memo,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -32,7 +32,7 @@ const JSXPreviewContext = createContext<JSXPreviewContextValue | null>(null);
 const TAG_REGEX = /<\/?([a-zA-Z][a-zA-Z0-9]*)\s*([^>]*?)(\/)?>/;
 
 export const useJSXPreview = () => {
-  const context = useContext(JSXPreviewContext);
+  const context = use(JSXPreviewContext);
   if (!context) {
     throw new Error("JSXPreview components must be used within JSXPreview");
   }

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -24,7 +24,7 @@ import {
   createContext,
   memo,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useState,
@@ -128,7 +128,7 @@ const MessageBranchContext = createContext<MessageBranchContextType | null>(
 );
 
 const useMessageBranch = () => {
-  const context = useContext(MessageBranchContext);
+  const context = use(MessageBranchContext);
 
   if (!context) {
     throw new Error(

--- a/packages/ui/src/components/ai-elements/mic-selector.tsx
+++ b/packages/ui/src/components/ai-elements/mic-selector.tsx
@@ -21,7 +21,7 @@ import { ChevronsUpDownIcon } from "lucide-react";
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -112,7 +112,7 @@ export const MicSelectorTrigger = ({
   children,
   ...props
 }: MicSelectorTriggerProps) => {
-  const { setWidth } = useContext(MicSelectorContext);
+  const { setWidth } = use(MicSelectorContext);
   const ref = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
@@ -158,7 +158,7 @@ export const MicSelectorContent = ({
   popoverOptions,
   ...props
 }: MicSelectorContentProps) => {
-  const { width, onValueChange, value } = useContext(MicSelectorContext);
+  const { width, onValueChange, value } = use(MicSelectorContext);
 
   return (
     <PopoverContent
@@ -192,7 +192,7 @@ export const MicSelectorList = ({
   children,
   ...props
 }: MicSelectorListProps) => {
-  const { data } = useContext(MicSelectorContext);
+  const { data } = use(MicSelectorContext);
 
   return <CommandList {...props}>{children(data)}</CommandList>;
 };
@@ -207,7 +207,7 @@ export const MicSelectorEmpty = ({
 export type MicSelectorItemProps = ComponentProps<typeof CommandItem>;
 
 export const MicSelectorItem = (props: MicSelectorItemProps) => {
-  const { onValueChange, onOpenChange } = useContext(MicSelectorContext);
+  const { onValueChange, onOpenChange } = use(MicSelectorContext);
 
   const handleSelect = useCallback(
     (currentValue: string) => {
@@ -256,7 +256,7 @@ export const MicSelectorValue = ({
   className,
   ...props
 }: MicSelectorValueProps) => {
-  const { data, value } = useContext(MicSelectorContext);
+  const { data, value } = use(MicSelectorContext);
   const currentDevice = data.find((d) => d.deviceId === value);
 
   if (!currentDevice) {

--- a/packages/ui/src/components/ai-elements/open-in-chat.tsx
+++ b/packages/ui/src/components/ai-elements/open-in-chat.tsx
@@ -17,7 +17,7 @@ import {
   ExternalLinkIcon,
   MessageCircleIcon,
 } from "lucide-react";
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 
 const providers = {
   chatgpt: {
@@ -188,7 +188,7 @@ const providers = {
 const OpenInContext = createContext<{ query: string } | undefined>(undefined);
 
 const useOpenInContext = () => {
-  const context = useContext(OpenInContext);
+  const context = use(OpenInContext);
   if (!context) {
     throw new Error("OpenIn components must be used within an OpenIn provider");
   }

--- a/packages/ui/src/components/ai-elements/package-info.tsx
+++ b/packages/ui/src/components/ai-elements/package-info.tsx
@@ -5,7 +5,7 @@ import type { HTMLAttributes } from "react";
 import { Badge } from "../ui/badge";
 import { cn } from "../../lib/utils";
 import { ArrowRightIcon, MinusIcon, PackageIcon, PlusIcon } from "lucide-react";
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 
 type ChangeType = "major" | "minor" | "patch" | "added" | "removed";
 
@@ -78,7 +78,7 @@ export const PackageInfoName = ({
   children,
   ...props
 }: PackageInfoNameProps) => {
-  const { name } = useContext(PackageInfoContext);
+  const { name } = use(PackageInfoContext);
 
   return (
     <div className={cn("flex items-center gap-2", className)} {...props}>
@@ -112,7 +112,7 @@ export const PackageInfoChangeType = ({
   children,
   ...props
 }: PackageInfoChangeTypeProps) => {
-  const { changeType } = useContext(PackageInfoContext);
+  const { changeType } = use(PackageInfoContext);
 
   if (!changeType) {
     return null;
@@ -141,7 +141,7 @@ export const PackageInfoVersion = ({
   children,
   ...props
 }: PackageInfoVersionProps) => {
-  const { currentVersion, newVersion } = useContext(PackageInfoContext);
+  const { currentVersion, newVersion } = use(PackageInfoContext);
 
   if (!(currentVersion || newVersion)) {
     return null;

--- a/packages/ui/src/components/ai-elements/plan.tsx
+++ b/packages/ui/src/components/ai-elements/plan.tsx
@@ -19,7 +19,7 @@ import {
 } from "../ui/collapsible";
 import { cn } from "../../lib/utils";
 import { ChevronsUpDownIcon } from "lucide-react";
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 
 import { Shimmer } from "./shimmer";
 
@@ -30,7 +30,7 @@ interface PlanContextValue {
 const PlanContext = createContext<PlanContextValue | null>(null);
 
 const usePlan = () => {
-  const context = useContext(PlanContext);
+  const context = use(PlanContext);
   if (!context) {
     throw new Error("Plan components must be used within Plan");
   }

--- a/packages/ui/src/components/ai-elements/prompt-input-context.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input-context.tsx
@@ -14,7 +14,7 @@ import { nanoid } from "nanoid";
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -71,7 +71,7 @@ export const LocalReferencedSourcesContext = createContext<ReferencedSourcesCont
 // ============================================================================
 
 export const usePromptInputController = () => {
-  const ctx = useContext(PromptInputController);
+  const ctx = use(PromptInputController);
   if (!ctx) {
     throw new Error(
       "Wrap your component inside <PromptInputProvider> to use usePromptInputController()."
@@ -82,10 +82,10 @@ export const usePromptInputController = () => {
 
 /** Optional variant, does NOT throw. Useful for dual-mode components. */
 export const useOptionalPromptInputController = () =>
-  useContext(PromptInputController);
+  use(PromptInputController);
 
 export const useProviderAttachments = () => {
-  const ctx = useContext(ProviderAttachmentsContext);
+  const ctx = use(ProviderAttachmentsContext);
   if (!ctx) {
     throw new Error(
       "Wrap your component inside <PromptInputProvider> to use useProviderAttachments()."
@@ -95,12 +95,12 @@ export const useProviderAttachments = () => {
 };
 
 const useOptionalProviderAttachments = () =>
-  useContext(ProviderAttachmentsContext);
+  use(ProviderAttachmentsContext);
 
 export const usePromptInputAttachments = () => {
   // Prefer local context (inside PromptInput) as it has validation, fall back to provider
   const provider = useOptionalProviderAttachments();
-  const local = useContext(LocalAttachmentsContext);
+  const local = use(LocalAttachmentsContext);
   const context = local ?? provider;
   if (!context) {
     throw new Error(
@@ -111,7 +111,7 @@ export const usePromptInputAttachments = () => {
 };
 
 export const usePromptInputReferencedSources = () => {
-  const ctx = useContext(LocalReferencedSourcesContext);
+  const ctx = use(LocalReferencedSourcesContext);
   if (!ctx) {
     throw new Error(
       "usePromptInputReferencedSources must be used within a LocalReferencedSourcesContext.Provider"

--- a/packages/ui/src/components/ai-elements/reasoning.tsx
+++ b/packages/ui/src/components/ai-elements/reasoning.tsx
@@ -18,7 +18,7 @@ import {
   createContext,
   memo,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -38,7 +38,7 @@ interface ReasoningContextValue {
 const ReasoningContext = createContext<ReasoningContextValue | null>(null);
 
 export const useReasoning = () => {
-  const context = useContext(ReasoningContext);
+  const context = use(ReasoningContext);
   if (!context) {
     throw new Error("Reasoning components must be used within Reasoning");
   }

--- a/packages/ui/src/components/ai-elements/schema-display.tsx
+++ b/packages/ui/src/components/ai-elements/schema-display.tsx
@@ -10,7 +10,7 @@ import {
 } from "../ui/collapsible";
 import { cn } from "../../lib/utils";
 import { ChevronRightIcon } from "lucide-react";
-import { createContext, useContext, useMemo } from "react";
+import { createContext, use, useMemo } from "react";
 
 type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -144,7 +144,7 @@ export const SchemaDisplayMethod = ({
   children,
   ...props
 }: SchemaDisplayMethodProps) => {
-  const { method } = useContext(SchemaDisplayContext);
+  const { method } = use(SchemaDisplayContext);
 
   return (
     <Badge
@@ -164,7 +164,7 @@ export const SchemaDisplayPath = ({
   children,
   ...props
 }: SchemaDisplayPathProps) => {
-  const { path } = useContext(SchemaDisplayContext);
+  const { path } = use(SchemaDisplayContext);
 
   // Highlight path parameters
   const highlightedPath = path.replaceAll(
@@ -191,7 +191,7 @@ export const SchemaDisplayDescription = ({
   children,
   ...props
 }: SchemaDisplayDescriptionProps) => {
-  const { description } = useContext(SchemaDisplayContext);
+  const { description } = use(SchemaDisplayContext);
 
   return (
     <p
@@ -225,7 +225,7 @@ export const SchemaDisplayParameters = ({
   children,
   ...props
 }: SchemaDisplayParametersProps) => {
-  const { parameters } = useContext(SchemaDisplayContext);
+  const { parameters } = use(SchemaDisplayContext);
 
   return (
     <Collapsible className={cn(className)} defaultOpen {...props}>
@@ -293,7 +293,7 @@ export const SchemaDisplayRequest = ({
   children,
   ...props
 }: SchemaDisplayRequestProps) => {
-  const { requestBody } = useContext(SchemaDisplayContext);
+  const { requestBody } = use(SchemaDisplayContext);
 
   return (
     <Collapsible className={cn(className)} defaultOpen {...props}>
@@ -320,7 +320,7 @@ export const SchemaDisplayResponse = ({
   children,
   ...props
 }: SchemaDisplayResponseProps) => {
-  const { responseBody } = useContext(SchemaDisplayContext);
+  const { responseBody } = use(SchemaDisplayContext);
 
   return (
     <Collapsible className={cn(className)} defaultOpen {...props}>

--- a/packages/ui/src/components/ai-elements/snippet.tsx
+++ b/packages/ui/src/components/ai-elements/snippet.tsx
@@ -14,7 +14,7 @@ import { CheckIcon, CopyIcon } from "lucide-react";
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useRef,
   useState,
@@ -66,7 +66,7 @@ export type SnippetInputProps = Omit<
 >;
 
 export const SnippetInput = ({ className, ...props }: SnippetInputProps) => {
-  const { code } = useContext(SnippetContext);
+  const { code } = use(SnippetContext);
 
   return (
     <InputGroupInput
@@ -94,7 +94,7 @@ export const SnippetCopyButton = ({
 }: SnippetCopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
-  const { code } = useContext(SnippetContext);
+  const { code } = use(SnippetContext);
 
   const copyToClipboard = useCallback(async () => {
     if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {

--- a/packages/ui/src/components/ai-elements/terminal.tsx
+++ b/packages/ui/src/components/ai-elements/terminal.tsx
@@ -9,7 +9,7 @@ import { CheckIcon, CopyIcon, TerminalIcon, Trash2Icon } from "lucide-react";
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -122,7 +122,7 @@ export const TerminalStatus = ({
   children,
   ...props
 }: TerminalStatusProps) => {
-  const { isStreaming } = useContext(TerminalContext);
+  const { isStreaming } = use(TerminalContext);
 
   if (!isStreaming) {
     return null;
@@ -166,7 +166,7 @@ export const TerminalCopyButton = ({
 }: TerminalCopyButtonProps) => {
   const [isCopied, setIsCopied] = useState(false);
   const timeoutRef = useRef<number>(0);
-  const { output } = useContext(TerminalContext);
+  const { output } = use(TerminalContext);
 
   const copyToClipboard = useCallback(async () => {
     if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
@@ -216,7 +216,7 @@ export const TerminalClearButton = ({
   className,
   ...props
 }: TerminalClearButtonProps) => {
-  const { onClear } = useContext(TerminalContext);
+  const { onClear } = use(TerminalContext);
 
   if (!onClear) {
     return null;
@@ -245,7 +245,7 @@ export const TerminalContent = ({
   children,
   ...props
 }: TerminalContentProps) => {
-  const { output, isStreaming, autoScroll } = useContext(TerminalContext);
+  const { output, isStreaming, autoScroll } = use(TerminalContext);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: output triggers auto-scroll when new content arrives

--- a/packages/ui/src/components/ai-elements/test-results.tsx
+++ b/packages/ui/src/components/ai-elements/test-results.tsx
@@ -16,7 +16,7 @@ import {
   CircleIcon,
   XCircleIcon,
 } from "lucide-react";
-import { createContext, useContext, useMemo } from "react";
+import { createContext, use, useMemo } from "react";
 
 type TestStatus = "passed" | "failed" | "skipped" | "running";
 
@@ -96,7 +96,7 @@ export const TestResultsSummary = ({
   children,
   ...props
 }: TestResultsSummaryProps) => {
-  const { summary } = useContext(TestResultsContext);
+  const { summary } = use(TestResultsContext);
 
   if (!summary) {
     return null;
@@ -144,7 +144,7 @@ export const TestResultsDuration = ({
   children,
   ...props
 }: TestResultsDurationProps) => {
-  const { summary } = useContext(TestResultsContext);
+  const { summary } = use(TestResultsContext);
 
   if (!summary?.duration) {
     return null;
@@ -164,7 +164,7 @@ export const TestResultsProgress = ({
   children,
   ...props
 }: TestResultsProgressProps) => {
-  const { summary } = useContext(TestResultsContext);
+  const { summary } = use(TestResultsContext);
 
   if (!summary) {
     return null;
@@ -251,7 +251,7 @@ export const TestSuiteName = ({
   children,
   ...props
 }: TestSuiteNameProps) => {
-  const { name, status } = useContext(TestSuiteContext);
+  const { name, status } = use(TestSuiteContext);
 
   return (
     <CollapsibleTrigger
@@ -395,7 +395,7 @@ export const TestStatus = ({
   children,
   ...props
 }: TestStatusProps) => {
-  const { status } = useContext(TestContext);
+  const { status } = use(TestContext);
 
   return (
     <span
@@ -410,7 +410,7 @@ export const TestStatus = ({
 export type TestNameProps = HTMLAttributes<HTMLSpanElement>;
 
 export const TestName = ({ className, children, ...props }: TestNameProps) => {
-  const { name } = useContext(TestContext);
+  const { name } = use(TestContext);
 
   return (
     <span className={cn("flex-1", className)} {...props}>
@@ -426,7 +426,7 @@ export const TestDuration = ({
   children,
   ...props
 }: TestDurationProps) => {
-  const { duration } = useContext(TestContext);
+  const { duration } = use(TestContext);
 
   if (duration === undefined) {
     return null;

--- a/packages/ui/src/components/ai-elements/transcription.tsx
+++ b/packages/ui/src/components/ai-elements/transcription.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps, ReactNode } from "react";
 
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { cn } from "../../lib/utils";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import { createContext, useCallback, use, useMemo } from "react";
 
 type TranscriptionSegment = TranscriptionResult["segments"][number];
 
@@ -21,7 +21,7 @@ const TranscriptionContext = createContext<TranscriptionContextValue | null>(
 );
 
 const useTranscription = () => {
-  const context = useContext(TranscriptionContext);
+  const context = use(TranscriptionContext);
   if (!context) {
     throw new Error(
       "Transcription components must be used within Transcription"

--- a/packages/ui/src/components/ai-elements/voice-selector.tsx
+++ b/packages/ui/src/components/ai-elements/voice-selector.tsx
@@ -38,7 +38,7 @@ import {
   VenusAndMarsIcon,
   VenusIcon,
 } from "lucide-react";
-import { createContext, useCallback, useContext, useMemo } from "react";
+import { createContext, useCallback, use, useMemo } from "react";
 
 interface VoiceSelectorContextValue {
   value: string | undefined;
@@ -52,7 +52,7 @@ const VoiceSelectorContext = createContext<VoiceSelectorContextValue | null>(
 );
 
 export const useVoiceSelector = () => {
-  const context = useContext(VoiceSelectorContext);
+  const context = use(VoiceSelectorContext);
   if (!context) {
     throw new Error(
       "VoiceSelector components must be used within VoiceSelector"

--- a/packages/ui/src/components/ai-elements/web-preview.tsx
+++ b/packages/ui/src/components/ai-elements/web-preview.tsx
@@ -20,7 +20,7 @@ import { ChevronDownIcon } from "lucide-react";
 import {
   createContext,
   useCallback,
-  useContext,
+  use,
   useMemo,
   useState,
 } from "react";
@@ -35,7 +35,7 @@ export interface WebPreviewContextValue {
 const WebPreviewContext = createContext<WebPreviewContextValue | null>(null);
 
 const useWebPreview = () => {
-  const context = useContext(WebPreviewContext);
+  const context = use(WebPreviewContext);
   if (!context) {
     throw new Error("WebPreview components must be used within a WebPreview");
   }

--- a/packages/ui/src/components/ui/carousel.tsx
+++ b/packages/ui/src/components/ui/carousel.tsx
@@ -31,7 +31,7 @@ type CarouselContextProps = {
 const CarouselContext = React.createContext<CarouselContextProps | null>(null)
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext)
+  const context = React.use(CarouselContext)
 
   if (!context) {
     throw new Error("useCarousel must be used within a <Carousel />")

--- a/packages/ui/src/components/ui/chart.tsx
+++ b/packages/ui/src/components/ui/chart.tsx
@@ -23,7 +23,7 @@ type ChartContextProps = {
 const ChartContext = React.createContext<ChartContextProps | null>(null)
 
 function useChart() {
-  const context = React.useContext(ChartContext)
+  const context = React.use(ChartContext)
 
   if (!context) {
     throw new Error("useChart must be used within a <ChartContainer />")

--- a/packages/ui/src/components/ui/form.tsx
+++ b/packages/ui/src/components/ui/form.tsx
@@ -41,8 +41,8 @@ const FormField = <
 }
 
 const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
+  const fieldContext = React.use(FormFieldContext)
+  const itemContext = React.use(FormItemContext)
   const { getFieldState } = useFormContext()
   const formState = useFormState({ name: fieldContext.name })
   const fieldState = getFieldState(fieldContext.name, formState)

--- a/packages/ui/src/components/ui/input-otp.tsx
+++ b/packages/ui/src/components/ui/input-otp.tsx
@@ -43,7 +43,7 @@ function InputOTPSlot({
 }: React.ComponentProps<"div"> & {
   index: number
 }) {
-  const inputOTPContext = React.useContext(OTPInputContext)
+  const inputOTPContext = React.use(OTPInputContext)
   const { char, hasFakeCaret, isActive } = inputOTPContext?.slots[index] ?? {}
 
   return (

--- a/packages/ui/src/components/ui/search-input.tsx
+++ b/packages/ui/src/components/ui/search-input.tsx
@@ -7,36 +7,33 @@ interface SearchInputProps extends React.ComponentProps<"input"> {
   containerClassName?: string
   endAdornment?: React.ReactNode
   iconClassName?: string
+  ref?: React.Ref<HTMLInputElement>
 }
 
-const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
-  ({ containerClassName, className, endAdornment, iconClassName, placeholder, "aria-label": ariaLabel, ...props }, ref) => {
-    return (
-      <div
-        data-slot="search-input"
-        className={cn("flex items-center gap-2 px-3", containerClassName)}
-      >
-        <SearchIcon
-          data-slot="search-input-icon"
-          className={cn("text-muted-foreground size-3.5 shrink-0", iconClassName)}
-        />
-        <input
-          aria-label={ariaLabel ?? (typeof placeholder === "string" ? placeholder : "Search")}
-          placeholder={placeholder}
-          ref={ref}
-          data-slot="search-input-control"
-          className={cn(
-            "placeholder:text-muted-foreground h-9 w-full min-w-0 bg-transparent pl-1.5 text-xs text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
-            className
-          )}
-          {...props}
-        />
-        {endAdornment}
-      </div>
-    )
-  }
-)
-
-SearchInput.displayName = "SearchInput"
+function SearchInput({ containerClassName, className, endAdornment, iconClassName, placeholder, "aria-label": ariaLabel, ref, ...props }: SearchInputProps) {
+  return (
+    <div
+      data-slot="search-input"
+      className={cn("flex items-center gap-2 px-3", containerClassName)}
+    >
+      <SearchIcon
+        data-slot="search-input-icon"
+        className={cn("text-muted-foreground size-3.5 shrink-0", iconClassName)}
+      />
+      <input
+        aria-label={ariaLabel ?? (typeof placeholder === "string" ? placeholder : "Search")}
+        placeholder={placeholder}
+        ref={ref}
+        data-slot="search-input-control"
+        className={cn(
+          "placeholder:text-muted-foreground h-9 w-full min-w-0 bg-transparent pl-1.5 text-xs text-foreground outline-none disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+      {endAdornment}
+    </div>
+  )
+}
 
 export { SearchInput }

--- a/packages/ui/src/components/ui/toggle-group.tsx
+++ b/packages/ui/src/components/ui/toggle-group.tsx
@@ -56,7 +56,7 @@ function ToggleGroupItem({
   ...props
 }: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
   VariantProps<typeof toggleVariants>) {
-  const context = React.useContext(ToggleGroupContext)
+  const context = React.use(ToggleGroupContext)
 
   return (
     <ToggleGroupPrimitive.Item

--- a/packages/ui/src/components/ui/tree.tsx
+++ b/packages/ui/src/components/ui/tree.tsx
@@ -20,7 +20,7 @@ const TreeContext = React.createContext<TreeContextValue>({
 });
 
 function useTreeContext<T = any>() {
-  return React.useContext(TreeContext) as TreeContextValue<T>;
+  return React.use(TreeContext) as TreeContextValue<T>;
 }
 
 interface TreeProps extends React.HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
## Summary
- replace React 19 deprecated `useContext(...)` calls with `use(...)` in app-runtime and ui contexts
- replace `forwardRef` wrappers with React 19 ref-as-prop patterns in focused components
- leave remaining deprecated-api findings in >500 LOC files untouched for a separate refactor

## React Doctor
- before: 898 issues
- after: 859 issues
- `no-react19-deprecated-apis`: 42 → 3

## Validation
- `pnpm dlx react-doctor@latest --json --full --no-score`
- `pnpm test`
- `pnpm typecheck`
