### PR TITLE
Fix macOS menu bar app name in dev and packaged builds

### DIFF
--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -19,6 +19,14 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
 import path from 'path';
 import type { SettingsPackageSource } from '../src/types/ipc';
 
+// electron-builder's `productName: Sero` only names the packaged macOS app
+// bundle. In dev mode (`electron .`), the process name — and so the macOS
+// menu bar app name — falls back to package.json's `name` field
+// (`@sero/desktop`), which Electron then mangles to "Electron". Setting it
+// explicitly here fixes the menu bar in both dev and packaged builds, and
+// must run before `app.whenReady()`.
+app.setName('Sero');
+
 // ── Per-profile Chromium userData isolation ──────────────────
 // Set userData path BEFORE app.whenReady() so Chromium initialises with the
 // correct directory. This isolates cookies, localStorage, caches, and


### PR DESCRIPTION
## Summary

- Added `app.setName('Sero')` call before `app.whenReady()` in the Electron main process
- Fixes the macOS menu bar app name, which was falling back to "Electron" in dev mode due to package.json's `name` field (`@sero/desktop`)
- The `productName` setting in electron-builder only affects packaged builds, not dev mode

## Validation

- [ ] `pnpm typecheck`
- [ ] `pnpm build` (if relevant)

## Safety checklist

- [ ] no secrets, tokens, credentials, or machine-specific private paths committed
- [ ] no unnecessary `any`, `@ts-ignore`, or `@ts-expect-error`
- [ ] touched source files remain under 500 LOC

## Risk / rollout notes

- breaking changes: none
- security or privacy impact: none
- follow-up work: none

https://claude.ai/code/session_01LhYszbxVu2mGbVk9axvwd6