### PR TITLE
fix(sessions): keep generated titles concise

### DIFF
--- a/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
+++ b/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
@@ -80,14 +80,23 @@ describe('CLI prompt block', () => {
     expect(prompt).toContain('app click');
   });
 
-  it('instructs the agent to create a concise title once', () => {
+  it('instructs the agent to create a concise title once when enabled', () => {
     const registry = new CliRegistry();
-    const prompt = buildCliPromptBlock(registry);
+    const prompt = buildCliPromptBlock(registry, undefined, {
+      includeSessionTitleInstruction: true,
+    });
 
     expect(prompt).toContain('sero set-title --if-unnamed');
     expect(prompt).toContain('2-6 words');
     expect(prompt).toContain('at most 48 characters');
     expect(prompt).toContain('Never use the full prompt or a sentence');
+  });
+
+  it('omits the title instruction for subagents and extensions', () => {
+    const registry = new CliRegistry();
+    const prompt = buildCliPromptBlock(registry);
+
+    expect(prompt).not.toContain('sero set-title --if-unnamed');
   });
 
   it('excludes hidden commands and help from the listing', () => {

--- a/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
+++ b/apps/desktop/electron/__tests__/cli/prompt-block.test.ts
@@ -80,6 +80,16 @@ describe('CLI prompt block', () => {
     expect(prompt).toContain('app click');
   });
 
+  it('instructs the agent to create a concise title once', () => {
+    const registry = new CliRegistry();
+    const prompt = buildCliPromptBlock(registry);
+
+    expect(prompt).toContain('sero set-title --if-unnamed');
+    expect(prompt).toContain('2-6 words');
+    expect(prompt).toContain('at most 48 characters');
+    expect(prompt).toContain('Never use the full prompt or a sentence');
+  });
+
   it('excludes hidden commands and help from the listing', () => {
     const registry = new CliRegistry();
     const execute = async () => ({ output: 'ok', exitCode: 0 });

--- a/apps/desktop/electron/__tests__/cli/session-title.test.ts
+++ b/apps/desktop/electron/__tests__/cli/session-title.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentSession } from '@earendil-works/pi-coding-agent';
+
+import { registerSessionCliCommands } from '@electron/cli/commands/agent';
+import { installCliSessionBridge } from '@electron/cli/bridges/session-bridge';
+import { CliRegistry } from '@electron/cli/core/registry';
+import type { CliCommandContext } from '@electron/cli/core/types';
+
+const setSessionTitle = vi.fn();
+let sessionName: string | undefined;
+
+const context = {
+  invocation: { sessionId: 'session-1' },
+} as CliCommandContext;
+
+async function runSetTitle(...args: string[]) {
+  const registry = new CliRegistry();
+  registerSessionCliCommands(registry);
+  const resolved = registry.resolveTokens(['set-title', ...args]);
+  return registry.executeResolved(resolved, resolved.args, context);
+}
+
+describe('set-title CLI command', () => {
+  beforeEach(() => {
+    sessionName = undefined;
+    setSessionTitle.mockReset();
+    installCliSessionBridge({
+      getSessionEntry: () => ({
+        sessionId: 'session-1',
+        workspaceId: 'workspace-1',
+        session: { sessionName } as AgentSession,
+      }),
+      getActiveSessionForWorkspace: () => undefined,
+      getActiveTurnId: () => null,
+      noteTurnStart: () => {},
+      noteTurnEnd: () => {},
+      consumeTurnBudget: () => ({ allowed: true, count: 1, limit: 50 }),
+      setSessionTitle,
+    });
+  });
+
+  it('sets a title only when the session is unnamed', async () => {
+    const result = await runSetTitle('--if-unnamed', 'Fix', 'session', 'titles');
+
+    expect(result.exitCode).toBe(0);
+    expect(setSessionTitle).toHaveBeenCalledWith('session-1', 'Fix session titles');
+  });
+
+  it('keeps an existing title when requested', async () => {
+    sessionName = 'Existing title';
+    const result = await runSetTitle('--if-unnamed', 'Replacement');
+
+    expect(result.output).toBe('Session already has a title');
+    expect(setSessionTitle).not.toHaveBeenCalled();
+  });
+
+  it('rejects titles longer than 48 characters', async () => {
+    const result = await runSetTitle('x'.repeat(49));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain('48 characters or fewer');
+    expect(setSessionTitle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/__tests__/cli/session-title.test.ts
+++ b/apps/desktop/electron/__tests__/cli/session-title.test.ts
@@ -54,11 +54,25 @@ describe('set-title CLI command', () => {
     expect(setSessionTitle).not.toHaveBeenCalled();
   });
 
-  it('rejects titles longer than 48 characters', async () => {
-    const result = await runSetTitle('x'.repeat(49));
+  it('truncates titles longer than 48 characters', async () => {
+    const result = await runSetTitle('x'.repeat(60));
 
-    expect(result.exitCode).toBe(1);
-    expect(result.output).toContain('48 characters or fewer');
+    expect(result.exitCode).toBe(0);
+    expect(setSessionTitle).toHaveBeenCalledWith('session-1', 'x'.repeat(48));
+  });
+
+  it('accepts --if-unnamed after the title text', async () => {
+    const result = await runSetTitle('Fix', 'session', 'titles', '--if-unnamed');
+
+    expect(result.exitCode).toBe(0);
+    expect(setSessionTitle).toHaveBeenCalledWith('session-1', 'Fix session titles');
+  });
+
+  it('honours --if-unnamed after the title when a title exists', async () => {
+    sessionName = 'Existing title';
+    const result = await runSetTitle('Replacement', '--if-unnamed');
+
+    expect(result.output).toBe('Session already has a title');
     expect(setSessionTitle).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/electron/cli/commands/agent/session.ts
+++ b/apps/desktop/electron/cli/commands/agent/session.ts
@@ -41,12 +41,15 @@ async function handleSession(args: string[], ctx: CliCommandContext) {
 }
 
 async function handleSetTitle(args: string[], ctx: CliCommandContext) {
-  const ifUnnamed = args[0] === '--if-unnamed';
-  const title = (ifUnnamed ? args.slice(1) : args).join(' ').trim();
-  if (!title) return fail('Usage: sero set-title [--if-unnamed] <text>');
-  if (title.length > MAX_SESSION_TITLE_LENGTH) {
-    return fail(`Session titles must be ${MAX_SESSION_TITLE_LENGTH} characters or fewer`);
-  }
+  const ifUnnamed = args.includes('--if-unnamed');
+  const rawTitle = args.filter((arg) => arg !== '--if-unnamed').join(' ').trim();
+  if (!rawTitle) return fail('Usage: sero set-title [--if-unnamed] <text>');
+  // Truncate rather than reject: an over-length title is hidden from the chat,
+  // so failing here would leave the session silently untitled.
+  const title =
+    rawTitle.length > MAX_SESSION_TITLE_LENGTH
+      ? rawTitle.slice(0, MAX_SESSION_TITLE_LENGTH).trimEnd()
+      : rawTitle;
 
   const sessionId = ctx.invocation.sessionId;
   if (!sessionId) return fail('set-title requires an active agent session');

--- a/apps/desktop/electron/cli/commands/agent/session.ts
+++ b/apps/desktop/electron/cli/commands/agent/session.ts
@@ -4,6 +4,8 @@ import type { CliRegistry } from '@electron/cli/core/registry';
 import type { CliCommandContext } from '@electron/cli/core/types';
 import { fail, ok } from '@electron/cli/lib/utils';
 
+const MAX_SESSION_TITLE_LENGTH = 48;
+
 async function handleSession(args: string[], ctx: CliCommandContext) {
   const [action = 'info'] = args;
   if (action !== 'info') return fail('Usage: sero session info');
@@ -39,13 +41,23 @@ async function handleSession(args: string[], ctx: CliCommandContext) {
 }
 
 async function handleSetTitle(args: string[], ctx: CliCommandContext) {
-  const title = args.join(' ').trim();
-  if (!title) return fail('Usage: sero set-title <text>');
+  const ifUnnamed = args[0] === '--if-unnamed';
+  const title = (ifUnnamed ? args.slice(1) : args).join(' ').trim();
+  if (!title) return fail('Usage: sero set-title [--if-unnamed] <text>');
+  if (title.length > MAX_SESSION_TITLE_LENGTH) {
+    return fail(`Session titles must be ${MAX_SESSION_TITLE_LENGTH} characters or fewer`);
+  }
+
   const sessionId = ctx.invocation.sessionId;
   if (!sessionId) return fail('set-title requires an active agent session');
 
   try {
-    getCliSessionBridge().setSessionTitle(sessionId, title);
+    const bridge = getCliSessionBridge();
+    if (ifUnnamed && bridge.getSessionEntry(sessionId)?.session.sessionName) {
+      return ok('Session already has a title');
+    }
+
+    bridge.setSessionTitle(sessionId, title);
     return ok(`Session titled: ${title}`);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to set title';
@@ -65,8 +77,8 @@ export function registerSessionCliCommands(registry: CliRegistry): void {
 
   registry.register({
     name: 'set-title',
-    summary: 'Set the current session title',
-    help: 'set-title — Set session title\n\nUsage: sero set-title <text>\n',
+    summary: 'Set a short session title',
+    help: 'set-title — Set a short session title (maximum 48 characters)\n\nUsage: sero set-title [--if-unnamed] <text>\n',
     source: 'builtin',
     group: 'Builtin',
     execute: handleSetTitle,

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -266,6 +266,7 @@ export function bridgeExtensionTools(
 export function buildCliPromptBlock(
   reg: CliRegistry = getCliRegistry(),
   scope?: { workspaceId?: string; sessionId?: string | null },
+  options?: { includeSessionTitleInstruction?: boolean },
 ): string {
   const commands = reg.list(scope).filter((c) => !c.hidden && c.name !== 'help');
 
@@ -287,6 +288,16 @@ export function buildCliPromptBlock(
       return `${group}:\n${lines.join('\n')}`;
     });
 
+  // Only primary user sessions get a title — subagents and extensions run in
+  // their own ephemeral sessions that are never shown, so titling them just
+  // wastes a turn.
+  const sessionTitleBlock = options?.includeSessionTitleInstruction
+    ? `
+On the first turn of a session, set its title once with \`sero set-title --if-unnamed "<title>"\` as its own separate command (never combined with other actions, or it will show in the chat).
+Summarize the user's goal in 2-6 words and at most 48 characters. Never use the full prompt or a sentence. Do not change the title later unless the user asks.
+`
+    : '';
+
   return `
 
 ## Sero CLI
@@ -297,10 +308,7 @@ ${sections.join('\n')}
 
 Run \`sero help <command>\` for details. Chain multiple commands (one per line).
 **Before calling any command that takes JSON parameters (e.g. \`question\`, \`questionnaire\`, \`interview\`), run \`sero help <command>\` first to check the exact schema.**
-
-On the first turn of a session, set its title once with \`sero set-title --if-unnamed "<title>"\`.
-Summarize the user's goal in 2-6 words and at most 48 characters. Never use the full prompt or a sentence. Do not change the title later unless the user asks.
-
+${sessionTitleBlock}
 For \`sero app\`, skip help for common flows.
 - Screenshot apps directly: \`sero app screenshot --app "<name or id>" [--save <path>]\`
 - Names resolve too (\`Calculator\` → \`calc\`); use \`sero app list\` only if ambiguous.

--- a/apps/desktop/electron/cli/index.ts
+++ b/apps/desktop/electron/cli/index.ts
@@ -298,6 +298,9 @@ ${sections.join('\n')}
 Run \`sero help <command>\` for details. Chain multiple commands (one per line).
 **Before calling any command that takes JSON parameters (e.g. \`question\`, \`questionnaire\`, \`interview\`), run \`sero help <command>\` first to check the exact schema.**
 
+On the first turn of a session, set its title once with \`sero set-title --if-unnamed "<title>"\`.
+Summarize the user's goal in 2-6 words and at most 48 characters. Never use the full prompt or a sentence. Do not change the title later unless the user asks.
+
 For \`sero app\`, skip help for common flows.
 - Screenshot apps directly: \`sero app screenshot --app "<name or id>" [--save <path>]\`
 - Names resolve too (\`Calculator\` → \`calc\`); use \`sero app list\` only if ambiguous.

--- a/apps/desktop/electron/features/apps/extensions/create-sero-extension.ts
+++ b/apps/desktop/electron/features/apps/extensions/create-sero-extension.ts
@@ -57,10 +57,14 @@ export function createSeroExtensionFactory(
 
     pi.on('before_agent_start', async (event) => {
       let systemPrompt = event.systemPrompt;
-      systemPrompt += buildCliPromptBlock(undefined, {
-        workspaceId: currentWorkspaceId,
-        sessionId: _sessionId,
-      });
+      systemPrompt += buildCliPromptBlock(
+        undefined,
+        {
+          workspaceId: currentWorkspaceId,
+          sessionId: _sessionId,
+        },
+        { includeSessionTitleInstruction: true },
+      );
 
       // Inject container environment context if workspace is containerised
       if (containerState) {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -84,6 +84,7 @@
     "@playwright/test": "^1.59.1",
     "@remixicon/react": "^4.9.0",
     "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",
+    "@sero-ai/plugin-vite": "workspace:*",
     "@sero-ai/ui": "workspace:*",
     "@streamdown/code": "^1.1.0",
     "@streamdown/math": "^1.0.2",

--- a/apps/desktop/src/components/layout/ToolCallGroup.test.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.test.tsx
@@ -239,6 +239,17 @@ describe('groupMessages', () => {
     expect(items[0]?.kind).toBe('tool-group');
   });
 
+  it('still shows an explicit user-requested rename', () => {
+    const items = groupMessages([
+      makeTool({
+        input: { command: 'sero set-title "Renamed by user"' },
+      }),
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.kind).toBe('tool-group');
+  });
+
   it('merges tool calls across finalized thinking-only assistant messages', () => {
     const items = groupMessages([
       makeTool({ id: 'tool-a', toolCallId: 'call-a', toolName: 'read' }),

--- a/apps/desktop/src/components/layout/ToolCallGroup.test.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.test.tsx
@@ -211,6 +211,34 @@ describe('ToolCallGroup image previews', () => {
 });
 
 describe('groupMessages', () => {
+  it('hides session title tool calls from the chat', () => {
+    const items = groupMessages([
+      makeTool({
+        id: 'title-tool',
+        toolCallId: 'title-call',
+        input: { command: 'sero set-title --if-unnamed "Fix session titles"' },
+      }),
+      makeAssistant({ id: 'assistant-response', text: 'Done.' }),
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: 'message',
+      message: { id: 'assistant-response' },
+    });
+  });
+
+  it('still shows sero-cli calls that batch title and other actions', () => {
+    const items = groupMessages([
+      makeTool({
+        input: { command: 'sero set-title "Session title"\nsero workspace info' },
+      }),
+    ]);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.kind).toBe('tool-group');
+  });
+
   it('merges tool calls across finalized thinking-only assistant messages', () => {
     const items = groupMessages([
       makeTool({ id: 'tool-a', toolCallId: 'call-a', toolName: 'read' }),

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -39,7 +39,12 @@ function isSessionTitleToolCall(tool: ChatToolCallMessage): boolean {
     .filter(Boolean);
   if (commands.length !== 1) return false;
 
-  return /^(?:sero\s+)?set-title(?:\s|$)/.test(commands[0]);
+  const command = commands[0];
+  if (!/^(?:sero\s+)?set-title(?:\s|$)/.test(command)) return false;
+
+  // Only the automatic first-turn title carries --if-unnamed. An explicit
+  // user-requested rename omits it and stays visible so the user sees it land.
+  return /(?:^|\s)--if-unnamed(?:\s|$)/.test(command);
 }
 
 // ── Grouping utility ────────────────────────────────────────────

--- a/apps/desktop/src/components/layout/ToolCallGroup.tsx
+++ b/apps/desktop/src/components/layout/ToolCallGroup.tsx
@@ -29,6 +29,19 @@ function isStreamingThinkingOnlyAssistantMessage(message: ChatMessage): boolean 
   );
 }
 
+function isSessionTitleToolCall(tool: ChatToolCallMessage): boolean {
+  if (tool.toolName === 'set_session_title') return true;
+  if (tool.toolName !== 'sero-cli' || typeof tool.input.command !== 'string') return false;
+
+  const commands = tool.input.command
+    .split('\n')
+    .map((command) => command.trim())
+    .filter(Boolean);
+  if (commands.length !== 1) return false;
+
+  return /^(?:sero\s+)?set-title(?:\s|$)/.test(commands[0]);
+}
+
 // ── Grouping utility ────────────────────────────────────────────
 
 /**
@@ -64,6 +77,8 @@ export function groupMessages(
     const msg = messages[i];
 
     if (msg.type === 'tool') {
+      // Session titles are background chat metadata, not meaningful agent work.
+      if (isSessionTitleToolCall(msg)) continue;
       toolBuffer.push(msg);
       continue;
     }

--- a/apps/docs-site/docs/reference/sero-cli.md
+++ b/apps/docs-site/docs/reference/sero-cli.md
@@ -143,7 +143,7 @@ Tabs are workspace-owned and loaded lazily through the browser panel. Explicit t
 | Command | Output / side effects |
 |---|---|
 | `sero session info` | Workspace, session id/name, model/provider, thinking level, tokens, cost, request count, streaming state, active turn. |
-| `sero set-title <text>` | Sets the current agent session title. |
+| `sero set-title [--if-unnamed] <text>` | Sets a session title of up to 48 characters. `--if-unnamed` keeps an existing title. |
 
 ## `appstate`
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,6 +220,9 @@ importers:
       '@sero-ai/app-runtime':
         specifier: workspace:@sero-ai/app-runtime@*
         version: link:../../packages/app-runtime
+      '@sero-ai/plugin-vite':
+        specifier: workspace:*
+        version: link:../../packages/plugin-vite
       '@sero-ai/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -306,7 +309,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       zustand:
         specifier: ^5.0.11
         version: 5.0.12(@types/react@19.2.14)(immer@11.1.11)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -426,7 +429,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/app-runtime:
     dependencies:
@@ -473,7 +476,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/plugin-vite:
     dependencies:
@@ -498,7 +501,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/ui:
     dependencies:
@@ -728,7 +731,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-cron-plugin:
     dependencies:
@@ -798,7 +801,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-git-plugin:
     dependencies:
@@ -868,7 +871,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-graphify-plugin:
     dependencies:
@@ -938,7 +941,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-mcp-plugin:
     dependencies:
@@ -1017,7 +1020,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-memory-plugin:
     dependencies:
@@ -1130,7 +1133,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-usage-plugin:
     dependencies:
@@ -1200,7 +1203,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-user-feedback-plugin:
     dependencies:
@@ -1267,7 +1270,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
   plugins/sero-web-plugin:
     dependencies:
@@ -1358,7 +1361,7 @@ importers:
         version: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -28744,10 +28747,10 @@ snapshots:
     optionalDependencies:
       vite: 7.3.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@7.3.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -28764,7 +28767,7 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -28773,7 +28776,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0(supports-color@7.2.0))(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(jsdom@26.1.0)(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(msw@2.12.10(@types/node@22.19.15)(typescript@5.9.3))(vite@6.4.2(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))


### PR DESCRIPTION
## Summary
- instruct the agent to create a short 2–6 word title on the first session turn
- add `--if-unnamed` so generated titles do not overwrite existing titles
- enforce a 48-character limit for titles set through the Sero CLI
- hide standalone session-title tool calls from the chat panel
- document and test the updated session-title behavior

## Testing
- `pnpm typecheck`
- `pnpm --filter @sero/desktop exec vitest run electron/__tests__/cli/prompt-block.test.ts electron/__tests__/cli/session-title.test.ts`
- `pnpm --filter @sero/desktop exec vitest run electron/__tests__/agent/token-baseline.test.ts`
- `pnpm --filter @sero/desktop exec vitest run src/components/layout/ToolCallGroup.test.tsx`
- `npx react-doctor@latest --verbose --scope changed` (83/100; two existing non-component export warnings in `ToolCallGroup.tsx`)
