### PR TITLE
fix: import files when connecting empty remote workspace

### DIFF
--- a/apps/desktop/e2e/editor-vcs.contract.spec.ts
+++ b/apps/desktop/e2e/editor-vcs.contract.spec.ts
@@ -35,6 +35,7 @@ const expectedVcsMethods = [
   'addRemote',
   'setRemoteUrl',
   'removeRemote',
+  'checkoutRemote',
   'fetch',
   'push',
   'pushDryRun',

--- a/apps/desktop/electron/__tests__/features/vcs/core/remote-ops.test.ts
+++ b/apps/desktop/electron/__tests__/features/vcs/core/remote-ops.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { checkoutRemote } from '@electron/features/vcs/core/vcs-ops/remote-ops';
+import type { GitRunner } from '@electron/features/vcs/core/git-runner';
+
+function createRunner(results: Array<{ exitCode: number; stdout?: string; stderr?: string }>): GitRunner {
+  return {
+    ensureRepoInitialized: vi.fn().mockResolvedValue(undefined),
+    run: vi.fn().mockImplementation(async () => {
+      const result = results.shift();
+      return { exitCode: result?.exitCode ?? 0, stdout: result?.stdout ?? '', stderr: result?.stderr ?? '' };
+    }),
+  } as unknown as GitRunner;
+}
+
+describe('remote ops', () => {
+  it('treats reachable empty remotes as successful connects', async () => {
+    const runner = createRunner([
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 1 },
+      { exitCode: 0, stdout: '' },
+    ]);
+
+    await expect(checkoutRemote(runner, 'workspace-1', 'origin')).resolves.toEqual({
+      success: true,
+      message: 'Connected origin; no remote branches to import',
+    });
+    expect(runner.run).toHaveBeenCalledWith('workspace-1', ['fetch', 'origin'], 120_000);
+  });
+});

--- a/apps/desktop/electron/features/vcs/core/vcs-ops.ts
+++ b/apps/desktop/electron/features/vcs/core/vcs-ops.ts
@@ -15,6 +15,7 @@ import {
 } from './vcs-ops/bookmark-ops';
 import {
   addRemote,
+  checkoutRemote,
   listRemotes,
   removeRemote,
   resolvePushRemote,
@@ -162,6 +163,10 @@ export class VcsOps {
   /** Update the URL of an existing remote. */
   async setRemoteUrl(workspaceId: string, name: string, url: string): Promise<void> {
     return setRemoteUrl(this.runner, workspaceId, name, url);
+  }
+
+  async checkoutRemote(workspaceId: string, remote?: string): Promise<SyncResult> {
+    return checkoutRemote(this.runner, workspaceId, remote);
   }
 
   async fetch(workspaceId: string, remote?: string): Promise<SyncResult> {

--- a/apps/desktop/electron/features/vcs/core/vcs-ops/remote-ops.ts
+++ b/apps/desktop/electron/features/vcs/core/vcs-ops/remote-ops.ts
@@ -1,4 +1,4 @@
-import type { Remote } from '@sero-ai/common';
+import type { Remote, SyncResult } from '@sero-ai/common';
 
 import { parseRemotes } from '../../support/parsers';
 import type { GitRunner } from '../git-runner';
@@ -49,6 +49,72 @@ export async function setRemoteUrl(
   if (result.exitCode !== 0) {
     throw new Error(result.stderr || `Failed to update remote URL for '${name}'`);
   }
+}
+
+async function resolveRemoteBranch(
+  runner: GitRunner,
+  workspaceId: string,
+  remote: string,
+): Promise<string | null> {
+  await runner.run(workspaceId, ['remote', 'set-head', remote, '--auto'], 60_000);
+
+  const head = await runner.run(
+    workspaceId,
+    ['symbolic-ref', '--quiet', '--short', `refs/remotes/${remote}/HEAD`],
+    10_000,
+  );
+  const headBranch = head.stdout.trim().replace(`${remote}/`, '');
+  if (head.exitCode === 0 && headBranch) return headBranch;
+
+  const branches = await runner.run(
+    workspaceId,
+    ['branch', '-r', '--format=%(refname:short)'],
+    10_000,
+  );
+  if (branches.exitCode !== 0) return null;
+
+  const names = branches.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith(`${remote}/`) && !line.endsWith('/HEAD'))
+    .map((line) => line.slice(remote.length + 1));
+
+  return names.find((name) => name === 'main') ?? names.find((name) => name === 'master') ?? names[0] ?? null;
+}
+
+export async function checkoutRemote(
+  runner: GitRunner,
+  workspaceId: string,
+  remote = 'origin',
+): Promise<SyncResult> {
+  await runner.ensureRepoInitialized(workspaceId);
+
+  const fetch = await runner.run(workspaceId, ['fetch', remote], 120_000);
+  if (fetch.exitCode !== 0) {
+    return { success: false, message: fetch.stderr || `Failed to fetch ${remote}` };
+  }
+
+  const branch = await resolveRemoteBranch(runner, workspaceId, remote);
+  if (!branch) {
+    return { success: true, message: `Connected ${remote}; no remote branches to import` };
+  }
+
+  const remoteRef = `${remote}/${branch}`;
+  const checkout = await runner.run(workspaceId, ['checkout', '-B', branch, remoteRef], 120_000);
+  if (checkout.exitCode !== 0) {
+    return { success: false, message: checkout.stderr || `Failed to check out ${remoteRef}` };
+  }
+
+  const upstream = await runner.run(
+    workspaceId,
+    ['branch', '--set-upstream-to', remoteRef, branch],
+    10_000,
+  );
+  if (upstream.exitCode !== 0) {
+    return { success: true, message: `Checked out ${remoteRef}. ${upstream.stderr}`.trim() };
+  }
+
+  return { success: true, message: `Checked out ${remoteRef}` };
 }
 
 export async function resolvePushRemote(

--- a/apps/desktop/electron/ipc/integrations/vcs.ts
+++ b/apps/desktop/electron/ipc/integrations/vcs.ts
@@ -115,6 +115,21 @@ export function registerVcsHandlers(): void {
     vcsOps.removeRemote(wsId, name),
   );
 
+  ipcMain.handle(Ch.checkoutRemote, async (_e, wsId: string, remote?: string) => {
+    const result = await vcsOps.checkoutRemote(wsId, remote);
+    if (result.success) {
+      const refresh = await gitWorkspaceStateManager.refreshWorkspace(wsId);
+      if (!refresh.ok) {
+        gitWorkspaceStateManager.invalidateWorkspace(wsId, 'vcs:checkout-remote');
+      }
+      broadcastToWindows(IpcChannels.filetree.changed, {
+        workspaceId: wsId,
+        directories: ['/workspace'],
+      });
+    }
+    return result;
+  });
+
   ipcMain.handle(Ch.fetch, async (_e, wsId: string, remote?: string) =>
     vcsOps.fetch(wsId, remote),
   );
@@ -176,4 +191,3 @@ export function registerVcsHandlers(): void {
     vcsOps.getOperationLog(wsId, limit ?? 20),
   );
 }
-

--- a/apps/desktop/electron/preload/api/workbench.ts
+++ b/apps/desktop/electron/preload/api/workbench.ts
@@ -77,6 +77,8 @@ export const vcsBridge = {
     ipcRenderer.invoke(IpcChannels.vcs.setRemoteUrl, workspaceId, name, url),
   removeRemote: (workspaceId: string, name: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.vcs.removeRemote, workspaceId, name),
+  checkoutRemote: (workspaceId: string, remote?: string): Promise<SyncResult> =>
+    ipcRenderer.invoke(IpcChannels.vcs.checkoutRemote, workspaceId, remote),
   fetch: (workspaceId: string, remote?: string): Promise<SyncResult> =>
     ipcRenderer.invoke(IpcChannels.vcs.fetch, workspaceId, remote),
   push: (workspaceId: string, bookmark?: string, changeId?: string): Promise<SyncResult> =>

--- a/apps/desktop/src/components/layout/git-remote/workflow.test.ts
+++ b/apps/desktop/src/components/layout/git-remote/workflow.test.ts
@@ -17,6 +17,10 @@ const seroBridge = {
     remotes: vi.fn(),
     addRemote: vi.fn(),
     setRemoteUrl: vi.fn(),
+    checkoutRemote: vi.fn(),
+  },
+  editor: {
+    listFiles: vi.fn(),
   },
 };
 
@@ -25,6 +29,10 @@ const originalSeroDescriptor = Object.getOwnPropertyDescriptor(window, 'sero');
 describe('git remote workflow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    seroBridge.vcs.addRemote.mockResolvedValue(undefined);
+    seroBridge.vcs.setRemoteUrl.mockResolvedValue(undefined);
+    seroBridge.vcs.checkoutRemote.mockResolvedValue({ success: true, message: 'checked out origin/main' });
+    seroBridge.editor.listFiles.mockResolvedValue([]);
     Object.defineProperty(window, 'sero', {
       configurable: true,
       value: seroBridge,
@@ -102,6 +110,71 @@ describe('git remote workflow', () => {
     });
     expect(seroBridge.vcs.addRemote).toHaveBeenCalledWith('workspace-1', 'origin', 'git@github.com:octocat/my-workspace.git');
     expect(seroBridge.vcs.setRemoteUrl).toHaveBeenCalledWith('workspace-1', 'origin', 'git@github.com:octocat/my-workspace.git');
+  });
+
+  it('imports repository files for an empty workspace when requested', async () => {
+    seroBridge.editor.listFiles.mockResolvedValue([
+      { name: '.sero-workspace.json', type: 'file', size: 32 },
+    ]);
+
+    const result = await connectOrigin({
+      workspaceId: 'workspace-1',
+      url: 'https://github.com/octocat/my-workspace.git',
+      importIfEmpty: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://github.com/octocat/my-workspace.git',
+      webUrl: 'https://github.com/octocat/my-workspace',
+      updatedExisting: false,
+    });
+    expect(seroBridge.vcs.checkoutRemote).toHaveBeenCalledWith('workspace-1', 'origin');
+  });
+
+  it('leaves non-empty workspaces unchanged when connecting origin', async () => {
+    seroBridge.editor.listFiles.mockResolvedValue([
+      { name: 'package.json', type: 'file', size: 128 },
+    ]);
+
+    const result = await connectOrigin({
+      workspaceId: 'workspace-1',
+      url: 'https://github.com/octocat/my-workspace.git',
+      importIfEmpty: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://github.com/octocat/my-workspace.git',
+      webUrl: 'https://github.com/octocat/my-workspace',
+      updatedExisting: false,
+    });
+    expect(seroBridge.vcs.checkoutRemote).not.toHaveBeenCalled();
+  });
+
+  it('keeps the origin connected when checkout import fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    seroBridge.editor.listFiles.mockResolvedValue([]);
+    seroBridge.vcs.checkoutRemote.mockResolvedValue({ success: false, message: 'checkout failed' });
+
+    const result = await connectOrigin({
+      workspaceId: 'workspace-1',
+      url: 'https://github.com/octocat/my-workspace.git',
+      importIfEmpty: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://github.com/octocat/my-workspace.git',
+      webUrl: 'https://github.com/octocat/my-workspace',
+      updatedExisting: false,
+      warning: "Connected, but Sero couldn't import files: checkout failed",
+    });
+    expect(warn).toHaveBeenCalledWith(
+      '[git-remote] Remote connected, but import failed:',
+      'checkout failed',
+    );
+    warn.mockRestore();
   });
 
   it('reads and parses the current origin from vcs remotes', async () => {

--- a/apps/desktop/src/components/layout/git-remote/workflow.ts
+++ b/apps/desktop/src/components/layout/git-remote/workflow.ts
@@ -35,6 +35,7 @@ export type ConnectOriginResult =
       url: string;
       webUrl?: string;
       updatedExisting: boolean;
+      warning?: string;
     }
   | {
       ok: false;
@@ -151,25 +152,46 @@ export async function createGitHubOrigin({
 export async function connectOrigin({
   workspaceId,
   url,
+  importIfEmpty,
 }: {
   workspaceId: string;
   url: string;
+  importIfEmpty?: boolean;
 }): Promise<ConnectOriginResult> {
+  let connected: Extract<ConnectOriginResult, { ok: true }>;
   try {
     await window.sero.vcs.addRemote(workspaceId, 'origin', url);
-    return { ok: true, url, webUrl: toGitHubWebUrl(url), updatedExisting: false };
+    connected = { ok: true, url, webUrl: toGitHubWebUrl(url), updatedExisting: false };
   } catch (error) {
     const message = toErrorMessage(error, 'Failed to connect remote');
     if (!message.includes('already exists')) {
       return { ok: false, message };
     }
+    try {
+      await window.sero.vcs.setRemoteUrl(workspaceId, 'origin', url);
+      connected = { ok: true, url, webUrl: toGitHubWebUrl(url), updatedExisting: true };
+    } catch (setError) {
+      return { ok: false, message: toErrorMessage(setError, 'Failed to update remote URL') };
+    }
   }
 
+  if (!importIfEmpty || await hasVisibleWorkspaceFiles(workspaceId)) return connected;
+
+  const checkout = await window.sero.vcs.checkoutRemote(workspaceId, 'origin');
+  if (checkout.success) return connected;
+  console.warn('[git-remote] Remote connected, but import failed:', checkout.message);
+  return { ...connected, warning: `Connected, but Sero couldn't import files: ${checkout.message}` };
+}
+
+async function hasVisibleWorkspaceFiles(workspaceId: string): Promise<boolean> {
   try {
-    await window.sero.vcs.setRemoteUrl(workspaceId, 'origin', url);
-    return { ok: true, url, webUrl: toGitHubWebUrl(url), updatedExisting: true };
-  } catch (error) {
-    return { ok: false, message: toErrorMessage(error, 'Failed to update remote URL') };
+    const entries = await window.sero.editor.listFiles(workspaceId, '/workspace');
+    return entries.some((entry) => !isWorkspaceScaffoldFile(entry.name));
+  } catch {
+    return false;
   }
 }
 
+function isWorkspaceScaffoldFile(name: string): boolean {
+  return name === '.git' || name === '.sero-workspace.json' || name === '.DS_Store';
+}

--- a/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx
+++ b/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx
@@ -16,6 +16,7 @@ const seroBridge = {
   vcs: {
     addRemote: vi.fn(),
     setRemoteUrl: vi.fn(),
+    checkoutRemote: vi.fn(),
   },
   github: {
     status: vi.fn(),
@@ -24,6 +25,9 @@ const seroBridge = {
     login: vi.fn(),
     logout: vi.fn(),
     cancel: vi.fn(),
+  },
+  editor: {
+    listFiles: vi.fn(),
   },
 };
 
@@ -85,6 +89,8 @@ describe('GitRemotePublishSection', () => {
 
     seroBridge.vcs.addRemote.mockResolvedValue(undefined);
     seroBridge.vcs.setRemoteUrl.mockResolvedValue(undefined);
+    seroBridge.vcs.checkoutRemote.mockResolvedValue({ success: true, message: 'checked out origin/main' });
+    seroBridge.editor.listFiles.mockResolvedValue([]);
     seroBridge.github.status.mockImplementation(async () => githubStatus);
     seroBridge.github.createRepo.mockResolvedValue({
       success: true,

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
@@ -18,6 +18,7 @@ const seroBridge = {
     remotes: vi.fn(),
     addRemote: vi.fn(),
     setRemoteUrl: vi.fn(),
+    checkoutRemote: vi.fn(),
   },
   github: {
     status: vi.fn(),
@@ -26,6 +27,9 @@ const seroBridge = {
     login: vi.fn(),
     logout: vi.fn(),
     cancel: vi.fn(),
+  },
+  editor: {
+    listFiles: vi.fn(),
   },
 };
 
@@ -99,6 +103,8 @@ describe('RemoteOriginManager', () => {
     seroBridge.vcs.remotes.mockResolvedValue([]);
     seroBridge.vcs.addRemote.mockResolvedValue(undefined);
     seroBridge.vcs.setRemoteUrl.mockResolvedValue(undefined);
+    seroBridge.vcs.checkoutRemote.mockResolvedValue({ success: true, message: 'checked out origin/main' });
+    seroBridge.editor.listFiles.mockResolvedValue([]);
     seroBridge.github.status.mockImplementation(async () => githubStatus);
     seroBridge.github.createRepo.mockResolvedValue({
       success: true,
@@ -343,5 +349,27 @@ describe('RemoteOriginManager', () => {
       });
       expect(document.body.textContent).toContain('octocat/alpha-repo');
     });
+  });
+
+  it('shows a non-blocking warning when origin connects but import fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    seroBridge.vcs.checkoutRemote.mockResolvedValue({ success: false, message: 'checkout failed' });
+
+    await renderManager();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Connect existing repository');
+    });
+
+    await clickButton('Connect existing repository');
+    await setInputValue('remote-url', 'https://github.com/octocat/workspace-1.git');
+    await clickButton('Connect Repository');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('octocat/workspace-1');
+      expect(document.body.textContent).toContain("Connected, but Sero couldn't import files: checkout failed");
+    });
+
+    warn.mockRestore();
   });
 });

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
@@ -49,12 +49,14 @@ export function RemoteOriginManager({
   const [view, setView] = useState<View>('loading');
   const [origin, setOrigin] = useState<GitRemoteOriginInfo | null>(null);
   const [originLoadError, setOriginLoadError] = useState<string | null>(null);
+  const [originWarning, setOriginWarning] = useState<string | null>(null);
   const prevOpenRef = useRef(false);
 
   const loadOrigin = useCallback(async () => {
     setView('loading');
     setOrigin(null);
     setOriginLoadError(null);
+    setOriginWarning(null);
 
     const result = await fetchOriginInfo(workspace.id);
     if (!result.ok) {
@@ -75,8 +77,9 @@ export function RemoteOriginManager({
     prevOpenRef.current = open;
   }, [loadOrigin, open]);
 
-  const handleOriginSet = (url: string) => {
+  const handleOriginSet = (url: string, warning?: string) => {
     setOrigin(toOriginInfo(url));
+    setOriginWarning(warning ?? null);
     setView('connected');
   };
 
@@ -127,6 +130,7 @@ export function RemoteOriginManager({
         {view === 'connected' && origin && (
           <ConnectedView
             origin={origin}
+            warning={originWarning}
             onChangeOrigin={() => setView('choose')}
             onClose={handleClose}
           />

--- a/apps/desktop/src/components/layout/workspace/remote-origin-views.tsx
+++ b/apps/desktop/src/components/layout/workspace/remote-origin-views.tsx
@@ -84,7 +84,7 @@ export function ChooseView({
         </div>
         <div className="flex flex-col">
           <span className="text-sm font-medium text-[var(--text-primary)]">Connect existing repository</span>
-          <span className="text-xs text-[var(--text-muted)]">Add an existing remote URL as origin</span>
+          <span className="text-xs text-[var(--text-muted)]">Import files when the workspace is empty</span>
         </div>
       </button>
     </div>
@@ -309,7 +309,7 @@ export function ConnectExistingView({
 }: {
   workspace: WorkspaceInfo;
   onBack: () => void;
-  onConnected: (url: string) => void;
+  onConnected: (url: string, warning?: string) => void;
 }) {
   const [url, setUrl] = useState('');
   const [isConnecting, setIsConnecting] = useState(false);
@@ -322,9 +322,9 @@ export function ConnectExistingView({
     setIsConnecting(true);
     setError(null);
     try {
-      const result = await connectOrigin({ workspaceId: workspace.id, url: trimmed });
+      const result = await connectOrigin({ workspaceId: workspace.id, url: trimmed, importIfEmpty: true });
       if (result.ok) {
-        onConnected(result.url);
+        onConnected(result.url, result.warning);
         return;
       }
 
@@ -357,7 +357,7 @@ export function ConnectExistingView({
           disabled={isConnecting}
         />
         <span className="text-xs text-[var(--text-muted)]">
-          HTTPS or SSH URL for the remote repository
+          Empty workspaces are fetched and checked out automatically
         </span>
       </div>
 
@@ -367,9 +367,9 @@ export function ConnectExistingView({
         <Button variant="ghost" onClick={onBack} disabled={isConnecting}>Cancel</Button>
         <Button onClick={handleConnect} disabled={isConnecting || !url.trim()}>
           {isConnecting ? (
-            <><Loader2 className="mr-1.5 size-3.5 animate-spin" />Connecting…</>
+            <><Loader2 className="mr-1.5 size-3.5 animate-spin" />Importing…</>
           ) : (
-            'Connect'
+            'Connect Repository'
           )}
         </Button>
       </div>
@@ -381,10 +381,12 @@ export function ConnectExistingView({
 
 export function ConnectedView({
   origin,
+  warning,
   onChangeOrigin,
   onClose,
 }: {
   origin: OriginInfo;
+  warning?: string | null;
   onChangeOrigin: () => void;
   onClose: () => void;
 }) {
@@ -417,6 +419,8 @@ export function ConnectedView({
         )}
       </div>
 
+      {warning && <WarningBanner message={warning} />}
+
       <div className="flex justify-between">
         <Button variant="ghost" size="sm" onClick={onChangeOrigin}>
           <Pencil className="mr-1.5 size-3" />
@@ -448,6 +452,10 @@ function ErrorBanner({ message }: { message: string }) {
       {message}
     </p>
   );
+}
+
+function WarningBanner({ message }: { message: string }) {
+  return <p className="rounded-md bg-status-warning-muted p-2 text-xs text-status-warning">{message}</p>;
 }
 
 function VisibilityButton({

--- a/apps/desktop/src/types/electron-workspace.d.ts
+++ b/apps/desktop/src/types/electron-workspace.d.ts
@@ -200,6 +200,7 @@ export interface SeroVcsAPI {
   addRemote(wsId: string, name: string, url: string): Promise<void>;
   setRemoteUrl(wsId: string, name: string, url: string): Promise<void>;
   removeRemote(wsId: string, name: string): Promise<void>;
+  checkoutRemote(wsId: string, remote?: string): Promise<SyncResult>;
   fetch(wsId: string, remote?: string): Promise<SyncResult>;
   push(wsId: string, bookmark?: string, changeId?: string): Promise<SyncResult>;
   pushDryRun(wsId: string, bookmark?: string, changeId?: string): Promise<PushPreview>;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -309,6 +309,7 @@ export const IpcChannels = {
     addRemote: 'sero:vcs:add-remote',
     setRemoteUrl: 'sero:vcs:set-remote-url',
     removeRemote: 'sero:vcs:remove-remote',
+    checkoutRemote: 'sero:vcs:checkout-remote',
     fetch: 'sero:vcs:fetch',
     push: 'sero:vcs:push',
     pushDryRun: 'sero:vcs:push-dry-run',


### PR DESCRIPTION
## Summary
- import remote repository files when connecting an existing origin to an empty workspace
- leave non-empty workspaces unchanged and only connect origin
- add checkoutRemote IPC/preload API and refresh explorer file tree after import

## Tests
- pnpm --filter @sero/desktop exec vitest run src/components/layout/git-remote/workflow.test.ts src/components/layout/workspace/RemoteOriginManager.test.tsx src/components/layout/titlebar/git/GitRemotePublishSection.test.tsx
- pnpm typecheck

## Docs
- No docs-site update needed; this is a small setup-flow behavior fix.