### PR TITLE
fix(desktop): scope contribution id dedupe to each extension point

### DIFF
--- a/apps/desktop/electron/__tests__/features/apps/app-contributions.test.ts
+++ b/apps/desktop/electron/__tests__/features/apps/app-contributions.test.ts
@@ -115,15 +115,10 @@ describe('app contribution parsing', () => {
       contributes: {
         components: [
           { id: 'shared', extensionPoint: 'ui.titlebar.control', component: 'Good' },
+          { id: 'shared', extensionPoint: 'ui.titlebar.control', component: 'Duplicate' },
           { id: 'unknown', extensionPoint: 'ui.future.surface', component: 'Future' },
         ],
         controls: [
-          {
-            id: 'shared',
-            extensionPoint: 'workspace.create.option',
-            control: { type: 'switch', label: 'Duplicate', defaultValue: true },
-            action: { type: 'tool', tool: 'duplicate' },
-          },
           {
             id: 'invalid',
             extensionPoint: 'workspace.create.option',
@@ -134,13 +129,83 @@ describe('app contribution parsing', () => {
       },
     });
 
-    expect(parsed.contributions.components).toHaveLength(1);
+    expect(parsed.contributions.components).toEqual([
+      expect.objectContaining({ id: 'shared', component: 'Good' }),
+    ]);
     expect(parsed.contributions.controls).toHaveLength(0);
     expect(parsed.diagnostics.map((entry) => entry.code)).toEqual([
       'unknown-extension-point',
       'invalid-contribution',
       'duplicate-id',
     ]);
+  });
+
+  it('keeps the same id in two different extension points', () => {
+    const parsed = parseAppContributions({
+      contributes: {
+        components: [
+          { id: 'shared', extensionPoint: 'ui.titlebar.control', component: 'Control' },
+        ],
+        controls: [
+          {
+            id: 'shared',
+            extensionPoint: 'workspace.create.option',
+            control: { type: 'switch', label: 'Shared', defaultValue: true },
+            action: { type: 'tool', tool: 'shared' },
+          },
+        ],
+      },
+    });
+
+    expect(parsed.contributions.components).toHaveLength(1);
+    expect(parsed.contributions.controls).toHaveLength(1);
+    expect(parsed.diagnostics).toEqual([]);
+  });
+
+  it('keeps every widget whose id matches a host-generated legacy id', () => {
+    const parsed = parseAppContributions({
+      search: { component: 'LegacySearch' },
+      explorerView: { component: 'LegacyExplorer' },
+      titlebar: { component: 'LegacyTitlebar' },
+      workspaceCreation: { label: 'Enable indexing', tool: 'enable_index' },
+      widgets: [
+        { id: 'global-search', name: 'Search stats', component: 'SearchStats' },
+        { id: 'explorer-view', name: 'Explorer stats', component: 'ExplorerStats' },
+        { id: 'titlebar-control', name: 'Titlebar stats', component: 'TitlebarStats' },
+        { id: 'workspace-creation', name: 'Workspace stats', component: 'WorkspaceStats' },
+      ],
+    });
+
+    const widgets = parsed.contributions.components.filter(
+      (entry) => entry.extensionPoint === 'ui.dashboard.widget',
+    );
+    expect(widgets.map((entry) => entry.component)).toEqual([
+      'SearchStats',
+      'ExplorerStats',
+      'TitlebarStats',
+      'WorkspaceStats',
+    ]);
+    expect(parsed.contributions.components.map((entry) => entry.component)).toEqual(
+      expect.arrayContaining(['LegacySearch', 'LegacyExplorer', 'LegacyTitlebar']),
+    );
+    expect(parsed.contributions.controls).toEqual([
+      expect.objectContaining({ id: 'workspace-creation' }),
+    ]);
+    expect(parsed.diagnostics).toEqual([]);
+  });
+
+  it('reports a duplicate legacy widget id inside one extension point', () => {
+    const parsed = parseAppContributions({
+      widgets: [
+        { id: 'stats', name: 'Stats one', component: 'StatsOne' },
+        { id: 'stats', name: 'Stats two', component: 'StatsTwo' },
+      ],
+    });
+
+    expect(parsed.contributions.components).toEqual([
+      expect.objectContaining({ component: 'StatsOne' }),
+    ]);
+    expect(parsed.diagnostics.map((entry) => entry.code)).toEqual(['duplicate-id']);
   });
 
   it('suppresses federated components but retains host controls', () => {

--- a/apps/desktop/electron/features/apps/discovery/contributions.ts
+++ b/apps/desktop/electron/features/apps/discovery/contributions.ts
@@ -341,13 +341,22 @@ export function parseAppContributions(
 
   const components: ComponentContribution[] = [];
   const controls: ControlContribution[] = [];
-  const seenIds = new Set<string>();
+  // Uniqueness is per extension point: the host resolves a contribution only
+  // inside its own point, so host-generated legacy ids ("global-search",
+  // "explorer-view", and the rest) must not hide an author id in another point.
+  const seenIdsByPoint = new Map<string, Set<string>>();
   const all = [...explicit.components, ...explicit.controls, ...legacy];
   for (const entry of all) {
+    let seenIds = seenIdsByPoint.get(entry.extensionPoint);
+    if (!seenIds) {
+      seenIds = new Set<string>();
+      seenIdsByPoint.set(entry.extensionPoint, seenIds);
+    }
     if (seenIds.has(entry.id)) {
       diagnostics.push({
         code: 'duplicate-id',
-        message: `Duplicate contribution id "${entry.id}" was ignored.`,
+        message: `Duplicate contribution id "${entry.id}" for extension point `
+          + `"${entry.extensionPoint}" was ignored.`,
         contributionId: entry.id,
         extensionPoint: entry.extensionPoint,
       });

--- a/apps/desktop/src/stores/app-contributions.test.ts
+++ b/apps/desktop/src/stores/app-contributions.test.ts
@@ -59,6 +59,26 @@ describe('getContributions', () => {
     ]);
   });
 
+  it('isolates a shared id used in two extension points', () => {
+    const app = createApp(createManifest('notes', [
+      { id: 'global-search', extensionPoint: 'ui.global-search.panel', component: 'SearchPanel' },
+      {
+        id: 'global-search',
+        extensionPoint: 'ui.dashboard.widget',
+        component: 'SearchWidget',
+        name: 'Search stats',
+        defaultSize: { w: 2, h: 2 },
+      },
+    ]));
+
+    const panels = getContributions([app], 'ui.global-search.panel');
+    const widgets = getContributions([app], 'ui.dashboard.widget');
+
+    expect(panels.map((entry) => entry.contribution.component)).toEqual(['SearchPanel']);
+    expect(widgets.map((entry) => entry.contribution.component)).toEqual(['SearchWidget']);
+    expect(panels[0].key).toBe(widgets[0].key);
+  });
+
   it('excludes host-incompatible apps', () => {
     const app = createApp(createManifest('future', [
       { id: 'search', extensionPoint: 'ui.global-search.panel', component: 'Search' },

--- a/apps/docs-site/docs/reference/plugin-extension-points.md
+++ b/apps/docs-site/docs/reference/plugin-extension-points.md
@@ -14,9 +14,10 @@ These manifest concepts are separate:
 | `sero.app.contributes.components` | Plugin | Extra federated React components mounted in host-defined locations. |
 | `sero.app.contributes.controls` | Host | Standard controls rendered by Sero and backed by a plugin action. |
 
-Every contribution needs an `id` that is unique across both contribution
-arrays in the app. Sero combines it with the app ID as
-`<app-id>:<contribution-id>`.
+Every contribution needs an `id` that is unique inside its extension point.
+The same ID can appear in two different extension points. Sero combines it
+with the app ID as `<app-id>:<contribution-id>`, which identifies the
+contribution inside one extension point only.
 
 ## Supported extension points
 
@@ -114,7 +115,7 @@ Electron validates all contribution data before the renderer receives it:
 
 - `components` and `controls` must be arrays when present
 - required strings must be non-empty
-- IDs must be unique across both arrays in the app
+- IDs must be unique inside one extension point
 - the extension point, control type, and action type must be host-defined
 - only point-specific allowlisted fields are retained
 

--- a/docs/plugins/guide.md
+++ b/docs/plugins/guide.md
@@ -366,8 +366,9 @@ uses `contributes.components`. Standard controls rendered by the host use
 `contributes.controls`. A plugin can only use an extension point defined by the
 host.
 
-Every entry needs an `id` that is unique across both arrays in the app. The
-host uses `<app-id>:<contribution-id>` as its stable global identity.
+Every entry needs an `id` that is unique inside its extension point. The same
+ID can appear in two different extension points. The host uses
+`<app-id>:<contribution-id>` as the stable key inside one extension point.
 
 | Extension point | Kind | Point-specific fields | Host surface |
 | --- | --- | --- | --- |

--- a/docs/plugins/technical.md
+++ b/docs/plugins/technical.md
@@ -196,7 +196,8 @@ provider-specific auth and model UI without hardcoded app-level logic:
 
 Electron is the trust boundary for `sero.app.contributes`. It validates common
 fields, resolves the host-owned extension point, validates point-specific
-fields, rejects duplicate IDs, and returns canonical `contributions` plus
+fields, rejects IDs that repeat inside one extension point, and returns
+canonical `contributions` plus
 non-fatal diagnostics on `SeroAppManifest`.
 
 The renderer calls the typed `getContributions(apps, extensionPoint)` query.

--- a/docs/specs/plugin-extension-point-framework.md
+++ b/docs/specs/plugin-extension-point-framework.md
@@ -86,7 +86,7 @@ would make this important ownership boundary less clear to plugin authors.
 | Extension point | A named location and contract owned by the Sero host. |
 | Component contribution | A plugin-rendered federated React component inserted into a host extension point. |
 | Control contribution | A host-rendered control that invokes a plugin-owned action. |
-| Contribution ID | A stable identifier unique within one app manifest. |
+| Contribution ID | A stable identifier unique within one extension point in one app manifest. |
 | Resolved contribution | A validated contribution combined with its owning app manifest. |
 
 ## Public Manifest Contract
@@ -142,7 +142,7 @@ Every component contribution has these common fields:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | Yes | Stable ID unique within this app's contributions. |
+| `id` | string | Yes | Stable ID unique within this extension point in this app. |
 | `extensionPoint` | string | Yes | Host extension point that receives the component. |
 | `component` | string | Yes | Exported federated React component name. |
 
@@ -183,7 +183,7 @@ Every control contribution has these common fields:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `id` | string | Yes | Stable ID unique within this app's contributions. |
+| `id` | string | Yes | Stable ID unique within this extension point in this app. |
 | `extensionPoint` | string | Yes | Host extension point that receives the control. |
 | `control` | object | Yes | Allowlisted host control description. |
 | `action` | object | Yes | Allowlisted plugin action description. |
@@ -193,15 +193,24 @@ The first supported control is `switch`. The first supported action is
 
 ### Identity
 
-Contribution IDs must be unique across `components` and `controls` within one
-app. The host creates the global identity:
+Contribution IDs must be unique within one extension point in one app. The
+same ID can appear in two different extension points, because the host always
+resolves a contribution inside its own point. For each extension point the host
+creates a consumer key:
 
 ```text
 <app-id>:<contribution-id>
 ```
 
-Stable identity is used for React keys, diagnostics, hot reload and any future
-persisted contribution preferences.
+This key is stable for React keys, diagnostics, hot reload and persisted
+contribution preferences inside one extension point. It is not a global
+identity: two contributions from one app can share it in different points, so
+any collection that holds contributions from more than one point must also key
+on the extension point.
+
+Legacy manifest fields keep host-generated IDs (`global-search`,
+`explorer-view`, `titlebar-control`, `workspace-creation`). Per-point
+uniqueness makes sure that these IDs cannot hide an author-chosen widget ID.
 
 ## Initial Extension-Point Catalogue
 
@@ -267,7 +276,7 @@ Discovery will:
 3. validate the common contribution fields;
 4. find the host definition for the named extension point;
 5. validate point-specific fields;
-6. reject duplicate contribution IDs within the app;
+6. reject duplicate contribution IDs within one extension point;
 7. record diagnostics for malformed or unknown entries;
 8. combine valid entries with legacy normalised contributions; and
 9. return one canonical `AppContributions` object on `SeroAppManifest`.

--- a/packages/templates/skills/sero-plugin/references/api-and-widgets.md
+++ b/packages/templates/skills/sero-plugin/references/api-and-widgets.md
@@ -221,7 +221,7 @@ Widget manifest fields:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `id` | Yes | Unique within the app |
+| `id` | Yes | Unique among this app's dashboard widgets |
 | `extensionPoint` | Yes | Must be `ui.dashboard.widget` |
 | `name` | Yes | Display name in header and picker |
 | `component` | Yes | Exported component name from MF remote |
@@ -388,7 +388,7 @@ Supported component extension points are `ui.global-search.panel`,
 `ui.explorer.view`, `ui.titlebar.control`, and `ui.dashboard.widget`. The
 supported control extension point is `workspace.create.option`, with a
 `switch` control and app-local `tool` action. Contribution IDs are unique
-across both arrays. Unknown points are ignored by the host, so set
+inside one extension point. Unknown points are ignored by the host, so set
 `minSeroVersion` if the plugin cannot work without a newer point.
 
 The old `search`, `explorerView`, `titlebar`, `widgets`, and


### PR DESCRIPTION
Closes #363

## Problem

`readLegacyEntries` gives legacy singleton fields fixed ids — `global-search`, `explorer-view`, `titlebar-control`, `workspace-creation` — while legacy widgets keep the id the author chose. The dedupe in `parseAppContributions` was per app, so a manifest with both `search` and a widget with `id: "global-search"` lost the widget. The only signal was a console `duplicate-id` diagnostic, which the app does not show.

## Fix

Dedupe per extension point instead of per app.

Every consumer already resolves contributions inside one point (`getContributions(apps, extensionPoint)`), so:

- no id is renamed;
- no persisted key changes (explorer active panel, dashboard layout);
- nothing is dropped when an author id matches a host-generated id;
- a repeated id inside one point still gets the `duplicate-id` diagnostic, and the message now names the point.

## Tests

- Legacy widgets that reuse all four host-generated ids all survive, next to the legacy singletons.
- The same id in two different extension points is kept.
- A repeated id inside one point is still dropped with a diagnostic.
- Renderer regression: two points that share one `<appId>:<id>` key stay isolated.

## Docs

`docs/specs/plugin-extension-point-framework.md` and `docs/plugins/technical.md` now state per-point uniqueness, and say that `<app-id>:<contribution-id>` is an extension-point-scoped consumer key, not a global identity.

## Verification

`pnpm typecheck` clean. Desktop suite: 1941 passed. One failure in `AddWorkspaceMenu.test.tsx` is pre-existing — it fails the same way on a clean tree.

A routed review (gpt-5.6-sol, high effort) found a stray NUL byte in the first version of the dedupe key and two test gaps. Both are fixed here; the dedupe now uses a `Map<extensionPoint, Set<id>>` with no delimiter.