### PR TITLE
feat(workspace): clone repos and sync existing git repos into workspaces

### DIFF
--- a/apps/desktop/electron/__tests__/features/vcs/core/remote-ops.test.ts
+++ b/apps/desktop/electron/__tests__/features/vcs/core/remote-ops.test.ts
@@ -27,4 +27,66 @@ describe('remote ops', () => {
     });
     expect(runner.run).toHaveBeenCalledWith('workspace-1', ['fetch', 'origin'], 120_000);
   });
+
+  it('refuses to reset a workspace that already has Git history', async () => {
+    const runner = createRunner([
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: 'origin/main\n' },
+      { exitCode: 0, stdout: 'local-commit\n' },
+    ]);
+
+    await expect(checkoutRemote(runner, 'workspace-1', 'origin')).resolves.toEqual({
+      success: false,
+      message: 'The workspace already has Git commits. Link the repository without importing to preserve its history.',
+    });
+    expect(runner.run).not.toHaveBeenCalledWith(
+      'workspace-1',
+      ['checkout', '-B', 'main', 'origin/main'],
+      120_000,
+    );
+  });
+
+  it('checks out a remote when existing untracked files do not overlap it', async () => {
+    const runner = createRunner([
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: 'origin/main\n' },
+      { exitCode: 1 },
+      { exitCode: 0, stdout: '' },
+      { exitCode: 0, stdout: 'README.md\0src/index.ts\0' },
+      { exitCode: 0, stdout: '.sero-workspace.json\0notes.txt\0' },
+      { exitCode: 0, stdout: '' },
+      { exitCode: 0 },
+      { exitCode: 0 },
+    ]);
+
+    await expect(checkoutRemote(runner, 'workspace-1', 'origin')).resolves.toEqual({
+      success: true,
+      message: 'Checked out origin/main',
+    });
+    expect(runner.run).toHaveBeenCalledWith(
+      'workspace-1',
+      ['checkout', '-B', 'main', 'origin/main'],
+      120_000,
+    );
+  });
+
+  it('refuses to overwrite ignored files during checkout', async () => {
+    const runner = createRunner([
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: 'origin/main\n' },
+      { exitCode: 1 },
+      { exitCode: 0, stdout: '' },
+      { exitCode: 0, stdout: 'config/local.env\0' },
+      { exitCode: 0, stdout: '.sero-workspace.json\0' },
+      { exitCode: 0, stdout: 'config/local.env\0' },
+    ]);
+
+    await expect(checkoutRemote(runner, 'workspace-1', 'origin')).resolves.toEqual({
+      success: false,
+      message: 'Import would overwrite an existing workspace path: config/local.env',
+    });
+  });
 });

--- a/apps/desktop/electron/__tests__/features/workspace/workspace-create.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/workspace-create.test.ts
@@ -1,0 +1,57 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WorkspaceManager } from '@electron/features/workspace/manager';
+
+const tempDirs: string[] = [];
+
+async function createTestManager(): Promise<{ manager: WorkspaceManager; workspacesDir: string }> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'sero-workspace-create-'));
+  tempDirs.push(root);
+  const agentDir = path.join(root, 'agent');
+  const workspacesDir = path.join(root, 'workspaces');
+  await Promise.all([
+    mkdir(agentDir, { recursive: true }),
+    mkdir(workspacesDir, { recursive: true }),
+  ]);
+  return {
+    manager: new WorkspaceManager({
+      agentDir,
+      workspacesDir,
+      registryPath: path.join(agentDir, 'workspaces.json'),
+      editorStateDir: path.join(agentDir, 'editor-state'),
+    }),
+    workspacesDir,
+  };
+}
+
+describe('workspace creation destinations', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('uses a new clone destination instead of modifying a non-empty directory', async () => {
+    const { manager, workspacesDir } = await createTestManager();
+    const destination = path.join(workspacesDir, 'existing-repo');
+    await mkdir(destination);
+    await writeFile(path.join(destination, 'keep.txt'), 'keep me', 'utf8');
+
+    const workspace = await manager.create('Existing Repo', undefined, { requireEmpty: true });
+
+    expect(workspace.id).toBe('existing-repo-2');
+    expect(await readFile(path.join(destination, 'keep.txt'), 'utf8')).toBe('keep me');
+    expect(await readdir(destination)).toEqual(['keep.txt']);
+    expect(await readdir(path.join(workspacesDir, 'existing-repo-2'))).toContain('.sero-workspace.json');
+  });
+
+  it('allows an existing empty clone destination', async () => {
+    const { manager, workspacesDir } = await createTestManager();
+    await mkdir(path.join(workspacesDir, 'empty-repo'));
+
+    const workspace = await manager.create('Empty Repo', undefined, { requireEmpty: true });
+
+    expect(workspace.id).toBe('empty-repo');
+    expect(await readdir(path.join(workspacesDir, 'empty-repo'))).toContain('.sero-workspace.json');
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/workspace-runtime-reconcile.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/workspace-runtime-reconcile.test.ts
@@ -153,7 +153,7 @@ describe('workspace IPC runtime reconcile', () => {
     await removeHandler?.({}, 'ws-1');
     await closeHandler?.({}, 'ws-1');
 
-    expect(mocks.workspaceManager.create).toHaveBeenCalledWith('Workspace 1', '/parent');
+    expect(mocks.workspaceManager.create).toHaveBeenCalledWith('Workspace 1', '/parent', undefined);
     expect(mocks.workspaceManager.addFolder).toHaveBeenCalledWith('/repo-1', 'Workspace 1');
     expect(mocks.workspaceManager.remove).toHaveBeenCalledWith('ws-1');
     expect(mocks.workspaceManager.close).toHaveBeenCalledWith('ws-1');

--- a/apps/desktop/electron/features/vcs/core/vcs-ops/remote-ops.ts
+++ b/apps/desktop/electron/features/vcs/core/vcs-ops/remote-ops.ts
@@ -82,6 +82,61 @@ async function resolveRemoteBranch(
   return names.find((name) => name === 'main') ?? names.find((name) => name === 'master') ?? names[0] ?? null;
 }
 
+function parseNullDelimitedPaths(output: string): string[] {
+  return output
+    .split('\0')
+    .map((filePath) => filePath.replace(/\/+$/, ''))
+    .filter(Boolean);
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  return left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
+}
+
+async function findUnsafeCheckoutReason(
+  runner: GitRunner,
+  workspaceId: string,
+  remoteRef: string,
+): Promise<string | null> {
+  const head = await runner.run(workspaceId, ['rev-parse', '--verify', 'HEAD'], 10_000);
+  if (head.exitCode === 0) {
+    return 'The workspace already has Git commits. Link the repository without importing to preserve its history.';
+  }
+
+  const tracked = await runner.run(workspaceId, ['ls-files', '-z'], 10_000);
+  if (tracked.exitCode !== 0) return tracked.stderr || 'Failed to inspect tracked workspace files';
+  if (parseNullDelimitedPaths(tracked.stdout).length > 0) {
+    return 'The workspace already has tracked Git files. Link the repository without importing to preserve them.';
+  }
+
+  const remoteFiles = await runner.run(workspaceId, ['ls-tree', '-r', '--name-only', '-z', remoteRef], 30_000);
+  if (remoteFiles.exitCode !== 0) {
+    return remoteFiles.stderr || `Failed to inspect ${remoteRef}`;
+  }
+
+  const untracked = await runner.run(
+    workspaceId,
+    ['ls-files', '--others', '--exclude-standard', '-z'],
+    10_000,
+  );
+  if (untracked.exitCode !== 0) return untracked.stderr || 'Failed to inspect workspace files';
+
+  const ignored = await runner.run(
+    workspaceId,
+    ['ls-files', '--others', '--ignored', '--exclude-standard', '-z'],
+    10_000,
+  );
+  if (ignored.exitCode !== 0) return ignored.stderr || 'Failed to inspect ignored workspace files';
+
+  const existingPaths = [untracked.stdout, ignored.stdout].flatMap(parseNullDelimitedPaths);
+  const conflictingPath = parseNullDelimitedPaths(remoteFiles.stdout).find((remotePath) =>
+    existingPaths.some((existingPath) => pathsOverlap(remotePath, existingPath)),
+  );
+  return conflictingPath
+    ? `Import would overwrite an existing workspace path: ${conflictingPath}`
+    : null;
+}
+
 export async function checkoutRemote(
   runner: GitRunner,
   workspaceId: string,
@@ -100,6 +155,9 @@ export async function checkoutRemote(
   }
 
   const remoteRef = `${remote}/${branch}`;
+  const unsafeReason = await findUnsafeCheckoutReason(runner, workspaceId, remoteRef);
+  if (unsafeReason) return { success: false, message: unsafeReason };
+
   const checkout = await runner.run(workspaceId, ['checkout', '-B', branch, remoteRef], 120_000);
   if (checkout.exitCode !== 0) {
     return { success: false, message: checkout.stderr || `Failed to check out ${remoteRef}` };

--- a/apps/desktop/electron/features/workspace/create-destination.ts
+++ b/apps/desktop/electron/features/workspace/create-destination.ts
@@ -1,0 +1,35 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { pathExists } from './registry-recovery';
+import { ensureUniqueId } from './utils';
+
+async function isEmptyOrMissing(directoryPath: string): Promise<boolean> {
+  if (!await pathExists(directoryPath)) return true;
+  const destination = await fs.stat(directoryPath);
+  return destination.isDirectory() && (await fs.readdir(directoryPath)).length === 0;
+}
+
+export async function resolveWorkspaceCreateDestination({
+  baseId,
+  parentPath,
+  workspacesDir,
+  registeredIds,
+  requireEmpty,
+}: {
+  baseId: string;
+  parentPath?: string;
+  workspacesDir: string;
+  registeredIds: Set<string>;
+  requireEmpty: boolean;
+}): Promise<{ id: string; path: string }> {
+  let id = ensureUniqueId(baseId, registeredIds);
+  let workspacePath = path.join(parentPath ? path.resolve(parentPath) : workspacesDir, id);
+
+  while (requireEmpty && !await isEmptyOrMissing(workspacePath)) {
+    registeredIds.add(id);
+    id = ensureUniqueId(baseId, registeredIds);
+    workspacePath = path.join(parentPath ? path.resolve(parentPath) : workspacesDir, id);
+  }
+
+  return { id, path: workspacePath };
+}

--- a/apps/desktop/electron/features/workspace/manager.ts
+++ b/apps/desktop/electron/features/workspace/manager.ts
@@ -12,6 +12,7 @@ import path from 'path';
 import type {
   WorkspaceRegistryEntry,
   WorkspaceConfig,
+  WorkspaceCreateOptions,
   WorkspaceInfo,
 } from '@/types/ipc';
 import type { WorkspaceRuntimeBackend, WorkspaceRuntimeBackendInput, WorkspaceRuntimeConfig } from '@/types/workspace-runtime';
@@ -31,6 +32,7 @@ import {
 } from './runtime/config';
 import { getDefaultContainerRuntimeBackend } from './runtime/platform-default';
 import { discoverManagedWorkspaceEntries, pathExists } from './registry-recovery';
+import { resolveWorkspaceCreateDestination } from './create-destination';
 
 export class WorkspaceManager {
   private registry: WorkspaceRegistry = { workspaces: [] };
@@ -271,7 +273,11 @@ export class WorkspaceManager {
    * If `parentPath` is provided, the workspace directory is created there
    * (e.g. /Users/me/projects/my-app). Otherwise falls back to ~/.sero-ui/workspaces/.
    */
-  async create(name: string, parentPath?: string): Promise<WorkspaceInfo> {
+  async create(
+    name: string,
+    parentPath?: string,
+    options?: WorkspaceCreateOptions,
+  ): Promise<WorkspaceInfo> {
     if (parentPath) {
       const resolved = path.resolve(parentPath);
       const home = os.homedir();
@@ -280,11 +286,15 @@ export class WorkspaceManager {
       }
     }
 
-    const id = slugify(name);
-    const uniqueId = this.ensureUniqueId(id);
-    const wsPath = parentPath
-      ? path.join(path.resolve(parentPath), uniqueId)
-      : path.join(this.workspacesDir, uniqueId);
+    const destination = await resolveWorkspaceCreateDestination({
+      baseId: slugify(name),
+      parentPath,
+      workspacesDir: this.workspacesDir,
+      registeredIds: new Set(this.registry.workspaces.map((workspace) => workspace.id)),
+      requireEmpty: options?.requireEmpty === true,
+    });
+    const uniqueId = destination.id;
+    const wsPath = destination.path;
 
     await fs.mkdir(wsPath, { recursive: true });
 

--- a/apps/desktop/electron/ipc/workspace/workspace.ts
+++ b/apps/desktop/electron/ipc/workspace/workspace.ts
@@ -7,7 +7,7 @@
 import { ipcMain, dialog, BrowserWindow } from 'electron';
 
 import { IpcChannels } from '@/types/ipc-channels';
-import type { WorkspaceInfo, WorkspaceConfig, WorkspaceRoot } from '@/types/ipc';
+import type { WorkspaceInfo, WorkspaceConfig, WorkspaceCreateOptions, WorkspaceRoot } from '@/types/ipc';
 import type { WorkspaceRuntimeBackend, WorkspaceRuntimeConfig } from '@/types/workspace-runtime';
 import type { BrowserPackStatusIPC, ToolchainStatusIPC, WorkspaceAccessRootsResult, WorkspaceRuntimeDiagnosticsIPC } from '@sero-ai/common';
 import { workspaceManager } from '@electron/features/workspace/manager';
@@ -68,8 +68,8 @@ export function registerWorkspaceHandlers(): void {
   // ── Create a new workspace ──────────────────────────────────
   ipcMain.handle(
     IpcChannels.workspace.create,
-    async (_event, name: string, parentPath?: string): Promise<WorkspaceInfo> => {
-      const workspace = await workspaceManager.create(name, parentPath);
+    async (_event, name: string, parentPath?: string, options?: WorkspaceCreateOptions): Promise<WorkspaceInfo> => {
+      const workspace = await workspaceManager.create(name, parentPath, options);
       await reconcileAppRuntimes('workspace create');
       notifyWorkspaceChanged();
       return workspace;

--- a/apps/desktop/electron/preload/api/core.ts
+++ b/apps/desktop/electron/preload/api/core.ts
@@ -16,6 +16,7 @@ import type {
   SessionModelState,
   SessionUsageStats,
   WorkspaceConfig,
+  WorkspaceCreateOptions,
   WorkspaceInfo,
   WorkspaceRoot,
 } from '@/types/ipc';
@@ -69,8 +70,8 @@ export const profilesBridge = {
 
 export const workspaceBridge = {
   list: (): Promise<WorkspaceInfo[]> => ipcRenderer.invoke(IpcChannels.workspace.list),
-  create: (name: string, parentPath?: string): Promise<WorkspaceInfo> =>
-    ipcRenderer.invoke(IpcChannels.workspace.create, name, parentPath),
+  create: (name: string, parentPath?: string, options?: WorkspaceCreateOptions): Promise<WorkspaceInfo> =>
+    ipcRenderer.invoke(IpcChannels.workspace.create, name, parentPath, options),
   remove: (id: string): Promise<void> => ipcRenderer.invoke(IpcChannels.workspace.remove, id),
   getConfig: (id: string): Promise<WorkspaceConfig | null> =>
     ipcRenderer.invoke(IpcChannels.workspace.getConfig, id),

--- a/apps/desktop/src/components/layout/git-remote/workflow.test.ts
+++ b/apps/desktop/src/components/layout/git-remote/workflow.test.ts
@@ -5,8 +5,10 @@ import {
   connectOrigin,
   createGitHubOrigin,
   defaultRepoName,
+  describeImportOutcome,
   fetchOriginInfo,
 } from './workflow';
+import { deriveRepoNameFromGitUrl } from '@sero-ai/common';
 
 const seroBridge = {
   github: {
@@ -107,12 +109,15 @@ describe('git remote workflow', () => {
       url: 'git@github.com:octocat/my-workspace.git',
       webUrl: 'https://github.com/octocat/my-workspace',
       updatedExisting: true,
+      import: { imported: false, reason: 'link-only' },
     });
     expect(seroBridge.vcs.addRemote).toHaveBeenCalledWith('workspace-1', 'origin', 'git@github.com:octocat/my-workspace.git');
     expect(seroBridge.vcs.setRemoteUrl).toHaveBeenCalledWith('workspace-1', 'origin', 'git@github.com:octocat/my-workspace.git');
+    // No import requested → checkout is never attempted.
+    expect(seroBridge.vcs.checkoutRemote).not.toHaveBeenCalled();
   });
 
-  it('imports repository files for an empty workspace when requested', async () => {
+  it('imports repository files for an empty workspace with auto import', async () => {
     seroBridge.editor.listFiles.mockResolvedValue([
       { name: '.sero-workspace.json', type: 'file', size: 32 },
     ]);
@@ -120,7 +125,7 @@ describe('git remote workflow', () => {
     const result = await connectOrigin({
       workspaceId: 'workspace-1',
       url: 'https://github.com/octocat/my-workspace.git',
-      importIfEmpty: true,
+      importMode: 'auto',
     });
 
     expect(result).toEqual({
@@ -128,11 +133,12 @@ describe('git remote workflow', () => {
       url: 'https://github.com/octocat/my-workspace.git',
       webUrl: 'https://github.com/octocat/my-workspace',
       updatedExisting: false,
+      import: { imported: true },
     });
     expect(seroBridge.vcs.checkoutRemote).toHaveBeenCalledWith('workspace-1', 'origin');
   });
 
-  it('leaves non-empty workspaces unchanged when connecting origin', async () => {
+  it('reports a skipped import for non-empty workspaces under auto mode', async () => {
     seroBridge.editor.listFiles.mockResolvedValue([
       { name: 'package.json', type: 'file', size: 128 },
     ]);
@@ -140,7 +146,7 @@ describe('git remote workflow', () => {
     const result = await connectOrigin({
       workspaceId: 'workspace-1',
       url: 'https://github.com/octocat/my-workspace.git',
-      importIfEmpty: true,
+      importMode: 'auto',
     });
 
     expect(result).toEqual({
@@ -148,11 +154,35 @@ describe('git remote workflow', () => {
       url: 'https://github.com/octocat/my-workspace.git',
       webUrl: 'https://github.com/octocat/my-workspace',
       updatedExisting: false,
+      import: { imported: false, reason: 'workspace-not-empty' },
     });
     expect(seroBridge.vcs.checkoutRemote).not.toHaveBeenCalled();
   });
 
-  it('keeps the origin connected when checkout import fails', async () => {
+  it('imports into a non-empty workspace when import is forced', async () => {
+    seroBridge.editor.listFiles.mockResolvedValue([
+      { name: 'notes.md', type: 'file', size: 12 },
+    ]);
+
+    const result = await connectOrigin({
+      workspaceId: 'workspace-1',
+      url: 'https://github.com/octocat/my-workspace.git',
+      importMode: 'force',
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      url: 'https://github.com/octocat/my-workspace.git',
+      webUrl: 'https://github.com/octocat/my-workspace',
+      updatedExisting: false,
+      import: { imported: true },
+    });
+    // Forced import skips the emptiness probe entirely.
+    expect(seroBridge.editor.listFiles).not.toHaveBeenCalled();
+    expect(seroBridge.vcs.checkoutRemote).toHaveBeenCalledWith('workspace-1', 'origin');
+  });
+
+  it('reports an import failure while keeping the remote linked', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     seroBridge.editor.listFiles.mockResolvedValue([]);
     seroBridge.vcs.checkoutRemote.mockResolvedValue({ success: false, message: 'checkout failed' });
@@ -160,7 +190,7 @@ describe('git remote workflow', () => {
     const result = await connectOrigin({
       workspaceId: 'workspace-1',
       url: 'https://github.com/octocat/my-workspace.git',
-      importIfEmpty: true,
+      importMode: 'auto',
     });
 
     expect(result).toEqual({
@@ -168,7 +198,7 @@ describe('git remote workflow', () => {
       url: 'https://github.com/octocat/my-workspace.git',
       webUrl: 'https://github.com/octocat/my-workspace',
       updatedExisting: false,
-      warning: "Connected, but Sero couldn't import files: checkout failed",
+      import: { imported: false, reason: 'import-failed', message: 'checkout failed' },
     });
     expect(warn).toHaveBeenCalledWith(
       '[git-remote] Remote connected, but import failed:',
@@ -200,5 +230,34 @@ describe('git remote workflow', () => {
       ok: false,
       message: 'jj remotes unavailable',
     });
+  });
+
+  it('describes import outcomes for the user only when there is something to say', () => {
+    expect(describeImportOutcome({ imported: true })).toBeNull();
+    expect(describeImportOutcome({ imported: false, reason: 'link-only' })).toBeNull();
+    expect(describeImportOutcome({ imported: false, reason: 'workspace-not-empty' })).toMatch(
+      /nothing was imported/i,
+    );
+    expect(
+      describeImportOutcome({ imported: false, reason: 'import-failed', message: 'boom' }),
+    ).toMatch(/boom/);
+  });
+});
+
+describe('deriveRepoNameFromGitUrl', () => {
+  it.each([
+    ['https://github.com/octocat/Hello-World.git', 'Hello-World'],
+    ['https://github.com/octocat/Hello-World', 'Hello-World'],
+    ['git@github.com:octocat/my-workspace.git', 'my-workspace'],
+    ['git@gitlab.com:group/sub/app.git', 'app'],
+    ['ssh://git@host:2222/team/repo', 'repo'],
+    ['https://example.com/scm/repo.git/', 'repo'],
+  ])('derives %s → %s', (url, expected) => {
+    expect(deriveRepoNameFromGitUrl(url)).toBe(expected);
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(deriveRepoNameFromGitUrl('')).toBeUndefined();
+    expect(deriveRepoNameFromGitUrl(null)).toBeUndefined();
   });
 });

--- a/apps/desktop/src/components/layout/git-remote/workflow.ts
+++ b/apps/desktop/src/components/layout/git-remote/workflow.ts
@@ -29,13 +29,37 @@ export type CreateGitHubOriginResult =
       url?: string;
     };
 
+/**
+ * How much to import when connecting a remote:
+ * - `never`  — record the remote only, touch no files (default).
+ * - `auto`   — fetch + check out only when the workspace is empty (safe default for new workspaces).
+ * - `force`  — always attempt to fetch + check out. Git still refuses to overwrite
+ *              conflicting local files, so this is safe: it either overlays cleanly
+ *              or fails with a conflict message.
+ */
+export type ImportMode = 'never' | 'auto' | 'force';
+
+/** What actually happened to the working tree when a remote was connected. */
+export type ImportOutcome =
+  | { imported: true }
+  | {
+      imported: false;
+      /**
+       * - `link-only`         — no import was requested.
+       * - `workspace-not-empty` — auto import skipped because the workspace already has files.
+       * - `import-failed`     — fetch/checkout ran but failed (e.g. path conflict, auth).
+       */
+      reason: 'link-only' | 'workspace-not-empty' | 'import-failed';
+      message?: string;
+    };
+
 export type ConnectOriginResult =
   | {
       ok: true;
       url: string;
       webUrl?: string;
       updatedExisting: boolean;
-      warning?: string;
+      import: ImportOutcome;
     }
   | {
       ok: false;
@@ -152,16 +176,16 @@ export async function createGitHubOrigin({
 export async function connectOrigin({
   workspaceId,
   url,
-  importIfEmpty,
+  importMode = 'never',
 }: {
   workspaceId: string;
   url: string;
-  importIfEmpty?: boolean;
+  importMode?: ImportMode;
 }): Promise<ConnectOriginResult> {
-  let connected: Extract<ConnectOriginResult, { ok: true }>;
+  let base: { url: string; webUrl?: string; updatedExisting: boolean };
   try {
     await window.sero.vcs.addRemote(workspaceId, 'origin', url);
-    connected = { ok: true, url, webUrl: toGitHubWebUrl(url), updatedExisting: false };
+    base = { url, webUrl: toGitHubWebUrl(url), updatedExisting: false };
   } catch (error) {
     const message = toErrorMessage(error, 'Failed to connect remote');
     if (!message.includes('already exists')) {
@@ -169,18 +193,44 @@ export async function connectOrigin({
     }
     try {
       await window.sero.vcs.setRemoteUrl(workspaceId, 'origin', url);
-      connected = { ok: true, url, webUrl: toGitHubWebUrl(url), updatedExisting: true };
+      base = { url, webUrl: toGitHubWebUrl(url), updatedExisting: true };
     } catch (setError) {
       return { ok: false, message: toErrorMessage(setError, 'Failed to update remote URL') };
     }
   }
 
-  if (!importIfEmpty || await hasVisibleWorkspaceFiles(workspaceId)) return connected;
+  const outcome = await importRemote(workspaceId, importMode);
+  return { ok: true, ...base, import: outcome };
+}
+
+/**
+ * Human-readable summary of what happened to the working tree, or `null` when
+ * there is nothing worth telling the user (a clean import or a plain link).
+ */
+export function describeImportOutcome(outcome: ImportOutcome): string | null {
+  if (outcome.imported) return null;
+  switch (outcome.reason) {
+    case 'link-only':
+      return null;
+    case 'workspace-not-empty':
+      return 'Remote linked. The workspace already has files, so nothing was imported.';
+    case 'import-failed':
+      return `Remote linked, but the files couldn't be imported: ${outcome.message ?? 'unknown error'}`;
+  }
+}
+
+async function importRemote(workspaceId: string, importMode: ImportMode): Promise<ImportOutcome> {
+  if (importMode === 'never') return { imported: false, reason: 'link-only' };
+
+  if (importMode === 'auto' && (await hasVisibleWorkspaceFiles(workspaceId))) {
+    return { imported: false, reason: 'workspace-not-empty' };
+  }
 
   const checkout = await window.sero.vcs.checkoutRemote(workspaceId, 'origin');
-  if (checkout.success) return connected;
+  if (checkout.success) return { imported: true };
+
   console.warn('[git-remote] Remote connected, but import failed:', checkout.message);
-  return { ...connected, warning: `Connected, but Sero couldn't import files: ${checkout.message}` };
+  return { imported: false, reason: 'import-failed', message: checkout.message };
 }
 
 async function hasVisibleWorkspaceFiles(workspaceId: string): Promise<boolean> {

--- a/apps/desktop/src/components/layout/git-remote/workflow.ts
+++ b/apps/desktop/src/components/layout/git-remote/workflow.ts
@@ -33,9 +33,8 @@ export type CreateGitHubOriginResult =
  * How much to import when connecting a remote:
  * - `never`  — record the remote only, touch no files (default).
  * - `auto`   — fetch + check out only when the workspace is empty (safe default for new workspaces).
- * - `force`  — always attempt to fetch + check out. Git still refuses to overwrite
- *              conflicting local files, so this is safe: it either overlays cleanly
- *              or fails with a conflict message.
+ * - `force`  — attempt to fetch + check out even when files are present. The VCS
+ *              layer refuses tracked history and path conflicts before checkout.
  */
 export type ImportMode = 'never' | 'auto' | 'force';
 

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -40,13 +40,13 @@ export function AddWorkspaceMenu() {
   // Clone view state
   const [cloneUrl, setCloneUrl] = useState('');
   const [cloneName, setCloneName] = useState('');
-  const [cloneNameEdited, setCloneNameEdited] = useState(false);
   const [isCloning, setIsCloning] = useState(false);
   const [cloneError, setCloneError] = useState<string | null>(null);
   const [cloneAuthHint, setCloneAuthHint] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const cloneInputRef = useRef<HTMLInputElement>(null);
+  const cloneNameEditedRef = useRef(false);
   // Guards against Radix auto-closing the popover when a native dialog steals focus
   const pickingFolderRef = useRef(false);
   const authInFlightRef = useRef(false);
@@ -63,7 +63,7 @@ export function AddWorkspaceMenu() {
     setParentPath(null);
     setCloneUrl('');
     setCloneName('');
-    setCloneNameEdited(false);
+    cloneNameEditedRef.current = false;
     setCloneError(null);
     setCloneAuthHint(false);
   };
@@ -113,7 +113,7 @@ export function AddWorkspaceMenu() {
   const handleUrlChange = (value: string) => {
     setCloneUrl(value);
     // Keep the name in sync with the URL until the user edits it themselves.
-    if (!cloneNameEdited) setCloneName(deriveRepoNameFromGitUrl(value) ?? '');
+    if (!cloneNameEditedRef.current) setCloneName(deriveRepoNameFromGitUrl(value) ?? '');
   };
 
   const handleClone = async () => {
@@ -200,7 +200,7 @@ export function AddWorkspaceMenu() {
             url={cloneUrl}
             onUrlChange={handleUrlChange}
             name={cloneName}
-            onNameChange={(v) => { setCloneNameEdited(true); setCloneName(v); }}
+            onNameChange={(v) => { cloneNameEditedRef.current = true; setCloneName(v); }}
             parentPath={parentPath}
             onPickLocation={handlePickLocation}
             onClearLocation={() => setParentPath(null)}

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -1,7 +1,9 @@
 import { useRef, useState } from 'react';
 import { Plus } from 'lucide-react';
+import { deriveRepoNameFromGitUrl } from '@sero-ai/common';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useSessionStore } from '@/stores/sessions';
+import { useGitHubAuthStore } from '@/stores/github-auth';
 import {
   Popover,
   PopoverContent,
@@ -9,12 +11,23 @@ import {
 } from '@sero-ai/ui/components/ui/popover';
 import type { WorkspaceInfo } from '@/types/ipc';
 import { IconAction } from '@/components/ui/IconAction';
-import { PickView, CreateView } from './AddWorkspaceViews';
+import { PickView, CreateView, CloneView } from './AddWorkspaceViews';
 import { RemoteOriginManager } from './RemoteOriginManager';
 
 // ── Add Workspace menu ─────────────────────────────────────────
 
-type AddView = 'pick' | 'create';
+type AddView = 'pick' | 'create' | 'clone';
+
+/** Errors that mean "you need GitHub credentials", as opposed to a bad URL. */
+function looksLikeAuthError(message: string): boolean {
+  return /authentication|authenticate|permission denied|access denied|403|terminal prompts disabled|could not read username|repository not found/i.test(
+    message,
+  );
+}
+
+function isGitHubUrl(url: string): boolean {
+  return url.includes('github.com');
+}
 
 export function AddWorkspaceMenu() {
   const [open, setOpen] = useState(false);
@@ -23,14 +36,37 @@ export function AddWorkspaceMenu() {
   const [parentPath, setParentPath] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
+
+  // Clone view state
+  const [cloneUrl, setCloneUrl] = useState('');
+  const [cloneName, setCloneName] = useState('');
+  const [cloneNameEdited, setCloneNameEdited] = useState(false);
+  const [isCloning, setIsCloning] = useState(false);
+  const [cloneError, setCloneError] = useState<string | null>(null);
+  const [cloneAuthHint, setCloneAuthHint] = useState(false);
+
   const inputRef = useRef<HTMLInputElement>(null);
+  const cloneInputRef = useRef<HTMLInputElement>(null);
   // Guards against Radix auto-closing the popover when a native dialog steals focus
   const pickingFolderRef = useRef(false);
+  const authInFlightRef = useRef(false);
+
   const createWorkspace = useWorkspaceStore((s) => s.createWorkspace);
+  const cloneWorkspace = useWorkspaceStore((s) => s.cloneWorkspace);
   const addFolder = useWorkspaceStore((s) => s.addFolder);
   const loadSessions = useSessionStore((s) => s.loadSessions);
+  const openGitHubAuthDialog = useGitHubAuthStore((s) => s.openGitHubAuthDialog);
 
-  const reset = () => { setView('pick'); setNewName(''); setParentPath(null); };
+  const reset = () => {
+    setView('pick');
+    setNewName('');
+    setParentPath(null);
+    setCloneUrl('');
+    setCloneName('');
+    setCloneNameEdited(false);
+    setCloneError(null);
+    setCloneAuthHint(false);
+  };
 
   const handleImportExisting = async () => {
     setOpen(false);
@@ -74,10 +110,47 @@ export function AddWorkspaceMenu() {
     }
   };
 
+  const handleUrlChange = (value: string) => {
+    setCloneUrl(value);
+    // Keep the name in sync with the URL until the user edits it themselves.
+    if (!cloneNameEdited) setCloneName(deriveRepoNameFromGitUrl(value) ?? '');
+  };
+
+  const handleClone = async () => {
+    const trimmedUrl = cloneUrl.trim();
+    if (!trimmedUrl || isCloning) return;
+    setIsCloning(true);
+    setCloneError(null);
+    setCloneAuthHint(false);
+    try {
+      await cloneWorkspace(trimmedUrl, cloneName.trim() || undefined, parentPath ?? undefined);
+      await loadSessions();
+      setOpen(false);
+      reset();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to clone repository';
+      setCloneError(message);
+      setCloneAuthHint(looksLikeAuthError(message) && isGitHubUrl(trimmedUrl));
+    } finally {
+      setIsCloning(false);
+    }
+  };
+
+  const handleSignInAndRetry = async () => {
+    authInFlightRef.current = true;
+    try {
+      const result = await openGitHubAuthDialog({ source: 'remote-origin' });
+      if (result.outcome === 'success') await handleClone();
+    } finally {
+      authInFlightRef.current = false;
+    }
+  };
+
   return (
     <>
     <Popover open={open} onOpenChange={(o) => {
-      if (!o && pickingFolderRef.current) return; // Native dialog stole focus, don't close
+      // Native folder dialog or GitHub auth dialog stole focus, don't close
+      if (!o && (pickingFolderRef.current || authInFlightRef.current)) return;
       setOpen(o);
       if (!o) reset();
     }}>
@@ -95,16 +168,20 @@ export function AddWorkspaceMenu() {
         className="w-64 p-0"
         onOpenAutoFocus={(e) => e.preventDefault()}
       >
-        {view === 'pick' ? (
+        {view === 'pick' && (
           <PickView
             onCreateNew={() => {
               setView('create');
-              // Focus the input after the view transition renders
               requestAnimationFrame(() => inputRef.current?.focus());
+            }}
+            onCloneRepo={() => {
+              setView('clone');
+              requestAnimationFrame(() => cloneInputRef.current?.focus());
             }}
             onImportExisting={handleImportExisting}
           />
-        ) : (
+        )}
+        {view === 'create' && (
           <CreateView
             inputRef={inputRef}
             name={newName}
@@ -115,6 +192,23 @@ export function AddWorkspaceMenu() {
             onBack={() => { setView('pick'); setNewName(''); setParentPath(null); }}
             onCreate={handleCreate}
             isCreating={isCreating}
+          />
+        )}
+        {view === 'clone' && (
+          <CloneView
+            inputRef={cloneInputRef}
+            url={cloneUrl}
+            onUrlChange={handleUrlChange}
+            name={cloneName}
+            onNameChange={(v) => { setCloneNameEdited(true); setCloneName(v); }}
+            parentPath={parentPath}
+            onPickLocation={handlePickLocation}
+            onClearLocation={() => setParentPath(null)}
+            onBack={() => { setView('pick'); reset(); }}
+            onClone={handleClone}
+            isCloning={isCloning}
+            error={cloneError}
+            onSignIn={cloneAuthHint ? handleSignInAndRetry : undefined}
           />
         )}
       </PopoverContent>

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
@@ -1,33 +1,37 @@
-import { FolderInput, FolderOpen, FolderPlus, Loader2, X } from 'lucide-react';
+import { FolderInput, FolderOpen, FolderPlus, GitBranch, Loader2, X } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Input } from '@sero-ai/ui/components/ui/input';
 import { cn } from '@sero-ai/ui/lib/utils';
 
-/** Initial view, two action rows. */
+/** Initial view, three action rows. */
 export function PickView({
   onCreateNew,
+  onCloneRepo,
   onImportExisting,
 }: {
   onCreateNew: () => void;
+  onCloneRepo: () => void;
   onImportExisting: () => void;
 }) {
   return (
     <div className="flex flex-col py-1">
-      <button type="button"
-        onClick={onCreateNew}
-        className="flex items-center gap-2.5 px-3 py-2 text-left text-base text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-      >
-        <FolderPlus className="size-3.5 text-[var(--text-muted)]" />
-        Create New
-      </button>
-      <button type="button"
-        onClick={onImportExisting}
-        className="flex items-center gap-2.5 px-3 py-2 text-left text-base text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-      >
-        <FolderInput className="size-3.5 text-[var(--text-muted)]" />
-        Import Existing
-      </button>
+      <PickRow icon={<FolderPlus className="size-3.5 text-[var(--text-muted)]" />} label="Create New" onClick={onCreateNew} />
+      <PickRow icon={<GitBranch className="size-3.5 text-[var(--text-muted)]" />} label="Clone Repository" onClick={onCloneRepo} />
+      <PickRow icon={<FolderInput className="size-3.5 text-[var(--text-muted)]" />} label="Import Existing" onClick={onImportExisting} />
     </div>
+  );
+}
+
+function PickRow({ icon, label, onClick }: { icon: React.ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-2.5 px-3 py-2 text-left text-base text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+    >
+      {icon}
+      {label}
+    </button>
   );
 }
 
@@ -53,20 +57,12 @@ export function CreateView({
   onCreate: () => void;
   isCreating: boolean;
 }) {
-  const locationLabel = parentPath
-    ? parentPath.split('/').filter(Boolean).pop()
-    : null;
-
   return (
     <form
       onSubmit={(e) => { e.preventDefault(); onCreate(); }}
       className="flex flex-col gap-2.5 p-3"
     >
-      {/* Name */}
-      <div>
-        <label htmlFor="new-workspace-name" className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">
-          Name
-        </label>
+      <Field label="Name" htmlFor="new-workspace-name">
         <Input
           id="new-workspace-name"
           ref={inputRef}
@@ -75,60 +71,181 @@ export function CreateView({
           placeholder="My Project"
           className="h-7 text-xs"
         />
-      </div>
+      </Field>
 
-      {/* Location */}
-      <div>
-        <div className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">
-          Location
-        </div>
-        <button
-          type="button"
-          onClick={onPickLocation}
-          className={cn(
-            'flex h-7 w-full items-center gap-1.5 rounded-md border px-2 text-xs transition-colors',
-            'border-[var(--border-default)] bg-[var(--bg-base)] hover:bg-[var(--bg-elevated)]',
-            parentPath ? 'text-[var(--text-primary)]' : 'text-[var(--text-muted)]',
-          )}
-          title={parentPath ?? 'Default (~/.sero-ui/workspaces)'}
-        >
-          <FolderOpen className="size-3 shrink-0" />
-          <span className="min-w-0 flex-1 truncate text-left">
-            {locationLabel ?? 'Default'}
-          </span>
-          {parentPath && (
-            <span
-              role="button"
-              tabIndex={-1}
-              onClick={(e) => { e.stopPropagation(); onClearLocation(); }}
-              className="shrink-0 rounded p-0.5 hover:bg-[var(--bg-base)]"
-            >
-              <X className="size-2.5 text-[var(--text-muted)]" />
-            </span>
-          )}
-        </button>
-      </div>
+      <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} />
 
-      {/* Actions */}
-      <div className="flex justify-between">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-6 px-2 text-xs"
-          onClick={onBack}
-        >
-          Back
-        </Button>
-        <Button
-          type="submit"
-          size="sm"
-          className="h-6 px-2 text-xs"
-          disabled={!name.trim() || isCreating}
-        >
-          {isCreating ? <Loader2 className="size-3 animate-spin" /> : 'Create'}
-        </Button>
-      </div>
+      <FormActions onBack={onBack} submitLabel="Create" busy={isCreating} disabled={!name.trim()} />
     </form>
+  );
+}
+
+/** Clone form view: git URL, derived name, optional location. */
+export function CloneView({
+  inputRef,
+  url,
+  onUrlChange,
+  name,
+  onNameChange,
+  parentPath,
+  onPickLocation,
+  onClearLocation,
+  onBack,
+  onClone,
+  isCloning,
+  error,
+  onSignIn,
+}: {
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  url: string;
+  onUrlChange: (v: string) => void;
+  name: string;
+  onNameChange: (v: string) => void;
+  parentPath: string | null;
+  onPickLocation: () => void;
+  onClearLocation: () => void;
+  onBack: () => void;
+  onClone: () => void;
+  isCloning: boolean;
+  error: string | null;
+  onSignIn?: () => void;
+}) {
+  return (
+    <form
+      onSubmit={(e) => { e.preventDefault(); onClone(); }}
+      className="flex flex-col gap-2.5 p-3"
+    >
+      <Field label="Repository URL" htmlFor="clone-url">
+        <Input
+          id="clone-url"
+          ref={inputRef}
+          value={url}
+          onChange={(e) => onUrlChange(e.target.value)}
+          placeholder="https://github.com/user/repo.git"
+          className="h-7 text-xs"
+          disabled={isCloning}
+        />
+      </Field>
+
+      <Field label="Name" htmlFor="clone-name">
+        <Input
+          id="clone-name"
+          value={name}
+          onChange={(e) => onNameChange(e.target.value)}
+          placeholder="Derived from URL"
+          className="h-7 text-xs"
+          disabled={isCloning}
+        />
+      </Field>
+
+      <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} disabled={isCloning} />
+
+      {error && (
+        <div className="flex flex-col gap-1.5 rounded-md bg-status-error-muted p-2">
+          <p className="text-xs text-status-error">{error}</p>
+          {onSignIn && (
+            <button
+              type="button"
+              onClick={onSignIn}
+              className="self-start text-xs font-medium text-status-error underline underline-offset-2"
+            >
+              Sign in to GitHub and retry
+            </button>
+          )}
+        </div>
+      )}
+
+      <FormActions onBack={onBack} submitLabel="Clone" busyLabel="Cloning…" busy={isCloning} disabled={!url.trim()} />
+    </form>
+  );
+}
+
+// ── Shared form pieces ─────────────────────────────────────────
+
+function Field({ label, htmlFor, children }: { label: string; htmlFor: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function LocationField({
+  parentPath,
+  onPick,
+  onClear,
+  disabled,
+}: {
+  parentPath: string | null;
+  onPick: () => void;
+  onClear: () => void;
+  disabled?: boolean;
+}) {
+  const locationLabel = parentPath ? parentPath.split('/').filter(Boolean).pop() : null;
+
+  return (
+    <div>
+      <div className="mb-1 block text-xs font-medium text-[var(--text-secondary)]">Location</div>
+      <button
+        type="button"
+        onClick={onPick}
+        disabled={disabled}
+        className={cn(
+          'flex h-7 w-full items-center gap-1.5 rounded-md border px-2 text-xs transition-colors',
+          'border-[var(--border-default)] bg-[var(--bg-base)] hover:bg-[var(--bg-elevated)]',
+          disabled && 'opacity-50',
+          parentPath ? 'text-[var(--text-primary)]' : 'text-[var(--text-muted)]',
+        )}
+        title={parentPath ?? 'Default (~/.sero-ui/workspaces)'}
+      >
+        <FolderOpen className="size-3 shrink-0" />
+        <span className="min-w-0 flex-1 truncate text-left">{locationLabel ?? 'Default'}</span>
+        {parentPath && (
+          <span
+            role="button"
+            tabIndex={-1}
+            onClick={(e) => { e.stopPropagation(); onClear(); }}
+            className="shrink-0 rounded p-0.5 hover:bg-[var(--bg-base)]"
+          >
+            <X className="size-2.5 text-[var(--text-muted)]" />
+          </span>
+        )}
+      </button>
+    </div>
+  );
+}
+
+function FormActions({
+  onBack,
+  submitLabel,
+  busyLabel,
+  busy,
+  disabled,
+}: {
+  onBack: () => void;
+  submitLabel: string;
+  busyLabel?: string;
+  busy: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <Button type="button" variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={onBack} disabled={busy}>
+        Back
+      </Button>
+      <Button type="submit" size="sm" className="h-6 px-2 text-xs" disabled={disabled || busy}>
+        {busy ? (
+          <span className="flex items-center gap-1.5">
+            <Loader2 className="size-3 animate-spin" />
+            {busyLabel ?? submitLabel}
+          </span>
+        ) : (
+          submitLabel
+        )}
+      </Button>
+    </div>
   );
 }

--- a/apps/desktop/src/components/layout/workspace/ConnectExistingView.tsx
+++ b/apps/desktop/src/components/layout/workspace/ConnectExistingView.tsx
@@ -1,0 +1,125 @@
+/**
+ * ConnectExistingView — paste a git remote URL and (optionally) import its files.
+ *
+ * Empty workspaces import automatically. When the workspace already has files,
+ * import is skipped and the user is shown an honest choice: overlay the repo
+ * anyway (git refuses to overwrite conflicting files) or just record the remote.
+ */
+
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import { Input } from '@sero-ai/ui/components/ui/input';
+import { Label } from '@sero-ai/ui/components/ui/label';
+import type { WorkspaceInfo } from '@/types/ipc';
+import { connectOrigin, describeImportOutcome } from '../git-remote/workflow';
+import { BackButton, ErrorBanner } from './remote-origin-views';
+
+type Phase =
+  | { kind: 'input' }
+  | { kind: 'busy'; label: string }
+  // Remote is linked, but files were not imported — let the user decide what to do.
+  | { kind: 'reconcile'; message: string };
+
+export function ConnectExistingView({
+  workspace,
+  onBack,
+  onConnected,
+}: {
+  workspace: WorkspaceInfo;
+  onBack: () => void;
+  onConnected: (url: string, warning?: string) => void;
+}) {
+  const [url, setUrl] = useState('');
+  const [phase, setPhase] = useState<Phase>({ kind: 'input' });
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedUrl = url.trim();
+  const busy = phase.kind === 'busy';
+
+  const run = async (importMode: 'auto' | 'force') => {
+    if (!trimmedUrl || busy) return;
+    setError(null);
+    setPhase({ kind: 'busy', label: importMode === 'force' ? 'Importing…' : 'Connecting…' });
+
+    const result = await connectOrigin({ workspaceId: workspace.id, url: trimmedUrl, importMode });
+    if (!result.ok) {
+      setError(result.message);
+      setPhase({ kind: 'input' });
+      return;
+    }
+
+    if (result.import.imported) {
+      onConnected(result.url);
+      return;
+    }
+
+    // Not imported: surface why and let the user pick a next step.
+    setPhase({
+      kind: 'reconcile',
+      message: describeImportOutcome(result.import) ?? 'Remote linked. Nothing was imported.',
+    });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && phase.kind === 'input' && trimmedUrl) {
+      e.preventDefault();
+      void run('auto');
+    }
+  };
+
+  if (phase.kind === 'reconcile') {
+    return (
+      <div className="flex flex-col gap-4 pt-1">
+        <BackButton onClick={onBack} />
+        <p className="rounded-md bg-status-warning-muted p-2 text-xs text-status-warning">{phase.message}</p>
+        <p className="text-xs text-[var(--text-muted)]">
+          Import will overlay the repository onto this workspace. Files already in the workspace are kept;
+          Sero won't overwrite anything that clashes with the repository.
+        </p>
+        {error && <ErrorBanner message={error} />}
+        <div className="flex justify-between gap-2 pt-1">
+          <Button variant="ghost" onClick={() => onConnected(trimmedUrl, phase.message)}>
+            Just link
+          </Button>
+          <Button onClick={() => { void run('force'); }}>Import anyway</Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 pt-1" onKeyDown={handleKeyDown}>
+      <BackButton onClick={onBack} />
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="remote-url" className="text-base font-medium text-[var(--text-secondary)]">
+          Remote URL
+        </Label>
+        <Input
+          id="remote-url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://github.com/user/repo.git"
+          disabled={busy}
+        />
+        <span className="text-xs text-[var(--text-muted)]">
+          An empty workspace is filled with the repository's files automatically.
+        </span>
+      </div>
+
+      {error && <ErrorBanner message={error} />}
+
+      <div className="flex justify-end gap-2 pt-1">
+        <Button variant="ghost" onClick={onBack} disabled={busy}>Cancel</Button>
+        <Button onClick={() => { void run('auto'); }} disabled={busy || !trimmedUrl}>
+          {busy ? (
+            <><Loader2 className="mr-1.5 size-3.5 animate-spin" />{phase.label}</>
+          ) : (
+            'Connect Repository'
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/workspace/ConnectExistingView.tsx
+++ b/apps/desktop/src/components/layout/workspace/ConnectExistingView.tsx
@@ -2,8 +2,8 @@
  * ConnectExistingView — paste a git remote URL and (optionally) import its files.
  *
  * Empty workspaces import automatically. When the workspace already has files,
- * import is skipped and the user is shown an honest choice: overlay the repo
- * anyway (git refuses to overwrite conflicting files) or just record the remote.
+ * import is skipped and the user can request a guarded import or just record
+ * the remote. The VCS layer refuses imports that could overwrite local data.
  */
 
 import { useState } from 'react';
@@ -74,15 +74,14 @@ export function ConnectExistingView({
         <BackButton onClick={onBack} />
         <p className="rounded-md bg-status-warning-muted p-2 text-xs text-status-warning">{phase.message}</p>
         <p className="text-xs text-[var(--text-muted)]">
-          Import will overlay the repository onto this workspace. Files already in the workspace are kept;
-          Sero won't overwrite anything that clashes with the repository.
+          Sero will import only when it can preserve the workspace's existing files and Git history.
         </p>
         {error && <ErrorBanner message={error} />}
         <div className="flex justify-between gap-2 pt-1">
           <Button variant="ghost" onClick={() => onConnected(trimmedUrl, phase.message)}>
             Just link
           </Button>
-          <Button onClick={() => { void run('force'); }}>Import anyway</Button>
+          <Button onClick={() => { void run('force'); }}>Import files</Button>
         </div>
       </div>
     );

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
@@ -351,7 +351,24 @@ describe('RemoteOriginManager', () => {
     });
   });
 
-  it('shows a non-blocking warning when origin connects but import fails', async () => {
+  it('imports files and shows the connected repo for an empty workspace', async () => {
+    await renderManager();
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('Connect existing repository');
+    });
+
+    await clickButton('Connect existing repository');
+    await setInputValue('remote-url', 'https://github.com/octocat/workspace-1.git');
+    await clickButton('Connect Repository');
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain('octocat/workspace-1');
+    });
+    expect(seroBridge.vcs.checkoutRemote).toHaveBeenCalledWith('workspace-1', 'origin');
+  });
+
+  it('offers a reconcile choice when the import fails, keeping the remote linked', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     seroBridge.vcs.checkoutRemote.mockResolvedValue({ success: false, message: 'checkout failed' });
 
@@ -365,9 +382,18 @@ describe('RemoteOriginManager', () => {
     await setInputValue('remote-url', 'https://github.com/octocat/workspace-1.git');
     await clickButton('Connect Repository');
 
+    // Import failed → user is offered a choice rather than a silent success.
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain("couldn't be imported: checkout failed");
+      expect(document.body.textContent).toContain('Import anyway');
+      expect(document.body.textContent).toContain('Just link');
+    });
+
+    // "Just link" keeps the remote and surfaces the warning on the connected view.
+    await clickButton('Just link');
     await vi.waitFor(() => {
       expect(document.body.textContent).toContain('octocat/workspace-1');
-      expect(document.body.textContent).toContain("Connected, but Sero couldn't import files: checkout failed");
+      expect(document.body.textContent).toContain("couldn't be imported: checkout failed");
     });
 
     warn.mockRestore();

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
@@ -385,7 +385,7 @@ describe('RemoteOriginManager', () => {
     // Import failed → user is offered a choice rather than a silent success.
     await vi.waitFor(() => {
       expect(document.body.textContent).toContain("couldn't be imported: checkout failed");
-      expect(document.body.textContent).toContain('Import anyway');
+      expect(document.body.textContent).toContain('Import files');
       expect(document.body.textContent).toContain('Just link');
     });
 

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
@@ -24,9 +24,9 @@ import {
   LoadingView,
   ChooseView,
   CreateGitHubView,
-  ConnectExistingView,
   ConnectedView,
 } from './remote-origin-views';
+import { ConnectExistingView } from './ConnectExistingView';
 import { fetchOriginInfo, toOriginInfo, type GitRemoteOriginInfo } from '../git-remote/workflow';
 
 // ── Types ────────────────────────────────────────────────────
@@ -89,11 +89,11 @@ export function RemoteOriginManager({
     <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>Remote Origin</DialogTitle>
+          <DialogTitle>Git Repository</DialogTitle>
           <DialogDescription>
             {view === 'connected'
-              ? `Remote origin for "${workspace.name}".`
-              : `Set up the remote origin for "${workspace.name}".`}
+              ? `The Git repository linked to "${workspace.name}".`
+              : `Link "${workspace.name}" to a Git repository.`}
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/desktop/src/components/layout/workspace/remote-origin-views.tsx
+++ b/apps/desktop/src/components/layout/workspace/remote-origin-views.tsx
@@ -24,7 +24,6 @@ import { IconAction } from '@/components/ui/IconAction';
 import type { WorkspaceInfo } from '@/types/ipc';
 import { useGitHubAuthStore } from '@/stores/github-auth';
 import {
-  connectOrigin,
   createGitHubOrigin,
   defaultRepoName,
   displayOriginUrl,
@@ -84,7 +83,7 @@ export function ChooseView({
         </div>
         <div className="flex flex-col">
           <span className="text-base font-medium text-[var(--text-primary)]">Connect existing repository</span>
-          <span className="text-xs text-[var(--text-muted)]">Import files when the workspace is empty</span>
+          <span className="text-xs text-[var(--text-muted)]">Link a repo and pull its files in</span>
         </div>
       </button>
     </div>
@@ -300,83 +299,6 @@ export function CreateGitHubView({
   );
 }
 
-// ── Connect existing repo ────────────────────────────────────
-
-export function ConnectExistingView({
-  workspace,
-  onBack,
-  onConnected,
-}: {
-  workspace: WorkspaceInfo;
-  onBack: () => void;
-  onConnected: (url: string, warning?: string) => void;
-}) {
-  const [url, setUrl] = useState('');
-  const [isConnecting, setIsConnecting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleConnect = async () => {
-    const trimmed = url.trim();
-    if (!trimmed || isConnecting) return;
-
-    setIsConnecting(true);
-    setError(null);
-    try {
-      const result = await connectOrigin({ workspaceId: workspace.id, url: trimmed, importIfEmpty: true });
-      if (result.ok) {
-        onConnected(result.url, result.warning);
-        return;
-      }
-
-      setError(result.message);
-    } finally {
-      setIsConnecting(false);
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && !isConnecting && url.trim()) {
-      e.preventDefault();
-      handleConnect();
-    }
-  };
-
-  return (
-    <div className="flex flex-col gap-4 pt-1" onKeyDown={handleKeyDown}>
-      <BackButton onClick={onBack} />
-
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="remote-url" className="text-base font-medium text-[var(--text-secondary)]">
-          Remote URL
-        </Label>
-        <Input
-          id="remote-url"
-          value={url}
-          onChange={(e) => setUrl(e.target.value)}
-          placeholder="https://github.com/user/repo.git"
-          disabled={isConnecting}
-        />
-        <span className="text-xs text-[var(--text-muted)]">
-          Empty workspaces are fetched and checked out automatically
-        </span>
-      </div>
-
-      {error && <ErrorBanner message={error} />}
-
-      <div className="flex justify-end gap-2 pt-1">
-        <Button variant="ghost" onClick={onBack} disabled={isConnecting}>Cancel</Button>
-        <Button onClick={handleConnect} disabled={isConnecting || !url.trim()}>
-          {isConnecting ? (
-            <><Loader2 className="mr-1.5 size-3.5 animate-spin" />Importing…</>
-          ) : (
-            'Connect Repository'
-          )}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 // ── Connected: show current origin ───────────────────────────
 
 export function ConnectedView({
@@ -434,7 +356,7 @@ export function ConnectedView({
 
 // ── Shared subcomponents ─────────────────────────────────────
 
-function BackButton({ onClick }: { onClick: () => void }) {
+export function BackButton({ onClick }: { onClick: () => void }) {
   return (
     <button type="button"
       onClick={onClick}
@@ -446,7 +368,7 @@ function BackButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-function ErrorBanner({ message }: { message: string }) {
+export function ErrorBanner({ message }: { message: string }) {
   return (
     <p className="rounded-md bg-status-error-muted p-2 text-xs text-status-error">
       {message}

--- a/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
+++ b/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
@@ -233,7 +233,7 @@ export function WorkspaceNode({ workspace, sessions }: WorkspaceNodeProps) {
                       setRemoteManagerOpen(true);
                     }
                   }}
-                  title="Remote origin"
+                  title="Git repository"
                 >
                   <GitBranch className="size-3" />
                 </IconAction>

--- a/apps/desktop/src/stores/workspace.test.ts
+++ b/apps/desktop/src/stores/workspace.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceInfo } from '@/types/ipc';
+
+const workflowMocks = vi.hoisted(() => ({
+  connectOrigin: vi.fn(),
+}));
+
+vi.mock('@/components/layout/git-remote/workflow', () => ({
+  connectOrigin: workflowMocks.connectOrigin,
+}));
+
+import { useWorkspaceStore } from './workspace';
+
+const workspaceBridge = {
+  create: vi.fn(),
+  close: vi.fn(),
+};
+
+const originalSeroDescriptor = Object.getOwnPropertyDescriptor(window, 'sero');
+const initialState = useWorkspaceStore.getInitialState();
+
+function workspace(id: string): WorkspaceInfo {
+  return {
+    id,
+    name: id,
+    path: `/workspaces/${id}`,
+    open: true,
+    runtime: { backend: 'host' },
+    container: false,
+    references: [],
+    mounts: [],
+    roots: [],
+  };
+}
+
+describe('workspace clone action', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useWorkspaceStore.setState(initialState, true);
+    workspaceBridge.create.mockResolvedValue(workspace('new-repo'));
+    workspaceBridge.close.mockResolvedValue(undefined);
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      value: { workspace: workspaceBridge },
+    });
+  });
+
+  afterEach(() => {
+    useWorkspaceStore.setState(initialState, true);
+    if (originalSeroDescriptor) {
+      Object.defineProperty(window, 'sero', originalSeroDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'sero');
+    }
+  });
+
+  it('requires an empty destination and restores the previous selection when import is skipped', async () => {
+    const existing = workspace('existing');
+    useWorkspaceStore.setState({
+      workspaces: [existing],
+      activeWorkspaceId: existing.id,
+    });
+    workflowMocks.connectOrigin.mockResolvedValue({
+      ok: true,
+      url: 'https://github.com/example/new-repo.git',
+      updatedExisting: false,
+      import: { imported: false, reason: 'workspace-not-empty' },
+    });
+
+    await expect(
+      useWorkspaceStore.getState().cloneWorkspace('https://github.com/example/new-repo.git'),
+    ).rejects.toThrow('Clone destination is not empty');
+
+    expect(workspaceBridge.create).toHaveBeenCalledWith('new-repo', undefined, { requireEmpty: true });
+    expect(workspaceBridge.close).toHaveBeenCalledWith('new-repo');
+    expect(useWorkspaceStore.getState().workspaces).toEqual([existing]);
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe(existing.id);
+  });
+
+  it('rolls the temporary workspace back when the import throws', async () => {
+    useWorkspaceStore.setState({ activeWorkspaceId: 'existing' });
+    workflowMocks.connectOrigin.mockRejectedValue(new Error('runtime unavailable'));
+
+    await expect(
+      useWorkspaceStore.getState().cloneWorkspace('https://github.com/example/new-repo.git'),
+    ).rejects.toThrow('runtime unavailable');
+
+    expect(workspaceBridge.close).toHaveBeenCalledWith('new-repo');
+    expect(useWorkspaceStore.getState().activeWorkspaceId).toBe('existing');
+  });
+});

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -160,24 +160,28 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
 
   cloneWorkspace: async (url, name, parentPath) => {
     const repoName = name?.trim() || deriveRepoNameFromGitUrl(url) || 'repository';
-    const workspace = await window.sero.workspace.create(repoName, parentPath);
+    const previousActiveWorkspaceId = get().activeWorkspaceId;
+    const workspace = await window.sero.workspace.create(repoName, parentPath, { requireEmpty: true });
     set((s) => ({
       workspaces: [...s.workspaces, workspace],
       activeWorkspaceId: workspace.id,
     }));
 
-    const result = await connectOrigin({ workspaceId: workspace.id, url, importMode: 'auto' });
-    // A fresh workspace is always empty, so auto import either lands the files or fails outright.
-    const failure = !result.ok
-      ? result.message
-      : !result.import.imported && result.import.reason === 'import-failed'
-        ? result.import.message ?? 'Failed to import repository'
-        : null;
-
-    if (failure) {
-      // Don't leave a stray empty workspace behind for a clone that didn't land.
+    try {
+      const result = await connectOrigin({ workspaceId: workspace.id, url, importMode: 'auto' });
+      if (!result.ok) throw new Error(result.message);
+      if (!result.import.imported) {
+        throw new Error(
+          result.import.reason === 'workspace-not-empty'
+            ? 'Clone destination is not empty'
+            : result.import.message ?? 'Failed to import repository',
+        );
+      }
+    } catch (error) {
+      const restorePreviousSelection = get().activeWorkspaceId === workspace.id;
       await get().closeWorkspace(workspace.id);
-      throw new Error(failure);
+      if (restorePreviousSelection) set({ activeWorkspaceId: previousActiveWorkspaceId });
+      throw error;
     }
 
     // Auto-create and select a default session in the cloned workspace.

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -1,9 +1,11 @@
 import { create } from 'zustand';
+import { deriveRepoNameFromGitUrl } from '@sero-ai/common';
 import type { WorkspaceInfo } from '@/types/ipc';
 import type { WorkspaceRuntimeBackend } from '@/types/workspace-runtime';
 import { useSessionStore } from '@/stores/sessions';
 import { persistLayout } from '@/lib/persist-layout';
 import { createDebouncedFn } from '@/hooks/useDebouncedCallback';
+import { connectOrigin } from '@/components/layout/git-remote/workflow';
 
 // ── Store ──────────────────────────────────────────────────────
 
@@ -45,6 +47,12 @@ interface WorkspaceState {
   createWorkspace: (name: string, parentPath?: string) => Promise<WorkspaceInfo>;
   /** Register an existing folder as a workspace (VSCode "Add Folder"). */
   addFolder: (folderPath: string, name?: string) => Promise<WorkspaceInfo>;
+  /**
+   * Create a workspace from a git remote and import its contents (clone).
+   * Rolls the empty workspace back out of the registry if the import fails.
+   * @param url Any git remote URL (https/ssh). Name is derived from it when omitted.
+   */
+  cloneWorkspace: (url: string, name?: string, parentPath?: string) => Promise<WorkspaceInfo>;
   /** Set provider-aware runtime backend for a workspace. */
   setRuntimeBackend: (id: string, backend: WorkspaceRuntimeBackend) => Promise<void>;
   /**
@@ -146,6 +154,37 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       await useSessionStore.getState().createSession(workspace.id);
     } catch (err) {
       console.warn('Failed to auto-create session for new workspace:', err);
+    }
+    return workspace;
+  },
+
+  cloneWorkspace: async (url, name, parentPath) => {
+    const repoName = name?.trim() || deriveRepoNameFromGitUrl(url) || 'repository';
+    const workspace = await window.sero.workspace.create(repoName, parentPath);
+    set((s) => ({
+      workspaces: [...s.workspaces, workspace],
+      activeWorkspaceId: workspace.id,
+    }));
+
+    const result = await connectOrigin({ workspaceId: workspace.id, url, importMode: 'auto' });
+    // A fresh workspace is always empty, so auto import either lands the files or fails outright.
+    const failure = !result.ok
+      ? result.message
+      : !result.import.imported && result.import.reason === 'import-failed'
+        ? result.import.message ?? 'Failed to import repository'
+        : null;
+
+    if (failure) {
+      // Don't leave a stray empty workspace behind for a clone that didn't land.
+      await get().closeWorkspace(workspace.id);
+      throw new Error(failure);
+    }
+
+    // Auto-create and select a default session in the cloned workspace.
+    try {
+      await useSessionStore.getState().createSession(workspace.id);
+    } catch (err) {
+      console.warn('Failed to auto-create session for cloned workspace:', err);
     }
     return workspace;
   },

--- a/apps/desktop/src/types/electron-workspace.d.ts
+++ b/apps/desktop/src/types/electron-workspace.d.ts
@@ -4,7 +4,7 @@
  * Split from electron.d.ts to keep each file under 500 LOC.
  */
 
-import type { EditorRoot, WorkspaceConfig, WorkspaceInfo, WorkspaceRoot } from './ipc';
+import type { EditorRoot, WorkspaceConfig, WorkspaceCreateOptions, WorkspaceInfo, WorkspaceRoot } from './ipc';
 import type { WorkspaceRuntimeBackend, WorkspaceRuntimeConfig } from './workspace-runtime';
 import type {
   BrowserPackProgressIPC,
@@ -38,7 +38,7 @@ export interface SeroWorkspaceAPI {
   /** List all registered workspaces (registry + config merged). */
   list(): Promise<WorkspaceInfo[]>;
   /** Create a new workspace. Optionally specify a parent directory for the workspace folder. */
-  create(name: string, parentPath?: string): Promise<WorkspaceInfo>;
+  create(name: string, parentPath?: string, options?: WorkspaceCreateOptions): Promise<WorkspaceInfo>;
   /** Unregister a workspace (does not delete files). */
   remove(id: string): Promise<void>;
   /** Get full config for a workspace (.sero-workspace.json). */

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -70,6 +70,11 @@ export interface WorkspaceInfo {
   missing?: boolean; // Registry path is currently unavailable (e.g. removable media).
 }
 
+export interface WorkspaceCreateOptions {
+  /** Use a new or empty destination instead of reusing a non-empty directory. */
+  requireEmpty?: boolean;
+}
+
 /**
  * Root surfaced to the editor IPC. Each entry has the virtual prefix
  * (e.g. `/workspace`, `/sero-source`) the renderer should use when

--- a/apps/docs-site/docs/guide/workspace-and-chat.md
+++ b/apps/docs-site/docs/guide/workspace-and-chat.md
@@ -152,9 +152,9 @@ repository:
 - If the workspace is **empty**, its files are fetched and checked out
   automatically.
 - If the workspace **already has files**, Sero does not overwrite them silently.
-  It tells you nothing was imported and offers a choice: **Import anyway**
-  (overlays the repository onto the workspace — Git still refuses to overwrite
-  any file that clashes) or **Just link** (record the remote only).
+  It tells you nothing was imported and offers a choice: **Import files**
+  (Sero proceeds only when it can preserve existing files and Git history) or
+  **Just link** (record the remote only).
 
 ## Global chat mental model
 

--- a/apps/docs-site/docs/guide/workspace-and-chat.md
+++ b/apps/docs-site/docs/guide/workspace-and-chat.md
@@ -131,6 +131,31 @@ and it is restored when you relaunch Sero with that profile.
 
 ![Workspace sessions](../assets/images/workspace-sessions.jpg)
 
+### Adding a workspace
+
+The **+** button next to the workspace list offers three ways to start:
+
+- **Create New** — makes an empty workspace. After it is created, Sero offers to
+  link it to a Git repository (create a new one on GitHub, or connect an
+  existing one).
+- **Clone Repository** — paste a Git URL and Sero creates a workspace and pulls
+  the repository's files into it in one step. The workspace name is filled in
+  from the URL and can be edited. Private repositories need GitHub sign-in; if a
+  clone fails for that reason, Sero offers to sign in and retry.
+- **Import Existing** — register a folder that already exists on your machine.
+
+### Linking a repository to an existing workspace
+
+Open a workspace's Git action (the branch icon on hover) to link it to a
+repository:
+
+- If the workspace is **empty**, its files are fetched and checked out
+  automatically.
+- If the workspace **already has files**, Sero does not overwrite them silently.
+  It tells you nothing was imported and offers a choice: **Import anyway**
+  (overlays the repository onto the workspace — Git still refuses to overwrite
+  any file that clashes) or **Just link** (record the remote only).
+
 ## Global chat mental model
 
 The chat panel is global to the shell, not tied to one app view. You can switch

--- a/packages/common/src/github-url.ts
+++ b/packages/common/src/github-url.ts
@@ -42,3 +42,22 @@ export function toGitHubWebUrl(url: string): string | undefined {
   if (!parsed) return undefined;
   return `https://github.com/${parsed.owner}/${parsed.repo}`;
 }
+
+/**
+ * Derive a workspace-friendly repository name from any git remote URL.
+ *
+ * Handles https/ssh/scp/self-hosted forms, e.g.
+ *   https://github.com/octocat/Hello-World.git → "Hello-World"
+ *   git@gitlab.com:group/sub/app.git           → "app"
+ *   ssh://git@host:2222/team/repo              → "repo"
+ * Returns undefined when no meaningful segment can be extracted.
+ */
+export function deriveRepoNameFromGitUrl(url: string | null | undefined): string | undefined {
+  if (!url) return undefined;
+
+  const cleaned = url.trim().replace(/[?#].*$/, '').replace(/\/+$/, '');
+  // A repo name never contains '/' or ':', so the last such segment is the name.
+  const lastSegment = cleaned.split(/[/:]/).filter(Boolean).pop();
+  const name = lastSegment?.replace(/\.git$/i, '').trim();
+  return name || undefined;
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -234,6 +234,7 @@ export {
   extractGitHubRepoName,
   extractGitHubUrl,
   toGitHubWebUrl,
+  deriveRepoNameFromGitUrl,
 } from './github-url';
 
 export type {


### PR DESCRIPTION
## Summary

Resolves the two gaps in #173: adding an existing git repo to a workspace didn't sync its contents, and there was no way to create a workspace by cloning a repo.

- **Clone Repository entry point** — a third row in the Add Workspace menu opens a clone view (git URL + auto-derived name + location + progress). Sero creates the workspace and pulls the repo's files in one step. On an auth failure for a private GitHub repo it offers **Sign in to GitHub and retry**.
- **Honest `connectOrigin`** — replaced the silent `importIfEmpty` boolean with an explicit `importMode` (`never | auto | force`) and a structured `ImportOutcome` (`imported` / `link-only` / `workspace-not-empty` / `import-failed`). No more "success but nothing happened".
- **Safe reconciliation for non-empty workspaces** — the user can choose **Import files** or **Just link**. Import now refuses to reset existing Git history or overwrite tracked, untracked, or ignored paths.
- **Safe clone destinations** — clone creation never reuses a non-empty directory. If the derived path is occupied, Sero chooses the next free workspace path instead of changing that directory's Git remote.
- **Complete clone rollback** — failed imports unregister the temporary workspace, restore the previously active workspace, and also clean up when the VCS call throws.
- **Human-friendly copy** — "Remote Origin" → "Git Repository" across the dialog, tree action, and connect view.
- Added `deriveRepoNameFromGitUrl` to `@sero-ai/common`; extracted `ConnectExistingView` into its own module.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm --filter @sero/desktop build`
- [x] `pnpm --filter @sero/desktop test -- --run` (320 files, 1,689 tests)
- [ ] `pnpm --filter @sero/desktop test:e2e` (if relevant)
- [x] React Doctor changed-scope scan (91/100; maintainability warnings only)
- [x] docs updated (`apps/docs-site/docs/guide/workspace-and-chat.md`)

Note: could not drive the full Electron app end-to-end in this environment (the `electron` binary can't download through the proxy), so verification is typecheck, build, and unit tests rather than a live click-through.

## Safety checklist

- [x] no secrets, tokens, credentials, or machine-specific private paths committed
- [x] no unnecessary `any`, `@ts-ignore`, or `@ts-expect-error`
- [x] touched source files remain under 500 LOC

## Screenshots / recordings

<!-- Not captured — Electron app couldn't be launched in this environment. -->

## Risk / rollout notes

- breaking changes: none — `connectOrigin` defaults to link-only, and the new workspace creation option is optional.
- security or privacy impact: none; private-repo clones use the existing GitHub auth flow.
- import safety: workspaces with existing Git history are linked without checkout; Sero does not reset their branch or tracked files.
- follow-up work: proactive sync indicator tracked in #267.

Closes #173.
