### PR TITLE
feat: React Grab element picker for browser tabs and dev-server previews

### DIFF
--- a/apps/desktop/electron/__tests__/features/gateway/devserver-proxy-parse.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/devserver-proxy-parse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { parseDevProxyPath } from '@electron/features/gateway/server/devserver-proxy';
 import {
   buildProxyLocation,
+  injectGrabScriptTag,
   readQueryTicket,
   rewriteProxyBody,
 } from '@electron/features/gateway/server/devserver-proxy-utils';
@@ -74,5 +75,23 @@ describe('parseDevProxyPath', () => {
     expect(rewritten).toContain("url('/p/ws-1/5173/assets/bg.png')");
     expect(rewritten).toContain('"/p/ws-1/5173/@react-refresh"');
     expect(rewritten).toContain("'/p/ws-1/5173/api/me'");
+  });
+});
+
+describe('injectGrabScriptTag', () => {
+  it('inserts the script at the top of <head> so it runs before page scripts', () => {
+    const html = '<!doctype html><html><head><meta charset="utf-8"></head><body></body></html>';
+    const injected = injectGrabScriptTag(html, '/__sero/grab.js');
+    expect(injected).toContain('<head><script src="/__sero/grab.js"></script><meta');
+  });
+
+  it('handles <head> tags with attributes', () => {
+    const injected = injectGrabScriptTag('<head lang="en"><title>x</title></head>', '/g.js');
+    expect(injected).toBe('<head lang="en"><script src="/g.js"></script><title>x</title></head>');
+  });
+
+  it('prepends when the document has no head', () => {
+    const injected = injectGrabScriptTag('<body>hi</body>', '/g.js');
+    expect(injected).toBe('<script src="/g.js"></script><body>hi</body>');
   });
 });

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
@@ -179,6 +179,7 @@ async function createHarness(): Promise<TestHarness> {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'gateway-integration-test-'));
   const server = new GatewayServer({
     port: 0,
+    previewPort: 0,
     host: '127.0.0.1',
     tokenPath: path.join(tmpDir, 'gateway-token.txt'),
     configDir: tmpDir,

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
@@ -2,86 +2,22 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { mkdtemp, rm } from 'fs/promises';
 import os from 'os';
 import path from 'path';
-import { WebSocket, type RawData } from 'ws';
+import { WebSocket } from 'ws';
 
 import { GatewayServer, type GatewayAgentOps } from '@electron/features/gateway';
 import type { GatewayPushEvent, GatewayResponse } from '@electron/features/gateway/server/protocol';
+import {
+  connectClient,
+  sendRequest,
+  waitForClose,
+  waitForMessage,
+  waitForOpen,
+} from './gateway-ws-test-utils';
 
 interface TestHarness {
   server: GatewayServer;
   port: number;
   tmpDir: string;
-}
-
-interface GatewayMessageBase {
-  type: string;
-}
-
-function waitForOpen(ws: WebSocket): Promise<void> {
-  if (ws.readyState === WebSocket.OPEN) {
-    return Promise.resolve();
-  }
-
-  return new Promise((resolve, reject) => {
-    ws.once('open', () => resolve());
-    ws.once('error', reject);
-  });
-}
-
-function waitForClose(ws: WebSocket): Promise<void> {
-  if (ws.readyState === WebSocket.CLOSED) {
-    return Promise.resolve();
-  }
-
-  return new Promise((resolve) => {
-    ws.once('close', () => resolve());
-  });
-}
-
-function waitForMessage<T extends GatewayMessageBase>(ws: WebSocket): Promise<T> {
-  return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      ws.off('message', onMessage);
-      ws.off('error', onError);
-      reject(new Error('Timed out waiting for gateway message'));
-    }, 2000);
-
-    const onMessage = (data: RawData) => {
-      clearTimeout(timeout);
-      ws.off('error', onError);
-      resolve(JSON.parse(data.toString()) as T);
-    };
-
-    const onError = (error: Error) => {
-      clearTimeout(timeout);
-      ws.off('message', onMessage);
-      reject(error);
-    };
-
-    ws.once('message', onMessage);
-    ws.once('error', onError);
-  });
-}
-
-async function sendRequest<T extends GatewayMessageBase>(ws: WebSocket, request: Record<string, unknown>): Promise<T> {
-  const responsePromise = waitForMessage<T>(ws);
-  ws.send(JSON.stringify(request));
-  return responsePromise;
-}
-
-async function connectClient(port: number, token: string): Promise<WebSocket> {
-  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
-  await waitForOpen(ws);
-
-  const response = await sendRequest<GatewayResponse>(ws, {
-    type: 'connect',
-    token,
-    clientType: 'web',
-    clientId: `test-${Date.now()}`,
-  });
-
-  expect(response).toEqual({ type: 'ok', requestType: 'connect' });
-  return ws;
 }
 
 function createAgentOps(): GatewayAgentOps {

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-integration.test.ts
@@ -180,6 +180,7 @@ async function createHarness(): Promise<TestHarness> {
   const server = new GatewayServer({
     port: 0,
     previewPort: 0,
+    previewTlsPort: 8443,
     host: '127.0.0.1',
     tokenPath: path.join(tmpDir, 'gateway-token.txt'),
     configDir: tmpDir,

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-owner-token.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-owner-token.test.ts
@@ -206,6 +206,7 @@ async function createHarness(): Promise<TestHarness> {
   const state = createAgentOps();
   const server = new GatewayServer({
     port: 0,
+    previewPort: 0,
     host: '127.0.0.1',
     tokenPath: path.join(tmpDir, 'gateway-token.txt'),
     configDir: tmpDir,

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-owner-token.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-owner-token.test.ts
@@ -207,6 +207,7 @@ async function createHarness(): Promise<TestHarness> {
   const server = new GatewayServer({
     port: 0,
     previewPort: 0,
+    previewTlsPort: 8443,
     host: '127.0.0.1',
     tokenPath: path.join(tmpDir, 'gateway-token.txt'),
     configDir: tmpDir,

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
@@ -21,6 +21,7 @@ describe('GatewayServer artifact authorization', () => {
 
     const server = new GatewayServer({
       port: 18800,
+      previewPort: 0,
       host: '127.0.0.1',
       tokenPath: path.join(tmpDir, 'gateway-token.txt'),
       configDir: tmpDir,

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-server.test.ts
@@ -22,6 +22,7 @@ describe('GatewayServer artifact authorization', () => {
     const server = new GatewayServer({
       port: 18800,
       previewPort: 0,
+      previewTlsPort: 8443,
       host: '127.0.0.1',
       tokenPath: path.join(tmpDir, 'gateway-token.txt'),
       configDir: tmpDir,

--- a/apps/desktop/electron/__tests__/features/gateway/gateway-ws-test-utils.ts
+++ b/apps/desktop/electron/__tests__/features/gateway/gateway-ws-test-utils.ts
@@ -1,0 +1,82 @@
+/**
+ * WebSocket helpers for gateway integration tests. Split from
+ * gateway-integration.test.ts to keep it under the 500-LOC rule.
+ */
+
+import { expect } from 'vitest';
+import { WebSocket, type RawData } from 'ws';
+import type { GatewayResponse } from '@electron/features/gateway/server/protocol';
+
+export interface GatewayMessageBase {
+  type: string;
+}
+
+export function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+}
+
+export function waitForClose(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.CLOSED) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    ws.once('close', () => resolve());
+  });
+}
+
+export function waitForMessage<T extends GatewayMessageBase>(ws: WebSocket): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      ws.off('message', onMessage);
+      ws.off('error', onError);
+      reject(new Error('Timed out waiting for gateway message'));
+    }, 2000);
+
+    const onMessage = (data: RawData) => {
+      clearTimeout(timeout);
+      ws.off('error', onError);
+      resolve(JSON.parse(data.toString()) as T);
+    };
+
+    const onError = (error: Error) => {
+      clearTimeout(timeout);
+      ws.off('message', onMessage);
+      reject(error);
+    };
+
+    ws.once('message', onMessage);
+    ws.once('error', onError);
+  });
+}
+
+export async function sendRequest<T extends GatewayMessageBase>(
+  ws: WebSocket,
+  request: Record<string, unknown>,
+): Promise<T> {
+  const responsePromise = waitForMessage<T>(ws);
+  ws.send(JSON.stringify(request));
+  return responsePromise;
+}
+
+export async function connectClient(port: number, token: string): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  await waitForOpen(ws);
+
+  const response = await sendRequest<GatewayResponse>(ws, {
+    type: 'connect',
+    token,
+    clientType: 'web',
+    clientId: `test-${Date.now()}`,
+  });
+
+  expect(response).toEqual({ type: 'ok', requestType: 'connect' });
+  return ws;
+}

--- a/apps/desktop/electron/features/browser/element-grab.ts
+++ b/apps/desktop/electron/features/browser/element-grab.ts
@@ -1,0 +1,143 @@
+/**
+ * React-grab element picking inside browser tabs.
+ *
+ * The react-grab IIFE bundle (staged next to the main bundle by
+ * build-electron.mjs) is injected into the page on first use, then driven
+ * through its `window.__REACT_GRAB__` API. A pick resolves through a
+ * page-side promise that settles when the user grabs an element (click /
+ * Cmd+C) or cancels (Escape) — push-based, no polling.
+ *
+ * Scripts below follow the same escaping rules as page-scripts.ts: they are
+ * serialized before the page parses them, so keep string literals and
+ * comments free of escape sequences and stray quotes.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { WebContents } from 'electron';
+import type { BrowserGrabResult } from '@/types/browser';
+
+let cachedBundle: string | null = null;
+
+function loadReactGrabBundle(): string {
+  cachedBundle ??= fs.readFileSync(path.join(__dirname, 'react-grab.global.js'), 'utf8');
+  return cachedBundle;
+}
+
+/**
+ * Load react-grab into the page and init it under our control. The bundle
+ * must run at top level: it publishes its module namespace via `this`,
+ * which only points at `window` in sloppy top-level code. Setting
+ * `__REACT_GRAB_DISABLED__` first suppresses its auto-init so we can init
+ * with telemetry off; the `sero-grab-host` plugin hides react-grab's own
+ * floating toolbar (we only expose picking through the Sero toolbar).
+ * If the page already ships react-grab (a dev app using it), we reuse the
+ * page's instance untouched.
+ */
+function buildInjectScript(): string {
+  return [
+    'window.__REACT_GRAB_DISABLED__ = true;',
+    loadReactGrabBundle(),
+    `;(() => {
+      if (window.__REACT_GRAB__) return true;
+      const mod = globalThis.__REACT_GRAB_MODULE__;
+      if (!mod || typeof mod.init !== 'function') return false;
+      const api = mod.init({ telemetry: false });
+      mod.setGlobalApi(api);
+      api.registerPlugin({ name: 'sero-grab-host', theme: { toolbar: { enabled: false } } });
+      return Boolean(window.__REACT_GRAB__);
+    })();`,
+  ].join('\n');
+}
+
+/**
+ * Activate the picker and return a promise that settles with the grab
+ * outcome. The bridge plugin resolves through `__SERO_GRAB_RESOLVE__` so a
+ * cancel script (or Escape via react-grab's own deactivation) can settle
+ * the same pick. `onCopySuccess` receives the exact agent-ready context
+ * string react-grab puts on the clipboard.
+ */
+function buildStartPickScript(): string {
+  return `(() => {
+    const api = window.__REACT_GRAB__;
+    if (!api) return { status: 'unavailable' };
+    if (window.__SERO_GRAB_RESOLVE__) return { status: 'unavailable' };
+    const settle = (result) => {
+      const resolve = window.__SERO_GRAB_RESOLVE__;
+      window.__SERO_GRAB_RESOLVE__ = null;
+      if (resolve) resolve(result);
+    };
+    if (!api.getPlugins().includes('sero-grab-bridge')) {
+      api.registerPlugin({
+        name: 'sero-grab-bridge',
+        hooks: {
+          onCopySuccess: (elements, content) => settle({ status: 'grabbed', content }),
+          onDeactivate: () => settle({ status: 'cancelled' }),
+        },
+      });
+    }
+    return new Promise((resolve) => {
+      window.__SERO_GRAB_RESOLVE__ = resolve;
+      api.activate();
+    });
+  })()`;
+}
+
+/**
+ * Cancel a pending pick. Deactivating settles the pick via the bridge
+ * plugin's onDeactivate; the direct settle covers the defensive case where
+ * a resolver is pending but the picker is no longer active.
+ */
+function buildCancelPickScript(): string {
+  return `(() => {
+    const api = window.__REACT_GRAB__;
+    if (api && api.isActive()) {
+      api.deactivate();
+      return;
+    }
+    const resolve = window.__SERO_GRAB_RESOLVE__;
+    window.__SERO_GRAB_RESOLVE__ = null;
+    if (resolve) resolve({ status: 'cancelled' });
+  })()`;
+}
+
+function isGrabResult(value: unknown): value is BrowserGrabResult {
+  if (!value || typeof value !== 'object') return false;
+  const status = (value as { status?: unknown }).status;
+  return status === 'grabbed' || status === 'cancelled' || status === 'unavailable';
+}
+
+/** Inject react-grab (once per page load) and run a pick to completion. */
+export async function grabElementInPage(wc: WebContents): Promise<BrowserGrabResult> {
+  try {
+    const present = await wc.executeJavaScript('Boolean(window.__REACT_GRAB__)', true);
+    if (!present) {
+      const injected = await wc.executeJavaScript(buildInjectScript(), true);
+      if (injected !== true) return { status: 'unavailable' };
+    }
+  } catch (err) {
+    console.warn('[browser] react-grab injection failed:', err);
+    return { status: 'unavailable' };
+  }
+
+  // The page-side promise dies silently if the page navigates away or the
+  // tab is closed, so race it against teardown events.
+  let onGone: () => void = () => {};
+  const gone = new Promise<null>((resolve) => {
+    onGone = () => resolve(null);
+    wc.on('did-navigate', onGone);
+    wc.on('destroyed', onGone);
+  });
+  const result = await Promise.race([
+    wc.executeJavaScript(buildStartPickScript(), true).catch(() => null),
+    gone,
+  ]);
+  wc.off('did-navigate', onGone);
+  wc.off('destroyed', onGone);
+  return isGrabResult(result) ? result : { status: 'cancelled' };
+}
+
+/** Cancel an in-flight pick (toolbar toggle-off). */
+export function cancelGrabInPage(wc: WebContents): void {
+  void wc.executeJavaScript(buildCancelPickScript(), true).catch(() => undefined);
+}

--- a/apps/desktop/electron/features/browser/element-grab.ts
+++ b/apps/desktop/electron/features/browser/element-grab.ts
@@ -19,7 +19,8 @@ import type { BrowserGrabResult } from '@/types/browser';
 
 let cachedBundle: string | null = null;
 
-function loadReactGrabBundle(): string {
+/** Also used by the gateway to build the dev-server preview grab script. */
+export function loadReactGrabBundle(): string {
   cachedBundle ??= fs.readFileSync(path.join(__dirname, 'react-grab.global.js'), 'utf8');
   return cachedBundle;
 }

--- a/apps/desktop/electron/features/browser/view-manager.ts
+++ b/apps/desktop/electron/features/browser/view-manager.ts
@@ -1,10 +1,11 @@
 import { BrowserWindow, WebContentsView, shell, session } from 'electron';
 import type { WebContents } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
-import type { BrowserEvent, BrowserViewBounds } from '@/types/browser';
-import { BROWSER_HOME_URL } from '@/types/browser';
+import type { BrowserEvent, BrowserGrabResult, BrowserViewBounds } from '@/types/browser';
 import { showBrowserContextMenu } from './context-menu';
+import { cancelGrabInPage, grabElementInPage } from './element-grab';
 import { buildExtractPageScript, buildScrollPageScript } from './page-scripts';
+import { handleBrowserShortcut } from './view-shortcuts';
 
 const BROWSER_PARTITION_PREFIX = 'persist:sero-browser';
 const ALLOWED_BROWSER_PROTOCOLS = new Set(['http:', 'https:']);
@@ -35,7 +36,7 @@ export interface LoadedTabInfo {
   isActive: boolean;
 }
 
-class BrowserViewManager {
+export class BrowserViewManager {
   private window: BrowserWindow | null = null;
   private readonly views = new Map<string, WebContentsView>();
   private readonly viewWorkspaces = new Map<string, string>();
@@ -283,7 +284,8 @@ class BrowserViewManager {
     return this.lastActivePerWorkspace.get(workspaceId) ?? null;
   }
 
-  private activateByOffset(workspaceId: string, delta: number): void {
+  /** Cycle the active tab within a workspace by the given offset (wraps). */
+  activateByOffset(workspaceId: string, delta: number): void {
     const tabs = this.listLoadedTabs(workspaceId);
     if (tabs.length === 0) return;
     const activeId = this.resolveActiveTabForWorkspace(workspaceId);
@@ -295,6 +297,28 @@ class BrowserViewManager {
   /** Whether a given tab id exists as a loaded WebContentsView. */
   hasTab(tabId: string): boolean {
     return this.views.has(tabId);
+  }
+
+  /** WebContents for a tab, gated on workspace ownership. */
+  webContentsFor(tabId: string, workspaceId: string): WebContents | null {
+    if (!this.ownsTab(tabId, workspaceId, 'webContentsFor')) return null;
+    return this.views.get(tabId)?.webContents ?? null;
+  }
+
+  /**
+   * Start a react-grab element pick in the tab. Resolves when the user
+   * grabs an element or cancels; navigation and tab close also cancel.
+   */
+  grabElement(tabId: string, workspaceId: string): Promise<BrowserGrabResult> {
+    const wc = this.webContentsFor(tabId, workspaceId);
+    if (!wc) return Promise.resolve({ status: 'unavailable' });
+    return grabElementInPage(wc);
+  }
+
+  /** Cancel an in-flight element pick in the tab. */
+  cancelGrab(tabId: string, workspaceId: string): void {
+    const wc = this.webContentsFor(tabId, workspaceId);
+    if (wc) cancelGrabInPage(wc);
   }
 
   /** Workspace a tab belongs to, or null if unknown. */
@@ -369,53 +393,7 @@ class BrowserViewManager {
     const wc = view.webContents;
 
     wc.on('before-input-event', (event, input) => {
-      if (input.type !== 'keyDown' || (!input.meta && !input.control) || input.alt) return;
-      const key = input.key.toLowerCase();
-      const loaded = this.listLoadedTabs(workspaceId);
-      const activeId = this.resolveActiveTabForWorkspace(workspaceId) ?? tabId;
-      const activeView = this.views.get(activeId);
-
-      if (input.shift && (key === '[' || key === ']')) {
-        event.preventDefault();
-        this.activateByOffset(workspaceId, key === '[' ? -1 : 1);
-        return;
-      }
-      if (input.shift) return;
-
-      if (/^[1-9]$/.test(key)) {
-        event.preventDefault();
-        const index = key === '9' ? loaded.length - 1 : Number(key) - 1;
-        const target = loaded[index];
-        if (target) this.setActive(target.id, workspaceId);
-        return;
-      }
-
-      switch (key) {
-        case 't':
-          event.preventDefault();
-          this.openTabForHost(BROWSER_HOME_URL, workspaceId);
-          return;
-        case 'w':
-          event.preventDefault();
-          this.closeTabForHost(activeId, workspaceId);
-          return;
-        case 'r':
-          event.preventDefault();
-          activeView?.webContents.reload();
-          return;
-        case '[':
-          if (activeView?.webContents.navigationHistory.canGoBack()) {
-            event.preventDefault();
-            activeView.webContents.navigationHistory.goBack();
-          }
-          return;
-        case ']':
-          if (activeView?.webContents.navigationHistory.canGoForward()) {
-            event.preventDefault();
-            activeView.webContents.navigationHistory.goForward();
-          }
-          return;
-      }
+      handleBrowserShortcut(this, event, input, tabId, workspaceId);
     });
 
     // Security: open new windows (target=_blank, window.open) as new tabs

--- a/apps/desktop/electron/features/browser/view-shortcuts.ts
+++ b/apps/desktop/electron/features/browser/view-shortcuts.ts
@@ -1,0 +1,65 @@
+/**
+ * Native keyboard shortcuts for browser tabs (Cmd/Ctrl+T/W/R, tab cycling,
+ * history). Runs inside each WebContentsView's before-input-event so the
+ * shortcuts work while the page has focus.
+ */
+
+import type { Event, Input } from 'electron';
+import { BROWSER_HOME_URL } from '@/types/browser';
+import type { BrowserViewManager } from './view-manager';
+
+export function handleBrowserShortcut(
+  manager: BrowserViewManager,
+  event: Event,
+  input: Input,
+  tabId: string,
+  workspaceId: string,
+): void {
+  if (input.type !== 'keyDown' || (!input.meta && !input.control) || input.alt) return;
+  const key = input.key.toLowerCase();
+  const loaded = manager.listLoadedTabs(workspaceId);
+  const activeId = manager.resolveActiveTabForWorkspace(workspaceId) ?? tabId;
+  const activeWc = manager.webContentsFor(activeId, workspaceId);
+
+  if (input.shift && (key === '[' || key === ']')) {
+    event.preventDefault();
+    manager.activateByOffset(workspaceId, key === '[' ? -1 : 1);
+    return;
+  }
+  if (input.shift) return;
+
+  if (/^[1-9]$/.test(key)) {
+    event.preventDefault();
+    const index = key === '9' ? loaded.length - 1 : Number(key) - 1;
+    const target = loaded[index];
+    if (target) manager.setActive(target.id, workspaceId);
+    return;
+  }
+
+  switch (key) {
+    case 't':
+      event.preventDefault();
+      manager.openTabForHost(BROWSER_HOME_URL, workspaceId);
+      return;
+    case 'w':
+      event.preventDefault();
+      manager.closeTabForHost(activeId, workspaceId);
+      return;
+    case 'r':
+      event.preventDefault();
+      activeWc?.reload();
+      return;
+    case '[':
+      if (activeWc?.navigationHistory.canGoBack()) {
+        event.preventDefault();
+        activeWc.navigationHistory.goBack();
+      }
+      return;
+    case ']':
+      if (activeWc?.navigationHistory.canGoForward()) {
+        event.preventDefault();
+        activeWc.navigationHistory.goForward();
+      }
+      return;
+  }
+}

--- a/apps/desktop/electron/features/gateway/bridge/tailscale.ts
+++ b/apps/desktop/electron/features/gateway/bridge/tailscale.ts
@@ -90,8 +90,15 @@ export class TailscaleIntegration {
    * Expose a local port on the tailnet using `tailscale serve`.
    * This makes the gateway accessible to other devices on your tailnet.
    * Does NOT use Funnel (no public internet exposure).
+   *
+   * When a preview mapping is given, the dev-server preview listener is
+   * also exposed, on its own HTTPS port — previews must keep a separate
+   * origin from the SPA (see GatewayConfig.previewPort).
    */
-  async serve(port: number): Promise<string | null> {
+  async serve(
+    port: number,
+    preview?: { previewPort: number; previewTlsPort: number },
+  ): Promise<string | null> {
     const bin = await this.findBinary();
     if (!bin) return null;
 
@@ -105,6 +112,21 @@ export class TailscaleIntegration {
         { timeout: 15000 },
       );
       this.servingPort = port;
+
+      if (preview) {
+        // Preview listener → https://<hostname>:<previewTlsPort>.
+        // Non-fatal: without it the SPA still works, only embedded
+        // previews are unavailable remotely.
+        try {
+          await execFileAsync(
+            bin,
+            ['serve', '--bg', `--https=${preview.previewTlsPort}`, String(preview.previewPort)],
+            { timeout: 15000 },
+          );
+        } catch (err) {
+          console.error('[tailscale] Failed to serve preview port:', err);
+        }
+      }
 
       const status = await this.getStatus();
       console.log(

--- a/apps/desktop/electron/features/gateway/bridge/tailscale.ts
+++ b/apps/desktop/electron/features/gateway/bridge/tailscale.ts
@@ -91,13 +91,14 @@ export class TailscaleIntegration {
    * This makes the gateway accessible to other devices on your tailnet.
    * Does NOT use Funnel (no public internet exposure).
    *
-   * When a preview mapping is given, the dev-server preview listener is
-   * also exposed, on its own HTTPS port — previews must keep a separate
-   * origin from the SPA (see GatewayConfig.previewPort).
+   * The dev-server preview listener is always exposed alongside, on its
+   * own HTTPS port — previews must keep a separate origin from the SPA
+   * (see GatewayConfig.previewPort). Required so no call site can expose
+   * the SPA without its preview mapping.
    */
   async serve(
     port: number,
-    preview?: { previewPort: number; previewTlsPort: number },
+    preview: { previewPort: number; previewTlsPort: number },
   ): Promise<string | null> {
     const bin = await this.findBinary();
     if (!bin) return null;
@@ -113,19 +114,17 @@ export class TailscaleIntegration {
       );
       this.servingPort = port;
 
-      if (preview) {
-        // Preview listener → https://<hostname>:<previewTlsPort>.
-        // Non-fatal: without it the SPA still works, only embedded
-        // previews are unavailable remotely.
-        try {
-          await execFileAsync(
-            bin,
-            ['serve', '--bg', `--https=${preview.previewTlsPort}`, String(preview.previewPort)],
-            { timeout: 15000 },
-          );
-        } catch (err) {
-          console.error('[tailscale] Failed to serve preview port:', err);
-        }
+      // Preview listener → https://<hostname>:<previewTlsPort>.
+      // Non-fatal: without it the SPA still works, only embedded
+      // previews are unavailable remotely.
+      try {
+        await execFileAsync(
+          bin,
+          ['serve', '--bg', `--https=${preview.previewTlsPort}`, String(preview.previewPort)],
+          { timeout: 15000 },
+        );
+      } catch (err) {
+        console.error('[tailscale] Failed to serve preview port:', err);
       }
 
       const status = await this.getStatus();

--- a/apps/desktop/electron/features/gateway/index.ts
+++ b/apps/desktop/electron/features/gateway/index.ts
@@ -15,13 +15,17 @@ import { primeStaticFileCache } from './server/static-files';
 import { redactSecrets } from '@electron/shared/lib/secret-redact';
 import { validateRequest, type GatewayRequest, type GatewayResponse, type GatewayPushEvent } from './server/protocol';
 import type { GatewayConfig, GatewayAgentOps, GatewayDevServerChange } from './server/types';
-import { hasWorkspaceAccess, authorizeArtifactFromSession, hasSessionAccess, type GatewayAccessScope } from './server/access-control';
+import type { GatewayAccessScope } from './server/access-control';
+import {
+  broadcastDevServerChange as fanoutDevServerChange,
+  broadcastGatewayEvent,
+  pushSessionEvent,
+} from './server/event-broadcast';
 import {
   DevProxyTicketManager,
   generateTicketSecret,
 } from './security/devserver-ticket';
-import { toDevServerChangedEvent } from './server/devserver-proxy';
-import { createGatewayHttpServer } from './server/http-app';
+import { createGatewayHttpServer, createPreviewHttpServer } from './server/http-app';
 import { getClientIp, isOriginAllowed } from './server/connection-security';
 
 export type {
@@ -70,7 +74,7 @@ function readBestEffortRequestId(raw: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
-interface ConnectedClient extends GatewayAccessScope {
+export interface ConnectedClient extends GatewayAccessScope {
   ws: WebSocket;
   clientType: string;
   clientId: string;
@@ -88,6 +92,7 @@ interface ConnectedClient extends GatewayAccessScope {
 export class GatewayServer {
   private wss: WebSocketServer | null = null;
   private httpServer: http.Server | null = null;
+  private previewServer: http.Server | null = null;
   private auth: GatewayAuth;
   private clients = new Map<WebSocket, ConnectedClient>();
   private agentOps: GatewayAgentOps | null = null;
@@ -146,6 +151,7 @@ export class GatewayServer {
 
     this.httpServer = createGatewayHttpServer({
       staticRoot: __dirname,
+      previewPort: this.config.previewPort,
       getWebChatHtml: () => this.webChatHtml,
       getProxyDeps: () => this.proxyDeps(),
       upgradeWebSocket: (req, socket, head) => {
@@ -153,6 +159,10 @@ export class GatewayServer {
           this.wss!.emit('connection', ws, req);
         });
       },
+    });
+
+    this.previewServer = createPreviewHttpServer({
+      getProxyDeps: () => this.proxyDeps(),
     });
 
     // The 'ws' library handles upgrades for paths it owns, but we need to
@@ -172,7 +182,7 @@ export class GatewayServer {
 
     this.idleCheckTimer = setInterval(() => this.checkIdleConnections(), 5 * 60_000);
 
-    return new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       this.httpServer!.listen(this.config.port, this.config.host, () => {
         console.log(
           `[gateway] Server listening on ws://${this.config.host}:${this.config.port}`,
@@ -180,6 +190,16 @@ export class GatewayServer {
         resolve();
       });
       this.httpServer!.on('error', reject);
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      this.previewServer!.listen(this.config.previewPort, this.config.host, () => {
+        console.log(
+          `[gateway] Preview listener on http://${this.config.host}:${this.config.previewPort}`,
+        );
+        resolve();
+      });
+      this.previewServer!.on('error', reject);
     });
   }
 
@@ -205,6 +225,8 @@ export class GatewayServer {
 
     return new Promise<void>((resolve) => {
       this.wss?.close(() => {
+        this.previewServer?.close();
+        this.previewServer = null;
         this.httpServer?.close(() => {
           this.wss = null;
           this.httpServer = null;
@@ -240,33 +262,12 @@ export class GatewayServer {
    * Called by the agent event bridge.
    */
   pushEvent(sessionId: string, event: GatewayPushEvent): void {
-    const payload = JSON.stringify(event);
-    for (const [ws, client] of this.clients) {
-      if (!client.authenticated || !client.subscribedSessions.has(sessionId)) {
-        continue;
-      }
-      if (!this.canReceiveSessionEvent(client, sessionId)) {
-        continue;
-      }
-      this.authorizeEventArtifacts(client, event);
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(payload);
-      }
-    }
+    pushSessionEvent(this.clients, sessionId, event);
   }
 
   /** Push an event to authenticated clients that are authorized for its session. */
   broadcastEvent(event: GatewayPushEvent): void {
-    const payload = JSON.stringify(event);
-    const sessionId = 'sessionId' in event ? event.sessionId : null;
-    for (const [ws, client] of this.clients) {
-      if (!client.authenticated) continue;
-      if (sessionId && !this.canReceiveSessionEvent(client, sessionId)) continue;
-      this.authorizeEventArtifacts(client, event);
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(payload);
-      }
-    }
+    broadcastGatewayEvent(this.clients, event);
   }
 
   /** Get the auth manager (for web token operations from the request handler). */
@@ -274,20 +275,9 @@ export class GatewayServer {
     return this.auth;
   }
 
-  /**
-   * Push a dev server change to clients authorized for the affected
-   * workspace. Master-token clients see everything; scoped clients
-   * only see workspaces in their authorization set.
-   */
+  /** Push a dev server change to clients authorized for the affected workspace. */
   broadcastDevServerChange(change: GatewayDevServerChange): void {
-    const payload = JSON.stringify(toDevServerChangedEvent(change));
-    for (const [ws, client] of this.clients) {
-      if (!client.authenticated) continue;
-      if (!hasWorkspaceAccess(client, change.workspaceId)) continue;
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(payload);
-      }
-    }
+    fanoutDevServerChange(this.clients, change);
   }
 
   private proxyDeps() {
@@ -295,16 +285,6 @@ export class GatewayServer {
       agentOps: () => this.agentOps,
       tickets: this.devProxyTickets,
     };
-  }
-
-  private canReceiveSessionEvent(client: ConnectedClient, sessionId: string): boolean {
-    return hasSessionAccess(client, sessionId);
-  }
-
-  private authorizeEventArtifacts(client: ConnectedClient, event: GatewayPushEvent): void {
-    if (event.type === 'artifact_added') {
-      authorizeArtifactFromSession(client, event.sessionId, event.artifactId);
-    }
   }
 
   private applyAuthResult(client: ConnectedClient, result: GatewayAuthResult): void {
@@ -513,6 +493,7 @@ export class GatewayServer {
       this.auth,
       client.isMasterAuth,
       this.devProxyTickets,
+      this.config.previewPort,
     );
   }
 }

--- a/apps/desktop/electron/features/gateway/index.ts
+++ b/apps/desktop/electron/features/gateway/index.ts
@@ -152,6 +152,7 @@ export class GatewayServer {
     this.httpServer = createGatewayHttpServer({
       staticRoot: __dirname,
       previewPort: this.config.previewPort,
+      previewTlsPort: this.config.previewTlsPort,
       getWebChatHtml: () => this.webChatHtml,
       getProxyDeps: () => this.proxyDeps(),
       upgradeWebSocket: (req, socket, head) => {
@@ -235,6 +236,14 @@ export class GatewayServer {
         });
       });
     });
+  }
+
+  /** Preview listener ports (direct + tailnet TLS mapping). */
+  getPreviewPorts(): { previewPort: number; previewTlsPort: number } {
+    return {
+      previewPort: this.config.previewPort,
+      previewTlsPort: this.config.previewTlsPort,
+    };
   }
 
   /** Get the auth token for display. */
@@ -493,7 +502,7 @@ export class GatewayServer {
       this.auth,
       client.isMasterAuth,
       this.devProxyTickets,
-      this.config.previewPort,
+      this.getPreviewPorts(),
     );
   }
 }

--- a/apps/desktop/electron/features/gateway/index.ts
+++ b/apps/desktop/electron/features/gateway/index.ts
@@ -17,6 +17,14 @@ import { validateRequest, type GatewayRequest, type GatewayResponse, type Gatewa
 import type { GatewayConfig, GatewayAgentOps, GatewayDevServerChange } from './server/types';
 import type { GatewayAccessScope } from './server/access-control';
 import {
+  AUTH_TIMEOUT_MS,
+  IDLE_TIMEOUT_MS,
+  MAX_CONNECTIONS_PER_IP,
+  MAX_PAYLOAD_BYTES,
+  MAX_TOTAL_CONNECTIONS,
+  readBestEffortRequestId,
+} from './server/connection-limits';
+import {
   broadcastDevServerChange as fanoutDevServerChange,
   broadcastGatewayEvent,
   pushSessionEvent,
@@ -38,41 +46,7 @@ export type {
   GatewayDevServerChange,
 } from './server/types';
 
-/**
- * Maximum WebSocket message payload (36 MB).
- *
- * This is the *first* gate: `ws` enforces it during frame reassembly, before
- * we ever see the bytes — over-limit messages close the socket with code
- * 1009. Sized to accommodate the voice transcription path: the OpenAI helper
- * caps decoded audio at 25 MB, which becomes ~33.4 MB after base64 encoding
- * plus the JSON envelope.
- *
- * Once a frame fits, two further checks run in order:
- *   1. `validateRequest` (protocol.ts) rejects voice payloads above 35 MB
- *      to short-circuit clearly bogus inputs.
- *   2. The OpenAI transcription helper enforces the 25 MB decoded ceiling.
- */
-const MAX_PAYLOAD_BYTES = 36 * 1024 * 1024;
-/** Maximum total concurrent WebSocket connections. */
-const MAX_TOTAL_CONNECTIONS = 50;
-/** Maximum concurrent WebSocket connections per source IP. */
-const MAX_CONNECTIONS_PER_IP = 10;
-/** Idle timeout for authenticated connections (30 minutes). */
-const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
-/** Auth timeout for unauthenticated connections (10 seconds). */
-const AUTH_TIMEOUT_MS = 10_000;
 type WebChatHtmlProvider = () => string;
-
-/**
- * Best-effort `requestId` extraction for early errors that fail before
- * `validateRequest` produces a typed request. Lets the client correlate the
- * error with its outstanding promise instead of leaving it pending.
- */
-function readBestEffortRequestId(raw: unknown): string | null {
-  if (!raw || typeof raw !== 'object') return null;
-  const value = (raw as { requestId?: unknown }).requestId;
-  return typeof value === 'string' && value.length > 0 ? value : null;
-}
 
 export interface ConnectedClient extends GatewayAccessScope {
   ws: WebSocket;
@@ -183,24 +157,36 @@ export class GatewayServer {
 
     this.idleCheckTimer = setInterval(() => this.checkIdleConnections(), 5 * 60_000);
 
-    await new Promise<void>((resolve, reject) => {
-      this.httpServer!.listen(this.config.port, this.config.host, () => {
-        console.log(
-          `[gateway] Server listening on ws://${this.config.host}:${this.config.port}`,
-        );
-        resolve();
-      });
-      this.httpServer!.on('error', reject);
-    });
+    try {
+      await this.listenOn(this.httpServer, this.config.port);
+      console.log(
+        `[gateway] Server listening on ws://${this.config.host}:${this.config.port}`,
+      );
+      await this.listenOn(this.previewServer, this.config.previewPort);
+      console.log(
+        `[gateway] Preview listener on http://${this.config.host}:${this.config.previewPort}`,
+      );
+    } catch (err) {
+      // Roll back everything: a half-started gateway must not report
+      // itself running, and a later start() has to retry from scratch.
+      if (this.idleCheckTimer) {
+        clearInterval(this.idleCheckTimer);
+        this.idleCheckTimer = null;
+      }
+      this.wss?.close();
+      this.wss = null;
+      this.previewServer?.close();
+      this.previewServer = null;
+      this.httpServer?.close();
+      this.httpServer = null;
+      throw err;
+    }
+  }
 
+  private listenOn(server: http.Server, port: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
-      this.previewServer!.listen(this.config.previewPort, this.config.host, () => {
-        console.log(
-          `[gateway] Preview listener on http://${this.config.host}:${this.config.previewPort}`,
-        );
-        resolve();
-      });
-      this.previewServer!.on('error', reject);
+      server.listen(port, this.config.host, () => resolve());
+      server.on('error', reject);
     });
   }
 

--- a/apps/desktop/electron/features/gateway/server/connection-limits.ts
+++ b/apps/desktop/electron/features/gateway/server/connection-limits.ts
@@ -1,0 +1,39 @@
+/**
+ * Gateway connection limits and early-error helpers. Split from
+ * gateway/index.ts to keep it under the 500-LOC rule.
+ */
+
+/**
+ * Maximum WebSocket message payload (36 MB).
+ *
+ * This is the *first* gate: `ws` enforces it during frame reassembly, before
+ * we ever see the bytes — over-limit messages close the socket with code
+ * 1009. Sized to accommodate the voice transcription path: the OpenAI helper
+ * caps decoded audio at 25 MB, which becomes ~33.4 MB after base64 encoding
+ * plus the JSON envelope.
+ *
+ * Once a frame fits, two further checks run in order:
+ *   1. `validateRequest` (protocol.ts) rejects voice payloads above 35 MB
+ *      to short-circuit clearly bogus inputs.
+ *   2. The OpenAI transcription helper enforces the 25 MB decoded ceiling.
+ */
+export const MAX_PAYLOAD_BYTES = 36 * 1024 * 1024;
+/** Maximum total concurrent WebSocket connections. */
+export const MAX_TOTAL_CONNECTIONS = 50;
+/** Maximum concurrent WebSocket connections per source IP. */
+export const MAX_CONNECTIONS_PER_IP = 10;
+/** Idle timeout for authenticated connections (30 minutes). */
+export const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+/** Auth timeout for unauthenticated connections (10 seconds). */
+export const AUTH_TIMEOUT_MS = 10_000;
+
+/**
+ * Best-effort `requestId` extraction for early errors that fail before
+ * `validateRequest` produces a typed request. Lets the client correlate the
+ * error with its outstanding promise instead of leaving it pending.
+ */
+export function readBestEffortRequestId(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = (raw as { requestId?: unknown }).requestId;
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}

--- a/apps/desktop/electron/features/gateway/server/devserver-proxy-utils.ts
+++ b/apps/desktop/electron/features/gateway/server/devserver-proxy-utils.ts
@@ -275,6 +275,22 @@ export function rewriteProxyBody(content: string, proxyBase: string): string {
     });
 }
 
+/**
+ * Add the react-grab preview script to a proxied HTML document. Placed at
+ * the top of <head> so the React DevTools hook it installs exists before
+ * the page's own (deferred module) scripts load React. Runs after path
+ * rewriting — the src must stay on the gateway origin, not the proxy base.
+ */
+export function injectGrabScriptTag(html: string, scriptPath: string): string {
+  const tag = `<script src="${scriptPath}"></script>`;
+  const headOpen = /<head[^>]*>/i.exec(html);
+  if (headOpen) {
+    const end = headOpen.index + headOpen[0].length;
+    return `${html.slice(0, end)}${tag}${html.slice(end)}`;
+  }
+  return `${tag}${html}`;
+}
+
 export function buildProxyLocation(parsed: ParsedProxyRequest, rest: string): string {
   const base = `${DEV_PROXY_PREFIX}${encodeURIComponent(parsed.workspaceId)}/${parsed.port}`;
   return `${base}${rest.startsWith('/') ? rest : `/${rest}`}`;

--- a/apps/desktop/electron/features/gateway/server/devserver-proxy.ts
+++ b/apps/desktop/electron/features/gateway/server/devserver-proxy.ts
@@ -17,6 +17,7 @@ import {
   buildProxyLocation,
   copyUpstreamHeaders,
   filterRequestHeaders,
+  injectGrabScriptTag,
   isHttps,
   parseDevProxyPath,
   readCookie,
@@ -27,6 +28,7 @@ import {
   shouldRewriteResponse,
   type ParsedProxyRequest,
 } from './devserver-proxy-utils';
+import { GRAB_SCRIPT_PATH } from './grab-script';
 
 export { DEV_PROXY_PREFIX, parseDevProxyPath } from './devserver-proxy-utils';
 
@@ -170,7 +172,11 @@ function pipeUpstreamResponse(
     if (streaming) return;
     res.writeHead(upstreamRes.statusCode ?? 502, responseHeaders);
     const body = Buffer.concat(chunks).toString('utf8');
-    res.end(rewriteProxyBody(body, proxyBase));
+    const rewritten = rewriteProxyBody(body, proxyBase);
+    const isHtml = String(upstreamRes.headers['content-type'] ?? '')
+      .toLowerCase()
+      .includes('text/html');
+    res.end(isHtml ? injectGrabScriptTag(rewritten, GRAB_SCRIPT_PATH) : rewritten);
   });
   upstreamRes.on('error', () => res.end());
 }

--- a/apps/desktop/electron/features/gateway/server/event-broadcast.ts
+++ b/apps/desktop/electron/features/gateway/server/event-broadcast.ts
@@ -1,0 +1,78 @@
+/**
+ * Push-event fan-out to connected gateway clients. Split from
+ * gateway/index.ts to keep it under the 500-LOC rule.
+ */
+
+import { WebSocket } from 'ws';
+import {
+  authorizeArtifactFromSession,
+  hasSessionAccess,
+  hasWorkspaceAccess,
+} from './access-control';
+import { toDevServerChangedEvent } from './devserver-proxy';
+import type { GatewayPushEvent } from './protocol';
+import type { GatewayDevServerChange } from './types';
+import type { ConnectedClient } from '../index';
+
+function authorizeEventArtifacts(client: ConnectedClient, event: GatewayPushEvent): void {
+  if (event.type === 'artifact_added') {
+    authorizeArtifactFromSession(client, event.sessionId, event.artifactId);
+  }
+}
+
+/** Push an event to all clients subscribed to (and authorized for) a session. */
+export function pushSessionEvent(
+  clients: Map<WebSocket, ConnectedClient>,
+  sessionId: string,
+  event: GatewayPushEvent,
+): void {
+  const payload = JSON.stringify(event);
+  for (const [ws, client] of clients) {
+    if (!client.authenticated || !client.subscribedSessions.has(sessionId)) {
+      continue;
+    }
+    if (!hasSessionAccess(client, sessionId)) {
+      continue;
+    }
+    authorizeEventArtifacts(client, event);
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(payload);
+    }
+  }
+}
+
+/** Push an event to authenticated clients that are authorized for its session. */
+export function broadcastGatewayEvent(
+  clients: Map<WebSocket, ConnectedClient>,
+  event: GatewayPushEvent,
+): void {
+  const payload = JSON.stringify(event);
+  const sessionId = 'sessionId' in event ? event.sessionId : null;
+  for (const [ws, client] of clients) {
+    if (!client.authenticated) continue;
+    if (sessionId && !hasSessionAccess(client, sessionId)) continue;
+    authorizeEventArtifacts(client, event);
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(payload);
+    }
+  }
+}
+
+/**
+ * Push a dev server change to clients authorized for the affected
+ * workspace. Master-token clients see everything; scoped clients
+ * only see workspaces in their authorization set.
+ */
+export function broadcastDevServerChange(
+  clients: Map<WebSocket, ConnectedClient>,
+  change: GatewayDevServerChange,
+): void {
+  const payload = JSON.stringify(toDevServerChangedEvent(change));
+  for (const [ws, client] of clients) {
+    if (!client.authenticated) continue;
+    if (!hasWorkspaceAccess(client, change.workspaceId)) continue;
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(payload);
+    }
+  }
+}

--- a/apps/desktop/electron/features/gateway/server/extended-handlers.ts
+++ b/apps/desktop/electron/features/gateway/server/extended-handlers.ts
@@ -50,6 +50,7 @@ export async function routeExtendedRequest(
   auth: GatewayAuth,
   isMasterAuth: boolean,
   devProxyTickets: DevProxyTicketManager | null,
+  previewPort: number | null,
 ): Promise<boolean> {
   const respond = makeResponder(ws, request.requestId);
   switch (request.type) {
@@ -390,6 +391,9 @@ export async function routeExtendedRequest(
             expiresAt: issued.expiresAt,
             workspaceId: issued.workspaceId,
             port: issued.port,
+            // Previews are served from their own origin (same host, this
+            // port) so the client should load them from there.
+            previewPort: previewPort ?? undefined,
           },
         });
       } catch (err) {

--- a/apps/desktop/electron/features/gateway/server/extended-handlers.ts
+++ b/apps/desktop/electron/features/gateway/server/extended-handlers.ts
@@ -50,7 +50,7 @@ export async function routeExtendedRequest(
   auth: GatewayAuth,
   isMasterAuth: boolean,
   devProxyTickets: DevProxyTicketManager | null,
-  previewPort: number | null,
+  previewPorts: { previewPort: number; previewTlsPort: number } | null,
 ): Promise<boolean> {
   const respond = makeResponder(ws, request.requestId);
   switch (request.type) {
@@ -391,9 +391,11 @@ export async function routeExtendedRequest(
             expiresAt: issued.expiresAt,
             workspaceId: issued.workspaceId,
             port: issued.port,
-            // Previews are served from their own origin (same host, this
-            // port) so the client should load them from there.
-            previewPort: previewPort ?? undefined,
+            // Previews are served from their own origin so the client
+            // should load them from there: previewPort for direct HTTP
+            // access, previewTlsPort when connected over TLS (tailnet).
+            previewPort: previewPorts?.previewPort,
+            previewTlsPort: previewPorts?.previewTlsPort,
           },
         });
       } catch (err) {

--- a/apps/desktop/electron/features/gateway/server/grab-script.ts
+++ b/apps/desktop/electron/features/gateway/server/grab-script.ts
@@ -1,0 +1,84 @@
+/**
+ * React-grab bundle for dev-server previews. The dev proxy injects a
+ * `<script src="/__sero/grab.js">` tag into proxied HTML documents; this
+ * module serves that script — the react-grab IIFE plus a bootstrap that
+ * bridges picks to the embedding web-remote SPA over postMessage.
+ *
+ * Message protocol (mirrored in apps/web-remote PreviewPanel):
+ *   parent → iframe: { type: 'sero:grab-start' } | { type: 'sero:grab-cancel' }
+ *   iframe → parent: { type: 'sero:grab-result', status: 'grabbed', content } |
+ *                    { type: 'sero:grab-result', status: 'cancelled' }
+ * The preview iframe is sandboxed without allow-same-origin, so both sides
+ * post with targetOrigin '*' and validate the source window instead.
+ */
+
+import http from 'http';
+import { loadReactGrabBundle } from '@electron/features/browser/element-grab';
+
+export const GRAB_SCRIPT_PATH = '/__sero/grab.js';
+
+let cachedScript: string | null = null;
+
+/**
+ * The bundle publishes its namespace through top-level `this`, so it must
+ * run at top level of this classic script. `__REACT_GRAB_DISABLED__`
+ * suppresses its auto-init; we init with telemetry off, hide react-grab's
+ * floating toolbar, then clear the flag so a page that ships its own
+ * react-grab copy reuses this instance instead of silently no-op'ing.
+ */
+function buildGrabScript(): string {
+  return [
+    'window.__REACT_GRAB_DISABLED__ = true;',
+    loadReactGrabBundle(),
+    `;(() => {
+      if (window.top === window) return;
+      const mod = globalThis.__REACT_GRAB_MODULE__;
+      if (!mod || typeof mod.init !== 'function') return;
+      if (!window.__REACT_GRAB__) {
+        const api = mod.init({ telemetry: false });
+        mod.setGlobalApi(api);
+        api.registerPlugin({ name: 'sero-grab-host', theme: { toolbar: { enabled: false } } });
+      }
+      delete window.__REACT_GRAB_DISABLED__;
+      const api = window.__REACT_GRAB__;
+      if (!api) return;
+      const post = (result) => window.parent.postMessage(result, '*');
+      // Source locations come from the dev server's module URLs, which the
+      // proxy has prefixed with /p/<workspace>/<port>. Strip that prefix
+      // (and vite's /@fs marker) so the agent sees real file paths.
+      const prefixMatch = /^\\/p\\/[^/]+\\/\\d+/.exec(location.pathname);
+      const cleanPaths = (content) => {
+        if (!prefixMatch) return content;
+        const prefix = prefixMatch[0];
+        return content.split(prefix + '/@fs').join('').split(prefix).join('');
+      };
+      api.registerPlugin({
+        name: 'sero-grab-bridge',
+        hooks: {
+          onCopySuccess: (elements, content) =>
+            post({ type: 'sero:grab-result', status: 'grabbed', content: cleanPaths(content) }),
+          onDeactivate: () => post({ type: 'sero:grab-result', status: 'cancelled' }),
+        },
+      });
+      window.addEventListener('message', (event) => {
+        if (event.source !== window.parent) return;
+        const data = event.data;
+        if (!data || typeof data !== 'object') return;
+        if (data.type === 'sero:grab-start') api.activate();
+        if (data.type === 'sero:grab-cancel') api.deactivate();
+      });
+    })();`,
+  ].join('\n');
+}
+
+/** Serve the grab script for `/__sero/grab.js`; returns false otherwise. */
+export function tryServeGrabScript(pathname: string, res: http.ServerResponse): boolean {
+  if (pathname !== GRAB_SCRIPT_PATH) return false;
+  cachedScript ??= buildGrabScript();
+  res.writeHead(200, {
+    'Content-Type': 'text/javascript; charset=utf-8',
+    'Cache-Control': 'no-store',
+  });
+  res.end(cachedScript);
+  return true;
+}

--- a/apps/desktop/electron/features/gateway/server/http-app.ts
+++ b/apps/desktop/electron/features/gateway/server/http-app.ts
@@ -1,12 +1,15 @@
 import http from 'http';
 import type { Duplex } from 'stream';
 import { DEV_PROXY_PREFIX, handleDevProxyRequest, handleDevProxyUpgrade, type DevProxyDeps } from './devserver-proxy';
+import { tryServeGrabScript } from './grab-script';
 import { tryServeStaticFile } from './static-files';
 
 type WebChatHtmlProvider = () => string;
 
 interface GatewayHttpServerOptions {
   staticRoot: string;
+  /** Port of the preview listener — allowed as a frame source for the SPA. */
+  previewPort: number;
   getWebChatHtml: () => WebChatHtmlProvider | null;
   getProxyDeps: () => DevProxyDeps;
   upgradeWebSocket: (
@@ -16,13 +19,24 @@ interface GatewayHttpServerOptions {
   ) => void;
 }
 
-function setGatewaySecurityHeaders(res: http.ServerResponse): void {
+function setGatewaySecurityHeaders(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  previewPort: number,
+): void {
   res.setHeader('Referrer-Policy', 'no-referrer');
   res.setHeader('X-Content-Type-Options', 'nosniff');
+  // Dev-server previews are framed from their own origin (same host,
+  // previewPort) so the sandboxed iframe can use allow-same-origin without
+  // sharing the SPA's origin. Derive that origin from the request host.
+  const hostname = (req.headers.host ?? '').split(':')[0];
+  const previewSrc = hostname
+    ? ` http://${hostname}:${previewPort} https://${hostname}:${previewPort}`
+    : '';
   res.setHeader(
     'Content-Security-Policy',
-    // frame-src 'self' lets the SPA iframe /p/... previews on the same origin.
-    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; frame-src 'self'",
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; " +
+      `frame-src 'self'${previewSrc}`,
   );
 }
 
@@ -51,7 +65,7 @@ export function createGatewayHttpServer(options: GatewayHttpServerOptions): http
     const pathname = rawUrl.split('?')[0];
     const isProxyRequest = pathname.startsWith(DEV_PROXY_PREFIX);
 
-    if (!isProxyRequest) setGatewaySecurityHeaders(res);
+    if (!isProxyRequest) setGatewaySecurityHeaders(req, res, options.previewPort);
 
     if (isProxyRequest) {
       void serveDevProxy(req, res, options.getProxyDeps());
@@ -70,6 +84,8 @@ export function createGatewayHttpServer(options: GatewayHttpServerOptions): http
       return;
     }
 
+    if (tryServeGrabScript(pathname, res)) return;
+
     if (tryServeStaticFile(pathname, res, options.staticRoot)) return;
 
     res.writeHead(404);
@@ -85,6 +101,45 @@ export function createGatewayHttpServer(options: GatewayHttpServerOptions): http
       return;
     }
     options.upgradeWebSocket(req, socket, head);
+  });
+
+  return server;
+}
+
+/**
+ * Dedicated listener for dev-server previews. Serves only the `/p/...`
+ * proxy routes (plus the grab script they inject) so previews live on
+ * their own origin — the preview iframe can then use allow-same-origin
+ * without becoming same-origin with the web-remote SPA.
+ */
+export function createPreviewHttpServer(
+  options: Pick<GatewayHttpServerOptions, 'getProxyDeps'>,
+): http.Server {
+  const server = http.createServer((req, res) => {
+    const pathname = (req.url ?? '/').split('?')[0];
+    if (pathname.startsWith(DEV_PROXY_PREFIX)) {
+      void serveDevProxy(req, res, options.getProxyDeps());
+      return;
+    }
+    if (tryServeGrabScript(pathname, res)) return;
+    if (pathname === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+
+  server.on('upgrade', (req, socket, head) => {
+    const path = (req.url ?? '/').split('?')[0];
+    if (path.startsWith(DEV_PROXY_PREFIX)) {
+      void handleDevProxyUpgrade(req, socket, head, options.getProxyDeps()).catch(() => {
+        socket.destroy();
+      });
+      return;
+    }
+    socket.destroy();
   });
 
   return server;

--- a/apps/desktop/electron/features/gateway/server/http-app.ts
+++ b/apps/desktop/electron/features/gateway/server/http-app.ts
@@ -8,8 +8,9 @@ type WebChatHtmlProvider = () => string;
 
 interface GatewayHttpServerOptions {
   staticRoot: string;
-  /** Port of the preview listener — allowed as a frame source for the SPA. */
+  /** Preview listener ports — allowed as frame sources for the SPA. */
   previewPort: number;
+  previewTlsPort: number;
   getWebChatHtml: () => WebChatHtmlProvider | null;
   getProxyDeps: () => DevProxyDeps;
   upgradeWebSocket: (
@@ -23,15 +24,18 @@ function setGatewaySecurityHeaders(
   req: http.IncomingMessage,
   res: http.ServerResponse,
   previewPort: number,
+  previewTlsPort: number,
 ): void {
   res.setHeader('Referrer-Policy', 'no-referrer');
   res.setHeader('X-Content-Type-Options', 'nosniff');
   // Dev-server previews are framed from their own origin (same host,
-  // previewPort) so the sandboxed iframe can use allow-same-origin without
-  // sharing the SPA's origin. Derive that origin from the request host.
+  // preview port — direct or tailnet TLS mapping) so the sandboxed iframe
+  // can use allow-same-origin without sharing the SPA's origin. Derive
+  // that origin from the request host.
   const hostname = (req.headers.host ?? '').split(':')[0];
   const previewSrc = hostname
-    ? ` http://${hostname}:${previewPort} https://${hostname}:${previewPort}`
+    ? ` http://${hostname}:${previewPort} https://${hostname}:${previewPort}` +
+      ` https://${hostname}:${previewTlsPort}`
     : '';
   res.setHeader(
     'Content-Security-Policy',
@@ -65,7 +69,9 @@ export function createGatewayHttpServer(options: GatewayHttpServerOptions): http
     const pathname = rawUrl.split('?')[0];
     const isProxyRequest = pathname.startsWith(DEV_PROXY_PREFIX);
 
-    if (!isProxyRequest) setGatewaySecurityHeaders(req, res, options.previewPort);
+    if (!isProxyRequest) {
+      setGatewaySecurityHeaders(req, res, options.previewPort, options.previewTlsPort);
+    }
 
     if (isProxyRequest) {
       void serveDevProxy(req, res, options.getProxyDeps());

--- a/apps/desktop/electron/features/gateway/server/request-handler.ts
+++ b/apps/desktop/electron/features/gateway/server/request-handler.ts
@@ -98,6 +98,7 @@ export async function routeAgentRequest(
   auth?: GatewayAuth,
   isMasterAuth?: boolean,
   devProxyTickets?: DevProxyTicketManager | null,
+  previewPort?: number | null,
 ): Promise<void> {
   const respond = makeResponder(ws, request.requestId);
   // Try extended handlers first (file ops, artifacts, web tokens, sessions)
@@ -111,6 +112,7 @@ export async function routeAgentRequest(
       auth,
       isMasterAuth ?? false,
       devProxyTickets ?? null,
+      previewPort ?? null,
     );
     if (handled) return;
   }

--- a/apps/desktop/electron/features/gateway/server/request-handler.ts
+++ b/apps/desktop/electron/features/gateway/server/request-handler.ts
@@ -98,7 +98,7 @@ export async function routeAgentRequest(
   auth?: GatewayAuth,
   isMasterAuth?: boolean,
   devProxyTickets?: DevProxyTicketManager | null,
-  previewPort?: number | null,
+  previewPorts?: { previewPort: number; previewTlsPort: number } | null,
 ): Promise<void> {
   const respond = makeResponder(ws, request.requestId);
   // Try extended handlers first (file ops, artifacts, web tokens, sessions)
@@ -112,7 +112,7 @@ export async function routeAgentRequest(
       auth,
       isMasterAuth ?? false,
       devProxyTickets ?? null,
-      previewPort ?? null,
+      previewPorts ?? null,
     );
     if (handled) return;
   }

--- a/apps/desktop/electron/features/gateway/server/types.ts
+++ b/apps/desktop/electron/features/gateway/server/types.ts
@@ -14,6 +14,12 @@ export interface GatewayConfig {
    * must not be able to reach the SPA's storage or gateway session.
    */
   previewPort: number;
+  /**
+   * HTTPS port the preview listener is mapped to when the gateway is
+   * exposed over the tailnet (`tailscale serve --https=<this> <previewPort>`).
+   * TLS-connected clients build preview URLs against this port.
+   */
+  previewTlsPort: number;
   /** Bind host. Default: '127.0.0.1' (localhost only). */
   host: string;
   /** Path to the auth token file. */

--- a/apps/desktop/electron/features/gateway/server/types.ts
+++ b/apps/desktop/electron/features/gateway/server/types.ts
@@ -7,6 +7,13 @@
 export interface GatewayConfig {
   /** Port for the WebSocket server. Default: 18800. */
   port: number;
+  /**
+   * Port for the dev-server preview listener. Previews are served from
+   * their own origin so the sandboxed preview iframe (allow-same-origin)
+   * stays isolated from the web-remote SPA's origin — previewed app code
+   * must not be able to reach the SPA's storage or gateway session.
+   */
+  previewPort: number;
   /** Bind host. Default: '127.0.0.1' (localhost only). */
   host: string;
   /** Path to the auth token file. */

--- a/apps/desktop/electron/ipc/apps/browser.ts
+++ b/apps/desktop/electron/ipc/apps/browser.ts
@@ -156,6 +156,20 @@ export function registerBrowserHandlers(): void {
   );
 
   ipcMain.handle(
+    IpcChannels.browser.grabElement,
+    (_e, tabId: string, workspaceId: string) => {
+      return browserViewManager.grabElement(tabId, workspaceId);
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.browser.cancelGrab,
+    (_e, tabId: string, workspaceId: string) => {
+      browserViewManager.cancelGrab(tabId, workspaceId);
+    },
+  );
+
+  ipcMain.handle(
     IpcChannels.browser.showTabContextMenu,
     (event, tabId: string, workspaceId: string) => {
       if (browserViewManager.workspaceForTab(tabId) !== workspaceId) return null;

--- a/apps/desktop/electron/ipc/gateway/gateway.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway.ts
@@ -121,7 +121,7 @@ export function registerGatewayHandlers(): void {
       const status = gatewayServer.getStatus();
       const tsStatus = await tailscale.getStatus();
       const tailnetUrl = tsStatus.running
-        ? await tailscale.serve(status.port)
+        ? await tailscale.serve(status.port, gatewayServer.getPreviewPorts())
         : null;
       const baseUrl = tailnetUrl ?? `http://127.0.0.1:${status.port}`;
 

--- a/apps/desktop/electron/ipc/gateway/gateway.ts
+++ b/apps/desktop/electron/ipc/gateway/gateway.ts
@@ -180,7 +180,10 @@ async function startGateway(): Promise<void> {
 
   // Tailscale: if enabled, expose on tailnet
   if (gatewayConfig.tailscaleEnabled) {
-    const url = await tailscale.serve(gatewayServer.getStatus().port);
+    const url = await tailscale.serve(
+      gatewayServer.getStatus().port,
+      gatewayServer.getPreviewPorts(),
+    );
     if (url) {
       console.log(`[gateway] Available on tailnet: ${url}`);
     }

--- a/apps/desktop/electron/preload/apps/browser.ts
+++ b/apps/desktop/electron/preload/apps/browser.ts
@@ -4,6 +4,7 @@ import { IpcChannels } from '@/types/ipc-channels';
 import type {
   BrowserBookmarkContextAction,
   BrowserEvent,
+  BrowserGrabResult,
   BrowserTabContextAction,
   BrowserViewBounds,
 } from '@/types/browser';
@@ -46,6 +47,10 @@ export const browserBridge = {
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<string | null> =>
     ipcRenderer.invoke(IpcChannels.browser.capturePage, tabId, workspaceId, rect),
+  grabElement: (tabId: string, workspaceId: string): Promise<BrowserGrabResult> =>
+    ipcRenderer.invoke(IpcChannels.browser.grabElement, tabId, workspaceId),
+  cancelGrab: (tabId: string, workspaceId: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.browser.cancelGrab, tabId, workspaceId),
   showTabContextMenu: (tabId: string, workspaceId: string): Promise<BrowserTabContextAction | null> =>
     ipcRenderer.invoke(IpcChannels.browser.showTabContextMenu, tabId, workspaceId),
   showBookmarkContextMenu: (): Promise<BrowserBookmarkContextAction | null> =>

--- a/apps/desktop/electron/shared/infra/singletons.ts
+++ b/apps/desktop/electron/shared/infra/singletons.ts
@@ -37,11 +37,13 @@ export const artifactRegistry = new ArtifactRegistry();
 const GATEWAY_PORT = 18800;
 const WEB_CHAT_PORT = 18801;
 const GATEWAY_PREVIEW_PORT = 18802;
+const GATEWAY_PREVIEW_TLS_PORT = 8443;
 const GATEWAY_TOKEN_PATH = path.join(SERO_AGENT_DIR, 'gateway-token');
 
 export const gatewayServer = new GatewayServer({
   port: GATEWAY_PORT,
   previewPort: GATEWAY_PREVIEW_PORT,
+  previewTlsPort: GATEWAY_PREVIEW_TLS_PORT,
   host: '127.0.0.1',
   tokenPath: GATEWAY_TOKEN_PATH,
   configDir: SERO_AGENT_DIR,

--- a/apps/desktop/electron/shared/infra/singletons.ts
+++ b/apps/desktop/electron/shared/infra/singletons.ts
@@ -36,10 +36,12 @@ export const artifactRegistry = new ArtifactRegistry();
 
 const GATEWAY_PORT = 18800;
 const WEB_CHAT_PORT = 18801;
+const GATEWAY_PREVIEW_PORT = 18802;
 const GATEWAY_TOKEN_PATH = path.join(SERO_AGENT_DIR, 'gateway-token');
 
 export const gatewayServer = new GatewayServer({
   port: GATEWAY_PORT,
+  previewPort: GATEWAY_PREVIEW_PORT,
   host: '127.0.0.1',
   tokenPath: GATEWAY_TOKEN_PATH,
   configDir: SERO_AGENT_DIR,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -110,6 +110,7 @@
     "motion": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
+    "react-grab": "^0.1.48",
     "react-grid-layout": "^2.2.3",
     "react-resizable-panels": "^4.7.2",
     "streamdown": "catalog:",

--- a/apps/desktop/scripts/build-electron.mjs
+++ b/apps/desktop/scripts/build-electron.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from 'child_process';
 import { build } from 'esbuild';
 import fs from 'fs';
+import { createRequire } from 'module';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import builtinPackageDetection from '../electron/platform/protocols/builtin-package-detection.js';
@@ -211,6 +212,15 @@ if (fs.existsSync(webDistSrc)) {
 // Copy built-in packages/templates into dist/electron/builtin/ so packaged
 // builds can discover them without depending on the monorepo layout.
 stageBuiltinResources();
+
+// Stage the react-grab in-page bundle next to main.mjs so the browser
+// feature can inject it into WebContentsView pages at runtime
+// (electron/features/browser/element-grab.ts).
+const require = createRequire(import.meta.url);
+fs.copyFileSync(
+  path.join(path.dirname(require.resolve('react-grab/package.json')), 'dist/index.global.js'),
+  path.join(electronOutDir, 'react-grab.global.js'),
+);
 
 // Preload — must be CJS for Electron's preload context
 await build({

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserPanel.tsx
@@ -72,6 +72,8 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
   const reload = useBrowserStore((s) => s.reload);
   const stop = useBrowserStore((s) => s.stop);
   const sharePageWithChat = useBrowserStore((s) => s.sharePageWithChat);
+  const grabElementToChat = useBrowserStore((s) => s.grabElementToChat);
+  const grabbingTabId = useBrowserStore((s) => s.grabbingTabId);
   const lightboxOpen = useLightbox((s) => s.open);
 
   const viewportRef = useRef<HTMLDivElement | null>(null);
@@ -281,6 +283,8 @@ export function BrowserPanel({ workspaceId }: BrowserPanelProps) {
         onStop={() => stop(activeTab.id)}
         onSharePage={() => { void sharePageWithChat(activeTab.id); }}
         onCaptureArea={() => { void startCapture(); }}
+        grabActive={grabbingTabId === activeTab.id}
+        onGrabElement={() => { void grabElementToChat(activeTab.id); }}
       />
       <BookmarksBar onNavigate={(url) => navigate(activeTab.id, url)} workspaceId={workspaceId} />
       {/*

--- a/apps/desktop/src/components/apps/explorer/browser/BrowserToolbar.tsx
+++ b/apps/desktop/src/components/apps/explorer/browser/BrowserToolbar.tsx
@@ -1,11 +1,21 @@
 import { useEffect, useState, type FormEvent, type KeyboardEvent } from 'react';
-import { ArrowLeft, ArrowRight, Camera, MessageSquareQuote, RotateCw, X } from 'lucide-react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Camera,
+  MessageSquareQuote,
+  RotateCw,
+  SquareDashedMousePointer,
+  X,
+} from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { BrowserTab } from '@/types/browser';
 
 interface BrowserToolbarProps {
   tab: BrowserTab;
+  /** True while a react-grab element pick is running in this tab. */
+  grabActive: boolean;
   onNavigate: (urlOrQuery: string) => void;
   onBack: () => void;
   onForward: () => void;
@@ -13,10 +23,11 @@ interface BrowserToolbarProps {
   onStop: () => void;
   onSharePage: () => void;
   onCaptureArea: () => void;
+  onGrabElement: () => void;
 }
 
 export function BrowserToolbar({
-  tab, onNavigate, onBack, onForward, onReload, onStop, onSharePage, onCaptureArea,
+  tab, grabActive, onNavigate, onBack, onForward, onReload, onStop, onSharePage, onCaptureArea, onGrabElement,
 }: BrowserToolbarProps) {
   // Mirror the tab URL into the input but let the user edit freely. When the
   // tab navigates elsewhere (e.g. clicking a link), the field refreshes to
@@ -100,6 +111,20 @@ export function BrowserToolbar({
           'focus:border-[var(--border-default)] focus:outline-none',
         )}
       />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onGrabElement}
+        title={grabActive ? 'Cancel element pick' : 'Pick element for chat'}
+        className={cn(
+          grabActive
+            ? 'text-[var(--accent-primary)] hover:text-[var(--accent-primary)]'
+            : 'text-[var(--text-muted)] hover:text-[var(--text-secondary)]',
+        )}
+      >
+        <SquareDashedMousePointer className="size-[14px]" />
+      </Button>
       <Button
         type="button"
         variant="ghost"

--- a/apps/desktop/src/stores/browser-events.ts
+++ b/apps/desktop/src/stores/browser-events.ts
@@ -1,0 +1,116 @@
+/**
+ * Main-process → renderer browser event handling. Split from
+ * `stores/browser.ts` to keep the store under the 500-LOC rule.
+ */
+
+import type { StoreApi } from 'zustand';
+import { persistLayout } from '@/lib/persist-layout';
+import {
+  formatSelectionForChat,
+  formatSelectionForMemory,
+  prefillChatComposer,
+  toPersistedTabs,
+} from './browser-helpers';
+import type { BrowserEvent, BrowserTab } from '@/types/browser';
+import type { BrowserState } from './browser';
+
+export function applyBrowserEvent(event: BrowserEvent, store: StoreApi<BrowserState>): void {
+  const { setState: set, getState: get } = store;
+
+  set((s) => {
+    const tabs = s.tabs.map((t) => {
+      if (t.id !== event.tabId) return t;
+      switch (event.kind) {
+        case 'did-navigate':
+          return {
+            ...t,
+            url: event.url,
+            canGoBack: event.canGoBack,
+            canGoForward: event.canGoForward,
+          };
+        case 'did-start-loading':
+          return { ...t, isLoading: true };
+        case 'did-stop-loading':
+          return { ...t, isLoading: false };
+        case 'title-updated':
+          return { ...t, title: event.title || t.title };
+        case 'favicon-updated':
+          return { ...t, favicon: event.favicon };
+        case 'did-fail-load':
+          return { ...t, isLoading: false };
+        default:
+          return t;
+      }
+    });
+    return { tabs };
+  });
+
+  if (event.kind === 'new-tab-request') {
+    get().createTab(event.workspaceId, event.url);
+    return;
+  }
+
+  if (event.kind === 'selection-to-chat') {
+    prefillChatComposer(formatSelectionForChat(event.selection, event.pageUrl, event.pageTitle));
+    return;
+  }
+
+  if (event.kind === 'selection-to-memory') {
+    prefillChatComposer(formatSelectionForMemory(event.selection, event.pageUrl, event.pageTitle));
+    return;
+  }
+
+  if (event.kind === 'host-tab-opened') {
+    // Mirror the host-created tab into the renderer store so it shows up
+    // in the tab strip. The view already exists in main; don't re-open it.
+    if (get().tabs.some((t) => t.id === event.tabId)) return;
+    const tab: BrowserTab = {
+      id: event.tabId,
+      workspaceId: event.workspaceId,
+      url: event.url,
+      title: event.url,
+      isLoading: true,
+      canGoBack: false,
+      canGoForward: false,
+    };
+    set((s) => ({
+      tabs: [...s.tabs, tab],
+      activeTabIds: { ...s.activeTabIds, [event.workspaceId]: event.tabId },
+    }));
+    persistLayout({
+      browserTabs: toPersistedTabs(get().tabs),
+      activeBrowserTabIds: get().activeTabIds,
+    });
+    return;
+  }
+
+  if (event.kind === 'host-tab-activated') {
+    if (!get().tabs.some((t) => t.id === event.tabId && t.workspaceId === event.workspaceId)) return;
+    set((s) => ({
+      activeTabIds: { ...s.activeTabIds, [event.workspaceId]: event.tabId },
+    }));
+    persistLayout({ activeBrowserTabIds: get().activeTabIds });
+    return;
+  }
+
+  if (event.kind === 'host-tab-closed') {
+    if (!get().tabs.some((t) => t.id === event.tabId)) return;
+    const nextTabs = get().tabs.filter((t) => t.id !== event.tabId);
+    const ws = event.workspaceId;
+    const activeIds = { ...get().activeTabIds };
+    if (activeIds[ws] === event.tabId) {
+      const replacement = nextTabs.find((t) => t.workspaceId === ws) ?? null;
+      activeIds[ws] = replacement ? replacement.id : null;
+    }
+    set({ tabs: nextTabs, activeTabIds: activeIds });
+    persistLayout({
+      browserTabs: toPersistedTabs(nextTabs),
+      activeBrowserTabIds: activeIds,
+    });
+    return;
+  }
+
+  if (event.kind === 'did-navigate' || event.kind === 'title-updated') {
+    persistLayout({ browserTabs: toPersistedTabs(get().tabs) });
+  }
+}

--- a/apps/desktop/src/stores/browser-helpers.ts
+++ b/apps/desktop/src/stores/browser-helpers.ts
@@ -6,6 +6,12 @@
 import { useAgentStore } from '@/stores/agent';
 import { useAppStore } from '@/stores/app';
 import { useSessionStore } from '@/stores/sessions';
+import type { BrowserTab } from '@/types/browser';
+import type { PersistedBrowserTab } from '@/types/layout';
+
+export function toPersistedTabs(tabs: BrowserTab[]): PersistedBrowserTab[] {
+  return tabs.map((t) => ({ id: t.id, workspaceId: t.workspaceId, url: t.url, title: t.title }));
+}
 
 /**
  * Format a page selection as a markdown blockquote with an attribution

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -11,11 +11,8 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
 import { persistLayout } from '@/lib/persist-layout';
-import {
-  formatSelectionForChat,
-  formatSelectionForMemory,
-  prefillChatComposer,
-} from './browser-helpers';
+import { applyBrowserEvent } from './browser-events';
+import { prefillChatComposer, toPersistedTabs } from './browser-helpers';
 import {
   BROWSER_HOME_URL,
   resolveAddressBarInput,
@@ -36,13 +33,15 @@ interface ClosedTab {
 
 const MAX_RECENTLY_CLOSED = 10;
 
-interface BrowserState {
+export interface BrowserState {
   tabs: BrowserTab[];
   /** Active tab id per workspace. */
   activeTabIds: Record<string, string | null>;
   bookmarks: BrowserBookmark[];
   /** Most-recently-closed first. In-memory only (not persisted). */
   recentlyClosed: ClosedTab[];
+  /** Tab with a react-grab element pick in progress, or null. */
+  grabbingTabId: string | null;
 
   /** Create a new tab under the given workspace. Returns the new id. */
   createTab: (workspaceId: string, urlOrQuery?: string) => string;
@@ -63,6 +62,11 @@ interface BrowserState {
   stop: (id: string) => void;
   /** Extract the tab's page (title + plain text) and prefill the chat composer. */
   sharePageWithChat: (id: string) => Promise<void>;
+  /**
+   * Toggle a react-grab element pick in the tab. On grab, the element's
+   * source context is prefilled into the chat composer.
+   */
+  grabElementToChat: (id: string) => Promise<void>;
 
   addBookmark: (input: { title: string; url: string; favicon?: string }) => void;
   removeBookmark: (id: string) => void;
@@ -83,10 +87,6 @@ function generateId(prefix: string): string {
   return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function toPersistedTabs(tabs: BrowserTab[]): PersistedBrowserTab[] {
-  return tabs.map((t) => ({ id: t.id, workspaceId: t.workspaceId, url: t.url, title: t.title }));
-}
-
 function newTab(workspaceId: string, url: string): BrowserTab {
   return {
     id: generateId('tab'),
@@ -104,6 +104,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
   activeTabIds: {},
   bookmarks: [],
   recentlyClosed: [],
+  grabbingTabId: null,
 
   createTab: (workspaceId, urlOrQuery) => {
     const url = urlOrQuery ? resolveAddressBarInput(urlOrQuery) : BROWSER_HOME_URL;
@@ -295,6 +296,25 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     prefillChatComposer(`${heading}${body}\n\n${attribution}\n\n`);
   },
 
+  grabElementToChat: async (id) => {
+    const tab = get().tabs.find((t) => t.id === id);
+    if (!tab) return;
+    if (get().grabbingTabId === id) {
+      void window.sero.browser.cancelGrab(id, tab.workspaceId);
+      return;
+    }
+    set({ grabbingTabId: id });
+    const result = await window.sero.browser.grabElement(id, tab.workspaceId);
+    set((s) => (s.grabbingTabId === id ? { grabbingTabId: null } : {}));
+    if (result.status === 'unavailable') {
+      console.warn('[browser] Element pick unavailable in this tab.');
+      return;
+    }
+    if (result.status !== 'grabbed') return;
+    const url = get().tabs.find((t) => t.id === id)?.url ?? tab.url;
+    prefillChatComposer(`${result.content}\n\n— ${url}\n\n`);
+  },
+
   addBookmark: (input) => {
     const { bookmarks } = get();
     const existing = bookmarks.find((b) => b.url === input.url);
@@ -386,104 +406,7 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
     void window.sero.browser.setActive(activeTabIds[workspaceId] ?? null, workspaceId);
   },
 
-  applyEvent: (event) => {
-    set((s) => {
-      const tabs = s.tabs.map((t) => {
-        if (t.id !== event.tabId) return t;
-        switch (event.kind) {
-          case 'did-navigate':
-            return {
-              ...t,
-              url: event.url,
-              canGoBack: event.canGoBack,
-              canGoForward: event.canGoForward,
-            };
-          case 'did-start-loading':
-            return { ...t, isLoading: true };
-          case 'did-stop-loading':
-            return { ...t, isLoading: false };
-          case 'title-updated':
-            return { ...t, title: event.title || t.title };
-          case 'favicon-updated':
-            return { ...t, favicon: event.favicon };
-          case 'did-fail-load':
-            return { ...t, isLoading: false };
-          default:
-            return t;
-        }
-      });
-      return { tabs };
-    });
-
-    if (event.kind === 'new-tab-request') {
-      get().createTab(event.workspaceId, event.url);
-      return;
-    }
-
-    if (event.kind === 'selection-to-chat') {
-      prefillChatComposer(formatSelectionForChat(event.selection, event.pageUrl, event.pageTitle));
-      return;
-    }
-
-    if (event.kind === 'selection-to-memory') {
-      prefillChatComposer(formatSelectionForMemory(event.selection, event.pageUrl, event.pageTitle));
-      return;
-    }
-
-    if (event.kind === 'host-tab-opened') {
-      // Mirror the host-created tab into the renderer store so it shows up
-      // in the tab strip. The view already exists in main; don't re-open it.
-      if (get().tabs.some((t) => t.id === event.tabId)) return;
-      const tab: BrowserTab = {
-        id: event.tabId,
-        workspaceId: event.workspaceId,
-        url: event.url,
-        title: event.url,
-        isLoading: true,
-        canGoBack: false,
-        canGoForward: false,
-      };
-      set((s) => ({
-        tabs: [...s.tabs, tab],
-        activeTabIds: { ...s.activeTabIds, [event.workspaceId]: event.tabId },
-      }));
-      persistLayout({
-        browserTabs: toPersistedTabs(get().tabs),
-        activeBrowserTabIds: get().activeTabIds,
-      });
-      return;
-    }
-
-    if (event.kind === 'host-tab-activated') {
-      if (!get().tabs.some((t) => t.id === event.tabId && t.workspaceId === event.workspaceId)) return;
-      set((s) => ({
-        activeTabIds: { ...s.activeTabIds, [event.workspaceId]: event.tabId },
-      }));
-      persistLayout({ activeBrowserTabIds: get().activeTabIds });
-      return;
-    }
-
-    if (event.kind === 'host-tab-closed') {
-      if (!get().tabs.some((t) => t.id === event.tabId)) return;
-      const nextTabs = get().tabs.filter((t) => t.id !== event.tabId);
-      const ws = event.workspaceId;
-      const activeIds = { ...get().activeTabIds };
-      if (activeIds[ws] === event.tabId) {
-        const replacement = nextTabs.find((t) => t.workspaceId === ws) ?? null;
-        activeIds[ws] = replacement ? replacement.id : null;
-      }
-      set({ tabs: nextTabs, activeTabIds: activeIds });
-      persistLayout({
-        browserTabs: toPersistedTabs(nextTabs),
-        activeBrowserTabIds: activeIds,
-      });
-      return;
-    }
-
-    if (event.kind === 'did-navigate' || event.kind === 'title-updated') {
-      persistLayout({ browserTabs: toPersistedTabs(get().tabs) });
-    }
-  },
+  applyEvent: (event) => applyBrowserEvent(event, useBrowserStore),
 }));
 
 /* ── Selectors ──────────────────────────────────────────────── */

--- a/apps/desktop/src/stores/browser.ts
+++ b/apps/desktop/src/stores/browser.ts
@@ -299,9 +299,16 @@ export const useBrowserStore = create<BrowserState>((set, get) => ({
   grabElementToChat: async (id) => {
     const tab = get().tabs.find((t) => t.id === id);
     if (!tab) return;
-    if (get().grabbingTabId === id) {
+    const grabbingTabId = get().grabbingTabId;
+    if (grabbingTabId === id) {
       void window.sero.browser.cancelGrab(id, tab.workspaceId);
       return;
+    }
+    // Only one pick at a time: a pick left running in another tab would
+    // otherwise stay active with no visible control to cancel it.
+    if (grabbingTabId) {
+      const previous = get().tabs.find((t) => t.id === grabbingTabId);
+      if (previous) void window.sero.browser.cancelGrab(previous.id, previous.workspaceId);
     }
     set({ grabbingTabId: id });
     const result = await window.sero.browser.grabElement(id, tab.workspaceId);

--- a/apps/desktop/src/types/browser.ts
+++ b/apps/desktop/src/types/browser.ts
@@ -47,6 +47,18 @@ export type BrowserBookmarkContextAction =
   | 'delete';
 
 /**
+ * Outcome of a react-grab element pick. `content` is the agent-ready
+ * context react-grab produces for the selection (element markup plus the
+ * component stack with source locations when the page is a React dev
+ * build). `unavailable` means react-grab could not be injected or was
+ * already picking.
+ */
+export type BrowserGrabResult =
+  | { status: 'grabbed'; content: string }
+  | { status: 'cancelled' }
+  | { status: 'unavailable' };
+
+/**
  * Events emitted by the main-process view manager to the renderer so the
  * store can keep tab metadata in sync with what the WebContentsView reports.
  */

--- a/apps/desktop/src/types/electron-browser.d.ts
+++ b/apps/desktop/src/types/electron-browser.d.ts
@@ -1,6 +1,7 @@
 import type {
   BrowserBookmarkContextAction,
   BrowserEvent,
+  BrowserGrabResult,
   BrowserTabContextAction,
   BrowserViewBounds,
 } from './browser';
@@ -25,6 +26,8 @@ export interface SeroBrowserAPI {
     workspaceId: string,
     rect?: { x: number; y: number; width: number; height: number },
   ): Promise<string | null>;
+  grabElement(tabId: string, workspaceId: string): Promise<BrowserGrabResult>;
+  cancelGrab(tabId: string, workspaceId: string): Promise<void>;
   showTabContextMenu(tabId: string, workspaceId: string): Promise<BrowserTabContextAction | null>;
   showBookmarkContextMenu(): Promise<BrowserBookmarkContextAction | null>;
   onEvent(callback: (event: BrowserEvent) => void): () => void;

--- a/apps/desktop/src/types/ipc-channels-browser.ts
+++ b/apps/desktop/src/types/ipc-channels-browser.ts
@@ -21,6 +21,10 @@ export const browserIpcChannels = {
   extractPage: 'sero:browser:extract-page',
   /** Capture the tab as a PNG (optionally cropped). Returns base64 PNG. */
   capturePage: 'sero:browser:capture-page',
+  /** Start a react-grab element pick; resolves with the grabbed context. */
+  grabElement: 'sero:browser:grab-element',
+  /** Cancel an in-flight element pick. */
+  cancelGrab: 'sero:browser:cancel-grab',
   /** Native tab-strip context menu. Returns selected action or null. */
   showTabContextMenu: 'sero:browser:show-tab-context-menu',
   /** Native bookmarks-bar context menu. Returns selected action or null. */

--- a/apps/docs-site/docs/guide/explorer-workspace.md
+++ b/apps/docs-site/docs/guide/explorer-workspace.md
@@ -119,6 +119,9 @@ Current safe expectations include:
 - navigation and history are managed inside the Explorer browser surface
 - bookmarks can be used from the browser UI
 - page sharing and screenshot capture can feed chat attachments where supported
+- the toolbar's element picker (powered by React Grab) copies a hovered
+  element into the chat composer; on React dev servers this includes the
+  component stack with source file locations
 
 This browser surface is part of Sero's local development workflow. It is the visible in-app browser, separate from Sero's UI-backed app screenshot/recording bridge. It should not be described as a general-purpose hardened browser or a guarantee that every web app behaves like it would in your default browser. See [Browser and Capture](/guide/browser-and-capture) for screenshots, interactions, and recording.
 

--- a/apps/docs-site/docs/guide/remote-control.md
+++ b/apps/docs-site/docs/guide/remote-control.md
@@ -86,6 +86,12 @@ A basic/legacy local web UI may also be available on:
 127.0.0.1:18801
 ```
 
+Dev-server previews are served from a dedicated listener:
+
+```text
+127.0.0.1:18802
+```
+
 For remote web access, Tailscale is the recommended transport. Sero can expose
 the gateway to your private tailnet through `tailscale serve`; a paired browser
 then uses the tailnet URL and a temporary web token/login flow.
@@ -99,7 +105,9 @@ proxy. This makes a dev server running in the local desktop session available to
 a trusted browser on your tailnet without exposing the dev server itself as a
 separate public or tailnet service.
 
-The proxy is path-based on the gateway origin:
+The proxy is path-based on the gateway's preview listener (port 18802), which
+gives previews their own browser origin so the embedded preview stays isolated
+from the Sero Remote app itself:
 
 ```text
 /p/<workspaceId>/<port>/...
@@ -123,6 +131,10 @@ Practical behavior:
   possible so absolute paths continue to work under `/p/<workspaceId>/<port>/`
 - the upstream dev server continues to run on your machine/workspace container; the
   remote browser talks only to the Sero gateway URL served over Tailscale
+- the embedded preview panel is resizable and includes an element picker
+  (powered by React Grab): pick an element in the previewed page and its
+  source context — on React dev servers, the component stack with file
+  locations — lands in the chat composer
 
 If a preview does not appear, confirm that the desktop app shows the dev server
 as registered/running for the target workspace and that the paired web client has

--- a/apps/docs-site/docs/guide/remote-control.md
+++ b/apps/docs-site/docs/guide/remote-control.md
@@ -92,6 +92,15 @@ Dev-server previews are served from a dedicated listener:
 127.0.0.1:18802
 ```
 
+When Sero exposes the gateway over the tailnet, it also maps this preview
+listener to HTTPS port 8443 on the tailnet hostname. If you configure
+`tailscale serve` manually instead, add that mapping yourself:
+
+```bash
+tailscale serve --bg 18800
+tailscale serve --bg --https=8443 18802
+```
+
 For remote web access, Tailscale is the recommended transport. Sero can expose
 the gateway to your private tailnet through `tailscale serve`; a paired browser
 then uses the tailnet URL and a temporary web token/login flow.

--- a/apps/web-remote/src/components/ChatPanel.tsx
+++ b/apps/web-remote/src/components/ChatPanel.tsx
@@ -5,7 +5,7 @@
  * for automatic stick-to-bottom scrolling (same component the desktop app uses).
  */
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useChatStore } from '@/stores/chat';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useConnectionStore } from '@/stores/connection';
@@ -63,6 +63,15 @@ export function ChatPanel() {
   const isConnected = connectionState === 'connected';
   const hasContent = input.trim().length > 0 || pendingImages.length > 0;
   const canSend = isConnected && !!activeWorkspaceId && !isStreaming && hasContent;
+
+  // Consume prefill pushed by other panels (e.g. a preview element grab).
+  const composerPrefill = useChatStore((s) => s.composerPrefill);
+  useEffect(() => {
+    if (!composerPrefill) return;
+    setInput((prev) => (prev ? `${prev}\n${composerPrefill}` : composerPrefill));
+    useChatStore.getState().clearComposerPrefill();
+    textareaRef.current?.focus();
+  }, [composerPrefill]);
 
   const addImages = useCallback(async (files: File[]) => {
     const imageFiles = files.filter((f) => f.type.startsWith('image/'));

--- a/apps/web-remote/src/components/Layout.tsx
+++ b/apps/web-remote/src/components/Layout.tsx
@@ -20,6 +20,11 @@ import { useArtifactStore } from '@/stores/artifacts';
 import { useDevServerStore } from '@/stores/dev-servers';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@sero-ai/ui/components/ui/resizable';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { useIsMobile } from '@sero-ai/ui/hooks/use-mobile';
 import {
@@ -134,19 +139,26 @@ export function Layout() {
           </div>
         )}
 
-        {/* Chat panel, fills remaining space */}
-        <div className="flex-1 min-w-0">
-          <ChatPanel />
-        </div>
-
-        {/* Desktop right panel, inline panel */}
-        {!isMobile && rightPanel && (
-          <div
-            className={`${rightPanel === 'preview' ? 'w-[28rem]' : 'w-80'} border-l border-border bg-card shrink-0 overflow-hidden`}
-          >
-            {rightPanel === 'files' && <FilesPanel />}
-            {rightPanel === 'artifacts' && <ArtifactPanelConnected />}
-            {rightPanel === 'preview' && <PreviewPanel />}
+        {/* Chat + right panel share the row; drag the divider to resize. */}
+        {!isMobile && rightPanel ? (
+          <ResizablePanelGroup orientation="horizontal" className="flex-1 min-w-0">
+            <ResizablePanel defaultSize={rightPanel === 'preview' ? 55 : 70} minSize={25}>
+              <ChatPanel />
+            </ResizablePanel>
+            <ResizableHandle />
+            <ResizablePanel
+              defaultSize={rightPanel === 'preview' ? 45 : 30}
+              minSize={20}
+              className="bg-card overflow-hidden"
+            >
+              {rightPanel === 'files' && <FilesPanel />}
+              {rightPanel === 'artifacts' && <ArtifactPanelConnected />}
+              {rightPanel === 'preview' && <PreviewPanel />}
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        ) : (
+          <div className="flex-1 min-w-0">
+            <ChatPanel />
           </div>
         )}
       </div>

--- a/apps/web-remote/src/components/Layout.tsx
+++ b/apps/web-remote/src/components/Layout.tsx
@@ -140,33 +140,30 @@ export function Layout() {
         )}
 
         {/* Chat + right panel share the row; drag the divider to resize.
-            The group (and the chat's position in it) stays mounted across
-            panel toggles so composer drafts survive opening a panel. */}
-        {isMobile ? (
-          <div className="flex-1 min-w-0">
+            The group renders on mobile too (right panels are Sheets there)
+            so ChatPanel keeps one position in the tree across panel
+            toggles AND the responsive breakpoint — composer drafts must
+            survive both. Numeric panel sizes are pixels in
+            react-resizable-panels v4, so sizes are percentage strings. */}
+        <ResizablePanelGroup orientation="horizontal" className="flex-1 min-w-0">
+          <ResizablePanel minSize="25%">
             <ChatPanel />
-          </div>
-        ) : (
-          <ResizablePanelGroup orientation="horizontal" className="flex-1 min-w-0">
-            <ResizablePanel minSize={25}>
-              <ChatPanel />
-            </ResizablePanel>
-            {rightPanel && (
-              <>
-                <ResizableHandle />
-                <ResizablePanel
-                  defaultSize={rightPanel === 'preview' ? 45 : 30}
-                  minSize={20}
-                  className="bg-card overflow-hidden"
-                >
-                  {rightPanel === 'files' && <FilesPanel />}
-                  {rightPanel === 'artifacts' && <ArtifactPanelConnected />}
-                  {rightPanel === 'preview' && <PreviewPanel />}
-                </ResizablePanel>
-              </>
-            )}
-          </ResizablePanelGroup>
-        )}
+          </ResizablePanel>
+          {!isMobile && rightPanel && (
+            <>
+              <ResizableHandle />
+              <ResizablePanel
+                defaultSize={rightPanel === 'preview' ? '45%' : '30%'}
+                minSize="20%"
+                className="bg-card overflow-hidden"
+              >
+                {rightPanel === 'files' && <FilesPanel />}
+                {rightPanel === 'artifacts' && <ArtifactPanelConnected />}
+                {rightPanel === 'preview' && <PreviewPanel />}
+              </ResizablePanel>
+            </>
+          )}
+        </ResizablePanelGroup>
       </div>
 
       {/* Status bar, hidden on mobile to save space */}

--- a/apps/web-remote/src/components/Layout.tsx
+++ b/apps/web-remote/src/components/Layout.tsx
@@ -139,27 +139,33 @@ export function Layout() {
           </div>
         )}
 
-        {/* Chat + right panel share the row; drag the divider to resize. */}
-        {!isMobile && rightPanel ? (
-          <ResizablePanelGroup orientation="horizontal" className="flex-1 min-w-0">
-            <ResizablePanel defaultSize={rightPanel === 'preview' ? 55 : 70} minSize={25}>
-              <ChatPanel />
-            </ResizablePanel>
-            <ResizableHandle />
-            <ResizablePanel
-              defaultSize={rightPanel === 'preview' ? 45 : 30}
-              minSize={20}
-              className="bg-card overflow-hidden"
-            >
-              {rightPanel === 'files' && <FilesPanel />}
-              {rightPanel === 'artifacts' && <ArtifactPanelConnected />}
-              {rightPanel === 'preview' && <PreviewPanel />}
-            </ResizablePanel>
-          </ResizablePanelGroup>
-        ) : (
+        {/* Chat + right panel share the row; drag the divider to resize.
+            The group (and the chat's position in it) stays mounted across
+            panel toggles so composer drafts survive opening a panel. */}
+        {isMobile ? (
           <div className="flex-1 min-w-0">
             <ChatPanel />
           </div>
+        ) : (
+          <ResizablePanelGroup orientation="horizontal" className="flex-1 min-w-0">
+            <ResizablePanel minSize={25}>
+              <ChatPanel />
+            </ResizablePanel>
+            {rightPanel && (
+              <>
+                <ResizableHandle />
+                <ResizablePanel
+                  defaultSize={rightPanel === 'preview' ? 45 : 30}
+                  minSize={20}
+                  className="bg-card overflow-hidden"
+                >
+                  {rightPanel === 'files' && <FilesPanel />}
+                  {rightPanel === 'artifacts' && <ArtifactPanelConnected />}
+                  {rightPanel === 'preview' && <PreviewPanel />}
+                </ResizablePanel>
+              </>
+            )}
+          </ResizablePanelGroup>
         )}
       </div>
 

--- a/apps/web-remote/src/components/PreviewPanel.tsx
+++ b/apps/web-remote/src/components/PreviewPanel.tsx
@@ -144,6 +144,16 @@ export function PreviewPanel() {
   };
 
   if (active) {
+    // allow-same-origin is only safe when the preview loads from the
+    // gateway's dedicated preview origin (see buildPreviewUrl): previewed
+    // workspace code must never be same-origin with this SPA, or it could
+    // reach our DOM and origin-scoped credentials. If an older gateway
+    // didn't advertise a preview origin, fail closed: keep the opaque
+    // sandbox (module-based dev servers won't render, but nothing leaks).
+    const isolated = new URL(active.url).origin !== window.location.origin;
+    const sandbox = isolated
+      ? 'allow-scripts allow-same-origin allow-forms allow-popups allow-modals'
+      : 'allow-scripts allow-forms allow-popups allow-modals';
     return (
       <div className="flex flex-col h-full">
         <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border bg-card shrink-0">
@@ -203,12 +213,7 @@ export function PreviewPanel() {
           onLoad={() => setPicking(false)}
           className="flex-1 w-full bg-background border-0"
           title={`Dev server preview: port ${active.port}`}
-          // allow-same-origin is safe here because previews load from the
-          // gateway's dedicated preview port — a different origin from this
-          // SPA. Without it the document gets an opaque origin, which breaks
-          // every module-based dev server (module scripts fail CORS and drop
-          // the ticket cookie), rendering the preview blank.
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+          sandbox={sandbox}
         />
       </div>
     );

--- a/apps/web-remote/src/components/PreviewPanel.tsx
+++ b/apps/web-remote/src/components/PreviewPanel.tsx
@@ -4,7 +4,8 @@
  * gateway's `/p/<workspace>/<port>/...` reverse proxy.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useChatStore } from '@/stores/chat';
 import { useDevServerStore, type DevServer } from '@/stores/dev-servers';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { Button } from '@sero-ai/ui/components/ui/button';
@@ -12,6 +13,7 @@ import {
   Globe,
   ExternalLink,
   RefreshCw,
+  SquareDashedMousePointer,
   X,
   ArrowLeftRight,
 } from 'lucide-react';
@@ -46,13 +48,56 @@ export function PreviewPanel() {
   const isLoading = useDevServerStore((s) => s.isLoading);
   const [active, setActive] = useState<ActivePreview | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // React-grab element pick in the previewed page. The proxy injects the
+  // grab script into preview documents; we talk to it over postMessage
+  // because the sandboxed iframe (no allow-same-origin) is an opaque origin.
+  const [picking, setPicking] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const setComposerPrefill = useChatStore((s) => s.setComposerPrefill);
 
   // Refresh when the workspace changes, registered servers are scoped to it.
   useEffect(() => {
     if (!activeWorkspaceId) return;
     fetchServers();
     setActive(null);
+    setPicking(false);
   }, [activeWorkspaceId, fetchServers]);
+
+  // Grab results posted by the injected script inside the preview iframe.
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (!iframeRef.current || event.source !== iframeRef.current.contentWindow) return;
+      const data = event.data as { type?: string; status?: string; content?: string } | null;
+      if (!data || data.type !== 'sero:grab-result') return;
+      const wasPicking = picking;
+      setPicking(false);
+      if (wasPicking && data.status === 'grabbed' && typeof data.content === 'string' && active) {
+        const cleanUrl = active.url.split('?')[0];
+        setComposerPrefill(`${data.content}\n\n— ${cleanUrl}\n\n`);
+      }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [picking, active, setComposerPrefill]);
+
+  const handlePickElement = () => {
+    const frame = iframeRef.current?.contentWindow;
+    if (!frame) return;
+    if (picking) {
+      // Clear locally too so a preview without the bridge (injection
+      // failed) can't leave the button stuck in the active state.
+      setPicking(false);
+      frame.postMessage({ type: 'sero:grab-cancel' }, '*');
+      return;
+    }
+    setPicking(true);
+    frame.postMessage({ type: 'sero:grab-start' }, '*');
+  };
+
+  const closePreview = () => {
+    setActive(null);
+    setPicking(false);
+  };
 
   const visible = (activeWorkspaceId
     ? servers.filter((s) => s.workspaceId === activeWorkspaceId)
@@ -103,7 +148,7 @@ export function PreviewPanel() {
       <div className="flex flex-col h-full">
         <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border bg-card shrink-0">
           <Button
-            onClick={() => setActive(null)}
+            onClick={closePreview}
             variant="ghost"
             size="icon-xs"
             title="Back to list"
@@ -113,6 +158,15 @@ export function PreviewPanel() {
           <div className="flex-1 min-w-0 text-xs font-medium truncate">
             Port {active.port}
           </div>
+          <Button
+            onClick={handlePickElement}
+            variant="ghost"
+            size="icon-xs"
+            title={picking ? 'Cancel element pick' : 'Pick element for chat'}
+            className={picking ? 'text-primary hover:text-primary' : ''}
+          >
+            <SquareDashedMousePointer className="size-4" />
+          </Button>
           <Button
             onClick={handleReload}
             variant="ghost"
@@ -130,7 +184,7 @@ export function PreviewPanel() {
             <ExternalLink className="size-4" />
           </Button>
           <Button
-            onClick={() => setActive(null)}
+            onClick={closePreview}
             variant="ghost"
             size="icon-xs"
             title="Close preview"
@@ -142,10 +196,19 @@ export function PreviewPanel() {
           // The key forces a full reload when the URL changes, including
           // when a stale ticket gets refreshed via handleReload.
           key={active.url}
+          ref={iframeRef}
           src={active.url}
+          // A (re)load resets the injected grab bridge, so drop any pick
+          // that was running against the previous document.
+          onLoad={() => setPicking(false)}
           className="flex-1 w-full bg-background border-0"
           title={`Dev server preview: port ${active.port}`}
-          sandbox="allow-scripts allow-forms allow-popups allow-modals"
+          // allow-same-origin is safe here because previews load from the
+          // gateway's dedicated preview port — a different origin from this
+          // SPA. Without it the document gets an opaque origin, which breaks
+          // every module-based dev server (module scripts fail CORS and drop
+          // the ticket cookie), rendering the preview blank.
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
         />
       </div>
     );

--- a/apps/web-remote/src/stores/chat.ts
+++ b/apps/web-remote/src/stores/chat.ts
@@ -47,7 +47,11 @@ interface ChatStore {
   renderItems: ChatRenderItem[];
   isStreaming: boolean;
   isLoadingHistory: boolean;
+  /** Text waiting to be inserted into the composer (e.g. a preview element grab). */
+  composerPrefill: string | null;
 
+  setComposerPrefill: (text: string) => void;
+  clearComposerPrefill: () => void;
   sendMessage: (text: string, images?: Array<{ data: string; mimeType: string }>) => void;
   handleMessage: (msg: GatewayMessage) => void;
   clearMessages: () => void;
@@ -99,6 +103,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   renderItems: [],
   isStreaming: false,
   isLoadingHistory: false,
+  composerPrefill: null,
+
+  setComposerPrefill: (text) => set({ composerPrefill: text }),
+  clearComposerPrefill: () => set({ composerPrefill: null }),
 
   _rebuildRenderItems: () => {
     const { messages, toolCalls } = get();

--- a/apps/web-remote/src/stores/dev-servers.ts
+++ b/apps/web-remote/src/stores/dev-servers.ts
@@ -63,13 +63,20 @@ function buildPreviewUrl(
   port: number,
   ticket: string,
   previewPort: number | undefined,
+  previewTlsPort: number | undefined,
 ): string {
   const base = `${getGatewayHttpOrigin()}/p/${encodeURIComponent(workspaceId)}/${port}/`;
   const url = new URL(base);
-  // Previews load from the gateway's dedicated preview port so they get
-  // their own origin — the sandboxed preview iframe can then use
-  // allow-same-origin without sharing this SPA's origin.
-  if (previewPort) url.port = String(previewPort);
+  // Previews load from the gateway's dedicated preview listener so they
+  // get their own origin — the sandboxed preview iframe can then use
+  // allow-same-origin without sharing this SPA's origin. Over TLS
+  // (tailnet access via `tailscale serve`) the listener is reachable on
+  // the mapped HTTPS port instead of the direct one.
+  if (url.protocol === 'https:') {
+    if (previewTlsPort) url.port = String(previewTlsPort);
+  } else if (previewPort) {
+    url.port = String(previewPort);
+  }
   url.searchParams.set('t', ticket);
   return url.toString();
 }
@@ -118,6 +125,7 @@ export const useDevServerStore = create<DevServerStore>((set, get) => ({
           workspaceId: string;
           port: number;
           previewPort?: number;
+          previewTlsPort?: number;
         } | undefined;
         if (!data) return;
         const key = `${data.workspaceId}:${data.port}`;
@@ -127,7 +135,13 @@ export const useDevServerStore = create<DevServerStore>((set, get) => ({
         next.delete(key);
         set({ _pendingTickets: next });
         pending.resolve(
-          buildPreviewUrl(data.workspaceId, data.port, data.ticket, data.previewPort),
+          buildPreviewUrl(
+            data.workspaceId,
+            data.port,
+            data.ticket,
+            data.previewPort,
+            data.previewTlsPort,
+          ),
         );
         return;
       }

--- a/apps/web-remote/src/stores/dev-servers.ts
+++ b/apps/web-remote/src/stores/dev-servers.ts
@@ -62,9 +62,14 @@ function buildPreviewUrl(
   workspaceId: string,
   port: number,
   ticket: string,
+  previewPort: number | undefined,
 ): string {
   const base = `${getGatewayHttpOrigin()}/p/${encodeURIComponent(workspaceId)}/${port}/`;
   const url = new URL(base);
+  // Previews load from the gateway's dedicated preview port so they get
+  // their own origin — the sandboxed preview iframe can then use
+  // allow-same-origin without sharing this SPA's origin.
+  if (previewPort) url.port = String(previewPort);
   url.searchParams.set('t', ticket);
   return url.toString();
 }
@@ -112,6 +117,7 @@ export const useDevServerStore = create<DevServerStore>((set, get) => ({
           ticket: string;
           workspaceId: string;
           port: number;
+          previewPort?: number;
         } | undefined;
         if (!data) return;
         const key = `${data.workspaceId}:${data.port}`;
@@ -120,7 +126,9 @@ export const useDevServerStore = create<DevServerStore>((set, get) => ({
         const next = new Map(get()._pendingTickets);
         next.delete(key);
         set({ _pendingTickets: next });
-        pending.resolve(buildPreviewUrl(data.workspaceId, data.port, data.ticket));
+        pending.resolve(
+          buildPreviewUrl(data.workspaceId, data.port, data.ticket, data.previewPort),
+        );
         return;
       }
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.5(react@19.2.5)
+      react-grab:
+        specifier: ^0.1.48
+        version: 0.1.48(react@19.2.5)
       react-grid-layout:
         specifier: ^2.2.3
         version: 2.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3021,6 +3024,9 @@ packages:
   '@huggingface/transformers@4.2.0':
     resolution: {integrity: sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==}
 
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
   '@ibm-cloud/watsonx-ai@1.7.12':
     resolution: {integrity: sha512-++tkoj1yLKNMeS+EPC/cvVYQZbyLAUGdDy/QeUObhRYSQmENDnCcA3Y1qquBH6XcPLXw7sQCQZCwFfhCTrvJow==}
     engines: {node: '>=20.0.0'}
@@ -5171,6 +5177,10 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-grab/cli@0.1.48':
+    resolution: {integrity: sha512-KXRZFN0b78BeVa4Tq1FC9kiXPpC5lS4pQp/mvQ1azy9dZUJ3zfc7Ei84+yvGh+WoYdceMCFxXfBp6qhU/G056g==}
+    hasBin: true
+
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
     engines: {node: '>= 18.19.0'}
@@ -6825,6 +6835,10 @@ packages:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
 
+  agent-install@0.0.6:
+    resolution: {integrity: sha512-7NRMZ/ZDz2vHevQTgJsocBFpakB1/Wx5ip19YSJuj4VOXpraWztTerViNtdSyARKZT9e2yVwUUB5JXXCE7mNrA==}
+    hasBin: true
+
   ai@6.0.116:
     resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
     engines: {node: '>=18'}
@@ -7091,6 +7105,11 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bippy@0.5.43:
+    resolution: {integrity: sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==}
+    peerDependencies:
+      react: '>=17.0.1'
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -11620,6 +11639,15 @@ packages:
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-grab@0.1.48:
+    resolution: {integrity: sha512-p3WnmK9LLvXE/c4ITPLlXcP1fkXo2VFEQqK94tIfcHIWKNdqdhYYFyNVioO50HR+uyHIwT63Z4txZDqJlVcD/Q==}
+    hasBin: true
+    peerDependencies:
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   react-grid-layout@2.2.3:
     resolution: {integrity: sha512-OAEJHBxmfuxQfVtZwRzmsokijGlBgzYIJ7MUlLk/VSa43SaGzu15w5D0P2RDrfX5EvP9POMbL6bFrai/huDzbQ==}
@@ -16376,6 +16404,8 @@ snapshots:
       sharp: 0.34.5
     optional: true
 
+  '@iarna/toml@2.2.5': {}
+
   '@ibm-cloud/watsonx-ai@1.7.12':
     dependencies:
       form-data: 4.0.5
@@ -18790,6 +18820,17 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-grab/cli@0.1.48':
+    dependencies:
+      agent-install: 0.0.6
+      commander: 14.0.3
+      ignore: 7.0.5
+      ora: 9.4.0
+      package-manager-detector: 1.6.0
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      tinyexec: 1.2.2
+
   '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.0))':
     dependencies:
       '@redis/client': 5.12.1(@opentelemetry/api@1.9.0)
@@ -20653,6 +20694,15 @@ snapshots:
 
   agent-base@9.0.0: {}
 
+  agent-install@0.0.6:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
+
   ai@6.0.116(zod@4.4.3):
     dependencies:
       '@ai-sdk/gateway': 3.0.66(zod@4.4.3)
@@ -21014,6 +21064,10 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  bippy@0.5.43(react@19.2.5):
+    dependencies:
+      react: 19.2.5
 
   bl@4.1.0:
     dependencies:
@@ -26704,6 +26758,13 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   react-fast-compare@3.2.2: {}
+
+  react-grab@0.1.48(react@19.2.5):
+    dependencies:
+      '@react-grab/cli': 0.1.48
+      bippy: 0.5.43(react@19.2.5)
+    optionalDependencies:
+      react: 19.2.5
 
   react-grid-layout@2.2.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## Summary

Integrates [React Grab](https://github.com/aidenybai/react-grab) so a hovered UI element can be picked directly as chat context — the element's markup plus its React component stack with source file locations (on dev servers) lands in the chat composer.

Two surfaces:

- **Explorer browser toolbar** — new "Pick element for chat" button. The react-grab bundle is injected on demand into the tab via `executeJavaScript` (no preload, nothing loaded until the button is clicked, telemetry off, react-grab's own floating toolbar hidden). The pick resolves push-style through plugin hooks; Escape, toolbar toggle, navigation, and tab close all cancel cleanly.
- **Sero Remote dev-server previews** — the gateway's dev proxy injects the bundle into proxied preview HTML (served from `/__sero/grab.js`), and the preview panel drives it over `postMessage` from outside the sandboxed iframe.

## Preview fixes that fell out of this

- **Blank previews for module-based dev servers (pre-existing bug):** the preview iframe's sandbox gave pages an opaque origin, so Vite/Next module scripts failed CORS and dropped the ticket cookie — every modern dev server rendered blank. Previews now load from a dedicated gateway listener (**18802**) so the iframe gets `allow-same-origin` on its own origin while staying fully isolated from the SPA (previewed code cannot reach the SPA's storage or gateway session).
- **Tailscale:** exposing the gateway now also maps the preview listener to HTTPS **8443** on the tailnet; the ticket response advertises both ports and the client picks by connection scheme. Manual `tailscale serve` setups need `tailscale serve --bg --https=8443 18802` (documented).
- The right panel in Sero Remote is now resizable (`@sero-ai/ui` resizable).

## Implementation notes

- react-grab is a devDependency only; `build-electron.mjs` stages its IIFE bundle into `dist/electron/`, shared by the browser feature and the gateway.
- `view-shortcuts.ts`, `browser-events.ts`, and `event-broadcast.ts` are verbatim extractions to keep their parent files under the 500-LOC rule.
- Docs updated: `guide/explorer-workspace.md`, `guide/remote-control.md`.

## Testing

- Verified end-to-end via CDP automation on the running app: desktop toolbar pick on a React dev server (full component stack with file paths in the composer), plain-HTML fallback (selector), cancel via Escape/toggle/navigation, re-injection after navigation.
- Web-remote verified in a real browser: preview renders on the isolated origin, picker round-trips through the sandboxed iframe into the composer with clean source paths, divider drag works.
- Tailscale path verified on a phone (manual).
- `pnpm typecheck` clean across the monorepo; gateway suite (54 tests) and browser tests pass, plus new tests for the HTML injection.

## Known limitation

react-grab's copy flow can hang on some production React sites (source symbolication of minified chunks — observed on duckduckgo.com). The cancel toggle recovers, and the intended targets (dev servers) work fully.