### PR TITLE
fix(design-library): refine Gallery page

### DIFF
--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -172,6 +172,8 @@ Choose **Save to Gallery** when a Design revision is worth keeping. The save con
 
 Each Design has one Gallery family. Saving it again adds another immutable version to the same card and makes the new version featured. Use the version selector to inspect an older save or feature it again.
 
+The Gallery rail shows live totals for all designs, favourites, recent saves, and Trash. Search works like Library search and narrows Gallery families by title.
+
 | Action | What it does |
 | --- | --- |
 | Open Design | Opens the source Design at the exact saved revision |

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -176,7 +176,7 @@ The Gallery rail shows live totals for all designs, favourites, recent saves, an
 
 | Action | What it does |
 | --- | --- |
-| Open Design | Opens the source Design at the exact saved revision |
+| Open icon | Opens the source Design at the exact saved revision |
 | Duplicate | Creates an exact editable copy in a new family |
 | Remix | Opens generation with the saved brief and references filled in |
 | Delete version | Moves one saved version to Gallery Trash |

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -172,7 +172,7 @@ Choose **Save to Gallery** when a Design revision is worth keeping. The save con
 
 Each Design has one Gallery family. Saving it again adds another immutable version to the same card and makes the new version featured. Use the version selector to inspect an older save or feature it again.
 
-The Gallery rail shows live totals for all designs, favourites, recent saves, and Trash. Search works like Library search and narrows Gallery families by title.
+The Gallery rail shows live family totals for all designs, favourites, recent saves, and Trash. The Gallery tab shows the same family total. Search works like Library search and narrows live Gallery items and Trash by title.
 
 | Action | What it does |
 | --- | --- |

--- a/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
@@ -29,13 +29,15 @@ Each scope shows a live count:
 
 **Consequence.** Shared local navigation components keep both rails aligned. Counts derive from current Gallery state and update when that state changes.
 
+The top Gallery badge and **All designs** both count families, because one Gallery item is one family card. The recent count and recent grid use the same derived family set.
+
 ## E3 · Gallery search matches Library search
 
 Gallery uses the shared `SearchInput` in the same compact toolbar layout as Library. The toolbar sits in the content column beside the rail and above the Gallery cards.
 
 **Reason.** A full input inside a separate padded panel gives one simple search action too much visual weight.
 
-**Consequence.** Search keeps the same filtering behaviour and gains the Library search icon, size, spacing, and placement. It does not span above the navigation rail.
+**Consequence.** Search keeps the same filtering behaviour and gains the Library search icon, size, spacing, and placement. It does not span above the navigation rail, and it filters both live Gallery cards and Gallery Trash.
 
 ## E4 · Gallery has no introduction header
 

--- a/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
@@ -1,0 +1,44 @@
+# Design Library Gallery-page enhancement decisions
+
+**Status:** Accepted
+**Date:** 2026-07-30
+**Scope:** Gallery navigation, search, version selection, and header
+
+This is a separate decision entry for Gallery-page enhancement work. It does not reopen the first-release decisions.
+
+## E1 · Version selection uses the shared Select
+
+Gallery cards use `Select` from `@sero-ai/ui` for version selection.
+
+**Reason.** The current control is a native HTML select with local styling. It does not match other Sero controls.
+
+**Consequence.** The shared `SelectItem` places the selected tick on the right. Gallery does not add local menu styling.
+
+## E2 · Gallery navigation matches Library navigation
+
+The Gallery rail uses the same row, heading, active, icon, and count styles as the Library rail.
+
+Each scope shows a live count:
+
+- **All designs** — live families
+- **Favourites** — favourite live families
+- **Recently saved** — live families updated in the last seven days
+- **Trash** — the entries shown in Gallery Trash
+
+**Reason.** The two rails perform the same kind of navigation. Different styles make the product feel inconsistent, and hidden counts make scope changes harder to predict.
+
+**Consequence.** Shared local navigation components keep both rails aligned. Counts derive from current Gallery state and update when that state changes.
+
+## E3 · Gallery search matches Library search
+
+Gallery uses the shared `SearchInput` in the same compact toolbar layout as Library.
+
+**Reason.** A full input inside a separate padded panel gives one simple search action too much visual weight.
+
+**Consequence.** Search keeps the same filtering behaviour and gains the Library search icon, size, and spacing.
+
+## E4 · The Gallery header has no aggregate sign
+
+Remove the “versions · families” summary from the Gallery header.
+
+**Reason.** The rail counts provide useful scope totals where people act on them. The header summary repeats data without helping a decision.

--- a/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
@@ -42,3 +42,9 @@ Gallery uses the shared `SearchInput` in the same compact toolbar layout as Libr
 Remove the full “Your Gallery” introduction block, including its description and aggregate summary. Search is the first row of the Gallery page.
 
 **Reason.** The main navigation already names the Gallery. The introduction repeats that name and takes space without supporting an action. The rail counts provide useful totals where people act on them.
+
+## E5 · Open Design is an icon action
+
+Gallery cards use an open icon instead of an **Open Design** text button. The button keeps **Open Design** as its accessible name and tooltip.
+
+**Reason.** The text action takes space from the version selector and repeats a standard navigation symbol.

--- a/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
@@ -31,11 +31,11 @@ Each scope shows a live count:
 
 ## E3 · Gallery search matches Library search
 
-Gallery uses the shared `SearchInput` in the same compact toolbar layout as Library.
+Gallery uses the shared `SearchInput` in the same compact toolbar layout as Library. The toolbar sits in the content column beside the rail and above the Gallery cards.
 
 **Reason.** A full input inside a separate padded panel gives one simple search action too much visual weight.
 
-**Consequence.** Search keeps the same filtering behaviour and gains the Library search icon, size, and spacing.
+**Consequence.** Search keeps the same filtering behaviour and gains the Library search icon, size, spacing, and placement. It does not span above the navigation rail.
 
 ## E4 · Gallery has no introduction header
 

--- a/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md
@@ -37,8 +37,8 @@ Gallery uses the shared `SearchInput` in the same compact toolbar layout as Libr
 
 **Consequence.** Search keeps the same filtering behaviour and gains the Library search icon, size, and spacing.
 
-## E4 · The Gallery header has no aggregate sign
+## E4 · Gallery has no introduction header
 
-Remove the “versions · families” summary from the Gallery header.
+Remove the full “Your Gallery” introduction block, including its description and aggregate summary. Search is the first row of the Gallery page.
 
-**Reason.** The rail counts provide useful scope totals where people act on them. The header summary repeats data without helping a decision.
+**Reason.** The main navigation already names the Gallery. The introduction repeats that name and takes space without supporting an action. The rail counts provide useful totals where people act on them.

--- a/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
@@ -15,7 +15,7 @@ Make Gallery controls consistent with the Library and shared Sero UI.
 2. Put the selected version tick on the right through the shared Select item.
 3. Add live counts to every Gallery scope.
 4. Match the Gallery rail to the Library rail.
-5. Match Gallery search to Library search.
+5. Match Gallery search styling and placement to Library search.
 6. Remove the Gallery introduction header.
 7. Update the product specification and user documentation.
 

--- a/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
@@ -23,7 +23,7 @@ Make Gallery controls consistent with the Library and shared Sero UI.
 ## 3. Verification
 
 1. Test version selection with the shared Select.
-2. Test Gallery scope counts and search.
+2. Test Gallery scope counts and search, including Trash.
 3. Run the Design Library plugin tests.
 4. Run the Design Library plugin typecheck and build.
 5. Run React Doctor.

--- a/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
@@ -1,0 +1,30 @@
+# Design Library Gallery-page enhancements plan
+
+**Status:** Complete
+**Branch:** `fix/design-library-gallery-page`
+**Scope:** Gallery navigation, search, version selection, and header
+**Decision entry:** `docs/decisions/sero-design-library-gallery-page-enhancement-decisions.md`
+
+## 1. Goal
+
+Make Gallery controls consistent with the Library and shared Sero UI.
+
+## 2. Changes
+
+1. Replace the native version picker with the shared Select.
+2. Put the selected version tick on the right through the shared Select item.
+3. Add live counts to every Gallery scope.
+4. Match the Gallery rail to the Library rail.
+5. Match Gallery search to Library search.
+6. Remove the header aggregate summary.
+7. Update the product specification and user documentation.
+
+## 3. Verification
+
+1. Test version selection with the shared Select.
+2. Test Gallery scope counts and search.
+3. Run the Design Library plugin tests.
+4. Run the Design Library plugin typecheck and build.
+5. Run React Doctor.
+6. Check every touched source file is below 500 lines.
+7. Run root `pnpm typecheck` before commit.

--- a/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
@@ -16,7 +16,7 @@ Make Gallery controls consistent with the Library and shared Sero UI.
 3. Add live counts to every Gallery scope.
 4. Match the Gallery rail to the Library rail.
 5. Match Gallery search to Library search.
-6. Remove the header aggregate summary.
+6. Remove the Gallery introduction header.
 7. Update the product specification and user documentation.
 
 ## 3. Verification

--- a/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-gallery-page-enhancements-plan.md
@@ -17,7 +17,8 @@ Make Gallery controls consistent with the Library and shared Sero UI.
 4. Match the Gallery rail to the Library rail.
 5. Match Gallery search styling and placement to Library search.
 6. Remove the Gallery introduction header.
-7. Update the product specification and user documentation.
+7. Replace the Open Design text button with an accessible open icon.
+8. Update the product specification and user documentation.
 
 ## 3. Verification
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -453,7 +453,7 @@ Each asset records tool, provider, capability, model, prompt, parameters, seed, 
 
 Saving creates an immutable version containing exact source files with effective tweak values resolved, the tweak manifest and saved overrides, bundled local assets, a bounded visual preview, the prompt and guardrail snapshot, source and model provenance, and the output target and dependency manifest.
 
-Subsequent saves add versions to the same family. A family shows as one card using its featured version; older versions are reachable through the shared Sero Select, with the selected tick on the right. The newest save becomes featured by default, and changing that pointer never mutates a version.
+Subsequent saves add versions to the same family. A family shows as one card using its featured version; older versions are reachable through the shared Sero Select, with the selected tick on the right. An open icon restores the source Design at the selected revision and keeps **Open Design** as its accessible name. The newest save becomes featured by default, and changing that pointer never mutates a version.
 
 New families come only from explicit Duplicate or Remix into a linked Design family.
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -457,7 +457,7 @@ Subsequent saves add versions to the same family. A family shows as one card usi
 
 New families come only from explicit Duplicate or Remix into a linked Design family.
 
-The Gallery rail matches the Library rail and shows live counts for All designs, Favourites, Recently saved, and Trash. Search uses the same shared search control and compact toolbar layout as Library. The Gallery header does not repeat aggregate family or version totals.
+The Gallery rail matches the Library rail and shows live counts for All designs, Favourites, Recently saved, and Trash. Search uses the same shared search control and compact toolbar layout as Library, and it is the first row of the page. Gallery has no separate introduction header.
 
 ### 9.2 Previews
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -457,7 +457,7 @@ Subsequent saves add versions to the same family. A family shows as one card usi
 
 New families come only from explicit Duplicate or Remix into a linked Design family.
 
-The Gallery rail matches the Library rail and shows live counts for All designs, Favourites, Recently saved, and Trash. Search uses the same shared search control and compact toolbar layout as Library. It sits beside the rail and above the Gallery cards. Gallery has no separate introduction header.
+The Gallery rail matches the Library rail and shows live counts for All designs, Favourites, Recently saved, and Trash. The top Gallery badge and All designs count families, which are the cards shown in the grid. The recent count and grid use the same derived family set. Search uses the same shared search control and compact toolbar layout as Library. It sits beside the rail, above the Gallery cards, and also filters Gallery Trash. Gallery has no separate introduction header.
 
 ### 9.2 Previews
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -453,9 +453,11 @@ Each asset records tool, provider, capability, model, prompt, parameters, seed, 
 
 Saving creates an immutable version containing exact source files with effective tweak values resolved, the tweak manifest and saved overrides, bundled local assets, a bounded visual preview, the prompt and guardrail snapshot, source and model provenance, and the output target and dependency manifest.
 
-Subsequent saves add versions to the same family. A family shows as one card using its featured version; older versions are reachable through a revision selector. The newest save becomes featured by default, and changing that pointer never mutates a version.
+Subsequent saves add versions to the same family. A family shows as one card using its featured version; older versions are reachable through the shared Sero Select, with the selected tick on the right. The newest save becomes featured by default, and changing that pointer never mutates a version.
 
 New families come only from explicit Duplicate or Remix into a linked Design family.
+
+The Gallery rail matches the Library rail and shows live counts for All designs, Favourites, Recently saved, and Trash. Search uses the same shared search control and compact toolbar layout as Library. The Gallery header does not repeat aggregate family or version totals.
 
 ### 9.2 Previews
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -457,7 +457,7 @@ Subsequent saves add versions to the same family. A family shows as one card usi
 
 New families come only from explicit Duplicate or Remix into a linked Design family.
 
-The Gallery rail matches the Library rail and shows live counts for All designs, Favourites, Recently saved, and Trash. Search uses the same shared search control and compact toolbar layout as Library, and it is the first row of the page. Gallery has no separate introduction header.
+The Gallery rail matches the Library rail and shows live counts for All designs, Favourites, Recently saved, and Trash. Search uses the same shared search control and compact toolbar layout as Library. It sits beside the rail and above the Gallery cards. Gallery has no separate introduction header.
 
 ### 9.2 Previews
 

--- a/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
+++ b/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
@@ -65,10 +65,7 @@ export function DesignLibraryApp() {
   const backToLibrary = () => navigateWithTransition(() => library.actions.select(undefined));
 
   const liveCount = library.state.items.filter((item) => item.deletedAt === undefined).length;
-  const galleryVersionCount = gallery.families.reduce(
-    (total, family) => total + family.versions.filter((version) => version.deletedAt === undefined).length,
-    0,
-  );
+  const galleryFamilyCount = gallery.families.length;
 
   // Videos generated while Sero was closed have no stills yet, and the runtime
   // cannot make them. Done here rather than on the Library page so it keeps
@@ -136,7 +133,7 @@ export function DesignLibraryApp() {
             }}
           >
             Gallery
-            <span className="text-muted-foreground tabular-nums">{galleryVersionCount}</span>
+            <span className="text-muted-foreground tabular-nums">{galleryFamilyCount}</span>
           </Button>
           <Button
             type="button"

--- a/plugins/sero-design-library-plugin/ui/components/LibraryRail.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryRail.tsx
@@ -13,6 +13,7 @@ import { useMemo, useState } from 'react';
 import type { Collection } from '../../shared/records';
 import { deriveStyleGroups, matchesScope } from '../../shared/search';
 import type { ItemSummary, LibraryScope } from '../../shared/types';
+import { NavigationRailHeading, NavigationRailRow } from './NavigationRail';
 
 /**
  * The left rail: fixed scopes, then the user's own collections, then style
@@ -37,40 +38,6 @@ function sameScope(a: LibraryScope, b: LibraryScope): boolean {
   if (a.kind === 'collection' && b.kind === 'collection') return a.collectionId === b.collectionId;
   if (a.kind === 'style' && b.kind === 'style') return a.style === b.style;
   return true;
-}
-
-interface RailRowProps {
-  active: boolean;
-  label: string;
-  count: number;
-  icon?: React.ReactNode;
-  onClick(): void;
-}
-
-function RailRow({ active, label, count, icon, onClick }: RailRowProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-current={active}
-      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
-        active ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-      }`}
-    >
-      {icon}
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      <span className="text-muted-foreground text-xs tabular-nums">{count}</span>
-    </button>
-  );
-}
-
-function RailHeading({ children, action }: { children: React.ReactNode; action?: React.ReactNode }) {
-  return (
-    <div className="text-muted-foreground flex items-center justify-between px-2 pt-4 pb-1 text-xs font-medium tracking-wide uppercase">
-      <span>{children}</span>
-      {action}
-    </div>
-  );
 }
 
 function CollectionRow({
@@ -152,29 +119,29 @@ export function LibraryRail({
   return (
     <ScrollArea className="border-border h-full w-56 shrink-0 border-r">
       <nav className="p-2" aria-label="Library navigation">
-        <RailHeading>Library</RailHeading>
-        <RailRow
+        <NavigationRailHeading>Library</NavigationRailHeading>
+        <NavigationRailRow
           active={sameScope(scope, { kind: 'all' })}
           label="All inspiration"
           count={countFor({ kind: 'all' })}
           icon={<Diamond className="size-3.5" />}
           onClick={() => onScopeChange({ kind: 'all' })}
         />
-        <RailRow
+        <NavigationRailRow
           active={sameScope(scope, { kind: 'favourites' })}
           label="Favourites"
           count={countFor({ kind: 'favourites' })}
           icon={<Star className="size-3.5" />}
           onClick={() => onScopeChange({ kind: 'favourites' })}
         />
-        <RailRow
+        <NavigationRailRow
           active={sameScope(scope, { kind: 'awaiting' })}
           label="Awaiting analysis"
           count={countFor({ kind: 'awaiting' })}
           icon={<Clock className="size-3.5" />}
           onClick={() => onScopeChange({ kind: 'awaiting' })}
         />
-        <RailRow
+        <NavigationRailRow
           active={sameScope(scope, { kind: 'recent' })}
           label="Recently added"
           count={countFor({ kind: 'recent' })}
@@ -182,7 +149,7 @@ export function LibraryRail({
           onClick={() => onScopeChange({ kind: 'recent' })}
         />
 
-        <RailHeading
+        <NavigationRailHeading
           action={
             <Button
               type="button"
@@ -197,7 +164,7 @@ export function LibraryRail({
           }
         >
           Collections
-        </RailHeading>
+        </NavigationRailHeading>
         {newCollection !== null && (
           <Input
             autoFocus
@@ -225,9 +192,9 @@ export function LibraryRail({
 
         {styleGroups.length > 0 && (
           <>
-            <RailHeading>Style groups</RailHeading>
+            <NavigationRailHeading>Style groups</NavigationRailHeading>
             {styleGroups.map((group) => (
-              <RailRow
+              <NavigationRailRow
                 key={group.style}
                 active={sameScope(scope, { kind: 'style', style: group.style })}
                 label={group.style}
@@ -239,8 +206,8 @@ export function LibraryRail({
           </>
         )}
 
-        <RailHeading>&nbsp;</RailHeading>
-        <RailRow
+        <NavigationRailHeading>&nbsp;</NavigationRailHeading>
+        <NavigationRailRow
           active={sameScope(scope, { kind: 'trash' })}
           label="Trash"
           count={countFor({ kind: 'trash' })}

--- a/plugins/sero-design-library-plugin/ui/components/NavigationRail.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/NavigationRail.tsx
@@ -1,0 +1,47 @@
+interface NavigationRailRowProps {
+  active: boolean;
+  label: string;
+  count: number;
+  icon?: React.ReactNode;
+  onClick(): void;
+}
+
+export function NavigationRailRow({
+  active,
+  label,
+  count,
+  icon,
+  onClick,
+}: NavigationRailRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={active}
+      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
+        active
+          ? 'bg-accent text-accent-foreground'
+          : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+      }`}
+    >
+      {icon}
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="text-muted-foreground text-xs tabular-nums">{count}</span>
+    </button>
+  );
+}
+
+export function NavigationRailHeading({
+  children,
+  action,
+}: {
+  children: React.ReactNode;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="text-muted-foreground flex items-center justify-between px-2 pt-4 pb-1 text-xs font-medium tracking-wide uppercase">
+      <span>{children}</span>
+      {action}
+    </div>
+  );
+}

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.test.tsx
@@ -53,7 +53,8 @@ describe('Gallery family card', () => {
       />,
     );
 
-    await user.selectOptions(screen.getByLabelText('Version'), 'ver-1');
+    await user.click(screen.getByRole('combobox', { name: 'Version' }));
+    await user.click(screen.getByRole('option', { name: 'V1 · First' }));
     await user.click(screen.getByRole('button', { name: 'Open Design' }));
     await user.click(screen.getByRole('button', { name: 'Gallery family actions' }));
     await user.click(screen.getByRole('menuitem', { name: 'Duplicate' }));

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.test.tsx
@@ -55,6 +55,7 @@ describe('Gallery family card', () => {
 
     await user.click(screen.getByRole('combobox', { name: 'Version' }));
     await user.click(screen.getByRole('option', { name: 'V1 · First' }));
+    expect(screen.queryByText('Open Design')).toBeNull();
     await user.click(screen.getByRole('button', { name: 'Open Design' }));
     await user.click(screen.getByRole('button', { name: 'Gallery family actions' }));
     await user.click(screen.getByRole('menuitem', { name: 'Duplicate' }));

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
@@ -4,6 +4,11 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from '@sero-ai/ui';
 import { Heart, ImageOff, MoreHorizontal } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -98,18 +103,19 @@ export function GalleryCard({
         </div>
 
         <div className="flex items-center gap-2">
-          <label className="text-muted-foreground flex min-w-0 flex-1 items-center gap-2 text-xs">
-            Version
-            <select
-              value={selected.id}
-              onChange={(event) => setSelectedId(event.target.value)}
-              className="border-border bg-background h-8 min-w-0 flex-1 rounded border px-2"
-            >
+          <span className="text-muted-foreground text-xs">Version</span>
+          <Select value={selected.id} onValueChange={setSelectedId}>
+            <SelectTrigger size="sm" className="min-w-0 flex-1" aria-label="Version">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
               {live.map((version, index) => (
-                <option key={version.id} value={version.id}>V{index + 1} · {version.title}</option>
+                <SelectItem key={version.id} value={version.id}>
+                  V{index + 1} · {version.title}
+                </SelectItem>
               ))}
-            </select>
-          </label>
+            </SelectContent>
+          </Select>
           {selected.id !== family.featuredVersionId && (
             <Button type="button" size="sm" variant="outline" onClick={() => onFeature(selected.id)}>
               Feature

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@sero-ai/ui';
-import { ExternalLink, Heart, ImageOff, MoreHorizontal } from 'lucide-react';
+import { SquareArrowOutUpRight, Heart, ImageOff, MoreHorizontal } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import type { GalleryFamilyRecord } from '../../../shared/gallery';
@@ -128,7 +128,7 @@ export function GalleryCard({
             title="Open Design"
             onClick={() => onOpen(selected.id)}
           >
-            <ExternalLink className="size-3.5" />
+            <SquareArrowOutUpRight className="size-3.5" />
           </Button>
         </div>
       </div>

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryCard.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@sero-ai/ui';
-import { Heart, ImageOff, MoreHorizontal } from 'lucide-react';
+import { ExternalLink, Heart, ImageOff, MoreHorizontal } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import type { GalleryFamilyRecord } from '../../../shared/gallery';
@@ -121,7 +121,15 @@ export function GalleryCard({
               Feature
             </Button>
           )}
-          <Button type="button" size="sm" onClick={() => onOpen(selected.id)}>Open Design</Button>
+          <Button
+            type="button"
+            size="icon-sm"
+            aria-label="Open Design"
+            title="Open Design"
+            onClick={() => onOpen(selected.id)}
+          >
+            <ExternalLink className="size-3.5" />
+          </Button>
         </div>
       </div>
     </article>

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryTrash.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryTrash.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GalleryFamilyRecord } from '../../../shared/gallery';
+import type { GalleryActions } from '../../hooks/useGallery';
+import { GalleryTrash } from './GalleryTrash';
+
+vi.mock('../../hooks/useAssetSrc', () => ({
+  useGalleryPreviewSrc: () => null,
+}));
+
+const actions = {
+  save: async () => true,
+  read: async () => null,
+  feature: async () => {},
+  favourite: async () => {},
+  open: async () => true,
+  duplicate: async () => true,
+  exportVersion: async () => {},
+  removeFamily: async () => {},
+  restoreFamily: async () => {},
+  purgeFamily: async () => {},
+  removeVersion: async () => {},
+  restoreVersion: async () => {},
+  purgeVersion: async () => {},
+} satisfies GalleryActions;
+
+const family: GalleryFamilyRecord = {
+  id: 'family-one',
+  schemaVersion: 1,
+  createdAt: 1,
+  updatedAt: 2,
+  title: 'Signal Ledger',
+  sourceDesignId: 'design-one',
+  featuredVersionId: 'version-one',
+  favourite: false,
+  versions: [
+    {
+      id: 'version-one',
+      createdAt: 1,
+      title: 'Teal Passage',
+      target: 'html',
+      sourceVariantId: 'variant-one',
+      sourceRevisionId: 'revision-one',
+      previewFile: 'preview.png',
+      deletedAt: 2,
+    },
+  ],
+};
+
+describe('Gallery Trash search', () => {
+  it('filters deleted entries by family or version title', () => {
+    const { rerender } = render(
+      <GalleryTrash families={[family]} query="missing" actions={actions} />,
+    );
+
+    expect(screen.getByText('No Gallery Trash entry matches.')).toBeDefined();
+    expect(screen.queryByText('Signal Ledger')).toBeNull();
+
+    rerender(<GalleryTrash families={[family]} query="teal" actions={actions} />);
+
+    expect(screen.getByText('Signal Ledger')).toBeDefined();
+    expect(screen.getByText('Deleted version · Teal Passage')).toBeDefined();
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/components/gallery/GalleryTrash.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/gallery/GalleryTrash.tsx
@@ -7,9 +7,11 @@ import { useVisible } from '../../hooks/useVisible';
 
 export function GalleryTrash({
   families,
+  query,
   actions,
 }: {
   families: GalleryFamilyRecord[];
+  query: string;
   actions: GalleryActions;
 }) {
   const entries = families.flatMap<TrashEntry>((family) =>
@@ -22,9 +24,24 @@ export function GalleryTrash({
   if (entries.length === 0) {
     return <p className="text-muted-foreground px-6 py-24 text-center text-sm">Gallery Trash is empty.</p>;
   }
+  const needle = query.trim().toLowerCase();
+  const visible = needle === ''
+    ? entries
+    : entries.filter(
+        (entry) =>
+          entry.family.title.toLowerCase().includes(needle) ||
+          (entry.kind === 'version' && entry.version.title.toLowerCase().includes(needle)),
+      );
+  if (visible.length === 0) {
+    return (
+      <p className="text-muted-foreground px-6 py-24 text-center text-sm">
+        No Gallery Trash entry matches.
+      </p>
+    );
+  }
   return (
     <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4 p-5">
-      {entries.map((entry) => (
+      {visible.map((entry) => (
         <TrashCard
           key={entry.kind === 'family' ? entry.family.id : entry.version.id}
           entry={entry}

--- a/plugins/sero-design-library-plugin/ui/pages/GalleryPage.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/GalleryPage.test.tsx
@@ -98,6 +98,7 @@ describe('Gallery navigation and search', () => {
     expect(screen.getByRole('button', { name: 'Recently saved 2' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Trash 1' })).toBeDefined();
     expect(screen.queryByText(/versions · families/)).toBeNull();
+    expect(screen.queryByRole('heading', { name: 'Your Gallery' })).toBeNull();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Search Gallery' }), {
       target: { value: 'signal' },

--- a/plugins/sero-design-library-plugin/ui/pages/GalleryPage.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/GalleryPage.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { GalleryFamilyRecord } from '../../shared/gallery';
+import type { GalleryActions } from '../hooks/useGallery';
+import { GalleryPage } from './GalleryPage';
+
+vi.mock('../components/gallery/GalleryCard', () => ({
+  GalleryCard: ({ family }: { family: GalleryFamilyRecord }) => <div>{family.title}</div>,
+}));
+
+vi.mock('../components/gallery/GalleryTrash', () => ({
+  GalleryTrash: () => <div>Gallery Trash</div>,
+}));
+
+const actions = {
+  save: async () => true,
+  read: async () => null,
+  feature: async () => {},
+  favourite: async () => {},
+  open: async () => true,
+  duplicate: async () => true,
+  exportVersion: async () => {},
+  removeFamily: async () => {},
+  restoreFamily: async () => {},
+  purgeFamily: async () => {},
+  removeVersion: async () => {},
+  restoreVersion: async () => {},
+  purgeVersion: async () => {},
+} satisfies GalleryActions;
+
+function family(
+  id: string,
+  title: string,
+  overrides: Partial<GalleryFamilyRecord> = {},
+): GalleryFamilyRecord {
+  return {
+    id,
+    schemaVersion: 1,
+    createdAt: 1,
+    updatedAt: Date.now(),
+    title,
+    sourceDesignId: `design-${id}`,
+    featuredVersionId: `version-${id}`,
+    favourite: false,
+    versions: [
+      {
+        id: `version-${id}`,
+        createdAt: 1,
+        title,
+        target: 'html',
+        sourceVariantId: `variant-${id}`,
+        sourceRevisionId: `revision-${id}`,
+        previewFile: 'preview.png',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('Gallery navigation and search', () => {
+  it('shows live scope counts and filters titles with the shared search field', () => {
+    const first = family('one', 'Signal Ledger', { favourite: true });
+    const second = family('two', 'Quiet Atlas');
+    const deletedVersion = family('three', 'Old Version', {
+      versions: [
+        {
+          id: 'version-three',
+          createdAt: 1,
+          title: 'Old Version',
+          target: 'html',
+          sourceVariantId: 'variant-three',
+          sourceRevisionId: 'revision-three',
+          previewFile: 'preview.png',
+          deletedAt: 2,
+        },
+      ],
+    });
+
+    const view = (
+      families: GalleryFamilyRecord[],
+    ) => (
+      <GalleryPage
+        families={families}
+        trash={[deletedVersion]}
+        actions={actions}
+        onOpened={() => {}}
+        onRemix={() => {}}
+      />
+    );
+
+    const { rerender } = render(view([first, second]));
+
+    expect(screen.getByRole('button', { name: 'All designs 2' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Favourites 1' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Recently saved 2' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Trash 1' })).toBeDefined();
+    expect(screen.queryByText(/versions · families/)).toBeNull();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search Gallery' }), {
+      target: { value: 'signal' },
+    });
+    expect(screen.getByText('Signal Ledger')).toBeDefined();
+    expect(screen.queryByText('Quiet Atlas')).toBeNull();
+
+    rerender(view([first, { ...second, favourite: true }]));
+    expect(screen.getByRole('button', { name: 'Favourites 2' })).toBeDefined();
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
@@ -64,14 +64,6 @@ export function GalleryPage({
   }, [families, query, scope]);
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="border-border border-b px-5 py-5">
-        <div>
-          <h2 className="text-xl font-semibold tracking-tight">Your Gallery</h2>
-          <p className="text-muted-foreground mt-1 text-sm">
-            Finished work worth keeping, revisiting, and remixing.
-          </p>
-        </div>
-      </div>
       <div className="border-border flex flex-wrap items-center gap-2 border-b px-4 py-2.5">
         <SearchInput
           value={query}

--- a/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
@@ -63,56 +63,57 @@ export function GalleryPage({
       : scoped.filter((family) => family.title.toLowerCase().includes(needle));
   }, [families, query, scope]);
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="border-border flex flex-wrap items-center gap-2 border-b px-4 py-2.5">
-        <SearchInput
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search saved designs"
-          aria-label="Search Gallery"
-          className="h-8 max-w-96 min-w-56 flex-1"
-        />
-      </div>
-      {error && (
-        <p className="text-destructive border-border border-b px-5 py-2 text-sm" role="alert">
-          {error}
-        </p>
-      )}
-      <div className="flex min-h-0 flex-1">
-        <ScrollArea className="border-border h-full w-56 shrink-0 border-r">
-          <nav className="p-2" aria-label="Gallery navigation">
-            <NavigationRailHeading>Gallery</NavigationRailHeading>
-            <NavigationRailRow
-              active={scope === 'all'}
-              label="All designs"
-              count={counts.all}
-              icon={<Images className="size-3.5" />}
-              onClick={() => setScope('all')}
-            />
-            <NavigationRailRow
-              active={scope === 'favourites'}
-              label="Favourites"
-              count={counts.favourites}
-              icon={<Heart className="size-3.5" />}
-              onClick={() => setScope('favourites')}
-            />
-            <NavigationRailRow
-              active={scope === 'recent'}
-              label="Recently saved"
-              count={counts.recent}
-              icon={<Clock className="size-3.5" />}
-              onClick={() => setScope('recent')}
-            />
-            <NavigationRailHeading>&nbsp;</NavigationRailHeading>
-            <NavigationRailRow
-              active={scope === 'trash'}
-              label="Trash"
-              count={counts.trash}
-              icon={<Trash2 className="size-3.5" />}
-              onClick={() => setScope('trash')}
-            />
-          </nav>
-        </ScrollArea>
+    <div className="flex min-h-0 flex-1">
+      <ScrollArea className="border-border h-full w-56 shrink-0 border-r">
+        <nav className="p-2" aria-label="Gallery navigation">
+          <NavigationRailHeading>Gallery</NavigationRailHeading>
+          <NavigationRailRow
+            active={scope === 'all'}
+            label="All designs"
+            count={counts.all}
+            icon={<Images className="size-3.5" />}
+            onClick={() => setScope('all')}
+          />
+          <NavigationRailRow
+            active={scope === 'favourites'}
+            label="Favourites"
+            count={counts.favourites}
+            icon={<Heart className="size-3.5" />}
+            onClick={() => setScope('favourites')}
+          />
+          <NavigationRailRow
+            active={scope === 'recent'}
+            label="Recently saved"
+            count={counts.recent}
+            icon={<Clock className="size-3.5" />}
+            onClick={() => setScope('recent')}
+          />
+          <NavigationRailHeading>&nbsp;</NavigationRailHeading>
+          <NavigationRailRow
+            active={scope === 'trash'}
+            label="Trash"
+            count={counts.trash}
+            icon={<Trash2 className="size-3.5" />}
+            onClick={() => setScope('trash')}
+          />
+        </nav>
+      </ScrollArea>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="border-border flex flex-wrap items-center gap-2 border-b px-4 py-2.5">
+          <SearchInput
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search saved designs"
+            aria-label="Search Gallery"
+            className="h-8 max-w-96 min-w-56 flex-1"
+          />
+        </div>
+        {error && (
+          <p className="text-destructive border-border border-b px-5 py-2 text-sm" role="alert">
+            {error}
+          </p>
+        )}
         <ScrollArea className="min-h-0 flex-1">
           {scope === 'trash' ? (
             <GalleryTrash families={trash} actions={actions} />

--- a/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
@@ -42,26 +42,30 @@ export function GalleryPage({
 }: GalleryPageProps) {
   const [query, setQuery] = useState('');
   const [scope, setScope] = useState<GalleryScope>('all');
-  const counts = useMemo(() => {
+  const recent = useMemo(() => {
     const now = Date.now();
+    return families.filter((family) => now - family.updatedAt < RECENT_MS);
+  }, [families]);
+  const counts = useMemo(() => {
     return {
       all: families.length,
       favourites: families.filter((family) => family.favourite).length,
-      recent: families.filter((family) => now - family.updatedAt < RECENT_MS).length,
+      recent: recent.length,
       trash: trashEntryCount(trash),
     };
-  }, [families, trash]);
+  }, [families, recent, trash]);
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
-    const scoped = families.filter((family) => {
-      if (scope === 'favourites') return family.favourite;
-      if (scope === 'recent') return Date.now() - family.updatedAt < RECENT_MS;
-      return true;
-    });
+    const scoped =
+      scope === 'favourites'
+        ? families.filter((family) => family.favourite)
+        : scope === 'recent'
+          ? recent
+          : families;
     return needle === ''
       ? scoped
       : scoped.filter((family) => family.title.toLowerCase().includes(needle));
-  }, [families, query, scope]);
+  }, [families, query, recent, scope]);
   return (
     <div className="flex min-h-0 flex-1">
       <ScrollArea className="border-border h-full w-56 shrink-0 border-r">
@@ -116,7 +120,7 @@ export function GalleryPage({
         )}
         <ScrollArea className="min-h-0 flex-1">
           {scope === 'trash' ? (
-            <GalleryTrash families={trash} actions={actions} />
+            <GalleryTrash families={trash} query={query} actions={actions} />
           ) : visible.length === 0 ? (
             <div className="text-muted-foreground flex flex-col items-center gap-3 px-6 py-24 text-center text-sm">
               <Images className="size-8" />

--- a/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/GalleryPage.tsx
@@ -1,11 +1,12 @@
-import { Button, Input, ScrollArea } from '@sero-ai/ui';
-import { Images } from 'lucide-react';
+import { ScrollArea, SearchInput } from '@sero-ai/ui';
+import { Clock, Heart, Images, Trash2 } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import type { GalleryFamilyRecord } from '../../shared/gallery';
 import type { GalleryActions } from '../hooks/useGallery';
 import { GalleryCard } from '../components/gallery/GalleryCard';
 import { GalleryTrash } from '../components/gallery/GalleryTrash';
+import { NavigationRailHeading, NavigationRailRow } from '../components/NavigationRail';
 
 interface GalleryPageProps {
   families: GalleryFamilyRecord[];
@@ -18,111 +19,152 @@ interface GalleryPageProps {
 
 type GalleryScope = 'all' | 'favourites' | 'recent' | 'trash';
 
-export function GalleryPage({ families, trash, actions, onOpened, onRemix, error }: GalleryPageProps) {
+const RECENT_MS = 7 * 24 * 60 * 60 * 1000;
+
+function trashEntryCount(families: GalleryFamilyRecord[]): number {
+  return families.reduce(
+    (total, family) =>
+      total +
+      (family.deletedAt === undefined
+        ? family.versions.filter((version) => version.deletedAt !== undefined).length
+        : 1),
+    0,
+  );
+}
+
+export function GalleryPage({
+  families,
+  trash,
+  actions,
+  onOpened,
+  onRemix,
+  error,
+}: GalleryPageProps) {
   const [query, setQuery] = useState('');
   const [scope, setScope] = useState<GalleryScope>('all');
+  const counts = useMemo(() => {
+    const now = Date.now();
+    return {
+      all: families.length,
+      favourites: families.filter((family) => family.favourite).length,
+      recent: families.filter((family) => now - family.updatedAt < RECENT_MS).length,
+      trash: trashEntryCount(trash),
+    };
+  }, [families, trash]);
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
     const scoped = families.filter((family) => {
       if (scope === 'favourites') return family.favourite;
-      if (scope === 'recent') return Date.now() - family.updatedAt < 7 * 24 * 60 * 60 * 1000;
+      if (scope === 'recent') return Date.now() - family.updatedAt < RECENT_MS;
       return true;
     });
-    return needle === '' ? scoped : scoped.filter((family) => family.title.toLowerCase().includes(needle));
+    return needle === ''
+      ? scoped
+      : scoped.filter((family) => family.title.toLowerCase().includes(needle));
   }, [families, query, scope]);
-  const versionCount = families.reduce(
-    (total, family) => total + family.versions.filter((version) => version.deletedAt === undefined).length,
-    0,
-  );
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="border-border flex items-end gap-4 border-b px-5 py-5">
+      <div className="border-border border-b px-5 py-5">
         <div>
           <h2 className="text-xl font-semibold tracking-tight">Your Gallery</h2>
-          <p className="text-muted-foreground mt-1 text-sm">Finished work worth keeping, revisiting, and remixing.</p>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Finished work worth keeping, revisiting, and remixing.
+          </p>
         </div>
-        <span className="text-muted-foreground ml-auto text-xs tabular-nums">
-          {versionCount} version{versionCount === 1 ? '' : 's'} · {families.length} families
-        </span>
       </div>
-      <div className="border-border border-b px-5 py-3">
-        <Input
+      <div className="border-border flex flex-wrap items-center gap-2 border-b px-4 py-2.5">
+        <SearchInput
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search saved designs"
           aria-label="Search Gallery"
-          className="max-w-md"
+          className="h-8 max-w-96 min-w-56 flex-1"
         />
       </div>
-      {error && <p className="text-destructive border-border border-b px-5 py-2 text-sm" role="alert">{error}</p>}
+      {error && (
+        <p className="text-destructive border-border border-b px-5 py-2 text-sm" role="alert">
+          {error}
+        </p>
+      )}
       <div className="flex min-h-0 flex-1">
-        <aside className="border-border w-48 shrink-0 space-y-1 border-r p-3">
-          <ScopeButton scope="all" current={scope} onSelect={setScope}>All designs</ScopeButton>
-          <ScopeButton scope="favourites" current={scope} onSelect={setScope}>Favourites</ScopeButton>
-          <ScopeButton scope="recent" current={scope} onSelect={setScope}>Recently saved</ScopeButton>
-          <ScopeButton scope="trash" current={scope} onSelect={setScope}>Trash</ScopeButton>
-        </aside>
+        <ScrollArea className="border-border h-full w-56 shrink-0 border-r">
+          <nav className="p-2" aria-label="Gallery navigation">
+            <NavigationRailHeading>Gallery</NavigationRailHeading>
+            <NavigationRailRow
+              active={scope === 'all'}
+              label="All designs"
+              count={counts.all}
+              icon={<Images className="size-3.5" />}
+              onClick={() => setScope('all')}
+            />
+            <NavigationRailRow
+              active={scope === 'favourites'}
+              label="Favourites"
+              count={counts.favourites}
+              icon={<Heart className="size-3.5" />}
+              onClick={() => setScope('favourites')}
+            />
+            <NavigationRailRow
+              active={scope === 'recent'}
+              label="Recently saved"
+              count={counts.recent}
+              icon={<Clock className="size-3.5" />}
+              onClick={() => setScope('recent')}
+            />
+            <NavigationRailHeading>&nbsp;</NavigationRailHeading>
+            <NavigationRailRow
+              active={scope === 'trash'}
+              label="Trash"
+              count={counts.trash}
+              icon={<Trash2 className="size-3.5" />}
+              onClick={() => setScope('trash')}
+            />
+          </nav>
+        </ScrollArea>
         <ScrollArea className="min-h-0 flex-1">
-        {scope === 'trash' ? (
-          <GalleryTrash families={trash} actions={actions} />
-        ) : visible.length === 0 ? (
-          <div className="text-muted-foreground flex flex-col items-center gap-3 px-6 py-24 text-center text-sm">
-            <Images className="size-8" />
-            <p>{families.length === 0 ? 'Save a Design when it is worth keeping.' : 'No saved Design matches.'}</p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4 p-5">
-            {visible.map((family) => (
-              <GalleryCard
-                key={family.id}
-                family={family}
-                onOpen={(versionId) => {
-                  void actions.open(family.id, versionId).then((opened) => {
-                    if (opened) onOpened();
-                  });
-                }}
-                onFeature={(versionId) => void actions.feature(family.id, versionId)}
-                onDuplicate={(versionId) => {
-                  void actions.duplicate(family.id, versionId).then((opened) => {
-                    if (opened) onOpened();
-                  });
-                }}
-                onRemix={(versionId) => onRemix(family.id, versionId)}
-                onExport={(versionId, destination) => {
-                  void actions.exportVersion(family.id, versionId, destination);
-                }}
-                onFavourite={(favourite) => void actions.favourite(family.id, favourite)}
-                onDelete={() => void actions.removeFamily(family.id)}
-                onDeleteVersion={(versionId) => void actions.removeVersion(family.id, versionId)}
-              />
-            ))}
-          </div>
-        )}
+          {scope === 'trash' ? (
+            <GalleryTrash families={trash} actions={actions} />
+          ) : visible.length === 0 ? (
+            <div className="text-muted-foreground flex flex-col items-center gap-3 px-6 py-24 text-center text-sm">
+              <Images className="size-8" />
+              <p>
+                {families.length === 0
+                  ? 'Save a Design when it is worth keeping.'
+                  : 'No saved Design matches.'}
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-4 p-5">
+              {visible.map((family) => (
+                <GalleryCard
+                  key={family.id}
+                  family={family}
+                  onOpen={(versionId) => {
+                    void actions.open(family.id, versionId).then((opened) => {
+                      if (opened) onOpened();
+                    });
+                  }}
+                  onFeature={(versionId) => void actions.feature(family.id, versionId)}
+                  onDuplicate={(versionId) => {
+                    void actions.duplicate(family.id, versionId).then((opened) => {
+                      if (opened) onOpened();
+                    });
+                  }}
+                  onRemix={(versionId) => onRemix(family.id, versionId)}
+                  onExport={(versionId, destination) => {
+                    void actions.exportVersion(family.id, versionId, destination);
+                  }}
+                  onFavourite={(favourite) => void actions.favourite(family.id, favourite)}
+                  onDelete={() => void actions.removeFamily(family.id)}
+                  onDeleteVersion={(versionId) =>
+                    void actions.removeVersion(family.id, versionId)
+                  }
+                />
+              ))}
+            </div>
+          )}
         </ScrollArea>
       </div>
     </div>
-  );
-}
-
-function ScopeButton({
-  scope,
-  current,
-  onSelect,
-  children,
-}: {
-  scope: GalleryScope;
-  current: GalleryScope;
-  onSelect(scope: GalleryScope): void;
-  children: React.ReactNode;
-}) {
-  return (
-    <Button
-      type="button"
-      variant={scope === current ? 'secondary' : 'ghost'}
-      className="w-full justify-start"
-      onClick={() => onSelect(scope)}
-    >
-      {children}
-    </Button>
   );
 }


### PR DESCRIPTION
## Summary

- replace the native version picker with the shared Sero Select and right-side tick
- add live counts to Gallery navigation scopes
- share navigation row and heading styles with the Library rail
- use the Library search control and place it beside the rail above Gallery cards
- remove the redundant Gallery introduction and aggregate summary
- replace the Open Design text button with a compact, accessible open icon
- add scoped plan and decision records and update the specification and user guide

## Why

Gallery used local controls and a layout that did not match Library. The native version select placed its tick inconsistently, navigation scopes hid useful totals, search spanned above the rail, and the introduction and text action used space without adding useful context.

## Impact

Gallery now follows the same navigation and search structure as Library. Counts update from current Gallery state. Version and open actions use compact shared patterns while keeping accessible names and tooltips.

## Validation

- `pnpm --filter @sero-ai/plugin-design-library test` — 761 tests passed
- `pnpm --filter @sero-ai/plugin-design-library typecheck`
- `pnpm --filter @sero-ai/plugin-design-library build`
- React Doctor — 100/100
- `pnpm typecheck`
- touched source files are below 500 lines