### PR TITLE
feat(orchestrator): add responsive plan map

### DIFF
--- a/docs/features/orchestration/sero-orchestrator/specs/09-ui-redesign.md
+++ b/docs/features/orchestration/sero-orchestrator/specs/09-ui-redesign.md
@@ -121,9 +121,11 @@ the sidebar list stays available in Detail for fast loop-to-loop movement.
 | `ui/components/LiveActivityStrip.tsx` | Running step + accumulated tokens/cost/elapsed (push). | <110 |
 | `ui/components/StepCard.tsx` | Extracted spine step card + tuning expander (keeps PlanView under cap). | <170 |
 | `ui/components/CreateLoopWizard.tsx` | D1→D2→D3 guided flow wrapper. | <180 |
+| `ui/components/PlanMap.tsx` | Read-only, responsive plan overview using HTML nodes over an SVG connector layer. | <300 |
+| `ui/components/PlanPresentation.tsx` | Map / Details switch and map orientation controls. | <100 |
 
 ### Rewritten / restructured
-- `PlanView.tsx` → C3 spine + C1 grouping (parallel boxed, branch grouped); delegates each step to `StepCard`.
+- `PlanView.tsx` → C3 spine + C1 grouping (parallel boxed, branch grouped); delegates each step to `StepCard` and remains the power-user Details view.
 - `LoopDetail.tsx` → B1 calm column; input request top-weighted; `LiveActivityStrip` when `runtime.activeRunId`; plan + history collapsible; Library folded in.
 - `OrchestratorApp.tsx` → adds Home view + nav; routes Create through the wizard.
 - `LoopList.tsx`, `LibraryBrowser.tsx`, controls → restyled to the visual system.
@@ -149,12 +151,32 @@ questions (`pendingInput.source === 'planner'`).
 
 1. **D1 Describe** — restyled create form: prompt first; safety options (worktree, dirty, activate) secondary.
 2. **D2 Clarify** — after `create`, if the new draft has `runtime.pendingInput` with `source: 'planner'`, render the questions inline (reuse `InputRequestCard` → `answer_input`); planner re-runs on submit.
-3. **D3 Review** — when the draft has a populated plan, show the read-only spine + `RefinePlan` + **Save draft** / **Activate**. A validation block surfaces here with refine/restart.
+3. **D3 Review** — when the draft has a populated plan, show the high-level map by default, with the editable spine behind **Details**, then `RefinePlan` + **Save draft** / **Activate**. A validation block surfaces here with refine/restart.
 
 The wizard tracks which stage the watched loop is in (no plan + pendingInput ⇒ D2; plan present ⇒ D3) and transitions on file updates — no polling.
 
-## 8. Out of scope (this pass)
-- React-Flow node graph (C4) — revisit only if a graph view is wanted later.
+## 8. Plan map
+
+The plan map is an overview, not a second workflow editor. It shows titles,
+dependency topology and live step state, with detail available by selecting a
+node or switching to the existing Details view.
+
+- **Auto** uses left-to-right flow in wide containers and top-to-bottom flow
+  below 760 px. Horizontal and Vertical can also be selected explicitly.
+- Nodes use fixed collision-free geometry. The entire stage scales to the
+  container, with zoom controls for closer inspection.
+- Runtime state changes colour and emphasis only. Nodes never move while a run
+  is executing; skipped routes dim rather than disappear.
+- Fan-out stays one durable node. Approval gates, branch decisions and bounded
+  feedback are compact markers; feedback uses a distinct outer return edge.
+- Planning shows a forming-map placeholder until the complete plan is
+  available. Incremental node streaming is out of scope.
+
+The implementation uses normal React nodes and one SVG connector layer. It adds
+no graph-layout or graph-rendering dependency.
+
+## 9. Out of scope (this pass)
+- Editable node graph, freeform positioning and plan authoring on the map.
 - B2 canvas + inspector — explicitly dropped.
 - Token-by-token live streaming — push-after-step only in v1.
 - Any change to planner/engine/recovery/library runtime logic.

--- a/plugins/sero-orchestrator-plugin/ui/__tests__/plan-map-layout.test.ts
+++ b/plugins/sero-orchestrator-plugin/ui/__tests__/plan-map-layout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { LoopStepDefinition } from '../../shared/types';
+import { computePlanMapLayout } from '../lib/plan-map-layout';
+
+const step = (
+  id: string,
+  dependsOn?: string[],
+  extra: Partial<LoopStepDefinition> = {},
+): LoopStepDefinition => ({
+  id,
+  title: id,
+  instructions: id,
+  dependsOn,
+  execution: { type: 'background-agent' },
+  ...extra,
+});
+
+const overlaps = (
+  a: { x: number; y: number; width: number; height: number },
+  b: { x: number; y: number; width: number; height: number },
+) =>
+  a.x < b.x + b.width
+  && a.x + a.width > b.x
+  && a.y < b.y + b.height
+  && a.y + a.height > b.y;
+
+describe('computePlanMapLayout', () => {
+  const branched = [
+    step('start'),
+    step('left', ['start']),
+    step('right', ['start']),
+    step('finish', ['left', 'right']),
+  ];
+
+  it.each(['horizontal', 'vertical'] as const)('keeps nodes collision-free in %s layout', (orientation) => {
+    const layout = computePlanMapLayout(branched, orientation);
+    for (const [index, node] of layout.nodes.entries()) {
+      for (const other of layout.nodes.slice(index + 1)) {
+        expect(overlaps(node, other), `${node.step.id} overlaps ${other.step.id}`).toBe(false);
+      }
+    }
+  });
+
+  it('lays dependency levels left to right in horizontal mode', () => {
+    const layout = computePlanMapLayout(branched, 'horizontal');
+    const byId = new Map(layout.nodes.map((node) => [node.step.id, node]));
+    expect(byId.get('start')!.x).toBeLessThan(byId.get('left')!.x);
+    expect(byId.get('left')!.x).toBeLessThan(byId.get('finish')!.x);
+  });
+
+  it('lays dependency levels top to bottom in vertical mode', () => {
+    const layout = computePlanMapLayout(branched, 'vertical');
+    const byId = new Map(layout.nodes.map((node) => [node.step.id, node]));
+    expect(byId.get('start')!.y).toBeLessThan(byId.get('left')!.y);
+    expect(byId.get('left')!.y).toBeLessThan(byId.get('finish')!.y);
+  });
+
+  it('includes every dependency and a distinct feedback edge', () => {
+    const steps = [
+      step('draft'),
+      step('review', ['draft'], {
+        feedback: {
+          id: 'revise',
+          toStepId: 'draft',
+          when: { var: 'approved', in: [false] },
+          maxTraversalsPerRun: 2,
+        },
+      }),
+    ];
+    const layout = computePlanMapLayout(steps, 'horizontal');
+    expect(layout.edges).toEqual([
+      expect.objectContaining({ fromStepId: 'draft', toStepId: 'review', feedback: false }),
+      expect.objectContaining({ id: 'revise', fromStepId: 'review', toStepId: 'draft', feedback: true }),
+    ]);
+  });
+});

--- a/plugins/sero-orchestrator-plugin/ui/__tests__/plan-map-state.test.ts
+++ b/plugins/sero-orchestrator-plugin/ui/__tests__/plan-map-state.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { Loop, LoopStepDefinition, StepStatus } from '../../shared/types';
+import { mapEdgeState, mapRouteState } from '../lib/plan-map-state';
+import { DEFAULT_LIMITS, DEFAULT_LOG_POLICY, DEFAULT_WORKSPACE_SETTINGS } from '../../shared/defaults';
+
+const step = (
+  id: string,
+  extra: Partial<LoopStepDefinition> = {},
+): LoopStepDefinition => ({
+  id,
+  title: id,
+  instructions: id,
+  execution: { type: 'background-agent' },
+  ...extra,
+});
+
+function loopWith(steps: LoopStepDefinition[], statuses: Record<string, StepStatus> = {}): Loop {
+  const now = '2026-07-27T00:00:00.000Z';
+  return {
+    id: 'map',
+    workspaceId: 'workspace',
+    title: 'Map',
+    prompt: 'Map',
+    summary: 'Map',
+    status: 'active',
+    workspace: { ...DEFAULT_WORKSPACE_SETTINGS },
+    plan: { schemaVersion: 1, revision: 1, objective: 'Map', steps },
+    runtime: {
+      parentSessionId: 'parent',
+      variables: {},
+      stepStates: Object.fromEntries(steps.map((candidate) => [
+        candidate.id,
+        { status: statuses[candidate.id] ?? 'pending', attempts: 0, updatedAt: now },
+      ])),
+      workspace: {},
+    },
+    triggers: [],
+    limits: { ...DEFAULT_LIMITS },
+    logPolicy: { ...DEFAULT_LOG_POLICY },
+    warnings: [],
+    runs: [],
+    revisions: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe('plan map runtime state', () => {
+  it('keeps guarded routes undecided until their variable exists', () => {
+    const guarded = step('guarded', { when: { var: 'route', in: ['yes'] } });
+    expect(mapRouteState(loopWith([guarded]), guarded)).toBe('undecided');
+  });
+
+  it('marks only the matching branch as taken', () => {
+    const yes = step('yes', { when: { var: 'route', in: ['yes'] } });
+    const fallback = step('fallback', { when: { var: 'route', default: true } });
+    const loop = loopWith([yes, fallback]);
+    loop.runtime.variables.route = 'yes';
+    expect(mapRouteState(loop, yes)).toBe('taken');
+    expect(mapRouteState(loop, fallback)).toBe('not-taken');
+  });
+
+  it('takes the default route for an unlisted value', () => {
+    const explicit = step('explicit', { when: { var: 'route', in: ['known'] } });
+    const fallback = step('fallback', { when: { var: 'route', default: true } });
+    const loop = loopWith([explicit, fallback]);
+    loop.runtime.variables.route = 'other';
+    expect(mapRouteState(loop, fallback)).toBe('taken');
+  });
+
+  it('uses the destination status to colour an edge', () => {
+    const loop = loopWith([step('a'), step('b')], { a: 'succeeded', b: 'running' });
+    expect(mapEdgeState(loop, 'a', 'b')).toBe('running');
+    loop.runtime.stepStates.b.status = 'skipped';
+    expect(mapEdgeState(loop, 'a', 'b')).toBe('skipped');
+  });
+});

--- a/plugins/sero-orchestrator-plugin/ui/components/CreateLoopWizard.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/CreateLoopWizard.tsx
@@ -10,14 +10,15 @@
 
 import { useState } from 'react';
 import { Button, Card } from '@sero-ai/ui';
-import { Loader2, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
 import type { Loop, OrchestratorAction } from '../../shared/types';
 import { useWatchedJson } from '../lib/use-watched-json';
 import { deriveCreateStage, type CreateStage as Stage } from '../lib/create-stage';
 import { CreateLoopForm, type CreateLoopSubmit } from './CreateLoopForm';
 import { InputRequestCard } from './InputRequestCard';
 import { LoopMetaStrip } from './LoopMetaStrip';
-import { PlanView } from './PlanView';
+import { PlanMapSkeleton } from './PlanMap';
+import { PlanPresentation } from './PlanPresentation';
 import { RefinePlan } from './RefinePlan';
 
 interface CreateLoopWizardProps {
@@ -58,9 +59,7 @@ export function CreateLoopWizard({ busy, stateDir, onCreate, onAction, onOpenLoo
       {stage === 'describe' && <CreateLoopForm busy={busy} onSubmit={create} onCancel={onCancel} />}
 
       {stage === 'planning' && (
-        <Card className="flex items-center gap-2 p-4 text-base text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" /> The AI is writing the plan…
-        </Card>
+        <PlanMapSkeleton />
       )}
 
       {stage === 'clarify' && loop && (
@@ -83,7 +82,7 @@ export function CreateLoopWizard({ busy, stateDir, onCreate, onAction, onOpenLoo
               {loop.runtime.block.reason} — refine below, or cancel and try a clearer prompt.
             </Card>
           )}
-          <PlanView loop={loop} onAction={onAction} />
+          <PlanPresentation loop={loop} onAction={onAction} />
           <RefinePlan busy={busy} onRefine={(prompt) => onAction({ kind: 'revise', loopId: loop.id, prompt })} />
           <div className="flex justify-end gap-2">
             <Button variant="ghost" disabled={busy} onClick={() => onOpenLoop(loop.id)}>Save as draft</Button>

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
@@ -120,7 +120,11 @@ export function LoopDetail({ loop, busy, onAction, stateDir, libraryDir, library
       )}
 
       <CollapsibleSection title="Plan" hint={`${loop.plan.steps.length} step(s)`} defaultOpen>
-        <MemoizedPlanPresentation loop={loop} onAction={onAction} />
+        <MemoizedPlanPresentation
+          key={`${loop.id}:${loop.status === 'draft' ? 'draft' : 'live'}`}
+          loop={loop}
+          onAction={onAction}
+        />
         {REFINABLE.has(loop.status) && (
           <RefinePlan key={loop.id} busy={busy} onRefine={(prompt) => onAction({ kind: 'revise', loopId: loop.id, prompt })} />
         )}

--- a/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/LoopDetail.tsx
@@ -22,14 +22,14 @@ import { LibraryLinkBadge } from './LibraryLinkBadge';
 import { LibraryLinkSection } from './LibraryLinkSection';
 import { LiveActivityStrip } from './LiveActivityStrip';
 import { CollapsibleSection } from './CollapsibleSection';
-import { PlanView } from './PlanView';
+import { PlanPresentation } from './PlanPresentation';
 import { RefinePlan } from './RefinePlan';
 import { AttemptHistory } from './AttemptHistory';
 import { SuggestionsInbox } from './SuggestionsInbox';
 import { InputRequestCard } from './InputRequestCard';
 
 const REFINABLE: ReadonlySet<Loop['status']> = new Set(['draft', 'active', 'disabled', 'blocked']);
-const MemoizedPlanView = memo(PlanView);
+const MemoizedPlanPresentation = memo(PlanPresentation);
 
 interface LoopDetailProps {
   loop: Loop;
@@ -120,7 +120,7 @@ export function LoopDetail({ loop, busy, onAction, stateDir, libraryDir, library
       )}
 
       <CollapsibleSection title="Plan" hint={`${loop.plan.steps.length} step(s)`} defaultOpen>
-        <MemoizedPlanView loop={loop} onAction={onAction} />
+        <MemoizedPlanPresentation loop={loop} onAction={onAction} />
         {REFINABLE.has(loop.status) && (
           <RefinePlan key={loop.id} busy={busy} onRefine={(prompt) => onAction({ kind: 'revise', loopId: loop.id, prompt })} />
         )}

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
@@ -84,7 +84,11 @@ export function PlanMap({ loop, orientation }: PlanMapProps) {
     [loop.plan.steps, resolvedOrientation],
   );
   const fit = containerWidth > 0 ? Math.min(1, Math.max(0.25, (containerWidth - 2) / layout.width)) : 1;
-  const scale = Math.min(MAX_SCALE, Math.max(fit * MIN_ZOOM_MULTIPLIER, fit * zoom));
+  const minimumScale = fit * MIN_ZOOM_MULTIPLIER;
+  const scale = Math.min(MAX_SCALE, Math.max(minimumScale, fit * zoom));
+  const setScale = (nextScale: number) => {
+    setZoom(Math.min(MAX_SCALE, Math.max(minimumScale, nextScale)) / fit);
+  };
   const selected = loop.plan.steps.find((step) => step.id === selectedId);
 
   if (loop.plan.steps.length === 0) {
@@ -108,8 +112,8 @@ export function PlanMap({ loop, orientation }: PlanMapProps) {
             size="icon-xs"
             aria-label="Zoom out"
             title="Zoom out"
-            disabled={zoom <= MIN_ZOOM_MULTIPLIER}
-            onClick={() => setZoom((value) => Math.max(MIN_ZOOM_MULTIPLIER, value - ZOOM_STEP / fit))}
+            disabled={scale <= minimumScale}
+            onClick={() => setScale(scale - ZOOM_STEP)}
           >
             <ZoomOut />
           </Button>
@@ -122,7 +126,7 @@ export function PlanMap({ loop, orientation }: PlanMapProps) {
             aria-label="Zoom in"
             title="Zoom in"
             disabled={scale >= MAX_SCALE}
-            onClick={() => setZoom((value) => Math.min(MAX_SCALE / fit, value + ZOOM_STEP / fit))}
+            onClick={() => setScale(scale + ZOOM_STEP)}
           >
             <ZoomIn />
           </Button>

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Badge, Button, Card } from '@sero-ai/ui';
+import {
+  Bot,
+  Check,
+  Circle,
+  GitBranch,
+  Maximize2,
+  MessageSquare,
+  ShieldCheck,
+  Sparkles,
+  Users,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
+import type { Loop, LoopStepDefinition, StepStatus } from '../../shared/types';
+import {
+  computePlanMapLayout,
+  type PlanMapEdge,
+  type PlanMapOrientation,
+} from '../lib/plan-map-layout';
+import { mapEdgeState, mapRouteState } from '../lib/plan-map-state';
+import { STEP_STATUS_STYLE } from '../lib/status-style';
+import { guardLabel } from './StepCard';
+
+export type PlanMapOrientationSetting = PlanMapOrientation | 'auto';
+
+interface PlanMapProps {
+  loop: Loop;
+  orientation: PlanMapOrientationSetting;
+}
+
+const NODE_STATUS_CLASS: Record<StepStatus, string> = {
+  pending: 'border-border bg-card',
+  ready: 'border-emerald-500/40 bg-emerald-500/[0.04]',
+  running: 'border-emerald-400/70 bg-emerald-500/[0.08] shadow-[0_0_18px_rgba(52,211,153,0.12)]',
+  succeeded: 'border-emerald-500/35 bg-emerald-500/[0.04]',
+  failed: 'border-rose-500/55 bg-rose-500/[0.07]',
+  blocked: 'border-amber-500/55 bg-amber-500/[0.07]',
+  skipped: 'border-border/70 bg-card opacity-45',
+  'needs-revision': 'border-amber-500/55 bg-amber-500/[0.07]',
+};
+
+const EDGE_STATUS_CLASS: Record<StepStatus, string> = {
+  pending: 'text-border',
+  ready: 'text-emerald-500/45',
+  running: 'text-emerald-400',
+  succeeded: 'text-emerald-500/65',
+  failed: 'text-rose-500/70',
+  blocked: 'text-amber-500/70',
+  skipped: 'text-border/45',
+  'needs-revision': 'text-amber-500/70',
+};
+
+const MIN_ZOOM = 0.7;
+const MAX_ZOOM = 1.9;
+const ZOOM_STEP = 0.15;
+
+export function PlanMap({ loop, orientation }: PlanMapProps) {
+  const markerPrefix = useId().replaceAll(':', '');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [zoom, setZoom] = useState(1);
+  const [selectedId, setSelectedId] = useState<string>();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const updateWidth = () => setContainerWidth(container.clientWidth);
+    updateWidth();
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  const resolvedOrientation: PlanMapOrientation =
+    orientation === 'auto'
+      ? containerWidth > 0 && containerWidth < 760 ? 'vertical' : 'horizontal'
+      : orientation;
+  const layout = useMemo(
+    () => computePlanMapLayout(loop.plan.steps, resolvedOrientation),
+    [loop.plan.steps, resolvedOrientation],
+  );
+  const fit = containerWidth > 0 ? Math.min(1, Math.max(0.25, (containerWidth - 2) / layout.width)) : 1;
+  const scale = fit * zoom;
+  const selected = loop.plan.steps.find((step) => step.id === selectedId);
+
+  if (loop.plan.steps.length === 0) {
+    return (
+      <Card className="p-3 text-base text-muted-foreground">
+        No plan generated yet. Creating a loop asks the model to author the steps for your prompt.
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden border-border/80 bg-background/30">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border/70 px-2 py-1.5">
+        <span className="px-1 text-xs text-muted-foreground">
+          {resolvedOrientation === 'horizontal' ? 'Left to right' : 'Top to bottom'}
+          {orientation === 'auto' && ' · Auto'}
+        </span>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Zoom out"
+            title="Zoom out"
+            disabled={zoom <= MIN_ZOOM}
+            onClick={() => setZoom((value) => Math.max(MIN_ZOOM, value - ZOOM_STEP))}
+          >
+            <ZoomOut />
+          </Button>
+          <span className="w-10 text-center text-xs tabular-nums text-muted-foreground">
+            {Math.round(scale * 100)}%
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Zoom in"
+            title="Zoom in"
+            disabled={zoom >= MAX_ZOOM}
+            onClick={() => setZoom((value) => Math.min(MAX_ZOOM, value + ZOOM_STEP))}
+          >
+            <ZoomIn />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label="Fit map"
+            title="Fit map"
+            disabled={zoom === 1}
+            onClick={() => setZoom(1)}
+          >
+            <Maximize2 />
+          </Button>
+        </div>
+      </div>
+
+      <div ref={containerRef} className="max-h-[560px] min-h-52 overflow-auto">
+        <div style={{ width: layout.width * scale, height: layout.height * scale }}>
+          <div
+            className="relative origin-top-left"
+            style={{ width: layout.width, height: layout.height, transform: `scale(${scale})` }}
+          >
+            <svg className="absolute inset-0 overflow-visible" width={layout.width} height={layout.height} aria-hidden>
+              <defs>
+                <marker id={`${markerPrefix}-arrow`} viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+                  <path d="M 0 0 L 8 4 L 0 8 Z" fill="context-stroke" />
+                </marker>
+                <marker id={`${markerPrefix}-feedback-arrow`} viewBox="0 0 8 8" refX="7" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+                  <path d="M 0 0 L 8 4 L 0 8 Z" fill="context-stroke" />
+                </marker>
+              </defs>
+              {layout.edges.map((edge) => (
+                <MapEdge key={`${edge.feedback ? 'feedback' : 'dependency'}:${edge.id}`} edge={edge} loop={loop} markerPrefix={markerPrefix} />
+              ))}
+            </svg>
+
+            {layout.nodes.map((node) => (
+              <MapNode
+                key={node.step.id}
+                loop={loop}
+                step={node.step}
+                number={node.number}
+                selected={selectedId === node.step.id}
+                onSelect={() => setSelectedId((current) => current === node.step.id ? undefined : node.step.id)}
+                style={{ left: node.x, top: node.y, width: node.width, height: node.height }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {selected && <SelectedStep loop={loop} step={selected} />}
+    </Card>
+  );
+}
+
+function MapEdge({ edge, loop, markerPrefix }: { edge: PlanMapEdge; loop: Loop; markerPrefix: string }) {
+  const status = mapEdgeState(loop, edge.fromStepId, edge.toStepId);
+  const traversals = edge.feedback ? loop.runtime.feedbackStates?.[edge.id]?.traversals ?? 0 : 0;
+  const statusClass = edge.feedback
+    ? traversals > 0 ? 'text-violet-400' : 'text-violet-500/55'
+    : EDGE_STATUS_CLASS[status];
+
+  return (
+    <path
+      d={edge.path}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={edge.feedback ? 1.75 : 1.5}
+      strokeDasharray={edge.feedback ? '5 4' : undefined}
+      markerEnd={`url(#${markerPrefix}-${edge.feedback ? 'feedback-arrow' : 'arrow'})`}
+      className={`transition-colors ${statusClass}`}
+    />
+  );
+}
+
+interface MapNodeProps {
+  loop: Loop;
+  step: LoopStepDefinition;
+  number: number;
+  selected: boolean;
+  onSelect: () => void;
+  style: React.CSSProperties;
+}
+
+function MapNode({ loop, step, number, selected, onSelect, style }: MapNodeProps) {
+  const status = loop.runtime.stepStates[step.id]?.status ?? 'pending';
+  const routeState = mapRouteState(loop, step);
+  const statusStyle = STEP_STATUS_STYLE[status];
+
+  return (
+    <button
+      type="button"
+      className={`absolute flex flex-col justify-between rounded-md border p-2.5 text-left transition-all hover:border-foreground/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${NODE_STATUS_CLASS[status]} ${routeState === 'not-taken' ? 'opacity-45' : ''} ${selected ? 'ring-2 ring-sky-500/60' : ''}`}
+      style={style}
+      onClick={onSelect}
+      aria-pressed={selected}
+      title={step.title}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <span className="text-xs tabular-nums text-muted-foreground">{number}</span>
+        <span className="truncate text-base font-medium">{step.title}</span>
+      </span>
+      <span className="flex items-center justify-between gap-2">
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <span className={`h-1.5 w-1.5 rounded-full ${statusStyle.dot} ${status === 'running' ? 'animate-pulse' : ''}`} />
+          {statusStyle.label}
+        </span>
+        <span className="flex items-center gap-1 text-muted-foreground">
+          {step.produces?.length ? <GitBranch className="h-3.5 w-3.5" aria-label="Decision" /> : null}
+          {step.when ? <Circle className="h-3.5 w-3.5" aria-label="Conditional route" /> : null}
+          {step.gate ? <ShieldCheck className="h-3.5 w-3.5" aria-label="Approval gate" /> : null}
+          {step.fanOut ? <span className="text-xs" aria-label={`Up to ${step.fanOut.maxItems} parallel items`}>×{step.fanOut.maxItems}</span> : null}
+          {step.feedback ? <span className="text-xs text-violet-400" aria-label="Feedback route">↩</span> : null}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function SelectedStep({ loop, step }: { loop: Loop; step: LoopStepDefinition }) {
+  const state = loop.runtime.stepStates[step.id];
+  const executionIcon = step.execution.type === 'background-agent'
+    ? <Bot className="h-3.5 w-3.5" />
+    : step.execution.type === 'active-session'
+      ? <MessageSquare className="h-3.5 w-3.5" />
+      : <Sparkles className="h-3.5 w-3.5" />;
+
+  return (
+    <div className="flex flex-wrap items-start gap-x-4 gap-y-2 border-t border-border/70 px-3 py-2.5 text-xs">
+      <div className="flex min-w-40 items-center gap-2 font-medium">
+        {state?.status === 'succeeded' ? <Check className="h-3.5 w-3.5 text-emerald-400" /> : executionIcon}
+        {step.title}
+      </div>
+      <p className="min-w-0 flex-1 text-muted-foreground">{step.instructions}</p>
+      <div className="flex flex-wrap gap-1">
+        <Badge variant="outline" className="text-xs font-normal">{step.execution.type}</Badge>
+        {step.when && <Badge variant="outline" className="text-xs font-normal">{guardLabel(step.when)}</Badge>}
+        {step.fanOut && <Badge variant="outline" className="text-xs font-normal"><Users className="mr-1 h-3 w-3" /> up to {step.fanOut.maxItems}</Badge>}
+      </div>
+    </div>
+  );
+}
+
+export function PlanMapSkeleton() {
+  return (
+    <Card className="overflow-hidden p-4">
+      <div className="mb-4 flex items-center gap-2 text-base text-muted-foreground">
+        <Sparkles className="h-4 w-4 animate-pulse text-sky-400" />
+        The AI is shaping the plan…
+      </div>
+      <div className="flex min-h-40 flex-wrap items-center justify-center gap-5">
+        {[0, 1, 2, 3].map((index) => (
+          <div key={index} className="flex items-center gap-5">
+            {index > 0 && <span className="h-px w-6 bg-border" />}
+            <div className="h-16 w-36 animate-pulse rounded-md border border-border bg-muted/35" />
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 import { Badge, Button, Card } from '@sero-ai/ui';
 import {
   Bot,
@@ -52,25 +52,27 @@ const EDGE_STATUS_CLASS: Record<StepStatus, string> = {
   'needs-revision': 'text-amber-500/70',
 };
 
-const MIN_ZOOM = 0.7;
-const MAX_ZOOM = 1.9;
+const MIN_ZOOM_MULTIPLIER = 0.7;
+const MAX_SCALE = 1.9;
 const ZOOM_STEP = 0.15;
+
+function observeContainerWidth(container: HTMLDivElement, onWidthChange: (width: number) => void) {
+  const updateWidth = () => onWidthChange(container.clientWidth);
+  updateWidth();
+  const observer = new ResizeObserver(updateWidth);
+  observer.observe(container);
+  return () => observer.disconnect();
+}
 
 export function PlanMap({ loop, orientation }: PlanMapProps) {
   const markerPrefix = useId().replaceAll(':', '');
-  const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [zoom, setZoom] = useState(1);
   const [selectedId, setSelectedId] = useState<string>();
 
-  useEffect(() => {
-    const container = containerRef.current;
+  const setContainerRef = useCallback((container: HTMLDivElement | null) => {
     if (!container) return;
-    const updateWidth = () => setContainerWidth(container.clientWidth);
-    updateWidth();
-    const observer = new ResizeObserver(updateWidth);
-    observer.observe(container);
-    return () => observer.disconnect();
+    return observeContainerWidth(container, setContainerWidth);
   }, []);
 
   const resolvedOrientation: PlanMapOrientation =
@@ -82,7 +84,7 @@ export function PlanMap({ loop, orientation }: PlanMapProps) {
     [loop.plan.steps, resolvedOrientation],
   );
   const fit = containerWidth > 0 ? Math.min(1, Math.max(0.25, (containerWidth - 2) / layout.width)) : 1;
-  const scale = fit * zoom;
+  const scale = Math.min(MAX_SCALE, Math.max(fit * MIN_ZOOM_MULTIPLIER, fit * zoom));
   const selected = loop.plan.steps.find((step) => step.id === selectedId);
 
   if (loop.plan.steps.length === 0) {
@@ -106,8 +108,8 @@ export function PlanMap({ loop, orientation }: PlanMapProps) {
             size="icon-xs"
             aria-label="Zoom out"
             title="Zoom out"
-            disabled={zoom <= MIN_ZOOM}
-            onClick={() => setZoom((value) => Math.max(MIN_ZOOM, value - ZOOM_STEP))}
+            disabled={zoom <= MIN_ZOOM_MULTIPLIER}
+            onClick={() => setZoom((value) => Math.max(MIN_ZOOM_MULTIPLIER, value - ZOOM_STEP / fit))}
           >
             <ZoomOut />
           </Button>
@@ -119,8 +121,8 @@ export function PlanMap({ loop, orientation }: PlanMapProps) {
             size="icon-xs"
             aria-label="Zoom in"
             title="Zoom in"
-            disabled={zoom >= MAX_ZOOM}
-            onClick={() => setZoom((value) => Math.min(MAX_ZOOM, value + ZOOM_STEP))}
+            disabled={scale >= MAX_SCALE}
+            onClick={() => setZoom((value) => Math.min(MAX_SCALE / fit, value + ZOOM_STEP / fit))}
           >
             <ZoomIn />
           </Button>
@@ -137,7 +139,7 @@ export function PlanMap({ loop, orientation }: PlanMapProps) {
         </div>
       </div>
 
-      <div ref={containerRef} className="max-h-[560px] min-h-52 overflow-auto">
+      <div ref={setContainerRef} className="max-h-[560px] min-h-52 overflow-auto [scrollbar-gutter:stable]">
         <div style={{ width: layout.width * scale, height: layout.height * scale }}>
           <div
             className="relative origin-top-left"

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanPresentation.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanPresentation.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { ToggleGroup, ToggleGroupItem } from '@sero-ai/ui';
+import { Columns3, ListTree, Map, Rows3 } from 'lucide-react';
+import type { Loop, OrchestratorAction } from '../../shared/types';
+import { PlanMap, type PlanMapOrientationSetting } from './PlanMap';
+import { PlanView } from './PlanView';
+
+type PlanPresentationMode = 'map' | 'details';
+
+interface PlanPresentationProps {
+  loop: Loop;
+  onAction: (action: OrchestratorAction) => void;
+}
+
+export function PlanPresentation({ loop, onAction }: PlanPresentationProps) {
+  const [mode, setMode] = useState<PlanPresentationMode>('map');
+  const [orientation, setOrientation] = useState<PlanMapOrientationSetting>('auto');
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ToggleGroup
+          type="single"
+          variant="outline"
+          size="sm"
+          value={mode}
+          onValueChange={(value) => value && setMode(value as PlanPresentationMode)}
+          aria-label="Plan presentation"
+        >
+          <ToggleGroupItem value="map"><Map /> Map</ToggleGroupItem>
+          <ToggleGroupItem value="details"><ListTree /> Details</ToggleGroupItem>
+        </ToggleGroup>
+
+        {mode === 'map' && (
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            size="sm"
+            value={orientation}
+            onValueChange={(value) => value && setOrientation(value as PlanMapOrientationSetting)}
+            aria-label="Map direction"
+          >
+            <ToggleGroupItem value="auto">Auto</ToggleGroupItem>
+            <ToggleGroupItem value="horizontal"><Columns3 /> Horizontal</ToggleGroupItem>
+            <ToggleGroupItem value="vertical"><Rows3 /> Vertical</ToggleGroupItem>
+          </ToggleGroup>
+        )}
+      </div>
+
+      {mode === 'map'
+        ? <PlanMap loop={loop} orientation={orientation} />
+        : <PlanView loop={loop} onAction={onAction} />}
+    </div>
+  );
+}

--- a/plugins/sero-orchestrator-plugin/ui/components/PlanPresentation.tsx
+++ b/plugins/sero-orchestrator-plugin/ui/components/PlanPresentation.tsx
@@ -13,7 +13,7 @@ interface PlanPresentationProps {
 }
 
 export function PlanPresentation({ loop, onAction }: PlanPresentationProps) {
-  const [mode, setMode] = useState<PlanPresentationMode>('map');
+  const [mode, setMode] = useState<PlanPresentationMode>(loop.status === 'draft' ? 'map' : 'details');
   const [orientation, setOrientation] = useState<PlanMapOrientationSetting>('auto');
 
   return (

--- a/plugins/sero-orchestrator-plugin/ui/lib/plan-map-layout.ts
+++ b/plugins/sero-orchestrator-plugin/ui/lib/plan-map-layout.ts
@@ -83,24 +83,25 @@ export function computePlanMapLayout(
   const edges: PlanMapEdge[] = [];
 
   for (const target of nodes) {
-    for (const dependencyId of target.step.dependsOn ?? []) {
+    const targetStep = target.step;
+    for (const dependencyId of targetStep.dependsOn ?? []) {
       const source = byId.get(dependencyId);
       if (!source) continue;
       edges.push({
-        id: `${dependencyId}->${target.step.id}`,
+        id: `${dependencyId}->${targetStep.id}`,
         fromStepId: dependencyId,
-        toStepId: target.step.id,
+        toStepId: targetStep.id,
         path: forwardPath(source, target, orientation),
         feedback: false,
       });
     }
 
-    const feedback = target.step.feedback;
+    const feedback = targetStep.feedback;
     const feedbackTarget = feedback ? byId.get(feedback.toStepId) : undefined;
     if (feedback && feedbackTarget) {
       edges.push({
         id: feedback.id,
-        fromStepId: target.step.id,
+        fromStepId: targetStep.id,
         toStepId: feedbackTarget.step.id,
         path: feedbackPath(target, feedbackTarget, orientation, width, height),
         feedback: true,

--- a/plugins/sero-orchestrator-plugin/ui/lib/plan-map-layout.ts
+++ b/plugins/sero-orchestrator-plugin/ui/lib/plan-map-layout.ts
@@ -1,0 +1,158 @@
+import type { LoopStepDefinition } from '../../shared/types';
+import { groupStepsByLevel } from './plan-levels';
+
+export type PlanMapOrientation = 'horizontal' | 'vertical';
+
+export interface PlanMapNode {
+  step: LoopStepDefinition;
+  number: number;
+  level: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PlanMapEdge {
+  id: string;
+  fromStepId: string;
+  toStepId: string;
+  path: string;
+  feedback: boolean;
+}
+
+export interface PlanMapLayout {
+  width: number;
+  height: number;
+  nodes: PlanMapNode[];
+  edges: PlanMapEdge[];
+}
+
+export const PLAN_MAP_NODE_WIDTH = 176;
+export const PLAN_MAP_NODE_HEIGHT = 64;
+
+const LEVEL_GAP = 72;
+const LANE_GAP = 18;
+const PADDING = 32;
+const FEEDBACK_GUTTER = 30;
+
+export function computePlanMapLayout(
+  steps: LoopStepDefinition[],
+  orientation: PlanMapOrientation,
+): PlanMapLayout {
+  if (steps.length === 0) return { width: 0, height: 0, nodes: [], edges: [] };
+
+  const levels = groupStepsByLevel(steps);
+  const maxLaneCount = Math.max(...levels.map((level) => level.length));
+  const hasFeedback = steps.some((step) => step.feedback);
+  const outerPadding = PADDING + (hasFeedback ? FEEDBACK_GUTTER : 0);
+
+  const horizontal = orientation === 'horizontal';
+  const contentWidth = horizontal
+    ? levels.length * PLAN_MAP_NODE_WIDTH + (levels.length - 1) * LEVEL_GAP
+    : maxLaneCount * PLAN_MAP_NODE_WIDTH + (maxLaneCount - 1) * LANE_GAP;
+  const contentHeight = horizontal
+    ? maxLaneCount * PLAN_MAP_NODE_HEIGHT + (maxLaneCount - 1) * LANE_GAP
+    : levels.length * PLAN_MAP_NODE_HEIGHT + (levels.length - 1) * LEVEL_GAP;
+  const width = contentWidth + outerPadding * 2;
+  const height = contentHeight + outerPadding * 2;
+  const numberById = new Map(steps.map((step, index) => [step.id, index + 1]));
+
+  const nodes = levels.flatMap((levelSteps, level) => {
+    const laneSpan = horizontal
+      ? levelSteps.length * PLAN_MAP_NODE_HEIGHT + (levelSteps.length - 1) * LANE_GAP
+      : levelSteps.length * PLAN_MAP_NODE_WIDTH + (levelSteps.length - 1) * LANE_GAP;
+    const laneOffset = (horizontal ? contentHeight - laneSpan : contentWidth - laneSpan) / 2;
+
+    return levelSteps.map((step, lane) => ({
+      step,
+      number: numberById.get(step.id)!,
+      level,
+      x: horizontal
+        ? outerPadding + level * (PLAN_MAP_NODE_WIDTH + LEVEL_GAP)
+        : outerPadding + laneOffset + lane * (PLAN_MAP_NODE_WIDTH + LANE_GAP),
+      y: horizontal
+        ? outerPadding + laneOffset + lane * (PLAN_MAP_NODE_HEIGHT + LANE_GAP)
+        : outerPadding + level * (PLAN_MAP_NODE_HEIGHT + LEVEL_GAP),
+      width: PLAN_MAP_NODE_WIDTH,
+      height: PLAN_MAP_NODE_HEIGHT,
+    }));
+  });
+
+  const byId = new Map(nodes.map((node) => [node.step.id, node]));
+  const edges: PlanMapEdge[] = [];
+
+  for (const target of nodes) {
+    for (const dependencyId of target.step.dependsOn ?? []) {
+      const source = byId.get(dependencyId);
+      if (!source) continue;
+      edges.push({
+        id: `${dependencyId}->${target.step.id}`,
+        fromStepId: dependencyId,
+        toStepId: target.step.id,
+        path: forwardPath(source, target, orientation),
+        feedback: false,
+      });
+    }
+
+    const feedback = target.step.feedback;
+    const feedbackTarget = feedback ? byId.get(feedback.toStepId) : undefined;
+    if (feedback && feedbackTarget) {
+      edges.push({
+        id: feedback.id,
+        fromStepId: target.step.id,
+        toStepId: feedbackTarget.step.id,
+        path: feedbackPath(target, feedbackTarget, orientation, width, height),
+        feedback: true,
+      });
+    }
+  }
+
+  return { width, height, nodes, edges };
+}
+
+function forwardPath(
+  source: PlanMapNode,
+  target: PlanMapNode,
+  orientation: PlanMapOrientation,
+): string {
+  if (orientation === 'horizontal') {
+    const fromX = source.x + source.width;
+    const fromY = source.y + source.height / 2;
+    const toX = target.x;
+    const toY = target.y + target.height / 2;
+    const controlX = (fromX + toX) / 2;
+    return `M ${fromX} ${fromY} C ${controlX} ${fromY}, ${controlX} ${toY}, ${toX} ${toY}`;
+  }
+
+  const fromX = source.x + source.width / 2;
+  const fromY = source.y + source.height;
+  const toX = target.x + target.width / 2;
+  const toY = target.y;
+  const controlY = (fromY + toY) / 2;
+  return `M ${fromX} ${fromY} C ${fromX} ${controlY}, ${toX} ${controlY}, ${toX} ${toY}`;
+}
+
+function feedbackPath(
+  source: PlanMapNode,
+  target: PlanMapNode,
+  orientation: PlanMapOrientation,
+  width: number,
+  height: number,
+): string {
+  if (orientation === 'horizontal') {
+    const fromX = source.x + source.width / 2;
+    const fromY = source.y + source.height;
+    const toX = target.x + target.width / 2;
+    const toY = target.y + target.height;
+    const outerY = height - PADDING / 2;
+    return `M ${fromX} ${fromY} C ${fromX} ${outerY}, ${toX} ${outerY}, ${toX} ${toY}`;
+  }
+
+  const fromX = source.x + source.width;
+  const fromY = source.y + source.height / 2;
+  const toX = target.x + target.width;
+  const toY = target.y + target.height / 2;
+  const outerX = width - PADDING / 2;
+  return `M ${fromX} ${fromY} C ${outerX} ${fromY}, ${outerX} ${toY}, ${toX} ${toY}`;
+}

--- a/plugins/sero-orchestrator-plugin/ui/lib/plan-map-state.ts
+++ b/plugins/sero-orchestrator-plugin/ui/lib/plan-map-state.ts
@@ -1,0 +1,30 @@
+import type { Loop, LoopStepDefinition, StepStatus } from '../../shared/types';
+
+export type MapRouteState = 'undecided' | 'taken' | 'not-taken';
+
+export function mapRouteState(loop: Loop, step: LoopStepDefinition): MapRouteState {
+  const runtimeStatus = loop.runtime.stepStates[step.id]?.status;
+  if (runtimeStatus === 'skipped') return 'not-taken';
+  if (!step.when) return 'taken';
+
+  const value = loop.runtime.variables[step.when.var];
+  if (value === undefined) return 'undecided';
+  if (step.when.in) return step.when.in.includes(value as string | number | boolean) ? 'taken' : 'not-taken';
+
+  const siblingMatched = loop.plan.steps.some((candidate) =>
+    candidate.id !== step.id
+    && candidate.when?.var === step.when?.var
+    && candidate.when?.in?.includes(value as string | number | boolean),
+  );
+  return siblingMatched ? 'not-taken' : 'taken';
+}
+
+export function mapEdgeState(loop: Loop, fromStepId: string, toStepId: string): StepStatus {
+  const target = loop.runtime.stepStates[toStepId]?.status;
+  const source = loop.runtime.stepStates[fromStepId]?.status;
+  if (target === 'skipped') return 'skipped';
+  if (target === 'failed' || target === 'blocked' || target === 'needs-revision') return target;
+  if (target === 'running' || source === 'running') return 'running';
+  if (target === 'succeeded') return 'succeeded';
+  return target ?? source ?? 'pending';
+}


### PR DESCRIPTION
## Summary

- add a restrained, read-only plan map alongside the existing detailed plan view
- support Auto, Horizontal and Vertical layouts with fit-to-container scaling and zoom
- overlay live execution, branch, fan-out, approval and bounded-feedback state without changing topology
- reuse the map in loop creation review and live loop detail
- document the responsive behaviour and add layout/runtime-state tests

## Why

The detailed plan view remains useful for power users, but it is too dense for quickly understanding plan shape and execution progress. This adds a lightweight overview without introducing a graph-rendering dependency.

## Validation

- Orchestrator production build passed
- Orchestrator test suite passed: 812 tests
- 23 of 24 root typecheck tasks passed; the homepage check is blocked only because Astro telemetry cannot create `/root/.config/astro` in this environment
- all touched source files remain below the 500-line limit