### PR TITLE
fix(test): match icon-only buttons by aria-label in AddWorkspaceMenu tests

### DIFF
--- a/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
+++ b/apps/desktop/src/components/layout/workspace/AddWorkspaceMenu.test.tsx
@@ -45,8 +45,12 @@ const promiseRuntime = Promise as PromiseConstructor & {
 
 
 function getButton(label: string): HTMLButtonElement {
+  // Some buttons are icon-only and carry their label on aria-label.
   const button = [...document.querySelectorAll('button')]
-    .find((candidate) => candidate.textContent?.trim() === label);
+    .find((candidate) => (
+      candidate.textContent?.trim() === label
+      || candidate.getAttribute('aria-label') === label
+    ));
   if (!(button instanceof HTMLButtonElement)) {
     throw new Error(`Expected button "${label}"`);
   }


### PR DESCRIPTION
`main` is red and it blocks every branch.

## Problem

```
FAIL src/components/layout/workspace/AddWorkspaceMenu.test.tsx > AddWorkspaceMenu
     > restores contribution defaults after leaving the create view
Error: Expected button "Back"
```

Failing on `main` since `ebd326ad3` ("fix(ui): remove text input focus glow and tidy Add Workspace menu") — see [run 31339679626](https://github.com/sero-labs/sero/actions/runs/31339679626).

That commit replaced the text `Back` button with an icon button carrying `aria-label="Back"` ([AddWorkspaceViews.tsx:252-266](apps/desktop/src/components/layout/workspace/AddWorkspaceViews.tsx#L252-L266)). The test helper `getButton` matched on `textContent` only, so it stopped finding the button.

## Fix

`getButton` now also matches `aria-label`. Test-only change; no product code touched.

## Verification

`pnpm typecheck` clean. `apps/desktop/src/components/layout/workspace/` — 37 tests, all passing.

Found while checking CI for #364, which is blocked by this same failure.