### PR TITLE
Implement Agent Board — cross-workspace task kanban

### DIFF
--- a/apps/desktop/electron/__tests__/features/apps/runtime/manager.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/runtime/manager.test.ts
@@ -120,6 +120,7 @@ function createHostStub(
       pushBranch: vi.fn(async () => true),
       ensureRemoteDefaultBranch: vi.fn(async () => 'main'),
       listPullRequests: vi.fn(async () => []),
+      listIssues: vi.fn(async () => []),
       createPr: vi.fn(async () => ({ success: true as const, url: '', number: 0 })),
       mergePr: vi.fn(async () => ({ success: true as const, state: 'merged' as const })),
       getPrMergeState: vi.fn(async () => 'unknown' as const),

--- a/apps/desktop/electron/features/apps/runtime/capabilities/create-host.ts
+++ b/apps/desktop/electron/features/apps/runtime/capabilities/create-host.ts
@@ -29,6 +29,7 @@ import {
 import {
   createPrFromWorktree,
   ensureRemoteDefaultBranch,
+  listOpenIssues,
   listOpenPullRequests,
   mergePrFromWorktree,
 } from '@electron/features/vcs/worktree/pull-request';
@@ -171,6 +172,7 @@ export function createAppRuntimeHost(_target: AppRuntimeTarget): AppRuntimeHost 
       pushBranch: pushWorktreeBranch,
       ensureRemoteDefaultBranch,
       listPullRequests: (cwd, options) => listOpenPullRequests(cwd, options),
+      listIssues: (cwd) => listOpenIssues(cwd),
       createPr: createPrFromWorktree,
       mergePr: mergePrFromWorktree,
       getPrMergeState: getPullRequestMergeState,

--- a/apps/desktop/electron/features/vcs/worktree/git.ts
+++ b/apps/desktop/electron/features/vcs/worktree/git.ts
@@ -149,6 +149,48 @@ export async function getWorktreeDiffSummary(worktreePath: string): Promise<stri
   }
 }
 
+export interface WorktreeDiffStat {
+  files: number;
+  additions: number;
+  deletions: number;
+}
+
+/**
+ * Aggregate +adds −dels of the branch's work relative to its base (the Agent
+ * Board card stat). Fail-soft to null when the path is not a repo or has no
+ * commits — the card simply omits the stat.
+ */
+export async function getWorktreeDiffStat(worktreePath: string): Promise<WorktreeDiffStat | null> {
+  if (!await hasCommits(worktreePath)) return null;
+  const base = await resolveBaseBranch(worktreePath);
+  const isBranch = /^[a-zA-Z]/.test(base) || base.startsWith('HEAD');
+  const diffSpec = isBranch ? `${base}...HEAD` : `${base}..HEAD`;
+  try {
+    const result = await execFileAsync('git', ['diff', '--shortstat', diffSpec], {
+      cwd: worktreePath,
+      timeout: 15_000,
+    });
+    return parseShortstat(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+/** Parses `git diff --shortstat` output ("3 files changed, 10 insertions(+), 2 deletions(-)"). */
+function parseShortstat(stdout: string): WorktreeDiffStat | null {
+  const text = stdout.trim();
+  if (!text) return { files: 0, additions: 0, deletions: 0 };
+  const files = /(\d+) files? changed/.exec(text);
+  const additions = /(\d+) insertions?\(\+\)/.exec(text);
+  const deletions = /(\d+) deletions?\(-\)/.exec(text);
+  if (!files && !additions && !deletions) return null;
+  return {
+    files: files ? Number(files[1]) : 0,
+    additions: additions ? Number(additions[1]) : 0,
+    deletions: deletions ? Number(deletions[1]) : 0,
+  };
+}
+
 /** Check whether the repo has any commits at all. */
 async function hasCommits(cwd: string): Promise<boolean> {
   try {

--- a/apps/desktop/electron/features/vcs/worktree/pull-request.ts
+++ b/apps/desktop/electron/features/vcs/worktree/pull-request.ts
@@ -227,6 +227,47 @@ export async function listOpenPullRequests(
   }
 }
 
+export interface OpenIssueSummary {
+  number: number;
+  url: string;
+  title: string;
+  labels: string[];
+  assignees: string[];
+  updatedAt: string;
+}
+
+/**
+ * Lists open issues in `cwd`'s repo via `gh` — the twin of `listOpenPullRequests`.
+ * `gh` returns labels/assignees as objects; they are flattened to names here so
+ * consumers get plain strings. Fail-soft to `[]` like the sibling helpers.
+ */
+export async function listOpenIssues(cwd: string): Promise<OpenIssueSummary[]> {
+  const args = ['issue', 'list', '--state', 'open',
+    '--json', 'number,url,title,labels,assignees,updatedAt'];
+  try {
+    const r = await execFileAsync('gh', args, { cwd, timeout: 30_000 });
+    const parsed = JSON.parse(r.stdout) as Array<{
+      number: number;
+      url: string;
+      title: string;
+      labels?: Array<{ name?: string }>;
+      assignees?: Array<{ login?: string }>;
+      updatedAt: string;
+    }>;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((issue) => ({
+      number: issue.number,
+      url: issue.url,
+      title: issue.title,
+      labels: (issue.labels ?? []).map((l) => l.name ?? '').filter(Boolean),
+      assignees: (issue.assignees ?? []).map((a) => a.login ?? '').filter(Boolean),
+      updatedAt: issue.updatedAt,
+    }));
+  } catch {
+    return [];
+  }
+}
+
 export async function createPrFromWorktree(
   worktreePath: string,
   opts: { title: string; body: string; baseBranch?: string; draft?: boolean },

--- a/apps/desktop/electron/features/vcs/worktree/pull-request.ts
+++ b/apps/desktop/electron/features/vcs/worktree/pull-request.ts
@@ -261,8 +261,8 @@ export async function listOpenIssues(cwd: string): Promise<OpenIssueSummary[]> {
       number: issue.number,
       url: issue.url,
       title: issue.title,
-      labels: (issue.labels ?? []).map((l) => l.name ?? '').filter(Boolean),
-      assignees: (issue.assignees ?? []).map((a) => a.login ?? '').filter(Boolean),
+      labels: (issue.labels ?? []).flatMap((label) => label.name ? [label.name] : []),
+      assignees: (issue.assignees ?? []).flatMap((assignee) => assignee.login ? [assignee.login] : []),
       updatedAt: issue.updatedAt,
     }));
   } catch {

--- a/apps/desktop/electron/features/vcs/worktree/pull-request.ts
+++ b/apps/desktop/electron/features/vcs/worktree/pull-request.ts
@@ -242,7 +242,9 @@ export interface OpenIssueSummary {
  * consumers get plain strings. Fail-soft to `[]` like the sibling helpers.
  */
 export async function listOpenIssues(cwd: string): Promise<OpenIssueSummary[]> {
-  const args = ['issue', 'list', '--state', 'open',
+  // Explicit cap (gh defaults to a silent 30): the board renders at most a
+  // screenful of backlog issues, and gh returns the most recently updated first.
+  const args = ['issue', 'list', '--state', 'open', '--limit', '50',
     '--json', 'number,url,title,labels,assignees,updatedAt'];
   try {
     const r = await execFileAsync('gh', args, { cwd, timeout: 30_000 });

--- a/apps/desktop/electron/ipc/index.ts
+++ b/apps/desktop/electron/ipc/index.ts
@@ -31,6 +31,7 @@ import { registerLspHandlers } from './editor/lsp';
 import { registerDebugHandlers } from './editor/debug';
 import { registerContextPresetsHandlers } from './workspace/context-presets';
 import { registerVcsHandlers } from './integrations/vcs';
+import { registerOrchestratorHandlers } from './integrations/orchestrator';
 import { registerGitHubHandlers } from './integrations/github';
 import { registerFeedbackHandlers } from './platform/ui/feedback';
 import { registerNetHandlers } from './platform/system/net';
@@ -77,6 +78,7 @@ export function registerAllIpcHandlers(): void {
   registerDebugHandlers();
   registerContextPresetsHandlers();
   registerVcsHandlers();
+  registerOrchestratorHandlers();
   registerGitHubHandlers();
   registerFeedbackHandlers();
   registerNetHandlers();

--- a/apps/desktop/electron/ipc/integrations/orchestrator.ts
+++ b/apps/desktop/electron/ipc/integrations/orchestrator.ts
@@ -32,7 +32,12 @@ export function registerOrchestratorHandlers(): void {
       }
       try {
         const result = await entry.coordinator.requestAction(action);
-        return { ok: result.ok, error: result.error, delivered: result.delivered };
+        return {
+          ok: result.ok,
+          error: result.error,
+          delivered: result.delivered,
+          deduped: result.deduped,
+        };
       } catch (err) {
         return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }

--- a/apps/desktop/electron/ipc/integrations/orchestrator.ts
+++ b/apps/desktop/electron/ipc/integrations/orchestrator.ts
@@ -1,0 +1,41 @@
+/**
+ * Agent Board → orchestrator coordinator seam.
+ *
+ * The board (a built-in shell app) reads loop state from each workspace's
+ * watched index; writes must reach that workspace's coordinator. Coordinators
+ * live in this process, registered on `globalThis` by the orchestrator plugin's
+ * runtime (its runtime and extension bundles load through different loaders, so
+ * the registry is deliberately a shared global). This handler resolves the
+ * coordinator through the cross-plugin contract types in @sero-ai/common —
+ * never by importing plugin internals.
+ */
+
+import { ipcMain } from 'electron';
+
+import { IpcChannels } from '@/types/ipc-channels';
+import {
+  getOrchestratorRegistry,
+  type OrchestratorBoardAction,
+  type OrchestratorBoardActionResult,
+} from '@sero-ai/common';
+
+export function registerOrchestratorHandlers(): void {
+  ipcMain.handle(
+    IpcChannels.orchestrator.action,
+    async (_e, workspaceId: string, action: OrchestratorBoardAction): Promise<OrchestratorBoardActionResult> => {
+      const entry = getOrchestratorRegistry()?.get(workspaceId);
+      if (!entry) {
+        return {
+          ok: false,
+          error: 'No orchestrator is running for this workspace — open the workspace to act on its loops.',
+        };
+      }
+      try {
+        const result = await entry.coordinator.requestAction(action);
+        return { ok: result.ok, error: result.error, delivered: result.delivered };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  );
+}

--- a/apps/desktop/electron/ipc/integrations/vcs.ts
+++ b/apps/desktop/electron/ipc/integrations/vcs.ts
@@ -6,6 +6,8 @@ import { runAdhocAgent } from '@electron/features/agent/assistants/adhoc-agent';
 import { buildPrDraftPrompt, parseDraft } from '@electron/features/agent/assistants/pr-draft';
 import { vcsManager, vcsOps, vcsPrOps, workspaceManager } from '@electron/shared/infra/shared-infra';
 import { gitWorkspaceStateManager } from '@electron/features/apps/git-app/manager';
+import { listOpenIssues, listOpenPullRequests } from '@electron/features/vcs/worktree/pull-request';
+import { getWorktreeDiffStat } from '@electron/features/vcs/worktree/git';
 import { broadcastToWindows } from '../lib/window-broadcast';
 
 const Ch = IpcChannels.vcs;
@@ -189,5 +191,23 @@ export function registerVcsHandlers(): void {
 
   ipcMain.handle(Ch.opLog, async (_e, wsId: string, limit?: number) =>
     vcsOps.getOperationLog(wsId, limit ?? 20),
+  );
+
+  // ── Repo-scoped gh reads (Agent Board) ────────────────────
+  // Fail-soft to [] inside the helpers; a workspace without a GitHub remote
+  // or gh auth simply contributes nothing.
+
+  ipcMain.handle(Ch.issues, async (_e, wsId: string) => {
+    const workspacePath = workspaceManager.getPath(wsId);
+    return workspacePath ? listOpenIssues(workspacePath) : [];
+  });
+
+  ipcMain.handle(Ch.openPrs, async (_e, wsId: string) => {
+    const workspacePath = workspaceManager.getPath(wsId);
+    return workspacePath ? listOpenPullRequests(workspacePath) : [];
+  });
+
+  ipcMain.handle(Ch.diffStat, async (_e, checkoutPath: string) =>
+    getWorktreeDiffStat(checkoutPath),
   );
 }

--- a/apps/desktop/electron/ipc/integrations/vcs.ts
+++ b/apps/desktop/electron/ipc/integrations/vcs.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { ipcMain } from 'electron';
 
 import { IpcChannels } from '@/types/ipc-channels';
@@ -207,7 +209,12 @@ export function registerVcsHandlers(): void {
     return workspacePath ? listOpenPullRequests(workspacePath) : [];
   });
 
-  ipcMain.handle(Ch.diffStat, async (_e, checkoutPath: string) =>
-    getWorktreeDiffStat(checkoutPath),
-  );
+  ipcMain.handle(Ch.diffStat, async (_e, checkoutPath: string) => {
+    // Renderer-supplied path: only serve checkouts inside a registered
+    // workspace (the root itself or a worktree under it, e.g. .sero/worktrees).
+    const resolved = path.resolve(checkoutPath);
+    const roots = (await workspaceManager.list()).map((ws) => ws.path);
+    const known = roots.some((root) => resolved === root || resolved.startsWith(root + path.sep));
+    return known ? getWorktreeDiffStat(resolved) : null;
+  });
 }

--- a/apps/desktop/electron/preload/api.ts
+++ b/apps/desktop/electron/preload/api.ts
@@ -34,6 +34,7 @@ import {
 } from './apps/app-domain';
 import { browserBridge } from './apps/browser';
 import { pluginsBridge } from './integrations/plugins';
+import { orchestratorBridge } from './integrations/orchestrator';
 import {
   agentBridge,
   contextPresetsBridge,
@@ -74,6 +75,7 @@ export const seroPreloadApi = {
   container: containerBridge,
   devServer: devServerBridge,
   vcs: vcsBridge,
+  orchestrator: orchestratorBridge,
   github: githubBridge,
   plugins: pluginsBridge,
   terminal: terminalBridge,

--- a/apps/desktop/electron/preload/api/workbench.ts
+++ b/apps/desktop/electron/preload/api/workbench.ts
@@ -1,11 +1,14 @@
 import { ipcRenderer, type IpcRendererEvent } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
 import type {
+  AppRuntimeIssueSummary,
+  AppRuntimePullRequestSummary,
   Bookmark,
   ChangeEntry,
   CreatePullRequestInput,
   CreatePullRequestResult,
   FileDiffEntry,
+  GitDiffStat,
   OperationEntry,
   PullRequestDraft,
   PullRequestPreview,
@@ -115,6 +118,12 @@ export const vcsBridge = {
     ipcRenderer.invoke(IpcChannels.vcs.squash, workspaceId, from, into),
   opLog: (workspaceId: string, limit?: number): Promise<OperationEntry[]> =>
     ipcRenderer.invoke(IpcChannels.vcs.opLog, workspaceId, limit),
+  issues: (workspaceId: string): Promise<AppRuntimeIssueSummary[]> =>
+    ipcRenderer.invoke(IpcChannels.vcs.issues, workspaceId),
+  openPrs: (workspaceId: string): Promise<AppRuntimePullRequestSummary[]> =>
+    ipcRenderer.invoke(IpcChannels.vcs.openPrs, workspaceId),
+  diffStat: (checkoutPath: string): Promise<GitDiffStat | null> =>
+    ipcRenderer.invoke(IpcChannels.vcs.diffStat, checkoutPath),
 };
 
 export const terminalBridge = {

--- a/apps/desktop/electron/preload/integrations/orchestrator.ts
+++ b/apps/desktop/electron/preload/integrations/orchestrator.ts
@@ -1,0 +1,15 @@
+import { ipcRenderer } from 'electron';
+import { IpcChannels } from '@/types/ipc-channels';
+import type { OrchestratorBoardAction, OrchestratorBoardActionResult } from '@sero-ai/common';
+
+/**
+ * Agent Board → per-workspace orchestrator coordinator. Reads stay on the
+ * watched index files; this is the single write path (contract types only).
+ */
+export const orchestratorBridge = {
+  requestAction: (
+    workspaceId: string,
+    action: OrchestratorBoardAction,
+  ): Promise<OrchestratorBoardActionResult> =>
+    ipcRenderer.invoke(IpcChannels.orchestrator.action, workspaceId, action),
+};

--- a/apps/desktop/src/components/apps/ActiveAppPanel.tsx
+++ b/apps/desktop/src/components/apps/ActiveAppPanel.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { Dashboard } from '@/components/apps/dashboard/Dashboard';
 import { SeroAppMount } from '@/components/apps/SeroAppMount';
 import { useAppStore } from '@/stores/app';
+import { AgentBoard } from './board/AgentBoard';
 import { ExplorerWorkspace } from './explorer/ExplorerWorkspace';
 
 interface ActiveAppPanelProps {
@@ -21,6 +22,8 @@ export const ActiveAppPanel = memo(function ActiveAppPanel({ app }: ActiveAppPan
 
   if (app === 'dashboard') {
     content = <Dashboard />;
+  } else if (app === 'board') {
+    content = <AgentBoard />;
   } else if (app === 'explorer') {
     content = <ExplorerWorkspace />;
   } else if (entry?.manifest) {

--- a/apps/desktop/src/components/apps/board/AgentBoard.tsx
+++ b/apps/desktop/src/components/apps/board/AgentBoard.tsx
@@ -6,7 +6,7 @@
  */
 
 import { memo, useEffect, useMemo } from 'react';
-import { LayoutGroup, motion } from 'motion/react';
+import { domMax, LazyMotion, LayoutGroup, m } from 'motion/react';
 import { Columns3, RefreshCw } from 'lucide-react';
 import { useAgentBoardStore } from '@/stores/agent-board';
 import { useWorkspaceStore } from '@/stores/workspace';
@@ -18,7 +18,8 @@ import {
   type BoardSession,
   type BoardWorkspace,
 } from './board-model';
-import { BoardColumn, COLUMN_ORDER } from './BoardColumn';
+import { BoardColumn } from './BoardColumn';
+import { COLUMN_ORDER } from './board-constants';
 
 export const AgentBoard = memo(function AgentBoard() {
   const start = useAgentBoardStore((s) => s.start);
@@ -39,9 +40,11 @@ export const AgentBoard = memo(function AgentBoard() {
 
   const boardWorkspaces = useMemo<BoardWorkspace[]>(
     () =>
-      workspaces
-        .filter((ws) => ws.path && (!workspaceFilter || ws.id === workspaceFilter))
-        .map((ws) => ({ id: ws.id, name: ws.name, path: ws.path })),
+      workspaces.flatMap((workspace) =>
+        workspace.path && (!workspaceFilter || workspace.id === workspaceFilter)
+          ? [{ id: workspace.id, name: workspace.name, path: workspace.path }]
+          : [],
+      ),
     [workspaces, workspaceFilter],
   );
 
@@ -73,7 +76,8 @@ export const AgentBoard = memo(function AgentBoard() {
   const attentionCount = columns.attention.length;
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col overflow-hidden bg-[var(--bg-base)]">
+    <LazyMotion features={domMax}>
+      <div className="relative flex h-full min-h-0 flex-col overflow-hidden bg-[var(--bg-base)]">
       {/* Ambient top glow — brand-tinted, purely decorative. */}
       <div
         aria-hidden
@@ -85,7 +89,7 @@ export const AgentBoard = memo(function AgentBoard() {
       />
 
       <header className="relative z-10 flex flex-wrap items-center gap-3 px-5 pb-3 pt-4">
-        <motion.div
+        <m.div
           initial={{ opacity: 0, y: -8 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.3, ease: 'easeOut' }}
@@ -103,11 +107,13 @@ export const AgentBoard = memo(function AgentBoard() {
               {attentionCount > 0 ? ` · ${attentionCount} need${attentionCount === 1 ? 's' : ''} you` : ''}
             </p>
           </div>
-        </motion.div>
+        </m.div>
 
         <div className="ml-auto flex items-center gap-1.5">
           <WorkspaceFilterChips
-            workspaces={workspaces.filter((ws) => ws.path).map((ws) => ({ id: ws.id, name: ws.name }))}
+            workspaces={workspaces.flatMap((workspace) =>
+              workspace.path ? [{ id: workspace.id, name: workspace.name }] : [],
+            )}
             selected={workspaceFilter}
             onSelect={setWorkspaceFilter}
           />
@@ -138,7 +144,8 @@ export const AgentBoard = memo(function AgentBoard() {
           </div>
         </LayoutGroup>
       </div>
-    </div>
+      </div>
+    </LazyMotion>
   );
 });
 
@@ -170,7 +177,7 @@ function WorkspaceFilterChips({ workspaces, selected, onSelect }: WorkspaceFilte
             }`}
           >
             {active && (
-              <motion.span
+              <m.span
                 layoutId="board-filter-pill"
                 className="absolute inset-0 rounded-full bg-[var(--bg-overlay)] ring-1 ring-[var(--border-default)]"
                 transition={{ type: 'spring', stiffness: 500, damping: 35 }}

--- a/apps/desktop/src/components/apps/board/AgentBoard.tsx
+++ b/apps/desktop/src/components/apps/board/AgentBoard.tsx
@@ -33,10 +33,6 @@ export const AgentBoard = memo(function AgentBoard() {
   const streamingSessionIds = useStreamingSessionIds();
   const agents = useAgentStore((s) => s.agents);
 
-  // No timers on the board: the clock advances whenever a watched file or
-  // agent event re-renders it, which is exactly when ages can change meaning.
-  const nowMs = Date.now();
-
   useEffect(() => {
     start();
   }, [start]);
@@ -62,10 +58,15 @@ export const AgentBoard = memo(function AgentBoard() {
     });
   }, [streamingSessionIds, agents, sessions]);
 
+  // No timers on the board: the clock advances only when board data changes,
+  // which is exactly when ages can change meaning. A stable value between data
+  // changes also keeps the memoized columns/cards from re-rendering for free.
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- data deps deliberately drive the clock
+  const nowMs = useMemo(() => Date.now(), [boardWorkspaces, slices, liveSessions]);
+
   const columns = useMemo(
     () => buildBoardColumns(boardWorkspaces, slices, liveSessions, nowMs),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- nowMs changes every render; columns should only recompute on data change
-    [boardWorkspaces, slices, liveSessions],
+    [boardWorkspaces, slices, liveSessions, nowMs],
   );
 
   const runningCount = columns.active.length;

--- a/apps/desktop/src/components/apps/board/AgentBoard.tsx
+++ b/apps/desktop/src/components/apps/board/AgentBoard.tsx
@@ -1,0 +1,184 @@
+/**
+ * Agent Board — profile-wide kanban of all agent work across workspaces
+ * (docs/features/agent-board/plan.md). Four columns: Backlog · Active ·
+ * Needs Attention · Finished. Reads are push-only (watched files + agent
+ * events); the columns recompute on state change, never on a timer.
+ */
+
+import { memo, useEffect, useMemo } from 'react';
+import { LayoutGroup, motion } from 'motion/react';
+import { Columns3, RefreshCw } from 'lucide-react';
+import { useAgentBoardStore } from '@/stores/agent-board';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { useSessionStore } from '@/stores/sessions';
+import { useStreamingSessionIds } from '@/stores/agent-selectors';
+import { useAgentStore } from '@/stores/agent';
+import {
+  buildBoardColumns,
+  type BoardSession,
+  type BoardWorkspace,
+} from './board-model';
+import { BoardColumn, COLUMN_ORDER } from './BoardColumn';
+
+export const AgentBoard = memo(function AgentBoard() {
+  const start = useAgentBoardStore((s) => s.start);
+  const slices = useAgentBoardStore((s) => s.slices);
+  const collapsedColumns = useAgentBoardStore((s) => s.collapsedColumns);
+  const workspaceFilter = useAgentBoardStore((s) => s.workspaceFilter);
+  const setWorkspaceFilter = useAgentBoardStore((s) => s.setWorkspaceFilter);
+  const refreshIssues = useAgentBoardStore((s) => s.refreshIssues);
+  const refreshingIssues = useAgentBoardStore((s) => s.refreshingIssues);
+  const workspaces = useWorkspaceStore((s) => s.workspaces);
+  const sessions = useSessionStore((s) => s.sessions);
+  const streamingSessionIds = useStreamingSessionIds();
+  const agents = useAgentStore((s) => s.agents);
+
+  // No timers on the board: the clock advances whenever a watched file or
+  // agent event re-renders it, which is exactly when ages can change meaning.
+  const nowMs = Date.now();
+
+  useEffect(() => {
+    start();
+  }, [start]);
+
+  const boardWorkspaces = useMemo<BoardWorkspace[]>(
+    () =>
+      workspaces
+        .filter((ws) => ws.path && (!workspaceFilter || ws.id === workspaceFilter))
+        .map((ws) => ({ id: ws.id, name: ws.name, path: ws.path })),
+    [workspaces, workspaceFilter],
+  );
+
+  const liveSessions = useMemo<BoardSession[]>(() => {
+    return streamingSessionIds.map((sessionId) => {
+      const agent = agents[sessionId];
+      const info = sessions.find((s) => s.id === sessionId);
+      return {
+        sessionId,
+        workspaceId: agent?.workspaceId ?? info?.workspaceId ?? 'global',
+        title: info?.name ?? info?.firstMessage ?? 'Live session',
+        streaming: true,
+      };
+    });
+  }, [streamingSessionIds, agents, sessions]);
+
+  const columns = useMemo(
+    () => buildBoardColumns(boardWorkspaces, slices, liveSessions, nowMs),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- nowMs changes every render; columns should only recompute on data change
+    [boardWorkspaces, slices, liveSessions],
+  );
+
+  const runningCount = columns.active.length;
+  const attentionCount = columns.attention.length;
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col overflow-hidden bg-[var(--bg-base)]">
+      {/* Ambient top glow — brand-tinted, purely decorative. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-48"
+        style={{
+          background:
+            'radial-gradient(60% 100% at 50% 0%, var(--brand-primary-faint) 0%, transparent 100%)',
+        }}
+      />
+
+      <header className="relative z-10 flex flex-wrap items-center gap-3 px-5 pb-3 pt-4">
+        <motion.div
+          initial={{ opacity: 0, y: -8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.3, ease: 'easeOut' }}
+          className="flex items-center gap-2.5"
+        >
+          <span className="flex size-8 items-center justify-center rounded-lg bg-brand-primary/10 text-brand-primary">
+            <Columns3 className="size-4.5" />
+          </span>
+          <div>
+            <h1 className="text-base font-semibold leading-tight text-[var(--text-primary)]">
+              Agent Board
+            </h1>
+            <p className="text-xs text-[var(--text-muted)]">
+              {runningCount > 0 ? `${runningCount} running` : 'Nothing running'}
+              {attentionCount > 0 ? ` · ${attentionCount} need${attentionCount === 1 ? 's' : ''} you` : ''}
+            </p>
+          </div>
+        </motion.div>
+
+        <div className="ml-auto flex items-center gap-1.5">
+          <WorkspaceFilterChips
+            workspaces={workspaces.filter((ws) => ws.path).map((ws) => ({ id: ws.id, name: ws.name }))}
+            selected={workspaceFilter}
+            onSelect={setWorkspaceFilter}
+          />
+          <button
+            type="button"
+            onClick={() => void refreshIssues()}
+            title="Refresh GitHub issues and pull requests"
+            className="flex size-7 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-overlay)] hover:text-[var(--text-primary)]"
+          >
+            <RefreshCw className={`size-3.5 ${refreshingIssues ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </header>
+
+      <div className="relative z-10 min-h-0 flex-1 overflow-x-auto px-4 pb-4">
+        <LayoutGroup>
+          <div className="grid h-full min-w-[880px] grid-cols-4 gap-3">
+            {COLUMN_ORDER.map((columnId, index) => (
+              <BoardColumn
+                key={columnId}
+                columnId={columnId}
+                cards={columns[columnId]}
+                collapsed={collapsedColumns.includes(columnId)}
+                index={index}
+                nowMs={nowMs}
+              />
+            ))}
+          </div>
+        </LayoutGroup>
+      </div>
+    </div>
+  );
+});
+
+interface WorkspaceFilterChipsProps {
+  workspaces: { id: string; name: string }[];
+  selected: string | null;
+  onSelect: (id: string | null) => void;
+}
+
+function WorkspaceFilterChips({ workspaces, selected, onSelect }: WorkspaceFilterChipsProps) {
+  if (workspaces.length < 2) return null;
+  const chips: { id: string | null; name: string }[] = [
+    { id: null, name: 'All' },
+    ...workspaces,
+  ];
+  return (
+    <div className="flex max-w-[40vw] items-center gap-1 overflow-x-auto">
+      {chips.map((chip) => {
+        const active = selected === chip.id;
+        return (
+          <button
+            key={chip.id ?? 'all'}
+            type="button"
+            onClick={() => onSelect(chip.id)}
+            className={`relative shrink-0 rounded-full px-2.5 py-1 text-xs transition-colors ${
+              active
+                ? 'text-[var(--text-primary)]'
+                : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]'
+            }`}
+          >
+            {active && (
+              <motion.span
+                layoutId="board-filter-pill"
+                className="absolute inset-0 rounded-full bg-[var(--bg-overlay)] ring-1 ring-[var(--border-default)]"
+                transition={{ type: 'spring', stiffness: 500, damping: 35 }}
+              />
+            )}
+            <span className="relative">{chip.name}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/apps/board/BoardCard.tsx
+++ b/apps/desktop/src/components/apps/board/BoardCard.tsx
@@ -1,0 +1,350 @@
+/**
+ * One Agent Board card. A card is a unit of work: an orchestrator loop, an
+ * unclaimed GitHub issue (backlog), or a live interactive session. Everything
+ * shown is derived from durable state; the animations are the only decoration.
+ */
+
+import { memo, useEffect } from 'react';
+import { motion } from 'motion/react';
+import { openSeroApp } from '@sero-ai/app-runtime';
+import { ORCHESTRATOR_APP_ID } from '@sero-ai/common';
+import {
+  ArrowDown,
+  ArrowUp,
+  CircleDot,
+  GitBranch,
+  GitPullRequest,
+  MessageSquare,
+} from 'lucide-react';
+import { useAgentBoardStore } from '@/stores/agent-board';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { useSessionStore } from '@/stores/sessions';
+import { useAgentStore } from '@/stores/agent';
+import { useAppStore } from '@/stores/app';
+import type { BoardColumnId } from '@/types/board';
+import {
+  formatAge,
+  formatCost,
+  formatTokens,
+  formatUntil,
+  type BoardCard as BoardCardModel,
+  type BoardIssueCard,
+  type BoardLoopCard,
+  type BoardSessionCard,
+} from './board-model';
+import { BoardCardActions } from './BoardCardActions';
+
+const COLUMN_ACCENT: Record<BoardColumnId, string> = {
+  backlog: 'var(--text-muted)',
+  active: 'var(--status-success)',
+  attention: 'var(--status-warning)',
+  done: 'var(--status-info)',
+};
+
+const CARD_SPRING = { type: 'spring', stiffness: 400, damping: 32 } as const;
+
+interface BoardCardProps {
+  card: BoardCardModel;
+  columnId: BoardColumnId;
+  nowMs: number;
+}
+
+export const BoardCard = memo(function BoardCard({ card, columnId, nowMs }: BoardCardProps) {
+  return (
+    <motion.article
+      layout
+      layoutId={card.key}
+      initial={{ opacity: 0, y: 14, scale: 0.97 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95, transition: { duration: 0.15 } }}
+      transition={CARD_SPRING}
+      whileHover={{ y: -2 }}
+      className={`group relative shrink-0 cursor-pointer overflow-hidden rounded-lg border bg-[var(--bg-surface)] shadow-sm transition-shadow hover:shadow-md ${
+        columnId === 'attention'
+          ? 'border-status-warning-border bg-status-warning-faint'
+          : 'border-[var(--border-subtle)]'
+      }`}
+      onClick={() => openCard(card)}
+    >
+      <span
+        aria-hidden
+        className="absolute inset-y-0 left-0 w-[3px]"
+        style={{ background: COLUMN_ACCENT[columnId] }}
+      />
+      <div className="flex flex-col gap-1.5 py-2.5 pl-3.5 pr-3">
+        {card.kind === 'loop' && <LoopCardBody card={card} columnId={columnId} nowMs={nowMs} />}
+        {card.kind === 'issue' && <IssueCardBody card={card} nowMs={nowMs} />}
+        {card.kind === 'session' && <SessionCardBody card={card} />}
+      </div>
+    </motion.article>
+  );
+});
+
+// ── Loop cards ──────────────────────────────────────────────
+
+function LoopCardBody({
+  card,
+  columnId,
+  nowMs,
+}: {
+  card: BoardLoopCard;
+  columnId: BoardColumnId;
+  nowMs: number;
+}) {
+  const { loop } = card;
+  const running = Boolean(loop.progress?.running);
+
+  return (
+    <>
+      <div className="flex items-start gap-2">
+        {running ? <PulsingDot tone="var(--status-success)" /> : null}
+        <h3 className="min-w-0 flex-1 truncate text-[13px] font-medium leading-snug text-[var(--text-primary)]">
+          {loop.title}
+        </h3>
+        <span className="shrink-0 text-[10px] tabular-nums text-[var(--text-muted)]">
+          {formatAge(loop.updatedAt, nowMs)}
+        </span>
+      </div>
+
+      <WorkspaceLine name={card.workspaceName} branch={loop.branchName} />
+
+      {running && loop.activeStepTitles?.length ? (
+        <ActivityLine titles={loop.activeStepTitles} />
+      ) : null}
+      {running && loop.progress ? (
+        <ProgressBar done={loop.progress.done} total={loop.progress.total} />
+      ) : null}
+
+      {card.queuedReason && columnId === 'backlog' ? (
+        <p className="text-[11px] text-[var(--text-muted)]">
+          {card.queuedReason === 'draft' && 'Draft — not yet activated'}
+          {card.queuedReason === 'scheduled' && `Next run ${formatUntil(card.queuedAt, nowMs)}`}
+          {card.queuedReason === 'snoozed' && `Snoozed — retries ${formatUntil(card.queuedAt, nowMs)}`}
+        </p>
+      ) : null}
+
+      {columnId === 'attention' ? <BoardCardActions card={card} /> : null}
+
+      <ChipRow card={card} />
+    </>
+  );
+}
+
+/** Bottom chips: model · tokens · cost · diffstat · PRs · issues. */
+function ChipRow({ card }: { card: BoardLoopCard }) {
+  const { loop } = card;
+  const fetchDiffStat = useAgentBoardStore((s) => s.fetchDiffStat);
+  const diffStat = useAgentBoardStore((s) =>
+    loop.checkoutPath ? s.diffStats[loop.checkoutPath]?.stat : undefined,
+  );
+
+  useEffect(() => {
+    if (loop.checkoutPath) fetchDiffStat(loop.checkoutPath, loop.updatedAt);
+  }, [loop.checkoutPath, loop.updatedAt, fetchDiffStat]);
+
+  const usage = loop.usage;
+  const hasChips =
+    loop.lastModel || usage?.inputTokens || usage?.outputTokens || usage?.costUsd
+    || diffStat?.additions || diffStat?.deletions
+    || loop.pullRequests?.length || card.issueNumbers.length;
+  if (!hasChips) return null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 pt-0.5 text-[10px] text-[var(--text-muted)]">
+      {loop.lastModel && (
+        <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 font-medium text-[var(--text-secondary)]">
+          {shortModel(loop.lastModel)}
+        </span>
+      )}
+      {usage?.inputTokens ? (
+        <span className="inline-flex items-center gap-0.5 tabular-nums">
+          <ArrowUp className="size-2.5" />
+          {formatTokens(usage.inputTokens)}
+        </span>
+      ) : null}
+      {usage?.outputTokens ? (
+        <span className="inline-flex items-center gap-0.5 tabular-nums">
+          <ArrowDown className="size-2.5" />
+          {formatTokens(usage.outputTokens)}
+        </span>
+      ) : null}
+      {usage?.costUsd ? <span className="tabular-nums">{formatCost(usage.costUsd)}</span> : null}
+      {diffStat && (diffStat.additions > 0 || diffStat.deletions > 0) ? (
+        <span className="tabular-nums">
+          <span className="text-status-success">+{diffStat.additions}</span>{' '}
+          <span className="text-status-error">−{diffStat.deletions}</span>
+        </span>
+      ) : null}
+      {(loop.pullRequests ?? []).map((pr) => (
+        <button
+          key={pr.number}
+          type="button"
+          title={pr.title}
+          onClick={(e) => {
+            e.stopPropagation();
+            void window.sero.shell.openExternal(pr.url);
+          }}
+          className="inline-flex items-center gap-0.5 rounded bg-status-info-muted px-1.5 py-0.5 font-medium text-status-info transition-colors hover:bg-status-info-subtle"
+        >
+          <GitPullRequest className="size-2.5" />#{pr.number}
+        </button>
+      ))}
+      {card.issueNumbers.map((n) => (
+        <span
+          key={n}
+          className="inline-flex items-center gap-0.5 rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 font-medium"
+        >
+          <CircleDot className="size-2.5" />#{n}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ── Issue cards (backlog) ───────────────────────────────────
+
+function IssueCardBody({ card, nowMs }: { card: BoardIssueCard; nowMs: number }) {
+  const { issue } = card;
+  return (
+    <>
+      <div className="flex items-start gap-2">
+        <CircleDot className="mt-0.5 size-3.5 shrink-0 text-status-success" />
+        <h3 className="min-w-0 flex-1 text-[13px] font-medium leading-snug text-[var(--text-primary)]">
+          <span className="mr-1 text-[var(--text-muted)]">#{issue.number}</span>
+          {issue.title}
+        </h3>
+        <span className="shrink-0 text-[10px] tabular-nums text-[var(--text-muted)]">
+          {formatAge(issue.updatedAt, nowMs)}
+        </span>
+      </div>
+      <WorkspaceLine name={card.workspaceName} />
+      {issue.labels.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {issue.labels.slice(0, 4).map((label) => (
+            <span
+              key={label}
+              className="rounded-full bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)]"
+            >
+              {label}
+            </span>
+          ))}
+        </div>
+      )}
+      <BoardCardActions card={card} />
+    </>
+  );
+}
+
+// ── Live session cards ──────────────────────────────────────
+
+function SessionCardBody({ card }: { card: BoardSessionCard }) {
+  return (
+    <>
+      <div className="flex items-start gap-2">
+        <PulsingDot tone="var(--status-success)" />
+        <h3 className="min-w-0 flex-1 truncate text-[13px] font-medium leading-snug text-[var(--text-primary)]">
+          {card.title}
+        </h3>
+        <MessageSquare className="size-3.5 shrink-0 text-[var(--text-muted)]" />
+      </div>
+      <WorkspaceLine name={card.workspaceName} />
+      <p className="text-[11px] text-status-success">Live session — responding…</p>
+    </>
+  );
+}
+
+// ── Shared bits ─────────────────────────────────────────────
+
+function WorkspaceLine({ name, branch }: { name: string; branch?: string }) {
+  return (
+    <div className="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+      <span className="truncate">{name}</span>
+      {branch && (
+        <span className="inline-flex min-w-0 items-center gap-0.5 truncate font-mono text-[10px]">
+          <GitBranch className="size-2.5 shrink-0" />
+          <span className="truncate">{branch}</span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** Soft-pulsing status dot for anything currently running. */
+function PulsingDot({ tone }: { tone: string }) {
+  return (
+    <span className="relative mt-1 flex size-2 shrink-0">
+      <motion.span
+        aria-hidden
+        className="absolute inline-flex h-full w-full rounded-full"
+        style={{ background: tone }}
+        animate={{ scale: [1, 2.1], opacity: [0.5, 0] }}
+        transition={{ duration: 1.6, repeat: Infinity, ease: 'easeOut' }}
+      />
+      <span className="relative inline-flex size-2 rounded-full" style={{ background: tone }} />
+    </span>
+  );
+}
+
+/** The live activity line — running step titles with a shimmering sweep. */
+function ActivityLine({ titles }: { titles: string[] }) {
+  const label = titles.length > 1 ? `${titles[0]} +${titles.length - 1} more` : titles[0];
+  return (
+    <div className="relative overflow-hidden rounded-md bg-status-success-faint px-2 py-1">
+      <motion.span
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 w-16"
+        style={{
+          background:
+            'linear-gradient(90deg, transparent, var(--status-success-muted), transparent)',
+        }}
+        animate={{ x: ['-4rem', '18rem'] }}
+        transition={{ duration: 2.2, repeat: Infinity, ease: 'linear' }}
+      />
+      <span className="relative truncate text-[11px] text-status-success">{label}</span>
+    </div>
+  );
+}
+
+function ProgressBar({ done, total }: { done: number; total: number }) {
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1 flex-1 overflow-hidden rounded-full bg-[var(--bg-muted)]">
+        <motion.div
+          className="h-full rounded-full bg-status-success"
+          initial={false}
+          animate={{ width: `${pct}%` }}
+          transition={{ type: 'spring', stiffness: 120, damping: 20 }}
+        />
+      </div>
+      <span className="text-[10px] tabular-nums text-[var(--text-muted)]">
+        {done}/{total}
+      </span>
+    </div>
+  );
+}
+
+/** "claude-sonnet-5" → "sonnet-5"; keeps unknown ids intact. */
+function shortModel(model: string): string {
+  return model.replace(/^claude-/, '').replace(/-\d{8}$/, '');
+}
+
+// ── Drilldown ───────────────────────────────────────────────
+
+/** Clicking a card lands the user where the work actually lives. */
+function openCard(card: BoardCardModel): void {
+  useWorkspaceStore.getState().setActiveWorkspace(card.workspaceId);
+  if (card.kind === 'loop') {
+    void openSeroApp(ORCHESTRATOR_APP_ID, { loopId: card.loop.id });
+    return;
+  }
+  if (card.kind === 'issue') {
+    void window.sero.shell.openExternal(card.issue.url);
+    return;
+  }
+  const info = useSessionStore.getState().sessions.find((s) => s.id === card.sessionId);
+  if (info) {
+    void useAgentStore.getState().openSession(info.id, info.path, info.workspaceId);
+    useAppStore.getState().setChatPanelOpen(true);
+  }
+}

--- a/apps/desktop/src/components/apps/board/BoardCard.tsx
+++ b/apps/desktop/src/components/apps/board/BoardCard.tsx
@@ -14,6 +14,7 @@ import {
   CircleDot,
   GitBranch,
   GitPullRequest,
+  ExternalLink,
   MessageSquare,
 } from 'lucide-react';
 import { useAgentBoardStore } from '@/stores/agent-board';
@@ -21,6 +22,8 @@ import { useWorkspaceStore } from '@/stores/workspace';
 import { useSessionStore } from '@/stores/sessions';
 import { useAgentStore } from '@/stores/agent';
 import { useAppStore } from '@/stores/app';
+import { useBrowserStore } from '@/stores/browser';
+import { useExplorerStore } from '@/stores/explorer';
 import type { BoardColumnId } from '@/types/board';
 import {
   formatAge,
@@ -58,13 +61,11 @@ export const BoardCard = memo(function BoardCard({ card, columnId, nowMs }: Boar
       animate={{ opacity: 1, y: 0, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95, transition: { duration: 0.15 } }}
       transition={CARD_SPRING}
-      whileHover={{ y: -2 }}
-      className={`group relative shrink-0 cursor-pointer overflow-hidden rounded-lg border bg-[var(--bg-surface)] shadow-sm transition-shadow hover:shadow-md ${
+      className={`group relative shrink-0 overflow-hidden rounded-lg border bg-[var(--bg-surface)] shadow-sm transition-shadow hover:shadow-md ${
         columnId === 'attention'
           ? 'border-status-warning-border bg-status-warning-faint'
           : 'border-[var(--border-subtle)]'
       }`}
-      onClick={() => openCard(card)}
     >
       <span
         aria-hidden
@@ -98,10 +99,11 @@ function LoopCardBody({
     <>
       <div className="flex items-start gap-2">
         {running ? <PulsingDot tone="var(--status-success)" /> : null}
-        <h3 className="min-w-0 flex-1 truncate text-[13px] font-medium leading-snug text-[var(--text-primary)]">
+        <h3 className="min-w-0 flex-1 truncate text-base font-medium leading-snug text-[var(--text-primary)]">
           {loop.title}
         </h3>
-        <span className="shrink-0 text-[10px] tabular-nums text-[var(--text-muted)]">
+        <OpenCardButton card={card} />
+        <span className="shrink-0 text-xs tabular-nums text-[var(--text-muted)]">
           {formatAge(loop.updatedAt, nowMs)}
         </span>
       </div>
@@ -116,7 +118,7 @@ function LoopCardBody({
       ) : null}
 
       {card.queuedReason && columnId === 'backlog' ? (
-        <p className="text-[11px] text-[var(--text-muted)]">
+        <p className="text-xs text-[var(--text-muted)]">
           {card.queuedReason === 'draft' && 'Draft — not yet activated'}
           {card.queuedReason === 'scheduled' && `Next run ${formatUntil(card.queuedAt, nowMs)}`}
           {card.queuedReason === 'snoozed' && `Snoozed — retries ${formatUntil(card.queuedAt, nowMs)}`}
@@ -150,7 +152,7 @@ function ChipRow({ card }: { card: BoardLoopCard }) {
   if (!hasChips) return null;
 
   return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 pt-0.5 text-[10px] text-[var(--text-muted)]">
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 pt-0.5 text-xs text-[var(--text-muted)]">
       {loop.lastModel && (
         <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 font-medium text-[var(--text-secondary)]">
           {shortModel(loop.lastModel)}
@@ -182,7 +184,7 @@ function ChipRow({ card }: { card: BoardLoopCard }) {
           title={pr.title}
           onClick={(e) => {
             e.stopPropagation();
-            void window.sero.shell.openExternal(pr.url);
+            openInBrowser(card.workspaceId, pr.url);
           }}
           className="inline-flex items-center gap-0.5 rounded bg-status-info-muted px-1.5 py-0.5 font-medium text-status-info transition-colors hover:bg-status-info-subtle"
         >
@@ -209,11 +211,12 @@ function IssueCardBody({ card, nowMs }: { card: BoardIssueCard; nowMs: number })
     <>
       <div className="flex items-start gap-2">
         <CircleDot className="mt-0.5 size-3.5 shrink-0 text-status-success" />
-        <h3 className="min-w-0 flex-1 text-[13px] font-medium leading-snug text-[var(--text-primary)]">
+        <h3 className="min-w-0 flex-1 text-base font-medium leading-snug text-[var(--text-primary)]">
           <span className="mr-1 text-[var(--text-muted)]">#{issue.number}</span>
           {issue.title}
         </h3>
-        <span className="shrink-0 text-[10px] tabular-nums text-[var(--text-muted)]">
+        <OpenCardButton card={card} />
+        <span className="shrink-0 text-xs tabular-nums text-[var(--text-muted)]">
           {formatAge(issue.updatedAt, nowMs)}
         </span>
       </div>
@@ -223,7 +226,7 @@ function IssueCardBody({ card, nowMs }: { card: BoardIssueCard; nowMs: number })
           {issue.labels.slice(0, 4).map((label) => (
             <span
               key={label}
-              className="rounded-full bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)]"
+              className="rounded-full bg-[var(--bg-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]"
             >
               {label}
             </span>
@@ -242,13 +245,13 @@ function SessionCardBody({ card }: { card: BoardSessionCard }) {
     <>
       <div className="flex items-start gap-2">
         <PulsingDot tone="var(--status-success)" />
-        <h3 className="min-w-0 flex-1 truncate text-[13px] font-medium leading-snug text-[var(--text-primary)]">
+        <h3 className="min-w-0 flex-1 truncate text-base font-medium leading-snug text-[var(--text-primary)]">
           {card.title}
         </h3>
         <MessageSquare className="size-3.5 shrink-0 text-[var(--text-muted)]" />
       </div>
       <WorkspaceLine name={card.workspaceName} />
-      <p className="text-[11px] text-status-success">Live session — responding…</p>
+      <p className="text-xs text-status-success">Live session — responding…</p>
     </>
   );
 }
@@ -257,10 +260,10 @@ function SessionCardBody({ card }: { card: BoardSessionCard }) {
 
 function WorkspaceLine({ name, branch }: { name: string; branch?: string }) {
   return (
-    <div className="flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+    <div className="flex items-center gap-1.5 text-xs text-[var(--text-muted)]">
       <span className="truncate">{name}</span>
       {branch && (
-        <span className="inline-flex min-w-0 items-center gap-0.5 truncate font-mono text-[10px]">
+        <span className="inline-flex min-w-0 items-center gap-0.5 truncate font-mono text-xs">
           <GitBranch className="size-2.5 shrink-0" />
           <span className="truncate">{branch}</span>
         </span>
@@ -300,7 +303,7 @@ function ActivityLine({ titles }: { titles: string[] }) {
         animate={{ x: ['-4rem', '18rem'] }}
         transition={{ duration: 2.2, repeat: Infinity, ease: 'linear' }}
       />
-      <span className="relative truncate text-[11px] text-status-success">{label}</span>
+      <span className="relative truncate text-xs text-status-success">{label}</span>
     </div>
   );
 }
@@ -317,7 +320,7 @@ function ProgressBar({ done, total }: { done: number; total: number }) {
           transition={{ type: 'spring', stiffness: 120, damping: 20 }}
         />
       </div>
-      <span className="text-[10px] tabular-nums text-[var(--text-muted)]">
+      <span className="text-xs tabular-nums text-[var(--text-muted)]">
         {done}/{total}
       </span>
     </div>
@@ -331,7 +334,30 @@ function shortModel(model: string): string {
 
 // ── Drilldown ───────────────────────────────────────────────
 
-/** Clicking a card lands the user where the work actually lives. */
+function OpenCardButton({ card }: { card: BoardLoopCard | BoardIssueCard }) {
+  const label = card.kind === 'loop' ? 'Open loop' : 'Open issue';
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      onClick={() => openCard(card)}
+      className="flex shrink-0 items-center justify-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-overlay)] hover:text-[var(--text-primary)]"
+    >
+      <ExternalLink className="size-3" />
+    </button>
+  );
+}
+
+/** Opens web links in the card's workspace-scoped Explorer browser. */
+function openInBrowser(workspaceId: string, url: string): void {
+  useWorkspaceStore.getState().setActiveWorkspace(workspaceId);
+  useAppStore.getState().setActiveApp('explorer');
+  useExplorerStore.getState().set(workspaceId, { activePanel: 'browser', sidebarOpen: false });
+  useBrowserStore.getState().createTab(workspaceId, url);
+}
+
+/** Opens the work item that the link button explicitly targets. */
 function openCard(card: BoardCardModel): void {
   useWorkspaceStore.getState().setActiveWorkspace(card.workspaceId);
   if (card.kind === 'loop') {
@@ -339,7 +365,7 @@ function openCard(card: BoardCardModel): void {
     return;
   }
   if (card.kind === 'issue') {
-    void window.sero.shell.openExternal(card.issue.url);
+    openInBrowser(card.workspaceId, card.issue.url);
     return;
   }
   const info = useSessionStore.getState().sessions.find((s) => s.id === card.sessionId);

--- a/apps/desktop/src/components/apps/board/BoardCard.tsx
+++ b/apps/desktop/src/components/apps/board/BoardCard.tsx
@@ -5,7 +5,7 @@
  */
 
 import { memo, useEffect } from 'react';
-import { motion } from 'motion/react';
+import { m } from 'motion/react';
 import { openSeroApp } from '@sero-ai/app-runtime';
 import { ORCHESTRATOR_APP_ID } from '@sero-ai/common';
 import {
@@ -54,7 +54,7 @@ interface BoardCardProps {
 
 export const BoardCard = memo(function BoardCard({ card, columnId, nowMs }: BoardCardProps) {
   return (
-    <motion.article
+    <m.article
       layout
       layoutId={card.key}
       initial={{ opacity: 0, y: 14, scale: 0.97 }}
@@ -77,7 +77,7 @@ export const BoardCard = memo(function BoardCard({ card, columnId, nowMs }: Boar
         {card.kind === 'issue' && <IssueCardBody card={card} nowMs={nowMs} />}
         {card.kind === 'session' && <SessionCardBody card={card} />}
       </div>
-    </motion.article>
+    </m.article>
   );
 });
 
@@ -276,7 +276,7 @@ function WorkspaceLine({ name, branch }: { name: string; branch?: string }) {
 function PulsingDot({ tone }: { tone: string }) {
   return (
     <span className="relative mt-1 flex size-2 shrink-0">
-      <motion.span
+      <m.span
         aria-hidden
         className="absolute inline-flex h-full w-full rounded-full"
         style={{ background: tone }}
@@ -293,7 +293,7 @@ function ActivityLine({ titles }: { titles: string[] }) {
   const label = titles.length > 1 ? `${titles[0]} +${titles.length - 1} more` : titles[0];
   return (
     <div className="relative overflow-hidden rounded-md bg-status-success-faint px-2 py-1">
-      <motion.span
+      <m.span
         aria-hidden
         className="pointer-events-none absolute inset-y-0 w-16"
         style={{
@@ -313,10 +313,10 @@ function ProgressBar({ done, total }: { done: number; total: number }) {
   return (
     <div className="flex items-center gap-2">
       <div className="h-1 flex-1 overflow-hidden rounded-full bg-[var(--bg-muted)]">
-        <motion.div
-          className="h-full rounded-full bg-status-success"
+        <m.div
+          className="h-full w-full origin-left rounded-full bg-status-success"
           initial={false}
-          animate={{ width: `${pct}%` }}
+          animate={{ scaleX: pct / 100 }}
           transition={{ type: 'spring', stiffness: 120, damping: 20 }}
         />
       </div>

--- a/apps/desktop/src/components/apps/board/BoardCardActions.tsx
+++ b/apps/desktop/src/components/apps/board/BoardCardActions.tsx
@@ -1,0 +1,305 @@
+/**
+ * Inline actions on Agent Board cards — the "resolve it right here" part.
+ * Renders and routes the orchestrator's existing durable actions (answer a
+ * question, approve a gate or suggestion, retry, run again, activate, start
+ * work on an issue). No second approval layer: the board only forwards.
+ */
+
+import { useState, type MouseEvent } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import { Check, CornerDownLeft, Play, RotateCcw, Sparkles, X } from 'lucide-react';
+import type { OrchestratorBoardAction } from '@sero-ai/common';
+import { openSeroApp } from '@sero-ai/app-runtime';
+import { ORCHESTRATOR_APP_ID } from '@sero-ai/common';
+import { useAgentBoardStore } from '@/stores/agent-board';
+import type { BoardIssueCard, BoardLoopCard } from './board-model';
+
+interface BoardCardActionsProps {
+  card: BoardLoopCard | BoardIssueCard;
+}
+
+export function BoardCardActions({ card }: BoardCardActionsProps) {
+  const requestAction = useAgentBoardStore((s) => s.requestAction);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [text, setText] = useState('');
+
+  async function run(action: OrchestratorBoardAction, e?: MouseEvent): Promise<void> {
+    e?.stopPropagation();
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const result = await requestAction(card.workspaceId, action);
+      if (!result.ok) {
+        setError(result.error ?? 'Action failed');
+      } else if (action.kind === 'fire_event') {
+        setNotice(
+          result.delivered
+            ? `Sent to ${result.delivered} loop${result.delivered === 1 ? '' : 's'}`
+            : 'No loop is listening — install the issue-implementer loop in Orchestrator',
+        );
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const body = card.kind === 'issue'
+    ? renderIssueActions(card, pending, run)
+    : renderLoopActions(card, pending, text, setText, run);
+  if (!body) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2 }}
+      className="flex flex-col gap-1.5"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {body}
+      <AnimatePresence>
+        {(error ?? notice) && (
+          <motion.p
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            className={`text-[11px] ${error ? 'text-status-error' : 'text-[var(--text-muted)]'}`}
+          >
+            {error ?? notice}
+            {notice?.includes('issue-implementer') && (
+              <button
+                type="button"
+                className="ml-1 underline hover:text-[var(--text-primary)]"
+                onClick={() => void openSeroApp(ORCHESTRATOR_APP_ID)}
+              >
+                Open Orchestrator
+              </button>
+            )}
+          </motion.p>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}
+
+// ── Loop attention / lifecycle actions ──────────────────────
+
+type RunFn = (action: OrchestratorBoardAction, e?: MouseEvent) => Promise<void>;
+
+function renderLoopActions(
+  card: BoardLoopCard,
+  pending: boolean,
+  text: string,
+  setText: (value: string) => void,
+  run: RunFn,
+) {
+  const { loop } = card;
+  const input = loop.attention?.input;
+  const question = input?.questions[0];
+
+  if (input && question) {
+    const answer = (choiceId?: string, freeText?: string, e?: MouseEvent) =>
+      run(
+        {
+          kind: 'answer_input',
+          loopId: loop.id,
+          requestId: input.requestId,
+          answers: [{ questionId: question.id, choiceId, text: freeText }],
+        },
+        e,
+      );
+
+    return (
+      <div className="flex flex-col gap-1.5 rounded-md bg-[var(--bg-elevated)]/60 p-2">
+        <p className="text-[11px] leading-snug text-[var(--text-secondary)]">{question.prompt}</p>
+        {question.kind === 'approval' ? (
+          <div className="flex gap-1.5">
+            <ActionButton
+              tone="success"
+              disabled={pending}
+              onClick={(e) => void answer('approve', undefined, e)}
+            >
+              <Check className="size-3" /> Approve
+            </ActionButton>
+            <ActionButton
+              tone="danger"
+              disabled={pending}
+              onClick={(e) => void answer('reject', undefined, e)}
+            >
+              <X className="size-3" /> Reject
+            </ActionButton>
+          </div>
+        ) : question.choices?.length ? (
+          <div className="flex flex-wrap gap-1">
+            {question.choices.map((choice) => (
+              <ActionButton
+                key={choice.id}
+                tone="neutral"
+                disabled={pending}
+                onClick={(e) => void answer(choice.id, undefined, e)}
+              >
+                {choice.label}
+              </ActionButton>
+            ))}
+          </div>
+        ) : (
+          <div className="flex items-center gap-1">
+            <input
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && text.trim()) void answer(undefined, text.trim());
+              }}
+              placeholder="Answer…"
+              className="h-6 min-w-0 flex-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-base)] px-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--border-focus)]"
+            />
+            <ActionButton
+              tone="neutral"
+              disabled={pending || !text.trim()}
+              onClick={(e) => void answer(undefined, text.trim(), e)}
+            >
+              <CornerDownLeft className="size-3" />
+            </ActionButton>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  const suggestion = loop.attention?.suggestions?.[0];
+  if (suggestion) {
+    return (
+      <div className="flex flex-col gap-1.5 rounded-md bg-[var(--bg-elevated)]/60 p-2">
+        <p className="flex items-start gap-1 text-[11px] leading-snug text-[var(--text-secondary)]">
+          <Sparkles className="mt-0.5 size-3 shrink-0 text-status-info" />
+          {suggestion.rationale}
+        </p>
+        <div className="flex gap-1.5">
+          <ActionButton
+            tone="success"
+            disabled={pending}
+            onClick={(e) =>
+              void run(
+                { kind: 'choose_suggestion', loopId: loop.id, suggestionId: suggestion.id, decision: 'approve' },
+                e,
+              )
+            }
+          >
+            <Check className="size-3" /> Apply
+          </ActionButton>
+          <ActionButton
+            tone="neutral"
+            disabled={pending}
+            onClick={(e) =>
+              void run(
+                { kind: 'choose_suggestion', loopId: loop.id, suggestionId: suggestion.id, decision: 'reject' },
+                e,
+              )
+            }
+          >
+            Dismiss
+          </ActionButton>
+        </div>
+      </div>
+    );
+  }
+
+  if (loop.status === 'blocked') {
+    return (
+      <div className="flex gap-1.5">
+        <ActionButton tone="neutral" disabled={pending} onClick={(e) => void run({ kind: 'retry', loopId: loop.id }, e)}>
+          <RotateCcw className="size-3" /> Retry
+        </ActionButton>
+        <ActionButton tone="neutral" disabled={pending} onClick={(e) => void run({ kind: 'run_again', loopId: loop.id }, e)}>
+          <Play className="size-3" /> Run again
+        </ActionButton>
+      </div>
+    );
+  }
+
+  if (loop.status === 'draft') {
+    return (
+      <div className="flex gap-1.5">
+        <ActionButton tone="success" disabled={pending} onClick={(e) => void run({ kind: 'activate', loopId: loop.id }, e)}>
+          <Play className="size-3" /> Activate
+        </ActionButton>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ── Issue actions (backlog) ─────────────────────────────────
+
+function renderIssueActions(card: BoardIssueCard, pending: boolean, run: RunFn) {
+  const { issue } = card;
+  return (
+    <div className="flex gap-1.5">
+      <ActionButton
+        tone="success"
+        disabled={pending}
+        onClick={(e) =>
+          void run(
+            {
+              kind: 'fire_event',
+              event: {
+                id: crypto.randomUUID(),
+                source: 'github:issue-opened',
+                payload: {
+                  number: issue.number,
+                  title: issue.title,
+                  url: issue.url,
+                  labels: issue.labels,
+                },
+                occurredAt: new Date().toISOString(),
+                summary: `Start work on issue #${issue.number}: ${issue.title}`,
+              },
+            },
+            e,
+          )
+        }
+      >
+        <Play className="size-3" /> Start work
+      </ActionButton>
+    </div>
+  );
+}
+
+// ── Tiny styled button ──────────────────────────────────────
+
+function ActionButton({
+  tone,
+  disabled,
+  onClick,
+  children,
+}: {
+  tone: 'success' | 'danger' | 'neutral';
+  disabled?: boolean;
+  onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+  children: React.ReactNode;
+}) {
+  const toneClass =
+    tone === 'success'
+      ? 'bg-status-success-muted text-status-success hover:bg-status-success-subtle'
+      : tone === 'danger'
+        ? 'bg-status-error-muted text-status-error hover:bg-status-error-subtle'
+        : 'bg-[var(--bg-elevated)] text-[var(--text-secondary)] hover:bg-[var(--bg-overlay)]';
+  return (
+    <motion.button
+      type="button"
+      whileTap={{ scale: 0.95 }}
+      disabled={disabled}
+      onClick={onClick}
+      className={`inline-flex h-6 items-center gap-1 rounded-md px-2 text-[11px] font-medium transition-colors disabled:opacity-50 ${toneClass}`}
+    >
+      {children}
+    </motion.button>
+  );
+}

--- a/apps/desktop/src/components/apps/board/BoardCardActions.tsx
+++ b/apps/desktop/src/components/apps/board/BoardCardActions.tsx
@@ -69,7 +69,7 @@ export function BoardCardActions({ card }: BoardCardActionsProps) {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
-            className={`text-[11px] ${error ? 'text-status-error' : 'text-[var(--text-muted)]'}`}
+            className={`text-sm ${error ? 'text-status-error' : 'text-[var(--text-muted)]'}`}
           >
             {error ?? notice}
             {notice?.includes('issue-implementer') && (
@@ -117,7 +117,7 @@ function renderLoopActions(
 
     return (
       <div className="flex flex-col gap-1.5 rounded-md bg-[var(--bg-elevated)]/60 p-2">
-        <p className="text-[11px] leading-snug text-[var(--text-secondary)]">{question.prompt}</p>
+        <p className="text-sm leading-snug text-[var(--text-secondary)]">{question.prompt}</p>
         {question.kind === 'approval' ? (
           <div className="flex gap-1.5">
             <ActionButton
@@ -157,7 +157,7 @@ function renderLoopActions(
                 if (e.key === 'Enter' && text.trim()) void answer(undefined, text.trim());
               }}
               placeholder="Answer…"
-              className="h-6 min-w-0 flex-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-base)] px-1.5 text-[11px] text-[var(--text-primary)] outline-none focus:border-[var(--border-focus)]"
+              className="h-6 min-w-0 flex-1 rounded border border-[var(--border-subtle)] bg-[var(--bg-base)] px-1.5 text-sm text-[var(--text-primary)] outline-none focus:border-[var(--border-focus)]"
             />
             <ActionButton
               tone="neutral"
@@ -176,7 +176,7 @@ function renderLoopActions(
   if (suggestion) {
     return (
       <div className="flex flex-col gap-1.5 rounded-md bg-[var(--bg-elevated)]/60 p-2">
-        <p className="flex items-start gap-1 text-[11px] leading-snug text-[var(--text-secondary)]">
+        <p className="flex items-start gap-1 text-sm leading-snug text-[var(--text-secondary)]">
           <Sparkles className="mt-0.5 size-3 shrink-0 text-status-info" />
           {suggestion.rationale}
         </p>
@@ -297,7 +297,7 @@ function ActionButton({
       whileTap={{ scale: 0.95 }}
       disabled={disabled}
       onClick={onClick}
-      className={`inline-flex h-6 items-center gap-1 rounded-md px-2 text-[11px] font-medium transition-colors disabled:opacity-50 ${toneClass}`}
+      className={`inline-flex h-6 items-center gap-1 rounded-md px-2 text-sm font-medium transition-colors disabled:opacity-50 ${toneClass}`}
     >
       {children}
     </motion.button>

--- a/apps/desktop/src/components/apps/board/BoardCardActions.tsx
+++ b/apps/desktop/src/components/apps/board/BoardCardActions.tsx
@@ -21,6 +21,7 @@ interface BoardCardActionsProps {
 export function BoardCardActions({ card }: BoardCardActionsProps) {
   const requestAction = useAgentBoardStore((s) => s.requestAction);
   const [pending, setPending] = useState(false);
+  const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [text, setText] = useState('');
@@ -36,11 +37,15 @@ export function BoardCardActions({ card }: BoardCardActionsProps) {
       if (!result.ok) {
         setError(result.error ?? 'Action failed');
       } else if (action.kind === 'fire_event') {
-        setNotice(
-          result.delivered
-            ? `Sent to ${result.delivered} loop${result.delivered === 1 ? '' : 's'}`
-            : 'No loop is listening — install the issue-implementer loop in Orchestrator',
-        );
+        if (result.deduped) {
+          setSent(true);
+          setNotice('Already sent — a loop is on it');
+        } else if (result.delivered) {
+          setSent(true);
+          setNotice(`Sent to ${result.delivered} loop${result.delivered === 1 ? '' : 's'}`);
+        } else {
+          setNotice('No loop is listening — install the issue-implementer loop in Orchestrator');
+        }
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -50,7 +55,7 @@ export function BoardCardActions({ card }: BoardCardActionsProps) {
   }
 
   const body = card.kind === 'issue'
-    ? renderIssueActions(card, pending, run)
+    ? renderIssueActions(card, pending, sent, run)
     : renderLoopActions(card, pending, text, setText, run);
   if (!body) return null;
 
@@ -238,13 +243,13 @@ function renderLoopActions(
 
 // ── Issue actions (backlog) ─────────────────────────────────
 
-function renderIssueActions(card: BoardIssueCard, pending: boolean, run: RunFn) {
+function renderIssueActions(card: BoardIssueCard, pending: boolean, sent: boolean, run: RunFn) {
   const { issue } = card;
   return (
     <div className="flex gap-1.5">
       <ActionButton
         tone="success"
-        disabled={pending}
+        disabled={pending || sent}
         onClick={(e) =>
           void run(
             {
@@ -260,13 +265,18 @@ function renderIssueActions(card: BoardIssueCard, pending: boolean, run: RunFn) 
                 },
                 occurredAt: new Date().toISOString(),
                 summary: `Start work on issue #${issue.number}: ${issue.title}`,
+                // Restart-safe duplicate guard: repeated Start-work clicks on the
+                // same issue dedupe in the coordinator. The `board:` prefix keeps
+                // the key clear of the GitHub adapter's `github:<kind>:<id>` keys.
+                dedupeKey: `board:issue-${issue.number}`,
               },
             },
             e,
           )
         }
       >
-        <Play className="size-3" /> Start work
+        {sent ? <Check className="size-3" /> : <Play className="size-3" />}
+        {sent ? 'Sent' : 'Start work'}
       </ActionButton>
     </div>
   );

--- a/apps/desktop/src/components/apps/board/BoardCardActions.tsx
+++ b/apps/desktop/src/components/apps/board/BoardCardActions.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, type MouseEvent } from 'react';
-import { AnimatePresence, motion } from 'motion/react';
+import { AnimatePresence, m } from 'motion/react';
 import { Check, CornerDownLeft, Play, RotateCcw, Sparkles, X } from 'lucide-react';
 import type { OrchestratorBoardAction } from '@sero-ai/common';
 import { openSeroApp } from '@sero-ai/app-runtime';
@@ -60,7 +60,7 @@ export function BoardCardActions({ card }: BoardCardActionsProps) {
   if (!body) return null;
 
   return (
-    <motion.div
+    <m.div
       initial={{ opacity: 0, y: 4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.2 }}
@@ -70,10 +70,11 @@ export function BoardCardActions({ card }: BoardCardActionsProps) {
       {body}
       <AnimatePresence>
         {(error ?? notice) && (
-          <motion.p
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
+          <m.p
+            layout
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
             className={`text-sm ${error ? 'text-status-error' : 'text-[var(--text-muted)]'}`}
           >
             {error ?? notice}
@@ -86,10 +87,10 @@ export function BoardCardActions({ card }: BoardCardActionsProps) {
                 Open Orchestrator
               </button>
             )}
-          </motion.p>
+          </m.p>
         )}
       </AnimatePresence>
-    </motion.div>
+    </m.div>
   );
 }
 
@@ -302,7 +303,7 @@ function ActionButton({
         ? 'bg-status-error-muted text-status-error hover:bg-status-error-subtle'
         : 'bg-[var(--bg-elevated)] text-[var(--text-secondary)] hover:bg-[var(--bg-overlay)]';
   return (
-    <motion.button
+    <m.button
       type="button"
       whileTap={{ scale: 0.95 }}
       disabled={disabled}
@@ -310,6 +311,6 @@ function ActionButton({
       className={`inline-flex h-6 items-center gap-1 rounded-md px-2 text-sm font-medium transition-colors disabled:opacity-50 ${toneClass}`}
     >
       {children}
-    </motion.button>
+    </m.button>
   );
 }

--- a/apps/desktop/src/components/apps/board/BoardColumn.tsx
+++ b/apps/desktop/src/components/apps/board/BoardColumn.tsx
@@ -5,14 +5,13 @@
  */
 
 import { memo } from 'react';
-import { AnimatePresence, motion } from 'motion/react';
+import { AnimatePresence, m } from 'motion/react';
 import { ChevronDown } from 'lucide-react';
 import { useAgentBoardStore } from '@/stores/agent-board';
 import type { BoardColumnId } from '@/types/board';
 import type { BoardCard as BoardCardModel } from './board-model';
+import { COLUMN_ORDER } from './board-constants';
 import { BoardCard } from './BoardCard';
-
-export const COLUMN_ORDER: BoardColumnId[] = ['backlog', 'active', 'attention', 'done'];
 
 const COLUMN_META: Record<
   BoardColumnId,
@@ -61,7 +60,7 @@ export const BoardColumn = memo(function BoardColumn({
   const highlight = columnId === 'attention' && cards.length > 0;
 
   return (
-    <motion.section
+    <m.section
       initial={{ opacity: 0, y: 16 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.35, delay: index * 0.06, ease: 'easeOut' }}
@@ -79,7 +78,7 @@ export const BoardColumn = memo(function BoardColumn({
           {meta.label}
         </span>
         <AnimatePresence mode="popLayout" initial={false}>
-          <motion.span
+          <m.span
             key={cards.length}
             initial={{ opacity: 0, scale: 0.6 }}
             animate={{ opacity: 1, scale: 1 }}
@@ -88,24 +87,25 @@ export const BoardColumn = memo(function BoardColumn({
             className={`rounded-full px-1.5 py-0.5 text-xs font-semibold tabular-nums ${meta.countClass}`}
           >
             {cards.length}
-          </motion.span>
+          </m.span>
         </AnimatePresence>
-        <motion.span
+        <m.span
           animate={{ rotate: collapsed ? -90 : 0 }}
           transition={{ duration: 0.15 }}
           className="ml-auto text-[var(--text-muted)]"
         >
           <ChevronDown className="size-3.5" />
-        </motion.span>
+        </m.span>
       </button>
 
       <AnimatePresence initial={false}>
         {!collapsed && (
-          <motion.div
+          <m.div
             key="body"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
+            layout
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
             transition={{ duration: 0.2, ease: 'easeInOut' }}
             className="min-h-0 flex-1 overflow-hidden"
           >
@@ -121,9 +121,9 @@ export const BoardColumn = memo(function BoardColumn({
                 </div>
               )}
             </div>
-          </motion.div>
+          </m.div>
         )}
       </AnimatePresence>
-    </motion.section>
+    </m.section>
   );
 });

--- a/apps/desktop/src/components/apps/board/BoardColumn.tsx
+++ b/apps/desktop/src/components/apps/board/BoardColumn.tsx
@@ -85,7 +85,7 @@ export const BoardColumn = memo(function BoardColumn({
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.6 }}
             transition={{ type: 'spring', stiffness: 500, damping: 30 }}
-            className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold tabular-nums ${meta.countClass}`}
+            className={`rounded-full px-1.5 py-0.5 text-xs font-semibold tabular-nums ${meta.countClass}`}
           >
             {cards.length}
           </motion.span>

--- a/apps/desktop/src/components/apps/board/BoardColumn.tsx
+++ b/apps/desktop/src/components/apps/board/BoardColumn.tsx
@@ -1,0 +1,129 @@
+/**
+ * One Agent Board column: accent-coloured header with an animated count,
+ * collapsible body, and spring-animated card list. Cards share layoutIds
+ * across columns, so a loop finishing visibly glides from Active to Finished.
+ */
+
+import { memo } from 'react';
+import { AnimatePresence, motion } from 'motion/react';
+import { ChevronDown } from 'lucide-react';
+import { useAgentBoardStore } from '@/stores/agent-board';
+import type { BoardColumnId } from '@/types/board';
+import type { BoardCard as BoardCardModel } from './board-model';
+import { BoardCard } from './BoardCard';
+
+export const COLUMN_ORDER: BoardColumnId[] = ['backlog', 'active', 'attention', 'done'];
+
+const COLUMN_META: Record<
+  BoardColumnId,
+  { label: string; dot: string; countClass: string }
+> = {
+  backlog: {
+    label: 'Backlog',
+    dot: 'bg-[var(--text-muted)]',
+    countClass: 'bg-[var(--bg-overlay)] text-[var(--text-muted)]',
+  },
+  active: {
+    label: 'Active',
+    dot: 'bg-status-success',
+    countClass: 'bg-status-success-muted text-status-success',
+  },
+  attention: {
+    label: 'Needs Attention',
+    dot: 'bg-status-warning',
+    countClass: 'bg-status-warning-muted text-status-warning',
+  },
+  done: {
+    label: 'Finished',
+    dot: 'bg-status-info',
+    countClass: 'bg-status-info-muted text-status-info',
+  },
+};
+
+interface BoardColumnProps {
+  columnId: BoardColumnId;
+  cards: BoardCardModel[];
+  collapsed: boolean;
+  /** Column position, drives the staggered entrance. */
+  index: number;
+  nowMs: number;
+}
+
+export const BoardColumn = memo(function BoardColumn({
+  columnId,
+  cards,
+  collapsed,
+  index,
+  nowMs,
+}: BoardColumnProps) {
+  const toggleColumn = useAgentBoardStore((s) => s.toggleColumn);
+  const meta = COLUMN_META[columnId];
+  const highlight = columnId === 'attention' && cards.length > 0;
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.35, delay: index * 0.06, ease: 'easeOut' }}
+      className={`flex min-h-0 flex-col rounded-xl border bg-[var(--bg-surface)]/60 ${
+        highlight ? 'border-status-warning-border' : 'border-[var(--border-subtle)]'
+      }`}
+    >
+      <button
+        type="button"
+        onClick={() => toggleColumn(columnId)}
+        className="flex shrink-0 items-center gap-2 rounded-t-xl px-3 py-2.5 text-left transition-colors hover:bg-[var(--bg-overlay)]/50"
+      >
+        <span className={`size-2 shrink-0 rounded-full ${meta.dot}`} />
+        <span className="text-xs font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+          {meta.label}
+        </span>
+        <AnimatePresence mode="popLayout" initial={false}>
+          <motion.span
+            key={cards.length}
+            initial={{ opacity: 0, scale: 0.6 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.6 }}
+            transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+            className={`rounded-full px-1.5 py-0.5 text-[10px] font-semibold tabular-nums ${meta.countClass}`}
+          >
+            {cards.length}
+          </motion.span>
+        </AnimatePresence>
+        <motion.span
+          animate={{ rotate: collapsed ? -90 : 0 }}
+          transition={{ duration: 0.15 }}
+          className="ml-auto text-[var(--text-muted)]"
+        >
+          <ChevronDown className="size-3.5" />
+        </motion.span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {!collapsed && (
+          <motion.div
+            key="body"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className="min-h-0 flex-1 overflow-hidden"
+          >
+            <div className="flex h-full flex-col gap-2 overflow-y-auto px-2 pb-2">
+              <AnimatePresence mode="popLayout" initial={false}>
+                {cards.map((card) => (
+                  <BoardCard key={card.key} card={card} columnId={columnId} nowMs={nowMs} />
+                ))}
+              </AnimatePresence>
+              {cards.length === 0 && (
+                <div className="mx-1 mt-1 rounded-lg border border-dashed border-[var(--border-subtle)] px-3 py-6 text-center text-xs text-[var(--text-muted)]">
+                  {columnId === 'attention' ? 'All clear' : 'Nothing here'}
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.section>
+  );
+});

--- a/apps/desktop/src/components/apps/board/board-constants.ts
+++ b/apps/desktop/src/components/apps/board/board-constants.ts
@@ -1,0 +1,3 @@
+import type { BoardColumnId } from '@/types/board';
+
+export const COLUMN_ORDER: BoardColumnId[] = ['backlog', 'active', 'attention', 'done'];

--- a/apps/desktop/src/components/apps/board/board-model.test.ts
+++ b/apps/desktop/src/components/apps/board/board-model.test.ts
@@ -55,7 +55,7 @@ function pr(partial: Partial<AppRuntimePullRequestSummary>): AppRuntimePullReque
 }
 
 function slice(partial: Partial<WorkspaceBoardSlice>): Record<string, WorkspaceBoardSlice> {
-  return { ws1: { index: null, git: null, issues: [], openPrs: [], ...partial } };
+  return { ws1: { index: null, issues: [], openPrs: [], ...partial } };
 }
 
 describe('loopColumn', () => {

--- a/apps/desktop/src/components/apps/board/board-model.test.ts
+++ b/apps/desktop/src/components/apps/board/board-model.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  AppRuntimeIssueSummary,
+  AppRuntimePullRequestSummary,
+  OrchestratorBoardLoopView,
+} from '@sero-ai/common';
+import type { WorkspaceBoardSlice } from '@/types/board';
+import {
+  buildBoardColumns,
+  extractClosedIssueNumbers,
+  formatAge,
+  formatCost,
+  formatTokens,
+  formatUntil,
+  isUnclaimedIssue,
+  loopColumn,
+  type BoardWorkspace,
+} from './board-model';
+
+const NOW = Date.parse('2026-07-18T12:00:00Z');
+
+const WS: BoardWorkspace = { id: 'ws1', name: 'Sero', path: '/tmp/ws1' };
+
+function loop(partial: Partial<OrchestratorBoardLoopView>): OrchestratorBoardLoopView {
+  return {
+    id: 'loop-1',
+    title: 'Fix flaky tests',
+    status: 'active',
+    updatedAt: '2026-07-18T11:00:00Z',
+    ...partial,
+  };
+}
+
+function issue(partial: Partial<AppRuntimeIssueSummary>): AppRuntimeIssueSummary {
+  return {
+    number: 42,
+    url: 'https://github.com/o/r/issues/42',
+    title: 'Broken thing',
+    labels: [],
+    assignees: [],
+    updatedAt: '2026-07-18T10:00:00Z',
+    ...partial,
+  };
+}
+
+function pr(partial: Partial<AppRuntimePullRequestSummary>): AppRuntimePullRequestSummary {
+  return {
+    number: 7,
+    url: 'https://github.com/o/r/pull/7',
+    title: 'A PR',
+    headRefName: 'feature',
+    updatedAt: '2026-07-18T10:30:00Z',
+    ...partial,
+  };
+}
+
+function slice(partial: Partial<WorkspaceBoardSlice>): Record<string, WorkspaceBoardSlice> {
+  return { ws1: { index: null, git: null, issues: [], openPrs: [], ...partial } };
+}
+
+describe('loopColumn', () => {
+  it('routes attention payloads and blocked loops to Needs Attention', () => {
+    expect(loopColumn(loop({ attention: { suggestions: [] } }), NOW)).toBe('attention');
+    expect(loopColumn(loop({ status: 'blocked' }), NOW)).toBe('attention');
+  });
+
+  it('routes drafts and queued work to Backlog', () => {
+    expect(loopColumn(loop({ status: 'draft' }), NOW)).toBe('backlog');
+    expect(loopColumn(loop({ snoozedUntil: '2026-07-18T14:00:00Z' }), NOW)).toBe('backlog');
+    expect(
+      loopColumn(
+        loop({
+          schedules: [
+            { triggerId: 't1', type: 'cron', schedule: '0 * * * *', nextFireAt: '2026-07-18T13:00:00Z' },
+          ],
+        }),
+        NOW,
+      ),
+    ).toBe('backlog');
+  });
+
+  it('keeps running and idle unscheduled loops in Active', () => {
+    expect(loopColumn(loop({ progress: { total: 3, done: 1, running: true } }), NOW)).toBe('active');
+    expect(loopColumn(loop({}), NOW)).toBe('active');
+  });
+
+  it('running wins over an upcoming schedule', () => {
+    expect(
+      loopColumn(
+        loop({
+          progress: { total: 3, done: 1, running: true },
+          schedules: [
+            { triggerId: 't1', type: 'cron', schedule: '0 * * * *', nextFireAt: '2026-07-18T13:00:00Z' },
+          ],
+        }),
+        NOW,
+      ),
+    ).toBe('active');
+  });
+
+  it('routes complete to Finished and hides disabled', () => {
+    expect(loopColumn(loop({ status: 'complete' }), NOW)).toBe('done');
+    expect(loopColumn(loop({ status: 'disabled' }), NOW)).toBeNull();
+  });
+
+  it('ignores an elapsed snooze and paused/exhausted schedules', () => {
+    expect(loopColumn(loop({ snoozedUntil: '2026-07-18T11:59:00Z' }), NOW)).toBe('active');
+    expect(
+      loopColumn(
+        loop({
+          schedules: [
+            { triggerId: 't1', type: 'cron', schedule: '0 * * * *', nextFireAt: '2026-07-18T13:00:00Z', paused: true },
+          ],
+        }),
+        NOW,
+      ),
+    ).toBe('active');
+  });
+});
+
+describe('issue claiming', () => {
+  it('extracts closing keywords case-insensitively and dedupes', () => {
+    expect(extractClosedIssueNumbers('Closes #12, fixes #9 and closes #12')).toEqual([12, 9]);
+    expect(extractClosedIssueNumbers('Resolved #3')).toEqual([3]);
+    expect(extractClosedIssueNumbers('see #4')).toEqual([]);
+    expect(extractClosedIssueNumbers(undefined)).toEqual([]);
+  });
+
+  it('treats assigned issues and PR-linked issues as claimed', () => {
+    expect(isUnclaimedIssue(issue({ assignees: ['someone'] }), [])).toBe(false);
+    expect(isUnclaimedIssue(issue({}), [pr({ body: 'Closes #42' })])).toBe(false);
+    expect(isUnclaimedIssue(issue({}), [pr({ body: 'Closes #41' })])).toBe(true);
+    expect(isUnclaimedIssue(issue({}), [])).toBe(true);
+  });
+});
+
+describe('buildBoardColumns', () => {
+  it('merges loops, unclaimed issues, and live sessions into columns', () => {
+    const columns = buildBoardColumns(
+      [WS],
+      slice({
+        index: {
+          loops: [
+            loop({ id: 'running', progress: { total: 2, done: 1, running: true } }),
+            loop({ id: 'draft', status: 'draft' }),
+            loop({ id: 'needy', attention: { suggestions: [] } }),
+            loop({ id: 'finished', status: 'complete' }),
+            loop({ id: 'hidden', status: 'disabled' }),
+          ],
+        },
+        issues: [issue({ number: 42 }), issue({ number: 43, assignees: ['x'] })],
+      }),
+      [{ sessionId: 's1', workspaceId: 'ws1', title: 'Chat', streaming: true }],
+      NOW,
+    );
+
+    expect(columns.active.map((c) => c.key)).toEqual(['ws1:session:s1', 'ws1:loop:running']);
+    expect(columns.backlog.map((c) => c.key)).toEqual(['ws1:loop:draft', 'ws1:issue:42']);
+    expect(columns.attention.map((c) => c.key)).toEqual(['ws1:loop:needy']);
+    expect(columns.done.map((c) => c.key)).toEqual(['ws1:loop:finished']);
+  });
+
+  it('links loop PRs to the issues they close and drops those issues from Backlog', () => {
+    const columns = buildBoardColumns(
+      [WS],
+      slice({
+        index: {
+          loops: [
+            loop({
+              id: 'worker',
+              progress: { total: 2, done: 0, running: true },
+              pullRequests: [{ number: 7, url: 'https://github.com/o/r/pull/7', title: 'Fix' }],
+            }),
+          ],
+        },
+        issues: [issue({ number: 42 })],
+        openPrs: [pr({ number: 7, body: 'Closes #42' })],
+      }),
+      [],
+      NOW,
+    );
+
+    expect(columns.backlog).toEqual([]);
+    expect(columns.active[0]).toMatchObject({ kind: 'loop', issueNumbers: [42] });
+  });
+
+  it('orders backlog by fire time before drafts before issues', () => {
+    const columns = buildBoardColumns(
+      [WS],
+      slice({
+        index: {
+          loops: [
+            loop({ id: 'draft', status: 'draft' }),
+            loop({
+              id: 'soon',
+              schedules: [
+                { triggerId: 't', type: 'cron', schedule: '0 * * * *', nextFireAt: '2026-07-18T13:00:00Z' },
+              ],
+            }),
+          ],
+        },
+        issues: [issue({ number: 42 })],
+      }),
+      [],
+      NOW,
+    );
+    expect(columns.backlog.map((c) => c.key)).toEqual([
+      'ws1:loop:soon',
+      'ws1:loop:draft',
+      'ws1:issue:42',
+    ]);
+  });
+});
+
+describe('formatting', () => {
+  it('formats tokens, cost, and relative times compactly', () => {
+    expect(formatTokens(999)).toBe('999');
+    expect(formatTokens(12_345)).toBe('12.3k');
+    expect(formatTokens(2_500_000)).toBe('2.5M');
+    expect(formatCost(0.42)).toBe('$0.42');
+    expect(formatCost(0.004)).toBe('$0.004');
+    expect(formatAge('2026-07-18T11:59:20Z', NOW)).toBe('40s');
+    expect(formatAge('2026-07-16T12:00:00Z', NOW)).toBe('2d');
+    expect(formatUntil('2026-07-18T13:30:00Z', NOW)).toBe('in 2h');
+    expect(formatUntil('2026-07-18T11:00:00Z', NOW)).toBe('due');
+  });
+});

--- a/apps/desktop/src/components/apps/board/board-model.ts
+++ b/apps/desktop/src/components/apps/board/board-model.ts
@@ -82,16 +82,22 @@ export function isUnclaimedIssue(
   openPrs: AppRuntimePullRequestSummary[],
 ): boolean {
   if (issue.assignees.length > 0) return false;
-  return !openPrs.some((pr) => extractClosedIssueNumbers(pr.body).includes(issue.number));
+  const closedIssueNumbers = new Set(
+    openPrs.flatMap((pullRequest) => extractClosedIssueNumbers(pullRequest.body)),
+  );
+  return !closedIssueNumbers.has(issue.number);
 }
 
 /** The soonest upcoming fire across a loop's schedules (paused/exhausted excluded). */
 function nextScheduledFire(loop: OrchestratorBoardLoopView): string | undefined {
-  const fires = (loop.schedules ?? [])
-    .filter((s) => !s.paused && !s.exhausted && s.nextFireAt)
-    .map((s) => s.nextFireAt as string)
-    .sort();
-  return fires[0];
+  let nextFire: string | undefined;
+  for (const schedule of loop.schedules ?? []) {
+    if (!schedule.paused && !schedule.exhausted && schedule.nextFireAt
+      && (!nextFire || schedule.nextFireAt < nextFire)) {
+      nextFire = schedule.nextFireAt;
+    }
+  }
+  return nextFire;
 }
 
 /** Which column a loop belongs to. Null = not shown (disabled loops). */
@@ -114,9 +120,9 @@ function toLoopCard(
   nowMs: number,
 ): BoardLoopCard {
   const prNumbers = new Set((loop.pullRequests ?? []).map((pr) => pr.number));
-  const issueNumbers = openPrs
-    .filter((pr) => prNumbers.has(pr.number))
-    .flatMap((pr) => extractClosedIssueNumbers(pr.body));
+  const issueNumbers = openPrs.flatMap((pullRequest) =>
+    prNumbers.has(pullRequest.number) ? extractClosedIssueNumbers(pullRequest.body) : [],
+  );
   const card: BoardLoopCard = {
     kind: 'loop',
     key: `${workspace.id}:loop:${loop.id}`,

--- a/apps/desktop/src/components/apps/board/board-model.ts
+++ b/apps/desktop/src/components/apps/board/board-model.ts
@@ -1,0 +1,272 @@
+/**
+ * Agent Board model — pure mapping from watched per-workspace state to the four
+ * board columns (Backlog · Active · Needs Attention · Finished). No IO, no
+ * heuristics: every card and column membership is derived from durable state
+ * (docs/features/agent-board/plan.md §4).
+ */
+
+import type {
+  AppRuntimeIssueSummary,
+  AppRuntimePullRequestSummary,
+  OrchestratorBoardLoopView,
+} from '@sero-ai/common';
+import type { BoardColumnId, WorkspaceBoardSlice } from '@/types/board';
+
+export interface BoardWorkspace {
+  id: string;
+  name: string;
+  path: string;
+}
+
+export interface BoardSession {
+  sessionId: string;
+  workspaceId: string;
+  title: string;
+  streaming: boolean;
+}
+
+export interface BoardLoopCard {
+  kind: 'loop';
+  key: string;
+  workspaceId: string;
+  workspaceName: string;
+  loop: OrchestratorBoardLoopView;
+  /** Issue numbers this loop's PRs close — rendered as #N chips. */
+  issueNumbers: number[];
+  /** Backlog cards only: why the work is parked and when it fires. */
+  queuedReason?: 'draft' | 'scheduled' | 'snoozed';
+  queuedAt?: string;
+}
+
+export interface BoardIssueCard {
+  kind: 'issue';
+  key: string;
+  workspaceId: string;
+  workspaceName: string;
+  issue: AppRuntimeIssueSummary;
+}
+
+export interface BoardSessionCard {
+  kind: 'session';
+  key: string;
+  workspaceId: string;
+  workspaceName: string;
+  sessionId: string;
+  title: string;
+}
+
+export type BoardCard = BoardLoopCard | BoardIssueCard | BoardSessionCard;
+
+export type BoardColumns = Record<BoardColumnId, BoardCard[]>;
+
+/** Finished stays bounded — most recent first. */
+const FINISHED_CARD_CAP = 30;
+
+const CLOSING_KEYWORD_RE = /(?:clos(?:e|es|ed)|fix(?:es|ed)?|resolv(?:e|es|ed))\s+#(\d+)/gi;
+
+/** Issue numbers a PR body claims to close (the `Closes #N` convention). */
+export function extractClosedIssueNumbers(body: string | undefined): number[] {
+  if (!body) return [];
+  const numbers = new Set<number>();
+  for (const match of body.matchAll(CLOSING_KEYWORD_RE)) numbers.add(Number(match[1]));
+  return [...numbers];
+}
+
+/**
+ * Unclaimed = mechanically checkable only (the spec-15 claim filter): not
+ * assigned and no open PR referencing it. Claim comments need an extra API
+ * call, so a claimed-by-comment issue disappears once its PR opens.
+ */
+export function isUnclaimedIssue(
+  issue: AppRuntimeIssueSummary,
+  openPrs: AppRuntimePullRequestSummary[],
+): boolean {
+  if (issue.assignees.length > 0) return false;
+  return !openPrs.some((pr) => extractClosedIssueNumbers(pr.body).includes(issue.number));
+}
+
+/** The soonest upcoming fire across a loop's schedules (paused/exhausted excluded). */
+function nextScheduledFire(loop: OrchestratorBoardLoopView): string | undefined {
+  const fires = (loop.schedules ?? [])
+    .filter((s) => !s.paused && !s.exhausted && s.nextFireAt)
+    .map((s) => s.nextFireAt as string)
+    .sort();
+  return fires[0];
+}
+
+/** Which column a loop belongs to. Null = not shown (disabled loops). */
+export function loopColumn(loop: OrchestratorBoardLoopView, nowMs: number): BoardColumnId | null {
+  if (loop.status === 'disabled') return null;
+  if (loop.attention || loop.status === 'blocked') return 'attention';
+  if (loop.status === 'draft') return 'backlog';
+  if (loop.status === 'complete') return 'done';
+  // status 'active'
+  if (loop.progress?.running) return 'active';
+  if (loop.snoozedUntil && Date.parse(loop.snoozedUntil) > nowMs) return 'backlog';
+  if (nextScheduledFire(loop)) return 'backlog';
+  return 'active';
+}
+
+function toLoopCard(
+  loop: OrchestratorBoardLoopView,
+  workspace: BoardWorkspace,
+  openPrs: AppRuntimePullRequestSummary[],
+  nowMs: number,
+): BoardLoopCard {
+  const prNumbers = new Set((loop.pullRequests ?? []).map((pr) => pr.number));
+  const issueNumbers = openPrs
+    .filter((pr) => prNumbers.has(pr.number))
+    .flatMap((pr) => extractClosedIssueNumbers(pr.body));
+  const card: BoardLoopCard = {
+    kind: 'loop',
+    key: `${workspace.id}:loop:${loop.id}`,
+    workspaceId: workspace.id,
+    workspaceName: workspace.name,
+    loop,
+    issueNumbers: [...new Set(issueNumbers)],
+  };
+  if (loop.status === 'draft') {
+    card.queuedReason = 'draft';
+  } else if (loop.snoozedUntil && Date.parse(loop.snoozedUntil) > nowMs) {
+    card.queuedReason = 'snoozed';
+    card.queuedAt = loop.snoozedUntil;
+  } else {
+    const fire = nextScheduledFire(loop);
+    if (fire) {
+      card.queuedReason = 'scheduled';
+      card.queuedAt = fire;
+    }
+  }
+  return card;
+}
+
+function updatedAtOf(card: BoardCard): number {
+  return card.kind === 'loop'
+    ? Date.parse(card.loop.updatedAt) || 0
+    : card.kind === 'issue'
+      ? Date.parse(card.issue.updatedAt) || 0
+      : Number.MAX_SAFE_INTEGER; // live sessions float to the top
+}
+
+function byUpdatedAtDesc(a: BoardCard, b: BoardCard): number {
+  return updatedAtOf(b) - updatedAtOf(a);
+}
+
+/** Backlog: what fires soonest first, then drafts, then issues by recency. */
+function backlogOrder(card: BoardCard): number {
+  if (card.kind === 'loop') {
+    if (card.queuedAt) return Date.parse(card.queuedAt) || 0;
+    return Number.MAX_SAFE_INTEGER - 1; // drafts after timed work
+  }
+  return Number.MAX_SAFE_INTEGER; // issues last, sorted among themselves below
+}
+
+/**
+ * Builds the four columns from every workspace's slices plus the live session
+ * pool. Pure — recomputed on watched-file change and agent events, never on a
+ * timer (`nowMs` is passed in for testability).
+ */
+export function buildBoardColumns(
+  workspaces: BoardWorkspace[],
+  slices: Record<string, WorkspaceBoardSlice | undefined>,
+  sessions: BoardSession[],
+  nowMs: number,
+): BoardColumns {
+  const columns: BoardColumns = { backlog: [], active: [], attention: [], done: [] };
+  const workspaceById = new Map(workspaces.map((ws) => [ws.id, ws]));
+
+  for (const workspace of workspaces) {
+    const slice = slices[workspace.id];
+    if (!slice) continue;
+
+    // Issues already worked by a loop render as chips on that loop's card, not
+    // as duplicate backlog cards.
+    const claimed = new Set<number>();
+
+    for (const loop of slice.index?.loops ?? []) {
+      const column = loopColumn(loop, nowMs);
+      if (!column) continue;
+      const card = toLoopCard(loop, workspace, slice.openPrs, nowMs);
+      for (const n of card.issueNumbers) claimed.add(n);
+      columns[column].push(card);
+    }
+
+    for (const issue of slice.issues) {
+      if (!isUnclaimedIssue(issue, slice.openPrs)) continue;
+      if (claimed.has(issue.number)) continue;
+      columns.backlog.push({
+        kind: 'issue',
+        key: `${workspace.id}:issue:${issue.number}`,
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        issue,
+      });
+    }
+  }
+
+  for (const session of sessions) {
+    if (!session.streaming) continue;
+    const workspace = workspaceById.get(session.workspaceId);
+    columns.active.push({
+      kind: 'session',
+      key: `${session.workspaceId}:session:${session.sessionId}`,
+      workspaceId: session.workspaceId,
+      workspaceName: workspace?.name ?? session.workspaceId,
+      sessionId: session.sessionId,
+      title: session.title,
+    });
+  }
+
+  columns.attention.sort(byUpdatedAtDesc);
+  columns.active.sort(byUpdatedAtDesc);
+  columns.backlog.sort((a, b) => {
+    const order = backlogOrder(a) - backlogOrder(b);
+    return order !== 0 ? order : byUpdatedAtDesc(a, b);
+  });
+  columns.done.sort(byUpdatedAtDesc);
+  columns.done = columns.done.slice(0, FINISHED_CARD_CAP);
+
+  return columns;
+}
+
+// ── Formatting helpers (shared by the card components) ──────
+
+/** 12345 → "12.3k", 999 → "999". */
+export function formatTokens(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+  return String(count);
+}
+
+/** 0.4218 → "$0.42"; sub-cent → "$0.004". */
+export function formatCost(costUsd: number): string {
+  if (costUsd >= 0.01) return `$${costUsd.toFixed(2)}`;
+  return `$${costUsd.toFixed(3)}`;
+}
+
+/** Compact relative age: "12s", "4m", "3h", "2d". */
+export function formatAge(iso: string | undefined, nowMs: number): string {
+  if (!iso) return '';
+  const deltaMs = nowMs - Date.parse(iso);
+  if (!Number.isFinite(deltaMs) || deltaMs < 0) return '';
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+/** Compact time-until: "in 5m", "in 3h", "in 2d"; past → "due". */
+export function formatUntil(iso: string | undefined, nowMs: number): string {
+  if (!iso) return '';
+  const deltaMs = Date.parse(iso) - nowMs;
+  if (!Number.isFinite(deltaMs)) return '';
+  if (deltaMs <= 0) return 'due';
+  const minutes = Math.ceil(deltaMs / 60_000);
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  return `in ${Math.round(hours / 24)}d`;
+}

--- a/apps/desktop/src/lib/persist-layout.ts
+++ b/apps/desktop/src/lib/persist-layout.ts
@@ -25,6 +25,7 @@ import { useDashboardStore } from '@/stores/dashboard';
 import { useBrowserStore } from '@/stores/browser';
 import { useExplorerStore } from '@/stores/explorer';
 import { useZoomStore } from '@/stores/zoom';
+import { useAgentBoardStore } from '@/stores/agent-board';
 
 // Re-export the canonical type so callers don't need a second import.
 export type { LayoutState };
@@ -72,6 +73,10 @@ function buildLayoutState(partial: Partial<LayoutState>): LayoutState {
       partial.activeBrowserTabIds ?? useBrowserStore.getState().activeTabIds,
     browserBookmarks: partial.browserBookmarks ?? useBrowserStore.getState().bookmarks,
     explorerLayout: partial.explorerLayout ?? useExplorerStore.getState().ui,
+    boardLayout: partial.boardLayout ?? {
+      collapsedColumns: useAgentBoardStore.getState().collapsedColumns,
+      workspaceFilter: useAgentBoardStore.getState().workspaceFilter,
+    },
   };
 }
 

--- a/apps/desktop/src/stores/agent-board.ts
+++ b/apps/desktop/src/stores/agent-board.ts
@@ -3,11 +3,10 @@
  * (docs/features/agent-board/plan.md).
  *
  * Reads are push-only: for every registered workspace the store watches the
- * orchestrator's loop index and the git app's state file through the
- * `window.sero.appState` bridge (it accepts arbitrary absolute paths). GitHub
- * issues/PRs are external state, so they are fetched on board mount and on
- * explicit refresh — never polled. Writes route through the single
- * `sero:orchestrator:action` seam.
+ * orchestrator's loop index through the `window.sero.appState` bridge (it
+ * accepts arbitrary absolute paths). GitHub issues/PRs are external state, so
+ * they are fetched on every board mount and on explicit refresh — never
+ * polled. Writes route through the single `sero:orchestrator:action` seam.
  */
 
 import { create } from 'zustand';
@@ -18,19 +17,11 @@ import {
   type OrchestratorBoardActionResult,
   type OrchestratorBoardIndexView,
 } from '@sero-ai/common';
-import type { BoardColumnId, BoardGitState, BoardLayoutState, WorkspaceBoardSlice } from '@/types/board';
+import type { BoardColumnId, BoardLayoutState, WorkspaceBoardSlice } from '@/types/board';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { persistLayout } from '@/lib/persist-layout';
 
-/** Written by the git plugin's extension; the board reads a structural subset. */
-const GIT_STATE_FILE = '.sero/apps/git/state.json';
-
-const EMPTY_SLICE: WorkspaceBoardSlice = { index: null, git: null, issues: [], openPrs: [] };
-
-interface WatchTarget {
-  workspaceId: string;
-  field: 'index' | 'git';
-}
+const EMPTY_SLICE: WorkspaceBoardSlice = { index: null, issues: [], openPrs: [] };
 
 interface AgentBoardState {
   /** Aggregated per-workspace state (watched files + fetched gh reads). */
@@ -56,17 +47,13 @@ interface AgentBoardState {
   hydrate: (layout: BoardLayoutState | undefined) => void;
 }
 
-/** Absolute path → which slice field it feeds. Module-level: survives store updates. */
-const watchTargets = new Map<string, WatchTarget>();
+/** Absolute index path → owning workspace id. Module-level: survives store updates. */
+const watchTargets = new Map<string, string>();
 let changeUnsubscribe: (() => void) | null = null;
 let workspaceUnsubscribe: (() => void) | null = null;
 
 function indexPath(workspacePath: string): string {
   return `${workspacePath}/${ORCHESTRATOR_INDEX_FILE}`;
-}
-
-function gitStatePath(workspacePath: string): string {
-  return `${workspacePath}/${GIT_STATE_FILE}`;
 }
 
 function normalizeIndex(data: unknown): OrchestratorBoardIndexView | null {
@@ -76,47 +63,38 @@ function normalizeIndex(data: unknown): OrchestratorBoardIndexView | null {
   return data as OrchestratorBoardIndexView;
 }
 
-function normalizeGit(data: unknown): BoardGitState | null {
-  if (!data || typeof data !== 'object') return null;
-  return data as BoardGitState;
-}
-
 export const useAgentBoardStore = create<AgentBoardState>((set, get) => {
-  function applyWatched(target: WatchTarget, data: unknown): void {
+  function applyWatched(workspaceId: string, data: unknown): void {
     set((state) => {
-      const slice = state.slices[target.workspaceId] ?? EMPTY_SLICE;
-      const next: WorkspaceBoardSlice =
-        target.field === 'index'
-          ? { ...slice, index: normalizeIndex(data) }
-          : { ...slice, git: normalizeGit(data) };
-      return { slices: { ...state.slices, [target.workspaceId]: next } };
+      const slice = state.slices[workspaceId] ?? EMPTY_SLICE;
+      const next: WorkspaceBoardSlice = { ...slice, index: normalizeIndex(data) };
+      return { slices: { ...state.slices, [workspaceId]: next } };
     });
   }
 
-  function watchPath(filePath: string, target: WatchTarget): void {
+  function watchPath(filePath: string, workspaceId: string): void {
     if (watchTargets.has(filePath)) return;
-    watchTargets.set(filePath, target);
+    watchTargets.set(filePath, workspaceId);
     window.sero.appState
       .watch(filePath)
-      .then((data: unknown) => applyWatched(target, data))
-      .catch(() => applyWatched(target, null));
+      .then((data: unknown) => applyWatched(workspaceId, data))
+      .catch(() => applyWatched(workspaceId, null));
   }
 
   /** Aligns watchers with the current workspace list (idempotent, push-driven). */
   function syncWatchers(): void {
     const workspaces = useWorkspaceStore.getState().workspaces;
-    const wanted = new Map<string, WatchTarget>();
+    const wanted = new Map<string, string>();
     for (const ws of workspaces) {
       if (!ws.path) continue;
-      wanted.set(indexPath(ws.path), { workspaceId: ws.id, field: 'index' });
-      wanted.set(gitStatePath(ws.path), { workspaceId: ws.id, field: 'git' });
+      wanted.set(indexPath(ws.path), ws.id);
     }
     for (const [filePath] of watchTargets) {
       if (wanted.has(filePath)) continue;
       watchTargets.delete(filePath);
       void window.sero.appState.unwatch(filePath).catch(() => undefined);
     }
-    for (const [filePath, target] of wanted) watchPath(filePath, target);
+    for (const [filePath, workspaceId] of wanted) watchPath(filePath, workspaceId);
     // Drop slices of workspaces that no longer exist.
     set((state) => {
       const ids = new Set(workspaces.map((ws) => ws.id));
@@ -135,20 +113,19 @@ export const useAgentBoardStore = create<AgentBoardState>((set, get) => {
     workspaceFilter: null,
 
     start: () => {
-      if (get().started) {
-        syncWatchers();
-        return;
+      if (!get().started) {
+        set({ started: true });
+        changeUnsubscribe ??= window.sero.appState.onChange((filePath: string, data: unknown) => {
+          const workspaceId = watchTargets.get(filePath);
+          if (workspaceId) applyWatched(workspaceId, data);
+        });
+        // Workspaces added/removed while the board is up re-align the watcher set.
+        workspaceUnsubscribe ??= useWorkspaceStore.subscribe((state, prev) => {
+          if (state.workspaces !== prev.workspaces) syncWatchers();
+        });
       }
-      set({ started: true });
-      changeUnsubscribe ??= window.sero.appState.onChange((filePath: string, data: unknown) => {
-        const target = watchTargets.get(filePath);
-        if (target) applyWatched(target, data);
-      });
-      // Workspaces added/removed while the board is up re-align the watcher set.
-      workspaceUnsubscribe ??= useWorkspaceStore.subscribe((state, prev) => {
-        if (state.workspaces !== prev.workspaces) syncWatchers();
-      });
       syncWatchers();
+      // Every mount refetches gh state, so a reopened board isn't stale.
       void get().refreshIssues();
     },
 

--- a/apps/desktop/src/stores/agent-board.ts
+++ b/apps/desktop/src/stores/agent-board.ts
@@ -1,0 +1,232 @@
+/**
+ * Agent Board store — cross-workspace aggregation of agent work
+ * (docs/features/agent-board/plan.md).
+ *
+ * Reads are push-only: for every registered workspace the store watches the
+ * orchestrator's loop index and the git app's state file through the
+ * `window.sero.appState` bridge (it accepts arbitrary absolute paths). GitHub
+ * issues/PRs are external state, so they are fetched on board mount and on
+ * explicit refresh — never polled. Writes route through the single
+ * `sero:orchestrator:action` seam.
+ */
+
+import { create } from 'zustand';
+import {
+  ORCHESTRATOR_INDEX_FILE,
+  type GitDiffStat,
+  type OrchestratorBoardAction,
+  type OrchestratorBoardActionResult,
+  type OrchestratorBoardIndexView,
+} from '@sero-ai/common';
+import type { BoardColumnId, BoardGitState, BoardLayoutState, WorkspaceBoardSlice } from '@/types/board';
+import { useWorkspaceStore } from '@/stores/workspace';
+import { persistLayout } from '@/lib/persist-layout';
+
+/** Written by the git plugin's extension; the board reads a structural subset. */
+const GIT_STATE_FILE = '.sero/apps/git/state.json';
+
+const EMPTY_SLICE: WorkspaceBoardSlice = { index: null, git: null, issues: [], openPrs: [] };
+
+interface WatchTarget {
+  workspaceId: string;
+  field: 'index' | 'git';
+}
+
+interface AgentBoardState {
+  /** Aggregated per-workspace state (watched files + fetched gh reads). */
+  slices: Record<string, WorkspaceBoardSlice>;
+  /** True once watchers are attached (board mounted at least once). */
+  started: boolean;
+  /** In-flight guard for the gh fetch sweep. */
+  refreshingIssues: boolean;
+  /** Cached diff stats keyed by checkout path; `key` invalidates on loop update. */
+  diffStats: Record<string, { key: string; stat: GitDiffStat | null }>;
+  collapsedColumns: BoardColumnId[];
+  workspaceFilter: string | null;
+
+  start: () => void;
+  refreshIssues: () => Promise<void>;
+  requestAction: (
+    workspaceId: string,
+    action: OrchestratorBoardAction,
+  ) => Promise<OrchestratorBoardActionResult>;
+  fetchDiffStat: (checkoutPath: string, cacheKey: string) => void;
+  toggleColumn: (column: BoardColumnId) => void;
+  setWorkspaceFilter: (workspaceId: string | null) => void;
+  hydrate: (layout: BoardLayoutState | undefined) => void;
+}
+
+/** Absolute path → which slice field it feeds. Module-level: survives store updates. */
+const watchTargets = new Map<string, WatchTarget>();
+let changeUnsubscribe: (() => void) | null = null;
+let workspaceUnsubscribe: (() => void) | null = null;
+
+function indexPath(workspacePath: string): string {
+  return `${workspacePath}/${ORCHESTRATOR_INDEX_FILE}`;
+}
+
+function gitStatePath(workspacePath: string): string {
+  return `${workspacePath}/${GIT_STATE_FILE}`;
+}
+
+function normalizeIndex(data: unknown): OrchestratorBoardIndexView | null {
+  if (!data || typeof data !== 'object' || !Array.isArray((data as { loops?: unknown }).loops)) {
+    return null;
+  }
+  return data as OrchestratorBoardIndexView;
+}
+
+function normalizeGit(data: unknown): BoardGitState | null {
+  if (!data || typeof data !== 'object') return null;
+  return data as BoardGitState;
+}
+
+export const useAgentBoardStore = create<AgentBoardState>((set, get) => {
+  function applyWatched(target: WatchTarget, data: unknown): void {
+    set((state) => {
+      const slice = state.slices[target.workspaceId] ?? EMPTY_SLICE;
+      const next: WorkspaceBoardSlice =
+        target.field === 'index'
+          ? { ...slice, index: normalizeIndex(data) }
+          : { ...slice, git: normalizeGit(data) };
+      return { slices: { ...state.slices, [target.workspaceId]: next } };
+    });
+  }
+
+  function watchPath(filePath: string, target: WatchTarget): void {
+    if (watchTargets.has(filePath)) return;
+    watchTargets.set(filePath, target);
+    window.sero.appState
+      .watch(filePath)
+      .then((data: unknown) => applyWatched(target, data))
+      .catch(() => applyWatched(target, null));
+  }
+
+  /** Aligns watchers with the current workspace list (idempotent, push-driven). */
+  function syncWatchers(): void {
+    const workspaces = useWorkspaceStore.getState().workspaces;
+    const wanted = new Map<string, WatchTarget>();
+    for (const ws of workspaces) {
+      if (!ws.path) continue;
+      wanted.set(indexPath(ws.path), { workspaceId: ws.id, field: 'index' });
+      wanted.set(gitStatePath(ws.path), { workspaceId: ws.id, field: 'git' });
+    }
+    for (const [filePath] of watchTargets) {
+      if (wanted.has(filePath)) continue;
+      watchTargets.delete(filePath);
+      void window.sero.appState.unwatch(filePath).catch(() => undefined);
+    }
+    for (const [filePath, target] of wanted) watchPath(filePath, target);
+    // Drop slices of workspaces that no longer exist.
+    set((state) => {
+      const ids = new Set(workspaces.map((ws) => ws.id));
+      const kept = Object.entries(state.slices).filter(([id]) => ids.has(id));
+      if (kept.length === Object.keys(state.slices).length) return state;
+      return { slices: Object.fromEntries(kept) };
+    });
+  }
+
+  return {
+    slices: {},
+    started: false,
+    refreshingIssues: false,
+    diffStats: {},
+    collapsedColumns: [],
+    workspaceFilter: null,
+
+    start: () => {
+      if (get().started) {
+        syncWatchers();
+        return;
+      }
+      set({ started: true });
+      changeUnsubscribe ??= window.sero.appState.onChange((filePath: string, data: unknown) => {
+        const target = watchTargets.get(filePath);
+        if (target) applyWatched(target, data);
+      });
+      // Workspaces added/removed while the board is up re-align the watcher set.
+      workspaceUnsubscribe ??= useWorkspaceStore.subscribe((state, prev) => {
+        if (state.workspaces !== prev.workspaces) syncWatchers();
+      });
+      syncWatchers();
+      void get().refreshIssues();
+    },
+
+    refreshIssues: async () => {
+      if (get().refreshingIssues) return;
+      set({ refreshingIssues: true });
+      try {
+        const workspaces = useWorkspaceStore.getState().workspaces.filter((ws) => ws.path);
+        await Promise.all(
+          workspaces.map(async (ws) => {
+            const [issues, openPrs] = await Promise.all([
+              window.sero.vcs.issues(ws.id).catch(() => []),
+              window.sero.vcs.openPrs(ws.id).catch(() => []),
+            ]);
+            set((state) => {
+              const slice = state.slices[ws.id] ?? EMPTY_SLICE;
+              return { slices: { ...state.slices, [ws.id]: { ...slice, issues, openPrs } } };
+            });
+          }),
+        );
+      } finally {
+        set({ refreshingIssues: false });
+      }
+    },
+
+    requestAction: (workspaceId, action) =>
+      window.sero.orchestrator.requestAction(workspaceId, action),
+
+    fetchDiffStat: (checkoutPath, cacheKey) => {
+      const cached = get().diffStats[checkoutPath];
+      if (cached?.key === cacheKey) return;
+      // Optimistically mark the key so concurrent renders don't re-request.
+      set((state) => ({
+        diffStats: {
+          ...state.diffStats,
+          [checkoutPath]: { key: cacheKey, stat: cached?.stat ?? null },
+        },
+      }));
+      window.sero.vcs
+        .diffStat(checkoutPath)
+        .then((stat) => {
+          set((state) => ({
+            diffStats: { ...state.diffStats, [checkoutPath]: { key: cacheKey, stat } },
+          }));
+        })
+        .catch(() => undefined);
+    },
+
+    toggleColumn: (column) => {
+      const current = get().collapsedColumns;
+      const collapsedColumns = current.includes(column)
+        ? current.filter((c) => c !== column)
+        : [...current, column];
+      set({ collapsedColumns });
+      persistLayout({ boardLayout: buildBoardLayout({ collapsedColumns }) });
+    },
+
+    setWorkspaceFilter: (workspaceId) => {
+      set({ workspaceFilter: workspaceId });
+      persistLayout({ boardLayout: buildBoardLayout({ workspaceFilter: workspaceId }) });
+    },
+
+    hydrate: (layout) => {
+      if (!layout) return;
+      set({
+        collapsedColumns: layout.collapsedColumns ?? [],
+        workspaceFilter: layout.workspaceFilter ?? null,
+      });
+    },
+  };
+});
+
+/** Current board prefs merged with a partial update (for persistLayout). */
+function buildBoardLayout(partial: Partial<BoardLayoutState>): BoardLayoutState {
+  const state = useAgentBoardStore.getState();
+  return {
+    collapsedColumns: partial.collapsedColumns ?? state.collapsedColumns,
+    workspaceFilter:
+      partial.workspaceFilter !== undefined ? partial.workspaceFilter : state.workspaceFilter,
+  };
+}

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -5,6 +5,7 @@ import { hydrateThemeStore, useThemeStore } from '@/stores/theme';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useBrowserStore } from '@/stores/browser';
 import { useExplorerStore } from '@/stores/explorer';
+import { useAgentBoardStore } from '@/stores/agent-board';
 import { seedNavigationHistory } from '@/stores/navigation';
 import { hydrateZoom } from '@/stores/zoom';
 import { normaliseChromeShortcuts, normaliseFavouriteApps } from './shared';
@@ -90,6 +91,9 @@ export async function loadLayout(): Promise<void> {
 
       // Hydrate Explorer panel sizes and visibility per workspace.
       useExplorerStore.getState().hydrate(state.explorerLayout);
+
+      // Hydrate Agent Board preferences.
+      useAgentBoardStore.getState().hydrate(state.boardLayout);
 
       return;
     }

--- a/apps/desktop/src/stores/app/shared.ts
+++ b/apps/desktop/src/stores/app/shared.ts
@@ -22,6 +22,7 @@ export type Theme = 'dark' | 'light';
 
 export const BUILTIN_APPS: AppEntry[] = [
   { id: 'dashboard', label: 'Dashboard', icon: 'layout-dashboard', builtin: true, manifest: null },
+  { id: 'board', label: 'Agent Board', icon: 'columns-3', builtin: true, manifest: null },
   { id: 'explorer', label: 'Explorer', icon: 'code', builtin: true, manifest: null },
 ];
 

--- a/apps/desktop/src/types/board.ts
+++ b/apps/desktop/src/types/board.ts
@@ -1,0 +1,49 @@
+/**
+ * Agent Board types — persisted preferences and the per-workspace state slices
+ * the board store aggregates (docs/features/agent-board/plan.md).
+ */
+
+import type {
+  AppRuntimeIssueSummary,
+  AppRuntimePullRequestSummary,
+  OrchestratorBoardIndexView,
+} from '@sero-ai/common';
+
+export type BoardColumnId = 'backlog' | 'active' | 'attention' | 'done';
+
+/** Board preferences persisted via layout.json (never localStorage). */
+export interface BoardLayoutState {
+  collapsedColumns?: BoardColumnId[];
+  /** Workspace id to filter to; absent/null = all workspaces. */
+  workspaceFilter?: string | null;
+}
+
+/**
+ * The slice of the git app's watched state file the board reads
+ * (`.sero/apps/git/state.json`, written by the git plugin's extension).
+ * Structural subset — the plugin owns the full shape.
+ */
+export interface BoardGitState {
+  repoName?: string;
+  currentBranch?: string;
+  headHash?: string;
+  branches?: {
+    name: string;
+    current: boolean;
+    ahead: number;
+    behind: number;
+  }[];
+  fileChanges?: { path: string }[];
+}
+
+/** Everything the board aggregates for one workspace (all push/watched or on-demand). */
+export interface WorkspaceBoardSlice {
+  /** Watched orchestrator loop index (null until first read / when absent). */
+  index: OrchestratorBoardIndexView | null;
+  /** Watched git app state (null when the workspace has no git state file). */
+  git: BoardGitState | null;
+  /** Open GitHub issues (fetched on mount/refresh, fail-soft []). */
+  issues: AppRuntimeIssueSummary[];
+  /** Open GitHub PRs — powers the unclaimed-issue filter and issue↔loop links. */
+  openPrs: AppRuntimePullRequestSummary[];
+}

--- a/apps/desktop/src/types/board.ts
+++ b/apps/desktop/src/types/board.ts
@@ -18,30 +18,10 @@ export interface BoardLayoutState {
   workspaceFilter?: string | null;
 }
 
-/**
- * The slice of the git app's watched state file the board reads
- * (`.sero/apps/git/state.json`, written by the git plugin's extension).
- * Structural subset — the plugin owns the full shape.
- */
-export interface BoardGitState {
-  repoName?: string;
-  currentBranch?: string;
-  headHash?: string;
-  branches?: {
-    name: string;
-    current: boolean;
-    ahead: number;
-    behind: number;
-  }[];
-  fileChanges?: { path: string }[];
-}
-
 /** Everything the board aggregates for one workspace (all push/watched or on-demand). */
 export interface WorkspaceBoardSlice {
   /** Watched orchestrator loop index (null until first read / when absent). */
   index: OrchestratorBoardIndexView | null;
-  /** Watched git app state (null when the workspace has no git state file). */
-  git: BoardGitState | null;
   /** Open GitHub issues (fetched on mount/refresh, fail-soft []). */
   issues: AppRuntimeIssueSummary[];
   /** Open GitHub PRs — powers the unclaimed-issue filter and issue↔loop links. */

--- a/apps/desktop/src/types/electron-workspace.d.ts
+++ b/apps/desktop/src/types/electron-workspace.d.ts
@@ -32,6 +32,11 @@ import type {
   PullRequestDraft,
   CreatePullRequestInput,
   CreatePullRequestResult,
+  GitDiffStat,
+  AppRuntimeIssueSummary,
+  AppRuntimePullRequestSummary,
+  OrchestratorBoardAction,
+  OrchestratorBoardActionResult,
 } from '@sero-ai/common';
 
 export interface SeroWorkspaceAPI {
@@ -217,4 +222,22 @@ export interface SeroVcsAPI {
   abandon(wsId: string, changeId: string): Promise<void>;
   squash(wsId: string, from?: string, into?: string): Promise<void>;
   opLog(wsId: string, limit?: number): Promise<OperationEntry[]>;
+
+  // ── Repo-scoped gh reads (Agent Board) — fail-soft to [] ──
+  issues(wsId: string): Promise<AppRuntimeIssueSummary[]>;
+  openPrs(wsId: string): Promise<AppRuntimePullRequestSummary[]>;
+  /** Aggregate +adds −dels of a checkout's branch work vs its base. Null when not a repo. */
+  diffStat(checkoutPath: string): Promise<GitDiffStat | null>;
+}
+
+export interface SeroOrchestratorAPI {
+  /**
+   * Route an Agent Board action to a workspace's orchestrator coordinator.
+   * Fails with a clear error when the workspace has no coordinator loaded
+   * (workspace not open) — the board renders that as "open workspace to act".
+   */
+  requestAction(
+    workspaceId: string,
+    action: OrchestratorBoardAction,
+  ): Promise<OrchestratorBoardActionResult>;
 }

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -9,6 +9,7 @@ import type {
   SeroLspAPI,
   SeroDebugAPI,
   SeroVcsAPI,
+  SeroOrchestratorAPI,
 } from './electron-workspace';
 import type { LayoutState, LoadedLayoutState } from './layout';
 import type { SeroBrowserAPI } from './electron-browser';
@@ -445,6 +446,7 @@ export interface SeroAPI {
   lsp: SeroLspAPI;
   debug: SeroDebugAPI;
   vcs: SeroVcsAPI;
+  orchestrator: SeroOrchestratorAPI;
   subagent: SeroSubagentAPI;
   skills: SeroSkillsAPI;
   prompts: SeroPromptsAPI;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -333,6 +333,15 @@ export const IpcChannels = {
     abandon: 'sero:vcs:abandon',
     squash: 'sero:vcs:squash',
     opLog: 'sero:vcs:op-log',
+    // Repo-scoped gh reads (Agent Board backlog + PR chips)
+    issues: 'sero:vcs:issues',
+    openPrs: 'sero:vcs:open-prs',
+    /** Aggregate +adds −dels of a checkout (workspace root or loop worktree). */
+    diffStat: 'sero:vcs:diff-stat',
+  },
+  orchestrator: {
+    /** Route an Agent Board action to a workspace's orchestrator coordinator. */
+    action: 'sero:orchestrator:action',
   },
   github: githubIpcChannels,
   net: netIpcChannels,

--- a/apps/desktop/src/types/layout.ts
+++ b/apps/desktop/src/types/layout.ts
@@ -8,6 +8,7 @@
 
 import type { DashboardLayoutState } from './dashboard';
 import type { BrowserBookmark, BrowserTab } from './browser';
+import type { BoardLayoutState } from './board';
 
 export interface PersistedWorkspaceExplorerLayout {
   sidebarOpen?: boolean;
@@ -66,6 +67,8 @@ export interface LayoutState {
   hiddenProviders?: string[];
   /** Dashboard widget grid layout. */
   dashboardLayout?: DashboardLayoutState;
+  /** Agent Board preferences (collapsed columns, workspace filter). */
+  boardLayout?: BoardLayoutState;
   /** Open browser tabs (restored on app start). */
   browserTabs?: PersistedBrowserTab[];
   /** Active browser tab id per workspace. */

--- a/apps/docs-site/docs/guide/app-store-favorites.md
+++ b/apps/docs-site/docs/guide/app-store-favorites.md
@@ -19,7 +19,7 @@ discovery, favorites, and plugin management.
 
 Sero shows a few categories of app-like surfaces:
 
-- **Core shell apps** such as Dashboard and Explorer are built into the desktop
+- **Core shell apps** such as Dashboard, Agent Board, and Explorer are built into the desktop
   shell and are always present.
 - **Bundled plugin apps** ship with the Sero source tree but are still surfaced
   through the plugin/discovered-app path. Examples can include internal apps
@@ -69,7 +69,7 @@ The main sidebar intentionally stays small. It shows core shell apps first, then
 favorited discovered app manifests that pass host compatibility checks.
 
 Favorites are for plugin-backed/discovered app surfaces. Core shell apps such as
-Dashboard and Explorer are always available and are not favorited or unfavorited
+Dashboard, Agent Board, and Explorer are always available and are not favorited or unfavorited
 through the same mechanism. Bundled plugin apps may still appear through the
 favorites path, so unstarring them can remove them from the sidebar without
 uninstalling them from Sero.

--- a/apps/docs-site/docs/guide/plugins-and-apps.md
+++ b/apps/docs-site/docs/guide/plugins-and-apps.md
@@ -14,7 +14,7 @@ bundled Sero features.
 
 Sero has a few app/plugin categories that users should keep separate:
 
-- **Core shell apps** such as Dashboard and Explorer are built into the desktop
+- **Core shell apps** such as Dashboard, Agent Board, and Explorer are built into the desktop
   shell and are always present.
 - **Bundled plugin apps** live in the Sero monorepo and ship with the local
   source checkout. They may appear through the same discovered-app/favorites path
@@ -63,7 +63,7 @@ host supports. Discovered apps are not all shown by default.
 
 Favorites are a convenience for keeping frequent plugin apps close at hand:
 
-- core shell apps such as Dashboard and Explorer are always available and are not
+- core shell apps such as Dashboard, Agent Board, and Explorer are always available and are not
   favorited/unfavorited the same way plugin-backed apps are
 - bundled plugin apps may be seeded as favorites and can be removed from the
   sidebar without being uninstalled from Sero

--- a/apps/docs-site/docs/guide/workspace-and-chat.md
+++ b/apps/docs-site/docs/guide/workspace-and-chat.md
@@ -99,13 +99,18 @@ Use `⌘+` / `⌘-` / `⌘0` (`Ctrl+` equivalents elsewhere) or the zoom control
 the status bar to zoom the active app in, out, or back to 100%. The title bar
 and status bar stay the same physical size at any zoom level.
 
-## Apps: Dashboard and Explorer
+## Apps: Dashboard, Agent Board, and Explorer
 
 Sero starts with core built-in apps:
 
 - **Dashboard** — a home surface for workspace/app summaries and widgets. See
   [Dashboard and Widgets](/guide/dashboard-widgets) for adding, moving, and
   resizing widgets.
+- **Agent Board** — a profile-wide board of all agent work across workspaces,
+  in four columns: Backlog, Active, Needs Attention, and Finished. Cards show
+  live progress, branch and PR chips, and token/cost stats; questions and
+  approvals can be answered directly on the card. Clicking a card jumps to the
+  owning workspace.
 - **Explorer** — the project workspace surface for files, editors, previews,
   diffs, and terminal-related work.
 

--- a/apps/docs-site/docs/reference/architecture.md
+++ b/apps/docs-site/docs/reference/architecture.md
@@ -54,8 +54,8 @@ The shell centers around:
 ├──────────────┬──────────────────────────────┬────────────────┤
 │ Main sidebar │ Active app area              │ Global chat    │
 │              │                              │ panel          │
-│ Apps         │ Dashboard / Explorer /       │ Pi-backed      │
-│ Workspaces   │ Plugin UI                    │ session        │
+│ Apps         │ Dashboard / Agent Board /    │ Pi-backed      │
+│ Workspaces   │ Explorer / Plugin UI         │ session        │
 │ Sessions     │                              │                │
 ├──────────────┴──────────────────────────────┴────────────────┤
 │ Status bar: workspace/runtime/session state, zoom control     │

--- a/docs/features/agent-board/plan.md
+++ b/docs/features/agent-board/plan.md
@@ -1,6 +1,9 @@
 # Agent Board — cross-workspace task board (design plan)
 
-Status: **proposed**. A high-level, profile-wide board that shows all agent work
+Status: **implemented** (phases 1–5; remote parity, §7.6, is a pending
+follow-up). Implementation notes at the end of this document.
+
+A high-level, profile-wide board that shows all agent work
 across workspaces in four columns — **Backlog · Active · Needs Attention ·
 Finished** — with drilldown into the owning workspace and inline resolution of
 the things that need the user (approvals, questions, failed steps).
@@ -252,3 +255,45 @@ preserved).
 - Shell imports plugin **contract types** only (`orchestrator-contract.ts`),
   never plugin internals.
 - Files ≤500 LOC; state in Zustand; layout persistence via `layout.json`.
+
+## 9. Implementation notes (phases 1–5, shipped)
+
+Where things landed, for the next person touching this:
+
+- **Board app**: `apps/desktop/src/components/apps/board/` — `AgentBoard`
+  (shell + header + columns), `BoardColumn`, `BoardCard`,
+  `BoardCardActions` (inline answers/approvals/retries/start-work), and the
+  pure `board-model.ts` (column mapping + unclaimed-issue filter +
+  formatting; unit-tested in `board-model.test.ts`). Registered as the
+  `board` entry in `BUILTIN_APPS` with a branch in `ActiveAppPanel`.
+- **Store**: `apps/desktop/src/stores/agent-board.ts` watches, per
+  registered workspace, `.sero/apps/orchestrator/index.json` and
+  `.sero/apps/git/state.json` through `window.sero.appState` (push-only);
+  gh reads (issues/PRs) fetch on mount + explicit refresh. Prefs persist as
+  `boardLayout` in `layout.json`.
+- **Contract**: `packages/common/src/orchestrator-contract.ts` gained the
+  `OrchestratorBoardLoopView` index view (attention content, progress,
+  usage roll-up, active step titles, model, branch, checkout path, PR
+  chips), the `OrchestratorBoardAction` subset union, and the typed
+  coordinator-registry seam (`getOrchestratorRegistry`). The plugin's
+  `LoopSummary` extends the board view and `shared/actions.ts` asserts the
+  action subset at compile time, so drift fails typecheck in the plugin.
+- **Index enrichment**: `runtime/store.ts#toSummary` now emits the board
+  fields (lifetime usage via `aggregateUsage`, running step titles, last
+  attempt model, branch/checkout from the resolved workspace, PR chips,
+  `lastRunAt`).
+- **Actions seam**: `sero:orchestrator:action` (`electron/ipc/integrations/
+  orchestrator.ts`) resolves the coordinator from the `globalThis` registry
+  via contract types and calls `requestAction`; exposed as
+  `window.sero.orchestrator.requestAction`. New coordinator action
+  `fire_event` broadcasts an event and reports the delivered count
+  (`broadcastEvent` now returns how many loops accepted), which powers
+  Start-work on issue cards and its "no loop is listening" hint.
+- **Git seams**: `gh issue list` twin (`listOpenIssues`) wired into the
+  app-runtime host and exposed with `sero:vcs:issues` / `sero:vcs:open-prs`;
+  `sero:vcs:diff-stat` computes the aggregate +adds −dels for a card's
+  checkout (`git diff --shortstat` vs the base branch), cached per
+  `loop.updatedAt` in the board store.
+- **Not shipped yet**: §7.6 remote parity (web-remote read-only board), and
+  one-tap catalog install of `issue-implementer` from the board (Start-work
+  currently deep-links to Orchestrator when no loop is subscribed).

--- a/docs/features/agent-board/plan.md
+++ b/docs/features/agent-board/plan.md
@@ -267,10 +267,10 @@ Where things landed, for the next person touching this:
   formatting; unit-tested in `board-model.test.ts`). Registered as the
   `board` entry in `BUILTIN_APPS` with a branch in `ActiveAppPanel`.
 - **Store**: `apps/desktop/src/stores/agent-board.ts` watches, per
-  registered workspace, `.sero/apps/orchestrator/index.json` and
-  `.sero/apps/git/state.json` through `window.sero.appState` (push-only);
-  gh reads (issues/PRs) fetch on mount + explicit refresh. Prefs persist as
-  `boardLayout` in `layout.json`.
+  registered workspace, `.sero/apps/orchestrator/index.json` through
+  `window.sero.appState` (push-only); gh reads (issues/PRs) fetch on every
+  board mount + explicit refresh. Prefs persist as `boardLayout` in
+  `layout.json`.
 - **Contract**: `packages/common/src/orchestrator-contract.ts` gained the
   `OrchestratorBoardLoopView` index view (attention content, progress,
   usage roll-up, active step titles, model, branch, checkout path, PR
@@ -286,14 +286,18 @@ Where things landed, for the next person touching this:
   orchestrator.ts`) resolves the coordinator from the `globalThis` registry
   via contract types and calls `requestAction`; exposed as
   `window.sero.orchestrator.requestAction`. New coordinator action
-  `fire_event` broadcasts an event and reports the delivered count
-  (`broadcastEvent` now returns how many loops accepted), which powers
-  Start-work on issue cards and its "no loop is listening" hint.
-- **Git seams**: `gh issue list` twin (`listOpenIssues`) wired into the
-  app-runtime host and exposed with `sero:vcs:issues` / `sero:vcs:open-prs`;
-  `sero:vcs:diff-stat` computes the aggregate +adds −dels for a card's
-  checkout (`git diff --shortstat` vs the base branch), cached per
-  `loop.updatedAt` in the board store.
+  `fire_event` broadcasts an event and reports the outcome
+  (`broadcastEvent` returns how many loops accepted and whether the event
+  was dropped as a dedupeKey duplicate), which powers Start-work on issue
+  cards and its "no loop is listening" hint. Start-work events carry
+  `dedupeKey: board:issue-<n>`, so repeated clicks can't start duplicate
+  work; the card shows a durable "Sent" state after a successful fire.
+- **Git seams**: `gh issue list` twin (`listOpenIssues`, explicit
+  `--limit 50`) wired into the app-runtime host and exposed with
+  `sero:vcs:issues` / `sero:vcs:open-prs`; `sero:vcs:diff-stat` computes
+  the aggregate +adds −dels for a card's checkout (`git diff --shortstat`
+  vs the base branch), cached per `loop.updatedAt` in the board store and
+  restricted to paths inside a registered workspace.
 - **Not shipped yet**: §7.6 remote parity (web-remote read-only board), and
   one-tap catalog install of `issue-implementer` from the board (Start-work
   currently deep-links to Orchestrator when no loop is subscribed).

--- a/packages/common/src/app-runtime-background.ts
+++ b/packages/common/src/app-runtime-background.ts
@@ -29,6 +29,7 @@ export type {
   AppRuntimeMergePullRequestResult,
   AppRuntimePullRequestMergeState,
   AppRuntimePullRequestSummary,
+  AppRuntimeIssueSummary,
   AppRuntimeWorkspaceStatusResult,
   AppRuntimeDirtyWorkspaceStashResult,
   AppRuntimeGitApi,

--- a/packages/common/src/app-runtime-git.ts
+++ b/packages/common/src/app-runtime-git.ts
@@ -75,6 +75,16 @@ export interface AppRuntimePullRequestSummary {
   body?: string;
 }
 
+/** An open issue in this workspace's repo (from `gh issue list`). */
+export interface AppRuntimeIssueSummary {
+  number: number;
+  url: string;
+  title: string;
+  labels: string[];
+  assignees: string[];
+  updatedAt: string;
+}
+
 export interface AppRuntimeWorkspaceStatusResult {
   isGitRepository: boolean;
   hasUncommittedChanges: boolean;
@@ -138,6 +148,12 @@ export interface AppRuntimeGitApi {
     workspacePath: string,
     options?: { author?: string },
   ): Promise<AppRuntimePullRequestSummary[]>;
+  /**
+   * Lists open issues in this workspace's repo (repo-scoped, `gh issue list`).
+   * Fail-soft to `[]` when `gh`, the remote, or issues are absent — a workspace
+   * without a GitHub remote simply contributes no issue cards.
+   */
+  listIssues(workspacePath: string): Promise<AppRuntimeIssueSummary[]>;
   createPr(
     worktreePath: string,
     options: AppRuntimeCreatePullRequestOptions,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -81,6 +81,7 @@ export type {
   AppRuntimeMergePullRequestResult,
   AppRuntimePullRequestMergeState,
   AppRuntimePullRequestSummary,
+  AppRuntimeIssueSummary,
   AppRuntimeWorkspaceStatusResult,
   AppRuntimeDirtyWorkspaceStashResult,
   AppRuntimeGitApi,
@@ -212,6 +213,7 @@ export type {
   StatusFile,
   WorkingCopyStatus,
   FileDiffEntry,
+  GitDiffStat,
   BookmarkRemoteStatus,
   Bookmark,
   Remote,
@@ -258,6 +260,8 @@ export type {
 export {
   ORCHESTRATOR_APP_ID,
   ORCHESTRATOR_INDEX_FILE,
+  ORCHESTRATOR_REGISTRY_GLOBAL_KEY,
+  getOrchestratorRegistry,
 } from './orchestrator-contract';
 export type {
   OrchestratorLoopStatus,
@@ -265,6 +269,22 @@ export type {
   OrchestratorScheduledLoopView,
   OrchestratorIndexView,
   OrchestratorSetScheduleParams,
+  OrchestratorQuestionChoiceView,
+  OrchestratorQuestionView,
+  OrchestratorAttentionInputView,
+  OrchestratorAttentionSuggestionView,
+  OrchestratorAttentionView,
+  OrchestratorProgressView,
+  OrchestratorUsageView,
+  OrchestratorPullRequestView,
+  OrchestratorBoardLoopView,
+  OrchestratorBoardIndexView,
+  OrchestratorInputAnswerView,
+  OrchestratorBoardEventView,
+  OrchestratorBoardAction,
+  OrchestratorBoardActionResult,
+  OrchestratorCoordinatorHandle,
+  OrchestratorRegistryEntryView,
 } from './orchestrator-contract';
 
 export type {

--- a/packages/common/src/orchestrator-contract.ts
+++ b/packages/common/src/orchestrator-contract.ts
@@ -64,3 +64,181 @@ export interface OrchestratorSetScheduleParams {
   /** Pause (true) or resume (false) the schedule. Omit to keep the current state. */
   scheduleDisabled?: boolean;
 }
+
+// ── Agent Board view (cross-workspace board, docs/features/agent-board/plan.md) ──
+//
+// The board reads every workspace's watched index and renders loop cards without
+// importing plugin internals. `LoopSummary` in the Orchestrator plugin extends
+// `OrchestratorBoardLoopView`, so a summary field the board relies on drifting
+// becomes a typecheck error in the plugin, not a runtime mismatch here.
+
+/** One choice of a multiple-choice question (mirrors the plugin's HumanChoice). */
+export interface OrchestratorQuestionChoiceView {
+  id: string;
+  label: string;
+}
+
+/** A pending question, enough to answer it inline from the board. */
+export interface OrchestratorQuestionView {
+  id: string;
+  prompt: string;
+  /** Approval gates render approve/reject instead of free-form input. */
+  kind?: 'approval';
+  /** Exact content the gate is approving (e.g. the message about to be sent). */
+  attachment?: string;
+  choices?: OrchestratorQuestionChoiceView[];
+}
+
+/** A loop's pending input request — `requestId` feeds the `answer_input` action. */
+export interface OrchestratorAttentionInputView {
+  requestId: string;
+  source: 'planner' | 'step';
+  questions: OrchestratorQuestionView[];
+}
+
+/** One pending reflection suggestion — `id` feeds the `choose_suggestion` action. */
+export interface OrchestratorAttentionSuggestionView {
+  id: string;
+  rationale: string;
+  confidence: 'low' | 'medium' | 'high';
+  changedStepCount: number;
+}
+
+/** The "needs you" content of one loop. Present only while the loop waits on the user. */
+export interface OrchestratorAttentionView {
+  input?: OrchestratorAttentionInputView;
+  suggestions?: OrchestratorAttentionSuggestionView[];
+}
+
+/** Step progress of the active plan. */
+export interface OrchestratorProgressView {
+  total: number;
+  done: number;
+  running: boolean;
+}
+
+/** Rolled-up token/cost/time totals. Fields present only when reported. */
+export interface OrchestratorUsageView {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  costUsd?: number;
+  durationMs?: number;
+}
+
+/** An open PR a loop has raised (compact chip data). */
+export interface OrchestratorPullRequestView {
+  number: number;
+  url: string;
+  title: string;
+}
+
+/**
+ * The per-loop slice of the watched index the Agent Board renders. Everything is
+ * derived from durable loop state by the plugin's index writer — the board adds
+ * no polling and no heuristics on top.
+ */
+export interface OrchestratorBoardLoopView extends OrchestratorScheduledLoopView {
+  summary?: string;
+  /** Count badges (the compact form of `attention`). */
+  pendingInput?: number;
+  pendingSuggestions?: number;
+  progress?: OrchestratorProgressView;
+  attention?: OrchestratorAttentionView;
+  /** Lifetime usage roll-up across all runs. */
+  usage?: OrchestratorUsageView;
+  /** Titles of the steps currently running — the card's live activity line. */
+  activeStepTitles?: string[];
+  /** Model of the most recent step attempt that reported one. */
+  lastModel?: string;
+  /** Branch of the loop's resolved workspace (worktree or workspace root). */
+  branchName?: string;
+  /** Absolute path of the loop's checkout (worktree or workspace root) — feeds the diff stat. */
+  checkoutPath?: string;
+  /** Open PRs attributed to this loop. */
+  pullRequests?: OrchestratorPullRequestView[];
+  lastRunAt?: string;
+  createdAt?: string;
+}
+
+/** The watched index as the board consumes it. */
+export interface OrchestratorBoardIndexView {
+  loops: OrchestratorBoardLoopView[];
+}
+
+// ── Board actions (shell → per-workspace coordinator) ──
+//
+// The subset of coordinator actions the board routes inline. Kinds and payloads
+// mirror the plugin's `OrchestratorAction` union — the plugin asserts the
+// subset relation at compile time, so a drifted payload fails typecheck there.
+
+/** One answer to a pending question (mirrors the plugin's InputAnswer). */
+export interface OrchestratorInputAnswerView {
+  questionId: string;
+  choiceId?: string;
+  text?: string;
+}
+
+/** An event fired at a workspace's loops (Start work on an issue, etc.). */
+export interface OrchestratorBoardEventView {
+  id: string;
+  /** Namespaced source id, e.g. "github:issue-opened". */
+  source: string;
+  payload: Record<string, unknown>;
+  occurredAt: string;
+  summary?: string;
+  dedupeKey?: string;
+}
+
+export type OrchestratorBoardAction =
+  | { kind: 'activate'; loopId: string }
+  | { kind: 'run_next'; loopId: string }
+  | { kind: 'run_again'; loopId: string }
+  | { kind: 'retry'; loopId: string }
+  | { kind: 'retry_step'; loopId: string; stepId: string }
+  | { kind: 'answer_input'; loopId: string; requestId: string; answers: OrchestratorInputAnswerView[] }
+  | {
+      kind: 'choose_suggestion';
+      loopId: string;
+      suggestionId: string;
+      decision: 'approve' | 'reject';
+      rejectionReason?: string;
+    }
+  | { kind: 'fire_event'; event: OrchestratorBoardEventView };
+
+/** The slice of the coordinator's action result the board consumes. */
+export interface OrchestratorBoardActionResult {
+  ok: boolean;
+  error?: string;
+  /** Set by `fire_event`: how many loops accepted the event (0 ⇒ nothing subscribed). */
+  delivered?: number;
+}
+
+// ── Coordinator registry seam (Electron main) ──
+//
+// Coordinators register on `globalThis` because the plugin's runtime and
+// extension bundles load through different loaders in the same main process
+// (see the plugin's runtime/registry.ts). The shell's `sero:orchestrator:action`
+// handler reaches a coordinator through this same global — typed here so the
+// shell never imports plugin internals.
+
+export const ORCHESTRATOR_REGISTRY_GLOBAL_KEY = '__seroOrchestratorCoordinators__';
+
+/** The narrow coordinator surface the shell invokes. */
+export interface OrchestratorCoordinatorHandle {
+  requestAction(action: OrchestratorBoardAction): Promise<OrchestratorBoardActionResult>;
+}
+
+export interface OrchestratorRegistryEntryView {
+  workspaceId: string;
+  workspacePath: string;
+  coordinator: OrchestratorCoordinatorHandle;
+}
+
+/** Reads the shared coordinator registry off `globalThis` (Electron main only). */
+export function getOrchestratorRegistry(): ReadonlyMap<string, OrchestratorRegistryEntryView> | undefined {
+  const globalScope = globalThis as Record<string, unknown>;
+  return globalScope[ORCHESTRATOR_REGISTRY_GLOBAL_KEY] as
+    | Map<string, OrchestratorRegistryEntryView>
+    | undefined;
+}

--- a/packages/common/src/orchestrator-contract.ts
+++ b/packages/common/src/orchestrator-contract.ts
@@ -212,6 +212,8 @@ export interface OrchestratorBoardActionResult {
   error?: string;
   /** Set by `fire_event`: how many loops accepted the event (0 ⇒ nothing subscribed). */
   delivered?: number;
+  /** Set by `fire_event`: the event's dedupeKey was already delivered, so it was dropped. */
+  deduped?: boolean;
 }
 
 // ── Coordinator registry seam (Electron main) ──

--- a/packages/common/src/vcs.ts
+++ b/packages/common/src/vcs.ts
@@ -49,6 +49,13 @@ export interface FileDiffEntry {
   oldPath?: string;
 }
 
+/** Aggregate diff counts of a checkout's branch work vs its base (`git diff --shortstat`). */
+export interface GitDiffStat {
+  files: number;
+  additions: number;
+  deletions: number;
+}
+
 export interface BookmarkRemoteStatus {
   remote: string;
   synced: boolean;

--- a/plugins/sero-orchestrator-plugin/extension/tools.ts
+++ b/plugins/sero-orchestrator-plugin/extension/tools.ts
@@ -398,6 +398,8 @@ function summarize(action: OrchestratorAction, res: OrchestratorActionResult): s
       return res.loop
         ? `Installed "${res.loop.title}" as a draft loop ${res.loop.id} — ${res.loop.runtime.pendingInput ? 'it has questions to adapt it to this workspace' : 'review the plan, then activate'}.`
         : `Installed ${action.repoKey}/${action.slug} into the library.`;
+    case 'fire_event':
+      return `Fired ${action.event.source} — accepted by ${res.delivered ?? 0} loop(s).`;
     default:
       return `${action.kind} ok — loop ${res.loop?.id ?? action.loopId} now "${res.loop?.status ?? '?'}".`;
   }

--- a/plugins/sero-orchestrator-plugin/extension/tools.ts
+++ b/plugins/sero-orchestrator-plugin/extension/tools.ts
@@ -399,7 +399,9 @@ function summarize(action: OrchestratorAction, res: OrchestratorActionResult): s
         ? `Installed "${res.loop.title}" as a draft loop ${res.loop.id} — ${res.loop.runtime.pendingInput ? 'it has questions to adapt it to this workspace' : 'review the plan, then activate'}.`
         : `Installed ${action.repoKey}/${action.slug} into the library.`;
     case 'fire_event':
-      return `Fired ${action.event.source} — accepted by ${res.delivered ?? 0} loop(s).`;
+      return res.deduped
+        ? `Dropped ${action.event.source} — an event with the same dedupeKey was already delivered.`
+        : `Fired ${action.event.source} — accepted by ${res.delivered ?? 0} loop(s).`;
     default:
       return `${action.kind} ok — loop ${res.loop?.id ?? action.loopId} now "${res.loop?.status ?? '?'}".`;
   }

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/coordinator-events.test.ts
@@ -155,6 +155,24 @@ describe('fireEvent broadcast', () => {
     expect(host.state.recentEventKeys).toContain('github:ci-failed#check-run-9');
   });
 
+  it('fire_event reports delivered vs deduped (the Agent Board Start-work contract)', async () => {
+    const host = createFakeHost();
+    host.frozenNow = NOW;
+    seedActiveLoop(host, oneStepPlan().plan);
+    setTriggers(host, 'loop-1', [eventTrigger()]);
+    const c = coordinator(host, { executor: fakeExecutor({ 'step-1': SUCCESS }) });
+
+    const first = await c.requestAction({ kind: 'fire_event', event: ciEvent({ dedupeKey: 'board:issue-42' }) });
+    expect(first).toMatchObject({ ok: true, delivered: 1 });
+    expect(first.deduped).toBeUndefined();
+
+    const second = await c.requestAction({
+      kind: 'fire_event',
+      event: ciEvent({ id: 'evt-2', dedupeKey: 'board:issue-42' }),
+    });
+    expect(second).toMatchObject({ ok: true, delivered: 0, deduped: true });
+  });
+
   it('drops a fire at the loop→loop chain-depth cap with a visible warning', async () => {
     const host = createFakeHost();
     host.frozenNow = NOW;

--- a/plugins/sero-orchestrator-plugin/runtime/__tests__/store.test.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/__tests__/store.test.ts
@@ -194,3 +194,55 @@ describe('schedule summaries (cross-plugin index view)', () => {
     expect(toSummary(loop).schedules).toBeUndefined();
   });
 });
+
+describe('board enrichment (Agent Board index view)', () => {
+  it('embeds usage roll-up, activity, model, branch, checkout, and PR chips', () => {
+    const host = createFakeHost();
+    const plan = oneStepPlan().plan;
+    const base = seedActiveLoop(host, plan, 'loop-a');
+    const stepId = plan.steps[0].id;
+    const usedRun: LoopRun = {
+      ...run('r1'),
+      stepAttempts: [
+        { ...run('r1').stepAttempts[0], model: 'claude-sonnet-5', usage: { inputTokens: 100, outputTokens: 40, costUsd: 0.02 } },
+      ],
+    };
+    const loop: Loop = {
+      ...base,
+      runs: [usedRun, { ...run('r2'), stepAttempts: [{ ...run('r2').stepAttempts[0], usage: { inputTokens: 10, outputTokens: 5 } }] }],
+      runtime: {
+        ...base.runtime,
+        activeRunId: 'r2',
+        lastRunAt: '2026-07-18T11:00:00Z',
+        stepStates: { ...base.runtime.stepStates, [stepId]: { status: 'running', attempts: 1, updatedAt: 't' } },
+        workspace: {
+          resolved: {
+            id: 'ctx', type: 'managed-worktree', workspaceRoot: '/ws', cwd: '/ws/.sero/worktrees/loop-a',
+            worktreePath: '/ws/.sero/worktrees/loop-a', branchName: 'sero/loop-a', resolvedBy: 'create-option', createdAt: 't',
+          },
+        },
+        pullRequests: [
+          { number: 7, url: 'https://github.com/o/r/pull/7', title: 'Fix', headRefName: 'sero/loop-a', updatedAt: 't' },
+        ],
+      },
+    };
+    const summary = toSummary(loop);
+    expect(summary.usage).toEqual({ inputTokens: 110, outputTokens: 45, costUsd: 0.02 });
+    expect(summary.activeStepTitles).toEqual([plan.steps[0].title]);
+    expect(summary.lastModel).toBe('claude-sonnet-5');
+    expect(summary.branchName).toBe('sero/loop-a');
+    expect(summary.checkoutPath).toBe('/ws/.sero/worktrees/loop-a');
+    expect(summary.pullRequests).toEqual([{ number: 7, url: 'https://github.com/o/r/pull/7', title: 'Fix' }]);
+    expect(summary.lastRunAt).toBe('2026-07-18T11:00:00Z');
+  });
+
+  it('omits every board field when the loop has no runs or workspace context', () => {
+    const host = createFakeHost();
+    const summary = toSummary(seedActiveLoop(host, oneStepPlan().plan, 'loop-a'));
+    expect(summary.usage).toBeUndefined();
+    expect(summary.activeStepTitles).toBeUndefined();
+    expect(summary.lastModel).toBeUndefined();
+    expect(summary.branchName).toBeUndefined();
+    expect(summary.pullRequests).toBeUndefined();
+  });
+});

--- a/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
@@ -37,7 +37,12 @@ import { handleCatalogAction, isCatalogAction } from './catalog-actions';
 import { handleOverrideAction, isOverrideAction } from './override-actions';
 import { applyAnswerInput } from './input-actions';
 import { evaluateCronTriggers, isEventArmedOnly, isRecurring, rearmLoop } from './scheduler';
-import { broadcastEvent, drainPendingEvent, type CoordinatorRunSeam } from './event-delivery';
+import {
+  broadcastEvent,
+  drainPendingEvent,
+  type CoordinatorRunSeam,
+  type EventBroadcast,
+} from './event-delivery';
 import { retryLoop, retryStepAction, runAgain } from './restart-actions';
 import { buildLifecycleEvents } from './lifecycle-events';
 import { computeReadySteps, hasRunningSteps } from './readiness';
@@ -125,7 +130,7 @@ export class Coordinator {
    * Semantics live in event-delivery.ts; the seam keeps the coordinator the
    * only component that starts runs.
    */
-  fireEvent(event: OrchestratorEvent): Promise<number> {
+  fireEvent(event: OrchestratorEvent): Promise<EventBroadcast> {
     return broadcastEvent(this.host, this.runSeam(), event);
   }
 
@@ -183,8 +188,10 @@ export class Coordinator {
       case 'answer_input':
         return this.answerInput(action);
       case 'fire_event': {
-        const delivered = await this.fireEvent(action.event);
-        return { ok: true, delivered };
+        const broadcast = await this.fireEvent(action.event);
+        return broadcast.deduped
+          ? { ok: true, delivered: 0, deduped: true }
+          : { ok: true, delivered: broadcast.delivered };
       }
       case 'delete':
         return this.delete(action.loopId, action.deleteBranch);

--- a/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/coordinator.ts
@@ -125,7 +125,7 @@ export class Coordinator {
    * Semantics live in event-delivery.ts; the seam keeps the coordinator the
    * only component that starts runs.
    */
-  fireEvent(event: OrchestratorEvent): Promise<void> {
+  fireEvent(event: OrchestratorEvent): Promise<number> {
     return broadcastEvent(this.host, this.runSeam(), event);
   }
 
@@ -182,6 +182,10 @@ export class Coordinator {
         return handleReflectAction(this.host, action);
       case 'answer_input':
         return this.answerInput(action);
+      case 'fire_event': {
+        const delivered = await this.fireEvent(action.event);
+        return { ok: true, delivered };
+      }
       case 'delete':
         return this.delete(action.loopId, action.deleteBranch);
       default: {

--- a/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
@@ -29,20 +29,27 @@ export interface CoordinatorRunSeam {
   runNext(loopId: string, known?: Loop): Promise<OrchestratorActionResult>;
 }
 
+/** Outcome of one broadcast — lets callers distinguish "nobody listened" from "dropped as duplicate". */
+export interface EventBroadcast {
+  /** How many loops accepted a fire (0 ⇒ nothing subscribed/matched). */
+  delivered: number;
+  /** The event's dedupeKey was already delivered, so the broadcast was dropped. */
+  deduped: boolean;
+}
+
 /**
  * Broadcasts one event to every active loop with a matching trigger.
- * Returns how many loops accepted a fire (0 ⇒ nothing subscribed/matched),
- * so callers like the Agent Board's "Start work" can tell the user when an
- * event landed nowhere.
+ * Callers like the Agent Board's "Start work" use the outcome to tell the user
+ * when an event landed nowhere versus when it was a duplicate.
  */
 export async function broadcastEvent(
   host: OrchestratorHost,
   seam: CoordinatorRunSeam,
   event: OrchestratorEvent,
-): Promise<number> {
-  if (await alreadyDelivered(host, event)) return 0;
+): Promise<EventBroadcast> {
+  if (await alreadyDelivered(host, event)) return { delivered: 0, deduped: true };
   const state = await host.readState();
-  if (!state) return 0;
+  if (!state) return { delivered: 0, deduped: false };
   let delivered = 0;
   const nowMs = Date.parse(host.now());
   for (const loop of state.loops) {
@@ -73,7 +80,7 @@ export async function broadcastEvent(
       delivered += 1;
     }
   }
-  return delivered;
+  return { delivered, deduped: false };
 }
 
 /**

--- a/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/event-delivery.ts
@@ -29,15 +29,21 @@ export interface CoordinatorRunSeam {
   runNext(loopId: string, known?: Loop): Promise<OrchestratorActionResult>;
 }
 
-/** Broadcasts one event to every active loop with a matching trigger. */
+/**
+ * Broadcasts one event to every active loop with a matching trigger.
+ * Returns how many loops accepted a fire (0 ⇒ nothing subscribed/matched),
+ * so callers like the Agent Board's "Start work" can tell the user when an
+ * event landed nowhere.
+ */
 export async function broadcastEvent(
   host: OrchestratorHost,
   seam: CoordinatorRunSeam,
   event: OrchestratorEvent,
-): Promise<void> {
-  if (await alreadyDelivered(host, event)) return;
+): Promise<number> {
+  if (await alreadyDelivered(host, event)) return 0;
   const state = await host.readState();
-  if (!state) return;
+  if (!state) return 0;
+  let delivered = 0;
   const nowMs = Date.parse(host.now());
   for (const loop of state.loops) {
     if (loop.status !== 'active') continue;
@@ -62,8 +68,12 @@ export async function broadcastEvent(
       }
       passing.push(trigger.id);
     }
-    if (passing.length > 0) await deliverEventFire(host, seam, loop.id, passing, event);
+    if (passing.length > 0) {
+      await deliverEventFire(host, seam, loop.id, passing, event);
+      delivered += 1;
+    }
   }
+  return delivered;
 }
 
 /**

--- a/plugins/sero-orchestrator-plugin/runtime/index.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/index.ts
@@ -30,7 +30,7 @@ export function createAppRuntime(ctx: AppRuntimeContext): AppRuntime {
   // demand follows loop state with no file watching and no timers.
   const host = attachDemandSync(createOrchestratorHost(ctx), manager);
   const coordinator = new Coordinator(host, createEngineDeps(new LoopLocks(), { stopChecker: llmStopChecker }));
-  const emit: EmitEvent = (event) => coordinator.fireEvent(event);
+  const emit: EmitEvent = (event) => coordinator.fireEvent(event).then(() => undefined);
   adapters.push(createFsAdapter(host, emit), createWebhookAdapter(host, emit), createGithubAdapter(host, emit));
   let tickTimer: ReturnType<typeof setInterval> | undefined;
 

--- a/plugins/sero-orchestrator-plugin/runtime/registry.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/registry.ts
@@ -11,6 +11,7 @@
  * process (see 02-integration-seams.md, "CLI Bridge Boundary").
  */
 
+import { ORCHESTRATOR_REGISTRY_GLOBAL_KEY } from '@sero-ai/common';
 import type { Coordinator } from './coordinator';
 
 interface RegistryEntry {
@@ -19,7 +20,9 @@ interface RegistryEntry {
   coordinator: Coordinator;
 }
 
-const REGISTRY_KEY = '__seroOrchestratorCoordinators__';
+// Shared with the shell's `sero:orchestrator:action` IPC handler, which reads
+// the same global through the contract types (@sero-ai/common).
+const REGISTRY_KEY = ORCHESTRATOR_REGISTRY_GLOBAL_KEY;
 
 function store(): Map<string, RegistryEntry> {
   const globalScope = globalThis as Record<string, unknown>;

--- a/plugins/sero-orchestrator-plugin/runtime/store.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/store.ts
@@ -8,7 +8,7 @@
  * unchanged loop's file is never rewritten when another loop changes.
  */
 
-import type { OrchestratorScheduleSummary } from '@sero-ai/common';
+import type { OrchestratorPullRequestView, OrchestratorScheduleSummary } from '@sero-ai/common';
 import type {
   Loop,
   LoopAttention,
@@ -18,6 +18,7 @@ import type {
   OrchestratorIndex,
   OrchestratorState,
   RunIndex,
+  UsageSummary,
 } from '../shared/types';
 import { aggregateUsage } from '../shared/usage';
 import { isExhausted } from './scheduler';
@@ -137,6 +138,38 @@ export function diffRuns(prev: LoopRun[], next: LoopRun[]): RunsDiff {
   return { changed, removedIds, indexChanged: changed.length > 0 || removedIds.length > 0 };
 }
 
+/** Titles of currently running steps — the Agent Board card's live activity line. */
+function toActiveStepTitles(loop: Loop): string[] | undefined {
+  if (!loop.runtime.activeRunId) return undefined;
+  const titles = loop.plan.steps
+    .filter((step) => loop.runtime.stepStates[step.id]?.status === 'running')
+    .map((step) => step.title);
+  return titles.length > 0 ? titles : undefined;
+}
+
+/** Lifetime usage roll-up: sums the per-run roll-ups across all runs. */
+function toLifetimeUsage(loop: Loop): UsageSummary | undefined {
+  return aggregateUsage(loop.runs.map((run) => ({ usage: aggregateUsage(run.stepAttempts) })));
+}
+
+/** Model of the most recent step attempt that reported one. */
+function toLastModel(loop: Loop): string | undefined {
+  for (let r = loop.runs.length - 1; r >= 0; r -= 1) {
+    const attempts = loop.runs[r].stepAttempts;
+    for (let a = attempts.length - 1; a >= 0; a -= 1) {
+      if (attempts[a].model) return attempts[a].model;
+    }
+  }
+  return undefined;
+}
+
+/** Open PRs attributed to this loop, slimmed to chip data. */
+function toPullRequests(loop: Loop): OrchestratorPullRequestView[] | undefined {
+  const prs = loop.runtime.pullRequests;
+  if (!prs?.length) return undefined;
+  return prs.map((pr) => ({ number: pr.number, url: pr.url, title: pr.title }));
+}
+
 export function toSummary(loop: Loop): LoopSummary {
   const pendingSuggestions = (loop.suggestions ?? []).filter((s) => s.status === 'pending').length;
   const pendingInput = loop.runtime.pendingInput?.questions.length ?? 0;
@@ -152,6 +185,13 @@ export function toSummary(loop: Loop): LoopSummary {
     attention: toAttention(loop),
     schedules: toSchedules(loop),
     snoozedUntil: loop.runtime.snoozedUntil,
+    usage: toLifetimeUsage(loop),
+    activeStepTitles: toActiveStepTitles(loop),
+    lastModel: toLastModel(loop),
+    branchName: loop.runtime.workspace.resolved?.branchName,
+    checkoutPath: loop.runtime.workspace.resolved?.cwd,
+    pullRequests: toPullRequests(loop),
+    lastRunAt: loop.runtime.lastRunAt,
     libraryLink: loop.libraryLink,
     createdAt: loop.createdAt,
     updatedAt: loop.updatedAt,

--- a/plugins/sero-orchestrator-plugin/runtime/store.ts
+++ b/plugins/sero-orchestrator-plugin/runtime/store.ts
@@ -141,9 +141,9 @@ export function diffRuns(prev: LoopRun[], next: LoopRun[]): RunsDiff {
 /** Titles of currently running steps — the Agent Board card's live activity line. */
 function toActiveStepTitles(loop: Loop): string[] | undefined {
   if (!loop.runtime.activeRunId) return undefined;
-  const titles = loop.plan.steps
-    .filter((step) => loop.runtime.stepStates[step.id]?.status === 'running')
-    .map((step) => step.title);
+  const titles = loop.plan.steps.flatMap((step) =>
+    loop.runtime.stepStates[step.id]?.status === 'running' ? [step.title] : [],
+  );
   return titles.length > 0 ? titles : undefined;
 }
 

--- a/plugins/sero-orchestrator-plugin/shared/actions.ts
+++ b/plugins/sero-orchestrator-plugin/shared/actions.ts
@@ -88,6 +88,8 @@ export interface OrchestratorActionResult {
   error?: string;
   /** Set by `fire_event`: how many active loops accepted the event. */
   delivered?: number;
+  /** Set by `fire_event`: the event's dedupeKey was already delivered, so it was dropped. */
+  deduped?: boolean;
   /** Set by `reflect`: how many suggestions this pass produced. */
   reflection?: { suggestionCount: number };
   /** Set by `reflect_workspace`: the consecutive per-loop sweep summary. */

--- a/plugins/sero-orchestrator-plugin/shared/actions.ts
+++ b/plugins/sero-orchestrator-plugin/shared/actions.ts
@@ -3,8 +3,9 @@
  * 500-LOC limit; re-exported from types.ts so existing imports are unaffected.
  */
 
-import type { ContextOverrides } from '@sero-ai/common';
+import type { ContextOverrides, OrchestratorBoardAction } from '@sero-ai/common';
 import type { CatalogRepoContents, CatalogRepoRef } from './catalog-types';
+import type { OrchestratorEvent } from './event-types';
 import type {
   InputAnswer,
   LibraryIndex,
@@ -59,7 +60,18 @@ export type OrchestratorAction =
   | { kind: 'catalog_remove_repo'; repoKey: string }
   | { kind: 'catalog_refresh'; repoKey?: string }
   | { kind: 'catalog_install'; repoKey: string; slug: string; workspaceLoad?: boolean }
-  | { kind: 'delete'; loopId: string; deleteBranch?: boolean };
+  | { kind: 'delete'; loopId: string; deleteBranch?: boolean }
+  | { kind: 'fire_event'; event: OrchestratorEvent };
+
+/**
+ * Compile-time guard: every action the shell's Agent Board can send
+ * (@sero-ai/common orchestrator-contract) must be a valid coordinator action.
+ * A drifted board payload fails typecheck here, next to the union it mirrors.
+ */
+type Assert<T extends true> = T;
+export type BoardActionContractCheck = Assert<
+  OrchestratorBoardAction extends OrchestratorAction ? true : false
+>;
 
 /** Per-loop result of a workspace-wide reflection sweep. */
 export interface ReflectedLoopSummary {
@@ -74,6 +86,8 @@ export interface OrchestratorActionResult {
   loops?: Loop[];
   run?: LoopRun;
   error?: string;
+  /** Set by `fire_event`: how many active loops accepted the event. */
+  delivered?: number;
   /** Set by `reflect`: how many suggestions this pass produced. */
   reflection?: { suggestionCount: number };
   /** Set by `reflect_workspace`: the consecutive per-loop sweep summary. */

--- a/plugins/sero-orchestrator-plugin/shared/index-types.ts
+++ b/plugins/sero-orchestrator-plugin/shared/index-types.ts
@@ -8,7 +8,11 @@
  * specs/09-ui-redesign.md). Type-only imports keep the re-export cycle harmless.
  */
 
-import type { OrchestratorScheduledLoopView, OrchestratorScheduleSummary } from '@sero-ai/common';
+import type {
+  OrchestratorBoardLoopView,
+  OrchestratorPullRequestView,
+  OrchestratorScheduleSummary,
+} from '@sero-ai/common';
 import type {
   CompletionSignal,
   LoopRunStatus,
@@ -37,10 +41,11 @@ export interface LoopProgress {
 /**
  * Lightweight per-loop entry for the watched index (drives the loop list + home).
  * Extends the cross-plugin view contract (@sero-ai/common orchestrator-contract)
- * that external surfaces like the Scheduler app read, so drifting from it fails
- * typecheck here.
+ * that external surfaces — the Scheduler app (`OrchestratorScheduledLoopView`)
+ * and the shell's Agent Board (`OrchestratorBoardLoopView`) — read, so drifting
+ * from it fails typecheck here.
  */
-export interface LoopSummary extends OrchestratorScheduledLoopView {
+export interface LoopSummary extends OrchestratorBoardLoopView {
   id: string;
   title: string;
   status: LoopStatus;
@@ -60,6 +65,19 @@ export interface LoopSummary extends OrchestratorScheduledLoopView {
    * loop is waiting on the user.
    */
   attention?: LoopAttention;
+  /** Lifetime token/cost roll-up across all runs — drives the board card stats. */
+  usage?: UsageSummary;
+  /** Titles of currently running steps — the board card's live activity line. */
+  activeStepTitles?: string[];
+  /** Model of the most recent step attempt that reported one — the board's model chip. */
+  lastModel?: string;
+  /** Branch of the loop's resolved workspace (worktree or workspace root). */
+  branchName?: string;
+  /** Absolute path of the loop's checkout (worktree or workspace root) — feeds the board's diff stat. */
+  checkoutPath?: string;
+  /** Open PRs attributed to this loop (compact chip data). */
+  pullRequests?: OrchestratorPullRequestView[];
+  lastRunAt?: string;
   /** Library link, when loaded from / saved to the Library — drives the update badge. */
   libraryLink?: LoopLibraryLink;
   createdAt: string;


### PR DESCRIPTION
## Summary

Implements the Agent Board feature (phases 1–5 of the design plan), a profile-wide kanban board showing all agent work across workspaces in four columns: **Backlog · Active · Needs Attention · Finished**.

### What changed

**New components & stores:**
- `AgentBoard.tsx` — main board component with four animated columns
- `BoardCard.tsx` — individual card renderer for loops, issues, and live sessions
- `BoardCardActions.tsx` — inline actions (approve/reject gates, answer questions, retry, activate)
- `BoardColumn.tsx` — collapsible column with spring animations and count badges
- `board-model.ts` — pure state-to-UI mapping (no IO, no heuristics; everything derived from durable state)
- `useAgentBoardStore` — Zustand store managing cross-workspace aggregation, the watched orchestrator index, and GitHub issue/PR fetches

**New types & contracts:**
- `BoardLayoutState` — persisted board preferences (collapsed columns, workspace filter)
- `OrchestratorBoardLoopView`, `OrchestratorBoardAction`, `OrchestratorBoardActionResult` — contract types for loop state and board actions
- `AppRuntimeIssueSummary`, `GitDiffStat` — new app-runtime types for issues and diff stats
- `WorkspaceBoardSlice` — internal state shape

**Integration seams:**
- `sero:orchestrator:action` IPC channel — board forwards user actions to orchestrator coordinators
- `sero:vcs:list-open-issues`, `sero:vcs:diff-stat` — board fetches GitHub issues and branch diff stats
- Orchestrator plugin's index writer now embeds board-specific fields (usage roll-up, active steps, model, PRs)

**Supporting changes:**
- `getWorktreeDiffStat()` — new git helper for branch diff aggregates
- `listOpenIssues()` — new gh CLI wrapper for open issues
- Orchestrator plugin's `store.ts` enriches loop summaries with board data
- Layout persistence now includes board state
- Built-in apps list includes the board

### Why it changed

The Agent Board provides a high-level, profile-wide view of all agent work without requiring users to navigate into individual workspaces. It surfaces:
- **Backlog**: draft loops, scheduled work, snoozed loops
- **Active**: running loops and idle unscheduled loops
- **Needs Attention**: loops with pending input/suggestions, blocked loops
- **Finished**: completed loops (bounded to 30 most recent)

The board reads only durable state (watched orchestrator index, fetched GitHub issues/PRs) with no polling or heuristics. Animations are purely decorative. Users can resolve attention items inline (approve gates, answer questions, retry, activate) without leaving the board.

### Review fixes (second commit)

- **Duplicate Start-work guard**: issue-card events now carry `dedupeKey: board:issue-<n>`; `broadcastEvent` reports delivered vs deduped, the coordinator/IPC pass it through, and the card shows a durable "Sent" state — repeated clicks can't start duplicate work
- Removed the unused git-state watcher (`BoardGitState` and per-workspace `.sero/apps/git/state.json` watches fed nothing)
- gh issues/PRs refetch on **every** board mount, not just the first
- Explicit `--limit 50` on `gh issue list` (was a silent 30 default)
- `sero:vcs:diff-stat` only serves paths inside a registered workspace
- Board clock (`nowMs`) memoized on data deps so memoized cards stop re-rendering on unrelated renders

## Validation

- [x] `pnpm typecheck` — all new types are contract-based; no `any` or `@ts-ignore`
- [x] `pnpm build` — new components and stores integrate cleanly
- [x] `pnpm --filter @sero/desktop test -- --run` and orchestrator plugin tests — `board-model.test.ts` covers column routing, issue claiming, and formatting; `coordinator-events.test.ts` covers the delivered/deduped fire_event contract
- [x] docs updated — `docs/features/agent-board/plan.md` marked implemented with implementation notes

## Safety checklist

- [x] no secrets, tokens, credentials, or machine-specific paths
- [x] no unnecessary `any`, `@ts-ignore`, or `@ts-expect-error`
- [x] all touched source files ≤500 LOC (largest: `BoardCard.tsx` 376, `BoardCardActions.tsx` 315, `board-model.ts` 272, `agent-board.ts` 209)

## Risk / rollout notes

- **Breaking changes**: None. New feature is additive; existing apps and stores unaffected. (`Coordinator.fireEvent` now returns a broadcast outcome instead of `void`/count — internal to the plugin and shell.)
- **Security/privacy**: Board reads only durable state (orchestrator index, public GitHub issues/PRs). Diff-stat IPC validates paths against registered workspaces. No new credentials or sensitive data exposure.
- **Follow-up work**: Remote parity

https://claude.ai/code/session_014sn2R49VXjPGyr86pPMA43
