### PR TITLE
feat(subagent): stream reasoning deltas to live output

### DIFF
--- a/apps/desktop/electron/__tests__/features/subagent/runner.test.ts
+++ b/apps/desktop/electron/__tests__/features/subagent/runner.test.ts
@@ -71,7 +71,7 @@ function createSession() {
   return {
     model: { id: 'claude-test-1', provider: 'anthropic' },
     setThinkingLevel: vi.fn(),
-    subscribe: vi.fn(() => vi.fn()),
+    subscribe: vi.fn((_listener?: (event: Record<string, unknown>) => void) => vi.fn()),
     prompt: vi.fn(async () => {}),
     messages: [],
     getSessionStats: vi.fn(() => ({
@@ -172,6 +172,37 @@ describe('resolveSubagentPaths', () => {
     expect(resolved.sessionPath).toBe('/tmp/outside');
     expect(resolved.containerHostPath).toBe('/Users/me/project');
     expect(resolved.containerCwd).toBeUndefined();
+  });
+});
+
+function createStreamingSession(events: Array<Record<string, unknown>>) {
+  const session = createSession();
+  let listener: ((event: Record<string, unknown>) => void) | null = null;
+  session.subscribe = vi.fn((cb?: (event: Record<string, unknown>) => void) => {
+    listener = cb ?? null;
+    return vi.fn();
+  });
+  session.prompt = vi.fn(async () => {
+    for (const event of events) listener?.(event);
+  });
+  return session;
+}
+
+describe('runSubagent live output', () => {
+  it('forwards both text and reasoning deltas into the live-output channel', async () => {
+    const session = createStreamingSession([
+      { type: 'message_update', assistantMessageEvent: { type: 'thinking_delta', delta: 'weighing options…' } },
+      { type: 'message_update', assistantMessageEvent: { type: 'text_delta', delta: 'final answer' } },
+    ]);
+    mocks.createAgentSession.mockImplementationOnce(async () => ({ session }));
+
+    const deltas: string[] = [];
+    const config = createConfig(new AbortController().signal);
+    config.onTextDelta = (delta) => deltas.push(delta);
+
+    await runSubagent(config, createDeps());
+
+    expect(deltas).toEqual(['weighing options…', 'final answer']);
   });
 });
 

--- a/apps/desktop/electron/features/subagent/runtime/runner.ts
+++ b/apps/desktop/electron/features/subagent/runtime/runner.ts
@@ -335,10 +335,17 @@ export async function runSubagent(
         clearStallTimer();
       }
 
-      // Text deltas → live output stream
+      // Text + reasoning deltas → live output stream. Reasoning is forwarded
+      // alongside the answer text so structured-output agents (which emit
+      // almost no answer text before their terminating tool call) still show
+      // live progress. The final response is rebuilt from message text only,
+      // so reasoning never leaks into the structured result.
       if (event.type === 'message_update') {
         const ame = event.assistantMessageEvent as Record<string, unknown> | undefined;
-        if (ame?.type === 'text_delta' && typeof ame.delta === 'string') {
+        if (
+          (ame?.type === 'text_delta' || ame?.type === 'thinking_delta') &&
+          typeof ame.delta === 'string'
+        ) {
           onTextDelta?.(ame.delta);
         }
       }


### PR DESCRIPTION
## Summary

Structured-output subagents can spend most of their run emitting reasoning events and only produce answer text at the very end, usually when they call their terminating submission tool. That meant the live-output channel stayed blank during the most important part of the run, making workflows such as the Factory Workflow Architect look stalled even though the agent was actively working.

This PR forwards `thinking_delta` events through the same `onTextDelta` live-output path that already handles `text_delta` events. The structured result remains safe: the final response is still reconstructed from message text only, so reasoning is displayed as transient progress and is not persisted into the returned structured answer.

## What changed

- Updated the subagent runtime stream handler to treat both `text_delta` and `thinking_delta` message updates as live-output deltas.
- Kept final response assembly unchanged, preserving the existing separation between live progress and returned structured output.
- Added a regression test that simulates both reasoning and text streaming from an agent session and verifies both deltas are forwarded in order.
- Tightened the test session mock typing around `subscribe` so the streaming test can capture and replay message events directly.

## Why this matters

Without this, structured-output subagents appear idle until their final tool call, even when the underlying model is producing useful progress signals. Forwarding reasoning deltas gives users immediate feedback during longer planning or factory-style workflows without changing the contract of the final result.

## Testing

- `pnpm --filter @sero/desktop test -- apps/desktop/electron/__tests__/features/subagent/runner.test.ts`
  - Passed: 315 test files, 1,638 tests
- `pnpm typecheck`
  - Passed: 17 tasks

## Review notes

The main thing to verify is the intended boundary: reasoning deltas now flow to live output, but only message text is used for the final subagent response.
