### PR TITLE
Fix React Doctor cleanup findings

### DIFF
--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -111,11 +111,11 @@ export function DiffTab({ state }: Props) {
         <AnimatePresence>
           {navOpen && files.length > 1 && (
             <motion.div
-              initial={{ width: 0, opacity: 0 }}
-              animate={{ width: 180, opacity: 1 }}
-              exit={{ width: 0, opacity: 0 }}
+              initial={{ x: -16, opacity: 0 }}
+              animate={{ x: 0, opacity: 1 }}
+              exit={{ x: -16, opacity: 0 }}
               transition={{ duration: 0.15 }}
-              className="overflow-hidden border-r border-[var(--border-subtle)]"
+              className="w-[180px] shrink-0 overflow-hidden border-r border-[var(--border-subtle)]"
             >
               <div className="h-full w-[180px] overflow-y-auto py-1">
                 {files.map((f) => (

--- a/packages/ui/src/components/ai-elements/speech-input.tsx
+++ b/packages/ui/src/components/ai-elements/speech-input.tsx
@@ -101,6 +101,7 @@ export const SpeechInput = ({
   const [isRecognitionReady, setIsRecognitionReady] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaRecorderCleanupRef = useRef<(() => void) | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
   const onTranscriptionChangeRef = useRef<
@@ -184,6 +185,7 @@ export const SpeechInput = ({
       if (mediaRecorderRef.current?.state === "recording") {
         mediaRecorderRef.current.stop();
       }
+      mediaRecorderCleanupRef.current?.();
       if (streamRef.current) {
         for (const track of streamRef.current.getTracks()) {
           track.stop();
@@ -216,6 +218,7 @@ export const SpeechInput = ({
           track.stop();
         }
         streamRef.current = null;
+        cleanupMediaRecorder();
 
         const audioBlob = new Blob(audioChunksRef.current, {
           type: "audio/webm",
@@ -242,6 +245,19 @@ export const SpeechInput = ({
           track.stop();
         }
         streamRef.current = null;
+        cleanupMediaRecorder();
+      };
+
+      const cleanupMediaRecorder = () => {
+        mediaRecorder.removeEventListener("dataavailable", handleDataAvailable);
+        mediaRecorder.removeEventListener("stop", handleStop);
+        mediaRecorder.removeEventListener("error", handleError);
+        if (mediaRecorderRef.current === mediaRecorder) {
+          mediaRecorderRef.current = null;
+        }
+        if (mediaRecorderCleanupRef.current === cleanupMediaRecorder) {
+          mediaRecorderCleanupRef.current = null;
+        }
       };
 
       mediaRecorder.addEventListener("dataavailable", handleDataAvailable);
@@ -249,6 +265,7 @@ export const SpeechInput = ({
       mediaRecorder.addEventListener("error", handleError);
 
       mediaRecorderRef.current = mediaRecorder;
+      mediaRecorderCleanupRef.current = cleanupMediaRecorder;
       mediaRecorder.start();
       setIsListening(true);
     } catch {

--- a/packages/ui/src/components/ui/carousel.tsx
+++ b/packages/ui/src/components/ui/carousel.tsx
@@ -98,7 +98,8 @@ function Carousel({
     api.on("select", onSelect)
 
     return () => {
-      api?.off("select", onSelect)
+      api.off("reInit", onSelect)
+      api.off("select", onSelect)
     }
   }, [api, onSelect])
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -501,3 +501,14 @@ html {
     @apply bg-background text-foreground;
   }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/plugins/sero-git-plugin/ui/styles.ts
+++ b/plugins/sero-git-plugin/ui/styles.ts
@@ -75,4 +75,18 @@ export const GIT_STYLES = `
     50% { opacity: 1; }
   }
   .git-loading { animation: git-pulse 1.5s ease-in-out infinite; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .git-root,
+    .git-root::before,
+    .git-root::after,
+    .git-root *,
+    .git-root *::before,
+    .git-root *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      scroll-behavior: auto !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
 `;

--- a/plugins/sero-usage-plugin/ui/UsageApp.tsx
+++ b/plugins/sero-usage-plugin/ui/UsageApp.tsx
@@ -58,7 +58,7 @@ export function UsageApp() {
   const hasAnyData = state.periods.allTime.totals.messages > 0;
   const dataState = state.lastRefreshedAt === null ? 'loading' : hasAnyData ? 'ready' : 'empty';
 
-  const setInterval = (minutes: number) => {
+  const updateRefreshInterval = (minutes: number) => {
     updateState((prev) => ({
       ...normalizeUsageState(prev),
       settings: { refreshIntervalMinutes: minutes },
@@ -86,7 +86,7 @@ export function UsageApp() {
             )}
             <Select
               value={String(state.settings.refreshIntervalMinutes)}
-              onValueChange={(value) => setInterval(Number(value))}
+              onValueChange={(value) => updateRefreshInterval(Number(value))}
             >
               <SelectTrigger size="sm" className="w-24" aria-label="Auto-refresh interval">
                 <SelectValue />


### PR DESCRIPTION
## Summary

- replace the diff navigator's layout-thrashing width animation with transform and opacity
- clean up carousel and MediaRecorder listeners, and clarify the usage refresh helper
- honor the operating system's reduced-motion preference in shared UI and the Git plugin

## Impact

This removes a potential animation stutter around large diffs, prevents stale listener callbacks from accumulating, and reduces motion for users who have requested it at the operating-system level.

The full React Doctor scan dropped from 620 to 612 findings. The selected roots are absent, and the earlier `artifact-env-leak`, `js-set-map-lookups`, and `deslop/circular-dependency` fixes remain clear.

## Validation

- `npx react-doctor@latest --verbose`
- React Doctor changed-scope scan: zero diagnostics
- `pnpm typecheck` — 20/20 tasks passed
- UI tests — 36 passed
- Usage plugin tests — 38 passed
- Git plugin tests — 45 passed
- desktop, UI, Git plugin, and Usage plugin builds
- `git diff --check`
- touched TypeScript source files remain below 500 lines
