### PR TITLE
fix(desktop): clean up workspace containers

### DIFF
--- a/apps/desktop/e2e/profiles-onboarding.contract.spec.ts
+++ b/apps/desktop/e2e/profiles-onboarding.contract.spec.ts
@@ -81,7 +81,7 @@ test.describe('profiles and onboarding IPC contracts', () => {
     ]));
     expect(afterRename.every((profile) => typeof profile.path === 'string')).toBe(true);
 
-    await page.evaluate((id) => window.sero.profiles.delete(id), inactive.id);
+    await page.evaluate((id) => window.sero.profiles.remove(id, 'remove'), inactive.id);
 
     const afterDelete = await page.evaluate(() => window.sero.profiles.list());
     expect(afterDelete).toHaveLength(1);

--- a/apps/desktop/e2e/profiles.workflow.spec.ts
+++ b/apps/desktop/e2e/profiles.workflow.spec.ts
@@ -55,11 +55,44 @@ test('creates a second profile from the profile switcher and requests restart on
   await expect.poll(relaunchCalls, { timeout: 10_000 }).toEqual(expect.arrayContaining(['relaunch', 'exit']));
 });
 
-test('deletes an inactive profile from the registry without deleting files', async () => {
-  const inactive = await page.evaluate(() => window.sero.profiles.create('Delete Me'));
-  await page.evaluate((id) => window.sero.profiles.delete(id), inactive.id);
+test('removes an inactive profile from the registry without deleting files', async () => {
+  const inactive = await page.evaluate(() => window.sero.profiles.create('Remove Me'));
+  await page.evaluate((id) => window.sero.profiles.remove(id, 'remove'), inactive.id);
   const profiles = await page.evaluate(() => window.sero.profiles.list());
   expect(profiles.some((profile) => profile.id === inactive.id)).toBe(false);
+});
+
+test('shows a clear two-step profile removal dialog', async () => {
+  await page.evaluate(() => window.sero.profiles.create('Research'));
+  await page.reload();
+  await waitForShell(page);
+  await page.getByRole('button', { name: /Primary/ }).click();
+  await page.getByRole('button', { name: 'Manage Research' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByRole('heading', { name: 'Remove profile' })).toBeVisible();
+  const retainFiles = dialog.getByRole('button', { name: 'Retain files' });
+  const deleteFiles = dialog.getByRole('button', { name: 'Delete files' });
+  await expect(retainFiles).toBeVisible();
+  await expect(deleteFiles).toBeVisible();
+
+  const [retainBox, deleteBox] = await Promise.all([
+    retainFiles.boundingBox(),
+    deleteFiles.boundingBox(),
+  ]);
+  expect(retainBox?.y).toBe(deleteBox?.y);
+
+  await deleteFiles.click();
+  await expect(dialog.getByRole('heading', { name: 'Are you sure?' })).toBeVisible();
+  await expect(dialog.getByText(
+    'The profile folder and its workspaces will be deleted. You cannot undo this.',
+  )).toBeVisible();
+  await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  await expect(dialog.getByRole('button', { name: 'Delete', exact: true })).toBeVisible();
+
+  await dialog.getByRole('button', { name: 'Cancel' }).click();
+  await expect(dialog.getByRole('heading', { name: 'Remove profile' })).toBeVisible();
+  await dialog.getByRole('button', { name: 'Close' }).click();
 });
 
 test.skip('custom storage location picker needs a deterministic folder-picker test hook', async () => {

--- a/apps/desktop/electron/__tests__/features/container/lifecycle.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/lifecycle.test.ts
@@ -86,6 +86,8 @@ describe('createFreshContainer', () => {
       'ai.sero.workspaceId=ws-1',
       '--label',
       'ai.sero.workspacePath=/host/workspace',
+      '--label',
+      'ai.sero.installationRoot=/tmp/sero-fixed',
       '--volume',
       '/host/workspace:/workspace',
       '--volume',
@@ -98,5 +100,39 @@ describe('createFreshContainer', () => {
       '/host/sero-logs:/workspace/.sero/logs/dev:ro',
     ]));
     expect(runArgs).not.toContain('/host/global:/host/global:ro');
+  });
+
+  it('retries creation when an uninspectable ghost reserves the container name', async () => {
+    const execFn = vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 }));
+    const inspectFn = vi.fn(async () => ({
+      id: 'sero-ws-1',
+      image: 'image',
+      state: 'running' as const,
+      cpus: 2,
+      memoryBytes: 1024,
+    }));
+    let runAttempts = 0;
+    mocks.execFileMock.mockImplementation(async (_file: string, args: string[]) => {
+      if (args[0] === 'run' && runAttempts++ === 0) {
+        throw { stderr: 'container already exists' };
+      }
+      if (args[0] === 'inspect') throw new Error('container not found');
+      return { stdout: '', stderr: '' };
+    });
+
+    await createFreshContainer(
+      { workspaceId: 'ws-1', hostPath: '/host/workspace' },
+      'sero-ws-1',
+      new Map(),
+      execFn,
+      inspectFn,
+    );
+
+    expect(runAttempts).toBe(2);
+    expect(mocks.execFileMock).toHaveBeenCalledWith(
+      '/usr/local/bin/container',
+      ['delete', '--force', 'sero-ws-1'],
+      { timeout: 15_000 },
+    );
   });
 });

--- a/apps/desktop/electron/__tests__/features/container/lifecycle.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/lifecycle.test.ts
@@ -78,6 +78,14 @@ describe('createFreshContainer', () => {
 
     const runArgs = mocks.execFileMock.mock.calls[0]?.[1] as string[];
     expect(runArgs).toEqual(expect.arrayContaining([
+      '--label',
+      'ai.sero.managed=true',
+      '--label',
+      'ai.sero.runtime=apple-container',
+      '--label',
+      'ai.sero.workspaceId=ws-1',
+      '--label',
+      'ai.sero.workspacePath=/host/workspace',
       '--volume',
       '/host/workspace:/workspace',
       '--volume',

--- a/apps/desktop/electron/__tests__/features/container/ownership.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/ownership.test.ts
@@ -14,6 +14,17 @@ import {
 const identity = { workspaceId: 'workspace-a', workspacePath: '/profiles/a/workspaces/workspace-a' };
 
 describe('Apple Container ownership', () => {
+  it('treats an empty inspect result as a missing container', () => {
+    expect(parseAppleContainerOwnership([], 'sero-workspace-a')).toEqual({
+      exists: false,
+      identity: null,
+      installationRoot: null,
+      workspaceMountSource: null,
+      running: null,
+      startedAt: null,
+    });
+  });
+
   it('recognizes a legacy deterministic container by its workspace mount', () => {
     const ownership = parseAppleContainerOwnership({
       configuration: {

--- a/apps/desktop/electron/__tests__/features/container/ownership.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/ownership.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@electron/platform/env', () => ({ SERO_FIXED_ROOT: '/sero/current' }));
+
+import {
+  SERO_INSTALLATION_ROOT_LABEL,
+  appleContainerBelongsToWorkspace,
+  appleContainerHasCurrentIdentity,
+  parseAppleContainerOwnership,
+  seroOwnershipLabels,
+} from '@electron/features/container/core/ownership';
+
+const identity = { workspaceId: 'workspace-a', workspacePath: '/profiles/a/workspaces/workspace-a' };
+
+describe('Apple Container ownership', () => {
+  it('recognizes a legacy deterministic container by its workspace mount', () => {
+    const ownership = parseAppleContainerOwnership({
+      configuration: {
+        id: 'sero-workspace-a',
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    }, 'sero-workspace-a');
+
+    expect(appleContainerBelongsToWorkspace(ownership, identity)).toBe(true);
+    expect(appleContainerHasCurrentIdentity(ownership, identity)).toBe(false);
+  });
+
+  it('recognizes current labels and rejects another installation', () => {
+    const current = parseAppleContainerOwnership({
+      configuration: {
+        labels: seroOwnershipLabels('apple-container', identity),
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    }, 'sero-workspace-a');
+    const foreign = parseAppleContainerOwnership({
+      configuration: {
+        labels: {
+          ...seroOwnershipLabels('apple-container', identity),
+          [SERO_INSTALLATION_ROOT_LABEL]: '/sero/other',
+        },
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    }, 'sero-workspace-a');
+
+    expect(appleContainerHasCurrentIdentity(current, identity)).toBe(true);
+    expect(appleContainerBelongsToWorkspace(foreign, identity)).toBe(false);
+  });
+});

--- a/apps/desktop/electron/__tests__/features/container/ownership.test.ts
+++ b/apps/desktop/electron/__tests__/features/container/ownership.test.ts
@@ -8,6 +8,7 @@ import {
   appleContainerHasCurrentIdentity,
   parseAppleContainerOwnership,
   seroOwnershipLabels,
+  shouldRecreateAppleContainer,
 } from '@electron/features/container/core/ownership';
 
 const identity = { workspaceId: 'workspace-a', workspacePath: '/profiles/a/workspaces/workspace-a' };
@@ -23,6 +24,24 @@ describe('Apple Container ownership', () => {
 
     expect(appleContainerBelongsToWorkspace(ownership, identity)).toBe(true);
     expect(appleContainerHasCurrentIdentity(ownership, identity)).toBe(false);
+  });
+
+  it('does not recreate a running legacy container when labels are unavailable', () => {
+    const running = parseAppleContainerOwnership({
+      status: 'running',
+      configuration: {
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    }, 'sero-workspace-a');
+    const stopped = parseAppleContainerOwnership({
+      status: 'stopped',
+      configuration: {
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    }, 'sero-workspace-a');
+
+    expect(shouldRecreateAppleContainer(running, identity)).toBe(false);
+    expect(shouldRecreateAppleContainer(stopped, identity)).toBe(true);
   });
 
   it('recognizes current labels and rejects another installation', () => {

--- a/apps/desktop/electron/__tests__/features/profile/profile-removal.test.ts
+++ b/apps/desktop/electron/__tests__/features/profile/profile-removal.test.ts
@@ -1,0 +1,85 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+// Dynamic imports intentionally reload the startup-bound registry root for each isolated test.
+
+let root = '';
+const previousFixedRoot = process.env.SERO_FIXED_ROOT_OVERRIDE;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-profile-removal-'));
+  process.env.SERO_FIXED_ROOT_OVERRIDE = root;
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  if (previousFixedRoot === undefined) delete process.env.SERO_FIXED_ROOT_OVERRIDE;
+  else process.env.SERO_FIXED_ROOT_OVERRIDE = previousFixedRoot;
+  await fs.rm(root, { recursive: true, force: true });
+  await fs.rm(`${root}-custom`, { recursive: true, force: true });
+  vi.resetModules();
+});
+
+describe('profile removal modes', () => {
+  it('creates an explicit empty workspace registry for a new profile', async () => {
+    const { profileManager } = await import('@electron/features/profile/manager');
+    const profile = await profileManager.create('Default', undefined, true);
+
+    const registry = JSON.parse(
+      await fs.readFile(path.join(profile.path, 'agent', 'workspaces.json'), 'utf8'),
+    ) as { workspaces: unknown[] };
+    expect(registry.workspaces).toEqual([]);
+  });
+
+  it('removes an inactive profile from Sero but retains its files by default', async () => {
+    const { profileManager } = await import('@electron/features/profile/manager');
+    await profileManager.create('Default', undefined, true);
+    const removable = await profileManager.create('Research');
+    await fs.writeFile(path.join(removable.path, 'keep.txt'), 'keep', 'utf8');
+
+    await profileManager.remove(removable.id, 'remove');
+
+    expect(profileManager.findById(removable.id)).toBeNull();
+    await expect(fs.readFile(path.join(removable.path, 'keep.txt'), 'utf8')).resolves.toBe('keep');
+  });
+
+  it('deletes files only for a profile with Sero-managed provenance', async () => {
+    const { profileManager } = await import('@electron/features/profile/manager');
+    await profileManager.create('Default', undefined, true);
+    const removable = await profileManager.create('Research');
+    await fs.writeFile(path.join(removable.path, 'delete.txt'), 'delete', 'utf8');
+
+    expect(profileManager.list().find((profile) => profile.id === removable.id)?.canDeleteFiles).toBe(true);
+    expect(profileManager.list().find((profile) => profile.isActive)?.canDeleteFiles).toBe(false);
+    await profileManager.remove(removable.id, 'delete-files');
+
+    await expect(fs.stat(removable.path)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('rejects permanent deletion for main, custom, and uncertain legacy folders', async () => {
+    const { canDeleteProfileFiles, profileManager } = await import('@electron/features/profile/manager');
+    await profileManager.create('Default', undefined, true);
+    const customPath = `${root}-custom`;
+    const custom = await profileManager.create('Custom', customPath);
+    expect(profileManager.list().find((profile) => profile.id === custom.id)?.canDeleteFiles).toBe(false);
+    expect(canDeleteProfileFiles({
+      id: 'legacy',
+      name: 'Legacy',
+      path: path.join(root, 'profiles', 'legacy'),
+      createdAt: '2026-01-01T00:00:00.000Z',
+    })).toBe(false);
+    await expect(profileManager.remove(custom.id, 'delete-files')).rejects.toThrow(/cannot verify/i);
+    await expect(fs.stat(customPath)).resolves.toBeDefined();
+  });
+
+  it('keeps active and sole profile protections', async () => {
+    const { profileManager } = await import('@electron/features/profile/manager');
+    const active = await profileManager.create('Default', undefined, true);
+
+    await expect(profileManager.remove(active.id, 'remove')).rejects.toThrow(/only profile/i);
+    const inactive = await profileManager.create('Research');
+    await expect(profileManager.remove(active.id, 'remove')).rejects.toThrow(/active profile/i);
+    expect(profileManager.findById(inactive.id)).not.toBeNull();
+  });
+});

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/apple-container-backend.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/apple-container-backend.test.ts
@@ -114,6 +114,18 @@ describe('AppleContainerBackend', () => {
     expect(containerManager.removeOwned).toHaveBeenCalledWith('workspace-a', '/Users/daniel/project');
   });
 
+  it('clears a cached session when owned container removal fails', async () => {
+    const containerManager = createContainerManager();
+    containerManager.removeOwned.mockRejectedValueOnce(new Error('runtime unavailable'));
+    const backend = createBackend(containerManager);
+    await backend.ensure();
+
+    await expect(backend.destroy()).rejects.toThrow('runtime unavailable');
+    await backend.ensure();
+
+    expect(containerManager.ensure).toHaveBeenCalledTimes(2);
+  });
+
   it('passes isolated exec requests into the first container config build', async () => {
     const containerManager = createContainerManager();
     const workspaceManager = createWorkspaceManager();

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/apple-container-backend.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/apple-container-backend.test.ts
@@ -36,6 +36,7 @@ function createContainerManager() {
     }),
     stop: vi.fn().mockResolvedValue(undefined),
     remove: vi.fn().mockResolvedValue(undefined),
+    removeOwned: vi.fn().mockResolvedValue(undefined),
     exec: vi.fn().mockResolvedValue({ stdout: 'ok', stderr: '', exitCode: 0 }),
     readFile: vi.fn().mockResolvedValue('file content'),
     writeFile: vi.fn().mockResolvedValue(undefined),
@@ -100,8 +101,17 @@ describe('AppleContainerBackend', () => {
     await backend.ensure();
     await backend.destroy();
 
-    expect(containerManager.remove).toHaveBeenCalledWith('workspace-a');
+    expect(containerManager.removeOwned).toHaveBeenCalledWith('workspace-a', '/Users/daniel/project');
     expect(containerManager.stop).not.toHaveBeenCalled();
+  });
+
+  it('destroy removes an owned container even when this backend did not start it', async () => {
+    const containerManager = createContainerManager();
+    const backend = createBackend(containerManager);
+
+    await backend.destroy();
+
+    expect(containerManager.removeOwned).toHaveBeenCalledWith('workspace-a', '/Users/daniel/project');
   });
 
   it('passes isolated exec requests into the first container config build', async () => {

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
@@ -118,11 +118,33 @@ describe('container cleanup provider ownership', () => {
     expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
   });
 
-  it('preserves a running Docker container for a previous-session deletion', async () => {
+  it('deletes a running Docker container from the shutdown that queued it', async () => {
     const run = dockerRunnerFor({
       Id: 'container-id',
       Name: '/sero-workspace-a',
       Created: '2026-08-11T22:00:00.000Z',
+      State: { Running: true, StartedAt: '2026-08-11T22:00:00.000Z' },
+      Config: { Labels: {
+        [SERO_MANAGED_LABEL]: 'true',
+        [SERO_RUNTIME_LABEL]: 'docker',
+        [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+        [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
+      } },
+      Mounts: [{ Source: identity.workspacePath, Destination: '/workspace' }],
+    });
+
+    await expect(createDockerCleanupProvider(run).deleteOwned({
+      ...identity,
+      createdBefore: '2026-08-11T23:00:00.000Z',
+      skipRunning: true,
+    })).resolves.toBe('deleted');
+    expect(run).toHaveBeenCalledWith(['rm', '-f', 'sero-workspace-a'], { timeoutMs: 30_000 });
+  });
+
+  it('preserves a running Docker container when its start time is unknown', async () => {
+    const run = dockerRunnerFor({
+      Id: 'container-id',
+      Name: '/sero-workspace-a',
       State: { Running: true },
       Config: { Labels: {
         [SERO_MANAGED_LABEL]: 'true',
@@ -259,10 +281,34 @@ describe('container cleanup provider ownership', () => {
     expect(run).toHaveBeenCalledWith(['delete', '--force', 'sero-workspace-a']);
   });
 
-  it('preserves a running Apple container for a previous-session deletion', async () => {
+  it('deletes a running Apple container from the shutdown that queued it', async () => {
     const run = appleRunnerFor({
       status: 'running',
       startedDate: '2026-08-11T22:00:00.000Z',
+      configuration: {
+        id: 'sero-workspace-a',
+        labels: {
+          [SERO_MANAGED_LABEL]: 'true',
+          [SERO_RUNTIME_LABEL]: 'apple-container',
+          [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+          [SERO_WORKSPACE_PATH_LABEL]: identity.workspacePath,
+          [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
+        },
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    });
+
+    await expect(createAppleContainerCleanupProvider(run).deleteOwned({
+      ...identity,
+      createdBefore: '2026-08-11T23:00:00.000Z',
+      skipRunning: true,
+    })).resolves.toBe('deleted');
+    expect(run).toHaveBeenCalledWith(['delete', '--force', 'sero-workspace-a']);
+  });
+
+  it('preserves a running Apple container when its start time is unknown', async () => {
+    const run = appleRunnerFor({
+      status: 'running',
       configuration: {
         id: 'sero-workspace-a',
         labels: {

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createAppleContainerCleanupProvider,
+  createDockerCleanupProvider,
+} from '@electron/features/workspace/runtime/container-cleanup/providers';
+import {
+  SERO_MANAGED_LABEL,
+  SERO_RUNTIME_LABEL,
+  SERO_WORKSPACE_ID_LABEL,
+  SERO_WORKSPACE_PATH_LABEL,
+} from '@electron/features/container/core/ownership';
+import type { DockerRunner } from '@electron/features/workspace/runtime/backends/docker/docker-cli';
+
+const identity = { workspaceId: 'workspace-a', workspacePath: '/profiles/work/workspaces/a' };
+
+function dockerRunnerFor(inspect: unknown | null): DockerRunner {
+  return vi.fn(async (args: string[]) => {
+    if (args[0] === 'ps') {
+      return { stdout: inspect ? 'container-id\n' : '', stderr: '', exitCode: 0 };
+    }
+    if (args[0] === 'inspect') {
+      return { stdout: JSON.stringify([inspect]), stderr: '', exitCode: 0 };
+    }
+    return { stdout: '', stderr: '', exitCode: 0 };
+  });
+}
+
+describe('container cleanup provider ownership', () => {
+  it('deletes a Docker container only when Sero labels and workspace mount agree', async () => {
+    const run = dockerRunnerFor({
+      Id: 'container-id',
+      Name: '/sero-workspace-a',
+      Config: { Labels: {
+        [SERO_MANAGED_LABEL]: 'true',
+        [SERO_RUNTIME_LABEL]: 'docker',
+        [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+      } },
+      Mounts: [{ Source: identity.workspacePath, Destination: '/workspace' }],
+    });
+
+    await expect(createDockerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('deleted');
+    expect(run).toHaveBeenCalledWith(['rm', '-f', 'sero-workspace-a'], { timeoutMs: 30_000 });
+  });
+
+  it('preserves a Docker ownership collision with a different workspace path', async () => {
+    const run = dockerRunnerFor({
+      Id: 'container-id',
+      Name: '/sero-workspace-a',
+      Config: { Labels: {
+        [SERO_MANAGED_LABEL]: 'true',
+        [SERO_RUNTIME_LABEL]: 'docker',
+        [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+      } },
+      Mounts: [{ Source: '/profiles/other/workspaces/a', Destination: '/workspace' }],
+    });
+
+    await expect(createDockerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('preserved');
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
+  });
+
+  it('deletes Apple Container records with durable Sero ownership labels', async () => {
+    const run = vi.fn(async (args: string[]) => ({
+      stdout: args[0] === 'list' ? JSON.stringify([{
+        configuration: {
+          id: 'sero-workspace-a',
+          labels: {
+            [SERO_MANAGED_LABEL]: 'true',
+            [SERO_RUNTIME_LABEL]: 'apple-container',
+            [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+            [SERO_WORKSPACE_PATH_LABEL]: identity.workspacePath,
+          },
+        },
+      }]) : '',
+    }));
+
+    await expect(createAppleContainerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('deleted');
+    expect(run).toHaveBeenCalledWith(['delete', '--force', 'sero-workspace-a']);
+  });
+
+  it('preserves prefix-only Apple Container collisions', async () => {
+    const run = vi.fn(async () => ({
+      stdout: JSON.stringify([{ configuration: { id: 'sero-workspace-a', labels: {} } }]),
+    }));
+
+    await expect(createAppleContainerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('preserved');
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['delete']));
+  });
+});

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
@@ -76,7 +76,45 @@ describe('container cleanup provider ownership', () => {
     });
 
     await expect(createDockerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('preserved');
-    await expect(createDockerCleanupProvider(run).listOwned()).resolves.toEqual([]);
+    await expect(createDockerCleanupProvider(run).listOwned([])).resolves.toEqual([]);
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
+  });
+
+  it('discovers legacy Docker containers inside a registered profile root', async () => {
+    const run = dockerRunnerFor({
+      Id: 'container-id',
+      Name: '/sero-workspace-a',
+      Config: { Labels: {
+        [SERO_MANAGED_LABEL]: 'true',
+        [SERO_RUNTIME_LABEL]: 'docker',
+        [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+      } },
+      Mounts: [{ Source: identity.workspacePath, Destination: '/workspace' }],
+    });
+
+    await expect(createDockerCleanupProvider(run).listOwned(['/profiles/work'])).resolves.toEqual([
+      expect.objectContaining(identity),
+    ]);
+  });
+
+  it('does not delete a Docker container created after a shutdown entry', async () => {
+    const run = dockerRunnerFor({
+      Id: 'new-container',
+      Name: '/sero-workspace-a',
+      Created: '2026-08-12T00:00:00.000Z',
+      Config: { Labels: {
+        [SERO_MANAGED_LABEL]: 'true',
+        [SERO_RUNTIME_LABEL]: 'docker',
+        [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+        [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
+      } },
+      Mounts: [{ Source: identity.workspacePath, Destination: '/workspace' }],
+    });
+
+    await expect(createDockerCleanupProvider(run).deleteOwned({
+      ...identity,
+      createdBefore: '2026-08-11T23:00:00.000Z',
+    })).resolves.toBe('superseded');
     expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
   });
 
@@ -118,6 +156,51 @@ describe('container cleanup provider ownership', () => {
     await expect(createAppleContainerCleanupProvider(matching).deleteOwned(identity)).resolves.toBe('deleted');
     await expect(createAppleContainerCleanupProvider(collision).deleteOwned(identity)).resolves.toBe('preserved');
     expect(collision).not.toHaveBeenCalledWith(expect.arrayContaining(['delete']));
+  });
+
+  it('inspects Apple list summaries before discovering legacy containers', async () => {
+    const run = vi.fn(async (args: string[]) => {
+      if (args[0] === 'list') {
+        return { stdout: JSON.stringify([{ id: 'sero-workspace-a' }]) };
+      }
+      return {
+        stdout: JSON.stringify([{
+          id: 'sero-workspace-a',
+          configuration: {
+            id: 'sero-workspace-a',
+            mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+          },
+        }]),
+      };
+    });
+
+    await expect(createAppleContainerCleanupProvider(run).listOwned(['/profiles/work'])).resolves.toEqual([
+      expect.objectContaining(identity),
+    ]);
+    expect(run).toHaveBeenCalledWith(['inspect', 'sero-workspace-a']);
+  });
+
+  it('does not delete an Apple container created after a shutdown entry', async () => {
+    const run = appleRunnerFor({
+      configuration: {
+        id: 'sero-workspace-a',
+        creationDate: '2026-08-12T00:00:00.000Z',
+        labels: {
+          [SERO_MANAGED_LABEL]: 'true',
+          [SERO_RUNTIME_LABEL]: 'apple-container',
+          [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+          [SERO_WORKSPACE_PATH_LABEL]: identity.workspacePath,
+          [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
+        },
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    });
+
+    await expect(createAppleContainerCleanupProvider(run).deleteOwned({
+      ...identity,
+      createdBefore: '2026-08-11T23:00:00.000Z',
+    })).resolves.toBe('superseded');
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['delete']));
   });
 });
 

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
@@ -1,4 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
+const dockerCliMocks = vi.hoisted(() => ({
+  checkDocker: vi.fn(),
+  runDocker: vi.fn(),
+}));
+
+vi.mock(
+  '@electron/features/workspace/runtime/backends/docker/docker-cli',
+  () => dockerCliMocks,
+);
+
 import {
   createAppleContainerCleanupProvider,
   createDockerCleanupProvider,
@@ -30,6 +40,20 @@ function dockerRunnerFor(inspect: unknown | null): DockerRunner {
 }
 
 describe('container cleanup provider ownership', () => {
+  it('reports a missing Docker container as absent through the default runner', async () => {
+    dockerCliMocks.runDocker.mockResolvedValueOnce({
+      stdout: '',
+      stderr: 'Error: No such object: sero-workspace-a',
+      exitCode: 1,
+    });
+
+    await expect(createDockerCleanupProvider().deleteOwned(identity)).resolves.toBe('absent');
+    expect(dockerCliMocks.runDocker).toHaveBeenCalledWith(
+      ['inspect', 'sero-workspace-a'],
+      { timeoutMs: 10_000 },
+    );
+  });
+
   it('deletes a Docker container only when Sero labels and workspace mount agree', async () => {
     const run = dockerRunnerFor({
       Id: 'container-id',
@@ -161,6 +185,12 @@ describe('container cleanup provider ownership', () => {
       skipRunning: true,
     })).resolves.toBe('preserved');
     expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
+  });
+
+  it('reports a missing Apple container as absent', async () => {
+    const run = vi.fn(async () => ({ stdout: '[]' }));
+
+    await expect(createAppleContainerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('absent');
   });
 
   it('deletes Apple Container records with durable Sero ownership labels', async () => {

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
@@ -4,6 +4,8 @@ import {
   createDockerCleanupProvider,
 } from '@electron/features/workspace/runtime/container-cleanup/providers';
 import {
+  SERO_INSTALLATION_ROOT,
+  SERO_INSTALLATION_ROOT_LABEL,
   SERO_MANAGED_LABEL,
   SERO_RUNTIME_LABEL,
   SERO_WORKSPACE_ID_LABEL,
@@ -19,7 +21,9 @@ function dockerRunnerFor(inspect: unknown | null): DockerRunner {
       return { stdout: inspect ? 'container-id\n' : '', stderr: '', exitCode: 0 };
     }
     if (args[0] === 'inspect') {
-      return { stdout: JSON.stringify([inspect]), stderr: '', exitCode: 0 };
+      return inspect
+        ? { stdout: JSON.stringify([inspect]), stderr: '', exitCode: 0 }
+        : { stdout: '', stderr: 'No such container', exitCode: 1 };
     }
     return { stdout: '', stderr: '', exitCode: 0 };
   });
@@ -40,6 +44,7 @@ describe('container cleanup provider ownership', () => {
 
     await expect(createDockerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('deleted');
     expect(run).toHaveBeenCalledWith(['rm', '-f', 'sero-workspace-a'], { timeoutMs: 30_000 });
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['ps']), expect.anything());
   });
 
   it('preserves a Docker ownership collision with a different workspace path', async () => {
@@ -58,31 +63,66 @@ describe('container cleanup provider ownership', () => {
     expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
   });
 
+  it('preserves Docker containers owned by another Sero installation', async () => {
+    const run = dockerRunnerFor({
+      Name: '/sero-workspace-a',
+      Config: { Labels: {
+        [SERO_MANAGED_LABEL]: 'true',
+        [SERO_RUNTIME_LABEL]: 'docker',
+        [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+        [SERO_INSTALLATION_ROOT_LABEL]: '/sero/other',
+      } },
+      Mounts: [{ Source: identity.workspacePath, Destination: '/workspace' }],
+    });
+
+    await expect(createDockerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('preserved');
+    await expect(createDockerCleanupProvider(run).listOwned()).resolves.toEqual([]);
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
+  });
+
   it('deletes Apple Container records with durable Sero ownership labels', async () => {
-    const run = vi.fn(async (args: string[]) => ({
-      stdout: args[0] === 'list' ? JSON.stringify([{
-        configuration: {
-          id: 'sero-workspace-a',
-          labels: {
-            [SERO_MANAGED_LABEL]: 'true',
-            [SERO_RUNTIME_LABEL]: 'apple-container',
-            [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
-            [SERO_WORKSPACE_PATH_LABEL]: identity.workspacePath,
-          },
+    const run = appleRunnerFor({
+      configuration: {
+        id: 'sero-workspace-a',
+        labels: {
+          [SERO_MANAGED_LABEL]: 'true',
+          [SERO_RUNTIME_LABEL]: 'apple-container',
+          [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+          [SERO_WORKSPACE_PATH_LABEL]: identity.workspacePath,
+          [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
         },
-      }]) : '',
-    }));
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    });
 
     await expect(createAppleContainerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('deleted');
     expect(run).toHaveBeenCalledWith(['delete', '--force', 'sero-workspace-a']);
   });
 
-  it('preserves prefix-only Apple Container collisions', async () => {
-    const run = vi.fn(async () => ({
-      stdout: JSON.stringify([{ configuration: { id: 'sero-workspace-a', labels: {} } }]),
-    }));
+  it('deletes a legacy Apple Container only when its deterministic mount agrees', async () => {
+    const matching = appleRunnerFor({
+      configuration: {
+        id: 'sero-workspace-a',
+        labels: {},
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    });
+    const collision = appleRunnerFor({
+      configuration: {
+        id: 'sero-workspace-a',
+        labels: {},
+        mounts: [{ source: '/profiles/other/workspace-a', destination: '/workspace' }],
+      },
+    });
 
-    await expect(createAppleContainerCleanupProvider(run).deleteOwned(identity)).resolves.toBe('preserved');
-    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['delete']));
+    await expect(createAppleContainerCleanupProvider(matching).deleteOwned(identity)).resolves.toBe('deleted');
+    await expect(createAppleContainerCleanupProvider(collision).deleteOwned(identity)).resolves.toBe('preserved');
+    expect(collision).not.toHaveBeenCalledWith(expect.arrayContaining(['delete']));
   });
 });
+
+function appleRunnerFor(inspect: unknown) {
+  return vi.fn(async (args: string[]) => ({
+    stdout: args[0] === 'delete' ? '' : JSON.stringify([inspect]),
+  }));
+}

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-providers.test.ts
@@ -118,6 +118,29 @@ describe('container cleanup provider ownership', () => {
     expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
   });
 
+  it('preserves a running Docker container for a previous-session deletion', async () => {
+    const run = dockerRunnerFor({
+      Id: 'container-id',
+      Name: '/sero-workspace-a',
+      Created: '2026-08-11T22:00:00.000Z',
+      State: { Running: true },
+      Config: { Labels: {
+        [SERO_MANAGED_LABEL]: 'true',
+        [SERO_RUNTIME_LABEL]: 'docker',
+        [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+        [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
+      } },
+      Mounts: [{ Source: identity.workspacePath, Destination: '/workspace' }],
+    });
+
+    await expect(createDockerCleanupProvider(run).deleteOwned({
+      ...identity,
+      createdBefore: '2026-08-11T23:00:00.000Z',
+      skipRunning: true,
+    })).resolves.toBe('preserved');
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
+  });
+
   it('deletes Apple Container records with durable Sero ownership labels', async () => {
     const run = appleRunnerFor({
       configuration: {
@@ -180,11 +203,21 @@ describe('container cleanup provider ownership', () => {
     expect(run).toHaveBeenCalledWith(['inspect', 'sero-workspace-a']);
   });
 
-  it('does not delete an Apple container created after a shutdown entry', async () => {
+  it('does not inspect Apple containers outside the Sero name prefix', async () => {
+    const run = vi.fn(async (args: string[]) => {
+      if (args[0] === 'list') return { stdout: JSON.stringify([{ id: 'unrelated' }]) };
+      throw new Error(`Unexpected inspect: ${args.join(' ')}`);
+    });
+
+    await expect(createAppleContainerCleanupProvider(run).listOwned(['/profiles/work'])).resolves.toEqual([]);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not delete an Apple container started after a shutdown entry', async () => {
     const run = appleRunnerFor({
+      startedDate: '2026-08-12T00:00:00.000Z',
       configuration: {
         id: 'sero-workspace-a',
-        creationDate: '2026-08-12T00:00:00.000Z',
         labels: {
           [SERO_MANAGED_LABEL]: 'true',
           [SERO_RUNTIME_LABEL]: 'apple-container',
@@ -200,6 +233,54 @@ describe('container cleanup provider ownership', () => {
       ...identity,
       createdBefore: '2026-08-11T23:00:00.000Z',
     })).resolves.toBe('superseded');
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['delete']));
+  });
+
+  it('deletes an owned Apple container when creation time is unavailable', async () => {
+    const run = appleRunnerFor({
+      status: 'stopped',
+      configuration: {
+        id: 'sero-workspace-a',
+        labels: {
+          [SERO_MANAGED_LABEL]: 'true',
+          [SERO_RUNTIME_LABEL]: 'apple-container',
+          [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+          [SERO_WORKSPACE_PATH_LABEL]: identity.workspacePath,
+          [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
+        },
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    });
+
+    await expect(createAppleContainerCleanupProvider(run).deleteOwned({
+      ...identity,
+      createdBefore: '2026-08-11T23:00:00.000Z',
+    })).resolves.toBe('deleted');
+    expect(run).toHaveBeenCalledWith(['delete', '--force', 'sero-workspace-a']);
+  });
+
+  it('preserves a running Apple container for a previous-session deletion', async () => {
+    const run = appleRunnerFor({
+      status: 'running',
+      startedDate: '2026-08-11T22:00:00.000Z',
+      configuration: {
+        id: 'sero-workspace-a',
+        labels: {
+          [SERO_MANAGED_LABEL]: 'true',
+          [SERO_RUNTIME_LABEL]: 'apple-container',
+          [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+          [SERO_WORKSPACE_PATH_LABEL]: identity.workspacePath,
+          [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
+        },
+        mounts: [{ source: identity.workspacePath, destination: '/workspace' }],
+      },
+    });
+
+    await expect(createAppleContainerCleanupProvider(run).deleteOwned({
+      ...identity,
+      createdBefore: '2026-08-11T23:00:00.000Z',
+      skipRunning: true,
+    })).resolves.toBe('preserved');
     expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['delete']));
   });
 });

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-registries.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-registries.test.ts
@@ -49,7 +49,7 @@ describe('registered workspace identity loading', () => {
     ]);
   });
 
-  it('fails closed when a registered profile has no workspace registry', async () => {
+  it('treats a missing legacy workspace registry as empty', async () => {
     const profilePath = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-profile-missing-registry-'));
     temporaryRoots.push(profilePath);
     await fs.mkdir(path.join(profilePath, 'agent'), { recursive: true });
@@ -58,6 +58,6 @@ describe('registered workspace identity loading', () => {
       { id: 'profile-missing', path: profilePath },
     ]);
 
-    expect(result).toEqual({ workspaces: [], complete: false });
+    expect(result).toEqual({ workspaces: [], complete: true });
   });
 });

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-registries.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-registries.test.ts
@@ -1,0 +1,63 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { readRegisteredWorkspaceIdentities } from '@electron/features/workspace/runtime/container-cleanup/registries';
+
+const temporaryRoots: string[] = [];
+
+async function createProfile(id: string, workspaces: Array<{ id: string; path: string }>): Promise<{ id: string; path: string }> {
+  const profilePath = await fs.mkdtemp(path.join(os.tmpdir(), `sero-profile-${id}-`));
+  temporaryRoots.push(profilePath);
+  await fs.mkdir(path.join(profilePath, 'agent'), { recursive: true });
+  await fs.writeFile(
+    path.join(profilePath, 'agent', 'workspaces.json'),
+    JSON.stringify({ workspaces }),
+    'utf8',
+  );
+  return { id, path: profilePath };
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('registered workspace identity loading', () => {
+  it('reads workspace registries from every registered profile', async () => {
+    const profileA = await createProfile('profile-a', [{ id: 'one', path: '/workspaces/one' }]);
+    const profileB = await createProfile('profile-b', [{ id: 'two', path: '/workspaces/two' }]);
+
+    const result = await readRegisteredWorkspaceIdentities([profileA, profileB]);
+
+    expect(result.complete).toBe(true);
+    expect(result.workspaces).toEqual([
+      { profileId: 'profile-a', workspaceId: 'one', workspacePath: '/workspaces/one' },
+      { profileId: 'profile-b', workspaceId: 'two', workspacePath: '/workspaces/two' },
+    ]);
+  });
+
+  it('marks reconciliation incomplete when one profile registry is malformed', async () => {
+    const profileA = await createProfile('profile-a', [{ id: 'one', path: '/workspaces/one' }]);
+    const profileB = await createProfile('profile-b', []);
+    await fs.writeFile(path.join(profileB.path, 'agent', 'workspaces.json'), '{broken', 'utf8');
+
+    const result = await readRegisteredWorkspaceIdentities([profileA, profileB]);
+
+    expect(result.complete).toBe(false);
+    expect(result.workspaces).toEqual([
+      { profileId: 'profile-a', workspaceId: 'one', workspacePath: '/workspaces/one' },
+    ]);
+  });
+
+  it('fails closed when a registered profile has no workspace registry', async () => {
+    const profilePath = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-profile-missing-registry-'));
+    temporaryRoots.push(profilePath);
+    await fs.mkdir(path.join(profilePath, 'agent'), { recursive: true });
+
+    const result = await readRegisteredWorkspaceIdentities([
+      { id: 'profile-missing', path: profilePath },
+    ]);
+
+    expect(result).toEqual({ workspaces: [], complete: false });
+  });
+});

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-registries.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-registries.test.ts
@@ -60,4 +60,16 @@ describe('registered workspace identity loading', () => {
 
     expect(result).toEqual({ workspaces: [], complete: true });
   });
+
+  it('fails closed when a missing registry has managed workspace files', async () => {
+    const profilePath = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-profile-lost-registry-'));
+    temporaryRoots.push(profilePath);
+    await fs.mkdir(path.join(profilePath, 'workspaces', 'existing'), { recursive: true });
+
+    const result = await readRegisteredWorkspaceIdentities([
+      { id: 'profile-missing', path: profilePath },
+    ]);
+
+    expect(result).toEqual({ workspaces: [], complete: false });
+  });
 });

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
@@ -11,6 +11,10 @@ const identity = {
   workspaceId: 'workspace-a',
   workspacePath: '/profiles/a/workspaces/workspace-a',
 };
+const providerIdentity = {
+  workspaceId: identity.workspaceId,
+  workspacePath: identity.workspacePath,
+};
 
 async function statePath(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-container-cleanup-'));
@@ -27,6 +31,7 @@ function provider(
 }
 
 afterEach(async () => {
+  vi.useRealTimers();
   await Promise.all(temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
 });
 
@@ -42,8 +47,8 @@ describe('persistent container cleanup', () => {
     const result = await service.requestDeletion(identity);
 
     expect(result.pending).toBe(0);
-    expect(appleDelete).toHaveBeenCalledWith(expect.objectContaining(identity));
-    expect(dockerDelete).toHaveBeenCalledWith(expect.objectContaining(identity));
+    expect(appleDelete).toHaveBeenCalledWith(expect.objectContaining(providerIdentity));
+    expect(dockerDelete).toHaveBeenCalledWith(expect.objectContaining(providerIdentity));
   });
 
   it('survives provider failure and retries after a new service instance starts', async () => {
@@ -59,18 +64,22 @@ describe('persistent container cleanup', () => {
     const retried = await restarted.retryPending();
 
     expect(retried.pending).toBe(0);
-    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(identity));
+    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(providerIdentity));
     const persisted = JSON.parse(await fs.readFile(cleanupStatePath, 'utf8')) as { pending: unknown[] };
     expect(persisted.pending).toEqual([]);
   });
 
-  it('retries shutdown cleanup even while the workspace remains registered', async () => {
+  it('keeps previous-session cleanup pending while its container is running', async () => {
     const cleanupStatePath = await statePath();
     const first = new ContainerCleanupService(cleanupStatePath, []);
     await first.queueRuntimeDeletion(identity, ['docker']);
-    const deleteOwned = vi.fn(async (request: { createdBefore?: string }) => {
+    const deleteOwned = vi.fn(async (request: {
+      createdBefore?: string;
+      skipRunning?: boolean;
+    }) => {
       expect(Date.parse(request.createdBefore ?? '')).not.toBeNaN();
-      return 'deleted' as const;
+      expect(request.skipRunning).toBe(true);
+      return 'preserved' as const;
     });
     const restarted = new ContainerCleanupService(cleanupStatePath, [
       provider('docker', deleteOwned),
@@ -78,8 +87,8 @@ describe('persistent container cleanup', () => {
 
     const result = await restarted.reconcile([identity], true);
 
-    expect(result.pending).toBe(0);
-    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(identity));
+    expect(result.pending).toBe(1);
+    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(providerIdentity));
   });
 
   it('reconciles orphans without deleting workspaces from another registered profile', async () => {
@@ -161,7 +170,45 @@ describe('persistent container cleanup', () => {
     const result = await service.retryPending();
 
     expect(result.deleted).toBe(1);
-    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(identity));
+    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(providerIdentity));
+  });
+
+  it('retries a valid legacy entry without a creation cutoff', async () => {
+    const cleanupStatePath = await statePath();
+    await fs.writeFile(cleanupStatePath, JSON.stringify({
+      version: 1,
+      pending: [{ provider: 'docker', ...identity, cancelWhenRegistered: false }],
+    }), 'utf8');
+    const deleteOwned = vi.fn(async () => 'deleted' as const);
+    const service = new ContainerCleanupService(cleanupStatePath, [
+      provider('docker', deleteOwned),
+    ]);
+
+    const result = await service.retryPending();
+
+    expect(result.deleted).toBe(1);
+    expect(result.pending).toBe(0);
+    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining({
+      ...providerIdentity,
+      skipRunning: true,
+    }));
+  });
+
+  it('refreshes the cutoff when shutdown cleanup is queued again', async () => {
+    vi.useFakeTimers();
+    const cleanupStatePath = await statePath();
+    const service = new ContainerCleanupService(cleanupStatePath, []);
+    vi.setSystemTime(new Date('2026-08-11T22:00:00.000Z'));
+    await service.queueRuntimeDeletion(identity, ['docker']);
+    vi.setSystemTime(new Date('2026-08-11T23:00:00.000Z'));
+    await service.queueRuntimeDeletion(identity, ['docker']);
+
+    const state = JSON.parse(await fs.readFile(cleanupStatePath, 'utf8')) as {
+      pending: Array<{ createdBefore?: string }>;
+    };
+
+    expect(state.pending).toHaveLength(1);
+    expect(state.pending[0]?.createdBefore).toBe('2026-08-11T23:00:00.000Z');
   });
 
   it('does not reconcile orphans when any profile registry is unreadable', async () => {

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
@@ -1,0 +1,125 @@
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ContainerCleanupService } from '@electron/features/workspace/runtime/container-cleanup/service';
+import type { ContainerCleanupProvider } from '@electron/features/workspace/runtime/container-cleanup/types';
+
+const temporaryRoots: string[] = [];
+const identity = {
+  profileId: 'profile-a',
+  workspaceId: 'workspace-a',
+  workspacePath: '/profiles/a/workspaces/workspace-a',
+};
+
+async function statePath(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'sero-container-cleanup-'));
+  temporaryRoots.push(root);
+  return path.join(root, 'container-cleanup.json');
+}
+
+function provider(
+  name: 'apple-container' | 'docker',
+  deleteOwned: ContainerCleanupProvider['deleteOwned'],
+  listOwned: ContainerCleanupProvider['listOwned'] = async () => [],
+): ContainerCleanupProvider {
+  return { provider: name, deleteOwned, listOwned };
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe('persistent container cleanup', () => {
+  it('deletes an uncached workspace through both providers', async () => {
+    const appleDelete = vi.fn(async () => 'absent' as const);
+    const dockerDelete = vi.fn(async () => 'deleted' as const);
+    const service = new ContainerCleanupService(await statePath(), [
+      provider('apple-container', appleDelete),
+      provider('docker', dockerDelete),
+    ]);
+
+    const result = await service.requestDeletion(identity);
+
+    expect(result.pending).toBe(0);
+    expect(appleDelete).toHaveBeenCalledWith(expect.objectContaining(identity));
+    expect(dockerDelete).toHaveBeenCalledWith(expect.objectContaining(identity));
+  });
+
+  it('survives provider failure and retries after a new service instance starts', async () => {
+    const cleanupStatePath = await statePath();
+    const unavailable = provider('docker', vi.fn(async () => { throw new Error('daemon unavailable'); }));
+    const first = new ContainerCleanupService(cleanupStatePath, [unavailable]);
+
+    const failed = await first.requestDeletion(identity, ['docker']);
+    expect(failed.pending).toBe(1);
+
+    const deleteOwned = vi.fn(async () => 'deleted' as const);
+    const restarted = new ContainerCleanupService(cleanupStatePath, [provider('docker', deleteOwned)]);
+    const retried = await restarted.retryPending();
+
+    expect(retried.pending).toBe(0);
+    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(identity));
+    const persisted = JSON.parse(await fs.readFile(cleanupStatePath, 'utf8')) as { pending: unknown[] };
+    expect(persisted.pending).toEqual([]);
+  });
+
+  it('reconciles orphans without deleting workspaces from another registered profile', async () => {
+    const dockerDelete = vi.fn(async () => 'deleted' as const);
+    const appleDelete = vi.fn(async () => 'deleted' as const);
+    const dockerList = vi.fn(async () => [
+      { provider: 'docker' as const, containerId: 'kept', workspaceId: 'shared', workspacePath: '/profiles/b/workspaces/shared' },
+      { provider: 'docker' as const, containerId: 'orphan', workspaceId: 'gone', workspacePath: '/profiles/old/workspaces/gone' },
+    ]);
+    const appleList = vi.fn(async () => [
+      { provider: 'apple-container' as const, containerId: 'apple-orphan', workspaceId: 'apple-gone', workspacePath: '/profiles/old/workspaces/apple-gone' },
+    ]);
+    const service = new ContainerCleanupService(await statePath(), [
+      provider('docker', dockerDelete, dockerList),
+      provider('apple-container', appleDelete, appleList),
+    ]);
+    const result = await service.reconcile([
+      { profileId: 'profile-a', workspaceId: 'workspace-a', workspacePath: '/profiles/a/workspaces/workspace-a' },
+      { profileId: 'profile-b', workspaceId: 'shared', workspacePath: '/profiles/b/workspaces/shared' },
+    ], true);
+
+    expect(result.deleted).toBe(2);
+    expect(dockerDelete).toHaveBeenCalledTimes(1);
+    expect(dockerDelete).toHaveBeenCalledWith(expect.objectContaining({ workspaceId: 'gone' }));
+    expect(appleDelete).toHaveBeenCalledWith(expect.objectContaining({ workspaceId: 'apple-gone' }));
+  });
+
+
+  it('cancels a pending orphan deletion when its workspace is restored', async () => {
+    const deleteOwned = vi.fn(async () => { throw new Error('daemon unavailable'); });
+    const listOwned = vi.fn(async () => [{
+      provider: 'docker' as const,
+      containerId: 'restored',
+      workspaceId: identity.workspaceId,
+      workspacePath: identity.workspacePath,
+    }]);
+    const service = new ContainerCleanupService(await statePath(), [
+      provider('docker', deleteOwned, listOwned),
+    ]);
+    expect((await service.requestDeletion(identity, ['docker'])).pending).toBe(1);
+    deleteOwned.mockClear();
+
+    const result = await service.reconcile([identity], true);
+
+    expect(result.pending).toBe(0);
+    expect(deleteOwned).not.toHaveBeenCalled();
+  });
+  it('does not reconcile orphans when any profile registry is unreadable', async () => {
+    const deleteOwned = vi.fn(async () => 'deleted' as const);
+    const listOwned = vi.fn(async () => [
+      { provider: 'docker' as const, containerId: 'unknown', workspaceId: 'unknown', workspacePath: '/unknown' },
+    ]);
+    const service = new ContainerCleanupService(await statePath(), [provider('docker', deleteOwned, listOwned)]);
+
+    const result = await service.reconcile([], false);
+
+    expect(result.registryComplete).toBe(false);
+    expect(listOwned).not.toHaveBeenCalled();
+    expect(deleteOwned).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
@@ -32,6 +32,7 @@ function provider(
 
 afterEach(async () => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
   await Promise.all(temporaryRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
 });
 
@@ -89,6 +90,21 @@ describe('persistent container cleanup', () => {
 
     expect(result.pending).toBe(1);
     expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(providerIdentity));
+  });
+
+  it('warns when a newer container supersedes a pending deletion', async () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const deleteOwned = vi.fn(async () => 'superseded' as const);
+    const service = new ContainerCleanupService(await statePath(), [
+      provider('docker', deleteOwned),
+    ]);
+
+    const result = await service.requestDeletion(identity, ['docker']);
+
+    expect(result.pending).toBe(0);
+    expect(warning).toHaveBeenCalledWith(
+      `[container-cleanup] Preserved newer docker container for ${identity.workspaceId}`,
+    );
   });
 
   it('reconciles orphans without deleting workspaces from another registered profile', async () => {

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
@@ -68,7 +68,10 @@ describe('persistent container cleanup', () => {
     const cleanupStatePath = await statePath();
     const first = new ContainerCleanupService(cleanupStatePath, []);
     await first.queueRuntimeDeletion(identity, ['docker']);
-    const deleteOwned = vi.fn(async () => 'deleted' as const);
+    const deleteOwned = vi.fn(async (request: { createdBefore?: string }) => {
+      expect(Date.parse(request.createdBefore ?? '')).not.toBeNaN();
+      return 'deleted' as const;
+    });
     const restarted = new ContainerCleanupService(cleanupStatePath, [
       provider('docker', deleteOwned),
     ]);
@@ -135,6 +138,32 @@ describe('persistent container cleanup', () => {
     expect(result.pending).toBe(0);
     await expect(fs.readFile(cleanupStatePath, 'utf8')).resolves.toContain('\"pending\": []');
   });
+
+  it('keeps valid pending deletions when one stored entry is malformed', async () => {
+    const cleanupStatePath = await statePath();
+    await fs.writeFile(cleanupStatePath, JSON.stringify({
+      version: 1,
+      pending: [
+        {
+          provider: 'docker',
+          ...identity,
+          cancelWhenRegistered: true,
+          createdBefore: '2026-08-11T23:00:00.000Z',
+        },
+        { provider: 'docker', ...identity, workspaceId: 'broken', workspacePath: 'relative' },
+      ],
+    }), 'utf8');
+    const deleteOwned = vi.fn(async () => 'deleted' as const);
+    const service = new ContainerCleanupService(cleanupStatePath, [
+      provider('docker', deleteOwned),
+    ]);
+
+    const result = await service.retryPending();
+
+    expect(result.deleted).toBe(1);
+    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(identity));
+  });
+
   it('does not reconcile orphans when any profile registry is unreadable', async () => {
     const deleteOwned = vi.fn(async () => 'deleted' as const);
     const listOwned = vi.fn(async () => [

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/container-cleanup-service.test.ts
@@ -64,6 +64,21 @@ describe('persistent container cleanup', () => {
     expect(persisted.pending).toEqual([]);
   });
 
+  it('retries shutdown cleanup even while the workspace remains registered', async () => {
+    const cleanupStatePath = await statePath();
+    const first = new ContainerCleanupService(cleanupStatePath, []);
+    await first.queueRuntimeDeletion(identity, ['docker']);
+    const deleteOwned = vi.fn(async () => 'deleted' as const);
+    const restarted = new ContainerCleanupService(cleanupStatePath, [
+      provider('docker', deleteOwned),
+    ]);
+
+    const result = await restarted.reconcile([identity], true);
+
+    expect(result.pending).toBe(0);
+    expect(deleteOwned).toHaveBeenCalledWith(expect.objectContaining(identity));
+  });
+
   it('reconciles orphans without deleting workspaces from another registered profile', async () => {
     const dockerDelete = vi.fn(async () => 'deleted' as const);
     const appleDelete = vi.fn(async () => 'deleted' as const);
@@ -108,6 +123,17 @@ describe('persistent container cleanup', () => {
 
     expect(result.pending).toBe(0);
     expect(deleteOwned).not.toHaveBeenCalled();
+  });
+
+  it('repairs a corrupt cleanup state file', async () => {
+    const cleanupStatePath = await statePath();
+    await fs.writeFile(cleanupStatePath, '{broken', 'utf8');
+    const service = new ContainerCleanupService(cleanupStatePath, []);
+
+    const result = await service.retryPending();
+
+    expect(result.pending).toBe(0);
+    await expect(fs.readFile(cleanupStatePath, 'utf8')).resolves.toContain('\"pending\": []');
   });
   it('does not reconcile orphans when any profile registry is unreadable', async () => {
     const deleteOwned = vi.fn(async () => 'deleted' as const);

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/docker-backend.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/docker-backend.test.ts
@@ -42,6 +42,7 @@ describe('Docker runtime backend core', () => {
       '--label', 'ai.sero.managed=true',
       '--label', 'ai.sero.runtime=docker',
       '--label', 'ai.sero.workspaceId=ws-1',
+      '--label', 'ai.sero.workspacePath=/host/workspace',
       '--label', 'ai.sero.image=ghcr.io/sero-labs/sero-node:test',
       '--workdir', '/workspace',
       '--env', 'TERM=xterm-256color',

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/docker-backend.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/docker-backend.test.ts
@@ -36,13 +36,13 @@ describe('Docker runtime backend core', () => {
       readOnlyMounts: ['/tmp/sero-agent/skills', '/tmp/sero-agent/prompts'],
       writableMounts: ['/tmp/sero-shared'],
     }, 'ghcr.io/sero-labs/sero-node:test');
-
     expect(args).toEqual(expect.arrayContaining([
       'run', '-d', '--name', 'sero-ws-1', '--init',
       '--label', 'ai.sero.managed=true',
       '--label', 'ai.sero.runtime=docker',
       '--label', 'ai.sero.workspaceId=ws-1',
       '--label', 'ai.sero.workspacePath=/host/workspace',
+      '--label', 'ai.sero.installationRoot=/tmp/sero-fixed',
       '--label', 'ai.sero.image=ghcr.io/sero-labs/sero-node:test',
       '--workdir', '/workspace',
       '--env', 'TERM=xterm-256color',
@@ -96,7 +96,6 @@ describe('Docker runtime backend core', () => {
     await ensureDockerContainer({ config, imageRef: 'image:test', run });
     expect(calls.map((args) => args[0]).slice(0, 5)).toEqual(['inspect', 'start', 'inspect', 'rm', 'run']);
   });
-
   it('reuses existing Docker containers only when effective bind mounts match', async () => {
     const workspacePath = mkdtempSync(path.join(tmpdir(), 'sero-docker-ws-'));
     const sharedPath = mkdtempSync(path.join(tmpdir(), 'sero-docker-shared-'));
@@ -472,13 +471,13 @@ describe('Docker runtime backend core', () => {
     ]));
   });
 });
-
 function expectedDockerLabels(imageRef: string): Record<string, string> {
   return {
     'ai.sero.managed': 'true',
     'ai.sero.runtime': 'docker',
     'ai.sero.workspaceId': 'ws-1',
     'ai.sero.image': imageRef,
+    'ai.sero.installationRoot': '/tmp/sero-fixed',
   };
 }
 

--- a/apps/desktop/electron/__tests__/features/workspace/runtime/docker-container-ownership.test.ts
+++ b/apps/desktop/electron/__tests__/features/workspace/runtime/docker-container-ownership.test.ts
@@ -1,0 +1,80 @@
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import type { DockerCommandResult, DockerRunner } from '@electron/features/workspace/runtime/backends/docker/docker-cli';
+import { ensureDockerContainer } from '@electron/features/workspace/runtime/backends/docker/docker-lifecycle';
+
+vi.mock('@electron/platform/env', () => ({
+  SERO_AGENT_DIR: '/tmp/sero-agent',
+  SERO_FIXED_ROOT: '/tmp/sero-current',
+  SERO_HOST_ARTIFACTS_ROOT: '/tmp/sero-host-artifacts',
+  SERO_HOME: '/tmp/sero-home',
+}));
+
+const imageRef = 'ghcr.io/sero-labs/sero-node:test';
+
+function ok(stdout = ''): DockerCommandResult {
+  return { stdout, stderr: '', exitCode: 0 };
+}
+
+function labels(installationRoot: string): Record<string, string> {
+  return {
+    'ai.sero.managed': 'true',
+    'ai.sero.runtime': 'docker',
+    'ai.sero.workspaceId': 'workspace-a',
+    'ai.sero.workspacePath': '/old/workspace',
+    'ai.sero.installationRoot': installationRoot,
+    'ai.sero.image': imageRef,
+  };
+}
+
+describe('Docker container ownership recovery', () => {
+  it('rebuilds a current-install container after its workspace path moves', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'sero-docker-moved-'));
+    const calls: string[][] = [];
+    let inspectCount = 0;
+    const run: DockerRunner = vi.fn(async (args) => {
+      calls.push(args);
+      if (args[0] === 'inspect') {
+        inspectCount += 1;
+        return ok(JSON.stringify([{
+          Config: { Image: imageRef, Labels: labels('/tmp/sero-current') },
+          State: { Running: true },
+          Mounts: [{ Type: 'bind', Source: inspectCount === 1 ? '/old/workspace' : workspacePath, Destination: '/workspace', RW: true }],
+        }]));
+      }
+      return ok(args[0] === 'run' ? 'container-id' : '');
+    });
+
+    await ensureDockerContainer({
+      config: { workspaceId: 'workspace-a', hostPath: workspacePath, readOnlyMounts: [], writableMounts: [] },
+      imageRef,
+      run,
+    });
+
+    expect(calls.map((args) => args[0])).toEqual(expect.arrayContaining(['inspect', 'rm', 'run']));
+    expect(calls.findIndex((args) => args[0] === 'rm')).toBeLessThan(calls.findIndex((args) => args[0] === 'run'));
+  });
+
+  it('preserves a same-name container from another installation', async () => {
+    const workspacePath = mkdtempSync(path.join(tmpdir(), 'sero-docker-foreign-'));
+    const run: DockerRunner = vi.fn(async (args) => {
+      if (args[0] === 'inspect') {
+        return ok(JSON.stringify([{
+          Config: { Image: imageRef, Labels: labels('/tmp/sero-other') },
+          State: { Running: true },
+          Mounts: [{ Type: 'bind', Source: workspacePath, Destination: '/workspace', RW: true }],
+        }]));
+      }
+      return ok();
+    });
+
+    await expect(ensureDockerContainer({
+      config: { workspaceId: 'workspace-a', hostPath: workspacePath, readOnlyMounts: [], writableMounts: [] },
+      imageRef,
+      run,
+    })).rejects.toThrow('Docker container name collision');
+    expect(run).not.toHaveBeenCalledWith(expect.arrayContaining(['rm']), expect.anything());
+  });
+});

--- a/apps/desktop/electron/__tests__/ipc/runtime-boundaries.test.ts
+++ b/apps/desktop/electron/__tests__/ipc/runtime-boundaries.test.ts
@@ -102,6 +102,7 @@ vi.mock('@electron/ipc/lib/window-broadcast', () => ({
 
 vi.mock('@electron/platform/env', () => ({
   SERO_AGENT_DIR: '/tmp/sero-agent',
+  SERO_FIXED_ROOT: '/tmp/sero-fixed-root',
 }));
 
 vi.mock('@electron/features/apps/git-app/manager', () => ({

--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -62,6 +62,11 @@ import { discoverApps, registerAppPath } from './features/apps/discovery';
 import { watchForNewApps } from './ipc/apps/apps';
 import { ensureBundledPiDocs, ensureDefaultAgents, ensureDefaultSkills, ensureDefaultThemes, ensureProfileTemplates } from './features/profile/setup';
 import { handleProfileRegistryRecovery } from './features/profile/recovery';
+import { profileManager } from './features/profile/manager';
+import {
+  containerCleanupService,
+  reconcileRegisteredProfileContainers,
+} from './features/workspace/runtime/container-cleanup';
 import {
   appRuntimeManager,
   containerManager,
@@ -288,6 +293,9 @@ app.whenReady().then(async () => {
 
   // Init workspace registry + default workspaces before anything else
   await workspaceManager.init();
+  void reconcileRegisteredProfileContainers(profileManager.list()).catch((error) => {
+    console.warn('[sero] Container reconciliation could not complete:', error);
+  });
 
   // Set up custom protocols for extension UI assets and profile-owned media.
   setupExtProtocol();
@@ -419,6 +427,22 @@ async function withShutdownTimeout(
   }
 }
 
+async function destroyWorkspaceRuntimes(): Promise<void> {
+  for (const identity of runtimeManager.listCachedContainerIdentities()) {
+    await containerCleanupService.queueDeletion(
+      { profileId: ACTIVE_PROFILE_ID ?? '', ...identity },
+      [identity.provider],
+    ).catch((error) => {
+      console.warn(`[sero] Could not persist shutdown cleanup for ${identity.workspaceId}:`, error);
+    });
+  }
+  try {
+    await runtimeManager.destroyAll();
+  } finally {
+    await containerCleanupService.retryPending();
+  }
+}
+
 async function performGracefulShutdown(): Promise<void> {
   const startedAt = Date.now();
   console.log('[sero] Shutting down — cleaning up containers, terminals, LSP, watchers...');
@@ -440,7 +464,7 @@ async function performGracefulShutdown(): Promise<void> {
       },
     ),
     withShutdownTimeout('language servers', () => lspManager.disposeAll()),
-    withShutdownTimeout('runtimes', () => runtimeManager.destroyAll()),
+    withShutdownTimeout('runtimes', destroyWorkspaceRuntimes),
   ]);
 
   console.log(`[sero] Graceful shutdown complete (${Date.now() - startedAt}ms)`);

--- a/apps/desktop/electron/app-main.ts
+++ b/apps/desktop/electron/app-main.ts
@@ -429,7 +429,7 @@ async function withShutdownTimeout(
 
 async function destroyWorkspaceRuntimes(): Promise<void> {
   for (const identity of runtimeManager.listCachedContainerIdentities()) {
-    await containerCleanupService.queueDeletion(
+    await containerCleanupService.queueRuntimeDeletion(
       { profileId: ACTIVE_PROFILE_ID ?? '', ...identity },
       [identity.provider],
     ).catch((error) => {

--- a/apps/desktop/electron/features/container/core/lifecycle.ts
+++ b/apps/desktop/electron/features/container/core/lifecycle.ts
@@ -22,7 +22,7 @@ import {
   type ExecResult,
 } from './types';
 import {
-  identitiesMatch,
+  appleContainerBelongsToWorkspace,
   inspectAppleContainerOwnership,
   seroOwnershipLabels,
 } from './ownership';
@@ -317,7 +317,7 @@ export async function createFreshContainer(
     // recovery if needed) and retry once.
     if (errStr.includes('already exists')) {
       const ownership = await inspectAppleContainerOwnership(cid);
-      if (!ownership.exists || !ownership.identity || !identitiesMatch(ownership.identity, {
+      if (ownership.exists && !appleContainerBelongsToWorkspace(ownership, {
         workspaceId: config.workspaceId,
         workspacePath: config.hostPath,
       })) {

--- a/apps/desktop/electron/features/container/core/lifecycle.ts
+++ b/apps/desktop/electron/features/container/core/lifecycle.ts
@@ -21,6 +21,11 @@ import {
   type ContainerState,
   type ExecResult,
 } from './types';
+import {
+  identitiesMatch,
+  inspectAppleContainerOwnership,
+  seroOwnershipLabels,
+} from './ownership';
 import { getContainerAvailability } from './availability';
 import { prepareWorkspaceLogPortal } from './log-access';
 
@@ -237,6 +242,10 @@ export async function createFreshContainer(
     '--name',
     cid,
     '-d',
+    ...Object.entries(seroOwnershipLabels('apple-container', {
+      workspaceId: config.workspaceId,
+      workspacePath: config.hostPath,
+    })).flatMap(([key, value]) => ['--label', `${key}=${value}`]),
     '--cpus',
     String(config.cpus ?? DEFAULT_CPUS),
     '--memory',
@@ -307,6 +316,13 @@ export async function createFreshContainer(
     // run that wasn't cleaned up), force-remove it (escalating to ghost
     // recovery if needed) and retry once.
     if (errStr.includes('already exists')) {
+      const ownership = await inspectAppleContainerOwnership(cid);
+      if (!ownership.exists || !ownership.identity || !identitiesMatch(ownership.identity, {
+        workspaceId: config.workspaceId,
+        workspacePath: config.hostPath,
+      })) {
+        throw new Error(`Apple Container name collision: ${cid} is not owned by this Sero workspace.`);
+      }
       console.warn(`[container] Stale container ${cid} detected, force-removing and retrying...`);
       await forceRemoveContainer(cid);
       try {
@@ -384,6 +400,7 @@ interface InspectData {
   networks?: Array<{ ipv4Address?: string }>;
 }
 
+
 /** Inspect a container and return its state. */
 export async function inspectContainer(
   workspaceId: string,
@@ -443,8 +460,8 @@ export async function removeContainer(
   const cid = containerMap.get(workspaceId) ?? containerId(workspaceId);
   try {
     await execFileAsync(CONTAINER_BIN, ['delete', '--force', cid], { timeout: 15_000 });
-  } catch {
-    /* May already be removed */
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
   }
   containerMap.delete(workspaceId);
 }

--- a/apps/desktop/electron/features/container/core/ownership.ts
+++ b/apps/desktop/electron/features/container/core/ownership.ts
@@ -1,0 +1,76 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import path from 'path';
+import { CONTAINER_BIN, errorMessage } from './types';
+
+const execFileAsync = promisify(execFile);
+
+interface AppleInspectData {
+  configuration?: { labels?: Record<string, string> };
+}
+
+export type SeroContainerProvider = 'apple-container' | 'docker';
+
+export const SERO_MANAGED_LABEL = 'ai.sero.managed';
+export const SERO_RUNTIME_LABEL = 'ai.sero.runtime';
+export const SERO_WORKSPACE_ID_LABEL = 'ai.sero.workspaceId';
+export const SERO_WORKSPACE_PATH_LABEL = 'ai.sero.workspacePath';
+
+export interface SeroContainerIdentity {
+  workspaceId: string;
+  workspacePath: string;
+}
+
+export function seroOwnershipLabels(
+  provider: SeroContainerProvider,
+  identity: SeroContainerIdentity,
+): Record<string, string> {
+  return {
+    [SERO_MANAGED_LABEL]: 'true',
+    [SERO_RUNTIME_LABEL]: provider,
+    [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
+    [SERO_WORKSPACE_PATH_LABEL]: path.resolve(identity.workspacePath),
+  };
+}
+
+export function readSeroContainerIdentity(
+  provider: SeroContainerProvider,
+  labels: Record<string, string> | undefined,
+): SeroContainerIdentity | null {
+  if (!labels) return null;
+  if (labels[SERO_MANAGED_LABEL] !== 'true') return null;
+  if (labels[SERO_RUNTIME_LABEL] !== provider) return null;
+  const workspaceId = labels[SERO_WORKSPACE_ID_LABEL];
+  const workspacePath = labels[SERO_WORKSPACE_PATH_LABEL];
+  if (!workspaceId || !workspacePath || !path.isAbsolute(workspacePath)) return null;
+  return { workspaceId, workspacePath: path.resolve(workspacePath) };
+}
+
+export function identitiesMatch(
+  left: SeroContainerIdentity,
+  right: SeroContainerIdentity,
+): boolean {
+  return left.workspaceId === right.workspaceId
+    && path.resolve(left.workspacePath) === path.resolve(right.workspacePath);
+}
+
+export async function inspectAppleContainerOwnership(
+  cid: string,
+): Promise<{ exists: boolean; identity: SeroContainerIdentity | null }> {
+  try {
+    const { stdout } = await execFileAsync(CONTAINER_BIN, ['inspect', cid], { timeout: 10_000 });
+    const raw = JSON.parse(stdout) as unknown;
+    const info = (Array.isArray(raw) ? raw[0] : raw) as AppleInspectData | undefined;
+    if (!info || typeof info !== 'object') throw new Error(`Unexpected inspect output for ${cid}`);
+    return {
+      exists: true,
+      identity: readSeroContainerIdentity('apple-container', info.configuration?.labels),
+    };
+  } catch (error) {
+    const message = errorMessage(error).toLowerCase();
+    if (message.includes('not found') || message.includes('no such container') || message.includes('does not exist')) {
+      return { exists: false, identity: null };
+    }
+    throw error;
+  }
+}

--- a/apps/desktop/electron/features/container/core/ownership.ts
+++ b/apps/desktop/electron/features/container/core/ownership.ts
@@ -1,12 +1,16 @@
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import path from 'path';
-import { CONTAINER_BIN, errorMessage } from './types';
+import { SERO_FIXED_ROOT } from '@electron/platform/env';
+import { CONTAINER_BIN, errorMessage, WORKSPACE_MOUNT } from './types';
 
 const execFileAsync = promisify(execFile);
 
 interface AppleInspectData {
-  configuration?: { labels?: Record<string, string> };
+  configuration?: {
+    labels?: Record<string, string>;
+    mounts?: Array<{ source?: string; destination?: string }>;
+  };
 }
 
 export type SeroContainerProvider = 'apple-container' | 'docker';
@@ -15,6 +19,8 @@ export const SERO_MANAGED_LABEL = 'ai.sero.managed';
 export const SERO_RUNTIME_LABEL = 'ai.sero.runtime';
 export const SERO_WORKSPACE_ID_LABEL = 'ai.sero.workspaceId';
 export const SERO_WORKSPACE_PATH_LABEL = 'ai.sero.workspacePath';
+export const SERO_INSTALLATION_ROOT_LABEL = 'ai.sero.installationRoot';
+export const SERO_INSTALLATION_ROOT = path.resolve(SERO_FIXED_ROOT);
 
 export interface SeroContainerIdentity {
   workspaceId: string;
@@ -30,6 +36,7 @@ export function seroOwnershipLabels(
     [SERO_RUNTIME_LABEL]: provider,
     [SERO_WORKSPACE_ID_LABEL]: identity.workspaceId,
     [SERO_WORKSPACE_PATH_LABEL]: path.resolve(identity.workspacePath),
+    [SERO_INSTALLATION_ROOT_LABEL]: SERO_INSTALLATION_ROOT,
   };
 }
 
@@ -54,22 +61,66 @@ export function identitiesMatch(
     && path.resolve(left.workspacePath) === path.resolve(right.workspacePath);
 }
 
+export interface AppleContainerOwnership {
+  exists: boolean;
+  identity: SeroContainerIdentity | null;
+  installationRoot: string | null;
+  workspaceMountSource: string | null;
+}
+
+export function labelsBelongToCurrentInstallation(
+  labels: Record<string, string> | undefined,
+): boolean {
+  return labels?.[SERO_INSTALLATION_ROOT_LABEL] === SERO_INSTALLATION_ROOT;
+}
+
+export function appleContainerBelongsToWorkspace(
+  ownership: AppleContainerOwnership,
+  expected: SeroContainerIdentity,
+): boolean {
+  if (!ownership.exists) return false;
+  if (ownership.installationRoot && ownership.installationRoot !== SERO_INSTALLATION_ROOT) return false;
+  if (ownership.identity) return ownership.identity.workspaceId === expected.workspaceId;
+  return ownership.workspaceMountSource !== null
+    && path.resolve(ownership.workspaceMountSource) === path.resolve(expected.workspacePath);
+}
+
+export function appleContainerHasCurrentIdentity(
+  ownership: AppleContainerOwnership,
+  expected: SeroContainerIdentity,
+): boolean {
+  return ownership.installationRoot === SERO_INSTALLATION_ROOT
+    && ownership.identity !== null
+    && identitiesMatch(ownership.identity, expected);
+}
+
+export function parseAppleContainerOwnership(raw: unknown, cid: string): AppleContainerOwnership {
+  const info = (Array.isArray(raw) ? raw[0] : raw) as AppleInspectData | undefined;
+  if (!info || typeof info !== 'object') throw new Error(`Unexpected inspect output for ${cid}`);
+  const labels = info.configuration?.labels;
+  const workspaceMount = info.configuration?.mounts?.find((mount) => mount.destination === WORKSPACE_MOUNT);
+  return {
+    exists: true,
+    identity: readSeroContainerIdentity('apple-container', labels),
+    installationRoot: labels?.[SERO_INSTALLATION_ROOT_LABEL]
+      ? path.resolve(labels[SERO_INSTALLATION_ROOT_LABEL])
+      : null,
+    workspaceMountSource: workspaceMount?.source && path.isAbsolute(workspaceMount.source)
+      ? path.resolve(workspaceMount.source)
+      : null,
+  };
+}
+
 export async function inspectAppleContainerOwnership(
   cid: string,
-): Promise<{ exists: boolean; identity: SeroContainerIdentity | null }> {
+): Promise<AppleContainerOwnership> {
   try {
     const { stdout } = await execFileAsync(CONTAINER_BIN, ['inspect', cid], { timeout: 10_000 });
-    const raw = JSON.parse(stdout) as unknown;
-    const info = (Array.isArray(raw) ? raw[0] : raw) as AppleInspectData | undefined;
-    if (!info || typeof info !== 'object') throw new Error(`Unexpected inspect output for ${cid}`);
-    return {
-      exists: true,
-      identity: readSeroContainerIdentity('apple-container', info.configuration?.labels),
-    };
+    return parseAppleContainerOwnership(JSON.parse(stdout) as unknown, cid);
   } catch (error) {
     const message = errorMessage(error).toLowerCase();
     if (message.includes('not found') || message.includes('no such container') || message.includes('does not exist')) {
-      return { exists: false, identity: null };
+      return { exists: false, identity: null, installationRoot: null, workspaceMountSource: null };
     }
     throw error;
   }

--- a/apps/desktop/electron/features/container/core/ownership.ts
+++ b/apps/desktop/electron/features/container/core/ownership.ts
@@ -7,7 +7,9 @@ import { CONTAINER_BIN, errorMessage, WORKSPACE_MOUNT } from './types';
 const execFileAsync = promisify(execFile);
 
 interface AppleInspectData {
+  status?: string | { state?: string };
   configuration?: {
+    creationDate?: string | number;
     labels?: Record<string, string>;
     mounts?: Array<{ source?: string; destination?: string }>;
   };
@@ -66,6 +68,8 @@ export interface AppleContainerOwnership {
   identity: SeroContainerIdentity | null;
   installationRoot: string | null;
   workspaceMountSource: string | null;
+  running: boolean | null;
+  createdAt: number | null;
 }
 
 export function labelsBelongToCurrentInstallation(
@@ -94,11 +98,32 @@ export function appleContainerHasCurrentIdentity(
     && identitiesMatch(ownership.identity, expected);
 }
 
+export function shouldRecreateAppleContainer(
+  ownership: AppleContainerOwnership,
+  expected: SeroContainerIdentity,
+): boolean {
+  return appleContainerBelongsToWorkspace(ownership, expected)
+    && !appleContainerHasCurrentIdentity(ownership, expected)
+    && ownership.running === false;
+}
+
+export function parseContainerCreationTime(value: unknown): number | null {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (value > 1_000_000_000_000) return value;
+  if (value >= 1_000_000_000) return value * 1_000;
+  return (value + 978_307_200) * 1_000;
+}
+
 export function parseAppleContainerOwnership(raw: unknown, cid: string): AppleContainerOwnership {
   const info = (Array.isArray(raw) ? raw[0] : raw) as AppleInspectData | undefined;
   if (!info || typeof info !== 'object') throw new Error(`Unexpected inspect output for ${cid}`);
   const labels = info.configuration?.labels;
   const workspaceMount = info.configuration?.mounts?.find((mount) => mount.destination === WORKSPACE_MOUNT);
+  const status = typeof info.status === 'string' ? info.status : info.status?.state;
   return {
     exists: true,
     identity: readSeroContainerIdentity('apple-container', labels),
@@ -108,6 +133,8 @@ export function parseAppleContainerOwnership(raw: unknown, cid: string): AppleCo
     workspaceMountSource: workspaceMount?.source && path.isAbsolute(workspaceMount.source)
       ? path.resolve(workspaceMount.source)
       : null,
+    running: status ? status === 'running' : null,
+    createdAt: parseContainerCreationTime(info.configuration?.creationDate),
   };
 }
 
@@ -120,7 +147,14 @@ export async function inspectAppleContainerOwnership(
   } catch (error) {
     const message = errorMessage(error).toLowerCase();
     if (message.includes('not found') || message.includes('no such container') || message.includes('does not exist')) {
-      return { exists: false, identity: null, installationRoot: null, workspaceMountSource: null };
+      return {
+        exists: false,
+        identity: null,
+        installationRoot: null,
+        workspaceMountSource: null,
+        running: null,
+        createdAt: null,
+      };
     }
     throw error;
   }

--- a/apps/desktop/electron/features/container/core/ownership.ts
+++ b/apps/desktop/electron/features/container/core/ownership.ts
@@ -107,7 +107,7 @@ export function shouldRecreateAppleContainer(
     && ownership.running === false;
 }
 
-export function parseContainerCreationTime(value: unknown): number | null {
+export function parseContainerTimestamp(value: unknown): number | null {
   if (typeof value === 'string') {
     const parsed = Date.parse(value);
     return Number.isNaN(parsed) ? null : parsed;
@@ -134,7 +134,7 @@ export function parseAppleContainerOwnership(raw: unknown, cid: string): AppleCo
       ? path.resolve(workspaceMount.source)
       : null,
     running: status ? status === 'running' : null,
-    startedAt: parseContainerCreationTime(info.startedDate),
+    startedAt: parseContainerTimestamp(info.startedDate),
   };
 }
 

--- a/apps/desktop/electron/features/container/core/ownership.ts
+++ b/apps/desktop/electron/features/container/core/ownership.ts
@@ -71,6 +71,15 @@ export interface AppleContainerOwnership {
   running: boolean | null;
   startedAt: number | null;
 }
+const MISSING_APPLE_CONTAINER_OWNERSHIP: AppleContainerOwnership = {
+  exists: false,
+  identity: null,
+  installationRoot: null,
+  workspaceMountSource: null,
+  running: null,
+  startedAt: null,
+};
+
 
 export function labelsBelongToCurrentInstallation(
   labels: Record<string, string> | undefined,
@@ -119,6 +128,7 @@ export function parseContainerTimestamp(value: unknown): number | null {
 }
 
 export function parseAppleContainerOwnership(raw: unknown, cid: string): AppleContainerOwnership {
+  if (Array.isArray(raw) && raw.length === 0) return MISSING_APPLE_CONTAINER_OWNERSHIP;
   const info = (Array.isArray(raw) ? raw[0] : raw) as AppleInspectData | undefined;
   if (!info || typeof info !== 'object') throw new Error(`Unexpected inspect output for ${cid}`);
   const labels = info.configuration?.labels;
@@ -147,14 +157,7 @@ export async function inspectAppleContainerOwnership(
   } catch (error) {
     const message = errorMessage(error).toLowerCase();
     if (message.includes('not found') || message.includes('no such container') || message.includes('does not exist')) {
-      return {
-        exists: false,
-        identity: null,
-        installationRoot: null,
-        workspaceMountSource: null,
-        running: null,
-        startedAt: null,
-      };
+      return MISSING_APPLE_CONTAINER_OWNERSHIP;
     }
     throw error;
   }

--- a/apps/desktop/electron/features/container/core/ownership.ts
+++ b/apps/desktop/electron/features/container/core/ownership.ts
@@ -8,8 +8,8 @@ const execFileAsync = promisify(execFile);
 
 interface AppleInspectData {
   status?: string | { state?: string };
+  startedDate?: string | number;
   configuration?: {
-    creationDate?: string | number;
     labels?: Record<string, string>;
     mounts?: Array<{ source?: string; destination?: string }>;
   };
@@ -69,7 +69,7 @@ export interface AppleContainerOwnership {
   installationRoot: string | null;
   workspaceMountSource: string | null;
   running: boolean | null;
-  createdAt: number | null;
+  startedAt: number | null;
 }
 
 export function labelsBelongToCurrentInstallation(
@@ -134,7 +134,7 @@ export function parseAppleContainerOwnership(raw: unknown, cid: string): AppleCo
       ? path.resolve(workspaceMount.source)
       : null,
     running: status ? status === 'running' : null,
-    createdAt: parseContainerCreationTime(info.configuration?.creationDate),
+    startedAt: parseContainerCreationTime(info.startedDate),
   };
 }
 
@@ -153,7 +153,7 @@ export async function inspectAppleContainerOwnership(
         installationRoot: null,
         workspaceMountSource: null,
         running: null,
-        createdAt: null,
+        startedAt: null,
       };
     }
     throw error;

--- a/apps/desktop/electron/features/container/index.ts
+++ b/apps/desktop/electron/features/container/index.ts
@@ -27,6 +27,7 @@ import {
   removeContainer,
   listContainers,
 } from './core/lifecycle';
+import { identitiesMatch, inspectAppleContainerOwnership } from './core/ownership';
 import { readContainerFile, writeContainerFile, listContainerFiles } from './filesystem/files';
 import { TerminalManager } from './terminal/terminal';
 import { ensureImage } from './core/image';
@@ -174,6 +175,13 @@ export class ContainerManager {
   private async ensureInternal(config: ContainerConfig): Promise<ContainerState> {
     const cid = containerId(config.workspaceId);
     prepareWorkspaceLogPortal(config.hostPath);
+    const ownership = await inspectAppleContainerOwnership(cid);
+    if (ownership.exists && (!ownership.identity || !identitiesMatch(ownership.identity, {
+      workspaceId: config.workspaceId,
+      workspacePath: config.hostPath,
+    }))) {
+      throw new Error(`Apple Container name collision: ${cid} is not owned by this Sero workspace.`);
+    }
 
     const existingState = await resolveExistingContainer(
       config.workspaceId,

--- a/apps/desktop/electron/features/container/index.ts
+++ b/apps/desktop/electron/features/container/index.ts
@@ -27,7 +27,11 @@ import {
   removeContainer,
   listContainers,
 } from './core/lifecycle';
-import { identitiesMatch, inspectAppleContainerOwnership } from './core/ownership';
+import {
+  appleContainerBelongsToWorkspace,
+  appleContainerHasCurrentIdentity,
+  inspectAppleContainerOwnership,
+} from './core/ownership';
 import { readContainerFile, writeContainerFile, listContainerFiles } from './filesystem/files';
 import { TerminalManager } from './terminal/terminal';
 import { ensureImage } from './core/image';
@@ -176,11 +180,13 @@ export class ContainerManager {
     const cid = containerId(config.workspaceId);
     prepareWorkspaceLogPortal(config.hostPath);
     const ownership = await inspectAppleContainerOwnership(cid);
-    if (ownership.exists && (!ownership.identity || !identitiesMatch(ownership.identity, {
-      workspaceId: config.workspaceId,
-      workspacePath: config.hostPath,
-    }))) {
+    const identity = { workspaceId: config.workspaceId, workspacePath: config.hostPath };
+    if (ownership.exists && !appleContainerBelongsToWorkspace(ownership, identity)) {
       throw new Error(`Apple Container name collision: ${cid} is not owned by this Sero workspace.`);
+    }
+    if (ownership.exists && !appleContainerHasCurrentIdentity(ownership, identity)) {
+      console.log(`[container] Recreating legacy container ${cid} with current ownership labels`);
+      await this.remove(config.workspaceId);
     }
 
     const existingState = await resolveExistingContainer(
@@ -301,6 +307,15 @@ export class ContainerManager {
     await this.portScanner.stopScanning(workspaceId);
     this.containerIps.delete(workspaceId);
     return removeContainer(workspaceId, this.containers);
+  }
+
+  async removeOwned(workspaceId: string, workspacePath: string): Promise<void> {
+    const ownership = await inspectAppleContainerOwnership(containerId(workspaceId));
+    const identity = { workspaceId, workspacePath };
+    if (ownership.exists && !appleContainerBelongsToWorkspace(ownership, identity)) {
+      throw new Error(`Apple Container name collision: ${containerId(workspaceId)} is not owned by this Sero workspace.`);
+    }
+    await this.remove(workspaceId);
   }
 
   async list(): Promise<ContainerState[]> {

--- a/apps/desktop/electron/features/container/index.ts
+++ b/apps/desktop/electron/features/container/index.ts
@@ -29,7 +29,7 @@ import {
 } from './core/lifecycle';
 import {
   appleContainerBelongsToWorkspace,
-  appleContainerHasCurrentIdentity,
+  shouldRecreateAppleContainer,
   inspectAppleContainerOwnership,
 } from './core/ownership';
 import { readContainerFile, writeContainerFile, listContainerFiles } from './filesystem/files';
@@ -184,7 +184,7 @@ export class ContainerManager {
     if (ownership.exists && !appleContainerBelongsToWorkspace(ownership, identity)) {
       throw new Error(`Apple Container name collision: ${cid} is not owned by this Sero workspace.`);
     }
-    if (ownership.exists && !appleContainerHasCurrentIdentity(ownership, identity)) {
+    if (shouldRecreateAppleContainer(ownership, identity)) {
       console.log(`[container] Recreating legacy container ${cid} with current ownership labels`);
       await this.remove(config.workspaceId);
     }

--- a/apps/desktop/electron/features/profile/manager.ts
+++ b/apps/desktop/electron/features/profile/manager.ts
@@ -19,7 +19,7 @@ import os from 'os';
 import path from 'path';
 import { randomUUID } from 'crypto';
 
-import type { ProfileInfo } from '@/types/profile';
+import type { ProfileInfo, ProfileRemovalMode } from '@/types/profile';
 import type { ProfileEntry, ProfileRegistry } from './types';
 
 function resolveSeroRoot(): string {
@@ -41,6 +41,12 @@ export const PROFILE_REGISTRY_PATH = REGISTRY_PATH;
 const DEFAULT_PROFILE_PATH = SERO_ROOT;
 const MANAGED_PROFILES_ROOT = path.join(SERO_ROOT, 'profiles');
 
+
+export function canDeleteProfileFiles(profile: ProfileEntry): boolean {
+  return profile.folderProvenance === 'sero-managed'
+    && path.resolve(profile.path) !== DEFAULT_PROFILE_PATH
+    && isManagedNestedProfilePath(path.resolve(profile.path));
+}
 // ── Registry I/O ────────────────────────────────────────────
 
 function emptyRegistry(): ProfileRegistry {
@@ -88,6 +94,10 @@ function isProfileEntry(value: unknown): value is ProfileEntry {
     && typeof value.name === 'string'
     && typeof value.path === 'string'
     && typeof value.createdAt === 'string'
+    && (value.folderProvenance === undefined
+      || value.folderProvenance === 'default-root'
+      || value.folderProvenance === 'sero-managed'
+      || value.folderProvenance === 'custom')
     && (value.onboarded === undefined || typeof value.onboarded === 'boolean');
 }
 
@@ -175,7 +185,7 @@ function repairIsolatedRootProfiles(registry: ProfileRegistry): boolean {
     }
 
     const repairedPath = defaultManagedPathForName(profile.name, repairedProfiles);
-    repairedProfiles.push({ ...profile, path: repairedPath });
+    repairedProfiles.push({ ...profile, path: repairedPath, folderProvenance: 'sero-managed' });
     mkdirSync(path.join(repairedPath, 'agent'), { recursive: true });
     changed = true;
   }
@@ -246,6 +256,7 @@ class ProfileManager {
   list(): ProfileInfo[] {
     return this.registry.profiles.map((p) => ({
       ...p,
+      canDeleteFiles: canDeleteProfileFiles(p),
       isActive: p.id === this.registry.activeProfileId,
     }));
   }
@@ -298,12 +309,21 @@ class ProfileManager {
     // Ensure the profile directory exists
     await fs.mkdir(resolvedPath, { recursive: true });
     await fs.mkdir(path.join(resolvedPath, 'agent'), { recursive: true });
+    const workspaceRegistryPath = path.join(resolvedPath, 'agent', 'workspaces.json');
+    if (!existsSync(workspaceRegistryPath)) {
+      await fs.writeFile(workspaceRegistryPath, '{\n  "workspaces": []\n}\n', 'utf8');
+    }
 
     const entry: ProfileEntry = {
       id,
       name: name.trim(),
       path: resolvedPath,
       createdAt: new Date().toISOString(),
+      folderProvenance: profilePath
+        ? 'custom'
+        : resolvedPath === DEFAULT_PROFILE_PATH
+          ? 'default-root'
+          : 'sero-managed',
     };
 
     this.registry.profiles.push(entry);
@@ -343,20 +363,27 @@ class ProfileManager {
   }
 
   /**
-   * Delete a profile from the registry.
-   * Does NOT delete files on disk — just unregisters it.
-   * Cannot delete the last/active profile.
+   * Remove an inactive profile from Sero. Files are retained by default.
+   * Managed profile files are deleted only with positive stored provenance.
    */
-  async delete(id: string): Promise<void> {
+  async remove(id: string, mode: ProfileRemovalMode = 'remove'): Promise<void> {
     if (this.registry.profiles.length <= 1) {
-      throw new Error('Cannot delete the only profile');
+      throw new Error('Cannot remove the only profile');
     }
     if (id === this.registry.activeProfileId) {
-      throw new Error('Cannot delete the active profile. Switch to another profile first.');
+      throw new Error('Cannot remove the active profile. Switch to another profile first.');
+    }
+    const profile = this.findById(id);
+    if (!profile) throw new Error(`Profile not found: ${id}`);
+    if (mode === 'delete-files' && !canDeleteProfileFiles(profile)) {
+      throw new Error('Sero cannot verify that it manages this profile folder.');
     }
 
-    this.registry.profiles = this.registry.profiles.filter((p) => p.id !== id);
+    this.registry.profiles = this.registry.profiles.filter((candidate) => candidate.id !== id);
     await writeRegistryAsync(this.registry);
+    if (mode === 'delete-files') {
+      await fs.rm(profile.path, { recursive: true, force: true });
+    }
   }
 
   // ── Helpers ─────────────────────────────────────────────

--- a/apps/desktop/electron/features/profile/migration.ts
+++ b/apps/desktop/electron/features/profile/migration.ts
@@ -56,6 +56,7 @@ export function migrateExistingInstall(): string | null {
         name: 'Default',
         path: SERO_ROOT,
         createdAt: new Date().toISOString(),
+        folderProvenance: 'default-root',
       },
     ],
   };

--- a/apps/desktop/electron/features/profile/types.ts
+++ b/apps/desktop/electron/features/profile/types.ts
@@ -9,6 +9,8 @@
  * and is read before anything else to determine which SERO_HOME to use.
  */
 
+import type { ProfileFolderProvenance } from '@/types/profile';
+
 /** A single profile entry in the registry. */
 export interface ProfileEntry {
   /** Unique identifier (UUID v4). */
@@ -19,6 +21,8 @@ export interface ProfileEntry {
   path: string;
   /** ISO timestamp of when the profile was created. */
   createdAt: string;
+  /** Positive folder origin. Missing means uncertain legacy provenance. */
+  folderProvenance?: ProfileFolderProvenance;
   /** True once onboarding has completed for this profile. */
   onboarded?: boolean;
 }

--- a/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
@@ -138,7 +138,7 @@ export class AppleContainerBackend implements RuntimeBackend {
     }
     // Mirror the Docker backend: destroy fully removes the container rather than just stopping
     // it, so stale Apple Container records do not accumulate across workspace resets.
-    await this.containerManager.remove(this.workspaceId);
+    if (this.session) await this.containerManager.remove(this.workspaceId);
     this.session = null;
     this.sessionIsolated = false;
   }

--- a/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
@@ -144,6 +144,7 @@ export class AppleContainerBackend implements RuntimeBackend {
       this.sessionIsolated = false;
     }
   }
+
   async exec(input: RuntimeExecInput): Promise<RuntimeExecResult> {
     const envPrefix = Object.entries(input.env ?? {})
       .map(([key, value]) => shellEnvAssignment(key, value))

--- a/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
@@ -138,7 +138,7 @@ export class AppleContainerBackend implements RuntimeBackend {
     }
     // Mirror the Docker backend: destroy fully removes the container rather than just stopping
     // it, so stale Apple Container records do not accumulate across workspace resets.
-    if (this.session) await this.containerManager.remove(this.workspaceId);
+    await this.containerManager.removeOwned(this.workspaceId, this.hostWorkspacePath);
     this.session = null;
     this.sessionIsolated = false;
   }

--- a/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/apple-container-backend.ts
@@ -136,13 +136,14 @@ export class AppleContainerBackend implements RuntimeBackend {
         status: 'stopped',
       });
     }
-    // Mirror the Docker backend: destroy fully removes the container rather than just stopping
-    // it, so stale Apple Container records do not accumulate across workspace resets.
-    await this.containerManager.removeOwned(this.workspaceId, this.hostWorkspacePath);
-    this.session = null;
-    this.sessionIsolated = false;
+    // Always clear the cached session, even when container removal fails.
+    try {
+      await this.containerManager.removeOwned(this.workspaceId, this.hostWorkspacePath);
+    } finally {
+      this.session = null;
+      this.sessionIsolated = false;
+    }
   }
-
   async exec(input: RuntimeExecInput): Promise<RuntimeExecResult> {
     const envPrefix = Object.entries(input.env ?? {})
       .map(([key, value]) => shellEnvAssignment(key, value))

--- a/apps/desktop/electron/features/workspace/runtime/backends/docker/docker-backend.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/docker/docker-backend.ts
@@ -66,6 +66,7 @@ export class DockerBackend implements RuntimeBackend {
   readonly workspaceAccess = 'live-mount' as const;
   readonly capabilities: RuntimeCapabilities = getRuntimeCapabilities('docker');
 
+  private containerEnsured = false;
   private readonly workspaceManager: WorkspaceManager;
   private readonly getGitAuthEnvVars?: () => Record<string, string>;
   private readonly imageRef: string;
@@ -109,7 +110,10 @@ export class DockerBackend implements RuntimeBackend {
         status: 'stopped',
       });
     }
-    await this.run(['rm', '-f', dockerContainerName(this.workspaceId)], { timeoutMs: 30_000 });
+    if (this.containerEnsured) {
+      await removeDockerContainer(dockerContainerName(this.workspaceId), this.run);
+      this.containerEnsured = false;
+    }
   }
 
   async exec(input: RuntimeExecInput): Promise<RuntimeExecResult> {
@@ -393,6 +397,7 @@ export class DockerBackend implements RuntimeBackend {
       state = await ensureDockerContainer({ config, imageRef: this.imageRef, imageId: image.imageId, run: this.run, previewPortPoolSize: poolSize });
       await (await this.portManager(poolSize)).refreshFromInspect();
     }
+    this.containerEnsured = true;
     return {
       backend: this.backend,
       workspaceId: this.workspaceId,

--- a/apps/desktop/electron/features/workspace/runtime/backends/docker/docker-lifecycle.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/docker/docker-lifecycle.ts
@@ -1,8 +1,15 @@
 import { execFile } from 'child_process';
 import { mkdirSync } from 'fs';
+import path from 'path';
 import { promisify } from 'util';
 import type { ContainerConfig, ContainerState } from '@electron/features/container/core/types';
 import { containerId, DEFAULT_CPUS, DEFAULT_IMAGE, DEFAULT_MEMORY_MB } from '@electron/features/container/core/types';
+import {
+  SERO_MANAGED_LABEL,
+  SERO_RUNTIME_LABEL,
+  SERO_WORKSPACE_ID_LABEL,
+  SERO_WORKSPACE_PATH_LABEL,
+} from '@electron/features/container/core/ownership';
 import { prepareWorkspaceLogPortal } from '@electron/features/container/core/log-access';
 import { mountArgs, buildDockerMounts } from './docker-mounts';
 import { checkDocker, type DockerRunner } from './docker-cli';
@@ -55,6 +62,9 @@ export async function ensureDockerContainer(options: DockerLifecycleOptions): Pr
         }
       }
     }
+    if (!isSeroOwnedDockerContainer(existing, options.config.workspaceId, options.config.hostPath)) {
+      throw new Error(`Docker container name collision: ${cid} is not owned by Sero.`);
+    }
     await removeDockerContainer(cid, run);
   }
 
@@ -71,9 +81,10 @@ export function createDockerRunArgs(config: ContainerConfig, imageRef: string = 
   const cid = dockerContainerName(config.workspaceId);
   const args = [
     'run', '-d', '--name', cid, '--init',
-    '--label', 'ai.sero.managed=true',
-    '--label', 'ai.sero.runtime=docker',
-    '--label', `ai.sero.workspaceId=${config.workspaceId}`,
+    '--label', `${SERO_MANAGED_LABEL}=true`,
+    '--label', `${SERO_RUNTIME_LABEL}=docker`,
+    '--label', `${SERO_WORKSPACE_ID_LABEL}=${config.workspaceId}`,
+    '--label', `${SERO_WORKSPACE_PATH_LABEL}=${config.hostPath}`,
     '--label', `ai.sero.image=${imageRef}`,
     '--workdir', '/workspace',
     '--cpus', String(config.cpus ?? DEFAULT_CPUS),
@@ -117,7 +128,33 @@ export async function inspectDockerContainer(cid: string, run: DockerRunner = ch
 }
 
 export async function removeDockerContainer(cid: string, run: DockerRunner = checkDocker): Promise<void> {
-  await run(['rm', '-f', cid], { timeoutMs: 30_000 });
+  try {
+    const result = await run(['rm', '-f', cid], { timeoutMs: 30_000 });
+    if (result.exitCode !== 0 && !isDockerNotFound(result.stderr || result.stdout)) {
+      throw new Error(result.stderr || result.stdout || `Failed to remove Docker container ${cid}`);
+    }
+  } catch (error) {
+    if (!isDockerNotFound(error instanceof Error ? error.message : String(error))) throw error;
+  }
+}
+export function isSeroOwnedDockerContainer(
+  inspect: DockerInspectData,
+  workspaceId: string,
+  workspacePath?: string,
+): boolean {
+  const labels = inspect.Config?.Labels ?? {};
+  if (labels[SERO_MANAGED_LABEL] !== 'true'
+    || labels[SERO_RUNTIME_LABEL] !== 'docker'
+    || labels[SERO_WORKSPACE_ID_LABEL] !== workspaceId) return false;
+  if (!workspacePath) return true;
+  const workspaceMount = inspect.Mounts?.find((mount) => mount.Destination === '/workspace');
+  return Boolean(workspaceMount?.Source)
+    && path.resolve(workspaceMount?.Source ?? '') === path.resolve(workspacePath);
+}
+
+function isDockerNotFound(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes('no such container') || normalized.includes('not found');
 }
 
 export function toContainerState(cid: string, inspect: DockerInspectData, imageRef: string): ContainerState {
@@ -137,9 +174,7 @@ function dockerPreviewPublishArgs(poolSize: number): string[] {
 
 function isExpectedContainer(inspect: DockerInspectData, config: ContainerConfig, imageRef: string, imageId?: string): boolean {
   const labels = inspect.Config?.Labels ?? {};
-  if (labels['ai.sero.managed'] !== 'true') return false;
-  if (labels['ai.sero.runtime'] !== 'docker') return false;
-  if (labels['ai.sero.workspaceId'] !== config.workspaceId) return false;
+  if (!isSeroOwnedDockerContainer(inspect, config.workspaceId)) return false;
   if (labels['ai.sero.image'] !== imageRef) return false;
   if (imageId && inspect.Image !== imageId) return false;
   return mountSignaturesMatch(expectedMountSignature(config), actualMountSignature(inspect));

--- a/apps/desktop/electron/features/workspace/runtime/backends/docker/docker-lifecycle.ts
+++ b/apps/desktop/electron/features/workspace/runtime/backends/docker/docker-lifecycle.ts
@@ -6,6 +6,9 @@ import type { ContainerConfig, ContainerState } from '@electron/features/contain
 import { containerId, DEFAULT_CPUS, DEFAULT_IMAGE, DEFAULT_MEMORY_MB } from '@electron/features/container/core/types';
 import {
   SERO_MANAGED_LABEL,
+  SERO_INSTALLATION_ROOT,
+  SERO_INSTALLATION_ROOT_LABEL,
+  labelsBelongToCurrentInstallation,
   SERO_RUNTIME_LABEL,
   SERO_WORKSPACE_ID_LABEL,
   SERO_WORKSPACE_PATH_LABEL,
@@ -62,7 +65,7 @@ export async function ensureDockerContainer(options: DockerLifecycleOptions): Pr
         }
       }
     }
-    if (!isSeroOwnedDockerContainer(existing, options.config.workspaceId, options.config.hostPath)) {
+    if (!isSeroOwnedDockerContainer(existing, options.config.workspaceId)) {
       throw new Error(`Docker container name collision: ${cid} is not owned by Sero.`);
     }
     await removeDockerContainer(cid, run);
@@ -85,6 +88,7 @@ export function createDockerRunArgs(config: ContainerConfig, imageRef: string = 
     '--label', `${SERO_RUNTIME_LABEL}=docker`,
     '--label', `${SERO_WORKSPACE_ID_LABEL}=${config.workspaceId}`,
     '--label', `${SERO_WORKSPACE_PATH_LABEL}=${config.hostPath}`,
+    '--label', `${SERO_INSTALLATION_ROOT_LABEL}=${SERO_INSTALLATION_ROOT}`,
     '--label', `ai.sero.image=${imageRef}`,
     '--workdir', '/workspace',
     '--cpus', String(config.cpus ?? DEFAULT_CPUS),
@@ -140,16 +144,13 @@ export async function removeDockerContainer(cid: string, run: DockerRunner = che
 export function isSeroOwnedDockerContainer(
   inspect: DockerInspectData,
   workspaceId: string,
-  workspacePath?: string,
 ): boolean {
   const labels = inspect.Config?.Labels ?? {};
   if (labels[SERO_MANAGED_LABEL] !== 'true'
     || labels[SERO_RUNTIME_LABEL] !== 'docker'
     || labels[SERO_WORKSPACE_ID_LABEL] !== workspaceId) return false;
-  if (!workspacePath) return true;
-  const workspaceMount = inspect.Mounts?.find((mount) => mount.Destination === '/workspace');
-  return Boolean(workspaceMount?.Source)
-    && path.resolve(workspaceMount?.Source ?? '') === path.resolve(workspacePath);
+  const installationRoot = labels[SERO_INSTALLATION_ROOT_LABEL];
+  return !installationRoot || path.resolve(installationRoot) === SERO_INSTALLATION_ROOT;
 }
 
 function isDockerNotFound(message: string): boolean {
@@ -175,6 +176,7 @@ function dockerPreviewPublishArgs(poolSize: number): string[] {
 function isExpectedContainer(inspect: DockerInspectData, config: ContainerConfig, imageRef: string, imageId?: string): boolean {
   const labels = inspect.Config?.Labels ?? {};
   if (!isSeroOwnedDockerContainer(inspect, config.workspaceId)) return false;
+  if (!labelsBelongToCurrentInstallation(labels)) return false;
   if (labels['ai.sero.image'] !== imageRef) return false;
   if (imageId && inspect.Image !== imageId) return false;
   return mountSignaturesMatch(expectedMountSignature(config), actualMountSignature(inspect));

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/index.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/index.ts
@@ -1,0 +1,33 @@
+import path from 'path';
+import type { ProfileInfo } from '@/types/profile';
+import { PROFILE_REGISTRY_PATH } from '@electron/features/profile/manager';
+import { createAppleContainerCleanupProvider, createDockerCleanupProvider } from './providers';
+import { readRegisteredWorkspaceIdentities } from './registries';
+import { ContainerCleanupService } from './service';
+
+export type {
+  ContainerCleanupProvider,
+  ContainerDeletionResult,
+  OwnedWorkspaceContainer,
+  PendingContainerDeletion,
+  ReconciliationResult,
+  WorkspaceContainerIdentity,
+} from './types';
+export { ContainerCleanupService } from './service';
+export { createAppleContainerCleanupProvider, createDockerCleanupProvider } from './providers';
+export { readProfileWorkspaceIdentities, readRegisteredWorkspaceIdentities } from './registries';
+
+export const containerCleanupService = new ContainerCleanupService(
+  path.join(path.dirname(PROFILE_REGISTRY_PATH), 'container-cleanup.json'),
+  [createAppleContainerCleanupProvider(), createDockerCleanupProvider()],
+);
+
+export async function reconcileRegisteredProfileContainers(
+  profiles: Array<Pick<ProfileInfo, 'id' | 'path'>>,
+): Promise<void> {
+  const registered = await readRegisteredWorkspaceIdentities(profiles);
+  const result = await containerCleanupService.reconcile(registered.workspaces, registered.complete);
+  if (result.pending > 0 || result.providerFailures > 0 || !result.registryComplete) {
+    console.warn('[container-cleanup] Reconciliation remains pending:', result);
+  }
+}

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/index.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/index.ts
@@ -26,7 +26,11 @@ export async function reconcileRegisteredProfileContainers(
   profiles: Array<Pick<ProfileInfo, 'id' | 'path'>>,
 ): Promise<void> {
   const registered = await readRegisteredWorkspaceIdentities(profiles);
-  const result = await containerCleanupService.reconcile(registered.workspaces, registered.complete);
+  const result = await containerCleanupService.reconcile(
+    registered.workspaces,
+    registered.complete,
+    profiles.map((profile) => profile.path),
+  );
   if (result.pending > 0 || result.providerFailures > 0 || !result.registryComplete) {
     console.warn('[container-cleanup] Reconciliation remains pending:', result);
   }

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
@@ -1,0 +1,147 @@
+import { execFile } from 'child_process';
+import path from 'path';
+import { promisify } from 'util';
+import { CONTAINER_BIN, containerId } from '@electron/features/container/core/types';
+import {
+  SERO_MANAGED_LABEL,
+  SERO_RUNTIME_LABEL,
+  SERO_WORKSPACE_ID_LABEL,
+  identitiesMatch,
+  readSeroContainerIdentity,
+  type SeroContainerIdentity,
+} from '@electron/features/container/core/ownership';
+import { checkDocker, type DockerRunner } from '../backends/docker/docker-cli';
+import type {
+  ContainerCleanupProvider,
+  ContainerDeletionResult,
+  OwnedWorkspaceContainer,
+} from './types';
+
+const execFileAsync = promisify(execFile);
+
+interface DockerInspectData {
+  Id?: string;
+  Name?: string;
+  Config?: { Labels?: Record<string, string> };
+  Mounts?: Array<{ Source?: string; Destination?: string }>;
+}
+
+interface AppleInspectData {
+  id?: string;
+  configuration?: {
+    id?: string;
+    labels?: Record<string, string>;
+  };
+}
+
+export type AppleContainerRunner = (args: string[]) => Promise<{ stdout: string }>;
+
+const runAppleContainer: AppleContainerRunner = async (args) => {
+  const result = await execFileAsync(CONTAINER_BIN, args, { timeout: 15_000 });
+  return { stdout: result.stdout };
+};
+
+export function createDockerCleanupProvider(
+  run: DockerRunner = checkDocker,
+): ContainerCleanupProvider {
+  const listInspected = async (): Promise<DockerInspectData[]> => {
+    const listed = await run([
+      'ps', '-a',
+      '--filter', `label=${SERO_MANAGED_LABEL}=true`,
+      '--filter', `label=${SERO_RUNTIME_LABEL}=docker`,
+      '--format', '{{.ID}}',
+    ], { timeoutMs: 15_000 });
+    if (listed.exitCode !== 0) {
+      throw new Error(listed.stderr || listed.stdout || 'Docker container listing failed');
+    }
+
+    const ids = listed.stdout.split('\n').map((id) => id.trim()).filter(Boolean);
+    const containers: DockerInspectData[] = [];
+    for (const id of ids) {
+      const inspected = await run(['inspect', id], { timeoutMs: 10_000 });
+      if (inspected.exitCode !== 0) continue;
+      const parsed = JSON.parse(inspected.stdout) as unknown;
+      const value = Array.isArray(parsed) ? parsed[0] : parsed;
+      if (value && typeof value === 'object') containers.push(value as DockerInspectData);
+    }
+    return containers;
+  };
+
+  const toOwned = (inspect: DockerInspectData): OwnedWorkspaceContainer | null => {
+    const labels = inspect.Config?.Labels;
+    if (labels?.[SERO_MANAGED_LABEL] !== 'true') return null;
+    if (labels[SERO_RUNTIME_LABEL] !== 'docker') return null;
+    const workspaceId = labels[SERO_WORKSPACE_ID_LABEL];
+    const workspaceMount = inspect.Mounts?.find((mount) => mount.Destination === '/workspace');
+    if (!workspaceId || !workspaceMount?.Source || !path.isAbsolute(workspaceMount.Source)) return null;
+    return {
+      provider: 'docker',
+      containerId: (inspect.Name ?? inspect.Id ?? '').replace(/^\//, ''),
+      workspaceId,
+      workspacePath: path.resolve(workspaceMount.Source),
+    };
+  };
+
+  return {
+    provider: 'docker',
+    async listOwned() {
+      return (await listInspected()).flatMap((inspect) => {
+        const owned = toOwned(inspect);
+        return owned ? [owned] : [];
+      });
+    },
+    async deleteOwned(identity): Promise<ContainerDeletionResult> {
+      const candidates = await listInspected();
+      const named = candidates.find((inspect) => {
+        const name = (inspect.Name ?? '').replace(/^\//, '');
+        return name === containerId(identity.workspaceId);
+      });
+      if (!named) return 'absent';
+      const owned = toOwned(named);
+      if (!owned || !identitiesMatch(owned, identity)) return 'preserved';
+      const removed = await run(['rm', '-f', owned.containerId], { timeoutMs: 30_000 });
+      if (removed.exitCode !== 0) {
+        throw new Error(removed.stderr || removed.stdout || `Failed to remove Docker container ${owned.containerId}`);
+      }
+      return 'deleted';
+    },
+  };
+}
+
+export function createAppleContainerCleanupProvider(
+  run: AppleContainerRunner = runAppleContainer,
+): ContainerCleanupProvider {
+  const listInspected = async (): Promise<AppleInspectData[]> => {
+    const result = await run(['list', '--all', '--format', 'json']);
+    const parsed = JSON.parse(result.stdout || '[]') as unknown;
+    if (!Array.isArray(parsed)) throw new Error('Unexpected Apple Container list output');
+    return parsed.filter((value): value is AppleInspectData => typeof value === 'object' && value !== null);
+  };
+
+  const toOwned = (inspect: AppleInspectData): OwnedWorkspaceContainer | null => {
+    const identity = readSeroContainerIdentity('apple-container', inspect.configuration?.labels);
+    const id = inspect.configuration?.id ?? inspect.id;
+    if (!identity || !id) return null;
+    return { provider: 'apple-container', containerId: id, ...identity };
+  };
+
+  return {
+    provider: 'apple-container',
+    async listOwned() {
+      return (await listInspected()).flatMap((inspect) => {
+        const owned = toOwned(inspect);
+        return owned ? [owned] : [];
+      });
+    },
+    async deleteOwned(identity: SeroContainerIdentity): Promise<ContainerDeletionResult> {
+      const candidates = await listInspected();
+      const named = candidates.find((inspect) =>
+        (inspect.configuration?.id ?? inspect.id) === containerId(identity.workspaceId));
+      if (!named) return 'absent';
+      const owned = toOwned(named);
+      if (!owned || !identitiesMatch(owned, identity)) return 'preserved';
+      await run(['delete', '--force', owned.containerId]);
+      return 'deleted';
+    },
+  };
+}

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
@@ -3,11 +3,16 @@ import path from 'path';
 import { promisify } from 'util';
 import { CONTAINER_BIN, containerId } from '@electron/features/container/core/types';
 import {
+  SERO_INSTALLATION_ROOT,
+  SERO_INSTALLATION_ROOT_LABEL,
   SERO_MANAGED_LABEL,
   SERO_RUNTIME_LABEL,
   SERO_WORKSPACE_ID_LABEL,
-  identitiesMatch,
+  appleContainerBelongsToWorkspace,
+  labelsBelongToCurrentInstallation,
+  parseAppleContainerOwnership,
   readSeroContainerIdentity,
+  type AppleContainerOwnership,
   type SeroContainerIdentity,
 } from '@electron/features/container/core/ownership';
 import { checkDocker, type DockerRunner } from '../backends/docker/docker-cli';
@@ -31,6 +36,7 @@ interface AppleInspectData {
   configuration?: {
     id?: string;
     labels?: Record<string, string>;
+    mounts?: Array<{ source?: string; destination?: string }>;
   };
 }
 
@@ -44,11 +50,24 @@ const runAppleContainer: AppleContainerRunner = async (args) => {
 export function createDockerCleanupProvider(
   run: DockerRunner = checkDocker,
 ): ContainerCleanupProvider {
+  const inspectNamed = async (cid: string): Promise<DockerInspectData | null> => {
+    const inspected = await run(['inspect', cid], { timeoutMs: 10_000 });
+    if (inspected.exitCode !== 0) {
+      if (isNotFound(inspected.stderr || inspected.stdout)) return null;
+      throw new Error(inspected.stderr || inspected.stdout || `Docker container inspect failed for ${cid}`);
+    }
+    const parsed = JSON.parse(inspected.stdout) as unknown;
+    const value = Array.isArray(parsed) ? parsed[0] : parsed;
+    if (!value || typeof value !== 'object') throw new Error(`Unexpected Docker inspect output for ${cid}`);
+    return value as DockerInspectData;
+  };
+
   const listInspected = async (): Promise<DockerInspectData[]> => {
     const listed = await run([
       'ps', '-a',
       '--filter', `label=${SERO_MANAGED_LABEL}=true`,
       '--filter', `label=${SERO_RUNTIME_LABEL}=docker`,
+      '--filter', `label=${SERO_INSTALLATION_ROOT_LABEL}=${SERO_INSTALLATION_ROOT}`,
       '--format', '{{.ID}}',
     ], { timeoutMs: 15_000 });
     if (listed.exitCode !== 0) {
@@ -58,19 +77,16 @@ export function createDockerCleanupProvider(
     const ids = listed.stdout.split('\n').map((id) => id.trim()).filter(Boolean);
     const containers: DockerInspectData[] = [];
     for (const id of ids) {
-      const inspected = await run(['inspect', id], { timeoutMs: 10_000 });
-      if (inspected.exitCode !== 0) continue;
-      const parsed = JSON.parse(inspected.stdout) as unknown;
-      const value = Array.isArray(parsed) ? parsed[0] : parsed;
-      if (value && typeof value === 'object') containers.push(value as DockerInspectData);
+      const inspected = await inspectNamed(id);
+      if (inspected) containers.push(inspected);
     }
     return containers;
   };
 
   const toOwned = (inspect: DockerInspectData): OwnedWorkspaceContainer | null => {
     const labels = inspect.Config?.Labels;
-    if (labels?.[SERO_MANAGED_LABEL] !== 'true') return null;
-    if (labels[SERO_RUNTIME_LABEL] !== 'docker') return null;
+    if (!labelsBelongToCurrentInstallation(labels)) return null;
+    if (labels?.[SERO_MANAGED_LABEL] !== 'true' || labels[SERO_RUNTIME_LABEL] !== 'docker') return null;
     const workspaceId = labels[SERO_WORKSPACE_ID_LABEL];
     const workspaceMount = inspect.Mounts?.find((mount) => mount.Destination === '/workspace');
     if (!workspaceId || !workspaceMount?.Source || !path.isAbsolute(workspaceMount.Source)) return null;
@@ -91,17 +107,21 @@ export function createDockerCleanupProvider(
       });
     },
     async deleteOwned(identity): Promise<ContainerDeletionResult> {
-      const candidates = await listInspected();
-      const named = candidates.find((inspect) => {
-        const name = (inspect.Name ?? '').replace(/^\//, '');
-        return name === containerId(identity.workspaceId);
-      });
+      const cid = containerId(identity.workspaceId);
+      const named = await inspectNamed(cid);
       if (!named) return 'absent';
-      const owned = toOwned(named);
-      if (!owned || !identitiesMatch(owned, identity)) return 'preserved';
-      const removed = await run(['rm', '-f', owned.containerId], { timeoutMs: 30_000 });
+      const labels = named.Config?.Labels;
+      if (labels?.[SERO_MANAGED_LABEL] !== 'true'
+        || labels[SERO_RUNTIME_LABEL] !== 'docker'
+        || labels[SERO_WORKSPACE_ID_LABEL] !== identity.workspaceId) return 'preserved';
+      const installationRoot = labels[SERO_INSTALLATION_ROOT_LABEL];
+      if (installationRoot && path.resolve(installationRoot) !== SERO_INSTALLATION_ROOT) return 'preserved';
+      const workspaceMount = named.Mounts?.find((mount) => mount.Destination === '/workspace');
+      if (!installationRoot && (!workspaceMount?.Source
+        || path.resolve(workspaceMount.Source) !== path.resolve(identity.workspacePath))) return 'preserved';
+      const removed = await run(['rm', '-f', cid], { timeoutMs: 30_000 });
       if (removed.exitCode !== 0) {
-        throw new Error(removed.stderr || removed.stdout || `Failed to remove Docker container ${owned.containerId}`);
+        throw new Error(removed.stderr || removed.stdout || `Failed to remove Docker container ${cid}`);
       }
       return 'deleted';
     },
@@ -119,9 +139,13 @@ export function createAppleContainerCleanupProvider(
   };
 
   const toOwned = (inspect: AppleInspectData): OwnedWorkspaceContainer | null => {
-    const identity = readSeroContainerIdentity('apple-container', inspect.configuration?.labels);
+    const labels = inspect.configuration?.labels;
+    if (!labelsBelongToCurrentInstallation(labels)) return null;
+    const identity = readSeroContainerIdentity('apple-container', labels);
     const id = inspect.configuration?.id ?? inspect.id;
-    if (!identity || !id) return null;
+    const workspaceMount = inspect.configuration?.mounts?.find((mount) => mount.destination === '/workspace');
+    if (!identity || !id || !workspaceMount?.source
+      || path.resolve(workspaceMount.source) !== path.resolve(identity.workspacePath)) return null;
     return { provider: 'apple-container', containerId: id, ...identity };
   };
 
@@ -134,14 +158,25 @@ export function createAppleContainerCleanupProvider(
       });
     },
     async deleteOwned(identity: SeroContainerIdentity): Promise<ContainerDeletionResult> {
-      const candidates = await listInspected();
-      const named = candidates.find((inspect) =>
-        (inspect.configuration?.id ?? inspect.id) === containerId(identity.workspaceId));
-      if (!named) return 'absent';
-      const owned = toOwned(named);
-      if (!owned || !identitiesMatch(owned, identity)) return 'preserved';
-      await run(['delete', '--force', owned.containerId]);
+      const cid = containerId(identity.workspaceId);
+      let ownership: AppleContainerOwnership;
+      try {
+        const result = await run(['inspect', cid]);
+        ownership = parseAppleContainerOwnership(JSON.parse(result.stdout) as unknown, cid);
+      } catch (error) {
+        if (isNotFound(error instanceof Error ? error.message : String(error))) return 'absent';
+        throw error;
+      }
+      if (!appleContainerBelongsToWorkspace(ownership, identity)) return 'preserved';
+      await run(['delete', '--force', cid]);
       return 'deleted';
     },
   };
+}
+
+function isNotFound(message: string): boolean {
+  const normalized = message.toLowerCase();
+  return normalized.includes('not found')
+    || normalized.includes('no such container')
+    || normalized.includes('does not exist');
 }

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
@@ -26,6 +26,7 @@ interface DockerInspectData {
   Id?: string;
   Name?: string;
   Created?: string;
+  State?: { Running?: boolean; StartedAt?: string };
   Config?: { Labels?: Record<string, string> };
   Mounts?: Array<{ Source?: string; Destination?: string }>;
 }
@@ -120,7 +121,9 @@ export function createDockerCleanupProvider(
       if (!installationRoot && (!workspaceMount?.Source
         || path.resolve(workspaceMount.Source) !== path.resolve(request.workspacePath))) return 'preserved';
       if (request.createdBefore
-        && !wasCreatedBefore(named.Created, request.createdBefore)) return 'superseded';
+        && (isAfterCutoff(named.Created, request.createdBefore)
+          || isAfterCutoff(named.State?.StartedAt, request.createdBefore))) return 'superseded';
+      if (request.skipRunning && named.State?.Running === true) return 'preserved';
       const removed = await run(['rm', '-f', cid], { timeoutMs: 30_000 });
       if (removed.exitCode !== 0) {
         throw new Error(removed.stderr || removed.stdout || `Failed to remove Docker container ${cid}`);
@@ -151,7 +154,7 @@ export function createAppleContainerCleanupProvider(
       if (!value || typeof value !== 'object') return [];
       const inspect = value as AppleInspectData;
       const id = inspect.configuration?.id ?? inspect.id;
-      return id ? [id] : [];
+      return id?.startsWith('sero-') ? [id] : [];
     });
   };
 
@@ -191,7 +194,8 @@ export function createAppleContainerCleanupProvider(
       if (!ownership) return 'absent';
       if (!appleContainerBelongsToWorkspace(ownership, request)) return 'preserved';
       if (request.createdBefore
-        && !wasCreatedBefore(ownership.createdAt, request.createdBefore)) return 'superseded';
+        && isAfterCutoff(ownership.startedAt, request.createdBefore)) return 'superseded';
+      if (request.skipRunning && ownership.running === true) return 'preserved';
       await run(['delete', '--force', cid]);
       return 'deleted';
     },
@@ -223,8 +227,10 @@ function isWithinProfileRoot(workspacePath: string, profileRoots: string[]): boo
   });
 }
 
-function wasCreatedBefore(createdAt: unknown, cutoff: string): boolean {
-  const createdAtMs = typeof createdAt === 'number' ? createdAt : parseContainerCreationTime(createdAt);
+function isAfterCutoff(observedAt: unknown, cutoff: string): boolean {
+  const observedAtMs = typeof observedAt === 'number'
+    ? observedAt
+    : parseContainerCreationTime(observedAt);
   const cutoffMs = Date.parse(cutoff);
-  return createdAtMs !== null && !Number.isNaN(cutoffMs) && createdAtMs <= cutoffMs;
+  return observedAtMs !== null && !Number.isNaN(cutoffMs) && observedAtMs > cutoffMs;
 }

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
@@ -10,7 +10,7 @@ import {
   SERO_WORKSPACE_ID_LABEL,
   appleContainerBelongsToWorkspace,
   parseAppleContainerOwnership,
-  parseContainerCreationTime,
+  parseContainerTimestamp,
   type AppleContainerOwnership,
 } from '@electron/features/container/core/ownership';
 import { checkDocker, type DockerRunner } from '../backends/docker/docker-cli';
@@ -120,10 +120,13 @@ export function createDockerCleanupProvider(
       const workspaceMount = named.Mounts?.find((mount) => mount.Destination === '/workspace');
       if (!installationRoot && (!workspaceMount?.Source
         || path.resolve(workspaceMount.Source) !== path.resolve(request.workspacePath))) return 'preserved';
-      if (request.createdBefore
-        && (isAfterCutoff(named.Created, request.createdBefore)
-          || isAfterCutoff(named.State?.StartedAt, request.createdBefore))) return 'superseded';
-      if (request.skipRunning && named.State?.Running === true) return 'preserved';
+      const cutoffMs = parseCutoff(request.createdBefore);
+      const startedAt = parseContainerTimestamp(named.State?.StartedAt);
+      if (cutoffMs !== null
+        && (isAfterCutoff(named.Created, cutoffMs)
+          || isAfterCutoff(startedAt, cutoffMs))) return 'superseded';
+      if (request.skipRunning && named.State?.Running === true
+        && (cutoffMs === null || startedAt === null)) return 'preserved';
       const removed = await run(['rm', '-f', cid], { timeoutMs: 30_000 });
       if (removed.exitCode !== 0) {
         throw new Error(removed.stderr || removed.stdout || `Failed to remove Docker container ${cid}`);
@@ -193,9 +196,10 @@ export function createAppleContainerCleanupProvider(
       const ownership = await inspectNamed(cid);
       if (!ownership) return 'absent';
       if (!appleContainerBelongsToWorkspace(ownership, request)) return 'preserved';
-      if (request.createdBefore
-        && isAfterCutoff(ownership.startedAt, request.createdBefore)) return 'superseded';
-      if (request.skipRunning && ownership.running === true) return 'preserved';
+      const cutoffMs = parseCutoff(request.createdBefore);
+      if (cutoffMs !== null && isAfterCutoff(ownership.startedAt, cutoffMs)) return 'superseded';
+      if (request.skipRunning && ownership.running === true
+        && (cutoffMs === null || ownership.startedAt === null)) return 'preserved';
       await run(['delete', '--force', cid]);
       return 'deleted';
     },
@@ -227,10 +231,15 @@ function isWithinProfileRoot(workspacePath: string, profileRoots: string[]): boo
   });
 }
 
-function isAfterCutoff(observedAt: unknown, cutoff: string): boolean {
+function parseCutoff(cutoff: string | undefined): number | null {
+  if (!cutoff) return null;
+  const cutoffMs = Date.parse(cutoff);
+  return Number.isNaN(cutoffMs) ? null : cutoffMs;
+}
+
+function isAfterCutoff(observedAt: unknown, cutoffMs: number): boolean {
   const observedAtMs = typeof observedAt === 'number'
     ? observedAt
-    : parseContainerCreationTime(observedAt);
-  const cutoffMs = Date.parse(cutoff);
-  return observedAtMs !== null && !Number.isNaN(cutoffMs) && observedAtMs > cutoffMs;
+    : parseContainerTimestamp(observedAt);
+  return observedAtMs !== null && observedAtMs > cutoffMs;
 }

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
@@ -9,11 +9,9 @@ import {
   SERO_RUNTIME_LABEL,
   SERO_WORKSPACE_ID_LABEL,
   appleContainerBelongsToWorkspace,
-  labelsBelongToCurrentInstallation,
   parseAppleContainerOwnership,
-  readSeroContainerIdentity,
+  parseContainerCreationTime,
   type AppleContainerOwnership,
-  type SeroContainerIdentity,
 } from '@electron/features/container/core/ownership';
 import { checkDocker, type DockerRunner } from '../backends/docker/docker-cli';
 import type {
@@ -27,6 +25,7 @@ const execFileAsync = promisify(execFile);
 interface DockerInspectData {
   Id?: string;
   Name?: string;
+  Created?: string;
   Config?: { Labels?: Record<string, string> };
   Mounts?: Array<{ Source?: string; Destination?: string }>;
 }
@@ -67,58 +66,61 @@ export function createDockerCleanupProvider(
       'ps', '-a',
       '--filter', `label=${SERO_MANAGED_LABEL}=true`,
       '--filter', `label=${SERO_RUNTIME_LABEL}=docker`,
-      '--filter', `label=${SERO_INSTALLATION_ROOT_LABEL}=${SERO_INSTALLATION_ROOT}`,
       '--format', '{{.ID}}',
     ], { timeoutMs: 15_000 });
     if (listed.exitCode !== 0) {
       throw new Error(listed.stderr || listed.stdout || 'Docker container listing failed');
     }
-
-    const ids = listed.stdout.split('\n').map((id) => id.trim()).filter(Boolean);
     const containers: DockerInspectData[] = [];
-    for (const id of ids) {
+    for (const id of listed.stdout.split('\n').map((value) => value.trim()).filter(Boolean)) {
       const inspected = await inspectNamed(id);
       if (inspected) containers.push(inspected);
     }
     return containers;
   };
 
-  const toOwned = (inspect: DockerInspectData): OwnedWorkspaceContainer | null => {
+  const toOwned = (
+    inspect: DockerInspectData,
+    profileRoots: string[],
+  ): OwnedWorkspaceContainer | null => {
     const labels = inspect.Config?.Labels;
-    if (!labelsBelongToCurrentInstallation(labels)) return null;
     if (labels?.[SERO_MANAGED_LABEL] !== 'true' || labels[SERO_RUNTIME_LABEL] !== 'docker') return null;
     const workspaceId = labels[SERO_WORKSPACE_ID_LABEL];
     const workspaceMount = inspect.Mounts?.find((mount) => mount.Destination === '/workspace');
     if (!workspaceId || !workspaceMount?.Source || !path.isAbsolute(workspaceMount.Source)) return null;
+    const workspacePath = path.resolve(workspaceMount.Source);
+    if (!belongsToCurrentInstallation(labels, workspacePath, profileRoots)) return null;
     return {
       provider: 'docker',
       containerId: (inspect.Name ?? inspect.Id ?? '').replace(/^\//, ''),
       workspaceId,
-      workspacePath: path.resolve(workspaceMount.Source),
+      workspacePath,
     };
   };
 
   return {
     provider: 'docker',
-    async listOwned() {
+    async listOwned(profileRoots) {
       return (await listInspected()).flatMap((inspect) => {
-        const owned = toOwned(inspect);
+        const owned = toOwned(inspect, profileRoots);
         return owned ? [owned] : [];
       });
     },
-    async deleteOwned(identity): Promise<ContainerDeletionResult> {
-      const cid = containerId(identity.workspaceId);
+    async deleteOwned(request): Promise<ContainerDeletionResult> {
+      const cid = containerId(request.workspaceId);
       const named = await inspectNamed(cid);
       if (!named) return 'absent';
       const labels = named.Config?.Labels;
       if (labels?.[SERO_MANAGED_LABEL] !== 'true'
         || labels[SERO_RUNTIME_LABEL] !== 'docker'
-        || labels[SERO_WORKSPACE_ID_LABEL] !== identity.workspaceId) return 'preserved';
+        || labels[SERO_WORKSPACE_ID_LABEL] !== request.workspaceId) return 'preserved';
       const installationRoot = labels[SERO_INSTALLATION_ROOT_LABEL];
       if (installationRoot && path.resolve(installationRoot) !== SERO_INSTALLATION_ROOT) return 'preserved';
       const workspaceMount = named.Mounts?.find((mount) => mount.Destination === '/workspace');
       if (!installationRoot && (!workspaceMount?.Source
-        || path.resolve(workspaceMount.Source) !== path.resolve(identity.workspacePath))) return 'preserved';
+        || path.resolve(workspaceMount.Source) !== path.resolve(request.workspacePath))) return 'preserved';
+      if (request.createdBefore
+        && !wasCreatedBefore(named.Created, request.createdBefore)) return 'superseded';
       const removed = await run(['rm', '-f', cid], { timeoutMs: 30_000 });
       if (removed.exitCode !== 0) {
         throw new Error(removed.stderr || removed.stdout || `Failed to remove Docker container ${cid}`);
@@ -131,43 +133,65 @@ export function createDockerCleanupProvider(
 export function createAppleContainerCleanupProvider(
   run: AppleContainerRunner = runAppleContainer,
 ): ContainerCleanupProvider {
-  const listInspected = async (): Promise<AppleInspectData[]> => {
+  const inspectNamed = async (cid: string): Promise<AppleContainerOwnership | null> => {
+    try {
+      const result = await run(['inspect', cid]);
+      return parseAppleContainerOwnership(JSON.parse(result.stdout) as unknown, cid);
+    } catch (error) {
+      if (isNotFound(error instanceof Error ? error.message : String(error))) return null;
+      throw error;
+    }
+  };
+
+  const listIds = async (): Promise<string[]> => {
     const result = await run(['list', '--all', '--format', 'json']);
     const parsed = JSON.parse(result.stdout || '[]') as unknown;
     if (!Array.isArray(parsed)) throw new Error('Unexpected Apple Container list output');
-    return parsed.filter((value): value is AppleInspectData => typeof value === 'object' && value !== null);
+    return parsed.flatMap((value) => {
+      if (!value || typeof value !== 'object') return [];
+      const inspect = value as AppleInspectData;
+      const id = inspect.configuration?.id ?? inspect.id;
+      return id ? [id] : [];
+    });
   };
 
-  const toOwned = (inspect: AppleInspectData): OwnedWorkspaceContainer | null => {
-    const labels = inspect.configuration?.labels;
-    if (!labelsBelongToCurrentInstallation(labels)) return null;
-    const identity = readSeroContainerIdentity('apple-container', labels);
-    const id = inspect.configuration?.id ?? inspect.id;
-    const workspaceMount = inspect.configuration?.mounts?.find((mount) => mount.destination === '/workspace');
-    if (!identity || !id || !workspaceMount?.source
-      || path.resolve(workspaceMount.source) !== path.resolve(identity.workspacePath)) return null;
-    return { provider: 'apple-container', containerId: id, ...identity };
+  const toOwned = (
+    cid: string,
+    ownership: AppleContainerOwnership,
+    profileRoots: string[],
+  ): OwnedWorkspaceContainer | null => {
+    const workspacePath = ownership.workspaceMountSource;
+    if (!workspacePath) return null;
+    if (ownership.installationRoot) {
+      if (ownership.installationRoot !== SERO_INSTALLATION_ROOT || !ownership.identity) return null;
+      return { provider: 'apple-container', containerId: cid, ...ownership.identity, workspacePath };
+    }
+    if (!isWithinProfileRoot(workspacePath, profileRoots)) return null;
+    const workspaceId = ownership.identity?.workspaceId
+      ?? (cid.startsWith('sero-') ? cid.slice('sero-'.length) : '');
+    if (!workspaceId) return null;
+    return { provider: 'apple-container', containerId: cid, workspaceId, workspacePath };
   };
 
   return {
     provider: 'apple-container',
-    async listOwned() {
-      return (await listInspected()).flatMap((inspect) => {
-        const owned = toOwned(inspect);
-        return owned ? [owned] : [];
-      });
-    },
-    async deleteOwned(identity: SeroContainerIdentity): Promise<ContainerDeletionResult> {
-      const cid = containerId(identity.workspaceId);
-      let ownership: AppleContainerOwnership;
-      try {
-        const result = await run(['inspect', cid]);
-        ownership = parseAppleContainerOwnership(JSON.parse(result.stdout) as unknown, cid);
-      } catch (error) {
-        if (isNotFound(error instanceof Error ? error.message : String(error))) return 'absent';
-        throw error;
+    async listOwned(profileRoots) {
+      const owned: OwnedWorkspaceContainer[] = [];
+      for (const cid of await listIds()) {
+        const inspected = await inspectNamed(cid);
+        if (!inspected) continue;
+        const container = toOwned(cid, inspected, profileRoots);
+        if (container) owned.push(container);
       }
-      if (!appleContainerBelongsToWorkspace(ownership, identity)) return 'preserved';
+      return owned;
+    },
+    async deleteOwned(request): Promise<ContainerDeletionResult> {
+      const cid = containerId(request.workspaceId);
+      const ownership = await inspectNamed(cid);
+      if (!ownership) return 'absent';
+      if (!appleContainerBelongsToWorkspace(ownership, request)) return 'preserved';
+      if (request.createdBefore
+        && !wasCreatedBefore(ownership.createdAt, request.createdBefore)) return 'superseded';
       await run(['delete', '--force', cid]);
       return 'deleted';
     },
@@ -179,4 +203,28 @@ function isNotFound(message: string): boolean {
   return normalized.includes('not found')
     || normalized.includes('no such container')
     || normalized.includes('does not exist');
+}
+
+function belongsToCurrentInstallation(
+  labels: Record<string, string>,
+  workspacePath: string,
+  profileRoots: string[],
+): boolean {
+  const installationRoot = labels[SERO_INSTALLATION_ROOT_LABEL];
+  return installationRoot
+    ? path.resolve(installationRoot) === SERO_INSTALLATION_ROOT
+    : isWithinProfileRoot(workspacePath, profileRoots);
+}
+
+function isWithinProfileRoot(workspacePath: string, profileRoots: string[]): boolean {
+  return profileRoots.some((root) => {
+    const relative = path.relative(path.resolve(root), path.resolve(workspacePath));
+    return relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
+  });
+}
+
+function wasCreatedBefore(createdAt: unknown, cutoff: string): boolean {
+  const createdAtMs = typeof createdAt === 'number' ? createdAt : parseContainerCreationTime(createdAt);
+  const cutoffMs = Date.parse(cutoff);
+  return createdAtMs !== null && !Number.isNaN(cutoffMs) && createdAtMs <= cutoffMs;
 }

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/providers.ts
@@ -13,7 +13,7 @@ import {
   parseContainerTimestamp,
   type AppleContainerOwnership,
 } from '@electron/features/container/core/ownership';
-import { checkDocker, type DockerRunner } from '../backends/docker/docker-cli';
+import { runDocker, type DockerRunner } from '../backends/docker/docker-cli';
 import type {
   ContainerCleanupProvider,
   ContainerDeletionResult,
@@ -48,7 +48,7 @@ const runAppleContainer: AppleContainerRunner = async (args) => {
 };
 
 export function createDockerCleanupProvider(
-  run: DockerRunner = checkDocker,
+  run: DockerRunner = runDocker,
 ): ContainerCleanupProvider {
   const inspectNamed = async (cid: string): Promise<DockerInspectData | null> => {
     const inspected = await run(['inspect', cid], { timeoutMs: 10_000 });
@@ -142,7 +142,8 @@ export function createAppleContainerCleanupProvider(
   const inspectNamed = async (cid: string): Promise<AppleContainerOwnership | null> => {
     try {
       const result = await run(['inspect', cid]);
-      return parseAppleContainerOwnership(JSON.parse(result.stdout) as unknown, cid);
+      const ownership = parseAppleContainerOwnership(JSON.parse(result.stdout) as unknown, cid);
+      return ownership.exists ? ownership : null;
     } catch (error) {
       if (isNotFound(error instanceof Error ? error.message : String(error))) return null;
       throw error;
@@ -210,6 +211,7 @@ function isNotFound(message: string): boolean {
   const normalized = message.toLowerCase();
   return normalized.includes('not found')
     || normalized.includes('no such container')
+    || normalized.includes('no such object')
     || normalized.includes('does not exist');
 }
 

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/registries.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/registries.ts
@@ -21,8 +21,7 @@ export async function readProfileWorkspaceIdentities(
     raw = await fs.readFile(registryPath, 'utf8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      console.warn(`[container-cleanup] Missing workspace registry ${registryPath}`);
-      return { workspaces: [], complete: false };
+      return { workspaces: [], complete: true };
     }
     console.warn(`[container-cleanup] Could not read workspace registry ${registryPath}:`, error);
     return { workspaces: [], complete: false };

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/registries.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/registries.ts
@@ -21,7 +21,17 @@ export async function readProfileWorkspaceIdentities(
     raw = await fs.readFile(registryPath, 'utf8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return { workspaces: [], complete: true };
+      const managedWorkspacesPath = path.join(profile.path, 'workspaces');
+      try {
+        const entries = await fs.readdir(managedWorkspacesPath);
+        return { workspaces: [], complete: entries.length === 0 };
+      } catch (workspaceError) {
+        if ((workspaceError as NodeJS.ErrnoException).code === 'ENOENT') {
+          return { workspaces: [], complete: true };
+        }
+        console.warn(`[container-cleanup] Could not inspect ${managedWorkspacesPath}:`, workspaceError);
+        return { workspaces: [], complete: false };
+      }
     }
     console.warn(`[container-cleanup] Could not read workspace registry ${registryPath}:`, error);
     return { workspaces: [], complete: false };

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/registries.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/registries.ts
@@ -1,0 +1,64 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { ProfileInfo } from '@/types/profile';
+import type { WorkspaceContainerIdentity } from './types';
+
+interface WorkspaceRegistryFile {
+  workspaces?: unknown;
+}
+
+export interface RegisteredWorkspaceReadResult {
+  workspaces: WorkspaceContainerIdentity[];
+  complete: boolean;
+}
+
+export async function readProfileWorkspaceIdentities(
+  profile: Pick<ProfileInfo, 'id' | 'path'>,
+): Promise<RegisteredWorkspaceReadResult> {
+  const registryPath = path.join(profile.path, 'agent', 'workspaces.json');
+  let raw: string;
+  try {
+    raw = await fs.readFile(registryPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      console.warn(`[container-cleanup] Missing workspace registry ${registryPath}`);
+      return { workspaces: [], complete: false };
+    }
+    console.warn(`[container-cleanup] Could not read workspace registry ${registryPath}:`, error);
+    return { workspaces: [], complete: false };
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as WorkspaceRegistryFile;
+    if (!parsed || !Array.isArray(parsed.workspaces)) {
+      return { workspaces: [], complete: false };
+    }
+    const workspaces: WorkspaceContainerIdentity[] = [];
+    for (const value of parsed.workspaces) {
+      if (!value || typeof value !== 'object') return { workspaces: [], complete: false };
+      const entry = value as { id?: unknown; path?: unknown };
+      if (typeof entry.id !== 'string' || typeof entry.path !== 'string' || !path.isAbsolute(entry.path)) {
+        return { workspaces: [], complete: false };
+      }
+      workspaces.push({
+        profileId: profile.id,
+        workspaceId: entry.id,
+        workspacePath: path.resolve(entry.path),
+      });
+    }
+    return { workspaces, complete: true };
+  } catch (error) {
+    console.warn(`[container-cleanup] Invalid workspace registry ${registryPath}:`, error);
+    return { workspaces: [], complete: false };
+  }
+}
+
+export async function readRegisteredWorkspaceIdentities(
+  profiles: Array<Pick<ProfileInfo, 'id' | 'path'>>,
+): Promise<RegisteredWorkspaceReadResult> {
+  const results = await Promise.all(profiles.map((profile) => readProfileWorkspaceIdentities(profile)));
+  return {
+    workspaces: results.flatMap((result) => result.workspaces),
+    complete: results.every((result) => result.complete),
+  };
+}

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
@@ -31,7 +31,22 @@ export class ContainerCleanupService {
   ): Promise<void> {
     return this.exclusive(async () => {
       const state = await this.readState();
-      for (const provider of providers) this.addPending(state, { provider, ...identity });
+      for (const provider of providers) {
+        this.addPending(state, { provider, ...identity, cancelWhenRegistered: true });
+      }
+      await this.writeState(state);
+    });
+  }
+
+  queueRuntimeDeletion(
+    identity: WorkspaceContainerIdentity,
+    providers: SeroContainerProvider[] = ['apple-container', 'docker'],
+  ): Promise<void> {
+    return this.exclusive(async () => {
+      const state = await this.readState();
+      for (const provider of providers) {
+        this.addPending(state, { provider, ...identity, cancelWhenRegistered: false });
+      }
       await this.writeState(state);
     });
   }
@@ -42,7 +57,9 @@ export class ContainerCleanupService {
   ): Promise<ReconciliationResult> {
     return this.exclusive(async () => {
       const state = await this.readState();
-      for (const provider of providers) this.addPending(state, { provider, ...identity });
+      for (const provider of providers) {
+        this.addPending(state, { provider, ...identity, cancelWhenRegistered: true });
+      }
       await this.writeState(state);
       return this.retryState(state);
     });
@@ -61,7 +78,8 @@ export class ContainerCleanupService {
       if (registryComplete) {
         const pendingBeforeValidation = state.pending.length;
         state.pending = state.pending.filter((pending) =>
-          !validWorkspaces.some((workspace) => identitiesMatch(pending, workspace)));
+          pending.cancelWhenRegistered === false
+          || !validWorkspaces.some((workspace) => identitiesMatch(pending, workspace)));
         if (state.pending.length !== pendingBeforeValidation) await this.writeState(state);
       }
       const result = await this.retryState(state);
@@ -79,6 +97,7 @@ export class ContainerCleanupService {
               profileId: '',
               workspaceId: container.workspaceId,
               workspacePath: container.workspacePath,
+              cancelWhenRegistered: true,
             });
             added = true;
           }
@@ -129,9 +148,13 @@ export class ContainerCleanupService {
   }
 
   private addPending(state: ContainerCleanupState, entry: PendingContainerDeletion): void {
-    const exists = state.pending.some((candidate) =>
+    const existing = state.pending.find((candidate) =>
       candidate.provider === entry.provider && identitiesMatch(candidate, entry));
-    if (!exists) state.pending.push(entry);
+    if (!existing) {
+      state.pending.push(entry);
+      return;
+    }
+    if (entry.cancelWhenRegistered === false) existing.cancelWhenRegistered = false;
   }
 
   private async readState(): Promise<ContainerCleanupState> {
@@ -142,11 +165,14 @@ export class ContainerCleanupService {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { version: 1, pending: [] };
       throw error;
     }
-    const parsed = JSON.parse(raw) as unknown;
-    if (!isCleanupState(parsed)) {
-      throw new Error(`Invalid container cleanup state: ${this.statePath}`);
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (isCleanupState(parsed)) return parsed;
+      console.warn(`[container-cleanup] Invalid cleanup state ${this.statePath}; resetting it`);
+    } catch (error) {
+      console.warn(`[container-cleanup] Could not parse cleanup state ${this.statePath}; resetting it:`, error);
     }
-    return parsed;
+    return { version: 1, pending: [] };
   }
 
   private async writeState(state: ContainerCleanupState): Promise<void> {
@@ -178,5 +204,6 @@ function isPendingDeletion(value: unknown): value is PendingContainerDeletion {
     && typeof entry.profileId === 'string'
     && typeof entry.workspaceId === 'string'
     && typeof entry.workspacePath === 'string'
-    && path.isAbsolute(entry.workspacePath);
+    && path.isAbsolute(entry.workspacePath)
+    && (entry.cancelWhenRegistered === undefined || typeof entry.cancelWhenRegistered === 'boolean');
 }

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
@@ -127,10 +127,6 @@ export class ContainerCleanupService {
     const result = { ...EMPTY_RESULT };
     const remaining: PendingContainerDeletion[] = [];
     for (const pending of state.pending) {
-      if (!pending.createdBefore) {
-        result.preserved += 1;
-        continue;
-      }
       const provider = this.providers.find((candidate) => candidate.provider === pending.provider);
       if (!provider) {
         remaining.push(pending);
@@ -138,7 +134,12 @@ export class ContainerCleanupService {
         continue;
       }
       try {
-        const outcome = await provider.deleteOwned(pending);
+        const outcome = await provider.deleteOwned({
+          workspaceId: pending.workspaceId,
+          workspacePath: pending.workspacePath,
+          createdBefore: pending.createdBefore,
+          skipRunning: pending.cancelWhenRegistered === false,
+        });
         if (outcome === 'deleted') result.deleted += 1;
         if (outcome === 'preserved') {
           result.preserved += 1;
@@ -164,6 +165,7 @@ export class ContainerCleanupService {
       return;
     }
     if (entry.cancelWhenRegistered === false) existing.cancelWhenRegistered = false;
+    // A repeated shutdown request targets the container current at the latest cutoff.
     existing.createdBefore = entry.createdBefore;
   }
 

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
@@ -1,0 +1,182 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { identitiesMatch, type SeroContainerProvider } from '@electron/features/container/core/ownership';
+import type {
+  ContainerCleanupProvider,
+  ContainerCleanupState,
+  PendingContainerDeletion,
+  ReconciliationResult,
+  WorkspaceContainerIdentity,
+} from './types';
+
+const EMPTY_RESULT: ReconciliationResult = {
+  pending: 0,
+  deleted: 0,
+  preserved: 0,
+  providerFailures: 0,
+  registryComplete: true,
+};
+
+export class ContainerCleanupService {
+  private serial: Promise<unknown> = Promise.resolve();
+
+  constructor(
+    private readonly statePath: string,
+    private readonly providers: ContainerCleanupProvider[],
+  ) {}
+
+  queueDeletion(
+    identity: WorkspaceContainerIdentity,
+    providers: SeroContainerProvider[] = ['apple-container', 'docker'],
+  ): Promise<void> {
+    return this.exclusive(async () => {
+      const state = await this.readState();
+      for (const provider of providers) this.addPending(state, { provider, ...identity });
+      await this.writeState(state);
+    });
+  }
+
+  requestDeletion(
+    identity: WorkspaceContainerIdentity,
+    providers: SeroContainerProvider[] = ['apple-container', 'docker'],
+  ): Promise<ReconciliationResult> {
+    return this.exclusive(async () => {
+      const state = await this.readState();
+      for (const provider of providers) this.addPending(state, { provider, ...identity });
+      await this.writeState(state);
+      return this.retryState(state);
+    });
+  }
+
+  retryPending(): Promise<ReconciliationResult> {
+    return this.exclusive(async () => this.retryState(await this.readState()));
+  }
+
+  reconcile(
+    validWorkspaces: WorkspaceContainerIdentity[],
+    registryComplete: boolean,
+  ): Promise<ReconciliationResult> {
+    return this.exclusive(async () => {
+      const state = await this.readState();
+      if (registryComplete) {
+        const pendingBeforeValidation = state.pending.length;
+        state.pending = state.pending.filter((pending) =>
+          !validWorkspaces.some((workspace) => identitiesMatch(pending, workspace)));
+        if (state.pending.length !== pendingBeforeValidation) await this.writeState(state);
+      }
+      const result = await this.retryState(state);
+      result.registryComplete = registryComplete;
+      if (!registryComplete) return result;
+      let added = false;
+      for (const provider of this.providers) {
+        try {
+          const containers = await provider.listOwned();
+          for (const container of containers) {
+            const exists = validWorkspaces.some((workspace) => identitiesMatch(container, workspace));
+            if (exists) continue;
+            this.addPending(state, {
+              provider: provider.provider,
+              profileId: '',
+              workspaceId: container.workspaceId,
+              workspacePath: container.workspacePath,
+            });
+            added = true;
+          }
+        } catch (error) {
+          result.providerFailures += 1;
+          console.warn(`[container-cleanup] Could not list ${provider.provider} containers:`, error);
+        }
+      }
+      if (added) await this.writeState(state);
+      const orphanResult = await this.retryState(state);
+      return {
+        pending: orphanResult.pending,
+        deleted: result.deleted + orphanResult.deleted,
+        preserved: result.preserved + orphanResult.preserved,
+        providerFailures: result.providerFailures + orphanResult.providerFailures,
+        registryComplete,
+      };
+    });
+  }
+
+  private async retryState(state: ContainerCleanupState): Promise<ReconciliationResult> {
+    const result = { ...EMPTY_RESULT };
+    const remaining: PendingContainerDeletion[] = [];
+    for (const pending of state.pending) {
+      const provider = this.providers.find((candidate) => candidate.provider === pending.provider);
+      if (!provider) {
+        remaining.push(pending);
+        result.providerFailures += 1;
+        continue;
+      }
+      try {
+        const outcome = await provider.deleteOwned(pending);
+        if (outcome === 'deleted') result.deleted += 1;
+        if (outcome === 'preserved') {
+          result.preserved += 1;
+          remaining.push(pending);
+        }
+      } catch (error) {
+        remaining.push(pending);
+        result.providerFailures += 1;
+        console.warn(`[container-cleanup] Could not delete ${pending.provider} container for ${pending.workspaceId}:`, error);
+      }
+    }
+    state.pending = remaining;
+    result.pending = remaining.length;
+    await this.writeState(state);
+    return result;
+  }
+
+  private addPending(state: ContainerCleanupState, entry: PendingContainerDeletion): void {
+    const exists = state.pending.some((candidate) =>
+      candidate.provider === entry.provider && identitiesMatch(candidate, entry));
+    if (!exists) state.pending.push(entry);
+  }
+
+  private async readState(): Promise<ContainerCleanupState> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.statePath, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { version: 1, pending: [] };
+      throw error;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isCleanupState(parsed)) {
+      throw new Error(`Invalid container cleanup state: ${this.statePath}`);
+    }
+    return parsed;
+  }
+
+  private async writeState(state: ContainerCleanupState): Promise<void> {
+    await fs.mkdir(path.dirname(this.statePath), { recursive: true });
+    const temporaryPath = `${this.statePath}.${process.pid}.tmp`;
+    await fs.writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+    await fs.rename(temporaryPath, this.statePath);
+  }
+
+  private exclusive<T>(operation: () => Promise<T>): Promise<T> {
+    const next = this.serial.then(operation, operation);
+    this.serial = next.then(() => undefined, () => undefined);
+    return next;
+  }
+}
+
+function isCleanupState(value: unknown): value is ContainerCleanupState {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<ContainerCleanupState>;
+  return candidate.version === 1
+    && Array.isArray(candidate.pending)
+    && candidate.pending.every((entry) => isPendingDeletion(entry));
+}
+
+function isPendingDeletion(value: unknown): value is PendingContainerDeletion {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Partial<PendingContainerDeletion>;
+  return (entry.provider === 'apple-container' || entry.provider === 'docker')
+    && typeof entry.profileId === 'string'
+    && typeof entry.workspaceId === 'string'
+    && typeof entry.workspacePath === 'string'
+    && path.isAbsolute(entry.workspacePath);
+}

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
@@ -31,8 +31,9 @@ export class ContainerCleanupService {
   ): Promise<void> {
     return this.exclusive(async () => {
       const state = await this.readState();
+      const createdBefore = new Date().toISOString();
       for (const provider of providers) {
-        this.addPending(state, { provider, ...identity, cancelWhenRegistered: true });
+        this.addPending(state, { provider, ...identity, cancelWhenRegistered: true, createdBefore });
       }
       await this.writeState(state);
     });
@@ -44,8 +45,9 @@ export class ContainerCleanupService {
   ): Promise<void> {
     return this.exclusive(async () => {
       const state = await this.readState();
+      const createdBefore = new Date().toISOString();
       for (const provider of providers) {
-        this.addPending(state, { provider, ...identity, cancelWhenRegistered: false });
+        this.addPending(state, { provider, ...identity, cancelWhenRegistered: false, createdBefore });
       }
       await this.writeState(state);
     });
@@ -57,8 +59,9 @@ export class ContainerCleanupService {
   ): Promise<ReconciliationResult> {
     return this.exclusive(async () => {
       const state = await this.readState();
+      const createdBefore = new Date().toISOString();
       for (const provider of providers) {
-        this.addPending(state, { provider, ...identity, cancelWhenRegistered: true });
+        this.addPending(state, { provider, ...identity, cancelWhenRegistered: true, createdBefore });
       }
       await this.writeState(state);
       return this.retryState(state);
@@ -72,6 +75,7 @@ export class ContainerCleanupService {
   reconcile(
     validWorkspaces: WorkspaceContainerIdentity[],
     registryComplete: boolean,
+    profileRoots: string[] = [],
   ): Promise<ReconciliationResult> {
     return this.exclusive(async () => {
       const state = await this.readState();
@@ -88,7 +92,7 @@ export class ContainerCleanupService {
       let added = false;
       for (const provider of this.providers) {
         try {
-          const containers = await provider.listOwned();
+          const containers = await provider.listOwned(profileRoots);
           for (const container of containers) {
             const exists = validWorkspaces.some((workspace) => identitiesMatch(container, workspace));
             if (exists) continue;
@@ -98,6 +102,7 @@ export class ContainerCleanupService {
               workspaceId: container.workspaceId,
               workspacePath: container.workspacePath,
               cancelWhenRegistered: true,
+              createdBefore: new Date().toISOString(),
             });
             added = true;
           }
@@ -122,6 +127,10 @@ export class ContainerCleanupService {
     const result = { ...EMPTY_RESULT };
     const remaining: PendingContainerDeletion[] = [];
     for (const pending of state.pending) {
+      if (!pending.createdBefore) {
+        result.preserved += 1;
+        continue;
+      }
       const provider = this.providers.find((candidate) => candidate.provider === pending.provider);
       if (!provider) {
         remaining.push(pending);
@@ -155,6 +164,7 @@ export class ContainerCleanupService {
       return;
     }
     if (entry.cancelWhenRegistered === false) existing.cancelWhenRegistered = false;
+    existing.createdBefore = entry.createdBefore;
   }
 
   private async readState(): Promise<ContainerCleanupState> {
@@ -167,7 +177,13 @@ export class ContainerCleanupService {
     }
     try {
       const parsed = JSON.parse(raw) as unknown;
-      if (isCleanupState(parsed)) return parsed;
+      if (hasCleanupStateShape(parsed)) {
+        const pending = parsed.pending.filter(isPendingDeletion);
+        if (pending.length !== parsed.pending.length) {
+          console.warn(`[container-cleanup] Ignored malformed entries in ${this.statePath}`);
+        }
+        return { version: 1, pending };
+      }
       console.warn(`[container-cleanup] Invalid cleanup state ${this.statePath}; resetting it`);
     } catch (error) {
       console.warn(`[container-cleanup] Could not parse cleanup state ${this.statePath}; resetting it:`, error);
@@ -189,12 +205,12 @@ export class ContainerCleanupService {
   }
 }
 
-function isCleanupState(value: unknown): value is ContainerCleanupState {
+function hasCleanupStateShape(
+  value: unknown,
+): value is { version: 1; pending: unknown[] } {
   if (!value || typeof value !== 'object') return false;
   const candidate = value as Partial<ContainerCleanupState>;
-  return candidate.version === 1
-    && Array.isArray(candidate.pending)
-    && candidate.pending.every((entry) => isPendingDeletion(entry));
+  return candidate.version === 1 && Array.isArray(candidate.pending);
 }
 
 function isPendingDeletion(value: unknown): value is PendingContainerDeletion {
@@ -205,5 +221,7 @@ function isPendingDeletion(value: unknown): value is PendingContainerDeletion {
     && typeof entry.workspaceId === 'string'
     && typeof entry.workspacePath === 'string'
     && path.isAbsolute(entry.workspacePath)
-    && (entry.cancelWhenRegistered === undefined || typeof entry.cancelWhenRegistered === 'boolean');
+    && (entry.cancelWhenRegistered === undefined || typeof entry.cancelWhenRegistered === 'boolean')
+    && (entry.createdBefore === undefined
+      || (typeof entry.createdBefore === 'string' && !Number.isNaN(Date.parse(entry.createdBefore))));
 }

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/service.ts
@@ -141,6 +141,9 @@ export class ContainerCleanupService {
           skipRunning: pending.cancelWhenRegistered === false,
         });
         if (outcome === 'deleted') result.deleted += 1;
+        if (outcome === 'superseded') {
+          console.warn(`[container-cleanup] Preserved newer ${pending.provider} container for ${pending.workspaceId}`);
+        }
         if (outcome === 'preserved') {
           result.preserved += 1;
           remaining.push(pending);

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
@@ -6,6 +6,7 @@ export interface WorkspaceContainerIdentity extends SeroContainerIdentity {
 
 export interface PendingContainerDeletion extends WorkspaceContainerIdentity {
   provider: SeroContainerProvider;
+  cancelWhenRegistered?: boolean;
 }
 
 export interface OwnedWorkspaceContainer extends SeroContainerIdentity {

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
@@ -1,0 +1,35 @@
+import type { SeroContainerIdentity, SeroContainerProvider } from '@electron/features/container/core/ownership';
+
+export interface WorkspaceContainerIdentity extends SeroContainerIdentity {
+  profileId: string;
+}
+
+export interface PendingContainerDeletion extends WorkspaceContainerIdentity {
+  provider: SeroContainerProvider;
+}
+
+export interface OwnedWorkspaceContainer extends SeroContainerIdentity {
+  provider: SeroContainerProvider;
+  containerId: string;
+}
+
+export type ContainerDeletionResult = 'deleted' | 'absent' | 'preserved';
+
+export interface ContainerCleanupProvider {
+  readonly provider: SeroContainerProvider;
+  listOwned(): Promise<OwnedWorkspaceContainer[]>;
+  deleteOwned(identity: SeroContainerIdentity): Promise<ContainerDeletionResult>;
+}
+
+export interface ContainerCleanupState {
+  version: 1;
+  pending: PendingContainerDeletion[];
+}
+
+export interface ReconciliationResult {
+  pending: number;
+  deleted: number;
+  preserved: number;
+  providerFailures: number;
+  registryComplete: boolean;
+}

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
@@ -4,22 +4,26 @@ export interface WorkspaceContainerIdentity extends SeroContainerIdentity {
   profileId: string;
 }
 
+export interface ContainerDeletionRequest extends SeroContainerIdentity {
+  createdBefore?: string;
+}
+
 export interface PendingContainerDeletion extends WorkspaceContainerIdentity {
   provider: SeroContainerProvider;
   cancelWhenRegistered?: boolean;
+  createdBefore?: string;
 }
 
 export interface OwnedWorkspaceContainer extends SeroContainerIdentity {
   provider: SeroContainerProvider;
   containerId: string;
 }
-
-export type ContainerDeletionResult = 'deleted' | 'absent' | 'preserved';
+export type ContainerDeletionResult = 'deleted' | 'absent' | 'preserved' | 'superseded';
 
 export interface ContainerCleanupProvider {
   readonly provider: SeroContainerProvider;
-  listOwned(): Promise<OwnedWorkspaceContainer[]>;
-  deleteOwned(identity: SeroContainerIdentity): Promise<ContainerDeletionResult>;
+  listOwned(profileRoots: string[]): Promise<OwnedWorkspaceContainer[]>;
+  deleteOwned(request: ContainerDeletionRequest): Promise<ContainerDeletionResult>;
 }
 
 export interface ContainerCleanupState {

--- a/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
+++ b/apps/desktop/electron/features/workspace/runtime/container-cleanup/types.ts
@@ -6,6 +6,7 @@ export interface WorkspaceContainerIdentity extends SeroContainerIdentity {
 
 export interface ContainerDeletionRequest extends SeroContainerIdentity {
   createdBefore?: string;
+  skipRunning?: boolean;
 }
 
 export interface PendingContainerDeletion extends WorkspaceContainerIdentity {

--- a/apps/desktop/electron/features/workspace/runtime/runtime-manager.ts
+++ b/apps/desktop/electron/features/workspace/runtime/runtime-manager.ts
@@ -1,5 +1,6 @@
 import type { ContainerManager } from '@electron/features/container';
 import { containerManager } from '@electron/features/container/core/singleton';
+import type { SeroContainerIdentity, SeroContainerProvider } from '@electron/features/container/core/ownership';
 import type { WorkspaceManager } from '@electron/features/workspace/manager';
 import { workspaceManager } from '@electron/features/workspace/manager';
 import { AppleContainerBackend } from './backends/apple-container-backend';
@@ -212,6 +213,17 @@ export class RuntimeManager {
       this.backends.delete(key);
     }
     throwFirstRejected(results);
+  }
+
+  listCachedContainerIdentities(): Array<SeroContainerIdentity & { provider: SeroContainerProvider }> {
+    return [...this.backends.values()].flatMap((runtime) => {
+      if (runtime.backend === 'host') return [];
+      return [{
+        provider: runtime.backend,
+        workspaceId: runtime.workspaceId,
+        workspacePath: runtime.hostWorkspacePath,
+      }];
+    });
   }
 
   async destroyAll(): Promise<void> {

--- a/apps/desktop/electron/ipc/workspace/profiles.ts
+++ b/apps/desktop/electron/ipc/workspace/profiles.ts
@@ -8,6 +8,10 @@
 import { app, dialog, ipcMain } from 'electron';
 import { IpcChannels } from '@/types/ipc-channels';
 import { profileManager } from '@electron/features/profile/manager';
+import {
+  containerCleanupService,
+  readProfileWorkspaceIdentities,
+} from '@electron/features/workspace/runtime/container-cleanup';
 import { clearLoadedProfileEnvForRelaunch } from '@electron/platform/env';
 import {
   applyLegacyProviderDefaultsMigration,
@@ -21,7 +25,7 @@ import {
 } from '@electron/shared/settings/settings-helpers';
 import { copyProfileDataSync, profileHasTransferableData } from '@electron/features/profile/copy-profile-data';
 
-import type { ProfileInfo } from '@/types/profile';
+import type { ProfileInfo, ProfileRemovalMode } from '@/types/profile';
 import type { GlobalModelConfigInput, GlobalModelConfigState } from '@/types/ipc';
 
 function readSettingsForModelConfig(): Record<string, unknown> {
@@ -54,9 +58,7 @@ export function registerProfileHandlers(): void {
 
   /** Get the currently active profile. */
   ipcMain.handle(IpcChannels.profiles.getActive, (): ProfileInfo | null => {
-    const active = profileManager.getActive();
-    if (!active) return null;
-    return { ...active, isActive: true };
+    return profileManager.list().find((profile) => profile.isActive) ?? null;
   });
 
   /** Check if a valid active profile exists. */
@@ -79,7 +81,9 @@ export function registerProfileHandlers(): void {
         }
       }
 
-      return { ...entry, isActive: entry.id === profileManager.getActiveId() };
+      const created = profileManager.list().find((profile) => profile.id === entry.id);
+      if (!created) throw new Error(`Created profile not found: ${entry.id}`);
+      return created;
     },
   );
 
@@ -110,11 +114,27 @@ export function registerProfileHandlers(): void {
     },
   );
 
-  /** Delete a profile (unregister only — files are not deleted). */
+  /** Remove an inactive profile, with optional safe managed-folder deletion. */
   ipcMain.handle(
-    IpcChannels.profiles.delete,
-    async (_e, id: string): Promise<void> => {
-      await profileManager.delete(id);
+    IpcChannels.profiles.remove,
+    async (_e, id: string, mode: ProfileRemovalMode = 'remove'): Promise<void> => {
+      const profile = profileManager.findById(id);
+      if (!profile) throw new Error(`Profile not found: ${id}`);
+      const profiles = profileManager.list();
+      if (profiles.length <= 1) throw new Error('Cannot remove the only profile');
+      if (profile.id === profileManager.getActiveId()) {
+        throw new Error('Cannot remove the active profile. Switch to another profile first.');
+      }
+      if (mode === 'delete-files' && !profiles.find((candidate) => candidate.id === id)?.canDeleteFiles) {
+        throw new Error('Sero cannot verify that it manages this profile folder.');
+      }
+      const registered = await readProfileWorkspaceIdentities(profile);
+      for (const workspace of registered.workspaces) {
+        await containerCleanupService.requestDeletion(workspace).catch((error) => {
+          console.warn(`[profiles] Could not queue container cleanup for ${workspace.workspaceId}:`, error);
+        });
+      }
+      await profileManager.remove(id, mode);
     },
   );
 

--- a/apps/desktop/electron/ipc/workspace/workspace.ts
+++ b/apps/desktop/electron/ipc/workspace/workspace.ts
@@ -11,6 +11,8 @@ import type { WorkspaceInfo, WorkspaceConfig, WorkspaceCreateOptions, WorkspaceR
 import type { WorkspaceRuntimeBackend, WorkspaceRuntimeConfig } from '@/types/workspace-runtime';
 import type { BrowserPackStatusIPC, ToolchainStatusIPC, WorkspaceAccessRootsResult, WorkspaceRuntimeDiagnosticsIPC } from '@sero-ai/common';
 import { workspaceManager } from '@electron/features/workspace/manager';
+import { ACTIVE_PROFILE_ID } from '@electron/platform/env';
+import { containerCleanupService } from '@electron/features/workspace/runtime/container-cleanup';
 import { isWorkspaceRuntimeBackend } from '@electron/features/workspace/runtime/config';
 import { listWorkspaceAccessRoots } from '@electron/features/workspace/access-roots';
 import { resolveWorkspaceRuntime } from '@electron/features/workspace/runtime-resolution';
@@ -140,6 +142,15 @@ export function registerWorkspaceHandlers(): void {
   ipcMain.handle(
     IpcChannels.workspace.delete,
     async (_event, id: string): Promise<void> => {
+      const workspacePath = workspaceManager.getPath(id);
+      if (!workspacePath) throw new Error(`Workspace not found: ${id}`);
+      await containerCleanupService.queueDeletion({
+        profileId: ACTIVE_PROFILE_ID ?? '',
+        workspaceId: id,
+        workspacePath,
+      }).catch((error) => {
+        console.warn(`[workspace:delete] Could not persist container cleanup for ${id}:`, error);
+      });
       // Release everything holding the workspace directory BEFORE erasing it:
       //  1. terminals + container backend (runtimeManager)
       //  2. plugin app-runtimes (orchestrator, cron, …) — these keep a cwd/state
@@ -153,6 +164,9 @@ export function registerWorkspaceHandlers(): void {
       teardown.catch(() => undefined); // Avoid an unhandled rejection if it settles after the timeout.
       await withTimeout(teardown, RUNTIME_TEARDOWN_TIMEOUT_MS, `runtime teardown for ${id}`).catch((err) => {
         console.error(`[workspace:delete] runtime teardown failed/slow for ${id}:`, err);
+      });
+      await containerCleanupService.retryPending().catch((error) => {
+        console.warn(`[workspace:delete] Container cleanup remains pending for ${id}:`, error);
       });
 
       await workspaceManager.delete(id);

--- a/apps/desktop/electron/preload/api/core.ts
+++ b/apps/desktop/electron/preload/api/core.ts
@@ -20,6 +20,7 @@ import type {
   WorkspaceInfo,
   WorkspaceRoot,
 } from '@/types/ipc';
+import type { ProfileRemovalMode } from '@/types/profile';
 import type { WorkspaceRuntimeBackend, WorkspaceRuntimeConfig } from '@/types/workspace-runtime';
 import type {
   BrowserPackProgressIPC,
@@ -57,7 +58,8 @@ export const profilesBridge = {
   switch: (id: string): Promise<void> => ipcRenderer.invoke(IpcChannels.profiles.switch, id),
   rename: (id: string, newName: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.profiles.rename, id, newName),
-  delete: (id: string): Promise<void> => ipcRenderer.invoke(IpcChannels.profiles.delete, id),
+  remove: (id: string, mode: ProfileRemovalMode): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.profiles.remove, id, mode),
   pickFolder: (): Promise<string | null> =>
     ipcRenderer.invoke(IpcChannels.profiles.pickFolder),
   needsOnboarding: (): Promise<boolean> =>

--- a/apps/desktop/src/components/profiles/ProfileOperations.test.tsx
+++ b/apps/desktop/src/components/profiles/ProfileOperations.test.tsx
@@ -17,6 +17,7 @@ const profileBridge = {
   create: vi.fn(),
   list: vi.fn(),
   switch: vi.fn(),
+  remove: vi.fn(),
   getActive: vi.fn(),
   listAuthSources: vi.fn(),
   pickFolder: vi.fn(),
@@ -61,6 +62,14 @@ function findButton(label: string): HTMLButtonElement {
   return button as HTMLButtonElement;
 }
 
+function findExactButton(label: string): HTMLButtonElement {
+  const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.trim() === label,
+  );
+  if (!button) throw new Error(`Expected button with label "${label}"`);
+  return button as HTMLButtonElement;
+}
+
 function findProfileNameInput(): HTMLInputElement {
   const input = document.querySelector('#profile-name');
   if (!(input instanceof HTMLInputElement)) {
@@ -84,6 +93,7 @@ describe('profile operation error surfaces', () => {
       path: '/profiles/next',
       createdAt: '2026-04-15T00:00:00.000Z',
       isActive: false,
+      canDeleteFiles: false,
     });
     profileBridge.list.mockResolvedValue([]);
     profileBridge.switch.mockRejectedValue(new Error('Profile switch blocked'));
@@ -91,6 +101,7 @@ describe('profile operation error surfaces', () => {
     profileBridge.listAuthSources.mockResolvedValue([]);
     profileBridge.pickFolder.mockResolvedValue(null);
     profileBridge.hasActive.mockResolvedValue(false);
+    profileBridge.remove.mockResolvedValue(undefined);
 
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -121,6 +132,7 @@ describe('profile operation error surfaces', () => {
       path: '/profiles/next',
       createdAt: '2026-04-15T00:00:00.000Z',
       isActive: false,
+      canDeleteFiles: false,
     };
     profileBridge.create.mockResolvedValue(createdProfile);
     profileBridge.list.mockResolvedValue([createdProfile]);
@@ -150,6 +162,7 @@ describe('profile operation error surfaces', () => {
       path: '/profiles/current',
       createdAt: '2026-04-14T00:00:00.000Z',
       isActive: true,
+      canDeleteFiles: false,
     };
     const createdProfile: ProfileInfo = {
       id: 'profile-next',
@@ -157,6 +170,7 @@ describe('profile operation error surfaces', () => {
       path: '/profiles/next',
       createdAt: '2026-04-15T00:00:00.000Z',
       isActive: false,
+      canDeleteFiles: false,
     };
     profileBridge.getActive.mockResolvedValue(existingProfile);
     profileBridge.listAuthSources.mockResolvedValue([existingProfile]);
@@ -197,6 +211,7 @@ describe('profile operation error surfaces', () => {
       path: '/profiles/current',
       createdAt: '2026-04-14T00:00:00.000Z',
       isActive: true,
+      canDeleteFiles: false,
     };
     const nextProfile: ProfileInfo = {
       id: 'profile-next',
@@ -204,6 +219,7 @@ describe('profile operation error surfaces', () => {
       path: '/profiles/research',
       createdAt: '2026-04-15T00:00:00.000Z',
       isActive: false,
+      canDeleteFiles: false,
     };
     useProfileStore.setState({
       profiles: [activeProfile, nextProfile],
@@ -232,5 +248,57 @@ describe('profile operation error surfaces', () => {
     });
 
     expect(findButton('Research').disabled).toBe(false);
+  });
+
+  it('defaults inactive profile management to file-retaining removal', async () => {
+    const active: ProfileInfo = {
+      id: 'active', name: 'Current', path: '/profiles/current',
+      createdAt: '2026-04-14T00:00:00.000Z', isActive: true, canDeleteFiles: false,
+    };
+    const custom: ProfileInfo = {
+      id: 'custom', name: 'Custom', path: '/custom/profile',
+      createdAt: '2026-04-15T00:00:00.000Z', isActive: false, canDeleteFiles: false,
+    };
+    useProfileStore.setState({ profiles: [active, custom], activeProfile: active, hasActiveProfile: true });
+    profileBridge.list.mockResolvedValue([active]);
+
+    await act(async () => { root?.render(<ProfileSwitcher />); });
+    await act(async () => { findButton('Current').click(); });
+    const manage = document.querySelector('button[aria-label=\"Manage Custom\"]');
+    if (!(manage instanceof HTMLButtonElement)) throw new Error('Expected profile management button');
+    await act(async () => { manage.click(); });
+
+    expect(document.body.textContent).toContain('Remove profile');
+    expect(document.body.textContent).toContain('Choose what to do with the files for Custom.');
+    expect(document.body.textContent).not.toContain('Delete files');
+    await act(async () => { findExactButton('Retain files').click(); });
+    await vi.waitFor(() => expect(profileBridge.remove).toHaveBeenCalledWith('custom', 'remove'));
+  });
+
+  it('shows a permanent warning only for a proven Sero-managed profile folder', async () => {
+    const active: ProfileInfo = {
+      id: 'active', name: 'Current', path: '/profiles/current',
+      createdAt: '2026-04-14T00:00:00.000Z', isActive: true, canDeleteFiles: false,
+    };
+    const managed: ProfileInfo = {
+      id: 'managed', name: 'Research', path: '/profiles/research',
+      createdAt: '2026-04-15T00:00:00.000Z', isActive: false, canDeleteFiles: true,
+      folderProvenance: 'sero-managed',
+    };
+    useProfileStore.setState({ profiles: [active, managed], activeProfile: active, hasActiveProfile: true });
+    profileBridge.list.mockResolvedValue([active]);
+
+    await act(async () => { root?.render(<ProfileSwitcher />); });
+    await act(async () => { findButton('Current').click(); });
+    const manage = document.querySelector('button[aria-label=\"Manage Research\"]');
+    if (!(manage instanceof HTMLButtonElement)) throw new Error('Expected profile management button');
+    await act(async () => { manage.click(); });
+    await act(async () => { findExactButton('Delete files').click(); });
+
+    expect(document.body.textContent).toContain('Are you sure?');
+    expect(document.body.textContent).toContain('You cannot undo this');
+    expect(document.body.textContent).toContain('/profiles/research');
+    await act(async () => { findExactButton('Delete').click(); });
+    await vi.waitFor(() => expect(profileBridge.remove).toHaveBeenCalledWith('managed', 'delete-files'));
   });
 });

--- a/apps/desktop/src/components/profiles/ProfileRemovalMenu.tsx
+++ b/apps/desktop/src/components/profiles/ProfileRemovalMenu.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { MoreHorizontal } from 'lucide-react';
+import { Button } from '@sero-ai/ui/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@sero-ai/ui/components/ui/dialog';
+import type { ProfileInfo, ProfileRemovalMode } from '@/types/profile';
+
+interface ProfileRemovalMenuProps {
+  profile: ProfileInfo;
+  disabled: boolean;
+  onRemove: (mode: ProfileRemovalMode) => void;
+}
+
+export function ProfileRemovalMenu({ profile, disabled, onRemove }: ProfileRemovalMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [confirmingFileDeletion, setConfirmingFileDeletion] = useState(false);
+
+  const finishRemoval = (mode: ProfileRemovalMode) => {
+    setOpen(false);
+    onRemove(mode);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+        if (!nextOpen) setConfirmingFileDeletion(false);
+      }}
+    >
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Manage ${profile.name}`}
+          disabled={disabled}
+          onClick={(event) => event.stopPropagation()}
+          className="rounded p-1 text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)] disabled:opacity-50"
+        >
+          <MoreHorizontal className="size-3.5" />
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        className="sm:max-w-sm"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {!confirmingFileDeletion ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>Remove profile</DialogTitle>
+              <DialogDescription>
+                Choose what to do with the files for {profile.name}.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="flex-row flex-nowrap justify-end">
+              <Button
+                variant="secondary"
+                className="whitespace-nowrap"
+                onClick={() => finishRemoval('remove')}
+              >
+                Retain files
+              </Button>
+              {profile.canDeleteFiles && (
+                <Button
+                  variant="destructive"
+                  className="whitespace-nowrap"
+                  onClick={() => setConfirmingFileDeletion(true)}
+                >
+                  Delete files
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>Are you sure?</DialogTitle>
+              <DialogDescription>
+                The profile folder and its workspaces will be deleted. You cannot undo this.
+              </DialogDescription>
+            </DialogHeader>
+            <p
+              className="truncate rounded bg-[var(--bg-base)] px-2 py-1.5 font-mono text-xs text-[var(--text-muted)]"
+              title={profile.path}
+            >
+              {profile.path}
+            </p>
+            <DialogFooter className="flex-row flex-nowrap justify-end">
+              <Button
+                variant="ghost"
+                className="whitespace-nowrap"
+                onClick={() => setConfirmingFileDeletion(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                className="whitespace-nowrap"
+                onClick={() => finishRemoval('delete-files')}
+              >
+                Delete
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/profiles/ProfileSwitcher.tsx
+++ b/apps/desktop/src/components/profiles/ProfileSwitcher.tsx
@@ -13,8 +13,10 @@ import { useState } from 'react';
 import { Button } from '@sero-ai/ui/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@sero-ai/ui/components/ui/popover';
 import { User, Check, Plus, Loader2 } from 'lucide-react';
-import { useProfileStore, switchProfile } from '@/stores/profiles';
+import { removeProfile, switchProfile, useProfileStore } from '@/stores/profiles';
+import type { ProfileRemovalMode } from '@/types/profile';
 import { CreateProfileDialog } from './CreateProfileDialog';
+import { ProfileRemovalMenu } from './ProfileRemovalMenu';
 import { useProfileOperationState } from './useProfileOperationState';
 
 export function ProfileSwitcher() {
@@ -29,6 +31,7 @@ export function ProfileSwitcher() {
   const [open, setOpen] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [switching, setSwitching] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<string | null>(null);
 
   // Don't render if there are no profiles at all
   if (profiles.length === 0) return null;
@@ -49,6 +52,15 @@ export function ProfileSwitcher() {
       () => setSwitching(null),
     );
     // App restarts on success.
+  };
+
+  const handleRemove = async (id: string, mode: ProfileRemovalMode) => {
+    setRemoving(id);
+    await runProfileOperation(
+      () => removeProfile(id, mode),
+      () => setRemoving(null),
+    );
+    setRemoving(null);
   };
 
   return (
@@ -89,29 +101,35 @@ export function ProfileSwitcher() {
             </div>
 
             {profiles.map((profile) => (
-              <button type="button"
-                key={profile.id}
-                onClick={() => handleSwitch(profile.id)}
-                disabled={switching !== null}
-                className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-[var(--bg-elevated)] disabled:opacity-50"
-              >
-                <span className="flex size-4 items-center justify-center">
-                  {switching === profile.id ? (
-                    <Loader2 className="size-3 animate-spin text-[var(--text-muted)]" />
-                  ) : profile.isActive ? (
-                    <Check className="size-3 text-[var(--accent-primary)]" />
-                  ) : null}
-                </span>
-                <span
-                  className={
-                    profile.isActive
-                      ? 'font-medium text-[var(--text-primary)]'
-                      : 'text-[var(--text-secondary)]'
-                  }
+              <div key={profile.id} className="flex items-center rounded-md hover:bg-[var(--bg-elevated)]">
+                <button type="button"
+                  onClick={() => handleSwitch(profile.id)}
+                  disabled={switching !== null || removing !== null}
+                  className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors disabled:opacity-50"
                 >
-                  {profile.name}
-                </span>
-              </button>
+                  <span className="flex size-4 items-center justify-center">
+                    {switching === profile.id || removing === profile.id ? (
+                      <Loader2 className="size-3 animate-spin text-[var(--text-muted)]" />
+                    ) : profile.isActive ? (
+                      <Check className="size-3 text-[var(--accent-primary)]" />
+                    ) : null}
+                  </span>
+                  <span
+                    className={`truncate ${profile.isActive
+                      ? 'font-medium text-[var(--text-primary)]'
+                      : 'text-[var(--text-secondary)]'}`}
+                  >
+                    {profile.name}
+                  </span>
+                </button>
+                {!profile.isActive && profiles.length > 1 && (
+                  <ProfileRemovalMenu
+                    profile={profile}
+                    disabled={switching !== null || removing !== null}
+                    onRemove={(mode) => { void handleRemove(profile.id, mode); }}
+                  />
+                )}
+              </div>
             ))}
 
             <div className="my-1 h-px bg-[var(--border-default)]" />

--- a/apps/desktop/src/stores/profiles.ts
+++ b/apps/desktop/src/stores/profiles.ts
@@ -7,20 +7,22 @@
  */
 
 import { create } from 'zustand';
-import type { ProfileInfo } from '@/types/ipc';
+import type { ProfileInfo, ProfileRemovalMode } from '@/types/profile';
 
-type ProfileOperation = 'create' | 'switch';
+type ProfileOperation = 'create' | 'switch' | 'remove';
 
 const PROFILE_RESTART_HINT = 'If the action succeeds, Sero restarts automatically.';
 
 function getProfileOperationError(operation: ProfileOperation, err: unknown): string {
   const defaultMessage = operation === 'create'
     ? 'Failed to create profile'
-    : 'Failed to switch profile';
+    : operation === 'switch'
+      ? 'Failed to switch profile'
+      : 'Failed to remove profile';
   const detail = err instanceof Error && err.message.trim().length > 0
     ? err.message.trim()
     : null;
-
+  if (operation === 'remove') return detail ?? defaultMessage;
   return detail
     ? `${detail} ${PROFILE_RESTART_HINT}`
     : `${defaultMessage}. ${PROFILE_RESTART_HINT}`;
@@ -139,6 +141,18 @@ export async function switchProfile(id: string): Promise<void> {
     // App will restart — this line may not execute
   } catch (err) {
     failProfileOperation('switch', err);
+  }
+}
+
+/** Remove an inactive profile and refresh the profile menu. */
+export async function removeProfile(id: string, mode: ProfileRemovalMode = 'remove'): Promise<void> {
+  useProfileStore.setState({ isLoading: true, error: null });
+  try {
+    await window.sero.profiles.remove(id, mode);
+    const profiles = await window.sero.profiles.list();
+    useProfileStore.setState({ profiles, isLoading: false });
+  } catch (err) {
+    failProfileOperation('remove', err);
   }
 }
 

--- a/apps/desktop/src/types/electron.d.ts
+++ b/apps/desktop/src/types/electron.d.ts
@@ -12,6 +12,7 @@ import type {
   SeroOrchestratorAPI,
 } from './electron-workspace';
 import type { LayoutState, LoadedLayoutState } from './layout';
+import type { ProfileRemovalMode } from './profile';
 import type { SeroBrowserAPI } from './electron-browser';
 import type {
   SeroGatewayAPI,
@@ -388,8 +389,8 @@ interface SeroProfilesAPI {
   switch(id: string): Promise<void>;
   /** Rename a profile's display name. */
   rename(id: string, newName: string): Promise<void>;
-  /** Delete a profile (unregister only — files stay). */
-  delete(id: string): Promise<void>;
+  /** Remove an inactive profile, retaining files unless delete-files is explicitly selected. */
+  remove(id: string, mode: ProfileRemovalMode): Promise<void>;
   /** Open native folder picker for custom profile path. */
   pickFolder(): Promise<string | null>;
   /** Check if onboarding is needed for this profile. */

--- a/apps/desktop/src/types/ipc-channels.ts
+++ b/apps/desktop/src/types/ipc-channels.ts
@@ -455,8 +455,8 @@ export const IpcChannels = {
     switch: 'sero:profiles:switch',
     /** Rename a profile. Args: id, newName. */
     rename: 'sero:profiles:rename',
-    /** Delete a profile (unregister only). Args: id. */
-    delete: 'sero:profiles:delete',
+    /** Remove an inactive profile. Args: id, mode. */
+    remove: 'sero:profiles:remove',
     /** Open native folder picker for custom profile path. */
     pickFolder: 'sero:profiles:pick-folder',
     /** Check if onboarding is needed (no .onboarding-complete marker). */

--- a/apps/desktop/src/types/profile.ts
+++ b/apps/desktop/src/types/profile.ts
@@ -2,6 +2,10 @@
  * Renderer-safe profile contract shared across IPC, preload, and main-process
  * profile management code.
  */
+export type ProfileFolderProvenance = 'default-root' | 'sero-managed' | 'custom';
+
+export type ProfileRemovalMode = 'remove' | 'delete-files';
+
 export interface ProfileInfo {
   /** Unique identifier. */
   id: string;
@@ -11,6 +15,10 @@ export interface ProfileInfo {
   path: string;
   /** ISO timestamp of when the profile was created. */
   createdAt: string;
+  /** How the profile folder entered the registry. Missing means uncertain legacy provenance. */
+  folderProvenance?: ProfileFolderProvenance;
+  /** True only when Sero can safely delete this managed profile folder. */
+  canDeleteFiles: boolean;
   /** True if this is the currently active profile. */
   isActive: boolean;
   /** True once onboarding has completed for this profile. */

--- a/apps/docs-site/docs/guide/profiles-and-onboarding.md
+++ b/apps/docs-site/docs/guide/profiles-and-onboarding.md
@@ -72,17 +72,14 @@ The copy flow can include these profile-agent files when they have meaningful co
 
 Only use this option when the new profile should trust the same providers, local endpoints, and credentials.
 
-## Deleting profiles
+## Removing profiles
 
-Deleting a profile unregisters it from `~/.sero-ui/profiles.json`.
+Use the profile menu to manage an inactive profile:
 
-Current behavior:
+- **Retain files** unregisters the profile and deletes its Sero-owned containers. It keeps all profile and workspace files.
+- **Delete files** also permanently deletes the profile folder. Sero shows this option only for a folder that it created under its managed profiles directory.
 
-- Sero will not delete the only profile.
-- Sero will not delete the active profile; switch to another profile first.
-- Profile deletion removes the registry entry only. It does **not** delete the profile files from disk, including Chromium browser data.
-
-If you want to remove the data too, first back up anything important, then delete the profile folder manually from your operating system.
+Sero will not remove the only profile or the active profile. Switch to another profile first. The permanent option is never available for the main `~/.sero-ui` folder, a custom folder, or a legacy profile with uncertain folder ownership.
 
 ## Redaction checklist
 

--- a/docs/prototypes/profile-removal.html
+++ b/docs/prototypes/profile-removal.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sero profile removal prototype</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, system-ui, sans-serif; background: #151515; color: #ece9e2; }
+    body { display: grid; min-height: 100vh; margin: 0; place-items: center; }
+    .menu { position: relative; width: 300px; padding: 20px; border: 1px solid #393834; border-radius: 10px; background: #22211f; }
+    h1 { margin: 0 0 6px; font-size: 14px; }
+    p { margin: 0 0 14px; color: #aaa69d; font-size: 12px; line-height: 1.5; }
+    .actions { display: flex; flex-wrap: nowrap; justify-content: flex-end; gap: 8px; }
+    button { padding: 7px 10px; border: 1px solid #46443f; border-radius: 6px; background: transparent; color: inherit; white-space: nowrap; }
+    .default { background: #34322e; }
+    .danger { border-color: #7c3b38; color: #f4aaa3; }
+    .close { position: absolute; top: 10px; right: 10px; padding: 3px 7px; border: 0; color: #aaa69d; }
+    .warning { margin-top: 20px; border-color: #643b38; }
+    code { display: block; overflow: hidden; margin-bottom: 14px; padding: 7px; border-radius: 5px; background: #171715; color: #aaa69d; text-overflow: ellipsis; }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="menu">
+      <button class="close" aria-label="Close">×</button>
+      <h1>Remove profile</h1>
+      <p>Choose what to do with the files for Research.</p>
+      <div class="actions">
+        <button class="default">Retain files</button><button class="danger">Delete files</button>
+      </div>
+    </section>
+    <section class="menu warning">
+      <button class="close" aria-label="Close">×</button>
+      <h1>Are you sure?</h1>
+      <p>The profile folder and its workspaces will be deleted. You cannot undo this.</p>
+      <code>~/.sero-ui/profiles/research</code>
+      <div class="actions"><button>Cancel</button><button class="danger">Delete</button></div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-05-17-e2e-phase-1-contract-layer.md
+++ b/docs/superpowers/plans/2026-05-17-e2e-phase-1-contract-layer.md
@@ -300,7 +300,7 @@ test('creates, lists, renames, and deletes an inactive profile', async () => {
 - `profiles.list()` returns an array of objects with `id`, `name`, `path`, and active marker/flag if present.
 - `profiles.create()` creates a profile visible in `profiles.list()`.
 - `profiles.rename()` changes only the target profile.
-- `profiles.delete()` unregisters an inactive profile without asserting filesystem deletion.
+- `profiles.remove(id, 'remove')` unregisters an inactive profile without deleting its files.
 - `profiles.needsOnboarding()` transitions from `true` to `false` after `markOnboardingDone()`.
 - `onboarding.getState()` returns a stable object shape with step/status fields currently exposed by `OnboardingState`.
 


### PR DESCRIPTION
## Summary

- add durable, provider-neutral cleanup for Sero-owned Apple and Docker containers
- remove containers when workspaces or profiles are removed, then retry failed deletions after restart
- reconcile owned containers against every registered profile while preserving uncertain or restored workspaces
- add safe profile removal with Retain files and Delete files modes
- replace the unclear profile popover with a two-screen dialog and explicit permanent-delete confirmation

## Review fixes

- migrate legacy Apple containers and recover uninspectable ghost name reservations
- retain shutdown cleanup across crashes while cancelling restored orphan deletions
- timestamp pending deletions so retries preserve containers created after the deletion request
- verify live Apple inspect output and use its top-level `startedDate` and `status` fields
- treat Apple empty inspect payloads and Docker `No such object` results as absent containers
- use the non-throwing Docker runner so missing containers clear their cleanup queue entries
- delete owned Apple containers when no timestamp is available; skip only containers proven newer
- delete known pre-cutoff running containers while preserving running containers only when their start time is unknown
- warn when a newer container supersedes a pending deletion
- retry legacy queue entries that do not have a creation cutoff
- limit Apple orphan inspection to deterministic `sero-` container names
- record that repeated shutdown queue requests intentionally refresh the deletion cutoff
- add per-install ownership labels without recreating running legacy Apple containers
- inspect named Apple containers directly and inspect each Apple list result before orphan cleanup
- discover legacy Apple and Docker orphans only inside registered profile roots
- rebuild owned Docker containers after workspace path changes and preserve foreign-install collisions
- fail closed when a missing workspace registry still has managed workspace files
- retain valid pending deletions when cleanup state also contains malformed entries
- clear failed Apple backend sessions so later ensure calls can recover

## Verification

- `pnpm typecheck` — 24 tasks passed
- focused container lifecycle, ownership, backend, provider, service, registry, workspace removal, and profile removal regressions — 107 tests passed
- live Apple Container probes confirmed missing inspect output is `[]` and running inspect records contain top-level `startedDate` and `status`
- the real `TestAppleContainer` workspace reused its running native container, loaded its model selector, and produced no renderer errors
- `pnpm --filter @sero/desktop exec playwright test e2e/profiles.workflow.spec.ts --project=workflow -g "shows a clear two-step profile removal dialog"` — passed
- `npx react-doctor@latest --verbose --scope changed` — 92/100
- all touched source files are at or below 500 lines

## Notes

- A broad workflow invocation timed out in Git workflow specs outside this change. The focused profile workflow passed.

Closes #172
