### PR TITLE
fix(desktop): isolate Chromium profile data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ dist/
 test-results/
 playwright-report/
 .playwright-cli/
+apps/desktop/.sero-e2e/
+apps/desktop/.sero-layout-test/
+apps/desktop/.sero-test-data/
 .sero-test-data/
 
 # Local agent scratch data

--- a/apps/desktop/e2e/global-setup.ts
+++ b/apps/desktop/e2e/global-setup.ts
@@ -1,0 +1,5 @@
+import { cleanupE2eDataRoot } from './helpers/seroHome';
+
+export default async function globalSetup(): Promise<void> {
+  cleanupE2eDataRoot();
+}

--- a/apps/desktop/e2e/helpers/__tests__/seroHome.test.ts
+++ b/apps/desktop/e2e/helpers/__tests__/seroHome.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import {
+  E2E_DATA_ROOT,
+  cleanupE2eDataRoot,
   createTempSeroHome,
   seedProfile,
   seedWorkspace,
@@ -22,8 +24,17 @@ describe('seroHome helper', () => {
     const home = createTempSeroHome();
     created.push(home);
     expect(fs.existsSync(home.path)).toBe(true);
-    expect(home.path).toMatch(/sero-e2e-/);
+    expect(home.path.startsWith(E2E_DATA_ROOT)).toBe(true);
     expect(fs.readdirSync(home.path)).toEqual([]);
+  });
+
+  it('cleanupE2eDataRoot removes the shared e2e root', () => {
+    const home = createTempSeroHome();
+    fs.writeFileSync(path.join(home.path, 'marker.txt'), 'x');
+
+    cleanupE2eDataRoot();
+
+    expect(fs.existsSync(E2E_DATA_ROOT)).toBe(false);
   });
 
   it('two consecutive calls produce distinct directories', () => {
@@ -46,12 +57,12 @@ describe('seroHome helper', () => {
     expect(() => home.cleanup()).not.toThrow();
   });
 
-  it('seedProfile writes profiles/registry.json and a default profile dir', () => {
+  it('seedProfile writes profiles.json and a default profile dir', () => {
     const home = createTempSeroHome();
     created.push(home);
     const profile = seedProfile(home, { name: 'Test' });
     const registry = JSON.parse(
-      fs.readFileSync(path.join(home.path, 'profiles', 'registry.json'), 'utf8'),
+      fs.readFileSync(path.join(home.path, 'profiles.json'), 'utf8'),
     );
     expect(registry.activeProfileId).toBe(profile.id);
     expect(registry.profiles).toHaveLength(1);
@@ -66,7 +77,7 @@ describe('seroHome helper', () => {
     const wsPath = path.join(home.path, 'sample-repo');
     fs.mkdirSync(wsPath, { recursive: true });
     const ws = seedWorkspace(home, { path: wsPath, name: 'sample' });
-    const wsFile = path.join(home.path, 'profiles', home.activeProfileId!, 'workspaces.json');
+    const wsFile = path.join(home.path, 'profiles', home.activeProfileId!, 'agent', 'workspaces.json');
     const wsJson = JSON.parse(fs.readFileSync(wsFile, 'utf8'));
     expect(wsJson.workspaces).toHaveLength(1);
     expect(wsJson.workspaces[0].id).toBe(ws.id);

--- a/apps/desktop/e2e/helpers/electron-app.ts
+++ b/apps/desktop/e2e/helpers/electron-app.ts
@@ -4,9 +4,11 @@ import type { ChildProcess } from 'node:child_process';
 import path from 'path';
 import type { RuntimeBackend } from './runtime';
 import { currentRuntimeFromEnv, runtimeAvailableOn } from './runtime';
+import { createTempSeroHome, type TempSeroHome } from './seroHome';
 
 const MAIN_PROCESS_EVAL_RETRIES = 5;
 const MAIN_PROCESS_EVAL_RETRY_DELAY_MS = 200;
+const ownedHomes = new WeakMap<ElectronApplication, TempSeroHome>();
 
 /**
  * Options for launching the Sero Electron app in tests.
@@ -73,7 +75,8 @@ export async function launchSeroApp(
     );
   }
 
-  const seroHome = options.seroHome ?? path.join(desktopRoot, '.sero-test-data');
+  let ownedHome: TempSeroHome | null = null;
+  const seroHome = options.seroHome ?? (ownedHome = createTempSeroHome()).path;
 
   if (options.seed) {
     await options.seed(seroHome);
@@ -97,42 +100,61 @@ export async function launchSeroApp(
   Object.assign(env, options.env);
   restoreWindowsProfileEnv(env);
 
-  const app = await electron.launch({
-    args: [mainEntry],
-    cwd: desktopRoot,
-    env,
-  });
-
-  const page = await app.firstWindow();
-  await page.waitForLoadState('domcontentloaded');
-
-  if (options.mockRelaunch) {
-    await app.evaluate(({ app: electronApp }) => {
-      const calls: Array<{ method: 'relaunch' | 'exit'; args: unknown[] }> = [];
-      (globalThis as Record<string, unknown>).__seroRelaunchCalls = calls;
-      const originalRelaunch = electronApp.relaunch.bind(electronApp);
-      const originalExit = electronApp.exit.bind(electronApp);
-      electronApp.relaunch = ((...args: unknown[]) => {
-        calls.push({ method: 'relaunch', args });
-      }) as typeof electronApp.relaunch;
-      electronApp.exit = ((...args: unknown[]) => {
-        calls.push({ method: 'exit', args });
-      }) as typeof electronApp.exit;
-      void originalRelaunch;
-      void originalExit;
+  let app: ElectronApplication;
+  try {
+    app = await electron.launch({
+      args: [mainEntry],
+      cwd: desktopRoot,
+      env,
     });
+  } catch (error) {
+    ownedHome?.cleanup();
+    throw error;
+  }
+
+  if (ownedHome) ownedHomes.set(app, ownedHome);
+
+  let page: Page;
+  try {
+    page = await app.firstWindow();
+    await page.waitForLoadState('domcontentloaded');
+
+    if (options.mockRelaunch) {
+      await app.evaluate(({ app: electronApp }) => {
+        const calls: Array<{ method: 'relaunch' | 'exit'; args: unknown[] }> = [];
+        (globalThis as Record<string, unknown>).__seroRelaunchCalls = calls;
+        const originalRelaunch = electronApp.relaunch.bind(electronApp);
+        const originalExit = electronApp.exit.bind(electronApp);
+        electronApp.relaunch = ((...args: unknown[]) => {
+          calls.push({ method: 'relaunch', args });
+        }) as typeof electronApp.relaunch;
+        electronApp.exit = ((...args: unknown[]) => {
+          calls.push({ method: 'exit', args });
+        }) as typeof electronApp.exit;
+        void originalRelaunch;
+        void originalExit;
+      });
+    }
+  } catch (error) {
+    await closeSeroApp(app).catch(() => undefined);
+    throw error;
   }
 
   return { app, page };
 }
 
 export async function closeSeroApp(app: ElectronApplication, timeoutMs = 5_000): Promise<void> {
-  const child = app.process();
-  const closeSettled = await withTimeout(app.close(), timeoutMs);
-  if (closeSettled) return;
+  try {
+    const child = app.process();
+    const closeSettled = await withTimeout(app.close(), timeoutMs);
+    if (closeSettled) return;
 
-  await killProcessTree(child);
-  await waitForProcessExit(child, timeoutMs);
+    await killProcessTree(child);
+    await waitForProcessExit(child, timeoutMs);
+  } finally {
+    ownedHomes.get(app)?.cleanup();
+    ownedHomes.delete(app);
+  }
 }
 
 async function withTimeout(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {

--- a/apps/desktop/e2e/helpers/index.ts
+++ b/apps/desktop/e2e/helpers/index.ts
@@ -3,6 +3,8 @@ export type { LaunchOptions } from './electron-app';
 export { layout, sidebar, chat, vcs, workspace, fileTree } from './selectors';
 export {
   createTempSeroHome,
+  cleanupE2eDataRoot,
+  E2E_DATA_ROOT,
   seedProfile,
   seedWorkspace,
   type TempSeroHome,

--- a/apps/desktop/e2e/helpers/seroHome.ts
+++ b/apps/desktop/e2e/helpers/seroHome.ts
@@ -1,12 +1,6 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-
-// NOTE: Seeded profiles/registry.json is only consulted when the app boots
-// WITHOUT SERO_HOME_OVERRIDE. Today's launcher uses SERO_HOME_OVERRIDE for
-// isolation; profile-switch tests in Phase 2 will need the launcher's
-// `seedMode: 'registry'` option (see app launcher extension in Task 5).
 
 export interface TempSeroHome {
   path: string;
@@ -14,10 +8,23 @@ export interface TempSeroHome {
   cleanup: () => void;
 }
 
+const DESKTOP_ROOT = path.resolve(__dirname, '../..');
+export const E2E_DATA_ROOT = path.join(DESKTOP_ROOT, '.sero-e2e');
+const LEGACY_E2E_DATA_ROOTS = [
+  path.join(DESKTOP_ROOT, '.sero-test-data'),
+  path.join(DESKTOP_ROOT, '.sero-layout-test'),
+];
+
+export function cleanupE2eDataRoot(): void {
+  fs.rmSync(E2E_DATA_ROOT, { recursive: true, force: true });
+  for (const legacyRoot of LEGACY_E2E_DATA_ROOTS) {
+    fs.rmSync(legacyRoot, { recursive: true, force: true });
+  }
+}
+
 export function createTempSeroHome(): TempSeroHome {
-  const baseDir = process.platform === 'win32' ? path.join(os.homedir(), '.sero-e2e') : os.tmpdir();
-  fs.mkdirSync(baseDir, { recursive: true });
-  const dir = fs.mkdtempSync(path.join(baseDir, 'sero-e2e-'));
+  fs.mkdirSync(E2E_DATA_ROOT, { recursive: true });
+  const dir = fs.mkdtempSync(path.join(E2E_DATA_ROOT, 'home-'));
   const handle: TempSeroHome = {
     path: dir,
     activeProfileId: null,
@@ -44,14 +51,21 @@ export function seedProfile(home: TempSeroHome, opts: SeedProfileOpts): SeededPr
   const profileRoot = path.join(home.path, 'profiles', id);
   fs.mkdirSync(path.join(profileRoot, 'agent'), { recursive: true });
 
-  const registryPath = path.join(home.path, 'profiles', 'registry.json');
+  const registryPath = path.join(home.path, 'profiles.json');
   const existing = readJsonIfExists(registryPath, {
+    version: 1,
     activeProfileId: null as string | null,
-    profiles: [] as Array<{ id: string; name: string; path: string }>,
+    profiles: [] as Array<{ id: string; name: string; path: string; createdAt: string; onboarded: boolean }>,
   });
-  existing.profiles.push({ id, name: opts.name, path: profileRoot });
+  existing.profiles.push({
+    id,
+    name: opts.name,
+    path: profileRoot,
+    createdAt: new Date().toISOString(),
+    onboarded: true,
+  });
   existing.activeProfileId = id;
-  fs.writeFileSync(registryPath, JSON.stringify(existing, null, 2));
+  fs.writeFileSync(registryPath, JSON.stringify(existing, null, 2) + '\n');
 
   home.activeProfileId = id;
   return { id, name: opts.name, path: profileRoot };
@@ -75,7 +89,7 @@ export function seedWorkspace(home: TempSeroHome, opts: SeedWorkspaceOpts): Seed
     throw new Error('seedWorkspace requires seedProfile first');
   }
   const id = opts.id ?? randomUUID();
-  const wsFile = path.join(home.path, 'profiles', home.activeProfileId, 'workspaces.json');
+  const wsFile = path.join(home.path, 'profiles', home.activeProfileId, 'agent', 'workspaces.json');
   const existing = readJsonIfExists(wsFile, {
     workspaces: [] as Array<{
       id: string;

--- a/apps/desktop/e2e/layout.workflow.spec.ts
+++ b/apps/desktop/e2e/layout.workflow.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type ElectronApplication, type Page } from '@playwright/test';
-import { launchSeroApp, layout } from './helpers';
+import { E2E_DATA_ROOT, launchSeroApp, layout } from './helpers';
 import fs from 'fs';
 import path from 'path';
 
@@ -10,7 +10,7 @@ import path from 'path';
  * for the main sidebar, chat panel, and ExplorerWorkspace terminal.
  */
 
-const SERO_TEST_HOME = path.resolve(__dirname, '../.sero-layout-test');
+const SERO_TEST_HOME = path.join(E2E_DATA_ROOT, 'layout-test');
 const LAYOUT_FILE = path.join(SERO_TEST_HOME, 'agent', 'layout.json');
 
 // ── Helpers ─────────────────────────────────────────────────────

--- a/apps/desktop/electron/__tests__/platform/profile-user-data.test.ts
+++ b/apps/desktop/electron/__tests__/platform/profile-user-data.test.ts
@@ -1,0 +1,66 @@
+import { existsSync } from 'fs';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  legacyProfileUserDataPath,
+  migrateLegacyProfileUserData,
+  profileUserDataPath,
+} from '@electron/platform/profile-user-data';
+
+describe('profile Chromium user data paths', () => {
+  let tmpRoot: string | null = null;
+
+  async function makeTmpRoot(): Promise<string> {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-profile-user-data-'));
+    return tmpRoot;
+  }
+
+  afterEach(async () => {
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = null;
+    }
+  });
+
+  it('stores Chromium data inside the active SERO_HOME', () => {
+    expect(profileUserDataPath('/profiles/work')).toBe('/profiles/work/chromium-user-data');
+  });
+
+  it('resolves the old Electron app-support profile path for migration', () => {
+    expect(legacyProfileUserDataPath('/app-support/Electron', 'profile-id')).toBe(
+      '/app-support/Electron/profiles/profile-id',
+    );
+  });
+
+  it('moves legacy Chromium data when the new profile path is empty', async () => {
+    const root = await makeTmpRoot();
+    const legacyPath = path.join(root, 'Electron', 'profiles', 'active-profile');
+    const targetPath = path.join(root, 'profile-home', 'chromium-user-data');
+    await fs.mkdir(legacyPath, { recursive: true });
+    await fs.writeFile(path.join(legacyPath, 'Preferences'), '{}');
+
+    migrateLegacyProfileUserData(legacyPath, targetPath);
+
+    expect(existsSync(legacyPath)).toBe(false);
+    await expect(fs.readFile(path.join(targetPath, 'Preferences'), 'utf8')).resolves.toBe('{}');
+  });
+
+  it('leaves legacy data in place when target data already exists', async () => {
+    const root = await makeTmpRoot();
+    const legacyPath = path.join(root, 'Electron', 'profiles', 'active-profile');
+    const targetPath = path.join(root, 'profile-home', 'chromium-user-data');
+    await fs.mkdir(legacyPath, { recursive: true });
+    await fs.mkdir(targetPath, { recursive: true });
+    await fs.writeFile(path.join(legacyPath, 'Preferences'), 'legacy');
+    await fs.writeFile(path.join(targetPath, 'Preferences'), 'target');
+
+    migrateLegacyProfileUserData(legacyPath, targetPath);
+
+    await expect(fs.readFile(path.join(legacyPath, 'Preferences'), 'utf8')).resolves.toBe('legacy');
+    await expect(fs.readFile(path.join(targetPath, 'Preferences'), 'utf8')).resolves.toBe('target');
+  });
+});

--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -23,6 +23,11 @@ import type { SettingsPackageSource } from '../src/types/ipc';
 // Set userData path BEFORE app.whenReady() so Chromium initialises with the
 // correct directory. This isolates cookies, localStorage, caches, and
 // session data between profiles.
+//
+// userData always lives under SERO_HOME so it tracks the active profile.
+// When there is no active profile yet (fresh install / pre-onboarding) there
+// is no legacy data worth preserving, so migration is intentionally skipped
+// and Chromium simply starts fresh in the SERO_HOME location.
 const profileUserData = profileUserDataPath(SERO_HOME);
 if (ACTIVE_PROFILE_ID) {
   const defaultUserDataPath = app.getPath('userData');

--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -23,14 +23,16 @@ import type { SettingsPackageSource } from '../src/types/ipc';
 // Set userData path BEFORE app.whenReady() so Chromium initialises with the
 // correct directory. This isolates cookies, localStorage, caches, and
 // session data between profiles.
+const profileUserData = profileUserDataPath(SERO_HOME);
 if (ACTIVE_PROFILE_ID) {
-  const profileUserData = path.join(
-    app.getPath('userData'),
-    'profiles',
-    ACTIVE_PROFILE_ID,
+  const defaultUserDataPath = app.getPath('userData');
+  migrateLegacyProfileUserData(
+    legacyProfileUserDataPath(defaultUserDataPath, ACTIVE_PROFILE_ID),
+    profileUserData,
   );
-  app.setPath('userData', profileUserData);
 }
+mkdirSync(profileUserData, { recursive: true });
+app.setPath('userData', profileUserData);
 import { registerAllIpcHandlers } from './ipc';
 import { forwardWindowStateEvents } from './ipc/platform/system/window';
 import {
@@ -76,6 +78,11 @@ import { executeCliArgv } from './cli/core/batch-executor';
 import { initUpdater } from './features/updater/updater';
 import { installApplicationMenu } from './features/updater/menu';
 import { getPackageSource, removeStaleBuiltinPackages } from './platform/protocols/builtin-package-settings';
+import {
+  legacyProfileUserDataPath,
+  migrateLegacyProfileUserData,
+  profileUserDataPath,
+} from './platform/profile-user-data';
 
 let mainWindow: BrowserWindow | null = null;
 let isGracefullyShuttingDown = false;

--- a/apps/desktop/electron/platform/profile-user-data.ts
+++ b/apps/desktop/electron/platform/profile-user-data.ts
@@ -29,8 +29,8 @@ export function migrateLegacyProfileUserData(
       cpSync(legacyPath, targetPath, { recursive: true });
       rmSync(legacyPath, { recursive: true, force: true });
       console.log('[sero:profile] Copied Chromium user data to', targetPath);
-    } catch {
-      console.warn('[sero:profile] Failed to move legacy Chromium user data:', error);
+    } catch (copyError) {
+      console.warn('[sero:profile] Failed to move legacy Chromium user data:', copyError);
     }
   }
 }

--- a/apps/desktop/electron/platform/profile-user-data.ts
+++ b/apps/desktop/electron/platform/profile-user-data.ts
@@ -1,0 +1,36 @@
+import { cpSync, existsSync, mkdirSync, renameSync, rmSync } from 'fs';
+import path from 'path';
+
+export const PROFILE_USER_DATA_DIRNAME = 'chromium-user-data';
+
+export function profileUserDataPath(seroHome: string): string {
+  return path.join(seroHome, PROFILE_USER_DATA_DIRNAME);
+}
+
+export function legacyProfileUserDataPath(
+  defaultUserDataPath: string,
+  activeProfileId: string,
+): string {
+  return path.join(defaultUserDataPath, 'profiles', activeProfileId);
+}
+
+export function migrateLegacyProfileUserData(
+  legacyPath: string,
+  targetPath: string,
+): void {
+  if (existsSync(targetPath) || !existsSync(legacyPath)) return;
+
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  try {
+    renameSync(legacyPath, targetPath);
+    console.log('[sero:profile] Moved Chromium user data to', targetPath);
+  } catch (error) {
+    try {
+      cpSync(legacyPath, targetPath, { recursive: true });
+      rmSync(legacyPath, { recursive: true, force: true });
+      console.log('[sero:profile] Copied Chromium user data to', targetPath);
+    } catch {
+      console.warn('[sero:profile] Failed to move legacy Chromium user data:', error);
+    }
+  }
+}

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -23,6 +23,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './e2e',
   testMatch: '**/*.spec.ts',
+  globalSetup: './e2e/global-setup.ts',
 
   /* Fail the build on CI if you accidentally left test.only in source. */
   forbidOnly: !!process.env.CI,

--- a/apps/docs-site/docs/guide/profiles-and-onboarding.md
+++ b/apps/docs-site/docs/guide/profiles-and-onboarding.md
@@ -27,6 +27,7 @@ Profiles are practical local separation, not cryptographic isolation. Someone wh
 | Profile-local environment variables | `<SERO_HOME>/agent/.env` |
 | Model/provider settings | `<SERO_HOME>/agent/settings.json`, `<SERO_HOME>/agent/models.json` |
 | Layout and UI state | `<SERO_HOME>/agent/layout.json` |
+| Chromium browser data | `<SERO_HOME>/chromium-user-data/` |
 | Skills, prompts, and agents | `<SERO_HOME>/agent/skills/`, `<SERO_HOME>/agent/prompts/`, `<SERO_HOME>/agent/agents/` |
 | Workspaces and global memory files | `<SERO_HOME>/workspaces/` |
 | App state | `<SERO_HOME>/apps/` and workspace `.sero/apps/` folders |
@@ -79,7 +80,7 @@ Current behavior:
 
 - Sero will not delete the only profile.
 - Sero will not delete the active profile; switch to another profile first.
-- Profile deletion removes the registry entry only. It does **not** delete the profile files from disk.
+- Profile deletion removes the registry entry only. It does **not** delete the profile files from disk, including Chromium browser data.
 
 If you want to remove the data too, first back up anything important, then delete the profile folder manually from your operating system.
 


### PR DESCRIPTION
## Summary
- Store Electron/Chromium user data inside the active Sero profile at `<SERO_HOME>/chromium-user-data` instead of the generic Electron app-support directory
- Migrate existing profile Chromium data from the old `Application Support/Electron/profiles/<id>` location
- Move e2e disposable Sero homes under `apps/desktop/.sero-e2e`, clean that root at Playwright startup, and clean launcher-owned homes on close
- Document the Chromium data location and ignore e2e scratch roots

## Tests
- `pnpm exec vitest run e2e/helpers/__tests__/seroHome.test.ts electron/__tests__/platform/profile-user-data.test.ts`
- `pnpm --filter @sero/desktop typecheck`
- `pnpm typecheck`