### PR TITLE
perf(react): reduce unnecessary rendering

### DIFF
--- a/apps/desktop/src/components/apps/ActiveAppPanel.tsx
+++ b/apps/desktop/src/components/apps/ActiveAppPanel.tsx
@@ -1,4 +1,4 @@
-
+import { memo } from 'react';
 import { Dashboard } from '@/components/apps/dashboard/Dashboard';
 import { SeroAppMount } from '@/components/apps/SeroAppMount';
 import { useAppStore } from '@/stores/app';
@@ -12,7 +12,7 @@ interface ActiveAppPanelProps {
  * Renders the currently visible app. The store keeps `activeApp` pinned to
  * the previous value while a new federated module preloads in the background.
  */
-export function ActiveAppPanel({ app }: ActiveAppPanelProps) {
+export const ActiveAppPanel = memo(function ActiveAppPanel({ app }: ActiveAppPanelProps) {
   const pendingApp = useAppStore((s) => s.pendingApp);
   const apps = useAppStore((s) => s.apps);
   const entry = apps.find((candidate) => candidate.id === app);
@@ -49,4 +49,4 @@ export function ActiveAppPanel({ app }: ActiveAppPanelProps) {
       {content}
     </div>
   );
-}
+});

--- a/apps/desktop/src/components/apps/SeroAppMount.tsx
+++ b/apps/desktop/src/components/apps/SeroAppMount.tsx
@@ -8,6 +8,7 @@
 
 import {
   Component,
+  memo,
   Suspense,
   useInsertionEffect,
   useId,
@@ -25,7 +26,7 @@ interface SeroAppMountProps {
   manifest: SeroAppManifest;
 }
 
-export function SeroAppMount({ manifest }: SeroAppMountProps) {
+export const SeroAppMount = memo(function SeroAppMount({ manifest }: SeroAppMountProps) {
   const { contextValue, status } = useAppRuntimeMount(manifest);
   const surfaceId = useId();
 
@@ -69,7 +70,7 @@ export function SeroAppMount({ manifest }: SeroAppMountProps) {
       </AppErrorBoundary>
     </AppProvider>
   );
-}
+});
 
 interface AppErrorBoundaryProps {
   children: ReactNode;

--- a/apps/desktop/src/components/apps/explorer/browser/ScreenshotOverlay.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/ScreenshotOverlay.tsx
@@ -38,7 +38,7 @@ export function ScreenshotOverlay({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const imgRef = useRef<HTMLImageElement | null>(null);
   const [rect, setRect] = useState<Rect | null>(null);
-  const [dragging, setDragging] = useState(false);
+  const draggingRef = useRef(false);
   const startRef = useRef<{ x: number; y: number } | null>(null);
 
   useEffect(() => {
@@ -64,11 +64,11 @@ export function ScreenshotOverlay({
     const pt = localCoords(e);
     startRef.current = pt;
     setRect({ x: pt.x, y: pt.y, w: 0, h: 0 });
-    setDragging(true);
+    draggingRef.current = true;
   };
 
   const handleMouseMove = (e: MouseEvent) => {
-    if (!dragging || !startRef.current) return;
+    if (!draggingRef.current || !startRef.current) return;
     const pt = localCoords(e);
     const s = startRef.current;
     setRect({
@@ -80,7 +80,7 @@ export function ScreenshotOverlay({
   };
 
   const handleMouseUp = () => {
-    setDragging(false);
+    draggingRef.current = false;
   };
 
   const confirm = useCallback(async () => {

--- a/apps/desktop/src/components/apps/explorer/orchestration/OrchestrationPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/orchestration/OrchestrationPanel.tsx
@@ -7,6 +7,7 @@
 
 import { useEffect, useMemo, useCallback } from 'react';
 import { Network, X } from 'lucide-react';
+import { useShallow } from 'zustand/react/shallow';
 import { useSubagentStore } from '@/stores/subagent';
 import { TERMINAL_STATUSES } from '@/stores/subagent-constants';
 import { SubagentList } from './SubagentList';
@@ -40,15 +41,17 @@ export function OrchestrationPanel({ workspaceId }: OrchestrationPanelProps) {
   const hydrated = useSubagentStore((s) => s.hydrated);
   const initListeners = useSubagentStore((s) => s.initListeners);
   const clearCompleted = useSubagentStore((s) => s.clearCompleted);
-  const entries = useSubagentStore((s) => s.entries);
+  const workspaceEntries = useSubagentStore(
+    useShallow((state) => (
+      Object.values(state.entries).filter((entry) => entry.workspaceId === workspaceId)
+    )),
+  );
 
   // Derive filtered + sorted entries, stable unless `entries` record changes
   const filtered = useMemo(
     () =>
-      sortEntries(
-        Object.values(entries).filter((e) => e.workspaceId === workspaceId),
-      ),
-    [entries, workspaceId],
+      sortEntries([...workspaceEntries]),
+    [workspaceEntries],
   );
 
   const hasCompleted = useMemo(

--- a/apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx
+++ b/apps/desktop/src/components/apps/explorer/orchestration/SubagentCard.tsx
@@ -5,7 +5,7 @@
  * Matches the rounded-border card style from ToolCallGroup.
  */
 
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { memo, useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import {
   AlertCircle,
   CheckCircle2,
@@ -157,7 +157,7 @@ function LiveOutputPreview({ text }: { text: string }) {
 /** Threshold (ms) after which a running card shows a "may be stalled" hint. */
 const STALL_HINT_MS = 90_000;
 
-export function SubagentCard({ entry }: SubagentCardProps) {
+export const SubagentCard = memo(function SubagentCard({ entry }: SubagentCardProps) {
   const isRunning = entry.status === 'running' || entry.status === 'queued';
   const isFailed = entry.status === 'failed' || entry.status === 'timed_out';
   const isAborted = entry.status === 'aborted';
@@ -312,4 +312,4 @@ export function SubagentCard({ entry }: SubagentCardProps) {
       )}
     </div>
   );
-}
+});

--- a/apps/desktop/src/components/apps/explorer/orchestration/SubagentSummary.tsx
+++ b/apps/desktop/src/components/apps/explorer/orchestration/SubagentSummary.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useMemo } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { useSubagentStore } from '@/stores/subagent';
 
 interface SubagentSummaryProps {
@@ -27,7 +28,11 @@ function formatCost(cost: number): string {
 }
 
 export function SubagentSummary({ workspaceId }: SubagentSummaryProps) {
-  const entries = useSubagentStore((s) => s.entries);
+  const entries = useSubagentStore(
+    useShallow((state) => (
+      Object.values(state.entries).filter((entry) => entry.workspaceId === workspaceId)
+    )),
+  );
 
   const summary = useMemo(() => {
     let count = 0;
@@ -35,8 +40,7 @@ export function SubagentSummary({ workspaceId }: SubagentSummaryProps) {
     let totalTokens = 0;
     let totalDurationMs = 0;
 
-    for (const e of Object.values(entries)) {
-      if (e.workspaceId !== workspaceId) continue;
+    for (const e of entries) {
       count++;
       totalCost += e.usage.cost;
       totalTokens += e.usage.totalTokens;
@@ -44,7 +48,7 @@ export function SubagentSummary({ workspaceId }: SubagentSummaryProps) {
     }
 
     return { count, totalCost, totalTokens, totalDurationMs };
-  }, [entries, workspaceId]);
+  }, [entries]);
 
   if (summary.count === 0) return null;
 

--- a/apps/desktop/src/components/apps/explorer/vcs/BookmarksSection.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/BookmarksSection.tsx
@@ -2,7 +2,7 @@
  * BookmarksSection, Git branch list with remote tracking indicators.
  */
 
-import { useCallback, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import {
   GitBranch,
@@ -35,7 +35,11 @@ export function BookmarksSection({
   remotes,
   activePushBookmark,
 }: Props) {
-  const store = useVcsStore();
+  const createBookmark = useVcsStore((state) => state.createBookmark);
+  const deleteBookmark = useVcsStore((state) => state.deleteBookmark);
+  const fetchRemote = useVcsStore((state) => state.fetch);
+  const push = useVcsStore((state) => state.push);
+  const setActivePushBookmark = useVcsStore((state) => state.setActivePushBookmark);
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState('');
   const [fetching, setFetching] = useState(false);
@@ -48,38 +52,42 @@ export function BookmarksSection({
     const sanitized = newName.trim().replace(/\s+/g, '-');
     if (!sanitized) return;
     try {
-      await store.createBookmark(workspaceId, sanitized);
+      await createBookmark(workspaceId, sanitized);
       setNewName('');
       setShowCreate(false);
     } catch (err) {
       showToast(err instanceof Error ? err.message : 'Failed to create branch');
     }
-  }, [workspaceId, newName, store, showToast]);
+  }, [createBookmark, workspaceId, newName, showToast]);
 
   const handleFetch = useCallback(async () => {
     setFetching(true);
     try {
-      const r = await store.fetch(workspaceId);
+      const r = await fetchRemote(workspaceId);
       showToast(r.message);
     } finally {
       setFetching(false);
     }
-  }, [workspaceId, store, showToast]);
+  }, [fetchRemote, workspaceId, showToast]);
 
   const handlePush = useCallback(async (bm: string) => {
     setPushing(true);
     try {
-      const r = await store.push(workspaceId, bm);
+      const r = await push(workspaceId, bm);
       showToast(r.message);
     } finally {
       setPushing(false);
     }
-  }, [workspaceId, store, showToast]);
+  }, [push, workspaceId, showToast]);
 
   const handleSetActive = useCallback((name: string) => {
-    store.setActivePushBookmark(workspaceId, name);
+    setActivePushBookmark(workspaceId, name);
     showToast(`Active push branch: ${name}`);
-  }, [workspaceId, store, showToast]);
+  }, [setActivePushBookmark, workspaceId, showToast]);
+
+  const handleDelete = useCallback((name: string) => {
+    void deleteBookmark(workspaceId, name);
+  }, [deleteBookmark, workspaceId]);
 
   return (
     <VcsSection
@@ -167,9 +175,9 @@ export function BookmarksSection({
               index={i}
               hasRemotes={hasRemotes}
               isActive={activePushBookmark === bm.name}
-              onPush={() => void handlePush(bm.name)}
-              onSetActive={() => handleSetActive(bm.name)}
-              onDelete={() => void store.deleteBookmark(workspaceId, bm.name)}
+              onPush={handlePush}
+              onSetActive={handleSetActive}
+              onDelete={handleDelete}
             />
           ))
         )}
@@ -194,7 +202,7 @@ export function BookmarksSection({
 
 // ── Branch row ───────────────────────────────────────────────
 
-function BookmarkRow({
+const BookmarkRow = memo(function BookmarkRow({
   bookmark,
   index,
   hasRemotes,
@@ -207,9 +215,9 @@ function BookmarkRow({
   index: number;
   hasRemotes: boolean;
   isActive: boolean;
-  onPush: () => void;
-  onSetActive: () => void;
-  onDelete: () => void;
+  onPush: (name: string) => void;
+  onSetActive: (name: string) => void;
+  onDelete: (name: string) => void;
 }) {
   const synced = bookmark.remoteStatuses.every((r) => r.synced);
   const hasRemote = bookmark.remoteStatuses.length > 0;
@@ -251,22 +259,22 @@ function BookmarkRow({
       {/* Hover actions */}
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
         {!isActive && (
-          <button type="button" onClick={onSetActive} title="Set active push branch" className="text-[var(--text-muted)] hover:text-[var(--brand-primary)] transition-colors">
+          <button type="button" onClick={() => onSetActive(bookmark.name)} title="Set active push branch" className="text-[var(--text-muted)] hover:text-[var(--brand-primary)] transition-colors">
             <Star className="size-3" />
           </button>
         )}
         {hasRemotes && !synced && (
-          <button type="button" onClick={onPush} title="Push" className="text-[var(--text-muted)] hover:text-status-info transition-colors">
+          <button type="button" onClick={() => void onPush(bookmark.name)} title="Push" className="text-[var(--text-muted)] hover:text-status-info transition-colors">
             <CloudUpload className="size-3" />
           </button>
         )}
-        <button type="button" onClick={onDelete} title="Delete" className="text-[var(--text-muted)] hover:text-status-error transition-colors">
+        <button type="button" onClick={() => onDelete(bookmark.name)} title="Delete" className="text-[var(--text-muted)] hover:text-status-error transition-colors">
           <Trash2 className="size-2.5" />
         </button>
       </div>
     </motion.div>
   );
-}
+});
 
 // ── Section action button ────────────────────────────────────
 

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.test.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.test.tsx
@@ -12,6 +12,7 @@ import { ChangeDetail } from './ChangeDetail';
 
 const vcsStoreMocks = vi.hoisted(() => {
   const store = {
+    byWorkspace: { 'ws-1': { activePushBookmark: null } },
     describe: vi.fn(async () => {}),
     push: vi.fn(async () => ({ success: true, message: 'ok' })),
     moveBookmark: vi.fn(async () => {}),
@@ -28,7 +29,9 @@ const vcsStoreMocks = vi.hoisted(() => {
 });
 
 vi.mock('@/stores/vcs', () => ({
-  useVcsStore: Object.assign(vi.fn(() => vcsStoreMocks.store), {
+  useVcsStore: Object.assign(vi.fn((selector: (store: typeof vcsStoreMocks.store) => unknown) => (
+    selector(vcsStoreMocks.store)
+  )), {
     getState: vcsStoreMocks.getState,
   }),
   useWorkspaceVcs: vcsStoreMocks.useWorkspaceVcs,

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.tsx
@@ -18,7 +18,7 @@ import {
   GitBranch,
 } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
-import { useVcsStore, useWorkspaceVcs } from '@/stores/vcs';
+import { useVcsStore } from '@/stores/vcs';
 import type { ChangeEntry, FileDiffEntry } from '@sero-ai/common';
 import { useTransientValue } from '../useTransientUiState';
 import { statusCode, statusColor } from './vcs-utils';
@@ -30,8 +30,15 @@ interface Props {
 }
 
 export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
-  const store = useVcsStore();
-  const ws = useWorkspaceVcs(workspaceId);
+  const abandon = useVcsStore((state) => state.abandon);
+  const createBookmark = useVcsStore((state) => state.createBookmark);
+  const describe = useVcsStore((state) => state.describe);
+  const moveBookmark = useVcsStore((state) => state.moveBookmark);
+  const push = useVcsStore((state) => state.push);
+  const restoreCheckpoint = useVcsStore((state) => state.restoreCheckpoint);
+  const activePushBookmark = useVcsStore(
+    (state) => state.byWorkspace[workspaceId]?.activePushBookmark ?? null,
+  );
   const [files, setFiles] = useState<FileDiffEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [fileLoadError, setFileLoadError] = useState<string | null>(null);
@@ -71,15 +78,15 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
 
   const handleSaveDesc = useCallback(async () => {
     if (descDraft.trim() && descDraft !== entry.description) {
-      await store.describe(workspaceId, entry.changeId, descDraft.trim());
+      await describe(workspaceId, entry.changeId, descDraft.trim());
     }
     setEditing(false);
-  }, [workspaceId, entry.changeId, descDraft, entry.description, store]);
+  }, [describe, descDraft, entry.changeId, entry.description, workspaceId]);
 
   const handlePush = useCallback(async () => {
     setPushing(true);
     try {
-      const r = await store.push(workspaceId, ws?.activePushBookmark ?? undefined, entry.changeId);
+      const r = await push(workspaceId, activePushBookmark ?? undefined, entry.changeId);
       showPushNotice({
         message: r.message || (r.success ? 'Push complete' : 'Push failed'),
         error: !r.success,
@@ -92,7 +99,7 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
     } finally {
       setPushing(false);
     }
-  }, [workspaceId, entry.changeId, ws?.activePushBookmark, store, showPushNotice]);
+  }, [activePushBookmark, entry.changeId, push, showPushNotice, workspaceId]);
 
   const handlePushAs = useCallback(async () => {
     const branch = pushBranch.trim().replace(/\s+/g, '-');
@@ -104,12 +111,12 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
       const freshWs = useVcsStore.getState().byWorkspace[workspaceId];
       const existing = freshWs?.bookmarks.find((b) => b.name === branch);
       if (existing) {
-        await store.moveBookmark(workspaceId, branch, entry.changeId);
+        await moveBookmark(workspaceId, branch, entry.changeId);
       } else {
-        await store.createBookmark(workspaceId, branch, entry.changeId);
+        await createBookmark(workspaceId, branch, entry.changeId);
       }
 
-      const r = await store.push(workspaceId, branch, entry.changeId);
+      const r = await push(workspaceId, branch, entry.changeId);
       showPushNotice({
         message: r.message || (r.success ? 'Push complete' : 'Push failed'),
         error: !r.success,
@@ -126,7 +133,7 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
     } finally {
       setPushing(false);
     }
-  }, [pushBranch, workspaceId, entry.changeId, store, showPushNotice]);
+  }, [createBookmark, entry.changeId, moveBookmark, push, pushBranch, showPushNotice, workspaceId]);
 
   return (
     <div className="border-t border-[var(--border-subtle)]/30 bg-[var(--bg-elevated)]/20 px-3 py-2">
@@ -230,17 +237,17 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
             <DetailAction
               icon={<RotateCcw className="size-3" />}
               label="Restore checkpoint"
-              onClick={() => void store.restoreCheckpoint(workspaceId, entry.changeId)}
+              onClick={() => void restoreCheckpoint(workspaceId, entry.changeId)}
             />
             <DetailAction
               icon={<ArrowDownToLine className="size-3" />}
               label="Squash"
-              onClick={() => void store.abandon(workspaceId, entry.changeId)}
+              onClick={() => void abandon(workspaceId, entry.changeId)}
             />
             <DetailAction
               icon={<Trash2 className="size-3" />}
               label="Abandon"
-              onClick={() => void store.abandon(workspaceId, entry.changeId)}
+              onClick={() => void abandon(workspaceId, entry.changeId)}
               danger
             />
             <DetailAction

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeLog.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeLog.tsx
@@ -50,7 +50,7 @@ export function ChangeLog({ workspaceId, entries, hasMore, onOpenDiff }: Props) 
                 entry={entry}
                 index={i}
                 isExpanded={expandedId === entry.changeId}
-                onToggle={() => handleToggle(entry.changeId)}
+                onToggle={handleToggle}
               />
               <AnimatePresence>
                 {expandedId === entry.changeId && (

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeLogRow.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeLogRow.tsx
@@ -16,7 +16,7 @@ interface Props {
   entry: ChangeEntry;
   index: number;
   isExpanded: boolean;
-  onToggle: () => void;
+  onToggle: (changeId: string) => void;
 }
 
 function ChangeGlyph({ entry }: { entry: ChangeEntry }) {
@@ -43,7 +43,7 @@ export const ChangeLogRow = memo(function ChangeLogRow({ entry, index, isExpande
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.1, delay: Math.min(index * 0.015, 0.3) }}
-      onClick={onToggle}
+      onClick={() => onToggle(entry.changeId)}
       className={cn(
         'group flex w-full items-center gap-1.5 px-3 py-[3px] text-left',
         'transition-colors duration-75',

--- a/apps/desktop/src/components/apps/explorer/vcs/RemotesSection.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/RemotesSection.tsx
@@ -16,7 +16,9 @@ interface Props {
 }
 
 export function RemotesSection({ workspaceId, remotes }: Props) {
-  const store = useVcsStore();
+  const addRemote = useVcsStore((state) => state.addRemote);
+  const removeRemote = useVcsStore((state) => state.removeRemote);
+  const setError = useVcsStore((state) => state.setError);
   const [showAdd, setShowAdd] = useState(false);
   const [name, setName] = useState('origin');
   const [url, setUrl] = useState('');
@@ -24,14 +26,14 @@ export function RemotesSection({ workspaceId, remotes }: Props) {
   const handleAdd = useCallback(async () => {
     if (!name.trim() || !url.trim()) return;
     try {
-      await store.addRemote(workspaceId, name.trim(), url.trim());
+      await addRemote(workspaceId, name.trim(), url.trim());
       setName('origin');
       setUrl('');
       setShowAdd(false);
     } catch (err) {
-      store.setError(workspaceId, err instanceof Error ? err.message : 'Failed to add remote');
+      setError(workspaceId, err instanceof Error ? err.message : 'Failed to add remote');
     }
-  }, [workspaceId, name, url, store]);
+  }, [addRemote, name, setError, url, workspaceId]);
 
   return (
     <VcsSection
@@ -140,7 +142,7 @@ export function RemotesSection({ workspaceId, remotes }: Props) {
                 {remote.url}
               </span>
               <button type="button"
-                onClick={() => void store.removeRemote(workspaceId, remote.name)}
+                onClick={() => void removeRemote(workspaceId, remote.name)}
                 title="Remove remote"
                 className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100 text-[var(--text-muted)] hover:text-status-error"
               >

--- a/apps/desktop/src/components/apps/explorer/vcs/WorkingCopySection.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/WorkingCopySection.tsx
@@ -2,7 +2,7 @@
  * WorkingCopySection, shows modified/added/deleted files in the working copy.
  */
 
-import { useCallback, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { motion } from 'motion/react';
 import { PlusCircle } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -51,33 +51,11 @@ export function WorkingCopySection({ workspaceId, status, currentChangeId, onOpe
       <div className="px-2 pb-2">
         {/* File list */}
         {hasChanges ? (
-          <div className="mb-2 space-y-px">
-            {status!.files.map((f, i) => (
-              <motion.button
-                key={f.path}
-                initial={{ opacity: 0, x: -4 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ duration: 0.12, delay: i * 0.02 }}
-                onClick={() => {
-                  if (currentChangeId && onOpenDiff) {
-                    onOpenDiff(currentChangeId + '-', currentChangeId, f.path);
-                  }
-                }}
-                className={cn(
-                  'flex w-full items-center gap-2 rounded px-2 py-0.5 text-left',
-                  'transition-colors duration-100',
-                  'hover:bg-[var(--bg-elevated)]/80',
-                )}
-              >
-                <span className={cn('w-3 shrink-0 text-center text-sm font-bold', statusColor(f.status))}>
-                  {statusCode(f.status)}
-                </span>
-                <span className="min-w-0 truncate text-sm text-[var(--text-secondary)]">
-                  {f.path}
-                </span>
-              </motion.button>
-            ))}
-          </div>
+          <WorkingCopyFileList
+            status={status!}
+            currentChangeId={currentChangeId}
+            onOpenDiff={onOpenDiff}
+          />
         ) : (
           <div className="px-2 py-1.5 text-sm text-[var(--text-muted)]/60">
             No working copy changes
@@ -122,3 +100,43 @@ export function WorkingCopySection({ workspaceId, status, currentChangeId, onOpe
     </VcsSection>
   );
 }
+
+const WorkingCopyFileList = memo(function WorkingCopyFileList({
+  status,
+  currentChangeId,
+  onOpenDiff,
+}: {
+  status: WorkingCopyStatus;
+  currentChangeId: string | null;
+  onOpenDiff?: (from: string, to: string, path?: string) => void;
+}) {
+  return (
+    <div className="mb-2 space-y-px">
+      {status.files.map((file, index) => (
+        <motion.button
+          key={file.path}
+          initial={{ opacity: 0, x: -4 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ duration: 0.12, delay: index * 0.02 }}
+          onClick={() => {
+            if (currentChangeId && onOpenDiff) {
+              onOpenDiff(currentChangeId + '-', currentChangeId, file.path);
+            }
+          }}
+          className={cn(
+            'flex w-full items-center gap-2 rounded px-2 py-0.5 text-left',
+            'transition-colors duration-100',
+            'hover:bg-[var(--bg-elevated)]/80',
+          )}
+        >
+          <span className={cn('w-3 shrink-0 text-center text-sm font-bold', statusColor(file.status))}>
+            {statusCode(file.status)}
+          </span>
+          <span className="min-w-0 truncate text-sm text-[var(--text-secondary)]">
+            {file.path}
+          </span>
+        </motion.button>
+      ))}
+    </div>
+  );
+});

--- a/apps/desktop/src/components/diagnostics/DoctorCategorySection.tsx
+++ b/apps/desktop/src/components/diagnostics/DoctorCategorySection.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { DoctorCategory, DoctorResult } from '@/types/ipc';
 import { DoctorResultRow } from './DoctorResultRow';
 
@@ -18,7 +19,7 @@ interface Props {
   onCopyFix?: (fix: string) => void;
 }
 
-export function DoctorCategorySection({ category, results, onCopyFix }: Props) {
+export const DoctorCategorySection = memo(function DoctorCategorySection({ category, results, onCopyFix }: Props) {
   if (results.length === 0) return null;
   return (
     <section className="mb-4">
@@ -34,4 +35,4 @@ export function DoctorCategorySection({ category, results, onCopyFix }: Props) {
       </ul>
     </section>
   );
-}
+});

--- a/apps/desktop/src/components/diagnostics/DoctorPanel.tsx
+++ b/apps/desktop/src/components/diagnostics/DoctorPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { DoctorCategory, DoctorResult } from '@/types/ipc';
 import { DoctorCategorySection } from './DoctorCategorySection';
 import { useDoctor } from './useDoctor';
@@ -34,13 +34,13 @@ export function DoctorPanel({ safeMode = false }: Props) {
     return map;
   }, [report]);
 
-  const onCopyFix = async (text: string) => {
+  const onCopyFix = useCallback(async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
     } catch {
       /* ignore, clipboard may be unavailable in tests */
     }
-  };
+  }, []);
 
   return (
     <div className="p-4 max-w-3xl mx-auto">

--- a/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
+++ b/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
@@ -15,10 +15,10 @@ import {
 } from '@sero-ai/ui/components/ai-elements/prompt-input';
 import { useAgentStore } from '@/stores/agent';
 import {
-  useFocusedAgent,
   useFocusedCollaborationMode,
   useFocusedCollaborationStrategy,
   useFocusedDebateConfig,
+  useFocusedModelState,
 } from '@/stores/agent-selectors';
 import { useContextEditorStore, useHasOverrides } from '@/stores/context-editor';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -59,12 +59,12 @@ export function ContextEditorMenuItem({
 // ── Thinking blocks toggle ─────────────────────────────────────
 
 export function ThinkingBlocksToggle({ disabled }: { disabled: boolean }) {
-  const focused = useFocusedAgent();
+  const modelState = useFocusedModelState();
   const showThinking = useAgentStore((s) => s.showThinkingBlocks);
   const toggle = useAgentStore((s) => s.toggleThinkingBlocks);
 
-  const isReasoning = focused?.modelState?.model.reasoning ?? false;
-  const thinkingLevel = focused?.modelState?.thinkingLevel ?? 'off';
+  const isReasoning = modelState?.model.reasoning ?? false;
+  const thinkingLevel = modelState?.thinkingLevel ?? 'off';
   const isActive = isReasoning && thinkingLevel !== 'off';
 
   return (

--- a/apps/desktop/src/components/layout/CollaborationActivityPanel.tsx
+++ b/apps/desktop/src/components/layout/CollaborationActivityPanel.tsx
@@ -12,9 +12,10 @@ import { useMemo } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Swords, Users, XCircle } from 'lucide-react';
 import {
-  useFocusedAgent,
   useFocusedCollaborationStatus,
   useFocusedCollaborationStrategy,
+  useFocusedSessionId,
+  useFocusedWorkspaceId,
 } from '@/stores/agent-selectors';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { CollaborationRole } from '@/types/collaboration';
@@ -32,14 +33,15 @@ import {
 } from './CollaborationFeedItems';
 
 export function CollaborationActivityPanel() {
-  const focused = useFocusedAgent();
+  const sessionId = useFocusedSessionId();
+  const workspaceId = useFocusedWorkspaceId();
   const status = useFocusedCollaborationStatus();
   const strategy = useFocusedCollaborationStrategy();
   const feed = useChatFeed();
   const scrollRef = useAutoScroll(feed.length);
   const { latestEntryByRole } = useCollaborationSubagentEntries(
-    focused?.sessionId ?? null,
-    focused?.workspaceId ?? null,
+    sessionId,
+    workspaceId,
   );
 
   const activeRoles = useMemo(() => {

--- a/apps/desktop/src/components/layout/shell/MainSidebar.tsx
+++ b/apps/desktop/src/components/layout/shell/MainSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import { Grid2x2Plus, Search, X } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Input } from '@sero-ai/ui/components/ui/input';
@@ -23,7 +23,7 @@ import { IconAction } from '@/components/ui/IconAction';
  * Top section: sidebar-visible apps (built-ins + favourited discovered apps)
  * Bottom section: workspace → session tree loaded from Pi SDK
  */
-export function MainSidebar() {
+export const MainSidebar = memo(function MainSidebar() {
   const [appStoreOpen, setAppStoreOpen] = useState(false);
   const open = useAppStore((s) => s.mainSidebarOpen);
   const apps = useAppStore((s) => s.apps);
@@ -89,7 +89,7 @@ export function MainSidebar() {
       />
     </>
   );
-}
+});
 
 // ── Search bar ─────────────────────────────────────────────────
 

--- a/apps/desktop/src/components/layout/shell/StatusBar.tsx
+++ b/apps/desktop/src/components/layout/shell/StatusBar.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { FolderOpen, Bug, Sun, Moon, Monitor, GitBranch, Palette } from 'lucide-react';
-import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
 import { MAX_ZOOM, MIN_ZOOM, useZoomStore } from '@/stores/zoom';
 import { useActiveWorkspace } from '@/stores/workspace';
 import { DevServerIndicator } from '@/components/layout/DevServerPanel';
-import { useWorkspaceVcs, useVcsStore } from '@/stores/vcs';
+import { useVcsStore } from '@/stores/vcs';
 import type { Bookmark } from '@sero-ai/common';
+
+const EMPTY_BOOKMARKS: Bookmark[] = [];
 
 /**
  * StatusBar, bottom bar showing workspace info (à la VSCode).
@@ -15,11 +16,20 @@ import type { Bookmark } from '@sero-ai/common';
  * Right side: debug toggle, active agent count, zoom, version, theme.
  */
 export function StatusBar() {
-  const theme = useAppStore((s) => s.theme);
   const themeMode = useThemeStore((s) => s.mode);
   const toggleMode = useThemeStore((s) => s.toggleMode);
   const activeWorkspace = useActiveWorkspace();
-  const vcsState = useWorkspaceVcs(activeWorkspace?.id ?? null);
+  const activeWorkspaceId = activeWorkspace?.id ?? null;
+  const activePushBookmark = useVcsStore((state) => (
+    activeWorkspaceId
+      ? (state.byWorkspace[activeWorkspaceId]?.activePushBookmark ?? null)
+      : null
+  ));
+  const bookmarks = useVcsStore((state) => (
+    activeWorkspaceId
+      ? (state.byWorkspace[activeWorkspaceId]?.bookmarks ?? EMPTY_BOOKMARKS)
+      : EMPTY_BOOKMARKS
+  ));
 
   return (
     <footer className="chrome-zoom-invariant flex h-6 shrink-0 items-center justify-between border-t border-[var(--border-default)] bg-[var(--bg-base)] px-3 text-xs text-[var(--text-muted)]">
@@ -47,9 +57,9 @@ export function StatusBar() {
         <DebugLogToggle />
         <DevServerIndicator />
         <ActivePushBranchPicker
-          workspaceId={activeWorkspace?.id ?? null}
-          activePushBookmark={vcsState?.activePushBookmark ?? null}
-          bookmarks={vcsState?.bookmarks ?? []}
+          workspaceId={activeWorkspaceId}
+          activePushBookmark={activePushBookmark}
+          bookmarks={bookmarks}
         />
         <ZoomControl />
         <span>Sero v0.1.0</span>

--- a/apps/desktop/src/components/layout/shell/TitleBar.tsx
+++ b/apps/desktop/src/components/layout/shell/TitleBar.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@sero-ai/ui/components/ui/tooltip';
 import { PanelLeft, PanelRight } from 'lucide-react';
@@ -29,7 +30,7 @@ const MACOS_TRAFFIC_LIGHT_WIDTH = 78;
 /** Width of the native Windows overlay buttons (3 × 46px). */
 const WINDOWS_OVERLAY_WIDTH = 138;
 
-export function TitleBar() {
+export const TitleBar = memo(function TitleBar() {
   const toggleSidebar = useAppStore((s) => s.toggleMainSidebar);
   const toggleChat = useAppStore((s) => s.toggleChatPanel);
   const platform = window.sero.platform;
@@ -120,4 +121,4 @@ export function TitleBar() {
       {platform === 'linux' && <WindowControls />}
     </header>
   );
-}
+});

--- a/apps/desktop/src/components/layout/theme/ThemeEditorSheet.tsx
+++ b/apps/desktop/src/components/layout/theme/ThemeEditorSheet.tsx
@@ -100,13 +100,13 @@ export function ThemeEditorSheet({
         {draft && (
           <>
             <ThemeEditorDetailsSection
-              draft={draft}
+              name={draft.name}
+              description={draft.description}
               onNameChange={handleDraftNameChange}
               onDescriptionChange={handleDraftDescriptionChange}
             />
             <ThemeEditorTabs
               currentColors={currentColors}
-              draft={draft}
               effectiveMode={effectiveMode}
               mode={mode}
               onColorChange={handleColorChange}
@@ -115,7 +115,10 @@ export function ThemeEditorSheet({
               onSpacingChange={handleSpacingChange}
               onTabChange={setTab}
               onTypographyChange={handleTypographyChange}
+              radius={draft.radius}
+              spacing={draft.spacing}
               tab={tab}
+              typography={draft.typography}
             />
             <ThemeEditorFooter
               canReset={Boolean(activeEditPresetId && activeEditPresetId !== '__new__')}

--- a/apps/desktop/src/components/layout/theme/theme-editor/ThemeEditorDetailsSection.tsx
+++ b/apps/desktop/src/components/layout/theme/theme-editor/ThemeEditorDetailsSection.tsx
@@ -1,13 +1,15 @@
-import type { ThemeEditorDraft } from './types';
+import { memo } from 'react';
 
 interface ThemeEditorDetailsSectionProps {
-  draft: ThemeEditorDraft;
+  description: string;
+  name: string;
   onDescriptionChange: (value: string) => void;
   onNameChange: (value: string) => void;
 }
 
-export function ThemeEditorDetailsSection({
-  draft,
+export const ThemeEditorDetailsSection = memo(function ThemeEditorDetailsSection({
+  description,
+  name,
   onDescriptionChange,
   onNameChange,
 }: ThemeEditorDetailsSectionProps) {
@@ -15,18 +17,18 @@ export function ThemeEditorDetailsSection({
     <div className="shrink-0 flex flex-col gap-2 border-b border-[var(--border-subtle)] px-4 py-3">
       <input aria-label="Theme name"
         type="text"
-        value={draft.name}
+        value={name}
         onChange={(event) => onNameChange(event.target.value)}
         placeholder="Theme name..."
         className="rounded border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-2 py-1.5 text-base font-medium text-[var(--text-primary)] outline-none focus:border-[var(--border-focus)]"
       />
       <input aria-label="Theme description"
         type="text"
-        value={draft.description}
+        value={description}
         onChange={(event) => onDescriptionChange(event.target.value)}
         placeholder="Description (optional)"
         className="rounded border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-2 py-1.5 text-xs text-[var(--text-secondary)] outline-none focus:border-[var(--border-focus)]"
       />
     </div>
   );
-}
+});

--- a/apps/desktop/src/components/layout/theme/theme-editor/ThemeEditorFooter.tsx
+++ b/apps/desktop/src/components/layout/theme/theme-editor/ThemeEditorFooter.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Checkbox } from '@sero-ai/ui/components/ui/checkbox';
 
@@ -11,7 +12,7 @@ interface ThemeEditorFooterProps {
   onSave: () => Promise<void>;
 }
 
-export function ThemeEditorFooter({
+export const ThemeEditorFooter = memo(function ThemeEditorFooter({
   autoSave,
   canReset,
   canSave,
@@ -54,4 +55,4 @@ export function ThemeEditorFooter({
       </div>
     </div>
   );
-}
+});

--- a/apps/desktop/src/components/layout/theme/theme-editor/ThemeEditorTabs.tsx
+++ b/apps/desktop/src/components/layout/theme/theme-editor/ThemeEditorTabs.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type {
   RadiusTokens,
   SpacingTokens,
@@ -13,7 +14,6 @@ import { ModeToggle } from '../theme-panel/ModeToggle';
 
 interface ThemeEditorTabsProps {
   currentColors: ThemeEditorDraft['colors']['light'];
-  draft: ThemeEditorDraft;
   effectiveMode: 'light' | 'dark';
   mode: ThemeMode;
   onColorChange: (key: string, value: string) => void;
@@ -22,12 +22,14 @@ interface ThemeEditorTabsProps {
   onSpacingChange: (key: keyof SpacingTokens, value: string) => void;
   onTabChange: (tab: EditorTab) => void;
   onTypographyChange: (key: keyof TypographyTokens, value: string) => void;
+  radius: Required<RadiusTokens>;
+  spacing: Required<SpacingTokens>;
   tab: EditorTab;
+  typography: Required<TypographyTokens>;
 }
 
-export function ThemeEditorTabs({
+export const ThemeEditorTabs = memo(function ThemeEditorTabs({
   currentColors,
-  draft,
   effectiveMode,
   mode,
   onColorChange,
@@ -36,7 +38,10 @@ export function ThemeEditorTabs({
   onSpacingChange,
   onTabChange,
   onTypographyChange,
+  radius,
+  spacing,
   tab,
+  typography,
 }: ThemeEditorTabsProps) {
   return (
     <>
@@ -71,14 +76,14 @@ export function ThemeEditorTabs({
         )}
         {tab === 'typography' && (
           <TypographyTab
-            typography={draft.typography}
+            typography={typography}
             onChange={onTypographyChange}
           />
         )}
         {tab === 'layout' && (
           <LayoutTab
-            spacing={draft.spacing}
-            radius={draft.radius}
+            spacing={spacing}
+            radius={radius}
             onSpacingChange={onSpacingChange}
             onRadiusChange={onRadiusChange}
           />
@@ -86,4 +91,4 @@ export function ThemeEditorTabs({
       </div>
     </>
   );
-}
+});

--- a/apps/desktop/src/components/layout/theme/theme-editor/useThemeEditorState.ts
+++ b/apps/desktop/src/components/layout/theme/theme-editor/useThemeEditorState.ts
@@ -148,19 +148,16 @@ export function useThemeEditorState({
 
   const updateDraft = useCallback(
     (updater: (previous: ThemeEditorDraft) => ThemeEditorDraft) => {
-      setDraft((previous) => {
-        if (!previous) {
-          return previous;
-        }
+      const previous = draftRef.current;
+      if (!previous) return;
 
-        const next = updater(previous);
-        draftRef.current = next;
-        applyDraftPreview(next, effectiveMode);
-        if (autoSave) {
-          scheduleAutoSave(next);
-        }
-        return next;
-      });
+      const next = updater(previous);
+      draftRef.current = next;
+      applyDraftPreview(next, effectiveMode);
+      if (autoSave) {
+        scheduleAutoSave(next);
+      }
+      setDraft(next);
     },
     [autoSave, effectiveMode, scheduleAutoSave],
   );
@@ -173,33 +170,27 @@ export function useThemeEditorState({
   }, []);
 
   const handleDraftNameChange = useCallback((value: string) => {
-    setDraft((previous) => {
-      if (!previous) {
-        return previous;
-      }
+    const previous = draftRef.current;
+    if (!previous) return;
 
-      const next = { ...previous, name: value };
-      draftRef.current = next;
-      if (autoSave) {
-        scheduleAutoSave(next);
-      }
-      return next;
-    });
+    const next = { ...previous, name: value };
+    draftRef.current = next;
+    if (autoSave) {
+      scheduleAutoSave(next);
+    }
+    setDraft(next);
   }, [autoSave, scheduleAutoSave]);
 
   const handleDraftDescriptionChange = useCallback((value: string) => {
-    setDraft((previous) => {
-      if (!previous) {
-        return previous;
-      }
+    const previous = draftRef.current;
+    if (!previous) return;
 
-      const next = { ...previous, description: value };
-      draftRef.current = next;
-      if (autoSave) {
-        scheduleAutoSave(next);
-      }
-      return next;
-    });
+    const next = { ...previous, description: value };
+    draftRef.current = next;
+    if (autoSave) {
+      scheduleAutoSave(next);
+    }
+    setDraft(next);
   }, [autoSave, scheduleAutoSave]);
 
   const handleColorChange = useCallback(
@@ -249,15 +240,16 @@ export function useThemeEditorState({
   );
 
   const handleSave = useCallback(async () => {
-    if (!draft || !draft.name.trim()) {
+    const latestDraft = draftRef.current;
+    if (!latestDraft || !latestDraft.name.trim()) {
       return;
     }
 
-    await flushAutoSave(draft);
+    await flushAutoSave(latestDraft);
     draftRef.current = null;
     setDraft(null);
     onOpenChange(false);
-  }, [draft, flushAutoSave, onOpenChange]);
+  }, [flushAutoSave, onOpenChange]);
 
   const handleReset = useCallback(async () => {
     if (!editPresetId || editPresetId === '__new__') {

--- a/apps/desktop/src/components/layout/titlebar/TitleBarBreadcrumb.tsx
+++ b/apps/desktop/src/components/layout/titlebar/TitleBarBreadcrumb.tsx
@@ -3,7 +3,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@sero-ai/ui/components/
 import { Star } from 'lucide-react';
 import { useAppStore } from '@/stores/app';
 import { MAX_CHROME_SHORTCUTS, isChromeShortcutsFull } from '@/stores/app/shared';
-import { useActiveWorkspace } from '@/stores/workspace';
+import { useWorkspaceStore } from '@/stores/workspace';
 import { getAppIcon } from '@/lib/app-icons';
 
 /** Active app · workspace breadcrumb with a star to pin the app as a shortcut. */
@@ -13,7 +13,9 @@ export function TitleBarBreadcrumb() {
   const pinned = useAppStore((s) => s.isChromeShortcut(s.activeApp));
   const atCap = useAppStore((s) => isChromeShortcutsFull(s.chromeShortcuts, s.apps));
   const toggleChromeShortcut = useAppStore((s) => s.toggleChromeShortcut);
-  const activeWorkspace = useActiveWorkspace();
+  const activeWorkspaceName = useWorkspaceStore(
+    (state) => state.workspaces.find((workspace) => workspace.id === state.activeWorkspaceId)?.name,
+  );
 
   const entry = apps.find((app) => app.id === activeApp);
   const Icon = getAppIcon(entry?.icon);
@@ -29,8 +31,8 @@ export function TitleBarBreadcrumb() {
       <Icon className="size-3.5 shrink-0 text-[var(--brand-primary)]" />
       <span className="truncate text-sm font-medium text-[var(--text-secondary)]" style={{ maxWidth: '30vw' }}>
         {appLabel}
-        {activeWorkspace?.name && (
-          <span className="text-[var(--text-muted)]"> · {activeWorkspace.name}</span>
+        {activeWorkspaceName && (
+          <span className="text-[var(--text-muted)]"> · {activeWorkspaceName}</span>
         )}
       </span>
       <Tooltip>

--- a/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx
+++ b/apps/desktop/src/components/layout/titlebar/git/GitRemotePublishSection.tsx
@@ -46,7 +46,7 @@ export function GitRemotePublishSection({
     })),
   );
   const [mode, setMode] = useState<'github' | 'existing'>('github');
-  const [name, setName] = useState(defaultRepoName(workspaceName, workspaceId));
+  const [name, setName] = useState(() => defaultRepoName(workspaceName, workspaceId));
   const [visibility, setVisibility] = useState<'public' | 'private'>('private');
   const [remoteUrl, setRemoteUrl] = useState('');
   const [action, setAction] = useState<'github' | 'existing' | null>(null);

--- a/apps/desktop/src/components/layout/titlebar/git/GitTitleBarControls.tsx
+++ b/apps/desktop/src/components/layout/titlebar/git/GitTitleBarControls.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui/components/ui/popover';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { ChevronDown, Sparkles } from 'lucide-react';
 
 import { useAppStore } from '@/stores/app';
-import { useActiveWorkspace } from '@/stores/workspace';
+import { useWorkspaceStore } from '@/stores/workspace';
 import { GitShipPanel } from './GitShipPanel';
 import {
   EMPTY_GIT_TITLE_STATE,
@@ -15,15 +16,21 @@ import {
 
 export function GitTitleBarControls() {
   const activeApp = useAppStore((state) => state.activeApp);
-  const workspace = useActiveWorkspace();
+  const workspace = useWorkspaceStore(
+    useShallow((state) => {
+      const active = state.workspaces.find((entry) => entry.id === state.activeWorkspaceId);
+      return active ? { id: active.id, name: active.name, path: active.path } : null;
+    }),
+  );
   const [open, setOpen] = useState(false);
   const [gitState, setGitState] = useState(EMPTY_GIT_TITLE_STATE);
 
-  const shouldRender = activeApp === 'git' && Boolean(workspace?.path);
-  const stateFilePath = shouldRender && workspace ? getGitStateFilePath(workspace.path) : null;
+  const workspacePath = workspace?.path ?? '';
+  const shouldRender = activeApp === 'git' && Boolean(workspacePath);
+  const stateFilePath = shouldRender ? getGitStateFilePath(workspacePath) : null;
 
   useEffect(() => {
-    if (!shouldRender || !workspace || !stateFilePath) {
+    if (!shouldRender || !stateFilePath) {
       setOpen(false);
       setGitState(EMPTY_GIT_TITLE_STATE);
       return;
@@ -32,18 +39,18 @@ export function GitTitleBarControls() {
     let active = true;
     setGitState({
       ...EMPTY_GIT_TITLE_STATE,
-      repoPath: workspace.path,
+      repoPath: workspacePath,
       loading: true,
     });
 
     const unsubscribe = window.sero.appState.onChange((filePath: string, data: unknown) => {
       if (!active || filePath !== stateFilePath || data == null) return;
-      setGitState(normalizeGitTitleState(data, workspace.path));
+      setGitState(normalizeGitTitleState(data, workspacePath));
     });
 
     void window.sero.appState.watch(stateFilePath).then((current: unknown) => {
       if (!active || current == null) return;
-      setGitState(normalizeGitTitleState(current, workspace.path));
+      setGitState(normalizeGitTitleState(current, workspacePath));
     });
 
     return () => {
@@ -51,7 +58,7 @@ export function GitTitleBarControls() {
       unsubscribe();
       void window.sero.appState.unwatch(stateFilePath);
     };
-  }, [shouldRender, stateFilePath, workspace]);
+  }, [shouldRender, stateFilePath, workspacePath]);
 
   useEffect(() => {
     setOpen(false);
@@ -71,7 +78,7 @@ export function GitTitleBarControls() {
   );
   const aheadCount = currentBranch?.ahead ?? 0;
   const behindCount = currentBranch?.behind ?? 0;
-  const isCurrentWorkspace = workspace ? gitState.repoPath === workspace.path : false;
+  const isCurrentWorkspace = workspace ? gitState.repoPath === workspacePath : false;
   const disabled = !workspace || !isCurrentWorkspace || gitState.error === 'Not a git repository';
 
   if (!shouldRender || !workspace) {

--- a/apps/desktop/src/components/layout/workspace/SessionNode.tsx
+++ b/apps/desktop/src/components/layout/workspace/SessionNode.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Check, Loader2, Pencil, Trash2 } from 'lucide-react';
 import { useSessionStore } from '@/stores/sessions';
-import { useStreamingSessionIds } from '@/stores/agent-selectors';
+import { useAgentStore } from '@/stores/agent';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import {
   Popover,
@@ -27,11 +27,13 @@ export function SessionNode({
   const [renameValue, setRenameValue] = useState('');
   const renameInputRef = useRef<HTMLInputElement>(null);
 
-  const activeSessionId = useSessionStore((s) => s.activeSessionId);
+  const isActive = useSessionStore((state) => state.activeSessionId === session.id);
   const setActiveSession = useSessionStore((s) => s.setActiveSession);
   const deleteSession = useSessionStore((s) => s.deleteSession);
   const renameSession = useSessionStore((s) => s.renameSession);
-  const streamingIds = useStreamingSessionIds();
+  const isStreaming = useAgentStore(
+    (state) => state.agents[session.id]?.isStreaming ?? false,
+  );
 
   // Multi-select
   const isSelected = useSessionStore((s) => s.selectedSessionIds.has(session.id));
@@ -39,9 +41,6 @@ export function SessionNode({
   const toggleSelectSession = useSessionStore((s) => s.toggleSelectSession);
   const selectSessionRange = useSessionStore((s) => s.selectSessionRange);
   const clearSelection = useSessionStore((s) => s.clearSelection);
-
-  const isActive = activeSessionId === session.id;
-  const isStreaming = streamingIds.includes(session.id);
 
   const title = session.name || session.firstMessage || 'New chat';
   const modified = formatRelativeDate(session.modified);

--- a/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
+++ b/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import {
   ChevronDown,
   ChevronRight,
@@ -58,22 +58,27 @@ interface WorkspaceNodeProps {
   sessions: SeroSessionInfo[];
 }
 
-export function WorkspaceNode({ workspace, sessions }: WorkspaceNodeProps) {
+export const WorkspaceNode = memo(function WorkspaceNode({ workspace, sessions }: WorkspaceNodeProps) {
   const [remoteManagerOpen, setRemoteManagerOpen] = useState(false);
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
   const toggleCollapsed = useWorkspaceStore((state) => state.toggleCollapsed);
-  const activeWorkspaceId = useWorkspaceStore((state) => state.activeWorkspaceId);
+  const isActive = useWorkspaceStore(
+    (state) => state.activeWorkspaceId === workspace.id,
+  );
   const setActiveWorkspace = useWorkspaceStore((state) => state.setActiveWorkspace);
   const closeWorkspace = useWorkspaceStore((state) => state.closeWorkspace);
   const createSession = useSessionStore((state) => state.createSession);
   const deleteSelectedSessions = useSessionStore((state) => state.deleteSelectedSessions);
   const clearSelection = useSessionStore((state) => state.clearSelection);
-  const selectedSessionIds = useSessionStore((state) => state.selectedSessionIds);
+  const selectedInWorkspace = useSessionStore((state) => (
+    sessions.reduce(
+      (count, session) => count + (state.selectedSessionIds.has(session.id) ? 1 : 0),
+      0,
+    )
+  ));
 
-  const selectedInWorkspace = sessions.filter((session) => selectedSessionIds.has(session.id)).length;
   const mountCount = workspace.references.length + workspace.mounts.length;
   const expanded = workspace.open;
-  const isActive = activeWorkspaceId === workspace.id;
   const isDefault = workspace.id === 'global';
 
   const handleHeaderClick = () => {
@@ -288,4 +293,4 @@ export function WorkspaceNode({ workspace, sessions }: WorkspaceNodeProps) {
       />
     </div>
   );
-}
+});

--- a/apps/desktop/src/stores/agent-selectors.test.tsx
+++ b/apps/desktop/src/stores/agent-selectors.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { useAgentStore } from './agent';
+import { useFocusedWorkspaceId } from './agent-selectors';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const initialState = useAgentStore.getState();
+
+function WorkspaceProbe({ onRender }: { onRender: () => void }) {
+  const workspaceId = useFocusedWorkspaceId();
+  onRender();
+  return <span>{workspaceId}</span>;
+}
+
+describe('agent selectors', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    useAgentStore.setState({
+      ...initialState,
+      focusedSessionId: 'session-1',
+      agents: {
+        'session-1': {
+          sessionId: 'session-1',
+          sessionPath: '/tmp/session-1.jsonl',
+          workspaceId: 'workspace-1',
+          messages: [],
+          isStreaming: false,
+          error: null,
+          commands: [],
+          modelState: null,
+        },
+      },
+    }, true);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    useAgentStore.setState(initialState, true);
+  });
+
+  it('does not re-render workspace consumers for streaming-only agent updates', async () => {
+    let renderCount = 0;
+
+    await act(async () => {
+      root.render(<WorkspaceProbe onRender={() => { renderCount += 1; }} />);
+    });
+
+    expect(container.textContent).toBe('workspace-1');
+    expect(renderCount).toBe(1);
+
+    await act(async () => {
+      useAgentStore.setState((state) => ({
+        agents: {
+          ...state.agents,
+          'session-1': {
+            ...state.agents['session-1']!,
+            isStreaming: true,
+            messages: [{
+              id: 'assistant-1',
+              type: 'assistant',
+              text: 'Hello',
+              isStreaming: true,
+            }],
+          },
+        },
+      }));
+    });
+
+    expect(renderCount).toBe(1);
+  });
+});

--- a/apps/desktop/src/stores/agent-selectors.ts
+++ b/apps/desktop/src/stores/agent-selectors.ts
@@ -81,6 +81,13 @@ export function useFocusedSessionId(): string | null {
   return useAgentStore((s) => s.focusedSessionId);
 }
 
+export function useFocusedWorkspaceId(): string | null {
+  return useAgentStore((s) => {
+    const focusedId = s.focusedSessionId;
+    return focusedId ? (s.agents[focusedId]?.workspaceId ?? null) : null;
+  });
+}
+
 export function useFocusedModelState(): SessionModelState | null {
   return useAgentStore((s) => {
     const focusedId = s.focusedSessionId;

--- a/apps/desktop/src/stores/workspace-selectors.test.tsx
+++ b/apps/desktop/src/stores/workspace-selectors.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import type { WorkspaceInfo } from '@/types/ipc';
+import { useActiveWorkspace, useWorkspaceStore } from './workspace';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean })
+  .IS_REACT_ACT_ENVIRONMENT = true;
+
+const initialState = useWorkspaceStore.getState();
+
+function createWorkspace(id: string): WorkspaceInfo {
+  return {
+    id,
+    name: id,
+    path: `/workspaces/${id}`,
+    open: true,
+    runtime: { backend: 'host' },
+    container: false,
+    references: [],
+    mounts: [],
+    roots: [],
+  };
+}
+
+function ActiveWorkspaceProbe({ onRender }: { onRender: () => void }) {
+  const activeWorkspace = useActiveWorkspace();
+  onRender();
+  return <span>{activeWorkspace?.name}</span>;
+}
+
+describe('workspace selectors', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    useWorkspaceStore.setState({
+      ...initialState,
+      workspaces: [createWorkspace('active'), createWorkspace('other')],
+      activeWorkspaceId: 'active',
+    }, true);
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    useWorkspaceStore.setState(initialState, true);
+  });
+
+  it('does not re-render active-workspace consumers when another workspace changes', async () => {
+    let renderCount = 0;
+    await act(async () => {
+      root.render(<ActiveWorkspaceProbe onRender={() => { renderCount += 1; }} />);
+    });
+
+    await act(async () => {
+      useWorkspaceStore.setState((state) => ({
+        workspaces: state.workspaces.map((entry) => (
+          entry.id === 'other' ? { ...entry, open: false } : entry
+        )),
+      }));
+    });
+
+    expect(container.textContent).toBe('active');
+    expect(renderCount).toBe(1);
+  });
+});

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -301,7 +301,7 @@ export function useOpenWorkspaces(): WorkspaceInfo[] {
 
 /** The currently active/focused workspace. */
 export function useActiveWorkspace(): WorkspaceInfo | null {
-  const workspaces = useWorkspaceStore((s) => s.workspaces);
-  const activeId = useWorkspaceStore((s) => s.activeWorkspaceId);
-  return workspaces.find((w) => w.id === activeId) ?? null;
+  return useWorkspaceStore(
+    (state) => state.workspaces.find((workspace) => workspace.id === state.activeWorkspaceId) ?? null,
+  );
 }

--- a/docs/plans/react-render-performance-audit.md
+++ b/docs/plans/react-render-performance-audit.md
@@ -1,0 +1,208 @@
+# React rendering performance audit
+
+This ledger tracks the section-by-section audit of React rendering performance in
+`apps/desktop` and `plugins`. React Doctor findings are candidates until the
+surrounding render path confirms that they can affect renderer responsiveness.
+
+## Method
+
+For each section:
+
+1. Inventory subscriptions, timers, IPC/file-watch updates, derived data, and large lists.
+2. Run a path-scoped React Doctor performance scan and targeted source searches.
+3. Classify candidates as confirmed, false positive, deferred, or low-value.
+4. Profile frequently updating or ambiguous surfaces when static evidence is insufficient.
+5. Apply the smallest behavior-preserving fix and run focused tests, typecheck, and a changed-scope scan.
+
+General JavaScript micro-optimizations, backend-only findings, bundle-size findings,
+and animation preferences are excluded unless they have a credible effect on render
+frequency, layout, or paint cost.
+
+## Progress
+
+| Section | Status | Evidence and outcome |
+| --- | --- | --- |
+| Desktop foundations: entry points, stores, selectors, shared app runtime | Complete | Provider values and federated mount context are referentially stable. Added a focused workspace selector for identity-only consumers. |
+| Desktop chat and collaboration | Complete | Removed two whole-agent subscriptions from controls that do not consume streaming messages. Existing message/tool memo boundaries are appropriate; remaining feed lists are small. |
+| Desktop explorer: file tree and editor | Complete | File watches are scoped and editor/Monaco updates stay behind imperative or workspace-specific boundaries. No high-value change identified. |
+| Desktop explorer: browser and terminal | Complete | Browser state is workspace-scoped and xterm output is imperative. Replaced handler-only screenshot drag state with a ref. |
+| Desktop explorer: VCS and orchestration | Complete | Narrowed whole-store/workspace subscriptions, restored effective list memo boundaries, and isolated workspace-specific subagent updates. |
+| Desktop dashboard and federated apps | Complete | Memoized stable app-mount and shell boundaries; dashboard subscriptions were already appropriately scoped. |
+| Desktop shell, workspace, and titlebar | Complete | Isolated workspace rows, narrowed breadcrumb and Git-control subscriptions, and prevented watcher restarts on unrelated workspace changes. |
+| Desktop models, themes, auth, profiles, and diagnostics | Complete | Isolated theme-editor sections and diagnostic result lists. Remaining candidates were low-frequency, animation-specific, or would not remove a render. |
+| Plugin: Git | Complete | Heavy top-level sections no longer redraw for transient notices and unrelated local diff state. |
+| Plugin: Orchestrator | Complete | Stabilized navigation/actions and isolated loop-list and plan rendering from live detail state. |
+| Plugin: MCP | Complete | Search and server-manager boundaries ignore unrelated bootstrap, diagnostics, and config state. |
+| Plugin: Cron | Complete | Removed handler-only state and effect-driven schedule validation. |
+| Plugin: Usage | Complete | Compact widget ignores invisible refresh status; chart/table/stat boundaries are memoized. |
+| Plugin: Admin | Complete | Resource lists are isolated from editor keystrokes and plugin-development callbacks are stable. |
+| Plugin: Web | Complete | Removed duplicate file-state subscriptions and isolated bookmark form/list work. |
+| Plugin: User Feedback | Complete | Interview answer edits now redraw only the changed question row. |
+| Plugin: Graphify | Complete | Search state is colocated so workspace rows do not redraw while typing/searching. |
+| Plugin: Memory | Not applicable | No React UI source; runtime-only plugin. |
+
+## Baseline
+
+- Desktop renderer: 218 React source/test files; 207 are under `src/components`.
+- Desktop feature concentration: 125 React files under layout and 58 under apps,
+  including 48 in explorer.
+- Plugin renderers range from 1 to 33 React files and are audited independently.
+- React Compiler is not configured, so subscription boundaries and referential
+  stability remain explicit application concerns.
+- The initial broad desktop React Doctor performance scan reported 140 candidates
+  (33 errors and 107 warnings). It also scanned Electron/backend code, confirming
+  that path and render-path filtering are required.
+
+## Findings
+
+### RR-001: Identity-only chat controls subscribed to the full agent
+
+- **Trigger:** every streamed assistant token replaces the focused `AgentInstance`.
+- **Impact:** `ThinkingBlocksToggle` and `CollaborationActivityPanel` re-rendered even
+  though neither consumes message content. The collaboration subtree includes motion
+  elements and a derived activity feed.
+- **Disposition:** confirmed, high confidence.
+- **Change:** `ThinkingBlocksToggle` now uses the existing model-state selector;
+  collaboration uses scalar session and workspace selectors.
+- **Validation:** added a selector isolation regression test proving streaming-only
+  agent updates do not re-render workspace consumers. Desktop typecheck and all 1,692
+  desktop tests pass. The changed-scope React Doctor score is 91/100; its remaining
+  findings in touched files are pre-existing accessibility, bundle, and array-loop
+  candidates unrelated to this change.
+
+### RR-002: VCS forms and details subscribed to every VCS update
+
+- **Trigger:** watcher refreshes replace per-workspace log, status, bookmark, remote,
+  loading, and diff state.
+- **Impact:** branch/remote forms and expanded change details redrew for unrelated
+  workspace VCS changes; the status bar also subscribed to the full workspace VCS object.
+- **Disposition:** confirmed, high confidence.
+- **Change:** replaced whole-store subscriptions with stable action selectors and scalar
+  field selectors. The status bar now subscribes only to bookmarks and the active push branch.
+- **Validation:** focused VCS tests and desktop typecheck pass.
+
+### RR-003: VCS list memo boundaries were missing or defeated
+
+- **Trigger:** local form typing, expansion changes, notices, and other parent state updates.
+- **Impact:** commit, branch, and working-copy rows reconciled even when their data was unchanged.
+- **Disposition:** confirmed, high confidence.
+- **Change:** passed a stable commit-toggle callback, memoized branch rows with keyed action
+  callbacks, and isolated the working-copy file list behind a memo boundary.
+- **Validation:** focused VCS tests pass; touched source files remain below 500 lines.
+
+### RR-004: Workspace and session rows subscribed to shared identifiers
+
+- **Trigger:** another workspace expanded, active workspace/session changed, session
+  streaming changed, or another workspace's selection changed.
+- **Impact:** unchanged shell consumers and all workspace/session rows could redraw.
+- **Disposition:** confirmed, high confidence.
+- **Change:** the active-workspace hook now selects the resolved object directly;
+  workspace/session rows select per-row booleans/counts and workspace nodes are memoized.
+- **Validation:** selector regression tests prove unrelated workspace and streaming updates
+  do not redraw unchanged consumers; desktop typecheck passes.
+
+### RR-005: Screenshot drag lifecycle used render state only as an event guard
+
+- **Trigger:** pointer down/up while selecting a screenshot region.
+- **Impact:** two reconciliations per drag with no visual dependency on the boolean.
+- **Disposition:** confirmed, high confidence using the canonical React Doctor rule prompt.
+- **Change:** moved the drag guard to a ref; the visible rectangle remains state-driven.
+
+### RR-006: Orchestration updates redrew unrelated cards and workspaces
+
+- **Trigger:** live subagent entry/output updates and one-second elapsed timers.
+- **Impact:** the panel filtered the global entry record and non-updated cards lacked a memo boundary.
+- **Disposition:** confirmed, high confidence.
+- **Change:** workspace-filtered shallow selectors now ignore other workspaces, and subagent
+  cards are memoized so stable entries do not redraw when a sibling changes.
+- **Validation:** focused desktop tests, typecheck, and `git diff --check` pass.
+
+### RR-007: Plugin roots coupled unrelated local and file-backed updates
+
+- **Trigger:** notices, bootstrap completion, diagnostics/config refreshes, selected-loop
+  live updates, search state, and refresh status.
+- **Impact:** stable commit graphs, branch/staging panels, MCP server management, loop
+  sidebars/plans, and Usage analytics could redraw without relevant prop changes.
+- **Disposition:** confirmed across Git, Orchestrator, MCP, and Usage; high confidence.
+- **Change:** added stable callbacks and memo boundaries at existing independent UI sections;
+  the Usage widget can opt out of refresh status it never displays.
+- **Validation:** regression tests assert Git commit-graph and MCP server-manager isolation.
+  All four plugin typechecks and 889 plugin tests pass.
+
+### RR-008: Plugin form state redrew adjacent lists
+
+- **Trigger:** editor keystrokes, bookmark/search input, and interview answer changes.
+- **Impact:** Admin resource lists, Web bookmarks, Graphify workspace rows, and every
+  interview question row reconciled for changes local to one form or row.
+- **Disposition:** confirmed across Admin, Web, Graphify, and User Feedback; high confidence.
+- **Change:** colocated local form/search state, memoized stable list/row boundaries, and
+  lifted Web file-backed state to the existing root subscription.
+- **Validation:** affected plugin typechecks and tests pass; User Feedback and Graphify
+  changed-scope React Doctor scans are clean.
+
+### RR-009: Cron validation used state synchronized by an effect
+
+- **Trigger:** every recurring schedule edit.
+- **Impact:** schedule validation caused a second render after the input render; the
+  constant notification channel was also held in state despite never changing.
+- **Disposition:** confirmed, high confidence.
+- **Change:** cron validation is derived during render and the constant channel is written
+  directly into the saved reminder.
+- **Validation:** Cron typecheck and all 231 tests pass.
+
+### RR-010: Stable shell and app subtrees lacked memo boundaries
+
+- **Trigger:** shell layout changes, app registry updates, and parent reconciliation while
+  the mounted app, sidebar, or title bar inputs were unchanged.
+- **Impact:** independent shell and federated-app subtrees could reconcile despite owning
+  their own scoped subscriptions.
+- **Disposition:** confirmed, medium confidence.
+- **Change:** memoized the active app panel, federated app mount, main sidebar, and title bar.
+  The dashboard itself already used appropriately scoped state.
+- **Validation:** focused shell/app tests and desktop typecheck pass.
+
+### RR-011: Git title-bar watchers depended on the whole workspace object
+
+- **Trigger:** any immutable update to the active workspace object.
+- **Impact:** repository-name and remote-status watchers could be torn down and restarted
+  even when the workspace path was unchanged; breadcrumb consumers also received unrelated
+  workspace fields.
+- **Disposition:** confirmed, high confidence.
+- **Change:** selected only workspace id, name, and path primitives and keyed watcher effects
+  to the path. Breadcrumbs now select only the displayed workspace name.
+- **Validation:** focused title-bar tests and desktop typecheck pass.
+
+### RR-012: Theme and diagnostic parent updates crossed stable section boundaries
+
+- **Trigger:** editing one theme token group, theme metadata changes, autosave state, or
+  diagnostic progress updates.
+- **Impact:** unrelated theme editor sections and an unchanged diagnostic result list could
+  reconcile with their parent.
+- **Disposition:** confirmed, medium confidence.
+- **Change:** split theme editor props into stable token groups, memoized its independent
+  sections, stabilized save/copy callbacks, and memoized diagnostic categories. Preview and
+  autosave side effects were also moved out of React state updater callbacks.
+- **Validation:** 12 focused theme/diagnostic tests, desktop typecheck, and the assigned
+  changed-scope React Doctor scan pass.
+
+## Deferred and excluded candidates
+
+- Framer Motion import and `height: 0` to `height: auto` diagnostics concern bundle policy
+  or intentional enter/exit animation, not an established avoidable render.
+- Generic chained-array and loop findings are JavaScript micro-optimizations without evidence
+  of meaningful renderer cost in these paths.
+- Handler-only state in auth/profile forms is batched with visible state changes, so replacing
+  it with refs would not remove a commit.
+- Large-component and reducer suggestions were not changed unless they exposed a concrete
+  subscription or reconciliation problem.
+
+## Final validation
+
+- Root `pnpm typecheck`: 22/22 tasks passed.
+- Root `pnpm test`: 15/15 tasks passed. Desktop completed 322 files and 1,693 tests;
+  the affected plugin suites also passed in the root run.
+- React Doctor v0.7.8 changed-file Performance scan: 60 files scanned. The remaining
+  21 diagnostics are the documented animation, bundle-loading, and array-loop exclusions
+  above; Admin, Cron, Git, Graphify, MCP, User Feedback, and Web have zero remaining
+  changed-file Performance diagnostics.
+- `git diff --check` passes and every touched source file remains below 500 lines.

--- a/plugins/sero-admin-plugin/ui/AdminApp.tsx
+++ b/plugins/sero-admin-plugin/ui/AdminApp.tsx
@@ -55,6 +55,9 @@ export function AdminApp() {
   const refreshAgents = agentCrud.refresh;
   const refreshSkills = skillCrud.refresh;
   const refreshPrompts = promptCrud.refresh;
+  const selectAgent = agentCrud.select;
+  const selectSkill = skillCrud.select;
+  const selectPrompt = promptCrud.select;
 
   const profilePath = activeProfile?.path ?? null;
   const profileName = activeProfile?.name ?? null;
@@ -124,22 +127,22 @@ export function AdminApp() {
   }, [updateState]);
 
   const handleAgentSelect = useCallback(async (name: string) => {
-    await agentCrud.select(name);
+    await selectAgent(name);
     restoredAgentRef.current = name;
     updateState((prev) => ({ ...prev, lastAgent: name }));
-  }, [agentCrud, updateState]);
+  }, [selectAgent, updateState]);
 
   const handleSkillSelect = useCallback(async (filePath: string) => {
-    await skillCrud.select(filePath);
+    await selectSkill(filePath);
     restoredSkillRef.current = filePath;
     updateState((prev) => ({ ...prev, lastSkill: filePath }));
-  }, [skillCrud, updateState]);
+  }, [selectSkill, updateState]);
 
   const handlePromptSelect = useCallback(async (filePath: string) => {
-    await promptCrud.select(filePath);
+    await selectPrompt(filePath);
     restoredPromptRef.current = filePath;
     updateState((prev) => ({ ...prev, lastPrompt: filePath }));
-  }, [promptCrud, updateState]);
+  }, [selectPrompt, updateState]);
 
   const getSkillVisibility = useCallback((skillName: string) => {
     const row = skillVisibility.skills.find((skill) => skill.name === skillName);

--- a/plugins/sero-admin-plugin/ui/components/AgentList.tsx
+++ b/plugins/sero-admin-plugin/ui/components/AgentList.tsx
@@ -2,6 +2,7 @@
  * AgentList, scrollable list of agent cards in the left panel.
  */
 
+import { memo } from 'react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
 import type { AgentModelConfig, AgentSummary } from './types';
@@ -30,7 +31,7 @@ function modelShort(model?: AgentModelConfig): string {
   return value.replace(/^claude-/, '').replace(/^[^/]+\//, '');
 }
 
-export function AgentList({ agents, selected, onSelect }: AgentListProps) {
+export const AgentList = memo(function AgentList({ agents, selected, onSelect }: AgentListProps) {
   if (agents.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center p-4">
@@ -80,4 +81,4 @@ export function AgentList({ agents, selected, onSelect }: AgentListProps) {
       ))}
     </div>
   );
-}
+});

--- a/plugins/sero-admin-plugin/ui/components/PluginsPanel.tsx
+++ b/plugins/sero-admin-plugin/ui/components/PluginsPanel.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useAppInfo } from '@sero-ai/app-runtime';
 import { PluginSafetyDisclaimer } from '@sero-ai/ui/components/ui/plugin-safety-disclaimer';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
@@ -18,6 +18,7 @@ export const PluginsPanel = memo(function PluginsPanel() {
   const installed = usePlugins();
   const devSessions = usePluginDevSessions();
   const attached = useAttachedFolders(workspaceId);
+  const handleStartDevSession = useCallback(() => devSessions.startDevSession(), [devSessions.startDevSession]);
 
   const summary = [
     `${installed.plugins.length} installed`,
@@ -58,7 +59,7 @@ export const PluginsPanel = memo(function PluginsPanel() {
             starting={devSessions.starting}
             refreshingIds={devSessions.refreshingIds}
             stoppingIds={devSessions.stoppingIds}
-            onStart={() => devSessions.startDevSession()}
+            onStart={handleStartDevSession}
             onRefresh={devSessions.refreshDevSession}
             onStop={devSessions.stopDevSession}
             onReveal={devSessions.revealInFinder}

--- a/plugins/sero-admin-plugin/ui/components/PromptList.tsx
+++ b/plugins/sero-admin-plugin/ui/components/PromptList.tsx
@@ -4,6 +4,7 @@
  * Selection is keyed by filePath (unique across the prompts tree).
  */
 
+import { memo } from 'react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { PromptTemplateSummary } from './types';
 
@@ -15,7 +16,7 @@ interface PromptListProps {
   onSelect: (filePath: string) => void;
 }
 
-export function PromptList({ prompts, selected, onSelect }: PromptListProps) {
+export const PromptList = memo(function PromptList({ prompts, selected, onSelect }: PromptListProps) {
   if (prompts.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center p-4">
@@ -56,4 +57,4 @@ export function PromptList({ prompts, selected, onSelect }: PromptListProps) {
       ))}
     </div>
   );
-}
+});

--- a/plugins/sero-admin-plugin/ui/components/SkillList.tsx
+++ b/plugins/sero-admin-plugin/ui/components/SkillList.tsx
@@ -5,6 +5,7 @@
  * across nested skill directories).
  */
 
+import { memo } from 'react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { SkillSummary } from './types';
 
@@ -16,7 +17,7 @@ interface SkillListProps {
   onSelect: (filePath: string) => void;
 }
 
-export function SkillList({ skills, selected, onSelect }: SkillListProps) {
+export const SkillList = memo(function SkillList({ skills, selected, onSelect }: SkillListProps) {
   if (skills.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center justify-center p-4">
@@ -57,4 +58,4 @@ export function SkillList({ skills, selected, onSelect }: SkillListProps) {
       ))}
     </div>
   );
-}
+});

--- a/plugins/sero-cron-plugin/ui/components/ReminderForm.tsx
+++ b/plugins/sero-cron-plugin/ui/components/ReminderForm.tsx
@@ -15,7 +15,6 @@ import {
 import { cn } from '@sero-ai/ui/lib/utils';
 import { validateCron, cronToHuman } from '../../shared/cron';
 import { generateId } from '../../shared/reminder-utils';
-import { normalizeReminderChannel } from '../../shared/reminder-mutations';
 import type { Reminder, ReminderType } from '../../shared/types';
 
 interface ReminderFormProps {
@@ -45,12 +44,10 @@ export function ReminderForm({
 
   const [title, setTitle] = useState('');
   const [notes, setNotes] = useState('');
-  const [channel, setChannel] = useState<'notification'>('notification');
   const [type, setType] = useState<ReminderType>('once');
   const [fireAt, setFireAt] = useState('');
   const [schedule, setSchedule] = useState('');
   const [recoverIfMissed, setRecoverIfMissed] = useState(false);
-  const [scheduleError, setScheduleError] = useState<string | null>(null);
 
   // Reset form when opening
   useEffect(() => {
@@ -58,7 +55,6 @@ export function ReminderForm({
     if (editingReminder) {
       setTitle(editingReminder.title);
       setNotes(editingReminder.notes ?? '');
-      setChannel(normalizeReminderChannel(editingReminder.channel));
       setType(editingReminder.type);
       setFireAt(editingReminder.fireAt ? toLocalDatetime(editingReminder.fireAt) : '');
       setSchedule(editingReminder.schedule ?? '');
@@ -66,23 +62,16 @@ export function ReminderForm({
     } else {
       setTitle('');
       setNotes('');
-      setChannel('notification');
       setType('once');
       setFireAt(defaultFireAt());
       setSchedule('');
       setRecoverIfMissed(false);
     }
-    setScheduleError(null);
   }, [open, editingReminder]);
 
-  // Validate cron
-  useEffect(() => {
-    if (type !== 'recurring' || !schedule.trim()) {
-      setScheduleError(null);
-      return;
-    }
-    setScheduleError(validateCron(schedule.trim()));
-  }, [schedule, type]);
+  const scheduleError = type === 'recurring' && schedule.trim()
+    ? validateCron(schedule.trim())
+    : null;
 
   const canSave = (() => {
     if (!title.trim()) return false;
@@ -98,7 +87,7 @@ export function ReminderForm({
       id: editingReminder?.id ?? generateId(),
       title: title.trim(),
       notes: notes.trim() || undefined,
-      channel,
+      channel: 'notification',
       type,
       status: editingReminder?.status ?? 'active',
       createdAt: editingReminder?.createdAt ?? new Date().toISOString(),
@@ -121,7 +110,7 @@ export function ReminderForm({
 
     onSave(reminder);
     onClose();
-  }, [canSave, title, notes, channel, type, fireAt, schedule, recoverIfMissed, editingReminder, onSave, onClose]);
+  }, [canSave, title, notes, type, fireAt, schedule, recoverIfMissed, editingReminder, onSave, onClose]);
 
   const inputCls =
     'w-full rounded-md border border-input bg-background px-3 py-2 text-base text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring';

--- a/plugins/sero-git-plugin/ui/GitApp.test.tsx
+++ b/plugins/sero-git-plugin/ui/GitApp.test.tsx
@@ -11,6 +11,7 @@ import { GitApp } from './GitApp';
 const getSeroApiMock = vi.fn();
 const useAppInfoMock = vi.fn();
 const useAppStateMock = vi.fn();
+const commitGraphRenderMock = vi.fn();
 
 vi.mock('@sero-ai/app-runtime', () => ({
   getSeroApi: () => getSeroApiMock(),
@@ -26,7 +27,12 @@ vi.mock('./components/Header', () => ({
 
 vi.mock('./components/BranchPanel', () => ({ BranchPanel: () => null }));
 vi.mock('./components/CommitDetail', () => ({ CommitDetail: () => null }));
-vi.mock('./components/CommitGraph', () => ({ CommitGraph: () => null }));
+vi.mock('./components/CommitGraph', () => ({
+  CommitGraph: () => {
+    commitGraphRenderMock();
+    return null;
+  },
+}));
 vi.mock('./components/DiffViewer', () => ({ DiffViewer: () => null }));
 vi.mock('./components/StagingArea', () => ({ StagingArea: () => null }));
 vi.mock('./styles', () => ({ GIT_STYLES: '' }));
@@ -62,6 +68,7 @@ describe('GitApp', () => {
 
     useAppInfoMock.mockReturnValue({ workspaceId: 'ws-1', workspacePath: '/workspace/repo' });
     useAppStateMock.mockReturnValue([state, vi.fn()]);
+    commitGraphRenderMock.mockReset();
   });
 
   afterEach(async () => {
@@ -84,6 +91,7 @@ describe('GitApp', () => {
     await act(async () => {
       root?.render(<GitApp />);
     });
+    expect(commitGraphRenderMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       clickButton(container, 'Trigger fetch');
@@ -91,6 +99,7 @@ describe('GitApp', () => {
 
     expect(container.textContent).toContain('Git bridge unavailable');
     expect(container.textContent).toContain('Reload Sero or reopen this workspace');
+    expect(commitGraphRenderMock).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       clickButton(container, 'Dismiss git action notice');

--- a/plugins/sero-git-plugin/ui/GitApp.tsx
+++ b/plugins/sero-git-plugin/ui/GitApp.tsx
@@ -6,7 +6,7 @@
  * from @sero-ai/app-runtime for file-backed reactive state.
  */
 
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useMemo, useRef, useState } from 'react';
 import { getSeroApi, useAppInfo, useAppState } from '@sero-ai/app-runtime';
 
 import type { GitActionResult } from '@sero-ai/common';
@@ -31,6 +31,16 @@ interface GitActionNoticeState {
   title: string;
   message: string;
 }
+
+// Git state refreshes and transient app UI (notices, open diffs, selections)
+// update independently. Keep the large, otherwise unchanged renderer sections
+// out of those unrelated commits.
+const MemoizedHeader = memo(Header);
+const MemoizedBranchPanel = memo(BranchPanel);
+const MemoizedCommitGraph = memo(CommitGraph);
+const MemoizedCommitDetail = memo(CommitDetail);
+const MemoizedDiffViewer = memo(DiffViewer);
+const MemoizedStagingArea = memo(StagingArea);
 
 export function GitApp() {
   const initialState = useMemo(() => createDefaultGitState(), []);
@@ -154,7 +164,7 @@ export function GitApp() {
     <>
       <style>{GIT_STYLES}</style>
       <div className="git-root relative flex size-full flex-col overflow-hidden">
-        <Header state={state} onAction={runAction} />
+        <MemoizedHeader state={state} onAction={runAction} />
 
         {notice && (
           <div className="pointer-events-none absolute right-4 top-14 z-30 flex w-[min(30rem,calc(100%-2rem))] justify-end">
@@ -169,7 +179,7 @@ export function GitApp() {
         ) : (
           <>
             <div className="flex flex-1 overflow-hidden">
-              <BranchPanel
+              <MemoizedBranchPanel
                 branches={state.branches}
                 remoteBranches={state.remoteBranches}
                 remotes={state.remotes}
@@ -180,7 +190,7 @@ export function GitApp() {
               />
 
               <div className="flex flex-1 overflow-hidden">
-                <CommitGraph
+                <MemoizedCommitGraph
                   commits={state.commits}
                   selectedHash={selectedCommit?.hash}
                   onSelectCommit={handleSelectCommit}
@@ -189,7 +199,7 @@ export function GitApp() {
                 {showDiffPanel && (
                   <div className="w-[45%] shrink-0 overflow-y-auto border-l border-[var(--g-border)] p-3 git-scrollbar">
                     {viewDiff ? (
-                      <DiffViewer diff={viewDiff} onClose={handleCloseDiff} />
+                      <MemoizedDiffViewer diff={viewDiff} onClose={handleCloseDiff} />
                     ) : (
                       <DiffPlaceholder onClose={handleCloseDiff} resolved={diffRequestResolved} />
                     )}
@@ -198,7 +208,7 @@ export function GitApp() {
               </div>
             </div>
 
-            <CommitDetail
+            <MemoizedCommitDetail
               key={selectedCommit?.hash ?? 'none'}
               commit={selectedCommit}
               diffs={commitDiffs}
@@ -208,7 +218,7 @@ export function GitApp() {
               onAction={runAction}
             />
 
-            <StagingArea
+            <MemoizedStagingArea
               fileChanges={state.fileChanges}
               onAction={runAction}
               onSelectFile={handleSelectStagingFile}

--- a/plugins/sero-graphify-plugin/ui/GraphifyApp.tsx
+++ b/plugins/sero-graphify-plugin/ui/GraphifyApp.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useAppState, useAppTools } from '@sero-ai/app-runtime';
+import { useCallback, useEffect, useState } from 'react';
+import { useAppState, useAppTools, type AppTools } from '@sero-ai/app-runtime';
 import { Badge, Button, Card, Input, Switch } from '@sero-ai/ui';
 import { Loader2, RefreshCw, Search, Waypoints } from 'lucide-react';
 import { DEFAULT_STATE, type GraphifyState, type WorkspaceIndexEntry } from '../shared/types';
@@ -19,13 +19,11 @@ function statusBadge(entry: WorkspaceIndexEntry) {
 export function GraphifyApp() {
   const [state] = useAppState<GraphifyState>(DEFAULT_STATE);
   const { run } = useAppTools();
-  const [question, setQuestion] = useState('');
-  const [answer, setAnswer] = useState<string | null>(null);
-  const [searching, setSearching] = useState(false);
 
   const workspaces = Object.values(state.workspaces);
-  const index = (action: string, workspaceId?: string) =>
+  const index = useCallback((action: string, workspaceId?: string) => {
     void run('graphify_index', { action, workspace: workspaceId });
+  }, [run]);
 
   // Push-based discovery: opening the panel asks the runtime to re-read the
   // profile workspace list, so newly created workspaces appear immediately.
@@ -33,17 +31,6 @@ export function GraphifyApp() {
     void run('graphify_index', { action: 'sync' });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const search = async () => {
-    if (!question.trim()) return;
-    setSearching(true);
-    try {
-      const result = await run('graphify_search', { question });
-      setAnswer(result.text || JSON.stringify(result));
-    } finally {
-      setSearching(false);
-    }
-  };
 
   return (
     <div className="flex h-full flex-col gap-4 overflow-auto bg-background p-4 text-foreground">
@@ -60,24 +47,7 @@ export function GraphifyApp() {
         <Card className="border-destructive p-3 text-base">{state.provisioning.error}</Card>
       )}
 
-      <Card className="p-3">
-        <div className="flex gap-2">
-          <Input
-            value={question}
-            onChange={(e) => setQuestion(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && void search()}
-            placeholder="Search across all indexed workspaces…"
-          />
-          <Button onClick={() => void search()} disabled={searching}>
-            {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
-          </Button>
-        </div>
-        {answer !== null && <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap text-xs">{answer}</pre>}
-        <p className="mt-2 text-xs text-muted-foreground">
-          Profile graph: {state.profileGraph.status}
-          {state.profileGraph.nodes ? ` — ${state.profileGraph.nodes} nodes, ${state.profileGraph.edges} edges` : ''}
-        </p>
-      </Card>
+      <GraphSearch run={run} profileGraph={state.profileGraph} />
 
       <div className="flex flex-col gap-2">
         {workspaces.length === 0 && (
@@ -112,6 +82,49 @@ export function GraphifyApp() {
         ))}
       </div>
     </div>
+  );
+}
+
+interface GraphSearchProps {
+  run: AppTools['run'];
+  profileGraph: GraphifyState['profileGraph'];
+}
+
+function GraphSearch({ run, profileGraph }: GraphSearchProps) {
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState<string | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  const search = async () => {
+    if (!question.trim()) return;
+    setSearching(true);
+    try {
+      const result = await run('graphify_search', { question });
+      setAnswer(result.text || JSON.stringify(result));
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  return (
+    <Card className="p-3">
+      <div className="flex gap-2">
+        <Input
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && void search()}
+          placeholder="Search across all indexed workspaces…"
+        />
+        <Button onClick={() => void search()} disabled={searching}>
+          {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+        </Button>
+      </div>
+      {answer !== null && <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap text-xs">{answer}</pre>}
+      <p className="mt-2 text-xs text-muted-foreground">
+        Profile graph: {profileGraph.status}
+        {profileGraph.nodes ? ` — ${profileGraph.nodes} nodes, ${profileGraph.edges} edges` : ''}
+      </p>
+    </Card>
   );
 }
 

--- a/plugins/sero-mcp-plugin/ui/McpApp.test.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.test.tsx
@@ -10,6 +10,7 @@ import { McpApp } from './McpApp';
 const useAppStateMock = vi.fn();
 const useAppToolsMock = vi.fn();
 const runMock = vi.fn();
+const serverCrudRenderMock = vi.fn();
 
 vi.mock('@sero-ai/app-runtime', () => ({
   useAppState: (initialState: McpAppState) => useAppStateMock(initialState),
@@ -29,7 +30,10 @@ vi.mock('./components/search/McpSearchWorkbenchPanel', () => ({
 }));
 
 vi.mock('./components/servers/McpServerCrudPanel', () => ({
-  McpServerCrudPanel: () => <div>server-crud-panel</div>,
+  McpServerCrudPanel: () => {
+    serverCrudRenderMock();
+    return <div>server-crud-panel</div>;
+  },
 }));
 
 describe('McpApp', () => {
@@ -44,6 +48,7 @@ describe('McpApp', () => {
     runMock.mockReset();
     runMock.mockResolvedValue({ text: '', content: [], details: null, isError: false });
     useAppToolsMock.mockReturnValue({ run: runMock });
+    serverCrudRenderMock.mockReset();
   });
 
   afterEach(async () => {
@@ -71,6 +76,7 @@ describe('McpApp', () => {
     expect(runMock).toHaveBeenCalledWith('mcp_manager', { action: 'bootstrap' });
     expect(container.textContent).toContain('server-crud-panel');
     expect(container.textContent).not.toContain('search-workbench');
+    expect(serverCrudRenderMock).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to a periodic background refresh while mounted', async () => {

--- a/plugins/sero-mcp-plugin/ui/McpApp.tsx
+++ b/plugins/sero-mcp-plugin/ui/McpApp.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useAppState } from '@sero-ai/app-runtime';
 import { Alert, AlertDescription, AlertTitle } from '@sero-ai/ui/components/ui/alert';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
@@ -15,6 +15,11 @@ import { useMcpBootstrap } from './hooks/useMcpBootstrap';
 import { useMcpDiagnostics } from './hooks/useMcpDiagnostics';
 import { useMcpRawConfig } from './hooks/useMcpRawConfig';
 import './styles.css';
+
+// These panels own independent local workflows. Bootstrap, diagnostics, raw
+// config, and search state should not redraw the full server manager.
+const MemoizedMcpSearchWorkbenchPanel = memo(McpSearchWorkbenchPanel);
+const MemoizedMcpServerCrudPanel = memo(McpServerCrudPanel);
 
 export function McpApp() {
   const initialState = useMemo(() => createDefaultMcpState(), []);
@@ -110,13 +115,13 @@ export function McpApp() {
         <McpDiagnosticsPanel state={diagnostics} />
         <McpRawConfigPanel state={rawConfig} />
         {searchOpen && state.servers.length > 0 && (
-          <McpSearchWorkbenchPanel
+          <MemoizedMcpSearchWorkbenchPanel
             servers={state.servers}
             selectedServerName={resolvedSelectedServerName}
             onSelectServer={setSelectedServerName}
           />
         )}
-        <McpServerCrudPanel
+        <MemoizedMcpServerCrudPanel
           servers={state.servers}
           selectedServerName={resolvedSelectedServerName}
           onSelectServerName={setSelectedServerName}

--- a/plugins/sero-orchestrator-plugin/ui/OrchestratorApp.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/OrchestratorApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { consumeAppLaunchParams, onAppLaunchParams, useAppTools } from '@sero-ai/app-runtime';
 import { Button } from '@sero-ai/ui';
 import { Home, Infinity as InfinityIcon, Library, Plus, Sparkles } from 'lucide-react';
@@ -21,6 +21,8 @@ type View = { mode: 'home' } | { mode: 'detail'; loopId: string | null } | { mod
 interface OrchestratorLaunchParams extends Record<string, unknown> {
   loopId?: string;
 }
+
+const MemoizedLoopList = memo(LoopList);
 
 /** Initial view: a loop deep-link from another app lands on that loop's detail. */
 function initialView(): View {
@@ -102,14 +104,14 @@ export function OrchestratorApp() {
     [dispatch],
   );
 
-  const onAction = async (action: OrchestratorAction) => {
+  const onAction = useCallback(async (action: OrchestratorAction) => {
     if (action.kind === 'create' || action.kind === 'list') return;
     const res = await dispatch(actionToParams(action));
     if (action.kind === 'delete') {
       const details = res?.details as { ok?: boolean } | null;
       if (details?.ok !== false) setView({ mode: 'home' });
     }
-  };
+  }, [dispatch]);
 
   const openLibrary = async () => {
     if (libraryDir === null) {
@@ -151,7 +153,8 @@ export function OrchestratorApp() {
     if (summary) setReflectSummary(`Reflected ${summary.reflected} loop(s) · ${summary.suggestionCount} suggestion(s) to review.`);
   };
 
-  const openLoop = (loopId: string) => setView({ mode: 'detail', loopId });
+  const openLoop = useCallback((loopId: string) => setView({ mode: 'detail', loopId }), []);
+  const openCreate = useCallback(() => setView({ mode: 'create' }), []);
 
   return (
     <div className="flex h-full flex-col bg-background text-foreground">
@@ -190,7 +193,7 @@ export function OrchestratorApp() {
 
       <div className="flex min-h-0 flex-1">
         {view.mode === 'home' && (
-          <HomeView loops={index.loops} busy={busy} onAction={onAction} onOpenLoop={openLoop} onNew={() => setView({ mode: 'create' })} />
+          <HomeView loops={index.loops} busy={busy} onAction={onAction} onOpenLoop={openLoop} onNew={openCreate} />
         )}
         {view.mode === 'create' && (
           <CreateLoopWizard busy={busy} stateDir={stateDir} onCreate={createLoop} onAction={onAction} onOpenLoop={openLoop} onCancel={() => setView({ mode: 'home' })} />
@@ -208,7 +211,7 @@ export function OrchestratorApp() {
         )}
         {view.mode === 'detail' && (
           <>
-            <LoopList loops={index.loops} libraryIndex={libraryIndex} selectedId={selectedId} onSelect={openLoop} onNew={() => setView({ mode: 'create' })} />
+            <MemoizedLoopList loops={index.loops} libraryIndex={libraryIndex} selectedId={selectedId} onSelect={openLoop} onNew={openCreate} />
             {selected ? (
               <LoopDetail loop={selected} busy={busy} onAction={onAction} stateDir={stateDir} libraryDir={libraryDir} libraryIndex={libraryIndex} />
             ) : (

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopDeliveryControl.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopDeliveryControl.tsx
@@ -35,7 +35,7 @@ export function LoopDeliveryControl({
   const [open, setOpen] = useState(false);
   const current = effectiveDelivery(loop);
   const [destination, setDestination] = useState<DeliveryDestinationId>(current.destination);
-  const [params, setParams] = useState<Record<string, string>>(
+  const [params, setParams] = useState<Record<string, string>>(() =>
     Object.fromEntries(Object.entries(current.params ?? {}).map(([k, v]) => [k, String(v)])),
   );
 

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Card } from '@sero-ai/ui';
 import { AlertTriangle } from 'lucide-react';
 import type {
@@ -28,6 +29,7 @@ import { SuggestionsInbox } from './SuggestionsInbox';
 import { InputRequestCard } from './InputRequestCard';
 
 const REFINABLE: ReadonlySet<Loop['status']> = new Set(['draft', 'active', 'disabled', 'blocked']);
+const MemoizedPlanView = memo(PlanView);
 
 interface LoopDetailProps {
   loop: Loop;
@@ -118,7 +120,7 @@ export function LoopDetail({ loop, busy, onAction, stateDir, libraryDir, library
       )}
 
       <CollapsibleSection title="Plan" hint={`${loop.plan.steps.length} step(s)`} defaultOpen>
-        <PlanView loop={loop} onAction={onAction} />
+        <MemoizedPlanView loop={loop} onAction={onAction} />
         {REFINABLE.has(loop.status) && (
           <RefinePlan key={loop.id} busy={busy} onRefine={(prompt) => onAction({ kind: 'revise', loopId: loop.id, prompt })} />
         )}

--- a/plugins/sero-usage-plugin/ui/components/ActivityHeatmap.tsx
+++ b/plugins/sero-usage-plugin/ui/components/ActivityHeatmap.tsx
@@ -3,7 +3,7 @@
  * day, weeks as columns (Mon-Sun rows), today in the rightmost column.
  */
 
-import { useMemo, type CSSProperties } from 'react';
+import { memo, useMemo, type CSSProperties } from 'react';
 import { Inline, Text } from '@sero-ai/ui';
 
 import { dateKey } from '../../shared/period';
@@ -83,7 +83,7 @@ function cellStyle(level: number): CSSProperties | undefined {
   return { backgroundColor: `color-mix(in oklab, var(--chart-2) ${LEVEL_MIX[level]}%, transparent)` };
 }
 
-export function ActivityHeatmap({ daily, metric }: { daily: DailyBucket[]; metric: TrendMetric }) {
+export const ActivityHeatmap = memo(function ActivityHeatmap({ daily, metric }: { daily: DailyBucket[]; metric: TrendMetric }) {
   const model = useMemo(() => buildModel(daily, metric), [daily, metric]);
 
   return (
@@ -140,4 +140,4 @@ export function ActivityHeatmap({ daily, metric }: { daily: DailyBucket[]; metri
       </Inline>
     </div>
   );
-}
+});

--- a/plugins/sero-usage-plugin/ui/components/ProviderTable.tsx
+++ b/plugins/sero-usage-plugin/ui/components/ProviderTable.tsx
@@ -3,7 +3,7 @@
  * aggregate values, with per-model rows beneath (default expanded).
  */
 
-import { useState } from 'react';
+import { memo, useState } from 'react';
 import {
   Table,
   TableBody,
@@ -49,7 +49,7 @@ function NumericCells({ stats, dimAll }: { stats: ProviderStats | ModelStats; di
   );
 }
 
-export function ProviderTable({ providers }: { providers: ProviderStats[] }) {
+export const ProviderTable = memo(function ProviderTable({ providers }: { providers: ProviderStats[] }) {
   const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set());
 
   const toggle = (provider: string) => {
@@ -113,4 +113,4 @@ export function ProviderTable({ providers }: { providers: ProviderStats[] }) {
       </Table>
     </div>
   );
-}
+});

--- a/plugins/sero-usage-plugin/ui/components/SessionsTable.tsx
+++ b/plugins/sero-usage-plugin/ui/components/SessionsTable.tsx
@@ -4,7 +4,7 @@
  * file manager bridge.
  */
 
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import {
   IconButton,
   Table,
@@ -39,7 +39,7 @@ function workspaceName(cwd: string): string {
   return cwd.split('/').filter(Boolean).at(-1) ?? cwd;
 }
 
-export function SessionsTable({ sessions }: { sessions: SessionStats[] }) {
+export const SessionsTable = memo(function SessionsTable({ sessions }: { sessions: SessionStats[] }) {
   const [sortKey, setSortKey] = useState<SortKey>('cost');
   const canReveal = canRevealInFolder();
 
@@ -112,4 +112,4 @@ export function SessionsTable({ sessions }: { sessions: SessionStats[] }) {
       )}
     </div>
   );
-}
+});

--- a/plugins/sero-usage-plugin/ui/components/StatTiles.tsx
+++ b/plugins/sero-usage-plugin/ui/components/StatTiles.tsx
@@ -1,9 +1,10 @@
+import { memo } from 'react';
 import { Metric, MetricGroup } from '@sero-ai/ui';
 
 import { formatCost, formatCount, formatTokens } from '../../shared/format';
 import type { PeriodStats } from '../../shared/types';
 
-export function StatTiles({ totals }: { totals: PeriodStats['totals'] }) {
+export const StatTiles = memo(function StatTiles({ totals }: { totals: PeriodStats['totals'] }) {
   const tokens = totals.tokens;
   return (
     <MetricGroup minColumnWidth={110}>
@@ -15,4 +16,4 @@ export function StatTiles({ totals }: { totals: PeriodStats['totals'] }) {
       <Metric label="Messages" value={formatCount(totals.messages)} />
     </MetricGroup>
   );
-}
+});

--- a/plugins/sero-usage-plugin/ui/components/TrendChart.tsx
+++ b/plugins/sero-usage-plugin/ui/components/TrendChart.tsx
@@ -4,7 +4,7 @@
  * (docs/specs/sero-usage-plugin-spec.md §4.1 item 4).
  */
 
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import {
   ChartContainer,
   ChartLegend,
@@ -95,7 +95,7 @@ function buildRows(
   return { rows, providers: hasOther ? [...top, OTHER_KEY] : top };
 }
 
-export function TrendChart({ period, daily, hourly, metric }: TrendChartProps) {
+export const TrendChart = memo(function TrendChart({ period, daily, hourly, metric }: TrendChartProps) {
   const { rows, providers } = useMemo(
     () => buildRows(period, daily, hourly, metric),
     [period, daily, hourly, metric],
@@ -133,4 +133,4 @@ export function TrendChart({ period, daily, hourly, metric }: TrendChartProps) {
       </BarChart>
     </ChartContainer>
   );
-}
+});

--- a/plugins/sero-usage-plugin/ui/lib/useAutoRefresh.ts
+++ b/plugins/sero-usage-plugin/ui/lib/useAutoRefresh.ts
@@ -19,7 +19,7 @@ export interface UsageRefresh {
   error: string | null;
 }
 
-export function useAutoRefresh(state: UsageState): UsageRefresh {
+export function useAutoRefresh(state: UsageState, trackStatus = true): UsageRefresh {
   const { run } = useAppTools();
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -32,22 +32,26 @@ export function useAutoRefresh(state: UsageState): UsageRefresh {
     async (force: boolean) => {
       if (inFlightRef.current) return;
       inFlightRef.current = true;
-      setRefreshing(true);
+      if (trackStatus) setRefreshing(true);
       try {
         const result = await run('usage', { action: 'refresh', force });
-        if (result.isError || result.text.startsWith('Error:')) {
-          setError(result.text || 'Refresh failed');
-        } else {
-          setError(null);
+        if (trackStatus) {
+          if (result.isError || result.text.startsWith('Error:')) {
+            setError(result.text || 'Refresh failed');
+          } else {
+            setError(null);
+          }
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Refresh failed');
+        if (trackStatus) {
+          setError(err instanceof Error ? err.message : 'Refresh failed');
+        }
       } finally {
         inFlightRef.current = false;
-        setRefreshing(false);
+        if (trackStatus) setRefreshing(false);
       }
     },
-    [run],
+    [run, trackStatus],
   );
 
   const refresh = useCallback(() => {

--- a/plugins/sero-usage-plugin/ui/widgets/UsageWidget.tsx
+++ b/plugins/sero-usage-plugin/ui/widgets/UsageWidget.tsx
@@ -116,7 +116,7 @@ function ProviderShare({ providers }: { providers: ProviderStats[] }) {
 export function UsageWidget() {
   const [rawState] = useAppState<UsageState>(DEFAULT_STATE);
   const state = useMemo(() => normalizeUsageState(rawState), [rawState]);
-  useAutoRefresh(state);
+  useAutoRefresh(state, false);
 
   const today = state.periods.today.totals;
   const week = state.periods.thisWeek.totals;

--- a/plugins/sero-user-feedback-plugin/ui/InterviewForm.tsx
+++ b/plugins/sero-user-feedback-plugin/ui/InterviewForm.tsx
@@ -6,7 +6,7 @@
  * Emerald-green Sero styling throughout.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { memo, useState, useCallback, useRef, useEffect } from 'react';
 import { Check } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
@@ -64,7 +64,7 @@ export function InterviewForm({ question, onSubmit, onCancel }: Props) {
             question={q}
             index={i}
             value={answers.get(q.id) ?? ''}
-            onChange={(text) => setAnswer(q.id, text)}
+            onChange={setAnswer}
             inputRef={i === 0 ? firstRef : undefined}
           />
         ))}
@@ -90,7 +90,7 @@ export function InterviewForm({ question, onSubmit, onCancel }: Props) {
 
 // ── Question row ───────────────────────────────────────────────
 
-function QuestionRow({
+const QuestionRow = memo(function QuestionRow({
   question,
   index,
   value,
@@ -100,7 +100,7 @@ function QuestionRow({
   question: UserFeedbackQuestionItem;
   index: number;
   value: string;
-  onChange: (text: string) => void;
+  onChange: (questionId: string, text: string) => void;
   inputRef?: React.RefObject<HTMLTextAreaElement | null>;
 }) {
   const localRef = useRef<HTMLTextAreaElement>(null);
@@ -109,12 +109,12 @@ function QuestionRow({
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      onChange(e.target.value);
+      onChange(question.id, e.target.value);
       const el = e.target;
       el.style.height = 'auto';
       el.style.height = `${Math.max(el.scrollHeight, 36)}px`;
     },
-    [onChange],
+    [onChange, question.id],
   );
 
   return (
@@ -151,4 +151,4 @@ function QuestionRow({
       </div>
     </div>
   );
-}
+});

--- a/plugins/sero-web-plugin/ui/WebApp.tsx
+++ b/plugins/sero-web-plugin/ui/WebApp.tsx
@@ -76,8 +76,8 @@ export function WebApp() {
       {/* Tab content */}
       <div className="flex min-h-0 flex-1 flex-col">
         {activeTab === 'history' && <SearchHistory entries={state.entries} />}
-        {activeTab === 'bookmarks' && <BookmarkList />}
-        {activeTab === 'downloads' && <DownloadsList />}
+        {activeTab === 'bookmarks' && <BookmarkList bookmarks={state.bookmarks ?? []} />}
+        {activeTab === 'downloads' && <DownloadsList downloads={state.downloads ?? []} />}
       </div>
     </div>
   );

--- a/plugins/sero-web-plugin/ui/components/BookmarkList.tsx
+++ b/plugins/sero-web-plugin/ui/components/BookmarkList.tsx
@@ -1,44 +1,26 @@
 // components/BookmarkList.tsx, Bookmark list with add form and delete.
 
 import { useState, useCallback } from 'react';
-import { useAppInfo, useAppState, useAgentPrompt } from '@sero-ai/app-runtime';
+import { useAppInfo, useAgentPrompt } from '@sero-ai/app-runtime';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
 import {
   Bookmark as BookmarkIcon, Plus, Trash2, Tag, ArrowRight, ExternalLink,
 } from 'lucide-react';
-import type { WebAccessState, Bookmark } from '../../shared/types';
-import { DEFAULT_STATE } from '../../shared/types';
+import type { Bookmark } from '../../shared/types';
 import { relativeTime } from '../lib/format';
 import {
   addBookmark as addBookmarkAction,
   removeBookmark as removeBookmarkAction,
 } from '../lib/web-actions';
 
-export function BookmarkList() {
-  const { workspaceId } = useAppInfo();
-  const [state] = useAppState<WebAccessState>(DEFAULT_STATE);
-  const [showAdd, setShowAdd] = useState(false);
-  const [url, setUrl] = useState('');
-  const [title, setTitle] = useState('');
-  const [tags, setTags] = useState('');
+interface BookmarkListProps {
+  bookmarks: Bookmark[];
+}
 
-  const addDirectly = useCallback(async () => {
-    const trimmedUrl = url.trim();
-    if (!trimmedUrl) return;
-    const tagList = tags.split(',').map(t => t.trim()).filter(Boolean);
-    await addBookmarkAction(workspaceId, {
-      action: 'add-bookmark',
-      url: trimmedUrl,
-      title: title.trim() || trimmedUrl,
-      tags: tagList,
-    });
-    setUrl('');
-    setTitle('');
-    setTags('');
-    setShowAdd(false);
-  }, [url, title, tags, workspaceId]);
+export function BookmarkList({ bookmarks }: BookmarkListProps) {
+  const { workspaceId } = useAppInfo();
 
   const removeBookmark = useCallback(
     async (id: string) => {
@@ -49,34 +31,10 @@ export function BookmarkList() {
 
   return (
     <div className="flex h-full flex-col">
-      {/* Add button / form */}
-      <div className="shrink-0 border-b border-border px-3 py-2">
-        {!showAdd ? (
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full justify-start gap-2 text-muted-foreground"
-            onClick={() => setShowAdd(true)}
-          >
-            <Plus className="size-3.5" />
-            Add bookmark
-          </Button>
-        ) : (
-          <AddBookmarkForm
-            url={url}
-            title={title}
-            tags={tags}
-            onUrlChange={setUrl}
-            onTitleChange={setTitle}
-            onTagsChange={setTags}
-            onSubmit={addDirectly}
-            onCancel={() => setShowAdd(false)}
-          />
-        )}
-      </div>
+      <AddBookmarkSection workspaceId={workspaceId} />
 
       {/* Bookmark list */}
-      {(state.bookmarks?.length ?? 0) === 0 ? (
+      {bookmarks.length === 0 ? (
         <div className="flex flex-1 flex-col items-center justify-center py-16">
           <BookmarkIcon className="mb-2 size-5 text-muted-foreground/40" />
           <p className="text-base text-muted-foreground">No bookmarks yet</p>
@@ -87,7 +45,7 @@ export function BookmarkList() {
       ) : (
         <ScrollArea className="flex-1">
           <div className="flex flex-col">
-            {(state.bookmarks ?? []).map((bm) => (
+            {bookmarks.map((bm) => (
               <BookmarkRow key={bm.id} bookmark={bm} onRemove={removeBookmark} />
             ))}
           </div>
@@ -98,6 +56,56 @@ export function BookmarkList() {
 }
 
 // ── Add form ────────────────────────────────────────────────
+
+function AddBookmarkSection({ workspaceId }: { workspaceId: string }) {
+  const [showAdd, setShowAdd] = useState(false);
+  const [url, setUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [tags, setTags] = useState('');
+
+  const addDirectly = useCallback(async () => {
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) return;
+    const tagList = tags.split(',').map((tag) => tag.trim()).filter(Boolean);
+    await addBookmarkAction(workspaceId, {
+      action: 'add-bookmark',
+      url: trimmedUrl,
+      title: title.trim() || trimmedUrl,
+      tags: tagList,
+    });
+    setUrl('');
+    setTitle('');
+    setTags('');
+    setShowAdd(false);
+  }, [tags, title, url, workspaceId]);
+
+  return (
+    <div className="shrink-0 border-b border-border px-3 py-2">
+      {!showAdd ? (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full justify-start gap-2 text-muted-foreground"
+          onClick={() => setShowAdd(true)}
+        >
+          <Plus className="size-3.5" />
+          Add bookmark
+        </Button>
+      ) : (
+        <AddBookmarkForm
+          url={url}
+          title={title}
+          tags={tags}
+          onUrlChange={setUrl}
+          onTitleChange={setTitle}
+          onTagsChange={setTags}
+          onSubmit={addDirectly}
+          onCancel={() => setShowAdd(false)}
+        />
+      )}
+    </div>
+  );
+}
 
 interface AddBookmarkFormProps {
   url: string;

--- a/plugins/sero-web-plugin/ui/components/DownloadsList.tsx
+++ b/plugins/sero-web-plugin/ui/components/DownloadsList.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useAppInfo, useAppState } from '@sero-ai/app-runtime';
+import { useAppInfo } from '@sero-ai/app-runtime';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Badge } from '@sero-ai/ui/components/ui/badge';
@@ -12,17 +12,19 @@ import {
   Trash2,
   AlertCircle,
 } from 'lucide-react';
-import type { WebAccessState, WebDownload } from '../../shared/types';
-import { DEFAULT_STATE } from '../../shared/types';
+import type { WebDownload } from '../../shared/types';
 import { relativeTime, truncate } from '../lib/format';
 import { isVisibleDownload } from '../lib/downloads';
 import { deleteDownload as deleteDownloadAction } from '../lib/web-actions';
 import { openWorkspaceFile, revealInFinder } from '../lib/host';
 
-export function DownloadsList() {
+interface DownloadsListProps {
+  downloads: WebDownload[];
+}
+
+export function DownloadsList({ downloads: stateDownloads }: DownloadsListProps) {
   const { workspaceId } = useAppInfo();
-  const [state] = useAppState<WebAccessState>(DEFAULT_STATE);
-  const downloads = [...(state.downloads ?? [])]
+  const downloads = [...stateDownloads]
     .filter(isVisibleDownload)
     .sort((a, b) => b.updatedAt - a.updatedAt);
 

--- a/plugins/sero-web-plugin/ui/widgets/WebWidget.tsx
+++ b/plugins/sero-web-plugin/ui/widgets/WebWidget.tsx
@@ -5,7 +5,7 @@
 // open their URL in the browser on click. Presentation is composed from
 // @sero-ai/ui — the provider badge stays plugin-local (brand colours).
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useAppState } from '@sero-ai/app-runtime';
 import {
   ActivityList,
@@ -67,10 +67,16 @@ export function WebWidget() {
   const [tab, setTab] = useState<TabKey>('activity');
 
   const entries = state.entries;
-  const bookmarks = [...(state.bookmarks ?? [])].sort((a, b) => b.createdAt - a.createdAt);
-  const downloads = (state.downloads ?? [])
-    .filter(isVisibleDownload)
-    .sort((a, b) => b.updatedAt - a.updatedAt);
+  const bookmarks = useMemo(
+    () => (state.bookmarks ?? []).toSorted((a, b) => b.createdAt - a.createdAt),
+    [state.bookmarks],
+  );
+  const downloads = useMemo(
+    () => (state.downloads ?? [])
+      .filter(isVisibleDownload)
+      .toSorted((a, b) => b.updatedAt - a.updatedAt),
+    [state.downloads],
+  );
 
   return (
     <WidgetContent>


### PR DESCRIPTION
## Summary

- narrow desktop Zustand subscriptions so streaming, workspace, VCS, and watcher updates only redraw relevant consumers
- add stable callbacks and memo boundaries around shell, explorer, theme, diagnostics, and federated app sections
- isolate plugin form, list, chart, and live-state rendering across the built-in React plugins
- add selector isolation regression tests and a section-by-section performance audit ledger

## Why

Several renderer surfaces subscribed to entire store objects or passed unstable callbacks through otherwise independent UI sections. Frequent updates such as streamed tokens, workspace changes, VCS refreshes, diagnostics progress, and form input could therefore reconcile unrelated subtrees.

The changes keep subscriptions and component boundaries aligned with the data each surface actually consumes.

## Impact

This reduces avoidable React work in frequently updating desktop and plugin paths without changing user-facing behavior or public APIs.

## Validation

- `pnpm typecheck` — 22/22 tasks passed
- `pnpm test` — 15/15 tasks passed
- desktop — 322 test files and 1,693 tests passed
- changed-file React Doctor performance scan completed across 60 files
- `git diff --check` passed
- all touched source files remain below 500 lines

The audit ledger documents confirmed findings and the animation, bundle-loading, and micro-optimization diagnostics intentionally left unchanged.