### PR TITLE
fix: support building appimage and rpm

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -78,6 +78,8 @@ linux:
   maintainer: Sero Labs <hello@sero.ai>
   target:
     - deb
+    - AppImage
+    - rpm
   category: Development
   artifactName: "${productName}-${version}-linux-${arch}.${ext}"
 


### PR DESCRIPTION
## Summary

- what changed
- why it changed

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm build` (if relevant)
- [ ] `pnpm --filter @sero/desktop test -- --run` (if relevant)
- [ ] `pnpm --filter @sero/desktop test:e2e` (if relevant)
- [ ] docs updated (if relevant)

## Safety checklist

- [ ] no secrets, tokens, credentials, or machine-specific private paths committed
- [ ] no unnecessary `any`, `@ts-ignore`, or `@ts-expect-error`
- [ ] touched source files remain under 500 LOC

## Screenshots / recordings

<!-- Add before/after UI evidence for visible changes. -->

## Risk / rollout notes

- breaking changes:
- security or privacy impact:
- follow-up work:
