### PR TITLE
Scale Design Library JSON state storage

### DIFF
--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -45,7 +45,7 @@ A field you edited is marked **Edited**. Blanking a field counts as an edit, so 
 
 ## Finding things
 
-- **Search** covers titles, tags, notes and every part of the analysis you can see.
+- **Search** covers titles, original file names, primary styles, tags and Design types. It does not search notes or detailed analysis.
 - **Filters** narrow by media, style, tag, colour and source. The colour filter uses families such as Reds, Greens, Blues and Neutrals. Values inside one filter widen the results; different filters narrow them.
 - **Favourites** and **Collections** are yours to arrange. A collection is a plain group you name.
 - Select references and open **Collections** to add or remove them. Use the action menu beside a custom collection to delete the collection; its references stay in the Library.

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -270,7 +270,7 @@ Design Library exposes its read surface to the main Sero agent, so you can work 
 | `design_library_media` | Generate artwork into a design or straight into the Library, list it, retry, delete and copy to the Library |
 | `design_library_gallery` | List saved families, read versions, open or duplicate an exact revision, feature versions, and manage Gallery Trash |
 | `design_library_export` | Export an exact Gallery version to Downloads or the active workspace, and read export status |
-| `design_library_settings` | Change defaults and schedule a full index repair for the next restart. A failed repair retries up to three starts; scheduling it again starts a fresh set of attempts. |
+| `design_library_settings` | Change defaults, read index-repair status and schedule a full repair for the next restart. A failed repair retries up to three starts; scheduling it again starts a fresh set of attempts. |
 
 Ask things like *"what dark, data-dense references do I have?"*, *"reanalyse the Northstar screenshot"*, *"make a dashboard from the Northstar and Material journal references"*, *"revise variant 2 to use a lighter surface"*, or *"generate a dark metallic texture into the Library"*.
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -270,6 +270,7 @@ Design Library exposes its read surface to the main Sero agent, so you can work 
 | `design_library_media` | Generate artwork into a design or straight into the Library, list it, retry, delete and copy to the Library |
 | `design_library_gallery` | List saved families, read versions, open or duplicate an exact revision, feature versions, and manage Gallery Trash |
 | `design_library_export` | Export an exact Gallery version to Downloads or the active workspace, and read export status |
+| `design_library_settings` | Change defaults and schedule a full index repair for the next restart |
 
 Ask things like *"what dark, data-dense references do I have?"*, *"reanalyse the Northstar screenshot"*, *"make a dashboard from the Northstar and Material journal references"*, *"revise variant 2 to use a lighter surface"*, or *"generate a dark metallic texture into the Library"*.
 

--- a/apps/docs-site/docs/plugins/design-library.md
+++ b/apps/docs-site/docs/plugins/design-library.md
@@ -270,7 +270,7 @@ Design Library exposes its read surface to the main Sero agent, so you can work 
 | `design_library_media` | Generate artwork into a design or straight into the Library, list it, retry, delete and copy to the Library |
 | `design_library_gallery` | List saved families, read versions, open or duplicate an exact revision, feature versions, and manage Gallery Trash |
 | `design_library_export` | Export an exact Gallery version to Downloads or the active workspace, and read export status |
-| `design_library_settings` | Change defaults and schedule a full index repair for the next restart |
+| `design_library_settings` | Change defaults and schedule a full index repair for the next restart. A failed repair retries up to three starts; scheduling it again starts a fresh set of attempts. |
 
 Ask things like *"what dark, data-dense references do I have?"*, *"reanalyse the Northstar screenshot"*, *"make a dashboard from the Northstar and Material journal references"*, *"revise variant 2 to use a lighter surface"*, or *"generate a dark metallic texture into the Library"*.
 

--- a/docs/plans/sero-design-library-json-state-scalability-plan.md
+++ b/docs/plans/sero-design-library-json-state-scalability-plan.md
@@ -165,6 +165,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Update an index only when its projected value changes.
 - [x] Write the record before the index so an observed index never points to a missing record.
 - [x] Journal each item, Design, Gallery, and export projection before its record changes, then replay only interrupted projections at startup.
+- [x] Keep each journal marker and its control-state notification inside the matching record lock during replay.
 - [x] Update the small control-state revision after record and index writes complete.
 - [x] Keep unreadable records on disk and exclude them from rebuilt indexes.
 
@@ -178,10 +179,13 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Change job writes, retention, dismissal, and recovery to update `jobs/index.json`.
 - [x] Prune orphan revision directories for Designs listed in `designs/index.json` at startup.
 - [x] Persist one record per export and update `exports/index.json`.
+- [x] Mark exports left running by a restart as interrupted before export pruning runs.
+- [x] Select the latest export by its creation time, independent of index file order.
 - [x] Keep only the 20 newest export records and index entries.
 - [x] Remove startup work that rebuilds entity arrays inside `state.json`.
 - [x] Retain a deliberate full index-rebuild operation for migration and repair.
 - [x] Let the agent schedule a full authoritative index repair for the next startup.
+- [x] Stop an automatic full repair after three failed starts and let a new repair request reset the attempts.
 
 ### Phase 4 — Extension read and request paths
 

--- a/docs/plans/sero-design-library-json-state-scalability-plan.md
+++ b/docs/plans/sero-design-library-json-state-scalability-plan.md
@@ -70,6 +70,7 @@ The version 2 state should contain:
 - Settings
 - Media model options
 - View preferences
+- Saved Library search query
 - Collections, unless measurements show that they need their own record store
 - The request queue
 - The next request id
@@ -82,7 +83,6 @@ It must not contain:
 - Gallery family records or summaries
 - Export history
 - Job history
-- Search text
 
 ### 2.4 Compact item index
 
@@ -175,6 +175,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Change Gallery writes and deletion to update `gallery/index.json`.
 - [x] Keep every Gallery family's version metadata in its single family record.
 - [x] Change job writes, retention, dismissal, and recovery to update `jobs/index.json`.
+- [x] Prune orphan revision directories for Designs listed in `designs/index.json` at startup.
 - [x] Persist one record per export and update `exports/index.json`.
 - [x] Remove startup work that rebuilds entity arrays inside `state.json`.
 - [x] Retain a deliberate full index-rebuild operation for migration and repair.
@@ -190,7 +191,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 
 ### Phase 5 — UI index subscriptions
 
-- [x] Add a small local hook that reads and watches a JSON index through the existing app-state bridge.
+- [x] Add and test a small local hook that reads and watches a JSON index through the existing app-state bridge.
 - [x] Make the Library page consume `items/index.json`.
 - [x] Make the Designs surfaces consume `designs/index.json`.
 - [x] Make the Gallery page consume `gallery/index.json`.
@@ -209,6 +210,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Update the search placeholder to **Search titles, styles, tags or files**.
 - [x] Update tests that currently expect notes or analysis to be searchable.
 - [x] Add explicit tests that notes, prompts, and detailed analysis are not index search fields.
+- [x] Restore the search query to saved view preferences and agent control.
 
 ### Phase 7 — Automatic migration
 
@@ -247,6 +249,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Run `git diff --check`.
 - [x] Check the line count of every touched source file.
 - [x] Review the migrated example profile without changing its source data.
+- [x] Test import, search, filters, Design detail, Gallery, and **Show more** in the running app with a copy of a real profile.
 - [x] Commit each coherent phase with a Conventional Commit message.
 - [x] Do not open a pull request until the specification and docs-site review are complete.
 

--- a/docs/plans/sero-design-library-json-state-scalability-plan.md
+++ b/docs/plans/sero-design-library-json-state-scalability-plan.md
@@ -1,0 +1,314 @@
+# Design Library JSON state scalability plan
+
+**Status:** Proposed
+**Scope:** Profile-global Design Library persistence, indexes, migration, and Library search
+**Plugin:** `plugins/sero-design-library-plugin/`
+**Storage:** JSON records and asset files only
+
+## 1. Goal
+
+Keep `state.json` small as the Design Library grows to hundreds or thousands of items and Designs.
+
+Use one complete JSON record for each top-level entity. Use one compact index file for each entity type. Keep filtering and high-level keyword search over item index fields. Do not add a database or split one entity across many metadata records.
+
+## 2. Agreed design
+
+### 2.1 Storage rules
+
+- Each item has one `record.json`.
+- Each Design has one `record.json`. It includes its variants and revision metadata.
+- Each Gallery family has one `record.json`. It includes its version metadata.
+- Each job has one JSON record.
+- Each export has one JSON record.
+- Binary assets, generated source files, built previews, and Gallery snapshot files remain separate from JSON records.
+- Each entity type has one compact `index.json` for list rendering and filtering.
+- `state.json` contains only bounded control state and the transient request queue.
+- The runtime remains the only authoritative record and index writer.
+
+### 2.2 Target layout
+
+```text
+design-library/
+├── state.json
+├── items/
+│   ├── index.json
+│   └── <item-id>/
+│       ├── record.json
+│       ├── original.<ext>
+│       ├── preview.webp
+│       └── frames.webp
+├── designs/
+│   ├── index.json
+│   └── <design-id>/
+│       ├── record.json
+│       ├── assets/
+│       └── variants/
+├── gallery/
+│   ├── index.json
+│   └── <family-id>/
+│       ├── record.json
+│       └── versions/
+├── jobs/
+│   ├── index.json
+│   └── <job-id>.json
+├── exports/
+│   ├── index.json
+│   └── <export-id>.json
+├── uploads/
+├── tombstones/
+└── secrets.json
+```
+
+Existing asset paths must not change unless a migration requires it. This work should move metadata, not media.
+
+### 2.3 Bounded reactive state
+
+The version 2 state should contain:
+
+- Schema version
+- Global revision used by detail views
+- Settings
+- Media model options
+- View preferences
+- Collections, unless measurements show that they need their own record store
+- The request queue
+- The next request id
+- The consumed request watermark
+
+It must not contain:
+
+- Item summaries
+- Design summaries
+- Gallery family records or summaries
+- Export history
+- Job history
+- Search text
+
+### 2.4 Compact item index
+
+`items/index.json` should contain the fields required by cards, scopes, filters, sorting, and high-level keyword search:
+
+```ts
+interface ItemIndexEntry {
+  id: string;
+  title: string;
+  fileName?: string;
+  primaryStyle: string;
+  tags: string[];
+  designTypes: string[];
+  kind: MediaKind;
+  previewPath: string;
+  analysisStatus: AnalysisStatus;
+  analysisError?: string;
+  awaitingFrames?: boolean;
+  favourite: boolean;
+  collectionIds: string[];
+  colours: string[];
+  sourceKind: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt?: number;
+  edited: boolean;
+}
+```
+
+The index must keep all tags needed by filtering. The card can still display only the first six tags.
+
+Do not persist a combined `searchText` value. Do not copy notes, summaries, prompts, guardrails, or detailed Librarian analysis into the index.
+
+### 2.5 Search contract
+
+The Library search box should match these fields without case sensitivity:
+
+- Title
+- Original file name
+- Primary style
+- Tags
+- Design types
+
+Split the query into whitespace-separated terms. Every term must match at least one field. Partial field matches remain valid.
+
+Search combines with the existing scope and filters. It does not search notes or detailed analysis. Change the placeholder to **Search titles, styles, tags or files**.
+
+The renderer can search and filter the compact item index in memory. Do not add a search service, persistent search cache, database, or model call.
+
+## 3. Non-goals
+
+- SQLite or another database
+- Sharded indexes
+- One record per Design variant or revision
+- One record per Gallery version
+- Full-text search over detailed Librarian analysis
+- Semantic or embedding search
+- A new host capability or Design Library-specific IPC
+- Moving binary assets into JSON
+- Changing media ingestion, generation, or Gallery product behavior
+
+## 4. Implementation task list
+
+### Phase 1 — Types and storage boundaries
+
+- [ ] Add version 2 control-state types and defaults.
+- [ ] Remove entity arrays from the control-state type.
+- [ ] Add normalized types for item, Design, Gallery, job, and export indexes.
+- [ ] Rename or separate `ItemSummary` so card display limits do not remove index values.
+- [ ] Add paths for every entity index and export record.
+- [ ] Keep one complete record type for each top-level entity.
+- [ ] Keep all new and touched source files below 500 lines.
+
+### Phase 2 — Shared JSON index storage
+
+- [ ] Add shared helpers to read, normalize, and atomically write each index.
+- [ ] Use the existing in-process queue and cross-process file locks.
+- [ ] Define one consistent lock order: entity record, entity index, then control state.
+- [ ] Add pure projection functions from each record to its index entry.
+- [ ] Update an index only when its projected value changes.
+- [ ] Write the record before the index so an observed index never points to a missing record.
+- [ ] Update the small control-state revision after record and index writes complete.
+- [ ] Keep unreadable records on disk and exclude them from rebuilt indexes.
+
+### Phase 3 — Runtime record stores
+
+- [ ] Change item writes and deletion to update `items/index.json` instead of the item array in `state.json`.
+- [ ] Change Design writes and deletion to update `designs/index.json`.
+- [ ] Keep every Design's variants and revision metadata in its single Design record.
+- [ ] Change Gallery writes and deletion to update `gallery/index.json`.
+- [ ] Keep every Gallery family's version metadata in its single family record.
+- [ ] Change job writes, retention, dismissal, and recovery to update `jobs/index.json`.
+- [ ] Persist one record per export and update `exports/index.json`.
+- [ ] Remove startup work that rebuilds entity arrays inside `state.json`.
+- [ ] Retain a deliberate full index-rebuild operation for migration and repair.
+
+### Phase 4 — Extension read and request paths
+
+- [ ] Audit every extension and runtime `readState()` call.
+- [ ] Read entity lists from their indexes.
+- [ ] Read full entity details from their records.
+- [ ] Keep mutation tools as intent writers through the existing request queue.
+- [ ] Remove assumptions that all items, Designs, Gallery families, jobs, or exports are present in control state.
+- [ ] Keep duplicate detection authoritative against item records or a normalized item-index field.
+
+### Phase 5 — UI index subscriptions
+
+- [ ] Add a small local hook that reads and watches a JSON index through the existing app-state bridge.
+- [ ] Make the Library page consume `items/index.json`.
+- [ ] Make the Designs surfaces consume `designs/index.json`.
+- [ ] Make the Gallery page consume `gallery/index.json`.
+- [ ] Make job and export notifications consume their indexes or a bounded current notification projection.
+- [ ] Keep full item and Design detail reads on demand.
+- [ ] Ensure an index update does not reset local view state or selection.
+- [ ] Keep large grids incrementally or window rendered.
+
+### Phase 6 — High-level search and filters
+
+- [ ] Remove `searchText` from the item index type and projection.
+- [ ] Search title, file name, primary style, tags, and Design types directly.
+- [ ] Preserve case-insensitive, partial, all-terms matching.
+- [ ] Keep scope, structured filters, and sorting behavior unchanged.
+- [ ] Keep every tag in the index while limiting only card presentation.
+- [ ] Update the search placeholder to **Search titles, styles, tags or files**.
+- [ ] Update tests that currently expect notes or analysis to be searchable.
+- [ ] Add explicit tests that notes, prompts, and detailed analysis are not index search fields.
+
+### Phase 7 — Automatic migration
+
+- [ ] Detect a legacy state that contains entity arrays.
+- [ ] Build normalized indexes from the authoritative record files.
+- [ ] Create export records for legacy exports that exist only in state.
+- [ ] Preserve collections and bounded settings without data loss.
+- [ ] Write all record and index files before switching to version 2 control state.
+- [ ] Preserve the old state as `state.json.pre-index-backup` before the final switch.
+- [ ] Make migration safe to retry after interruption.
+- [ ] Do not move or duplicate original media and generated assets.
+- [ ] Report unreadable records without deleting them.
+- [ ] Do not run a full record scan on every normal startup after migration.
+
+### Phase 8 — Tests and documentation
+
+- [ ] Add unit tests for every index normalizer and projection.
+- [ ] Add storage tests that prove one entity change does not rewrite unrelated entity records.
+- [ ] Add migration tests for items, Designs, Gallery families, jobs, exports, settings, collections, requests, and deleted records.
+- [ ] Add interruption tests for record, index, and final control-state writes.
+- [ ] Add restart tests for pending requests and active jobs.
+- [ ] Add search tests for all supported high-level fields and all excluded detailed fields.
+- [ ] Add filter and facet tests that include tags beyond the first six.
+- [ ] Add a generated fixture with at least 5,000 items and 1,000 Designs.
+- [ ] Verify that the large fixture does not add entity data to `state.json`.
+- [ ] Update the Design Library specification and first-release storage documentation.
+- [ ] Update the docs site only where user-visible search behavior is described.
+
+### Phase 9 — Verification and delivery
+
+- [ ] Run the Design Library focused test suite.
+- [ ] Run the Design Library typecheck.
+- [ ] Run the Design Library build.
+- [ ] Run React Doctor after the React changes.
+- [ ] Run root `pnpm typecheck` before each commit.
+- [ ] Run `git diff --check`.
+- [ ] Check the line count of every touched source file.
+- [ ] Review the migrated example profile without changing its source data.
+- [ ] Commit each coherent phase with a Conventional Commit message.
+- [ ] Do not open a pull request until the specification and docs-site review are complete.
+
+## 5. Acceptance criteria
+
+### Storage and compatibility
+
+- [ ] `state.json` contains no item, Design, Gallery, export, or job arrays after migration.
+- [ ] Adding entities does not increase `state.json` except for bounded revision and request data.
+- [ ] Every item has one complete item record.
+- [ ] Every Design has one complete Design record, including its variants and revision metadata.
+- [ ] Every Gallery family has one complete family record, including its version metadata.
+- [ ] Every job and export has one complete JSON record.
+- [ ] Original media, previews, generated files, and Gallery assets retain their current ownership and paths.
+- [ ] An existing profile migrates automatically without losing records, settings, collections, requests, deletion state, or asset references.
+- [ ] A failed or interrupted migration leaves the legacy state usable and can be retried.
+
+### Index behavior
+
+- [ ] Each entity index contains only normalized list data for that entity type.
+- [ ] No index contains notes, prompts, guardrails, detailed Librarian analysis, generated source, or binary data.
+- [ ] `items/index.json` contains all tags required by filters and facets.
+- [ ] A record change updates its own record and relevant index without rewriting unrelated entity records.
+- [ ] A corrupt record is reported and skipped without preventing other entities from loading.
+- [ ] Normal startup reads the indexes and does not rebuild them from every record.
+
+### Search and filters
+
+- [ ] Search matches title, original file name, primary style, tags, and Design types.
+- [ ] Search is case-insensitive and supports partial terms.
+- [ ] Every query term must match at least one supported field.
+- [ ] Search combines correctly with scopes, filters, and sorting.
+- [ ] Search does not match notes, summaries, prompts, guardrails, or detailed analysis.
+- [ ] The search placeholder describes the supported fields accurately.
+- [ ] Existing media, style, tag, colour, source, status, date, favourite, collection, recent, awaiting, and trash filters keep their behavior.
+
+### Scale and responsiveness
+
+- [ ] A fixture with 5,000 items and 1,000 Designs loads from compact indexes without loading every full record into the renderer.
+- [ ] Search, filters, facets, and sorting return correct results for the large fixture.
+- [ ] Opening one item or Design reads only its full record and required assets.
+- [ ] Updating view preferences rewrites only the small control state.
+- [ ] Updating one item does not broadcast every full item or Design record.
+- [ ] The rendered grid remains bounded as the index grows.
+
+### Quality gates
+
+- [ ] All focused tests pass.
+- [ ] Plugin typecheck and build pass.
+- [ ] React Doctor has no unresolved regression caused by this work.
+- [ ] Root `pnpm typecheck` passes before every commit.
+- [ ] Every touched source file remains below 500 lines.
+- [ ] Documentation matches the implemented storage and search behavior.
+
+## 6. Deferred decisions
+
+Do not solve these in the first implementation:
+
+- Index sharding
+- Server-side pagination
+- Deep search over full records
+- Semantic search
+- A collection record store
+
+Measure the compact indexes with the 5,000-item fixture first. If one index later becomes a measured write or load bottleneck, its persistence can change without changing the one-record-per-entity contract.

--- a/docs/plans/sero-design-library-json-state-scalability-plan.md
+++ b/docs/plans/sero-design-library-json-state-scalability-plan.md
@@ -1,6 +1,6 @@
 # Design Library JSON state scalability plan
 
-**Status:** Proposed
+**Status:** Complete
 **Scope:** Profile-global Design Library persistence, indexes, migration, and Library search
 **Plugin:** `plugins/sero-design-library-plugin/`
 **Storage:** JSON records and asset files only
@@ -148,158 +148,158 @@ The renderer can search and filter the compact item index in memory. Do not add 
 
 ### Phase 1 — Types and storage boundaries
 
-- [ ] Add version 2 control-state types and defaults.
-- [ ] Remove entity arrays from the control-state type.
-- [ ] Add normalized types for item, Design, Gallery, job, and export indexes.
-- [ ] Rename or separate `ItemSummary` so card display limits do not remove index values.
-- [ ] Add paths for every entity index and export record.
-- [ ] Keep one complete record type for each top-level entity.
-- [ ] Keep all new and touched source files below 500 lines.
+- [x] Add version 2 control-state types and defaults.
+- [x] Remove entity arrays from the control-state type.
+- [x] Add normalized types for item, Design, Gallery, job, and export indexes.
+- [x] Rename or separate `ItemSummary` so card display limits do not remove index values.
+- [x] Add paths for every entity index and export record.
+- [x] Keep one complete record type for each top-level entity.
+- [x] Keep all new and touched source files below 500 lines.
 
 ### Phase 2 — Shared JSON index storage
 
-- [ ] Add shared helpers to read, normalize, and atomically write each index.
-- [ ] Use the existing in-process queue and cross-process file locks.
-- [ ] Define one consistent lock order: entity record, entity index, then control state.
-- [ ] Add pure projection functions from each record to its index entry.
-- [ ] Update an index only when its projected value changes.
-- [ ] Write the record before the index so an observed index never points to a missing record.
-- [ ] Update the small control-state revision after record and index writes complete.
-- [ ] Keep unreadable records on disk and exclude them from rebuilt indexes.
+- [x] Add shared helpers to read, normalize, and atomically write each index.
+- [x] Use the existing in-process queue and cross-process file locks.
+- [x] Define one consistent lock order: entity record, entity index, then control state.
+- [x] Add pure projection functions from each record to its index entry.
+- [x] Update an index only when its projected value changes.
+- [x] Write the record before the index so an observed index never points to a missing record.
+- [x] Update the small control-state revision after record and index writes complete.
+- [x] Keep unreadable records on disk and exclude them from rebuilt indexes.
 
 ### Phase 3 — Runtime record stores
 
-- [ ] Change item writes and deletion to update `items/index.json` instead of the item array in `state.json`.
-- [ ] Change Design writes and deletion to update `designs/index.json`.
-- [ ] Keep every Design's variants and revision metadata in its single Design record.
-- [ ] Change Gallery writes and deletion to update `gallery/index.json`.
-- [ ] Keep every Gallery family's version metadata in its single family record.
-- [ ] Change job writes, retention, dismissal, and recovery to update `jobs/index.json`.
-- [ ] Persist one record per export and update `exports/index.json`.
-- [ ] Remove startup work that rebuilds entity arrays inside `state.json`.
-- [ ] Retain a deliberate full index-rebuild operation for migration and repair.
+- [x] Change item writes and deletion to update `items/index.json` instead of the item array in `state.json`.
+- [x] Change Design writes and deletion to update `designs/index.json`.
+- [x] Keep every Design's variants and revision metadata in its single Design record.
+- [x] Change Gallery writes and deletion to update `gallery/index.json`.
+- [x] Keep every Gallery family's version metadata in its single family record.
+- [x] Change job writes, retention, dismissal, and recovery to update `jobs/index.json`.
+- [x] Persist one record per export and update `exports/index.json`.
+- [x] Remove startup work that rebuilds entity arrays inside `state.json`.
+- [x] Retain a deliberate full index-rebuild operation for migration and repair.
 
 ### Phase 4 — Extension read and request paths
 
-- [ ] Audit every extension and runtime `readState()` call.
-- [ ] Read entity lists from their indexes.
-- [ ] Read full entity details from their records.
-- [ ] Keep mutation tools as intent writers through the existing request queue.
-- [ ] Remove assumptions that all items, Designs, Gallery families, jobs, or exports are present in control state.
-- [ ] Keep duplicate detection authoritative against item records or a normalized item-index field.
+- [x] Audit every extension and runtime `readState()` call.
+- [x] Read entity lists from their indexes.
+- [x] Read full entity details from their records.
+- [x] Keep mutation tools as intent writers through the existing request queue.
+- [x] Remove assumptions that all items, Designs, Gallery families, jobs, or exports are present in control state.
+- [x] Keep duplicate detection authoritative against item records or a normalized item-index field.
 
 ### Phase 5 — UI index subscriptions
 
-- [ ] Add a small local hook that reads and watches a JSON index through the existing app-state bridge.
-- [ ] Make the Library page consume `items/index.json`.
-- [ ] Make the Designs surfaces consume `designs/index.json`.
-- [ ] Make the Gallery page consume `gallery/index.json`.
-- [ ] Make job and export notifications consume their indexes or a bounded current notification projection.
-- [ ] Keep full item and Design detail reads on demand.
-- [ ] Ensure an index update does not reset local view state or selection.
-- [ ] Keep large grids incrementally or window rendered.
+- [x] Add a small local hook that reads and watches a JSON index through the existing app-state bridge.
+- [x] Make the Library page consume `items/index.json`.
+- [x] Make the Designs surfaces consume `designs/index.json`.
+- [x] Make the Gallery page consume `gallery/index.json`.
+- [x] Make job and export notifications consume their indexes or a bounded current notification projection.
+- [x] Keep full item and Design detail reads on demand.
+- [x] Ensure an index update does not reset local view state or selection.
+- [x] Keep large grids incrementally or window rendered.
 
 ### Phase 6 — High-level search and filters
 
-- [ ] Remove `searchText` from the item index type and projection.
-- [ ] Search title, file name, primary style, tags, and Design types directly.
-- [ ] Preserve case-insensitive, partial, all-terms matching.
-- [ ] Keep scope, structured filters, and sorting behavior unchanged.
-- [ ] Keep every tag in the index while limiting only card presentation.
-- [ ] Update the search placeholder to **Search titles, styles, tags or files**.
-- [ ] Update tests that currently expect notes or analysis to be searchable.
-- [ ] Add explicit tests that notes, prompts, and detailed analysis are not index search fields.
+- [x] Remove `searchText` from the item index type and projection.
+- [x] Search title, file name, primary style, tags, and Design types directly.
+- [x] Preserve case-insensitive, partial, all-terms matching.
+- [x] Keep scope, structured filters, and sorting behavior unchanged.
+- [x] Keep every tag in the index while limiting only card presentation.
+- [x] Update the search placeholder to **Search titles, styles, tags or files**.
+- [x] Update tests that currently expect notes or analysis to be searchable.
+- [x] Add explicit tests that notes, prompts, and detailed analysis are not index search fields.
 
 ### Phase 7 — Automatic migration
 
-- [ ] Detect a legacy state that contains entity arrays.
-- [ ] Build normalized indexes from the authoritative record files.
-- [ ] Create export records for legacy exports that exist only in state.
-- [ ] Preserve collections and bounded settings without data loss.
-- [ ] Write all record and index files before switching to version 2 control state.
-- [ ] Preserve the old state as `state.json.pre-index-backup` before the final switch.
-- [ ] Make migration safe to retry after interruption.
-- [ ] Do not move or duplicate original media and generated assets.
-- [ ] Report unreadable records without deleting them.
-- [ ] Do not run a full record scan on every normal startup after migration.
+- [x] Detect a legacy state that contains entity arrays.
+- [x] Build normalized indexes from the authoritative record files.
+- [x] Create export records for legacy exports that exist only in state.
+- [x] Preserve collections and bounded settings without data loss.
+- [x] Write all record and index files before switching to version 2 control state.
+- [x] Preserve the old state as `state.json.pre-index-backup` before the final switch.
+- [x] Make migration safe to retry after interruption.
+- [x] Do not move or duplicate original media and generated assets.
+- [x] Report unreadable records without deleting them.
+- [x] Do not run a full record scan on every normal startup after migration.
 
 ### Phase 8 — Tests and documentation
 
-- [ ] Add unit tests for every index normalizer and projection.
-- [ ] Add storage tests that prove one entity change does not rewrite unrelated entity records.
-- [ ] Add migration tests for items, Designs, Gallery families, jobs, exports, settings, collections, requests, and deleted records.
-- [ ] Add interruption tests for record, index, and final control-state writes.
-- [ ] Add restart tests for pending requests and active jobs.
-- [ ] Add search tests for all supported high-level fields and all excluded detailed fields.
-- [ ] Add filter and facet tests that include tags beyond the first six.
-- [ ] Add a generated fixture with at least 5,000 items and 1,000 Designs.
-- [ ] Verify that the large fixture does not add entity data to `state.json`.
-- [ ] Update the Design Library specification and first-release storage documentation.
-- [ ] Update the docs site only where user-visible search behavior is described.
+- [x] Add unit tests for every index normalizer and projection.
+- [x] Add storage tests that prove one entity change does not rewrite unrelated entity records.
+- [x] Add migration tests for items, Designs, Gallery families, jobs, exports, settings, collections, requests, and deleted records.
+- [x] Add interruption tests for record, index, and final control-state writes.
+- [x] Add restart tests for pending requests and active jobs.
+- [x] Add search tests for all supported high-level fields and all excluded detailed fields.
+- [x] Add filter and facet tests that include tags beyond the first six.
+- [x] Add a generated fixture with at least 5,000 items and 1,000 Designs.
+- [x] Verify that the large fixture does not add entity data to `state.json`.
+- [x] Update the Design Library specification and first-release storage documentation.
+- [x] Update the docs site only where user-visible search behavior is described.
 
 ### Phase 9 — Verification and delivery
 
-- [ ] Run the Design Library focused test suite.
-- [ ] Run the Design Library typecheck.
-- [ ] Run the Design Library build.
-- [ ] Run React Doctor after the React changes.
-- [ ] Run root `pnpm typecheck` before each commit.
-- [ ] Run `git diff --check`.
-- [ ] Check the line count of every touched source file.
-- [ ] Review the migrated example profile without changing its source data.
-- [ ] Commit each coherent phase with a Conventional Commit message.
-- [ ] Do not open a pull request until the specification and docs-site review are complete.
+- [x] Run the Design Library focused test suite.
+- [x] Run the Design Library typecheck.
+- [x] Run the Design Library build.
+- [x] Run React Doctor after the React changes.
+- [x] Run root `pnpm typecheck` before each commit.
+- [x] Run `git diff --check`.
+- [x] Check the line count of every touched source file.
+- [x] Review the migrated example profile without changing its source data.
+- [x] Commit each coherent phase with a Conventional Commit message.
+- [x] Do not open a pull request until the specification and docs-site review are complete.
 
 ## 5. Acceptance criteria
 
 ### Storage and compatibility
 
-- [ ] `state.json` contains no item, Design, Gallery, export, or job arrays after migration.
-- [ ] Adding entities does not increase `state.json` except for bounded revision and request data.
-- [ ] Every item has one complete item record.
-- [ ] Every Design has one complete Design record, including its variants and revision metadata.
-- [ ] Every Gallery family has one complete family record, including its version metadata.
-- [ ] Every job and export has one complete JSON record.
-- [ ] Original media, previews, generated files, and Gallery assets retain their current ownership and paths.
-- [ ] An existing profile migrates automatically without losing records, settings, collections, requests, deletion state, or asset references.
-- [ ] A failed or interrupted migration leaves the legacy state usable and can be retried.
+- [x] `state.json` contains no item, Design, Gallery, export, or job arrays after migration.
+- [x] Adding entities does not increase `state.json` except for bounded revision and request data.
+- [x] Every item has one complete item record.
+- [x] Every Design has one complete Design record, including its variants and revision metadata.
+- [x] Every Gallery family has one complete family record, including its version metadata.
+- [x] Every job and export has one complete JSON record.
+- [x] Original media, previews, generated files, and Gallery assets retain their current ownership and paths.
+- [x] An existing profile migrates automatically without losing records, settings, collections, requests, deletion state, or asset references.
+- [x] A failed or interrupted migration leaves the legacy state usable and can be retried.
 
 ### Index behavior
 
-- [ ] Each entity index contains only normalized list data for that entity type.
-- [ ] No index contains notes, prompts, guardrails, detailed Librarian analysis, generated source, or binary data.
-- [ ] `items/index.json` contains all tags required by filters and facets.
-- [ ] A record change updates its own record and relevant index without rewriting unrelated entity records.
-- [ ] A corrupt record is reported and skipped without preventing other entities from loading.
-- [ ] Normal startup reads the indexes and does not rebuild them from every record.
+- [x] Each entity index contains only normalized list data for that entity type.
+- [x] No index contains notes, prompts, guardrails, detailed Librarian analysis, generated source, or binary data.
+- [x] `items/index.json` contains all tags required by filters and facets.
+- [x] A record change updates its own record and relevant index without rewriting unrelated entity records.
+- [x] A corrupt record is reported and skipped without preventing other entities from loading.
+- [x] Normal startup reads the indexes and does not rebuild them from every record.
 
 ### Search and filters
 
-- [ ] Search matches title, original file name, primary style, tags, and Design types.
-- [ ] Search is case-insensitive and supports partial terms.
-- [ ] Every query term must match at least one supported field.
-- [ ] Search combines correctly with scopes, filters, and sorting.
-- [ ] Search does not match notes, summaries, prompts, guardrails, or detailed analysis.
-- [ ] The search placeholder describes the supported fields accurately.
-- [ ] Existing media, style, tag, colour, source, status, date, favourite, collection, recent, awaiting, and trash filters keep their behavior.
+- [x] Search matches title, original file name, primary style, tags, and Design types.
+- [x] Search is case-insensitive and supports partial terms.
+- [x] Every query term must match at least one supported field.
+- [x] Search combines correctly with scopes, filters, and sorting.
+- [x] Search does not match notes, summaries, prompts, guardrails, or detailed analysis.
+- [x] The search placeholder describes the supported fields accurately.
+- [x] Existing media, style, tag, colour, source, status, date, favourite, collection, recent, awaiting, and trash filters keep their behavior.
 
 ### Scale and responsiveness
 
-- [ ] A fixture with 5,000 items and 1,000 Designs loads from compact indexes without loading every full record into the renderer.
-- [ ] Search, filters, facets, and sorting return correct results for the large fixture.
-- [ ] Opening one item or Design reads only its full record and required assets.
-- [ ] Updating view preferences rewrites only the small control state.
-- [ ] Updating one item does not broadcast every full item or Design record.
-- [ ] The rendered grid remains bounded as the index grows.
+- [x] A fixture with 5,000 items and 1,000 Designs loads from compact indexes without loading every full record into the renderer.
+- [x] Search, filters, facets, and sorting return correct results for the large fixture.
+- [x] Opening one item or Design reads only its full record and required assets.
+- [x] Updating view preferences rewrites only the small control state.
+- [x] Updating one item does not broadcast every full item or Design record.
+- [x] The rendered grid remains bounded as the index grows.
 
 ### Quality gates
 
-- [ ] All focused tests pass.
-- [ ] Plugin typecheck and build pass.
-- [ ] React Doctor has no unresolved regression caused by this work.
-- [ ] Root `pnpm typecheck` passes before every commit.
-- [ ] Every touched source file remains below 500 lines.
-- [ ] Documentation matches the implemented storage and search behavior.
+- [x] All focused tests pass.
+- [x] Plugin typecheck and build pass.
+- [x] React Doctor has no unresolved regression caused by this work.
+- [x] Root `pnpm typecheck` passes before every commit.
+- [x] Every touched source file remains below 500 lines.
+- [x] Documentation matches the implemented storage and search behavior.
 
 ## 6. Deferred decisions
 

--- a/docs/plans/sero-design-library-json-state-scalability-plan.md
+++ b/docs/plans/sero-design-library-json-state-scalability-plan.md
@@ -180,12 +180,15 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Prune orphan revision directories for Designs listed in `designs/index.json` at startup.
 - [x] Persist one record per export and update `exports/index.json`.
 - [x] Mark exports left running by a restart as interrupted before export pruning runs.
+- [x] Keep an unconsumed export request for idempotent replay when terminal-state persistence fails.
+- [x] Report unreadable export records and leave their index entries untouched during recovery.
 - [x] Select the latest export by its creation time, independent of index file order.
 - [x] Keep only the 20 newest export records and index entries.
 - [x] Remove startup work that rebuilds entity arrays inside `state.json`.
 - [x] Retain a deliberate full index-rebuild operation for migration and repair.
 - [x] Let the agent schedule a full authoritative index repair for the next startup.
 - [x] Stop an automatic full repair after three failed starts and let a new repair request reset the attempts.
+- [x] Report scheduled and retired full-repair status through the settings tool.
 
 ### Phase 4 — Extension read and request paths
 

--- a/docs/plans/sero-design-library-json-state-scalability-plan.md
+++ b/docs/plans/sero-design-library-json-state-scalability-plan.md
@@ -181,6 +181,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Keep only the 20 newest export records and index entries.
 - [x] Remove startup work that rebuilds entity arrays inside `state.json`.
 - [x] Retain a deliberate full index-rebuild operation for migration and repair.
+- [x] Let the agent schedule a full authoritative index repair for the next startup.
 
 ### Phase 4 — Extension read and request paths
 

--- a/docs/plans/sero-design-library-json-state-scalability-plan.md
+++ b/docs/plans/sero-design-library-json-state-scalability-plan.md
@@ -164,6 +164,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Add pure projection functions from each record to its index entry.
 - [x] Update an index only when its projected value changes.
 - [x] Write the record before the index so an observed index never points to a missing record.
+- [x] Journal each item, Design, Gallery, and export projection before its record changes, then replay only interrupted projections at startup.
 - [x] Update the small control-state revision after record and index writes complete.
 - [x] Keep unreadable records on disk and exclude them from rebuilt indexes.
 
@@ -177,6 +178,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 - [x] Change job writes, retention, dismissal, and recovery to update `jobs/index.json`.
 - [x] Prune orphan revision directories for Designs listed in `designs/index.json` at startup.
 - [x] Persist one record per export and update `exports/index.json`.
+- [x] Keep only the 20 newest export records and index entries.
 - [x] Remove startup work that rebuilds entity arrays inside `state.json`.
 - [x] Retain a deliberate full index-rebuild operation for migration and repair.
 
@@ -203,6 +205,7 @@ The renderer can search and filter the compact item index in memory. Do not add 
 ### Phase 6 — High-level search and filters
 
 - [x] Remove `searchText` from the item index type and projection.
+- [x] Cache normalized search text per in-memory item and parse query terms once per selection.
 - [x] Search title, file name, primary style, tags, and Design types directly.
 - [x] Preserve case-insensitive, partial, all-terms matching.
 - [x] Keep scope, structured filters, and sorting behavior unchanged.

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -521,7 +521,7 @@ The plugin exposes its tools to the main Sero agent via `sero.plugin.bridgeTools
 
 `state.json` holds bounded control state only: schema and detail revisions, settings, media options, view preferences, collections and the transient request queue. The saved Library query is part of the bounded view preferences, so it returns after restart and the agent can set it.
 
-Each top-level entity has one complete JSON record. Items and Designs use one `record.json` in each entity directory. Gallery families use one `record.json` with their version metadata. Jobs and exports use one JSON file per record. Each entity type also has one compact `index.json` for list rendering, filters and high-level search. Binary assets, generated source, previews and Gallery snapshots stay outside these JSON files and keep their existing paths.
+Each top-level entity has one complete JSON record. Items and Designs use one `record.json` in each entity directory. Gallery families use one `record.json` with their version metadata. Jobs and exports use one JSON file per record. Export history keeps the 20 newest records. Each entity type also has one compact `index.json` for list rendering, filters and high-level search. Binary assets, generated source, previews and Gallery snapshots stay outside these JSON files and keep their existing paths.
 
 Version 2 migrates legacy entity arrays automatically. It builds indexes from authoritative records, creates records for legacy exports, preserves settings, collections and pending requests, and saves the old control document as `state.json.pre-index-backup` before the final switch. Unreadable records stay on disk and are omitted from rebuilt indexes. Normal startup reads the indexes and does not scan every record.
 
@@ -533,7 +533,7 @@ Ownership rules:
 - Designs own their media until promotion; Library promotion creates a new independent asset.
 - Permanent deletion of a source leaves tombstoned provenance behind.
 
-Atomic file replacement is required but is **not** sufficient concurrency control: Pi tool calls run in a separate process from the host runtime, so writes need an in-process queue, a cross-process lock and control-state revision checks. Indexes are pure projections of records and can be rebuilt deliberately for migration or repair.
+Atomic file replacement is required but is **not** sufficient concurrency control: Pi tool calls run in a separate process from the host runtime, so writes need an in-process queue, a cross-process lock and control-state revision checks. Item, Design, Gallery and export writes create a small repair marker before the record changes and clear it only after the index and control-state revision are durable. Startup replays these exact interrupted projections without scanning every record. Indexes are pure projections of records and can also be rebuilt deliberately for migration or repair.
 
 ---
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -203,7 +203,7 @@ The generated profile supplies a baseline for every editable field; the Libraria
 
 ### 5.5 Finding things
 
-Keyword search covers title, tags, notes and all user-visible analysis. Filters: media type, style, colour, tags, source, analysis status and date.
+Keyword search covers titles, original file names, primary styles, tags and Design types. It is case-insensitive, accepts partial matches and requires every query term to match one of those fields. It does not search notes, prompts, guardrails or detailed Librarian analysis. Filters: media type, style, colour, tags, source, analysis status and date.
 
 ### 5.6 Deletion
 
@@ -519,17 +519,21 @@ The plugin exposes its tools to the main Sero agent via `sero.plugin.bridgeTools
 
 ## 12. Storage and ownership
 
-Reactive state holds lightweight summaries only — item, Design, family, version and job summaries; search, filter and page preferences; generation defaults; schema version and state revision. Full records and binaries are plugin-owned files under the resolved global app state directory.
+`state.json` holds bounded control state only: schema and detail revisions, settings, media options, view preferences, collections and the transient request queue. Search text is local to the open Library view and is not persisted.
+
+Each top-level entity has one complete JSON record. Items and Designs use one `record.json` in each entity directory. Gallery families use one `record.json` with their version metadata. Jobs and exports use one JSON file per record. Each entity type also has one compact `index.json` for list rendering, filters and high-level search. Binary assets, generated source, previews and Gallery snapshots stay outside these JSON files and keep their existing paths.
+
+Version 2 migrates legacy entity arrays automatically. It builds indexes from authoritative records, creates records for legacy exports, preserves settings, collections and pending requests, and saves the old control document as `state.json.pre-index-backup` before the final switch. Unreadable records stay on disk and are omitted from rebuilt indexes. Normal startup reads the indexes and does not scan every record.
 
 Ownership rules:
 
-- One authoritative serialisation path per mutable record and per index.
+- One authoritative serialisation path per mutable record and per index. Writers lock and write in record, index, control-state order.
 - The background runtime is the single authoritative writer. Extension tools submit intent; they never write records.
 - Gallery versions own immutable copies of everything they need.
 - Designs own their media until promotion; Library promotion creates a new independent asset.
 - Permanent deletion of a source leaves tombstoned provenance behind.
 
-Atomic file replacement is required but is **not** sufficient concurrency control: Pi tool calls run in a separate process from the host runtime, so writes need a cross-process lock plus a revision compare-and-swap. The index is a pure projection of the records, which is what makes an interrupted index write recoverable.
+Atomic file replacement is required but is **not** sufficient concurrency control: Pi tool calls run in a separate process from the host runtime, so writes need an in-process queue, a cross-process lock and control-state revision checks. Indexes are pure projections of records and can be rebuilt deliberately for migration or repair.
 
 ---
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -519,7 +519,7 @@ The plugin exposes its tools to the main Sero agent via `sero.plugin.bridgeTools
 
 ## 12. Storage and ownership
 
-`state.json` holds bounded control state only: schema and detail revisions, settings, media options, view preferences, collections and the transient request queue. Search text is local to the open Library view and is not persisted.
+`state.json` holds bounded control state only: schema and detail revisions, settings, media options, view preferences, collections and the transient request queue. The saved Library query is part of the bounded view preferences, so it returns after restart and the agent can set it.
 
 Each top-level entity has one complete JSON record. Items and Designs use one `record.json` in each entity directory. Gallery families use one `record.json` with their version metadata. Jobs and exports use one JSON file per record. Each entity type also has one compact `index.json` for list rendering, filters and high-level search. Binary assets, generated source, previews and Gallery snapshots stay outside these JSON files and keep their existing paths.
 

--- a/docs/specs/sero-design-library-plugin-spec.md
+++ b/docs/specs/sero-design-library-plugin-spec.md
@@ -523,7 +523,7 @@ The plugin exposes its tools to the main Sero agent via `sero.plugin.bridgeTools
 
 Each top-level entity has one complete JSON record. Items and Designs use one `record.json` in each entity directory. Gallery families use one `record.json` with their version metadata. Jobs and exports use one JSON file per record. Export history keeps the 20 newest records. Each entity type also has one compact `index.json` for list rendering, filters and high-level search. Binary assets, generated source, previews and Gallery snapshots stay outside these JSON files and keep their existing paths.
 
-Version 2 migrates legacy entity arrays automatically. It builds indexes from authoritative records, creates records for legacy exports, preserves settings, collections and pending requests, and saves the old control document as `state.json.pre-index-backup` before the final switch. Unreadable records stay on disk and are omitted from rebuilt indexes. Normal startup reads the indexes and does not scan every record.
+Version 2 migrates legacy entity arrays automatically. It builds indexes from authoritative records, creates records for legacy exports, preserves settings, collections and pending requests, and saves the old control document as `state.json.pre-index-backup` before the final switch. Unreadable records stay on disk and are omitted from rebuilt indexes. Normal startup reads the indexes and does not scan every record. The settings tool can schedule a full authoritative repair for the next startup when damage did not produce a repair marker.
 
 Ownership rules:
 

--- a/docs/testing/design-library-first-release-acceptance.md
+++ b/docs/testing/design-library-first-release-acceptance.md
@@ -38,3 +38,9 @@ Active workspace: `orchestrator-demo-1`
 | External plugin uninstalls and the built-in source registration restores cleanly | Pass |
 
 The external-install pass first caught a stale package built before the active-workspace fix. The package was rebuilt and the full install and export pass then succeeded. This proves the release package, not only the source checkout.
+
+## Current storage model
+
+The first-release entity summaries moved out of `state.json` in schema version 2. Items, Designs, Gallery families, jobs and exports now have compact `index.json` files beside their complete per-entity records. `state.json` contains only bounded settings, preferences, collections, revision data and the transient request queue.
+
+An existing profile migrates automatically. Sero builds indexes from authoritative records, creates records for legacy exports, and keeps `state.json.pre-index-backup` before it writes version 2 control state. Media, generated files and Gallery snapshot paths do not move.

--- a/plugins/sero-design-library-plugin/extension/tools/analysis.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/analysis.ts
@@ -2,8 +2,10 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
+import { readIndex } from '../../shared/index-storage';
+import { normalizeItemIndex, normalizeJobIndex } from '../../shared/indexes';
 import type { DesignLibraryPaths } from '../../shared/paths';
-import { appendRequest, readState } from '../../shared/state-io';
+import { appendRequest } from '../../shared/state-io';
 import { checkId, failure, text, type ToolResult } from './result';
 
 /**
@@ -28,8 +30,11 @@ export function registerAnalysisTool(pi: ExtensionAPI, paths: DesignLibraryPaths
     }),
     async execute(_toolCallId, params): Promise<ToolResult> {
       if (params.action === 'status') {
-        const state = await readState(paths);
-        const live = state.items.filter((item) => item.deletedAt === undefined);
+        const [items, jobs] = await Promise.all([
+          readIndex(paths.itemsIndexFile, normalizeItemIndex),
+          readIndex(paths.jobsIndexFile, normalizeJobIndex),
+        ]);
+        const live = items.filter((item) => item.deletedAt === undefined);
         const counts = live.reduce<Record<string, number>>((totals, item) => {
           totals[item.analysisStatus] = (totals[item.analysisStatus] ?? 0) + 1;
           return totals;
@@ -39,7 +44,7 @@ export function registerAnalysisTool(pi: ExtensionAPI, paths: DesignLibraryPaths
           .join(', ');
         return text(
           live.length === 0 ? 'The Library is empty.' : `${live.length} references: ${summary}.`,
-          { counts, jobs: state.jobs },
+          { counts, jobs },
         );
       }
 

--- a/plugins/sero-design-library-plugin/extension/tools/designs.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/designs.test.ts
@@ -10,7 +10,7 @@ import {
   revisionDir,
   type DesignLibraryPaths,
 } from '../../shared/paths';
-import { readState } from '../../shared/state-io';
+import { readStateWithIndexes } from '../../shared/state-io';
 import { createDesign } from '../../runtime/designs';
 import { mutateVariant } from '../../runtime/design-store';
 import { seedItem } from '../../runtime/test-fixtures';
@@ -62,7 +62,7 @@ describe('refusing to start a Design', () => {
     const result = await call({ ...CREATE, referenceItemIds: ['../../..'] });
 
     expect(textOf(result)).toContain('not a valid item id');
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
   });
 
   it('rejects a traversal in a design id', async () => {
@@ -88,7 +88,7 @@ describe('refusing to start a Design', () => {
     const result = await call({ ...CREATE, referenceItemIds: ['itm-ready', 'itm-waiting'] });
 
     expect(textOf(result)).toContain('itm-waiting');
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
   });
 
   it('names a reference that does not exist', async () => {
@@ -117,7 +117,7 @@ describe('refusing to start a Design', () => {
 
     const blocked = await call({ ...CREATE, referenceItemIds: ['itm-a', 'itm-b'] });
     expect(textOf(blocked)).toContain('Resolve these guardrail conflicts first');
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
 
     const allowed = await call({
       ...CREATE,
@@ -223,7 +223,7 @@ describe('queuing work on a Design', () => {
     });
 
     expect((result.details as { variantCount?: number }).variantCount).toBe(2);
-    const [request] = (await readState(paths)).requests;
+    const [request] = (await readStateWithIndexes(paths)).requests;
     expect(request?.body).toMatchObject({ kind: 'design.create' });
   });
 
@@ -233,7 +233,7 @@ describe('queuing work on a Design', () => {
 
     await call({ ...CREATE, referenceItemIds: ['itm-b', 'itm-a'] });
 
-    const [request] = (await readState(paths)).requests;
+    const [request] = (await readStateWithIndexes(paths)).requests;
     expect(request?.body).toMatchObject({ referenceItemIds: ['itm-b', 'itm-a'] });
   });
 
@@ -247,7 +247,7 @@ describe('queuing work on a Design', () => {
       galleryParentVersionId: 'ver-1',
     });
 
-    const [request] = (await readState(paths)).requests;
+    const [request] = (await readStateWithIndexes(paths)).requests;
     expect(request?.body).toMatchObject({
       kind: 'design.create',
       galleryLineage: {
@@ -267,7 +267,7 @@ describe('queuing work on a Design', () => {
     });
 
     expect(textOf(result)).toContain('joins this variant');
-    const [request] = (await readState(paths)).requests;
+    const [request] = (await readStateWithIndexes(paths)).requests;
     expect(request?.body).toEqual({
       kind: 'design.revise-variant',
       designId: 'dsn-1',
@@ -285,7 +285,7 @@ describe('queuing work on a Design', () => {
       instruction: '   ',
     });
     expect(textOf(empty)).toContain('needs an instruction');
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
 
     await call({
       action: 'revise-variant',
@@ -295,7 +295,7 @@ describe('queuing work on a Design', () => {
     });
     // The default is the generation setting, so an agent that does not care gets
     // the behaviour the user last chose rather than one this tool invented.
-    expect((await readState(paths)).requests[0]?.body).toMatchObject({ behaviour: 'replace' });
+    expect((await readStateWithIndexes(paths)).requests[0]?.body).toMatchObject({ behaviour: 'replace' });
   });
 
   it('rejects an unsafe revision id before queuing a tweak', async () => {
@@ -310,7 +310,7 @@ describe('queuing work on a Design', () => {
       });
       expect(textOf(result), action).toContain('not a valid revision id');
     }
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
   });
 
   it('queues a tweak against the revision it belongs to', async () => {
@@ -323,7 +323,7 @@ describe('queuing work on a Design', () => {
       value: '20',
     });
 
-    const [request] = (await readState(paths)).requests;
+    const [request] = (await readStateWithIndexes(paths)).requests;
     expect(request?.body).toEqual({
       kind: 'design.set-tweak',
       designId: 'dsn-1',
@@ -337,7 +337,7 @@ describe('queuing work on a Design', () => {
   it('queues a retry that names one variant only', async () => {
     await call({ action: 'retry-variant', designId: 'dsn-1', variantId: 'var-1' });
 
-    const [request] = (await readState(paths)).requests;
+    const [request] = (await readStateWithIndexes(paths)).requests;
     expect(request?.body).toEqual({
       kind: 'design.retry-variant',
       designId: 'dsn-1',

--- a/plugins/sero-design-library-plugin/extension/tools/designs.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/designs.ts
@@ -4,6 +4,9 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
+import { readIndex } from '../../shared/index-storage';
+import { normalizeDesignIndex } from '../../shared/indexes';
+
 import type { DesignBrief, DesignRecord } from '../../shared/design';
 import { MAX_REFERENCES, MAX_VARIANTS, MIN_VARIANTS, plannedVariantCount } from '../../shared/design';
 import { normalizeDesignBrief, normalizeDesignRecord } from '../../shared/design-normalize';
@@ -221,8 +224,7 @@ export function registerDesignTool(pi: ExtensionAPI, paths: DesignLibraryPaths):
 
       switch (params.action) {
         case 'list': {
-          const state = await readState(paths);
-          const designs = state.designs.filter(
+          const designs = (await readIndex(paths.designsIndexFile, normalizeDesignIndex)).filter(
             (design) => params.includeDeleted === true || design.deletedAt === undefined,
           );
           if (designs.length === 0) return text('No designs yet.', { designs: [] });

--- a/plugins/sero-design-library-plugin/extension/tools/export.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/export.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-agent';
 
 import { designLibraryPathsFromHome, galleryVersionRecordFile, type DesignLibraryPaths } from '../../shared/paths';
-import { readState, updateState, writeJsonFile } from '../../shared/state-io';
+import { readStateWithIndexes, writeJsonFile } from '../../shared/state-io';
 import { registerExportTool } from './export';
 
 let home: string;
@@ -54,7 +54,7 @@ describe('Design Library export tool', () => {
       action: 'run', familyId: 'fam-1', versionId: 'ver-1', destination: 'workspace',
       workspacePath: '/workspace',
     });
-    const request = (await readState(paths)).requests[0];
+    const request = (await readStateWithIndexes(paths)).requests[0];
 
     expect(result.details).toEqual({ exportId: expect.any(String) });
     expect(request?.body).toMatchObject({
@@ -69,17 +69,14 @@ describe('Design Library export tool', () => {
     });
 
     expect(resultText(result)).toContain('downloads');
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
   });
 
   it('reports the latest export status', async () => {
-    await updateState(paths, (state) => ({
-      ...state,
-      exports: [{
+    await writeJsonFile(paths.exportsIndexFile, [{
         id: 'exp-1', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
         status: 'succeeded', createdAt: 1, completedAt: 2, path: '/Downloads/signal',
-      }],
-    }));
+    }]);
 
     const result = await call({ action: 'status' });
     expect(resultText(result)).toContain('/Downloads/signal');

--- a/plugins/sero-design-library-plugin/extension/tools/export.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/export.test.ts
@@ -74,11 +74,14 @@ describe('Design Library export tool', () => {
 
   it('reports the latest export status', async () => {
     await writeJsonFile(paths.exportsIndexFile, [{
+        id: 'exp-2', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+        status: 'succeeded', createdAt: 2, completedAt: 3, path: '/Downloads/latest',
+      }, {
         id: 'exp-1', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
         status: 'succeeded', createdAt: 1, completedAt: 2, path: '/Downloads/signal',
-    }]);
+      }]);
 
     const result = await call({ action: 'status' });
-    expect(resultText(result)).toContain('/Downloads/signal');
+    expect(resultText(result)).toContain('/Downloads/latest');
   });
 });

--- a/plugins/sero-design-library-plugin/extension/tools/export.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/export.ts
@@ -4,11 +4,13 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
+import { readIndex } from '../../shared/index-storage';
+import { normalizeExportIndex } from '../../shared/indexes';
 import { isExportDestination } from '../../shared/export';
 import { normalizeGalleryVersion } from '../../shared/gallery';
 import type { DesignLibraryPaths } from '../../shared/paths';
 import { galleryVersionRecordFile } from '../../shared/paths';
-import { appendRequest, readJsonFile, readState } from '../../shared/state-io';
+import { appendRequest, readJsonFile } from '../../shared/state-io';
 import { checkId, failure, text, type ToolResult } from './result';
 
 const ACTIONS = ['run', 'status'] as const;
@@ -33,11 +35,11 @@ export function registerExportTool(pi: ExtensionAPI, paths: DesignLibraryPaths):
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, context): Promise<ToolResult> {
       if (params.action === 'status') {
-        const state = await readState(paths);
+        const exports = await readIndex(paths.exportsIndexFile, normalizeExportIndex);
         const selected = params.exportId
-          ? state.exports.find((entry) => entry.id === params.exportId)
-          : state.exports.at(-1);
-        if (!selected) return text('No exports have run yet.', { exports: state.exports });
+          ? exports.find((entry) => entry.id === params.exportId)
+          : exports.at(-1);
+        if (!selected) return text('No exports have run yet.', { exports });
         return text(
           selected.status === 'succeeded'
             ? `Exported to ${selected.path}.`

--- a/plugins/sero-design-library-plugin/extension/tools/export.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/export.ts
@@ -6,7 +6,7 @@ import { Type } from 'typebox';
 
 import { readIndex } from '../../shared/index-storage';
 import { normalizeExportIndex } from '../../shared/indexes';
-import { isExportDestination } from '../../shared/export';
+import { isExportDestination, type ExportSummary } from '../../shared/export';
 import { normalizeGalleryVersion } from '../../shared/gallery';
 import type { DesignLibraryPaths } from '../../shared/paths';
 import { galleryVersionRecordFile } from '../../shared/paths';
@@ -18,6 +18,14 @@ const DESTINATIONS = ['downloads', 'workspace'] as const;
 
 function required(value: string | undefined, label: string): { id: string } | { error: ToolResult } {
   return checkId(value, label);
+}
+
+function latestExport(exports: ExportSummary[]): ExportSummary | undefined {
+  let latest: ExportSummary | undefined;
+  for (const entry of exports) {
+    if (latest === undefined || entry.createdAt > latest.createdAt) latest = entry;
+  }
+  return latest;
 }
 
 export function registerExportTool(pi: ExtensionAPI, paths: DesignLibraryPaths): void {
@@ -38,7 +46,7 @@ export function registerExportTool(pi: ExtensionAPI, paths: DesignLibraryPaths):
         const exports = await readIndex(paths.exportsIndexFile, normalizeExportIndex);
         const selected = params.exportId
           ? exports.find((entry) => entry.id === params.exportId)
-          : exports.at(-1);
+          : latestExport(exports);
         if (!selected) return text('No exports have run yet.', { exports });
         return text(
           selected.status === 'succeeded'

--- a/plugins/sero-design-library-plugin/extension/tools/gallery.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/gallery.ts
@@ -6,11 +6,13 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
+import { readIndex } from '../../shared/index-storage';
+import { normalizeGalleryIndex } from '../../shared/indexes';
 import { normalizeGalleryVersion } from '../../shared/gallery';
 import { normalizeDesignRecord } from '../../shared/design-normalize';
 import type { DesignLibraryPaths } from '../../shared/paths';
 import { designRecordFile, galleryVersionDir, galleryVersionRecordFile } from '../../shared/paths';
-import { appendRequest, readJsonFile, readState } from '../../shared/state-io';
+import { appendRequest, readJsonFile } from '../../shared/state-io';
 import { readUploadManifest } from '../../shared/uploads';
 import { checkId, failure, image, text, type ToolResult } from './result';
 
@@ -53,8 +55,7 @@ export function registerGalleryTool(pi: ExtensionAPI, paths: DesignLibraryPaths)
     }),
     async execute(_toolCallId, params): Promise<ToolResult> {
       if (params.action === 'list') {
-        const state = await readState(paths);
-        const families = state.galleryFamilies.filter(
+        const families = (await readIndex(paths.galleryIndexFile, normalizeGalleryIndex)).filter(
           (family) => params.includeDeleted === true || family.deletedAt === undefined,
         );
         return text(
@@ -76,7 +77,7 @@ export function registerGalleryTool(pi: ExtensionAPI, paths: DesignLibraryPaths)
         if ('error' in revision) return revision.error;
         const upload = required(params.previewUploadId, 'preview upload id');
         if ('error' in upload) return upload.error;
-        const state = await readState(paths);
+        const families = await readIndex(paths.galleryIndexFile, normalizeGalleryIndex);
         const record = normalizeDesignRecord(
           await readJsonFile<unknown>(designRecordFile(paths, design.id)),
         );
@@ -88,7 +89,7 @@ export function registerGalleryTool(pi: ExtensionAPI, paths: DesignLibraryPaths)
         if (!preview?.complete || preview.purpose !== 'gallery-preview') {
           return failure('The Gallery preview upload is incomplete.');
         }
-        const familyId = record.galleryFamilyId ?? state.galleryFamilies.find(
+        const familyId = record.galleryFamilyId ?? families.find(
           (family) => family.sourceDesignId === design.id,
         )?.id ?? randomUUID();
         const versionId = randomUUID();

--- a/plugins/sero-design-library-plugin/extension/tools/items.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/items.ts
@@ -4,6 +4,8 @@ import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
+import { readIndex } from '../../shared/index-storage';
+import { normalizeItemIndex } from '../../shared/indexes';
 import {
   effectiveAnalysis,
   isLibrarianField,
@@ -115,7 +117,7 @@ export function registerItemTool(pi: ExtensionAPI, paths: DesignLibraryPaths): v
     parameters: Type.Object({
       action: StringEnum(ACTIONS, { description: 'Which item operation to perform' }),
       itemId: Type.Optional(Type.String()),
-      query: Type.Optional(Type.String({ description: 'Keyword search over titles, tags, notes and analysis' })),
+      query: Type.Optional(Type.String({ description: 'Search titles, file names, styles, tags and Design types' })),
       limit: Type.Optional(Type.Number({ description: 'Maximum results for `search` (default 20)' })),
       field: Type.Optional(Type.String({ description: 'Analysis field name for set-field/reset-field' })),
       value: Type.Optional(Type.Unknown({ description: 'New value for set-field; must match the field type' })),
@@ -140,8 +142,8 @@ export function registerItemTool(pi: ExtensionAPI, paths: DesignLibraryPaths): v
 
       switch (params.action) {
         case 'search': {
-          const state = await readState(paths);
-          const matched = selectItems(state.items, {
+          const items = await readIndex(paths.itemsIndexFile, normalizeItemIndex);
+          const matched = selectItems(items, {
             scope: { kind: 'all' },
             query: params.query ?? '',
             filters: EMPTY_FILTERS,
@@ -151,7 +153,7 @@ export function registerItemTool(pi: ExtensionAPI, paths: DesignLibraryPaths): v
           if (limited.length === 0) return text('No references matched.', { items: [] });
           return text(
             `${matched.length} reference${matched.length === 1 ? '' : 's'} matched:\n${limited.map(describe).join('\n')}`,
-            { items: limited, facets: deriveFacets(state.items) },
+            { items: limited, facets: deriveFacets(items) },
           );
         }
 
@@ -221,9 +223,10 @@ export function registerItemTool(pi: ExtensionAPI, paths: DesignLibraryPaths): v
 
         case 'collections': {
           const state = await readState(paths);
+          const items = await readIndex(paths.itemsIndexFile, normalizeItemIndex);
           if (state.collections.length === 0) return text('No collections yet.', { collections: [] });
           const counts = new Map<string, number>();
-          for (const item of state.items) {
+          for (const item of items) {
             if (item.deletedAt !== undefined) continue;
             for (const id of item.collectionIds) counts.set(id, (counts.get(id) ?? 0) + 1);
           }

--- a/plugins/sero-design-library-plugin/extension/tools/media.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/media.test.ts
@@ -9,7 +9,7 @@ import { deleteAsset, recordAttempt, reserveAsset } from '../../runtime/media/as
 import { seedDesign, seedItem } from '../../runtime/test-fixtures';
 import { assetReferenceFor } from '../../shared/media';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../../shared/paths';
-import { readState } from '../../shared/state-io';
+import { readStateWithIndexes } from '../../shared/state-io';
 import { registerMediaTool } from './media';
 
 /**
@@ -45,7 +45,7 @@ function textOf(result: { content: Array<{ type: string }> }): string {
 }
 
 async function requests() {
-  return (await readState(paths)).requests.map((request) => request.body);
+  return (await readStateWithIndexes(paths)).requests.map((request) => request.body);
 }
 
 beforeEach(async () => {

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -7,7 +7,7 @@ import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-age
 
 import type { MediaModelCatalog } from '../../shared/media-model-catalog';
 import { designLibraryPathsFromHome, secretsFile, type DesignLibraryPaths } from '../../shared/paths';
-import { readStateWithIndexes } from '../../shared/state-io';
+import { readStateWithIndexes, writeJsonFile } from '../../shared/state-io';
 import { registerSettingsTool } from './settings';
 
 /**
@@ -168,10 +168,12 @@ describe('saved view preferences', () => {
 
 describe('index repair', () => {
   it('lets the agent schedule a full repair for the next restart', async () => {
+    await writeJsonFile(paths.repairFailedFile, { attempts: 3 });
     const result = await call({ action: 'repair-indexes' });
 
     expect(textOf(result)).toContain('next Sero restart');
     expect(await readFile(paths.repairRequestFile, 'utf8')).toContain('requestedAt');
+    await expect(readFile(paths.repairFailedFile, 'utf8')).rejects.toThrow();
     expect((await readStateWithIndexes(paths)).requests).toEqual([]);
   });
 });

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -7,7 +7,7 @@ import type { ExtensionAPI, ToolDefinition } from '@earendil-works/pi-coding-age
 
 import type { MediaModelCatalog } from '../../shared/media-model-catalog';
 import { designLibraryPathsFromHome, secretsFile, type DesignLibraryPaths } from '../../shared/paths';
-import { readState } from '../../shared/state-io';
+import { readStateWithIndexes } from '../../shared/state-io';
 import { registerSettingsTool } from './settings';
 
 /**
@@ -84,7 +84,7 @@ describe('the provider key', () => {
     expect(JSON.stringify(stored)).not.toContain(SECRET);
     // The whole state file, not just the requests: a key that reached any part
     // of it would be readable by the UI.
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     expect(JSON.stringify(state)).not.toContain(SECRET);
     expect(state.requests).toEqual([]);
     // It did get saved, though — in the file that is not reactive state.
@@ -132,7 +132,7 @@ describe('media settings', () => {
   it('sets one capability’s model without disturbing the others', async () => {
     await call({ action: 'set-media-model', capability: 'text-to-video', mediaModel: 'fast-video' });
 
-    const [queued] = (await readState(paths)).requests;
+    const [queued] = (await readStateWithIndexes(paths)).requests;
     expect(queued?.body).toMatchObject({
       kind: 'settings.update',
       patch: { media: { models: { 'text-to-video': 'fast-video' } } },
@@ -146,10 +146,10 @@ describe('media settings', () => {
   it('keeps the per-run cap inside its range', async () => {
     expect(textOf(await call({ action: 'set-media-cap', callsPerRun: -1 }))).toContain('must be 0');
     expect(textOf(await call({ action: 'set-media-cap', callsPerRun: 999 }))).toContain('must be 0');
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
 
     await call({ action: 'set-media-cap', callsPerRun: 3 });
-    expect((await readState(paths)).requests[0]?.body).toMatchObject({
+    expect((await readStateWithIndexes(paths)).requests[0]?.body).toMatchObject({
       patch: { media: { callsPerRun: 3 } },
     });
   });

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -175,5 +175,35 @@ describe('index repair', () => {
     expect(await readFile(paths.repairRequestFile, 'utf8')).toContain('requestedAt');
     await expect(readFile(paths.repairFailedFile, 'utf8')).rejects.toThrow();
     expect((await readStateWithIndexes(paths)).requests).toEqual([]);
+
+    const status = await call({ action: 'read' });
+    expect(textOf(status)).toContain('Index repair: scheduled');
+    expect(status.details).toMatchObject({
+      indexRepair: { status: 'scheduled', attempts: 0 },
+    });
+  });
+
+  it('reports a repair that stopped after its retry limit', async () => {
+    await writeJsonFile(paths.repairFailedFile, {
+      requestedAt: 1,
+      attempts: 3,
+      failedAt: 2,
+      error: 'The index file is not writable.',
+    });
+
+    const result = await call({ action: 'read' });
+
+    expect(textOf(result)).toContain(
+      'Index repair: stopped after 3 attempts — The index file is not writable.',
+    );
+    expect(result.details).toMatchObject({
+      indexRepair: {
+        status: 'failed',
+        requestedAt: 1,
+        attempts: 3,
+        failedAt: 2,
+        error: 'The index file is not writable.',
+      },
+    });
   });
 });

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -165,3 +165,13 @@ describe('saved view preferences', () => {
     });
   });
 });
+
+describe('index repair', () => {
+  it('lets the agent schedule a full repair for the next restart', async () => {
+    const result = await call({ action: 'repair-indexes' });
+
+    expect(textOf(result)).toContain('next Sero restart');
+    expect(await readFile(paths.repairRequestFile, 'utf8')).toContain('requestedAt');
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
+  });
+});

--- a/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.test.ts
@@ -154,3 +154,14 @@ describe('media settings', () => {
     });
   });
 });
+
+describe('saved view preferences', () => {
+  it('lets the agent set the Library query', async () => {
+    await call({ action: 'set-view', view: { query: 'editorial grid' } });
+
+    expect((await readStateWithIndexes(paths)).requests[0]?.body).toEqual({
+      kind: 'view.set',
+      patch: { query: 'editorial grid' },
+    });
+  });
+});

--- a/plugins/sero-design-library-plugin/extension/tools/settings.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.ts
@@ -10,7 +10,7 @@ import { MEDIA_CAPABILITIES, type MediaCapability } from '../../shared/media';
 import type { DesignLibraryPaths } from '../../shared/paths';
 import type { DesignLibrarySettings, PromptRecipe } from '../../shared/settings';
 import { MAX_CALLS_PER_RUN } from '../../shared/settings';
-import { appendRequest, readState } from '../../shared/state-io';
+import { appendRequest, readState, writeJsonFile } from '../../shared/state-io';
 import type { ViewPatch } from '../../shared/types';
 import { createFalMediaModelCatalog } from '../fal-media-model-catalog';
 import { failure, text, type ToolResult } from './result';
@@ -21,11 +21,11 @@ import { failure, text, type ToolResult } from './result';
  * Model selections are provider + model pairs, and an empty pair means "use
  * Sero's configured model" — the same default the model picker shows.
  *
- * The three key actions are the exception to everything else in this file: they
- * call `shared/credentials` directly instead of appending a request. A request
- * is a line in `state.json`, which the UI reads, so routing a key through it
- * would put the key in reactive state — the one thing §8.3 forbids. What comes
- * back out is `env | stored | missing` and never the key itself.
+ * The key actions call `shared/credentials` directly instead of appending a
+ * request. A request is a line in `state.json`, which the UI reads, so routing a
+ * key through it would put the key in reactive state — the one thing §8.3
+ * forbids. The repair action also writes a separate marker because the runtime
+ * must see it before normal work starts on the next launch.
  */
 
 const ACTIONS = [
@@ -42,6 +42,7 @@ const ACTIONS = [
   'key-status',
   'store-key',
   'clear-key',
+  'repair-indexes',
 ] as const;
 
 const MODEL_ROLES = ['librarian', 'design'] as const;
@@ -78,7 +79,7 @@ export function registerSettingsTool(
   pi.registerTool({
     name: 'design_library_settings',
     label: 'Design Library Settings',
-    description: 'Read and update Design Library settings: model choices, generation defaults and prompt recipes.',
+    description: 'Read and update Design Library settings, or schedule an index repair.',
     parameters: Type.Object({
       action: StringEnum(ACTIONS, { description: 'Which settings operation to perform' }),
       role: Type.Optional(StringEnum(MODEL_ROLES, { description: 'Which model to set' })),
@@ -117,6 +118,11 @@ export function registerSettingsTool(
       switch (params.action) {
         case 'read':
           return renderSettings(settings);
+
+        case 'repair-indexes': {
+          await writeJsonFile(paths.repairRequestFile, { requestedAt: Date.now() });
+          return text('A full index repair is scheduled for the next Sero restart.');
+        }
 
         case 'set-model': {
           if (!params.role) return failure('`set-model` needs role: librarian or design.');

--- a/plugins/sero-design-library-plugin/extension/tools/settings.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { rm } from 'node:fs/promises';
 
 import { StringEnum } from '@earendil-works/pi-ai';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
@@ -121,6 +122,7 @@ export function registerSettingsTool(
 
         case 'repair-indexes': {
           await writeJsonFile(paths.repairRequestFile, { requestedAt: Date.now() });
+          await rm(paths.repairFailedFile, { force: true });
           return text('A full index repair is scheduled for the next Sero restart.');
         }
 

--- a/plugins/sero-design-library-plugin/extension/tools/settings.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/settings.ts
@@ -6,12 +6,18 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
 import { clearFalKey, falKeyStatus, storeFalKey } from '../../shared/credentials';
+import {
+  normalizeFailedIndexRepair,
+  normalizeFullIndexRepairRequest,
+  type FailedIndexRepair,
+  type FullIndexRepairRequest,
+} from '../../shared/index-repair';
 import type { MediaModelCatalog } from '../../shared/media-model-catalog';
 import { MEDIA_CAPABILITIES, type MediaCapability } from '../../shared/media';
 import type { DesignLibraryPaths } from '../../shared/paths';
 import type { DesignLibrarySettings, PromptRecipe } from '../../shared/settings';
 import { MAX_CALLS_PER_RUN } from '../../shared/settings';
-import { appendRequest, readState, writeJsonFile } from '../../shared/state-io';
+import { appendRequest, readJsonFile, readState, writeJsonFile } from '../../shared/state-io';
 import type { ViewPatch } from '../../shared/types';
 import { createFalMediaModelCatalog } from '../fal-media-model-catalog';
 import { failure, text, type ToolResult } from './result';
@@ -54,7 +60,36 @@ const KEY_STATUS_TEXT: Record<string, string> = {
   missing: 'No provider key — generation will fail until one is set.',
 };
 
-function renderSettings(settings: DesignLibrarySettings): ToolResult {
+type IndexRepairStatus =
+  | { status: 'idle' }
+  | ({ status: 'scheduled' } & FullIndexRepairRequest)
+  | ({ status: 'failed' } & FailedIndexRepair);
+
+async function readIndexRepairStatus(paths: DesignLibraryPaths): Promise<IndexRepairStatus> {
+  const scheduled = normalizeFullIndexRepairRequest(
+    await readJsonFile<unknown>(paths.repairRequestFile),
+  );
+  if (scheduled) return { status: 'scheduled', ...scheduled };
+  const failed = normalizeFailedIndexRepair(
+    await readJsonFile<unknown>(paths.repairFailedFile),
+  );
+  return failed ? { status: 'failed', ...failed } : { status: 'idle' };
+}
+
+function repairStatusText(status: IndexRepairStatus): string {
+  if (status.status === 'scheduled') {
+    return `Index repair: scheduled (${status.attempts} of 3 attempts used)`;
+  }
+  if (status.status === 'failed') {
+    return `Index repair: stopped after ${status.attempts} attempts — ${status.error}`;
+  }
+  return 'Index repair: not scheduled';
+}
+
+function renderSettings(
+  settings: DesignLibrarySettings,
+  indexRepair: IndexRepairStatus,
+): ToolResult {
   const model = (selection: { providerId: string; modelId: string }) =>
     selection.modelId === '' ? "Sero's configured model" : `${selection.providerId}/${selection.modelId}`;
   const lines = [
@@ -64,12 +99,13 @@ function renderSettings(settings: DesignLibrarySettings): ToolResult {
     `Revision behaviour: ${settings.generation.revisionBehaviour}`,
     `Prompt recipes: ${settings.generation.recipes.map((recipe) => recipe.name).join(', ') || 'none'}`,
     `Media calls per run: ${settings.media.callsPerRun}`,
+    repairStatusText(indexRepair),
     ...MEDIA_CAPABILITIES.map(
       (capability) =>
         `Media model (${capability}): ${settings.media.models[capability] || "the adapter's default"}`,
     ),
   ];
-  return text(lines.join('\n'), { settings });
+  return text(lines.join('\n'), { settings, indexRepair });
 }
 
 export function registerSettingsTool(
@@ -118,7 +154,7 @@ export function registerSettingsTool(
 
       switch (params.action) {
         case 'read':
-          return renderSettings(settings);
+          return renderSettings(settings, await readIndexRepairStatus(paths));
 
         case 'repair-indexes': {
           await writeJsonFile(paths.repairRequestFile, { requestedAt: Date.now() });

--- a/plugins/sero-design-library-plugin/extension/tools/tools.test.ts
+++ b/plugins/sero-design-library-plugin/extension/tools/tools.test.ts
@@ -9,7 +9,7 @@ import { recordAttempt, reserveAsset } from '../../runtime/media/assets';
 import { seedDesign } from '../../runtime/test-fixtures';
 import type { MediaAttempt } from '../../shared/media';
 import { designAssetDir, designLibraryPathsFromHome, type DesignLibraryPaths } from '../../shared/paths';
-import { readState } from '../../shared/state-io';
+import { readStateWithIndexes } from '../../shared/state-io';
 import { UPLOAD_CHUNK_BYTES } from '../../shared/uploads';
 import { registerAssetTool } from './assets';
 import { registerItemTool } from './items';
@@ -145,7 +145,7 @@ describe('the item tool refuses unsafe ids', () => {
 
   it('queues nothing when an id is refused', async () => {
     await call('design_library_items', { action: 'purge', itemId: TRAVERSAL });
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
   });
 });
 
@@ -158,7 +158,7 @@ describe('the item tool validates field values', () => {
       value: 99,
     });
     expect(textOf(result)).toContain('`tags` expects an array of strings');
-    expect((await readState(paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(paths)).requests).toEqual([]);
   });
 
   it('rejects an unknown field name', async () => {
@@ -178,7 +178,7 @@ describe('the item tool validates field values', () => {
       field: 'tags',
       value: ['dense', 'editorial'],
     });
-    const [request] = (await readState(paths)).requests;
+    const [request] = (await readStateWithIndexes(paths)).requests;
     expect(request?.body).toMatchObject({ kind: 'item.set-field', field: 'tags' });
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/coordinator-context.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-context.ts
@@ -1,0 +1,17 @@
+import type { AppRuntimeHost } from '@sero-ai/common';
+
+import type { DesignLibraryPaths } from '../shared/paths';
+import type { ExportRequests } from './export-requests';
+import type { MediaQueueContext } from './media/queue';
+
+export interface CoordinatorContext {
+  host: AppRuntimeHost;
+  paths: DesignLibraryPaths;
+  workspaceId: string;
+  sessionId: string;
+  onError(message: string, error: unknown): void;
+  /** Test and fault-injection seam; defaults to the shipped fal adapter. */
+  createMediaProvider?: MediaQueueContext['createProvider'];
+  /** Test seam for export persistence failures. */
+  exportRequests?: Pick<ExportRequests, 'apply'>;
+}

--- a/plugins/sero-design-library-plugin/runtime/coordinator-designs.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-designs.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { DesignBrief } from '../shared/design';
-import { appendRequest, readState } from '../shared/state-io';
+import { appendRequest, readStateWithIndexes } from '../shared/state-io';
 import { useCoordinator } from './coordinator-harness';
 
 const harness = useCoordinator('coordinator-designs');
@@ -29,7 +29,7 @@ describe('starting a Design', () => {
     });
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.designs.map((design) => design.id)).toEqual(['dsn-1']);
     expect(state.designs[0]?.variants).toHaveLength(2);
     expect(state.view.selectedDesignId).toBe('dsn-1');
@@ -60,7 +60,7 @@ describe('starting a Design', () => {
     await strict.dispose();
 
     expect(failures.some((message) => message.includes('design.create'))).toBe(true);
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.designs).toEqual([]);
     expect(state.collections.map((entry) => entry.name)).toEqual(['Still applied']);
   });
@@ -81,7 +81,7 @@ describe('starting a Design', () => {
     await appendRequest(harness.paths, { kind: 'design.delete', designId: 'dsn-1' });
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.designs[0]?.deletedAt).toBeDefined();
     expect(state.view.selectedDesignId).toBeUndefined();
   });

--- a/plugins/sero-design-library-plugin/runtime/coordinator-harness.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-harness.ts
@@ -15,6 +15,7 @@ import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/p
 import { appendRequest, readStateWithIndexes } from '../shared/state-io';
 import { beginUpload, completeUpload, writeUploadChunk } from '../shared/uploads';
 import { Coordinator } from './coordinator';
+import type { CoordinatorContext } from './coordinator-context';
 import { invokeTool } from './librarian/test-support';
 import { createFakeProvider, type FakeProviderOptions } from './media/providers/fake';
 import { readItem } from './store';
@@ -37,6 +38,11 @@ export interface CoordinatorHarness {
   importAndAnalyse(uploadId: string, fileName: string, content: string): Promise<string>;
   /** A second coordinator over the same storage, with error reporting captured. */
   withErrors(failures: string[]): Coordinator;
+  /** A second coordinator with injected export persistence behavior. */
+  withExportRequests(
+    exportRequests: NonNullable<CoordinatorContext['exportRequests']>,
+    failures: string[],
+  ): Coordinator;
 }
 
 export const ANALYSIS_REPLY = JSON.stringify({
@@ -295,6 +301,16 @@ export function useCoordinator(label: string, options: HarnessOptions = {}): Coo
         workspaceId: 'ws',
         sessionId: 'session',
         onError: (message) => failures.push(message),
+      });
+    },
+    withExportRequests(exportRequests, failures) {
+      return new Coordinator({
+        host: { subagents: { runStructured } } as unknown as AppRuntimeHost,
+        paths,
+        workspaceId: 'ws',
+        sessionId: 'session',
+        onError: (message) => failures.push(message),
+        exportRequests,
       });
     },
   };

--- a/plugins/sero-design-library-plugin/runtime/coordinator-harness.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-harness.ts
@@ -12,7 +12,7 @@ import {
   hasBaselineTweakPrefix,
 } from '../shared/baseline-tweaks';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
-import { appendRequest, readState } from '../shared/state-io';
+import { appendRequest, readStateWithIndexes } from '../shared/state-io';
 import { beginUpload, completeUpload, writeUploadChunk } from '../shared/uploads';
 import { Coordinator } from './coordinator';
 import { invokeTool } from './librarian/test-support';
@@ -277,7 +277,7 @@ export function useCoordinator(label: string, options: HarnessOptions = {}): Coo
       await upload(uploadId, fileName, content);
       await appendRequest(paths, { kind: 'ingest', uploadId });
       await coordinator.drain();
-      const state = await readState(paths);
+      const state = await readStateWithIndexes(paths);
       const itemId = state.items[state.items.length - 1]!.id;
       await vi.waitFor(async () => {
         expect((await readItem(paths, itemId))?.analysis.status).toBe('ready');

--- a/plugins/sero-design-library-plugin/runtime/coordinator-media.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-media.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { currentAttempt } from '../shared/media';
-import { appendRequest, readState } from '../shared/state-io';
+import { appendRequest, readStateWithIndexes } from '../shared/state-io';
 
 import { useCoordinator } from './coordinator-harness';
 import { readDesign } from './design-store';
@@ -188,7 +188,7 @@ describe('copy to library', () => {
     await appendRequest(harness.paths, copy);
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     // One item, not two: the recorded item id is what refuses the second copy.
     expect(state.items.filter((item) => item.sourceKind === 'generated')).toHaveLength(1);
   });
@@ -205,7 +205,7 @@ describe('generating into the Library', () => {
     await harness.coordinator.drain();
 
     const itemId = await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       const generated = state.items.find((item) => item.sourceKind === 'generated');
       expect(generated).toBeDefined();
       return generated!.id;
@@ -255,7 +255,7 @@ describe('generating into the Library', () => {
     await harness.coordinator.drain();
 
     await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       expect(state.items.filter((item) => item.sourceKind === 'generated')).toHaveLength(1);
     });
   });
@@ -274,9 +274,9 @@ describe('video confirmation', () => {
     await harness.coordinator.drain();
 
     await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.target.kind === 'library')?.status).toBe('failed');
     });
-    expect((await readState(harness.paths)).items).toEqual([]);
+    expect((await readStateWithIndexes(harness.paths)).items).toEqual([]);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/coordinator-video.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator-video.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { appendRequest, readState } from '../shared/state-io';
+import { appendRequest, readStateWithIndexes } from '../shared/state-io';
 import { beginUpload, completeUpload, writeUploadChunk } from '../shared/uploads';
 import { useCoordinator } from './coordinator-harness';
 import { readItem } from './store';
@@ -34,7 +34,7 @@ describe('a generated video', () => {
     await harness.coordinator.drain();
 
     const itemId = await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       const generated = state.items.find((item) => item.kind === 'video');
       expect(generated).toBeDefined();
       return generated!.id;
@@ -59,7 +59,7 @@ describe('a generated video', () => {
     await harness.coordinator.drain();
 
     const generated = await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       const item = state.items.find((entry) => entry.sourceKind === 'derived');
       expect(item).toBeDefined();
       return readItem(harness.paths, item!.id);
@@ -81,7 +81,7 @@ describe('a generated video', () => {
     await harness.coordinator.drain();
 
     const itemId = await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       const generated = state.items.find((item) => item.kind === 'video');
       expect(generated).toBeDefined();
       return generated!.id;
@@ -141,13 +141,13 @@ describe('a video model that only makes long clips', () => {
     await longOnly.coordinator.drain();
 
     await vi.waitFor(async () => {
-      const state = await readState(longOnly.paths);
+      const state = await readStateWithIndexes(longOnly.paths);
       const job = state.jobs.find((entry) => entry.status === 'failed');
       expect(job?.error).toContain('shorter');
     });
 
     // Nothing was made and nothing was charged for.
-    const state = await readState(longOnly.paths);
+    const state = await readStateWithIndexes(longOnly.paths);
     expect(state.items).toHaveLength(0);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/coordinator.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator.test.ts
@@ -274,6 +274,37 @@ describe('request consumption', () => {
     expect(harness.runStructured).toHaveBeenCalledTimes(1);
     expect((await readStateWithIndexes(harness.paths)).items).toHaveLength(1);
   });
+
+  it('retains an export request until its terminal state is durable', async () => {
+    const failures: string[] = [];
+    const apply = vi.fn()
+      .mockRejectedValueOnce(new Error('export record lock timed out'))
+      .mockResolvedValueOnce(undefined);
+    const retrying = harness.withExportRequests({ apply }, failures);
+    await appendRequest(harness.paths, {
+      kind: 'export.run',
+      exportId: 'exp-retry',
+      familyId: 'fam-1',
+      versionId: 'ver-1',
+      destination: 'downloads',
+    });
+
+    try {
+      await retrying.drain();
+      const retained = await readStateWithIndexes(harness.paths);
+      expect(retained.requests.map((request) => request.body.kind)).toEqual(['export.run']);
+      expect(retained.consumedRequestId).toBe(0);
+
+      await retrying.drain();
+      const recovered = await readStateWithIndexes(harness.paths);
+      expect(recovered.requests).toEqual([]);
+      expect(recovered.consumedRequestId).toBe(1);
+      expect(apply).toHaveBeenCalledTimes(2);
+      expect(failures).toEqual(['Request 1 (export.run) failed']);
+    } finally {
+      await retrying.dispose();
+    }
+  });
 });
 
 describe('field validation', () => {

--- a/plugins/sero-design-library-plugin/runtime/coordinator.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator.test.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { describe, expect, it, vi } from 'vitest';
 
 import { tombstoneFile } from '../shared/paths';
-import { appendRequest, readState, updateState } from '../shared/state-io';
+import { appendRequest, readStateWithIndexes, updateState } from '../shared/state-io';
 import type { AppRuntimeSubagentRunParams } from '@sero-ai/common';
 
 import { ANALYSIS_REPLY, useCoordinator, viewReference } from './coordinator-harness';
@@ -29,7 +29,7 @@ describe('applying requests', () => {
     await harness.importAndAnalyse('u1', 'a.png', 'first');
     await harness.importAndAnalyse('u2', 'b.png', 'second');
 
-    expect((await readState(harness.paths)).view.selectedItemId).toBeUndefined();
+    expect((await readStateWithIndexes(harness.paths)).view.selectedItemId).toBeUndefined();
   });
 
   it('opens the existing item when a duplicate is imported', async () => {
@@ -39,7 +39,7 @@ describe('applying requests', () => {
     await appendRequest(harness.paths, { kind: 'ingest', uploadId: 'u2' });
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.items).toHaveLength(1);
     expect(state.view.selectedItemId).toBe(first);
   });
@@ -61,14 +61,14 @@ describe('applying requests', () => {
       expect((await readItem(harness.paths, itemId))?.analysis.attempts).toBe(2);
     });
 
-    const summary = (await readState(harness.paths)).items.find((entry) => entry.id === itemId);
+    const summary = (await readStateWithIndexes(harness.paths)).items.find((entry) => entry.id === itemId);
     expect(summary?.primaryStyle).toBe('My own style');
     expect(summary?.edited).toBe(true);
 
     await appendRequest(harness.paths, { kind: 'item.reset-field', itemId, field: 'primaryStyle' });
     await harness.coordinator.drain();
 
-    const afterReset = (await readState(harness.paths)).items.find((entry) => entry.id === itemId);
+    const afterReset = (await readStateWithIndexes(harness.paths)).items.find((entry) => entry.id === itemId);
     expect(afterReset?.primaryStyle).toBe('Technical monochrome');
     expect(afterReset?.edited).toBe(false);
   });
@@ -78,7 +78,7 @@ describe('applying requests', () => {
     await appendRequest(harness.paths, { kind: 'item.favourite', itemId, favourite: true });
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.requests).toEqual([]);
     expect(state.consumedRequestId).toBeGreaterThan(0);
     expect(state.items[0].favourite).toBe(true);
@@ -115,7 +115,7 @@ describe('deletion', () => {
     await harness.coordinator.drain();
 
     expect(await readItem(harness.paths, itemId)).toBeNull();
-    expect((await readState(harness.paths)).items).toEqual([]);
+    expect((await readStateWithIndexes(harness.paths)).items).toEqual([]);
 
     const tombstone = JSON.parse(await readFile(tombstoneFile(harness.paths, itemId), 'utf8')) as {
       itemId: string;
@@ -133,12 +133,12 @@ describe('collections', () => {
     await appendRequest(harness.paths, { kind: 'collection.create', collectionId: 'c1', name: 'Dashboards', colour: 'primary' });
     await appendRequest(harness.paths, { kind: 'item.collect', itemId, collectionId: 'c1', member: true });
     await harness.coordinator.drain();
-    expect((await readState(harness.paths)).items[0].collectionIds).toEqual(['c1']);
+    expect((await readStateWithIndexes(harness.paths)).items[0].collectionIds).toEqual(['c1']);
 
     await appendRequest(harness.paths, { kind: 'collection.delete', collectionId: 'c1' });
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.collections).toEqual([]);
     expect(state.items).toHaveLength(1);
     expect(state.items[0].collectionIds).toEqual([]);
@@ -235,7 +235,7 @@ describe('request consumption', () => {
     await appendRequest(harness.paths, { kind: 'collection.create', collectionId: 'c2', name: 'Two', colour: 'primary' });
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.requests).toEqual([]);
     expect(state.consumedRequestId).toBe(state.nextRequestId - 1);
   });
@@ -246,7 +246,7 @@ describe('request consumption', () => {
     // Simulate the crash window: apply, then put the request back unconsumed.
     await appendRequest(harness.paths, { kind: 'item.favourite', itemId, favourite: true });
     await harness.coordinator.drain();
-    const applied = await readState(harness.paths);
+    const applied = await readStateWithIndexes(harness.paths);
     expect(applied.items[0].favourite).toBe(true);
 
     await updateState(harness.paths, (current) => ({
@@ -258,7 +258,7 @@ describe('request consumption', () => {
     }));
     await harness.coordinator.drain();
 
-    const replayed = await readState(harness.paths);
+    const replayed = await readStateWithIndexes(harness.paths);
     expect(replayed.items[0].favourite).toBe(true);
     expect(replayed.requests).toEqual([]);
   });
@@ -272,7 +272,7 @@ describe('request consumption', () => {
     await harness.coordinator.drain();
 
     expect(harness.runStructured).toHaveBeenCalledTimes(1);
-    expect((await readState(harness.paths)).items).toHaveLength(1);
+    expect((await readStateWithIndexes(harness.paths)).items).toHaveLength(1);
   });
 });
 
@@ -292,7 +292,7 @@ describe('field validation', () => {
     const item = await readItem(harness.paths, itemId);
     expect(item?.profile.overrides.tags).toBeUndefined();
     // The bad request is consumed rather than stalling the queue.
-    expect((await readState(harness.paths)).requests).toEqual([]);
+    expect((await readStateWithIndexes(harness.paths)).requests).toEqual([]);
   });
 });
 
@@ -304,7 +304,7 @@ describe('failure handling', () => {
     await appendRequest(harness.paths, { kind: 'ingest', uploadId: 'u1' });
     await harness.coordinator.drain();
 
-    const itemId = (await readState(harness.paths)).items[0].id;
+    const itemId = (await readStateWithIndexes(harness.paths)).items[0].id;
     await vi.waitFor(async () => {
       expect((await readItem(harness.paths, itemId))?.analysis.status).toBe('failed');
     });
@@ -314,7 +314,7 @@ describe('failure handling', () => {
     // Waited for rather than read once: the record is written before the index,
     // so a read taken the moment the record lands can precede the projection.
     await vi.waitFor(async () => {
-      const summary = (await readState(harness.paths)).items.find((entry) => entry.id === itemId);
+      const summary = (await readStateWithIndexes(harness.paths)).items.find((entry) => entry.id === itemId);
       expect(summary?.analysisError).toBe('provider exploded');
     });
   });
@@ -347,7 +347,7 @@ describe('failure handling', () => {
     });
     await harness.coordinator.drain();
 
-    const state = await readState(harness.paths);
+    const state = await readStateWithIndexes(harness.paths);
     expect(state.collections.map((entry) => entry.name)).toEqual(['Still applied']);
     expect(state.requests).toEqual([]);
   });

--- a/plugins/sero-design-library-plugin/runtime/coordinator.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator.ts
@@ -1,6 +1,7 @@
 import type { AppRuntimeHost } from '@sero-ai/common';
-
 import { clearOverride, effectiveField, setOverride, validateFieldValue } from '../shared/librarian';
+import { readIndex } from '../shared/index-storage';
+import { normalizeItemIndex } from '../shared/indexes';
 import type { DesignLibraryPaths } from '../shared/paths';
 import { tombstoneFile } from '../shared/paths';
 import type { JobKind, TombstonedProvenance } from '../shared/records';
@@ -25,7 +26,6 @@ import { MediaRequests, isMediaRequest } from './media/requests';
 import { GalleryRequests, isGalleryRequest } from './gallery-requests';
 import { ExportRequests, isExportRequest } from './export-requests';
 import { destroyItem, dismissJob, mutateItem, readItem, readJob, scanItems } from './store';
-
 /**
  * Applies intent submitted by extension tools.
  *
@@ -472,8 +472,8 @@ export class Coordinator {
 
   /** Deleting a collection drops the grouping, never the items inside it. */
   private async deleteCollection(collectionId: string): Promise<void> {
-    const state = await readState(this.context.paths);
-    const members = state.items.filter((item) => item.collectionIds.includes(collectionId));
+    const items = await readIndex(this.context.paths.itemsIndexFile, normalizeItemIndex);
+    const members = items.filter((item) => item.collectionIds.includes(collectionId));
     for (const member of members) {
       await mutateItem(this.context.paths, member.id, (item) => ({
         ...item,

--- a/plugins/sero-design-library-plugin/runtime/coordinator.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator.ts
@@ -1,8 +1,6 @@
-import type { AppRuntimeHost } from '@sero-ai/common';
 import { clearOverride, effectiveField, setOverride, validateFieldValue } from '../shared/librarian';
 import { readIndex } from '../shared/index-storage';
 import { normalizeItemIndex } from '../shared/indexes';
-import type { DesignLibraryPaths } from '../shared/paths';
 import { tombstoneFile } from '../shared/paths';
 import type { JobKind, TombstonedProvenance } from '../shared/records';
 import { itemTarget } from '../shared/records';
@@ -12,12 +10,13 @@ import type { MediaSettings } from '../shared/settings';
 import type { DesignLibraryState } from '../shared/types';
 import { applyViewPatch } from '../shared/types';
 import { AnalysisQueue } from './analysis-queue';
+import type { CoordinatorContext } from './coordinator-context';
 import { DesignRequests, isDesignRequest } from './design-requests';
 import { resumePendingVariants, startPendingVariants } from './designs';
 import { VariantQueue } from './generation/queue';
 import { ingestUpload } from './ingest';
 import { createJob, reconcileJobs, requestCancel } from './jobs';
-import { MediaQueue, type MediaQueueContext } from './media/queue';
+import { MediaQueue } from './media/queue';
 import { attachFrames } from './frames';
 import type { MediaProvider } from './media/contract';
 import { mediaModelsChanged, refreshMediaOptions } from './media/options';
@@ -36,16 +35,6 @@ import { destroyItem, dismissJob, mutateItem, readItem, readJob, scanItems } fro
  * time it is applied.
  */
 
-export interface CoordinatorContext {
-  host: AppRuntimeHost;
-  paths: DesignLibraryPaths;
-  workspaceId: string;
-  sessionId: string;
-  onError(message: string, error: unknown): void;
-  /** Test and fault-injection seam; defaults to the shipped fal adapter. */
-  createMediaProvider?: MediaQueueContext['createProvider'];
-}
-
 export class Coordinator {
   private readonly queue: AnalysisQueue;
   private readonly variants: VariantQueue;
@@ -53,12 +42,11 @@ export class Coordinator {
   private readonly mediaQueue: MediaQueue;
   private readonly media: MediaRequests;
   private readonly gallery: GalleryRequests;
-  private readonly exports: ExportRequests;
+  private readonly exports: Pick<ExportRequests, 'apply'>;
   private draining = false;
   private drainAgain = false;
   private readonly optionsRefreshes = new Set<Promise<void>>(); // Disposal waits for these writes.
   private readonly shutdown = new AbortController();
-
   constructor(private readonly context: CoordinatorContext) {
     const shared = {
       host: context.host,
@@ -84,7 +72,8 @@ export class Coordinator {
     });
     this.media = new MediaRequests(context.paths, this.mediaQueue);
     this.gallery = new GalleryRequests(context.paths);
-    this.exports = new ExportRequests(context.paths, context.host.workspace, context.onError);
+    this.exports = context.exportRequests ??
+      new ExportRequests(context.paths, context.host.workspace, context.onError);
   }
 
   /** Resume interrupted work, then apply anything queued while we were away. */
@@ -176,11 +165,18 @@ export class Coordinator {
     }
     this.draining = true;
     try {
-      do {
+      drainPass: do {
         this.drainAgain = false;
         const state = await readState(this.context.paths);
         for (const request of pendingRequests(state)) {
-          await this.applyOne(request);
+          const applied = await this.applyOne(request);
+          if (!applied) {
+            // A state change that arrived during the failed write earns one
+            // more pass. Without one, that already-delivered change could not
+            // trigger the retained request again.
+            if (this.drainAgain) continue drainPass;
+            return;
+          }
           await this.consume(request);
         }
       } while (this.drainAgain);
@@ -198,13 +194,17 @@ export class Coordinator {
     }));
   }
 
-  private async applyOne(request: LibraryRequest): Promise<void> {
+  private async applyOne(request: LibraryRequest): Promise<boolean> {
     try {
       await this.apply(request.body, request.id);
+      return true;
     } catch (error) {
-      // One bad request must not stall the whole queue, so it is reported and
-      // the watermark still advances past it.
       this.context.onError(`Request ${request.id} (${request.body.kind}) failed`, error);
+      // Export execution makes destination and build failures durable, so a
+      // throw here means persistence failed. Keep that request so the export
+      // can recover its output on the next state change or restart. Other bad
+      // requests still advance, so one invalid action cannot stall the queue.
+      return !isExportRequest(request.body);
     }
   }
 

--- a/plugins/sero-design-library-plugin/runtime/coordinator.ts
+++ b/plugins/sero-design-library-plugin/runtime/coordinator.ts
@@ -84,7 +84,7 @@ export class Coordinator {
     });
     this.media = new MediaRequests(context.paths, this.mediaQueue);
     this.gallery = new GalleryRequests(context.paths);
-    this.exports = new ExportRequests(context.paths, context.host.workspace);
+    this.exports = new ExportRequests(context.paths, context.host.workspace, context.onError);
   }
 
   /** Resume interrupted work, then apply anything queued while we were away. */

--- a/plugins/sero-design-library-plugin/runtime/design-store.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/design-store.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
-import { readState } from '../shared/state-io';
+import { readStateWithIndexes } from '../shared/state-io';
 import { createDesignRecord, mutateVariant, readDesign } from './design-store';
 import { createDesign } from './designs';
 import { TEST_BRIEF as BRIEF, seedItem } from './test-fixtures';
@@ -62,7 +62,7 @@ describe('the Design projection', () => {
       ],
     }));
 
-    const summary = (await readState(paths)).designs.find((entry) => entry.id === 'dsn-1');
+    const summary = (await readStateWithIndexes(paths)).designs.find((entry) => entry.id === 'dsn-1');
     const variant = summary?.variants[0];
     expect(variant?.previewPath).toBe(
       `designs/dsn-1/variants/${variantId}/rev-old/preview.html`,

--- a/plugins/sero-design-library-plugin/runtime/design-store.ts
+++ b/plugins/sero-design-library-plugin/runtime/design-store.ts
@@ -4,7 +4,9 @@ import type { DesignRecord, DesignVariant } from '../shared/design';
 import { normalizeDesignRecord } from '../shared/design-normalize';
 import type { DesignLibraryPaths } from '../shared/paths';
 import { designDir, designRecordFile, revisionDir, variantDir } from '../shared/paths';
-import { readJsonFile, updateState, withRecordLock, writeJsonFile } from '../shared/state-io';
+import { bumpControlRevision, updateIndex } from '../shared/index-storage';
+import { normalizeDesignIndex } from '../shared/indexes';
+import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io';
 import { projectDesign } from './projection';
 
 /**
@@ -56,10 +58,8 @@ async function writeDesign(
   const next: DesignRecord = { ...design, updatedAt: Date.now() };
   await writeJsonFile(designRecordFile(paths, next.id), next);
   const summary = projectDesign(next);
-  await updateState(paths, (current) => ({
-    ...current,
-    designs: [...current.designs.filter((entry) => entry.id !== next.id), summary],
-  }));
+  await updateIndex(paths, paths.designsIndexFile, normalizeDesignIndex, next.id, summary);
+  await bumpControlRevision(paths);
   return next;
 }
 
@@ -138,10 +138,8 @@ export async function mutateVariant(
 export async function destroyDesign(paths: DesignLibraryPaths, designId: string): Promise<void> {
   await withRecordLock(paths, designRecordFile(paths, designId), async () => {
     await rm(designDir(paths, designId), { recursive: true, force: true });
-    await updateState(paths, (current) => ({
-      ...current,
-      designs: current.designs.filter((entry) => entry.id !== designId),
-    }));
+    await updateIndex(paths, paths.designsIndexFile, normalizeDesignIndex, designId, null);
+    await bumpControlRevision(paths);
   });
 }
 

--- a/plugins/sero-design-library-plugin/runtime/design-store.ts
+++ b/plugins/sero-design-library-plugin/runtime/design-store.ts
@@ -4,6 +4,7 @@ import type { DesignRecord, DesignVariant } from '../shared/design';
 import { normalizeDesignRecord } from '../shared/design-normalize';
 import type { DesignLibraryPaths } from '../shared/paths';
 import { designDir, designRecordFile, revisionDir, variantDir } from '../shared/paths';
+import { withIndexRepair } from '../shared/index-repair';
 import { bumpControlRevision, readIndex, updateIndex } from '../shared/index-storage';
 import { normalizeDesignIndex } from '../shared/indexes';
 import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io';
@@ -56,10 +57,12 @@ async function writeDesign(
   design: DesignRecord,
 ): Promise<DesignRecord> {
   const next: DesignRecord = { ...design, updatedAt: Date.now() };
-  await writeJsonFile(designRecordFile(paths, next.id), next);
-  const summary = projectDesign(next);
-  await updateIndex(paths, paths.designsIndexFile, normalizeDesignIndex, next.id, summary);
-  await bumpControlRevision(paths);
+  await withIndexRepair(paths, 'designs', next.id, async () => {
+    await writeJsonFile(designRecordFile(paths, next.id), next);
+    const summary = projectDesign(next);
+    await updateIndex(paths, paths.designsIndexFile, normalizeDesignIndex, next.id, summary);
+    await bumpControlRevision(paths);
+  });
   return next;
 }
 
@@ -137,9 +140,11 @@ export async function mutateVariant(
 /** Permanent deletion of a Design and everything generated under it. */
 export async function destroyDesign(paths: DesignLibraryPaths, designId: string): Promise<void> {
   await withRecordLock(paths, designRecordFile(paths, designId), async () => {
-    await rm(designDir(paths, designId), { recursive: true, force: true });
-    await updateIndex(paths, paths.designsIndexFile, normalizeDesignIndex, designId, null);
-    await bumpControlRevision(paths);
+    await withIndexRepair(paths, 'designs', designId, async () => {
+      await rm(designDir(paths, designId), { recursive: true, force: true });
+      await updateIndex(paths, paths.designsIndexFile, normalizeDesignIndex, designId, null);
+      await bumpControlRevision(paths);
+    });
   });
 }
 

--- a/plugins/sero-design-library-plugin/runtime/design-store.ts
+++ b/plugins/sero-design-library-plugin/runtime/design-store.ts
@@ -4,7 +4,7 @@ import type { DesignRecord, DesignVariant } from '../shared/design';
 import { normalizeDesignRecord } from '../shared/design-normalize';
 import type { DesignLibraryPaths } from '../shared/paths';
 import { designDir, designRecordFile, revisionDir, variantDir } from '../shared/paths';
-import { bumpControlRevision, updateIndex } from '../shared/index-storage';
+import { bumpControlRevision, readIndex, updateIndex } from '../shared/index-storage';
 import { normalizeDesignIndex } from '../shared/indexes';
 import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io';
 import { projectDesign } from './projection';
@@ -170,6 +170,17 @@ export async function pruneOrphanRevisions(
       });
       removed += 1;
     }
+  }
+  return removed;
+}
+
+/** Clean only Designs named by the compact index, without a directory scan. */
+export async function pruneIndexedOrphanRevisions(paths: DesignLibraryPaths): Promise<number> {
+  const designs = await readIndex(paths.designsIndexFile, normalizeDesignIndex);
+  let removed = 0;
+  for (const summary of designs) {
+    const design = await readDesign(paths, summary.id);
+    if (design) removed += await pruneOrphanRevisions(paths, design);
   }
   return removed;
 }

--- a/plugins/sero-design-library-plugin/runtime/designs.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/designs.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { designLibraryPathsFromHome, revisionDir, type DesignLibraryPaths } from '../shared/paths';
-import { readState } from '../shared/state-io';
+import { readStateWithIndexes } from '../shared/state-io';
 import {
   mutateVariant,
   pruneOrphanRevisions,
@@ -154,7 +154,7 @@ describe('creating a Design', () => {
       resolutions: [],
     });
 
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     expect(state.designs).toHaveLength(1);
     expect(state.designs[0]?.title).toBe('A dense operational dashboard');
     expect(state.designs[0]?.referenceItemIds).toEqual(['itm-a']);

--- a/plugins/sero-design-library-plugin/runtime/designs.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/designs.test.ts
@@ -7,6 +7,7 @@ import { designLibraryPathsFromHome, revisionDir, type DesignLibraryPaths } from
 import { readStateWithIndexes } from '../shared/state-io';
 import {
   mutateVariant,
+  pruneIndexedOrphanRevisions,
   pruneOrphanRevisions,
   readDesign,
 } from './design-store';
@@ -364,5 +365,17 @@ describe('variant lifecycle', () => {
 
     await expect(access(revisionDir(paths, designId, variantId, 'rev-kept'))).resolves.toBeUndefined();
     await expect(access(revisionDir(paths, designId, variantId, 'rev-orphan'))).rejects.toThrow();
+  });
+
+  it('removes orphan revisions for Designs named by the index', async () => {
+    const designId = await seedDesign();
+    const design = await readDesign(paths, designId);
+    const variantId = design!.variants[0]!.id;
+    const orphan = revisionDir(paths, designId, variantId, 'rev-index-orphan');
+    await mkdir(orphan, { recursive: true });
+    await writeFile(path.join(orphan, 'index.html'), '<p>orphan</p>', 'utf8');
+
+    expect(await pruneIndexedOrphanRevisions(paths)).toBe(1);
+    await expect(access(orphan)).rejects.toThrow();
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
 
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
-import { readState } from '../shared/state-io';
+import { readStateWithIndexes } from '../shared/state-io';
 import { runGalleryExport } from './export';
 import { ExportRequests } from './export-requests';
 
@@ -42,7 +42,7 @@ describe('export request state', () => {
     vi.mocked(runGalleryExport).mockResolvedValue('/workspace/signal');
     await new ExportRequests(paths, workspaces).apply(REQUEST);
 
-    expect((await readState(paths)).exports[0]).toMatchObject({
+    expect((await readStateWithIndexes(paths)).exports[0]).toMatchObject({
       id: 'exp-1', status: 'succeeded', path: '/workspace/signal',
     });
   });
@@ -51,7 +51,7 @@ describe('export request state', () => {
     vi.mocked(runGalleryExport).mockRejectedValue(new Error('Snapshot is incomplete.'));
     await new ExportRequests(paths, workspaces).apply(REQUEST);
 
-    expect((await readState(paths)).exports[0]).toMatchObject({
+    expect((await readStateWithIndexes(paths)).exports[0]).toMatchObject({
       id: 'exp-1', status: 'failed', error: 'Snapshot is incomplete.',
     });
   });
@@ -63,7 +63,7 @@ describe('export request state', () => {
     });
 
     expect(runGalleryExport).not.toHaveBeenCalled();
-    expect((await readState(paths)).exports[0]).toMatchObject({
+    expect((await readStateWithIndexes(paths)).exports[0]).toMatchObject({
       status: 'failed', error: 'The requested export path is not inside an open workspace.',
     });
   });

--- a/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
@@ -7,7 +7,7 @@ import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
 import { designLibraryPathsFromHome, exportFile, type DesignLibraryPaths } from '../shared/paths';
 import { readStateWithIndexes, writeJsonFile } from '../shared/state-io';
 import { runGalleryExport } from './export';
-import { ExportRequests, pruneExportHistory } from './export-requests';
+import { ExportRequests, pruneExportHistory, reconcileExports } from './export-requests';
 
 vi.mock('./export', () => ({ runGalleryExport: vi.fn() }));
 
@@ -132,5 +132,45 @@ describe('export request state', () => {
 
     await expect(pruneExportHistory(paths, 0)).resolves.toBe(0);
     await expect(access(exportFile(paths, running.id))).resolves.toBeUndefined();
+  });
+
+  it('marks an export left running by a restart as failed before pruning', async () => {
+    const running = {
+      id: 'exp-interrupted', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'running', createdAt: 1,
+    } as const;
+    await Promise.all([
+      writeJsonFile(exportFile(paths, running.id), running),
+      writeJsonFile(paths.exportsIndexFile, [running]),
+    ]);
+
+    await expect(reconcileExports(paths, 10)).resolves.toBe(1);
+
+    const failed = (await readStateWithIndexes(paths)).exports[0];
+    expect(failed).toMatchObject({
+      id: running.id,
+      status: 'failed',
+      completedAt: 10,
+      error: 'The export was interrupted by a Sero restart.',
+    });
+    await expect(pruneExportHistory(paths, 0)).resolves.toBe(1);
+    await expect(access(exportFile(paths, running.id))).rejects.toThrow();
+  });
+
+  it('preserves a terminal record when its index still says running', async () => {
+    const running = {
+      id: 'exp-terminal', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'running', createdAt: 1,
+    } as const;
+    const succeeded = {
+      ...running, status: 'succeeded', completedAt: 2, path: '/tmp/export',
+    } as const;
+    await Promise.all([
+      writeJsonFile(exportFile(paths, running.id), succeeded),
+      writeJsonFile(paths.exportsIndexFile, [running]),
+    ]);
+
+    await expect(reconcileExports(paths, 10)).resolves.toBe(0);
+    expect((await readStateWithIndexes(paths)).exports).toEqual([succeeded]);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
@@ -56,6 +56,28 @@ describe('export request state', () => {
     });
   });
 
+  it('re-publishes a terminal record without running the export again', async () => {
+    const succeeded = {
+      id: REQUEST.exportId,
+      familyId: REQUEST.familyId,
+      versionId: REQUEST.versionId,
+      destination: REQUEST.destination,
+      status: 'succeeded',
+      createdAt: 1,
+      completedAt: 2,
+      path: '/workspace/existing',
+    } as const;
+    await Promise.all([
+      writeJsonFile(exportFile(paths, succeeded.id), succeeded),
+      writeJsonFile(paths.exportsIndexFile, [{ ...succeeded, status: 'running' }]),
+    ]);
+
+    await new ExportRequests(paths, workspaces).apply(REQUEST);
+
+    expect(runGalleryExport).not.toHaveBeenCalled();
+    expect((await readStateWithIndexes(paths)).exports).toEqual([succeeded]);
+  });
+
   it('refuses a workspace path that the host did not register', async () => {
     await new ExportRequests(paths, workspaces).apply({
       ...REQUEST,
@@ -144,7 +166,10 @@ describe('export request state', () => {
       writeJsonFile(paths.exportsIndexFile, [running]),
     ]);
 
-    await expect(reconcileExports(paths, 10)).resolves.toBe(1);
+    await expect(reconcileExports(paths, 10)).resolves.toEqual({
+      reconciled: 1,
+      unreadable: [],
+    });
 
     const failed = (await readStateWithIndexes(paths)).exports[0];
     expect(failed).toMatchObject({
@@ -170,7 +195,41 @@ describe('export request state', () => {
       writeJsonFile(paths.exportsIndexFile, [running]),
     ]);
 
-    await expect(reconcileExports(paths, 10)).resolves.toBe(0);
+    await expect(reconcileExports(paths, 10)).resolves.toEqual({
+      reconciled: 0,
+      unreadable: [],
+    });
     expect((await readStateWithIndexes(paths)).exports).toEqual([succeeded]);
+  });
+
+  it('leaves a pending export running so its idempotent request can resume', async () => {
+    const running = {
+      id: 'exp-pending', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'running', createdAt: 1,
+    } as const;
+    await Promise.all([
+      writeJsonFile(exportFile(paths, running.id), running),
+      writeJsonFile(paths.exportsIndexFile, [running]),
+    ]);
+
+    await expect(reconcileExports(paths, 10, new Set([running.id]))).resolves.toEqual({
+      reconciled: 0,
+      unreadable: [],
+    });
+    expect((await readStateWithIndexes(paths)).exports).toEqual([running]);
+  });
+
+  it('reports an unreadable export and leaves its index entry untouched', async () => {
+    const running = {
+      id: 'exp-unreadable', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'running', createdAt: 1,
+    } as const;
+    await writeJsonFile(paths.exportsIndexFile, [running]);
+
+    await expect(reconcileExports(paths, 10)).resolves.toEqual({
+      reconciled: 0,
+      unreadable: [running.id],
+    });
+    expect((await readStateWithIndexes(paths)).exports).toEqual([running]);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
@@ -5,9 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
 
 import { designLibraryPathsFromHome, exportFile, type DesignLibraryPaths } from '../shared/paths';
-import { readStateWithIndexes } from '../shared/state-io';
+import { readStateWithIndexes, writeJsonFile } from '../shared/state-io';
 import { runGalleryExport } from './export';
-import { ExportRequests } from './export-requests';
+import { ExportRequests, pruneExportHistory } from './export-requests';
 
 vi.mock('./export', () => ({ runGalleryExport: vi.fn() }));
 
@@ -80,5 +80,57 @@ describe('export request state', () => {
     expect(exports).toHaveLength(20);
     expect(exports.map((entry) => entry.id)).not.toContain('exp-0');
     await expect(access(exportFile(paths, 'exp-0'))).rejects.toThrow();
+  });
+
+  it('does not turn a successful export into a failure when cleanup fails', async () => {
+    vi.mocked(runGalleryExport).mockResolvedValue('/workspace/signal');
+    const onError = vi.fn();
+    const prune = vi.fn().mockRejectedValue(new Error('lock timed out'));
+
+    await new ExportRequests(paths, workspaces, onError, prune).apply(REQUEST);
+
+    expect(runGalleryExport).toHaveBeenCalledOnce();
+    expect((await readStateWithIndexes(paths)).exports[0]).toMatchObject({
+      status: 'succeeded', path: '/workspace/signal',
+    });
+    expect(onError).toHaveBeenCalledWith(
+      'Could not prune Design Library export history',
+      expect.objectContaining({ message: 'lock timed out' }),
+    );
+  });
+
+  it('keeps running exports and removes every terminal export when the maximum is zero', async () => {
+    const running = {
+      id: 'exp-running', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'running', createdAt: 1,
+    } as const;
+    const finished = {
+      id: 'exp-finished', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'succeeded', createdAt: 2, completedAt: 3, path: '/tmp/export',
+    } as const;
+    await Promise.all([
+      writeJsonFile(exportFile(paths, running.id), running),
+      writeJsonFile(exportFile(paths, finished.id), finished),
+      writeJsonFile(paths.exportsIndexFile, [running, finished]),
+    ]);
+
+    await expect(pruneExportHistory(paths, 0)).resolves.toBe(1);
+    expect((await readStateWithIndexes(paths)).exports).toEqual([running]);
+    await expect(access(exportFile(paths, running.id))).resolves.toBeUndefined();
+    await expect(access(exportFile(paths, finished.id))).rejects.toThrow();
+  });
+
+  it('rechecks a terminal candidate under its lock before deletion', async () => {
+    const running = {
+      id: 'exp-raced', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'running', createdAt: 1,
+    } as const;
+    await writeJsonFile(exportFile(paths, running.id), running);
+    await writeJsonFile(paths.exportsIndexFile, [{
+      ...running, status: 'succeeded', completedAt: 2, path: '/tmp/export',
+    }]);
+
+    await expect(pruneExportHistory(paths, 0)).resolves.toBe(0);
+    await expect(access(exportFile(paths, running.id))).resolves.toBeUndefined();
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.test.ts
@@ -1,10 +1,10 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
 
-import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
+import { designLibraryPathsFromHome, exportFile, type DesignLibraryPaths } from '../shared/paths';
 import { readStateWithIndexes } from '../shared/state-io';
 import { runGalleryExport } from './export';
 import { ExportRequests } from './export-requests';
@@ -66,5 +66,19 @@ describe('export request state', () => {
     expect((await readStateWithIndexes(paths)).exports[0]).toMatchObject({
       status: 'failed', error: 'The requested export path is not inside an open workspace.',
     });
+  });
+
+  it('keeps only the 20 newest export records and index entries', async () => {
+    vi.mocked(runGalleryExport).mockImplementation(async (_paths, request) =>
+      `/workspace/${request.exportId}`);
+    const exporter = new ExportRequests(paths, workspaces);
+    for (let index = 0; index < 21; index += 1) {
+      await exporter.apply({ ...REQUEST, exportId: `exp-${index}` });
+    }
+
+    const exports = (await readStateWithIndexes(paths)).exports;
+    expect(exports).toHaveLength(20);
+    expect(exports.map((entry) => entry.id)).not.toContain('exp-0');
+    await expect(access(exportFile(paths, 'exp-0'))).rejects.toThrow();
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/export-requests.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.ts
@@ -3,9 +3,13 @@ import path from 'node:path';
 import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
 
 import type { ExportSummary } from '../shared/export';
+import { normalizeExportSummary } from '../shared/export';
+import { bumpControlRevision, readIndex, updateIndex } from '../shared/index-storage';
+import { normalizeExportIndex } from '../shared/indexes';
 import type { DesignLibraryPaths } from '../shared/paths';
+import { exportFile } from '../shared/paths';
 import type { LibraryRequestBody } from '../shared/requests';
-import { readState, updateState } from '../shared/state-io';
+import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io';
 import { runGalleryExport } from './export';
 
 type ExportRequestBody = Extract<LibraryRequestBody, { kind: `export.${string}` }>;
@@ -76,16 +80,18 @@ export class ExportRequests {
   }
 
   private async find(exportId: string): Promise<ExportSummary | undefined> {
-    return (await readState(this.paths)).exports.find((entry) => entry.id === exportId);
+    const record = normalizeExportSummary(await readJsonFile<unknown>(exportFile(this.paths, exportId)));
+    if (record) return record;
+    return (await readIndex(this.paths.exportsIndexFile, normalizeExportIndex))
+      .find((entry) => entry.id === exportId);
   }
 
   private async publish(summary: ExportSummary): Promise<void> {
-    await updateState(this.paths, (state) => ({
-      ...state,
-      exports: [
-        ...state.exports.filter((entry) => entry.id !== summary.id),
-        summary,
-      ].toSorted((a, b) => a.createdAt - b.createdAt).slice(-20),
-    }));
+    const file = exportFile(this.paths, summary.id);
+    await withRecordLock(this.paths, file, async () => {
+      await writeJsonFile(file, summary);
+      await updateIndex(this.paths, this.paths.exportsIndexFile, normalizeExportIndex, summary.id, summary);
+      await bumpControlRevision(this.paths);
+    });
   }
 }

--- a/plugins/sero-design-library-plugin/runtime/export-requests.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.ts
@@ -1,3 +1,4 @@
+import { rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
@@ -5,6 +6,7 @@ import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
 import type { ExportSummary } from '../shared/export';
 import { normalizeExportSummary } from '../shared/export';
 import { bumpControlRevision, readIndex, updateIndex } from '../shared/index-storage';
+import { withIndexRepair } from '../shared/index-repair';
 import { normalizeExportIndex } from '../shared/indexes';
 import type { DesignLibraryPaths } from '../shared/paths';
 import { exportFile } from '../shared/paths';
@@ -13,6 +15,28 @@ import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io'
 import { runGalleryExport } from './export';
 
 type ExportRequestBody = Extract<LibraryRequestBody, { kind: `export.${string}` }>;
+
+const MAX_EXPORT_HISTORY = 20;
+
+export async function pruneExportHistory(
+  paths: DesignLibraryPaths,
+  maximum = MAX_EXPORT_HISTORY,
+): Promise<number> {
+  const history = (await readIndex(paths.exportsIndexFile, normalizeExportIndex))
+    .toSorted((left, right) => left.createdAt - right.createdAt);
+  const expired = history.slice(0, -maximum);
+  for (const summary of expired) {
+    const file = exportFile(paths, summary.id);
+    await withRecordLock(paths, file, async () => {
+      await withIndexRepair(paths, 'exports', summary.id, async () => {
+        await rm(file, { force: true });
+        await updateIndex(paths, paths.exportsIndexFile, normalizeExportIndex, summary.id, null);
+        await bumpControlRevision(paths);
+      });
+    });
+  }
+  return expired.length;
+}
 
 export function isExportRequest(body: LibraryRequestBody): body is ExportRequestBody {
   return body.kind.startsWith('export.');
@@ -89,9 +113,12 @@ export class ExportRequests {
   private async publish(summary: ExportSummary): Promise<void> {
     const file = exportFile(this.paths, summary.id);
     await withRecordLock(this.paths, file, async () => {
-      await writeJsonFile(file, summary);
-      await updateIndex(this.paths, this.paths.exportsIndexFile, normalizeExportIndex, summary.id, summary);
-      await bumpControlRevision(this.paths);
+      await withIndexRepair(this.paths, 'exports', summary.id, async () => {
+        await writeJsonFile(file, summary);
+        await updateIndex(this.paths, this.paths.exportsIndexFile, normalizeExportIndex, summary.id, summary);
+        await bumpControlRevision(this.paths);
+      });
     });
+    await pruneExportHistory(this.paths);
   }
 }

--- a/plugins/sero-design-library-plugin/runtime/export-requests.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.ts
@@ -1,11 +1,11 @@
-import { rm } from 'node:fs/promises';
+import { readdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { AppRuntimeWorkspaceApi } from '@sero-ai/common';
 
 import type { ExportSummary } from '../shared/export';
 import { normalizeExportSummary } from '../shared/export';
-import { bumpControlRevision, readIndex, updateIndex } from '../shared/index-storage';
+import { bumpControlRevision, readIndex, replaceIndex, updateIndex } from '../shared/index-storage';
 import { withIndexRepair } from '../shared/index-repair';
 import { normalizeExportIndex } from '../shared/indexes';
 import type { DesignLibraryPaths } from '../shared/paths';
@@ -18,24 +18,45 @@ type ExportRequestBody = Extract<LibraryRequestBody, { kind: `export.${string}` 
 
 const MAX_EXPORT_HISTORY = 20;
 
+export async function reindexExports(
+  paths: DesignLibraryPaths,
+  notify = true,
+): Promise<string[]> {
+  const names = (await readdir(paths.exportsDir).catch(() => []))
+    .filter((name) => name.endsWith('.json') && name !== 'index.json');
+  const records = await Promise.all(names.map((name) =>
+    readJsonFile<unknown>(path.join(paths.exportsDir, name)).then(normalizeExportSummary)));
+  const exports = records.filter((record): record is ExportSummary => record !== null);
+  await replaceIndex(paths, paths.exportsIndexFile, normalizeExportIndex, exports);
+  if (notify) await bumpControlRevision(paths);
+  return names.filter((_, index) => records[index] === null);
+}
+
 export async function pruneExportHistory(
   paths: DesignLibraryPaths,
   maximum = MAX_EXPORT_HISTORY,
 ): Promise<number> {
   const history = (await readIndex(paths.exportsIndexFile, normalizeExportIndex))
+    .filter((summary) => summary.status !== 'running')
     .toSorted((left, right) => left.createdAt - right.createdAt);
-  const expired = history.slice(0, -maximum);
+  const keep = Math.max(0, Math.floor(maximum));
+  const expired = history.slice(0, Math.max(0, history.length - keep));
+  let removed = 0;
   for (const summary of expired) {
     const file = exportFile(paths, summary.id);
-    await withRecordLock(paths, file, async () => {
+    const deleted = await withRecordLock(paths, file, async () => {
+      const current = normalizeExportSummary(await readJsonFile<unknown>(file));
+      if (current?.status === 'running') return false;
       await withIndexRepair(paths, 'exports', summary.id, async () => {
         await rm(file, { force: true });
         await updateIndex(paths, paths.exportsIndexFile, normalizeExportIndex, summary.id, null);
         await bumpControlRevision(paths);
       });
+      return true;
     });
+    if (deleted) removed += 1;
   }
-  return expired.length;
+  return removed;
 }
 
 export function isExportRequest(body: LibraryRequestBody): body is ExportRequestBody {
@@ -46,6 +67,8 @@ export class ExportRequests {
   constructor(
     private readonly paths: DesignLibraryPaths,
     private readonly workspaces: AppRuntimeWorkspaceApi,
+    private readonly onError: (message: string, error: unknown) => void = () => undefined,
+    private readonly pruneHistory: typeof pruneExportHistory = pruneExportHistory,
   ) {}
 
   async apply(body: ExportRequestBody): Promise<void> {
@@ -59,11 +82,12 @@ export class ExportRequests {
       status: 'running',
       createdAt,
     });
+    let terminal: ExportSummary;
     try {
       const outputPath = await runGalleryExport(this.paths, body, {
         workspacePath: await this.workspacePath(body),
       });
-      await this.publish({
+      terminal = {
         id: body.exportId,
         familyId: body.familyId,
         versionId: body.versionId,
@@ -72,9 +96,9 @@ export class ExportRequests {
         createdAt,
         completedAt: Date.now(),
         path: outputPath,
-      });
+      };
     } catch (error) {
-      await this.publish({
+      terminal = {
         id: body.exportId,
         familyId: body.familyId,
         versionId: body.versionId,
@@ -83,8 +107,10 @@ export class ExportRequests {
         createdAt,
         completedAt: Date.now(),
         error: error instanceof Error ? error.message : String(error),
-      });
+      };
     }
+    await this.publish(terminal);
+    await this.pruneAfterTerminalPublish();
   }
 
   private async workspacePath(body: ExportRequestBody): Promise<string> {
@@ -119,6 +145,13 @@ export class ExportRequests {
         await bumpControlRevision(this.paths);
       });
     });
-    await pruneExportHistory(this.paths);
+  }
+
+  private async pruneAfterTerminalPublish(): Promise<void> {
+    try {
+      await this.pruneHistory(this.paths);
+    } catch (error) {
+      this.onError('Could not prune Design Library export history', error);
+    }
   }
 }

--- a/plugins/sero-design-library-plugin/runtime/export-requests.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.ts
@@ -83,16 +83,22 @@ export async function pruneExportHistory(
 export async function reconcileExports(
   paths: DesignLibraryPaths,
   completedAt = Date.now(),
-): Promise<number> {
+  pendingExportIds: ReadonlySet<string> = new Set(),
+): Promise<{ reconciled: number; unreadable: string[] }> {
   const running = (await readIndex(paths.exportsIndexFile, normalizeExportIndex))
-    .filter((summary) => summary.status === 'running');
+    .filter((summary) => summary.status === 'running' && !pendingExportIds.has(summary.id));
   let reconciled = 0;
+  const unreadable: string[] = [];
 
   for (const summary of running) {
     const file = exportFile(paths, summary.id);
     const changed = await withRecordLock(paths, file, async () => {
       const current = normalizeExportSummary(await readJsonFile<unknown>(file));
-      if (current?.status !== 'running') {
+      if (!current) {
+        unreadable.push(summary.id);
+        return false;
+      }
+      if (current.status !== 'running') {
         const updated = await updateIndex(
           paths,
           paths.exportsIndexFile,
@@ -113,7 +119,7 @@ export async function reconcileExports(
     });
     if (changed) reconciled += 1;
   }
-  return reconciled;
+  return { reconciled, unreadable };
 }
 
 export function isExportRequest(body: LibraryRequestBody): body is ExportRequestBody {
@@ -130,6 +136,13 @@ export class ExportRequests {
 
   async apply(body: ExportRequestBody): Promise<void> {
     const existing = await this.find(body.exportId);
+    if (existing?.status === 'succeeded' || existing?.status === 'failed') {
+      // The request may have completed before its watermark write failed.
+      // Re-publish the durable terminal record without running the export again.
+      await this.publish(existing);
+      await this.pruneAfterTerminalPublish();
+      return;
+    }
     const createdAt = existing?.createdAt ?? Date.now();
     await this.publish({
       id: body.exportId,

--- a/plugins/sero-design-library-plugin/runtime/export-requests.ts
+++ b/plugins/sero-design-library-plugin/runtime/export-requests.ts
@@ -17,6 +17,26 @@ import { runGalleryExport } from './export';
 type ExportRequestBody = Extract<LibraryRequestBody, { kind: `export.${string}` }>;
 
 const MAX_EXPORT_HISTORY = 20;
+const INTERRUPTED_EXPORT_ERROR = 'The export was interrupted by a Sero restart.';
+
+async function writeExportSummaryLocked(
+  paths: DesignLibraryPaths,
+  summary: ExportSummary,
+): Promise<void> {
+  await withIndexRepair(paths, 'exports', summary.id, async () => {
+    await writeJsonFile(exportFile(paths, summary.id), summary);
+    await updateIndex(paths, paths.exportsIndexFile, normalizeExportIndex, summary.id, summary);
+    await bumpControlRevision(paths);
+  });
+}
+
+async function writeExportSummary(
+  paths: DesignLibraryPaths,
+  summary: ExportSummary,
+): Promise<void> {
+  const file = exportFile(paths, summary.id);
+  await withRecordLock(paths, file, () => writeExportSummaryLocked(paths, summary));
+}
 
 export async function reindexExports(
   paths: DesignLibraryPaths,
@@ -57,6 +77,43 @@ export async function pruneExportHistory(
     if (deleted) removed += 1;
   }
   return removed;
+}
+
+/** Settle exports that could not publish a terminal state before shutdown. */
+export async function reconcileExports(
+  paths: DesignLibraryPaths,
+  completedAt = Date.now(),
+): Promise<number> {
+  const running = (await readIndex(paths.exportsIndexFile, normalizeExportIndex))
+    .filter((summary) => summary.status === 'running');
+  let reconciled = 0;
+
+  for (const summary of running) {
+    const file = exportFile(paths, summary.id);
+    const changed = await withRecordLock(paths, file, async () => {
+      const current = normalizeExportSummary(await readJsonFile<unknown>(file));
+      if (current?.status !== 'running') {
+        const updated = await updateIndex(
+          paths,
+          paths.exportsIndexFile,
+          normalizeExportIndex,
+          summary.id,
+          current,
+        );
+        if (updated) await bumpControlRevision(paths);
+        return false;
+      }
+      await writeExportSummaryLocked(paths, {
+        ...current,
+        status: 'failed',
+        completedAt,
+        error: INTERRUPTED_EXPORT_ERROR,
+      });
+      return true;
+    });
+    if (changed) reconciled += 1;
+  }
+  return reconciled;
 }
 
 export function isExportRequest(body: LibraryRequestBody): body is ExportRequestBody {
@@ -137,14 +194,7 @@ export class ExportRequests {
   }
 
   private async publish(summary: ExportSummary): Promise<void> {
-    const file = exportFile(this.paths, summary.id);
-    await withRecordLock(this.paths, file, async () => {
-      await withIndexRepair(this.paths, 'exports', summary.id, async () => {
-        await writeJsonFile(file, summary);
-        await updateIndex(this.paths, this.paths.exportsIndexFile, normalizeExportIndex, summary.id, summary);
-        await bumpControlRevision(this.paths);
-      });
-    });
+    await writeExportSummary(this.paths, summary);
   }
 
   private async pruneAfterTerminalPublish(): Promise<void> {

--- a/plugins/sero-design-library-plugin/runtime/full-repair.ts
+++ b/plugins/sero-design-library-plugin/runtime/full-repair.ts
@@ -1,0 +1,25 @@
+import { rm } from 'node:fs/promises';
+
+import { bumpControlRevision } from '../shared/index-storage';
+import type { DesignLibraryPaths } from '../shared/paths';
+import { readJsonFile } from '../shared/state-io';
+import { reindexExports } from './export-requests';
+import { reindexGallery } from './gallery-store';
+import { reindex } from './store';
+
+/** Run the user-requested authoritative scan before normal runtime work starts. */
+export async function runRequestedFullRepair(
+  paths: DesignLibraryPaths,
+): Promise<string[] | null> {
+  const request = await readJsonFile<unknown>(paths.repairRequestFile);
+  if (request === null) return null;
+
+  const unreadable = (await Promise.all([
+    reindex(paths, false),
+    reindexGallery(paths, false),
+    reindexExports(paths, false),
+  ])).flat();
+  await bumpControlRevision(paths);
+  await rm(paths.repairRequestFile, { force: true });
+  return unreadable;
+}

--- a/plugins/sero-design-library-plugin/runtime/full-repair.ts
+++ b/plugins/sero-design-library-plugin/runtime/full-repair.ts
@@ -1,25 +1,77 @@
-import { rm } from 'node:fs/promises';
+import { rename, rm } from 'node:fs/promises';
 
 import { bumpControlRevision } from '../shared/index-storage';
 import type { DesignLibraryPaths } from '../shared/paths';
-import { readJsonFile } from '../shared/state-io';
+import { readJsonFile, writeJsonFile } from '../shared/state-io';
 import { reindexExports } from './export-requests';
 import { reindexGallery } from './gallery-store';
 import { reindex } from './store';
+
+const MAX_REPAIR_ATTEMPTS = 3;
+
+interface FullRepairRequest {
+  requestedAt: number;
+  attempts: number;
+}
+
+function repairRequest(value: unknown): FullRepairRequest | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+  const entry = value as Record<string, unknown>;
+  if (typeof entry.requestedAt !== 'number') return null;
+  return {
+    requestedAt: entry.requestedAt,
+    attempts: typeof entry.attempts === 'number' && Number.isInteger(entry.attempts)
+      ? Math.max(0, entry.attempts)
+      : 0,
+  };
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function failRepairRequest(
+  paths: DesignLibraryPaths,
+  request: FullRepairRequest,
+  error: unknown,
+): Promise<void> {
+  await writeJsonFile(paths.repairRequestFile, {
+    ...request,
+    failedAt: Date.now(),
+    error: errorText(error),
+  });
+  await rm(paths.repairFailedFile, { force: true });
+  await rename(paths.repairRequestFile, paths.repairFailedFile);
+}
 
 /** Run the user-requested authoritative scan before normal runtime work starts. */
 export async function runRequestedFullRepair(
   paths: DesignLibraryPaths,
 ): Promise<string[] | null> {
-  const request = await readJsonFile<unknown>(paths.repairRequestFile);
+  const request = repairRequest(await readJsonFile<unknown>(paths.repairRequestFile));
   if (request === null) return null;
 
-  const unreadable = (await Promise.all([
-    reindex(paths, false),
-    reindexGallery(paths, false),
-    reindexExports(paths, false),
-  ])).flat();
-  await bumpControlRevision(paths);
-  await rm(paths.repairRequestFile, { force: true });
-  return unreadable;
+  if (request.attempts >= MAX_REPAIR_ATTEMPTS) {
+    const error = new Error('The full index repair reached its retry limit.');
+    await failRepairRequest(paths, request, error);
+    throw error;
+  }
+
+  const attempted = { ...request, attempts: request.attempts + 1 };
+  await writeJsonFile(paths.repairRequestFile, attempted);
+  try {
+    const unreadable = (await Promise.all([
+      reindex(paths, false),
+      reindexGallery(paths, false),
+      reindexExports(paths, false),
+    ])).flat();
+    await bumpControlRevision(paths);
+    await rm(paths.repairRequestFile, { force: true });
+    return unreadable;
+  } catch (error) {
+    if (attempted.attempts >= MAX_REPAIR_ATTEMPTS) {
+      await failRepairRequest(paths, attempted, error);
+    }
+    throw error;
+  }
 }

--- a/plugins/sero-design-library-plugin/runtime/full-repair.ts
+++ b/plugins/sero-design-library-plugin/runtime/full-repair.ts
@@ -1,5 +1,9 @@
 import { rename, rm } from 'node:fs/promises';
 
+import {
+  normalizeFullIndexRepairRequest,
+  type FullIndexRepairRequest,
+} from '../shared/index-repair';
 import { bumpControlRevision } from '../shared/index-storage';
 import type { DesignLibraryPaths } from '../shared/paths';
 import { readJsonFile, writeJsonFile } from '../shared/state-io';
@@ -9,30 +13,13 @@ import { reindex } from './store';
 
 const MAX_REPAIR_ATTEMPTS = 3;
 
-interface FullRepairRequest {
-  requestedAt: number;
-  attempts: number;
-}
-
-function repairRequest(value: unknown): FullRepairRequest | null {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
-  const entry = value as Record<string, unknown>;
-  if (typeof entry.requestedAt !== 'number') return null;
-  return {
-    requestedAt: entry.requestedAt,
-    attempts: typeof entry.attempts === 'number' && Number.isInteger(entry.attempts)
-      ? Math.max(0, entry.attempts)
-      : 0,
-  };
-}
-
 function errorText(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
 async function failRepairRequest(
   paths: DesignLibraryPaths,
-  request: FullRepairRequest,
+  request: FullIndexRepairRequest,
   error: unknown,
 ): Promise<void> {
   await writeJsonFile(paths.repairRequestFile, {
@@ -48,7 +35,9 @@ async function failRepairRequest(
 export async function runRequestedFullRepair(
   paths: DesignLibraryPaths,
 ): Promise<string[] | null> {
-  const request = repairRequest(await readJsonFile<unknown>(paths.repairRequestFile));
+  const request = normalizeFullIndexRepairRequest(
+    await readJsonFile<unknown>(paths.repairRequestFile),
+  );
   if (request === null) return null;
 
   if (request.attempts >= MAX_REPAIR_ATTEMPTS) {

--- a/plugins/sero-design-library-plugin/runtime/gallery-snapshot.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/gallery-snapshot.test.ts
@@ -11,7 +11,7 @@ import {
   revisionDir,
 } from '../shared/paths';
 import type { DesignLibraryPaths } from '../shared/paths';
-import { readState, updateState } from '../shared/state-io';
+import { readStateWithIndexes, updateState } from '../shared/state-io';
 import { stageGeneratedUpload } from '../shared/uploads';
 import { mutateDesign, mutateVariant, readDesign } from './design-store';
 import { createDesign } from './designs';
@@ -135,7 +135,7 @@ describe('Gallery snapshot transaction', () => {
     await expect(readFile(path.join(versionDir, 'effective-tweaks.css'), 'utf8')).resolves.toContain(
       '--signal: #ff0000',
     );
-    expect((await readState(paths)).galleryFamilies[0]?.featuredVersionId).toBe('ver-1');
+    expect((await readStateWithIndexes(paths)).galleryFamilies[0]?.featuredVersionId).toBe('ver-1');
   });
 
   it('stays byte-identical after the source Design is removed', async () => {
@@ -162,7 +162,7 @@ describe('Gallery snapshot transaction', () => {
     await saveGalleryVersion(paths, input);
     await saveGalleryVersion(paths, input);
 
-    expect((await readState(paths)).galleryFamilies[0]?.versions).toHaveLength(1);
+    expect((await readStateWithIndexes(paths)).galleryFamilies[0]?.versions).toHaveLength(1);
   });
 
   it('repairs a snapshot committed before its family pointer', async () => {
@@ -177,7 +177,7 @@ describe('Gallery snapshot transaction', () => {
 
     await saveGalleryVersion(paths, input);
 
-    expect((await readState(paths)).galleryFamilies[0]?.versions[0]?.id).toBe('ver-1');
+    expect((await readStateWithIndexes(paths)).galleryFamilies[0]?.versions[0]?.id).toBe('ver-1');
   });
 
   it('duplicates an editable Design from the Gallery-owned snapshot', async () => {
@@ -231,7 +231,7 @@ describe('Gallery snapshot transaction', () => {
     await new GalleryRequests(paths).apply({ kind: 'gallery.open', familyId: 'fam-1', versionId: 'ver-1' });
 
     expect((await readDesign(paths, 'dsn-1'))?.variants[0]?.visibleRevisionId).toBe('rev-1');
-    expect((await readState(paths)).view.selectedDesignId).toBe('dsn-1');
+    expect((await readStateWithIndexes(paths)).view.selectedDesignId).toBe('dsn-1');
   });
 
   it('restores and permanently deletes a Gallery version', async () => {
@@ -242,13 +242,13 @@ describe('Gallery snapshot transaction', () => {
     });
     const requests = new GalleryRequests(paths);
     await requests.apply({ kind: 'gallery.delete-version', familyId: 'fam-1', versionId: 'ver-1', deleted: true });
-    expect((await readState(paths)).galleryFamilies[0]?.versions[0]?.deletedAt).toEqual(expect.any(Number));
+    expect((await readStateWithIndexes(paths)).galleryFamilies[0]?.versions[0]?.deletedAt).toEqual(expect.any(Number));
 
     await requests.apply({ kind: 'gallery.delete-version', familyId: 'fam-1', versionId: 'ver-1', deleted: false });
-    expect((await readState(paths)).galleryFamilies[0]?.versions[0]?.deletedAt).toBeUndefined();
+    expect((await readStateWithIndexes(paths)).galleryFamilies[0]?.versions[0]?.deletedAt).toBeUndefined();
 
     await requests.apply({ kind: 'gallery.purge-version', familyId: 'fam-1', versionId: 'ver-1' });
-    expect((await readState(paths)).galleryFamilies).toHaveLength(0);
+    expect((await readStateWithIndexes(paths)).galleryFamilies).toHaveLength(0);
     await expect(stat(galleryVersionDir(paths, 'fam-1', 'ver-1')).catch(() => null)).resolves.toBeNull();
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/gallery-store.ts
+++ b/plugins/sero-design-library-plugin/runtime/gallery-store.ts
@@ -11,7 +11,9 @@ import {
   galleryVersionRecordFile,
   isSafeId,
 } from '../shared/paths';
-import { readJsonFile, updateState, withRecordLock, writeJsonFile } from '../shared/state-io';
+import { bumpControlRevision, replaceIndex, updateIndex } from '../shared/index-storage';
+import { normalizeGalleryIndex } from '../shared/indexes';
+import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io';
 import { mutateDesign } from './design-store';
 
 export async function readGalleryFamily(
@@ -33,13 +35,8 @@ export async function readGalleryVersion(
 
 async function publishFamily(paths: DesignLibraryPaths, family: GalleryFamilyRecord): Promise<void> {
   await writeJsonFile(galleryFamilyRecordFile(paths, family.id), family);
-  await updateState(paths, (state) => ({
-    ...state,
-    galleryFamilies: [
-      ...state.galleryFamilies.filter((entry) => entry.id !== family.id),
-      family,
-    ],
-  }));
+  await updateIndex(paths, paths.galleryIndexFile, normalizeGalleryIndex, family.id, family);
+  await bumpControlRevision(paths);
 }
 
 export async function mutateGalleryFamily(
@@ -57,19 +54,29 @@ export async function mutateGalleryFamily(
   });
 }
 
-export async function scanGalleryFamilies(paths: DesignLibraryPaths): Promise<GalleryFamilyRecord[]> {
-  const entries = await readdir(paths.galleryDir, { withFileTypes: true }).catch(() => []);
-  const families = await Promise.all(
-    entries.flatMap((entry) =>
-      entry.isDirectory() && isSafeId(entry.name) ? [readGalleryFamily(paths, entry.name)] : [],
-    ),
-  );
-  return families.filter((family): family is GalleryFamilyRecord => family !== null);
+export interface GalleryScan {
+  families: GalleryFamilyRecord[];
+  unreadable: string[];
 }
 
-export async function reindexGallery(paths: DesignLibraryPaths): Promise<void> {
-  const galleryFamilies = await scanGalleryFamilies(paths);
-  await updateState(paths, (state) => ({ ...state, galleryFamilies }));
+export async function scanGalleryFamilies(paths: DesignLibraryPaths): Promise<GalleryScan> {
+  const entries = await readdir(paths.galleryDir, { withFileTypes: true }).catch(() => []);
+  const families: GalleryFamilyRecord[] = [];
+  const unreadable: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !isSafeId(entry.name)) continue;
+    const family = await readGalleryFamily(paths, entry.name);
+    if (family) families.push(family);
+    else unreadable.push(entry.name);
+  }
+  return { families, unreadable };
+}
+
+export async function reindexGallery(paths: DesignLibraryPaths, notify = true): Promise<string[]> {
+  const { families: galleryFamilies, unreadable } = await scanGalleryFamilies(paths);
+  await replaceIndex(paths, paths.galleryIndexFile, normalizeGalleryIndex, galleryFamilies);
+  if (notify) await bumpControlRevision(paths);
+  return unreadable;
 }
 
 /** Remove transaction directories that were never atomically renamed into versions. */
@@ -120,10 +127,8 @@ export async function purgeGalleryFamily(
   const file = galleryFamilyRecordFile(paths, familyId);
   await withRecordLock(paths, file, async () => {
     await rm(galleryFamilyDir(paths, familyId), { recursive: true, force: true });
-    await updateState(paths, (state) => ({
-      ...state,
-      galleryFamilies: state.galleryFamilies.filter((family) => family.id !== familyId),
-    }));
+    await updateIndex(paths, paths.galleryIndexFile, normalizeGalleryIndex, familyId, null);
+    await bumpControlRevision(paths);
   });
   if (family) {
     await mutateDesign(paths, family.sourceDesignId, (design) =>

--- a/plugins/sero-design-library-plugin/runtime/gallery-store.ts
+++ b/plugins/sero-design-library-plugin/runtime/gallery-store.ts
@@ -12,6 +12,7 @@ import {
   isSafeId,
 } from '../shared/paths';
 import { bumpControlRevision, replaceIndex, updateIndex } from '../shared/index-storage';
+import { withIndexRepair } from '../shared/index-repair';
 import { normalizeGalleryIndex } from '../shared/indexes';
 import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io';
 import { mutateDesign } from './design-store';
@@ -34,9 +35,11 @@ export async function readGalleryVersion(
 }
 
 async function publishFamily(paths: DesignLibraryPaths, family: GalleryFamilyRecord): Promise<void> {
-  await writeJsonFile(galleryFamilyRecordFile(paths, family.id), family);
-  await updateIndex(paths, paths.galleryIndexFile, normalizeGalleryIndex, family.id, family);
-  await bumpControlRevision(paths);
+  await withIndexRepair(paths, 'gallery', family.id, async () => {
+    await writeJsonFile(galleryFamilyRecordFile(paths, family.id), family);
+    await updateIndex(paths, paths.galleryIndexFile, normalizeGalleryIndex, family.id, family);
+    await bumpControlRevision(paths);
+  });
 }
 
 export async function mutateGalleryFamily(
@@ -126,9 +129,11 @@ export async function purgeGalleryFamily(
   const family = await readGalleryFamily(paths, familyId);
   const file = galleryFamilyRecordFile(paths, familyId);
   await withRecordLock(paths, file, async () => {
-    await rm(galleryFamilyDir(paths, familyId), { recursive: true, force: true });
-    await updateIndex(paths, paths.galleryIndexFile, normalizeGalleryIndex, familyId, null);
-    await bumpControlRevision(paths);
+    await withIndexRepair(paths, 'gallery', familyId, async () => {
+      await rm(galleryFamilyDir(paths, familyId), { recursive: true, force: true });
+      await updateIndex(paths, paths.galleryIndexFile, normalizeGalleryIndex, familyId, null);
+      await bumpControlRevision(paths);
+    });
   });
   if (family) {
     await mutateDesign(paths, family.sourceDesignId, (design) =>

--- a/plugins/sero-design-library-plugin/runtime/generation/queue-lifecycle.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/generation/queue-lifecycle.test.ts
@@ -6,7 +6,7 @@ import type { AppRuntimeSubagentRunParams } from '@sero-ai/common';
 
 import type { DesignBrief } from '../../shared/design';
 import { revisionDir } from '../../shared/paths';
-import { appendRequest, readState } from '../../shared/state-io';
+import { appendRequest, readStateWithIndexes } from '../../shared/state-io';
 import { PREVIEW_CSP } from '../preview/harness';
 import {
   STUB_PAGE,

--- a/plugins/sero-design-library-plugin/runtime/generation/queue.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/generation/queue.test.ts
@@ -8,7 +8,7 @@ import type { AppRuntimeSubagentRunParams } from '@sero-ai/common';
 
 import type { DesignBrief } from '../../shared/design';
 import { revisionDir } from '../../shared/paths';
-import { appendRequest, readState } from '../../shared/state-io';
+import { appendRequest, readStateWithIndexes } from '../../shared/state-io';
 import { PREVIEW_CSP } from '../preview/harness';
 import {
   BASELINE_STYLE,
@@ -145,7 +145,7 @@ describe('generating a variant', () => {
     });
     try {
       await vi.waitFor(async () => {
-        const state = await readState(harness.paths);
+        const state = await readStateWithIndexes(harness.paths);
         expect(state.designs[0]?.variants[0]?.progress).toBe('Writing the design files…');
       });
     } finally {
@@ -178,7 +178,7 @@ describe('generating a variant', () => {
       expect(await readFile(path.join(directory, 'index.html'), 'utf8')).toBe(STUB_PAGE);
     }
 
-    const summary = (await readState(harness.paths)).designs.find((entry) => entry.id === designId);
+    const summary = (await readStateWithIndexes(harness.paths)).designs.find((entry) => entry.id === designId);
     expect(summary?.variants.every((variant) => variant.previewPath !== undefined)).toBe(true);
   });
 

--- a/plugins/sero-design-library-plugin/runtime/index-repair.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/index-repair.test.ts
@@ -11,7 +11,8 @@ import {
   galleryFamilyRecordFile,
   type DesignLibraryPaths,
 } from '../shared/paths';
-import { readStateWithIndexes, writeJsonFile } from '../shared/state-io';
+import { readJsonFile, readStateWithIndexes, writeJsonFile } from '../shared/state-io';
+import { runRequestedFullRepair } from './full-repair';
 import { repairPendingIndexes } from './index-repair';
 import { seedDesign, seedItem } from './test-fixtures';
 
@@ -78,5 +79,24 @@ describe('targeted index repair', () => {
     expect(state.gallery.map((entry) => entry.id)).toEqual(['fam-1']);
     expect(state.exports.map((entry) => entry.id)).toEqual(['exp-1']);
     await expect(repairPendingIndexes(paths)).resolves.toBe(0);
+  });
+
+  it('runs a requested full repair and clears the request after success', async () => {
+    await seedItem(paths, 'itm-full', { status: 'ready' });
+    await writeJsonFile(exportFile(paths, 'exp-full'), {
+      id: 'exp-full', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'succeeded', createdAt: 1, completedAt: 2, path: '/tmp/export',
+    });
+    await Promise.all([
+      writeJsonFile(paths.itemsIndexFile, []),
+      writeJsonFile(paths.exportsIndexFile, []),
+    ]);
+    await writeJsonFile(paths.repairRequestFile, { requestedAt: 1 });
+
+    await expect(runRequestedFullRepair(paths)).resolves.toEqual([]);
+    const state = await readStateWithIndexes(paths);
+    expect(state.items.map((entry) => entry.id)).toEqual(['itm-full']);
+    expect(state.exports.map((entry) => entry.id)).toEqual(['exp-full']);
+    expect(await readJsonFile(paths.repairRequestFile)).toBeNull();
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/index-repair.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/index-repair.test.ts
@@ -1,0 +1,82 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { GALLERY_SCHEMA_VERSION, type GalleryFamilyRecord } from '../shared/gallery';
+import { markIndexRepair } from '../shared/index-repair';
+import {
+  designLibraryPathsFromHome,
+  exportFile,
+  galleryFamilyRecordFile,
+  type DesignLibraryPaths,
+} from '../shared/paths';
+import { readStateWithIndexes, writeJsonFile } from '../shared/state-io';
+import { repairPendingIndexes } from './index-repair';
+import { seedDesign, seedItem } from './test-fixtures';
+
+let home: string;
+let paths: DesignLibraryPaths;
+
+beforeEach(async () => {
+  home = await mkdtemp(path.join(tmpdir(), 'design-library-index-repair-'));
+  paths = designLibraryPathsFromHome(home);
+});
+
+afterEach(async () => rm(home, { recursive: true, force: true }));
+
+describe('targeted index repair', () => {
+  it('replays only interrupted item, Design, Gallery, and export projections', async () => {
+    await seedItem(paths, 'itm-1', { status: 'ready' });
+    await seedDesign(paths, 'dsn-1', { variantCount: 1 });
+    const family: GalleryFamilyRecord = {
+      id: 'fam-1',
+      schemaVersion: GALLERY_SCHEMA_VERSION,
+      createdAt: 1,
+      updatedAt: 2,
+      title: 'Family',
+      sourceDesignId: 'dsn-1',
+      featuredVersionId: 'ver-1',
+      favourite: false,
+      versions: [{
+        id: 'ver-1',
+        createdAt: 1,
+        title: 'Version',
+        target: 'html',
+        sourceVariantId: 'variant-1',
+        sourceRevisionId: 'revision-1',
+        previewFile: 'preview.png',
+      }],
+    };
+    await writeJsonFile(galleryFamilyRecordFile(paths, family.id), family);
+    await writeJsonFile(exportFile(paths, 'exp-1'), {
+      id: 'exp-1',
+      familyId: 'fam-1',
+      versionId: 'ver-1',
+      destination: 'downloads',
+      status: 'succeeded',
+      createdAt: 1,
+      completedAt: 2,
+      path: '/tmp/export',
+    });
+
+    await Promise.all([
+      writeJsonFile(paths.itemsIndexFile, []),
+      writeJsonFile(paths.designsIndexFile, []),
+      writeJsonFile(paths.galleryIndexFile, []),
+      writeJsonFile(paths.exportsIndexFile, []),
+      markIndexRepair(paths, 'items', 'itm-1'),
+      markIndexRepair(paths, 'designs', 'dsn-1'),
+      markIndexRepair(paths, 'gallery', 'fam-1'),
+      markIndexRepair(paths, 'exports', 'exp-1'),
+    ]);
+
+    await expect(repairPendingIndexes(paths)).resolves.toBe(4);
+    const state = await readStateWithIndexes(paths);
+    expect(state.items.map((entry) => entry.id)).toEqual(['itm-1']);
+    expect(state.designs.map((entry) => entry.id)).toEqual(['dsn-1']);
+    expect(state.gallery.map((entry) => entry.id)).toEqual(['fam-1']);
+    expect(state.exports.map((entry) => entry.id)).toEqual(['exp-1']);
+    await expect(repairPendingIndexes(paths)).resolves.toBe(0);
+  });
+});

--- a/plugins/sero-design-library-plugin/runtime/index-repair.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/index-repair.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -71,6 +71,7 @@ describe('targeted index repair', () => {
       markIndexRepair(paths, 'gallery', 'fam-1'),
       markIndexRepair(paths, 'exports', 'exp-1'),
     ]);
+    const revisionBeforeRepair = (await readStateWithIndexes(paths)).revision;
 
     await expect(repairPendingIndexes(paths)).resolves.toBe(4);
     const state = await readStateWithIndexes(paths);
@@ -78,6 +79,7 @@ describe('targeted index repair', () => {
     expect(state.designs.map((entry) => entry.id)).toEqual(['dsn-1']);
     expect(state.gallery.map((entry) => entry.id)).toEqual(['fam-1']);
     expect(state.exports.map((entry) => entry.id)).toEqual(['exp-1']);
+    expect(state.revision).toBe(revisionBeforeRepair + 4);
     await expect(repairPendingIndexes(paths)).resolves.toBe(0);
   });
 
@@ -98,5 +100,20 @@ describe('targeted index repair', () => {
     expect(state.items.map((entry) => entry.id)).toEqual(['itm-full']);
     expect(state.exports.map((entry) => entry.id)).toEqual(['exp-full']);
     expect(await readJsonFile(paths.repairRequestFile)).toBeNull();
+  });
+
+  it('stops retrying a permanently failing full repair after three starts', async () => {
+    await writeJsonFile(paths.repairRequestFile, { requestedAt: 1 });
+    await mkdir(paths.exportsIndexFile, { recursive: true });
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await expect(runRequestedFullRepair(paths)).rejects.toThrow();
+    }
+
+    await expect(access(paths.repairRequestFile)).rejects.toThrow();
+    const failed = JSON.parse(await readFile(paths.repairFailedFile, 'utf8')) as Record<string, unknown>;
+    expect(failed).toMatchObject({ requestedAt: 1, attempts: 3, failedAt: expect.any(Number) });
+    expect(failed.error).toEqual(expect.any(String));
+    await expect(runRequestedFullRepair(paths)).resolves.toBeNull();
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/index-repair.ts
+++ b/plugins/sero-design-library-plugin/runtime/index-repair.ts
@@ -1,0 +1,84 @@
+import { clearIndexRepair, listPendingIndexRepairs } from '../shared/index-repair';
+import { bumpControlRevision, updateIndex } from '../shared/index-storage';
+import { normalizeExportSummary } from '../shared/export';
+import {
+  normalizeDesignIndex,
+  normalizeExportIndex,
+  normalizeGalleryIndex,
+  normalizeItemIndex,
+} from '../shared/indexes';
+import type { DesignLibraryPaths } from '../shared/paths';
+import { exportFile } from '../shared/paths';
+import { readJsonFile } from '../shared/state-io';
+import { readDesign } from './design-store';
+import { readGalleryFamily } from './gallery-store';
+import { projectDesign, projectItem } from './projection';
+import { previewPathFor, readItem } from './store';
+
+/**
+ * Replay only writes left in the crash journal. A clean start reads no entity
+ * records, while an interrupted write repairs its exact index entry.
+ */
+export async function repairPendingIndexes(paths: DesignLibraryPaths): Promise<number> {
+  const pending = await listPendingIndexRepairs(paths);
+  if (pending.length === 0) return 0;
+
+  for (const repair of pending) {
+    switch (repair.index) {
+      case 'items': {
+        const item = await readItem(paths, repair.id);
+        await updateIndex(
+          paths,
+          paths.itemsIndexFile,
+          normalizeItemIndex,
+          repair.id,
+          item ? projectItem(item, previewPathFor(item)) : null,
+        );
+        break;
+      }
+      case 'designs': {
+        const design = await readDesign(paths, repair.id);
+        await updateIndex(
+          paths,
+          paths.designsIndexFile,
+          normalizeDesignIndex,
+          repair.id,
+          design ? projectDesign(design) : null,
+        );
+        break;
+      }
+      case 'gallery': {
+        const family = await readGalleryFamily(paths, repair.id);
+        await updateIndex(
+          paths,
+          paths.galleryIndexFile,
+          normalizeGalleryIndex,
+          repair.id,
+          family,
+        );
+        break;
+      }
+      case 'exports': {
+        const summary = normalizeExportSummary(
+          await readJsonFile<unknown>(exportFile(paths, repair.id)),
+        );
+        await updateIndex(
+          paths,
+          paths.exportsIndexFile,
+          normalizeExportIndex,
+          repair.id,
+          summary,
+        );
+        break;
+      }
+    }
+  }
+
+  // A marker also means the original control-state notification may not have
+  // completed. Clear markers only after this notification is durable.
+  await bumpControlRevision(paths);
+  await Promise.all(
+    pending.map((repair) => clearIndexRepair(paths, repair.index, repair.id)),
+  );
+  return pending.length;
+}

--- a/plugins/sero-design-library-plugin/runtime/index-repair.ts
+++ b/plugins/sero-design-library-plugin/runtime/index-repair.ts
@@ -86,14 +86,12 @@ export async function repairPendingIndexes(paths: DesignLibraryPaths): Promise<n
           break;
         }
       }
+      // The marker belongs to this record transaction. Keep the record lock
+      // until both the notification and marker removal are durable, so a new
+      // writer cannot start between replay and cleanup.
+      await bumpControlRevision(paths);
+      await clearIndexRepair(paths, repair.index, repair.id);
     });
   }
-
-  // A marker also means the original control-state notification may not have
-  // completed. Clear markers only after this notification is durable.
-  await bumpControlRevision(paths);
-  await Promise.all(
-    pending.map((repair) => clearIndexRepair(paths, repair.index, repair.id)),
-  );
   return pending.length;
 }

--- a/plugins/sero-design-library-plugin/runtime/index-repair.ts
+++ b/plugins/sero-design-library-plugin/runtime/index-repair.ts
@@ -1,4 +1,8 @@
-import { clearIndexRepair, listPendingIndexRepairs } from '../shared/index-repair';
+import {
+  clearIndexRepair,
+  listPendingIndexRepairs,
+  type PendingIndexRepair,
+} from '../shared/index-repair';
 import { bumpControlRevision, updateIndex } from '../shared/index-storage';
 import { normalizeExportSummary } from '../shared/export';
 import {
@@ -8,12 +12,21 @@ import {
   normalizeItemIndex,
 } from '../shared/indexes';
 import type { DesignLibraryPaths } from '../shared/paths';
-import { exportFile } from '../shared/paths';
-import { readJsonFile } from '../shared/state-io';
+import { designRecordFile, exportFile, galleryFamilyRecordFile, itemRecordFile } from '../shared/paths';
+import { readJsonFile, withRecordLock } from '../shared/state-io';
 import { readDesign } from './design-store';
 import { readGalleryFamily } from './gallery-store';
 import { projectDesign, projectItem } from './projection';
 import { previewPathFor, readItem } from './store';
+
+function repairRecordFile(paths: DesignLibraryPaths, repair: PendingIndexRepair): string {
+  switch (repair.index) {
+    case 'items': return itemRecordFile(paths, repair.id);
+    case 'designs': return designRecordFile(paths, repair.id);
+    case 'gallery': return galleryFamilyRecordFile(paths, repair.id);
+    case 'exports': return exportFile(paths, repair.id);
+  }
+}
 
 /**
  * Replay only writes left in the crash journal. A clean start reads no entity
@@ -24,54 +37,56 @@ export async function repairPendingIndexes(paths: DesignLibraryPaths): Promise<n
   if (pending.length === 0) return 0;
 
   for (const repair of pending) {
-    switch (repair.index) {
-      case 'items': {
-        const item = await readItem(paths, repair.id);
-        await updateIndex(
-          paths,
-          paths.itemsIndexFile,
-          normalizeItemIndex,
-          repair.id,
-          item ? projectItem(item, previewPathFor(item)) : null,
-        );
-        break;
+    await withRecordLock(paths, repairRecordFile(paths, repair), async () => {
+      switch (repair.index) {
+        case 'items': {
+          const item = await readItem(paths, repair.id);
+          await updateIndex(
+            paths,
+            paths.itemsIndexFile,
+            normalizeItemIndex,
+            repair.id,
+            item ? projectItem(item, previewPathFor(item)) : null,
+          );
+          break;
+        }
+        case 'designs': {
+          const design = await readDesign(paths, repair.id);
+          await updateIndex(
+            paths,
+            paths.designsIndexFile,
+            normalizeDesignIndex,
+            repair.id,
+            design ? projectDesign(design) : null,
+          );
+          break;
+        }
+        case 'gallery': {
+          const family = await readGalleryFamily(paths, repair.id);
+          await updateIndex(
+            paths,
+            paths.galleryIndexFile,
+            normalizeGalleryIndex,
+            repair.id,
+            family,
+          );
+          break;
+        }
+        case 'exports': {
+          const summary = normalizeExportSummary(
+            await readJsonFile<unknown>(exportFile(paths, repair.id)),
+          );
+          await updateIndex(
+            paths,
+            paths.exportsIndexFile,
+            normalizeExportIndex,
+            repair.id,
+            summary,
+          );
+          break;
+        }
       }
-      case 'designs': {
-        const design = await readDesign(paths, repair.id);
-        await updateIndex(
-          paths,
-          paths.designsIndexFile,
-          normalizeDesignIndex,
-          repair.id,
-          design ? projectDesign(design) : null,
-        );
-        break;
-      }
-      case 'gallery': {
-        const family = await readGalleryFamily(paths, repair.id);
-        await updateIndex(
-          paths,
-          paths.galleryIndexFile,
-          normalizeGalleryIndex,
-          repair.id,
-          family,
-        );
-        break;
-      }
-      case 'exports': {
-        const summary = normalizeExportSummary(
-          await readJsonFile<unknown>(exportFile(paths, repair.id)),
-        );
-        await updateIndex(
-          paths,
-          paths.exportsIndexFile,
-          normalizeExportIndex,
-          repair.id,
-          summary,
-        );
-        break;
-      }
-    }
+    });
   }
 
   // A marker also means the original control-state notification may not have

--- a/plugins/sero-design-library-plugin/runtime/index.ts
+++ b/plugins/sero-design-library-plugin/runtime/index.ts
@@ -6,6 +6,7 @@ import { pruneStaleUploads } from '../shared/uploads';
 import { Coordinator } from './coordinator';
 import { pruneIndexedOrphanRevisions } from './design-store';
 import { pruneExportHistory } from './export-requests';
+import { runRequestedFullRepair } from './full-repair';
 import { pruneGalleryTemps } from './gallery-store';
 import { repairPendingIndexes } from './index-repair';
 import { migrateLegacyState } from './migration';
@@ -61,6 +62,15 @@ class DesignLibraryRuntime implements AppRuntime {
       this.report(
         `Skipped ${migration.unreadable.length} record(s) this version cannot read (${migration.unreadable.join(', ')}). ` +
           'Their files are untouched under items/ and designs/.',
+        null,
+      );
+    }
+    const repair = await this.attempt('run requested full index repair', () =>
+      runRequestedFullRepair(paths));
+    if (repair !== undefined && repair !== null && repair.length > 0) {
+      this.report(
+        `Skipped ${repair.length} record(s) this version cannot read (${repair.join(', ')}). ` +
+          'Their files are untouched.',
         null,
       );
     }

--- a/plugins/sero-design-library-plugin/runtime/index.ts
+++ b/plugins/sero-design-library-plugin/runtime/index.ts
@@ -4,9 +4,9 @@ import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/p
 import { pendingRequests, readState } from '../shared/state-io';
 import { pruneStaleUploads } from '../shared/uploads';
 import { Coordinator } from './coordinator';
+import { pruneIndexedOrphanRevisions } from './design-store';
 import { pruneGalleryTemps } from './gallery-store';
 import { migrateLegacyState } from './migration';
-import { pruneFinishedJobs } from './store';
 
 /**
  * The Design Library background runtime — the single authoritative writer.
@@ -63,7 +63,7 @@ class DesignLibraryRuntime implements AppRuntime {
       );
     }
     await this.attempt('remove incomplete Gallery snapshots', () => pruneGalleryTemps(paths));
-    await this.attempt('prune retained jobs', () => pruneFinishedJobs(paths));
+    await this.attempt('remove orphan Design revisions', () => pruneIndexedOrphanRevisions(paths));
 
     this.coordinator = new Coordinator({
       host: this.ctx.host,

--- a/plugins/sero-design-library-plugin/runtime/index.ts
+++ b/plugins/sero-design-library-plugin/runtime/index.ts
@@ -5,7 +5,7 @@ import { pendingRequests, readState } from '../shared/state-io';
 import { pruneStaleUploads } from '../shared/uploads';
 import { Coordinator } from './coordinator';
 import { pruneIndexedOrphanRevisions } from './design-store';
-import { pruneExportHistory } from './export-requests';
+import { pruneExportHistory, reconcileExports } from './export-requests';
 import { runRequestedFullRepair } from './full-repair';
 import { pruneGalleryTemps } from './gallery-store';
 import { repairPendingIndexes } from './index-repair';
@@ -75,6 +75,7 @@ class DesignLibraryRuntime implements AppRuntime {
       );
     }
     await this.attempt('repair interrupted index writes', () => repairPendingIndexes(paths));
+    await this.attempt('settle interrupted exports', () => reconcileExports(paths));
     await this.attempt('prune export history', () => pruneExportHistory(paths));
     await this.attempt('remove incomplete Gallery snapshots', () => pruneGalleryTemps(paths));
     await this.attempt('remove orphan Design revisions', () => pruneIndexedOrphanRevisions(paths));

--- a/plugins/sero-design-library-plugin/runtime/index.ts
+++ b/plugins/sero-design-library-plugin/runtime/index.ts
@@ -4,9 +4,9 @@ import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/p
 import { pendingRequests, readState } from '../shared/state-io';
 import { pruneStaleUploads } from '../shared/uploads';
 import { Coordinator } from './coordinator';
-import { pruneOrphanRevisions, scanDesigns } from './design-store';
-import { reindex } from './store';
-import { pruneGalleryTemps, reindexGallery } from './gallery-store';
+import { pruneGalleryTemps } from './gallery-store';
+import { migrateLegacyState } from './migration';
+import { pruneFinishedJobs } from './store';
 
 /**
  * The Design Library background runtime — the single authoritative writer.
@@ -54,26 +54,16 @@ class DesignLibraryRuntime implements AppRuntime {
       return pruneStaleUploads(paths, STALE_UPLOAD_MS, Date.now(), awaited);
     });
 
-    // Rebuild the index from the records: an index write interrupted by a
-    // crash is a cache miss, not data loss, and this is where it heals.
-    const unreadable = await this.attempt('rebuild the index', () => reindex(paths));
-    if (unreadable !== undefined && unreadable.length > 0) {
+    const migration = await this.attempt('migrate legacy state', () => migrateLegacyState(paths));
+    if (migration !== undefined && migration.unreadable.length > 0) {
       this.report(
-        `Skipped ${unreadable.length} record(s) this version cannot read (${unreadable.join(', ')}). ` +
+        `Skipped ${migration.unreadable.length} record(s) this version cannot read (${migration.unreadable.join(', ')}). ` +
           'Their files are untouched under items/ and designs/.',
         null,
       );
     }
-    await this.attempt('rebuild the Gallery index', () => reindexGallery(paths));
     await this.attempt('remove incomplete Gallery snapshots', () => pruneGalleryTemps(paths));
-
-    // A revision's files are written before the record entry naming them, so a
-    // crash in between leaves a directory nothing points at. The variant is
-    // regenerated from scratch, which makes those files dead weight.
-    await this.attempt('remove orphaned revision files', async () => {
-      const { designs } = await scanDesigns(paths);
-      for (const design of designs) await pruneOrphanRevisions(paths, design);
-    });
+    await this.attempt('prune retained jobs', () => pruneFinishedJobs(paths));
 
     this.coordinator = new Coordinator({
       host: this.ctx.host,

--- a/plugins/sero-design-library-plugin/runtime/index.ts
+++ b/plugins/sero-design-library-plugin/runtime/index.ts
@@ -75,7 +75,22 @@ class DesignLibraryRuntime implements AppRuntime {
       );
     }
     await this.attempt('repair interrupted index writes', () => repairPendingIndexes(paths));
-    await this.attempt('settle interrupted exports', () => reconcileExports(paths));
+    const requestState = await this.attempt('read pending export requests', () => readState(paths));
+    const pendingExportIds = new Set(
+      requestState === undefined
+        ? []
+        : pendingRequests(requestState).flatMap((request) =>
+            request.body.kind === 'export.run' ? [request.body.exportId] : []),
+    );
+    const exportRecovery = await this.attempt('settle interrupted exports', () =>
+      reconcileExports(paths, Date.now(), pendingExportIds));
+    if (exportRecovery !== undefined && exportRecovery.unreadable.length > 0) {
+      this.report(
+        `Could not reconcile ${exportRecovery.unreadable.length} export record(s) ` +
+          `(${exportRecovery.unreadable.join(', ')}). Their index entries are untouched.`,
+        null,
+      );
+    }
     await this.attempt('prune export history', () => pruneExportHistory(paths));
     await this.attempt('remove incomplete Gallery snapshots', () => pruneGalleryTemps(paths));
     await this.attempt('remove orphan Design revisions', () => pruneIndexedOrphanRevisions(paths));

--- a/plugins/sero-design-library-plugin/runtime/index.ts
+++ b/plugins/sero-design-library-plugin/runtime/index.ts
@@ -5,7 +5,9 @@ import { pendingRequests, readState } from '../shared/state-io';
 import { pruneStaleUploads } from '../shared/uploads';
 import { Coordinator } from './coordinator';
 import { pruneIndexedOrphanRevisions } from './design-store';
+import { pruneExportHistory } from './export-requests';
 import { pruneGalleryTemps } from './gallery-store';
+import { repairPendingIndexes } from './index-repair';
 import { migrateLegacyState } from './migration';
 
 /**
@@ -62,6 +64,8 @@ class DesignLibraryRuntime implements AppRuntime {
         null,
       );
     }
+    await this.attempt('repair interrupted index writes', () => repairPendingIndexes(paths));
+    await this.attempt('prune export history', () => pruneExportHistory(paths));
     await this.attempt('remove incomplete Gallery snapshots', () => pruneGalleryTemps(paths));
     await this.attempt('remove orphan Design revisions', () => pruneIndexedOrphanRevisions(paths));
 

--- a/plugins/sero-design-library-plugin/runtime/ingest.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/ingest.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
-import { readState } from '../shared/state-io';
+import { readStateWithIndexes } from '../shared/state-io';
 import { beginUpload, completeUpload, pruneStaleUploads, writeUploadChunk } from '../shared/uploads';
 import type { UploadManifest } from '../shared/uploads';
 import { ingestUpload } from './ingest';
@@ -57,7 +57,7 @@ describe('ingestUpload', () => {
     // The file name becomes a readable starting title before analysis lands.
     expect(outcome.item.profile.generated.title).toBe('Northstar Operations');
 
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     expect(state.items).toHaveLength(1);
     expect(state.items[0].previewPath).toBe(`items/${outcome.item.id}/preview.webp`);
   });

--- a/plugins/sero-design-library-plugin/runtime/jobs.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/jobs.test.ts
@@ -7,7 +7,7 @@ import { emptyAnalysis } from '../shared/librarian';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
 import type { ItemRecord } from '../shared/records';
 import { ITEM_SCHEMA_VERSION, itemTarget, libraryTarget, variantTarget } from '../shared/records';
-import { readState } from '../shared/state-io';
+import { readStateWithIndexes } from '../shared/state-io';
 import { mutateVariant, readDesign } from './design-store';
 import {
   createJob,
@@ -68,7 +68,7 @@ describe('restart recovery', () => {
     const resumable = await reconcileJobs(paths);
 
     expect(resumable.map((entry) => entry.id)).toContain(job.id);
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     expect(state.jobs.find((entry) => entry.id === job.id)?.status).toBe('queued');
   });
 
@@ -109,13 +109,13 @@ describe('reindex', () => {
     await seedItem('item-2');
 
     // Simulate an index write that never landed: the records are on disk but
-    // reactive state has lost them.
-    const { updateState } = await import('../shared/state-io');
-    await updateState(paths, (current) => ({ ...current, items: [] }));
-    expect((await readState(paths)).items).toHaveLength(0);
+    // the compact index has lost them.
+    const { writeJsonFile } = await import('../shared/state-io');
+    await writeJsonFile(paths.itemsIndexFile, []);
+    expect((await readStateWithIndexes(paths)).items).toHaveLength(0);
 
     await reindex(paths);
-    expect((await readState(paths)).items.map((item) => item.id).sort()).toEqual(['item-1', 'item-2']);
+    expect((await readStateWithIndexes(paths)).items.map((item) => item.id).sort()).toEqual(['item-1', 'item-2']);
   });
 
   it('projects the effective title, so an override shows in the grid', async () => {
@@ -129,7 +129,7 @@ describe('reindex', () => {
     });
 
     await reindex(paths);
-    const summary = (await readState(paths)).items.find((entry) => entry.id === 'item-1');
+    const summary = (await readStateWithIndexes(paths)).items.find((entry) => entry.id === 'item-1');
     expect(summary?.title).toBe('My own title');
     expect(summary?.edited).toBe(true);
   });
@@ -426,7 +426,7 @@ describe('forgetting a job', () => {
     expect(await listJobs(paths)).toEqual([]);
     // The index is what the UI renders: a summary outliving its record is
     // exactly the tile that cannot be got rid of.
-    expect((await readState(paths)).jobs).toEqual([]);
+    expect((await readStateWithIndexes(paths)).jobs).toEqual([]);
   });
 
   it('refuses to forget a job that is still working', async () => {
@@ -437,7 +437,7 @@ describe('forgetting a job', () => {
 
     // Hiding a running job would hide work that is still going — and, for
     // media, still spending. Cancelling is the way to stop one.
-    expect((await readState(paths)).jobs).toHaveLength(1);
+    expect((await readStateWithIndexes(paths)).jobs).toHaveLength(1);
   });
 
   it('is safe to apply twice, because the request log is at-least-once', async () => {
@@ -446,6 +446,6 @@ describe('forgetting a job', () => {
 
     await dismissJob(paths, job.id);
     await expect(dismissJob(paths, job.id)).resolves.toBe(true);
-    expect((await readState(paths)).jobs).toEqual([]);
+    expect((await readStateWithIndexes(paths)).jobs).toEqual([]);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/jobs.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/jobs.test.ts
@@ -7,7 +7,7 @@ import { emptyAnalysis } from '../shared/librarian';
 import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
 import type { ItemRecord } from '../shared/records';
 import { ITEM_SCHEMA_VERSION, itemTarget, libraryTarget, variantTarget } from '../shared/records';
-import { readStateWithIndexes } from '../shared/state-io';
+import { readStateWithIndexes, writeJsonFile } from '../shared/state-io';
 import { mutateVariant, readDesign } from './design-store';
 import {
   createJob,
@@ -100,6 +100,24 @@ describe('restart recovery', () => {
 
     const resumable = await reconcileJobs(paths);
     expect(resumable.map((entry) => entry.id)).toEqual([job.id]);
+  });
+
+  it('finds a running media record missing from the jobs index', async () => {
+    const job = await createJob(paths, 'media', libraryTarget('slot-missing-index'), {
+      capability: 'text-to-image',
+      prompt: 'paid generation',
+    });
+    await markRunning(paths, job.id);
+
+    // The process stops after the record rename and before the index rename.
+    await writeJsonFile(paths.jobsIndexFile, []);
+
+    await reconcileJobs(paths);
+
+    expect((await readJob(paths, job.id))?.status).toBe('failed');
+    expect((await readStateWithIndexes(paths)).jobs).toEqual([
+      expect.objectContaining({ id: job.id, status: 'failed' }),
+    ]);
   });
 });
 

--- a/plugins/sero-design-library-plugin/runtime/jobs.ts
+++ b/plugins/sero-design-library-plugin/runtime/jobs.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import type { DesignLibraryPaths } from '../shared/paths';
 import type { JobKind, JobRecord, JobTarget, MediaJobRequest } from '../shared/records';
 import { mutateDesign, mutateVariant, readDesign } from './design-store';
-import { listJobs, mutateItem, mutateJob, readItem, saveJob } from './store';
+import { healJobsIndex, mutateItem, mutateJob, readItem, saveJob } from './store';
 
 /**
  * The persisted job contract.
@@ -101,7 +101,7 @@ const TERMINAL: readonly JobRecord['status'][] = ['succeeded', 'failed', 'cancel
  * nothing else ever revisits it.
  */
 export async function reconcileJobs(paths: DesignLibraryPaths): Promise<JobRecord[]> {
-  const jobs = await listJobs(paths);
+  const jobs = await healJobsIndex(paths);
 
   // Media never resumes. Every other kind of job is free to run again — a
   // generation or an analysis costs a model call the user already asked for —

--- a/plugins/sero-design-library-plugin/runtime/media-faults.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/media-faults.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { assetIsPending, currentAttempt } from '../shared/media';
 import { designAssetDir } from '../shared/paths';
 import { assetTarget } from '../shared/records';
-import { appendRequest, readState } from '../shared/state-io';
+import { appendRequest, readStateWithIndexes } from '../shared/state-io';
 import { useCoordinator } from './coordinator-harness';
 import { readDesign } from './design-store';
 import { createJob, markRunning, reconcileJobs } from './jobs';
@@ -76,7 +76,7 @@ describe('a provider that fails', () => {
     await harness.coordinator.drain();
 
     await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.target.kind === 'asset')?.status).toBe('failed');
     });
     // The Design is untouched — a provider outage is not a reason to lose it.
@@ -263,7 +263,7 @@ describe('two jobs racing for one asset', () => {
     // resumable and routes it to the media queue — the real path it takes.
     await harness.coordinator.start();
     await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.id === orphan.id)?.status).toBe('failed');
     });
 
@@ -287,7 +287,7 @@ describe('a video the user declines', () => {
     await harness.coordinator.drain();
 
     await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.find((job) => job.target.kind === 'asset')?.status).toBe('failed');
     });
 
@@ -304,7 +304,7 @@ describe('a video the user declines', () => {
     });
     await harness.coordinator.drain();
     await vi.waitFor(async () => {
-      const state = await readState(harness.paths);
+      const state = await readStateWithIndexes(harness.paths);
       expect(state.jobs.filter((job) => job.target.kind === 'asset')).toHaveLength(2);
     });
   });

--- a/plugins/sero-design-library-plugin/runtime/migration.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/migration.test.ts
@@ -51,6 +51,7 @@ async function seedLegacyState(): Promise<void> {
   await writeJsonFile(paths.stateFile, {
     ...current,
     schemaVersion: 1,
+    view: { ...current.view, query: 'legacy search' },
     collections: [{ id: 'col-1', name: 'Saved', colour: 'primary', createdAt: 1 }],
     items: current.items,
     designs: current.designs,
@@ -82,6 +83,7 @@ describe('legacy state migration', () => {
       expect(raw).not.toHaveProperty(key);
     }
     expect(raw.collections).toEqual([{ id: 'col-1', name: 'Saved', colour: 'primary', createdAt: 1 }]);
+    expect((raw.view as Record<string, unknown>).query).toBe('legacy search');
     expect(raw.requests).toHaveLength(1);
     expect(await readFile(path.join(home, 'state.json.pre-index-backup'), 'utf8')).toContain('"schemaVersion": 1');
 

--- a/plugins/sero-design-library-plugin/runtime/migration.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/migration.test.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readIndex } from '../shared/index-storage';
+import {
+  normalizeDesignIndex,
+  normalizeExportIndex,
+  normalizeGalleryIndex,
+  normalizeItemIndex,
+  normalizeJobIndex,
+} from '../shared/indexes';
+import { GALLERY_SCHEMA_VERSION, type GalleryFamilyRecord } from '../shared/gallery';
+import {
+  designLibraryPathsFromHome,
+  galleryFamilyRecordFile,
+  type DesignLibraryPaths,
+} from '../shared/paths';
+import { appendRequest, readStateWithIndexes, writeJsonFile } from '../shared/state-io';
+import { createJob } from './jobs';
+import { migrateLegacyState } from './migration';
+import { seedDesign, seedItem } from './test-fixtures';
+
+let home: string;
+let paths: DesignLibraryPaths;
+
+beforeEach(async () => {
+  home = await mkdtemp(path.join(tmpdir(), 'design-library-migration-'));
+  paths = designLibraryPathsFromHome(home);
+});
+
+afterEach(async () => rm(home, { recursive: true, force: true }));
+
+async function seedLegacyState(): Promise<void> {
+  await seedItem(paths, 'itm-live', { status: 'ready' });
+  await seedItem(paths, 'itm-deleted', { deleted: true });
+  await seedDesign(paths, 'dsn-1', { variantCount: 1 });
+  await createJob(paths, 'analysis', { kind: 'item', itemId: 'itm-live' });
+  const family: GalleryFamilyRecord = {
+    id: 'fam-1', schemaVersion: GALLERY_SCHEMA_VERSION, createdAt: 1, updatedAt: 2,
+    title: 'Family', sourceDesignId: 'dsn-1', featuredVersionId: 'ver-1', favourite: true,
+    versions: [{
+      id: 'ver-1', createdAt: 1, title: 'Version', target: 'html',
+      sourceVariantId: 'variant-1', sourceRevisionId: 'revision-1', previewFile: 'preview.png',
+    }],
+  };
+  await writeJsonFile(galleryFamilyRecordFile(paths, family.id), family);
+  await appendRequest(paths, { kind: 'item.favourite', itemId: 'itm-live', favourite: true });
+  const current = await readStateWithIndexes(paths);
+  await writeJsonFile(paths.stateFile, {
+    ...current,
+    schemaVersion: 1,
+    collections: [{ id: 'col-1', name: 'Saved', colour: 'primary', createdAt: 1 }],
+    items: current.items,
+    designs: current.designs,
+    galleryFamilies: [family],
+    jobs: current.jobs,
+    exports: [{
+      id: 'exp-1', familyId: 'fam-1', versionId: 'ver-1', destination: 'downloads',
+      status: 'succeeded', createdAt: 1, completedAt: 2, path: '/tmp/export',
+    }],
+  });
+  await Promise.all([
+    rm(paths.itemsIndexFile, { force: true }),
+    rm(paths.designsIndexFile, { force: true }),
+    rm(paths.galleryIndexFile, { force: true }),
+    rm(paths.jobsIndexFile, { force: true }),
+    rm(paths.exportsIndexFile, { force: true }),
+  ]);
+}
+
+describe('legacy state migration', () => {
+  it('moves every entity list to indexes and preserves bounded state', async () => {
+    await seedLegacyState();
+    const result = await migrateLegacyState(paths);
+    expect(result).toEqual({ migrated: true, unreadable: [] });
+
+    const raw = JSON.parse(await readFile(paths.stateFile, 'utf8')) as Record<string, unknown>;
+    expect(raw.schemaVersion).toBe(2);
+    for (const key of ['items', 'designs', 'galleryFamilies', 'jobs', 'exports']) {
+      expect(raw).not.toHaveProperty(key);
+    }
+    expect(raw.collections).toEqual([{ id: 'col-1', name: 'Saved', colour: 'primary', createdAt: 1 }]);
+    expect(raw.requests).toHaveLength(1);
+    expect(await readFile(path.join(home, 'state.json.pre-index-backup'), 'utf8')).toContain('"schemaVersion": 1');
+
+    expect(await readIndex(paths.itemsIndexFile, normalizeItemIndex)).toHaveLength(3);
+    expect((await readIndex(paths.itemsIndexFile, normalizeItemIndex)).find((item) => item.id === 'itm-deleted')?.deletedAt).toBeDefined();
+    expect(await readIndex(paths.designsIndexFile, normalizeDesignIndex)).toHaveLength(1);
+    expect(await readIndex(paths.galleryIndexFile, normalizeGalleryIndex)).toEqual([expect.objectContaining({ id: 'fam-1' })]);
+    expect(await readIndex(paths.jobsIndexFile, normalizeJobIndex)).toHaveLength(1);
+    expect(await readIndex(paths.exportsIndexFile, normalizeExportIndex)).toEqual([expect.objectContaining({ id: 'exp-1' })]);
+  });
+
+  it('is safe to retry when index files and the backup already exist', async () => {
+    await seedLegacyState();
+    await writeJsonFile(path.join(home, 'state.json.pre-index-backup'), { preserved: true });
+    await expect(migrateLegacyState(paths)).resolves.toMatchObject({ migrated: true });
+    await expect(migrateLegacyState(paths)).resolves.toEqual({ migrated: false, unreadable: [] });
+    expect(await readFile(path.join(home, 'state.json.pre-index-backup'), 'utf8')).toContain('preserved');
+  });
+});

--- a/plugins/sero-design-library-plugin/runtime/migration.ts
+++ b/plugins/sero-design-library-plugin/runtime/migration.ts
@@ -1,0 +1,85 @@
+import { constants } from 'node:fs';
+import { copyFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+
+import { normalizeExportSummary, type ExportSummary } from '../shared/export';
+import { replaceIndex } from '../shared/index-storage';
+import { normalizeExportIndex } from '../shared/indexes';
+import type { DesignLibraryPaths } from '../shared/paths';
+import { exportFile } from '../shared/paths';
+import {
+  commitMigratedState,
+  readJsonFile,
+  readUnnormalizedState,
+  writeJsonFile,
+} from '../shared/state-io';
+import { normalizeState, STATE_SCHEMA_VERSION } from '../shared/types';
+import { reindexGallery } from './gallery-store';
+import { reindex } from './store';
+
+const LEGACY_ARRAYS = ['items', 'designs', 'galleryFamilies', 'jobs', 'exports'] as const;
+
+function object(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function needsIndexMigration(value: unknown): boolean {
+  const state = object(value);
+  if (!state) return false;
+  return state.schemaVersion !== STATE_SCHEMA_VERSION || LEGACY_ARRAYS.some((key) => Array.isArray(state[key]));
+}
+
+function legacyExports(value: unknown): ExportSummary[] {
+  const state = object(value);
+  if (!state || !Array.isArray(state.exports)) return [];
+  return state.exports.flatMap((candidate) => {
+    const entry = normalizeExportSummary(candidate);
+    return entry ? [entry] : [];
+  });
+}
+
+async function rebuildExportIndex(paths: DesignLibraryPaths): Promise<string[]> {
+  const names = await readdir(paths.exportsDir).catch(() => []);
+  const recordNames = names.filter((name) => name.endsWith('.json') && name !== 'index.json');
+  const records = await Promise.all(
+    recordNames.map((name) => readJsonFile<unknown>(path.join(paths.exportsDir, name))),
+  );
+  const exports = records.flatMap((candidate) => {
+    const entry = normalizeExportSummary(candidate);
+    return entry ? [entry] : [];
+  });
+  await replaceIndex(paths, paths.exportsIndexFile, normalizeExportIndex, exports);
+  return recordNames.filter((_, index) => records[index] === null);
+}
+
+export interface MigrationResult {
+  migrated: boolean;
+  unreadable: string[];
+}
+
+/** One-time migration. Media and generated files never move. */
+export async function migrateLegacyState(paths: DesignLibraryPaths): Promise<MigrationResult> {
+  const raw = await readUnnormalizedState(paths);
+  if (!needsIndexMigration(raw)) return { migrated: false, unreadable: [] };
+
+  for (const entry of legacyExports(raw)) await writeJsonFile(exportFile(paths, entry.id), entry);
+  const unreadable = await reindex(paths, false);
+  unreadable.push(...await reindexGallery(paths, false));
+  unreadable.push(...await rebuildExportIndex(paths));
+
+  await copyFile(
+    paths.stateFile,
+    path.join(paths.home, 'state.json.pre-index-backup'),
+    constants.COPYFILE_EXCL,
+  ).catch((error: NodeJS.ErrnoException) => {
+    if (error.code !== 'EEXIST') throw error;
+  });
+
+  await commitMigratedState(paths, (latest) => ({
+    ...normalizeState(latest),
+    schemaVersion: STATE_SCHEMA_VERSION,
+  }));
+  return { migrated: true, unreadable };
+}

--- a/plugins/sero-design-library-plugin/runtime/projection.ts
+++ b/plugins/sero-design-library-plugin/runtime/projection.ts
@@ -11,55 +11,17 @@ import type { DesignRecord, DesignVariant } from '../shared/design';
 import { orderedReferences, visibleRevision } from '../shared/design';
 import { effectiveAnalysis, isOverridden, LIBRARIAN_FIELDS } from '../shared/librarian';
 import type { ItemRecord, JobRecord } from '../shared/records';
-import type {
-  DesignSummary,
-  DesignVariantSummary,
-  ItemSummary,
-  JobSummary,
-} from '../shared/types';
+import type { ItemIndexEntry, JobIndexEntry } from '../shared/indexes';
+import type { DesignSummary, DesignVariantSummary } from '../shared/types';
 
-const CARD_TAG_LIMIT = 6;
-
-/** Everything keyword search covers: title, tags, notes and visible analysis. */
-function buildSearchText(item: ItemRecord): string {
-  const analysis = effectiveAnalysis(item.profile);
-  const profile = analysis.visualProfile;
-  const parts: string[] = [
-    analysis.title,
-    analysis.notes,
-    analysis.primaryStyle,
-    analysis.summary,
-    analysis.designIntent,
-    analysis.generationPrompt,
-    ...analysis.tags,
-    ...analysis.designTypes,
-    ...analysis.always,
-    ...analysis.never,
-    ...analysis.aestheticVocabulary.flatMap((entry) => [entry.term, entry.meaning ?? '']),
-    ...(analysis.palette ?? []).flatMap((entry) => [entry.hex, entry.role]),
-    ...profile.colour,
-    ...profile.typography,
-    ...profile.layout,
-    ...profile.spacingAndDensity,
-    ...profile.shapeLanguage,
-    ...profile.surfaces,
-    ...profile.imagery,
-    ...profile.motion,
-    item.source.fileName ?? '',
-  ];
-  return parts
-    .filter((part) => part !== '')
-    .join(' ')
-    .toLowerCase();
-}
-
-export function projectItem(item: ItemRecord, previewPath: string): ItemSummary {
+export function projectItem(item: ItemRecord, previewPath: string): ItemIndexEntry {
   const analysis = effectiveAnalysis(item.profile);
   return {
     id: item.id,
     title: analysis.title,
+    ...(item.source.fileName === undefined ? {} : { fileName: item.source.fileName }),
     primaryStyle: analysis.primaryStyle,
-    tags: analysis.tags.slice(0, CARD_TAG_LIMIT),
+    tags: analysis.tags,
     designTypes: analysis.designTypes,
     kind: item.kind,
     previewPath,
@@ -74,17 +36,17 @@ export function projectItem(item: ItemRecord, previewPath: string): ItemSummary 
     updatedAt: item.updatedAt,
     ...(item.deletedAt === undefined ? {} : { deletedAt: item.deletedAt }),
     edited: LIBRARIAN_FIELDS.some((field) => isOverridden(item.profile, field)),
-    searchText: buildSearchText(item),
   };
 }
 
-export function projectJob(job: JobRecord): JobSummary {
+export function projectJob(job: JobRecord): JobIndexEntry {
   return {
     id: job.id,
     kind: job.kind,
     status: job.status,
     target: job.target,
     createdAt: job.createdAt,
+    ...(job.completedAt === undefined ? {} : { completedAt: job.completedAt }),
     ...(job.error === undefined ? {} : { error: job.error }),
   };
 }

--- a/plugins/sero-design-library-plugin/runtime/store.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/store.test.ts
@@ -7,7 +7,7 @@ import { emptyAnalysis } from '../shared/librarian';
 import { designLibraryPathsFromHome, itemRecordFile, jobFile, type DesignLibraryPaths } from '../shared/paths';
 import type { ItemRecord } from '../shared/records';
 import { ITEM_SCHEMA_VERSION } from '../shared/records';
-import { readState, writeJsonFile } from '../shared/state-io';
+import { readStateWithIndexes, writeJsonFile } from '../shared/state-io';
 import { listJobs, readItem, reindex, saveItem, scanItems } from './store';
 
 /**
@@ -90,7 +90,7 @@ describe('reading records this version does not understand', () => {
     const unreadable = await reindex(paths);
 
     expect(unreadable).toEqual(['itm-legacy']);
-    expect((await readState(paths)).items.map((item) => item.id)).toEqual(['good-1']);
+    expect((await readStateWithIndexes(paths)).items.map((item) => item.id)).toEqual(['good-1']);
     // Nothing is destroyed just because this version cannot read it.
     expect(await readItem(paths, 'itm-legacy')).toBeNull();
     await expect(
@@ -101,12 +101,8 @@ describe('reading records this version does not understand', () => {
   it('drops a stale summary for a record that no longer validates', async () => {
     await saveItem(paths, validItem('good-1'));
     await writeJsonFile(itemRecordFile(paths, 'itm-legacy'), LEGACY_RECORD);
-    // Reactive state still carries a summary written by the older version.
-    const { updateState } = await import('../shared/state-io');
-    await updateState(paths, (current) => ({
-      ...current,
-      items: [
-        ...current.items,
+    // The compact index still carries a summary written by the older version.
+    await writeJsonFile(paths.itemsIndexFile, [
         {
           id: 'itm-legacy',
           title: 'Image unavailable',
@@ -123,13 +119,11 @@ describe('reading records this version does not understand', () => {
           createdAt: 0,
           updatedAt: 0,
           edited: false,
-          searchText: '',
         },
-      ],
-    }));
+    ]);
 
     await reindex(paths);
-    expect((await readState(paths)).items.map((item) => item.id)).toEqual(['good-1']);
+    expect((await readStateWithIndexes(paths)).items.map((item) => item.id)).toEqual(['good-1']);
   });
 
   it('skips a truncated record rather than crashing on it', async () => {
@@ -149,7 +143,7 @@ describe('reading records this version does not understand', () => {
     });
 
     await expect(reindex(paths)).resolves.toEqual([]);
-    const summary = (await readState(paths)).items.find((item) => item.id === 'itm-thin');
+    const summary = (await readStateWithIndexes(paths)).items.find((item) => item.id === 'itm-thin');
     expect(summary?.title).toBe('Only a title');
     expect(summary?.tags).toEqual([]);
     expect(summary?.colours).toEqual([]);
@@ -166,6 +160,7 @@ describe('reading records this version does not understand', () => {
       attempts: 0,
     });
 
+    await expect(reindex(paths)).resolves.toEqual(['job-legacy.json']);
     expect((await listJobs(paths)).map((job) => job.id)).toEqual(['job-ok']);
   });
 });

--- a/plugins/sero-design-library-plugin/runtime/store.ts
+++ b/plugins/sero-design-library-plugin/runtime/store.ts
@@ -151,6 +151,33 @@ async function scanJobRecords(paths: DesignLibraryPaths): Promise<{ jobs: JobRec
   };
 }
 
+/**
+ * Rebuild the jobs index from its authoritative records before restart recovery.
+ *
+ * A process can stop after a job record is durable but before its index entry
+ * lands. Recovery must still see that record, especially for media jobs that
+ * must not run twice. This is the only entity scan on normal startup.
+ */
+export async function healJobsIndex(paths: DesignLibraryPaths): Promise<JobRecord[]> {
+  const { jobs } = await scanJobRecords(paths);
+  const cutoff = Date.now() - FINISHED_JOB_RETENTION_MS;
+  const isLive = (job: JobRecord) =>
+    job.status === 'queued' || job.status === 'running' || (job.completedAt ?? job.createdAt) > cutoff;
+  const liveJobs = jobs.filter(isLive);
+
+  await Promise.all(
+    jobs.flatMap((job) => (isLive(job) ? [] : [rm(jobFile(paths, job.id), { force: true })])),
+  );
+  const changed = await replaceIndex(
+    paths,
+    paths.jobsIndexFile,
+    normalizeJobIndex,
+    liveJobs.map(projectJob),
+  );
+  if (changed) await bumpControlRevision(paths);
+  return liveJobs;
+}
+
 /** Assumes the caller holds the job's record lock. */
 async function writeJob(paths: DesignLibraryPaths, job: JobRecord): Promise<JobRecord> {
   await writeJsonFile(jobFile(paths, job.id), job);
@@ -218,8 +245,7 @@ export async function mutateJob(
 }
 
 /**
- * Rebuild the whole index from the records. Called at startup, which is what
- * makes an index write interrupted by a crash self-healing rather than fatal.
+ * Rebuild every index from the records during migration or an explicit repair.
  *
  * Returns the record directories this version could not read, item ids and
  * design ids together — they are reported to the user, never deleted.

--- a/plugins/sero-design-library-plugin/runtime/store.ts
+++ b/plugins/sero-design-library-plugin/runtime/store.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import type { DesignLibraryPaths } from '../shared/paths';
 import { itemDir, itemRecordFile, jobFile } from '../shared/paths';
+import { withIndexRepair } from '../shared/index-repair';
 import type { ItemRecord, JobRecord } from '../shared/records';
 import { normalizeItemRecord, normalizeJobRecord } from '../shared/records';
 import { bumpControlRevision, readIndex, replaceIndex, updateIndex } from '../shared/index-storage';
@@ -79,10 +80,12 @@ export function originalPathFor(item: ItemRecord): string {
  */
 async function writeItem(paths: DesignLibraryPaths, item: ItemRecord): Promise<ItemRecord> {
   const next: ItemRecord = { ...item, updatedAt: Date.now() };
-  await writeJsonFile(itemRecordFile(paths, next.id), next);
-  const summary = projectItem(next, previewPathFor(next));
-  await updateIndex(paths, paths.itemsIndexFile, normalizeItemIndex, next.id, summary);
-  await bumpControlRevision(paths);
+  await withIndexRepair(paths, 'items', next.id, async () => {
+    await writeJsonFile(itemRecordFile(paths, next.id), next);
+    const summary = projectItem(next, previewPathFor(next));
+    await updateIndex(paths, paths.itemsIndexFile, normalizeItemIndex, next.id, summary);
+    await bumpControlRevision(paths);
+  });
   return next;
 }
 
@@ -123,9 +126,11 @@ export async function mutateItem(
  */
 export async function destroyItem(paths: DesignLibraryPaths, itemId: string): Promise<void> {
   await withRecordLock(paths, itemRecordFile(paths, itemId), async () => {
-    await rm(itemDir(paths, itemId), { recursive: true, force: true });
-    await updateIndex(paths, paths.itemsIndexFile, normalizeItemIndex, itemId, null);
-    await bumpControlRevision(paths);
+    await withIndexRepair(paths, 'items', itemId, async () => {
+      await rm(itemDir(paths, itemId), { recursive: true, force: true });
+      await updateIndex(paths, paths.itemsIndexFile, normalizeItemIndex, itemId, null);
+      await bumpControlRevision(paths);
+    });
   });
 }
 
@@ -218,17 +223,6 @@ export async function dismissJob(paths: DesignLibraryPaths, jobId: string): Prom
     await bumpControlRevision(paths);
     return true;
   });
-}
-
-/** Prune retained job records from the compact index without scanning all records. */
-export async function pruneFinishedJobs(paths: DesignLibraryPaths, now = Date.now()): Promise<number> {
-  const jobs = await readIndex(paths.jobsIndexFile, normalizeJobIndex);
-  const cutoff = now - FINISHED_JOB_RETENTION_MS;
-  const expired = jobs.filter((job) =>
-    job.status !== 'queued' && job.status !== 'running' && (job.completedAt ?? job.createdAt) <= cutoff,
-  );
-  for (const job of expired) await dismissJob(paths, job.id);
-  return expired.length;
 }
 
 /** Read and write under one lock, for the same reason as `mutateItem`. */

--- a/plugins/sero-design-library-plugin/runtime/store.ts
+++ b/plugins/sero-design-library-plugin/runtime/store.ts
@@ -5,8 +5,9 @@ import type { DesignLibraryPaths } from '../shared/paths';
 import { itemDir, itemRecordFile, jobFile } from '../shared/paths';
 import type { ItemRecord, JobRecord } from '../shared/records';
 import { normalizeItemRecord, normalizeJobRecord } from '../shared/records';
-import { readJsonFile, updateState, withRecordLock, writeJsonFile } from '../shared/state-io';
-import type { DesignLibraryState } from '../shared/types';
+import { bumpControlRevision, readIndex, replaceIndex, updateIndex } from '../shared/index-storage';
+import { normalizeDesignIndex, normalizeItemIndex, normalizeJobIndex } from '../shared/indexes';
+import { readJsonFile, withRecordLock, writeJsonFile } from '../shared/state-io';
 import { scanDesigns } from './design-store';
 import { projectDesign, projectItem, projectJob } from './projection';
 
@@ -80,10 +81,8 @@ async function writeItem(paths: DesignLibraryPaths, item: ItemRecord): Promise<I
   const next: ItemRecord = { ...item, updatedAt: Date.now() };
   await writeJsonFile(itemRecordFile(paths, next.id), next);
   const summary = projectItem(next, previewPathFor(next));
-  await updateState(paths, (current) => ({
-    ...current,
-    items: [...current.items.filter((entry) => entry.id !== next.id), summary],
-  }));
+  await updateIndex(paths, paths.itemsIndexFile, normalizeItemIndex, next.id, summary);
+  await bumpControlRevision(paths);
   return next;
 }
 
@@ -125,10 +124,8 @@ export async function mutateItem(
 export async function destroyItem(paths: DesignLibraryPaths, itemId: string): Promise<void> {
   await withRecordLock(paths, itemRecordFile(paths, itemId), async () => {
     await rm(itemDir(paths, itemId), { recursive: true, force: true });
-    await updateState(paths, (current) => ({
-      ...current,
-      items: current.items.filter((entry) => entry.id !== itemId),
-    }));
+    await updateIndex(paths, paths.itemsIndexFile, normalizeItemIndex, itemId, null);
+    await bumpControlRevision(paths);
   });
 }
 
@@ -137,25 +134,29 @@ export async function readJob(paths: DesignLibraryPaths, jobId: string): Promise
 }
 
 export async function listJobs(paths: DesignLibraryPaths): Promise<JobRecord[]> {
-  const entries = await readdir(paths.jobsDir).catch(() => []);
-  const jobs = await Promise.all(
-    entries.flatMap((entry) =>
-      entry.endsWith('.json')
-        ? [readJsonFile<unknown>(path.join(paths.jobsDir, entry)).then(normalizeJobRecord)]
-        : [],
-    ),
-  );
+  const index = await readIndex(paths.jobsIndexFile, normalizeJobIndex);
+  const jobs = await Promise.all(index.map((entry) => readJob(paths, entry.id)));
   return jobs.filter((job): job is JobRecord => job !== null);
+}
+
+async function scanJobRecords(paths: DesignLibraryPaths): Promise<{ jobs: JobRecord[]; unreadable: string[] }> {
+  const entries = await readdir(paths.jobsDir).catch(() => []);
+  const names = entries.filter((entry) => entry.endsWith('.json') && entry !== 'index.json');
+  const records = await Promise.all(
+    names.map((entry) => readJsonFile<unknown>(path.join(paths.jobsDir, entry)).then(normalizeJobRecord)),
+  );
+  return {
+    jobs: records.filter((job): job is JobRecord => job !== null),
+    unreadable: names.filter((_, index) => records[index] === null),
+  };
 }
 
 /** Assumes the caller holds the job's record lock. */
 async function writeJob(paths: DesignLibraryPaths, job: JobRecord): Promise<JobRecord> {
   await writeJsonFile(jobFile(paths, job.id), job);
   const summary = projectJob(job);
-  await updateState(paths, (current) => ({
-    ...current,
-    jobs: [...current.jobs.filter((entry) => entry.id !== job.id), summary],
-  }));
+  await updateIndex(paths, paths.jobsIndexFile, normalizeJobIndex, job.id, summary);
+  await bumpControlRevision(paths);
   return job;
 }
 
@@ -186,12 +187,21 @@ export async function dismissJob(paths: DesignLibraryPaths, jobId: string): Prom
     // renders, and a summary outliving its record is exactly the tile that
     // cannot be got rid of.
     await rm(jobFile(paths, jobId), { force: true });
-    await updateState(paths, (current) => ({
-      ...current,
-      jobs: current.jobs.filter((entry) => entry.id !== jobId),
-    }));
+    await updateIndex(paths, paths.jobsIndexFile, normalizeJobIndex, jobId, null);
+    await bumpControlRevision(paths);
     return true;
   });
+}
+
+/** Prune retained job records from the compact index without scanning all records. */
+export async function pruneFinishedJobs(paths: DesignLibraryPaths, now = Date.now()): Promise<number> {
+  const jobs = await readIndex(paths.jobsIndexFile, normalizeJobIndex);
+  const cutoff = now - FINISHED_JOB_RETENTION_MS;
+  const expired = jobs.filter((job) =>
+    job.status !== 'queued' && job.status !== 'running' && (job.completedAt ?? job.createdAt) <= cutoff,
+  );
+  for (const job of expired) await dismissJob(paths, job.id);
+  return expired.length;
 }
 
 /** Read and write under one lock, for the same reason as `mutateItem`. */
@@ -214,12 +224,13 @@ export async function mutateJob(
  * Returns the record directories this version could not read, item ids and
  * design ids together — they are reported to the user, never deleted.
  */
-export async function reindex(paths: DesignLibraryPaths): Promise<string[]> {
-  const [{ items, unreadable }, designScan, jobs] = await Promise.all([
+export async function reindex(paths: DesignLibraryPaths, notify = true): Promise<string[]> {
+  const [{ items, unreadable }, designScan, jobScan] = await Promise.all([
     scanItems(paths),
     scanDesigns(paths),
-    listJobs(paths),
+    scanJobRecords(paths),
   ]);
+  const jobs = jobScan.jobs;
   const cutoff = Date.now() - FINISHED_JOB_RETENTION_MS;
   const isLive = (job: JobRecord) =>
     job.status === 'queued' || job.status === 'running' || (job.completedAt ?? job.createdAt) > cutoff;
@@ -231,14 +242,22 @@ export async function reindex(paths: DesignLibraryPaths): Promise<string[]> {
     jobs.flatMap((job) => (isLive(job) ? [] : [rm(jobFile(paths, job.id), { force: true })])),
   );
 
-  await updateState(paths, (current: DesignLibraryState) => ({
-    ...current,
-    items: items.map((item) => projectItem(item, previewPathFor(item))),
-    designs: designScan.designs.map(projectDesign),
-    jobs: liveJobs.map(projectJob),
-  }));
+  await replaceIndex(
+    paths,
+    paths.itemsIndexFile,
+    normalizeItemIndex,
+    items.map((item) => projectItem(item, previewPathFor(item))),
+  );
+  await replaceIndex(
+    paths,
+    paths.designsIndexFile,
+    normalizeDesignIndex,
+    designScan.designs.map(projectDesign),
+  );
+  await replaceIndex(paths, paths.jobsIndexFile, normalizeJobIndex, liveJobs.map(projectJob));
+  if (notify) await bumpControlRevision(paths);
 
-  return [...unreadable, ...designScan.unreadable];
+  return [...unreadable, ...designScan.unreadable, ...jobScan.unreadable];
 }
 
 /** An item is a duplicate when another live record shares its checksum. */

--- a/plugins/sero-design-library-plugin/runtime/write-interruption.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/write-interruption.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as IndexStorage from '../shared/index-storage';
+import { designLibraryPathsFromHome, type DesignLibraryPaths } from '../shared/paths';
+import type { ItemRecord } from '../shared/records';
+import { ITEM_SCHEMA_VERSION } from '../shared/records';
+import type * as StateIo from '../shared/state-io';
+
+const fault = vi.hoisted(() => ({ stage: null as 'record' | 'index' | 'control' | null }));
+
+vi.mock('../shared/state-io', async (importOriginal) => {
+  const actual = await importOriginal<typeof StateIo>();
+  return {
+    ...actual,
+    writeJsonFile: async (filePath: string, value: unknown) => {
+      if (fault.stage === 'record' && filePath.endsWith('/record.json')) {
+        fault.stage = null;
+        throw new Error('interrupted record write');
+      }
+      await actual.writeJsonFile(filePath, value);
+    },
+  };
+});
+
+vi.mock('../shared/index-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof IndexStorage>();
+  return {
+    ...actual,
+    updateIndex: async (...args: Parameters<typeof actual.updateIndex>) => {
+      if (fault.stage === 'index') {
+        fault.stage = null;
+        throw new Error('interrupted index write');
+      }
+      return actual.updateIndex(...args);
+    },
+    bumpControlRevision: async (...args: Parameters<typeof actual.bumpControlRevision>) => {
+      if (fault.stage === 'control') {
+        fault.stage = null;
+        throw new Error('interrupted control-state write');
+      }
+      return actual.bumpControlRevision(...args);
+    },
+  };
+});
+
+import { emptyAnalysis } from '../shared/librarian';
+import { readStateWithIndexes } from '../shared/state-io';
+import { readItem, reindex, saveItem } from './store';
+
+let home: string;
+let paths: DesignLibraryPaths;
+
+beforeEach(async () => {
+  home = await mkdtemp(path.join(tmpdir(), 'design-library-interruption-'));
+  paths = designLibraryPathsFromHome(home);
+  fault.stage = null;
+});
+
+afterEach(async () => rm(home, { recursive: true, force: true }));
+
+function item(): ItemRecord {
+  return {
+    id: 'item-1', schemaVersion: ITEM_SCHEMA_VERSION, createdAt: 1, updatedAt: 1,
+    kind: 'image', source: { kind: 'file', fileName: 'source.png' },
+    asset: { originalFile: 'original.png', previewFile: 'preview.webp', mediaType: 'image/png', bytes: 1, checksum: 'sum' },
+    profile: { generated: emptyAnalysis('Reference'), overrides: {} },
+    analysis: { status: 'ready', attempts: 1 }, favourite: false, collectionIds: [],
+  };
+}
+
+describe('interrupted record projection writes', () => {
+  it('publishes nothing when the record write is interrupted', async () => {
+    fault.stage = 'record';
+    await expect(saveItem(paths, item())).rejects.toThrow('interrupted record write');
+
+    expect(await readItem(paths, 'item-1')).toBeNull();
+    const state = await readStateWithIndexes(paths);
+    expect(state.items).toEqual([]);
+    expect(state.revision).toBe(0);
+  });
+
+  it('repairs a durable record after the index write is interrupted', async () => {
+    fault.stage = 'index';
+    await expect(saveItem(paths, item())).rejects.toThrow('interrupted index write');
+
+    expect(await readItem(paths, 'item-1')).not.toBeNull();
+    expect((await readStateWithIndexes(paths)).items).toEqual([]);
+
+    await reindex(paths);
+    const state = await readStateWithIndexes(paths);
+    expect(state.items.map((entry) => entry.id)).toEqual(['item-1']);
+    expect(state.revision).toBe(1);
+  });
+
+  it('keeps the record and index when the control-state write is interrupted', async () => {
+    fault.stage = 'control';
+    await expect(saveItem(paths, item())).rejects.toThrow('interrupted control-state write');
+
+    const interrupted = await readStateWithIndexes(paths);
+    expect(interrupted.items.map((entry) => entry.id)).toEqual(['item-1']);
+    expect(interrupted.revision).toBe(0);
+
+    await reindex(paths);
+    expect((await readStateWithIndexes(paths)).revision).toBe(1);
+  });
+});

--- a/plugins/sero-design-library-plugin/runtime/write-interruption.test.ts
+++ b/plugins/sero-design-library-plugin/runtime/write-interruption.test.ts
@@ -47,8 +47,10 @@ vi.mock('../shared/index-storage', async (importOriginal) => {
 });
 
 import { emptyAnalysis } from '../shared/librarian';
+import { listPendingIndexRepairs } from '../shared/index-repair';
 import { readStateWithIndexes } from '../shared/state-io';
-import { readItem, reindex, saveItem } from './store';
+import { repairPendingIndexes } from './index-repair';
+import { readItem, saveItem } from './store';
 
 let home: string;
 let paths: DesignLibraryPaths;
@@ -80,6 +82,10 @@ describe('interrupted record projection writes', () => {
     const state = await readStateWithIndexes(paths);
     expect(state.items).toEqual([]);
     expect(state.revision).toBe(0);
+
+    await repairPendingIndexes(paths);
+    expect((await readStateWithIndexes(paths)).items).toEqual([]);
+    expect(await listPendingIndexRepairs(paths)).toEqual([]);
   });
 
   it('repairs a durable record after the index write is interrupted', async () => {
@@ -89,7 +95,7 @@ describe('interrupted record projection writes', () => {
     expect(await readItem(paths, 'item-1')).not.toBeNull();
     expect((await readStateWithIndexes(paths)).items).toEqual([]);
 
-    await reindex(paths);
+    await repairPendingIndexes(paths);
     const state = await readStateWithIndexes(paths);
     expect(state.items.map((entry) => entry.id)).toEqual(['item-1']);
     expect(state.revision).toBe(1);
@@ -103,7 +109,8 @@ describe('interrupted record projection writes', () => {
     expect(interrupted.items.map((entry) => entry.id)).toEqual(['item-1']);
     expect(interrupted.revision).toBe(0);
 
-    await reindex(paths);
+    await repairPendingIndexes(paths);
     expect((await readStateWithIndexes(paths)).revision).toBe(1);
+    expect(await listPendingIndexRepairs(paths)).toEqual([]);
   });
 });

--- a/plugins/sero-design-library-plugin/shared/index-repair.ts
+++ b/plugins/sero-design-library-plugin/shared/index-repair.ts
@@ -1,0 +1,62 @@
+import { readdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+import type { DesignLibraryPaths } from './paths';
+import { assertSafeId, isSafeId } from './paths';
+import { writeJsonFile } from './state-io';
+
+export type RepairIndexName = 'items' | 'designs' | 'gallery' | 'exports';
+
+export interface PendingIndexRepair {
+  index: RepairIndexName;
+  id: string;
+}
+
+function repairFile(paths: DesignLibraryPaths, index: RepairIndexName, id: string): string {
+  return path.join(paths.indexRepairsDir, index, `${assertSafeId(id, `${index} record id`)}.json`);
+}
+
+/** Record an index projection before its authoritative record can change. */
+export async function markIndexRepair(
+  paths: DesignLibraryPaths,
+  index: RepairIndexName,
+  id: string,
+): Promise<void> {
+  await writeJsonFile(repairFile(paths, index, id), { id });
+}
+
+export async function clearIndexRepair(
+  paths: DesignLibraryPaths,
+  index: RepairIndexName,
+  id: string,
+): Promise<void> {
+  await rm(repairFile(paths, index, id), { force: true });
+}
+
+export async function withIndexRepair<T>(
+  paths: DesignLibraryPaths,
+  index: RepairIndexName,
+  id: string,
+  write: () => Promise<T>,
+): Promise<T> {
+  await markIndexRepair(paths, index, id);
+  const result = await write();
+  await clearIndexRepair(paths, index, id);
+  return result;
+}
+
+/** Read only the small set of interrupted transactions, not every entity. */
+export async function listPendingIndexRepairs(
+  paths: DesignLibraryPaths,
+): Promise<PendingIndexRepair[]> {
+  const indexes: RepairIndexName[] = ['items', 'designs', 'gallery', 'exports'];
+  const pending = await Promise.all(indexes.map(async (index) => {
+    const entries = await readdir(path.join(paths.indexRepairsDir, index)).catch(() => []);
+    return entries.flatMap((entry) => {
+      if (!entry.endsWith('.json')) return [];
+      const id = entry.slice(0, -'.json'.length);
+      return isSafeId(id) ? [{ index, id }] : [];
+    });
+  }));
+  return pending.flat();
+}

--- a/plugins/sero-design-library-plugin/shared/index-repair.ts
+++ b/plugins/sero-design-library-plugin/shared/index-repair.ts
@@ -12,6 +12,42 @@ export interface PendingIndexRepair {
   id: string;
 }
 
+export interface FullIndexRepairRequest {
+  requestedAt: number;
+  attempts: number;
+}
+
+export interface FailedIndexRepair extends FullIndexRepairRequest {
+  failedAt: number;
+  error: string;
+}
+
+function object(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+export function normalizeFullIndexRepairRequest(value: unknown): FullIndexRepairRequest | null {
+  const entry = object(value);
+  if (!entry || typeof entry.requestedAt !== 'number') return null;
+  return {
+    requestedAt: entry.requestedAt,
+    attempts: typeof entry.attempts === 'number' && Number.isInteger(entry.attempts)
+      ? Math.max(0, entry.attempts)
+      : 0,
+  };
+}
+
+export function normalizeFailedIndexRepair(value: unknown): FailedIndexRepair | null {
+  const request = normalizeFullIndexRepairRequest(value);
+  const entry = object(value);
+  if (!request || !entry || typeof entry.failedAt !== 'number' || typeof entry.error !== 'string') {
+    return null;
+  }
+  return { ...request, failedAt: entry.failedAt, error: entry.error };
+}
+
 function repairFile(paths: DesignLibraryPaths, index: RepairIndexName, id: string): string {
   return path.join(paths.indexRepairsDir, index, `${assertSafeId(id, `${index} record id`)}.json`);
 }

--- a/plugins/sero-design-library-plugin/shared/index-storage.ts
+++ b/plugins/sero-design-library-plugin/shared/index-storage.ts
@@ -1,0 +1,59 @@
+import type { DesignLibraryPaths } from './paths';
+import { readJsonFile, updateState, withRecordLock, writeJsonFile } from './state-io';
+
+export async function readIndex<T>(
+  filePath: string,
+  normalize: (value: unknown) => T[],
+): Promise<T[]> {
+  return normalize(await readJsonFile<unknown>(filePath));
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+/**
+ * Update one compact index under its cross-process lock. The caller holds the
+ * entity record lock, which establishes the order record, index, control state.
+ */
+export async function updateIndex<T extends { id: string }>(
+  paths: DesignLibraryPaths,
+  filePath: string,
+  normalize: (value: unknown) => T[],
+  id: string,
+  entry: T | null,
+): Promise<boolean> {
+  return withRecordLock(paths, filePath, async () => {
+    const current = await readIndex(filePath, normalize);
+    const existing = current.find((candidate) => candidate.id === id);
+    if (entry !== null && existing !== undefined && sameValue(existing, entry)) return false;
+    if (entry === null && existing === undefined) return false;
+    const next = entry === null
+      ? current.filter((candidate) => candidate.id !== id)
+      : existing === undefined
+        ? [...current, entry]
+        : current.map((candidate) => candidate.id === id ? entry : candidate);
+    await writeJsonFile(filePath, next);
+    return true;
+  });
+}
+
+export async function replaceIndex<T>(
+  paths: DesignLibraryPaths,
+  filePath: string,
+  normalize: (value: unknown) => T[],
+  entries: T[],
+): Promise<boolean> {
+  return withRecordLock(paths, filePath, async () => {
+    const raw = await readJsonFile<unknown>(filePath);
+    const current = normalize(raw);
+    if (raw !== null && sameValue(current, entries)) return false;
+    await writeJsonFile(filePath, entries);
+    return true;
+  });
+}
+
+/** Notify detail views after the record and its index are durable. */
+export async function bumpControlRevision(paths: DesignLibraryPaths): Promise<void> {
+  await updateState(paths, (state) => state);
+}

--- a/plugins/sero-design-library-plugin/shared/indexes.test.ts
+++ b/plugins/sero-design-library-plugin/shared/indexes.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeDesignIndex,
+  normalizeExportIndex,
+  normalizeGalleryIndex,
+  normalizeItemIndex,
+  normalizeJobIndex,
+} from './indexes';
+
+describe('entity index normalizers', () => {
+  it('normalizes item list fields without detailed analysis', () => {
+    const [item] = normalizeItemIndex([{
+      id: 'itm-1', title: 'Poster', fileName: 'poster.png', primaryStyle: 'Editorial',
+      tags: ['one', 2, 'seven'], designTypes: ['Landing'], kind: 'image', previewPath: 'preview.webp',
+      analysisStatus: 'ready', favourite: true, collectionIds: [], colours: ['#fff'],
+      sourceKind: 'file', createdAt: 1, updatedAt: 2, edited: false, notes: 'excluded',
+    }]);
+    expect(item?.tags).toEqual(['one', 'seven']);
+    expect(item).not.toHaveProperty('notes');
+  });
+
+  it('drops invalid entries from every index', () => {
+    expect(normalizeItemIndex([null])).toEqual([]);
+    expect(normalizeDesignIndex([null])).toEqual([]);
+    expect(normalizeGalleryIndex([null])).toEqual([]);
+    expect(normalizeJobIndex([null])).toEqual([]);
+    expect(normalizeExportIndex([null])).toEqual([]);
+  });
+});

--- a/plugins/sero-design-library-plugin/shared/indexes.ts
+++ b/plugins/sero-design-library-plugin/shared/indexes.ts
@@ -1,0 +1,136 @@
+import { normalizeDesignSummary } from './design-summary';
+import type { ExportSummary } from './export';
+import { normalizeExportSummary } from './export';
+import type { GalleryFamilyRecord } from './gallery';
+import { normalizeGalleryFamily } from './gallery';
+import type { AnalysisStatus, JobKind, JobStatus, JobTarget, MediaKind } from './records';
+import { normalizeJobRecord } from './records';
+import type { DesignSummary } from './types';
+
+export interface ItemIndexEntry {
+  id: string;
+  title: string;
+  fileName?: string;
+  primaryStyle: string;
+  tags: string[];
+  designTypes: string[];
+  kind: MediaKind;
+  previewPath: string;
+  analysisStatus: AnalysisStatus;
+  analysisError?: string;
+  awaitingFrames?: boolean;
+  favourite: boolean;
+  collectionIds: string[];
+  colours: string[];
+  sourceKind: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt?: number;
+  edited: boolean;
+}
+
+export interface JobIndexEntry {
+  id: string;
+  kind: JobKind;
+  status: JobStatus;
+  target: JobTarget;
+  createdAt: number;
+  completedAt?: number;
+  error?: string;
+}
+
+export type DesignIndexEntry = DesignSummary;
+export type GalleryIndexEntry = GalleryFamilyRecord;
+export type ExportIndexEntry = ExportSummary;
+
+export interface EntityIndexes {
+  items: ItemIndexEntry[];
+  designs: DesignIndexEntry[];
+  gallery: GalleryIndexEntry[];
+  jobs: JobIndexEntry[];
+  exports: ExportIndexEntry[];
+}
+
+export const EMPTY_INDEXES: EntityIndexes = {
+  items: [],
+  designs: [],
+  gallery: [],
+  jobs: [],
+  exports: [],
+};
+
+function object(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : [];
+}
+
+function number(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function analysisStatus(value: unknown): AnalysisStatus {
+  return value === 'running' || value === 'ready' || value === 'failed' || value === 'cancelled'
+    ? value
+    : 'pending';
+}
+
+export function normalizeItemIndexEntry(value: unknown): ItemIndexEntry | null {
+  const entry = object(value);
+  if (!entry || typeof entry.id !== 'string') return null;
+  return {
+    id: entry.id,
+    title: typeof entry.title === 'string' ? entry.title : 'Untitled',
+    ...(typeof entry.fileName === 'string' ? { fileName: entry.fileName } : {}),
+    primaryStyle: typeof entry.primaryStyle === 'string' ? entry.primaryStyle : '',
+    tags: strings(entry.tags),
+    designTypes: strings(entry.designTypes),
+    kind: entry.kind === 'video' ? 'video' : 'image',
+    previewPath: typeof entry.previewPath === 'string' ? entry.previewPath : '',
+    analysisStatus: analysisStatus(entry.analysisStatus),
+    ...(typeof entry.analysisError === 'string' ? { analysisError: entry.analysisError } : {}),
+    ...(entry.awaitingFrames === true ? { awaitingFrames: true } : {}),
+    favourite: entry.favourite === true,
+    collectionIds: strings(entry.collectionIds),
+    colours: strings(entry.colours),
+    sourceKind: typeof entry.sourceKind === 'string' ? entry.sourceKind : 'file',
+    createdAt: number(entry.createdAt),
+    updatedAt: number(entry.updatedAt),
+    ...(typeof entry.deletedAt === 'number' ? { deletedAt: entry.deletedAt } : {}),
+    edited: entry.edited === true,
+  };
+}
+
+export function normalizeJobIndexEntry(value: unknown): JobIndexEntry | null {
+  const entry = object(value);
+  if (!entry || typeof entry.id !== 'string') return null;
+  const record = normalizeJobRecord({ ...entry, attempts: 0 });
+  if (!record) return null;
+  return {
+    id: record.id,
+    kind: record.kind,
+    status: record.status,
+    target: record.target,
+    createdAt: record.createdAt,
+    ...(record.completedAt === undefined ? {} : { completedAt: record.completedAt }),
+    ...(typeof entry.error === 'string' ? { error: entry.error } : {}),
+  };
+}
+
+function normalizeList<T>(value: unknown, normalize: (entry: unknown) => T | null): T[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    const normalized = normalize(entry);
+    return normalized === null ? [] : [normalized];
+  });
+}
+
+export const normalizeItemIndex = (value: unknown) => normalizeList(value, normalizeItemIndexEntry);
+export const normalizeDesignIndex = (value: unknown) => normalizeList(value, normalizeDesignSummary);
+export const normalizeGalleryIndex = (value: unknown) => normalizeList(value, normalizeGalleryFamily);
+export const normalizeJobIndex = (value: unknown) => normalizeList(value, normalizeJobIndexEntry);
+export const normalizeExportIndex = (value: unknown) => normalizeList(value, normalizeExportSummary);

--- a/plugins/sero-design-library-plugin/shared/paths.ts
+++ b/plugins/sero-design-library-plugin/shared/paths.ts
@@ -28,11 +28,17 @@ export interface DesignLibraryPaths {
    */
   recordLocksDir: string;
   itemsDir: string;
+  itemsIndexFile: string;
   designsDir: string;
+  designsIndexFile: string;
   jobsDir: string;
+  jobsIndexFile: string;
+  exportsDir: string;
+  exportsIndexFile: string;
   uploadsDir: string;
   tombstonesDir: string;
   galleryDir: string;
+  galleryIndexFile: string;
   /**
    * The user-supplied provider key, written `0600` (spec §8.3). Deliberately a
    * file rather than reactive state: state is read by the UI, and the key must
@@ -48,11 +54,17 @@ export function designLibraryPathsFromHome(home: string): DesignLibraryPaths {
     lockDir: path.join(home, '.state.lock'),
     recordLocksDir: path.join(home, '.record-locks'),
     itemsDir: path.join(home, 'items'),
+    itemsIndexFile: path.join(home, 'items', 'index.json'),
     designsDir: path.join(home, 'designs'),
+    designsIndexFile: path.join(home, 'designs', 'index.json'),
     jobsDir: path.join(home, 'jobs'),
+    jobsIndexFile: path.join(home, 'jobs', 'index.json'),
+    exportsDir: path.join(home, 'exports'),
+    exportsIndexFile: path.join(home, 'exports', 'index.json'),
     uploadsDir: path.join(home, 'uploads'),
     tombstonesDir: path.join(home, 'tombstones'),
     galleryDir: path.join(home, 'gallery'),
+    galleryIndexFile: path.join(home, 'gallery', 'index.json'),
     secretsFile: path.join(home, 'secrets.json'),
   };
 }
@@ -178,6 +190,10 @@ export function galleryVersionRecordFile(
 
 export function jobFile(paths: DesignLibraryPaths, jobId: string): string {
   return path.join(paths.jobsDir, `${assertSafeId(jobId, 'job id')}.json`);
+}
+
+export function exportFile(paths: DesignLibraryPaths, exportId: string): string {
+  return path.join(paths.exportsDir, `${assertSafeId(exportId, 'export id')}.json`);
 }
 
 export function uploadDir(paths: DesignLibraryPaths, uploadId: string): string {

--- a/plugins/sero-design-library-plugin/shared/paths.ts
+++ b/plugins/sero-design-library-plugin/shared/paths.ts
@@ -29,6 +29,8 @@ export interface DesignLibraryPaths {
   recordLocksDir: string;
   /** Small crash journal for record writes that still need index projection. */
   indexRepairsDir: string;
+  /** Durable request for a deliberate full index repair on next startup. */
+  repairRequestFile: string;
   itemsDir: string;
   itemsIndexFile: string;
   designsDir: string;
@@ -56,6 +58,7 @@ export function designLibraryPathsFromHome(home: string): DesignLibraryPaths {
     lockDir: path.join(home, '.state.lock'),
     recordLocksDir: path.join(home, '.record-locks'),
     indexRepairsDir: path.join(home, '.index-repairs'),
+    repairRequestFile: path.join(home, '.repair-indexes.json'),
     itemsDir: path.join(home, 'items'),
     itemsIndexFile: path.join(home, 'items', 'index.json'),
     designsDir: path.join(home, 'designs'),

--- a/plugins/sero-design-library-plugin/shared/paths.ts
+++ b/plugins/sero-design-library-plugin/shared/paths.ts
@@ -27,6 +27,8 @@ export interface DesignLibraryPaths {
    * lock on the way out.
    */
   recordLocksDir: string;
+  /** Small crash journal for record writes that still need index projection. */
+  indexRepairsDir: string;
   itemsDir: string;
   itemsIndexFile: string;
   designsDir: string;
@@ -53,6 +55,7 @@ export function designLibraryPathsFromHome(home: string): DesignLibraryPaths {
     stateFile: path.join(home, 'state.json'),
     lockDir: path.join(home, '.state.lock'),
     recordLocksDir: path.join(home, '.record-locks'),
+    indexRepairsDir: path.join(home, '.index-repairs'),
     itemsDir: path.join(home, 'items'),
     itemsIndexFile: path.join(home, 'items', 'index.json'),
     designsDir: path.join(home, 'designs'),

--- a/plugins/sero-design-library-plugin/shared/paths.ts
+++ b/plugins/sero-design-library-plugin/shared/paths.ts
@@ -31,6 +31,8 @@ export interface DesignLibraryPaths {
   indexRepairsDir: string;
   /** Durable request for a deliberate full index repair on next startup. */
   repairRequestFile: string;
+  /** A full repair request that reached its automatic retry limit. */
+  repairFailedFile: string;
   itemsDir: string;
   itemsIndexFile: string;
   designsDir: string;
@@ -59,6 +61,7 @@ export function designLibraryPathsFromHome(home: string): DesignLibraryPaths {
     recordLocksDir: path.join(home, '.record-locks'),
     indexRepairsDir: path.join(home, '.index-repairs'),
     repairRequestFile: path.join(home, '.repair-indexes.json'),
+    repairFailedFile: path.join(home, '.repair-indexes.failed.json'),
     itemsDir: path.join(home, 'items'),
     itemsIndexFile: path.join(home, 'items', 'index.json'),
     designsDir: path.join(home, 'designs'),

--- a/plugins/sero-design-library-plugin/shared/scalability.test.ts
+++ b/plugins/sero-design-library-plugin/shared/scalability.test.ts
@@ -1,0 +1,45 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { DesignIndexEntry, ItemIndexEntry } from './indexes';
+import { designLibraryPathsFromHome } from './paths';
+import { selectItems } from './search';
+import { readStateWithIndexes, writeJsonFile } from './state-io';
+import { EMPTY_FILTERS } from './types';
+
+const homes: string[] = [];
+afterEach(async () => Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true }))));
+
+describe('large compact indexes', () => {
+  it('keeps 5,000 items and 1,000 Designs out of control state', async () => {
+    const home = await mkdtemp(path.join(tmpdir(), 'design-library-scale-'));
+    homes.push(home);
+    const paths = designLibraryPathsFromHome(home);
+    const items: ItemIndexEntry[] = Array.from({ length: 5_000 }, (_, index) => ({
+      id: `item-${index}`, title: `Reference ${index}`, fileName: `source-${index}.png`,
+      primaryStyle: index % 2 === 0 ? 'Editorial' : 'Technical', tags: [`tag-${index % 20}`, `tag-${index % 50}`],
+      designTypes: ['Landing'], kind: 'image', previewPath: `items/item-${index}/preview.webp`,
+      analysisStatus: 'ready', favourite: false, collectionIds: [], colours: [], sourceKind: 'file',
+      createdAt: index, updatedAt: index, edited: false,
+    }));
+    const designs: DesignIndexEntry[] = Array.from({ length: 1_000 }, (_, index) => ({
+      id: `design-${index}`, title: `Design ${index}`, target: 'html', variationMode: 'blend',
+      referenceItemIds: [`item-${index}`], variants: [], createdAt: index, updatedAt: index,
+    }));
+    await writeJsonFile(paths.itemsIndexFile, items);
+    await writeJsonFile(paths.designsIndexFile, designs);
+    await writeJsonFile(paths.stateFile, await readStateWithIndexes(paths));
+
+    const selected = selectItems(items, {
+      scope: { kind: 'all' }, filters: { ...EMPTY_FILTERS, tags: ['tag-8'] },
+      sort: 'newest', query: 'editorial landing source',
+    });
+    expect(selected.length).toBeGreaterThan(0);
+    const state = JSON.parse(await readFile(paths.stateFile, 'utf8')) as Record<string, unknown>;
+    expect(state).not.toHaveProperty('items');
+    expect(state).not.toHaveProperty('designs');
+    expect((await readFile(paths.stateFile, 'utf8')).length).toBeLessThan(10_000);
+  });
+});

--- a/plugins/sero-design-library-plugin/shared/search.test.ts
+++ b/plugins/sero-design-library-plugin/shared/search.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { deriveFacets, deriveStyleGroups, selectItems } from './search';
-import { EMPTY_FILTERS, type ItemSummary, type ViewPreferences } from './types';
+import { EMPTY_FILTERS, type ItemSummary, type LibraryViewPreferences } from './types';
 
 const NOW = 1_700_000_000_000;
 const DAY = 24 * 60 * 60 * 1000;
@@ -22,20 +22,19 @@ function item(overrides: Partial<ItemSummary> & { id: string }): ItemSummary {
     createdAt: NOW,
     updatedAt: NOW,
     edited: false,
-    searchText: '',
     ...overrides,
   };
 }
 
-function view(overrides: Partial<ViewPreferences> = {}): ViewPreferences {
+function view(overrides: Partial<LibraryViewPreferences> = {}): LibraryViewPreferences {
   return { scope: { kind: 'all' }, query: '', filters: EMPTY_FILTERS, sort: 'newest', ...overrides };
 }
 
 const ITEMS: ItemSummary[] = [
-  item({ id: 'a', title: 'Northstar', primaryStyle: 'Technical monochrome', tags: ['dense'], favourite: true, searchText: 'northstar technical monochrome dense grid' }),
-  item({ id: 'b', title: 'Material journal', primaryStyle: 'Editorial', tags: ['warm'], createdAt: NOW - 30 * DAY, searchText: 'material journal editorial warm overscale' }),
-  item({ id: 'c', title: 'Signal archive', primaryStyle: 'Technical monochrome', analysisStatus: 'pending', kind: 'video', searchText: 'signal archive technical monochrome' }),
-  item({ id: 'd', title: 'Deleted thing', deletedAt: NOW, searchText: 'deleted thing' }),
+  item({ id: 'a', title: 'Northstar', primaryStyle: 'Technical monochrome', tags: ['dense', 'grid'], favourite: true }),
+  item({ id: 'b', title: 'Material journal', fileName: 'overscale-board.png', primaryStyle: 'Editorial', tags: ['warm'], createdAt: NOW - 30 * DAY }),
+  item({ id: 'c', title: 'Signal archive', primaryStyle: 'Technical monochrome', analysisStatus: 'pending', kind: 'video' }),
+  item({ id: 'd', title: 'Deleted thing', deletedAt: NOW }),
 ];
 
 describe('scopes', () => {
@@ -66,6 +65,16 @@ describe('query', () => {
 
   it('ignores case and surrounding whitespace', () => {
     expect(selectItems(ITEMS, view({ query: '  EDITORIAL ' }), NOW).map((e) => e.id)).toEqual(['b']);
+  });
+
+  it('searches file names and Design types', () => {
+    const typed = item({ id: 'typed', fileName: 'launch-board.png', designTypes: ['Campaign landing'] });
+    expect(selectItems([typed], view({ query: 'board campaign' }), NOW)).toEqual([typed]);
+  });
+
+  it('does not search notes, prompts or detailed analysis', () => {
+    const detailed = { ...item({ id: 'detail' }), notes: 'secret-note', generationPrompt: 'secret-prompt' };
+    expect(selectItems([detailed], view({ query: 'secret' }), NOW)).toEqual([]);
   });
 });
 
@@ -118,6 +127,6 @@ describe('derived groups and facets', () => {
   it('excludes deleted items from facets', () => {
     const facets = deriveFacets(ITEMS);
     expect(facets.styles).toEqual(['Editorial', 'Technical monochrome']);
-    expect(facets.tags).toEqual(['dense', 'warm']);
+    expect(facets.tags).toEqual(['dense', 'grid', 'warm']);
   });
 });

--- a/plugins/sero-design-library-plugin/shared/search.test.ts
+++ b/plugins/sero-design-library-plugin/shared/search.test.ts
@@ -76,6 +76,17 @@ describe('query', () => {
     const detailed = { ...item({ id: 'detail' }), notes: 'secret-note', generationPrompt: 'secret-prompt' };
     expect(selectItems([detailed], view({ query: 'secret' }), NOW)).toEqual([]);
   });
+
+  it('refreshes cached search fields when a summary changes in place', () => {
+    const mutable = item({ id: 'mutable', title: 'Before', tags: ['old-tag'] });
+    expect(selectItems([mutable], view({ query: 'before old-tag' }), NOW)).toEqual([mutable]);
+
+    mutable.title = 'After';
+    mutable.tags[0] = 'new-tag';
+
+    expect(selectItems([mutable], view({ query: 'after new-tag' }), NOW)).toEqual([mutable]);
+    expect(selectItems([mutable], view({ query: 'before' }), NOW)).toEqual([]);
+  });
 });
 
 describe('filters', () => {

--- a/plugins/sero-design-library-plugin/shared/search.ts
+++ b/plugins/sero-design-library-plugin/shared/search.ts
@@ -8,19 +8,26 @@ import type { ItemSummary, LibraryFilters, LibraryScope, LibrarySort, LibraryVie
 import { colourFamily } from './colour-families';
 
 const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const searchTextCache = new WeakMap<ItemSummary, string>();
 
-/** Every term must match at least one supported high-level index field. */
-export function matchesQuery(item: ItemSummary, query: string): boolean {
-  const terms = query.toLowerCase().split(/\s+/).filter((term) => term !== '');
-  if (terms.length === 0) return true;
-  const fields = [
+function searchText(item: ItemSummary): string {
+  const cached = searchTextCache.get(item);
+  if (cached !== undefined) return cached;
+  const value = [
     item.title,
     item.fileName ?? '',
     item.primaryStyle,
     ...item.tags,
     ...item.designTypes,
-  ].map((field) => field.toLowerCase());
-  return terms.every((term) => fields.some((field) => field.includes(term)));
+  ].join('\n').toLowerCase();
+  searchTextCache.set(item, value);
+  return value;
+}
+
+/** Every normalized term must match the item's cached high-level fields. */
+function matchesQuery(item: ItemSummary, terms: string[]): boolean {
+  const text = searchText(item);
+  return terms.every((term) => text.includes(term));
 }
 
 export function matchesScope(item: ItemSummary, scope: LibraryScope, now: number): boolean {
@@ -82,11 +89,12 @@ export function selectItems(
   view: LibraryViewPreferences,
   now = Date.now(),
 ): ItemSummary[] {
+  const terms = view.query.toLowerCase().split(/\s+/).filter((term) => term !== '');
   const matched = items.filter(
     (item) =>
       matchesScope(item, view.scope, now) &&
       matchesFilters(item, view.filters) &&
-      matchesQuery(item, view.query),
+      matchesQuery(item, terms),
   );
   return sortItems(matched, view.sort);
 }

--- a/plugins/sero-design-library-plugin/shared/search.ts
+++ b/plugins/sero-design-library-plugin/shared/search.ts
@@ -8,11 +8,35 @@ import type { ItemSummary, LibraryFilters, LibraryScope, LibrarySort, LibraryVie
 import { colourFamily } from './colour-families';
 
 const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-const searchTextCache = new WeakMap<ItemSummary, string>();
+interface SearchTextCacheEntry {
+  title: string;
+  fileName?: string;
+  primaryStyle: string;
+  tags: string[];
+  designTypes: string[];
+  text: string;
+}
+
+const searchTextCache = new WeakMap<ItemSummary, SearchTextCacheEntry>();
+
+function sameStrings(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
 
 function searchText(item: ItemSummary): string {
   const cached = searchTextCache.get(item);
-  if (cached !== undefined) return cached;
+  if (
+    cached !== undefined &&
+    cached.title === item.title &&
+    cached.fileName === item.fileName &&
+    cached.primaryStyle === item.primaryStyle &&
+    sameStrings(cached.tags, item.tags) &&
+    sameStrings(cached.designTypes, item.designTypes)
+  ) return cached.text;
   const value = [
     item.title,
     item.fileName ?? '',
@@ -20,7 +44,14 @@ function searchText(item: ItemSummary): string {
     ...item.tags,
     ...item.designTypes,
   ].join('\n').toLowerCase();
-  searchTextCache.set(item, value);
+  searchTextCache.set(item, {
+    title: item.title,
+    ...(item.fileName === undefined ? {} : { fileName: item.fileName }),
+    primaryStyle: item.primaryStyle,
+    tags: [...item.tags],
+    designTypes: [...item.designTypes],
+    text: value,
+  });
   return value;
 }
 

--- a/plugins/sero-design-library-plugin/shared/search.ts
+++ b/plugins/sero-design-library-plugin/shared/search.ts
@@ -4,7 +4,7 @@
  * 'editorial', matching 'grid'" means.
  */
 
-import type { ItemSummary, LibraryFilters, LibraryScope, LibrarySort, ViewPreferences } from './types';
+import type { ItemSummary, LibraryFilters, LibraryScope, LibrarySort, LibraryViewPreferences } from './types';
 import { colourFamily } from './colour-families';
 
 const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
@@ -79,14 +79,14 @@ export function sortItems(items: ItemSummary[], sort: LibrarySort): ItemSummary[
 
 export function selectItems(
   items: ItemSummary[],
-  view: ViewPreferences & { query?: string },
+  view: LibraryViewPreferences,
   now = Date.now(),
 ): ItemSummary[] {
   const matched = items.filter(
     (item) =>
       matchesScope(item, view.scope, now) &&
       matchesFilters(item, view.filters) &&
-      matchesQuery(item, view.query ?? ''),
+      matchesQuery(item, view.query),
   );
   return sortItems(matched, view.sort);
 }

--- a/plugins/sero-design-library-plugin/shared/search.ts
+++ b/plugins/sero-design-library-plugin/shared/search.ts
@@ -9,11 +9,18 @@ import { colourFamily } from './colour-families';
 
 const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
-/** Every term must match somewhere in the item's searchable text. */
+/** Every term must match at least one supported high-level index field. */
 export function matchesQuery(item: ItemSummary, query: string): boolean {
   const terms = query.toLowerCase().split(/\s+/).filter((term) => term !== '');
   if (terms.length === 0) return true;
-  return terms.every((term) => item.searchText.includes(term));
+  const fields = [
+    item.title,
+    item.fileName ?? '',
+    item.primaryStyle,
+    ...item.tags,
+    ...item.designTypes,
+  ].map((field) => field.toLowerCase());
+  return terms.every((term) => fields.some((field) => field.includes(term)));
 }
 
 export function matchesScope(item: ItemSummary, scope: LibraryScope, now: number): boolean {
@@ -72,14 +79,14 @@ export function sortItems(items: ItemSummary[], sort: LibrarySort): ItemSummary[
 
 export function selectItems(
   items: ItemSummary[],
-  view: ViewPreferences,
+  view: ViewPreferences & { query?: string },
   now = Date.now(),
 ): ItemSummary[] {
   const matched = items.filter(
     (item) =>
       matchesScope(item, view.scope, now) &&
       matchesFilters(item, view.filters) &&
-      matchesQuery(item, view.query),
+      matchesQuery(item, view.query ?? ''),
   );
   return sortItems(matched, view.sort);
 }

--- a/plugins/sero-design-library-plugin/shared/state-io.test.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.test.ts
@@ -10,7 +10,7 @@ import {
   appendRequest,
   commitState,
   pendingRequests,
-  readState,
+  readStateWithIndexes,
   updateState,
 } from './state-io';
 
@@ -26,10 +26,10 @@ afterEach(async () => {
   await rm(home, { recursive: true, force: true });
 });
 
-describe('readState', () => {
+describe('readStateWithIndexes', () => {
   it('returns defaults when no state file exists yet', async () => {
-    const state = await readState(paths);
-    expect(state.items).toEqual([]);
+    const state = await readStateWithIndexes(paths);
+    expect(state.schemaVersion).toBe(2);
     expect(state.revision).toBe(0);
     expect(state.settings.generation.variantCount).toBe(3);
   });
@@ -37,19 +37,19 @@ describe('readState', () => {
 
 describe('updateState', () => {
   it('bumps the revision on every write', async () => {
-    await updateState(paths, (current) => ({ ...current, view: { ...current.view, query: 'a' } }));
-    await updateState(paths, (current) => ({ ...current, view: { ...current.view, query: 'b' } }));
-    const state = await readState(paths);
+    await updateState(paths, (current) => ({ ...current, view: { ...current.view, sort: 'oldest' } }));
+    await updateState(paths, (current) => ({ ...current, view: { ...current.view, sort: 'title' } }));
+    const state = await readStateWithIndexes(paths);
     expect(state.revision).toBe(2);
-    expect(state.view.query).toBe('b');
+    expect(state.view.sort).toBe('title');
   });
 
   it('abandons the write when the updater returns null', async () => {
-    await updateState(paths, (current) => ({ ...current, view: { ...current.view, query: 'kept' } }));
+    await updateState(paths, (current) => ({ ...current, view: { ...current.view, sort: 'oldest' } }));
     await updateState(paths, () => null);
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     expect(state.revision).toBe(1);
-    expect(state.view.query).toBe('kept');
+    expect(state.view.sort).toBe('oldest');
   });
 
   it('serialises concurrent read-modify-write cycles without losing updates', async () => {
@@ -66,7 +66,7 @@ describe('updateState', () => {
         })),
       ),
     );
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     expect(state.collections).toHaveLength(25);
     expect(state.revision).toBe(25);
   });
@@ -76,35 +76,35 @@ describe('updateState', () => {
       throw new Error('updater exploded');
     });
     await expect(failure).rejects.toThrow('updater exploded');
-    await updateState(paths, (current) => ({ ...current, view: { ...current.view, query: 'after' } }));
-    expect((await readState(paths)).view.query).toBe('after');
+    await updateState(paths, (current) => ({ ...current, view: { ...current.view, sort: 'oldest' } }));
+    expect((await readStateWithIndexes(paths)).view.sort).toBe('oldest');
   });
 });
 
 describe('commitState', () => {
   it('rejects a writer holding a stale revision', async () => {
-    await updateState(paths, (current) => ({ ...current, view: { ...current.view, query: 'first' } }));
-    const stale = await readState(paths);
+    await updateState(paths, (current) => ({ ...current, view: { ...current.view, sort: 'oldest' } }));
+    const stale = await readStateWithIndexes(paths);
 
     // Someone else writes in between.
-    await updateState(paths, (current) => ({ ...current, view: { ...current.view, query: 'newer' } }));
+    await updateState(paths, (current) => ({ ...current, view: { ...current.view, sort: 'title' } }));
 
     await expect(
-      commitState(paths, { ...stale, view: { ...stale.view, query: 'clobber' } }, stale.revision),
+      commitState(paths, { ...stale, view: { ...stale.view, sort: 'newest' } }, stale.revision),
     ).rejects.toBeInstanceOf(StaleStateError);
 
-    expect((await readState(paths)).view.query).toBe('newer');
+    expect((await readStateWithIndexes(paths)).view.sort).toBe('title');
   });
 
   it('accepts a writer holding the current revision', async () => {
-    const current = await readState(paths);
+    const current = await readStateWithIndexes(paths);
     const committed = await commitState(
       paths,
-      { ...current, view: { ...current.view, query: 'ok' } },
+      { ...current, view: { ...current.view, sort: 'oldest' } },
       current.revision,
     );
     expect(committed.revision).toBe(1);
-    expect((await readState(paths)).view.query).toBe('ok');
+    expect((await readStateWithIndexes(paths)).view.sort).toBe('oldest');
   });
 });
 
@@ -114,11 +114,11 @@ describe('requests', () => {
     const second = await appendRequest(paths, { kind: 'analysis.run', itemId: 'i2', force: false });
     expect(second).toBe(first + 1);
 
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     expect(pendingRequests(state).map((request) => request.id)).toEqual([first, second]);
 
     await updateState(paths, (current) => ({ ...current, consumedRequestId: first }));
-    expect(pendingRequests(await readState(paths)).map((request) => request.id)).toEqual([second]);
+    expect(pendingRequests(await readStateWithIndexes(paths)).map((request) => request.id)).toEqual([second]);
   });
 
   it('does not reuse an id after concurrent appends', async () => {
@@ -127,7 +127,7 @@ describe('requests', () => {
         appendRequest(paths, { kind: 'item.favourite', itemId: `i${index}`, favourite: true }),
       ),
     );
-    const state = await readState(paths);
+    const state = await readStateWithIndexes(paths);
     const ids = state.requests.map((request) => request.id);
     expect(new Set(ids).size).toBe(20);
   });

--- a/plugins/sero-design-library-plugin/shared/state-io.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.ts
@@ -113,8 +113,8 @@ export async function readState(paths: DesignLibraryPaths): Promise<DesignLibrar
 
 /** Test inspection helper. Product code reads each entity index directly. */
 export async function readStateWithIndexes(paths: DesignLibraryPaths): Promise<StateReadResult> {
-  const state = await readState(paths);
-  const [items, designs, gallery, jobs, exports] = await Promise.all([
+  const [state, items, designs, gallery, jobs, exports] = await Promise.all([
+    readState(paths),
     readIndexForTests(paths.itemsIndexFile, normalizeItemIndex),
     readIndexForTests(paths.designsIndexFile, normalizeDesignIndex),
     readIndexForTests(paths.galleryIndexFile, normalizeGalleryIndex),

--- a/plugins/sero-design-library-plugin/shared/state-io.ts
+++ b/plugins/sero-design-library-plugin/shared/state-io.ts
@@ -2,6 +2,14 @@ import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { withLock, type FileLockOptions } from './file-lock';
+import {
+  normalizeDesignIndex,
+  normalizeExportIndex,
+  normalizeGalleryIndex,
+  normalizeItemIndex,
+  normalizeJobIndex,
+  type EntityIndexes,
+} from './indexes';
 import type { DesignLibraryPaths } from './paths';
 import type { LibraryRequestBody } from './requests';
 import type { DesignLibraryState } from './types';
@@ -62,6 +70,11 @@ async function readRaw(stateFile: string): Promise<DesignLibraryState | null> {
   return normalizeState(JSON.parse(raw) as unknown);
 }
 
+export async function readUnnormalizedState(paths: DesignLibraryPaths): Promise<unknown> {
+  const raw = await readFile(paths.stateFile, 'utf8').catch(() => null);
+  return raw === null ? null : JSON.parse(raw) as unknown;
+}
+
 /**
  * A temp path no concurrent write can collide with. The pid alone is not
  * enough — two writes to one file from the same process would share it — and
@@ -80,8 +93,43 @@ async function writeAtomic(stateFile: string, state: DesignLibraryState): Promis
   await rename(temp, stateFile);
 }
 
+export type StateReadResult = DesignLibraryState & EntityIndexes & {
+  galleryFamilies: EntityIndexes['gallery'];
+};
+
+async function readIndexForTests<T>(filePath: string, normalize: (value: unknown) => T[]): Promise<T[]> {
+  const raw = await readFile(filePath, 'utf8').catch(() => null);
+  if (raw === null) return [];
+  try {
+    return normalize(JSON.parse(raw) as unknown);
+  } catch {
+    return [];
+  }
+}
+
 export async function readState(paths: DesignLibraryPaths): Promise<DesignLibraryState> {
   return (await readRaw(paths.stateFile)) ?? structuredClone(DEFAULT_STATE);
+}
+
+/** Test inspection helper. Product code reads each entity index directly. */
+export async function readStateWithIndexes(paths: DesignLibraryPaths): Promise<StateReadResult> {
+  const state = await readState(paths);
+  const [items, designs, gallery, jobs, exports] = await Promise.all([
+    readIndexForTests(paths.itemsIndexFile, normalizeItemIndex),
+    readIndexForTests(paths.designsIndexFile, normalizeDesignIndex),
+    readIndexForTests(paths.galleryIndexFile, normalizeGalleryIndex),
+    readIndexForTests(paths.jobsIndexFile, normalizeJobIndex),
+    readIndexForTests(paths.exportsIndexFile, normalizeExportIndex),
+  ]);
+  Object.defineProperties(state, {
+    items: { value: items, enumerable: false },
+    designs: { value: designs, enumerable: false },
+    gallery: { value: gallery, enumerable: false },
+    galleryFamilies: { value: gallery, enumerable: false },
+    jobs: { value: jobs, enumerable: false },
+    exports: { value: exports, enumerable: false },
+  });
+  return state as StateReadResult;
 }
 
 /**
@@ -135,6 +183,21 @@ export async function commitState(
       },
       options.lock,
     ),
+  );
+}
+
+/** Replace legacy control state once migration has made every entity file durable. */
+export async function commitMigratedState(
+  paths: DesignLibraryPaths,
+  migrate: (legacy: unknown) => DesignLibraryState,
+): Promise<DesignLibraryState> {
+  return enqueue(paths.stateFile, () =>
+    withLock(paths.lockDir, async () => {
+      const raw = await readUnnormalizedState(paths);
+      const committed = migrate(raw);
+      await writeAtomic(paths.stateFile, committed);
+      return committed;
+    }),
   );
 }
 

--- a/plugins/sero-design-library-plugin/shared/types.test.ts
+++ b/plugins/sero-design-library-plugin/shared/types.test.ts
@@ -27,3 +27,14 @@ describe('colour filter normalization', () => {
     expect(normalized.view.filters.colourFamilies).toEqual(['Reds']);
   });
 });
+
+describe('view normalization', () => {
+  it('keeps the saved Library query', () => {
+    const normalized = normalizeState({
+      ...DEFAULT_STATE,
+      view: { ...DEFAULT_STATE.view, query: 'editorial grid' },
+    });
+
+    expect(normalized.view.query).toBe('editorial grid');
+  });
+});

--- a/plugins/sero-design-library-plugin/shared/types.ts
+++ b/plugins/sero-design-library-plugin/shared/types.ts
@@ -2,71 +2,27 @@
  * Reactive state — the single JSON document shared by the extension, the UI
  * and the background runtime.
  *
- * It holds lightweight summaries only. Full records and binaries are
- * plugin-owned files (spec §12), and every summary here is a pure projection
- * of those records, which is what makes an interrupted index write
- * recoverable: the projection can always be rebuilt from the records.
+ * It holds bounded control state only. Entity records and compact indexes are
+ * plugin-owned files beside this document.
  */
 
-import type { OutputTarget, VariantStatus, VariationMode } from './design';
 import type { ColourFamily } from './colour-families';
 import { isColourFamily } from './colour-families';
-import { normalizeDesignSummary } from './design-summary';
-import type { ExportSummary } from './export';
-import { normalizeExportSummary } from './export';
-import type { GalleryFamilyRecord } from './gallery';
-import { normalizeGalleryFamily } from './gallery';
+import type { OutputTarget, VariantStatus, VariationMode } from './design';
 import type { MediaCapability, MediaModelOptions } from './media';
 import { MEDIA_CAPABILITIES, normalizeModelOptions } from './media';
-import type { AnalysisStatus, Collection, JobKind, JobStatus, JobTarget, MediaKind } from './records';
-import { normalizeJobRecord } from './records';
+import type { AnalysisStatus, Collection, MediaKind } from './records';
 import type { LibraryRequest } from './requests';
 import { isLibraryRequest } from './requests';
 import type { DesignLibrarySettings, MediaSettings } from './settings';
 import { DEFAULT_SETTINGS, MAX_CALLS_PER_RUN } from './settings';
 
-export const STATE_SCHEMA_VERSION = 1;
+export const STATE_SCHEMA_VERSION = 2;
 
-export interface ItemSummary {
-  id: string;
-  title: string;
-  primaryStyle: string;
-  /** Trimmed for the card; the full set lives in the record. */
-  tags: string[];
-  designTypes: string[];
-  kind: MediaKind;
-  /** Path relative to the app state directory, for the UI to request bytes. */
-  previewPath: string;
-  analysisStatus: AnalysisStatus;
-  /**
-   * A generated video whose stills have not been captured yet (D4). The open
-   * app looks for this, captures them, and the flag clears.
-   */
-  awaitingFrames?: boolean;
-  /** Why analysis failed. Carried in the summary so a failure explains itself. */
-  analysisError?: string;
-  favourite: boolean;
-  collectionIds: string[];
-  /** Palette hexes, for the colour filter and card accents. */
-  colours: string[];
-  sourceKind: string;
-  createdAt: number;
-  updatedAt: number;
-  deletedAt?: number;
-  /** True when any field carries a user override. Drives the "edited" marker. */
-  edited: boolean;
-  /** Lowercased searchable blob projected from the effective analysis. */
-  searchText: string;
-}
-
-export interface JobSummary {
-  id: string;
-  kind: JobKind;
-  status: JobStatus;
-  target: JobTarget;
-  createdAt: number;
-  error?: string;
-}
+/** @deprecated Use ItemIndexEntry for index and card data. */
+export type ItemSummary = import('./indexes').ItemIndexEntry;
+/** @deprecated Use JobIndexEntry for job list data. */
+export type JobSummary = import('./indexes').JobIndexEntry;
 
 /**
  * One variant, as the sessions rail and the variant tabs need it.
@@ -131,7 +87,6 @@ export interface LibraryFilters {
 
 export interface ViewPreferences {
   scope: LibraryScope;
-  query: string;
   filters: LibraryFilters;
   sort: LibrarySort;
   selectedItemId?: string;
@@ -150,6 +105,7 @@ export interface ViewPreferences {
  * survive, invisibly, until the next restart brought it back.
  */
 export type ViewPatch = { [K in keyof ViewPreferences]?: ViewPreferences[K] | null };
+export type LibraryViewPreferences = ViewPreferences & { query: string };
 
 /** Apply a patch, turning an explicit `null` into an absent key. */
 export function applyViewPatch(view: ViewPreferences, patch: ViewPatch): ViewPreferences {
@@ -165,12 +121,7 @@ export interface DesignLibraryState {
   schemaVersion: number;
   /** Bumped on every write. Writers compare-and-swap against it. */
   revision: number;
-  items: ItemSummary[];
-  designs: DesignSummary[];
-  galleryFamilies: GalleryFamilyRecord[];
-  exports: ExportSummary[];
   collections: Collection[];
-  jobs: JobSummary[];
   settings: DesignLibrarySettings;
   /**
    * What each capability's model accepts — clip lengths, aspect ratios — as the
@@ -201,17 +152,11 @@ export const EMPTY_FILTERS: LibraryFilters = {
 export const DEFAULT_STATE: DesignLibraryState = {
   schemaVersion: STATE_SCHEMA_VERSION,
   revision: 0,
-  items: [],
-  designs: [],
-  galleryFamilies: [],
-  exports: [],
   collections: [],
-  jobs: [],
   settings: DEFAULT_SETTINGS,
   mediaOptions: {},
   view: {
     scope: { kind: 'all' },
-    query: '',
     filters: EMPTY_FILTERS,
     sort: 'newest',
   },
@@ -232,32 +177,6 @@ function num(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
-function normalizeItem(value: unknown): ItemSummary | null {
-  if (!isRecord(value)) return null;
-  if (typeof value.id !== 'string') return null;
-  return {
-    id: value.id,
-    title: typeof value.title === 'string' ? value.title : 'Untitled',
-    primaryStyle: typeof value.primaryStyle === 'string' ? value.primaryStyle : '',
-    tags: stringArray(value.tags),
-    designTypes: stringArray(value.designTypes),
-    kind: value.kind === 'video' ? 'video' : 'image',
-    previewPath: typeof value.previewPath === 'string' ? value.previewPath : '',
-    analysisStatus: normalizeAnalysisStatus(value.analysisStatus),
-    ...(value.awaitingFrames === true ? { awaitingFrames: true } : {}),
-    ...(typeof value.analysisError === 'string' ? { analysisError: value.analysisError } : {}),
-    favourite: value.favourite === true,
-    collectionIds: stringArray(value.collectionIds),
-    colours: stringArray(value.colours),
-    sourceKind: typeof value.sourceKind === 'string' ? value.sourceKind : 'file',
-    createdAt: num(value.createdAt, 0),
-    updatedAt: num(value.updatedAt, 0),
-    ...(typeof value.deletedAt === 'number' ? { deletedAt: value.deletedAt } : {}),
-    edited: value.edited === true,
-    searchText: typeof value.searchText === 'string' ? value.searchText : '',
-  };
-}
-
 function normalizeAnalysisStatus(value: unknown): AnalysisStatus {
   return value === 'running' || value === 'ready' || value === 'failed' || value === 'cancelled'
     ? value
@@ -274,26 +193,6 @@ function normalizeCollection(value: unknown): Collection | null {
   };
 }
 
-function normalizeJob(value: unknown): JobSummary | null {
-  if (!isRecord(value) || typeof value.id !== 'string') return null;
-  const target = normalizeJobRecord({ ...value, id: value.id })?.target;
-  if (!target) return null;
-  const status = value.status;
-  return {
-    id: value.id,
-    kind:
-      value.kind === 'ingest' || value.kind === 'generate' || value.kind === 'media'
-        ? value.kind
-        : 'analysis',
-    status:
-      status === 'running' || status === 'succeeded' || status === 'failed' || status === 'cancelled'
-        ? status
-        : 'queued',
-    target,
-    createdAt: num(value.createdAt, 0),
-    ...(typeof value.error === 'string' ? { error: value.error } : {}),
-  };
-}
 
 function normalizeScope(value: unknown): LibraryScope {
   if (!isRecord(value)) return { kind: 'all' };
@@ -338,7 +237,6 @@ function normalizeView(value: unknown): ViewPreferences {
   const sort = value.sort;
   return {
     scope: normalizeScope(value.scope),
-    query: typeof value.query === 'string' ? value.query : '',
     filters: normalizeFilters(value.filters),
     sort: sort === 'oldest' || sort === 'title' ? sort : 'newest',
     ...(typeof value.selectedItemId === 'string' ? { selectedItemId: value.selectedItemId } : {}),
@@ -431,40 +329,10 @@ export function normalizeState(value: unknown): DesignLibraryState {
   return {
     schemaVersion: num(value.schemaVersion, STATE_SCHEMA_VERSION),
     revision: num(value.revision, 0),
-    items: Array.isArray(value.items)
-      ? value.items.flatMap((entry) => {
-          const item = normalizeItem(entry);
-          return item === null ? [] : [item];
-        })
-      : [],
-    designs: Array.isArray(value.designs)
-      ? value.designs.flatMap((entry) => {
-          const design = normalizeDesignSummary(entry);
-          return design === null ? [] : [design];
-        })
-      : [],
-    galleryFamilies: Array.isArray(value.galleryFamilies)
-      ? value.galleryFamilies.flatMap((entry) => {
-          const family = normalizeGalleryFamily(entry);
-          return family === null ? [] : [family];
-        })
-      : [],
-    exports: Array.isArray(value.exports)
-      ? value.exports.flatMap((entry) => {
-          const summary = normalizeExportSummary(entry);
-          return summary === null ? [] : [summary];
-        })
-      : [],
     collections: Array.isArray(value.collections)
       ? value.collections.flatMap((entry) => {
           const collection = normalizeCollection(entry);
           return collection === null ? [] : [collection];
-        })
-      : [],
-    jobs: Array.isArray(value.jobs)
-      ? value.jobs.flatMap((entry) => {
-          const job = normalizeJob(entry);
-          return job === null ? [] : [job];
         })
       : [],
     settings: normalizeSettings(value.settings),

--- a/plugins/sero-design-library-plugin/shared/types.ts
+++ b/plugins/sero-design-library-plugin/shared/types.ts
@@ -87,6 +87,7 @@ export interface LibraryFilters {
 
 export interface ViewPreferences {
   scope: LibraryScope;
+  query: string;
   filters: LibraryFilters;
   sort: LibrarySort;
   selectedItemId?: string;
@@ -105,7 +106,7 @@ export interface ViewPreferences {
  * survive, invisibly, until the next restart brought it back.
  */
 export type ViewPatch = { [K in keyof ViewPreferences]?: ViewPreferences[K] | null };
-export type LibraryViewPreferences = ViewPreferences & { query: string };
+export type LibraryViewPreferences = ViewPreferences;
 
 /** Apply a patch, turning an explicit `null` into an absent key. */
 export function applyViewPatch(view: ViewPreferences, patch: ViewPatch): ViewPreferences {
@@ -157,6 +158,7 @@ export const DEFAULT_STATE: DesignLibraryState = {
   mediaOptions: {},
   view: {
     scope: { kind: 'all' },
+    query: '',
     filters: EMPTY_FILTERS,
     sort: 'newest',
   },
@@ -237,6 +239,7 @@ function normalizeView(value: unknown): ViewPreferences {
   const sort = value.sort;
   return {
     scope: normalizeScope(value.scope),
+    query: typeof value.query === 'string' ? value.query : '',
     filters: normalizeFilters(value.filters),
     sort: sort === 'oldest' || sort === 'title' ? sort : 'newest',
     ...(typeof value.selectedItemId === 'string' ? { selectedItemId: value.selectedItemId } : {}),

--- a/plugins/sero-design-library-plugin/shared/types.ts
+++ b/plugins/sero-design-library-plugin/shared/types.ts
@@ -12,6 +12,7 @@ import type { OutputTarget, VariantStatus, VariationMode } from './design';
 import type { MediaCapability, MediaModelOptions } from './media';
 import { MEDIA_CAPABILITIES, normalizeModelOptions } from './media';
 import type { AnalysisStatus, Collection, MediaKind } from './records';
+import type { ItemIndexEntry, JobIndexEntry } from './indexes';
 import type { LibraryRequest } from './requests';
 import { isLibraryRequest } from './requests';
 import type { DesignLibrarySettings, MediaSettings } from './settings';
@@ -20,9 +21,9 @@ import { DEFAULT_SETTINGS, MAX_CALLS_PER_RUN } from './settings';
 export const STATE_SCHEMA_VERSION = 2;
 
 /** @deprecated Use ItemIndexEntry for index and card data. */
-export type ItemSummary = import('./indexes').ItemIndexEntry;
+export type ItemSummary = ItemIndexEntry;
 /** @deprecated Use JobIndexEntry for job list data. */
-export type JobSummary = import('./indexes').JobIndexEntry;
+export type JobSummary = JobIndexEntry;
 
 /**
  * One variant, as the sessions rail and the variant tabs need it.

--- a/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
+++ b/plugins/sero-design-library-plugin/ui/DesignLibraryApp.tsx
@@ -64,7 +64,7 @@ export function DesignLibraryApp() {
 
   const backToLibrary = () => navigateWithTransition(() => library.actions.select(undefined));
 
-  const liveCount = library.state.items.filter((item) => item.deletedAt === undefined).length;
+  const liveCount = library.items.filter((item) => item.deletedAt === undefined).length;
   const galleryFamilyCount = gallery.families.length;
 
   // Videos generated while Sero was closed have no stills yet, and the runtime
@@ -72,12 +72,12 @@ export function DesignLibraryApp() {
   // going while the user is inside a Design (D4).
   const awaitingFrames = useMemo(
     () =>
-      library.state.items.flatMap((item) =>
+      library.items.flatMap((item) =>
         item.awaitingFrames === true && item.deletedAt === undefined
           ? [{ kind: 'item' as const, itemId: item.id }]
           : [],
       ),
-    [library.state.items],
+    [library.items],
   );
   useVideoFrames(awaitingFrames);
 
@@ -85,10 +85,10 @@ export function DesignLibraryApp() {
   // does not need the Librarian to have read it first.
   const librarySources = useMemo<GenerateSource[]>(
     () =>
-      library.state.items.flatMap((item) =>
+      library.items.flatMap((item) =>
         item.deletedAt === undefined ? [{ id: item.id, label: item.title, kind: item.kind }] : [],
       ),
-    [library.state.items],
+    [library.items],
   );
 
   return (
@@ -179,7 +179,7 @@ export function DesignLibraryApp() {
             void gallery.actions.read(familyId, versionId).then((version) => {
               if (!version) return;
               const references = version.references.flatMap((reference) => {
-                const item = library.state.items.find(
+                const item = library.items.find(
                   (candidate) => candidate.id === reference.itemId && candidate.deletedAt === undefined,
                 );
                 return item ? [item] : [];
@@ -196,7 +196,7 @@ export function DesignLibraryApp() {
         <DesignPage
           design={designs.open}
           designs={designs.list}
-          items={library.state.items}
+          items={library.items}
           settings={library.state.settings}
           mediaOptions={library.state.mediaOptions}
           activeVariantId={designs.state.view.activeVariantId}

--- a/plugins/sero-design-library-plugin/ui/components/ItemInspector.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/ItemInspector.test.tsx
@@ -30,7 +30,6 @@ const ITEM: ItemSummary = {
   createdAt: 1,
   updatedAt: 2,
   edited: false,
-  searchText: '',
 };
 
 const ACTIONS: LibraryActions = {

--- a/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/LibraryToolbar.tsx
@@ -117,7 +117,7 @@ export function LibraryToolbar({
       <SearchInput
         value={query}
         onChange={(event) => onQueryChange(event.target.value)}
-        placeholder="Search styles, tags, notes or analysis"
+        placeholder="Search titles, styles, tags or files"
         className="h-8 max-w-96 min-w-56 flex-1"
       />
 

--- a/plugins/sero-design-library-plugin/ui/components/SelectionBar.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/components/SelectionBar.test.tsx
@@ -23,7 +23,6 @@ const SELECTED: ItemSummary = {
   createdAt: 0,
   updatedAt: 0,
   edited: false,
-  searchText: '',
 };
 
 describe('selected reference collections', () => {

--- a/plugins/sero-design-library-plugin/ui/hooks/useDesigns.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useDesigns.ts
@@ -3,11 +3,13 @@ import { useAppState, useAppTools } from '@sero-ai/app-runtime';
 import { useCallback, useMemo } from 'react';
 
 import type { DesignBrief, DesignRecord } from '../../shared/design';
+import { normalizeDesignIndex } from '../../shared/indexes';
 import type { LayoutSettings, RevisionBehaviour } from '../../shared/settings';
 import type { ConflictResolution, GuardrailSynthesis } from '../../shared/synthesis';
 import type { DesignLibraryState, DesignSummary } from '../../shared/types';
 import { DEFAULT_STATE } from '../../shared/types';
 import { showItemInFolder } from '../lib/host-files';
+import { useJsonIndex } from './useJsonIndex';
 
 /**
  * The Design surface's read and write path.
@@ -77,6 +79,7 @@ function textOf(result: AppToolResult): string {
 
 export function useDesigns(): Designs {
   const [state] = useAppState<DesignLibraryState>(DEFAULT_STATE);
+  const designIndex = useJsonIndex('designs/index.json', normalizeDesignIndex);
   const tools = useAppTools();
 
   const run = useCallback(
@@ -165,10 +168,10 @@ export function useDesigns(): Designs {
 
   const list = useMemo(
     () =>
-      state.designs
+      designIndex
         .filter((design) => design.deletedAt === undefined)
         .toSorted((a, b) => b.createdAt - a.createdAt),
-    [state.designs],
+    [designIndex],
   );
 
   const open = useMemo(

--- a/plugins/sero-design-library-plugin/ui/hooks/useGallery.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useGallery.ts
@@ -1,11 +1,11 @@
-import { useAppInfo, useAppState, useAppTools } from '@sero-ai/app-runtime';
+import { useAppInfo, useAppTools } from '@sero-ai/app-runtime';
 import { useCallback, useMemo, useState } from 'react';
 
 import type { GalleryFamilyRecord, GalleryVersionRecord } from '../../shared/gallery';
+import { normalizeExportIndex, normalizeGalleryIndex } from '../../shared/indexes';
 import type { ExportDestination, ExportSummary } from '../../shared/export';
-import type { DesignLibraryState } from '../../shared/types';
-import { DEFAULT_STATE } from '../../shared/types';
 import { captureGalleryPreview } from '../lib/gallery-capture';
+import { useJsonIndex } from './useJsonIndex';
 
 export interface GalleryActions {
   save(target: HTMLElement, designId: string, variantId: string, revisionId: string): Promise<boolean>;
@@ -32,7 +32,8 @@ export function useGallery(): {
   latestExportWorkspaceId?: string;
   actions: GalleryActions;
 } {
-  const [state] = useAppState<DesignLibraryState>(DEFAULT_STATE);
+  const galleryIndex = useJsonIndex('gallery/index.json', normalizeGalleryIndex);
+  const exportIndex = useJsonIndex('exports/index.json', normalizeExportIndex);
   const tools = useAppTools();
   const { workspaceId, workspacePath } = useAppInfo();
   const [saving, setSaving] = useState(false);
@@ -128,22 +129,22 @@ export function useGallery(): {
   }), [run, runExport, saving, tools, workspaceId, workspacePath]);
 
   const families = useMemo(
-    () => state.galleryFamilies
+    () => galleryIndex
       .filter((family) =>
         family.deletedAt === undefined &&
         family.versions.some((version) => version.deletedAt === undefined),
       )
       .toSorted((a, b) => b.updatedAt - a.updatedAt),
-    [state.galleryFamilies],
+    [galleryIndex],
   );
   const trash = useMemo(
-    () => state.galleryFamilies.filter((family) =>
+    () => galleryIndex.filter((family) =>
       family.deletedAt !== undefined ||
       family.versions.some((version) => version.deletedAt !== undefined),
     ),
-    [state.galleryFamilies],
+    [galleryIndex],
   );
-  const latestExport = state.exports.find((entry) => entry.id === visibleExport?.id);
+  const latestExport = exportIndex.find((entry) => entry.id === visibleExport?.id);
   return {
     families,
     trash,

--- a/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { AppContext } from '@sero-ai/app-runtime';
+import type * as AppRuntime from '@sero-ai/app-runtime';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const bridge = vi.hoisted(() => {
+  const listeners = new Set<(filePath: string, value: unknown) => void>();
+  return {
+    listeners,
+    watch: vi.fn<(filePath: string) => Promise<unknown>>(),
+    unwatch: vi.fn<(filePath: string) => Promise<void>>(),
+    onChange: vi.fn((listener: (filePath: string, value: unknown) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+  };
+});
+
+vi.mock('@sero-ai/app-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof AppRuntime>();
+  return {
+    ...actual,
+    getSeroApi: () => ({ appState: bridge }),
+  };
+});
+
+import { useJsonIndex } from './useJsonIndex';
+
+const context = {
+  appId: 'design-library', workspaceId: 'global', workspacePath: '/profile',
+  stateFilePath: '/profile/apps/design-library/state.json',
+};
+
+function normalize(value: unknown): Array<{ id: string }> {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is { id: string } =>
+        typeof entry === 'object' && entry !== null && typeof Reflect.get(entry, 'id') === 'string')
+    : [];
+}
+
+function Probe({ relativePath = 'items/index.json' }: { relativePath?: string }) {
+  const entries = useJsonIndex(relativePath, normalize);
+  return <span data-testid="ids">{entries.map((entry) => entry.id).join(',')}</span>;
+}
+
+beforeEach(() => {
+  bridge.listeners.clear();
+  bridge.watch.mockReset().mockResolvedValue([{ id: 'initial' }]);
+  bridge.unwatch.mockReset().mockResolvedValue(undefined);
+  bridge.onChange.mockClear();
+});
+
+describe('useJsonIndex', () => {
+  it('reads the index and applies matching file updates', async () => {
+    render(<AppContext.Provider value={context}><Probe /></AppContext.Provider>);
+
+    await waitFor(() => expect(screen.getByTestId('ids').textContent).toBe('initial'));
+    expect(bridge.watch).toHaveBeenCalledWith('/profile/apps/design-library/items/index.json');
+
+    act(() => {
+      for (const listener of bridge.listeners) {
+        listener('/profile/apps/design-library/items/index.json', [{ id: 'changed' }]);
+        listener('/profile/apps/design-library/jobs/index.json', [{ id: 'ignored' }]);
+      }
+    });
+    expect(screen.getByTestId('ids').textContent).toBe('changed');
+  });
+
+  it('unwatches the old file when its path changes and on unmount', async () => {
+    const rendered = render(<AppContext.Provider value={context}><Probe /></AppContext.Provider>);
+    await waitFor(() => expect(screen.getByTestId('ids').textContent).toBe('initial'));
+
+    rendered.rerender(
+      <AppContext.Provider value={context}><Probe relativePath="jobs/index.json" /></AppContext.Provider>,
+    );
+    await waitFor(() => {
+      expect(bridge.unwatch).toHaveBeenCalledWith('/profile/apps/design-library/items/index.json');
+      expect(bridge.watch).toHaveBeenCalledWith('/profile/apps/design-library/jobs/index.json');
+    });
+
+    rendered.unmount();
+    expect(bridge.unwatch).toHaveBeenCalledWith('/profile/apps/design-library/jobs/index.json');
+    expect(bridge.listeners.size).toBe(0);
+  });
+});

--- a/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.test.tsx
+++ b/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.test.tsx
@@ -68,6 +68,22 @@ describe('useJsonIndex', () => {
     expect(screen.getByTestId('ids').textContent).toBe('changed');
   });
 
+  it('keeps a newer change event when the initial watch finishes later', async () => {
+    let resolveWatch: (value: unknown) => void = () => undefined;
+    bridge.watch.mockReturnValue(new Promise((resolve) => { resolveWatch = resolve; }));
+    render(<AppContext.Provider value={context}><Probe /></AppContext.Provider>);
+
+    act(() => {
+      for (const listener of bridge.listeners) {
+        listener('/profile/apps/design-library/items/index.json', [{ id: 'newer' }]);
+      }
+    });
+    expect(screen.getByTestId('ids').textContent).toBe('newer');
+
+    await act(async () => resolveWatch([{ id: 'stale-initial' }]));
+    expect(screen.getByTestId('ids').textContent).toBe('newer');
+  });
+
   it('unwatches the old file when its path changes and on unmount', async () => {
     const rendered = render(<AppContext.Provider value={context}><Probe /></AppContext.Provider>);
     await waitFor(() => expect(screen.getByTestId('ids').textContent).toBe('initial'));

--- a/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.ts
@@ -19,12 +19,16 @@ export function useJsonIndex<T>(
   useEffect(() => {
     const api = getSeroApi().appState;
     let active = true;
+    let changedWhileWatching = false;
     setEntries([]);
     const unsubscribe = api.onChange<unknown>((changedPath, value) => {
-      if (active && changedPath === filePath) setEntries(normalize(value));
+      if (active && changedPath === filePath) {
+        changedWhileWatching = true;
+        setEntries(normalize(value));
+      }
     });
     void api.watch<unknown>(filePath).then((value) => {
-      if (active) setEntries(normalize(value));
+      if (active && !changedWhileWatching) setEntries(normalize(value));
     });
     return () => {
       active = false;

--- a/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useJsonIndex.ts
@@ -1,0 +1,37 @@
+import { AppContext, getSeroApi } from '@sero-ai/app-runtime';
+import { use, useEffect, useMemo, useState } from 'react';
+
+/** Read and watch one plugin-owned JSON index through the generic file bridge. */
+export function useJsonIndex<T>(
+  relativePath: string,
+  normalize: (value: unknown) => T[],
+): T[] {
+  const context = use(AppContext);
+  if (!context) throw new Error('useJsonIndex must be used inside an <AppProvider>');
+
+  const filePath = useMemo(() => {
+    const separator = context.stateFilePath.includes('\\') ? '\\' : '/';
+    const parent = context.stateFilePath.slice(0, context.stateFilePath.lastIndexOf(separator));
+    return `${parent}${separator}${relativePath.split('/').join(separator)}`;
+  }, [context.stateFilePath, relativePath]);
+  const [entries, setEntries] = useState<T[]>([]);
+
+  useEffect(() => {
+    const api = getSeroApi().appState;
+    let active = true;
+    setEntries([]);
+    const unsubscribe = api.onChange<unknown>((changedPath, value) => {
+      if (active && changedPath === filePath) setEntries(normalize(value));
+    });
+    void api.watch<unknown>(filePath).then((value) => {
+      if (active) setEntries(normalize(value));
+    });
+    return () => {
+      active = false;
+      unsubscribe();
+      void api.unwatch(filePath);
+    };
+  }, [filePath, normalize]);
+
+  return entries;
+}

--- a/plugins/sero-design-library-plugin/ui/hooks/useLibrary.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useLibrary.ts
@@ -77,7 +77,6 @@ export function useLibrary(): Library {
   // Local view state leads; the persisted copy follows. `null` means "nothing
   // changed locally yet", so a view restored from state on load still wins.
   const [localView, setLocalView] = useState<ViewPatch | null>(null);
-  const [query, setQuery] = useState('');
 
   // Retire optimistic keys the moment state reports them. Merging alone is not
   // enough: a key that stays forever also outranks any *later* value the
@@ -95,8 +94,8 @@ export function useLibrary(): Library {
   }
 
   const view = useMemo<LibraryViewPreferences>(
-    () => ({ ...mergeView(localView, state.view), query }),
-    [state.view, localView, query],
+    () => mergeView(localView, state.view),
+    [state.view, localView],
   );
 
   // Built once, lazily. `useRef(createDebouncedFn(...))` keeps the first value
@@ -126,7 +125,7 @@ export function useLibrary(): Library {
   const actions = useMemo<LibraryActions>(
     () => ({
       setScope: (scope) => patchView({ scope }),
-      setQuery,
+      setQuery: (query) => patchView({ query }),
       setFilters: (filters) => patchView({ filters }),
       setSort: (sort) => patchView({ sort }),
       // `null`, not `undefined`: the patch travels as JSON, and an undefined

--- a/plugins/sero-design-library-plugin/ui/hooks/useLibrary.ts
+++ b/plugins/sero-design-library-plugin/ui/hooks/useLibrary.ts
@@ -4,17 +4,25 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 
 import type { LibrarianField, LibrarianUserFacingAnalysis } from '../../shared/librarian';
 import { deriveFacets, selectItems } from '../../shared/search';
+import {
+  normalizeItemIndex,
+  normalizeJobIndex,
+  type ItemIndexEntry,
+  type JobIndexEntry,
+} from '../../shared/indexes';
 import type { DesignLibrarySettings } from '../../shared/settings';
 import type {
   DesignLibraryState,
   LibraryFilters,
   LibraryScope,
   LibrarySort,
+  LibraryViewPreferences,
   ViewPatch,
   ViewPreferences,
 } from '../../shared/types';
 import { DEFAULT_STATE } from '../../shared/types';
 import { mergeView, outstandingView, viewSignature } from '../lib/view-sync';
+import { useJsonIndex } from './useJsonIndex';
 
 /**
  * One place the whole app reads state and asks for changes.
@@ -50,21 +58,26 @@ export interface LibraryActions {
 
 export interface Library {
   state: DesignLibraryState;
-  view: ViewPreferences;
+  items: ItemIndexEntry[];
+  jobs: JobIndexEntry[];
+  view: LibraryViewPreferences;
   /** The items the current scope, filters and query select, already sorted. */
   visible: ReturnType<typeof selectItems>;
   facets: ReturnType<typeof deriveFacets>;
-  selected: DesignLibraryState['items'][number] | undefined;
+  selected: ItemIndexEntry | undefined;
   actions: LibraryActions;
 }
 
 export function useLibrary(): Library {
   const [state] = useAppState<DesignLibraryState>(DEFAULT_STATE);
+  const items = useJsonIndex('items/index.json', normalizeItemIndex);
+  const jobs = useJsonIndex('jobs/index.json', normalizeJobIndex);
   const tools = useAppTools();
 
   // Local view state leads; the persisted copy follows. `null` means "nothing
   // changed locally yet", so a view restored from state on load still wins.
   const [localView, setLocalView] = useState<ViewPatch | null>(null);
+  const [query, setQuery] = useState('');
 
   // Retire optimistic keys the moment state reports them. Merging alone is not
   // enough: a key that stays forever also outranks any *later* value the
@@ -81,7 +94,10 @@ export function useLibrary(): Library {
     });
   }
 
-  const view = useMemo<ViewPreferences>(() => mergeView(localView, state.view), [state.view, localView]);
+  const view = useMemo<LibraryViewPreferences>(
+    () => ({ ...mergeView(localView, state.view), query }),
+    [state.view, localView, query],
+  );
 
   // Built once, lazily. `useRef(createDebouncedFn(...))` keeps the first value
   // but still *calls* the factory on every render, allocating a timer-holding
@@ -110,7 +126,7 @@ export function useLibrary(): Library {
   const actions = useMemo<LibraryActions>(
     () => ({
       setScope: (scope) => patchView({ scope }),
-      setQuery: (query) => patchView({ query }),
+      setQuery,
       setFilters: (filters) => patchView({ filters }),
       setSort: (sort) => patchView({ sort }),
       // `null`, not `undefined`: the patch travels as JSON, and an undefined
@@ -163,12 +179,12 @@ export function useLibrary(): Library {
     [patchView, run],
   );
 
-  const visible = useMemo(() => selectItems(state.items, view), [state.items, view]);
-  const facets = useMemo(() => deriveFacets(state.items), [state.items]);
+  const visible = useMemo(() => selectItems(items, view), [items, view]);
+  const facets = useMemo(() => deriveFacets(items), [items]);
   const selected = useMemo(
-    () => state.items.find((item) => item.id === view.selectedItemId),
-    [state.items, view.selectedItemId],
+    () => items.find((item) => item.id === view.selectedItemId),
+    [items, view.selectedItemId],
   );
 
-  return { state, view, visible, facets, selected, actions };
+  return { state, items, jobs, view, visible, facets, selected, actions };
 }

--- a/plugins/sero-design-library-plugin/ui/lib/view-sync.test.ts
+++ b/plugins/sero-design-library-plugin/ui/lib/view-sync.test.ts
@@ -16,6 +16,11 @@ describe('retiring optimistic view keys', () => {
     expect(outstandingView({ sort: 'oldest' }, base)).toEqual({ sort: 'oldest' });
   });
 
+  it('keeps a query local until saved state catches up', () => {
+    expect(mergeView({ query: 'editorial' }, base).query).toBe('editorial');
+    expect(outstandingView({ query: 'editorial' }, { ...base, query: 'editorial' })).toEqual({});
+  });
+
   it('drops a key once state reports the same value', () => {
     expect(Object.keys(outstandingView({ sort: 'oldest' }, { ...base, sort: 'oldest' }))).toEqual([]);
   });

--- a/plugins/sero-design-library-plugin/ui/lib/view-sync.test.ts
+++ b/plugins/sero-design-library-plugin/ui/lib/view-sync.test.ts
@@ -13,11 +13,11 @@ const base: ViewPreferences = DEFAULT_STATE.view;
 
 describe('retiring optimistic view keys', () => {
   it('keeps a key state has not caught up with', () => {
-    expect(outstandingView({ query: 'grid' }, base)).toEqual({ query: 'grid' });
+    expect(outstandingView({ sort: 'oldest' }, base)).toEqual({ sort: 'oldest' });
   });
 
   it('drops a key once state reports the same value', () => {
-    expect(Object.keys(outstandingView({ query: 'grid' }, { ...base, query: 'grid' }))).toEqual([]);
+    expect(Object.keys(outstandingView({ sort: 'oldest' }, { ...base, sort: 'oldest' }))).toEqual([]);
   });
 
   it('drops an object key that state rebuilt with its keys in another order', () => {
@@ -82,7 +82,7 @@ describe('the persisted-view signature', () => {
   });
 
   it('changes when any value changes', () => {
-    expect(viewSignature({ ...base, query: 'grid' })).not.toBe(viewSignature(base));
+    expect(viewSignature({ ...base, sort: 'oldest' })).not.toBe(viewSignature(base));
   });
 });
 

--- a/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
+++ b/plugins/sero-design-library-plugin/ui/pages/LibraryPage.tsx
@@ -39,6 +39,8 @@ interface LibraryPageProps {
   transitionName: string;
 }
 
+const GRID_PAGE_SIZE = 200;
+
 export function LibraryPage({
   library,
   importState,
@@ -52,10 +54,11 @@ export function LibraryPage({
   transitioningItemId,
   transitionName,
 }: LibraryPageProps) {
-  const { state, view, visible, facets, actions } = library;
+  const { state, items, jobs, view, visible, facets, actions } = library;
 
   const [picked, setPicked] = useState<string[]>([]);
   const [dragging, setDragging] = useState(false);
+  const [renderedCount, setRenderedCount] = useState(GRID_PAGE_SIZE);
 
   const inTrash = view.scope.kind === 'trash';
   // A generation has no item until the provider answers and the bytes take the
@@ -63,17 +66,18 @@ export function LibraryPage({
   // the obvious thing to do about that is press Generate again and pay twice.
   // Trash is the one scope they do not belong in: nothing there is arriving.
   const pending = useMemo(
-    () => (inTrash ? [] : pendingGenerations(state.jobs)),
-    [state.jobs, inTrash],
+    () => (inTrash ? [] : pendingGenerations(jobs)),
+    [jobs, inTrash],
   );
   // A Set because both of these are consulted once per card in the grid.
   const pickedIds = useMemo(() => new Set(picked), [picked]);
-  // Mapped over `picked` rather than filtered out of `state.items`: reference
+  // Mapped over `picked` rather than filtered out of `items`: reference
   // order is what makes the first one primary, and the grid's order is not it.
   const pickedItems = useMemo(
-    () => picked.flatMap((id) => state.items.filter((item) => item.id === id)),
-    [state.items, picked],
+    () => picked.flatMap((id) => items.filter((item) => item.id === id)),
+    [items, picked],
   );
+  const renderedItems = visible.slice(0, renderedCount);
 
   const togglePicked = useCallback((itemId: string) => {
     setPicked((current) =>
@@ -101,7 +105,7 @@ export function LibraryPage({
       onPaste={(event) => void importFiles(filesFromClipboard(event.clipboardData), 'paste')}
     >
       <LibraryRail
-        items={state.items}
+        items={items}
         collections={state.collections}
         scope={view.scope}
         onScopeChange={(scope) => {
@@ -188,11 +192,11 @@ export function LibraryPage({
               <div className="flex flex-col items-center justify-center gap-3 px-6 py-24 text-center">
                 <ImagePlus className="text-muted-foreground size-8" />
                 <p className="text-muted-foreground text-sm">
-                  {state.items.length === 0
+                  {items.length === 0
                     ? 'Drop images here, paste from the clipboard, or add a file to start the Library.'
                     : 'Nothing matches the current scope and filters.'}
                 </p>
-                {state.items.length === 0 && (
+                {items.length === 0 && (
                   <div className="flex items-center gap-2">
                     <Button type="button" size="sm" onClick={onPickFiles}>
                       Add inspiration
@@ -216,7 +220,7 @@ export function LibraryPage({
                     onDismiss={onDismissJob}
                   />
                 ))}
-                {visible.map((item) => (
+                {renderedItems.map((item) => (
                   <ItemCard
                     key={item.id}
                     item={item}
@@ -227,6 +231,17 @@ export function LibraryPage({
                     onFavourite={(favourite) => void actions.favourite(item.id, favourite)}
                   />
                 ))}
+                {renderedItems.length < visible.length && (
+                  <div className="col-span-full flex justify-center py-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setRenderedCount((count) => count + GRID_PAGE_SIZE)}
+                    >
+                      Show more
+                    </Button>
+                  </div>
+                )}
               </div>
             )}
           </ScrollArea>


### PR DESCRIPTION
## Summary

- replace unbounded Design Library entity arrays with per-record storage and compact JSON indexes
- migrate existing profiles and keep normal startup work limited to targeted recovery and index-driven cleanup
- recover interrupted item, Design, Gallery, export, and job projections after restart
- keep terminal export history bounded to the 20 newest records without touching running exports
- use compact index subscriptions for the Library, Designs, and Gallery, with bounded search and incremental display
- keep the saved Library search query in view preferences and document the supported search fields

## Why

The previous control-state file grew with every item, Design, Gallery family, job, and export. The indexed format keeps control state bounded.

Record and index writes are separate atomic operations. A crash between them could leave a durable record hidden from its index. Item, Design, Gallery, and export writes now use durable repair markers, so startup replays only interrupted projections. Job recovery remains authoritative against job records, which prevents a media job from running and charging twice.

The agent can also schedule a full authoritative repair for the next startup. This repairs damage that has no journal marker without adding a full record scan to every normal startup. A failed full repair retries for up to three starts, then moves to a failed marker. Scheduling another repair starts a fresh set of attempts.

## Review fixes

- settle exports left running by a restart as interrupted before terminal-history pruning
- report the latest export by highest creation time, independent of rebuilt index order
- keep targeted repair notification and marker cleanup inside each record lock
- bound automatic full-repair retries and preserve a user-reachable fresh retry action
- isolate export-history cleanup from export execution and terminal status reporting
- skip running exports and re-check each candidate under its record lock before deletion
- support a zero export-history limit correctly
- take record locks during targeted repair replay
- make the in-memory search cache detect in-place field changes
- add a supported full index-repair action for non-journal damage
- prevent a late initial watch result from replacing a newer change event
- remove unused job-pruning code and replace inline type imports
- retain an export request when terminal persistence fails, then replay it without rerunning an already completed export
- keep pending exports out of restart interruption recovery so their queued requests can resume safely
- report unreadable export records without deleting their index entries
- expose scheduled and stopped full-repair details through the settings tool

## Validation

- Design Library tests: 96 files and 805 tests passed
- Design Library typecheck passed
- Design Library production and installable builds passed
- root `pnpm typecheck` passed for all 24 tasks
- React Doctor changed-file scan: 100/100
- `git diff --check` passed
- all touched source files are below 500 lines
- manual Electron pass with an isolated copy of a real profile: import, search, media filter, Design detail, Gallery, and **Show more** all passed

## Notes

The manual pass did not change the source profile.
