### PR TITLE
fix(desktop): repair browser page-extraction script so "share page" works

### DIFF
--- a/apps/desktop/electron/__tests__/features/browser/page-scripts.test.ts
+++ b/apps/desktop/electron/__tests__/features/browser/page-scripts.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { buildExtractPageScript, buildScrollPageScript } from '@electron/features/browser/page-scripts';
+
+/**
+ * These scripts are strings evaluated inside a page via
+ * `webContents.executeJavaScript`. They are authored as template literals,
+ * so any escape sequence has to survive being turned into a string once
+ * before the page parses it. A bare '\n' inside a quoted string in the
+ * template literal becomes a real newline in the emitted script — an
+ * unterminated string literal — which makes executeJavaScript reject and
+ * the caller see "extraction returned nothing" (issue #247).
+ *
+ * `new Function` parses the source the same way the page's JS engine does,
+ * so it catches that class of bug without needing a real browser.
+ */
+function parse(script: string): void {
+  // Throws SyntaxError if the emitted script is not valid JS.
+  new Function(`return (${script});`);
+}
+
+/** Evaluate the extract script against a mock DOM and return its result. */
+function runExtract(innerText: string): { title: string; url: string; text: string } {
+  const doc = {
+    title: 'Example',
+    body: { cloneNode: () => ({ querySelectorAll: () => [], innerText }) },
+  };
+  const loc = { href: 'https://example.com/' };
+  return new Function('document', 'location', `return (${buildExtractPageScript()});`)(doc, loc);
+}
+
+describe('buildExtractPageScript', () => {
+  it('emits syntactically valid JavaScript', () => {
+    expect(() => parse(buildExtractPageScript())).not.toThrow();
+  });
+
+  it('splits and collapses on real newlines', () => {
+    const result = runExtract('One\n\n\n  Two  \nThree');
+    expect(result).toEqual({
+      title: 'Example',
+      url: 'https://example.com/',
+      text: 'One\n\nTwo\nThree',
+    });
+  });
+});
+
+describe('buildScrollPageScript', () => {
+  it('emits syntactically valid JavaScript', () => {
+    expect(() => parse(buildScrollPageScript(800))).not.toThrow();
+  });
+});

--- a/apps/desktop/electron/features/browser/page-scripts.ts
+++ b/apps/desktop/electron/features/browser/page-scripts.ts
@@ -1,3 +1,9 @@
+// This template literal is serialized to a string before the page parses and
+// runs it, so any escape sequence inside it is expanded one hop early. A bare
+// `\n` in a quoted string below would become a real newline in the emitted
+// script — an unterminated string literal that makes executeJavaScript reject —
+// so newlines are written as `\\n` to reach the page as `\n`. The same trap
+// applies inside `//` comments here: keep them free of escapes and stray quotes.
 export function buildExtractPageScript(): string {
   return `(() => {
     try {
@@ -13,10 +19,10 @@ export function buildExtractPageScript(): string {
       // can report an empty innerText even after the DOM has loaded.
       const raw = body.innerText || body.textContent || '';
       const text = raw
-        .split('\n')
+        .split('\\n')
         .map((l) => l.trim())
         .filter((l, i, a) => !(l === '' && a[i - 1] === ''))
-        .join('\n')
+        .join('\\n')
         .trim();
       return { title, url, text };
     } catch (err) {


### PR DESCRIPTION
The in-app browser's "Share page with chat" (and the CLI `browser get-text`)
never returned any content. `buildExtractPageScript()` builds the extraction
script as a template literal, and inside it `.split('\n')` / `.join('\n')`
were written with bare `\n`. The template literal expanded those to real
newlines before the string reached the page, so the emitted script contained
an unterminated single-quoted string (`'<newline>'`). The page failed to
parse it, `webContents.executeJavaScript` rejected, `extractPage` swallowed
the error into `null`, and the renderer logged "Page extraction returned
nothing." The failure was deterministic on every page, not site-specific.

Escape the newlines as `\\n` so the page receives valid `'\n'` literals, and
add a note documenting why escapes (and `//` comments) inside this template
literal are hazardous. Adds a unit test that asserts the generated scripts are
syntactically valid and that text is normalized on real newlines, so the
regression can't return silently.

Fixes #247

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SeXma1jzsUidqCBuNFGe6h