### PR TITLE
feat(design-library): improve generation workflows

### DIFF
--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -209,7 +209,8 @@ You can also generate straight into the Library, from the **Generate** button in
 | A new image or video from a description | **Generate**, then choose the media type |
 | A new image based on a reference | Select one reference, choose **Remix**, then **New image** |
 | A video based on a reference | Select one reference, choose **Remix**, then **New video** |
-| A restyled or sharper copy | Select one reference, choose **Remix**, then **Restyle** or **Upscale** |
+| A restyled copy | Select one reference, choose **Remix**, then **New image** |
+| A sharper copy | Select one reference, choose **Remix**, then **Upscale** |
 
 Generated references arrive in the Library like any other and are read by the Librarian automatically. Open one to see the original prompt and model at the end of the inspector. While one is on its way it shows as a tile in the grid, so you can see that it is coming rather than wondering whether the button worked.
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -206,12 +206,12 @@ You can also generate straight into the Library, from the **Generate** button in
 
 | What | How |
 | --- | --- |
-| A new reference from a description | **Generate**, describe what you want |
-| A variation of something you have | Select one reference, then **Restyle** |
-| A sharper copy | **Generate** → Upscale, and choose the reference |
-| A short video | **Generate** → Video |
+| A new image or video from a description | **Generate**, then choose the media type |
+| A new image based on a reference | Select one reference, choose **Remix**, then **New image** |
+| A video based on a reference | Select one reference, choose **Remix**, then **New video** |
+| A restyled or sharper copy | Select one reference, choose **Remix**, then **Restyle** or **Upscale** |
 
-Generated references arrive in the Library like any other and are read by the Librarian automatically, keeping the prompt that made them. While one is on its way it shows as a tile in the grid, so you can see that it is coming rather than wondering whether the button worked.
+Generated references arrive in the Library like any other and are read by the Librarian automatically. Open one to see the original prompt and model at the end of the inspector. While one is on its way it shows as a tile in the grid, so you can see that it is coming rather than wondering whether the button worked.
 
 ### Video
 
@@ -240,7 +240,7 @@ Importing your own video files is not supported yet.
 | Variants per design | 3 | How many directions a new design starts with |
 | On revise | Replace what is visible | Or keep each revision separately |
 | Prompt recipes | Three built in | Named instruction templates applied on top of a request |
-| Media models | The provider's defaults | One model per kind of generation: image, restyle, upscale, video |
+| Media models | The provider's defaults | One model per kind of generation: image, restyle, upscale, text-to-video and image-to-video |
 | Media calls per run | 4 | How many pictures one design run may ask for. The run is told the number, so it plans around it; going over stops further calls and says so, and the design still finishes |
 | Provider key | From the environment | See below |
 

--- a/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
@@ -1,0 +1,74 @@
+# Design Library library-workflow enhancement decisions
+
+**Status:** Accepted  
+**Date:** 2026-07-30  
+**Scope:** Post-first-release Library workflow enhancements
+
+This is a separate decision entry for enhancement work. It does not reopen the first-release decisions.
+
+## E1 · Fresh generation and source-led work are separate flows
+
+The Library header **Generate** action offers text-to-image and text-to-video only. It does not show operations that require a source.
+
+The selected-reference **Remix** action opens a source-led panel. That panel separates operations that create new media from operations that edit the current reference.
+
+**Reason.** The current flat capability row mixes two different user intentions. It also allows a selected source to disappear when the user changes to a capability that cannot use it.
+
+**Consequence.** The dialog receives an explicit mode. It does not infer intent only from the current capability.
+
+## E2 · Remix can create an image or a video from a reference
+
+Remix offers source-aware image and video generation. Image generation uses image-to-image. Video generation uses a new vendor-neutral `image-to-video` capability backed by a configured fal.ai model.
+
+Text-to-video remains the fresh video operation.
+
+**Reason.** A movie based on a reference must send that reference to the provider. Reusing text-to-video would silently ignore it.
+
+**Consequence.** Settings gain one editable image-to-video model id. Existing profiles normalize with an empty override and therefore use the adapter default.
+
+## E3 · Restyle and Upscale remain operations, not top-level workflows
+
+The selected-reference action is named **Remix**. Inside the panel, **Restyle** and **Upscale** stay as operation names under **Edit this reference**.
+
+**Reason.** Remix describes the broader task. Restyle and Upscale describe specific changes to the source.
+
+**Consequence.** The first-release Restyle action name changes, but persisted media capability names do not change.
+
+## E4 · Original provenance is read-only and last
+
+Generated references show an **Original request** section at the end of the inspector. It projects the prompt, operation, and model from the item’s existing generation provenance.
+
+The Librarian’s editable **Generation prompt** stays where it is and keeps its current meaning.
+
+**Reason.** These prompts answer different questions. One records what made this file. The other describes how to make future work in the same language.
+
+**Consequence.** No generation data is copied into the Librarian profile.
+
+## E5 · Large pickers use the shared searchable Combobox
+
+The source picker and facet menus use the searchable Combobox from `@sero-ai/ui`. Its result area has a fixed maximum height.
+
+Facet menus use multi-select. Selection ticks appear on the right through the shared component.
+
+**Reason.** A plain select or complete menu does not scale to thousands of values. A scroll area alone moves the problem into a long scroll.
+
+**Consequence.** Users type to narrow large lists. Selection, keyboard control, filtering and focus behavior stay consistent with other Sero pickers.
+
+## E6 · The generation choice uses grouped controls, not flat tabs
+
+Fresh Generate uses a small option grid. Remix uses two labelled option groups:
+
+- **Create new**
+- **Edit this reference**
+
+**Reason.** Tabs imply peer views. These controls select an operation and include an important source-versus-output distinction.
+
+**Consequence.** The panel uses selectable controls that match the inspector’s border, spacing, focus, and selected-state language.
+
+## E7 · Video protections apply to both video capabilities
+
+Mandatory confirmation, duration limits, cost tracking, pending states, frame capture, playback, and Librarian analysis apply to text-to-video and image-to-video.
+
+**Reason.** Source input does not change the spend or lifecycle risks of video generation.
+
+**Consequence.** Shared video checks use an explicit video-capability predicate instead of one direct equality check.

--- a/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
@@ -26,13 +26,13 @@ Text-to-video remains the fresh video operation.
 
 **Consequence.** Settings gain one editable image-to-video model id. Existing profiles normalize with an empty override and therefore use the adapter default.
 
-## E3 · Restyle and Upscale remain operations, not top-level workflows
+## E3 · Remix has one image-to-image operation
 
-The selected-reference action is named **Remix**. Inside the panel, **Restyle** and **Upscale** stay as operation names under **Edit this reference**.
+The selected-reference action is named **Remix**. Inside the panel, **New image** uses image-to-image, **New video** uses image-to-video, and **Upscale** remains under **Edit this reference**.
 
-**Reason.** Remix describes the broader task. Restyle and Upscale describe specific changes to the source.
+**Reason.** New image and Restyle sent the same request. Two labels must not promise two operations when the runtime cannot tell them apart.
 
-**Consequence.** The first-release Restyle action name changes, but persisted media capability names do not change.
+**Consequence.** The first-release Restyle action becomes Remix → New image. Persisted media capability names do not change.
 
 ## E4 · Original provenance is read-only and last
 

--- a/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
+++ b/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
@@ -60,10 +60,9 @@ The Remix panel starts with that reference selected. It has two groups:
   - New image — image-to-image
   - New video — image-to-video
 - **Edit this reference**
-  - Restyle — image-to-image
   - Upscale — upscale
 
-“New image” and “Restyle” use the same provider capability in the first enhancement. Their labels explain the result, not a different backend operation. Both create a derived Library item and keep the source item unchanged.
+**New image** replaces the separate Restyle operation. Both controls sent the same image-to-image request, so separate labels promised a difference that did not exist. It creates a derived item and keeps the source item unchanged.
 
 Image-to-video is a new application capability backed by the configured fal.ai image-to-video model. It sends the selected reference as the source. It does not reuse text-to-video and does not discard the source.
 
@@ -224,6 +223,6 @@ The scope does not include video import, webpage capture, clipboard HTML, semant
 ## 9. Resolved review questions
 
 1. Use **Create new** and **Edit this reference** as the group names.
-2. Restyle keeps the current first-release behavior and creates a derived item.
-3. **New image** and **Restyle** share the configured image-to-image model.
+2. **New image** keeps the first-release Restyle behavior and creates a derived item.
+3. Do not show two controls that send the same image-to-image request.
 4. Shared `@sero-ai/ui` Combobox behavior supplies search, bounded height, multi-select and right-side ticks. Do not duplicate these controls in the plugin.

--- a/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
+++ b/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
@@ -1,0 +1,229 @@
+# Design Library library-workflow enhancements plan
+
+**Status:** Complete  
+**Branch:** `feat/design-library-workflow-enhancements`  
+**Scope:** Library inspector, generation flow, source picker, and filters  
+**Authority:**
+
+- `docs/specs/sero-design-library-plugin-spec.md`
+- `docs/decisions/sero-design-library-first-release-decisions.md`
+- `docs/prototypes/sero-design-library-plugin.html`
+- `docs/plans/sero-design-library-plugin-implementation-plan.md`
+
+This plan starts enhancement work after the first release. It does not reopen or amend the closed first-release plan.
+
+## 1. Goal
+
+Make generation and filtering clear when a Library has many references.
+
+The work must:
+
+1. Show the original generation prompt for generated references.
+2. Separate fresh generation from work based on an existing reference.
+3. Replace the current flat capability tabs with clear groups.
+4. Make source and filter pickers usable with hundreds or thousands of values.
+5. Give the generation prompt more writing space.
+6. Rename the selected-reference action from **Restyle** to **Remix**.
+
+## 2. Product decisions
+
+The companion decision proposal is:
+
+`docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md`
+
+The static review prototype is:
+
+`docs/prototypes/sero-design-library-generation-workflow-enhancement.html`
+
+No product implementation starts until this plan and prototype are approved.
+
+## 3. User flows
+
+### 3.1 Generate
+
+The Library header **Generate** action starts without a source reference. The panel title is **Generate**.
+
+It offers only:
+
+- **New image** — text-to-image
+- **New video** — text-to-video
+
+It does not show Restyle or Upscale. It does not show a source picker.
+
+### 3.2 Remix
+
+When one reference is selected, the action bar shows **Remix** instead of **Restyle**.
+
+The Remix panel starts with that reference selected. It has two groups:
+
+- **Create new**
+  - New image — image-to-image
+  - New video — image-to-video
+- **Edit this reference**
+  - Restyle — image-to-image
+  - Upscale — upscale
+
+“New image” and “Restyle” use the same provider capability in the first enhancement. Their labels explain the result, not a different backend operation. Both create a derived Library item and keep the source item unchanged.
+
+Image-to-video is a new application capability backed by the configured fal.ai image-to-video model. It sends the selected reference as the source. It does not reuse text-to-video and does not discard the source.
+
+The source picker stays available in Remix so the user can change the reference without closing the panel.
+
+### 3.3 Generated-reference inspector
+
+The inspector adds a final read-only section named **Original request** when generation provenance exists.
+
+It shows:
+
+- The original prompt, including an explicit “No prompt” value for an empty upscale prompt
+- The operation label
+- The model id
+
+The section is last because it is supporting provenance. The Librarian’s editable **Generation prompt** remains separate. That field describes how to make future work in the same design language; it is not the prompt that created the current file.
+
+### 3.4 Large source lists
+
+Replace the source select with a searchable popover.
+
+- The trigger shows the selected reference.
+- Opening the picker focuses search.
+- Search matches reference titles without case sensitivity.
+- The list has a fixed maximum height.
+- Typing narrows the list, so the user does not need to scan the full Library.
+- The selected result has a right-side tick.
+- Keyboard users can search, move through results, select, and close the picker.
+
+This bound protects the renderer when a Library has thousands of references. It also removes the need to scroll through the complete Library.
+
+### 3.5 Large filter lists
+
+Each facet menu keeps its current multi-select behavior.
+
+- Move ticks to the right.
+- Use the shared searchable multi-select Combobox.
+- Keep the menu at a fixed maximum height.
+- Filter matching values as the user types.
+- Keep the menu open while the user selects more than one value.
+
+Short filter lists stay simple and do not show a search field.
+
+## 4. Interface changes
+
+### 4.1 Generation panel
+
+- Use a two-column option grid instead of a flat tab row.
+- Use section headings only when a source exists.
+- Show the selected state with the same surface and border language as the inspector.
+- Increase **Describe it** to six visible rows and set a useful minimum height.
+- Keep aspect and duration controls below the prompt.
+- Keep the spend note and final action in the footer.
+- Change the final action label to match the selected operation where useful, such as **Generate video** or **Upscale**.
+
+### 4.2 Wording
+
+- Selection action: **Restyle** → **Remix**
+- Panel title: **Generate**
+- Source-led panel title: **Remix reference**
+- Source field: **Work from**
+- Provenance section: **Original request**
+- Original prompt label: **Prompt**
+
+## 5. Data and runtime changes
+
+### 5.1 Original request
+
+The item record already stores generation provenance. Extend the item-detail result with a read-only projection of that provenance. Do not duplicate it in state or the Librarian profile.
+
+### 5.2 Image-to-video
+
+Add `image-to-video` to the vendor-neutral media capability type and every exhaustive capability map.
+
+Required changes include:
+
+- Persisted settings normalization with a safe default for existing profiles
+- fal.ai default model configuration
+- Source resolution and upload
+- fal.ai request mapping with `image_url`, prompt, duration, and supported aspect fields
+- Video confirmation and duration limits
+- Generated item kind, frames, analysis, provenance, and parent link
+- Tool and UI labels
+- Contract, coordinator, settings, and recovery tests
+
+The model id remains editable in Settings. The user chooses a capability, not an endpoint.
+
+## 6. Delivery sequence
+
+### Phase 0 — Review gate
+
+- [x] Create a fresh enhancement branch.
+- [x] Create this separate plan.
+- [x] Create a separate decision proposal.
+- [x] Create a static panel prototype.
+- [x] Receive approval before product implementation.
+
+### Phase 1 — Provenance and scalable controls
+
+- [x] Project original generation provenance into item details.
+- [x] Add the final inspector section and tests.
+- [x] Use the shared searchable Combobox for references.
+- [x] Use the shared multi-select Combobox for facets and right-side ticks.
+- [x] Add large-list tests for source and filter pickers.
+
+### Phase 2 — Generation workflow
+
+- [x] Add explicit `fresh` and `remix` dialog modes.
+- [x] Replace the flat capability tabs with grouped option controls.
+- [x] Hide source operations from fresh Generate.
+- [x] Rename the selection action to Remix.
+- [x] Increase the prompt area.
+- [x] Add dialog behavior and accessibility tests.
+
+### Phase 3 — fal.ai image-to-video
+
+- [x] Add the vendor-neutral capability and settings migration.
+- [x] Add fal.ai request and result mapping.
+- [x] Route Remix → New video through the source-aware capability.
+- [x] Confirm spend before every video request.
+- [x] Add provider contract, runtime, and UI tests.
+
+### Phase 4 — Documentation and verification
+
+- [x] Update the product spec for approved behavior.
+- [x] Update the docs site where Library generation is described.
+- [x] Run focused plugin tests.
+- [x] Run `npx react-doctor@latest --verbose --scope changed` after React changes.
+- [x] Run root `pnpm typecheck` before each commit.
+- [x] Check every touched source file is below 500 lines.
+- [x] Run the plugin build and test suite.
+- [x] Commit with a Conventional Commit message.
+
+## 7. Acceptance checks
+
+1. Fresh Generate has only New image and New video.
+2. Remix opens with the selected reference and shows two clear operation groups.
+3. Remix → New video sends the reference to an image-to-video fal.ai model.
+4. No operation silently ignores a selected source.
+5. The original prompt appears only when provenance exists and is last in the inspector.
+6. The Librarian generation prompt remains editable and distinct from the original prompt.
+7. A source among 5,000 references can be found by typing part of its title.
+8. A filter facet with 5,000 values has a fixed-height searchable list.
+9. Filter ticks appear on the right.
+10. The prompt area is visibly larger than the first-release control.
+11. Existing generated and imported records still normalize without data loss.
+12. Video confirmation and duration limits apply to text-to-video and image-to-video.
+
+## 8. Small workflow improvements included
+
+These completed changes have low complexity and support the requested flow:
+
+- Keep the last typed prompt when the user changes operation inside one open panel.
+- Clear an invalid aspect or duration choice when the selected model does not support it.
+
+The scope does not include video import, webpage capture, clipboard HTML, semantic search, plugin output, arbitrary npm dependencies, mixed output targets, pinning, or archiving.
+
+## 9. Resolved review questions
+
+1. Use **Create new** and **Edit this reference** as the group names.
+2. Restyle keeps the current first-release behavior and creates a derived item.
+3. **New image** and **Restyle** share the configured image-to-image model.
+4. Shared `@sero-ai/ui` Combobox behavior supplies search, bounded height, multi-select and right-side ticks. Do not duplicate these controls in the plugin.

--- a/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
+++ b/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Design Library generation workflow enhancement</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #09090b;
+      --surface: #111114;
+      --raised: #1b1b20;
+      --line: #2c2c33;
+      --strong: #494953;
+      --text: #f4f4f5;
+      --muted: #9b9ba7;
+      --quiet: #6f6f7b;
+      --accent: #4aa9d5;
+      --accent-wash: rgba(74, 169, 213, .12);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-width: 1180px;
+      background: #050506;
+      color: var(--text);
+      font: 14px/1.45 Inter, ui-sans-serif, system-ui, sans-serif;
+    }
+    button, textarea { font: inherit; }
+    .page { width: 1160px; margin: 0 auto; padding: 56px 0 80px; }
+    h1 { margin: 0; font-size: 27px; letter-spacing: -.04em; }
+    .lede { width: 710px; margin: 10px 0 34px; color: var(--muted); }
+    .states { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; align-items: start; }
+    .state-title { margin: 0 0 9px; font-size: 15px; }
+    .state-note { min-height: 42px; margin: 0 0 14px; color: var(--quiet); font-size: 12px; }
+    .dialog {
+      min-height: 678px;
+      display: flex;
+      flex-direction: column;
+      background: var(--surface);
+      border: 1px solid var(--strong);
+      border-radius: 12px;
+      box-shadow: 0 28px 80px rgba(0, 0, 0, .52);
+      overflow: hidden;
+    }
+    .head { padding: 20px 21px 17px; border-bottom: 1px solid var(--line); }
+    .head-row { display: flex; align-items: start; }
+    .head h2 { margin: 0; font-size: 18px; letter-spacing: -.025em; }
+    .head p { margin: 5px 0 0; color: var(--muted); font-size: 12px; }
+    .close { margin-left: auto; color: var(--quiet); font-size: 22px; line-height: 1; }
+    .body { flex: 1; padding: 19px 21px 22px; }
+    .group + .group { margin-top: 18px; }
+    .group-label { margin-bottom: 8px; color: var(--muted); font-size: 11px; font-weight: 650; }
+    .options { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+    .option {
+      min-height: 64px;
+      padding: 11px 12px;
+      text-align: left;
+      color: var(--muted);
+      background: var(--bg);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+    .option strong { display: block; color: var(--text); font-size: 13px; font-weight: 600; }
+    .option span { display: block; margin-top: 3px; color: var(--quiet); font-size: 11px; }
+    .option.active { border-color: var(--accent); background: var(--accent-wash); }
+    .option.active strong { color: #a9ddf2; }
+    .field { margin-top: 18px; }
+    label { display: block; margin-bottom: 7px; color: #ddddE2; font-size: 12px; font-weight: 560; }
+    .picker {
+      height: 38px;
+      display: flex;
+      align-items: center;
+      padding: 0 11px;
+      color: var(--text);
+      background: var(--bg);
+      border: 1px solid var(--strong);
+      border-radius: 7px;
+    }
+    .picker .thumb { width: 20px; height: 20px; margin-right: 8px; border-radius: 4px; background: linear-gradient(140deg, #204352, #a96042); }
+    .picker .chev { margin-left: auto; color: var(--quiet); }
+    textarea {
+      width: 100%;
+      min-height: 132px;
+      resize: none;
+      padding: 11px 12px;
+      color: var(--text);
+      background: var(--bg);
+      border: 1px solid var(--strong);
+      border-radius: 8px;
+      outline: 0;
+    }
+    textarea::placeholder { color: #777789; }
+    .controls { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 16px; }
+    .select { height: 37px; display: flex; align-items: center; padding: 0 10px; background: var(--bg); border: 1px solid var(--strong); border-radius: 7px; }
+    .select span { margin-left: auto; color: var(--quiet); }
+    .foot { min-height: 67px; display: flex; align-items: center; gap: 16px; padding: 13px 21px; border-top: 1px solid var(--line); }
+    .foot p { flex: 1; margin: 0; color: var(--quiet); font-size: 11px; }
+    .primary { height: 37px; padding: 0 15px; color: #071319; background: var(--accent); border: 0; border-radius: 8px; font-weight: 670; }
+    .callout { margin-top: 28px; padding: 16px 18px; border-left: 2px solid var(--accent); background: #0d0d10; color: var(--muted); font-size: 12px; }
+    .callout b { color: var(--text); }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <h1>Generation workflow enhancement</h1>
+    <p class="lede">Two entry points express two intentions. Generate starts from words. Remix starts from a Library reference and separates new output from edits to that reference.</p>
+
+    <div class="states">
+      <section>
+        <h2 class="state-title">A · Generate</h2>
+        <p class="state-note">Opened from the Library header. Source-only operations do not appear.</p>
+        <div class="dialog">
+          <div class="head">
+            <div class="head-row"><div><h2>Generate</h2><p>New references enter the Library and are analysed automatically.</p></div><span class="close">×</span></div>
+          </div>
+          <div class="body">
+            <div class="group">
+              <div class="options">
+                <button class="option active"><strong>New image</strong><span>Create an image from your description</span></button>
+                <button class="option"><strong>New video</strong><span>Create a video from your description</span></button>
+              </div>
+            </div>
+            <div class="field">
+              <label for="fresh-prompt">Describe it</label>
+              <textarea id="fresh-prompt" placeholder="Hero imagery, textures, abstract graphics — not interface icons."></textarea>
+            </div>
+            <div class="controls">
+              <div><label>Aspect</label><div class="select">16:9 <span>⌄</span></div></div>
+            </div>
+          </div>
+          <div class="foot"><p>The model behind each capability is a setting, not a choice made here.</p><button class="primary">Generate image</button></div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="state-title">B · Remix</h2>
+        <p class="state-note">Opened from one selected reference. Every option uses the shown source.</p>
+        <div class="dialog">
+          <div class="head">
+            <div class="head-row"><div><h2>Remix reference</h2><p>Create new media or edit the current reference.</p></div><span class="close">×</span></div>
+          </div>
+          <div class="body">
+            <div class="group">
+              <div class="group-label">Create new</div>
+              <div class="options">
+                <button class="option active"><strong>New image</strong><span>Use this reference as visual direction</span></button>
+                <button class="option"><strong>New video</strong><span>Animate from this reference</span></button>
+              </div>
+            </div>
+            <div class="group">
+              <div class="group-label">Edit this reference</div>
+              <div class="options">
+                <button class="option"><strong>Restyle</strong><span>Change its visual treatment</span></button>
+                <button class="option"><strong>Upscale</strong><span>Increase its resolution</span></button>
+              </div>
+            </div>
+            <div class="field">
+              <label>Work from</label>
+              <div class="picker"><span class="thumb"></span>Ember in the Blue <span class="chev">⌄</span></div>
+            </div>
+            <div class="field">
+              <label for="remix-prompt">Describe it</label>
+              <textarea id="remix-prompt" placeholder="Describe the new image and what to keep from the reference."></textarea>
+            </div>
+          </div>
+          <div class="foot"><p>The new item keeps a link to this source and records the original request.</p><button class="primary">Generate image</button></div>
+        </div>
+      </section>
+    </div>
+
+    <aside class="callout"><b>Large lists:</b> Work from becomes a searchable picker with a fixed-height, bounded result list. Long filter menus use the same rule, keep multi-select, and place ticks on the right.</aside>
+  </main>
+</body>
+</html>

--- a/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
+++ b/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
@@ -150,8 +150,7 @@
             </div>
             <div class="group">
               <div class="group-label">Edit this reference</div>
-              <div class="options">
-                <button class="option"><strong>Restyle</strong><span>Change its visual treatment</span></button>
+              <div class="options" style="grid-template-columns:1fr">
                 <button class="option"><strong>Upscale</strong><span>Increase its resolution</span></button>
               </div>
             </div>

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -118,8 +118,8 @@ Exact duplicates are detected by content checksum; importing one opens the exist
 
 Two further routes create items through the media contract (§8):
 
-- **Generate inspiration** — a prompt produces a new image or video item.
-- **Restyle / vary** — an existing item produces a derived item, linked to its parent.
+- **Generate** — a prompt produces a new image or video item.
+- **Remix** — an existing item can produce a new image or video, a restyled image, or an upscale. The derived item links to its parent.
 
 Generated items are ordinary Library items: they analyse automatically and carry generation provenance alongside their Librarian profile.
 
@@ -127,7 +127,7 @@ Generated items are ordinary Library items: they analyse automatically and carry
 
 Analysis starts automatically after a successful import or generation, using the configured **Librarian model**.
 
-The inspector presents editable title, tags and notes; primary style and design types; a one-sentence summary and a short intent; aesthetic vocabulary; colour, typography, layout, density, shape, surface, imagery and motion observations; a palette; editable Always/Never guardrails; and an editable generation prompt. Source, checksum, model and analysis provenance are immutable.
+The inspector presents editable title, tags and notes; primary style and design types; a one-sentence summary and a short intent; aesthetic vocabulary; colour, typography, layout, density, shape, surface, imagery and motion observations; a palette; editable Always/Never guardrails; and an editable generation prompt. A generated item also shows its original request last in the inspector. Source, checksum, model and analysis provenance are immutable.
 
 ```ts
 interface LibrarianVisualProfile {
@@ -340,14 +340,15 @@ type MediaCapability =
   | 'text-to-image'
   | 'image-to-image'
   | 'upscale'
-  | 'text-to-video';
+  | 'text-to-video'
+  | 'image-to-video';
 
 interface MediaRequest {
   capability: MediaCapability;
   prompt: string;
   /** Opaque provider model id. Defaults come from settings. */
   model?: string;
-  /** Local source assets for image-to-image and upscale. */
+  /** Local source assets for image-to-image, upscale and image-to-video. */
   sourceAssetIds?: string[];
   aspectRatio?: string;
   seed?: number;
@@ -433,7 +434,7 @@ The key is never placed in reactive state and never returned to the UI. The UI s
 Two entry points, one implementation:
 
 - **Agent tools.** Media tools are passed as `customTools` into the design-generation run and bridged to the main Sero agent. The model decides when to call them.
-- **Explicit actions.** Generate inspiration and Restyle/vary in Library; Generate asset in the Design asset tray.
+- **Explicit actions.** Generate and Remix in Library; Generate asset in the Design asset tray.
 
 Spend protection, all configurable:
 

--- a/plugins/sero-design-library-plugin/extension/tools/items.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/items.ts
@@ -93,6 +93,15 @@ function renderItem(record: ItemRecord): ToolResult {
       width: record.asset.width ?? 0,
       height: record.asset.height ?? 0,
       bytes: record.asset.bytes,
+      ...(record.generation === undefined
+        ? {}
+        : {
+            generation: {
+              capability: record.generation.capability,
+              prompt: record.generation.prompt,
+              model: record.generation.model,
+            },
+          }),
     },
   });
 }

--- a/plugins/sero-design-library-plugin/extension/tools/media.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/media.ts
@@ -115,7 +115,7 @@ export function registerMediaTool(pi: ExtensionAPI, paths: DesignLibraryPaths): 
       capability: Type.Optional(
         StringEnum(MEDIA_CAPABILITIES as MediaCapability[], {
           description:
-            'text-to-image makes artwork from a description; image-to-image restyles a source; upscale raises a source\'s resolution; text-to-video makes a short clip',
+            'text-to-image makes artwork from a description; image-to-image restyles a source; upscale raises a source\'s resolution; text-to-video makes a short clip; image-to-video animates a source image',
         }),
       ),
       prompt: Type.Optional(
@@ -123,7 +123,7 @@ export function registerMediaTool(pi: ExtensionAPI, paths: DesignLibraryPaths): 
       ),
       sourceId: Type.Optional(
         Type.String({
-          description: 'For `generate` with image-to-image or upscale: a tray asset id or Library item id',
+          description: 'For a source capability: a tray asset id or Library item id',
         }),
       ),
       sourceItemId: Type.Optional(

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -119,7 +119,7 @@ describe('media settings', () => {
     // The other three keep whatever they had, rather than being cleared by a
     // patch that only named one.
     const patch = (queued?.body as { patch: { media: { models: Record<string, string> } } }).patch;
-    expect(Object.keys(patch.media.models)).toHaveLength(4);
+    expect(Object.keys(patch.media.models)).toHaveLength(5);
   });
 
   it('keeps the per-run cap inside its range', async () => {

--- a/plugins/sero-design-library-plugin/runtime/coordinator-video.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-video.test.ts
@@ -4,6 +4,7 @@ import { appendRequest, readState } from '../shared/state-io';
 import { beginUpload, completeUpload, writeUploadChunk } from '../shared/uploads';
 import { useCoordinator } from './coordinator-harness';
 import { readItem } from './store';
+import { seedItem } from './test-fixtures';
 
 /**
  * Generated video, end to end (D4).
@@ -44,6 +45,30 @@ describe('a generated video', () => {
     // Held, not failed: it resolves by itself the next time the app is open.
     expect(item?.analysis.status).toBe('pending');
     expect(item?.analysis.jobId).toBeUndefined();
+  });
+
+  it('creates a derived video from a source image', async () => {
+    await seedItem(harness.paths, 'source-image');
+    await appendRequest(harness.paths, {
+      kind: 'library.generate',
+      slotId: 'slot-image-video',
+      capability: 'image-to-video',
+      prompt: 'a slow push in',
+      sourceItemId: 'source-image',
+    });
+    await harness.coordinator.drain();
+
+    const generated = await vi.waitFor(async () => {
+      const state = await readState(harness.paths);
+      const item = state.items.find((entry) => entry.sourceKind === 'derived');
+      expect(item).toBeDefined();
+      return readItem(harness.paths, item!.id);
+    });
+
+    expect(generated?.kind).toBe('video');
+    expect(generated?.source.parentItemId).toBe('source-image');
+    expect(generated?.generation?.capability).toBe('image-to-video');
+    expect(generated?.awaitingFrames).toBe(true);
   });
 
   it('analyses once the renderer has sent frames', async () => {

--- a/plugins/sero-design-library-plugin/runtime/media/contract.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/contract.test.ts
@@ -345,4 +345,27 @@ describe('executeMedia', () => {
 
     expect(attempt.error).toEqual({ code: 'rate-limit', message: 'Slow down.', retryable: true });
   });
+
+  it('refuses a video used where an image source is required', async () => {
+    const provider = createFakeProvider();
+    const attempt = await executeMedia(
+      provider,
+      { capability: 'image-to-video', prompt: 'move', sourceAssetIds: ['video-1'] },
+      {
+        directory,
+        signal: new AbortController().signal,
+        readAsset: async () => ({
+          path: '/tmp/source.mp4',
+          bytes: new Uint8Array(),
+          mediaType: 'video/mp4',
+        }),
+      },
+    );
+
+    expect(attempt.error).toEqual({
+      code: 'invalid-request',
+      message: 'image-to-video needs an image source.',
+      retryable: false,
+    });
+  });
 });

--- a/plugins/sero-design-library-plugin/runtime/media/execute.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/execute.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { MediaAttempt, MediaProvenance } from '../../shared/media';
+import { needsSource } from '../../shared/media';
 import type { MediaContext, MediaProvider, MediaRequest, MediaSourceAsset } from './contract';
 import { MediaError } from './contract';
 
@@ -66,6 +67,7 @@ export async function executeMedia(
 ): Promise<MediaAttempt> {
   const attemptId = randomUUID();
   const startedAt = Date.now();
+  const sourceAssets = new Map<string, MediaSourceAsset>();
 
   // Names are generated here, not taken from the adapter, so a provider cannot
   // choose where its bytes land. `store` is the only write it has.
@@ -73,7 +75,13 @@ export async function executeMedia(
   const context: MediaContext = {
     signal: options.signal,
     ...(options.onProgress === undefined ? {} : { onProgress: options.onProgress }),
-    readAsset: options.readAsset,
+    readAsset: async (assetId) => {
+      const cached = sourceAssets.get(assetId);
+      if (cached !== undefined) return cached;
+      const asset = await options.readAsset(assetId);
+      sourceAssets.set(assetId, asset);
+      return asset;
+    },
     async store(name, bytes) {
       const safe = `${attemptId}-${path.basename(name).replace(/[^A-Za-z0-9._-]/g, '_')}`;
       await mkdir(options.directory, { recursive: true });
@@ -98,6 +106,31 @@ export async function executeMedia(
   // is not a property the tenth adapter will have.
   if (options.signal.aborted) {
     return failure(new MediaError('cancelled', 'The request was cancelled.', false));
+  }
+
+  if (needsSource(request.capability)) {
+    const resolved = await Promise.all(
+      (request.sourceAssetIds ?? []).map(async (assetId) => {
+        const asset = await options.readAsset(assetId);
+        sourceAssets.set(assetId, asset);
+        return asset;
+      }),
+    ).then(
+      (assets) => ({ ok: true as const, assets }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    if (!resolved.ok) {
+      return failure(
+        resolved.error instanceof MediaError
+          ? resolved.error
+          : new MediaError('invalid-request', 'The source image could not be read.', false),
+      );
+    }
+    if (resolved.assets.some((asset) => !asset.mediaType.startsWith('image/'))) {
+      return failure(
+        new MediaError('invalid-request', `${request.capability} needs an image source.`, false),
+      );
+    }
   }
 
   // The call is wrapped rather than chained off `provider.generate(...)`: a

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fake.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fake.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import { deflateSync } from 'node:zlib';
 
 import type { MediaCapability, MediaModelOptions } from '../../../shared/media';
-import { MEDIA_CAPABILITIES, needsSource } from '../../../shared/media';
+import { MEDIA_CAPABILITIES, isVideoCapability, needsSource } from '../../../shared/media';
 import type { MediaContext, MediaProvider, MediaRequest, MediaResult } from '../contract';
 import { MediaError } from '../contract';
 
@@ -24,6 +24,7 @@ const CAPABILITY_MODELS: Record<MediaCapability, string> = {
   'image-to-image': 'fake/image-edit',
   upscale: 'fake/upscale',
   'text-to-video': 'fake/video',
+  'image-to-video': 'fake/image-video',
 };
 
 /** How the fake can be told to fail, for the recovery and retry tests. */
@@ -161,7 +162,7 @@ export function createFakeProvider(options: FakeProviderOptions = {}): MediaProv
 
       const hash = digest(request);
       const model = request.model ?? CAPABILITY_MODELS[request.capability];
-      const isVideo = request.capability === 'text-to-video';
+      const isVideo = isVideoCapability(request.capability);
       const { width, height } = dimensions(request.aspectRatio);
       const bytes = solidPng(width, height, [hash[0], hash[1], hash[2]]);
       const name = `${hash.toString('hex').slice(0, 16)}.${isVideo ? 'mp4' : 'png'}`;

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFalInput } from './fal-input';
+
+describe('fal image-to-video input', () => {
+  it('sends the source image and normalized video controls', () => {
+    expect(
+      buildFalInput(
+        {
+          capability: 'image-to-video',
+          prompt: 'a slow push in',
+          sourceAssetIds: ['reference'],
+          durationSeconds: 5,
+          aspectRatio: '16:9',
+        },
+        ['https://fal.media/source.png'],
+        new Map([[5, '5']]),
+      ),
+    ).toEqual({
+      prompt: 'a slow push in',
+      image_url: 'https://fal.media/source.png',
+      duration: '5',
+      aspect_ratio: '16:9',
+    });
+  });
+});

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.test.ts
@@ -23,4 +23,23 @@ describe('fal image-to-video input', () => {
       aspect_ratio: '16:9',
     });
   });
+
+  it('omits aspect ratio when the endpoint schema does not accept it', () => {
+    expect(
+      buildFalInput(
+        {
+          capability: 'image-to-video',
+          prompt: 'a slow push in',
+          sourceAssetIds: ['reference'],
+          aspectRatio: '16:9',
+        },
+        ['https://fal.media/source.png'],
+        new Map(),
+        false,
+      ),
+    ).toEqual({
+      prompt: 'a slow push in',
+      image_url: 'https://fal.media/source.png',
+    });
+  });
 });

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.ts
@@ -1,0 +1,68 @@
+import type { MediaRequest } from '../contract';
+
+/** fal takes a named size rather than a ratio; anything unmapped is left to it. */
+const IMAGE_SIZES: Record<string, string> = {
+  '1:1': 'square_hd',
+  '4:3': 'landscape_4_3',
+  '3:4': 'portrait_4_3',
+  '16:9': 'landscape_16_9',
+  '9:16': 'portrait_16_9',
+};
+
+function videoInput(
+  request: MediaRequest,
+  durationTokens: Map<number, string | number>,
+): Record<string, unknown> {
+  return {
+    prompt: request.prompt,
+    ...(request.durationSeconds === undefined
+      ? {}
+      : { duration: durationTokens.get(request.durationSeconds) ?? String(request.durationSeconds) }),
+    ...(request.aspectRatio === undefined ? {} : { aspect_ratio: request.aspectRatio }),
+  };
+}
+
+/** Map the vendor-neutral request into the configured fal.ai endpoint input. */
+export function buildFalInput(
+  request: MediaRequest,
+  sourceUrls: string[],
+  /** The endpoint's original token for each normalized duration. */
+  durationTokens: Map<number, string | number>,
+): Record<string, unknown> {
+  const size = request.aspectRatio === undefined ? undefined : IMAGE_SIZES[request.aspectRatio];
+  const shared = {
+    ...(request.seed === undefined ? {} : { seed: request.seed }),
+    ...request.extra,
+  };
+
+  switch (request.capability) {
+    case 'text-to-image':
+      return {
+        prompt: request.prompt,
+        num_images: 1,
+        ...(size === undefined ? {} : { image_size: size }),
+        ...shared,
+      };
+    case 'image-to-image':
+      return {
+        prompt: request.prompt,
+        image_url: sourceUrls[0],
+        ...(size === undefined ? {} : { image_size: size }),
+        ...shared,
+      };
+    case 'upscale':
+      return {
+        image_url: sourceUrls[0],
+        ...(request.prompt === '' ? {} : { prompt: request.prompt }),
+        ...shared,
+      };
+    case 'text-to-video':
+      return { ...videoInput(request, durationTokens), ...shared };
+    case 'image-to-video':
+      return {
+        ...videoInput(request, durationTokens),
+        image_url: sourceUrls[0],
+        ...shared,
+      };
+  }
+}

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.ts
@@ -12,13 +12,16 @@ const IMAGE_SIZES: Record<string, string> = {
 function videoInput(
   request: MediaRequest,
   durationTokens: Map<number, string | number>,
+  supportsAspectRatio: boolean | undefined,
 ): Record<string, unknown> {
   return {
     prompt: request.prompt,
     ...(request.durationSeconds === undefined
       ? {}
       : { duration: durationTokens.get(request.durationSeconds) ?? String(request.durationSeconds) }),
-    ...(request.aspectRatio === undefined ? {} : { aspect_ratio: request.aspectRatio }),
+    ...(request.aspectRatio === undefined || supportsAspectRatio === false
+      ? {}
+      : { aspect_ratio: request.aspectRatio }),
   };
 }
 
@@ -28,6 +31,8 @@ export function buildFalInput(
   sourceUrls: string[],
   /** The endpoint's original token for each normalized duration. */
   durationTokens: Map<number, string | number>,
+  /** False when this endpoint's schema has no aspect-ratio input. */
+  supportsAspectRatio?: boolean,
 ): Record<string, unknown> {
   const size = request.aspectRatio === undefined ? undefined : IMAGE_SIZES[request.aspectRatio];
   const shared = {
@@ -57,10 +62,10 @@ export function buildFalInput(
         ...shared,
       };
     case 'text-to-video':
-      return { ...videoInput(request, durationTokens), ...shared };
+      return { ...videoInput(request, durationTokens, supportsAspectRatio), ...shared };
     case 'image-to-video':
       return {
-        ...videoInput(request, durationTokens),
+        ...videoInput(request, durationTokens, supportsAspectRatio),
         image_url: sourceUrls[0],
         ...shared,
       };

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-schema.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-schema.test.ts
@@ -40,6 +40,7 @@ describe('reading a fal endpoint schema', () => {
     expect(schema.options).toEqual({
       durationsSeconds: [5, 10],
       aspectRatios: ['16:9', '9:16', '1:1'],
+      supportsAspectRatio: true,
     });
   });
 
@@ -50,7 +51,7 @@ describe('reading a fal endpoint schema', () => {
       schemaDocument({ prompt: {}, duration: { type: 'string', enum: ['4s', '6s', '8s'] } }),
     );
 
-    expect(schema.options).toEqual({ durationsSeconds: [4, 6, 8] });
+    expect(schema.options).toEqual({ durationsSeconds: [4, 6, 8], supportsAspectRatio: false });
     expect(schema.durationTokens.get(8)).toBe('8s');
   });
 
@@ -59,13 +60,16 @@ describe('reading a fal endpoint schema', () => {
       schemaDocument({ prompt: {}, duration: { type: 'integer', minimum: 2, maximum: 6 } }),
     );
 
-    expect(schema.options).toEqual({ durationRange: { min: 2, max: 6 } });
+    expect(schema.options).toEqual({
+      durationRange: { min: 2, max: 6 },
+      supportsAspectRatio: false,
+    });
   });
 
   it('says nothing rather than guessing when the schema has nothing to say', () => {
     expect(
       parseFalSchema(schemaDocument({ prompt: {}, image_size: { type: 'string' } })).options,
-    ).toEqual({});
+    ).toEqual({ supportsAspectRatio: false });
     expect(parseFalSchema({ components: {} }).options).toEqual({});
     expect(parseFalSchema('not a schema').options).toEqual({});
   });
@@ -82,7 +86,7 @@ describe('reading a fal endpoint schema', () => {
       },
     });
 
-    expect(schema.options).toEqual({ durationsSeconds: [5] });
+    expect(schema.options).toEqual({ durationsSeconds: [5], supportsAspectRatio: false });
   });
 });
 
@@ -96,8 +100,14 @@ describe('the reader', () => {
     );
     const read = createFalSchemaReader(transport as unknown as typeof globalThis.fetch);
 
-    expect((await read('fal-ai/kling')).options).toEqual({ durationsSeconds: [5, 10] });
-    expect((await read('fal-ai/kling')).options).toEqual({ durationsSeconds: [5, 10] });
+    expect((await read('fal-ai/kling')).options).toEqual({
+      durationsSeconds: [5, 10],
+      supportsAspectRatio: false,
+    });
+    expect((await read('fal-ai/kling')).options).toEqual({
+      durationsSeconds: [5, 10],
+      supportsAspectRatio: false,
+    });
 
     // A round trip in front of every video — including one inside a generation
     // run that is already waiting on a model — for an answer that cannot change

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-schema.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-schema.ts
@@ -123,6 +123,7 @@ export function parseFalSchema(document: unknown): FalModelSchema {
   return {
     options: {
       ...durationOptions(properties.duration, tokens),
+      supportsAspectRatio: properties.aspect_ratio !== undefined,
       ...(ratios === undefined ? {} : { aspectRatios: ratios }),
     },
     durationTokens: tokens,

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal.ts
@@ -2,6 +2,7 @@ import { ApiError, createFalClient, ValidationError } from '@fal-ai/client';
 
 import type { MediaCapability, MediaErrorCode, MediaModelOptions } from '../../../shared/media';
 import { MEDIA_CAPABILITIES, needsSource } from '../../../shared/media';
+import { buildFalInput } from './fal-input';
 import { createFalSchemaReader } from './fal-schema';
 import type {
   MediaContext,
@@ -41,15 +42,7 @@ export const FAL_DEFAULT_MODELS: Record<MediaCapability, string> = {
   'image-to-image': 'fal-ai/flux/dev/image-to-image',
   upscale: 'fal-ai/clarity-upscaler',
   'text-to-video': 'fal-ai/kling-video/v1/standard/text-to-video',
-};
-
-/** fal takes a named size rather than a ratio; anything unmapped is left to it. */
-const IMAGE_SIZES: Record<string, string> = {
-  '1:1': 'square_hd',
-  '4:3': 'landscape_4_3',
-  '3:4': 'portrait_4_3',
-  '16:9': 'landscape_16_9',
-  '9:16': 'portrait_16_9',
+  'image-to-video': 'fal-ai/kling-video/v2.1/pro/image-to-video',
 };
 
 const DOWNLOAD_TIMEOUT_MS = 120_000;
@@ -167,58 +160,6 @@ export function normalizeFalError(error: unknown): MediaError {
   }
 
   return new MediaError('provider', String(error), true);
-}
-
-function buildInput(
-  request: MediaRequest,
-  sourceUrls: string[],
-  /**
-   * How this endpoint spells a length. `"5"` on one model, `"8s"` on the next —
-   * so the value it published is what goes back, and the seconds are only how
-   * the rest of the plugin refers to it.
-   */
-  durationTokens: Map<number, string | number>,
-): Record<string, unknown> {
-  const size = request.aspectRatio === undefined ? undefined : IMAGE_SIZES[request.aspectRatio];
-  const shared = {
-    ...(request.seed === undefined ? {} : { seed: request.seed }),
-    ...request.extra,
-  };
-
-  switch (request.capability) {
-    case 'text-to-image':
-      return {
-        prompt: request.prompt,
-        num_images: 1,
-        ...(size === undefined ? {} : { image_size: size }),
-        ...shared,
-      };
-    case 'image-to-image':
-      return {
-        prompt: request.prompt,
-        image_url: sourceUrls[0],
-        ...(size === undefined ? {} : { image_size: size }),
-        ...shared,
-      };
-    case 'upscale':
-      return {
-        image_url: sourceUrls[0],
-        ...(request.prompt === '' ? {} : { prompt: request.prompt }),
-        ...shared,
-      };
-    case 'text-to-video':
-      return {
-        prompt: request.prompt,
-        ...(request.durationSeconds === undefined
-          ? {}
-          : {
-              duration:
-                durationTokens.get(request.durationSeconds) ?? String(request.durationSeconds),
-            }),
-        ...(request.aspectRatio === undefined ? {} : { aspect_ratio: request.aspectRatio }),
-        ...shared,
-      };
-  }
 }
 
 function progressMessage(status: { status: string; queue_position?: number }): string {
@@ -411,7 +352,7 @@ export function createFalProvider(options: FalProviderOptions): MediaProvider {
         // only how to spell it. A schema that cannot be read leaves the number
         // as it stands, which is what the endpoint got before any of this.
         const schema = await readSchema(model, context.signal);
-        const input = buildInput(request, sourceUrls, schema.durationTokens);
+        const input = buildFalInput(request, sourceUrls, schema.durationTokens);
         const result = await client.subscribe(model, {
           input,
           abortSignal: context.signal,

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal.ts
@@ -352,7 +352,12 @@ export function createFalProvider(options: FalProviderOptions): MediaProvider {
         // only how to spell it. A schema that cannot be read leaves the number
         // as it stands, which is what the endpoint got before any of this.
         const schema = await readSchema(model, context.signal);
-        const input = buildFalInput(request, sourceUrls, schema.durationTokens);
+        const input = buildFalInput(
+          request,
+          sourceUrls,
+          schema.durationTokens,
+          schema.options.supportsAspectRatio,
+        );
         const result = await client.subscribe(model, {
           input,
           abortSignal: context.signal,

--- a/plugins/sero-design-library-plugin/runtime/media/tools.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/tools.test.ts
@@ -60,6 +60,7 @@ describe('media tools', () => {
       'design_library_restyle_image',
       'design_library_upscale_image',
       'design_library_generate_video',
+      'design_library_animate_image',
     ]);
   });
 

--- a/plugins/sero-design-library-plugin/runtime/media/tools.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/tools.ts
@@ -23,8 +23,8 @@ import { executeMedia } from './execute';
  * The media capabilities, as tools (spec §8.4, D5).
  *
  * One tool per capability rather than one tool with a mode: the model chooses a
- * *capability* and never an endpoint, and four narrow descriptions say when each
- * is worth using far better than one description covering all four.
+ * *capability* and never an endpoint, and narrow descriptions say when each is
+ * worth using far better than one description covering every operation.
  *
  * The same definitions serve both entry points. Inside a generation run they go
  * in as `customTools` and execute in-process here; for the main Sero agent the
@@ -98,6 +98,20 @@ const SHAPES: Record<MediaCapability, CapabilityShape> = {
       'Generates a short video from a description. This always asks the user first and is the most expensive capability, so use it only when motion is the point.',
     parameters: Type.Object({
       prompt: Type.String({ description: 'What the video should show, including the motion.' }),
+      durationSeconds: Type.Optional(
+        Type.Number({ description: `Seconds of footage, up to ${MAX_VIDEO_SECONDS}.` }),
+      ),
+      aspectRatio: Type.Optional(Type.String()),
+    }),
+  },
+  'image-to-video': {
+    name: 'design_library_animate_image',
+    label: 'Animate Image',
+    summary:
+      'Generates a short video from an existing image. This always asks the user first and is expensive, so use it only when motion is the point.',
+    parameters: Type.Object({
+      prompt: Type.String({ description: 'How the source should move and what the video should show.' }),
+      sourceId: Type.String({ description: 'Id of an asset you generated, or a Library item.' }),
       durationSeconds: Type.Optional(
         Type.Number({ description: `Seconds of footage, up to ${MAX_VIDEO_SECONDS}.` }),
       ),

--- a/plugins/sero-design-library-plugin/runtime/reference-assets.ts
+++ b/plugins/sero-design-library-plugin/runtime/reference-assets.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 
 import { effectiveAnalysis } from '../shared/librarian';
 import type { DesignAsset, MediaCapability } from '../shared/media';
-import { assetReferenceFor } from '../shared/media';
+import { assetReferenceFor, isVideoCapability } from '../shared/media';
 import type { DesignLibraryPaths } from '../shared/paths';
 import { designAssetDir } from '../shared/paths';
 import type { ItemRecord } from '../shared/records';
@@ -43,7 +43,7 @@ export async function stageReferenceAssets(
     const now = Date.now();
     const generatedWith = item.generation?.capability;
     const capability: MediaCapability =
-      generatedWith === undefined || generatedWith === 'text-to-video'
+      generatedWith === undefined || isVideoCapability(generatedWith)
         ? 'text-to-image'
         : generatedWith;
     assets.push({

--- a/plugins/sero-design-library-plugin/shared/media-options.test.ts
+++ b/plugins/sero-design-library-plugin/shared/media-options.test.ts
@@ -36,6 +36,19 @@ describe('settling a video request', () => {
     expect(settleMediaRequest({ ...video, durationSeconds: 8 }, fixed).durationSeconds).toBe(10);
   });
 
+  it('applies the same video limits to image-to-video', () => {
+    const request = {
+      capability: 'image-to-video' as const,
+      prompt: 'a slow push in',
+      sourceAssetIds: ['reference'],
+      durationSeconds: 8,
+    };
+    expect(settleMediaRequest(request, fixed).durationSeconds).toBe(10);
+    expect(videoLengthRefusal('image-to-video', { durationsSeconds: [20] })).toContain(
+      String(MAX_VIDEO_SECONDS),
+    );
+  });
+
   it('fills in a default when nobody asked for a length', () => {
     expect(settleMediaRequest(video, fixed).durationSeconds).toBe(DEFAULT_VIDEO_SECONDS);
   });

--- a/plugins/sero-design-library-plugin/shared/media-options.ts
+++ b/plugins/sero-design-library-plugin/shared/media-options.ts
@@ -15,7 +15,12 @@
  */
 
 import type { MediaCapability, MediaModelOptions } from './media';
-import { DEFAULT_VIDEO_SECONDS, MAX_VIDEO_SECONDS, boundedDuration } from './media';
+import {
+  DEFAULT_VIDEO_SECONDS,
+  MAX_VIDEO_SECONDS,
+  boundedDuration,
+  isVideoCapability,
+} from './media';
 
 /**
  * Every length worth offering for a model, ascending, or null when unknown.
@@ -54,7 +59,7 @@ export function videoLengthRefusal(
   capability: MediaCapability,
   options: MediaModelOptions | undefined,
 ): string | null {
-  if (capability !== 'text-to-video') return null;
+  if (!isVideoCapability(capability)) return null;
   if (allowedDurations(options)?.length !== 0) return null;
   return (
     `The video model in Settings makes nothing shorter than ${MAX_VIDEO_SECONDS} seconds, ` +
@@ -122,7 +127,7 @@ export function settleMediaRequest<
   // A duration on a still image is noise in the record and in the parameters
   // sent to the provider.
   const { durationSeconds: requested, ...rest } = request;
-  if (request.capability !== 'text-to-video') return rest as T;
+  if (!isVideoCapability(request.capability)) return rest as T;
 
   const allowed = allowedDurations(options);
   const preferred = boundedDuration(requested);

--- a/plugins/sero-design-library-plugin/shared/media.test.ts
+++ b/plugins/sero-design-library-plugin/shared/media.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { DesignAsset } from './media';
-import { assetCostUsd, normalizeDesignAsset } from './media';
+import { assetCostUsd, normalizeDesignAsset, normalizeModelOptions } from './media';
 
 function asset(overrides: Partial<DesignAsset> = {}): DesignAsset {
   return {
@@ -51,5 +51,13 @@ describe('Design reference assets', () => {
         id: 'attempt-1', outcome: 'ready', startedAt: 1, completedAt: 2, file: '../secret',
       }],
     }))?.attempts[0]?.file).toBeUndefined();
+  });
+});
+
+describe('model options', () => {
+  it('keeps explicit aspect-ratio support from the provider schema', () => {
+    expect(normalizeModelOptions({ supportsAspectRatio: false })).toEqual({
+      supportsAspectRatio: false,
+    });
   });
 });

--- a/plugins/sero-design-library-plugin/shared/media.ts
+++ b/plugins/sero-design-library-plugin/shared/media.ts
@@ -11,13 +11,19 @@
 import type { MediaKind } from './records';
 import { isSafeId } from './safe-id';
 
-export type MediaCapability = 'text-to-image' | 'image-to-image' | 'upscale' | 'text-to-video';
+export type MediaCapability =
+  | 'text-to-image'
+  | 'image-to-image'
+  | 'upscale'
+  | 'text-to-video'
+  | 'image-to-video';
 
 export const MEDIA_CAPABILITIES: readonly MediaCapability[] = [
   'text-to-image',
   'image-to-image',
   'upscale',
   'text-to-video',
+  'image-to-video',
 ] as const;
 
 export function isMediaCapability(value: unknown): value is MediaCapability {
@@ -25,7 +31,11 @@ export function isMediaCapability(value: unknown): value is MediaCapability {
 }
 
 /** Capabilities that consume local source assets, so callers can check before asking. */
-export const SOURCE_CAPABILITIES: readonly MediaCapability[] = ['image-to-image', 'upscale'] as const;
+export const SOURCE_CAPABILITIES: readonly MediaCapability[] = [
+  'image-to-image',
+  'upscale',
+  'image-to-video',
+] as const;
 
 export function needsSource(capability: MediaCapability): boolean {
   return (SOURCE_CAPABILITIES as readonly string[]).includes(capability);
@@ -33,7 +43,11 @@ export function needsSource(capability: MediaCapability): boolean {
 
 /** The one capability that always costs a confirmation before it runs (D10). */
 export function needsConfirmation(capability: MediaCapability): boolean {
-  return capability === 'text-to-video';
+  return isVideoCapability(capability);
+}
+
+export function isVideoCapability(capability: MediaCapability): boolean {
+  return capability === 'text-to-video' || capability === 'image-to-video';
 }
 
 /**
@@ -104,7 +118,7 @@ export function normalizeModelOptions(value: unknown): MediaModelOptions {
 }
 
 export function kindFor(capability: MediaCapability): MediaKind {
-  return capability === 'text-to-video' ? 'video' : 'image';
+  return isVideoCapability(capability) ? 'video' : 'image';
 }
 
 export type MediaErrorCode =

--- a/plugins/sero-design-library-plugin/shared/media.ts
+++ b/plugins/sero-design-library-plugin/shared/media.ts
@@ -95,6 +95,8 @@ export interface MediaModelOptions {
   durationRange?: { min: number; max: number };
   /** The only aspect ratios this model accepts, as `w:h`. */
   aspectRatios?: string[];
+  /** False when the provider schema explicitly has no aspect-ratio input. */
+  supportsAspectRatio?: boolean;
 }
 
 export function normalizeModelOptions(value: unknown): MediaModelOptions {
@@ -114,6 +116,9 @@ export function normalizeModelOptions(value: unknown): MediaModelOptions {
     ...(durations === undefined || durations.length === 0 ? {} : { durationsSeconds: durations }),
     ...(min === undefined || max === undefined || max < min ? {} : { durationRange: { min, max } }),
     ...(ratios === undefined || ratios.length === 0 ? {} : { aspectRatios: ratios }),
+    ...(typeof value.supportsAspectRatio === 'boolean'
+      ? { supportsAspectRatio: value.supportsAspectRatio }
+      : {}),
   };
 }
 

--- a/plugins/sero-design-library-plugin/shared/settings.ts
+++ b/plugins/sero-design-library-plugin/shared/settings.ts
@@ -109,6 +109,7 @@ export const DEFAULT_SETTINGS: DesignLibrarySettings = {
       'image-to-image': '',
       upscale: '',
       'text-to-video': '',
+      'image-to-video': '',
     },
     callsPerRun: 4,
   },

--- a/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
+++ b/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
@@ -89,7 +89,7 @@ export function DesignLibraryApp() {
   const librarySources = useMemo<GenerateSource[]>(
     () =>
       library.state.items.flatMap((item) =>
-        item.deletedAt === undefined ? [{ id: item.id, label: item.title }] : [],
+        item.deletedAt === undefined ? [{ id: item.id, label: item.title, kind: item.kind }] : [],
       ),
     [library.state.items],
   );

--- a/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
+++ b/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
@@ -272,7 +272,7 @@ export function DesignLibraryApp() {
 
       {generatingFrom !== null && (
         <GenerateDialog
-          // Keyed on the source so opening Restyle on a different reference
+          // Keyed on the source so opening Remix on a different reference
           // starts from that one, rather than reusing the last dialog's state.
           key={generatingFrom.item?.id ?? 'new'}
           open

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -108,8 +108,8 @@ describe('remixing a reference', () => {
     });
 
     const source = screen.getByLabelText('Work from');
-    await userEvent.clear(source);
-    await userEvent.type(source, 'Reference 999');
+    source.focus();
+    fireEvent.change(source, { target: { value: 'Reference 999' } });
     await userEvent.keyboard('{ArrowDown}{Enter}');
     await userEvent.type(screen.getByLabelText('Describe it'), 'a colder composition');
     await userEvent.click(screen.getByRole('button', { name: 'Generate image' }));

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -32,16 +32,29 @@ function renderDialog(overrides: Partial<GenerateDialogProps> = {}) {
   return { onGenerate };
 }
 
-async function chooseCapability(label: string) {
+async function chooseOperation(label: string) {
   await userEvent.click(screen.getByRole('radio', { name: label }));
 }
+
+describe('fresh generation', () => {
+  it('shows only source-free operations and gives the prompt more space', () => {
+    renderDialog();
+
+    expect(screen.getByRole('heading', { name: 'Generate' })).toBeDefined();
+    expect(screen.getByRole('radio', { name: 'New image' })).toBeDefined();
+    expect(screen.getByRole('radio', { name: 'New video' })).toBeDefined();
+    expect(screen.queryByRole('radio', { name: 'Restyle' })).toBeNull();
+    expect(screen.queryByRole('radio', { name: 'Upscale' })).toBeNull();
+    expect(screen.getByLabelText('Describe it').getAttribute('rows')).toBe('6');
+  });
+});
 
 describe('a video model that only makes long clips', () => {
   const longOnly = { 'text-to-video': { durationsSeconds: [20, 40] } };
 
   it('says why, and will not let the generation be started', async () => {
     const { onGenerate } = renderDialog({ modelOptions: longOnly });
-    await chooseCapability('Video');
+    await chooseOperation('New video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'a slow pan');
 
     expect(screen.getByText(/shorter/)).toBeDefined();
@@ -54,7 +67,7 @@ describe('a video model that only makes long clips', () => {
 
   it('lets a model through as soon as one length fits', async () => {
     renderDialog({ modelOptions: { 'text-to-video': { durationsSeconds: [5, 20] } } });
-    await chooseCapability('Video');
+    await chooseOperation('New video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'a slow pan');
 
     expect(screen.queryByText(/shorter/)).toBeNull();
@@ -62,22 +75,47 @@ describe('a video model that only makes long clips', () => {
   });
 });
 
-describe('a reference the capability cannot use', () => {
-  it('says so rather than dropping it in silence', async () => {
+describe('remixing a reference', () => {
+  it('offers grouped source operations and sends the source to image-to-video', async () => {
     const { onGenerate } = renderDialog({ initialSourceId: 'item-1' });
-    // Restyle opens working from the chosen picture; Video cannot use one.
     expect(screen.getByLabelText('Work from')).toBeDefined();
+    expect(screen.getByText('Create new')).toBeDefined();
+    expect(screen.getByText('Edit this reference')).toBeDefined();
+    expect(screen.getByRole('radio', { name: 'Restyle' })).toBeDefined();
+    expect(screen.getByRole('radio', { name: 'Upscale' })).toBeDefined();
 
-    await chooseCapability('Video');
+    await chooseOperation('New video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');
+    await userEvent.click(screen.getByRole('button', { name: 'Generate video' }));
 
-    expect(screen.getByText(/will not be used/)).toBeDefined();
-
-    await userEvent.click(screen.getByRole('button', { name: /Generate/ }));
-    // And what goes out matches what was said: no source on the request.
     expect(onGenerate).toHaveBeenCalledWith(
-      expect.objectContaining({ capability: 'text-to-video', prompt: 'animate this' }),
+      expect.objectContaining({
+        capability: 'image-to-video',
+        prompt: 'animate this',
+        sourceId: 'item-1',
+      }),
     );
-    expect(onGenerate.mock.calls[0]?.[0].sourceId).toBeUndefined();
+  });
+
+  it('finds a different source in a large Library by typing', async () => {
+    const sources = Array.from({ length: 1_000 }, (_, index) => ({
+      id: `item-${index}`,
+      label: `Reference ${index}`,
+    }));
+    const { onGenerate } = renderDialog({
+      sources,
+      initialSourceId: 'item-0',
+    });
+
+    const source = screen.getByLabelText('Work from');
+    await userEvent.clear(source);
+    await userEvent.type(source, 'Reference 999');
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+    await userEvent.type(screen.getByLabelText('Describe it'), 'a colder composition');
+    await userEvent.click(screen.getByRole('button', { name: 'Generate image' }));
+
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceId: 'item-999' }),
+    );
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -23,7 +23,7 @@ function renderDialog(overrides: Partial<GenerateDialogProps> = {}) {
     <GenerateDialog
       open
       target={{ kind: 'library' }}
-      sources={[{ id: 'item-1', label: 'A warm gradient' }]}
+      sources={[{ id: 'item-1', label: 'A warm gradient', kind: 'image' }]}
       onOpenChange={() => {}}
       onGenerate={onGenerate}
       {...overrides}
@@ -81,7 +81,7 @@ describe('remixing a reference', () => {
     expect(screen.getByLabelText('Work from')).toBeDefined();
     expect(screen.getByText('Create new')).toBeDefined();
     expect(screen.getByText('Edit this reference')).toBeDefined();
-    expect(screen.getByRole('radio', { name: 'Restyle' })).toBeDefined();
+    expect(screen.queryByRole('radio', { name: 'Restyle' })).toBeNull();
     expect(screen.getByRole('radio', { name: 'Upscale' })).toBeDefined();
 
     await chooseOperation('New video');
@@ -97,10 +97,26 @@ describe('remixing a reference', () => {
     );
   });
 
+  it('hides aspect ratio when the image-to-video endpoint does not accept it', async () => {
+    const { onGenerate } = renderDialog({
+      initialSourceId: 'item-1',
+      modelOptions: { 'image-to-video': { supportsAspectRatio: false } },
+    });
+    await chooseOperation('New video');
+    await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');
+
+    expect(screen.queryByLabelText('Aspect')).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'Generate video' }));
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ aspectRatio: expect.anything() }),
+    );
+  });
+
   it('finds a different source in a large Library by typing', async () => {
     const sources = Array.from({ length: 1_000 }, (_, index) => ({
       id: `item-${index}`,
       label: `Reference ${index}`,
+      kind: 'image' as const,
     }));
     const { onGenerate } = renderDialog({
       sources,
@@ -117,5 +133,29 @@ describe('remixing a reference', () => {
     expect(onGenerate).toHaveBeenCalledWith(
       expect.objectContaining({ sourceId: 'item-999' }),
     );
+  });
+
+  it('does not offer a video as an image source', () => {
+    renderDialog({
+      sources: [{ id: 'video-1', label: 'A short clip', kind: 'video' }],
+      initialSourceId: 'video-1',
+    });
+
+    expect(screen.getByText('Nothing in the Library to work from yet.')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Generate image' }).hasAttribute('disabled')).toBe(
+      true,
+    );
+  });
+
+  it('clears the selected source when the combobox is cleared', async () => {
+    const { onGenerate } = renderDialog({ initialSourceId: 'item-1' });
+    const source = screen.getByLabelText('Work from');
+    await userEvent.clear(source);
+    await userEvent.type(screen.getByLabelText('Describe it'), 'a colder composition');
+
+    expect(screen.getByRole('button', { name: 'Generate image' }).hasAttribute('disabled')).toBe(
+      true,
+    );
+    expect(onGenerate).not.toHaveBeenCalled();
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -1,5 +1,11 @@
 import {
   Button,
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -22,13 +28,12 @@ import type { MediaCapability, MediaModelOptions } from '../../shared/media';
 import {
   DEFAULT_VIDEO_SECONDS,
   MAX_VIDEO_SECONDS,
-  MEDIA_CAPABILITIES,
+  isVideoCapability,
   missingRequirement,
   needsConfirmation,
   needsSource,
 } from '../../shared/media';
 import { allowedDurations, videoLengthRefusal } from '../../shared/media-options';
-import { capabilityLabel } from '../lib/asset-view';
 
 /**
  * Asking for artwork, from either place it can be asked for (D5).
@@ -89,6 +94,53 @@ const FALLBACK_DURATIONS = [DEFAULT_VIDEO_SECONDS, 10].filter(
   (seconds) => seconds <= MAX_VIDEO_SECONDS,
 );
 
+type GenerationOperation =
+  | 'fresh-image'
+  | 'fresh-video'
+  | 'reference-image'
+  | 'reference-video'
+  | 'restyle'
+  | 'upscale';
+
+interface OperationChoice {
+  value: GenerationOperation;
+  label: string;
+  description: string;
+}
+
+const FRESH_OPERATIONS: OperationChoice[] = [
+  { value: 'fresh-image', label: 'New image', description: 'Create from your description' },
+  { value: 'fresh-video', label: 'New video', description: 'Create from your description' },
+];
+
+const CREATE_OPERATIONS: OperationChoice[] = [
+  { value: 'reference-image', label: 'New image', description: 'Use this as visual direction' },
+  { value: 'reference-video', label: 'New video', description: 'Animate from this reference' },
+];
+
+const EDIT_OPERATIONS: OperationChoice[] = [
+  { value: 'restyle', label: 'Restyle', description: 'Change its visual treatment' },
+  { value: 'upscale', label: 'Upscale', description: 'Increase its resolution' },
+];
+
+const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
+  'fresh-image': 'text-to-image',
+  'fresh-video': 'text-to-video',
+  'reference-image': 'image-to-image',
+  'reference-video': 'image-to-video',
+  restyle: 'image-to-image',
+  upscale: 'upscale',
+};
+
+const ACTION_LABEL: Record<GenerationOperation, string> = {
+  'fresh-image': 'Generate image',
+  'fresh-video': 'Generate video',
+  'reference-image': 'Generate image',
+  'reference-video': 'Generate video',
+  restyle: 'Restyle',
+  upscale: 'Upscale',
+};
+
 export function GenerateDialog({
   open,
   target,
@@ -98,9 +150,11 @@ export function GenerateDialog({
   onOpenChange,
   onGenerate,
 }: GenerateDialogProps) {
-  const [capability, setCapability] = useState<MediaCapability>(
-    initialSourceId === undefined ? 'text-to-image' : 'image-to-image',
+  const remix = initialSourceId !== undefined;
+  const [operation, setOperation] = useState<GenerationOperation>(
+    remix ? 'reference-image' : 'fresh-image',
   );
+  const capability = OPERATION_CAPABILITY[operation];
   const [prompt, setPrompt] = useState('');
   const [sourceId, setSourceId] = useState<string>(initialSourceId ?? '');
   const [chosenAspect, setChosenAspect] = useState<string | null>(null);
@@ -126,6 +180,9 @@ export function GenerateDialog({
       : (ratios.find((ratio) => ratio === DEFAULT_ASPECT) ?? ratios[0]);
 
   const wantsSource = needsSource(capability);
+  const video = isVideoCapability(capability);
+  const sourceOptions = sources.map((source) => ({ value: source.id, label: source.label }));
+  const selectedSource = sourceOptions.find((source) => source.value === sourceId) ?? null;
   // The same check the tool and the model's own tool run, so the dialog cannot
   // offer a request either of them would refuse.
   const missing = missingRequirement(capability, {
@@ -142,7 +199,7 @@ export function GenerateDialog({
       prompt: prompt.trim(),
       ...(wantsSource ? { sourceId } : {}),
       ...(capability === 'upscale' ? {} : { aspectRatio }),
-      ...(capability === 'text-to-video' ? { durationSeconds } : {}),
+      ...(video ? { durationSeconds } : {}),
     });
     setPrompt('');
     setSourceId('');
@@ -153,45 +210,51 @@ export function GenerateDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>
-            {target.kind === 'library' ? 'Generate inspiration' : 'Generate artwork'}
-          </DialogTitle>
+          <DialogTitle>Generate</DialogTitle>
           <DialogDescription>
-            {target.kind === 'library'
-              ? 'New references enter the Library and are analysed automatically.'
-              : `Artwork for ${target.designTitle}, reusable across its variants.`}
+            {remix
+              ? 'Create new media or edit the selected reference.'
+              : target.kind === 'library'
+                ? 'New references enter the Library and are analysed automatically.'
+                : `Artwork for ${target.designTitle}, reusable across its variants.`}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
-          <ToggleGroup
-            type="single"
-            value={capability}
-            onValueChange={(value) => {
-              if (value !== '') setCapability(value as MediaCapability);
-            }}
-            className="grid grid-cols-4"
-            aria-label="Capability"
-          >
-            {MEDIA_CAPABILITIES.map((entry) => (
-              <ToggleGroupItem key={entry} value={entry}>
-                {capabilityLabel(entry)}
-              </ToggleGroupItem>
-            ))}
-          </ToggleGroup>
-
-          {/*
-            A reference chosen for a restyle stays chosen when the capability
-            changes, and the row that showed it disappears — so the request went
-            out from the words alone while the dialog still looked like it was
-            working from the picture. It says so now instead.
-          */}
-          {!wantsSource && sourceId !== '' && (
-            <p className="text-muted-foreground text-sm">
-              {capabilityLabel(capability)} works from your description alone. The reference you
-              chose will not be used.
-            </p>
-          )}
+          {(remix
+            ? [
+                { label: 'Create new', choices: CREATE_OPERATIONS },
+                { label: 'Edit this reference', choices: EDIT_OPERATIONS },
+              ]
+            : [{ label: undefined, choices: FRESH_OPERATIONS }]
+          ).map((group) => (
+            <section key={group.label ?? 'fresh'} className="space-y-2">
+              {group.label && <h3 className="text-muted-foreground text-xs font-medium">{group.label}</h3>}
+              <ToggleGroup
+                type="single"
+                value={operation}
+                onValueChange={(value) => value !== '' && setOperation(value as GenerationOperation)}
+                className="grid grid-cols-2 gap-2"
+                aria-label={group.label ?? 'Media type'}
+              >
+                {group.choices.map((choice) => (
+                  <ToggleGroupItem
+                    key={choice.value}
+                    value={choice.value}
+                    className="h-auto min-h-16 items-start justify-start px-3 py-2.5 text-left"
+                    aria-label={choice.label}
+                  >
+                    <span>
+                      <span className="block text-sm font-medium">{choice.label}</span>
+                      <span className="text-muted-foreground mt-0.5 block text-xs font-normal">
+                        {choice.description}
+                      </span>
+                    </span>
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </section>
+          ))}
 
           {wantsSource && (
             <div className="space-y-1.5">
@@ -203,18 +266,23 @@ export function GenerateDialog({
                     : 'This Design has no artwork to work from yet.'}
                 </p>
               ) : (
-                <Select value={sourceId} onValueChange={setSourceId}>
-                  <SelectTrigger id="generate-source">
-                    <SelectValue placeholder="Choose a source" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {sources.map((source) => (
-                      <SelectItem key={source.id} value={source.id}>
-                        {source.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
+                <Combobox
+                  items={sourceOptions}
+                  value={selectedSource}
+                  onValueChange={(source) => source && setSourceId(source.value)}
+                >
+                  <ComboboxInput id="generate-source" placeholder="Search references" className="w-full" />
+                  <ComboboxContent>
+                    <ComboboxEmpty>No references found</ComboboxEmpty>
+                    <ComboboxList>
+                      {(source) => (
+                        <ComboboxItem key={source.value} value={source}>
+                          {source.label}
+                        </ComboboxItem>
+                      )}
+                    </ComboboxList>
+                  </ComboboxContent>
+                </Combobox>
               )}
             </div>
           )}
@@ -225,11 +293,12 @@ export function GenerateDialog({
             </Label>
             <Textarea
               id="generate-prompt"
-              rows={4}
+              rows={6}
+              className="min-h-32"
               value={prompt}
               onChange={(event) => setPrompt(event.target.value)}
               placeholder={
-                capability === 'text-to-video'
+                video
                   ? 'What the video should show, including the motion.'
                   : 'Hero imagery, textures, abstract graphics — not interface icons.'
               }
@@ -255,7 +324,7 @@ export function GenerateDialog({
               </div>
             )}
 
-            {capability === 'text-to-video' && (
+            {video && (
               <div className="space-y-1.5">
                 <Label htmlFor="generate-duration">Length</Label>
                 <Select
@@ -287,7 +356,7 @@ export function GenerateDialog({
           </p>
           <Button type="button" onClick={submit} disabled={blocked}>
             <Sparkles className="size-3.5" />
-            Generate
+            {ACTION_LABEL[operation]}
           </Button>
         </div>
       </DialogContent>

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -25,6 +25,7 @@ import { Sparkles } from 'lucide-react';
 import { useState } from 'react';
 
 import type { MediaCapability, MediaModelOptions } from '../../shared/media';
+import type { MediaKind } from '../../shared/records';
 import {
   DEFAULT_VIDEO_SECONDS,
   MAX_VIDEO_SECONDS,
@@ -52,6 +53,7 @@ export type GenerateTarget =
 export interface GenerateSource {
   id: string;
   label: string;
+  kind: MediaKind;
 }
 
 export interface GenerateRequest {
@@ -68,7 +70,7 @@ export interface GenerateDialogProps {
   /** Assets in this Design, or Library items — whichever the target can use. */
   sources: GenerateSource[];
   /**
-   * A source the dialog opens already working from — Restyle on a chosen
+   * A source the dialog opens already working from — Remix on a chosen
    * reference. The capability follows it, because arriving on "new image" with
    * a source selected says the source will be used when it will not be.
    */
@@ -99,7 +101,6 @@ type GenerationOperation =
   | 'fresh-video'
   | 'reference-image'
   | 'reference-video'
-  | 'restyle'
   | 'upscale';
 
 interface OperationChoice {
@@ -119,7 +120,6 @@ const CREATE_OPERATIONS: OperationChoice[] = [
 ];
 
 const EDIT_OPERATIONS: OperationChoice[] = [
-  { value: 'restyle', label: 'Restyle', description: 'Change its visual treatment' },
   { value: 'upscale', label: 'Upscale', description: 'Increase its resolution' },
 ];
 
@@ -128,7 +128,6 @@ const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
   'fresh-video': 'text-to-video',
   'reference-image': 'image-to-image',
   'reference-video': 'image-to-video',
-  restyle: 'image-to-image',
   upscale: 'upscale',
 };
 
@@ -137,7 +136,6 @@ const ACTION_LABEL: Record<GenerationOperation, string> = {
   'fresh-video': 'Generate video',
   'reference-image': 'Generate image',
   'reference-video': 'Generate video',
-  restyle: 'Restyle',
   upscale: 'Upscale',
 };
 
@@ -173,6 +171,7 @@ export function GenerateDialog({
     chosenDuration !== null && durations.includes(chosenDuration)
       ? chosenDuration
       : (durations[0] ?? DEFAULT_VIDEO_SECONDS);
+  const supportsAspectRatio = options?.supportsAspectRatio !== false;
   const ratios = options?.aspectRatios ?? FALLBACK_ASPECT_RATIOS;
   const aspectRatio =
     chosenAspect !== null && ratios.includes(chosenAspect)
@@ -181,7 +180,8 @@ export function GenerateDialog({
 
   const wantsSource = needsSource(capability);
   const video = isVideoCapability(capability);
-  const sourceOptions = sources.map((source) => ({ value: source.id, label: source.label }));
+  const imageSources = sources.filter((source) => source.kind === 'image');
+  const sourceOptions = imageSources.map((source) => ({ value: source.id, label: source.label }));
   const selectedSource = sourceOptions.find((source) => source.value === sourceId) ?? null;
   // The same check the tool and the model's own tool run, so the dialog cannot
   // offer a request either of them would refuse.
@@ -189,7 +189,7 @@ export function GenerateDialog({
     prompt,
     ...(sourceId === '' ? {} : { sourceIds: [sourceId] }),
   });
-  const noSources = wantsSource && sources.length === 0;
+  const noSources = wantsSource && imageSources.length === 0;
   const blocked = missing !== null || noSources || tooLong !== null;
 
   const submit = () => {
@@ -198,7 +198,7 @@ export function GenerateDialog({
       capability,
       prompt: prompt.trim(),
       ...(wantsSource ? { sourceId } : {}),
-      ...(capability === 'upscale' ? {} : { aspectRatio }),
+      ...(capability === 'upscale' || !supportsAspectRatio ? {} : { aspectRatio }),
       ...(video ? { durationSeconds } : {}),
     });
     setPrompt('');
@@ -210,7 +210,7 @@ export function GenerateDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-xl">
         <DialogHeader>
-          <DialogTitle>Generate</DialogTitle>
+          <DialogTitle>{remix ? 'Remix reference' : 'Generate'}</DialogTitle>
           <DialogDescription>
             {remix
               ? 'Create new media or edit the selected reference.'
@@ -234,7 +234,7 @@ export function GenerateDialog({
                 type="single"
                 value={operation}
                 onValueChange={(value) => value !== '' && setOperation(value as GenerationOperation)}
-                className="grid grid-cols-2 gap-2"
+                className={`grid gap-2 ${group.choices.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}
                 aria-label={group.label ?? 'Media type'}
               >
                 {group.choices.map((choice) => (
@@ -269,7 +269,7 @@ export function GenerateDialog({
                 <Combobox
                   items={sourceOptions}
                   value={selectedSource}
-                  onValueChange={(source) => source && setSourceId(source.value)}
+                  onValueChange={(source) => setSourceId(source?.value ?? '')}
                 >
                   <ComboboxInput id="generate-source" placeholder="Search references" className="w-full" />
                   <ComboboxContent>
@@ -306,7 +306,7 @@ export function GenerateDialog({
           </div>
 
           <div className="grid grid-cols-2 gap-3">
-            {capability !== 'upscale' && (
+            {capability !== 'upscale' && supportsAspectRatio && (
               <div className="space-y-1.5">
                 <Label htmlFor="generate-aspect">Aspect</Label>
                 <Select value={aspectRatio} onValueChange={setChosenAspect}>

--- a/plugins/sero-design-library-plugin/ui/components/ItemInspector.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/ItemInspector.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { emptyAnalysis } from '../../shared/librarian';
+import type { ItemSummary } from '../../shared/types';
+import type { LibraryActions } from '../hooks/useLibrary';
+import type { ItemDetail } from '../hooks/useItemDetail';
+
+const mocks = vi.hoisted(() => ({ useItemDetail: vi.fn() }));
+vi.mock('../hooks/useItemDetail', () => ({ useItemDetail: mocks.useItemDetail }));
+
+// eslint-disable-next-line import/first -- the hook mock must be registered first
+import { ItemInspector } from './ItemInspector';
+
+const ITEM: ItemSummary = {
+  id: 'item-1',
+  title: 'Generated surface',
+  primaryStyle: 'Editorial',
+  tags: [],
+  designTypes: [],
+  kind: 'image',
+  previewPath: 'items/item-1/preview.png',
+  analysisStatus: 'ready',
+  favourite: false,
+  collectionIds: [],
+  colours: [],
+  sourceKind: 'generated',
+  createdAt: 1,
+  updatedAt: 2,
+  edited: false,
+  searchText: '',
+};
+
+const ACTIONS: LibraryActions = {
+  setScope: vi.fn(),
+  setQuery: vi.fn(),
+  setFilters: vi.fn(),
+  setSort: vi.fn(),
+  select: vi.fn(),
+  setField: vi.fn(),
+  resetField: vi.fn(),
+  favourite: vi.fn(),
+  collect: vi.fn(),
+  remove: vi.fn(),
+  restore: vi.fn(),
+  purge: vi.fn(),
+  reanalyse: vi.fn(),
+  cancelAnalysis: vi.fn(),
+  createCollection: vi.fn(),
+  renameCollection: vi.fn(),
+  deleteCollection: vi.fn(),
+  updateSettings: vi.fn(),
+};
+
+function detail(generated: boolean): ItemDetail {
+  return {
+    id: ITEM.id,
+    analysis: emptyAnalysis(ITEM.title),
+    overridden: [],
+    confidence: 0.8,
+    updatedAt: 2,
+    createdAt: 1,
+    fileName: 'surface.png',
+    width: 1280,
+    height: 720,
+    bytes: 400,
+    ...(generated
+      ? {
+          generation: {
+            capability: 'text-to-image' as const,
+            prompt: 'A dark metallic hero surface',
+            model: 'fal-ai/flux/dev',
+          },
+        }
+      : {}),
+  };
+}
+
+describe('generation provenance', () => {
+  it('shows the original prompt last for a generated reference', () => {
+    mocks.useItemDetail.mockReturnValue(detail(true));
+    render(<ItemInspector item={ITEM} revision={1} actions={ACTIONS} onClose={() => {}} />);
+
+    expect(screen.getByText('Original request')).toBeDefined();
+    expect(screen.getByText('A dark metallic hero surface')).toBeDefined();
+    expect(screen.getByText('fal-ai/flux/dev')).toBeDefined();
+    const sections = screen.getAllByRole('heading', { level: 3 });
+    expect(sections.at(-1)?.textContent).toBe('Original request');
+  });
+
+  it('does not add provenance to an imported reference', () => {
+    mocks.useItemDetail.mockReturnValue(detail(false));
+    render(<ItemInspector item={ITEM} revision={1} actions={ACTIONS} onClose={() => {}} />);
+
+    expect(screen.queryByText('Original request')).toBeNull();
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/components/ItemInspector.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/ItemInspector.tsx
@@ -5,6 +5,7 @@ import type { LibrarianField } from '../../shared/librarian';
 import type { ItemSummary } from '../../shared/types';
 import type { LibraryActions } from '../hooks/useLibrary';
 import { useItemDetail, type ItemDetail } from '../hooks/useItemDetail';
+import { capabilityLabel } from '../lib/asset-view';
 import { EditableField, type FieldTone } from './inspector/EditableField';
 import { FieldValue } from './inspector/FieldValue';
 import { InspectorHeader } from './inspector/InspectorHeader';
@@ -96,6 +97,23 @@ function Sections({
           ))}
         </div>
       ))}
+      {detail.generation && (
+        <section className="border-border space-y-3 border-b px-4 py-3 last:border-b-0">
+          <h3 className="text-sm font-medium">Original request</h3>
+          <div>
+            <p className="text-muted-foreground text-xs">Prompt</p>
+            <p className="mt-1 wrap-break-word text-sm whitespace-pre-wrap">
+              {detail.generation.prompt || 'No prompt'}
+            </p>
+          </div>
+          <dl className="text-muted-foreground grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs">
+            <dt>Operation</dt>
+            <dd className="text-foreground">{capabilityLabel(detail.generation.capability)}</dd>
+            <dt>Model</dt>
+            <dd className="text-foreground wrap-break-word">{detail.generation.model}</dd>
+          </dl>
+        </section>
+      )}
     </>
   );
 }

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LibraryFilters } from '../../shared/types';
+import { LibraryToolbar } from './LibraryToolbar';
+
+const FILTERS: LibraryFilters = {
+  mediaKinds: [],
+  styles: [],
+  tags: [],
+  colours: [],
+  sourceKinds: [],
+  analysisStatuses: [],
+};
+
+describe('large Library facets', () => {
+  it('uses searchable multi-select options instead of a long unfiltered menu', async () => {
+    const onFiltersChange = vi.fn();
+    render(
+      <LibraryToolbar
+        query=""
+        filters={FILTERS}
+        facets={{
+          styles: Array.from({ length: 1_000 }, (_, index) => `Style ${index}`),
+          tags: [],
+          colours: [],
+          sourceKinds: [],
+        }}
+        sort="newest"
+        onQueryChange={() => {}}
+        onFiltersChange={onFiltersChange}
+        onSortChange={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('combobox', { name: 'Style' }));
+    await userEvent.type(screen.getByPlaceholderText('Search style'), 'Style 999');
+    await userEvent.click(screen.getByRole('option', { name: 'Style 999' }));
+
+    expect(onFiltersChange).toHaveBeenCalledWith({ ...FILTERS, styles: ['Style 999'] });
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -37,7 +37,9 @@ describe('large Library facets', () => {
     );
 
     await userEvent.click(screen.getByRole('combobox', { name: 'Style' }));
-    await userEvent.type(screen.getByPlaceholderText('Search style'), 'Style 999');
+    fireEvent.change(screen.getByPlaceholderText('Search style'), {
+      target: { value: 'Style 999' },
+    });
     await userEvent.click(screen.getByRole('option', { name: 'Style 999' }));
 
     expect(onFiltersChange).toHaveBeenCalledWith({ ...FILTERS, styles: ['Style 999'] });

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -1,5 +1,20 @@
-import { Button, DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger, SearchInput } from '@sero-ai/ui';
-import { ArrowDownUp, ChevronDown } from 'lucide-react';
+import {
+  Button,
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxTrigger,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  SearchInput,
+} from '@sero-ai/ui';
+import { ArrowDownUp } from 'lucide-react';
+import { useState } from 'react';
 
 import type { LibraryFacets } from '../../shared/search';
 import type { LibraryFilters, LibrarySort } from '../../shared/types';
@@ -20,51 +35,61 @@ interface LibraryToolbarProps {
   onSortChange(sort: LibrarySort): void;
 }
 
-type ListFilterKey = 'styles' | 'tags' | 'colours' | 'sourceKinds' | 'mediaKinds';
-
 const SORT_LABELS: Record<LibrarySort, string> = {
   newest: 'Newest first',
   oldest: 'Oldest first',
   title: 'By title',
 };
 
-function toggle(values: string[], value: string): string[] {
-  return values.includes(value) ? values.filter((entry) => entry !== value) : [...values, value];
-}
-
 interface FacetMenuProps {
   label: string;
   options: string[];
   selected: string[];
-  onToggle(value: string): void;
+  onChange(values: string[]): void;
 }
 
-function FacetMenu({ label, options, selected, onToggle }: FacetMenuProps) {
+function FacetMenu({ label, options, selected, onChange }: FacetMenuProps) {
+  const [open, setOpen] = useState(false);
   if (options.length === 0) return null;
-  // Checked once per option, so membership is a Set lookup.
-  const chosen = new Set(selected);
+  const items = options.map((option) => ({ value: option, label: option }));
+  const selectedValues = new Set(selected);
+  const chosen = items.filter((item) => selectedValues.has(item.value));
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button type="button" variant={selected.length > 0 ? 'secondary' : 'outline'} size="sm">
+    <Combobox
+      items={items}
+      multiple
+      open={open}
+      onOpenChange={setOpen}
+      value={chosen}
+      isItemEqualToValue={(item, value) => item.value === value.value}
+      onValueChange={(values) => onChange(values.map((value) => value.value))}
+    >
+      <ComboboxTrigger
+        aria-label={label}
+        onClick={() => setOpen((current) => !current)}
+        render={
+          <Button type="button" variant={selected.length > 0 ? 'secondary' : 'outline'} size="sm" />
+        }
+      >
           {label}
           {selected.length > 0 && <span className="tabular-nums">{selected.length}</span>}
-          <ChevronDown className="size-3.5" />
-        </Button>
-      </DropdownMenuTrigger>
-      {/* No heading inside: the trigger already says which facet this is. */}
-      <DropdownMenuContent align="start" className="max-h-80 overflow-y-auto">
-        {options.map((option) => (
-          <DropdownMenuCheckboxItem
-            key={option}
-            checked={chosen.has(option)}
-            onCheckedChange={() => onToggle(option)}
-          >
-            {option}
-          </DropdownMenuCheckboxItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      </ComboboxTrigger>
+      <ComboboxContent>
+        <ComboboxInput
+          showTrigger={false}
+          placeholder={`Search ${label.toLocaleLowerCase()}`}
+        />
+        <ComboboxEmpty>No options found</ComboboxEmpty>
+        <ComboboxList>
+          {(item) => (
+            <ComboboxItem key={item.value} value={item}>
+              {item.label}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
   );
 }
 
@@ -77,9 +102,6 @@ export function LibraryToolbar({
   onFiltersChange,
   onSortChange,
 }: LibraryToolbarProps) {
-  const toggleIn = (key: ListFilterKey, value: string) =>
-    onFiltersChange({ ...filters, [key]: toggle(filters[key] as string[], value) });
-
   const active =
     filters.styles.length +
     filters.tags.length +
@@ -100,31 +122,33 @@ export function LibraryToolbar({
         label="Media"
         options={['image', 'video']}
         selected={filters.mediaKinds}
-        onToggle={(value) => toggleIn('mediaKinds', value)}
+        onChange={(values) =>
+          onFiltersChange({ ...filters, mediaKinds: values as LibraryFilters['mediaKinds'] })
+        }
       />
       <FacetMenu
         label="Style"
         options={facets.styles}
         selected={filters.styles}
-        onToggle={(value) => toggleIn('styles', value)}
+        onChange={(values) => onFiltersChange({ ...filters, styles: values })}
       />
       <FacetMenu
         label="Tag"
         options={facets.tags}
         selected={filters.tags}
-        onToggle={(value) => toggleIn('tags', value)}
+        onChange={(values) => onFiltersChange({ ...filters, tags: values })}
       />
       <FacetMenu
         label="Colour"
         options={facets.colours}
         selected={filters.colours}
-        onToggle={(value) => toggleIn('colours', value)}
+        onChange={(values) => onFiltersChange({ ...filters, colours: values })}
       />
       <FacetMenu
         label="Source"
         options={facets.sourceKinds}
         selected={filters.sourceKinds}
-        onToggle={(value) => toggleIn('sourceKinds', value)}
+        onChange={(values) => onFiltersChange({ ...filters, sourceKinds: values })}
       />
 
       {active > 0 && (

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -41,14 +41,19 @@ const SORT_LABELS: Record<LibrarySort, string> = {
   title: 'By title',
 };
 
-interface FacetMenuProps {
+interface FacetMenuProps<Value extends string> {
   label: string;
-  options: string[];
-  selected: string[];
-  onChange(values: string[]): void;
+  options: Value[];
+  selected: Value[];
+  onChange(values: Value[]): void;
 }
 
-function FacetMenu({ label, options, selected, onChange }: FacetMenuProps) {
+function FacetMenu<Value extends string>({
+  label,
+  options,
+  selected,
+  onChange,
+}: FacetMenuProps<Value>) {
   const [open, setOpen] = useState(false);
   if (options.length === 0) return null;
   const items = options.map((option) => ({ value: option, label: option }));
@@ -120,11 +125,9 @@ export function LibraryToolbar({
 
       <FacetMenu
         label="Media"
-        options={['image', 'video']}
+        options={['image', 'video'] satisfies LibraryFilters['mediaKinds']}
         selected={filters.mediaKinds}
-        onChange={(values) =>
-          onFiltersChange({ ...filters, mediaKinds: values as LibraryFilters['mediaKinds'] })
-        }
+        onChange={(mediaKinds) => onFiltersChange({ ...filters, mediaKinds })}
       />
       <FacetMenu
         label="Style"

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -111,7 +111,7 @@ describe('media models', () => {
   it('shows each capability separately, so one does not stand for all five', () => {
     render(<MediaSettings media={MEDIA} />);
 
-    for (const label of ['Image', 'Restyle', 'Upscale', 'Video', 'Image to video']) {
+    for (const label of ['Image', 'Remix', 'Upscale', 'Video', 'Animate']) {
       expect(screen.getByLabelText(label), label).toBeDefined();
     }
   });

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -27,6 +27,7 @@ const MEDIA: MediaSettingsValue = {
     'image-to-image': '',
     upscale: '',
     'text-to-video': '',
+    'image-to-video': '',
   },
   callsPerRun: 6,
 };
@@ -107,10 +108,10 @@ describe('media models', () => {
     expect(callsFor('set-media-model')).toHaveLength(0);
   });
 
-  it('shows each capability separately, so one does not stand for all four', () => {
+  it('shows each capability separately, so one does not stand for all five', () => {
     render(<MediaSettings media={MEDIA} />);
 
-    for (const label of ['Image', 'Restyle', 'Upscale', 'Video']) {
+    for (const label of ['Image', 'Restyle', 'Upscale', 'Video', 'Image to video']) {
       expect(screen.getByLabelText(label), label).toBeDefined();
     }
   });

--- a/plugins/sero-design-library-plugin/ui/components/PendingItemTile.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/PendingItemTile.test.tsx
@@ -17,6 +17,18 @@ import { PendingItemTile } from './PendingItemTile';
 
 
 describe('the tile', () => {
+  it('fills the grid row like a completed reference card', () => {
+    const { container } = render(
+      <PendingItemTile
+        generation={{ jobId: 'j1', slotId: 's1', status: 'running', error: undefined }}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(container.firstElementChild?.classList.contains('h-full')).toBe(true);
+    expect(container.firstElementChild?.classList.contains('aspect-4/3')).toBe(false);
+  });
+
   it('says something is coming, and announces it', () => {
     render(
       <PendingItemTile

--- a/plugins/sero-design-library-plugin/ui/components/PendingItemTile.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/PendingItemTile.tsx
@@ -20,7 +20,7 @@ export function PendingItemTile({ generation, onDismiss }: PendingItemTileProps)
 
   return (
     <div
-      className={`border-border flex aspect-4/3 flex-col items-center justify-center gap-2 rounded-lg border p-4 text-center ${
+      className={`border-border flex h-full min-h-64 flex-col items-center justify-center gap-2 rounded-lg border p-4 text-center ${
         failed ? 'border-destructive/40 bg-destructive/5' : 'bg-muted/40'
       }`}
     >

--- a/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
@@ -83,7 +83,7 @@ export function SelectionBar({
             </Button>
             {/* One reference only: a variation is made *from* something, and
                 "restyle these four" has no single source to work from. */}
-            {selected.length === 1 && (
+            {selected.length === 1 && selected[0]?.kind === 'image' && (
               <Button type="button" variant="ghost" size="sm" onClick={onRemix}>
                 <Shuffle className="size-3.5" />
                 Remix

--- a/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
@@ -26,8 +26,8 @@ interface SelectionBarProps {
   onRestore(): void;
   onPurge(): void;
   onCreateDesign(): void;
-  /** Generate a variation of the one selected reference (D3). */
-  onRestyle(): void;
+  /** Generate new work from the one selected reference (E3). */
+  onRemix(): void;
 }
 
 export function SelectionBar({
@@ -42,7 +42,7 @@ export function SelectionBar({
   onRestore,
   onPurge,
   onCreateDesign,
-  onRestyle,
+  onRemix,
 }: SelectionBarProps) {
   if (selected.length === 0) return null;
   const count = `${selected.length} reference${selected.length === 1 ? '' : 's'} selected`;
@@ -84,9 +84,9 @@ export function SelectionBar({
             {/* One reference only: a variation is made *from* something, and
                 "restyle these four" has no single source to work from. */}
             {selected.length === 1 && (
-              <Button type="button" variant="ghost" size="sm" onClick={onRestyle}>
+              <Button type="button" variant="ghost" size="sm" onClick={onRemix}>
                 <Shuffle className="size-3.5" />
-                Restyle
+                Remix
               </Button>
             )}
             <Button type="button" variant="ghost" size="sm" onClick={onFavourite}>

--- a/plugins/sero-design-library-plugin/ui/components/design/VariantInspector.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/VariantInspector.tsx
@@ -61,6 +61,7 @@ export interface VariantInspectorProps {
   onCopyAssetToLibrary(assetId: string): void;
   onDeleteAsset(assetId: string): void;
   onGenerateAsset(): void;
+  onRemixAsset(assetId: string): void;
 }
 
 export function VariantInspector({
@@ -81,6 +82,7 @@ export function VariantInspector({
   onCopyAssetToLibrary,
   onDeleteAsset,
   onGenerateAsset,
+  onRemixAsset,
 }: VariantInspectorProps) {
   const [tab, setTab] = useState<TabId>('design');
   const running = variant.status === 'pending' || variant.status === 'running';
@@ -221,6 +223,7 @@ export function VariantInspector({
             onCopyToLibrary={onCopyAssetToLibrary}
             onDelete={onDeleteAsset}
             onGenerate={onGenerateAsset}
+            onRemix={onRemixAsset}
           />
         </TabsContent>
       </Tabs>

--- a/plugins/sero-design-library-plugin/ui/components/design/inspector/AssetsTab.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/inspector/AssetsTab.test.tsx
@@ -43,6 +43,7 @@ const handlers = {
   onCopyToLibrary: vi.fn(),
   onDelete: vi.fn(),
   onGenerate: vi.fn(),
+  onRemix: vi.fn(),
 };
 
 function renderTray(assets: DesignAsset[]) {
@@ -141,6 +142,19 @@ describe('a ready asset', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Delete this asset' }));
     expect(handlers.onDelete).toHaveBeenCalledWith('asset-1');
+  });
+
+  it('opens Remix from the selected Design asset', async () => {
+    renderTray([ready]);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remix' }));
+    expect(handlers.onRemix).toHaveBeenCalledWith('asset-1');
+  });
+
+  it('does not offer a video asset as a Remix source', () => {
+    renderTray([{ ...ready, kind: 'video' }]);
+
+    expect(screen.queryByRole('button', { name: 'Remix' })).toBeNull();
   });
 });
 

--- a/plugins/sero-design-library-plugin/ui/components/design/inspector/AssetsTab.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/inspector/AssetsTab.tsx
@@ -1,5 +1,5 @@
 import { Button, ScrollArea } from '@sero-ai/ui';
-import { Copy, Library, RotateCw, Trash2 } from 'lucide-react';
+import { Copy, Library, RotateCw, Shuffle, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import type { DesignAsset } from '../../../../shared/media';
@@ -29,6 +29,8 @@ export interface AssetsTabProps {
   onDelete(assetId: string): void;
   /** Opens the generation dialog for this Design. */
   onGenerate(): void;
+  /** Opens Remix with this ready image selected as its source. */
+  onRemix(assetId: string): void;
 }
 
 export function AssetsTab({
@@ -38,6 +40,7 @@ export function AssetsTab({
   onCopyToLibrary,
   onDelete,
   onGenerate,
+  onRemix,
 }: AssetsTabProps) {
   const tray = trayView(assets);
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -104,6 +107,7 @@ export function AssetsTab({
           onRetry={() => onRetry(selected.id)}
           onCopyToLibrary={() => onCopyToLibrary(selected.id)}
           onDelete={() => onDelete(selected.id)}
+          onRemix={() => onRemix(selected.id)}
         />
       )}
     </ScrollArea>
@@ -115,9 +119,10 @@ interface AssetDetailProps {
   onRetry(): void;
   onCopyToLibrary(): void;
   onDelete(): void;
+  onRemix(): void;
 }
 
-function AssetDetail({ view, onRetry, onCopyToLibrary, onDelete }: AssetDetailProps) {
+function AssetDetail({ view, onRetry, onCopyToLibrary, onDelete, onRemix }: AssetDetailProps) {
   const [copied, setCopied] = useState(false);
 
   return (
@@ -181,6 +186,19 @@ function AssetDetail({ view, onRetry, onCopyToLibrary, onDelete }: AssetDetailPr
             to this asset are drawn: a disabled button beside a failed generation
             says the tray is broken, where its absence says nothing at all. */}
         <div className="flex flex-wrap items-center gap-2">
+          {view.state === 'ready' && view.kind === 'image' && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="min-w-0 flex-1"
+              onClick={onRemix}
+            >
+              <Shuffle className="size-3.5" />
+              Remix
+            </Button>
+          )}
+
           {view.canRetry && (
             <Button
               type="button"

--- a/plugins/sero-design-library-plugin/ui/hooks/useItemDetail.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useItemDetail.ts
@@ -2,6 +2,8 @@ import { useAppTools } from '@sero-ai/app-runtime';
 import { useEffect, useState } from 'react';
 
 import type { LibrarianField, LibrarianUserFacingAnalysis } from '../../shared/librarian';
+import type { MediaProvenance } from '../../shared/media';
+import { isMediaCapability } from '../../shared/media';
 
 /**
  * The full analysis behind one item.
@@ -25,6 +27,7 @@ export interface ItemDetail {
   width: number;
   height: number;
   bytes: number;
+  generation?: Pick<MediaProvenance, 'capability' | 'prompt' | 'model'>;
 }
 
 interface DetailPayload {
@@ -35,11 +38,29 @@ function num(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
+function parseGeneration(value: unknown): ItemDetail['generation'] {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const generation = value as Record<string, unknown>;
+  if (
+    !isMediaCapability(generation.capability) ||
+    typeof generation.prompt !== 'string' ||
+    typeof generation.model !== 'string'
+  ) {
+    return undefined;
+  }
+  return {
+    capability: generation.capability,
+    prompt: generation.prompt,
+    model: generation.model,
+  };
+}
+
 function parse(details: unknown): ItemDetail | null {
   const item = (details as DetailPayload | undefined)?.item;
   if (!item || typeof item.id !== 'string' || typeof item.analysis !== 'object' || item.analysis === null) {
     return null;
   }
+  const parsedGeneration = parseGeneration((item as Record<string, unknown>).generation);
   return {
     id: item.id,
     analysis: item.analysis as LibrarianUserFacingAnalysis,
@@ -51,6 +72,7 @@ function parse(details: unknown): ItemDetail | null {
     width: num(item.width),
     height: num(item.height),
     bytes: num(item.bytes),
+    ...(parsedGeneration === undefined ? {} : { generation: parsedGeneration }),
   };
 }
 

--- a/plugins/sero-design-library-plugin/ui/lib/asset-view.ts
+++ b/plugins/sero-design-library-plugin/ui/lib/asset-view.ts
@@ -40,10 +40,10 @@ export interface AssetView {
 
 const CAPABILITY_LABELS: Record<DesignAsset['request']['capability'], string> = {
   'text-to-image': 'Image',
-  'image-to-image': 'Restyle',
+  'image-to-image': 'Remix',
   upscale: 'Upscale',
   'text-to-video': 'Video',
-  'image-to-video': 'Image to video',
+  'image-to-video': 'Animate',
 };
 
 export function capabilityLabel(capability: DesignAsset['request']['capability']): string {

--- a/plugins/sero-design-library-plugin/ui/lib/asset-view.ts
+++ b/plugins/sero-design-library-plugin/ui/lib/asset-view.ts
@@ -43,6 +43,7 @@ const CAPABILITY_LABELS: Record<DesignAsset['request']['capability'], string> = 
   'image-to-image': 'Restyle',
   upscale: 'Upscale',
   'text-to-video': 'Video',
+  'image-to-video': 'Image to video',
 };
 
 export function capabilityLabel(capability: DesignAsset['request']['capability']): string {

--- a/plugins/sero-design-library-plugin/ui/pages/DesignPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/DesignPage.tsx
@@ -86,7 +86,7 @@ export function DesignPage({
    * inspector's width.
    */
   const [focused, setFocused] = useState(false);
-  const [generating, setGenerating] = useState(false);
+  const [generation, setGeneration] = useState<{ sourceId?: string } | null>(null);
   const [captureReady, setCaptureReady] = useState(false);
   const [startingGallerySave, setStartingGallerySave] = useState(false);
   const [gallerySaveError, setGallerySaveError] = useState<string>();
@@ -157,6 +157,7 @@ export function DesignPage({
               {
                 id: asset.id,
                 label: asset.request.prompt === '' ? asset.reference : asset.request.prompt,
+                kind: asset.kind,
               },
             ]
           : [],
@@ -330,7 +331,8 @@ export function DesignPage({
                   onRetryAsset={(assetId) => void media.retry(design.id, assetId)}
                   onCopyAssetToLibrary={(assetId) => void media.copyToLibrary(design.id, assetId)}
                   onDeleteAsset={(assetId) => void media.remove(design.id, assetId)}
-                  onGenerateAsset={() => setGenerating(true)}
+                  onGenerateAsset={() => setGeneration({})}
+                  onRemixAsset={(sourceId) => setGeneration({ sourceId })}
                 />
               </ResizablePanel>
               )}
@@ -365,11 +367,15 @@ export function DesignPage({
       </div>
 
       <GenerateDialog
-        open={generating}
+        key={generation?.sourceId ?? 'new'}
+        open={generation !== null}
         target={{ kind: 'design', designId: design.id, designTitle: design.title }}
         sources={assetSources}
         modelOptions={mediaOptions}
-        onOpenChange={setGenerating}
+        {...(generation?.sourceId === undefined ? {} : { initialSourceId: generation.sourceId })}
+        onOpenChange={(open) => {
+          if (!open) setGeneration(null);
+        }}
         onGenerate={(request) => {
           // Nothing waits on the result: the asset is reserved immediately and
           // the tray paints whatever the record says about it from then on.

--- a/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
@@ -134,7 +134,7 @@ export function LibraryPage({
           onRestore={() => applyToPicked((id) => actions.restore(id))}
           onPurge={() => applyToPicked((id) => actions.purge(id))}
           onCreateDesign={() => onCreateDesign(pickedItems)}
-          onRestyle={() => {
+          onRemix={() => {
             const [first] = pickedItems;
             if (first) onGenerate(first);
           }}


### PR DESCRIPTION
## Summary

- separate fresh Generate work from source-based Remix work
- add fal.ai image-to-video support and show original generation requests
- use shared searchable Combobox controls for references and Library filters
- add the enhancement plan, decision entry, prototype, product spec, and user documentation

## Verification

- `pnpm --filter @sero-ai/plugin-design-library test` — 738 tests passed
- `pnpm --filter @sero-ai/plugin-design-library build`
- `npx react-doctor@latest --verbose --scope changed` — 100/100
- `pnpm typecheck` — 24 tasks passed
- all touched source files are below 500 lines

## Notes

- the fal.ai image-to-video default is `fal-ai/kling-video/v2.1/pro/image-to-video`
- the unrelated local `AGENTS.md` change is not part of this PR