### PR TITLE
feat(desktop): publish Linux AppImage alongside the .deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,7 @@ jobs:
           path: |
             apps/desktop/release/*.blockmap
             apps/desktop/release/*.deb
+            apps/desktop/release/*.AppImage
             apps/desktop/release/*.dmg
             apps/desktop/release/*.exe
             apps/desktop/release/*.yml

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -76,8 +76,12 @@ mac:
 # ── Linux ─────────────────────────────────────────────────────
 linux:
   maintainer: Sero Labs <hello@sero.ai>
+  # deb is built manually with dpkg-deb (see build-linux-deb.mjs) because
+  # electron-builder's deb/rpm path uses fpm, which is x64-only and cannot run
+  # on the native arm64 release runner. AppImage uses appimagetool instead of
+  # fpm, so electron-builder builds it directly for both architectures.
   target:
-    - deb
+    - AppImage
   category: Development
   artifactName: "${productName}-${version}-linux-${arch}.${ext}"
 

--- a/apps/desktop/scripts/build-release.sh
+++ b/apps/desktop/scripts/build-release.sh
@@ -89,7 +89,7 @@ electron_builder_arch_flag() {
 artifact_patterns() {
   case "$1" in
     mac) echo "release/*.dmg release/*.zip" ;;
-    linux) echo "release/*.deb" ;;
+    linux) echo "release/*.deb release/*.AppImage" ;;
     win) echo "release/*.exe release/*.zip" ;;
   esac
 }
@@ -334,16 +334,22 @@ BUILDER_ARGS=(
   --publish never
   "$BUILDER_FLAG"
 )
-# Linux releases are Debian packages built with dpkg-deb after electron-builder
-# creates the unpacked app directory. This keeps maintainer scripts consistent
-# across architectures and avoids electron-builder's bundled fpm helper, which
-# is x64-only and cannot run on native arm64 runners.
+# Linux .deb packages are built with dpkg-deb after electron-builder creates the
+# unpacked app directory. This keeps maintainer scripts consistent across
+# architectures and avoids electron-builder's bundled fpm helper, which is
+# x64-only and cannot run on native arm64 runners. The AppImage target does not
+# use fpm (it packages with appimagetool), so electron-builder builds it directly
+# for both architectures — its distributable pass also emits the linux-unpacked
+# directory that build-linux-deb.mjs consumes afterwards.
 MANUAL_DEB=false
 if [ "$TARGET" = "linux" ]; then
   MANUAL_DEB=true
 fi
 BUILDER_ARGS+=("$BUILDER_ARCH_FLAG")
-if [ "$DIR_BUILD" = true ] || [ "$MANUAL_DEB" = true ]; then
+# Only build an unpacked directory when explicitly requested (--dir). Linux
+# release builds run electron-builder's normal distributable pass so the AppImage
+# target is produced; the unpacked directory it also writes feeds the manual deb.
+if [ "$DIR_BUILD" = true ]; then
   BUILDER_ARGS+=(--dir)
 fi
 printf '▸ electron-builder args:'

--- a/apps/docs-site/docs/guide/installation-requirements.md
+++ b/apps/docs-site/docs/guide/installation-requirements.md
@@ -9,7 +9,7 @@ Most beta users should download the packaged desktop installer for their platfor
 Supported packaged beta artifacts are:
 
 - macOS Apple Silicon: DMG installer
-- Linux x64/arm64: Debian package (`.deb`)
+- Linux x64/arm64: Debian package (`.deb`) for Debian/Ubuntu, or AppImage (`.AppImage`) for any distribution
 - Windows x64: setup EXE installer
 
 Developers and contributors can still build from source on supported targets. Use the source path when you are modifying Sero, testing a branch, or contributing a fix.

--- a/apps/docs-site/docs/reference/support-scope.md
+++ b/apps/docs-site/docs/reference/support-scope.md
@@ -8,7 +8,7 @@ This page is the canonical public support matrix for the Sero public beta deskto
 | --- | --- | --- |
 | Release status | Public beta | Packaged desktop installers are available for supported beta targets. |
 | Packaged desktop targets | Supported | macOS Apple Silicon, Linux x64/arm64, and Windows x64 |
-| Installer artifacts | Supported where published | macOS DMG, Linux DEB, and Windows setup EXE; see [GitHub Releases](https://github.com/sero-labs/sero/releases) for exact current filenames. |
+| Installer artifacts | Supported where published | macOS DMG, Linux DEB and AppImage, and Windows setup EXE; see [GitHub Releases](https://github.com/sero-labs/sero/releases) for exact current filenames. |
 | Source builds | Supported for developers | Developers and contributors can still build from source on supported targets. |
 | Current maintainer-validated baseline | Validated | macOS `26.3`, `arm64`, Node `22.22.0`, pnpm `10.11.0` |
 | Default workspace runtime | Supported / recommended | Host is the default on supported Host platforms. |
@@ -36,7 +36,7 @@ If you are unsure which runtime to choose, use the default Host runtime. Select 
 Most beta users should download the packaged desktop artifact for their platform from [GitHub Releases](https://github.com/sero-labs/sero/releases):
 
 - macOS Apple Silicon: DMG installer
-- Linux x64/arm64: Debian package (`.deb`)
+- Linux x64/arm64: Debian package (`.deb`) for Debian/Ubuntu, or AppImage (`.AppImage`) for any distribution
 - Windows x64: setup EXE installer
 
 GitHub Releases is the source of truth for exact current artifact names. Public docs intentionally avoid hardcoding versioned filenames.


### PR DESCRIPTION
## Summary

- **what changed:** The Linux release now produces an **AppImage** for x64 and arm64, in addition to the existing `.deb`. AppImage runs on any distribution, so users who aren't on Debian/Ubuntu can run Sero.
- **why it changed:** Requested by users who can't install the `.deb` (see #228). The one-line target change in #228 could not work on its own — our Linux build forces electron-builder into `--dir` (unpacked-only) mode and hand-builds only the `.deb`, so any `target:` list in `electron-builder.yml` is ignored on Linux.

Why the build bypasses electron-builder for `.deb`: electron-builder builds `.deb`/`.rpm` via the bundled `fpm` helper, which is x64-only and cannot run on the native arm64 release runner. **AppImage does not use `fpm`** — it packages with `appimagetool`, which works on both architectures — so we can let electron-builder build it directly without hitting that constraint. Its distributable pass also emits the `linux-unpacked` directory that `build-linux-deb.mjs` already consumes, so the `.deb` flow is unchanged.

Changes:
- `electron-builder.yml` — replace the (ignored) `deb` target with `AppImage`
- `build-release.sh` — only pass `--dir` when explicitly requested, so Linux runs electron-builder's normal distributable pass; collect `*.AppImage` as a Linux artifact
- `release.yml` — upload and publish `*.AppImage`
- docs — list AppImage as a Linux install option in the install guide and support scope

`rpm` is intentionally left out: it goes through `fpm` and would fail on the arm64 runner exactly like `.deb` would. Supporting it properly is a larger change (build x64-only, or hand-build like the `.deb`) and can be tracked separately.

## Validation

- [ ] `pnpm typecheck` — not run; no TypeScript touched (YAML/shell/docs only)
- [ ] `pnpm build` (if relevant) — n/a
- [ ] `pnpm --filter @sero/desktop test -- --run` (if relevant) — n/a
- [ ] `pnpm --filter @sero/desktop test:e2e` (if relevant) — n/a
- [x] docs updated — install guide + support scope now list AppImage
- [x] **Desktop Release dry-run — both architectures green** ([linux-x64 run 53](https://github.com/sero-labs/sero/actions/runs/29076700906), [linux-arm64 run 54](https://github.com/sero-labs/sero/actions/runs/29076725797)); each produced its `desktop-release-linux-*` bundle (~265 MB, `.deb` + `.AppImage`), and the existing `.deb` smoke test still passes

## Safety checklist

- [x] no secrets, tokens, credentials, or machine-specific private paths committed
- [x] no unnecessary `any`, `@ts-ignore`, or `@ts-expect-error`
- [x] touched source files remain under 500 LOC

## Screenshots / recordings

n/a — build/packaging change, no UI surface.

## Risk / rollout notes

- **breaking changes:** none. The `.deb` artifact, its filename, and its auto-update feed are unchanged.
- **security or privacy impact:** none.
- **follow-up work:** AppImage auto-update is not wired up — the update feed stays `.deb`-based, so AppImage is a manual download for now. AppImage arm64 packaging is confirmed green (run 54). `rpm` support is a possible follow-up. Credit to @airtonix for raising #228, which prompted this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SBAAGKc6nrNaXABLdhQtf