### PR TITLE
feat(orchestrator): add PR lifecycle loops

### DIFF
--- a/apps/desktop/e2e/catalog-author.agent.spec.ts
+++ b/apps/desktop/e2e/catalog-author.agent.spec.ts
@@ -99,9 +99,35 @@ const RECIPES: Recipe[] = [
     slug: 'ci-fixer',
     name: 'CI fixer',
     prompt:
-      'Whenever a CI run fails in this repository, investigate that failed run: read the failure logs, find the cause, make the smallest fix that addresses it, and verify the fix by running the checks that failed. Open a pull request with the fix.',
-    create: { useManagedWorktree: true, deliveryDestination: 'pr' },
+      "Whenever a CI run fails on a pull request branch in this repository, fix that failure: read the failed run's logs with gh, find the root cause, make the smallest fix that addresses it, run the checks that failed to confirm they now pass, and push the fix so the pull request updates. Only act when the failing branch belongs to an open pull request that I authored or that Sero created; ignore failures on other branches.",
+    create: { useManagedWorktree: true, worktreeBranchSource: 'event-pr', deliveryDestination: 'pr' },
     wantTrigger: (t) => t.some((x) => x.eventSource === 'github:ci-failed' && !x.maxFires),
+  },
+  {
+    slug: 'review-responder',
+    name: 'Review responder',
+    prompt:
+      'Whenever a review comment is posted on one of my open pull requests by someone other than me, respond to that review: read the full review thread and the pull request diff, work through every unaddressed comment — apply the requested change when it is right, answer it when it is a question, or explain briefly why you disagree — verify the project still passes its checks after any changes, push, and reply to each comment on the pull request with what was done. Comments that arrive close together should be handled as one batch.',
+    create: { useManagedWorktree: true, worktreeBranchSource: 'event-pr', deliveryDestination: 'pr' },
+    wantTrigger: (t) => t.some((x) => x.eventSource === 'github:review-comment' && !x.maxFires),
+  },
+  {
+    slug: 'rebase-on-main',
+    name: 'Rebase on main',
+    prompt:
+      'Whenever the main branch of this repository is updated, bring my open pull requests up to date: list the open pull requests that I authored or that Sero created, and for each one that is behind main, rebase it onto the latest main (or merge main in when rebasing is unsafe), resolve conflicts only when the resolution is obvious, run the project checks, and push the updated branch. Leave any pull request whose conflicts are not clearly resolvable untouched and describe the conflict in a comment on that pull request instead. Wait at least fifteen minutes after the last main update before starting so a burst of pushes is handled once.',
+    create: { useManagedWorktree: true, deliveryDestination: 'pr' },
+    wantTrigger: (t) => t.some((x) => x.eventSource === 'github:main-updated' && !x.maxFires),
+  },
+  {
+    slug: 'issue-implementer',
+    name: 'Issue implementer',
+    prompt:
+      'Every two hours, and whenever a new issue is opened in this repository, work the issue backlog. First scan: list open unassigned issues and exclude any that already have an open pull request linked, a human assignee, or a recent Sero claim comment (a "Sero started work on this issue" marker posted within the last day — older markers with no linked pull request count as expired). Judge the remaining candidates on clarity, size, risk, and value, and pick the single best one — or, if none is suitable, finish the pass reporting that plainly without claiming completion of any delivery. Before writing any code, claim the chosen issue: assign it to me and post the comment "Sero started work on this issue" with the current time; then re-read the issue, and if someone else is now also assigned or posted an earlier active claim, remove my assignment and finish the pass as skipped. Once the claim is verified, decide the approach: implement directly when the issue is small and clear; write a short implementation plan first when it is substantial; when it is too vague, post concrete clarifying questions on the issue, remove my assignment, and finish the pass; when it needs a product decision or is too large for one change, comment why with a suggested breakdown, remove my assignment, and finish the pass. When implementing: make the change, add or update tests and documentation where they apply, run the project checks, and open a pull request whose description includes "Closes #<issue number>"; then comment the pull request link on the issue. Handle exactly one issue per pass and never merge pull requests.',
+    create: { useManagedWorktree: true, deliveryDestination: 'pr' },
+    wantTrigger: (t) =>
+      t.some((x) => (x.type === 'cron' || x.type === 'hybrid') && !!x.schedule && !x.maxFires) &&
+      t.some((x) => x.eventSource === 'github:issue-opened' && !x.maxFires),
   },
   {
     slug: 'issue-triage-report',

--- a/apps/desktop/electron/__tests__/features/vcs/worktree/manager-existing-branch.test.ts
+++ b/apps/desktop/electron/__tests__/features/vcs/worktree/manager-existing-branch.test.ts
@@ -1,0 +1,94 @@
+/**
+ * WorktreeManager existing-branch checkout (orchestrator spec 15, FR-P2):
+ * PR-lifecycle work must land on the PR's own branch, so `create` with
+ * `existingBranch` checks that branch out instead of minting a new one —
+ * from a local ref, or from origin when it only exists remotely. Real git
+ * against temp repos; no mocks.
+ */
+
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { WorktreeManager } from '@electron/features/vcs/worktree/manager';
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd });
+  return stdout.trim();
+}
+
+async function initRepo(dir: string): Promise<void> {
+  await git(dir, 'init', '-b', 'main');
+  await git(dir, 'config', 'user.email', 'test@example.com');
+  await git(dir, 'config', 'user.name', 'Test');
+  await writeFile(path.join(dir, 'readme.md'), 'hello');
+  await git(dir, 'add', '.');
+  await git(dir, 'commit', '-m', 'init');
+}
+
+describe('WorktreeManager.create with existingBranch', () => {
+  let root: string;
+  let workspace: string;
+  const manager = new WorktreeManager();
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'wt-existing-'));
+    workspace = path.join(root, 'workspace');
+    await execFileAsync('mkdir', ['-p', workspace]);
+    await initRepo(workspace);
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('checks out a local branch as-is, minting nothing', async () => {
+    await git(workspace, 'branch', 'feat/pr-branch');
+    const result = await manager.create(workspace, 'loop-1', 'ignored title', { existingBranch: 'feat/pr-branch' });
+
+    expect(result.branchName).toBe('feat/pr-branch');
+    expect(await git(result.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('feat/pr-branch');
+    // Removal keeps the branch — it belongs to the PR.
+    await manager.remove(workspace, 'loop-1');
+    expect(await git(workspace, 'rev-parse', '--verify', 'refs/heads/feat/pr-branch')).toBeTruthy();
+  });
+
+  it('fetches and tracks a branch that only exists on origin', async () => {
+    // A second repo plays "origin" holding the PR branch.
+    const origin = path.join(root, 'origin');
+    await execFileAsync('mkdir', ['-p', origin]);
+    await initRepo(origin);
+    await git(origin, 'checkout', '-b', 'feat/remote-only');
+    await writeFile(path.join(origin, 'change.md'), 'remote work');
+    await git(origin, 'add', '.');
+    await git(origin, 'commit', '-m', 'remote work');
+    await git(workspace, 'remote', 'add', 'origin', origin);
+
+    const result = await manager.create(workspace, 'loop-2', 'ignored', { existingBranch: 'feat/remote-only' });
+
+    expect(result.branchName).toBe('feat/remote-only');
+    expect(await git(result.worktreePath, 'rev-parse', '--abbrev-ref', 'HEAD')).toBe('feat/remote-only');
+    const upstream = await git(result.worktreePath, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}');
+    expect(upstream).toBe('origin/feat/remote-only');
+  });
+
+  it('errors clearly when the branch exists nowhere — never falls back to a fresh branch', async () => {
+    await expect(manager.create(workspace, 'loop-3', 'ignored', { existingBranch: 'no/such-branch' })).rejects.toThrow(
+      'exists neither locally nor on origin',
+    );
+  });
+
+  it('refuses branch names git would refuse', async () => {
+    await expect(manager.create(workspace, 'loop-4', 'ignored', { existingBranch: '--upload-pack=x' })).rejects.toThrow(
+      'Invalid branch name',
+    );
+    await expect(manager.create(workspace, 'loop-5', 'ignored', { existingBranch: 'a..b' })).rejects.toThrow(
+      'Invalid branch name',
+    );
+  });
+});

--- a/apps/desktop/electron/features/apps/runtime/capabilities/create-host.ts
+++ b/apps/desktop/electron/features/apps/runtime/capabilities/create-host.ts
@@ -156,8 +156,8 @@ export function createAppRuntimeHost(_target: AppRuntimeTarget): AppRuntimeHost 
       summarizeFailure: summarizeVerificationFailure,
     },
     git: {
-      createWorktree: (workspacePath, cardId, cardTitle) =>
-        worktreeManager.create(workspacePath, cardId, cardTitle),
+      createWorktree: (workspacePath, cardId, cardTitle, options) =>
+        worktreeManager.create(workspacePath, cardId, cardTitle, options),
       removeWorktree: (workspacePath, cardId, options) =>
         worktreeManager.remove(workspacePath, cardId, options),
       getWorkspaceStatus,

--- a/apps/desktop/electron/features/vcs/worktree/manager.ts
+++ b/apps/desktop/electron/features/vcs/worktree/manager.ts
@@ -107,6 +107,9 @@ export class WorktreeManager {
    *
    * Creates a new branch and checks it out in an isolated directory.
    * The worktree shares the `.git` object store with the main repo.
+   * With `existingBranch`, checks out that branch (fetching it from origin
+   * when it only exists remotely) instead of minting a new one — never
+   * delete such a worktree's branch on removal, it belongs to a PR.
    *
    * @returns The absolute path to the worktree directory
    */
@@ -114,7 +117,11 @@ export class WorktreeManager {
     workspacePath: string,
     cardId: string,
     cardTitle: string,
+    options?: { existingBranch?: string },
   ): Promise<{ worktreePath: string; branchName: string; greenfield: boolean }> {
+    if (options?.existingBranch) {
+      return this.createAtExistingBranch(workspacePath, cardId, options.existingBranch);
+    }
     // Ensure the workspace is a valid git repo with at least one commit
     const greenfield = await ensureGitReady(workspacePath);
 
@@ -160,6 +167,61 @@ export class WorktreeManager {
 
     console.log(`[worktree] Created worktree for card-${cardId} at ${worktreePath} (branch: ${branchName})${greenfield ? ' [greenfield]' : ''}`);
     return { worktreePath, branchName, greenfield };
+  }
+
+  /**
+   * Check an EXISTING branch out into a worktree (PR-lifecycle work: commits
+   * must land on the PR's own branch). The branch is fetched from origin
+   * first so a PR pushed from elsewhere is present and current; a local-only
+   * branch (no remote) is used as-is.
+   */
+  private async createAtExistingBranch(
+    workspacePath: string,
+    cardId: string,
+    branchName: string,
+  ): Promise<{ worktreePath: string; branchName: string; greenfield: boolean }> {
+    // Branch names come from event payloads — refuse anything git itself
+    // would refuse rather than passing surprising tokens to the CLI.
+    if (branchName.startsWith('-') || !/^[^\s~^:?*[\\]+$/.test(branchName) || branchName.includes('..')) {
+      throw new Error(`Invalid branch name "${branchName}"`);
+    }
+    const worktreePath = this.getPath(workspacePath, cardId);
+    await fs.mkdir(path.dirname(worktreePath), { recursive: true });
+
+    // Best-effort: a local-only branch or an offline repo still resolves below.
+    try {
+      await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: workspacePath, timeout: 60_000 });
+    } catch {
+      console.log(`[worktree] fetch origin ${branchName} failed — trying local refs`);
+    }
+
+    const hasRef = async (ref: string): Promise<boolean> => {
+      try {
+        await execFileAsync('git', ['rev-parse', '--verify', '--quiet', ref], { cwd: workspacePath, timeout: 5_000 });
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const addArgs = (await hasRef(`refs/heads/${branchName}`))
+      ? ['worktree', 'add', worktreePath, branchName]
+      : (await hasRef(`refs/remotes/origin/${branchName}`))
+        ? ['worktree', 'add', '--track', '-b', branchName, worktreePath, `origin/${branchName}`]
+        : null;
+    if (!addArgs) {
+      throw new Error(`Branch "${branchName}" exists neither locally nor on origin`);
+    }
+    try {
+      await execFileAsync('git', addArgs, { cwd: workspacePath, timeout: 30_000 });
+    } catch (err: unknown) {
+      const stderr = err && typeof err === 'object' && 'stderr' in err ? String((err as { stderr: unknown }).stderr) : '';
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to check out branch "${branchName}" for card ${cardId}: ${stderr || message}`);
+    }
+
+    console.log(`[worktree] Created worktree for card-${cardId} at ${worktreePath} (existing branch: ${branchName})`);
+    return { worktreePath, branchName, greenfield: false };
   }
 
   /**

--- a/apps/docs-site/docs/reference/orchestrator.md
+++ b/apps/docs-site/docs/reference/orchestrator.md
@@ -119,6 +119,15 @@ until you set it, so a run never stalls halfway to ask for it. Loops installed
 from the catalog never include these values (they're yours, not the
 author's) — set them in Delivery before activating.
 
+**Working on an existing pull request.** A loop that reacts to PR events (CI
+failed, review comments) can be set to **work on the PR branch from the firing
+event** — a switch next to the worktree setting when you create it. Instead of
+starting a fresh branch, each run checks out the branch of the PR the event
+points at, so its commits and pushes update that PR directly. The branch
+belongs to the PR: deleting the loop never deletes it. If a run can't tell
+which PR branch to use (for example you ran it manually, with no event), it
+stops with a plain explanation rather than guessing.
+
 **Receipts.** A loop that declares a destination completes only when its final
 step reports a delivery receipt — what landed and where (PR URL, message link,
 draft id, file path). A completion claim without one is rejected and the step
@@ -190,13 +199,25 @@ event details on hover.
 | --- | --- |
 | `loop:completed` / `loop:blocked` / `loop:asked-question` | another loop in the workspace finishes, blocks, or asks a question |
 | `fs:changed` | files in the workspace change (one batched event per burst) |
-| `github:pr-opened`, `github:ci-failed`, `github:ci-passed`, `github:issue-labelled`, `github:review-requested`, `github:review-comment` | the matching activity happens on the workspace's GitHub repo |
+| `github:pr-opened`, `github:ci-failed`, `github:ci-passed`, `github:issue-labelled`, `github:review-requested`, `github:review-comment`, `github:pr-approved`, `github:main-updated`, `github:issue-opened` | the matching activity happens on the workspace's GitHub repo |
 | `webhook:<name>` | an external system POSTs JSON to `http://127.0.0.1:<port>/hooks/<name>` |
 
 An event trigger can carry an exact-match filter ("only the `bug` label") and a
 plain-language condition ("only when the failing PR is mine") judged at fire
 time. The event that started a run shows as a chip on that run in the history,
 and its details (source, summary, payload) are given to every step.
+
+Events that arrive while a run is already going are not lost: they queue (up
+to ten, oldest first) and each one gets its own run when the current one
+finishes. The loop's summary line shows how many are waiting and which is
+next; if the queue ever overflows, the oldest event is dropped with a visible
+warning on the loop.
+
+Some situations have no event because nothing "happens" — a pull request going
+stale is just time passing. Write those as a schedule instead: "every morning,
+list my open pull requests that have had no activity for a week and …". A
+hybrid loop can combine both — a schedule for the sweep plus events for
+instant reaction.
 
 Sources only do work while an active loop uses them: the file watcher, webhook
 listener, and GitHub poller all stop when the last subscribing loop is paused.

--- a/apps/docs-site/docs/reference/orchestrator.md
+++ b/apps/docs-site/docs/reference/orchestrator.md
@@ -124,9 +124,11 @@ failed, review comments) can be set to **work on the PR branch from the firing
 event** — a switch next to the worktree setting when you create it. Instead of
 starting a fresh branch, each run checks out the branch of the PR the event
 points at, so its commits and pushes update that PR directly. The branch
-belongs to the PR: deleting the loop never deletes it. If a run can't tell
-which PR branch to use (for example you ran it manually, with no event), it
-stops with a plain explanation rather than guessing.
+belongs to the PR: deleting the loop never deletes it. Only a firing event
+that points at a pull request can name the branch (CI results, PR opened,
+approvals, review comments); any other start — a schedule, a manual run, or a
+repo-wide event like "main updated" — stops with a plain explanation rather
+than guessing.
 
 **Receipts.** A loop that declares a destination completes only when its final
 step reports a delivery receipt — what landed and where (PR URL, message link,

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -1,0 +1,63 @@
+# PR Lifecycle Loops — implementation plan (spec 15)
+
+Branch: `feat/orchestrator-pr-lifecycle`. Spec:
+[specs/15-pr-lifecycle.md](specs/15-pr-lifecycle.md).
+
+## Phases
+
+- [x] **Phase 1 — Pending-event FIFO queue** (FR-P3): `runtime.pendingEvents`
+      replaces latest-wins `pendingEvent`; cap 10, dedupe `source#dedupeKey`,
+      drop-oldest → `event-queue-overflow` warning; drain oldest-first;
+      persisted `pendingEvent` migrates as a one-element queue.
+- [ ] **Phase 2 — New GitHub kinds** (FR-P4): `pr-approved` + `main-updated`
+      via `repo-events`, `issue-opened` via `issues` (PR entries dropped);
+      source catalog entries.
+- [ ] **Phase 3 — Existing-branch worktree host seam** (FR-P2):
+      `createWorktree(key, title, { existingBranch })` through
+      packages/common → desktop-core `WorktreeManager` → plugin host;
+      removal never deletes the branch.
+- [ ] **Phase 4 — event-pr branch resolution** (FR-P1):
+      `worktreeBranchSource: 'new' | 'event-pr'`; branch from event payload,
+      else PR-number lookup in `listPullRequests()`; unresolvable → visible
+      block, no fallback; `deleteBranch` guarded for event-pr worktrees.
+- [ ] **Phase 5 — pr receipt widening** (FR-P5): verify-back accepts an
+      update to an existing open PR named by number.
+- [ ] **Phase 6 — UI**: branch source control (event/hybrid loops), queued
+      events count in loop detail, overflow warning chip.
+- [ ] **Phase 7 — Catalog entries** (FR-P7, FR-P9): `issue-implementer`
+      (claim protocol), `ci-fixer`, `review-responder`, `rebase-on-main`;
+      content validation + e2e (lost claim race ⇒ skipped, no PR).
+- [ ] **Phase 8 — Docs** (FR-P6, FR-P8): docs-site reference (branch source,
+      event queue, new sources, stale-PR hybrid pattern).
+
+## FR matrix
+
+| FR | Phase | Status |
+| --- | --- | --- |
+| FR-P1 event-pr resolution, visible block | 4 | pending |
+| FR-P2 existingBranch worktree seam | 3 | pending |
+| FR-P3 pending-event FIFO | 1 | done |
+| FR-P4 three new GitHub kinds | 2 | pending |
+| FR-P5 updated-PR receipts | 5 | pending |
+| FR-P6 stale-PR hybrid pattern documented | 8 | pending |
+| FR-P7 four catalog entries shipped | 7 | pending |
+| FR-P8 docs-site reference updated | 8 | pending |
+| FR-P9 claim protocol e2e-verified | 7 | pending |
+
+## Constraints carried in
+
+- `run-engine.ts` (487 LOC) and `coordinator.ts` (496 LOC) are at the
+  500-LOC cap — spec-15 work lands in new modules or must move weight out
+  first.
+- Catalog authoring uses the spec-14 harness (`catalog-author.agent.spec.ts`
+  RECIPES) against the official catalog checkout; per-entry `version` bumps
+  are what make updates visible to installed loops.
+
+## Findings during implementation
+
+- Phase 1: `runEventPass` previously re-armed from a caller-held loop copy via
+  `replaceLoop`, which could overwrite an event enqueued concurrently — the
+  re-arm now happens inside `updateState` against the on-disk copy. Also
+  caught in review: `rearmLoop` clears `runtime.workspace`, so the prior
+  worktree must be captured before the re-arm or it leaks. `run-engine.ts` is
+  now 494/500 LOC.

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -20,8 +20,9 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
       `worktreeBranchSource: 'new' | 'event-pr'`; branch from event payload,
       else PR-number lookup in `listPullRequests()`; unresolvable → visible
       block, no fallback; `deleteBranch` guarded for event-pr worktrees.
-- [ ] **Phase 5 — pr receipt widening** (FR-P5): verify-back accepts an
-      update to an existing open PR named by number.
+- [x] **Phase 5 — pr receipt widening** (FR-P5): verify-back accepts an
+      update to an existing open PR named by number; pr receipt hint covers
+      opened-or-updated; event-pr loops get push-not-open planner rules.
 - [ ] **Phase 6 — UI**: branch source control (event/hybrid loops), queued
       events count in loop detail, overflow warning chip.
 - [ ] **Phase 7 — Catalog entries** (FR-P7, FR-P9): `issue-implementer`
@@ -38,7 +39,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
 | FR-P2 existingBranch worktree seam | 3 | done |
 | FR-P3 pending-event FIFO | 1 | done |
 | FR-P4 three new GitHub kinds | 2 | done |
-| FR-P5 updated-PR receipts | 5 | pending |
+| FR-P5 updated-PR receipts | 5 | done |
 | FR-P6 stale-PR hybrid pattern documented | 8 | pending |
 | FR-P7 four catalog entries shipped | 7 | pending |
 | FR-P8 docs-site reference updated | 8 | pending |

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -9,7 +9,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
       replaces latest-wins `pendingEvent`; cap 10, dedupe `source#dedupeKey`,
       drop-oldest → `event-queue-overflow` warning; drain oldest-first;
       persisted `pendingEvent` migrates as a one-element queue.
-- [ ] **Phase 2 — New GitHub kinds** (FR-P4): `pr-approved` + `main-updated`
+- [x] **Phase 2 — New GitHub kinds** (FR-P4): `pr-approved` + `main-updated`
       via `repo-events`, `issue-opened` via `issues` (PR entries dropped);
       source catalog entries.
 - [ ] **Phase 3 — Existing-branch worktree host seam** (FR-P2):
@@ -37,7 +37,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
 | FR-P1 event-pr resolution, visible block | 4 | pending |
 | FR-P2 existingBranch worktree seam | 3 | pending |
 | FR-P3 pending-event FIFO | 1 | done |
-| FR-P4 three new GitHub kinds | 2 | pending |
+| FR-P4 three new GitHub kinds | 2 | done |
 | FR-P5 updated-PR receipts | 5 | pending |
 | FR-P6 stale-PR hybrid pattern documented | 8 | pending |
 | FR-P7 four catalog entries shipped | 7 | pending |
@@ -61,3 +61,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
   caught in review: `rearmLoop` clears `runtime.workspace`, so the prior
   worktree must be captured before the re-arm or it leaks. `run-engine.ts` is
   now 494/500 LOC.
+- Phase 2: `main-updated` needs the repo default branch, which no list
+  endpoint carries — the adapter resolves `repos/{owner}/{repo}` once under
+  demand and persists it in `events/github.json`; until it resolves the kind
+  emits nothing (a failed meta fetch counts as a failed cycle and retries).

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -23,8 +23,10 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
 - [x] **Phase 5 — pr receipt widening** (FR-P5): verify-back accepts an
       update to an existing open PR named by number; pr receipt hint covers
       opened-or-updated; event-pr loops get push-not-open planner rules.
-- [ ] **Phase 6 — UI**: branch source control (event/hybrid loops), queued
-      events count in loop detail, overflow warning chip.
+- [x] **Phase 6 — UI**: branch source switch in the create form, queued
+      events chip in the loop meta strip (count + next summary), "PR branch
+      from event" workspace label; overflow warning renders via the existing
+      generic warning list. `worktreeBranchSource` exposed on the tool.
 - [ ] **Phase 7 — Catalog entries** (FR-P7, FR-P9): `issue-implementer`
       (claim protocol), `ci-fixer`, `review-responder`, `rebase-on-main`;
       content validation + e2e (lost claim race ⇒ skipped, no PR).

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -81,6 +81,16 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
   run history reads oddly for honest no-ops. If it grates in practice, the
   fix is a first-class no-delivery completion in the contract — a deliberate
   contract change, not something to slip in here.
+- Post-review (PR #227): event-pr resolution is now SOURCE-aware. The original
+  resolver took any `payload.branch` at face value, but `github:main-updated`
+  carries `branch: <default branch>` — pairing it with `event-pr` would have
+  checked out main as the "PR branch" and the update planner rules push the
+  current branch. Only PR-scoped GitHub events resolve now: `ci-failed`,
+  `ci-passed`, `pr-opened` may use `payload.branch` (their branch IS the PR
+  head ref); `pr-approved`, `review-comment`, `review-requested` must go
+  through the PR-number lookup; every other source blocks visibly. A failed
+  `listPullRequests()` call is also its own block reason now, no longer
+  indistinguishable from "PR not open".
 - Phase 4: `worktreeBranchSource` had to join `SharedLoopDefinition` — the
   spec's catalog loops set it, but workspace settings don't travel in shared
   definitions; the branch source is definitional (like the delivery kind), so

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -27,11 +27,16 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
       events chip in the loop meta strip (count + next summary), "PR branch
       from event" workspace label; overflow warning renders via the existing
       generic warning list. `worktreeBranchSource` exposed on the tool.
-- [ ] **Phase 7 — Catalog entries** (FR-P7, FR-P9): `issue-implementer`
-      (claim protocol), `ci-fixer`, `review-responder`, `rebase-on-main`;
-      content validation + e2e (lost claim race ⇒ skipped, no PR).
-- [ ] **Phase 8 — Docs** (FR-P6, FR-P8): docs-site reference (branch source,
-      event queue, new sources, stale-PR hybrid pattern).
+- [x] **Phase 7 — Catalog entries** (FR-P7, FR-P9): all four authored via the
+      product harness into the official catalog checkout
+      (`~/Documents/Dev/projects/sero/orchestrator-catalog`, committed, NOT
+      pushed); ci-fixer re-authored as v2 (event-pr, push-not-open); content
+      validation 28/28. REMAINING: the live claim-race e2e (a pre-claimed
+      issue must yield a skipped pass and no PR) — needs the real-repo
+      verification round, same as spec 12's.
+- [x] **Phase 8 — Docs** (FR-P6, FR-P8): docs-site reference covers the PR
+      branch source, the event queue, the three new sources, and the
+      stale-PR schedule pattern.
 
 ## FR matrix
 
@@ -42,10 +47,10 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
 | FR-P3 pending-event FIFO | 1 | done |
 | FR-P4 three new GitHub kinds | 2 | done |
 | FR-P5 updated-PR receipts | 5 | done |
-| FR-P6 stale-PR hybrid pattern documented | 8 | pending |
-| FR-P7 four catalog entries shipped | 7 | pending |
-| FR-P8 docs-site reference updated | 8 | pending |
-| FR-P9 claim protocol e2e-verified | 7 | pending |
+| FR-P6 stale-PR hybrid pattern documented | 8 | done |
+| FR-P7 four catalog entries shipped | 7 | done (catalog repo committed, push pending) |
+| FR-P8 docs-site reference updated | 8 | done |
+| FR-P9 claim protocol e2e-verified | 7 | authored + content-validated; live claim-race e2e pending |
 
 ## Constraints carried in
 
@@ -68,6 +73,14 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
   endpoint carries — the adapter resolves `repos/{owner}/{repo}` once under
   demand and persists it in `events/github.json`; until it resolves the kind
   emits nothing (a failed meta fetch counts as a failed cycle and retries).
+- Phase 7 (open question for Dan): a scan pass that finds NOTHING to do
+  cannot claim completion on a `pr`-destination loop — the delivery contract
+  (rightly) refuses completion without a receipt, so the sanctioned no-op
+  shape is "final step succeeds WITHOUT a completion signal" and the run ends
+  as `waiting`. Mechanically fine (the next fire re-arms regardless), but the
+  run history reads oddly for honest no-ops. If it grates in practice, the
+  fix is a first-class no-delivery completion in the contract — a deliberate
+  contract change, not something to slip in here.
 - Phase 4: `worktreeBranchSource` had to join `SharedLoopDefinition` — the
   spec's catalog loops set it, but workspace settings don't travel in shared
   definitions; the branch source is definitional (like the delivery kind), so

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -16,7 +16,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
       `createWorktree(key, title, { existingBranch })` through
       packages/common → desktop-core `WorktreeManager` → plugin host;
       removal never deletes the branch.
-- [ ] **Phase 4 — event-pr branch resolution** (FR-P1):
+- [x] **Phase 4 — event-pr branch resolution** (FR-P1):
       `worktreeBranchSource: 'new' | 'event-pr'`; branch from event payload,
       else PR-number lookup in `listPullRequests()`; unresolvable → visible
       block, no fallback; `deleteBranch` guarded for event-pr worktrees.
@@ -34,7 +34,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
 
 | FR | Phase | Status |
 | --- | --- | --- |
-| FR-P1 event-pr resolution, visible block | 4 | pending |
+| FR-P1 event-pr resolution, visible block | 4 | done |
 | FR-P2 existingBranch worktree seam | 3 | done |
 | FR-P3 pending-event FIFO | 1 | done |
 | FR-P4 three new GitHub kinds | 2 | done |
@@ -65,3 +65,10 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
   endpoint carries — the adapter resolves `repos/{owner}/{repo}` once under
   demand and persists it in `events/github.json`; until it resolves the kind
   emits nothing (a failed meta fetch counts as a failed cycle and retries).
+- Phase 4: `worktreeBranchSource` had to join `SharedLoopDefinition` — the
+  spec's catalog loops set it, but workspace settings don't travel in shared
+  definitions; the branch source is definitional (like the delivery kind), so
+  it rides the definition and tracks version switches. Also: the resolver now
+  receives the RUN (the event payload lives in the run's `event` observation,
+  not on `firedBy`), and `needsWorkspace` moved to run-engine-helpers to keep
+  run-engine.ts at 496/500.

--- a/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
+++ b/docs/features/orchestration/sero-orchestrator/pr-lifecycle-implementation-plan.md
@@ -12,7 +12,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
 - [x] **Phase 2 — New GitHub kinds** (FR-P4): `pr-approved` + `main-updated`
       via `repo-events`, `issue-opened` via `issues` (PR entries dropped);
       source catalog entries.
-- [ ] **Phase 3 — Existing-branch worktree host seam** (FR-P2):
+- [x] **Phase 3 — Existing-branch worktree host seam** (FR-P2):
       `createWorktree(key, title, { existingBranch })` through
       packages/common → desktop-core `WorktreeManager` → plugin host;
       removal never deletes the branch.
@@ -35,7 +35,7 @@ Branch: `feat/orchestrator-pr-lifecycle`. Spec:
 | FR | Phase | Status |
 | --- | --- | --- |
 | FR-P1 event-pr resolution, visible block | 4 | pending |
-| FR-P2 existingBranch worktree seam | 3 | pending |
+| FR-P2 existingBranch worktree seam | 3 | done |
 | FR-P3 pending-event FIFO | 1 | done |
 | FR-P4 three new GitHub kinds | 2 | done |
 | FR-P5 updated-PR receipts | 5 | pending |

--- a/docs/features/orchestration/sero-orchestrator/specs/15-pr-lifecycle.md
+++ b/docs/features/orchestration/sero-orchestrator/specs/15-pr-lifecycle.md
@@ -1,0 +1,343 @@
+# 15 — PR Lifecycle Loops
+
+Status: **draft — direction approved 2026-07-03**.
+
+The killer-features analysis frames the Autonomous PR Lifecycle Manager as "a
+specialised bundle built on Living Loops, Graduated Autonomy, Verified
+Delivery, Pluggable Delivery" — and two of those four now exist (specs 12 and
+13). The GitHub adapter already emits `pr-opened`, `ci-failed`, `ci-passed`,
+`issue-labelled`, `review-requested`, and `review-comment` with payloads that
+name the branch, PR number, sha, and author; a fired event starts a fresh
+iteration and its payload reaches every step prompt; `pr` delivery has
+verified receipts; the Catalog (spec 14) is the packaging.
+
+So this spec is **not a new subsystem**. It closes four mechanical gaps and
+then authors three catalog loops on top of the existing machinery.
+
+Example loops this enables:
+
+```text
+When CI fails on a PR I opened, diagnose the failure, fix it on the PR's own
+branch, rerun validation, and push.
+
+When a reviewer comments on one of my PRs, classify the comments, apply the
+requested fixes, push, and reply.
+
+When main moves, rebase my open Sero PRs onto it, resolve what's resolvable,
+run validation, and push the updated branches.
+```
+
+## Current state and gaps
+
+1. **Worktrees always mint a fresh branch.** `workspace.ts` keys a worktree
+   per run and `WorktreeManager.create` (desktop-core,
+   `electron/features/vcs/worktree/manager.ts`) always does
+   `git worktree add -b <new-branch> <baseRef>`. A lifecycle loop must check
+   out the PR's **own head branch**, commit, and push to it so the PR
+   updates. No seam for that exists anywhere.
+2. **Discrete events get dropped while a run is in flight.** Delivery is
+   single-flight per loop with a *latest-wins* stash
+   (`event-delivery.ts` — a busy loop overwrites `runtime.pendingEvent`).
+   That was the right coalescing rule for debounced file batches (spec 12
+   decision 4); it is a data-loss bug for per-PR events: CI fails on PR #12
+   and #14 during one run → #12 silently vanishes.
+3. **Missing event kinds.** No `pr-approved` and no `main-updated`. (Stale
+   PRs and merge conflicts are handled without new kinds — see decisions 4
+   and 5.)
+4. **`pr` receipt verify-back assumes a *created* PR.** The reconcile matches
+   PRs whose branch embeds the loop id; a lifecycle loop updates a PR it did
+   not create, on a branch it did not name.
+
+## Decisions (confirmed)
+
+1. **Work happens on the PR's own head branch inside a managed worktree** —
+   never the workspace root, never a fresh branch. A new loop workspace
+   setting (`worktreeBranchSource: 'event-pr'`) makes workspace resolution
+   read the target branch from the firing event. If the branch cannot be
+   determined or fetched, the run **blocks visibly** — falling back to a
+   fresh branch would be hollow success (the push would never reach the PR).
+2. **Latest-wins becomes a small bounded FIFO queue.** `runtime.pendingEvent`
+   is replaced by `runtime.pendingEvents` (cap 10, oldest dropped with a
+   visible `event-queue-overflow` warning, dedupe by `source#dedupeKey`).
+   Drained oldest-first, one fresh pass per event, through the existing
+   `drainPendingEvent` chain. Uniform for all sources — debounce already
+   coalesces the batchy ones upstream, so no per-source policy.
+3. **Two new GitHub kinds via one new coarse endpoint.** `pr-approved` and
+   `main-updated` both map onto the repo activity feed
+   (`repos/{owner}/{repo}/events`), keeping the spec-12 anti-abuse shape: no
+   per-PR fan-out, demand-driven, cursor + dedupe ring, 120s cadence floor.
+   The feed can lag a few minutes; with polling that is already the latency
+   class, and the adapter interface stays push-shaped for a future webhook
+   transport.
+4. **Stale PRs need no event kind.** Hybrid triggers (cron + event) already
+   exist; a stale-PR loop is a scheduled loop whose step asks `gh` which PRs
+   went quiet. Documented, zero engine change.
+5. **Merge conflicts are derived, not polled.** Polling mergeable state is a
+   per-PR call per poll (exactly what the anti-abuse design forbids), and
+   "what to do about a conflict" is model judgement anyway. The
+   rebase-on-main loop discovers conflicts when it attempts the rebase after
+   a `main-updated` fire.
+6. **PR pushes and PR comments stay ungated**, riding the existing `pr`
+   delivery posture (dev-tool parity; Graduated Autonomy is deselected).
+   Safety lives in the **trigger filter**, not a gate: the catalog loops
+   default to firing only on PRs authored by the user or on Sero-created
+   branches. Loops in this spec never merge a PR — merging stays human.
+7. **Verified Delivery stays out** (separate future spec). v1 relies on
+   planner-authored validation steps plus the existing receipt machinery,
+   like everything else shipped so far.
+8. **Packaging is four catalog entries** — CI fixer, review responder,
+   rebase-on-main, and the Issue Implementer — authored and e2e-verified
+   with the spec-14 harness. No mega-loop: one loop per event family keeps
+   plans flat and the queue semantics simple. The Issue Implementer is the
+   *entry point* of the bundle (it creates the PRs the other three keep
+   alive) and gets its own section below.
+9. **Issue claiming is a soft-lock protocol, self-healing by expiry.**
+   GitHub has no atomic locks, so duplicate-effort prevention cannot be a
+   guarantee — it is claim → verify → back off, with stale claims expiring
+   so a crashed run never wedges an issue forever. Mechanics in the Issue
+   Implementer section.
+
+## Data model
+
+Loop workspace settings gain one field:
+
+```ts
+interface LoopWorkspaceSettings {
+  // …existing fields…
+  /**
+   * Where a managed worktree's branch comes from. 'new' (default) mints a
+   * fresh branch per run, exactly today's behavior. 'event-pr' checks out
+   * the PR branch named by the firing event; requires useManagedWorktree.
+   */
+  worktreeBranchSource?: 'new' | 'event-pr';
+}
+```
+
+Branch resolution for `'event-pr'` is deterministic code, never heuristic:
+
+1. `event.payload.branch` if present (`pr-opened`, `ci-failed`, `ci-passed`
+   carry it);
+2. else `event.payload.prNumber ?? event.payload.number` looked up in
+   `host.listPullRequests()` (already available; the open-PR summaries carry
+   head branch names) — this covers `review-comment`, `review-requested`,
+   and `pr-approved`, whose source endpoints don't expose the head ref;
+3. else — or if the lookup finds no open PR — the run records a
+   `runtime-error` block naming the event and the missing field. No
+   fallback branch.
+
+Pending events:
+
+```ts
+interface LoopRuntime {
+  // pendingEvent?: OrchestratorEvent   ← replaced
+  /** FIFO of stashed event fires, drained oldest-first when idle. Cap 10. */
+  pendingEvents?: OrchestratorEvent[];
+}
+```
+
+Migration: a persisted `pendingEvent` is read as a one-element queue.
+
+## Host seam (desktop-core)
+
+`createWorktree` gains an options bag:
+
+```ts
+createWorktree(
+  key: string,
+  title: string,
+  options?: { existingBranch?: string },
+): Promise<WorktreeHandle>;
+```
+
+With `existingBranch`, `WorktreeManager.create`:
+
+- fetches the branch (`git fetch origin <branch>`) so a PR pushed from
+  elsewhere is present locally;
+- runs `git worktree add <path> <branch>` (no `-b`), creating a local
+  tracking branch when only `origin/<branch>` exists;
+- errors clearly when the branch exists nowhere (surfaces as the resolution
+  block above).
+
+Worktree removal for these runs **never deletes the branch** — it is the
+PR's branch, not ours. The existing per-run worktree key (`<loopId>-r<seq>`)
+is unchanged: each fire gets a fresh checkout of the *current* branch tip,
+which is exactly the re-entrancy the per-run-key fix bought us.
+
+## GitHub adapter changes
+
+New kinds in `github-kinds.ts`, two new endpoints:
+
+```ts
+{
+  id: 'repo-events',
+  path: 'repos/{owner}/{repo}/events?per_page=30',
+  kinds: ['pr-approved', 'main-updated'],
+},
+{
+  id: 'issues',
+  path: 'repos/{owner}/{repo}/issues?state=open&sort=created&direction=desc&per_page=30',
+  kinds: ['issue-opened'],
+},
+```
+
+- `pr-approved`: `PullRequestReviewEvent` with `review.state === 'approved'`.
+  Payload: `prNumber, prTitle, reviewer, url`.
+- `main-updated`: `PushEvent` whose ref is the repo default branch. Payload:
+  `branch, beforeSha, afterSha, commitCount, pusher`. Consecutive pushes
+  produce distinct occurrences; the pending-event queue plus trigger
+  `debounceMs` handle bursts.
+- `issue-opened`: items from the issues list **excluding PRs** (the GitHub
+  issues endpoint includes pull requests; entries carrying a `pull_request`
+  key are dropped). Payload: `number, title, author, labels, url`.
+
+Both entries join `EVENT_SOURCE_CATALOG` (source-catalog.ts) with their
+filterable fields, so the trigger extractor and planner can author against
+them — the model maps language to sources, as always.
+
+## Receipt semantics
+
+No new destination. `pr` delivery's verify-back is widened: a receipt is
+also valid when its `ref` names an **open PR by number** in
+`listPullRequests()` (an update to an existing PR), not only a PR on a
+loop-named branch. The receipt `summary` states what changed ("pushed 2
+commits fixing CI", "replied to 3 review comments").
+
+## Catalog entries (the product surface)
+
+Four entries in the official catalog, authored + verified with the spec-14
+harness, each with `example-output.md`, cost band, and limitations:
+
+| Slug | Trigger default | What it does |
+| --- | --- | --- |
+| `issue-implementer` | hybrid: cron sweep + `github:issue-opened` / `github:issue-labelled`, debounced | Scan open unassigned issues, claim the best candidate, classify the approach, plan when warranted, implement with tests and docs, raise a PR — full SDLC, one issue per fire (own section below) |
+| `ci-fixer` | `github:ci-failed`, filtered to own/Sero branches | Fetch failing run logs via `gh`, diagnose, fix on the PR branch, run the repo's validation, push, comment the diagnosis on the PR |
+| `review-responder` | `github:review-comment`, filtered to own PRs, debounced | Read the full review thread, classify comments (fix / answer / decline), apply fixes, push, reply per comment |
+| `rebase-on-main` | `github:main-updated`, debounced ≥15min | List own open PRs, rebase each onto main, resolve trivial conflicts, run validation, push; report unresolvable conflicts instead of forcing them |
+
+`ci-fixer` and `review-responder` set `worktreeBranchSource: 'event-pr'`;
+`rebase-on-main` and `issue-implementer` iterate/create branches themselves
+and use plain worktrees. Trigger filters scope to the user's or Sero's PRs
+by default — the installer can widen them deliberately.
+
+Together the four are the actual "autonomous PR lifecycle": the Issue
+Implementer opens the PR, then CI fixer, review responder, and
+rebase-on-main keep it alive until a human merges it.
+
+## The Issue Implementer
+
+The core entry. Its whole run is one funnel — scan → select → claim →
+classify → (plan) → implement → validate → deliver — and every stage can
+end the run *honestly* (explicit completion with a reason), never by
+pretending success. One issue per fire, end-to-end; throughput is bounded
+by the trigger cadence, which is the safety valve — no batch mode, no
+parallel issues per run (that is the change-graph problem, out of scope).
+
+**Trigger.** Hybrid: a cron sweep (default every 2 hours) works the
+backlog, while `github:issue-opened` and `github:issue-labelled` fires give
+instant pickup. Bursts queue in the pending-event FIFO and each drain is a
+fresh pass, so a storm of new issues becomes a sequence of single-issue
+runs, rate-shaped by debounce.
+
+**Selection is model judgement, not label rails.** The scan step lists
+open, unassigned issues and excludes only what is mechanically checkable:
+already assigned, an open PR already linked, an active claim comment, or
+already delivered by this loop (receipts from `runtime.deliveries` are in
+the run context). The model then scores the remainder on clarity, size,
+risk, and value, and picks one — or emits explicit completion "no suitable
+issue" with the reasons. Suitability is the LLM's call (per the no-rails
+rule); safety lives in the run mechanics around it.
+
+**The claim protocol** (decision 9 — soft lock, verify, expire):
+
+1. **Claim**: assign `@me` and post a structured claim comment (a fixed
+   marker plus the loop id and timestamp). Two writes, because they serve
+   different readers: assignment is what humans and other scanners filter
+   on; the comment carries the identity and age that make verification and
+   expiry possible.
+2. **Verify**: re-read the issue *after* claiming. Proceed only if we are
+   the sole assignee and ours is the only active claim comment; on a lost
+   race (someone else claimed in the window), remove our assignment and
+   complete the run as "skipped — claimed by someone else". GitHub allows
+   multiple assignees, so claim-then-verify is the only honest protocol;
+   the race window is seconds wide and a collision costs one skipped run,
+   not duplicate code.
+3. **Expire**: a claim with no linked open PR after 24 hours is stale, and
+   later sweeps may reclaim the issue. This is the self-healing half:
+   recovery prompts tell a failing run to release its claim (unassign +
+   status comment), but a crashed run can't be trusted to clean up — expiry
+   is the durable backstop, so no issue stays wedged.
+4. **Resolve**: the PR body carries `Closes #N` and the run comments the PR
+   link on the issue, closing the claim's lifecycle. From here the other
+   three loops own the PR.
+
+**Route shape** (spec-05 judge step): after claiming, a classify step
+routes the work — *implement now* (small and clear; skips the planning
+step), *plan first* (authors an implementation plan step before code),
+*needs clarification* (posts concrete questions on the issue, releases the
+claim, completes), or *decline* (product decision or too big; comments why
+with a suggested breakdown, releases the claim, completes). Clarify and
+decline are first-class outcomes, not failures — an issue tracker full of
+good questions beats one full of wrong PRs.
+
+**Implementation and delivery.** Managed worktree with a fresh branch
+(`worktreeBranchSource: 'new'` — this loop creates PRs, it doesn't join
+them). Tests and docs are part of the implement/plan routes where the
+classify step deems them applicable, followed by the repo's validation
+step. Delivery is `pr` with the existing verified receipt. Entry metadata
+is honest: cost band high, model tier high, limitations state that it never
+merges, handles one issue per fire, and declines issues needing product
+decisions.
+
+## UI
+
+- Loop workspace settings: the existing worktree control gains the branch
+  source choice, shown only for event/hybrid loops ("Work on the PR branch
+  from the firing event").
+- Loop detail: queued events surface as a small count with the next event's
+  summary ("2 events queued — next: CI failed on PR #14").
+- The overflow warning renders through the existing warning chip.
+
+## Functional requirements
+
+- **FR-P1** With `worktreeBranchSource: 'event-pr'`, workspace resolution
+  checks out the firing event's PR branch in a managed worktree; an
+  unresolvable branch blocks the run visibly — never a fresh-branch
+  fallback, never workspace root.
+- **FR-P2** `createWorktree` supports `existingBranch` (fetch, add without
+  `-b`, track origin); removal of such worktrees never deletes the branch.
+- **FR-P3** Stashed event fires queue FIFO (cap 10, dedupe by
+  `source#dedupeKey`, drop-oldest records an `event-queue-overflow`
+  warning) and drain oldest-first; a persisted `pendingEvent` migrates as a
+  one-element queue.
+- **FR-P4** `github:pr-approved`, `github:main-updated`, and
+  `github:issue-opened` poll through the two new coarse endpoints under the
+  existing cursor, dedupe-ring, rate-limit, and cadence-floor mechanics,
+  and appear in the event source catalog with filter fields; `issue-opened`
+  never emits for pull requests.
+- **FR-P5** `pr` receipt verify-back accepts an update to an existing open
+  PR (receipt names it by number), alongside today's created-PR match.
+- **FR-P6** Stale-PR handling is documented as a hybrid-trigger pattern; no
+  engine change, no `pr-stale` kind.
+- **FR-P7** `issue-implementer`, `ci-fixer`, `review-responder`, and
+  `rebase-on-main` ship in the official catalog, pass content validation,
+  and are e2e-verified; default trigger filters scope to the user's/Sero's
+  PRs; none of them merges a PR.
+- **FR-P8** Docs-site orchestrator reference covers the branch source
+  setting, the event queue, and the new sources in plain language.
+- **FR-P9** The Issue Implementer never writes code for an issue it has not
+  claimed and verified: it assigns + posts the marker claim comment,
+  re-reads, and a lost race ends the run as "skipped" with the assignment
+  released — e2e-verified (a pre-claimed issue produces no PR). Stale-claim
+  expiry reclaims only issues carrying a Sero marker comment, never a plain
+  human assignment.
+
+## Out of scope (v1)
+
+- Verified Delivery (independent adversarial verification) — separate spec.
+- Graduated Autonomy — remains deselected; the fixed posture is decision 6.
+- Merging PRs, closing PRs, or any terminal PR action.
+- `merge-conflict` / `pr-stale` event kinds (decisions 4–5).
+- A GitHub webhook push transport (the local `webhook:<name>` source already
+  accepts one today for users who wire it; a hosted relay is future work).
+- Cross-repo lifecycle management — the adapter stays scoped to the
+  workspace repo's remote.

--- a/docs/features/orchestration/sero-orchestrator/specs/index.md
+++ b/docs/features/orchestration/sero-orchestrator/specs/index.md
@@ -58,6 +58,7 @@ restrictions.
 | [12-living-loops.md](12-living-loops.md) | Living Loops: event-driven triggers — broadcast fireEvent with payloads, demand-driven source adapters (internal loop events, filesystem, GitHub polling, local webhook), filter/condition semantics, planner-authored event triggers |
 | [13-pluggable-delivery.md](13-pluggable-delivery.md) | Pluggable delivery: user-chosen destinations (PR, files, artifact, email draft/send, chat, webhook), agent-authored delivery with enforced DeliveryReceipt, approval-gated external sends, destination registry |
 | [14-loop-catalog.md](14-loop-catalog.md) | Loop Catalog: git-repo catalogs (official + user-added/team), on-demand clone cache, install links into library versioning, model-adapted installs, verified badge |
+| [15-pr-lifecycle.md](15-pr-lifecycle.md) | PR lifecycle loops: work on the PR's own branch (event-scoped worktree checkout), pending-event FIFO queue, `pr-approved`/`main-updated`/`issue-opened` sources, updated-PR receipts, four catalog loops (Issue Implementer with claim protocol, CI fixer, review responder, rebase-on-main) |
 
 ## Non-Goals
 

--- a/packages/common/src/app-runtime-background.ts
+++ b/packages/common/src/app-runtime-background.ts
@@ -16,6 +16,7 @@ import type { AppRuntimeGitApi } from './app-runtime-git';
 // imports from '@sero-ai/common' (via this module) keep resolving unchanged.
 export type {
   AppRuntimeWorktreeCreateResult,
+  AppRuntimeWorktreeCreateOptions,
   AppRuntimeWorktreeRemoveOptions,
   AppRuntimeConflictResolutionContext,
   AppRuntimeWorktreeSyncOptions,

--- a/packages/common/src/app-runtime-git.ts
+++ b/packages/common/src/app-runtime-git.ts
@@ -85,11 +85,21 @@ export interface AppRuntimeDirtyWorkspaceStashResult {
   stashRef: string | null;
 }
 
+export interface AppRuntimeWorktreeCreateOptions {
+  /**
+   * Check out this existing branch (fetched from origin when only remote)
+   * instead of minting a new one — for work that must land on a PR's own
+   * branch. Removal of such a worktree must never delete the branch.
+   */
+  existingBranch?: string;
+}
+
 export interface AppRuntimeGitApi {
   createWorktree(
     workspacePath: string,
     cardId: string,
     cardTitle: string,
+    options?: AppRuntimeWorktreeCreateOptions,
   ): Promise<AppRuntimeWorktreeCreateResult>;
   removeWorktree(
     workspacePath: string,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -64,6 +64,7 @@ export type {
   AppRuntimeVerificationResult,
   AppRuntimeVerificationApi,
   AppRuntimeWorktreeCreateResult,
+  AppRuntimeWorktreeCreateOptions,
   AppRuntimeWorktreeRemoveOptions,
   AppRuntimeConflictResolutionContext,
   AppRuntimeWorktreeSyncOptions,

--- a/plugins/sero-orchestrator-plugin/extension/tools.ts
+++ b/plugins/sero-orchestrator-plugin/extension/tools.ts
@@ -59,6 +59,7 @@ export const ORCHESTRATOR_ACTIONS = [
 
 const SUGGESTION_DECISIONS = ['approve', 'reject'] as const;
 const LIBRARY_SAVE_MODES = ['new-version', 'new-entry'] as const;
+const WORKTREE_BRANCH_SOURCES = ['new', 'event-pr'] as const;
 
 export const OrchestratorToolParams = Type.Object({
   action: StringEnum(ORCHESTRATOR_ACTIONS, {
@@ -70,6 +71,7 @@ export const OrchestratorToolParams = Type.Object({
   activate: Type.Optional(Type.Boolean({ description: 'Activate the loop immediately after create' })),
   useManagedWorktree: Type.Optional(Type.Boolean({ description: 'Workspace isolation for create (default true)' })),
   allowDirtyWorkspaceRoot: Type.Optional(Type.Boolean({ description: 'For create in workspace-root mode (useManagedWorktree false): run in place even when the workspace is dirty, skipping the dirty preflight (default false)' })),
+  worktreeBranchSource: Type.Optional(StringEnum(WORKTREE_BRANCH_SOURCES, { description: 'For create with a managed worktree: "event-pr" checks out the PR branch named by the firing event instead of minting a new branch (PR-lifecycle loops); default "new"' })),
   decisionJson: Type.Optional(Type.String({ description: 'JSON-encoded RecoveryDecision for choose_recovery' })),
   stepId: Type.Optional(Type.String({ description: 'Target step id (required for set_step_model/set_step_tools)' })),
   model: Type.Optional(Type.String({ description: 'For set_step_model: a tier ("LOW"/"MED"/"HIGH") or a "provider/modelId"; omit to revert the step to the default' })),
@@ -104,6 +106,7 @@ export interface OrchestratorToolParamsShape {
   activate?: boolean;
   useManagedWorktree?: boolean;
   allowDirtyWorkspaceRoot?: boolean;
+  worktreeBranchSource?: (typeof WORKTREE_BRANCH_SOURCES)[number];
   decisionJson?: string;
   stepId?: string;
   model?: string;
@@ -173,10 +176,11 @@ export function buildAction(params: OrchestratorToolParamsShape): OrchestratorAc
       if (!params.prompt) return { error: 'create requires a prompt' };
       const options: CreateLoopOptions = {};
       if (params.activate !== undefined) options.activate = params.activate;
-      if (params.useManagedWorktree !== undefined || params.allowDirtyWorkspaceRoot !== undefined) {
+      if (params.useManagedWorktree !== undefined || params.allowDirtyWorkspaceRoot !== undefined || params.worktreeBranchSource !== undefined) {
         options.workspace = {};
         if (params.useManagedWorktree !== undefined) options.workspace.useManagedWorktree = params.useManagedWorktree;
         if (params.allowDirtyWorkspaceRoot !== undefined) options.workspace.allowDirtyWorkspaceRoot = params.allowDirtyWorkspaceRoot;
+        if (params.worktreeBranchSource !== undefined) options.workspace.worktreeBranchSource = params.worktreeBranchSource;
       }
       if (params.deliveryDestination !== undefined) {
         const delivery = buildDelivery(params);

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-core.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-core.test.ts
@@ -202,6 +202,15 @@ describe('Coordinator delete', () => {
     expect(host.worktreeRemovals[0]).toMatchObject({ loopId: 'loop-1', deleteBranch: true });
   });
 
+  it('never deletes an event-pr worktree branch — it belongs to the PR (spec 15)', async () => {
+    const host = createFakeHost();
+    const loop = seedActiveLoop(host, oneStepPlan().plan);
+    loop.runtime.workspace.resolved = { ...managedWorktree, branchName: 'feat/someones-pr', externalBranch: true };
+    host.state = { ...host.state, loops: [loop] };
+    await new Coordinator(host).requestAction({ kind: 'delete', loopId: 'loop-1', deleteBranch: true });
+    expect(host.worktreeRemovals[0]).toMatchObject({ loopId: 'loop-1', deleteBranch: undefined });
+  });
+
   it('touches no worktree when none was resolved', async () => {
     const host = createFakeHost();
     seedActiveLoop(host, oneStepPlan().plan);

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
@@ -133,7 +133,7 @@ describe('fireEvent broadcast', () => {
     expect(run.firedBy).toEqual({ source: 'github:ci-failed', occurredAt: NOW, summary: 'CI failed on PR #42' });
     const observation = run.observations.find((o) => o.source === 'event')!;
     expect(observation.data).toEqual({ pr: 42 });
-    expect(loop.runtime.pendingEvent).toBeUndefined(); // consumed by the run
+    expect(loop.runtime.pendingEvents).toBeUndefined(); // consumed by the run
 
     const task = buildStepTask(loop, loop.plan.steps[0], run);
     expect(task).toContain('fired by an event');
@@ -199,24 +199,56 @@ describe('fireEvent broadcast', () => {
 
     expect(executor.calls).toEqual([]); // nothing ran — the human gate holds
     expect(host.state.loops[0].triggers[0].fireCount).toBe(1);
-    expect(host.state.loops[0].runtime.pendingEvent?.id).toBe('evt-1');
+    expect(host.state.loops[0].runtime.pendingEvents?.[0]?.id).toBe('evt-1');
   });
 
-  it('tick drains a stashed pending event after a restart', async () => {
+  it('tick drains a queued pending event after a restart', async () => {
     const host = createFakeHost();
     host.frozenNow = NOW;
     const loop = seedActiveLoop(host, oneStepPlan().plan);
     host.state = {
       ...host.state,
-      loops: [{ ...loop, triggers: [eventTrigger({ fireCount: 1 })], runtime: { ...loop.runtime, pendingEvent: ciEvent() } }],
+      loops: [{ ...loop, triggers: [eventTrigger({ fireCount: 1 })], runtime: { ...loop.runtime, pendingEvents: [ciEvent()] } }],
     };
     const executor = fakeExecutor({ 'step-1': SUCCESS });
 
     await coordinator(host, { executor }).tick();
 
     expect(executor.calls).toEqual(['step-1']);
-    expect(host.state.loops[0].runtime.pendingEvent).toBeUndefined();
+    expect(host.state.loops[0].runtime.pendingEvents).toBeUndefined();
     expect(host.state.loops[0].runs.at(-1)?.firedBy?.source).toBe('github:ci-failed');
+  });
+
+  it('events fired mid-run queue FIFO and each drains into its own run, oldest first', async () => {
+    const host = createFakeHost();
+    host.frozenNow = NOW;
+    seedActiveLoop(host, oneStepPlan().plan);
+    setTriggers(host, 'loop-1', [eventTrigger()]);
+    // Two DIFFERENT discrete events (CI failed on PR #12 and #14) arrive while
+    // the first run is mid-step — the spec-12 latest-wins stash lost #12.
+    let midRunFired = false;
+    const c: Coordinator = coordinator(host, {
+      executor: fakeExecutor({
+        'step-1': async () => {
+          if (!midRunFired) {
+            midRunFired = true;
+            await c.fireEvent(ciEvent({ id: 'evt-12', summary: 'CI failed on PR #12', payload: { prNumbers: [12] } }));
+            await c.fireEvent(ciEvent({ id: 'evt-14', summary: 'CI failed on PR #14', payload: { prNumbers: [14] } }));
+          }
+          return SUCCESS;
+        },
+      }),
+    });
+
+    await c.fireEvent(ciEvent({ summary: 'CI failed on PR #10' }));
+
+    const loop = host.state.loops[0];
+    expect(loop.runs.map((r) => r.firedBy?.summary)).toEqual([
+      'CI failed on PR #10',
+      'CI failed on PR #12',
+      'CI failed on PR #14',
+    ]);
+    expect(loop.runtime.pendingEvents).toBeUndefined();
   });
 });
 
@@ -270,9 +302,9 @@ describe('event loops and completion (found by e2e — an event loop must outliv
     await c.fireEvent(ciEvent());
 
     const loop = host.state.loops[0];
-    expect(loop.runs).toHaveLength(2); // stash consumed into a fresh pass
+    expect(loop.runs).toHaveLength(2); // queued fire consumed into a fresh pass
     expect(loop.runs[1].firedBy?.summary).toBe('arrived mid-run');
-    expect(loop.runtime.pendingEvent).toBeUndefined();
+    expect(loop.runtime.pendingEvents).toBeUndefined();
     expect(loop.status).toBe('active');
   });
 
@@ -298,8 +330,8 @@ describe('event loops and completion (found by e2e — an event loop must outliv
 
     const loop = host.state.loops[0];
     expect(loop.status).toBe('complete');
-    expect(loop.runs).toHaveLength(1); // the stash never becomes a run…
-    expect(loop.runtime.pendingEvent).toBeUndefined(); // …and never lingers…
+    expect(loop.runs).toHaveLength(1); // the queued fire never becomes a run…
+    expect(loop.runtime.pendingEvents).toBeUndefined(); // …and never lingers…
     expect(loop.warnings.some((w) => w.code === 'event-dropped')).toBe(true); // …but is dropped visibly
     expect(loop.triggers[0].disabled).toBe(true); // nothing can fire a completed loop
   });

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-scheduling.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-scheduling.test.ts
@@ -72,7 +72,7 @@ describe('Coordinator scheduling (Phase 7)', () => {
     expect(host.state.loops[0].runtime.stepStates['step-1'].status).toBe('pending');
   });
 
-  it('events during an active run coalesce latest-wins into ONE fresh follow-up iteration', async () => {
+  it('events during an active run queue FIFO into one follow-up iteration EACH', async () => {
     const host = createFakeHost();
     host.frozenNow = NOW;
     seedActiveLoop(host, oneStepPlan().plan);
@@ -83,23 +83,23 @@ describe('Coordinator scheduling (Phase 7)', () => {
     const running = c.runNext('loop-1');
     await Promise.resolve(); // let the run acquire the lock and reach the gate
     await new Promise((r) => setTimeout(r, 0));
-    // Two events arrive while the run holds the lock: both count as fires, the
-    // stash keeps only the latest.
+    // Two DISCRETE events arrive while the run holds the lock: both count as
+    // fires and both queue — the spec-12 latest-wins stash dropped the first.
     await c.fireEvent({ id: 'evt-1', source: 'x', payload: { n: 1 }, occurredAt: NOW });
     await c.fireEvent({ id: 'evt-2', source: 'x', payload: { n: 2 }, occurredAt: NOW });
-    expect(host.state.loops[0].runtime.pendingEvent?.id).toBe('evt-2');
+    expect(host.state.loops[0].runtime.pendingEvents?.map((e) => e.id)).toEqual(['evt-1', 'evt-2']);
     expect(host.state.loops[0].triggers[0].fireCount).toBe(2);
 
     release();
     await running;
-    // Exactly one follow-up iteration, seeded with the latest event; the engine's
-    // mid-run snapshots did not clobber the stash or the fire counters.
-    expect(executor.calls).toEqual(['step-1', 'step-1']);
+    // One follow-up iteration per queued event, oldest first; the engine's
+    // mid-run snapshots did not clobber the queue or the fire counters.
+    expect(executor.calls).toEqual(['step-1', 'step-1', 'step-1']);
     expect(host.state.loops[0].triggers[0].fireCount).toBe(2);
-    expect(host.state.loops[0].runtime.pendingEvent).toBeUndefined();
-    const lastRun = host.state.loops[0].runs.at(-1)!;
-    expect(lastRun.firedBy?.source).toBe('x');
-    expect(lastRun.observations.find((o) => o.source === 'event')?.data).toEqual({ n: 2 });
+    expect(host.state.loops[0].runtime.pendingEvents).toBeUndefined();
+    const [, second, third] = host.state.loops[0].runs;
+    expect(second.observations.find((o) => o.source === 'event')?.data).toEqual({ n: 1 });
+    expect(third.observations.find((o) => o.source === 'event')?.data).toEqual({ n: 2 });
   });
 
   it('a recurring iteration that completes stays active and scheduled (does not finish forever)', async () => {

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/delivery-contract.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/delivery-contract.test.ts
@@ -111,6 +111,15 @@ describe('verifyReceipt', () => {
     expect(missed.ok).toBe(false);
   });
 
+  it('accepts an update to an existing open PR named by number even when the URL form differs (spec 15)', async () => {
+    const host = createFakeHost();
+    const loop = seedDeliveryLoop(host, 'pr');
+    host.pullRequests = [{ number: 12, url: 'https://github.com/o/r/pull/12', title: 't', headRefName: 'feat/someones-pr', updatedAt: 'now' }];
+    expect(await verifyReceipt(host, loop, { ...RECEIPT, destination: 'pr', ref: 'https://www.github.com/o/r/pull/12#issuecomment-1' })).toEqual({ ok: true });
+    const closed = await verifyReceipt(host, loop, { ...RECEIPT, destination: 'pr', ref: 'https://github.com/o/r/pull/13' });
+    expect(closed.ok).toBe(false); // a PR not in the open list still fails
+  });
+
   it('fails soft when the PR list itself cannot be read', async () => {
     const host = createFakeHost();
     const loop = seedDeliveryLoop(host, 'pr');

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/event-queue.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/event-queue.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Pending-event FIFO helpers (spec 15, FR-P3): bounded queue, dedupe, visible
+ * overflow, and the read-time migration of the legacy single-event stash.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { enqueuePendingEvent, migrateLegacyPendingEvent, PENDING_EVENT_QUEUE_CAP } from '../event-queue';
+import type { Loop, OrchestratorEvent } from '../../shared/types';
+import { createFakeHost } from './fake-host';
+import { oneStepPlan, seedActiveLoop } from './fixtures';
+
+const NOW = '2026-07-03T10:00:00.000Z';
+
+function event(id: string, overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
+  return { id, source: 'github:ci-failed', payload: {}, occurredAt: NOW, ...overrides };
+}
+
+function seededLoop(): { loop: Loop; host: ReturnType<typeof createFakeHost> } {
+  const host = createFakeHost();
+  host.frozenNow = NOW;
+  return { loop: seedActiveLoop(host, oneStepPlan().plan), host };
+}
+
+describe('enqueuePendingEvent', () => {
+  it('appends in arrival order', () => {
+    const { loop, host } = seededLoop();
+    let next = enqueuePendingEvent(host, loop, event('a'));
+    next = enqueuePendingEvent(host, next, event('b'));
+    expect(next.runtime.pendingEvents?.map((e) => e.id)).toEqual(['a', 'b']);
+  });
+
+  it('ignores a duplicate id and a duplicate source+dedupeKey', () => {
+    const { loop, host } = seededLoop();
+    let next = enqueuePendingEvent(host, loop, event('a', { dedupeKey: 'k1' }));
+    next = enqueuePendingEvent(host, next, event('a', { dedupeKey: 'other' })); // same id
+    next = enqueuePendingEvent(host, next, event('b', { dedupeKey: 'k1' })); // same source+key
+    next = enqueuePendingEvent(host, next, event('c', { source: 'fs:changed', dedupeKey: 'k1' })); // different source
+    expect(next.runtime.pendingEvents?.map((e) => e.id)).toEqual(['a', 'c']);
+  });
+
+  it('drops the OLDEST beyond the cap, with a visible warning that replaces the prior one', () => {
+    const { loop, host } = seededLoop();
+    let next = loop;
+    for (let i = 0; i < PENDING_EVENT_QUEUE_CAP + 2; i += 1) {
+      next = enqueuePendingEvent(host, next, event(`e${i}`));
+    }
+    const queue = next.runtime.pendingEvents!;
+    expect(queue).toHaveLength(PENDING_EVENT_QUEUE_CAP);
+    expect(queue[0].id).toBe('e2'); // e0 and e1 dropped, oldest first
+    expect(queue.at(-1)?.id).toBe(`e${PENDING_EVENT_QUEUE_CAP + 1}`);
+    const overflows = next.warnings.filter((w) => w.code === 'event-queue-overflow');
+    expect(overflows).toHaveLength(1); // replaced, not accumulated
+  });
+});
+
+describe('migrateLegacyPendingEvent', () => {
+  it('reads a persisted single pendingEvent as a one-element queue', () => {
+    const { loop } = seededLoop();
+    const legacy = { ...loop, runtime: { ...loop.runtime, pendingEvent: event('old') } } as Loop;
+    const migrated = migrateLegacyPendingEvent(legacy);
+    expect(migrated.runtime.pendingEvents?.map((e) => e.id)).toEqual(['old']);
+    expect('pendingEvent' in migrated.runtime).toBe(false);
+  });
+
+  it('leaves a queue-era loop untouched', () => {
+    const { loop } = seededLoop();
+    expect(migrateLegacyPendingEvent(loop)).toBe(loop);
+  });
+});

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/fake-host.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/fake-host.ts
@@ -56,6 +56,8 @@ export interface FakeHost extends OrchestratorHost {
   choiceResult: ChoiceResult;
   /** Records created/removed worktrees and notifications/choices. */
   worktreesCreated: string[];
+  /** Full createWorktree calls, including the existing-branch option. */
+  worktreeCreates: { loopId: string; existingBranch?: string }[];
   worktreesRemoved: string[];
   /** Full removeWorktree calls, including the options passed. */
   worktreeRemovals: { loopId: string; deleteBranch?: boolean; force?: boolean }[];
@@ -103,6 +105,7 @@ export function createFakeHost(options: FakeHostOptions = {}): FakeHost {
     workspaceStatus: { isGitRepository: true, hasUncommittedChanges: false, summary: 'Clean working tree' },
     choiceResult: { choiceId: null, timedOut: true },
     worktreesCreated: [],
+    worktreeCreates: [],
     worktreesRemoved: [],
     worktreeRemovals: [],
     notifications: [],
@@ -160,9 +163,13 @@ export function createFakeHost(options: FakeHostOptions = {}): FakeHost {
       // Mirror the real host: accept the write ref OR a state-dir-relative path.
       return this.artifacts.get(ref) ?? this.artifacts.get(`artifact://${ref}`) ?? null;
     },
-    async createWorktree(loopId) {
+    async createWorktree(loopId, _title, options) {
       this.worktreesCreated.push(loopId);
-      return { worktreePath: `${this.workspacePath}/.sero/worktrees/${loopId}`, branchName: `orchestrator/${loopId}` };
+      this.worktreeCreates.push({ loopId, existingBranch: options?.existingBranch });
+      return {
+        worktreePath: `${this.workspacePath}/.sero/worktrees/${loopId}`,
+        branchName: options?.existingBranch ?? `orchestrator/${loopId}`,
+      };
     },
     async removeWorktree(loopId, options) {
       this.worktreesRemoved.push(loopId);

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/github-adapter.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/github-adapter.test.ts
@@ -269,4 +269,86 @@ describe('occurrence extraction per kind', () => {
     expect(result.occurrences).toHaveLength(1);
     expect(result.occurrences[0].payload).toMatchObject({ prNumber: 12, author: 'dan', excerpt: 'nit: rename' });
   });
+
+  it('splits the repo activity feed into pr-approved and default-branch main-updated (spec 15)', () => {
+    const repoEventsEndpoint = GITHUB_ENDPOINTS.find((endpoint) => endpoint.id === 'repo-events')!;
+    const body = [
+      {
+        id: '101', type: 'PullRequestReviewEvent', created_at: '2026-03-02T00:00:00Z', actor: { login: 'reviewer' },
+        payload: { review: { state: 'approved', user: { login: 'reviewer' } }, pull_request: { number: 9, title: 'Fix', html_url: 'https://x/pr/9' } },
+      },
+      {
+        id: '102', type: 'PullRequestReviewEvent', created_at: '2026-03-02T01:00:00Z',
+        payload: { review: { state: 'changes_requested' }, pull_request: { number: 9 } }, // not an approval
+      },
+      {
+        id: '103', type: 'PushEvent', created_at: '2026-03-02T02:00:00Z', actor: { login: 'dan' },
+        payload: { ref: 'refs/heads/main', before: 'aaa', head: 'bbb', size: 2 },
+      },
+      {
+        id: '104', type: 'PushEvent', created_at: '2026-03-02T03:00:00Z', actor: { login: 'dan' },
+        payload: { ref: 'refs/heads/feature', before: 'ccc', head: 'ddd', size: 1 }, // not the default branch
+      },
+    ];
+    const known = { 'pr-approved': '2026-03-01T00:00:00Z', 'main-updated': '2026-03-01T00:00:00Z' };
+    const result = extractOccurrences(
+      repoEventsEndpoint, body, new Set(['pr-approved', 'main-updated']), known, '2026-03-03T00:00:00Z', { defaultBranch: 'main' },
+    );
+    expect(result.occurrences.map((o) => o.kind)).toEqual(['pr-approved', 'main-updated']);
+    expect(result.occurrences[0].payload).toMatchObject({ prNumber: 9, reviewer: 'reviewer', url: 'https://x/pr/9' });
+    expect(result.occurrences[1].payload).toEqual({ branch: 'main', beforeSha: 'aaa', afterSha: 'bbb', commitCount: 2, pusher: 'dan' });
+
+    // Without the default branch resolved, main-updated stays silent (never guesses).
+    const withoutBranch = extractOccurrences(
+      repoEventsEndpoint, body, new Set(['main-updated']), known, '2026-03-03T00:00:00Z', {},
+    );
+    expect(withoutBranch.occurrences).toEqual([]);
+  });
+
+  it('emits issue-opened for real issues only — the issues list mixes in pull requests', () => {
+    const issuesEndpoint = GITHUB_ENDPOINTS.find((endpoint) => endpoint.id === 'issues')!;
+    const body = [
+      { id: 61, number: 61, title: 'A PR in disguise', created_at: '2026-03-02T01:00:00Z', user: { login: 'dan' }, pull_request: { url: 'x' } },
+      { id: 60, number: 60, title: 'Real bug', created_at: '2026-03-02T00:00:00Z', user: { login: 'ann' }, labels: [{ name: 'bug' }], html_url: 'https://x/i/60' },
+    ];
+    const result = extractOccurrences(
+      issuesEndpoint, body, new Set(['issue-opened']), { 'issue-opened': '2026-03-01T00:00:00Z' }, '2026-03-03T00:00:00Z',
+    );
+    expect(result.occurrences).toHaveLength(1);
+    expect(result.occurrences[0].payload).toEqual({ number: 60, title: 'Real bug', author: 'ann', labels: ['bug'], url: 'https://x/i/60' });
+  });
+});
+
+describe('default-branch resolution (spec 15)', () => {
+  it('fetches the repo meta once under main-updated demand, persists it, and passes it to extraction', async () => {
+    const host = createFakeHost();
+    const { adapter, events } = makeAdapter(host, [subscription('loop-1', 'main-updated')]);
+
+    // Poll 1: repo meta + baseline of the feed.
+    host.commandResults.push(ghOk({ default_branch: 'trunk' }), ghOk([]));
+    await adapter.pollOnce();
+    expect(host.commands[0]).toMatch(/repos\/\{owner\}\/\{repo\}[^/]/);
+    const state = await readAdapterState<GithubAdapterState>(host, 'github');
+    expect(state?.defaultBranch).toBe('trunk');
+
+    // Poll 2: no meta re-fetch; a trunk push now fires.
+    host.commandResults.push(
+      ghOk([{ id: '7', type: 'PushEvent', created_at: '2026-03-02T00:00:00Z', actor: { login: 'dan' }, payload: { ref: 'refs/heads/trunk', size: 1 } }]),
+    );
+    await adapter.pollOnce();
+    expect(host.commands).toHaveLength(3); // 2 from poll 1, 1 from poll 2
+    expect(events).toHaveLength(1);
+    expect(events[0].source).toBe('github:main-updated');
+    expect(events[0].payload).toMatchObject({ branch: 'trunk', pusher: 'dan' });
+  });
+
+  it('a failed meta fetch counts as a failed cycle and main-updated stays silent', async () => {
+    const host = createFakeHost();
+    const { adapter, events } = makeAdapter(host, [subscription('loop-1', 'main-updated')]);
+    host.commandResults.push(ghError(500), ghOk([]));
+    await adapter.pollOnce();
+    expect(adapter.debug().consecutiveFailures).toBe(1);
+    expect(events).toEqual([]);
+    expect(host.logs.some((line) => line.includes('could not resolve the default branch'))).toBe(true);
+  });
 });

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/planner-prompt.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/planner-prompt.test.ts
@@ -70,6 +70,18 @@ describe('buildPlanningTask placement + delivery', () => {
     expect(buildPlanningTask(baseArgs)).not.toContain('Declared delivery params');
   });
 
+  it("swaps the pr rules to push-to-the-PR's-branch for event-pr loops (spec 15)", () => {
+    const updating = buildPlanningTask({ ...baseArgs, worktreeBranchSource: 'event-pr' });
+    expect(updating).toContain("checked out at that PR's OWN branch");
+    expect(updating).toContain('NEVER open a new pull request');
+    expect(updating).toContain(deliverySpec('pr').receiptHint); // receipt contract unchanged
+
+    // Only the pr destination is affected, and only under event-pr.
+    expect(buildPlanningTask(baseArgs)).not.toContain('NEVER open a new pull request');
+    const chat = buildPlanningTask({ ...baseArgs, worktreeBranchSource: 'event-pr', delivery: { destination: 'chat-post' } });
+    expect(chat).toContain(deliverySpec('chat-post').plannerRules);
+  });
+
   it('keeps the two legacy behaviors intact (pr commit/PR, workspace-files leave-in-tree)', () => {
     const pr = buildPlanningTask(baseArgs);
     expect(pr).toContain('pull request');

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/workspace.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/workspace.test.ts
@@ -138,9 +138,10 @@ describe('event-pr branch resolution (spec 15, FR-P1)', () => {
     return { ...loop, workspace: { ...loop.workspace, worktreeBranchSource: 'event-pr' as const } };
   }
 
-  function eventRun(payload: Record<string, unknown>): LoopRun {
+  function eventRun(payload: Record<string, unknown>, source = 'github:ci-failed'): LoopRun {
     return {
       id: 'run-1', runNumber: 1, status: 'running', startedStepIds: [], stepAttempts: [], recoveryDecisions: [],
+      firedBy: { source, occurredAt: 't', summary: 'fired' },
       observations: [{ id: 'obs-1', source: 'event', summary: 'fired', data: payload, createdAt: 't' }], startedAt: 't',
     };
   }
@@ -186,6 +187,35 @@ describe('event-pr branch resolution (spec 15, FR-P1)', () => {
     const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
     const result = await resolve(host, loop, eventRun({ count: 3 }));
     expect(result.blocked).toContain('neither a branch nor a PR number');
+  });
+
+  it('blocks a non-PR event even though its payload carries a branch field (main-updated names the DEFAULT branch)', async () => {
+    const host = createFakeHost();
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ branch: 'main', afterSha: 'abc123' }, 'github:main-updated'));
+    expect(result.blocked).toContain('not scoped to a pull request');
+    expect(result.workspace).toBeUndefined();
+    expect(host.worktreesCreated).toHaveLength(0);
+  });
+
+  it('a PR-number event never trusts a generic branch field — resolution goes through the open-PR list', async () => {
+    const host = createFakeHost();
+    host.pullRequests = [{ number: 7, url: 'https://x/pr/7', title: 'Fix', headRefName: 'feat/real-head', updatedAt: 't' }];
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ branch: 'main', prNumber: 7 }, 'github:pr-approved'));
+    expect(result.workspace?.branchName).toBe('feat/real-head');
+  });
+
+  it('blocks with a distinct reason when the open-PR list cannot be read (not "PR not open")', async () => {
+    const host = createFakeHost();
+    host.listPullRequests = async () => {
+      throw new Error('gh exited 4: network unreachable');
+    };
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ prNumber: 12 }));
+    expect(result.blocked).toContain('Could not read the open pull-request list');
+    expect(result.blocked).toContain('gh exited 4');
+    expect(host.worktreesCreated).toHaveLength(0);
   });
 
   it('blocks with the checkout error when the branch cannot be checked out', async () => {

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/workspace.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/workspace.test.ts
@@ -133,6 +133,72 @@ describe('workspace resolution', () => {
   });
 });
 
+describe('event-pr branch resolution (spec 15, FR-P1)', () => {
+  function eventPrLoop(loop: Loop): Loop {
+    return { ...loop, workspace: { ...loop.workspace, worktreeBranchSource: 'event-pr' as const } };
+  }
+
+  function eventRun(payload: Record<string, unknown>): LoopRun {
+    return {
+      id: 'run-1', runNumber: 1, status: 'running', startedStepIds: [], stepAttempts: [], recoveryDecisions: [],
+      observations: [{ id: 'obs-1', source: 'event', summary: 'fired', data: payload, createdAt: 't' }], startedAt: 't',
+    };
+  }
+
+  it('checks out the branch named directly by the firing event', async () => {
+    const host = createFakeHost();
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ branch: 'feat/broken-ci', prNumbers: [12] }));
+    expect(host.worktreeCreates).toEqual([{ loopId: worktreeKeyFor(loop), existingBranch: 'feat/broken-ci' }]);
+    expect(result.workspace?.branchName).toBe('feat/broken-ci');
+    expect(result.workspace?.externalBranch).toBe(true);
+    expect(result.blocked).toBeUndefined();
+  });
+
+  it('resolves a PR number through the open-PR list when the event has no branch', async () => {
+    const host = createFakeHost();
+    host.pullRequests = [{ number: 12, url: 'https://x/pr/12', title: 'Fix', headRefName: 'feat/from-pr-12', updatedAt: 't' }];
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ prNumber: 12, author: 'ann' }));
+    expect(result.workspace?.branchName).toBe('feat/from-pr-12');
+  });
+
+  it('blocks visibly when the run was not event-fired — never a fresh-branch fallback', async () => {
+    const host = createFakeHost();
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, undefined);
+    expect(result.blocked).toContain('not started by an event');
+    expect(result.workspace).toBeUndefined();
+    expect(host.worktreesCreated).toHaveLength(0);
+  });
+
+  it('blocks when the PR number is not in the open-PR list', async () => {
+    const host = createFakeHost();
+    host.pullRequests = [];
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ prNumber: 99 }));
+    expect(result.blocked).toContain('PR #99');
+    expect(host.worktreesCreated).toHaveLength(0);
+  });
+
+  it('blocks when the event names neither branch nor PR number', async () => {
+    const host = createFakeHost();
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ count: 3 }));
+    expect(result.blocked).toContain('neither a branch nor a PR number');
+  });
+
+  it('blocks with the checkout error when the branch cannot be checked out', async () => {
+    const host = createFakeHost();
+    host.createWorktree = async () => {
+      throw new Error('Branch "gone" exists neither locally nor on origin');
+    };
+    const loop = eventPrLoop(seedActiveLoop(host, oneStepPlan().plan));
+    const result = await resolve(host, loop, eventRun({ branch: 'gone' }));
+    expect(result.blocked).toContain('exists neither locally nor on origin');
+  });
+});
+
 describe('worktreeKeyFor', () => {
   it('keys a one-shot loop by its run counter so each fresh run gets its own branch (not a reuse of the prior run)', () => {
     const host = createFakeHost();

--- a/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
@@ -274,7 +274,12 @@ export class Coordinator {
     if (!loop) return { ok: false, error: `Loop not found: ${loopId}` };
     const resolved = loop.runtime.workspace.resolved;
     if (resolved?.type === 'managed-worktree') {
-      await this.host.removeWorktree(resolved.worktreeKey ?? loopId, { force: true, deleteBranch });
+      // An event-pr worktree's branch belongs to a PR, never to this loop —
+      // deleteBranch must not reach it (spec 15, FR-P2).
+      await this.host.removeWorktree(resolved.worktreeKey ?? loopId, {
+        force: true,
+        deleteBranch: resolved.externalBranch ? undefined : deleteBranch,
+      });
     }
     await this.host.updateState((state) => ({
       ...state,

--- a/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
@@ -80,7 +80,7 @@ export class Coordinator {
     // Restart safety: an event stashed while the loop was busy (or while the
     // app was quitting) still owes the loop a fresh iteration — consume it.
     for (const loop of state.loops) {
-      if (loop.runtime.pendingEvent) await this.drainPendingEvent(loop.id);
+      if (loop.runtime.pendingEvents?.length) await this.drainPendingEvent(loop.id);
     }
   }
 

--- a/plugins/sero-orchestrator-plugin/runtime/delivery/registry.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/delivery/registry.ts
@@ -24,6 +24,14 @@ export interface DeliveryDestinationSpec {
   receiptHint: string;
 }
 
+/**
+ * Replaces the `pr` planner rules when the loop works ON an existing PR
+ * (worktreeBranchSource: 'event-pr', spec 15): the workspace is already
+ * checked out at the PR's own branch, so delivery is a push, never a new PR.
+ */
+export const PR_UPDATE_PLANNER_RULES =
+  "This loop responds to an existing pull request: the workspace is checked out at that PR's OWN branch. Deliver by committing the change on the current branch with a clear message and pushing it — the PR updates automatically. NEVER open a new pull request and never switch branches. After pushing, comment on the PR (gh pr comment) describing what changed and why. The FIRST step should read the firing event context plus the PR itself (gh pr view, gh pr diff) to understand what is being responded to.";
+
 const EXTERNAL_STAGING =
   'This is externally visible, so the plan MUST stage it: one step composes the content; a separate step marked "gate": "approval" presents that exact content to the user for approval (per HUMAN APPROVAL / INPUT GATES — it records the decision in a "produces" variable); and the step that actually delivers depends on the gate step and is guarded ("when") so it only runs once approved. The final step must (transitively) depend on the gate step. Never deliver without the recorded approval — an unapproved delivery is refused mechanically. If the user rejects, deliver nothing: route past the send and report honestly (a one-shot loop completes as "blocked").';
 
@@ -32,7 +40,7 @@ const RULES: Record<DeliveryDestinationId, Pick<DeliveryDestinationSpec, 'requir
     requiredTools: [],
     plannerRules:
       'The result must be delivered as a pull request or it is lost. After the change is made and verified, add a step that commits it on the current branch with a clear message; if the repository has a git remote and the `gh` CLI is available, that step should also push the branch and open a pull request describing the change. For a recurring loop, the FIRST step should review any open pull requests listed in its run context and skip work an open PR already covers before implementing.',
-    receiptHint: 'the opened pull request URL',
+    receiptHint: 'the pull request URL (the PR this run opened, or the existing PR it updated)',
   },
   'workspace-files': {
     requiredTools: [],

--- a/plugins/sero-orchestrator-plugin/runtime/delivery/verify-receipt.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/delivery/verify-receipt.ts
@@ -25,7 +25,14 @@ export async function verifyReceipt(host: OrchestratorHost, loop: Loop, receipt:
     const open = await host.listPullRequests().catch(() => undefined);
     if (open === undefined) return { ok: true };
     const ref = receipt.ref.trim();
-    const matches = open.some((pr) => ref === pr.url || ref.startsWith(`${pr.url}/`) || ref.startsWith(`${pr.url}#`));
+    // URL match covers both a PR this run opened and an existing PR it updated
+    // (spec 15 — same URL); the /pull/<n> number match tolerates a ref whose
+    // URL form differs from the list's (host casing, trailing segments).
+    const refNumber = /\/pull\/(\d+)(?:[/#?]|$)/.exec(ref)?.[1];
+    const matches = open.some(
+      (pr) =>
+        ref === pr.url || ref.startsWith(`${pr.url}/`) || ref.startsWith(`${pr.url}#`) || (refNumber !== undefined && Number(refNumber) === pr.number),
+    );
     return matches ? { ok: true } : { ok: false, reason: `no open pull request matches the receipt ref "${receipt.ref}"` };
   }
   if (receipt.destination === 'saved-artifact') {

--- a/plugins/sero-orchestrator-plugin/runtime/engine-types.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/engine-types.ts
@@ -50,9 +50,18 @@ export interface OutcomeEvaluator {
   evaluate(input: { host: OrchestratorHost; loop: Loop; step: LoopStepDefinition; attempt: StepAttempt }): Promise<StepOutcome>;
 }
 
-/** Resolves the loop workspace before background filesystem work starts (Phase 4). */
+/**
+ * Resolves the loop workspace before background filesystem work starts.
+ * `run` carries the firing event's observation, which `event-pr` branch
+ * resolution reads (spec 15). `blocked` is a hard stop with a visible reason —
+ * unlike `deferred`, nothing is waited for.
+ */
 export interface WorkspaceResolver {
-  resolve(host: OrchestratorHost, loop: Loop): Promise<{ loop: Loop; workspace?: ResolvedWorkspaceContext; deferred?: string }>;
+  resolve(
+    host: OrchestratorHost,
+    loop: Loop,
+    run?: LoopRun,
+  ): Promise<{ loop: Loop; workspace?: ResolvedWorkspaceContext; deferred?: string; blocked?: string }>;
 }
 
 /**

--- a/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
@@ -6,9 +6,11 @@
  *
  * Delivery semantics: matching per trigger is exact source, structured filter,
  * and debounce in code, then the optional natural-language condition as a model
- * call (last, so the code checks bound the model-call volume). A due idle loop
- * starts a fresh iteration seeded with the event; a busy loop stashes it
- * latest-wins for the iteration that follows. Every fire increments fireCount.
+ * call (last, so the code checks bound the model-call volume). Every accepted
+ * fire is APPENDED to the loop's pending-event FIFO (spec 15 — the spec-12
+ * latest-wins stash silently dropped discrete per-PR events); an idle loop
+ * additionally starts a fresh pass, and the engine consumes the queue HEAD at
+ * run start. Every fire increments fireCount.
  */
 
 import type { Loop, LoopWarning, OrchestratorActionResult, OrchestratorEvent } from '../shared/types';
@@ -16,6 +18,7 @@ import type { OrchestratorHost } from './host';
 import { applyEventFires, rearmLoop } from './scheduler';
 import { codeMatchEventTrigger, EVENT_CHAIN_DEPTH_LIMIT, RECENT_EVENT_KEYS_LIMIT } from './event-match';
 import { evaluateEventCondition } from './event-condition';
+import { enqueuePendingEvent } from './event-queue';
 
 /** The coordinator internals event delivery needs — nothing else mutates runs. */
 export interface CoordinatorRunSeam {
@@ -64,10 +67,11 @@ export async function broadcastEvent(
 }
 
 /**
- * Consumes a stashed pending event once the loop is idle: clears the stash and
- * runs a fresh event pass seeded with it. Each drained pass goes back through
- * runNext, so a NEW event arriving during that pass stashes again and drains in
- * turn — the chain ends when no new event arrived.
+ * Starts the next queued iteration once the loop is idle. The queue rides in
+ * `runtime.pendingEvents` through the re-arm; the engine consumes the HEAD at
+ * run start. Each drained pass goes back through runNext, so events arriving
+ * during a pass queue behind and drain in turn — the chain ends when the
+ * queue is empty.
  */
 export async function drainPendingEvent(
   host: OrchestratorHost,
@@ -75,12 +79,9 @@ export async function drainPendingEvent(
   loopId: string,
 ): Promise<void> {
   const loop = await seam.findLoop(loopId);
-  if (!loop || loop.status !== 'active' || !loop.runtime.pendingEvent) return;
+  if (!loop || loop.status !== 'active' || !loop.runtime.pendingEvents?.length) return;
   if (loop.runtime.activeRunId || seam.isRunning(loopId) || loop.runtime.pendingInput) return;
-  const event = loop.runtime.pendingEvent;
-  const cleared: Loop = { ...loop, runtime: { ...loop.runtime, pendingEvent: undefined } };
-  await seam.replaceLoop(cleared);
-  await runEventPass(host, seam, cleared, event);
+  await runEventPass(host, seam, loopId);
 }
 
 /** Restart-safe dedupe: an event carrying a dedupeKey is delivered at most once. */
@@ -121,10 +122,10 @@ async function recordChainDepthWarning(
 }
 
 /**
- * Records the fires and either starts a fresh pass (idle) or stashes the event
- * latest-wins (run in flight / parked on a question). The code match is
- * re-checked inside the state update — the condition calls above take time, and
- * another event may have debounced or exhausted a trigger meanwhile.
+ * Records the fires and appends the event to the loop's pending FIFO; an idle
+ * loop additionally starts the next pass. The code match is re-checked inside
+ * the state update — the condition calls above take time, and another event
+ * may have debounced or exhausted a trigger meanwhile.
  */
 async function deliverEventFire(
   host: OrchestratorHost,
@@ -134,7 +135,7 @@ async function deliverEventFire(
   event: OrchestratorEvent,
 ): Promise<void> {
   const wanted = new Set(triggerIds);
-  let fired: Loop | undefined;
+  let fired = false;
   let busy = false;
   await host.updateState((state) => {
     const index = state.loops.findIndex((l) => l.id === loopId);
@@ -147,34 +148,37 @@ async function deliverEventFire(
       .map((t) => t.id);
     if (firing.length === 0) return state;
     busy = Boolean(current.runtime.activeRunId) || seam.isRunning(loopId) || Boolean(current.runtime.pendingInput);
-    let next = applyEventFires(current, firing, nowMs);
-    if (busy) next = { ...next, runtime: { ...next.runtime, pendingEvent: event } };
-    fired = next;
+    const next = enqueuePendingEvent(host, applyEventFires(current, firing, nowMs), event);
+    fired = true;
     const loops = [...state.loops];
     loops[index] = next;
     return { ...state, loops };
   });
   if (!fired || busy) return;
-  await runEventPass(host, seam, fired, event);
+  await runEventPass(host, seam, loopId);
 }
 
 /**
- * Starts a fresh event-fired iteration (cron semantics): drops the previous
- * iteration's worktree, re-arms the plan, and seeds the firing event — the
- * engine consumes it into the run's `firedBy` and an `event` observation.
+ * Starts the next event-fired iteration (cron semantics): drops the previous
+ * iteration's worktree and re-arms the plan. The re-arm reads the CURRENT
+ * on-disk loop inside updateState — never a caller-held copy — so an event
+ * enqueued concurrently is never overwritten. The queued events survive the
+ * re-arm; the engine consumes the head into the run's `firedBy` and an
+ * `event` observation.
  */
-async function runEventPass(
-  host: OrchestratorHost,
-  seam: CoordinatorRunSeam,
-  loop: Loop,
-  event: OrchestratorEvent,
-): Promise<void> {
-  const prior = loop.runtime.workspace.resolved;
+async function runEventPass(host: OrchestratorHost, seam: CoordinatorRunSeam, loopId: string): Promise<void> {
+  let rearmed: Loop | undefined;
+  let prior: Loop['runtime']['workspace']['resolved'];
+  await host.updateState((state) => {
+    const current = state.loops.find((l) => l.id === loopId);
+    if (!current || current.status !== 'active') return state;
+    prior = current.runtime.workspace.resolved; // captured pre-rearm: rearmLoop clears workspace
+    rearmed = rearmLoop(current, host.now());
+    return { ...state, loops: state.loops.map((l) => (l.id === loopId ? rearmed! : l)) };
+  });
+  if (!rearmed) return;
   if (prior?.type === 'managed-worktree') {
-    await host.removeWorktree(prior.worktreeKey ?? loop.id, { force: true });
+    await host.removeWorktree(prior.worktreeKey ?? loopId, { force: true });
   }
-  const rearmed = rearmLoop(loop, host.now());
-  const seeded: Loop = { ...rearmed, runtime: { ...rearmed.runtime, pendingEvent: event } };
-  await seam.replaceLoop(seeded);
-  await seam.runNext(loop.id, seeded);
+  await seam.runNext(loopId, rearmed);
 }

--- a/plugins/sero-orchestrator-plugin/runtime/event-queue.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/event-queue.ts
@@ -1,0 +1,62 @@
+/**
+ * Pending-event FIFO (spec 15, FR-P3). Replaces the spec-12 latest-wins stash:
+ * coalescing was right for debounced file batches but silently dropped
+ * discrete per-PR events (CI fails on two PRs during one run → one vanished).
+ * Fires now queue oldest-first; the engine consumes the HEAD of the queue at
+ * run start, so every drained pass handles exactly one event in arrival order.
+ */
+
+import type { Loop, OrchestratorEvent } from '../shared/types';
+import type { OrchestratorHost } from './host';
+
+export const PENDING_EVENT_QUEUE_CAP = 10;
+
+const OVERFLOW_CODE = 'event-queue-overflow';
+
+/**
+ * Appends an event to the loop's pending queue. Duplicates of an already
+ * queued occurrence (same source + dedupeKey, or same event id) are ignored.
+ * Beyond the cap the OLDEST event is dropped with a visible warning — the
+ * queue bounds memory, never silently truncates.
+ */
+export function enqueuePendingEvent(host: OrchestratorHost, loop: Loop, event: OrchestratorEvent): Loop {
+  const queue = loop.runtime.pendingEvents ?? [];
+  const duplicate = queue.some(
+    (queued) =>
+      queued.id === event.id ||
+      (event.dedupeKey !== undefined && queued.source === event.source && queued.dedupeKey === event.dedupeKey),
+  );
+  if (duplicate) return loop;
+
+  const next = [...queue, event];
+  if (next.length <= PENDING_EVENT_QUEUE_CAP) {
+    return { ...loop, runtime: { ...loop.runtime, pendingEvents: next } };
+  }
+
+  const [dropped, ...kept] = next;
+  return {
+    ...loop,
+    warnings: [
+      ...loop.warnings.filter((w) => w.code !== OVERFLOW_CODE),
+      {
+        id: host.newId('warning'),
+        code: OVERFLOW_CODE,
+        message: `Dropped the oldest queued event ("${dropped.source}") — more than ${PENDING_EVENT_QUEUE_CAP} events fired while runs were in flight.`,
+        createdAt: host.now(),
+      },
+    ],
+    runtime: { ...loop.runtime, pendingEvents: kept },
+  };
+}
+
+/**
+ * Read-time migration for loops persisted before the queue existed: the old
+ * single `pendingEvent` stash becomes a one-element queue.
+ */
+export function migrateLegacyPendingEvent(loop: Loop): Loop {
+  const legacy = (loop.runtime as { pendingEvent?: OrchestratorEvent }).pendingEvent;
+  if (!legacy) return loop;
+  const runtime = { ...loop.runtime, pendingEvents: loop.runtime.pendingEvents ?? [legacy] };
+  delete (runtime as { pendingEvent?: OrchestratorEvent }).pendingEvent;
+  return { ...loop, runtime };
+}

--- a/plugins/sero-orchestrator-plugin/runtime/events/github-adapter.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/events/github-adapter.ts
@@ -31,6 +31,8 @@ export interface GithubAdapterState {
   etags?: Record<string, string>;
   /** Newest-seen item timestamp per event kind (restart-safe cursor). */
   cursors?: Record<string, string>;
+  /** Repo default branch, resolved once on demand for `main-updated` (spec 15). */
+  defaultBranch?: string;
   /** Source-health facts the UI watches (GithubSourceHealth slice). */
   lastPolledAt?: string;
   throttledUntil?: string;
@@ -93,6 +95,20 @@ export function createGithubAdapter(
       const etags = { ...state.etags };
       let cursors = { ...state.cursors };
       let failed = false;
+      // `main-updated` needs the repo default branch: resolved once (one cheap
+      // call, only under demand) and persisted; until it resolves, the kind
+      // emits nothing and the fetch retries next cycle.
+      let defaultBranch = state.defaultBranch;
+      if (kinds.has('main-updated') && defaultBranch === undefined) {
+        const meta = await runGhApi(host, 'repos/{owner}/{repo}');
+        const repo = meta.body as { default_branch?: string } | undefined;
+        if (meta.status >= 200 && meta.status < 300 && repo?.default_branch) {
+          defaultBranch = repo.default_branch;
+        } else {
+          failed = true;
+          host.log(`github adapter: could not resolve the default branch (HTTP ${meta.status}) — main-updated waits`);
+        }
+      }
       for (const endpoint of endpointsForKinds(kinds)) {
         const response = await runGhApi(host, endpoint.path, etags[endpoint.id]);
         if (response.rateLimitRemaining !== undefined && response.rateLimitRemaining < RATE_LIMIT_THRESHOLD) {
@@ -109,7 +125,7 @@ export function createGithubAdapter(
           continue;
         }
         if (response.etag) etags[endpoint.id] = response.etag;
-        const extracted = extractOccurrences(endpoint, response.body, kinds, cursors, host.now());
+        const extracted = extractOccurrences(endpoint, response.body, kinds, cursors, host.now(), { defaultBranch });
         cursors = extracted.cursors;
         for (const occurrence of extracted.occurrences) {
           await emit({
@@ -127,6 +143,7 @@ export function createGithubAdapter(
         ...state,
         etags,
         cursors,
+        defaultBranch,
         lastPolledAt: polledAt,
         throttledUntil:
           rateLimitedUntilMs > Date.parse(polledAt) ? new Date(rateLimitedUntilMs).toISOString() : undefined,

--- a/plugins/sero-orchestrator-plugin/runtime/events/github-kinds.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/events/github-kinds.ts
@@ -18,7 +18,10 @@ export type GithubKind =
   | 'ci-passed'
   | 'issue-labelled'
   | 'review-requested'
-  | 'review-comment';
+  | 'review-comment'
+  | 'pr-approved'
+  | 'main-updated'
+  | 'issue-opened';
 
 const ALL_KINDS: readonly string[] = [
   'pr-opened',
@@ -27,6 +30,9 @@ const ALL_KINDS: readonly string[] = [
   'issue-labelled',
   'review-requested',
   'review-comment',
+  'pr-approved',
+  'main-updated',
+  'issue-opened',
 ];
 
 export interface GithubEndpoint {
@@ -57,7 +63,23 @@ export const GITHUB_ENDPOINTS: GithubEndpoint[] = [
     path: 'repos/{owner}/{repo}/pulls/comments?sort=created&direction=desc&per_page=30',
     kinds: ['review-comment'],
   },
+  {
+    id: 'repo-events',
+    path: 'repos/{owner}/{repo}/events?per_page=30',
+    kinds: ['pr-approved', 'main-updated'],
+  },
+  {
+    id: 'issues',
+    path: 'repos/{owner}/{repo}/issues?state=open&sort=created&direction=desc&per_page=30',
+    kinds: ['issue-opened'],
+  },
 ];
+
+/** Facts some extractors need beyond the endpoint body (spec 15). */
+export interface ExtractionContext {
+  /** The repo default branch — `main-updated` emits nothing until it is known. */
+  defaultBranch?: string;
+}
 
 /** The kinds live subscriptions demand; unknown `github:*` sources are reported, not polled. */
 export function demandedKinds(subscriptions: EventSubscription[]): { kinds: Set<GithubKind>; unknown: string[] } {
@@ -130,6 +152,31 @@ interface GhReviewComment {
   html_url?: string;
   user?: GhUser;
   pull_request_url?: string;
+}
+interface GhRepoEvent {
+  id?: string;
+  type?: string;
+  created_at?: string;
+  actor?: GhUser;
+  payload?: {
+    ref?: string;
+    before?: string;
+    head?: string;
+    size?: number;
+    review?: { state?: string; user?: GhUser };
+    pull_request?: { number?: number; title?: string; html_url?: string };
+  };
+}
+interface GhIssue {
+  id?: number;
+  number?: number;
+  title?: string;
+  created_at?: string;
+  html_url?: string;
+  user?: GhUser;
+  labels?: { name?: string }[];
+  /** Present when the "issue" is actually a pull request — the list mixes them. */
+  pull_request?: unknown;
 }
 
 const CI_FAILURE_CONCLUSIONS = new Set(['failure', 'timed_out', 'startup_failure']);
@@ -243,11 +290,73 @@ function reviewCommentCandidates(body: unknown): Candidate[] {
   return candidates;
 }
 
-const CANDIDATE_EXTRACTORS: Record<string, (body: unknown) => Candidate[]> = {
+/** The repo activity feed: one coarse endpoint carrying review approvals and default-branch pushes. */
+function repoEventCandidates(body: unknown, context: ExtractionContext): Candidate[] {
+  const candidates: Candidate[] = [];
+  for (const entry of asArray<GhRepoEvent>(body)) {
+    if (!entry?.created_at || entry.id === undefined) continue;
+    const shared = { occurredAt: entry.created_at, id: String(entry.id) };
+    if (entry.type === 'PullRequestReviewEvent' && entry.payload?.review?.state === 'approved') {
+      const pull = entry.payload.pull_request;
+      const reviewer = entry.payload.review.user?.login ?? entry.actor?.login;
+      candidates.push({
+        ...shared,
+        kind: 'pr-approved',
+        summary: `PR #${pull?.number} approved by ${reviewer ?? 'unknown'}`,
+        payload: { prNumber: pull?.number, prTitle: pull?.title, reviewer, url: pull?.html_url },
+      });
+    } else if (
+      entry.type === 'PushEvent' &&
+      context.defaultBranch !== undefined &&
+      entry.payload?.ref === `refs/heads/${context.defaultBranch}`
+    ) {
+      const commitCount = entry.payload.size ?? 0;
+      candidates.push({
+        ...shared,
+        kind: 'main-updated',
+        summary: `${context.defaultBranch} updated: ${commitCount} commit${commitCount === 1 ? '' : 's'} by ${entry.actor?.login ?? 'unknown'}`,
+        payload: {
+          branch: context.defaultBranch,
+          beforeSha: entry.payload.before,
+          afterSha: entry.payload.head,
+          commitCount,
+          pusher: entry.actor?.login,
+        },
+      });
+    }
+  }
+  return candidates;
+}
+
+function issueCandidates(body: unknown): Candidate[] {
+  const candidates: Candidate[] = [];
+  for (const issue of asArray<GhIssue>(body)) {
+    // The issues list includes pull requests — `issue-opened` never emits for them.
+    if (!issue?.created_at || issue.id === undefined || issue.pull_request) continue;
+    candidates.push({
+      kind: 'issue-opened',
+      occurredAt: issue.created_at,
+      id: String(issue.id),
+      summary: `Issue #${issue.number} opened: ${issue.title ?? ''}`.trim(),
+      payload: {
+        number: issue.number,
+        title: issue.title,
+        author: issue.user?.login,
+        labels: issue.labels?.map((label) => label.name).filter((name) => name !== undefined) ?? [],
+        url: issue.html_url,
+      },
+    });
+  }
+  return candidates;
+}
+
+const CANDIDATE_EXTRACTORS: Record<string, (body: unknown, context: ExtractionContext) => Candidate[]> = {
   pulls: pullCandidates,
   'workflow-runs': workflowRunCandidates,
   'issue-events': issueEventCandidates,
   'review-comments': reviewCommentCandidates,
+  'repo-events': repoEventCandidates,
+  issues: issueCandidates,
 };
 
 /**
@@ -260,8 +369,9 @@ export function extractOccurrences(
   demanded: Set<GithubKind>,
   cursors: Record<string, string>,
   nowIso: string,
+  context: ExtractionContext = {},
 ): { occurrences: GithubOccurrence[]; cursors: Record<string, string> } {
-  const candidates = CANDIDATE_EXTRACTORS[endpoint.id]?.(body) ?? [];
+  const candidates = CANDIDATE_EXTRACTORS[endpoint.id]?.(body, context) ?? [];
   const next = { ...cursors };
   const occurrences: GithubOccurrence[] = [];
   for (const kind of endpoint.kinds) {

--- a/plugins/sero-orchestrator-plugin/runtime/events/source-catalog.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/events/source-catalog.ts
@@ -69,6 +69,21 @@ export const EVENT_SOURCE_CATALOG: EventSourceInfo[] = [
     filterFields: 'prNumber, author, path',
   },
   {
+    source: 'github:pr-approved',
+    description: 'a pull request review was submitted approving the PR',
+    filterFields: 'prNumber, prTitle, reviewer',
+  },
+  {
+    source: 'github:main-updated',
+    description: 'commits were pushed to the repo default branch',
+    filterFields: 'branch, pusher, commitCount',
+  },
+  {
+    source: 'github:issue-opened',
+    description: 'an issue was opened on the workspace repo (never fires for pull requests)',
+    filterFields: 'number, title, author, labels',
+  },
+  {
     source: 'webhook:<name>',
     description:
       'an external system POSTed JSON to the local hook endpoint /hooks/<name> — invent a short kebab-case name for <name> (e.g. webhook:deploy); the JSON body is the payload',

--- a/plugins/sero-orchestrator-plugin/runtime/host-adapter.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/host-adapter.ts
@@ -92,8 +92,8 @@ export function createOrchestratorHost(ctx: AppRuntimeContext): OrchestratorHost
       }
     },
 
-    createWorktree: async (loopId, title) => {
-      const result = await ctx.host.git.createWorktree(ctx.workspacePath, loopId, title);
+    createWorktree: async (loopId, title, options) => {
+      const result = await ctx.host.git.createWorktree(ctx.workspacePath, loopId, title, options);
       return { worktreePath: result.worktreePath, branchName: result.branchName };
     },
     removeWorktree: (loopId, options) => ctx.host.git.removeWorktree(ctx.workspacePath, loopId, options),

--- a/plugins/sero-orchestrator-plugin/runtime/host.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/host.ts
@@ -217,8 +217,13 @@ export interface OrchestratorHost {
   readArtifact(ref: string): Promise<string | null>;
 
   // ── Workspace isolation (user-selected placement) ─────────
-  /** Creates or reuses one managed worktree for a loop. */
-  createWorktree(loopId: string, title: string): Promise<WorktreeHandle>;
+  /**
+   * Creates or reuses one managed worktree for a loop. With `existingBranch`
+   * the worktree checks out that branch (fetched from origin when only
+   * remote) instead of minting a new one — PR-lifecycle work lands on the
+   * PR's own branch, and removal never deletes it.
+   */
+  createWorktree(loopId: string, title: string, options?: { existingBranch?: string }): Promise<WorktreeHandle>;
   removeWorktree(loopId: string, options?: { deleteBranch?: boolean; force?: boolean }): Promise<void>;
   /** Workspace-root dirty preflight (workspace-root mode only). */
   getWorkspaceStatus(): Promise<WorkspaceStatus>;

--- a/plugins/sero-orchestrator-plugin/runtime/library-actions.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/library-actions.ts
@@ -170,7 +170,9 @@ async function setVersion(
     logPolicy: { ...def.logPolicy },
     contextOverrides: def.contextOverrides ? structuredClone(def.contextOverrides) : undefined,
     delivery: def.delivery ? structuredClone(def.delivery) : undefined,
-    workspace: placement ? { ...loop.workspace, ...placement } : loop.workspace,
+    // Placement stays the workspace/user choice, but the branch source is
+    // definitional (spec 15) and tracks the version like delivery does.
+    workspace: { ...loop.workspace, ...placement, worktreeBranchSource: def.worktreeBranchSource },
     answeredInputs: voidOpenApprovals(loop.answeredInputs, now),
     runtime: { ...loop.runtime, variables: {}, stepStates: initStepStates(plan, now), block: undefined, completion: undefined },
     libraryLink: { ...loop.libraryLink, version: action.version, syncedAt: now },

--- a/plugins/sero-orchestrator-plugin/runtime/library.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/library.ts
@@ -45,7 +45,12 @@ export function instantiate(host: OrchestratorHost, def: SharedLoopDefinition, l
     prompt: def.prompt,
     summary: def.summary,
     status: 'draft',
-    workspace: mergeWorkspaceSettings(fileDeliveryPlacement(def)),
+    workspace: mergeWorkspaceSettings({
+      ...fileDeliveryPlacement(def),
+      // Definitional, like delivery (spec 15): the branch source travels with
+      // the definition; absent means the default fresh-branch behavior.
+      worktreeBranchSource: def.worktreeBranchSource,
+    }),
     plan: structuredClone(def.plan),
     runtime: {
       parentSessionId: loopParentSessionId(host.workspaceId, id),

--- a/plugins/sero-orchestrator-plugin/runtime/loop-store.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/loop-store.ts
@@ -28,6 +28,7 @@ import type {
   RunIndex,
 } from '../shared/types';
 import { buildIndex, buildRunIndex, composeState, diffRuns, diffState, stripLoopForPersist } from './store';
+import { migrateLegacyPendingEvent } from './event-queue';
 
 export interface LoopStore {
   readState(): Promise<OrchestratorState>;
@@ -83,7 +84,10 @@ export function createLoopStore(ctx: AppRuntimeContext): LoopStore {
   }
 
   /** Reassembles a loop's runs/revisions from their files, migrating legacy inline data. */
-  async function reassembleLoop(loop: Loop): Promise<Loop> {
+  async function reassembleLoop(persisted: Loop): Promise<Loop> {
+    // Pre-queue loops persisted a single `pendingEvent` stash — read it as a
+    // one-element queue (spec 15).
+    const loop = migrateLegacyPendingEvent(persisted);
     const runIndex = await readJson<RunIndex>(runIndexFile(loop.id));
     if (runIndex?.runs) {
       const runs: LoopRun[] = [];

--- a/plugins/sero-orchestrator-plugin/runtime/outcomes.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/outcomes.ts
@@ -163,9 +163,9 @@ export function recordCompletion(
     completion.status === 'blocked'
       ? { kind: 'planned-block' as const, reason: completion.reason, createdAt: now, sourceStepId: stepId, sourceAttemptId: attempt.id }
       : undefined;
-  // A pendingEvent stashed mid-run lives on DISK, not on this in-memory copy —
-  // the engine's commit() drops it (with an `event-dropped` warning) when the
-  // loop leaves 'active', so nothing stale fires on a later re-activation.
+  // Events queued mid-run live on DISK, not on this in-memory copy — the
+  // engine's commit() drops the queue (with an `event-dropped` warning) when
+  // the loop leaves 'active', so nothing stale fires on a later re-activation.
   return {
     loop: {
       ...loop,

--- a/plugins/sero-orchestrator-plugin/runtime/planner-prompt.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/planner-prompt.ts
@@ -9,7 +9,7 @@ import type { LoopDeliverySettings } from '../shared/delivery-types';
 import type { SharedLoopDefinition } from '../shared/library-types';
 import { DEFAULT_TOOLS } from '../shared/constants';
 import { buildEventSourceCatalogBlock } from './events/source-catalog';
-import { deliverySpec, type DeliveryDestinationSpec } from './delivery/registry';
+import { deliverySpec, PR_UPDATE_PLANNER_RULES, type DeliveryDestinationSpec } from './delivery/registry';
 
 export const PLANNING_SYSTEM_PROMPT = `You are the PLANNER for Sero Orchestrator. You do NOT make any change yourself — a separate background agent will carry out each step you author. Your only job is to turn the user's prompt into a durable step plan. Not having edit/file tools is expected; never refuse or describe the edit instead.
 
@@ -189,6 +189,8 @@ Keep the step structure, intent, and any tuned trigger settings (debounce, max f
 export interface PlanningTaskArgs {
   prompt: string;
   useManagedWorktree: boolean;
+  /** 'event-pr' swaps the pr delivery rules to push-to-the-PR's-own-branch (spec 15). */
+  worktreeBranchSource?: 'new' | 'event-pr';
   /** The loop's effective delivery — always resolved by the caller (effectiveDelivery), never chosen here. */
   delivery: LoopDeliverySettings;
   toolCatalog?: PlanningToolInfo[];
@@ -200,6 +202,9 @@ export interface PlanningTaskArgs {
 
 export function buildPlanningTask(args: PlanningTaskArgs): string {
   const { prompt, useManagedWorktree, delivery, toolCatalog = [], clarifications = [], agentCatalog = [] } = args;
+  const spec = deliverySpec(delivery.destination);
+  const effectiveSpec =
+    spec.id === 'pr' && args.worktreeBranchSource === 'event-pr' ? { ...spec, plannerRules: PR_UPDATE_PLANNER_RULES } : spec;
   return `A background agent will carry out the work below. Author the step plan it should follow — do not perform the work yourself, and do not ask the user to specify mechanics like committing, opening a PR, or marking the loop complete. Add those yourself per the rules.
 
 Goal:
@@ -211,7 +216,7 @@ ${buildEventSourceCatalogBlock()}
 
 ${buildToolCatalogBlock(toolCatalog)}${buildAgentCatalogBlock(agentCatalog)}${buildPlacementBlock(useManagedWorktree)}
 
-${buildDeliveryBlock(deliverySpec(delivery.destination), delivery.params)}
+${buildDeliveryBlock(effectiveSpec, delivery.params)}
 
 Return the PlanningResponse JSON now (one object, top-level "plan", no prose) — or the clarifyingQuestions object if you are genuinely blocked.`;
 }

--- a/plugins/sero-orchestrator-plugin/runtime/planner.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/planner.ts
@@ -21,6 +21,8 @@ export interface PlanRequest {
   parentSessionId: string;
   /** The loop's workspace isolation, so the planner adds the right placement rules. */
   useManagedWorktree: boolean;
+  /** 'event-pr' swaps the pr delivery rules to push-to-the-PR's-own-branch (spec 15). */
+  worktreeBranchSource?: 'new' | 'event-pr';
   /** The loop's effective delivery (user-chosen or derived) — the planner authors its steps, never picks it. */
   delivery: LoopDeliverySettings;
   /** The real tool catalog the planner picks each step's tools from. */
@@ -82,6 +84,7 @@ export async function planLoop(host: OrchestratorHost, req: PlanRequest): Promis
     first = await runPlanning(host, req, buildPlanningTask({
       prompt: req.prompt,
       useManagedWorktree: req.useManagedWorktree,
+      worktreeBranchSource: req.worktreeBranchSource,
       delivery: req.delivery,
       toolCatalog: req.toolCatalog,
       clarifications: req.clarifications,

--- a/plugins/sero-orchestrator-plugin/runtime/planning-flow.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/planning-flow.ts
@@ -56,6 +56,7 @@ export async function runPlanningFlow(host: OrchestratorHost, draft: Loop, args:
     prompt: args.prompt,
     parentSessionId: draft.runtime.parentSessionId,
     useManagedWorktree: draft.workspace.useManagedWorktree,
+    worktreeBranchSource: draft.workspace.worktreeBranchSource,
     delivery: effectiveDelivery(draft),
     toolCatalog,
     agentCatalog,

--- a/plugins/sero-orchestrator-plugin/runtime/run-engine-helpers.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/run-engine-helpers.ts
@@ -75,6 +75,12 @@ export function mergeTriggers(disk: Loop['triggers'], memory: Loop['triggers']):
   });
 }
 
+/** True when this batch is about to start background filesystem work with no workspace resolved yet. */
+export function needsWorkspace(loop: Loop, batch: string[]): boolean {
+  if (loop.runtime.workspace.resolved) return false;
+  return batch.some((id) => loop.plan.steps.find((step) => step.id === id)?.execution.type === 'background-agent');
+}
+
 /**
  * A loop leaving 'active' can never drain its pending-event queue — drop it
  * VISIBLY (an `event-dropped` warning) instead of leaving stale fires to go

--- a/plugins/sero-orchestrator-plugin/runtime/run-engine-helpers.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/run-engine-helpers.ts
@@ -76,13 +76,15 @@ export function mergeTriggers(disk: Loop['triggers'], memory: Loop['triggers']):
 }
 
 /**
- * A loop leaving 'active' can never drain a stashed pendingEvent — drop it
- * VISIBLY (an `event-dropped` warning) instead of leaving a stale fire to go
+ * A loop leaving 'active' can never drain its pending-event queue — drop it
+ * VISIBLY (an `event-dropped` warning) instead of leaving stale fires to go
  * off on a later re-activation. No-op while the loop stays active.
  */
 export function dropStrandedEvent(host: OrchestratorHost, loop: Loop): Loop {
-  const dropped = loop.status !== 'active' ? loop.runtime.pendingEvent : undefined;
-  if (!dropped) return loop;
+  const stranded = loop.status !== 'active' ? (loop.runtime.pendingEvents ?? []) : [];
+  if (stranded.length === 0) return loop;
+  const sources = [...new Set(stranded.map((e) => e.source))].join(', ');
+  const count = stranded.length === 1 ? 'An event' : `${stranded.length} queued events`;
   return {
     ...loop,
     warnings: [
@@ -90,10 +92,10 @@ export function dropStrandedEvent(host: OrchestratorHost, loop: Loop): Loop {
       {
         id: host.newId('warning'),
         code: 'event-dropped',
-        message: `A "${dropped.source}" event arrived during the final run and was not processed because the loop is now ${loop.status}.`,
+        message: `${count} ("${sources}") arrived during the final run and ${stranded.length === 1 ? 'was' : 'were'} not processed because the loop is now ${loop.status}.`,
         createdAt: host.now(),
       },
     ],
-    runtime: { ...loop.runtime, pendingEvent: undefined },
+    runtime: { ...loop.runtime, pendingEvents: undefined },
   };
 }

--- a/plugins/sero-orchestrator-plugin/runtime/run-engine.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/run-engine.ts
@@ -25,7 +25,7 @@ import { checkManagementLimits } from './limits';
 import { recordAgentWarning, recordModelWarning } from './run-warnings';
 import { isRecurring } from './scheduler';
 import { toEventFiredBy, toEventObservation } from './event-match';
-import { blockLimit, blockRuntime, dropStrandedEvent, mergeTriggers, replaceRun, resetRunningSteps, resetStepPending } from './run-engine-helpers';
+import { blockLimit, blockRuntime, dropStrandedEvent, mergeTriggers, needsWorkspace, replaceRun, resetRunningSteps, resetStepPending } from './run-engine-helpers';
 import { enforceDeliveryContract } from './delivery/delivery-contract';
 import { applyDeliveryContract } from './delivery/verify-receipt';
 import { reconcileDeliveryWarning } from './delivery/availability';
@@ -180,9 +180,15 @@ export class RunEngine {
       const batch = ready.slice(0, loop.limits.maxConcurrentSteps ?? ready.length);
 
       // Resolve the loop workspace lazily, only when a background-agent
-      // filesystem step is about to start (D-06).
-      if (this.needsWorkspace(loop, batch) && this.deps.workspaceResolver) {
-        const resolution = await this.deps.workspaceResolver.resolve(this.host, loop);
+      // filesystem step is about to start (D-06). `run` rides along for
+      // event-pr branch resolution (spec 15).
+      if (needsWorkspace(loop, batch) && this.deps.workspaceResolver) {
+        const resolution = await this.deps.workspaceResolver.resolve(this.host, loop, run);
+        if (resolution.blocked) {
+          loop = await this.commit(blockRuntime(resolution.loop, resolution.blocked, this.host.now()));
+          run = { ...run, status: 'blocked', block: loop.runtime.block };
+          break;
+        }
         loop = await this.commit(resolution.loop);
         if (resolution.deferred) {
           run = { ...run, status: 'waiting' };
@@ -212,10 +218,6 @@ export class RunEngine {
     return this.commit({ ...loop, runtime: { ...loop.runtime, pullRequests: mine } });
   }
 
-  private needsWorkspace(loop: Loop, batch: string[]): boolean {
-    if (loop.runtime.workspace.resolved) return false;
-    return batch.some((id) => this.step(loop, id).execution.type === 'background-agent');
-  }
 
   private async runBatch(
     loop: Loop,

--- a/plugins/sero-orchestrator-plugin/runtime/run-engine.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/run-engine.ts
@@ -104,12 +104,13 @@ export class RunEngine {
     // Monotonic, never reused — `runs.length` repeats once run-history pruning
     // caps it, which would reuse worktree keys/branch names across iterations.
     const runSeq = (initial.runtime.runSeq ?? initial.runs.length) + 1;
-    // Consume the event this iteration was fired by (Living Loops): it becomes
-    // the run's `firedBy` plus an `event` observation the steps read, and the
-    // stash is cleared. A NEW event stashed while this run is in flight is a
-    // different id and survives `commit`'s preservation for the next iteration.
-    const event = initial.runtime.pendingEvent;
+    // Consume the HEAD of the pending-event queue (Living Loops): it becomes
+    // the run's `firedBy` plus an `event` observation the steps read. Events
+    // queued while this run is in flight have different ids and survive
+    // `commit`'s disk-authoritative merge for the iterations that follow.
+    const event = initial.runtime.pendingEvents?.[0];
     if (event) this.consumedEvents.set(initial.id, event.id);
+    const remainingEvents = initial.runtime.pendingEvents?.slice(1);
     let run: LoopRun = {
       id: this.host.newId('run'),
       runNumber: runSeq,
@@ -126,7 +127,13 @@ export class RunEngine {
       runs: [...initial.runs, run],
       // Drop last run's model/agent-unavailable warnings; this run re-discovers them.
       warnings: initial.warnings.filter((w) => w.code !== 'model-unavailable' && w.code !== 'agent-unavailable'),
-      runtime: { ...initial.runtime, activeRunId: run.id, lastRunAt: now, runSeq, pendingEvent: undefined },
+      runtime: {
+        ...initial.runtime,
+        activeRunId: run.id,
+        lastRunAt: now,
+        runSeq,
+        pendingEvents: remainingEvents?.length ? remainingEvents : undefined,
+      },
     };
     loop = await this.commit(loop);
     loop = await this.reconcilePullRequests(loop);
@@ -452,10 +459,10 @@ export class RunEngine {
    *   trigger write (the terminal-completion disable) is merged on top;
    * - `dueAgain` (a folded rerun request) is only ever SET concurrently, so a
    *   set flag on disk wins over the engine's stale false;
-   * - `pendingEvent` is coordinator-stashed; the engine only clears the one it
-   *   consumed at run start — a NEWER stash (different id) is preserved, and a
-   *   stash stranded by the loop leaving 'active' is dropped visibly
-   *   (dropStrandedEvent).
+   * - `pendingEvents` is coordinator-enqueued; the on-disk queue is
+   *   authoritative (it may have grown mid-run) and the engine only removes
+   *   the head it consumed at run start. A queue stranded by the loop leaving
+   *   'active' is dropped visibly (dropStrandedEvent).
    */
   private async commit(loop: Loop): Promise<Loop> {
     let result = loop;
@@ -464,14 +471,14 @@ export class RunEngine {
       result = loop;
       if (current) {
         const consumedId = this.consumedEvents.get(loop.id);
-        const stashed = current.runtime.pendingEvent;
+        const queued = (current.runtime.pendingEvents ?? []).filter((e) => e.id !== consumedId);
         result = {
           ...result,
           triggers: mergeTriggers(current.triggers, result.triggers),
           runtime: {
             ...result.runtime,
             dueAgain: current.runtime.dueAgain || result.runtime.dueAgain,
-            pendingEvent: stashed && stashed.id !== consumedId ? stashed : result.runtime.pendingEvent,
+            pendingEvents: queued.length ? queued : undefined,
           },
         };
       }

--- a/plugins/sero-orchestrator-plugin/runtime/workspace.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/workspace.ts
@@ -10,7 +10,7 @@
  * Resolution runs only when background-agent filesystem work is about to start.
  */
 
-import type { DirtyWorkspaceDecision, Loop, ResolvedWorkspaceContext } from '../shared/types';
+import type { DirtyWorkspaceDecision, Loop, LoopRun, ResolvedWorkspaceContext } from '../shared/types';
 import type { OrchestratorHost } from './host';
 import type { WorkspaceResolver } from './engine-types';
 
@@ -42,6 +42,56 @@ export interface ResolveResult {
   loop: Loop;
   workspace?: ResolvedWorkspaceContext;
   deferred?: string;
+  /** Hard stop with a visible reason (event-pr branch unresolvable, FR-P1). */
+  blocked?: string;
+}
+
+/**
+ * The PR branch an `event-pr` run works on, from the run's firing-event
+ * observation: payload `branch` directly, else `prNumber`/`number` looked up
+ * in the open-PR list. Deterministic field reads — the payload shapes are our
+ * own adapters' (github-kinds.ts), never guessed.
+ */
+async function eventPrBranch(host: OrchestratorHost, run: LoopRun | undefined): Promise<string | { error: string }> {
+  const payload = run?.observations.find((o) => o.source === 'event')?.data as
+    | { branch?: unknown; prNumber?: unknown; number?: unknown }
+    | undefined;
+  if (!payload) {
+    return { error: 'This loop works on the PR branch named by its firing event, but this run was not started by an event.' };
+  }
+  if (typeof payload.branch === 'string' && payload.branch.length > 0) return payload.branch;
+  const prNumber = typeof payload.prNumber === 'number' ? payload.prNumber : typeof payload.number === 'number' ? payload.number : undefined;
+  if (prNumber === undefined) {
+    return { error: 'The firing event names neither a branch nor a PR number, so there is no PR branch to work on.' };
+  }
+  const open = await host.listPullRequests().catch(() => []);
+  const pr = open.find((candidate) => candidate.number === prNumber);
+  if (!pr) return { error: `PR #${prNumber} from the firing event is not in the open-PR list — it may be closed or merged.` };
+  return pr.headRefName;
+}
+
+/** Managed worktree checked out at the PR's own branch (spec 15, FR-P1). */
+async function resolveEventPrWorktree(host: OrchestratorHost, loop: Loop, run: LoopRun | undefined): Promise<ResolveResult> {
+  const branch = await eventPrBranch(host, run);
+  if (typeof branch !== 'string') return { loop, blocked: branch.error };
+  const worktreeKey = worktreeKeyFor(loop);
+  const handle = await host
+    .createWorktree(worktreeKey, loop.title, { existingBranch: branch })
+    .catch((error: unknown) => ({ error: error instanceof Error ? error.message : String(error) }));
+  if ('error' in handle) return { loop, blocked: `Could not check out branch "${branch}": ${handle.error}` };
+  const resolved: ResolvedWorkspaceContext = {
+    id: host.newId('ws'),
+    type: 'managed-worktree',
+    workspaceRoot: host.workspacePath,
+    cwd: handle.worktreePath,
+    worktreePath: handle.worktreePath,
+    branchName: handle.branchName,
+    worktreeKey,
+    externalBranch: true,
+    resolvedBy: 'create-option',
+    createdAt: host.now(),
+  };
+  return { loop: withResolved(loop, resolved), workspace: resolved };
 }
 
 async function resolveManagedWorktree(
@@ -95,13 +145,16 @@ function withResolved(loop: Loop, resolved: ResolvedWorkspaceContext, decision?:
 /** The default resolver used by the runtime. */
 export const workspaceResolver: WorkspaceResolver = { resolve };
 
-export async function resolve(host: OrchestratorHost, loop: Loop): Promise<ResolveResult> {
+export async function resolve(host: OrchestratorHost, loop: Loop, run?: LoopRun): Promise<ResolveResult> {
   // Reuse an already-resolved workspace for the loop's lifetime.
   if (loop.runtime.workspace.resolved) {
     return { loop, workspace: loop.runtime.workspace.resolved };
   }
 
   if (loop.workspace.useManagedWorktree) {
+    if (loop.workspace.worktreeBranchSource === 'event-pr') {
+      return resolveEventPrWorktree(host, loop, run);
+    }
     const resolved = await resolveManagedWorktree(host, loop, 'create-option');
     return { loop: withResolved(loop, resolved), workspace: resolved };
   }

--- a/plugins/sero-orchestrator-plugin/runtime/workspace.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/workspace.ts
@@ -47,24 +47,47 @@ export interface ResolveResult {
 }
 
 /**
+ * Which firing events can name a PR branch, and how. Resolution is
+ * source-aware because a generic `payload.branch` read is unsafe: the
+ * `github:main-updated` payload carries `branch: <default branch>`, so a bare
+ * field read would check out main as the "PR branch" and the event-pr planner
+ * rules would then push straight to it. Only PR-scoped GitHub events resolve —
+ * through the field that genuinely carries the PR head ref for that source.
+ */
+const PR_HEAD_BRANCH_SOURCES = new Set(['github:ci-failed', 'github:ci-passed', 'github:pr-opened']);
+const PR_NUMBER_SOURCES = new Set(['github:pr-approved', 'github:review-comment', 'github:review-requested']);
+
+/**
  * The PR branch an `event-pr` run works on, from the run's firing-event
- * observation: payload `branch` directly, else `prNumber`/`number` looked up
- * in the open-PR list. Deterministic field reads — the payload shapes are our
- * own adapters' (github-kinds.ts), never guessed.
+ * observation. PR-head-branch sources use payload `branch` directly; other
+ * PR-scoped sources resolve `prNumber`/`number` through the open-PR list.
+ * Deterministic field reads — the payload shapes are our own adapters'
+ * (github-kinds.ts), never guessed.
  */
 async function eventPrBranch(host: OrchestratorHost, run: LoopRun | undefined): Promise<string | { error: string }> {
+  const source = run?.firedBy?.source;
   const payload = run?.observations.find((o) => o.source === 'event')?.data as
     | { branch?: unknown; prNumber?: unknown; number?: unknown }
     | undefined;
-  if (!payload) {
+  if (!source || !payload) {
     return { error: 'This loop works on the PR branch named by its firing event, but this run was not started by an event.' };
   }
-  if (typeof payload.branch === 'string' && payload.branch.length > 0) return payload.branch;
+  if (!PR_HEAD_BRANCH_SOURCES.has(source) && !PR_NUMBER_SOURCES.has(source)) {
+    return { error: `The firing event (${source}) is not scoped to a pull request, so there is no PR branch to work on.` };
+  }
+  if (PR_HEAD_BRANCH_SOURCES.has(source) && typeof payload.branch === 'string' && payload.branch.length > 0) {
+    return payload.branch;
+  }
   const prNumber = typeof payload.prNumber === 'number' ? payload.prNumber : typeof payload.number === 'number' ? payload.number : undefined;
   if (prNumber === undefined) {
     return { error: 'The firing event names neither a branch nor a PR number, so there is no PR branch to work on.' };
   }
-  const open = await host.listPullRequests().catch(() => []);
+  const open = await host
+    .listPullRequests()
+    .catch((cause: unknown) => (cause instanceof Error ? cause.message : String(cause)));
+  if (typeof open === 'string') {
+    return { error: `Could not read the open pull-request list to resolve PR #${prNumber}: ${open}` };
+  }
   const pr = open.find((candidate) => candidate.number === prNumber);
   if (!pr) return { error: `PR #${prNumber} from the firing event is not in the open-PR list — it may be closed or merged.` };
   return pr.headRefName;

--- a/plugins/sero-orchestrator-plugin/shared/library-types.ts
+++ b/plugins/sero-orchestrator-plugin/shared/library-types.ts
@@ -38,6 +38,13 @@ export interface SharedLoopDefinition {
    * per workspace on load/install. Optional — schemaVersion stays 1.
    */
   delivery?: LoopDeliverySettings;
+  /**
+   * Definitional like the delivery kind: "this loop works on the PR branch
+   * from its firing event" is what the loop IS (spec 15), while the rest of
+   * the workspace settings stay per-workspace choices. Optional —
+   * schemaVersion stays 1.
+   */
+  worktreeBranchSource?: 'new' | 'event-pr';
 }
 
 /** Where a library version came from when installed from a catalog (spec 14). */

--- a/plugins/sero-orchestrator-plugin/shared/library.ts
+++ b/plugins/sero-orchestrator-plugin/shared/library.ts
@@ -46,6 +46,7 @@ export function toSharedDefinition(loop: Loop): SharedLoopDefinition {
     logPolicy: { ...loop.logPolicy },
     contextOverrides: loop.contextOverrides ? structuredClone(loop.contextOverrides) : undefined,
     delivery: loop.delivery ? structuredClone(loop.delivery) : undefined,
+    worktreeBranchSource: loop.workspace.worktreeBranchSource,
   };
 }
 

--- a/plugins/sero-orchestrator-plugin/shared/types.ts
+++ b/plugins/sero-orchestrator-plugin/shared/types.ts
@@ -157,6 +157,7 @@ export interface LoopWarning {
     | 'agent-unavailable'
     | 'event-chain-depth'
     | 'event-dropped'
+    | 'event-queue-overflow'
     | 'delivery-tool-missing'
     | 'catalog-tool-missing';
   message: string;
@@ -314,12 +315,13 @@ export interface LoopRuntimeState {
    */
   deliveries?: DeliveryReceipt[];
   /**
-   * The latest event that fired while this loop was busy (run in flight or
-   * parked on a question) — latest wins, at most one pending fire. Consumed by
-   * the next iteration: the engine turns it into the run's `firedBy` + an
-   * `event` observation. Only the coordinator writes this field.
+   * FIFO of event fires awaiting their iteration (queued while a run was in
+   * flight or the loop was parked on a question), oldest first, bounded —
+   * overflow drops the oldest with a visible warning (event-queue.ts). The
+   * engine consumes the HEAD at run start and turns it into the run's
+   * `firedBy` + an `event` observation. Only the coordinator enqueues.
    */
-  pendingEvent?: OrchestratorEvent;
+  pendingEvents?: OrchestratorEvent[];
 }
 
 export interface LoopBlock {

--- a/plugins/sero-orchestrator-plugin/shared/workspace-types.ts
+++ b/plugins/sero-orchestrator-plugin/shared/workspace-types.ts
@@ -17,6 +17,15 @@ export interface LoopWorkspaceSettings {
    * worktree. Default false (the preflight prompts as before).
    */
   allowDirtyWorkspaceRoot: boolean;
+  /**
+   * Where a managed worktree's branch comes from (spec 15). 'new' (default,
+   * also when absent) mints a fresh branch per run. 'event-pr' checks out the
+   * PR branch named by the firing event — payload `branch`, else
+   * `prNumber`/`number` looked up in the open-PR list — so commits land on
+   * the PR's own branch; an unresolvable branch blocks the run visibly,
+   * never falls back to a fresh branch. Requires useManagedWorktree.
+   */
+  worktreeBranchSource?: 'new' | 'event-pr';
 }
 
 // ── Workspace runtime context ───────────────────────────────
@@ -30,6 +39,8 @@ export interface ResolvedWorkspaceContext {
   branchName?: string;
   /** Key the worktree was created under (per-iteration for recurring loops); used for cleanup. */
   worktreeKey?: string;
+  /** The branch belongs to a PR, not this loop — cleanup must never delete it. */
+  externalBranch?: boolean;
   resolvedBy:
     | 'create-option'
     | 'clean-workspace'

--- a/plugins/sero-orchestrator-plugin/ui/OrchestratorApp.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/OrchestratorApp.tsx
@@ -116,6 +116,7 @@ export function OrchestratorApp() {
       title: values.title,
       useManagedWorktree: values.useManagedWorktree,
       allowDirtyWorkspaceRoot: values.allowDirtyWorkspaceRoot,
+      worktreeBranchSource: values.worktreeBranchSource,
       deliveryDestination: values.delivery?.destination,
       deliveryParamsJson: values.delivery?.params ? JSON.stringify(values.delivery.params) : undefined,
       activate: false,

--- a/plugins/sero-orchestrator-plugin/ui/components/CreateLoopForm.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/CreateLoopForm.tsx
@@ -9,6 +9,8 @@ export interface CreateLoopSubmit {
   title?: string;
   useManagedWorktree: boolean;
   allowDirtyWorkspaceRoot: boolean;
+  /** 'event-pr' = the worktree checks out the PR branch named by the firing event. */
+  worktreeBranchSource?: 'new' | 'event-pr';
   /** Absent = automatic (follows placement: worktree ⇒ PR, root ⇒ workspace files). */
   delivery?: LoopDeliverySettings;
 }
@@ -29,6 +31,7 @@ export function CreateLoopForm({ busy, onSubmit, onCancel }: CreateLoopFormProps
   const [title, setTitle] = useState('');
   const [useManagedWorktree, setUseManagedWorktree] = useState(true);
   const [allowDirtyWorkspaceRoot, setAllowDirtyWorkspaceRoot] = useState(false);
+  const [eventPrBranch, setEventPrBranch] = useState(false);
   const [destination, setDestination] = useState<DeliveryDestinationId | 'auto'>('auto');
   const [deliveryParams, setDeliveryParams] = useState<Record<string, string>>({});
 
@@ -44,6 +47,7 @@ export function CreateLoopForm({ busy, onSubmit, onCancel }: CreateLoopFormProps
       title: title.trim() || undefined,
       useManagedWorktree,
       allowDirtyWorkspaceRoot: useManagedWorktree ? false : allowDirtyWorkspaceRoot,
+      worktreeBranchSource: useManagedWorktree && eventPrBranch ? 'event-pr' : undefined,
       delivery:
         destination === 'auto'
           ? undefined
@@ -80,6 +84,12 @@ export function CreateLoopForm({ busy, onSubmit, onCancel }: CreateLoopFormProps
           <div className="flex items-center justify-between gap-3">
             <Label htmlFor="loop-allow-dirty" className="font-normal">Run here even with uncommitted changes</Label>
             <Switch id="loop-allow-dirty" checked={allowDirtyWorkspaceRoot} onCheckedChange={setAllowDirtyWorkspaceRoot} />
+          </div>
+        )}
+        {useManagedWorktree && (
+          <div className="flex items-center justify-between gap-3">
+            <Label htmlFor="loop-event-pr" className="font-normal">Work on the PR branch from the firing event</Label>
+            <Switch id="loop-event-pr" checked={eventPrBranch} onCheckedChange={setEventPrBranch} />
           </div>
         )}
         <div className="flex items-center justify-between gap-3">

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopMetaStrip.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopMetaStrip.tsx
@@ -6,7 +6,7 @@
  * chip's hover title.
  */
 
-import { Activity, Clock, Coins, FolderGit2, GitBranch, Gauge, Repeat, Send, Zap } from 'lucide-react';
+import { Activity, Clock, Coins, FolderGit2, GitBranch, Gauge, Inbox, Repeat, Send, Zap } from 'lucide-react';
 import type { GithubSourceHealth, Loop, LoopRunSummary, WebhookSourceHealth } from '../../shared/types';
 import { formatTime } from '../lib/format';
 import { deliveryChip } from '../lib/delivery-summary';
@@ -49,6 +49,7 @@ export function LoopMetaStrip({
       <span className="flex items-center gap-1.5">
         {workspace.useManagedWorktree ? <GitBranch className="h-3.5 w-3.5" /> : <FolderGit2 className="h-3.5 w-3.5" />}
         {workspace.useManagedWorktree ? 'Managed worktree' : 'Workspace root'}
+        {workspace.useManagedWorktree && workspace.worktreeBranchSource === 'event-pr' ? ' · PR branch from event' : ''}
         {!workspace.useManagedWorktree && workspace.allowDirtyWorkspaceRoot ? ' · runs in place' : ''}
         {resolved ? ` · ${resolved.type}` : ''}
       </span>
@@ -83,6 +84,16 @@ export function LoopMetaStrip({
           <Activity className="h-3.5 w-3.5" /> {chip.label}
         </span>
       ))}
+      {(loop.runtime.pendingEvents?.length ?? 0) > 0 && (
+        <span
+          className="flex items-center gap-1.5"
+          title={loop.runtime.pendingEvents!.map((e) => e.summary ?? e.source).join('\n')}
+        >
+          <Inbox className="h-3.5 w-3.5" />
+          {loop.runtime.pendingEvents!.length} event{loop.runtime.pendingEvents!.length === 1 ? '' : 's'} queued · next:{' '}
+          {loop.runtime.pendingEvents![0].summary ?? loop.runtime.pendingEvents![0].source}
+        </span>
+      )}
       {(() => {
         const t = loop.triggers.find((tr) => tr.fireCount > 0);
         const fires = loop.triggers.reduce((n, tr) => n + tr.fireCount, 0);


### PR DESCRIPTION
## Summary

Implements the PR lifecycle loop work from orchestrator spec 15. This lets orchestrator loops react to PR events, operate on the PR's own branch, queue discrete events safely, and ship catalog recipes for common PR maintenance workflows.

## What changed

- Added spec 15 and implementation notes for PR lifecycle loops.
- Added managed worktree support for existing PR branches via `worktreeBranchSource: 'event-pr'`.
- Replaced single pending-event overwrite behavior with a bounded FIFO event queue, including dedupe and overflow reporting.
- Expanded GitHub event support with PR lifecycle kinds such as `pr-approved`, `main-updated`, `pr-closed`, and `issue-opened` metadata used by catalog recipes.
- Updated planner prompts and delivery receipts so lifecycle loops can push updates to existing PRs instead of only treating PR delivery as newly created PRs.
- Added branch-source controls and event-queue visibility in the orchestrator UI.
- Added/updated catalog recipes for CI fixing, review response, main rebasing, and issue implementation flows.
- Updated orchestrator reference docs.

## Tests

- `pnpm typecheck`

## Suggested review focus

1. **Worktree branch safety** — check that `event-pr` branch resolution cannot silently fall back to a fresh branch when the event payload is missing or ambiguous.
2. **Queue semantics** — verify FIFO ordering, dedupe keys, queue cap behavior, and the visible overflow warning match the spec.
3. **GitHub event mapping** — review the new/expanded GitHub event kinds and payload fields, especially PR branch, PR number, SHA, author, and dedupe values.
4. **Receipt verification** — confirm updated-PR receipt matching works for existing branches that were not created by the loop.
5. **Catalog recipe prompts** — read the shipped PR lifecycle catalog entries for clear trigger filters and safe default behavior.
