### PR TITLE
Improve design library options controls

### DIFF
--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -244,7 +244,7 @@ Importing your own video files is not supported yet.
 | Variants per design | 3 | How many directions a new design starts with |
 | On revise | Replace what is visible | Or keep each revision separately |
 | Prompt recipes | Three built in | Named instruction templates applied on top of a request |
-| Media models | The provider's defaults | Choose a live provider model for each kind of generation: image, restyle, upscale, text-to-video and image-to-video |
+| Media models | The provider's defaults | Search live models by name or endpoint for each kind of generation. Choices are grouped by model provider |
 | Media calls per run | 4 | Use the stepper to set how many pictures one design run may ask for. Going over stops further calls and says so, and the design still finishes |
 | Provider key | From the environment | See below |
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -244,11 +244,13 @@ Importing your own video files is not supported yet.
 | Variants per design | 3 | How many directions a new design starts with |
 | On revise | Replace what is visible | Or keep each revision separately |
 | Prompt recipes | Three built in | Named instruction templates applied on top of a request |
-| Media models | The provider's defaults | Search live models by name or endpoint for each kind of generation. Choices are grouped by model provider. Use the info icon beside a label to see where that model is used |
-| Media calls per run | 4 | Use the stepper to set how many pictures one design run may ask for. Going over stops further calls and says so, and the design still finishes |
+| Media models | The provider's defaults | Search loaded models by name or endpoint for each kind of generation. Choices are grouped by model provider. You can enter an endpoint that is not listed. Use the info icon beside a label to see where that model is used |
+| Media calls per run | 4 | Use the stepper buttons or enter a number to set how many pictures one design run may ask for. Going over stops further calls and says so, and the design still finishes |
 | Provider key | From the environment | See below |
 
 For Librarian and Design models, clearing the choice uses Sero's configured model. For media models, choose **Provider default** to use the provider's default.
+
+Sero caches the media model list after it loads. If the provider cannot load the list, Settings shows the error and a **Retry** action. Saved choices and manual endpoint entry still work.
 
 ### The picture provider
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -244,7 +244,7 @@ Importing your own video files is not supported yet.
 | Variants per design | 3 | How many directions a new design starts with |
 | On revise | Replace what is visible | Or keep each revision separately |
 | Prompt recipes | Three built in | Named instruction templates applied on top of a request |
-| Media models | The provider's defaults | Search live models by name or endpoint for each kind of generation. Choices are grouped by model provider |
+| Media models | The provider's defaults | Search live models by name or endpoint for each kind of generation. Choices are grouped by model provider. Use the info icon beside a label to see where that model is used |
 | Media calls per run | 4 | Use the stepper to set how many pictures one design run may ask for. Going over stops further calls and says so, and the design still finishes |
 | Provider key | From the environment | See below |
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -244,7 +244,7 @@ Importing your own video files is not supported yet.
 | Variants per design | 3 | How many directions a new design starts with |
 | On revise | Replace what is visible | Or keep each revision separately |
 | Prompt recipes | Three built in | Named instruction templates applied on top of a request |
-| Media models | The provider's defaults | Search loaded models by name or endpoint for each kind of generation. Choices are grouped by model provider. You can enter an endpoint that is not listed. Use the info icon beside a label to see where that model is used |
+| Media models | The provider's defaults | Search loaded models by name or endpoint for each kind of generation. Choices are grouped by model provider and show the endpoint below the readable name. You can enter an endpoint that is not listed. Use the info icon beside a label to see where that model is used |
 | Media calls per run | 4 | Use the stepper buttons or enter a number to set how many pictures one design run may ask for. Going over stops further calls and says so, and the design still finishes |
 | Provider key | From the environment | See below |
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -244,11 +244,11 @@ Importing your own video files is not supported yet.
 | Variants per design | 3 | How many directions a new design starts with |
 | On revise | Replace what is visible | Or keep each revision separately |
 | Prompt recipes | Three built in | Named instruction templates applied on top of a request |
-| Media models | The provider's defaults | One model per kind of generation: image, restyle, upscale, text-to-video and image-to-video |
-| Media calls per run | 4 | How many pictures one design run may ask for. The run is told the number, so it plans around it; going over stops further calls and says so, and the design still finishes |
+| Media models | The provider's defaults | Choose a live provider model for each kind of generation: image, restyle, upscale, text-to-video and image-to-video |
+| Media calls per run | 4 | Use the stepper to set how many pictures one design run may ask for. Going over stops further calls and says so, and the design still finishes |
 | Provider key | From the environment | See below |
 
-Leaving a model empty means "use whatever Sero is configured to use".
+For Librarian and Design models, clearing the choice uses Sero's configured model. For media models, choose **Provider default** to use the provider's default.
 
 ### The picture provider
 

--- a/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
@@ -10,7 +10,7 @@ This is a separate decision entry for options-page enhancement work. It does not
 
 The settings tool returns model choices by media capability. Each choice has an opaque ID and a display label.
 
-The active provider owns its API URL, authentication, pagination, category mapping, and response parsing. The UI does not read provider-specific data.
+The active provider owns its API URL, catalogue access, category mapping, and response parsing. The UI does not read provider-specific data.
 
 **Reason.** The current text fields make people find and type endpoint IDs. A provider-neutral contract lets the UI use live choices without coupling it to fal.ai.
 
@@ -18,9 +18,9 @@ The active provider owns its API URL, authentication, pagination, category mappi
 
 ## E2 · Media model choices use the shared Combobox
 
-Each media capability uses the single-choice `Combobox` from `@sero-ai/ui`. The menu is searchable, groups models by provider, and limits the initial visible matches so opening a long catalogue stays responsive.
+Each media capability uses the single-choice `Combobox` from `@sero-ai/ui`. The menu is searchable and groups models by provider.
 
-The list includes the provider default and the current saved value. The current value stays available if it is absent from the latest provider response.
+The list includes the provider default and the current saved value. The current value stays available if it is absent from the latest provider response. A user can also enter a model endpoint that is not in the working set.
 
 **Reason.** Model selection is a fixed choice from live provider data. A long Select is slow to open and hard to scan. Search and provider groups make the same catalogue practical.
 
@@ -43,3 +43,17 @@ Each media-model label has an info icon. Its tooltip explains where that capabil
 **Reason.** The short labels keep the page easy to scan, but terms such as **Remix** and **Animate** do not explain their input and output. A tooltip gives this detail only when it is needed.
 
 **Consequence.** Each icon supports pointer hover and keyboard focus and has an accessible name.
+
+## E6 · Catalogue discovery is bounded and cached
+
+The fal.ai adapter reads one anonymous working set of active models and classifies it by capability. It caches a successful result across Settings visits. Retry asks the adapter to refresh the cache.
+
+**Reason.** Crawling every page for several categories exceeds the public endpoint's rate limit. The model-discovery endpoint does not need the generation key. One bounded request avoids request bursts and prevents a stale key from blocking discovery.
+
+**Consequence.** Settings shows the provider error and a Retry action when discovery fails. Manual endpoint entry and saved choices stay available.
+
+## E7 · The shared stepper has accessible value entry
+
+The stepper is an accessible named group. **Media calls per run** also provides direct numeric entry inside the group.
+
+**Reason.** Increment and decrement buttons are useful for small changes. Direct entry prevents many clicks across the 0–20 range.

--- a/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
@@ -1,0 +1,37 @@
+# Design Library options-page enhancement decisions
+
+**Status:** Accepted
+**Date:** 2026-07-30
+**Scope:** Model choices, settings help text, and media-call control
+
+This is a separate decision entry for options-page enhancement work. It does not reopen the first-release decisions.
+
+## E1 · Model choices use a provider-neutral catalogue
+
+The settings tool returns model choices by media capability. Each choice has an opaque ID and a display label.
+
+The active provider owns its API URL, authentication, pagination, category mapping, and response parsing. The UI does not read provider-specific data.
+
+**Reason.** The current text fields make people find and type endpoint IDs. A provider-neutral contract lets the UI use live choices without coupling it to fal.ai.
+
+**Consequence.** The first adapter reads active models from the fal.ai Model Search API. A later provider can implement the same catalogue contract without changing the settings page.
+
+## E2 · Media model choices use the shared Select
+
+Each media capability uses `Select` from `@sero-ai/ui`.
+
+The list includes the provider default and the current saved value. The current value stays available if it is absent from the latest provider response.
+
+**Reason.** Model selection is a fixed choice from live provider data. Free text is error-prone and does not match Sero controls.
+
+## E3 · Count settings share one stepper
+
+The Create Design variant count and **Media calls per run** use one local `CountStepper` component.
+
+**Reason.** Both controls change a bounded integer. One control keeps keyboard, disabled, icon, and boundary behaviour consistent.
+
+## E4 · Remove redundant model help text
+
+The options page removes the help lines under Librarian model, Design model, and Media models.
+
+**Reason.** The labels and control values explain these settings. The extra text adds visual noise.

--- a/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
@@ -35,3 +35,11 @@ The Create Design variant count and **Media calls per run** use one local `Count
 The options page removes the help lines under Librarian model, Design model, and Media models.
 
 **Reason.** The labels and control values explain these settings. The extra text adds visual noise.
+
+## E5 · Capability help stays behind an info tooltip
+
+Each media-model label has an info icon. Its tooltip explains where that capability is used.
+
+**Reason.** The short labels keep the page easy to scan, but terms such as **Remix** and **Animate** do not explain their input and output. A tooltip gives this detail only when it is needed.
+
+**Consequence.** Each icon supports pointer hover and keyboard focus and has an accessible name.

--- a/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
@@ -16,13 +16,13 @@ The active provider owns its API URL, authentication, pagination, category mappi
 
 **Consequence.** The first adapter reads active models from the fal.ai Model Search API. A later provider can implement the same catalogue contract without changing the settings page.
 
-## E2 · Media model choices use the shared Select
+## E2 · Media model choices use the shared Combobox
 
-Each media capability uses `Select` from `@sero-ai/ui`.
+Each media capability uses the single-choice `Combobox` from `@sero-ai/ui`. The menu is searchable, groups models by provider, and limits the initial visible matches so opening a long catalogue stays responsive.
 
 The list includes the provider default and the current saved value. The current value stays available if it is absent from the latest provider response.
 
-**Reason.** Model selection is a fixed choice from live provider data. Free text is error-prone and does not match Sero controls.
+**Reason.** Model selection is a fixed choice from live provider data. A long Select is slow to open and hard to scan. Search and provider groups make the same catalogue practical.
 
 ## E3 · Count settings share one stepper
 

--- a/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
+++ b/docs/decisions/sero-design-library-options-page-enhancement-decisions.md
@@ -22,6 +22,8 @@ Each media capability uses the single-choice `Combobox` from `@sero-ai/ui`. The 
 
 The list includes the provider default and the current saved value. The current value stays available if it is absent from the latest provider response. A user can also enter a model endpoint that is not in the working set.
 
+Catalogue options show the readable model name on the first line and the endpoint ID in smaller text on the second line.
+
 **Reason.** Model selection is a fixed choice from live provider data. A long Select is slow to open and hard to scan. Search and provider groups make the same catalogue practical.
 
 ## E3 · Count settings share one stepper

--- a/docs/plans/sero-design-library-options-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-options-page-enhancements-plan.md
@@ -1,0 +1,31 @@
+# Design Library options-page enhancements plan
+
+**Status:** Complete
+**Branch:** `fix/design-library-options-page`
+**Scope:** Model choices, settings help text, and media-call control
+**Decision entry:** `docs/decisions/sero-design-library-options-page-enhancement-decisions.md`
+
+## 1. Goal
+
+Make the Design Library options page simpler and safer to use.
+
+## 2. Changes
+
+1. Remove the marked help text from the model settings.
+2. Add a provider-neutral media-model catalogue contract.
+3. Read active model choices from the fal.ai Model Search API.
+4. Replace media-model text fields with the shared Select.
+5. Extract the Create Design count stepper.
+6. Use the shared stepper for Media calls per run.
+7. Update the product specification and user documentation.
+
+## 3. Verification
+
+1. Test catalogue pagination, authentication, and capability mapping.
+2. Test media-model selection and fallback choices.
+3. Test the media-call stepper boundaries and settings action.
+4. Run the Design Library plugin tests.
+5. Run the Design Library plugin typecheck and build.
+6. Run React Doctor.
+7. Check every touched source file is below 500 lines.
+8. Run root `pnpm typecheck` before commit.

--- a/docs/plans/sero-design-library-options-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-options-page-enhancements-plan.md
@@ -17,12 +17,13 @@ Make the Design Library options page simpler and safer to use.
 4. Replace media-model text fields with the shared searchable, grouped, single-choice Combobox.
 5. Extract the Create Design count stepper.
 6. Use the shared stepper for Media calls per run.
-7. Update the product specification and user documentation.
+7. Add an accessible usage tooltip beside each media-model label.
+8. Update the product specification and user documentation.
 
 ## 3. Verification
 
 1. Test catalogue pagination, authentication, and capability mapping.
-2. Test media-model search, provider groups, selection, and fallback choices.
+2. Test media-model search, provider groups, selection, fallback choices, and usage tooltips.
 3. Test the media-call stepper boundaries and settings action.
 4. Run the Design Library plugin tests.
 5. Run the Design Library plugin typecheck and build.

--- a/docs/plans/sero-design-library-options-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-options-page-enhancements-plan.md
@@ -18,13 +18,17 @@ Make the Design Library options page simpler and safer to use.
 5. Extract the Create Design count stepper.
 6. Use the shared stepper for Media calls per run.
 7. Add an accessible usage tooltip beside each media-model label.
-8. Update the product specification and user documentation.
+8. Bound fal.ai discovery to one anonymous request and cache successful results.
+9. Keep saved and manual endpoint choices available when discovery fails.
+10. Show catalogue errors with Retry and remove the grouped-list display cap.
+11. Give the shared stepper an accessible group and direct entry for media calls.
+12. Update the product specification and user documentation.
 
 ## 3. Verification
 
-1. Test catalogue pagination, authentication, and capability mapping.
-2. Test media-model search, provider groups, selection, fallback choices, and usage tooltips.
-3. Test the media-call stepper boundaries and settings action.
+1. Test the anonymous catalogue request, capability mapping, cache, refresh, and failure fallback.
+2. Test media-model search, all provider groups, manual entry, Retry, fallback choices, and usage tooltips.
+3. Test the media-call stepper boundaries, direct entry, accessibility, and settings action.
 4. Run the Design Library plugin tests.
 5. Run the Design Library plugin typecheck and build.
 6. Run React Doctor.

--- a/docs/plans/sero-design-library-options-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-options-page-enhancements-plan.md
@@ -14,7 +14,7 @@ Make the Design Library options page simpler and safer to use.
 1. Remove the marked help text from the model settings.
 2. Add a provider-neutral media-model catalogue contract.
 3. Read active model choices from the fal.ai Model Search API.
-4. Replace media-model text fields with the shared Select.
+4. Replace media-model text fields with the shared searchable, grouped, single-choice Combobox.
 5. Extract the Create Design count stepper.
 6. Use the shared stepper for Media calls per run.
 7. Update the product specification and user documentation.
@@ -22,7 +22,7 @@ Make the Design Library options page simpler and safer to use.
 ## 3. Verification
 
 1. Test catalogue pagination, authentication, and capability mapping.
-2. Test media-model selection and fallback choices.
+2. Test media-model search, provider groups, selection, and fallback choices.
 3. Test the media-call stepper boundaries and settings action.
 4. Run the Design Library plugin tests.
 5. Run the Design Library plugin typecheck and build.

--- a/docs/plans/sero-design-library-options-page-enhancements-plan.md
+++ b/docs/plans/sero-design-library-options-page-enhancements-plan.md
@@ -22,7 +22,8 @@ Make the Design Library options page simpler and safer to use.
 9. Keep saved and manual endpoint choices available when discovery fails.
 10. Show catalogue errors with Retry and remove the grouped-list display cap.
 11. Give the shared stepper an accessible group and direct entry for media calls.
-12. Update the product specification and user documentation.
+12. Split catalogue options into a readable name and a smaller endpoint line.
+13. Update the product specification and user documentation.
 
 ## 3. Verification
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -493,6 +493,7 @@ All settings persist to plugin state.
 
 - Active provider and its credential status (`env | stored | missing`).
 - One shared, single-choice Sero Combobox per capability. Choices come from a provider-neutral catalogue backed by the active provider's API. The menu is searchable, groups choices by model provider, and limits initial visible matches. The empty choice uses the provider default.
+- An accessible info tooltip beside each capability label explains where that model is used.
 - Maximum media calls per generation run, set with the same bounded stepper as Create Design variants.
 - Video confirmation (on by default).
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -492,9 +492,10 @@ All settings persist to plugin state.
 **Media**
 
 - Active provider and its credential status (`env | stored | missing`).
-- One shared, single-choice Sero Combobox per capability. Choices come from a provider-neutral catalogue backed by the active provider's API. The menu is searchable, groups choices by model provider, and limits initial visible matches. The empty choice uses the provider default.
+- One shared, single-choice Sero Combobox per capability. Choices come from a cached, provider-neutral working set backed by the active provider's API. The menu is searchable and groups all loaded choices by model provider. A user can enter an endpoint that is not listed. The empty choice uses the provider default.
+- Catalogue failure keeps saved and manual choices available, shows the provider error, and offers Retry.
 - An accessible info tooltip beside each capability label explains where that model is used.
-- Maximum media calls per generation run, set with the same bounded stepper as Create Design variants.
+- Maximum media calls per generation run, set with the same bounded stepper as Create Design variants. The stepper is an accessible named group and supports direct numeric entry for this range.
 - Video confirmation (on by default).
 
 **Layout** (persisted, not user-editable in a settings form)

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -492,7 +492,7 @@ All settings persist to plugin state.
 **Media**
 
 - Active provider and its credential status (`env | stored | missing`).
-- One shared, single-choice Sero Combobox per capability. Choices come from a cached, provider-neutral working set backed by the active provider's API. The menu is searchable and groups all loaded choices by model provider. A user can enter an endpoint that is not listed. The empty choice uses the provider default.
+- One shared, single-choice Sero Combobox per capability. Choices come from a cached, provider-neutral working set backed by the active provider's API. The menu is searchable and groups all loaded choices by model provider. Each catalogue option shows the readable name above a smaller endpoint ID. A user can enter an endpoint that is not listed. The empty choice uses the provider default.
 - Catalogue failure keeps saved and manual choices available, shows the provider error, and offers Retry.
 - An accessible info tooltip beside each capability label explains where that model is used.
 - Maximum media calls per generation run, set with the same bounded stepper as Create Design variants. The stepper is an accessible named group and supports direct numeric entry for this range.

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -492,7 +492,7 @@ All settings persist to plugin state.
 **Media**
 
 - Active provider and its credential status (`env | stored | missing`).
-- One shared Sero Select per capability. Choices come from a provider-neutral catalogue backed by the active provider's API. The empty choice uses the provider default.
+- One shared, single-choice Sero Combobox per capability. Choices come from a provider-neutral catalogue backed by the active provider's API. The menu is searchable, groups choices by model provider, and limits initial visible matches. The empty choice uses the provider default.
 - Maximum media calls per generation run, set with the same bounded stepper as Create Design variants.
 - Video confirmation (on by default).
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -487,12 +487,13 @@ All settings persist to plugin state.
 
 - **Librarian model** — used for analysis. `AvailableModelPicker` fed by `useAvailableModels()`, empty meaning "use Sero's configured model".
 - **Design model** — used for generation, revision and tweak authoring. Same control and default.
+- The model controls do not add help text below their labels.
 
 **Media**
 
 - Active provider and its credential status (`env | stored | missing`).
-- One editable model id per capability, pre-filled with a sensible default.
-- Maximum media calls per generation run.
+- One shared Sero Select per capability. Choices come from a provider-neutral catalogue backed by the active provider's API. The empty choice uses the provider default.
+- Maximum media calls per generation run, set with the same bounded stepper as Create Design variants.
 - Video confirmation (on by default).
 
 **Layout** (persisted, not user-editable in a settings form)

--- a/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.test.ts
+++ b/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.test.ts
@@ -2,81 +2,96 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { createFalMediaModelCatalog } from './fal-media-model-catalog';
 
-function response(body: unknown): Response {
+function response(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
-    status: 200,
+    status,
     headers: { 'Content-Type': 'application/json' },
   });
 }
 
 describe('fal media model catalogue', () => {
-  it('maps provider data to capability choices and shares duplicate queries', async () => {
-    const fetch = vi.fn(async (input: Parameters<typeof globalThis.fetch>[0]) => {
-      const url = new URL(String(input));
-      const category = url.searchParams.get('category');
-      return response({
-        models: [
-          {
-            endpoint_id: `model/${category}`,
-            metadata: { display_name: `Model ${category}` },
-          },
-        ],
-        has_more: false,
-        next_cursor: null,
-      });
-    });
-    const catalog = createFalMediaModelCatalog({
-      credentials: async () => undefined,
-      fetch: fetch as typeof globalThis.fetch,
-    });
+  it('maps one anonymous working set to provider-neutral capability choices', async () => {
+    const fetch = vi.fn(
+      async (
+        _input: Parameters<typeof globalThis.fetch>[0],
+        _init?: Parameters<typeof globalThis.fetch>[1],
+      ) =>
+        response({
+          models: [
+            {
+              endpoint_id: 'fal-ai/flux/dev',
+              metadata: { display_name: 'FLUX Dev', category: 'text-to-image' },
+            },
+            {
+              endpoint_id: 'partner/editor',
+              metadata: { display_name: 'Editor', category: 'image-to-image' },
+            },
+            {
+              endpoint_id: 'partner/upscaler',
+              metadata: { display_name: 'Photo Upscale', category: 'image-to-image' },
+            },
+            {
+              endpoint_id: 'partner/video',
+              metadata: { display_name: 'Video', category: 'text-to-video' },
+            },
+            {
+              endpoint_id: 'partner/animate',
+              metadata: { display_name: 'Animate', category: 'image-to-video' },
+            },
+          ],
+        }),
+    );
+    const catalog = createFalMediaModelCatalog({ fetch: fetch as typeof globalThis.fetch });
 
     const models = await catalog.list();
 
     expect(models['text-to-image'][0]).toEqual({
-      id: 'model/text-to-image',
-      label: 'Model text-to-image · model/text-to-image',
-      provider: 'model',
+      id: 'fal-ai/flux/dev',
+      label: 'FLUX Dev · fal-ai/flux/dev',
+      provider: 'fal-ai',
     });
     expect(models['reference-to-image']).toEqual(models['image-to-image']);
-    expect(fetch).toHaveBeenCalledTimes(5);
-    const upscaleUrl = fetch.mock.calls
-      .map(([input]) => new URL(String(input)))
-      .find((url) => url.searchParams.get('q') === 'upscale');
-    expect(upscaleUrl?.searchParams.get('category')).toBe('image-to-image');
+    expect(models.upscale.map((model) => model.id)).toEqual(['partner/upscaler']);
+    expect(models['text-to-video'][0]?.id).toBe('partner/video');
+    expect(models['image-to-video'][0]?.id).toBe('partner/animate');
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const [input, init] = fetch.mock.calls[0] ?? [];
+    const url = new URL(String(input));
+    expect(url.searchParams.get('limit')).toBe('100');
+    expect(url.searchParams.get('status')).toBe('active');
+    expect(init?.headers).toBeUndefined();
   });
 
-  it('reads every page and sends the key only in the provider adapter', async () => {
-    const fetch = vi.fn(
-      async (
-        input: Parameters<typeof globalThis.fetch>[0],
-        init?: Parameters<typeof globalThis.fetch>[1],
-      ) => {
-        const url = new URL(String(input));
-        const cursor = url.searchParams.get('cursor');
-        if (url.searchParams.get('category') !== 'text-to-image') {
-          return response({ models: [], has_more: false, next_cursor: null });
-        }
-        return cursor === null
-          ? response({
-              models: [{ endpoint_id: 'model/b', metadata: { display_name: 'B' } }],
-              has_more: true,
-              next_cursor: 'page-2',
-            })
-          : response({
-              models: [{ endpoint_id: 'model/a', metadata: { display_name: 'A' } }],
-              has_more: false,
-              next_cursor: null,
-            });
-      },
-    );
-    const catalog = createFalMediaModelCatalog({
-      credentials: async () => 'secret',
-      fetch: fetch as typeof globalThis.fetch,
-    });
+  it('caches successful results until an explicit refresh', async () => {
+    const fetch = vi.fn(async () => response({ models: [] }));
+    const catalog = createFalMediaModelCatalog({ fetch: fetch as typeof globalThis.fetch });
 
-    const models = await catalog.list();
+    await catalog.list();
+    await catalog.list();
+    await catalog.list({ refresh: true });
 
-    expect(models['text-to-image'].map((model) => model.id)).toEqual(['model/a', 'model/b']);
-    expect(fetch.mock.calls[0]?.[1]?.headers).toEqual({ Authorization: 'Key secret' });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the cached result when a refresh fails', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          models: [
+            {
+              endpoint_id: 'provider/model',
+              metadata: { display_name: 'Model', category: 'text-to-image' },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(response({}, 429));
+    const catalog = createFalMediaModelCatalog({ fetch: fetch as typeof globalThis.fetch });
+
+    const cached = await catalog.list();
+    await expect(catalog.list({ refresh: true })).rejects.toThrow('returned 429');
+    expect(await catalog.list()).toEqual(cached);
   });
 });

--- a/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.test.ts
+++ b/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.test.ts
@@ -35,6 +35,7 @@ describe('fal media model catalogue', () => {
     expect(models['text-to-image'][0]).toEqual({
       id: 'model/text-to-image',
       label: 'Model text-to-image · model/text-to-image',
+      provider: 'model',
     });
     expect(models['reference-to-image']).toEqual(models['image-to-image']);
     expect(fetch).toHaveBeenCalledTimes(5);

--- a/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.test.ts
+++ b/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createFalMediaModelCatalog } from './fal-media-model-catalog';
+
+function response(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('fal media model catalogue', () => {
+  it('maps provider data to capability choices and shares duplicate queries', async () => {
+    const fetch = vi.fn(async (input: Parameters<typeof globalThis.fetch>[0]) => {
+      const url = new URL(String(input));
+      const category = url.searchParams.get('category');
+      return response({
+        models: [
+          {
+            endpoint_id: `model/${category}`,
+            metadata: { display_name: `Model ${category}` },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      });
+    });
+    const catalog = createFalMediaModelCatalog({
+      credentials: async () => undefined,
+      fetch: fetch as typeof globalThis.fetch,
+    });
+
+    const models = await catalog.list();
+
+    expect(models['text-to-image'][0]).toEqual({
+      id: 'model/text-to-image',
+      label: 'Model text-to-image · model/text-to-image',
+    });
+    expect(models['reference-to-image']).toEqual(models['image-to-image']);
+    expect(fetch).toHaveBeenCalledTimes(5);
+    const upscaleUrl = fetch.mock.calls
+      .map(([input]) => new URL(String(input)))
+      .find((url) => url.searchParams.get('q') === 'upscale');
+    expect(upscaleUrl?.searchParams.get('category')).toBe('image-to-image');
+  });
+
+  it('reads every page and sends the key only in the provider adapter', async () => {
+    const fetch = vi.fn(
+      async (
+        input: Parameters<typeof globalThis.fetch>[0],
+        init?: Parameters<typeof globalThis.fetch>[1],
+      ) => {
+        const url = new URL(String(input));
+        const cursor = url.searchParams.get('cursor');
+        if (url.searchParams.get('category') !== 'text-to-image') {
+          return response({ models: [], has_more: false, next_cursor: null });
+        }
+        return cursor === null
+          ? response({
+              models: [{ endpoint_id: 'model/b', metadata: { display_name: 'B' } }],
+              has_more: true,
+              next_cursor: 'page-2',
+            })
+          : response({
+              models: [{ endpoint_id: 'model/a', metadata: { display_name: 'A' } }],
+              has_more: false,
+              next_cursor: null,
+            });
+      },
+    );
+    const catalog = createFalMediaModelCatalog({
+      credentials: async () => 'secret',
+      fetch: fetch as typeof globalThis.fetch,
+    });
+
+    const models = await catalog.list();
+
+    expect(models['text-to-image'].map((model) => model.id)).toEqual(['model/a', 'model/b']);
+    expect(fetch.mock.calls[0]?.[1]?.headers).toEqual({ Authorization: 'Key secret' });
+  });
+});

--- a/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.ts
+++ b/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.ts
@@ -3,6 +3,7 @@ import type {
   MediaModelChoice,
   MediaModelChoices,
 } from '../shared/media-model-catalog';
+import type { MediaCapability } from '../shared/media';
 
 const FAL_MODELS_URL = 'https://api.fal.ai/v1/models';
 const PAGE_SIZE = 100;
@@ -10,149 +11,133 @@ const PAGE_SIZE = 100;
 interface FalModel {
   endpoint_id?: unknown;
   metadata?: {
+    category?: unknown;
     display_name?: unknown;
   };
 }
 
 interface FalModelPage {
   models?: unknown;
-  has_more?: unknown;
-  next_cursor?: unknown;
 }
-
-interface FalQuery {
-  category: string;
-  query?: string;
-}
-
-const CAPABILITY_QUERIES = {
-  'text-to-image': { category: 'text-to-image' },
-  'reference-to-image': { category: 'image-to-image' },
-  'image-to-image': { category: 'image-to-image' },
-  upscale: { category: 'image-to-image', query: 'upscale' },
-  'text-to-video': { category: 'text-to-video' },
-  'image-to-video': { category: 'image-to-video' },
-} satisfies Record<keyof MediaModelChoices, FalQuery>;
 
 export interface FalMediaModelCatalogOptions {
-  credentials(): Promise<string | undefined>;
   fetch?: typeof globalThis.fetch;
 }
 
-function modelChoice(value: unknown): MediaModelChoice | null {
-  if (typeof value !== 'object' || value === null) return null;
-  const model = value as FalModel;
-  if (typeof model.endpoint_id !== 'string' || model.endpoint_id === '') return null;
-  const displayName = model.metadata?.display_name;
+function emptyChoices(): MediaModelChoices {
   return {
-    id: model.endpoint_id,
-    label:
-      typeof displayName === 'string' && displayName !== ''
-        ? `${displayName} · ${model.endpoint_id}`
-        : model.endpoint_id,
-    provider: model.endpoint_id.split('/')[0] ?? 'Other',
+    'text-to-image': [],
+    'reference-to-image': [],
+    'image-to-image': [],
+    upscale: [],
+    'text-to-video': [],
+    'image-to-video': [],
   };
 }
 
-function queryKey(query: FalQuery): string {
-  return `${query.category}:${query.query ?? ''}`;
+function modelChoice(value: unknown): { category: string; choice: MediaModelChoice } | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const model = value as FalModel;
+  if (
+    typeof model.endpoint_id !== 'string' ||
+    model.endpoint_id === '' ||
+    typeof model.metadata?.category !== 'string'
+  ) {
+    return null;
+  }
+  const displayName = model.metadata.display_name;
+  return {
+    category: model.metadata.category,
+    choice: {
+      id: model.endpoint_id,
+      label:
+        typeof displayName === 'string' && displayName !== ''
+          ? `${displayName} · ${model.endpoint_id}`
+          : model.endpoint_id,
+      provider: model.endpoint_id.split('/')[0] ?? 'Other',
+    },
+  };
 }
 
-async function readQuery(
-  query: FalQuery,
-  credentials: string | undefined,
+function addChoice(
+  choices: MediaModelChoices,
+  capability: MediaCapability,
+  choice: MediaModelChoice,
+): void {
+  choices[capability].push(choice);
+}
+
+function classifyModels(models: unknown[]): MediaModelChoices {
+  const choices = emptyChoices();
+  for (const value of models) {
+    const model = modelChoice(value);
+    if (model === null) continue;
+
+    switch (model.category) {
+      case 'text-to-image':
+        addChoice(choices, 'text-to-image', model.choice);
+        break;
+      case 'image-to-image':
+        addChoice(choices, 'reference-to-image', model.choice);
+        addChoice(choices, 'image-to-image', model.choice);
+        if (/upscal/i.test(`${model.choice.label} ${model.choice.id}`)) {
+          addChoice(choices, 'upscale', model.choice);
+        }
+        break;
+      case 'text-to-video':
+        addChoice(choices, 'text-to-video', model.choice);
+        break;
+      case 'image-to-video':
+        addChoice(choices, 'image-to-video', model.choice);
+        break;
+    }
+  }
+
+  for (const capability of Object.keys(choices) as MediaCapability[]) {
+    choices[capability].sort((left, right) => left.label.localeCompare(right.label));
+  }
+  return choices;
+}
+
+async function readCatalogue(
   transport: typeof globalThis.fetch,
   signal?: AbortSignal,
-): Promise<MediaModelChoice[]> {
-  const choices: MediaModelChoice[] = [];
-  const seenCursors = new Set<string>();
-  let cursor: string | undefined;
+): Promise<MediaModelChoices> {
+  const url = new URL(FAL_MODELS_URL);
+  url.searchParams.set('status', 'active');
+  url.searchParams.set('limit', String(PAGE_SIZE));
 
-  do {
-    const url = new URL(FAL_MODELS_URL);
-    url.searchParams.set('category', query.category);
-    url.searchParams.set('status', 'active');
-    url.searchParams.set('limit', String(PAGE_SIZE));
-    if (query.query !== undefined) url.searchParams.set('q', query.query);
-    if (cursor !== undefined) url.searchParams.set('cursor', cursor);
+  const response = await transport(url, { signal });
+  if (!response.ok) {
+    throw new Error(`The media provider model catalogue returned ${response.status}.`);
+  }
 
-    const response = await transport(url, {
-      signal,
-      headers: credentials === undefined ? undefined : { Authorization: `Key ${credentials}` },
-    });
-    if (!response.ok) {
-      throw new Error(`The media provider model catalogue returned ${response.status}.`);
-    }
-
-    const page = (await response.json()) as FalModelPage;
-    if (!Array.isArray(page.models)) {
-      throw new Error('The media provider model catalogue returned an invalid model list.');
-    }
-    choices.push(
-      ...page.models.flatMap((entry) => {
-        const choice = modelChoice(entry);
-        return choice === null ? [] : [choice];
-      }),
-    );
-
-    const next = typeof page.next_cursor === 'string' ? page.next_cursor : undefined;
-    if (page.has_more !== true || next === undefined) break;
-    if (seenCursors.has(next)) {
-      throw new Error('The media provider model catalogue repeated a page cursor.');
-    }
-    seenCursors.add(next);
-    cursor = next;
-  } while (true);
-
-  const unique = new Map(choices.map((choice) => [choice.id, choice]));
-  return [...unique.values()].sort((left, right) => left.label.localeCompare(right.label));
+  const page = (await response.json()) as FalModelPage;
+  if (!Array.isArray(page.models)) {
+    throw new Error('The media provider model catalogue returned an invalid model list.');
+  }
+  return classifyModels(page.models);
 }
 
 /**
  * fal.ai implementation of the provider-neutral settings catalogue.
  *
- * Duplicate capability queries share one request. Reference image and remix,
- * for example, both use the provider's image-to-image category.
+ * One anonymous request reads a useful working set. The adapter caches it
+ * across Settings visits. Users can still enter an endpoint that is not in the
+ * working set, so discovery does not need to crawl every provider page.
  */
 export function createFalMediaModelCatalog(
-  options: FalMediaModelCatalogOptions,
+  options: FalMediaModelCatalogOptions = {},
 ): MediaModelCatalog {
   const transport = options.fetch ?? globalThis.fetch;
+  let cached: MediaModelChoices | undefined;
 
   return {
-    async list(signal) {
-      const credentials = await options.credentials();
-      const pending = new Map<string, Promise<MediaModelChoice[]>>();
-      const read = (query: FalQuery) => {
-        const key = queryKey(query);
-        const current = pending.get(key);
-        if (current !== undefined) return current;
-        const request = readQuery(query, credentials, transport, signal);
-        pending.set(key, request);
-        return request;
-      };
-
-      const textToImage = read(CAPABILITY_QUERIES['text-to-image']);
-      const imageToImage = read(CAPABILITY_QUERIES['image-to-image']);
-      const upscale = read(CAPABILITY_QUERIES.upscale);
-      const textToVideo = read(CAPABILITY_QUERIES['text-to-video']);
-      const imageToVideo = read(CAPABILITY_QUERIES['image-to-video']);
-      const [
-        textToImageChoices,
-        imageToImageChoices,
-        upscaleChoices,
-        textToVideoChoices,
-        imageToVideoChoices,
-      ] = await Promise.all([textToImage, imageToImage, upscale, textToVideo, imageToVideo]);
-
-      return {
-        'text-to-image': textToImageChoices,
-        'reference-to-image': imageToImageChoices,
-        'image-to-image': imageToImageChoices,
-        upscale: upscaleChoices,
-        'text-to-video': textToVideoChoices,
-        'image-to-video': imageToVideoChoices,
-      };
+    async list({ refresh = false, signal } = {}) {
+      if (!refresh && cached !== undefined) return cached;
+      const choices = await readCatalogue(transport, signal);
+      cached = choices;
+      return choices;
     },
   };
 }

--- a/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.ts
+++ b/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.ts
@@ -1,0 +1,157 @@
+import type {
+  MediaModelCatalog,
+  MediaModelChoice,
+  MediaModelChoices,
+} from '../shared/media-model-catalog';
+
+const FAL_MODELS_URL = 'https://api.fal.ai/v1/models';
+const PAGE_SIZE = 100;
+
+interface FalModel {
+  endpoint_id?: unknown;
+  metadata?: {
+    display_name?: unknown;
+  };
+}
+
+interface FalModelPage {
+  models?: unknown;
+  has_more?: unknown;
+  next_cursor?: unknown;
+}
+
+interface FalQuery {
+  category: string;
+  query?: string;
+}
+
+const CAPABILITY_QUERIES = {
+  'text-to-image': { category: 'text-to-image' },
+  'reference-to-image': { category: 'image-to-image' },
+  'image-to-image': { category: 'image-to-image' },
+  upscale: { category: 'image-to-image', query: 'upscale' },
+  'text-to-video': { category: 'text-to-video' },
+  'image-to-video': { category: 'image-to-video' },
+} satisfies Record<keyof MediaModelChoices, FalQuery>;
+
+export interface FalMediaModelCatalogOptions {
+  credentials(): Promise<string | undefined>;
+  fetch?: typeof globalThis.fetch;
+}
+
+function modelChoice(value: unknown): MediaModelChoice | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const model = value as FalModel;
+  if (typeof model.endpoint_id !== 'string' || model.endpoint_id === '') return null;
+  const displayName = model.metadata?.display_name;
+  return {
+    id: model.endpoint_id,
+    label:
+      typeof displayName === 'string' && displayName !== ''
+        ? `${displayName} · ${model.endpoint_id}`
+        : model.endpoint_id,
+  };
+}
+
+function queryKey(query: FalQuery): string {
+  return `${query.category}:${query.query ?? ''}`;
+}
+
+async function readQuery(
+  query: FalQuery,
+  credentials: string | undefined,
+  transport: typeof globalThis.fetch,
+  signal?: AbortSignal,
+): Promise<MediaModelChoice[]> {
+  const choices: MediaModelChoice[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+
+  do {
+    const url = new URL(FAL_MODELS_URL);
+    url.searchParams.set('category', query.category);
+    url.searchParams.set('status', 'active');
+    url.searchParams.set('limit', String(PAGE_SIZE));
+    if (query.query !== undefined) url.searchParams.set('q', query.query);
+    if (cursor !== undefined) url.searchParams.set('cursor', cursor);
+
+    const response = await transport(url, {
+      signal,
+      headers: credentials === undefined ? undefined : { Authorization: `Key ${credentials}` },
+    });
+    if (!response.ok) {
+      throw new Error(`The media provider model catalogue returned ${response.status}.`);
+    }
+
+    const page = (await response.json()) as FalModelPage;
+    if (!Array.isArray(page.models)) {
+      throw new Error('The media provider model catalogue returned an invalid model list.');
+    }
+    choices.push(
+      ...page.models.flatMap((entry) => {
+        const choice = modelChoice(entry);
+        return choice === null ? [] : [choice];
+      }),
+    );
+
+    const next = typeof page.next_cursor === 'string' ? page.next_cursor : undefined;
+    if (page.has_more !== true || next === undefined) break;
+    if (seenCursors.has(next)) {
+      throw new Error('The media provider model catalogue repeated a page cursor.');
+    }
+    seenCursors.add(next);
+    cursor = next;
+  } while (true);
+
+  const unique = new Map(choices.map((choice) => [choice.id, choice]));
+  return [...unique.values()].sort((left, right) => left.label.localeCompare(right.label));
+}
+
+/**
+ * fal.ai implementation of the provider-neutral settings catalogue.
+ *
+ * Duplicate capability queries share one request. Reference image and remix,
+ * for example, both use the provider's image-to-image category.
+ */
+export function createFalMediaModelCatalog(
+  options: FalMediaModelCatalogOptions,
+): MediaModelCatalog {
+  const transport = options.fetch ?? globalThis.fetch;
+
+  return {
+    async list(signal) {
+      const credentials = await options.credentials();
+      const pending = new Map<string, Promise<MediaModelChoice[]>>();
+      const read = (query: FalQuery) => {
+        const key = queryKey(query);
+        const current = pending.get(key);
+        if (current !== undefined) return current;
+        const request = readQuery(query, credentials, transport, signal);
+        pending.set(key, request);
+        return request;
+      };
+
+      const textToImage = read(CAPABILITY_QUERIES['text-to-image']);
+      const imageToImage = read(CAPABILITY_QUERIES['image-to-image']);
+      const upscale = read(CAPABILITY_QUERIES.upscale);
+      const textToVideo = read(CAPABILITY_QUERIES['text-to-video']);
+      const imageToVideo = read(CAPABILITY_QUERIES['image-to-video']);
+      const [
+        textToImageChoices,
+        imageToImageChoices,
+        upscaleChoices,
+        textToVideoChoices,
+        imageToVideoChoices,
+      ] = await Promise.all([textToImage, imageToImage, upscale, textToVideo, imageToVideo]);
+
+      return {
+        'text-to-image': textToImageChoices,
+        'reference-to-image': imageToImageChoices,
+        'image-to-image': imageToImageChoices,
+        upscale: upscaleChoices,
+        'text-to-video': textToVideoChoices,
+        'image-to-video': imageToVideoChoices,
+      };
+    },
+  };
+}

--- a/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.ts
+++ b/plugins/sero-design-library-plugin/extension/fal-media-model-catalog.ts
@@ -50,6 +50,7 @@ function modelChoice(value: unknown): MediaModelChoice | null {
       typeof displayName === 'string' && displayName !== ''
         ? `${displayName} · ${model.endpoint_id}`
         : model.endpoint_id,
+    provider: model.endpoint_id.split('/')[0] ?? 'Other',
   };
 }
 

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -27,7 +27,7 @@ let tools: Map<string, ToolDefinition>;
 const mediaModelCatalog: MediaModelCatalog = {
   async list() {
     return {
-      'text-to-image': [{ id: 'image/model', label: 'Image model' }],
+      'text-to-image': [{ id: 'image/model', label: 'Image model', provider: 'image' }],
       'reference-to-image': [],
       'image-to-image': [],
       upscale: [],
@@ -123,7 +123,9 @@ describe('the provider key', () => {
 describe('media settings', () => {
   it('returns provider-neutral model choices', async () => {
     expect((await call({ action: 'list-media-models' })).details).toMatchObject({
-      models: { 'text-to-image': [{ id: 'image/model', label: 'Image model' }] },
+      models: {
+        'text-to-image': [{ id: 'image/model', label: 'Image model', provider: 'image' }],
+      },
     });
   });
 

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-agent';
 
+import type { MediaModelCatalog } from '../../shared/media-model-catalog';
 import { designLibraryPathsFromHome, secretsFile, type DesignLibraryPaths } from '../../shared/paths';
 import { readState } from '../../shared/state-io';
 import { registerSettingsTool } from './settings';
@@ -23,6 +24,18 @@ import { registerSettingsTool } from './settings';
 let home: string;
 let paths: DesignLibraryPaths;
 let tools: Map<string, ToolDefinition>;
+const mediaModelCatalog: MediaModelCatalog = {
+  async list() {
+    return {
+      'text-to-image': [{ id: 'image/model', label: 'Image model' }],
+      'reference-to-image': [],
+      'image-to-image': [],
+      upscale: [],
+      'text-to-video': [],
+      'image-to-video': [],
+    };
+  },
+};
 
 function collectTools(): ExtensionAPI {
   tools = new Map();
@@ -54,7 +67,7 @@ beforeEach(async () => {
   delete process.env.FAL_KEY;
   home = await mkdtemp(path.join(tmpdir(), 'design-library-settings-tool-'));
   paths = designLibraryPathsFromHome(path.join(home, 'apps', 'design-library'));
-  registerSettingsTool(collectTools(), paths);
+  registerSettingsTool(collectTools(), paths, mediaModelCatalog);
 });
 
 afterEach(async () => {
@@ -108,6 +121,12 @@ describe('the provider key', () => {
 });
 
 describe('media settings', () => {
+  it('returns provider-neutral model choices', async () => {
+    expect((await call({ action: 'list-media-models' })).details).toMatchObject({
+      models: { 'text-to-image': [{ id: 'image/model', label: 'Image model' }] },
+    });
+  });
+
   it('sets one capability’s model without disturbing the others', async () => {
     await call({ action: 'set-media-model', capability: 'text-to-video', mediaModel: 'fast-video' });
 

--- a/plugins/sero-design-library-plugin/extension/tools/settings.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.ts
@@ -4,13 +4,15 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
-import { clearFalKey, falKeyStatus, storeFalKey } from '../../shared/credentials';
+import { clearFalKey, falKeyStatus, resolveFalKey, storeFalKey } from '../../shared/credentials';
+import type { MediaModelCatalog } from '../../shared/media-model-catalog';
 import { MEDIA_CAPABILITIES, type MediaCapability } from '../../shared/media';
 import type { DesignLibraryPaths } from '../../shared/paths';
 import type { DesignLibrarySettings, PromptRecipe } from '../../shared/settings';
 import { MAX_CALLS_PER_RUN } from '../../shared/settings';
 import { appendRequest, readState } from '../../shared/state-io';
 import type { ViewPatch } from '../../shared/types';
+import { createFalMediaModelCatalog } from '../fal-media-model-catalog';
 import { failure, text, type ToolResult } from './result';
 
 /**
@@ -35,6 +37,7 @@ const ACTIONS = [
   'set-layout',
   'set-view',
   'set-media-model',
+  'list-media-models',
   'set-media-cap',
   'key-status',
   'store-key',
@@ -67,7 +70,13 @@ function renderSettings(settings: DesignLibrarySettings): ToolResult {
   return text(lines.join('\n'), { settings });
 }
 
-export function registerSettingsTool(pi: ExtensionAPI, paths: DesignLibraryPaths): void {
+export function registerSettingsTool(
+  pi: ExtensionAPI,
+  paths: DesignLibraryPaths,
+  mediaModelCatalog: MediaModelCatalog = createFalMediaModelCatalog({
+    credentials: () => resolveFalKey(paths),
+  }),
+): void {
   pi.registerTool({
     name: 'design_library_settings',
     label: 'Design Library Settings',
@@ -100,7 +109,7 @@ export function registerSettingsTool(pi: ExtensionAPI, paths: DesignLibraryPaths
       ),
       key: Type.Optional(Type.String({ description: 'Provider key, for `store-key`' })),
     }),
-    async execute(_toolCallId, params): Promise<ToolResult> {
+    async execute(_toolCallId, params, signal): Promise<ToolResult> {
       const state = await readState(paths);
       const settings = state.settings;
 
@@ -219,6 +228,11 @@ export function registerSettingsTool(pi: ExtensionAPI, paths: DesignLibraryPaths
               ? `${params.capability} now uses the adapter's default model.`
               : `${params.capability} now uses ${modelId}.`,
           );
+        }
+
+        case 'list-media-models': {
+          const models = await mediaModelCatalog.list(signal);
+          return text('Media models loaded.', { models });
         }
 
         case 'set-media-cap': {

--- a/plugins/sero-design-library-plugin/extension/tools/settings.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.ts
@@ -4,7 +4,7 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
-import { clearFalKey, falKeyStatus, resolveFalKey, storeFalKey } from '../../shared/credentials';
+import { clearFalKey, falKeyStatus, storeFalKey } from '../../shared/credentials';
 import type { MediaModelCatalog } from '../../shared/media-model-catalog';
 import { MEDIA_CAPABILITIES, type MediaCapability } from '../../shared/media';
 import type { DesignLibraryPaths } from '../../shared/paths';
@@ -73,9 +73,7 @@ function renderSettings(settings: DesignLibrarySettings): ToolResult {
 export function registerSettingsTool(
   pi: ExtensionAPI,
   paths: DesignLibraryPaths,
-  mediaModelCatalog: MediaModelCatalog = createFalMediaModelCatalog({
-    credentials: () => resolveFalKey(paths),
-  }),
+  mediaModelCatalog: MediaModelCatalog = createFalMediaModelCatalog(),
 ): void {
   pi.registerTool({
     name: 'design_library_settings',
@@ -106,6 +104,9 @@ export function registerSettingsTool(
       ),
       callsPerRun: Type.Optional(
         Type.Number({ description: `Media calls one generation run may make, 0–${MAX_CALLS_PER_RUN}` }),
+      ),
+      refresh: Type.Optional(
+        Type.Boolean({ description: 'Refresh the cached media-model catalogue' }),
       ),
       key: Type.Optional(Type.String({ description: 'Provider key, for `store-key`' })),
     }),
@@ -231,7 +232,7 @@ export function registerSettingsTool(
         }
 
         case 'list-media-models': {
-          const models = await mediaModelCatalog.list(signal);
+          const models = await mediaModelCatalog.list({ refresh: params.refresh, signal });
           return text('Media models loaded.', { models });
         }
 

--- a/plugins/sero-design-library-plugin/shared/media-model-catalog.ts
+++ b/plugins/sero-design-library-plugin/shared/media-model-catalog.ts
@@ -9,6 +9,8 @@ import type { MediaCapability } from './media';
 export interface MediaModelChoice {
   id: string;
   label: string;
+  /** Provider label used to group choices. Its source is adapter-owned. */
+  provider: string;
 }
 
 export type MediaModelChoices = Record<MediaCapability, MediaModelChoice[]>;

--- a/plugins/sero-design-library-plugin/shared/media-model-catalog.ts
+++ b/plugins/sero-design-library-plugin/shared/media-model-catalog.ts
@@ -15,7 +15,12 @@ export interface MediaModelChoice {
 
 export type MediaModelChoices = Record<MediaCapability, MediaModelChoice[]>;
 
+export interface ListMediaModelsOptions {
+  refresh?: boolean;
+  signal?: AbortSignal;
+}
+
 /** Provider-neutral model discovery used by the settings tool. */
 export interface MediaModelCatalog {
-  list(signal?: AbortSignal): Promise<MediaModelChoices>;
+  list(options?: ListMediaModelsOptions): Promise<MediaModelChoices>;
 }

--- a/plugins/sero-design-library-plugin/shared/media-model-catalog.ts
+++ b/plugins/sero-design-library-plugin/shared/media-model-catalog.ts
@@ -1,0 +1,19 @@
+import type { MediaCapability } from './media';
+
+/**
+ * One model exposed to settings.
+ *
+ * The ID is opaque outside the provider adapter. A provider can replace fal.ai
+ * without changing the settings tool or UI.
+ */
+export interface MediaModelChoice {
+  id: string;
+  label: string;
+}
+
+export type MediaModelChoices = Record<MediaCapability, MediaModelChoice[]>;
+
+/** Provider-neutral model discovery used by the settings tool. */
+export interface MediaModelCatalog {
+  list(signal?: AbortSignal): Promise<MediaModelChoices>;
+}

--- a/plugins/sero-design-library-plugin/ui/components/CountStepper.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/CountStepper.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CountStepper } from './CountStepper';
+
+describe('CountStepper', () => {
+  it('changes by one and stops at its bounds', async () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <CountStepper
+        value={2}
+        min={1}
+        max={3}
+        label="Items"
+        decrementLabel="One fewer item"
+        incrementLabel="One more item"
+        onChange={onChange}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'One fewer item' }));
+    await userEvent.click(screen.getByRole('button', { name: 'One more item' }));
+    expect(onChange.mock.calls.map(([value]) => value)).toEqual([1, 3]);
+
+    rerender(
+      <CountStepper
+        value={1}
+        min={1}
+        max={3}
+        label="Items"
+        decrementLabel="One fewer item"
+        incrementLabel="One more item"
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'One fewer item' }).hasAttribute('disabled')).toBe(
+      true,
+    );
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/components/CountStepper.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/CountStepper.test.tsx
@@ -24,6 +24,7 @@ describe('CountStepper', () => {
     await userEvent.click(screen.getByRole('button', { name: 'One fewer item' }));
     await userEvent.click(screen.getByRole('button', { name: 'One more item' }));
     expect(onChange.mock.calls.map(([value]) => value)).toEqual([1, 3]);
+    expect(screen.getByRole('group', { name: 'Items' })).toBeDefined();
 
     rerender(
       <CountStepper
@@ -39,5 +40,28 @@ describe('CountStepper', () => {
     expect(screen.getByRole('button', { name: 'One fewer item' }).hasAttribute('disabled')).toBe(
       true,
     );
+  });
+
+  it('allows direct entry when the range is large', async () => {
+    const onChange = vi.fn();
+    render(
+      <CountStepper
+        value={4}
+        min={0}
+        max={20}
+        label="Media calls per run"
+        decrementLabel="One fewer media call"
+        incrementLabel="One more media call"
+        editable
+        onChange={onChange}
+      />,
+    );
+
+    const input = screen.getByRole('spinbutton', { name: 'Media calls per run value' });
+    await userEvent.clear(input);
+    await userEvent.type(input, '20');
+    await userEvent.tab();
+
+    expect(onChange).toHaveBeenLastCalledWith(20);
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/CountStepper.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/CountStepper.tsx
@@ -1,0 +1,78 @@
+import { Button } from '@sero-ai/ui';
+import { Minus, Plus } from 'lucide-react';
+
+export interface CountStepperProps {
+  value: number;
+  min: number;
+  max: number;
+  label: string;
+  decrementLabel: string;
+  incrementLabel: string;
+  disabled?: boolean;
+  onChange(value: number): void;
+}
+
+/** A bounded integer control shared by Design creation and Settings. */
+export function CountStepper({
+  value,
+  min,
+  max,
+  label,
+  decrementLabel,
+  incrementLabel,
+  disabled = false,
+  onChange,
+}: CountStepperProps) {
+  return (
+    <div
+      aria-label={label}
+      className={`border-input flex h-9 items-center justify-between rounded-md border ${
+        disabled ? 'opacity-50' : ''
+      }`}
+    >
+      <StepButton
+        label={decrementLabel}
+        disabled={disabled || value <= min}
+        onClick={() => onChange(value - 1)}
+      >
+        <Minus className="size-3.5" />
+      </StepButton>
+      <span className="tabular-nums" aria-live="polite">
+        {value}
+      </span>
+      <StepButton
+        label={incrementLabel}
+        disabled={disabled || value >= max}
+        onClick={() => onChange(value + 1)}
+      >
+        <Plus className="size-3.5" />
+      </StepButton>
+    </div>
+  );
+}
+
+function StepButton({
+  label,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled: boolean;
+  onClick(): void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="size-8"
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/plugins/sero-design-library-plugin/ui/components/CountStepper.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/CountStepper.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@sero-ai/ui';
+import { Button, Input } from '@sero-ai/ui';
 import { Minus, Plus } from 'lucide-react';
 
 export interface CountStepperProps {
@@ -9,6 +9,7 @@ export interface CountStepperProps {
   decrementLabel: string;
   incrementLabel: string;
   disabled?: boolean;
+  editable?: boolean;
   onChange(value: number): void;
 }
 
@@ -21,10 +22,18 @@ export function CountStepper({
   decrementLabel,
   incrementLabel,
   disabled = false,
+  editable = false,
   onChange,
 }: CountStepperProps) {
+  const commit = (input: HTMLInputElement) => {
+    const next = Number(input.value);
+    if (Number.isInteger(next) && next >= min && next <= max) onChange(next);
+    else input.value = String(value);
+  };
+
   return (
     <div
+      role="group"
       aria-label={label}
       className={`border-input flex h-9 items-center justify-between rounded-md border ${
         disabled ? 'opacity-50' : ''
@@ -37,9 +46,26 @@ export function CountStepper({
       >
         <Minus className="size-3.5" />
       </StepButton>
-      <span className="tabular-nums" aria-live="polite">
-        {value}
-      </span>
+      {editable ? (
+        <Input
+          key={value}
+          type="number"
+          min={min}
+          max={max}
+          aria-label={`${label} value`}
+          className="h-8 w-20 border-0 text-center tabular-nums shadow-none focus-visible:ring-0"
+          disabled={disabled}
+          defaultValue={value}
+          onBlur={(event) => commit(event.currentTarget)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') event.currentTarget.blur();
+          }}
+        />
+      ) : (
+        <span className="tabular-nums" aria-live="polite">
+          {value}
+        </span>
+      )}
       <StepButton
         label={incrementLabel}
         disabled={disabled || value >= max}

--- a/plugins/sero-design-library-plugin/ui/components/MediaModelSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaModelSettings.tsx
@@ -39,6 +39,8 @@ const MEDIA_MODEL_USAGE: Record<MediaCapability, string> = {
 interface ModelOption {
   value: string;
   label: string;
+  displayName: string;
+  modelId?: string;
   provider: string;
 }
 
@@ -170,13 +172,20 @@ function ModelSelect({
       choice.label.toLocaleLowerCase() === trimmedQuery.toLocaleLowerCase(),
   );
   const options: ModelOption[] = [
-    { value: PROVIDER_DEFAULT, label: 'Provider default', provider: 'Default' },
+    {
+      value: PROVIDER_DEFAULT,
+      label: 'Provider default',
+      displayName: 'Provider default',
+      provider: 'Default',
+    },
     ...(value !== '' && !selectedIsListed
-      ? [{ value, label: value, provider: 'Saved choice' }]
+      ? [{ value, label: value, displayName: value, provider: 'Saved choice' }]
       : []),
     ...choices.map((choice) => ({
       value: choice.id,
       label: choice.label,
+      displayName: displayName(choice),
+      modelId: choice.id,
       provider: choice.provider,
     })),
     ...(trimmedQuery !== '' && trimmedQuery !== selectedLabel && !customIsListed
@@ -184,6 +193,7 @@ function ModelSelect({
           {
             value: trimmedQuery,
             label: trimmedQuery,
+            displayName: trimmedQuery,
             provider: 'Custom model ID',
           },
         ]
@@ -223,7 +233,14 @@ function ModelSelect({
                 <ComboboxCollection>
                   {(option: ModelOption) => (
                     <ComboboxItem key={`${group.value}:${option.value}`} value={option}>
-                      {option.label}
+                      <span className="min-w-0 leading-tight">
+                        <span className="block">{option.displayName}</span>
+                        {option.modelId !== undefined && (
+                          <span className="text-muted-foreground mt-0.5 block break-all text-xs">
+                            {option.modelId}
+                          </span>
+                        )}
+                      </span>
                     </ComboboxItem>
                   )}
                 </ComboboxCollection>
@@ -234,6 +251,13 @@ function ModelSelect({
       </Combobox>
     </div>
   );
+}
+
+function displayName(choice: MediaModelChoice): string {
+  const endpointSuffix = ` · ${choice.id}`;
+  return choice.label.endsWith(endpointSuffix)
+    ? choice.label.slice(0, -endpointSuffix.length)
+    : choice.label;
 }
 
 function MediaModelLabel({ capability }: { capability: MediaCapability }) {

--- a/plugins/sero-design-library-plugin/ui/components/MediaModelSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaModelSettings.tsx
@@ -1,0 +1,276 @@
+import { useAppTools } from '@sero-ai/app-runtime';
+import {
+  Button,
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  Label,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@sero-ai/ui';
+import { Info } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+import type { MediaCapability } from '../../shared/media';
+import { MEDIA_CAPABILITIES } from '../../shared/media';
+import type { MediaModelChoice, MediaModelChoices } from '../../shared/media-model-catalog';
+import type { MediaSettings } from '../../shared/settings';
+import { capabilityLabel } from '../lib/asset-view';
+
+const PROVIDER_DEFAULT = 'provider-default';
+
+const MEDIA_MODEL_USAGE: Record<MediaCapability, string> = {
+  'text-to-image': 'Used when a Design creates a new image from a text prompt.',
+  'reference-to-image':
+    'Used when a Design creates a new image from one or more Library references.',
+  'image-to-image': 'Used when a Design edits or restyles an existing image.',
+  upscale: 'Used when a Design increases the resolution of an existing image.',
+  'text-to-video': 'Used when a Design creates a video from a text prompt.',
+  'image-to-video': 'Used when a Design animates an existing image.',
+};
+
+interface ModelOption {
+  value: string;
+  label: string;
+  provider: string;
+}
+
+interface ModelOptionGroup {
+  value: string;
+  label: string;
+  items: ModelOption[];
+}
+
+export interface MediaModelSettingsProps {
+  media: MediaSettings;
+  onChange(capability: MediaCapability, modelId: string): void;
+}
+
+export function MediaModelSettings({ media, onChange }: MediaModelSettingsProps) {
+  const tools = useAppTools();
+  const [choices, setChoices] = useState<MediaModelChoices>(emptyChoices);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = (refresh: boolean) => {
+    setLoading(true);
+    setError(null);
+    return tools
+      .run('design_library_settings', {
+        action: 'list-media-models',
+        ...(refresh ? { refresh: true } : {}),
+      })
+      .then((result) => setChoices(normalizeChoices(result.details?.models)))
+      .catch((cause: unknown) => setError(errorMessage(cause)))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    void load(false);
+    // The provider adapter caches this result across Settings visits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {MEDIA_CAPABILITIES.map((capability) => (
+          <ModelSelect
+            key={capability}
+            capability={capability}
+            value={media.models[capability]}
+            choices={choices[capability]}
+            loading={loading}
+            onChange={(modelId) => onChange(capability, modelId)}
+          />
+        ))}
+      </div>
+
+      {error !== null && (
+        <div className="mt-3 flex items-center gap-2" role="alert">
+          <p className="text-destructive text-sm">{error}</p>
+          <Button type="button" size="sm" variant="ghost" onClick={() => void load(true)}>
+            Retry
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function emptyChoices(): MediaModelChoices {
+  return {
+    'text-to-image': [],
+    'reference-to-image': [],
+    'image-to-image': [],
+    upscale: [],
+    'text-to-video': [],
+    'image-to-video': [],
+  };
+}
+
+function modelChoices(value: unknown): MediaModelChoice[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (choice): choice is MediaModelChoice =>
+      typeof choice === 'object' &&
+      choice !== null &&
+      typeof (choice as Record<string, unknown>).id === 'string' &&
+      typeof (choice as Record<string, unknown>).label === 'string' &&
+      typeof (choice as Record<string, unknown>).provider === 'string',
+  );
+}
+
+function normalizeChoices(value: unknown): MediaModelChoices {
+  if (typeof value !== 'object' || value === null) return emptyChoices();
+  const source = value as Record<string, unknown>;
+  return {
+    'text-to-image': modelChoices(source['text-to-image']),
+    'reference-to-image': modelChoices(source['reference-to-image']),
+    'image-to-image': modelChoices(source['image-to-image']),
+    upscale: modelChoices(source.upscale),
+    'text-to-video': modelChoices(source['text-to-video']),
+    'image-to-video': modelChoices(source['image-to-video']),
+  };
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : 'Could not load media models.';
+}
+
+function ModelSelect({
+  capability,
+  value,
+  choices,
+  loading,
+  onChange,
+}: {
+  capability: MediaCapability;
+  value: string;
+  choices: MediaModelChoice[];
+  loading: boolean;
+  onChange(modelId: string): void;
+}) {
+  const selectedIsListed = choices.some((choice) => choice.id === value);
+  const listedSelection = choices.find((choice) => choice.id === value);
+  const selectedLabel =
+    value === '' ? 'Provider default' : (listedSelection?.label ?? value);
+  const [query, setQuery] = useState(selectedLabel);
+  const trimmedQuery = query.trim();
+  const customIsListed = choices.some(
+    (choice) =>
+      choice.id.toLocaleLowerCase() === trimmedQuery.toLocaleLowerCase() ||
+      choice.label.toLocaleLowerCase() === trimmedQuery.toLocaleLowerCase(),
+  );
+  const options: ModelOption[] = [
+    { value: PROVIDER_DEFAULT, label: 'Provider default', provider: 'Default' },
+    ...(value !== '' && !selectedIsListed
+      ? [{ value, label: value, provider: 'Saved choice' }]
+      : []),
+    ...choices.map((choice) => ({
+      value: choice.id,
+      label: choice.label,
+      provider: choice.provider,
+    })),
+    ...(trimmedQuery !== '' && trimmedQuery !== selectedLabel && !customIsListed
+      ? [
+          {
+            value: trimmedQuery,
+            label: trimmedQuery,
+            provider: 'Custom model ID',
+          },
+        ]
+      : []),
+  ];
+  const groups = groupModelOptions(options);
+  const selectedValue = options.find(
+    (option) => option.value === (value === '' ? PROVIDER_DEFAULT : value),
+  );
+
+  return (
+    <div className="space-y-1.5">
+      <MediaModelLabel capability={capability} />
+      <Combobox
+        items={groups}
+        value={selectedValue}
+        inputValue={query}
+        isItemEqualToValue={(item, selected) => item.value === selected.value}
+        onInputValueChange={setQuery}
+        onValueChange={(model) => {
+          if (model === null) return;
+          setQuery(model.label);
+          onChange(model.value === PROVIDER_DEFAULT ? '' : model.value);
+        }}
+      >
+        <ComboboxInput
+          id={`media-model-${capability}`}
+          className="w-full"
+          placeholder={loading ? 'Loading models…' : 'Search or enter a model ID'}
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No models found</ComboboxEmpty>
+          <ComboboxList>
+            {(group: ModelOptionGroup) => (
+              <ComboboxGroup key={group.value} items={group.items}>
+                <ComboboxLabel>{group.label}</ComboboxLabel>
+                <ComboboxCollection>
+                  {(option: ModelOption) => (
+                    <ComboboxItem key={`${group.value}:${option.value}`} value={option}>
+                      {option.label}
+                    </ComboboxItem>
+                  )}
+                </ComboboxCollection>
+              </ComboboxGroup>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
+    </div>
+  );
+}
+
+function MediaModelLabel({ capability }: { capability: MediaCapability }) {
+  const label = capabilityLabel(capability);
+  return (
+    <div className="flex items-center gap-1">
+      <Label htmlFor={`media-model-${capability}`}>{label}</Label>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground size-5"
+            aria-label={`How ${label} is used`}
+          >
+            <Info className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          {MEDIA_MODEL_USAGE[capability]}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function groupModelOptions(options: ModelOption[]): ModelOptionGroup[] {
+  const grouped = new Map<string, ModelOption[]>();
+  for (const option of options) {
+    const group = grouped.get(option.provider);
+    if (group === undefined) grouped.set(option.provider, [option]);
+    else group.push(option);
+  }
+  return [...grouped].map(([provider, items]) => ({
+    value: provider,
+    label: provider,
+    items,
+  }));
+}

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -123,6 +123,7 @@ describe('media models', () => {
     expect(screen.getByText('openai')).toBeDefined();
     await userEvent.clear(screen.getByLabelText('Image'));
     await userEvent.type(screen.getByLabelText('Image'), 'OpenAI');
+    expect(screen.getByText('openai/image').classList.contains('text-xs')).toBe(true);
     await userEvent.click(screen.getByRole('option', { name: /OpenAI Image/ }));
 
     expect(callsFor('set-media-model')[0]?.[1]).toMatchObject({

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -46,8 +46,16 @@ beforeEach(() => {
         ? {
             models: {
               'text-to-image': [
-                { id: 'fal-ai/flux/dev', label: 'FLUX Dev · fal-ai/flux/dev' },
-                { id: 'fal-ai/flux/schnell', label: 'FLUX Schnell · fal-ai/flux/schnell' },
+                {
+                  id: 'fal-ai/flux/dev',
+                  label: 'FLUX Dev · fal-ai/flux/dev',
+                  provider: 'fal-ai',
+                },
+                {
+                  id: 'openai/image',
+                  label: 'OpenAI Image · openai/image',
+                  provider: 'openai',
+                },
               ],
               'reference-to-image': [],
               'image-to-image': [],
@@ -102,16 +110,20 @@ describe('the provider key', () => {
 });
 
 describe('media models', () => {
-  it('loads provider choices and saves the selected opaque model id', async () => {
+  it('searches grouped provider choices and saves the selected opaque model id', async () => {
     render(<MediaSettings media={MEDIA} />);
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
     await userEvent.click(screen.getByLabelText('Image'));
-    await userEvent.click(screen.getByRole('option', { name: /FLUX Schnell/ }));
+    expect(screen.getByText('fal-ai')).toBeDefined();
+    expect(screen.getByText('openai')).toBeDefined();
+    await userEvent.clear(screen.getByLabelText('Image'));
+    await userEvent.type(screen.getByLabelText('Image'), 'OpenAI');
+    await userEvent.click(screen.getByRole('option', { name: /OpenAI Image/ }));
 
     expect(callsFor('set-media-model')[0]?.[1]).toMatchObject({
       capability: 'text-to-image',
-      mediaModel: 'fal-ai/flux/schnell',
+      mediaModel: 'openai/image',
     });
   });
 
@@ -120,6 +132,7 @@ describe('media models', () => {
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
     await userEvent.click(screen.getByLabelText('Image'));
+    expect(screen.getByText('Saved choice')).toBeDefined();
     expect(screen.getByRole('option', { name: 'flux/dev' })).toBeDefined();
   });
 

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -33,6 +33,10 @@ const MEDIA: MediaSettingsValue = {
   callsPerRun: 6,
 };
 
+function renderSettings() {
+  return render(<MediaSettings media={MEDIA} />);
+}
+
 function callsFor(action: string) {
   return run.mock.calls.filter(([, params]) => params?.action === action);
 }
@@ -71,7 +75,7 @@ beforeEach(() => {
 describe('the provider key', () => {
   it('asks where the key came from and says so', async () => {
     run.mockResolvedValue({ content: [], details: { status: 'env' } });
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
 
     await waitFor(() =>
       expect(screen.getByText('Using FAL_KEY from the environment')).toBeDefined(),
@@ -81,7 +85,7 @@ describe('the provider key', () => {
   });
 
   it('saves a key and re-reads the status rather than assuming it', async () => {
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
     await waitFor(() => expect(callsFor('key-status')).toHaveLength(1));
 
     await userEvent.type(screen.getByLabelText('Provider key'), 'secret-key');
@@ -95,14 +99,14 @@ describe('the provider key', () => {
   });
 
   it('will not submit an empty key', async () => {
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
     await waitFor(() => expect(callsFor('key-status')).toHaveLength(1));
 
     expect(screen.getByRole('button', { name: 'Save' }).hasAttribute('disabled')).toBe(true);
   });
 
   it('offers Remove only when there is a saved key to remove', async () => {
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
     await waitFor(() => expect(screen.getByText(/No key/)).toBeDefined());
     // Nothing stored: removing would be a button that does nothing.
     expect(screen.queryByRole('button', { name: 'Remove' })).toBeNull();
@@ -111,7 +115,7 @@ describe('the provider key', () => {
 
 describe('media models', () => {
   it('searches grouped provider choices and saves the selected opaque model id', async () => {
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
     await userEvent.click(screen.getByLabelText('Image'));
@@ -128,7 +132,7 @@ describe('media models', () => {
   });
 
   it('keeps a saved model that the provider no longer lists', async () => {
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
     await userEvent.click(screen.getByLabelText('Image'));
@@ -137,18 +141,28 @@ describe('media models', () => {
   });
 
   it('shows each capability separately', async () => {
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
 
     await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
     for (const label of ['Image', 'Reference image', 'Remix', 'Upscale', 'Video', 'Animate']) {
       expect(screen.getByLabelText(label), label).toBeDefined();
+      expect(screen.getByRole('button', { name: `How ${label} is used` }), label).toBeDefined();
     }
+  });
+
+  it('explains where each model is used', async () => {
+    renderSettings();
+
+    await userEvent.hover(screen.getByRole('button', { name: 'How Animate is used' }));
+    expect((await screen.findByRole('tooltip')).textContent).toContain(
+      'Used when a Design animates an existing image.',
+    );
   });
 });
 
 describe('the per-run cap', () => {
   it('uses the bounded stepper to update the cap', async () => {
-    render(<MediaSettings media={MEDIA} />);
+    renderSettings();
     await userEvent.click(screen.getByRole('button', { name: 'One more media call' }));
 
     const written = callsFor('set-media-cap').map(([, params]) => params?.callsPerRun);

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -39,7 +39,25 @@ function callsFor(action: string) {
 
 beforeEach(() => {
   run.mockReset();
-  run.mockResolvedValue({ content: [], details: { status: 'missing' } });
+  run.mockImplementation(async (_tool: string, params: Record<string, unknown>) => ({
+    content: [],
+    details:
+      params.action === 'list-media-models'
+        ? {
+            models: {
+              'text-to-image': [
+                { id: 'fal-ai/flux/dev', label: 'FLUX Dev · fal-ai/flux/dev' },
+                { id: 'fal-ai/flux/schnell', label: 'FLUX Schnell · fal-ai/flux/schnell' },
+              ],
+              'reference-to-image': [],
+              'image-to-image': [],
+              upscale: [],
+              'text-to-video': [],
+              'image-to-video': [],
+            },
+          }
+        : { status: 'missing' },
+  }));
 });
 
 describe('the provider key', () => {
@@ -84,34 +102,31 @@ describe('the provider key', () => {
 });
 
 describe('media models', () => {
-  it('commits an endpoint id when the field is done, not on every keystroke', async () => {
+  it('loads provider choices and saves the selected opaque model id', async () => {
     render(<MediaSettings media={MEDIA} />);
 
-    const field = screen.getByLabelText('Video');
-    await userEvent.type(field, 'veo/fast');
-    // A model id is meaningless half-written; a per-keystroke write would queue
-    // eight settings updates for values that were never a real endpoint.
-    expect(callsFor('set-media-model')).toHaveLength(0);
+    await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
+    await userEvent.click(screen.getByLabelText('Image'));
+    await userEvent.click(screen.getByRole('option', { name: /FLUX Schnell/ }));
 
-    await userEvent.tab();
     expect(callsFor('set-media-model')[0]?.[1]).toMatchObject({
-      capability: 'text-to-video',
-      mediaModel: 'veo/fast',
+      capability: 'text-to-image',
+      mediaModel: 'fal-ai/flux/schnell',
     });
   });
 
-  it('writes nothing when the value comes back unchanged', async () => {
+  it('keeps a saved model that the provider no longer lists', async () => {
     render(<MediaSettings media={MEDIA} />);
 
+    await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
     await userEvent.click(screen.getByLabelText('Image'));
-    await userEvent.tab();
-
-    expect(callsFor('set-media-model')).toHaveLength(0);
+    expect(screen.getByRole('option', { name: 'flux/dev' })).toBeDefined();
   });
 
-  it('shows each capability separately', () => {
+  it('shows each capability separately', async () => {
     render(<MediaSettings media={MEDIA} />);
 
+    await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
     for (const label of ['Image', 'Reference image', 'Remix', 'Upscale', 'Video', 'Animate']) {
       expect(screen.getByLabelText(label), label).toBeDefined();
     }
@@ -119,15 +134,11 @@ describe('media models', () => {
 });
 
 describe('the per-run cap', () => {
-  it('refuses a value outside the range instead of storing it', async () => {
+  it('uses the bounded stepper to update the cap', async () => {
     render(<MediaSettings media={MEDIA} />);
-    const field = screen.getByLabelText('Media calls per run');
+    await userEvent.click(screen.getByRole('button', { name: 'One more media call' }));
 
-    await userEvent.clear(field);
-    await userEvent.type(field, '99');
-
-    // 9 is in range and is written; 99 is not and is not.
     const written = callsFor('set-media-cap').map(([, params]) => params?.callsPerRun);
-    expect(written).not.toContain(99);
+    expect(written).toEqual([7]);
   });
 });

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.test.tsx
@@ -140,6 +140,58 @@ describe('media models', () => {
     expect(screen.getByRole('option', { name: 'flux/dev' })).toBeDefined();
   });
 
+  it('keeps manual entry available and retries after a catalogue error', async () => {
+    run.mockImplementation(async (_tool: string, params: Record<string, unknown>) => {
+      if (params.action === 'list-media-models') {
+        throw new Error('The media provider model catalogue returned 429.');
+      }
+      return { content: [], details: { status: 'missing' } };
+    });
+    renderSettings();
+
+    expect((await screen.findByRole('alert')).textContent).toContain('returned 429');
+    const input = screen.getByLabelText('Image');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'private/image-model');
+    await userEvent.click(screen.getByRole('option', { name: 'private/image-model' }));
+
+    expect(callsFor('set-media-model')[0]?.[1]).toMatchObject({
+      capability: 'text-to-image',
+      mediaModel: 'private/image-model',
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(2));
+    expect(callsFor('list-media-models')[1]?.[1]).toMatchObject({ refresh: true });
+  });
+
+  it('does not hide later provider groups in a long catalogue', async () => {
+    run.mockImplementation(async (_tool: string, params: Record<string, unknown>) => ({
+      content: [],
+      details:
+        params.action === 'list-media-models'
+          ? {
+              models: {
+                ...MEDIA.models,
+                'text-to-image': [
+                  ...Array.from({ length: 55 }, (_, index) => ({
+                    id: `fal-ai/model-${index}`,
+                    label: `FAL model ${index}`,
+                    provider: 'fal-ai',
+                  })),
+                  { id: 'openai/image', label: 'OpenAI Image', provider: 'openai' },
+                ],
+              },
+            }
+          : { status: 'missing' },
+    }));
+    renderSettings();
+
+    await waitFor(() => expect(callsFor('list-media-models')).toHaveLength(1));
+    await userEvent.click(screen.getByLabelText('Image'));
+    expect(screen.getByText('openai')).toBeDefined();
+  });
+
   it('shows each capability separately', async () => {
     renderSettings();
 

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
@@ -1,32 +1,12 @@
-import {
-  Button,
-  Combobox,
-  ComboboxCollection,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxGroup,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxLabel,
-  ComboboxList,
-  Input,
-  Label,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@sero-ai/ui';
 import { useAppTools } from '@sero-ai/app-runtime';
-import { Info } from 'lucide-react';
+import { Button, Input, TooltipProvider } from '@sero-ai/ui';
 import { useEffect, useState } from 'react';
 
-import type { CredentialStatus, MediaCapability } from '../../shared/media';
-import { MEDIA_CAPABILITIES } from '../../shared/media';
-import type { MediaModelChoice, MediaModelChoices } from '../../shared/media-model-catalog';
+import type { CredentialStatus } from '../../shared/media';
 import type { MediaSettings as MediaSettingsValue } from '../../shared/settings';
 import { MAX_CALLS_PER_RUN } from '../../shared/settings';
-import { capabilityLabel } from '../lib/asset-view';
 import { CountStepper } from './CountStepper';
+import { MediaModelSettings } from './MediaModelSettings';
 
 /**
  * Media configuration (spec §8.3, §10, D7, D9, D10).
@@ -45,31 +25,6 @@ const KEY_STATUS_LABEL: Record<CredentialStatus, string> = {
   missing: 'No key — generation will fail until one is set',
 };
 
-const PROVIDER_DEFAULT = 'provider-default';
-const VISIBLE_MODEL_LIMIT = 50;
-
-const MEDIA_MODEL_USAGE: Record<MediaCapability, string> = {
-  'text-to-image': 'Used when a Design creates a new image from a text prompt.',
-  'reference-to-image':
-    'Used when a Design creates a new image from one or more Library references.',
-  'image-to-image': 'Used when a Design edits or restyles an existing image.',
-  upscale: 'Used when a Design increases the resolution of an existing image.',
-  'text-to-video': 'Used when a Design creates a video from a text prompt.',
-  'image-to-video': 'Used when a Design animates an existing image.',
-};
-
-interface ModelOption {
-  value: string;
-  label: string;
-  provider: string;
-}
-
-interface ModelOptionGroup {
-  value: string;
-  label: string;
-  items: ModelOption[];
-}
-
 export interface MediaSettingsProps {
   media: MediaSettingsValue;
 }
@@ -80,9 +35,14 @@ export function MediaSettings({ media }: MediaSettingsProps) {
 
   return (
     <TooltipProvider>
-      <ModelIds media={media} onChange={(capability, mediaModel) =>
-        void run({ action: 'set-media-model', capability, mediaModel })
-      } />
+      <Section title="Media models">
+        <MediaModelSettings
+          media={media}
+          onChange={(capability, mediaModel) =>
+            void run({ action: 'set-media-model', capability, mediaModel })
+          }
+        />
+      </Section>
 
       <CallCap
         callsPerRun={media.callsPerRun}
@@ -114,196 +74,6 @@ function Section({
   );
 }
 
-function ModelIds({
-  media,
-  onChange,
-}: {
-  media: MediaSettingsValue;
-  onChange(capability: MediaCapability, modelId: string): void;
-}) {
-  const tools = useAppTools();
-  const [choices, setChoices] = useState<MediaModelChoices | null>(null);
-
-  useEffect(() => {
-    let active = true;
-    void tools
-      .run('design_library_settings', { action: 'list-media-models' })
-      .then((result) => {
-        if (active) setChoices(normalizeChoices(result.details?.models));
-      })
-      .catch(() => {
-        if (active) setChoices(emptyChoices());
-      });
-    return () => {
-      active = false;
-    };
-    // The catalogue is read once when Settings opens.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  return (
-    <Section title="Media models">
-      <div className="grid gap-4 sm:grid-cols-2">
-        {MEDIA_CAPABILITIES.map((capability) => (
-          <ModelSelect
-            key={capability}
-            capability={capability}
-            value={media.models[capability]}
-            choices={choices?.[capability] ?? []}
-            loading={choices === null}
-            onChange={(modelId) => onChange(capability, modelId)}
-          />
-        ))}
-      </div>
-    </Section>
-  );
-}
-
-function emptyChoices(): MediaModelChoices {
-  return {
-    'text-to-image': [],
-    'reference-to-image': [],
-    'image-to-image': [],
-    upscale: [],
-    'text-to-video': [],
-    'image-to-video': [],
-  };
-}
-
-function modelChoices(value: unknown): MediaModelChoice[] {
-  if (!Array.isArray(value)) return [];
-  return value.filter(
-    (choice): choice is MediaModelChoice =>
-      typeof choice === 'object' &&
-      choice !== null &&
-      typeof (choice as Record<string, unknown>).id === 'string' &&
-      typeof (choice as Record<string, unknown>).label === 'string' &&
-      typeof (choice as Record<string, unknown>).provider === 'string',
-  );
-}
-
-function normalizeChoices(value: unknown): MediaModelChoices {
-  if (typeof value !== 'object' || value === null) return emptyChoices();
-  const source = value as Record<string, unknown>;
-  return {
-    'text-to-image': modelChoices(source['text-to-image']),
-    'reference-to-image': modelChoices(source['reference-to-image']),
-    'image-to-image': modelChoices(source['image-to-image']),
-    upscale: modelChoices(source.upscale),
-    'text-to-video': modelChoices(source['text-to-video']),
-    'image-to-video': modelChoices(source['image-to-video']),
-  };
-}
-
-function ModelSelect({
-  capability,
-  value,
-  choices,
-  loading,
-  onChange,
-}: {
-  capability: MediaCapability;
-  value: string;
-  choices: MediaModelChoice[];
-  loading: boolean;
-  onChange(modelId: string): void;
-}) {
-  const selectedIsListed = choices.some((choice) => choice.id === value);
-  const options: ModelOption[] = [
-    { value: PROVIDER_DEFAULT, label: 'Provider default', provider: 'Default' },
-    ...(value !== '' && !selectedIsListed
-      ? [{ value, label: value, provider: 'Saved choice' }]
-      : []),
-    ...choices.map((choice) => ({
-      value: choice.id,
-      label: choice.label,
-      provider: choice.provider,
-    })),
-  ];
-  const groups = groupModelOptions(options);
-  const selectedValue = options.find(
-    (option) => option.value === (value === '' ? PROVIDER_DEFAULT : value),
-  );
-
-  return (
-    <div className="space-y-1.5">
-      <MediaModelLabel capability={capability} />
-      <Combobox
-        items={groups}
-        value={selectedValue}
-        disabled={loading}
-        limit={VISIBLE_MODEL_LIMIT}
-        isItemEqualToValue={(item, selected) => item.value === selected.value}
-        onValueChange={(model) => {
-          if (model !== null) onChange(model.value === PROVIDER_DEFAULT ? '' : model.value);
-        }}
-      >
-        <ComboboxInput
-          id={`media-model-${capability}`}
-          className="w-full"
-          placeholder={loading ? 'Loading models…' : 'Search models'}
-        />
-        <ComboboxContent>
-          <ComboboxEmpty>No models found</ComboboxEmpty>
-          <ComboboxList>
-            {(group: ModelOptionGroup) => (
-              <ComboboxGroup key={group.value} items={group.items}>
-                <ComboboxLabel>{group.label}</ComboboxLabel>
-                <ComboboxCollection>
-                  {(option: ModelOption) => (
-                    <ComboboxItem key={option.value} value={option}>
-                      {option.label}
-                    </ComboboxItem>
-                  )}
-                </ComboboxCollection>
-              </ComboboxGroup>
-            )}
-          </ComboboxList>
-        </ComboboxContent>
-      </Combobox>
-    </div>
-  );
-}
-
-function MediaModelLabel({ capability }: { capability: MediaCapability }) {
-  const label = capabilityLabel(capability);
-  return (
-    <div className="flex items-center gap-1">
-      <Label htmlFor={`media-model-${capability}`}>{label}</Label>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="text-muted-foreground size-5"
-            aria-label={`How ${label} is used`}
-          >
-            <Info className="size-3.5" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-xs">
-          {MEDIA_MODEL_USAGE[capability]}
-        </TooltipContent>
-      </Tooltip>
-    </div>
-  );
-}
-
-function groupModelOptions(options: ModelOption[]): ModelOptionGroup[] {
-  const grouped = new Map<string, ModelOption[]>();
-  for (const option of options) {
-    const group = grouped.get(option.provider);
-    if (group === undefined) grouped.set(option.provider, [option]);
-    else group.push(option);
-  }
-  return [...grouped].map(([provider, items]) => ({
-    value: provider,
-    label: provider,
-    items,
-  }));
-}
-
 function CallCap({
   callsPerRun,
   onChange,
@@ -324,6 +94,7 @@ function CallCap({
           min={0}
           max={MAX_CALLS_PER_RUN}
           value={callsPerRun}
+          editable
           onChange={onChange}
         />
       </div>

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
@@ -1,12 +1,16 @@
 import {
   Button,
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
   Input,
   Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
 } from '@sero-ai/ui';
 import { useAppTools } from '@sero-ai/app-runtime';
 import { useEffect, useState } from 'react';
@@ -37,6 +41,19 @@ const KEY_STATUS_LABEL: Record<CredentialStatus, string> = {
 };
 
 const PROVIDER_DEFAULT = 'provider-default';
+const VISIBLE_MODEL_LIMIT = 50;
+
+interface ModelOption {
+  value: string;
+  label: string;
+  provider: string;
+}
+
+interface ModelOptionGroup {
+  value: string;
+  label: string;
+  items: ModelOption[];
+}
 
 export interface MediaSettingsProps {
   media: MediaSettingsValue;
@@ -145,7 +162,8 @@ function modelChoices(value: unknown): MediaModelChoice[] {
       typeof choice === 'object' &&
       choice !== null &&
       typeof (choice as Record<string, unknown>).id === 'string' &&
-      typeof (choice as Record<string, unknown>).label === 'string',
+      typeof (choice as Record<string, unknown>).label === 'string' &&
+      typeof (choice as Record<string, unknown>).provider === 'string',
   );
 }
 
@@ -176,30 +194,74 @@ function ModelSelect({
   onChange(modelId: string): void;
 }) {
   const selectedIsListed = choices.some((choice) => choice.id === value);
+  const options: ModelOption[] = [
+    { value: PROVIDER_DEFAULT, label: 'Provider default', provider: 'Default' },
+    ...(value !== '' && !selectedIsListed
+      ? [{ value, label: value, provider: 'Saved choice' }]
+      : []),
+    ...choices.map((choice) => ({
+      value: choice.id,
+      label: choice.label,
+      provider: choice.provider,
+    })),
+  ];
+  const groups = groupModelOptions(options);
+  const selectedValue = options.find(
+    (option) => option.value === (value === '' ? PROVIDER_DEFAULT : value),
+  );
 
   return (
     <div className="space-y-1.5">
       <Label htmlFor={`media-model-${capability}`}>{capabilityLabel(capability)}</Label>
-      <Select
-        value={value === '' ? PROVIDER_DEFAULT : value}
+      <Combobox
+        items={groups}
+        value={selectedValue}
         disabled={loading}
-        onValueChange={(modelId) => onChange(modelId === PROVIDER_DEFAULT ? '' : modelId)}
+        limit={VISIBLE_MODEL_LIMIT}
+        isItemEqualToValue={(item, selected) => item.value === selected.value}
+        onValueChange={(model) => {
+          if (model !== null) onChange(model.value === PROVIDER_DEFAULT ? '' : model.value);
+        }}
       >
-        <SelectTrigger id={`media-model-${capability}`} className="w-full">
-          <SelectValue placeholder="Loading models…" />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value={PROVIDER_DEFAULT}>Provider default</SelectItem>
-          {value !== '' && !selectedIsListed && <SelectItem value={value}>{value}</SelectItem>}
-          {choices.map((choice) => (
-            <SelectItem key={choice.id} value={choice.id}>
-              {choice.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        <ComboboxInput
+          id={`media-model-${capability}`}
+          className="w-full"
+          placeholder={loading ? 'Loading models…' : 'Search models'}
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No models found</ComboboxEmpty>
+          <ComboboxList>
+            {(group: ModelOptionGroup) => (
+              <ComboboxGroup key={group.value} items={group.items}>
+                <ComboboxLabel>{group.label}</ComboboxLabel>
+                <ComboboxCollection>
+                  {(option: ModelOption) => (
+                    <ComboboxItem key={option.value} value={option}>
+                      {option.label}
+                    </ComboboxItem>
+                  )}
+                </ComboboxCollection>
+              </ComboboxGroup>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
     </div>
   );
+}
+
+function groupModelOptions(options: ModelOption[]): ModelOptionGroup[] {
+  const grouped = new Map<string, ModelOption[]>();
+  for (const option of options) {
+    const group = grouped.get(option.provider);
+    if (group === undefined) grouped.set(option.provider, [option]);
+    else group.push(option);
+  }
+  return [...grouped].map(([provider, items]) => ({
+    value: provider,
+    label: provider,
+    items,
+  }));
 }
 
 function CallCap({

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
@@ -1,19 +1,29 @@
-import { Button, Input, Label } from '@sero-ai/ui';
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@sero-ai/ui';
 import { useAppTools } from '@sero-ai/app-runtime';
 import { useEffect, useState } from 'react';
 
 import type { CredentialStatus, MediaCapability } from '../../shared/media';
 import { MEDIA_CAPABILITIES } from '../../shared/media';
+import type { MediaModelChoice, MediaModelChoices } from '../../shared/media-model-catalog';
 import type { MediaSettings as MediaSettingsValue } from '../../shared/settings';
 import { MAX_CALLS_PER_RUN } from '../../shared/settings';
 import { capabilityLabel } from '../lib/asset-view';
+import { CountStepper } from './CountStepper';
 
 /**
  * Media configuration (spec §8.3, §10, D7, D9, D10).
  *
- * Configured by *capability*, never by provider: the endpoint ids are editable
- * text because the provider exposes hundreds of them and a live browser would
- * need a catalogue API and network at settings time for marginal benefit.
+ * Configured by *capability*, never by provider. The settings tool translates
+ * the active provider's catalogue into opaque model ids and display labels.
  *
  * The key is the one value here that never touches reactive state. It is read
  * and written through the tool directly, and what comes back is where the key
@@ -25,6 +35,8 @@ const KEY_STATUS_LABEL: Record<CredentialStatus, string> = {
   stored: 'Using a key saved here',
   missing: 'No key — generation will fail until one is set',
 };
+
+const PROVIDER_DEFAULT = 'provider-default';
 
 export interface MediaSettingsProps {
   media: MediaSettingsValue;
@@ -56,14 +68,16 @@ function Section({
   children,
 }: {
   title: string;
-  description: string;
+  description?: string;
   children: React.ReactNode;
 }) {
   return (
     <section className="border-border border-b px-6 py-5 last:border-b-0">
       <h3 className="text-sm font-medium">{title}</h3>
-      <p className="text-muted-foreground mt-0.5 mb-3 text-sm">{description}</p>
-      {children}
+      {description !== undefined && (
+        <p className="text-muted-foreground mt-0.5 mb-3 text-sm">{description}</p>
+      )}
+      <div className={description === undefined ? 'mt-3' : ''}>{children}</div>
     </section>
   );
 }
@@ -75,17 +89,36 @@ function ModelIds({
   media: MediaSettingsValue;
   onChange(capability: MediaCapability, modelId: string): void;
 }) {
+  const tools = useAppTools();
+  const [choices, setChoices] = useState<MediaModelChoices | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void tools
+      .run('design_library_settings', { action: 'list-media-models' })
+      .then((result) => {
+        if (active) setChoices(normalizeChoices(result.details?.models));
+      })
+      .catch(() => {
+        if (active) setChoices(emptyChoices());
+      });
+    return () => {
+      active = false;
+    };
+    // The catalogue is read once when Settings opens.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
-    <Section
-      title="Media models"
-      description="One model per capability. Leave empty to use the adapter's default."
-    >
+    <Section title="Media models">
       <div className="grid gap-4 sm:grid-cols-2">
         {MEDIA_CAPABILITIES.map((capability) => (
-          <ModelIdField
+          <ModelSelect
             key={capability}
             capability={capability}
             value={media.models[capability]}
+            choices={choices?.[capability] ?? []}
+            loading={choices === null}
             onChange={(modelId) => onChange(capability, modelId)}
           />
         ))}
@@ -94,49 +127,77 @@ function ModelIds({
   );
 }
 
-/**
- * One endpoint id, committed on blur rather than on every keystroke.
- *
- * A model id is typed in one go and is meaningless half-written, so a debounce
- * would queue several settings writes of values that were never a real
- * endpoint. Blur is the moment the user is done with the field.
- */
-function ModelIdField({
+function emptyChoices(): MediaModelChoices {
+  return {
+    'text-to-image': [],
+    'reference-to-image': [],
+    'image-to-image': [],
+    upscale: [],
+    'text-to-video': [],
+    'image-to-video': [],
+  };
+}
+
+function modelChoices(value: unknown): MediaModelChoice[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (choice): choice is MediaModelChoice =>
+      typeof choice === 'object' &&
+      choice !== null &&
+      typeof (choice as Record<string, unknown>).id === 'string' &&
+      typeof (choice as Record<string, unknown>).label === 'string',
+  );
+}
+
+function normalizeChoices(value: unknown): MediaModelChoices {
+  if (typeof value !== 'object' || value === null) return emptyChoices();
+  const source = value as Record<string, unknown>;
+  return {
+    'text-to-image': modelChoices(source['text-to-image']),
+    'reference-to-image': modelChoices(source['reference-to-image']),
+    'image-to-image': modelChoices(source['image-to-image']),
+    upscale: modelChoices(source.upscale),
+    'text-to-video': modelChoices(source['text-to-video']),
+    'image-to-video': modelChoices(source['image-to-video']),
+  };
+}
+
+function ModelSelect({
   capability,
   value,
+  choices,
+  loading,
   onChange,
 }: {
   capability: MediaCapability;
   value: string;
+  choices: MediaModelChoice[];
+  loading: boolean;
   onChange(modelId: string): void;
 }) {
-  const [draft, setDraft] = useState(value);
-  // The stored value can change underneath — the agent can set it too — and the
-  // field should follow unless it is being edited right now.
-  const [focused, setFocused] = useState(false);
-  useEffect(() => {
-    if (!focused) setDraft(value);
-  }, [value, focused]);
-
-  const commit = () => {
-    setFocused(false);
-    if (draft.trim() !== value) onChange(draft.trim());
-  };
+  const selectedIsListed = choices.some((choice) => choice.id === value);
 
   return (
     <div className="space-y-1.5">
       <Label htmlFor={`media-model-${capability}`}>{capabilityLabel(capability)}</Label>
-      <Input
-        id={`media-model-${capability}`}
-        value={draft}
-        placeholder="The adapter's default"
-        onFocus={() => setFocused(true)}
-        onChange={(event) => setDraft(event.target.value)}
-        onBlur={commit}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter') event.currentTarget.blur();
-        }}
-      />
+      <Select
+        value={value === '' ? PROVIDER_DEFAULT : value}
+        disabled={loading}
+        onValueChange={(modelId) => onChange(modelId === PROVIDER_DEFAULT ? '' : modelId)}
+      >
+        <SelectTrigger id={`media-model-${capability}`} className="w-full">
+          <SelectValue placeholder="Loading models…" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={PROVIDER_DEFAULT}>Provider default</SelectItem>
+          {value !== '' && !selectedIsListed && <SelectItem value={value}>{value}</SelectItem>}
+          {choices.map((choice) => (
+            <SelectItem key={choice.id} value={choice.id}>
+              {choice.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
     </div>
   );
 }
@@ -153,18 +214,17 @@ function CallCap({
       title="Media calls per run"
       description={`How many images or clips one generation run may ask for, 0–${MAX_CALLS_PER_RUN}. Going over stops further calls and is reported; it does not fail the run.`}
     >
-      <Input
-        type="number"
-        min={0}
-        max={MAX_CALLS_PER_RUN}
-        className="w-24"
-        aria-label="Media calls per run"
-        value={callsPerRun}
-        onChange={(event) => {
-          const next = Number(event.target.value);
-          if (Number.isFinite(next) && next >= 0 && next <= MAX_CALLS_PER_RUN) onChange(next);
-        }}
-      />
+      <div className="max-w-sm">
+        <CountStepper
+          label="Media calls per run"
+          decrementLabel="One fewer media call"
+          incrementLabel="One more media call"
+          min={0}
+          max={MAX_CALLS_PER_RUN}
+          value={callsPerRun}
+          onChange={onChange}
+        />
+      </div>
     </Section>
   );
 }

--- a/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/MediaSettings.tsx
@@ -11,8 +11,13 @@ import {
   ComboboxList,
   Input,
   Label,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
 } from '@sero-ai/ui';
 import { useAppTools } from '@sero-ai/app-runtime';
+import { Info } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import type { CredentialStatus, MediaCapability } from '../../shared/media';
@@ -43,6 +48,16 @@ const KEY_STATUS_LABEL: Record<CredentialStatus, string> = {
 const PROVIDER_DEFAULT = 'provider-default';
 const VISIBLE_MODEL_LIMIT = 50;
 
+const MEDIA_MODEL_USAGE: Record<MediaCapability, string> = {
+  'text-to-image': 'Used when a Design creates a new image from a text prompt.',
+  'reference-to-image':
+    'Used when a Design creates a new image from one or more Library references.',
+  'image-to-image': 'Used when a Design edits or restyles an existing image.',
+  upscale: 'Used when a Design increases the resolution of an existing image.',
+  'text-to-video': 'Used when a Design creates a video from a text prompt.',
+  'image-to-video': 'Used when a Design animates an existing image.',
+};
+
 interface ModelOption {
   value: string;
   label: string;
@@ -64,7 +79,7 @@ export function MediaSettings({ media }: MediaSettingsProps) {
   const run = (params: Record<string, unknown>) => tools.run('design_library_settings', params);
 
   return (
-    <>
+    <TooltipProvider>
       <ModelIds media={media} onChange={(capability, mediaModel) =>
         void run({ action: 'set-media-model', capability, mediaModel })
       } />
@@ -75,7 +90,7 @@ export function MediaSettings({ media }: MediaSettingsProps) {
       />
 
       <ProviderKey />
-    </>
+    </TooltipProvider>
   );
 }
 
@@ -212,7 +227,7 @@ function ModelSelect({
 
   return (
     <div className="space-y-1.5">
-      <Label htmlFor={`media-model-${capability}`}>{capabilityLabel(capability)}</Label>
+      <MediaModelLabel capability={capability} />
       <Combobox
         items={groups}
         value={selectedValue}
@@ -246,6 +261,31 @@ function ModelSelect({
           </ComboboxList>
         </ComboboxContent>
       </Combobox>
+    </div>
+  );
+}
+
+function MediaModelLabel({ capability }: { capability: MediaCapability }) {
+  const label = capabilityLabel(capability);
+  return (
+    <div className="flex items-center gap-1">
+      <Label htmlFor={`media-model-${capability}`}>{label}</Label>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground size-5"
+            aria-label={`How ${label} is used`}
+          >
+            <Info className="size-3.5" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          {MEDIA_MODEL_USAGE[capability]}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/plugins/sero-design-library-plugin/ui/components/design/BriefFields.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/design/BriefFields.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Label,
   Select,
   SelectContent,
@@ -11,12 +10,12 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from '@sero-ai/ui';
-import { Minus, Plus } from 'lucide-react';
 
 import type { DesignBrief } from '../../../shared/design';
 import { MAX_VARIANTS, MIN_VARIANTS } from '../../../shared/design';
 import type { GuardrailSynthesis } from '../../../shared/synthesis';
 import type { DesignLibrarySettings, PromptRecipe } from '../../../shared/settings';
+import { CountStepper } from '../CountStepper';
 import { GuardrailChips } from './GuardrailChips';
 
 /**
@@ -141,8 +140,13 @@ export function BriefFields({
         </Field>
 
         <Field label="Variants">
-          <VariantStepper
+          <CountStepper
             value={perReference ? referenceCount : brief.variantCount}
+            min={MIN_VARIANTS}
+            max={MAX_VARIANTS}
+            label="Variants"
+            decrementLabel="One fewer variant"
+            incrementLabel="One more variant"
             // One variant per reference: the count is the reference list, and a
             // stepper that silently disagreed with the footer would be a lie.
             disabled={perReference}
@@ -211,67 +215,5 @@ function Field({
       </div>
       {children}
     </div>
-  );
-}
-
-function VariantStepper({
-  value,
-  disabled,
-  onChange,
-}: {
-  value: number;
-  disabled: boolean;
-  onChange(value: number): void;
-}) {
-  return (
-    <div
-      className={`border-input flex h-9 items-center justify-between rounded-md border ${
-        disabled ? 'opacity-50' : ''
-      }`}
-    >
-      <StepButton
-        label="One fewer variant"
-        disabled={disabled || value <= MIN_VARIANTS}
-        onClick={() => onChange(value - 1)}
-      >
-        <Minus className="size-3.5" />
-      </StepButton>
-      <span className="tabular-nums" aria-live="polite">
-        {value}
-      </span>
-      <StepButton
-        label="One more variant"
-        disabled={disabled || value >= MAX_VARIANTS}
-        onClick={() => onChange(value + 1)}
-      >
-        <Plus className="size-3.5" />
-      </StepButton>
-    </div>
-  );
-}
-
-function StepButton({
-  label,
-  disabled,
-  onClick,
-  children,
-}: {
-  label: string;
-  disabled: boolean;
-  onClick(): void;
-  children: React.ReactNode;
-}) {
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon"
-      className="size-8"
-      aria-label={label}
-      disabled={disabled}
-      onClick={onClick}
-    >
-      {children}
-    </Button>
   );
 }

--- a/plugins/sero-design-library-plugin/ui/pages/SettingsPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/SettingsPage.tsx
@@ -82,10 +82,7 @@ export function SettingsPage({ state }: SettingsPageProps) {
   return (
     <ScrollArea className="min-h-0 flex-1">
       <div className="mx-auto max-w-3xl">
-        <SettingsSection
-          title="Librarian model"
-          description="Reads each reference and writes its design language. Leave empty to follow Sero's configured model."
-        >
+        <SettingsSection title="Librarian model">
           <AvailableModelPicker
             groups={groups}
             value={modelKeyOf(settings.librarianModel)}
@@ -95,10 +92,7 @@ export function SettingsPage({ state }: SettingsPageProps) {
           />
         </SettingsSection>
 
-        <SettingsSection
-          title="Design model"
-          description="Generates, revises and authors tweaks. Leave empty to follow Sero's configured model."
-        >
+        <SettingsSection title="Design model">
           <AvailableModelPicker
             groups={groups}
             value={modelKeyOf(settings.designModel)}


### PR DESCRIPTION
## Summary

- remove extra model help text from the options page
- load provider-neutral media model choices from a bounded fal.ai working set
- use grouped, searchable single-choice comboboxes for media models
- keep saved and manual endpoint choices available when discovery fails
- show catalogue errors with Retry and cache successful results
- use the shared, accessible count stepper for media calls per run
- add accessible usage tooltips for each media model field
- update the specification, decision record, plan, and user documentation

## Why

The former media model fields were slow to use and exposed provider-specific details in the settings UI. The first catalogue implementation also crawled enough pages to hit fal.ai rate limits, attached a generation key to public discovery, hid errors, and blocked selection when discovery failed. The media call limit used a different control from the design creation flow.

## Impact

Users can search a provider-grouped working set or enter any model endpoint. Settings makes one anonymous catalogue request, caches successful results, and provides Retry without removing saved or manual choices. The media-call stepper has an accessible name and supports direct numeric entry.

## Fix details

The active adapter owns model discovery and returns opaque provider-neutral choices. The fal.ai adapter classifies one 100-model active working set instead of running parallel pagination chains. A live anonymous check returned all required image and video categories in that one request. The plugin also owns its tooltip provider because a federated plugin cannot depend on tooltip context from the desktop shell.

## Checks

- full design-library test suite: 90 files and 771 tests passed
- focused review regression tests: 23 passed
- design-library plugin typecheck passed
- design-library production and installable plugin builds passed
- live anonymous fal.ai working-set request passed without an API key
- React Doctor: 100/100
- root `pnpm typecheck`: 24 tasks passed
- source file size and diff checks passed