### PR TITLE
fix(ui): replace status-* color misuse with brand/accent tokens

### DIFF
--- a/apps/desktop/src/components/apps/explorer/ActivityBar.tsx
+++ b/apps/desktop/src/components/apps/explorer/ActivityBar.tsx
@@ -69,12 +69,12 @@ export function ActivityBar({
                 onClick={() => onPanelClick(item.id)}
                 className={cn(
                   'relative text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
-                  isActive && 'text-status-success',
+                  isActive && 'text-[var(--brand-primary)]',
                 )}
               >
                 {item.icon}
                 {isActive && (
-                  <span className="absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r bg-status-success" />
+                  <span className="absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r bg-[var(--brand-primary)]" />
                 )}
                 {showBadge && (
                   <span className="absolute -right-0.5 -top-0.5 flex size-3.5 items-center justify-center rounded-full bg-status-info text-xs font-bold text-white">
@@ -106,12 +106,12 @@ export function ActivityBar({
                 onClick={() => onPanelClick(item.id)}
                 className={cn(
                   'relative text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
-                  isActive && 'text-status-success',
+                  isActive && 'text-[var(--brand-primary)]',
                 )}
               >
                 {item.icon}
                 {isActive && (
-                  <span className="absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r bg-status-success" />
+                  <span className="absolute left-0 top-1.5 bottom-1.5 w-[2px] rounded-r bg-[var(--brand-primary)]" />
                 )}
               </Button>
             </TooltipTrigger>

--- a/apps/desktop/src/components/apps/explorer/editor/EditorThemePicker.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorThemePicker.tsx
@@ -132,7 +132,7 @@ function ThemeOption({
       )}
     >
       <span className="truncate">{label}</span>
-      {active ? <Check className="size-3 shrink-0 text-status-success" /> : null}
+      {active ? <Check className="size-3 shrink-0 text-[var(--brand-primary)]" /> : null}
     </button>
   );
 }

--- a/apps/desktop/src/components/apps/explorer/editor/ViewModeToggle.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/ViewModeToggle.tsx
@@ -26,7 +26,7 @@ export function ViewModeToggle({ viewMode, onModeChange }: Props) {
             className={cn(
               'inline-flex size-7 items-center justify-center transition-colors duration-150',
               viewMode === 'code'
-                ? 'bg-status-success-subtle text-status-success'
+                ? 'bg-[var(--brand-primary-subtle)] text-[var(--brand-primary)]'
                 : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)]/80 hover:text-[var(--text-secondary)]',
             )}
           >
@@ -44,7 +44,7 @@ export function ViewModeToggle({ viewMode, onModeChange }: Props) {
             className={cn(
               'inline-flex size-7 items-center justify-center transition-colors duration-150',
               viewMode === 'preview'
-                ? 'bg-status-success-subtle text-status-success'
+                ? 'bg-[var(--brand-primary-subtle)] text-[var(--brand-primary)]'
                 : 'text-[var(--text-muted)] hover:bg-[var(--bg-elevated)]/80 hover:text-[var(--text-secondary)]',
             )}
           >

--- a/apps/desktop/src/components/apps/explorer/vcs/BookmarksSection.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/BookmarksSection.tsx
@@ -251,7 +251,7 @@ function BookmarkRow({
       {/* Hover actions */}
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
         {!isActive && (
-          <button type="button" onClick={onSetActive} title="Set active push branch" className="text-[var(--text-muted)] hover:text-status-warning transition-colors">
+          <button type="button" onClick={onSetActive} title="Set active push branch" className="text-[var(--text-muted)] hover:text-[var(--brand-primary)] transition-colors">
             <Star className="size-3" />
           </button>
         )}

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeLogRow.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeLogRow.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 function ChangeGlyph({ entry }: { entry: ChangeEntry }) {
   if (entry.isWorkingCopy) {
-    return <span className="text-sm font-bold text-status-info">@</span>;
+    return <span className="text-sm font-bold text-[var(--brand-primary)]">@</span>;
   }
   if (entry.immutable) {
     return <CheckCircle2 className="size-3 text-status-success" />;
@@ -61,7 +61,7 @@ export const ChangeLogRow = memo(function ChangeLogRow({ entry, index, isExpande
         className={cn(
           'shrink-0 font-mono text-sm',
           entry.isWorkingCopy
-            ? 'text-status-info/80'
+            ? 'text-[var(--brand-primary)]/80'
             : 'text-[var(--text-muted)]/50',
         )}
       >
@@ -95,8 +95,8 @@ export const ChangeLogRow = memo(function ChangeLogRow({ entry, index, isExpande
               key={bm}
               className={cn(
                 'rounded-sm px-1 py-px text-xs font-medium leading-tight',
-                'bg-status-info-muted text-status-info',
-                'border border-status-info-subtle',
+                'bg-[var(--brand-primary-muted)] text-[var(--brand-primary)]',
+                'border border-[var(--brand-primary-subtle)]',
               )}
             >
               {truncate(bm, 18)}

--- a/apps/desktop/src/components/apps/explorer/vcs/PullRequestSection.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/PullRequestSection.tsx
@@ -307,8 +307,8 @@ export function PullRequestSection({
             disabled={!canCreate}
             className={cn(
               'flex h-7 items-center gap-1 rounded px-2.5 text-sm font-semibold',
-              'bg-status-info-border text-status-info ring-1 ring-status-info-subtle',
-              'hover:bg-status-info-subtle hover:text-status-info',
+              'bg-[var(--brand-primary)] text-[var(--brand-primary-foreground)] ring-1 ring-[var(--brand-primary-border)]',
+              'hover:bg-[var(--brand-primary-hover)] hover:text-[var(--brand-primary-foreground)]',
               'transition-colors disabled:opacity-40',
             )}
           >

--- a/apps/desktop/src/components/layout/VoiceTranscriptionControl.tsx
+++ b/apps/desktop/src/components/layout/VoiceTranscriptionControl.tsx
@@ -379,7 +379,7 @@ export function VoiceTranscriptionControl({
                     )}
                   >
                     <span className="min-w-0 flex-1 truncate">{input.label}</span>
-                    {selected && <Check className="size-3.5 shrink-0 text-status-success" />}
+                    {selected && <Check className="size-3.5 shrink-0 text-[var(--brand-primary)]" />}
                   </button>
                 );
               })}

--- a/apps/desktop/src/components/layout/models/model-manager/ModelManagerItem.tsx
+++ b/apps/desktop/src/components/layout/models/model-manager/ModelManagerItem.tsx
@@ -69,7 +69,7 @@ const ModelManagerItem = memo(function ModelManagerItem({
           {model.name}
         </span>
         {model.reasoning && (
-          <Sparkles className="size-3 shrink-0 text-status-warning/60" />
+          <Sparkles className="size-3 shrink-0 text-[var(--accent-primary)]/60" />
         )}
         <span className="hidden truncate text-sm text-[var(--text-muted)] group-hover:inline">
           {providerName}

--- a/apps/desktop/src/components/layout/models/model-selector/ModelSelectorList.tsx
+++ b/apps/desktop/src/components/layout/models/model-selector/ModelSelectorList.tsx
@@ -26,7 +26,7 @@ const ModelItem = memo(function ModelItem({
     >
       <div className="flex size-4 shrink-0 items-center justify-center">
         {isSelected ? (
-          <Check className="size-3.5 scale-100 text-status-success transition-transform duration-150" />
+          <Check className="size-3.5 scale-100 text-[var(--brand-primary)] transition-transform duration-150" />
         ) : isFavourite ? (
           <Star className="size-3 text-amber-400" fill="currentColor" />
         ) : (
@@ -36,7 +36,7 @@ const ModelItem = memo(function ModelItem({
       <div className="flex min-w-0 flex-1 items-center justify-between gap-2">
         <span className="truncate text-sm font-medium">{model.name}</span>
         {model.reasoning ? (
-          <Sparkles className="size-3 shrink-0 text-status-warning/60" />
+          <Sparkles className="size-3 shrink-0 text-[var(--accent-primary)]/60" />
         ) : null}
       </div>
     </button>

--- a/apps/desktop/src/components/layout/shell/StatusBar.tsx
+++ b/apps/desktop/src/components/layout/shell/StatusBar.tsx
@@ -101,7 +101,7 @@ function ActivePushBranchPicker({
         className="flex items-center gap-1 hover:text-[var(--text-primary)] transition-colors"
       >
         <GitBranch className="size-3" />
-        <span className="rounded-sm border border-status-info-border bg-status-info-muted px-1 py-px font-mono text-xs text-status-info">
+        <span className="rounded-sm border border-[var(--brand-primary-border)] bg-[var(--brand-primary-muted)] px-1 py-px font-mono text-xs text-[var(--brand-primary)]">
           {activePushBookmark ?? 'auto'}
         </span>
       </button>
@@ -116,7 +116,7 @@ function ActivePushBranchPicker({
             className="flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs hover:bg-[var(--bg-muted)]"
           >
             <span>Auto (main/first)</span>
-            {!activePushBookmark && <span className="text-status-info">active</span>}
+            {!activePushBookmark && <span className="text-[var(--brand-primary)]">active</span>}
           </button>
           {bookmarks.map((bm) => (
             <button type="button"
@@ -128,7 +128,7 @@ function ActivePushBranchPicker({
               className="flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs hover:bg-[var(--bg-muted)]"
             >
               <span className="truncate">{bm.name}</span>
-              {activePushBookmark === bm.name && <span className="text-status-info">active</span>}
+              {activePushBookmark === bm.name && <span className="text-[var(--brand-primary)]">active</span>}
             </button>
           ))}
         </div>

--- a/apps/desktop/src/components/layout/workspace/SessionNode.tsx
+++ b/apps/desktop/src/components/layout/workspace/SessionNode.tsx
@@ -133,7 +133,7 @@ export function SessionNode({
             }}
             onBlur={commitRename}
             onClick={(e) => e.stopPropagation()}
-            className="w-full truncate rounded border border-[var(--border-subtle)] bg-[var(--bg-base)] px-1 py-0 text-sm font-medium text-[var(--text-primary)] outline-none focus:border-status-success"
+            className="w-full truncate rounded border border-[var(--border-subtle)] bg-[var(--bg-base)] px-1 py-0 text-sm font-medium text-[var(--text-primary)] outline-none focus:border-[var(--brand-primary)]"
           />
         ) : (
           <span className={cn('truncate text-sm font-medium', isActive ? 'text-[var(--brand-primary)]' : 'text-[var(--text-primary)]')}>

--- a/apps/desktop/src/components/layout/workspace/workspace-tree/RuntimePickerMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/workspace-tree/RuntimePickerMenu.tsx
@@ -175,10 +175,10 @@ export function RuntimePickerMenu({ workspace }: { workspace: WorkspaceInfo }) {
                   aria-current={selected ? 'true' : undefined}
                   className={cn(
                     'group flex w-full items-start gap-2 rounded-lg border p-2.5 text-left transition-all duration-150',
-                    'border-transparent hover:border-[var(--accent-primary)] hover:bg-status-info-faint hover:shadow-sm',
+                    'border-transparent hover:border-[var(--accent-primary)] hover:bg-[var(--brand-primary-faint)] hover:shadow-sm',
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]',
                     'disabled:cursor-not-allowed disabled:opacity-60',
-                    selected && 'border-[var(--accent-primary)] bg-status-info-faint',
+                    selected && 'border-[var(--accent-primary)] bg-[var(--brand-primary-faint)]',
                     pending && 'border-status-info bg-status-info-muted',
                   )}
                 >
@@ -198,7 +198,7 @@ export function RuntimePickerMenu({ workspace }: { workspace: WorkspaceInfo }) {
                         </span>
                       ) : null}
                       {option.recommended ? (
-                        <span className="rounded bg-status-success-faint px-1 py-0.5 text-sm uppercase tracking-wide text-[var(--brand-primary)]">
+                        <span className="rounded bg-[var(--brand-primary-faint)] px-1 py-0.5 text-sm uppercase tracking-wide text-[var(--brand-primary)]">
                           Default
                         </span>
                       ) : null}

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -186,7 +186,7 @@ export function OnboardingSetupScreen({
       <div className="space-y-5">
         <div className="space-y-3">
           <div className="flex size-11 items-center justify-center rounded-xl bg-[var(--bg-elevated)]">
-            <Sparkles className="size-5 text-status-success" />
+            <Sparkles className="size-5 text-[var(--brand-primary)]" />
           </div>
           <div>
             <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">{GITHUB_STEP_CONFIG.title}</DialogTitle>
@@ -230,7 +230,7 @@ export function OnboardingSetupScreen({
     <div className="space-y-5">
       <div className="space-y-3">
         <div className="flex size-11 items-center justify-center rounded-xl bg-[var(--bg-elevated)]">
-          <Sparkles className="size-5 text-status-success" />
+          <Sparkles className="size-5 text-[var(--brand-primary)]" />
         </div>
         <div>
           <DialogTitle className="text-lg font-semibold text-[var(--text-primary)]">Choose your defaults</DialogTitle>

--- a/plugins/sero-admin-plugin/ui/components/SkillEditor.tsx
+++ b/plugins/sero-admin-plugin/ui/components/SkillEditor.tsx
@@ -117,7 +117,6 @@ export function SkillEditor({
             disabled={lockedHidden}
             onCheckedChange={onVisibilityChange}
             aria-label={`Toggle model visibility for ${data.name}`}
-            className="data-[state=checked]:bg-status-success"
           />
         </div>
       )}


### PR DESCRIPTION
Several components used semantic status colors (status-success,
status-info, status-warning) to indicate active/selected UI state,
decorative icons, or CTA buttons rather than actual success/error/
warning/info semantics. Swap these to --brand-primary / --accent-primary
tokens so they track the brand palette instead of unexpectedly
following status-color theme changes.

Affected: activity bar active state, status bar active push branch,
session rename focus ring, runtime picker selection/recommended badge,
PR creation CTA, changelog working-copy/bookmark badges, editor
view-mode toggle, theme/model/audio-device selection checkmarks,
reasoning-model sparkle icon, onboarding hero icon, and an admin
skill-visibility switch override that duplicated the component default.