### PR TITLE
docs(marketing): add community inbox slot

### DIFF
--- a/docs/marketing/community-inbox.md
+++ b/docs/marketing/community-inbox.md
@@ -1,0 +1,13 @@
+# Community inbox
+
+Manual input slot for the `community-digest` loop (Sero can't read Discord
+channels, so highlights get pasted here by hand).
+
+During the week, paste Discord highlights below: questions, feedback, notable
+messages, anything worth mentioning in the weekly community update. The loop
+reads this file on Mondays and folds entries into the digest draft; it never
+modifies or clears it — delete old entries yourself after they've been used.
+
+## Highlights
+
+(none yet)


### PR DESCRIPTION
Docs-only. Paste-in slot for the weekly community digest. Merge to fire the proof-moment-miner loop.