### PR TITLE
refactor: high-value React Doctor findings

### DIFF
--- a/apps/desktop/electron/features/container/registries/dev-server-registry.ts
+++ b/apps/desktop/electron/features/container/registries/dev-server-registry.ts
@@ -9,7 +9,7 @@
  */
 
 import type { DevServer } from '@/types/ipc';
-import type { PortScanner } from '../network/port-forward';
+import type { DetectedPort, PortScanner } from '../network/port-forward';
 import type { ContainerManager } from '..';
 import { WORKSPACE_DIR } from '../tools/tool-schemas';
 
@@ -228,18 +228,22 @@ export class DevServerRegistry {
 
   /** Check all registered servers against PortScanner data. */
   private checkLiveness(): void {
+    const portsByWorkspace = new Map<string, Map<number, DetectedPort>>();
+
     for (const server of this.servers.values()) {
-      const detectedPorts = this.portScanner.getPorts(server.workspaceId);
-      const isListening = detectedPorts.some((p) => p.port === server.port);
+      let detectedPorts = portsByWorkspace.get(server.workspaceId);
+      if (!detectedPorts) {
+        detectedPorts = new Map(this.portScanner.getPorts(server.workspaceId).map((p) => [p.port, p]));
+        portsByWorkspace.set(server.workspaceId, detectedPorts);
+      }
+      const detected = detectedPorts.get(server.port);
+      const isListening = !!detected;
       const newStatus: DevServer['status'] = isListening ? 'running' : 'stopped';
 
       if (server.status !== newStatus && server.status !== 'starting') {
         server.status = newStatus;
         // Update URL if port scanner has a fresher one
-        if (isListening) {
-          const detected = detectedPorts.find((p) => p.port === server.port);
-          if (detected) server.url = detected.url;
-        }
+        if (detected) server.url = detected.url;
         this.emit({ type: 'status_changed', serverId: server.id, status: newStatus });
       }
     }

--- a/apps/desktop/electron/ipc/gateway/gateway.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway.ts
@@ -203,10 +203,10 @@ async function startGateway(): Promise<void> {
 }
 
 async function stopGateway(): Promise<void> {
-  await tailscale.unserve();
-
-  await webChatServer.stop();
-
-  await gatewayServer.stop();
+  await Promise.all([
+    tailscale.unserve(),
+    webChatServer.stop(),
+    gatewayServer.stop(),
+  ]);
   console.log('[gateway] All services stopped');
 }

--- a/apps/desktop/src/components/layout/collaboration-chat-feed.ts
+++ b/apps/desktop/src/components/layout/collaboration-chat-feed.ts
@@ -170,9 +170,10 @@ function buildStandardFeed(
 ): ChatItem[] {
   items.push({ kind: 'phase', key: 'phase-research', phase: 'research' });
 
+  const specialistsByRole = indexSpecialistsByRole(specialists);
   const completedRoles = new Set(specialists.map((s) => s.role));
 
-  const researcher = specialists.find((s) => s.role === 'researcher');
+  const researcher = specialistsByRole.get('researcher');
   if (researcher) {
     items.push({ kind: 'message', key: 'msg-researcher', role: 'researcher', text: researcher.response, durationMs: researcher.durationMs, isError: !!researcher.error });
   } else if (status === 'research') {
@@ -184,7 +185,7 @@ function buildStandardFeed(
   }
 
   for (const role of ['analyst', 'visionary'] as CollaborationRole[]) {
-    const spec = specialists.find((s) => s.role === role);
+    const spec = specialistsByRole.get(role);
     if (spec) {
       items.push({ kind: 'message', key: `msg-${role}`, role, text: spec.response, durationMs: spec.durationMs, isError: !!spec.error });
     } else if (status === 'specialists') {
@@ -196,7 +197,7 @@ function buildStandardFeed(
     items.push({ kind: 'phase', key: 'phase-synthesis', phase: 'synthesis' });
   }
 
-  const coordinator = specialists.find((s) => s.role === 'coordinator');
+  const coordinator = specialistsByRole.get('coordinator');
   if (coordinator) {
     items.push({ kind: 'message', key: 'msg-coordinator', role: 'coordinator', text: coordinator.response, durationMs: coordinator.durationMs, isError: !!coordinator.error });
   } else if (status === 'synthesis') {
@@ -215,12 +216,13 @@ function buildDebateFeed(
 ): ChatItem[] {
   const phases: string[] = ['decomposition', 'independent_analysis', 'debate', 'synthesis'];
   const currentIdx = phases.indexOf(debate.phase);
+  const specialistsByRole = indexSpecialistsByRole(specialists);
 
   for (let i = 0; i <= currentIdx; i++) {
     items.push({ kind: 'phase', key: `phase-${phases[i]}`, phase: phases[i]! });
 
     if (phases[i] === 'decomposition') {
-      const decomposition = specialists.find((s) => s.role === 'coordinator');
+      const decomposition = specialistsByRole.get('coordinator');
       const coordinatorStatus =
         debate.agentStatuses.coordinator ?? debate.agentStatuses['collab-coordinator'];
       if (decomposition) {
@@ -239,7 +241,7 @@ function buildDebateFeed(
 
     if (phases[i] === 'independent_analysis') {
       for (const role of ['researcher', 'analyst', 'visionary'] as CollaborationRole[]) {
-        const spec = specialists.find((s) => s.role === role);
+        const spec = specialistsByRole.get(role);
         const agentName = role === 'analyst' ? 'collab-analyst' : role;
         const agentStatus = debate.agentStatuses[agentName];
         if (spec) {
@@ -277,6 +279,14 @@ function buildDebateFeed(
   }
 
   return items;
+}
+
+function indexSpecialistsByRole(specialists: SpecialistEntry[]): Map<CollaborationRole, SpecialistEntry> {
+  const specialistsByRole = new Map<CollaborationRole, SpecialistEntry>();
+  for (const specialist of specialists) {
+    if (!specialistsByRole.has(specialist.role)) specialistsByRole.set(specialist.role, specialist);
+  }
+  return specialistsByRole;
 }
 
 function agentNameToRole(name: string): CollaborationRole | null {

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -203,6 +203,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
   reorderTabs: (workspaceId, ids) => {
     const { tabs } = get();
     const byId = new Map(tabs.map((t) => [t.id, t]));
+    const idsToKeep = new Set(ids);
 
     // Split current tabs into "belongs to workspace" (reordered) and "other" (kept in place).
     const wsTabsInNewOrder: BrowserTab[] = [];
@@ -212,7 +213,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     }
     // Append any workspace tabs that got dropped (defensive).
     for (const t of tabs) {
-      if (t.workspaceId === workspaceId && !ids.includes(t.id)) wsTabsInNewOrder.push(t);
+      if (t.workspaceId === workspaceId && !idsToKeep.has(t.id)) wsTabsInNewOrder.push(t);
     }
 
     // Rebuild the flat list, slotting reordered workspace tabs into the
@@ -357,11 +358,13 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     }
 
     // Backfill: every workspace with tabs should have an active tab.
-    const workspaces = new Set(hydratedTabs.map((t) => t.workspaceId));
-    for (const ws of workspaces) {
+    const firstTabByWorkspace = new Map<string, BrowserTab>();
+    for (const tab of hydratedTabs) {
+      if (!firstTabByWorkspace.has(tab.workspaceId)) firstTabByWorkspace.set(tab.workspaceId, tab);
+    }
+    for (const [ws, first] of firstTabByWorkspace) {
       if (!resolvedActiveIds[ws]) {
-        const first = hydratedTabs.find((t) => t.workspaceId === ws);
-        if (first) resolvedActiveIds[ws] = first.id;
+        resolvedActiveIds[ws] = first.id;
       }
     }
 

--- a/apps/web-remote/src/components/ChatPanel.tsx
+++ b/apps/web-remote/src/components/ChatPanel.tsx
@@ -68,15 +68,14 @@ export function ChatPanel() {
     const imageFiles = files.filter((f) => f.type.startsWith('image/'));
     if (imageFiles.length === 0) return;
 
-    const newImages: PendingImage[] = [];
-    for (const file of imageFiles) {
+    const newImages = await Promise.all(imageFiles.map(async (file) => {
       const { data, mimeType } = await readFileAsBase64(file);
-      newImages.push({
+      return {
         data,
         mimeType,
         preview: URL.createObjectURL(file),
-      });
-    }
+      } satisfies PendingImage;
+    }));
     setPendingImages((prev) => [...prev, ...newImages]);
   }, []);
 


### PR DESCRIPTION
## Summary
- Parallelize independent image reads in web remote chat uploads
- Parallelize gateway shutdown tasks
- Replace repeated scans with indexed lookups in collaboration feed, browser tab hydration, and dev server liveness checks

## React Doctor
Before: 859 findings
After: 851 findings

Improved groups:
- async-await-in-loop: 10 -> 9
- async-parallel: 13 -> 12
- js-index-maps: 16 -> 11
- js-set-map-lookups: 20 -> 19

Skipped remaining React 19 deprecated API findings because they are in packages/ui shadcn components.

## Validation
- pnpm dlx react-doctor@latest --json --full --no-score
- pnpm test
- pnpm typecheck
