### PR TITLE
feat(workspace): delete workspaces from the sidebar + graphify index cleanup

### DIFF
--- a/apps/desktop/electron/__tests__/features/apps/runtime/manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/runtime/manager.test.ts
@@ -451,6 +451,38 @@ describe('AppRuntimeManager', () => {
     expect(initialCalendarRuntime.dispose).not.toHaveBeenCalled();
   });
 
+  it('disposeWorkspace tears down only the target workspace runtimes and their watchers', async () => {
+    const manifests = [createManifest('notes')];
+    const workspaces = [
+      { id: 'ws-1', path: '/repo-1' },
+      { id: 'ws-2', path: '/repo-2' },
+    ];
+    const runtimesByWorkspace = new Map<string, { dispose: ReturnType<typeof vi.fn> }>();
+    const watch = vi.fn<(filePath: string) => void>();
+    const unwatch = vi.fn<(filePath: string) => void>();
+
+    const manager = new AppRuntimeManager({
+      discoverApps: async () => manifests,
+      getOpenWorkspaces: async () => workspaces,
+      loadRuntimeModule: async (): Promise<AppRuntimeModule> => ({
+        createAppRuntime: async (ctx) => {
+          const runtime = { start: vi.fn(async () => {}), handleStateChange: vi.fn(async () => {}), dispose: vi.fn(async () => {}) };
+          runtimesByWorkspace.set(ctx.workspaceId, runtime);
+          return runtime;
+        },
+      }),
+      createHost: () => createHostStub(watch, unwatch),
+    });
+
+    await manager.initialize();
+    await manager.disposeWorkspace('ws-1');
+
+    expect(runtimesByWorkspace.get('ws-1')!.dispose).toHaveBeenCalledTimes(1);
+    expect(runtimesByWorkspace.get('ws-2')!.dispose).not.toHaveBeenCalled();
+    expect(unwatch).toHaveBeenCalledWith(path.join('/repo-1', '.sero/apps/notes/state.json'));
+    expect(unwatch).not.toHaveBeenCalledWith(path.join('/repo-2', '.sero/apps/notes/state.json'));
+  });
+
   it('disposes stale runtimes during reconcile', async () => {
     const runtime = {
       start: vi.fn(async () => {}),

--- a/apps/desktop/electron/__tests__/features/workspace/workspace-delete.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/workspace-delete.test.ts
@@ -1,0 +1,82 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { existsSync, promises as fsp } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WorkspaceManager } from '@electron/features/workspace/manager';
+
+const tempDirs: string[] = [];
+
+async function createTestManager(): Promise<{ manager: WorkspaceManager; workspacesDir: string }> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'sero-workspace-delete-'));
+  tempDirs.push(root);
+  const agentDir = path.join(root, 'agent');
+  const workspacesDir = path.join(root, 'workspaces');
+  await Promise.all([
+    mkdir(agentDir, { recursive: true }),
+    mkdir(workspacesDir, { recursive: true }),
+  ]);
+  return {
+    manager: new WorkspaceManager({
+      agentDir,
+      workspacesDir,
+      registryPath: path.join(agentDir, 'workspaces.json'),
+      editorStateDir: path.join(agentDir, 'editor-state'),
+    }),
+    workspacesDir,
+  };
+}
+
+describe('workspace deletion', () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it('erases the folder from disk and unregisters the workspace', async () => {
+    const { manager, workspacesDir } = await createTestManager();
+    const workspace = await manager.create('Doomed');
+    const workspacePath = path.join(workspacesDir, workspace.id);
+    await writeFile(path.join(workspacePath, 'file.txt'), 'data', 'utf8');
+    expect(existsSync(workspacePath)).toBe(true);
+
+    await manager.delete(workspace.id);
+
+    expect(existsSync(workspacePath)).toBe(false);
+    expect((await manager.list()).some((w) => w.id === workspace.id)).toBe(false);
+  });
+
+  it('deletes external "Add Folder" workspaces too (real delete, per design)', async () => {
+    const { manager } = await createTestManager();
+    const external = await mkdtemp(path.join(os.tmpdir(), 'sero-external-'));
+    tempDirs.push(external);
+    await writeFile(path.join(external, 'keep.txt'), 'x', 'utf8');
+    const workspace = await manager.addFolder(external);
+
+    await manager.delete(workspace.id);
+
+    expect(existsSync(external)).toBe(false);
+  });
+
+  it('unregisters the workspace even when file removal fails (no half-deleted ghost)', async () => {
+    const { manager } = await createTestManager();
+    const workspace = await manager.create('Busy');
+    // Simulate a large/busy tree that fails to delete (e.g. EBUSY on node_modules).
+    const spy = vi.spyOn(fsp, 'rm').mockRejectedValue(new Error('EBUSY: resource busy'));
+
+    await expect(manager.delete(workspace.id)).rejects.toThrow(/EBUSY/);
+    // Registry updated first → the workspace is gone from the sidebar regardless.
+    expect((await manager.list()).some((w) => w.id === workspace.id)).toBe(false);
+
+    spy.mockRestore();
+  });
+
+  it('refuses to delete the default workspace', async () => {
+    const { manager } = await createTestManager();
+    await expect(manager.delete('global')).rejects.toThrow(/default workspace/);
+  });
+
+  it('is a no-op for an unknown workspace id', async () => {
+    const { manager } = await createTestManager();
+    await expect(manager.delete('does-not-exist')).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/electron/features/apps/runtime/manager.ts
+++ b/apps/desktop/electron/features/apps/runtime/manager.ts
@@ -230,6 +230,24 @@ export class AppRuntimeManager {
     }
   }
 
+  /**
+   * Dispose every app-runtime bound to a workspace, releasing the file handles
+   * and state-file watchers they hold inside it. MUST run before a workspace's
+   * files are deleted — otherwise a live runtime keeps its cwd/handles open and
+   * the directory can't be fully removed (ENOTEMPTY on node_modules). Per-instance
+   * errors are swallowed so one stuck runtime can't block the others.
+   */
+  async disposeWorkspace(workspaceId: string): Promise<void> {
+    const instances = [...this.instances.values()].filter((instance) => instance.workspaceId === workspaceId);
+    await Promise.all(instances.map(async (instance) => {
+      try {
+        await this.disposeInstance(instance.key);
+      } catch (error) {
+        console.error(`[app-runtime] Failed to dispose runtime ${instance.key} for workspace ${workspaceId}:`, error);
+      }
+    }));
+  }
+
   private async disposeInstance(key: string): Promise<void> {
     const instance = this.instances.get(key);
     if (!instance) return;

--- a/apps/desktop/electron/features/workspace/manager.ts
+++ b/apps/desktop/electron/features/workspace/manager.ts
@@ -20,7 +20,8 @@ import type { SetContainerEnabledResult, WorkspaceManagerOptions, WorkspaceRegis
 export type { SetContainerEnabledResult, WorkspaceManagerOptions } from './manager-types';
 
 import { inferWorkspaceFromMessage } from './inference';
-import { slugify, ensureUniqueId, prettifyName, isSafeWorkspaceId } from './utils';
+import { slugify, ensureUniqueId, prettifyName, isSafeWorkspaceId, assertSafeToDelete } from './utils';
+import { readWorkspaceConfig, writeWorkspaceConfig, cleanupEditorState } from './workspace-io';
 import { AGENT_DIR, DEFAULT_GLOBAL_CONFIG, EDITOR_STATE_DIR, REGISTRY_PATH, WORKSPACES_DIR } from './defaults';
 import * as mounts from './mounts';
 import * as roots from './roots';
@@ -118,7 +119,7 @@ export class WorkspaceManager {
     if (!this.findEntry('global')) {
       const globalPath = path.join(this.workspacesDir, 'global');
       await fs.mkdir(globalPath, { recursive: true });
-      await this.writeConfig(globalPath, DEFAULT_GLOBAL_CONFIG);
+      await writeWorkspaceConfig(globalPath, DEFAULT_GLOBAL_CONFIG);
       this.registry.workspaces.push({
         id: 'global',
         path: globalPath,
@@ -146,38 +147,14 @@ export class WorkspaceManager {
       const runtimeBackend = config?.runtime?.backend as WorkspaceRuntimeBackendInput | undefined;
       // Deprecated compatibility input; normalize to host on write.
       if (!config || (runtimeBackend && runtimeBackend !== 'mac-host' && config.container === undefined)) return;
-      await this.writeConfig(entry.path, config);
+      await writeWorkspaceConfig(entry.path, config);
       this.configCache.delete(entry.id);
     }));
   }
 
   /** Read .sero-workspace.json from a workspace directory. */
   async readConfig(workspacePath: string): Promise<WorkspaceConfig | null> {
-    const configPath = path.join(workspacePath, '.sero-workspace.json');
-    try {
-      const raw = await fs.readFile(configPath, 'utf8');
-      return JSON.parse(raw) as WorkspaceConfig;
-    } catch {
-      return null;
-    }
-  }
-
-  /** Write .sero-workspace.json to a workspace directory. */
-  private async writeConfig(workspacePath: string, config: WorkspaceConfig): Promise<void> {
-    const configPath = path.join(workspacePath, '.sero-workspace.json');
-    const json = JSON.stringify(normalizeWorkspaceConfigForWrite(config), null, 2) + '\n';
-    await fs.writeFile(configPath, json, 'utf8');
-  }
-
-  private async cleanupEditorState(id: string): Promise<void> {
-    const editorStateFile = path.join(this.editorStateDir, `${id}.json`);
-    try {
-      await fs.rm(editorStateFile, { force: true });
-    } catch (error: unknown) {
-      const err = error as NodeJS.ErrnoException;
-      if (err.code === 'ENOENT') return;
-      console.warn(`[workspace] Failed to remove editor state for ${id}:`, error);
-    }
+    return readWorkspaceConfig(workspacePath);
   }
 
   /** List all registered workspaces with merged config data. */
@@ -241,13 +218,13 @@ export class WorkspaceManager {
         id: uniqueId,
         name: name || prettifyName(path.basename(absPath)),
       };
-      await this.writeConfig(absPath, config);
+      await writeWorkspaceConfig(absPath, config);
     } else {
       const configuredId = isSafeWorkspaceId(config.id) ? config.id : uniqueId;
       const safeUniqueId = this.ensureUniqueId(configuredId);
       if (config.id !== safeUniqueId) {
         config = { ...config, id: safeUniqueId };
-        await this.writeConfig(absPath, config);
+        await writeWorkspaceConfig(absPath, config);
       }
     }
 
@@ -302,7 +279,7 @@ export class WorkspaceManager {
       id: uniqueId,
       name,
     };
-    await this.writeConfig(wsPath, config);
+    await writeWorkspaceConfig(wsPath, config);
 
     const entry: WorkspaceRegistryEntry = {
       id: uniqueId,
@@ -330,7 +307,7 @@ export class WorkspaceManager {
     this.configCache.delete(id);
     await this.saveRegistry();
 
-    await this.cleanupEditorState(id);
+    await cleanupEditorState(this.editorStateDir, id);
   }
 
   // ── Open / Close ────────────────────────────────────────────
@@ -357,7 +334,29 @@ export class WorkspaceManager {
     this.configCache.delete(id);
     await this.saveRegistry();
 
-    await this.cleanupEditorState(id);
+    await cleanupEditorState(this.editorStateDir, id);
+  }
+
+  /**
+   * Delete a workspace: unregister it AND permanently erase its folder. The
+   * registry is updated FIRST so a slow or partially-failing removal never
+   * leaves a half-deleted ghost in the sidebar. `fs.rm` retries ride out the
+   * transient EBUSY/ENOTEMPTY large trees (node_modules) throw; a final failure
+   * surfaces rather than being swallowed. Caller tears down the runtime first.
+   */
+  async delete(id: string): Promise<void> {
+    if (id === 'global') throw new Error('Cannot delete the default workspace');
+    const entry = this.findEntry(id);
+    if (!entry) return; // Already gone — nothing to do.
+
+    assertSafeToDelete(entry.path, path.dirname(AGENT_DIR));
+
+    this.registry.workspaces = this.registry.workspaces.filter((w) => w.id !== id);
+    this.configCache.delete(id);
+    await this.saveRegistry();
+    await cleanupEditorState(this.editorStateDir, id);
+
+    await fs.rm(entry.path, { recursive: true, force: true, maxRetries: 5, retryDelay: 250 });
   }
 
   /** Set expanded/collapsed state for a workspace tree node. */

--- a/apps/desktop/electron/features/workspace/utils.ts
+++ b/apps/desktop/electron/features/workspace/utils.ts
@@ -4,6 +4,9 @@
  * Extracted from WorkspaceManager to keep file sizes manageable.
  */
 
+import os from 'os';
+import path from 'path';
+
 // Workspace IDs are interpolated into dev-server IDs as the first colon-separated segment
 // (see runtime-manager `workspaceIdFromServerId`), so they must not themselves contain colons.
 // Slugify enforces this by construction; the regex below is the runtime guard for any path
@@ -49,4 +52,17 @@ export function prettifyName(slug: string): string {
   return slug
     .replace(/[-_]+/g, ' ')
     .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Defence-in-depth against a malformed registry pointing a workspace at a
+ * dangerous path. Deletion is only ever allowed for a real, absolute, nested
+ * directory — never the filesystem root, the user's home, or the Sero home.
+ */
+export function assertSafeToDelete(targetPath: string, seroHome: string): void {
+  const resolved = path.resolve(targetPath);
+  const forbidden = new Set([path.parse(resolved).root, os.homedir(), path.resolve(seroHome)]);
+  if (!path.isAbsolute(resolved) || forbidden.has(resolved)) {
+    throw new Error(`Refusing to delete unsafe workspace path: ${resolved}`);
+  }
 }

--- a/apps/desktop/electron/features/workspace/utils.ts
+++ b/apps/desktop/electron/features/workspace/utils.ts
@@ -62,7 +62,9 @@ export function prettifyName(slug: string): string {
 export function assertSafeToDelete(targetPath: string, seroHome: string): void {
   const resolved = path.resolve(targetPath);
   const forbidden = new Set([path.parse(resolved).root, os.homedir(), path.resolve(seroHome)]);
-  if (!path.isAbsolute(resolved) || forbidden.has(resolved)) {
+  // Guard the *raw* input: path.resolve() always yields an absolute path, so a
+  // relative registry entry would otherwise be silently joined to the cwd.
+  if (!path.isAbsolute(targetPath) || forbidden.has(resolved)) {
     throw new Error(`Refusing to delete unsafe workspace path: ${resolved}`);
   }
 }

--- a/apps/desktop/electron/features/workspace/workspace-io.ts
+++ b/apps/desktop/electron/features/workspace/workspace-io.ts
@@ -1,0 +1,38 @@
+/**
+ * Disk I/O helpers for workspace state — the per-workspace config file and
+ * the persisted editor state. Extracted from WorkspaceManager to keep it
+ * under the file-size budget.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import type { WorkspaceConfig } from '@/types/ipc';
+import { normalizeWorkspaceConfigForWrite } from './runtime/config';
+
+/** Read .sero-workspace.json from a workspace directory. */
+export async function readWorkspaceConfig(workspacePath: string): Promise<WorkspaceConfig | null> {
+  try {
+    const raw = await fs.readFile(path.join(workspacePath, '.sero-workspace.json'), 'utf8');
+    return JSON.parse(raw) as WorkspaceConfig;
+  } catch {
+    return null;
+  }
+}
+
+/** Write .sero-workspace.json to a workspace directory. */
+export async function writeWorkspaceConfig(workspacePath: string, config: WorkspaceConfig): Promise<void> {
+  const json = JSON.stringify(normalizeWorkspaceConfigForWrite(config), null, 2) + '\n';
+  await fs.writeFile(path.join(workspacePath, '.sero-workspace.json'), json, 'utf8');
+}
+
+/** Remove a workspace's persisted editor state. Best-effort — never throws on a missing file. */
+export async function cleanupEditorState(editorStateDir: string, id: string): Promise<void> {
+  try {
+    await fs.rm(path.join(editorStateDir, `${id}.json`), { force: true });
+  } catch (error: unknown) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') return;
+    console.warn(`[workspace] Failed to remove editor state for ${id}:`, error);
+  }
+}

--- a/apps/desktop/electron/ipc/workspace/workspace.ts
+++ b/apps/desktop/electron/ipc/workspace/workspace.ts
@@ -32,6 +32,18 @@ function notifyWorkspaceChanged(): void {
   broadcastToWindows(IpcChannels.workspace.changed);
 }
 
+/** Cap on best-effort runtime teardown so a stuck container/runtime can't hang a workspace delete. */
+const RUNTIME_TEARDOWN_TIMEOUT_MS = 15_000;
+
+/** Resolve the promise, or reject once `ms` elapses — whichever comes first. */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms: ${label}`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
 let runtimeInstallProgressRegistered = false;
 
 function registerRuntimeInstallProgressBroadcasts(): void {
@@ -121,6 +133,36 @@ export function registerWorkspaceHandlers(): void {
       await workspaceManager.close(id);
       await reconcileAppRuntimes('workspace close');
       notifyWorkspaceChanged();
+    },
+  );
+
+  // ── Delete workspace (unregister + erase files from disk) ──
+  ipcMain.handle(
+    IpcChannels.workspace.delete,
+    async (_event, id: string): Promise<void> => {
+      // Release everything holding the workspace directory BEFORE erasing it:
+      //  1. terminals + container backend (runtimeManager)
+      //  2. plugin app-runtimes (orchestrator, cron, …) — these keep a cwd/state
+      //     watcher inside the workspace, and a live one blocks removal of
+      //     node_modules (ENOTEMPTY). Missed by runtimeManager.destroy.
+      // Both are bounded + best-effort so a stuck runtime can never hang the delete.
+      const teardown = Promise.all([
+        runtimeManager.destroy(id),
+        appRuntimeManager.disposeWorkspace(id),
+      ]);
+      teardown.catch(() => undefined); // Avoid an unhandled rejection if it settles after the timeout.
+      await withTimeout(teardown, RUNTIME_TEARDOWN_TIMEOUT_MS, `runtime teardown for ${id}`).catch((err) => {
+        console.error(`[workspace:delete] runtime teardown failed/slow for ${id}:`, err);
+      });
+
+      await workspaceManager.delete(id);
+      notifyWorkspaceChanged(); // Sidebar clears as soon as the files are gone — don't wait on reconcile.
+
+      // App-runtime reconciliation is a queued, potentially-blocking operation;
+      // awaiting it inline held the delete response open and showed an infinite
+      // "Deleting…" spinner. The workspace is already unregistered, so reconcile
+      // in the background.
+      void reconcileAppRuntimes('workspace delete');
     },
   );
 

--- a/apps/desktop/electron/preload/api/core.ts
+++ b/apps/desktop/electron/preload/api/core.ts
@@ -79,6 +79,7 @@ export const workspaceBridge = {
     ipcRenderer.invoke(IpcChannels.workspace.addFolder, folderPath, name),
   open: (id: string): Promise<void> => ipcRenderer.invoke(IpcChannels.workspace.open, id),
   close: (id: string): Promise<void> => ipcRenderer.invoke(IpcChannels.workspace.close, id),
+  delete: (id: string): Promise<void> => ipcRenderer.invoke(IpcChannels.workspace.delete, id),
   pickFolder: (): Promise<string | null> =>
     ipcRenderer.invoke(IpcChannels.workspace.pickFolder),
   infer: (message: string): Promise<string> =>

--- a/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceCloseMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceCloseMenu.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { Minus } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@sero-ai/ui/components/ui/popover';
+import { IconAction } from '@/components/ui/IconAction';
+
+interface WorkspaceCloseMenuProps {
+  workspaceName: string;
+  /** Absolute path shown in the delete confirmation so the user sees exactly what is erased. */
+  workspacePath: string;
+  /** Remove from the sidebar, keep files on disk. */
+  onClose: () => void;
+  /** Permanently erase the folder from disk. */
+  onDelete: () => void;
+}
+
+/**
+ * The workspace "−" action. Opens a small menu asking whether to Close (unregister,
+ * keep files) or Delete (erase from disk). Delete requires a second, explicit
+ * confirmation because it is irreversible and can remove real project folders.
+ */
+export function WorkspaceCloseMenu({ workspaceName, workspacePath, onClose, onDelete }: WorkspaceCloseMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setConfirmingDelete(false); // Always reopen on the first step.
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <IconAction
+          as="span"
+          role="button"
+          tabIndex={-1}
+          onClick={(e) => { e.stopPropagation(); setOpen(true); }}
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); setOpen(true); } }}
+          title="Close or delete workspace"
+        >
+          <Minus className="size-3" />
+        </IconAction>
+      </PopoverTrigger>
+      <PopoverContent align="start" side="right" className="w-64 p-3" onClick={(e) => e.stopPropagation()}>
+        {!confirmingDelete ? (
+          <>
+            <p className="mb-1 truncate text-sm font-medium text-[var(--text-primary)]" title={workspaceName}>
+              {workspaceName}
+            </p>
+            <p className="mb-3 text-xs text-[var(--text-secondary)]">
+              Close removes it from the sidebar. Delete permanently erases the folder from disk.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-base"
+                onClick={(e) => { e.stopPropagation(); setOpen(false); }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                className="h-6 px-2 text-base"
+                onClick={(e) => { e.stopPropagation(); setOpen(false); onClose(); }}
+              >
+                Close
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-6 px-2 text-base"
+                onClick={(e) => { e.stopPropagation(); setConfirmingDelete(true); }}
+              >
+                Delete
+              </Button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="mb-1 text-sm font-medium text-status-error">Delete this workspace?</p>
+            <p className="mb-2 text-xs text-[var(--text-secondary)]">
+              This permanently deletes the folder and everything in it. It cannot be undone.
+            </p>
+            <p
+              className="mb-3 truncate rounded bg-[var(--bg-base)] px-1.5 py-1 font-mono text-[11px] text-[var(--text-muted)]"
+              title={workspacePath}
+            >
+              {workspacePath}
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-base"
+                onClick={(e) => { e.stopPropagation(); setConfirmingDelete(false); }}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                className="h-6 px-2 text-base"
+                onClick={(e) => { e.stopPropagation(); setOpen(false); onDelete(); }}
+              >
+                Delete permanently
+              </Button>
+            </div>
+          </>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
+++ b/apps/desktop/src/components/layout/workspace/workspace-tree/WorkspaceNode.tsx
@@ -4,7 +4,6 @@ import {
   ChevronRight,
   FolderOpen,
   GitBranch,
-  Minus,
   Plus,
   Trash2,
   X,
@@ -21,6 +20,7 @@ import { useSessionStore } from '@/stores/sessions';
 import { type ContainerStatus, useWorkspaceContainer } from '@/stores/container';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { WorkspaceBulkDeleteDialog } from './WorkspaceBulkDeleteDialog';
+import { WorkspaceCloseMenu } from './WorkspaceCloseMenu';
 
 function ContainerIndicator({ workspaceId, containerEnabled }: { workspaceId: string; containerEnabled: boolean }) {
   const container = useWorkspaceContainer(workspaceId);
@@ -67,6 +67,7 @@ export const WorkspaceNode = memo(function WorkspaceNode({ workspace, sessions }
   );
   const setActiveWorkspace = useWorkspaceStore((state) => state.setActiveWorkspace);
   const closeWorkspace = useWorkspaceStore((state) => state.closeWorkspace);
+  const deleteWorkspace = useWorkspaceStore((state) => state.deleteWorkspace);
   const createSession = useSessionStore((state) => state.createSession);
   const deleteSelectedSessions = useSessionStore((state) => state.deleteSelectedSessions);
   const clearSelection = useSessionStore((state) => state.clearSelection);
@@ -92,9 +93,12 @@ export const WorkspaceNode = memo(function WorkspaceNode({ workspace, sessions }
     setActiveWorkspace(workspace.id);
   };
 
-  const handleClose = (event: React.MouseEvent | React.KeyboardEvent) => {
-    event.stopPropagation();
+  const handleClose = () => {
     void closeWorkspace(workspace.id);
+  };
+
+  const handleDelete = () => {
+    void deleteWorkspace(workspace.id);
   };
 
   const handleBulkDelete = async () => {
@@ -243,20 +247,12 @@ export const WorkspaceNode = memo(function WorkspaceNode({ workspace, sessions }
                   <GitBranch className="size-3" />
                 </IconAction>
                 {!isDefault && (
-                  <IconAction
-                    as="span"
-                    role="button"
-                    tabIndex={-1}
-                    onClick={handleClose}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter') {
-                        handleClose(event);
-                      }
-                    }}
-                    title="Close workspace"
-                  >
-                    <Minus className="size-3" />
-                  </IconAction>
+                  <WorkspaceCloseMenu
+                    workspaceName={workspace.name}
+                    workspacePath={workspace.path}
+                    onClose={handleClose}
+                    onDelete={handleDelete}
+                  />
                 )}
               </motion.span>
             </AnimatePresence>

--- a/apps/desktop/src/stores/workspace.ts
+++ b/apps/desktop/src/stores/workspace.ts
@@ -37,6 +37,8 @@ interface WorkspaceState {
   loadWorkspaces: () => Promise<void>;
   /** Close a workspace — removes it from the registry entirely. */
   closeWorkspace: (id: string) => Promise<void>;
+  /** Permanently delete a workspace and erase its folder from disk. Destructive. */
+  deleteWorkspace: (id: string) => Promise<void>;
   /** Toggle expanded/collapsed state of a workspace tree node. */
   toggleCollapsed: (id: string) => void;
   /** Collapse all workspace tree nodes. */
@@ -112,6 +114,30 @@ export const useWorkspaceStore = create<WorkspaceState>((set, get) => ({
       workspaces: s.workspaces.filter((w) => w.id !== id),
       activeWorkspaceId: s.activeWorkspaceId === id ? 'global' : s.activeWorkspaceId,
     }));
+  },
+
+  deleteWorkspace: async (id) => {
+    if (id === 'global') return; // Can't delete global
+
+    // Remove from the sidebar immediately. The backend unregisters the workspace
+    // before the (potentially slow) file removal, so a deleted workspace must
+    // never linger in the tree as a hung entry — the erase finishes in the
+    // background.
+    set((s) => ({
+      workspaces: s.workspaces.filter((w) => w.id !== id),
+      activeWorkspaceId: s.activeWorkspaceId === id ? 'global' : s.activeWorkspaceId,
+    }));
+
+    try {
+      await window.sero.workspace.delete(id);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to delete workspace';
+      console.error('[workspace] deleteWorkspace failed:', err);
+      // Reconcile with the true registry — this re-adds the workspace only if it
+      // was never actually unregistered — then surface the error.
+      await get().loadWorkspaces();
+      set({ error: message });
+    }
   },
 
   toggleCollapsed: (id) => {

--- a/apps/desktop/src/types/electron-workspace.d.ts
+++ b/apps/desktop/src/types/electron-workspace.d.ts
@@ -49,6 +49,8 @@ export interface SeroWorkspaceAPI {
   open(id: string): Promise<void>;
   /** Remove workspace from registry. Re-add via addFolder to restore. */
   close(id: string): Promise<void>;
+  /** Delete a workspace: unregister AND permanently erase its folder from disk. Destructive. */
+  delete(id: string): Promise<void>;
   /** Open native folder picker. Returns selected path or null. */
   pickFolder(): Promise<string | null>;
   /** Infer best workspace for a message. Returns workspace ID. */

--- a/apps/desktop/src/types/ipc-channels-workspace.ts
+++ b/apps/desktop/src/types/ipc-channels-workspace.ts
@@ -8,6 +8,8 @@ export const workspaceIpcChannels = {
   open: 'sero:workspace:open',
   /** Close workspace in sidebar (persisted). */
   close: 'sero:workspace:close',
+  /** Delete workspace: unregister AND permanently remove its folder from disk. Destructive. */
+  delete: 'sero:workspace:delete',
   /** Open native folder picker dialog. Returns path or null. */
   pickFolder: 'sero:workspace:pick-folder',
   /** Infer best workspace for a given message. Returns workspace ID. */

--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -64,6 +64,7 @@ Both behaviours are on by default and can be turned off in Graphify's settings.
 - Your code is read **once** during the initial build, using your own provider credentials — nothing is sent to Sero.
 - Routine updates (file structure and AST changes) run with no LLM calls.
 - Graph files are stored locally at `~/.sero/apps/graphify/` and never inside your repos.
+- Turning a workspace **off** keeps its graph so re-enabling is instant. **Deleting** the workspace removes its graph automatically — no manual cleanup, no leftover files.
 - Container sessions only need read access to the graph directory — your code stays inside its container.
 
 If something goes wrong: check workspace toggle state in the Graphify panel, confirm your provider credentials are set, then restart Sero. Collect redacted logs only — do not include API keys, workspace paths, or private code content in support reports.

--- a/packages/common/src/workspace-ignores.ts
+++ b/packages/common/src/workspace-ignores.ts
@@ -10,6 +10,7 @@ export const WORKSPACE_COMMON_IGNORES = [
   'node_modules/',
   'dist/',
   'build/',
+  'out/',
   '.DS_Store',
   '*.log',
   '.env',

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -13,7 +13,7 @@ import { Type } from 'typebox';
 
 import { resolveGraphifyPaths, workspaceGraphJson } from '../shared/paths';
 import { readStateFile, appendIndexRequest } from '../shared/state-io';
-import { loadGraph, queryGraph, searchGraph, findPath, explainNode } from '../shared/query-engine';
+import { loadGraphResult, queryGraph, findPath, explainNode, type GraphLoadFailure } from '../shared/query-engine';
 import { resolveCurrentWorkspace } from './current-workspace';
 import { registerAutoContext } from './auto-context';
 import { registerRefreshOnEdit } from './refresh-on-edit';
@@ -29,6 +29,18 @@ function text(message: string): ToolResult {
 
 const NOT_BUILT = 'Profile graph not built yet. Enable workspace indexing in the Graphify panel or run: graphify_index enable-all';
 
+/** Turn a load failure into a message that names the real problem, not a generic "not built". */
+function unavailableMessage(failure: GraphLoadFailure, detail?: string): string {
+  switch (failure) {
+    case 'too-large':
+      return `Profile graph is built but too large to load (${detail}). Disable or remove some workspaces in the Graphify panel to shrink it.`;
+    case 'invalid':
+      return `Profile graph could not be read (${detail}). Rebuild it from the Graphify panel.`;
+    case 'absent':
+      return NOT_BUILT;
+  }
+}
+
 export default function graphifyExtension(pi: ExtensionAPI): void {
   const paths = resolveGraphifyPaths();
 
@@ -42,12 +54,9 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       budget: Type.Optional(Type.Number({ description: 'Max answer tokens (default 1200)' })),
     }),
     async execute(_toolCallId, params) {
-      const graph = await loadGraph(paths.profileGraph);
-      if (!graph) return text(NOT_BUILT);
-      const { text: answer, files } = searchGraph(graph, params.question, { mode: params.mode, budget: params.budget });
-      // `files` rides on `details` (UI-only) so the search panel can open them;
-      // the agent still sees the identical text in `content`.
-      return { content: [{ type: 'text', text: answer }], details: { files } };
+      const result = await loadGraphResult(paths.profileGraph);
+      if (!('graph' in result)) return text(unavailableMessage(result.failure, result.detail));
+      return text(queryGraph(result.graph, params.question, { mode: params.mode, budget: params.budget }));
     },
   });
 
@@ -64,9 +73,12 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       const state = await readStateFile(paths.stateFile);
       const entry = state && ctx ? resolveCurrentWorkspace(state, ctx.cwd) : null;
       const graphPath = entry ? workspaceGraphJson(paths, entry.workspaceId) : paths.profileGraph;
-      const graph = (await loadGraph(graphPath)) ?? (await loadGraph(paths.profileGraph));
-      if (!graph) return text('No graph available for this workspace yet. Enable indexing in the Graphify panel.');
-      return text(queryGraph(graph, params.question, { mode: params.mode, budget: params.budget }));
+      const primary = await loadGraphResult(graphPath);
+      if ('graph' in primary) return text(queryGraph(primary.graph, params.question, { mode: params.mode, budget: params.budget }));
+      // Fall back to the profile graph when the workspace has no graph of its own.
+      const fallback = graphPath === paths.profileGraph ? primary : await loadGraphResult(paths.profileGraph);
+      if ('graph' in fallback) return text(queryGraph(fallback.graph, params.question, { mode: params.mode, budget: params.budget }));
+      return text(unavailableMessage(fallback.failure, fallback.detail));
     },
   });
 
@@ -79,9 +91,9 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       to: Type.String({ description: 'Target concept name or node id' }),
     }),
     async execute(_toolCallId, params) {
-      const graph = await loadGraph(paths.profileGraph);
-      if (!graph) return text(NOT_BUILT);
-      return text(findPath(graph, params.from, params.to));
+      const result = await loadGraphResult(paths.profileGraph);
+      if (!('graph' in result)) return text(unavailableMessage(result.failure, result.detail));
+      return text(findPath(result.graph, params.from, params.to));
     },
   });
 
@@ -93,9 +105,9 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       concept: Type.String({ description: 'Concept name or node id to explain' }),
     }),
     async execute(_toolCallId, params) {
-      const graph = await loadGraph(paths.profileGraph);
-      if (!graph) return text(NOT_BUILT);
-      return text(explainNode(graph, params.concept));
+      const result = await loadGraphResult(paths.profileGraph);
+      if (!('graph' in result)) return text(unavailableMessage(result.failure, result.detail));
+      return text(explainNode(result.graph, params.concept));
     },
   });
 

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -13,7 +13,7 @@ import { Type } from 'typebox';
 
 import { resolveGraphifyPaths, workspaceGraphJson } from '../shared/paths';
 import { readStateFile, appendIndexRequest } from '../shared/state-io';
-import { loadGraphResult, queryGraph, findPath, explainNode, type GraphLoadFailure } from '../shared/query-engine';
+import { loadGraphResult, queryGraph, searchGraph, findPath, explainNode, type GraphLoadFailure } from '../shared/query-engine';
 import { resolveCurrentWorkspace } from './current-workspace';
 import { registerAutoContext } from './auto-context';
 import { registerRefreshOnEdit } from './refresh-on-edit';
@@ -56,7 +56,10 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
     async execute(_toolCallId, params) {
       const result = await loadGraphResult(paths.profileGraph);
       if (!('graph' in result)) return text(unavailableMessage(result.failure, result.detail));
-      return text(queryGraph(result.graph, params.question, { mode: params.mode, budget: params.budget }));
+      const { text: answer, files } = searchGraph(result.graph, params.question, { mode: params.mode, budget: params.budget });
+      // `files` rides on `details` (UI-only) so the search panel can open them;
+      // the agent still sees the identical text in `content`.
+      return { content: [{ type: 'text', text: answer }], details: { files } };
     },
   });
 
@@ -75,8 +78,13 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       const graphPath = entry ? workspaceGraphJson(paths, entry.workspaceId) : paths.profileGraph;
       const primary = await loadGraphResult(graphPath);
       if ('graph' in primary) return text(queryGraph(primary.graph, params.question, { mode: params.mode, budget: params.budget }));
-      // Fall back to the profile graph when the workspace has no graph of its own.
-      const fallback = graphPath === paths.profileGraph ? primary : await loadGraphResult(paths.profileGraph);
+      // Fall back to the profile graph only when the workspace simply has no graph
+      // of its own. A built-but-unreadable workspace graph (too-large/invalid)
+      // reports its real reason instead of a misleading "not built yet".
+      if (primary.failure !== 'absent' || graphPath === paths.profileGraph) {
+        return text(unavailableMessage(primary.failure, primary.detail));
+      }
+      const fallback = await loadGraphResult(paths.profileGraph);
       if ('graph' in fallback) return text(queryGraph(fallback.graph, params.question, { mode: params.mode, budget: params.budget }));
       return text(unavailableMessage(fallback.failure, fallback.detail));
     },

--- a/plugins/sero-graphify-plugin/runtime/host-adapter.ts
+++ b/plugins/sero-graphify-plugin/runtime/host-adapter.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { readdir, rm } from 'node:fs/promises';
 import type { AppRuntimeContext } from '@sero-ai/common';
 import type { GraphifyState } from '../shared/types';
 import { DEFAULT_STATE } from '../shared/types';
@@ -110,6 +111,12 @@ export function createIndexerHost(ctx: AppRuntimeContext): { host: IndexerHost; 
       await runMerge(await localDeps(), workspaceIds.map((id) => workspaceGraphJson(paths, id)), paths.profileGraph);
       const merged = await loadGraph(paths.profileGraph);
       return { nodes: merged?.nodes.size ?? 0, edges: merged?.edgeCount ?? 0 };
+    },
+    removeWorkspaceArtifacts: (workspaceId) =>
+      rm(workspaceGraphDir(paths, workspaceId), { recursive: true, force: true }),
+    listArtifactWorkspaceIds: async () => {
+      const entries = await readdir(paths.graphsDir, { withFileTypes: true }).catch(() => []);
+      return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
     },
     log: (message) => console.log(message),
   };

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -18,6 +18,8 @@ function makeHost(overrides: Partial<IndexerHost> = {}, seed?: (state: GraphifyS
     buildGraph: vi.fn().mockResolvedValue(STATS),
     updateGraph: vi.fn().mockResolvedValue(STATS),
     mergeProfileGraph: vi.fn().mockResolvedValue({ nodes: 20, edges: 40 }),
+    removeWorkspaceArtifacts: vi.fn().mockResolvedValue(undefined),
+    listArtifactWorkspaceIds: vi.fn().mockResolvedValue([]),
     log: () => {},
     ...overrides,
   };
@@ -255,6 +257,19 @@ describe('GraphifyIndexer', () => {
     await indexer.syncWorkspaces();
     expect(getState().workspaces.ws1).toBeUndefined();
     expect(getState().profileGraph.status).toBe('absent'); // no indexed workspaces left
+    expect(host.removeWorkspaceArtifacts).toHaveBeenCalledWith('ws1'); // artifacts cleaned up too
+    indexer.dispose();
+  });
+
+  it('sweeps orphaned artifacts on start but keeps live (incl. disabled) workspaces', async () => {
+    // ws1/ws2 are live; 'ws-gone' only has artifacts on disk (deleted workspace).
+    const { host } = makeHost({ listArtifactWorkspaceIds: vi.fn().mockResolvedValue(['ws1', 'ws2', 'ws-gone']) });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.idle();
+    expect(host.removeWorkspaceArtifacts).toHaveBeenCalledWith('ws-gone');
+    expect(host.removeWorkspaceArtifacts).not.toHaveBeenCalledWith('ws1');
+    expect(host.removeWorkspaceArtifacts).not.toHaveBeenCalledWith('ws2');
     indexer.dispose();
   });
 

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -128,7 +128,8 @@ export class GraphifyIndexer {
     });
     // A removed workspace's per-workspace graph is now an orphan — delete it so
     // disk tracks the live workspace list (disable keeps artifacts; removal does not).
-    for (const id of removedIds) await this.host.removeWorkspaceArtifacts(id);
+    // Removals are independent, so run them together.
+    await Promise.all(removedIds.map((id) => this.host.removeWorkspaceArtifacts(id)));
     // A deleted workspace that was part of the profile graph leaves stale
     // nodes behind until the next merge — re-merge promptly.
     if (removedIndexed) await this.merge();
@@ -143,12 +144,11 @@ export class GraphifyIndexer {
    */
   private async sweepOrphanArtifacts(): Promise<void> {
     const live = new Set((await this.host.listWorkspaces()).map((ws) => ws.id));
-    for (const id of await this.host.listArtifactWorkspaceIds()) {
-      if (!live.has(id)) {
-        this.host.log(`[graphify] removing orphaned graph artifacts for ${id}`);
-        await this.host.removeWorkspaceArtifacts(id);
-      }
-    }
+    const orphans = (await this.host.listArtifactWorkspaceIds()).filter((id) => !live.has(id));
+    await Promise.all(orphans.map((id) => {
+      this.host.log(`[graphify] removing orphaned graph artifacts for ${id}`);
+      return this.host.removeWorkspaceArtifacts(id);
+    }));
   }
 
   private async applyRequest(request: IndexRequest): Promise<void> {

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -16,6 +16,10 @@ export interface IndexerHost {
   buildGraph(workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings'], onProgress?: (message: string) => void): Promise<WorkspaceIndexStats>;
   updateGraph(workspace: { workspaceId: string; path: string }, settings: GraphifyState['settings'], onProgress?: (message: string) => void): Promise<WorkspaceIndexStats>;
   mergeProfileGraph(workspaceIds: string[]): Promise<{ nodes: number; edges: number }>;
+  /** Delete a workspace's on-disk graph artifacts (idempotent — no-op if absent). */
+  removeWorkspaceArtifacts(workspaceId: string): Promise<void>;
+  /** Ids of every workspace that has graph artifacts on disk. */
+  listArtifactWorkspaceIds(): Promise<string[]>;
   log(message: string): void;
 }
 
@@ -44,6 +48,9 @@ export class GraphifyIndexer {
     // the catch-up decisions need.
     const before = await this.host.readState();
     await this.syncWorkspaces({ normalizeStatuses: true });
+    // Reclaim disk left by workspaces deleted while Sero was closed (or by
+    // older builds that never cleaned up after themselves).
+    await this.sweepOrphanArtifacts();
 
     // Boot catch-up: interrupted full builds restart full; everything else
     // enabled gets one cheap AST-only update to absorb changes made while
@@ -102,9 +109,8 @@ export class GraphifyIndexer {
       });
     if (unchanged) return;
 
-    const removedIndexed = Object.values(current).some(
-      (entry) => entry.enabled && entry.lastBuiltAt && !workspaces.some((ws) => ws.id === entry.workspaceId),
-    );
+    const removedIds = Object.keys(current).filter((id) => !workspaces.some((ws) => ws.id === id));
+    const removedIndexed = removedIds.some((id) => current[id]?.enabled && current[id]?.lastBuiltAt);
 
     await this.host.updateState((raw) => {
       const state = raw ?? structuredClone(DEFAULT_STATE);
@@ -120,9 +126,29 @@ export class GraphifyIndexer {
       }
       return next;
     });
+    // A removed workspace's per-workspace graph is now an orphan — delete it so
+    // disk tracks the live workspace list (disable keeps artifacts; removal does not).
+    for (const id of removedIds) await this.host.removeWorkspaceArtifacts(id);
     // A deleted workspace that was part of the profile graph leaves stale
     // nodes behind until the next merge — re-merge promptly.
     if (removedIndexed) await this.merge();
+  }
+
+  /**
+   * Delete graph artifacts whose workspace no longer exists in the profile.
+   * Reactive removal (above) handles workspaces that vanish while running;
+   * this catches artifacts already orphaned on disk at boot. Disabled-but-present
+   * workspaces are safe: listWorkspaces() still returns them, so they are never
+   * mistaken for orphans.
+   */
+  private async sweepOrphanArtifacts(): Promise<void> {
+    const live = new Set((await this.host.listWorkspaces()).map((ws) => ws.id));
+    for (const id of await this.host.listArtifactWorkspaceIds()) {
+      if (!live.has(id)) {
+        this.host.log(`[graphify] removing orphaned graph artifacts for ${id}`);
+        await this.host.removeWorkspaceArtifacts(id);
+      }
+    }
   }
 
   private async applyRequest(request: IndexRequest): Promise<void> {

--- a/plugins/sero-graphify-plugin/shared/query-engine/graph-loader.test.ts
+++ b/plugins/sero-graphify-plugin/shared/query-engine/graph-loader.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import path from 'node:path';
-import { loadGraph } from './graph-loader';
+import { loadGraph, loadGraphResult } from './graph-loader';
 
 const FIXTURE = path.join(__dirname, 'fixtures', 'small-graph.json');
 
@@ -18,5 +18,17 @@ describe('loadGraph', () => {
   it('returns null for missing, oversized, or malformed files', async () => {
     expect(await loadGraph('/nonexistent/graph.json')).toBeNull();
     expect(await loadGraph(FIXTURE, 10)).toBeNull(); // 10-byte cap
+  });
+});
+
+describe('loadGraphResult', () => {
+  it('reports the real failure reason instead of a bare null', async () => {
+    expect(await loadGraphResult('/nonexistent/graph.json')).toEqual({ failure: 'absent' });
+
+    const tooLarge = await loadGraphResult(FIXTURE, 10);
+    expect(tooLarge).toMatchObject({ failure: 'too-large' });
+
+    const ok = await loadGraphResult(FIXTURE);
+    expect('graph' in ok && ok.graph.nodes.size).toBe(6);
   });
 });

--- a/plugins/sero-graphify-plugin/shared/query-engine/graph-loader.ts
+++ b/plugins/sero-graphify-plugin/shared/query-engine/graph-loader.ts
@@ -26,7 +26,21 @@ export interface KnowledgeGraph {
   edgeCount: number;
 }
 
-export const MAX_GRAPH_BYTES = 64 * 1024 * 1024;
+/**
+ * Upper bound on a graph.json we will read into memory. Merged profile graphs
+ * grow with every indexed workspace, so this must comfortably exceed a
+ * multi-workspace merge — 64 MB was hit in practice by three monorepo-sized
+ * workspaces. Reducing the number of indexed workspaces is the real lever;
+ * this cap only guards against loading something pathologically large.
+ */
+export const MAX_GRAPH_BYTES = 256 * 1024 * 1024;
+
+/** Why a graph could not be loaded — lets callers explain the real reason. */
+export type GraphLoadFailure = 'absent' | 'too-large' | 'invalid';
+
+export type GraphLoadResult =
+  | { graph: KnowledgeGraph }
+  | { failure: GraphLoadFailure; detail?: string };
 
 function endpointId(value: unknown): string | null {
   if (typeof value === 'string') return value;
@@ -37,26 +51,34 @@ function endpointId(value: unknown): string | null {
   return null;
 }
 
-/** Load a graphify graph.json (networkx node-link). Returns null on any problem — callers treat that as "no graph". */
-export async function loadGraph(filePath: string, maxBytes = MAX_GRAPH_BYTES): Promise<KnowledgeGraph | null> {
+const MB = 1024 * 1024;
+
+/**
+ * Load a graphify graph.json (networkx node-link), reporting *why* it could not
+ * be loaded so callers can distinguish "never built" from "built but too large
+ * / corrupt" — the difference between a useful message and a misleading one.
+ */
+export async function loadGraphResult(filePath: string, maxBytes = MAX_GRAPH_BYTES): Promise<GraphLoadResult> {
   let raw: string;
   try {
     const info = await stat(filePath);
-    if (info.size > maxBytes) return null;
+    if (info.size > maxBytes) {
+      return { failure: 'too-large', detail: `${Math.round(info.size / MB)} MB exceeds the ${Math.round(maxBytes / MB)} MB load limit` };
+    }
     raw = await readFile(filePath, 'utf8');
   } catch {
-    return null;
+    return { failure: 'absent' };
   }
 
   let data: { nodes?: unknown; links?: unknown; edges?: unknown };
   try {
     data = JSON.parse(raw);
   } catch {
-    return null;
+    return { failure: 'invalid', detail: 'file is not valid JSON' };
   }
 
   const rawLinks = Array.isArray(data?.links) ? data.links : Array.isArray(data?.edges) ? data.edges : null;
-  if (!Array.isArray(data?.nodes) || !rawLinks) return null;
+  if (!Array.isArray(data?.nodes) || !rawLinks) return { failure: 'invalid', detail: 'missing nodes/links arrays' };
 
   const graph: KnowledgeGraph = { nodes: new Map(), out: new Map(), in: new Map(), edgeCount: 0 };
 
@@ -79,5 +101,11 @@ export async function loadGraph(filePath: string, maxBytes = MAX_GRAPH_BYTES): P
     graph.edgeCount += 1;
   }
 
-  return graph;
+  return { graph };
+}
+
+/** Convenience wrapper: the loaded graph, or null on any problem. */
+export async function loadGraph(filePath: string, maxBytes = MAX_GRAPH_BYTES): Promise<KnowledgeGraph | null> {
+  const result = await loadGraphResult(filePath, maxBytes);
+  return 'graph' in result ? result.graph : null;
 }

--- a/plugins/sero-graphify-plugin/shared/query-engine/index.ts
+++ b/plugins/sero-graphify-plugin/shared/query-engine/index.ts
@@ -7,8 +7,8 @@ function nameResolver(graph: KnowledgeGraph): (id: string) => string {
   return (id) => displayName(graph.nodes.get(id), id);
 }
 
-export { loadGraph, MAX_GRAPH_BYTES } from './graph-loader';
-export type { KnowledgeGraph, GraphNode, GraphEdge } from './graph-loader';
+export { loadGraph, loadGraphResult, MAX_GRAPH_BYTES } from './graph-loader';
+export type { KnowledgeGraph, GraphNode, GraphEdge, GraphLoadFailure, GraphLoadResult } from './graph-loader';
 
 /** Authoritative structural counts straight from a loaded graph. */
 export function graphStats(graph: KnowledgeGraph): { nodes: number; edges: number; communities: number } {


### PR DESCRIPTION
## Summary

Two related pieces of workspace hygiene, split into one commit each.

### 1. Delete workspaces from the sidebar (`feat(workspace)`)
Previously the only way to remove a workspace was **Close**, which unregisters it but leaves the folder (and its graph index) on disk — so stale multi-GB clones piled up with no way to remove them from the app.

- The sidebar **−** now opens a **Close / Delete** menu instead of closing immediately.
  - **Close** — unregister, keep files (unchanged behaviour).
  - **Delete** — permanently erase the folder, behind a second confirmation that shows the exact path.
- **Reliability** (this is what makes a big/busy workspace actually delete):
  - Dispose the workspace's **plugin app-runtimes** *and* workspace runtime before erasing. A live app-runtime (e.g. orchestrator) keeps a cwd/state-watcher inside the workspace, which blocks removal of `node_modules` (`ENOTEMPTY`). Bounded by a timeout so a stuck runtime can't hang the delete.
  - Unregister first, then `fs.rm` with retries; app-runtime reconcile runs in the background.
  - A deleted workspace disappears from the sidebar **immediately** — it never lingers as a hung "Deleting…" entry; the erase finishes in the background and only surfaces an error if files remain.
  - Guard against deleting the filesystem root, home, or the Sero home.
- Extracted config/editor-state I/O to `workspace-io.ts` to keep `manager.ts` under the file-size budget.

### 2. Graphify index cleanup + large-graph loading (`fix(graphify)`)
Surfaced while investigating why profile-wide graph search reported "not built yet" despite everything being indexed.

- Raise the graph-loader cap 64MB → 256MB so merged multi-workspace profile graphs load instead of silently failing.
- `loadGraphResult` distinguishes *absent / too-large / invalid* so search reports the real reason instead of a misleading "not built yet".
- Auto-delete a workspace's on-disk graph artifacts when it leaves the profile (reactive) + a boot-time orphan sweep to reclaim past leftovers. Disabling a workspace still keeps its artifacts for instant re-enable.
- Add `out/` to `WORKSPACE_COMMON_IGNORES` (electron build output).

## Testing
- `pnpm typecheck` — 22/22 packages clean.
- Desktop workspace/app-runtime/store suites — 462 pass, incl. new tests for `manager.delete` (managed + external + ordering-guarantee when `fs.rm` fails) and `appRuntimeManager.disposeWorkspace`.
- Graphify plugin suite — 116 pass, incl. new orphan-sweep, reactive-delete and `loadGraphResult` failure-reason tests.
- Manually verified against a real 68MB profile graph and by deleting multi-GB workspace clones.

> Note: independent of #270 (only the graphify docs page overlaps, auto-merged). Based on `main`.