### PR TITLE
feat: global search via plugin-contributed search panels

### DIFF
--- a/apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-discovery.test.ts
@@ -154,6 +154,49 @@ describe('app discovery devPort handling', () => {
     }
   });
 
+  it('parses the search contribution and drops it when the UI is suppressed', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-app-discovery-search-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+
+    try {
+      const packageDir = path.join(tempRoot, 'search-plugin');
+      await writeManifestPackage(packageDir, 'search-plugin', 'Search Plugin', undefined, {
+        ui: './dist/ui/remoteEntry.js',
+        component: 'SearchApp',
+        search: { component: 'SearchPanel', description: 'Search everything' },
+      });
+
+      const { readAppManifestFromPackagePath } = await importAppDiscovery();
+
+      const manifest = await readAppManifestFromPackagePath(packageDir);
+      expect(manifest?.search).toEqual({ component: 'SearchPanel', description: 'Search everything' });
+
+      const suppressed = await readAppManifestFromPackagePath(packageDir, { suppressUi: true });
+      expect(suppressed?.search).toBeNull();
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores search contributions without a component name', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-app-discovery-search-invalid-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+
+    try {
+      const packageDir = path.join(tempRoot, 'searchless-plugin');
+      await writeManifestPackage(packageDir, 'searchless-plugin', 'Searchless Plugin', undefined, {
+        search: { description: 'missing component' },
+      });
+
+      const { readAppManifestFromPackagePath } = await importAppDiscovery();
+      const manifest = await readAppManifestFromPackagePath(packageDir);
+
+      expect(manifest?.search).toBeNull();
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('preserves valid plugin metadata during discovery', async () => {
     const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-app-discovery-plugin-valid-'));
     process.env.SERO_HOME_OVERRIDE = tempRoot;

--- a/apps/desktop/electron/features/apps/discovery/index.ts
+++ b/apps/desktop/electron/features/apps/discovery/index.ts
@@ -10,7 +10,7 @@
 
 import { promises as fs } from 'fs';
 import path from 'path';
-import type { SeroAppManifest, SeroWidgetManifest, SettingsPackageSource } from '@/types/ipc';
+import type { SeroAppManifest, SeroSearchManifest, SeroWidgetManifest, SettingsPackageSource } from '@/types/ipc';
 import type { PluginDevSessionRecord } from '@electron/features/plugins/dev-sessions/types';
 import { buildCacheBustedRemoteEntryOverride } from '@electron/features/plugins/dev-sessions/remote-entry';
 import { readPluginDevSessionRecords } from '@electron/features/plugins/dev-sessions/settings';
@@ -36,6 +36,11 @@ interface PkgWidgetDef {
   description?: string;
 }
 
+interface PkgSearchDef {
+  component?: string;
+  description?: string;
+}
+
 interface PkgSeroApp {
   id: string;
   styleIsolation?: 'scope';
@@ -49,6 +54,7 @@ interface PkgSeroApp {
   component?: string;
   devPort?: number;
   widgets?: PkgWidgetDef[];
+  search?: PkgSearchDef;
 }
 
 interface PkgJson {
@@ -145,6 +151,14 @@ function parseWidgets(app: PkgSeroApp): SeroWidgetManifest[] {
   return widgets;
 }
 
+function parseSearch(app: PkgSeroApp): SeroSearchManifest | null {
+  if (typeof app.search?.component !== 'string' || !app.search.component) return null;
+  return {
+    component: app.search.component,
+    description: typeof app.search.description === 'string' ? app.search.description : undefined,
+  };
+}
+
 function buildManifest(
   pkgJson: PkgJson,
   packagePath: string,
@@ -199,6 +213,7 @@ function buildManifest(
       ? evaluatePluginCompatibility(compatibilityRequirements)
       : null,
     widgets: parseWidgets(app),
+    search: suppressUi ? null : parseSearch(app),
   };
 }
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -32,6 +32,14 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useUserFeedbackInit } from '@/hooks/useUserFeedbackInit';
 import { GlobalQuestionPrompt } from '@/components/layout/shell/GlobalQuestionPrompt';
 
+function persistMainSidebarSize(pct: number): void {
+  useAppStore.getState().setMainSidebarSizePct(Math.round(pct * 10) / 10);
+}
+
+function persistChatPanelSize(pct: number): void {
+  useAppStore.getState().setChatPanelSizePct(Math.round(pct * 10) / 10);
+}
+
 /**
  * App shell.
  *
@@ -148,15 +156,8 @@ export function App() {
     });
   }, []);
 
-  const persistMainSidebarSize = useDebouncedCallback(
-    (pct: number) => useAppStore.getState().setMainSidebarSizePct(Math.round(pct * 10) / 10),
-    300,
-  );
-
-  const persistChatPanelSize = useDebouncedCallback(
-    (pct: number) => useAppStore.getState().setChatPanelSizePct(Math.round(pct * 10) / 10),
-    300,
-  );
+  const persistMainSidebarSizeDebounced = useDebouncedCallback(persistMainSidebarSize, 300);
+  const persistChatPanelSizeDebounced = useDebouncedCallback(persistChatPanelSize, 300);
 
   const handleMainSidebarResize = useCallback(
     ({ inPixels, asPercentage }: { inPixels: number; asPercentage: number }) => {
@@ -169,9 +170,9 @@ export function App() {
       }
 
       mainSidebarLastExpandedPctRef.current = asPercentage;
-      persistMainSidebarSize(asPercentage);
+      persistMainSidebarSizeDebounced(asPercentage);
     },
-    [appsReady, layoutReady, setMainSidebarOpen, persistMainSidebarSize],
+    [appsReady, layoutReady, setMainSidebarOpen, persistMainSidebarSizeDebounced],
   );
 
   const handleChatPanelResize = useCallback(
@@ -185,9 +186,9 @@ export function App() {
       }
 
       chatPanelLastExpandedPctRef.current = asPercentage;
-      persistChatPanelSize(asPercentage);
+      persistChatPanelSizeDebounced(asPercentage);
     },
-    [appsReady, layoutReady, setChatPanelOpen, persistChatPanelSize],
+    [appsReady, layoutReady, setChatPanelOpen, persistChatPanelSizeDebounced],
   );
 
   // ── Panel sync effects ──────────────────────────────────────

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -22,6 +22,7 @@ import { NewAppBanner } from '@/components/layout/shell/NewAppBanner';
 import { useSessionAgent } from '@/hooks/useSessionAgent';
 import { useKeyboardShortcuts } from '@/hooks/useKeyboardShortcuts';
 import { CommandMenu } from '@/components/layout/shell/CommandMenu';
+import { GlobalSearchDialog } from '@/components/layout/search/GlobalSearchDialog';
 import { GitHubAuthDialog } from '@/components/layout/auth/github/GitHubAuthDialog';
 import { initAppControlBridge } from '@/lib/app-control-bridge';
 import { hydrateShellState } from '@/lib/app-startup';
@@ -331,6 +332,7 @@ export function App() {
         </div>
 
         <CommandMenu />
+        <GlobalSearchDialog />
         <GitHubAuthDialog />
         <NewAppBanner />
         <OnboardingWizard />

--- a/apps/desktop/src/components/layout/search/GlobalSearchDialog.tsx
+++ b/apps/desktop/src/components/layout/search/GlobalSearchDialog.tsx
@@ -1,0 +1,78 @@
+/**
+ * GlobalSearchDialog, overlay hosting app-contributed global-search panels.
+ *
+ * Apps declare a panel via `sero.app.search` in their manifest; this dialog
+ * mounts the federated component(s). With multiple contributions the panels
+ * are switchable via tabs. Opened from the main sidebar and the ⌘K menu.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@sero-ai/ui/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@sero-ai/ui/components/ui/tabs';
+import { getSearchContributionApps, useAppStore, type AppEntry } from '@/stores/app';
+import { useGlobalSearchStore } from '@/stores/global-search';
+import { getAppIcon } from '@/lib/app-icons';
+import { SearchContributionMount } from './SearchContributionMount';
+
+export function GlobalSearchDialog() {
+  const open = useGlobalSearchStore((s) => s.open);
+  const setOpen = useGlobalSearchStore((s) => s.setOpen);
+  const activeAppId = useGlobalSearchStore((s) => s.activeAppId);
+  const setActiveAppId = useGlobalSearchStore((s) => s.setActiveAppId);
+  const apps = useAppStore((s) => s.apps);
+
+  const contributions = getSearchContributionApps(apps);
+  if (contributions.length === 0) return null;
+
+  const activeId = contributions.some((app) => app.id === activeAppId)
+    ? activeAppId!
+    : contributions[0].id;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="flex h-[min(70vh,40rem)] max-w-2xl flex-col gap-0 overflow-hidden p-0">
+        <DialogHeader className="sr-only">
+          <DialogTitle>Global Search</DialogTitle>
+          <DialogDescription>Search panels contributed by installed apps</DialogDescription>
+        </DialogHeader>
+        {contributions.length === 1 ? (
+          <div className="min-h-0 flex-1">
+            <SearchContributionMount manifest={contributions[0].manifest!} />
+          </div>
+        ) : (
+          <Tabs
+            value={activeId}
+            onValueChange={setActiveAppId}
+            className="flex min-h-0 flex-1 flex-col gap-0"
+          >
+            <TabsList className="m-2 self-start">
+              {contributions.map((app) => (
+                <SearchTabTrigger key={app.id} app={app} />
+              ))}
+            </TabsList>
+            {contributions.map((app) => (
+              <TabsContent key={app.id} value={app.id} className="min-h-0 flex-1">
+                <SearchContributionMount manifest={app.manifest!} />
+              </TabsContent>
+            ))}
+          </Tabs>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SearchTabTrigger({ app }: { app: AppEntry }) {
+  const Icon = getAppIcon(app.icon);
+  return (
+    <TabsTrigger value={app.id}>
+      <Icon className="size-3.5" />
+      {app.label}
+    </TabsTrigger>
+  );
+}

--- a/apps/desktop/src/components/layout/search/GlobalSearchDialog.tsx
+++ b/apps/desktop/src/components/layout/search/GlobalSearchDialog.tsx
@@ -8,12 +8,16 @@
 
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@sero-ai/ui/components/ui/dialog';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@sero-ai/ui/components/ui/tabs';
+import { XIcon } from 'lucide-react';
+import { useEffect, type ReactNode } from 'react';
+import { SERO_GLOBAL_SEARCH_CLOSE_EVENT } from '@sero-ai/app-runtime';
 import { getSearchContributionApps, useAppStore, type AppEntry } from '@/stores/app';
 import { useGlobalSearchStore } from '@/stores/global-search';
 import { getAppIcon } from '@/lib/app-icons';
@@ -26,6 +30,14 @@ export function GlobalSearchDialog() {
   const setActiveAppId = useGlobalSearchStore((s) => s.setActiveAppId);
   const apps = useAppStore((s) => s.apps);
 
+  // Contributed panels ask to dismiss the overlay via this window event (e.g.
+  // after opening a search result), keeping them decoupled from this store.
+  useEffect(() => {
+    const close = () => setOpen(false);
+    window.addEventListener(SERO_GLOBAL_SEARCH_CLOSE_EVENT, close);
+    return () => window.removeEventListener(SERO_GLOBAL_SEARCH_CLOSE_EVENT, close);
+  }, [setOpen]);
+
   const contributions = getSearchContributionApps(apps);
   if (contributions.length === 0) return null;
 
@@ -35,26 +47,38 @@ export function GlobalSearchDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="flex h-[min(70vh,40rem)] max-w-2xl flex-col gap-0 overflow-hidden p-0">
+      {/* Own header bar (tabs + close) so the close button never overlaps the
+          contributed panel's own controls; panels mount below it, full-bleed. */}
+      {/* max-w-4xl is set at the sm: breakpoint too — the base content pins
+          `sm:max-w-lg`, which otherwise wins at every desktop width. */}
+      <DialogContent
+        showCloseButton={false}
+        className="flex h-[min(72vh,44rem)] max-w-4xl flex-col gap-0 overflow-hidden p-0 sm:max-w-4xl"
+      >
         <DialogHeader className="sr-only">
           <DialogTitle>Global Search</DialogTitle>
           <DialogDescription>Search panels contributed by installed apps</DialogDescription>
         </DialogHeader>
         {contributions.length === 1 ? (
-          <div className="min-h-0 flex-1">
-            <SearchContributionMount manifest={contributions[0].manifest!} />
-          </div>
+          <>
+            <SearchHeaderBar />
+            <div className="min-h-0 flex-1">
+              <SearchContributionMount manifest={contributions[0].manifest!} />
+            </div>
+          </>
         ) : (
           <Tabs
             value={activeId}
             onValueChange={setActiveAppId}
             className="flex min-h-0 flex-1 flex-col gap-0"
           >
-            <TabsList className="m-2 self-start">
-              {contributions.map((app) => (
-                <SearchTabTrigger key={app.id} app={app} />
-              ))}
-            </TabsList>
+            <SearchHeaderBar>
+              <TabsList>
+                {contributions.map((app) => (
+                  <SearchTabTrigger key={app.id} app={app} />
+                ))}
+              </TabsList>
+            </SearchHeaderBar>
             {contributions.map((app) => (
               <TabsContent key={app.id} value={app.id} className="min-h-0 flex-1">
                 <SearchContributionMount manifest={app.manifest!} />
@@ -64,6 +88,18 @@ export function GlobalSearchDialog() {
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+function SearchHeaderBar({ children }: { children?: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-2 border-b px-2 py-1.5">
+      {children ?? <span />}
+      <DialogClose className="rounded-sm p-1 text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+        <XIcon className="size-4" />
+        <span className="sr-only">Close</span>
+      </DialogClose>
+    </div>
   );
 }
 

--- a/apps/desktop/src/components/layout/search/SearchContributionMount.tsx
+++ b/apps/desktop/src/components/layout/search/SearchContributionMount.tsx
@@ -7,8 +7,9 @@
  * app-runtime hooks — the search logic itself stays inside the plugin.
  */
 
-import { Suspense } from 'react';
+import { Suspense, useId } from 'react';
 import { AppProvider } from '@sero-ai/app-runtime';
+import { PluginStyleScope } from '@sero-ai/ui/plugin-style-scope';
 import type { SeroAppManifest } from '@/types/ipc';
 import { getFederatedComponent } from '@/lib/federation-registry';
 import { Spinner } from '@sero-ai/ui/components/ui/spinner';
@@ -16,6 +17,7 @@ import { useAppRuntimeMount } from '@/components/apps/useAppRuntimeMount';
 
 export function SearchContributionMount({ manifest }: { manifest: SeroAppManifest }) {
   const { contextValue, status } = useAppRuntimeMount(manifest);
+  const surfaceId = useId();
 
   if (status === 'loading-workspace') {
     return <SearchPanelLoading />;
@@ -39,9 +41,13 @@ export function SearchContributionMount({ manifest }: { manifest: SeroAppManifes
 
   return (
     <AppProvider value={contextValue}>
-      <Suspense fallback={<SearchPanelLoading />}>
-        <LazyComponent />
-      </Suspense>
+      <PluginStyleScope pluginId={manifest.id} surfaceId={surfaceId}>
+        <div data-sero-plugin={manifest.id} className="contents">
+          <Suspense fallback={<SearchPanelLoading />}>
+            <LazyComponent />
+          </Suspense>
+        </div>
+      </PluginStyleScope>
     </AppProvider>
   );
 }

--- a/apps/desktop/src/components/layout/search/SearchContributionMount.tsx
+++ b/apps/desktop/src/components/layout/search/SearchContributionMount.tsx
@@ -1,0 +1,64 @@
+/**
+ * SearchContributionMount, loads and mounts an app's federated global-search
+ * panel (declared via `sero.app.search`).
+ *
+ * Mirrors WidgetMount: wraps the federated component in AppProvider so the
+ * panel has full access to useAppState, useAppTools, and the other
+ * app-runtime hooks — the search logic itself stays inside the plugin.
+ */
+
+import { Suspense } from 'react';
+import { AppProvider } from '@sero-ai/app-runtime';
+import type { SeroAppManifest } from '@/types/ipc';
+import { getFederatedComponent } from '@/lib/federation-registry';
+import { Spinner } from '@sero-ai/ui/components/ui/spinner';
+import { useAppRuntimeMount } from '@/components/apps/useAppRuntimeMount';
+
+export function SearchContributionMount({ manifest }: { manifest: SeroAppManifest }) {
+  const { contextValue, status } = useAppRuntimeMount(manifest);
+
+  if (status === 'loading-workspace') {
+    return <SearchPanelLoading />;
+  }
+
+  if (status === 'missing-workspace') {
+    return <SearchPanelFallback message="No workspace selected" />;
+  }
+
+  const LazyComponent = manifest.search
+    ? getFederatedComponent(
+        manifest.id,
+        manifest.search.component,
+        manifest.devPort,
+        manifest.remoteEntryOverride,
+      )
+    : null;
+  if (!LazyComponent) {
+    return <SearchPanelFallback message="Search panel unavailable" />;
+  }
+
+  return (
+    <AppProvider value={contextValue}>
+      <Suspense fallback={<SearchPanelLoading />}>
+        <LazyComponent />
+      </Suspense>
+    </AppProvider>
+  );
+}
+
+function SearchPanelFallback({ message }: { message: string }) {
+  return (
+    <div className="flex h-full items-center justify-center text-xs text-[var(--text-muted)]">
+      {message}
+    </div>
+  );
+}
+
+function SearchPanelLoading() {
+  return (
+    <div role="status" className="flex h-full items-center justify-center gap-2">
+      <Spinner className="size-4 text-[var(--text-muted)]" />
+      <span className="text-xs text-[var(--text-muted)]">Loading search</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/shell/CommandMenu.tsx
+++ b/apps/desktop/src/components/layout/shell/CommandMenu.tsx
@@ -104,23 +104,6 @@ export function CommandMenu() {
         <CommandInput placeholder="Search apps..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
-          {searchApps.length > 0 && (
-            <CommandGroup heading="Search">
-              {searchApps.map((app) => (
-                <CommandItem
-                  key={`search-${app.id}`}
-                  value={`Search ${app.label} global search`}
-                  onSelect={() => {
-                    setOpen(false);
-                    openSearch(app.id);
-                  }}
-                >
-                  <TextSearch className="size-4 shrink-0" />
-                  <span>Search {app.label}</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          )}
           <CommandGroup heading="Apps">
             {apps.map((app) => {
               const Icon = getAppIcon(app.icon);
@@ -153,6 +136,20 @@ export function CommandMenu() {
               </span>
             </CommandItem>
           </CommandGroup>
+          {searchApps.length > 0 && (
+            <CommandGroup heading="Search">
+              <CommandItem
+                value="Global Search"
+                onSelect={() => {
+                  setOpen(false);
+                  openSearch();
+                }}
+              >
+                <TextSearch className="size-4 shrink-0" />
+                <span>Global Search</span>
+              </CommandItem>
+            </CommandGroup>
+          )}
           <CommandGroup heading="Diagnostics">
             <CommandItem value="Environment Doctor Diagnostics" onSelect={handleOpenDoctor}>
               <Stethoscope className="size-4 shrink-0" />

--- a/apps/desktop/src/components/layout/shell/CommandMenu.tsx
+++ b/apps/desktop/src/components/layout/shell/CommandMenu.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Monitor, Palette, Pencil, Smartphone, Star, Stethoscope } from 'lucide-react';
+import { Monitor, Palette, Pencil, Smartphone, Star, Stethoscope, TextSearch } from 'lucide-react';
 import {
   CommandDialog,
   CommandEmpty,
@@ -15,8 +15,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@sero-ai/ui/components/ui/dialog';
-import { useAppStore } from '@/stores/app';
+import { getSearchContributionApps, useAppStore } from '@/stores/app';
 import { isChromeShortcutsFull } from '@/stores/app/shared';
+import { useGlobalSearchStore } from '@/stores/global-search';
 import { useThemeStore } from '@/stores/theme';
 import { getAppIcon } from '@/lib/app-icons';
 import { openApp } from '@/lib/open-app';
@@ -45,6 +46,8 @@ export function CommandMenu() {
   const toggleChromeShortcut = useAppStore((s) => s.toggleChromeShortcut);
   const toggleMode = useThemeStore((s) => s.toggleMode);
   const activePresetId = useThemeStore((s) => s.activePresetId);
+  const openSearch = useGlobalSearchStore((s) => s.openSearch);
+  const searchApps = getSearchContributionApps(apps);
 
   // Listen for ⌘K / Ctrl+K
   useEffect(() => {
@@ -101,6 +104,23 @@ export function CommandMenu() {
         <CommandInput placeholder="Search apps..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
+          {searchApps.length > 0 && (
+            <CommandGroup heading="Search">
+              {searchApps.map((app) => (
+                <CommandItem
+                  key={`search-${app.id}`}
+                  value={`Search ${app.label} global search`}
+                  onSelect={() => {
+                    setOpen(false);
+                    openSearch(app.id);
+                  }}
+                >
+                  <TextSearch className="size-4 shrink-0" />
+                  <span>Search {app.label}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          )}
           <CommandGroup heading="Apps">
             {apps.map((app) => {
               const Icon = getAppIcon(app.icon);

--- a/apps/desktop/src/components/layout/shell/MainSidebar.tsx
+++ b/apps/desktop/src/components/layout/shell/MainSidebar.tsx
@@ -1,14 +1,16 @@
 import { memo, useState } from 'react';
-import { Grid2x2Plus, Search, X } from 'lucide-react';
+import { Grid2x2Plus, Search, TextSearch, X } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Input } from '@sero-ai/ui/components/ui/input';
 import { Separator } from '@sero-ai/ui/components/ui/separator';
 import {
   getDiscoveredApps,
+  getSearchContributionApps,
   getSidebarApps,
   useAppStore,
   type AppEntry,
 } from '@/stores/app';
+import { useGlobalSearchStore } from '@/stores/global-search';
 import { useSessionStore } from '@/stores/sessions';
 import { getAppIcon } from '@/lib/app-icons';
 import { openApp } from '@/lib/open-app';
@@ -96,10 +98,12 @@ export const MainSidebar = memo(function MainSidebar() {
 function SearchBar() {
   const searchQuery = useSessionStore((s) => s.searchQuery);
   const setSearchQuery = useSessionStore((s) => s.setSearchQuery);
+  const hasGlobalSearch = useAppStore((s) => getSearchContributionApps(s.apps).length > 0);
+  const openSearch = useGlobalSearchStore((s) => s.openSearch);
 
   return (
-    <div className="px-3 py-2">
-      <div className="relative">
+    <div className="flex items-center gap-1 px-3 py-2">
+      <div className="relative flex-1">
         <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--text-muted)]" />
         <Input
           placeholder="Search sessions..."
@@ -108,6 +112,18 @@ function SearchBar() {
           className="h-7 !pl-8 text-xs"
         />
       </div>
+      {hasGlobalSearch && (
+        <Button
+          type="button"
+          size="icon-xs"
+          variant="ghost"
+          aria-label="Global search"
+          title="Global search"
+          onClick={() => openSearch()}
+        >
+          <TextSearch className="size-3.5" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -1,6 +1,7 @@
 export { useAppStore, type AppState } from './app/state';
 export {
   getDiscoveredApps,
+  getSearchContributionApps,
   getSidebarApps,
   type AppEntry,
   type Theme,

--- a/apps/desktop/src/stores/app/shared.ts
+++ b/apps/desktop/src/stores/app/shared.ts
@@ -113,6 +113,11 @@ export function getSidebarApps(apps: AppEntry[], favouriteApps: string[]): AppEn
   return [...builtins, ...favourites];
 }
 
+/** Apps that contribute a global-search panel (`sero.app.search`) and are host-supported. */
+export function getSearchContributionApps(apps: AppEntry[]): AppEntry[] {
+  return apps.filter((app) => app.manifest?.search && isAppEntrySupported(app));
+}
+
 export function getPriorityPreloadApps(
   manifests: SeroAppManifest[],
   activeApp: string,

--- a/apps/desktop/src/stores/global-search.ts
+++ b/apps/desktop/src/stores/global-search.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+
+/**
+ * Global search overlay state. The dialog hosts search panels contributed
+ * by apps via the `sero.app.search` manifest field, and is opened from the
+ * main sidebar and the ⌘K command menu.
+ */
+export interface GlobalSearchState {
+  open: boolean;
+  /** Contribution to focus when multiple apps contribute a panel. Null = first. */
+  activeAppId: string | null;
+  openSearch: (appId?: string) => void;
+  setActiveAppId: (appId: string) => void;
+  setOpen: (open: boolean) => void;
+}
+
+export const useGlobalSearchStore = create<GlobalSearchState>((set) => ({
+  open: false,
+  activeAppId: null,
+  openSearch: (appId) => set((state) => ({ open: true, activeAppId: appId ?? state.activeAppId })),
+  setActiveAppId: (appId) => set({ activeAppId: appId }),
+  setOpen: (open) => set({ open }),
+}));

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -271,7 +271,7 @@ export type {
 
 // ── Sero Apps ──────────────────────────────────────────────────
 
-export type { SettingsPackageSource, SeroAppManifest, SeroWidgetManifest } from './sero-apps';
+export type { SettingsPackageSource, SeroAppManifest, SeroSearchManifest, SeroWidgetManifest } from './sero-apps';
 
 // ── Plugins ─────────────────────────────────────────────────
 

--- a/apps/desktop/src/types/search-manifest.ts
+++ b/apps/desktop/src/types/search-manifest.ts
@@ -1,0 +1,7 @@
+/** Global-search panel contribution declared in an app manifest (`sero.app.search`). */
+export interface SearchManifest {
+  /** Exported component name from the module federation remote (e.g. "GraphifySearch"). */
+  component: string;
+  /** Optional short description shown in search entry points (e.g. the ⌘K item). */
+  description?: string;
+}

--- a/apps/desktop/src/types/sero-apps.ts
+++ b/apps/desktop/src/types/sero-apps.ts
@@ -3,6 +3,7 @@ import type {
   PluginCompatibilityStatus,
   PluginMeta,
 } from '@sero-ai/common';
+import type { SearchManifest } from './search-manifest';
 import type { WidgetManifest } from './widget-manifest';
 
 /**
@@ -12,6 +13,7 @@ import type { WidgetManifest } from './widget-manifest';
 export type SettingsPackageSource = PackageSource;
 
 export type { WidgetManifest as SeroWidgetManifest } from './widget-manifest';
+export type { SearchManifest as SeroSearchManifest } from './search-manifest';
 
 /** Manifest for a Sero app discovered from a Pi package. */
 export interface SeroAppManifest {
@@ -64,4 +66,6 @@ export interface SeroAppManifest {
   hostCompatibility?: PluginCompatibilityStatus | null;
   /** Widget definitions declared in the app manifest. */
   widgets: WidgetManifest[];
+  /** Global-search panel contribution declared in the app manifest. */
+  search?: SearchManifest | null;
 }

--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -30,6 +30,15 @@ Once a workspace is indexed, the agent has six new tools it uses automatically:
 
 You don't need to invoke these manually — the agent picks them up when relevant.
 
+## Global search
+
+You can search the profile-wide graph yourself, from anywhere in Sero:
+
+- Click the search icon next to the session search field in the main sidebar, or
+- Press **⌘K** and choose **Search Graphify**.
+
+Type a question and press Enter — results come from every indexed workspace.
+
 ## Auto-context
 
 Graphify quietly enriches every session in an indexed workspace:

--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -35,7 +35,7 @@ You don't need to invoke these manually — the agent picks them up when relevan
 You can search the profile-wide graph yourself, from anywhere in Sero:
 
 - Click the search icon next to the session search field in the main sidebar, or
-- Press **⌘K** and choose **Search Graphify**.
+- Press **⌘K** and choose **Global Search**.
 
 Type a question and press Enter — results come from every indexed workspace.
 

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -349,6 +349,28 @@ For the complete feature behavior, recovery model, and terminology, see
 The standard Sero app manifest used by all Sero apps and plugins. For a
 step-by-step guide to building a new app, use the `sero-plugin` skill.
 
+#### `sero.app.search` (optional)
+
+Contribute a global-search panel to the shell. The host mounts the named
+federated component in the global search overlay, reachable from the main
+sidebar and the ⌘K menu; the panel renders its own input and results, so all
+search logic stays inside the plugin.
+
+```json
+"search": {
+  "component": "MySearchPanel",
+  "description": "Search my data"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `component` | string | Yes | Exported component name from the module federation remote. Expose it in `vite.config.ts` alongside the app component. |
+| `description` | string | No | Short description shown in search entry points. |
+
+The component is wrapped in `AppProvider` like the main app component, so all
+`@sero-ai/app-runtime` hooks (`useAppState`, `useAppTools`, …) work as usual.
+
 ### `sero.plugin` (required for plugins)
 
 See also: [`docs/plugins/host-compatibility.md`](./host-compatibility.md) for

--- a/docs/plugins/technical.md
+++ b/docs/plugins/technical.md
@@ -155,6 +155,7 @@ provider-specific auth and model UI without hardcoded app-level logic:
       "stateFile": ".sero/apps/todo/state.json",
       "ui": "./dist/ui/remoteEntry.js",
       "component": "TodoApp",
+      "search": { "component": "TodoSearch", "description": "Search todos" },
       "devPort": 5174
     },
     "plugin": {

--- a/packages/app-runtime/src/app-launch.ts
+++ b/packages/app-runtime/src/app-launch.ts
@@ -39,6 +39,30 @@ export async function openSeroApp(appId: string, params?: Record<string, unknown
 }
 
 /**
+ * Open a workspace file in the shell's explorer editor. Resolves false when the
+ * shell doesn't expose file opening. Used by search panels to make results
+ * clickable — `workspaceId` + `filePath` come straight from graph node tags.
+ * Opening a file does NOT close the search overlay; the panel decides that via
+ * `closeSeroSearch` so it can keep the overlay open for opening several files.
+ */
+export async function openSeroFile(workspaceId: string, filePath: string): Promise<boolean> {
+  return (await getSeroApi().appControl?.openFile(workspaceId, filePath)) ?? false;
+}
+
+/** Event the shell's global-search overlay listens for to dismiss itself. */
+export const SERO_GLOBAL_SEARCH_CLOSE_EVENT = 'sero:global-search:close';
+
+/**
+ * Ask the shell to close the global-search overlay a search panel is mounted in.
+ * Uses a window event (same renderer as the host, like `openSeroApp`'s launch
+ * events) so panels stay decoupled from the host's store. No-op outside a window.
+ */
+export function closeSeroSearch(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(SERO_GLOBAL_SEARCH_CLOSE_EVENT));
+}
+
+/**
  * Take (and clear) the launch params another app handed to `openSeroApp`.
  * Call from a mount-time state initializer; returns undefined when the app
  * was opened without params.

--- a/packages/app-runtime/src/index.ts
+++ b/packages/app-runtime/src/index.ts
@@ -16,7 +16,14 @@ export { useSubagentContext, type UseSubagentContextResult } from './use-subagen
 export { useContextPresets, type UseContextPresetsResult } from './use-context-presets';
 export { useTheme, type UseThemeResult } from './use-theme';
 export { getSeroApi } from './sero-bridge';
-export { openSeroApp, consumeAppLaunchParams, onAppLaunchParams } from './app-launch';
+export {
+  openSeroApp,
+  openSeroFile,
+  closeSeroSearch,
+  SERO_GLOBAL_SEARCH_CLOSE_EVENT,
+  consumeAppLaunchParams,
+  onAppLaunchParams,
+} from './app-launch';
 export type { AppModelInfo, AppModelGroup } from './sero-bridge';
 export type { AppToolContentBlock, AppToolImageContent, AppToolResult, AppToolTextContent } from '@sero-ai/common';
 export { registerWidget, getRuntimeWidgets, onWidgetRegistryChange } from './widget-registry';

--- a/packages/app-runtime/src/sero-bridge.ts
+++ b/packages/app-runtime/src/sero-bridge.ts
@@ -46,6 +46,8 @@ export interface SeroAppAgentBridge {
 export interface SeroAppControlBridge {
   /** Switch the shell to the app with this id. False when the app is unknown. */
   open(appId: string): Promise<boolean>;
+  /** Open a workspace file in the explorer editor. False when unavailable. */
+  openFile(workspaceId: string, filePath: string): Promise<boolean>;
 }
 
 export interface SeroGitAppBridge {

--- a/plugins/sero-graphify-plugin/README.md
+++ b/plugins/sero-graphify-plugin/README.md
@@ -40,6 +40,10 @@ The profile graph re-merges after every change. The toolchain (`uv` + pinned
 
 All tools are CLI-bridged (`sero graphify_search ...`).
 
+The plugin also contributes a global-search panel to the shell
+(`sero.app.search` → `GraphifySearch`), reachable from the main sidebar and
+the ⌘K menu, so the profile graph can be searched without opening the app.
+
 Auto-context (ported from pi-graphify) adds a one-time session orientation from
 the workspace's `GRAPH_REPORT.md` + profile-graph stats, and appends bounded
 graph-query hints to broad search results. Hard per-session budgets, dedup

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -13,7 +13,7 @@ import { Type } from 'typebox';
 
 import { resolveGraphifyPaths, workspaceGraphJson } from '../shared/paths';
 import { readStateFile, appendIndexRequest } from '../shared/state-io';
-import { loadGraph, queryGraph, findPath, explainNode } from '../shared/query-engine';
+import { loadGraph, queryGraph, searchGraph, findPath, explainNode } from '../shared/query-engine';
 import { resolveCurrentWorkspace } from './current-workspace';
 import { registerAutoContext } from './auto-context';
 import { registerRefreshOnEdit } from './refresh-on-edit';
@@ -44,7 +44,10 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
     async execute(_toolCallId, params) {
       const graph = await loadGraph(paths.profileGraph);
       if (!graph) return text(NOT_BUILT);
-      return text(queryGraph(graph, params.question, { mode: params.mode, budget: params.budget }));
+      const { text: answer, files } = searchGraph(graph, params.question, { mode: params.mode, budget: params.budget });
+      // `files` rides on `details` (UI-only) so the search panel can open them;
+      // the agent still sees the identical text in `content`.
+      return { content: [{ type: 'text', text: answer }], details: { files } };
     },
   });
 

--- a/plugins/sero-graphify-plugin/package.json
+++ b/plugins/sero-graphify-plugin/package.json
@@ -23,6 +23,10 @@
       "stateFile": ".sero/apps/graphify/state.json",
       "ui": "./dist/ui/remoteEntry.js",
       "component": "GraphifyApp",
+      "search": {
+        "component": "GraphifySearch",
+        "description": "Search the profile-wide knowledge graph"
+      },
       "devPort": 5197,
       "runtime": "./runtime/index.ts"
     },

--- a/plugins/sero-graphify-plugin/shared/query-engine/fixtures/repo-graph.json
+++ b/plugins/sero-graphify-plugin/shared/query-engine/fixtures/repo-graph.json
@@ -1,0 +1,16 @@
+{
+  "directed": false,
+  "multigraph": false,
+  "graph": {},
+  "nodes": [
+    { "id": "app-1::src_tip", "label": "tip.js", "type": "code", "repo": "app-1", "source_file": "src/tip.js", "description": "Tip calculator" },
+    { "id": "app-1::src_tip_split", "label": "splitBill()", "type": "code", "repo": "app-1", "source_file": "src/tip.js", "description": "Splits a bill" },
+    { "id": "app-1::readme", "label": "README.md", "type": "document", "repo": "app-1", "source_file": "README.md", "description": "Docs" },
+    { "id": "app-1::concept_rounding", "label": "Rounding", "type": "concept", "repo": "app-1", "description": "Rounding rules" }
+  ],
+  "links": [
+    { "source": "app-1::src_tip", "target": "app-1::src_tip_split", "relation": "contains" },
+    { "source": "app-1::src_tip", "target": "app-1::readme", "relation": "references" },
+    { "source": "app-1::readme", "target": "app-1::concept_rounding", "relation": "references" }
+  ]
+}

--- a/plugins/sero-graphify-plugin/shared/query-engine/index.test.ts
+++ b/plugins/sero-graphify-plugin/shared/query-engine/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeAll } from 'vitest';
 import path from 'node:path';
-import { loadGraph, queryGraph, findPath, explainNode, graphStats, type KnowledgeGraph } from './index';
+import { loadGraph, queryGraph, searchGraph, findPath, explainNode, graphStats, type KnowledgeGraph } from './index';
 
 let graph: KnowledgeGraph;
 beforeAll(async () => {
@@ -26,6 +26,37 @@ describe('queryGraph', () => {
   });
   it('handles no matches', () => {
     expect(queryGraph(graph, 'zzzz')).toContain('No matching concepts');
+  });
+});
+
+describe('searchGraph', () => {
+  let repoGraph: KnowledgeGraph;
+  beforeAll(async () => {
+    repoGraph = (await loadGraph(path.join(__dirname, 'fixtures', 'repo-graph.json')))!;
+  });
+
+  it('returns the same text as queryGraph plus openable files', () => {
+    const result = searchGraph(repoGraph, 'tip split');
+    expect(result.text).toBe(queryGraph(repoGraph, 'tip split'));
+    expect(result.files.length).toBeGreaterThan(0);
+  });
+
+  it('dedupes files by workspace + path and skips concept-only nodes', () => {
+    const { files } = searchGraph(repoGraph, 'tip split rounding');
+    const paths = files.map((f) => `${f.workspaceId}/${f.path}`);
+    // src/tip.js is backed by two nodes but appears once; Rounding has no file.
+    expect(paths).toEqual([...new Set(paths)]);
+    expect(paths).toContain('app-1/src/tip.js');
+    expect(files.some((f) => f.label === 'Rounding')).toBe(false);
+  });
+
+  it('carries workspace id and relative path for opening', () => {
+    const file = searchGraph(repoGraph, 'tip').files.find((f) => f.path === 'src/tip.js');
+    expect(file?.workspaceId).toBe('app-1');
+  });
+
+  it('returns no files when nothing matches', () => {
+    expect(searchGraph(repoGraph, 'zzzz').files).toEqual([]);
   });
 });
 

--- a/plugins/sero-graphify-plugin/shared/query-engine/index.ts
+++ b/plugins/sero-graphify-plugin/shared/query-engine/index.ts
@@ -24,15 +24,30 @@ export interface QueryOptions {
   budget?: number;
 }
 
-/**
- * Answer a question with a relevant subgraph rendered as text.
- * bfs = broad context (depth 2 wide), dfs = trace (depth 4 narrow).
- * Output shape mirrors `graphify query`: traversal header, NODE lines, edges.
- */
-export function queryGraph(graph: KnowledgeGraph, question: string, options: QueryOptions = {}): string {
+/** A file the search touched, resolvable back to a workspace file the UI can open. */
+export interface SearchFileHit {
+  /** Node display name, e.g. "CHANGELOG.md" or "splitBill()". */
+  label: string;
+  /** Node kind (code / document / concept …). */
+  type?: string;
+  /** Workspace id the file belongs to (profile graphs tag this as `repo`). */
+  workspaceId: string;
+  /** File path within the workspace, relative to its root. */
+  path: string;
+}
+
+export interface GraphSearchResult {
+  /** The same text `queryGraph` returns — the agent-facing subgraph rendering. */
+  text: string;
+  /** Distinct, openable files surfaced by the traversal, in relevance order. */
+  files: SearchFileHit[];
+}
+
+/** Run the traversal shared by `queryGraph` and `searchGraph`. */
+function traverse(graph: KnowledgeGraph, question: string, options: QueryOptions) {
   const { mode = 'bfs', budget = 1200 } = options;
   const seeds = findSeeds(graph, question);
-  if (seeds.length === 0) return 'No matching concepts found in the graph.';
+  if (seeds.length === 0) return null;
 
   const depth = mode === 'dfs' ? 4 : 2;
   const hits = mode === 'dfs'
@@ -49,7 +64,44 @@ export function queryGraph(graph: KnowledgeGraph, question: string, options: Que
   for (const hit of hits) {
     lines.push(`  ${'  '.repeat(hit.depth - 1)}↳ ${nodeLine(hit.node)}${hit.via ? `  [via ${edgeLine(hit.via, name)}]` : ''}`);
   }
-  return withinBudget(lines, budget);
+  return { seeds, hits, text: withinBudget(lines, budget) };
+}
+
+/**
+ * Answer a question with a relevant subgraph rendered as text.
+ * bfs = broad context (depth 2 wide), dfs = trace (depth 4 narrow).
+ * Output shape mirrors `graphify query`: traversal header, NODE lines, edges.
+ */
+export function queryGraph(graph: KnowledgeGraph, question: string, options: QueryOptions = {}): string {
+  return traverse(graph, question, options)?.text ?? 'No matching concepts found in the graph.';
+}
+
+/**
+ * Like `queryGraph`, but also returns the distinct files the traversal touched
+ * so a UI can offer to open them. A file is openable only when the node carries
+ * both a workspace tag (`repo`) and a `source_file` path; concept-only nodes are
+ * skipped. Files are deduped by workspace + path, seeds first, in relevance order.
+ */
+export function searchGraph(graph: KnowledgeGraph, question: string, options: QueryOptions = {}): GraphSearchResult {
+  const result = traverse(graph, question, options);
+  if (!result) return { text: 'No matching concepts found in the graph.', files: [] };
+
+  const files: SearchFileHit[] = [];
+  const seen = new Set<string>();
+  const nodes = [...result.seeds, ...result.hits.map((h) => h.node)];
+  for (const node of nodes) {
+    if (!node.repo || !node.source_file) continue;
+    const key = `${node.repo}\0${node.source_file}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    files.push({
+      label: displayName(node, node.id),
+      type: node.type ?? node.file_type,
+      workspaceId: node.repo,
+      path: node.source_file,
+    });
+  }
+  return { text: result.text, files };
 }
 
 export function findPath(graph: KnowledgeGraph, from: string, to: string, budget = 800): string {

--- a/plugins/sero-graphify-plugin/ui/GraphifyApp.tsx
+++ b/plugins/sero-graphify-plugin/ui/GraphifyApp.tsx
@@ -54,7 +54,7 @@ export function GraphifyApp() {
           <p className="text-base text-muted-foreground">No workspaces discovered yet — the background runtime populates this list on startup.</p>
         )}
         {workspaces.map((entry) => (
-          <Card key={entry.workspaceId} className="flex flex-row items-center justify-between p-3">
+          <Card key={entry.workspaceId} className="flex flex-row items-center justify-between border-border/40 p-3">
             <div className="min-w-0">
               <div className="flex items-center gap-2">
                 <span className="truncate font-medium">{entry.name}</span>
@@ -107,7 +107,7 @@ function GraphSearch({ run, profileGraph }: GraphSearchProps) {
   };
 
   return (
-    <Card className="p-3">
+    <Card className="border-border/40 p-3">
       <div className="flex gap-2">
         <Input
           value={question}

--- a/plugins/sero-graphify-plugin/ui/GraphifySearch.tsx
+++ b/plugins/sero-graphify-plugin/ui/GraphifySearch.tsx
@@ -2,23 +2,58 @@
  * GraphifySearch — compact global-search panel contributed to the Sero shell
  * via `sero.app.search`. Mounted by the host in the global search overlay
  * (sidebar trigger and ⌘K); all querying stays inside this plugin.
+ *
+ * Results list the files the query touched; clicking one opens it in the
+ * workspace editor. By default opening a result closes the overlay so the file
+ * is visible — toggle "Keep open" to open several files in a row.
+ *
+ * The last query, its results and the toggle live in a module-scoped cache so
+ * the panel restores when reopened in the same session. It is intentionally NOT
+ * persisted to disk — a fresh app launch starts empty.
  */
 
 import { useState } from 'react';
-import { openSeroApp, useAppState, useAppTools } from '@sero-ai/app-runtime';
-import { Button, Input } from '@sero-ai/ui';
-import { Loader2, Search, Waypoints } from 'lucide-react';
+import {
+  closeSeroSearch,
+  openSeroApp,
+  openSeroFile,
+  useAppState,
+  useAppTools,
+} from '@sero-ai/app-runtime';
+import { Button, Input, Label, Switch } from '@sero-ai/ui';
+import { FileText, Loader2, Search, Waypoints } from 'lucide-react';
+import type { SearchFileHit } from '../shared/query-engine';
 import { DEFAULT_STATE, type GraphifyState } from '../shared/types';
 import './styles.css';
+
+/** In-memory, session-scoped so the panel restores on reopen without persisting. */
+const session: {
+  question: string;
+  files: SearchFileHit[] | null;
+  note: string | null;
+  keepOpen: boolean;
+} = { question: '', files: null, note: null, keepOpen: false };
 
 export function GraphifySearch() {
   const [state] = useAppState<GraphifyState>(DEFAULT_STATE);
   const { run } = useAppTools();
-  const [question, setQuestion] = useState('');
-  const [answer, setAnswer] = useState<string | null>(null);
+  const [question, setQuestion] = useState(session.question);
+  const [files, setFiles] = useState(session.files);
+  const [note, setNote] = useState(session.note);
+  const [keepOpen, setKeepOpen] = useState(session.keepOpen);
   const [searching, setSearching] = useState(false);
 
   const { profileGraph } = state;
+
+  const updateQuestion = (value: string) => {
+    session.question = value;
+    setQuestion(value);
+  };
+
+  const updateKeepOpen = (value: boolean) => {
+    session.keepOpen = value;
+    setKeepOpen(value);
+  };
 
   const search = async () => {
     const trimmed = question.trim();
@@ -26,12 +61,22 @@ export function GraphifySearch() {
     setSearching(true);
     try {
       const result = await run('graphify_search', { question: trimmed });
-      setAnswer(result.text || JSON.stringify(result));
+      const hits = (result.details?.files as SearchFileHit[] | undefined) ?? [];
+      session.files = hits;
+      session.note = hits.length === 0 ? result.text || 'No files matched.' : null;
     } catch (err) {
-      setAnswer(err instanceof Error ? err.message : String(err));
+      session.files = [];
+      session.note = err instanceof Error ? err.message : String(err);
     } finally {
+      setFiles(session.files);
+      setNote(session.note);
       setSearching(false);
     }
+  };
+
+  const openFile = async (file: SearchFileHit) => {
+    await openSeroFile(file.workspaceId, file.path);
+    if (!keepOpen) closeSeroSearch();
   };
 
   return (
@@ -40,7 +85,7 @@ export function GraphifySearch() {
         <Input
           autoFocus
           value={question}
-          onChange={(e) => setQuestion(e.target.value)}
+          onChange={(e) => updateQuestion(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && void search()}
           placeholder="Search across all indexed workspaces…"
         />
@@ -50,8 +95,33 @@ export function GraphifySearch() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
-        {answer !== null ? (
-          <pre className="whitespace-pre-wrap text-xs">{answer}</pre>
+        {files && files.length > 0 ? (
+          <ul className="flex flex-col gap-0.5">
+            {files.map((file) => {
+              const location = `${file.workspaceId}/${file.path}`;
+              return (
+                <li key={location}>
+                  <button
+                    type="button"
+                    onClick={() => void openFile(file)}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-accent"
+                  >
+                    <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate text-sm" title={file.label}>
+                        {file.label}
+                      </span>
+                      <span className="block truncate text-xs text-muted-foreground" title={location}>
+                        {location}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        ) : note !== null ? (
+          <p className="text-sm text-muted-foreground">{note}</p>
         ) : (
           <p className="text-base text-muted-foreground">
             {profileGraph.status === 'ready'
@@ -61,12 +131,18 @@ export function GraphifySearch() {
         )}
       </div>
 
-      <footer className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-        <span className="truncate">
+      <footer className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span className="min-w-0 flex-1 truncate">
           {profileGraph.status === 'ready' && profileGraph.nodes
             ? `${profileGraph.nodes} nodes · ${profileGraph.edges} edges`
             : `Profile graph: ${profileGraph.status}`}
         </span>
+        <div className="flex shrink-0 items-center gap-2">
+          <Switch id="graphify-keep-open" checked={keepOpen} onCheckedChange={updateKeepOpen} />
+          <Label htmlFor="graphify-keep-open" className="cursor-pointer font-normal">
+            Keep open
+          </Label>
+        </div>
         <Button size="sm" variant="ghost" onClick={() => void openSeroApp('graphify')}>
           <Waypoints className="h-4 w-4" />
           Open Graphify

--- a/plugins/sero-graphify-plugin/ui/GraphifySearch.tsx
+++ b/plugins/sero-graphify-plugin/ui/GraphifySearch.tsx
@@ -89,7 +89,11 @@ export function GraphifySearch() {
           onKeyDown={(e) => e.key === 'Enter' && void search()}
           placeholder="Search across all indexed workspaces…"
         />
-        <Button onClick={() => void search()} disabled={searching || !question.trim()}>
+        <Button
+          aria-label="Search"
+          onClick={() => void search()}
+          disabled={searching || !question.trim()}
+        >
           {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
         </Button>
       </div>

--- a/plugins/sero-graphify-plugin/ui/GraphifySearch.tsx
+++ b/plugins/sero-graphify-plugin/ui/GraphifySearch.tsx
@@ -1,0 +1,79 @@
+/**
+ * GraphifySearch — compact global-search panel contributed to the Sero shell
+ * via `sero.app.search`. Mounted by the host in the global search overlay
+ * (sidebar trigger and ⌘K); all querying stays inside this plugin.
+ */
+
+import { useState } from 'react';
+import { openSeroApp, useAppState, useAppTools } from '@sero-ai/app-runtime';
+import { Button, Input } from '@sero-ai/ui';
+import { Loader2, Search, Waypoints } from 'lucide-react';
+import { DEFAULT_STATE, type GraphifyState } from '../shared/types';
+import './styles.css';
+
+export function GraphifySearch() {
+  const [state] = useAppState<GraphifyState>(DEFAULT_STATE);
+  const { run } = useAppTools();
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState<string | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  const { profileGraph } = state;
+
+  const search = async () => {
+    const trimmed = question.trim();
+    if (!trimmed || searching) return;
+    setSearching(true);
+    try {
+      const result = await run('graphify_search', { question: trimmed });
+      setAnswer(result.text || JSON.stringify(result));
+    } catch (err) {
+      setAnswer(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col gap-3 bg-background p-4 text-foreground">
+      <div className="flex gap-2">
+        <Input
+          autoFocus
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && void search()}
+          placeholder="Search across all indexed workspaces…"
+        />
+        <Button onClick={() => void search()} disabled={searching || !question.trim()}>
+          {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+        </Button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        {answer !== null ? (
+          <pre className="whitespace-pre-wrap text-xs">{answer}</pre>
+        ) : (
+          <p className="text-base text-muted-foreground">
+            {profileGraph.status === 'ready'
+              ? 'Ask about any concept, file, or connection in your indexed workspaces.'
+              : 'No profile graph yet — index workspaces in the Graphify app first.'}
+          </p>
+        )}
+      </div>
+
+      <footer className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span className="truncate">
+          {profileGraph.status === 'ready' && profileGraph.nodes
+            ? `${profileGraph.nodes} nodes · ${profileGraph.edges} edges`
+            : `Profile graph: ${profileGraph.status}`}
+        </span>
+        <Button size="sm" variant="ghost" onClick={() => void openSeroApp('graphify')}>
+          <Waypoints className="h-4 w-4" />
+          Open Graphify
+        </Button>
+      </footer>
+    </div>
+  );
+}
+
+export default GraphifySearch;

--- a/plugins/sero-graphify-plugin/vite.config.ts
+++ b/plugins/sero-graphify-plugin/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         manifest: true,
         exposes: {
           './GraphifyApp': './ui/GraphifyApp.tsx',
+          './GraphifySearch': './ui/GraphifySearch.tsx',
         },
         shared: {
           react: { singleton: true },


### PR DESCRIPTION
Closes #231.

Add a `sero.app.search` manifest contribution point so plugins can
inject a global-search panel into the shell without any search logic
leaking into host code:

- Discovery parses `sero.app.search` ({ component, description }) into
  the app manifest (nulled when the plugin UI is suppressed).
- New GlobalSearchDialog hosts contributed panels (tabs when several
  apps contribute); SearchContributionMount loads the federated
  component wrapped in AppProvider, mirroring dashboard widgets.
- Entry points: a global-search button next to the session search in
  MainSidebar and a "Global Search" command in the ⌘K menu, both driven
  by a small global-search Zustand store.
- Graphify plugin contributes the first panel: GraphifySearch queries
  the profile-wide knowledge graph through the existing
  graphify_search tool.
- Docs: plugin guide/technical manifest reference and the Graphify
  docs-site page.

## Follow-up: usable, openable results

The first cut returned a wall of raw graph text with no way to act on it.
Reworked so the panel is actually useful:

- **Open files from results.** `graphify_search` now also returns the
  distinct files a query touched (on the tool's UI-only `details`;
  `node.repo` = workspace id, `source_file` = path). The panel renders
  them as clickable rows that open the file in the workspace editor. Each
  row stacks name over `workspace/path`, truncates both, and shows the
  full value on hover.
- **Panel owns open/close.** Added `openSeroFile` + `closeSeroSearch` to
  app-runtime. Opening a result no longer closes the overlay from the
  shared host `openFile` bridge (that path also serves the agent tool);
  the panel closes it via a decoupled window-event seam instead.
- **"Keep open" toggle** to open several files without the overlay
  dismissing. Last query, results and toggle are kept in-memory for the
  session (never persisted to disk) and restore when the panel reopens.
- **Chrome fixes.** Dedicated header bar so the close button never
  overlaps panel controls; widened to `sm:max-w-4xl` (the base dialog's
  `sm:max-w-lg` was winning at every desktop width).
- **⌘K menu.** Replaced per-app "Search <app>" entries with a single
  "Global Search" command placed after the Apps section.

Adds `searchGraph()` with tests covering file extraction, dedup by
workspace + path, and skipping concept-only nodes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DabAT6EQVry2zw8JnM7RBH