### PR TITLE
fix(ui): prevent root barrel imports from bundling unrelated assets

### DIFF
--- a/.agents/skills/sero-plugin/SKILL.md
+++ b/.agents/skills/sero-plugin/SKILL.md
@@ -210,7 +210,7 @@ Required:
 - Import UI components from `@sero-ai/ui`
 - Import `./styles.css` from **every** exposed MF entry (main app, widgets, etc.)
 - Tailwind semantic colors (`bg-background`, `text-foreground`, etc.)
-- `ui/styles.css` should import `@sero-ai/ui/styles/plugin.css` and scan plugin-local files with `@source "./**/*.{ts,tsx}"`
+- `ui/styles.css` should import `@sero-ai/ui/styles/plugin.css` and scan plugin-local files with `@source "./**/*.{ts,tsx}"`. The base stylesheet scans only shared primitives and dashboard components; add `styles/ai-elements.css`, `styles/model-selection.css`, or `styles/context-editor.css` when the UI uses those families.
 - UI plugins must set `sero.app.styleIsolation` to `"scope"` and add `seroPluginCssScope({ pluginId: '<app-id>' })` after Tailwind in `vite.config.ts`.
 - Do not alias `@sero-ai/app-runtime`
 - Scope keyboard listeners to the container (`tabIndex={0}`), never `window`

--- a/.agents/skills/sero-plugin/references/templates.md
+++ b/.agents/skills/sero-plugin/references/templates.md
@@ -875,8 +875,19 @@ If you do this, declare:
 ```
 
 **Why needed:**
-- `@import "@sero-ai/ui/styles/plugin.css"` — imports Sero's shared Tailwind 4 theme bridge and scans shared UI components
+- `@import "@sero-ai/ui/styles/plugin.css"` — imports Sero's shared Tailwind 4 theme bridge and scans shared primitives plus dashboard components
 - `@source "./**/*.{ts,tsx}"` — keeps external remotes from silently missing plugin-local utility classes at runtime
+
+Add the matching source stylesheet immediately after `plugin.css` when the UI
+uses a specialized component family:
+
+```css
+@import "@sero-ai/ui/styles/ai-elements.css";
+@import "@sero-ai/ui/styles/model-selection.css";
+@import "@sero-ai/ui/styles/context-editor.css";
+```
+
+Only import the specialized stylesheets the plugin needs.
 
 ---
 
@@ -898,6 +909,8 @@ If you do this, declare:
     "paths": {
       "@sero-ai/app-runtime": ["../../app-runtime/src/index.ts"],
       "@sero-ai/ui": ["../../ui/src/index.ts"],
+      "@sero-ai/ui/ai-elements/*": ["../../ui/src/components/ai-elements/*"],
+      "@sero-ai/ui/model-selection/*": ["../../ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../ui/src/*"]
     }
   },

--- a/apps/desktop/src/components/layout/ChatAttachments.tsx
+++ b/apps/desktop/src/components/layout/ChatAttachments.tsx
@@ -6,10 +6,10 @@ import {
   AttachmentPreview,
   AttachmentInfo,
   AttachmentRemove,
-} from '@sero-ai/ui/components/ai-elements/attachments';
+} from '@sero-ai/ui/ai-elements/attachments';
 import {
   usePromptInputAttachments,
-} from '@sero-ai/ui/components/ai-elements/prompt-input';
+} from '@sero-ai/ui/ai-elements/prompt-input';
 import type { ChatAttachment } from '@/types/ipc';
 import { useLightbox, type LightboxImage } from './ImageLightbox';
 

--- a/apps/desktop/src/components/layout/ChatMessageItem.test.tsx
+++ b/apps/desktop/src/components/layout/ChatMessageItem.test.tsx
@@ -21,7 +21,7 @@ vi.mock('lucide-react', () => ({
   ChevronDown: () => <svg data-icon="chevron-down" />,
 }));
 
-vi.mock('@sero-ai/ui/components/ai-elements/message', () => ({
+vi.mock('@sero-ai/ui/ai-elements/message', () => ({
   Message: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   MessageActions: ({ children }: { children: ReactNode }) => <div>{children}</div>,
   MessageAction: ({ children, label, onClick }: ComponentPropsWithoutRef<'button'> & { label?: string }) => (

--- a/apps/desktop/src/components/layout/ChatMessageItem.tsx
+++ b/apps/desktop/src/components/layout/ChatMessageItem.tsx
@@ -9,7 +9,7 @@ import {
   MessageActions,
   MessageContent,
   MessageResponse,
-} from '@sero-ai/ui/components/ai-elements/message';
+} from '@sero-ai/ui/ai-elements/message';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { MessageAttachments } from './ChatAttachments';
 import { ThinkingBlock } from './ThinkingBlock';

--- a/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
+++ b/apps/desktop/src/components/layout/ChatPanelHelpers.tsx
@@ -12,7 +12,7 @@ import { useRef, useState, useCallback } from 'react';
 import { Settings2, Brain, Database, MessageSquare, Users, Swords, ChevronDown, Loader2 } from 'lucide-react';
 import {
   PromptInputActionMenuItem,
-} from '@sero-ai/ui/components/ai-elements/prompt-input';
+} from '@sero-ai/ui/ai-elements/prompt-input';
 import { useAgentStore } from '@/stores/agent';
 import {
   useFocusedCollaborationMode,

--- a/apps/desktop/src/components/layout/ChatPromptArea.tsx
+++ b/apps/desktop/src/components/layout/ChatPromptArea.tsx
@@ -21,7 +21,7 @@ import {
   PromptInputActionMenuTrigger,
   PromptInputActionMenuContent,
   PromptInputActionAddAttachments,
-} from '@sero-ai/ui/components/ai-elements/prompt-input';
+} from '@sero-ai/ui/ai-elements/prompt-input';
 import { useAgentStore } from '@/stores/agent';
 import {
   useFocusedCollaborationMode,

--- a/apps/desktop/src/components/layout/ComposerAttachmentBridge.tsx
+++ b/apps/desktop/src/components/layout/ComposerAttachmentBridge.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useEffect } from 'react';
-import { usePromptInputAttachments } from '@sero-ai/ui/components/ai-elements/prompt-input-context';
+import { usePromptInputAttachments } from '@sero-ai/ui/ai-elements/prompt-input-context';
 import { useComposerAttachmentQueue } from '@/stores/composer-attachments';
 
 export function ComposerAttachmentBridge() {

--- a/apps/desktop/src/components/layout/WorkspaceSnapshotMenuItem.tsx
+++ b/apps/desktop/src/components/layout/WorkspaceSnapshotMenuItem.tsx
@@ -16,7 +16,7 @@
  */
 
 import { FolderTree } from 'lucide-react';
-import { PromptInputActionMenuItem } from '@sero-ai/ui/components/ai-elements/prompt-input-elements';
+import { PromptInputActionMenuItem } from '@sero-ai/ui/ai-elements/prompt-input-elements';
 import { useAgentStore } from '@/stores/agent';
 import { useAppStore } from '@/stores/app';
 import { useBrowserStore } from '@/stores/browser';

--- a/apps/desktop/src/components/layout/models/ModelSelector.tsx
+++ b/apps/desktop/src/components/layout/models/ModelSelector.tsx
@@ -4,7 +4,7 @@ import { SearchInput } from '@sero-ai/ui/components/ui/search-input';
 import { ModelManagerDialog } from './model-manager/ModelManagerDialog';
 import { ModelSelectorList } from './model-selector/ModelSelectorList';
 import { MemoizedModelSelectorTrigger } from './model-selector/ModelSelectorTrigger';
-import { ThinkingPicker } from '@sero-ai/ui/components/model-selection/thinking-picker';
+import { ThinkingPicker } from '@sero-ai/ui/model-selection/thinking-picker';
 import { useModelSelectorState } from './model-selector/useModelSelectorState';
 
 export function ModelSelector({ disabled }: { disabled: boolean }) {

--- a/apps/desktop/src/components/layout/shell/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/shell/ChatPanel.tsx
@@ -4,7 +4,7 @@ import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
-} from '@sero-ai/ui/components/ai-elements/conversation';
+} from '@sero-ai/ui/ai-elements/conversation';
 import { useAgentStore } from '@/stores/agent';
 import {
   useFocusedAgent,

--- a/apps/desktop/src/components/layout/shell/ChatPanel.tsx
+++ b/apps/desktop/src/components/layout/shell/ChatPanel.tsx
@@ -82,9 +82,14 @@ export function ChatPanel() {
   const clearComposerPrefill = useAgentStore((s) => s.clearComposerPrefill);
   const checkpoint = useCheckpointRestore(focusedWorkspaceId, sessionId);
 
-  const persistCollaborationSize = useDebouncedCallback((pct: number) => {
-    setChatCollaborationSizePct(Math.round(pct * 10) / 10);
-  }, 300);
+  const updateCollaborationSize = useCallback(
+    (pct: number) => setChatCollaborationSizePct(Math.round(pct * 10) / 10),
+    [setChatCollaborationSizePct],
+  );
+  const persistCollaborationSize = useDebouncedCallback(
+    updateCollaborationSize,
+    300,
+  );
 
   const handleCollaborationResize = useCallback(
     ({ asPercentage }: { inPixels: number; asPercentage: number }) => {

--- a/apps/desktop/src/components/layout/tool-call-helpers/ToolDetail.tsx
+++ b/apps/desktop/src/components/layout/tool-call-helpers/ToolDetail.tsx
@@ -6,7 +6,7 @@ import {
   ToolHeader,
   ToolInput,
   ToolOutput,
-} from '@sero-ai/ui/components/ai-elements/tool';
+} from '@sero-ai/ui/ai-elements/tool';
 import {
   ToolCallProgress,
   buildToolProgressModel,

--- a/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
+++ b/apps/desktop/src/components/profiles/onboarding/SetupScreen.tsx
@@ -8,9 +8,9 @@ import {
   resolveSupportedThinkingLevel,
   validateGlobalTierSelections,
 } from '@sero-ai/common';
-import { AvailableModelPicker } from '@sero-ai/ui/components/model-selection/available-model-picker';
-import { ModelWarningList } from '@sero-ai/ui/components/model-selection/model-warning-list';
-import { ThinkingLevelPicker } from '@sero-ai/ui/components/model-selection/thinking-level-picker';
+import { AvailableModelPicker } from '@sero-ai/ui/model-selection/available-model-picker';
+import { ModelWarningList } from '@sero-ai/ui/model-selection/model-warning-list';
+import { ThinkingLevelPicker } from '@sero-ai/ui/model-selection/thinking-level-picker';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import {
   DialogDescription,

--- a/apps/desktop/src/hooks/useChatPromptInput.ts
+++ b/apps/desktop/src/hooks/useChatPromptInput.ts
@@ -9,7 +9,7 @@ import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useFocusedCommands } from '@/stores/agent-selectors';
 import { useWorkspaceFiles, fuzzyMatchFiles } from '@/hooks/useWorkspaceFiles';
 import type { SeroSlashCommandInfo, ChatAttachment, ChatComposerPrefill } from '@/types/ipc';
-import type { PromptInputMessage } from '@sero-ai/ui/components/ai-elements/prompt-input';
+import type { PromptInputMessage } from '@sero-ai/ui/ai-elements/prompt-input';
 
 /** Built-in commands handled client-side (not sent to the agent). */
 const BUILTIN_COMMANDS: SeroSlashCommandInfo[] = [

--- a/apps/desktop/tsconfig.electron.json
+++ b/apps/desktop/tsconfig.electron.json
@@ -23,6 +23,8 @@
       "@sero-ai/common": ["../../packages/common/src/index.ts"],
       "@sero-ai/extension-runtime": ["../../packages/extension-runtime/src/index.ts"],
       "@sero-ai/ui": ["../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/ai-elements/*": ["../../packages/ui/src/components/ai-elements/*"],
+      "@sero-ai/ui/model-selection/*": ["../../packages/ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../packages/ui/src/*"],
       // Pi exports this subpath, but moduleResolution:node still needs this mapping.
       "@earendil-works/pi-ai/oauth": ["./node_modules/@earendil-works/pi-ai/dist/oauth"],

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -22,6 +22,8 @@
       "@sero-ai/app-runtime": ["../../packages/app-runtime/src/index.ts"],
       "@sero-ai/common": ["../../packages/common/src/index.ts"],
       "@sero-ai/ui": ["../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/ai-elements/*": ["../../packages/ui/src/components/ai-elements/*"],
+      "@sero-ai/ui/model-selection/*": ["../../packages/ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../packages/ui/src/*"]
     }
   },

--- a/apps/docs-site/docs/reference/dashboard-components.md
+++ b/apps/docs-site/docs/reference/dashboard-components.md
@@ -20,12 +20,17 @@ import { Message } from '@sero-ai/ui/ai-elements/message';
 ```
 
 Federated plugins that use AI elements should also import their Tailwind source
-entry after the base plugin stylesheet:
+entry after the base plugin stylesheet. The same rule applies to model-selection
+and context-editor components:
 
 ```css
 @import "@sero-ai/ui/styles/plugin.css";
 @import "@sero-ai/ui/styles/ai-elements.css";
+@import "@sero-ai/ui/styles/model-selection.css";
+@import "@sero-ai/ui/styles/context-editor.css";
 ```
+
+Only import the specialized stylesheets for component families the plugin uses.
 
 Detailed props are canonical in the exported TypeScript types. The
 machine-readable catalogue (the data behind the tables below) ships as plain

--- a/apps/docs-site/docs/reference/dashboard-components.md
+++ b/apps/docs-site/docs/reference/dashboard-components.md
@@ -11,6 +11,22 @@ Import everything from the package root:
 import { WidgetContent, Stack, Metric, Status, ItemList } from '@sero-ai/ui';
 ```
 
+The root is for primitives, dashboard components, hooks and theme utilities.
+Import AI elements from their stable subpaths so plugins only load the editor
+and rendering dependencies they use:
+
+```tsx
+import { Message } from '@sero-ai/ui/ai-elements/message';
+```
+
+Federated plugins that use AI elements should also import their Tailwind source
+entry after the base plugin stylesheet:
+
+```css
+@import "@sero-ai/ui/styles/plugin.css";
+@import "@sero-ai/ui/styles/ai-elements.css";
+```
+
 Detailed props are canonical in the exported TypeScript types. The
 machine-readable catalogue (the data behind the tables below) ships as plain
 JSON at a stable subpath — read it directly:

--- a/apps/styleguide/tsconfig.json
+++ b/apps/styleguide/tsconfig.json
@@ -16,6 +16,8 @@
     "paths": {
       "@/*": ["src/*"],
       "@sero-ai/ui": ["../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/ai-elements/*": ["../../packages/ui/src/components/ai-elements/*"],
+      "@sero-ai/ui/model-selection/*": ["../../packages/ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../packages/ui/src/*"]
     }
   },

--- a/apps/styleguide/vite.config.ts
+++ b/apps/styleguide/vite.config.ts
@@ -6,10 +6,27 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
-      '@sero-ai/ui': path.resolve(__dirname, '../../packages/ui/src'),
-    },
+    alias: [
+      {
+        find: '@sero-ai/ui/ai-elements',
+        replacement: path.resolve(
+          __dirname,
+          '../../packages/ui/src/components/ai-elements',
+        ),
+      },
+      {
+        find: '@sero-ai/ui/model-selection',
+        replacement: path.resolve(
+          __dirname,
+          '../../packages/ui/src/components/model-selection',
+        ),
+      },
+      {
+        find: '@sero-ai/ui',
+        replacement: path.resolve(__dirname, '../../packages/ui/src'),
+      },
+      { find: '@', replacement: path.resolve(__dirname, 'src') },
+    ],
   },
   server: {
     port: 5176,

--- a/apps/web-remote/src/components/ChatPanel.tsx
+++ b/apps/web-remote/src/components/ChatPanel.tsx
@@ -20,7 +20,7 @@ import {
   ConversationContent,
   ConversationScrollButton,
   ConversationEmptyState,
-} from '@sero-ai/ui/components/ai-elements/conversation';
+} from '@sero-ai/ui/ai-elements/conversation';
 import { Send, Square, Paperclip, X, MessageSquare } from 'lucide-react';
 
 interface PendingImage {

--- a/apps/web-remote/tsconfig.json
+++ b/apps/web-remote/tsconfig.json
@@ -18,6 +18,8 @@
       "@/*": ["src/*"],
       "@assets/*": ["../../assets/*"],
       "@sero-ai/ui": ["../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/ai-elements/*": ["../../packages/ui/src/components/ai-elements/*"],
+      "@sero-ai/ui/model-selection/*": ["../../packages/ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../packages/ui/src/*"]
     }
   },

--- a/apps/web-remote/vite.config.ts
+++ b/apps/web-remote/vite.config.ts
@@ -6,11 +6,28 @@ import path from 'path';
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, 'src'),
-      '@assets': path.resolve(__dirname, '../../assets'),
-      '@sero-ai/ui': path.resolve(__dirname, '../../packages/ui/src'),
-    },
+    alias: [
+      {
+        find: '@sero-ai/ui/ai-elements',
+        replacement: path.resolve(
+          __dirname,
+          '../../packages/ui/src/components/ai-elements',
+        ),
+      },
+      {
+        find: '@sero-ai/ui/model-selection',
+        replacement: path.resolve(
+          __dirname,
+          '../../packages/ui/src/components/model-selection',
+        ),
+      },
+      {
+        find: '@sero-ai/ui',
+        replacement: path.resolve(__dirname, '../../packages/ui/src'),
+      },
+      { find: '@assets', replacement: path.resolve(__dirname, '../../assets') },
+      { find: '@', replacement: path.resolve(__dirname, 'src') },
+    ],
   },
   build: {
     outDir: path.resolve(__dirname, '../desktop/electron/features/gateway/web-dist'),

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -562,7 +562,18 @@ export default defineConfig({
 UI plugins must also declare `"styleIsolation": "scope"` beside
 `sero.app.id`. The plugin ID passed to `seroPluginCssScope` must match that
 manifest ID exactly. Import `@sero-ai/ui/styles/plugin.css` from the plugin's
-stylesheet; document resets and theme variables remain owned by the host.
+stylesheet; document resets and theme variables remain owned by the host. That
+base stylesheet scans only shared primitives and dashboard components. If the
+plugin uses specialized components, import the matching source stylesheet after
+it:
+
+```css
+@import "@sero-ai/ui/styles/ai-elements.css";
+@import "@sero-ai/ui/styles/model-selection.css";
+@import "@sero-ai/ui/styles/context-editor.css";
+```
+
+Only import the specialized stylesheets the plugin needs.
 
 ## Publishing
 

--- a/packages/ui-test-consumer/index.html
+++ b/packages/ui-test-consumer/index.html
@@ -1,0 +1,2 @@
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>

--- a/packages/ui-test-consumer/package.json
+++ b/packages/ui-test-consumer/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@sero-ai/ui-test-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build --mode source && vite build --mode published",
+    "typecheck": "node scripts/assert-type-boundary.mjs"
+  },
+  "dependencies": {
+    "@sero-ai/ui": "workspace:*",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@module-federation/vite": "catalog:",
+    "@tailwindcss/vite": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:"
+  }
+}

--- a/packages/ui-test-consumer/scripts/assert-type-boundary.mjs
+++ b/packages/ui-test-consumer/scripts/assert-type-boundary.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,6 +8,7 @@ const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 const tsc = require.resolve("typescript/bin/tsc");
+const publishedTypes = resolve(root, "../ui/dist/index.d.ts");
 const forbidden = [
   /components\/ai-elements/,
   /node_modules\/react-jsx-parser/,
@@ -16,6 +18,12 @@ const forbidden = [
 ];
 
 for (const config of ["tsconfig.json", "tsconfig.published.json"]) {
+  if (config === "tsconfig.published.json" && !existsSync(publishedTypes)) {
+    throw new Error(
+      "Published UI types are missing; run `pnpm --filter @sero-ai/ui build` first",
+    );
+  }
+
   const result = spawnSync(
     process.execPath,
     [tsc, "--project", config, "--listFiles", "--pretty", "false"],

--- a/packages/ui-test-consumer/scripts/assert-type-boundary.mjs
+++ b/packages/ui-test-consumer/scripts/assert-type-boundary.mjs
@@ -1,0 +1,40 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const tsc = require.resolve("typescript/bin/tsc");
+const forbidden = [
+  /components\/ai-elements/,
+  /node_modules\/react-jsx-parser/,
+  /node_modules\/@streamdown/,
+  /node_modules\/shiki/,
+  /node_modules\/unified/,
+];
+
+for (const config of ["tsconfig.json", "tsconfig.published.json"]) {
+  const result = spawnSync(
+    process.execPath,
+    [tsc, "--project", config, "--listFiles", "--pretty", "false"],
+    { cwd: root, encoding: "utf8" },
+  );
+
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout);
+    process.stderr.write(result.stderr);
+    process.exit(result.status ?? 1);
+  }
+
+  const leak = result.stdout
+    .split("\n")
+    .find((file) => forbidden.some((pattern) => pattern.test(file)));
+
+  if (leak) {
+    throw new Error(`${config} traversed an unrelated UI dependency: ${leak}`);
+  }
+
+  console.log(`✓ ${config} keeps AI/editor types outside the root consumer`);
+}

--- a/packages/ui-test-consumer/src/main.tsx
+++ b/packages/ui-test-consumer/src/main.tsx
@@ -1,0 +1,13 @@
+import { Button, cn } from "@sero-ai/ui";
+import { createRoot } from "react-dom/client";
+import "@sero-ai/ui/styles/plugin.css";
+
+export function MinimalUiConsumer() {
+  return <Button className={cn("minimal-consumer")}>Ready</Button>;
+}
+
+const root = document.getElementById("root");
+
+if (root) {
+  createRoot(root).render(<MinimalUiConsumer />);
+}

--- a/packages/ui-test-consumer/tsconfig.json
+++ b/packages/ui-test-consumer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*.tsx"]
+}

--- a/packages/ui-test-consumer/tsconfig.published.json
+++ b/packages/ui-test-consumer/tsconfig.published.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@sero-ai/ui": ["../ui/dist/index.d.ts"]
+    }
+  }
+}

--- a/packages/ui-test-consumer/vite.config.ts
+++ b/packages/ui-test-consumer/vite.config.ts
@@ -1,0 +1,70 @@
+import { federation } from "@module-federation/vite";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "node:path";
+import { defineConfig, type Plugin } from "vite";
+
+const forbiddenOutput = [
+  /mermaid/i,
+  /shiki/i,
+  /cytoscape/i,
+  /react-jsx-parser/i,
+  /streamdown/i,
+];
+
+function assertMinimalUiBundle(): Plugin {
+  return {
+    name: "assert-minimal-ui-bundle",
+    generateBundle(_, bundle) {
+      for (const [fileName, output] of Object.entries(bundle)) {
+        const content =
+          output.type === "chunk"
+            ? output.code
+            : typeof output.source === "string"
+              ? output.source
+              : new TextDecoder().decode(output.source);
+        if (forbiddenOutput.some((pattern) => pattern.test(fileName + content))) {
+          throw new Error(`Unrelated UI dependency emitted in ${fileName}`);
+        }
+      }
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => ({
+  plugins: [
+    react(),
+    tailwindcss(),
+    federation({
+      name: `sero_ui_consumer_${mode}`,
+      filename: "remoteEntry.js",
+      dts: false,
+      exposes: {
+        "./MinimalUiConsumer": "./src/main.tsx",
+      },
+      shared: {
+        react: { singleton: true },
+        "react/": { singleton: true },
+        "react-dom": { singleton: true },
+        "react-dom/": { singleton: true },
+      },
+    }),
+    assertMinimalUiBundle(),
+  ],
+  resolve: {
+    alias:
+      mode === "published"
+        ? [
+            {
+              find: /^@sero-ai\/ui$/,
+              replacement: resolve("../ui/dist/index.js"),
+            },
+          ]
+        : [],
+  },
+  build: {
+    target: "esnext",
+    outDir: `dist/${mode}`,
+    emptyOutDir: true,
+  },
+}));

--- a/packages/ui-test-consumer/vite.config.ts
+++ b/packages/ui-test-consumer/vite.config.ts
@@ -1,7 +1,7 @@
 import { federation } from "@module-federation/vite";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig, type Plugin } from "vite";
 
 const forbiddenOutput = [
@@ -11,6 +11,9 @@ const forbiddenOutput = [
   /react-jsx-parser/i,
   /streamdown/i,
 ];
+const publishedUiEntry = fileURLToPath(
+  new URL("../ui/dist/index.js", import.meta.url),
+);
 
 function assertMinimalUiBundle(): Plugin {
   return {
@@ -57,7 +60,7 @@ export default defineConfig(({ mode }) => ({
         ? [
             {
               find: /^@sero-ai\/ui$/,
-              replacement: resolve("../ui/dist/index.js"),
+              replacement: publishedUiEntry,
             },
           ]
         : [],

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @sero-ai/ui changelog
 
+## Unreleased
+
+### Fixed
+
+- Root imports now expose primitives, dashboard components, hooks and theme
+  utilities without traversing specialized dependency graphs. AI elements use
+  stable `@sero-ai/ui/ai-elements/*` subpaths and model controls use
+  `@sero-ai/ui/model-selection/*`, so a plugin importing `Button` and `cn` no
+  longer emits Mermaid, Shiki or graph-rendering assets or loads their
+  transitive types. Specialized plugin styles opt in through
+  `styles/ai-elements.css` and `styles/model-selection.css`.
+
 ## 0.4.1
 
 ### Fixed

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -10,7 +10,9 @@
   `@sero-ai/ui/model-selection/*`, so a plugin importing `Button` and `cn` no
   longer emits Mermaid, Shiki or graph-rendering assets or loads their
   transitive types. Specialized plugin styles opt in through
-  `styles/ai-elements.css` and `styles/model-selection.css`.
+  `styles/ai-elements.css`, `styles/model-selection.css`, and
+  `styles/context-editor.css`. Plugins using those component families must
+  import the matching stylesheet after `styles/plugin.css`.
 
 ## 0.4.1
 

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,18 +1,22 @@
 # @sero-ai/ui changelog
 
-## Unreleased
+## 0.5.0
+
+### Breaking
+
+- AI elements and model controls are no longer exported from the package root.
+  Migrate them to `@sero-ai/ui/ai-elements/*` and
+  `@sero-ai/ui/model-selection/*`. Plugins using those component families must
+  also import the matching specialized stylesheet after `styles/plugin.css`.
 
 ### Fixed
 
 - Root imports now expose primitives, dashboard components, hooks and theme
-  utilities without traversing specialized dependency graphs. AI elements use
-  stable `@sero-ai/ui/ai-elements/*` subpaths and model controls use
-  `@sero-ai/ui/model-selection/*`, so a plugin importing `Button` and `cn` no
-  longer emits Mermaid, Shiki or graph-rendering assets or loads their
-  transitive types. Specialized plugin styles opt in through
+  utilities without traversing specialized dependency graphs, so a plugin
+  importing `Button` and `cn` no longer emits Mermaid, Shiki or graph-rendering
+  assets or loads their transitive types. Specialized plugin styles opt in through
   `styles/ai-elements.css`, `styles/model-selection.css`, and
-  `styles/context-editor.css`. Plugins using those component families must
-  import the matching stylesheet after `styles/plugin.css`.
+  `styles/context-editor.css`.
 
 ## 0.4.1
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sero-ai/ui",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Shared UI components, AI elements, and design tokens for the Sero platform",
   "type": "module",
   "sideEffects": [
@@ -21,11 +21,11 @@
     "./*": "./src/*"
   },
   "scripts": {
-    "build": "tsup && tsup --config tsup.reference.config.ts",
+    "build": "tsup && tsup --config tsup.reference.config.ts && node scripts/smoke-dist.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "smoke": "node scripts/smoke-dist.mjs",
-    "prepublishOnly": "node scripts/ensure-pnpm-publish.mjs && pnpm build && pnpm smoke"
+    "prepublishOnly": "node scripts/ensure-pnpm-publish.mjs && pnpm build"
   },
   "publishConfig": {
     "main": "./dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,10 +3,15 @@
   "version": "0.4.2",
   "description": "Shared UI components, AI elements, and design tokens for the Sero platform",
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./ai-elements/*": "./src/components/ai-elements/*.tsx",
+    "./model-selection/*": "./src/components/model-selection/*.tsx",
     "./dashboard-catalog.json": "./src/components/dashboard/catalog.json",
     "./reference": "./src/reference.ts",
     "./theme": "./src/theme/index.ts",
@@ -31,6 +36,16 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "require": "./dist/index.cjs"
+      },
+      "./ai-elements/*": {
+        "types": "./dist/components/ai-elements/*.d.ts",
+        "import": "./dist/components/ai-elements/*.js",
+        "require": "./dist/components/ai-elements/*.cjs"
+      },
+      "./model-selection/*": {
+        "types": "./dist/components/model-selection/*.d.ts",
+        "import": "./dist/components/model-selection/*.js",
+        "require": "./dist/components/model-selection/*.cjs"
       },
       "./dashboard-catalog.json": "./dist/components/dashboard/catalog.json",
       "./reference": {

--- a/packages/ui/scripts/smoke-dist.mjs
+++ b/packages/ui/scripts/smoke-dist.mjs
@@ -14,6 +14,7 @@ import { dirname, resolve } from "node:path";
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 const dist = resolve(here, "..", "dist");
+const packageRoot = resolve(here, "..");
 
 const fail = (msg) => {
   console.error(`✗ ${msg}`);
@@ -23,6 +24,39 @@ const fail = (msg) => {
 if (!existsSync(dist)) {
   fail("dist/ is missing — run `pnpm build` first");
   process.exit(1);
+}
+
+// The lightweight root must not re-export specialized dependency graphs.
+const rootEntries = ["index.js", "index.cjs", "index.d.ts", "index.d.cts"];
+const forbiddenRootImports = [
+  "components/ai-elements",
+  "components/model-selection",
+  "mermaid",
+  "shiki",
+  "react-jsx-parser",
+  "streamdown",
+];
+
+for (const file of rootEntries) {
+  const contents = readFileSync(resolve(dist, file), "utf8");
+  const leak = forbiddenRootImports.find((dependency) =>
+    contents.includes(dependency),
+  );
+  if (leak) fail(`${file} exposes unrelated dependency ${leak}`);
+}
+
+// Specialized components remain available through stable public subpaths.
+const packageJson = JSON.parse(
+  readFileSync(resolve(packageRoot, "package.json"), "utf8"),
+);
+for (const [subpath, output] of [
+  ["./ai-elements/*", "components/ai-elements/message.js"],
+  ["./model-selection/*", "components/model-selection/available-model-picker.js"],
+]) {
+  if (!packageJson.publishConfig.exports[subpath]) {
+    fail(`publishConfig is missing ${subpath}`);
+  }
+  if (!existsSync(resolve(dist, output))) fail(`${output} not emitted to dist`);
 }
 
 // 1. Reference entrypoint resolves as ESM and exposes the example widgets.
@@ -64,5 +98,7 @@ else {
 if (process.exitCode) {
   console.error("Smoke test failed.");
 } else {
-  console.log("✓ dist entrypoints resolve (reference esm+cjs, catalog json)");
+  console.log(
+    "✓ dist entrypoints resolve and the root excludes specialized dependencies",
+  );
 }

--- a/packages/ui/scripts/smoke-dist.mjs
+++ b/packages/ui/scripts/smoke-dist.mjs
@@ -29,6 +29,9 @@ if (!existsSync(dist)) {
 // The lightweight root must not re-export specialized dependency graphs.
 const rootEntries = ["index.js", "index.cjs", "index.d.ts", "index.d.cts"];
 const forbiddenRootImports = [
+  "@sero-ai/ui/ai-elements",
+  "@sero-ai/ui/model-selection",
+  "@sero-ai/ui/components/context-editor",
   "components/ai-elements",
   "components/model-selection",
   "components/context-editor",

--- a/packages/ui/scripts/smoke-dist.mjs
+++ b/packages/ui/scripts/smoke-dist.mjs
@@ -7,7 +7,7 @@
 // any entrypoint no longer resolves. Run after `pnpm build`.
 
 import { createRequire } from "node:module";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -31,18 +31,74 @@ const rootEntries = ["index.js", "index.cjs", "index.d.ts", "index.d.cts"];
 const forbiddenRootImports = [
   "components/ai-elements",
   "components/model-selection",
+  "components/context-editor",
   "mermaid",
   "shiki",
   "react-jsx-parser",
   "streamdown",
+  "unified",
 ];
 
-for (const file of rootEntries) {
-  const contents = readFileSync(resolve(dist, file), "utf8");
-  const leak = forbiddenRootImports.find((dependency) =>
-    contents.includes(dependency),
+const importPatterns = [
+  /(?:from\s+|import\s*)["'](\.[^"']+)["']/g,
+  /(?:require|import)\(\s*["'](\.[^"']+)["']\s*\)/g,
+];
+
+function localImports(contents) {
+  return importPatterns.flatMap((pattern) =>
+    [...contents.matchAll(pattern)].map((match) => match[1]),
   );
-  if (leak) fail(`${file} exposes unrelated dependency ${leak}`);
+}
+
+function emittedExtension(file) {
+  if (file.endsWith(".d.cts")) return ".d.cts";
+  if (file.endsWith(".d.ts")) return ".d.ts";
+  if (file.endsWith(".cjs")) return ".cjs";
+  return ".js";
+}
+
+function resolveLocalImport(fromFile, specifier) {
+  const base = resolve(dirname(fromFile), specifier);
+  const extension = emittedExtension(fromFile);
+  const candidates = [];
+
+  if (extension.startsWith(".d.") && specifier.endsWith(".js")) {
+    candidates.push(base.replace(/\.js$/, extension));
+  }
+  candidates.push(base, `${base}${extension}`, resolve(base, `index${extension}`));
+
+  return candidates.find(
+    (candidate) => existsSync(candidate) && statSync(candidate).isFile(),
+  );
+}
+
+function inspectRootGraph(entry) {
+  const pending = [resolve(dist, entry)];
+  const visited = new Set();
+
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    const contents = readFileSync(file, "utf8");
+    const relativeFile = file.slice(dist.length + 1);
+    const leak = forbiddenRootImports.find(
+      (dependency) =>
+        relativeFile.includes(dependency) || contents.includes(dependency),
+    );
+    if (leak) fail(`${relativeFile} exposes unrelated dependency ${leak}`);
+
+    for (const specifier of localImports(contents)) {
+      const dependency = resolveLocalImport(file, specifier);
+      if (dependency) pending.push(dependency);
+      else fail(`${relativeFile} has unresolved local import ${specifier}`);
+    }
+  }
+}
+
+for (const file of rootEntries) {
+  inspectRootGraph(file);
 }
 
 // Specialized components remain available through stable public subpaths.
@@ -57,6 +113,13 @@ for (const [subpath, output] of [
     fail(`publishConfig is missing ${subpath}`);
   }
   if (!existsSync(resolve(dist, output))) fail(`${output} not emitted to dist`);
+}
+for (const style of [
+  "styles/ai-elements.css",
+  "styles/model-selection.css",
+  "styles/context-editor.css",
+]) {
+  if (!existsSync(resolve(dist, style))) fail(`${style} not emitted to dist`);
 }
 
 // 1. Reference entrypoint resolves as ESM and exposes the example widgets.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,12 +1,11 @@
 // @sero-ai/ui — Shared UI components, AI elements, and utilities
 //
-// Prefer importing common primitives from the barrel export:
+// Import primitives, dashboard components, hooks, and utilities from the root:
 //   import { Button, Card, Input, cn, useIsMobile } from "@sero-ai/ui"
 //
-// Deep subpath imports are still supported when needed. Because this package is
-// native ESM, consumers should use runtime .js extensions for deep imports:
-//   import { Button } from "@sero-ai/ui/components/ui/button.js"
-//   import { cn } from "@sero-ai/ui/lib/utils.js"
+// AI elements have stable public subpaths so their editor and rendering
+// dependencies are loaded only by consumers that use them:
+//   import { Message } from "@sero-ai/ui/ai-elements/message"
 
 // ── Utilities ──
 export { cn } from "./lib/utils";
@@ -77,60 +76,6 @@ export * from "./components/ui/toggle-group";
 export * from "./components/ui/toggle";
 export * from "./components/ui/tooltip";
 export * from "./components/ui/tree";
-// ── AI Elements ──
-export * from "./components/ai-elements/agent";
-export * from "./components/ai-elements/artifact";
-export * from "./components/ai-elements/attachments";
-export * from "./components/ai-elements/audio-player";
-export * from "./components/ai-elements/canvas";
-export * from "./components/ai-elements/chain-of-thought";
-export * from "./components/ai-elements/checkpoint";
-export * from "./components/ai-elements/code-block";
-export * from "./components/ai-elements/commit";
-export * from "./components/ai-elements/confirmation";
-export * from "./components/ai-elements/connection";
-export * from "./components/ai-elements/context";
-export * from "./components/ai-elements/controls";
-export * from "./components/ai-elements/conversation";
-export * from "./components/ai-elements/edge";
-export * from "./components/ai-elements/environment-variables";
-export * from "./components/ai-elements/file-tree";
-export * from "./components/ai-elements/image";
-export * from "./components/ai-elements/inline-citation";
-export * from "./components/ai-elements/jsx-preview";
-export * from "./components/ai-elements/message";
-export * from "./components/ai-elements/mic-selector";
-export * from "./components/ai-elements/model-selector";
-export * from "./components/ai-elements/node";
-export * from "./components/ai-elements/open-in-chat";
-export * from "./components/ai-elements/package-info";
-export * from "./components/ai-elements/panel";
-export * from "./components/ai-elements/persona";
-export * from "./components/ai-elements/plan";
-export * from "./components/ai-elements/prompt-input-context";
-export * from "./components/ai-elements/prompt-input-elements";
-export * from "./components/ai-elements/prompt-input-textarea";
-export * from "./components/ai-elements/prompt-input";
-export * from "./components/ai-elements/queue";
-export * from "./components/ai-elements/reasoning";
-export * from "./components/ai-elements/sandbox";
-export * from "./components/ai-elements/schema-display";
-export * from "./components/ai-elements/shimmer";
-export * from "./components/ai-elements/snippet";
-export * from "./components/ai-elements/sources";
-export * from "./components/ai-elements/speech-input";
-export * from "./components/ai-elements/stack-trace";
-export * from "./components/ai-elements/suggestion";
-export * from "./components/ai-elements/task";
-export * from "./components/ai-elements/terminal";
-export * from "./components/ai-elements/test-results";
-export * from "./components/ai-elements/tool";
-export * from "./components/ai-elements/toolbar";
-export * from "./components/ai-elements/transcription";
-export * from "./components/ai-elements/voice-selector-accent";
-export * from "./components/ai-elements/voice-selector";
-export * from "./components/ai-elements/web-preview";
-
 // ── Dashboard Components ──
 // Compact presentation components for dashboard widgets and full plugin views.
 // The discovery catalogue is plain data at "@sero-ai/ui/dashboard-catalog.json";
@@ -138,9 +83,5 @@ export * from "./components/ai-elements/web-preview";
 export * from "./components/dashboard";
 export type { DashboardComponentCatalogEntry } from "./components/dashboard/catalog";
 
-// ── Model Selection Components ──
-export * from "./components/model-selection/available-model-picker";
-export * from "./components/model-selection/model-warning-list";
-export * from "./components/model-selection/thinking-level-picker";
 export { PluginStyleScope, type PluginStyleScopeProps } from './plugin-style-scope';
 export { usePluginPortalContainer } from './plugin-style-scope-context';

--- a/packages/ui/src/styles/ai-elements.css
+++ b/packages/ui/src/styles/ai-elements.css
@@ -1,0 +1,2 @@
+/* Import after plugin.css when a federated plugin uses @sero-ai/ui/ai-elements/*. */
+@source "../components/ai-elements";

--- a/packages/ui/src/styles/context-editor.css
+++ b/packages/ui/src/styles/context-editor.css
@@ -1,0 +1,2 @@
+/* Import after plugin.css when a federated plugin uses components/context-editor/*. */
+@source "../components/context-editor";

--- a/packages/ui/src/styles/model-selection.css
+++ b/packages/ui/src/styles/model-selection.css
@@ -1,0 +1,2 @@
+/* Import after plugin.css when a federated plugin uses @sero-ai/ui/model-selection/*. */
+@source "../components/model-selection";

--- a/packages/ui/src/styles/plugin.css
+++ b/packages/ui/src/styles/plugin.css
@@ -3,8 +3,8 @@
 @import "shadcn/tailwind.css";
 @import "./plugin-theme.css";
 
-/* Match the lightweight package root. Specialized entrypoints opt into their
-   own source files through styles/ai-elements.css or styles/model-selection.css. */
+/* Match the lightweight package root. Specialized components opt into their
+   own source files through a matching stylesheet under styles/. */
 @source "../components/ui";
 @source "../components/dashboard";
 

--- a/packages/ui/src/styles/plugin.css
+++ b/packages/ui/src/styles/plugin.css
@@ -3,7 +3,10 @@
 @import "shadcn/tailwind.css";
 @import "./plugin-theme.css";
 
-@source "../components";
+/* Match the lightweight package root. Specialized entrypoints opt into their
+   own source files through styles/ai-elements.css or styles/model-selection.css. */
+@source "../components/ui";
+@source "../components/dashboard";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/plugins/sero-admin-plugin/ui/components/AgentEditor.tsx
+++ b/plugins/sero-admin-plugin/ui/components/AgentEditor.tsx
@@ -12,8 +12,8 @@ import {
   resolveSupportedThinkingLevel,
   validateAgentModelConfig,
 } from '@sero-ai/common';
-import { AvailableModelPicker } from '@sero-ai/ui/components/model-selection/available-model-picker';
-import { ModelWarningList } from '@sero-ai/ui/components/model-selection/model-warning-list';
+import { AvailableModelPicker } from '@sero-ai/ui/model-selection/available-model-picker';
+import { ModelWarningList } from '@sero-ai/ui/model-selection/model-warning-list';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { cn } from '@sero-ai/ui/lib/utils';
 import { getSero, type AvailableModelGroupIPC, type GlobalModelConfigStateIPC } from '../hooks/host';

--- a/plugins/sero-admin-plugin/ui/components/ModelPanel.tsx
+++ b/plugins/sero-admin-plugin/ui/components/ModelPanel.tsx
@@ -7,9 +7,9 @@ import {
   resolveSupportedThinkingLevel,
   validateGlobalTierSelections,
 } from '@sero-ai/common';
-import { AvailableModelPicker } from '@sero-ai/ui/components/model-selection/available-model-picker';
-import { ModelWarningList } from '@sero-ai/ui/components/model-selection/model-warning-list';
-import { ThinkingPicker } from '@sero-ai/ui/components/model-selection/thinking-picker';
+import { AvailableModelPicker } from '@sero-ai/ui/model-selection/available-model-picker';
+import { ModelWarningList } from '@sero-ai/ui/model-selection/model-warning-list';
+import { ThinkingPicker } from '@sero-ai/ui/model-selection/thinking-picker';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { ScrollArea } from '@sero-ai/ui/components/ui/scroll-area';
 import {

--- a/plugins/sero-admin-plugin/ui/styles.css
+++ b/plugins/sero-admin-plugin/ui/styles.css
@@ -1,4 +1,5 @@
 @import "@sero-ai/ui/styles/plugin.css";
+@import "@sero-ai/ui/styles/model-selection.css";
 
 @source "./**/*.{ts,tsx}";
 

--- a/plugins/sero-admin-plugin/ui/tsconfig.json
+++ b/plugins/sero-admin-plugin/ui/tsconfig.json
@@ -13,6 +13,8 @@
       "@sero-ai/app-runtime": ["../../../packages/app-runtime/src/index.ts"],
       "@sero-ai/common": ["../../../packages/common/src/index.ts"],
       "@sero-ai/ui": ["../../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/ai-elements/*": ["../../../packages/ui/src/components/ai-elements/*"],
+      "@sero-ai/ui/model-selection/*": ["../../../packages/ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../../packages/ui/src/*"]
     }
   },

--- a/plugins/sero-orchestrator-plugin/ui/components/StepModelControl.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/StepModelControl.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { isModelTier, MODEL_TIERS } from '@sero-ai/common';
 import type { AppModelGroup } from '@sero-ai/app-runtime';
-import { AvailableModelPicker } from '@sero-ai/ui/components/model-selection/available-model-picker';
+import { AvailableModelPicker } from '@sero-ai/ui/model-selection/available-model-picker';
 import { cn } from '@sero-ai/ui/lib/utils';
 import type { LoopStepDefinition } from '../../shared/types';
 

--- a/plugins/sero-orchestrator-plugin/ui/styles.css
+++ b/plugins/sero-orchestrator-plugin/ui/styles.css
@@ -1,3 +1,5 @@
 @import "@sero-ai/ui/styles/plugin.css";
+@import "@sero-ai/ui/styles/context-editor.css";
+@import "@sero-ai/ui/styles/model-selection.css";
 
 @source "./**/*.{ts,tsx}";

--- a/plugins/sero-orchestrator-plugin/ui/tsconfig.json
+++ b/plugins/sero-orchestrator-plugin/ui/tsconfig.json
@@ -13,6 +13,8 @@
       "@sero-ai/app-runtime": ["../../../packages/app-runtime/src/index.ts"],
       "@sero-ai/common": ["../../../packages/common/src/index.ts"],
       "@sero-ai/ui": ["../../../packages/ui/src/index.ts"],
+      "@sero-ai/ui/ai-elements/*": ["../../../packages/ui/src/components/ai-elements/*"],
+      "@sero-ai/ui/model-selection/*": ["../../../packages/ui/src/components/model-selection/*"],
       "@sero-ai/ui/*": ["../../../packages/ui/src/*"]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -675,6 +675,40 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@26.1.0)(msw@2.12.10(@types/node@26.1.1)(typescript@5.9.3))(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
 
+  packages/ui-test-consumer:
+    dependencies:
+      '@sero-ai/ui':
+        specifier: workspace:*
+        version: link:../ui
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@module-federation/vite':
+        specifier: 'catalog:'
+        version: 1.19.1(typescript@5.9.3)(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@tailwindcss/vite':
+        specifier: 'catalog:'
+        version: 4.1.18(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 4.7.0(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+
   plugins/sero-admin-plugin:
     dependencies:
       '@earendil-works/pi-ai':
@@ -8647,10 +8681,6 @@ packages:
 
   enhanced-resolve@5.18.0:
     resolution: {integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==}
-    engines: {node: '>=10.13.0'}
-
-  enhanced-resolve@5.24.2:
-    resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
     engines: {node: '>=10.13.0'}
 
   enhanced-resolve@5.24.3:
@@ -17185,6 +17215,18 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
+  '@module-federation/vite@1.19.1(typescript@5.9.3)(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@module-federation/dts-plugin': 2.8.0(typescript@5.9.3)
+      '@module-federation/runtime': 2.8.0
+      '@module-federation/sdk': 2.8.0
+      vite: 6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
   '@module-federation/webpack-bundler-runtime@0.14.0':
     dependencies:
       '@module-federation/runtime': 0.14.0
@@ -19556,7 +19598,7 @@ snapshots:
   '@tailwindcss/node@4.1.18':
     dependencies:
       '@jridgewell/remapping': 2.3.5
-      enhanced-resolve: 5.24.2
+      enhanced-resolve: 5.24.3
       jiti: 2.7.0
       lightningcss: 1.30.2
       magic-string: 0.30.21
@@ -19620,6 +19662,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+
+  '@tailwindcss/vite@4.1.18(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      tailwindcss: 4.1.18
+      vite: 6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tinyhttp/content-disposition@2.2.4': {}
 
@@ -20086,6 +20135,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 6.4.3(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -21974,11 +22035,6 @@ snapshots:
       - utf-8-validate
 
   enhanced-resolve@5.18.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
-  enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -28345,6 +28401,25 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.19.15
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      sass: 1.99.0
+      sass-embedded: 1.99.0
+      terser: 5.49.0
+      tsx: 4.21.0
+      yaml: 2.9.0
+
+  vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.99.0)(sass@1.99.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.23
+      rollup: 4.60.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0


### PR DESCRIPTION
Closes #307.

## What changed

- Keep the `@sero-ai/ui` root entry focused on primitives and dashboard components.
- Expose AI elements and model-selection components through stable subpath exports.
- Scope plugin CSS scanning so minimal consumers do not include AI/editor styles.
- Migrate host and built-in plugin imports to the new public subpaths.
- Add `packages/ui-test-consumer`, which validates source and published-package type and bundle boundaries.
- Extend the distribution smoke test and document the supported import paths.

## Why

The root UI barrel re-exported specialized AI/editor modules. A plugin importing only `Button` or `cn` could therefore traverse and bundle unrelated Mermaid, Shiki, graph, parser, and Streamdown dependencies.

External plugins that only consume primitives remain compatible and require no source changes. Notes, Logbook, ImageGen, and Google Mail/Calendar were tested against a packed build of the fixed UI package.

## Validation

- `pnpm typecheck` — 23/23 tasks passed
- `pnpm --filter @sero-ai/ui test` — 37/37 tests passed
- `pnpm --filter @sero-ai/ui smoke`
- `pnpm --filter @sero-ai/ui-test-consumer typecheck`
- `pnpm --filter @sero-ai/ui-test-consumer build`
- External Notes, Logbook, ImageGen, and Google plugin typechecks and production builds
- React Doctor: `@sero-ai/ui` 100/100
- `git diff --check`
