### PR TITLE
feat(dashboard): let plugins set background images

### DIFF
--- a/apps/desktop/electron/__tests__/features/doctor/main-bootstrap.test.ts
+++ b/apps/desktop/electron/__tests__/features/doctor/main-bootstrap.test.ts
@@ -86,5 +86,6 @@ describe('electron/main.ts — safe-mode bootstrap shape', () => {
     expect(source).toContain('protocol.registerSchemesAsPrivileged');
     expect(source).toContain("scheme: 'sero-ext'");
     expect(source).toContain("scheme: 'sero-media'");
+    expect(source).toMatch(/scheme:\s*'sero-media'[\s\S]*?corsEnabled:\s*true/);
   });
 });

--- a/apps/desktop/electron/__tests__/features/doctor/main-bootstrap.test.ts
+++ b/apps/desktop/electron/__tests__/features/doctor/main-bootstrap.test.ts
@@ -82,8 +82,9 @@ describe('electron/main.ts — safe-mode bootstrap shape', () => {
     expect(source).toMatch(/await\s+import\(['"]\.\/app-main['"]\)/);
   });
 
-  it('registers the extension protocol scheme in the tiny bootstrap', () => {
+  it('registers privileged protocol schemes in the tiny bootstrap', () => {
     expect(source).toContain('protocol.registerSchemesAsPrivileged');
     expect(source).toContain("scheme: 'sero-ext'");
+    expect(source).toContain("scheme: 'sero-media'");
   });
 });

--- a/apps/desktop/electron/__tests__/ipc/dashboard-background.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/dashboard-background.test.ts
@@ -180,6 +180,15 @@ describe('dashboard background IPC', () => {
     expect(mocks.resizeImageForApi).not.toHaveBeenCalled();
   });
 
+  it('does not hydrate a corrupted background asset', async () => {
+    await fs.writeFile(
+      path.join(mocks.agentDir, 'dashboard-background.image'),
+      Buffer.from('corrupted image'),
+    );
+
+    expect(await handler(IpcChannels.dashboard.getBackground)(event)).toBeNull();
+  });
+
   it('rejects non-string input with the validation error', async () => {
     await expect(handler(IpcChannels.dashboard.setBackground)(event, undefined)).rejects.toThrow(
       'Dashboard background must be a PNG or JPEG data URL',

--- a/apps/desktop/electron/__tests__/ipc/dashboard-background.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/dashboard-background.test.ts
@@ -8,15 +8,7 @@ const mocks = vi.hoisted(() => ({
   agentDir: `/tmp/sero-dashboard-background-${process.pid}`,
   handlers: new Map<string, (...args: unknown[]) => unknown>(),
   broadcastToWindows: vi.fn(),
-  resizeImageForApi: vi.fn((data: string, mimeType: string) => ({
-    data,
-    mimeType,
-    originalWidth: 100,
-    originalHeight: 100,
-    width: 100,
-    height: 100,
-    wasResized: false,
-  })),
+  resizeImageForApi: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -26,9 +18,9 @@ vi.mock('electron', () => ({
     }),
   },
   nativeImage: {
-    createFromDataURL: vi.fn((dataUrl: string) => ({
+    createFromBuffer: vi.fn(() => ({
+      getSize: () => ({ width: 100, height: 100 }),
       isEmpty: () => false,
-      toPNG: () => Buffer.from(dataUrl.split(',')[1] ?? '', 'base64'),
     })),
   },
 }));
@@ -47,11 +39,31 @@ vi.mock('@electron/shared/media/image-resize', () => ({
 
 import { registerLayoutHandlers } from '@electron/ipc/workspace/layout';
 
-const sender = { send: vi.fn() };
-const event = { sender };
+const event = { sender: { send: vi.fn() } };
 
-function dataUrl(mimeType: 'image/png' | 'image/jpeg', content: string): string {
-  return `data:${mimeType};base64,${Buffer.from(content).toString('base64')}`;
+function pngBytes(marker = 0): Buffer {
+  const buffer = Buffer.alloc(33);
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(buffer);
+  buffer.write('IHDR', 12, 'ascii');
+  buffer.writeUInt32BE(100, 16);
+  buffer.writeUInt32BE(100, 20);
+  buffer[24] = 8;
+  buffer[25] = 6;
+  buffer[32] = marker;
+  return buffer;
+}
+
+function jpegBytes(): Buffer {
+  return Buffer.from([
+    0xff, 0xd8,
+    0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x64, 0x00, 0x64,
+    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x00, 0x03, 0x11, 0x00,
+    0xff, 0xd9,
+  ]);
+}
+
+function imageDataUrl(declaredMimeType: 'image/png' | 'image/jpeg', bytes: Buffer): string {
+  return `data:${declaredMimeType};base64,${bytes.toString('base64')}`;
 }
 
 function handler(channel: string): (...args: unknown[]) => unknown {
@@ -60,8 +72,8 @@ function handler(channel: string): (...args: unknown[]) => unknown {
   return registered;
 }
 
-async function readSavedBackground(extension: 'png' | 'jpg'): Promise<string> {
-  return fs.readFile(path.join(mocks.agentDir, `dashboard-background.${extension}`), 'utf8');
+async function readSavedBackground(): Promise<Buffer> {
+  return fs.readFile(path.join(mocks.agentDir, 'dashboard-background.image'));
 }
 
 describe('dashboard background IPC', () => {
@@ -72,9 +84,9 @@ describe('dashboard background IPC', () => {
   beforeEach(async () => {
     await fs.rm(mocks.agentDir, { recursive: true, force: true });
     await fs.mkdir(mocks.agentDir, { recursive: true });
-    sender.send.mockReset();
+    event.sender.send.mockReset();
     mocks.broadcastToWindows.mockReset();
-    mocks.resizeImageForApi.mockClear();
+    mocks.resizeImageForApi.mockReset();
   });
 
   it('rejects WebP with the stable supported-format error', async () => {
@@ -84,56 +96,88 @@ describe('dashboard background IPC', () => {
     )).rejects.toThrow('PNG or JPEG');
   });
 
-  it('uses the shared image resizer and returns a protocol URL', async () => {
-    mocks.resizeImageForApi.mockReturnValueOnce({
-      data: Buffer.from('bounded').toString('base64'),
-      mimeType: 'image/jpeg',
-      originalWidth: 4000,
-      originalHeight: 3000,
-      width: 1920,
-      height: 1440,
-      wasResized: true,
-    });
-
-    await handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/jpeg', 'large-jpeg'));
-
-    expect(mocks.resizeImageForApi).toHaveBeenCalledWith(
-      Buffer.from('large-jpeg').toString('base64'),
-      'image/jpeg',
-      expect.objectContaining({
-        maxBytes: expect.any(Number),
-        maxWidth: expect.any(Number),
-        maxHeight: expect.any(Number),
-      }),
+  it('persists the original bytes without CPU-bound re-encoding', async () => {
+    const bytes = pngBytes();
+    await handler(IpcChannels.dashboard.setBackground)(
+      event,
+      imageDataUrl('image/png', bytes),
     );
-    expect(await readSavedBackground('jpg')).toBe('bounded');
-    await expect(handler(IpcChannels.dashboard.getBackground)(event)).resolves.toMatch(
-      /^sero-media:\/\/dashboard\/background\.jpg\?v=/,
-    );
+
+    expect(mocks.resizeImageForApi).not.toHaveBeenCalled();
+    expect(await readSavedBackground()).toEqual(bytes);
   });
 
-  it('broadcasts background changes to every window', async () => {
-    await handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/png', 'pixels'));
+  it('preserves transparent PNG bytes', async () => {
+    const transparentPng = pngBytes(42);
+    await handler(IpcChannels.dashboard.setBackground)(
+      event,
+      imageDataUrl('image/png', transparentPng),
+    );
+
+    expect(await readSavedBackground()).toEqual(transparentPng);
+  });
+
+  it('broadcasts a cache-safe media URL to every window', async () => {
+    await handler(IpcChannels.dashboard.setBackground)(
+      event,
+      imageDataUrl('image/png', pngBytes()),
+    );
 
     expect(mocks.broadcastToWindows).toHaveBeenCalledWith(
       IpcChannels.dashboard.backgroundChanged,
-      expect.stringMatching(/^sero-media:\/\/dashboard\/background\.png\?v=/),
+      expect.stringMatching(/^sero-media:\/\/dashboard\/background\?v=/),
     );
-    expect(sender.send).not.toHaveBeenCalled();
+    expect(event.sender.send).not.toHaveBeenCalled();
+
+    const firstUrl = await handler(IpcChannels.dashboard.getBackground)(event);
+    const secondUrl = await handler(IpcChannels.dashboard.getBackground)(event);
+    expect(firstUrl).not.toBe(secondUrl);
   });
 
   it('serializes concurrent background writes', async () => {
-    const now = vi.spyOn(Date, 'now').mockReturnValue(1234);
-    try {
-      await expect(Promise.all([
-        handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/png', 'first')),
-        handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/png', 'second')),
-      ])).resolves.toEqual([undefined, undefined]);
-    } finally {
-      now.mockRestore();
-    }
+    const first = pngBytes(1);
+    const second = pngBytes(2);
+    await expect(Promise.all([
+      handler(IpcChannels.dashboard.setBackground)(event, imageDataUrl('image/png', first)),
+      handler(IpcChannels.dashboard.setBackground)(event, imageDataUrl('image/png', second)),
+    ])).resolves.toEqual([undefined, undefined]);
 
-    expect(await readSavedBackground('png')).toBe('second');
+    expect(await readSavedBackground()).toEqual(second);
+  });
+
+  it('does not run a second-file cleanup after a successful write', async () => {
+    const remove = vi.spyOn(fs, 'rm');
+    try {
+      await handler(IpcChannels.dashboard.setBackground)(
+        event,
+        imageDataUrl('image/png', pngBytes()),
+      );
+
+      expect(remove).not.toHaveBeenCalled();
+    } finally {
+      remove.mockRestore();
+    }
+  });
+
+  it('derives the stored image type from bytes instead of the data URL prefix', async () => {
+    const jpeg = jpegBytes();
+    await handler(IpcChannels.dashboard.setBackground)(
+      event,
+      imageDataUrl('image/png', jpeg),
+    );
+
+    expect(await readSavedBackground()).toEqual(jpeg);
+  });
+
+  it('rejects images above the dashboard dimension limit without encoding', async () => {
+    const oversized = pngBytes();
+    oversized.writeUInt32BE(3000, 16);
+
+    await expect(handler(IpcChannels.dashboard.setBackground)(
+      event,
+      imageDataUrl('image/png', oversized),
+    )).rejects.toThrow('2560 × 1600');
+    expect(mocks.resizeImageForApi).not.toHaveBeenCalled();
   });
 
   it('rejects non-string input with the validation error', async () => {

--- a/apps/desktop/electron/__tests__/ipc/dashboard-background.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/dashboard-background.test.ts
@@ -1,0 +1,144 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IpcChannels } from '@/types/ipc-channels';
+
+const mocks = vi.hoisted(() => ({
+  agentDir: `/tmp/sero-dashboard-background-${process.pid}`,
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  broadcastToWindows: vi.fn(),
+  resizeImageForApi: vi.fn((data: string, mimeType: string) => ({
+    data,
+    mimeType,
+    originalWidth: 100,
+    originalHeight: 100,
+    width: 100,
+    height: 100,
+    wasResized: false,
+  })),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      mocks.handlers.set(channel, handler);
+    }),
+  },
+  nativeImage: {
+    createFromDataURL: vi.fn((dataUrl: string) => ({
+      isEmpty: () => false,
+      toPNG: () => Buffer.from(dataUrl.split(',')[1] ?? '', 'base64'),
+    })),
+  },
+}));
+
+vi.mock('@electron/platform/env', () => ({
+  SERO_AGENT_DIR: mocks.agentDir,
+}));
+
+vi.mock('@electron/ipc/lib/window-broadcast', () => ({
+  broadcastToWindows: mocks.broadcastToWindows,
+}));
+
+vi.mock('@electron/shared/media/image-resize', () => ({
+  resizeImageForApi: mocks.resizeImageForApi,
+}));
+
+import { registerLayoutHandlers } from '@electron/ipc/workspace/layout';
+
+const sender = { send: vi.fn() };
+const event = { sender };
+
+function dataUrl(mimeType: 'image/png' | 'image/jpeg', content: string): string {
+  return `data:${mimeType};base64,${Buffer.from(content).toString('base64')}`;
+}
+
+function handler(channel: string): (...args: unknown[]) => unknown {
+  const registered = mocks.handlers.get(channel);
+  if (!registered) throw new Error(`Missing IPC handler: ${channel}`);
+  return registered;
+}
+
+async function readSavedBackground(extension: 'png' | 'jpg'): Promise<string> {
+  return fs.readFile(path.join(mocks.agentDir, `dashboard-background.${extension}`), 'utf8');
+}
+
+describe('dashboard background IPC', () => {
+  beforeAll(() => {
+    registerLayoutHandlers();
+  });
+
+  beforeEach(async () => {
+    await fs.rm(mocks.agentDir, { recursive: true, force: true });
+    await fs.mkdir(mocks.agentDir, { recursive: true });
+    sender.send.mockReset();
+    mocks.broadcastToWindows.mockReset();
+    mocks.resizeImageForApi.mockClear();
+  });
+
+  it('rejects WebP with the stable supported-format error', async () => {
+    await expect(handler(IpcChannels.dashboard.setBackground)(
+      event,
+      'data:image/webp;base64,d2VicA==',
+    )).rejects.toThrow('PNG or JPEG');
+  });
+
+  it('uses the shared image resizer and returns a protocol URL', async () => {
+    mocks.resizeImageForApi.mockReturnValueOnce({
+      data: Buffer.from('bounded').toString('base64'),
+      mimeType: 'image/jpeg',
+      originalWidth: 4000,
+      originalHeight: 3000,
+      width: 1920,
+      height: 1440,
+      wasResized: true,
+    });
+
+    await handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/jpeg', 'large-jpeg'));
+
+    expect(mocks.resizeImageForApi).toHaveBeenCalledWith(
+      Buffer.from('large-jpeg').toString('base64'),
+      'image/jpeg',
+      expect.objectContaining({
+        maxBytes: expect.any(Number),
+        maxWidth: expect.any(Number),
+        maxHeight: expect.any(Number),
+      }),
+    );
+    expect(await readSavedBackground('jpg')).toBe('bounded');
+    await expect(handler(IpcChannels.dashboard.getBackground)(event)).resolves.toMatch(
+      /^sero-media:\/\/dashboard\/background\.jpg\?v=/,
+    );
+  });
+
+  it('broadcasts background changes to every window', async () => {
+    await handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/png', 'pixels'));
+
+    expect(mocks.broadcastToWindows).toHaveBeenCalledWith(
+      IpcChannels.dashboard.backgroundChanged,
+      expect.stringMatching(/^sero-media:\/\/dashboard\/background\.png\?v=/),
+    );
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it('serializes concurrent background writes', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1234);
+    try {
+      await expect(Promise.all([
+        handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/png', 'first')),
+        handler(IpcChannels.dashboard.setBackground)(event, dataUrl('image/png', 'second')),
+      ])).resolves.toEqual([undefined, undefined]);
+    } finally {
+      now.mockRestore();
+    }
+
+    expect(await readSavedBackground('png')).toBe('second');
+  });
+
+  it('rejects non-string input with the validation error', async () => {
+    await expect(handler(IpcChannels.dashboard.setBackground)(event, undefined)).rejects.toThrow(
+      'Dashboard background must be a PNG or JPEG data URL',
+    );
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/preload-api-subscriptions.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/preload-api-subscriptions.test.ts
@@ -17,6 +17,7 @@ import { agentBridge, workspaceBridge } from '@electron/preload/api/core';
 import { filetreeBridge, vcsBridge } from '@electron/preload/api/workbench';
 import { lspBridge } from '@electron/preload/editor/debug-lsp';
 import { pluginsBridge } from '@electron/preload/integrations/plugins';
+import { dashboardBridge } from '@electron/preload/platform/host-services';
 
 describe('preload event bridge subscriptions', () => {
   beforeEach(() => {
@@ -178,6 +179,29 @@ describe('preload event bridge subscriptions', () => {
 
     expect(mocks.ipcRenderer.removeListener).toHaveBeenCalledWith(
       IpcChannels.plugins.event,
+      handler,
+    );
+  });
+
+  it('sends dashboard backgrounds and forwards change events', async () => {
+    const callback = vi.fn();
+    const unsubscribe = dashboardBridge.onBackgroundChanged(callback);
+    const handler = mocks.ipcRenderer.on.mock.calls.at(-1)?.[1];
+
+    handler?.({}, 'data:image/png;base64,cGl4ZWxz');
+    expect(callback).toHaveBeenCalledWith('data:image/png;base64,cGl4ZWxz');
+
+    await dashboardBridge.setBackground('data:image/png;base64,cGl4ZWxz');
+    await dashboardBridge.getBackground();
+    unsubscribe();
+
+    expect(mocks.ipcRenderer.invoke).toHaveBeenCalledWith(
+      IpcChannels.dashboard.setBackground,
+      'data:image/png;base64,cGl4ZWxz',
+    );
+    expect(mocks.ipcRenderer.invoke).toHaveBeenCalledWith(IpcChannels.dashboard.getBackground);
+    expect(mocks.ipcRenderer.removeListener).toHaveBeenCalledWith(
+      IpcChannels.dashboard.backgroundChanged,
       handler,
     );
   });

--- a/apps/desktop/electron/__tests__/platform/csp.test.ts
+++ b/apps/desktop/electron/__tests__/platform/csp.test.ts
@@ -21,7 +21,7 @@ describe('content security policy', () => {
     expect(csp).toContain("frame-src 'self' blob: http://localhost:* http://127.0.0.1:* sero-ext:");
     expect(csp).toContain("child-src 'self' blob: http://localhost:* http://127.0.0.1:* sero-ext:");
     expect(csp).toContain("connect-src 'self' blob:");
-    expect(csp).toContain("img-src 'self' data: blob: https: http: sero-ext:");
+    expect(csp).toContain("img-src 'self' data: blob: https: http: sero-ext: sero-media:");
     expect(csp).toContain("media-src 'self' blob:");
     // Concatenate these terms so source scans do not false-positive on this test.
     for (const blockedSource of ['spot' + 'ify', 's' + 'cdn']) {

--- a/apps/desktop/electron/__tests__/platform/host-media-protocol.test.ts
+++ b/apps/desktop/electron/__tests__/platform/host-media-protocol.test.ts
@@ -21,6 +21,15 @@ vi.mock('@electron/platform/env', () => ({
 
 import { setupHostMediaProtocol } from '@electron/platform/protocols/host-media-protocol';
 
+function jpegBytes(): Buffer {
+  return Buffer.from([
+    0xff, 0xd8,
+    0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x64, 0x00, 0x64,
+    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x00, 0x03, 0x11, 0x00,
+    0xff, 0xd9,
+  ]);
+}
+
 describe('host media protocol', () => {
   beforeEach(async () => {
     await fs.rm(mocks.agentDir, { recursive: true, force: true });
@@ -28,17 +37,37 @@ describe('host media protocol', () => {
     mocks.protocolHandler = null;
   });
 
-  it('serves the dashboard background with its image content type', async () => {
-    await fs.writeFile(path.join(mocks.agentDir, 'dashboard-background.png'), Buffer.from('pixels'));
+  it('serves the dashboard background with a byte-derived content type and no cache', async () => {
+    const jpeg = jpegBytes();
+    await fs.writeFile(path.join(mocks.agentDir, 'dashboard-background.image'), jpeg);
     setupHostMediaProtocol();
 
     const response = await mocks.protocolHandler!(
-      new Request('sero-media://dashboard/background.png?v=1'),
+      new Request('sero-media://dashboard/background?v=1'),
     );
 
     expect(response.status).toBe(200);
-    expect(response.headers.get('content-type')).toBe('image/png');
-    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe('pixels');
+    expect(response.headers.get('content-type')).toBe('image/jpeg');
+    expect(response.headers.get('cache-control')).toBe('no-store');
+    expect(response.headers.get('access-control-allow-origin')).toBe('*');
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(jpeg);
+  });
+
+  it('maps a delete race to a 404 response', async () => {
+    await fs.writeFile(path.join(mocks.agentDir, 'dashboard-background.image'), jpegBytes());
+    setupHostMediaProtocol();
+    const readFile = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(
+      Object.assign(new Error('missing'), { code: 'ENOENT' }),
+    );
+
+    try {
+      const response = await mocks.protocolHandler!(
+        new Request('sero-media://dashboard/background?v=1'),
+      );
+      expect(response.status).toBe(404);
+    } finally {
+      readFile.mockRestore();
+    }
   });
 
   it('does not expose other profile files', async () => {

--- a/apps/desktop/electron/__tests__/platform/host-media-protocol.test.ts
+++ b/apps/desktop/electron/__tests__/platform/host-media-protocol.test.ts
@@ -1,0 +1,54 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  agentDir: `/tmp/sero-host-media-${process.pid}`,
+  protocolHandler: null as ((request: Request) => Promise<Response>) | null,
+}));
+
+vi.mock('electron', () => ({
+  protocol: {
+    handle: vi.fn((_scheme: string, handler: (request: Request) => Promise<Response>) => {
+      mocks.protocolHandler = handler;
+    }),
+  },
+}));
+
+vi.mock('@electron/platform/env', () => ({
+  SERO_AGENT_DIR: mocks.agentDir,
+}));
+
+import { setupHostMediaProtocol } from '@electron/platform/protocols/host-media-protocol';
+
+describe('host media protocol', () => {
+  beforeEach(async () => {
+    await fs.rm(mocks.agentDir, { recursive: true, force: true });
+    await fs.mkdir(mocks.agentDir, { recursive: true });
+    mocks.protocolHandler = null;
+  });
+
+  it('serves the dashboard background with its image content type', async () => {
+    await fs.writeFile(path.join(mocks.agentDir, 'dashboard-background.png'), Buffer.from('pixels'));
+    setupHostMediaProtocol();
+
+    const response = await mocks.protocolHandler!(
+      new Request('sero-media://dashboard/background.png?v=1'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('image/png');
+    expect(Buffer.from(await response.arrayBuffer()).toString()).toBe('pixels');
+  });
+
+  it('does not expose other profile files', async () => {
+    await fs.writeFile(path.join(mocks.agentDir, 'layout.json'), '{}');
+    setupHostMediaProtocol();
+
+    const response = await mocks.protocolHandler!(
+      new Request('sero-media://dashboard/../layout.json'),
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/apps/desktop/electron/__tests__/shared/media/dashboard-background-image.test.ts
+++ b/apps/desktop/electron/__tests__/shared/media/dashboard-background-image.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { inspectDashboardBackgroundImage } from '@electron/shared/media/dashboard-background-image';
+
+function pngBytes(width: number, height: number, colorType: number): Buffer {
+  const buffer = Buffer.alloc(33);
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(buffer);
+  buffer.write('IHDR', 12, 'ascii');
+  buffer.writeUInt32BE(width, 16);
+  buffer.writeUInt32BE(height, 20);
+  buffer[24] = 8;
+  buffer[25] = colorType;
+  return buffer;
+}
+
+function jpegBytes(width: number, height: number): Buffer {
+  return Buffer.from([
+    0xff, 0xd8,
+    0xff, 0xe0, 0x00, 0x04, 0x00, 0x00,
+    0xff, 0xc0, 0x00, 0x11, 0x08,
+    (height >> 8) & 0xff, height & 0xff,
+    (width >> 8) & 0xff, width & 0xff,
+    0x03, 0x01, 0x11, 0x00, 0x02, 0x11, 0x00, 0x03, 0x11, 0x00,
+    0xff, 0xd9,
+  ]);
+}
+
+describe('dashboard background image inspection', () => {
+  it('reads PNG dimensions and type from bytes', () => {
+    expect(inspectDashboardBackgroundImage(pngBytes(800, 600, 6))).toEqual({
+      mimeType: 'image/png',
+      width: 800,
+      height: 600,
+    });
+  });
+
+  it('reads JPEG dimensions and type after metadata segments', () => {
+    expect(inspectDashboardBackgroundImage(jpegBytes(1920, 1080))).toEqual({
+      mimeType: 'image/jpeg',
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it('rejects unsupported or malformed bytes', () => {
+    expect(inspectDashboardBackgroundImage(Buffer.from('not an image'))).toBeNull();
+    expect(inspectDashboardBackgroundImage(Buffer.from([0xff, 0xd8, 0xff, 0xd9]))).toBeNull();
+  });
+});

--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -57,6 +57,7 @@ import {
 import { disposeAllAgentSessions } from './ipc/agent/core/agent';
 import { workspaceManager } from './features/workspace/manager';
 import { setupExtProtocol, registerAllExtAssets } from './platform/protocols/ext-protocol';
+import { setupHostMediaProtocol } from './platform/protocols/host-media-protocol';
 import { discoverApps, registerAppPath } from './features/apps/discovery';
 import { watchForNewApps } from './ipc/apps/apps';
 import { ensureBundledPiDocs, ensureDefaultAgents, ensureDefaultSkills, ensureDefaultThemes, ensureProfileTemplates } from './features/profile/setup';
@@ -288,8 +289,9 @@ app.whenReady().then(async () => {
   // Init workspace registry + default workspaces before anything else
   await workspaceManager.init();
 
-  // Set up custom protocol for serving extension UI assets
+  // Set up custom protocols for extension UI assets and profile-owned media.
   setupExtProtocol();
+  setupHostMediaProtocol();
 
   // Ensure built-in app packages and workspace plugins are in settings.json.
   ensureBuiltinPackages();

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -5,7 +5,7 @@
  * to prevent corruption from concurrent saves.
  */
 
-import { ipcMain } from 'electron';
+import { ipcMain, nativeImage } from 'electron';
 import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'fs';
 import { existsSync, mkdirSync } from 'fs';
@@ -14,19 +14,18 @@ import { IpcChannels } from '@/types/ipc-channels';
 import type { LayoutState, LoadedLayoutState } from '@/types/layout';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
 import { broadcastToWindows } from '@electron/ipc/lib/window-broadcast';
-import { resizeImageForApi } from '@electron/shared/media/image-resize';
 import {
   getDashboardBackgroundPath,
   getDashboardBackgroundUrl,
-  getOtherDashboardBackgroundPath,
-  type DashboardBackgroundMimeType,
 } from '@electron/platform/protocols/host-media-protocol';
+import { inspectDashboardBackgroundImage } from '@electron/shared/media/dashboard-background-image';
 
 export type { LayoutState, LoadedLayoutState };
 
 const LAYOUT_FILE = path.join(SERO_AGENT_DIR, 'layout.json');
-const MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH = 64 * 1024 * 1024;
 const MAX_DASHBOARD_BACKGROUND_BYTES = 4 * 1024 * 1024;
+const MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH =
+  Math.ceil(MAX_DASHBOARD_BACKGROUND_BYTES * 4 / 3) + 64;
 const MAX_DASHBOARD_BACKGROUND_WIDTH = 2560;
 const MAX_DASHBOARD_BACKGROUND_HEIGHT = 1600;
 
@@ -147,12 +146,10 @@ async function saveLayoutFile(state: LayoutState): Promise<void> {
 
 async function setDashboardBackground(dataUrl: unknown): Promise<string | null> {
   mkdirSync(SERO_AGENT_DIR, { recursive: true });
+  const targetFile = getDashboardBackgroundPath();
 
   if (dataUrl === null) {
-    await Promise.all([
-      fs.rm(getDashboardBackgroundPath('image/png'), { force: true }),
-      fs.rm(getDashboardBackgroundPath('image/jpeg'), { force: true }),
-    ]);
+    await fs.rm(targetFile, { force: true });
     return null;
   }
 
@@ -160,57 +157,46 @@ async function setDashboardBackground(dataUrl: unknown): Promise<string | null> 
     typeof dataUrl !== 'string'
     || dataUrl.length > MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH
   ) {
-    throw new Error('Dashboard background must be a PNG or JPEG data URL under 64 MB');
+    throw new Error('Dashboard background must be a PNG or JPEG data URL under 4 MB');
   }
-  const match = /^data:(image\/(?:png|jpeg));base64,(.+)$/i.exec(dataUrl);
+  const match = /^data:image\/(?:png|jpeg);base64,(.+)$/i.exec(dataUrl);
   if (!match) {
-    throw new Error('Dashboard background must be a PNG or JPEG data URL under 64 MB');
+    throw new Error('Dashboard background must be a PNG or JPEG data URL under 4 MB');
   }
 
-  const sourceMimeType = match[1]!.toLowerCase() as DashboardBackgroundMimeType;
-  const resized = resizeImageForApi(match[2]!, sourceMimeType, {
-    maxBytes: MAX_DASHBOARD_BACKGROUND_BYTES,
-    maxWidth: MAX_DASHBOARD_BACKGROUND_WIDTH,
-    maxHeight: MAX_DASHBOARD_BACKGROUND_HEIGHT,
-  });
+  const encoded = Buffer.from(match[1]!, 'base64');
+  if (encoded.length === 0 || encoded.length > MAX_DASHBOARD_BACKGROUND_BYTES) {
+    throw new Error('Dashboard background must be a PNG or JPEG data URL under 4 MB');
+  }
+
+  const imageInfo = inspectDashboardBackgroundImage(encoded);
+  if (!imageInfo) throw new Error('Dashboard background image is invalid');
   if (
-    resized.width <= 0
-    || resized.height <= 0
-    || resized.width > MAX_DASHBOARD_BACKGROUND_WIDTH
-    || resized.height > MAX_DASHBOARD_BACKGROUND_HEIGHT
-    || (resized.mimeType !== 'image/png' && resized.mimeType !== 'image/jpeg')
+    imageInfo.width > MAX_DASHBOARD_BACKGROUND_WIDTH
+    || imageInfo.height > MAX_DASHBOARD_BACKGROUND_HEIGHT
+  ) {
+    throw new Error('Dashboard background image must be 2560 × 1600 or smaller');
+  }
+
+  const decodedImage = nativeImage.createFromBuffer(encoded);
+  const decodedSize = decodedImage.getSize();
+  if (
+    decodedImage.isEmpty()
+    || decodedSize.width !== imageInfo.width
+    || decodedSize.height !== imageInfo.height
   ) {
     throw new Error('Dashboard background image is invalid');
   }
 
-  const encoded = Buffer.from(resized.data, 'base64');
-  if (encoded.length === 0 || encoded.length > MAX_DASHBOARD_BACKGROUND_BYTES) {
-    throw new Error('Dashboard background cannot be reduced below 4 MB');
-  }
-
-  const mimeType = resized.mimeType;
-  const targetFile = getDashboardBackgroundPath(mimeType);
   const tmpFile = `${targetFile}.${process.pid}.${randomUUID()}.tmp`;
   await fs.writeFile(tmpFile, encoded);
   await fs.rename(tmpFile, targetFile);
-  await fs.rm(getOtherDashboardBackgroundPath(mimeType), { force: true });
-
-  const stat = await fs.stat(targetFile);
-  return getDashboardBackgroundUrl(mimeType, `${stat.mtimeMs}-${stat.size}`);
+  return getDashboardBackgroundUrl(randomUUID());
 }
 
-async function getDashboardBackground(): Promise<string | null> {
-  let newest: { mimeType: DashboardBackgroundMimeType; mtimeMs: number; size: number } | null = null;
-  for (const mimeType of ['image/png', 'image/jpeg'] as const) {
-    const filePath = getDashboardBackgroundPath(mimeType);
-    if (!existsSync(filePath)) continue;
-    const stat = await fs.stat(filePath);
-    if (!newest || stat.mtimeMs > newest.mtimeMs) {
-      newest = { mimeType, mtimeMs: stat.mtimeMs, size: stat.size };
-    }
-  }
-  return newest
-    ? getDashboardBackgroundUrl(newest.mimeType, `${newest.mtimeMs}-${newest.size}`)
+function getDashboardBackground(): string | null {
+  return existsSync(getDashboardBackgroundPath())
+    ? getDashboardBackgroundUrl(randomUUID())
     : null;
 }
 

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -28,6 +28,11 @@ const MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH =
   Math.ceil(MAX_DASHBOARD_BACKGROUND_BYTES * 4 / 3) + 64;
 const MAX_DASHBOARD_BACKGROUND_WIDTH = 2560;
 const MAX_DASHBOARD_BACKGROUND_HEIGHT = 1600;
+const DASHBOARD_BACKGROUND_INPUT_ERROR =
+  'Dashboard background must be a PNG or JPEG data URL under 4 MB';
+const DASHBOARD_BACKGROUND_IMAGE_ERROR = 'Dashboard background image is invalid';
+const DASHBOARD_BACKGROUND_DIMENSIONS_ERROR =
+  'Dashboard background image must be 2560 × 1600 or smaller';
 
 let writeQueue: Promise<void> = Promise.resolve();
 let backgroundWriteQueue: Promise<string | null> = Promise.resolve(null);
@@ -144,6 +149,29 @@ async function saveLayoutFile(state: LayoutState): Promise<void> {
   await fs.rename(tmpFile, LAYOUT_FILE);
 }
 
+function dashboardBackgroundValidationError(encoded: Buffer): string | null {
+  if (encoded.length === 0 || encoded.length > MAX_DASHBOARD_BACKGROUND_BYTES) {
+    return DASHBOARD_BACKGROUND_INPUT_ERROR;
+  }
+
+  const imageInfo = inspectDashboardBackgroundImage(encoded);
+  if (!imageInfo) return DASHBOARD_BACKGROUND_IMAGE_ERROR;
+  if (
+    imageInfo.width > MAX_DASHBOARD_BACKGROUND_WIDTH
+    || imageInfo.height > MAX_DASHBOARD_BACKGROUND_HEIGHT
+  ) {
+    return DASHBOARD_BACKGROUND_DIMENSIONS_ERROR;
+  }
+
+  const decodedImage = nativeImage.createFromBuffer(encoded);
+  const decodedSize = decodedImage.getSize();
+  return decodedImage.isEmpty()
+    || decodedSize.width !== imageInfo.width
+    || decodedSize.height !== imageInfo.height
+    ? DASHBOARD_BACKGROUND_IMAGE_ERROR
+    : null;
+}
+
 async function setDashboardBackground(dataUrl: unknown): Promise<string | null> {
   mkdirSync(SERO_AGENT_DIR, { recursive: true });
   const targetFile = getDashboardBackgroundPath();
@@ -157,36 +185,16 @@ async function setDashboardBackground(dataUrl: unknown): Promise<string | null> 
     typeof dataUrl !== 'string'
     || dataUrl.length > MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH
   ) {
-    throw new Error('Dashboard background must be a PNG or JPEG data URL under 4 MB');
+    throw new Error(DASHBOARD_BACKGROUND_INPUT_ERROR);
   }
   const match = /^data:image\/(?:png|jpeg);base64,(.+)$/i.exec(dataUrl);
   if (!match) {
-    throw new Error('Dashboard background must be a PNG or JPEG data URL under 4 MB');
+    throw new Error(DASHBOARD_BACKGROUND_INPUT_ERROR);
   }
 
   const encoded = Buffer.from(match[1]!, 'base64');
-  if (encoded.length === 0 || encoded.length > MAX_DASHBOARD_BACKGROUND_BYTES) {
-    throw new Error('Dashboard background must be a PNG or JPEG data URL under 4 MB');
-  }
-
-  const imageInfo = inspectDashboardBackgroundImage(encoded);
-  if (!imageInfo) throw new Error('Dashboard background image is invalid');
-  if (
-    imageInfo.width > MAX_DASHBOARD_BACKGROUND_WIDTH
-    || imageInfo.height > MAX_DASHBOARD_BACKGROUND_HEIGHT
-  ) {
-    throw new Error('Dashboard background image must be 2560 × 1600 or smaller');
-  }
-
-  const decodedImage = nativeImage.createFromBuffer(encoded);
-  const decodedSize = decodedImage.getSize();
-  if (
-    decodedImage.isEmpty()
-    || decodedSize.width !== imageInfo.width
-    || decodedSize.height !== imageInfo.height
-  ) {
-    throw new Error('Dashboard background image is invalid');
-  }
+  const validationError = dashboardBackgroundValidationError(encoded);
+  if (validationError) throw new Error(validationError);
 
   const tmpFile = `${targetFile}.${process.pid}.${randomUUID()}.tmp`;
   await fs.writeFile(tmpFile, encoded);
@@ -194,10 +202,10 @@ async function setDashboardBackground(dataUrl: unknown): Promise<string | null> 
   return getDashboardBackgroundUrl(randomUUID());
 }
 
-function getDashboardBackground(): string | null {
-  return existsSync(getDashboardBackgroundPath())
-    ? getDashboardBackgroundUrl(randomUUID())
-    : null;
+async function getDashboardBackground(): Promise<string | null> {
+  const encoded = await fs.readFile(getDashboardBackgroundPath()).catch(() => null);
+  if (!encoded || dashboardBackgroundValidationError(encoded)) return null;
+  return getDashboardBackgroundUrl(randomUUID());
 }
 
 export function registerLayoutHandlers(): void {

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -5,21 +5,33 @@
  * to prevent corruption from concurrent saves.
  */
 
-import { ipcMain, nativeImage } from 'electron';
+import { ipcMain } from 'electron';
+import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'fs';
 import { existsSync, mkdirSync } from 'fs';
 import path from 'path';
 import { IpcChannels } from '@/types/ipc-channels';
 import type { LayoutState, LoadedLayoutState } from '@/types/layout';
 import { SERO_AGENT_DIR } from '@electron/platform/env';
+import { broadcastToWindows } from '@electron/ipc/lib/window-broadcast';
+import { resizeImageForApi } from '@electron/shared/media/image-resize';
+import {
+  getDashboardBackgroundPath,
+  getDashboardBackgroundUrl,
+  getOtherDashboardBackgroundPath,
+  type DashboardBackgroundMimeType,
+} from '@electron/platform/protocols/host-media-protocol';
 
 export type { LayoutState, LoadedLayoutState };
 
 const LAYOUT_FILE = path.join(SERO_AGENT_DIR, 'layout.json');
-const DASHBOARD_BACKGROUND_FILE = path.join(SERO_AGENT_DIR, 'dashboard-background.png');
 const MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH = 64 * 1024 * 1024;
+const MAX_DASHBOARD_BACKGROUND_BYTES = 4 * 1024 * 1024;
+const MAX_DASHBOARD_BACKGROUND_WIDTH = 2560;
+const MAX_DASHBOARD_BACKGROUND_HEIGHT = 1600;
 
 let writeQueue: Promise<void> = Promise.resolve();
+let backgroundWriteQueue: Promise<string | null> = Promise.resolve(null);
 
 function isOptionalArray(value: unknown): boolean {
   return value === undefined || Array.isArray(value);
@@ -133,37 +145,73 @@ async function saveLayoutFile(state: LayoutState): Promise<void> {
   await fs.rename(tmpFile, LAYOUT_FILE);
 }
 
-async function setDashboardBackground(dataUrl: string | null): Promise<string | null> {
+async function setDashboardBackground(dataUrl: unknown): Promise<string | null> {
   mkdirSync(SERO_AGENT_DIR, { recursive: true });
 
   if (dataUrl === null) {
-    await fs.rm(DASHBOARD_BACKGROUND_FILE, { force: true });
+    await Promise.all([
+      fs.rm(getDashboardBackgroundPath('image/png'), { force: true }),
+      fs.rm(getDashboardBackgroundPath('image/jpeg'), { force: true }),
+    ]);
     return null;
   }
 
   if (
-    dataUrl.length > MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH
-    || !/^data:image\/(?:png|jpeg|webp);base64,/i.test(dataUrl)
+    typeof dataUrl !== 'string'
+    || dataUrl.length > MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH
   ) {
-    throw new Error('Dashboard background must be a PNG, JPEG, or WebP data URL under 64 MB');
+    throw new Error('Dashboard background must be a PNG or JPEG data URL under 64 MB');
+  }
+  const match = /^data:(image\/(?:png|jpeg));base64,(.+)$/i.exec(dataUrl);
+  if (!match) {
+    throw new Error('Dashboard background must be a PNG or JPEG data URL under 64 MB');
   }
 
-  const image = nativeImage.createFromDataURL(dataUrl);
-  if (image.isEmpty()) {
+  const sourceMimeType = match[1]!.toLowerCase() as DashboardBackgroundMimeType;
+  const resized = resizeImageForApi(match[2]!, sourceMimeType, {
+    maxBytes: MAX_DASHBOARD_BACKGROUND_BYTES,
+    maxWidth: MAX_DASHBOARD_BACKGROUND_WIDTH,
+    maxHeight: MAX_DASHBOARD_BACKGROUND_HEIGHT,
+  });
+  if (
+    resized.width <= 0
+    || resized.height <= 0
+    || resized.width > MAX_DASHBOARD_BACKGROUND_WIDTH
+    || resized.height > MAX_DASHBOARD_BACKGROUND_HEIGHT
+    || (resized.mimeType !== 'image/png' && resized.mimeType !== 'image/jpeg')
+  ) {
     throw new Error('Dashboard background image is invalid');
   }
 
-  const png = image.toPNG();
-  const tmpFile = `${DASHBOARD_BACKGROUND_FILE}.${process.pid}.${Date.now()}.tmp`;
-  await fs.writeFile(tmpFile, png);
-  await fs.rename(tmpFile, DASHBOARD_BACKGROUND_FILE);
-  return `data:image/png;base64,${png.toString('base64')}`;
+  const encoded = Buffer.from(resized.data, 'base64');
+  if (encoded.length === 0 || encoded.length > MAX_DASHBOARD_BACKGROUND_BYTES) {
+    throw new Error('Dashboard background cannot be reduced below 4 MB');
+  }
+
+  const mimeType = resized.mimeType;
+  const targetFile = getDashboardBackgroundPath(mimeType);
+  const tmpFile = `${targetFile}.${process.pid}.${randomUUID()}.tmp`;
+  await fs.writeFile(tmpFile, encoded);
+  await fs.rename(tmpFile, targetFile);
+  await fs.rm(getOtherDashboardBackgroundPath(mimeType), { force: true });
+
+  const stat = await fs.stat(targetFile);
+  return getDashboardBackgroundUrl(mimeType, `${stat.mtimeMs}-${stat.size}`);
 }
 
 async function getDashboardBackground(): Promise<string | null> {
-  if (!existsSync(DASHBOARD_BACKGROUND_FILE)) return null;
-  const png = await fs.readFile(DASHBOARD_BACKGROUND_FILE);
-  return `data:image/png;base64,${png.toString('base64')}`;
+  let newest: { mimeType: DashboardBackgroundMimeType; mtimeMs: number; size: number } | null = null;
+  for (const mimeType of ['image/png', 'image/jpeg'] as const) {
+    const filePath = getDashboardBackgroundPath(mimeType);
+    if (!existsSync(filePath)) continue;
+    const stat = await fs.stat(filePath);
+    if (!newest || stat.mtimeMs > newest.mtimeMs) {
+      newest = { mimeType, mtimeMs: stat.mtimeMs, size: stat.size };
+    }
+  }
+  return newest
+    ? getDashboardBackgroundUrl(newest.mimeType, `${newest.mtimeMs}-${newest.size}`)
+    : null;
 }
 
 export function registerLayoutHandlers(): void {
@@ -193,9 +241,13 @@ export function registerLayoutHandlers(): void {
 
   ipcMain.handle(
     IpcChannels.dashboard.setBackground,
-    async (event, dataUrl: string | null) => {
-      const background = await setDashboardBackground(dataUrl);
-      event.sender.send(IpcChannels.dashboard.backgroundChanged, background);
+    async (_event, dataUrl: unknown) => {
+      backgroundWriteQueue = backgroundWriteQueue.then(
+        () => setDashboardBackground(dataUrl),
+        () => setDashboardBackground(dataUrl),
+      );
+      const background = await backgroundWriteQueue;
+      broadcastToWindows(IpcChannels.dashboard.backgroundChanged, background);
     },
   );
 

--- a/apps/desktop/electron/ipc/workspace/layout.ts
+++ b/apps/desktop/electron/ipc/workspace/layout.ts
@@ -5,7 +5,7 @@
  * to prevent corruption from concurrent saves.
  */
 
-import { ipcMain } from 'electron';
+import { ipcMain, nativeImage } from 'electron';
 import { promises as fs } from 'fs';
 import { existsSync, mkdirSync } from 'fs';
 import path from 'path';
@@ -16,6 +16,8 @@ import { SERO_AGENT_DIR } from '@electron/platform/env';
 export type { LayoutState, LoadedLayoutState };
 
 const LAYOUT_FILE = path.join(SERO_AGENT_DIR, 'layout.json');
+const DASHBOARD_BACKGROUND_FILE = path.join(SERO_AGENT_DIR, 'dashboard-background.png');
+const MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH = 64 * 1024 * 1024;
 
 let writeQueue: Promise<void> = Promise.resolve();
 
@@ -131,6 +133,39 @@ async function saveLayoutFile(state: LayoutState): Promise<void> {
   await fs.rename(tmpFile, LAYOUT_FILE);
 }
 
+async function setDashboardBackground(dataUrl: string | null): Promise<string | null> {
+  mkdirSync(SERO_AGENT_DIR, { recursive: true });
+
+  if (dataUrl === null) {
+    await fs.rm(DASHBOARD_BACKGROUND_FILE, { force: true });
+    return null;
+  }
+
+  if (
+    dataUrl.length > MAX_DASHBOARD_BACKGROUND_DATA_URL_LENGTH
+    || !/^data:image\/(?:png|jpeg|webp);base64,/i.test(dataUrl)
+  ) {
+    throw new Error('Dashboard background must be a PNG, JPEG, or WebP data URL under 64 MB');
+  }
+
+  const image = nativeImage.createFromDataURL(dataUrl);
+  if (image.isEmpty()) {
+    throw new Error('Dashboard background image is invalid');
+  }
+
+  const png = image.toPNG();
+  const tmpFile = `${DASHBOARD_BACKGROUND_FILE}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpFile, png);
+  await fs.rename(tmpFile, DASHBOARD_BACKGROUND_FILE);
+  return `data:image/png;base64,${png.toString('base64')}`;
+}
+
+async function getDashboardBackground(): Promise<string | null> {
+  if (!existsSync(DASHBOARD_BACKGROUND_FILE)) return null;
+  const png = await fs.readFile(DASHBOARD_BACKGROUND_FILE);
+  return `data:image/png;base64,${png.toString('base64')}`;
+}
+
 export function registerLayoutHandlers(): void {
   ipcMain.handle(
     IpcChannels.layout.save,
@@ -154,5 +189,18 @@ export function registerLayoutHandlers(): void {
         return null;
       }
     },
+  );
+
+  ipcMain.handle(
+    IpcChannels.dashboard.setBackground,
+    async (event, dataUrl: string | null) => {
+      const background = await setDashboardBackground(dataUrl);
+      event.sender.send(IpcChannels.dashboard.backgroundChanged, background);
+    },
+  );
+
+  ipcMain.handle(
+    IpcChannels.dashboard.getBackground,
+    () => getDashboardBackground(),
   );
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -60,6 +60,7 @@ protocol.registerSchemesAsPrivileged([
       standard: true,
       secure: true,
       supportFetchAPI: true,
+      corsEnabled: true,
     },
   },
 ]);

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -54,6 +54,14 @@ protocol.registerSchemesAsPrivileged([
       corsEnabled: true,
     },
   },
+  {
+    scheme: 'sero-media',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+    },
+  },
 ]);
 
 async function bootstrap(): Promise<void> {

--- a/apps/desktop/electron/platform/protocols/host-media-protocol.ts
+++ b/apps/desktop/electron/platform/protocols/host-media-protocol.ts
@@ -1,0 +1,60 @@
+import { protocol } from 'electron';
+import { existsSync, promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { SERO_AGENT_DIR } from '@electron/platform/env';
+
+export type DashboardBackgroundMimeType = 'image/png' | 'image/jpeg';
+
+const DASHBOARD_BACKGROUND_PATHS: Record<DashboardBackgroundMimeType, string> = {
+  'image/png': path.join(SERO_AGENT_DIR, 'dashboard-background.png'),
+  'image/jpeg': path.join(SERO_AGENT_DIR, 'dashboard-background.jpg'),
+};
+
+const DASHBOARD_BACKGROUND_MIME_BY_PATH: Record<string, DashboardBackgroundMimeType> = {
+  '/background.png': 'image/png',
+  '/background.jpg': 'image/jpeg',
+};
+
+export function getDashboardBackgroundPath(mimeType: DashboardBackgroundMimeType): string {
+  return DASHBOARD_BACKGROUND_PATHS[mimeType];
+}
+
+export function getOtherDashboardBackgroundPath(mimeType: DashboardBackgroundMimeType): string {
+  return mimeType === 'image/png'
+    ? DASHBOARD_BACKGROUND_PATHS['image/jpeg']
+    : DASHBOARD_BACKGROUND_PATHS['image/png'];
+}
+
+export function getDashboardBackgroundUrl(
+  mimeType: DashboardBackgroundMimeType,
+  version: string,
+): string {
+  const extension = mimeType === 'image/png' ? 'png' : 'jpg';
+  return `sero-media://dashboard/background.${extension}?v=${encodeURIComponent(version)}`;
+}
+
+export function setupHostMediaProtocol(): void {
+  protocol.handle('sero-media', async (request) => {
+    const url = new URL(request.url);
+    const mimeType = url.hostname === 'dashboard'
+      ? DASHBOARD_BACKGROUND_MIME_BY_PATH[url.pathname]
+      : undefined;
+    if (!mimeType) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    const filePath = DASHBOARD_BACKGROUND_PATHS[mimeType];
+    if (!existsSync(filePath)) {
+      return new Response('Not found', { status: 404 });
+    }
+    const data = await fs.readFile(filePath);
+
+    return new Response(new Uint8Array(data), {
+      headers: {
+        'cache-control': 'private, max-age=31536000, immutable',
+        'content-type': mimeType,
+      },
+    });
+  });
+}

--- a/apps/desktop/electron/platform/protocols/host-media-protocol.ts
+++ b/apps/desktop/electron/platform/protocols/host-media-protocol.ts
@@ -1,59 +1,45 @@
 import { protocol } from 'electron';
-import { existsSync, promises as fs } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { SERO_AGENT_DIR } from '@electron/platform/env';
+import { inspectDashboardBackgroundImage } from '@electron/shared/media/dashboard-background-image';
 
-export type DashboardBackgroundMimeType = 'image/png' | 'image/jpeg';
+const DASHBOARD_BACKGROUND_PATH = path.join(SERO_AGENT_DIR, 'dashboard-background.image');
 
-const DASHBOARD_BACKGROUND_PATHS: Record<DashboardBackgroundMimeType, string> = {
-  'image/png': path.join(SERO_AGENT_DIR, 'dashboard-background.png'),
-  'image/jpeg': path.join(SERO_AGENT_DIR, 'dashboard-background.jpg'),
-};
-
-const DASHBOARD_BACKGROUND_MIME_BY_PATH: Record<string, DashboardBackgroundMimeType> = {
-  '/background.png': 'image/png',
-  '/background.jpg': 'image/jpeg',
-};
-
-export function getDashboardBackgroundPath(mimeType: DashboardBackgroundMimeType): string {
-  return DASHBOARD_BACKGROUND_PATHS[mimeType];
+export function getDashboardBackgroundPath(): string {
+  return DASHBOARD_BACKGROUND_PATH;
 }
 
-export function getOtherDashboardBackgroundPath(mimeType: DashboardBackgroundMimeType): string {
-  return mimeType === 'image/png'
-    ? DASHBOARD_BACKGROUND_PATHS['image/jpeg']
-    : DASHBOARD_BACKGROUND_PATHS['image/png'];
-}
-
-export function getDashboardBackgroundUrl(
-  mimeType: DashboardBackgroundMimeType,
-  version: string,
-): string {
-  const extension = mimeType === 'image/png' ? 'png' : 'jpg';
-  return `sero-media://dashboard/background.${extension}?v=${encodeURIComponent(version)}`;
+export function getDashboardBackgroundUrl(version: string): string {
+  return `sero-media://dashboard/background?v=${encodeURIComponent(version)}`;
 }
 
 export function setupHostMediaProtocol(): void {
   protocol.handle('sero-media', async (request) => {
     const url = new URL(request.url);
-    const mimeType = url.hostname === 'dashboard'
-      ? DASHBOARD_BACKGROUND_MIME_BY_PATH[url.pathname]
-      : undefined;
-    if (!mimeType) {
+    if (url.hostname !== 'dashboard' || url.pathname !== '/background') {
       return new Response('Not found', { status: 404 });
     }
 
-    const filePath = DASHBOARD_BACKGROUND_PATHS[mimeType];
-    if (!existsSync(filePath)) {
-      return new Response('Not found', { status: 404 });
+    let data: Buffer;
+    try {
+      data = await fs.readFile(DASHBOARD_BACKGROUND_PATH);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return new Response('Not found', { status: 404 });
+      }
+      throw error;
     }
-    const data = await fs.readFile(filePath);
+
+    const image = inspectDashboardBackgroundImage(data);
+    if (!image) return new Response('Not found', { status: 404 });
 
     return new Response(new Uint8Array(data), {
       headers: {
-        'cache-control': 'private, max-age=31536000, immutable',
-        'content-type': mimeType,
+        'access-control-allow-origin': '*',
+        'cache-control': 'no-store',
+        'content-type': image.mimeType,
       },
     });
   });

--- a/apps/desktop/electron/platform/security/csp.ts
+++ b/apps/desktop/electron/platform/security/csp.ts
@@ -40,6 +40,7 @@ export function buildContentSecurityPolicy(
 ): string {
   const isDevelopment = options.isDevelopment ?? process.env.NODE_ENV === 'development';
   const extensionSrc = ['sero-ext:'];
+  const hostMediaSrc = ['sero-media:'];
   const devHttpSrc = isDevelopment ? LOOPBACK_HTTP_SRC : [];
   const devConnectSrc = isDevelopment ? [...LOOPBACK_HTTP_SRC, ...LOOPBACK_WS_SRC] : [];
   const devMonacoConnectSrc = isDevelopment ? ['https://cdn.jsdelivr.net'] : [];
@@ -98,6 +99,7 @@ export function buildContentSecurityPolicy(
     'https:',
     'http:',
     ...extensionSrc,
+    ...hostMediaSrc,
   ];
 
   // -- font-src --

--- a/apps/desktop/electron/preload/api.ts
+++ b/apps/desktop/electron/preload/api.ts
@@ -3,6 +3,7 @@ import { windowBridge } from './platform/window';
 import {
   clipboardBridge,
   feedbackBridge,
+  dashboardBridge,
   gatewayBridge,
   layoutBridge,
   netBridge,
@@ -80,6 +81,7 @@ export const seroPreloadApi = {
   agentPlugins: agentPluginsBridge,
   terminal: terminalBridge,
   layout: layoutBridge,
+  dashboard: dashboardBridge,
   themes: themesBridge,
   net: netBridge,
   safeStorage: safeStorageBridge,

--- a/apps/desktop/electron/preload/platform/host-services.ts
+++ b/apps/desktop/electron/preload/platform/host-services.ts
@@ -25,6 +25,18 @@ export const layoutBridge = {
     ipcRenderer.invoke(IpcChannels.layout.load),
 };
 
+export const dashboardBridge = {
+  setBackground: (dataUrl: string | null): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.dashboard.setBackground, dataUrl),
+  getBackground: (): Promise<string | null> =>
+    ipcRenderer.invoke(IpcChannels.dashboard.getBackground),
+  onBackgroundChanged: (callback: (dataUrl: string | null) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, dataUrl: string | null) => callback(dataUrl);
+    ipcRenderer.on(IpcChannels.dashboard.backgroundChanged, handler);
+    return () => ipcRenderer.removeListener(IpcChannels.dashboard.backgroundChanged, handler);
+  },
+};
+
 export const themesBridge = {
   list: (): Promise<ThemePresetMeta[]> =>
     ipcRenderer.invoke(IpcChannels.themes.list),

--- a/apps/desktop/electron/shared/media/dashboard-background-image.ts
+++ b/apps/desktop/electron/shared/media/dashboard-background-image.ts
@@ -1,0 +1,75 @@
+export type DashboardBackgroundMimeType = 'image/png' | 'image/jpeg';
+
+export interface DashboardBackgroundImageInfo {
+  mimeType: DashboardBackgroundMimeType;
+  width: number;
+  height: number;
+}
+
+const PNG_SIGNATURE = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+const JPEG_START_OF_FRAME_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3,
+  0xc5, 0xc6, 0xc7,
+  0xc9, 0xca, 0xcb,
+  0xcd, 0xce, 0xcf,
+]);
+
+function inspectPng(data: Buffer): DashboardBackgroundImageInfo | null {
+  if (
+    data.length < 26
+    || !data.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)
+    || data.toString('ascii', 12, 16) !== 'IHDR'
+  ) {
+    return null;
+  }
+
+  const width = data.readUInt32BE(16);
+  const height = data.readUInt32BE(20);
+  if (width === 0 || height === 0) return null;
+
+  return {
+    mimeType: 'image/png',
+    width,
+    height,
+  };
+}
+
+function inspectJpeg(data: Buffer): DashboardBackgroundImageInfo | null {
+  if (data.length < 4 || data[0] !== 0xff || data[1] !== 0xd8) return null;
+
+  let offset = 2;
+  while (offset < data.length) {
+    while (offset < data.length && data[offset] !== 0xff) offset += 1;
+    while (offset < data.length && data[offset] === 0xff) offset += 1;
+    if (offset >= data.length) return null;
+
+    const marker = data[offset]!;
+    offset += 1;
+    if (marker === 0xd9 || marker === 0xda) return null;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+    if (offset + 2 > data.length) return null;
+
+    const segmentLength = data.readUInt16BE(offset);
+    if (segmentLength < 2 || offset + segmentLength > data.length) return null;
+    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
+      if (segmentLength < 7) return null;
+      const height = data.readUInt16BE(offset + 3);
+      const width = data.readUInt16BE(offset + 5);
+      if (width === 0 || height === 0) return null;
+      return {
+        mimeType: 'image/jpeg',
+        width,
+        height,
+      };
+    }
+    offset += segmentLength;
+  }
+
+  return null;
+}
+
+export function inspectDashboardBackgroundImage(
+  data: Buffer,
+): DashboardBackgroundImageInfo | null {
+  return inspectPng(data) ?? inspectJpeg(data);
+}

--- a/apps/desktop/src/components/apps/dashboard/Dashboard.test.tsx
+++ b/apps/desktop/src/components/apps/dashboard/Dashboard.test.tsx
@@ -137,7 +137,7 @@ describe('Dashboard', () => {
   it('renders the persisted dashboard background', async () => {
     useDashboardStore.setState({
       ...useDashboardStore.getState(),
-      backgroundImage: 'sero-media://dashboard/background.png?v=1',
+      backgroundImage: 'sero-media://dashboard/background?v=1',
     }, true);
 
     await act(async () => {
@@ -147,7 +147,7 @@ describe('Dashboard', () => {
     const dashboard = container.querySelector<HTMLElement>('.sero-dashboard');
     expect(dashboard?.dataset.hasBackground).toBe('true');
     expect(dashboard?.style.getPropertyValue('--dashboard-background-image')).toContain(
-      'sero-media://dashboard/background.png?v=1',
+      'sero-media://dashboard/background?v=1',
     );
     expect(dashboard?.style.backgroundImage).toBe('');
   });

--- a/apps/desktop/src/components/apps/dashboard/Dashboard.test.tsx
+++ b/apps/desktop/src/components/apps/dashboard/Dashboard.test.tsx
@@ -137,7 +137,7 @@ describe('Dashboard', () => {
   it('renders the persisted dashboard background', async () => {
     useDashboardStore.setState({
       ...useDashboardStore.getState(),
-      backgroundImage: 'data:image/png;base64,cGl4ZWxz',
+      backgroundImage: 'sero-media://dashboard/background.png?v=1',
     }, true);
 
     await act(async () => {
@@ -145,8 +145,11 @@ describe('Dashboard', () => {
     });
 
     const dashboard = container.querySelector<HTMLElement>('.sero-dashboard');
-    expect(dashboard?.style.backgroundImage).toContain('data:image/png;base64,cGl4ZWxz');
-    expect(dashboard?.style.backgroundSize).toBe('cover');
+    expect(dashboard?.dataset.hasBackground).toBe('true');
+    expect(dashboard?.style.getPropertyValue('--dashboard-background-image')).toContain(
+      'sero-media://dashboard/background.png?v=1',
+    );
+    expect(dashboard?.style.backgroundImage).toBe('');
   });
 
   it('renders the widget grid when widgets exist and width is available', async () => {

--- a/apps/desktop/src/components/apps/dashboard/Dashboard.test.tsx
+++ b/apps/desktop/src/components/apps/dashboard/Dashboard.test.tsx
@@ -134,6 +134,21 @@ describe('Dashboard', () => {
     expect(container.textContent).toContain('widgets:0');
   });
 
+  it('renders the persisted dashboard background', async () => {
+    useDashboardStore.setState({
+      ...useDashboardStore.getState(),
+      backgroundImage: 'data:image/png;base64,cGl4ZWxz',
+    }, true);
+
+    await act(async () => {
+      root?.render(<Dashboard />);
+    });
+
+    const dashboard = container.querySelector<HTMLElement>('.sero-dashboard');
+    expect(dashboard?.style.backgroundImage).toContain('data:image/png;base64,cGl4ZWxz');
+    expect(dashboard?.style.backgroundSize).toBe('cover');
+  });
+
   it('renders the widget grid when widgets exist and width is available', async () => {
     useAppStore.setState({
       ...useAppStore.getState(),

--- a/apps/desktop/src/components/apps/dashboard/Dashboard.tsx
+++ b/apps/desktop/src/components/apps/dashboard/Dashboard.tsx
@@ -55,6 +55,7 @@ export const Dashboard = memo(function Dashboard() {
   const apps = useAppStore((s) => s.apps);
   const widgets = useDashboardStore((s) => s.widgets);
   const layouts = useDashboardStore((s) => s.layouts);
+  const backgroundImage = useDashboardStore((s) => s.backgroundImage);
   const updateLayouts = useDashboardStore((s) => s.updateLayouts);
   const persistLayouts = useDashboardStore((s) => s.persistLayouts);
   const runtimeWidgets = useRuntimeWidgets();
@@ -126,11 +127,22 @@ export const Dashboard = memo(function Dashboard() {
   );
 
   const hasWidgets = widgets.length > 0;
+  const backgroundStyle = useMemo(
+    () => backgroundImage
+      ? {
+          backgroundImage: `linear-gradient(rgba(6, 6, 8, 0.28), rgba(6, 6, 8, 0.28)), url("${backgroundImage}")`,
+          backgroundPosition: 'center',
+          backgroundSize: 'cover',
+        }
+      : undefined,
+    [backgroundImage],
+  );
 
   return (
     <div
       ref={containerRef}
       className="sero-dashboard glass-canvas flex h-full flex-col overflow-auto"
+      style={backgroundStyle}
     >
       {/* ── Toolbar ── */}
       <div className="flex items-center justify-between border-b border-[var(--dash-seam)] px-4 py-2">

--- a/apps/desktop/src/components/apps/dashboard/Dashboard.tsx
+++ b/apps/desktop/src/components/apps/dashboard/Dashboard.tsx
@@ -6,7 +6,7 @@
  * Layout is persisted to layout.json.
  */
 
-import { memo, useMemo, useCallback } from 'react';
+import { memo, useMemo, useCallback, type CSSProperties } from 'react';
 import { GridLayout } from 'react-grid-layout';
 import type { Layout, LayoutItem, GridLayoutProps } from 'react-grid-layout';
 import 'react-grid-layout/css/styles.css';
@@ -130,10 +130,8 @@ export const Dashboard = memo(function Dashboard() {
   const backgroundStyle = useMemo(
     () => backgroundImage
       ? {
-          backgroundImage: `linear-gradient(rgba(6, 6, 8, 0.28), rgba(6, 6, 8, 0.28)), url("${backgroundImage}")`,
-          backgroundPosition: 'center',
-          backgroundSize: 'cover',
-        }
+          '--dashboard-background-image': `url("${backgroundImage}")`,
+        } as CSSProperties
       : undefined,
     [backgroundImage],
   );
@@ -142,6 +140,7 @@ export const Dashboard = memo(function Dashboard() {
     <div
       ref={containerRef}
       className="sero-dashboard glass-canvas flex h-full flex-col overflow-auto"
+      data-has-background={backgroundImage ? 'true' : undefined}
       style={backgroundStyle}
     >
       {/* ── Toolbar ── */}

--- a/apps/desktop/src/components/apps/dashboard/dashboard.css
+++ b/apps/desktop/src/components/apps/dashboard/dashboard.css
@@ -20,13 +20,24 @@
   --dash-accent: var(--accent-primary);
   --dash-accent-soft: color-mix(in srgb, var(--accent-primary) 12%, transparent);
   --dash-lift-shadow: 0 16px 40px rgba(15, 17, 23, 0.22);
+  --dash-background-scrim: rgba(255, 255, 255, 0.24);
 }
 
 .dark .sero-dashboard {
   --dash-seam-strong: rgba(255, 255, 255, 0.18);
   --dash-chrome-scrim: rgba(8, 8, 12, 0.6);
   --dash-accent-soft: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+  --dash-background-scrim: rgba(6, 6, 8, 0.28);
   --dash-lift-shadow: 0 16px 48px rgba(0, 0, 0, 0.65);
+}
+
+.sero-dashboard[data-has-background="true"] {
+  background-image:
+    linear-gradient(var(--dash-background-scrim), var(--dash-background-scrim)),
+    var(--dashboard-background-image);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
 }
 
 /* ── Drag/resize target preview ──────────────────────────────────

--- a/apps/desktop/src/stores/app/layout-hydration.test.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDashboardStore } from '@/stores/dashboard';
+import { loadLayout } from './layout-hydration';
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('layout hydration', () => {
+  const initialDashboardState = useDashboardStore.getState();
+
+  afterEach(() => {
+    useDashboardStore.setState(initialDashboardState, true);
+    Reflect.deleteProperty(window, 'sero');
+  });
+
+  it('does not overwrite a background change that arrives during hydration', async () => {
+    const backgroundLoad = deferred<string | null>();
+    const listener: { current: ((dataUrl: string | null) => void) | null } = { current: null };
+
+    Reflect.set(window, 'sero', {
+      layout: { load: vi.fn(async () => null) },
+      dashboard: {
+        getBackground: vi.fn(() => backgroundLoad.promise),
+        onBackgroundChanged: vi.fn((callback: (dataUrl: string | null) => void) => {
+          listener.current = callback;
+          return () => undefined;
+        }),
+      },
+    });
+
+    const hydration = loadLayout();
+    await vi.waitFor(() => expect(listener.current).not.toBeNull());
+    if (!listener.current) throw new Error('Background listener was not registered');
+
+    listener.current('sero-media://dashboard/background.png?v=new');
+    backgroundLoad.resolve(null);
+    await hydration;
+
+    expect(useDashboardStore.getState().backgroundImage).toBe(
+      'sero-media://dashboard/background.png?v=new',
+    );
+  });
+});

--- a/apps/desktop/src/stores/app/layout-hydration.test.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.test.ts
@@ -45,12 +45,12 @@ describe('layout hydration', () => {
     await vi.waitFor(() => expect(listener.current).not.toBeNull());
     if (!listener.current) throw new Error('Background listener was not registered');
 
-    listener.current('sero-media://dashboard/background.png?v=new');
+    listener.current('sero-media://dashboard/background?v=new');
     backgroundLoad.resolve(null);
     await hydration;
 
     expect(useDashboardStore.getState().backgroundImage).toBe(
-      'sero-media://dashboard/background.png?v=new',
+      'sero-media://dashboard/background?v=new',
     );
   });
 });

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -18,8 +18,10 @@ let unsubscribeDashboardBackground: (() => void) | null = null;
 export async function loadLayout(): Promise<void> {
   try {
     const dashboardApi = window.sero.dashboard;
+    let backgroundChangedDuringLoad = false;
     unsubscribeDashboardBackground?.();
     unsubscribeDashboardBackground = dashboardApi?.onBackgroundChanged((backgroundImage) => {
+      backgroundChangedDuringLoad = true;
       useDashboardStore.getState().setBackgroundImage(backgroundImage);
     }) ?? null;
 
@@ -33,7 +35,9 @@ export async function loadLayout(): Promise<void> {
       window.sero.layout.load(),
       backgroundPromise,
     ]);
-    useDashboardStore.getState().setBackgroundImage(backgroundImage);
+    if (!backgroundChangedDuringLoad) {
+      useDashboardStore.getState().setBackgroundImage(backgroundImage);
+    }
     if (state) {
       const favouriteApps = normaliseFavouriteApps(state.favouriteApps);
       const update: Partial<AppState> & { layoutReady: true } = {

--- a/apps/desktop/src/stores/app/layout-hydration.ts
+++ b/apps/desktop/src/stores/app/layout-hydration.ts
@@ -12,10 +12,28 @@ import { normaliseChromeShortcuts, normaliseFavouriteApps } from './shared';
 import type { AppState } from './state';
 import { useAppStore } from './state';
 
+let unsubscribeDashboardBackground: (() => void) | null = null;
+
 /** Load layout state from disk and hydrate all stores. */
 export async function loadLayout(): Promise<void> {
   try {
-    const state = await window.sero.layout.load();
+    const dashboardApi = window.sero.dashboard;
+    unsubscribeDashboardBackground?.();
+    unsubscribeDashboardBackground = dashboardApi?.onBackgroundChanged((backgroundImage) => {
+      useDashboardStore.getState().setBackgroundImage(backgroundImage);
+    }) ?? null;
+
+    const backgroundPromise = dashboardApi
+      ? dashboardApi.getBackground().catch((err: unknown) => {
+          console.warn('[app-store] Failed to load dashboard background:', err);
+          return null;
+        })
+      : Promise.resolve(null);
+    const [state, backgroundImage] = await Promise.all([
+      window.sero.layout.load(),
+      backgroundPromise,
+    ]);
+    useDashboardStore.getState().setBackgroundImage(backgroundImage);
     if (state) {
       const favouriteApps = normaliseFavouriteApps(state.favouriteApps);
       const update: Partial<AppState> & { layoutReady: true } = {

--- a/apps/desktop/src/stores/dashboard.ts
+++ b/apps/desktop/src/stores/dashboard.ts
@@ -53,6 +53,10 @@ interface DashboardState {
   widgets: DashboardWidgetInstance[];
   /** react-grid-layout positions (keyed by instanceId). */
   layouts: LayoutItem[];
+  /** Persisted image rendered behind the dashboard grid. */
+  backgroundImage: string | null;
+  /** Replace the background image after host persistence or hydration. */
+  setBackgroundImage: (dataUrl: string | null) => void;
 
   /** Add a widget to the dashboard. */
   addWidget: (widget: AvailableWidget) => void;
@@ -74,6 +78,8 @@ function buildPersistState(widgets: DashboardWidgetInstance[], layouts: LayoutIt
 export const useDashboardStore = create<DashboardState>((set, get) => ({
   widgets: [],
   layouts: [],
+  backgroundImage: null,
+  setBackgroundImage: (backgroundImage) => set({ backgroundImage }),
 
   addWidget: (widget) => {
     const instanceId = generateInstanceId();

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -237,6 +237,15 @@ interface SeroLayoutAPI {
   load(): Promise<LoadedLayoutState | null>;
 }
 
+interface SeroDashboardAPI {
+  /** Persist or clear the dashboard background image. */
+  setBackground(dataUrl: string | null): Promise<void>;
+  /** Load the persisted dashboard background image. */
+  getBackground(): Promise<string | null>;
+  /** Subscribe to dashboard background changes. Returns unsubscribe. */
+  onBackgroundChanged(callback: (dataUrl: string | null) => void): () => void;
+}
+
 interface SeroThemesAPI {
   /** List all available theme presets (built-in + custom). */
   list(): Promise<ThemePresetMeta[]>;
@@ -433,6 +442,7 @@ export interface SeroAPI {
   devServer: SeroDevServerAPI;
   terminal: SeroTerminalAPI;
   layout: SeroLayoutAPI;
+  dashboard: SeroDashboardAPI;
   themes: SeroThemesAPI;
   net: SeroNetAPI;
   safeStorage: SeroSafeStorageAPI;

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -212,6 +212,14 @@ export const IpcChannels = {
     /** Load UI layout state. */
     load: 'sero:layout:load',
   },
+  dashboard: {
+    /** Persist or clear the host dashboard background image. */
+    setBackground: 'sero:dashboard:set-background',
+    /** Load the persisted host dashboard background image. */
+    getBackground: 'sero:dashboard:get-background',
+    /** Main → renderer push: dashboard background changed. */
+    backgroundChanged: 'sero:dashboard:background-changed',
+  },
   browser: browserIpcChannels,
   themes: {
     /** List all available theme presets (built-in + custom). */

--- a/docs/plugins/host-compatibility.md
+++ b/docs/plugins/host-compatibility.md
@@ -115,9 +115,9 @@ Declare this when your plugin contributes a title-bar control
 ### `ui.dashboardBackground`
 
 Declare this when a federated UI sets the host dashboard background. Call
-`window.sero.dashboard.setBackground(imageDataUrl)` with a PNG, JPEG, or WebP
-data URL. Call it with `null` to clear the background. The host converts the
-image to PNG and saves it outside `layout.json`.
+`window.sero.dashboard.setBackground(imageDataUrl)` with a PNG or JPEG data
+URL. Call it with `null` to clear the background. The host limits the saved
+image to 2560 × 1600 and 4 MB, then serves it through a private host-media URL.
 
 ### `appRuntime.media`
 

--- a/docs/plugins/host-compatibility.md
+++ b/docs/plugins/host-compatibility.md
@@ -67,6 +67,7 @@ These values are currently recognized by the host:
 - `appControl.capture`
 - `ui.explorerView`
 - `ui.titlebar`
+- `ui.dashboardBackground`
 
 Unknown capability strings are treated as unmet host requirements, so older
 hosts fail closed instead of partially loading the plugin. Downstream plugins
@@ -110,6 +111,13 @@ the plugin; this capability only captures pixels already on screen.
 
 Declare this when your plugin contributes a title-bar control
 (`sero.app.titlebar`).
+
+### `ui.dashboardBackground`
+
+Declare this when a federated UI sets the host dashboard background. Call
+`window.sero.dashboard.setBackground(imageDataUrl)` with a PNG, JPEG, or WebP
+data URL. Call it with `null` to clear the background. The host converts the
+image to PNG and saves it outside `layout.json`.
 
 ### `appRuntime.media`
 

--- a/docs/plugins/host-compatibility.md
+++ b/docs/plugins/host-compatibility.md
@@ -116,8 +116,9 @@ Declare this when your plugin contributes a title-bar control
 
 Declare this when a federated UI sets the host dashboard background. Call
 `window.sero.dashboard.setBackground(imageDataUrl)` with a PNG or JPEG data
-URL. Call it with `null` to clear the background. The host limits the saved
-image to 2560 × 1600 and 4 MB, then serves it through a private host-media URL.
+URL. The image must be 2560 × 1600 or smaller and no more than 4 MB. The host
+validates its bytes, stores them without re-encoding, and rejects larger input.
+Call the method with `null` to clear the background.
 
 ### `appRuntime.media`
 

--- a/packages/common/src/plugins.ts
+++ b/packages/common/src/plugins.ts
@@ -33,6 +33,8 @@ export const SERO_HOST_CAPABILITIES = [
   'ui.explorerView',
   /** Host mounts `sero.app.titlebar` as a title-bar control. */
   'ui.titlebar',
+  /** Federated UI can persist an image as the host dashboard background. */
+  'ui.dashboardBackground',
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

- expose a generic dashboard background API through the plugin preload bridge
- validate plugin-provided PNG and JPEG bytes, dimensions, and decoded image integrity
- atomically persist the original image bytes in one profile-owned asset file
- serve the image through a CORS-enabled private `sero-media://` URL
- update every open dashboard immediately and restore its background after restart
- add the `ui.dashboardBackground` host capability and documentation

## Review fixes

- removed synchronous image resizing and encoding from the Electron main thread
- preserved original PNG transparency and JPEG bytes
- use a fresh UUID URL and `Cache-Control: no-store` for every load
- map media-file delete races to 404 responses
- enabled protocol CORS and explicit cross-origin image responses
- collapsed persistence to one asset file with no post-success cleanup
- derive MIME type and dimensions from image bytes, not the data-URL prefix
- reject input above 2560 × 1600 or 4 MB; Loom produces compliant JPEG captures
- validate persisted bytes before hydration so a damaged asset cannot enable the dashboard scrim

## Verification

- `pnpm typecheck` — all 22 packages passed
- desktop suite — 353 files and 1,892 tests passed
- React Doctor — 98/100, no issues
- Electron smoke — corrupt asset rejection and recovery, transparent PNG alpha, mismatched-prefix JPEG, live rendering, reload persistence, and clear passed
- all touched source files remain below 500 lines

## Companion PR

- https://github.com/sero-labs/sero-loom-plugin/pull/1