### PR TITLE
feat: add caveman onboarding mode

### DIFF
--- a/apps/desktop/electron/__tests__/features/profile/manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/profile/manager.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 describe('profile manager path validation', () => {
   let tmpHome: string | null = null;
   const originalHome = process.env.HOME;
+  const originalSeroHomeOverride = process.env.SERO_HOME_OVERRIDE;
 
   async function importManager() {
     if (!tmpHome) {
@@ -15,12 +16,18 @@ describe('profile manager path validation', () => {
 
     vi.resetModules();
     process.env.HOME = tmpHome;
+    delete process.env.SERO_HOME_OVERRIDE;
     return import('@electron/features/profile/manager');
   }
 
   afterEach(async () => {
     vi.resetModules();
     process.env.HOME = originalHome;
+    if (originalSeroHomeOverride === undefined) {
+      delete process.env.SERO_HOME_OVERRIDE;
+    } else {
+      process.env.SERO_HOME_OVERRIDE = originalSeroHomeOverride;
+    }
 
     if (tmpHome) {
       await fs.rm(tmpHome, { recursive: true, force: true });
@@ -38,6 +45,47 @@ describe('profile manager path validation', () => {
 
     expect(defaultProfile.path).toBe(path.join(tmpHome, '.sero-ui'));
     expect(workProfile.path).toBe(path.join(tmpHome, '.sero-ui', 'profiles', 'work'));
+  });
+
+  it('uses SERO_HOME_OVERRIDE as the isolated profile registry root', async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'profile-manager-override-'));
+
+    vi.resetModules();
+    process.env.HOME = path.join(tmpHome, 'real-home');
+    process.env.SERO_HOME_OVERRIDE = path.join(tmpHome, 'isolated-home');
+
+    const { profileManager, PROFILE_REGISTRY_PATH } = await import('@electron/features/profile/manager');
+
+    const defaultProfile = await profileManager.create('Default');
+    const workProfile = await profileManager.create('Work');
+
+    expect(PROFILE_REGISTRY_PATH).toBe(path.join(tmpHome, 'isolated-home', 'profiles.json'));
+    expect(defaultProfile.path).toBe(path.join(tmpHome, 'isolated-home', 'profiles', 'default'));
+    expect(workProfile.path).toBe(path.join(tmpHome, 'isolated-home', 'profiles', 'work'));
+  });
+
+  it('repairs isolated profiles that were created at the override root', async () => {
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'profile-manager-override-repair-'));
+    const isolatedHome = path.join(tmpHome, 'isolated-home');
+    await fs.mkdir(isolatedHome, { recursive: true });
+    await fs.writeFile(path.join(isolatedHome, 'profiles.json'), JSON.stringify({
+      version: 1,
+      activeProfileId: 'contaminated',
+      profiles: [{
+        id: 'contaminated',
+        name: 'Contaminated',
+        path: isolatedHome,
+        createdAt: '2026-06-02T00:00:00.000Z',
+      }],
+    }, null, 2));
+
+    vi.resetModules();
+    process.env.HOME = path.join(tmpHome, 'real-home');
+    process.env.SERO_HOME_OVERRIDE = isolatedHome;
+
+    const { profileManager } = await import('@electron/features/profile/manager');
+
+    expect(profileManager.getActive()?.path).toBe(path.join(isolatedHome, 'profiles', 'contaminated'));
   });
 
   it('rejects duplicate and overlapping custom profile roots', async () => {

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/browser-pack/installer.test.ts
@@ -9,6 +9,7 @@ const testEnv = vi.hoisted(() => {
   return {
     SERO_AGENT_DIR: `${root}/agent`,
     SERO_FIXED_ROOT: root,
+    SERO_HOST_ARTIFACTS_ROOT: root,
     SERO_HOME: root,
   };
 });

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/manager.test.ts
@@ -9,6 +9,7 @@ const testEnv = vi.hoisted(() => {
   return {
     SERO_AGENT_DIR: `${root}/agent`,
     SERO_FIXED_ROOT: root,
+    SERO_HOST_ARTIFACTS_ROOT: root,
     SERO_HOME: root,
   };
 });

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/storage.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/toolchains/storage.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { describe, expect, it } from 'vitest';
 
-import { SERO_AGENT_DIR, SERO_FIXED_ROOT, SERO_HOME } from '@electron/platform/env';
+import { SERO_AGENT_DIR, SERO_FIXED_ROOT, SERO_HOME, SERO_HOST_ARTIFACTS_ROOT } from '@electron/platform/env';
 import {
   INSTALLED_MARKER,
   STAGING_SUFFIX,
@@ -17,15 +17,15 @@ import {
 } from '@electron/features/workspace/runtime/toolchains/storage';
 
 function expectUnderToolchainsRoot(value: string, version = '2026.05.16'): void {
-  const expectedRoot = path.join(SERO_FIXED_ROOT, 'toolchains', version);
+  const expectedRoot = path.join(SERO_HOST_ARTIFACTS_ROOT, 'toolchains', version);
   expect(path.relative(expectedRoot, value).startsWith('..')).toBe(false);
 }
 
 describe('toolchain storage paths', () => {
-  it('roots managed toolchains under SERO_FIXED_ROOT/toolchains', () => {
-    expect(toolchainsRoot()).toBe(path.join(SERO_FIXED_ROOT, 'toolchains'));
+  it('roots managed toolchains under the host artifacts root', () => {
+    expect(toolchainsRoot()).toBe(path.join(SERO_HOST_ARTIFACTS_ROOT, 'toolchains'));
     expect(toolchainVersionRoot('2026.05.16')).toBe(
-      path.join(SERO_FIXED_ROOT, 'toolchains', '2026.05.16'),
+      path.join(SERO_HOST_ARTIFACTS_ROOT, 'toolchains', '2026.05.16'),
     );
   });
 
@@ -38,13 +38,13 @@ describe('toolchain storage paths', () => {
 
   it('builds activation marker and staging paths deterministically', () => {
     expect(installedMarkerPath('2026.05.16')).toBe(
-      path.join(SERO_FIXED_ROOT, 'toolchains', '2026.05.16', INSTALLED_MARKER),
+      path.join(SERO_HOST_ARTIFACTS_ROOT, 'toolchains', '2026.05.16', INSTALLED_MARKER),
     );
     expect(toolchainStagingRoot('2026.05.16')).toBe(
-      `${path.join(SERO_FIXED_ROOT, 'toolchains', '2026.05.16')}${STAGING_SUFFIX}`,
+      `${path.join(SERO_HOST_ARTIFACTS_ROOT, 'toolchains', '2026.05.16')}${STAGING_SUFFIX}`,
     );
     expect(artifactStagingPath('2026.05.16', 'node')).toBe(
-      path.join(SERO_FIXED_ROOT, 'toolchains', `2026.05.16${STAGING_SUFFIX}`, 'node'),
+      path.join(SERO_HOST_ARTIFACTS_ROOT, 'toolchains', `2026.05.16${STAGING_SUFFIX}`, 'node'),
     );
   });
 

--- a/apps/desktop/electron/__tests__/platform/env.test.ts
+++ b/apps/desktop/electron/__tests__/platform/env.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import os from 'os';
 
 const mocks = vi.hoisted(() => ({
   readFileSync: vi.fn(),
@@ -30,6 +31,7 @@ describe('staged env bootstrap', () => {
     vi.resetModules();
     delete process.env.SERO_HOME;
     delete process.env.PI_CODING_AGENT_DIR;
+    delete process.env.SERO_HOST_ARTIFACTS_ROOT_OVERRIDE;
     delete process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
     process.env.SERO_HOME_OVERRIDE = '/tmp/sero-profile';
@@ -43,7 +45,10 @@ describe('staged env bootstrap', () => {
     mocks.writeFileSync.mockReset();
     mocks.mkdirSync.mockReset();
     mocks.migrateExistingInstall.mockReset();
-    mocks.readRegistryLoadSync.mockReset();
+    mocks.readRegistryLoadSync.mockReset().mockReturnValue({
+      registry: { version: 1, activeProfileId: null, profiles: [] },
+      error: null,
+    });
     mocks.readRegistrySync.mockReset();
   });
 
@@ -60,6 +65,44 @@ describe('staged env bootstrap', () => {
     expect(process.env.SERO_HOME).toBe('/tmp/sero-profile');
     expect(process.env.PI_CODING_AGENT_DIR).toBe('/tmp/sero-profile/agent');
     expect(process.env.OPENAI_API_KEY).toBe('test-key');
+  });
+
+  it('resolves the active profile path inside SERO_HOME_OVERRIDE', async () => {
+    mocks.readRegistryLoadSync.mockReturnValue({
+      registry: {
+        version: 1,
+        activeProfileId: 'work',
+        profiles: [{
+          id: 'work',
+          name: 'Work',
+          path: '/tmp/sero-profile/profiles/work',
+          createdAt: '2026-06-02T00:00:00.000Z',
+        }],
+      },
+      error: null,
+    });
+    mocks.readFileSync.mockReset().mockImplementation((filePath: string) => {
+      if (filePath === '/tmp/sero-profile/profiles/work/agent/.env') return '';
+      throw new Error(`Unexpected read: ${filePath}`);
+    });
+
+    const env = await import('@electron/platform/env');
+
+    expect(env.SERO_FIXED_ROOT).toBe('/tmp/sero-profile');
+    expect(env.SERO_HOST_ARTIFACTS_ROOT).toBe(`${os.homedir()}/.sero-ui`);
+    expect(env.SERO_HOME).toBe('/tmp/sero-profile/profiles/work');
+    expect(env.SERO_AGENT_DIR).toBe('/tmp/sero-profile/profiles/work/agent');
+    expect(env.ACTIVE_PROFILE_ID).toBe('work');
+    expect(mocks.migrateExistingInstall).not.toHaveBeenCalled();
+  });
+
+  it('allows tests to isolate host artifacts separately from profile state', async () => {
+    process.env.SERO_HOST_ARTIFACTS_ROOT_OVERRIDE = '/tmp/host-artifacts';
+
+    const env = await import('@electron/platform/env');
+
+    expect(env.SERO_FIXED_ROOT).toBe('/tmp/sero-profile');
+    expect(env.SERO_HOST_ARTIFACTS_ROOT).toBe('/tmp/host-artifacts');
   });
 
   it('clears only profile-loaded env values before profile relaunch', async () => {

--- a/apps/desktop/electron/__tests__/plugins/memory-context-injector-auto-retrieve.test.ts
+++ b/apps/desktop/electron/__tests__/plugins/memory-context-injector-auto-retrieve.test.ts
@@ -26,6 +26,8 @@ vi.mock('@plugins/sero-memory-plugin/extension/bootstrap', () => ({
 }));
 
 vi.mock('@plugins/sero-memory-plugin/extension/memory-manager', () => ({
+  getUserPath: () => '/tmp/memory-root/USER.md',
+  readFile: vi.fn(async () => null),
   resolveMemoryRoot: () => '/tmp/memory-root',
 }));
 

--- a/apps/desktop/electron/features/profile/manager.ts
+++ b/apps/desktop/electron/features/profile/manager.ts
@@ -26,6 +26,9 @@ function resolveSeroRoot(): string {
   if (process.env.NODE_ENV === 'test' && process.env.SERO_FIXED_ROOT_OVERRIDE) {
     return path.resolve(process.env.SERO_FIXED_ROOT_OVERRIDE);
   }
+  if (process.env.SERO_HOME_OVERRIDE) {
+    return path.resolve(process.env.SERO_HOME_OVERRIDE);
+  }
   return path.join(os.homedir(), '.sero-ui');
 }
 
@@ -69,6 +72,14 @@ function isAllowedDefaultProfileContainment(
   candidatePath: string,
 ): boolean {
   return existingPath === DEFAULT_PROFILE_PATH && isManagedNestedProfilePath(candidatePath);
+}
+
+function slugForProfileName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || 'profile';
 }
 
 function isProfileEntry(value: unknown): value is ProfileEntry {
@@ -141,6 +152,38 @@ function writeRegistrySync(registry: ProfileRegistry): void {
   writeFileSync(REGISTRY_PATH, JSON.stringify(registry, null, 2) + '\n', 'utf8');
 }
 
+function defaultManagedPathForName(name: string, existingProfiles: ProfileEntry[]): string {
+  const slug = slugForProfileName(name);
+  let candidate = path.join(MANAGED_PROFILES_ROOT, slug);
+  let suffix = 1;
+  while (existingProfiles.some((p) => p.path === candidate)) {
+    candidate = path.join(MANAGED_PROFILES_ROOT, `${slug}-${suffix}`);
+    suffix++;
+  }
+  return candidate;
+}
+
+function repairIsolatedRootProfiles(registry: ProfileRegistry): boolean {
+  if (!process.env.SERO_HOME_OVERRIDE) return false;
+
+  let changed = false;
+  const repairedProfiles: ProfileEntry[] = [];
+  for (const profile of registry.profiles) {
+    if (path.resolve(profile.path) !== DEFAULT_PROFILE_PATH) {
+      repairedProfiles.push(profile);
+      continue;
+    }
+
+    const repairedPath = defaultManagedPathForName(profile.name, repairedProfiles);
+    repairedProfiles.push({ ...profile, path: repairedPath });
+    mkdirSync(path.join(repairedPath, 'agent'), { recursive: true });
+    changed = true;
+  }
+
+  if (changed) registry.profiles = repairedProfiles;
+  return changed;
+}
+
 /** Write registry asynchronously (for non-critical-path mutations). */
 async function writeRegistryAsync(registry: ProfileRegistry): Promise<void> {
   await fs.mkdir(SERO_ROOT, { recursive: true });
@@ -182,6 +225,9 @@ class ProfileManager {
     const result = readRegistryLoadSync();
     this.registry = result.registry;
     this.loadError = result.error;
+    if (!this.loadError && repairIsolatedRootProfiles(this.registry)) {
+      writeRegistrySync(this.registry);
+    }
   }
 
   /** Reload registry from disk (e.g. after external modification). */
@@ -346,17 +392,19 @@ class ProfileManager {
 
   /** Generate a default path for a new profile. */
   private defaultPathForName(name: string): string {
-    // First profile gets the default SERO_ROOT
+    // Source-dev/test isolation roots may already contain scratch data. Keep
+    // every created profile under profiles/<slug> so fresh profiles are empty.
+    if (process.env.SERO_HOME_OVERRIDE) {
+      return defaultManagedPathForName(name, this.registry.profiles);
+    }
+
+    // First production profile gets the default SERO_ROOT for migration/back-compat.
     if (this.registry.profiles.length === 0) {
       return DEFAULT_PROFILE_PATH;
     }
 
     // Subsequent profiles go under ~/.sero-ui/profiles/<slug>/
-    const slug = name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      || 'profile';
+    const slug = slugForProfileName(name);
 
     let candidate = path.join(SERO_ROOT, 'profiles', slug);
     let suffix = 1;

--- a/apps/desktop/electron/features/workspace/runtime/toolchains/storage.ts
+++ b/apps/desktop/electron/features/workspace/runtime/toolchains/storage.ts
@@ -1,14 +1,14 @@
 import fs from 'fs';
 import path from 'path';
 
-import { SERO_FIXED_ROOT } from '@electron/platform/env';
+import { SERO_HOST_ARTIFACTS_ROOT } from '@electron/platform/env';
 
 export const TOOLCHAINS_DIR_NAME = 'toolchains';
 export const INSTALLED_MARKER = '.installed';
 export const STAGING_SUFFIX = '.staging';
 
 export function toolchainsRoot(): string {
-  return path.join(SERO_FIXED_ROOT, TOOLCHAINS_DIR_NAME);
+  return path.join(SERO_HOST_ARTIFACTS_ROOT, TOOLCHAINS_DIR_NAME);
 }
 
 export function assertValidToolchainVersion(version: string): void {

--- a/apps/desktop/electron/platform/env/index.ts
+++ b/apps/desktop/electron/platform/env/index.ts
@@ -31,11 +31,27 @@ function resolveSeroFixedRoot(): string {
   if (process.env.NODE_ENV === 'test' && process.env.SERO_FIXED_ROOT_OVERRIDE) {
     return path.resolve(process.env.SERO_FIXED_ROOT_OVERRIDE);
   }
+  if (process.env.SERO_HOME_OVERRIDE) {
+    return path.resolve(process.env.SERO_HOME_OVERRIDE);
+  }
   return path.join(os.homedir(), '.sero-ui');
 }
 
 /** The fixed Sero root directory. profiles.json always lives here. */
 export const SERO_FIXED_ROOT = resolveSeroFixedRoot();
+
+function resolveHostArtifactsRoot(): string {
+  if (process.env.NODE_ENV === 'test' && process.env.SERO_FIXED_ROOT_OVERRIDE) {
+    return path.resolve(process.env.SERO_FIXED_ROOT_OVERRIDE);
+  }
+  if (process.env.SERO_HOST_ARTIFACTS_ROOT_OVERRIDE) {
+    return path.resolve(process.env.SERO_HOST_ARTIFACTS_ROOT_OVERRIDE);
+  }
+  return path.join(os.homedir(), '.sero-ui');
+}
+
+/** Machine-level host artifacts shared by all profiles and source-dev roots. */
+export const SERO_HOST_ARTIFACTS_ROOT = resolveHostArtifactsRoot();
 
 // ── Profile-aware SERO_HOME resolution ──────────────────────
 
@@ -43,14 +59,15 @@ export const SERO_FIXED_ROOT = resolveSeroFixedRoot();
  * Resolve the active profile's SERO_HOME.
  *
  * Priority:
- * 1. SERO_HOME_OVERRIDE env var (tests and isolated source-dev launcher)
- * 2. Active profile from profiles.json
+ * 1. Active profile from profiles.json under SERO_HOME_OVERRIDE when set
+ * 2. Active profile from profiles.json under ~/.sero-ui
  * 3. Migration of existing install
  * 4. Fallback to ~/.sero-ui/ (fresh install, pre-setup)
  *
- * NOTE: SERO_HOME_OVERRIDE bypasses the profile registry, so ACTIVE_PROFILE_ID
- * is null in isolated source-dev mode. We deliberately do NOT check
- * process.env.SERO_HOME here.
+ * SERO_HOME_OVERRIDE changes the fixed registry root used by source-dev and
+ * tests. It must not bypass profile resolution, otherwise renderer profile
+ * state and extension/workspace paths drift apart after profile switching.
+ * We deliberately do NOT check process.env.SERO_HOME here.
  * loadSeroEnv() sets SERO_HOME for extensions to read, and app.relaunch()
  * inherits env vars from the parent process. If we checked SERO_HOME,
  * profile switching would be silently ignored after a relaunch.
@@ -112,7 +129,9 @@ function repairActiveProfile(
 }
 
 function resolveProfileHomeFromRegistry(): string {
-  migrateExistingInstall();
+  if (!process.env.SERO_HOME_OVERRIDE) {
+    migrateExistingInstall();
+  }
 
   const registry = loadRegistryForStartup();
   if (registry.activeProfileId) {
@@ -137,9 +156,6 @@ function resolveProfileHomeFromRegistry(): string {
 }
 
 function resolveSeroHome(): string {
-  if (process.env.SERO_HOME_OVERRIDE) {
-    return process.env.SERO_HOME_OVERRIDE;
-  }
   return resolveProfileHomeFromRegistry();
 }
 
@@ -147,9 +163,6 @@ function readPostResolveRegistry(seroHome: string): {
   activeProfileId: string | null;
   profiles: Array<{ id: string }>;
 } {
-  if (process.env.SERO_HOME_OVERRIDE || seroHome === process.env.SERO_HOME_OVERRIDE) {
-    return { activeProfileId: null, profiles: [] };
-  }
   return loadRegistryForStartup();
 }
 

--- a/apps/desktop/electron/platform/env/index.ts
+++ b/apps/desktop/electron/platform/env/index.ts
@@ -159,7 +159,7 @@ function resolveSeroHome(): string {
   return resolveProfileHomeFromRegistry();
 }
 
-function readPostResolveRegistry(seroHome: string): {
+function readPostResolveRegistry(): {
   activeProfileId: string | null;
   profiles: Array<{ id: string }>;
 } {
@@ -170,7 +170,7 @@ function resolveStartupEnv(): ResolvedSeroEnv {
   const seroHome = resolveSeroHome();
   const seroAgentDir = path.join(seroHome, 'agent');
   const envPath = path.join(seroAgentDir, '.env');
-  const postResolveRegistry = readPostResolveRegistry(seroHome);
+  const postResolveRegistry = readPostResolveRegistry();
 
   return {
     seroHome,

--- a/apps/desktop/src/components/profiles/OnboardingWizard.test.tsx
+++ b/apps/desktop/src/components/profiles/OnboardingWizard.test.tsx
@@ -78,6 +78,7 @@ describe('OnboardingWizard', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseLaunchingDialogVisibility.mockReturnValue(false);
     Object.defineProperty(window, 'sero', {
       configurable: true,
       value: {
@@ -203,6 +204,37 @@ describe('OnboardingWizard', () => {
     const dialog = document.querySelector('[data-slot="dialog-content"]');
     expect(dialog?.className).toContain('max-h-[calc(100vh-2rem)]');
     expect(dialog?.className).toContain('overflow-y-auto');
+  });
+
+  it('centers transient onboarding status screens', async () => {
+    mockUseLaunchingDialogVisibility.mockReturnValue(true);
+    mockUseOnboardingLaunch.mockReturnValue(createLaunchState({
+      uiPhase: 'launching',
+      launchStatusMessage: 'Starting memory setup...',
+    }));
+
+    await act(async () => {
+      root?.render(<OnboardingWizard />);
+    });
+
+    const launchingHeader = document.querySelector('[data-onboarding-step="launching"]');
+    expect(launchingHeader?.className).toContain('items-center');
+    expect(launchingHeader?.className).toContain('text-center');
+  });
+
+  it('centers the onboarding error header', async () => {
+    mockUseOnboardingLaunch.mockReturnValue(createLaunchState({
+      uiPhase: 'error',
+      errorMessage: 'Try again.',
+    }));
+
+    await act(async () => {
+      root?.render(<OnboardingWizard />);
+    });
+
+    const errorHeader = document.querySelector('[data-onboarding-step="error"]');
+    expect(errorHeader?.className).toContain('items-center');
+    expect(errorHeader?.className).toContain('text-center');
   });
 
   it('moves optional dependency installs to their own onboarding step', async () => {

--- a/apps/desktop/src/components/profiles/onboarding/OnboardingViews.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/OnboardingViews.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { KeyRound, Loader2, TriangleAlert } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import {
@@ -7,6 +8,32 @@ import {
 import type { ProviderHealthInfo } from '@/types/ipc';
 
 export { OnboardingSetupScreen } from './SetupScreen';
+
+function CenteredStatusHeader({
+  icon,
+  title,
+  description,
+  step,
+}: {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  step: string;
+}) {
+  return (
+    <div data-onboarding-step={step} className="flex flex-col items-center gap-3 text-center">
+      <div className="flex size-12 items-center justify-center rounded-xl bg-[var(--bg-elevated)]">
+        {icon}
+      </div>
+      <div className="max-w-sm space-y-1.5">
+        <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">{title}</DialogTitle>
+        <DialogDescription className="text-sm leading-6 text-[var(--text-secondary)]">
+          {description}
+        </DialogDescription>
+      </div>
+    </div>
+  );
+}
 
 function statusLabel(provider: ProviderHealthInfo): string {
   switch (provider.status) {
@@ -101,18 +128,15 @@ export function AuthScreen({
 
 export function LaunchingScreen({ statusMessage }: { statusMessage?: string | null }) {
   return (
-    <div className="space-y-3">
-      <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-        <Loader2 className="size-5 animate-spin text-status-success" />
-      </div>
-      <div>
-        <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">Preparing Onboarding</DialogTitle>
-        <DialogDescription className="text-sm text-[var(--text-secondary)]">
-          Sero is saving your model preferences and starting the memory onboarding workflow.
-        </DialogDescription>
-      </div>
+    <div className="flex flex-col items-center gap-4 py-2">
+      <CenteredStatusHeader
+        step="launching"
+        icon={<Loader2 className="size-5 animate-spin text-status-success" />}
+        title="Preparing Onboarding"
+        description="Sero is saving your model preferences and starting the memory onboarding workflow."
+      />
       {statusMessage ? (
-        <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+        <div className="w-full rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 text-center text-xs text-[var(--text-secondary)]">
           {statusMessage}
         </div>
       ) : null}
@@ -131,20 +155,15 @@ export function ErrorScreen({
 }) {
   return (
     <div className="space-y-4">
-      <div className="space-y-2">
-        <div className="flex size-10 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-          <TriangleAlert className="size-5 text-status-warning" />
-        </div>
-        <div>
-          <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">Onboarding hit an error</DialogTitle>
-          <DialogDescription className="text-sm text-[var(--text-secondary)]">
-            Something unexpected happened while Sero was preparing your first session.
-          </DialogDescription>
-        </div>
-      </div>
+      <CenteredStatusHeader
+        step="error"
+        icon={<TriangleAlert className="size-5 text-status-warning" />}
+        title="Onboarding hit an error"
+        description="Something unexpected happened while Sero was preparing your first session."
+      />
 
       {message ? (
-        <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--text-secondary)]">
+        <div className="rounded-lg border border-[var(--border-default)] bg-[var(--bg-elevated)] px-3 py-2 text-center text-xs text-[var(--text-secondary)]">
           {message}
         </div>
       ) : null}

--- a/docs/features/host-toolchain.md
+++ b/docs/features/host-toolchain.md
@@ -19,7 +19,7 @@ Managed host tools are stored under the fixed Sero root, not the active profile 
 └── browser/
 ```
 
-Implementation uses `SERO_FIXED_ROOT` from `apps/desktop/electron/platform/env/index.ts`, which resolves to `~/.sero-ui`. Do not store shared toolchains under `SERO_HOME`, `~/.sero`, `~/.pi/agent`, or `~/.sero-ui/agent`.
+Implementation uses `SERO_HOST_ARTIFACTS_ROOT` from `apps/desktop/electron/platform/env/index.ts`, which resolves to `~/.sero-ui` unless tests explicitly override it. Do not store shared toolchains under `SERO_HOME`, `~/.sero`, `~/.pi/agent`, or `~/.sero-ui/agent`.
 
 Installers download from published GitHub Release assets into staging paths, verify pinned SHA-256 checksums, and atomically activate final directories. Core tools share a version-level `.installed` marker that is removed before any core install and written only after every required core tool resolves successfully; absence of `.installed` means the managed toolchain version is incomplete and must not be used for PATH resolution. Non-core artifacts write the marker only after their own activation/verification completes. Concurrent installs for the same manifest/artifact attach to the same in-flight operation.
 
@@ -28,7 +28,7 @@ Installers download from published GitHub Release assets into staging paths, ver
 For each tool, Sero resolves in this order:
 
 1. Compatible verified system tool.
-2. Existing Sero-managed tool under `SERO_FIXED_ROOT/toolchains/<manifest-version>/`.
+2. Existing Sero-managed tool under `SERO_HOST_ARTIFACTS_ROOT/toolchains/<manifest-version>/`.
 3. Managed first-use install when policy allows.
 4. Typed install failure with retry/fallback metadata.
 

--- a/docs/features/runtime-provider-architecture.md
+++ b/docs/features/runtime-provider-architecture.md
@@ -82,7 +82,7 @@ Packaged-app host mode resolves required CLIs through the host toolchain manager
 3. first-use managed install when policy permits,
 4. typed failure with retry/fallback metadata.
 
-Managed artifacts are stored under `SERO_FIXED_ROOT`, currently `~/.sero-ui/toolchains/<manifest-version>/`. They are not stored under profile-local `SERO_HOME`, `~/.sero`, or `~/.pi/agent`. See `docs/features/host-toolchain.md`.
+Managed artifacts are stored under `SERO_HOST_ARTIFACTS_ROOT`, currently `~/.sero-ui/toolchains/<manifest-version>/`. They are not stored under profile-local `SERO_HOME`, `~/.sero`, or `~/.pi/agent`. See `docs/features/host-toolchain.md`.
 
 Sero does not mutate global Corepack, npm prefixes, shell profiles, or machine PATH for these installs.
 

--- a/docs/reference/runtime-smoke.md
+++ b/docs/reference/runtime-smoke.md
@@ -57,7 +57,7 @@ Run on release-supported macOS Apple Silicon, Linux, and Windows x64 with backen
 ## Managed toolchain checks
 
 1. Locate the fixed toolchain root: `~/.sero-ui/toolchains/<manifest-version>/`.
-2. Confirm managed artifacts, if installed, are under `SERO_FIXED_ROOT` and not under profile-local `SERO_HOME`, `~/.sero`, or `~/.pi/agent`.
+2. Confirm managed artifacts, if installed, are under `SERO_HOST_ARTIFACTS_ROOT` and not under profile-local `SERO_HOME`, `~/.sero`, or `~/.pi/agent`.
 3. Confirm `.installed` is present for ready managed artifacts.
 4. In Runtime settings, trigger core tool install/retry when status permits and verify progress/failure details are visible.
 5. Confirm onboarding shows core development tools before browser automation and starts managed core install when host tools are missing.

--- a/packages/common/src/user-feedback.ts
+++ b/packages/common/src/user-feedback.ts
@@ -9,6 +9,7 @@ export interface UserFeedbackQuestionOption {
   label: string;
   description?: string;
   exclusive?: boolean;
+  subQuestion?: UserFeedbackQuestionItem;
 }
 
 export interface UserFeedbackQuestionItem {

--- a/plugins/sero-memory-plugin/extension/__tests__/bootstrap.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/bootstrap.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { USER_QUESTIONS } from '../bootstrap';
+
+describe('memory bootstrap questions', () => {
+  it('offers caveman mode in the communication step', () => {
+    const communication = USER_QUESTIONS.questions.find((question) => question.id === 'communication');
+
+    const caveman = communication?.options.find((option) => option.value === 'caveman');
+
+    expect(caveman).toEqual(expect.objectContaining({ value: 'caveman' }));
+    expect(caveman?.subQuestion?.options.map((option) => option.value)).toEqual([
+      'lite',
+      'full',
+      'ultra',
+    ]);
+  });
+});

--- a/plugins/sero-memory-plugin/extension/__tests__/caveman.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/caveman.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCavemanLevel, getCavemanPromptAddition } from '../caveman';
+
+describe('caveman mode memory parsing', () => {
+  it('uses explicit caveman mode level from USER.md context', () => {
+    const context = '# User\n\n- **Communication:** Direct\n- **Caveman Mode:** ultra';
+
+    expect(getCavemanLevel(context)).toBe('ultra');
+  });
+
+  it('defaults to full when communication selected caveman but no level is stored', () => {
+    const context = '# User\n\n- **Communication:** Direct, Caveman mode — compressed replies';
+
+    expect(getCavemanLevel(context)).toBe('full');
+  });
+
+  it('does not enable caveman mode when stored as off', () => {
+    const context = '# User\n\n- **Communication:** Direct\n- **Caveman Mode:** off';
+
+    expect(getCavemanLevel(context)).toBeNull();
+  });
+
+  it('uses the latest profile field when older response-style memories conflict', () => {
+    const context = [
+      '# User',
+      '',
+      '- **Communication:** Caveman mode — compressed replies',
+      '- **Caveman Mode:** full',
+      '',
+      'Communication: Ultra caveman mode — even more compressed.',
+    ].join('\n');
+
+    expect(getCavemanLevel(context)).toBe('ultra');
+  });
+
+  it('supports loose appended off fields so contaminated profiles recover', () => {
+    const context = [
+      '# User',
+      '',
+      '- **Communication:** Caveman mode — compressed replies',
+      '- **Caveman Mode:** full',
+      '',
+      'Communication: Caveman mode off when user asks; use normal concise style.',
+    ].join('\n');
+
+    expect(getCavemanLevel(context)).toBeNull();
+  });
+
+  it('builds level-specific prompt additions', () => {
+    const addition = getCavemanPromptAddition('# User\n\n- **Caveman Mode:** lite');
+
+    expect(addition).toContain('## Caveman Mode');
+    expect(addition).toContain('Caveman Lite mode');
+    expect(addition).toContain('Code blocks: write normally');
+  });
+});

--- a/plugins/sero-memory-plugin/extension/__tests__/caveman.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/caveman.test.ts
@@ -15,6 +15,12 @@ describe('caveman mode memory parsing', () => {
     expect(getCavemanLevel(context)).toBe('full');
   });
 
+  it('does not treat normal no-filler communication phrasing as disabled', () => {
+    const context = '# User\n\n- **Communication:** Caveman mode — compressed replies, no filler';
+
+    expect(getCavemanLevel(context)).toBe('full');
+  });
+
   it('does not enable caveman mode when stored as off', () => {
     const context = '# User\n\n- **Communication:** Direct\n- **Caveman Mode:** off';
 

--- a/plugins/sero-memory-plugin/extension/__tests__/context-injector.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/context-injector.test.ts
@@ -24,6 +24,8 @@ vi.mock('../bootstrap', () => ({
 }));
 
 vi.mock('../memory-manager', () => ({
+  getUserPath: () => '/tmp/sero-memory-root/USER.md',
+  readFile: vi.fn(async () => null),
   resolveMemoryRoot: () => '/tmp/sero-memory-root',
 }));
 
@@ -159,5 +161,28 @@ describe('context injector phase-1 migration state', () => {
     });
     expect(firstResult).toEqual({ systemPrompt: 'baseStatic memory context\nMemory instructions' });
     expect(secondResult).toEqual({ systemPrompt: 'baseStatic memory context\nMemory instructions' });
+  });
+
+  it('adds caveman instructions when USER.md context enables caveman mode', async () => {
+    mocks.buildPriorityContextSplit.mockResolvedValue({
+      staticContext: '\n\n## Memory\n\n### USER.md\n\n# User\n\n- **Communication:** Caveman mode — compressed replies\n- **Caveman Mode:** full',
+      searchContext: '',
+    });
+
+    const { api, handlers } = createPiHarness();
+    registerContextInjection(api);
+    setPhase1MigrationState('session-caveman', false);
+
+    const beforeAgentStart = handlers.get('before_agent_start');
+    expect(beforeAgentStart).toBeDefined();
+
+    const result = await beforeAgentStart!(
+      { prompt: 'hello', systemPrompt: 'base' },
+      createBeforeAgentStartContext('session-caveman'),
+    );
+
+    expect(result).toMatchObject({
+      systemPrompt: expect.stringContaining('IMPORTANT: Respond in Caveman mode'),
+    });
   });
 });

--- a/plugins/sero-memory-plugin/extension/__tests__/memory-instructions.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/memory-instructions.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMemoryInstructions } from '../memory-instructions';
+
+describe('memory instructions', () => {
+  it('tells agents to update existing memories instead of appending contradictions', () => {
+    const instructions = getMemoryInstructions();
+
+    expect(instructions).toContain('never create contradictions');
+    expect(instructions).toContain('USER.md` and `IDENTITY.md` are profile files');
+    expect(instructions).toContain('writing the complete revised file with `--mode overwrite`');
+    expect(instructions).toContain('read --target memory --with_ids true');
+    expect(instructions).toContain('daily` is the only append-only target');
+  });
+});

--- a/plugins/sero-memory-plugin/extension/__tests__/memory-tool.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/memory-tool.test.ts
@@ -102,6 +102,22 @@ describe('memory tool CRUD semantics', () => {
     expect(content.match(/Communication:/g)).toHaveLength(1);
   });
 
+  it('keeps unmatched USER.md content when merging profile field updates', async () => {
+    await handleWrite(root, 'user', '# User\n\n- **Communication:** Direct', 'overwrite');
+
+    const updateResult = await handleWrite(
+      root,
+      'user',
+      'Communication: direct, no waffle\nEmployer: Acme Corp\nPrefers Postgres over MySQL.',
+    );
+
+    expect(getText(updateResult)).toBe('Updated USER.md (Communication)');
+    const content = await readFile(getUserPath(root), 'utf8');
+    expect(content).toContain('- **Communication:** direct, no waffle');
+    expect(content).toContain('Employer: Acme Corp');
+    expect(content).toContain('Prefers Postgres over MySQL.');
+  });
+
   it('still appends USER.md notes that are not field updates', async () => {
     await handleWrite(root, 'user', '# User\n\n- **Name:** Dan', 'overwrite');
 

--- a/plugins/sero-memory-plugin/extension/__tests__/memory-tool.test.ts
+++ b/plugins/sero-memory-plugin/extension/__tests__/memory-tool.test.ts
@@ -11,7 +11,7 @@ import {
   handleReplace,
   handleWrite,
 } from '../memory-tool';
-import { getMemoryPath } from '../memory-manager';
+import { getMemoryPath, getUserPath } from '../memory-manager';
 
 function getText(result: Awaited<ReturnType<typeof handleWrite>>): string {
   const firstBlock = result.content[0];
@@ -83,5 +83,32 @@ describe('memory tool CRUD semantics', () => {
 
     const readResult = await handleRead(root, 'memory');
     expect(getText(readResult)).toBe('MEMORY.md not found or empty.');
+  });
+
+  it('updates existing USER.md fields instead of appending conflicting profile lines', async () => {
+    await handleWrite(root, 'user', '# User\n\n- **Name:** Dan\n- **Communication:** Caveman mode — compressed replies\n- **Caveman Mode:** full', 'overwrite');
+
+    const updateResult = await handleWrite(
+      root,
+      'user',
+      'Communication: Normal concise style\nCaveman Mode: off',
+    );
+
+    expect(getText(updateResult)).toBe('Updated USER.md (Communication, Caveman Mode)');
+    const content = await readFile(getUserPath(root), 'utf8');
+    expect(content).toContain('- **Communication:** Normal concise style');
+    expect(content).toContain('- **Caveman Mode:** off');
+    expect(content).not.toContain('Caveman mode — compressed replies');
+    expect(content.match(/Communication:/g)).toHaveLength(1);
+  });
+
+  it('still appends USER.md notes that are not field updates', async () => {
+    await handleWrite(root, 'user', '# User\n\n- **Name:** Dan', 'overwrite');
+
+    const appendResult = await handleWrite(root, 'user', 'Prefers short implementation notes.');
+
+    expect(getText(appendResult)).toBe('Appended to USER.md');
+    const content = await readFile(getUserPath(root), 'utf8');
+    expect(content).toContain('Prefers short implementation notes.');
   });
 });

--- a/plugins/sero-memory-plugin/extension/bootstrap.ts
+++ b/plugins/sero-memory-plugin/extension/bootstrap.ts
@@ -129,6 +129,22 @@ export const USER_QUESTIONS: QuestionnairePayload = {
         { value: 'direct', label: 'Direct — no waffle, just answers', description: 'Optimise for speed and clarity' },
         { value: 'explanatory', label: 'Explanatory — teach me as we go', description: 'Include reasoning and learning context' },
         { value: 'collaborative', label: 'Collaborative — discuss options together', description: 'Explore trade-offs before deciding' },
+        {
+          value: 'caveman',
+          label: 'Caveman mode — compressed replies',
+          description: 'Cut filler and tokens while keeping technical accuracy',
+          subQuestion: {
+            id: 'caveman_level',
+            label: 'Caveman Level',
+            prompt: 'How strong should caveman mode be?',
+            options: [
+              { value: 'lite', label: 'Lite', description: 'Keep grammar. Remove filler and pleasantries.' },
+              { value: 'full', label: 'Full', description: 'Drop articles and filler. Fragments are fine.' },
+              { value: 'ultra', label: 'Ultra', description: 'Maximum compression with symbols and fragments.' },
+            ],
+            allowOther: false,
+          },
+        },
       ],
       allowOther: true,
       multiSelect: true,

--- a/plugins/sero-memory-plugin/extension/caveman-instructions/full.md
+++ b/plugins/sero-memory-plugin/extension/caveman-instructions/full.md
@@ -1,0 +1,25 @@
+IMPORTANT: Respond in Caveman mode for this entire conversation.
+
+Speak like a smart caveman. Cut tokens aggressively. Keep all technical substance.
+
+Rules:
+- Drop articles: a, an, the
+- Drop filler: just, really, basically, actually, simply, very, quite
+- Drop pleasantries: sure, certainly, of course, happy to, great question, absolutely
+- Use short synonyms: big not extensive, fix not "implement a solution for", use not "utilize", need not "require"
+- No hedging: never write "it might be worth considering", "you could potentially", "one option would be"
+- Fragments fine. No need full sentence
+- Technical terms stay exact: "polymorphism" stays "polymorphism", "idempotent" stays "idempotent"
+- Code blocks: write normally. Caveman rules apply to prose only
+- Error messages: quote exact. Caveman only for explanation around them
+
+Pattern for answers:
+[thing] [action] [reason]. [next step].
+
+Examples:
+
+Wrong: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Right: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+Wrong: "Your React component is re-rendering because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time."
+Right: "New object ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."

--- a/plugins/sero-memory-plugin/extension/caveman-instructions/lite.md
+++ b/plugins/sero-memory-plugin/extension/caveman-instructions/lite.md
@@ -1,0 +1,11 @@
+IMPORTANT: Respond in Caveman Lite mode for this entire conversation.
+
+Keep full grammar and sentences. Remove all filler and pleasantries.
+
+Remove these words from every response:
+- Filler: just, really, basically, actually, simply, very, quite
+- Pleasantries: sure, certainly, of course, happy to, great question, absolutely, of course
+
+Do not start responses with affirmations. Get straight to the answer.
+
+Code blocks: write normally. Caveman rules apply to prose only.

--- a/plugins/sero-memory-plugin/extension/caveman-instructions/ultra.md
+++ b/plugins/sero-memory-plugin/extension/caveman-instructions/ultra.md
@@ -1,0 +1,27 @@
+IMPORTANT: Respond in Caveman Ultra mode for this entire conversation. Maximum compression.
+
+Every word must earn its place. Cut everything that does not carry meaning.
+
+Rules:
+- Drop articles, most prepositions, most conjunctions
+- Use symbols over words: →, =, +, &, vs, !=
+- No filler, no hedging, no pleasantries — none
+- Shortest possible synonyms: fix, use, add, rm, run, set, get, need
+- Fragments only. No full sentences
+- Technical terms stay exact
+- Code blocks: write normally. Rules apply to prose only
+- Numbers and symbols preferred over spelled-out words
+
+Pattern:
+[thing] → [effect]. [fix].
+
+Examples:
+
+Wrong: "Your React component is re-rendering because you're creating a new object reference on each render cycle."
+Right: "Inline obj prop → new ref → re-render. useMemo."
+
+Wrong: "The database query is slow because there's no index on the user_id column."
+Right: "No index on user_id → slow query. Add index."
+
+Wrong: "You need to install the dependency first before running the build."
+Right: "npm i <pkg> first."

--- a/plugins/sero-memory-plugin/extension/caveman.ts
+++ b/plugins/sero-memory-plugin/extension/caveman.ts
@@ -1,0 +1,125 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { normalizeFieldLabel, parseManagedFieldLines } from './managed-markdown-fields';
+
+export type CavemanLevel = 'lite' | 'full' | 'ultra';
+
+const FALLBACK_CAVEMAN_INSTRUCTIONS: Record<CavemanLevel, string> = {
+  lite: `IMPORTANT: Respond in Caveman Lite mode for this entire conversation.
+
+Keep full grammar and sentences. Remove all filler and pleasantries.
+
+Remove these words from every response:
+- Filler: just, really, basically, actually, simply, very, quite
+- Pleasantries: sure, certainly, of course, happy to, great question, absolutely, of course
+
+Do not start responses with affirmations. Get straight to the answer.
+
+Code blocks: write normally. Caveman rules apply to prose only.`,
+
+  full: `IMPORTANT: Respond in Caveman mode for this entire conversation.
+
+Speak like a smart caveman. Cut tokens aggressively. Keep all technical substance.
+
+Rules:
+- Drop articles: a, an, the
+- Drop filler: just, really, basically, actually, simply, very, quite
+- Drop pleasantries: sure, certainly, of course, happy to, great question, absolutely
+- Use short synonyms: big not extensive, fix not "implement a solution for", use not "utilize", need not "require"
+- No hedging: never write "it might be worth considering", "you could potentially", "one option would be"
+- Fragments fine. No need full sentence
+- Technical terms stay exact: "polymorphism" stays "polymorphism", "idempotent" stays "idempotent"
+- Code blocks: write normally. Caveman rules apply to prose only
+- Error messages: quote exact. Caveman only for explanation around them
+
+Pattern for answers:
+[thing] [action] [reason]. [next step].
+
+Examples:
+
+Wrong: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Right: "Bug in auth middleware. Token expiry check use \`<\` not \`<=\`. Fix:"
+
+Wrong: "Your React component is re-rendering because you're creating a new object reference on each render cycle. When you pass an inline object as a prop, React's shallow comparison sees it as a different object every time."
+Right: "New object ref each render. Inline object prop = new ref = re-render. Wrap in \`useMemo\`."`,
+
+  ultra: `IMPORTANT: Respond in Caveman Ultra mode for this entire conversation. Maximum compression.
+
+Every word must earn its place. Cut everything that does not carry meaning.
+
+Rules:
+- Drop articles, most prepositions, most conjunctions
+- Use symbols over words: →, =, +, &, vs, !=
+- No filler, no hedging, no pleasantries — none
+- Shortest possible synonyms: fix, use, add, rm, run, set, get, need
+- Fragments only. No full sentences
+- Technical terms stay exact
+- Code blocks: write normally. Rules apply to prose only
+- Numbers and symbols preferred over spelled-out words
+
+Pattern:
+[thing] → [effect]. [fix].
+
+Examples:
+
+Wrong: "Your React component is re-rendering because you're creating a new object reference on each render cycle."
+Right: "Inline obj prop → new ref → re-render. useMemo."
+
+Wrong: "The database query is slow because there's no index on the user_id column."
+Right: "No index on user_id → slow query. Add index."
+
+Wrong: "You need to install the dependency first before running the build."
+Right: "npm i <pkg> first."`,
+};
+
+const moduleDir = typeof __dirname === 'string' ? __dirname : process.cwd();
+const instructionsDir = path.join(moduleDir, 'caveman-instructions');
+
+function readInstruction(level: CavemanLevel): string {
+  const instructionPath = path.join(instructionsDir, `${level}.md`);
+  if (!existsSync(instructionPath)) return FALLBACK_CAVEMAN_INSTRUCTIONS[level];
+  return readFileSync(instructionPath, 'utf-8');
+}
+
+const CAVEMAN_INSTRUCTIONS: Record<CavemanLevel, string> = {
+  lite: readInstruction('lite'),
+  full: readInstruction('full'),
+  ultra: readInstruction('ultra'),
+};
+
+const CAVEMAN_FIELD_LABELS = new Set([
+  normalizeFieldLabel('Caveman Mode'),
+  normalizeFieldLabel('Caveman Level'),
+  normalizeFieldLabel('Communication'),
+]);
+
+function parseLevel(value: string): CavemanLevel | null {
+  const normalized = value.toLowerCase();
+  if (/\blite\b/.test(normalized)) return 'lite';
+  if (/\bfull\b/.test(normalized)) return 'full';
+  if (/\bultra\b/.test(normalized)) return 'ultra';
+  return null;
+}
+
+function isOff(value: string): boolean {
+  return /\b(off|none|disabled|false|no)\b/i.test(value);
+}
+
+export function getCavemanLevel(memoryContext: string): CavemanLevel | null {
+  const signal = parseManagedFieldLines(memoryContext)
+    .filter((field) => CAVEMAN_FIELD_LABELS.has(field.normalizedLabel))
+    .at(-1);
+
+  if (!signal) return null;
+  if (isOff(signal.value)) return null;
+
+  const level = parseLevel(signal.value);
+  if (level) return level;
+  return signal.value.toLowerCase().includes('caveman') ? 'full' : null;
+}
+
+export function getCavemanPromptAddition(memoryContext: string): string {
+  const level = getCavemanLevel(memoryContext);
+  return level ? `\n\n## Caveman Mode\n\n${CAVEMAN_INSTRUCTIONS[level]}` : '';
+}

--- a/plugins/sero-memory-plugin/extension/caveman.ts
+++ b/plugins/sero-memory-plugin/extension/caveman.ts
@@ -103,10 +103,13 @@ function parseLevel(value: string): CavemanLevel | null {
 }
 
 function isOff(value: string): boolean {
-  return /\b(off|none|disabled|false|no)\b/i.test(value);
+  return /\b(off|none|disabled|disable|false)\b/i.test(value);
 }
 
 export function getCavemanLevel(memoryContext: string): CavemanLevel | null {
+  // Prefer the last relevant field so legacy USER.md files with appended corrections
+  // can recover. Bootstrap writes `Caveman Mode` after `Communication`, and the
+  // managed field merge preserves that order for canonical profiles.
   const signal = parseManagedFieldLines(memoryContext)
     .filter((field) => CAVEMAN_FIELD_LABELS.has(field.normalizedLabel))
     .at(-1);

--- a/plugins/sero-memory-plugin/extension/context-injector.ts
+++ b/plugins/sero-memory-plugin/extension/context-injector.ts
@@ -25,7 +25,7 @@ import {
   USER_QUESTIONS,
 } from './bootstrap';
 import type { BootstrapStatus } from './bootstrap';
-import { resolveMemoryRoot } from './memory-manager';
+import { getUserPath, readFile, resolveMemoryRoot } from './memory-manager';
 import { getAutoRetrieveModeSync, getMemorySnapshotModeSync } from './memory-config';
 import type { AutoRetrieveMode } from './memory-config';
 import { buildPriorityContextSplit, clearPriorityContextCache } from './priority-context';
@@ -38,6 +38,7 @@ import {
   setPhase1MigrationState,
 } from './phase1-migration-state';
 import { flushPendingStats } from './memory-scoring';
+import { getCavemanPromptAddition } from './caveman';
 import { getMemoryInstructions } from './memory-instructions';
 import {
   clearMemoryPromptDebugState,
@@ -84,7 +85,7 @@ function buildBootstrapInstructions(existingUserContent: string | null): string 
 The memory system is not yet initialised. You MUST set it up now before doing anything else.
 Use the \`questionnaire\` tool to ask the user three rounds of questions, then write the answers to memory files.${userNote}
 
-The questionnaire UI supports step-based multiple-choice forms, including multi-select questions. For any question that already includes predefined \`options\`, preserve those options exactly so the user gets clickable choices. Do NOT rewrite option-based questions into free-form chat. Only rely on custom text when none of the provided options fit.
+The questionnaire UI supports step-based multiple-choice forms, multi-select questions, and option-specific \`subQuestion\` choices. For any question that already includes predefined \`options\`, preserve those options exactly so the user gets clickable choices. Do NOT rewrite option-based questions into free-form chat. Only rely on custom text when none of the provided options fit.
 
 ### Step 1: Identity Setup
 YOU MUST call the \`questionnaire\` tool with the exact JSON parameters below to configure the agent persona. Preserve every \`options\`, \`label\`, \`description\`, \`exclusive\`, \`multiSelect\`, and \`allowOther\` field exactly as shown:
@@ -98,7 +99,9 @@ YOU MUST call the \`questionnaire\` tool again with the exact JSON parameters be
 ${userJson}
 
 After receiving answers, write USER.md:
-\`sero memory write --target user --mode overwrite --content "# User\\n\\n- **Name:** <name>\\n- **Role:** <role answers joined with commas if multiple>\\n- **Location:** <location>\\n- **Tech Stack:** <stack answers joined with commas if multiple>\\n- **Communication:** <communication answers joined with commas if multiple>"\`
+\`sero memory write --target user --mode overwrite --content "# User\\n\\n- **Name:** <name>\\n- **Role:** <role answers joined with commas if multiple>\\n- **Location:** <location>\\n- **Tech Stack:** <stack answers joined with commas if multiple>\\n- **Communication:** <communication answers joined with commas if multiple>\\n- **Caveman Mode:** <lite|full|ultra if selected, otherwise off>"\`
+
+If the user selected caveman mode but the level answer is unavailable, write \`full\` for \`Caveman Mode\`.
 
 ### Step 3: Long-term Memory
 YOU MUST call the \`questionnaire\` tool again with the exact JSON parameters below. Keep the option lists intact instead of converting these prompts into open-ended chat questions:
@@ -147,7 +150,9 @@ async function buildTurnContext(
     { includeSearch: autoRetrieveMode === 'on' },
   );
   const memoryInstructions = getMemoryInstructions();
-  const systemPromptAddition = staticContext + memoryInstructions;
+  const userContent = await readFile(getUserPath(root));
+  const cavemanInstructions = getCavemanPromptAddition(userContent ?? staticContext);
+  const systemPromptAddition = staticContext + memoryInstructions + cavemanInstructions;
   // Full combined context for debug logging only — not the wire format.
   const parts: string[] = [];
   if (staticContext) parts.push(staticContext);

--- a/plugins/sero-memory-plugin/extension/managed-markdown-fields.ts
+++ b/plugins/sero-memory-plugin/extension/managed-markdown-fields.ts
@@ -1,0 +1,84 @@
+import { stripManagedFileMetadata } from './memory-format';
+
+export interface ManagedFieldLine {
+  lineIndex: number;
+  label: string;
+  normalizedLabel: string;
+  value: string;
+}
+
+export interface ManagedFieldMergeResult {
+  content: string;
+  updatedLabels: string[];
+}
+
+const FIELD_LINE_REGEX = /^\s*(?:[-*]\s*)?(?:\*\*)?([A-Za-z][A-Za-z0-9 /_-]{0,60}?)(?::\s*(?:\*\*)?|\*\*\s*:\s*)(.+?)\s*$/;
+
+export function normalizeFieldLabel(label: string): string {
+  return label.replace(/\*+/g, '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+export function parseManagedFieldLines(content: string): ManagedFieldLine[] {
+  return stripManagedFileMetadata(content)
+    .split('\n')
+    .map((line, lineIndex) => ({ line, lineIndex, match: line.match(FIELD_LINE_REGEX) }))
+    .filter((item): item is { lineIndex: number; match: RegExpMatchArray; line: string } => Boolean(item.match))
+    .map(({ lineIndex, match }) => {
+      const label = match[1]!.trim();
+      return {
+        lineIndex,
+        label,
+        normalizedLabel: normalizeFieldLabel(label),
+        value: match[2]!.trim(),
+      };
+    })
+    .filter((field) => Boolean(field.value));
+}
+
+export function formatManagedFieldLine(label: string, value: string): string {
+  return `- **${label.trim()}:** ${value.trim()}`;
+}
+
+export function mergeManagedFieldUpdate(
+  existingContent: string | null,
+  incomingContent: string,
+): ManagedFieldMergeResult | null {
+  const existingBody = stripManagedFileMetadata(existingContent ?? '').trimEnd();
+  if (!existingBody.trim()) return null;
+
+  const existingFields = parseManagedFieldLines(existingBody);
+  const incomingFields = parseManagedFieldLines(incomingContent);
+  if (existingFields.length === 0 || incomingFields.length === 0) return null;
+
+  const existingLabels = new Set(existingFields.map((field) => field.normalizedLabel));
+  const incomingByLabel = new Map<string, ManagedFieldLine>();
+  for (const field of incomingFields) incomingByLabel.set(field.normalizedLabel, field);
+
+  const matchingLabels = [...incomingByLabel.keys()].filter((label) => existingLabels.has(label));
+  if (matchingLabels.length === 0) return null;
+
+  const fieldByLine = new Map(existingFields.map((field) => [field.lineIndex, field]));
+  const replacedLabels = new Set<string>();
+  const updatedLabels: string[] = [];
+  const nextLines: string[] = [];
+
+  for (const [lineIndex, line] of existingBody.split('\n').entries()) {
+    const existingField = fieldByLine.get(lineIndex);
+    const incomingField = existingField ? incomingByLabel.get(existingField.normalizedLabel) : undefined;
+    if (!existingField || !incomingField) {
+      nextLines.push(line);
+      continue;
+    }
+
+    if (replacedLabels.has(existingField.normalizedLabel)) continue;
+
+    nextLines.push(formatManagedFieldLine(existingField.label, incomingField.value));
+    replacedLabels.add(existingField.normalizedLabel);
+    updatedLabels.push(existingField.label);
+  }
+
+  return {
+    content: nextLines.join('\n').trimEnd(),
+    updatedLabels,
+  };
+}

--- a/plugins/sero-memory-plugin/extension/managed-markdown-fields.ts
+++ b/plugins/sero-memory-plugin/extension/managed-markdown-fields.ts
@@ -44,10 +44,11 @@ export function mergeManagedFieldUpdate(
   incomingContent: string,
 ): ManagedFieldMergeResult | null {
   const existingBody = stripManagedFileMetadata(existingContent ?? '').trimEnd();
+  const incomingBody = stripManagedFileMetadata(incomingContent).trimEnd();
   if (!existingBody.trim()) return null;
 
   const existingFields = parseManagedFieldLines(existingBody);
-  const incomingFields = parseManagedFieldLines(incomingContent);
+  const incomingFields = parseManagedFieldLines(incomingBody);
   if (existingFields.length === 0 || incomingFields.length === 0) return null;
 
   const existingLabels = new Set(existingFields.map((field) => field.normalizedLabel));
@@ -58,6 +59,7 @@ export function mergeManagedFieldUpdate(
   if (matchingLabels.length === 0) return null;
 
   const fieldByLine = new Map(existingFields.map((field) => [field.lineIndex, field]));
+  const incomingFieldByLine = new Map(incomingFields.map((field) => [field.lineIndex, field]));
   const replacedLabels = new Set<string>();
   const updatedLabels: string[] = [];
   const nextLines: string[] = [];
@@ -75,6 +77,20 @@ export function mergeManagedFieldUpdate(
     nextLines.push(formatManagedFieldLine(existingField.label, incomingField.value));
     replacedLabels.add(existingField.normalizedLabel);
     updatedLabels.push(existingField.label);
+  }
+
+  const unmatchedIncomingLines = incomingBody
+    .split('\n')
+    .filter((line, lineIndex) => {
+      const incomingField = incomingFieldByLine.get(lineIndex);
+      return !incomingField || !existingLabels.has(incomingField.normalizedLabel);
+    })
+    .join('\n')
+    .trim();
+
+  if (unmatchedIncomingLines) {
+    if (nextLines.some((line) => line.trim())) nextLines.push('');
+    nextLines.push(unmatchedIncomingLines);
   }
 
   return {

--- a/plugins/sero-memory-plugin/extension/memory-instructions.ts
+++ b/plugins/sero-memory-plugin/extension/memory-instructions.ts
@@ -68,11 +68,17 @@ function getMemoryStorageInstructions(): string[] {
     '- `sero memory consolidate [--schedule daily|weekly|off]`',
     '- `sero memory config [--snapshot frozen|live] [--auto_retrieve on|off]`',
     '',
+    '**Update rule — never create contradictions:** if the user says change, update, switch, correct, remove, or turn off an existing memory, read the target first and modify the existing memory. Do not append a second conflicting line.',
+    '- `USER.md` and `IDENTITY.md` are profile files. Update them by reading the file, keeping unchanged fields, then writing the complete revised file with `--mode overwrite`.',
+    '- For profile fields, keep canonical lines like `- **Communication:** ...` and `- **Caveman Mode:** off|lite|full|ultra`. Do not append loose `Communication:` / `Rules:` paragraphs after existing fields.',
+    '- `MEMORY.md` is structured. Before changing a durable memory, run `sero memory read --target memory --with_ids true`, then use `replace` or `remove` with the entry id. Append only genuinely new, non-conflicting memories.',
+    '- `daily` is the only append-only target. Use it for session notes, not current preferences or profile changes.',
+    '',
     '**Where to put what** — pick the target that matches the lifespan:',
     '- `daily` — completed work / progress notes / blockers from *this* session that future-you will want to skim tomorrow. Written-once, append-only.',
     '- `memory` — durable cross-session knowledge: decisions that outlive the session, user preferences, project facts, lessons. Use type tags: [fact], [decision], [preference], [lesson], etc.',
     '',
     'Default routing: a summary of what you finished → `daily`. A choice you made that the next session should respect → `memory`.',
-    'Read with IDs before updating `memory` to avoid duplicates. Near capacity? Replace or remove stale entries instead of appending.',
+    'Near capacity? Replace or remove stale entries instead of appending.',
   ];
 }

--- a/plugins/sero-memory-plugin/extension/memory-tool.ts
+++ b/plugins/sero-memory-plugin/extension/memory-tool.ts
@@ -41,6 +41,7 @@ import {
   handleMemoryConfig,
   handleMemoryConsolidate,
 } from './memory-tool-admin';
+import { mergeManagedFieldUpdate } from './managed-markdown-fields';
 import type { AutoConsolidationCadence } from './automation-state';
 import type { ConsolidationTrigger } from './consolidation';
 import type { AutoRetrieveMode, MemorySnapshotMode } from './memory-config';
@@ -259,9 +260,10 @@ export async function handleWrite(root: string, target?: string, rawContent?: st
   }
 
   const existing = await readFile(resolved.path);
+  const fieldUpdate = mode === 'overwrite' ? null : mergeManagedFieldUpdate(existing, content);
   const nextBody = mode === 'overwrite'
     ? content
-    : [existing ? stripManagedFileMetadata(existing) : '', content].filter(Boolean).join('\n\n');
+    : fieldUpdate?.content ?? [existing ? stripManagedFileMetadata(existing) : '', content].filter(Boolean).join('\n\n');
   const nextContent = normalizeManagedMarkdown(nextBody);
   const managedTarget = target === 'identity' ? 'identity' : 'user';
   const error = capacityError(resolved.displayName, managedTarget, nextContent);
@@ -269,6 +271,9 @@ export async function handleWrite(root: string, target?: string, rawContent?: st
 
   await writeFile(resolved.path, nextContent);
   scheduleQmdUpdate();
+  if (fieldUpdate) {
+    return text(`${formatWarnings(warnings)}Updated ${resolved.displayName} (${fieldUpdate.updatedLabels.join(', ')})`.trim());
+  }
   return text(`${formatWarnings(warnings)}${mode === 'overwrite' ? 'Wrote to' : 'Appended to'} ${resolved.displayName}`.trim());
 }
 
@@ -382,6 +387,7 @@ export function registerMemoryTool(pi: ExtensionAPI): void {
       '',
       'Actions: read, write, replace, remove, search, list, consolidate, config.',
       'Targets: memory (MEMORY.md), identity (IDENTITY.md), user (USER.md), daily (daily log).',
+      'For updates, read first and change existing memory. Use overwrite for USER.md/IDENTITY.md, replace/remove for MEMORY.md ids, append only for new non-conflicting memory or daily logs.',
     ].join('\n'),
     parameters: MemoryParams,
 

--- a/plugins/sero-memory-plugin/shared/types.ts
+++ b/plugins/sero-memory-plugin/shared/types.ts
@@ -52,6 +52,7 @@ export interface QuestionOption {
   label: string;
   description?: string;
   exclusive?: boolean;
+  subQuestion?: QuestionDef;
 }
 
 export interface QuestionDef {

--- a/plugins/sero-user-feedback-plugin/extension/index.ts
+++ b/plugins/sero-user-feedback-plugin/extension/index.ts
@@ -36,11 +36,28 @@ const QuestionParams = Type.Object({
   options: Type.Array(OptionSchema, { description: 'Options for the user to choose from' }),
 });
 
+const SubQuestionSchema = Type.Object({
+  id: Type.String({ description: 'Unique identifier for this sub-question' }),
+  label: Type.Optional(Type.String({ description: 'Short label for the nested choice' })),
+  prompt: Type.String({ description: 'The nested question text to display' }),
+  options: Type.Array(OptionSchema, { description: 'Available nested options' }),
+  allowOther: Type.Optional(Type.Boolean({ description: 'Allow custom text input (default: true)' })),
+  multiSelect: Type.Optional(Type.Boolean({ description: 'Allow selecting multiple nested options (default: false)' })),
+});
+
+const QuestionnaireOptionSchema = Type.Object({
+  label: Type.String({ description: 'Display label for the option' }),
+  value: Type.Optional(Type.String({ description: 'Value returned when selected (defaults to label)' })),
+  description: Type.Optional(Type.String({ description: 'Optional description shown below label' })),
+  exclusive: Type.Optional(Type.Boolean({ description: 'In multi-select mode, this option clears other selections (for example: None)' })),
+  subQuestion: Type.Optional(SubQuestionSchema),
+});
+
 const QuestionnaireQuestionSchema = Type.Object({
   id: Type.String({ description: 'Unique identifier for this question' }),
   label: Type.Optional(Type.String({ description: 'Short label for tab/step (defaults to Q1, Q2)' })),
   prompt: Type.String({ description: 'The full question text to display' }),
-  options: Type.Array(OptionSchema, { description: 'Available options' }),
+  options: Type.Array(QuestionnaireOptionSchema, { description: 'Available options' }),
   allowOther: Type.Optional(Type.Boolean({ description: 'Allow custom text input (default: true)' })),
   multiSelect: Type.Optional(Type.Boolean({ description: 'Allow selecting multiple options for this question (default: false)' })),
 });
@@ -177,19 +194,7 @@ function registerQuestionnaireTool(pi: ExtensionAPI) {
         };
       }
 
-      const questions: QuestionItem[] = params.questions.map((q, i) => ({
-        id: q.id,
-        label: q.label || `Q${i + 1}`,
-        prompt: q.prompt,
-        options: (q.options ?? []).map((o) => ({
-          value: o.value ?? o.label,
-          label: o.label,
-          description: o.description,
-          exclusive: o.exclusive,
-        })),
-        allowOther: q.allowOther !== false,
-        multiSelect: q.multiSelect === true,
-      }));
+      const questions: QuestionItem[] = params.questions.map((q, i) => normalizeQuestion(q, `Q${i + 1}`));
 
       // ── Sero mode: IPC bridge ──────────────────────────────
       if (hasSeroIPCBridge()) {
@@ -248,17 +253,48 @@ function registerQuestionnaireTool(pi: ExtensionAPI) {
   });
 }
 
+function normalizeQuestion(q: {
+  id: string;
+  label?: string;
+  prompt: string;
+  options?: Array<{
+    value?: string;
+    label: string;
+    description?: string;
+    exclusive?: boolean;
+    subQuestion?: Parameters<typeof normalizeQuestion>[0];
+  }>;
+  allowOther?: boolean;
+  multiSelect?: boolean;
+}, fallbackLabel: string): QuestionItem {
+  return {
+    id: q.id,
+    label: q.label || fallbackLabel,
+    prompt: q.prompt,
+    options: (q.options ?? []).map((o) => ({
+      value: o.value ?? o.label,
+      label: o.label,
+      description: o.description,
+      exclusive: o.exclusive,
+      subQuestion: o.subQuestion ? normalizeQuestion(o.subQuestion, o.subQuestion.label || o.subQuestion.id) : undefined,
+    })),
+    allowOther: q.allowOther !== false,
+    multiSelect: q.multiSelect === true,
+  };
+}
+
 // ── Result builders ────────────────────────────────────────────
 
 function groupAnswersByQuestion(
   questions: QuestionItem[],
   answers: QuestionAnswer[],
 ): Array<{ questionLabel: string; answers: QuestionAnswer[] }> {
-  const order = new Map<string, number>(questions.map((q, index) => [q.id, index]));
+  const flatQuestions = flattenQuestions(questions);
+  const order = new Map<string, number>(flatQuestions.map((q, index) => [q.id, index]));
   const grouped = new Map<string, { questionLabel: string; answers: QuestionAnswer[] }>();
 
   for (const answer of answers) {
-    const questionLabel = questions.find((q) => q.id === answer.questionId)?.label || answer.questionId;
+    const questionLabel = flatQuestions.find((q) => q.id === answer.questionId)?.label || answer.questionId;
     const existing = grouped.get(answer.questionId);
     if (existing) {
       existing.answers.push(answer);
@@ -270,6 +306,15 @@ function groupAnswersByQuestion(
   return Array.from(grouped.entries())
     .sort(([a], [b]) => (order.get(a) ?? Number.MAX_SAFE_INTEGER) - (order.get(b) ?? Number.MAX_SAFE_INTEGER))
     .map(([, group]) => group);
+}
+
+function flattenQuestions(questions: QuestionItem[]): QuestionItem[] {
+  return questions.flatMap((question) => [
+    question,
+    ...question.options.flatMap((option) => (
+      option.subQuestion ? flattenQuestions([option.subQuestion]) : []
+    )),
+  ]);
 }
 
 function formatAnswerText(answer: QuestionAnswer): string {

--- a/plugins/sero-user-feedback-plugin/shared/__tests__/questionnaire-flow.test.ts
+++ b/plugins/sero-user-feedback-plugin/shared/__tests__/questionnaire-flow.test.ts
@@ -4,6 +4,7 @@ import {
   canSubmitQuestionnaire,
   flattenQuestionnaireAnswers,
   formatQuestionnaireAnswerLabel,
+  hasQuestionAnswerDeep,
   selectQuestionOption,
   submitCustomQuestionAnswer,
 } from '../questionnaire-flow';
@@ -120,5 +121,35 @@ describe('questionnaire flow helpers', () => {
         wasCustom: true,
       }),
     ).toBe('✎ Custom answer');
+  });
+
+  it('requires selected sub-question answers and flattens them under their parent', () => {
+    const nestedQuestion: QuestionItem = {
+      ...singleQuestion,
+      options: [{
+        value: 'one',
+        label: 'One',
+        subQuestion: {
+          id: 'depth',
+          label: 'Depth',
+          prompt: 'Pick depth',
+          options: [{ value: 'full', label: 'Full' }],
+          allowOther: false,
+        },
+      }],
+    };
+    const parentAnswer = selectQuestionOption(nestedQuestion, nestedQuestion.options[0], 0, []);
+    const answers = new Map<string, QuestionAnswer[]>([[nestedQuestion.id, parentAnswer]]);
+
+    expect(hasQuestionAnswerDeep(answers, nestedQuestion)).toBe(false);
+
+    const subQuestion = nestedQuestion.options[0].subQuestion!;
+    answers.set(subQuestion.id, selectQuestionOption(subQuestion, subQuestion.options[0], 0, []));
+
+    expect(hasQuestionAnswerDeep(answers, nestedQuestion)).toBe(true);
+    expect(flattenQuestionnaireAnswers([nestedQuestion], answers).map((answer) => answer.questionId)).toEqual([
+      'q1',
+      'depth',
+    ]);
   });
 });

--- a/plugins/sero-user-feedback-plugin/shared/questionnaire-flow.ts
+++ b/plugins/sero-user-feedback-plugin/shared/questionnaire-flow.ts
@@ -16,6 +16,26 @@ export function hasQuestionAnswer(
   return getQuestionAnswers(answers, questionId).length > 0;
 }
 
+export function getSelectedSubQuestions(
+  question: QuestionItem,
+  answers: ReadonlyMap<string, QuestionAnswer[]>,
+): QuestionItem[] {
+  return getQuestionAnswers(answers, question.id)
+    .filter((answer) => !answer.wasCustom)
+    .map((answer) => getOptionByValue(question, answer.value)?.subQuestion)
+    .filter((subQuestion): subQuestion is QuestionItem => Boolean(subQuestion));
+}
+
+export function hasQuestionAnswerDeep(
+  answers: ReadonlyMap<string, QuestionAnswer[]>,
+  question: QuestionItem,
+): boolean {
+  if (!hasQuestionAnswer(answers, question.id)) return false;
+  return getSelectedSubQuestions(question, answers).every((subQuestion) => (
+    hasQuestionAnswerDeep(answers, subQuestion)
+  ));
+}
+
 export function getCustomAnswer(
   answers: QuestionAnswer[],
 ): QuestionAnswer | undefined {
@@ -119,7 +139,7 @@ export function flattenQuestionnaireAnswers(
   questions: QuestionItem[],
   answers: ReadonlyMap<string, QuestionAnswer[]>,
 ): QuestionAnswer[] {
-  return questions.flatMap((question) => getQuestionAnswers(answers, question.id));
+  return questions.flatMap((question) => flattenQuestionAnswers(question, answers));
 }
 
 export function canSubmitQuestionnaire(
@@ -131,4 +151,15 @@ export function canSubmitQuestionnaire(
 
 export function formatQuestionnaireAnswerLabel(answer: QuestionAnswer): string {
   return answer.wasCustom ? `✎ ${answer.label}` : `${answer.index}. ${answer.label}`;
+}
+
+function flattenQuestionAnswers(
+  question: QuestionItem,
+  answers: ReadonlyMap<string, QuestionAnswer[]>,
+): QuestionAnswer[] {
+  const ownAnswers = getQuestionAnswers(answers, question.id);
+  const subAnswers = getSelectedSubQuestions(question, answers)
+    .flatMap((subQuestion) => flattenQuestionAnswers(subQuestion, answers));
+
+  return [...ownAnswers, ...subAnswers];
 }

--- a/plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.test.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.test.tsx
@@ -112,4 +112,67 @@ describe('QuestionnaireForm', () => {
     ]);
     expect(onCancel).not.toHaveBeenCalled();
   });
+
+  it('reveals an option sub-question inline when that option is selected', async () => {
+    const nestedQuestion: UserFeedbackPendingQuestion = {
+      ...pendingQuestion,
+      questions: [{
+        id: 'delivery',
+        label: 'Delivery',
+        prompt: 'How should this be delivered?',
+        allowOther: true,
+        multiSelect: true,
+        options: [
+          { value: 'summary', label: 'Summary only' },
+          {
+            value: 'customized',
+            label: 'Custom format',
+            subQuestion: {
+              id: 'format_depth',
+              label: 'Depth',
+              prompt: 'How much detail should the custom format include?',
+              allowOther: false,
+              options: [
+                { value: 'light', label: 'Light' },
+                { value: 'full', label: 'Full' },
+              ],
+            },
+          },
+        ],
+      }],
+    };
+
+    await act(async () => {
+      root?.render(
+        <QuestionnaireForm
+          question={nestedQuestion}
+          onSubmit={onSubmit}
+          onCancel={onCancel}
+        />,
+      );
+    });
+
+    await act(async () => {
+      clickButton(container, 'Custom format');
+    });
+
+    expect(container.textContent).toContain('How much detail should the custom format include?');
+
+    await act(async () => {
+      clickButton(container, 'Full');
+    });
+
+    await act(async () => {
+      clickButton(container, 'Review');
+    });
+
+    await act(async () => {
+      clickButton(container, 'Submit All Answers');
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith('pending-1', [
+      expect.objectContaining({ questionId: 'delivery', value: 'customized' }),
+      expect.objectContaining({ questionId: 'format_depth', value: 'full' }),
+    ]);
+  });
 });

--- a/plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/QuestionnaireForm.tsx
@@ -14,7 +14,7 @@ import { cn } from '@sero-ai/ui/lib/utils';
 import {
   flattenQuestionnaireAnswers,
   getQuestionAnswers,
-  hasQuestionAnswer,
+  hasQuestionAnswerDeep,
   removeCustomQuestionAnswer,
   selectQuestionOption,
   submitCustomQuestionAnswer,
@@ -36,14 +36,10 @@ interface Props {
   onCancel: (id: string) => void;
 }
 
-const EMPTY_ANSWERS: UserFeedbackAnswer[] = [];
-
 export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
   const questions = question.questions;
   const [currentStep, setCurrentStep] = useState(0);
   const [answers, setAnswers] = useState<AnswerMap>(new Map());
-  const [customMode, setCustomMode] = useState(false);
-  const [customText, setCustomText] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -51,13 +47,10 @@ export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
   }, []);
 
   const isReview = currentStep === questions.length;
-  const allAnswered = questions.every((item) => hasQuestionAnswer(answers, item.id));
+  const allAnswered = questions.every((item) => hasQuestionAnswerDeep(answers, item));
   const currentQuestion = questions[currentStep] as UserFeedbackQuestionItem | undefined;
-  const currentAnswers = currentQuestion
-    ? getQuestionAnswers(answers, currentQuestion.id)
-    : EMPTY_ANSWERS;
   const currentQuestionAnswered = currentQuestion
-    ? hasQuestionAnswer(answers, currentQuestion.id)
+    ? hasQuestionAnswerDeep(answers, currentQuestion)
     : false;
   const advanceLabel = currentStep < questions.length - 1 ? 'Next' : 'Review';
   const actionHint = isReview
@@ -68,57 +61,81 @@ export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
       ? `${advanceLabel} is ready when you want to continue.`
       : 'Pick an answer, or use Skip if you want to leave this question unanswered.';
 
-  const resetCustomInput = useCallback(() => {
-    setCustomMode(false);
-    setCustomText('');
-  }, []);
-
-  const saveQuestionAnswers = useCallback((questionId: string, nextAnswers: UserFeedbackAnswer[]) => {
-    setAnswers((previous) => updateQuestionAnswers(previous, questionId, nextAnswers));
+  const clearQuestionTree = useCallback((next: AnswerMap, questionItem: UserFeedbackQuestionItem): AnswerMap => {
+    const cleaned = new Map(next);
+    cleaned.delete(questionItem.id);
+    for (const option of questionItem.options) {
+      if (option.subQuestion) clearQuestionTree(cleaned, option.subQuestion);
+    }
+    return cleaned;
   }, []);
 
   const goToNextStep = useCallback(() => {
     setCurrentStep((previous) => previous + 1);
-    resetCustomInput();
-  }, [resetCustomInput]);
+  }, []);
 
   const handleSelectOption = useCallback(
-    (option: UserFeedbackQuestionOption, index: number) => {
-      if (!currentQuestion) return;
+    (questionItem: UserFeedbackQuestionItem, option: UserFeedbackQuestionOption, index: number) => {
+      const isCurrentQuestion = currentQuestion?.id === questionItem.id;
+      const currentQuestionAnswers = getQuestionAnswers(answers, questionItem.id);
 
       const nextAnswers = selectQuestionOption(
-        currentQuestion,
+        questionItem,
         option,
         index,
-        currentAnswers,
+        currentQuestionAnswers,
       );
-      saveQuestionAnswers(currentQuestion.id, nextAnswers);
-      if (currentQuestion.multiSelect !== true) {
+      const selectedSubQuestionIds = new Set(
+        nextAnswers
+          .map((answer) => questionItem.options.find((item) => item.value === answer.value)?.subQuestion?.id)
+          .filter(Boolean),
+      );
+
+      setAnswers((previous) => {
+        const next = updateQuestionAnswers(previous, questionItem.id, nextAnswers);
+        let cleaned = next;
+        for (const optionItem of questionItem.options) {
+          const subQuestion = optionItem.subQuestion;
+          if (subQuestion && !selectedSubQuestionIds.has(subQuestion.id)) {
+            cleaned = clearQuestionTree(cleaned, subQuestion);
+          }
+        }
+        return cleaned;
+      });
+
+      if (isCurrentQuestion && questionItem.multiSelect !== true && !option.subQuestion) {
         goToNextStep();
       }
     },
-    [currentAnswers, currentQuestion, goToNextStep, saveQuestionAnswers],
+    [answers, clearQuestionTree, currentQuestion?.id, goToNextStep],
   );
 
-  const handleCustomSubmit = useCallback(() => {
-    if (!currentQuestion) return;
-    const text = customText.trim();
-    if (!text) return;
+  const handleCustomSubmit = useCallback((questionItem: UserFeedbackQuestionItem, text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
 
-    const nextAnswers = submitCustomQuestionAnswer(
-      currentQuestion,
-      currentAnswers,
-      text,
-    );
-    saveQuestionAnswers(currentQuestion.id, nextAnswers);
+    setAnswers((previous) => {
+      const currentQuestionAnswers = getQuestionAnswers(previous, questionItem.id);
+      const nextAnswers = submitCustomQuestionAnswer(questionItem, currentQuestionAnswers, trimmed);
+      let next = updateQuestionAnswers(previous, questionItem.id, nextAnswers);
+      for (const option of questionItem.options) {
+        if (option.subQuestion) next = clearQuestionTree(next, option.subQuestion);
+      }
+      return next;
+    });
 
-    if (currentQuestion.multiSelect !== true) {
+    if (currentQuestion?.id === questionItem.id && questionItem.multiSelect !== true) {
       goToNextStep();
-      return;
     }
+  }, [clearQuestionTree, currentQuestion?.id, goToNextStep]);
 
-    resetCustomInput();
-  }, [currentAnswers, currentQuestion, customText, goToNextStep, resetCustomInput, saveQuestionAnswers]);
+  const handleRemoveCustom = useCallback((questionItem: UserFeedbackQuestionItem) => {
+    setAnswers((previous) => updateQuestionAnswers(
+      previous,
+      questionItem.id,
+      removeCustomQuestionAnswer(getQuestionAnswers(previous, questionItem.id)),
+    ));
+  }, []);
 
   const handleSubmit = useCallback(() => {
     onSubmit(question.id, flattenQuestionnaireAnswers(questions, answers));
@@ -136,22 +153,19 @@ export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
           {questions.map((item, index) => (
             <button type="button"
               key={item.id}
-              onClick={() => {
-                setCurrentStep(index);
-                resetCustomInput();
-              }}
+              onClick={() => setCurrentStep(index)}
               className={cn(
                 'flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
                 index === currentStep && !isReview
-                  ? hasQuestionAnswer(answers, item.id)
+                  ? hasQuestionAnswerDeep(answers, item)
                     ? 'bg-emerald-500 text-white'
                     : 'bg-amber-500 text-white'
-                  : hasQuestionAnswer(answers, item.id)
+                  : hasQuestionAnswerDeep(answers, item)
                     ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
                     : 'bg-secondary text-muted-foreground',
               )}
             >
-              {hasQuestionAnswer(answers, item.id) ? <Check className="size-3" /> : index + 1} {item.label}
+              {hasQuestionAnswerDeep(answers, item) ? <Check className="size-3" /> : index + 1} {item.label}
             </button>
           ))}
           <button type="button"
@@ -183,26 +197,10 @@ export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
         ) : currentQuestion ? (
           <QuestionnaireQuestionStep
             question={currentQuestion}
-            answers={currentAnswers}
-            customMode={customMode}
-            customText={customText}
+            answers={answers}
             onSelectOption={handleSelectOption}
-            onEnableCustom={() => {
-              setCustomMode(true);
-              setCustomText(
-                currentAnswers.find((answer) => answer.wasCustom)?.label ?? '',
-              );
-            }}
-            onRemoveCustom={() => {
-              saveQuestionAnswers(
-                currentQuestion.id,
-                removeCustomQuestionAnswer(currentAnswers),
-              );
-              resetCustomInput();
-            }}
-            onCustomTextChange={setCustomText}
             onCustomSubmit={handleCustomSubmit}
-            onCancelCustom={resetCustomInput}
+            onRemoveCustom={handleRemoveCustom}
           />
         ) : null}
       </Card>
@@ -231,10 +229,7 @@ export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
               <Button
                 variant="secondary"
                 size="sm"
-                onClick={() => {
-                  setCurrentStep(currentStep - 1);
-                  resetCustomInput();
-                }}
+                onClick={() => setCurrentStep(currentStep - 1)}
               >
                 Back
               </Button>
@@ -244,10 +239,7 @@ export function QuestionnaireForm({ question, onSubmit, onCancel }: Props) {
                 <Button
                   variant={currentQuestionAnswered ? 'ghost' : 'secondary'}
                   size="sm"
-                  onClick={() => {
-                    setCurrentStep(currentStep + 1);
-                    resetCustomInput();
-                  }}
+                  onClick={() => setCurrentStep(currentStep + 1)}
                   className={cn(
                     !currentQuestionAnswered &&
                       'border border-amber-500/30 bg-amber-500/10 text-amber-700 hover:bg-amber-500/20 hover:text-amber-800 dark:text-amber-300 dark:hover:bg-amber-500/15',

--- a/plugins/sero-user-feedback-plugin/ui/questionnaire/QuestionnaireQuestionStep.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/questionnaire/QuestionnaireQuestionStep.tsx
@@ -1,42 +1,72 @@
+import { useState } from 'react';
 import { Check, Pencil } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 
 import {
   getCustomAnswer,
+  getQuestionAnswers,
+  type AnswerMap,
 } from '../../shared/questionnaire-flow';
 import type {
-  UserFeedbackAnswer,
   UserFeedbackQuestionItem,
   UserFeedbackQuestionOption,
 } from '../types';
 
 interface QuestionnaireQuestionStepProps {
   question: UserFeedbackQuestionItem;
-  answers: UserFeedbackAnswer[];
-  customMode: boolean;
-  customText: string;
-  onSelectOption: (option: UserFeedbackQuestionOption, index: number) => void;
-  onEnableCustom: () => void;
-  onRemoveCustom: () => void;
-  onCustomTextChange: (text: string) => void;
-  onCustomSubmit: () => void;
-  onCancelCustom: () => void;
+  answers: AnswerMap;
+  onSelectOption: (question: UserFeedbackQuestionItem, option: UserFeedbackQuestionOption, index: number) => void;
+  onCustomSubmit: (question: UserFeedbackQuestionItem, text: string) => void;
+  onRemoveCustom: (question: UserFeedbackQuestionItem) => void;
 }
 
 export function QuestionnaireQuestionStep({
   question,
   answers,
-  customMode,
-  customText,
   onSelectOption,
-  onEnableCustom,
-  onRemoveCustom,
-  onCustomTextChange,
   onCustomSubmit,
-  onCancelCustom,
+  onRemoveCustom,
 }: QuestionnaireQuestionStepProps) {
-  const customAnswer = getCustomAnswer(answers);
+  return (
+    <QuestionBlock
+      question={question}
+      answers={answers}
+      onSelectOption={onSelectOption}
+      onCustomSubmit={onCustomSubmit}
+      onRemoveCustom={onRemoveCustom}
+    />
+  );
+}
+
+function QuestionBlock({
+  question,
+  answers,
+  onSelectOption,
+  onCustomSubmit,
+  onRemoveCustom,
+}: QuestionnaireQuestionStepProps) {
+  const [customMode, setCustomMode] = useState(false);
+  const [customText, setCustomText] = useState('');
+  const questionAnswers = getQuestionAnswers(answers, question.id);
+  const customAnswer = getCustomAnswer(questionAnswers);
+
+  const openCustom = () => {
+    setCustomMode(true);
+    setCustomText(customAnswer?.label ?? '');
+  };
+
+  const closeCustom = () => {
+    setCustomMode(false);
+    setCustomText('');
+  };
+
+  const submitCustom = () => {
+    const trimmed = customText.trim();
+    if (!trimmed) return;
+    onCustomSubmit(question, trimmed);
+    closeCustom();
+  };
 
   return (
     <div>
@@ -48,40 +78,56 @@ export function QuestionnaireQuestionStep({
       )}
       <div className="space-y-1.5">
         {question.options.map((option, index) => {
-          const isSelected = answers.some(
+          const isSelected = questionAnswers.some(
             (answer) => !answer.wasCustom && answer.value === option.value,
           );
+          const subQuestion = isSelected ? option.subQuestion : undefined;
           return (
-            <button type="button"
-              key={option.value}
-              onClick={() => onSelectOption(option, index)}
-              className={cn(
-                'flex w-full items-start gap-3 rounded-md border px-3 py-2.5 text-left transition-colors',
-                isSelected
-                  ? 'border-emerald-500/40 bg-emerald-500/5'
-                  : 'border-transparent hover:border-border hover:bg-secondary',
-              )}
-            >
-              <span
+            <div key={option.value} className="space-y-1.5">
+              <button type="button"
+                onClick={() => onSelectOption(question, option, index)}
                 className={cn(
-                  'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-medium',
-                  question.multiSelect && 'rounded-[4px]',
+                  'flex w-full items-start gap-3 rounded-md border px-3 py-2.5 text-left transition-colors duration-200 active:scale-[0.99]',
                   isSelected
-                    ? 'border-emerald-500 text-emerald-400'
-                    : 'border-[var(--border)] text-muted-foreground',
+                    ? 'border-emerald-500/40 bg-emerald-500/5'
+                    : 'border-transparent hover:border-border hover:bg-secondary',
                 )}
               >
-                {question.multiSelect ? (isSelected ? <Check className="size-3" /> : null) : index + 1}
-              </span>
-              <div className="min-w-0 flex-1">
-                <span className="text-sm text-foreground">{option.label}</span>
-                {option.description && (
-                  <p className="mt-0.5 text-xs text-muted-foreground">
-                    {option.description}
-                  </p>
-                )}
-              </div>
-            </button>
+                <span
+                  className={cn(
+                    'mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-medium',
+                    question.multiSelect && 'rounded-[4px]',
+                    isSelected
+                      ? 'border-emerald-500 text-emerald-400'
+                      : 'border-[var(--border)] text-muted-foreground',
+                  )}
+                >
+                  {question.multiSelect ? (isSelected ? <Check className="size-3" /> : null) : index + 1}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <span className="text-sm text-foreground">{option.label}</span>
+                  {option.description && (
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {option.description}
+                    </p>
+                  )}
+                </div>
+              </button>
+
+              {subQuestion && (
+                <div className="ml-8 border-l border-emerald-500/25 pl-4 animate-in fade-in slide-in-from-top-1 duration-200">
+                  <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/[0.03] p-3">
+                    <QuestionBlock
+                      question={subQuestion}
+                      answers={answers}
+                      onSelectOption={onSelectOption}
+                      onCustomSubmit={onCustomSubmit}
+                      onRemoveCustom={onRemoveCustom}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
           );
         })}
 
@@ -95,11 +141,11 @@ export function QuestionnaireQuestionStep({
                 <p className="mt-0.5 text-sm text-foreground">{customAnswer.label}</p>
               </div>
               <div className="flex gap-2">
-                <Button size="sm" variant="ghost" onClick={onEnableCustom}>
+                <Button size="sm" variant="ghost" onClick={openCustom}>
                   Edit
                 </Button>
                 {question.multiSelect && (
-                  <Button size="sm" variant="ghost" onClick={onRemoveCustom}>
+                  <Button size="sm" variant="ghost" onClick={() => onRemoveCustom(question)}>
                     Clear
                   </Button>
                 )}
@@ -110,7 +156,7 @@ export function QuestionnaireQuestionStep({
 
         {question.allowOther && !customMode && !customAnswer && (
           <button type="button"
-            onClick={onEnableCustom}
+            onClick={openCustom}
             className="flex w-full items-center gap-3 rounded-md border border-transparent px-3 py-2.5 text-left hover:border-border hover:bg-secondary"
           >
             <span className="flex size-5 shrink-0 items-center justify-center rounded-full border border-[var(--border)] text-[10px] text-muted-foreground">
@@ -125,18 +171,18 @@ export function QuestionnaireQuestionStep({
             <input aria-label="Other answer"
               type="text"
               value={customText}
-              onChange={(event) => onCustomTextChange(event.target.value)}
+              onChange={(event) => setCustomText(event.target.value)}
               onKeyDown={(event) => {
-                if (event.key === 'Enter') onCustomSubmit();
-                if (event.key === 'Escape') onCancelCustom();
+                if (event.key === 'Enter') submitCustom();
+                if (event.key === 'Escape') closeCustom();
               }}
               placeholder="Type your answer…"
               className="flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
             />
-            <Button size="sm" onClick={onCustomSubmit} disabled={!customText.trim()}>
+            <Button size="sm" onClick={submitCustom} disabled={!customText.trim()}>
               Submit
             </Button>
-            <Button size="sm" variant="ghost" onClick={onCancelCustom}>
+            <Button size="sm" variant="ghost" onClick={closeCustom}>
               Cancel
             </Button>
           </div>

--- a/plugins/sero-user-feedback-plugin/ui/questionnaire/QuestionnaireReviewStep.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/questionnaire/QuestionnaireReviewStep.tsx
@@ -3,8 +3,9 @@ import { cn } from '@sero-ai/ui/lib/utils';
 
 import {
   canSubmitQuestionnaire,
+  flattenQuestionnaireAnswers,
   formatQuestionnaireAnswerLabel,
-  getQuestionAnswers,
+  hasQuestionAnswerDeep,
 } from '../../shared/questionnaire-flow';
 import type {
   UserFeedbackAnswer,
@@ -24,9 +25,7 @@ export function QuestionnaireReviewStep({
   onSubmit,
   onGoToStep,
 }: QuestionnaireReviewStepProps) {
-  const skippedCount = questions.filter(
-    (question) => getQuestionAnswers(answers, question.id).length === 0,
-  ).length;
+  const skippedCount = questions.filter((question) => !hasQuestionAnswerDeep(answers, question)).length;
 
   return (
     <div>
@@ -45,8 +44,8 @@ export function QuestionnaireReviewStep({
       </p>
       <div className="space-y-3">
         {questions.map((question, index) => {
-          const questionAnswers = getQuestionAnswers(answers, question.id);
-          const isSkipped = questionAnswers.length === 0;
+          const questionAnswers = flattenQuestionnaireAnswers([question], answers);
+          const isSkipped = !hasQuestionAnswerDeep(answers, question);
           return (
             <div
               key={question.id}


### PR DESCRIPTION
## Summary
- add caveman mode as a nested memory onboarding communication option with lite/full/ultra levels
- make questionnaire option sub-questions generic across UI/TUI flow helpers and review/submission
- harden memory updates so profile changes update existing fields instead of appending contradictions
- isolate dev profile roots while keeping shared host artifacts under the real Sero toolchain root
- center transient onboarding status/error screens

## Validation
- pnpm --filter @sero-ai/plugin-user-feedback typecheck
- pnpm --filter @sero-ai/plugin-user-feedback test -- ui/QuestionnaireForm.test.tsx shared/__tests__/questionnaire-flow.test.ts
- pnpm --filter @sero-ai/plugin-memory typecheck
- pnpm --filter @sero-ai/plugin-memory test -- extension/__tests__/memory-tool.test.ts extension/__tests__/caveman.test.ts extension/__tests__/memory-instructions.test.ts
- pnpm --filter @sero/desktop test -- src/components/profiles/OnboardingWizard.test.tsx
- pnpm --filter @sero/desktop typecheck
- pnpm typecheck
- git diff HEAD --check