### PR TITLE
fix(design-library): use shared generation controls

### DIFF
--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -208,6 +208,7 @@ You can also generate straight into the Library, from the **Generate** button in
 | What | How |
 | --- | --- |
 | A new image or video from a description | **Generate**, then choose the media type |
+| A new image based on a reference | Select one reference, choose **Remix**, then **Image** |
 | A restyled image based on a reference | Select one reference, choose **Remix**, then **Restyle** |
 | A video based on a reference | Select one reference, choose **Remix**, then **Video** |
 | A sharper copy | Select one reference, choose **Remix**, then **Upscale** |

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -209,7 +209,7 @@ You can also generate straight into the Library, from the **Generate** button in
 | A new image or video from a description | **Generate**, then choose the media type |
 | A new image based on a reference | Select one reference, choose **Remix**, then **New image** |
 | A video based on a reference | Select one reference, choose **Remix**, then **New video** |
-| A restyled copy | Select one reference, choose **Remix**, then **New image** |
+| A restyled copy | Select one reference, choose **Remix**, then **Restyle** |
 | A sharper copy | Select one reference, choose **Remix**, then **Upscale** |
 
 Generated references arrive in the Library like any other and are read by the Librarian automatically. Open one to see the original prompt and model at the end of the inspector. While one is on its way it shows as a tile in the grid, so you can see that it is coming rather than wondering whether the button worked.

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -46,7 +46,7 @@ A field you edited is marked **Edited**. Blanking a field counts as an edit, so 
 ## Finding things
 
 - **Search** covers titles, tags, notes and every part of the analysis you can see.
-- **Filters** narrow by media, style, tag, colour and source. Values inside one filter widen the results; different filters narrow them.
+- **Filters** narrow by media, style, tag, colour and source. The colour filter uses families such as Reds, Greens, Blues and Neutrals. Values inside one filter widen the results; different filters narrow them.
 - **Favourites** and **Collections** are yours to arrange. A collection is a plain group you name.
 - **Style groups** appear on their own once two references share a primary style. They are simply what the Librarian already said, counted — nothing extra runs to produce them.
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -207,8 +207,8 @@ You can also generate straight into the Library, from the **Generate** button in
 | What | How |
 | --- | --- |
 | A new image or video from a description | **Generate**, then choose the media type |
-| A new image based on a reference | Select one reference, choose **Remix**, then **New image** |
-| A video based on a reference | Select one reference, choose **Remix**, then **New video** |
+| A new image based on a reference | Select one reference, choose **Remix**, then **Image** |
+| A video based on a reference | Select one reference, choose **Remix**, then **Video** |
 | A restyled copy | Select one reference, choose **Remix**, then **Restyle** |
 | A sharper copy | Select one reference, choose **Remix**, then **Upscale** |
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -48,6 +48,7 @@ A field you edited is marked **Edited**. Blanking a field counts as an edit, so 
 - **Search** covers titles, tags, notes and every part of the analysis you can see.
 - **Filters** narrow by media, style, tag, colour and source. The colour filter uses families such as Reds, Greens, Blues and Neutrals. Values inside one filter widen the results; different filters narrow them.
 - **Favourites** and **Collections** are yours to arrange. A collection is a plain group you name.
+- Select references and open **Collections** to add or remove them. Use the action menu beside a custom collection to delete the collection; its references stay in the Library.
 - **Style groups** appear on their own once two references share a primary style. They are simply what the Librarian already said, counted — nothing extra runs to produce them.
 
 ## Designing from your references
@@ -207,9 +208,8 @@ You can also generate straight into the Library, from the **Generate** button in
 | What | How |
 | --- | --- |
 | A new image or video from a description | **Generate**, then choose the media type |
-| A new image based on a reference | Select one reference, choose **Remix**, then **Image** |
+| A restyled image based on a reference | Select one reference, choose **Remix**, then **Restyle** |
 | A video based on a reference | Select one reference, choose **Remix**, then **Video** |
-| A restyled copy | Select one reference, choose **Remix**, then **Restyle** |
 | A sharper copy | Select one reference, choose **Remix**, then **Upscale** |
 
 Generated references arrive in the Library like any other and are read by the Librarian automatically. Open one to see the original prompt and model at the end of the inspector. While one is on its way it shows as a tile in the grid, so you can see that it is coming rather than wondering whether the button worked.

--- a/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
@@ -50,6 +50,8 @@ The source picker and facet menus use the searchable Combobox from `@sero-ai/ui`
 
 Facet menus use multi-select. Selection ticks appear on the right through the shared component.
 
+The Colour menu groups exact analysed values into named families such as Reds, Greens, Blues, Purples, and Neutrals. Selecting a family includes all current Library colours in that family.
+
 **Reason.** A plain select or complete menu does not scale to thousands of values. A scroll area alone moves the problem into a long scroll.
 
 **Consequence.** Users type to narrow large lists. Selection, keyboard control, filtering and focus behavior stay consistent with other Sero pickers.

--- a/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
@@ -28,11 +28,11 @@ Text-to-video remains the fresh video operation.
 
 ## E3 · Remix keeps explicit create and edit actions
 
-The selected-reference action is named **Remix**. Inside the panel, **New image** uses image-to-image, **New video** uses image-to-video, and **Restyle** and **Upscale** remain under **Edit this reference**.
+The selected-reference action is named **Remix**. Inside the panel, **Image** uses image-to-image, **Video** uses image-to-video, and **Restyle** and **Upscale** remain under **Edit this reference**.
 
 **Reason.** The group labels show the intended result. New image makes a new composition from the reference. Restyle changes the current reference's visual style. Both results remain derived items so the source is safe.
 
-**Consequence.** New image and Restyle both use the vendor-neutral image-to-image capability. Persisted media capability names do not change.
+**Consequence.** Image and Restyle both use the vendor-neutral image-to-image capability. Persisted media capability names do not change.
 
 ## E4 · Original provenance is read-only and last
 

--- a/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
@@ -18,21 +18,21 @@ The selected-reference **Remix** action opens a source-led panel. That panel sep
 
 ## E2 · Remix can create an image or a video from a reference
 
-Remix offers source-aware restyling and video generation. Restyle uses image-to-image. Video uses a new vendor-neutral `image-to-video` capability backed by a configured fal.ai model.
+Remix offers source-aware image generation, restyling, and video generation. Image uses the vendor-neutral `reference-to-image` capability. Restyle uses `image-to-image`. Video uses `image-to-video`. Each capability is backed by a configured fal.ai model.
 
 Text-to-video remains the fresh video operation.
 
-**Reason.** A movie based on a reference must send that reference to the provider. Reusing text-to-video would silently ignore it.
+**Reason.** New media based on a reference must send that reference to the provider. Reusing text-only capabilities would silently ignore it.
 
-**Consequence.** Settings gain one editable image-to-video model id. Existing profiles normalize with an empty override and therefore use the adapter default.
+**Consequence.** Settings gain editable reference-to-image and image-to-video model ids. Existing profiles normalize with empty overrides and therefore use the adapter defaults.
 
 ## E3 · Remix keeps explicit create and edit actions
 
-The selected-reference action is named **Remix**. Inside the panel, **Video** uses image-to-video, and **Restyle** and **Upscale** remain under **Edit this reference**.
+The selected-reference action is named **Remix**. **Image** and **Video** remain under **Create new**. **Restyle** and **Upscale** remain under **Edit this reference**.
 
-**Reason.** Restyle and Image previously sent the same request. One image-to-image action states the real capability without offering a duplicate control.
+**Reason.** Image and Restyle have different user intentions. Image makes new artwork that uses the source as visual direction. Restyle edits the source's visual style.
 
-**Consequence.** Restyle is the only image-to-image operation. Persisted media capability names do not change.
+**Consequence.** Image sends `reference-to-image`. Restyle sends `image-to-image`. Existing profiles gain an empty reference-to-image model override and use the fal.ai adapter default.
 
 ## E4 · Original provenance is read-only and last
 

--- a/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
@@ -18,7 +18,7 @@ The selected-reference **Remix** action opens a source-led panel. That panel sep
 
 ## E2 · Remix can create an image or a video from a reference
 
-Remix offers source-aware image and video generation. Image generation uses image-to-image. Video generation uses a new vendor-neutral `image-to-video` capability backed by a configured fal.ai model.
+Remix offers source-aware restyling and video generation. Restyle uses image-to-image. Video uses a new vendor-neutral `image-to-video` capability backed by a configured fal.ai model.
 
 Text-to-video remains the fresh video operation.
 
@@ -28,11 +28,11 @@ Text-to-video remains the fresh video operation.
 
 ## E3 · Remix keeps explicit create and edit actions
 
-The selected-reference action is named **Remix**. Inside the panel, **Image** uses image-to-image, **Video** uses image-to-video, and **Restyle** and **Upscale** remain under **Edit this reference**.
+The selected-reference action is named **Remix**. Inside the panel, **Video** uses image-to-video, and **Restyle** and **Upscale** remain under **Edit this reference**.
 
-**Reason.** The group labels show the intended result. New image makes a new composition from the reference. Restyle changes the current reference's visual style. Both results remain derived items so the source is safe.
+**Reason.** Restyle and Image previously sent the same request. One image-to-image action states the real capability without offering a duplicate control.
 
-**Consequence.** Image and Restyle both use the vendor-neutral image-to-image capability. Persisted media capability names do not change.
+**Consequence.** Restyle is the only image-to-image operation. Persisted media capability names do not change.
 
 ## E4 · Original provenance is read-only and last
 
@@ -74,3 +74,11 @@ Mandatory confirmation, duration limits, cost tracking, pending states, frame ca
 **Reason.** Source input does not change the spend or lifecycle risks of video generation.
 
 **Consequence.** Shared video checks use an explicit video-capability predicate instead of one direct equality check.
+
+## E8 · Collection membership and deletion are visible
+
+The selected-reference bar lists collections as checked items. Clearing a check removes the selected references from that collection. Each custom collection row has an action menu with **Delete collection**.
+
+**Reason.** An add-only menu and collection rows with no actions hide existing runtime capabilities.
+
+**Consequence.** Deleting a collection returns an active collection view to All inspiration. It does not delete the references in the collection.

--- a/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-library-workflow-enhancement-decisions.md
@@ -26,13 +26,13 @@ Text-to-video remains the fresh video operation.
 
 **Consequence.** Settings gain one editable image-to-video model id. Existing profiles normalize with an empty override and therefore use the adapter default.
 
-## E3 · Remix has one image-to-image operation
+## E3 · Remix keeps explicit create and edit actions
 
-The selected-reference action is named **Remix**. Inside the panel, **New image** uses image-to-image, **New video** uses image-to-video, and **Upscale** remains under **Edit this reference**.
+The selected-reference action is named **Remix**. Inside the panel, **New image** uses image-to-image, **New video** uses image-to-video, and **Restyle** and **Upscale** remain under **Edit this reference**.
 
-**Reason.** New image and Restyle sent the same request. Two labels must not promise two operations when the runtime cannot tell them apart.
+**Reason.** The group labels show the intended result. New image makes a new composition from the reference. Restyle changes the current reference's visual style. Both results remain derived items so the source is safe.
 
-**Consequence.** The first-release Restyle action becomes Remix → New image. Persisted media capability names do not change.
+**Consequence.** New image and Restyle both use the vendor-neutral image-to-image capability. Persisted media capability names do not change.
 
 ## E4 · Original provenance is read-only and last
 
@@ -54,16 +54,16 @@ Facet menus use multi-select. Selection ticks appear on the right through the sh
 
 **Consequence.** Users type to narrow large lists. Selection, keyboard control, filtering and focus behavior stay consistent with other Sero pickers.
 
-## E6 · The generation choice uses grouped controls, not flat tabs
+## E6 · Generation choices use shared line tabs
 
-Fresh Generate uses a small option grid. Remix uses two labelled option groups:
+Fresh Generate uses one line-tab row. Remix uses line tabs in two labelled groups:
 
 - **Create new**
 - **Edit this reference**
 
-**Reason.** Tabs imply peer views. These controls select an operation and include an important source-versus-output distinction.
+**Reason.** The shared `@sero-ai/ui` line tabs match the inspector and give each group a clear, standard selection state.
 
-**Consequence.** The panel uses selectable controls that match the inspector’s border, spacing, focus, and selected-state language.
+**Consequence.** The panel does not implement a local operation picker.
 
 ## E7 · Video protections apply to both video capabilities
 

--- a/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
+++ b/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
@@ -57,13 +57,12 @@ When one reference is selected, the action bar shows **Remix** instead of **Rest
 The Remix panel starts with that reference selected. It has two groups:
 
 - **Create new**
-  - Image — image-to-image
   - Video — image-to-video
 - **Edit this reference**
   - Restyle — image-to-image
   - Upscale — upscale
 
-**Image** creates a new composition from the reference. **Restyle** changes its visual style. Both use image-to-image, create a derived item, and keep the source item unchanged.
+**Restyle** creates a derived image and keeps the source item unchanged. It is the only image-to-image operation.
 
 Image-to-video is a new application capability backed by the configured fal.ai image-to-video model. It sends the selected reference as the source. It does not reuse text-to-video and does not discard the source.
 
@@ -218,13 +217,15 @@ These completed changes have low complexity and support the requested flow:
 
 - Keep the last typed prompt when the user changes operation inside one open panel.
 - Clear an invalid aspect or duration choice when the selected model does not support it.
+- Make collection membership a checked action that supports add and remove.
+- Add custom collection deletion without deleting its references.
 
 The scope does not include video import, webpage capture, clipboard HTML, semantic search, plugin output, arbitrary npm dependencies, mixed output targets, pinning, or archiving.
 
 ## 9. Resolved review questions
 
 1. Use **Create new** and **Edit this reference** as the group names.
-2. **Image** creates a derived item from the selected reference.
-3. Do not show two controls that send the same image-to-image request.
+2. **Restyle** creates a derived item from the selected reference.
+3. Restyle is the only control that sends an image-to-image request.
 4. Shared `@sero-ai/ui` Combobox behavior supplies search, bounded height, multi-select and right-side ticks. Do not duplicate these controls in the plugin.
 5. The Colour Combobox shows named colour families instead of raw colour codes.

--- a/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
+++ b/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
@@ -60,9 +60,10 @@ The Remix panel starts with that reference selected. It has two groups:
   - New image — image-to-image
   - New video — image-to-video
 - **Edit this reference**
+  - Restyle — image-to-image
   - Upscale — upscale
 
-**New image** replaces the separate Restyle operation. Both controls sent the same image-to-image request, so separate labels promised a difference that did not exist. It creates a derived item and keeps the source item unchanged.
+**New image** creates a new composition from the reference. **Restyle** changes its visual style. Both use image-to-image, create a derived item, and keep the source item unchanged.
 
 Image-to-video is a new application capability backed by the configured fal.ai image-to-video model. It sends the selected reference as the source. It does not reuse text-to-video and does not discard the source.
 

--- a/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
+++ b/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
@@ -57,12 +57,13 @@ When one reference is selected, the action bar shows **Remix** instead of **Rest
 The Remix panel starts with that reference selected. It has two groups:
 
 - **Create new**
+  - Image — reference-to-image
   - Video — image-to-video
 - **Edit this reference**
   - Restyle — image-to-image
   - Upscale — upscale
 
-**Restyle** creates a derived image and keeps the source item unchanged. It is the only image-to-image operation.
+**Image** creates new artwork that uses the selected reference as visual direction. **Restyle** changes the selected image's visual style. Both create a derived Library item and keep the source item unchanged.
 
 Image-to-video is a new application capability backed by the configured fal.ai image-to-video model. It sends the selected reference as the source. It does not reuse text-to-video and does not discard the source.
 
@@ -174,6 +175,8 @@ The model id remains editable in Settings. The user chooses a capability, not an
 - [x] Replace the flat capability tabs with grouped option controls.
 - [x] Hide source operations from fresh Generate.
 - [x] Rename the selection action to Remix.
+- [x] Keep Image and Video under Create new.
+- [x] Give reference-based Image and Restyle separate capabilities.
 - [x] Increase the prompt area.
 - [x] Add dialog behavior and accessibility tests.
 
@@ -200,16 +203,18 @@ The model id remains editable in Settings. The user chooses a capability, not an
 
 1. Fresh Generate has only Image and Video.
 2. Remix opens with the selected reference and shows two clear operation groups.
-3. Remix → Video sends the reference to an image-to-video fal.ai model.
-4. No operation silently ignores a selected source.
-5. The original prompt appears only when provenance exists and is last in the inspector.
-6. The Librarian generation prompt remains editable and distinct from the original prompt.
-7. A source among 5,000 references can be found by typing part of its title.
-8. A filter facet with 5,000 values has a fixed-height searchable list.
-9. Filter ticks appear on the right.
-10. The prompt area is visibly larger than the first-release control.
-11. Existing generated and imported records still normalize without data loss.
-12. Video confirmation and duration limits apply to text-to-video and image-to-video.
+3. Remix → Image sends the reference to a reference-to-image fal.ai model.
+4. Remix → Restyle sends an image-to-image request that is distinct from Image.
+5. Remix → Video sends the reference to an image-to-video fal.ai model.
+6. No operation silently ignores a selected source.
+7. The original prompt appears only when provenance exists and is last in the inspector.
+8. The Librarian generation prompt remains editable and distinct from the original prompt.
+9. A source among 5,000 references can be found by typing part of its title.
+10. A filter facet with 5,000 values has a fixed-height searchable list.
+11. Filter ticks appear on the right.
+12. The prompt area is visibly larger than the first-release control.
+13. Existing generated and imported records still normalize without data loss.
+14. Video confirmation and duration limits apply to text-to-video and image-to-video.
 
 ## 8. Small workflow improvements included
 
@@ -226,6 +231,6 @@ The scope does not include video import, webpage capture, clipboard HTML, semant
 
 1. Use **Create new** and **Edit this reference** as the group names.
 2. **Restyle** creates a derived item from the selected reference.
-3. Restyle is the only control that sends an image-to-image request.
+3. Image creates new artwork from a reference. Restyle changes the reference's style.
 4. Shared `@sero-ai/ui` Combobox behavior supplies search, bounded height, multi-select and right-side ticks. Do not duplicate these controls in the plugin.
 5. The Colour Combobox shows named colour families instead of raw colour codes.

--- a/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
+++ b/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
@@ -227,3 +227,4 @@ The scope does not include video import, webpage capture, clipboard HTML, semant
 2. **Image** creates a derived item from the selected reference.
 3. Do not show two controls that send the same image-to-image request.
 4. Shared `@sero-ai/ui` Combobox behavior supplies search, bounded height, multi-select and right-side ticks. Do not duplicate these controls in the plugin.
+5. The Colour Combobox shows named colour families instead of raw colour codes.

--- a/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
+++ b/docs/plans/sero-design-library-library-workflow-enhancements-plan.md
@@ -45,8 +45,8 @@ The Library header **Generate** action starts without a source reference. The pa
 
 It offers only:
 
-- **New image** — text-to-image
-- **New video** — text-to-video
+- **Image** — text-to-image
+- **Video** — text-to-video
 
 It does not show Restyle or Upscale. It does not show a source picker.
 
@@ -57,13 +57,13 @@ When one reference is selected, the action bar shows **Remix** instead of **Rest
 The Remix panel starts with that reference selected. It has two groups:
 
 - **Create new**
-  - New image — image-to-image
-  - New video — image-to-video
+  - Image — image-to-image
+  - Video — image-to-video
 - **Edit this reference**
   - Restyle — image-to-image
   - Upscale — upscale
 
-**New image** creates a new composition from the reference. **Restyle** changes its visual style. Both use image-to-image, create a derived item, and keep the source item unchanged.
+**Image** creates a new composition from the reference. **Restyle** changes its visual style. Both use image-to-image, create a derived item, and keep the source item unchanged.
 
 Image-to-video is a new application capability backed by the configured fal.ai image-to-video model. It sends the selected reference as the source. It does not reuse text-to-video and does not discard the source.
 
@@ -182,7 +182,7 @@ The model id remains editable in Settings. The user chooses a capability, not an
 
 - [x] Add the vendor-neutral capability and settings migration.
 - [x] Add fal.ai request and result mapping.
-- [x] Route Remix → New video through the source-aware capability.
+- [x] Route Remix → Video through the source-aware capability.
 - [x] Confirm spend before every video request.
 - [x] Add provider contract, runtime, and UI tests.
 
@@ -199,9 +199,9 @@ The model id remains editable in Settings. The user chooses a capability, not an
 
 ## 7. Acceptance checks
 
-1. Fresh Generate has only New image and New video.
+1. Fresh Generate has only Image and Video.
 2. Remix opens with the selected reference and shows two clear operation groups.
-3. Remix → New video sends the reference to an image-to-video fal.ai model.
+3. Remix → Video sends the reference to an image-to-video fal.ai model.
 4. No operation silently ignores a selected source.
 5. The original prompt appears only when provenance exists and is last in the inspector.
 6. The Librarian generation prompt remains editable and distinct from the original prompt.
@@ -224,6 +224,6 @@ The scope does not include video import, webpage capture, clipboard HTML, semant
 ## 9. Resolved review questions
 
 1. Use **Create new** and **Edit this reference** as the group names.
-2. **New image** keeps the first-release Restyle behavior and creates a derived item.
+2. **Image** creates a derived item from the selected reference.
 3. Do not show two controls that send the same image-to-image request.
 4. Shared `@sero-ai/ui` Combobox behavior supplies search, bounded height, multi-select and right-side ticks. Do not duplicate these controls in the plugin.

--- a/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
+++ b/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
@@ -51,20 +51,11 @@
     .body { flex: 1; padding: 19px 21px 22px; }
     .group + .group { margin-top: 18px; }
     .group-label { margin-bottom: 8px; color: var(--muted); font-size: 11px; font-weight: 650; }
-    .options { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-    .option {
-      min-height: 64px;
-      padding: 11px 12px;
-      text-align: left;
-      color: var(--muted);
-      background: var(--bg);
-      border: 1px solid var(--line);
-      border-radius: 8px;
-    }
-    .option strong { display: block; color: var(--text); font-size: 13px; font-weight: 600; }
-    .option span { display: block; margin-top: 3px; color: var(--quiet); font-size: 11px; }
-    .option.active { border-color: var(--accent); background: var(--accent-wash); }
-    .option.active strong { color: #a9ddf2; }
+    .tabs { display: flex; gap: 6px; border-bottom: 1px solid var(--line); }
+    .tab { position: relative; padding: 7px 10px; color: var(--muted); background: transparent; border: 0; }
+    .tab.active { color: var(--text); }
+    .tab.active::after { position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; content: ""; background: var(--text); }
+    .tab-note { margin: 9px 0 0; color: var(--quiet); font-size: 12px; }
     .field { margin-top: 18px; }
     label { display: block; margin-bottom: 7px; color: #ddddE2; font-size: 12px; font-weight: 560; }
     .picker {
@@ -116,10 +107,8 @@
           </div>
           <div class="body">
             <div class="group">
-              <div class="options">
-                <button class="option active"><strong>New image</strong><span>Create an image from your description</span></button>
-                <button class="option"><strong>New video</strong><span>Create a video from your description</span></button>
-              </div>
+              <div class="tabs"><button class="tab active">New image</button><button class="tab">New video</button></div>
+              <p class="tab-note">Create an image from your description</p>
             </div>
             <div class="field">
               <label for="fresh-prompt">Describe it</label>
@@ -143,16 +132,12 @@
           <div class="body">
             <div class="group">
               <div class="group-label">Create new</div>
-              <div class="options">
-                <button class="option active"><strong>New image</strong><span>Use this reference as visual direction</span></button>
-                <button class="option"><strong>New video</strong><span>Animate from this reference</span></button>
-              </div>
+              <div class="tabs"><button class="tab active">New image</button><button class="tab">New video</button></div>
+              <p class="tab-note">Use this reference as visual direction</p>
             </div>
             <div class="group">
               <div class="group-label">Edit this reference</div>
-              <div class="options" style="grid-template-columns:1fr">
-                <button class="option"><strong>Upscale</strong><span>Increase its resolution</span></button>
-              </div>
+              <div class="tabs"><button class="tab">Restyle</button><button class="tab">Upscale</button></div>
             </div>
             <div class="field">
               <label>Work from</label>

--- a/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
+++ b/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
@@ -130,7 +130,7 @@
           <div class="body">
             <div class="group">
               <div class="group-label">Create new</div>
-              <div class="tabs"><button class="tab">Video</button></div>
+              <div class="tabs"><button class="tab">Image</button><button class="tab">Video</button></div>
             </div>
             <div class="group">
               <div class="group-label">Edit this reference</div>

--- a/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
+++ b/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
@@ -55,7 +55,6 @@
     .tab { position: relative; padding: 7px 10px; color: var(--muted); background: transparent; border: 0; }
     .tab.active { color: var(--accent); }
     .tab.active::after { position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; content: ""; background: var(--accent); }
-    .tab-note { margin: 9px 0 0; color: var(--quiet); font-size: 12px; }
     .field { margin-top: 18px; }
     label { display: block; margin-bottom: 7px; color: #ddddE2; font-size: 12px; font-weight: 560; }
     .picker {
@@ -132,7 +131,6 @@
             <div class="group">
               <div class="group-label">Create new</div>
               <div class="tabs"><button class="tab active">Image</button><button class="tab">Video</button></div>
-              <p class="tab-note">Use this reference as visual direction</p>
             </div>
             <div class="group">
               <div class="group-label">Edit this reference</div>

--- a/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
+++ b/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
@@ -51,10 +51,10 @@
     .body { flex: 1; padding: 19px 21px 22px; }
     .group + .group { margin-top: 18px; }
     .group-label { margin-bottom: 8px; color: var(--muted); font-size: 11px; font-weight: 650; }
-    .tabs { display: flex; gap: 6px; border-bottom: 1px solid var(--line); }
+    .tabs { display: flex; gap: 6px; }
     .tab { position: relative; padding: 7px 10px; color: var(--muted); background: transparent; border: 0; }
-    .tab.active { color: var(--text); }
-    .tab.active::after { position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; content: ""; background: var(--text); }
+    .tab.active { color: var(--accent); }
+    .tab.active::after { position: absolute; right: 0; bottom: -1px; left: 0; height: 2px; content: ""; background: var(--accent); }
     .tab-note { margin: 9px 0 0; color: var(--quiet); font-size: 12px; }
     .field { margin-top: 18px; }
     label { display: block; margin-bottom: 7px; color: #ddddE2; font-size: 12px; font-weight: 560; }
@@ -87,7 +87,7 @@
     .select span { margin-left: auto; color: var(--quiet); }
     .foot { min-height: 67px; display: flex; align-items: center; gap: 16px; padding: 13px 21px; border-top: 1px solid var(--line); }
     .foot p { flex: 1; margin: 0; color: var(--quiet); font-size: 11px; }
-    .primary { height: 37px; padding: 0 15px; color: #071319; background: var(--accent); border: 0; border-radius: 8px; font-weight: 670; }
+    .primary { height: 37px; margin-left: auto; padding: 0 15px; color: #071319; background: var(--accent); border: 0; border-radius: 8px; font-weight: 670; }
     .callout { margin-top: 28px; padding: 16px 18px; border-left: 2px solid var(--accent); background: #0d0d10; color: var(--muted); font-size: 12px; }
     .callout b { color: var(--text); }
   </style>
@@ -107,8 +107,7 @@
           </div>
           <div class="body">
             <div class="group">
-              <div class="tabs"><button class="tab active">New image</button><button class="tab">New video</button></div>
-              <p class="tab-note">Create an image from your description</p>
+              <div class="tabs"><button class="tab active">Image</button><button class="tab">Video</button></div>
             </div>
             <div class="field">
               <label for="fresh-prompt">Describe it</label>
@@ -118,7 +117,7 @@
               <div><label>Aspect</label><div class="select">16:9 <span>⌄</span></div></div>
             </div>
           </div>
-          <div class="foot"><p>The model behind each capability is a setting, not a choice made here.</p><button class="primary">Generate image</button></div>
+          <div class="foot"><button class="primary">Generate image</button></div>
         </div>
       </section>
 
@@ -132,7 +131,7 @@
           <div class="body">
             <div class="group">
               <div class="group-label">Create new</div>
-              <div class="tabs"><button class="tab active">New image</button><button class="tab">New video</button></div>
+              <div class="tabs"><button class="tab active">Image</button><button class="tab">Video</button></div>
               <p class="tab-note">Use this reference as visual direction</p>
             </div>
             <div class="group">

--- a/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
+++ b/docs/prototypes/sero-design-library-generation-workflow-enhancement.html
@@ -130,11 +130,11 @@
           <div class="body">
             <div class="group">
               <div class="group-label">Create new</div>
-              <div class="tabs"><button class="tab active">Image</button><button class="tab">Video</button></div>
+              <div class="tabs"><button class="tab">Video</button></div>
             </div>
             <div class="group">
               <div class="group-label">Edit this reference</div>
-              <div class="tabs"><button class="tab">Restyle</button><button class="tab">Upscale</button></div>
+              <div class="tabs"><button class="tab active">Restyle</button><button class="tab">Upscale</button></div>
             </div>
             <div class="field">
               <label>Work from</label>

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -338,6 +338,7 @@ The application speaks in capabilities and opaque model ids. Vendor specifics li
 ```ts
 type MediaCapability =
   | 'text-to-image'
+  | 'reference-to-image'
   | 'image-to-image'
   | 'upscale'
   | 'text-to-video'
@@ -348,7 +349,7 @@ interface MediaRequest {
   prompt: string;
   /** Opaque provider model id. Defaults come from settings. */
   model?: string;
-  /** Local source assets for image-to-image, upscale and image-to-video. */
+  /** Local source assets for reference-to-image, image-to-image, upscale and image-to-video. */
   sourceAssetIds?: string[];
   aspectRatio?: string;
   seed?: number;
@@ -414,7 +415,7 @@ No vendor type appears in this contract, in UI code, in Design or Gallery domain
 
 - configures credentials at call time and never persists them;
 - maps each capability to a configured endpoint id and runs it through the client's queue-subscribe API, forwarding the `AbortSignal` and reporting queue progress through `onProgress`;
-- uploads local source assets through the client's storage API for image-to-image and upscale;
+- uploads local source assets through the client's storage API for reference-to-image, image-to-image, upscale and image-to-video;
 - downloads every result into plugin-owned storage via `context.store` before returning, so no remote URL escapes the adapter;
 - normalises failures into `MediaError` with an honest `retryable`.
 

--- a/plugins/sero-design-library-plugin/extension/tools/media.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/media.test.ts
@@ -94,8 +94,8 @@ describe('refusing a generation', () => {
     expect(await requests()).toEqual([]);
   });
 
-  it('needs a source for image-to-image and upscale, naming the parameter', async () => {
-    for (const capability of ['image-to-image', 'upscale']) {
+  it('needs a source for reference images, restyles and upscale, naming the parameter', async () => {
+    for (const capability of ['reference-to-image', 'image-to-image', 'upscale']) {
       const result = await call({ ...GENERATE, capability, prompt: 'sharper' });
       expect(textOf(result), capability).toContain('`sourceId`');
     }

--- a/plugins/sero-design-library-plugin/extension/tools/media.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/media.ts
@@ -115,7 +115,7 @@ export function registerMediaTool(pi: ExtensionAPI, paths: DesignLibraryPaths): 
       capability: Type.Optional(
         StringEnum(MEDIA_CAPABILITIES as MediaCapability[], {
           description:
-            'text-to-image makes artwork from a description; image-to-image restyles a source; upscale raises a source\'s resolution; text-to-video makes a short clip; image-to-video animates a source image',
+            'text-to-image makes artwork from a description; reference-to-image makes new artwork from a source; image-to-image restyles a source; upscale raises a source\'s resolution; text-to-video makes a short clip; image-to-video animates a source image',
         }),
       ),
       prompt: Type.Optional(

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -116,10 +116,10 @@ describe('media settings', () => {
       kind: 'settings.update',
       patch: { media: { models: { 'text-to-video': 'fast-video' } } },
     });
-    // The other three keep whatever they had, rather than being cleared by a
+    // The other capabilities keep whatever they had, rather than being cleared by a
     // patch that only named one.
     const patch = (queued?.body as { patch: { media: { models: Record<string, string> } } }).patch;
-    expect(Object.keys(patch.media.models)).toHaveLength(5);
+    expect(Object.keys(patch.media.models)).toHaveLength(6);
   });
 
   it('keeps the per-run cap inside its range', async () => {

--- a/plugins/sero-design-library-plugin/runtime/media/contract.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/contract.ts
@@ -24,7 +24,7 @@ export interface MediaRequest {
   prompt: string;
   /** Opaque provider model id. Defaults come from settings (spec §10). */
   model?: string;
-  /** Local source assets for image-to-image and upscale. */
+  /** Local source assets for source-aware image and video capabilities. */
   sourceAssetIds?: string[];
   aspectRatio?: string;
   seed?: number;
@@ -70,7 +70,7 @@ export function isMediaError(value: unknown): value is MediaError {
   return value instanceof MediaError;
 }
 
-/** A local asset an adapter may upload as a source for image-to-image or upscale. */
+/** A local asset an adapter may upload for a source-aware capability. */
 export interface MediaSourceAsset {
   path: string;
   bytes: Uint8Array;

--- a/plugins/sero-design-library-plugin/runtime/media/execute.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/execute.ts
@@ -26,7 +26,7 @@ export interface ExecuteMediaOptions {
   /** Directory the produced files land in. Created if it is not there. */
   directory: string;
   signal: AbortSignal;
-  /** Resolves a local source for image-to-image and upscale. */
+  /** Resolves a local source for a source-aware capability. */
   readAsset(assetId: string): Promise<MediaSourceAsset>;
   onProgress?(message: string): void;
 }

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fake.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fake.ts
@@ -21,6 +21,7 @@ import { MediaError } from '../contract';
 
 const CAPABILITY_MODELS: Record<MediaCapability, string> = {
   'text-to-image': 'fake/image',
+  'reference-to-image': 'fake/reference-image',
   'image-to-image': 'fake/image-edit',
   upscale: 'fake/upscale',
   'text-to-video': 'fake/video',

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.test.ts
@@ -2,6 +2,27 @@ import { describe, expect, it } from 'vitest';
 
 import { buildFalInput } from './fal-input';
 
+describe('fal reference-to-image input', () => {
+  it('sends the source image and new composition prompt', () => {
+    expect(
+      buildFalInput(
+        {
+          capability: 'reference-to-image',
+          prompt: 'a new coastal composition',
+          sourceAssetIds: ['reference'],
+          aspectRatio: '16:9',
+        },
+        ['https://fal.media/source.png'],
+        new Map(),
+      ),
+    ).toEqual({
+      prompt: 'a new coastal composition',
+      image_url: 'https://fal.media/source.png',
+      image_size: 'landscape_16_9',
+    });
+  });
+});
+
 describe('fal image-to-video input', () => {
   it('sends the source image and normalized video controls', () => {
     expect(

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal-input.ts
@@ -48,6 +48,7 @@ export function buildFalInput(
         ...(size === undefined ? {} : { image_size: size }),
         ...shared,
       };
+    case 'reference-to-image':
     case 'image-to-image':
       return {
         prompt: request.prompt,

--- a/plugins/sero-design-library-plugin/runtime/media/providers/fal.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/providers/fal.ts
@@ -39,6 +39,7 @@ import { MediaError } from '../contract';
  */
 export const FAL_DEFAULT_MODELS: Record<MediaCapability, string> = {
   'text-to-image': 'fal-ai/flux/dev',
+  'reference-to-image': 'fal-ai/flux/dev/image-to-image',
   'image-to-image': 'fal-ai/flux/dev/image-to-image',
   upscale: 'fal-ai/clarity-upscaler',
   'text-to-video': 'fal-ai/kling-video/v1/standard/text-to-video',

--- a/plugins/sero-design-library-plugin/runtime/media/tools.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/tools.test.ts
@@ -57,6 +57,7 @@ describe('media tools', () => {
 
     expect(tools.map((tool) => tool.name)).toEqual([
       'design_library_generate_image',
+      'design_library_generate_image_from_reference',
       'design_library_restyle_image',
       'design_library_upscale_image',
       'design_library_generate_video',

--- a/plugins/sero-design-library-plugin/runtime/media/tools.ts
+++ b/plugins/sero-design-library-plugin/runtime/media/tools.ts
@@ -71,6 +71,17 @@ const SHAPES: Record<MediaCapability, CapabilityShape> = {
       seed: Type.Optional(Type.Number({ description: 'For a repeatable result.' })),
     }),
   },
+  'reference-to-image': {
+    name: 'design_library_generate_image_from_reference',
+    label: 'Generate Image from Reference',
+    summary: 'Generates new artwork that uses an existing image as visual direction.',
+    parameters: Type.Object({
+      prompt: Type.String({ description: 'What the new image should show, in detail.' }),
+      sourceId: Type.String({ description: 'Id of an asset you generated, or a Library item.' }),
+      aspectRatio: Type.Optional(Type.String()),
+      seed: Type.Optional(Type.Number()),
+    }),
+  },
   'image-to-image': {
     name: 'design_library_restyle_image',
     label: 'Restyle Image',

--- a/plugins/sero-design-library-plugin/shared/colour-families.ts
+++ b/plugins/sero-design-library-plugin/shared/colour-families.ts
@@ -1,0 +1,84 @@
+/** Stable colour families used by the Library filter. */
+
+export const COLOUR_FAMILIES = [
+  'Reds',
+  'Oranges',
+  'Yellows',
+  'Greens',
+  'Cyans',
+  'Blues',
+  'Purples',
+  'Pinks',
+  'Neutrals',
+  'Other colours',
+] as const;
+
+export type ColourFamily = (typeof COLOUR_FAMILIES)[number];
+
+interface Rgb {
+  red: number;
+  green: number;
+  blue: number;
+}
+
+const HUE_FAMILIES: { upperBound: number; family: ColourFamily }[] = [
+  { upperBound: 15, family: 'Reds' },
+  { upperBound: 45, family: 'Oranges' },
+  { upperBound: 70, family: 'Yellows' },
+  { upperBound: 165, family: 'Greens' },
+  { upperBound: 200, family: 'Cyans' },
+  { upperBound: 260, family: 'Blues' },
+  { upperBound: 320, family: 'Purples' },
+  { upperBound: 345, family: 'Pinks' },
+];
+
+export function isColourFamily(value: unknown): value is ColourFamily {
+  return typeof value === 'string' && (COLOUR_FAMILIES as readonly string[]).includes(value);
+}
+
+function rgbFromHex(value: string): Rgb | null {
+  const match = /^#([\da-f]{3}|[\da-f]{6}|[\da-f]{8})$/i.exec(value);
+  if (!match) return null;
+
+  const compact = match[1];
+  let hex = compact.slice(0, 6);
+  if (compact.length === 3) {
+    hex = compact.split('').map((digit) => `${digit}${digit}`).join('');
+  }
+  return {
+    red: Number.parseInt(hex.slice(0, 2), 16) / 255,
+    green: Number.parseInt(hex.slice(2, 4), 16) / 255,
+    blue: Number.parseInt(hex.slice(4, 6), 16) / 255,
+  };
+}
+
+function hueFor({ red, green, blue }: Rgb, maximum: number, difference: number): number {
+  let hueBase: number;
+  if (maximum === red) hueBase = (green - blue) / difference;
+  else if (maximum === green) hueBase = (blue - red) / difference + 2;
+  else hueBase = (red - green) / difference + 4;
+  return (hueBase * 60 + 360) % 360;
+}
+
+export function colourFamily(value: string): ColourFamily {
+  const rgb = rgbFromHex(value);
+  if (!rgb) return 'Other colours';
+
+  const { red, green, blue } = rgb;
+  const maximum = Math.max(red, green, blue);
+  const minimum = Math.min(red, green, blue);
+  const difference = maximum - minimum;
+  const lightness = (maximum + minimum) / 2;
+  const saturation = difference / Math.max(1 - Math.abs(2 * lightness - 1), Number.EPSILON);
+
+  if (lightness < 0.08 || lightness > 0.92 || saturation < 0.16) return 'Neutrals';
+
+  const hue = hueFor(rgb, maximum, difference);
+  return HUE_FAMILIES.find((entry) => hue < entry.upperBound)?.family ?? 'Reds';
+}
+
+export function availableColourFamilies(colours: string[]): ColourFamily[] {
+  const available = new Set<ColourFamily>();
+  for (const colour of colours) available.add(colourFamily(colour));
+  return COLOUR_FAMILIES.filter((family) => available.has(family));
+}

--- a/plugins/sero-design-library-plugin/shared/media.ts
+++ b/plugins/sero-design-library-plugin/shared/media.ts
@@ -13,6 +13,7 @@ import { isSafeId } from './safe-id';
 
 export type MediaCapability =
   | 'text-to-image'
+  | 'reference-to-image'
   | 'image-to-image'
   | 'upscale'
   | 'text-to-video'
@@ -20,6 +21,7 @@ export type MediaCapability =
 
 export const MEDIA_CAPABILITIES: readonly MediaCapability[] = [
   'text-to-image',
+  'reference-to-image',
   'image-to-image',
   'upscale',
   'text-to-video',
@@ -32,6 +34,7 @@ export function isMediaCapability(value: unknown): value is MediaCapability {
 
 /** Capabilities that consume local source assets, so callers can check before asking. */
 export const SOURCE_CAPABILITIES: readonly MediaCapability[] = [
+  'reference-to-image',
   'image-to-image',
   'upscale',
   'image-to-video',

--- a/plugins/sero-design-library-plugin/shared/search.test.ts
+++ b/plugins/sero-design-library-plugin/shared/search.test.ts
@@ -83,6 +83,24 @@ describe('filters', () => {
   it('treats an empty facet as inactive', () => {
     expect(selectItems(ITEMS, view({ filters: EMPTY_FILTERS }), NOW)).toHaveLength(3);
   });
+
+  it('matches a colour family without storing the current exact colours', () => {
+    const red = item({ id: 'red', colours: ['#e53935'] });
+    const laterRed = item({ id: 'later-red', colours: ['#b71c1c'] });
+    const filters = { ...EMPTY_FILTERS, colourFamilies: ['Reds' as const] };
+
+    expect(selectItems([red, laterRed], view({ filters }), NOW).map((entry) => entry.id)).toEqual([
+      'red',
+      'later-red',
+    ]);
+  });
+
+  it('treats near-black tints as neutrals', () => {
+    const nearBlack = item({ id: 'near-black', colours: ['#03090c'] });
+    const filters = { ...EMPTY_FILTERS, colourFamilies: ['Neutrals' as const] };
+
+    expect(selectItems([nearBlack], view({ filters }), NOW)).toEqual([nearBlack]);
+  });
 });
 
 describe('sorting', () => {

--- a/plugins/sero-design-library-plugin/shared/search.ts
+++ b/plugins/sero-design-library-plugin/shared/search.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ItemSummary, LibraryFilters, LibraryScope, LibrarySort, ViewPreferences } from './types';
+import { colourFamily } from './colour-families';
 
 const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -46,7 +47,11 @@ export function matchesFilters(item: ItemSummary, filters: LibraryFilters): bool
   if (!passesList(filters.mediaKinds, (kind) => item.kind === kind)) return false;
   if (!passesList(filters.styles, (style) => item.primaryStyle === style)) return false;
   if (!passesList(filters.tags, (tag) => item.tags.includes(tag))) return false;
-  if (!passesList(filters.colours, (colour) => item.colours.includes(colour))) return false;
+  if (
+    !passesList(filters.colourFamilies, (family) =>
+      item.colours.some((colour) => colourFamily(colour) === family),
+    )
+  ) return false;
   if (!passesList(filters.sourceKinds, (source) => item.sourceKind === source)) return false;
   if (!passesList(filters.analysisStatuses, (status) => item.analysisStatus === status)) return false;
   if (filters.createdAfter !== undefined && item.createdAt < filters.createdAfter) return false;

--- a/plugins/sero-design-library-plugin/shared/settings.ts
+++ b/plugins/sero-design-library-plugin/shared/settings.ts
@@ -106,6 +106,7 @@ export const DEFAULT_SETTINGS: DesignLibrarySettings = {
     // endpoint reaches every profile that never edited it.
     models: {
       'text-to-image': '',
+      'reference-to-image': '',
       'image-to-image': '',
       upscale: '',
       'text-to-video': '',

--- a/plugins/sero-design-library-plugin/shared/types.test.ts
+++ b/plugins/sero-design-library-plugin/shared/types.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_STATE, normalizeState } from './types';
+
+describe('colour filter normalization', () => {
+  it('drops the obsolete exact-colour filter values', () => {
+    const normalized = normalizeState({
+      ...DEFAULT_STATE,
+      view: {
+        ...DEFAULT_STATE.view,
+        filters: { ...DEFAULT_STATE.view.filters, colours: ['#e53935'] },
+      },
+    });
+
+    expect(normalized.view.filters.colourFamilies).toEqual([]);
+  });
+
+  it('keeps valid colour families', () => {
+    const normalized = normalizeState({
+      ...DEFAULT_STATE,
+      view: {
+        ...DEFAULT_STATE.view,
+        filters: { ...DEFAULT_STATE.view.filters, colourFamilies: ['Reds', 'invalid'] },
+      },
+    });
+
+    expect(normalized.view.filters.colourFamilies).toEqual(['Reds']);
+  });
+});

--- a/plugins/sero-design-library-plugin/shared/types.ts
+++ b/plugins/sero-design-library-plugin/shared/types.ts
@@ -9,6 +9,8 @@
  */
 
 import type { OutputTarget, VariantStatus, VariationMode } from './design';
+import type { ColourFamily } from './colour-families';
+import { isColourFamily } from './colour-families';
 import { normalizeDesignSummary } from './design-summary';
 import type { ExportSummary } from './export';
 import { normalizeExportSummary } from './export';
@@ -120,7 +122,7 @@ export interface LibraryFilters {
   mediaKinds: MediaKind[];
   styles: string[];
   tags: string[];
-  colours: string[];
+  colourFamilies: ColourFamily[];
   sourceKinds: string[];
   analysisStatuses: AnalysisStatus[];
   /** Epoch millis; items created before this are hidden. */
@@ -191,7 +193,7 @@ export const EMPTY_FILTERS: LibraryFilters = {
   mediaKinds: [],
   styles: [],
   tags: [],
-  colours: [],
+  colourFamilies: [],
   sourceKinds: [],
   analysisStatuses: [],
 };
@@ -322,7 +324,9 @@ function normalizeFilters(value: unknown): LibraryFilters {
     mediaKinds,
     styles: stringArray(value.styles),
     tags: stringArray(value.tags),
-    colours: stringArray(value.colours),
+    // Raw colour filters from the first enhancement draft are deliberately
+    // dropped. Families are stable when new references add more exact hexes.
+    colourFamilies: stringArray(value.colourFamilies).filter(isColourFamily),
     sourceKinds: stringArray(value.sourceKinds),
     analysisStatuses,
     ...(typeof value.createdAfter === 'number' ? { createdAfter: value.createdAfter } : {}),

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -89,6 +89,10 @@ describe('remixing a reference', () => {
     expect(screen.getByText('Edit this reference')).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Restyle' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Upscale' })).toBeDefined();
+    expect(screen.queryByText('Use this as visual direction')).toBeNull();
+    expect(screen.queryByText('Animate from this reference')).toBeNull();
+    expect(screen.queryByText('Change its visual style')).toBeNull();
+    expect(screen.queryByText('Increase its resolution')).toBeNull();
 
     await chooseOperation('Video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -33,7 +33,7 @@ function renderDialog(overrides: Partial<GenerateDialogProps> = {}) {
 }
 
 async function chooseOperation(label: string) {
-  await userEvent.click(screen.getByRole('radio', { name: label }));
+  await userEvent.click(screen.getByRole('tab', { name: label }));
 }
 
 describe('fresh generation', () => {
@@ -41,10 +41,10 @@ describe('fresh generation', () => {
     renderDialog();
 
     expect(screen.getByRole('heading', { name: 'Generate' })).toBeDefined();
-    expect(screen.getByRole('radio', { name: 'New image' })).toBeDefined();
-    expect(screen.getByRole('radio', { name: 'New video' })).toBeDefined();
-    expect(screen.queryByRole('radio', { name: 'Restyle' })).toBeNull();
-    expect(screen.queryByRole('radio', { name: 'Upscale' })).toBeNull();
+    expect(screen.getByRole('tab', { name: 'New image' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'New video' })).toBeDefined();
+    expect(screen.queryByRole('tab', { name: 'Restyle' })).toBeNull();
+    expect(screen.queryByRole('tab', { name: 'Upscale' })).toBeNull();
     expect(screen.getByLabelText('Describe it').getAttribute('rows')).toBe('6');
   });
 });
@@ -81,8 +81,8 @@ describe('remixing a reference', () => {
     expect(screen.getByLabelText('Work from')).toBeDefined();
     expect(screen.getByText('Create new')).toBeDefined();
     expect(screen.getByText('Edit this reference')).toBeDefined();
-    expect(screen.queryByRole('radio', { name: 'Restyle' })).toBeNull();
-    expect(screen.getByRole('radio', { name: 'Upscale' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'Restyle' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'Upscale' })).toBeDefined();
 
     await chooseOperation('New video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');
@@ -92,6 +92,21 @@ describe('remixing a reference', () => {
       expect.objectContaining({
         capability: 'image-to-video',
         prompt: 'animate this',
+        sourceId: 'item-1',
+      }),
+    );
+  });
+
+  it('restyles the current reference', async () => {
+    const { onGenerate } = renderDialog({ initialSourceId: 'item-1' });
+    await chooseOperation('Restyle');
+    await userEvent.type(screen.getByLabelText('Describe it'), 'use a paper collage style');
+    await userEvent.click(screen.getByRole('button', { name: 'Restyle' }));
+
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capability: 'image-to-image',
+        prompt: 'use a paper collage style',
         sourceId: 'item-1',
       }),
     );

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -50,7 +50,9 @@ describe('fresh generation', () => {
       screen.queryByText('The model behind each capability is a setting, not a choice made here.'),
     ).toBeNull();
     expect(screen.getByRole('tablist').className).not.toContain('border-b');
-    expect(screen.getByRole('tab', { name: 'Image' }).className).toContain('after:bg-primary');
+    const imageTab = screen.getByRole('tab', { name: 'Image' });
+    expect(imageTab.className).toContain('after:bg-primary');
+    expect(document.getElementById(imageTab.getAttribute('aria-controls') ?? '')).not.toBeNull();
     expect(screen.getByLabelText('Describe it').getAttribute('rows')).toBe('6');
   });
 });
@@ -87,6 +89,8 @@ describe('remixing a reference', () => {
     expect(screen.getByLabelText('Work from')).toBeDefined();
     expect(screen.getByText('Create new')).toBeDefined();
     expect(screen.getByText('Edit this reference')).toBeDefined();
+    expect(screen.queryByRole('tab', { name: 'Image' })).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Video' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Restyle' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Upscale' })).toBeDefined();
     expect(screen.queryByText('Use this as visual direction')).toBeNull();
@@ -105,6 +109,15 @@ describe('remixing a reference', () => {
         sourceId: 'item-1',
       }),
     );
+  });
+
+  it('does not change the operation when another tab receives focus', async () => {
+    renderDialog({ initialSourceId: 'item-1' });
+    await chooseOperation('Upscale');
+
+    screen.getByRole('tab', { name: 'Video' }).focus();
+
+    expect(screen.getByRole('button', { name: 'Upscale' })).toBeDefined();
   });
 
   it('restyles the current reference', async () => {
@@ -153,7 +166,7 @@ describe('remixing a reference', () => {
     fireEvent.change(source, { target: { value: 'Reference 999' } });
     await userEvent.keyboard('{ArrowDown}{Enter}');
     await userEvent.type(screen.getByLabelText('Describe it'), 'a colder composition');
-    await userEvent.click(screen.getByRole('button', { name: 'Generate image' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Restyle' }));
 
     expect(onGenerate).toHaveBeenCalledWith(
       expect.objectContaining({ sourceId: 'item-999' }),
@@ -167,7 +180,7 @@ describe('remixing a reference', () => {
     });
 
     expect(screen.getByText('Nothing in the Library to work from yet.')).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Generate image' }).hasAttribute('disabled')).toBe(
+    expect(screen.getByRole('button', { name: 'Restyle' }).hasAttribute('disabled')).toBe(
       true,
     );
   });
@@ -178,7 +191,7 @@ describe('remixing a reference', () => {
     await userEvent.clear(source);
     await userEvent.type(screen.getByLabelText('Describe it'), 'a colder composition');
 
-    expect(screen.getByRole('button', { name: 'Generate image' }).hasAttribute('disabled')).toBe(
+    expect(screen.getByRole('button', { name: 'Restyle' }).hasAttribute('disabled')).toBe(
       true,
     );
     expect(onGenerate).not.toHaveBeenCalled();

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -89,7 +89,7 @@ describe('remixing a reference', () => {
     expect(screen.getByLabelText('Work from')).toBeDefined();
     expect(screen.getByText('Create new')).toBeDefined();
     expect(screen.getByText('Edit this reference')).toBeDefined();
-    expect(screen.queryByRole('tab', { name: 'Image' })).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Image' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Video' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Restyle' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Upscale' })).toBeDefined();
@@ -106,6 +106,21 @@ describe('remixing a reference', () => {
       expect.objectContaining({
         capability: 'image-to-video',
         prompt: 'animate this',
+        sourceId: 'item-1',
+      }),
+    );
+  });
+
+  it('creates a new image from the current reference', async () => {
+    const { onGenerate } = renderDialog({ initialSourceId: 'item-1' });
+    await chooseOperation('Image');
+    await userEvent.type(screen.getByLabelText('Describe it'), 'a new coastal composition');
+    await userEvent.click(screen.getByRole('button', { name: 'Generate image' }));
+
+    expect(onGenerate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        capability: 'reference-to-image',
+        prompt: 'a new coastal composition',
         sourceId: 'item-1',
       }),
     );

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.test.tsx
@@ -41,10 +41,16 @@ describe('fresh generation', () => {
     renderDialog();
 
     expect(screen.getByRole('heading', { name: 'Generate' })).toBeDefined();
-    expect(screen.getByRole('tab', { name: 'New image' })).toBeDefined();
-    expect(screen.getByRole('tab', { name: 'New video' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'Image' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'Video' })).toBeDefined();
     expect(screen.queryByRole('tab', { name: 'Restyle' })).toBeNull();
     expect(screen.queryByRole('tab', { name: 'Upscale' })).toBeNull();
+    expect(screen.queryByText('Create from your description')).toBeNull();
+    expect(
+      screen.queryByText('The model behind each capability is a setting, not a choice made here.'),
+    ).toBeNull();
+    expect(screen.getByRole('tablist').className).not.toContain('border-b');
+    expect(screen.getByRole('tab', { name: 'Image' }).className).toContain('after:bg-primary');
     expect(screen.getByLabelText('Describe it').getAttribute('rows')).toBe('6');
   });
 });
@@ -54,7 +60,7 @@ describe('a video model that only makes long clips', () => {
 
   it('says why, and will not let the generation be started', async () => {
     const { onGenerate } = renderDialog({ modelOptions: longOnly });
-    await chooseOperation('New video');
+    await chooseOperation('Video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'a slow pan');
 
     expect(screen.getByText(/shorter/)).toBeDefined();
@@ -67,7 +73,7 @@ describe('a video model that only makes long clips', () => {
 
   it('lets a model through as soon as one length fits', async () => {
     renderDialog({ modelOptions: { 'text-to-video': { durationsSeconds: [5, 20] } } });
-    await chooseOperation('New video');
+    await chooseOperation('Video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'a slow pan');
 
     expect(screen.queryByText(/shorter/)).toBeNull();
@@ -84,7 +90,7 @@ describe('remixing a reference', () => {
     expect(screen.getByRole('tab', { name: 'Restyle' })).toBeDefined();
     expect(screen.getByRole('tab', { name: 'Upscale' })).toBeDefined();
 
-    await chooseOperation('New video');
+    await chooseOperation('Video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');
     await userEvent.click(screen.getByRole('button', { name: 'Generate video' }));
 
@@ -117,7 +123,7 @@ describe('remixing a reference', () => {
       initialSourceId: 'item-1',
       modelOptions: { 'image-to-video': { supportsAspectRatio: false } },
     });
-    await chooseOperation('New video');
+    await chooseOperation('Video');
     await userEvent.type(screen.getByLabelText('Describe it'), 'animate this');
 
     expect(screen.queryByLabelText('Aspect')).toBeNull();

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -109,17 +109,17 @@ type GenerationOperation =
 interface OperationChoice {
   value: GenerationOperation;
   label: string;
-  description: string;
+  description?: string;
 }
 
 const FRESH_OPERATIONS: OperationChoice[] = [
-  { value: 'fresh-image', label: 'New image', description: 'Create from your description' },
-  { value: 'fresh-video', label: 'New video', description: 'Create from your description' },
+  { value: 'fresh-image', label: 'Image' },
+  { value: 'fresh-video', label: 'Video' },
 ];
 
 const CREATE_OPERATIONS: OperationChoice[] = [
-  { value: 'reference-image', label: 'New image', description: 'Use this as visual direction' },
-  { value: 'reference-video', label: 'New video', description: 'Animate from this reference' },
+  { value: 'reference-image', label: 'Image', description: 'Use this as visual direction' },
+  { value: 'reference-video', label: 'Video', description: 'Animate from this reference' },
 ];
 
 const EDIT_OPERATIONS: OperationChoice[] = [
@@ -240,22 +240,28 @@ export function GenerateDialog({
                 value={group.choices.some((choice) => choice.value === operation) ? operation : ''}
                 onValueChange={(value) => setOperation(value as GenerationOperation)}
               >
-                <TabsList variant="line" className="w-full justify-start border-b">
+                <TabsList variant="line" className="justify-start">
                   {group.choices.map((choice) => (
-                    <TabsTrigger key={choice.value} value={choice.value} className="flex-none px-3">
+                    <TabsTrigger
+                      key={choice.value}
+                      value={choice.value}
+                      className="data-[state=active]:text-primary after:bg-primary flex-none px-3"
+                    >
                       {choice.label}
                     </TabsTrigger>
                   ))}
                 </TabsList>
-                {group.choices.map((choice) => (
-                  <TabsContent
-                    key={choice.value}
-                    value={choice.value}
-                    className="text-muted-foreground text-sm"
-                  >
-                    {choice.description}
-                  </TabsContent>
-                ))}
+                {group.choices.map((choice) =>
+                  choice.description ? (
+                    <TabsContent
+                      key={choice.value}
+                      value={choice.value}
+                      className="text-muted-foreground text-sm"
+                    >
+                      {choice.description}
+                    </TabsContent>
+                  ) : null,
+                )}
               </Tabs>
             </section>
           ))}
@@ -352,13 +358,12 @@ export function GenerateDialog({
         </div>
 
         <div className="flex items-center gap-3">
-          <p className="text-muted-foreground flex-1 text-xs">
-            {tooLong ??
-              (needsConfirmation(capability)
-                ? 'Video is the most expensive capability and asks again before it spends.'
-                : 'The model behind each capability is a setting, not a choice made here.')}
-          </p>
-          <Button type="button" onClick={submit} disabled={blocked}>
+          {(tooLong !== null || needsConfirmation(capability)) && (
+            <p className="text-muted-foreground flex-1 text-xs">
+              {tooLong ?? 'Video is the most expensive capability and asks again before it spends.'}
+            </p>
+          )}
+          <Button type="button" onClick={submit} disabled={blocked} className="ml-auto">
             <Sparkles className="size-3.5" />
             {ACTION_LABEL[operation]}
           </Button>

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -18,7 +18,6 @@ import {
   SelectTrigger,
   SelectValue,
   Tabs,
-  TabsContent,
   TabsList,
   TabsTrigger,
   Textarea,
@@ -109,7 +108,6 @@ type GenerationOperation =
 interface OperationChoice {
   value: GenerationOperation;
   label: string;
-  description?: string;
 }
 
 const FRESH_OPERATIONS: OperationChoice[] = [
@@ -118,13 +116,13 @@ const FRESH_OPERATIONS: OperationChoice[] = [
 ];
 
 const CREATE_OPERATIONS: OperationChoice[] = [
-  { value: 'reference-image', label: 'Image', description: 'Use this as visual direction' },
-  { value: 'reference-video', label: 'Video', description: 'Animate from this reference' },
+  { value: 'reference-image', label: 'Image' },
+  { value: 'reference-video', label: 'Video' },
 ];
 
 const EDIT_OPERATIONS: OperationChoice[] = [
-  { value: 'restyle', label: 'Restyle', description: 'Change its visual style' },
-  { value: 'upscale', label: 'Upscale', description: 'Increase its resolution' },
+  { value: 'restyle', label: 'Restyle' },
+  { value: 'upscale', label: 'Upscale' },
 ];
 
 const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
@@ -251,17 +249,6 @@ export function GenerateDialog({
                     </TabsTrigger>
                   ))}
                 </TabsList>
-                {group.choices.map((choice) =>
-                  choice.description ? (
-                    <TabsContent
-                      key={choice.value}
-                      value={choice.value}
-                      className="text-muted-foreground text-sm"
-                    >
-                      {choice.description}
-                    </TabsContent>
-                  ) : null,
-                )}
               </Tabs>
             </section>
           ))}

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -17,9 +17,11 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
   Textarea,
-  ToggleGroup,
-  ToggleGroupItem,
 } from '@sero-ai/ui';
 import { Sparkles } from 'lucide-react';
 import { useState } from 'react';
@@ -101,6 +103,7 @@ type GenerationOperation =
   | 'fresh-video'
   | 'reference-image'
   | 'reference-video'
+  | 'restyle'
   | 'upscale';
 
 interface OperationChoice {
@@ -120,6 +123,7 @@ const CREATE_OPERATIONS: OperationChoice[] = [
 ];
 
 const EDIT_OPERATIONS: OperationChoice[] = [
+  { value: 'restyle', label: 'Restyle', description: 'Change its visual style' },
   { value: 'upscale', label: 'Upscale', description: 'Increase its resolution' },
 ];
 
@@ -128,6 +132,7 @@ const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
   'fresh-video': 'text-to-video',
   'reference-image': 'image-to-image',
   'reference-video': 'image-to-video',
+  restyle: 'image-to-image',
   upscale: 'upscale',
 };
 
@@ -136,6 +141,7 @@ const ACTION_LABEL: Record<GenerationOperation, string> = {
   'fresh-video': 'Generate video',
   'reference-image': 'Generate image',
   'reference-video': 'Generate video',
+  restyle: 'Restyle',
   upscale: 'Upscale',
 };
 
@@ -230,29 +236,27 @@ export function GenerateDialog({
           ).map((group) => (
             <section key={group.label ?? 'fresh'} className="space-y-2">
               {group.label && <h3 className="text-muted-foreground text-xs font-medium">{group.label}</h3>}
-              <ToggleGroup
-                type="single"
-                value={operation}
-                onValueChange={(value) => value !== '' && setOperation(value as GenerationOperation)}
-                className={`grid gap-2 ${group.choices.length === 1 ? 'grid-cols-1' : 'grid-cols-2'}`}
-                aria-label={group.label ?? 'Media type'}
+              <Tabs
+                value={group.choices.some((choice) => choice.value === operation) ? operation : ''}
+                onValueChange={(value) => setOperation(value as GenerationOperation)}
               >
+                <TabsList variant="line" className="w-full justify-start border-b">
+                  {group.choices.map((choice) => (
+                    <TabsTrigger key={choice.value} value={choice.value} className="flex-none px-3">
+                      {choice.label}
+                    </TabsTrigger>
+                  ))}
+                </TabsList>
                 {group.choices.map((choice) => (
-                  <ToggleGroupItem
+                  <TabsContent
                     key={choice.value}
                     value={choice.value}
-                    className="h-auto min-h-16 items-start justify-start px-3 py-2.5 text-left"
-                    aria-label={choice.label}
+                    className="text-muted-foreground text-sm"
                   >
-                    <span>
-                      <span className="block text-sm font-medium">{choice.label}</span>
-                      <span className="text-muted-foreground mt-0.5 block text-xs font-normal">
-                        {choice.description}
-                      </span>
-                    </span>
-                  </ToggleGroupItem>
+                    {choice.description}
+                  </TabsContent>
                 ))}
-              </ToggleGroup>
+              </Tabs>
             </section>
           ))}
 

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -51,7 +51,7 @@ export type GenerateTarget =
   | { kind: 'design'; designId: string; designTitle: string }
   | { kind: 'library' };
 
-/** Something a restyle or an upscale can work from. */
+/** An image that a reference generation, restyle, upscale, or video can use. */
 export interface GenerateSource {
   id: string;
   label: string;
@@ -101,6 +101,7 @@ const FALLBACK_DURATIONS = [DEFAULT_VIDEO_SECONDS, 10].filter(
 type GenerationOperation =
   | 'fresh-image'
   | 'fresh-video'
+  | 'reference-image'
   | 'reference-video'
   | 'restyle'
   | 'upscale';
@@ -116,6 +117,7 @@ const FRESH_OPERATIONS: OperationChoice[] = [
 ];
 
 const CREATE_OPERATIONS: OperationChoice[] = [
+  { value: 'reference-image', label: 'Image' },
   { value: 'reference-video', label: 'Video' },
 ];
 
@@ -127,6 +129,7 @@ const EDIT_OPERATIONS: OperationChoice[] = [
 const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
   'fresh-image': 'text-to-image',
   'fresh-video': 'text-to-video',
+  'reference-image': 'reference-to-image',
   'reference-video': 'image-to-video',
   restyle: 'image-to-image',
   upscale: 'upscale',
@@ -135,6 +138,7 @@ const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
 const ACTION_LABEL: Record<GenerationOperation, string> = {
   'fresh-image': 'Generate image',
   'fresh-video': 'Generate video',
+  'reference-image': 'Generate image',
   'reference-video': 'Generate video',
   restyle: 'Restyle',
   upscale: 'Upscale',

--- a/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/GenerateDialog.tsx
@@ -18,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
   Tabs,
+  TabsContent,
   TabsList,
   TabsTrigger,
   Textarea,
@@ -100,7 +101,6 @@ const FALLBACK_DURATIONS = [DEFAULT_VIDEO_SECONDS, 10].filter(
 type GenerationOperation =
   | 'fresh-image'
   | 'fresh-video'
-  | 'reference-image'
   | 'reference-video'
   | 'restyle'
   | 'upscale';
@@ -116,7 +116,6 @@ const FRESH_OPERATIONS: OperationChoice[] = [
 ];
 
 const CREATE_OPERATIONS: OperationChoice[] = [
-  { value: 'reference-image', label: 'Image' },
   { value: 'reference-video', label: 'Video' },
 ];
 
@@ -128,7 +127,6 @@ const EDIT_OPERATIONS: OperationChoice[] = [
 const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
   'fresh-image': 'text-to-image',
   'fresh-video': 'text-to-video',
-  'reference-image': 'image-to-image',
   'reference-video': 'image-to-video',
   restyle: 'image-to-image',
   upscale: 'upscale',
@@ -137,7 +135,6 @@ const OPERATION_CAPABILITY: Record<GenerationOperation, MediaCapability> = {
 const ACTION_LABEL: Record<GenerationOperation, string> = {
   'fresh-image': 'Generate image',
   'fresh-video': 'Generate video',
-  'reference-image': 'Generate image',
   'reference-video': 'Generate video',
   restyle: 'Restyle',
   upscale: 'Upscale',
@@ -154,11 +151,11 @@ export function GenerateDialog({
 }: GenerateDialogProps) {
   const remix = initialSourceId !== undefined;
   const [operation, setOperation] = useState<GenerationOperation>(
-    remix ? 'reference-image' : 'fresh-image',
+    remix ? 'restyle' : 'fresh-image',
   );
   const capability = OPERATION_CAPABILITY[operation];
   const [prompt, setPrompt] = useState('');
-  const [sourceId, setSourceId] = useState<string>(initialSourceId ?? '');
+  const [sourceId, setSourceId] = useState(initialSourceId ?? '');
   const [chosenAspect, setChosenAspect] = useState<string | null>(null);
   const [chosenDuration, setChosenDuration] = useState<number | null>(null);
 
@@ -235,10 +232,15 @@ export function GenerateDialog({
             <section key={group.label ?? 'fresh'} className="space-y-2">
               {group.label && <h3 className="text-muted-foreground text-xs font-medium">{group.label}</h3>}
               <Tabs
+                activationMode="manual"
                 value={group.choices.some((choice) => choice.value === operation) ? operation : ''}
                 onValueChange={(value) => setOperation(value as GenerationOperation)}
               >
-                <TabsList variant="line" className="justify-start">
+                <TabsList
+                  variant="line"
+                  className="justify-start"
+                  aria-label={group.label ?? 'Output type'}
+                >
                   {group.choices.map((choice) => (
                     <TabsTrigger
                       key={choice.value}
@@ -249,6 +251,11 @@ export function GenerateDialog({
                     </TabsTrigger>
                   ))}
                 </TabsList>
+                {group.choices.map((choice) => (
+                  <TabsContent key={choice.value} value={choice.value} className="sr-only">
+                    {choice.label} operation selected
+                  </TabsContent>
+                ))}
               </Tabs>
             </section>
           ))}

--- a/plugins/sero-design-library-plugin/ui/components/ItemCard.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/ItemCard.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ItemSummary } from '../../shared/types';
@@ -43,10 +44,16 @@ function item(overrides: Partial<ItemSummary> = {}): ItemSummary {
   } as ItemSummary;
 }
 
-function renderCard(summary: ItemSummary) {
+function renderCard(summary: ItemSummary, onFavourite = vi.fn()) {
   runs.length = 0;
   return render(
-    <ItemCard item={summary} selected={false} onOpen={vi.fn()} onToggleSelect={vi.fn()} />,
+    <ItemCard
+      item={summary}
+      selected={false}
+      onOpen={vi.fn()}
+      onToggleSelect={vi.fn()}
+      onFavourite={onFavourite}
+    />,
   );
 }
 
@@ -62,5 +69,16 @@ describe('a clip whose frames have not been captured', () => {
     renderCard(item());
 
     expect(runs).toEqual([{ action: 'preview', itemId: 'item-1' }]);
+  });
+});
+
+describe('a favourite reference', () => {
+  it('can be removed from favourites from its card', async () => {
+    const onFavourite = vi.fn();
+    renderCard(item({ favourite: true }), onFavourite);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Remove from favourites' }));
+
+    expect(onFavourite).toHaveBeenCalledWith(false);
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/ItemCard.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/ItemCard.tsx
@@ -27,6 +27,7 @@ interface ItemCardProps {
   transitionName?: string;
   onOpen(): void;
   onToggleSelect(): void;
+  onFavourite(favourite: boolean): void;
 }
 
 function StatusMark({ status }: { status: ItemSummary['analysisStatus'] }) {
@@ -52,7 +53,14 @@ function statusLabel(item: ItemSummary): string {
   }
 }
 
-export function ItemCard({ item, selected, transitionName, onOpen, onToggleSelect }: ItemCardProps) {
+export function ItemCard({
+  item,
+  selected,
+  transitionName,
+  onOpen,
+  onToggleSelect,
+  onFavourite,
+}: ItemCardProps) {
   // Nothing is asked for until there is a still to ask for. A generated clip
   // arrives with no thumbnail of its own, and an item's stored preview falls
   // back to the original when it has none — so asking early fetched the whole
@@ -142,12 +150,15 @@ export function ItemCard({ item, selected, transitionName, onOpen, onToggleSelec
           its own surface to stay legible over an arbitrary image. */}
       <div className="absolute top-2 right-2 z-20 flex items-center gap-1">
         {item.favourite && (
-          <span
-            className="bg-background/85 flex size-6 items-center justify-center rounded-md backdrop-blur-sm"
-            aria-label="Favourite"
+          <button
+            type="button"
+            className="bg-background/85 hover:bg-background focus-visible:ring-ring flex size-6 items-center justify-center rounded-md backdrop-blur-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+            aria-label="Remove from favourites"
+            title="Remove from favourites"
+            onClick={() => onFavourite(false)}
           >
             <Star className="text-primary size-3.5 fill-current" />
-          </span>
+          </button>
         )}
         <button
           type="button"

--- a/plugins/sero-design-library-plugin/ui/components/LibraryRail.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryRail.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LibraryRail } from './LibraryRail';
+
+describe('custom collections', () => {
+  it('exposes deletion from the collection row', async () => {
+    const onDeleteCollection = vi.fn();
+    render(
+      <LibraryRail
+        items={[]}
+        collections={[{ id: 'collection-1', name: 'Moodboard', colour: 'primary', createdAt: 0 }]}
+        scope={{ kind: 'all' }}
+        onScopeChange={() => {}}
+        onCreateCollection={() => {}}
+        onDeleteCollection={onDeleteCollection}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Actions for Moodboard' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Delete collection' }));
+
+    expect(onDeleteCollection).toHaveBeenCalledWith('collection-1');
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/components/LibraryRail.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryRail.tsx
@@ -1,5 +1,13 @@
-import { Button, Input, ScrollArea } from '@sero-ai/ui';
-import { Clock, Diamond, Plus, Sparkles, Star, Trash2 } from 'lucide-react';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+  ScrollArea,
+} from '@sero-ai/ui';
+import { Clock, Diamond, MoreHorizontal, Plus, Sparkles, Star, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import type { Collection } from '../../shared/records';
@@ -21,6 +29,7 @@ interface LibraryRailProps {
   scope: LibraryScope;
   onScopeChange(scope: LibraryScope): void;
   onCreateCollection(name: string): void;
+  onDeleteCollection(collectionId: string): void;
 }
 
 function sameScope(a: LibraryScope, b: LibraryScope): boolean {
@@ -64,12 +73,65 @@ function RailHeading({ children, action }: { children: React.ReactNode; action?:
   );
 }
 
+function CollectionRow({
+  collection,
+  active,
+  count,
+  onClick,
+  onDelete,
+}: {
+  collection: Collection;
+  active: boolean;
+  count: number;
+  onClick(): void;
+  onDelete(): void;
+}) {
+  return (
+    <div className="flex items-center gap-0.5">
+      <button
+        type="button"
+        onClick={onClick}
+        aria-current={active}
+        className={`flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
+          active
+            ? 'bg-accent text-accent-foreground'
+            : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+        }`}
+      >
+        <span className="bg-primary size-2 shrink-0 rounded-full" />
+        <span className="min-w-0 flex-1 truncate">{collection.name}</span>
+        <span className="text-muted-foreground text-xs tabular-nums">{count}</span>
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-7 shrink-0"
+            aria-label={`Actions for ${collection.name}`}
+          >
+            <MoreHorizontal className="size-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+            <Trash2 className="size-3.5" />
+            Delete collection
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 export function LibraryRail({
   items,
   collections,
   scope,
   onScopeChange,
   onCreateCollection,
+  onDeleteCollection,
 }: LibraryRailProps) {
   const [newCollection, setNewCollection] = useState<string | null>(null);
 
@@ -151,13 +213,13 @@ export function LibraryRail({
           />
         )}
         {collections.map((collection) => (
-          <RailRow
+          <CollectionRow
             key={collection.id}
+            collection={collection}
             active={sameScope(scope, { kind: 'collection', collectionId: collection.id })}
-            label={collection.name}
             count={countFor({ kind: 'collection', collectionId: collection.id })}
-            icon={<span className="bg-primary size-2 rounded-full" />}
             onClick={() => onScopeChange({ kind: 'collection', collectionId: collection.id })}
+            onDelete={() => onDeleteCollection(collection.id)}
           />
         ))}
 

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -47,29 +47,37 @@ describe('large Library facets', () => {
     expect(screen.getByRole('listbox')).toBeDefined();
   });
 
-  it('shows aligned previews beside colour codes', async () => {
+  it('groups exact colours into named families', async () => {
+    const onFiltersChange = vi.fn();
     render(
       <LibraryToolbar
         query=""
         filters={FILTERS}
-        facets={{ styles: [], tags: [], colours: ['#03090c', '#f4a261'], sourceKinds: [] }}
+        facets={{
+          styles: [],
+          tags: [],
+          colours: ['#e53935', '#b71c1c', '#43a047', '#1e88e5', '#777777'],
+          sourceKinds: [],
+        }}
         sort="newest"
         onQueryChange={() => {}}
-        onFiltersChange={() => {}}
+        onFiltersChange={onFiltersChange}
         onSortChange={() => {}}
       />,
     );
 
     await userEvent.click(screen.getByRole('combobox', { name: 'Colour' }));
 
-    const option = screen.getByRole('option', { name: '#03090c' });
-    const swatch = option.querySelector('[aria-hidden="true"]');
-    expect(swatch?.getAttribute('style')).toContain('background-color: rgb(3, 9, 12)');
-    expect(swatch?.className).toContain('w-12');
-    expect(swatch?.className).toContain('min-h-8');
-    expect(swatch?.className).toContain('self-stretch');
-    expect(swatch?.className).not.toContain('border');
-    expect(swatch?.className).toContain('shrink-0');
-    expect(option.className).toContain('gap-3');
+    expect(screen.getByRole('option', { name: 'Reds' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'Greens' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'Blues' })).toBeDefined();
+    expect(screen.getByRole('option', { name: 'Neutrals' })).toBeDefined();
+    expect(screen.queryByRole('option', { name: '#e53935' })).toBeNull();
+
+    await userEvent.click(screen.getByRole('option', { name: 'Reds' }));
+    expect(onFiltersChange).toHaveBeenCalledWith({
+      ...FILTERS,
+      colours: ['#e53935', '#b71c1c'],
+    });
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -11,7 +11,7 @@ const FILTERS: LibraryFilters = {
   mediaKinds: [],
   styles: [],
   tags: [],
-  colours: [],
+  colourFamilies: [],
   sourceKinds: [],
   analysisStatuses: [],
 };
@@ -45,6 +45,9 @@ describe('large Library facets', () => {
 
     expect(onFiltersChange).toHaveBeenCalledWith({ ...FILTERS, styles: ['Style 999'] });
     expect(screen.getByRole('listbox')).toBeDefined();
+
+    fireEvent.change(style, { target: { value: 'Style 998' } });
+    expect(screen.getByRole('option', { name: 'Style 998' })).toBeDefined();
   });
 
   it('groups exact colours into named families', async () => {
@@ -77,7 +80,7 @@ describe('large Library facets', () => {
     await userEvent.click(screen.getByRole('option', { name: 'Reds' }));
     expect(onFiltersChange).toHaveBeenCalledWith({
       ...FILTERS,
-      colours: ['#e53935', '#b71c1c'],
+      colourFamilies: ['Reds'],
     });
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -65,8 +65,11 @@ describe('large Library facets', () => {
     const option = screen.getByRole('option', { name: '#03090c' });
     const swatch = option.querySelector('[aria-hidden="true"]');
     expect(swatch?.getAttribute('style')).toContain('background-color: rgb(3, 9, 12)');
-    expect(swatch?.className).toContain('w-8');
-    expect(swatch?.className).toContain('h-4');
+    expect(swatch?.className).toContain('w-12');
+    expect(swatch?.className).toContain('min-h-8');
+    expect(swatch?.className).toContain('self-stretch');
+    expect(swatch?.className).not.toContain('border');
     expect(swatch?.className).toContain('shrink-0');
+    expect(option.className).toContain('gap-3');
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -36,12 +36,14 @@ describe('large Library facets', () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole('combobox', { name: 'Style' }));
-    fireEvent.change(screen.getByPlaceholderText('Search style'), {
+    const style = screen.getByRole('combobox', { name: 'Style' });
+    await userEvent.click(style);
+    fireEvent.change(style, {
       target: { value: 'Style 999' },
     });
     await userEvent.click(screen.getByRole('option', { name: 'Style 999' }));
 
     expect(onFiltersChange).toHaveBeenCalledWith({ ...FILTERS, styles: ['Style 999'] });
+    expect(screen.getByRole('listbox')).toBeDefined();
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -26,7 +26,7 @@ describe('large Library facets', () => {
         facets={{
           styles: Array.from({ length: 1_000 }, (_, index) => `Style ${index}`),
           tags: [],
-          colours: [],
+          colours: ['#03090c', '#f4a261'],
           sourceKinds: [],
         }}
         sort="newest"
@@ -45,5 +45,26 @@ describe('large Library facets', () => {
 
     expect(onFiltersChange).toHaveBeenCalledWith({ ...FILTERS, styles: ['Style 999'] });
     expect(screen.getByRole('listbox')).toBeDefined();
+  });
+
+  it('shows aligned previews beside colour codes', async () => {
+    render(
+      <LibraryToolbar
+        query=""
+        filters={FILTERS}
+        facets={{ styles: [], tags: [], colours: ['#03090c', '#f4a261'], sourceKinds: [] }}
+        sort="newest"
+        onQueryChange={() => {}}
+        onFiltersChange={() => {}}
+        onSortChange={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('combobox', { name: 'Colour' }));
+
+    const option = screen.getByRole('option', { name: '#03090c' });
+    const swatch = option.querySelector('[aria-hidden="true"]');
+    expect(swatch?.getAttribute('style')).toContain('background-color: rgb(3, 9, 12)');
+    expect(swatch?.className).toContain('shrink-0');
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.test.tsx
@@ -65,6 +65,8 @@ describe('large Library facets', () => {
     const option = screen.getByRole('option', { name: '#03090c' });
     const swatch = option.querySelector('[aria-hidden="true"]');
     expect(swatch?.getAttribute('style')).toContain('background-color: rgb(3, 9, 12)');
+    expect(swatch?.className).toContain('w-8');
+    expect(swatch?.className).toContain('h-4');
     expect(swatch?.className).toContain('shrink-0');
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -83,11 +83,15 @@ function FacetMenu<Value extends string>({
         <ComboboxEmpty>No options found</ComboboxEmpty>
         <ComboboxList>
           {(item) => (
-            <ComboboxItem key={item.value} value={item}>
+            <ComboboxItem
+              key={item.value}
+              value={item}
+              className={showColourSwatch ? 'gap-3 py-1' : undefined}
+            >
               {showColourSwatch && (
                 <span
                   aria-hidden="true"
-                  className="border-border h-4 w-8 shrink-0 border"
+                  className="min-h-8 w-12 shrink-0 self-stretch"
                   style={{ backgroundColor: item.value }}
                 />
               )}

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -6,7 +6,6 @@ import {
   ComboboxInput,
   ComboboxItem,
   ComboboxList,
-  ComboboxTrigger,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -65,26 +64,20 @@ function FacetMenu<Value extends string>({
       items={items}
       multiple
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={(nextOpen, details) => {
+        if (!nextOpen && details.reason === 'item-press') return;
+        setOpen(nextOpen);
+      }}
       value={chosen}
       isItemEqualToValue={(item, value) => item.value === value.value}
       onValueChange={(values) => onChange(values.map((value) => value.value))}
     >
-      <ComboboxTrigger
+      <ComboboxInput
         aria-label={label}
-        onClick={() => setOpen((current) => !current)}
-        render={
-          <Button type="button" variant={selected.length > 0 ? 'secondary' : 'outline'} size="sm" />
-        }
-      >
-          {label}
-          {selected.length > 0 && <span className="tabular-nums">{selected.length}</span>}
-      </ComboboxTrigger>
-      <ComboboxContent>
-        <ComboboxInput
-          showTrigger={false}
-          placeholder={`Search ${label.toLocaleLowerCase()}`}
-        />
+        placeholder={selected.length > 0 ? `${label} (${selected.length})` : label}
+        className="h-8 w-32"
+      />
+      <ComboboxContent className="min-w-64">
         <ComboboxEmpty>No options found</ComboboxEmpty>
         <ComboboxList>
           {(item) => (

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -87,7 +87,7 @@ function FacetMenu<Value extends string>({
               {showColourSwatch && (
                 <span
                   aria-hidden="true"
-                  className="border-border size-4 shrink-0 rounded-sm border"
+                  className="border-border h-4 w-8 shrink-0 border"
                   style={{ backgroundColor: item.value }}
                 />
               )}

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -40,11 +40,79 @@ const SORT_LABELS: Record<LibrarySort, string> = {
   title: 'By title',
 };
 
+const COLOUR_FAMILY_ORDER = [
+  'Reds',
+  'Oranges',
+  'Yellows',
+  'Greens',
+  'Cyans',
+  'Blues',
+  'Purples',
+  'Pinks',
+  'Neutrals',
+  'Other colours',
+] as const;
+
+type ColourFamily = (typeof COLOUR_FAMILY_ORDER)[number];
+
+interface ColourGroup {
+  name: ColourFamily;
+  colours: string[];
+}
+
+function colourFamily(value: string): ColourFamily {
+  const match = /^#([\da-f]{3}|[\da-f]{6}|[\da-f]{8})$/i.exec(value);
+  if (!match) return 'Other colours';
+
+  const compact = match[1];
+  const hex = compact.length === 3
+    ? compact.split('').map((digit) => `${digit}${digit}`).join('')
+    : compact.slice(0, 6);
+  const red = Number.parseInt(hex.slice(0, 2), 16) / 255;
+  const green = Number.parseInt(hex.slice(2, 4), 16) / 255;
+  const blue = Number.parseInt(hex.slice(4, 6), 16) / 255;
+  const maximum = Math.max(red, green, blue);
+  const minimum = Math.min(red, green, blue);
+  const difference = maximum - minimum;
+
+  if (difference === 0 || difference / (1 - Math.abs(maximum + minimum - 1)) < 0.16) {
+    return 'Neutrals';
+  }
+
+  const hueBase =
+    maximum === red
+      ? (green - blue) / difference
+      : maximum === green
+        ? (blue - red) / difference + 2
+        : (red - green) / difference + 4;
+  const hue = (hueBase * 60 + 360) % 360;
+
+  if (hue < 15 || hue >= 345) return 'Reds';
+  if (hue < 45) return 'Oranges';
+  if (hue < 70) return 'Yellows';
+  if (hue < 165) return 'Greens';
+  if (hue < 200) return 'Cyans';
+  if (hue < 260) return 'Blues';
+  if (hue < 320) return 'Purples';
+  return 'Pinks';
+}
+
+function groupColours(colours: string[]): ColourGroup[] {
+  const groups = new Map<ColourFamily, string[]>();
+  for (const colour of colours) {
+    const family = colourFamily(colour);
+    groups.set(family, [...(groups.get(family) ?? []), colour]);
+  }
+  return COLOUR_FAMILY_ORDER.flatMap((name) => {
+    const grouped = groups.get(name);
+    return grouped ? [{ name, colours: grouped }] : [];
+  });
+}
+
 interface FacetMenuProps<Value extends string> {
   label: string;
   options: Value[];
   selected: Value[];
-  showColourSwatch?: boolean;
   onChange(values: Value[]): void;
 }
 
@@ -52,7 +120,6 @@ function FacetMenu<Value extends string>({
   label,
   options,
   selected,
-  showColourSwatch = false,
   onChange,
 }: FacetMenuProps<Value>) {
   const [open, setOpen] = useState(false);
@@ -83,19 +150,8 @@ function FacetMenu<Value extends string>({
         <ComboboxEmpty>No options found</ComboboxEmpty>
         <ComboboxList>
           {(item) => (
-            <ComboboxItem
-              key={item.value}
-              value={item}
-              className={showColourSwatch ? 'gap-3 py-1' : undefined}
-            >
-              {showColourSwatch && (
-                <span
-                  aria-hidden="true"
-                  className="min-h-8 w-12 shrink-0 self-stretch"
-                  style={{ backgroundColor: item.value }}
-                />
-              )}
-              <span className={showColourSwatch ? 'font-mono' : undefined}>{item.label}</span>
+            <ComboboxItem key={item.value} value={item}>
+              {item.label}
             </ComboboxItem>
           )}
         </ComboboxList>
@@ -113,6 +169,11 @@ export function LibraryToolbar({
   onFiltersChange,
   onSortChange,
 }: LibraryToolbarProps) {
+  const colourGroups = groupColours(facets.colours);
+  const selectedColours = new Set(filters.colours);
+  const selectedColourGroups = colourGroups
+    .filter((group) => group.colours.some((colour) => selectedColours.has(colour)))
+    .map((group) => group.name);
   const active =
     filters.styles.length +
     filters.tags.length +
@@ -149,10 +210,16 @@ export function LibraryToolbar({
       />
       <FacetMenu
         label="Colour"
-        options={facets.colours}
-        selected={filters.colours}
-        showColourSwatch
-        onChange={(values) => onFiltersChange({ ...filters, colours: values })}
+        options={colourGroups.map((group) => group.name)}
+        selected={selectedColourGroups}
+        onChange={(values) =>
+          onFiltersChange({
+            ...filters,
+            colours: colourGroups
+              .filter((group) => values.includes(group.name))
+              .flatMap((group) => group.colours),
+          })
+        }
       />
       <FacetMenu
         label="Source"

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -15,6 +15,7 @@ import {
 import { ArrowDownUp } from 'lucide-react';
 import { useState } from 'react';
 
+import { availableColourFamilies } from '../../shared/colour-families';
 import type { LibraryFacets } from '../../shared/search';
 import type { LibraryFilters, LibrarySort } from '../../shared/types';
 
@@ -39,75 +40,6 @@ const SORT_LABELS: Record<LibrarySort, string> = {
   oldest: 'Oldest first',
   title: 'By title',
 };
-
-const COLOUR_FAMILY_ORDER = [
-  'Reds',
-  'Oranges',
-  'Yellows',
-  'Greens',
-  'Cyans',
-  'Blues',
-  'Purples',
-  'Pinks',
-  'Neutrals',
-  'Other colours',
-] as const;
-
-type ColourFamily = (typeof COLOUR_FAMILY_ORDER)[number];
-
-interface ColourGroup {
-  name: ColourFamily;
-  colours: string[];
-}
-
-function colourFamily(value: string): ColourFamily {
-  const match = /^#([\da-f]{3}|[\da-f]{6}|[\da-f]{8})$/i.exec(value);
-  if (!match) return 'Other colours';
-
-  const compact = match[1];
-  const hex = compact.length === 3
-    ? compact.split('').map((digit) => `${digit}${digit}`).join('')
-    : compact.slice(0, 6);
-  const red = Number.parseInt(hex.slice(0, 2), 16) / 255;
-  const green = Number.parseInt(hex.slice(2, 4), 16) / 255;
-  const blue = Number.parseInt(hex.slice(4, 6), 16) / 255;
-  const maximum = Math.max(red, green, blue);
-  const minimum = Math.min(red, green, blue);
-  const difference = maximum - minimum;
-
-  if (difference === 0 || difference / (1 - Math.abs(maximum + minimum - 1)) < 0.16) {
-    return 'Neutrals';
-  }
-
-  const hueBase =
-    maximum === red
-      ? (green - blue) / difference
-      : maximum === green
-        ? (blue - red) / difference + 2
-        : (red - green) / difference + 4;
-  const hue = (hueBase * 60 + 360) % 360;
-
-  if (hue < 15 || hue >= 345) return 'Reds';
-  if (hue < 45) return 'Oranges';
-  if (hue < 70) return 'Yellows';
-  if (hue < 165) return 'Greens';
-  if (hue < 200) return 'Cyans';
-  if (hue < 260) return 'Blues';
-  if (hue < 320) return 'Purples';
-  return 'Pinks';
-}
-
-function groupColours(colours: string[]): ColourGroup[] {
-  const groups = new Map<ColourFamily, string[]>();
-  for (const colour of colours) {
-    const family = colourFamily(colour);
-    groups.set(family, [...(groups.get(family) ?? []), colour]);
-  }
-  return COLOUR_FAMILY_ORDER.flatMap((name) => {
-    const grouped = groups.get(name);
-    return grouped ? [{ name, colours: grouped }] : [];
-  });
-}
 
 interface FacetMenuProps<Value extends string> {
   label: string;
@@ -134,7 +66,10 @@ function FacetMenu<Value extends string>({
       multiple
       open={open}
       onOpenChange={(nextOpen, details) => {
-        if (!nextOpen && details.reason === 'item-press') return;
+        if (!nextOpen && details.reason === 'item-press') {
+          details.cancel();
+          return;
+        }
         setOpen(nextOpen);
       }}
       value={chosen}
@@ -169,15 +104,11 @@ export function LibraryToolbar({
   onFiltersChange,
   onSortChange,
 }: LibraryToolbarProps) {
-  const colourGroups = groupColours(facets.colours);
-  const selectedColours = new Set(filters.colours);
-  const selectedColourGroups = colourGroups
-    .filter((group) => group.colours.some((colour) => selectedColours.has(colour)))
-    .map((group) => group.name);
+  const colourFamilies = availableColourFamilies(facets.colours);
   const active =
     filters.styles.length +
     filters.tags.length +
-    filters.colours.length +
+    filters.colourFamilies.length +
     filters.sourceKinds.length +
     filters.mediaKinds.length;
 
@@ -210,16 +141,9 @@ export function LibraryToolbar({
       />
       <FacetMenu
         label="Colour"
-        options={colourGroups.map((group) => group.name)}
-        selected={selectedColourGroups}
-        onChange={(values) =>
-          onFiltersChange({
-            ...filters,
-            colours: colourGroups
-              .filter((group) => values.includes(group.name))
-              .flatMap((group) => group.colours),
-          })
-        }
+        options={colourFamilies}
+        selected={filters.colourFamilies}
+        onChange={(colourFamilies) => onFiltersChange({ ...filters, colourFamilies })}
       />
       <FacetMenu
         label="Source"
@@ -238,7 +162,7 @@ export function LibraryToolbar({
               mediaKinds: [],
               styles: [],
               tags: [],
-              colours: [],
+              colourFamilies: [],
               sourceKinds: [],
               analysisStatuses: [],
             })

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -44,6 +44,7 @@ interface FacetMenuProps<Value extends string> {
   label: string;
   options: Value[];
   selected: Value[];
+  showColourSwatch?: boolean;
   onChange(values: Value[]): void;
 }
 
@@ -51,6 +52,7 @@ function FacetMenu<Value extends string>({
   label,
   options,
   selected,
+  showColourSwatch = false,
   onChange,
 }: FacetMenuProps<Value>) {
   const [open, setOpen] = useState(false);
@@ -82,7 +84,14 @@ function FacetMenu<Value extends string>({
         <ComboboxList>
           {(item) => (
             <ComboboxItem key={item.value} value={item}>
-              {item.label}
+              {showColourSwatch && (
+                <span
+                  aria-hidden="true"
+                  className="border-border size-4 shrink-0 rounded-sm border"
+                  style={{ backgroundColor: item.value }}
+                />
+              )}
+              <span className={showColourSwatch ? 'font-mono' : undefined}>{item.label}</span>
             </ComboboxItem>
           )}
         </ComboboxList>
@@ -138,6 +147,7 @@ export function LibraryToolbar({
         label="Colour"
         options={facets.colours}
         selected={filters.colours}
+        showColourSwatch
         onChange={(values) => onFiltersChange({ ...filters, colours: values })}
       />
       <FacetMenu

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -24,6 +24,7 @@ import { MediaSettings } from './MediaSettings';
 const MEDIA: MediaSettingsValue = {
   models: {
     'text-to-image': 'flux/dev',
+    'reference-to-image': '',
     'image-to-image': '',
     upscale: '',
     'text-to-video': '',
@@ -108,10 +109,10 @@ describe('media models', () => {
     expect(callsFor('set-media-model')).toHaveLength(0);
   });
 
-  it('shows each capability separately, so one does not stand for all five', () => {
+  it('shows each capability separately', () => {
     render(<MediaSettings media={MEDIA} />);
 
-    for (const label of ['Image', 'Remix', 'Upscale', 'Video', 'Animate']) {
+    for (const label of ['Image', 'Reference image', 'Remix', 'Upscale', 'Video', 'Animate']) {
       expect(screen.getByLabelText(label), label).toBeDefined();
     }
   });

--- a/plugins/sero-design-library-plugin/ui/components/SelectionBar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/SelectionBar.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ItemSummary } from '../../shared/types';
+import { SelectionBar } from './SelectionBar';
+
+const SELECTED: ItemSummary = {
+  id: 'item-1',
+  title: 'Selected reference',
+  primaryStyle: 'Editorial',
+  tags: [],
+  designTypes: [],
+  kind: 'image',
+  previewPath: '',
+  analysisStatus: 'ready',
+  favourite: false,
+  collectionIds: ['collection-1'],
+  colours: [],
+  sourceKind: 'file',
+  createdAt: 0,
+  updatedAt: 0,
+  edited: false,
+  searchText: '',
+};
+
+describe('selected reference collections', () => {
+  it('removes a selected reference from a checked collection', async () => {
+    const onCollect = vi.fn();
+    render(
+      <SelectionBar
+        selected={[SELECTED]}
+        collections={[{ id: 'collection-1', name: 'Moodboard', colour: 'primary', createdAt: 0 }]}
+        inTrash={false}
+        onClear={() => {}}
+        onFavourite={() => {}}
+        onCollect={onCollect}
+        onReanalyse={() => {}}
+        onDelete={() => {}}
+        onRestore={() => {}}
+        onPurge={() => {}}
+        onCreateDesign={() => {}}
+        onRemix={() => {}}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Collections' }));
+    const collection = screen.getByRole('menuitemcheckbox', { name: 'Moodboard' });
+    expect(collection.getAttribute('aria-checked')).toBe('true');
+    await userEvent.click(collection);
+
+    expect(onCollect).toHaveBeenCalledWith('collection-1', false);
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
@@ -1,4 +1,10 @@
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@sero-ai/ui';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@sero-ai/ui';
 import { FolderPlus, RotateCw, Shuffle, Sparkles, Star, Trash2, X } from 'lucide-react';
 
 import { MAX_REFERENCES } from '../../shared/design';
@@ -20,7 +26,7 @@ interface SelectionBarProps {
   inTrash: boolean;
   onClear(): void;
   onFavourite(): void;
-  onCollect(collectionId: string): void;
+  onCollect(collectionId: string, member: boolean): void;
   onReanalyse(): void;
   onDelete(): void;
   onRestore(): void;
@@ -28,6 +34,12 @@ interface SelectionBarProps {
   onCreateDesign(): void;
   /** Generate new work from the one selected reference (E3). */
   onRemix(): void;
+}
+
+function collectionChecked(members: number, selected: number): boolean | 'indeterminate' {
+  if (members === 0) return false;
+  if (members === selected) return true;
+  return 'indeterminate';
 }
 
 export function SelectionBar({
@@ -46,6 +58,12 @@ export function SelectionBar({
 }: SelectionBarProps) {
   if (selected.length === 0) return null;
   const count = `${selected.length} reference${selected.length === 1 ? '' : 's'} selected`;
+  const collectionMembers = new Map<string, number>();
+  for (const item of selected) {
+    for (const collectionId of item.collectionIds) {
+      collectionMembers.set(collectionId, (collectionMembers.get(collectionId) ?? 0) + 1);
+    }
+  }
 
   return (
     <div className="border-border bg-accent/40 flex flex-wrap items-center gap-2 border-b px-4 py-2">
@@ -98,15 +116,23 @@ export function SelectionBar({
                 <DropdownMenuTrigger asChild>
                   <Button type="button" variant="ghost" size="sm">
                     <FolderPlus className="size-3.5" />
-                    Add to collection
+                    Collections
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  {collections.map((collection) => (
-                    <DropdownMenuItem key={collection.id} onSelect={() => onCollect(collection.id)}>
-                      {collection.name}
-                    </DropdownMenuItem>
-                  ))}
+                  {collections.map((collection) => {
+                    const members = collectionMembers.get(collection.id) ?? 0;
+                    const checked = collectionChecked(members, selected.length);
+                    return (
+                      <DropdownMenuCheckboxItem
+                        key={collection.id}
+                        checked={checked}
+                        onCheckedChange={(next) => onCollect(collection.id, next === true)}
+                      >
+                        {collection.name}
+                      </DropdownMenuCheckboxItem>
+                    );
+                  })}
                 </DropdownMenuContent>
               </DropdownMenu>
             )}

--- a/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/SelectionBar.tsx
@@ -126,6 +126,7 @@ export function SelectionBar({
                     return (
                       <DropdownMenuCheckboxItem
                         key={collection.id}
+                        className="pr-8 pl-2 [&>span:first-child]:right-2 [&>span:first-child]:left-auto"
                         checked={checked}
                         onCheckedChange={(next) => onCollect(collection.id, next === true)}
                       >

--- a/plugins/sero-design-library-plugin/ui/hooks/useMedia.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useMedia.ts
@@ -16,7 +16,7 @@ import type { MediaCapability } from '../../shared/media';
 export interface GenerateAssetInput {
   capability: MediaCapability;
   prompt: string;
-  /** A sibling asset or a Library item, for image-to-image and upscale. */
+  /** A sibling asset or Library item for a source-aware capability. */
   sourceId?: string;
   aspectRatio?: string;
   seed?: number;

--- a/plugins/sero-design-library-plugin/ui/lib/asset-view.ts
+++ b/plugins/sero-design-library-plugin/ui/lib/asset-view.ts
@@ -40,6 +40,7 @@ export interface AssetView {
 
 const CAPABILITY_LABELS: Record<DesignAsset['request']['capability'], string> = {
   'text-to-image': 'Image',
+  'reference-to-image': 'Reference image',
   'image-to-image': 'Remix',
   upscale: 'Upscale',
   'text-to-video': 'Video',

--- a/plugins/sero-design-library-plugin/ui/lib/view-sync.test.ts
+++ b/plugins/sero-design-library-plugin/ui/lib/view-sync.test.ts
@@ -29,7 +29,7 @@ describe('retiring optimistic view keys', () => {
       filters: {
         analysisStatuses: [],
         sourceKinds: [],
-        colours: [],
+        colourFamilies: [],
         tags: ['editorial'],
         styles: [],
         mediaKinds: [],

--- a/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
@@ -109,6 +109,12 @@ export function LibraryPage({
           actions.setScope(scope);
         }}
         onCreateCollection={(name) => void actions.createCollection(name, 'primary')}
+        onDeleteCollection={(collectionId) => {
+          if (view.scope.kind === 'collection' && view.scope.collectionId === collectionId) {
+            actions.setScope({ kind: 'all' });
+          }
+          void actions.deleteCollection(collectionId);
+        }}
       />
 
       <div className="flex min-w-0 flex-1 flex-col">
@@ -128,7 +134,9 @@ export function LibraryPage({
           inTrash={inTrash}
           onClear={() => setPicked([])}
           onFavourite={() => applyToPicked((id) => actions.favourite(id, true))}
-          onCollect={(collectionId) => applyToPicked((id) => actions.collect(id, collectionId, true))}
+          onCollect={(collectionId, member) =>
+            applyToPicked((id) => actions.collect(id, collectionId, member))
+          }
           onReanalyse={() => applyToPicked((id) => actions.reanalyse(id))}
           onDelete={() => applyToPicked((id) => actions.remove(id))}
           onRestore={() => applyToPicked((id) => actions.restore(id))}

--- a/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
@@ -216,6 +216,7 @@ export function LibraryPage({
                     {...(item.id === transitioningItemId ? { transitionName } : {})}
                     onOpen={() => onOpenItem(item.id)}
                     onToggleSelect={() => togglePicked(item.id)}
+                    onFavourite={(favourite) => void actions.favourite(item.id, favourite)}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary

- use the shared `Tabs` component with `variant="line"` in Generate and Remix
- restore Restyle under the current-reference actions
- use the standard shared `Combobox` input for Library filters
- keep multi-select filters open while options are selected
- update the enhancement plan, decision entry, prototype, and user guide

## Validation

- `pnpm --filter @sero-ai/plugin-design-library test` — 83 files and 749 tests passed
- `pnpm --filter @sero-ai/plugin-design-library build`
- `pnpm typecheck` — 24 tasks passed
- `npx react-doctor@latest --verbose --scope changed` — 98/100, no diagnostics
- touched source files remain below 500 lines
