### PR TITLE
feat(workspace): add plugin creation options

### DIFF
--- a/.agents/skills/sero-code-review/SKILL.md
+++ b/.agents/skills/sero-code-review/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: sero-code-review
+description: |
+  Review a PR, a branch, or a diff in the Sero monorepo and post the findings.
+  Use when the user asks to review code, review a PR, re-review after new
+  commits, check a branch before merge, or double-check an earlier review.
+  Trigger on phrases like "review this PR", "review the delta", "check the
+  changes", "double check it", or any request that ends in review findings.
+  Use this in place of the built-in code-review skill.
+---
+
+# Sero Code Review
+
+Applies to every PR review, branch review, and delta re-review.
+
+These rules exist because unverified findings and split review rounds waste more
+time than the review saves.
+
+## 0. The goal is a green light
+
+A review succeeds when the branch ships. It does not succeed by finding more
+things. Each round must move towards a verdict, never away from one.
+
+- Give a clear verdict every time: **green** (ship it) or **red** (do not ship,
+  and here is exactly what blocks it). Never end a review with an open-ended
+  list and no call.
+- Only a correctness, data-loss, or security defect can hold a red light. Style,
+  taste, "could be cleaner", and hypothetical edge cases never block a merge.
+- Everything else is a **non-blocking note**. Say so plainly, in the same
+  breath, so nobody has to guess whether it must be fixed.
+- When the blocking findings are fixed, call it green. Do not replace them with
+  a fresh tier of smaller findings you did not think worth raising before.
+- Later rounds must shrink. If a re-review produces more blocking findings than
+  the round before it, the earlier round was not done properly — say that
+  instead of quietly extending the list.
+- No finding at all is a valid and good result. Say "green, nothing found."
+
+## 1. Verify before you report
+
+- Read the mechanism in the source. Do not infer it. If a finding says "this
+  function returns null", "A runs before B", or "this value is stale", open the
+  file and read the lines that prove it.
+- Quote the `file:line` you read, not the one you guessed.
+- A finding you cannot prove goes in a separate **Suspected** list, marked
+  unproven — or it is not reported. Never present an inferred cause as a fact.
+- State what you ran (`pnpm typecheck`, test suites, line counts) and what you
+  could not check. Never imply coverage you do not have.
+
+## 2. Sweep the fault class
+
+- For every defect, search the sibling paths for the same pattern before you
+  close it out. Error handling, guards, and races cluster: if one branch has no
+  error surface, check the other branches in the same component.
+- Do the same for every fix on a re-review. A fix can leave the identical gap in
+  the path beside it, and can add a new fault.
+- Re-read changed logic in full. A green test suite does not clear a concurrency
+  or ordering change.
+
+## 3. One review, one comment
+
+- Post to the PR yourself as part of the job. Do not ask first.
+- Keep **one** comment per PR. Update it with `gh pr comment --edit-last`. Never
+  stack a comment per round — the PR holds one current review, not a pile of
+  rounds and corrections.
+- A delta re-review opens with the status of every previous finding (fixed / not
+  fixed / changed), then the new ones.
+- Lead with the verdict, then the blocking findings, then the non-blocking notes.
+
+## 4. Second pass before posting
+
+Route the review to the configured review model, then reconcile its findings
+with yours **before** the comment goes up. A wrong finding corrected in session
+costs nothing; corrected on the PR it costs a round trip and the reader's trust.
+
+## 5. Scope
+
+- Review when the branch is ready, not on every push, unless asked for a
+  mid-flight pass.
+- Check type safety, the 500 LOC file limit, and whether `apps/docs-site` and
+  `docs/prototypes` needed an update.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,9 @@ If you change `apps/desktop/images/Dockerfile.sero-node` or container-installed 
 - Never commit local Pi scratch/planning files under `.pi/` (especially `.pi/plans/`); the directory is gitignored and should remain local-only.
 - Use Conventional Commit messages
 - Always create pull requests as drafts. Never mark a pull request ready for review unless the user explicitly asks.
+- **CRITICAL** Reviewing a PR, a branch, or a diff — use the `sero-code-review` skill (not the built-in `code-review`). It is the process: verify every finding in the source, sweep the fault class, and keep one comment per PR.
 - Ensure good type safety in source files when conducting PR reviews
+- Always add code reviews as a comment in related Github issue
 - Avoid duplicating types that already exist in Pi SDK libraries. Import the canonical Pi types instead so upstream changes fail at typecheck time rather than becoming runtime mismatches.
 - Do not delete relevant comments
 - Prefer `useDebouncedCallback` / `createDebouncedFn` from `src/hooks/useDebouncedCallback.ts` over hand-rolled `setTimeout` debounce patterns
@@ -123,6 +125,7 @@ If you change `apps/desktop/images/Dockerfile.sero-node` or container-installed 
 - NEVER add unnecessary clutter to UI components
 - When giving instructions to manually review changes do so in simple unambiguous terms - no jargon or expectation of recent familiarity with the subject
 - After making changes to `packages/*` remind that the packages may need to be republished to npm
+- UX prototypes should be saved in `docs/prototypes`. Always create a prototype when developing a new feature or component. Prototypes should be static unless stated (see existing examples).
 
 ## Styling
  - Don't use specific tailwind font-sizes, use utilities like `text-sm`,`text-base`, etc.

--- a/apps/desktop/electron/__tests__/features/apps/app-discovery-workspace-creation.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-discovery-workspace-creation.test.ts
@@ -1,0 +1,74 @@
+import os from 'node:os';
+import path from 'node:path';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalHomeOverride = process.env.SERO_HOME_OVERRIDE;
+
+async function writeApp(packageDir: string, workspaceCreation: unknown): Promise<void> {
+  await mkdir(packageDir, { recursive: true });
+  await writeFile(path.join(packageDir, 'package.json'), JSON.stringify({
+    name: 'workspace-creation-plugin',
+    version: '1.0.0',
+    sero: {
+      app: {
+        id: 'workspace-creation',
+        name: 'Workspace Creation',
+        icon: 'box',
+        stateFile: '.sero/apps/workspace-creation/state.json',
+        workspaceCreation,
+      },
+      plugin: { category: 'utilities', tags: ['test'] },
+    },
+  }));
+}
+
+afterEach(() => {
+  vi.resetModules();
+  if (originalHomeOverride === undefined) delete process.env.SERO_HOME_OVERRIDE;
+  else process.env.SERO_HOME_OVERRIDE = originalHomeOverride;
+});
+
+describe('workspace creation app contribution discovery', () => {
+  it('parses a valid contribution', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-workspace-creation-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+    const packageDir = path.join(tempRoot, 'plugin');
+
+    try {
+      await writeApp(packageDir, {
+        label: 'Enable indexing',
+        defaultEnabled: true,
+        tool: 'enable_index',
+        params: { mode: 'full' },
+      });
+      const { readAppManifestFromPackagePath } = await import('@electron/features/apps/discovery');
+
+      const manifest = await readAppManifestFromPackagePath(packageDir);
+
+      expect(manifest?.workspaceCreation).toEqual({
+        label: 'Enable indexing',
+        defaultEnabled: true,
+        tool: 'enable_index',
+        params: { mode: 'full' },
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores a contribution without a label or tool', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-workspace-creation-invalid-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+    const packageDir = path.join(tempRoot, 'plugin');
+
+    try {
+      await writeApp(packageDir, { defaultEnabled: true });
+      const { readAppManifestFromPackagePath } = await import('@electron/features/apps/discovery');
+
+      expect((await readAppManifestFromPackagePath(packageDir))?.workspaceCreation).toBeNull();
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/electron/__tests__/features/apps/app-discovery-workspace-creation.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-discovery-workspace-creation.test.ts
@@ -71,4 +71,28 @@ describe('workspace creation app contribution discovery', () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
+
+  it('omits params that are not an object', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-workspace-creation-params-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+    const packageDir = path.join(tempRoot, 'plugin');
+
+    try {
+      await writeApp(packageDir, {
+        label: 'Enable indexing',
+        tool: 'enable_index',
+        params: ['full'],
+      });
+      const { readAppManifestFromPackagePath } = await import('@electron/features/apps/discovery');
+
+      expect((await readAppManifestFromPackagePath(packageDir))?.workspaceCreation).toEqual({
+        label: 'Enable indexing',
+        defaultEnabled: false,
+        tool: 'enable_index',
+        params: undefined,
+      });
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/desktop/electron/__tests__/features/apps/app-discovery-workspace-creation.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-discovery-workspace-creation.test.ts
@@ -95,4 +95,24 @@ describe('workspace creation app contribution discovery', () => {
       await rm(tempRoot, { recursive: true, force: true });
     }
   });
+  it('suppresses the contribution with the rest of the app UI', async () => {
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'sero-workspace-creation-suppressed-'));
+    process.env.SERO_HOME_OVERRIDE = tempRoot;
+    const packageDir = path.join(tempRoot, 'plugin');
+
+    try {
+      await writeApp(packageDir, {
+        label: 'Enable indexing',
+        tool: 'enable_index',
+      });
+      const { readAppManifestFromPackagePath } = await import('@electron/features/apps/discovery');
+
+      const manifest = await readAppManifestFromPackagePath(packageDir, { suppressUi: true });
+
+      expect(manifest?.workspaceCreation).toBeNull();
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
 });

--- a/apps/desktop/electron/__tests__/features/git/remote-connect.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/remote-connect.test.ts
@@ -48,7 +48,11 @@ describe('connectRemote', () => {
 
   it('imports into an empty workspace under auto mode', async () => {
     vcsOps.listRemotes.mockResolvedValue([]);
-    listFiles.mockResolvedValue([{ name: '.git' }, { name: '.sero-workspace.json' }]);
+    listFiles.mockResolvedValue([
+      { name: '.git' },
+      { name: '.sero' },
+      { name: '.sero-workspace.json' },
+    ]);
     vcsOps.checkoutRemote.mockResolvedValue({ success: true, message: 'ok' });
 
     const result = await connectRemote(deps, 'ws-1', URL, 'auto');

--- a/apps/desktop/electron/__tests__/features/git/remote-connect.test.ts
+++ b/apps/desktop/electron/__tests__/features/git/remote-connect.test.ts
@@ -73,6 +73,19 @@ describe('connectRemote', () => {
     });
   });
 
+  it('does not auto-import when workspace files cannot be listed', async () => {
+    vcsOps.listRemotes.mockResolvedValue([]);
+    listFiles.mockRejectedValue(new Error('workspace unavailable'));
+
+    const result = await connectRemote(deps, 'ws-1', URL, 'auto');
+
+    expect(vcsOps.checkoutRemote).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      ok: true,
+      import: { imported: false, reason: 'import-failed', message: 'workspace unavailable' },
+    });
+  });
+
   it('imports into a non-empty workspace when forced', async () => {
     vcsOps.listRemotes.mockResolvedValue([]);
     listFiles.mockResolvedValue([{ name: 'src' }]);

--- a/apps/desktop/electron/features/apps/discovery/index.ts
+++ b/apps/desktop/electron/features/apps/discovery/index.ts
@@ -284,7 +284,7 @@ function buildManifest(
     search: suppressUi ? null : parseSearch(app),
     explorerView: suppressUi ? null : parseExplorerView(app),
     titlebar: suppressUi ? null : parseTitleBar(app),
-    workspaceCreation: parseWorkspaceCreation(app),
+    workspaceCreation: suppressUi ? null : parseWorkspaceCreation(app),
   };
 }
 

--- a/apps/desktop/electron/features/apps/discovery/index.ts
+++ b/apps/desktop/electron/features/apps/discovery/index.ts
@@ -16,6 +16,7 @@ import type {
   SeroSearchManifest,
   SeroTitleBarManifest,
   SeroWidgetManifest,
+  SeroWorkspaceCreationManifest,
   SettingsPackageSource,
 } from '@/types/ipc';
 import type { PluginDevSessionRecord } from '@electron/features/plugins/dev-sessions/types';
@@ -58,6 +59,13 @@ interface PkgTitleBarDef {
   component?: string;
 }
 
+interface PkgWorkspaceCreationDef {
+  label?: string;
+  defaultEnabled?: boolean;
+  tool?: string;
+  params?: Record<string, unknown>;
+}
+
 interface PkgSeroApp {
   id: string;
   styleIsolation?: 'scope';
@@ -74,6 +82,7 @@ interface PkgSeroApp {
   search?: PkgSearchDef;
   explorerView?: PkgExplorerViewDef;
   titlebar?: PkgTitleBarDef;
+  workspaceCreation?: PkgWorkspaceCreationDef;
 }
 
 interface PkgJson {
@@ -192,6 +201,23 @@ function parseTitleBar(app: PkgSeroApp): SeroTitleBarManifest | null {
   return { component: app.titlebar.component };
 }
 
+function parseWorkspaceCreation(app: PkgSeroApp): SeroWorkspaceCreationManifest | null {
+  const contribution = app.workspaceCreation;
+  if (
+    typeof contribution?.label !== 'string'
+    || !contribution.label.trim()
+    || typeof contribution.tool !== 'string'
+    || !contribution.tool.trim()
+  ) return null;
+
+  return {
+    label: contribution.label.trim(),
+    defaultEnabled: contribution.defaultEnabled === true,
+    tool: contribution.tool.trim(),
+    params: contribution.params,
+  };
+}
+
 function buildManifest(
   pkgJson: PkgJson,
   packagePath: string,
@@ -253,6 +279,7 @@ function buildManifest(
     search: suppressUi ? null : parseSearch(app),
     explorerView: suppressUi ? null : parseExplorerView(app),
     titlebar: suppressUi ? null : parseTitleBar(app),
+    workspaceCreation: parseWorkspaceCreation(app),
   };
 }
 

--- a/apps/desktop/electron/features/apps/discovery/index.ts
+++ b/apps/desktop/electron/features/apps/discovery/index.ts
@@ -63,7 +63,7 @@ interface PkgWorkspaceCreationDef {
   label?: string;
   defaultEnabled?: boolean;
   tool?: string;
-  params?: Record<string, unknown>;
+  params?: unknown;
 }
 
 interface PkgSeroApp {
@@ -201,6 +201,11 @@ function parseTitleBar(app: PkgSeroApp): SeroTitleBarManifest | null {
   return { component: app.titlebar.component };
 }
 
+function parseWorkspaceCreationParams(params: unknown): Record<string, unknown> | undefined {
+  if (typeof params !== 'object' || params === null || Array.isArray(params)) return undefined;
+  return params as Record<string, unknown>;
+}
+
 function parseWorkspaceCreation(app: PkgSeroApp): SeroWorkspaceCreationManifest | null {
   const contribution = app.workspaceCreation;
   if (
@@ -214,7 +219,7 @@ function parseWorkspaceCreation(app: PkgSeroApp): SeroWorkspaceCreationManifest 
     label: contribution.label.trim(),
     defaultEnabled: contribution.defaultEnabled === true,
     tool: contribution.tool.trim(),
-    params: contribution.params,
+    params: parseWorkspaceCreationParams(contribution.params),
   };
 }
 

--- a/apps/desktop/electron/features/git/remote-connect.ts
+++ b/apps/desktop/electron/features/git/remote-connect.ts
@@ -68,8 +68,14 @@ async function importRemote(
 ): Promise<RemoteImportOutcome> {
   if (importMode === 'never') return { imported: false, reason: 'link-only' };
 
-  if (importMode === 'auto' && (await hasVisibleWorkspaceFiles(deps, workspaceId))) {
-    return { imported: false, reason: 'workspace-not-empty' };
+  if (importMode === 'auto') {
+    const inspection = await inspectWorkspaceFiles(deps, workspaceId);
+    if (!inspection.ok) {
+      return { imported: false, reason: 'import-failed', message: inspection.message };
+    }
+    if (inspection.hasVisibleFiles) {
+      return { imported: false, reason: 'workspace-not-empty' };
+    }
   }
 
   const checkout = await deps.vcsOps.checkoutRemote(workspaceId, 'origin');
@@ -79,16 +85,23 @@ async function importRemote(
   return { imported: false, reason: 'import-failed', message: checkout.message };
 }
 
-async function hasVisibleWorkspaceFiles(
+type WorkspaceFileInspection =
+  | { ok: true; hasVisibleFiles: boolean }
+  | { ok: false; message: string };
+
+async function inspectWorkspaceFiles(
   deps: RemoteConnectDeps,
   workspaceId: string,
-): Promise<boolean> {
+): Promise<WorkspaceFileInspection> {
   try {
     const runtime = await deps.runtimeManager.getRuntime(workspaceId);
     const entries = await runtime.listFiles({ path: runtime.runtimeWorkspacePath });
-    return entries.some((entry) => !WORKSPACE_SCAFFOLD_ENTRIES.has(entry.name));
-  } catch {
-    return false;
+    return {
+      ok: true,
+      hasVisibleFiles: entries.some((entry) => !WORKSPACE_SCAFFOLD_ENTRIES.has(entry.name)),
+    };
+  } catch (error) {
+    return { ok: false, message: toMessage(error, 'Failed to inspect workspace files') };
   }
 }
 

--- a/apps/desktop/electron/features/git/remote-connect.ts
+++ b/apps/desktop/electron/features/git/remote-connect.ts
@@ -18,7 +18,12 @@ import type { VcsOps } from '@electron/features/git/core/vcs-ops';
 import type { RuntimeManager } from '@electron/features/workspace/runtime/runtime-manager';
 
 /** Entries every workspace starts with — not "files" for the import policy. */
-const WORKSPACE_SCAFFOLD_ENTRIES = new Set(['.git', '.sero-workspace.json', '.DS_Store']);
+const WORKSPACE_SCAFFOLD_ENTRIES = new Set([
+  '.git',
+  '.sero',
+  '.sero-workspace.json',
+  '.DS_Store',
+]);
 
 export interface RemoteConnectDeps {
   vcsOps: VcsOps;

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.fixtures.ts
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.fixtures.ts
@@ -1,0 +1,45 @@
+import type { SeroAppManifest, WorkspaceInfo } from '@/types/ipc';
+
+export const createdWorkspace: WorkspaceInfo = {
+  id: 'workspace-1',
+  name: 'Workspace 1',
+  path: '/tmp/workspace-1',
+  open: true,
+  runtime: { backend: 'host' },
+  container: false,
+  references: [],
+  mounts: [],
+  roots: [],
+};
+
+export const secondWorkspace: WorkspaceInfo = {
+  ...createdWorkspace,
+  id: 'workspace-2',
+  name: 'Workspace 2',
+  path: '/tmp/workspace-2',
+};
+
+export const graphifyManifest: SeroAppManifest = {
+  id: 'graphify',
+  name: 'Graphify',
+  description: null,
+  version: '1.0.0',
+  packageName: '@sero-ai/sero-graphify-plugin',
+  icon: 'network',
+  stateFile: '.sero/apps/graphify/state.json',
+  scope: 'global',
+  globalStatePath: '/tmp/graphify-state.json',
+  uiEntry: null,
+  runtimeEntry: null,
+  component: null,
+  devPort: undefined,
+  remoteEntryOverride: null,
+  packagePath: '/tmp/graphify',
+  isPlugin: true,
+  widgets: [],
+  workspaceCreation: {
+    label: 'Enable Graphify indexing',
+    defaultEnabled: true,
+    tool: 'graphify_index',
+  },
+};

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SeroAppManifest } from '@/types/ipc';
+import { useAppStore } from '@/stores/app';
+import { AddWorkspaceMenu } from './AddWorkspaceMenu';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const initialAppState = useAppStore.getState();
+
+const graphifyManifest: SeroAppManifest = {
+  id: 'graphify',
+  name: 'Graphify',
+  description: null,
+  version: '1.0.0',
+  packageName: '@sero-ai/sero-graphify-plugin',
+  icon: 'network',
+  stateFile: '.sero/apps/graphify/state.json',
+  scope: 'global',
+  globalStatePath: '/tmp/graphify-state.json',
+  uiEntry: null,
+  runtimeEntry: null,
+  component: null,
+  devPort: undefined,
+  remoteEntryOverride: null,
+  packagePath: '/tmp/graphify',
+  isPlugin: true,
+  widgets: [],
+  workspaceCreation: {
+    label: 'Enable Graphify indexing',
+    defaultEnabled: true,
+    tool: 'graphify_index',
+  },
+};
+
+function getButton(label: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll('button')]
+    .find((candidate) => candidate.textContent?.trim() === label);
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected button "${label}"`);
+  }
+  return button;
+}
+
+async function click(element: HTMLElement): Promise<void> {
+  await act(async () => {
+    element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+describe('AddWorkspaceMenu', () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    useAppStore.setState({
+      ...initialAppState,
+      apps: [
+        ...initialAppState.apps,
+        {
+          id: 'graphify',
+          label: 'Graphify',
+          icon: 'network',
+          builtin: false,
+          manifest: graphifyManifest,
+        },
+      ],
+    }, true);
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    root = null;
+    container.remove();
+    useAppStore.setState(initialAppState, true);
+    vi.unstubAllGlobals();
+  });
+
+  it('restores contribution defaults after leaving the create view', async () => {
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+
+    const trigger = document.querySelector('[title="Add workspace"]');
+    if (!(trigger instanceof HTMLElement)) throw new Error('Expected add workspace trigger');
+    await click(trigger);
+    await click(getButton('Create New'));
+
+    const switchId = '#workspace-create-option-graphify';
+    const option = document.querySelector(switchId);
+    if (!(option instanceof HTMLButtonElement)) throw new Error('Expected Graphify option');
+    expect(option.getAttribute('aria-checked')).toBe('true');
+
+    await click(option);
+    expect(option.getAttribute('aria-checked')).toBe('false');
+    await click(getButton('Back'));
+    await click(getButton('Create New'));
+
+    expect(document.querySelector(switchId)?.getAttribute('aria-checked')).toBe('true');
+  });
+});

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -25,6 +25,9 @@ const seroBridge = {
   vcs: {
     remotes: vi.fn(),
   },
+  workspace: {
+    pickFolder: vi.fn(),
+  },
 };
 
 interface Deferred<T> {
@@ -92,6 +95,15 @@ function getButton(label: string): HTMLButtonElement {
   return button;
 }
 
+function getButtonContaining(text: string): HTMLButtonElement {
+  const button = [...document.querySelectorAll('button')]
+    .find((candidate) => candidate.textContent?.includes(text));
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Expected button containing "${text}"`);
+  }
+  return button;
+}
+
 async function click(element: HTMLElement): Promise<void> {
   await act(async () => {
     element.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -117,6 +129,12 @@ async function openCreateView(): Promise<void> {
   await setInputValue(input, createdWorkspace.name);
 }
 
+
+async function openWorkspacePicker(): Promise<void> {
+  const trigger = document.querySelector('[title="Add workspace"]');
+  if (!(trigger instanceof HTMLElement)) throw new Error('Expected add workspace trigger');
+  await click(trigger);
+}
 describe('AddWorkspaceMenu', () => {
   let container: HTMLDivElement;
   let root: Root | null = null;
@@ -128,6 +146,7 @@ describe('AddWorkspaceMenu', () => {
     });
     seroBridge.appAgent.invokeTool.mockReset();
     seroBridge.vcs.remotes.mockResolvedValue([]);
+    seroBridge.workspace.pickFolder.mockReset();
     Object.defineProperty(window, 'sero', {
       configurable: true,
       value: seroBridge,
@@ -148,6 +167,8 @@ describe('AddWorkspaceMenu', () => {
     useWorkspaceStore.setState({
       ...initialWorkspaceState,
       createWorkspace: vi.fn().mockResolvedValue(createdWorkspace),
+      cloneWorkspace: vi.fn().mockResolvedValue(createdWorkspace),
+      addFolder: vi.fn().mockResolvedValue(createdWorkspace),
     }, true);
     useSessionStore.setState({
       ...initialSessionState,
@@ -258,6 +279,148 @@ describe('AddWorkspaceMenu', () => {
       .toContain('Graphify: State file is read-only');
   });
 
+  it('keeps the remote form open when contribution setup fails', async () => {
+    const { promise, resolve } = promiseRuntime.withResolvers<AppToolResult>();
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockReturnValue(promise);
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openCreateView();
+    await click(getButton('Create'));
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(document.body.textContent).toContain('Connect existing repository');
+      });
+    });
+    await click(getButtonContaining('Connect existing repository'));
+    const remoteUrl = document.querySelector('#remote-url');
+    if (!(remoteUrl instanceof HTMLInputElement)) throw new Error('Expected remote URL input');
+    await setInputValue(remoteUrl, 'https://github.com/sero-labs/sero.git');
+
+    await act(async () => {
+      resolve({
+        text: 'State file is read-only',
+        content: [],
+        details: null,
+        isError: true,
+      });
+      await promise;
+    });
+
+    expect(document.body.textContent).toContain('Git Repository');
+    expect(document.querySelector<HTMLInputElement>('#remote-url')?.value)
+      .toBe('https://github.com/sero-labs/sero.git');
+    expect(document.querySelector('[role="alert"]')?.textContent)
+      .toContain('Graphify: State file is read-only');
+  });
+
+  it('shows the current remote prompt while an earlier setup failure remains', async () => {
+    const first = promiseRuntime.withResolvers<AppToolResult>();
+    const second = Promise.race<AppToolResult>([]);
+    vi.spyOn(window.sero.appAgent, 'invokeTool')
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second);
+    useWorkspaceStore.setState({
+      createWorkspace: vi.fn()
+        .mockResolvedValueOnce(createdWorkspace)
+        .mockResolvedValueOnce(secondWorkspace),
+    });
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openCreateView();
+    await click(getButton('Create'));
+    await click(getButton('Close'));
+    await act(async () => {
+      first.resolve({
+        text: 'First setup failed',
+        content: [],
+        details: null,
+        isError: true,
+      });
+      await first.promise;
+    });
+
+    await openWorkspacePicker();
+    await click(getButton('Create New'));
+    const nameInput = document.querySelector('#new-workspace-name');
+    if (!(nameInput instanceof HTMLInputElement)) throw new Error('Expected workspace name input');
+    await setInputValue(nameInput, secondWorkspace.name);
+    await click(getButton('Create'));
+
+    expect(document.body.textContent).toContain('Link "Workspace 2" to a Git repository.');
+    expect(document.querySelector('[role="alert"]')?.textContent)
+      .toContain('Graphify: First setup failed');
+  });
+
+  it('runs enabled contributions after cloning a workspace', async () => {
+    const cloneWorkspace = vi.fn().mockResolvedValue(createdWorkspace);
+    useWorkspaceStore.setState({ cloneWorkspace });
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockResolvedValue({
+      text: 'Queued',
+      content: [],
+      details: null,
+      isError: false,
+    });
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openWorkspacePicker();
+    await click(getButton('Clone Repository'));
+    expect(document.querySelector('#workspace-create-option-graphify')).not.toBeNull();
+    const cloneUrl = document.querySelector('#clone-url');
+    if (!(cloneUrl instanceof HTMLInputElement)) throw new Error('Expected clone URL input');
+    await setInputValue(cloneUrl, 'https://github.com/sero-labs/sero.git');
+    await click(getButton('Clone'));
+
+    expect(cloneWorkspace).toHaveBeenCalled();
+    expect(window.sero.appAgent.invokeTool).toHaveBeenCalledWith(
+      'graphify',
+      createdWorkspace.id,
+      'graphify_index',
+      expect.objectContaining({
+        workspaceId: createdWorkspace.id,
+        workspaceName: createdWorkspace.name,
+        workspacePath: createdWorkspace.path,
+      }),
+    );
+  });
+
+  it('runs enabled contributions after importing a workspace', async () => {
+    const addFolder = vi.fn().mockResolvedValue(createdWorkspace);
+    useWorkspaceStore.setState({ addFolder });
+    seroBridge.workspace.pickFolder.mockResolvedValue(createdWorkspace.path);
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockResolvedValue({
+      text: 'Queued',
+      content: [],
+      details: null,
+      isError: false,
+    });
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openWorkspacePicker();
+    await click(getButton('Import Existing'));
+    expect(document.querySelector('#workspace-create-option-graphify')).not.toBeNull();
+    await click(getButton('Choose Folder'));
+
+    expect(addFolder).toHaveBeenCalledWith(createdWorkspace.path);
+    expect(window.sero.appAgent.invokeTool).toHaveBeenCalledWith(
+      'graphify',
+      createdWorkspace.id,
+      'graphify_index',
+      expect.objectContaining({
+        workspaceId: createdWorkspace.id,
+        workspaceName: createdWorkspace.name,
+        workspacePath: createdWorkspace.path,
+      }),
+    );
+  });
+
   it('keeps setup failures for each workspace until dismissed', async () => {
     const first = promiseRuntime.withResolvers<AppToolResult>();
     const second = promiseRuntime.withResolvers<AppToolResult>();
@@ -279,6 +442,10 @@ describe('AddWorkspaceMenu', () => {
     const trigger = document.querySelector('[title="Add workspace"]');
     if (!(trigger instanceof HTMLElement)) throw new Error('Expected add workspace trigger');
     await click(trigger);
+    await click(getButton('Create New'));
+    const secondNameInput = document.querySelector('#new-workspace-name');
+    if (!(secondNameInput instanceof HTMLInputElement)) throw new Error('Expected workspace name input');
+    await setInputValue(secondNameInput, secondWorkspace.name);
     await click(getButton('Create'));
     await click(getButton('Close'));
 
@@ -303,7 +470,7 @@ describe('AddWorkspaceMenu', () => {
 
     expect(document.querySelector('[role="alert"]')?.textContent)
       .toContain('Graphify: First setup failed');
-    await click(getButton('Close'));
+    await click(getButton('Dismiss'));
     expect(document.querySelector('[role="alert"]')?.textContent)
       .toContain('Graphify: Second setup failed');
   });

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -24,6 +24,7 @@ const seroBridge = {
   },
   vcs: {
     remotes: vi.fn(),
+    connectRemote: vi.fn(),
   },
   workspace: {
     pickFolder: vi.fn(),
@@ -129,7 +130,6 @@ async function openCreateView(): Promise<void> {
   await setInputValue(input, createdWorkspace.name);
 }
 
-
 async function openWorkspacePicker(): Promise<void> {
   const trigger = document.querySelector('[title="Add workspace"]');
   if (!(trigger instanceof HTMLElement)) throw new Error('Expected add workspace trigger');
@@ -146,6 +146,12 @@ describe('AddWorkspaceMenu', () => {
     });
     seroBridge.appAgent.invokeTool.mockReset();
     seroBridge.vcs.remotes.mockResolvedValue([]);
+    seroBridge.vcs.connectRemote.mockResolvedValue({
+      ok: true,
+      url: 'https://github.com/sero-labs/sero.git',
+      updatedExisting: false,
+      import: { imported: true },
+    });
     seroBridge.workspace.pickFolder.mockReset();
     Object.defineProperty(window, 'sero', {
       configurable: true,
@@ -200,10 +206,16 @@ describe('AddWorkspaceMenu', () => {
     vi.unstubAllGlobals();
   });
 
-  it('restores contribution defaults after leaving the create view', async () => {
+  async function renderMenu(): Promise<void> {
+    const mountedRoot = root;
+    if (!mountedRoot) throw new Error('Expected mounted test root');
     await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
+      mountedRoot.render(<AddWorkspaceMenu />);
     });
+  }
+
+  it('restores contribution defaults after leaving the create view', async () => {
+    await renderMenu();
 
     await openCreateView();
 
@@ -220,17 +232,23 @@ describe('AddWorkspaceMenu', () => {
     expect(document.querySelector(switchId)?.getAttribute('aria-checked')).toBe('true');
   });
 
-  it('opens the remote prompt before contribution setup finishes', async () => {
-    const pendingTool = Promise.race<AppToolResult>([]);
-    vi.spyOn(window.sero.appAgent, 'invokeTool').mockReturnValue(pendingTool);
-
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
+  it('waits to run contribution setup until the remote prompt finishes', async () => {
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockResolvedValue({
+      text: 'Queued',
+      content: [],
+      details: null,
+      isError: false,
     });
+
+    await renderMenu();
     await openCreateView();
     await click(getButton('Create'));
 
     expect(document.body.textContent).toContain('Git Repository');
+    expect(window.sero.appAgent.invokeTool).not.toHaveBeenCalled();
+
+    await click(getButton('Close'));
+    expect(window.sero.appAgent.invokeTool).toHaveBeenCalledOnce();
   });
 
   it('shows a fulfilled contribution tool error', async () => {
@@ -241,11 +259,10 @@ describe('AddWorkspaceMenu', () => {
       isError: true,
     });
 
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
-    });
+    await renderMenu();
     await openCreateView();
     await click(getButton('Create'));
+    await click(getButton('Close'));
     await act(async () => {
       await Promise.resolve();
     });
@@ -258,9 +275,7 @@ describe('AddWorkspaceMenu', () => {
     const { promise, resolve } = promiseRuntime.withResolvers<AppToolResult>();
     vi.spyOn(window.sero.appAgent, 'invokeTool').mockReturnValue(promise);
 
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
-    });
+    await renderMenu();
     await openCreateView();
     await click(getButton('Create'));
     await click(getButton('Close'));
@@ -277,15 +292,14 @@ describe('AddWorkspaceMenu', () => {
     expect(document.body.textContent).toContain('Workspace setup failed');
     expect(document.querySelector('[role="alert"]')?.textContent)
       .toContain('Graphify: State file is read-only');
+    expect(document.querySelector('[role="alert"]')?.classList.contains('fixed')).toBe(true);
   });
 
   it('keeps the remote form open when contribution setup fails', async () => {
     const { promise, resolve } = promiseRuntime.withResolvers<AppToolResult>();
     vi.spyOn(window.sero.appAgent, 'invokeTool').mockReturnValue(promise);
 
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
-    });
+    await renderMenu();
     await openCreateView();
     await click(getButton('Create'));
     await act(async () => {
@@ -296,7 +310,10 @@ describe('AddWorkspaceMenu', () => {
     await click(getButtonContaining('Connect existing repository'));
     const remoteUrl = document.querySelector('#remote-url');
     if (!(remoteUrl instanceof HTMLInputElement)) throw new Error('Expected remote URL input');
+    expect(window.sero.appAgent.invokeTool).not.toHaveBeenCalled();
     await setInputValue(remoteUrl, 'https://github.com/sero-labs/sero.git');
+    await click(getButton('Connect Repository'));
+    expect(window.sero.appAgent.invokeTool).toHaveBeenCalledOnce();
 
     await act(async () => {
       resolve({
@@ -309,43 +326,36 @@ describe('AddWorkspaceMenu', () => {
     });
 
     expect(document.body.textContent).toContain('Git Repository');
-    expect(document.querySelector<HTMLInputElement>('#remote-url')?.value)
-      .toBe('https://github.com/sero-labs/sero.git');
     expect(document.querySelector('[role="alert"]')?.textContent)
       .toContain('Graphify: State file is read-only');
     const dialog = document.querySelector('[role="dialog"]');
     const alert = document.querySelector('[role="alert"]');
     expect(dialog?.contains(alert)).toBe(true);
+    expect(alert?.classList.contains('fixed')).toBe(false);
     await click(getButton('Dismiss'));
     expect(document.querySelector('[role="alert"]')).toBeNull();
   });
 
   it('shows the current remote prompt while an earlier setup failure remains', async () => {
-    const first = promiseRuntime.withResolvers<AppToolResult>();
-    const second = Promise.race<AppToolResult>([]);
-    vi.spyOn(window.sero.appAgent, 'invokeTool')
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second);
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockResolvedValue({
+      text: 'First setup failed',
+      content: [],
+      details: null,
+      isError: true,
+    });
     useWorkspaceStore.setState({
       createWorkspace: vi.fn()
         .mockResolvedValueOnce(createdWorkspace)
         .mockResolvedValueOnce(secondWorkspace),
     });
 
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
-    });
+    await renderMenu();
     await openCreateView();
     await click(getButton('Create'));
     await click(getButton('Close'));
-    await act(async () => {
-      first.resolve({
-        text: 'First setup failed',
-        content: [],
-        details: null,
-        isError: true,
-      });
-      await first.promise;
+    await vi.waitFor(() => {
+      expect(document.querySelector('[role="alert"]')?.textContent)
+        .toContain('Graphify: First setup failed');
     });
 
     await openWorkspacePicker();
@@ -370,9 +380,7 @@ describe('AddWorkspaceMenu', () => {
       isError: false,
     });
 
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
-    });
+    await renderMenu();
     await openWorkspacePicker();
     await click(getButton('Clone Repository'));
     expect(document.querySelector('#workspace-create-option-graphify')).not.toBeNull();
@@ -405,9 +413,7 @@ describe('AddWorkspaceMenu', () => {
       isError: false,
     });
 
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
-    });
+    await renderMenu();
     await openWorkspacePicker();
     await click(getButton('Import Existing'));
     expect(document.querySelector('#workspace-create-option-graphify')).not.toBeNull();
@@ -426,6 +432,20 @@ describe('AddWorkspaceMenu', () => {
     );
   });
 
+  it('imports directly without options and shows folder errors', async () => {
+    const addFolder = vi.fn().mockRejectedValue(new Error('Folder is unavailable'));
+    useAppStore.setState({ ...initialAppState, apps: [] }, true);
+    useWorkspaceStore.setState({ addFolder });
+    seroBridge.workspace.pickFolder.mockResolvedValue('/tmp/unavailable');
+
+    await renderMenu();
+    await openWorkspacePicker();
+    await click(getButton('Import Existing'));
+
+    await vi.waitFor(() => expect(addFolder).toHaveBeenCalledWith('/tmp/unavailable'));
+    expect(document.body.textContent).toContain('Folder is unavailable');
+  });
+
   it('keeps setup failures for each workspace until dismissed', async () => {
     const first = promiseRuntime.withResolvers<AppToolResult>();
     const second = promiseRuntime.withResolvers<AppToolResult>();
@@ -438,9 +458,7 @@ describe('AddWorkspaceMenu', () => {
         .mockResolvedValueOnce(secondWorkspace),
     });
 
-    await act(async () => {
-      root?.render(<AddWorkspaceMenu />);
-    });
+    await renderMenu();
     await openCreateView();
     await click(getButton('Create'));
     await click(getButton('Close'));

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -3,7 +3,10 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { SeroAppManifest } from '@/types/ipc';
+import type { AppToolResult } from '@sero-ai/common';
+import type { SeroAppManifest, WorkspaceInfo } from '@/types/ipc';
+import { useSessionStore } from '@/stores/sessions';
+import { useWorkspaceStore } from '@/stores/workspace';
 import { useAppStore } from '@/stores/app';
 import { AddWorkspaceMenu } from './AddWorkspaceMenu';
 
@@ -12,6 +15,29 @@ import { AddWorkspaceMenu } from './AddWorkspaceMenu';
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const initialAppState = useAppStore.getState();
+const initialSessionState = useSessionStore.getState();
+const initialWorkspaceState = useWorkspaceStore.getState();
+const originalSeroDescriptor = Object.getOwnPropertyDescriptor(window, 'sero');
+const seroBridge = {
+  appAgent: {
+    invokeTool: vi.fn(),
+  },
+  vcs: {
+    remotes: vi.fn(),
+  },
+};
+
+const createdWorkspace: WorkspaceInfo = {
+  id: 'workspace-1',
+  name: 'Workspace 1',
+  path: '/tmp/workspace-1',
+  open: true,
+  runtime: { backend: 'host' },
+  container: false,
+  references: [],
+  mounts: [],
+  roots: [],
+};
 
 const graphifyManifest: SeroAppManifest = {
   id: 'graphify',
@@ -53,6 +79,25 @@ async function click(element: HTMLElement): Promise<void> {
   });
 }
 
+async function setInputValue(input: HTMLInputElement, value: string): Promise<void> {
+  const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  if (!valueSetter) throw new Error('Expected HTMLInputElement value setter');
+  await act(async () => {
+    valueSetter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+async function openCreateView(): Promise<void> {
+  const trigger = document.querySelector('[title="Add workspace"]');
+  if (!(trigger instanceof HTMLElement)) throw new Error('Expected add workspace trigger');
+  await click(trigger);
+  await click(getButton('Create New'));
+  const input = document.querySelector('#new-workspace-name');
+  if (!(input instanceof HTMLInputElement)) throw new Error('Expected workspace name input');
+  await setInputValue(input, createdWorkspace.name);
+}
+
 describe('AddWorkspaceMenu', () => {
   let container: HTMLDivElement;
   let root: Root | null = null;
@@ -61,6 +106,12 @@ describe('AddWorkspaceMenu', () => {
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0);
       return 1;
+    });
+    seroBridge.appAgent.invokeTool.mockReset();
+    seroBridge.vcs.remotes.mockResolvedValue([]);
+    Object.defineProperty(window, 'sero', {
+      configurable: true,
+      value: seroBridge,
     });
     useAppStore.setState({
       ...initialAppState,
@@ -74,6 +125,14 @@ describe('AddWorkspaceMenu', () => {
           manifest: graphifyManifest,
         },
       ],
+    }, true);
+    useWorkspaceStore.setState({
+      ...initialWorkspaceState,
+      createWorkspace: vi.fn().mockResolvedValue(createdWorkspace),
+    }, true);
+    useSessionStore.setState({
+      ...initialSessionState,
+      loadSessions: vi.fn().mockResolvedValue(undefined),
     }, true);
 
     container = document.createElement('div');
@@ -90,6 +149,14 @@ describe('AddWorkspaceMenu', () => {
     root = null;
     container.remove();
     useAppStore.setState(initialAppState, true);
+    useWorkspaceStore.setState(initialWorkspaceState, true);
+    useSessionStore.setState(initialSessionState, true);
+    if (originalSeroDescriptor) {
+      Object.defineProperty(window, 'sero', originalSeroDescriptor);
+    } else {
+      Reflect.deleteProperty(window, 'sero');
+    }
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -98,10 +165,7 @@ describe('AddWorkspaceMenu', () => {
       root?.render(<AddWorkspaceMenu />);
     });
 
-    const trigger = document.querySelector('[title="Add workspace"]');
-    if (!(trigger instanceof HTMLElement)) throw new Error('Expected add workspace trigger');
-    await click(trigger);
-    await click(getButton('Create New'));
+    await openCreateView();
 
     const switchId = '#workspace-create-option-graphify';
     const option = document.querySelector(switchId);
@@ -114,5 +178,39 @@ describe('AddWorkspaceMenu', () => {
     await click(getButton('Create New'));
 
     expect(document.querySelector(switchId)?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('opens the remote prompt before contribution setup finishes', async () => {
+    const pendingTool = Promise.race<AppToolResult>([]);
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockReturnValue(pendingTool);
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openCreateView();
+    await click(getButton('Create'));
+
+    expect(document.body.textContent).toContain('Git Repository');
+  });
+
+  it('shows a fulfilled contribution tool error', async () => {
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockResolvedValue({
+      text: 'State file is read-only',
+      content: [],
+      details: null,
+      isError: true,
+    });
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openCreateView();
+    await click(getButton('Create'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(document.querySelector('[role="alert"]')?.textContent)
+      .toContain('Graphify: State file is read-only');
   });
 });

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -4,11 +4,11 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AppToolResult } from '@sero-ai/common';
-import type { SeroAppManifest, WorkspaceInfo } from '@/types/ipc';
 import { useSessionStore } from '@/stores/sessions';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useAppStore } from '@/stores/app';
 import { AddWorkspaceMenu } from './AddWorkspaceMenu';
+import { createdWorkspace, graphifyManifest, secondWorkspace } from './AddWorkspaceMenu.fixtures';
 
 (
   globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -43,49 +43,6 @@ const promiseRuntime = Promise as PromiseConstructor & {
   withResolvers<T>(): Deferred<T>;
 };
 
-const createdWorkspace: WorkspaceInfo = {
-  id: 'workspace-1',
-  name: 'Workspace 1',
-  path: '/tmp/workspace-1',
-  open: true,
-  runtime: { backend: 'host' },
-  container: false,
-  references: [],
-  mounts: [],
-  roots: [],
-};
-
-const secondWorkspace: WorkspaceInfo = {
-  ...createdWorkspace,
-  id: 'workspace-2',
-  name: 'Workspace 2',
-  path: '/tmp/workspace-2',
-};
-
-const graphifyManifest: SeroAppManifest = {
-  id: 'graphify',
-  name: 'Graphify',
-  description: null,
-  version: '1.0.0',
-  packageName: '@sero-ai/sero-graphify-plugin',
-  icon: 'network',
-  stateFile: '.sero/apps/graphify/state.json',
-  scope: 'global',
-  globalStatePath: '/tmp/graphify-state.json',
-  uiEntry: null,
-  runtimeEntry: null,
-  component: null,
-  devPort: undefined,
-  remoteEntryOverride: null,
-  packagePath: '/tmp/graphify',
-  isPlugin: true,
-  widgets: [],
-  workspaceCreation: {
-    label: 'Enable Graphify indexing',
-    defaultEnabled: true,
-    tool: 'graphify_index',
-  },
-};
 
 function getButton(label: string): HTMLButtonElement {
   const button = [...document.querySelectorAll('button')]
@@ -230,6 +187,19 @@ describe('AddWorkspaceMenu', () => {
     await click(getButton('Create New'));
 
     expect(document.querySelector(switchId)?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('shows workspace creation failures', async () => {
+    useWorkspaceStore.setState({
+      createWorkspace: vi.fn().mockRejectedValue(new Error('Workspace name already exists')),
+    });
+    await renderMenu();
+    await openCreateView();
+    await click(getButton('Create'));
+    await vi.waitFor(() => {
+      expect(document.querySelector('[role="alert"]')?.textContent)
+        .toContain('Workspace name already exists');
+    });
   });
 
   it('waits to run contribution setup until the remote prompt finishes', async () => {

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -313,6 +313,11 @@ describe('AddWorkspaceMenu', () => {
       .toBe('https://github.com/sero-labs/sero.git');
     expect(document.querySelector('[role="alert"]')?.textContent)
       .toContain('Graphify: State file is read-only');
+    const dialog = document.querySelector('[role="dialog"]');
+    const alert = document.querySelector('[role="alert"]');
+    expect(dialog?.contains(alert)).toBe(true);
+    await click(getButton('Dismiss'));
+    expect(document.querySelector('[role="alert"]')).toBeNull();
   });
 
   it('shows the current remote prompt while an earlier setup failure remains', async () => {

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -27,6 +27,18 @@ const seroBridge = {
   },
 };
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+// The test runtime supports ES2024 Promise.withResolvers, but the renderer
+// TypeScript library target does not declare it yet.
+const promiseRuntime = Promise as PromiseConstructor & {
+  withResolvers<T>(): Deferred<T>;
+};
+
 const createdWorkspace: WorkspaceInfo = {
   id: 'workspace-1',
   name: 'Workspace 1',
@@ -37,6 +49,13 @@ const createdWorkspace: WorkspaceInfo = {
   references: [],
   mounts: [],
   roots: [],
+};
+
+const secondWorkspace: WorkspaceInfo = {
+  ...createdWorkspace,
+  id: 'workspace-2',
+  name: 'Workspace 2',
+  path: '/tmp/workspace-2',
 };
 
 const graphifyManifest: SeroAppManifest = {
@@ -212,5 +231,80 @@ describe('AddWorkspaceMenu', () => {
 
     expect(document.querySelector('[role="alert"]')?.textContent)
       .toContain('Graphify: State file is read-only');
+  });
+
+  it('shows a contribution failure after the remote prompt closes', async () => {
+    const { promise, resolve } = promiseRuntime.withResolvers<AppToolResult>();
+    vi.spyOn(window.sero.appAgent, 'invokeTool').mockReturnValue(promise);
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openCreateView();
+    await click(getButton('Create'));
+    await click(getButton('Close'));
+    await act(async () => {
+      resolve({
+        text: 'State file is read-only',
+        content: [],
+        details: null,
+        isError: true,
+      });
+      await promise;
+    });
+
+    expect(document.body.textContent).toContain('Workspace setup failed');
+    expect(document.querySelector('[role="alert"]')?.textContent)
+      .toContain('Graphify: State file is read-only');
+  });
+
+  it('keeps setup failures for each workspace until dismissed', async () => {
+    const first = promiseRuntime.withResolvers<AppToolResult>();
+    const second = promiseRuntime.withResolvers<AppToolResult>();
+    vi.spyOn(window.sero.appAgent, 'invokeTool')
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    useWorkspaceStore.setState({
+      createWorkspace: vi.fn()
+        .mockResolvedValueOnce(createdWorkspace)
+        .mockResolvedValueOnce(secondWorkspace),
+    });
+
+    await act(async () => {
+      root?.render(<AddWorkspaceMenu />);
+    });
+    await openCreateView();
+    await click(getButton('Create'));
+    await click(getButton('Close'));
+    const trigger = document.querySelector('[title="Add workspace"]');
+    if (!(trigger instanceof HTMLElement)) throw new Error('Expected add workspace trigger');
+    await click(trigger);
+    await click(getButton('Create'));
+    await click(getButton('Close'));
+
+    await act(async () => {
+      first.resolve({
+        text: 'First setup failed',
+        content: [],
+        details: null,
+        isError: true,
+      });
+      await first.promise;
+    });
+    await act(async () => {
+      second.resolve({
+        text: 'Second setup failed',
+        content: [],
+        details: null,
+        isError: true,
+      });
+      await second.promise;
+    });
+
+    expect(document.querySelector('[role="alert"]')?.textContent)
+      .toContain('Graphify: First setup failed');
+    await click(getButton('Close'));
+    expect(document.querySelector('[role="alert"]')?.textContent)
+      .toContain('Graphify: Second setup failed');
   });
 });

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -4,6 +4,7 @@ import { deriveRepoNameFromGitUrl } from '@sero-ai/common';
 import { useWorkspaceStore } from '@/stores/workspace';
 import { useSessionStore } from '@/stores/sessions';
 import { useGitHubAuthStore } from '@/stores/github-auth';
+import { getWorkspaceCreationContributionApps, useAppStore } from '@/stores/app';
 import {
   Popover,
   PopoverContent,
@@ -36,6 +37,7 @@ export function AddWorkspaceMenu() {
   const [parentPath, setParentPath] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
+  const [workspaceCreationSelections, setWorkspaceCreationSelections] = useState<Record<string, boolean>>({});
 
   // Clone view state
   const [cloneUrl, setCloneUrl] = useState('');
@@ -56,6 +58,14 @@ export function AddWorkspaceMenu() {
   const addFolder = useWorkspaceStore((s) => s.addFolder);
   const loadSessions = useSessionStore((s) => s.loadSessions);
   const openGitHubAuthDialog = useGitHubAuthStore((s) => s.openGitHubAuthDialog);
+  const workspaceCreationContributions = useAppStore((s) => getWorkspaceCreationContributionApps(s.apps));
+  const workspaceCreationOptions = workspaceCreationContributions.map((app) => ({
+    id: app.id,
+    label: app.manifest!.workspaceCreation!.label,
+    enabled: workspaceCreationSelections[app.id]
+      ?? app.manifest!.workspaceCreation!.defaultEnabled
+      ?? false,
+  }));
 
   const reset = () => {
     setView('pick');
@@ -66,6 +76,7 @@ export function AddWorkspaceMenu() {
     cloneNameEditedRef.current = false;
     setCloneError(null);
     setCloneAuthHint(false);
+    setWorkspaceCreationSelections({});
   };
 
   const handleImportExisting = async () => {
@@ -99,6 +110,28 @@ export function AddWorkspaceMenu() {
     setIsCreating(true);
     try {
       const ws = await createWorkspace(trimmed, parentPath ?? undefined);
+      const enabledContributions = workspaceCreationContributions.filter((app) => (
+        workspaceCreationSelections[app.id]
+          ?? app.manifest!.workspaceCreation!.defaultEnabled
+          ?? false
+      ));
+      const results = await Promise.allSettled(enabledContributions.map((app) => {
+        const contribution = app.manifest!.workspaceCreation!;
+        return window.sero.appAgent.invokeTool(app.id, ws.id, contribution.tool, {
+          ...contribution.params,
+          workspaceId: ws.id,
+          workspaceName: ws.name,
+          workspacePath: ws.path,
+        });
+      }));
+      results.forEach((result, index) => {
+        if (result.status === 'rejected') {
+          console.warn(
+            `[workspace] ${enabledContributions[index].label} setup failed:`,
+            result.reason,
+          );
+        }
+      });
       await loadSessions();
       setOpen(false);
       // Prompt user to set up remote origin for the new workspace
@@ -192,6 +225,11 @@ export function AddWorkspaceMenu() {
             onBack={() => { setView('pick'); setNewName(''); setParentPath(null); }}
             onCreate={handleCreate}
             isCreating={isCreating}
+            options={workspaceCreationOptions}
+            onOptionChange={(id, enabled) => setWorkspaceCreationSelections((current) => ({
+              ...current,
+              [id]: enabled,
+            }))}
           />
         )}
         {view === 'clone' && (

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -21,7 +21,6 @@ import { useWorkspaceSetup } from './workspace-setup';
 
 type AddView = 'pick' | 'create' | 'clone' | 'import';
 
-
 /** Errors that mean "you need GitHub credentials", as opposed to a bad URL. */
 function looksLikeAuthError(message: string): boolean {
   return /authentication|authenticate|permission denied|access denied|403|terminal prompts disabled|could not read username|repository not found/i.test(
@@ -39,6 +38,7 @@ export function AddWorkspaceMenu() {
   const [newName, setNewName] = useState('');
   const [parentPath, setParentPath] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
   const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
@@ -83,6 +83,7 @@ export function AddWorkspaceMenu() {
   const reset = () => {
     setView('pick');
     setNewName('');
+    setCreateError(null);
     setParentPath(null);
     setCloneUrl('');
     setCloneName('');
@@ -124,7 +125,6 @@ export function AddWorkspaceMenu() {
     }
   };
 
-
   const completeWorkspaceAddition = async (
     ws: WorkspaceInfo,
     promptForRemote = false,
@@ -145,11 +145,12 @@ export function AddWorkspaceMenu() {
     const trimmed = newName.trim();
     if (!trimmed || isCreating) return;
     setIsCreating(true);
+    setCreateError(null);
     try {
       const ws = await createWorkspace(trimmed, parentPath ?? undefined);
       await completeWorkspaceAddition(ws, true);
     } catch (err) {
-      console.error('Failed to create workspace:', err);
+      setCreateError(err instanceof Error ? err.message : 'Failed to create workspace');
     } finally {
       setIsCreating(false);
     }
@@ -196,7 +197,6 @@ export function AddWorkspaceMenu() {
   const handleOptionChange = (id: string, enabled: boolean): void => {
     setWorkspaceCreationSelections((current) => ({ ...current, [id]: enabled }));
   };
-
 
   const workspaceSetupFailureNotice = activeWorkspaceSetupFailure
     ? (
@@ -260,6 +260,7 @@ export function AddWorkspaceMenu() {
             onBack={reset}
             onCreate={handleCreate}
             isCreating={isCreating}
+            error={createError}
             options={workspaceCreationOptions}
             onOptionChange={handleOptionChange}
           />

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -38,6 +38,10 @@ export function AddWorkspaceMenu() {
   const [isCreating, setIsCreating] = useState(false);
   const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
   const [workspaceCreationSelections, setWorkspaceCreationSelections] = useState<Record<string, boolean>>({});
+  const [workspaceSetupFailure, setWorkspaceSetupFailure] = useState<{
+    workspaceId: string;
+    message: string;
+  } | null>(null);
 
   // Clone view state
   const [cloneUrl, setCloneUrl] = useState('');
@@ -78,6 +82,7 @@ export function AddWorkspaceMenu() {
     setCloneError(null);
     setCloneAuthHint(false);
     setWorkspaceCreationSelections({});
+    setWorkspaceSetupFailure(null);
   };
 
   const handleImportExisting = async () => {
@@ -109,6 +114,7 @@ export function AddWorkspaceMenu() {
     const trimmed = newName.trim();
     if (!trimmed || isCreating) return;
     setIsCreating(true);
+    setWorkspaceSetupFailure(null);
     try {
       const ws = await createWorkspace(trimmed, parentPath ?? undefined);
       const enabledContributions = workspaceCreationContributions.filter((app) => (
@@ -116,7 +122,11 @@ export function AddWorkspaceMenu() {
           ?? app.manifest!.workspaceCreation!.defaultEnabled
           ?? false
       ));
-      const results = await Promise.allSettled(enabledContributions.map((app) => {
+      await loadSessions();
+      setOpen(false);
+      // Prompt user to set up remote origin without waiting for plugin agent sessions.
+      setNewWorkspace(ws);
+      void Promise.allSettled(enabledContributions.map((app) => Promise.resolve().then(() => {
         const contribution = app.manifest!.workspaceCreation!;
         return window.sero.appAgent.invokeTool(app.id, ws.id, contribution.tool, {
           ...contribution.params,
@@ -124,19 +134,25 @@ export function AddWorkspaceMenu() {
           workspaceName: ws.name,
           workspacePath: ws.path,
         });
-      }));
-      results.forEach((result, index) => {
-        if (result.status === 'rejected') {
-          console.warn(
-            `[workspace] ${enabledContributions[index].label} setup failed:`,
-            result.reason,
-          );
-        }
+      }))).then((results) => {
+        const failures = results.flatMap((result, index) => {
+          const label = enabledContributions[index].label;
+          if (result.status === 'rejected') {
+            const message = result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason);
+            return [`${label}: ${message}`];
+          }
+          if (result.value.isError) {
+            return [`${label}: ${result.value.text || 'Setup failed.'}`];
+          }
+          return [];
+        });
+        if (failures.length === 0) return;
+        const message = failures.join(' ');
+        console.warn('[workspace] Workspace setup failed:', message);
+        setWorkspaceSetupFailure({ workspaceId: ws.id, message });
       });
-      await loadSessions();
-      setOpen(false);
-      // Prompt user to set up remote origin for the new workspace
-      setNewWorkspace(ws);
     } catch (err) {
       console.error('Failed to create workspace:', err);
     } finally {
@@ -259,6 +275,11 @@ export function AddWorkspaceMenu() {
         open={!!newWorkspace}
         onOpenChange={(o) => { if (!o) setNewWorkspace(null); }}
         workspace={newWorkspace}
+        setupError={
+          workspaceSetupFailure?.workspaceId === newWorkspace.id
+            ? workspaceSetupFailure.message
+            : null
+        }
       />
     )}
     </>

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -197,6 +197,24 @@ export function AddWorkspaceMenu() {
     setWorkspaceCreationSelections((current) => ({ ...current, [id]: enabled }));
   };
 
+  const dismissActiveWorkspaceSetupFailure = (): void => {
+    if (!activeWorkspaceSetupFailure) return;
+    setWorkspaceSetupFailures((current) => {
+      const next = { ...current };
+      delete next[activeWorkspaceSetupFailure.workspace.id];
+      return next;
+    });
+  };
+
+  const workspaceSetupFailureNotice = activeWorkspaceSetupFailure
+    ? (
+        <WorkspaceSetupFailureNotice
+          failure={activeWorkspaceSetupFailure}
+          onDismiss={dismissActiveWorkspaceSetupFailure}
+        />
+      )
+    : null;
+
   return (
     <>
     <Popover open={open} onOpenChange={(o) => {
@@ -284,21 +302,12 @@ export function AddWorkspaceMenu() {
         open
         onOpenChange={(o) => { if (!o) setNewWorkspace(null); }}
         workspace={newWorkspace}
-      />
+      >
+        {workspaceSetupFailureNotice}
+      </RemoteOriginManager>
     )}
 
-    {activeWorkspaceSetupFailure && (
-      <WorkspaceSetupFailureNotice
-        failure={activeWorkspaceSetupFailure}
-        onDismiss={() => {
-          setWorkspaceSetupFailures((current) => {
-            const next = { ...current };
-            delete next[activeWorkspaceSetupFailure.workspace.id];
-            return next;
-          });
-        }}
-      />
-    )}
+    {!newWorkspace && workspaceSetupFailureNotice}
     </>
   );
 }

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -14,11 +14,8 @@ import type { WorkspaceInfo } from '@/types/ipc';
 import { IconAction } from '@/components/ui/IconAction';
 import { CloneView, CreateView, ImportView, PickView } from './AddWorkspaceViews';
 import { RemoteOriginManager } from './RemoteOriginManager';
-import {
-  runWorkspaceSetup,
-  WorkspaceSetupFailureNotice,
-  type WorkspaceSetupFailure,
-} from './workspace-setup';
+import { WorkspaceSetupFailureNotice } from './WorkspaceSetupFailureNotice';
+import { runWorkspaceSetup, type WorkspaceSetupFailure } from './workspace-setup';
 
 // ── Add Workspace menu ─────────────────────────────────────────
 

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -58,7 +58,8 @@ export function AddWorkspaceMenu() {
   const addFolder = useWorkspaceStore((s) => s.addFolder);
   const loadSessions = useSessionStore((s) => s.loadSessions);
   const openGitHubAuthDialog = useGitHubAuthStore((s) => s.openGitHubAuthDialog);
-  const workspaceCreationContributions = useAppStore((s) => getWorkspaceCreationContributionApps(s.apps));
+  const apps = useAppStore((s) => s.apps);
+  const workspaceCreationContributions = getWorkspaceCreationContributionApps(apps);
   const workspaceCreationOptions = workspaceCreationContributions.map((app) => ({
     id: app.id,
     label: app.manifest!.workspaceCreation!.label,
@@ -222,7 +223,7 @@ export function AddWorkspaceMenu() {
             parentPath={parentPath}
             onPickLocation={handlePickLocation}
             onClearLocation={() => setParentPath(null)}
-            onBack={() => { setView('pick'); setNewName(''); setParentPath(null); }}
+            onBack={reset}
             onCreate={handleCreate}
             isCreating={isCreating}
             options={workspaceCreationOptions}

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -10,26 +10,20 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@sero-ai/ui/components/ui/popover';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@sero-ai/ui/components/ui/dialog';
 import type { WorkspaceInfo } from '@/types/ipc';
 import { IconAction } from '@/components/ui/IconAction';
-import { PickView, CreateView, CloneView } from './AddWorkspaceViews';
+import { CloneView, CreateView, ImportView, PickView } from './AddWorkspaceViews';
 import { RemoteOriginManager } from './RemoteOriginManager';
+import {
+  runWorkspaceSetup,
+  WorkspaceSetupFailureNotice,
+  type WorkspaceSetupFailure,
+} from './workspace-setup';
 
 // ── Add Workspace menu ─────────────────────────────────────────
 
-type AddView = 'pick' | 'create' | 'clone';
+type AddView = 'pick' | 'create' | 'clone' | 'import';
 
-interface WorkspaceSetupFailure {
-  workspace: WorkspaceInfo;
-  message: string;
-}
 
 /** Errors that mean "you need GitHub credentials", as opposed to a bad URL. */
 function looksLikeAuthError(message: string): boolean {
@@ -48,6 +42,7 @@ export function AddWorkspaceMenu() {
   const [newName, setNewName] = useState('');
   const [parentPath, setParentPath] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
   const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
   const [workspaceCreationSelections, setWorkspaceCreationSelections] = useState<Record<string, boolean>>({});
   const [workspaceSetupFailures, setWorkspaceSetupFailures] = useState<
@@ -97,17 +92,19 @@ export function AddWorkspaceMenu() {
   };
 
   const handleImportExisting = async () => {
-    setOpen(false);
+    if (isImporting) return;
+    setIsImporting(true);
     pickingFolderRef.current = true;
     try {
       const folderPath = await window.sero.workspace.pickFolder();
       if (!folderPath) return;
-      await addFolder(folderPath);
-      await loadSessions();
+      const ws = await addFolder(folderPath);
+      await completeWorkspaceAddition(ws);
     } catch (err) {
       console.error('Failed to import workspace:', err);
     } finally {
       pickingFolderRef.current = false;
+      setIsImporting(false);
     }
   };
 
@@ -121,51 +118,39 @@ export function AddWorkspaceMenu() {
     }
   };
 
+  const startWorkspaceSetup = (workspace: WorkspaceInfo): void => {
+    void runWorkspaceSetup({
+      apps: workspaceCreationContributions,
+      selections: workspaceCreationSelections,
+      workspace,
+    }).then((message) => {
+      if (!message) return;
+      console.warn('[workspace] Workspace setup failed:', message);
+      setWorkspaceSetupFailures((current) => ({
+        ...current,
+        [workspace.id]: { workspace, message },
+      }));
+    });
+  };
+
+  const completeWorkspaceAddition = async (
+    ws: WorkspaceInfo,
+    promptForRemote = false,
+  ): Promise<void> => {
+    await loadSessions();
+    setOpen(false);
+    reset();
+    if (promptForRemote) setNewWorkspace(ws);
+    startWorkspaceSetup(ws);
+  };
+
   const handleCreate = async () => {
     const trimmed = newName.trim();
     if (!trimmed || isCreating) return;
     setIsCreating(true);
     try {
       const ws = await createWorkspace(trimmed, parentPath ?? undefined);
-      const enabledContributions = workspaceCreationContributions.filter((app) => (
-        workspaceCreationSelections[app.id]
-          ?? app.manifest!.workspaceCreation!.defaultEnabled
-          ?? false
-      ));
-      await loadSessions();
-      setOpen(false);
-      // Prompt user to set up remote origin without waiting for plugin agent sessions.
-      setNewWorkspace(ws);
-      void Promise.allSettled(enabledContributions.map((app) => Promise.resolve().then(() => {
-        const contribution = app.manifest!.workspaceCreation!;
-        return window.sero.appAgent.invokeTool(app.id, ws.id, contribution.tool, {
-          ...contribution.params,
-          workspaceId: ws.id,
-          workspaceName: ws.name,
-          workspacePath: ws.path,
-        });
-      }))).then((results) => {
-        const failures = results.flatMap((result, index) => {
-          const label = enabledContributions[index].label;
-          if (result.status === 'rejected') {
-            const message = result.reason instanceof Error
-              ? result.reason.message
-              : String(result.reason);
-            return [`${label}: ${message}`];
-          }
-          if (result.value.isError) {
-            return [`${label}: ${result.value.text || 'Setup failed.'}`];
-          }
-          return [];
-        });
-        if (failures.length === 0) return;
-        const message = failures.join(' ');
-        console.warn('[workspace] Workspace setup failed:', message);
-        setWorkspaceSetupFailures((current) => ({
-          ...current,
-          [ws.id]: { workspace: ws, message },
-        }));
-      });
+      await completeWorkspaceAddition(ws, true);
     } catch (err) {
       console.error('Failed to create workspace:', err);
     } finally {
@@ -186,10 +171,12 @@ export function AddWorkspaceMenu() {
     setCloneError(null);
     setCloneAuthHint(false);
     try {
-      await cloneWorkspace(trimmedUrl, cloneName.trim() || undefined, parentPath ?? undefined);
-      await loadSessions();
-      setOpen(false);
-      reset();
+      const ws = await cloneWorkspace(
+        trimmedUrl,
+        cloneName.trim() || undefined,
+        parentPath ?? undefined,
+      );
+      await completeWorkspaceAddition(ws);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to clone repository';
       setCloneError(message);
@@ -207,6 +194,10 @@ export function AddWorkspaceMenu() {
     } finally {
       authInFlightRef.current = false;
     }
+  };
+
+  const handleOptionChange = (id: string, enabled: boolean): void => {
+    setWorkspaceCreationSelections((current) => ({ ...current, [id]: enabled }));
   };
 
   return (
@@ -241,7 +232,7 @@ export function AddWorkspaceMenu() {
               setView('clone');
               requestAnimationFrame(() => cloneInputRef.current?.focus());
             }}
-            onImportExisting={handleImportExisting}
+            onImportExisting={() => setView('import')}
           />
         )}
         {view === 'create' && (
@@ -256,10 +247,16 @@ export function AddWorkspaceMenu() {
             onCreate={handleCreate}
             isCreating={isCreating}
             options={workspaceCreationOptions}
-            onOptionChange={(id, enabled) => setWorkspaceCreationSelections((current) => ({
-              ...current,
-              [id]: enabled,
-            }))}
+            onOptionChange={handleOptionChange}
+          />
+        )}
+        {view === 'import' && (
+          <ImportView
+            onBack={reset}
+            onImport={handleImportExisting}
+            isImporting={isImporting}
+            options={workspaceCreationOptions}
+            onOptionChange={handleOptionChange}
           />
         )}
         {view === 'clone' && (
@@ -277,6 +274,8 @@ export function AddWorkspaceMenu() {
             isCloning={isCloning}
             error={cloneError}
             onSignIn={cloneAuthHint ? handleSignInAndRetry : undefined}
+            options={workspaceCreationOptions}
+            onOptionChange={handleOptionChange}
           />
         )}
       </PopoverContent>
@@ -285,39 +284,23 @@ export function AddWorkspaceMenu() {
     {/* Prompt to set up remote origin after workspace creation */}
     {newWorkspace && (
       <RemoteOriginManager
-        open={!activeWorkspaceSetupFailure}
+        open
         onOpenChange={(o) => { if (!o) setNewWorkspace(null); }}
         workspace={newWorkspace}
       />
     )}
 
     {activeWorkspaceSetupFailure && (
-      <Dialog
-        open
-        onOpenChange={(open) => {
-          if (open) return;
+      <WorkspaceSetupFailureNotice
+        failure={activeWorkspaceSetupFailure}
+        onDismiss={() => {
           setWorkspaceSetupFailures((current) => {
             const next = { ...current };
             delete next[activeWorkspaceSetupFailure.workspace.id];
             return next;
           });
         }}
-      >
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Workspace setup failed</DialogTitle>
-            <DialogDescription>
-              Setup did not finish for &quot;{activeWorkspaceSetupFailure.workspace.name}&quot;.
-            </DialogDescription>
-          </DialogHeader>
-          <div
-            role="alert"
-            className="rounded-md border border-status-error-border bg-status-error-faint px-3 py-2 text-sm text-status-error"
-          >
-            {activeWorkspaceSetupFailure.message}
-          </div>
-        </DialogContent>
-      </Dialog>
+      />
     )}
     </>
   );

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -15,7 +15,7 @@ import { IconAction } from '@/components/ui/IconAction';
 import { CloneView, CreateView, ImportView, PickView } from './AddWorkspaceViews';
 import { RemoteOriginManager } from './RemoteOriginManager';
 import { WorkspaceSetupFailureNotice } from './WorkspaceSetupFailureNotice';
-import { runWorkspaceSetup, type WorkspaceSetupFailure } from './workspace-setup';
+import { useWorkspaceSetup } from './workspace-setup';
 
 // ── Add Workspace menu ─────────────────────────────────────────
 
@@ -40,11 +40,9 @@ export function AddWorkspaceMenu() {
   const [parentPath, setParentPath] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
   const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
   const [workspaceCreationSelections, setWorkspaceCreationSelections] = useState<Record<string, boolean>>({});
-  const [workspaceSetupFailures, setWorkspaceSetupFailures] = useState<
-    Record<string, WorkspaceSetupFailure>
-  >({});
 
   // Clone view state
   const [cloneUrl, setCloneUrl] = useState('');
@@ -74,7 +72,13 @@ export function AddWorkspaceMenu() {
       ?? app.manifest!.workspaceCreation!.defaultEnabled
       ?? false,
   }));
-  const activeWorkspaceSetupFailure = Object.values(workspaceSetupFailures)[0] ?? null;
+  const {
+    activeFailure: activeWorkspaceSetupFailure,
+    completePendingSetup: completePendingWorkspaceSetup,
+    createSetup: createWorkspaceSetup,
+    deferSetup: deferWorkspaceSetup,
+    dismissActiveFailure: dismissActiveWorkspaceSetupFailure,
+  } = useWorkspaceSetup(workspaceCreationContributions, workspaceCreationSelections);
 
   const reset = () => {
     setView('pick');
@@ -85,12 +89,14 @@ export function AddWorkspaceMenu() {
     cloneNameEditedRef.current = false;
     setCloneError(null);
     setCloneAuthHint(false);
+    setImportError(null);
     setWorkspaceCreationSelections({});
   };
 
   const handleImportExisting = async () => {
     if (isImporting) return;
     setIsImporting(true);
+    setImportError(null);
     pickingFolderRef.current = true;
     try {
       const folderPath = await window.sero.workspace.pickFolder();
@@ -98,7 +104,10 @@ export function AddWorkspaceMenu() {
       const ws = await addFolder(folderPath);
       await completeWorkspaceAddition(ws);
     } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to import workspace';
       console.error('Failed to import workspace:', err);
+      setImportError(message);
+      setView('import');
     } finally {
       pickingFolderRef.current = false;
       setIsImporting(false);
@@ -115,30 +124,21 @@ export function AddWorkspaceMenu() {
     }
   };
 
-  const startWorkspaceSetup = (workspace: WorkspaceInfo): void => {
-    void runWorkspaceSetup({
-      apps: workspaceCreationContributions,
-      selections: workspaceCreationSelections,
-      workspace,
-    }).then((message) => {
-      if (!message) return;
-      console.warn('[workspace] Workspace setup failed:', message);
-      setWorkspaceSetupFailures((current) => ({
-        ...current,
-        [workspace.id]: { workspace, message },
-      }));
-    });
-  };
 
   const completeWorkspaceAddition = async (
     ws: WorkspaceInfo,
     promptForRemote = false,
   ): Promise<void> => {
+    const setup = createWorkspaceSetup(ws);
     await loadSessions();
     setOpen(false);
     reset();
-    if (promptForRemote) setNewWorkspace(ws);
-    startWorkspaceSetup(ws);
+    if (promptForRemote) {
+      deferWorkspaceSetup(setup);
+      setNewWorkspace(ws);
+    } else {
+      setup();
+    }
   };
 
   const handleCreate = async () => {
@@ -197,19 +197,12 @@ export function AddWorkspaceMenu() {
     setWorkspaceCreationSelections((current) => ({ ...current, [id]: enabled }));
   };
 
-  const dismissActiveWorkspaceSetupFailure = (): void => {
-    if (!activeWorkspaceSetupFailure) return;
-    setWorkspaceSetupFailures((current) => {
-      const next = { ...current };
-      delete next[activeWorkspaceSetupFailure.workspace.id];
-      return next;
-    });
-  };
 
   const workspaceSetupFailureNotice = activeWorkspaceSetupFailure
     ? (
         <WorkspaceSetupFailureNotice
           failure={activeWorkspaceSetupFailure}
+          embedded={newWorkspace !== null}
           onDismiss={dismissActiveWorkspaceSetupFailure}
         />
       )
@@ -247,7 +240,13 @@ export function AddWorkspaceMenu() {
               setView('clone');
               requestAnimationFrame(() => cloneInputRef.current?.focus());
             }}
-            onImportExisting={() => setView('import')}
+            onImportExisting={() => {
+              if (workspaceCreationOptions.length === 0) {
+                void handleImportExisting();
+                return;
+              }
+              setView('import');
+            }}
           />
         )}
         {view === 'create' && (
@@ -270,6 +269,7 @@ export function AddWorkspaceMenu() {
             onBack={reset}
             onImport={handleImportExisting}
             isImporting={isImporting}
+            error={importError}
             options={workspaceCreationOptions}
             onOptionChange={handleOptionChange}
           />
@@ -300,7 +300,12 @@ export function AddWorkspaceMenu() {
     {newWorkspace && (
       <RemoteOriginManager
         open
-        onOpenChange={(o) => { if (!o) setNewWorkspace(null); }}
+        onOpenChange={(o) => {
+          if (o) return;
+          setNewWorkspace(null);
+          completePendingWorkspaceSetup();
+        }}
+        onWorkspaceReady={completePendingWorkspaceSetup}
         workspace={newWorkspace}
       >
         {workspaceSetupFailureNotice}

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.tsx
@@ -10,6 +10,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@sero-ai/ui/components/ui/popover';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@sero-ai/ui/components/ui/dialog';
 import type { WorkspaceInfo } from '@/types/ipc';
 import { IconAction } from '@/components/ui/IconAction';
 import { PickView, CreateView, CloneView } from './AddWorkspaceViews';
@@ -18,6 +25,11 @@ import { RemoteOriginManager } from './RemoteOriginManager';
 // ── Add Workspace menu ─────────────────────────────────────────
 
 type AddView = 'pick' | 'create' | 'clone';
+
+interface WorkspaceSetupFailure {
+  workspace: WorkspaceInfo;
+  message: string;
+}
 
 /** Errors that mean "you need GitHub credentials", as opposed to a bad URL. */
 function looksLikeAuthError(message: string): boolean {
@@ -38,10 +50,9 @@ export function AddWorkspaceMenu() {
   const [isCreating, setIsCreating] = useState(false);
   const [newWorkspace, setNewWorkspace] = useState<WorkspaceInfo | null>(null);
   const [workspaceCreationSelections, setWorkspaceCreationSelections] = useState<Record<string, boolean>>({});
-  const [workspaceSetupFailure, setWorkspaceSetupFailure] = useState<{
-    workspaceId: string;
-    message: string;
-  } | null>(null);
+  const [workspaceSetupFailures, setWorkspaceSetupFailures] = useState<
+    Record<string, WorkspaceSetupFailure>
+  >({});
 
   // Clone view state
   const [cloneUrl, setCloneUrl] = useState('');
@@ -71,6 +82,7 @@ export function AddWorkspaceMenu() {
       ?? app.manifest!.workspaceCreation!.defaultEnabled
       ?? false,
   }));
+  const activeWorkspaceSetupFailure = Object.values(workspaceSetupFailures)[0] ?? null;
 
   const reset = () => {
     setView('pick');
@@ -82,7 +94,6 @@ export function AddWorkspaceMenu() {
     setCloneError(null);
     setCloneAuthHint(false);
     setWorkspaceCreationSelections({});
-    setWorkspaceSetupFailure(null);
   };
 
   const handleImportExisting = async () => {
@@ -114,7 +125,6 @@ export function AddWorkspaceMenu() {
     const trimmed = newName.trim();
     if (!trimmed || isCreating) return;
     setIsCreating(true);
-    setWorkspaceSetupFailure(null);
     try {
       const ws = await createWorkspace(trimmed, parentPath ?? undefined);
       const enabledContributions = workspaceCreationContributions.filter((app) => (
@@ -151,7 +161,10 @@ export function AddWorkspaceMenu() {
         if (failures.length === 0) return;
         const message = failures.join(' ');
         console.warn('[workspace] Workspace setup failed:', message);
-        setWorkspaceSetupFailure({ workspaceId: ws.id, message });
+        setWorkspaceSetupFailures((current) => ({
+          ...current,
+          [ws.id]: { workspace: ws, message },
+        }));
       });
     } catch (err) {
       console.error('Failed to create workspace:', err);
@@ -272,15 +285,39 @@ export function AddWorkspaceMenu() {
     {/* Prompt to set up remote origin after workspace creation */}
     {newWorkspace && (
       <RemoteOriginManager
-        open={!!newWorkspace}
+        open={!activeWorkspaceSetupFailure}
         onOpenChange={(o) => { if (!o) setNewWorkspace(null); }}
         workspace={newWorkspace}
-        setupError={
-          workspaceSetupFailure?.workspaceId === newWorkspace.id
-            ? workspaceSetupFailure.message
-            : null
-        }
       />
+    )}
+
+    {activeWorkspaceSetupFailure && (
+      <Dialog
+        open
+        onOpenChange={(open) => {
+          if (open) return;
+          setWorkspaceSetupFailures((current) => {
+            const next = { ...current };
+            delete next[activeWorkspaceSetupFailure.workspace.id];
+            return next;
+          });
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Workspace setup failed</DialogTitle>
+            <DialogDescription>
+              Setup did not finish for &quot;{activeWorkspaceSetupFailure.workspace.name}&quot;.
+            </DialogDescription>
+          </DialogHeader>
+          <div
+            role="alert"
+            className="rounded-md border border-status-error-border bg-status-error-faint px-3 py-2 text-sm text-status-error"
+          >
+            {activeWorkspaceSetupFailure.message}
+          </div>
+        </DialogContent>
+      </Dialog>
     )}
     </>
   );

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.test.tsx
@@ -32,6 +32,7 @@ function busyViews(): Array<{ name: string; view: ReactNode }> {
           onBack={noop}
           onCreate={noop}
           isCreating
+          error={null}
           options={options}
           onOptionChange={noop}
         />

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+
+import { act, createRef, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CloneView, CreateView, ImportView, type WorkspaceCreationOption } from './AddWorkspaceViews';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const options: WorkspaceCreationOption[] = [{
+  id: 'graphify',
+  label: 'Enable Graphify indexing',
+  enabled: true,
+}];
+const noop = vi.fn();
+const inputRef = createRef<HTMLInputElement>();
+
+function busyViews(): Array<{ name: string; view: ReactNode }> {
+  return [
+    {
+      name: 'create',
+      view: (
+        <CreateView
+          inputRef={inputRef}
+          name="Workspace"
+          onNameChange={noop}
+          parentPath={null}
+          onPickLocation={noop}
+          onClearLocation={noop}
+          onBack={noop}
+          onCreate={noop}
+          isCreating
+          options={options}
+          onOptionChange={noop}
+        />
+      ),
+    },
+    {
+      name: 'clone',
+      view: (
+        <CloneView
+          inputRef={inputRef}
+          url="https://github.com/sero-labs/sero.git"
+          onUrlChange={noop}
+          name="sero"
+          onNameChange={noop}
+          parentPath={null}
+          onPickLocation={noop}
+          onClearLocation={noop}
+          onBack={noop}
+          onClone={noop}
+          isCloning
+          error={null}
+          options={options}
+          onOptionChange={noop}
+        />
+      ),
+    },
+    {
+      name: 'import',
+      view: (
+        <ImportView
+          onBack={noop}
+          onImport={noop}
+          isImporting
+          error={null}
+          options={options}
+          onOptionChange={noop}
+        />
+      ),
+    },
+  ];
+}
+
+describe('workspace creation options', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it.each(busyViews())('disables the $name option while the operation runs', async ({ view }) => {
+    await act(async () => root.render(view));
+
+    const option = document.querySelector('#workspace-create-option-graphify');
+    expect(option).toBeInstanceOf(HTMLButtonElement);
+    expect((option as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
@@ -53,6 +53,7 @@ export function CreateView({
   onBack,
   onCreate,
   isCreating,
+  error,
   options,
   onOptionChange,
 }: {
@@ -65,6 +66,7 @@ export function CreateView({
   onBack: () => void;
   onCreate: () => void;
   isCreating: boolean;
+  error: string | null;
   options: WorkspaceCreationOption[];
   onOptionChange: (id: string, enabled: boolean) => void;
 }) {
@@ -85,6 +87,11 @@ export function CreateView({
       </Field>
 
       <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} />
+      {error && (
+        <div className="rounded-md bg-status-error-muted p-2">
+          <p role="alert" className="text-xs text-status-error">{error}</p>
+        </div>
+      )}
       <WorkspaceCreationOptions
         options={options}
         onOptionChange={onOptionChange}

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
@@ -1,7 +1,14 @@
 import { FolderInput, FolderOpen, FolderPlus, GitBranch, Loader2, X } from 'lucide-react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Input } from '@sero-ai/ui/components/ui/input';
+import { Switch } from '@sero-ai/ui/components/ui/switch';
 import { cn } from '@sero-ai/ui/lib/utils';
+
+export interface WorkspaceCreationOption {
+  id: string;
+  label: string;
+  enabled: boolean;
+}
 
 /** Initial view, three action rows. */
 export function PickView({
@@ -46,6 +53,8 @@ export function CreateView({
   onBack,
   onCreate,
   isCreating,
+  options,
+  onOptionChange,
 }: {
   inputRef: React.RefObject<HTMLInputElement | null>;
   name: string;
@@ -56,6 +65,8 @@ export function CreateView({
   onBack: () => void;
   onCreate: () => void;
   isCreating: boolean;
+  options: WorkspaceCreationOption[];
+  onOptionChange: (id: string, enabled: boolean) => void;
 }) {
   return (
     <form
@@ -74,6 +85,21 @@ export function CreateView({
       </Field>
 
       <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} />
+
+      {options.map((option) => (
+        <label
+          key={option.id}
+          htmlFor={`workspace-create-option-${option.id}`}
+          className="flex items-center justify-between gap-3 text-xs text-[var(--text-secondary)]"
+        >
+          {option.label}
+          <Switch
+            id={`workspace-create-option-${option.id}`}
+            checked={option.enabled}
+            onCheckedChange={(enabled) => onOptionChange(option.id, enabled)}
+          />
+        </label>
+      ))}
 
       <FormActions onBack={onBack} submitLabel="Create" busy={isCreating} disabled={!name.trim()} />
     </form>

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
@@ -85,23 +85,39 @@ export function CreateView({
       </Field>
 
       <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} />
-
-      {options.map((option) => (
-        <label
-          key={option.id}
-          htmlFor={`workspace-create-option-${option.id}`}
-          className="flex items-center justify-between gap-3 text-xs text-[var(--text-secondary)]"
-        >
-          {option.label}
-          <Switch
-            id={`workspace-create-option-${option.id}`}
-            checked={option.enabled}
-            onCheckedChange={(enabled) => onOptionChange(option.id, enabled)}
-          />
-        </label>
-      ))}
-
+      <WorkspaceCreationOptions options={options} onOptionChange={onOptionChange} />
       <FormActions onBack={onBack} submitLabel="Create" busy={isCreating} disabled={!name.trim()} />
+    </form>
+  );
+}
+
+/** Import form view: plugin options followed by the native folder picker. */
+export function ImportView({
+  onBack,
+  onImport,
+  isImporting,
+  options,
+  onOptionChange,
+}: {
+  onBack: () => void;
+  onImport: () => void;
+  isImporting: boolean;
+  options: WorkspaceCreationOption[];
+  onOptionChange: (id: string, enabled: boolean) => void;
+}) {
+  return (
+    <form
+      onSubmit={(e) => { e.preventDefault(); onImport(); }}
+      className="flex flex-col gap-2.5 p-3"
+    >
+      <WorkspaceCreationOptions options={options} onOptionChange={onOptionChange} />
+      <FormActions
+        onBack={onBack}
+        submitLabel="Choose Folder"
+        busyLabel="Importing…"
+        busy={isImporting}
+        disabled={false}
+      />
     </form>
   );
 }
@@ -121,6 +137,8 @@ export function CloneView({
   isCloning,
   error,
   onSignIn,
+  options,
+  onOptionChange,
 }: {
   inputRef: React.RefObject<HTMLInputElement | null>;
   url: string;
@@ -135,6 +153,8 @@ export function CloneView({
   isCloning: boolean;
   error: string | null;
   onSignIn?: () => void;
+  options: WorkspaceCreationOption[];
+  onOptionChange: (id: string, enabled: boolean) => void;
 }) {
   return (
     <form
@@ -165,6 +185,7 @@ export function CloneView({
       </Field>
 
       <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} disabled={isCloning} />
+      <WorkspaceCreationOptions options={options} onOptionChange={onOptionChange} />
 
       {error && (
         <div className="flex flex-col gap-1.5 rounded-md bg-status-error-muted p-2">
@@ -184,6 +205,29 @@ export function CloneView({
       <FormActions onBack={onBack} submitLabel="Clone" busyLabel="Cloning…" busy={isCloning} disabled={!url.trim()} />
     </form>
   );
+}
+
+function WorkspaceCreationOptions({
+  options,
+  onOptionChange,
+}: {
+  options: WorkspaceCreationOption[];
+  onOptionChange: (id: string, enabled: boolean) => void;
+}) {
+  return options.map((option) => (
+    <label
+      key={option.id}
+      htmlFor={`workspace-create-option-${option.id}`}
+      className="flex items-center justify-between gap-3 text-xs text-[var(--text-secondary)]"
+    >
+      {option.label}
+      <Switch
+        id={`workspace-create-option-${option.id}`}
+        checked={option.enabled}
+        onCheckedChange={(enabled) => onOptionChange(option.id, enabled)}
+      />
+    </label>
+  ));
 }
 
 // ── Shared form pieces ─────────────────────────────────────────

--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx
@@ -85,7 +85,11 @@ export function CreateView({
       </Field>
 
       <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} />
-      <WorkspaceCreationOptions options={options} onOptionChange={onOptionChange} />
+      <WorkspaceCreationOptions
+        options={options}
+        onOptionChange={onOptionChange}
+        disabled={isCreating}
+      />
       <FormActions onBack={onBack} submitLabel="Create" busy={isCreating} disabled={!name.trim()} />
     </form>
   );
@@ -96,12 +100,14 @@ export function ImportView({
   onBack,
   onImport,
   isImporting,
+  error,
   options,
   onOptionChange,
 }: {
   onBack: () => void;
   onImport: () => void;
   isImporting: boolean;
+  error: string | null;
   options: WorkspaceCreationOption[];
   onOptionChange: (id: string, enabled: boolean) => void;
 }) {
@@ -110,7 +116,16 @@ export function ImportView({
       onSubmit={(e) => { e.preventDefault(); onImport(); }}
       className="flex flex-col gap-2.5 p-3"
     >
-      <WorkspaceCreationOptions options={options} onOptionChange={onOptionChange} />
+      <WorkspaceCreationOptions
+        options={options}
+        onOptionChange={onOptionChange}
+        disabled={isImporting}
+      />
+      {error && (
+        <div className="rounded-md bg-status-error-muted p-2">
+          <p role="alert" className="text-xs text-status-error">{error}</p>
+        </div>
+      )}
       <FormActions
         onBack={onBack}
         submitLabel="Choose Folder"
@@ -185,7 +200,11 @@ export function CloneView({
       </Field>
 
       <LocationField parentPath={parentPath} onPick={onPickLocation} onClear={onClearLocation} disabled={isCloning} />
-      <WorkspaceCreationOptions options={options} onOptionChange={onOptionChange} />
+      <WorkspaceCreationOptions
+        options={options}
+        onOptionChange={onOptionChange}
+        disabled={isCloning}
+      />
 
       {error && (
         <div className="flex flex-col gap-1.5 rounded-md bg-status-error-muted p-2">
@@ -210,20 +229,26 @@ export function CloneView({
 function WorkspaceCreationOptions({
   options,
   onOptionChange,
+  disabled,
 }: {
   options: WorkspaceCreationOption[];
   onOptionChange: (id: string, enabled: boolean) => void;
+  disabled: boolean;
 }) {
   return options.map((option) => (
     <label
       key={option.id}
       htmlFor={`workspace-create-option-${option.id}`}
-      className="flex items-center justify-between gap-3 text-xs text-[var(--text-secondary)]"
+      className={cn(
+        'flex items-center justify-between gap-3 text-xs text-[var(--text-secondary)]',
+        disabled && 'opacity-50',
+      )}
     >
       {option.label}
       <Switch
         id={`workspace-create-option-${option.id}`}
         checked={option.enabled}
+        disabled={disabled}
         onCheckedChange={(enabled) => onOptionChange(option.id, enabled)}
       />
     </label>

--- a/apps/desktop/src/components/layout/workspace/ConnectExistingView.tsx
+++ b/apps/desktop/src/components/layout/workspace/ConnectExistingView.tsx
@@ -25,10 +25,12 @@ export function ConnectExistingView({
   workspace,
   onBack,
   onConnected,
+  onBusyChange,
 }: {
   workspace: WorkspaceInfo;
   onBack: () => void;
   onConnected: (url: string, warning?: string) => void;
+  onBusyChange: (busy: boolean) => void;
 }) {
   const [url, setUrl] = useState('');
   const [phase, setPhase] = useState<Phase>({ kind: 'input' });
@@ -41,8 +43,10 @@ export function ConnectExistingView({
     if (!trimmedUrl || busy) return;
     setError(null);
     setPhase({ kind: 'busy', label: importMode === 'force' ? 'Importing…' : 'Connecting…' });
+    onBusyChange(true);
 
     const result = await connectOrigin({ workspaceId: workspace.id, url: trimmedUrl, importMode });
+    onBusyChange(false);
     if (!result.ok) {
       setError(result.message);
       setPhase({ kind: 'input' });

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.test.tsx
@@ -3,6 +3,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConnectRemoteResult } from '@sero-ai/common';
 import type { GitHubAuthStatus, GitHubDeviceFlowEvent } from '@/types/electron-services';
 import type { WorkspaceInfo } from '@/types/ipc';
 import { resetGitHubAuthStore, useGitHubAuthStore } from '@/stores/github-auth';
@@ -407,4 +408,42 @@ describe('RemoteOriginManager', () => {
 
     warn.mockRestore();
   });
+  it('cannot close while an existing repository import is running', async () => {
+    let finishConnect: (result: ConnectRemoteResult) => void = () => {};
+    seroBridge.vcs.connectRemote.mockImplementation(() => new Promise((resolve) => {
+      finishConnect = resolve;
+    }));
+    const onOpenChange = vi.fn();
+    await act(async () => {
+      root?.render(
+        <RemoteOriginManager
+          open
+          onOpenChange={onOpenChange}
+          workspace={workspace}
+        />,
+      );
+    });
+    await vi.waitFor(() => expect(document.body.textContent).toContain('Connect existing repository'));
+    await clickButton('Connect existing repository');
+    await setInputValue('remote-url', 'https://github.com/octocat/workspace-1.git');
+    await clickButton('Connect Repository');
+
+    expect(findButton('Connecting…').disabled).toBe(true);
+    expect(document.querySelector('[data-slot="dialog-close"]')).toBeNull();
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      finishConnect({
+        ok: true,
+        url: 'https://github.com/octocat/workspace-1.git',
+        updatedExisting: false,
+        import: { imported: true },
+      });
+    });
+    await vi.waitFor(() => expect(document.body.textContent).toContain('octocat/workspace-1'));
+  });
+
 });

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
@@ -35,6 +35,7 @@ interface RemoteOriginManagerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   workspace: WorkspaceInfo;
+  setupError?: string | null;
 }
 
 type View = 'loading' | 'load-error' | 'choose' | 'create-github' | 'connect-existing' | 'connected';
@@ -45,6 +46,7 @@ export function RemoteOriginManager({
   open,
   onOpenChange,
   workspace,
+  setupError,
 }: RemoteOriginManagerProps) {
   const [view, setView] = useState<View>('loading');
   const [origin, setOrigin] = useState<GitRemoteOriginInfo | null>(null);
@@ -96,6 +98,15 @@ export function RemoteOriginManager({
               : `Link "${workspace.name}" to a Git repository.`}
           </DialogDescription>
         </DialogHeader>
+
+        {setupError && (
+          <div
+            role="alert"
+            className="rounded-md border border-status-error-border bg-status-error-faint px-3 py-2 text-sm text-status-error"
+          >
+            {setupError}
+          </div>
+        )}
 
         {view === 'loading' && <LoadingView />}
         {view === 'load-error' && originLoadError && (

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
@@ -35,7 +35,6 @@ interface RemoteOriginManagerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   workspace: WorkspaceInfo;
-  setupError?: string | null;
 }
 
 type View = 'loading' | 'load-error' | 'choose' | 'create-github' | 'connect-existing' | 'connected';
@@ -46,7 +45,6 @@ export function RemoteOriginManager({
   open,
   onOpenChange,
   workspace,
-  setupError,
 }: RemoteOriginManagerProps) {
   const [view, setView] = useState<View>('loading');
   const [origin, setOrigin] = useState<GitRemoteOriginInfo | null>(null);
@@ -99,14 +97,6 @@ export function RemoteOriginManager({
           </DialogDescription>
         </DialogHeader>
 
-        {setupError && (
-          <div
-            role="alert"
-            className="rounded-md border border-status-error-border bg-status-error-faint px-3 py-2 text-sm text-status-error"
-          >
-            {setupError}
-          </div>
-        )}
 
         {view === 'loading' && <LoadingView />}
         {view === 'load-error' && originLoadError && (

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
@@ -10,7 +10,7 @@
  * Opened from WorkspaceTree hover actions and after workspace creation.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -35,6 +35,7 @@ interface RemoteOriginManagerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   workspace: WorkspaceInfo;
+  children?: ReactNode;
 }
 
 type View = 'loading' | 'load-error' | 'choose' | 'create-github' | 'connect-existing' | 'connected';
@@ -45,6 +46,7 @@ export function RemoteOriginManager({
   open,
   onOpenChange,
   workspace,
+  children,
 }: RemoteOriginManagerProps) {
   const [view, setView] = useState<View>('loading');
   const [origin, setOrigin] = useState<GitRemoteOriginInfo | null>(null);
@@ -136,6 +138,7 @@ export function RemoteOriginManager({
             onClose={handleClose}
           />
         )}
+        {children}
       </DialogContent>
     </Dialog>
   );

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
@@ -35,6 +35,7 @@ interface RemoteOriginManagerProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   workspace: WorkspaceInfo;
+  onWorkspaceReady?: () => void;
   children?: ReactNode;
 }
 
@@ -46,6 +47,7 @@ export function RemoteOriginManager({
   open,
   onOpenChange,
   workspace,
+  onWorkspaceReady,
   children,
 }: RemoteOriginManagerProps) {
   const [view, setView] = useState<View>('loading');
@@ -68,8 +70,9 @@ export function RemoteOriginManager({
     }
 
     setOrigin(result.origin);
+    if (result.origin) onWorkspaceReady?.();
     setView(result.origin ? 'connected' : 'choose');
-  }, [workspace.id]);
+  }, [onWorkspaceReady, workspace.id]);
 
   // Fetch origin when dialog opens (acceptable useEffect: IPC on external state change)
   useEffect(() => {
@@ -82,6 +85,7 @@ export function RemoteOriginManager({
   const handleOriginSet = (url: string, warning?: string) => {
     setOrigin(toOriginInfo(url));
     setOriginWarning(warning ?? null);
+    onWorkspaceReady?.();
     setView('connected');
   };
 

--- a/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
+++ b/apps/desktop/src/components/layout/workspace/RemoteOriginManager.tsx
@@ -39,7 +39,14 @@ interface RemoteOriginManagerProps {
   children?: ReactNode;
 }
 
-type View = 'loading' | 'load-error' | 'choose' | 'create-github' | 'connect-existing' | 'connected';
+type View =
+  | 'loading'
+  | 'load-error'
+  | 'choose'
+  | 'create-github'
+  | 'connect-existing'
+  | 'connect-existing-busy'
+  | 'connected';
 
 // ── Main component ───────────────────────────────────────────
 
@@ -54,6 +61,7 @@ export function RemoteOriginManager({
   const [origin, setOrigin] = useState<GitRemoteOriginInfo | null>(null);
   const [originLoadError, setOriginLoadError] = useState<string | null>(null);
   const [originWarning, setOriginWarning] = useState<string | null>(null);
+  const connectBusy = view === 'connect-existing-busy';
   const prevOpenRef = useRef(false);
 
   const loadOrigin = useCallback(async () => {
@@ -89,11 +97,15 @@ export function RemoteOriginManager({
     setView('connected');
   };
 
-  const handleClose = () => onOpenChange(false);
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen && connectBusy) return;
+    onOpenChange(nextOpen);
+  };
+  const handleClose = (): void => handleOpenChange(false);
 
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-md">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md" showCloseButton={!connectBusy}>
         <DialogHeader>
           <DialogTitle>Git Repository</DialogTitle>
           <DialogDescription>
@@ -102,7 +114,6 @@ export function RemoteOriginManager({
               : `Link "${workspace.name}" to a Git repository.`}
           </DialogDescription>
         </DialogHeader>
-
 
         {view === 'loading' && <LoadingView />}
         {view === 'load-error' && originLoadError && (
@@ -127,11 +138,12 @@ export function RemoteOriginManager({
             onCreated={handleOriginSet}
           />
         )}
-        {view === 'connect-existing' && (
+        {(view === 'connect-existing' || view === 'connect-existing-busy') && (
           <ConnectExistingView
             workspace={workspace}
             onBack={() => setView('choose')}
             onConnected={handleOriginSet}
+            onBusyChange={(busy) => setView(busy ? 'connect-existing-busy' : 'connect-existing')}
           />
         )}
         {view === 'connected' && origin && (

--- a/apps/desktop/src/components/layout/workspace/WorkspaceSetupFailureNotice.tsx
+++ b/apps/desktop/src/components/layout/workspace/WorkspaceSetupFailureNotice.tsx
@@ -1,17 +1,23 @@
 import { Button } from '@sero-ai/ui/components/ui/button';
+import { cn } from '@sero-ai/ui/lib/utils';
 import type { WorkspaceSetupFailure } from './workspace-setup';
 
 export function WorkspaceSetupFailureNotice({
   failure,
   onDismiss,
+  embedded = false,
 }: {
   failure: WorkspaceSetupFailure;
   onDismiss: () => void;
+  embedded?: boolean;
 }) {
   return (
     <div
       role="alert"
-      className="fixed right-4 bottom-4 z-[60] flex w-80 flex-col gap-2 rounded-md border border-status-error-border bg-[var(--bg-elevated)] p-3 shadow-lg"
+      className={cn(
+        'flex flex-col gap-2 rounded-md border border-status-error-border bg-[var(--bg-elevated)] p-3',
+        embedded ? 'w-full' : 'fixed right-4 bottom-4 z-[60] w-80 shadow-lg',
+      )}
     >
       <div>
         <p className="text-sm font-medium text-[var(--text-primary)]">Workspace setup failed</p>

--- a/apps/desktop/src/components/layout/workspace/WorkspaceSetupFailureNotice.tsx
+++ b/apps/desktop/src/components/layout/workspace/WorkspaceSetupFailureNotice.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
+import type { WorkspaceSetupFailure } from './workspace-setup';
+
+export function WorkspaceSetupFailureNotice({
+  failure,
+  onDismiss,
+}: {
+  failure: WorkspaceSetupFailure;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className="fixed right-4 bottom-4 z-[60] flex w-80 flex-col gap-2 rounded-md border border-status-error-border bg-[var(--bg-elevated)] p-3 shadow-lg"
+    >
+      <div>
+        <p className="text-sm font-medium text-[var(--text-primary)]">Workspace setup failed</p>
+        <p className="text-xs text-[var(--text-secondary)]">
+          Setup did not finish for &quot;{failure.workspace.name}&quot;.
+        </p>
+      </div>
+      <p className="text-sm text-status-error">{failure.message}</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="self-end"
+        onClick={onDismiss}
+      >
+        Dismiss
+      </Button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/layout/workspace/workspace-setup.ts
+++ b/apps/desktop/src/components/layout/workspace/workspace-setup.ts
@@ -1,3 +1,4 @@
+import { useCallback, useRef, useState } from 'react';
 import type { AppEntry } from '@/stores/app';
 import type { WorkspaceInfo } from '@/types/ipc';
 
@@ -43,5 +44,61 @@ export async function runWorkspaceSetup({
     return [];
   });
   return failures.length > 0 ? failures.join(' ') : null;
+}
+
+export function useWorkspaceSetup(
+  apps: AppEntry[],
+  selections: Record<string, boolean>,
+) {
+  const [failures, setFailures] = useState<Record<string, WorkspaceSetupFailure>>({});
+  const pendingSetupRef = useRef<(() => void) | null>(null);
+  const activeFailure = Object.values(failures)[0] ?? null;
+
+  const createSetup = (workspace: WorkspaceInfo): (() => void) => {
+    const setupApps = apps;
+    const setupSelections = selections;
+    return () => {
+      void runWorkspaceSetup({
+        apps: setupApps,
+        selections: setupSelections,
+        workspace,
+      }).then((message) => {
+        if (!message) return;
+        console.warn('[workspace] Workspace setup failed:', message);
+        setFailures((current) => ({
+          ...current,
+          [workspace.id]: { workspace, message },
+        }));
+      });
+    };
+  };
+
+  const deferSetup = (setup: () => void): void => {
+    pendingSetupRef.current = setup;
+  };
+
+  const completePendingSetup = useCallback((): void => {
+    const setup = pendingSetupRef.current;
+    if (!setup) return;
+    pendingSetupRef.current = null;
+    setup();
+  }, []);
+
+  const dismissActiveFailure = (): void => {
+    if (!activeFailure) return;
+    setFailures((current) => {
+      const next = { ...current };
+      delete next[activeFailure.workspace.id];
+      return next;
+    });
+  };
+
+  return {
+    activeFailure,
+    completePendingSetup,
+    createSetup,
+    deferSetup,
+    dismissActiveFailure,
+  };
 }
 

--- a/apps/desktop/src/components/layout/workspace/workspace-setup.ts
+++ b/apps/desktop/src/components/layout/workspace/workspace-setup.ts
@@ -1,4 +1,3 @@
-import { Button } from '@sero-ai/ui/components/ui/button';
 import type { AppEntry } from '@/stores/app';
 import type { WorkspaceInfo } from '@/types/ipc';
 
@@ -46,34 +45,3 @@ export async function runWorkspaceSetup({
   return failures.length > 0 ? failures.join(' ') : null;
 }
 
-export function WorkspaceSetupFailureNotice({
-  failure,
-  onDismiss,
-}: {
-  failure: WorkspaceSetupFailure;
-  onDismiss: () => void;
-}) {
-  return (
-    <div
-      role="alert"
-      className="fixed right-4 bottom-4 z-[60] flex w-80 flex-col gap-2 rounded-md border border-status-error-border bg-[var(--bg-elevated)] p-3 shadow-lg"
-    >
-      <div>
-        <p className="text-sm font-medium text-[var(--text-primary)]">Workspace setup failed</p>
-        <p className="text-xs text-[var(--text-secondary)]">
-          Setup did not finish for &quot;{failure.workspace.name}&quot;.
-        </p>
-      </div>
-      <p className="text-sm text-status-error">{failure.message}</p>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        className="self-end"
-        onClick={onDismiss}
-      >
-        Dismiss
-      </Button>
-    </div>
-  );
-}

--- a/apps/desktop/src/components/layout/workspace/workspace-setup.ts
+++ b/apps/desktop/src/components/layout/workspace/workspace-setup.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
-import type { AppEntry } from '@/stores/app';
+import type { WorkspaceCreationContributionApp } from '@/stores/app';
 import type { WorkspaceInfo } from '@/types/ipc';
 
 export interface WorkspaceSetupFailure {
@@ -12,17 +12,17 @@ export async function runWorkspaceSetup({
   selections,
   workspace,
 }: {
-  apps: AppEntry[];
+  apps: WorkspaceCreationContributionApp[];
   selections: Record<string, boolean>;
   workspace: WorkspaceInfo;
 }): Promise<string | null> {
   const enabledApps = apps.filter((app) => (
     selections[app.id]
-      ?? app.manifest!.workspaceCreation!.defaultEnabled
+      ?? app.manifest.workspaceCreation.defaultEnabled
       ?? false
   ));
   const results = await Promise.allSettled(enabledApps.map((app) => Promise.resolve().then(() => {
-    const contribution = app.manifest!.workspaceCreation!;
+    const contribution = app.manifest.workspaceCreation;
     return window.sero.appAgent.invokeTool(app.id, workspace.id, contribution.tool, {
       ...contribution.params,
       workspaceId: workspace.id,
@@ -47,7 +47,7 @@ export async function runWorkspaceSetup({
 }
 
 export function useWorkspaceSetup(
-  apps: AppEntry[],
+  apps: WorkspaceCreationContributionApp[],
   selections: Record<string, boolean>,
 ) {
   const [failures, setFailures] = useState<Record<string, WorkspaceSetupFailure>>({});
@@ -55,14 +55,8 @@ export function useWorkspaceSetup(
   const activeFailure = Object.values(failures)[0] ?? null;
 
   const createSetup = (workspace: WorkspaceInfo): (() => void) => {
-    const setupApps = apps;
-    const setupSelections = selections;
     return () => {
-      void runWorkspaceSetup({
-        apps: setupApps,
-        selections: setupSelections,
-        workspace,
-      }).then((message) => {
+      void runWorkspaceSetup({ apps, selections, workspace }).then((message) => {
         if (!message) return;
         console.warn('[workspace] Workspace setup failed:', message);
         setFailures((current) => ({

--- a/apps/desktop/src/components/layout/workspace/workspace-setup.tsx
+++ b/apps/desktop/src/components/layout/workspace/workspace-setup.tsx
@@ -1,0 +1,79 @@
+import { Button } from '@sero-ai/ui/components/ui/button';
+import type { AppEntry } from '@/stores/app';
+import type { WorkspaceInfo } from '@/types/ipc';
+
+export interface WorkspaceSetupFailure {
+  workspace: WorkspaceInfo;
+  message: string;
+}
+
+export async function runWorkspaceSetup({
+  apps,
+  selections,
+  workspace,
+}: {
+  apps: AppEntry[];
+  selections: Record<string, boolean>;
+  workspace: WorkspaceInfo;
+}): Promise<string | null> {
+  const enabledApps = apps.filter((app) => (
+    selections[app.id]
+      ?? app.manifest!.workspaceCreation!.defaultEnabled
+      ?? false
+  ));
+  const results = await Promise.allSettled(enabledApps.map((app) => Promise.resolve().then(() => {
+    const contribution = app.manifest!.workspaceCreation!;
+    return window.sero.appAgent.invokeTool(app.id, workspace.id, contribution.tool, {
+      ...contribution.params,
+      workspaceId: workspace.id,
+      workspaceName: workspace.name,
+      workspacePath: workspace.path,
+    });
+  })));
+  const failures = results.flatMap((result, index) => {
+    const label = enabledApps[index].label;
+    if (result.status === 'rejected') {
+      const message = result.reason instanceof Error
+        ? result.reason.message
+        : String(result.reason);
+      return [`${label}: ${message}`];
+    }
+    if (result.value.isError) {
+      return [`${label}: ${result.value.text || 'Setup failed.'}`];
+    }
+    return [];
+  });
+  return failures.length > 0 ? failures.join(' ') : null;
+}
+
+export function WorkspaceSetupFailureNotice({
+  failure,
+  onDismiss,
+}: {
+  failure: WorkspaceSetupFailure;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className="fixed right-4 bottom-4 z-[60] flex w-80 flex-col gap-2 rounded-md border border-status-error-border bg-[var(--bg-elevated)] p-3 shadow-lg"
+    >
+      <div>
+        <p className="text-sm font-medium text-[var(--text-primary)]">Workspace setup failed</p>
+        <p className="text-xs text-[var(--text-secondary)]">
+          Setup did not finish for &quot;{failure.workspace.name}&quot;.
+        </p>
+      </div>
+      <p className="text-sm text-status-error">{failure.message}</p>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="self-end"
+        onClick={onDismiss}
+      >
+        Dismiss
+      </Button>
+    </div>
+  );
+}

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -7,6 +7,7 @@ export {
   getSidebarApps,
   getTitleBarContributionApps,
   type AppEntry,
+  type WorkspaceCreationContributionApp,
   type Theme,
 } from './app/shared';
 export { loadLayout } from './app/layout-hydration';

--- a/apps/desktop/src/stores/app.ts
+++ b/apps/desktop/src/stores/app.ts
@@ -3,6 +3,7 @@ export {
   getDiscoveredApps,
   getExplorerViewContributionApps,
   getSearchContributionApps,
+  getWorkspaceCreationContributionApps,
   getSidebarApps,
   getTitleBarContributionApps,
   type AppEntry,

--- a/apps/desktop/src/stores/app/shared.ts
+++ b/apps/desktop/src/stores/app/shared.ts
@@ -119,6 +119,11 @@ export function getSearchContributionApps(apps: AppEntry[]): AppEntry[] {
   return apps.filter((app) => app.manifest?.search && isAppEntrySupported(app));
 }
 
+/** Apps that contribute an option to the new-workspace form. */
+export function getWorkspaceCreationContributionApps(apps: AppEntry[]): AppEntry[] {
+  return apps.filter((app) => app.manifest?.workspaceCreation && isAppEntrySupported(app));
+}
+
 /** Apps that contribute an Explorer view (`sero.app.explorerView`) and are host-supported. */
 export function getExplorerViewContributionApps(apps: AppEntry[]): AppEntry[] {
   return apps.filter((app) => app.manifest?.explorerView && isAppEntrySupported(app));

--- a/apps/desktop/src/stores/app/shared.ts
+++ b/apps/desktop/src/stores/app/shared.ts
@@ -119,7 +119,7 @@ export function getSearchContributionApps(apps: AppEntry[]): AppEntry[] {
   return apps.filter((app) => app.manifest?.search && isAppEntrySupported(app));
 }
 
-/** Apps that contribute an option to the new-workspace form. */
+/** Apps that contribute an option to workspace creation, clone, and import forms. */
 export function getWorkspaceCreationContributionApps(apps: AppEntry[]): AppEntry[] {
   return apps.filter((app) => app.manifest?.workspaceCreation && isAppEntrySupported(app));
 }

--- a/apps/desktop/src/stores/app/shared.ts
+++ b/apps/desktop/src/stores/app/shared.ts
@@ -1,4 +1,4 @@
-import type { SeroAppManifest } from '@/types/ipc';
+import type { SeroAppManifest, SeroWorkspaceCreationManifest } from '@/types/ipc';
 
 export interface AppEntry {
   id: string;
@@ -8,6 +8,12 @@ export interface AppEntry {
   builtin: boolean;
   /** Manifest for discovered sero apps (null for built-ins). */
   manifest: SeroAppManifest | null;
+}
+
+export interface WorkspaceCreationContributionApp extends AppEntry {
+  manifest: SeroAppManifest & {
+    workspaceCreation: SeroWorkspaceCreationManifest;
+  };
 }
 
 export function isManifestHostSupported(manifest: SeroAppManifest | null): boolean {
@@ -120,8 +126,11 @@ export function getSearchContributionApps(apps: AppEntry[]): AppEntry[] {
 }
 
 /** Apps that contribute an option to workspace creation, clone, and import forms. */
-export function getWorkspaceCreationContributionApps(apps: AppEntry[]): AppEntry[] {
-  return apps.filter((app) => app.manifest?.workspaceCreation && isAppEntrySupported(app));
+export function getWorkspaceCreationContributionApps(
+  apps: AppEntry[],
+): WorkspaceCreationContributionApp[] {
+  return apps.filter((app): app is WorkspaceCreationContributionApp =>
+    Boolean(app.manifest?.workspaceCreation) && isAppEntrySupported(app));
 }
 
 /** Apps that contribute an Explorer view (`sero.app.explorerView`) and are host-supported. */

--- a/apps/desktop/src/types/ipc.ts
+++ b/apps/desktop/src/types/ipc.ts
@@ -269,6 +269,7 @@ export type {
   SeroSearchManifest,
   SeroTitleBarManifest,
   SeroWidgetManifest,
+  SeroWorkspaceCreationManifest,
 } from './sero-apps';
 
 // ── Plugins ─────────────────────────────────────────────────

--- a/apps/desktop/src/types/sero-apps.ts
+++ b/apps/desktop/src/types/sero-apps.ts
@@ -7,6 +7,7 @@ import type { ExplorerViewManifest } from './explorer-view-manifest';
 import type { SearchManifest } from './search-manifest';
 import type { TitleBarManifest } from './titlebar-manifest';
 import type { WidgetManifest } from './widget-manifest';
+import type { WorkspaceCreationManifest } from './workspace-creation-manifest';
 
 /**
  * Canonical Pi package source shape from settings.json.
@@ -18,6 +19,7 @@ export type { WidgetManifest as SeroWidgetManifest } from './widget-manifest';
 export type { SearchManifest as SeroSearchManifest } from './search-manifest';
 export type { ExplorerViewManifest as SeroExplorerViewManifest } from './explorer-view-manifest';
 export type { TitleBarManifest as SeroTitleBarManifest } from './titlebar-manifest';
+export type { WorkspaceCreationManifest as SeroWorkspaceCreationManifest } from './workspace-creation-manifest';
 
 /** Manifest for a Sero app discovered from a Pi package. */
 export interface SeroAppManifest {
@@ -76,4 +78,6 @@ export interface SeroAppManifest {
   explorerView?: ExplorerViewManifest | null;
   /** Title-bar contribution declared in the app manifest. */
   titlebar?: TitleBarManifest | null;
+  /** Option contributed to the new-workspace form. */
+  workspaceCreation?: WorkspaceCreationManifest | null;
 }

--- a/apps/desktop/src/types/sero-apps.ts
+++ b/apps/desktop/src/types/sero-apps.ts
@@ -78,6 +78,6 @@ export interface SeroAppManifest {
   explorerView?: ExplorerViewManifest | null;
   /** Title-bar contribution declared in the app manifest. */
   titlebar?: TitleBarManifest | null;
-  /** Option contributed to the new-workspace form. */
+  /** Option contributed to workspace creation, clone, and import forms. */
   workspaceCreation?: WorkspaceCreationManifest | null;
 }

--- a/apps/desktop/src/types/workspace-creation-manifest.ts
+++ b/apps/desktop/src/types/workspace-creation-manifest.ts
@@ -1,11 +1,11 @@
-/** Option contributed to the new-workspace form through `sero.app.workspaceCreation`. */
+/** Option contributed to workspace creation, clone, and import forms. */
 export interface WorkspaceCreationManifest {
   /** Text shown next to the option switch. */
   label: string;
   /** Initial switch state. Defaults to false. */
   defaultEnabled?: boolean;
-  /** App-local extension tool invoked after the workspace is created. */
+  /** App-local extension tool invoked after the workspace is added. */
   tool: string;
-  /** Static tool arguments merged with the new workspace context. */
+  /** Static tool arguments merged with the workspace context. */
   params?: Record<string, unknown>;
 }

--- a/apps/desktop/src/types/workspace-creation-manifest.ts
+++ b/apps/desktop/src/types/workspace-creation-manifest.ts
@@ -1,0 +1,11 @@
+/** Option contributed to the new-workspace form through `sero.app.workspaceCreation`. */
+export interface WorkspaceCreationManifest {
+  /** Text shown next to the option switch. */
+  label: string;
+  /** Initial switch state. Defaults to false. */
+  defaultEnabled?: boolean;
+  /** App-local extension tool invoked after the workspace is created. */
+  tool: string;
+  /** Static tool arguments merged with the new workspace context. */
+  params?: Record<string, unknown>;
+}

--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -8,11 +8,11 @@ Graphify builds a knowledge graph of your code across every workspace you opt in
 
 ## Getting started
 
-When you create a workspace, **Enable Graphify indexing** is on by default if
-Graphify is available. Turn it off in the creation form if you do not want to
-index that workspace.
+When you create, clone, or import a workspace, **Enable Graphify indexing** is
+on by default if Graphify is available. Turn it off in the workspace form if
+you do not want to index that workspace.
 
-For an existing workspace:
+For a workspace that is already registered:
 
 1. Open **Graphify** from the sidebar.
 2. Toggle on the workspaces you want indexed, or click **Index all**.

--- a/apps/docs-site/docs/plugins/graphify.md
+++ b/apps/docs-site/docs/plugins/graphify.md
@@ -8,6 +8,12 @@ Graphify builds a knowledge graph of your code across every workspace you opt in
 
 ## Getting started
 
+When you create a workspace, **Enable Graphify indexing** is on by default if
+Graphify is available. Turn it off in the creation form if you do not want to
+index that workspace.
+
+For an existing workspace:
+
 1. Open **Graphify** from the sidebar.
 2. Toggle on the workspaces you want indexed, or click **Index all**.
 3. Wait for the first build to finish — this is the only step that uses your AI provider.

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -383,9 +383,9 @@ The component is wrapped in `AppProvider` like the main app component, so all
 
 #### `sero.app.workspaceCreation` (optional)
 
-Contribute a switch to the **Create New Workspace** form. When the switch is
-on, the host invokes the declared app-local tool after it creates the
-workspace.
+Contribute a switch to the **Create New**, **Clone Repository**, and **Import
+Existing** forms. When the switch is on, the host invokes the declared
+app-local tool after it adds the workspace.
 
 ```json
 "workspaceCreation": {
@@ -400,12 +400,12 @@ workspace.
 |-------|------|----------|-------------|
 | `label` | string | Yes | Text shown next to the switch. |
 | `defaultEnabled` | boolean | No | Initial switch state. Defaults to `false`. |
-| `tool` | string | Yes | App-local extension tool to invoke after creation. |
+| `tool` | string | Yes | App-local extension tool to invoke after the workspace is added. |
 | `params` | object | No | Static arguments sent to the tool. |
 
 The host adds `workspaceId`, `workspaceName`, and `workspacePath` to the tool
-arguments. Host values take precedence over static `params`. The workspace
-still opens if optional plugin setup fails.
+arguments. Host values take precedence over static `params`. Create, clone,
+and import still finish if optional plugin setup fails.
 
 #### `sero.app.explorerView` (optional)
 

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -381,6 +381,32 @@ search logic stays inside the plugin.
 The component is wrapped in `AppProvider` like the main app component, so all
 `@sero-ai/app-runtime` hooks (`useAppState`, `useAppTools`, …) work as usual.
 
+#### `sero.app.workspaceCreation` (optional)
+
+Contribute a switch to the **Create New Workspace** form. When the switch is
+on, the host invokes the declared app-local tool after it creates the
+workspace.
+
+```json
+"workspaceCreation": {
+  "label": "Enable indexing",
+  "defaultEnabled": true,
+  "tool": "enable_index",
+  "params": { "mode": "full" }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `label` | string | Yes | Text shown next to the switch. |
+| `defaultEnabled` | boolean | No | Initial switch state. Defaults to `false`. |
+| `tool` | string | Yes | App-local extension tool to invoke after creation. |
+| `params` | object | No | Static arguments sent to the tool. |
+
+The host adds `workspaceId`, `workspaceName`, and `workspacePath` to the tool
+arguments. Host values take precedence over static `params`. The workspace
+still opens if optional plugin setup fails.
+
 #### `sero.app.explorerView` (optional)
 
 Contribute a view to the Explorer. The host adds an activity-bar entry and

--- a/plugins/sero-graphify-plugin/extension/index.test.ts
+++ b/plugins/sero-graphify-plugin/extension/index.test.ts
@@ -1,6 +1,6 @@
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readStateFile } from '../shared/state-io';
 
@@ -45,6 +45,44 @@ describe('graphify workspace creation indexing', () => {
         { action: 'sync', workspaceId: undefined },
         { action: 'enable', workspaceId: 'new-workspace' },
       ]);
+    } finally {
+      await rm(seroHome, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the panel fallback when deferred setup cannot write state', async () => {
+    const seroHome = await mkdtemp(path.join(os.tmpdir(), 'graphify-extension-read-only-'));
+    process.env.SERO_HOME = seroHome;
+
+    try {
+      await writeFile(path.join(seroHome, 'apps'), 'not a directory');
+      type RegisteredTool = {
+        name: string;
+        execute: (...args: unknown[]) => Promise<unknown>;
+      };
+      const registeredTools: RegisteredTool[] = [];
+      const pi = {
+        registerTool: vi.fn((tool: RegisteredTool) => registeredTools.push(tool)),
+        on: vi.fn(),
+      };
+      const { default: registerGraphify } = await import('./index');
+      registerGraphify(pi as never);
+      const indexTool = registeredTools.find((tool) => tool.name === 'graphify_index');
+
+      const result = await indexTool!.execute(
+        'call-1',
+        { action: 'enable', workspaceId: 'new-workspace' },
+        undefined,
+        undefined,
+        { cwd: '/workspace/new-workspace' },
+      );
+
+      expect(result).toMatchObject({
+        content: [{
+          type: 'text',
+          text: expect.stringContaining('Use the Graphify panel instead.'),
+        }],
+      });
     } finally {
       await rm(seroHome, { recursive: true, force: true });
     }

--- a/plugins/sero-graphify-plugin/extension/index.test.ts
+++ b/plugins/sero-graphify-plugin/extension/index.test.ts
@@ -1,0 +1,52 @@
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readStateFile } from '../shared/state-io';
+
+const originalSeroHome = process.env.SERO_HOME;
+
+afterEach(() => {
+  vi.resetModules();
+  if (originalSeroHome === undefined) delete process.env.SERO_HOME;
+  else process.env.SERO_HOME = originalSeroHome;
+});
+
+describe('graphify workspace creation indexing', () => {
+  it('queues sync before enabling a newly created workspace', async () => {
+    const seroHome = await mkdtemp(path.join(os.tmpdir(), 'graphify-extension-'));
+    process.env.SERO_HOME = seroHome;
+
+    try {
+      type RegisteredTool = {
+        name: string;
+        execute: (...args: unknown[]) => Promise<unknown>;
+      };
+      const registeredTools: RegisteredTool[] = [];
+      const pi = {
+        registerTool: vi.fn((tool: RegisteredTool) => registeredTools.push(tool)),
+        on: vi.fn(),
+      };
+      const { default: registerGraphify } = await import('./index');
+      registerGraphify(pi as never);
+      const indexTool = registeredTools.find((tool) => tool.name === 'graphify_index');
+
+      expect(indexTool).toBeDefined();
+      await indexTool!.execute(
+        'call-1',
+        { action: 'enable', workspaceId: 'new-workspace' },
+        undefined,
+        undefined,
+        { cwd: '/workspace/new-workspace' },
+      );
+
+      const state = await readStateFile(path.join(seroHome, 'apps', 'graphify', 'state.json'));
+      expect(state?.requests.map(({ action, workspaceId }) => ({ action, workspaceId }))).toEqual([
+        { action: 'sync', workspaceId: undefined },
+        { action: 'enable', workspaceId: 'new-workspace' },
+      ]);
+    } finally {
+      await rm(seroHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/sero-graphify-plugin/extension/index.test.ts
+++ b/plugins/sero-graphify-plugin/extension/index.test.ts
@@ -60,6 +60,43 @@ describe('graphify workspace creation indexing', () => {
     }
   });
 
+  it('returns an error when the requested workspace cannot be resolved', async () => {
+    const seroHome = await mkdtemp(path.join(os.tmpdir(), 'graphify-extension-missing-workspace-'));
+    process.env.SERO_HOME = seroHome;
+
+    try {
+      type RegisteredTool = {
+        name: string;
+        execute: (...args: unknown[]) => Promise<unknown>;
+      };
+      const registeredTools: RegisteredTool[] = [];
+      const pi = {
+        registerTool: vi.fn((tool: RegisteredTool) => registeredTools.push(tool)),
+        on: vi.fn(),
+      };
+      const { default: registerGraphify } = await import('./index');
+      registerGraphify(pi as never);
+      const indexTool = registeredTools.find((tool) => tool.name === 'graphify_index');
+
+      const result = await indexTool!.execute(
+        'call-1',
+        { action: 'enable', workspace: 'missing-workspace' },
+        undefined,
+        undefined,
+        { cwd: '/workspace/missing-workspace' },
+      );
+
+      expect(result).toMatchObject({
+        content: [{
+          type: 'text',
+          text: expect.stringMatching(/^Error: Could not resolve workspace/),
+        }],
+      });
+    } finally {
+      await rm(seroHome, { recursive: true, force: true });
+    }
+  });
+
   it('returns the panel fallback when deferred setup cannot write state', async () => {
     const seroHome = await mkdtemp(path.join(os.tmpdir(), 'graphify-extension-read-only-'));
     process.env.SERO_HOME = seroHome;
@@ -81,7 +118,12 @@ describe('graphify workspace creation indexing', () => {
 
       const result = await indexTool!.execute(
         'call-1',
-        { action: 'enable', workspaceId: 'new-workspace' },
+        {
+          action: 'enable',
+          workspaceId: 'new-workspace',
+          workspaceName: 'New Workspace',
+          workspacePath: '/workspace/new-workspace',
+        },
         undefined,
         undefined,
         { cwd: '/workspace/new-workspace' },

--- a/plugins/sero-graphify-plugin/extension/index.test.ts
+++ b/plugins/sero-graphify-plugin/extension/index.test.ts
@@ -34,16 +34,26 @@ describe('graphify workspace creation indexing', () => {
       expect(indexTool).toBeDefined();
       await indexTool!.execute(
         'call-1',
-        { action: 'enable', workspaceId: 'new-workspace' },
+        {
+          action: 'enable',
+          workspaceId: 'new-workspace',
+          workspaceName: 'New Workspace',
+          workspacePath: '/workspace/new-workspace',
+        },
         undefined,
         undefined,
         { cwd: '/workspace/new-workspace' },
       );
 
       const state = await readStateFile(path.join(seroHome, 'apps', 'graphify', 'state.json'));
-      expect(state?.requests.map(({ action, workspaceId }) => ({ action, workspaceId }))).toEqual([
-        { action: 'sync', workspaceId: undefined },
-        { action: 'enable', workspaceId: 'new-workspace' },
+      expect(state?.requests).toMatchObject([
+        { action: 'sync' },
+        {
+          action: 'enable',
+          workspaceId: 'new-workspace',
+          workspaceName: 'New Workspace',
+          workspacePath: '/workspace/new-workspace',
+        },
       ]);
     } finally {
       await rm(seroHome, { recursive: true, force: true });
@@ -80,7 +90,7 @@ describe('graphify workspace creation indexing', () => {
       expect(result).toMatchObject({
         content: [{
           type: 'text',
-          text: expect.stringContaining('Use the Graphify panel instead.'),
+          text: expect.stringMatching(/^Error: .*Use the Graphify panel instead\.$/),
         }],
       });
     } finally {

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -145,6 +145,8 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       action: StringEnum(['enable', 'disable', 'rebuild', 'refresh', 'enable-all', 'sync'] as const),
       workspace: Type.Optional(Type.String({ description: 'Workspace id or name (omit for enable-all/sync, or to target the current workspace)' })),
       workspaceId: Type.Optional(Type.String({ description: 'Exact workspace id supplied by a host contribution' })),
+      workspaceName: Type.Optional(Type.String({ description: 'Workspace name supplied by a host contribution' })),
+      workspacePath: Type.Optional(Type.String({ description: 'Workspace path supplied by a host contribution' })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       try {
@@ -164,7 +166,12 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
             if (params.action === 'enable' && params.workspaceId) {
               const [syncId, enableId] = await appendIndexRequests(paths.stateFile, [
                 { action: 'sync' },
-                { action: 'enable', workspaceId: params.workspaceId },
+                {
+                  action: 'enable',
+                  workspaceId: params.workspaceId,
+                  workspaceName: params.workspaceName,
+                  workspacePath: params.workspacePath,
+                },
               ]);
               return text(`Queued workspace sync (request #${syncId}) and enable for ${params.workspaceId} (request #${enableId}). Track with graphify_status.`);
             }
@@ -176,7 +183,7 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
         return text(`Queued ${params.action}${workspaceId ? ` for ${workspaceId}` : ''} (request #${id}). Track with graphify_status.`);
       } catch (error) {
         // Container sessions may have the profile home mounted read-only.
-        return text(`Could not queue the request (state file not writable from this session): ${error instanceof Error ? error.message : String(error)}. Use the Graphify panel instead.`);
+        return text(`Error: Could not queue the request (state file not writable from this session): ${error instanceof Error ? error.message : String(error)}. Use the Graphify panel instead.`);
       }
     },
   });

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -163,7 +163,12 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
             // A workspace-creation contribution runs immediately after the host
             // creates the workspace. Queue sync first so the following enable
             // request can target its new registry entry.
-            if (params.action === 'enable' && params.workspaceId) {
+            if (
+              params.action === 'enable'
+              && params.workspaceId
+              && params.workspaceName
+              && params.workspacePath
+            ) {
               const [syncId, enableId] = await appendIndexRequests(paths.stateFile, [
                 { action: 'sync' },
                 {
@@ -175,7 +180,7 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
               ]);
               return text(`Queued workspace sync (request #${syncId}) and enable for ${params.workspaceId} (request #${enableId}). Track with graphify_status.`);
             }
-            return text(`Could not resolve workspace${params.workspace ? ` "${params.workspace}"` : ' from cwd'}. Known: ${entries.map((e) => e.workspaceId).join(', ') || '(none — runtime not started yet)'}`);
+            return text(`Error: Could not resolve workspace${params.workspace ? ` "${params.workspace}"` : ' from cwd'}. Known: ${entries.map((e) => e.workspaceId).join(', ') || '(none — runtime not started yet)'}`);
           }
           workspaceId = entry.workspaceId;
         }

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -147,31 +147,31 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
       workspaceId: Type.Optional(Type.String({ description: 'Exact workspace id supplied by a host contribution' })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-      const state = await readStateFile(paths.stateFile);
-      let workspaceId: string | undefined;
-      if (params.action !== 'enable-all' && params.action !== 'sync') {
-        const entries = Object.values(state?.workspaces ?? {});
-        const entry = params.workspaceId
-          ? entries.find((candidate) => candidate.workspaceId === params.workspaceId)
-          : params.workspace
-          ? entries.find((e) => e.workspaceId === params.workspace || e.name === params.workspace)
-          : state && ctx ? resolveCurrentWorkspace(state, ctx.cwd) : null;
-        if (!entry) {
-          // A workspace-creation contribution runs immediately after the host
-          // creates the workspace. Queue sync first so the following enable
-          // request can target its new registry entry.
-          if (params.action === 'enable' && params.workspaceId) {
-            const [syncId, enableId] = await appendIndexRequests(paths.stateFile, [
-              { action: 'sync' },
-              { action: 'enable', workspaceId: params.workspaceId },
-            ]);
-            return text(`Queued workspace sync (request #${syncId}) and enable for ${params.workspaceId} (request #${enableId}). Track with graphify_status.`);
-          }
-          return text(`Could not resolve workspace${params.workspace ? ` "${params.workspace}"` : ' from cwd'}. Known: ${entries.map((e) => e.workspaceId).join(', ') || '(none — runtime not started yet)'}`);
-        }
-        workspaceId = entry.workspaceId;
-      }
       try {
+        const state = await readStateFile(paths.stateFile);
+        let workspaceId: string | undefined;
+        if (params.action !== 'enable-all' && params.action !== 'sync') {
+          const entries = Object.values(state?.workspaces ?? {});
+          const entry = params.workspaceId
+            ? entries.find((candidate) => candidate.workspaceId === params.workspaceId)
+            : params.workspace
+            ? entries.find((e) => e.workspaceId === params.workspace || e.name === params.workspace)
+            : state && ctx ? resolveCurrentWorkspace(state, ctx.cwd) : null;
+          if (!entry) {
+            // A workspace-creation contribution runs immediately after the host
+            // creates the workspace. Queue sync first so the following enable
+            // request can target its new registry entry.
+            if (params.action === 'enable' && params.workspaceId) {
+              const [syncId, enableId] = await appendIndexRequests(paths.stateFile, [
+                { action: 'sync' },
+                { action: 'enable', workspaceId: params.workspaceId },
+              ]);
+              return text(`Queued workspace sync (request #${syncId}) and enable for ${params.workspaceId} (request #${enableId}). Track with graphify_status.`);
+            }
+            return text(`Could not resolve workspace${params.workspace ? ` "${params.workspace}"` : ' from cwd'}. Known: ${entries.map((e) => e.workspaceId).join(', ') || '(none — runtime not started yet)'}`);
+          }
+          workspaceId = entry.workspaceId;
+        }
         const id = await appendIndexRequest(paths.stateFile, params.action, workspaceId);
         return text(`Queued ${params.action}${workspaceId ? ` for ${workspaceId}` : ''} (request #${id}). Track with graphify_status.`);
       } catch (error) {

--- a/plugins/sero-graphify-plugin/extension/index.ts
+++ b/plugins/sero-graphify-plugin/extension/index.ts
@@ -12,7 +12,7 @@ import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Type } from 'typebox';
 
 import { resolveGraphifyPaths, workspaceGraphJson } from '../shared/paths';
-import { readStateFile, appendIndexRequest } from '../shared/state-io';
+import { readStateFile, appendIndexRequest, appendIndexRequests } from '../shared/state-io';
 import { loadGraphResult, queryGraph, searchGraph, findPath, explainNode, type GraphLoadFailure } from '../shared/query-engine';
 import { resolveCurrentWorkspace } from './current-workspace';
 import { registerAutoContext } from './auto-context';
@@ -144,16 +144,29 @@ export default function graphifyExtension(pi: ExtensionAPI): void {
     parameters: Type.Object({
       action: StringEnum(['enable', 'disable', 'rebuild', 'refresh', 'enable-all', 'sync'] as const),
       workspace: Type.Optional(Type.String({ description: 'Workspace id or name (omit for enable-all/sync, or to target the current workspace)' })),
+      workspaceId: Type.Optional(Type.String({ description: 'Exact workspace id supplied by a host contribution' })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const state = await readStateFile(paths.stateFile);
       let workspaceId: string | undefined;
       if (params.action !== 'enable-all' && params.action !== 'sync') {
         const entries = Object.values(state?.workspaces ?? {});
-        const entry = params.workspace
+        const entry = params.workspaceId
+          ? entries.find((candidate) => candidate.workspaceId === params.workspaceId)
+          : params.workspace
           ? entries.find((e) => e.workspaceId === params.workspace || e.name === params.workspace)
           : state && ctx ? resolveCurrentWorkspace(state, ctx.cwd) : null;
         if (!entry) {
+          // A workspace-creation contribution runs immediately after the host
+          // creates the workspace. Queue sync first so the following enable
+          // request can target its new registry entry.
+          if (params.action === 'enable' && params.workspaceId) {
+            const [syncId, enableId] = await appendIndexRequests(paths.stateFile, [
+              { action: 'sync' },
+              { action: 'enable', workspaceId: params.workspaceId },
+            ]);
+            return text(`Queued workspace sync (request #${syncId}) and enable for ${params.workspaceId} (request #${enableId}). Track with graphify_status.`);
+          }
           return text(`Could not resolve workspace${params.workspace ? ` "${params.workspace}"` : ' from cwd'}. Known: ${entries.map((e) => e.workspaceId).join(', ') || '(none — runtime not started yet)'}`);
         }
         workspaceId = entry.workspaceId;

--- a/plugins/sero-graphify-plugin/package.json
+++ b/plugins/sero-graphify-plugin/package.json
@@ -27,6 +27,12 @@
         "component": "GraphifySearch",
         "description": "Search the profile-wide knowledge graph"
       },
+      "workspaceCreation": {
+        "label": "Enable Graphify indexing",
+        "defaultEnabled": true,
+        "tool": "graphify_index",
+        "params": { "action": "enable" }
+      },
       "devPort": 5197,
       "runtime": "./runtime/index.ts"
     },

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -261,8 +261,9 @@ describe('GraphifyIndexer', () => {
     indexer.dispose();
   });
 
-  it('uses request metadata when discovery has not observed a new workspace', async () => {
-    const { host, getState } = makeHost({ listWorkspaces: async () => [] });
+  it('keeps a metadata-backed workspace until host discovery observes it', async () => {
+    const live: Array<{ id: string; name: string; path: string; open: boolean }> = [];
+    const { host, getState } = makeHost({ listWorkspaces: async () => [...live] });
     const indexer = new GraphifyIndexer(host);
     await indexer.start();
     await indexer.handleStateChange({
@@ -278,12 +279,19 @@ describe('GraphifyIndexer', () => {
     });
     await indexer.idle();
 
+    await indexer.syncWorkspaces();
     expect(getState().workspaces['ws-new']).toMatchObject({
       name: 'New Workspace',
       path: '/p/new',
       enabled: true,
       status: 'idle',
+      pendingHostDiscovery: true,
     });
+    expect(host.removeWorkspaceArtifacts).not.toHaveBeenCalledWith('ws-new');
+
+    live.push({ id: 'ws-new', name: 'New Workspace', path: '/p/new', open: true });
+    await indexer.syncWorkspaces();
+    expect(getState().workspaces['ws-new'].pendingHostDiscovery).toBeUndefined();
     expect(host.buildGraph).toHaveBeenCalledWith(
       { workspaceId: 'ws-new', path: '/p/new' },
       DEFAULT_STATE.settings,
@@ -292,8 +300,9 @@ describe('GraphifyIndexer', () => {
     indexer.dispose();
   });
 
-  it('records an error when an enable request has no workspace metadata', async () => {
-    const { host, getState } = makeHost({ listWorkspaces: async () => [] });
+  it('does not create a phantom workspace for a request without metadata', async () => {
+    const log = vi.fn();
+    const { host, getState } = makeHost({ listWorkspaces: async () => [], log });
     const indexer = new GraphifyIndexer(host);
     await indexer.start();
     await indexer.handleStateChange({
@@ -307,11 +316,10 @@ describe('GraphifyIndexer', () => {
     });
     await indexer.idle();
 
-    expect(getState().workspaces['ws-missing']).toMatchObject({
-      enabled: false,
-      status: 'error',
-      lastError: 'Workspace is not available. Sync Graphify and enable indexing again.',
-    });
+    expect(getState().workspaces['ws-missing']).toBeUndefined();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining(
+      'ws-missing: Workspace is not available.',
+    ));
     expect(host.buildGraph).not.toHaveBeenCalled();
     indexer.dispose();
   });

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -322,6 +322,40 @@ describe('GraphifyIndexer', () => {
     indexer.dispose();
   });
 
+  it('keeps a pending workspace while its build is active', async () => {
+    let finishBuild: (stats: WorkspaceIndexStats) => void = () => {};
+    const buildGraph = vi.fn(() => new Promise<WorkspaceIndexStats>((resolve) => {
+      finishBuild = resolve;
+    }));
+    const { host, getState } = makeHost({ listWorkspaces: async () => [], buildGraph });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.handleStateChange({
+      ...getState(),
+      requests: [{
+        id: 1,
+        action: 'enable',
+        workspaceId: 'ws-building',
+        workspaceName: 'Building Workspace',
+        workspacePath: '/p/building',
+        requestedAt: 'now',
+      }],
+    });
+    await vi.waitFor(() => expect(getState().workspaces['ws-building']?.status).toBe('building'));
+
+    await indexer.syncWorkspaces();
+
+    expect(getState().workspaces['ws-building']).toBeDefined();
+    expect(host.removeWorkspaceArtifacts).not.toHaveBeenCalledWith('ws-building');
+
+    finishBuild(STATS);
+    await indexer.idle();
+    await indexer.syncWorkspaces();
+    expect(getState().workspaces['ws-building']).toBeUndefined();
+    expect(host.removeWorkspaceArtifacts).toHaveBeenCalledWith('ws-building');
+    indexer.dispose();
+  });
+
   it('does not create a phantom workspace for a request without metadata', async () => {
     const log = vi.fn();
     const { host, getState } = makeHost({ listWorkspaces: async () => [], log });

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -295,7 +295,8 @@ describe('GraphifyIndexer', () => {
   });
 
   it('expires a metadata-backed workspace after one missed discovery sync', async () => {
-    const { host, getState } = makeHost({ listWorkspaces: async () => [] });
+    const log = vi.fn();
+    const { host, getState } = makeHost({ listWorkspaces: async () => [], log });
     const indexer = new GraphifyIndexer(host);
     await indexer.start();
     await indexer.handleStateChange({
@@ -319,6 +320,7 @@ describe('GraphifyIndexer', () => {
 
     expect(getState().workspaces['ws-deleted']).toBeUndefined();
     expect(host.removeWorkspaceArtifacts).toHaveBeenCalledWith('ws-deleted');
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('ws-deleted'));
     indexer.dispose();
   });
 
@@ -353,6 +355,26 @@ describe('GraphifyIndexer', () => {
     await indexer.syncWorkspaces();
     expect(getState().workspaces['ws-building']).toBeUndefined();
     expect(host.removeWorkspaceArtifacts).toHaveBeenCalledWith('ws-building');
+    indexer.dispose();
+  });
+
+  it('removes an interrupted undiscovered workspace during boot normalization', async () => {
+    const { host, getState } = makeHost({ listWorkspaces: async () => [] }, (state) => {
+      state.workspaces['ws-interrupted'] = {
+        workspaceId: 'ws-interrupted',
+        name: 'Interrupted Workspace',
+        path: '/p/interrupted',
+        enabled: false,
+        status: 'building',
+        pendingHostDiscovery: true,
+      };
+    });
+    const indexer = new GraphifyIndexer(host);
+
+    await indexer.start();
+    await indexer.idle();
+    expect(getState().workspaces['ws-interrupted']).toBeUndefined();
+    expect(host.removeWorkspaceArtifacts).toHaveBeenCalledWith('ws-interrupted');
     indexer.dispose();
   });
 

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -268,26 +268,20 @@ describe('GraphifyIndexer', () => {
     await indexer.start();
     await indexer.handleStateChange({
       ...getState(),
-      requests: [{
-        id: 1,
-        action: 'enable',
-        workspaceId: 'ws-new',
-        workspaceName: 'New Workspace',
-        workspacePath: '/p/new',
-        requestedAt: 'now',
-      }],
+      requests: [
+        { id: 1, action: 'sync', requestedAt: 'now' },
+        {
+          id: 2,
+          action: 'enable',
+          workspaceId: 'ws-new',
+          workspaceName: 'New Workspace',
+          workspacePath: '/p/new',
+          requestedAt: 'now',
+        },
+      ],
     });
     await indexer.idle();
-
-    await indexer.syncWorkspaces();
-    expect(getState().workspaces['ws-new']).toMatchObject({
-      name: 'New Workspace',
-      path: '/p/new',
-      enabled: true,
-      status: 'idle',
-      pendingHostDiscovery: true,
-    });
-    expect(host.removeWorkspaceArtifacts).not.toHaveBeenCalledWith('ws-new');
+    expect(getState().workspaces['ws-new']?.pendingHostDiscovery).toBe(true);
 
     live.push({ id: 'ws-new', name: 'New Workspace', path: '/p/new', open: true });
     await indexer.syncWorkspaces();
@@ -297,6 +291,34 @@ describe('GraphifyIndexer', () => {
       DEFAULT_STATE.settings,
       expect.any(Function),
     );
+    indexer.dispose();
+  });
+
+  it('expires a metadata-backed workspace after one missed discovery sync', async () => {
+    const { host, getState } = makeHost({ listWorkspaces: async () => [] });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.handleStateChange({
+      ...getState(),
+      requests: [
+        { id: 1, action: 'sync', requestedAt: 'now' },
+        {
+          id: 2,
+          action: 'enable',
+          workspaceId: 'ws-deleted',
+          workspaceName: 'Deleted Workspace',
+          workspacePath: '/p/deleted',
+          requestedAt: 'now',
+        },
+      ],
+    });
+    await indexer.idle();
+    expect(getState().workspaces['ws-deleted']?.pendingHostDiscovery).toBe(true);
+
+    await indexer.syncWorkspaces();
+
+    expect(getState().workspaces['ws-deleted']).toBeUndefined();
+    expect(host.removeWorkspaceArtifacts).toHaveBeenCalledWith('ws-deleted');
     indexer.dispose();
   });
 

--- a/plugins/sero-graphify-plugin/runtime/indexer.test.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.test.ts
@@ -261,6 +261,61 @@ describe('GraphifyIndexer', () => {
     indexer.dispose();
   });
 
+  it('uses request metadata when discovery has not observed a new workspace', async () => {
+    const { host, getState } = makeHost({ listWorkspaces: async () => [] });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.handleStateChange({
+      ...getState(),
+      requests: [{
+        id: 1,
+        action: 'enable',
+        workspaceId: 'ws-new',
+        workspaceName: 'New Workspace',
+        workspacePath: '/p/new',
+        requestedAt: 'now',
+      }],
+    });
+    await indexer.idle();
+
+    expect(getState().workspaces['ws-new']).toMatchObject({
+      name: 'New Workspace',
+      path: '/p/new',
+      enabled: true,
+      status: 'idle',
+    });
+    expect(host.buildGraph).toHaveBeenCalledWith(
+      { workspaceId: 'ws-new', path: '/p/new' },
+      DEFAULT_STATE.settings,
+      expect.any(Function),
+    );
+    indexer.dispose();
+  });
+
+  it('records an error when an enable request has no workspace metadata', async () => {
+    const { host, getState } = makeHost({ listWorkspaces: async () => [] });
+    const indexer = new GraphifyIndexer(host);
+    await indexer.start();
+    await indexer.handleStateChange({
+      ...getState(),
+      requests: [{
+        id: 1,
+        action: 'enable',
+        workspaceId: 'ws-missing',
+        requestedAt: 'now',
+      }],
+    });
+    await indexer.idle();
+
+    expect(getState().workspaces['ws-missing']).toMatchObject({
+      enabled: false,
+      status: 'error',
+      lastError: 'Workspace is not available. Sync Graphify and enable indexing again.',
+    });
+    expect(host.buildGraph).not.toHaveBeenCalled();
+    indexer.dispose();
+  });
+
   it('sweeps orphaned artifacts on start but keeps live (incl. disabled) workspaces', async () => {
     // ws1/ws2 are live; 'ws-gone' only has artifacts on disk (deleted workspace).
     const { host } = makeHost({ listArtifactWorkspaceIds: vi.fn().mockResolvedValue(['ws1', 'ws2', 'ws-gone']) });

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -101,6 +101,10 @@ export class GraphifyIndexer {
     const workspaces = (await this.host.listWorkspaces()).filter((ws) => ws.id !== 'global');
     const current = (await this.host.readState())?.workspaces ?? {};
     const discoveredIds = new Set(workspaces.map((workspace) => workspace.id));
+    // Outside start(), live statuses (queued/building/updating) must survive a
+    // discovery tick; only the boot pass may normalize interrupted work to idle.
+    const nextStatus = (existing: GraphifyState['workspaces'][string]): WorkspaceIndexStatus =>
+      normalize ? (existing.status === 'error' ? 'error' : 'idle') : existing.status;
     // Expire only pending entries present in this opening snapshot. An entry
     // created while this sync runs gets one full discovery cycle of its own.
     const expiringPendingIds = new Set<string>();
@@ -108,16 +112,11 @@ export class GraphifyIndexer {
       if (
         entry.pendingHostDiscovery
         && !discoveredIds.has(entry.workspaceId)
-        && !isIndexing(entry.status)
+        && !isIndexing(nextStatus(entry))
       ) {
         expiringPendingIds.add(entry.workspaceId);
       }
     }
-
-    // Outside start(), live statuses (queued/building/updating) must survive a
-    // discovery tick; only the boot pass may normalize interrupted work to idle.
-    const nextStatus = (existing: GraphifyState['workspaces'][string]): WorkspaceIndexStatus =>
-      normalize ? (existing.status === 'error' ? 'error' : 'idle') : existing.status;
 
     const unchanged = workspaces.length === Object.keys(current).length
       && workspaces.every((ws) => {
@@ -157,7 +156,13 @@ export class GraphifyIndexer {
         };
       }
       for (const id of Object.keys(next.workspaces)) {
-        const entry = next.workspaces[id];
+        let entry = next.workspaces[id];
+        const status = nextStatus(entry);
+        if (status !== entry.status) {
+          entry = { ...entry, status };
+          delete entry.progress;
+          next.workspaces[id] = entry;
+        }
         if (
           !discoveredIds.has(id)
           && !isIndexing(entry.status)
@@ -168,13 +173,18 @@ export class GraphifyIndexer {
       }
       return next;
     });
+    // The updater can preserve entries against the opening snapshot. Re-read
+    // state so artifact removal uses the authoritative reconciliation result.
     const reconciled = (await this.host.readState())?.workspaces ?? {};
     const removedIds = removalCandidates.filter((id) => !reconciled[id]);
     const removedIndexed = removedIds.some((id) => current[id]?.enabled && current[id]?.lastBuiltAt);
     // A removed workspace's per-workspace graph is now an orphan — delete it so
     // disk tracks the live workspace list (disable keeps artifacts; removal does not).
     // Removals are independent, so run them together.
-    await Promise.all(removedIds.map((id) => this.host.removeWorkspaceArtifacts(id)));
+    await Promise.all(removedIds.map((id) => {
+      this.host.log(`[graphify] removing undiscovered workspace ${id} and its graph artifacts`);
+      return this.host.removeWorkspaceArtifacts(id);
+    }));
     // A deleted workspace that was part of the profile graph leaves stale
     // nodes behind until the next merge — re-merge promptly.
     if (removedIndexed) await this.merge();

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -28,6 +28,10 @@ interface Job {
   full: boolean;
 }
 
+function isIndexing(status: WorkspaceIndexStatus): boolean {
+  return status === 'queued' || status === 'building' || status === 'updating';
+}
+
 export class GraphifyIndexer {
   private queue: Job[] = [];
   private current: Promise<void> = Promise.resolve();
@@ -101,7 +105,11 @@ export class GraphifyIndexer {
     // created while this sync runs gets one full discovery cycle of its own.
     const expiringPendingIds = new Set<string>();
     for (const entry of Object.values(current)) {
-      if (entry.pendingHostDiscovery && !discoveredIds.has(entry.workspaceId)) {
+      if (
+        entry.pendingHostDiscovery
+        && !discoveredIds.has(entry.workspaceId)
+        && !isIndexing(entry.status)
+      ) {
         expiringPendingIds.add(entry.workspaceId);
       }
     }
@@ -122,8 +130,7 @@ export class GraphifyIndexer {
       });
     if (unchanged) return;
 
-    const removedIds = Object.keys(current).filter((id) => !discoveredIds.has(id));
-    const removedIndexed = removedIds.some((id) => current[id]?.enabled && current[id]?.lastBuiltAt);
+    const removalCandidates = Object.keys(current).filter((id) => !discoveredIds.has(id));
 
     await this.host.updateState((raw) => {
       const state = raw ?? structuredClone(DEFAULT_STATE);
@@ -153,11 +160,17 @@ export class GraphifyIndexer {
         const entry = next.workspaces[id];
         if (
           !discoveredIds.has(id)
+          && !isIndexing(entry.status)
           && (!entry.pendingHostDiscovery || expiringPendingIds.has(id))
-        ) delete next.workspaces[id];
+        ) {
+          delete next.workspaces[id];
+        }
       }
       return next;
     });
+    const reconciled = (await this.host.readState())?.workspaces ?? {};
+    const removedIds = removalCandidates.filter((id) => !reconciled[id]);
+    const removedIndexed = removedIds.some((id) => current[id]?.enabled && current[id]?.lastBuiltAt);
     // A removed workspace's per-workspace graph is now an orphan — delete it so
     // disk tracks the live workspace list (disable keeps artifacts; removal does not).
     // Removals are independent, so run them together.

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -96,20 +96,31 @@ export class GraphifyIndexer {
     const normalize = options.normalizeStatuses === true;
     const workspaces = (await this.host.listWorkspaces()).filter((ws) => ws.id !== 'global');
     const current = (await this.host.readState())?.workspaces ?? {};
+    const discoveredIds = new Set(workspaces.map((workspace) => workspace.id));
+    const pendingEntries = Object.values(current).filter(
+      (entry) => entry.pendingHostDiscovery && !discoveredIds.has(entry.workspaceId),
+    );
 
     // Outside start(), live statuses (queued/building/updating) must survive a
     // discovery tick; only the boot pass may normalize interrupted work to idle.
     const nextStatus = (existing: GraphifyState['workspaces'][string]): WorkspaceIndexStatus =>
       normalize ? (existing.status === 'error' ? 'error' : 'idle') : existing.status;
 
-    const unchanged = workspaces.length === Object.keys(current).length
+    const unchanged = workspaces.length + pendingEntries.length === Object.keys(current).length
       && workspaces.every((ws) => {
         const existing = current[ws.id];
-        return existing && existing.name === ws.name && existing.path === ws.path && existing.status === nextStatus(existing);
-      });
+        return existing
+          && !existing.pendingHostDiscovery
+          && existing.name === ws.name
+          && existing.path === ws.path
+          && existing.status === nextStatus(existing);
+      })
+      && pendingEntries.every((entry) => entry.status === nextStatus(entry));
     if (unchanged) return;
 
-    const removedIds = Object.keys(current).filter((id) => !workspaces.some((ws) => ws.id === id));
+    const removedIds = Object.keys(current).filter((id) => (
+      !discoveredIds.has(id) && !current[id]?.pendingHostDiscovery
+    ));
     const removedIndexed = removedIds.some((id) => current[id]?.enabled && current[id]?.lastBuiltAt);
 
     await this.host.updateState((raw) => {
@@ -117,12 +128,29 @@ export class GraphifyIndexer {
       const next = { ...state, workspaces: { ...state.workspaces } };
       for (const ws of workspaces) {
         const existing = next.workspaces[ws.id];
-        next.workspaces[ws.id] = existing
-          ? { ...existing, name: ws.name, path: ws.path, status: nextStatus(existing) }
-          : { workspaceId: ws.id, name: ws.name, path: ws.path, enabled: false, status: 'idle' };
+        if (!existing) {
+          next.workspaces[ws.id] = {
+            workspaceId: ws.id,
+            name: ws.name,
+            path: ws.path,
+            enabled: false,
+            status: 'idle',
+          };
+          continue;
+        }
+        const observed = { ...existing };
+        delete observed.pendingHostDiscovery;
+        next.workspaces[ws.id] = {
+          ...observed,
+          name: ws.name,
+          path: ws.path,
+          status: nextStatus(existing),
+        };
       }
       for (const id of Object.keys(next.workspaces)) {
-        if (!workspaces.some((ws) => ws.id === id)) delete next.workspaces[id];
+        if (!discoveredIds.has(id) && !next.workspaces[id].pendingHostDiscovery) {
+          delete next.workspaces[id];
+        }
       }
       return next;
     });
@@ -143,7 +171,11 @@ export class GraphifyIndexer {
    * mistaken for orphans.
    */
   private async sweepOrphanArtifacts(): Promise<void> {
+    const state = await this.host.readState();
     const live = new Set((await this.host.listWorkspaces()).map((ws) => ws.id));
+    for (const entry of Object.values(state?.workspaces ?? {})) {
+      if (entry.pendingHostDiscovery) live.add(entry.workspaceId);
+    }
     const orphans = (await this.host.listArtifactWorkspaceIds()).filter((id) => !live.has(id));
     await Promise.all(orphans.map((id) => {
       this.host.log(`[graphify] removing orphaned graph artifacts for ${id}`);
@@ -161,20 +193,7 @@ export class GraphifyIndexer {
         const existing = state.workspaces[workspaceId];
         if (!existing && (!request.workspaceName || !request.workspacePath)) {
           missingMessage = 'Workspace is not available. Sync Graphify and enable indexing again.';
-          return {
-            ...state,
-            workspaces: {
-              ...state.workspaces,
-              [workspaceId]: {
-                workspaceId,
-                name: request.workspaceName ?? workspaceId,
-                path: request.workspacePath ?? '',
-                enabled: false,
-                status: 'error',
-                lastError: missingMessage,
-              },
-            },
-          };
+          return state;
         }
         const entry = existing
           ? {
@@ -188,6 +207,7 @@ export class GraphifyIndexer {
               path: request.workspacePath!,
               enabled: false,
               status: 'idle' as const,
+              pendingHostDiscovery: true,
             };
         shouldEnqueue = true;
         return {

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -152,26 +152,72 @@ export class GraphifyIndexer {
   }
 
   private async applyRequest(request: IndexRequest): Promise<void> {
-    const enable = async (workspaceId: string, rebuild: boolean) => {
+    const enable = async (request: IndexRequest, rebuild: boolean) => {
+      const workspaceId = request.workspaceId;
+      if (!workspaceId) return;
+      let shouldEnqueue = false;
+      let missingMessage: string | null = null;
       await this.host.updateState((state) => {
-        const entry = state.workspaces[workspaceId];
-        if (!entry) return state;
-        return { ...state, workspaces: { ...state.workspaces, [workspaceId]: { ...entry, enabled: true, status: 'queued', lastError: undefined } } };
+        const existing = state.workspaces[workspaceId];
+        if (!existing && (!request.workspaceName || !request.workspacePath)) {
+          missingMessage = 'Workspace is not available. Sync Graphify and enable indexing again.';
+          return {
+            ...state,
+            workspaces: {
+              ...state.workspaces,
+              [workspaceId]: {
+                workspaceId,
+                name: request.workspaceName ?? workspaceId,
+                path: request.workspacePath ?? '',
+                enabled: false,
+                status: 'error',
+                lastError: missingMessage,
+              },
+            },
+          };
+        }
+        const entry = existing
+          ? {
+              ...existing,
+              name: request.workspaceName ?? existing.name,
+              path: request.workspacePath ?? existing.path,
+            }
+          : {
+              workspaceId,
+              name: request.workspaceName!,
+              path: request.workspacePath!,
+              enabled: false,
+              status: 'idle' as const,
+            };
+        shouldEnqueue = true;
+        return {
+          ...state,
+          workspaces: {
+            ...state.workspaces,
+            [workspaceId]: {
+              ...entry,
+              enabled: true,
+              status: 'queued',
+              lastError: undefined,
+            },
+          },
+        };
       });
-      this.enqueue(workspaceId, rebuild);
+      if (shouldEnqueue) this.enqueue(workspaceId, rebuild);
+      else if (missingMessage) this.host.log(`[graphify] ${workspaceId}: ${missingMessage}`);
     };
 
     switch (request.action) {
       case 'enable':
       case 'rebuild':
-        if (request.workspaceId) await enable(request.workspaceId, true);
+        await enable(request, true);
         break;
       case 'refresh': {
         // Refresh is the push-update path (edit hooks, panel). It must never
         // resurrect a workspace the user disabled.
         if (!request.workspaceId) break;
         const state = await this.host.readState();
-        if (state?.workspaces[request.workspaceId]?.enabled) await enable(request.workspaceId, false);
+        if (state?.workspaces[request.workspaceId]?.enabled) await enable(request, false);
         break;
       }
       case 'sync':
@@ -179,7 +225,9 @@ export class GraphifyIndexer {
         break;
       case 'enable-all': {
         const state = await this.host.readState();
-        for (const id of Object.keys(state?.workspaces ?? {})) await enable(id, true);
+        for (const id of Object.keys(state?.workspaces ?? {})) {
+          await enable({ ...request, workspaceId: id }, true);
+        }
         break;
       }
       case 'disable':

--- a/plugins/sero-graphify-plugin/runtime/indexer.ts
+++ b/plugins/sero-graphify-plugin/runtime/indexer.ts
@@ -97,16 +97,21 @@ export class GraphifyIndexer {
     const workspaces = (await this.host.listWorkspaces()).filter((ws) => ws.id !== 'global');
     const current = (await this.host.readState())?.workspaces ?? {};
     const discoveredIds = new Set(workspaces.map((workspace) => workspace.id));
-    const pendingEntries = Object.values(current).filter(
-      (entry) => entry.pendingHostDiscovery && !discoveredIds.has(entry.workspaceId),
-    );
+    // Expire only pending entries present in this opening snapshot. An entry
+    // created while this sync runs gets one full discovery cycle of its own.
+    const expiringPendingIds = new Set<string>();
+    for (const entry of Object.values(current)) {
+      if (entry.pendingHostDiscovery && !discoveredIds.has(entry.workspaceId)) {
+        expiringPendingIds.add(entry.workspaceId);
+      }
+    }
 
     // Outside start(), live statuses (queued/building/updating) must survive a
     // discovery tick; only the boot pass may normalize interrupted work to idle.
     const nextStatus = (existing: GraphifyState['workspaces'][string]): WorkspaceIndexStatus =>
       normalize ? (existing.status === 'error' ? 'error' : 'idle') : existing.status;
 
-    const unchanged = workspaces.length + pendingEntries.length === Object.keys(current).length
+    const unchanged = workspaces.length === Object.keys(current).length
       && workspaces.every((ws) => {
         const existing = current[ws.id];
         return existing
@@ -114,13 +119,10 @@ export class GraphifyIndexer {
           && existing.name === ws.name
           && existing.path === ws.path
           && existing.status === nextStatus(existing);
-      })
-      && pendingEntries.every((entry) => entry.status === nextStatus(entry));
+      });
     if (unchanged) return;
 
-    const removedIds = Object.keys(current).filter((id) => (
-      !discoveredIds.has(id) && !current[id]?.pendingHostDiscovery
-    ));
+    const removedIds = Object.keys(current).filter((id) => !discoveredIds.has(id));
     const removedIndexed = removedIds.some((id) => current[id]?.enabled && current[id]?.lastBuiltAt);
 
     await this.host.updateState((raw) => {
@@ -148,9 +150,11 @@ export class GraphifyIndexer {
         };
       }
       for (const id of Object.keys(next.workspaces)) {
-        if (!discoveredIds.has(id) && !next.workspaces[id].pendingHostDiscovery) {
-          delete next.workspaces[id];
-        }
+        const entry = next.workspaces[id];
+        if (
+          !discoveredIds.has(id)
+          && (!entry.pendingHostDiscovery || expiringPendingIds.has(id))
+        ) delete next.workspaces[id];
       }
       return next;
     });

--- a/plugins/sero-graphify-plugin/shared/state-io.test.ts
+++ b/plugins/sero-graphify-plugin/shared/state-io.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mkdtemp, readFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { readStateFile, appendIndexRequest } from './state-io';
+import { readStateFile, appendIndexRequest, appendIndexRequests } from './state-io';
 import { DEFAULT_STATE } from './types';
 
 describe('state-io', () => {
@@ -20,5 +20,21 @@ describe('state-io', () => {
     const state = JSON.parse(await readFile(stateFile, 'utf8'));
     expect(state.requests).toHaveLength(2);
     expect(state.settings).toEqual(DEFAULT_STATE.settings);
+  });
+
+  it('appends related requests in one batch', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'graphify-state-batch-'));
+    const stateFile = path.join(dir, 'state.json');
+    const ids = await appendIndexRequests(stateFile, [
+      { action: 'sync' },
+      { action: 'enable', workspaceId: 'ws1' },
+    ]);
+
+    expect(ids).toEqual([1, 2]);
+    const state = await readStateFile(stateFile);
+    expect(state?.requests.map(({ action, workspaceId }) => ({ action, workspaceId }))).toEqual([
+      { action: 'sync', workspaceId: undefined },
+      { action: 'enable', workspaceId: 'ws1' },
+    ]);
   });
 });

--- a/plugins/sero-graphify-plugin/shared/state-io.ts
+++ b/plugins/sero-graphify-plugin/shared/state-io.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import { DEFAULT_STATE, type GraphifyState, type IndexAction } from './types';
+import { DEFAULT_STATE, type GraphifyState, type IndexAction, type IndexRequest } from './types';
 
 export async function readStateFile(stateFile: string): Promise<GraphifyState | null> {
   try {
@@ -24,7 +24,7 @@ export async function appendIndexRequest(stateFile: string, action: IndexAction,
 /** Append related requests in one state write so the runtime observes them together. */
 export async function appendIndexRequests(
   stateFile: string,
-  requests: Array<{ action: IndexAction; workspaceId?: string }>,
+  requests: Array<Omit<IndexRequest, 'id' | 'requestedAt'>>,
 ): Promise<number[]> {
   const current = (await readStateFile(stateFile)) ?? structuredClone(DEFAULT_STATE);
   const requestedAt = new Date().toISOString();

--- a/plugins/sero-graphify-plugin/shared/state-io.ts
+++ b/plugins/sero-graphify-plugin/shared/state-io.ts
@@ -18,13 +18,26 @@ export async function writeStateFile(stateFile: string, state: GraphifyState): P
 }
 
 export async function appendIndexRequest(stateFile: string, action: IndexAction, workspaceId?: string): Promise<number> {
+  return (await appendIndexRequests(stateFile, [{ action, workspaceId }]))[0];
+}
+
+/** Append related requests in one state write so the runtime observes them together. */
+export async function appendIndexRequests(
+  stateFile: string,
+  requests: Array<{ action: IndexAction; workspaceId?: string }>,
+): Promise<number[]> {
   const current = (await readStateFile(stateFile)) ?? structuredClone(DEFAULT_STATE);
-  const id = current.nextRequestId;
+  const requestedAt = new Date().toISOString();
+  const queued = requests.map((request, index) => ({
+    id: current.nextRequestId + index,
+    ...request,
+    requestedAt,
+  }));
   const next: GraphifyState = {
     ...current,
-    nextRequestId: id + 1,
-    requests: [...current.requests, { id, action, workspaceId, requestedAt: new Date().toISOString() }],
+    nextRequestId: current.nextRequestId + queued.length,
+    requests: [...current.requests, ...queued],
   };
   await writeStateFile(stateFile, next);
-  return id;
+  return queued.map((request) => request.id);
 }

--- a/plugins/sero-graphify-plugin/shared/types.ts
+++ b/plugins/sero-graphify-plugin/shared/types.ts
@@ -48,6 +48,8 @@ export interface IndexRequest {
   id: number;
   action: IndexAction;
   workspaceId?: string;
+  workspaceName?: string;
+  workspacePath?: string;
   requestedAt: string;
 }
 

--- a/plugins/sero-graphify-plugin/shared/types.ts
+++ b/plugins/sero-graphify-plugin/shared/types.ts
@@ -40,7 +40,7 @@ export interface WorkspaceIndexEntry {
   stats?: WorkspaceIndexStats;
   /** Latest build progress line; only set while building/updating. */
   progress?: string;
-  /** Host-supplied entry retained until runtime discovery confirms it. */
+  /** Host-supplied entry removed if the next discovery sync still cannot find it. */
   pendingHostDiscovery?: boolean;
 }
 

--- a/plugins/sero-graphify-plugin/shared/types.ts
+++ b/plugins/sero-graphify-plugin/shared/types.ts
@@ -40,6 +40,8 @@ export interface WorkspaceIndexEntry {
   stats?: WorkspaceIndexStats;
   /** Latest build progress line; only set while building/updating. */
   progress?: string;
+  /** Host-supplied entry retained until runtime discovery confirms it. */
+  pendingHostDiscovery?: boolean;
 }
 
 export type IndexAction = 'enable' | 'disable' | 'rebuild' | 'refresh' | 'enable-all' | 'sync';


### PR DESCRIPTION
## Summary
- add a generic `sero.app.workspaceCreation` manifest contribution for plugin-owned setup options in create, clone, and import workspace forms
- validate static contribution parameters as plain records before they cross the discovery boundary
- invoke enabled app-local setup tools with host-owned workspace metadata only after the workspace and any requested remote checkout are ready
- keep setup failures by workspace, show the active failure in the open Git Repository dialog, and keep each failure until dismissal
- keep workspace forms and the Git Repository dialog open while their current operation runs
- make Git import fail open when Sero cannot inspect existing files, so it does not overwrite an unknown working tree
- make Graphify queue sync and enable requests atomically, preserve entries that are actively indexing during discovery, and normalize interrupted work at startup
- document the contribution contract and Graphify behavior
- add focused discovery, workspace UI, Git import, Graphify extension, runtime, and request-batching tests

## Validation
- focused desktop Vitest: 5 files passed, 35 tests passed
- full Graphify Vitest: 19 files passed, 129 tests passed
- monorepo typecheck: 24/24 tasks passed
- React Doctor: 90/100, no issues
- Electron main-process build passed
- Electron smoke: create, clone, and import contribution flows passed; clone checkout completed before setup; a setup failure stayed in the Git Repository dialog until dismissal; a slow remote import ignored Escape while busy and reached the connected state
- all touched source files are at or below 500 lines