### PR TITLE
feat(explorer): rebuild diff view on @pierre/diffs and @pierre/trees

### DIFF
--- a/apps/desktop/electron/features/vcs/core/vcs-ops.ts
+++ b/apps/desktop/electron/features/vcs/core/vcs-ops.ts
@@ -36,6 +36,10 @@ import type {
   SyncResult,
   WorkingCopyStatus,
 } from '@sero-ai/common';
+import { WORKING_TREE_REV } from '@sero-ai/common';
+
+/** git's well-known empty tree object — the base every root commit diffs against. */
+const EMPTY_TREE_REV = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
 export class VcsOps {
   constructor(private readonly runner: GitRunner) {}
@@ -68,13 +72,53 @@ export class VcsOps {
     from: string,
     to?: string,
   ): Promise<FileDiffEntry[]> {
-    const args = to
-      ? ['diff', '--name-status', `${from}..${to}`]
-      : ['diff', '--name-status', from];
+    const fromRev = await this.resolveDiffBase(workspaceId, from);
+    if (to && to !== WORKING_TREE_REV) {
+      const result = await this.runner.run(workspaceId, ['diff', '--name-status', `${fromRev}..${to}`]);
+      if (result.exitCode !== 0) throw new Error(result.stderr || 'Failed to get diff summary');
+      return parseDiffSummary(result.stdout);
+    }
+    return this.getWorkingTreeDiffSummary(workspaceId, fromRev);
+  }
 
-    const result = await this.runner.run(workspaceId, args);
-    if (result.exitCode !== 0) throw new Error(result.stderr || 'Failed to get diff summary');
-    return parseDiffSummary(result.stdout);
+  /**
+   * Diff a commit against the working tree. `git diff <rev>` alone misses
+   * untracked files, so merge them in from `git status` (`-uall` expands
+   * untracked directories into their files).
+   */
+  private async getWorkingTreeDiffSummary(
+    workspaceId: string,
+    fromRev: string,
+  ): Promise<FileDiffEntry[]> {
+    const [diff, status] = await Promise.all([
+      this.runner.run(workspaceId, ['diff', '--name-status', fromRev]),
+      this.runner.run(workspaceId, ['status', '--porcelain', '-uall']),
+    ]);
+    if (diff.exitCode !== 0) throw new Error(diff.stderr || 'Failed to get diff summary');
+    if (status.exitCode !== 0) throw new Error(status.stderr || 'Failed to get status');
+
+    const entries = parseDiffSummary(diff.stdout);
+    const seen = new Set(entries.map((entry) => entry.path));
+    for (const file of parseStatus(status.stdout).files) {
+      if (seen.has(file.path)) continue;
+      entries.push({ path: file.path, status: file.status, oldPath: file.oldPath });
+    }
+    return entries;
+  }
+
+  /**
+   * Resolve the base revision of a diff. A root commit has no parent, so
+   * `<rev>^` doesn't resolve — fall back to git's empty tree, which diffs
+   * the first commit as all-added.
+   */
+  private async resolveDiffBase(workspaceId: string, rev: string): Promise<string> {
+    const result = await this.runner.run(workspaceId, [
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      `${rev}^{commit}`,
+    ]);
+    return result.exitCode === 0 ? rev : EMPTY_TREE_REV;
   }
 
   async getFileContent(

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -82,6 +82,7 @@
     "@module-federation/vite": "catalog:",
     "@monaco-editor/react": "^4.7.0",
     "@pierre/diffs": "1.2.12",
+    "@pierre/trees": "1.0.0-beta.5",
     "@playwright/test": "^1.59.1",
     "@remixicon/react": "^4.9.0",
     "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -81,6 +81,7 @@
     "@module-federation/enhanced": "2.2.2",
     "@module-federation/vite": "catalog:",
     "@monaco-editor/react": "^4.7.0",
+    "@pierre/diffs": "1.2.12",
     "@playwright/test": "^1.59.1",
     "@remixicon/react": "^4.9.0",
     "@sero-ai/app-runtime": "workspace:@sero-ai/app-runtime@*",

--- a/apps/desktop/src/components/apps/explorer/editor/DiffChangeset.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffChangeset.tsx
@@ -1,0 +1,130 @@
+/**
+ * DiffChangeset — whole-changeset diff viewer built on @pierre/diffs CodeView.
+ *
+ * Loads each file's old/new contents over IPC in small batches and appends
+ * them to the CodeView as they arrive, so the first files paint while the
+ * rest of a large changeset is still loading.
+ */
+
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import { parseDiffFromFile } from '@pierre/diffs';
+import type { CodeViewItem, CodeViewOptions } from '@pierre/diffs';
+import { CodeView, type CodeViewHandle } from '@pierre/diffs/react';
+import type { FileDiffEntry } from '@sero-ai/common';
+import { resolveDiffThemes } from './diff-themes';
+import './diff-view.css';
+
+/** Files fetched per batch — bounds concurrent IPC/VCS calls. */
+const LOAD_BATCH_SIZE = 8;
+
+export type DiffStyle = 'split' | 'unified';
+
+export interface DiffChangesetHandle {
+  scrollToFile(path: string): void;
+}
+
+interface Props {
+  workspaceId: string;
+  fromRev: string;
+  toRev: string;
+  files: FileDiffEntry[];
+  diffStyle: DiffStyle;
+  editorThemeId: string;
+  themeType: 'light' | 'dark';
+  /** Scroll to this file once its diff has been added. */
+  initialPath?: string;
+}
+
+export const DiffChangeset = forwardRef<DiffChangesetHandle, Props>(
+  function DiffChangeset(
+    { workspaceId, fromRev, toRev, files, diffStyle, editorThemeId, themeType, initialPath },
+    ref,
+  ) {
+    const codeViewRef = useRef<CodeViewHandle<undefined>>(null);
+    const pendingScrollRef = useRef<string | null>(initialPath ?? null);
+
+    const options = useMemo<CodeViewOptions<undefined>>(
+      () => ({
+        theme: resolveDiffThemes(editorThemeId),
+        themeType,
+        diffStyle,
+        lineDiffType: 'word-alt',
+        stickyHeaders: true,
+      }),
+      [editorThemeId, themeType, diffStyle],
+    );
+
+    useImperativeHandle(
+      ref,
+      () => ({
+        scrollToFile(path: string) {
+          codeViewRef.current?.scrollTo({ type: 'item', id: path, align: 'start' });
+        },
+      }),
+      [],
+    );
+
+    // Mounted once per changeset — DiffTab keys this component on
+    // workspaceId/fromRev/toRev, so this effect only runs for a new changeset.
+    useEffect(() => {
+      let cancelled = false;
+
+      async function loadFile(entry: FileDiffEntry): Promise<CodeViewItem> {
+        const oldPath = entry.oldPath ?? entry.path;
+        const [oldContents, newContents] = await Promise.all([
+          entry.status === 'added'
+            ? ''
+            : window.sero.vcs.fileContent(workspaceId, fromRev, oldPath).catch(() => ''),
+          entry.status === 'deleted'
+            ? ''
+            : window.sero.vcs.fileContent(workspaceId, toRev, entry.path).catch(() => ''),
+        ]);
+        try {
+          return {
+            id: entry.path,
+            type: 'diff',
+            fileDiff: parseDiffFromFile(
+              { name: oldPath, contents: oldContents },
+              { name: entry.path, contents: newContents },
+            ),
+          };
+        } catch {
+          // Pairs the diff parser rejects (e.g. identical contents on a pure
+          // rename) fall back to rendering the file contents directly.
+          return {
+            id: entry.path,
+            type: 'file',
+            file: { name: entry.path, contents: newContents || oldContents },
+          };
+        }
+      }
+
+      (async () => {
+        for (let i = 0; i < files.length; i += LOAD_BATCH_SIZE) {
+          const batch = files.slice(i, i + LOAD_BATCH_SIZE);
+          const items = await Promise.all(batch.map(loadFile));
+          if (cancelled) return;
+          codeViewRef.current?.addItems(items);
+
+          const target = pendingScrollRef.current;
+          if (target != null && batch.some((entry) => entry.path === target)) {
+            pendingScrollRef.current = null;
+            codeViewRef.current?.scrollTo({ type: 'item', id: target, align: 'start' });
+          }
+        }
+      })();
+
+      return () => {
+        cancelled = true;
+      };
+    }, [workspaceId, fromRev, toRev, files]);
+
+    return (
+      <CodeView
+        ref={codeViewRef}
+        className="diff-changeset h-full overflow-auto"
+        options={options}
+      />
+    );
+  },
+);

--- a/apps/desktop/src/components/apps/explorer/editor/DiffChangeset.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffChangeset.tsx
@@ -11,6 +11,7 @@ import { parseDiffFromFile } from '@pierre/diffs';
 import type { CodeViewItem, CodeViewOptions } from '@pierre/diffs';
 import { CodeView, type CodeViewHandle } from '@pierre/diffs/react';
 import type { FileDiffEntry } from '@sero-ai/common';
+import { WORKING_TREE_REV } from '@sero-ai/common';
 import { resolveDiffThemes } from './diff-themes';
 import './diff-view.css';
 
@@ -69,15 +70,17 @@ export const DiffChangeset = forwardRef<DiffChangesetHandle, Props>(
     useEffect(() => {
       let cancelled = false;
 
+      function readAtRev(rev: string, path: string): Promise<string> {
+        return rev === WORKING_TREE_REV
+          ? window.sero.editor.readFile(workspaceId, path).catch(() => '')
+          : window.sero.vcs.fileContent(workspaceId, rev, path).catch(() => '');
+      }
+
       async function loadFile(entry: FileDiffEntry): Promise<CodeViewItem> {
         const oldPath = entry.oldPath ?? entry.path;
         const [oldContents, newContents] = await Promise.all([
-          entry.status === 'added'
-            ? ''
-            : window.sero.vcs.fileContent(workspaceId, fromRev, oldPath).catch(() => ''),
-          entry.status === 'deleted'
-            ? ''
-            : window.sero.vcs.fileContent(workspaceId, toRev, entry.path).catch(() => ''),
+          entry.status === 'added' ? '' : readAtRev(fromRev, oldPath),
+          entry.status === 'deleted' ? '' : readAtRev(toRev, entry.path),
         ]);
         try {
           return {

--- a/apps/desktop/src/components/apps/explorer/editor/DiffFileNavigator.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffFileNavigator.tsx
@@ -1,0 +1,52 @@
+/**
+ * DiffFileNavigator — changed-files tree for the diff view, built on
+ * @pierre/trees. Every changed file shows a git-status lane; selecting a
+ * file (click or keyboard) scrolls the changeset to it. Built-in search
+ * filters the tree.
+ */
+
+import { FileTree, useFileTree } from '@pierre/trees/react';
+import type { GitStatusEntry } from '@pierre/trees';
+import type { FileDiffEntry, FileStatus } from '@sero-ai/common';
+import './diff-view.css';
+
+interface Props {
+  files: FileDiffEntry[];
+  /** Selected initially and scrolled into view. */
+  initialPath?: string;
+  /**
+   * Called with the file path when the selection changes. Captured once at
+   * model creation — pass a stable callback.
+   */
+  onSelectFile: (path: string) => void;
+}
+
+function toGitStatus(status: FileStatus): GitStatusEntry['status'] {
+  switch (status) {
+    case 'added':
+    case 'copied':
+      return 'added';
+    case 'deleted':
+      return 'deleted';
+    case 'renamed':
+      return 'renamed';
+    default:
+      return 'modified';
+  }
+}
+
+export function DiffFileNavigator({ files, initialPath, onSelectFile }: Props) {
+  const { model } = useFileTree({
+    paths: files.map((f) => f.path),
+    initialExpansion: 'open',
+    initialSelectedPaths: initialPath ? [initialPath] : undefined,
+    search: true,
+    gitStatus: files.map((f): GitStatusEntry => ({ path: f.path, status: toGitStatus(f.status) })),
+    onSelectionChange: (selectedPaths) => {
+      const path = selectedPaths[0];
+      if (path) onSelectFile(path);
+    },
+  });
+
+  return <FileTree model={model} className="diff-file-navigator block h-full" />;
+}

--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -5,15 +5,14 @@
  * The sidebar lists changed files; clicking one scrolls the changeset to it.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { FileText, Columns2, Rows2, Loader2 } from 'lucide-react';
-import { cn } from '@sero-ai/ui/lib/utils';
 import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
 import type { FileDiffEntry } from '@sero-ai/common';
-import { statusCode, statusColor, basename } from '@/components/apps/explorer/vcs/vcs-utils';
 import { DiffChangeset, type DiffChangesetHandle, type DiffStyle } from './DiffChangeset';
+import { DiffFileNavigator } from './DiffFileNavigator';
 
 export interface DiffTabState {
   type: 'diff';
@@ -33,7 +32,6 @@ export function DiffTab({ state }: Props) {
   const editorThemeId = useAppStore((s) => s.editorThemeId);
 
   const [files, setFiles] = useState<FileDiffEntry[] | null>(null);
-  const [activePath, setActivePath] = useState<string | null>(initialPath ?? null);
   const [diffStyle, setDiffStyle] = useState<DiffStyle>('split');
   const [navOpen, setNavOpen] = useState(true);
   const changesetRef = useRef<DiffChangesetHandle>(null);
@@ -49,10 +47,10 @@ export function DiffTab({ state }: Props) {
     return () => { cancelled = true; };
   }, [workspaceId, fromRev, toRev]);
 
-  const selectFile = (path: string) => {
-    setActivePath(path);
+  // Stable — DiffFileNavigator captures this once at tree-model creation.
+  const selectFile = useCallback((path: string) => {
     changesetRef.current?.scrollToFile(path);
-  };
+  }, []);
 
   if (files === null) {
     return (
@@ -98,31 +96,15 @@ export function DiffTab({ state }: Props) {
               animate={{ x: 0, opacity: 1 }}
               exit={{ x: -16, opacity: 0 }}
               transition={{ duration: 0.15 }}
-              className="w-[180px] shrink-0 overflow-hidden border-r border-[var(--border-subtle)]"
+              className="w-[220px] shrink-0 overflow-hidden border-r border-[var(--border-subtle)]"
             >
-              <div className="h-full w-[180px] overflow-y-auto py-1">
-                {files.map((f) => (
-                  <button type="button"
-                    key={f.path}
-                    onClick={() => selectFile(f.path)}
-                    className={cn(
-                      'flex w-full items-center gap-1.5 px-2 py-0.5 text-left',
-                      'transition-colors duration-75',
-                      'hover:bg-[var(--bg-elevated)]/60',
-                      activePath === f.path && 'bg-[var(--bg-elevated)]',
-                    )}
-                  >
-                    <span className={cn('w-3 shrink-0 text-center text-sm font-bold', statusColor(f.status))}>
-                      {statusCode(f.status)}
-                    </span>
-                    <span className={cn(
-                      'min-w-0 truncate text-sm',
-                      activePath === f.path ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]',
-                    )}>
-                      {basename(f.path)}
-                    </span>
-                  </button>
-                ))}
+              <div className="h-full w-[220px] py-1">
+                <DiffFileNavigator
+                  key={`${workspaceId}:${fromRev}:${toRev}`}
+                  files={files}
+                  initialPath={initialPath}
+                  onSelectFile={selectFile}
+                />
               </div>
             </motion.div>
           )}

--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -1,37 +1,19 @@
 /**
- * DiffTab, Monaco DiffEditor for comparing file contents between revisions.
+ * DiffTab — revision-to-revision changeset viewer built on @pierre/diffs.
  *
- * Renders a side-by-side (or inline) diff view with full syntax highlighting,
- * char-level diff decorations, and minimap.
- *
- * The DiffEditor is keyed on `activePath` so React fully unmounts/remounts it
- * on file switch, this avoids Monaco's "TextModel got disposed before
- * DiffEditorWidget model got reset" error that happens when swapping models
- * on a live widget.
+ * Shows every changed file in one scrollable view with sticky file headers.
+ * The sidebar lists changed files; clicking one scrolls the changeset to it.
  */
 
-import { lazy, useEffect, useState, useCallback, useRef } from 'react';
-import type { RefObject } from 'react';
-import type { editor as MonacoEditor } from 'monaco-editor';
+import { useEffect, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
-import {
-  FileText,
-  Columns2,
-  Rows2,
-  Loader2,
-} from 'lucide-react';
+import { FileText, Columns2, Rows2, Loader2 } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
-import { registerCustomEditorThemes, resolveMonacoThemeName } from './monaco-themes';
-import { EditorSuspense } from './EditorSuspense';
 import type { FileDiffEntry } from '@sero-ai/common';
-import { statusCode, statusColor, basename, langFromPath } from '@/components/apps/explorer/vcs/vcs-utils';
-
-const DiffEditor = lazy(async () => {
-  const { DiffEditor: MonacoDiffEditor } = await import('@monaco-editor/react');
-  return { default: MonacoDiffEditor };
-});
+import { statusCode, statusColor, basename } from '@/components/apps/explorer/vcs/vcs-utils';
+import { DiffChangeset, type DiffChangesetHandle, type DiffStyle } from './DiffChangeset';
 
 export interface DiffTabState {
   type: 'diff';
@@ -49,33 +31,30 @@ export function DiffTab({ state }: Props) {
   const { workspaceId, fromRev, toRev, initialPath } = state;
   const effectiveMode = useThemeStore((s) => s.effectiveMode);
   const editorThemeId = useAppStore((s) => s.editorThemeId);
-  const monacoThemeName = resolveMonacoThemeName(editorThemeId, effectiveMode);
 
-  const [files, setFiles] = useState<FileDiffEntry[]>([]);
+  const [files, setFiles] = useState<FileDiffEntry[] | null>(null);
   const [activePath, setActivePath] = useState<string | null>(initialPath ?? null);
-  const [loading, setLoading] = useState(true);
-  const [sideBySide, setSideBySide] = useState(true);
+  const [diffStyle, setDiffStyle] = useState<DiffStyle>('split');
   const [navOpen, setNavOpen] = useState(true);
+  const changesetRef = useRef<DiffChangesetHandle>(null);
 
-  // Load file list
+  // Load the changed-file list for the revision pair.
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
+    setFiles(null);
     window.sero.vcs
       .fileDiffSummary(workspaceId, fromRev, toRev)
-      .then((f) => {
-        if (cancelled) return;
-        setFiles(f);
-        setActivePath((currentPath) => currentPath ?? f[0]?.path ?? null);
-        setLoading(false);
-      })
-      .catch(() => { if (!cancelled) setLoading(false); });
+      .then((f) => { if (!cancelled) setFiles(f); })
+      .catch(() => { if (!cancelled) setFiles([]); });
     return () => { cancelled = true; };
   }, [workspaceId, fromRev, toRev]);
 
-  const language = activePath ? langFromPath(activePath) : 'plaintext';
+  const selectFile = (path: string) => {
+    setActivePath(path);
+    changesetRef.current?.scrollToFile(path);
+  };
 
-  if (loading) {
+  if (files === null) {
     return (
       <div className="flex h-full items-center justify-center bg-[var(--bg-base)]">
         <Loader2 className="size-5 animate-spin text-[var(--text-muted)]" />
@@ -95,24 +74,23 @@ export function DiffTab({ state }: Props) {
           <FileText className="size-3.5" />
         </button>
         <span className="text-sm text-[var(--text-muted)]">
-          {activePath ? basename(activePath) : 'No files'}
+          {files.length === 1 ? '1 file changed' : `${files.length} files changed`}
         </span>
         <span className="text-sm text-[var(--text-muted)]/40">
           {fromRev.slice(0, 8)} → {toRev.slice(0, 8)}
         </span>
         <span className="flex-1" />
         <button type="button"
-          onClick={() => setSideBySide((v) => !v)}
-          title={sideBySide ? 'Inline diff' : 'Side-by-side diff'}
+          onClick={() => setDiffStyle((v) => (v === 'split' ? 'unified' : 'split'))}
+          title={diffStyle === 'split' ? 'Unified diff' : 'Side-by-side diff'}
           className="text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
         >
-          {sideBySide ? <Rows2 className="size-3.5" /> : <Columns2 className="size-3.5" />}
+          {diffStyle === 'split' ? <Rows2 className="size-3.5" /> : <Columns2 className="size-3.5" />}
         </button>
       </div>
 
-      {/* ── Body: file nav + diff editor ──────────────────── */}
+      {/* ── Body: file nav + changeset ────────────────────── */}
       <div className="flex min-h-0 flex-1">
-        {/* File navigator */}
         <AnimatePresence>
           {navOpen && files.length > 1 && (
             <motion.div
@@ -126,7 +104,7 @@ export function DiffTab({ state }: Props) {
                 {files.map((f) => (
                   <button type="button"
                     key={f.path}
-                    onClick={() => setActivePath(f.path)}
+                    onClick={() => selectFile(f.path)}
                     className={cn(
                       'flex w-full items-center gap-1.5 px-2 py-0.5 text-left',
                       'transition-colors duration-75',
@@ -150,18 +128,19 @@ export function DiffTab({ state }: Props) {
           )}
         </AnimatePresence>
 
-        {/* Keyed DiffEditor, remounts cleanly per file */}
         <div className="min-w-0 flex-1">
-          {activePath ? (
-            <DiffFileView
-              key={activePath}
+          {files.length > 0 ? (
+            <DiffChangeset
+              key={`${workspaceId}:${fromRev}:${toRev}`}
+              ref={changesetRef}
               workspaceId={workspaceId}
               fromRev={fromRev}
               toRev={toRev}
-              path={activePath}
-              language={language}
-              theme={monacoThemeName}
-              sideBySide={sideBySide}
+              files={files}
+              diffStyle={diffStyle}
+              editorThemeId={editorThemeId}
+              themeType={effectiveMode}
+              initialPath={initialPath}
             />
           ) : (
             <div className="flex h-full items-center justify-center">
@@ -172,104 +151,4 @@ export function DiffTab({ state }: Props) {
       </div>
     </div>
   );
-}
-
-// ── Per-file diff viewer (keyed, owns its own content loading) ──
-
-function DiffFileView({
-  workspaceId,
-  fromRev,
-  toRev,
-  path,
-  language,
-  theme,
-  sideBySide,
-}: {
-  workspaceId: string;
-  fromRev: string;
-  toRev: string;
-  path: string;
-  language: string;
-  theme: string;
-  sideBySide: boolean;
-}) {
-  const [left, setLeft] = useState<string | null>(null);
-  const [right, setRight] = useState<string | null>(null);
-  const modelRefs = useRef<{
-    original: MonacoEditor.ITextModel | null;
-    modified: MonacoEditor.ITextModel | null;
-  }>({ original: null, modified: null });
-
-  useEffect(() => {
-    let cancelled = false;
-    Promise.all([
-      window.sero.vcs.fileContent(workspaceId, fromRev, path).catch(() => ''),
-      window.sero.vcs.fileContent(workspaceId, toRev, path).catch(() => ''),
-    ]).then(([l, r]) => {
-      if (!cancelled) { setLeft(l); setRight(r); }
-    });
-    return () => { cancelled = true; };
-  }, [workspaceId, fromRev, toRev, path]);
-
-  useEffect(() => {
-    return () => {
-      disposeDiffModels(modelRefs);
-    };
-  }, []);
-
-  const handleDiffMount = useCallback((editor: MonacoEditor.IStandaloneDiffEditor) => {
-    const model = editor.getModel();
-    modelRefs.current = {
-      original: model?.original ?? null,
-      modified: model?.modified ?? null,
-    };
-  }, []);
-
-  if (left === null || right === null) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <Loader2 className="size-4 animate-spin text-[var(--text-muted)]" />
-      </div>
-    );
-  }
-
-  return (
-    <EditorSuspense>
-      <DiffEditor
-        original={left}
-        modified={right}
-        language={language}
-        theme={theme}
-        beforeMount={registerCustomEditorThemes}
-        onMount={handleDiffMount}
-        keepCurrentOriginalModel
-        keepCurrentModifiedModel
-        options={{
-          readOnly: true,
-          renderSideBySide: sideBySide,
-          minimap: { enabled: true },
-          scrollBeyondLastLine: false,
-          fontSize: 12,
-          lineNumbers: 'on',
-          renderOverviewRuler: true,
-          diffWordWrap: 'on',
-        }}
-      />
-    </EditorSuspense>
-  );
-}
-
-function disposeDiffModels(refs: RefObject<{
-  original: MonacoEditor.ITextModel | null;
-  modified: MonacoEditor.ITextModel | null;
-}>) {
-  const { original, modified } = refs.current;
-  refs.current = { original: null, modified: null };
-  if (!original && !modified) return;
-
-  // Defer model disposal until after DiffEditor has fully unmounted.
-  setTimeout(() => {
-    try { original?.dispose(); } catch {}
-    try { modified?.dispose(); } catch {}
-  }, 0);
 }

--- a/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx
@@ -11,8 +11,13 @@ import { FileText, Columns2, Rows2, Loader2 } from 'lucide-react';
 import { useAppStore } from '@/stores/app';
 import { useThemeStore } from '@/stores/theme';
 import type { FileDiffEntry } from '@sero-ai/common';
+import { WORKING_TREE_REV } from '@sero-ai/common';
 import { DiffChangeset, type DiffChangesetHandle, type DiffStyle } from './DiffChangeset';
 import { DiffFileNavigator } from './DiffFileNavigator';
+
+function revLabel(rev: string): string {
+  return rev === WORKING_TREE_REV ? 'working tree' : rev.slice(0, 8);
+}
 
 export interface DiffTabState {
   type: 'diff';
@@ -75,7 +80,7 @@ export function DiffTab({ state }: Props) {
           {files.length === 1 ? '1 file changed' : `${files.length} files changed`}
         </span>
         <span className="text-sm text-[var(--text-muted)]/40">
-          {fromRev.slice(0, 8)} → {toRev.slice(0, 8)}
+          {revLabel(fromRev)} → {revLabel(toRev)}
         </span>
         <span className="flex-1" />
         <button type="button"

--- a/apps/desktop/src/components/apps/explorer/editor/EditorSuspense.tsx
+++ b/apps/desktop/src/components/apps/explorer/editor/EditorSuspense.tsx
@@ -1,7 +1,7 @@
 /**
  * EditorSuspense, shared boundary for lazily-loaded Monaco editors.
  *
- * Wraps a lazy Editor/DiffEditor in a spinner fallback plus an error boundary
+ * Wraps a lazy Editor in a spinner fallback plus an error boundary
  * so a chunk-load failure or Monaco render error stays contained to the editor
  * pane (and auto-recovers stale chunks) instead of blanking the whole app.
  */

--- a/apps/desktop/src/components/apps/explorer/editor/diff-themes.ts
+++ b/apps/desktop/src/components/apps/explorer/editor/diff-themes.ts
@@ -1,0 +1,16 @@
+/**
+ * Theme bridge between Sero's editor theme picker and @pierre/diffs.
+ *
+ * Diff code colors come from shiki themes (same mapping as markdown code
+ * blocks); diff chrome (fonts, spacing) is aligned to the app's design
+ * tokens via `--diffs-*` CSS variables in diff-view.css.
+ */
+
+import type { ThemesType } from '@pierre/diffs';
+import { resolveShikiThemePair } from './monaco-themes';
+
+/** Shiki theme pair for the diff view, derived from the editor theme id. */
+export function resolveDiffThemes(editorThemeId: string): ThemesType {
+  const { light, dark } = resolveShikiThemePair(editorThemeId);
+  return { light, dark };
+}

--- a/apps/desktop/src/components/apps/explorer/editor/diff-view.css
+++ b/apps/desktop/src/components/apps/explorer/editor/diff-view.css
@@ -8,3 +8,24 @@
   --diffs-tab-size: 4;
   --diffs-header-font-family: var(--font-sans);
 }
+
+/* Changed-files tree (@pierre/trees) — documented `--trees-*-override` vars. */
+.diff-file-navigator {
+  --trees-bg-override: transparent;
+  --trees-fg-override: var(--text-secondary);
+  --trees-fg-muted-override: var(--text-muted);
+  --trees-selected-bg-override: var(--bg-elevated);
+  --trees-selected-fg-override: var(--text-primary);
+  --trees-accent-override: var(--status-info);
+  --trees-border-color-override: var(--border-subtle);
+  --trees-input-bg-override: var(--bg-elevated);
+  --trees-font-family-override: var(--font-sans);
+  --trees-git-added-color-override: var(--status-success);
+  --trees-git-modified-color-override: var(--status-warning);
+  --trees-git-deleted-color-override: var(--status-error);
+  --trees-git-renamed-color-override: var(--status-info);
+  --trees-status-added-override: var(--status-success);
+  --trees-status-modified-override: var(--status-warning);
+  --trees-status-deleted-override: var(--status-error);
+  --trees-status-renamed-override: var(--status-info);
+}

--- a/apps/desktop/src/components/apps/explorer/editor/diff-view.css
+++ b/apps/desktop/src/components/apps/explorer/editor/diff-view.css
@@ -1,0 +1,10 @@
+/* Diff view (@pierre/diffs) chrome alignment with app design tokens.
+   Only documented `--diffs-*` custom properties — no unsafeCSS. */
+
+.diff-changeset {
+  --diffs-font-family: var(--font-mono);
+  --diffs-font-size: 12px;
+  --diffs-line-height: 1.5;
+  --diffs-tab-size: 4;
+  --diffs-header-font-family: var(--font-sans);
+}

--- a/apps/desktop/src/components/apps/explorer/editor/monaco-themes.ts
+++ b/apps/desktop/src/components/apps/explorer/editor/monaco-themes.ts
@@ -340,36 +340,42 @@ export function resolveEditorThemePalette(
   };
 }
 
+/** Bundled shiki theme name (the string half of ThemeInput). */
+export type ShikiThemeName = Extract<ThemeInput, string>;
+
+export interface ShikiThemePair {
+  light: ShikiThemeName;
+  dark: ShikiThemeName;
+}
+
+/**
+ * Editor theme id → shiki theme names. Non-auto themes use the same shiki
+ * theme in both slots so code colors follow the editor theme regardless of
+ * the app's light/dark mode. Shared by markdown code blocks and the diff view.
+ */
+const SHIKI_THEME_PAIRS: Record<string, ShikiThemePair> = {
+  vs: { light: 'light-plus', dark: 'light-plus' },
+  'vs-dark': { light: 'dark-plus', dark: 'dark-plus' },
+  'hc-light': { light: 'github-light-high-contrast', dark: 'github-light-high-contrast' },
+  'hc-black': { light: 'github-dark-high-contrast', dark: 'github-dark-high-contrast' },
+  'one-dark': { light: 'one-dark-pro', dark: 'one-dark-pro' },
+  'github-light': { light: 'github-light', dark: 'github-light' },
+  'github-dark': { light: 'github-dark', dark: 'github-dark' },
+  dracula: { light: 'dracula', dark: 'dracula' },
+  monokai: { light: 'monokai', dark: 'monokai' },
+  'solarized-light': { light: 'solarized-light', dark: 'solarized-light' },
+  'solarized-dark': { light: 'solarized-dark', dark: 'solarized-dark' },
+  nord: { light: 'nord', dark: 'nord' },
+  [AUTO_EDITOR_THEME_ID]: { light: 'github-light', dark: 'github-dark' },
+};
+
+export function resolveShikiThemePair(id: string): ShikiThemePair {
+  return SHIKI_THEME_PAIRS[id] ?? SHIKI_THEME_PAIRS[AUTO_EDITOR_THEME_ID];
+}
+
 export function resolveMarkdownCodeThemes(id: string): [ThemeInput, ThemeInput] {
-  switch (id) {
-    case 'vs':
-      return ['light-plus', 'light-plus'];
-    case 'vs-dark':
-      return ['dark-plus', 'dark-plus'];
-    case 'hc-light':
-      return ['github-light-high-contrast', 'github-light-high-contrast'];
-    case 'hc-black':
-      return ['github-dark-high-contrast', 'github-dark-high-contrast'];
-    case 'one-dark':
-      return ['one-dark-pro', 'one-dark-pro'];
-    case 'github-light':
-      return ['github-light', 'github-light'];
-    case 'github-dark':
-      return ['github-dark', 'github-dark'];
-    case 'dracula':
-      return ['dracula', 'dracula'];
-    case 'monokai':
-      return ['monokai', 'monokai'];
-    case 'solarized-light':
-      return ['solarized-light', 'solarized-light'];
-    case 'solarized-dark':
-      return ['solarized-dark', 'solarized-dark'];
-    case 'nord':
-      return ['nord', 'nord'];
-    case AUTO_EDITOR_THEME_ID:
-    default:
-      return ['github-light', 'github-dark'];
-  }
+  const { light, dark } = resolveShikiThemePair(id);
+  return [light, dark];
 }
 
 /**

--- a/apps/desktop/src/components/apps/explorer/useExplorerEditorState.ts
+++ b/apps/desktop/src/components/apps/explorer/useExplorerEditorState.ts
@@ -38,6 +38,9 @@ export function useExplorerEditorState(workspaceId: string) {
   // workspace transitions don't apply stale results to the new workspace.
   useEffect(() => {
     editorReadyRef.current = false;
+    // A diff tab belongs to the workspace it was opened in — close it so it
+    // can't render another workspace's changes over this one.
+    setDiffState(null);
     let cancelled = false;
 
     (async () => {

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.test.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.test.tsx
@@ -103,7 +103,7 @@ describe('ChangeDetail', () => {
       expect(container.textContent).toContain('Failed to load changed files: boom');
     });
     expect(container.textContent).toContain('Restore checkpoint');
-    expect(fileDiffSummary).toHaveBeenCalledWith('ws-1', 'change-1');
+    expect(fileDiffSummary).toHaveBeenCalledWith('ws-1', 'change-1^', 'change-1');
     expect(warnSpy).toHaveBeenCalledWith(
       '[vcs-change-detail] Failed to load changed files:',
       expect.any(Error),

--- a/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/ChangeDetail.tsx
@@ -54,7 +54,7 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
     setLoading(true);
     setFileLoadError(null);
     void window.sero.vcs
-      .fileDiffSummary(workspaceId, entry.changeId)
+      .fileDiffSummary(workspaceId, `${entry.changeId}^`, entry.changeId)
       .then((summary) => {
         if (cancelled) return;
         setFiles(summary);
@@ -207,7 +207,7 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
               initial={{ opacity: 0, x: -3 }}
               animate={{ opacity: 1, x: 0 }}
               transition={{ duration: 0.08, delay: i * 0.02 }}
-              onClick={() => onOpenDiff?.(entry.changeId + '-', entry.changeId, f.path)}
+              onClick={() => onOpenDiff?.(`${entry.changeId}^`, entry.changeId, f.path)}
               className={cn(
                 'flex w-full items-center gap-2 rounded px-1.5 py-px text-left',
                 'transition-colors duration-75 hover:bg-[var(--bg-elevated)]',
@@ -230,7 +230,7 @@ export function ChangeDetail({ workspaceId, entry, onOpenDiff }: Props) {
         <DetailAction
           icon={<FileText className="size-3" />}
           label="Diff"
-          onClick={() => onOpenDiff?.(entry.changeId + '-', entry.changeId)}
+          onClick={() => onOpenDiff?.(`${entry.changeId}^`, entry.changeId)}
         />
         {!entry.immutable && (
           <>

--- a/apps/desktop/src/components/apps/explorer/vcs/WorkingCopySection.tsx
+++ b/apps/desktop/src/components/apps/explorer/vcs/WorkingCopySection.tsx
@@ -8,6 +8,7 @@ import { PlusCircle } from 'lucide-react';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { useVcsStore } from '@/stores/vcs';
 import type { WorkingCopyStatus } from '@sero-ai/common';
+import { WORKING_TREE_REV } from '@sero-ai/common';
 import { VcsSection } from './VcsSection';
 import { statusCode, statusColor } from './vcs-utils';
 
@@ -120,7 +121,7 @@ const WorkingCopyFileList = memo(function WorkingCopyFileList({
           transition={{ duration: 0.12, delay: index * 0.02 }}
           onClick={() => {
             if (currentChangeId && onOpenDiff) {
-              onOpenDiff(currentChangeId + '-', currentChangeId, file.path);
+              onOpenDiff(currentChangeId, WORKING_TREE_REV, file.path);
             }
           }}
           className={cn(

--- a/apps/docs-site/docs/guide/explorer-workspace.md
+++ b/apps/docs-site/docs/guide/explorer-workspace.md
@@ -89,8 +89,13 @@ Explorer's main area can show several kinds of tabs:
 - dev-server previews for known local servers
 - revision-based Git diff views
 
-The diff view is designed around comparing Git revisions and changed files. Do
-not treat it as a complete arbitrary file-comparison product.
+The diff view shows the whole changeset in one scrollable view, with sticky
+file headers and unchanged regions collapsed by default. A file tree sidebar
+lists every changed file with its Git status, and you can search the list or
+click a file to jump to it. A split/unified toggle switches how each file's
+changes are laid out. It is designed around comparing Git revisions and
+changed files — do not treat it as a complete arbitrary file-comparison
+product.
 
 The editor view is the normal path for reading and changing text files in the
 active workspace.

--- a/docs/plans/pierre-diffs-trees-migration.md
+++ b/docs/plans/pierre-diffs-trees-migration.md
@@ -1,0 +1,104 @@
+# Pierre Diffs & Trees — Migration Analysis and Plan
+
+**Date:** 2026-07-17
+**Packages evaluated:** `@pierre/diffs` v1.2.12, `@pierre/trees` v1.0.0-beta.5 (Apache-2.0, by The Pierre Computer Company)
+**Sero surfaces evaluated:** `apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx` (Monaco DiffEditor) and `apps/desktop/src/components/apps/explorer/file-tree/` (@headless-tree)
+
+## Decision summary
+
+| Surface | Verdict |
+|---|---|
+| Diff viewer (`DiffTab`) | **Migrate to `@pierre/diffs`** — clear win, low risk |
+| Diff view's changed-files navigator | **Migrate to `@pierre/trees`** — perfect fit (path list known upfront, git-status lanes built in) |
+| Explorer file tree (`FileTree`) | **Do not migrate now** — structural mismatch with lazy IPC loading; keep `@headless-tree`, revisit if upstream adds async loading |
+
+## Why migrate the diff viewer
+
+Sero's diff surface is read-only end-to-end (`options.readOnly: true`, IPC handlers are read-only queries). We pay Monaco's editor semantics for none of its editing value, and `DiffTab` carries a keyed-remount + deferred-dispose workaround for Monaco's model-disposal bug.
+
+What `@pierre/diffs` gives us that Monaco's DiffEditor doesn't:
+
+- **Whole-changeset view** (`CodeView`): every changed file in one virtualized scroll with sticky file headers, instead of the manual one-file-at-a-time navigator.
+- **Collapsed unchanged regions** with click-to-expand (100 lines per click, auto-expands small gaps).
+- **Better git-diff ergonomics**: file headers with rename/mode changes, hunk separators with line info, word-level intraline highlighting, split/unified toggle that's cheap to switch.
+- **Annotation framework**: React nodes injected at any diff line — the future seam for AI review comments and inline chat on diffs. Nothing comparable exists in our Monaco setup.
+- **Accept/reject hunk helpers** (`diffAcceptRejectHunk`) — future seam for apply/revert-hunk UX.
+- **Line selection API** — future seam for "comment on lines X–Y" and permalinks.
+
+Why it's low-risk:
+
+- **Input shape matches exactly.** `MultiFileDiff` takes `oldFile`/`newFile` content strings — precisely what `window.sero.vcs.fileContent()` returns. `PatchDiff` also accepts the raw patch text `window.sero.vcs.diff()` already produces (future chat previews).
+- **Shiki is already in our bundle** (streamdown chat markdown + `ai-elements/code-block.tsx`, `shiki ^3.23`, in-range for the package's `^3 || ^4` peer). We even already map editor themes → shiki theme names (`resolveMarkdownCodeThemes` in `monaco-themes.ts`) — the diff theme wiring reuses that mapping.
+- **Read-only by design** — matches our surface.
+- **Mature**: v1.2.12, 59 test suites, production use on pierre.co, docs at diffs.com.
+- **Monaco stays regardless** (EditorPanel is the main editor), so this is not a bundle-size play — it's a UX and capability play. The diff-only Monaco entanglement (disposal hack, `DiffEditor` lazy import) goes away.
+
+Known losses / gaps (accepted):
+
+- No minimap (low value in a diff; collapse-unchanged covers the navigation need).
+- No image/binary diffs (Monaco didn't render those either).
+- No built-in keyboard line navigation.
+- Worker pool and render cache are flagged experimental — **we skip them initially**. Default `shiki-js` engine renders plain text synchronously first, then swaps in highlights, so the main-thread path doesn't jank.
+
+## Why the changed-files navigator is the right first `@pierre/trees` adoption
+
+The diff view's file list is where trees + diffs "integrate nicely":
+
+- The path list is **fully known upfront** (`fileDiffSummary`) — no lazy-loading mismatch.
+- Built-in **git-status decorations** (added/deleted/modified/renamed lanes) replace our hand-rolled status letter + color column.
+- Selection events drive `CodeView.scrollTo` — click a file in the tree, the changeset scrolls to it.
+- Virtualized + searchable out of the box for large changesets.
+
+## Why NOT the explorer file tree (for now)
+
+`@pierre/trees` is genuinely good (virtualized, multi-select, DnD, inline rename, search, vscode-style icons, strong tests), but two structural facts disqualify it for the explorer today:
+
+1. **No lazy/async directory loading and no expand event.** The model requires the complete flat path list upfront; `onMutation` covers add/remove/move/reset only — expansion is not observable per-directory. Our explorer's core contract is IPC-on-expand (`window.sero.editor.listFiles` per directory). Emulating laziness means polling `getItem(path).isExpanded()` behind a generic `subscribe()` — an unsupported hack. Enumerating everything upfront means either walking `node_modules`/`.git` (100k+ paths over IPC per workspace) or silently hiding ignored directories from the explorer — both product regressions.
+2. **Rows are Preact inside a shadow root.** Only the header and context menu accept React nodes (via slots). Our current row customization is modest so this alone wouldn't block, but combined with (1) and the package's beta status (`1.0.0-beta.5`), the trade is bad while `@headless-tree` covers current needs.
+
+**Revisit trigger:** upstream adds an async loader or a public expand/collapse event (worth filing an issue — the mutation/batch/`resetPaths(preparedInput)` APIs are already efficient enough that an expand hook is the only missing piece).
+
+**Independent quick wins for the current explorer tree** (optional, no migration required): enable `@headless-tree`'s search feature (the shared `tree.tsx` already exposes `data-search-match`), and add git-status coloring using the data the VCS panel already has.
+
+## Migration plan
+
+### Phase 1 — Diff viewer (`@pierre/diffs`)
+
+1. **Add dependency** to `apps/desktop`: `@pierre/diffs` (pin exact; pnpm brings `diff`, `hast-util-to-html`, `lru_map`, `@pierre/theme(-ing)`, `@shikijs/transformers`; `shiki` peer already satisfied by the workspace).
+2. **Theme bridge** (new small module, e.g. `editor/diff-themes.ts`): map `editorThemeId` → `ThemesType` (`{ light, dark }` shiki theme names), reusing/extending `resolveMarkdownCodeThemes`. Pass `themeType` from `useThemeStore().effectiveMode`. Set `--diffs-*` CSS vars (font family/size, backgrounds) from our design tokens (`--bg-base`, `--text-*`, `--border-subtle`) in one stylesheet block.
+3. **Rebuild `DiffTab` body** around `CodeView`:
+   - Fetch `fileDiffSummary`, then load file pairs (`fileContent` × 2) **progressively** and append via the `CodeViewHandle.addItems` ref API — first file paints immediately, big changesets stream in.
+   - Item type `'diff'` per file, `parseDiffFromFile(oldFile, newFile)` per pair (main thread; no worker pool in phase 1).
+   - Keep the toolbar: split/unified toggle → `diffStyle` option; revision labels unchanged.
+   - Delete `DiffFileView`, `disposeDiffModels`, the Monaco disposal comment block, and the `@monaco-editor/react` `DiffEditor` lazy import.
+4. **Options baseline:** `diffStyle: 'split'` default, `lineDiffType: 'word-alt'`, collapse-unchanged on (default), sticky headers on, line selection off (phase 1).
+5. **Respect the 500-LOC rule**: the new tab splits into `DiffTab.tsx` (shell/toolbar/state), `DiffChangeset.tsx` (CodeView wiring), `diff-themes.ts`.
+6. **Verify:** `pnpm typecheck`; drive the real flow — open a diff from the VCS panel (ChangeDetail → onOpenDiff) on a multi-file change, check light/dark and each editor theme, toggle split/unified, large-file changeset, added/deleted/renamed files.
+
+### Phase 2 — Changed-files navigator (`@pierre/trees`)
+
+1. **Add dependency**: `@pierre/trees` (pin; note it brings a small `preact` runtime — render-internal only, invisible to our React tree).
+2. Replace the hand-rolled button list in the diff tab with `useFileTree` + `<FileTree>`:
+   - `paths` from `fileDiffSummary` (full list known upfront; `initialExpansion: 'open'`).
+   - `setGitStatus()` from each entry's status → built-in status lanes replace `statusCode`/`statusColor` here.
+   - `onSelectionChange` → `codeViewRef.scrollTo({ item })`.
+   - Theme via `--trees-*-override` vars from our tokens (or `themeToTreeStyles()` from the active shiki theme for consistency with the diff pane).
+3. Keep it scoped to the diff view. The explorer keeps `MultiRootFileTree` unchanged.
+4. **Verify:** navigator click scrolls to the file; status lanes match the VCS panel; keyboard nav works.
+
+### Phase 3 (optional, later) — follow-up opportunities
+
+- **Chat/tool-call diff previews:** `PatchDiff` can render `window.sero.vcs.diff()` patch text inline in sessions — a surface we currently don't have at all.
+- **Worker pool** for very large changesets once the API leaves experimental (needs `worker.format: 'es'` in vite config and a `workerFactory`).
+- **Annotations**: AI review comments / inline discussion on diff lines.
+- **Explorer tree migration**: only if upstream ships async loading (see revisit trigger above).
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| Shadow-DOM theming misses a token (odd colors in a custom theme) | Everything themeable via documented `--diffs-*` / `--trees-*` vars; `unsafeCSS` exists but is explicitly not back-compat-safe — avoid it |
+| `@pierre/trees` is beta | Confined to the diff navigator (small, easily reverted); explorer untouched |
+| Big changesets loading 2× file contents over IPC | Progressive `addItems` streaming; same data volume as today's per-file loads, just batched |
+| Second VDOM (preact) in bundle | ~4 KB, shadow-root-internal; no interaction with React 19 |
+| Docs-site | Check `apps/docs-site` for any diff-view screenshots/description to refresh before PR |

--- a/docs/specs/pierre-diff-viewer-spec.md
+++ b/docs/specs/pierre-diff-viewer-spec.md
@@ -69,7 +69,7 @@ Theming: `theme` = `{ light, dark }` shiki names derived from `editorThemeId` (r
 ### Wrap-up
 
 - [x] Check `apps/docs-site` for diff-view screenshots/descriptions; update if stale *(explorer-workspace.md updated. `docs/assets/images/explorer-diff.jpg` shows the old Monaco diff — re-capture manually once the new view is verified.)*
-- [ ] Conventional-commit PR: `feat(explorer): rebuild diff view on @pierre/diffs and @pierre/trees`
+- [x] Conventional-commit PR: `feat(explorer): rebuild diff view on @pierre/diffs and @pierre/trees` — [#279](https://github.com/sero-labs/sero/pull/279)
 
 ## Acceptance criteria
 

--- a/docs/specs/pierre-diff-viewer-spec.md
+++ b/docs/specs/pierre-diff-viewer-spec.md
@@ -68,7 +68,7 @@ Theming: `theme` = `{ light, dark }` shiki names derived from `editorThemeId` (r
 
 ### Wrap-up
 
-- [ ] Check `apps/docs-site` for diff-view screenshots/descriptions; update if stale
+- [x] Check `apps/docs-site` for diff-view screenshots/descriptions; update if stale *(explorer-workspace.md updated. `docs/assets/images/explorer-diff.jpg` shows the old Monaco diff — re-capture manually once the new view is verified.)*
 - [ ] Conventional-commit PR: `feat(explorer): rebuild diff view on @pierre/diffs and @pierre/trees`
 
 ## Acceptance criteria

--- a/docs/specs/pierre-diff-viewer-spec.md
+++ b/docs/specs/pierre-diff-viewer-spec.md
@@ -66,6 +66,14 @@ Theming: `theme` = `{ light, dark }` shiki names derived from `editorThemeId` (r
   - [ ] Toggle hide/show navigator still works
   - [x] `pnpm typecheck` green (also `vite build` + all 1711 unit tests pass)
 
+### Scope amendment (approved during verification)
+
+The "no main-process changes" assumption was wrong: every diff-open call passed
+jujutsu-style parent revisions (`rev-`) to plain git, so the diff data path had
+never worked. Fixed in `fix(vcs)`: commit diffs use `rev^..rev` (empty-tree
+fallback for root commits), working-copy diffs use the `WORKING_TREE_REV`
+sentinel (summary merges untracked files; after-side content reads from disk).
+
 ### Wrap-up
 
 - [x] Check `apps/docs-site` for diff-view screenshots/descriptions; update if stale *(explorer-workspace.md updated. `docs/assets/images/explorer-diff.jpg` shows the old Monaco diff — re-capture manually once the new view is verified.)*

--- a/docs/specs/pierre-diff-viewer-spec.md
+++ b/docs/specs/pierre-diff-viewer-spec.md
@@ -1,0 +1,80 @@
+# Spec: Diff Viewer on @pierre/diffs + @pierre/trees
+
+**Status:** Phase 1 implemented — manual verification pending
+**Branch:** `feat/pierre-diff-viewer`
+**Background:** [docs/plans/pierre-diffs-trees-migration.md](../plans/pierre-diffs-trees-migration.md) (analysis & rationale — not needed to execute this spec)
+
+## Goal
+
+Replace the Monaco-based diff tab with a diff viewer built on `@pierre/diffs`: the whole changeset in one scrollable view with sticky file headers and collapsible unchanged regions, plus a changed-files tree navigator built on `@pierre/trees` with git-status decorations and click-to-scroll.
+
+## Scope
+
+**In:**
+- Rewrite `DiffTab` on `@pierre/diffs` `CodeView` (Phase 1)
+- Replace the diff tab's file-list sidebar with a `@pierre/trees` tree (Phase 2)
+
+**Out (explicitly not in this spec):**
+- Explorer sidebar file tree — stays on `@headless-tree`, unchanged
+- Worker pool, render cache, annotations, line selection, chat diff previews
+- Any IPC / main-process changes — the existing `window.sero.vcs` API is sufficient
+
+## Current state (what gets replaced)
+
+`apps/desktop/src/components/apps/explorer/editor/DiffTab.tsx` — Monaco `DiffEditor`, one file at a time, hand-rolled file-list sidebar, keyed remount + deferred model disposal to work around a Monaco bug. Single call site: `ExplorerWorkspace.tsx`. Data comes from `window.sero.vcs.fileDiffSummary(wsId, from, to)` and `window.sero.vcs.fileContent(wsId, rev, path)`. `DiffTabState` (`type/workspaceId/fromRev/toRev/initialPath`) is the external contract and must not change.
+
+## Target design
+
+```
+DiffTab.tsx                     shell: toolbar (split/unified toggle, rev labels), layout, state
+├── DiffFileNavigator.tsx       Phase 2: @pierre/trees tree of changed files w/ git status
+├── DiffChangeset.tsx           @pierre/diffs CodeView: all files, progressive loading
+└── diff-themes.ts              editorThemeId → shiki ThemesType + --diffs-*/--trees-* token CSS
+```
+
+Data flow: `fileDiffSummary` → file list → for each file, fetch `fileContent` for both revs → `parseDiffFromFile(oldFile, newFile)` → append to `CodeView` via `CodeViewHandle.addItems` (progressive: first file paints immediately). Tree selection → `codeViewRef.scrollTo({ item })`.
+
+Theming: `theme` = `{ light, dark }` shiki names derived from `editorThemeId` (reuse the `resolveMarkdownCodeThemes` mapping in `monaco-themes.ts`); `themeType` from `useThemeStore().effectiveMode`. App-token alignment (fonts, chrome) via `--diffs-*` / `--trees-*` CSS variables only — no `unsafeCSS`.
+
+## Task list
+
+### Phase 1 — Changeset viewer on @pierre/diffs
+
+- [x] **1.1 Dependency**: add `@pierre/diffs` (exact pin) to `apps/desktop`. Confirm install brings its own deps and that the workspace `shiki ^3.23` satisfies the peer range. `pnpm typecheck` still green before any code changes. *(shiki@3.23.0 deduped — single copy in the workspace.)*
+- [x] **1.2 Theme bridge** (`editor/diff-themes.ts`): export `resolveDiffThemes(editorThemeId): { light, dark }` reusing the editor→shiki mapping from `monaco-themes.ts` (extract/share, don't duplicate the table). Add one CSS block setting `--diffs-font-family`, `--diffs-font-size`, and chrome vars from design tokens (`--bg-base`, `--text-*`, `--border-subtle`). *(Mapping extracted to `resolveShikiThemePair`; chrome vars in `diff-view.css` — only font/spacing vars needed, colors come from the shiki theme.)*
+- [x] **1.3 `DiffChangeset.tsx`**: `CodeView` wrapper. Props: `workspaceId/fromRev/toRev/files/diffStyle` + ref for scroll. Progressive loading loop: fetch both revisions per file, `parseDiffFromFile`, `addItems`; per-file fetch failure renders that file as an error item, doesn't abort the rest. Options: `diffStyle` from prop, `lineDiffType: 'word-alt'`, collapse-unchanged on (default), `stickyHeaders: true`. *(Batches of 8 files to bound concurrent IPC calls; unparseable pairs fall back to plain file rendering.)*
+- [x] **1.4 Rewrite `DiffTab.tsx`**: keep `DiffTabState` contract, loading state, toolbar (split/unified toggle now switches `diffStyle`, rev labels unchanged), file-list sidebar temporarily kept as the existing button list. `initialPath` → scroll to that file once its item is added.
+- [x] **1.5 Cleanup**: delete `DiffFileView`, `disposeDiffModels`, the Monaco disposal workaround comment, and the `@monaco-editor/react` `DiffEditor` lazy import. No file over 500 LOC.
+- [ ] **1.6 Verify** (manual, via VCS panel → open diff on a real multi-file change):
+  - [ ] Multi-file changeset renders with sticky headers; unchanged regions collapse/expand
+  - [ ] Split/unified toggle works
+  - [ ] Added, deleted, and renamed files render correctly
+  - [ ] Light/dark mode and at least 3 editor themes look right
+  - [ ] Large changeset (50+ files) streams in without blocking the UI
+  - [ ] `initialPath` opens scrolled to the right file
+  - [x] `pnpm typecheck` green (also `vite build` passes)
+
+### Phase 2 — File navigator on @pierre/trees
+
+- [ ] **2.1 Dependency**: add `@pierre/trees` (exact pin) to `apps/desktop`. Note: brings a small internal `preact` runtime (render-internal, no React interaction).
+- [ ] **2.2 `DiffFileNavigator.tsx`**: `useFileTree` + `<FileTree>` fed the full path list from `files` (`initialExpansion: 'open'`, search on). Map each entry's status → `setGitStatus()` entries. `onSelectionChange` → `scrollTo` callback prop. Theme via `--trees-*-override` vars from design tokens.
+- [ ] **2.3 Wire into `DiffTab`**: replace the button-list sidebar with `DiffFileNavigator`; keep the show/hide toggle. Selected file follows scroll target; drop `statusCode`/`statusColor` usage from this view (they remain used by the VCS panel).
+- [ ] **2.4 Verify**:
+  - [ ] Clicking a file scrolls the changeset to it
+  - [ ] Status decorations match the VCS panel for the same change
+  - [ ] Tree search filters files; keyboard navigation works
+  - [ ] Toggle hide/show navigator still works
+  - [ ] `pnpm typecheck` green
+
+### Wrap-up
+
+- [ ] Check `apps/docs-site` for diff-view screenshots/descriptions; update if stale
+- [ ] Conventional-commit PR: `feat(explorer): rebuild diff view on @pierre/diffs and @pierre/trees`
+
+## Acceptance criteria
+
+1. Opening a diff from the VCS panel shows the entire changeset in one scroll view — no per-file clicking required to review a change.
+2. All existing entry points (`DiffTabState`, `onOpenDiff`) work unchanged.
+3. No Monaco code remains in the diff path; the main editor (`EditorPanel`) is untouched.
+4. Themes: diff colors follow the selected editor theme; chrome follows app light/dark tokens.
+5. Zero typecheck errors; every touched file ≤ 500 LOC.

--- a/docs/specs/pierre-diff-viewer-spec.md
+++ b/docs/specs/pierre-diff-viewer-spec.md
@@ -1,6 +1,6 @@
 # Spec: Diff Viewer on @pierre/diffs + @pierre/trees
 
-**Status:** Phase 1 implemented — manual verification pending
+**Status:** Phases 1 & 2 implemented — manual verification pending
 **Branch:** `feat/pierre-diff-viewer`
 **Background:** [docs/plans/pierre-diffs-trees-migration.md](../plans/pierre-diffs-trees-migration.md) (analysis & rationale — not needed to execute this spec)
 
@@ -56,15 +56,15 @@ Theming: `theme` = `{ light, dark }` shiki names derived from `editorThemeId` (r
 
 ### Phase 2 — File navigator on @pierre/trees
 
-- [ ] **2.1 Dependency**: add `@pierre/trees` (exact pin) to `apps/desktop`. Note: brings a small internal `preact` runtime (render-internal, no React interaction).
-- [ ] **2.2 `DiffFileNavigator.tsx`**: `useFileTree` + `<FileTree>` fed the full path list from `files` (`initialExpansion: 'open'`, search on). Map each entry's status → `setGitStatus()` entries. `onSelectionChange` → `scrollTo` callback prop. Theme via `--trees-*-override` vars from design tokens.
-- [ ] **2.3 Wire into `DiffTab`**: replace the button-list sidebar with `DiffFileNavigator`; keep the show/hide toggle. Selected file follows scroll target; drop `statusCode`/`statusColor` usage from this view (they remain used by the VCS panel).
+- [x] **2.1 Dependency**: add `@pierre/trees` (exact pin) to `apps/desktop`. Note: brings a small internal `preact` runtime (render-internal, no React interaction).
+- [x] **2.2 `DiffFileNavigator.tsx`**: `useFileTree` + `<FileTree>` fed the full path list from `files` (`initialExpansion: 'open'`, search on). Map each entry's status → git-status entries. `onSelectionChange` → `scrollTo` callback prop. Theme via `--trees-*-override` vars from design tokens. *(Git status passed at model creation via the `gitStatus` option; `copied` maps to `added`, `conflict` to `modified` — the trees lane set has no equivalents.)*
+- [x] **2.3 Wire into `DiffTab`**: replace the button-list sidebar with `DiffFileNavigator`; keep the show/hide toggle. Selected file follows scroll target; drop `statusCode`/`statusColor` usage from this view (they remain used by the VCS panel). *(Navigator keyed per changeset; `initialPath` pre-selected in the tree.)*
 - [ ] **2.4 Verify**:
   - [ ] Clicking a file scrolls the changeset to it
   - [ ] Status decorations match the VCS panel for the same change
   - [ ] Tree search filters files; keyboard navigation works
   - [ ] Toggle hide/show navigator still works
-  - [ ] `pnpm typecheck` green
+  - [x] `pnpm typecheck` green (also `vite build` + all 1711 unit tests pass)
 
 ### Wrap-up
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -227,6 +227,8 @@ export type {
   VcsEvent,
 } from './vcs';
 
+export { WORKING_TREE_REV } from './vcs';
+
 export {
   parseGitHubUrl,
   normalizeGitHubRemoteUrl,

--- a/packages/common/src/vcs.ts
+++ b/packages/common/src/vcs.ts
@@ -29,6 +29,13 @@ export interface ChangeEntry {
   tags: string[];
 }
 
+/**
+ * Sentinel revision meaning "the working tree" in diff APIs. Valid only as
+ * the `to` side: the diff summary compares a commit against uncommitted
+ * changes, and file contents are read from disk instead of a commit.
+ */
+export const WORKING_TREE_REV = ':working-tree';
+
 export type FileStatus = 'modified' | 'added' | 'deleted' | 'renamed' | 'copied' | 'conflict';
 
 export interface StatusFile {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@pierre/diffs':
+        specifier: 1.2.12
+        version: 1.2.12(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -4362,6 +4365,36 @@ packages:
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
     engines: {node: ^20.9.0 || >=22.0.0, npm: '>=10.8.2'}
 
+  '@pierre/diffs@1.2.12':
+    resolution: {integrity: sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+
+  '@pierre/theme@1.1.0':
+    resolution: {integrity: sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==}
+    engines: {vscode: ^1.0.0}
+
+  '@pierre/theming@0.0.2':
+    resolution: {integrity: sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==}
+    peerDependencies:
+      '@pierre/theme': ^1.1.0
+      '@shikijs/themes': ^3.0.0 || ^4.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
+      shiki: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@pierre/theme':
+        optional: true
+      '@shikijs/themes':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      shiki:
+        optional: true
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -5681,6 +5714,10 @@ packages:
     resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
     engines: {node: '>=20'}
 
+  '@shikijs/core@4.3.1':
+    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
+    engines: {node: '>=20'}
+
   '@shikijs/engine-javascript@3.23.0':
     resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
@@ -5706,6 +5743,10 @@ packages:
     resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
     engines: {node: '>=20'}
 
+  '@shikijs/primitive@4.3.1':
+    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
+    engines: {node: '>=20'}
+
   '@shikijs/themes@3.23.0':
     resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
 
@@ -5713,11 +5754,19 @@ packages:
     resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
     engines: {node: '>=20'}
 
+  '@shikijs/transformers@4.3.1':
+    resolution: {integrity: sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==}
+    engines: {node: '>=20'}
+
   '@shikijs/types@3.23.0':
     resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/types@4.1.0':
     resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.3.1':
+    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
     engines: {node: '>=20'}
 
   '@shikijs/vscode-textmate@10.0.2':
@@ -7981,6 +8030,10 @@ packages:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
 
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
   dijkstrajs@1.0.3:
     resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
@@ -9990,6 +10043,9 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lru_map@0.4.1:
+    resolution: {integrity: sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg==}
 
   lucide-react@0.563.0:
     resolution: {integrity: sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==}
@@ -17867,6 +17923,30 @@ snapshots:
 
   '@phun-ky/typeof@2.0.3': {}
 
+  '@pierre/diffs@1.2.12(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@pierre/theme': 1.1.0
+      '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.23.0)
+      '@shikijs/transformers': 4.3.1
+      diff: 9.0.0
+      hast-util-to-html: 9.0.5
+      lru_map: 0.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      shiki: 3.23.0
+    transitivePeerDependencies:
+      - '@shikijs/themes'
+
+  '@pierre/theme@1.1.0': {}
+
+  '@pierre/theming@0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.23.0)':
+    optionalDependencies:
+      '@pierre/theme': 1.1.0
+      '@shikijs/themes': 4.1.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      shiki: 3.23.0
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -19173,6 +19253,14 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/core@4.3.1':
+    dependencies:
+      '@shikijs/primitive': 4.3.1
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/engine-javascript@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -19209,6 +19297,12 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  '@shikijs/primitive@4.3.1':
+    dependencies:
+      '@shikijs/types': 4.3.1
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
   '@shikijs/themes@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -19217,12 +19311,22 @@ snapshots:
     dependencies:
       '@shikijs/types': 4.1.0
 
+  '@shikijs/transformers@4.3.1':
+    dependencies:
+      '@shikijs/core': 4.3.1
+      '@shikijs/types': 4.3.1
+
   '@shikijs/types@3.23.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
   '@shikijs/types@4.1.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/types@4.3.1':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -21847,6 +21951,8 @@ snapshots:
 
   diff@8.0.4: {}
 
+  diff@9.0.0: {}
+
   dijkstrajs@1.0.3: {}
 
   dir-compare@4.2.0:
@@ -24136,6 +24242,8 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
+
+  lru_map@0.4.1: {}
 
   lucide-react@0.563.0(react@19.2.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,6 +214,9 @@ importers:
       '@pierre/diffs':
         specifier: 1.2.12
         version: 1.2.12(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@pierre/trees':
+        specifier: 1.0.0-beta.5
+        version: 1.0.0-beta.5(@pierre/theme@1.1.0)(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.23.0)
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
@@ -4394,6 +4397,12 @@ packages:
         optional: true
       shiki:
         optional: true
+
+  '@pierre/trees@1.0.0-beta.5':
+    resolution: {integrity: sha512-IzxkB9qv6GLbeEXObhlAD205LfYHiLeRwJdnaIdX0f5keTZF4X9EfiuEQ3QiyxOxouVVmUX3rX7m6a8zNMo/wA==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.3.1 || ^19.0.0
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -11406,6 +11415,14 @@ packages:
     resolution: {integrity: sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==}
     engines: {node: '>=20'}
 
+  preact-render-to-string@6.6.5:
+    resolution: {integrity: sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
+  preact@11.0.0-beta.0:
+    resolution: {integrity: sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg==}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -17946,6 +17963,18 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       shiki: 3.23.0
+
+  '@pierre/trees@1.0.0-beta.5(@pierre/theme@1.1.0)(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.23.0)':
+    dependencies:
+      '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(shiki@3.23.0)
+      preact: 11.0.0-beta.0
+      preact-render-to-string: 6.6.5(preact@11.0.0-beta.0)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@pierre/theme'
+      - '@shikijs/themes'
+      - shiki
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -26221,6 +26250,12 @@ snapshots:
   powershell-utils@0.1.0: {}
 
   powershell-utils@0.2.0: {}
+
+  preact-render-to-string@6.6.5(preact@11.0.0-beta.0):
+    dependencies:
+      preact: 11.0.0-beta.0
+
+  preact@11.0.0-beta.0: {}
 
   prebuild-install@7.1.3:
     dependencies:


### PR DESCRIPTION
## Summary

Rebuilds the Explorer diff tab per [docs/specs/pierre-diff-viewer-spec.md](https://github.com/sero-labs/sero/blob/feat/pierre-diff-viewer/docs/specs/pierre-diff-viewer-spec.md) (background analysis in docs/plans/pierre-diffs-trees-migration.md).

**Before:** Monaco DiffEditor, one file at a time, hand-rolled file button list, keyed-remount + deferred model disposal to work around a Monaco bug.

**After:**
- **Whole-changeset view** (`@pierre/diffs` CodeView): every changed file in one virtualized scroll with sticky headers, collapsible unchanged regions, word-level intraline highlighting, split/unified toggle.
- **Changed-files tree sidebar** (`@pierre/trees`): git-status lanes, search, keyboard navigation, click-to-scroll.
- **Progressive loading:** file pairs fetched in batches of 8 and appended as they arrive, so large changesets stream in.
- **Theming:** diff colors follow the selected editor theme via the shared editor→shiki mapping (extracted from `monaco-themes.ts`); chrome follows app design tokens via `--diffs-*` / `--trees-*` CSS variables only.

The `DiffTabState` contract and `onOpenDiff` entry points are unchanged. The main editor (EditorPanel) stays on Monaco; only the diff path changed.

## Structure

```
DiffTab.tsx              shell: toolbar, layout, file-list fetch  (136 LOC)
├── DiffFileNavigator.tsx  @pierre/trees changed-files tree        (52 LOC)
├── DiffChangeset.tsx      @pierre/diffs CodeView + batch loading  (130 LOC)
└── diff-themes.ts + diff-view.css   theme bridge + token CSS
```

## Verification

- `pnpm typecheck` green (all 22 packages), `vite build` passes, all 1711 desktop unit tests pass.
- Manual checklist from the spec still pending (multi-file changeset, renames, themes, 50+ files, `initialPath`): see spec tasks 1.6 / 2.4.
- `docs/assets/images/explorer-diff.jpg` in the docs site shows the old Monaco diff and needs re-capturing after verification.