### PR TITLE
feat(cron): surface scheduled Orchestrator loops with editable schedules

### DIFF
--- a/apps/docs-site/docs/guide/scheduler-reminders.md
+++ b/apps/docs-site/docs/guide/scheduler-reminders.md
@@ -49,9 +49,9 @@ You can use Scheduler from a few surfaces:
   checking status.
 - **Agent tools** — `current_time`, `cron`, and `reminder`.
 
-The app's main tabs are **Jobs**, **Reminders**, and **History**. The app defaults
-to the Reminders view and includes a top status area for scheduler state,
-autostart, and notification settings.
+The app's main tabs are **Jobs**, **Reminders**, **Loops**, and **History**. The
+app defaults to the Reminders view and includes a top status area for scheduler
+state, autostart, and notification settings.
 
 The widget can show whether the scheduler is active or paused, counts for jobs
 and reminders, a few upcoming items, and recent job-result dots. Treat widget
@@ -65,6 +65,19 @@ The editor view is where schedule, prompt, model, and missed-run behavior become
 explicit. Review these fields carefully before enabling a job.
 
 ![Cron jobs editor](../assets/images/cron-jobs-editor.jpg)
+
+## Scheduled Orchestrator loops
+
+The **Loops** tab lists the active workspace's Orchestrator loops that run on a
+schedule. Loops are created and managed in the Orchestrator app — this tab is a
+window into them:
+
+- **Edit schedule** changes the loop's cron schedule (evaluated in UTC).
+- **Pause / Resume** stops or re-arms the schedule without touching the loop.
+- **Open in Orchestrator** jumps to the loop's details.
+
+Loop schedules are fired by Orchestrator, not by the cron scheduler — they run
+even when the scheduler here is stopped.
 
 ## Start, stop, and check status with `/cron`
 

--- a/apps/docs-site/docs/guide/scheduler-reminders.md
+++ b/apps/docs-site/docs/guide/scheduler-reminders.md
@@ -73,8 +73,13 @@ schedule. Loops are created and managed in the Orchestrator app — this tab is 
 window into them:
 
 - **Edit schedule** changes the loop's cron schedule (evaluated in UTC).
-- **Pause / Resume** stops or re-arms the schedule without touching the loop.
+- **Pause / Resume** stops or re-arms only the schedule. A loop that also runs
+  on events (shown with an **Events** badge) keeps firing on those events while
+  its schedule is paused.
 - **Open in Orchestrator** jumps to the loop's details.
+
+A schedule that has reached its run limit shows **Run limit reached** and can no
+longer be edited or resumed — restart the loop in Orchestrator to run it again.
 
 Loop schedules are fired by Orchestrator, not by the cron scheduler — they run
 even when the scheduler here is stopped.

--- a/apps/docs-site/docs/reference/orchestrator.md
+++ b/apps/docs-site/docs/reference/orchestrator.md
@@ -198,7 +198,8 @@ read-only in the loop's summary line, with the event details on hover.
 The cron schedule is the one exception: the Scheduler app's **Loops** tab lists
 every scheduled loop in the workspace and can edit or pause the schedule
 directly (the `set_schedule` action). Only the schedule is editable there — the
-loop itself is still managed in Orchestrator.
+loop itself is still managed in Orchestrator. Pausing a hybrid loop's schedule
+stops only its scheduled runs; it keeps firing on its events.
 
 ### Event sources
 

--- a/apps/docs-site/docs/reference/orchestrator.md
+++ b/apps/docs-site/docs/reference/orchestrator.md
@@ -29,6 +29,7 @@ Actions: `create`, `list`, `show`, `activate`, `pause`, `resume`, `stop`,
 /orchestrator create <prompt>
 /orchestrator create --deliver <destination> <prompt>
 /orchestrator set_delivery <loopId> <destination>
+/orchestrator set_schedule <loopId> <triggerId> <cron schedule (UTC)>
 /orchestrator list
 /orchestrator show <loopId>
 /orchestrator activate <loopId>
@@ -190,10 +191,14 @@ Sero was closed runs once on next open (missed fires collapse into one catch-up
 run).
 
 The schedule, events, and stop condition are authored in the prompt and changed
-with **Refine**, never through a form. Write them in plain language — "every
-morning", "when CI fails on my PRs", "whenever docs/ changes" — and Sero
-derives the trigger. They show read-only in the loop's summary line, with the
-event details on hover.
+with **Refine**. Write them in plain language — "every morning", "when CI fails
+on my PRs", "whenever docs/ changes" — and Sero derives the trigger. They show
+read-only in the loop's summary line, with the event details on hover.
+
+The cron schedule is the one exception: the Scheduler app's **Loops** tab lists
+every scheduled loop in the workspace and can edit or pause the schedule
+directly (the `set_schedule` action). Only the schedule is editable there — the
+loop itself is still managed in Orchestrator.
 
 ### Event sources
 

--- a/packages/app-runtime/src/app-launch.ts
+++ b/packages/app-runtime/src/app-launch.ts
@@ -1,0 +1,44 @@
+/**
+ * Cross-app navigation — open another Sero app, optionally handing it launch
+ * params (e.g. the Scheduler app opening the Orchestrator on a specific loop).
+ *
+ * Only the active app is mounted, so the target app always mounts fresh and can
+ * consume its pending params in a state initializer. The registry is a
+ * globalThis singleton so all module-federation copies share it, matching the
+ * AppContext pattern.
+ */
+
+import { getSeroApi } from './sero-bridge';
+
+declare global {
+  var __sero_app_launch_params__: Map<string, Record<string, unknown>> | undefined;
+}
+
+function getRegistry(): Map<string, Record<string, unknown>> {
+  globalThis.__sero_app_launch_params__ ??= new Map();
+  return globalThis.__sero_app_launch_params__;
+}
+
+/**
+ * Switch the shell to another app. Optional `params` are held for the target
+ * app to pick up via `consumeAppLaunchParams` when it mounts. Resolves false
+ * when the app is unknown or the shell doesn't expose app control.
+ */
+export async function openSeroApp(appId: string, params?: Record<string, unknown>): Promise<boolean> {
+  if (params) getRegistry().set(appId, params);
+  const opened = (await getSeroApi().appControl?.open(appId)) ?? false;
+  if (!opened) getRegistry().delete(appId);
+  return opened;
+}
+
+/**
+ * Take (and clear) the launch params another app handed to `openSeroApp`.
+ * Call from a mount-time state initializer; returns undefined when the app
+ * was opened without params.
+ */
+export function consumeAppLaunchParams<T extends Record<string, unknown>>(appId: string): T | undefined {
+  const registry = getRegistry();
+  const params = registry.get(appId);
+  registry.delete(appId);
+  return params as T | undefined;
+}

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -16,6 +16,7 @@ export { useSubagentContext, type UseSubagentContextResult } from './use-subagen
 export { useContextPresets, type UseContextPresetsResult } from './use-context-presets';
 export { useTheme, type UseThemeResult } from './use-theme';
 export { getSeroApi } from './sero-bridge';
+export { openSeroApp, consumeAppLaunchParams } from './app-launch';
 export type { AppModelInfo, AppModelGroup } from './sero-bridge';
 export type { AppToolContentBlock, AppToolImageContent, AppToolResult, AppToolTextContent } from '@sero-ai/common';
 export { registerWidget, getRuntimeWidgets, onWidgetRegistryChange } from './widget-registry';

--- a/packages/app-runtime/src/sero-bridge.ts
+++ b/packages/app-runtime/src/sero-bridge.ts
@@ -43,6 +43,11 @@ export interface SeroAppAgentBridge {
   ): Promise<AppToolResult>;
 }
 
+export interface SeroAppControlBridge {
+  /** Switch the shell to the app with this id. False when the app is unknown. */
+  open(appId: string): Promise<boolean>;
+}
+
 export interface SeroGitAppBridge {
   run(workspaceId: string, params: GitManagerRequest): Promise<GitActionResult>;
 }
@@ -88,6 +93,7 @@ export interface SeroContextPresetsBridge {
 export interface SeroBridge {
   appState: SeroWindowAppStateBridge;
   appAgent: SeroAppAgentBridge;
+  appControl?: SeroAppControlBridge;
   gitApp?: SeroGitAppBridge;
   webApp?: SeroWebAppBridge;
   editor?: SeroEditorBridge;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -249,6 +249,18 @@ export type {
   CronState,
 } from './cron-contract';
 
+export {
+  ORCHESTRATOR_APP_ID,
+  ORCHESTRATOR_INDEX_FILE,
+} from './orchestrator-contract';
+export type {
+  OrchestratorLoopStatus,
+  OrchestratorScheduleSummary,
+  OrchestratorScheduledLoopView,
+  OrchestratorIndexView,
+  OrchestratorSetScheduleParams,
+} from './orchestrator-contract';
+
 export type {
   PluginDevSessionStatus,
   PluginDevSessionUiMode,

--- a/packages/common/src/orchestrator-contract.ts
+++ b/packages/common/src/orchestrator-contract.ts
@@ -25,8 +25,16 @@ export interface OrchestratorScheduleSummary {
   /** ISO timestamp of the next scheduled fire (absent when paused or exhausted). */
   nextFireAt?: string;
   lastFireAt?: string;
-  /** True when the schedule is paused (the loop itself may still be active). */
-  disabled?: boolean;
+  /**
+   * True when the user paused the cron schedule (resumable). A hybrid trigger
+   * still fires on its events while paused — only the schedule is stopped.
+   */
+  paused?: boolean;
+  /**
+   * True when the trigger hit its declared run limit (maxFires) — it will not
+   * fire again and can't be resumed; the loop must be restarted in Orchestrator.
+   */
+  exhausted?: boolean;
 }
 
 /** The subset of a loop-index entry that external surfaces rely on. */

--- a/packages/common/src/orchestrator-contract.ts
+++ b/packages/common/src/orchestrator-contract.ts
@@ -1,0 +1,56 @@
+/**
+ * Cross-plugin contract for the Orchestrator's scheduled loops.
+ *
+ * The Orchestrator app (workspace-scoped) maintains a small watched loop index;
+ * other surfaces — currently the Scheduler (cron) app — read that index to list
+ * scheduled loops, deep-link back into the Orchestrator, and edit a loop's
+ * schedule through the `orchestrator` tool. Keeping the shared shapes here makes
+ * producer/consumer drift a typecheck error instead of a runtime mismatch.
+ */
+
+export const ORCHESTRATOR_APP_ID = 'orchestrator';
+
+/** The Orchestrator's watched loop index, relative to the workspace root. */
+export const ORCHESTRATOR_INDEX_FILE = '.sero/apps/orchestrator/index.json';
+
+export type OrchestratorLoopStatus = 'draft' | 'active' | 'blocked' | 'complete' | 'disabled';
+
+/** Compact view of one scheduled (cron/hybrid) trigger, embedded in the loop index. */
+export interface OrchestratorScheduleSummary {
+  triggerId: string;
+  /** 'cron' fires purely on schedule; 'hybrid' also fires on events. */
+  type: 'cron' | 'hybrid';
+  /** 5-field cron expression (minute hour dom month dow), evaluated in UTC. */
+  schedule: string;
+  /** ISO timestamp of the next scheduled fire (absent when paused or exhausted). */
+  nextFireAt?: string;
+  lastFireAt?: string;
+  /** True when the schedule is paused (the loop itself may still be active). */
+  disabled?: boolean;
+}
+
+/** The subset of a loop-index entry that external surfaces rely on. */
+export interface OrchestratorScheduledLoopView {
+  id: string;
+  title: string;
+  status: OrchestratorLoopStatus;
+  /** Present only when the loop has cron/hybrid triggers carrying a schedule. */
+  schedules?: OrchestratorScheduleSummary[];
+  updatedAt: string;
+}
+
+/** The watched index file shape (the externally consumed subset). */
+export interface OrchestratorIndexView {
+  loops: OrchestratorScheduledLoopView[];
+}
+
+/** Flat params for the `orchestrator` tool's `set_schedule` action (cross-app schedule edits). */
+export interface OrchestratorSetScheduleParams {
+  action: 'set_schedule';
+  loopId: string;
+  triggerId: string;
+  /** New 5-field cron expression (UTC). Omit to keep the current one. */
+  schedule?: string;
+  /** Pause (true) or resume (false) the schedule. Omit to keep the current state. */
+  scheduleDisabled?: boolean;
+}

--- a/plugins/sero-cron-plugin/README.md
+++ b/plugins/sero-cron-plugin/README.md
@@ -20,8 +20,9 @@ React UI is Sero-only.
   accessible via the 🔔 button in the scheduler bar.
 - **Job completion notifications** — desktop notification when any cron job
   finishes (✅ success or ❌ failure with duration).
-- **Visual dashboard** — three tabs (Reminders, Jobs, History) for managing
-  everything. Live cron expression validation with human-readable previews.
+- **Visual dashboard** — four tabs (Reminders, Jobs, Loops, History) for
+  managing everything. Live cron expression validation with human-readable
+  previews.
 - **Run output capture** — agent responses from cron job runs are saved and
   viewable in the History tab. Latest result auto-expands; older results
   show an inline preview with a toggle to expand.
@@ -54,12 +55,13 @@ React UI is Sero-only.
 
 ### Opening the app
 
-Click **Cron** (🕐) in the Sero sidebar. The dashboard has three tabs:
+Click **Cron** (🕐) in the Sero sidebar. The dashboard has four tabs:
 
 | Tab | What it shows |
 |-----|---------------|
 | **Reminders** | All reminders with status filters, snooze, and management |
 | **Jobs** | Configured cron jobs with status, schedule, and actions |
+| **Loops** | The workspace's scheduled Orchestrator loops — edit/pause their schedule or jump to the loop |
 | **History** | Recent cron job execution results with expandable output |
 
 ---
@@ -403,7 +405,7 @@ plugins/sero-cron-plugin/
 │       ├── session-runner.test.ts  # Concurrency, cleanup, re-entrancy, timeout
 │       └── scheduler.test.ts      # Tick execution, callbacks, running-set mgmt
 └── ui/
-    ├── CronApp.tsx              # Root — tabs (Reminders, Jobs, History)
+    ├── CronApp.tsx              # Root — tabs (Reminders, Jobs, Loops, History)
     ├── components/
     │   ├── SchedulerBar.tsx     # Status + notification settings + start/stop
     │   ├── NotificationSettings.tsx # Sound toggle + sound picker popover

--- a/plugins/sero-cron-plugin/ui/CronApp.test.tsx
+++ b/plugins/sero-cron-plugin/ui/CronApp.test.tsx
@@ -56,6 +56,24 @@ function renderButton({
 vi.mock('@sero-ai/app-runtime', () => ({
   useAppState: () => useAppStateMock(),
   useAgentPrompt: () => promptMock,
+  useAppInfo: () => ({ appId: 'cron', workspaceId: 'ws-1', workspacePath: '/workspace' }),
+}));
+
+vi.mock('./lib/use-watched-json', () => ({
+  useWatchedJson: (_path: string | null, fallback: unknown) => fallback,
+}));
+
+vi.mock('./lib/orchestrator-bridge', () => ({
+  openOrchestrator: vi.fn(),
+  setLoopSchedule: vi.fn(),
+}));
+
+vi.mock('./components/LoopsTab', () => ({
+  LoopsTab: () => null,
+}));
+
+vi.mock('./components/LoopScheduleForm', () => ({
+  LoopScheduleForm: () => null,
 }));
 
 vi.mock('@sero-ai/ui/components/ui/button', () => ({

--- a/plugins/sero-cron-plugin/ui/CronApp.tsx
+++ b/plugins/sero-cron-plugin/ui/CronApp.tsx
@@ -1,14 +1,16 @@
 /**
  * CronApp, Sero web UI for the cron scheduler extension.
  *
- * Tabs: Jobs | Reminders | History
+ * Tabs: Jobs | Reminders | Loops | History
  *
  * Uses useAppState to read/write the same state.json the Pi extension
- * writes. Changes from either direction are reflected instantly.
+ * writes. Changes from either direction are reflected instantly. The Loops
+ * tab follows the Orchestrator's watched loop index for the active workspace.
  */
 
 import { useState, useCallback, useMemo } from 'react';
-import { useAppState, useAgentPrompt } from '@sero-ai/app-runtime';
+import { useAppState, useAgentPrompt, useAppInfo } from '@sero-ai/app-runtime';
+import type { OrchestratorIndexView } from '@sero-ai/common';
 import { Card } from '@sero-ai/ui/components/ui/card';
 import type { CronState, CronJob, Reminder, NotificationSettings } from '../shared/types';
 import { DEFAULT_CRON_STATE, DEFAULT_NOTIFICATION_SETTINGS } from '../shared/types';
@@ -23,25 +25,40 @@ import { CronAppHeader } from './components/CronAppHeader';
 import { CronTabs } from './components/CronTabs';
 import { JobForm } from './components/JobForm';
 import { JobsTab } from './components/JobsTab';
+import { LoopScheduleForm } from './components/LoopScheduleForm';
+import { LoopsTab } from './components/LoopsTab';
 import { ReminderForm } from './components/ReminderForm';
 import { ReminderList } from './components/ReminderList';
 import { RunHistory } from './components/RunHistory';
 import { SchedulerBar } from './components/SchedulerBar';
+import { openOrchestrator, setLoopSchedule } from './lib/orchestrator-bridge';
+import { orchestratorIndexPath, scheduledLoopRows, type ScheduledLoopRow } from './lib/orchestrator-loops';
+import { useWatchedJson } from './lib/use-watched-json';
 import './styles.css';
 
-type Tab = 'jobs' | 'reminders' | 'history';
+type Tab = 'jobs' | 'reminders' | 'loops' | 'history';
 
 const EMPTY_REMINDERS: Reminder[] = [];
 
 export function CronApp() {
   const [state, updateState] = useAppState<CronState>(DEFAULT_CRON_STATE);
   const prompt = useAgentPrompt();
+  const { workspaceId, workspacePath } = useAppInfo();
 
   const [showJobForm, setShowJobForm] = useState(false);
   const [editingJob, setEditingJob] = useState<CronJob | null>(null);
   const [showReminderForm, setShowReminderForm] = useState(false);
   const [editingReminder, setEditingReminder] = useState<Reminder | null>(null);
+  const [editingLoopRow, setEditingLoopRow] = useState<ScheduledLoopRow | null>(null);
+  const [loopError, setLoopError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>('reminders');
+
+  // Scheduled Orchestrator loops (per-workspace, watched from its loop index)
+  const orchestratorIndex = useWatchedJson<OrchestratorIndexView | null>(
+    orchestratorIndexPath(workspacePath),
+    null,
+  );
+  const loopRows = useMemo(() => scheduledLoopRows(orchestratorIndex), [orchestratorIndex]);
 
   // Ensure reminders array exists (migration)
   const reminders = state.reminders ?? EMPTY_REMINDERS;
@@ -180,6 +197,30 @@ export function CronApp() {
     });
   }, [updateState]);
 
+  // ── Scheduled loops (Orchestrator) ───────────────────────
+
+  const handleSaveLoopSchedule = useCallback(
+    (row: ScheduledLoopRow, schedule: string) =>
+      setLoopSchedule(workspaceId, { loopId: row.loopId, triggerId: row.triggerId, schedule }),
+    [workspaceId],
+  );
+
+  const handleToggleLoopPaused = useCallback(
+    async (row: ScheduledLoopRow) => {
+      setLoopError(null);
+      const error = await setLoopSchedule(workspaceId, {
+        loopId: row.loopId,
+        triggerId: row.triggerId,
+        scheduleDisabled: !row.scheduleDisabled,
+      });
+      if (error) setLoopError(error);
+    },
+    [workspaceId],
+  );
+
+  const handleOpenLoop = useCallback((loopId: string) => { void openOrchestrator(loopId); }, []);
+  const handleOpenOrchestrator = useCallback(() => { void openOrchestrator(); }, []);
+
   // ── History ───────────────────────────────────────────────
 
   const handleClearHistory = useCallback(() => {
@@ -195,6 +236,7 @@ export function CronApp() {
         historyCount={state.lastRunResults.length}
         onAddReminder={handleAddReminder}
         onAddJob={handleAddJob}
+        onOpenOrchestrator={handleOpenOrchestrator}
         onClearHistory={handleClearHistory}
       />
 
@@ -218,6 +260,7 @@ export function CronApp() {
         activeTab={activeTab}
         totalJobs={stats.totalJobs}
         totalReminders={stats.totalReminders}
+        totalLoops={loopRows.length}
         historyCount={state.lastRunResults.length}
         onSelect={setActiveTab}
       />
@@ -246,6 +289,18 @@ export function CronApp() {
             onAdd={handleAddJob}
           />
         )}
+        {activeTab === 'loops' && (
+          <LoopsTab
+            rows={loopRows}
+            hasWorkspace={!!workspacePath}
+            error={loopError}
+            onDismissError={() => setLoopError(null)}
+            onEditSchedule={setEditingLoopRow}
+            onTogglePaused={handleToggleLoopPaused}
+            onOpenLoop={handleOpenLoop}
+            onOpenOrchestrator={handleOpenOrchestrator}
+          />
+        )}
         {activeTab === 'history' && (
           <Card className="gap-0 py-0 shadow-none">
             <RunHistory results={state.lastRunResults} />
@@ -265,6 +320,11 @@ export function CronApp() {
         onClose={() => setShowReminderForm(false)}
         onSave={handleSaveReminder}
         editingReminder={editingReminder}
+      />
+      <LoopScheduleForm
+        row={editingLoopRow}
+        onClose={() => setEditingLoopRow(null)}
+        onSave={handleSaveLoopSchedule}
       />
     </div>
   );

--- a/plugins/sero-cron-plugin/ui/components/CronAppHeader.tsx
+++ b/plugins/sero-cron-plugin/ui/components/CronAppHeader.tsx
@@ -1,13 +1,14 @@
-import { Clock3, Plus } from 'lucide-react';
+import { Clock3, ExternalLink, Plus } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 
-type CronAppTab = 'jobs' | 'reminders' | 'history';
+type CronAppTab = 'jobs' | 'reminders' | 'loops' | 'history';
 
 interface CronAppHeaderProps {
   activeTab: CronAppTab;
   historyCount: number;
   onAddReminder: () => void;
   onAddJob: () => void;
+  onOpenOrchestrator: () => void;
   onClearHistory: () => void;
 }
 
@@ -16,6 +17,7 @@ export function CronAppHeader({
   historyCount,
   onAddReminder,
   onAddJob,
+  onOpenOrchestrator,
   onClearHistory,
 }: CronAppHeaderProps) {
   return (
@@ -37,6 +39,12 @@ export function CronAppHeader({
           <Button size="sm" onClick={onAddJob}>
             <Plus className="size-3.5" />
             Job
+          </Button>
+        )}
+        {activeTab === 'loops' && (
+          <Button size="sm" variant="ghost" onClick={onOpenOrchestrator}>
+            <ExternalLink className="size-3.5" />
+            Orchestrator
           </Button>
         )}
         {activeTab === 'history' && historyCount > 0 && (

--- a/plugins/sero-cron-plugin/ui/components/CronTabs.tsx
+++ b/plugins/sero-cron-plugin/ui/components/CronTabs.tsx
@@ -1,9 +1,10 @@
-type CronAppTab = 'jobs' | 'reminders' | 'history';
+type CronAppTab = 'jobs' | 'reminders' | 'loops' | 'history';
 
 interface CronTabsProps {
   activeTab: CronAppTab;
   totalJobs: number;
   totalReminders: number;
+  totalLoops: number;
   historyCount: number;
   onSelect: (tab: CronAppTab) => void;
 }
@@ -18,6 +19,10 @@ const TAB_LABELS: Array<{ key: CronAppTab; label: (counts: Omit<CronTabsProps, '
     label: ({ totalJobs }) => `Jobs (${totalJobs})`,
   },
   {
+    key: 'loops',
+    label: ({ totalLoops }) => `Loops (${totalLoops})`,
+  },
+  {
     key: 'history',
     label: ({ historyCount }) => `History (${historyCount})`,
   },
@@ -27,10 +32,11 @@ export function CronTabs({
   activeTab,
   totalJobs,
   totalReminders,
+  totalLoops,
   historyCount,
   onSelect,
 }: CronTabsProps) {
-  const counts = { totalJobs, totalReminders, historyCount };
+  const counts = { totalJobs, totalReminders, totalLoops, historyCount };
 
   return (
     <div className="mb-3 flex gap-1 border-b border-border">

--- a/plugins/sero-cron-plugin/ui/components/LoopScheduleCard.tsx
+++ b/plugins/sero-cron-plugin/ui/components/LoopScheduleCard.tsx
@@ -1,0 +1,93 @@
+/**
+ * LoopScheduleCard, one scheduled Orchestrator loop with schedule actions.
+ * The loop itself is managed in the Orchestrator app; from here you can edit
+ * or pause its schedule and jump to the loop's details.
+ */
+
+import { ExternalLink, Pause, Play } from 'lucide-react';
+import { Badge } from '@sero-ai/ui/components/ui/badge';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Card } from '@sero-ai/ui/components/ui/card';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { cronToHuman } from '../../shared/cron';
+import { formatFireTime, type ScheduledLoopRow } from '../lib/orchestrator-loops';
+
+interface LoopScheduleCardProps {
+  row: ScheduledLoopRow;
+  onEditSchedule: (row: ScheduledLoopRow) => void;
+  onTogglePaused: (row: ScheduledLoopRow) => void;
+  onOpenLoop: (loopId: string) => void;
+}
+
+const STATUS_BADGE: Record<ScheduledLoopRow['status'], { label: string; className: string }> = {
+  active: { label: 'Active', className: 'border-emerald-500/30 text-emerald-500' },
+  draft: { label: 'Draft', className: 'border-border text-muted-foreground' },
+  blocked: { label: 'Blocked', className: 'border-destructive/30 text-destructive' },
+  complete: { label: 'Complete', className: 'border-blue-500/30 text-blue-500' },
+  disabled: { label: 'Disabled', className: 'border-border text-muted-foreground' },
+};
+
+export function LoopScheduleCard({ row, onEditSchedule, onTogglePaused, onOpenLoop }: LoopScheduleCardProps) {
+  const status = STATUS_BADGE[row.status];
+
+  return (
+    <Card className={cn('gap-0 py-0 shadow-none transition-colors', row.scheduleDisabled && 'opacity-50')}>
+      <div className="px-4 py-3">
+        {/* Header row: title + badges */}
+        <div className="mb-2 flex items-center gap-2">
+          <span className="text-sm font-semibold text-foreground">{row.title}</span>
+          <Badge variant="outline" className={cn('text-[10px]', status.className)}>
+            {status.label}
+          </Badge>
+          {row.scheduleDisabled && (
+            <Badge variant="secondary" className="text-[10px]">
+              Schedule paused
+            </Badge>
+          )}
+          {row.firesOnEvents && (
+            <Badge variant="outline" className="border-primary/30 text-[10px] text-primary" title="This loop also runs when its events fire">
+              Events
+            </Badge>
+          )}
+        </div>
+
+        {/* Schedule */}
+        <div className="mb-1.5 flex items-center gap-2">
+          <code className="rounded bg-secondary px-2 py-0.5 text-xs text-foreground">{row.schedule}</code>
+          <span className="text-xs text-muted-foreground">{cronToHuman(row.schedule)} (UTC)</span>
+        </div>
+
+        {/* Next / last fire */}
+        <p className="mb-3 text-xs text-muted-foreground">
+          {row.nextFireAt ? `Next run ${formatFireTime(row.nextFireAt)}` : 'No run scheduled'}
+          {row.lastFireAt ? ` · Last run ${formatFireTime(row.lastFireAt)}` : ''}
+        </p>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1.5">
+          <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onEditSchedule(row)}>
+            Edit schedule
+          </Button>
+          <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onTogglePaused(row)}>
+            {row.scheduleDisabled ? (
+              <>
+                <Play className="size-3.5" />
+                Resume
+              </>
+            ) : (
+              <>
+                <Pause className="size-3.5" />
+                Pause
+              </>
+            )}
+          </Button>
+          <div className="flex-1" />
+          <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onOpenLoop(row.loopId)}>
+            <ExternalLink className="size-3.5" />
+            Open in Orchestrator
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/plugins/sero-cron-plugin/ui/components/LoopScheduleCard.tsx
+++ b/plugins/sero-cron-plugin/ui/components/LoopScheduleCard.tsx
@@ -29,9 +29,12 @@ const STATUS_BADGE: Record<ScheduledLoopRow['status'], { label: string; classNam
 
 export function LoopScheduleCard({ row, onEditSchedule, onTogglePaused, onOpenLoop }: LoopScheduleCardProps) {
   const status = STATUS_BADGE[row.status];
+  // A schedule can only be edited/paused while it can still fire: not exhausted,
+  // and on a loop that is still running (complete/disabled loops restart in Orchestrator).
+  const canManage = !row.exhausted && row.status !== 'complete' && row.status !== 'disabled';
 
   return (
-    <Card className={cn('gap-0 py-0 shadow-none transition-colors', row.scheduleDisabled && 'opacity-50')}>
+    <Card className={cn('gap-0 py-0 shadow-none transition-colors', (row.scheduleDisabled || row.exhausted) && 'opacity-50')}>
       <div className="px-4 py-3">
         {/* Header row: title + badges */}
         <div className="mb-2 flex items-center gap-2">
@@ -39,10 +42,16 @@ export function LoopScheduleCard({ row, onEditSchedule, onTogglePaused, onOpenLo
           <Badge variant="outline" className={cn('text-[10px]', status.className)}>
             {status.label}
           </Badge>
-          {row.scheduleDisabled && (
-            <Badge variant="secondary" className="text-[10px]">
-              Schedule paused
+          {row.exhausted ? (
+            <Badge variant="secondary" className="text-[10px]" title="This schedule reached its run limit and won't fire again">
+              Run limit reached
             </Badge>
+          ) : (
+            row.scheduleDisabled && canManage && (
+              <Badge variant="secondary" className="text-[10px]">
+                Schedule paused
+              </Badge>
+            )
           )}
           {row.firesOnEvents && (
             <Badge variant="outline" className="border-primary/30 text-[10px] text-primary" title="This loop also runs when its events fire">
@@ -59,28 +68,36 @@ export function LoopScheduleCard({ row, onEditSchedule, onTogglePaused, onOpenLo
 
         {/* Next / last fire */}
         <p className="mb-3 text-xs text-muted-foreground">
-          {row.nextFireAt ? `Next run ${formatFireTime(row.nextFireAt)}` : 'No run scheduled'}
+          {row.exhausted
+            ? 'Reached its run limit'
+            : row.nextFireAt
+              ? `Next run ${formatFireTime(row.nextFireAt)}`
+              : 'No run scheduled'}
           {row.lastFireAt ? ` · Last run ${formatFireTime(row.lastFireAt)}` : ''}
         </p>
 
-        {/* Actions */}
+        {/* Actions — a spent schedule (exhausted, or a complete/disabled loop) can't be edited or resumed; restart the loop in Orchestrator */}
         <div className="flex items-center gap-1.5">
-          <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onEditSchedule(row)}>
-            Edit schedule
-          </Button>
-          <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onTogglePaused(row)}>
-            {row.scheduleDisabled ? (
-              <>
-                <Play className="size-3.5" />
-                Resume
-              </>
-            ) : (
-              <>
-                <Pause className="size-3.5" />
-                Pause
-              </>
-            )}
-          </Button>
+          {canManage && (
+            <>
+              <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onEditSchedule(row)}>
+                Edit schedule
+              </Button>
+              <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onTogglePaused(row)}>
+                {row.scheduleDisabled ? (
+                  <>
+                    <Play className="size-3.5" />
+                    Resume
+                  </>
+                ) : (
+                  <>
+                    <Pause className="size-3.5" />
+                    Pause
+                  </>
+                )}
+              </Button>
+            </>
+          )}
           <div className="flex-1" />
           <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => onOpenLoop(row.loopId)}>
             <ExternalLink className="size-3.5" />

--- a/plugins/sero-cron-plugin/ui/components/LoopScheduleForm.tsx
+++ b/plugins/sero-cron-plugin/ui/components/LoopScheduleForm.tsx
@@ -1,0 +1,139 @@
+/**
+ * LoopScheduleForm, dialog for editing a scheduled loop's cron schedule.
+ * Only the schedule is editable here — the loop itself is managed in the
+ * Orchestrator app. Saving goes through the Orchestrator tool, so the dialog
+ * stays open with the error when the update fails.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { Check } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@sero-ai/ui/components/ui/dialog';
+import { cn } from '@sero-ai/ui/lib/utils';
+import { validateCron, cronToHuman } from '../../shared/cron';
+import { CRON_PRESETS } from '../lib/cron-utils';
+import type { ScheduledLoopRow } from '../lib/orchestrator-loops';
+
+interface LoopScheduleFormProps {
+  /** The row being edited, or null when the dialog is closed. */
+  row: ScheduledLoopRow | null;
+  onClose: () => void;
+  /** Persists the new schedule; resolves to null on success, an error message otherwise. */
+  onSave: (row: ScheduledLoopRow, schedule: string) => Promise<string | null>;
+}
+
+export function LoopScheduleForm({ row, onClose, onSave }: LoopScheduleFormProps) {
+  const [schedule, setSchedule] = useState('');
+  const [scheduleError, setScheduleError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Reset to the row's current schedule when opening
+  useEffect(() => {
+    if (row) {
+      setSchedule(row.schedule);
+      setScheduleError(null);
+      setSaveError(null);
+      setBusy(false);
+    }
+  }, [row]);
+
+  // Validate schedule on change
+  useEffect(() => {
+    setScheduleError(schedule.trim() ? validateCron(schedule.trim()) : null);
+  }, [schedule]);
+
+  const canSave = !!schedule.trim() && !scheduleError && !busy;
+
+  const handleSave = useCallback(async () => {
+    if (!row || !canSave) return;
+    setBusy(true);
+    setSaveError(null);
+    const error = await onSave(row, schedule.trim());
+    setBusy(false);
+    if (error) {
+      setSaveError(error);
+      return;
+    }
+    onClose();
+  }, [row, canSave, schedule, onSave, onClose]);
+
+  const inputCls =
+    'w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';
+
+  return (
+    <Dialog open={!!row} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit schedule — {row?.title}</DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleSave();
+          }}
+          className="flex flex-col gap-4 py-2"
+        >
+          <div>
+            <label htmlFor="loop-schedule" className="mb-1 block text-xs font-medium text-muted-foreground">
+              Schedule (UTC) *
+            </label>
+            <input
+              id="loop-schedule"
+              type="text"
+              value={schedule}
+              onChange={(e) => setSchedule(e.target.value)}
+              placeholder="0 9 * * 1-5"
+              className={cn(inputCls, 'font-mono')}
+            />
+            {scheduleError ? (
+              <p className="mt-1 text-[11px] text-destructive">{scheduleError}</p>
+            ) : schedule.trim() ? (
+              <p className="mt-1 inline-flex items-center gap-1 text-[11px] text-emerald-500">
+                <Check className="size-3" />
+                {cronToHuman(schedule.trim())} (UTC)
+              </p>
+            ) : (
+              <p className="mt-1 text-[11px] text-muted-foreground">min hour dom month dow</p>
+            )}
+
+            {/* Presets */}
+            <div className="mt-2 flex flex-wrap gap-1">
+              {CRON_PRESETS.map((p) => (
+                <button
+                  key={p.value}
+                  type="button"
+                  onClick={() => setSchedule(p.value)}
+                  className={cn(
+                    'rounded-full border border-border px-2 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground',
+                    schedule === p.value && 'border-primary bg-primary/10 text-primary',
+                  )}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {saveError && <p className="text-[11px] text-destructive">{saveError}</p>}
+        </form>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSave()} disabled={!canSave}>
+            {busy ? 'Saving…' : 'Save Schedule'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/plugins/sero-cron-plugin/ui/components/LoopsTab.tsx
+++ b/plugins/sero-cron-plugin/ui/components/LoopsTab.tsx
@@ -1,0 +1,76 @@
+/**
+ * LoopsTab, scheduled Orchestrator loops for the active workspace.
+ * Read-only except for the schedule: edit/pause it here, everything else in
+ * the Orchestrator app.
+ */
+
+import { ExternalLink, Infinity as InfinityIcon } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+
+import type { ScheduledLoopRow } from '../lib/orchestrator-loops';
+import { LoopScheduleCard } from './LoopScheduleCard';
+
+interface LoopsTabProps {
+  rows: ScheduledLoopRow[];
+  /** False when no workspace is active (loops are per-workspace). */
+  hasWorkspace: boolean;
+  error: string | null;
+  onDismissError: () => void;
+  onEditSchedule: (row: ScheduledLoopRow) => void;
+  onTogglePaused: (row: ScheduledLoopRow) => void;
+  onOpenLoop: (loopId: string) => void;
+  onOpenOrchestrator: () => void;
+}
+
+export function LoopsTab({
+  rows,
+  hasWorkspace,
+  error,
+  onDismissError,
+  onEditSchedule,
+  onTogglePaused,
+  onOpenLoop,
+  onOpenOrchestrator,
+}: LoopsTabProps) {
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center animate-cron-fade-in">
+        <InfinityIcon className="mb-4 size-10 text-muted-foreground" />
+        <h2 className="text-base font-medium text-foreground">No scheduled loops</h2>
+        <p className="mt-1.5 max-w-[260px] text-xs leading-relaxed text-muted-foreground">
+          {hasWorkspace
+            ? 'Orchestrator loops with a schedule show up here.'
+            : 'Open a workspace to see its scheduled loops.'}
+        </p>
+        {hasWorkspace && (
+          <Button size="sm" className="mt-4" onClick={onOpenOrchestrator}>
+            <ExternalLink className="size-3.5" />
+            Open Orchestrator
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 animate-cron-fade-in">
+      {error && (
+        <div className="flex items-center justify-between gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          <span>{error}</span>
+          <button type="button" className="shrink-0 underline" onClick={onDismissError}>
+            dismiss
+          </button>
+        </div>
+      )}
+      {rows.map((row) => (
+        <LoopScheduleCard
+          key={`${row.loopId}:${row.triggerId}`}
+          row={row}
+          onEditSchedule={onEditSchedule}
+          onTogglePaused={onTogglePaused}
+          onOpenLoop={onOpenLoop}
+        />
+      ))}
+    </div>
+  );
+}

--- a/plugins/sero-cron-plugin/ui/lib/orchestrator-bridge.ts
+++ b/plugins/sero-cron-plugin/ui/lib/orchestrator-bridge.ts
@@ -1,0 +1,38 @@
+/**
+ * Calls into the Orchestrator plugin: open its app (optionally on a specific
+ * loop) and edit a loop's schedule through its `orchestrator` tool.
+ */
+
+import { getSeroApi, openSeroApp } from '@sero-ai/app-runtime';
+import type { OrchestratorSetScheduleParams } from '@sero-ai/common';
+import { ORCHESTRATOR_APP_ID } from '@sero-ai/common';
+
+/** Switch to the Orchestrator app, landing on the loop's detail when given. */
+export function openOrchestrator(loopId?: string): Promise<boolean> {
+  return openSeroApp(ORCHESTRATOR_APP_ID, loopId ? { loopId } : undefined);
+}
+
+/**
+ * Update a loop trigger's cron schedule and/or paused state.
+ * Resolves to null on success, an error message otherwise.
+ */
+export async function setLoopSchedule(
+  workspaceId: string,
+  params: Omit<OrchestratorSetScheduleParams, 'action'>,
+): Promise<string | null> {
+  const { appAgent } = getSeroApi();
+  if (!appAgent.invokeTool) return 'App tool bridge unavailable.';
+  try {
+    const res = await appAgent.invokeTool(ORCHESTRATOR_APP_ID, workspaceId, 'orchestrator', {
+      action: 'set_schedule',
+      ...params,
+    });
+    const details = res.details as { ok?: boolean; error?: string } | null;
+    if (res.isError || details?.ok === false) {
+      return details?.error ?? 'Schedule update failed.';
+    }
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}

--- a/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.test.ts
+++ b/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { OrchestratorIndexView } from '@sero-ai/common';
+import { formatFireTime, orchestratorIndexPath, scheduledLoopRows } from './orchestrator-loops';
+
+const index: OrchestratorIndexView = {
+  loops: [
+    {
+      id: 'loop-1',
+      title: 'Daily digest',
+      status: 'active',
+      updatedAt: '2026-07-01T09:00:00.000Z',
+      schedules: [
+        {
+          triggerId: 'trig-1',
+          type: 'cron',
+          schedule: '0 9 * * *',
+          nextFireAt: '2026-07-02T09:00:00.000Z',
+          lastFireAt: '2026-07-01T09:00:00.000Z',
+        },
+      ],
+    },
+    {
+      id: 'loop-2',
+      title: 'PR watcher',
+      status: 'active',
+      updatedAt: '2026-07-01T09:00:00.000Z',
+      // No schedules: event-only loop, must not appear.
+    },
+    {
+      id: 'loop-3',
+      title: 'Weekly report',
+      status: 'disabled',
+      updatedAt: '2026-07-01T09:00:00.000Z',
+      schedules: [
+        { triggerId: 'trig-3', type: 'hybrid', schedule: '0 8 * * 1', disabled: true },
+      ],
+    },
+  ],
+};
+
+describe('orchestratorIndexPath', () => {
+  it('builds the index path from the workspace root', () => {
+    expect(orchestratorIndexPath('/ws')).toBe('/ws/.sero/apps/orchestrator/index.json');
+  });
+
+  it('is null without a workspace', () => {
+    expect(orchestratorIndexPath('')).toBeNull();
+  });
+});
+
+describe('scheduledLoopRows', () => {
+  it('flattens only loops that carry schedules', () => {
+    const rows = scheduledLoopRows(index);
+    expect(rows.map((r) => r.loopId)).toEqual(['loop-1', 'loop-3']);
+    expect(rows[0]).toMatchObject({
+      triggerId: 'trig-1',
+      title: 'Daily digest',
+      schedule: '0 9 * * *',
+      firesOnEvents: false,
+      scheduleDisabled: false,
+      nextFireAt: '2026-07-02T09:00:00.000Z',
+    });
+  });
+
+  it('marks hybrid triggers as event-driven and carries the paused state', () => {
+    const row = scheduledLoopRows(index)[1];
+    expect(row).toMatchObject({ triggerId: 'trig-3', firesOnEvents: true, scheduleDisabled: true, status: 'disabled' });
+  });
+
+  it('is empty for a missing index', () => {
+    expect(scheduledLoopRows(null)).toEqual([]);
+  });
+});
+
+describe('formatFireTime', () => {
+  it('falls back to the raw string for invalid dates', () => {
+    expect(formatFireTime('not-a-date')).toBe('not-a-date');
+  });
+
+  it('formats a valid ISO timestamp', () => {
+    expect(formatFireTime('2026-07-02T09:00:00.000Z')).not.toBe('2026-07-02T09:00:00.000Z');
+  });
+});

--- a/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.test.ts
+++ b/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.test.ts
@@ -32,7 +32,16 @@ const index: OrchestratorIndexView = {
       status: 'disabled',
       updatedAt: '2026-07-01T09:00:00.000Z',
       schedules: [
-        { triggerId: 'trig-3', type: 'hybrid', schedule: '0 8 * * 1', disabled: true },
+        { triggerId: 'trig-3', type: 'hybrid', schedule: '0 8 * * 1', paused: true },
+      ],
+    },
+    {
+      id: 'loop-4',
+      title: 'One-shot rollout',
+      status: 'active',
+      updatedAt: '2026-07-01T09:00:00.000Z',
+      schedules: [
+        { triggerId: 'trig-4', type: 'cron', schedule: '0 6 * * *', exhausted: true },
       ],
     },
   ],
@@ -51,20 +60,26 @@ describe('orchestratorIndexPath', () => {
 describe('scheduledLoopRows', () => {
   it('flattens only loops that carry schedules', () => {
     const rows = scheduledLoopRows(index);
-    expect(rows.map((r) => r.loopId)).toEqual(['loop-1', 'loop-3']);
+    expect(rows.map((r) => r.loopId)).toEqual(['loop-1', 'loop-3', 'loop-4']);
     expect(rows[0]).toMatchObject({
       triggerId: 'trig-1',
       title: 'Daily digest',
       schedule: '0 9 * * *',
       firesOnEvents: false,
       scheduleDisabled: false,
+      exhausted: false,
       nextFireAt: '2026-07-02T09:00:00.000Z',
     });
   });
 
   it('marks hybrid triggers as event-driven and carries the paused state', () => {
     const row = scheduledLoopRows(index)[1];
-    expect(row).toMatchObject({ triggerId: 'trig-3', firesOnEvents: true, scheduleDisabled: true, status: 'disabled' });
+    expect(row).toMatchObject({ triggerId: 'trig-3', firesOnEvents: true, scheduleDisabled: true, exhausted: false, status: 'disabled' });
+  });
+
+  it('carries the exhausted state for triggers past their run limit', () => {
+    const row = scheduledLoopRows(index)[2];
+    expect(row).toMatchObject({ triggerId: 'trig-4', exhausted: true, scheduleDisabled: false });
   });
 
   it('is empty for a missing index', () => {

--- a/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.ts
+++ b/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.ts
@@ -24,8 +24,10 @@ export interface ScheduledLoopRow {
   firesOnEvents: boolean;
   nextFireAt?: string;
   lastFireAt?: string;
-  /** The schedule itself is paused (trigger disabled). */
+  /** The user paused the cron schedule (resumable); events still fire on hybrid triggers. */
   scheduleDisabled: boolean;
+  /** The trigger hit its run limit (maxFires) — done for good, not resumable. */
+  exhausted: boolean;
 }
 
 /** Absolute path of the Orchestrator's loop index, or null without a workspace. */
@@ -46,7 +48,8 @@ export function scheduledLoopRows(index: OrchestratorIndexView | null): Schedule
       firesOnEvents: schedule.type === 'hybrid',
       nextFireAt: schedule.nextFireAt,
       lastFireAt: schedule.lastFireAt,
-      scheduleDisabled: schedule.disabled === true,
+      scheduleDisabled: schedule.paused === true,
+      exhausted: schedule.exhausted === true,
     })),
   );
 }

--- a/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.ts
+++ b/plugins/sero-cron-plugin/ui/lib/orchestrator-loops.ts
@@ -1,0 +1,64 @@
+/**
+ * Scheduled Orchestrator loops shown in the Scheduler app.
+ *
+ * The Orchestrator (workspace-scoped) maintains a watched loop index whose
+ * entries carry a compact schedule summary; this module maps that index into
+ * flat display rows. Pure — the file watching and tool calls live elsewhere.
+ */
+
+import type {
+  OrchestratorIndexView,
+  OrchestratorLoopStatus,
+} from '@sero-ai/common';
+import { ORCHESTRATOR_INDEX_FILE } from '@sero-ai/common';
+
+/** One cron/hybrid trigger of one loop, flattened for display. */
+export interface ScheduledLoopRow {
+  loopId: string;
+  triggerId: string;
+  title: string;
+  status: OrchestratorLoopStatus;
+  /** 5-field cron expression, evaluated in UTC. */
+  schedule: string;
+  /** True for hybrid triggers, which also fire on events. */
+  firesOnEvents: boolean;
+  nextFireAt?: string;
+  lastFireAt?: string;
+  /** The schedule itself is paused (trigger disabled). */
+  scheduleDisabled: boolean;
+}
+
+/** Absolute path of the Orchestrator's loop index, or null without a workspace. */
+export function orchestratorIndexPath(workspacePath: string): string | null {
+  return workspacePath ? `${workspacePath}/${ORCHESTRATOR_INDEX_FILE}` : null;
+}
+
+/** Flattens the watched loop index into one row per scheduled trigger. */
+export function scheduledLoopRows(index: OrchestratorIndexView | null): ScheduledLoopRow[] {
+  if (!index?.loops) return [];
+  return index.loops.flatMap((loop) =>
+    (loop.schedules ?? []).map((schedule) => ({
+      loopId: loop.id,
+      triggerId: schedule.triggerId,
+      title: loop.title,
+      status: loop.status,
+      schedule: schedule.schedule,
+      firesOnEvents: schedule.type === 'hybrid',
+      nextFireAt: schedule.nextFireAt,
+      lastFireAt: schedule.lastFireAt,
+      scheduleDisabled: schedule.disabled === true,
+    })),
+  );
+}
+
+/** Formats an ISO timestamp as a short local date-time for the next/last fire. */
+export function formatFireTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/plugins/sero-cron-plugin/ui/lib/use-watched-json.ts
+++ b/plugins/sero-cron-plugin/ui/lib/use-watched-json.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef, useState } from 'react';
+import { getSeroApi } from '@sero-ai/app-runtime';
+
+/**
+ * Reactively reads and watches a JSON file by absolute path through the Sero
+ * bridge. Pass `null` to watch nothing (returns the fallback). Used to follow
+ * the Orchestrator's loop index, which lives outside this app's own state file.
+ */
+export function useWatchedJson<T>(filePath: string | null, fallback: T): T {
+  const [data, setData] = useState<T>(fallback);
+  const fallbackRef = useRef<T>(fallback);
+  fallbackRef.current = fallback;
+
+  useEffect(() => {
+    if (!filePath) {
+      setData(fallbackRef.current);
+      return;
+    }
+    const api = getSeroApi().appState;
+    let active = true;
+    setData(fallbackRef.current); // reset while the new path loads
+
+    const unsubscribe = api.onChange<T | null>((changedPath, value) => {
+      if (!active || changedPath !== filePath) return;
+      setData(value == null ? fallbackRef.current : value);
+    });
+    void api.watch<T | null>(filePath).then((current) => {
+      if (active) setData(current == null ? fallbackRef.current : current);
+    });
+
+    return () => {
+      active = false;
+      unsubscribe();
+      void api.unwatch(filePath);
+    };
+  }, [filePath]);
+
+  return data;
+}

--- a/plugins/sero-cron-plugin/ui/widgets/CronWidget.test.tsx
+++ b/plugins/sero-cron-plugin/ui/widgets/CronWidget.test.tsx
@@ -90,8 +90,8 @@ describe('CronWidget', () => {
     });
 
     expect(container.textContent).toContain('Scheduler active');
-    expect(container.textContent).toContain('1 jobs');
-    expect(container.textContent).toContain('1 reminders');
+    expect(container.textContent).toContain('Jobs1');
+    expect(container.textContent).toContain('Reminders1');
     expect(container.textContent).toContain('Daily report');
     expect(container.textContent).toContain('Stretch');
   });

--- a/plugins/sero-orchestrator-plugin/extension/__tests__/tools.test.ts
+++ b/plugins/sero-orchestrator-plugin/extension/__tests__/tools.test.ts
@@ -96,6 +96,24 @@ describe('buildAction', () => {
     });
   });
 
+  it('builds set_schedule from triggerId + schedule/scheduleDisabled', () => {
+    expect(buildAction({ action: 'set_schedule', loopId: 'l1', triggerId: 't1', schedule: '0 9 * * *' })).toEqual({
+      kind: 'set_schedule', loopId: 'l1', triggerId: 't1', schedule: '0 9 * * *', disabled: undefined,
+    });
+    expect(buildAction({ action: 'set_schedule', loopId: 'l1', triggerId: 't1', scheduleDisabled: true })).toEqual({
+      kind: 'set_schedule', loopId: 'l1', triggerId: 't1', schedule: undefined, disabled: true,
+    });
+    expect(buildAction({ action: 'set_schedule', triggerId: 't1', schedule: '0 9 * * *' })).toEqual({
+      error: 'set_schedule requires a loopId',
+    });
+    expect(buildAction({ action: 'set_schedule', loopId: 'l1', schedule: '0 9 * * *' })).toEqual({
+      error: 'set_schedule requires a triggerId',
+    });
+    expect(buildAction({ action: 'set_schedule', loopId: 'l1', triggerId: 't1' })).toEqual({
+      error: 'set_schedule requires a schedule and/or scheduleDisabled',
+    });
+  });
+
   it('rejects malformed delivery params', () => {
     expect(buildAction({ action: 'set_delivery', loopId: 'l1', deliveryDestination: 'webhook-post', deliveryParamsJson: '{bad' })).toEqual({
       error: 'deliveryParamsJson is not valid JSON',

--- a/plugins/sero-orchestrator-plugin/extension/commands.ts
+++ b/plugins/sero-orchestrator-plugin/extension/commands.ts
@@ -23,6 +23,7 @@ const HELP = `Usage:
   /orchestrator activate|disable|enable|run_next|run_again|retry|reflect|delete <loopId>
   /orchestrator retry_step <loopId> <stepId>
   /orchestrator set_delivery <loopId> <destination>
+  /orchestrator set_schedule <loopId> <triggerId> <cron schedule (UTC)>
   /orchestrator reflect_workspace
   /orchestrator answer <loopId> <your answer>
   /orchestrator revise <loopId> [request]
@@ -95,6 +96,14 @@ export function parseCommand(args: string): ParsedCommand {
       if (!loopId || !destination) return { error: 'set_delivery requires a loopId and a destination' };
       if (!isDeliveryDestinationId(destination)) return { error: `Unknown destination "${destination}". Destinations: ${DELIVERY_DESTINATION_IDS.join(', ')}` };
       return { action, loopId, deliveryDestination: destination };
+    }
+    case 'set_schedule': {
+      const [loopId, triggerId, ...scheduleParts] = rest;
+      const schedule = scheduleParts.join(' ').trim();
+      if (!loopId || !triggerId || !schedule) {
+        return { error: 'set_schedule requires a loopId, a triggerId, and a cron schedule: /orchestrator set_schedule <loopId> <triggerId> <min hour dom month dow>' };
+      }
+      return { action, loopId, triggerId, schedule };
     }
     case 'library_save': {
       const [loopId, mode, ...noteParts] = rest;

--- a/plugins/sero-orchestrator-plugin/extension/tools.ts
+++ b/plugins/sero-orchestrator-plugin/extension/tools.ts
@@ -39,6 +39,7 @@ export const ORCHESTRATOR_ACTIONS = [
   'set_step_agent',
   'set_loop_context',
   'set_delivery',
+  'set_schedule',
   'reflect',
   'reflect_workspace',
   'choose_suggestion',
@@ -79,6 +80,9 @@ export const OrchestratorToolParams = Type.Object({
   toolsJson: Type.Optional(Type.String({ description: 'For set_step_tools: JSON-encoded array of EXTRA tool names beyond the always-on default tools (e.g. ["web_search","git_manager"]) or "null"/"[]" to use the default tools only' })),
   agent: Type.Optional(Type.String({ description: 'For set_step_agent: a named agent role for the background-agent step; omit/empty to revert the step to the default agent' })),
   contextJson: Type.Optional(Type.String({ description: 'For set_loop_context: JSON-encoded ContextOverrides ({systemPrompt?, disabledTools?, disabledSkills?}) or "null" to clear' })),
+  triggerId: Type.Optional(Type.String({ description: 'For set_schedule: the cron/hybrid trigger id (loop.triggers[].id)' })),
+  schedule: Type.Optional(Type.String({ description: 'For set_schedule: the new 5-field cron expression (minute hour dom month dow, UTC); omit to keep the current one' })),
+  scheduleDisabled: Type.Optional(Type.Boolean({ description: 'For set_schedule: pause (true) or resume (false) the trigger\'s schedule; omit to keep the current state' })),
   deliveryDestination: Type.Optional(StringEnum(DELIVERY_DESTINATION_IDS, { description: 'For create/set_delivery: where the loop ships its results (user-chosen; omit on create to derive from placement — worktree ⇒ pr, root ⇒ workspace-files)' })),
   deliveryParamsJson: Type.Optional(Type.String({ description: 'For create/set_delivery: JSON-encoded flat object of destination params (e.g. {"channel":"#market-intel"} or {"url":"https://…"})' })),
   suggestionId: Type.Optional(Type.String({ description: 'For choose_suggestion: the reflection suggestion id to approve/reject' })),
@@ -114,6 +118,9 @@ export interface OrchestratorToolParamsShape {
   toolsJson?: string;
   agent?: string;
   contextJson?: string;
+  triggerId?: string;
+  schedule?: string;
+  scheduleDisabled?: boolean;
   deliveryDestination?: (typeof DELIVERY_DESTINATION_IDS)[number];
   deliveryParamsJson?: string;
   suggestionId?: string;
@@ -251,6 +258,13 @@ export function buildAction(params: OrchestratorToolParamsShape): OrchestratorAc
       }
       return { kind: 'set_loop_context', loopId: params.loopId, overrides };
     }
+    case 'set_schedule':
+      if (!params.loopId) return { error: 'set_schedule requires a loopId' };
+      if (!params.triggerId) return { error: 'set_schedule requires a triggerId' };
+      if (params.schedule === undefined && params.scheduleDisabled === undefined) {
+        return { error: 'set_schedule requires a schedule and/or scheduleDisabled' };
+      }
+      return { kind: 'set_schedule', loopId: params.loopId, triggerId: params.triggerId, schedule: params.schedule, disabled: params.scheduleDisabled };
     case 'reflect_workspace':
       return { kind: 'reflect_workspace' };
     case 'choose_suggestion': {
@@ -343,6 +357,10 @@ function summarize(action: OrchestratorAction, res: OrchestratorActionResult): s
       return `Retried step "${action.stepId}" — loop ${action.loopId} now "${res.loop?.status ?? '?'}".`;
     case 'set_delivery':
       return `Loop ${action.loopId} now delivers to "${action.delivery.destination}".`;
+    case 'set_schedule': {
+      const trigger = res.loop?.triggers.find((t) => t.id === action.triggerId);
+      return `Loop ${action.loopId} schedule is now "${trigger?.schedule}"${trigger?.disabled ? ' (paused)' : ''} — next fire ${trigger?.nextFireAt ?? 'n/a'}.`;
+    }
     case 'library_save':
       return `Saved loop to the library (now ${res.loop?.libraryLink ? `v${res.loop.libraryLink.version}` : 'linked'}).`;
     case 'library_load':

--- a/plugins/sero-orchestrator-plugin/extension/tools.ts
+++ b/plugins/sero-orchestrator-plugin/extension/tools.ts
@@ -359,7 +359,7 @@ function summarize(action: OrchestratorAction, res: OrchestratorActionResult): s
       return `Loop ${action.loopId} now delivers to "${action.delivery.destination}".`;
     case 'set_schedule': {
       const trigger = res.loop?.triggers.find((t) => t.id === action.triggerId);
-      return `Loop ${action.loopId} schedule is now "${trigger?.schedule}"${trigger?.disabled ? ' (paused)' : ''} — next fire ${trigger?.nextFireAt ?? 'n/a'}.`;
+      return `Loop ${action.loopId} schedule is now "${trigger?.schedule}"${trigger?.scheduleDisabled ? ' (paused)' : ''} — next fire ${trigger?.nextFireAt ?? 'n/a'}.`;
     }
     case 'library_save':
       return `Saved loop to the library (now ${res.loop?.libraryLink ? `v${res.loop.libraryLink.version}` : 'linked'}).`;

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/scheduler.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/scheduler.test.ts
@@ -144,15 +144,25 @@ describe('applyScheduleOverride', () => {
     expect(result.loop?.updatedAt).toBe(NOW);
   });
 
-  it('pauses (clearing nextFireAt) and resumes (re-arming it)', () => {
-    const loop = withTriggers(base(), [cronTrigger({ schedule: '0 * * * *', nextFireAt: '2026-06-22T11:00:00.000Z' })]);
+  it('pauses only the schedule (scheduleDisabled, not disabled) and resumes it', () => {
+    const loop = withTriggers(base(), [cronTrigger({ type: 'hybrid', eventSource: 'fs:changed', schedule: '0 * * * *', nextFireAt: '2026-06-22T11:00:00.000Z' })]);
     const paused = applyScheduleOverride(loop, 't', { disabled: true }, NOW);
-    expect(paused.loop?.triggers[0].disabled).toBe(true);
+    expect(paused.loop?.triggers[0].scheduleDisabled).toBe(true);
+    // A hybrid trigger stays fully enabled so its events keep firing.
+    expect(paused.loop?.triggers[0].disabled).toBeUndefined();
     expect(paused.loop?.triggers[0].nextFireAt).toBeUndefined();
 
     const resumed = applyScheduleOverride(paused.loop!, 't', { disabled: false }, NOW);
-    expect(resumed.loop?.triggers[0].disabled).toBe(false);
+    expect(resumed.loop?.triggers[0].scheduleDisabled).toBe(false);
     expect(resumed.loop?.triggers[0].nextFireAt).toBe('2026-06-22T11:00:00.000Z');
+  });
+
+  it('does not stop a paused hybrid from firing on its events', () => {
+    const loop = withTriggers(base(), [cronTrigger({ type: 'hybrid', eventSource: 'fs:changed', schedule: '0 * * * *' })]);
+    const paused = applyScheduleOverride(loop, 't', { disabled: true }, NOW).loop!;
+    // event matching only rejects fully-disabled triggers, so the paused schedule leaves events live.
+    expect(paused.triggers[0].disabled).toBeUndefined();
+    expect(isRecurring(paused)).toBe(true);
   });
 
   it('rejects an invalid cron expression, an unknown trigger, and an event trigger', () => {
@@ -163,5 +173,11 @@ describe('applyScheduleOverride', () => {
     expect(applyScheduleOverride(loop, 't', { schedule: 'not a cron' }, NOW).ok).toBe(false);
     expect(applyScheduleOverride(loop, 'missing', { schedule: '0 9 * * *' }, NOW).ok).toBe(false);
     expect(applyScheduleOverride(loop, 'e', { schedule: '0 9 * * *' }, NOW).ok).toBe(false);
+  });
+
+  it('rejects editing or resuming an exhausted trigger (past its run limit)', () => {
+    const loop = withTriggers(base(), [cronTrigger({ schedule: '0 * * * *', maxFires: 3, fireCount: 3, disabled: true })]);
+    expect(applyScheduleOverride(loop, 't', { schedule: '0 9 * * *' }, NOW).ok).toBe(false);
+    expect(applyScheduleOverride(loop, 't', { disabled: false }, NOW).ok).toBe(false);
   });
 });

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/scheduler.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyEventFires, evaluateCronTriggers, isRecurring, nextFireAfter, parseCron, rearmLoop } from '../scheduler';
+import { applyEventFires, applyScheduleOverride, evaluateCronTriggers, isRecurring, nextFireAfter, parseCron, rearmLoop } from '../scheduler';
 import type { Loop, LoopTrigger } from '../../shared/types';
 import { createFakeHost } from './fake-host';
 import { oneStepPlan, seedActiveLoop } from './fixtures';
@@ -128,5 +128,40 @@ describe('applyEventFires', () => {
     const trigger: LoopTrigger = { id: 'e', loopId: 'loop-1', workspaceId: 'ws-1', type: 'event', eventSource: 'fs:changed', fireCount: 0 };
     const withTrigger = withTriggers(loop, [trigger]);
     expect(applyEventFires(withTrigger, [], T0)).toBe(withTrigger);
+  });
+});
+
+describe('applyScheduleOverride', () => {
+  const NOW = '2026-06-22T10:00:00.000Z';
+  const base = () => seedActiveLoop(createFakeHost(), oneStepPlan().plan);
+
+  it('applies a new schedule and re-arms nextFireAt from now', () => {
+    const loop = withTriggers(base(), [cronTrigger({ schedule: '0 * * * *', nextFireAt: '2026-06-22T11:00:00.000Z' })]);
+    const result = applyScheduleOverride(loop, 't', { schedule: '0 9 * * *' }, NOW);
+    expect(result.ok).toBe(true);
+    expect(result.loop?.triggers[0].schedule).toBe('0 9 * * *');
+    expect(result.loop?.triggers[0].nextFireAt).toBe('2026-06-23T09:00:00.000Z');
+    expect(result.loop?.updatedAt).toBe(NOW);
+  });
+
+  it('pauses (clearing nextFireAt) and resumes (re-arming it)', () => {
+    const loop = withTriggers(base(), [cronTrigger({ schedule: '0 * * * *', nextFireAt: '2026-06-22T11:00:00.000Z' })]);
+    const paused = applyScheduleOverride(loop, 't', { disabled: true }, NOW);
+    expect(paused.loop?.triggers[0].disabled).toBe(true);
+    expect(paused.loop?.triggers[0].nextFireAt).toBeUndefined();
+
+    const resumed = applyScheduleOverride(paused.loop!, 't', { disabled: false }, NOW);
+    expect(resumed.loop?.triggers[0].disabled).toBe(false);
+    expect(resumed.loop?.triggers[0].nextFireAt).toBe('2026-06-22T11:00:00.000Z');
+  });
+
+  it('rejects an invalid cron expression, an unknown trigger, and an event trigger', () => {
+    const loop = withTriggers(base(), [
+      cronTrigger(),
+      { id: 'e', loopId: 'loop-1', workspaceId: 'ws-1', type: 'event', eventSource: 'fs:changed', fireCount: 0 },
+    ]);
+    expect(applyScheduleOverride(loop, 't', { schedule: 'not a cron' }, NOW).ok).toBe(false);
+    expect(applyScheduleOverride(loop, 'missing', { schedule: '0 9 * * *' }, NOW).ok).toBe(false);
+    expect(applyScheduleOverride(loop, 'e', { schedule: '0 9 * * *' }, NOW).ok).toBe(false);
   });
 });

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/store.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/store.test.ts
@@ -152,3 +152,29 @@ describe('run-split helpers', () => {
     expect(diff.indexChanged).toBe(true);
   });
 });
+
+describe('schedule summaries (cross-plugin index view)', () => {
+  it('embeds cron/hybrid triggers with a schedule and skips event/manual triggers', () => {
+    const host = createFakeHost();
+    const base = seedActiveLoop(host, oneStepPlan().plan, 'loop-a');
+    const loop: Loop = {
+      ...base,
+      triggers: [
+        { id: 'tc', loopId: 'loop-a', workspaceId: 'ws-1', type: 'cron', schedule: '0 9 * * *', fireCount: 2, nextFireAt: 'n', lastFireAt: 'l' },
+        { id: 'th', loopId: 'loop-a', workspaceId: 'ws-1', type: 'hybrid', schedule: '0 8 * * 1', fireCount: 0, disabled: true },
+        { id: 'te', loopId: 'loop-a', workspaceId: 'ws-1', type: 'event', eventSource: 'fs:changed', fireCount: 0 },
+        { id: 'tm', loopId: 'loop-a', workspaceId: 'ws-1', type: 'manual', fireCount: 0 },
+      ],
+    };
+    expect(toSummary(loop).schedules).toEqual([
+      { triggerId: 'tc', type: 'cron', schedule: '0 9 * * *', nextFireAt: 'n', lastFireAt: 'l', disabled: undefined },
+      { triggerId: 'th', type: 'hybrid', schedule: '0 8 * * 1', nextFireAt: undefined, lastFireAt: undefined, disabled: true },
+    ]);
+  });
+
+  it('omits schedules entirely for unscheduled loops (index stays small)', () => {
+    const host = createFakeHost();
+    const loop = seedActiveLoop(host, oneStepPlan().plan, 'loop-a');
+    expect(toSummary(loop).schedules).toBeUndefined();
+  });
+});

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/store.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/store.test.ts
@@ -161,14 +161,16 @@ describe('schedule summaries (cross-plugin index view)', () => {
       ...base,
       triggers: [
         { id: 'tc', loopId: 'loop-a', workspaceId: 'ws-1', type: 'cron', schedule: '0 9 * * *', fireCount: 2, nextFireAt: 'n', lastFireAt: 'l' },
-        { id: 'th', loopId: 'loop-a', workspaceId: 'ws-1', type: 'hybrid', schedule: '0 8 * * 1', fireCount: 0, disabled: true },
+        { id: 'th', loopId: 'loop-a', workspaceId: 'ws-1', type: 'hybrid', schedule: '0 8 * * 1', fireCount: 0, scheduleDisabled: true },
+        { id: 'tx', loopId: 'loop-a', workspaceId: 'ws-1', type: 'cron', schedule: '0 7 * * *', fireCount: 3, maxFires: 3, disabled: true },
         { id: 'te', loopId: 'loop-a', workspaceId: 'ws-1', type: 'event', eventSource: 'fs:changed', fireCount: 0 },
         { id: 'tm', loopId: 'loop-a', workspaceId: 'ws-1', type: 'manual', fireCount: 0 },
       ],
     };
     expect(toSummary(loop).schedules).toEqual([
-      { triggerId: 'tc', type: 'cron', schedule: '0 9 * * *', nextFireAt: 'n', lastFireAt: 'l', disabled: undefined },
-      { triggerId: 'th', type: 'hybrid', schedule: '0 8 * * 1', nextFireAt: undefined, lastFireAt: undefined, disabled: true },
+      { triggerId: 'tc', type: 'cron', schedule: '0 9 * * *', nextFireAt: 'n', lastFireAt: 'l', paused: undefined, exhausted: undefined },
+      { triggerId: 'th', type: 'hybrid', schedule: '0 8 * * 1', nextFireAt: undefined, lastFireAt: undefined, paused: true, exhausted: undefined },
+      { triggerId: 'tx', type: 'cron', schedule: '0 7 * * *', nextFireAt: undefined, lastFireAt: undefined, paused: undefined, exhausted: true },
     ]);
   });
 

--- a/plugins/sero-orchestrator-plugin/runtime/override-actions.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/override-actions.ts
@@ -1,19 +1,20 @@
 /**
  * Coordinator-facing handlers for the user-override actions (`set_step_model`,
- * `set_step_tools`, `set_step_agent`, `set_loop_context`, `set_delivery`).
- * Kept out of coordinator.ts (500-LOC limit); the coordinator delegates the
- * whole group here. Each is a pure per-loop mapping applied and persisted —
- * overrides take effect on the next run.
+ * `set_step_tools`, `set_step_agent`, `set_loop_context`, `set_delivery`,
+ * `set_schedule`). Kept out of coordinator.ts (500-LOC limit); the coordinator
+ * delegates the whole group here. Each is a pure per-loop mapping applied and
+ * persisted — overrides take effect on the next run.
  */
 
 import type { Loop, OrchestratorAction, OrchestratorActionResult } from '../shared/types';
 import type { OrchestratorHost } from './host';
 import { voidOpenApprovals } from './delivery/delivery-contract';
 import { applyLoopContext, applyLoopDelivery, applyStepAgent, applyStepModel, applyStepTools } from './plan-mapping';
+import { applyScheduleOverride } from './scheduler';
 
 export type OverrideAction = Extract<
   OrchestratorAction,
-  { kind: 'set_step_model' | 'set_step_tools' | 'set_step_agent' | 'set_loop_context' | 'set_delivery' }
+  { kind: 'set_step_model' | 'set_step_tools' | 'set_step_agent' | 'set_loop_context' | 'set_delivery' | 'set_schedule' }
 >;
 
 const OVERRIDE_KINDS: ReadonlySet<string> = new Set([
@@ -22,6 +23,7 @@ const OVERRIDE_KINDS: ReadonlySet<string> = new Set([
   'set_step_agent',
   'set_loop_context',
   'set_delivery',
+  'set_schedule',
 ]);
 
 /** True for every override action — lets the coordinator route them in one line. */
@@ -39,6 +41,8 @@ function mapOverride(loop: Loop, action: OverrideAction, now: string): { ok: boo
       return applyStepAgent(loop, action.stepId, action.agent, now);
     case 'set_loop_context':
       return { ok: true, loop: applyLoopContext(loop, action.overrides, now) };
+    case 'set_schedule':
+      return applyScheduleOverride(loop, action.triggerId, { schedule: action.schedule, disabled: action.disabled }, now);
     case 'set_delivery': {
       const result = applyLoopDelivery(loop, action.delivery, now);
       if (!result.ok || !result.loop) return result;

--- a/plugins/sero-orchestrator-plugin/runtime/scheduler.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/scheduler.ts
@@ -114,6 +114,41 @@ export function reenableSchedule(loop: Loop, now: string): LoopTrigger[] {
 }
 
 /**
+ * Direct user edit of one cron/hybrid trigger's schedule (set_schedule action —
+ * e.g. from the Scheduler app): validates the cron expression, applies the new
+ * schedule and/or paused state, and re-arms nextFireAt from now (cleared while
+ * paused). Event triggers have no schedule and are rejected.
+ */
+export function applyScheduleOverride(
+  loop: Loop,
+  triggerId: string,
+  override: { schedule?: string; disabled?: boolean },
+  now: string,
+): { ok: boolean; loop?: Loop; error?: string } {
+  const index = loop.triggers.findIndex((t) => t.id === triggerId);
+  if (index === -1) return { ok: false, error: `Trigger not found: ${triggerId}` };
+  const trigger = loop.triggers[index];
+  if (trigger.type !== 'cron' && trigger.type !== 'hybrid') {
+    return { ok: false, error: `Trigger ${triggerId} is "${trigger.type}" — only cron/hybrid triggers have a schedule.` };
+  }
+  const schedule = override.schedule ?? trigger.schedule;
+  if (!schedule) return { ok: false, error: 'A cron schedule is required.' };
+  if (!isValidCron(schedule)) {
+    return { ok: false, error: `Invalid cron schedule: "${schedule}" (5 fields: minute hour day-of-month month day-of-week, UTC).` };
+  }
+  const disabled = override.disabled ?? trigger.disabled ?? false;
+  const next = disabled ? null : nextFireAfter(schedule, Date.parse(now));
+  const triggers = [...loop.triggers];
+  triggers[index] = {
+    ...trigger,
+    schedule,
+    disabled,
+    nextFireAt: next !== null ? new Date(next).toISOString() : undefined,
+  };
+  return { ok: true, loop: { ...loop, triggers, updatedAt: now } };
+}
+
+/**
  * Re-applies goal-derived triggers to a loop's EXISTING triggers without
  * resetting run history (used when a refinement changes the goal's cadence or
  * events): an existing cron/hybrid trigger keeps its fireCount/lastFireAt but

--- a/plugins/sero-orchestrator-plugin/runtime/scheduler.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/scheduler.ts
@@ -35,7 +35,7 @@ function fire(trigger: LoopTrigger, nowMs: number, nextFireAt?: string): LoopTri
 export function evaluateCronTriggers(loop: Loop, nowMs: number): { loop: Loop; due: boolean } {
   let due = false;
   const triggers = loop.triggers.map((trigger) => {
-    if (trigger.disabled) return trigger;
+    if (trigger.disabled || trigger.scheduleDisabled) return trigger;
     if (trigger.type !== 'cron' && trigger.type !== 'hybrid') return trigger;
     if (!trigger.schedule || !trigger.nextFireAt) return trigger;
     if (Date.parse(trigger.nextFireAt) > nowMs) return trigger;
@@ -113,11 +113,20 @@ export function reenableSchedule(loop: Loop, now: string): LoopTrigger[] {
   });
 }
 
+/** True once a trigger has fired its declared maxFires — it will never fire again. */
+export function isExhausted(trigger: LoopTrigger): boolean {
+  return trigger.maxFires !== undefined && trigger.fireCount >= trigger.maxFires;
+}
+
 /**
  * Direct user edit of one cron/hybrid trigger's schedule (set_schedule action —
  * e.g. from the Scheduler app): validates the cron expression, applies the new
  * schedule and/or paused state, and re-arms nextFireAt from now (cleared while
- * paused). Event triggers have no schedule and are rejected.
+ * paused). The paused state maps to `scheduleDisabled`, not `disabled`, so a
+ * hybrid trigger paused here keeps firing on its events — only its cron schedule
+ * pauses. Event triggers have no schedule and are rejected; a trigger that is
+ * fully off (loop complete/disabled, or maxFires exhausted) can't be re-armed
+ * from here and is rejected — the loop must be restarted in Orchestrator.
  */
 export function applyScheduleOverride(
   loop: Loop,
@@ -131,18 +140,25 @@ export function applyScheduleOverride(
   if (trigger.type !== 'cron' && trigger.type !== 'hybrid') {
     return { ok: false, error: `Trigger ${triggerId} is "${trigger.type}" — only cron/hybrid triggers have a schedule.` };
   }
+  if (trigger.disabled) {
+    const why = isExhausted(trigger)
+      ? `has reached its run limit (${trigger.fireCount}/${trigger.maxFires})`
+      : 'belongs to a loop that is complete or turned off';
+    return { ok: false, error: `Trigger ${triggerId} ${why} — restart or re-enable the loop in Orchestrator to run it again.` };
+  }
   const schedule = override.schedule ?? trigger.schedule;
   if (!schedule) return { ok: false, error: 'A cron schedule is required.' };
   if (!isValidCron(schedule)) {
     return { ok: false, error: `Invalid cron schedule: "${schedule}" (5 fields: minute hour day-of-month month day-of-week, UTC).` };
   }
-  const disabled = override.disabled ?? trigger.disabled ?? false;
-  const next = disabled ? null : nextFireAfter(schedule, Date.parse(now));
+  const scheduleDisabled = override.disabled ?? trigger.scheduleDisabled ?? false;
+  // The trigger is live (guarded above), so arm the next fire unless it's paused.
+  const next = scheduleDisabled ? null : nextFireAfter(schedule, Date.parse(now));
   const triggers = [...loop.triggers];
   triggers[index] = {
     ...trigger,
     schedule,
-    disabled,
+    scheduleDisabled,
     nextFireAt: next !== null ? new Date(next).toISOString() : undefined,
   };
   return { ok: true, loop: { ...loop, triggers, updatedAt: now } };

--- a/plugins/sero-orchestrator-plugin/runtime/store.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/store.ts
@@ -20,6 +20,7 @@ import type {
   RunIndex,
 } from '../shared/types';
 import { aggregateUsage } from '../shared/usage';
+import { isExhausted } from './scheduler';
 
 /** Step progress for the home overview, derived from the plan + step states. */
 function toProgress(loop: Loop): LoopProgress | undefined {
@@ -67,7 +68,8 @@ function toSchedules(loop: Loop): OrchestratorScheduleSummary[] | undefined {
       schedule: t.schedule,
       nextFireAt: t.nextFireAt,
       lastFireAt: t.lastFireAt,
-      disabled: t.disabled,
+      paused: t.scheduleDisabled || undefined,
+      exhausted: isExhausted(t) || undefined,
     });
   }
   return schedules.length > 0 ? schedules : undefined;

--- a/plugins/sero-orchestrator-plugin/runtime/store.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/store.ts
@@ -8,6 +8,7 @@
  * unchanged loop's file is never rewritten when another loop changes.
  */
 
+import type { OrchestratorScheduleSummary } from '@sero-ai/common';
 import type {
   Loop,
   LoopAttention,
@@ -49,6 +50,27 @@ function toAttention(loop: Loop): LoopAttention | undefined {
     }));
   if (!input && suggestions.length === 0) return undefined;
   return { input, suggestions: suggestions.length ? suggestions : undefined };
+}
+
+/**
+ * The loop's cron/hybrid schedules embedded in its summary, so external surfaces
+ * (the Scheduler app) can list scheduled loops from the watched index alone.
+ * Undefined when the loop has no schedule, keeping the index small.
+ */
+function toSchedules(loop: Loop): OrchestratorScheduleSummary[] | undefined {
+  const schedules: OrchestratorScheduleSummary[] = [];
+  for (const t of loop.triggers) {
+    if ((t.type !== 'cron' && t.type !== 'hybrid') || !t.schedule) continue;
+    schedules.push({
+      triggerId: t.id,
+      type: t.type,
+      schedule: t.schedule,
+      nextFireAt: t.nextFireAt,
+      lastFireAt: t.lastFireAt,
+      disabled: t.disabled,
+    });
+  }
+  return schedules.length > 0 ? schedules : undefined;
 }
 
 /**
@@ -124,6 +146,7 @@ export function toSummary(loop: Loop): LoopSummary {
     pendingInput: pendingInput || undefined,
     progress: toProgress(loop),
     attention: toAttention(loop),
+    schedules: toSchedules(loop),
     libraryLink: loop.libraryLink,
     createdAt: loop.createdAt,
     updatedAt: loop.updatedAt,

--- a/plugins/sero-orchestrator-plugin/shared/actions.ts
+++ b/plugins/sero-orchestrator-plugin/shared/actions.ts
@@ -43,6 +43,7 @@ export type OrchestratorAction =
   | { kind: 'set_step_agent'; loopId: string; stepId: string; agent?: string }
   | { kind: 'set_loop_context'; loopId: string; overrides: ContextOverrides | null }
   | { kind: 'set_delivery'; loopId: string; delivery: LoopDeliverySettings }
+  | { kind: 'set_schedule'; loopId: string; triggerId: string; schedule?: string; disabled?: boolean }
   | { kind: 'reflect'; loopId: string }
   | { kind: 'reflect_workspace' }
   | { kind: 'choose_suggestion'; loopId: string; suggestionId: string; decision: 'approve' | 'reject'; rejectionReason?: string }

--- a/plugins/sero-orchestrator-plugin/shared/index-types.ts
+++ b/plugins/sero-orchestrator-plugin/shared/index-types.ts
@@ -8,6 +8,7 @@
  * specs/09-ui-redesign.md). Type-only imports keep the re-export cycle harmless.
  */
 
+import type { OrchestratorScheduledLoopView, OrchestratorScheduleSummary } from '@sero-ai/common';
 import type {
   CompletionSignal,
   LoopRunStatus,
@@ -33,13 +34,20 @@ export interface LoopProgress {
   running: boolean;
 }
 
-/** Lightweight per-loop entry for the watched index (drives the loop list + home). */
-export interface LoopSummary {
+/**
+ * Lightweight per-loop entry for the watched index (drives the loop list + home).
+ * Extends the cross-plugin view contract (@sero-ai/common orchestrator-contract)
+ * that external surfaces like the Scheduler app read, so drifting from it fails
+ * typecheck here.
+ */
+export interface LoopSummary extends OrchestratorScheduledLoopView {
   id: string;
   title: string;
   status: LoopStatus;
   summary: string;
   prompt: string;
+  /** Cron/hybrid trigger schedules — lets external surfaces list scheduled loops from the index alone. */
+  schedules?: OrchestratorScheduleSummary[];
   /** Count of pending reflection suggestions — drives the loop-list badge. */
   pendingSuggestions?: number;
   /** Count of open questions the loop is waiting on — drives the input badge. */

--- a/plugins/sero-orchestrator-plugin/shared/trigger-types.ts
+++ b/plugins/sero-orchestrator-plugin/shared/trigger-types.ts
@@ -35,5 +35,15 @@ export interface LoopTrigger {
   fireCount: number;
   lastFireAt?: string;
   nextFireAt?: string;
+  /**
+   * Fully off — nothing fires this trigger (loop disabled/complete, or maxFires
+   * exhausted). Blocks BOTH the cron schedule and event matching.
+   */
   disabled?: boolean;
+  /**
+   * Only the cron schedule is paused (user action, e.g. from the Scheduler app).
+   * A hybrid trigger paused this way keeps firing on its events — unlike
+   * `disabled`, this never touches event matching.
+   */
+  scheduleDisabled?: boolean;
 }

--- a/plugins/sero-orchestrator-plugin/ui/OrchestratorApp.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/OrchestratorApp.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useAppTools } from '@sero-ai/app-runtime';
+import { consumeAppLaunchParams, useAppTools } from '@sero-ai/app-runtime';
 import { Button } from '@sero-ai/ui';
 import { Home, Infinity as InfinityIcon, Library, Plus, Sparkles } from 'lucide-react';
 import { DEFAULT_LIBRARY_INDEX } from '../shared/defaults';
@@ -17,6 +17,23 @@ import './styles.css';
 
 type View = { mode: 'home' } | { mode: 'detail'; loopId: string | null } | { mode: 'create' } | { mode: 'library' };
 
+/** Launch params another app can hand to `openSeroApp('orchestrator', { loopId })`. */
+interface OrchestratorLaunchParams extends Record<string, unknown> {
+  loopId?: string;
+}
+
+/** Initial view: a loop deep-link from another app lands on that loop's detail. */
+function initialView(): View {
+  const params = consumeAppLaunchParams<OrchestratorLaunchParams>('orchestrator');
+  return typeof params?.loopId === 'string' ? { mode: 'detail', loopId: params.loopId } : { mode: 'home' };
+}
+
+/** Directory of a file path, tolerant of either separator (renderer has no node:path). */
+function dirOf(filePath: string): string {
+  const i = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  return i >= 0 ? filePath.slice(0, i) : '';
+}
+
 /**
  * Orchestrator panel. The home view (default) is a cross-loop "Needs you" inbox +
  * loops overview; selecting a loop opens the list+detail surface. All mutations
@@ -27,7 +44,7 @@ type View = { mode: 'home' } | { mode: 'detail'; loopId: string | null } | { mod
 export function OrchestratorApp() {
   const stateDir = useStateDir();
   const { run } = useAppTools();
-  const [view, setView] = useState<View>({ mode: 'home' });
+  const [view, setView] = useState<View>(initialView);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [reflectSummary, setReflectSummary] = useState<string | null>(null);

--- a/plugins/sero-orchestrator-plugin/ui/__tests__/action-params.test.ts
+++ b/plugins/sero-orchestrator-plugin/ui/__tests__/action-params.test.ts
@@ -33,6 +33,21 @@ describe('actionToParams', () => {
     });
   });
 
+  it('maps set_schedule (schedule edits also arrive from the Scheduler app)', () => {
+    expect(actionToParams({ kind: 'set_schedule', loopId: 'l1', triggerId: 't1', schedule: '0 9 * * *' })).toEqual({
+      action: 'set_schedule',
+      loopId: 'l1',
+      triggerId: 't1',
+      schedule: '0 9 * * *',
+    });
+    expect(actionToParams({ kind: 'set_schedule', loopId: 'l1', triggerId: 't1', disabled: true })).toEqual({
+      action: 'set_schedule',
+      loopId: 'l1',
+      triggerId: 't1',
+      scheduleDisabled: true,
+    });
+  });
+
   it('maps the catalog actions', () => {
     expect(actionToParams({ kind: 'catalog_install', repoKey: 'official', slug: 'ci-fixer' })).toEqual({
       action: 'catalog_install',

--- a/plugins/sero-orchestrator-plugin/ui/lib/action-params.ts
+++ b/plugins/sero-orchestrator-plugin/ui/lib/action-params.ts
@@ -49,6 +49,11 @@ export function actionToParams(action: OrchestratorAction): Record<string, unkno
       params.deliveryDestination = action.delivery.destination;
       if (action.delivery.params) params.deliveryParamsJson = JSON.stringify(action.delivery.params);
       break;
+    case 'set_schedule':
+      params.triggerId = action.triggerId;
+      if (action.schedule !== undefined) params.schedule = action.schedule;
+      if (action.disabled !== undefined) params.scheduleDisabled = action.disabled;
+      break;
     case 'library_save':
       params.mode = action.mode;
       if (action.name !== undefined) params.name = action.name;


### PR DESCRIPTION
The Scheduler app gains a Loops tab listing the active workspace's
scheduled Orchestrator loops, with a link back to the loop's details in
the Orchestrator app and a cron-focused editor for the loop schedule
(edit/pause/resume only — the loop itself stays managed in Orchestrator).

- common: new orchestrator-contract with the cross-plugin index view and
  set_schedule param shapes, so producer/consumer drift fails typecheck
- orchestrator: embed cron/hybrid trigger summaries in the watched loop
  index; new set_schedule action (tool + /orchestrator command) that
  validates the cron expression and re-arms nextFireAt via the scheduler
- app-runtime: openSeroApp/consumeAppLaunchParams for cross-app deep
  links over the existing appControl bridge; Orchestrator consumes a
  loopId launch param to open directly on that loop's detail view
- cron: Loops tab (cards + schedule dialog reusing the cron validation
  and presets), watching the Orchestrator index via the appState bridge

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y2Ca3KR2PFEMU9tE6b1vkV