### PR TITLE
docs(specs): add clean-room spec for built-in usage plugin

### DIFF
--- a/docs/specs/sero-usage-plugin-spec.md
+++ b/docs/specs/sero-usage-plugin-spec.md
@@ -1,0 +1,472 @@
+# Sero Usage Plugin — Specification
+
+**Built-in global plugin that aggregates AI usage across all sessions in the
+active profile and presents it in a Usage app plus a dashboard widget.**
+
+This is a **clean-room spec**: it describes the observable behaviour of an
+existing Pi `/usage` TUI extension (data model, aggregation rules, formatting)
+so the plugin can be implemented from scratch inside this repo. Do **not** copy
+source code from the original extension — reimplement from this document,
+following the `sero-plugin` and `sero-dashboard-ui` skills.
+
+---
+
+## 1. Overview
+
+- **Problem**: Sero records token/cost usage in every session `.jsonl` file,
+  but there is no way to see aggregate usage — per provider, per model, per
+  session, or over time — without leaving the app.
+- **Solution**: A built-in plugin (`plugins/sero-usage-plugin/`) that scans the
+  profile's session files, aggregates usage into a compact state file, and
+  renders it in a rich web UI (stat tiles, activity heatmap, provider/model
+  table, per-session breakdown) plus a compact dashboard widget. Data
+  refreshes on demand and on a user-selectable interval.
+- **Success criteria**:
+  - Usage app shows totals, provider/model breakdown, daily activity and top
+    sessions for Today / This Week / Last Week / All Time.
+  - Dashboard widget shows an at-a-glance summary that stays legible at 1×1.
+  - Refresh completes without blocking the agent or the UI, and repeated
+    refreshes are incremental (unchanged files are not re-parsed).
+  - Works per profile automatically — no configuration needed.
+
+### Naming
+
+| Item | Value |
+|---|---|
+| Directory | `plugins/sero-usage-plugin/` |
+| npm package | `@sero-ai/plugin-usage` |
+| App id | `usage` |
+| Display name | `Usage` |
+| Icon (Lucide) | `chart-column` |
+| Scope | `global` |
+| State file (Pi CLI fallback) | `.sero/apps/usage/state.json` |
+| Dev port | `5189` (unique; checked against existing plugins) |
+| Tool | `usage` (CLI-bridged → `sero usage …`) |
+
+---
+
+## 2. Source data
+
+### 2.1 Where sessions live
+
+Session transcripts are `.jsonl` files under the profile's agent directory:
+
+```
+${PI_CODING_AGENT_DIR}/sessions/**/*.jsonl
+```
+
+Resolution order (extension must be Pi-CLI safe):
+
+1. `process.env.PI_CODING_AGENT_DIR` — Sero always sets this to the active
+   profile's agent dir (`SERO_HOME/agent`), so aggregation is per profile with
+   zero extra work.
+2. Fallback `~/.pi/agent` when the env var is unset (plain Pi CLI).
+
+Scan is **recursive** (session files may be nested in subdirectories) and
+**read-only** — the plugin never writes into the sessions tree.
+
+### 2.2 Entries the scanner consumes
+
+Each line is one JSON object. Only three entry shapes matter; everything else
+(and any malformed line) is skipped silently:
+
+| Entry | Fields used |
+|---|---|
+| `type: "session"` (header) | `id`, `cwd`, `timestamp` |
+| `type: "session_info"` | `name` (session display name, may appear later in the file) |
+| `type: "message"` with `message.role === "assistant"` | `message.provider`, `message.model`, `message.usage.{input, output, cacheRead, cacheWrite, cost.total}`, `message.timestamp` (fallback: entry `timestamp`) |
+
+Assistant messages missing `usage`, `provider` or `model` are ignored. A file
+with no session header is ignored. For the per-session breakdown, the first
+`user` message's text is captured as a fallback label when no `session_info`
+name exists (same rule the desktop session browser uses —
+`apps/desktop/electron/ipc/agent/core/session-metadata.ts`).
+
+### 2.3 Deduplication (critical)
+
+Branched/forked session files duplicate copied history. To keep totals honest,
+messages are deduplicated **globally across all files** with the fingerprint:
+
+```
+`${timestamp}:${input + output + cacheRead + cacheWrite}`
+```
+
+A message whose fingerprint was already seen in this scan is skipped. Files
+must be processed in a stable order (sorted by path) so results are
+deterministic.
+
+### 2.4 Token accounting rules
+
+These formulas are product decisions inherited from the original extension —
+keep them, and state them in the UI footnote:
+
+| Displayed value | Formula | Rationale |
+|---|---|---|
+| **Tokens** (headline) | `input + output + cacheWrite` | Fresh tokens processed. `cacheRead` is excluded — repeated cache hits would dominate totals. `cacheWrite` is included — those prompt tokens were newly written and billed. |
+| **↑ In** | `input + cacheWrite` | Fresh input sent this turn, even for providers (Anthropic) that split cached-prompt creation out of the input count. |
+| **↓ Out** | `output` | |
+| **Cache** | `cacheRead + cacheWrite` | |
+| **Cost** | `usage.cost.total` summed | Zero/absent cost (subscription auth, local models) renders as `-`, never `$0.00`. |
+
+### 2.5 Time periods and buckets
+
+- Periods: **Today** (local midnight), **This Week** (Monday 00:00 local),
+  **Last Week** (previous Monday → Monday), **All Time**.
+- A message belongs to every period containing its timestamp; a session counts
+  toward a period's session count if it contributed ≥ 1 message to it.
+- **Daily buckets** (for the heatmap and trend chart): one bucket per local
+  calendar day for the last 365 days, each holding
+  `{ date, cost, tokens, input, output, messages }` using the formulas above.
+  Days with no activity may be omitted from state (the UI fills gaps).
+- Messages with missing/unparseable timestamps count toward All Time only and
+  are excluded from time-sensitive views.
+
+---
+
+## 3. Architecture
+
+```
+                 SERO_HOME/apps/usage/state.json   (aggregated, UI-facing)
+                        ▲ write            ▲ watch (useAppState)
+   sessions/**/*.jsonl ─┘                  │
+        ▲ read                             │
+        │                          ┌───────┴────────┐
+  extension/ `usage` tool          │ UsageApp (UI)  │   UsageWidget (dashboard)
+  (scan → aggregate → state)       └────────────────┘
+```
+
+Three parts, no background runtime:
+
+1. **Pi extension** (`extension/`) — owns all scanning/aggregation. Registers
+   the `usage` tool (CLI-bridged). Pi-CLI safe: no Sero imports.
+2. **Web UI** (`ui/`) — reads `state.json` via `useAppState`, triggers
+   refreshes via `useAppTools().run('usage', { action: 'refresh' })`.
+3. **Dashboard widget** (`ui/widgets/`) — compact summary from the same state.
+
+### 3.1 Why not the cron plugin (decision)
+
+The cron plugin schedules **agent prompts** — each job spawns an agent session,
+shows up in the user's job list, and burns tokens. A usage refresh is a pure
+local data pass; routing it through cron would create cross-plugin coupling and
+user-visible noise for no benefit. **Decision: the plugin owns its refresh
+schedule** (see 3.3). If a truly headless refresh is ever needed (Sero closed,
+gateway-only), revisit with a `runtime/` entry — out of scope for v1.
+
+### 3.2 The `usage` tool
+
+One tool, action-based (use `StringEnum` for the action field), bridged to the
+CLI (`bridgeTools: ["usage"]` → `sero usage …`):
+
+| Action | Params | Behaviour |
+|---|---|---|
+| `refresh` | `force?: boolean` | Run a scan and rewrite `state.json`. If a scan is already running, return its status instead of starting another (module-level singleton guard, same pattern as the cron scheduler singleton). Returns a one-line summary (files scanned, files reused from cache, duration, totals). |
+| `summary` | `period?` (`today` default) | Text summary of totals + top providers for the agent/CLI. |
+| `sessions` | `period?`, `limit?` (default 20) | Top sessions by cost for the period — for agent/CLI drill-down beyond the top-N stored in state. |
+| `config` | `refreshIntervalMinutes?` | Read/update settings stored in state (`0` = manual only). |
+
+Keep tool output concise (it lands in agent context). No `pi.registerCommand`
+named `usage` — that would shadow the bridged CLI entry; if a `/usage` slash
+shortcut is wanted, add a prompt template under `prompts/` declared in
+`pi.prompts`.
+
+### 3.3 Refresh scheduling
+
+- **Interval options**: Manual (off), 5 m, 30 m, 1 h, 6 h, 12 h, 24 h.
+  Default: **30 m**. Stored in state (`settings.refreshIntervalMinutes`).
+- **Trigger locations**: a small shared hook (`ui/lib/useAutoRefresh.ts`) used
+  by both the app and the widget:
+  - on mount: refresh if `now - lastRefreshedAt ≥ interval` (and always if
+    state is empty);
+  - `setInterval` at 60 s: re-check the same staleness condition.
+- **Concurrency**: staleness is re-checked against the latest state before
+  each call, and the extension-side singleton guard makes concurrent
+  `refresh` calls idempotent — so app + widget both mounting is safe.
+- **Manual refresh**: button in both surfaces; always calls
+  `refresh { force: true }`.
+
+Because widgets live on the dashboard, an open Sero window keeps the schedule
+alive; when Sero was closed, the on-mount staleness check catches up
+immediately. This needs `requiredHostCapabilities: ["appAgent.invokeTool", "tool.cli"]`.
+
+### 3.4 Incremental scan cache
+
+Parsing every `.jsonl` on every refresh does not scale (hundreds of files,
+some large). The scanner keeps a **per-file cache** keyed by absolute path
+with fingerprint `{ mtimeMs, size }`:
+
+- Fingerprint unchanged → reuse the cached compact per-message records
+  (needed because dedup is cross-file, so aggregation must re-run globally,
+  but parsing — the expensive part — is skipped).
+- Cached record shape (compact): `{ provider, model, cost, input, output,
+  cacheRead, cacheWrite, timestamp }` plus per-file `{ sessionId, name,
+  firstMessage, cwd }`.
+- Cache lives at `SERO_HOME/apps/usage/scan-cache.json` (data → profile dir is
+  correct; this is not a tool install). Versioned with `schemaVersion`;
+  mismatch → discard and rescan. Atomic writes (temp → rename).
+- Deleted files are dropped from the cache on each scan.
+
+Scan hygiene: stream files line-by-line (`readline` over `createReadStream`),
+yield to the event loop periodically, skip unreadable files/dirs silently,
+and cap malformed-line handling at "skip and continue".
+
+### 3.5 State shape (`shared/types.ts`)
+
+Single source of truth imported by extension, UI and widget. JSON-serialisable
+only; export `DEFAULT_STATE`. Keep it compact — this file is watched and
+shipped to the renderer on every change.
+
+```ts
+interface UsageState {
+  schemaVersion: 1;
+  settings: { refreshIntervalMinutes: number };          // 0 = manual
+  lastRefreshedAt: number | null;                        // epoch ms
+  lastScan: { files: number; reused: number; durationMs: number } | null;
+  periods: Record<'today' | 'thisWeek' | 'lastWeek' | 'allTime', PeriodStats>;
+  daily: DailyBucket[];                                  // ≤ 365 entries, ascending date
+}
+
+interface TokenBreakdown { total: number; input: number; output: number; cacheRead: number; cacheWrite: number }
+
+interface PeriodStats {
+  totals: { sessions: number; messages: number; cost: number; tokens: TokenBreakdown };
+  providers: ProviderStats[];                            // sorted by cost desc
+  topSessions: SessionStats[];                           // top 50 by cost
+}
+
+interface ProviderStats {
+  provider: string;
+  sessions: number; messages: number; cost: number; tokens: TokenBreakdown;
+  models: ModelStats[];                                  // sorted by cost desc
+}
+
+interface ModelStats {
+  model: string;
+  sessions: number; messages: number; cost: number; tokens: TokenBreakdown;
+}
+
+interface SessionStats {
+  id: string;
+  label: string;            // session_info name, else first user message (truncated ~80 chars), else id
+  cwd: string;              // workspace path, for display
+  messages: number; cost: number; tokens: TokenBreakdown;
+  firstActivity: number; lastActivity: number;           // epoch ms
+}
+
+interface DailyBucket { date: string /* YYYY-MM-DD local */; cost: number; tokens: number; input: number; output: number; messages: number }
+```
+
+State path: Sero resolves global app state to `SERO_HOME/apps/usage/state.json`;
+the extension resolves the same via `process.env.SERO_HOME`, falling back to
+`<cwd>/.sero/apps/usage/state.json` for Pi CLI. Atomic writes only.
+
+---
+
+## 4. UI specification
+
+All presentation composes `@sero-ai/ui` — shadcn primitives, the dashboard
+component set (`WidgetContent`, `Stack`, `Inline`, `Grid`, `Metric`, `Text`,
+`ItemList`, `DataBoundary`, `EmptyState`, …) and the recharts-based
+`ChartContainer`/`ChartTooltip` for charts. Semantic theme tokens only — no
+hard-coded colours. Read the `dataviz` guidance before building the charts.
+
+### 4.1 Usage app (`ui/UsageApp.tsx`)
+
+Layout, top to bottom (reference: the two design screenshots — TUI table and
+"pi-tokamak" heatmap page):
+
+1. **Header row** — period tabs `Today · This Week · Last Week · All Time`
+   (shadcn `Tabs`); right-aligned: refresh-interval `Select` (Manual/5m/30m/
+   1h/6h/12h/24h), manual refresh `IconButton` (spinning while a refresh is in
+   flight), and muted "updated 5 min ago" text derived from `lastRefreshedAt`.
+2. **Stat tile row** — six `Metric` tiles for the active period: Total cost,
+   Total tokens, Input (↑In formula), Output, Sessions, Messages. Responsive
+   `Grid` (wraps on narrow widths).
+3. **Daily Activity heatmap** — GitHub-style calendar (53×7 CSS grid),
+   plugin-local component. Metric selector: `tokens | cost | messages`.
+   5-step colour scale from theme chart/success tokens; empty cells use a
+   muted surface token. Cell tooltip: date + formatted value. Legend
+   `less → more` + "max N/day". Today is the rightmost column. Always renders
+   the full trailing year regardless of period tab (it is a global view).
+4. **Cost/usage trend chart** — stacked bar chart of the selected metric per
+   day, split by provider (top 5 providers + "other"), via `ChartContainer`.
+   X-range follows the active period (Today → hourly buckets are **not**
+   required; hide the chart for Today, show it for week/all-time views).
+5. **By Provider · Model table** — the core table. One row group per provider
+   (sorted by cost desc): provider header row with aggregate values, model
+   rows beneath, subtotal row when a provider has > 1 model (matches
+   screenshot 2). Columns: `Provider/Model · Sessions · Msgs · Cost · Tokens ·
+   ↑In · ↓Out · Cache`. Providers collapsible (default expanded); dim the
+   ↑In/↓Out/Cache columns (`text-muted-foreground`).
+6. **Sessions section** (the optional per-session breakdown) — table of
+   `topSessions` for the active period: Label, Workspace (basename of `cwd`),
+   Msgs, Tokens, Cost, Last active (relative). Sortable by cost (default),
+   tokens, last active. Capped at the stored top 50 with a muted footer note
+   when more sessions exist.
+7. **Footnote** — muted, single line:
+   `Tokens = Input + Output + CacheWrite · ↑In = Input + CacheWrite · costs are approximate, based on local session data.`
+
+States: `DataBoundary` everywhere — skeleton tiles/table while first scan
+runs, `EmptyState` ("No usage recorded yet" / "No usage for this period"),
+`Alert` on scan failure (surface the tool error text).
+
+### 4.2 Dashboard widget (`ui/widgets/UsageWidget.tsx`)
+
+Static manifest widget, id `usage-summary`, name `Usage`, default 2×2,
+min 1×1, max 4×3. Content per size (container queries via `WidgetContent`):
+
+- **1×1** — today's cost as a big `Metric` + tokens beneath (`Text variant="muted"`).
+- **2×2 (default)** — `Metric` pair: cost Today and This Week; a 14-day
+  mini bar sparkline (tokens/day) built from `daily`; muted "top: anthropic
+  $257" line for the week's top provider.
+- **3×2+** — adds a compact 3-row provider `ItemList` (name → cost) for This
+  Week.
+
+Clicking through to the app is host-owned chrome — do not add custom open
+buttons. Widget participates in auto-refresh via the shared hook (3.3).
+
+### 4.3 Formatting rules (shared `ui/lib/format.ts` + extension summaries)
+
+| Value | Rule |
+|---|---|
+| Cost | `-` when 0; 4 dp under $0.01; 2 dp under $10; 1 dp under $100; whole dollars above |
+| Tokens | `-` when 0; raw under 1 000; `1.2k` under 10 000; `123k` under 1 M; `1.4M` under 10 M; `284M` above |
+| Counts | `-` when 0; else locale-formatted (`4,148`) |
+| Relative time | `just now / N min ago / N h ago / date` |
+
+### 4.4 Insights view (phase 2, optional)
+
+The original extension ships cost-attribution heuristics worth porting later
+as an "Insights" tab: share of cost while ≥ 4 sessions ran in parallel
+(±2 min window), at > 150k context, from > 100k-token uncached prompts, from
+sessions active ≥ 8 h, and from the top-5 sessions. Each is a card:
+`%` + headline + one-line advice, weighted by cost, hidden under 1 %.
+Not required for v1 — the state already carries enough raw material except
+per-message windows, so phase 2 would extend the scanner. Keep out of scope
+until the core ships.
+
+---
+
+## 5. Package layout & manifest
+
+```
+plugins/sero-usage-plugin/
+├── package.json
+├── vite.config.ts
+├── shared/
+│   └── types.ts              # UsageState + DEFAULT_STATE (§3.5)
+├── extension/
+│   ├── index.ts              # entry: registers tool, wires singleton
+│   ├── tools.ts              # `usage` tool actions (§3.2)
+│   ├── scan.ts               # file discovery, streaming parse, dedup (§2)
+│   ├── aggregate.ts          # periods, daily buckets, provider/model/session rollups
+│   ├── scan-cache.ts         # per-file fingerprint cache (§3.4)
+│   ├── state-io.ts           # resolve state path, atomic read/write
+│   └── tsconfig.json
+└── ui/
+    ├── UsageApp.tsx
+    ├── components/           # StatTiles, ActivityHeatmap, TrendChart,
+    │                         # ProviderTable, SessionsTable
+    ├── widgets/UsageWidget.tsx
+    ├── lib/format.ts
+    ├── lib/useAutoRefresh.ts
+    ├── styles.css            # imports @sero-ai/ui/styles/plugin.css + @source
+    ├── index.html
+    ├── vite-env.d.ts
+    └── tsconfig.json
+```
+
+Every source file stays under 500 LOC — the component split above exists for
+that reason.
+
+`package.json` essentials (full template in the `sero-plugin` skill):
+
+```jsonc
+{
+  "name": "@sero-ai/plugin-usage",
+  "keywords": ["pi-package"],
+  "pi": { "extensions": ["./extension/index.ts"] },
+  "sero": {
+    "app": {
+      "id": "usage",
+      "name": "Usage",
+      "icon": "chart-column",
+      "scope": "global",
+      "stateFile": ".sero/apps/usage/state.json",   // Pi CLI fallback
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "UsageApp",
+      "devPort": 5189,
+      "widgets": [{
+        "id": "usage-summary",
+        "name": "Usage",
+        "component": "UsageWidget",
+        "description": "AI usage and cost summary",
+        "defaultSize": { "w": 2, "h": 2 },
+        "minSize": { "w": 1, "h": 1 },
+        "maxSize": { "w": 4, "h": 3 }
+      }]
+    },
+    "plugin": {
+      "category": "productivity",
+      "tags": ["usage", "cost", "tokens", "analytics"],
+      "requiredHostCapabilities": ["appAgent.invokeTool", "tool.cli"],
+      "bridgeTools": ["usage"]
+    }
+  }
+}
+```
+
+Pi SDK packages go in `peerDependencies` (`catalog:peer`); `@sero-ai/ui`,
+`@sero-ai/app-runtime`, react, vite tooling in `devDependencies` (`catalog:`);
+`typebox` in `dependencies`. MF remote name `sero_usage`; exposes
+`./UsageApp` and `./UsageWidget`, both importing `./styles.css`.
+
+Being a built-in plugin, it is auto-discovered from `plugins/` and does not
+appear in the Plugin Manager.
+
+---
+
+## 6. Performance & robustness requirements
+
+- First full scan of ~500 files / ~200 MB of jsonl must not freeze the app:
+  streaming parse, periodic event-loop yields, and the UI stays interactive
+  (refresh runs through the app-agent tool invocation, off the renderer).
+- Warm refresh (no file changes) should be near-instant: all files reused
+  from the fingerprint cache, aggregation only.
+- A corrupt `state.json` or `scan-cache.json` must never crash anything:
+  invalid JSON → treat as absent, rescan, rewrite.
+- All writes atomic (temp file → rename). Never use `localStorage`.
+- No network access; read-only against session files.
+
+## 7. Non-goals (v1)
+
+- No provider billing-API integration — local session data only.
+- No per-workspace scope, no cross-profile aggregation.
+- No background runtime / headless refresh while Sero is closed.
+- No insights tab (phase 2, §4.4), no CSV export.
+
+## 8. Verification checklist
+
+1. `pnpm install && pnpm --filter @sero-ai/plugin-usage build && pnpm typecheck` pass.
+2. `SERO_DEV_PLUGINS=usage bash scripts/dev.sh` → Usage app appears in the
+   sidebar; dashboard widget available in the Add Widget picker.
+3. First open triggers a scan; tiles/heatmap/table populate; numbers match a
+   hand-checked sample session file (dedup rule verified against a branched
+   session pair).
+4. `sero usage summary` and `sero usage sessions` return concise text in a
+   chat session; `/reload` shows no command/tool name shadowing.
+5. Interval select persists across restarts (state, not localStorage);
+   staleness refresh fires after the interval elapses; two surfaces mounted
+   do not double-scan.
+6. Widget legible at 1×1, 2×2 and 3×2; light and dark themes; empty-profile
+   case shows `EmptyState`, not zeros.
+7. Unit tests (vitest, colocated `__tests__/` like the cron plugin) for:
+   period bucketing, dedup fingerprinting, token formulas, formatting rules,
+   cache reuse/invalidation, top-session ranking.
+
+## 9. Open questions
+
+- Should the Today tab get an hourly trend chart instead of hiding the trend?
+  (v1 hides it; cheap to add later from message timestamps if wanted.)
+- Insights tab (§4.4): port in phase 2, or drop?
+- Should `topSessions` deep-link to the session browser (Admin app) when a
+  session still exists? Needs a host seam check — not assumed in v1.

--- a/docs/specs/sero-usage-plugin-spec.md
+++ b/docs/specs/sero-usage-plugin-spec.md
@@ -165,7 +165,7 @@ CLI (`bridgeTools: ["usage"]` → `sero usage …`):
 |---|---|---|
 | `refresh` | `force?: boolean` | Run a scan and rewrite `state.json`. If a scan is already running, return its status instead of starting another (module-level singleton guard, same pattern as the cron scheduler singleton). Returns a one-line summary (files scanned, files reused from cache, duration, totals). |
 | `summary` | `period?` (`today` default) | Text summary of totals + top providers for the agent/CLI. |
-| `sessions` | `period?`, `limit?` (default 20) | Top sessions by cost for the period — for agent/CLI drill-down beyond the top-N stored in state. |
+| `sessions` | `period?`, `limit?` (default 20, max 50) | Top sessions by cost for the period, served from the top-50 stored in state. |
 | `config` | `refreshIntervalMinutes?` | Read/update settings stored in state (`0` = manual only). |
 
 Keep tool output concise (it lands in agent context). No `pi.registerCommand`
@@ -313,11 +313,11 @@ Layout, top to bottom (reference: the two design screenshots — TUI table and
    `hourly`, 00–23 with empty hours rendered as gaps), week/all-time views
    show per-day bars (from `daily`).
 5. **By Provider · Model table** — the core table. One row group per provider
-   (sorted by cost desc): provider header row with aggregate values, model
-   rows beneath, subtotal row when a provider has > 1 model (matches
-   screenshot 2). Columns: `Provider/Model · Sessions · Msgs · Cost · Tokens ·
-   ↑In · ↓Out · Cache`. Providers collapsible (default expanded); dim the
-   ↑In/↓Out/Cache columns (`text-muted-foreground`).
+   (sorted by cost desc): provider header row carrying the aggregate values,
+   model rows beneath (no separate subtotal row — the header row already
+   shows the aggregates). Columns: `Provider/Model · Sessions · Msgs · Cost ·
+   Tokens · ↑In · ↓Out · Cache`. Providers collapsible (default expanded);
+   dim the ↑In/↓Out/Cache columns (`text-muted-foreground`).
 6. **Sessions section** (the optional per-session breakdown) — table of
    `topSessions` for the active period: Label, Workspace (basename of `cwd`),
    Msgs, Tokens, Cost, Last active (relative). Sortable by cost (default),
@@ -365,23 +365,30 @@ buttons. Widget participates in auto-refresh via the shared hook (3.3).
 plugins/sero-usage-plugin/
 ├── package.json
 ├── vite.config.ts
-├── shared/
-│   └── types.ts              # UsageState + DEFAULT_STATE (§3.5)
+├── vitest.config.ts
+├── shared/                   # imported by extension AND UI
+│   ├── types.ts              # UsageState + DEFAULT_STATE + normalize (§3.5)
+│   ├── period.ts             # period boundaries, dateKey (§2.5)
+│   ├── format.ts             # display formatting rules (§4.3)
+│   └── __tests__/
 ├── extension/
-│   ├── index.ts              # entry: registers tool, wires singleton
-│   ├── tools.ts              # `usage` tool actions (§3.2)
-│   ├── scan.ts               # file discovery, streaming parse, dedup (§2)
-│   ├── aggregate.ts          # periods, daily buckets, provider/model/session rollups
+│   ├── index.ts              # entry: registers the tool
+│   ├── tools.ts              # `usage` tool actions + CLI surface (§3.2)
+│   ├── refresh.ts            # scan → aggregate → state, in-flight singleton
+│   ├── scan.ts               # file discovery, streaming parse (§2)
+│   ├── aggregate.ts          # dedup, periods, daily/hourly buckets, rollups
 │   ├── scan-cache.ts         # per-file fingerprint cache (§3.4)
-│   ├── state-io.ts           # resolve state path, atomic read/write
+│   ├── state-io.ts           # Sero-only path resolution, atomic writes
+│   ├── __tests__/
 │   └── tsconfig.json
 └── ui/
     ├── UsageApp.tsx
     ├── components/           # StatTiles, ActivityHeatmap, TrendChart,
     │                         # ProviderTable, SessionsTable
     ├── widgets/UsageWidget.tsx
-    ├── lib/format.ts
-    ├── lib/useAutoRefresh.ts
+    ├── lib/useAutoRefresh.ts # staleness-driven refresh (§3.3)
+    ├── lib/trend.ts          # metric selection + provider ranking
+    ├── lib/host.ts           # reveal-in-folder shell bridge
     ├── styles.css            # imports @sero-ai/ui/styles/plugin.css + @source
     ├── index.html
     ├── vite-env.d.ts

--- a/docs/specs/sero-usage-plugin-spec.md
+++ b/docs/specs/sero-usage-plugin-spec.md
@@ -115,8 +115,11 @@ keep them, and state them in the UI footnote:
   toward a period's session count if it contributed ≥ 1 message to it.
 - **Daily buckets** (for the heatmap and trend chart): one bucket per local
   calendar day for the last 365 days, each holding
-  `{ date, cost, tokens, input, output, messages }` using the formulas above.
-  Days with no activity may be omitted from state (the UI fills gaps).
+  `{ date, cost, tokens, input, output, messages }` using the formulas above,
+  plus a per-provider split (`byProvider`) so the trend chart can stack by
+  provider. Days with no activity may be omitted from state (the UI fills gaps).
+- **Hourly buckets**: the same shape per local hour (0–23) of the current day,
+  recomputed on every refresh — backing the Today tab's trend chart.
 - Messages with missing/unparseable timestamps count toward All Time only and
   are excluded from time-sensitive views.
 
@@ -224,6 +227,7 @@ interface UsageState {
   lastScan: { files: number; reused: number; durationMs: number } | null;
   periods: Record<'today' | 'thisWeek' | 'lastWeek' | 'allTime', PeriodStats>;
   daily: DailyBucket[];                                  // ≤ 365 entries, ascending date
+  hourly: HourlyBucket[];                                // current day only, ≤ 24 entries
 }
 
 interface TokenBreakdown { total: number; input: number; output: number; cacheRead: number; cacheWrite: number }
@@ -249,11 +253,24 @@ interface SessionStats {
   id: string;
   label: string;            // session_info name, else first user message (truncated ~80 chars), else id
   cwd: string;              // workspace path, for display
+  path: string;             // absolute session .jsonl path — for reveal-in-folder
   messages: number; cost: number; tokens: TokenBreakdown;
   firstActivity: number; lastActivity: number;           // epoch ms
 }
 
-interface DailyBucket { date: string /* YYYY-MM-DD local */; cost: number; tokens: number; input: number; output: number; messages: number }
+interface ProviderSlice { cost: number; tokens: number; messages: number }
+
+interface DailyBucket {
+  date: string;             // YYYY-MM-DD local
+  cost: number; tokens: number; input: number; output: number; messages: number;
+  byProvider: Record<string, ProviderSlice>;             // for the stacked trend chart
+}
+
+interface HourlyBucket {
+  hour: number;             // 0–23, local, current day
+  cost: number; tokens: number; messages: number;
+  byProvider: Record<string, ProviderSlice>;
+}
 ```
 
 State path: Sero resolves global app state to `SERO_HOME/apps/usage/state.json`;
@@ -290,10 +307,11 @@ Layout, top to bottom (reference: the two design screenshots — TUI table and
    muted surface token. Cell tooltip: date + formatted value. Legend
    `less → more` + "max N/day". Today is the rightmost column. Always renders
    the full trailing year regardless of period tab (it is a global view).
-4. **Cost/usage trend chart** — stacked bar chart of the selected metric per
-   day, split by provider (top 5 providers + "other"), via `ChartContainer`.
-   X-range follows the active period (Today → hourly buckets are **not**
-   required; hide the chart for Today, show it for week/all-time views).
+4. **Cost/usage trend chart** — stacked bar chart of the selected metric,
+   split by provider (top 5 providers + "other"), via `ChartContainer`.
+   X-range follows the active period: **Today shows per-hour bars** (from
+   `hourly`, 00–23 with empty hours rendered as gaps), week/all-time views
+   show per-day bars (from `daily`).
 5. **By Provider · Model table** — the core table. One row group per provider
    (sorted by cost desc): provider header row with aggregate values, model
    rows beneath, subtotal row when a provider has > 1 model (matches
@@ -304,7 +322,10 @@ Layout, top to bottom (reference: the two design screenshots — TUI table and
    `topSessions` for the active period: Label, Workspace (basename of `cwd`),
    Msgs, Tokens, Cost, Last active (relative). Sortable by cost (default),
    tokens, last active. Capped at the stored top 50 with a muted footer note
-   when more sessions exist.
+   when more sessions exist. Each row has a reveal-in-folder action
+   (`IconButton`, `folder-open`) calling
+   `window.sero.shell.showItemInFolder(session.path)` — the same generic host
+   bridge the status bar uses for the workspace/profile folder.
 7. **Footnote** — muted, single line:
    `Tokens = Input + Output + CacheWrite · ↑In = Input + CacheWrite · costs are approximate, based on local session data.`
 
@@ -335,17 +356,6 @@ buttons. Widget participates in auto-refresh via the shared hook (3.3).
 | Tokens | `-` when 0; raw under 1 000; `1.2k` under 10 000; `123k` under 1 M; `1.4M` under 10 M; `284M` above |
 | Counts | `-` when 0; else locale-formatted (`4,148`) |
 | Relative time | `just now / N min ago / N h ago / date` |
-
-### 4.4 Insights view (phase 2, optional)
-
-The original extension ships cost-attribution heuristics worth porting later
-as an "Insights" tab: share of cost while ≥ 4 sessions ran in parallel
-(±2 min window), at > 150k context, from > 100k-token uncached prompts, from
-sessions active ≥ 8 h, and from the top-5 sessions. Each is a card:
-`%` + headline + one-line advice, weighted by cost, hidden under 1 %.
-Not required for v1 — the state already carries enough raw material except
-per-message windows, so phase 2 would extend the scanner. Keep out of scope
-until the core ships.
 
 ---
 
@@ -445,7 +455,9 @@ appear in the Plugin Manager.
 - No provider billing-API integration — local session data only.
 - No per-workspace scope, no cross-profile aggregation.
 - No background runtime / headless refresh while Sero is closed.
-- No insights tab (phase 2, §4.4), no CSV export.
+- No insights/cost-attribution heuristics (the original extension's Insights
+  view is intentionally dropped, not deferred).
+- No CSV export.
 
 ## 8. Verification checklist
 
@@ -466,10 +478,12 @@ appear in the Plugin Manager.
    period bucketing, dedup fingerprinting, token formulas, formatting rules,
    cache reuse/invalidation, top-session ranking.
 
-## 9. Open questions
+## 9. Resolved decisions
 
-- Should the Today tab get an hourly trend chart instead of hiding the trend?
-  (v1 hides it; cheap to add later from message timestamps if wanted.)
-- Insights tab (§4.4): port in phase 2, or drop?
-- Should `topSessions` deep-link to the session browser (Admin app) when a
-  session still exists? Needs a host seam check — not assumed in v1.
+- **Today tab trend chart**: shows per-hour stacked bars (not hidden) — see
+  §2.5 hourly buckets and §4.1 item 4.
+- **Insights view**: dropped entirely, not deferred — see non-goals.
+- **Session drill-down**: each sessions-table row reveals the session's
+  `.jsonl` in the file manager via `window.sero.shell.showItemInFolder`
+  (existing generic host bridge; no new seam needed). Opening the session in
+  the Admin session browser remains out of scope.

--- a/docs/specs/sero-usage-plugin-spec.md
+++ b/docs/specs/sero-usage-plugin-spec.md
@@ -39,7 +39,7 @@ following the `sero-plugin` and `sero-dashboard-ui` skills.
 | Display name | `Usage` |
 | Icon (Lucide) | `chart-column` |
 | Scope | `global` |
-| State file (Pi CLI fallback) | `.sero/apps/usage/state.json` |
+| State file (manifest field) | `.sero/apps/usage/state.json` |
 | Dev port | `5189` (unique; checked against existing plugins) |
 | Tool | `usage` (CLI-bridged → `sero usage …`) |
 
@@ -55,12 +55,11 @@ Session transcripts are `.jsonl` files under the profile's agent directory:
 ${PI_CODING_AGENT_DIR}/sessions/**/*.jsonl
 ```
 
-Resolution order (extension must be Pi-CLI safe):
-
-1. `process.env.PI_CODING_AGENT_DIR` — Sero always sets this to the active
-   profile's agent dir (`SERO_HOME/agent`), so aggregation is per profile with
-   zero extra work.
-2. Fallback `~/.pi/agent` when the env var is unset (plain Pi CLI).
+Resolution: `process.env.PI_CODING_AGENT_DIR` only. Sero always sets it to the
+active profile's agent dir (`SERO_HOME/agent`), so aggregation is per profile
+with zero extra work. This is a Sero-only built-in plugin — there is **no
+`~/.pi/agent` fallback**; if the env var is somehow unset, the `refresh` action
+returns an explicit error instead of scanning standalone Pi CLI sessions.
 
 Scan is **recursive** (session files may be nested in subdirectories) and
 **read-only** — the plugin never writes into the sessions tree.
@@ -138,7 +137,9 @@ keep them, and state them in the UI footnote:
 Three parts, no background runtime:
 
 1. **Pi extension** (`extension/`) — owns all scanning/aggregation. Registers
-   the `usage` tool (CLI-bridged). Pi-CLI safe: no Sero imports.
+   the `usage` tool (CLI-bridged). Follows standard extension boundaries (no
+   Sero/desktop imports), but is Sero-only in practice — it resolves
+   everything from Sero-provided env vars and is never run in the plain Pi CLI.
 2. **Web UI** (`ui/`) — reads `state.json` via `useAppState`, triggers
    refreshes via `useAppTools().run('usage', { action: 'refresh' })`.
 3. **Dashboard widget** (`ui/widgets/`) — compact summary from the same state.
@@ -256,8 +257,10 @@ interface DailyBucket { date: string /* YYYY-MM-DD local */; cost: number; token
 ```
 
 State path: Sero resolves global app state to `SERO_HOME/apps/usage/state.json`;
-the extension resolves the same via `process.env.SERO_HOME`, falling back to
-`<cwd>/.sero/apps/usage/state.json` for Pi CLI. Atomic writes only.
+the extension resolves the same via `process.env.SERO_HOME` (always set by
+Sero — error if absent, no cwd fallback). Atomic writes only. The manifest
+`stateFile` field is still declared because the app-manifest schema requires
+it, but it is never used as a runtime fallback.
 
 ---
 
@@ -391,7 +394,7 @@ that reason.
       "name": "Usage",
       "icon": "chart-column",
       "scope": "global",
-      "stateFile": ".sero/apps/usage/state.json",   // Pi CLI fallback
+      "stateFile": ".sero/apps/usage/state.json",   // required by manifest schema; unused at runtime
       "ui": "./dist/ui/remoteEntry.js",
       "component": "UsageApp",
       "devPort": 5189,

--- a/plugins/sero-usage-plugin/extension/__tests__/aggregate.test.ts
+++ b/plugins/sero-usage-plugin/extension/__tests__/aggregate.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+
+import { aggregate, messageFingerprint } from '../aggregate';
+import type { ParsedSession, UsageMessage } from '../scan';
+
+// Fixed reference: Wednesday 2026-07-08, 15:30 local time.
+const NOW = new Date(2026, 6, 8, 15, 30);
+
+function msg(overrides: Partial<UsageMessage>): UsageMessage {
+  return {
+    provider: 'anthropic',
+    model: 'claude-opus-4-5',
+    cost: 1,
+    input: 100,
+    output: 50,
+    cacheRead: 1000,
+    cacheWrite: 200,
+    timestamp: new Date(2026, 6, 8, 9, 0).getTime(),
+    ...overrides,
+  };
+}
+
+function session(id: string, messages: UsageMessage[], overrides: Partial<ParsedSession> = {}): ParsedSession {
+  return {
+    sessionId: id,
+    path: `/sessions/${id}.jsonl`,
+    cwd: `/workspaces/${id}`,
+    messages,
+    ...overrides,
+  };
+}
+
+describe('token accounting formulas', () => {
+  it('counts total as input + output + cacheWrite, excluding cacheRead', () => {
+    const result = aggregate([session('s1', [msg({})])], NOW);
+    const tokens = result.periods.allTime.totals.tokens;
+    expect(tokens.total).toBe(100 + 50 + 200);
+    expect(tokens.input).toBe(100);
+    expect(tokens.output).toBe(50);
+    expect(tokens.cacheRead).toBe(1000);
+    expect(tokens.cacheWrite).toBe(200);
+  });
+});
+
+describe('deduplication', () => {
+  it('fingerprints by timestamp + total raw tokens', () => {
+    const a = msg({});
+    expect(messageFingerprint(a)).toBe(`${a.timestamp}:${100 + 50 + 1000 + 200}`);
+  });
+
+  it('drops copied history across branched session files', () => {
+    const shared = msg({});
+    const branchOnly = msg({ timestamp: shared.timestamp + 60_000, input: 111 });
+    const result = aggregate(
+      [session('original', [shared]), session('branch', [shared, branchOnly])],
+      NOW,
+    );
+    expect(result.periods.allTime.totals.messages).toBe(2);
+    expect(result.periods.allTime.totals.cost).toBe(2);
+  });
+});
+
+describe('period bucketing', () => {
+  it('splits messages across today / thisWeek / lastWeek / allTime', () => {
+    const todayMsg = msg({});
+    const mondayMsg = msg({ timestamp: new Date(2026, 6, 6, 9, 0).getTime(), input: 101 });
+    const lastWeekMsg = msg({ timestamp: new Date(2026, 6, 1, 9, 0).getTime(), input: 102 });
+    const oldMsg = msg({ timestamp: new Date(2026, 3, 1, 9, 0).getTime(), input: 103 });
+    const result = aggregate([session('s1', [todayMsg, mondayMsg, lastWeekMsg, oldMsg])], NOW);
+
+    expect(result.periods.today.totals.messages).toBe(1);
+    expect(result.periods.thisWeek.totals.messages).toBe(2);
+    expect(result.periods.lastWeek.totals.messages).toBe(1);
+    expect(result.periods.allTime.totals.messages).toBe(4);
+  });
+
+  it('counts messages without timestamps toward allTime only', () => {
+    const result = aggregate([session('s1', [msg({ timestamp: 0 })])], NOW);
+    expect(result.periods.allTime.totals.messages).toBe(1);
+    expect(result.periods.today.totals.messages).toBe(0);
+    expect(result.daily).toHaveLength(0);
+    expect(result.hourly).toHaveLength(0);
+  });
+});
+
+describe('provider and model rollups', () => {
+  it('sorts providers and models by cost descending with session counts', () => {
+    const result = aggregate(
+      [
+        session('s1', [
+          msg({ provider: 'openai', model: 'gpt-6', cost: 10 }),
+          msg({ provider: 'anthropic', model: 'claude-opus-4-5', cost: 3, timestamp: msg({}).timestamp + 1 }),
+          msg({ provider: 'anthropic', model: 'claude-haiku-4-5', cost: 1, timestamp: msg({}).timestamp + 2 }),
+        ]),
+        session('s2', [msg({ provider: 'anthropic', model: 'claude-opus-4-5', cost: 4, timestamp: msg({}).timestamp + 3 })]),
+      ],
+      NOW,
+    );
+
+    const providers = result.periods.allTime.providers;
+    expect(providers.map((p) => p.provider)).toEqual(['openai', 'anthropic']);
+    expect(providers[1]!.sessions).toBe(2);
+    expect(providers[1]!.models.map((m) => m.model)).toEqual(['claude-opus-4-5', 'claude-haiku-4-5']);
+    expect(providers[1]!.models[0]!.cost).toBe(7);
+  });
+});
+
+describe('top sessions', () => {
+  it('ranks sessions by cost and labels from name, first message, then id', () => {
+    const base = msg({}).timestamp;
+    const result = aggregate(
+      [
+        session('cheap', [msg({ cost: 1, timestamp: base + 1 })], { firstMessage: 'fix the bug' }),
+        session('pricey', [msg({ cost: 9, timestamp: base + 2 })], { name: 'Named session' }),
+        session('anonymous', [msg({ cost: 5, timestamp: base + 3 })]),
+      ],
+      NOW,
+    );
+
+    const sessions = result.periods.allTime.topSessions;
+    expect(sessions.map((s) => s.id)).toEqual(['pricey', 'anonymous', 'cheap']);
+    expect(sessions[0]!.label).toBe('Named session');
+    expect(sessions[1]!.label).toBe('anonymous');
+    expect(sessions[2]!.label).toBe('fix the bug');
+    expect(sessions[2]!.path).toBe('/sessions/cheap.jsonl');
+  });
+
+  it('tracks first/last activity per period', () => {
+    const first = new Date(2026, 6, 8, 8, 0).getTime();
+    const last = new Date(2026, 6, 8, 14, 0).getTime();
+    const result = aggregate([session('s1', [msg({ timestamp: last }), msg({ timestamp: first, input: 7 })])], NOW);
+    const stats = result.periods.today.topSessions[0]!;
+    expect(stats.firstActivity).toBe(first);
+    expect(stats.lastActivity).toBe(last);
+  });
+});
+
+describe('daily and hourly buckets', () => {
+  it('builds ascending daily buckets with per-provider slices', () => {
+    const result = aggregate(
+      [
+        session('s1', [
+          msg({ timestamp: new Date(2026, 6, 7, 10, 0).getTime(), provider: 'openai', cost: 2 }),
+          msg({ timestamp: new Date(2026, 6, 8, 9, 0).getTime(), cost: 3 }),
+        ]),
+      ],
+      NOW,
+    );
+
+    expect(result.daily.map((d) => d.date)).toEqual(['2026-07-07', '2026-07-08']);
+    expect(result.daily[0]!.byProvider.openai!.cost).toBe(2);
+    expect(result.daily[1]!.byProvider.anthropic!.tokens).toBe(100 + 50 + 200);
+    // Daily input column shows fresh input incl. cacheWrite.
+    expect(result.daily[1]!.input).toBe(100 + 200);
+  });
+
+  it('builds hourly buckets for the current day only', () => {
+    const result = aggregate(
+      [
+        session('s1', [
+          msg({ timestamp: new Date(2026, 6, 8, 9, 15).getTime() }),
+          msg({ timestamp: new Date(2026, 6, 8, 9, 45).getTime(), input: 7 }),
+          msg({ timestamp: new Date(2026, 6, 7, 9, 0).getTime(), input: 8 }),
+        ]),
+      ],
+      NOW,
+    );
+
+    expect(result.hourly).toHaveLength(1);
+    expect(result.hourly[0]!.hour).toBe(9);
+    expect(result.hourly[0]!.messages).toBe(2);
+    expect(result.hourly[0]!.byProvider.anthropic!.messages).toBe(2);
+  });
+});

--- a/plugins/sero-usage-plugin/extension/__tests__/refresh.test.ts
+++ b/plugins/sero-usage-plugin/extension/__tests__/refresh.test.ts
@@ -1,0 +1,77 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runRefresh } from '../refresh';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'usage-refresh-'));
+  process.env.SERO_HOME = path.join(dir, 'sero-home');
+  process.env.PI_CODING_AGENT_DIR = path.join(dir, 'agent');
+  await mkdir(path.join(dir, 'agent', 'sessions'), { recursive: true });
+});
+
+afterEach(async () => {
+  delete process.env.SERO_HOME;
+  delete process.env.PI_CODING_AGENT_DIR;
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function writeSession(name: string, sessionId: string, cost: number): Promise<void> {
+  const now = Date.now();
+  await writeFile(
+    path.join(dir, 'agent', 'sessions', name),
+    [
+      JSON.stringify({ type: 'session', id: sessionId, cwd: '/w', timestamp: new Date(now).toISOString() }),
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          provider: 'anthropic',
+          model: 'claude-opus-4-5',
+          timestamp: now,
+          usage: { input: 100, output: 50, cacheRead: 0, cacheWrite: 20, cost: { total: cost } },
+        },
+      }),
+    ].join('\n'),
+  );
+}
+
+describe('runRefresh end-to-end', () => {
+  it('scans sessions, writes state.json, and reuses the cache on the next run', async () => {
+    await writeSession('a.jsonl', 'sess-a', 1.5);
+    await writeSession('b.jsonl', 'sess-b', 0.5);
+
+    const first = await runRefresh(true);
+    expect(first.skipped).toBe(false);
+    expect(first.files).toBe(2);
+    expect(first.reused).toBe(0);
+    expect(first.state.periods.allTime.totals.cost).toBe(2);
+    expect(first.state.periods.today.totals.sessions).toBe(2);
+    expect(first.state.hourly.length).toBeGreaterThan(0);
+
+    const written = JSON.parse(
+      await readFile(path.join(dir, 'sero-home', 'apps', 'usage', 'state.json'), 'utf8'),
+    );
+    expect(written.periods.allTime.totals.messages).toBe(2);
+    expect(written.lastScan.files).toBe(2);
+
+    const second = await runRefresh(true);
+    expect(second.reused).toBe(2);
+  });
+
+  it('treats a non-forced refresh within the fresh window as already fresh', async () => {
+    await writeSession('a.jsonl', 'sess-a', 1);
+    await runRefresh(true);
+    const skipped = await runRefresh(false);
+    expect(skipped.skipped).toBe(true);
+  });
+
+  it('fails with a clear error when the Sero env vars are missing', async () => {
+    delete process.env.PI_CODING_AGENT_DIR;
+    await expect(runRefresh(true)).rejects.toThrow(/PI_CODING_AGENT_DIR/);
+  });
+});

--- a/plugins/sero-usage-plugin/extension/__tests__/scan-cache.test.ts
+++ b/plugins/sero-usage-plugin/extension/__tests__/scan-cache.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm, utimes, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { CACHE_SCHEMA_VERSION, emptyScanCache, loadScanCache, saveScanCache, scanWithCache } from '../scan-cache';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'usage-cache-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+async function writeSessionFile(name: string, sessionId: string): Promise<string> {
+  const filePath = path.join(dir, name);
+  await writeFile(
+    filePath,
+    [
+      JSON.stringify({ type: 'session', id: sessionId, cwd: '/w', timestamp: '2026-07-08T09:00:00.000Z' }),
+      JSON.stringify({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          provider: 'anthropic',
+          model: 'claude-opus-4-5',
+          timestamp: 1751960460000,
+          usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0.1 } },
+        },
+      }),
+    ].join('\n'),
+  );
+  return filePath;
+}
+
+describe('scanWithCache', () => {
+  it('parses fresh files, then reuses them while fingerprints are unchanged', async () => {
+    const fileA = await writeSessionFile('a.jsonl', 'sess-a');
+    const fileB = await writeSessionFile('b.jsonl', 'sess-b');
+
+    const first = await scanWithCache([fileA, fileB], emptyScanCache());
+    expect(first.files).toBe(2);
+    expect(first.reused).toBe(0);
+    expect(first.sessions.map((s) => s.sessionId)).toEqual(['sess-a', 'sess-b']);
+
+    const second = await scanWithCache([fileA, fileB], first.cache);
+    expect(second.reused).toBe(2);
+    expect(second.sessions.map((s) => s.sessionId)).toEqual(['sess-a', 'sess-b']);
+  });
+
+  it('re-parses when mtime or size changes', async () => {
+    const fileA = await writeSessionFile('a.jsonl', 'sess-a');
+    const first = await scanWithCache([fileA], emptyScanCache());
+
+    await writeSessionFile('a.jsonl', 'sess-a-rewritten');
+    await utimes(fileA, new Date(), new Date());
+    const second = await scanWithCache([fileA], first.cache);
+
+    expect(second.reused).toBe(0);
+    expect(second.sessions[0]!.sessionId).toBe('sess-a-rewritten');
+  });
+
+  it('drops deleted files from the next cache', async () => {
+    const fileA = await writeSessionFile('a.jsonl', 'sess-a');
+    const first = await scanWithCache([fileA], emptyScanCache());
+    expect(Object.keys(first.cache.files)).toEqual([fileA]);
+
+    const second = await scanWithCache([], first.cache);
+    expect(Object.keys(second.cache.files)).toEqual([]);
+  });
+});
+
+describe('cache persistence', () => {
+  it('round-trips through disk atomically', async () => {
+    const cachePath = path.join(dir, 'scan-cache.json');
+    const fileA = await writeSessionFile('a.jsonl', 'sess-a');
+    const { cache } = await scanWithCache([fileA], emptyScanCache());
+
+    await saveScanCache(cachePath, cache);
+    const loaded = await loadScanCache(cachePath);
+    expect(loaded).toEqual(cache);
+    expect(JSON.parse(await readFile(cachePath, 'utf8')).schemaVersion).toBe(CACHE_SCHEMA_VERSION);
+  });
+
+  it('starts empty on missing, corrupt, or version-mismatched cache files', async () => {
+    const cachePath = path.join(dir, 'scan-cache.json');
+    expect(await loadScanCache(cachePath)).toEqual(emptyScanCache());
+
+    await writeFile(cachePath, 'not json');
+    expect(await loadScanCache(cachePath)).toEqual(emptyScanCache());
+
+    await writeFile(cachePath, JSON.stringify({ schemaVersion: 999, files: {} }));
+    expect(await loadScanCache(cachePath)).toEqual(emptyScanCache());
+  });
+});

--- a/plugins/sero-usage-plugin/extension/__tests__/scan.test.ts
+++ b/plugins/sero-usage-plugin/extension/__tests__/scan.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { collectSessionFiles, parseSessionFile } from '../scan';
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'usage-scan-'));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+function line(entry: unknown): string {
+  return JSON.stringify(entry);
+}
+
+const SESSION_HEADER = line({ type: 'session', id: 'sess-1', cwd: '/workspaces/demo', timestamp: '2026-07-08T09:00:00.000Z' });
+
+function assistantMessage(overrides: Record<string, unknown> = {}): string {
+  return line({
+    type: 'message',
+    timestamp: '2026-07-08T09:01:00.000Z',
+    message: {
+      role: 'assistant',
+      provider: 'anthropic',
+      model: 'claude-opus-4-5',
+      timestamp: new Date('2026-07-08T09:01:00.000Z').getTime(),
+      usage: { input: 10, output: 5, cacheRead: 100, cacheWrite: 20, cost: { total: 0.5 } },
+      ...overrides,
+    },
+  });
+}
+
+describe('collectSessionFiles', () => {
+  it('finds .jsonl files recursively, sorted, skipping other files', async () => {
+    await mkdir(path.join(dir, 'nested/deep'), { recursive: true });
+    await writeFile(path.join(dir, 'b.jsonl'), '');
+    await writeFile(path.join(dir, 'nested/deep/a.jsonl'), '');
+    await writeFile(path.join(dir, 'ignore.txt'), '');
+
+    const files = await collectSessionFiles(dir);
+    expect(files).toEqual([path.join(dir, 'b.jsonl'), path.join(dir, 'nested/deep/a.jsonl')].sort());
+  });
+
+  it('returns empty for a missing root instead of throwing', async () => {
+    expect(await collectSessionFiles(path.join(dir, 'does-not-exist'))).toEqual([]);
+  });
+});
+
+describe('parseSessionFile', () => {
+  it('extracts header, name, first user message, and usage messages', async () => {
+    const filePath = path.join(dir, 's.jsonl');
+    await writeFile(
+      filePath,
+      [
+        SESSION_HEADER,
+        line({ type: 'message', message: { role: 'user', content: [{ type: 'text', text: '  fix the   bug  ' }] } }),
+        line({ type: 'session_info', name: 'My session' }),
+        assistantMessage(),
+        'this is not json {{{',
+        line({ type: 'message', message: { role: 'assistant', provider: 'openai', model: 'gpt-6' } }), // no usage
+      ].join('\n'),
+    );
+
+    const parsed = await parseSessionFile(filePath);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.sessionId).toBe('sess-1');
+    expect(parsed!.cwd).toBe('/workspaces/demo');
+    expect(parsed!.name).toBe('My session');
+    expect(parsed!.firstMessage).toBe('fix the bug');
+    expect(parsed!.messages).toHaveLength(1);
+    expect(parsed!.messages[0]).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude-opus-4-5',
+      cost: 0.5,
+      input: 10,
+      output: 5,
+      cacheRead: 100,
+      cacheWrite: 20,
+    });
+  });
+
+  it('falls back to the entry timestamp when the message has none', async () => {
+    const filePath = path.join(dir, 's.jsonl');
+    await writeFile(filePath, [SESSION_HEADER, assistantMessage({ timestamp: undefined })].join('\n'));
+    const parsed = await parseSessionFile(filePath);
+    expect(parsed!.messages[0]!.timestamp).toBe(new Date('2026-07-08T09:01:00.000Z').getTime());
+  });
+
+  it('returns null for files with no session header', async () => {
+    const filePath = path.join(dir, 'headerless.jsonl');
+    await writeFile(filePath, assistantMessage());
+    expect(await parseSessionFile(filePath)).toBeNull();
+  });
+
+  it('returns null for unreadable files', async () => {
+    expect(await parseSessionFile(path.join(dir, 'missing.jsonl'))).toBeNull();
+  });
+});

--- a/plugins/sero-usage-plugin/extension/aggregate.ts
+++ b/plugins/sero-usage-plugin/extension/aggregate.ts
@@ -1,0 +1,242 @@
+/**
+ * Aggregation: parsed sessions → period stats, daily and hourly buckets.
+ *
+ * Token accounting rules (docs/specs/sero-usage-plugin-spec.md §2.4):
+ * headline tokens = input + output + cacheWrite. cacheRead is excluded
+ * from totals (repeated cache hits would dominate) but tracked in the
+ * breakdown for the Cache column.
+ */
+
+import { dateKey, periodBoundaries, periodsForTimestamp } from '../shared/period';
+import type {
+  DailyBucket,
+  HourlyBucket,
+  PeriodKey,
+  PeriodStats,
+  ProviderSlice,
+  SessionStats,
+  TokenBreakdown,
+} from '../shared/types';
+import { PERIOD_KEYS, emptyTokens } from '../shared/types';
+import type { ParsedSession, UsageMessage } from './scan';
+
+const TOP_SESSIONS_LIMIT = 50;
+const DAILY_WINDOW_DAYS = 365;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface AggregateResult {
+  periods: Record<PeriodKey, PeriodStats>;
+  daily: DailyBucket[];
+  hourly: HourlyBucket[];
+}
+
+interface StatsAccumulator {
+  sessions: Set<string>;
+  messages: number;
+  cost: number;
+  tokens: TokenBreakdown;
+}
+
+interface ProviderAccumulator extends StatsAccumulator {
+  models: Map<string, StatsAccumulator>;
+}
+
+interface SessionAccumulator {
+  session: ParsedSession;
+  messages: number;
+  cost: number;
+  tokens: TokenBreakdown;
+  firstActivity: number;
+  lastActivity: number;
+}
+
+interface PeriodAccumulator {
+  totals: StatsAccumulator;
+  providers: Map<string, ProviderAccumulator>;
+  sessions: Map<string, SessionAccumulator>;
+}
+
+function emptyStatsAccumulator(): StatsAccumulator {
+  return { sessions: new Set(), messages: 0, cost: 0, tokens: emptyTokens() };
+}
+
+function accumulate(target: StatsAccumulator, msg: UsageMessage): void {
+  target.messages++;
+  target.cost += msg.cost;
+  target.tokens.total += msg.input + msg.output + msg.cacheWrite;
+  target.tokens.input += msg.input;
+  target.tokens.output += msg.output;
+  target.tokens.cacheRead += msg.cacheRead;
+  target.tokens.cacheWrite += msg.cacheWrite;
+}
+
+function accumulateSlice(slices: Record<string, ProviderSlice>, msg: UsageMessage): void {
+  const slice = (slices[msg.provider] ??= { cost: 0, tokens: 0, messages: 0 });
+  slice.cost += msg.cost;
+  slice.tokens += msg.input + msg.output + msg.cacheWrite;
+  slice.messages++;
+}
+
+/** Cross-file dedup fingerprint for copied history in branched sessions (spec §2.3). */
+export function messageFingerprint(msg: UsageMessage): string {
+  return `${msg.timestamp}:${msg.input + msg.output + msg.cacheRead + msg.cacheWrite}`;
+}
+
+function sessionLabel(session: ParsedSession): string {
+  return session.name || session.firstMessage || session.sessionId;
+}
+
+export function aggregate(sessions: ParsedSession[], now = new Date()): AggregateResult {
+  const bounds = periodBoundaries(now);
+  const dailyWindowStartMs = bounds.todayMs - (DAILY_WINDOW_DAYS - 1) * DAY_MS;
+
+  const accumulators = {} as Record<PeriodKey, PeriodAccumulator>;
+  for (const key of PERIOD_KEYS) {
+    accumulators[key] = { totals: emptyStatsAccumulator(), providers: new Map(), sessions: new Map() };
+  }
+  const dailyBuckets = new Map<string, DailyBucket>();
+  const hourlyBuckets = new Map<number, HourlyBucket>();
+  const seenFingerprints = new Set<string>();
+
+  for (const session of sessions) {
+    for (const msg of session.messages) {
+      const fingerprint = messageFingerprint(msg);
+      if (seenFingerprints.has(fingerprint)) continue;
+      seenFingerprints.add(fingerprint);
+
+      for (const period of periodsForTimestamp(msg.timestamp, bounds)) {
+        const acc = accumulators[period];
+        accumulate(acc.totals, msg);
+        acc.totals.sessions.add(session.sessionId);
+
+        let provider = acc.providers.get(msg.provider);
+        if (!provider) {
+          provider = { ...emptyStatsAccumulator(), models: new Map() };
+          acc.providers.set(msg.provider, provider);
+        }
+        accumulate(provider, msg);
+        provider.sessions.add(session.sessionId);
+
+        let model = provider.models.get(msg.model);
+        if (!model) {
+          model = emptyStatsAccumulator();
+          provider.models.set(msg.model, model);
+        }
+        accumulate(model, msg);
+        model.sessions.add(session.sessionId);
+
+        let sessionAcc = acc.sessions.get(session.sessionId);
+        if (!sessionAcc) {
+          sessionAcc = {
+            session,
+            messages: 0,
+            cost: 0,
+            tokens: emptyTokens(),
+            firstActivity: 0,
+            lastActivity: 0,
+          };
+          acc.sessions.set(session.sessionId, sessionAcc);
+        }
+        sessionAcc.messages++;
+        sessionAcc.cost += msg.cost;
+        sessionAcc.tokens.total += msg.input + msg.output + msg.cacheWrite;
+        sessionAcc.tokens.input += msg.input;
+        sessionAcc.tokens.output += msg.output;
+        sessionAcc.tokens.cacheRead += msg.cacheRead;
+        sessionAcc.tokens.cacheWrite += msg.cacheWrite;
+        if (msg.timestamp > 0) {
+          if (!sessionAcc.firstActivity || msg.timestamp < sessionAcc.firstActivity) {
+            sessionAcc.firstActivity = msg.timestamp;
+          }
+          if (msg.timestamp > sessionAcc.lastActivity) sessionAcc.lastActivity = msg.timestamp;
+        }
+      }
+
+      if (msg.timestamp >= dailyWindowStartMs) {
+        const key = dateKey(msg.timestamp);
+        let bucket = dailyBuckets.get(key);
+        if (!bucket) {
+          bucket = { date: key, cost: 0, tokens: 0, input: 0, output: 0, messages: 0, byProvider: {} };
+          dailyBuckets.set(key, bucket);
+        }
+        bucket.cost += msg.cost;
+        bucket.tokens += msg.input + msg.output + msg.cacheWrite;
+        bucket.input += msg.input + msg.cacheWrite;
+        bucket.output += msg.output;
+        bucket.messages++;
+        accumulateSlice(bucket.byProvider, msg);
+      }
+
+      if (msg.timestamp >= bounds.todayMs) {
+        const hour = new Date(msg.timestamp).getHours();
+        let bucket = hourlyBuckets.get(hour);
+        if (!bucket) {
+          bucket = { hour, cost: 0, tokens: 0, messages: 0, byProvider: {} };
+          hourlyBuckets.set(hour, bucket);
+        }
+        bucket.cost += msg.cost;
+        bucket.tokens += msg.input + msg.output + msg.cacheWrite;
+        bucket.messages++;
+        accumulateSlice(bucket.byProvider, msg);
+      }
+    }
+  }
+
+  const periods = {} as Record<PeriodKey, PeriodStats>;
+  for (const key of PERIOD_KEYS) {
+    periods[key] = finalizePeriod(accumulators[key]);
+  }
+
+  return {
+    periods,
+    daily: Array.from(dailyBuckets.values()).sort((a, b) => a.date.localeCompare(b.date)),
+    hourly: Array.from(hourlyBuckets.values()).sort((a, b) => a.hour - b.hour),
+  };
+}
+
+function finalizePeriod(acc: PeriodAccumulator): PeriodStats {
+  const providers = Array.from(acc.providers.entries())
+    .map(([providerName, provider]) => ({
+      provider: providerName,
+      sessions: provider.sessions.size,
+      messages: provider.messages,
+      cost: provider.cost,
+      tokens: provider.tokens,
+      models: Array.from(provider.models.entries())
+        .map(([modelName, model]) => ({
+          model: modelName,
+          sessions: model.sessions.size,
+          messages: model.messages,
+          cost: model.cost,
+          tokens: model.tokens,
+        }))
+        .sort((a, b) => b.cost - a.cost || b.tokens.total - a.tokens.total),
+    }))
+    .sort((a, b) => b.cost - a.cost || b.tokens.total - a.tokens.total);
+
+  const topSessions: SessionStats[] = Array.from(acc.sessions.values())
+    .sort((a, b) => b.cost - a.cost || b.tokens.total - a.tokens.total)
+    .slice(0, TOP_SESSIONS_LIMIT)
+    .map((s) => ({
+      id: s.session.sessionId,
+      label: sessionLabel(s.session),
+      cwd: s.session.cwd,
+      path: s.session.path,
+      messages: s.messages,
+      cost: s.cost,
+      tokens: s.tokens,
+      firstActivity: s.firstActivity,
+      lastActivity: s.lastActivity,
+    }));
+
+  return {
+    totals: {
+      sessions: acc.totals.sessions.size,
+      messages: acc.totals.messages,
+      cost: acc.totals.cost,
+      tokens: acc.totals.tokens,
+    },
+    providers,
+    topSessions,
+  };
+}

--- a/plugins/sero-usage-plugin/extension/index.ts
+++ b/plugins/sero-usage-plugin/extension/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Usage Extension — aggregates AI usage/cost from the active profile's
+ * session .jsonl files into ~/.sero-ui (SERO_HOME)/apps/usage/state.json.
+ *
+ * Sero-only built-in plugin: paths resolve exclusively from SERO_HOME /
+ * PI_CODING_AGENT_DIR (no ~/.pi fallback). Read-only against sessions.
+ *
+ * Spec: docs/specs/sero-usage-plugin-spec.md
+ */
+
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+
+import { registerUsageTool } from './tools';
+
+export default function (pi: ExtensionAPI) {
+  registerUsageTool(pi);
+}

--- a/plugins/sero-usage-plugin/extension/refresh.ts
+++ b/plugins/sero-usage-plugin/extension/refresh.ts
@@ -1,0 +1,97 @@
+/**
+ * Refresh orchestration: scan → aggregate → state.json.
+ *
+ * The in-flight guard is a module-level singleton (same pattern as the
+ * cron scheduler): concurrent refresh calls — e.g. the app and the
+ * dashboard widget mounting together — share one scan instead of
+ * starting another.
+ */
+
+import { formatCost, formatCount, formatTokens } from '../shared/format';
+import type { UsageState } from '../shared/types';
+import { aggregate } from './aggregate';
+import { collectSessionFiles } from './scan';
+import { loadScanCache, saveScanCache, scanWithCache } from './scan-cache';
+import { readState, resolveScanCachePath, resolveSessionsDir, resolveStatePath, writeJsonFile } from './state-io';
+
+/** Non-forced refreshes within this window are treated as already fresh. */
+const FRESH_WINDOW_MS = 60_000;
+
+export interface RefreshSummary {
+  files: number;
+  reused: number;
+  durationMs: number;
+  state: UsageState;
+  skipped: boolean;
+}
+
+let refreshInFlight: Promise<RefreshSummary> | null = null;
+
+export function runRefresh(force: boolean): Promise<RefreshSummary> {
+  if (refreshInFlight) return refreshInFlight;
+
+  const refresh = doRefresh(force).finally(() => {
+    refreshInFlight = null;
+  });
+  refreshInFlight = refresh;
+  return refresh;
+}
+
+async function doRefresh(force: boolean): Promise<RefreshSummary> {
+  const startedAt = Date.now();
+  const statePath = resolveStatePath();
+  const previousState = await readState(statePath);
+
+  if (
+    !force &&
+    previousState.lastRefreshedAt !== null &&
+    startedAt - previousState.lastRefreshedAt < FRESH_WINDOW_MS
+  ) {
+    return {
+      files: previousState.lastScan?.files ?? 0,
+      reused: previousState.lastScan?.reused ?? 0,
+      durationMs: 0,
+      state: previousState,
+      skipped: true,
+    };
+  }
+
+  const sessionsDir = resolveSessionsDir();
+  const cachePath = resolveScanCachePath();
+  const cache = await loadScanCache(cachePath);
+
+  const sessionFiles = await collectSessionFiles(sessionsDir);
+  const scan = await scanWithCache(sessionFiles, cache);
+  await saveScanCache(cachePath, scan.cache);
+
+  const { periods, daily, hourly } = aggregate(scan.sessions);
+  const durationMs = Date.now() - startedAt;
+
+  // Re-read settings just before writing so a mid-scan settings change
+  // from the UI is not clobbered.
+  const currentState = await readState(statePath);
+  const state: UsageState = {
+    schemaVersion: 1,
+    settings: currentState.settings,
+    lastRefreshedAt: Date.now(),
+    lastScan: { files: scan.files, reused: scan.reused, durationMs },
+    periods,
+    daily,
+    hourly,
+  };
+  await writeJsonFile(statePath, state);
+
+  return { files: scan.files, reused: scan.reused, durationMs, state, skipped: false };
+}
+
+export function summarizeRefresh(summary: RefreshSummary): string {
+  if (summary.skipped) {
+    return 'Usage data is already fresh (refreshed under a minute ago).';
+  }
+  const totals = summary.state.periods.allTime.totals;
+  return (
+    `Scanned ${summary.files} session files (${summary.reused} unchanged, from cache) in ${summary.durationMs}ms. ` +
+    `All time: ${formatCost(totals.cost)} · ${formatTokens(totals.tokens.total)} tokens · ` +
+    `${formatCount(totals.sessions)} sessions · ${formatCount(totals.messages)} messages.`
+  );
+}

--- a/plugins/sero-usage-plugin/extension/scan-cache.ts
+++ b/plugins/sero-usage-plugin/extension/scan-cache.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-file scan cache: parsing is the expensive part of a refresh, so
+ * files whose { mtimeMs, size } fingerprint is unchanged reuse their
+ * previously parsed compact records. Aggregation always re-runs globally
+ * because dedup is cross-file (docs/specs/sero-usage-plugin-spec.md §3.4).
+ */
+
+import { promises as fs } from 'node:fs';
+
+import type { ParsedSession } from './scan';
+import { parseSessionFile } from './scan';
+import { writeJsonFile } from './state-io';
+
+export const CACHE_SCHEMA_VERSION = 1;
+
+interface CacheEntry {
+  mtimeMs: number;
+  size: number;
+  /** null = file parsed but had no usable session header. */
+  session: ParsedSession | null;
+}
+
+export interface ScanCache {
+  schemaVersion: number;
+  files: Record<string, CacheEntry>;
+}
+
+export function emptyScanCache(): ScanCache {
+  return { schemaVersion: CACHE_SCHEMA_VERSION, files: {} };
+}
+
+/** Missing, corrupt, or version-mismatched cache → start empty and rescan. */
+export async function loadScanCache(filePath: string): Promise<ScanCache> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as ScanCache;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      parsed.schemaVersion === CACHE_SCHEMA_VERSION &&
+      typeof parsed.files === 'object' &&
+      parsed.files !== null
+    ) {
+      return parsed;
+    }
+  } catch {
+    // fall through
+  }
+  return emptyScanCache();
+}
+
+export async function saveScanCache(filePath: string, cache: ScanCache): Promise<void> {
+  await writeJsonFile(filePath, cache);
+}
+
+export interface ScanResult {
+  sessions: ParsedSession[];
+  /** Next cache — deleted files already dropped. */
+  cache: ScanCache;
+  files: number;
+  reused: number;
+}
+
+/**
+ * Parse every file in `sessionFiles`, reusing cached results for unchanged
+ * fingerprints. Input order is preserved so downstream dedup stays
+ * deterministic.
+ */
+export async function scanWithCache(sessionFiles: string[], cache: ScanCache): Promise<ScanResult> {
+  const nextCache = emptyScanCache();
+  const sessions: ParsedSession[] = [];
+  let reused = 0;
+
+  for (const filePath of sessionFiles) {
+    let stats;
+    try {
+      stats = await fs.stat(filePath);
+    } catch {
+      continue; // deleted between listing and stat
+    }
+
+    const cached = cache.files[filePath];
+    if (cached && cached.mtimeMs === stats.mtimeMs && cached.size === stats.size) {
+      nextCache.files[filePath] = cached;
+      if (cached.session) sessions.push(cached.session);
+      reused++;
+      continue;
+    }
+
+    const session = await parseSessionFile(filePath);
+    nextCache.files[filePath] = { mtimeMs: stats.mtimeMs, size: stats.size, session };
+    if (session) sessions.push(session);
+  }
+
+  return { sessions, cache: nextCache, files: sessionFiles.length, reused };
+}

--- a/plugins/sero-usage-plugin/extension/scan.ts
+++ b/plugins/sero-usage-plugin/extension/scan.ts
@@ -1,0 +1,168 @@
+/**
+ * Session file discovery and streaming parse.
+ *
+ * Read-only against the profile's sessions tree. Consumes exactly three
+ * entry shapes per docs/specs/sero-usage-plugin-spec.md §2.2; everything
+ * else — including malformed lines — is skipped silently.
+ */
+
+import { createReadStream } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { createInterface } from 'node:readline';
+
+export interface UsageMessage {
+  provider: string;
+  model: string;
+  cost: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  /** Epoch ms; 0 when missing/unparseable. */
+  timestamp: number;
+}
+
+export interface ParsedSession {
+  sessionId: string;
+  /** Absolute .jsonl path. */
+  path: string;
+  cwd: string;
+  name?: string;
+  firstMessage?: string;
+  messages: UsageMessage[];
+}
+
+const LABEL_MAX_LENGTH = 100;
+
+/** Recursively collect .jsonl files, sorted by path for deterministic dedup. */
+export async function collectSessionFiles(rootDir: string): Promise<string[]> {
+  const files: string[] = [];
+  await collectRecursively(rootDir, files);
+  files.sort();
+  return files;
+}
+
+async function collectRecursively(dir: string, files: string[]): Promise<void> {
+  let entries;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return; // unreadable directory — skip silently
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectRecursively(entryPath, files);
+    } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+      files.push(entryPath);
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function textFromContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((part) => (isRecord(part) && typeof part.text === 'string' ? part.text : ''))
+    .filter(Boolean)
+    .join(' ');
+}
+
+function toLabel(text: string): string {
+  const singleLine = text.replace(/\s+/g, ' ').trim();
+  return singleLine.length > LABEL_MAX_LENGTH ? `${singleLine.slice(0, LABEL_MAX_LENGTH)}…` : singleLine;
+}
+
+function parseUsageMessage(entry: Record<string, unknown>): UsageMessage | null {
+  const message = entry.message;
+  if (!isRecord(message) || message.role !== 'assistant') return null;
+  const usage = message.usage;
+  if (!isRecord(usage) || typeof message.provider !== 'string' || typeof message.model !== 'string') {
+    return null;
+  }
+
+  const entryTs = typeof entry.timestamp === 'string' ? new Date(entry.timestamp).getTime() : 0;
+  const timestamp =
+    typeof message.timestamp === 'number' && message.timestamp > 0
+      ? message.timestamp
+      : Number.isFinite(entryTs) && entryTs > 0
+        ? entryTs
+        : 0;
+
+  const cost = isRecord(usage.cost) && typeof usage.cost.total === 'number' ? usage.cost.total : 0;
+
+  return {
+    provider: message.provider,
+    model: message.model,
+    cost,
+    input: typeof usage.input === 'number' ? usage.input : 0,
+    output: typeof usage.output === 'number' ? usage.output : 0,
+    cacheRead: typeof usage.cacheRead === 'number' ? usage.cacheRead : 0,
+    cacheWrite: typeof usage.cacheWrite === 'number' ? usage.cacheWrite : 0,
+    timestamp,
+  };
+}
+
+/**
+ * Streaming parse of one session file. Returns null for files with no
+ * session header or that cannot be read. Dedup is NOT applied here —
+ * it must run globally across files (spec §2.3).
+ */
+export async function parseSessionFile(filePath: string): Promise<ParsedSession | null> {
+  let lines;
+  try {
+    lines = createInterface({ input: createReadStream(filePath), crlfDelay: Infinity });
+  } catch {
+    return null;
+  }
+
+  let sessionId = '';
+  let cwd = '';
+  let name: string | undefined;
+  let firstMessage: string | undefined;
+  const messages: UsageMessage[] = [];
+
+  try {
+    for await (const line of lines) {
+      if (!line.trim()) continue;
+      let entry: unknown;
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue; // malformed line
+      }
+      if (!isRecord(entry)) continue;
+
+      if (entry.type === 'session') {
+        if (!sessionId && typeof entry.id === 'string') {
+          sessionId = entry.id;
+          if (typeof entry.cwd === 'string') cwd = entry.cwd;
+        }
+        continue;
+      }
+      if (entry.type === 'session_info') {
+        if (typeof entry.name === 'string' && entry.name.trim()) name = toLabel(entry.name);
+        continue;
+      }
+      if (entry.type !== 'message' || !isRecord(entry.message)) continue;
+
+      if (!firstMessage && entry.message.role === 'user') {
+        const text = toLabel(textFromContent(entry.message.content));
+        if (text) firstMessage = text;
+      }
+
+      const usageMessage = parseUsageMessage(entry);
+      if (usageMessage) messages.push(usageMessage);
+    }
+  } catch {
+    return null; // read error mid-stream — skip the file
+  }
+
+  if (!sessionId) return null;
+  return { sessionId, path: filePath, cwd, name, firstMessage, messages };
+}

--- a/plugins/sero-usage-plugin/extension/state-io.ts
+++ b/plugins/sero-usage-plugin/extension/state-io.ts
@@ -1,0 +1,71 @@
+/**
+ * State + path resolution for the Usage plugin.
+ *
+ * This is a Sero-only built-in plugin: paths resolve exclusively from the
+ * Sero-provided env vars. There is deliberately NO ~/.pi/agent or cwd
+ * fallback (docs/specs/sero-usage-plugin-spec.md §2.1, §3.5).
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { UsageState } from '../shared/types';
+import { normalizeUsageState } from '../shared/types';
+
+export const APP_ID = 'usage';
+
+/** Sessions live under the profile's agent dir: `${PI_CODING_AGENT_DIR}/sessions`. */
+export function resolveSessionsDir(): string {
+  const agentDir = process.env.PI_CODING_AGENT_DIR;
+  if (!agentDir) {
+    throw new Error(
+      'PI_CODING_AGENT_DIR is not set. The Usage plugin is Sero-only and reads sessions from the active profile.',
+    );
+  }
+  return path.join(agentDir, 'sessions');
+}
+
+function resolveAppDataDir(): string {
+  const seroHome = process.env.SERO_HOME;
+  if (!seroHome) {
+    throw new Error('SERO_HOME is not set. The Usage plugin is Sero-only and stores state per profile.');
+  }
+  return path.join(seroHome, 'apps', APP_ID);
+}
+
+export function resolveStatePath(): string {
+  return path.join(resolveAppDataDir(), 'state.json');
+}
+
+export function resolveScanCachePath(): string {
+  return path.join(resolveAppDataDir(), 'scan-cache.json');
+}
+
+/** Missing or corrupt state is never fatal — fall back to defaults. */
+export async function readState(filePath: string): Promise<UsageState> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return normalizeUsageState(JSON.parse(raw));
+  } catch {
+    return normalizeUsageState(null);
+  }
+}
+
+const writeQueues = new Map<string, Promise<void>>();
+
+/** Atomic, per-file-serialised write (temp file → rename). */
+export async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
+  const previous = writeQueues.get(filePath) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(async () => {
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+    await fs.writeFile(tmpPath, JSON.stringify(value), 'utf8');
+    await fs.rename(tmpPath, filePath);
+  });
+  writeQueues.set(filePath, next);
+  try {
+    await next;
+  } finally {
+    if (writeQueues.get(filePath) === next) writeQueues.delete(filePath);
+  }
+}

--- a/plugins/sero-usage-plugin/extension/tools.ts
+++ b/plugins/sero-usage-plugin/extension/tools.ts
@@ -1,0 +1,201 @@
+/**
+ * The `usage` tool — the plugin's single agent/CLI/UI entry point.
+ * Actions: refresh, summary, sessions, config. Bridged to `sero usage …`
+ * via `sero.plugin.bridgeTools` (docs/specs/sero-usage-plugin-spec.md §3.2).
+ */
+
+import { StringEnum } from '@earendil-works/pi-ai';
+import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-agent';
+import { Type } from 'typebox';
+
+import { formatCost, formatCount, formatRelativeTime, formatTokens } from '../shared/format';
+import type { PeriodKey, UsageState } from '../shared/types';
+import { PERIOD_LABELS, REFRESH_INTERVAL_OPTIONS } from '../shared/types';
+import { runRefresh, summarizeRefresh } from './refresh';
+import { readState, resolveStatePath, writeJsonFile } from './state-io';
+
+const ACTIONS = ['refresh', 'summary', 'sessions', 'config'] as const;
+const PERIODS = ['today', 'thisWeek', 'lastWeek', 'allTime'] as const;
+
+const Params = Type.Object({
+  action: StringEnum(ACTIONS),
+  period: Type.Optional(StringEnum(PERIODS)),
+  force: Type.Optional(Type.Boolean({ description: 'refresh: rescan even if data is fresh' })),
+  limit: Type.Optional(Type.Number({ description: 'sessions: max rows (default 20, max 50)' })),
+  refreshIntervalMinutes: Type.Optional(
+    Type.Number({ description: `config: one of ${REFRESH_INTERVAL_OPTIONS.join(', ')} (0 = manual)` }),
+  ),
+});
+
+type CliResult = { output: string; exitCode: number };
+
+type SeroToolCli = {
+  summary: string;
+  help: string;
+  group: string;
+  execute(args: readonly string[], context: { cwd?: string }, signal?: AbortSignal): Promise<CliResult>;
+};
+
+type SeroCliTool<T> = T & { cli: SeroToolCli };
+
+const CLI_PERIOD_ALIASES: Record<string, PeriodKey> = {
+  today: 'today',
+  week: 'thisWeek',
+  thisweek: 'thisWeek',
+  'this-week': 'thisWeek',
+  lastweek: 'lastWeek',
+  'last-week': 'lastWeek',
+  all: 'allTime',
+  alltime: 'allTime',
+  'all-time': 'allTime',
+};
+
+function text(message: string) {
+  return { content: [{ type: 'text' as const, text: message }], details: {} };
+}
+
+async function actionRefresh(force: boolean): Promise<string> {
+  const summary = await runRefresh(force);
+  return summarizeRefresh(summary);
+}
+
+async function actionSummary(period: PeriodKey): Promise<string> {
+  const state = await readState(resolveStatePath());
+  const stats = state.periods[period];
+  if (stats.totals.messages === 0) {
+    return `No usage recorded for ${PERIOD_LABELS[period]}.${refreshedNote(state)}`;
+  }
+  const t = stats.totals;
+  const lines = [
+    `Usage (${PERIOD_LABELS[period]}): ${formatCost(t.cost)} · ${formatTokens(t.tokens.total)} tokens ` +
+      `(${formatTokens(t.tokens.input + t.tokens.cacheWrite)} in / ${formatTokens(t.tokens.output)} out) · ` +
+      `${formatCount(t.sessions)} sessions · ${formatCount(t.messages)} messages`,
+  ];
+  const topProviders = stats.providers.slice(0, 5);
+  if (topProviders.length > 0) {
+    lines.push(
+      `Top providers: ${topProviders
+        .map((p) => `${p.provider} ${formatCost(p.cost)} (${formatTokens(p.tokens.total)})`)
+        .join(' · ')}`,
+    );
+  }
+  return lines.join('\n') + refreshedNote(state);
+}
+
+async function actionSessions(period: PeriodKey, limit: number): Promise<string> {
+  const state = await readState(resolveStatePath());
+  const rows = state.periods[period].topSessions.slice(0, Math.max(1, Math.min(limit, 50)));
+  if (rows.length === 0) {
+    return `No sessions recorded for ${PERIOD_LABELS[period]}.${refreshedNote(state)}`;
+  }
+  const lines = rows.map(
+    (s, i) =>
+      `${i + 1}. ${formatCost(s.cost)} · ${formatTokens(s.tokens.total)} tokens · ` +
+      `${formatCount(s.messages)} msgs · ${s.label}`,
+  );
+  return `Top sessions by cost (${PERIOD_LABELS[period]}):\n${lines.join('\n')}${refreshedNote(state)}`;
+}
+
+async function actionConfig(refreshIntervalMinutes?: number): Promise<string> {
+  const statePath = resolveStatePath();
+  const state = await readState(statePath);
+  if (refreshIntervalMinutes === undefined) {
+    return `Auto-refresh interval: ${describeInterval(state.settings.refreshIntervalMinutes)}.`;
+  }
+  if (!(REFRESH_INTERVAL_OPTIONS as readonly number[]).includes(refreshIntervalMinutes)) {
+    return `Error: refreshIntervalMinutes must be one of ${REFRESH_INTERVAL_OPTIONS.join(', ')} (0 = manual).`;
+  }
+  const next: UsageState = { ...state, settings: { refreshIntervalMinutes } };
+  await writeJsonFile(statePath, next);
+  return `Auto-refresh interval set to ${describeInterval(refreshIntervalMinutes)}.`;
+}
+
+function describeInterval(minutes: number): string {
+  if (minutes <= 0) return 'manual only';
+  return minutes < 60 ? `every ${minutes} minutes` : `every ${minutes / 60} hours`;
+}
+
+function refreshedNote(state: UsageState): string {
+  if (state.lastRefreshedAt === null) return '\nNo scan has run yet — use the refresh action first.';
+  return `\nLast refreshed ${formatRelativeTime(state.lastRefreshedAt)}.`;
+}
+
+async function dispatch(params: {
+  action: (typeof ACTIONS)[number];
+  period?: PeriodKey;
+  force?: boolean;
+  limit?: number;
+  refreshIntervalMinutes?: number;
+}): Promise<string> {
+  try {
+    switch (params.action) {
+      case 'refresh':
+        return await actionRefresh(params.force ?? true);
+      case 'summary':
+        return await actionSummary(params.period ?? 'today');
+      case 'sessions':
+        return await actionSessions(params.period ?? 'today', params.limit ?? 20);
+      case 'config':
+        return await actionConfig(params.refreshIntervalMinutes);
+    }
+  } catch (error) {
+    return `Error: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+
+export function registerUsageTool(pi: ExtensionAPI): void {
+  const usageTool: SeroCliTool<ToolDefinition<typeof Params>> = {
+    name: 'usage',
+    label: 'Usage',
+    description:
+      'AI usage and cost statistics for this profile. Actions: refresh (rescan session data), ' +
+      'summary (totals + top providers for a period), sessions (top sessions by cost), ' +
+      'config (get/set auto-refresh interval). Periods: today, thisWeek, lastWeek, allTime.',
+    parameters: Params,
+
+    async execute(_toolCallId, params) {
+      return text(await dispatch(params));
+    },
+
+    cli: {
+      summary: 'Show AI usage and cost statistics',
+      help: 'sero usage <refresh|summary|sessions|config> [today|week|last-week|all] [limit|interval-minutes]',
+      group: 'Apps',
+      async execute(args) {
+        const [subcommand, ...rest] = args;
+        if (!subcommand) {
+          return { output: 'Usage: sero usage <refresh|summary|sessions|config>', exitCode: 1 };
+        }
+
+        const resolvePeriod = (raw: string | undefined): PeriodKey | null => {
+          if (!raw) return 'today';
+          return CLI_PERIOD_ALIASES[raw.toLowerCase()] ?? null;
+        };
+
+        if (subcommand === 'refresh') {
+          return { output: await dispatch({ action: 'refresh', force: true }), exitCode: 0 };
+        }
+        if (subcommand === 'summary' || subcommand === 'sessions') {
+          const period = resolvePeriod(rest[0]);
+          if (!period) {
+            return { output: `Error: unknown period "${rest[0]}". Use today, week, last-week, or all.`, exitCode: 1 };
+          }
+          const limit = rest[1] !== undefined ? Number(rest[1]) : undefined;
+          const output = await dispatch({ action: subcommand, period, limit });
+          return { output, exitCode: output.startsWith('Error:') ? 1 : 0 };
+        }
+        if (subcommand === 'config') {
+          const interval = rest[0] !== undefined ? Number(rest[0]) : undefined;
+          if (rest[0] !== undefined && !Number.isFinite(interval)) {
+            return { output: 'Error: interval must be a number of minutes (0 = manual).', exitCode: 1 };
+          }
+          const output = await dispatch({ action: 'config', refreshIntervalMinutes: interval });
+          return { output, exitCode: output.startsWith('Error:') ? 1 : 0 };
+        }
+        return { output: `Unknown subcommand: ${subcommand}. Use refresh, summary, sessions, or config.`, exitCode: 1 };
+      },
+    },
+  };
+
+  pi.registerTool(usageTool);
+}

--- a/plugins/sero-usage-plugin/extension/tsconfig.json
+++ b/plugins/sero-usage-plugin/extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"],
+    "lib": ["ES2023"]
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/plugins/sero-usage-plugin/package.json
+++ b/plugins/sero-usage-plugin/package.json
@@ -1,0 +1,87 @@
+{
+  "name": "@sero-ai/plugin-usage",
+  "version": "0.1.0",
+  "description": "AI usage and cost analytics for Sero - aggregated per profile from local session data",
+  "keywords": [
+    "pi-package"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "test": "pnpm exec vitest run",
+    "test:watch": "pnpm exec vitest",
+    "typecheck": "tsc --noEmit -p ui/tsconfig.json && tsc --noEmit -p extension/tsconfig.json"
+  },
+  "pi": {
+    "extensions": [
+      "./extension/index.ts"
+    ]
+  },
+  "sero": {
+    "app": {
+      "id": "usage",
+      "name": "Usage",
+      "icon": "chart-column",
+      "scope": "global",
+      "stateFile": ".sero/apps/usage/state.json",
+      "ui": "./dist/ui/remoteEntry.js",
+      "component": "UsageApp",
+      "devPort": 5189,
+      "widgets": [
+        {
+          "id": "usage-summary",
+          "name": "Usage",
+          "component": "UsageWidget",
+          "description": "AI usage and cost summary",
+          "defaultSize": { "w": 2, "h": 2 },
+          "minSize": { "w": 1, "h": 1 },
+          "maxSize": { "w": 4, "h": 3 }
+        }
+      ]
+    },
+    "plugin": {
+      "category": "productivity",
+      "tags": [
+        "usage",
+        "cost",
+        "tokens",
+        "analytics"
+      ],
+      "minSeroVersion": "0.1.0",
+      "requiredHostCapabilities": [
+        "appAgent.invokeTool",
+        "tool.cli"
+      ],
+      "bridgeTools": [
+        "usage"
+      ]
+    }
+  },
+  "dependencies": {
+    "typebox": "catalog:"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "catalog:peer",
+    "@earendil-works/pi-coding-agent": "catalog:peer",
+    "@earendil-works/pi-tui": "catalog:peer",
+    "zod": "catalog:peer"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "catalog:",
+    "@sero-ai/app-runtime": "workspace:*",
+    "@sero-ai/ui": "workspace:*",
+    "@tailwindcss/vite": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "lucide-react": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "recharts": "3.9.2",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/plugins/sero-usage-plugin/shared/__tests__/format.test.ts
+++ b/plugins/sero-usage-plugin/shared/__tests__/format.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatCost, formatCount, formatIntervalMinutes, formatRelativeTime, formatTokens } from '../format';
+
+describe('formatCost', () => {
+  it('renders zero as a dash, never $0.00', () => {
+    expect(formatCost(0)).toBe('-');
+  });
+
+  it('applies the tiered precision rules', () => {
+    expect(formatCost(0.0042)).toBe('$0.0042');
+    expect(formatCost(0.84)).toBe('$0.84');
+    expect(formatCost(9.99)).toBe('$9.99');
+    expect(formatCost(41.7)).toBe('$41.7');
+    expect(formatCost(417.23)).toBe('$417');
+  });
+});
+
+describe('formatTokens', () => {
+  it('renders zero as a dash', () => {
+    expect(formatTokens(0)).toBe('-');
+  });
+
+  it('applies the tiered magnitude rules', () => {
+    expect(formatTokens(999)).toBe('999');
+    expect(formatTokens(1_234)).toBe('1.2k');
+    expect(formatTokens(54_321)).toBe('54k');
+    expect(formatTokens(1_400_000)).toBe('1.4M');
+    expect(formatTokens(284_000_000)).toBe('284M');
+  });
+});
+
+describe('formatCount', () => {
+  it('renders zero as a dash and locale-formats the rest', () => {
+    expect(formatCount(0)).toBe('-');
+    expect(formatCount(4148)).toBe((4148).toLocaleString());
+  });
+});
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2026-07-12T12:00:00').getTime();
+
+  it('covers the just now / minutes / hours / date tiers', () => {
+    expect(formatRelativeTime(now - 30_000, now)).toBe('just now');
+    expect(formatRelativeTime(now - 5 * 60_000, now)).toBe('5 min ago');
+    expect(formatRelativeTime(now - 3 * 3_600_000, now)).toBe('3 h ago');
+    expect(formatRelativeTime(now - 48 * 3_600_000, now)).toBe(
+      new Date(now - 48 * 3_600_000).toLocaleDateString(),
+    );
+  });
+});
+
+describe('formatIntervalMinutes', () => {
+  it('labels manual and minute/hour intervals', () => {
+    expect(formatIntervalMinutes(0)).toBe('Manual');
+    expect(formatIntervalMinutes(5)).toBe('5m');
+    expect(formatIntervalMinutes(30)).toBe('30m');
+    expect(formatIntervalMinutes(60)).toBe('1h');
+    expect(formatIntervalMinutes(1440)).toBe('24h');
+  });
+});

--- a/plugins/sero-usage-plugin/shared/__tests__/period.test.ts
+++ b/plugins/sero-usage-plugin/shared/__tests__/period.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { dateKey, periodBoundaries, periodsForTimestamp } from '../period';
+
+// Fixed reference: Wednesday 2026-07-08, 15:30 local time.
+const NOW = new Date(2026, 6, 8, 15, 30);
+
+describe('periodBoundaries', () => {
+  it('computes local midnight, Monday week start, and previous Monday', () => {
+    const bounds = periodBoundaries(NOW);
+    expect(new Date(bounds.todayMs)).toEqual(new Date(2026, 6, 8, 0, 0, 0, 0));
+    expect(new Date(bounds.weekStartMs)).toEqual(new Date(2026, 6, 6, 0, 0, 0, 0));
+    expect(new Date(bounds.lastWeekStartMs)).toEqual(new Date(2026, 5, 29, 0, 0, 0, 0));
+  });
+
+  it('treats Sunday as the last day of the week (Monday start)', () => {
+    const sunday = new Date(2026, 6, 12, 10, 0);
+    const bounds = periodBoundaries(sunday);
+    expect(new Date(bounds.weekStartMs)).toEqual(new Date(2026, 6, 6, 0, 0, 0, 0));
+  });
+});
+
+describe('periodsForTimestamp', () => {
+  const bounds = periodBoundaries(NOW);
+
+  it('assigns a message this morning to today, thisWeek, allTime', () => {
+    const ts = new Date(2026, 6, 8, 9, 0).getTime();
+    expect(periodsForTimestamp(ts, bounds)).toEqual(['allTime', 'today', 'thisWeek']);
+  });
+
+  it('assigns a message earlier this week to thisWeek but not today', () => {
+    const ts = new Date(2026, 6, 6, 9, 0).getTime();
+    expect(periodsForTimestamp(ts, bounds)).toEqual(['allTime', 'thisWeek']);
+  });
+
+  it('assigns last week and older messages exclusively', () => {
+    const lastWeekTs = new Date(2026, 6, 1, 9, 0).getTime();
+    expect(periodsForTimestamp(lastWeekTs, bounds)).toEqual(['allTime', 'lastWeek']);
+    const oldTs = new Date(2026, 4, 1, 9, 0).getTime();
+    expect(periodsForTimestamp(oldTs, bounds)).toEqual(['allTime']);
+  });
+
+  it('assigns missing timestamps to allTime only', () => {
+    expect(periodsForTimestamp(0, bounds)).toEqual(['allTime']);
+  });
+});
+
+describe('dateKey', () => {
+  it('formats local YYYY-MM-DD with zero padding', () => {
+    expect(dateKey(new Date(2026, 0, 5, 23, 59).getTime())).toBe('2026-01-05');
+    expect(dateKey(new Date(2026, 11, 31, 0, 0).getTime())).toBe('2026-12-31');
+  });
+});

--- a/plugins/sero-usage-plugin/shared/format.ts
+++ b/plugins/sero-usage-plugin/shared/format.ts
@@ -1,0 +1,45 @@
+// Display formatting rules, shared by the extension (tool/CLI text output)
+// and the UI. Specified in docs/specs/sero-usage-plugin-spec.md §4.3.
+
+/** `-` when 0; 4 dp under $0.01; 2 dp under $10; 1 dp under $100; whole dollars above. */
+export function formatCost(cost: number): string {
+  if (cost === 0) return '-';
+  if (cost < 0.01) return `$${cost.toFixed(4)}`;
+  if (cost < 10) return `$${cost.toFixed(2)}`;
+  if (cost < 100) return `$${cost.toFixed(1)}`;
+  return `$${Math.round(cost).toLocaleString()}`;
+}
+
+/** `-` when 0; raw under 1k; `1.2k` under 10k; `123k` under 1M; `1.4M` under 10M; `284M` above. */
+export function formatTokens(count: number): string {
+  if (count === 0) return '-';
+  if (count < 1_000) return String(count);
+  if (count < 10_000) return `${(count / 1_000).toFixed(1)}k`;
+  if (count < 1_000_000) return `${Math.round(count / 1_000)}k`;
+  if (count < 10_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  return `${Math.round(count / 1_000_000)}M`;
+}
+
+/** `-` when 0; else locale-formatted (`4,148`). */
+export function formatCount(count: number): string {
+  if (count === 0) return '-';
+  return count.toLocaleString();
+}
+
+/** `just now / N min ago / N h ago / local date`. */
+export function formatRelativeTime(timestamp: number, now = Date.now()): string {
+  const elapsed = now - timestamp;
+  if (elapsed < 60_000) return 'just now';
+  const minutes = Math.floor(elapsed / 60_000);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
+
+/** Interval select labels: `Manual`, `5m`, `30m`, `1h`, `6h`, `12h`, `24h`. */
+export function formatIntervalMinutes(minutes: number): string {
+  if (minutes <= 0) return 'Manual';
+  if (minutes < 60) return `${minutes}m`;
+  return `${minutes / 60}h`;
+}

--- a/plugins/sero-usage-plugin/shared/period.ts
+++ b/plugins/sero-usage-plugin/shared/period.ts
@@ -1,0 +1,57 @@
+// Period boundary math, shared by the extension aggregator and the UI
+// (trend chart range filtering). All boundaries are local time; weeks
+// start on Monday per docs/specs/sero-usage-plugin-spec.md §2.5.
+
+import type { PeriodKey } from './types';
+
+export interface PeriodBoundaries {
+  /** Local midnight today, epoch ms. */
+  todayMs: number;
+  /** Monday 00:00 of the current week, epoch ms. */
+  weekStartMs: number;
+  /** Monday 00:00 of the previous week, epoch ms. */
+  lastWeekStartMs: number;
+}
+
+export function periodBoundaries(now: Date): PeriodBoundaries {
+  const startOfToday = new Date(now);
+  startOfToday.setHours(0, 0, 0, 0);
+
+  const startOfWeek = new Date(startOfToday);
+  const dayOfWeek = startOfWeek.getDay(); // 0 = Sunday
+  const daysSinceMonday = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  startOfWeek.setDate(startOfWeek.getDate() - daysSinceMonday);
+
+  const startOfLastWeek = new Date(startOfWeek);
+  startOfLastWeek.setDate(startOfLastWeek.getDate() - 7);
+
+  return {
+    todayMs: startOfToday.getTime(),
+    weekStartMs: startOfWeek.getTime(),
+    lastWeekStartMs: startOfLastWeek.getTime(),
+  };
+}
+
+/**
+ * Periods a message timestamp belongs to. `allTime` always applies;
+ * `lastWeek` and `thisWeek` are mutually exclusive.
+ */
+export function periodsForTimestamp(timestamp: number, bounds: PeriodBoundaries): PeriodKey[] {
+  const periods: PeriodKey[] = ['allTime'];
+  if (timestamp <= 0) return periods;
+  if (timestamp >= bounds.todayMs) periods.push('today');
+  if (timestamp >= bounds.weekStartMs) {
+    periods.push('thisWeek');
+  } else if (timestamp >= bounds.lastWeekStartMs) {
+    periods.push('lastWeek');
+  }
+  return periods;
+}
+
+/** Local-time YYYY-MM-DD key for daily buckets. */
+export function dateKey(timestamp: number): string {
+  const date = new Date(timestamp);
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${date.getFullYear()}-${month}-${day}`;
+}

--- a/plugins/sero-usage-plugin/shared/types.ts
+++ b/plugins/sero-usage-plugin/shared/types.ts
@@ -1,0 +1,180 @@
+// Single source of truth for state shared across extension and UI.
+// JSON-serialisable only — no Date, Map, Set, or functions.
+// Shape is specified in docs/specs/sero-usage-plugin-spec.md §3.5.
+
+export const PERIOD_KEYS = ['today', 'thisWeek', 'lastWeek', 'allTime'] as const;
+export type PeriodKey = (typeof PERIOD_KEYS)[number];
+
+export const PERIOD_LABELS: Record<PeriodKey, string> = {
+  today: 'Today',
+  thisWeek: 'This Week',
+  lastWeek: 'Last Week',
+  allTime: 'All Time',
+};
+
+/** Allowed auto-refresh intervals in minutes. 0 = manual only. */
+export const REFRESH_INTERVAL_OPTIONS = [0, 5, 30, 60, 360, 720, 1440] as const;
+export const DEFAULT_REFRESH_INTERVAL_MINUTES = 30;
+
+export interface TokenBreakdown {
+  /** Fresh tokens processed: input + output + cacheWrite (cacheRead excluded). */
+  total: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+export interface ModelStats {
+  model: string;
+  sessions: number;
+  messages: number;
+  cost: number;
+  tokens: TokenBreakdown;
+}
+
+export interface ProviderStats {
+  provider: string;
+  sessions: number;
+  messages: number;
+  cost: number;
+  tokens: TokenBreakdown;
+  /** Sorted by cost desc. */
+  models: ModelStats[];
+}
+
+export interface SessionStats {
+  id: string;
+  /** session_info name, else first user message (truncated), else id. */
+  label: string;
+  /** Workspace path, for display. */
+  cwd: string;
+  /** Absolute session .jsonl path — for reveal-in-folder. */
+  path: string;
+  messages: number;
+  cost: number;
+  tokens: TokenBreakdown;
+  firstActivity: number;
+  lastActivity: number;
+}
+
+export interface PeriodStats {
+  totals: { sessions: number; messages: number; cost: number; tokens: TokenBreakdown };
+  /** Sorted by cost desc. */
+  providers: ProviderStats[];
+  /** Top 50 by cost. */
+  topSessions: SessionStats[];
+}
+
+export interface ProviderSlice {
+  cost: number;
+  tokens: number;
+  messages: number;
+}
+
+export interface DailyBucket {
+  /** YYYY-MM-DD, local time. */
+  date: string;
+  cost: number;
+  tokens: number;
+  input: number;
+  output: number;
+  messages: number;
+  /** For the stacked trend chart. */
+  byProvider: Record<string, ProviderSlice>;
+}
+
+export interface HourlyBucket {
+  /** 0-23, local time, current day only. */
+  hour: number;
+  cost: number;
+  tokens: number;
+  messages: number;
+  byProvider: Record<string, ProviderSlice>;
+}
+
+export interface UsageState {
+  schemaVersion: 1;
+  settings: { refreshIntervalMinutes: number };
+  lastRefreshedAt: number | null;
+  lastScan: { files: number; reused: number; durationMs: number } | null;
+  periods: Record<PeriodKey, PeriodStats>;
+  /** ≤ 365 entries, ascending date. */
+  daily: DailyBucket[];
+  /** Current day only, ≤ 24 entries, ascending hour. */
+  hourly: HourlyBucket[];
+}
+
+export function emptyTokens(): TokenBreakdown {
+  return { total: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+}
+
+export function emptyPeriodStats(): PeriodStats {
+  return {
+    totals: { sessions: 0, messages: 0, cost: 0, tokens: emptyTokens() },
+    providers: [],
+    topSessions: [],
+  };
+}
+
+export function emptyPeriods(): Record<PeriodKey, PeriodStats> {
+  return {
+    today: emptyPeriodStats(),
+    thisWeek: emptyPeriodStats(),
+    lastWeek: emptyPeriodStats(),
+    allTime: emptyPeriodStats(),
+  };
+}
+
+export const DEFAULT_STATE: UsageState = {
+  schemaVersion: 1,
+  settings: { refreshIntervalMinutes: DEFAULT_REFRESH_INTERVAL_MINUTES },
+  lastRefreshedAt: null,
+  lastScan: null,
+  periods: emptyPeriods(),
+  daily: [],
+  hourly: [],
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Defensive normalisation for state read from disk. A corrupt or
+ * older-schema file must never crash a surface — fall back to defaults
+ * per field and let the next refresh rewrite the file.
+ */
+export function normalizeUsageState(value: unknown): UsageState {
+  if (!isRecord(value) || value.schemaVersion !== 1) return structuredClone(DEFAULT_STATE);
+
+  const settings = isRecord(value.settings) ? value.settings : {};
+  const interval =
+    typeof settings.refreshIntervalMinutes === 'number' &&
+    (REFRESH_INTERVAL_OPTIONS as readonly number[]).includes(settings.refreshIntervalMinutes)
+      ? settings.refreshIntervalMinutes
+      : DEFAULT_REFRESH_INTERVAL_MINUTES;
+
+  const periods = isRecord(value.periods) ? value.periods : {};
+  const normalizedPeriods = emptyPeriods();
+  for (const key of PERIOD_KEYS) {
+    const period = periods[key];
+    if (isRecord(period) && isRecord(period.totals)) {
+      normalizedPeriods[key] = period as unknown as PeriodStats;
+    }
+  }
+
+  const lastScan = isRecord(value.lastScan)
+    ? (value.lastScan as unknown as UsageState['lastScan'])
+    : null;
+
+  return {
+    schemaVersion: 1,
+    settings: { refreshIntervalMinutes: interval },
+    lastRefreshedAt: typeof value.lastRefreshedAt === 'number' ? value.lastRefreshedAt : null,
+    lastScan,
+    periods: normalizedPeriods,
+    daily: Array.isArray(value.daily) ? (value.daily as DailyBucket[]) : [],
+    hourly: Array.isArray(value.hourly) ? (value.hourly as HourlyBucket[]) : [],
+  };
+}

--- a/plugins/sero-usage-plugin/ui/UsageApp.tsx
+++ b/plugins/sero-usage-plugin/ui/UsageApp.tsx
@@ -1,0 +1,191 @@
+/**
+ * Usage app — profile-wide AI usage and cost analytics.
+ * Spec: docs/specs/sero-usage-plugin-spec.md §4.1
+ */
+
+import { useMemo, useState } from 'react';
+import { useAppState } from '@sero-ai/app-runtime';
+import {
+  Alert,
+  AlertDescription,
+  DataBoundary,
+  EmptyState,
+  IconButton,
+  Inline,
+  ListSkeleton,
+  MetricSkeleton,
+  Section,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Stack,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Text,
+} from '@sero-ai/ui';
+import { ChartColumn, RotateCw } from 'lucide-react';
+
+import { formatIntervalMinutes, formatRelativeTime } from '../shared/format';
+import type { PeriodKey, UsageState } from '../shared/types';
+import {
+  DEFAULT_STATE,
+  PERIOD_KEYS,
+  PERIOD_LABELS,
+  REFRESH_INTERVAL_OPTIONS,
+  normalizeUsageState,
+} from '../shared/types';
+import { ActivityHeatmap } from './components/ActivityHeatmap';
+import { ProviderTable } from './components/ProviderTable';
+import { SessionsTable } from './components/SessionsTable';
+import { StatTiles } from './components/StatTiles';
+import { TrendChart } from './components/TrendChart';
+import { TREND_METRICS, TREND_METRIC_LABELS, type TrendMetric } from './lib/trend';
+import { useAutoRefresh } from './lib/useAutoRefresh';
+import './styles.css';
+
+export function UsageApp() {
+  const [rawState, updateState] = useAppState<UsageState>(DEFAULT_STATE);
+  const state = useMemo(() => normalizeUsageState(rawState), [rawState]);
+  const { refresh, refreshing, error } = useAutoRefresh(state);
+
+  const [period, setPeriod] = useState<PeriodKey>('today');
+  const [metric, setMetric] = useState<TrendMetric>('tokens');
+
+  const stats = state.periods[period];
+  const hasAnyData = state.periods.allTime.totals.messages > 0;
+  const dataState = state.lastRefreshedAt === null ? 'loading' : hasAnyData ? 'ready' : 'empty';
+
+  const setInterval = (minutes: number) => {
+    updateState((prev) => ({
+      ...normalizeUsageState(prev),
+      settings: { refreshIntervalMinutes: minutes },
+    }));
+  };
+
+  return (
+    <div className="size-full overflow-y-auto bg-background text-foreground">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-5 p-5">
+        <Inline justify="between" align="center" wrap>
+          <Tabs value={period} onValueChange={(value) => setPeriod(value as PeriodKey)}>
+            <TabsList>
+              {PERIOD_KEYS.map((key) => (
+                <TabsTrigger key={key} value={key}>
+                  {PERIOD_LABELS[key]}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+          <Inline gap="sm" align="center">
+            {state.lastRefreshedAt !== null && (
+              <Text variant="muted" className="text-[11px]">
+                updated {formatRelativeTime(state.lastRefreshedAt)}
+              </Text>
+            )}
+            <Select
+              value={String(state.settings.refreshIntervalMinutes)}
+              onValueChange={(value) => setInterval(Number(value))}
+            >
+              <SelectTrigger size="sm" className="w-24" aria-label="Auto-refresh interval">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REFRESH_INTERVAL_OPTIONS.map((minutes) => (
+                  <SelectItem key={minutes} value={String(minutes)}>
+                    {formatIntervalMinutes(minutes)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <IconButton
+              icon={RotateCw}
+              label="Refresh usage data"
+              onClick={refresh}
+              disabled={refreshing}
+              className={refreshing ? 'animate-spin' : undefined}
+            />
+          </Inline>
+        </Inline>
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <DataBoundary
+          state={dataState}
+          loading={
+            <Stack gap="lg">
+              <MetricSkeleton count={6} />
+              <ListSkeleton count={6} />
+            </Stack>
+          }
+          empty={
+            <EmptyState
+              icon={ChartColumn}
+              title="No usage recorded yet"
+              message="Usage appears here after your first agent session."
+            />
+          }
+        >
+          <Stack gap="lg">
+            <StatTiles totals={stats.totals} />
+
+            <Section
+              heading="Daily Activity"
+              action={
+                <Select value={metric} onValueChange={(value) => setMetric(value as TrendMetric)}>
+                  <SelectTrigger size="sm" className="w-28" aria-label="Metric">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {TREND_METRICS.map((key) => (
+                      <SelectItem key={key} value={key}>
+                        {TREND_METRIC_LABELS[key]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              }
+            >
+              <ActivityHeatmap daily={state.daily} metric={metric} />
+            </Section>
+
+            <Section heading={period === 'today' ? 'Trend by hour' : 'Trend by day'}>
+              {stats.totals.messages === 0 ? (
+                <EmptyState icon={ChartColumn} title={`No usage for ${PERIOD_LABELS[period]}`} />
+              ) : (
+                <TrendChart period={period} daily={state.daily} hourly={state.hourly} metric={metric} />
+              )}
+            </Section>
+
+            <Section heading="By Provider · Model">
+              {stats.providers.length === 0 ? (
+                <EmptyState icon={ChartColumn} title={`No usage for ${PERIOD_LABELS[period]}`} />
+              ) : (
+                <ProviderTable providers={stats.providers} />
+              )}
+            </Section>
+
+            {stats.topSessions.length > 0 && (
+              <Section heading="Sessions">
+                <SessionsTable sessions={stats.topSessions} />
+              </Section>
+            )}
+
+            <Text variant="muted" className="text-[11px]">
+              Tokens = Input + Output + CacheWrite · ↑ In = Input + CacheWrite · costs are approximate,
+              based on local session data.
+            </Text>
+          </Stack>
+        </DataBoundary>
+      </div>
+    </div>
+  );
+}
+
+// Both named and default exports are required for Module Federation lazy loading.
+export default UsageApp;

--- a/plugins/sero-usage-plugin/ui/components/ActivityHeatmap.tsx
+++ b/plugins/sero-usage-plugin/ui/components/ActivityHeatmap.tsx
@@ -1,0 +1,143 @@
+/**
+ * GitHub-style calendar heatmap of the trailing year, one cell per local
+ * day, weeks as columns (Mon-Sun rows), today in the rightmost column.
+ */
+
+import { useMemo, type CSSProperties } from 'react';
+import { Inline, Text } from '@sero-ai/ui';
+
+import { dateKey } from '../../shared/period';
+import type { DailyBucket } from '../../shared/types';
+import { formatMetricValue, metricOfBucket, type TrendMetric } from '../lib/trend';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const WEEKS = 53;
+const LEVEL_MIX = [0, 30, 55, 78, 100] as const;
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+interface DayCell {
+  key: string;
+  label: string;
+  value: number;
+  level: number;
+  inRange: boolean;
+}
+
+interface HeatmapModel {
+  weeks: DayCell[][];
+  monthLabels: Array<string | null>;
+  max: number;
+}
+
+function buildModel(daily: DailyBucket[], metric: TrendMetric): HeatmapModel {
+  const values = new Map<string, number>();
+  let max = 0;
+  for (const bucket of daily) {
+    const value = metricOfBucket(bucket, metric);
+    values.set(bucket.date, value);
+    if (value > max) max = value;
+  }
+
+  const today = new Date();
+  today.setHours(12, 0, 0, 0); // noon avoids DST edge cases when stepping by days
+  const todayKey = dateKey(today.getTime());
+  // Align the grid start to the Monday WEEKS-1 weeks before this week's Monday.
+  const daysSinceMonday = (today.getDay() + 6) % 7;
+  const gridStartMs = today.getTime() - daysSinceMonday * DAY_MS - (WEEKS - 1) * 7 * DAY_MS;
+
+  const weeks: DayCell[][] = [];
+  const monthLabels: Array<string | null> = [];
+  let lastMonth = -1;
+
+  for (let week = 0; week < WEEKS; week++) {
+    const column: DayCell[] = [];
+    const weekStart = new Date(gridStartMs + week * 7 * DAY_MS);
+    const month = weekStart.getMonth();
+    // Label a column when the month changes at its start (skip a cramped first label).
+    monthLabels.push(month !== lastMonth && (week > 0 || weekStart.getDate() <= 7) ? MONTH_LABELS[month] : null);
+    lastMonth = month;
+
+    for (let day = 0; day < 7; day++) {
+      const cellDate = new Date(gridStartMs + (week * 7 + day) * DAY_MS);
+      const key = dateKey(cellDate.getTime());
+      const inRange = key <= todayKey;
+      const value = values.get(key) ?? 0;
+      const level = value <= 0 || max <= 0 ? 0 : Math.min(4, Math.max(1, Math.ceil((value / max) * 4)));
+      column.push({
+        key,
+        label: `${key} · ${formatMetricValue(value, metric)}`,
+        value,
+        level,
+        inRange,
+      });
+    }
+    weeks.push(column);
+  }
+
+  return { weeks, monthLabels, max };
+}
+
+function cellStyle(level: number): CSSProperties | undefined {
+  if (level === 0) return undefined;
+  return { backgroundColor: `color-mix(in oklab, var(--chart-2) ${LEVEL_MIX[level]}%, transparent)` };
+}
+
+export function ActivityHeatmap({ daily, metric }: { daily: DailyBucket[]; metric: TrendMetric }) {
+  const model = useMemo(() => buildModel(daily, metric), [daily, metric]);
+
+  return (
+    <div className="flex flex-col gap-2 overflow-x-auto">
+      <div className="flex w-max gap-[3px] pl-8">
+        {model.monthLabels.map((label, i) => (
+          <div key={i} className="w-[10px] text-[9px] leading-3 text-muted-foreground">
+            {label && <span className="absolute">{label}</span>}
+          </div>
+        ))}
+      </div>
+      <div className="flex w-max gap-1.5">
+        <div className="grid w-6 grid-rows-7 gap-[3px] text-[9px] leading-[10px] text-muted-foreground">
+          {['Mon', '', 'Wed', '', 'Fri', '', ''].map((label, i) => (
+            <span key={i} className="h-[10px]">
+              {label}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-[3px]">
+          {model.weeks.map((week, weekIndex) => (
+            <div key={weekIndex} className="grid grid-rows-7 gap-[3px]">
+              {week.map((cell) =>
+                cell.inRange ? (
+                  <div
+                    key={cell.key}
+                    title={cell.label}
+                    className="size-[10px] rounded-[2px] bg-secondary/60"
+                    style={cellStyle(cell.level)}
+                  />
+                ) : (
+                  <div key={cell.key} className="size-[10px]" />
+                ),
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+      <Inline gap="sm" align="center" className="pl-8">
+        <Inline gap="xs" align="center">
+          <Text variant="muted" className="text-[10px]">
+            less
+          </Text>
+          {LEVEL_MIX.map((_, level) => (
+            <div key={level} className="size-[10px] rounded-[2px] bg-secondary/60" style={cellStyle(level)} />
+          ))}
+          <Text variant="muted" className="text-[10px]">
+            more
+          </Text>
+        </Inline>
+        <Text variant="muted" className="text-[10px]">
+          max {formatMetricValue(model.max, metric)}/day · today is the rightmost column
+        </Text>
+      </Inline>
+    </div>
+  );
+}

--- a/plugins/sero-usage-plugin/ui/components/ProviderTable.tsx
+++ b/plugins/sero-usage-plugin/ui/components/ProviderTable.tsx
@@ -1,0 +1,116 @@
+/**
+ * By Provider · Model breakdown — expandable provider rows carrying
+ * aggregate values, with per-model rows beneath (default expanded).
+ */
+
+import { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  cn,
+} from '@sero-ai/ui';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+import { formatCost, formatCount, formatTokens } from '../../shared/format';
+import type { ModelStats, ProviderStats, TokenBreakdown } from '../../shared/types';
+
+interface NumericColumn {
+  label: string;
+  dimmed?: boolean;
+  value: (stats: { sessions: number; messages: number; cost: number; tokens: TokenBreakdown }) => string;
+}
+
+const COLUMNS: NumericColumn[] = [
+  { label: 'Sessions', value: (s) => formatCount(s.sessions) },
+  { label: 'Msgs', value: (s) => formatCount(s.messages) },
+  { label: 'Cost', value: (s) => formatCost(s.cost) },
+  { label: 'Tokens', value: (s) => formatTokens(s.tokens.total) },
+  { label: '↑ In', dimmed: true, value: (s) => formatTokens(s.tokens.input + s.tokens.cacheWrite) },
+  { label: '↓ Out', dimmed: true, value: (s) => formatTokens(s.tokens.output) },
+  { label: 'Cache', dimmed: true, value: (s) => formatTokens(s.tokens.cacheRead + s.tokens.cacheWrite) },
+];
+
+function NumericCells({ stats, dimAll }: { stats: ProviderStats | ModelStats; dimAll?: boolean }) {
+  return (
+    <>
+      {COLUMNS.map((column) => (
+        <TableCell
+          key={column.label}
+          className={cn('text-right tabular-nums', (column.dimmed || dimAll) && 'text-muted-foreground')}
+        >
+          {column.value(stats)}
+        </TableCell>
+      ))}
+    </>
+  );
+}
+
+export function ProviderTable({ providers }: { providers: ProviderStats[] }) {
+  const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
+
+  const toggle = (provider: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(provider)) {
+        next.delete(provider);
+      } else {
+        next.add(provider);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Provider / Model</TableHead>
+            {COLUMNS.map((column) => (
+              <TableHead
+                key={column.label}
+                className={cn('text-right', column.dimmed && 'text-muted-foreground/70')}
+              >
+                {column.label}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {providers.map((provider) => {
+            const isCollapsed = collapsed.has(provider.provider);
+            const Chevron = isCollapsed ? ChevronRight : ChevronDown;
+            return [
+              <TableRow key={provider.provider}>
+                <TableCell>
+                  <button
+                    type="button"
+                    onClick={() => toggle(provider.provider)}
+                    className="flex items-center gap-1.5 font-medium hover:text-foreground"
+                    aria-expanded={!isCollapsed}
+                  >
+                    <Chevron className="size-3.5 text-muted-foreground" aria-hidden />
+                    {provider.provider}
+                  </button>
+                </TableCell>
+                <NumericCells stats={provider} />
+              </TableRow>,
+              ...(isCollapsed
+                ? []
+                : provider.models.map((model) => (
+                    <TableRow key={`${provider.provider}/${model.model}`} className="hover:bg-transparent">
+                      <TableCell className="pl-9 text-muted-foreground">{model.model}</TableCell>
+                      <NumericCells stats={model} dimAll />
+                    </TableRow>
+                  ))),
+            ];
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/plugins/sero-usage-plugin/ui/components/SessionsTable.tsx
+++ b/plugins/sero-usage-plugin/ui/components/SessionsTable.tsx
@@ -1,0 +1,115 @@
+/**
+ * Per-session breakdown: top sessions by cost for the active period,
+ * sortable, with a reveal-in-folder action per row when the host has a
+ * file manager bridge.
+ */
+
+import { useMemo, useState } from 'react';
+import {
+  IconButton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+  cn,
+} from '@sero-ai/ui';
+import { ArrowDown, FolderOpen } from 'lucide-react';
+
+import { formatCost, formatCount, formatRelativeTime, formatTokens } from '../../shared/format';
+import type { SessionStats } from '../../shared/types';
+import { canRevealInFolder, revealInFolder } from '../lib/host';
+
+type SortKey = 'cost' | 'tokens' | 'lastActivity';
+
+const SORTS: Array<{ key: SortKey; label: string }> = [
+  { key: 'cost', label: 'Cost' },
+  { key: 'tokens', label: 'Tokens' },
+  { key: 'lastActivity', label: 'Last active' },
+];
+
+function sortValue(session: SessionStats, key: SortKey): number {
+  if (key === 'tokens') return session.tokens.total;
+  return session[key];
+}
+
+function workspaceName(cwd: string): string {
+  return cwd.split('/').filter(Boolean).at(-1) ?? cwd;
+}
+
+export function SessionsTable({ sessions }: { sessions: SessionStats[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>('cost');
+  const canReveal = canRevealInFolder();
+
+  const sorted = useMemo(
+    () => [...sessions].sort((a, b) => sortValue(b, sortKey) - sortValue(a, sortKey)),
+    [sessions, sortKey],
+  );
+
+  const sortHeader = (key: SortKey, label: string) => (
+    <TableHead key={key} className="text-right">
+      <button
+        type="button"
+        onClick={() => setSortKey(key)}
+        className={cn('inline-flex items-center gap-0.5', sortKey === key && 'text-foreground')}
+      >
+        {label}
+        {sortKey === key && <ArrowDown className="size-3" aria-hidden />}
+      </button>
+    </TableHead>
+  );
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Session</TableHead>
+              <TableHead>Workspace</TableHead>
+              <TableHead className="text-right">Msgs</TableHead>
+              {SORTS.map(({ key, label }) => (key === 'cost' || key === 'tokens' ? sortHeader(key, label) : null))}
+              {sortHeader('lastActivity', 'Last active')}
+              {canReveal && <TableHead className="w-8" aria-label="Actions" />}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sorted.map((session) => (
+              <TableRow key={session.id}>
+                <TableCell className="max-w-64 truncate" title={session.label}>
+                  {session.label}
+                </TableCell>
+                <TableCell className="max-w-40 truncate text-muted-foreground" title={session.cwd}>
+                  {workspaceName(session.cwd)}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{formatCount(session.messages)}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatCost(session.cost)}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatTokens(session.tokens.total)}</TableCell>
+                <TableCell className="text-right tabular-nums text-muted-foreground">
+                  {session.lastActivity > 0 ? formatRelativeTime(session.lastActivity) : '-'}
+                </TableCell>
+                {canReveal && (
+                  <TableCell>
+                    <IconButton
+                      icon={FolderOpen}
+                      label="Reveal session file in folder"
+                      size="xs"
+                      onClick={() => revealInFolder(session.path)}
+                    />
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {sessions.length >= 50 && (
+        <Text variant="muted" className="text-[11px]">
+          Showing the top 50 sessions by cost for this period.
+        </Text>
+      )}
+    </div>
+  );
+}

--- a/plugins/sero-usage-plugin/ui/components/StatTiles.tsx
+++ b/plugins/sero-usage-plugin/ui/components/StatTiles.tsx
@@ -1,0 +1,18 @@
+import { Metric, MetricGroup } from '@sero-ai/ui';
+
+import { formatCost, formatCount, formatTokens } from '../../shared/format';
+import type { PeriodStats } from '../../shared/types';
+
+export function StatTiles({ totals }: { totals: PeriodStats['totals'] }) {
+  const tokens = totals.tokens;
+  return (
+    <MetricGroup minColumnWidth={110}>
+      <Metric label="Total cost" value={formatCost(totals.cost)} />
+      <Metric label="Tokens" value={formatTokens(tokens.total)} />
+      <Metric label="Input" value={formatTokens(tokens.input + tokens.cacheWrite)} />
+      <Metric label="Output" value={formatTokens(tokens.output)} />
+      <Metric label="Sessions" value={formatCount(totals.sessions)} />
+      <Metric label="Messages" value={formatCount(totals.messages)} />
+    </MetricGroup>
+  );
+}

--- a/plugins/sero-usage-plugin/ui/components/TrendChart.tsx
+++ b/plugins/sero-usage-plugin/ui/components/TrendChart.tsx
@@ -1,0 +1,135 @@
+/**
+ * Stacked bar chart of the selected metric split by provider.
+ * Today shows per-hour bars; week and all-time views show per-day bars
+ * (docs/specs/sero-usage-plugin-spec.md §4.1 item 4).
+ */
+
+import { useMemo } from 'react';
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from '@sero-ai/ui';
+import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
+
+import { dateKey, periodBoundaries } from '../../shared/period';
+import type { DailyBucket, HourlyBucket, PeriodKey } from '../../shared/types';
+import { formatMetricValue, metricOfSlice, rankProviders, type TrendMetric } from '../lib/trend';
+
+const TOP_PROVIDERS = 5;
+const OTHER_KEY = 'other';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface TrendChartProps {
+  period: PeriodKey;
+  daily: DailyBucket[];
+  hourly: HourlyBucket[];
+  metric: TrendMetric;
+}
+
+type ChartRow = Record<string, number | string>;
+
+/** Provider names become chart config keys / CSS variable suffixes. */
+function providerKey(provider: string): string {
+  return provider.replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+function visibleDaily(period: Exclude<PeriodKey, 'today'>, daily: DailyBucket[]): DailyBucket[] {
+  if (period === 'allTime') return daily;
+  const bounds = periodBoundaries(new Date());
+  const fromMs = period === 'thisWeek' ? bounds.weekStartMs : bounds.lastWeekStartMs;
+  const toMs = period === 'thisWeek' ? Date.now() : bounds.weekStartMs - 1;
+  const buckets = new Map(daily.map((bucket) => [bucket.date, bucket]));
+  const result: DailyBucket[] = [];
+  for (let ms = fromMs; ms <= toMs; ms += DAY_MS) {
+    const key = dateKey(ms);
+    result.push(buckets.get(key) ?? { date: key, cost: 0, tokens: 0, input: 0, output: 0, messages: 0, byProvider: {} });
+  }
+  return result;
+}
+
+function shortDateLabel(date: string): string {
+  const [, month, day] = date.split('-');
+  return `${Number(day)}/${Number(month)}`;
+}
+
+function buildRows(
+  period: PeriodKey,
+  daily: DailyBucket[],
+  hourly: HourlyBucket[],
+  metric: TrendMetric,
+): { rows: ChartRow[]; providers: string[] } {
+  const buckets: Array<{ label: string; byProvider: DailyBucket['byProvider'] }> =
+    period === 'today'
+      ? Array.from({ length: 24 }, (_, hour) => {
+          const bucket = hourly.find((b) => b.hour === hour);
+          return { label: `${hour}h`, byProvider: bucket?.byProvider ?? {} };
+        })
+      : visibleDaily(period, daily).map((bucket) => ({
+          label: shortDateLabel(bucket.date),
+          byProvider: bucket.byProvider,
+        }));
+
+  const ranked = rankProviders(
+    period === 'today' ? hourly : visibleDaily(period, daily),
+    metric,
+  );
+  const top = ranked.slice(0, TOP_PROVIDERS);
+  const hasOther = ranked.length > TOP_PROVIDERS;
+
+  const rows = buckets.map((bucket) => {
+    const row: ChartRow = { label: bucket.label };
+    for (const provider of top) row[providerKey(provider)] = 0;
+    if (hasOther) row[OTHER_KEY] = 0;
+    for (const [provider, slice] of Object.entries(bucket.byProvider)) {
+      const key = top.includes(provider) ? providerKey(provider) : OTHER_KEY;
+      row[key] = ((row[key] as number) ?? 0) + metricOfSlice(slice, metric);
+    }
+    return row;
+  });
+
+  return { rows, providers: hasOther ? [...top, OTHER_KEY] : top };
+}
+
+export function TrendChart({ period, daily, hourly, metric }: TrendChartProps) {
+  const { rows, providers } = useMemo(
+    () => buildRows(period, daily, hourly, metric),
+    [period, daily, hourly, metric],
+  );
+
+  const config = useMemo(() => {
+    const entries: ChartConfig = {};
+    providers.forEach((provider, index) => {
+      const key = provider === OTHER_KEY ? OTHER_KEY : providerKey(provider);
+      entries[key] = {
+        label: provider === OTHER_KEY ? 'other' : provider,
+        color: provider === OTHER_KEY ? 'var(--muted-foreground)' : `var(--chart-${(index % 5) + 1})`,
+      };
+    });
+    return entries;
+  }, [providers]);
+
+  return (
+    <ChartContainer config={config} className="aspect-auto h-56 w-full">
+      <BarChart data={rows} margin={{ top: 4, right: 4, bottom: 0, left: 4 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="label" tickLine={false} axisLine={false} tickMargin={6} minTickGap={16} />
+        <YAxis
+          tickLine={false}
+          axisLine={false}
+          width={44}
+          tickFormatter={(value: number) => formatMetricValue(value, metric)}
+        />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <ChartLegend content={<ChartLegendContent />} />
+        {providers.map((provider) => {
+          const key = provider === OTHER_KEY ? OTHER_KEY : providerKey(provider);
+          return <Bar key={key} dataKey={key} stackId="usage" fill={`var(--color-${key})`} radius={[2, 2, 0, 0]} />;
+        })}
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/plugins/sero-usage-plugin/ui/index.html
+++ b/plugins/sero-usage-plugin/ui/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sero Usage (remote)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/plugins/sero-usage-plugin/ui/lib/host.ts
+++ b/plugins/sero-usage-plugin/ui/lib/host.ts
@@ -1,0 +1,21 @@
+/**
+ * Generic host shell bridge — the same seam the desktop status bar uses
+ * to reveal the workspace folder. Absent on hosts without a file manager
+ * (e.g. web remote), in which case reveal actions are hidden.
+ */
+
+interface SeroShellBridge {
+  shell?: { showItemInFolder?(fullPath: string): Promise<void> };
+}
+
+function seroShell(): SeroShellBridge['shell'] {
+  return (window as unknown as { sero?: SeroShellBridge }).sero?.shell;
+}
+
+export function canRevealInFolder(): boolean {
+  return typeof seroShell()?.showItemInFolder === 'function';
+}
+
+export function revealInFolder(fullPath: string): void {
+  void seroShell()?.showItemInFolder?.(fullPath);
+}

--- a/plugins/sero-usage-plugin/ui/lib/trend.ts
+++ b/plugins/sero-usage-plugin/ui/lib/trend.ts
@@ -1,0 +1,46 @@
+/**
+ * Trend metric selection and bucket → chart-row mapping shared by the
+ * heatmap, trend chart, and widget sparkline.
+ */
+
+import { formatCost, formatCount, formatTokens } from '../../shared/format';
+import type { DailyBucket, HourlyBucket, ProviderSlice } from '../../shared/types';
+
+export const TREND_METRICS = ['tokens', 'cost', 'messages'] as const;
+export type TrendMetric = (typeof TREND_METRICS)[number];
+
+export const TREND_METRIC_LABELS: Record<TrendMetric, string> = {
+  tokens: 'Tokens',
+  cost: 'Cost',
+  messages: 'Messages',
+};
+
+export function metricOfBucket(bucket: { cost: number; tokens: number; messages: number }, metric: TrendMetric): number {
+  return bucket[metric];
+}
+
+export function metricOfSlice(slice: ProviderSlice, metric: TrendMetric): number {
+  return slice[metric];
+}
+
+export function formatMetricValue(value: number, metric: TrendMetric): string {
+  if (metric === 'cost') return formatCost(value);
+  if (metric === 'messages') return formatCount(value);
+  return formatTokens(value);
+}
+
+/**
+ * Providers ranked by the chosen metric across the given buckets.
+ * Everything past the top N is grouped as "other" by the chart.
+ */
+export function rankProviders(buckets: Array<DailyBucket | HourlyBucket>, metric: TrendMetric): string[] {
+  const totals = new Map<string, number>();
+  for (const bucket of buckets) {
+    for (const [provider, slice] of Object.entries(bucket.byProvider)) {
+      totals.set(provider, (totals.get(provider) ?? 0) + metricOfSlice(slice, metric));
+    }
+  }
+  return Array.from(totals.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([provider]) => provider);
+}

--- a/plugins/sero-usage-plugin/ui/lib/useAutoRefresh.ts
+++ b/plugins/sero-usage-plugin/ui/lib/useAutoRefresh.ts
@@ -1,0 +1,79 @@
+/**
+ * Staleness-driven refresh shared by the Usage app and the dashboard
+ * widget (docs/specs/sero-usage-plugin-spec.md §3.3). Both surfaces may
+ * mount together; the extension-side in-flight guard makes the concurrent
+ * calls share one scan.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAppTools } from '@sero-ai/app-runtime';
+
+import type { UsageState } from '../../shared/types';
+
+const CHECK_EVERY_MS = 60_000;
+
+export interface UsageRefresh {
+  /** Manual refresh — always rescans. */
+  refresh: () => void;
+  refreshing: boolean;
+  error: string | null;
+}
+
+export function useAutoRefresh(state: UsageState): UsageRefresh {
+  const { run } = useAppTools();
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const inFlightRef = useRef(false);
+
+  const doRefresh = useCallback(
+    async (force: boolean) => {
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      setRefreshing(true);
+      try {
+        const result = await run('usage', { action: 'refresh', force });
+        if (result.isError || result.text.startsWith('Error:')) {
+          setError(result.text || 'Refresh failed');
+        } else {
+          setError(null);
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Refresh failed');
+      } finally {
+        inFlightRef.current = false;
+        setRefreshing(false);
+      }
+    },
+    [run],
+  );
+
+  const refresh = useCallback(() => {
+    void doRefresh(true);
+  }, [doRefresh]);
+
+  // External side effect (interval timer): check staleness against the
+  // latest state once a minute, and once on mount to catch up after Sero
+  // was closed. Interval 0 = manual only (still populates an empty state).
+  useEffect(() => {
+    const check = () => {
+      const current = stateRef.current;
+      const intervalMinutes = current.settings.refreshIntervalMinutes;
+      if (current.lastRefreshedAt === null) {
+        void doRefresh(false);
+        return;
+      }
+      if (intervalMinutes <= 0) return;
+      if (Date.now() - current.lastRefreshedAt >= intervalMinutes * 60_000) {
+        void doRefresh(false);
+      }
+    };
+    check();
+    const id = window.setInterval(check, CHECK_EVERY_MS);
+    return () => window.clearInterval(id);
+  }, [doRefresh]);
+
+  return { refresh, refreshing, error };
+}

--- a/plugins/sero-usage-plugin/ui/styles.css
+++ b/plugins/sero-usage-plugin/ui/styles.css
@@ -1,0 +1,5 @@
+@import "@sero-ai/ui/styles/plugin.css";
+
+/* REQUIRED: scan plugin-local UI files so external remotes emit the utility
+   classes they use instead of accidentally depending on host CSS. */
+@source "./**/*.{ts,tsx}";

--- a/plugins/sero-usage-plugin/ui/tsconfig.json
+++ b/plugins/sero-usage-plugin/ui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["./**/*", "../shared/**/*"]
+}

--- a/plugins/sero-usage-plugin/ui/vite-env.d.ts
+++ b/plugins/sero-usage-plugin/ui/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/plugins/sero-usage-plugin/ui/widgets/UsageWidget.tsx
+++ b/plugins/sero-usage-plugin/ui/widgets/UsageWidget.tsx
@@ -1,0 +1,115 @@
+/**
+ * Dashboard widget — at-a-glance usage summary. Content scales with tile
+ * width via container queries (WidgetContent provides the boundary):
+ * base 1×1 shows today's cost; wider tiles add this week + a 14-day
+ * sparkline; 3×2+ adds this week's top providers.
+ */
+
+import { useMemo } from 'react';
+import { useAppState } from '@sero-ai/app-runtime';
+import {
+  EmptyState,
+  Inline,
+  ItemList,
+  ItemListItem,
+  Metric,
+  Stack,
+  Text,
+  WidgetContent,
+} from '@sero-ai/ui';
+import { ChartColumn } from 'lucide-react';
+
+import { formatCost, formatTokens } from '../../shared/format';
+import type { UsageState } from '../../shared/types';
+import { DEFAULT_STATE, normalizeUsageState } from '../../shared/types';
+import { useAutoRefresh } from '../lib/useAutoRefresh';
+// Every directly-exposed MF entry must import its own stylesheet so external
+// remotes ship their own CSS assets.
+import '../styles.css';
+
+const SPARKLINE_DAYS = 14;
+
+function Sparkline({ state }: { state: UsageState }) {
+  const bars = useMemo(() => {
+    const recent = state.daily.slice(-SPARKLINE_DAYS);
+    const max = Math.max(1, ...recent.map((bucket) => bucket.tokens));
+    return recent.map((bucket) => ({
+      date: bucket.date,
+      label: `${bucket.date} · ${formatTokens(bucket.tokens)} tokens`,
+      heightPct: Math.max(6, Math.round((bucket.tokens / max) * 100)),
+      empty: bucket.tokens === 0,
+    }));
+  }, [state.daily]);
+
+  if (bars.length === 0) return null;
+  return (
+    <div className="flex h-10 items-end gap-[3px]" role="img" aria-label="Tokens per day, last 14 days">
+      {bars.map((bar) => (
+        <div
+          key={bar.date}
+          title={bar.label}
+          className="min-w-1 flex-1 rounded-[2px]"
+          style={{
+            height: `${bar.heightPct}%`,
+            backgroundColor: bar.empty ? 'var(--surface-flat, var(--secondary))' : 'var(--chart-2)',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function UsageWidget() {
+  const [rawState] = useAppState<UsageState>(DEFAULT_STATE);
+  const state = useMemo(() => normalizeUsageState(rawState), [rawState]);
+  useAutoRefresh(state);
+
+  const today = state.periods.today.totals;
+  const week = state.periods.thisWeek.totals;
+  const topProviders = state.periods.thisWeek.providers.slice(0, 3);
+  const hasAnyData = state.periods.allTime.totals.messages > 0;
+
+  if (!hasAnyData) {
+    return (
+      <WidgetContent>
+        <EmptyState icon={ChartColumn} title="No usage yet" />
+      </WidgetContent>
+    );
+  }
+
+  return (
+    <WidgetContent>
+      <Stack gap="sm" fill>
+        <Inline gap="lg" align="start">
+          <Metric label="Cost today" value={formatCost(today.cost)} supporting={`${formatTokens(today.tokens.total)} tokens`} />
+          <div className="hidden @[280px]:block">
+            <Metric label="This week" value={formatCost(week.cost)} supporting={`${formatTokens(week.tokens.total)} tokens`} />
+          </div>
+        </Inline>
+
+        <div className="hidden @[280px]:block">
+          <Sparkline state={state} />
+        </div>
+
+        {topProviders.length > 0 && (
+          <div className="hidden min-h-0 @[440px]:block">
+            <Stack gap="none" scroll>
+              <Text variant="label">Top providers this week</Text>
+              <ItemList>
+                {topProviders.map((provider) => (
+                  <ItemListItem
+                    key={provider.provider}
+                    primary={provider.provider}
+                    trailing={formatCost(provider.cost)}
+                  />
+                ))}
+              </ItemList>
+            </Stack>
+          </div>
+        )}
+      </Stack>
+    </WidgetContent>
+  );
+}
+
+export default UsageWidget;

--- a/plugins/sero-usage-plugin/ui/widgets/UsageWidget.tsx
+++ b/plugins/sero-usage-plugin/ui/widgets/UsageWidget.tsx
@@ -1,8 +1,9 @@
 /**
  * Dashboard widget — at-a-glance usage summary. Content scales with tile
  * width via container queries (WidgetContent provides the boundary):
- * base 1×1 shows today's cost; wider tiles add this week + a 14-day
- * sparkline; 3×2+ adds this week's top providers.
+ * base shows today's cost; wider tiles add this week (with a week-over-week
+ * delta) and a token trend chart that grows to fill the tile; widest tiles
+ * add this week's top providers with cost-share bars.
  */
 
 import { useMemo } from 'react';
@@ -10,8 +11,7 @@ import { useAppState } from '@sero-ai/app-runtime';
 import {
   EmptyState,
   Inline,
-  ItemList,
-  ItemListItem,
+  type MetricTrend,
   Metric,
   Stack,
   Text,
@@ -20,7 +20,7 @@ import {
 import { ChartColumn } from 'lucide-react';
 
 import { formatCost, formatTokens } from '../../shared/format';
-import type { UsageState } from '../../shared/types';
+import type { DailyBucket, ProviderStats, UsageState } from '../../shared/types';
 import { DEFAULT_STATE, normalizeUsageState } from '../../shared/types';
 import { useAutoRefresh } from '../lib/useAutoRefresh';
 // Every directly-exposed MF entry must import its own stylesheet so external
@@ -28,10 +28,21 @@ import { useAutoRefresh } from '../lib/useAutoRefresh';
 import '../styles.css';
 
 const SPARKLINE_DAYS = 14;
+const TOP_PROVIDERS = 3;
+// Distinct series colours so provider bars read apart at a glance.
+const PROVIDER_COLORS = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)'];
 
-function Sparkline({ state }: { state: UsageState }) {
+/** Week-over-week change, shown as a signed % delta next to the week metric. */
+function weekTrend(current: number, previous: number): MetricTrend | undefined {
+  if (previous <= 0) return undefined;
+  const pct = Math.round(((current - previous) / previous) * 100);
+  if (pct === 0) return { direction: 'flat', value: '0%' };
+  return { direction: pct > 0 ? 'up' : 'down', value: `${pct > 0 ? '+' : ''}${pct}%` };
+}
+
+function Sparkline({ daily }: { daily: DailyBucket[] }) {
   const bars = useMemo(() => {
-    const recent = state.daily.slice(-SPARKLINE_DAYS);
+    const recent = daily.slice(-SPARKLINE_DAYS);
     const max = Math.max(1, ...recent.map((bucket) => bucket.tokens));
     return recent.map((bucket) => ({
       date: bucket.date,
@@ -39,16 +50,20 @@ function Sparkline({ state }: { state: UsageState }) {
       heightPct: Math.max(6, Math.round((bucket.tokens / max) * 100)),
       empty: bucket.tokens === 0,
     }));
-  }, [state.daily]);
+  }, [daily]);
 
   if (bars.length === 0) return null;
   return (
-    <div className="flex h-10 items-end gap-[3px]" role="img" aria-label="Tokens per day, last 14 days">
+    <div
+      className="flex min-h-10 flex-1 items-end gap-[3px]"
+      role="img"
+      aria-label={`Tokens per day, last ${SPARKLINE_DAYS} days`}
+    >
       {bars.map((bar) => (
         <div
           key={bar.date}
           title={bar.label}
-          className="min-w-1 flex-1 rounded-[2px]"
+          className="min-w-1 flex-1 rounded-[2px] transition-colors"
           style={{
             height: `${bar.heightPct}%`,
             backgroundColor: bar.empty ? 'var(--surface-flat, var(--secondary))' : 'var(--chart-2)',
@@ -59,6 +74,45 @@ function Sparkline({ state }: { state: UsageState }) {
   );
 }
 
+/** Top providers this week as labelled cost-share bars. */
+function ProviderShare({ providers }: { providers: ProviderStats[] }) {
+  // Share is by cost, falling back to tokens so local/free models still rank.
+  const byCost = providers.some((provider) => provider.cost > 0);
+  const total = Math.max(
+    1,
+    ...providers.map((provider) => (byCost ? provider.cost : provider.tokens.total)),
+  );
+  return (
+    <Stack gap="xs">
+      <Text variant="label">Top providers this week</Text>
+      {providers.map((provider, index) => {
+        const value = byCost ? provider.cost : provider.tokens.total;
+        return (
+          <div key={provider.provider} className="flex flex-col gap-1">
+            <Inline justify="between" align="center" gap="sm">
+              <Text variant="body" className="min-w-0 truncate">
+                {provider.provider}
+              </Text>
+              <Text variant="numeric" className="shrink-0 text-muted-foreground">
+                {byCost ? formatCost(provider.cost) : `${formatTokens(provider.tokens.total)} tok`}
+              </Text>
+            </Inline>
+            <div className="h-1.5 overflow-hidden rounded-full bg-[var(--surface-flat,var(--secondary))]">
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${Math.max(3, Math.round((value / total) * 100))}%`,
+                  backgroundColor: PROVIDER_COLORS[index % PROVIDER_COLORS.length],
+                }}
+              />
+            </div>
+          </div>
+        );
+      })}
+    </Stack>
+  );
+}
+
 export function UsageWidget() {
   const [rawState] = useAppState<UsageState>(DEFAULT_STATE);
   const state = useMemo(() => normalizeUsageState(rawState), [rawState]);
@@ -66,7 +120,8 @@ export function UsageWidget() {
 
   const today = state.periods.today.totals;
   const week = state.periods.thisWeek.totals;
-  const topProviders = state.periods.thisWeek.providers.slice(0, 3);
+  const lastWeek = state.periods.lastWeek.totals;
+  const topProviders = state.periods.thisWeek.providers.slice(0, TOP_PROVIDERS);
   const hasAnyData = state.periods.allTime.totals.messages > 0;
 
   if (!hasAnyData) {
@@ -80,31 +135,32 @@ export function UsageWidget() {
   return (
     <WidgetContent>
       <Stack gap="sm" fill>
-        <Inline gap="lg" align="start">
-          <Metric label="Cost today" value={formatCost(today.cost)} supporting={`${formatTokens(today.tokens.total)} tokens`} />
-          <div className="hidden @[280px]:block">
-            <Metric label="This week" value={formatCost(week.cost)} supporting={`${formatTokens(week.tokens.total)} tokens`} />
+        <Inline gap="lg" align="start" justify="between">
+          <Metric
+            label="Cost today"
+            value={formatCost(today.cost)}
+            supporting={`${formatTokens(today.tokens.total)} tokens`}
+          />
+          <div className="hidden @[240px]:block">
+            <Metric
+              label="This week"
+              value={formatCost(week.cost)}
+              supporting={`${formatTokens(week.tokens.total)} tokens`}
+              trend={weekTrend(week.cost, lastWeek.cost)}
+            />
           </div>
         </Inline>
 
-        <div className="hidden @[280px]:block">
-          <Sparkline state={state} />
+        <div className="hidden min-h-10 flex-1 flex-col justify-end gap-1 @[240px]:flex">
+          <Sparkline daily={state.daily} />
+          <Text variant="muted" className="text-[10px] uppercase tracking-wide">
+            Tokens · last {SPARKLINE_DAYS} days
+          </Text>
         </div>
 
         {topProviders.length > 0 && (
-          <div className="hidden min-h-0 @[440px]:block">
-            <Stack gap="none" scroll>
-              <Text variant="label">Top providers this week</Text>
-              <ItemList>
-                {topProviders.map((provider) => (
-                  <ItemListItem
-                    key={provider.provider}
-                    primary={provider.provider}
-                    trailing={formatCost(provider.cost)}
-                  />
-                ))}
-              </ItemList>
-            </Stack>
+          <div className="hidden @[380px]:block">
+            <ProviderShare providers={topProviders} />
           </div>
         )}
       </Stack>

--- a/plugins/sero-usage-plugin/vite.config.ts
+++ b/plugins/sero-usage-plugin/vite.config.ts
@@ -1,0 +1,52 @@
+// Vite config lives at the package root (not inside ui/).
+// `base: './'` in production is required so installed plugin remotes resolve
+// assets via the `sero-ext://` scheme.
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { federation } from '@module-federation/vite';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  base: process.env.NODE_ENV === 'production' ? './' : '/',
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: 'sero_usage',
+      filename: 'remoteEntry.js',
+      dts: false,
+      manifest: true,
+      exposes: {
+        './UsageApp': './ui/UsageApp.tsx',
+        './UsageWidget': './ui/widgets/UsageWidget.tsx',
+      },
+      shared: {
+        react: { singleton: true },
+        'react/': { singleton: true },
+        'react-dom': { singleton: true },
+        'react-dom/': { singleton: true },
+        // NOTE: @sero-ai/app-runtime is NOT shared via MF.
+        // The host provides a globalThis singleton; we just excludeDeps below.
+      },
+    }),
+  ],
+  server: {
+    // Must match `sero.app.devPort` in package.json.
+    port: 5189,
+    strictPort: true,
+    origin: 'http://localhost:5189',
+  },
+  optimizeDeps: {
+    exclude: ['@sero-ai/app-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client'],
+  },
+  build: {
+    target: 'esnext',
+    outDir: 'dist/ui',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: 'ui/index.html',
+    },
+  },
+});

--- a/plugins/sero-usage-plugin/vitest.config.ts
+++ b/plugins/sero-usage-plugin/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['extension/__tests__/**/*.test.ts', 'shared/__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1092,6 +1092,73 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  plugins/sero-usage-plugin:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: catalog:peer
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)
+      '@earendil-works/pi-coding-agent':
+        specifier: catalog:peer
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)
+      '@earendil-works/pi-tui':
+        specifier: catalog:peer
+        version: 0.80.6
+      typebox:
+        specifier: 'catalog:'
+        version: 1.1.38
+      zod:
+        specifier: catalog:peer
+        version: 4.4.3
+    devDependencies:
+      '@module-federation/vite':
+        specifier: 'catalog:'
+        version: 1.11.0(rollup@4.60.4)(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@sero-ai/app-runtime':
+        specifier: workspace:*
+        version: link:../../packages/app-runtime
+      '@sero-ai/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.1.18(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.15
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.563.0(react@19.2.5)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
+      recharts:
+        specifier: 3.9.2
+        version: 3.9.2(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@18.3.1)(react@19.2.5)(redux@5.0.1)
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 4.1.18
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+
   plugins/sero-user-feedback-plugin:
     dependencies:
       '@earendil-works/pi-coding-agent':
@@ -15359,6 +15426,20 @@ snapshots:
       - ws
       - zod
 
+  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)
+      ignore: 7.0.5
+      typebox: 1.1.38
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
@@ -15419,6 +15500,27 @@ snapshots:
       http-proxy-agent: 7.0.2(supports-color@7.2.0)
       https-proxy-agent: 7.0.6(supports-color@7.2.0)
       openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2(supports-color@7.2.0)
+      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      openai: 6.26.0(ws@8.18.0)(zod@4.4.3)
       partial-json: 0.1.7
       typebox: 1.1.38
     transitivePeerDependencies:
@@ -15505,6 +15607,36 @@ snapshots:
     dependencies:
       '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(supports-color@7.2.0)(zod@4.4.3))(supports-color@7.2.0)(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.80.6
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.1.38
+      undici: 8.5.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-coding-agent@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.18.0)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.80.6
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -25451,6 +25583,11 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  openai@6.26.0(ws@8.18.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.18.0
+      zod: 4.4.3
 
   openai@6.26.0(ws@8.20.0)(zod@4.4.3):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8122,10 +8122,6 @@ packages:
     resolution: {integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==}
     engines: {node: '>=10.13.0'}
 
-  enhanced-resolve@5.24.0:
-    resolution: {integrity: sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.24.2:
     resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
@@ -15680,7 +15676,7 @@ snapshots:
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3(supports-color@7.2.0)
       dir-compare: 4.2.0
-      fs-extra: 11.3.4
+      fs-extra: 11.3.6
       minimatch: 9.0.9
       plist: 3.1.0
     transitivePeerDependencies:
@@ -19536,7 +19532,7 @@ snapshots:
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.24.0
+      enhanced-resolve: 5.24.2
       jiti: 2.7.0
       lightningcss: 1.30.2
       magic-string: 0.30.21
@@ -20731,7 +20727,7 @@ snapshots:
       on-finished: 2.4.1
       qs: 6.15.0
       raw-body: 3.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -21042,7 +21038,7 @@ snapshots:
   cmake-js@8.0.0:
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
       node-api-headers: 1.9.0
       rc: 1.2.8
       semver: 7.8.1
@@ -21979,11 +21975,6 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
-  enhanced-resolve@5.24.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
   enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -22577,7 +22568,7 @@ snapshots:
   fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fs-extra@11.3.6:
@@ -22585,7 +22576,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -23321,7 +23311,7 @@ snapshots:
       commander: 10.0.1
       eventemitter3: 5.0.4
       filenamify: 6.0.0
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
       is-unicode-supported: 2.1.0
       lifecycle-utils: 2.1.0
       lodash.debounce: 4.0.8
@@ -27056,7 +27046,7 @@ snapshots:
 
   rspack-plugin-virtual-module@0.1.13:
     dependencies:
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
 
   rspress@1.47.1(tslib@2.8.1)(webpack@5.106.2):
     dependencies:
@@ -28379,7 +28369,7 @@ snapshots:
     dependencies:
       bluebird: 3.7.2
       duplexer2: 0.1.4
-      fs-extra: 11.3.5
+      fs-extra: 11.3.6
       graceful-fs: 4.2.11
       node-int64: 0.4.0
     optional: true


### PR DESCRIPTION
Specifies and implements a global sero-usage-plugin that aggregates per-profile AI usage from session jsonl files into a Usage app (stat tiles, activity heatmap, provider/model table, per-session breakdown) and a dashboard widget, with user-selectable auto-refresh and an incremental scan cache.

## Dashboard widget

Reworked the summary widget so it earns its space at every size:
- **Week-over-week cost delta** on the This-week metric (signed % arrow).
- **Token trend chart** (last 14 days) that grows to fill the tile — fixes the previously near-empty 2×2 tile.
- **Top-provider cost-share bars** for the week, falling back to token share when costs are $0 (local/free models).

Responsive: 1×1 shows today's cost; ≥240px adds the week metric + trend chart; ≥380px adds the provider bars.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D1HUaZjFZwDvZGLAe22v7V