### PR TITLE
fix: address high-impact React Doctor findings

### DIFF
--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -10,9 +10,8 @@
  * on a live widget.
  */
 
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { lazy, Suspense, useEffect, useState, useCallback, useRef } from 'react';
 import type { RefObject } from 'react';
-import { DiffEditor } from '@monaco-editor/react';
 import type { editor as MonacoEditor } from 'monaco-editor';
 import { AnimatePresence, motion } from 'motion/react';
 import {
@@ -27,6 +26,11 @@ import { useThemeStore } from '@/stores/theme';
 import { registerCustomEditorThemes, resolveMonacoThemeName } from './monaco-themes';
 import type { FileDiffEntry } from '@sero-ai/common';
 import { statusCode, statusColor, basename, langFromPath } from '@/components/apps/explorer/vcs/vcs-utils';
+
+const DiffEditor = lazy(async () => {
+  const { DiffEditor: MonacoDiffEditor } = await import('@monaco-editor/react');
+  return { default: MonacoDiffEditor };
+});
 
 export interface DiffTabState {
   type: 'diff';
@@ -229,26 +233,28 @@ function DiffFileView({
   }
 
   return (
-    <DiffEditor
-      original={left}
-      modified={right}
-      language={language}
-      theme={theme}
-      beforeMount={registerCustomEditorThemes}
-      onMount={handleDiffMount}
-      keepCurrentOriginalModel
-      keepCurrentModifiedModel
-      options={{
-        readOnly: true,
-        renderSideBySide: sideBySide,
-        minimap: { enabled: true },
-        scrollBeyondLastLine: false,
-        fontSize: 12,
-        lineNumbers: 'on',
-        renderOverviewRuler: true,
-        diffWordWrap: 'on',
-      }}
-    />
+    <Suspense fallback={<div className="flex h-full items-center justify-center"><Loader2 className="size-4 animate-spin text-[var(--text-muted)]" /></div>}>
+      <DiffEditor
+        original={left}
+        modified={right}
+        language={language}
+        theme={theme}
+        beforeMount={registerCustomEditorThemes}
+        onMount={handleDiffMount}
+        keepCurrentOriginalModel
+        keepCurrentModifiedModel
+        options={{
+          readOnly: true,
+          renderSideBySide: sideBySide,
+          minimap: { enabled: true },
+          scrollBeyondLastLine: false,
+          fontSize: 12,
+          lineNumbers: 'on',
+          renderOverviewRuler: true,
+          diffWordWrap: 'on',
+        }}
+      />
+    </Suspense>
   );
 }
 

--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -10,7 +10,7 @@
  * on a live widget.
  */
 
-import { lazy, Suspense, useEffect, useState, useCallback, useRef } from 'react';
+import { lazy, useEffect, useState, useCallback, useRef } from 'react';
 import type { RefObject } from 'react';
 import type { editor as MonacoEditor } from 'monaco-editor';
 import { AnimatePresence, motion } from 'motion/react';
@@ -24,6 +24,7 @@ import { cn } from '@sero-ai/ui/lib/utils';
 import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
 import { registerCustomEditorThemes, resolveMonacoThemeName } from './monaco-themes';
+import { EditorSuspense } from './EditorSuspense';
 import type { FileDiffEntry } from '@sero-ai/common';
 import { statusCode, statusColor, basename, langFromPath } from '@/components/apps/explorer/vcs/vcs-utils';
 
@@ -233,7 +234,7 @@ function DiffFileView({
   }
 
   return (
-    <Suspense fallback={<div className="flex h-full items-center justify-center"><Loader2 className="size-4 animate-spin text-[var(--text-muted)]" /></div>}>
+    <EditorSuspense>
       <DiffEditor
         original={left}
         modified={right}
@@ -254,7 +255,7 @@ function DiffFileView({
           diffWordWrap: 'on',
         }}
       />
-    </Suspense>
+    </EditorSuspense>
   );
 }
 

--- a/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
@@ -6,10 +6,11 @@
  * Tab/file state is managed by the parent ExplorerWorkspace.
  */
 
-import { lazy, Suspense, useMemo, useRef, type KeyboardEvent } from 'react';
+import { lazy, useMemo, useRef, type KeyboardEvent } from 'react';
 import { FileCode2 } from 'lucide-react';
 import { EditorTabBar, type EditorTab } from './EditorTabBar';
 import { DevServerPreview, isDevServerTab } from './DevServerPreview';
+import { EditorSuspense } from './EditorSuspense';
 import { FilePreviewPane } from './FilePreviewPane';
 import { getFilePreviewSpec } from './file-preview-registry';
 import { ViewModeToggle } from './ViewModeToggle';
@@ -167,7 +168,7 @@ export function EditorPanel({
               spec={previewSpec}
             />
           ) : (
-            <Suspense fallback={<div className="flex h-full items-center justify-center text-sm text-[var(--text-muted)]">Loading editor…</div>}>
+            <EditorSuspense>
               <Editor
                 height="100%"
                 language={documentState.language}
@@ -193,7 +194,7 @@ export function EditorPanel({
                   bracketPairColorization: { enabled: true },
                 }}
               />
-            </Suspense>
+            </EditorSuspense>
           )
         ) : (
           <EmptyEditorState />

--- a/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorPanel.tsx
@@ -6,9 +6,8 @@
  * Tab/file state is managed by the parent ExplorerWorkspace.
  */
 
-import { useMemo, useRef, type KeyboardEvent } from 'react';
+import { lazy, Suspense, useMemo, useRef, type KeyboardEvent } from 'react';
 import { FileCode2 } from 'lucide-react';
-import Editor from '@monaco-editor/react';
 import { EditorTabBar, type EditorTab } from './EditorTabBar';
 import { DevServerPreview, isDevServerTab } from './DevServerPreview';
 import { FilePreviewPane } from './FilePreviewPane';
@@ -26,6 +25,8 @@ import { useMonacoNavigation } from './useMonacoNavigation';
 import { useLsp } from '@/lsp/use-lsp';
 import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
+
+const Editor = lazy(() => import('@monaco-editor/react'));
 
 function EmptyEditorState() {
   return (
@@ -166,31 +167,33 @@ export function EditorPanel({
               spec={previewSpec}
             />
           ) : (
-            <Editor
-              height="100%"
-              language={documentState.language}
-              path={activeTab}
-              value={documentState.content}
-              onChange={documentState.handleChange}
-              beforeMount={monacoState.handleBeforeMount}
-              onMount={monacoState.handleEditorMount}
-              theme={monacoThemeName}
-              options={{
-                fontSize: 13,
-                fontFamily: "var(--font-mono, 'JetBrains Mono', 'SF Mono', monospace)",
-                minimap: { enabled: false },
-                lineNumbers: 'on',
-                scrollBeyondLastLine: false,
-                wordWrap: 'on',
-                tabSize: 2,
-                padding: { top: 8 },
-                renderLineHighlight: 'gutter',
-                smoothScrolling: true,
-                cursorBlinking: 'smooth',
-                cursorSmoothCaretAnimation: 'on',
-                bracketPairColorization: { enabled: true },
-              }}
-            />
+            <Suspense fallback={<div className="flex h-full items-center justify-center text-sm text-[var(--text-muted)]">Loading editor…</div>}>
+              <Editor
+                height="100%"
+                language={documentState.language}
+                path={activeTab}
+                value={documentState.content}
+                onChange={documentState.handleChange}
+                beforeMount={monacoState.handleBeforeMount}
+                onMount={monacoState.handleEditorMount}
+                theme={monacoThemeName}
+                options={{
+                  fontSize: 13,
+                  fontFamily: "var(--font-mono, 'JetBrains Mono', 'SF Mono', monospace)",
+                  minimap: { enabled: false },
+                  lineNumbers: 'on',
+                  scrollBeyondLastLine: false,
+                  wordWrap: 'on',
+                  tabSize: 2,
+                  padding: { top: 8 },
+                  renderLineHighlight: 'gutter',
+                  smoothScrolling: true,
+                  cursorBlinking: 'smooth',
+                  cursorSmoothCaretAnimation: 'on',
+                  bracketPairColorization: { enabled: true },
+                }}
+              />
+            </Suspense>
           )
         ) : (
           <EmptyEditorState />

--- a/apps/desktop/src/components/apps/explorer/editor/EditorSuspense.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorSuspense.tsx
@@ -1,0 +1,27 @@
+/**
+ * EditorSuspense, shared boundary for lazily-loaded Monaco editors.
+ *
+ * Wraps a lazy Editor/DiffEditor in a spinner fallback plus an error boundary
+ * so a chunk-load failure or Monaco render error stays contained to the editor
+ * pane (and auto-recovers stale chunks) instead of blanking the whole app.
+ */
+
+import { Suspense, type ReactNode } from 'react';
+import { Loader2 } from 'lucide-react';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+
+function EditorLoading() {
+  return (
+    <div className="flex h-full items-center justify-center">
+      <Loader2 className="size-4 animate-spin text-[var(--text-muted)]" />
+    </div>
+  );
+}
+
+export function EditorSuspense({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary region="Editor" compact>
+      <Suspense fallback={<EditorLoading />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/apps/desktop/src/components/apps/explorer/editor/FilePreviewPane.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/FilePreviewPane.tsx
@@ -80,16 +80,6 @@ function BinaryFilePreview({ workspaceId, filePath, spec }: BinaryFilePreviewPro
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
-    setError(null);
-    setBlobUrl(null);
-    setFileSize(null);
-    setDimensions(null);
-
-    if (blobUrlRef.current) {
-      URL.revokeObjectURL(blobUrlRef.current);
-      blobUrlRef.current = null;
-    }
 
     (async () => {
       try {
@@ -249,6 +239,7 @@ export function FilePreviewPane({ workspaceId, filePath, content, spec }: Props)
 
   return (
     <BinaryFilePreview
+      key={`${workspaceId}\0${filePath}\0${spec.kind}\0${spec.mimeType}`}
       workspaceId={workspaceId}
       filePath={filePath}
       spec={spec}

--- a/apps/desktop/src/components/layout/VoiceTranscriptionControl.tsx
+++ b/apps/desktop/src/components/layout/VoiceTranscriptionControl.tsx
@@ -260,6 +260,15 @@ export function VoiceTranscriptionControl({
   const visible = phase !== 'disabled';
   const micDisabled = phase === 'starting' || phase === 'processing' || (disabled && phase !== 'recording');
   const selectorDisabled = disabled || phase === 'starting' || phase === 'recording' || phase === 'processing';
+  const micLabel = phase === 'recording'
+    ? 'Stop voice recording'
+    : phase === 'starting'
+      ? 'Starting microphone'
+      : phase === 'processing'
+        ? 'Transcribing voice message'
+        : phase === 'error'
+          ? 'Retry voice recording'
+          : 'Record voice message';
 
   const micTooltip = useMemo(() => {
     if (phase === 'recording') {
@@ -288,6 +297,7 @@ export function VoiceTranscriptionControl({
             type="button"
             onClick={onToggle}
             disabled={micDisabled}
+            aria-label={micLabel}
             className={cn(
               'relative rounded-md p-1.5 transition-all duration-150',
               phase === 'recording' && 'bg-[var(--voice-recording-muted)] text-[var(--voice-recording)] shadow-[0_0_0_2px_var(--voice-recording-muted)]',
@@ -321,6 +331,7 @@ export function VoiceTranscriptionControl({
               <button
                 type="button"
                 disabled={selectorDisabled}
+                aria-label={`Select recording input. Current: ${selectedDeviceLabel}`}
                 className={cn(
                   'rounded-md p-1.5 text-[var(--text-muted)] transition-all duration-150 hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]',
                   selectorDisabled && 'cursor-not-allowed opacity-50',

--- a/plugins/sero-cron-plugin/ui/components/ModelPicker.tsx
+++ b/plugins/sero-cron-plugin/ui/components/ModelPicker.tsx
@@ -6,7 +6,7 @@
  * as a "provider/modelId" string matching the `pi --model` flag format.
  */
 
-import { useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { useState, useMemo, useRef, useEffect, useCallback, useId } from 'react';
 import { Check, Settings2, Sparkles, X } from 'lucide-react';
 import {
   useAvailableModels,
@@ -71,6 +71,7 @@ export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
   const [filter, setFilter] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listboxId = useId();
 
   // Resolve current selection
   const resolved = useMemo(() => findModel(groups, value), [groups, value]);
@@ -132,7 +133,9 @@ export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
         <button
           type="button"
           onClick={() => setOpen(!open)}
+          aria-haspopup="listbox"
           aria-expanded={open}
+          aria-controls={open ? listboxId : undefined}
           className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 focus:outline-none"
         >
           {resolved ? (
@@ -191,7 +194,7 @@ export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
           />
 
           {/* Model list */}
-          <div className="max-h-[240px] overflow-y-auto py-1">
+          <div id={listboxId} role="listbox" className="max-h-[240px] overflow-y-auto py-1">
             {loading ? (
               <div className="px-3 py-4 text-center text-xs text-muted-foreground">
                 Loading models…
@@ -270,7 +273,7 @@ function ProviderGroup({
           {group.displayName}
         </span>
       </div>
-      <div className="px-1">
+      <div role="group" aria-label={group.displayName} className="px-1">
         {group.models.map((model) => {
           const modelStr = toModelString(model);
           const isSelected = selectedValue === modelStr || selectedValue === model.modelId;
@@ -278,6 +281,8 @@ function ProviderGroup({
             <button
               key={modelStr}
               type="button"
+              role="option"
+              aria-selected={isSelected}
               onClick={() => onSelect(model)}
               className={cn(
                 'flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-xs transition-colors',

--- a/plugins/sero-cron-plugin/ui/components/ModelPicker.tsx
+++ b/plugins/sero-cron-plugin/ui/components/ModelPicker.tsx
@@ -122,55 +122,60 @@ export function ModelPicker({ value, onChange, className }: ModelPickerProps) {
   return (
     <div ref={containerRef} className={cn('relative', className)}>
       {/* Trigger */}
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
+      <div
         className={cn(
-          'flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-base text-foreground transition-colors',
-          'hover:bg-secondary/50 focus:outline-none focus:ring-1 focus:ring-ring',
+          'flex w-full items-center rounded-md border border-input bg-background text-base text-foreground transition-colors',
+          'hover:bg-secondary/50 focus-within:ring-1 focus-within:ring-ring',
           open && 'ring-1 ring-ring',
         )}
       >
-        {resolved ? (
-          <>
-            <img
-              src={resolved.group.logo}
-              alt={resolved.group.displayName}
-              className="size-4 rounded-sm dark:invert"
-            />
-            <span className="flex-1 truncate text-left font-medium">
-              {resolved.model.name}
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-center gap-2 px-3 py-2 focus:outline-none"
+        >
+          {resolved ? (
+            <>
+              <img
+                src={resolved.group.logo}
+                alt={resolved.group.displayName}
+                className="size-4 rounded-sm dark:invert"
+              />
+              <span className="flex-1 truncate text-left font-medium">
+                {resolved.model.name}
+              </span>
+              {resolved.model.reasoning && (
+                <Sparkles className="size-3 text-amber-500" />
+              )}
+            </>
+          ) : value ? (
+            <span className="flex-1 truncate text-left font-mono text-muted-foreground">
+              {value}
             </span>
-            {resolved.model.reasoning && (
-              <Sparkles className="size-3 text-amber-500" />
-            )}
-          </>
-        ) : value ? (
-          <span className="flex-1 truncate text-left font-mono text-muted-foreground">
-            {value}
-          </span>
-        ) : (
-          <span className="flex-1 text-left text-muted-foreground">
-            Default model
-          </span>
-        )}
-
-        {/* Clear / chevron */}
+          ) : (
+            <span className="flex-1 text-left text-muted-foreground">
+              Default model
+            </span>
+          )}
+          {!value && (
+            <svg className="size-3 text-muted-foreground" viewBox="0 0 12 12" fill="none">
+              <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          )}
+        </button>
         {value ? (
           <button
             type="button"
             onClick={handleClear}
-            className="ml-1 rounded p-0.5 text-muted-foreground hover:text-foreground"
+            className="mr-2 rounded p-0.5 text-muted-foreground hover:text-foreground focus:outline-none"
             title="Reset to default"
+            aria-label="Reset to default"
           >
             <X className="size-3" />
           </button>
-        ) : (
-          <svg className="size-3 text-muted-foreground" viewBox="0 0 12 12" fill="none">
-            <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-        )}
-      </button>
+        ) : null}
+      </div>
 
       {/* Dropdown, opens upward to avoid overflowing the dialog */}
       {open && (

--- a/plugins/sero-usage-plugin/extension/refresh.ts
+++ b/plugins/sero-usage-plugin/extension/refresh.ts
@@ -58,9 +58,10 @@ async function doRefresh(force: boolean): Promise<RefreshSummary> {
 
   const sessionsDir = resolveSessionsDir();
   const cachePath = resolveScanCachePath();
-  const cache = await loadScanCache(cachePath);
-
-  const sessionFiles = await collectSessionFiles(sessionsDir);
+  const [cache, sessionFiles] = await Promise.all([
+    loadScanCache(cachePath),
+    collectSessionFiles(sessionsDir),
+  ]);
   const scan = await scanWithCache(sessionFiles, cache);
   await saveScanCache(cachePath, scan.cache);
 


### PR DESCRIPTION
## Summary

- add accessible names to voice recording controls and remove nested interactive controls from the cron model picker
- lazy-load Monaco editors so they are excluded from the normal startup path
- remount binary previews when file identity changes to prevent stale preview state
- run independent usage cache and session discovery work concurrently

## Follow-up (code-review fixes)

- wrap the lazy Monaco `Editor`/`DiffEditor` in a shared `EditorSuspense` (spinner fallback + error boundary) so a chunk-load or render failure stays contained to the editor pane instead of bubbling to the app-level region boundary
- replace EditorPanel's text loading fallback with a spinner, consistent with the other editor surfaces
- expose the ModelPicker popup to assistive tech: `aria-haspopup`/`aria-controls` on the trigger, `role="listbox"` on the list, `role="option"` + `aria-selected` on rows, and a labelled `role="group"` per provider

## Why

A fresh React Doctor scan identified accessibility, correctness, and normal-use performance issues with credible user impact. These changes apply the canonical rule recipes to the underlying causes without suppressing diagnostics or sweeping broad migration rules.

The full scan decreased from 608 to 604 diagnostics. The selected root causes and the earlier accessibility findings are absent, and changed-scope scanning introduced no new diagnostics.

## Validation

- `pnpm typecheck`
- `pnpm --filter @sero/desktop typecheck`
- `pnpm --filter @sero-ai/plugin-usage typecheck`
- `pnpm --filter @sero-ai/plugin-cron typecheck`
- `pnpm --filter @sero-ai/plugin-usage test -- extension/__tests__/refresh.test.ts` — 38 tests passed
- `pnpm --filter @sero-ai/plugin-cron test` — 230 tests passed
- `pnpm --filter @sero/desktop build`
- `pnpm --filter @sero-ai/plugin-usage build`
- `npx react-doctor@latest --verbose`
- `npx react-doctor@latest --verbose --scope changed`
- `git diff --check`
